### PR TITLE
Expose constructors to more efficiently translate transactions

### DIFF
--- a/byron/ledger/impl/src/Cardano/Chain/Common/Compact.hs
+++ b/byron/ledger/impl/src/Cardano/Chain/Common/Compact.hs
@@ -9,6 +9,7 @@ module Cardano.Chain.Common.Compact
   ( CompactAddress
   , toCompactAddress
   , fromCompactAddress
+  , unsafeGetCompactAddress
   )
 where
 
@@ -49,3 +50,6 @@ fromCompactAddress (CompactAddress addr) =
   case decodeFull' (BSS.fromShort addr) of
     Left err      -> panic ("fromCompactAddress: impossible: " <> show err)
     Right decAddr -> decAddr
+
+unsafeGetCompactAddress :: CompactAddress -> ShortByteString
+unsafeGetCompactAddress (CompactAddress sbs) = sbs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -50,6 +50,7 @@ module Shelley.Spec.Ledger.TxData
     TxIn (TxIn),
     pattern TxInCompact,
     TxOut (TxOut),
+    pattern TxOutCompact,
     Url,
     Wdrl (..),
     WitVKey (WitVKey, wvkBytes),


### PR DESCRIPTION
We will use these in consensus to more efficiently translate the Byron UTxO to the Shelley UTxO by going from compact to compact.