### PR TITLE
Correct text on how pledge is enforced.

### DIFF
--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -2313,7 +2313,7 @@ an adversarial stake pool operator could circumvent the Sybil protection
 of the pledge mechanism, by pledging stake to a pool until it attracted stake,
 and then simply pledging the stake to the next pool. The pledge will be
 enforced during the reward calculation: pools where the owners do not meet the
-pledge in a given epoch will earn no rewards for that epoch.
+pledge in a given epoch will earn no rewards for that epoch. Note that this affects \emph{all} pool rewards, both for the operator and for pool members.
 
 Note that it will still be possible for a stake pool operator to decrease the
 amount of stake that they pledge to the pool, but this will require them to post

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -12,8 +12,8 @@
    \\[1em]
    Duncan Coutts  \quad \texttt{<duncan.coutts@iohk.io>}
 }
-\DueDate{16$^{\textrm{th}}$ June 2020}
-\SubmissionDate{16$^{\textrm{th}}$ June 2020}{2020/06/15}
+\DueDate{06$^{\textrm{th}}$ July 2020}
+\SubmissionDate{06$^{\textrm{th}}$ July 2020}{2020/07/06}
 \LeaderName{Philipp Kant, \IOHK}
 \InstitutionAddress{\IOHK}
 \Version{1.20}
@@ -181,6 +181,9 @@ First version officially published on the IOHK blog.}
   addresses, credentials.}
 \change{2020-06-15}{PK}{FM (IOHK)}{Ensure consistent wording, after the change
   in terminology in the last edit.}
+\change{2020-07-06}{PK}{FM (IOHK)}{Correct sentence about enforcing pledge, to
+  be consistent with implementation; pools do not receive rewards, but can still
+  create blocks when they fafil to meet their pledge.}
 \end{changelog}
 
 \clearpage%
@@ -2309,11 +2312,8 @@ pledged is registered in the certificate: otherwise,
 an adversarial stake pool operator could circumvent the Sybil protection
 of the pledge mechanism, by pledging stake to a pool until it attracted stake,
 and then simply pledging the stake to the next pool. The pledge will be
-enforced at the point of leader election; stake pools that do not
-honour their pledge (i.e., pools where the amount of stake delegated
-to the pool from the set of owner stake addresses is less than the pledge listed
-in its stake pool registration certificate) will be excluded from the election,
-and as a consequence forfeit their rewards for that epoch.
+enforced during the reward calculation: pools where the owners do not meet the
+pledge in a given epoch will earn no rewards for that epoch.
 
 Note that it will still be possible for a stake pool operator to decrease the
 amount of stake that they pledge to the pool, but this will require them to post


### PR DESCRIPTION
Small PR, where the design spec was lagging behind on decisions we had made during the implementation.

Pools that do not meet their pledge can still produce blocks, but get no rewards.