### PR TITLE
Limit the size of attributes in new Byron addresses.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -264,11 +264,10 @@ utxoInductive = do
   -- process Protocol Parameter Update Proposals
   ppup' <- trans @(PPUP crypto) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
-  let outputCoins = [c | (TxOut _ c) <- Set.toList (eval (rng (txouts txb)))]
-  let minUTxOValue = _minUTxOValue pp
-  all (minUTxOValue <=) outputCoins
-    ?! OutputTooSmallUTxO
-      (filter (\(TxOut _ c) -> c < minUTxOValue) (Set.toList (eval (rng (txouts txb)))))
+  let outputs = Set.toList (eval (rng (txouts txb)))
+      minUTxOValue = _minUTxOValue pp
+      outputsTooSmall = [out | out@(TxOut _ c) <- outputs, c < minUTxOValue]
+  null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
 
   let maxTxSize_ = fromIntegral (_maxTxSize pp)
       txSize_ = txsize tx


### PR DESCRIPTION
 Check Byron address attributes are not too big or we'll have the
same old problem as in the Byron era.

This is now a stricter limit 64 vs 128, and only applied for new txs
for their tx outputs, not in the witnesses. It does not affect any
addresses brought over from the Byron era.

We calculate the size based on both the variable-sized known attributes
and the variable-sized unknown attributes. You get a free pass on the
fixed-size known attrs.

The limit of 64 is adequate for the known existing uses by legacy
wallets, which should have attributes of around 32 bytes at most.

