### PR TITLE
formal spec to support MIR from treasury

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -241,18 +241,43 @@ It has no environment or signal, and the state is $\EpochState$.
     \vdash \var{\_} \trans{mir}{} \var{\_} \subseteq
     \powerset (\EpochState \times \EpochState)
   \end{equation*}
+  %
+  \emph{Helper function}
+  \begin{align*}
+      & \fun{mirUpdates} \in \InstantaneousRewards \to \StakeCreds \to
+      (\AddrRWD \mapsto \Coin)\times(\AddrRWD \mapsto \Coin)
+      \\
+      & \fun{mirUpdates}~(\var{irReserves},~\var{irTreasury})~\var{stkCreds} =
+      (\var{updateR},~\var{updateT})\\
+      & ~~~~\where \\
+      & ~~~~~~~~~\var{updateR} =
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{stkCreds})\restrictdom\var{irReserves}
+        \right\}
+        \\
+      & ~~~~~~~~~\var{updateT} =
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{stkCreds})\restrictdom\var{irTreasury}
+        \right\}
+        \\
+  \end{align*}
   \caption{MIR transition-system types}
   \label{fig:ts-types:mir}
 \end{figure}
 
 Figure~\ref{fig:rules:mir} defines the MIR state transition.
-The transition first restricts the instantaneous rewards to those which
-correspond to registered stake keys.
-If the reserve pot is large enough to cover the sum of these rewards,
-the corresponding reward accounts are increased by the appropriate amount
-and the reserve pot is proportionally decreased.
-In either case, if the reserve pot was large enough or not,
-we reset the instantaneous rewards back to the empty mapping.
+The transition uses the function $\fun{mirUpdates}$ to restrict
+the two instantaneous rewards mappings to the registered stake keys,
+and transforms the keys of the mappiing to reward accouts.
+
+If the reserve and treasury pots are large enough to cover the sum
+of the corresponding instantaneous rewards,
+the reward accounts are increased by the appropriate amount
+and the two pots are decreased appropriately.
+In either case, if the pots are large enough or not,
+we reset both of the instantaneous reward mappings back to the empty mapping.
 
 \begin{figure}[ht]
   \begin{equation}\label{eq:mir}
@@ -264,24 +289,26 @@ we reset the instantaneous rewards back to the empty mapping.
       \\
       (\var{treasury},~\var{reserves})\leteq\var{acnt}
       &
-      \var{i_{rwd}'}\leteq (\dom{stkCreds})\restrictdom\var{i_{rwd}}
+      (\var{updateR},~\var{updateT})\leteq\fun{mirUpdates}~\var{i_{rwd}}~\var{stkCreds}
       \\
-      \var{tot}\leteq\sum\limits_{\wcard\mapsto v\in\var{i_{rwd}'}}v
+      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateR}}v
       &
-      \var{update} =
-        \left\{
-        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
-        ~\vert~\var{hk}\mapsto\var{val}\in\var{i_{rwd}'}
-        \right\}
+      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateT}}v
       \\
-      \var{tot}\leq\var{reserves}
+      \var{totR}\leq\var{reserves}
+      &
+      \var{totT}\leq\var{treasury}
       \\~\\
-      \var{acnt'}\leteq(\var{treasury},~\varUpdate{\var{reserves}-\var{tot}})
+      \var{acnt'}\leteq
+        (\varUpdate{\var{treasury}-\var{totT}},~\varUpdate{\var{reserves}-\var{totR}})
+      \\
+      \var{rewards'}\leteq\var{rewards}\unionoverridePlus\var{updateR}\unionoverridePlus\var{updateT}
       \\
       \var{ds'} \leteq
       (\var{stkCreds},~
-      \varUpdate{\var{rewards}\unionoverridePlus\var{update}},~\var{delegations},~
-      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},~\varUpdate{\emptyset})
+      \varUpdate{\var{rewards}'},~\var{delegations},~
+      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},
+      ~(\varUpdate{\emptyset},~\varUpdate{\emptyset}))
     }
     {
       \vdash
@@ -312,16 +339,20 @@ we reset the instantaneous rewards back to the empty mapping.
       \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})
         \leteq \var{ds}
       \\
-      (\wcard,~\var{reserves})\leteq\var{acnt}
+      (\var{treasury},~\var{reserves})\leteq\var{acnt}
       &
