### PR TITLE
Fix laziness

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/bench/Main.hs
+++ b/shelley/chain-and-ledger/executable-spec/bench/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra (keysEqual)
 import Criterion.Main (Benchmark, bench, bgroup, defaultMain, env, whnf)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Word (Word64)
 import Shelley.Spec.Ledger.LedgerState (DPState (..), UTxOState (..))
 import Test.Shelley.Spec.Ledger.BenchmarkFunctions

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -12,8 +12,8 @@ import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (SlotNo)
 import Data.Functor.Identity (runIdentity)
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
 import Data.Set (Set)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -27,7 +27,7 @@ import Cardano.Binary
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.Iterate.SetAlgebra (dom, eval, (∈), (⨃))
 import Control.State.Transition (Embed (..), STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans, (?!), (?!:))
-import Data.Map as Map
+import Data.Map.Strict as Map
 import Data.Sequence (Seq (..))
 import Data.Typeable (Typeable)
 import Data.Word (Word8)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
@@ -88,8 +88,8 @@ import Data.IP
     toHostAddress,
     toHostAddress6,
   )
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Ratio (Ratio, denominator, numerator, (%))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq


### PR DESCRIPTION
While testing the memory footprint when we translate a Byron ledger to a Shelley for https://github.com/input-output-hk/ouroboros-network/issues/1404, we noticed a thunk at the Delegations Keys Map. The reason it exists is that aeson uses the lazy version of functions to create a Map from a JSON file. So even if we import the Strict Map, we still get a Map with unevaluated values.

This pr makes sure that this particular issue is fixed and makes the parsers for all fields of Genesis strict. It also replaces Data.Map with Data.Map.Strict in some places.