### PR TITLE
Fix POOLREAP in the case of multiple pools sharing a reward account

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -72,7 +72,7 @@ poolReapTransition = do
       pr = Map.fromList $ fmap (\kh -> (kh, _poolDeposit pp)) (Set.toList retired)
       rewardAcnts = Map.map _poolRAcnt $ retired ◁ (_pParams ps)
       rewardAcnts' =
-        Map.fromList
+        Map.fromListWith (+)
           . Map.elems
           $ Map.intersectionWith (,) rewardAcnts pr
       (refunds, mRefunds) =


### PR DESCRIPTION
This fixes another cause of `UnexpectedDepositPot` failures...

In the POOLREAP rule we were doing a `Map.fromList` on a list of tuples like so:

`[(rewardAccount1, rewardAmt), (rewardAccount2, rewardAmt), ...]`

but in the case of multiple pools sharing a reward account, this would lose ADA! 
We need a `Map.fromListWith (+)` instead.

