### PR TITLE
remove `stkcreds` and `stpools`

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -14,7 +14,6 @@ module Shelley.Spec.Ledger.Delegation.Certificates
     GenesisDelegCert (..),
     MIRCert (..),
     StakeCreds (..),
-    StakePools (..),
     PoolDistr (..),
     delegCWitness,
     poolCWitness,
@@ -55,7 +54,6 @@ import Shelley.Spec.Ledger.TxData
     PoolCert (..),
     PoolParams (..),
     StakeCreds (..),
-    StakePools (..),
   )
 
 -- We had to do a bit of type synonym unfolding of VRF and HASH from Shelley.Spec.Ledger.Crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -46,10 +46,6 @@ import Shelley.Spec.Ledger.Address (Addr (..))
 import Shelley.Spec.Ledger.Coin (Coin (..), coinToRational, rationalToCoinViaFloor)
 import Shelley.Spec.Ledger.Credential (Credential, Ptr, StakeReference (..))
 import Shelley.Spec.Ledger.Crypto
-import Shelley.Spec.Ledger.Delegation.Certificates
-  ( StakeCreds (..),
-    StakePools (..),
-  )
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), _a0, _nOpt)
 import Shelley.Spec.Ledger.TxData (PoolParams, TxOut (..))
@@ -138,9 +134,9 @@ poolStake hk delegs (Stake stake) =
 obligation ::
   PParams ->
   Map (Credential 'Staking crypto) Coin ->
-  StakePools crypto ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
   Coin
-obligation pp rewards (StakePools stakePools) =
+obligation pp rewards stakePools =
   (_keyDeposit pp) * (fromIntegral $ length rewards)
     + (_poolDeposit pp) * (fromIntegral $ length stakePools)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -137,11 +137,11 @@ poolStake hk delegs (Stake stake) =
 -- | Calculate total possible refunds.
 obligation ::
   PParams ->
-  StakeCreds crypto ->
+  Map (Credential 'Staking crypto) Coin ->
   StakePools crypto ->
   Coin
-obligation pp (StakeCreds stakeKeys) (StakePools stakePools) =
-  (_keyDeposit pp) * (fromIntegral $ length stakeKeys)
+obligation pp rewards (StakePools stakePools) =
+  (_keyDeposit pp) * (fromIntegral $ length rewards)
     + (_poolDeposit pp) * (fromIntegral $ length stakePools)
 
 -- | Calculate maximal pool reward

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -272,7 +272,7 @@ chainTransition =
       let NewEpochState e1 _ _ _ _ _ _ = nes
           NewEpochState e2 _ bcur es _ _pd osched = nes'
       let EpochState account _ ls _ pp' _ = es
-      let LedgerState _ (DPState (DState _ _ _ _ _genDelegs _) (PState _ _ _ _)) = ls
+      let LedgerState _ (DPState (DState _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
 
       let ph = lastAppliedHash lab
           etaPH = prevHashToNonce ph

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -272,7 +272,7 @@ chainTransition =
       let NewEpochState e1 _ _ _ _ _ _ = nes
           NewEpochState e2 _ bcur es _ _pd osched = nes'
       let EpochState account _ ls _ pp' _ = es
-      let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _ _)) = ls
+      let LedgerState _ (DPState (DState _ _ _ _ _genDelegs _) (PState _ _ _ _)) = ls
 
       let ph = lastAppliedHash lab
           etaPH = prevHashToNonce ph

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -22,7 +22,7 @@ import Cardano.Binary
     matchSize,
   )
 import Cardano.Prelude (NoUnexpectedThunks (..))
-import Control.Iterate.SetAlgebra (dom, eval, range, setSingleton, singleton, (∈), (∉), (∪), (≍), (⋪), (⋫))
+import Control.Iterate.SetAlgebra (dom, eval, range, setSingleton, singleton, (∈), (∉), (∪), (⋪), (⋫))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
 import qualified Data.Map.Strict as Map

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -58,7 +58,6 @@ import Shelley.Spec.Ledger.LedgerState
     _irwd,
     _ptrs,
     _rewards,
-    _stkCreds,
   )
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
@@ -124,15 +123,6 @@ instance Typeable crypto => STS (DELEG crypto) where
 
   initialRules = [pure emptyDState]
   transitionRules = [delegationTransition]
