### PR TITLE
remove set tag from cddl file

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/real/extras.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/real/extras.cddl
@@ -1,4 +1,4 @@
-finite_set<a> = #6.258([* a ])
+finite_set<a> = [* a ]
 
 unit_interval = #6.30([uint, uint])
 


### PR DESCRIPTION
:microscope: Micro PR :microscope: 

Remove the cddl set tag `#6.258` from the cddl file `cddl-files/real/extras.cddl`.

We decided to just use lists a while ago (as is mentioned in the comment in `cddl-files/mock/extras.cddl`), but we missed this spot. 