### PR TITLE
Define leader value calculations

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -50,7 +50,6 @@ module Shelley.Spec.Ledger.Keys
 
     -- * VRF
     VRFSignable,
-    VRFValue (..),
 
     -- * Re-exports from cardano-crypto-class
     DSIGN.decodeSignedDSIGN,
@@ -93,12 +92,9 @@ import qualified Data.Aeson as Aeson
 import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
-import Data.Ratio ((%))
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
-import Shelley.Spec.Ledger.BaseTypes (Nonce, UnitInterval, mkNonce, truncateUnitInterval)
 import Shelley.Spec.Ledger.Crypto
 
 -- | Shelley has two types of hashes.
@@ -329,19 +325,6 @@ type KESignable c = KES.Signable (KES c)
 --------------------------------------------------------------------------------
 
 type VRFSignable c = VRF.Signable (VRF c)
-
--- | Our VRFAlgorithm provides a 'Natural', so we must exhibit an extractor to
---   use the bits as some other type
-class VRFValue a where
-  -- | Extract a value from a natural number derived from the VRF computation.
-  fromNatural :: Natural -> a
-
-instance VRFValue Nonce where
-  fromNatural = mkNonce
-
-instance VRFValue UnitInterval where
-  -- TODO Consider whether this is a reasonable thing to do
-  fromNatural k = truncateUnitInterval $ fromIntegral k % 10000
 
 --------------------------------------------------------------------------------
 -- Genesis delegation

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -41,7 +41,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
     BHeader (..),
-    checkVRFValue,
+    checkLeaderValue,
     mkSeed,
     seedEta,
     seedL,
@@ -193,7 +193,7 @@ praosVrfChecks eta0 (PoolDistr pd) f bhb = do
         (throwError $ VRFKeyWrongVRFKey hk vrfHK (hashVerKeyVRF vrfK))
       vrfChecks eta0 bhb
       unless
-        (checkVRFValue (VRF.certifiedNatural $ bheaderL bhb) sigma f)
+        (checkLeaderValue (VRF.certifiedNatural $ bheaderL bhb) sigma f)
         (throwError $ VRFLeaderValueTooBig (VRF.certifiedNatural $ bheaderL bhb) sigma f)
       pure ()
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -34,7 +34,7 @@ import Control.State.Transition
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
-import Shelley.Spec.Ledger.BaseTypes (Nonce, Seed, ShelleyBase)
+import Shelley.Spec.Ledger.BaseTypes (Nonce, Seed, ShelleyBase, mkNonce)
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
     BHeader (..),
@@ -53,7 +53,6 @@ import Shelley.Spec.Ledger.Keys
     KeyRole (..),
     VRFSignable,
     VerKeyKES,
-    fromNatural,
   )
 import Shelley.Spec.Ledger.LedgerState (OBftSlot)
 import Shelley.Spec.Ledger.OCert (KESPeriod)
@@ -166,7 +165,7 @@ prtclTransition = do
     judgmentContext
   let bhb = bhbody bh
       slot = bheaderSlotNo bhb
-      eta = fromNatural . VRF.certifiedNatural $ bheaderEta bhb
+      eta = mkNonce . VRF.certifiedNatural $ bheaderEta bhb
 
   UpdnState eta0' etaV' etaC' etaH' <-
     trans @(UPDN crypto) $

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -19,7 +19,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Address (mkVKeyRwdAcnt, pattern Addr)
 import Shelley.Spec.Ledger.BaseTypes
-import Shelley.Spec.Ledger.BlockChain (checkVRFValue)
+import Shelley.Spec.Ledger.BlockChain (checkLeaderValue)
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.Credential (Credential (..), pattern StakeRefBase)
 import Shelley.Spec.Ledger.Delegation.Certificates (pattern RegPool)
@@ -79,7 +79,6 @@ import Shelley.Spec.Ledger.TxData
 import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessVKey, makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 import Test.Shelley.Spec.Ledger.Fees (sizeTests)
-import Test.Shelley.Spec.Ledger.Generator.Core (unitIntervalToNatural)
 import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty
@@ -147,13 +146,7 @@ testNoGenesisOverlay =
 
 testVRFCheckWithActiveSlotCoeffOne :: Assertion
 testVRFCheckWithActiveSlotCoeffOne =
-  checkVRFValue 0 (1 % 2) (mkActiveSlotCoeff $ unsafeMkUnitInterval 1) @?= True
-
-testVRFCheckWithLeaderValueOne :: Assertion
-testVRFCheckWithLeaderValueOne =
-  checkVRFValue vrfOne (1 % 2) (mkActiveSlotCoeff $ unsafeMkUnitInterval 0.5) @?= False
-  where
-    vrfOne = unitIntervalToNatural (unsafeMkUnitInterval 1)
+  checkLeaderValue 0 (1 % 2) (mkActiveSlotCoeff $ unsafeMkUnitInterval 1) @?= True
 
 testsPParams :: TestTree
 testsPParams =
@@ -164,9 +157,7 @@ testsPParams =
       testCase "generate overlay schedule without genesis nodes" $
         testNoGenesisOverlay,
       testCase "VRF checks when the activeSlotCoeff is one" $