-
-  assertions =
-    [ PreCondition
-        "_stkCreds and _rewards must have the same domain"
-        ( \(TRC (_, st, _)) ->
-            -- eval(dom(_stkCreds st)) == (Set.map getRwdCred $ domain (_rewards st))
-            eval (dom (_stkCreds st) ≍ dom (_rewards st))
-        )
-    ]
 
 instance NoUnexpectedThunks (PredicateFailure (DELEG crypto))
 
@@ -230,36 +220,29 @@ delegationTransition = do
   case c of
     DCertDeleg (RegKey hk) -> do
       -- note that pattern match is used instead of regCred, as in the spec
-      eval (hk ∉ dom (_stkCreds ds)) ?! StakeKeyAlreadyRegisteredDELEG hk
       eval (hk ∉ dom (_rewards ds)) ?! StakeKeyInRewardsDELEG hk
 
       pure $
         ds
-          { _stkCreds = eval (_stkCreds ds ∪ (singleton hk slot)),
-            _rewards = eval (_rewards ds ∪ (singleton hk (Coin 0))),
+          { _rewards = eval (_rewards ds ∪ (singleton hk (Coin 0))),
             _ptrs = eval (_ptrs ds ∪ (singleton ptr hk))
           }
     DCertDeleg (DeRegKey hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
-      eval (hk ∈ dom (_stkCreds ds)) ?! StakeKeyNotRegisteredDELEG hk
+      eval (hk ∈ dom (_rewards ds)) ?! StakeKeyNotRegisteredDELEG hk
 
       let rewardCoin = Map.lookup hk (_rewards ds)
       rewardCoin == Just 0 ?! StakeKeyNonZeroAccountBalanceDELEG rewardCoin
 
       pure $
         ds
-          { _stkCreds = eval (setSingleton hk ⋪ _stkCreds ds),
-            _rewards = eval (setSingleton hk ⋪ _rewards ds),
+          { _rewards = eval (setSingleton hk ⋪ _rewards ds),
             _delegations = eval (setSingleton hk ⋪ _delegations ds),
             _ptrs = eval (_ptrs ds ⋫ setSingleton hk)
-            -- TODO make _ptrs a bijection. This operation takes time proportional to (_ptrs ds)
-            -- OR turn _stkCreds into a mapping of stake credentials to pointers
-            -- note that the slot values in _stkCreds is no longer needed (no decay)
-            -- then we could use (lookup hk (_delecations ds)) to get ptr, then use domain removal on (_ptrs ds) rather than range removal
           }
     DCertDeleg (Delegate (Delegation hk dpool)) -> do
       -- note that pattern match is used instead of cwitness and dpool, as in the spec
-      eval (hk ∈ dom (_stkCreds ds)) ?! StakeDelegationImpossibleDELEG hk
+      eval (hk ∈ dom (_rewards ds)) ?! StakeDelegationImpossibleDELEG hk
 
       pure $
         ds

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -42,15 +42,24 @@ import Shelley.Spec.Ledger.LedgerState
     DPState (..),
     emptyDelegation,
     _dstate,
+    _pParams,
     _rewards,
-    _stPools,
   )
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Delpl (DELPL, DelplEnv (..))
 import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..))
-import Shelley.Spec.Ledger.TxData (DCert (..), DelegCert (..), Delegation (..), Ix, Ptr (..), RewardAcnt, StakePools (..), TxBody (..), Wdrl (..))
+import Shelley.Spec.Ledger.TxData
+  ( DCert (..),
+    DelegCert (..),
+    Delegation (..),
+    Ix,
+    Ptr (..),
+    RewardAcnt,
+    TxBody (..),
+    Wdrl (..),
+  )
 
 data DELEGS crypto
 
@@ -142,7 +151,7 @@ delegsTransition = do
 
       let isDelegationRegistered = case c of
             DCertDeleg (Delegate deleg) ->
-              let StakePools stPools_ = _stPools $ _pstate dpstate'
+              let stPools_ = _pParams $ _pstate dpstate'
                   targetPool = _delegatee deleg
                in case eval (targetPool ∈ dom stPools_) of
                     True -> Right ()

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -117,7 +117,7 @@ epochTransition = do
   ss' <-
     trans @(SNAP crypto) $ TRC (ls, ss, ())
 
-  let PState _ pParams fPParams _ = pstate
+  let PState pParams fPParams _ = pstate
       ppp = eval (pParams ⨃ fPParams)
       pstate' =
         pstate

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -143,7 +143,7 @@ ledgerTransition = do
 
   let DPState dstate pstate = dpstate
       genDelegs = _genDelegs dstate
