### PR TITLE
spec typos: POOLREAP to update fPoolParams, and change variable name kh to hk

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -70,7 +70,7 @@ poolReapTransition = do
 
   let retired = dom $ (_retiring ps) ▷ Set.singleton e
       StakePools stpools = _stPools ps
-      pr = Map.fromList $ fmap (\kh -> (kh, _poolDeposit pp)) (Set.toList retired)
+      pr = Map.fromList $ fmap (\hk -> (hk, _poolDeposit pp)) (Set.toList retired)
       rewardAcnts = Map.map _poolRAcnt $ retired ◁ (_pParams ps)
       rewardAcnts' =
         Map.fromListWith (+)

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -796,7 +796,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       & \var{pool} \leteq \poolParam{c}
       \\
       hk \notin \dom \var{stpools}
-      & \fun{poolCost}~\var{pool}\leq\fun{minPoolCost}~\var{pp}
+      & \fun{poolCost}~\var{pool}\geq\fun{minPoolCost}~\var{pp}
     }
     {
       \begin{array}{r}
@@ -834,7 +834,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       & \var{pool} \leteq \poolParam{c}
       \\
       hk \in \dom \var{stpools}
-      & \fun{poolCost}~\var{pool}\leq\fun{minPoolCost}~\var{pp}
+      & \fun{poolCost}~\var{pool}\geq\fun{minPoolCost}~\var{pp}
     }
     {
       \begin{array}{r}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -450,9 +450,9 @@ This transition has no preconditions and results in the following state change:
       \begin{array}{r@{~\leteq~}l}
         \var{retired} & \dom{(\var{retiring}^{-1}~\var{e})} \\
         \var{pr} & \left\{
-                   \var{kh}\mapsto(\fun{poolDeposit}~\var{pp})
+                   \var{hk}\mapsto(\fun{poolDeposit}~\var{pp})
                      \mid
-                     \var{kh}\in\var{retired}
+                     \var{hk}\in\var{retired}
                    \right\}\\
         \var{rewardAcnts}
                  & \{\var{hk}\mapsto \fun{poolRAcnt}~\var{pool} \mid
@@ -495,6 +495,7 @@ This transition has no preconditions and results in the following state change:
           ~ \\
           \var{stpools} \\
           \var{poolParams} \\
+          \var{fPoolParams} \\
           \var{retiring} \\
         \end{array}
       \right)
@@ -521,6 +522,7 @@ This transition has no preconditions and results in the following state change:
           ~ \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{fPoolParams}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
         \end{array}
       \right)


### PR DESCRIPTION
* The formal spec did not remove the retiring pools from the `fPoolParams` mapping in the `POOLREAP` rule. It was, however, correct in the implementation.

* In the spec and in the implementation, there was a variable `kh` in `POOLREAP` that should have been named `hk` to be consistent with the rest of the spec.

* In the `POOL` transition, the formal spec had backward inequality (but the implementation was correct). The pool cost should be at least as big an the minimum cost.

closes #1654 
closes #1656