### PR TITLE
helper functions to get pool id from block headers

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -21,6 +21,7 @@ module Shelley.Spec.Ledger.BlockChain
     LastAppliedBlock (..),
     lastAppliedHash,
     BHBody (..),
+    poolIDfromBHBody,
     BHeader (BHeader),
     Block (Block),
     LaxBlock (..),
@@ -123,6 +124,7 @@ import Shelley.Spec.Ledger.Keys
     decodeVerKeyVRF,
     encodeSignedKES,
     encodeVerKeyVRF,
+    hashKey,
   )
 import Shelley.Spec.Ledger.OCert (OCert (..))
 import Shelley.Spec.Ledger.PParams (ProtVer (..))
@@ -469,6 +471,11 @@ instance
           bheaderOCert,
           bprotver
         }
+
+-- | Retrieve the pool id (the hash of the pool operator's cold key)
+-- from the body of the block header.
+poolIDfromBHBody :: Crypto crypto => BHBody crypto -> KeyHash 'BlockIssuer crypto
+poolIDfromBHBody = hashKey . bheaderVk
 
 data Block crypto
   = Block' !(BHeader crypto) !(TxSeq crypto) LByteString

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -41,11 +41,12 @@ import Shelley.Spec.Ledger.BlockChain
     bbHash,
     hBbsize,
     incrBlocks,
+    poolIDfromBHBody,
   )
 import Shelley.Spec.Ledger.Core ((∈))
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
-import Shelley.Spec.Ledger.Keys (DSignable, Hash, coerceKeyRole, hashKey)
+import Shelley.Spec.Ledger.Keys (DSignable, Hash, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState (AccountState, LedgerState)
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
@@ -111,8 +112,7 @@ bbodyTransition =
                Block (BHeader bhb _) txsSeq
                )
            ) -> do
-        let hk = hashKey $ bheaderVk bhb
-            TxSeq txs = txsSeq
+        let TxSeq txs = txsSeq
             actualBodySize = bBodySize txsSeq
             actualBodyHash = bbHash txsSeq
 
@@ -128,7 +128,7 @@ bbodyTransition =
         -- Note that this may not actually be a stake pool - it could be a genesis key
         -- delegate. However, this would only entail an overhead of 7 counts, and it's
         -- easier than differentiating here.
-        let hkAsStakePool = coerceKeyRole hk
+        let hkAsStakePool = coerceKeyRole . poolIDfromBHBody $ bhb
         pure $ BbodyState ls' (incrBlocks (bheaderSlotNo bhb ∈ oslots) hkAsStakePool b)
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -43,6 +43,7 @@ import Shelley.Spec.Ledger.BlockChain
     BHeader (..),
     checkLeaderValue,
     mkSeed,
+    poolIDfromBHBody,
     seedEta,
     seedL,
   )
@@ -197,7 +198,7 @@ praosVrfChecks eta0 (PoolDistr pd) f bhb = do
         (throwError $ VRFLeaderValueTooBig (VRF.certifiedOutput $ bheaderL bhb) sigma f)
       pure ()
   where
-    hk = coerceKeyRole . hashKey $ bheaderVk bhb
+    hk = coerceKeyRole . poolIDfromBHBody $ bhb
     vrfK = bheaderVrfVk bhb
 
 pbftVrfChecks ::
@@ -217,7 +218,7 @@ pbftVrfChecks vrfHK eta0 bhb = do
   vrfChecks eta0 bhb
   pure ()
   where
-    hk = coerceKeyRole . hashKey $ bheaderVk bhb
+    hk = poolIDfromBHBody bhb
     vrfK = bheaderVrfVk bhb
 
 overlayTransition ::


### PR DESCRIPTION
Two new helper functions: `poolIDfromBHBody` and `poolIDfromBHeader`, to get the pool ID (the hash of the pool operator's cold key) from the blocker header body and the block header.