### PR TITLE
network ID in spec, appendix for binary addr fmt

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/address-binary.tex
+++ b/shelley/chain-and-ledger/formal-spec/address-binary.tex
@@ -1,0 +1,108 @@
+\section{Binary Address Format}
+\label{sec:address-binary}
+
+\newcommand{\binary}[1]{\ensuremath{\mathsf{#1}}}
+
+Excepting bootstrap addresses,
+the binary format for every address has a 1-byte header, followed by a payload
+(bootstrap addresses use the binary encoding from the Byron era).
+The header is composed of two nibbles (two 4-bit segments),
+indicating the address type and the network id.
+
+$$
+\begin{array}{r@{~=~}l}
+    \mathsf{address} & \mathsf{header\_byte}|\mathsf{payload} \\
+                     & \mathsf{addr\_type\_nibble}|\mathsf{network\_nibble}|\mathsf{payload}
+\end{array}
+$$
+
+\subsection{Header, first nibble}
+\label{sec:address-binary-header-first-nibble}
+
+The first nibble of the header specifies the type of the address.
+Bootstrap addresses can also be identified by the first nibble.
+
+\begin{center}
+\begin{tabular}{ |c|c|c|c| }
+ \hline
+ address type & payment credential & stake credential & header, first nibble \\
+ \hline
+ \hline
+ base address & keyhash      & keyhash    & \binary{0000} \\
+ base address & scripthash   & keyhash    & \binary{0001} \\
+ base address & keyhash      & scripthash & \binary{0010} \\
+ base address & scripthash   & scripthash & \binary{0011} \\
+ \hline
+ pointer address & keyhash    & ptr & \binary{0100} \\
+ pointer address & scripthash & ptr & \binary{0101} \\
+ \hline
+ enterprise address & keyhash    & - & \binary{0110} \\
+ enterprise address & scripthash & - & \binary{0111} \\
+ \hline
+ bootstrap address & keyhash    & - & \binary{1000} \\
+ \hline
+ stake address & - & keyhash & \binary{1110} \\
+ stake address & - & scripthash & \binary{1111} \\
+ \hline
+ future formats & ? & ? & \binary{1001}-\binary{1101} \\
+ \hline
+\end{tabular}
+\end{center}
+
+\subsection{Header, second nibble}
+\label{sec:address-binary-header-second-nibble}
+
+Excepting boostrap addresses, the second nibble of the header specifies the network.
+
+\begin{center}
+\begin{tabular}{ |c|c| }
+ \hline
+ network & header, second nibble \\
+ \hline
+ \hline
+ testnets & \binary{0000} \\
+ mainnet & \binary{0001} \\
+ future networks & \binary{0010}-\binary{1111}\\
+ \hline
+\end{tabular}
+\end{center}
+
+\subsection{Header, examples}
+\label{sec:address-binary-header-examples}
+
+On a \textbf{testnet},
+the header for a \textbf{pointer} address whose payment credential is a \textbf{keyhash} is:
+$$\binary{00000100}$$
+
+On \textbf{mainnet}, the header for a \textbf{pointer} address whose payment credential is a \textbf{keyhash} is:
+$$\binary{00010100}$$
+
+On \textbf{mainnet}, the header for a \textbf{pointer} address whose payment credential is a \textbf{scripthash} is:
+$$\binary{00010101}$$
+
+\subsection{Payloads}
+\label{sec:address-binary-payloads}
+
+The payload for the different address types are as follows:
+
+\begin{center}
+\begin{tabular}{ |c|c| }
+ \hline
+ address type & payload \\
+ \hline
+ \hline
+ base address & two 28-byte bytestrings \\
+ \hline
+ pointer address & one 28-byte bytestring,
+ and three variable-length unsigned integers \\
+ \hline
+ enterprise address & one 28-byte bytestrings \\
+ \hline
+ stake address & one 28-byte bytestrings \\
+ \hline
+\end{tabular}
+\end{center}
+
+The variable-length encoding used in pointers addresses is the base-128 representation
+of the number, with the the most significant bit of each byte indicating continuation.
+If the significant bit is $0$, then another bytes follows.

--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -66,6 +66,8 @@ outlined in the rules in Sections~\ref{sec:utxo} and Section~\ref{sec:epoch}.
 For each staking credential, we use the function $\fun{addr_{rwd}}$ to create
 the reward address corresponding to the credential, or to access an existing one
 if it already exists.
+Note that $\fun{addr_{rwd}}$ uses the global constant $\NetworkId$ to
+attach a network ID to the given stake credential.
 
 Base, pointer and enterprise addresses contain a payment credential which is
 either a key hash or a script hash. Base addresses contain a staking credential
@@ -76,15 +78,16 @@ which is also either a key hash or a script hash.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      slot & \Slot & \text{absolute slot}\\
-      ix & \Ix & \text{index}\\
+      \var{slot} & \Slot & \text{absolute slot}\\
+      \var{ix} & \Ix & \text{index}\\
+      \var{net} & \Network & \text{either $\mathsf{Testnet}$ or $\mathsf{Mainnet}$}\\
     \end{array}
   \end{equation*}
   %
   \emph{Derived types}
   %
   \begin{equation*}
-    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+    \begin{array}{r@{\in}l@{\qquad=\qquad}lr}
       \var{cred} & \Credential & \KeyHash\uniondistinct\HashScr \\
       \var{(s,t,c)}
       & \Ptr
@@ -93,22 +96,22 @@ which is also either a key hash or a script hash.
       \\
       \var{addr}
       & \AddrB
-      & \Credential_{pay}\times\Credential_{stake}
+      & \NetworkId\times\Credential_{pay}\times\Credential_{stake}
       & \text{base address}
       \\
       \var{addr}
       & \AddrP
-      & \Credential_{pay}\times\Ptr
+      & \NetworkId\times\Credential_{pay}\times\Ptr
       & \text{pointer address}
       \\
       \var{addr}
       & \AddrE
-      & \Credential_{pay}
+      & \NetworkId\times\Credential_{pay}
       & \text{enterprise address}
       \\
       \var{addr}
       & \AddrBS
-      & \KeyHash_{pay}
+      & \NetworkId\times\KeyHash_{pay}
       & \text{bootstrap address}
       \\
       \var{addr}
@@ -122,7 +125,7 @@ which is also either a key hash or a script hash.
       \\
       \var{acct}
       & \AddrRWD
-      & \Credential_{stake}
+      & \NetworkId\times\Credential_{stake}
       & \text{reward account}
       \\
     \end{array}
@@ -186,6 +189,8 @@ which is also either a key hash or a script hash.
                                                    from reward addr}\\
       \fun{addrPtr} & \AddrP \to \Ptr
                     & \text{pointer from pointer addr}\\
+      \fun{netId} & \Addr \to \NetworkId
+                    & \text{network Id from addr}\\
     \end{array}
   \end{equation*}
   %
@@ -195,7 +200,10 @@ which is also either a key hash or a script hash.
     \begin{array}{r@{~\in~}lr}
       \fun{addr_{rwd}}
         & \Credential_{stake} \to \AddrRWD
-        & \text{construct a reward account}
+        & \begin{array}{l}
+            \text{construct a reward account,} \\
+            \text{implicitly using $\NetworkId$}
+          \end{array}
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -295,6 +295,8 @@ and the protocol parameters.
       \var{stpools} & \StakePools & \text{registered pools to creation time}\\
       \var{poolParams} & \KeyHash_{pool} \mapsto \PoolParam
         & \text{registered pools to pool parameters}\\
+      \var{fPoolParams} & \KeyHash_{pool} \mapsto \PoolParam
+        & \text{future pool parameters}\\
       \var{retiring} & \KeyHash_{pool} \mapsto \Epoch & \text{retiring stake pools}\\
     \end{array}\right)
     \end{array}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -82,6 +82,8 @@
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
 \newcommand{\MaxMajorPV}{\mathsf{MaxMajorPV}}
 \newcommand{\ActiveSlotCoeff}{\mathsf{ActiveSlotCoeff}}
+\newcommand{\Network}{\mathsf{Network}}
+\newcommand{\NetworkId}{\mathsf{NetworkId}}
 \newcommand{\BlockNo}{\type{BlockNo}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}
 \newcommand{\Quorum}{\ensuremath{\mathsf{Quorum}}}
@@ -316,6 +318,7 @@
 \clearpage
 \begin{appendix}
   \input{crypto-details}
+  \input{address-binary}
   \input{cddl}
   \input{txsize}
   \input{proofs}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -1,6 +1,9 @@
 \section{Protocol Parameters}
 \label{sec:protocol-parameters}
 
+\subsection{Updatble Protocol Parameters}
+\label{sec:updatable-protocol-parameters}
+
 The Shelley protocol parameters are listed in Figure~\ref{fig:defs:protocol-parameters}.
 Some of the Shelley protocol parameters are common to the Byron era,
 specifically, the common ones are $\var{a}$, $\var{b}$, $\var{maxTxSize}$, and
@@ -19,36 +22,6 @@ system explained in Section~\ref{sec:update}.
 The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
 and $\Z$ is only chosen over $\N$ for its additive inverses.
-
-Nine global constants are defined.
-As global constants, these values can only be changed by updating the software,
-i.e. a soft or a hard fork.
-For the software update mechanism, see Section~\ref{sec:software-updates}.
-The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
-represent the number of slots in an epoch/KES period (for a brief explanation
-of a KES period, see Section \ref{sec:crypto-primitives-shelley}).
-The constants $\StabilityWindow$ and $\RandomnessStabilisationWindow$ concern the chain stability.
-The maximum number of time a KES key can be evolved before a pool operator
-must create a new operational certificate is given by $\MaxKESEvo$.
-\textbf{Note that if } $\MaxKESEvo$
-\textbf{is changed, the KES signature format may have to change as well.}
-The constant $\ActiveSlotCoeff$ is the value $f$ from the
-Praos paper \cite{ouroboros_praos}.
-
-The constant $\Quorum$ determines the quorum amount needed for votes on the
-protocol parameter updates and the application version updates.
-
-The constant $\MaxMajorPV$ provides a mechanism for halting outdated nodes.
-Once the major component of the protocol version in the protocol parameters
-exceeds this value, every subsequent block is invalid.
-See Figure~\ref{fig:rules:chain}.
-
-Finally, $\MaxLovelaceSupply$ gives the total number of lovelace in the system,
-which is used in the reward calculation.
-It is always equal to the sum of the values in the UTxO, plus the sum of the
-values in the reward accounts, plus the deposit pot, plus the fee pot,
-plus the treasury and the reserves.
-
 
 Some helper functions are defined in Figure~\ref{fig:defs:protocol-parameters-helpers}.
 The $\fun{minfee}$ function calculates the minimum fee that must be paid by a transaction.
@@ -150,7 +123,7 @@ without being explicit about the types and conversion.
     \fun{d},
     \fun{extraEntropy},
     \fun{pv},
-    \fun{minUTxOValue},
+    \fun{minUTxOValue}
   \end{center}
   %
   \emph{Abstract Functions}
@@ -162,6 +135,52 @@ without being explicit about the types and conversion.
     \end{array}
   \end{equation*}
   %
+  \caption{Definitions Used in Protocol Parameters}
+  \label{fig:defs:protocol-parameters}
+\end{figure*}
+
+\subsection{Global Constants}
+\label{sec:global-constants}
+
+In additon to the updatable protocol parameters defined in
+Section~\ref{sec:updatable-protocol-parameters},
+there are ten parameters which cannot be changed by the update
+system in Section~\ref{sec:update}.
+We call these the global constants, as changing these values can only
+be done by updating the software, i.e. a soft or a hard fork.
+For the software update mechanism, see Section~\ref{sec:software-updates}.
+
+The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
+represent the number of slots in an epoch/KES period (for a brief explanation
+of a KES period, see Section \ref{sec:crypto-primitives-shelley}).
+The constants $\StabilityWindow$ and $\RandomnessStabilisationWindow$ concern the chain stability.
+The maximum number of time a KES key can be evolved before a pool operator
+must create a new operational certificate is given by $\MaxKESEvo$.
+\textbf{Note that if } $\MaxKESEvo$
+\textbf{is changed, the KES signature format may have to change as well.}
+
+The constant $\Quorum$ determines the quorum amount needed for votes on the
+protocol parameter updates and the application version updates.
+
+The constant $\MaxMajorPV$ provides a mechanism for halting outdated nodes.
+Once the major component of the protocol version in the protocol parameters
+exceeds this value, every subsequent block is invalid.
+See Figure~\ref{fig:rules:chain}.
+
+The constant $\MaxLovelaceSupply$ gives the total number of lovelace in the system,
+which is used in the reward calculation.
+It is always equal to the sum of the values in the UTxO, plus the sum of the
+values in the reward accounts, plus the deposit pot, plus the fee pot,
+plus the treasury and the reserves.
+
+The constant $\ActiveSlotCoeff$ is the value $f$ from the
+Praos paper \cite{ouroboros_praos}.
+
+Lastly, $\NetworkId$ determines what network, either mainnet or testnet, is expected.
+This value will also appear inside every address, and transactions
+containing addresses with an unexpected network ID are rejected.
+
+\begin{figure*}[htb]
   \emph{Global Constants}
   %
   \begin{equation*}
@@ -182,12 +201,13 @@ without being explicit about the types and conversion.
       \Quorum & \N & \text{- quorum for update system votes}\\
       \MaxMajorPV & \N & \text{- all blocks are invalid after this value}\\
       \MaxLovelaceSupply & \Coin & \text{- total lovelace in the system}\\
-      \ActiveSlotCoeff & (0, 1] & -~f\text{ in \cite{ouroboros_praos}}\\
+      \ActiveSlotCoeff & (0, 1] & \text{ - }f\text{ in \cite{ouroboros_praos}}\\
+      \NetworkId & \Network & \text{- the network, mainnet or testnet}\\
     \end{array}
   \end{equation*}
   %
-  \caption{Definitions Used in Protocol Parameters}
-  \label{fig:defs:protocol-parameters}
+  \caption{Global Constants}
+  \label{fig:defs:global-constants}
 \end{figure*}
 
 \begin{figure*}[htb]

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -313,7 +313,9 @@ requests).
       \\
       ~
       \\
-      \forall (\_\mapsto (\_, c)) \in \txouts{txb}, c \geq (\fun{minUTxOValue}~\var{pp})
+      \forall (\wcard\mapsto (\wcard,~c)) \in \txouts{txb}, c \geq (\fun{minUTxOValue}~\var{pp})
+      \\
+      \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, \fun{netId}~a =\NetworkId
       \\
       \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
       \\


### PR DESCRIPTION
Updating the formal spec to include network IDs in the addresses (including reward accounts), as was added to the implementation in #1487 

There is a new global constant, `NeworkId` for the network (mainnet or testnet), and in the `UTxO` rule we have a new predicate that checks that each address contains the correct network ID (as per the global constant).

The protocol parameter / global constant table was getting a bit huge, so I split it up.

I also added a new section to the appendix for the binary address format.

closes #1489 