### PR TITLE
rename KESPeriodWrongOCERT to CounterTooSmallOCERT

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -52,7 +52,7 @@ instance
         !KESPeriod -- Current KES Period
         !KESPeriod -- OCert Start KES Period
         !Word64 -- Max KES Key Evolutions
-    | KESPeriodWrongOCERT
+    | CounterTooSmallOCERT
         !Natural -- last KES counter used
         !Natural -- current KES counter
     | InvalidSignatureOCERT -- TODO use whole OCert
@@ -106,5 +106,5 @@ ocertTransition =
         failBecause $ NoCounterForKeyHashOCERT hk
         pure cs
       Just m -> do
-        m <= n ?! KESPeriodWrongOCERT m n
+        m <= n ?! CounterTooSmallOCERT m n
         pure $ addpair hk n cs


### PR DESCRIPTION
The error `KESPeriodWrongOCERT` is wrongly named. The actual error has to do with the supplied operational cert counter being too small.

closes #1589 