### PR TITLE
Ts flex record decoding

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Integration between the Shelley ledger and its corresponding (Transitional
 -- Praos) protocol.
@@ -55,10 +55,10 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.PParams (PParams)
-import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
 import Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
 -- | Data required by the Transitional Praos protocol from the Shelley ledger.
@@ -74,12 +74,15 @@ instance NoUnexpectedThunks (LedgerView crypto)
 
 instance Crypto crypto => FromCBOR (LedgerView crypto) where
   fromCBOR =
-    decodeRecordNamed "LedgerView" (const 4)
-      (LedgerView
-       <$> fromCBOR
-       <*> fromCBOR
-       <*> fromCBOR
-       <*> fromCBOR)
+    decodeRecordNamed
+      "LedgerView"
+      (const 4)
+      ( LedgerView
+          <$> fromCBOR
+          <*> fromCBOR
+          <*> fromCBOR
+          <*> fromCBOR
+      )
 
 instance Crypto crypto => ToCBOR (LedgerView crypto) where
   toCBOR
@@ -216,11 +219,14 @@ instance Crypto c => NoUnexpectedThunks (ChainDepState c)
 
 instance Crypto crypto => FromCBOR (ChainDepState crypto) where
   fromCBOR =
-    decodeRecordNamed "ChainDepState" (const 3)
-      (ChainDepState
-       <$> fromCBOR
-       <*> fromCBOR
-       <*> fromCBOR)
+    decodeRecordNamed
+      "ChainDepState"
+      (const 3)
+      ( ChainDepState
+          <$> fromCBOR
+          <*> fromCBOR
+          <*> fromCBOR
+      )
 
 instance Crypto crypto => ToCBOR (ChainDepState crypto) where
   toCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Integration between the Shelley ledger and its corresponding (Transitional
 -- Praos) protocol.
@@ -25,7 +26,7 @@ module Shelley.Spec.Ledger.API.Protocol
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.KES.Class
 import Cardano.Crypto.VRF.Class
@@ -54,6 +55,7 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.PParams (PParams)
+import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
 import Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
@@ -72,12 +74,12 @@ instance NoUnexpectedThunks (LedgerView crypto)
 
 instance Crypto crypto => FromCBOR (LedgerView crypto) where
   fromCBOR =
-    decodeListLenOf 4
-      >> LedgerView
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+    decodeRecordNamed "LedgerView" (const 4)
+      (LedgerView
+       <$> fromCBOR
+       <*> fromCBOR
+       <*> fromCBOR
+       <*> fromCBOR)
 
 instance Crypto crypto => ToCBOR (LedgerView crypto) where
   toCBOR
@@ -214,11 +216,11 @@ instance Crypto c => NoUnexpectedThunks (ChainDepState c)
 
 instance Crypto crypto => FromCBOR (ChainDepState crypto) where
   fromCBOR =
-    decodeListLenOf 3
-      >> ChainDepState
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+    decodeRecordNamed "ChainDepState" (const 3)
+      (ChainDepState
+       <$> fromCBOR
+       <*> fromCBOR
+       <*> fromCBOR)
 
 instance Crypto crypto => ToCBOR (ChainDepState crypto) where
   toCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -59,9 +59,9 @@ import Cardano.Binary
     DecoderError (..),
     FromCBOR (fromCBOR),
     ToCBOR (toCBOR),
-    encodeListLen,
-    decodeListLenOrIndef,
     decodeBreakOr,
