### PR TITLE
Make tests parametric on crypto

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Genesis.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Genesis where
 
@@ -25,9 +29,8 @@ import Shelley.Spec.Ledger.Genesis
 import Shelley.Spec.Ledger.Keys (Hash, KeyHash, KeyPair (..), KeyRole (..), VKey (..), hashKey, hashVerKeyVRF)
 import Shelley.Spec.Ledger.PParams
 import Test.Cardano.Crypto.Gen (genProtocolMagicId)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes hiding (Addr, KeyHash, KeyPair, SignKeyDSIGN, SignKeyVRF, VKey, VerKeyVRF)
 
-genShelleyGenesis :: Gen (ShelleyGenesis ConcreteCrypto)
+genShelleyGenesis :: Crypto c => Gen (ShelleyGenesis c)
 genShelleyGenesis =
   ShelleyGenesis
     <$> genUTCTime
@@ -68,7 +71,7 @@ genPParams =
     <*> genMinUTxOValue
 
 genNatural :: Range Natural -> Gen Natural
-genNatural range = Gen.integral range
+genNatural = Gen.integral
 
 genRational :: Gen Rational
 genRational = Gen.realFrac_ (Range.linearFrac 0 10000)
@@ -98,60 +101,65 @@ genUnitInterval =
     <$> Gen.realFrac_ (Range.linearFrac 0.01 1)
 
 genGenesisDelegationList ::
+  Crypto c =>
   Gen
