### PR TITLE
Remove Shelley.Spec.Ledger.Core methods not used by Shelley

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -285,7 +285,7 @@ text64FromCBOR = do
 
 newtype Url = Url {urlToText :: Text}
   deriving (Eq, Ord, Generic, Show)
-  deriving newtype (ToCBOR, NoUnexpectedThunks)
+  deriving newtype (ToCBOR, NFData, NoUnexpectedThunks)
 
 textToUrl :: Text -> Maybe Url
 textToUrl t = Url <$> text64 t
@@ -295,7 +295,7 @@ instance FromCBOR Url where
 
 newtype DnsName = DnsName {dnsToText :: Text}
   deriving (Eq, Ord, Generic, Show)
-  deriving newtype (ToCBOR, NoUnexpectedThunks)
+  deriving newtype (ToCBOR, NoUnexpectedThunks, NFData)
 
 textToDns :: Text -> Maybe DnsName
 textToDns t = DnsName <$> text64 t
@@ -305,7 +305,7 @@ instance FromCBOR DnsName where
 
 newtype Port = Port {portToWord16 :: Word16}
   deriving (Eq, Ord, Generic, Show)
-  deriving newtype (Num, FromCBOR, ToCBOR, NoUnexpectedThunks)
+  deriving newtype (Num, FromCBOR, ToCBOR, NFData, NoUnexpectedThunks)
 
 --------------------------------------------------------------------------------
 -- Active Slot Coefficent, named f in

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -79,6 +79,7 @@ import Cardano.Prelude
   ( AllowThunksIn (..),
     ByteString,
     LByteString,
+    NFData,
     NoUnexpectedThunks (..),
   )
 import Cardano.Slotting.Slot (WithOrigin (..))
@@ -142,12 +143,11 @@ import Shelley.Spec.NonIntegral (CompareResult (..), taylorExpCmp)
 -- | The hash of a Block Header
 newtype HashHeader crypto = HashHeader {unHashHeader :: (Hash crypto (BHeader crypto))}
   deriving (Show, Eq, Generic, Ord)
+  deriving newtype (NFData, NoUnexpectedThunks)
 
 deriving instance Crypto crypto => ToCBOR (HashHeader crypto)
 
 deriving instance Crypto crypto => FromCBOR (HashHeader crypto)
