### PR TITLE
Cabal flag to turn on assertions.

### DIFF
--- a/semantics/executable-spec/small-steps.cabal
+++ b/semantics/executable-spec/small-steps.cabal
@@ -21,6 +21,11 @@ flag development
     default: False
     manual: True
 
+flag sts_assert
+    description: Enable STS assertions by default
+    default: False
+    manual: True
+
 library
   exposed-modules:     Control.State.Transition
                      , Control.State.Transition.Extended
@@ -53,6 +58,8 @@ library
                       -Wredundant-constraints
   if (!flag(development))
     ghc-options:      -Werror
+  if (flag(sts_assert))
+    cpp-options:      -DSTS_ASSERT
 
 test-suite doctests
   hs-source-dirs:      test


### PR DESCRIPTION
By default, STS assertions are turned on in tests and off in production.
One can enable them manually, but this also allows this default to be
controlled by a cabal flag.

Setting the `sts_assert` flag on the small-steps package will turn on
assertions for production code.