### PR TITLE
nonmyopic member rewards bug fix

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -468,4 +468,4 @@ nonMyopicMemberRew
     let nm' = max t nm -- TODO check with researchers that this is how to handle t > nm
         (Coin f) = maxPool pp rPot nm' s
         fHat = floor (p * fromIntegral f)
-     in memberRew (Coin fHat) pool (StakeShare s) (StakeShare nm')
+     in memberRew (Coin fHat) pool (StakeShare t) (StakeShare nm')


### PR DESCRIPTION
Single character PR. :) We obviously need better tests for the non-myopic rewards calculation, for which I made #1600.

The calculation was previously using the stake pool's stake in place of the member's stake.