### PR TITLE
Fix minor typo: argument binders out of order in toShelley

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -2106,7 +2106,7 @@ candidate nonces for Shelley.
           \wcard \\
           \var{us}
         \end{array}
-      \right)~\var{bn}~\var{gd}
+      \right)~\var{gd}~\var{bn}
       =
       \fun{initialShelleyState}~
       \left(


### PR DESCRIPTION
Very minor typo:

```
toShelley ∈ CEState → GenesisDelegation → BlockNo → ChainState

toShelley (...) bn gd = initialShelleyState (...)
```