### PR TITLE
Add comments for Relation class changes

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -783,12 +783,10 @@ consumed ::
   UTxO crypto ->
   TxBody crypto ->
   Coin
-consumed pp (_u@(UTxO v)) tx =
-  -- balance (txins tx ◁ _u) + refunds + withdrawals
-  -- We do not call ◁, as this causes an identity call to toSet(txins tx)
-  -- To be fixed in a following PR
-  balance (UTxO (Map.restrictKeys v (txins tx))) + refunds + withdrawals
+consumed pp u tx =
+  balance (txins tx ◁ u) + refunds + withdrawals
   where
+    -- balance (UTxO (Map.restrictKeys v (txins tx))) + refunds + withdrawals
     refunds = keyRefunds pp tx
     withdrawals = sum . unWdrl $ _wdrls tx
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -107,4 +107,4 @@ ocertTransition =
         pure cs
       Just m -> do
         m <= n ?! KESPeriodWrongOCERT m n
-        pure $ addpair hk n cs
+        pure $ addpair hk n cs -- cs ⨃ (singleton hk n)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -139,6 +139,7 @@ poolDelegationTransition = do
               }
     DCertPool (RetirePool hk (EpochNo e)) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
+      --  hk ∈ dom stpools  -- Specification code translates below
       haskey hk stpools ?! StakePoolNotRegisteredOnKeyPOOL hk
       EpochNo cepoch <- liftSTS $ do
         ei <- asks epochInfo

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -225,6 +225,7 @@ utxoInductive = do
   minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
   let validInputs = dom utxo
+  --   txins txb ⊆ validInputs  -- Specification translates below
   all (`Map.member` v) (txins txb) ?! BadInputsUTxO (txins txb `Set.difference` validInputs)
 
   ni <- liftSTS $ asks networkId

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -264,14 +264,16 @@ scriptsNeeded ::
   UTxO crypto ->
   Tx crypto ->
   Set (ScriptHash crypto)
-scriptsNeeded (u@(UTxO v)) tx =
+scriptsNeeded u tx =
   Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
     `Set.union` Set.fromList (Maybe.mapMaybe (scriptCred . getRwdCred) $ Map.keys withdrawals)
     `Set.union` Set.fromList (Maybe.mapMaybe scriptStakeCred (filter requiresVKeyWitness certificates))
   where
     unTxOut (TxOut a _) = a
     withdrawals = unWdrl $ _wdrls $ _body tx
-    u'' = Map.restrictKeys v (txinsScript (txins $ _body tx) u)
+
+    UTxO u'' = (txinsScript (txins $ _body tx) u) ◁ u
+    -- u'' = Map.restrictKeys v (txinsScript (txins $ _body tx) u)  TODO
     certificates = (toList . _certs . _body) tx
 
 -- | Compute the subset of inputs of the set 'txInps' for which each input is


### PR DESCRIPTION

Every place where we used a call to one of the new methods of Relation: haskey, addpair, removekey
I have added a comment indication the original 'specification code' that was replaced. The hope is
that we can revert to this specification by adding GHC rewrites or some other method, sometime in the future.