-      \var{i_{rwd}'}\leteq (\dom{stkCreds})\restrictdom\var{i_{rwd}}
-      &
-      \var{tot}\leteq\sum\limits_{\wcard\mapsto v\in\var{i_{rwd}'}}v
+      (\var{updateR},~\var{updateT})\leteq\fun{mirUpdates}~\var{i_{rwd}}~\var{stkCreds}
       \\
-      \var{tot}>\var{reserves}
+      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateR}}v
+      &
+      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateT}}v
+      \\
+      \var{totR}>\var{reserves}~\lor~\var{totT}>\var{treasury}
       \\~\\
-      \var{ds'} \leteq (\var{stkCreds},~\var{rewards},~\var{delegations},~
-      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},~\varUpdate{\emptyset})
+      \var{ds'} \leteq
+      (\var{stkCreds},~\var{rewards},~\var{delegations},~
+      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},
+      ~(\varUpdate{\emptyset},~\varUpdate{\emptyset}))
     }
     {
       \vdash
@@ -1494,8 +1525,8 @@ The PRTCL rule has no predicate failures.
 
 The Block Body Transition updates the block body state which comprises the ledger state and the
 map describing the produced blocks.
-The environment of the $\mathsf{BBODY}$ transition are overlay schedule slots and the protocol
-parameters.
+The environment of the $\mathsf{BBODY}$ transition are overlay schedule slots,
+the protocol parameters, and the accounting state.
 The environments and states are defined in Figure~\ref{fig:ts-types:bbody}, along with
 a helper function $\fun{incrBlocks}$, which counts the number of non-overlay blocks
 produced by each stake pool.
@@ -1508,7 +1539,7 @@ produced by each stake pool.
       \begin{array}{r@{~\in~}lr}
         \var{oslots} & \powerset{\Slot} & \text{overlay slots} \\
         \var{pp} & \PParams & \text{protocol parameters} \\
-        \var{reserves} & \Coin & \text{total reserves}
+        \var{acnt} & \Acnt & \text{accounting state}
       \end{array}
     \right)
   \end{equation*}
@@ -1587,7 +1618,7 @@ current slot is not an overlay slot.
         {\begin{array}{c}
                  \bslot{bhb} \\
                  \var{pp} \\
-                 \var{reserves}
+                 \var{acnt}
         \end{array}}
         \vdash
              \var{ls} \\
