### PR TITLE
Copy byron core to create shelley core

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -26,6 +26,7 @@ library
                      Shelley.Spec.Ledger.BaseTypes
                      Shelley.Spec.Ledger.BlockChain
                      Shelley.Spec.Ledger.Coin
+                     Shelley.Spec.Ledger.Core
                      Shelley.Spec.Ledger.Credential
                      Shelley.Spec.Ledger.Genesis
                      Shelley.Spec.Ledger.Keys
@@ -114,7 +115,11 @@ library
     stm,
     text,
     time,
-    transformers
+    transformers,
+    -- Added for clone of Core
+    bimap,
+    hashable,
+    goblins
 
 test-suite shelley-spec-ledger-test
     type:                exitcode-stdio-1.0

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -16,7 +16,6 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Arrow (left, right)
 import Control.Monad.Except
@@ -26,6 +25,7 @@ import Data.Either (fromRight)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -16,7 +16,7 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Byron.Spec.Ledger.Core (Relation (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Arrow (left, right)
 import Control.Monad.Except

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
@@ -16,34 +16,37 @@
 
 module Shelley.Spec.Ledger.Core where
 
-import           Data.Bimap (Bimap)
+import Cardano.Binary (ToCBOR)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Data.AbstractSize
+import Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
-import           Data.Data (Data, Typeable)
-import           Data.Foldable (elem, toList)
-import           Data.Hashable (Hashable)
+import Data.Data (Data, Typeable)
+import Data.Foldable (elem, toList)
+import Data.Hashable (Hashable)
 import qualified Data.Hashable as H
-import           Data.Int (Int64)
-import           Data.Map.Strict (Map)
+import Data.Int (Int64)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (isJust)
-import           Data.Monoid (Sum (..))
+import Data.Maybe (isJust)
+import Data.Monoid (Sum (..))
 import qualified Data.Sequence as Seq
-import           Data.Set (Set, intersection, isSubsetOf)
+import Data.Set (Set, intersection, isSubsetOf)
 import qualified Data.Set as Set
-import           Data.Typeable (typeOf)
-import           Data.Word (Word64, Word8)
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Prelude (NoUnexpectedThunks(..))
-import           Cardano.Binary (ToCBOR)
-
-import           Data.AbstractSize
-
-import           Test.Goblin (AddShrinks (..), GeneOps, Goblin (..), SeedGoblin (..),
-                     saveInBagOfTricks, tinkerRummagedOrConjureOrSave, (<$$>))
-import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
-
+import Data.Typeable (typeOf)
+import Data.Word (Word64, Word8)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Test.Goblin
+  ( (<$$>),
+    AddShrinks (..),
+    GeneOps,
+    Goblin (..),
+    SeedGoblin (..),
+    saveInBagOfTricks,
+    tinkerRummagedOrConjureOrSave,
+  )
+import Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
 
 -- | An encoded hash of part of the system.
 --
@@ -52,9 +55,10 @@ import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGobli
 -- invalid concrete hash.
 newtype Hash = Hash
   { unHash :: Maybe Int
-  } deriving stock (Show, Generic, Data, Typeable)
-    deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-    deriving anyclass (HasTypeReps)
+  }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
 
 isValid :: Hash -> Bool
 isValid = isJust . unHash
@@ -67,17 +71,18 @@ class HasHash a where
 -- Signing and verification
 ---------------------------------------------------------------------------------
 
--- |Representation of the owner of key pair.
+-- | Representation of the owner of key pair.
 newtype Owner = Owner
   { unOwner :: Natural
-  } deriving stock (Show, Generic, Data, Typeable)
-    deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-    deriving anyclass (HasTypeReps)
+  }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
 
 class HasOwner a where
   owner :: a -> Owner
 
--- |Signing Key.
+-- | Signing Key.
 newtype SKey = SKey Owner
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, ToCBOR, NoUnexpectedThunks)
@@ -86,7 +91,7 @@ newtype SKey = SKey Owner
 instance HasOwner SKey where
   owner (SKey o) = o
 
--- |Verification Key.
+-- | Verification Key.
 newtype VKey = VKey Owner
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
@@ -99,7 +104,7 @@ instance HasOwner VKey where
   owner (VKey o) = o
 
 -- | A genesis key is a specialisation of a generic VKey.
-newtype VKeyGenesis = VKeyGenesis { unVKeyGenesis :: VKey }
+newtype VKeyGenesis = VKeyGenesis {unVKeyGenesis :: VKey}
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, Hashable, HasHash, ToCBOR, NoUnexpectedThunks)
   deriving anyclass (HasTypeReps)
@@ -112,26 +117,26 @@ mkVKeyGenesis = VKeyGenesis . VKey . Owner
 
 -- | Make a set of genesis keys. The genesis keys are continuously numbered from 0 to the given
 -- number of genesis keys minus 1.
-mkVkGenesisSet
-  :: Word8
-  -- ^ Number of genesis keys
-  -> Set VKeyGenesis
+mkVkGenesisSet ::
+  -- | Number of genesis keys
+  Word8 ->
+  Set VKeyGenesis
 mkVkGenesisSet ngk = Set.fromAscList $ mkVKeyGenesis <$> [0 .. (fromIntegral ngk - 1)]
 
-
--- |Key Pair.
+-- | Key Pair.
 data KeyPair = KeyPair
-  { sKey :: SKey
-  , vKey :: VKey
-  } deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
+  { sKey :: SKey,
+    vKey :: VKey
+  }
+  deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
 
 instance HasTypeReps KeyPair
 
--- |Return a key pair for a given owner.
+-- | Return a key pair for a given owner.
 keyPair :: Owner -> KeyPair
 keyPair o = KeyPair (SKey o) (VKey o)
 
--- |A digital signature.
+-- | A digital signature.
 data Sig a = Sig a Owner
   deriving (Show, Eq, Ord, Generic, Hashable, Typeable, Data, NoUnexpectedThunks)
 
@@ -143,11 +148,11 @@ data Sig a = Sig a Owner
 instance Typeable a => HasTypeReps (Sig a) where
   typeReps x = typeOf x Seq.<| Seq.empty
 
--- |Produce a digital signature
+-- | Produce a digital signature
 sign :: SKey -> a -> Sig a
 sign (SKey k) d = Sig d k
 