+    decodeListLenOrIndef,
+    encodeListLen,
   )
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Util (SignableRepresentation (..))
@@ -83,7 +83,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Word (Word16, Word64, Word8)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
-import Shelley.Spec.Ledger.Serialization (ratioFromCBOR, ratioToCBOR, decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum, ratioFromCBOR, ratioToCBOR)
 import Shelley.Spec.NonIntegral (ln')
 
 data E34
@@ -172,9 +172,10 @@ invalidKey k = cborError $ DecoderErrorCustom "not a valid key:" (Text.pack $ sh
 instance FromCBOR Nonce where
   fromCBOR = decodeRecordSum "Nonce" $
     \case
-      0 -> pure (1,NeutralNonce)
-      1 -> do x <- fromCBOR
-              pure(2,Nonce x)
+      0 -> pure (1, NeutralNonce)
+      1 -> do
+        x <- fromCBOR
+        pure (2, Nonce x)
       k -> invalidKey k
 
 deriving anyclass instance ToJSON Nonce
@@ -258,19 +259,22 @@ instance ToCBOR a => ToCBOR (StrictMaybe a) where
   toCBOR (SJust x) = encodeListLen 1 <> toCBOR x
 
 instance FromCBOR a => FromCBOR (StrictMaybe a) where
- fromCBOR = do
+  fromCBOR = do
     maybeN <- decodeListLenOrIndef
     case maybeN of
       Just 0 -> pure SNothing
       Just 1 -> SJust <$> fromCBOR
       Just _ -> fail "too many elements in length-style decoding of StrictMaybe."
       Nothing -> do
-         isBreak <- decodeBreakOr
-         if isBreak then pure SNothing
-                    else do x <- fromCBOR
-                            isBreak2 <- decodeBreakOr
-                            if isBreak2 then pure(SJust x)
-                                        else fail "too many elements in break-style decoding of StrictMaybe."
+        isBreak <- decodeBreakOr
+        if isBreak
+          then pure SNothing
+          else do
+            x <- fromCBOR
+            isBreak2 <- decodeBreakOr
+            if isBreak2
+              then pure (SJust x)
+              else fail "too many elements in break-style decoding of StrictMaybe."
 
 instance ToJSON a => ToJSON (StrictMaybe a) where
   toJSON = toJSON . strictMaybeToMaybe

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -286,10 +286,11 @@ instance
   Crypto crypto =>
   FromCBOR (Annotator (BHeader crypto))
   where
-  fromCBOR = annotatorSlice $ decodeRecordNamed "Header" (const 2) $ do
-    bhb <- fromCBOR
-    sig <- decodeSignedKES
-    pure $ BHeader' <$> pure bhb <*> pure sig
+  fromCBOR = annotatorSlice $
+    decodeRecordNamed "Header" (const 2) $ do
+      bhb <- fromCBOR
+      sig <- decodeSignedKES
+      pure $ BHeader' <$> pure bhb <*> pure sig
 
 -- | The previous hash of a block
 data PrevHash crypto = GenesisHash | BlockHash !(HashHeader crypto)
@@ -361,11 +362,14 @@ instance Crypto crypto => ToCBOR (LastAppliedBlock crypto) where
 
 instance Crypto crypto => FromCBOR (LastAppliedBlock crypto) where
   fromCBOR =
-    decodeRecordNamed "lastAppliedBlock" (const 3)
-      (LastAppliedBlock
-       <$> fromCBOR
-       <*> fromCBOR
-       <*> fromCBOR)
+    decodeRecordNamed
+      "lastAppliedBlock"
+      (const 3)
+      ( LastAppliedBlock
+          <$> fromCBOR
+          <*> fromCBOR
+          <*> fromCBOR
+      )
 
 lastAppliedHash :: WithOrigin (LastAppliedBlock crypto) -> PrevHash crypto
 lastAppliedHash Origin = GenesisHash
@@ -451,36 +455,34 @@ instance
   Crypto crypto =>
   FromCBOR (BHBody crypto)
   where
-   fromCBOR = decodeRecordNamed "BHBody" bhBodySize  $ do
-     bheaderBlockNo <- fromCBOR
-     bheaderSlotNo <- fromCBOR
-     bheaderPrev <- fromCBOR
-     bheaderVk <- fromCBOR
-     bheaderVrfVk <- decodeVerKeyVRF
-     bheaderEta <- fromCBOR
-     bheaderL <- fromCBOR
-     bsize <- fromCBOR
-     bhash <- fromCBOR
-     bheaderOCert <- fromCBORGroup
-     bprotver <- fromCBORGroup
-     pure $
-       BHBody
-         { bheaderBlockNo,
-           bheaderSlotNo,
-           bheaderPrev,
-           bheaderVk,
-           bheaderVrfVk,
-           bheaderEta,
-           bheaderL,
-           bsize,
-           bhash,
-           bheaderOCert,
-           bprotver
-         }
-       where bhBodySize body = 9 + listLenInt (bheaderOCert body) + listLenInt (bprotver body)
-
-
-
+  fromCBOR = decodeRecordNamed "BHBody" bhBodySize $ do
+    bheaderBlockNo <- fromCBOR
+    bheaderSlotNo <- fromCBOR
+    bheaderPrev <- fromCBOR
+    bheaderVk <- fromCBOR
+    bheaderVrfVk <- decodeVerKeyVRF
+    bheaderEta <- fromCBOR
+    bheaderL <- fromCBOR
+    bsize <- fromCBOR
+    bhash <- fromCBOR
+    bheaderOCert <- fromCBORGroup
+    bprotver <- fromCBORGroup
+    pure $
+      BHBody
+        { bheaderBlockNo,
+          bheaderSlotNo,
+          bheaderPrev,
+          bheaderVk,
+          bheaderVrfVk,
+          bheaderEta,
+          bheaderL,
+          bsize,
+          bhash,
+          bheaderOCert,
+          bprotver
+        }
+    where
+      bhBodySize body = 9 + listLenInt (bheaderOCert body) + listLenInt (bprotver body)
 
 -- | Retrieve the pool id (the hash of the pool operator's cold key)
 -- from the body of the block header.
@@ -516,11 +518,11 @@ instance
   toCBOR (Block' _ _ blockBytes) = encodePreEncoded $ BSL.toStrict blockBytes
 
 blockDecoder :: Crypto crypto => Bool -> forall s. Decoder s (Annotator (Block crypto))
-blockDecoder lax = annotatorSlice $ decodeRecordNamed "Block" (const 4) $ do
-  header <- fromCBOR
-  txns <- txSeqDecoder lax
-  pure $ Block' <$> header <*> txns
-
+blockDecoder lax = annotatorSlice $
+  decodeRecordNamed "Block" (const 4) $ do
+    header <- fromCBOR
+    txns <- txSeqDecoder lax
+    pure $ Block' <$> header <*> txns
 
 txSeqDecoder :: Crypto crypto => Bool -> forall s. Decoder s (Annotator (TxSeq crypto))
 txSeqDecoder lax = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Credential.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Credential.hs
@@ -20,7 +20,7 @@ module Shelley.Spec.Ledger.Credential
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord, encodeListLen)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import Cardano.Prelude (NFData, Natural, NoUnexpectedThunks, Typeable, Word8, asum)
 import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey, (.:), (.=))
 import qualified Data.Aeson as Aeson
@@ -39,7 +39,7 @@ import Shelley.Spec.Ledger.Serialization
   ( CBORGroup (..),
     FromCBORGroup (..),
     ToCBORGroup (..),
-    decodeRecordNamed,
+    decodeRecordSum,
   )
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 
@@ -112,11 +112,12 @@ instance
   (Typeable kr, Crypto crypto) =>
   FromCBOR (Credential kr crypto)
   where
-  fromCBOR =
-    decodeRecordNamed "Credential" (const 2) $
-      decodeWord >>= \case
-        0 -> KeyHashObj <$> fromCBOR
-        1 -> ScriptHashObj <$> fromCBOR
+  fromCBOR = decodeRecordSum "Credential" $
+     \case
+        0 -> do x <- fromCBOR
+                pure (2,KeyHashObj x)
+        1 -> do x <- fromCBOR
+                pure (2, ScriptHashObj x)
         k -> invalidKey k
 
 instance ToCBORGroup Ptr where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Credential.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Credential.hs
@@ -113,12 +113,14 @@ instance
   FromCBOR (Credential kr crypto)
   where
   fromCBOR = decodeRecordSum "Credential" $
-     \case
-        0 -> do x <- fromCBOR
-                pure (2,KeyHashObj x)
-        1 -> do x <- fromCBOR
-                pure (2, ScriptHashObj x)
-        k -> invalidKey k
+    \case
+      0 -> do
+        x <- fromCBOR
+        pure (2, KeyHashObj x)
+      1 -> do
+        x <- fromCBOR
+        pure (2, ScriptHashObj x)
+      k -> invalidKey k
 
 instance ToCBORGroup Ptr where
   toCBORGroup (Ptr sl txIx certIx) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -31,7 +31,7 @@ module Shelley.Spec.Ledger.EpochBoundary
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Control.Iterate.SetAlgebra (dom, eval, (▷), (◁))
 import Data.Map.Strict (Map)
@@ -48,6 +48,7 @@ import Shelley.Spec.Ledger.Credential (Credential, Ptr, StakeReference (..))
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), _a0, _nOpt)
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.TxData (PoolParams, TxOut (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
@@ -201,11 +202,11 @@ instance
   FromCBOR (SnapShot crypto)
   where
   fromCBOR = do
-    enforceSize "SnapShot" 3
-    s <- fromCBOR
-    d <- fromCBOR
-    p <- fromCBOR
-    pure $ SnapShot s d p
+    decodeRecordNamed "SnapShot" (const 3) $ do
+      s <- fromCBOR
+      d <- fromCBOR
+      p <- fromCBOR
+      pure $ SnapShot s d p
 
 -- | Snapshots of the stake distribution.
 data SnapShots crypto = SnapShots
@@ -236,12 +237,12 @@ instance
   FromCBOR (SnapShots crypto)
   where
   fromCBOR = do
-    enforceSize "SnapShots" 4
-    mark <- fromCBOR
-    set <- fromCBOR
-    go <- fromCBOR
-    f <- fromCBOR
-    pure $ SnapShots mark set go f
+    decodeRecordNamed "SnapShots" (const 4) $ do
+      mark <- fromCBOR
+      set <- fromCBOR
+      go <- fromCBOR
+      f <- fromCBOR
+      pure $ SnapShots mark set go f
 
 emptySnapShot :: SnapShot crypto
 emptySnapShot = SnapShot (Stake Map.empty) Map.empty Map.empty

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -92,7 +92,6 @@ import Quiet
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 
-
 -- | The role of a key.
 --
 --   Note that a role is not _fixed_, nor is it unique. In particular, keys may
@@ -289,7 +288,9 @@ instance Crypto crypto => ToCBOR (GenDelegPair crypto) where
 
 instance Crypto crypto => FromCBOR (GenDelegPair crypto) where
   fromCBOR = do
-    decodeRecordNamed "GenDelegPair" (const 2)
+    decodeRecordNamed
+      "GenDelegPair"
+      (const 2)
       (GenDelegPair <$> fromCBOR <*> fromCBOR)
 
 instance Crypto crypto => ToJSON (GenDelegPair crypto) where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -74,7 +74,7 @@ module Shelley.Spec.Ledger.Keys
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.KES as KES
@@ -90,6 +90,8 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Quiet
 import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
+
 
 -- | The role of a key.
 --
@@ -287,8 +289,8 @@ instance Crypto crypto => ToCBOR (GenDelegPair crypto) where
 
 instance Crypto crypto => FromCBOR (GenDelegPair crypto) where
   fromCBOR = do
-    enforceSize "GenDelegPair" 2
-    GenDelegPair <$> fromCBOR <*> fromCBOR
+    decodeRecordNamed "GenDelegPair" (const 2)
+      (GenDelegPair <$> fromCBOR <*> fromCBOR)
 
 instance Crypto crypto => ToJSON (GenDelegPair crypto) where
   toJSON (GenDelegPair d v) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -179,7 +179,7 @@ import Shelley.Spec.Ledger.Rewards
     emptyNonMyopic,
     reward,
   )
-import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR, decodeRecordNamed)
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed, mapFromCBOR, mapToCBOR)
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
     EpochNo (..),
@@ -337,10 +337,10 @@ instance Crypto crypto => ToCBOR (PState crypto) where
 instance Crypto crypto => FromCBOR (PState crypto) where
   fromCBOR = do
     decodeRecordNamed "PState" (const 3) $ do
-       a <- fromCBOR
-       b <- fromCBOR
-       c <- fromCBOR
-       pure $ PState a b c
+      a <- fromCBOR
+      b <- fromCBOR
+      c <- fromCBOR
+      pure $ PState a b c
 
 -- | The state associated with the current stake delegation.
 data DPState crypto = DPState
@@ -360,9 +360,9 @@ instance Crypto crypto => ToCBOR (DPState crypto) where
 instance Crypto crypto => FromCBOR (DPState crypto) where
   fromCBOR = do
     decodeRecordNamed "DPState" (const 2) $ do
