### PR TITLE
MIR certs to draw from reserves or treasury

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -111,7 +111,7 @@ certificate =
   // 6, move_instantaneous_reward      ; move inst. rewards
   ]
 
-move_instantaneous_reward = { * stake_credential => coin }
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => coin } ]
 
 stake_credential =
   [  0, addr_keyhash

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -64,9 +64,7 @@ mkMempoolEnv
     Ledgers.LedgersEnv
       { Ledgers.ledgersSlotNo = slot,
         Ledgers.ledgersPp = LedgerState.esPp nesEs,
-        Ledgers.ledgersReserves =
-          LedgerState._reserves $
-            LedgerState.esAccountState nesEs
+        Ledgers.ledgersAccount = LedgerState.esAccountState nesEs
       }
 
 -- | Construct a mempool state from the wider ledger state.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -71,10 +71,7 @@ mkBbodyEnv
     STS.BbodyEnv
       { STS.bbodySlots = dom nesOsched,
         STS.bbodyPp = LedgerState.esPp nesEs,
-        STS.bbodyReserves =
-          LedgerState._reserves
-            . LedgerState.esAccountState
-            $ nesEs
+        STS.bbodyAccount = LedgerState.esAccountState nesEs
       }
 
 newtype TickTransitionError crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -152,6 +152,6 @@ isInstantaneousRewards _ = False
 -- one witness, and False otherwise. It is mainly used to ensure
 -- that calling a variant of `cwitness` is safe.
 requiresVKeyWitness :: DCert crypto -> Bool
-requiresVKeyWitness (DCertMir (MIRCert _)) = False
+requiresVKeyWitness (DCertMir (MIRCert _ _)) = False
 requiresVKeyWitness (DCertDeleg (RegKey _)) = False
 requiresVKeyWitness _ = True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -261,7 +261,7 @@ chainTransition =
 
       let NewEpochState e1 _ _ _ _ _ _ = nes
           NewEpochState e2 _ bcur es _ _pd osched = nes'
-      let EpochState (AccountState _ _reserves) _ ls _ pp' _ = es
+      let EpochState account _ ls _ pp' _ = es
       let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _ _)) = ls
 
       let ph = lastAppliedHash lab
@@ -276,7 +276,7 @@ chainTransition =
 
       BbodyState ls' bcur' <-
         trans @(BBODY crypto) $
