### PR TITLE
Historical Pool Performance

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -33,6 +33,7 @@ import Shelley.Spec.Ledger.Rewards
     getTopRankedPools,
     nonMyopicMemberRew,
     nonMyopicStake,
+    percentile',
   )
 import Shelley.Spec.Ledger.TxData (PoolParams (..), TxOut (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
@@ -59,16 +60,16 @@ getNonMyopicMemberRewards globals ss creds =
     es = nesEs ss
     pp = esPp es
     NonMyopic
-      { apparentPerformances = aps,
-        rewardPot = rPot,
-        snap = (SnapShot stake delegs poolParams)
+      { likelihoodsNM = ls,
+        rewardPotNM = rPot,
+        snapNM = (SnapShot stake delegs poolParams)
       } = esNonMyopic es
     poolData =
       Map.intersectionWithKey
-        (\k a p -> (a, p, toShare . sum . unStake $ poolStake k delegs stake))
-        aps
+        (\k h p -> (percentile' h, p, toShare . sum . unStake $ poolStake k delegs stake))
+        ls
         poolParams
-    topPools = getTopRankedPools rPot (Coin total) pp poolParams aps
+    topPools = getTopRankedPools rPot (Coin total) pp poolParams (fmap percentile' ls)
     mkNMMRewards ms k (ap, poolp, sigma) = nonMyopicMemberRew pp poolp rPot s ms nmps ap
       where
         s = (toShare . _poolPledge) poolp

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -106,6 +106,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -166,7 +167,7 @@ import Shelley.Spec.Ledger.PParams
     emptyPParams,
   )
 import Shelley.Spec.Ledger.Rewards
-  ( ApparentPerformance (..),
+  ( Likelihood,
     NonMyopic (..),
     emptyNonMyopic,
     reward,
@@ -962,7 +963,7 @@ applyRUpd ::
   RewardUpdate crypto ->
   EpochState crypto ->
   EpochState crypto
-applyRUpd ru (EpochState as ss ls pr pp nm) = EpochState as' ss ls' pr pp nm
+applyRUpd ru (EpochState as ss ls pr pp _nm) = EpochState as' ss ls' pr pp nm'
   where
     utxoState_ = _utxoState ls
     delegState = _delegationState ls
@@ -984,35 +985,24 @@ applyRUpd ru (EpochState as ss ls pr pp nm) = EpochState as' ss ls' pr pp nm
                     }
               }
         }
+    nm' = nonMyopic ru
 
 updateNonMypopic ::
   NonMyopic crypto ->
   Coin ->
-  Map (KeyHash 'StakePool crypto) Rational ->
+  Map (KeyHash 'StakePool crypto) Likelihood ->
   SnapShot crypto ->
   NonMyopic crypto
-updateNonMypopic nm rPot aps ss =
+updateNonMypopic nm rPot newLikelihoods ss =
   nm
-    { apparentPerformances = aps',
-      rewardPot = rPot,
-      snap = ss
+    { likelihoodsNM = updatedLikelihoods,
+      rewardPotNM = rPot,
+      snapNM = ss
     }
   where
-    SnapShot _ _ poolParams = ss
-    absentPools =
-      Set.toList $
-        (Map.keysSet poolParams) `Set.difference` (Map.keysSet aps)
-    performanceZero = Map.fromList $ fmap (\p -> (p, 0)) absentPools
-    -- TODO how to handle pools with near zero stake?
-
-    expMovAvgWeight = 0.5 -- TODO move to globals or protocol parameters?
-    prev = apparentPerformances nm
-    performance kh ap = case Map.lookup kh prev of
-      Nothing -> ApparentPerformance $ fromRational ap -- TODO give new pools the average performance?
-      Just (ApparentPerformance p) ->
-        ApparentPerformance $
-          expMovAvgWeight * p + (1 - expMovAvgWeight) * (fromRational ap)
-    aps' = Map.mapWithKey performance (aps `Map.union` performanceZero)
+    history = likelihoodsNM nm
+    performance kh newPerf = fromMaybe mempty (Map.lookup kh history) <> newPerf
+    updatedLikelihoods = Map.mapWithKey performance newLikelihoods
 
 -- | Create a reward update
 createRUpd ::
@@ -1038,8 +1028,8 @@ createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
       deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
       _R = Coin $ rPot - deltaT1
       circulation = total - (_reserves acnt)
-      (rs_, aps) =
-        reward network pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' circulation
+      (rs_, newLikelihoods) =
+        reward network pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' circulation asc slotsPerEpoch
       deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $
@@ -1048,7 +1038,7 @@ createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
       (- deltaR_)
       rs_
       (- (_feeSS ss))
-      (updateNonMypopic nm _R aps (_pstakeGo ss))
+      (updateNonMypopic nm _R newLikelihoods (_pstakeGo ss))
 
 -- | Overlay schedule
 -- This is just a very simple round-robin, evenly spaced schedule.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SerializationProperties.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SerializationProperties.hs
@@ -95,7 +95,11 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams, ProtVer)
-import Shelley.Spec.Ledger.Rewards (ApparentPerformance (..))
+import Shelley.Spec.Ledger.Rewards
+  ( Likelihood (..),
+    LogWeight (..),
+    PerformanceEstimate (..),
+  )
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS (PrtclState)
 import Shelley.Spec.Ledger.Scripts (ScriptHash (ScriptHash))
@@ -446,6 +450,12 @@ instance Arbitrary PParams where
       p :: Proxy Monomorphic.ShortHash
       p = Proxy
 
+instance Arbitrary Likelihood where
+  arbitrary = Likelihood <$> arbitrary
+
+instance Arbitrary LogWeight where
+  arbitrary = LogWeight <$> arbitrary
+
 instance HashAlgorithm h => Arbitrary (Mock.NonMyopic h) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
@@ -458,8 +468,8 @@ instance HashAlgorithm h => Arbitrary (Mock.SnapShots h) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Arbitrary ApparentPerformance where
-  arbitrary = ApparentPerformance <$> arbitrary
+instance Arbitrary PerformanceEstimate where
+  arbitrary = PerformanceEstimate <$> arbitrary
 
 instance HashAlgorithm h => Arbitrary (Mock.Stake h) where
   arbitrary = Stake <$> arbitrary


### PR DESCRIPTION
This PR removes the previous historical stake pool performance calculations, which used an exponential moving average, and replaces it with a approximations of probability distribution functions via histograms. This data is only used in the non-myopic reward calculation used rank stake pools.