### PR TITLE
adding missing DELEG predicate failures to spec

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -94,7 +94,8 @@ instance Typeable crypto => STS (DELEG crypto) where
     = StakeKeyAlreadyRegisteredDELEG
         !(Credential 'Staking crypto) -- Credential which is already registered
     | -- | Indicates that the stake key is somehow already in the rewards map.
-      --   This error being seen indicates a potential bug in the rules.
+      --   This error is now redundant with StakeKeyAlreadyRegisteredDELEG.
+      --   We should remove it and replace its one use with StakeKeyAlreadyRegisteredDELEG.
       StakeKeyInRewardsDELEG
         !(Credential 'Staking crypto) -- Credential which is already registered
     | StakeKeyNotRegisteredDELEG
@@ -206,6 +207,8 @@ delegationTransition = do
   case c of
     DCertDeleg (RegKey hk) -> do
       -- note that pattern match is used instead of regCred, as in the spec
+      -- TODO we can remove the failure StakeKeyInRewardsDELEG and replace
+      -- the use below with StakeKeyAlreadyRegisteredDELEG
       eval (hk ∉ dom (_rewards ds)) ?! StakeKeyInRewardsDELEG hk
 
       pure $

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -672,12 +672,14 @@ concerns are independent of the ledger rules.
   \label{fig:dcert-mir}
 \end{figure}
 
-The DELEG rule has seven possible predicate failures:
+The DELEG rule has ten possible predicate failures:
 \begin{itemize}
 \item In the case of a key registration certificate, if the staking credential
-  is already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
+  is already registered, there is a \emph{StakeKeyAlreadyRegistered} failure.
 \item In the case of a key deregistration certificate, if the key is not
   registered, there is a \emph{StakeKeyNotRegistered} failure.
+\item In the case of a key deregistration certificate, if the associated
+  reward account is non-zero, there is a \emph{StakeKeyNonZeroAccountBalance} failure.
 \item In the case of a non-existing stake pool key in a delegation certificate,
   there is a \emph{StakeDelegationImpossible} failure.
 \item In the case of a pool delegation certificate, there is a
@@ -690,6 +692,12 @@ The DELEG rule has seven possible predicate failures:
   \emph{DuplicateGenesisDelegate} failure.
 \item In the case of insufficient reserves to pay the instantaneous rewards,
   there is a \emph{InsufficientForInstantaneousRewards} failure.
+\item In the case that a MIR certificate is issued during the last
+  $\StabilityWindow$-many slots of the epoch,
+  there is a \emph{MIRCertificateTooLateinEpoch} failure.
+\item  In the case of a genesis key delegation certificate, if the VRF key is
+  in the range of the genesis delegation mapping, there is a
+  \emph{DuplicateGenesisVRF} failure.
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
The formal spec listed only 7 predicate failures for the DELEG rule, but the implementation contained 11 (which did include the 7).

* The predicate `StakeKeyInRewards` should actually be removed. It is redundant with `StakeKeyAlreadyRegistered` (we removed the `stkCreds` mapping from the implementation in #1683 and from the spec in #1692, making the reward mapping the source of truth for registered stake credentials). Unfortunately, we are using `StakeKeyInRewards` in the place where `StakeKeyAlreadyRegistered` is the more helpful name. I have made a TODO in the implementation to replace ` StakeKeyInRewards` with `StakeKeyAlreadyRegistered` when there is a good time (right now is not).
* I added `StakeKeyNonZeroAccountBalance`, `MIRCertificateTooLateInEpoch`, and `DuplicateGenesisVRF` to the spec.

closes #1719 