### PR TITLE
Derive Generic instances for some data types

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -112,7 +112,8 @@ library
 test-suite shelley-spec-ledger-test
     type:                exitcode-stdio-1.0
     main-is:             Tests.hs
-    other-modules:       Test.Shelley.Spec.Ledger.Utils
+    other-modules:       Test.Shelley.Spec.Ledger.Orphans
+                         Test.Shelley.Spec.Ledger.Utils
                          Test.Cardano.Crypto.VRF.Fake
                          Test.Shelley.Spec.Ledger.Address
                          Test.Shelley.Spec.Ledger.CDDL

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -91,7 +91,7 @@ fpEpsilon = (10 :: FixedPoint) ^ (17 :: Integer) / fpPrecision
 
 -- | Type to represent a value in the unit interval [0; 1]
 newtype UnitInterval = UnsafeUnitInterval Rational -- TODO: Fixed precision
-  deriving (Show, Ord, Eq, NoUnexpectedThunks)
+  deriving (Show, Ord, Eq, NoUnexpectedThunks, Generic)
 
 instance ToCBOR UnitInterval where
   toCBOR (UnsafeUnitInterval u) = rationalToCBOR u

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -12,10 +13,11 @@ import Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
 import Cardano.Prelude (NoUnexpectedThunks (..), cborError)
 import Data.Text (pack)
 import Data.Word (Word64)
+import GHC.Generics (Generic)
 
 -- | The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, Generic)
 
 instance ToCBOR Coin where
   toCBOR (Coin c) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -201,7 +201,7 @@ verifySignedDSIGN (VKey vk) vd sigDSIGN =
 newtype KeyHash (discriminator :: KeyRole) crypto
   = KeyHash (Hash crypto (DSIGN.VerKeyDSIGN (DSIGN crypto)))
   deriving (Show, Eq, Ord)
-  deriving newtype (NFData, NoUnexpectedThunks)
+  deriving newtype (NFData, NoUnexpectedThunks, Generic)
 
 deriving instance (Crypto crypto, Typeable disc) => ToCBOR (KeyHash disc crypto)
 
@@ -249,10 +249,10 @@ instance VRFValue UnitInterval where
 
 newtype GenDelegs crypto
   = GenDelegs (Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto))
-  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic)
 
 newtype GKeys crypto = GKeys (Set (VKey 'Genesis crypto))
-  deriving (Show, Eq, NoUnexpectedThunks)
+  deriving (Show, Eq, NoUnexpectedThunks, Generic)
 
 --------------------------------------------------------------------------------
 -- crypto-parametrised types

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -144,8 +144,6 @@ deriving instance Crypto crypto => Show (VKey kd crypto)
 
 deriving instance Crypto crypto => Eq (VKey kd crypto)
 
-deriving instance Num (DSIGN.VerKeyDSIGN (DSIGN crypto)) => Num (VKey kd crypto)
-
 deriving instance (Crypto crypto, NFData (DSIGN.VerKeyDSIGN (DSIGN crypto))) => NFData (VKey kd crypto)
 
 deriving instance Crypto crypto => NoUnexpectedThunks (VKey kd crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -40,7 +41,7 @@ where
 import Byron.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (hashWithSerialiser)
-import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Prelude (Generic, NoUnexpectedThunks (..))
 import Data.Foldable (toList)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
@@ -89,7 +90,7 @@ import Shelley.Spec.Ledger.TxData
 -- | The unspent transaction outputs.
 newtype UTxO crypto
   = UTxO (Map (TxIn crypto) (TxOut crypto))
-  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic)
 
 instance Relation (UTxO crypto) where
   type Domain (UTxO crypto) = TxIn crypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
@@ -92,6 +92,7 @@ import Shelley.Spec.Ledger.UTxO (balance, hashTxBody, makeWitnessVKey, pattern U
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 import Test.Shelley.Spec.Ledger.NonTraceProperties.Mutator
 import Test.Shelley.Spec.Ledger.NonTraceProperties.Validity
+import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils
 
 -- | Find first matching key pair for address. Returns the matching key pair

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Orphans.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Shelley.Spec.Ledger.Orphans () where
+
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
+
+-- We need this here for the tests, but should not be in the actual library because
+-- a Num instance for this type does not make sense in the general case.
+deriving instance Num (DSIGN.VerKeyDSIGN (DSIGN crypto)) => Num (VKey kd crypto)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -48,6 +48,7 @@ import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessVKey, makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 import Test.Shelley.Spec.Ledger.Fees (sizeTests)
 import Test.Shelley.Spec.Ledger.Generator.Core (unitIntervalToNatural)
+import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -35,6 +35,7 @@ library
                      Test.Shelley.Spec.Ledger.NonTraceProperties.Validity
                      Test.Shelley.Spec.Ledger.Serialization
                      Test.Shelley.Spec.Ledger.Shrinkers
+                     Test.Shelley.Spec.Ledger.Orphans
                      Test.Shelley.Spec.Ledger.Utils
   ghc-options:
     -Wall


### PR DESCRIPTION
Also move a `Num VKey` instance out of the main library.