-       ds <- fromCBOR
-       ps <- fromCBOR
-       pure $ DPState ds ps
+      ds <- fromCBOR
+      ps <- fromCBOR
+      pure $ DPState ds ps
 
 data RewardUpdate crypto = RewardUpdate
   { deltaT :: !Coin,
@@ -389,12 +389,12 @@ instance Crypto crypto => ToCBOR (RewardUpdate crypto) where
 instance Crypto crypto => FromCBOR (RewardUpdate crypto) where
   fromCBOR = do
     decodeRecordNamed "RewardUpdate" (const 5) $ do
-       dt <- fromCBOR
-       dr <- fromCBOR -- TODO change Coin serialization to use integers?
-       rw <- fromCBOR
-       df <- fromCBOR -- TODO change Coin serialization to use integers?
-       nm <- fromCBOR
-       pure $ RewardUpdate dt (- dr) rw (- df) nm
+      dt <- fromCBOR
+      dr <- fromCBOR -- TODO change Coin serialization to use integers?
+      rw <- fromCBOR
+      df <- fromCBOR -- TODO change Coin serialization to use integers?
+      nm <- fromCBOR
+      pure $ RewardUpdate dt (- dr) rw (- df) nm
 
 emptyRewardUpdate :: RewardUpdate crypto
 emptyRewardUpdate = RewardUpdate (Coin 0) (Coin 0) Map.empty (Coin 0) emptyNonMyopic
@@ -412,9 +412,9 @@ instance ToCBOR AccountState where
 instance FromCBOR AccountState where
   fromCBOR = do
     decodeRecordNamed "AccountState" (const 2) $ do
-       t <- fromCBOR
-       r <- fromCBOR
-       pure $ AccountState t r
+      t <- fromCBOR
+      r <- fromCBOR
+      pure $ AccountState t r
 
 instance NoUnexpectedThunks AccountState
 
@@ -441,13 +441,13 @@ instance Crypto crypto => ToCBOR (EpochState crypto) where
 instance Crypto crypto => FromCBOR (EpochState crypto) where
   fromCBOR = do
     decodeRecordNamed "EpochState" (const 6) $ do
-       a <- fromCBOR
-       s <- fromCBOR
-       l <- fromCBOR
-       r <- fromCBOR
-       p <- fromCBOR
-       n <- fromCBOR
-       pure $ EpochState a s l r p n
+      a <- fromCBOR
+      s <- fromCBOR
+      l <- fromCBOR
+      r <- fromCBOR
+      p <- fromCBOR
+      n <- fromCBOR
+      pure $ EpochState a s l r p n
 
 emptyPPUPState :: PPUPState crypto
 emptyPPUPState = PPUPState emptyPPPUpdates emptyPPPUpdates
@@ -505,9 +505,9 @@ instance Crypto crypto => ToCBOR (PPUPState crypto) where
 instance Crypto crypto => FromCBOR (PPUPState crypto) where
   fromCBOR = do
     decodeRecordNamed "PPUPState" (const 2) $ do
-       ppup <- fromCBOR
-       fppup <- fromCBOR
-       pure $ PPUPState ppup fppup
+      ppup <- fromCBOR
+      fppup <- fromCBOR
+      pure $ PPUPState ppup fppup
 
 pvCanFollow :: ProtVer -> StrictMaybe ProtVer -> Bool
 pvCanFollow _ SNothing = True
@@ -541,11 +541,11 @@ instance Crypto crypto => ToCBOR (UTxOState crypto) where
 instance Crypto crypto => FromCBOR (UTxOState crypto) where
   fromCBOR = do
     decodeRecordNamed "UTxOState" (const 4) $ do
-       ut <- fromCBOR
-       dp <- fromCBOR
-       fs <- fromCBOR
-       us <- fromCBOR
-       pure $ UTxOState ut dp fs us
+      ut <- fromCBOR
+      dp <- fromCBOR
+      fs <- fromCBOR
+      us <- fromCBOR
+      pure $ UTxOState ut dp fs us
 
 data OBftSlot crypto
   = NonActiveSlot
@@ -607,14 +607,14 @@ instance Crypto crypto => ToCBOR (NewEpochState crypto) where
 instance Crypto crypto => FromCBOR (NewEpochState crypto) where
   fromCBOR = do
     decodeRecordNamed "NewEpochState" (const 7) $ do
-       e <- fromCBOR
-       bp <- fromCBOR
-       bc <- fromCBOR
-       es <- fromCBOR
-       ru <- fromCBOR
-       pd <- fromCBOR
-       os <- decompactOverlaySchedule <$> fromCBOR
-       pure $ NewEpochState e bp bc es ru pd os
+      e <- fromCBOR
+      bp <- fromCBOR
+      bc <- fromCBOR
+      es <- fromCBOR
+      ru <- fromCBOR
+      pd <- fromCBOR
+      os <- decompactOverlaySchedule <$> fromCBOR
+      pure $ NewEpochState e bp bc es ru pd os
 
 -- | Convert the overlay schedule to a representation that is more compact
 -- when serialised to a bytestring, but less efficient for lookups.
@@ -679,9 +679,9 @@ instance Crypto crypto => ToCBOR (LedgerState crypto) where
 instance Crypto crypto => FromCBOR (LedgerState crypto) where
   fromCBOR = do
     decodeRecordNamed "LedgerState" (const 2) $ do
-       u <- fromCBOR
-       dp <- fromCBOR
-       pure $ LedgerState u dp
+      u <- fromCBOR
+      dp <- fromCBOR
+      pure $ LedgerState u dp
 
 -- | Creates the ledger state for an empty ledger which
 --  contains the specified transaction outputs.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -98,7 +98,6 @@ import Cardano.Binary
     decodeNull,
     encodeListLen,
     encodeNull,
-    enforceSize,
     peekTokenType,
   )
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
@@ -180,7 +179,7 @@ import Shelley.Spec.Ledger.Rewards
     emptyNonMyopic,
     reward,
   )
-import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
+import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR, decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
     EpochNo (..),
@@ -242,10 +241,10 @@ instance Crypto crypto => ToCBOR (FutureGenDeleg crypto) where
 
 instance Crypto crypto => FromCBOR (FutureGenDeleg crypto) where
   fromCBOR = do
