### PR TITLE
use <= current epoch + eMax for latest pool retirement

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -129,7 +129,7 @@ poolDelegationTransition = do
         ei <- asks epochInfo
         epochInfoEpoch ei slot
       let EpochNo maxEpoch = _eMax pp
-      cepoch < e && e < cepoch + maxEpoch
+      cepoch < e && e <= cepoch + maxEpoch
         ?! StakePoolRetirementWrongEpochPOOL cepoch e (cepoch + maxEpoch)
       pure $ ps {_retiring = _retiring ps ⨃ (hk, EpochNo e)}
     DCertDeleg _ -> do

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -439,7 +439,7 @@ genRetirePool Constants {frequencyLowMaxEpoch} keysByHash pState slot =
     -- future updates of the protocol parameter, MaxEpoch, will not decrease
     -- the cut-off for pool-retirement and render this RetirePool
     -- "too late in the epoch" when it is retired
-    epochHigh = cepoch + frequencyLowMaxEpoch - 1
+    epochHigh = cepoch + frequencyLowMaxEpoch
 
 -- | Generate an InstantaneousRewards Transfer certificate
 genInstantaneousRewards ::

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -701,7 +701,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     Given a slot number $\var{slot}$, the application of this rule requires that the
     planned retirement epoch $\var{e}$ stated in the certificate is in the future,
     i.e.~after $\var{cepoch}$ (the epoch of the current slot number in this context) and
-    that it is less than $\emax$ epochs after the current one.
+    that it is no more than than $\emax$ epochs after the current one.
     It is also required that the pool be registered.
     Note that imposing the $\emax$ constraint on the system is not strictly necessary.
     However, forcing stake pools to announce their retirement a shorter time in
@@ -801,7 +801,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     & \var{hk} \in \dom \var{stpools} \\
     \var{e} \leteq \retire{c}
     & \var{cepoch} \leteq \epoch{slot}
-    & \var{cepoch} < \var{e} < \var{cepoch} + (\fun{emax}~{pp})
+    & \var{cepoch} < \var{e} \leq \var{cepoch} + (\fun{emax}~{pp})
   }
   {
     \begin{array}{r}


### PR DESCRIPTION
The protocol parameter `eMax` determines how far out in advance a stake pool can stage a retirement.

Previously `current epoch + eMax` was the _first unallowed_ epoch. And since a stake pool must in a future epoch, this means that if `eMax = 1` then retirement is not possible. The parameter `eMax` should really be set to something much higher than `1`, but making  `current epoch + eMax` the _last allowed_ epoch is perhaps more intuitive.

closes https://github.com/input-output-hk/cardano-node/issues/1121