### PR TITLE
adding NFData instances for UTxOState

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -102,7 +102,7 @@ fpEpsilon = (10 :: FixedPoint) ^ (17 :: Integer) / fpPrecision
 -- | Type to represent a value in the unit interval [0; 1]
 newtype UnitInterval = UnsafeUnitInterval (Ratio Word64)
   deriving (Show, Ord, Eq, Generic)
-  deriving newtype (NoUnexpectedThunks)
+  deriving newtype (NoUnexpectedThunks, NFData)
 
 instance ToCBOR UnitInterval where
   toCBOR (UnsafeUnitInterval u) = ratioToCBOR u
@@ -154,7 +154,7 @@ data Nonce
   = Nonce !(Hash SHA256 Nonce)
   | -- | Identity element
     NeutralNonce
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Ord, Show, NFData)
 
 instance NoUnexpectedThunks Nonce
 
@@ -213,6 +213,8 @@ data StrictMaybe a
   deriving (Eq, Ord, Show, Generic)
 
 instance NoUnexpectedThunks a => NoUnexpectedThunks (StrictMaybe a)
+
+instance NFData a => NFData (StrictMaybe a)
 
 instance Functor StrictMaybe where
   fmap _ SNothing = SNothing

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -10,7 +10,7 @@ module Shelley.Spec.Ledger.Coin
 where
 
 import Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
-import Cardano.Prelude (NoUnexpectedThunks (..), cborError)
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..), cborError)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (pack)
 import Data.Word (Word64)
@@ -18,7 +18,20 @@ import GHC.Generics (Generic)
 
 -- | The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, Generic, ToJSON, FromJSON)
+  deriving
+    ( Show,
+      Eq,
+      Ord,
+      Num,
+      Integral,
+      Real,
+      Enum,
+      NoUnexpectedThunks,
+      Generic,
+      ToJSON,
+      FromJSON,
+      NFData
+    )
 
 instance ToCBOR Coin where
   toCBOR (Coin c) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -90,7 +91,7 @@ import Cardano.Binary
     peekTokenType,
   )
 import Cardano.Crypto.Hash (hashWithSerialiser)
-import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Foldable (toList)
@@ -472,7 +473,7 @@ data UTxOState crypto = UTxOState
     _fees :: !Coin,
     _ppups :: !(ProposedPPUpdates crypto)
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, NFData)
 
 instance NoUnexpectedThunks (UTxOState crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
@@ -2,9 +2,12 @@
 
 module Shelley.Spec.Ledger.Orphans where
 
-import Cardano.Prelude (NoUnexpectedThunks)
+import Cardano.Prelude (NFData, NoUnexpectedThunks)
 import Data.IP (IPv4, IPv6)
+import Shelley.Spec.Ledger.Slot (EpochNo)
 
 instance NoUnexpectedThunks IPv4
 
 instance NoUnexpectedThunks IPv6
+
+instance NFData EpochNo

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -36,7 +36,7 @@ import Cardano.Binary
     encodeWord,
     enforceSize,
   )
-import Cardano.Prelude (NoUnexpectedThunks (..), mapMaybe)
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..), mapMaybe)
 import Control.Monad (unless)
 import Data.Aeson ((.!=), (.:), (.:?), (.=), FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as Aeson
@@ -60,6 +60,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.Orphans ()
 import Shelley.Spec.Ledger.Serialization
   ( CBORGroup (..),
     FromCBORGroup (..),
@@ -143,8 +144,10 @@ deriving instance Eq (PParams' Identity)
 
 deriving instance Show (PParams' Identity)
 
+deriving instance NFData (PParams' Identity)
+
 data ProtVer = ProtVer !Natural !Natural
-  deriving (Show, Eq, Generic, Ord)
+  deriving (Show, Eq, Generic, Ord, NFData)
   deriving (ToCBOR) via (CBORGroup ProtVer)
   deriving (FromCBOR) via (CBORGroup ProtVer)
 
@@ -341,6 +344,8 @@ deriving instance Show (PParams' StrictMaybe)
 
 deriving instance Ord (PParams' StrictMaybe)
 
+deriving instance NFData (PParams' StrictMaybe)
+
 instance NoUnexpectedThunks PParamsUpdate
 
 instance ToCBOR PParamsUpdate where
@@ -421,7 +426,7 @@ instance FromCBOR PParamsUpdate where
 -- | Update operation for protocol parameters structure @PParams
 newtype ProposedPPUpdates crypto
   = ProposedPPUpdates (Map (KeyHash 'Genesis crypto) PParamsUpdate)
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, NFData)
 
 instance NoUnexpectedThunks (ProposedPPUpdates crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -264,14 +264,14 @@ deriving newtype instance Crypto crypto => FromCBOR (TxId crypto)
 -- | The input of a UTxO.
 data TxIn crypto
   = TxIn !(TxId crypto) !Natural -- TODO use our own Natural type
-  deriving (Show, Eq, Generic, Ord)
+  deriving (Show, Eq, Generic, Ord, NFData)
 
 instance NoUnexpectedThunks (TxIn crypto)
 
 -- | The output of a UTxO.
 data TxOut crypto
   = TxOut !(Addr crypto) !Coin
-  deriving (Show, Eq, Generic, Ord)
+  deriving (Show, Eq, Generic, Ord, NFData)
 
 instance NoUnexpectedThunks (TxOut crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -41,7 +41,7 @@ where
 import Byron.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (hashWithSerialiser)
-import Cardano.Prelude (Generic, NoUnexpectedThunks (..))
+import Cardano.Prelude (Generic, NFData, NoUnexpectedThunks (..))
 import Data.Foldable (toList)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
@@ -90,7 +90,7 @@ import Shelley.Spec.Ledger.TxData
 -- | The unspent transaction outputs.
 newtype UTxO crypto
   = UTxO (Map (TxIn crypto) (TxOut crypto))
-  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic)
+  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic, NFData)
 
 instance Relation (UTxO crypto) where
   type Domain (UTxO crypto) = TxIn crypto


### PR DESCRIPTION
In order to use the criterion `env :: NFData a => IO a -> (a -> Benchmark) -> Benchmark` we needed `NFData` instances for `UTxOState`.