-      stpools = _stPools pstate
+      stpools = _pParams pstate
 
   utxoSt' <-
     trans @(UTXOW crypto) $

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -26,7 +26,6 @@ import Control.State.Transition
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
-import Shelley.Spec.Ledger.Delegation.Certificates (StakeCreds (..))
 import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -46,7 +46,6 @@ import Shelley.Spec.Ledger.LedgerState
     _dstate,
     _irwd,
     _rewards,
-    _stkCreds,
     pattern EpochState,
   )
 import Shelley.Spec.Ledger.PParams (emptyPParams)
@@ -95,11 +94,11 @@ mirTransition = do
     judgmentContext
   let dpState = _delegationState ls
       dState = _dstate dpState
-      StakeCreds stkcreds = _stkCreds dState
-      irwdR = eval $ (dom stkcreds) ◁ (iRReserves $ _irwd dState) :: RewardAccounts crypto
+      rewards = _rewards dState
+      irwdR = eval $ (dom rewards) ◁ (iRReserves $ _irwd dState) :: RewardAccounts crypto
       totFromReserves = sum irwdR
       reserves = _reserves acnt
-      irwdT = eval $ (dom stkcreds) ◁ (iRTreasury $ _irwd dState) :: RewardAccounts crypto
+      irwdT = eval $ (dom rewards) ◁ (iRTreasury $ _irwd dState) :: RewardAccounts crypto
       totFromTreasury = sum irwdT
       treasury = _treasury acnt
       update = (eval (irwdR ∪+ irwdT)) :: RewardAccounts crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -83,8 +83,8 @@ newPpTransition = do
 
   case ppNew of
     Just ppNew' -> do
-      let Coin oblgCurr = obligation pp (_rewards dstate) (_stPools pstate)
-          Coin oblgNew = obligation ppNew' (_rewards dstate) (_stPools pstate)
+      let Coin oblgCurr = obligation pp (_rewards dstate) (_pParams pstate)
+          Coin oblgNew = obligation ppNew' (_rewards dstate) (_pParams pstate)
           diff = oblgCurr - oblgNew
           Coin reserves = _reserves acnt
           Coin requiredInstantaneousRewards = totalInstantaneousReservesRewards (_irwd dstate)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -83,8 +83,8 @@ newPpTransition = do
 
   case ppNew of
     Just ppNew' -> do
-      let Coin oblgCurr = obligation pp (_stkCreds dstate) (_stPools pstate)
-          Coin oblgNew = obligation ppNew' (_stkCreds dstate) (_stPools pstate)
+      let Coin oblgCurr = obligation pp (_rewards dstate) (_stPools pstate)
+          Coin oblgNew = obligation ppNew' (_rewards dstate) (_stPools pstate)
           diff = oblgCurr - oblgNew
           Coin reserves = _reserves acnt
           Coin requiredInstantaneousRewards = totalInstantaneousReservesRewards (_irwd dstate)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -24,7 +24,6 @@ import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
-import Shelley.Spec.Ledger.Delegation.Certificates (StakePools (..))
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     DState (..),
@@ -69,7 +68,6 @@ poolReapTransition = do
   TRC (pp, PoolreapState us a ds ps, e) <- judgmentContext
 
   let retired = eval (dom ((_retiring ps) ▷ Set.singleton e))
-      StakePools stpools = _stPools ps
       pr = Map.fromList $ fmap (\kh -> (kh, _poolDeposit pp)) (Set.toList retired)
       rewardAcnts = Map.map _poolRAcnt $ eval (retired ◁ (_pParams ps))
       rewardAcnts' =
@@ -92,8 +90,7 @@ poolReapTransition = do
           _delegations = eval (_delegations ds ⋫ retired)
         }
       ps
