### PR TITLE
Changed the _ptrs field of DState to a BiMap. 

### DIFF
--- a/semantics/executable-spec/small-steps.cabal
+++ b/semantics/executable-spec/small-steps.cabal
@@ -42,6 +42,8 @@ library
                      -- IOHK deps
                      , cardano-crypto-class
                      , cardano-prelude
+                     , cardano-binary
+                     , cborg
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:        -Wall

--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
@@ -3,7 +3,7 @@ module Control.Iterate.SetAlgebra
   (-- In addition to Data.Map.Map and Data.Set.Set, the following new types can be used in the set algegra
    List,        -- A list type whose constructor is hidden (sorted [(key,value)] pairs, with no duplicate keys).
                 -- Use 'fromList' to constuct concrete values
-   BiMap,       -- Maps for Bijections. Use 'biMapFromList' and 'biMapEmpty' toconstruct concrete values.
+   BiMap,Bimap, -- Maps for Bijections. Use 'biMapFromList' and 'biMapEmpty' toconstruct concrete values.
    Single(..),  -- Sets with a single pair. Visible constructors 'Singleton', 'SetSingleton', and 'Fail'.
 
    -- Classes supporting abstract constructors of Set Algebra Expressions. These show up in the types of overloaded functions.
@@ -24,11 +24,17 @@ module Control.Iterate.SetAlgebra
    eval,
 
    -- Functions to build concrete Set-like things useable as Set Algebra Expressions
-   materialize, biMapFromList, biMapEmpty, fromList, keysEqual,
+   materialize, biMapFromList, biMapEmpty, fromList, keysEqual, forwards, backwards
 
   )
 where
 
 
-
+import Data.Map(Map)
 import Control.Iterate.SetAlgebraInternal
+
+forwards :: BiMap v k v -> Map k v
+forwards (MkBiMap l _r) = l
+
+backwards :: BiMap v k v -> Map v k
+backwards (MkBiMap _l r) = r

--- a/shelley/chain-and-ledger/executable-spec/bench/Main.hs
+++ b/shelley/chain-and-ledger/executable-spec/bench/Main.hs
@@ -159,10 +159,8 @@ main :: IO ()
 main =
   defaultMain $
     [ bgroup "vary input size" $
-        [ -- varyInput "deregister key" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
-          -- The above quuery is too slow to run at the given size. It needs a change in data structure (to a BiMap) so that
-          -- range restriction has a big O better than O(n * log n) To be done in a follow on PR.
-          varyInput "register key" (20001, 20501) [(1, 20), (1, 200), (1, 2000)] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
+        [ varyInput "deregister key" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
+          varyInput "register key" (20001, 25001) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
           varyInput "withdrawal" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerRewardWithdrawals,
           varyInput "register pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerRegisterStakePools,
           varyInput "reregister pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerReRegisterStakePools,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -103,7 +103,7 @@ import Cardano.Binary
   )
 import Cardano.Crypto.Hash (hashWithSerialiser)
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
-import Control.Iterate.SetAlgebra (Bimap,biMapEmpty,forwards, dom, eval, range, (∈), (∪+), (▷), (◁))
+import Control.Iterate.SetAlgebra (Bimap, biMapEmpty, dom, eval, forwards, range, (∈), (∪+), (▷), (◁))
 import Control.Monad.Trans.Reader (asks)
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Foldable (toList)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -103,7 +103,7 @@ import Cardano.Binary
   )
 import Cardano.Crypto.Hash (hashWithSerialiser)
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
-import Control.Iterate.SetAlgebra (dom, eval, range, (∈), (∪+), (▷), (◁))
+import Control.Iterate.SetAlgebra (Bimap,biMapEmpty,forwards, dom, eval, range, (∈), (∪+), (▷), (◁))
 import Control.Monad.Trans.Reader (asks)
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Foldable (toList)
@@ -285,7 +285,7 @@ data DState crypto = DState
     -- | The current delegations.
     _delegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)),
     -- | The pointed to hash keys.