--- |Verify a digital signature
+-- | Verify a digital signature
 verify :: Eq a => VKey -> a -> Sig a -> Bool
 verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 
@@ -155,12 +160,12 @@ verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 -- Slots and Epochs
 ---------------------------------------------------------------------------------
 
-newtype Epoch = Epoch { unEpoch :: Word64 }
+newtype Epoch = Epoch {unEpoch :: Word64}
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, Hashable, Num, ToCBOR, NoUnexpectedThunks)
   deriving anyclass (HasTypeReps)
 
-newtype Slot = Slot { unSlot :: Word64 }
+newtype Slot = Slot {unSlot :: Word64}
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
   deriving anyclass (HasTypeReps)
@@ -170,7 +175,7 @@ newtype Slot = Slot { unSlot :: Word64 }
 --  We use this newtype to distinguish between a cardinal slot and a relative
 --  period of slots, and also to distinguish between number of slots and number
 --  of blocks.
-newtype SlotCount = SlotCount { unSlotCount :: Word64 }
+newtype SlotCount = SlotCount {unSlotCount :: Word64}
   deriving stock (Generic, Show, Data, Typeable)
   deriving newtype (Eq, Ord, Num, Hashable, ToCBOR, NoUnexpectedThunks)
 
@@ -191,7 +196,7 @@ infixl 6 +.
 --   This is bounded below by 0.
 minusSlot :: Slot -> SlotCount -> Slot
 minusSlot (Slot m) (SlotCount n)
-  | m <= n    = Slot 0
+  | m <= n = Slot 0
   | otherwise = Slot $ m - n
 
 -- | An alias for 'minusSlot'
@@ -213,10 +218,10 @@ infixl 7 *.
 -- Nothing.
 minusSlotMaybe :: Slot -> SlotCount -> Maybe Slot
 minusSlotMaybe (Slot m) (SlotCount n)
-  | m < n     = Nothing
+  | m < n = Nothing
   | otherwise = Just . Slot $ m - n
 
-newtype BlockCount = BlockCount { unBlockCount :: Word64 }
+newtype BlockCount = BlockCount {unBlockCount :: Word64}
   deriving stock (Generic, Show)
   deriving newtype (Eq, Ord, Num, Hashable, NoUnexpectedThunks)
 
@@ -226,7 +231,7 @@ instance HasTypeReps BlockCount
 -- Transactions
 ---------------------------------------------------------------------------------
 
--- |The address of a transaction output, used to identify the owner.
+-- | The address of a transaction output, used to identify the owner.
 newtype Addr = Addr VKey
   deriving stock (Show, Generic, Data, Typeable)
   deriving newtype (Eq, Ord, Hashable, HasOwner, ToCBOR, NoUnexpectedThunks)
@@ -240,13 +245,13 @@ instance HasHash Addr where
   hash = Hash . Just . H.hash
 
 -- | A unit of value held by a UTxO.
---
 newtype Lovelace = Lovelace
   { unLovelace :: Integer
-  } deriving stock (Show, Generic, Data, Typeable)
-    deriving newtype (Eq, Ord, Num, Hashable, Enum, Real, Integral, ToCBOR, NoUnexpectedThunks)
-    deriving (Semigroup, Monoid) via (Sum Integer)
-    deriving anyclass (HasTypeReps)
+  }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Num, Hashable, Enum, Real, Integral, ToCBOR, NoUnexpectedThunks)
+  deriving (Semigroup, Monoid) via (Sum Integer)
+  deriving anyclass (HasTypeReps)
 
 -- | Constant amount of Lovelace in the system.
 lovelaceCap :: Lovelace
@@ -302,20 +307,22 @@ class Relation m where
   --
   -- Unicode: 25c1
   (<=◁) :: Ord (Domain m) => Domain m -> m -> m
+
   infixl 5 <=◁
 
   -- | Restrict range to values less or equal than the given value
   --
   -- Unicode: 25b7
   (▷<=) :: (Ord (Range m)) => m -> Range m -> m
+
   infixl 5 ▷<=
 
   -- | Restrict range to values greater or equal than the given value
   --
   -- Unicode: 25b7
   (▷>=) :: (Ord (Range m)) => m -> Range m -> m
-  infixl 5 ▷>=
 
+  infixl 5 ▷>=
 
   -- | Size of the relation
   size :: Integral n => m -> n
@@ -371,8 +378,9 @@ instance Relation (Map k v) where
   dom = Map.keysSet
   range = Set.fromList . Map.elems
 
-  s ◁ r = -- Map.filterWithKey (\k _ -> k `Set.member` toSet s) r
-          Map.restrictKeys r (toSet s) --TIMCHANGED
+  s ◁ r =
+    -- Map.filterWithKey (\k _ -> k `Set.member` toSet s) r
+    Map.restrictKeys r (toSet s) --TIMCHANGED
 
   s ⋪ r = Map.filterWithKey (\k _ -> k `Set.notMember` toSet s) r
 
@@ -381,6 +389,7 @@ instance Relation (Map k v) where
   r ⋫ s = Map.filter (flip Set.notMember s) r
 
   d0 ∪ d1 = Map.union d0 d1
+
   -- For union override we pass @d1@ as first argument, since 'Map.union' is
   -- left biased.
   d0 ⨃ d1 = Map.union (Map.fromList . toList $ d1) d0
@@ -399,21 +408,21 @@ a ∪+ b = ((dom a) ⋪ b) ∪ ((dom b) ⋪ a) ∪ (Map.unionWith (+) a b)
 
 instance Relation (Set (a, b)) where
   type Domain (Set (a, b)) = a
-  type Range (Set (a, b))  = b
+  type Range (Set (a, b)) = b
 
-  singleton a b = Set.singleton (a,b)
+  singleton a b = Set.singleton (a, b)
 
   dom = Set.map fst
 
   range = Set.map snd
 
-  s ◁ r = Set.filter (\(k,_) -> k `Set.member` toSet s) r
+  s ◁ r = Set.filter (\(k, _) -> k `Set.member` toSet s) r
 
-  s ⋪ r = Set.filter (\(k,_) -> k `Set.notMember` toSet s) r
+  s ⋪ r = Set.filter (\(k, _) -> k `Set.notMember` toSet s) r
 
-  r ▷ s = Set.filter (\(_,v) -> Set.member v s) r
+  r ▷ s = Set.filter (\(_, v) -> Set.member v s) r
 