@@ -1599,7 +1630,7 @@ current slot is not an overlay slot.
       {\begin{array}{c}
                \var{oslots} \\
                \var{pp} \\
-               \var{reserves}
+               \var{acnt}
       \end{array}}
       \vdash
       {\left(\begin{array}{c}
@@ -1815,7 +1846,6 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
         ( \wcard,
           ( (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{genDelegs}),~
           (\wcard,~\wcard,~\wcard)))\leteq\var{ls}\\
-          (\wcard, reserves) \leteq \var{acnt}\\
           \var{ne} \leteq  \var{e_1} \neq \var{e_2}\\
           \eta_{ph} \leteq \prevHashToNonce{(\lastAppliedHash{lab})} \\
       {
@@ -1848,7 +1878,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
         {\begin{array}{c}
                  \dom{osched} \\
                  \var{pp'} \\
-                 \var{reserves}
+                 \var{acnt}
         \end{array}}
         \vdash
         {\left(\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -264,7 +264,7 @@ see the document~\cite{delegation_design}, and for
 the relevant rules, see Section \ref{sec:oper-cert-trans}.
 
 The environment for the state transition for $\DState$ contains the current slot number,
-an the index for the current certificate pointer, and the account state.
+the index for the current certificate pointer, and the account state.
 The environment for the state transition for $\PState$ contains the current slot number
 and the protocol parameters.
 

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -33,8 +33,10 @@ genesis keys. The genesis keys will still be used for update proposals at the
 beginning of the Shelley era, and so there must be a way to maintain the delegation
 of these keys to their cold keys.  This mapping is also maintained by the
 delegation state. There is also a mechanism to transfer rewards directly from
-the reserves pot to a reward address. While technically everybody can post such
-a certificate, the transaction that contains it must be signed by genesis keys.
+either the reserves pot or the treasury pot to a reward address.
+While technically everybody can post such a certificate,
+the transaction that contains it must be signed by $\Quorum$-many
+genesis key delegates.
 
 \subsection{Delegation Definitions}
 \label{sec:deleg-defs}
@@ -109,6 +111,7 @@ It does the following:
     \begin{array}{r@{~\in~}lr}
       \var{url} & \URL & \text{a url}\\
       \var{pmd} & \PoolMD & \text{pool metadata}\\
+      \var{mp} & \MIRPot & \text{either $\ReservesMIR$ or $\TreasuryMIR$}\\
     \end{array}
   \end{equation*}
   %
@@ -171,6 +174,8 @@ It does the following:
       \\
       \fun{moveRewards} & \DCertMir \to (\StakeCredential \mapsto \Coin)
                                             & \text{moved inst. rewards}
+      \\
+      \fun{mirPot} & \DCertMir \to \MIRPot & \text{pot for inst. rewards}
     \end{array}
   \end{equation*}
   %
@@ -231,8 +236,10 @@ state transition types. We define two separate parts of the ledger state.
       necessary for header validation, see Section \ref{sec:chain})
       \item $\var{genDelegs}$ maps genesis key hashes to hashes of the cold key
         delegates.
-      \item $\var{i_{rwd}}$ stored the map of stake credentials to $\Coin$
-        values for moving instantaneous rewards at the epoch boundary.
+      \item $\var{i_{rwd}}$ stores two maps of stake credentials to $\Coin$,
+        which is used for moving instantaneous rewards at the epoch boundary.
+        One map corresponds to rewards taken from the reserves,
+        and the other corresponds to rewards taken from the treasury.
     \end{itemize}
   \item $\PState$ keeps track of the stake pool information:
     \begin{itemize}
@@ -256,8 +263,8 @@ For a discussion of why this additional mechanism is needed,
 see the document~\cite{delegation_design}, and for
 the relevant rules, see Section \ref{sec:oper-cert-trans}.
 
-The environment for the state transition for $\DState$ contains the current slot number
-and the index for the current certificate pointer.
+The environment for the state transition for $\DState$ contains the current slot number,
+an the index for the current certificate pointer, and the account state.
 The environment for the state transition for $\PState$ contains the current slot number
 and the protocol parameters.
 
@@ -267,11 +274,14 @@ and the protocol parameters.
 \begin{figure}
   \emph{Delegation Types}
   \begin{equation*}
-    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
-      \var{stakeCred} & \StakeCredential & (\KeyHash_{stake} \uniondistinct
+    \begin{array}{rclclr}
+      \var{stakeCred} & \in &  \StakeCredential & = & (\KeyHash_{stake} \uniondistinct
                                        \HashScr) \\
-      \var{fGenDelegs} & \FutGenesisDelegation
+      \var{fGenDelegs} & \in &  \FutGenesisDelegation & =
                        & (\Slot\times\KeyHashGen)\mapsto(\KeyHash\times\KeyHash_{vrf}) \\
+      \var{ir} & \in &  \InstantaneousRewards & =
+               & (\StakeCredential \mapsto \Coin) \\
+               & & & & ~~~~\times(\StakeCredential \mapsto \Coin) \\
     \end{array}
   \end{equation*}
   %
@@ -287,7 +297,7 @@ and the protocol parameters.
             \var{ptrs} & \Ptr \mapsto \StakeCredential & \text{pointer to stake credential}\\
             \var{fGenDelegs} & \FutGenesisDelegation & \text{future genesis key delegations}\\
             \var{genDelegs} & \GenesisDelegation & \text{genesis key delegations}\\
-            \var{i_{rwd}} & \StakeCredential \mapsto \Coin & \text{instantaneous rewards}\\
+            \var{i_{rwd}} & \InstantaneousRewards & \text{instantaneous rewards}\\
           \end{array}
       \right)
       \\
@@ -311,7 +321,7 @@ and the protocol parameters.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{slot}\\
         \var{ptr} & \Ptr & \text{certificate pointer}\\
-        \var{reserves} & \Coin & \text{total reserves available}
+        \var{acnt} & \Acnt & \text{accounting state}
       \end{array}
     \right)
   \end{equation*}
@@ -405,9 +415,10 @@ concerns are independent of the ledger rules.
         to be adopted in $\StabilityWindow$-many slots.
       \end{itemize}
 
-    \item  Moving instantaneous rewards is handled by \cref{eq:deleg-mir}. There
-      is a precondition that the current slot is early enough in the current
-      epoch and that the available reserves are sufficient to pay for the
+    \item  Moving instantaneous rewards is handled by
+      \cref{eq:deleg-mir-reserves} and \cref{eq:deleg-mir-treasury}.
+      There is a precondition that the current slot is early enough in the current
+      epoch and that the available reserves or treasury are sufficient to pay for the
       instantaneous rewards.
 \end{itemize}
 
@@ -427,7 +438,7 @@ concerns are independent of the ledger rules.
       \begin{array}{r}
         \var{slot} \\
         \var{ptr} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -466,7 +477,7 @@ concerns are independent of the ledger rules.
       \begin{array}{r}
         \var{slot} \\
         \var{ptr} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -504,7 +515,7 @@ concerns are independent of the ledger rules.
       \begin{array}{r}
         \var{slot} \\
         \var{ptr} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -560,7 +571,7 @@ concerns are independent of the ledger rules.
       \begin{array}{r}
         \var{slot} \\
         \var{ptr} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -597,19 +608,24 @@ concerns are independent of the ledger rules.
 
 \begin{figure}[htp]
   \centering
-  \begin{equation}\label{eq:deleg-mir}
+  \begin{equation}\label{eq:deleg-mir-reserves}
     \inference[Deleg-Mir]
     {
-      \var{c}\in \DCertMir\\
+      \var{c}\in \DCertMir
+      &
+      \fun{mirPot}~\var{c}=\ReservesMIR
+      \\
       slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
-      \left(
-        \sum\limits_{\wcard\mapsto\var{val}\in(\var{i_{rwd}}\unionoverrideRight\var{i_{rwd}})} val      \right)\leq\var{reserves}
+      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
+      &
+      \var{combinedR}\leteq\var{irReserves}\unionoverrideRight(\fun{moveRewards}~\var{c}) \\
+      \sum\limits_{\wcard\mapsto\var{val}\in\var{combinedR}} val \leq\var{reserves}
     }
     {
       \begin{array}{r}
         \var{slot} \\
         \var{ptr} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -625,15 +641,60 @@ concerns are independent of the ledger rules.
       \right)
       \trans{deleg}{c}
       \left(
-      \begin{array}{rcl}
+      \begin{array}{c}
         \var{stkCreds}\\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
         \var{fGenDelegs}\\
         \var{genDelegs} \\
-        \varUpdate{\var{i_{rwd}}} & \varUpdate{\unionoverrideRight}
-        & \varUpdate{\fun{moveRewards}~\var{c}}
+        (\varUpdate{\var{combinedR}},~\var{irTreasury}) \\
+      \end{array}
+      \right)
+    }
+  \end{equation}
+  \\~\\
+  \begin{equation}\label{eq:deleg-mir-treasury}
+    \inference[Deleg-Mir]
+    {
+      \var{c}\in \DCertMir
+      &
+      \fun{mirPot}~\var{c}=\TreasuryMIR
+      \\
+      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
+      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
+      &
+      \var{combinedT}\leteq\var{irTreasury}\unionoverrideRight(\fun{moveRewards}~\var{c}) \\
+      \sum\limits_{\wcard\mapsto\var{val}\in\var{combinedT}} val \leq\var{treasury}
+    }
+    {
+      \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+        \var{acnt}
+      \end{array}
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{stkCreds} \\
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
+        \var{i_{rwd}}
+      \end{array}
+      \right)
+      \trans{deleg}{c}
+      \left(
+      \begin{array}{c}
+        \var{stkCreds}\\
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs}\\
+        \var{genDelegs} \\
+        (\var{irReserves},~\varUpdate{\var{combinedT}}) \\
       \end{array}
       \right)
     }
@@ -865,7 +926,7 @@ combined transition.
         \var{slot} & \Slot & \text{slot}\\
         \var{ptr} & \Ptr & \text{certificate pointer}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{reserves} & \Coin & \text{total available reserves}
+        \var{acnt} & \Acnt & \text{accounting state}
       \end{array}
     \right)
   \end{equation*}