-    enforceSize "FutureGenDeleg" 2
-    a <- fromCBOR
-    b <- fromCBOR
-    pure $ FutureGenDeleg a b
+    decodeRecordNamed "FutureGenDeleg" (const 2) $ do
+      a <- fromCBOR
+      b <- fromCBOR
+      pure $ FutureGenDeleg a b
 
 data InstantaneousRewards crypto = InstantaneousRewards
   { iRReserves :: !(Map (Credential 'Staking crypto) Coin),
@@ -269,10 +268,10 @@ instance Crypto crypto => ToCBOR (InstantaneousRewards crypto) where
 
 instance Crypto crypto => FromCBOR (InstantaneousRewards crypto) where
   fromCBOR = do
-    enforceSize "InstantaneousRewards" 2
-    irR <- mapFromCBOR
-    irT <- mapFromCBOR
-    pure $ InstantaneousRewards irR irT
+    decodeRecordNamed "InstantaneousRewards" (const 2) $ do
+      irR <- mapFromCBOR
+      irT <- mapFromCBOR
+      pure $ InstantaneousRewards irR irT
 
 -- | State of staking pool delegations and rewards
 data DState crypto = DState
@@ -307,14 +306,14 @@ instance Crypto crypto => ToCBOR (DState crypto) where
 
 instance Crypto crypto => FromCBOR (DState crypto) where
   fromCBOR = do
-    enforceSize "DState" 6
-    rw <- fromCBOR
-    dlg <- fromCBOR
-    p <- fromCBOR
-    fgs <- fromCBOR
-    gs <- fromCBOR
-    ir <- fromCBOR
-    pure $ DState rw dlg p fgs gs ir
+    decodeRecordNamed "DState" (const 6) $ do
+      rw <- fromCBOR
+      dlg <- fromCBOR
+      p <- fromCBOR
+      fgs <- fromCBOR
+      gs <- fromCBOR
+      ir <- fromCBOR
+      pure $ DState rw dlg p fgs gs ir
 
 -- | Current state of staking pools and their certificate counters.
 data PState crypto = PState
@@ -337,11 +336,11 @@ instance Crypto crypto => ToCBOR (PState crypto) where
 
 instance Crypto crypto => FromCBOR (PState crypto) where
   fromCBOR = do
-    enforceSize "PState" 3
-    a <- fromCBOR
-    b <- fromCBOR
-    c <- fromCBOR
-    pure $ PState a b c
+    decodeRecordNamed "PState" (const 3) $ do
+       a <- fromCBOR
+       b <- fromCBOR
+       c <- fromCBOR
+       pure $ PState a b c
 
 -- | The state associated with the current stake delegation.
 data DPState crypto = DPState
@@ -360,10 +359,10 @@ instance Crypto crypto => ToCBOR (DPState crypto) where
 
 instance Crypto crypto => FromCBOR (DPState crypto) where
   fromCBOR = do
-    enforceSize "DPState" 2
-    ds <- fromCBOR
-    ps <- fromCBOR
-    pure $ DPState ds ps
+    decodeRecordNamed "DPState" (const 2) $ do
+       ds <- fromCBOR
+       ps <- fromCBOR
+       pure $ DPState ds ps
 
 data RewardUpdate crypto = RewardUpdate
   { deltaT :: !Coin,
@@ -389,13 +388,13 @@ instance Crypto crypto => ToCBOR (RewardUpdate crypto) where
 
 instance Crypto crypto => FromCBOR (RewardUpdate crypto) where
   fromCBOR = do
-    enforceSize "RewardUpdate" 5
-    dt <- fromCBOR
-    dr <- fromCBOR -- TODO change Coin serialization to use integers?
-    rw <- fromCBOR
-    df <- fromCBOR -- TODO change Coin serialization to use integers?
-    nm <- fromCBOR
-    pure $ RewardUpdate dt (- dr) rw (- df) nm
+    decodeRecordNamed "RewardUpdate" (const 5) $ do
+       dt <- fromCBOR
+       dr <- fromCBOR -- TODO change Coin serialization to use integers?
+       rw <- fromCBOR
+       df <- fromCBOR -- TODO change Coin serialization to use integers?
+       nm <- fromCBOR
+       pure $ RewardUpdate dt (- dr) rw (- df) nm
 
 emptyRewardUpdate :: RewardUpdate crypto
 emptyRewardUpdate = RewardUpdate (Coin 0) (Coin 0) Map.empty (Coin 0) emptyNonMyopic
@@ -412,10 +411,10 @@ instance ToCBOR AccountState where
 
 instance FromCBOR AccountState where
   fromCBOR = do
-    enforceSize "AccountState" 2
-    t <- fromCBOR
-    r <- fromCBOR
-    pure $ AccountState t r
+    decodeRecordNamed "AccountState" (const 2) $ do
+       t <- fromCBOR
+       r <- fromCBOR
+       pure $ AccountState t r
 
 instance NoUnexpectedThunks AccountState
 
@@ -441,14 +440,14 @@ instance Crypto crypto => ToCBOR (EpochState crypto) where
 
 instance Crypto crypto => FromCBOR (EpochState crypto) where
   fromCBOR = do
-    enforceSize "EpochState" 6
-    a <- fromCBOR
-    s <- fromCBOR
-    l <- fromCBOR
-    r <- fromCBOR
-    p <- fromCBOR
-    n <- fromCBOR
-    pure $ EpochState a s l r p n
+    decodeRecordNamed "EpochState" (const 6) $ do
+       a <- fromCBOR
+       s <- fromCBOR
+       l <- fromCBOR
+       r <- fromCBOR
+       p <- fromCBOR
+       n <- fromCBOR
+       pure $ EpochState a s l r p n
 
 emptyPPUPState :: PPUPState crypto
 emptyPPUPState = PPUPState emptyPPPUpdates emptyPPPUpdates
@@ -505,10 +504,10 @@ instance Crypto crypto => ToCBOR (PPUPState crypto) where
 
 instance Crypto crypto => FromCBOR (PPUPState crypto) where
   fromCBOR = do
-    enforceSize "PPUPState" 2
-    ppup <- fromCBOR
-    fppup <- fromCBOR
-    pure $ PPUPState ppup fppup
+    decodeRecordNamed "PPUPState" (const 2) $ do
+       ppup <- fromCBOR
+       fppup <- fromCBOR
+       pure $ PPUPState ppup fppup
 
 pvCanFollow :: ProtVer -> StrictMaybe ProtVer -> Bool
 pvCanFollow _ SNothing = True
@@ -541,12 +540,12 @@ instance Crypto crypto => ToCBOR (UTxOState crypto) where
 
 instance Crypto crypto => FromCBOR (UTxOState crypto) where
   fromCBOR = do
-    enforceSize "UTxOState" 4
-    ut <- fromCBOR
-    dp <- fromCBOR
-    fs <- fromCBOR
-    us <- fromCBOR
-    pure $ UTxOState ut dp fs us
+    decodeRecordNamed "UTxOState" (const 4) $ do
+       ut <- fromCBOR
+       dp <- fromCBOR
+       fs <- fromCBOR
+       us <- fromCBOR
+       pure $ UTxOState ut dp fs us
 
 data OBftSlot crypto
   = NonActiveSlot
@@ -607,15 +606,15 @@ instance Crypto crypto => ToCBOR (NewEpochState crypto) where
 
 instance Crypto crypto => FromCBOR (NewEpochState crypto) where
   fromCBOR = do
-    enforceSize "NewEpochState" 7
-    e <- fromCBOR
-    bp <- fromCBOR
-    bc <- fromCBOR
-    es <- fromCBOR
-    ru <- fromCBOR
-    pd <- fromCBOR
-    os <- decompactOverlaySchedule <$> fromCBOR
-    pure $ NewEpochState e bp bc es ru pd os
+    decodeRecordNamed "NewEpochState" (const 7) $ do
+       e <- fromCBOR
+       bp <- fromCBOR
+       bc <- fromCBOR
+       es <- fromCBOR
+       ru <- fromCBOR
+       pd <- fromCBOR
+       os <- decompactOverlaySchedule <$> fromCBOR
+       pure $ NewEpochState e bp bc es ru pd os
 
 -- | Convert the overlay schedule to a representation that is more compact
 -- when serialised to a bytestring, but less efficient for lookups.
@@ -679,10 +678,10 @@ instance Crypto crypto => ToCBOR (LedgerState crypto) where
 
 instance Crypto crypto => FromCBOR (LedgerState crypto) where
   fromCBOR = do
-    enforceSize "LedgerState" 2
-    u <- fromCBOR
-    dp <- fromCBOR
-    pure $ LedgerState u dp
+    decodeRecordNamed "LedgerState" (const 2) $ do
+       u <- fromCBOR
+       dp <- fromCBOR
+       pure $ LedgerState u dp
 
 -- | Creates the ledger state for an empty ledger which
 --  contains the specified transaction outputs.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -34,7 +34,6 @@ import Cardano.Binary
     encodeListLen,
     encodeMapLen,
     encodeWord,
-    enforceSize,
   )
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..), mapMaybe)
 import Control.Monad (unless)
@@ -66,6 +65,7 @@ import Shelley.Spec.Ledger.Serialization
     FromCBORGroup (..),
     ToCBORGroup (..),
     decodeMapContents,
+    decodeRecordNamed,
     mapFromCBOR,
     mapToCBOR,
     ratioFromCBOR,
@@ -232,25 +232,25 @@ instance ToCBOR PParams where
 
 instance FromCBOR PParams where
   fromCBOR = do
-    enforceSize "PParams" 18
-    PParams
-      <$> fromCBOR -- _minfeeA         :: Integer
-      <*> fromCBOR -- _minfeeB         :: Natural
-      <*> fromCBOR -- _maxBBSize       :: Natural
-      <*> fromCBOR -- _maxTxSize       :: Natural
-      <*> fromCBOR -- _maxBHSize       :: Natural
-      <*> fromCBOR -- _keyDeposit      :: Coin
-      <*> fromCBOR -- _poolDeposit     :: Coin
-      <*> fromCBOR -- _eMax            :: EpochNo
-      <*> fromCBOR -- _nOpt            :: Natural
-      <*> ratioFromCBOR -- _a0         :: Rational
-      <*> fromCBOR -- _rho             :: UnitInterval
-      <*> fromCBOR -- _tau             :: UnitInterval
-      <*> fromCBOR -- _d               :: UnitInterval
-      <*> fromCBOR -- _extraEntropy    :: Nonce
-      <*> fromCBORGroup -- _protocolVersion :: ProtVer
-      <*> fromCBOR -- _minUTxOValue    :: Natural
-      <*> fromCBOR -- _minPoolCost     :: Natural
+    decodeRecordNamed "PParams" (const 18) $
+      PParams
+        <$> fromCBOR -- _minfeeA         :: Integer
+        <*> fromCBOR -- _minfeeB         :: Natural
+        <*> fromCBOR -- _maxBBSize       :: Natural
+        <*> fromCBOR -- _maxTxSize       :: Natural
+        <*> fromCBOR -- _maxBHSize       :: Natural
+        <*> fromCBOR -- _keyDeposit      :: Coin
+        <*> fromCBOR -- _poolDeposit     :: Coin
+        <*> fromCBOR -- _eMax            :: EpochNo
+        <*> fromCBOR -- _nOpt            :: Natural
+        <*> ratioFromCBOR -- _a0         :: Rational
+        <*> fromCBOR -- _rho             :: UnitInterval
+        <*> fromCBOR -- _tau             :: UnitInterval
+        <*> fromCBOR -- _d               :: UnitInterval
+        <*> fromCBOR -- _extraEntropy    :: Nonce
+        <*> fromCBORGroup -- _protocolVersion :: ProtVer
+        <*> fromCBOR -- _minUTxOValue    :: Natural
+        <*> fromCBOR -- _minPoolCost     :: Natural
 
 instance ToJSON PParams where
   toJSON pp =
@@ -333,10 +333,10 @@ instance Crypto crypto => ToCBOR (Update crypto) where
     encodeListLen 2 <> toCBOR ppUpdate <> toCBOR e
 
 instance Crypto crypto => FromCBOR (Update crypto) where
-  fromCBOR =
-    Update <$ enforceSize "Update" 2
-      <*> fromCBOR
-      <*> fromCBOR
+  fromCBOR = decodeRecordNamed "Update" (const 2) $ do
+      x <- fromCBOR
+      y <- fromCBOR
+      pure (Update x y)
 
 data PPUpdateEnv crypto = PPUpdateEnv SlotNo (GenDelegs crypto)
   deriving (Show, Eq, Generic)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -334,9 +334,9 @@ instance Crypto crypto => ToCBOR (Update crypto) where
 
 instance Crypto crypto => FromCBOR (Update crypto) where
   fromCBOR = decodeRecordNamed "Update" (const 2) $ do
-      x <- fromCBOR
-      y <- fromCBOR
-      pure (Update x y)
+    x <- fromCBOR
+    y <- fromCBOR
+    pure (Update x y)
 
 data PPUpdateEnv crypto = PPUpdateEnv SlotNo (GenDelegs crypto)
   deriving (Show, Eq, Generic)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -72,7 +72,7 @@ import Shelley.Spec.Ledger.EpochBoundary
   )
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
-import Shelley.Spec.Ledger.Serialization (decodeSeq, encodeFoldable, decodeRecordNamed)
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed, decodeSeq, encodeFoldable)
 import Shelley.Spec.Ledger.TxData (PoolParams (..), getRwdCred)
 
 newtype LogWeight = LogWeight {unLogWeight :: Float}