-
-instance NoUnexpectedThunks (HashHeader crypto)
 
 data TxSeq crypto = TxSeq'
   { txSeqTxns' :: !(StrictSeq (Tx crypto)),
@@ -349,6 +349,8 @@ data LastAppliedBlock crypto = LastAppliedBlock
   deriving (Show, Eq, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (LastAppliedBlock crypto)
+
+instance NFData (LastAppliedBlock crypto)
 
 instance Crypto crypto => ToCBOR (LastAppliedBlock crypto) where
   toCBOR (LastAppliedBlock b s h) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Core.hs
@@ -1,261 +1,44 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NumDecimals #-}
-{-# LANGUAGE StrictData #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
-module Shelley.Spec.Ledger.Core where
+module Shelley.Spec.Ledger.Core
+  ( Relation
+      ( (⨃),
+        (∪),
+        dom,
+        range,
+        (◁),
+        (<|),
+        (▷),
+        (|>),
+        singleton,
+        (⋪),
+        (</|),
+        (⋫),
+        (|/>),
+        Domain,
+        Range,
+        -- below are methods not used anywhere
+        size,
+        (<=◁),
+        (▷<=),
+        (▷>=)
+      ),
+    (⊆),
+    (∪+),
+    (∈),
+    (∉),
+    (∩),
+  )
+where
 
-import Cardano.Binary (ToCBOR)
-import Cardano.Prelude (NoUnexpectedThunks (..))
-import Data.AbstractSize
-import Data.Bimap (Bimap)
-import qualified Data.Bimap as Bimap
-import Data.Data (Data, Typeable)
 import Data.Foldable (elem, toList)
-import Data.Hashable (Hashable)
-import qualified Data.Hashable as H
-import Data.Int (Int64)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
-import Data.Monoid (Sum (..))
-import qualified Data.Sequence as Seq
 import Data.Set (Set, intersection, isSubsetOf)
 import qualified Data.Set as Set
-import Data.Typeable (typeOf)
-import Data.Word (Word64, Word8)
-import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
-import Test.Goblin
-  ( (<$$>),
-    AddShrinks (..),
-    GeneOps,
-    Goblin (..),
-    SeedGoblin (..),
-    saveInBagOfTricks,
-    tinkerRummagedOrConjureOrSave,
-  )
-import Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
-
--- | An encoded hash of part of the system.
---
--- 'Nothing' is used to signal to the elaborators (i.e. the algorithms that
--- translate abstract data into data concrete) that they should produce an
--- invalid concrete hash.
-newtype Hash = Hash
-  { unHash :: Maybe Int
-  }
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-isValid :: Hash -> Bool
-isValid = isJust . unHash
-
--- | Hash part of the ledger payload
-class HasHash a where
-  hash :: a -> Hash
-
----------------------------------------------------------------------------------
--- Signing and verification
----------------------------------------------------------------------------------
-
--- | Representation of the owner of key pair.
-newtype Owner = Owner
-  { unOwner :: Natural
-  }
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-class HasOwner a where
-  owner :: a -> Owner
-
--- | Signing Key.
-newtype SKey = SKey Owner
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-instance HasOwner SKey where
-  owner (SKey o) = o
-
--- | Verification Key.
-newtype VKey = VKey Owner
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-instance HasHash VKey where
-  hash = Hash . Just . H.hash
-
-instance HasOwner VKey where
-  owner (VKey o) = o
-
--- | A genesis key is a specialisation of a generic VKey.
-newtype VKeyGenesis = VKeyGenesis {unVKeyGenesis :: VKey}
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, HasHash, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-instance HasOwner VKeyGenesis where
-  owner (VKeyGenesis vk) = owner vk
-
-mkVKeyGenesis :: Natural -> VKeyGenesis
-mkVKeyGenesis = VKeyGenesis . VKey . Owner
-
--- | Make a set of genesis keys. The genesis keys are continuously numbered from 0 to the given
--- number of genesis keys minus 1.
-mkVkGenesisSet ::
-  -- | Number of genesis keys
-  Word8 ->
-  Set VKeyGenesis
-mkVkGenesisSet ngk = Set.fromAscList $ mkVKeyGenesis <$> [0 .. (fromIntegral ngk - 1)]
-
--- | Key Pair.
-data KeyPair = KeyPair
-  { sKey :: SKey,
-    vKey :: VKey
-  }
-  deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
-
-instance HasTypeReps KeyPair
-
--- | Return a key pair for a given owner.
-keyPair :: Owner -> KeyPair
-keyPair o = KeyPair (SKey o) (VKey o)
-
--- | A digital signature.
-data Sig a = Sig a Owner
-  deriving (Show, Eq, Ord, Generic, Hashable, Typeable, Data, NoUnexpectedThunks)
-
--- | We need a custom instance here that returns only the top level type.
---   A generic instance would have recursed into type 'a' and since we use
---   'typeReps' to compute 'abstractSize', this would mean the size of
---   'Sig a' would include the size of 'a' (e.g. 'Tx'). This would create an
---   artificial coupling between the size of a type and it's "signature".
-instance Typeable a => HasTypeReps (Sig a) where
-  typeReps x = typeOf x Seq.<| Seq.empty
-
--- | Produce a digital signature
-sign :: SKey -> a -> Sig a
-sign (SKey k) d = Sig d k
-
--- | Verify a digital signature
-verify :: Eq a => VKey -> a -> Sig a -> Bool
-verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
-
----------------------------------------------------------------------------------
--- Slots and Epochs
----------------------------------------------------------------------------------
-
-newtype Epoch = Epoch {unEpoch :: Word64}
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, Num, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
-newtype Slot = Slot {unSlot :: Word64}
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
--- | A number of slots.
---
---  We use this newtype to distinguish between a cardinal slot and a relative
---  period of slots, and also to distinguish between number of slots and number
---  of blocks.
-newtype SlotCount = SlotCount {unSlotCount :: Word64}
-  deriving stock (Generic, Show, Data, Typeable)
-  deriving newtype (Eq, Ord, Num, Hashable, ToCBOR, NoUnexpectedThunks)
-
-instance HasTypeReps SlotCount
-
--- | Add a slot count to a slot.
-addSlot :: Slot -> SlotCount -> Slot
-addSlot (Slot n) (SlotCount m) = Slot $ m + n
-
--- | An alias for 'addSlot'
-(+.) :: Slot -> SlotCount -> Slot
-(+.) = addSlot
-
-infixl 6 +.
-
--- | Subtract a slot count from a slot.
---
---   This is bounded below by 0.
-minusSlot :: Slot -> SlotCount -> Slot
-minusSlot (Slot m) (SlotCount n)
-  | m <= n = Slot 0
-  | otherwise = Slot $ m - n
-
--- | An alias for 'minusSlot'
-(-.) :: Slot -> SlotCount -> Slot
-(-.) = minusSlot
-
-infixl 6 -.
-
--- | Multiply the block count by the given constant. This function does not
--- check for overflow.
-(*.) :: Word64 -> BlockCount -> SlotCount
-n *. (BlockCount c) = SlotCount $ n * c
-
-infixl 7 *.
-
--- | Subtract a slot count from a slot.
---
--- In case the slot count is greater than the slot's index, it returns
--- Nothing.
-minusSlotMaybe :: Slot -> SlotCount -> Maybe Slot
-minusSlotMaybe (Slot m) (SlotCount n)
-  | m < n = Nothing
-  | otherwise = Just . Slot $ m - n
-
-newtype BlockCount = BlockCount {unBlockCount :: Word64}
-  deriving stock (Generic, Show)
-  deriving newtype (Eq, Ord, Num, Hashable, NoUnexpectedThunks)
-
-instance HasTypeReps BlockCount
-
----------------------------------------------------------------------------------
--- Transactions
----------------------------------------------------------------------------------
-
--- | The address of a transaction output, used to identify the owner.
-newtype Addr = Addr VKey
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Hashable, HasOwner, ToCBOR, NoUnexpectedThunks)
-  deriving anyclass (HasTypeReps)
-
--- | Create an address from a number.
-mkAddr :: Natural -> Addr
-mkAddr = Addr . VKey . Owner
-
-instance HasHash Addr where
-  hash = Hash . Just . H.hash
-
--- | A unit of value held by a UTxO.
-newtype Lovelace = Lovelace
-  { unLovelace :: Integer
-  }
-  deriving stock (Show, Generic, Data, Typeable)
-  deriving newtype (Eq, Ord, Num, Hashable, Enum, Real, Integral, ToCBOR, NoUnexpectedThunks)
-  deriving (Semigroup, Monoid) via (Sum Integer)
-  deriving anyclass (HasTypeReps)
-
--- | Constant amount of Lovelace in the system.
-lovelaceCap :: Lovelace
-lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion
@@ -341,34 +124,6 @@ a ∉ f = not $ elem a f
 
 infixl 4 ∉
 
-instance (Ord k, Ord v) => Relation (Bimap k v) where
-  type Domain (Bimap k v) = k
-  type Range (Bimap k v) = v
-
-  singleton = Bimap.singleton
-
-  dom = Set.fromList . Bimap.keys
-  range = Set.fromList . Bimap.elems
-
-  s ◁ r = Bimap.filter (\k _ -> k `Set.member` toSet s) r
-
-  s ⋪ r = Bimap.filter (\k _ -> k `Set.notMember` toSet s) r
-
-  r ▷ s = Bimap.filter (\_ v -> Set.member v s) r
-
-  r ⋫ s = Bimap.filter (\_ v -> Set.notMember v s) r
-
-  d0 ∪ d1 = Bimap.fold Bimap.insert d0 d1
-  d0 ⨃ d1 = foldr (uncurry Bimap.insert) d0 (toList d1)
-
-  vmax <=◁ r = Bimap.filter (\v _ -> v <= vmax) r
-
-  r ▷<= vmax = Bimap.filter (\_ v -> v <= vmax) r
-
-  r ▷>= vmin = Bimap.filter (\_ v -> v >= vmin) r
-
-  size = fromIntegral . Bimap.size
-
 instance Relation (Map k v) where
   type Domain (Map k v) = k
   type Range (Map k v) = v
@@ -378,9 +133,7 @@ instance Relation (Map k v) where
   dom = Map.keysSet
   range = Set.fromList . Map.elems
 
-  s ◁ r =
-    -- Map.filterWithKey (\k _ -> k `Set.member` toSet s) r
-    Map.restrictKeys r (toSet s) --TIMCHANGED
+  s ◁ r = Map.restrictKeys r (toSet s)
 
   s ⋪ r = Map.filterWithKey (\k _ -> k `Set.notMember` toSet s) r
 
@@ -438,6 +191,8 @@ instance Relation (Set (a, b)) where
 
   size = fromIntegral . Set.size
 
+-- The [(a,b)] instance is used in `stakeDistr` in the file LedgerState.hs
+
 instance Relation [(a, b)] where
   type Domain [(a, b)] = a
   type Range [(a, b)] = b
@@ -484,71 +239,3 @@ toSet = Set.fromList . toList
 
 (∩) :: Ord a => Set a -> Set a -> Set a
 (∩) = intersection
-
---------------------------------------------------------------------------------
--- Goblins instances
---------------------------------------------------------------------------------
-
-deriveGoblin ''Addr
-deriveGoblin ''BlockCount
-deriveGoblin ''Epoch
-deriveGoblin ''Owner
-deriveGoblin ''Sig
-deriveGoblin ''Slot
-deriveGoblin ''SlotCount
-deriveGoblin ''VKey
-deriveGoblin ''VKeyGenesis
-
-instance GeneOps g => Goblin g Hash where
-  tinker gen =
-    tinkerRummagedOrConjureOrSave
-      ( (Hash . Just . (`mod` 30))
-          <$$> tinker (unwrapValue <$> gen)
-      )
-    where
-      unwrapValue (Hash (Just x)) = x
-      unwrapValue (Hash Nothing) =
-        error $
-          "tinker Hash instance: trying to tinker with an invalid hash"
-            ++ " (which contains nothing)"
-
-  conjure = saveInBagOfTricks =<< (Hash . Just . (`mod` 30) <$> conjure)
-
-instance GeneOps g => Goblin g Lovelace where
-  tinker gen =
-    tinkerRummagedOrConjureOrSave
-      ( (\x -> (Lovelace x) `mod` lovelaceCap)
-          <$$> tinker ((\(Lovelace x) -> x) <$> gen)
-      )
-  conjure = saveInBagOfTricks =<< ((`mod` lovelaceCap) . Lovelace <$> conjure)
-
---------------------------------------------------------------------------------
--- AddShrinks instances
---------------------------------------------------------------------------------
-
-deriveAddShrinks ''Addr
-deriveAddShrinks ''BlockCount
-deriveAddShrinks ''Epoch
-deriveAddShrinks ''Hash
-deriveAddShrinks ''Lovelace
-deriveAddShrinks ''Owner
-deriveAddShrinks ''Sig
-deriveAddShrinks ''Slot
-deriveAddShrinks ''SlotCount
-deriveAddShrinks ''VKey
-deriveAddShrinks ''VKeyGenesis
-
---------------------------------------------------------------------------------
--- SeedGoblin instances
---------------------------------------------------------------------------------
-
-deriveSeedGoblin ''Addr
-deriveSeedGoblin ''BlockCount
-deriveSeedGoblin ''Epoch
-deriveSeedGoblin ''Hash
-deriveSeedGoblin ''Lovelace
-deriveSeedGoblin ''Owner
-deriveSeedGoblin ''Slot
-deriveSeedGoblin ''SlotCount
-deriveSeedGoblin ''VKey
-deriveSeedGoblin ''VKeyGenesis

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -31,7 +31,7 @@ module Shelley.Spec.Ledger.Delegation.Certificates
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Core (Relation (..))
@@ -107,7 +107,7 @@ newtype PoolDistr crypto = PoolDistr
           (Rational, Hash crypto (VerKeyVRF crypto))
       )
   }