@@ -909,7 +970,7 @@ will be successful, since the pool certificates are disjoint from the delegation
         \begin{array}{r}
           \var{slot} \\
           \var{ptr} \\
-          \var{reserves}
+          \var{acnt}
         \end{array}
       }
       \vdash \var{dstate} \trans{\hyperref[fig:delegation-rules]{deleg}}{c} \var{dstate'}
@@ -919,7 +980,7 @@ will be successful, since the pool certificates are disjoint from the delegation
         \var{slot} \\
         \var{ptr} \\
         \var{pp} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -955,7 +1016,7 @@ will be successful, since the pool certificates are disjoint from the delegation
         \var{slot} \\
         \var{ptr} \\
         \var{pp} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -993,7 +1054,7 @@ transition.
         \var{txIx} & \Ix & \text{transaction index}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
         \var{tx} & \Tx & \text{transaction} \\
-        \var{reserves} & \Coin & \text{total reserves}
+        \var{acnt} & \Acnt & \text{accounting state}
       \end{array}
     \right)
   \end{equation*}
@@ -1053,7 +1114,7 @@ will be invalid.
         \var{txIx} \\
         \var{pp} \\
         \var{tx} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -1116,7 +1177,7 @@ will be invalid.
             \var{txIx}\\
             \var{pp}\\
             \var{tx}\\