@@ -234,15 +234,15 @@ instance Crypto crypto => ToCBOR (NonMyopic crypto) where
 instance Crypto crypto => FromCBOR (NonMyopic crypto) where
   fromCBOR = do
     decodeRecordNamed "NonMyopic" (const 3) $ do
-       aps <- fromCBOR
-       rp <- fromCBOR
-       s <- fromCBOR
-       pure $
-          NonMyopic
-           { likelihoodsNM = aps,
-             rewardPotNM = rp,
-             snapNM = s
-           }
+      aps <- fromCBOR
+      rp <- fromCBOR
+      s <- fromCBOR
+      pure $
+        NonMyopic
+          { likelihoodsNM = aps,
+            rewardPotNM = rp,
+            snapNM = s
+          }
 
 -- | Desirability calculation for non-myopic utily,
 -- corresponding to f^~ in section 5.6.1 of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -30,7 +30,6 @@ import Cardano.Binary
     decodeDouble,
     encodeDouble,
     encodeListLen,
-    enforceSize,
   )
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import Cardano.Slotting.Slot (EpochSize)
@@ -73,7 +72,7 @@ import Shelley.Spec.Ledger.EpochBoundary
   )
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
-import Shelley.Spec.Ledger.Serialization (decodeSeq, encodeFoldable)
+import Shelley.Spec.Ledger.Serialization (decodeSeq, encodeFoldable, decodeRecordNamed)
 import Shelley.Spec.Ledger.TxData (PoolParams (..), getRwdCred)
 
 newtype LogWeight = LogWeight {unLogWeight :: Float}
@@ -234,16 +233,16 @@ instance Crypto crypto => ToCBOR (NonMyopic crypto) where
 
 instance Crypto crypto => FromCBOR (NonMyopic crypto) where
   fromCBOR = do
-    enforceSize "NonMyopic" 3
-    aps <- fromCBOR
-    rp <- fromCBOR
-    s <- fromCBOR
-    pure $
-      NonMyopic
-        { likelihoodsNM = aps,
-          rewardPotNM = rp,
-          snapNM = s
-        }
+    decodeRecordNamed "NonMyopic" (const 3) $ do
+       aps <- fromCBOR
+       rp <- fromCBOR
+       s <- fromCBOR
+       pure $
+          NonMyopic
+           { likelihoodsNM = aps,
+             rewardPotNM = rp,
+             snapNM = s
+           }
 
 -- | Desirability calculation for non-myopic utily,
 -- corresponding to f^~ in section 5.6.1 of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Deleg
   ( DELEG,
@@ -16,10 +17,7 @@ where
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
-    decodeListLen,
-    decodeWord,
     encodeListLen,
-    matchSize,
   )
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Iterate.SetAlgebra (dom, eval, range, setSingleton, singleton, (∈), (∉), (∪), (⋪), (⋫))
@@ -59,6 +57,7 @@ import Shelley.Spec.Ledger.LedgerState
     _ptrs,
     _rewards,
   )
+import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
     EpochNo (..),
@@ -161,55 +160,43 @@ instance
   (Crypto crypto) =>
   FromCBOR (PredicateFailure (DELEG crypto))
   where
-  fromCBOR = do
-    n <- decodeListLen
-    decodeWord >>= \case
+  fromCBOR = decodeRecordSum "PredicateFailure (DELEG crypto)" $
+    \case
       0 -> do
-        matchSize "StakeKeyAlreadyRegisteredDELEG" 2 n
         kh <- fromCBOR
-        pure $ StakeKeyAlreadyRegisteredDELEG kh
+        pure (2,StakeKeyAlreadyRegisteredDELEG kh)
       10 -> do
-        matchSize "StakeKeyInRewardsDELEG" 2 n
         kh <- fromCBOR
-        pure $ StakeKeyInRewardsDELEG kh
+        pure (2,StakeKeyInRewardsDELEG kh)
       1 -> do
-        matchSize "StakeKeyNotRegisteredDELEG" 2 n
         kh <- fromCBOR
-        pure $ StakeKeyNotRegisteredDELEG kh
+        pure (2,StakeKeyNotRegisteredDELEG kh)
       2 -> do
-        matchSize "StakeKeyNonZeroAccountBalanceDELEG" 2 n
         b <- fromCBOR
-        pure $ StakeKeyNonZeroAccountBalanceDELEG b
+        pure (2,StakeKeyNonZeroAccountBalanceDELEG b)
       3 -> do
-        matchSize "StakeDelegationImpossibleDELEG" 2 n
         kh <- fromCBOR
-        pure $ StakeDelegationImpossibleDELEG kh
+        pure (2,StakeDelegationImpossibleDELEG kh)
       4 -> do
-        matchSize "WrongCertificateTypeDELEG" 1 n
-        pure WrongCertificateTypeDELEG
+        pure (1,WrongCertificateTypeDELEG)
       5 -> do
-        matchSize "GenesisKeyNotInpMappingDELEG" 2 n
         gkh <- fromCBOR
-        pure $ GenesisKeyNotInpMappingDELEG gkh
+        pure (2,GenesisKeyNotInpMappingDELEG gkh)
       6 -> do
-        matchSize "DuplicateGenesisDelegateDELEG" 2 n
         kh <- fromCBOR
-        pure $ DuplicateGenesisDelegateDELEG kh
+        pure (2,DuplicateGenesisDelegateDELEG kh)
       7 -> do
-        matchSize "InsufficientForInstantaneousRewardsDELEG" 4 n
         pot <- fromCBOR
         needed <- fromCBOR
         potAmount <- fromCBOR
-        pure $ InsufficientForInstantaneousRewardsDELEG pot needed potAmount
+        pure (4,InsufficientForInstantaneousRewardsDELEG pot needed potAmount)
       8 -> do
-        matchSize "MIRCertificateTooLateinEpochDELEG" 3 n
         sNow <- fromCBOR
         sTooLate <- fromCBOR
-        pure $ MIRCertificateTooLateinEpochDELEG sNow sTooLate
+        pure (3,MIRCertificateTooLateinEpochDELEG sNow sTooLate)
       9 -> do
-        matchSize "DuplicateGenesisVRFDELEG" 2 n
         vrf <- fromCBOR
-        pure $ DuplicateGenesisVRFDELEG vrf
+        pure (2,DuplicateGenesisVRFDELEG vrf)
       k -> invalidKey k
 
 delegationTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Deleg
   ( DELEG,
@@ -57,7 +56,7 @@ import Shelley.Spec.Ledger.LedgerState
     _ptrs,
     _rewards,
   )
-import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
     EpochNo (..),
@@ -164,39 +163,39 @@ instance
     \case
       0 -> do
         kh <- fromCBOR
-        pure (2,StakeKeyAlreadyRegisteredDELEG kh)
+        pure (2, StakeKeyAlreadyRegisteredDELEG kh)
       10 -> do
         kh <- fromCBOR
-        pure (2,StakeKeyInRewardsDELEG kh)
+        pure (2, StakeKeyInRewardsDELEG kh)
       1 -> do
         kh <- fromCBOR
-        pure (2,StakeKeyNotRegisteredDELEG kh)
+        pure (2, StakeKeyNotRegisteredDELEG kh)
       2 -> do
         b <- fromCBOR
-        pure (2,StakeKeyNonZeroAccountBalanceDELEG b)
+        pure (2, StakeKeyNonZeroAccountBalanceDELEG b)
       3 -> do
         kh <- fromCBOR
-        pure (2,StakeDelegationImpossibleDELEG kh)
+        pure (2, StakeDelegationImpossibleDELEG kh)
       4 -> do
-        pure (1,WrongCertificateTypeDELEG)
+        pure (1, WrongCertificateTypeDELEG)
       5 -> do
         gkh <- fromCBOR
-        pure (2,GenesisKeyNotInpMappingDELEG gkh)
+        pure (2, GenesisKeyNotInpMappingDELEG gkh)
       6 -> do
         kh <- fromCBOR
-        pure (2,DuplicateGenesisDelegateDELEG kh)
+        pure (2, DuplicateGenesisDelegateDELEG kh)
       7 -> do
         pot <- fromCBOR
         needed <- fromCBOR
         potAmount <- fromCBOR
-        pure (4,InsufficientForInstantaneousRewardsDELEG pot needed potAmount)
+        pure (4, InsufficientForInstantaneousRewardsDELEG pot needed potAmount)
       8 -> do
         sNow <- fromCBOR
         sTooLate <- fromCBOR
-        pure (3,MIRCertificateTooLateinEpochDELEG sNow sTooLate)
+        pure (3, MIRCertificateTooLateinEpochDELEG sNow sTooLate)
       9 -> do
         vrf <- fromCBOR
-        pure (2,DuplicateGenesisVRFDELEG vrf)
+        pure (2, DuplicateGenesisVRFDELEG vrf)
       k -> invalidKey k
 
 delegationTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Delegs
   ( DELEGS,
@@ -45,7 +44,7 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Delpl (DELPL, DelplEnv (..))
-import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR,decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum, mapFromCBOR, mapToCBOR)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..))
 import Shelley.Spec.Ledger.TxData
