### PR TITLE
better error types for many of the STS rules

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -25,6 +25,7 @@ module Shelley.Spec.Ledger.BlockChain
     Block (Block),
     LaxBlock (..),
     TxSeq (TxSeq),
+    HashBBody,
     bhHash,
     bbHash,
     hashHeaderToNonce,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -66,8 +66,8 @@ instance
   type BaseM (BBODY crypto) = ShelleyBase
 
   data PredicateFailure (BBODY crypto)
-    = WrongBlockBodySizeBBODY
-    | InvalidBodyHashBBODY
+    = WrongBlockBodySizeBBODY Int Int
+    | InvalidBodyHashBBODY (HashBBody crypto) (HashBBody crypto)
     | LedgersFailure (PredicateFailure (LEDGERS crypto))
     deriving (Show, Eq, Generic)
 
@@ -92,10 +92,13 @@ bbodyTransition =
            ) -> do
         let hk = hashKey $ bheaderVk bhb
             TxSeq txs = txsSeq
+            actualBodySize = bBodySize txsSeq
+            actualBodyHash = bbHash txsSeq
 
-        bBodySize txsSeq == fromIntegral (hBbsize bhb) ?! WrongBlockBodySizeBBODY
+        actualBodySize == fromIntegral (hBbsize bhb)
+          ?! WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ hBbsize bhb)
 
-        bbHash txsSeq == bhash bhb ?! InvalidBodyHashBBODY
+        actualBodyHash == bhash bhb ?! InvalidBodyHashBBODY actualBodyHash (bhash bhb)
 
         ls' <-
           trans @(LEDGERS crypto) $

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -175,8 +175,8 @@ instance
   type BaseM (CHAIN crypto) = ShelleyBase
 
   data PredicateFailure (CHAIN crypto)
-    = HeaderSizeTooLargeCHAIN
-    | BlockSizeTooLargeCHAIN
+    = HeaderSizeTooLargeCHAIN Int Natural
+    | BlockSizeTooLargeCHAIN Natural Natural
     | ObsoleteNodeCHAIN !Natural !Natural
     | BbodyFailure !(PredicateFailure (BBODY crypto))
     | TickFailure (PredicateFailure (TICK crypto))
@@ -197,8 +197,12 @@ chainChecks ::
   m ()
 chainChecks maxpv pp bh = do
   unless (m <= maxpv) $ throwError (ObsoleteNodeCHAIN m maxpv)
-  unless (fromIntegral (bHeaderSize bh) <= _maxBHSize pp) $ throwError HeaderSizeTooLargeCHAIN
-  unless (hBbsize (bhbody bh) <= _maxBBSize pp) $ throwError BlockSizeTooLargeCHAIN
+  unless (fromIntegral (bHeaderSize bh) <= _maxBHSize pp)
+    $ throwError
+    $ HeaderSizeTooLargeCHAIN (bHeaderSize bh) (_maxBHSize pp)
+  unless (hBbsize (bhbody bh) <= _maxBBSize pp)
+    $ throwError
+    $ BlockSizeTooLargeCHAIN (hBbsize (bhbody bh)) (_maxBBSize pp)
   where
     (ProtVer m _) = _protocolVersion pp
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -59,9 +59,6 @@ instance
   data PredicateFailure (DELPL crypto)
     = PoolFailure (PredicateFailure (POOL crypto))
     | DelegFailure (PredicateFailure (DELEG crypto))
-    | ScriptNotInWitnessDELPL
-    | ScriptHashNotMatchDELPL
-    | ScriptDoesNotValidateDELPL
     deriving (Show, Eq, Generic)
 
   initialRules = [pure emptyDelegation]
@@ -80,9 +77,6 @@ instance
     (DelegFailure a) ->
       encodeListLen 2 <> toCBOR (1 :: Word8)
         <> toCBOR a
-    ScriptNotInWitnessDELPL -> encodeListLen 1 <> toCBOR (2 :: Word8)
-    ScriptHashNotMatchDELPL -> encodeListLen 1 <> toCBOR (3 :: Word8)
-    ScriptDoesNotValidateDELPL -> encodeListLen 1 <> toCBOR (4 :: Word8)
 
 instance
   (Crypto crypto) =>
@@ -99,15 +93,6 @@ instance
         matchSize "DelegFailure" 2 n
         a <- fromCBOR
         pure $ DelegFailure a