-  r ⋫ s = Set.filter (\(_,v) -> Set.notMember v s) r
+  r ⋫ s = Set.filter (\(_, v) -> Set.notMember v s) r
 
   (∪) = Set.union
 
@@ -467,7 +476,6 @@ instance Relation [(a, b)] where
 -- | Inclusion among foldables.
 --
 -- Unicode: 2286
---
 (⊆) :: (Foldable f, Foldable g, Ord a) => f a -> g a -> Bool
 x ⊆ y = toSet x `isSubsetOf` toSet y
 
@@ -476,7 +484,6 @@ toSet = Set.fromList . toList
 
 (∩) :: Ord a => Set a -> Set a -> Set a
 (∩) = intersection
-
 
 --------------------------------------------------------------------------------
 -- Goblins instances
@@ -493,25 +500,27 @@ deriveGoblin ''VKey
 deriveGoblin ''VKeyGenesis
 
 instance GeneOps g => Goblin g Hash where
-  tinker gen
-    = tinkerRummagedOrConjureOrSave
-        ((Hash . Just . (`mod` 30))
-           <$$> tinker (unwrapValue <$> gen))
+  tinker gen =
+    tinkerRummagedOrConjureOrSave
+      ( (Hash . Just . (`mod` 30))
+          <$$> tinker (unwrapValue <$> gen)
+      )
     where
       unwrapValue (Hash (Just x)) = x
       unwrapValue (Hash Nothing) =
-        error $  "tinker Hash instance: trying to tinker with an invalid hash"
-              ++ " (which contains nothing)"
+        error $
+          "tinker Hash instance: trying to tinker with an invalid hash"
+            ++ " (which contains nothing)"
 
   conjure = saveInBagOfTricks =<< (Hash . Just . (`mod` 30) <$> conjure)
 
 instance GeneOps g => Goblin g Lovelace where
-  tinker gen
-    = tinkerRummagedOrConjureOrSave
-        ((\x -> (Lovelace x) `mod` lovelaceCap)
-           <$$> tinker ((\(Lovelace x) -> x) <$> gen))
+  tinker gen =
+    tinkerRummagedOrConjureOrSave
+      ( (\x -> (Lovelace x) `mod` lovelaceCap)
+          <$$> tinker ((\(Lovelace x) -> x) <$> gen)
+      )
   conjure = saveInBagOfTricks =<< ((`mod` lovelaceCap) . Lovelace <$> conjure)
-
 
 --------------------------------------------------------------------------------
 -- AddShrinks instances
@@ -528,7 +537,6 @@ deriveAddShrinks ''Slot
 deriveAddShrinks ''SlotCount
 deriveAddShrinks ''VKey
 deriveAddShrinks ''VKeyGenesis
