### PR TITLE
latex: consistently use variable name pp instead of pps

### DIFF
--- a/shelley-mc/formal-spec/mc-changes.tex
+++ b/shelley-mc/formal-spec/mc-changes.tex
@@ -274,7 +274,6 @@ Multicurrency Implementation}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~\var{#1}}
 \newcommand{\kesPeriod}[1]{\fun{kesPeriod}~\var{#1}}
-\newcommand{\pps}[1]{\fun{pps}~ \var{#1}}
 
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -2125,7 +2125,7 @@ candidate nonces for Shelley.
       \right) \\
       & ~~~~\where \\
       & ~~~~~~~~~e = \epoch{s_{last}} \\
-      & ~~~~~~~~~pp = \pps{us} \\
+      & ~~~~~~~~~pp = \fun{pps}~{us} \\   % this pps function is defined in the Byron chain spec
   \end{align*}
 
   \caption{Byron to Shelley State Transtition}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -806,10 +806,10 @@ $\Quorum > |\var{genDelegs}|/2$ \textbf{.}
   \emph{Helper Functions}
   \begin{align*}
       & \fun{votedValue} \in (\KeyHashGen\mapsto\PParamsUpdate) \to \PParams \to \N \to \PParamsUpdate^?\\
-      & \fun{votedValue}~\var{pup}~\var{pps}~\var{quorum} =
+      & \fun{votedValue}~\var{pup}~\var{pp}~\var{quorum} =
       \begin{cases}
-        \var{pps}\unionoverrideRight\var{p}
-          & \exists! p\in\range{vs}~(|vs\restrictrange p|\geq \var{quorum}) \\
+        \var{pp}\unionoverrideRight\var{p}
+          & \exists! p\in\range{pup}~(|pup\restrictrange p|\geq \var{quorum}) \\
         \Nothing & \text{otherwise} \\
       \end{cases}
   \end{align*}
@@ -882,7 +882,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
       \\~\\~\\
       \var{(\wcard,~\wcard,~\wcard,~(\var{pup},\wcard))}\leteq\var{utxoSt'}\\
       \var{pp_{new}}\leteq\var{pp}\unionoverrideRight
-      \fun{votedValue}~\var{pup}~\var{pps}~\Quorum\\
+      \fun{votedValue}~\var{pup}~\var{pp}~\Quorum\\
       {
         \begin{array}{r}
           \var{dstate'}\\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -230,7 +230,6 @@
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~\var{#1}}
 \newcommand{\kesPeriod}[1]{\fun{kesPeriod}~\var{#1}}
-\newcommand{\pps}[1]{\fun{pps}~ \var{#1}}
 
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -191,7 +191,6 @@
 \newcommand{\epoch}[1]{\fun{epoch}~\var{#1}}
 \newcommand{\kesPeriod}[1]{\fun{kesPeriod}~\var{#1}}
 \newcommand{\dcerts}[1]{\fun{dcerts}~ \var{#1}}
-\newcommand{\pps}[1]{\fun{pps}~ \var{#1}}
 
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}


### PR DESCRIPTION
I noticed that `Figure 45:Epoch Inference Rule` included an expression `votedValue pup pps Quorum` but the `pps` argument was unbound; I think it should be `pp` instead. After a few more minor related changes, I opened this PR.