@@ -106,18 +105,20 @@ instance
   (Crypto crypto) =>
   FromCBOR (PredicateFailure (DELEGS crypto))
   where
-  fromCBOR = decodeRecordSum "PredicateFailure" $
-   (\case
-      0 -> do
-        kh <- fromCBOR
-        pure (2, DelegateeNotRegisteredDELEG kh)
-      1 -> do
-        ws <- mapFromCBOR
-        pure (2,WithdrawalsNotInRewardsDELEGS ws)
-      2 -> do
-        a <- fromCBOR
-        pure (2,DelplFailure a)
-      k -> invalidKey k)
+  fromCBOR =
+    decodeRecordSum "PredicateFailure" $
+      ( \case
+          0 -> do
+            kh <- fromCBOR
+            pure (2, DelegateeNotRegisteredDELEG kh)
+          1 -> do
+            ws <- mapFromCBOR
+            pure (2, WithdrawalsNotInRewardsDELEGS ws)
+          2 -> do
+            a <- fromCBOR
+            pure (2, DelplFailure a)
+          k -> invalidKey k
+      )
 
 delegsTransition ::
   forall crypto.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -37,7 +37,7 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..))
 import Shelley.Spec.Ledger.STS.Pool (POOL, PoolEnv (..))
-import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.TxData
   ( DCert (..),
@@ -91,15 +91,17 @@ instance
   FromCBOR (PredicateFailure (DELPL crypto))
   where
   fromCBOR =
-    decodeRecordSum "PredicateFailure (DELPL crypto)"
-    (\case
-      0 -> do
-        a <- fromCBOR
-        pure (2,PoolFailure a)
-      1 -> do
-        a <- fromCBOR
-        pure (2,DelegFailure a)
-      k -> invalidKey k)
+    decodeRecordSum
+      "PredicateFailure (DELPL crypto)"
+      ( \case
+          0 -> do
+            a <- fromCBOR
+            pure (2, PoolFailure a)
+          1 -> do
+            a <- fromCBOR
+            pure (2, DelegFailure a)
+          k -> invalidKey k
+      )
 
 delplTransition ::
   forall crypto.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -48,7 +48,6 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState,
   )
 import Shelley.Spec.Ledger.PParams (PParams)
-import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
 import Shelley.Spec.Ledger.STS.Delegs (DELEGS, DelegsEnv (..))
 import Shelley.Spec.Ledger.STS.Utxo
   ( UtxoEnv (..),
@@ -62,6 +61,7 @@ import Shelley.Spec.Ledger.STS.Utxo
     pattern ValueNotConservedUTxO,
   )
 import Shelley.Spec.Ledger.STS.Utxow (PredicateFailure (..), UTXOW)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..), TxBody (..))
 
@@ -109,15 +109,17 @@ instance
   (Crypto crypto) =>
   FromCBOR (PredicateFailure (LEDGER crypto))
   where
-  fromCBOR = decodeRecordSum "PredicateFailure (LEDGER crypto)" $
-    (\case
-      0 -> do
-        a <- fromCBOR
-        pure (2,UtxowFailure a)
-      1 -> do
-        a <- fromCBOR
-        pure (2,DelegsFailure a)
-      k -> invalidKey k)
+  fromCBOR =
+    decodeRecordSum "PredicateFailure (LEDGER crypto)" $
+      ( \case
+          0 -> do
+            a <- fromCBOR
+            pure (2, UtxowFailure a)
+          1 -> do
+            a <- fromCBOR
+            pure (2, DelegsFailure a)
+          k -> invalidKey k
+      )
 
 ledgerTransition ::
   forall crypto.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -40,8 +40,8 @@ import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState (PState (..), emptyPState)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo, epochInfoEpoch)