-
 
 --------------------------------------------------------------------------------
 -- SeedGoblin instances

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
@@ -1,0 +1,546 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Shelley.Spec.Ledger.Core where
+
+import           Data.Bimap (Bimap)
+import qualified Data.Bimap as Bimap
+import           Data.Data (Data, Typeable)
+import           Data.Foldable (elem, toList)
+import           Data.Hashable (Hashable)
+import qualified Data.Hashable as H
+import           Data.Int (Int64)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (isJust)
+import           Data.Monoid (Sum (..))
+import qualified Data.Sequence as Seq
+import           Data.Set (Set, intersection, isSubsetOf)
+import qualified Data.Set as Set
+import           Data.Typeable (typeOf)
+import           Data.Word (Word64, Word8)
+import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
+
+import           Cardano.Prelude (NoUnexpectedThunks(..))
+import           Cardano.Binary (ToCBOR)
+
+import           Data.AbstractSize
+
+import           Test.Goblin (AddShrinks (..), GeneOps, Goblin (..), SeedGoblin (..),
+                     saveInBagOfTricks, tinkerRummagedOrConjureOrSave, (<$$>))
+import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
+
+
+-- | An encoded hash of part of the system.
+--
+-- 'Nothing' is used to signal to the elaborators (i.e. the algorithms that
+-- translate abstract data into data concrete) that they should produce an
+-- invalid concrete hash.
+newtype Hash = Hash
+  { unHash :: Maybe Int
+  } deriving stock (Show, Generic, Data, Typeable)
+    deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+    deriving anyclass (HasTypeReps)
+
+isValid :: Hash -> Bool
+isValid = isJust . unHash
+
+-- | Hash part of the ledger payload
+class HasHash a where
+  hash :: a -> Hash
+
+---------------------------------------------------------------------------------
+-- Signing and verification
+---------------------------------------------------------------------------------
+
+-- |Representation of the owner of key pair.
+newtype Owner = Owner
+  { unOwner :: Natural
+  } deriving stock (Show, Generic, Data, Typeable)
+    deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+    deriving anyclass (HasTypeReps)
+
+class HasOwner a where
+  owner :: a -> Owner
+
+-- |Signing Key.
+newtype SKey = SKey Owner
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+instance HasOwner SKey where
+  owner (SKey o) = o
+
+-- |Verification Key.
+newtype VKey = VKey Owner
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+instance HasHash VKey where
+  hash = Hash . Just . H.hash
+
+instance HasOwner VKey where
+  owner (VKey o) = o
+
+-- | A genesis key is a specialisation of a generic VKey.
+newtype VKeyGenesis = VKeyGenesis { unVKeyGenesis :: VKey }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, HasHash, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+instance HasOwner VKeyGenesis where
+  owner (VKeyGenesis vk) = owner vk
+
+mkVKeyGenesis :: Natural -> VKeyGenesis
+mkVKeyGenesis = VKeyGenesis . VKey . Owner
+
+-- | Make a set of genesis keys. The genesis keys are continuously numbered from 0 to the given
+-- number of genesis keys minus 1.
+mkVkGenesisSet
+  :: Word8
+  -- ^ Number of genesis keys
+  -> Set VKeyGenesis
+mkVkGenesisSet ngk = Set.fromAscList $ mkVKeyGenesis <$> [0 .. (fromIntegral ngk - 1)]
+
+
+-- |Key Pair.
+data KeyPair = KeyPair
+  { sKey :: SKey
+  , vKey :: VKey
+  } deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
+
+instance HasTypeReps KeyPair
+
+-- |Return a key pair for a given owner.
+keyPair :: Owner -> KeyPair
+keyPair o = KeyPair (SKey o) (VKey o)
+
+-- |A digital signature.
+data Sig a = Sig a Owner
+  deriving (Show, Eq, Ord, Generic, Hashable, Typeable, Data, NoUnexpectedThunks)
+
+-- | We need a custom instance here that returns only the top level type.
+--   A generic instance would have recursed into type 'a' and since we use
+--   'typeReps' to compute 'abstractSize', this would mean the size of
+--   'Sig a' would include the size of 'a' (e.g. 'Tx'). This would create an
+--   artificial coupling between the size of a type and it's "signature".
+instance Typeable a => HasTypeReps (Sig a) where
+  typeReps x = typeOf x Seq.<| Seq.empty
+
+-- |Produce a digital signature
+sign :: SKey -> a -> Sig a
+sign (SKey k) d = Sig d k
+
+-- |Verify a digital signature
+verify :: Eq a => VKey -> a -> Sig a -> Bool
+verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
+
+---------------------------------------------------------------------------------
+-- Slots and Epochs
+---------------------------------------------------------------------------------
+
+newtype Epoch = Epoch { unEpoch :: Word64 }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, Num, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+newtype Slot = Slot { unSlot :: Word64 }
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+-- | A number of slots.
+--
+--  We use this newtype to distinguish between a cardinal slot and a relative
+--  period of slots, and also to distinguish between number of slots and number
+--  of blocks.
+newtype SlotCount = SlotCount { unSlotCount :: Word64 }
+  deriving stock (Generic, Show, Data, Typeable)
+  deriving newtype (Eq, Ord, Num, Hashable, ToCBOR, NoUnexpectedThunks)
+
+instance HasTypeReps SlotCount
+
+-- | Add a slot count to a slot.
+addSlot :: Slot -> SlotCount -> Slot
+addSlot (Slot n) (SlotCount m) = Slot $ m + n
+
+-- | An alias for 'addSlot'
+(+.) :: Slot -> SlotCount -> Slot
+(+.) = addSlot
+
+infixl 6 +.
+
+-- | Subtract a slot count from a slot.
+--
+--   This is bounded below by 0.
+minusSlot :: Slot -> SlotCount -> Slot
+minusSlot (Slot m) (SlotCount n)
+  | m <= n    = Slot 0
+  | otherwise = Slot $ m - n
+
+-- | An alias for 'minusSlot'
+(-.) :: Slot -> SlotCount -> Slot
+(-.) = minusSlot
+
+infixl 6 -.
+
+-- | Multiply the block count by the given constant. This function does not
+-- check for overflow.
+(*.) :: Word64 -> BlockCount -> SlotCount
+n *. (BlockCount c) = SlotCount $ n * c
+
+infixl 7 *.
+
+-- | Subtract a slot count from a slot.
+--
+-- In case the slot count is greater than the slot's index, it returns
+-- Nothing.
+minusSlotMaybe :: Slot -> SlotCount -> Maybe Slot
+minusSlotMaybe (Slot m) (SlotCount n)
+  | m < n     = Nothing
+  | otherwise = Just . Slot $ m - n
+
+newtype BlockCount = BlockCount { unBlockCount :: Word64 }
+  deriving stock (Generic, Show)
+  deriving newtype (Eq, Ord, Num, Hashable, NoUnexpectedThunks)
+
+instance HasTypeReps BlockCount
+
+---------------------------------------------------------------------------------
+-- Transactions
+---------------------------------------------------------------------------------
+
+-- |The address of a transaction output, used to identify the owner.
+newtype Addr = Addr VKey
+  deriving stock (Show, Generic, Data, Typeable)
+  deriving newtype (Eq, Ord, Hashable, HasOwner, ToCBOR, NoUnexpectedThunks)
+  deriving anyclass (HasTypeReps)
+
+-- | Create an address from a number.
+mkAddr :: Natural -> Addr
+mkAddr = Addr . VKey . Owner
+
+instance HasHash Addr where
+  hash = Hash . Just . H.hash
+
+-- | A unit of value held by a UTxO.
+--
+newtype Lovelace = Lovelace
+  { unLovelace :: Integer
+  } deriving stock (Show, Generic, Data, Typeable)
+    deriving newtype (Eq, Ord, Num, Hashable, Enum, Real, Integral, ToCBOR, NoUnexpectedThunks)
+    deriving (Semigroup, Monoid) via (Sum Integer)
+    deriving anyclass (HasTypeReps)
+
+-- | Constant amount of Lovelace in the system.
+lovelaceCap :: Lovelace
+lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
+
+---------------------------------------------------------------------------------
+-- Domain restriction and exclusion
+---------------------------------------------------------------------------------
+
+class Relation m where
+  type Domain m :: *
+  type Range m :: *
+
+  singleton :: Domain m -> Range m -> m
+
+  -- | Domain
+  dom :: Ord (Domain m) => m -> Set (Domain m)
+
+  -- | Range
+  range :: Ord (Range m) => m -> Set (Range m)
+
+  -- | Domain restriction
+  --
+  -- Unicode: 25c1
+  (◁), (<|) :: (Ord (Domain m), Foldable f) => f (Domain m) -> m -> m
+  s <| r = s ◁ r
+
+  -- | Domain exclusion
+  --
+  -- Unicode: 22ea
+  (⋪), (</|) :: (Ord (Domain m), Foldable f) => f (Domain m) -> m -> m
+  s </| r = s ⋪ r
+
+  -- | Range restriction
+  --
+  -- Unicode: 25b7
+  (▷), (|>) :: Ord (Range m) => m -> Set (Range m) -> m
+  s |> r = s ▷ r
+
+  -- | Range exclusion
+  --
+  -- Unicode: 22eb
+  (⋫), (|/>) :: Ord (Range m) => m -> Set (Range m) -> m
+  s |/> r = s ⋫ r
+
+  -- | Union
+  (∪) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
+
+  -- | Union Override Right
+  (⨃) :: (Ord (Domain m), Ord (Range m), Foldable f) => m -> f (Domain m, Range m) -> m
+
+  -- | Restrict domain to values less or equal than the given value.
+  --
+  -- Unicode: 25c1
+  (<=◁) :: Ord (Domain m) => Domain m -> m -> m
+  infixl 5 <=◁
+
+  -- | Restrict range to values less or equal than the given value
+  --
+  -- Unicode: 25b7
+  (▷<=) :: (Ord (Range m)) => m -> Range m -> m
+  infixl 5 ▷<=
+
+  -- | Restrict range to values greater or equal than the given value
+  --
+  -- Unicode: 25b7
+  (▷>=) :: (Ord (Range m)) => m -> Range m -> m
+  infixl 5 ▷>=
+
+
+  -- | Size of the relation
+  size :: Integral n => m -> n
+
+-- | Alias for 'elem'.
+--
+-- Unicode: 2208
+(∈) :: (Eq a, Foldable f) => a -> f a -> Bool
+a ∈ f = elem a f
+
+-- | Alias for not 'elem'.
+--
+-- Unicode: 2209
+(∉) :: (Eq a, Foldable f) => a -> f a -> Bool
+a ∉ f = not $ elem a f
+
+infixl 4 ∉
+
+instance (Ord k, Ord v) => Relation (Bimap k v) where
+  type Domain (Bimap k v) = k
+  type Range (Bimap k v) = v
+
+  singleton = Bimap.singleton
+
+  dom = Set.fromList . Bimap.keys
+  range = Set.fromList . Bimap.elems
+
+  s ◁ r = Bimap.filter (\k _ -> k `Set.member` toSet s) r
+
+  s ⋪ r = Bimap.filter (\k _ -> k `Set.notMember` toSet s) r
+
+  r ▷ s = Bimap.filter (\_ v -> Set.member v s) r
+
+  r ⋫ s = Bimap.filter (\_ v -> Set.notMember v s) r
+
+  d0 ∪ d1 = Bimap.fold Bimap.insert d0 d1
+  d0 ⨃ d1 = foldr (uncurry Bimap.insert) d0 (toList d1)
+
+  vmax <=◁ r = Bimap.filter (\v _ -> v <= vmax) r
+
+  r ▷<= vmax = Bimap.filter (\_ v -> v <= vmax) r
+
+  r ▷>= vmin = Bimap.filter (\_ v -> v >= vmin) r
+
+  size = fromIntegral . Bimap.size
+
+instance Relation (Map k v) where
+  type Domain (Map k v) = k
+  type Range (Map k v) = v
+
+  singleton = Map.singleton
+
+  dom = Map.keysSet
+  range = Set.fromList . Map.elems
+
+  s ◁ r = -- Map.filterWithKey (\k _ -> k `Set.member` toSet s) r
+          Map.restrictKeys r (toSet s) --TIMCHANGED
+
+  s ⋪ r = Map.filterWithKey (\k _ -> k `Set.notMember` toSet s) r
+
+  r ▷ s = Map.filter (flip Set.member s) r
+
+  r ⋫ s = Map.filter (flip Set.notMember s) r
+
+  d0 ∪ d1 = Map.union d0 d1
+  -- For union override we pass @d1@ as first argument, since 'Map.union' is
+  -- left biased.
+  d0 ⨃ d1 = Map.union (Map.fromList . toList $ d1) d0
+
+  vmax <=◁ r = Map.filterWithKey (\k _ -> k <= vmax) r
+
+  r ▷<= vmax = Map.filter (<= vmax) r
+
+  r ▷>= vmin = Map.filter (>= vmin) r
+
+  size = fromIntegral . Map.size
+
+-- | Union override plus is (A\B)∪(B\A)∪{k|->v1+v2 | k|->v1 : A /\ k|->v2 : B}
+(∪+) :: (Ord a, Ord b, Num b) => Map a b -> Map a b -> Map a b
+a ∪+ b = ((dom a) ⋪ b) ∪ ((dom b) ⋪ a) ∪ (Map.unionWith (+) a b)
+
+instance Relation (Set (a, b)) where
+  type Domain (Set (a, b)) = a
+  type Range (Set (a, b))  = b
+
+  singleton a b = Set.singleton (a,b)
+
+  dom = Set.map fst
+
+  range = Set.map snd
+
+  s ◁ r = Set.filter (\(k,_) -> k `Set.member` toSet s) r
+
+  s ⋪ r = Set.filter (\(k,_) -> k `Set.notMember` toSet s) r
+
+  r ▷ s = Set.filter (\(_,v) -> Set.member v s) r
+
+  r ⋫ s = Set.filter (\(_,v) -> Set.notMember v s) r
+
+  (∪) = Set.union
+
+  d0 ⨃ d1 = d1' ∪ ((dom d1') ⋪ d0)
+    where
+      d1' = toSet d1
+
+  vmax <=◁ r = Set.filter ((<= vmax) . fst) $ r
+
+  r ▷<= vmax = Set.filter ((<= vmax) . snd) $ r
+
+  r ▷>= vmax = Set.filter ((>= vmax) . snd) $ r
+
+  size = fromIntegral . Set.size
+
+instance Relation [(a, b)] where
+  type Domain [(a, b)] = a
+  type Range [(a, b)] = b
+
+  singleton a b = [(a, b)]
+
+  dom = toSet . fmap fst
+
+  range = toSet . fmap snd
+
+  s ◁ r = filter ((`Set.member` toSet s) . fst) r
+
+  s ⋪ r = filter ((`Set.notMember` toSet s) . fst) r
+
+  r ▷ s = filter ((`Set.member` toSet s) . snd) r
+
+  r ⋫ s = filter ((`Set.notMember` toSet s) . snd) r
+
+  (∪) = (++)
+
+  -- In principle a list of pairs allows for duplicated keys.
+  d0 ⨃ d1 = d0 ++ toList d1
+
+  vmax <=◁ r = filter ((<= vmax) . fst) r
+
+  r ▷<= vmax = filter ((<= vmax) . snd) r
+
+  r ▷>= vmin = filter ((vmin <=) . snd) r
+
+  size = fromIntegral . length
+
+---------------------------------------------------------------------------------
+-- Aliases
+---------------------------------------------------------------------------------
+
+-- | Inclusion among foldables.
+--
+-- Unicode: 2286
+--
+(⊆) :: (Foldable f, Foldable g, Ord a) => f a -> g a -> Bool
+x ⊆ y = toSet x `isSubsetOf` toSet y
+
+toSet :: (Foldable f, Ord a) => f a -> Set a
+toSet = Set.fromList . toList
+
+(∩) :: Ord a => Set a -> Set a -> Set a
+(∩) = intersection
+
+
+--------------------------------------------------------------------------------
+-- Goblins instances
+--------------------------------------------------------------------------------
+
+deriveGoblin ''Addr
+deriveGoblin ''BlockCount
+deriveGoblin ''Epoch
+deriveGoblin ''Owner
+deriveGoblin ''Sig
+deriveGoblin ''Slot
+deriveGoblin ''SlotCount
+deriveGoblin ''VKey
+deriveGoblin ''VKeyGenesis
+
+instance GeneOps g => Goblin g Hash where
+  tinker gen
+    = tinkerRummagedOrConjureOrSave
+        ((Hash . Just . (`mod` 30))
+           <$$> tinker (unwrapValue <$> gen))
+    where
+      unwrapValue (Hash (Just x)) = x
+      unwrapValue (Hash Nothing) =
+        error $  "tinker Hash instance: trying to tinker with an invalid hash"
+              ++ " (which contains nothing)"
+
+  conjure = saveInBagOfTricks =<< (Hash . Just . (`mod` 30) <$> conjure)
+
+instance GeneOps g => Goblin g Lovelace where
+  tinker gen
+    = tinkerRummagedOrConjureOrSave
+        ((\x -> (Lovelace x) `mod` lovelaceCap)
+           <$$> tinker ((\(Lovelace x) -> x) <$> gen))
+  conjure = saveInBagOfTricks =<< ((`mod` lovelaceCap) . Lovelace <$> conjure)
+
+
+--------------------------------------------------------------------------------
+-- AddShrinks instances
+--------------------------------------------------------------------------------
+
+deriveAddShrinks ''Addr
+deriveAddShrinks ''BlockCount
+deriveAddShrinks ''Epoch
+deriveAddShrinks ''Hash
+deriveAddShrinks ''Lovelace
+deriveAddShrinks ''Owner
+deriveAddShrinks ''Sig
+deriveAddShrinks ''Slot
+deriveAddShrinks ''SlotCount
+deriveAddShrinks ''VKey
+deriveAddShrinks ''VKeyGenesis
+
+
+--------------------------------------------------------------------------------
+-- SeedGoblin instances
+--------------------------------------------------------------------------------
+
+deriveSeedGoblin ''Addr
+deriveSeedGoblin ''BlockCount
+deriveSeedGoblin ''Epoch
+deriveSeedGoblin ''Hash
+deriveSeedGoblin ''Lovelace
+deriveSeedGoblin ''Owner
+deriveSeedGoblin ''Slot
+deriveSeedGoblin ''SlotCount
+deriveSeedGoblin ''VKey
+deriveSeedGoblin ''VKeyGenesis

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -30,7 +30,7 @@ module Shelley.Spec.Ledger.Delegation.Certificates
   )
 where
 