-            \var{reserves}
+            \var{acnt}
           \end{array}
         }
       \vdash
@@ -1131,7 +1192,7 @@ will be invalid.
         \var{slot}\\
         \var{ptr}\\
         \var{pp}\\
-        \var{reserves}
+        \var{acnt}
       \end{array}
     }
     \vdash
@@ -1146,7 +1207,7 @@ will be invalid.
         \var{txIx}\\
         \var{pp}\\
         \var{tx}\\
-        \var{reserves}
+        \var{acnt}
       \end{array}
     }
     \vdash

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -2,7 +2,6 @@
 \label{sec:epoch}
 
 \newcommand{\UTxOEpState}{\type{UTxOEpState}}
-\newcommand{\Acnt}{\type{Acnt}}
 \newcommand{\PlReapState}{\type{PlReapState}}
 \newcommand{\NewPParamEnv}{\type{NewPParamEnv}}
 \newcommand{\Snapshot}{\type{Snapshot}}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -113,6 +113,10 @@
 \newcommand{\DCertMir}{\type{DCert_{mir}}}
 \newcommand{\PoolParam}{\type{PoolParam}}
 \newcommand{\PoolMD}{\type{PoolMD}}
+\newcommand{\MIRPot}{\type{MIRPot}}
+\newcommand{\InstantaneousRewards}{\type{InstantaneousRewards}}
+\newcommand{\ReservesMIR}{\type{ReservesMIR}}
+\newcommand{\TreasuryMIR}{\type{TreasuryMIR}}
 \newcommand{\URL}{\type{Url}}
 \newcommand{\UTxOState}{\ensuremath{\type{UTxOState}}}
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
@@ -178,6 +182,7 @@
 \newcommand{\Epoch}{\type{Epoch}}
 \newcommand{\KESPeriod}{\type{KESPeriod}}
 %% Blockchain
+\newcommand{\Acnt}{\type{Acnt}}
 \newcommand{\Gkeys}{\var{G_{keys}}}
 \newcommand{\Block}{\type{Block}}
 \newcommand{\SlotId}{\type{SlotId}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -10,7 +10,7 @@ The environment for this rule consists of:
   \item The current slot.
   \item The transaction index within the current block.
   \item The protocol parameters.
-  \item The amount of available reserves.
+  \item The accounting state.
 \end{itemize}
 The ledger state consists of:
 \begin{itemize}
@@ -27,7 +27,7 @@ The ledger state consists of:
         \var{slot} & \Slot & \text{current slot}\\
         \var{txIx} & \Ix & \text{transaction index}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{reserves} & \Coin & \text{total reserves}
+        \var{acnt} & \Acnt & \text{accounting state}
       \end{array}
     \right)
   \end{equation*}
@@ -68,7 +68,7 @@ then calls the $\mathsf{DELEGS}$ transition.
           \var{txIx} \\
           \var{pp} \\
           \var{tx}\\
-          \var{reserves}
+          \var{acnt}
         \end{array}
       }
       \vdash
@@ -94,7 +94,7 @@ then calls the $\mathsf{DELEGS}$ transition.
         \var{slot} \\
         \var{txIx} \\
         \var{pp} \\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash
       \left(
@@ -141,7 +141,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{reserves}
+        \var{acnt}
       \end{array}
       \vdash \var{ls} \trans{ledgers}{\epsilon} \varUpdate{\var{ls'}}
     }
@@ -157,7 +157,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
         \begin{array}{r}
           \var{slot}\\
           \var{pp}\\
-          \var{reserves}
+          \var{acnt}
         \end{array}
       }
       \vdash
@@ -170,7 +170,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
           \var{slot}\\
           \mathsf{len}~\Gamma - 1\\
           \var{pp}\\
-          \var{reserves}
+          \var{acnt}
         \end{array}
       }
       \vdash
@@ -182,7 +182,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{reserves}
+        \var{acnt}
       \end{array}
     \vdash
       \var{ls}


### PR DESCRIPTION
This PR updates the formal spec to the changes made to the executable spec in #1496, namely the ability for the MIR certs to draw from the treasury as well as the reserves.

closes #1523 