-      2 ->
-        matchSize "ScriptNotInWitnessDELPL" 1 n
-          >> pure ScriptNotInWitnessDELPL
-      3 ->
-        matchSize "ScriptHashNotMatchDELPL" 1 n
-          >> pure ScriptHashNotMatchDELPL
-      4 ->
-        matchSize "ScriptDoesNotValidateDELPL" 1 n
-          >> pure ScriptDoesNotValidateDELPL
       k -> invalidKey k
 
 delplTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -52,7 +52,7 @@ instance STS (NEWPP crypto) where
   type Environment (NEWPP crypto) = NewppEnv crypto
   type BaseM (NEWPP crypto) = ShelleyBase
   data PredicateFailure (NEWPP crypto)
-    = UnexpectedDepositPot
+    = UnexpectedDepositPot Coin Coin
     deriving (Show, Eq, Generic)
 
   initialRules = [initialNewPp]
@@ -83,7 +83,7 @@ newPpTransition = do
           Coin reserves = _reserves acnt
           Coin requiredInstantaneousRewards = foldl' (+) (Coin 0) $ _irwd dstate
 
-      (Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot
+      (Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
 
       if reserves + diff >= requiredInstantaneousRewards
         && (_maxTxSize ppNew' + _maxBHSize ppNew') < _maxBBSize ppNew'

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -15,7 +15,7 @@ module Shelley.Spec.Ledger.STS.Prtcl
     PrtclEnv (..),
     PrtclState (..),
     PredicateFailure (..),
-    PrtlSeqFailure(..),
+    PrtlSeqFailure (..),
     prtlSeqChecks,
   )
 where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -103,6 +103,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust, isJust, maybe)
 import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
+import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
@@ -2698,8 +2699,11 @@ blockEx5B =
     0
     (mkOCert (slotKeys 10) 0 (KESPeriod 0))
 
+mirWitsEx5B :: Set (KeyHash 'Witness)
+mirWitsEx5B = Set.fromList [asWitness . hk . coreNodeKeys $ i | i <- [0 .. 3]]
+
 expectedStEx5B :: PredicateFailure CHAIN
-expectedStEx5B = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRInsufficientGenesisSigsUTXOW)))
+expectedStEx5B = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure $ MIRInsufficientGenesisSigsUTXOW mirWitsEx5B)))
 
 ex5B :: CHAINExample
 ex5B = CHAINExample initStEx2A blockEx5B (Left [[expectedStEx5B]])

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
@@ -459,7 +459,7 @@ predicateFailureToValidationError (UtxowFailure (UtxoFailure InputSetEmptyUTxO))
   InputSetEmpty
 predicateFailureToValidationError (UtxowFailure (UtxoFailure (ExpiredUTxO a b))) =
   Expired a b
-predicateFailureToValidationError (UtxowFailure (UtxoFailure BadInputsUTxO)) =
+predicateFailureToValidationError (UtxowFailure (UtxoFailure (BadInputsUTxO _))) =
   BadInputs
 predicateFailureToValidationError (UtxowFailure (UtxoFailure (FeeTooSmallUTxO a b))) =
   FeeTooSmall a b

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -230,7 +230,7 @@ testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
   testInvalidTx
     [ UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Coin 0) (Coin 10000))),
-      UtxowFailure (UtxoFailure BadInputsUTxO)
+      UtxowFailure (UtxoFailure $ BadInputsUTxO (Set.singleton $ TxIn genesisId 42))
     ]
     $ aliceGivesBobLovelace
     $ AliceToBob
@@ -438,7 +438,7 @@ testWithdrawalWrongAmt =
 testOutputTooSmall :: Assertion
 testOutputTooSmall =
   testInvalidTx
-    [UtxowFailure (UtxoFailure OutputTooSmallUTxO)]
+    [UtxowFailure (UtxoFailure $ OutputTooSmallUTxO [TxOut bobAddr (Coin 1)])]
     $ aliceGivesBobLovelace
     $ AliceToBob
       { input = (TxIn genesisId 0),


### PR DESCRIPTION
I've made a bunch of the STS errors more descriptive.  The main things left to add are 1) `DELEG` failures, 2) maybe add more to the OCert signature failure (had some trouble with the show instance), and 3) multisig errors.

The `Delpl` rule has three errors that seemed to be totally unused:
```
ScriptNotInWitnessDELPL	
ScriptHashNotMatchDELPL	
ScriptDoesNotValidateDELPL
```
I have deleted these three error types.