### PR TITLE
Improve Coin type

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -6,6 +6,8 @@
 module Shelley.Spec.Ledger.Coin
   ( Coin (..),
     splitCoin,
+    coinToRational,
+    rationalToCoinViaFloor,
   )
 where
 
@@ -23,8 +25,6 @@ newtype Coin = Coin Integer
       Eq,
       Ord,
       Num,
-      Integral,
-      Real,
       Enum,
       NoUnexpectedThunks,
       Generic,
@@ -32,6 +32,12 @@ newtype Coin = Coin Integer
       FromJSON,
       NFData
     )
+
+coinToRational :: Coin -> Rational
+coinToRational (Coin c) = fromIntegral c
+
+rationalToCoinViaFloor :: Rational -> Coin
+rationalToCoinViaFloor r = Coin . floor $ r
 
 instance ToCBOR Coin where
   toCBOR (Coin c) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -5,6 +5,7 @@
 
 module Shelley.Spec.Ledger.Coin
   ( Coin (..),
+    word64ToCoin,
     splitCoin,
     coinToRational,
     rationalToCoinViaFloor,
@@ -33,24 +34,30 @@ newtype Coin = Coin Integer
       NFData
     )
 
+word64ToCoin :: Word64 -> Coin
+word64ToCoin w = Coin $ fromIntegral w
+
 coinToRational :: Coin -> Rational
 coinToRational (Coin c) = fromIntegral c
 
 rationalToCoinViaFloor :: Rational -> Coin
 rationalToCoinViaFloor r = Coin . floor $ r
 
+isValidCoinValue :: Integer -> Bool
+isValidCoinValue c = 0 <= c && c <= (fromIntegral (maxBound :: Word64))
+
 instance ToCBOR Coin where
   toCBOR (Coin c) =
-    if c >= 0
+    if isValidCoinValue c
       then toCBOR (fromInteger c :: Word64)
       else toCBOR c
 
 instance FromCBOR Coin where
   fromCBOR = do
     c <- fromCBOR
-    if c >= 0
+    if isValidCoinValue c
       then pure (Coin c)
-      else cborError $ DecoderErrorCustom "Negative Coin" (pack $ show c)
+      else cborError $ DecoderErrorCustom "Invalid Coin Value" (pack $ show c)
 
 splitCoin :: Coin -> Integer -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -40,7 +40,7 @@ import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.Address (Addr (..))
-import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Coin (Coin (..), coinToRational, rationalToCoinViaFloor)
 import Shelley.Spec.Ledger.Core (dom, (▷), (◁))
 import Shelley.Spec.Ledger.Credential (Credential, Ptr, StakeReference (..))
 import Shelley.Spec.Ledger.Crypto
@@ -143,14 +143,14 @@ obligation pp (StakeCreds stakeKeys) (StakePools stakePools) =
 
 -- | Calculate maximal pool reward
 maxPool :: PParams -> Coin -> Rational -> Rational -> Coin
-maxPool pc (Coin r) sigma pR = floor $ factor1 * factor2
+maxPool pc r sigma pR = rationalToCoinViaFloor $ factor1 * factor2
   where
     a0 = _a0 pc
     nOpt = _nOpt pc
     z0 = 1 % fromIntegral nOpt
     sigma' = min sigma z0
     p' = min pR z0
-    factor1 = fromIntegral r / (1 + a0)
+    factor1 = coinToRational r / (1 + a0)
     factor2 = sigma' + p' * a0 * factor3
     factor3 = (sigma' - p' * factor4) / z0
     factor4 = (z0 - sigma') / z0

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -243,7 +243,7 @@ utxoInductive = do
   ppup' <- trans @(PPUP crypto) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
   let outputCoins = [c | (TxOut _ c) <- Set.toList (range (txouts txb))]
-  let minUTxOValue = fromIntegral $ _minUTxOValue pp
+  let minUTxOValue = _minUTxOValue pp
   all (minUTxOValue <=) outputCoins
     ?! OutputTooSmallUTxO
       (filter (\(TxOut _ c) -> c < minUTxOValue) (Set.toList (range (txouts txb))))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -1661,10 +1661,10 @@ alicePerfEx2H p = likelihood blocks t slotsPerEpoch
       epochInfoSize ei 0
     blocks = 1
     t = leaderProbability f relativeStake (_d ppsEx1)
-    stake = aliceCoinEx2BBase + aliceCoinEx2BPtr + bobInitCoin
+    (Coin stake) = aliceCoinEx2BBase + aliceCoinEx2BPtr + bobInitCoin
     reserves = _reserves (acntEx2G p)
-    relativeStake =
-      fromRational (fromIntegral stake % (fromIntegral $ maxLLSupply - reserves))
+    (Coin tot) = maxLLSupply - reserves
+    relativeStake = fromRational (stake % tot)
     f = runShelleyBase (asks activeSlotCoeff)
 
 deltaT2H :: Coin
@@ -2057,9 +2057,9 @@ alicePerfEx2K p = (alicePerfEx2H p) <> epoch4Likelihood
       epochInfoSize ei 0
     blocks = 0
     t = leaderProbability f relativeStake (_d ppsEx1)
-    stake = sum . unStake . _stake . _pstakeSet $ (snapsEx2I p) -- everyone has delegated to Alice's Pool
-    relativeStake = fromRational (fromIntegral stake % (fromIntegral $ supply))
-    supply = maxLLSupply - _reserves (acntEx2I p)
+    (Coin stake) = sum . unStake . _stake . _pstakeSet $ (snapsEx2I p) -- everyone has delegated to Alice's Pool
+    relativeStake = fromRational (stake % supply)
+    (Coin supply) = maxLLSupply - _reserves (acntEx2I p)
     f = runShelleyBase (asks activeSlotCoeff)
 
 nonMyopicEx2K :: forall h. HashAlgorithm h => NonMyopic h


### PR DESCRIPTION
This PR addresses the concerns about the `Coin` type listed in #1475.

I have:
* removed the `Integral` and `Real` instances in place of a new `rationalToCoinViaFloor` function,
* added a `word64ToCoin` convenience function,
* made it impossible to deserialize a `Coin` value above `maxBound :: Word64`.

This addresses #1475 as follows:

* Question: Why does it have Real and what happens with float rounding?
Answer: `Integral` was needed because we sometimes need to call `floor` on a rational to obtain a `Coin`. And `Real` is required by `Integral`. I have removed `Integral` and `Real`, and added a new function `rationalToCoinViaFloor`.
* Question: Why does it have Num and what happens when + or * overflows maxLovelace or - goes negative?
Answer: Since `Coin` is a newtype around `Integer`, these operations are all total and give the expected results. It is a property of the system that we cannot create negative valued UTxO, or values above  `maxLovelace`. As such, we only allow the de-serialization of `Coin` values between 0 and `maxBound :: Word64`. We have chosen `maxBound :: Word64` over `maxLovelace` since it is more future proof (ie not tied to the current monetary policy) and more natural. We do, however, allow the serialization of `Coin` values outside of this range, since we want to be able to report bugs un-obscured.
* Question: Why are we newtype wrapping Integer and not Word64 ?
Answer: The answer above applies to this question as well, namely that `Integer` is always correct and would give us better errors in the case of a bug.
* Question: Why do we not provide functions for addition/subtraction etc which check for over/underflow?
Answer: `Integer` does not have these problems.