### PR TITLE
Add addrhash parameter to ConcreteCrypto

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -53,7 +53,9 @@ import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
 type C = ConcreteCrypto ShortHash
 
-data ConcreteCrypto (h :: *)
+data ConcreteCrypto_ (ah :: *) (h :: *)
+
+type ConcreteCrypto h = ConcreteCrypto_ h h
 
 type Mock c =
   ( Crypto c,
@@ -64,12 +66,15 @@ type Mock c =
     DSIGN.Signable (DSIGN c) ~ SignableRepresentation
   )
 
-instance HashAlgorithm h => Crypto (ConcreteCrypto h) where
-  type HASH (ConcreteCrypto h) = h
-  type ADDRHASH (ConcreteCrypto h) = h
-  type DSIGN (ConcreteCrypto h) = MockDSIGN
-  type KES (ConcreteCrypto h) = MockKES 10
-  type VRF (ConcreteCrypto h) = FakeVRF
+instance
+  (HashAlgorithm ah, HashAlgorithm h) =>
+  Crypto (ConcreteCrypto_ ah h)
+  where
+  type HASH (ConcreteCrypto_ ah h) = h
+  type ADDRHASH (ConcreteCrypto_ ah h) = ah
+  type DSIGN (ConcreteCrypto_ ah h) = MockDSIGN
+  type KES (ConcreteCrypto_ ah h) = MockKES 10
+  type VRF (ConcreteCrypto_ ah h) = FakeVRF
 
 type DCert c = Delegation.Certificates.DCert c
 


### PR DESCRIPTION
[The existence of this branch unblocks input-output-hk/ouroboros-network#2388, so if you dislike this diff, it's fine to reject this PR. I'll be able to integrate whatever solution for this need you eventually provide with whatever I'm able to implement against this in the meantime.]

This capability is used by the downstream `ouroboros-consensus-shelley-test`. For example, on my WIP branch, it allows the Cardano ThreadNet test to re-use the various Shelley test infrastructure while using blake2b 224 bit address hashes and 256 bit block hashes, as does Byron (the Byron-to-Shelley translation used by the HFC in those Cardano ThreadNet tests currently assumes the two eras use the same address hash algo).