-        { _stPools = StakePools $ eval (retired ⋪ stpools),
-          _pParams = eval (retired ⋪ _pParams ps),
+        { _pParams = eval (retired ⋪ _pParams ps),
           _fPParams = eval (retired ⋪ _fPParams ps),
           _retiring = eval (retired ⋪ _retiring ps)
         }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -40,6 +41,7 @@ import Control.State.Transition
     (?!),
   )
 import Data.Foldable (foldl', toList)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -55,8 +57,7 @@ import Shelley.Spec.Ledger.Address
 import Shelley.Spec.Ledger.BaseTypes (Network, ShelleyBase, invalidKey, networkId)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Crypto (Crypto)
-import Shelley.Spec.Ledger.Delegation.Certificates (StakePools)
-import Shelley.Spec.Ledger.Keys (GenDelegs)
+import Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState
   ( UTxOState (..),
     consumed,
@@ -76,7 +77,7 @@ import Shelley.Spec.Ledger.Serialization
   )
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..), TxIn, TxOut (..))
-import Shelley.Spec.Ledger.TxData (RewardAcnt, TxBody (..), unWdrl)
+import Shelley.Spec.Ledger.TxData (PoolParams, RewardAcnt, TxBody (..), unWdrl)
 import Shelley.Spec.Ledger.UTxO
   ( UTxO (..),
     balance,
@@ -92,7 +93,7 @@ data UtxoEnv crypto
   = UtxoEnv
       SlotNo
       PParams
-      (StakePools crypto)
+      (Map (KeyHash 'StakePool crypto) (PoolParams crypto))
       (GenDelegs crypto)
   deriving (Show)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -32,7 +32,6 @@ module Shelley.Spec.Ledger.TxData
     Ptr (..),
     RewardAcnt (..),
     StakeCreds (..),
-    StakePools (..),
     StakePoolRelay (..),
     TxBody
       ( TxBody,
@@ -658,13 +657,6 @@ addStakeCreds ::
   (StakeCreds crypto) ->
   StakeCreds crypto
 addStakeCreds newCred s (StakeCreds creds) = StakeCreds $ Map.insert newCred s creds
-
-newtype StakePools crypto = StakePools
-  { unStakePools :: (Map (KeyHash 'StakePool crypto) SlotNo)
-  }
-  deriving (Eq, Generic)
-  deriving (Show) via Quiet (StakePools crypto)
-  deriving newtype (FromCBOR, NFData, NoUnexpectedThunks, ToCBOR)
 
 -- CBOR
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -58,7 +58,6 @@ import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates
   ( DCert (..),
-    StakePools (..),
     isRegKey,
     requiresVKeyWitness,
   )
@@ -232,10 +231,10 @@ balance (UTxO utxo) = foldr addCoins 0 utxo
 -- registration certificates would be invalid.
 totalDeposits ::
   PParams ->
-  StakePools crypto ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
   [DCert crypto] ->
   Coin
-totalDeposits pp (StakePools stpools) cs =
+totalDeposits pp stpools cs =
   (_keyDeposit pp) * numKeys + (_poolDeposit pp) * numNewPools
   where
     numKeys = intToCoin . length $ filter isRegKey cs

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -78,8 +78,7 @@ import Shelley.Spec.Ledger.Tx
     WitnessSetHKD (..),
   )
 import Shelley.Spec.Ledger.TxData
-  ( StakePools (..),
-    TxBody (..),
+  ( TxBody (..),
     TxId (..),
     TxIn (..),
     TxOut (..),
@@ -178,7 +177,7 @@ utxoEnv =
   UtxoEnv
     0
     emptyPParams {_maxTxSize = 1000}
-    (StakePools mempty)
+    mempty
     (GenDelegs mempty)
 
 aliceInitCoin :: Coin

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -62,8 +62,6 @@ type PoolParams h = TxData.PoolParams (ConcreteCrypto h)
 
 type RewardAcnt h = TxData.RewardAcnt (ConcreteCrypto h)
 
-type StakePools h = TxData.StakePools (ConcreteCrypto h)
-
 type KeyHash h kr = Keys.KeyHash kr (ConcreteCrypto h)
 
 pattern KeyHash ::

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -122,7 +122,7 @@ import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
-import Shelley.Spec.Ledger.Address (getRwdCred, mkRwdAcnt, pattern Addr)
+import Shelley.Spec.Ledger.Address (pattern Addr)
 import Shelley.Spec.Ledger.BaseTypes
   ( Globals (..),
     Network (..),
@@ -212,7 +212,6 @@ import Shelley.Spec.Ledger.LedgerState
     _reserves,
     _retiring,
     _rewards,
-    _stPools,
     _treasury,
     pattern ActiveSlot,
     pattern DPState,
@@ -274,7 +273,6 @@ import Shelley.Spec.Ledger.TxData
     PoolMetaData (..),
     StakePoolRelay (..),
     Wdrl (..),
-    addStakeCreds,
     _poolCost,
     _poolMD,
     _poolMDHash,
@@ -293,8 +291,6 @@ import Shelley.Spec.Ledger.TxData
     pattern Delegation,
     pattern PoolParams,
     pattern RewardAcnt,
-    pattern StakeCreds,
-    pattern StakePools,
     pattern TxBody,
     pattern TxIn,
     pattern TxOut,
@@ -855,8 +851,7 @@ dsEx2A =
 psEx2A :: forall h. HashAlgorithm h => PState h
 psEx2A =
   psEx1
-    { _stPools = StakePools $ Map.singleton (hk (alicePool p)) (SlotNo 10),
-      _pParams = Map.singleton (hk (alicePool p)) alicePoolParams
+    { _pParams = Map.singleton (hk (alicePool p)) alicePoolParams
     }
   where
     p :: Proxy h

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -213,7 +213,6 @@ import Shelley.Spec.Ledger.LedgerState
     _retiring,
     _rewards,
     _stPools,
-    _stkCreds,
     _treasury,
     pattern ActiveSlot,
     pattern DPState,
@@ -836,13 +835,6 @@ dsEx2A =
             (Ptr (SlotNo 10) 0 1, bobSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],
-      _stkCreds =
-        StakeCreds $
-          Map.fromList
-            [ (aliceSHK, SlotNo 10),
-              (bobSHK, SlotNo 10),
-              (carlSHK, SlotNo 10)
-            ],
       _rewards =
         Map.fromList
           [ (aliceSHK, Coin 0),
@@ -1131,7 +1123,6 @@ expectedLSEx2C =
     ( DPState
         dsEx2B
           { _irwd = emptyInstantaneousRewards,
-            _stkCreds = addStakeCreds carlSHK (SlotNo 10) $ _stkCreds dsEx2B,
             _rewards = Map.insert (carlSHK) 110 $ _rewards dsEx2B
           }
         psEx2A
@@ -1372,7 +1363,6 @@ expectedLSEx2E =
     ( DPState
         dsEx2D
           { _irwd = emptyInstantaneousRewards,
-            _stkCreds = addStakeCreds carlSHK (SlotNo 10) $ _stkCreds dsEx2B,
             _rewards = Map.insert carlSHK 110 $ _rewards dsEx2B
           }
         psEx2A
@@ -1906,7 +1896,6 @@ dsEx2J =
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],
-      _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)],
       _delegations = Map.fromList [(aliceSHK, hk (alicePool p)), (carlSHK, hk (alicePool p))],
       _rewards = Map.fromList [(aliceSHK, aliceRAcnt2H), (carlSHK, carlMIR)]
     }
@@ -2175,7 +2164,6 @@ dsEx2L =
           [ (Ptr (SlotNo 10) 0 0, aliceSHK),
             (Ptr (SlotNo 10) 0 2, carlSHK)
           ],
-      _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)],
       _rewards =
         Map.fromList
           [ (aliceSHK, aliceRAcnt2H + Coin 250),
@@ -3320,12 +3308,8 @@ test5D p pot = do
   case ex5D' p pot of
     Left e -> assertFailure (show e)
     Right ex5DState -> do
-      let getDState = _dstate . _delegationState . esLState . nesEs . chainNes
-          ds = getDState ex5DState
-          StakeCreds stkCreds = _stkCreds ds
-          rews = _rewards ds
-          rewEntry = rews Map.!? (getRwdCred $ mkRwdAcnt Testnet aliceSHK)
-      assertBool "Alice's credential not in stkCreds" (aliceSHK `Map.member` stkCreds)
+      let rews = _rewards . _dstate . _delegationState . esLState . nesEs . chainNes $ ex5DState
+          rewEntry = rews Map.!? aliceSHK
       assertBool "Alice's reward account does not exist" $ isJust rewEntry
       assertBool "Alice's rewards are wrong" $ maybe False (== Coin 100) rewEntry
       assertBool "Total amount of ADA is not preserved" $ maxLLSupply == totalAda ex5DState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -43,7 +43,6 @@ import Shelley.Spec.Ledger.Delegation.Certificates
     pattern RegKey,
     pattern RegPool,
     pattern RetirePool,
-    pattern StakeCreds,
   )
 import Shelley.Spec.Ledger.Keys
   ( GenDelegPair (..),
@@ -58,23 +57,21 @@ import Shelley.Spec.Ledger.LedgerState
     _dstate,
     _fGenDelegs,
     _genDelegs,
+    _pParams,
     _pstate,
     _retiring,
     _rewards,
-    _stPools,
   )
 import Shelley.Spec.Ledger.PParams (PParams, _d, _minPoolCost)
 import Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
 import Shelley.Spec.Ledger.TxData
   ( MIRPot (..),
     RewardAcnt (..),
-    unStakePools,
     pattern DCertDeleg,
     pattern DCertGenesis,
     pattern DCertPool,
     pattern Delegation,
     pattern PoolParams,
-    pattern StakePools,
   )
 import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
@@ -320,7 +317,7 @@ genDelegation
       availableDelegates = filter (registeredDelegate . toCred . snd) keys
       availableDelegatesScripts =
         filter (registeredDelegate . scriptToCred . snd) scripts
-      (StakePools registeredPools) = _stPools (_pstate dpState)
+      registeredPools = _pParams (_pstate dpState)
       availablePools = Set.toList $ domain registeredPools
 
 genGenesisDelegation ::
@@ -440,7 +437,7 @@ genRetirePool Constants {frequencyLowMaxEpoch} poolKeys pState slot =
         <$> QC.elements retireable
         <*> (EpochNo <$> genWord64 epochLow epochHigh)
   where
-    stakePools = (unStakePools . _stPools) pState
+    stakePools = _pParams pState
     registered_ = eval (dom stakePools)
     retiring_ = domain (_retiring pState)
     retireable = Set.toList (registered_ \\ retiring_)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -62,7 +62,6 @@ import Shelley.Spec.Ledger.LedgerState
     _retiring,
     _rewards,
     _stPools,
-    _stkCreds,
   )
 import Shelley.Spec.Ledger.PParams (PParams, _d, _minPoolCost)
 import Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
@@ -218,7 +217,7 @@ genRegKeyCert
         )
       ]
     where
-      notRegistered k = eval (k ∉ dom (_stkCreds delegSt))
+      notRegistered k = eval (k ∉ dom (_rewards delegSt))
       availableKeys = filter (notRegistered . toCred . snd) keys
       availableScripts = filter (notRegistered . scriptToCred . snd) scripts
 
@@ -253,7 +252,7 @@ genDeRegKeyCert Constants {frequencyKeyCredDeReg, frequencyScriptCredDeReg} keys
       )
     ]
   where
-    registered k = eval (k ∈ dom (_stkCreds dState))
+    registered k = eval (k ∈ dom (_rewards dState))
     availableKeys =
       filter
         ( \(_, k) ->
@@ -317,7 +316,7 @@ genDelegation
         where
           scriptCert =
             DCertDeleg (Delegate (Delegation (scriptToCred delegatorScript) poolKey))
-      registeredDelegate k = eval (k ∈ dom (_stkCreds (_dstate dpState)))
+      registeredDelegate k = eval (k ∈ dom (_rewards (_dstate dpState)))
       availableDelegates = filter (registeredDelegate . toCred . snd) keys
       availableDelegatesScripts =
         filter (registeredDelegate . scriptToCred . snd) scripts
@@ -475,7 +474,7 @@ genInstantaneousRewards s coreNodes delegateKeys pparams accountState delegSt = 
         fromMaybe
           (error "genInstantaneousRewards: lookupGenDelegate failed")
           (lookupGenDelegate coreNodes delegateKeys gk)
-      StakeCreds credentials = _stkCreds delegSt
+      credentials = _rewards delegSt
 
   winnerCreds <-
     take <$> QC.elements [0 .. (max 0 $ Map.size credentials - 1)]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -46,8 +46,8 @@ import Shelley.Spec.Ledger.Delegation.Certificates (isDeRegKey)
 import Shelley.Spec.Ledger.Keys (HasKeyRole (coerceKeyRole))
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
+    _pParams,
     _pstate,
-    _stPools,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.STS.Delpl (DelplEnv (..))
@@ -162,7 +162,7 @@ genDCerts
     pure
       ( StrictSeq.fromList certs,
         withScriptCreds,
-        totalDeposits pparams (_stPools (_pstate dpState)) certs,
+        totalDeposits pparams (_pParams (_pstate dpState)) certs,
         (_keyDeposit pparams) * (fromIntegral $ length deRegStakeCreds),
         lastState_
       )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -50,7 +50,6 @@ import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx (WitnessSetHKD (..), hashScript, _body, pattern Tx)
 import Shelley.Spec.Ledger.TxData
   ( unWdrl,
-    pattern StakePools,
     pattern TxBody,
     pattern TxIn,
     pattern TxOut,
@@ -211,7 +210,7 @@ initialUTxOState aliceKeep msigs =
                     ( UtxoEnv
                         (SlotNo 0)
                         initPParams
-                        (StakePools Map.empty)
+                        Map.empty
                         (GenDelegs Map.empty),
                       _utxoState genesis,
                       tx
@@ -270,7 +269,7 @@ applyTxWithScript _ lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
               ( UtxoEnv
                   (SlotNo 0)
                   initPParams
-                  (StakePools Map.empty)
+                  Map.empty
                   (GenDelegs Map.empty),
                 utxoSt,
                 tx

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
@@ -52,7 +52,7 @@ import Shelley.Spec.Ledger.LedgerState
     _delegationState,
     _dstate,
     _genDelegs,
-    _stkCreds,
+    _rewards,
     _utxo,
     _utxoState,
   )
@@ -405,11 +405,9 @@ genDCertRetirePool keys epoch = do
 
 genDelegation :: HashAlgorithm h => KeyPairs h -> DPState h -> Gen (Delegation h)
 genDelegation keys d = do
-  poolKey <- Gen.element $ Map.keys stkCreds'
+  poolKey <- Gen.element $ Map.keys $ _rewards . _dstate $ d
   delegatorKey <- getAnyStakeKey keys
   pure $ Delegation (KeyHashObj $ hashKey delegatorKey) $ (unsafeCoerce . hashKey $ vKey $ findStakeKeyPair poolKey keys)
-  where
-    (StakeCreds stkCreds') = (_stkCreds . _dstate) d
 
 genDCertDelegate :: HashAlgorithm h => KeyPairs h -> DPState h -> Gen (DCert h)
 genDCertDelegate keys ds = (DCertDeleg . Delegate) <$> genDelegation keys ds

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
@@ -85,8 +85,7 @@ import Shelley.Spec.Ledger.Tx
     pattern TxOut,
   )
 import Shelley.Spec.Ledger.TxData
-  ( StakeCreds (..),
-    Wdrl (..),
+  ( Wdrl (..),
     pattern DCertDeleg,
     pattern DCertPool,
     pattern DeRegKey,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/PropertyTests.hs
@@ -306,7 +306,7 @@ propPreserveBalance = property $ do
   let created =
         balance ((_utxo . _utxoState) l')
           + fee
-          + (totalDeposits emptyPParams ((_stPools . _pstate . _delegationState) l') $ toList $ (_certs . _body) tx)
+          + (totalDeposits emptyPParams ((_pParams . _pstate . _delegationState) l') $ toList $ (_certs . _body) tx)
   destroyed === created
 
 -- | 'TestTree' of property-based testing properties.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Validity.hs
@@ -1,18 +1,21 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE Rank2Types #-}
 
 module Test.Shelley.Spec.Ledger.NonTraceProperties.Validity where
 
 import Control.Iterate.SetAlgebra (dom, eval, (⊆))
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Address (getRwdCred)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Crypto (Crypto)
-import Shelley.Spec.Ledger.Delegation.Certificates (StakePools (..))
 import Shelley.Spec.Ledger.Keys
   ( DSignable,
     GenDelegs (..),
     Hash,
+    KeyHash,
+    KeyRole (..),
   )
 import Shelley.Spec.Ledger.LedgerState
   ( DPState (..),
@@ -38,7 +41,8 @@ import Shelley.Spec.Ledger.Slot
   )
 import Shelley.Spec.Ledger.Tx (Tx (..))
 import Shelley.Spec.Ledger.TxData
-  ( TxBody (..),
+  ( PoolParams (..),
+    TxBody (..),
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (txins)
@@ -136,7 +140,7 @@ validFee pc tx =
 --  in an acceptable way by a transaction.
 preserveBalance ::
   (Crypto crypto) =>
-  StakePools crypto ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
   PParams ->
   TxBody crypto ->
   UTxOState crypto ->
@@ -163,7 +167,7 @@ correctWithdrawals accs withdrawals =
 validRuleUTXO ::
   (Crypto crypto) =>
   RewardAccounts crypto ->
-  StakePools crypto ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
   PParams ->
   SlotNo ->
   Tx crypto ->
@@ -235,7 +239,7 @@ validTx ::
 validTx tx d' slot pp l =
   validRuleUTXO
     ((_rewards . _dstate . _delegationState) l)
-    ((_stPools . _pstate . _delegationState) l)
+    ((_pParams . _pstate . _delegationState) l)
     pp
     slot
     tx

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -17,7 +17,6 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
     constantSumPots,
     nonNegativeDeposits,
     removedAfterPoolreap,
-    rewardStkCredSync,
   )
 import Test.Shelley.Spec.Ledger.Rules.TestLedger
   ( consumedEqualsProduced,
@@ -51,7 +50,6 @@ minimalPropertyTests =
     "Minimal Property Tests"
     [ TQC.testProperty "Chain and Ledger traces cover the relevant cases" relevantCasesAreCovered,
       TQC.testProperty "total amount of Ada is preserved (Chain)" adaPreservationChain,
-      TQC.testProperty "reward and stake credential maps stay in sync" rewardStkCredSync,
       TQC.testProperty "Only valid CHAIN STS signals are generated" onlyValidChainSignalsAreGenerated,
       bootstrapHashTest
     ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -11,7 +11,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestChain
     removedAfterPoolreap,
     -- TestNewEpoch
     adaPreservationChain,
-    rewardStkCredSync,
   )
 where
 
@@ -68,35 +67,6 @@ traceLen = 100
 ----------------------------------------------------------------------
 -- Properties for Chain
 ---------------------------------------------------------------------
-
--- | Verify that the domains for '_rewards' and '_srkCreds' remain in sync.
-rewardStkCredSync :: Property
-rewardStkCredSync =
-  forAllChainTrace $ \tr ->
-    conjoin $
-      map checkSync $
-        sourceSignalTargets tr
-  where
-    checkSync SourceSignalTarget {source, signal, target} =
-      let ds =
-            _dstate
-              . _delegationState
-              . esLState
-              . nesEs
-              . chainNes
-              $ target
-       in counterexample
-            ( mconcat
-                [ "source\n",
-                  show source,
-                  "signal\n",
-                  show signal,
-                  "target\n",
-                  show target
-                ]
-            )
-            $ eval (dom (_stkCreds ds))
-              === domain (_rewards ds)
 
 adaPreservationChain :: Property
 adaPreservationChain =

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -15,7 +15,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestChain
 where
 
 import Cardano.Crypto.Hash (ShortHash)
-import Control.Iterate.SetAlgebra (dom, domain, eval)
 import Control.Monad (join)
 import Control.State.Transition.Extended (TRC (TRC))
 import Control.State.Transition.Trace

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
@@ -38,7 +38,6 @@ import Shelley.Spec.Ledger.LedgerState
     _delegations,
     _irwd,
     _rewards,
-    _stkCreds,
   )
 import Shelley.Spec.Ledger.TxData
   ( MIRPot (..),
@@ -63,7 +62,7 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 -------------------------------
 
 getStDelegs :: DState ShortHash -> Set (Credential ShortHash 'Staking)
-getStDelegs = \x -> eval (dom (_stkCreds x))
+getStDelegs = \x -> eval (dom (_rewards x))
 
 getRewards :: DState ShortHash -> Map (Credential ShortHash 'Staking) Coin
 getRewards = _rewards

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -28,6 +28,7 @@ import Shelley.Spec.Ledger.Keys (KeyRole (StakePool))
 import Shelley.Spec.Ledger.LedgerState
   ( _deposited,
     _fees,
+    _pParams,
     _reserves,
     _rewards,
     _treasury,
@@ -43,11 +44,10 @@ import Shelley.Spec.Ledger.STS.PoolReap
     prUTxOSt,
     pattern PoolreapState,
   )
-import Shelley.Spec.Ledger.TxData (pattern StakePools)
 import Shelley.Spec.Ledger.UTxO (balance)
 import Test.QuickCheck (Property, conjoin)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (KeyHash, POOLREAP)
-import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring, getStPools)
+import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring)
 
 -----------------------------
 -- Properties for POOLREAP --
@@ -69,8 +69,8 @@ removedAfterPoolreap tr =
             target = PoolreapState {prPState = p'}
           }
         ) =
-        let StakePools stp = getStPools p
-            StakePools stp' = getStPools p'
+        let stp = _pParams p
+            stp' = _pParams p'
             retiring = getRetiring p
             retiring' = getRetiring p'
             retire :: Set.Set (KeyHash ShortHash 'StakePool) -- This declaration needed to disambiguate 'eval'


### PR DESCRIPTION
This PR removes the `stkCreds` mapping from the delegation state and the `stpools` mapping from the pool state. They became redundant with `rewards` and `poolParams` (respectively) when we removed the decaying deposits.

(I will update the formal spec in an up coming PR)

closes #1520 