-import Byron.Spec.Ledger.Core (Relation (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -30,11 +30,11 @@ module Shelley.Spec.Ledger.Delegation.Certificates
   )
 where
 
-import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Keys (Hash, KeyHash, KeyRole (..), VerKeyVRF)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -30,7 +30,6 @@ module Shelley.Spec.Ledger.EpochBoundary
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (▷), (◁))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)
@@ -42,6 +41,7 @@ import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.Address (Addr (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom, (▷), (◁))
 import Shelley.Spec.Ledger.Credential (Credential, Ptr, StakeReference (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -30,7 +30,7 @@ module Shelley.Spec.Ledger.EpochBoundary
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (▷), (◁))
+import Shelley.Spec.Ledger.Core (dom, (▷), (◁))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -79,7 +79,7 @@ module Shelley.Spec.Ledger.LedgerState
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
+import Shelley.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -79,7 +79,6 @@ module Shelley.Spec.Ledger.LedgerState
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -113,6 +112,7 @@ import Shelley.Spec.Ledger.BaseTypes
     intervalValue,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.Certificates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.Rewards
   )
 where
 
-import Shelley.Spec.Ledger.Core ((◁))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -43,6 +42,7 @@ import Shelley.Spec.Ledger.BaseTypes
     unitIntervalToRational,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core ((◁))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.PoolParams (poolSpec)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -17,7 +17,7 @@ module Shelley.Spec.Ledger.Rewards
   )
 where
 
