### PR TITLE
Re-enable coverage check for Updates in Trace classifier

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -63,7 +63,7 @@ import Shelley.Spec.Ledger.STS.Ocert (pattern OCertEnv)
 import Shelley.Spec.Ledger.STS.Tick (TickEnv (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Test.QuickCheck (Gen)
-import qualified Test.QuickCheck as QC (choose, discard, shuffle)
+import qualified Test.QuickCheck as QC (choose, shuffle)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( Block,
     ChainState,
@@ -196,7 +196,7 @@ genBlock
         nes' = runShelleyBase $ applySTSTest @(TICK h) $ TRC (TickEnv (getGKeys nes), nes, nextSlot)
 
     case nes' of
-      Left _ -> QC.discard
+      Left pf -> error ("genBlock TICK rule failed - " <> show pf)
       Right _nes' -> do
         let NewEpochState _ _ _ es _ _ _ = _nes'
             EpochState acnt _ ls _ pp' _ = es

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -212,14 +212,11 @@ relevantCasesAreCoveredForTrace tr = do
             0.1 < withdrawalRatio txs,
             60
           ),
-          -- TODO @uroboros Restore Updates to generated transactions and restore this coverage requirement 60%.
-          -- see https://github.com/input-output-hk/cardano-ledger-specs/issues/1582
-          ( "at least 2% of transactions have non-trivial protocol param updates",
-            0.98 > noPPUpdateRatio (ppUpdatesByTx txs),
-            0
+          ( "at least 5% of transactions have non-trivial protocol param updates",
+            0.95 > noPPUpdateRatio (ppUpdatesByTx txs),
+            60
           ),
-          -- TODO @uroboros increase the occurence (and coverage requirement) of epoch transitions in chain traces
-          ( "at least 2 epoch changes in trace",
+          ( "at least 2 epoch changes in trace, 10% of the time",
             2 <= epochBoundariesInTrace bs,
             10
           )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
@@ -35,11 +35,6 @@ shrinkTx ::
 shrinkTx (Tx _b _ws _md) =
   [Tx b' _ws _md | b' <- shrinkTxBody _b]
 
-{- TODO @uroboros write shrinker that shrinks to valid transactions
-[ Tx b ws' wm | ws' <- shrinkSet shrinkWitVKey ws ] ++
-[ Tx b ws wm' | wm' <- shrinkMap shrinkScriptHash shrinkMultiSig wm ]
--}
-
 shrinkTxBody :: Crypto crypto => TxBody crypto -> [TxBody crypto]
 shrinkTxBody (TxBody is os cs ws tf tl tu md) =
   -- shrinking inputs is probably not very beneficial


### PR DESCRIPTION
After re-introducing generation of Updates in #1582 - this PR

* re-enables coverage check for Updates in Trace Generator
* in an aside, during Block generation, fail hard with an error (as opposed to Gen.discard) if the TICK rule fails
