### PR TITLE
Move tag validation from UPPVV to UPSVV

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -304,6 +304,7 @@ instance STS UPSVV where
     = AlreadyProposedSv
     | CannotFollowSv
     | InvalidApplicationName
+    | InvalidSystemTags
     deriving (Eq, Show)
 
   initialRules = []
@@ -314,11 +315,13 @@ instance STS UPSVV where
         apNameValid an ?! InvalidApplicationName
         svCanFollow avs (an,av) ?! CannotFollowSv
         (an, av) `notElem` fmap fstSnd (Map.elems raus) ?! AlreadyProposedSv
+        all sTagValid (up ^. upSTags) ?! InvalidSystemTags
         return $! raus ⨃ [(up ^. upId, (an, av, up ^. upMdt))]
     ]
     where
       apNameValid (ApName n) = all isAscii n && length n <= 12
       fstSnd (x, y, _) = (x, y)
+      sTagValid tag = all isAscii tag && length tag <= 10
 
 
 data UPPVV
@@ -335,7 +338,6 @@ instance STS UPPVV where
     = CannotFollowPv
     | CannotUpdatePv [UpdateConstraintViolation]
     | AlreadyProposedPv
-    | InvalidSystemTags
     deriving (Eq, Show)
 
   initialRules = []
@@ -348,11 +350,8 @@ instance STS UPPVV where
         pvCanFollow nv pv ?! CannotFollowPv
         canUpdate pps up
         nv `notElem` (fst <$> Map.elems rpus) ?! AlreadyProposedPv
-        all sTagValid (up ^. upSTags) ?! InvalidSystemTags
         return $! rpus ⨃ [(pid, (nv, ppsn))]
     ]
-    where
-      sTagValid tag = all isAscii tag && length tag <= 10
 
 
 -- | Update proposal validity

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -362,7 +362,8 @@ functions:
       (\var{an}, \var{av}) \leteq \upSwVer{up}
       & \fun{apNameValid}~\var{an}\\
       & \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av})
-      & (\var{an}, \var{av}, \wcard) \notin \range~\var{raus}
+      & (\var{an}, \var{av}, \wcard) \notin \range~\var{raus}\\
+      \forall \var{t} \in \fun{upSTags}~\var{up} \cdot \fun{sTagValid}~t
     }
     {
       {\left(
@@ -398,8 +399,7 @@ functions:
       & \var{nv} \leteq \upPV{up}
       & \fun{pvCanFollow}~\var{nv}~\var{pv}\\
       & \upSize{up} \leq \var{pps}~\var{maxProposalSize}
-      & \var{nv} \notin \dom~(\range~\var{rpus})\\
-      \forall \var{t} \in \fun{upSTags}~\var{up} \cdot \fun{sTagValid}~t
+      & \var{nv} \notin \dom~(\range~\var{rpus})
     }
     {
       {\left(


### PR DESCRIPTION
This PR moves tag validation from the `UPPVV` STS to the `UPSVV` STS.

It closes #628.