-import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
 import Shelley.Spec.Ledger.TxData
   ( DCert (..),
     PoolCert (..),
@@ -102,22 +102,22 @@ instance
   FromCBOR (PredicateFailure (POOL crypto))
   where
   fromCBOR = decodeRecordSum "PredicateFailure (POOL crypto)" $
-   \case
+    \case
       0 -> do
         kh <- fromCBOR
-        pure (2,StakePoolNotRegisteredOnKeyPOOL kh)
+        pure (2, StakePoolNotRegisteredOnKeyPOOL kh)
       1 -> do
         ce <- fromCBOR
         e <- fromCBOR
         em <- fromCBOR
-        pure (4,StakePoolRetirementWrongEpochPOOL ce e em)
+        pure (4, StakePoolRetirementWrongEpochPOOL ce e em)
       2 -> do
         ct <- fromCBOR
-        pure (2,WrongCertificateTypePOOL ct)
+        pure (2, WrongCertificateTypePOOL ct)
       3 -> do
         pc <- fromCBOR
         mc <- fromCBOR
-        pure (3,StakePoolCostTooLowPOOL pc mc)
+        pure (3, StakePoolCostTooLowPOOL pc mc)
       k -> invalidKey k
 
 poolDelegationTransition :: Typeable crypto => TransitionRule (POOL crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -16,10 +16,7 @@ where
 import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (..),
-    decodeListLen,
-    decodeWord,
     encodeListLen,
-    matchSize,
   )
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Iterate.SetAlgebra (dom, eval, setSingleton, singleton, (∈), (∉), (∪), (⋪), (⨃))
@@ -44,6 +41,7 @@ import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState (PState (..), emptyPState)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo, epochInfoEpoch)
+import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
 import Shelley.Spec.Ledger.TxData
   ( DCert (..),
     PoolCert (..),
@@ -103,28 +101,23 @@ instance
   (Crypto crypto) =>
   FromCBOR (PredicateFailure (POOL crypto))
   where
-  fromCBOR = do
-    n <- decodeListLen
-    decodeWord >>= \case
+  fromCBOR = decodeRecordSum "PredicateFailure (POOL crypto)" $
+   \case
       0 -> do
-        matchSize "StakePoolNotRegisteredOnKeyPOOL" 2 n
         kh <- fromCBOR
-        pure $ StakePoolNotRegisteredOnKeyPOOL kh
+        pure (2,StakePoolNotRegisteredOnKeyPOOL kh)
       1 -> do
         ce <- fromCBOR
         e <- fromCBOR
         em <- fromCBOR
-        matchSize "StakePoolRetirementWrongEpochPOOL" 4 n
-        pure $ StakePoolRetirementWrongEpochPOOL ce e em
+        pure (4,StakePoolRetirementWrongEpochPOOL ce e em)
       2 -> do
-        matchSize "WrongCertificateTypePOOL" 2 n
         ct <- fromCBOR
-        pure $ WrongCertificateTypePOOL ct
+        pure (2,WrongCertificateTypePOOL ct)
       3 -> do
-        matchSize "StakePoolCostTooLowPOOL" 3 n
         pc <- fromCBOR
         mc <- fromCBOR
-        pure $ StakePoolCostTooLowPOOL pc mc
+        pure (3,StakePoolCostTooLowPOOL pc mc)
       k -> invalidKey k
 
 poolDelegationTransition :: Typeable crypto => TransitionRule (POOL crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -35,7 +35,7 @@ import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.LedgerState (PPUPState (..), pvCanFollow)
 import Shelley.Spec.Ledger.PParams
-import Shelley.Spec.Ledger.Serialization(decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot
 
 data PPUP crypto
@@ -105,15 +105,15 @@ instance
       0 -> do
         a <- fromCBOR
         b <- fromCBOR
-        pure (3,NonGenesisUpdatePPUP a b)
+        pure (3, NonGenesisUpdatePPUP a b)
       1 -> do
         a <- fromCBOR
         b <- fromCBOR
         c <- fromCBOR
-        pure (4,PPUpdateWrongEpoch a b c)
+        pure (4, PPUpdateWrongEpoch a b c)
       2 -> do
         p <- fromCBOR
-        pure (2,PVCannotFollowPPUP p)
+        pure (2, PVCannotFollowPPUP p)
       k -> invalidKey k
 
 ppupTransitionNonEmpty :: Typeable crypto => TransitionRule (PPUP crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL,
@@ -24,7 +25,6 @@ where
 import Cardano.Binary
   ( FromCBOR (fromCBOR),
     ToCBOR (toCBOR),
-    decodeListLenOf,
     encodeListLen,
   )
 import qualified Cardano.Crypto.VRF as VRF
@@ -60,6 +60,7 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.LedgerState (OBftSlot)
 import Shelley.Spec.Ledger.OCert (OCertSignable)
+import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
 import Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
 import Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
 import Shelley.Spec.Ledger.Slot (BlockNo, SlotNo)
@@ -87,11 +88,11 @@ instance Crypto crypto => ToCBOR (PrtclState crypto) where
 
 instance Crypto crypto => FromCBOR (PrtclState crypto) where
   fromCBOR =
-    decodeListLenOf 3
-      >> PrtclState
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+    decodeRecordNamed "PrtclState" (const 3)
+      (PrtclState
+       <$> fromCBOR
+       <*> fromCBOR
+       <*> fromCBOR)
 
 instance Crypto crypto => NoUnexpectedThunks (PrtclState crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL,
@@ -60,9 +60,9 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.LedgerState (OBftSlot)
 import Shelley.Spec.Ledger.OCert (OCertSignable)
-import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
 import Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
 import Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (BlockNo, SlotNo)
 
 data PRTCL crypto
@@ -88,11 +88,14 @@ instance Crypto crypto => ToCBOR (PrtclState crypto) where
 
 instance Crypto crypto => FromCBOR (PrtclState crypto) where
   fromCBOR =
-    decodeRecordNamed "PrtclState" (const 3)
-      (PrtclState
-       <$> fromCBOR
-       <*> fromCBOR
-       <*> fromCBOR)
+    decodeRecordNamed
+      "PrtclState"
+      (const 3)
+      ( PrtclState
+          <$> fromCBOR
+          <*> fromCBOR
+          <*> fromCBOR
+      )
 
 instance Crypto crypto => NoUnexpectedThunks (PrtclState crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Tickn
   ( TICKN,
@@ -22,7 +21,7 @@ import Control.State.Transition
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.PParams
-import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
+import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 
 data TICKN
 
@@ -43,10 +42,13 @@ instance NoUnexpectedThunks TicknState
 
 instance FromCBOR TicknState where
   fromCBOR =
-    decodeRecordNamed "TicknState" (const 2)
-      (TicknState
-       <$> fromCBOR
-       <*> fromCBOR)
+    decodeRecordNamed
+      "TicknState"
+      (const 2)
+      ( TicknState
+          <$> fromCBOR
+          <*> fromCBOR
+      )
 
 instance ToCBOR TicknState where
   toCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.STS.Tickn
   ( TICKN,
@@ -15,12 +16,13 @@ module Shelley.Spec.Ledger.STS.Tickn
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import Cardano.Prelude (NoUnexpectedThunks)
 import Control.State.Transition
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Serialization(decodeRecordNamed)
 
 data TICKN
 
@@ -41,10 +43,10 @@ instance NoUnexpectedThunks TicknState
 
 instance FromCBOR TicknState where
   fromCBOR =
-    decodeListLenOf 2
-      >> TicknState
-      <$> fromCBOR
-      <*> fromCBOR
+    decodeRecordNamed "TicknState" (const 2)
+      (TicknState
+       <$> fromCBOR
+       <*> fromCBOR)
 
 instance ToCBOR TicknState where
   toCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -201,36 +201,45 @@ instance
   where
   fromCBOR =
     decodeRecordSum "PredicateFailureUTXO" $
-        \case
-          0 -> do ins <- decodeSet fromCBOR
-                  pure (2,BadInputsUTxO ins)   -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
-          1 -> do a <- fromCBOR
-                  b <- fromCBOR
-                  pure (3,ExpiredUTxO a b)
-          2 -> do a <- fromCBOR
-                  b <- fromCBOR
-                  pure (3,MaxTxSizeUTxO a b)
-          3 -> pure (1,InputSetEmptyUTxO)
-          4 -> do a <- fromCBOR
-                  b <- fromCBOR
-                  pure (3,FeeTooSmallUTxO a b)
-          5 -> do a <- fromCBOR
-                  b <- fromCBOR
-                  pure (3,ValueNotConservedUTxO a b)
-          6 -> do outs <- decodeList fromCBOR
-                  pure (2,OutputTooSmallUTxO outs)
-          7 -> do a <- fromCBOR
-                  pure (2,UpdateFailure a)
-          8 -> do right <- fromCBOR
-                  wrongs <- decodeSet fromCBOR
-                  pure (3,WrongNetwork right wrongs)
-          9 -> do right <- fromCBOR
-                  wrongs <- decodeSet fromCBOR
-                  pure (3,WrongNetworkWithdrawal right wrongs)
-          10-> do outs <- decodeList fromCBOR
-                  pure (2,OutputBootAddrAttrsTooBig outs)
-          k -> invalidKey k
-
+      \case
+        0 -> do
+          ins <- decodeSet fromCBOR
+          pure (2, BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
+        1 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, ExpiredUTxO a b)
+        2 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, MaxTxSizeUTxO a b)
+        3 -> pure (1, InputSetEmptyUTxO)
+        4 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, FeeTooSmallUTxO a b)
+        5 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, ValueNotConservedUTxO a b)
+        6 -> do
+          outs <- decodeList fromCBOR
+          pure (2, OutputTooSmallUTxO outs)
+        7 -> do
+          a <- fromCBOR
+          pure (2, UpdateFailure a)
+        8 -> do
+          right <- fromCBOR
+          wrongs <- decodeSet fromCBOR
+          pure (3, WrongNetwork right wrongs)
+        9 -> do
+          right <- fromCBOR
+          wrongs <- decodeSet fromCBOR
+          pure (3, WrongNetworkWithdrawal right wrongs)
+        10 -> do
+          outs <- decodeList fromCBOR
+          pure (2, OutputBootAddrAttrsTooBig outs)
+        k -> invalidKey k
 
 initialLedgerState :: InitialRule (UTXO crypto)
 initialLedgerState = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -78,7 +78,7 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.MetaData (MetaDataHash, hashMetaData)
 import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv (..))
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
-import Shelley.Spec.Ledger.Serialization (decodeList, decodeSet, encodeFoldable, decodeRecordSum)
+import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordSum, decodeSet, encodeFoldable)
 import Shelley.Spec.Ledger.Tx
   ( Tx (..),
     hashScript,
@@ -156,32 +156,32 @@ instance
     \case
       0 -> do
         wits <- decodeList fromCBOR
-        pure (2,InvalidWitnessesUTXOW wits)
+        pure (2, InvalidWitnessesUTXOW wits)
       1 -> do
         missing <- decodeSet fromCBOR
-        pure (2,MissingVKeyWitnessesUTXOW $ WitHashes missing)
+        pure (2, MissingVKeyWitnessesUTXOW $ WitHashes missing)
       2 -> do
         ss <- decodeSet fromCBOR
-        pure (2,MissingScriptWitnessesUTXOW ss)
+        pure (2, MissingScriptWitnessesUTXOW ss)
       3 -> do
         ss <- decodeSet fromCBOR
-        pure (2,ScriptWitnessNotValidatingUTXOW ss)
+        pure (2, ScriptWitnessNotValidatingUTXOW ss)
       4 -> do
         a <- fromCBOR
-        pure (2,UtxoFailure a)
+        pure (2, UtxoFailure a)
       5 -> do
         s <- decodeSet fromCBOR
-        pure (2,MIRInsufficientGenesisSigsUTXOW s)
+        pure (2, MIRInsufficientGenesisSigsUTXOW s)
       6 -> do
         h <- fromCBOR
-        pure (2,MissingTxBodyMetaDataHash h)
+        pure (2, MissingTxBodyMetaDataHash h)
       7 -> do
         h <- fromCBOR
-        pure (2,MissingTxMetaData h)
+        pure (2, MissingTxMetaData h)
       8 -> do
         bodyHash <- fromCBOR
         fullMDHash <- fromCBOR
-        pure (3,ConflictingMetaDataHash bodyHash fullMDHash)
+        pure (3, ConflictingMetaDataHash bodyHash fullMDHash)
       k -> invalidKey k
 
 initialLedgerStateUTXOW ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -220,16 +220,16 @@ instance
   FromCBOR (Annotator (MultiSig' crypto))
   where
   fromCBOR = decodeRecordSum "MultiSig" $
-        \case
-          0 -> (,) 2 . pure . RequireSignature' . KeyHash <$> fromCBOR
-          1 -> do
-            multiSigs <- sequence <$> decodeList fromCBOR
-            pure (2, RequireAllOf' <$> multiSigs)
-          2 -> do
-            multiSigs <- sequence <$> decodeList fromCBOR
-            pure (2, RequireAnyOf' <$> multiSigs)
-          3 -> do
-            m <- fromCBOR
-            multiSigs <- sequence <$> decodeList fromCBOR
-            pure $ (3, RequireMOf' m <$> multiSigs)
-          k -> invalidKey k
+    \case
+      0 -> (,) 2 . pure . RequireSignature' . KeyHash <$> fromCBOR
+      1 -> do
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure (2, RequireAllOf' <$> multiSigs)
+      2 -> do
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure (2, RequireAnyOf' <$> multiSigs)
+      3 -> do
+        m <- fromCBOR
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure $ (3, RequireMOf' m <$> multiSigs)
+      k -> invalidKey k

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -34,7 +34,6 @@ import Cardano.Binary
     FromCBOR (fromCBOR),
     ToCBOR (toCBOR),
     annotatorSlice,
-    decodeWord,
     encodeListLen,
     encodePreEncoded,
     encodeWord,
@@ -57,7 +56,7 @@ import Shelley.Spec.Ledger.BaseTypes (invalidKey)
 import Shelley.Spec.Ledger.Crypto (Crypto (..))
 import Shelley.Spec.Ledger.Hashing (HashAnnotated (..))
 import Shelley.Spec.Ledger.Keys (Hash, KeyHash (..), KeyRole (Witness))
-import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordNamed, encodeFoldable)
+import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordSum, encodeFoldable)
 
 -- | Magic number representing the tag of the native multi-signature script
 -- language. For each script language included, a new tag is chosen and the tag
@@ -220,10 +219,8 @@ instance
   Crypto crypto =>
   FromCBOR (Annotator (MultiSig' crypto))
   where
-  fromCBOR =
-    fmap snd $
-      decodeRecordNamed "MultiSig" fst $
-        decodeWord >>= \case
+  fromCBOR = decodeRecordSum "MultiSig" $
+        \case
           0 -> (,) 2 . pure . RequireSignature' . KeyHash <$> fromCBOR
           1 -> do
             multiSigs <- sequence <$> decodeList fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
@@ -21,6 +21,7 @@ module Shelley.Spec.Ledger.Serialization
     decodeMapTraverse,
     decodeMaybe,
     decodeRecordNamed,
+    decodeRecordSum,
     decodeNullMaybe,
     encodeFoldable,
     encodeFoldableEncoder,
@@ -42,6 +43,7 @@ module Shelley.Spec.Ledger.Serialization
     ipv6ToCBOR,
     ipv6FromCBOR,
     -- Raw
+    listLenInt,
     runByteBuilder,
   )
 where
@@ -59,6 +61,7 @@ import Cardano.Binary
     decodeMapLenOrIndef,
     decodeNull,
     decodeTag,
+    decodeWord,
     encodeBreak,
     encodeListLen,
     encodeListLenIndef,
@@ -115,6 +118,10 @@ class Typeable a => ToCBORGroup a where
   -- | an upper bound for 'listLen', used in 'Size' expressions.
   listLenBound :: Proxy a -> Word
 
+
+listLenInt :: ToCBORGroup a => a -> Int
+listLenInt x = fromIntegral (listLen x)
+
 newtype CBORGroup a = CBORGroup {unCBORGroup :: a}
 
 instance ToCBORGroup a => ToCBOR (CBORGroup a) where
@@ -140,6 +147,19 @@ decodeRecordNamed name getRecordSize decode = do
     Nothing -> do
       isBreak <- decodeBreakOr
       unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
+  pure x
+
+
+decodeRecordSum:: String -> (Word -> Decoder s (Int, a)) -> Decoder s a
+decodeRecordSum name decode = do
+  lenOrIndef <- decodeListLenOrIndef
+  tag <- decodeWord
+  (size, x) <- decode tag -- we decode all the stuff we want
+  case lenOrIndef of
+    Just n -> matchSize (Text.pack(name++" tag="++show size)) size n
+    Nothing -> do
+      isBreak <- decodeBreakOr -- if there is stuff left, it is unnecessary extra stuff
+      unless isBreak $ cborError $ DecoderErrorCustom (Text.pack name) "Excess terms in array"
   pure x
 
 groupRecord :: forall a s. (ToCBORGroup a, FromCBORGroup a) => Decoder s a

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
@@ -118,7 +118,6 @@ class Typeable a => ToCBORGroup a where
   -- | an upper bound for 'listLen', used in 'Size' expressions.
   listLenBound :: Proxy a -> Word
 
-
 listLenInt :: ToCBORGroup a => a -> Int
 listLenInt x = fromIntegral (listLen x)
 
@@ -149,14 +148,13 @@ decodeRecordNamed name getRecordSize decode = do
       unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
   pure x
 
-
-decodeRecordSum:: String -> (Word -> Decoder s (Int, a)) -> Decoder s a
+decodeRecordSum :: String -> (Word -> Decoder s (Int, a)) -> Decoder s a
 decodeRecordSum name decode = do
   lenOrIndef <- decodeListLenOrIndef
   tag <- decodeWord
   (size, x) <- decode tag -- we decode all the stuff we want
   case lenOrIndef of
-    Just n -> matchSize (Text.pack(name++" tag="++show size)) size n
+    Just n -> matchSize (Text.pack (name ++ " tag=" ++ show size)) size n
     Nothing -> do
       isBreak <- decodeBreakOr -- if there is stuff left, it is unnecessary extra stuff
       unless isBreak $ cborError $ DecoderErrorCustom (Text.pack name) "Excess terms in array"

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -75,7 +75,6 @@ import Cardano.Binary
     encodeMapLen,
     encodePreEncoded,
     encodeWord,
-    enforceSize,
     serializeEncoding,
     serializeEncoding',
     szCases,
@@ -746,10 +745,10 @@ instance
   FromCBOR (TxIn crypto)
   where
   fromCBOR = do
-    enforceSize "TxIn" 2
-    a <- fromCBOR
-    (b :: Word64) <- fromCBOR
-    pure $ TxIn a (fromInteger $ toInteger b)
+    decodeRecordNamed "TxIn" (const 2) $ do
+       a <- fromCBOR
+       (b :: Word64) <- fromCBOR
+       pure $ TxIn a (fromInteger $ toInteger b)
 
 instance
   (Typeable crypto, Crypto crypto) =>
@@ -872,10 +871,10 @@ instance ToCBOR PoolMetaData where
 
 instance FromCBOR PoolMetaData where
   fromCBOR = do
-    enforceSize "PoolMetaData" 2
-    u <- fromCBOR
-    h <- fromCBOR
-    pure $ PoolMetaData u h
+    decodeRecordNamed "PoolMetaData" (const 2) $ do
+       u <- fromCBOR
+       h <- fromCBOR
+       pure $ PoolMetaData u h
 
 -- | The size of the '_poolOwners' 'Set'.  Only used to compute size of encoded
 -- 'PoolParams'.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -14,10 +14,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE TupleSections #-}
 
 module Shelley.Spec.Ledger.TxData
   ( DCert (..),
@@ -303,15 +303,18 @@ instance ToCBOR StakePoolRelay where
 instance FromCBOR StakePoolRelay where
   fromCBOR = decodeRecordSum "StakePoolRelay" $
     \case
-      0 -> (\ x y z -> (4,SingleHostAddr x y z))
-           <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
-           <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
-           <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
-      1 -> (\ x y -> (3,SingleHostName x y))
-           <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
-           <*> fromCBOR
-      2 -> do x <- fromCBOR
-              pure(2,MultiHostName x)
+      0 ->
+        (\x y z -> (4, SingleHostAddr x y z))
+          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
+          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
+          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
+      1 ->
+        (\x y -> (3, SingleHostName x y))
+          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
+          <*> fromCBOR
+      2 -> do
+        x <- fromCBOR
+        pure (2, MultiHostName x)
       k -> invalidKey k
 
 -- | A stake pool.
@@ -704,29 +707,29 @@ instance
     \case
       0 -> do
         x <- fromCBOR
-        pure(2, DCertDeleg . RegKey $ x)
+        pure (2, DCertDeleg . RegKey $ x)
       1 -> do
         x <- fromCBOR
-        pure(2, DCertDeleg . DeRegKey $ x)
+        pure (2, DCertDeleg . DeRegKey $ x)
       2 -> do
         a <- fromCBOR
         b <- fromCBOR
-        pure (3,DCertDeleg $ Delegate (Delegation a b))
+        pure (3, DCertDeleg $ Delegate (Delegation a b))
       3 -> do
         group <- fromCBORGroup
-        pure (fromIntegral(1 + listLenInt group),DCertPool(RegPool group))
+        pure (fromIntegral (1 + listLenInt group), DCertPool (RegPool group))
       4 -> do
         a <- fromCBOR
         b <- fromCBOR
-        pure (3,DCertPool $ RetirePool a (EpochNo b))
+        pure (3, DCertPool $ RetirePool a (EpochNo b))
       5 -> do
         a <- fromCBOR
         b <- fromCBOR
         c <- fromCBOR
-        pure (4,DCertGenesis $ GenesisDelegCert a b c)
+        pure (4, DCertGenesis $ GenesisDelegCert a b c)
       6 -> do
         x <- fromCBOR
-        pure(2,DCertMir x)
+        pure (2, DCertMir x)
       k -> invalidKey k
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -746,9 +746,9 @@ instance
   where
   fromCBOR = do
     decodeRecordNamed "TxIn" (const 2) $ do
-       a <- fromCBOR
-       (b :: Word64) <- fromCBOR
-       pure $ TxIn a (fromInteger $ toInteger b)
+      a <- fromCBOR
+      (b :: Word64) <- fromCBOR
+      pure $ TxIn a (fromInteger $ toInteger b)
 
 instance
   (Typeable crypto, Crypto crypto) =>
@@ -872,9 +872,9 @@ instance ToCBOR PoolMetaData where
 instance FromCBOR PoolMetaData where
   fromCBOR = do
     decodeRecordNamed "PoolMetaData" (const 2) $ do
-       u <- fromCBOR
-       h <- fromCBOR
-       pure $ PoolMetaData u h
+      u <- fromCBOR
+      h <- fromCBOR
+      pure $ PoolMetaData u h
 
 -- | The size of the '_poolOwners' 'Set'.  Only used to compute size of encoded
 -- 'PoolParams'.


### PR DESCRIPTION
This PR will close issue #1324 when approved.  It removes all occurrences of decodeListLen and replaces them with decoders that will accept either listLength -style encoding, or break-style encoding of record fields.