### PR TITLE
small changes from pre-version-1.2 review pt 2

### DIFF
--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -207,7 +207,7 @@ Figure~\ref{fig:epoch-defs} introduces three new derived types:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
-      \var{prod}
+      \var{blocks}
       & \BlocksMade
       & \HashKey_{pool} \mapsto \N
       & \text{blocks made by stake pools} \\
@@ -243,7 +243,7 @@ Figure~\ref{fig:functions:helper-stake-distribution} defines some helper functio
   \item $\fun{poolStake}$ filters all stake in the system into just the stake delegated to a given
     stake pool operator hashkey.  Additionally, it combines all of the stake controlled by the
     pool owners into a single key-value pair mapping the pool operator's hashkey to the
-    owner-operator total.
+    owner total.
 \end{itemize}
 
 %%
@@ -276,12 +276,11 @@ Figure~\ref{fig:functions:helper-stake-distribution} defines some helper functio
       & \fun{poolStake} \in \HashKey \to \powerset{\HashKey} \to (\HashKey \mapsto \HashKey)
           \to \Stake \to \Stake \\
       & \poolStake{operator}{owners}{delegations}{stake} = \\
-      & ~~ \left\{hk\mapsto c \mid hk\notin\var{owners'},~hk\mapsto c\in\var{poolStake} \right\}
+      & ~~ \left\{hk\mapsto c \mid hk\notin\var{owners},~hk\mapsto c\in\var{poolStake} \right\}
            \cup
            \left\{ \var{operator}\mapsto
-             \sum_{\substack{hk\in\var{owners'} \\ hk\mapsto c\in\var{poolStake}}} c\right\} \\
+             \sum_{\substack{hk\in\var{owners} \\ hk\mapsto c\in\var{poolStake}}} c\right\} \\
       & ~~ \where \\
-      & ~~~~~~ \var{owners'} = owners \cup \{operator\} \\
       & ~~~~~~ \var{poolStake} =
                  \{hk \mapsto c
                  \mid
@@ -417,7 +416,7 @@ This transition has no preconditions and results in the following state change:
   \item The pool performance is stored.
   \item The fees and decayed deposits are stored in $\var{feeSS}$. Note that this value will not
     change between epochs, unlike the $\var{fees}$ and $\var{deposits}$ values in the UTxO state.
-  \item In the UTxO state, the decayed deposit amounts are moved from the deposit pool
+  \item In the UTxO state, the decayed deposit amounts are moved from the deposit pot
     to the fee pool. Note that in the reward transition (Section~\ref{sec:reward-trans}),
     the value $\var{feeSS}$ will be removed from the fee pot in the UTxO state.
     The decay is calculated based on \textit{the first slot in the upcoming epoch}.
@@ -1183,7 +1182,7 @@ The calculation is done pool-by-pool.
       & \rewardOnePool{pp}{R}{n}{poolHK}{pool}{stake}{avgs}{tot}{addrs_{rew}} =
           (\var{rewards},~\var{unrealized})\\
       & ~~~\where \\
-      & ~~~~~~~\var{pstake} = \sum_{\_\mapsto t\in\var{stake}} t \\
+      & ~~~~~~~\var{pstake} = \sum_{\_\mapsto c\in\var{stake}} c \\
       & ~~~~~~~\var{ostake} = \var{stake}~\var{poolHK} \\
       & ~~~~~~~\sigma = \var{pstake} / tot \\
       & ~~~~~~~\var{\overline{N}} = \sigma * \SlotsPerEpoch\\
@@ -1235,7 +1234,7 @@ The calculation is done pool-by-pool.
                  \mid
                  hk\mapsto(p, n, s)\in\var{pdata} \right\} \\
       & ~~~~~~~\var{unrealized} = \sum_{\wcard\mapsto (\wcard,~u)\in\var{results}}u \\
-      & ~~~~~~~\var{rewards} = \bigcup_{\wcard\mapsto(\var{rwds},~\wcard)}\var{rwds}
+      & ~~~~~~~\var{rewards} = \bigcup_{\wcard\mapsto(\var{r},~\wcard)\in\var{results}}\var{r}
   \end{align*}
   \caption{The Reward Calculation}
   \label{fig:functions:reward-calc}

--- a/latex/intro.tex
+++ b/latex/intro.tex
@@ -17,11 +17,11 @@ of the functionality of the ledger on the blockchain:
   In particular, every coin is accounted for by one of the following categories:
   \begin{itemize}
     \item Circulation (UTxO)
-    \item Deposit pool
-    \item Fee pool
+    \item Deposit pot
+    \item Fee pot
     \item Reserves (monetary expansion)
     \item Rewards (account addresses)
-    \item Reward Pool (undistributed)
+    \item Reward pot (undistributed)
     \item Treasury
   \end{itemize}
 \item[Witnesses] Authentication of parts of the transaction data by means of

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -522,7 +522,7 @@ between epochs and slots.
         \var{poolMinRefund} & \unitInterval & \text{stake pool min refund}\\
         \var{poolDecayRate} & \nonnegReals & \text{stake pool decay rate}\\
         \var{movingAvgWeight} & \unitInterval & \text{moving average weight}\\
-        \var{movingAvgExp} & \unitInterval & \text{moving average exponent}\\
+        \var{movingAvgExp} & \posReals & \text{moving average exponent}\\
         \var{E_{max}} & \Epoch & \text{epoch bound on pool retirement}\\
         \var{n_{opt}} & \Npos & \text{desired number of pools}\\
         \var{a_0} & \posReals & \text{pool influence}\\
@@ -758,14 +758,20 @@ Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition
   \item The calculation $\fun{consumed}$ gives the value consumed by the transaction $\var{tx}$
     in the context of the protocol parameters, the current UTxO on the ledger, and the registered
     stake keys.  This calculation is a sum of all coin in the inputs of $\var{tx}$,
-    reward withdrawals, and stake key deposit refunds. The method $\fun{keyRefunds}$ used
-    to calculate the refunds will be defined in Section~\ref{sec:deps-refunds}.
+    reward withdrawals, and stake key deposit refunds.
+    Some of the definitions used in this function will be defined in
+    Section~\ref{sec:deps-refunds}.
+    In particular, $\fun{keyRefunds}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
+    and $\StakeKeys$ is defined in Figure~\ref{fig:delegation-defs}.
 
   \item The calculation $\fun{produced}$ gives the value produced by the transaction $\var{tx}$
     in the context of the protocol parameters and the registered stake pools.
     This calculation is a sum of all coin in the outputs of $\var{tx}$,
-    the transaction fee, and all needed deposits. The method $\fun{deposits}$ used
-    to calculate the deposits will be defined in Section~\ref{sec:deps-refunds}.
+    the transaction fee, and all needed deposits.
+    Some of the definitions used in this function will be defined in
+    Section~\ref{sec:deps-refunds}.
+    In particular, $\fun{deposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
+    and $\StakePools$ is defined in Figure~\ref{fig:delegation-defs}.
 \end{itemize}
 
 The preservation of value property holds for a transaction, for a given ledger state,
@@ -822,8 +828,10 @@ The environment, $\UTxOEnv$, consists of:
 \begin{itemize}
   \item The current slot.
   \item The protocol parameters.
-  \item The registered stake keys (which will be explained in Section~\ref{sec:delegation}).
-  \item The registered stake pools (which will be explained in Section~\ref{sec:delegation}).
+  \item The registered stake keys
+    (which will be explained in Section~\ref{sec:delegation}, Figure~\ref{fig:delegation-defs}).
+  \item The registered stake pools
+    (also explained in Section~\ref{sec:delegation}, Figure~\ref{fig:delegation-defs}).
 \end{itemize}
 The current slot and the registrations are need for the refund calculations
 described in Section~\ref{sec:deps-refunds}.
@@ -882,7 +890,7 @@ The transition contains the following predicates:
 
 \begin{itemize}
   \item
-    The transaction is live (its time to live is less than the current slot).
+    The transaction is live (the current slot is less than its time to live).
   \item
     The transaction has at least one input.
     The global uniqueness of transaction inputs prevents replay attacks.
@@ -994,7 +1002,8 @@ requests).
       \\
       \var{decayed} = \decayedTx{pp}{stkeys}~{tx}
       \\
-      \var{depositChange} = (\deposits{pp}~{stpools}~{\fun{dcerts}~tx}) - (\var{refunded} + \var{decayed})
+      \var{depositChange} =
+        (\deposits{pp}~{stpools}~{\fun{dcerts}~tx}) - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{l}
@@ -1114,8 +1123,9 @@ Section~\cref{sec:epoch}.
     & \text{total deposits for transaction} \\
     & \fun{deposits}~{pp}~{stpools}~{certs} = \\
     &  \sum\limits_{c\in\var{certs} \cap \DCertRegKey}(\fun{keyDeposit}~pp)
-    +  \sum\limits_{\substack{c\in\var{certs}\cap\DCertRegPool \\ (\cwitness{c})\notin \var{stpools}}}
-            (\fun{poolDeposit}~pp)
+    +  \sum\limits_{\substack{
+         c\in\var{certs}\cap\DCertRegPool \\ (\cwitness{c})\notin \var{stpools}}}
+         (\fun{poolDeposit}~pp)
       \nextdef
       & \fun{refund} \in \Coin \to \unitInterval \to \posReals \to \Duration \to \Coin
       & \text{refund calculation} \\


### PR DESCRIPTION
Changes from the review today:

- change variable name "prod" to "blocks" in fig 25
- pool operator hashkey no longer considered an owner by default
- in the reward calc in fig 35, the reward value was missing the set being unioned over
- in figure 38, use variable c instead of t for pstake sum

Also a few changes from the recent audit comments:

- changed the word "pool" to "pot" in the introduction for things like the deposit pot.
- added more forward references to the UTxO section that makes use of the delegation definitions
- the time to live description was backwards in the prose (it should be smaller than the current slot).

And a suggestion from @jcmincke:
- the range for the exponent of the moving average was changed from the unit interval to the positive reals.