### PR TITLE
Bump dependency on goblins

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -77,5 +77,5 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
-  tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
-  --sha256: 17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b
+  tag: 312198a1523736181ef7ddab15958bb32a9d9052
+  --sha256: 1w1b3g1s64rv4glrj416v1jmwnqhlz1zcqmz2y813jgs4d32m27k

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
     - contra-tracer
 
 - git: https://github.com/input-output-hk/goblins
-  commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
+  commit: 312198a1523736181ef7ddab15958bb32a9d9052
 - moo-1.2
 - gray-code-0.3.1
 


### PR DESCRIPTION
Removes the final dependency on `lens`.