### PR TITLE
Fix generation of MIR and Genesis Delegation certs

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -24,6 +24,8 @@ module Shelley.Spec.Ledger.Delegation.Certificates
     isRegPool,
     isRetirePool,
     isInstantaneousRewards,
+    isReservesMIRCert,
+    isTreasuryMIRCert,
     requiresVKeyWitness,
   )
 where
@@ -42,6 +44,7 @@ import Shelley.Spec.Ledger.TxData
     Delegation (..),
     GenesisDelegCert (..),
     MIRCert (..),
+    MIRPot (..),
     PoolCert (..),
     PoolParams (..),
     StakeCreds (..),
@@ -109,6 +112,14 @@ newtype PoolDistr crypto = PoolDistr
 isInstantaneousRewards :: DCert crypto -> Bool
 isInstantaneousRewards (DCertMir _) = True
 isInstantaneousRewards _ = False
+
+isReservesMIRCert :: DCert crypto -> Bool
+isReservesMIRCert (DCertMir (MIRCert ReservesMIR _)) = True
+isReservesMIRCert _ = False
+
+isTreasuryMIRCert :: DCert crypto -> Bool
+isTreasuryMIRCert (DCertMir (MIRCert TreasuryMIR _)) = True
+isTreasuryMIRCert _ = False
 
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -113,16 +113,17 @@ instance QC.HasTrace CERTS GenEnv where
           )
         constants
       )
-    (slot, _txIx, pparams, _reserves)
+    (slot, _txIx, pparams, accountState)
     (dpState, _certIx) =
       genDCert
         constants
         ksKeyPairs
         ksMSigScripts
-        (fst <$> ksCoreNodes)
+        ksCoreNodes
         ksVRFKeyPairs
         (ksKeyPairsByStakeHash ks)
         pparams
+        accountState
         dpState
         slot
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -43,10 +43,11 @@ import Shelley.Spec.Ledger.Delegation.Certificates
   ( isDeRegKey,
     isDelegation,
     isGenesisDelegation,
-    isInstantaneousRewards,
     isRegKey,
     isRegPool,
+    isReservesMIRCert,
     isRetirePool,
+    isTreasuryMIRCert,
   )
 import Shelley.Spec.Ledger.LedgerState (txsize)
 import Shelley.Spec.Ledger.PParams
@@ -172,9 +173,15 @@ relevantCasesAreCovered = do
             (property ()),
         checkCoverage $
           cover
-            60
-            (traceLength tr < 30 * length (filter isInstantaneousRewards certs_))
-            "there is at least 1 MIR certificate for every 30 transactions"
+            40
+            (traceLength tr < 60 * length (filter isReservesMIRCert certs_))
+            "there is at least 1 Reserves MIR certificate (spending Reserves) for every 60 transactions"
+            (property ()),
+        checkCoverage $
+          cover
+            40
+            (traceLength tr < 60 * length (filter isTreasuryMIRCert certs_))
+            "there is at least 1 MIR certificate (spending Treasury) for every 60 transactions"
             (property ()),
         checkCoverage $
           cover


### PR DESCRIPTION
This PR catches up the property test generators with some recent changes to MIR and GenesisDelegation certs:

**MIR certificate generators** 

* now that MIR certs can draw from the Treasury, we need to check the pot size (treasury/reserves) for sufficient funds
* related to this, we preload the test initial Shelley state with some Treasury
* MIR certs are now witnessed by the Genesis _Delegation_ keys
* the Trace classifier now checks for generation of Treasury and Reserves MIR certs separately

**Genesis Delegation certificate generators** 

* we now consider the Future Genesis delegations to avoid duplicate genesis delegation certs