-  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NFData, NoUnexpectedThunks, Relation)
 
 isInstantaneousRewards :: DCert crypto -> Bool
 isInstantaneousRewards (DCertMir _) = True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -31,7 +31,7 @@ module Shelley.Spec.Ledger.EpochBoundary
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
-import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -56,11 +56,11 @@ import Shelley.Spec.Ledger.UTxO (UTxO (..))
 -- | Blocks made
 newtype BlocksMade crypto
   = BlocksMade (Map (KeyHash 'StakePool crypto) Natural)
-  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Generic, NFData)
 
 -- | Type of stake as map from hash key to coins associated.
 newtype Stake crypto = Stake {unStake :: (Map (Credential 'Staking crypto) Coin)}
-  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks, NFData)
 
 -- | Add two stake distributions
 (⊎) ::
@@ -179,6 +179,8 @@ data SnapShot crypto = SnapShot
 
 instance NoUnexpectedThunks (SnapShot crypto)
 
+instance NFData (SnapShot crypto)
+
 instance
   Crypto crypto =>
   ToCBOR (SnapShot crypto)
@@ -216,6 +218,8 @@ data SnapShots crypto = SnapShots
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (SnapShots crypto)
+
+instance NFData (SnapShots crypto)
 
 instance
   Crypto crypto =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -352,7 +352,7 @@ newtype GenDelegs crypto
           (KeyHash 'Genesis crypto)
           (KeyHash 'GenesisDelegate crypto, Hash crypto (VerKeyVRF crypto))
       )
-  deriving (Show, Eq, FromCBOR, NoUnexpectedThunks, Generic)
+  deriving (Show, Eq, FromCBOR, NoUnexpectedThunks, NFData, Generic)
 
 deriving instance
   (Crypto crypto) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -228,6 +228,8 @@ data FutureGenDeleg crypto = FutureGenDeleg
 
 instance NoUnexpectedThunks (FutureGenDeleg crypto)
 
+instance NFData (FutureGenDeleg crypto)
+
 instance Crypto crypto => ToCBOR (FutureGenDeleg crypto) where
   toCBOR (FutureGenDeleg a b) =
     encodeListLen 2 <> toCBOR a <> toCBOR b
@@ -252,6 +254,8 @@ totalInstantaneousTreasuryRewards :: InstantaneousRewards crypto -> Coin
 totalInstantaneousTreasuryRewards (InstantaneousRewards _ irT) = sum irT
 
 instance NoUnexpectedThunks (InstantaneousRewards crypto)
+
+instance NFData (InstantaneousRewards crypto)
 
 instance Crypto crypto => ToCBOR (InstantaneousRewards crypto) where
   toCBOR (InstantaneousRewards irR irT) =
@@ -288,6 +292,8 @@ data DState crypto = DState
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (DState crypto)
+
+instance NFData (DState crypto)
 
 instance Crypto crypto => ToCBOR (DState crypto) where
   toCBOR (DState sc rw dlg p fgs gs ir) =
@@ -327,6 +333,8 @@ data PState crypto = PState
 
 instance NoUnexpectedThunks (PState crypto)
 
+instance NFData (PState crypto)
+
 instance Crypto crypto => ToCBOR (PState crypto) where
   toCBOR (PState a b c d) =
     encodeListLen 4 <> toCBOR a <> toCBOR b <> toCBOR c <> toCBOR d
@@ -349,6 +357,8 @@ data DPState crypto = DPState
 
 instance NoUnexpectedThunks (DPState crypto)
 
+instance NFData (DPState crypto)
+
 instance Crypto crypto => ToCBOR (DPState crypto) where
   toCBOR (DPState ds ps) =
     encodeListLen 2 <> toCBOR ds <> toCBOR ps
@@ -370,6 +380,8 @@ data RewardUpdate crypto = RewardUpdate
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (RewardUpdate crypto)
+
+instance NFData (RewardUpdate crypto)
 
 instance Crypto crypto => ToCBOR (RewardUpdate crypto) where
   toCBOR (RewardUpdate dt dr rw df nm) =
@@ -412,6 +424,8 @@ instance FromCBOR AccountState where
 
 instance NoUnexpectedThunks AccountState
 
+instance NFData AccountState
+
 data EpochState crypto = EpochState
   { esAccountState :: !AccountState,
     esSnapshots :: !(SnapShots crypto),
@@ -423,6 +437,8 @@ data EpochState crypto = EpochState
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (EpochState crypto)
+
+instance NFData (EpochState crypto)
 
 instance Crypto crypto => ToCBOR (EpochState crypto) where
   toCBOR (EpochState a s l r p n) =
@@ -534,6 +550,8 @@ instance
 
 instance NoUnexpectedThunks (OBftSlot crypto)
 
+instance NFData (OBftSlot crypto)
+
 -- | New Epoch state and environment
 data NewEpochState crypto = NewEpochState
   { -- | Last epoch
@@ -552,6 +570,8 @@ data NewEpochState crypto = NewEpochState
     nesOsched :: !(Map SlotNo (OBftSlot crypto))
   }
   deriving (Show, Eq, Generic)
+
+instance NFData (NewEpochState crypto)
 
 instance NoUnexpectedThunks (NewEpochState crypto)
 
@@ -627,6 +647,8 @@ data LedgerState crypto = LedgerState
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (LedgerState crypto)
+
+instance NFData (LedgerState crypto)
 
 instance Crypto crypto => ToCBOR (LedgerState crypto) where
   toCBOR (LedgerState u dp) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
@@ -2,12 +2,28 @@
 
 module Shelley.Spec.Ledger.Orphans where
 
-import Cardano.Prelude (NFData, NoUnexpectedThunks)
+import Cardano.Prelude (NFData (..), NoUnexpectedThunks)
+import Cardano.Slotting.Slot (WithOrigin (..))
 import Data.IP (IPv4, IPv6)
-import Shelley.Spec.Ledger.Slot (EpochNo)
+import Data.Sequence.Strict (StrictSeq, getSeq)
+import Shelley.Spec.Ledger.Slot (BlockNo, EpochNo)
 
 instance NoUnexpectedThunks IPv4
 
 instance NoUnexpectedThunks IPv6
 
+instance NFData IPv4
+
+instance NFData IPv6
+
+{- The following NFData instances probably belong in base -}
 instance NFData EpochNo
+
+instance NFData (StrictSeq a) where
+  rnf x = case getSeq x of _any -> ()
+
+instance NFData a => NFData (WithOrigin a)
+
+instance NFData BlockNo
+
+{- ------------------------------------------------------ -}

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -25,7 +25,7 @@ import Cardano.Binary
     encodeListLen,
     enforceSize,
   )
-import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Data.Function (on)
 import Data.List (foldl', sortBy)
 import Data.Map.Strict (Map)
@@ -59,7 +59,7 @@ import Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
 import Shelley.Spec.Ledger.TxData (PoolParams (..), RewardAcnt (..))
 
 newtype ApparentPerformance = ApparentPerformance {unApparentPerformance :: Double}
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+  deriving (Show, Eq, Generic, NoUnexpectedThunks, NFData)
 
 instance ToCBOR ApparentPerformance where
   toCBOR = encodeDouble . unApparentPerformance
@@ -78,6 +78,8 @@ emptyNonMyopic :: NonMyopic crypto
 emptyNonMyopic = NonMyopic Map.empty (Coin 0) emptySnapShot
 
 instance NoUnexpectedThunks (NonMyopic crypto)
+
+instance NFData (NonMyopic crypto)
 
 instance Crypto crypto => ToCBOR (NonMyopic crypto) where
   toCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -20,7 +20,13 @@ module Shelley.Spec.Ledger.STS.Chain
 where
 
 import qualified Cardano.Crypto.VRF as VRF
-import Cardano.Prelude (MonadError (..), NoUnexpectedThunks, asks, unless)
+import Cardano.Prelude
+  ( MonadError (..),
+    NFData,
+    NoUnexpectedThunks,
+    asks,
+    unless,
+  )
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.State.Transition
   ( Embed (..),
@@ -122,7 +128,9 @@ data ChainState crypto = ChainState
     chainPrevEpochNonce :: Nonce,
     chainLastAppliedBlock :: WithOrigin (LastAppliedBlock crypto)
   }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData (ChainState crypto)
 
 -- | Creates a valid initial chain state
 initialShelleyState ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -184,6 +184,8 @@ data PoolMetaData = PoolMetaData
 
 instance NoUnexpectedThunks PoolMetaData
 
+instance NFData PoolMetaData
+
 data StakePoolRelay
   = -- | One or both of IPv4 & IPv6
     SingleHostAddr !(StrictMaybe Port) !(StrictMaybe IPv4) !(StrictMaybe IPv6)
@@ -194,6 +196,8 @@ data StakePoolRelay
   deriving (Eq, Ord, Generic, Show)
 
 instance NoUnexpectedThunks StakePoolRelay
+
+instance NFData StakePoolRelay
 
 instance ToCBOR StakePoolRelay where
   toCBOR (SingleHostAddr p ipv4 ipv6) =
@@ -245,6 +249,8 @@ data PoolParams crypto = PoolParams
   deriving (FromCBOR) via CBORGroup (PoolParams crypto)
 
 instance NoUnexpectedThunks (PoolParams crypto)
+
+instance NFData (PoolParams crypto)
 
 newtype Wdrl crypto = Wdrl {unWdrl :: Map (RewardAcnt crypto) Coin}
   deriving (Show, Eq, Generic)


### PR DESCRIPTION
The PR is the "phase 2" of our plan to adapt the `Byron.Spec.Ledger.Core` to Shelley. In "phase 1" we copied the module. In this PR we:

1. Added an (almost) exact export list. (exported but not used: size,(<=◁),(▷<=),(▷>=))
2. Removed lots of unused code involving Hashes, Slots, and Goblins.
3. Removed the (Relation (Bimap a b)) instance.
4. Could NOT remove the (Relation [(a,b)]) instance, as it is used in  in the file LedgerState.hs. Maybe we can remove this soon.
5. Removed lots of {-# LANGUAGE features #-}  not used anymore.

Additionally, with an eye toward "phase 3" where we will remove methods that do no scale, in this PR we have also:
* Added new methods (haskey,addpair,removekey) to the Relation class.
* Adden `NFData` instances for the top level `ChainState` type so that we can place more things in the criterion environment.