### PR TITLE
Add type specific domain exclusion implementation

### DIFF
--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
@@ -1053,6 +1053,7 @@ compute (e@(Intersect a b)) = run(compile e)
 
 compute (UnionOverrideLeft (Base rep x) (Singleton k v))  = addkv (k,v) x (\ new old -> old) -- The value on the left is preferred over the right, so 'addkv' chooses 'old'
 compute (UnionOverrideLeft (Base MapR d0) (Base MapR d1)) = Map.union d0 d1  -- 'Map.union' is left biased, just what we want.
+compute (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m2)) (Base MapR m3)) =  Map.union (Map.withoutKeys m2 s1) m3
 compute (e@(UnionOverrideLeft a b)) = run(compile e)
 
 compute (UnionOverrideRight (Base rep x) (Singleton k v)) = addkv (k,v) x (\ new old -> new) -- The value on the right is preferred over the left, so 'addkv' chooses 'new'

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SetAlgTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SetAlgTests.hs
@@ -30,7 +30,6 @@ import Data.Char (ord)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import qualified Data.Set as Set
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -148,6 +147,19 @@ ex6 = rng (singleton 'z' 2) ⋪ m0
 ex7 :: Exp Bool
 ex7 = 70 ∉ (dom m1)
 
+
+z1:: Map Int String
+z1 = Map.fromList [(3, "c"), (4, "d"), (5, "e"), (6, "f"), (10, "j"), (11, "k"), (21, "v")]
+
+z2 :: Set.Set Int
+z2 = Set.fromList [4,6,11,13,2]
+
+z3 :: Map Int String
+z3 = Map.fromList [(9,"3"),(10,"j"),(30,"a")]
+
+z4::Map Int String
+z4 =  Map.fromList [(3, "c"), (5, "e"), (10, "j"), (21, "v"), (9,"3"),(30,"a")]
+
 -- ===================== test that compute works ======================
 
 -- Test that computing  x::(Exp t) computes to the given object with type t.
@@ -182,6 +194,8 @@ eval_tests =
       evalTest "Range exclude 1" (l4 ⋫ Set.empty) (UnSafeList l4),
       evalTest "Range exclude 2" (l4 ⋫ Fail) (UnSafeList l4),
       evalTest "Range exclude 3" (l4 ⋫ (Set.fromList ["m", "Z"])) (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "a"), (50, "q"), (51, "l")]),
+      evalTest "DomExclude Union" ((z2 ⋪ z1) ∪ z3) z4,
+
       eval_compile (((dom stkcred) ◁ deleg) ▷ (dom stpool)),
       eval_compile (l4 ⋫ (Set.fromList ["m", "Z"])),
       eval_compile (m0 ∪ (singleton 3 'b')),

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SetAlgTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/SetAlgTests.hs
@@ -147,18 +147,17 @@ ex6 = rng (singleton 'z' 2) ⋪ m0
 ex7 :: Exp Bool
 ex7 = 70 ∉ (dom m1)
 
-
-z1:: Map Int String
+z1 :: Map Int String
 z1 = Map.fromList [(3, "c"), (4, "d"), (5, "e"), (6, "f"), (10, "j"), (11, "k"), (21, "v")]
 
 z2 :: Set.Set Int
-z2 = Set.fromList [4,6,11,13,2]
+z2 = Set.fromList [4, 6, 11, 13, 2]
 
 z3 :: Map Int String
-z3 = Map.fromList [(9,"3"),(10,"j"),(30,"a")]
+z3 = Map.fromList [(9, "3"), (10, "j"), (30, "a")]
 
-z4::Map Int String
-z4 =  Map.fromList [(3, "c"), (5, "e"), (10, "j"), (21, "v"), (9,"3"),(30,"a")]
+z4 :: Map Int String
+z4 = Map.fromList [(3, "c"), (5, "e"), (10, "j"), (21, "v"), (9, "3"), (30, "a")]
 
 -- ===================== test that compute works ======================
 
@@ -195,7 +194,6 @@ eval_tests =
       evalTest "Range exclude 2" (l4 ⋫ Fail) (UnSafeList l4),
       evalTest "Range exclude 3" (l4 ⋫ (Set.fromList ["m", "Z"])) (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "a"), (50, "q"), (51, "l")]),
       evalTest "DomExclude Union" ((z2 ⋪ z1) ∪ z3) z4,
-
       eval_compile (((dom stkcred) ◁ deleg) ▷ (dom stpool)),
       eval_compile (l4 ⋫ (Set.fromList ["m", "Z"])),
       eval_compile (m0 ∪ (singleton 3 'b')),


### PR DESCRIPTION
Kevin Hammond communicated a problem with SetAlgebra. Studying a .profile file, it appears to be a generic

implementation of   ((txins txb ⋪ utxo) ∪ txouts txb).  We modified SetAlgebraInternal.hs to provide
a type specific implementation, and added a new test to SetAlgebraTests.hs to be sure it works.