### PR TITLE
use Ratio Word64 for UnitInterval

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -106,6 +106,7 @@ import Shelley.Spec.Ledger.BaseTypes
     intervalValue,
     mkNonce,
     strictMaybeToMaybe,
+    unitIntervalToRational,
   )
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
@@ -643,7 +644,7 @@ checkVRFValue certNat σ f =
           BELOW _ _ -> True
           MaxReached _ -> False
   where
-    leaderVal = (intervalValue . fromNatural) certNat
+    leaderVal = (unitIntervalToRational . fromNatural) certNat
     c = activeSlotLog f
     q = fromRational $ 1 - leaderVal
     x = (- fromRational σ * c)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -239,7 +239,7 @@ instance VRFValue Nonce where
 
 instance VRFValue UnitInterval where
   -- TODO Consider whether this is a reasonable thing to do
-  fromNatural k = truncateUnitInterval $ toInteger k % 10000
+  fromNatural k = truncateUnitInterval $ fromIntegral k % 10000
 
 --------------------------------------------------------------------------------
 -- Genesis delegation

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -64,8 +64,8 @@ import Shelley.Spec.Ledger.Serialization
     decodeMapContents,
     mapFromCBOR,
     mapToCBOR,
-    rationalFromCBOR,
-    rationalToCBOR,
+    ratioFromCBOR,
+    ratioToCBOR,
   )
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 
@@ -198,7 +198,7 @@ instance ToCBOR PParams where
         <> toCBOR poolDeposit'
         <> toCBOR eMax'
         <> toCBOR nOpt'
-        <> rationalToCBOR a0'
+        <> ratioToCBOR a0'
         <> toCBOR rho'
         <> toCBOR tau'
         <> toCBOR d'
@@ -219,7 +219,7 @@ instance FromCBOR PParams where
       <*> fromCBOR -- _poolDeposit     :: Coin
       <*> fromCBOR -- _eMax            :: EpochNo
       <*> fromCBOR -- _nOpt            :: Natural
-      <*> rationalFromCBOR -- _a0              :: Rational
+      <*> ratioFromCBOR -- _a0         :: Rational
       <*> fromCBOR -- _rho             :: UnitInterval
       <*> fromCBOR -- _tau             :: UnitInterval
       <*> fromCBOR -- _d               :: UnitInterval
@@ -295,7 +295,7 @@ instance ToCBOR PParamsUpdate where
               encodeMapElement 6 toCBOR =<< _poolDeposit ppup,
               encodeMapElement 7 toCBOR =<< _eMax ppup,
               encodeMapElement 8 toCBOR =<< _nOpt ppup,
-              encodeMapElement 9 rationalToCBOR =<< _a0 ppup,
+              encodeMapElement 9 ratioToCBOR =<< _a0 ppup,
               encodeMapElement 10 toCBOR =<< _rho ppup,
               encodeMapElement 11 toCBOR =<< _tau ppup,
               encodeMapElement 12 toCBOR =<< _d ppup,
@@ -342,7 +342,7 @@ instance FromCBOR PParamsUpdate where
         6 -> fromCBOR >>= \x -> pure (6, \up -> up {_poolDeposit = SJust x})
         7 -> fromCBOR >>= \x -> pure (7, \up -> up {_eMax = SJust x})
         8 -> fromCBOR >>= \x -> pure (8, \up -> up {_nOpt = SJust x})
-        9 -> rationalFromCBOR >>= \x -> pure (9, \up -> up {_a0 = SJust x})
+        9 -> ratioFromCBOR >>= \x -> pure (9, \up -> up {_a0 = SJust x})
         10 -> fromCBOR >>= \x -> pure (10, \up -> up {_rho = SJust x})
         11 -> fromCBOR >>= \x -> pure (11, \up -> up {_tau = SJust x})
         12 -> fromCBOR >>= \x -> pure (12, \up -> up {_d = SJust x})

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -76,6 +76,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     KeySpace (..),
     NatNonce (..),
     genNatural,
+    genWord64,
     getKESPeriodRenewalNo,
     mkBlock,
     mkOCert,
@@ -269,12 +270,13 @@ genBlock
             -- integer in [1,10]. This value is guaranteed to be below the ϕ
             -- function for the VRF value comparison and generates a valid leader
             -- value for Praos.
+            let (stNumer, stDenom) = (fromIntegral $ numerator stake, fromIntegral $ denominator stake)
             let stake' =
                   if stake > 0
-                    then (numerator stake - 1) % denominator stake
-                    else stake
+                    then (stNumer - 1) % stDenom
+                    else stNumer % stDenom
                 asc = activeSlotCoeff testGlobals
-            n <- genNatural 1 10
+            n <- genWord64 1 10
             pure
               ( unsafeMkUnitInterval
                   ( (stake' / fromIntegral n)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -17,7 +17,8 @@ where
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
-import Data.Ratio ((%))
+import Data.Ratio ((%), Ratio)
+import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.BaseTypes
@@ -81,9 +82,13 @@ genRationalInThousands :: HasCallStack => Integer -> Integer -> Gen Rational
 genRationalInThousands lower upper =
   (% 1000) <$> genInteger lower upper
 
-genIntervalInThousands :: HasCallStack => Integer -> Integer -> Gen UnitInterval
+genRatioWord64InThousands :: HasCallStack => Word64 -> Word64 -> Gen (Ratio Word64)
+genRatioWord64InThousands lower upper =
+  (% 1000) <$> genWord64 lower upper
+
+genIntervalInThousands :: HasCallStack => Word64 -> Word64 -> Gen UnitInterval
 genIntervalInThousands lower upper =
-  unsafeMkUnitInterval <$> genRationalInThousands lower upper
+  unsafeMkUnitInterval <$> genRatioWord64InThousands lower upper
 
 genPParams :: HasCallStack => Constants -> Gen PParams
 genPParams c@(Constants {maxMinFeeA, maxMinFeeB}) =

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
@@ -555,7 +555,7 @@ serializationUnitTests =
       checkEncodingCBOR
         "rational"
         (UnsafeUnitInterval (1 % 2))
-        (T (TkTag 30 . TkListLen 2 . TkInteger 1 . TkInteger 2)),
+        (T (TkTag 30 . TkListLen 2 . TkWord64 1 . TkWord64 2)),
       checkEncodingCBOR
         "slot"
         (SlotNo 7)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -38,6 +38,7 @@ import Crypto.Random (drgNewTest, withDRG)
 import Data.Coerce (coerce)
 import Data.Functor.Identity (runIdentity)
 import Data.Maybe (fromMaybe)
+import Data.Ratio (Ratio)
 import Data.Word (Word64)
 import Hedgehog ((===), MonadTest)
 import Shelley.Spec.Ledger.Address (pattern Addr)
@@ -126,7 +127,7 @@ mkAddr (payKey, stakeKey) =
     (StakeRefBase . KeyHashObj . hashKey $ vKey stakeKey)
 
 -- | You vouch that argument is in [0; 1].
-unsafeMkUnitInterval :: Rational -> UnitInterval
+unsafeMkUnitInterval :: Ratio Word64 -> UnitInterval
 unsafeMkUnitInterval r =
   fromMaybe (error "could not construct unit interval") $ mkUnitInterval r
 


### PR DESCRIPTION
Previously `UnitInterval` was a newtype of `Rational` (ie `Ratio Integer`). Now it is a newtype of `Ratio Word64`.

closes #1508 