### PR TITLE
Use the correct nonce!

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -322,4 +322,4 @@ updateChainDepState
               csProtocol,
               bh
             )
-      STS.Tickn.TicknState epochNonce _ = csTickn
+      epochNonce = STS.Tickn.ticknStateEpochNonce csTickn

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -322,4 +322,4 @@ updateChainDepState
               csProtocol,
               bh
             )
-      STS.Tickn.TicknState _ epochNonce = csTickn
+      STS.Tickn.TicknState epochNonce _ = csTickn

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
@@ -31,7 +31,10 @@ data TicknEnv = TicknEnv
     ticknEnvHashHeaderNonce :: Nonce
   }
 
-data TicknState = TicknState !Nonce !Nonce
+data TicknState = TicknState
+  { ticknStateEpochNonce :: !Nonce,
+    ticknStatePrevHashNonce :: !Nonce
+  }
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks TicknState
@@ -82,6 +85,7 @@ tickTransition = do
     if newEpoch
       then
         TicknState
-          (ηc ⭒ ηh ⭒ _extraEntropy pp)
-          ηph
+          { ticknStateEpochNonce = (ηc ⭒ ηh ⭒ _extraEntropy pp),
+            ticknStatePrevHashNonce = ηph
+          }
       else st


### PR DESCRIPTION
Spotted this while looking at another issue, it seems we were using the "previous epoch hash header" nonce as the epoch nonce, which would skip most of the randomness...