### PR TITLE
Fix typo in the description of the previous hash

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -155,7 +155,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
     \BHBody =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{prev} & \HashHeader^? & \text{hash of previous block body}\\
+        \var{prev} & \HashHeader^? & \text{hash of previous block header}\\
         \var{vk} & \VKey & \text{block issuer}\\
         \var{vrfVk} & \VKey & \text{VRF verification key}\\
         \var{slot} & \Slot & \text{block slot}\\


### PR DESCRIPTION
:microscope: micro PR:

the description in the formal spec of the previous hash has been changed from the incorrect "hash of previous block body" to the correct "hash of previous block header".