-import Byron.Spec.Ledger.Core ((◁))
+import Shelley.Spec.Ledger.Core ((◁))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.STS.Bbody
   )
 where
 
-import Shelley.Spec.Ledger.Core ((∈))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.State.Transition
   ( (?!),
@@ -43,6 +42,7 @@ import Shelley.Spec.Ledger.BlockChain
     hBbsize,
     incrBlocks,
   )
+import Shelley.Spec.Ledger.Core ((∈))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
 import Shelley.Spec.Ledger.Keys (DSignable, Hash, coerceKeyRole, hashKey)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -17,7 +17,7 @@ module Shelley.Spec.Ledger.STS.Bbody
   )
 where
 
-import Byron.Spec.Ledger.Core ((∈))
+import Shelley.Spec.Ledger.Core ((∈))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.State.Transition
   ( (?!),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -13,7 +13,6 @@ module Shelley.Spec.Ledger.STS.Deleg
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -44,6 +43,7 @@ import Shelley.Spec.Ledger.BaseTypes
     invalidKey,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import Shelley.Spec.Ledger.Credential (Credential)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -13,7 +13,7 @@ module Shelley.Spec.Ledger.STS.Deleg
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
+import Shelley.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -16,7 +16,6 @@ module Shelley.Spec.Ledger.STS.Delegs
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -35,6 +34,7 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, invalidKey)
 import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -16,7 +16,7 @@ module Shelley.Spec.Ledger.STS.Delegs
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
+import Shelley.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -13,7 +13,7 @@ module Shelley.Spec.Ledger.STS.Epoch
   )
 where
 
-import Byron.Spec.Ledger.Core ((⨃))
+import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.State.Transition (Embed (..), InitialRule, STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
 import Data.Map.Strict (Map)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -13,13 +13,13 @@ module Shelley.Spec.Ledger.STS.Epoch
   )
 where
 
