### PR TITLE
Genesis Delegations Certificates now register the VRF key

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -100,13 +100,15 @@ transaction_output = [address, amount : uint]
 ; 1001 - 1101: future formats
 
 certificate =
-  [  0, stake_credential                   ; stake registration
-  // 1, stake_credential                   ; stake deregistration
-  // 2, stake_credential, pool_keyhash     ; stake delegation
-  // 3, pool_params                        ; pool registration
-  // 4, pool_keyhash, epoch                ; pool retirement
-  // 5, genesishash, genesis_delegate_hash ; genesis key delegation
-  // 6, move_instantaneous_reward          ; move inst. rewards
+  [  0, stake_credential               ; stake registration
+  // 1, stake_credential               ; stake deregistration
+  // 2, stake_credential, pool_keyhash ; stake delegation
+  // 3, pool_params                    ; pool registration
+  // 4, pool_keyhash, epoch            ; pool retirement
+  // 5, genesishash,                   ; genesis key delegation
+        genesis_delegate_hash,
+        vrf_keyhash,
+  // 6, move_instantaneous_reward      ; move inst. rewards
   ]
 
 move_instantaneous_reward = { * stake_credential => coin }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -74,7 +74,7 @@ poolCWitness (RegPool pool) = KeyHashObj $ _poolPubKey pool
 poolCWitness (RetirePool k _) = KeyHashObj k
 
 genesisCWitness :: GenesisDelegCert crypto -> KeyHash 'Genesis crypto
-genesisCWitness (GenesisDelegCert gk _) = gk
+genesisCWitness (GenesisDelegCert gk _ _) = gk
 
 -- | Retrieve the deposit amount for a certificate
 dvalue :: DCert crypto -> PParams -> Coin

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -248,7 +248,11 @@ instance VRFValue UnitInterval where
 --------------------------------------------------------------------------------
 
 newtype GenDelegs crypto
-  = GenDelegs (Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto))
+  = GenDelegs
+      ( Map
+          (KeyHash 'Genesis crypto)
+          (KeyHash 'GenesisDelegate crypto, Hash crypto (VerKeyVRF crypto))
+      )
   deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic)
 
 newtype GKeys crypto = GKeys (Set (VKey 'Genesis crypto))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -69,6 +69,7 @@ import Shelley.Spec.Ledger.Keys
     KeyHash,
     KeyRole (..),
     VerKeyKES,
+    VerKeyVRF,
     coerceKeyRole,
   )
 import Shelley.Spec.Ledger.LedgerState
@@ -129,7 +130,9 @@ initialShelleyState ::
   EpochNo ->
   UTxO crypto ->
   Coin ->
-  Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto) ->
+  Map
+    (KeyHash 'Genesis crypto)
+    (KeyHash 'GenesisDelegate crypto, Hash crypto (VerKeyVRF crypto)) ->
   Map SlotNo (OBftSlot crypto) ->
   PParams ->
   Nonce ->
@@ -167,7 +170,7 @@ initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
     NeutralNonce
     lab
   where
-    cs = Map.fromList (fmap (\hk -> (coerceKeyRole hk, 0)) (Map.elems genDelegs))
+    cs = Map.fromList (fmap (\(hk, _) -> (coerceKeyRole hk, 0)) (Map.elems genDelegs))
 
 instance
   ( Crypto crypto,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -19,15 +19,34 @@ where
 
 import Byron.Spec.Ledger.Core (dom, range)
 import qualified Cardano.Crypto.VRF as VRF
-import Cardano.Prelude (MonadError (..), NoUnexpectedThunks (..), asks, unless)
+import Cardano.Prelude
+  ( MonadError (..),
+    NoUnexpectedThunks (..),
+    asks,
+    unless,
+  )
 import Control.State.Transition
 import Data.Coerce (coerce)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
-import Shelley.Spec.Ledger.BaseTypes (ActiveSlotCoeff, Nonce, Seed, ShelleyBase, activeSlotCoeff)
-import Shelley.Spec.Ledger.BlockChain (BHBody (..), BHeader (..), checkVRFValue, mkSeed, seedEta, seedL)
+import Shelley.Spec.Ledger.BaseTypes
+  ( ActiveSlotCoeff,
+    Nonce,
+    Seed,
+    ShelleyBase,
+    activeSlotCoeff,
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( BHBody (..),
+    BHeader (..),
+    checkVRFValue,
+    mkSeed,
+    seedEta,
+    seedL,
+  )
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import Shelley.Spec.Ledger.Keys
@@ -83,6 +102,7 @@ instance
     = VRFKeyUnknown
         !(KeyHash 'StakePool crypto) -- unknown VRF keyhash (not registered)
     | VRFKeyWrongVRFKey
+        !(KeyHash 'StakePool crypto) -- KeyHash of block issuer
         !(Hash crypto (VerKeyVRF crypto)) --VRF KeyHash registered with stake pool
         !(Hash crypto (VerKeyVRF crypto)) --VRF KeyHash from Header
     | VRFKeyBadNonce
@@ -104,6 +124,10 @@ instance
     | WrongGenesisColdKeyOVERLAY
         !(KeyHash 'BlockIssuer crypto) -- KeyHash of block issuer
         !(KeyHash 'GenesisDelegate crypto) -- KeyHash genesis delegate keyhash assigned to this slot
+    | WrongGenesisVRFKeyOVERLAY
+        !(KeyHash 'BlockIssuer crypto) -- KeyHash of block issuer
+        !(Hash crypto (VerKeyVRF crypto)) --VRF KeyHash registered with genesis delegation
+        !(Hash crypto (VerKeyVRF crypto)) --VRF KeyHash from Header
     | UnknownGenesisKeyOVERLAY
         !(KeyHash 'Genesis crypto) -- KeyHash which does not correspond to o genesis node
     | OcertFailure (PredicateFailure (OCERT crypto)) -- Subtransition Failures
@@ -124,34 +148,49 @@ vrfChecks ::
     VRF.ContextVRF (VRF crypto) ~ ()
   ) =>
   Nonce ->
+  BHBody crypto ->
+  Either (PredicateFailure (OVERLAY crypto)) ()
+vrfChecks eta0 bhb = do
+  unless
+    ( VRF.verifyCertified
+        ()
+        vrfK
+        (mkSeed seedEta slot eta0)
+        (coerce $ bheaderEta bhb)
+    )
+    (throwError $ VRFKeyBadNonce seedEta slot eta0 (coerce $ bheaderEta bhb))
+  unless
+    ( VRF.verifyCertified
+        ()
+        vrfK
+        (mkSeed seedL slot eta0)
+        (coerce $ bheaderL bhb)
+    )
+    (throwError $ VRFKeyBadLeaderValue seedEta slot eta0 (coerce $ bheaderL bhb))
+  where
+    vrfK = bheaderVrfVk bhb
+    slot = bheaderSlotNo bhb
+
+praosVrfChecks ::
+  forall crypto.
+  ( Crypto crypto,
+    VRF.Signable (VRF crypto) Seed,
+    VRF.ContextVRF (VRF crypto) ~ ()
+  ) =>
+  Nonce ->
   PoolDistr crypto ->
   ActiveSlotCoeff ->
   BHBody crypto ->
   Either (PredicateFailure (OVERLAY crypto)) ()
-vrfChecks eta0 (PoolDistr pd) f bhb = do
+praosVrfChecks eta0 (PoolDistr pd) f bhb = do
   let sigma' = Map.lookup hk pd
   case sigma' of
     Nothing -> throwError $ VRFKeyUnknown hk
     Just (sigma, vrfHK) -> do
       unless
         (vrfHK == hashVerKeyVRF vrfK)
-        (throwError $ VRFKeyWrongVRFKey vrfHK (hashVerKeyVRF vrfK))
-      unless
-        ( VRF.verifyCertified
-            ()
-            vrfK
-            (mkSeed seedEta slot eta0)
-            (coerce $ bheaderEta bhb)
-        )
-        (throwError $ VRFKeyBadNonce seedEta slot eta0 (coerce $ bheaderEta bhb))
-      unless
-        ( VRF.verifyCertified
-            ()
-            vrfK
-            (mkSeed seedL slot eta0)
-            (coerce $ bheaderL bhb)
-        )
-        (throwError $ VRFKeyBadLeaderValue seedEta slot eta0 (coerce $ bheaderL bhb))
+        (throwError $ VRFKeyWrongVRFKey hk vrfHK (hashVerKeyVRF vrfK))
+      vrfChecks eta0 bhb
       unless
         (checkVRFValue (VRF.certifiedNatural $ bheaderL bhb) sigma f)
         (throwError $ VRFLeaderValueTooBig (VRF.certifiedNatural $ bheaderL bhb) sigma f)
@@ -159,7 +198,26 @@ vrfChecks eta0 (PoolDistr pd) f bhb = do
   where
     hk = coerceKeyRole . hashKey $ bheaderVk bhb
     vrfK = bheaderVrfVk bhb
-    slot = bheaderSlotNo bhb
+
+pbftVrfChecks ::
+  forall crypto.
+  ( Crypto crypto,
+    VRF.Signable (VRF crypto) Seed,
+    VRF.ContextVRF (VRF crypto) ~ ()
+  ) =>
+  Hash crypto (VerKeyVRF crypto) ->
+  Nonce ->
+  BHBody crypto ->
+  Either (PredicateFailure (OVERLAY crypto)) ()
+pbftVrfChecks vrfHK eta0 bhb = do
+  unless
+    (vrfHK == hashVerKeyVRF vrfK)
+    (throwError $ WrongGenesisVRFKeyOVERLAY hk vrfHK (hashVerKeyVRF vrfK))
+  vrfChecks eta0 bhb
+  pure ()
+  where
+    hk = coerceKeyRole . hashKey $ bheaderVk bhb
+    vrfK = bheaderVrfVk bhb
 
 overlayTransition ::
   forall crypto.
@@ -184,20 +242,21 @@ overlayTransition =
 
         case Map.lookup (bheaderSlotNo bhb) osched of
           Nothing ->
-            vrfChecks eta0 pd asc bhb ?!: id
+            praosVrfChecks eta0 pd asc bhb ?!: id
           Just NonActiveSlot ->
             failBecause $ NotActiveSlotOVERLAY (bheaderSlotNo bhb)
           Just (ActiveSlot gkey) ->
             case Map.lookup gkey genDelegs of
               Nothing ->
                 failBecause $ UnknownGenesisKeyOVERLAY gkey
-              Just genDelegsKey ->
+              Just (genDelegsKey, genesisVrfKH) -> do
                 vkh == coerceKeyRole genDelegsKey ?! WrongGenesisColdKeyOVERLAY vkh genDelegsKey
+                pbftVrfChecks genesisVrfKH eta0 bhb ?!: id
 
         let oce =
               OCertEnv
                 { ocertEnvStPools = dom pd,
-                  ocertEnvGenDelegs = range genDelegs
+                  ocertEnvGenDelegs = Set.map fst $ range genDelegs
                 }
 
         trans @(OCERT crypto) $ TRC (oce, cs, bh)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -72,7 +72,7 @@ pattern KeyHash h = Keys.KeyHash h
 type GenDelegs = Keys.GenDelegs ConcreteCrypto
 
 pattern GenDelegs ::
-  (Map (KeyHash 'Keys.Genesis) (KeyHash 'Keys.GenesisDelegate)) ->
+  (Map (KeyHash 'Keys.Genesis) (KeyHash 'Keys.GenesisDelegate, VRFKeyHash)) ->
   GenDelegs
 pattern GenDelegs m = Keys.GenDelegs m
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -37,7 +37,9 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
     MultiSigPairs,
     SignKeyVRF,
     UTxO,
+    VRFKeyHash,
     VerKeyVRF,
+    hashKeyVRF,
     pattern KeyPair,
   )
 import Test.Shelley.Spec.Ledger.Generator.Constants
@@ -148,10 +150,14 @@ genUtxo0 c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts} = do
       (fmap (toAddr Testnet) genesisKeys ++ fmap (scriptsToAddr Testnet) genesisScripts)
   return (genesisCoins outs)
 
-genesisDelegs0 :: Constants -> Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate)
+genesisDelegs0 :: Constants -> Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate, VRFKeyHash)
 genesisDelegs0 c =
   Map.fromList
-    [ (hashVKey gkey, coerceKeyRole $ hashVKey (cold pkeys))
+    [ ( hashVKey gkey,
+        ( coerceKeyRole $ hashVKey (cold pkeys),
+          hashKeyVRF . snd . vrf $ pkeys
+        )
+      )
       | (gkey, pkeys) <- coreNodeKeys c
     ]
   where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -116,4 +116,4 @@ mkOCertIssueNos ::
 mkOCertIssueNos (GenDelegs delegs0) =
   Map.fromList (fmap f (Map.elems delegs0))
   where
-    f vk = (coerceKeyRole vk, 0)
+    f (vk, _) = (coerceKeyRole vk, 0)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -338,7 +338,7 @@ genUpdate
         case Map.lookup (hashKey . vKey $ gkey) genDelegs_ of
           Nothing ->
             error "genUpdate: NoGenesisStaking"
-          Just gkeyHash ->
+          Just (gkeyHash, _) ->
             fromMaybe
               (cold pkeys)
               (coerceKeyRole <$> Map.lookup (coerceKeyRole gkeyHash) keysByStakeHash)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Mutator.hs
@@ -199,9 +199,9 @@ mutateDCert keys _ (DCertDeleg (Delegate (Delegation _ _))) = do
   delegator' <- getAnyStakeKey keys
   delegatee' <- getAnyStakeKey keys
   pure $ DCertDeleg $ Delegate $ Delegation (KeyHashObj $ hashKey delegator') (coerceKeyRole $ hashKey delegatee')
-mutateDCert keys _ (DCertGenesis (GenesisDelegCert gk _)) = do
+mutateDCert keys _ (DCertGenesis (GenesisDelegCert gk _ vrfKH)) = do
   _delegatee <- getAnyStakeKey keys
-  pure $ DCertGenesis $ GenesisDelegCert gk (coerceKeyRole $ hashKey _delegatee)
+  pure $ DCertGenesis $ GenesisDelegCert gk (coerceKeyRole $ hashKey _delegatee) vrfKH
 mutateDCert _ _ (DCertMir (MIRCert credCoinMap)) = do
   let credCoinList = Map.toList credCoinMap
       coins = List.map snd credCoinList

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
@@ -684,13 +684,14 @@ serializationTests =
         ),
       checkEncodingCBOR
         "genesis_delegation"
-        (DCertGenesis (GenesisDelegCert testGKeyHash (coerceKeyRole testKeyHash1)))
+        (DCertGenesis (GenesisDelegCert testGKeyHash (coerceKeyRole testKeyHash1) testVRFKH))
         ( T
-            ( TkListLen 3
+            ( TkListLen 4
                 . TkWord 5 -- genesis delegation cert
             )
             <> S testGKeyHash -- delegator credential
             <> S testKeyHash1 -- delegatee key hash
+            <> S testVRFKH -- delegatee vrf key hash
         ),
       -- checkEncodingCBOR "mir"
       let rws = Map.singleton testStakeCred 77


### PR DESCRIPTION
Previously, genesis key delegation certificates only registered the delegate cold key. Now the Genesis delegation certificates also register a VRF key, and the resulting genesis delegation map maps genesis keyhashes to pairs of cold keyhashes and vrf keyhashes.

We used to check that new delegates were not in the range of the delegation mapping, but now it is reasonable that a genesis key would want to keep the same cold key and only change the vrf key. Additionally, I realized that we should also exclude the delegates listed in the future delegation mapping. Therefore, we now check that the cold keyhash and the vrf keyhash listed in a genesis delegation certificate are not in either the existing delegation mapping or the future mapping, excluding the genesis key delegates for the genesis key in the certificate.

Moreover, we now check the two VRF values in the overlay/pbft blocks, namely the block nonce and the leader value. We could perhaps skip checking the leader value for pbft blocks since they are not actually used, but for now it is being checked.

I have not updated the formal spec with these changes, but I will do that after merging this PR.

I did not update the property tests to generate genesis delegation certificates with new vrf keys (it just always reuses the previous one), but I did leave a TODO for this.

closes #1481 
closes #1482 