### PR TITLE
Hardwire bootstrap witnesses and key hashes to Ed25519

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
@@ -13,4 +13,7 @@ signkeyKES = bytes .size 16
 
 $signature /= bytes .size 16
 
+$bootstrap_vkey /= bytes .size 32
+$bootstrap_signature /= bytes .size 64
+
 $nonce /= [ 0 // 1, bytes .size 32 ]

--- a/shelley/chain-and-ledger/executable-spec/cddl-files/real/crypto
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/real/crypto
@@ -2,3 +2,6 @@ $hash28 /= bytes .size 28
 $hash32 /= bytes .size 32
 
 $vkey /= bytes .size 32
+
+$bootstrap_vkey /= bytes .size 32
+$bootstrap_signature /= bytes .size 64

--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -214,8 +214,8 @@ vkeywitness = [ $vkey, $signature ]
 
 ; explicit CBOR list of length 5
 bootstrap_witness =
-  [ public_key : $vkey
-  , signature  : $signature
+  [ public_key : $bootstrap_vkey
+  , signature  : $bootstrap_signature
   , chain_code : bytes .size 32
   , attributes : bytes
   ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/NonTraceProperties/Generator.hs
@@ -472,7 +472,7 @@ predicateFailureToValidationError (UtxowFailure (MissingVKeyWitnessesUTXOW _)) =
   MissingWitnesses
 predicateFailureToValidationError (UtxowFailure (MissingScriptWitnessesUTXOW _)) =
   MissingWitnesses
-predicateFailureToValidationError (UtxowFailure (InvalidWitnessesUTXOW [])) =
+predicateFailureToValidationError (UtxowFailure (InvalidWitnessesUTXOW [] [])) =
   InvalidWitness
 predicateFailureToValidationError (UtxowFailure (UtxoFailure InputSetEmptyUTxO)) =
   InputSetEmpty

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -55,7 +55,9 @@ import Shelley.Spec.Ledger.API
 import Shelley.Spec.Ledger.Address (Addr (Addr))
 import Shelley.Spec.Ledger.Address.Bootstrap (BootstrapWitness)
 import Shelley.Spec.Ledger.Address.Bootstrap
-  ( ChainCode (..),
+  ( BootstrapVerKey (..),
+    ChainCode (..),
+    unpackByronVKey,
     pattern BootstrapWitness,
   )
 import Shelley.Spec.Ledger.BaseTypes
@@ -133,7 +135,8 @@ import Test.QuickCheck
   )
 import Test.QuickCheck.Hedgehog (hedgehog)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
-  ( genSignature,
+  ( genByronVKey,
+    genSignature,
   )
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Core
@@ -164,6 +167,9 @@ mkDummyHash = coerce . hashWithSerialiser @h toCBOR
 -------------------------------------------------------------------------------}
 
 type MockGen c = (Mock c, Arbitrary (VerKeyDSIGN (DSIGN c)))
+
+instance Arbitrary BootstrapVerKey where
+  arbitrary = fst . unpackByronVKey <$> genByronVKey
 
 instance
   Mock c =>

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -447,7 +447,10 @@ testWitnessNotIncluded =
    in testInvalidTx
         [ UtxowFailure $
             MissingVKeyWitnessesUTXOW $
-              WitHashes wits
+              WitHashes
+                { bootstrapWitHashes = Set.empty,
+                  properWitHashes = wits
+                }
         ]
         tx
 
@@ -469,7 +472,10 @@ testSpendNotOwnedUTxO =
    in testInvalidTx
         [ UtxowFailure $
             MissingVKeyWitnessesUTXOW $
-              WitHashes wits
+              WitHashes
+                { bootstrapWitHashes = Set.empty,
+                  properWitHashes = wits
+                }
         ]
         tx
 
@@ -501,10 +507,14 @@ testWitnessWrongUTxO =
    in testInvalidTx
         [ UtxowFailure $
             InvalidWitnessesUTXOW
-              [asWitness $ vKey alicePay],
+              [asWitness $ vKey alicePay]
+              [],
           UtxowFailure $
             MissingVKeyWitnessesUTXOW $
-              WitHashes wits
+              WitHashes
+                { bootstrapWitHashes = Set.empty,
+                  properWitHashes = wits
+                }
         ]
         tx
 
@@ -587,6 +597,7 @@ testInvalidWintess =
         [ UtxowFailure $
             InvalidWitnessesUTXOW
               [asWitness $ vKey alicePay]
+              []
         ]
    in testLEDGER (utxoState, dpState) tx ledgerEnv (Left [errs])
 
@@ -608,9 +619,12 @@ testWithdrawalNoWit =
           SNothing
       wits = mempty {addrWits = Set.singleton $ makeWitnessVKey (hashAnnotated txb) alicePay}
       tx = Tx txb wits SNothing
-      missing = Set.singleton (asWitness $ hashKey $ vKey bobStake)
       errs =
-        [ UtxowFailure . MissingVKeyWitnessesUTXOW $ WitHashes missing
+        [ UtxowFailure . MissingVKeyWitnessesUTXOW $
+            WitHashes
+              { bootstrapWitHashes = Set.empty,
+                properWitHashes = Set.singleton (asWitness $ hashKey $ vKey bobStake)
+              }
         ]
       dpState' = addReward dpState (getRwdCred $ mkVKeyRwdAcnt Testnet bobStake) (Coin 10)
    in testLEDGER (utxoState, dpState') tx ledgerEnv (Left [errs])


### PR DESCRIPTION
This patch allows the Shelley ledger to be instantiated with a DSIGN algorithm other than Ed25519. Previously, the Shelley ledger implementation was using the given DSIGN algorithm for everything, including bootstrap keys and witnesses. The algorithm had to be Ed25519 because that's the only way to validate a bootstrap (ie Byron) signature.

This PR is motivated by input-output-hk/ouroboros-network#2388 -- we'd like to continue to use `MockDSIGN` in the Shelley era of the Cardano TheadNet test.

I'm opening it as Draft and with an unverified commit to avoid accidental premature merge.

Please review thoroughly :) In particular, I expect that this initial diff violates some of your intended abstraction boundaries etc. I went for the straight-forward/minimal option in a few places.