-import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.State.Transition (Embed (..), InitialRule, STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Shelley.Spec.Ledger.Core ((⨃))
 import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -14,7 +14,6 @@ module Shelley.Spec.Ledger.STS.Mir
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∪+), (◁))
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.State.Transition
   ( InitialRule,
@@ -28,6 +27,7 @@ import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.Address (mkRwdAcnt)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Shelley.Spec.Ledger.Core (dom, (∪+), (◁))
 import Shelley.Spec.Ledger.Delegation.Certificates (StakeCreds (..))
 import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -14,7 +14,7 @@ module Shelley.Spec.Ledger.STS.Mir
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∪+), (◁))
+import Shelley.Spec.Ledger.Core (dom, (∪+), (◁))
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.State.Transition
   ( InitialRule,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -13,7 +13,6 @@ module Shelley.Spec.Ledger.STS.Ocert
   )
 where
 
-import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks, asks)
 import Control.State.Transition
 import Data.Map.Strict (Map)
@@ -23,6 +22,7 @@ import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Core ((⨃))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.OCert

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -13,7 +13,7 @@ module Shelley.Spec.Ledger.STS.Ocert
   )
 where
 
-import Byron.Spec.Ledger.Core ((⨃))
+import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks, asks)
 import Control.State.Transition
 import Data.Map.Strict (Map)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -17,7 +17,7 @@ module Shelley.Spec.Ledger.STS.Overlay
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, range)
+import Shelley.Spec.Ledger.Core (dom, range)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Prelude
   ( MonadError (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.STS.Overlay
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, range)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Prelude
   ( MonadError (..),
@@ -47,6 +46,7 @@ import Shelley.Spec.Ledger.BlockChain
     seedEta,
     seedL,
   )
+import Shelley.Spec.Ledger.Core (dom, range)
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import Shelley.Spec.Ledger.Keys

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -13,7 +13,6 @@ module Shelley.Spec.Ledger.STS.Pool
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord, encodeListLen, matchSize)
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)
@@ -25,6 +24,7 @@ import Data.Typeable (Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, invalidKey)
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState (PState (..), emptyPState)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -13,7 +13,7 @@ module Shelley.Spec.Ledger.STS.Pool
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord, encodeListLen, matchSize)
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -11,7 +11,7 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.State.Transition
   ( STS (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -11,7 +11,6 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.State.Transition
   ( STS (..),
@@ -23,6 +22,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Shelley.Spec.Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Shelley.Spec.Ledger.Delegation.Certificates (StakePools (..))
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -14,7 +14,7 @@ module Shelley.Spec.Ledger.STS.Ppup
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (⊆), (⨃))
+import Shelley.Spec.Ledger.Core (dom, (⊆), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -14,7 +14,6 @@ module Shelley.Spec.Ledger.STS.Ppup
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (⊆), (⨃))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -32,6 +31,7 @@ import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Core (dom, (⊆), (⨃))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.PParams

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -15,7 +15,6 @@ module Shelley.Spec.Ledger.STS.Tick
   )
 where
 
-import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
@@ -23,6 +22,7 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
+import Shelley.Spec.Ledger.Core ((⨃))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -15,7 +15,7 @@ module Shelley.Spec.Ledger.STS.Tick
   )
 where
 
-import Byron.Spec.Ledger.Core ((⨃))
+import Shelley.Spec.Ledger.Core ((⨃))
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -17,8 +17,6 @@ module Shelley.Spec.Ledger.STS.Utxo
   )
 where
 
-
-import Shelley.Spec.Ledger.Core (dom, range, (∪), (⊆), (⋪))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -49,6 +47,7 @@ import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.Address (Addr, getNetwork)
 import Shelley.Spec.Ledger.BaseTypes (Network, ShelleyBase, invalidKey, networkId)
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom, range, (∪), (⊆), (⋪))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.Certificates (StakePools)
 import Shelley.Spec.Ledger.Keys (GenDelegs)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -17,7 +17,8 @@ module Shelley.Spec.Ledger.STS.Utxo
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, range, (∪), (⊆), (⋪))
+
+import Shelley.Spec.Ledger.Core (dom, range, (∪), (⊆), (⋪))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.STS.Utxow
   )
 where
 
-import Shelley.Spec.Ledger.Core ((∩))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
@@ -58,6 +57,7 @@ import Shelley.Spec.Ledger.BaseTypes
     invalidKey,
     quorum,
   )
+import Shelley.Spec.Ledger.Core ((∩))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.Certificates (isInstantaneousRewards)
 import Shelley.Spec.Ledger.Keys

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -17,7 +17,7 @@ module Shelley.Spec.Ledger.STS.Utxow
   )
 where
 
-import Byron.Spec.Ledger.Core ((∩))
+import Shelley.Spec.Ledger.Core ((∩))
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -59,7 +59,6 @@ module Shelley.Spec.Ledger.TxData
   )
 where
 