-          TRC (BbodyEnv (Map.keysSet osched) pp' _reserves, BbodyState ls bcur, block)
+          TRC (BbodyEnv (Map.keysSet osched) pp' account, BbodyState ls bcur, block)
 
       let nes'' = updateNES nes' bcur' ls'
           bhb = bhbody bh

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -38,7 +38,8 @@ import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState
-  ( DPState (..),
+  ( AccountState,
+    DPState (..),
     _dstate,
     _rewards,
     _stPools,
@@ -58,7 +59,7 @@ data DelegsEnv crypto = DelegsEnv
     delegsIx :: Ix,
     delegspp :: PParams,
     delegsTx :: (Tx crypto),
-    delegsReserves :: Coin
+    delegsAccount :: AccountState
   }
   deriving (Show)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -33,7 +33,6 @@ import Shelley.Spec.Ledger.LedgerState
   ( _delegationState,
     _dstate,
     _genDelegs,
-    _reserves,
     esLState,
     esPp,
     getGKeys,
@@ -225,7 +224,7 @@ genBlock
           <$> pure hashheader
           <*> pure keys'
           <*> toList
-          <$> genTxs pp' (_reserves acnt) ls nextSlot
+          <$> genTxs pp' acnt ls nextSlot
           <*> pure nextSlot
           <*> pure (block + 1)
           <*> pure epochNonce

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -80,7 +80,11 @@ data Constants = Constants
     frequencyLowMaxEpoch :: Word64,
     maxMinFeeA :: Natural,
     maxMinFeeB :: Natural,
-    numCoreNodes :: Word64
+    numCoreNodes :: Word64,
+    minTreasury :: Integer,
+    maxTreasury :: Integer,
+    minReserves :: Integer,
+    maxReserves :: Integer
   }
   deriving (Show)
 
@@ -120,5 +124,9 @@ defaultConstants =
       frequencyLowMaxEpoch = 6,
       maxMinFeeA = 1000,
       maxMinFeeB = 3,
-      numCoreNodes = 7
+      numCoreNodes = 7,
+      minTreasury = 1000000,
+      maxTreasury = 10000000,
+      minReserves = 1000000,
+      maxReserves = 10000000
     }

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -58,7 +58,8 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.PParams (PParams, _d)
 import Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
 import Shelley.Spec.Ledger.TxData
-  ( RewardAcnt (..),
+  ( MIRPot (..),
+    RewardAcnt (..),
     _poolPubKey,
     _poolVrf,
     unStakePools,
@@ -456,6 +457,7 @@ genInstantaneousRewards s coreKeys pparams delegSt = do
     take <$> QC.elements [0 .. (max 0 $ (Map.size credentials) - 1)]
       <*> QC.shuffle (Map.keys credentials)
   coins <- genCoinList 1 1000 (length winnerCreds) (length winnerCreds)
+  pot <- QC.elements [ReservesMIR, TreasuryMIR]
 
   coreSigners <-
     take <$> QC.elements [5 .. (max 0 $ (length coreKeys) - 1)]
@@ -475,6 +477,6 @@ genInstantaneousRewards s coreKeys pparams delegSt = do
       then Nothing
       else
         Just
-          ( DCertMir (MIRCert credCoinMap),
+          ( DCertMir (MIRCert pot credCoinMap),
             CoreKeyCred coreSigners
           )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Mutator.hs
@@ -202,8 +202,8 @@ mutateDCert keys _ (DCertDeleg (Delegate (Delegation _ _))) = do
 mutateDCert keys _ (DCertGenesis (GenesisDelegCert gk _ vrfKH)) = do
   _delegatee <- getAnyStakeKey keys
   pure $ DCertGenesis $ GenesisDelegCert gk (coerceKeyRole $ hashKey _delegatee) vrfKH
-mutateDCert _ _ (DCertMir (MIRCert credCoinMap)) = do
+mutateDCert _ _ (DCertMir (MIRCert pot credCoinMap)) = do
   let credCoinList = Map.toList credCoinMap
       coins = List.map snd credCoinList
   coins' <- mapM (mutateCoin 1 100) coins
-  pure $ DCertMir $ MIRCert $ Map.fromList $ zip (List.map fst credCoinList) coins'
+  pure $ DCertMir $ MIRCert pot $ Map.fromList $ zip (List.map fst credCoinList) coins'

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
@@ -247,7 +247,7 @@ propCheckRedundantWitnessSet = property $ do
   let tx = _body txwits
   let witness = makeWitnessVKey (hashTxBody tx) keyPair
   let txwits' = txwits {_witnessVKeySet = (Set.insert witness (_witnessVKeySet txwits))}
-  let l'' = asStateTransition (SlotNo $ fromIntegral steps) emptyPParams l txwits' (Coin 0)
+  let l'' = asStateTransition (SlotNo $ fromIntegral steps) emptyPParams l txwits' (AccountState 0 0)
   classify
     "unneeded signature added"
     (not $ witness `Set.member` (_witnessVKeySet txwits))
@@ -276,7 +276,7 @@ propCheckMissingWitness = property $ do
           emptyPParams
           l
           (txwits {_witnessVKeySet = witnessVKeySet'})
-          (Coin 0)
+          (AccountState 0 0)
   let isRealSubset =
         witnessVKeySet' `Set.isSubsetOf` witnessVKeySet''
           && witnessVKeySet' /= witnessVKeySet''

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -56,16 +56,21 @@ import Test.Shelley.Spec.Ledger.Examples
     ex3C,
     ex4A,
     ex4B,
-    ex5A,
-    ex5B,
-    ex5C,
-    ex5D',
+    ex5AReserves,
+    ex5ATreasury,
+    ex5BReserves,
+    ex5BTreasury,
+    ex5CReserves,
+    ex5CTreasury,
+    ex5DReserves',
+    ex5DTreasury',
     ex6A,
     ex6A',
     ex6BExpectedNES,
     ex6BExpectedNES',
     ex6BPoolParams,
-    test5D,
+    test5DReserves,
+    test5DTreasury,
   )
 import Test.Shelley.Spec.Ledger.MultiSigExamples
   ( aliceAndBob,
@@ -165,10 +170,18 @@ stsTests =
       testCase "CHAIN example 3C - processes a pparam update" $ testCHAINExample ex3C,
       testCase "CHAIN example 4A - stage genesis key delegation" $ testCHAINExample ex4A,
       testCase "CHAIN example 4B - adopt genesis key delegation" $ testCHAINExample ex4B,
-      testCase "CHAIN example 5A - create MIR cert" $ testCHAINExample ex5A,
-      testCase "CHAIN example 5B - FAIL: insufficient core node signatures" $ testCHAINExample ex5B,
-      testCase "CHAIN example 5C - FAIL: MIR insufficient reserves" $ testCHAINExample ex5C,
-      testCase "CHAIN example 5D - apply MIR at epoch boundary" test5D,
+      testCase "CHAIN example 5A - create MIR cert - reserves" $ testCHAINExample ex5AReserves,
+      testCase "CHAIN example 5A - create MIR cert - treasury" $ testCHAINExample ex5ATreasury,
+      testCase "CHAIN example 5B - FAIL: insufficient core node signatures MIR reserves" $
+        testCHAINExample ex5BReserves,
+      testCase "CHAIN example 5B - FAIL: insufficient core node signatures MIR treasury" $
+        testCHAINExample ex5BTreasury,
+      testCase "CHAIN example 5C - FAIL: MIR insufficient reserves" $
+        testCHAINExample ex5CReserves,
+      testCase "CHAIN example 5C - FAIL: MIR insufficient treasury" $
+        testCHAINExample ex5CTreasury,
+      testCase "CHAIN example 5D - apply reserves MIR at epoch boundary" test5DReserves,
+      testCase "CHAIN example 5D - apply treasury MIR at epoch boundary" test5DTreasury,
       testCase "CHAIN example 6A - Early Pool Re-registration" $ testCHAINExample ex6A,
       testCase "CHAIN example 6A' - Late Pool Re-registration" $ testCHAINExample ex6A',
       testCase "CHAIN example 6B - Adopt Early Pool Re-registration" $ testAdoptEarlyPoolRegistration,
@@ -191,9 +204,14 @@ stsTests =
       testCase "CHAIN example 3C - Preservation of ADA" $ testPreservationOfAda ex3C,
       testCase "CHAIN example 4A - Preservation of ADA" $ testPreservationOfAda ex4A,
       testCase "CHAIN example 4B - Preservation of ADA" $ testPreservationOfAda ex4B,
-      testCase "CHAIN example 5A - Preservation of ADA" $ testPreservationOfAda ex5A,
-      testCase "CHAIN example 5D - Preservation of ADA" $
-        (totalAda (fromRight (error "CHAIN example 5D") ex5D') @?= maxLLSupply),
+      testCase "CHAIN example 5A Reserves - Preservation of ADA" $
+        testPreservationOfAda ex5AReserves,
+      testCase "CHAIN example 5A Treasury - Preservation of ADA" $
+        testPreservationOfAda ex5ATreasury,
+      testCase "CHAIN example 5D Reserves - Preservation of ADA" $
+        (totalAda (fromRight (error "CHAIN example 5D") ex5DReserves') @?= maxLLSupply),
+      testCase "CHAIN example 5D Treasury - Preservation of ADA" $
+        (totalAda (fromRight (error "CHAIN example 5D") ex5DTreasury') @?= maxLLSupply),
       testCase "CHAIN example 6A - Preservation of ADA" $ testPreservationOfAda ex6A,
       testCase "Alice uses SingleSig script" testAliceSignsAlone,
       testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
@@ -165,7 +165,8 @@ import Shelley.Spec.Ledger.Serialization
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
 import Shelley.Spec.Ledger.TxData
-  ( PoolMetaData (..),
+  ( MIRPot (..),
+    PoolMetaData (..),
     StakePoolRelay (..),
     Wdrl (..),
     WitVKey (..),
@@ -732,10 +733,12 @@ serializationUnitTests =
       let rws = Map.singleton testStakeCred 77
        in checkEncodingCBOR
             "mir"
-            (DCertMir (MIRCert rws))
+            (DCertMir (MIRCert ReservesMIR rws))
             ( T
                 ( TkListLen 2
                     . TkWord 6 -- make instantaneous rewards cert
+                    . TkListLen 2
+                    . TkWord 0 -- take from the reserves
                 )
                 <> S rws
             ),

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SerializationProperties.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SerializationProperties.hs
@@ -92,7 +92,8 @@ import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS (PrtclState)
 import Shelley.Spec.Ledger.Scripts (ScriptHash (ScriptHash))
 import Shelley.Spec.Ledger.TxData
-  ( PoolMetaData (PoolMetaData),
+  ( MIRPot,
+    PoolMetaData (PoolMetaData),
     PoolParams (PoolParams),
     RewardAcnt (RewardAcnt),
     StakePoolRelay,
@@ -268,6 +269,9 @@ instance Arbitrary UnitInterval where
 
 instance Crypto c => Arbitrary (KeyHash a c) where
   arbitrary = KeyHash <$> genHash (Proxy @c)
+
+instance Arbitrary MIRPot where
+  arbitrary = genericArbitraryU
 
 instance Arbitrary Natural where
   arbitrary = fromInteger <$> choose (0, 1000)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -20,7 +20,8 @@ import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.Credential (Credential (..), pattern StakeRefBase)
 import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, hashKey, vKey)
 import Shelley.Spec.Ledger.LedgerState
-  ( _dstate,
+  ( AccountState (..),
+    _dstate,
     _rewards,
     emptyDState,
     emptyPState,
@@ -220,7 +221,7 @@ addReward dp ra c = dp {_dstate = ds {_rewards = rewards}}
     rewards = Map.insert ra c $ _rewards ds
 
 ledgerEnv :: LedgerEnv
-ledgerEnv = LedgerEnv (SlotNo 0) 0 pp 0
+ledgerEnv = LedgerEnv (SlotNo 0) 0 pp (AccountState 0 0)
 
 testInvalidTx ::
   [PredicateFailure LEDGER] ->
@@ -368,7 +369,7 @@ testExpiredTx =
               ttl = (SlotNo 0),
               signers = [asWitness alicePay]
             }
-      ledgerEnv' = LedgerEnv (SlotNo 1) 0 pp 0
+      ledgerEnv' = LedgerEnv (SlotNo 1) 0 pp (AccountState 0 0)
    in testLEDGER (utxoState, dpState) tx ledgerEnv' (Left [errs])
 
 testInvalidWintess :: Assertion


### PR DESCRIPTION
This PR adds the ability for the MIR certificates to state whether they will draw from the reserves or the treasury.

Now the MIR certs contain an addition field, with value `ReservesMIR` or `TreasuryMIR`. Additionally, the delegation state now maintains two separate mappings, one for reserves and one for treasury, for giving out instantaneous rewards at the end of the epoch. Similar checks for the reserves, such as not taking in below zero, are in place for the treasury. For this reason, the whole `AccountState` (as apposed to just the rewards) now needs to be passed in the environment from the top level `CHAIN` rule down to `DELEG`.

~I am marking this PR as a draft, but it is nearly done, I really just want to add more tests.~
EDIT: I have updated the tests to check both MIR certs with reserves and treasury.

(And I will update the spec after this PR is merged)

closes #1484 