-    _ptrs :: !(Map Ptr (Credential 'Staking crypto)),
+    _ptrs :: !(Bimap Ptr (Credential 'Staking crypto)),
     -- | future genesis key delegations
     _fGenDelegs :: !(Map (FutureGenDeleg crypto) (GenDelegPair crypto)),
     -- | Genesis key delegations
@@ -491,7 +491,7 @@ emptyDState =
     (StakeCreds Map.empty)
     Map.empty
     Map.empty
-    Map.empty
+    biMapEmpty
     Map.empty
     (GenDelegs Map.empty)
     emptyInstantaneousRewards
@@ -939,7 +939,7 @@ stakeDistr u ds ps =
     PState (StakePools stpools) poolParams _ _ = ps
     outs = aggregateOuts u
     stakeRelation :: [(Credential 'Staking crypto, Coin)] -- We compute Lists (not Maps) because the duplicate tuples matter, later when we use: Map.fromListWith (+)
-    stakeRelation = (baseStake outs ++ ptrStake outs ptrs' ++ rewardStake rewards')
+    stakeRelation = (baseStake outs ++ ptrStake outs (forwards ptrs') ++ rewardStake rewards')
     activeDelegs :: Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)
     activeDelegs = eval ((dom stkcreds ◁ delegs) ▷ dom stpools)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -253,7 +253,7 @@ delegationTransition = do
           { _stkCreds = eval (setSingleton hk ⋪ _stkCreds ds),
             _rewards = eval (setSingleton (RewardAcnt network hk) ⋪ _rewards ds),
             _delegations = eval (setSingleton hk ⋪ _delegations ds),
-            _ptrs = eval (_ptrs ds ⋫ Set.singleton hk)
+            _ptrs = eval (_ptrs ds ⋫ setSingleton hk)
             -- TODO make _ptrs a bijection. This operation takes time proportional to (_ptrs ds)
             -- OR turn _stkCreds into a mapping of stake credentials to pointers
             -- note that the slot values in _stkCreds is no longer needed (no decay)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -107,8 +107,8 @@ import Cardano.Crypto.ProtocolMagic
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Prelude (asks)
 import Cardano.Slotting.Slot (EpochSize (..), WithOrigin (..))
+import Control.Iterate.SetAlgebra (biMapFromList)
 import Control.State.Transition.Extended hiding (Assertion)
-import Control.Iterate.SetAlgebra(biMapFromList)
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Coerce (coerce)
 import Data.List (foldl')
@@ -834,7 +834,8 @@ dsEx2A :: HashAlgorithm h => DState h
 dsEx2A =
   dsEx1
     { _ptrs =
-        biMapFromList (\ l _r -> l)
+        biMapFromList
+          (\l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 1, bobSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
@@ -1904,7 +1905,8 @@ dsEx2J :: HashAlgorithm h => DState h
 dsEx2J =
   dsEx1
     { _ptrs =
-        biMapFromList (\ l _r -> l)
+        biMapFromList
+          (\l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],
@@ -2172,7 +2174,8 @@ dsEx2L :: HashAlgorithm h => DState h
 dsEx2L =
   dsEx1
     { _ptrs =
-        biMapFromList (\ l _r -> l)
+        biMapFromList
+          (\l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -108,6 +108,7 @@ import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Prelude (asks)
 import Cardano.Slotting.Slot (EpochSize (..), WithOrigin (..))
 import Control.State.Transition.Extended hiding (Assertion)
+import Control.Iterate.SetAlgebra(biMapFromList)
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Coerce (coerce)
 import Data.List (foldl')
@@ -833,7 +834,7 @@ dsEx2A :: HashAlgorithm h => DState h
 dsEx2A =
   dsEx1
     { _ptrs =
-        Map.fromList
+        biMapFromList (\ l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 1, bobSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
@@ -1903,7 +1904,7 @@ dsEx2J :: HashAlgorithm h => DState h
 dsEx2J =
   dsEx1
     { _ptrs =
-        Map.fromList
+        biMapFromList (\ l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],
@@ -2171,7 +2172,7 @@ dsEx2L :: HashAlgorithm h => DState h
 dsEx2L =
   dsEx1
     { _ptrs =
-        Map.fromList
+        biMapFromList (\ l _r -> l)
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -13,7 +13,7 @@ module Test.Shelley.Spec.Ledger.Generator.Utxo
 where
 
 import Cardano.Crypto.Hash (HashAlgorithm)
-import Control.Iterate.SetAlgebra(forwards)
+import Control.Iterate.SetAlgebra (forwards)
 import qualified Data.Either as Either (lefts, rights)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
@@ -481,7 +481,7 @@ genRecipients len keys scripts = do
 
 genPtrAddrs :: HasCallStack => DState h -> [Addr h] -> Gen [Addr h]
 genPtrAddrs ds addrs = do
-  let pointers = forwards( _ptrs ds )
+  let pointers = forwards (_ptrs ds)
 
   n <- QC.choose (0, min (Map.size pointers) (length addrs))
   pointerList <- take n <$> QC.shuffle (Map.keys pointers)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -13,6 +13,7 @@ module Test.Shelley.Spec.Ledger.Generator.Utxo
 where
 
 import Cardano.Crypto.Hash (HashAlgorithm)
+import Control.Iterate.SetAlgebra(forwards)
 import qualified Data.Either as Either (lefts, rights)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
@@ -480,7 +481,7 @@ genRecipients len keys scripts = do
 
 genPtrAddrs :: HasCallStack => DState h -> [Addr h] -> Gen [Addr h]
 genPtrAddrs ds addrs = do
-  let pointers = _ptrs ds
+  let pointers = forwards( _ptrs ds )
 
   n <- QC.choose (0, min (Map.size pointers) (length addrs))
   pointerList <- take n <$> QC.shuffle (Map.keys pointers)


### PR DESCRIPTION
When deregistering a key we have to range exclude the key.
This takes time O(_ptrs). By making _ptrs a BiMap it takes time O(log _ptrs). So if we deregister many
keys this can speed things up quite a Bit. 

We had to add ToCBOR, FromCBOR, NFData, NoUnExpectedThunks
instances for BiMap. We also adjusted the use of the _ptrs fields in 2 ledger files and 2 test files.
It is interesting in that the line that did the range exclude did not have to change. The type specific
implementation in the Set Algebra for range exclude automatically picked the most efficient implementation.