### PR TITLE
unclaimed rewards in update go to treasury

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -937,8 +937,8 @@ applyRUpd ru (EpochState as ss ls pr pp _nm) = EpochState as' ss ls' pr pp nm'
         (rs ru)
     as' =
       as
-        { _treasury = _treasury as + deltaT ru,
-          _reserves = _reserves as + deltaR ru + sum (range unregRU)
+        { _treasury = _treasury as + deltaT ru + sum (range unregRU),
+          _reserves = _reserves as + deltaR ru
         }
     ls' =
       ls

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1384,8 +1384,8 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
       =
       \left(
         \begin{array}{c}
-          \varUpdate{\var{treasury} + \Delta t}\\
-          \varUpdate{\var{reserves} + \Delta r+ \var{unregRU'}}\\
+          \varUpdate{\var{treasury} + \Delta t + \var{unregRU'}}\\
+          \varUpdate{\var{reserves} + \Delta r}\\
           ~ \\
           \var{\var{stkCreds}} \\
           \varUpdate{\var{rewards}\unionoverridePlus\var{regRU}} \\


### PR DESCRIPTION
This make the unclaimed rewards in a reward update go to treasury instead of the reserves.

closes #1636 