### PR TITLE
excess expansion goes back to the reserves

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -1262,8 +1262,8 @@ expectedStEx2D =
         )
         ( SJust
             RewardUpdate
-              { deltaT = Coin 7,
-                deltaR = Coin 0,
+              { deltaT = Coin 1,
+                deltaR = Coin 6,
                 rs = Map.empty,
                 deltaF = Coin (-7),
                 nonMyopic = emptyNonMyopic {rewardPotNM = Coin 6}
@@ -1360,8 +1360,8 @@ blockEx2EHash = bhHash (bheader blockEx2E)
 acntEx2E :: Crypto c => proxy c -> AccountState
 acntEx2E p =
   AccountState
-    { _treasury = Coin 7,
-      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR
+    { _treasury = Coin 1,
+      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR + Coin 6
     }
 
 oCertIssueNosEx2 :: Crypto c => Map (KeyHash 'BlockIssuer c) Word64
@@ -1456,8 +1456,8 @@ expectedStEx2F =
         (EpochState (acntEx2E p) (snapsEx2E p) expectedLSEx2E ppsEx1 ppsEx1 nonMyopicEx2E)
         ( SJust
             RewardUpdate
-              { deltaT = Coin 5,
-                deltaR = Coin 0,
+              { deltaT = Coin 1,
+                deltaR = Coin 4,
                 rs = Map.empty,
                 deltaF = Coin (-5),
                 nonMyopic = nonMyopicEx2F
@@ -1553,7 +1553,11 @@ oCertIssueNosEx2G =
     oCertIssueNosEx2F
 
 acntEx2G :: Crypto c => proxy c -> AccountState
-acntEx2G p = (acntEx2E p) {_treasury = Coin 12}
+acntEx2G p =
+  (acntEx2E p)
+    { _treasury = Coin 2,
+      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR + Coin 10
+    }
 
 expectedStEx2G :: forall c. Mock c => ChainState c
 expectedStEx2G =
@@ -1642,10 +1646,10 @@ alicePerfEx2H p = likelihood blocks t slotsPerEpoch
     f = runShelleyBase (asks activeSlotCoeff)
 
 deltaT2H :: Coin
-deltaT2H = Coin 786986666668
+deltaT2H = Coin 158666666666
 
 deltaR2H :: Coin
-deltaR2H = Coin (-793333333333)
+deltaR2H = Coin (-165013333331)
 
 nonMyopicEx2H :: forall c. Crypto c => NonMyopic c
 nonMyopicEx2H =

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1262,14 +1262,13 @@ The $\fun{createRUpd}$ function does the following:
   \item First we calculate the change to the reserves,
     as determined by the $\rho$ protocol parameter.
   \item Next we calculate $\var{rewardPot}$, the total amount of coin available for rewards this
-    epoch, as described in section 6.4 of \cite{delegation_design}. It consists of four pots:
+    epoch, as described in section 6.4 of \cite{delegation_design}. It consists of:
     \begin{itemize}
       \item The fee pot, containing the transaction fees from the epoch.
-      \item The amount of coin in the deposit pot that is no longer needed, due to decay.
       \item The amount of monetary expansion from the reserves, calculated above.
     \end{itemize}
-    Note that the fee pot and the decayed amount are taken from the snapshot taken at the
-    epoch boundary.  (See~Figure\ref{fig:rules:snapshot}).
+    Note that the fee pot is taken from the snapshot taken at the epoch boundary.
+    (See~Figure\ref{fig:rules:snapshot}).
   \item Next we calculate the proportion of the reward pot that will move to the treasury,
     as determined by the $\tau$ protocol parameter. The remaining pot is called the
     $\var{R}$, just as in section 6.5 of \cite{delegation_design}.
@@ -1313,7 +1312,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \begin{align*}
     & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
     & \createRUpd{b}{es}{total} = \left(
-      \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS}\right) \\
+      \Delta t,-~\Delta r,~\var{rs},~-\var{feeSS}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{prevPp},~\wcard) = \var{es} \\
     & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{feeSS}) = \var{ss}\\
@@ -1326,18 +1325,19 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
       \wcard
       \right)
       \right) = \var{ls} \\
-    & ~~~~~~~\Delta r = \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
+    & ~~~~~~~\var{maxExpansion}= \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
       \var{reserves}}
     \\
     & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \ActiveSlotCoeff} \\
-    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r \\
-    & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
-    & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
+    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \var{maxExpansion} \\
+    & ~~~~~~~\Delta t = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
+    & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t \\
     & ~~~~~~~\var{circulation} = \var{total} - \var{reserves} \\
     & ~~~~~~~\var{rs}
       = \reward{prevPp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs}{circulation} \\
-    & ~~~~~~~\Delta t_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
-    & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m
+    & ~~~~~~~\var{totalRewards} = \sum\limits_{\_\mapsto c\in\var{rs}}c \\
+    & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m \\
+    & ~~~~~~~\Delta r = \var{feeSS} - (\Delta t + totalRewards)
   \end{align*}
 
   \caption{Reward Update Creation}


### PR DESCRIPTION
Instead of putting the excess expansion into the treasury, we now put it into the reserves

**Note** this is equivalent to #1703 but does just a little bit of clean up and algebraic simplification. We should not merge both.