### PR TITLE
Fix EPOCH STS rule to feed correct Pool state into NEWPP

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -128,7 +128,7 @@ epochTransition = do
   let ppNew = votedValuePParams ppup pp (fromIntegral coreNodeQuorum)
   NewppState utxoSt'' acnt'' pp' <-
     trans @(NEWPP crypto) $
-      TRC (NewppEnv dstate' pstate', NewppState utxoSt' acnt' pp, ppNew)
+      TRC (NewppEnv dstate' pstate'', NewppState utxoSt' acnt' pp, ppNew)
   pure $
     EpochState
       acnt''


### PR DESCRIPTION
The EPOCH rule in the exec spec was feeding the incorrect Pool state into the NEWPP rule.
(The formal spec describes this correctly)

Before this change, NEWPP was getting the Pool state from _before_ POOLREAP being applied, but the Utxo state from _after_ the POOLREAP.

This meant that the NEWPP rule would often fail on

`(Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot` 

because the RHS deposit pot would reflect the reaped pools (with deposits flowing out to rewards/treasury) while the LHS (which depends on the number of pools) would still count all the pools, pre-POOLREAP.