-        testVRFCheckWithActiveSlotCoeffOne,
-      testCase "VRF checks when the VRF leader value is one" $
-        testVRFCheckWithLeaderValueOne
+        testVRFCheckWithActiveSlotCoeffOne
     ]
 
 testTruncateUnitInterval :: TestTree

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -214,7 +214,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
       \fun{bblockno} & \BHBody \to \BlockNo &
       \fun{bnonce} & \BHBody \to \Seed \\
       \fun{\bprfn{}} & \BHBody \to \Proof &
-      \fun{bleader} & \BHBody \to \unitInterval \\
+      \fun{bleader} & \BHBody \to \N \\
       \fun{\bprfl{}} & \BHBody \to \Proof &
       \fun{hBbsize} & \BHBody \to \N \\
       \fun{bhash} & \BHBody \to \HashBBody &
@@ -1150,7 +1150,7 @@ parameters. The function checks:
 \item The validity of the proofs for the leader value and the new nonce.
 \item The verification key is associated with relative stake $\sigma$ in the stake distribution.
 \item The $\fun{bleader}$ value of \var{bhb} indicates a possible leader for
-  this slot.
+  this slot. The function $\fun{checkLeaderVal}$ is defined in \ref{sec:leader-value-calc}.
 \end{itemize}
 
 \begin{figure}
@@ -1177,7 +1177,7 @@ parameters. The function checks:
       & \begin{array}{cl}
         ~~~~ & \var{hk}\mapsto (\sigma,~\var{hk_{vrf}})\in\var{pd} \\
         ~~~~ \land & \fun{vrfChecks}~\eta_0~\var{bhb} \\
-        ~~~~ \land & \fun{bleader}~\var{bhb} < 1 - (1 - f)^{\sigma} \\
+        ~~~~ \land & \fun{checkLeaderVal}~(\fun{bleader}~\var{bhb})~\sigma~\var{f} \\
       \end{array} \\
       & ~~~~\where \\
       & ~~~~~~~~~~\var{hk} \leteq \hashKey{(\bvkcold bhb)} \\

--- a/shelley/chain-and-ledger/formal-spec/leader-value.tex
+++ b/shelley/chain-and-ledger/formal-spec/leader-value.tex
@@ -19,7 +19,7 @@ calculation.
 \subsection{Computing the leader value}
 
 The verifiable random function gives us a 32-byte random output. We interpret
-this as a natural number $\var{certNat}$ in the range $[0,2^{256}]$.
+this as a natural number $\var{certNat}$ in the range $[0,2^{256})$.
 
 \subsection{Node eligibility}
 

--- a/shelley/chain-and-ledger/formal-spec/leader-value.tex
+++ b/shelley/chain-and-ledger/formal-spec/leader-value.tex
@@ -1,0 +1,59 @@
+\section{Leader Value Calculation}
+\label{sec:leader-value-calc}
+
+This section details how we determine whether a node is entitled to lead (under
+the Praos protocol) given the output of its verifiable random function
+calculation.
+
+\begin{figure}
+  \emph{Values associated with the leader value calculations}
+  \begin{equation*}
+  \begin{array}{r@{~\in~}lr}
+    \var{certNat} & \{n | n \in \N, n \in [0,2^{256})\} & \text{Certified natural value from VRF} \\
+    \var{f} & [0,1] & \text{Active slot coefficient} \\
+    \sigma & [0,1] & \text{Stake proportion}
+  \end{array}
+  \end{equation*}
+\end{figure}
+
+\subsection{Computing the leader value}
+
+The verifiable random function gives us a 32-byte random output. We interpret
+this as a natural number $\var{certNat}$ in the range $[0,2^{256}]$.
+
+\subsection{Node eligibility}
+
+As per \cite{ouroboros_praos}, a node is eligible to lead when its leader value
+$\ell < 1 - (1 - f)^\sigma$. We have
+
+\begin{align*}
+  \ell & < 1 - (1 -f)^\sigma \\
+  \iff \left(\frac{1}{1-\ell}\right) & > \exp{(-\sigma \cdot \ln{(1-f)})}
+\end{align*}
+
+The latter inquality can be efficiently computed through use of its Taylor
+expansion and error estimation to stop computing terms once we are certain that
+the result will be either above or below the target value.
+
+We carry out all computations using fixed precision arithmetic (specifically, we
+use 34 decimal bits of precision, since this is enough to represent the fraction
+of a single lovelace.)
+
+As such, we define the following:
+
+\begin{align*}
+  q & = \frac{2^{256}}{2^{256} - \var{certNat}} \\
+  c & = \ln{(1 - f)}
+\end{align*}
+
+and define the function \textit{checkLeaderVal} as follows:
+
+\begin{equation*}
+  \fun{checkLeaderVal}~\var{certNat}~\sigma~\var{f} =
+    \left\{
+      \begin{array}{l@{~}r}
+        \mathsf{True}, & f = 1 \\
+        q > \exp{(-\sigma \cdot c)}, & \text{otherwise}
+      \end{array}
+    \right.
+\end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -315,6 +315,7 @@
 \include{sts-overview}
 \include{properties}
 \include{non-integral}
+\include{leader-value}
 
 \clearpage
 


### PR DESCRIPTION
This PR

- Defines how we do the leader value calculations as an addendum to the formal spec.
- Re-implements the calculation in the executable spec to match. As part of this, we
  - Remove the `VRFValue` class
  - Remove the indirection via `UnitInterval`