### PR TITLE
Restore property tests (with Tx Protocol Updates disabled)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -29,6 +29,7 @@ module Test.Shelley.Spec.Ledger.Generator.Core
     genWord64,
     genTxOut,
     increasingProbabilityAt,
+    lookupGenDelegate,
     mkScriptsFromKeyPair,
     pickStakeKey,
     toAddr,
@@ -53,7 +54,7 @@ import Control.Monad (replicateM)
 import Control.Monad.Trans.Reader (asks)
 import Data.Coerce (coerce)
 import Data.List (foldl')
-import qualified Data.List as List (findIndex, (\\))
+import qualified Data.List as List (find, findIndex, (\\))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (fromList, lookup)
 import Data.Ratio ((%))
@@ -219,6 +220,18 @@ pattern KeySpace
           ksIndexedStakingKeys = mkStakeKeyHashMap ksKeyPairs,
           ksMSigScripts
         }
+
+-- | Look up the given GenesisDelegate key in the combined list of
+-- core nodes and potential genesis delegate keys.
+lookupGenDelegate ::
+  HashAlgorithm h =>
+  [(GenesisKeyPair h, AllIssuerKeys h 'GenesisDelegate)] ->
+  [AllIssuerKeys h 'GenesisDelegate] ->
+  KeyHash h 'GenesisDelegate ->
+  Maybe (AllIssuerKeys h 'GenesisDelegate)
+lookupGenDelegate coreNodes genesisDelegates gkey =
+  let allDelegateKeys = (snd <$> coreNodes) <> genesisDelegates
+   in List.find (\a -> (hashKey . vKey . cold) a == gkey) allDelegateKeys
 
 genBool :: HasCallStack => Gen Bool
 genBool = QC.arbitraryBoundedRandom

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -99,7 +99,6 @@ import Test.Shelley.Spec.Ledger.Generator.Core
   )
 import Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..))
 import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
-import Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 
 -- | Generate a new transaction in the context of the LEDGER STS environment and state.
 --
@@ -114,9 +113,7 @@ genTx ::
 genTx
   ge@( GenEnv
          KeySpace_
-           { ksCoreNodes,
-             ksKeyPairs,
-             ksGenesisDelegates,
+           { ksKeyPairs,
              ksIndexedPaymentKeys,
              ksIndexedStakingKeys,
              ksMSigScripts
@@ -124,7 +121,7 @@ genTx
          constants
        )
   (LedgerEnv slot txIx pparams reserves)
-  (utxoSt@(UTxOState utxo _ _ _), dpState) =
+  (_utxoSt@(UTxOState utxo _ _ _), dpState) =
     do
       keys' <- QC.shuffle ksKeyPairs
       scripts' <- QC.shuffle ksMSigScripts
@@ -156,7 +153,7 @@ genTx
       let slotWithTTL = slot + SlotNo (fromIntegral ttl)
 
       -- certificates
-      (certs, certCreds, deposits_, refunds_, dpState') <-
+      (certs, certCreds, deposits_, refunds_, _dpState') <-
         genDCerts ge pparams dpState slot txIx reserves
 
       let balance_ = spendingBalance - deposits_ + refunds_
@@ -173,8 +170,11 @@ genTx
           let (_, outputs) = calcOutputsFromBalance balance_ recipientAddrs (Coin 0)
 
           --- PParam + AV Updates
-          (update, updateWitnesses) <-
-            genUpdate constants slot ksCoreNodes ksGenesisDelegates pparams (utxoSt, dpState')
+          -- TODO @uroboros Restore Updates to generated transactions,
+          -- see https://github.com/input-output-hk/cardano-ledger-specs/issues/1582
+          let (update, updateWitnesses) = (Nothing, []) :: (Maybe (Update h), [KeyPair h 'Witness])
+          -- (update, updateWitnesses) <-
+          --  genUpdate constants slot ksCoreNodes ((snd <$> ksCoreNodes) <> ksGenesisDelegates) pparams (utxoSt, dpState')
 
           -- this is the "model" `TxBody` which is used to calculate the fees
           --

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -4,7 +4,7 @@ import Test.Shelley.Spec.Ledger.Address (addressTests)
 import Test.Shelley.Spec.Ledger.CDDL (cddlTests)
 import Test.Shelley.Spec.Ledger.Genesis.Properties
 import Test.Shelley.Spec.Ledger.NonTraceProperties.PropertyTests (nonTracePropertyTests)
-import Test.Shelley.Spec.Ledger.PropertyTests (propertyTests)
+import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Shelley.Spec.Ledger.STSTests (stsTests)
 import Test.Shelley.Spec.Ledger.Serialization (serializationTests)
 import Test.Shelley.Spec.Ledger.UnitTests (unitTests)
@@ -23,7 +23,7 @@ mainTests =
     "Ledger with Delegation"
     [ addressTests,
       cddlTests 5,
-      --minimalPropertyTests, TODO re-enable when we can get these to not time out in CI.
+      minimalPropertyTests,
       serializationTests,
       stsTests,
       unitTests,


### PR DESCRIPTION
Closes #1545 

This PR 

(1) updated the generators (RegPool, PParams) to reflect the new _minPoolCost protocol param.

(2) Unrelated to these changes, an `UnexpectedDepositPot` predicate failure has been causing property tests to time out. In particular, the failures happen in the presence of protocol param updates. This PR disables generating PParam Updates in transactions and includes the tests to run in CI again. 
(see #1582 to add the generation of Updates again)

(3) This PR also solves the issue of checkCoverage _not_ failing when coverage was not being met.

(4) Unifies the "looking up of genesis delegates" across several generators - this was being done slightly differently in multiple locations 

 



