### PR TITLE
removing optional port from MultiHostName

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -144,7 +144,6 @@ single_host_name = ( 1
                    , dns_name ; An A or AAAA DNS record
                    )
 multi_host_name = ( 2
-                   , port / null
                    , dns_name ; A SRV DNS record
                    )
 relay =

--- a/shelley/chain-and-ledger/executable-spec/test/Golden/ShelleyGenesis
+++ b/shelley/chain-and-ledger/executable-spec/test/Golden/ShelleyGenesis
@@ -70,8 +70,7 @@
                     },
                     {
                         "multi host name": {
-                            "dnsName": "cool.domain.com",
-                            "port": 65000
+                            "dnsName": "cool.domain.com"
                         }
                     }
                 ],

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -3385,7 +3385,7 @@ exampleShelleyGenesis =
       StrictSeq.fromList
         [ SingleHostAddr (SJust $ Port 1234) (SJust $ read "0.0.0.0") (SJust $ read "2001:db8:a::123"),
           SingleHostName SNothing (fromJust $ textToDns "cool.domain.com"),
-          MultiHostName (SJust $ Port 65000) (fromJust $ textToDns "cool.domain.com")
+          MultiHostName (fromJust $ textToDns "cool.domain.com")
         ]
     poolParams :: PoolParams h
     poolParams =

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Genesis.hs
@@ -115,7 +115,7 @@ genStakePoolRelay =
   Gen.choice
     [ SingleHostAddr <$> genStrictMaybe genPort <*> genStrictMaybe genIPv4 <*> genStrictMaybe genIPv6,
       SingleHostName <$> genStrictMaybe genPort <*> genDnsName,
-      MultiHostName <$> genStrictMaybe genPort <*> genDnsName
+      MultiHostName <$> genDnsName
     ]
 
 genStrictMaybe :: Gen a -> Gen (StrictMaybe a)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialization.hs
@@ -663,8 +663,8 @@ serializationUnitTests =
           poolRelays =
             StrictSeq.fromList
               [ SingleHostAddr SNothing (SJust ipv4) SNothing,
-                SingleHostName SNothing $ Maybe.fromJust $ textToDns "singlehost.relay.com",
-                MultiHostName (SJust 42) $ Maybe.fromJust $ textToDns "multihost.relay.com"
+                SingleHostName (SJust 42) $ Maybe.fromJust $ textToDns "singlehost.relay.com",
+                MultiHostName $ Maybe.fromJust $ textToDns "multihost.relay.com"
               ]
        in checkEncodingCBOR
             "register_pool"
@@ -701,8 +701,8 @@ serializationUnitTests =
                 <> S poolOwner -- owners
                 <> T (TkListLen 3) -- relays
                 <> T (TkListLen 4 . TkWord 0 . TkNull . TkBytes ipv4Bytes . TkNull)
-                <> T (TkListLen 3 . TkWord 1 . TkNull . TkString ("singlehost.relay.com"))
-                <> T (TkListLen 3 . TkWord 2 . (TkWord 42) . TkString ("multihost.relay.com"))
+                <> T (TkListLen 3 . TkWord 1 . (TkWord 42) . TkString ("singlehost.relay.com"))
+                <> T (TkListLen 2 . TkWord 2 . TkString ("multihost.relay.com"))
                 <> T (TkListLen 2) -- metadata present
                 <> S poolUrl -- metadata url
                 <> S poolMDHash -- metadata hash


### PR DESCRIPTION
The `StakePoolRelay` types has a constructor for SRV DNS records, `MultiHostName`, which has an optional port. The optional port is not helpful and this PR removes it.

closes #1568 