-import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary
   ( Annotator (..),
     Case (..),
@@ -121,6 +120,7 @@ import Shelley.Spec.Ledger.BaseTypes
     strictMaybeToMaybe,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Shelley.Spec.Ledger.Credential
   ( Credential (..),
     Ix,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -59,7 +59,7 @@ module Shelley.Spec.Ledger.TxData
   )
 where
 
-import Byron.Spec.Ledger.Core (Relation (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary
   ( Annotator (..),
     Case (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -38,7 +38,7 @@ module Shelley.Spec.Ledger.UTxO
   )
 where
 
-import Byron.Spec.Ledger.Core (Relation (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (hashWithSerialiser)
 import Cardano.Prelude (Generic, NFData, NoUnexpectedThunks (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -38,7 +38,6 @@ module Shelley.Spec.Ledger.UTxO
   )
 where
 
-import Shelley.Spec.Ledger.Core (Relation (..))
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (hashWithSerialiser)
 import Cardano.Prelude (Generic, NFData, NoUnexpectedThunks (..))
@@ -52,6 +51,7 @@ import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Address (Addr (..))
 import Shelley.Spec.Ledger.BaseTypes (strictMaybeToMaybe)
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (Relation (..))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -9,7 +9,7 @@ module Test.Shelley.Spec.Ledger.Generator.Block
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, range)
+import Shelley.Spec.Ledger.Core (dom, range)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.State.Transition.Extended (TRC (..), applySTS)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -9,7 +9,6 @@ module Test.Shelley.Spec.Ledger.Generator.Block
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, range)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.State.Transition.Extended (TRC (..), applySTS)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
@@ -27,6 +26,7 @@ import Shelley.Spec.Ledger.BaseTypes
     (⭒),
   )
 import Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
+import Shelley.Spec.Ledger.Core (dom, range)
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyRole (..), coerceKeyRole, hashKey, vKey)
 import Shelley.Spec.Ledger.LedgerState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -15,7 +15,6 @@ module Test.Shelley.Spec.Ledger.Generator.Delegation
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, findWithDefault, fromList, keys, lookup, size)
 import Data.Maybe (fromMaybe)
@@ -32,6 +31,7 @@ import Shelley.Spec.Ledger.BaseTypes
     interval0,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Shelley.Spec.Ledger.Credential (pattern KeyHashObj)
 import Shelley.Spec.Ledger.Delegation.Certificates
   ( pattern DCertMir,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -15,7 +15,7 @@ module Test.Shelley.Spec.Ledger.Generator.Delegation
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (∈), (∉))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, findWithDefault, fromList, keys, lookup, size)
 import Data.Maybe (fromMaybe)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
@@ -4,7 +4,6 @@
 
 module Test.Shelley.Spec.Ledger.NonTraceProperties.PropertyTests (nonTracePropertyTests) where
 
-import Shelley.Spec.Ledger.Core ((<|))
 import Data.Foldable (toList)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -25,6 +24,7 @@ import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
 import Hedgehog.Internal.Property (LabelName (..))
 import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Core ((<|))
 import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.PParams
 import Shelley.Spec.Ledger.Slot

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
@@ -4,7 +4,7 @@
 
 module Test.Shelley.Spec.Ledger.NonTraceProperties.PropertyTests (nonTracePropertyTests) where
 
-import Byron.Spec.Ledger.Core ((<|))
+import Shelley.Spec.Ledger.Core ((<|))
 import Data.Foldable (toList)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
@@ -2,7 +2,7 @@
 
 module Test.Shelley.Spec.Ledger.NonTraceProperties.Validity where
 
-import Byron.Spec.Ledger.Core (dom)
+import Shelley.Spec.Ledger.Core (dom)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Coin (Coin (..))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
@@ -2,10 +2,10 @@
 
 module Test.Shelley.Spec.Ledger.NonTraceProperties.Validity where
 
-import Shelley.Spec.Ledger.Core (dom)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Core (dom)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.Certificates (StakePools (..))
 import Shelley.Spec.Ledger.Keys

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
@@ -15,7 +15,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestDeleg
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, range, (∈), (∉), (◁))
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,
@@ -32,6 +31,7 @@ import qualified Data.Set as Set (isSubsetOf, singleton, size)
 import Shelley.Spec.Ledger.Address (mkRwdAcnt)
 import Shelley.Spec.Ledger.BaseTypes ((==>), Network (..))
 import Shelley.Spec.Ledger.Coin (Coin, pattern Coin)
+import Shelley.Spec.Ledger.Core (dom, range, (∈), (∉), (◁))
 import Shelley.Spec.Ledger.Keys (KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState
   ( InstantaneousRewards (..),

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
@@ -15,7 +15,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestDeleg
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, range, (∈), (∉), (◁))
+import Shelley.Spec.Ledger.Core (dom, range, (∈), (∉), (◁))
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -7,7 +7,7 @@
 
 module Test.Shelley.Spec.Ledger.Rules.TestPool where
 
-import Byron.Spec.Ledger.Core (dom, (∈), (∉))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Control.State.Transition (Environment, State)
 import Control.State.Transition.Trace
   ( SourceSignalTarget,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -7,7 +7,6 @@
 
 module Test.Shelley.Spec.Ledger.Rules.TestPool where
 
-import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Control.State.Transition (Environment, State)
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
@@ -22,6 +21,7 @@ import qualified Data.Maybe as Maybe (maybe)
 import qualified Data.Set as S
 import Data.Word (Word64)
 import Shelley.Spec.Ledger.BaseTypes ((==>))
+import Shelley.Spec.Ledger.Core (dom, (∈), (∉))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (poolCWitness)
 import Shelley.Spec.Ledger.Keys (KeyRole (..))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -11,7 +11,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
   )
 where
 
-import Byron.Spec.Ledger.Core (dom, (▷))
+import Shelley.Spec.Ledger.Core (dom, (▷))
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -11,7 +11,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
   )
 where
 
-import Shelley.Spec.Ledger.Core (dom, (▷))
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,
@@ -22,6 +21,7 @@ import Control.State.Transition.Trace
 import Data.List (foldl')
 import qualified Data.Set as Set (intersection, isSubsetOf, null, singleton)
 import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.Core (dom, (▷))
 import Shelley.Spec.Ledger.LedgerState
   ( _deposited,
     _fees,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
@@ -15,7 +15,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestUtxow
   )
 where
 
-import Byron.Spec.Ledger.Core ((<|), dom)
+import Shelley.Spec.Ledger.Core ((<|), dom)
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
@@ -15,7 +15,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestUtxow
   )
 where
 
-import Shelley.Spec.Ledger.Core ((<|), dom)
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,
@@ -26,6 +25,7 @@ import Control.State.Transition.Trace
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map (isSubmapOf)
 import qualified Data.Set as Set (fromList, intersection, isSubsetOf, map, null)
+import Shelley.Spec.Ledger.Core ((<|), dom)
 import Shelley.Spec.Ledger.LedgerState (keyRefunds, pattern UTxOState)
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.Tx


### PR DESCRIPTION
This PR is the first step in a series of four planned PRs to replace Byron.Spec.Ledger.Core, with a new version Shelley.Spec.Ledger.Core; The new version will be a stripped down version, implementing only the functionality needed for Shelley, and with more attention paid to efficient implementations. In all but the last PR, the API of the Relation class, will remain the same.
In this first PR the Shelley version is an exact copy of the Byron version, except its module name has been changed to record that appears in a different place in the source tree.

Future PRs will address the following

step 1) Restrict the export list, and delete the unneeded code.
step 2) Rewrite the needed operations so that they pay attention to efficiency.
step 3) Rework some of the calls to the API, to take advantage of more efficient versions
step 3) Rework the API. Change some inputs from (Foldable f => f a) to (Set a)
        A foldable input forces linear behavior.