### PR TITLE
property test for NewEpochState deserialization

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -14,6 +14,7 @@ import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
   )
 import Test.Shelley.Spec.Ledger.Rules.TestChain
   ( adaPreservationChain,
+    canRoundTripNewEpochState,
     constantSumPots,
     nonNegativeDeposits,
     removedAfterPoolreap,
@@ -121,7 +122,10 @@ propertyTests =
         "STS Rules - NewEpoch Properties"
         [ TQC.testProperty
             "total amount of Ada is preserved"
-            adaPreservationChain
+            adaPreservationChain,
+          TQC.testProperty
+            "can serialize the NewEpochState (Chain)"
+            canRoundTripNewEpochState
         ],
       testGroup
         "STS Rules - MIR certificates"

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -11,10 +11,12 @@ module Test.Shelley.Spec.Ledger.Rules.TestChain
     removedAfterPoolreap,
     -- TestNewEpoch
     adaPreservationChain,
+    canRoundTripNewEpochState,
     rewardStkCredSync,
   )
 where
 
+import Cardano.Binary (serialize)
 import Cardano.Crypto.Hash (ShortHash)
 import Control.Monad (join)
 import Control.State.Transition.Extended (TRC (TRC), applySTS)
@@ -24,6 +26,7 @@ import Control.State.Transition.Trace
     sourceSignalTargets,
   )
 import Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
+import qualified Data.ByteString.Base16.Lazy as Base16
 import Data.Foldable (foldl')
 import Data.Proxy
 import qualified Data.Set as Set
@@ -43,6 +46,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
+import Test.Shelley.Spec.Ledger.SerializationProperties (prop_roundtrip_NewEpochState)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, runShelleyBase, testGlobals)
 
 ------------------------------
@@ -143,6 +147,27 @@ adaPreservationChain =
                   . chainNes
                   $ target
               )
+
+-- | Verify that the New Epoch state has no serialization failures.
+-- This is particularly useful for detecting negative Coin value.
+canRoundTripNewEpochState :: Property
+canRoundTripNewEpochState =
+  forAllChainTrace $ \tr ->
+    conjoin $
+      map serialization $
+        sourceSignalTargets tr
+  where
+    serialization SourceSignalTarget {target} =
+      let nes = chainNes target
+       in counterexample
+            ( mconcat
+                [ "target\n",
+                  show target,
+                  "base16 encoding\n",
+                  show . Base16.encode . serialize $ nes
+                ]
+            )
+            $ prop_roundtrip_NewEpochState nes
 
 ----------------------------------------------------------------------
 -- Properties for PoolReap (using the CHAIN Trace) --


### PR DESCRIPTION
I added a new property test that checks round trip serialization of the `NewEpochState` for an arbitrary chain trace. The hope was to figure out what was happening with https://github.com/input-output-hk/cardano-node/issues/1312, but I have not seen any failures yet.