### PR TITLE
excess expansion goes back to the reserves - minimal change

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -43,7 +43,7 @@ with (import pkgs.iohkNix.release-lib) {
 with pkgs.lib;
 
 let
-  testsSupportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+  testsSupportedSystems = [ "x86_64-linux" ];
   # Recurse through an attrset, returning all test derivations in a list.
   collectTests' = ds: filter (d: elem d.system testsSupportedSystems) (collect isDerivation ds);
   # Adds the package name to the test derivations for windows-testing-bundle.nix

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -998,28 +998,29 @@ createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
       Coin reserves = _reserves acnt
       ds = _dstate $ _delegationState ls
       -- reserves and rewards change
-      deltaR_ = (rationalToCoinViaFloor $ min 1 eta * unitIntervalToRational (_rho pr) * fromIntegral reserves)
+      deltaR1 = (rationalToCoinViaFloor $ min 1 eta * unitIntervalToRational (_rho pr) * fromIntegral reserves)
       expectedBlocks =
         floor $
           unitIntervalToRational (activeSlotVal asc) * fromIntegral slotsPerEpoch
       -- TODO asc is a global constant, and slotsPerEpoch should not change often at all,
       -- it would be nice to not have to compute expectedBlocks every epoch
       eta = blocksMade % expectedBlocks
-      Coin rPot = _feeSS ss + deltaR_
+      Coin rPot = _feeSS ss + deltaR1
       deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
       _R = Coin $ rPot - deltaT1
       circulation = total - (_reserves acnt)
       (rs_, newLikelihoods) =
         reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' circulation asc slotsPerEpoch
-      deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
+      deltaR2 = _R - (Map.foldr (+) (Coin 0) rs_)
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $
     RewardUpdate
-      (Coin deltaT1 + deltaT2)
-      (- deltaR_)
-      rs_
-      (- (_feeSS ss))
-      (updateNonMypopic nm _R newLikelihoods (_pstakeGo ss))
+      { deltaT = (Coin deltaT1),
+        deltaR = (- deltaR1 + deltaR2),
+        rs = rs_,
+        deltaF = (- (_feeSS ss)),
+        nonMyopic = (updateNonMypopic nm _R newLikelihoods (_pstakeGo ss))
+      }
 
 -- | Overlay schedule
 -- This is just a very simple round-robin, evenly spaced schedule.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -1262,8 +1262,8 @@ expectedStEx2D =
         )
         ( SJust
             RewardUpdate
-              { deltaT = Coin 7,
-                deltaR = Coin 0,
+              { deltaT = Coin 1,
+                deltaR = Coin 6,
                 rs = Map.empty,
                 deltaF = Coin (-7),
                 nonMyopic = emptyNonMyopic {rewardPotNM = Coin 6}
@@ -1360,8 +1360,8 @@ blockEx2EHash = bhHash (bheader blockEx2E)
 acntEx2E :: Crypto c => proxy c -> AccountState
 acntEx2E p =
   AccountState
-    { _treasury = Coin 7,
-      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR
+    { _treasury = Coin 1,
+      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR + Coin 6
     }
 
 oCertIssueNosEx2 :: Crypto c => Map (KeyHash 'BlockIssuer c) Word64
@@ -1456,8 +1456,8 @@ expectedStEx2F =
         (EpochState (acntEx2E p) (snapsEx2E p) expectedLSEx2E ppsEx1 ppsEx1 nonMyopicEx2E)
         ( SJust
             RewardUpdate
-              { deltaT = Coin 5,
-                deltaR = Coin 0,
+              { deltaT = Coin 1,
+                deltaR = Coin 4,
                 rs = Map.empty,
                 deltaF = Coin (-5),
                 nonMyopic = nonMyopicEx2F
@@ -1553,7 +1553,11 @@ oCertIssueNosEx2G =
     oCertIssueNosEx2F
 
 acntEx2G :: Crypto c => proxy c -> AccountState
-acntEx2G p = (acntEx2E p) {_treasury = Coin 12}
+acntEx2G p =
+  (acntEx2E p)
+    { _treasury = Coin 2,
+      _reserves = maxLLSupply - balance (utxoEx2A p) - carlMIR + Coin 10
+    }
 
 expectedStEx2G :: forall c. Mock c => ChainState c
 expectedStEx2G =
@@ -1642,10 +1646,10 @@ alicePerfEx2H p = likelihood blocks t slotsPerEpoch
     f = runShelleyBase (asks activeSlotCoeff)
 
 deltaT2H :: Coin
-deltaT2H = Coin 786986666668
+deltaT2H = Coin 158666666666
 
 deltaR2H :: Coin
-deltaR2H = Coin (-793333333333)
+deltaR2H = Coin (-165013333331)
 
 nonMyopicEx2H :: forall c. Crypto c => NonMyopic c
 nonMyopicEx2H =

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1262,14 +1262,13 @@ The $\fun{createRUpd}$ function does the following:
   \item First we calculate the change to the reserves,
     as determined by the $\rho$ protocol parameter.
   \item Next we calculate $\var{rewardPot}$, the total amount of coin available for rewards this
-    epoch, as described in section 6.4 of \cite{delegation_design}. It consists of four pots:
+    epoch, as described in section 6.4 of \cite{delegation_design}. It consists of:
     \begin{itemize}
       \item The fee pot, containing the transaction fees from the epoch.
-      \item The amount of coin in the deposit pot that is no longer needed, due to decay.
       \item The amount of monetary expansion from the reserves, calculated above.
     \end{itemize}
-    Note that the fee pot and the decayed amount are taken from the snapshot taken at the
-    epoch boundary.  (See~Figure\ref{fig:rules:snapshot}).
+    Note that the fee pot is taken from the snapshot taken at the epoch boundary.
+    (See~Figure\ref{fig:rules:snapshot}).
   \item Next we calculate the proportion of the reward pot that will move to the treasury,
     as determined by the $\tau$ protocol parameter. The remaining pot is called the
     $\var{R}$, just as in section 6.5 of \cite{delegation_design}.
@@ -1313,7 +1312,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \begin{align*}
     & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
     & \createRUpd{b}{es}{total} = \left(
-      \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS}\right) \\
+      \Delta t_1,-~\Delta r_1+\Delta r_2,~\var{rs},~-\var{feeSS}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{prevPp},~\wcard) = \var{es} \\
     & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{feeSS}) = \var{ss}\\
@@ -1326,17 +1325,17 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
       \wcard
       \right)
       \right) = \var{ls} \\
-    & ~~~~~~~\Delta r = \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
+    & ~~~~~~~\Delta r_1 = \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
       \var{reserves}}
     \\
     & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \ActiveSlotCoeff} \\
-    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r \\
+    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r_1 \\
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
     & ~~~~~~~\var{circulation} = \var{total} - \var{reserves} \\
     & ~~~~~~~\var{rs}
       = \reward{prevPp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs}{circulation} \\
-    & ~~~~~~~\Delta t_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
+    & ~~~~~~~\Delta r_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
     & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m
   \end{align*}
 

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -12,11 +12,11 @@
    \\[1em]
    Duncan Coutts  \quad \texttt{<duncan.coutts@iohk.io>}
 }
