### PR TITLE
sync formal spec and implementation in EPOCH rule

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -427,7 +427,7 @@ data EpochState crypto = EpochState
     esLState :: !(LedgerState crypto),
     esPrevPp :: !PParams,
     esPp :: !PParams,
-    esNonMyopic :: !(NonMyopic crypto)
+    esNonMyopic :: !(NonMyopic crypto) -- TODO document this in the formal spec, see github #1319
   }
   deriving (Show, Eq, Generic)
 

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -766,7 +766,7 @@ protocol parameters.
 The transition uses a helper function $\fun{votedValue}$ which returns
 the consensus value of update proposals in the event that consensus is met.
 \textbf{Note that} $\fun{votedValue}$
-\textbf{is only well-defined if } $\Quorum$
+\textbf{is only well-defined if } $\var{quorum}$
 \textbf{is greater than half the number of core nodes, i.e.}
 $\Quorum > |\var{genDelegs}|/2$ \textbf{.}
 
@@ -805,12 +805,13 @@ $\Quorum > |\var{genDelegs}|/2$ \textbf{.}
   %
   \emph{Helper Functions}
   \begin{align*}
-      & \fun{votedValue} \in (\KeyHashGen\mapsto\PParamsUpdate) \to \PParamsUpdate^?\\
-      & \fun{votedValue}~\var{vs} =
-        \begin{cases}
-          p & \exists p\in\range{vs}~(|vs\restrictrange p|\geq \Quorum) \\
-          \Nothing & \text{otherwise} \\
-        \end{cases}
+      & \fun{votedValue} \in (\KeyHashGen\mapsto\PParamsUpdate) \to \PParams \to \N \to \PParamsUpdate^?\\
+      & \fun{votedValue}~\var{pup}~\var{pps}~\var{quorum} =
+      \begin{cases}
+        \var{pps}\unionoverrideRight\var{p}
+          & \exists! p\in\range{vs}~(|vs\restrictrange p|\geq \var{quorum}) \\
+        \Nothing & \text{otherwise} \\
+      \end{cases}
   \end{align*}
   %
   \caption{Epoch transition-system types}
@@ -881,7 +882,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
       \\~\\~\\
       \var{(\wcard,~\wcard,~\wcard,~(\var{pup},\wcard))}\leteq\var{utxoSt'}\\
       \var{pp_{new}}\leteq\var{pp}\unionoverrideRight
-      \fun{votedValue}~\var{pup}\\
+      \fun{votedValue}~\var{pup}~\var{pps}~\Quorum\\
       {
         \begin{array}{r}
           \var{dstate'}\\


### PR DESCRIPTION
* add validation to the shelley genesis config for the `Quorum` being greater than half the number of genesis nodes
* rename `votedValuePParams` in implementation to match spec, ie `votedValue`
* perform the union override right on the new protocol parameters _inside_ `votedValue` in the formal spec (as done in the impl).
* rename `ppup` to `pup` in EPOCH rule.
* obtain the `pup` from `utxoState'`, not `utxoState`, in the EPOCH rule.
* add some comments explaining the `votedValue` function.

closes #1685