### PR TITLE
More Benchmark tests and optimizations of Shelley.Spec.Ledger.Core Relation Class

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/bench/Main.hs
+++ b/shelley/chain-and-ledger/executable-spec/bench/Main.hs
@@ -1,16 +1,152 @@
 module Main where
 
-import Criterion.Main (bench, bgroup, defaultMain, whnf)
+import Control.DeepSeq (NFData)
+import Criterion.Main (Benchmark, bench, bgroup, defaultMain, env, whnf)
+import Data.Word (Word64)
+import Shelley.Spec.Ledger.LedgerState (DPState (..), UTxOState (..))
 import Test.Shelley.Spec.Ledger.BenchmarkFunctions
-  ( ledgerSpendOneUTxO,
+  ( initUTxO, -- How to precompute env for the UTxO transactions
+    ledgerDeRegisterStakeKeys,
+    ledgerDelegateManyKeysOnePool,
+    ledgerReRegisterStakePools,
+    ledgerRegisterStakeKeys,
+    ledgerRegisterStakePools,
+    ledgerRetireStakePools,
+    ledgerRewardWithdrawals,
+    ledgerSpendOneGivenUTxO,
+    ledgerSpendOneUTxO,
+    ledgerStateWithNkeysMpools, -- How to precompute env for the Stake Delegation transactions
+    ledgerStateWithNregisteredKeys, -- How to precompute env for the StakeKey transactions
+    ledgerStateWithNregisteredPools, -- How to compute an initial state with N StakePools
   )
 
--- Our benchmark harness.
-main :: IO ()
-main =
+-- =================================================
+-- Spending 1 UTxO
+
+includes_init_SpendOneUTxO :: IO ()
+includes_init_SpendOneUTxO =
   defaultMain
-    [ bgroup "ledger" $
+    [ bgroup "Spend 1 UTXO with initialization" $
         fmap
           (\n -> bench (show n) $ whnf ledgerSpendOneUTxO n)
           [50, 500, 5000, 50000]
+    ]
+
+profileUTxO :: IO ()
+profileUTxO = do
+  putStrLn "Enter profiling"
+  let ans = ledgerSpendOneGivenUTxO (initUTxO 500000)
+  putStrLn ("Exit profiling " ++ show ans)
+
+-- ==========================================
+-- Registering Stake Keys
+
+touchDPState :: DPState crypto -> Int
+touchDPState (DPState _x _y) = 1
+
+touchUTxOState :: Shelley.Spec.Ledger.LedgerState.UTxOState cryto -> Int
+touchUTxOState (UTxOState _utxo _deposited _fees _ppups) = 2
+
+profileCreateRegKeys :: IO ()
+profileCreateRegKeys = do
+  putStrLn "Enter profiling stake key creation"
+  let state = ledgerStateWithNregisteredKeys 1 500000 -- using 75,000 and 100,000 causes
+  -- mainbench: internal error: PAP object entered!
+  -- (GHC version 8.6.5 for x86_64_unknown_linux)
+  -- Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
+  let touch (x, y) = touchUTxOState x + touchDPState y
+  putStrLn ("Exit profiling " ++ show (touch state))
+
+-- ==========================================
+-- Registering Pools
+
+profileCreateRegPools :: Word64 -> IO ()
+profileCreateRegPools size = do
+  putStrLn "Enter profiling pool creation"
+  let state = ledgerStateWithNregisteredPools 1 size
+  let touch (x, y) = touchUTxOState x + touchDPState y
+  putStrLn ("Exit profiling " ++ show (touch state))
+
+-- =================================================
+-- Some things we might want to profile.
+
+-- main = profileUTxO
+-- main = includes_init_SpendOneUTxO
+-- main = profileCreateRegPools 10000
+-- main = profileCreateRegPools 100000
+
+-- =========================================================
+
+varyState ::
+  NFData state =>
+  String ->
+  Word64 ->
+  [Word64] ->
+  (Word64 -> Word64 -> state) ->
+  (Word64 -> Word64 -> state -> ()) ->
+  Benchmark
+varyState tag fixed changes initstate action =
+  bgroup ("state/" ++ tag ++ "/constant") $ map runAtSize changes
+  where
+    runAtSize n =
+      env
+        (return $ initstate 1 n)
+        (\state -> bench (show n) (whnf (action fixed fixed) state))
+
+varyInput ::
+  NFData state =>
+  String ->
+  (Word64, Word64) ->
+  [(Word64, Word64)] ->
+  (Word64 -> Word64 -> state) ->
+  (Word64 -> Word64 -> state -> ()) ->
+  Benchmark
+varyInput tag fixed changes initstate action =
+  bgroup ("input/" ++ tag ++ "/growing") $ map runAtSize changes
+  where
+    runAtSize n =
+      env
+        (return $ initstate (fst fixed) (snd fixed))
+        (\state -> bench (show n) (whnf (action (fst n) (snd n)) state))
+
+varyDelegState ::
+  NFData state =>
+  String ->
+  Word64 ->
+  [Word64] ->
+  (Word64 -> Word64 -> state) ->
+  (Word64 -> Word64 -> state -> ()) ->
+  Benchmark
+varyDelegState tag fixed changes initstate action =
+  bgroup ("state/" ++ tag ++ "/growing") $ map runAtSize changes
+  where
+    runAtSize n =
+      env
+        (return $ initstate n n)
+        (\state -> bench (show n) (whnf (action 1 fixed) state))
+
+-- =============================================================================
+
+main :: IO ()
+main =
+  defaultMain $
+    [ bgroup "vary input size" $
+        [ varyInput "deregister key" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
+          varyInput "register key" (20001, 20501) [(1, 20), (1, 200), (1, 2000)] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
+          varyInput "withdrawal" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerRewardWithdrawals,
+          varyInput "register pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerRegisterStakePools,
+          varyInput "reregister pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerReRegisterStakePools,
+          varyInput "retire pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerRetireStakePools,
+          varyInput "manyKeysOnePool" (5000, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNkeysMpools ledgerDelegateManyKeysOnePool
+        ],
+      bgroup "vary initial state" $
+        [ varyState "spendOne" 1 [50, 500, 5000] (\_ n -> initUTxO (fromIntegral n)) (\_ _ -> ledgerSpendOneGivenUTxO),
+          varyState "register key" 5001 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
+          varyState "deregister key" 50 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
+          varyState "withdrawal" 50 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerRewardWithdrawals,
+          varyState "register pool" 5001 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerRegisterStakePools,
+          varyState "reregister pool" 5001 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerReRegisterStakePools,
+          varyState "retire pool" 50 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerRetireStakePools,
+          varyDelegState "manyKeysOnePool" 50 [50, 500, 5000] ledgerStateWithNkeysMpools ledgerDelegateManyKeysOnePool
+        ]
     ]

--- a/shelley/chain-and-ledger/executable-spec/bench/README.md
+++ b/shelley/chain-and-ledger/executable-spec/bench/README.md
@@ -8,8 +8,15 @@ The benchmark suite can be run from the command line with:
 stack bench
 ```
 
+The benchmark groups can be specified by name, eg:
+
+```shell
+stack bench --ba 'utxo'
+stack bench --ba 'stake-key/register'
+```
+
 More output is available by specifying at html output file:
 
 ```shell
-stack bench --ba --bench=bench.html
+stack bench --ba --output=bench.html
 ```

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -240,6 +240,7 @@ benchmark mainbench
                     cardano-binary,
                     cardano-crypto,
                     cardano-crypto-class,
+                    cardano-crypto-wrapper,
                     cardano-prelude,
                     cardano-slotting,
                     cryptonite,
@@ -251,11 +252,13 @@ benchmark mainbench
                     tasty-quickcheck,
                     tasty-hunit,
                     tasty,
+                    time,
                     small-steps,
                     criterion,
                     random,
                     containers,
-                    MonadRandom
+                    MonadRandom,
+                    deepseq
   ghc-options:
       -threaded
       -rtsopts
@@ -265,6 +268,7 @@ benchmark mainbench
       -Wincomplete-record-updates
       -Wincomplete-uni-patterns
       -Wredundant-constraints
+      -O
   if (!flag(development))
     ghc-options:
       -Werror

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -101,7 +101,6 @@ import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Control.Monad.Trans.Reader (asks)
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Foldable (toList)
-import Data.List (foldl')
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
@@ -186,7 +185,7 @@ import Shelley.Spec.Ledger.Tx
     WitnessSet,
     WitnessSetHKD (..),
     addrWits,
-    extractKeyHash,
+    extractKeyHashWitnessSet,
     regWits,
   )
 import Shelley.Spec.Ledger.TxData
@@ -752,8 +751,11 @@ consumed ::
   UTxO crypto ->
   TxBody crypto ->
   Coin
-consumed pp u tx =
-  balance (txins tx ◁ u) + refunds + withdrawals
+consumed pp (_u@(UTxO v)) tx =
+  -- balance (txins tx ◁ _u) + refunds + withdrawals
+  -- We do not call ◁, as this causes an identity call to toSet(txins tx)
+  -- To be fixed in a following PR
+  balance (UTxO (Map.restrictKeys v (txins tx))) + refunds + withdrawals
   where
     refunds = keyRefunds pp tx
     withdrawals = sum . unWdrl $ _wdrls tx
@@ -796,45 +798,44 @@ witsVKeyNeeded ::
   Tx crypto ->
   GenDelegs crypto ->
   WitHashes crypto
-witsVKeyNeeded utxo' tx@(Tx txbody _ _) _genDelegs =
+witsVKeyNeeded utxo' tx@(Tx txbody _ _) genDelegs =
   WitHashes
-    { addrWitHashes =
-        (Set.fromList $ fst certAuthors)
-          `Set.union` inputAuthors
-          `Set.union` owners
-          `Set.union` wdrlAuthors,
-      regWitHashes =
-        (Set.fromList $ snd certAuthors)
-          `Set.union` updateKeys
+    { addrWitHashes = fst certAuthors `Set.union` inputAuthors `Set.union` owners `Set.union` wdrlAuthors,
+      regWitHashes = snd certAuthors `Set.union` updateKeys
     }
   where
-    inputAuthors = asWitness `Set.map` Set.foldr insertHK Set.empty (_inputs txbody)
-    insertHK txin hkeys =
-      case txinLookup txin utxo' of
-        Just (TxOut (Addr _ (KeyHashObj pay) _) _) -> Set.insert pay hkeys
-        Just (TxOut (AddrBootstrap bootAddr) _) -> Set.insert (bootstrapKeyHash bootAddr) hkeys
-        _ -> hkeys
-    wdrlAuthors =
-      Set.map asWitness
-        . Set.fromList
-        . extractKeyHash
-        $ map getRwdCred (Map.keys (unWdrl $ _wdrls txbody))
-    owners =
-      foldl'
-        Set.union
-        Set.empty
-        [ ((Set.map asWitness) . _poolOwners) pool
-          | DCertPool (RegPool pool) <- toList $ _certs txbody
-        ]
-    certAuthors = foldl' (<>) ([], []) $ fmap cwitness certificates
-    -- key reg requires no witness but this is already filtered out before the
-    -- call to `cwitness`
-    cwitness (DCertDeleg dc) = (,[]) $ asWitness <$> extractKeyHash [delegCWitness dc]
-    cwitness (DCertPool pc) = ([],) $ asWitness <$> extractKeyHash [poolCWitness pc]
-    cwitness (DCertGenesis gc) = ([], [asWitness $ genesisCWitness gc])
+    inputAuthors :: Set (KeyHash 'AWitness crypto)
+    inputAuthors = foldr accum Set.empty (_inputs txbody)
+      where
+        accum txin ans =
+          case txinLookup txin utxo' of
+            Just (TxOut (Addr _ (KeyHashObj pay) _) _) -> Set.insert (asWitness pay) ans
+            Just (TxOut (AddrBootstrap bootAddr) _) -> Set.insert (asWitness (bootstrapKeyHash bootAddr)) ans
+            _other -> ans
+    wdrlAuthors :: Set (KeyHash 'AWitness crypto)
+    wdrlAuthors = Map.foldrWithKey accum Set.empty (unWdrl (_wdrls txbody))
+      where
+        accum key _ ans = Set.union (extractKeyHashWitnessSet [getRwdCred key]) ans
+    owners :: Set (KeyHash 'AWitness crypto)
+    owners = foldr accum Set.empty (_certs txbody)
+      where
+        accum (DCertPool (RegPool pool)) ans = Set.union (Set.map asWitness (_poolOwners pool)) ans
+        accum _cert ans = ans
+    cwitness (DCertDeleg dc) = (extractKeyHashWitnessSet [delegCWitness dc], Set.empty)
+    cwitness (DCertPool pc) = (Set.empty, extractKeyHashWitnessSet [poolCWitness pc])
+    cwitness (DCertGenesis gc) = (Set.empty, Set.singleton (asWitness $ genesisCWitness gc))
     cwitness c = error $ show c ++ " does not have a witness"
-    certificates = filter requiresVKeyWitness (toList $ _certs txbody)
-    updateKeys = asWitness `Set.map` propWits (txup tx) _genDelegs
+    -- key reg requires no witness but this is already filtered outby requiresVKeyWitness
+    -- before the call to `cwitness`, so this error should never be reached.
+
+    certAuthors :: (Set (KeyHash 'AWitness crypto), Set (KeyHash 'RWitness crypto))
+    certAuthors = foldr accum (Set.empty, Set.empty) (_certs txbody)
+      where
+        accum cert ans | requiresVKeyWitness cert = unionPair (cwitness cert) ans
+        accum _cert ans = ans
+        unionPair (x, y) (a, b) = (Set.union x a, Set.union y b)
+    updateKeys :: Set (KeyHash 'RWitness crypto)
+    updateKeys = asWitness `Set.map` propWits (txup tx) genDelegs
 
 -- | Given a ledger state, determine if the UTxO witnesses in a given
 --  transaction are correct.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
@@ -2,7 +2,7 @@
 
 module Shelley.Spec.Ledger.Orphans where
 
-import Cardano.Prelude (NFData (..), NoUnexpectedThunks, readEither)
+import Cardano.Prelude (NFData (rnf), NoUnexpectedThunks, readEither)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Data.Aeson
 import Data.Foldable
@@ -49,8 +49,8 @@ instance NFData EpochNo
 instance NFData (StrictSeq a) where
   rnf x = case getSeq x of _any -> ()
 
+-- By defintion it is strict, so as long as the (hidden) constructor is evident, it is in normal form
+
 instance NFData a => NFData (WithOrigin a)
 
 instance NFData BlockNo
-
-{- ------------------------------------------------------ -}

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -43,7 +43,7 @@ import Shelley.Spec.Ledger.BaseTypes
     invalidKey,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
+import Shelley.Spec.Ledger.Core (addpair, haskey, range, removekey, (∉), (⋫))
 import Shelley.Spec.Ledger.Credential (Credential)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys
@@ -220,35 +220,39 @@ delegationTransition = do
   case c of
     DCertDeleg (RegKey hk) -> do
       -- note that pattern match is used instead of regCred, as in the spec
-      hk ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG hk
+      not (haskey hk (_stkCreds ds)) ?! StakeKeyAlreadyRegisteredDELEG hk
 
       pure $
         ds
-          { _stkCreds = _stkCreds ds ∪ singleton hk slot,
-            _rewards = _rewards ds ∪ Map.singleton (RewardAcnt network hk) (Coin 0), -- ∪ is override left
-            _ptrs = _ptrs ds ∪ Map.singleton ptr hk
+          { _stkCreds = addpair hk slot (_stkCreds ds), -- _stkCreds ds ∪ (singleton hk slot)
+            _rewards = addpair (RewardAcnt network hk) (Coin 0) (_rewards ds), -- _rewards ds ∪ (singleton (RewardAcnt network hk) (Coin 0) )
+            _ptrs = addpair ptr hk (_ptrs ds) -- _ptrs ds ∪ (singleton ptr hk)
           }
     DCertDeleg (DeRegKey hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
-      hk ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG hk
+      haskey hk (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG hk
 
       let rewardCoin = Map.lookup (RewardAcnt network hk) (_rewards ds)
       rewardCoin == Just 0 ?! StakeKeyNonZeroAccountBalanceDELEG rewardCoin
 
       pure $
         ds
-          { _stkCreds = Set.singleton hk ⋪ _stkCreds ds,
-            _rewards = Set.singleton (RewardAcnt network hk) ⋪ _rewards ds,
-            _delegations = Set.singleton hk ⋪ _delegations ds,
+          { _stkCreds = removekey hk (_stkCreds ds),
+            _rewards = removekey (RewardAcnt network hk) (_rewards ds),
+            _delegations = removekey hk (_delegations ds),
             _ptrs = _ptrs ds ⋫ Set.singleton hk
+            -- TODO make _ptrs a bijection. This operation takes time proportional to (_ptrs ds)
+            -- OR turn _stkCreds into a mapping of stake credentials to pointers
+            -- note that the slot values in _stkCreds is no longer needed (no decay)
+            -- then we could use (lookup hk (_delecations ds)) to get ptr, then use domain removal on (_ptrs ds) rather than range removal
           }
     DCertDeleg (Delegate (Delegation hk dpool)) -> do
       -- note that pattern match is used instead of cwitness and dpool, as in the spec
-      hk ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG hk
+      haskey hk (_stkCreds ds) ?! StakeDelegationImpossibleDELEG hk
 
       pure $
         ds
-          { _delegations = _delegations ds ⨃ [(hk, dpool)]
+          { _delegations = addpair hk dpool (_delegations ds)
           }
     DCertGenesis (GenesisDelegCert gkh vkh vrf) -> do
       sp <- liftSTS $ asks stabilityWindow
@@ -256,7 +260,8 @@ delegationTransition = do
       let s' = slot +* Duration sp
           (GenDelegs genDelegs) = _genDelegs ds
 
-      gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG gkh
+      -- gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG gkh
+      (case Map.lookup gkh genDelegs of Just _ -> True; Nothing -> False) ?! GenesisKeyNotInpMappingDELEG gkh
 
       let currentOtherDelegations =
             range $
@@ -276,7 +281,7 @@ delegationTransition = do
 
       pure $
         ds
-          { _fGenDelegs = _fGenDelegs ds ⨃ [(FutureGenDeleg s' gkh, (GenDelegPair vkh vrf))]
+          { _fGenDelegs = addpair (FutureGenDeleg s' gkh) (GenDelegPair vkh vrf) (_fGenDelegs ds)
           }
     DCertMir (MIRCert targetPot credCoinMap) -> do
       sp <- liftSTS $ asks stabilityWindow

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -112,7 +112,7 @@ epochTransition = do
     trans @(SNAP crypto) $ TRC (ls, ss, ())
 
   let PState _ pParams fPParams _ = pstate
-      ppp = pParams ⨃ (Map.toList fPParams)
+      ppp = pParams ⨃ fPParams
       pstate' =
         pstate
           { _pParams = ppp,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -22,7 +22,7 @@ import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain
-import Shelley.Spec.Ledger.Core ((⨃))
+import Shelley.Spec.Ledger.Core (addpair)
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.OCert
@@ -106,4 +106,4 @@ ocertTransition = judgmentContext >>= \(TRC (env, cs, BHeader bhb sigma)) -> do
       pure cs
     Just m -> do
       m <= n ?! KESPeriodWrongOCERT m n
-      pure $ cs ⨃ [(hk, n)]
+      pure $ addpair hk n cs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -21,13 +21,12 @@ import Control.State.Transition ((?!), STS (..), TRC (..), TransitionRule, failB
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, invalidKey)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
+import Shelley.Spec.Ledger.Core (addpair, haskey, removekey)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState (PState (..), emptyPState)
@@ -125,7 +124,7 @@ poolDelegationTransition = do
       poolCost >= minPoolCost ?! StakePoolCostTooLowPOOL poolCost minPoolCost
 
       let hk = _poolPubKey poolParam
-      if hk ∉ dom stpools
+      if not (haskey hk stpools) -- hk ∉ (dom stpools)
         then -- register new, Pool-Reg
 
           pure $
@@ -137,11 +136,11 @@ poolDelegationTransition = do
           pure $
             ps
               { _fPParams = _fPParams ps ⨃ (hk, poolParam),
-                _retiring = Set.singleton hk ⋪ _retiring ps
+                _retiring = removekey hk (_retiring ps) -- Set.singleton hk ⋪ _retiring ps
               }
     DCertPool (RetirePool hk (EpochNo e)) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
-      hk ∈ dom stpools ?! StakePoolNotRegisteredOnKeyPOOL hk
+      haskey hk stpools ?! StakePoolNotRegisteredOnKeyPOOL hk
       EpochNo cepoch <- liftSTS $ do
         ei <- asks epochInfo
         epochInfoEpoch ei slot
@@ -167,10 +166,11 @@ poolDelegationTransition = do
   Map (KeyHash kr crypto) a ->
   (KeyHash kr crypto, a) ->
   Map (KeyHash kr crypto) a
-m ⨃ (k, v) = Map.union (Map.singleton k v) m
+m ⨃ (k, v) = Map.insertWith (\x _ -> x) k v m -- we want this to be left biased, hence (\ x _ -> x)
 
 (∪) ::
+  Ord a =>
   Map (KeyHash kr crypto) a ->
   (KeyHash kr crypto, a) ->
   Map (KeyHash kr crypto) a
-m ∪ (k, v) = Map.union m (Map.singleton k v)
+m ∪ (k, v) = addpair k v m

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -143,4 +143,4 @@ ppupTransitionNonEmpty = do
         epochInfoEpoch ei slot
       currentEpoch == te ?! PPUpdateWrongEpoch currentEpoch te
 
-      pure $ ProposedPPUpdates (pupS ⨃ Map.toList pup)
+      pure $ ProposedPPUpdates (pupS ⨃ pup)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -88,7 +88,7 @@ adoptGenesisDelegs es slot = es'
     ds' =
       ds
         { _fGenDelegs = fGenDelegs',
-          _genDelegs = GenDelegs $ genDelegs ⨃ Map.toList genDelegs'
+          _genDelegs = GenDelegs $ genDelegs ⨃ genDelegs'
         }
     dp' = dp {_dstate = ds'}
     ls' = ls {_delegationState = dp'}

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -47,7 +47,7 @@ import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.Address (Addr, getNetwork)
 import Shelley.Spec.Ledger.BaseTypes (Network, ShelleyBase, invalidKey, networkId)
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Core (dom, range, (∪), (⊆), (⋪))
+import Shelley.Spec.Ledger.Core (dom, range, (∪), (⋪))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Delegation.Certificates (StakePools)
 import Shelley.Spec.Ledger.Keys (GenDelegs)
@@ -203,7 +203,7 @@ utxoInductive ::
   TransitionRule (UTXO crypto)
 utxoInductive = do
   TRC (UtxoEnv slot pp stakepools genDelegs, u, tx) <- judgmentContext
-  let UTxOState utxo deposits' fees ppup = u
+  let UTxOState (utxo@(UTxO v)) deposits' fees ppup = u
   let txb = _body tx
 
   _ttl txb >= slot ?! ExpiredUTxO (_ttl txb) slot
@@ -215,7 +215,7 @@ utxoInductive = do
   minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
   let validInputs = dom utxo
-  txins txb ⊆ validInputs ?! BadInputsUTxO (txins txb `Set.difference` validInputs)
+  all (`Map.member` v) (txins txb) ?! BadInputsUTxO (txins txb `Set.difference` validInputs)
 
   ni <- liftSTS $ asks networkId
   let addrsWrongNetwork =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -47,6 +47,7 @@ module Shelley.Spec.Ledger.Tx
     hashScript,
     txwitsScript,
     extractKeyHash,
+    extractKeyHashWitnessSet,
     extractScriptHash,
     getKeyCombinations,
     getKeyCombination,
@@ -367,6 +368,15 @@ extractKeyHash =
         KeyHashObj hk -> Just hk
         _ -> Nothing
     )
+
+extractKeyHashWitnessSet ::
+  forall (h :: HashType) (r :: KeyRole h) crypto.
+  [Credential r crypto] ->
+  Set (KeyHash (WitnessFor r) crypto)
+extractKeyHashWitnessSet credentials = foldr accum Set.empty credentials
+  where
+    accum (KeyHashObj hk) ans = Set.insert (asWitness hk) ans
+    accum _other ans = ans
 
 extractScriptHash ::
   [Credential 'Payment crypto] ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -115,15 +115,18 @@ instance Relation (UTxO crypto) where
 
   (UTxO a) ∪ (UTxO b) = UTxO $ a ∪ b
 
-  (UTxO a) ⨃ b = UTxO $ a ⨃ b
-
-  vmax <=◁ (UTxO utxo) = UTxO $ vmax <=◁ utxo
-
-  (UTxO utxo) ▷<= vmax = UTxO $ utxo ▷<= vmax
-
-  (UTxO utxo) ▷>= vmin = UTxO $ utxo ▷>= vmin
+  (UTxO a) ⨃ (UTxO b) = UTxO $ a ⨃ b
 
   size (UTxO utxo) = size utxo
+
+  {-# INLINE haskey #-}
+  haskey k (UTxO x) = case Map.lookup k x of Just _ -> True; Nothing -> False
+
+  {-# INLINE addpair #-}
+  addpair k v (UTxO x) = UTxO (Map.insertWith (\y _z -> y) k v x)
+
+  {-# INLINE removekey #-}
+  removekey k (UTxO m) = UTxO (Map.delete k m)
 
 -- | Compute the hash of a transaction body.
 hashTxBody ::
@@ -264,14 +267,14 @@ scriptsNeeded ::
   UTxO crypto ->
   Tx crypto ->
   Set (ScriptHash crypto)
-scriptsNeeded u tx =
+scriptsNeeded (u@(UTxO v)) tx =
   Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
     `Set.union` Set.fromList (Maybe.mapMaybe (scriptCred . getRwdCred) $ Map.keys withdrawals)
     `Set.union` Set.fromList (Maybe.mapMaybe scriptStakeCred (filter requiresVKeyWitness certificates))
   where
     unTxOut (TxOut a _) = a
     withdrawals = unWdrl $ _wdrls $ _body tx
-    UTxO u'' = txinsScript (txins $ _body tx) u <| u
+    u'' = Map.restrictKeys v (txinsScript (txins $ _body tx) u)
     certificates = (toList . _certs . _body) tx
 
 -- | Compute the subset of inputs of the set 'txInps' for which each input is
@@ -280,14 +283,10 @@ txinsScript ::
   Set (TxIn crypto) ->
   UTxO crypto ->
   Set (TxIn crypto)
-txinsScript txInps (UTxO u) =
-  txInps
-    `Set.intersection` Map.keysSet
-      ( Map.filter
-          ( \(TxOut a _) ->
-              case a of
-                Addr _ (ScriptHashObj _) _ -> True
-                _ -> False
-          )
-          u
-      )
+txinsScript txInps (UTxO u) = foldr add Set.empty txInps
+  where
+    -- to get subset, start with empty, and only insert those inputs in txInps that are locked in u
+    add input ans = case Map.lookup input u of
+      Just (TxOut (Addr _ (ScriptHashObj _) _) _) -> Set.insert input ans
+      Just _ -> ans
+      Nothing -> ans

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -1,18 +1,52 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.BenchmarkFunctions
   ( ledgerSpendOneUTxO,
+    ledgerSpendOneGivenUTxO,
+    initUTxO, -- How to precompute env for the UTxO transactions
+    ledgerRegisterStakeKeys,
+    ledgerDeRegisterStakeKeys,
+    ledgerRewardWithdrawals,
+    ledgerStateWithNregisteredKeys, -- How to precompute env for the StakeKey transactions
+    ledgerRegisterStakePools,
+    ledgerReRegisterStakePools,
+    ledgerRetireStakePools,
+    ledgerStateWithNregisteredPools, -- How to precompute env for the Stake Pool transactions
+    ledgerDelegateManyKeysOnePool,
+    ledgerStateWithNkeysMpools, -- How to precompute env for the Stake Delegation transactions
   )
 where
 
+import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
 import Control.State.Transition.Extended (TRC (..), applySTS)
 import qualified Data.Map as Map
+import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Data.Word (Word64)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Network (..),
+    StrictMaybe (..),
+  )
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Keys (asWitness)
+import Shelley.Spec.Ledger.Credential (pattern KeyHashObj)
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DeRegKey,
+    pattern Delegate,
+    pattern RegKey,
+  )
+import Shelley.Spec.Ledger.Keys
+  ( KeyRole (..),
+    asWitness,
+    hashKey,
+    vKey,
+  )
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     emptyDPState,
@@ -22,60 +56,116 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPPPUpdates)
 import Shelley.Spec.Ledger.STS.Ledger (pattern LedgerEnv)
-import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx (WitnessSetHKD (..), pattern Tx)
 import Shelley.Spec.Ledger.TxData
-  ( pattern TxBody,
+  ( Delegation (..),
+    PoolCert (..),
+    _poolCost,
+    _poolMD,
+    _poolMargin,
+    _poolOwners,
+    _poolPledge,
+    _poolPubKey,
+    _poolRAcnt,
+    _poolRelays,
+    _poolVrf,
+    pattern DCertDeleg,
+    pattern DCertPool,
+    pattern PoolParams,
+    pattern RewardAcnt,
+    pattern TxBody,
     pattern TxIn,
     pattern TxOut,
     pattern Wdrl,
   )
 import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-  ( DPState,
+  ( Addr,
+    Credential,
+    DCert,
+    DPState,
+    KeyHash,
+    KeyPair,
     LEDGER,
     LedgerEnv,
+    PoolParams,
     Tx,
     TxBody,
     TxOut,
     UTxOState,
+    VRFKeyHash,
+    hashKeyVRF,
+    pattern KeyPair,
   )
-import Test.Shelley.Spec.Ledger.Examples
-  ( aliceAddr,
-    alicePay,
-    ppsEx1,
+import Test.Shelley.Spec.Ledger.Examples (ppsEx1)
+import Test.Shelley.Spec.Ledger.Utils
+  ( mkAddr,
+    mkKeyPair,
+    mkKeyPair',
+    mkVRFKeyPair,
+    runShelleyBase,
+    unsafeMkUnitInterval,
   )
-import Test.Shelley.Spec.Ledger.Utils (runShelleyBase)
 
-coins :: Integer -> [TxOut]
+-- =========================================================
+
+aliceStake :: KeyPair Blake2b_256 'Staking
+aliceStake = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 1)
+
+alicePay :: KeyPair Blake2b_256 'Payment
+alicePay = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
+
+aliceAddr :: Addr Blake2b_256
+aliceAddr = mkAddr (alicePay, aliceStake)
+
+-- ==========================================================
+
+coins :: Integer -> [TxOut Blake2b_256]
 coins n = fmap (\_ -> TxOut aliceAddr (Coin $ 100)) [0 .. n]
 
-utxoState :: Integer -> UTxOState
-utxoState n =
+-- Cretae an initial UTxO set with n-many transaction outputs
+initUTxO :: Integer -> UTxOState Blake2b_256
+initUTxO n =
   UTxOState
     (genesisCoins (coins n))
     (Coin 0)
     (Coin 0)
     emptyPPPUpdates
 
+-- Protocal Parameters used for the benchmarknig tests.
+-- Note that the fees and deposits are set to zero for
+-- ease of creating transactions.
 ppsBench :: PParams
-ppsBench = ppsEx1 {_minUTxOValue = 10}
+ppsBench =
+  ppsEx1
+    { _minUTxOValue = 10,
+      _keyDeposit = Coin 0,
+      _poolDeposit = Coin 0,
+      _minfeeA = 0,
+      _minfeeB = 0,
+      _maxTxSize = 1000000000
+    }
 
 ledgerEnv :: LedgerEnv
 ledgerEnv = LedgerEnv (SlotNo 0) 0 ppsBench (AccountState 0 0)
 
 testLEDGER ::
-  (UTxOState, DPState) ->
-  Tx ->
+  (UTxOState Blake2b_256, DPState Blake2b_256) ->
+  Tx Blake2b_256 ->
   LedgerEnv ->
-  Bool
+  ()
 testLEDGER initSt tx env = do
-  let st = runShelleyBase $ applySTS @LEDGER (TRC (env, initSt, tx))
+  let st = runShelleyBase $ applySTS @(LEDGER Blake2b_256) (TRC (env, initSt, tx))
   case st of
-    Right _ -> True
-    Left _ -> False
+    Right _ -> ()
+    Left e -> error $ show e
 
-txbSpendOneUTxO :: TxBody
+txbSpendOneUTxO :: TxBody Blake2b_256
 txbSpendOneUTxO =
   TxBody
     (Set.fromList [TxIn genesisId 0])
@@ -87,7 +177,7 @@ txbSpendOneUTxO =
     SNothing
     SNothing
 
-txSpendOneUTxO :: Tx
+txSpendOneUTxO :: Tx Blake2b_256
 txSpendOneUTxO =
   Tx
     txbSpendOneUTxO
@@ -96,5 +186,348 @@ txSpendOneUTxO =
       }
     SNothing
 
-ledgerSpendOneUTxO :: Integer -> Bool
-ledgerSpendOneUTxO n = testLEDGER (utxoState n, emptyDPState) txSpendOneUTxO ledgerEnv
+ledgerSpendOneUTxO :: Integer -> ()
+ledgerSpendOneUTxO n = testLEDGER (initUTxO n, emptyDPState) txSpendOneUTxO ledgerEnv
+
+ledgerSpendOneGivenUTxO :: UTxOState Blake2b_256 -> ()
+ledgerSpendOneGivenUTxO state = testLEDGER (state, emptyDPState) txSpendOneUTxO ledgerEnv
+
+-- ===========================================================================
+--
+-- Register a stake keys when there are a lot of registered stake keys
+--
+
+-- Create stake key pairs, corresponding to seeds
+-- (start, 0, 0, 0, 0) through (end, 0, 0, 0, 0)
+stakeKeys :: Word64 -> Word64 -> [KeyPair Blake2b_256 'Staking]
+stakeKeys start end = fmap (\w -> mkKeyPair' (w, 0, 0, 0, 0)) [start .. end]
+
+stakeKeyOne :: KeyPair Blake2b_256 'Staking
+stakeKeyOne = mkKeyPair' (1, 0, 0, 0, 0)
+
+stakeKeyToCred :: KeyPair Blake2b_256 'Staking -> Credential Blake2b_256 'Staking
+stakeKeyToCred = KeyHashObj . hashKey . vKey
+
+firstStakeKeyCred :: Credential Blake2b_256 'Staking
+firstStakeKeyCred = stakeKeyToCred stakeKeyOne
+
+-- Create stake key registration certificates
+stakeKeyRegistrations :: [KeyPair Blake2b_256 'Staking] -> StrictSeq (DCert Blake2b_256)
+stakeKeyRegistrations keys =
+  StrictSeq.fromList $
+    fmap (DCertDeleg . RegKey . (KeyHashObj . hashKey . vKey)) keys
+
+-- Create a transaction body given a sequence of certificates.
+-- It spends the genesis coin given by the index ix.
+txbFromCerts :: Natural -> StrictSeq (DCert Blake2b_256) -> TxBody Blake2b_256
+txbFromCerts ix regCerts =
+  TxBody
+    (Set.fromList [TxIn genesisId ix])
+    (StrictSeq.fromList [TxOut aliceAddr (Coin 100)])
+    regCerts
+    (Wdrl Map.empty)
+    (Coin 0)
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+makeSimpleTx ::
+  TxBody Blake2b_256 ->
+  [KeyPair Blake2b_256 'AWitness] ->
+  [KeyPair Blake2b_256 'RWitness] ->
+  Tx Blake2b_256
+makeSimpleTx body keysAddr keysReg =
+  Tx
+    body
+    mempty
+      { addrWits = makeWitnessesVKey (hashTxBody body) keysAddr,
+        regWits = makeWitnessesVKey (hashTxBody body) keysReg
+      }
+    SNothing
+
+-- Create a transaction that registers stake credentials.
+txRegStakeKeys :: Natural -> [KeyPair Blake2b_256 'Staking] -> Tx Blake2b_256
+txRegStakeKeys ix keys =
+  makeSimpleTx
+    (txbFromCerts ix $ stakeKeyRegistrations keys)
+    [asWitness alicePay]
+    []
+
+initLedgerState :: Integer -> (UTxOState Blake2b_256, DPState Blake2b_256)
+initLedgerState n = (initUTxO n, emptyDPState)
+
+makeLEDGERState ::
+  (UTxOState Blake2b_256, DPState Blake2b_256) ->
+  Tx Blake2b_256 ->
+  (UTxOState Blake2b_256, DPState Blake2b_256)
+makeLEDGERState start tx =
+  let st = applySTS @(LEDGER Blake2b_256) (TRC (ledgerEnv, start, tx))
+   in case runShelleyBase st of
+        Right st' -> st'
+        Left e -> error $ show e
+
+-- Create a ledger state that has registered stake credentials that
+-- are seeded with (n, 0, 0, 0, 0) to (m, 0, 0, 0, 0).
+-- It is pre-populated with 2 genesis coins.
+ledgerStateWithNregisteredKeys ::
+  Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256)
+ledgerStateWithNregisteredKeys n m =
+  makeLEDGERState (initLedgerState 1) $ txRegStakeKeys 0 (stakeKeys n m)
+
+-- ===========================================================
+-- Stake Key Registration example
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredKeys n m,
+-- so that keys (n, 0, 0, 0, 0) through (m, 0, 0, 0, 0) are already registered,
+-- register new keys (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [n, m] must be disjoint from [x, y].
+ledgerRegisterStakeKeys :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerRegisterStakeKeys x y state =
+  testLEDGER
+    state
+    (txRegStakeKeys 1 (stakeKeys x y))
+    ledgerEnv
+
+-- ===========================================================
+-- Deregistration example
+
+-- Create a transaction body that de-registers stake credentials,
+-- corresponding to the keys seeded with (x, 0, 0, 0, 0) to (y, 0, 0, 0, 0)
+txbDeRegStakeKey :: Word64 -> Word64 -> TxBody Blake2b_256
+txbDeRegStakeKey x y =
+  TxBody
+    (Set.fromList [TxIn genesisId 1])
+    (StrictSeq.fromList [TxOut aliceAddr (Coin 100)])
+    ( StrictSeq.fromList $
+        fmap (DCertDeleg . DeRegKey . stakeKeyToCred) (stakeKeys x y)
+    )
+    (Wdrl Map.empty)
+    (Coin 0)
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+-- Create a transaction that deregisters stake credentials numbered x through y.
+-- It spends the genesis coin indexed by 1.
+txDeRegStakeKeys :: Word64 -> Word64 -> Tx Blake2b_256
+txDeRegStakeKeys x y =
+  makeSimpleTx
+    (txbDeRegStakeKey x y)
+    (asWitness alicePay : (fmap asWitness (stakeKeys x y)))
+    []
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredKeys n m,
+-- so that keys (n, 0, 0, 0, 0) through (m, 0, 0, 0, 0) are already registered,
+-- deregister keys (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [x, y] must be contained in [n, m].
+ledgerDeRegisterStakeKeys :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerDeRegisterStakeKeys x y state =
+  testLEDGER
+    state
+    (txDeRegStakeKeys x y)
+    ledgerEnv
+
+-- ===========================================================
+-- Reward Withdrawal example
+
+-- Create a transaction body that withdrawls from reward accounts,
+-- corresponding to the keys seeded with (x, 0, 0, 0, 0) to (y, 0, 0, 0, 0).
+txbWithdrawals :: Word64 -> Word64 -> TxBody Blake2b_256
+txbWithdrawals x y =
+  TxBody
+    (Set.fromList [TxIn genesisId 1])
+    (StrictSeq.fromList [TxOut aliceAddr (Coin 100)])
+    StrictSeq.empty
+    ( Wdrl $ Map.fromList $
+        fmap (\ks -> (RewardAcnt Testnet (stakeKeyToCred ks), Coin 0)) (stakeKeys x y)
+    )
+    (Coin 0)
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+-- Create a transaction that withdrawls from a reward accounts.
+-- It spends the genesis coin indexed by 1.
+txWithdrawals :: Word64 -> Word64 -> Tx Blake2b_256
+txWithdrawals x y =
+  makeSimpleTx
+    (txbWithdrawals x y)
+    (asWitness alicePay : (fmap asWitness (stakeKeys x y)))
+    []
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredKeys n m,
+-- so that keys (n, 0, 0, 0, 0) through (m, 0, 0, 0, 0) are already registered,
+-- make reward withdrawls for keys (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [x, y] must be contained in [n, m].
+ledgerRewardWithdrawals :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerRewardWithdrawals x y state = testLEDGER state (txWithdrawals x y) ledgerEnv
+
+-- ===========================================================================
+--
+-- Register a stake pool when there are a lot of registered stake pool
+--
+
+-- Create stake pool key pairs, corresponding to seeds
+-- (start, 0, 0, 0, 0) through (end, 0, 0, 0, 0)
+poolColdKeys :: Word64 -> Word64 -> [KeyPair Blake2b_256 'StakePool]
+poolColdKeys start end = fmap (\w -> mkKeyPair' (w, 1, 0, 0, 0)) [start .. end]
+
+firstStakePool :: KeyPair Blake2b_256 'StakePool
+firstStakePool = mkKeyPair' (1, 1, 0, 0, 0)
+
+mkPoolKeyHash :: KeyPair Blake2b_256 'StakePool -> KeyHash Blake2b_256 'StakePool
+mkPoolKeyHash = hashKey . vKey
+
+firstStakePoolKeyHash :: KeyHash Blake2b_256 'StakePool
+firstStakePoolKeyHash = mkPoolKeyHash firstStakePool
+
+vrfKeyHash :: VRFKeyHash Blake2b_256
+vrfKeyHash = hashKeyVRF . snd . mkVRFKeyPair $ (0, 0, 0, 0, 0)
+
+mkPoolParameters :: KeyPair Blake2b_256 'StakePool -> PoolParams Blake2b_256
+mkPoolParameters keys =
+  PoolParams
+    { _poolPubKey = (hashKey . vKey) keys,
+      _poolVrf = vrfKeyHash,
+      _poolPledge = Coin 0,
+      _poolCost = Coin 0,
+      _poolMargin = unsafeMkUnitInterval 0,
+      _poolRAcnt = RewardAcnt Testnet firstStakeKeyCred,
+      _poolOwners = Set.singleton $ (hashKey . vKey) stakeKeyOne,
+      _poolRelays = StrictSeq.empty,
+      _poolMD = SNothing
+    }
+
+-- Create stake pool registration certs
+poolRegCerts :: [KeyPair Blake2b_256 'StakePool] -> StrictSeq (DCert Blake2b_256)
+poolRegCerts = StrictSeq.fromList . fmap (DCertPool . RegPool . mkPoolParameters)
+
+-- Create a transaction that registers stake pools.
+txRegStakePools :: Natural -> [KeyPair Blake2b_256 'StakePool] -> Tx Blake2b_256
+txRegStakePools ix keys =
+  makeSimpleTx
+    (txbFromCerts ix $ poolRegCerts keys)
+    [asWitness alicePay, asWitness stakeKeyOne]
+    (fmap asWitness keys)
+
+-- Create a ledger state that has n registered stake pools.
+-- The keys are seeded with (n, 1, 0, 0, 0) to (m, 1, 0, 0, 0)
+-- It is pre-populated with 2 genesis coins.
+ledgerStateWithNregisteredPools :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256)
+ledgerStateWithNregisteredPools n m =
+  makeLEDGERState (initLedgerState 1) $ txRegStakePools 0 (poolColdKeys n m)
+
+-- ===========================================================
+-- Stake Pool Registration example
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredPools n m,
+-- so that pool keys (n, 1, 0, 0, 0) through (m, 1, 0, 0, 0) are already registered,
+-- register new pools (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [n, m] must be disjoint from [x, y].
+ledgerRegisterStakePools :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerRegisterStakePools x y state =
+  testLEDGER
+    state
+    (txRegStakePools 1 (poolColdKeys x y))
+    ledgerEnv
+
+-- ===========================================================
+-- Stake Pool Re-Registration/Update example
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredPools n m,
+-- so that pool keys (n, 1, 0, 0, 0) through (m, 1, 0, 0, 0) are already registered,
+-- re-register pools (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [n, m] must be contained in [x, y].
+ledgerReRegisterStakePools :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerReRegisterStakePools x y state =
+  testLEDGER
+    state
+    (txRegStakePools 1 (poolColdKeys x y))
+    ledgerEnv
+
+-- ===========================================================
+-- Stake Pool Retirement example
+
+-- Create a transaction body that retires stake pools,
+-- corresponding to the keys seeded with (x, 1, 0, 0, 0) to (y, 1, 0, 0, 0)
+txbRetireStakePool :: Word64 -> Word64 -> TxBody Blake2b_256
+txbRetireStakePool x y =
+  TxBody
+    (Set.fromList [TxIn genesisId 1])
+    (StrictSeq.fromList [TxOut aliceAddr (Coin 100)])
+    ( StrictSeq.fromList $
+        fmap
+          (\ks -> DCertPool $ RetirePool (mkPoolKeyHash ks) (EpochNo 1))
+          (poolColdKeys x y)
+    )
+    (Wdrl Map.empty)
+    (Coin 0)
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+-- Create a transaction that retires stake pools x through y.
+-- It spends the genesis coin indexed by 1.
+txRetireStakePool :: Word64 -> Word64 -> Tx Blake2b_256
+txRetireStakePool x y =
+  makeSimpleTx
+    (txbRetireStakePool x y)
+    [asWitness alicePay]
+    (fmap asWitness (poolColdKeys x y))
+
+-- Given a ledger state, presumably created by ledgerStateWithNregisteredPools n m,
+-- so that pool keys (n, 1, 0, 0, 0) through (m, 1, 0, 0, 0) are already registered,
+-- retire pools (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0).
+-- Note that [n, m] must be contained in [x, y].
+ledgerRetireStakePools :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerRetireStakePools x y state = testLEDGER state (txRetireStakePool x y) ledgerEnv
+
+-- ===========================================================================
+--
+-- Delegate Stake Credentials when many stake keys and stake pools are registered.
+--
+
+-- Create a ledger state that has n registered stake keys and m stake pools.
+-- The stake keys are seeded with (1, 0, 0, 0, 0) to (n, 0, 0, 0, 0)
+-- The stake pools are seeded with (1, 1, 0, 0, 0) to (m, 1, 0, 0, 0)
+-- It is pre-populated with 3 genesis coins.
+ledgerStateWithNkeysMpools :: Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256)
+ledgerStateWithNkeysMpools n m =
+  makeLEDGERState
+    (makeLEDGERState (initLedgerState 2) $ txRegStakeKeys 0 (stakeKeys 1 n))
+    (txRegStakePools 1 (poolColdKeys 1 m))
+
+-- Create a transaction body that delegates several keys to ONE stake pool,
+-- corresponding to the keys seeded with (n, 0, 0, 0, 0) to (m, 0, 0, 0, 0)
+txbDelegate :: Word64 -> Word64 -> TxBody Blake2b_256
+txbDelegate n m =
+  TxBody
+    (Set.fromList [TxIn genesisId 2])
+    (StrictSeq.fromList [TxOut aliceAddr (Coin 100)])
+    ( StrictSeq.fromList $
+        fmap
+          (\ks -> DCertDeleg $ Delegate (Delegation (stakeKeyToCred ks) firstStakePoolKeyHash))
+          (stakeKeys n m)
+    )
+    (Wdrl Map.empty)
+    (Coin 0)
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+-- Create a transaction that delegates stake.
+txDelegate :: Word64 -> Word64 -> Tx Blake2b_256
+txDelegate n m =
+  makeSimpleTx
+    (txbDelegate n m)
+    (asWitness alicePay : fmap asWitness (stakeKeys n m))
+    []
+
+-- Given a ledger state, presumably created by ledgerStateWithNkeysMpools n m,
+-- so that stake keys (1, 0, 0, 0, 0) through (n, 0, 0, 0, 0) are already registered
+-- and pool keys (1, 1, 0, 0, 0) through (m, 1, 0, 0, 0) are already registered,
+-- delegate stake keys (x, 0, 0, 0, 0) through (y, 0, 0, 0, 0) to ONE pool.
+-- Note that [x, y] must be contained in [1, n].
+ledgerDelegateManyKeysOnePool ::
+  Word64 -> Word64 -> (UTxOState Blake2b_256, DPState Blake2b_256) -> ()
+ledgerDelegateManyKeysOnePool x y state = testLEDGER state (txDelegate x y) ledgerEnv

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -13,6 +13,7 @@ module Test.Shelley.Spec.Ledger.Utils
     evolveKESUntil,
     slotFromEpoch,
     mkKeyPair,
+    mkKeyPair',
     mkGenKey,
     mkKESKeyPair,
     mkVRFKeyPair,
@@ -53,7 +54,7 @@ import Shelley.Spec.Ledger.BaseTypes
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
-import Shelley.Spec.Ledger.Keys (KeyRole (..), hashKey, updateKES, vKey)
+import Shelley.Spec.Ledger.Keys (KeyRole (..), hashKey, updateKES, vKey, pattern KeyPair)
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
 import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
@@ -95,6 +96,12 @@ mkKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyDSIGN h, VKey h
 mkKeyPair seed =
   let sk = genKeyDSIGN $ mkSeedFromWords seed
    in (sk, VKey $ deriveVerKeyDSIGN sk)
+
+-- | For testing purposes, generate a deterministic key pair given a seed.
+mkKeyPair' :: (Word64, Word64, Word64, Word64, Word64) -> KeyPair h kr
+mkKeyPair' seed = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair seed
 
 -- | For testing purposes, generate a deterministic VRF key pair given a seed.
 mkVRFKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyVRF h, VerKeyVRF h)


### PR DESCRIPTION
This is mostly @TimSheard 's work, but I have been helping.

We now have several benchmark tests which process transactions using the `LEDGER` transition. This includes spending UTxOs, stake key registrations, deregistrations, withdrawals, stake pool registrations, re-registrations, retirements, and delegations. These tests use a variety of environment sizes (how big the UTxO set is, how many registered stake keys and stake pools), with a variety of transaction sizes (such as how many registrations, etc).

In the process, many optimizations were found and applied.

~I tried to clean up the commit history, but had a lot of trouble doing so, and abandoned it. We will soon remove the `BenchmarkCrypto` module in favor of something better, but would like to merge this long running PR fairly soon.~

closes #1504 