-\DueDate{06$^{\textrm{th}}$ July 2020}
-\SubmissionDate{06$^{\textrm{th}}$ July 2020}{2020/07/06}
+\DueDate{23$^{\textrm{th}}$ July 2020}
+\SubmissionDate{23$^{\textrm{th}}$ July 2020}{2020/07/23}
 \LeaderName{Philipp Kant, \IOHK}
 \InstitutionAddress{\IOHK}
-\Version{1.20}
+\Version{1.21}
 \Project{Shelley Ledger}
 \DisseminationPU
 
@@ -187,6 +187,8 @@ First version officially published on the IOHK blog.}
   create blocks when they fafil to meet their pledge.}
 \change{2020-07-06}{PK}{FM (IOHK)}{Minor changes after audit. Nothing that
   affects the implementation.}
+\change{2020-07-23}{PK}{FM (IOHK)}{Change: undistributed rewards go to the
+  reserves, not to the treasury.}
 \end{changelog}
 
 \clearpage%
@@ -1145,8 +1147,8 @@ The certificate contains the following:
 
   Should the reward address be unregistered, the stake pool operator will be
   unable to receive rewards. In that case, any rewards that they would be due
-  are instead paid to the treasury (but the stake pool members would still get
-  their usual rewards).
+  are instead sent back to the reserves (but the stake pool members would still
+  get their usual rewards).
 
 \item
   A list of stake addresses controlled by the pool owner(s),
@@ -3011,7 +3013,7 @@ Note that
     \(\sum_{\text{pools}}\beta=1\).}.
 
   The difference \(R - \sum_{\text{pools}} \hat{f}(s,\sigma,\pbar)\) will be
-  sent to the treasury.
+  sent back to the reserves.
 \end{itemize}
 
 \subsubsection{Reward Splitting inside a pool}


### PR DESCRIPTION
Instead of putting the excess expansion into the treasury, we now put it into the reserves

**Note** this is equivalent to #1699 but is the bare minimum change (#1699 does just a little bit of clean up and algebraic simplification). We should not merge both.