-    [ ( KeyHash 'Genesis ConcreteCrypto,
-        ( KeyHash 'GenesisDelegate ConcreteCrypto,
+    [ ( KeyHash 'Genesis c,
+        ( KeyHash 'GenesisDelegate c,
           Hash
-            ConcreteCrypto
-            (VerKeyVRF (VRF ConcreteCrypto))
+            c
+            (VerKeyVRF (VRF c))
         )
       )
     ]
 genGenesisDelegationList = Gen.list (Range.linear 1 10) genGenesisDelegationPair
 
 genGenesisDelegationPair ::
+  forall c.
+  Crypto c =>
   Gen
-    ( KeyHash 'Genesis ConcreteCrypto,
-      ( KeyHash 'GenesisDelegate ConcreteCrypto,
+    ( KeyHash 'Genesis c,
+      ( KeyHash 'GenesisDelegate c,
         Hash
-          ConcreteCrypto
-          (VerKeyVRF (VRF ConcreteCrypto))
+          c
+          (VerKeyVRF (VRF c))
       )
     )
 genGenesisDelegationPair =
   (,) <$> genKeyHash <*> ((,) <$> genKeyHash <*> genVRFKeyHash)
-
-genVRFKeyHash :: Gen (Hash ConcreteCrypto (VerKeyVRF (VRF ConcreteCrypto)))
-genVRFKeyHash = hashVerKeyVRF . snd <$> genVRFKeyPair
+  where
+    genVRFKeyHash :: Gen (Hash c (VerKeyVRF (VRF c)))
+    genVRFKeyHash = hashVerKeyVRF . snd <$> (genVRFKeyPair @c)
 
 genVRFKeyPair ::
-  Gen
-    ( SignKeyVRF (VRF ConcreteCrypto),
-      VerKeyVRF (VRF ConcreteCrypto)
-    )
+  forall c.
+  Crypto c =>
+  Gen (SignKeyVRF (VRF c), VerKeyVRF (VRF c))
 genVRFKeyPair = do
   seed <- genSeed seedSize
   let sk = genKeyVRF seed
       vk = deriveVerKeyVRF sk
   pure (sk, vk)
   where
-    seedSize :: Int
-    seedSize = fromIntegral (seedSizeVRF (Proxy :: Proxy (VRF ConcreteCrypto)))
+    seedSize = fromIntegral (seedSizeVRF (Proxy :: Proxy (VRF c)))
 
-genFundsList :: Gen [(Addr ConcreteCrypto, Coin)]
+genFundsList :: Crypto c => Gen [(Addr c, Coin)]
 genFundsList = Gen.list (Range.linear 1 100) genGenesisFundPair
 
 genSeed :: Int -> Gen Seed
 genSeed n = mkSeedFromBytes <$> Gen.bytes (Range.singleton n)
 
-genKeyHash :: Gen (KeyHash krole ConcreteCrypto)
+genKeyHash ::
+  Crypto c =>
+  Gen (KeyHash krole c)
 genKeyHash = hashKey . snd <$> genKeyPair
 
 -- | Generate a deterministic key pair given a seed.
 genKeyPair ::
+  forall c krole.
+  DSIGNAlgorithm (DSIGN c) =>
   Gen
-    ( SignKeyDSIGN (DSIGN ConcreteCrypto),
-      VKey krole ConcreteCrypto
+    ( SignKeyDSIGN (DSIGN c),
+      VKey krole c
     )
 genKeyPair = do
   seed <- genSeed seedSize
@@ -160,13 +168,13 @@ genKeyPair = do
   pure (sk, VKey vk)
   where
     seedSize :: Int
-    seedSize = fromIntegral (seedSizeDSIGN (Proxy :: Proxy (DSIGN ConcreteCrypto)))
+    seedSize = fromIntegral (seedSizeDSIGN (Proxy :: Proxy (DSIGN c)))
 
-genGenesisFundPair :: Gen (Addr ConcreteCrypto, Coin)
+genGenesisFundPair :: Crypto c => Gen (Addr c, Coin)
 genGenesisFundPair =
   (,) <$> genAddress <*> genCoin
 
-genAddress :: Gen (Addr ConcreteCrypto)
+genAddress :: Crypto c => Gen (Addr c)
 genAddress = do
   (secKey1, verKey1) <- genKeyPair
   (secKey2, verKey2) <- genKeyPair

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Genesis/Properties.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Genesis/Properties.hs
@@ -1,12 +1,24 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Test.Shelley.Spec.Ledger.Genesis.Properties
   ( genesis,
+
+    -- * exported since they can be used for different cryptos
+    prop_roundtrip_Address_JSON,
+    prop_roundtrip_FundPair_JSON,
+    prop_roundtrip_GenesisDelegationPair_JSON,
+    prop_roundtrip_ShelleyGenesis_JSON,
   )
 where
 
 import Data.Aeson (decode, encode, fromJSON, toJSON)
+import Data.Proxy
 import Hedgehog (Property)
 import qualified Hedgehog
+import Shelley.Spec.Ledger.Crypto
 import Test.Cardano.Prelude
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ConcreteCrypto)
 import Test.Shelley.Spec.Ledger.Generator.Genesis
 import Test.Shelley.Spec.Ledger.Genesis.Example
 import Test.Tasty
@@ -15,18 +27,34 @@ import Test.Tasty.Hedgehog
 prop_golden_ShelleyGenesis :: Property
 prop_golden_ShelleyGenesis = goldenTestJSON exampleShelleyGenesis "test/Golden/ShelleyGenesis"
 
-prop_roundtrip_GenesisDelegationPair_JSON :: Property
-prop_roundtrip_GenesisDelegationPair_JSON =
+prop_roundtrip_Address_JSON :: forall c. Crypto c => Proxy c -> Property
+prop_roundtrip_Address_JSON _ =
+  -- If this fails, FundPair and ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    dp <- Hedgehog.forAll genGenesisDelegationPair
+    addr <- Hedgehog.forAll $ genAddress @c
+    Hedgehog.tripping addr toJSON fromJSON
+    Hedgehog.tripping addr encode decode
+
+prop_roundtrip_GenesisDelegationPair_JSON :: forall c. Crypto c => Proxy c -> Property
+prop_roundtrip_GenesisDelegationPair_JSON _ =
+  Hedgehog.property $ do
+    dp <- Hedgehog.forAll $ genGenesisDelegationPair @c
     Hedgehog.tripping dp toJSON fromJSON
     Hedgehog.tripping dp encode decode
 
-prop_roundtrip_ShelleyGenesis_JSON :: Property
-prop_roundtrip_ShelleyGenesis_JSON = Hedgehog.withTests 500
+prop_roundtrip_FundPair_JSON :: forall c. Crypto c => Proxy c -> Property
+prop_roundtrip_FundPair_JSON _ =
+  -- If this fails, ShelleyGenesis can also fail.
+  Hedgehog.property $ do
+    fp <- Hedgehog.forAll $ genGenesisFundPair @c
+    Hedgehog.tripping fp toJSON fromJSON
+    Hedgehog.tripping fp encode decode
+
+prop_roundtrip_ShelleyGenesis_JSON :: forall c. Crypto c => Proxy c -> Property
+prop_roundtrip_ShelleyGenesis_JSON _ = Hedgehog.withTests 500
   $ Hedgehog.property
   $ do
-    sg <- Hedgehog.forAll genShelleyGenesis
+    sg <- Hedgehog.forAll $ genShelleyGenesis @c
     Hedgehog.tripping sg toJSON fromJSON
     Hedgehog.tripping sg encode decode
 
@@ -35,6 +63,12 @@ genesis =
   testGroup
     "Shelley Genesis"
     [ testProperty "Genesis Golden Test" prop_golden_ShelleyGenesis,
-      testProperty "Genesis round trip" prop_roundtrip_ShelleyGenesis_JSON,
-      testProperty "delegation pair round trip" prop_roundtrip_GenesisDelegationPair_JSON
+      testProperty "Adress round trip" $
+        prop_roundtrip_Address_JSON @ConcreteCrypto Proxy,
+      testProperty "Genesis round trip" $
+        prop_roundtrip_ShelleyGenesis_JSON @ConcreteCrypto Proxy,
+      testProperty "fund pair round trip" $
+        prop_roundtrip_FundPair_JSON @ConcreteCrypto Proxy,
+      testProperty "delegation pair round trip" $
+        prop_roundtrip_GenesisDelegationPair_JSON @ConcreteCrypto Proxy
     ]


### PR DESCRIPTION
Similar tests exists at cardano-node, but with `TPraosStandardCrypto` instead of `ConcreteCrypto`. It makes sence to make them parametric, to avoid some code replication.

The updates tests at node are here https://github.com/input-output-hk/cardano-node/tree/kderme/update-deps and I have tested locally that they also pass.