### PR TITLE
Refactoring examples (a first step)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -132,6 +132,12 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Address.Bootstrap
       Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
       Test.Shelley.Spec.Ledger.Examples
+      Test.Shelley.Spec.Ledger.Examples.Cast
+      Test.Shelley.Spec.Ledger.Examples.Combinators
+      Test.Shelley.Spec.Ledger.Examples.Federation
+      Test.Shelley.Spec.Ledger.Examples.Init
+      Test.Shelley.Spec.Ledger.Examples.EmptyBlock
+      Test.Shelley.Spec.Ledger.Examples.PoolLifetime
       Test.Shelley.Spec.Ledger.Fees
       Test.Shelley.Spec.Ledger.Generator.Block
       Test.Shelley.Spec.Ledger.Generator.Constants
@@ -245,6 +251,7 @@ benchmark mainbench
   other-modules:    Test.Shelley.Spec.Ledger.BenchmarkFunctions,
                     Test.Shelley.Spec.Ledger.ConcreteCryptoTypes,
                     Test.Shelley.Spec.Ledger.Examples,
+                    Test.Shelley.Spec.Ledger.Examples.Cast,
                     Test.Shelley.Spec.Ledger.Generator.Constants,
                     Test.Shelley.Spec.Ledger.Generator.Core,
                     Test.Shelley.Spec.Ledger.Orphans,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Test.Shelley.Spec.Ledger.Examples.Cast
+-- Description : Cast of characters for Shelley ledger examples
+--
+-- The cast of Characters for Shelley Ledger Examples
+-- (excluding the genesis/cord nodes,
+-- which are in Test.Shelley.Spec.Ledger.Examples.Federation).
+module Test.Shelley.Spec.Ledger.Examples.Cast
+  ( -- | = Alice
+    --
+    -- === Alice's payment key pair
+    alicePay,
+    -- | === Alice's stake key pair
+    aliceStake,
+    -- | === Alice's stake credential
+    aliceSHK,
+    -- | === Alice's base address
+    aliceAddr,
+    -- | === Alice's base address
+    alicePtrAddr,
+    -- | === Alice's stake pool keys (cold keys, VRF keys, hot KES keys)
+    alicePoolKeys,
+    -- | === Alice's stake pool parameters
+    alicePoolParams,
+    -- | = Bob
+    --
+    -- === Bob's payment key pair
+    bobPay,
+    -- | === Bob's stake key pair
+    bobStake,
+    -- | === Bob's stake credential
+    bobSHK,
+    -- | === Bob's address
+    bobAddr,
+    -- | = Carl
+    --
+    -- === Carl's payment key pair
+    carlPay,
+    -- | === Carl's stake key pair
+    carlStake,
+    -- | === Carl's stake credential
+    carlSHK,
+    -- | === Carl's address
+    carlAddr,
+    -- | = Daria
+    --
+    -- === Daria's payment key pair
+    dariaPay,
+    -- | === Daria's stake key pair
+    dariaStake,
+    -- | === Daria's stake credential
+    dariaSHK,
+    -- | === Daria's address
+    dariaAddr,
+  )
+where
+
+import qualified Data.ByteString.Char8 as BS (pack)
+import Data.Maybe (fromJust)
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import Shelley.Spec.Ledger.Address (Addr (..))
+import Shelley.Spec.Ledger.BaseTypes
+  ( Network (..),
+    StrictMaybe (..),
+    textToUrl,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Credential
+  ( Credential (..),
+    Ptr (..),
+    StakeReference (..),
+  )
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.Keys
+  ( KeyPair (..),
+    KeyRole (..),
+    hashKey,
+    hashVerKeyVRF,
+  )
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Shelley.Spec.Ledger.TxData
+  ( PoolMetaData (..),
+    PoolParams (..),
+    RewardAcnt (..),
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllIssuerKeys (..),
+  )
+import Test.Shelley.Spec.Ledger.Utils
+  ( mkAddr,
+    mkKESKeyPair,
+    mkKeyPair,
+    mkVRFKeyPair,
+    unsafeMkUnitInterval,
+  )
+
+alicePay :: Crypto c => KeyPair 'Payment c
+alicePay = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
+
+aliceStake :: Crypto c => KeyPair 'Staking c
+aliceStake = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (1, 1, 1, 1, 1)
+
+alicePoolKeys :: Crypto c => AllIssuerKeys c 'StakePool
+alicePoolKeys =
+  AllIssuerKeys
+    (KeyPair vkCold skCold)
+    (mkVRFKeyPair (1, 0, 0, 0, 2))
+    [(KESPeriod 0, mkKESKeyPair (1, 0, 0, 0, 3))]
+    (hashKey vkCold)
+  where
+    (skCold, vkCold) = mkKeyPair (1, 0, 0, 0, 1)
+
+aliceAddr :: Crypto c => Addr c
+aliceAddr = mkAddr (alicePay, aliceStake)
+
+alicePHK :: Crypto c => Credential 'Payment c
+alicePHK = (KeyHashObj . hashKey . vKey) alicePay
+
+aliceSHK :: Crypto c => Credential 'Staking c
+aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
+
+alicePtrAddr :: Crypto c => Addr c
+alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) 0 0)
+
+alicePoolParams :: forall c. Crypto c => PoolParams c
+alicePoolParams =
+  PoolParams
+    { _poolPubKey = (hashKey . vKey . cold) alicePoolKeys,
+      _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @c),
+      _poolPledge = Coin 1,
+      _poolCost = Coin 5,
+      _poolMargin = unsafeMkUnitInterval 0.1,
+      _poolRAcnt = RewardAcnt Testnet aliceSHK,
+      _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake,
+      _poolRelays = StrictSeq.empty,
+      _poolMD =
+        SJust $
+          PoolMetaData
+            { _poolMDUrl = fromJust $ textToUrl "alice.pool",
+              _poolMDHash = BS.pack "{}"
+            }
+    }
+
+bobPay :: Crypto c => KeyPair 'Payment c
+bobPay = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (2, 2, 2, 2, 2)
+
+bobStake :: Crypto c => KeyPair 'Staking c
+bobStake = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (3, 3, 3, 3, 3)
+
+bobAddr :: Crypto c => Addr c
+bobAddr = mkAddr (bobPay, bobStake)
+
+bobSHK :: Crypto c => Credential 'Staking c
+bobSHK = (KeyHashObj . hashKey . vKey) bobStake
+
+carlPay :: Crypto c => KeyPair 'Payment c
+carlPay = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (4, 4, 4, 4, 4)
+
+carlStake :: Crypto c => KeyPair 'Staking c
+carlStake = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (5, 5, 5, 5, 5)
+
+carlAddr :: Crypto c => Addr c
+carlAddr = mkAddr (carlPay, carlStake)
+
+carlSHK :: Crypto c => Credential 'Staking c
+carlSHK = (KeyHashObj . hashKey . vKey) carlStake
+
+dariaPay :: Crypto c => KeyPair 'Payment c
+dariaPay = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (6, 6, 6, 6, 6)
+
+dariaStake :: Crypto c => KeyPair 'Staking c
+dariaStake = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair (7, 7, 7, 7, 7)
+
+dariaAddr :: Crypto c => Addr c
+dariaAddr = mkAddr (dariaPay, dariaStake)
+
+dariaSHK :: Crypto c => Credential 'Staking c
+dariaSHK = (KeyHashObj . hashKey . vKey) dariaStake

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      : Test.Shelley.Spec.Ledger.Examples.Federation
+-- Description : Chain State Combinators
+--
+-- A collection of combinators for manipulating Chain State.
+-- The idea is to provide a clear way of describing the
+-- changes to the chain state when a block is processed.
+module Test.Shelley.Spec.Ledger.Examples.Combinators
+  ( -- | = Evolve Nonces - Frozen
+    --
+    -- Evolve the appropriate nonces under the assumption
+    -- that the candidate nonce is now frozen.
+    evolveNonceFrozen,
+    -- | = Evolve Nonces - Unfrozen
+    --
+    -- Evolve the appropriate nonces under the assumption
+    -- that the candidate nonce is not frozen.
+    evolveNonceUnfrozen,
+    -- | = New 'LastAppliedBlock'
+    --
+    -- Update the chain state with the details of 'LastAppliedBlock'
+    -- that occur when a new block is processed.
+    newLab,
+    -- | = Update Fees and Deposits
+    --
+    -- Update the fee pot and deposit pot with the new fees
+    -- and the change to the deposit pot.
+    feesAndDeposits,
+    -- | = Update the UTxO
+    --
+    -- Update the UTxO for given transaction body.
+    newUTxO,
+    -- | = New Stake Credential
+    --
+    -- Add a newly registered stake credential
+    newStakeCred,
+    -- | = New Stake Pool
+    --
+    -- Add a newly registered stake pool
+    newPool,
+    -- | = MIR
+    --
+    -- Add a credential to the MIR mapping for the given pot (reserves or treasury)
+    mir,
+  )
+where
+
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.Iterate.SetAlgebra (eval, singleton, (∪), (⋪))
+import qualified Data.Map.Strict as Map
+import Shelley.Spec.Ledger.BaseTypes ((⭒))
+import Shelley.Spec.Ledger.BaseTypes (Nonce (..))
+import Shelley.Spec.Ledger.BlockChain
+  ( BHBody (..),
+    Block (..),
+    LastAppliedBlock (..),
+    bhHash,
+    bhbody,
+    bheader,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Credential
+  ( Credential (..),
+    Ptr,
+  )
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.Keys (KeyRole (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState (..),
+    DState (..),
+    EpochState (..),
+    InstantaneousRewards (..),
+    LedgerState (..),
+    NewEpochState (..),
+    PState (..),
+    UTxOState (..),
+  )
+import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
+import Shelley.Spec.Ledger.TxData (MIRPot (..), PoolParams (..), TxBody (..))
+import Shelley.Spec.Ledger.UTxO (txins, txouts)
+
+evolveNonceFrozen :: forall c. Nonce -> ChainState c -> ChainState c
+evolveNonceFrozen n cs = cs {chainCandidateNonce = chainCandidateNonce cs ⭒ n}
+
+evolveNonceUnfrozen :: forall c. Nonce -> ChainState c -> ChainState c
+evolveNonceUnfrozen n cs =
+  cs
+    { chainCandidateNonce = chainCandidateNonce cs ⭒ n,
+      chainEvolvingNonce = chainEvolvingNonce cs ⭒ n
+    }
+
+newLab ::
+  forall c.
+  Crypto c =>
+  Block c ->
+  ChainState c ->
+  ChainState c
+newLab b cs =
+  cs {chainLastAppliedBlock = At $ LastAppliedBlock bn sn (bhHash bh)}
+  where
+    bh = bheader b
+    bn = bheaderBlockNo . bhbody $ bh
+    sn = bheaderSlotNo . bhbody $ bh
+
+feesAndDeposits ::
+  forall c.
+  Coin ->
+  Coin ->
+  ChainState c ->
+  ChainState c
+feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
+  where
+    nes = chainNes cs
+    es = nesEs nes
+    ls = esLState es
+    utxoSt = _utxoState ls
+    utxoSt' =
+      utxoSt
+        { _deposited = (_deposited utxoSt) + depositChange,
+          _fees = (_fees utxoSt) + newFees
+        }
+    ls' = ls {_utxoState = utxoSt'}
+    es' = es {esLState = ls'}
+    nes' = nes {nesEs = es'}
+
+newUTxO ::
+  forall c.
+  Crypto c =>
+  TxBody c ->
+  ChainState c ->
+  ChainState c
+newUTxO txb cs = cs {chainNes = nes'}
+  where
+    nes = chainNes cs
+    es = nesEs nes
+    ls = esLState es
+    utxoSt = _utxoState ls
+    utxo = _utxo utxoSt
+    utxo' = eval ((txins txb ⋪ utxo) ∪ txouts txb)
+    utxoSt' = utxoSt {_utxo = utxo'}
+    ls' = ls {_utxoState = utxoSt'}
+    es' = es {esLState = ls'}
+    nes' = nes {nesEs = es'}
+
+newStakeCred ::
+  forall c.
+  Credential 'Staking c ->
+  Ptr ->
+  ChainState c ->
+  ChainState c
+newStakeCred cred ptr cs = cs {chainNes = nes'}
+  where
+    nes = chainNes cs
+    es = nesEs nes
+    ls = esLState es
+    dps = _delegationState ls
+    ds = _dstate dps
+    ds' =
+      ds
+        { _rewards = Map.insert cred (Coin 0) (_rewards ds),
+          _ptrs = eval (_ptrs ds ∪ (singleton ptr cred))
+        }
+    dps' = dps {_dstate = ds'}
+    ls' = ls {_delegationState = dps'}
+    es' = es {esLState = ls'}
+    nes' = nes {nesEs = es'}
+
+newPool ::
+  forall c.
+  PoolParams c ->
+  ChainState c ->
+  ChainState c
+newPool pool cs = cs {chainNes = nes'}
+  where
+    nes = chainNes cs
+    es = nesEs nes
+    ls = esLState es
+    dps = _delegationState ls
+    ps = _pstate dps
+    ps' =
+      ps
+        { _pParams = Map.insert (_poolPubKey pool) pool (_pParams ps)
+        }
+    dps' = dps {_pstate = ps'}
+    ls' = ls {_delegationState = dps'}
+    es' = es {esLState = ls'}
+    nes' = nes {nesEs = es'}
+
+mir ::
+  forall c.
+  Credential 'Staking c ->
+  MIRPot ->
+  Coin ->
+  ChainState c ->
+  ChainState c
+mir cred pot amnt cs = cs {chainNes = nes'}
+  where
+    nes = chainNes cs
+    es = nesEs nes
+    ls = esLState es
+    dps = _delegationState ls
+    ds = _dstate dps
+    InstantaneousRewards
+      { iRReserves = ir,
+        iRTreasury = it
+      } = _irwd ds
+    irwd' = case pot of
+      ReservesMIR -> InstantaneousRewards (Map.insert cred amnt ir) it
+      TreasuryMIR -> InstantaneousRewards ir (Map.insert cred amnt it)
+    ds' = ds {_irwd = irwd'}
+    dps' = dps {_dstate = ds'}
+    ls' = ls {_delegationState = dps'}
+    es' = es {esLState = ls'}
+    nes' = nes {nesEs = es'}

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Shelley.Spec.Ledger.Examples.EmptyBlock
+  ( -- | = Empty Block Example
+    --
+    -- This is the most minimal example of using the CHAIN STS transition.
+    -- It applies an empty block to an initial shelley chain state.
+    --
+    -- The only things that change in the chain state are the
+    -- evolving and candidate nonces, and the last applied block.
+    exEmptyBlock,
+  )
+where
+
+import qualified Data.Map.Strict as Map
+import GHC.Stack (HasCallStack)
+import Shelley.Spec.Ledger.BaseTypes (Nonce)
+import Shelley.Spec.Ledger.BlockChain (Block)
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
+import Shelley.Spec.Ledger.Slot
+  ( BlockNo (..),
+    SlotNo (..),
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
+import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..))
+import Test.Shelley.Spec.Ledger.Examples.Combinators
+  ( evolveNonceUnfrozen,
+    newLab,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Federation (coreNodeKeysBySchedule)
+import Test.Shelley.Spec.Ledger.Examples.Init
+  ( initSt,
+    lastByronHeaderHash,
+    nonce0,
+    ppEx,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( NatNonce (..),
+    mkBlock,
+    mkOCert,
+    zero,
+  )
+import Test.Shelley.Spec.Ledger.Utils (getBlockNonce)
+
+initStEx1 :: forall c. Crypto c => ChainState c
+initStEx1 = initSt (UTxO Map.empty)
+
+blockEx1 :: forall c. (HasCallStack, Mock c) => Block c
+blockEx1 =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeysBySchedule ppEx 10)
+    []
+    (SlotNo 10)
+    (BlockNo 1)
+    (nonce0 @c)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeysBySchedule ppEx 10) 0 (KESPeriod 0))
+
+blockNonce :: forall c. (HasCallStack, Mock c) => Nonce
+blockNonce = getBlockNonce (blockEx1 @c)
+
+expectedStEx1 :: forall c. Mock c => ChainState c
+expectedStEx1 =
+  (evolveNonceUnfrozen (blockNonce @c))
+    . (newLab blockEx1)
+    $ initStEx1
+
+exEmptyBlock :: Mock c => CHAINExample c
+exEmptyBlock = CHAINExample initStEx1 blockEx1 (Right expectedStEx1)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Test.Shelley.Spec.Ledger.Examples.Federation
+-- Description : Core Nodes for Shelley ledger examples
+--
+-- The genesis/core nodes for Shelley Ledger Examples.
+module Test.Shelley.Spec.Ledger.Examples.Federation
+  ( -- | Number of Core Node
+    numCoreNodes,
+    -- | = Core Node Keys
+    --
+    -- === Signing (Secret) Keys
+    -- Retrieve the signing key for a core node by providing
+    -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
+    coreNodeSK,
+    -- | === Verification (Public) Keys
+    -- Retrieve the verification key for a core node by providing
+    -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
+    coreNodeVK,
+    -- | === Block Issuer Keys
+    -- Retrieve the block issuer keys (cold, VRF, and hot KES keys)
+    -- for a core node by providing
+    -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
+    coreNodeIssuerKeys,
+    -- | === Keys by Overlay Schedule
+    -- Retrieve all the keys associated with a core node
+    -- for a given slot and protocol parameters.
+    -- It will return an error if there is not a core node scheduled
+    -- for the given slot.
+    coreNodeKeysBySchedule,
+    -- | === Genesis Delegation Mapping
+    -- The map from genesis/core node (verification) key hashes
+    -- to their delegate's (verification) key hashe.
+    genDelegs,
+    -- | === Overlay Schedule
+    -- Retrieve the overlay schedule for a given epoch and protocol parameters.
+    overlayScheduleFor,
+  )
+where
+
+import qualified Data.List
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Word (Word64)
+import GHC.Stack (HasCallStack)
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.Keys
+  ( GenDelegPair (..),
+    KeyHash (..),
+    KeyPair (..),
+    KeyRole (..),
+    SignKeyDSIGN,
+    VKey (..),
+    coerceKeyRole,
+    hashKey,
+    hashVerKeyVRF,
+    vKey,
+  )
+import Shelley.Spec.Ledger.LedgerState
+  ( OBftSlot (..),
+    overlaySchedule,
+  )
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+  )
+import Shelley.Spec.Ledger.Slot
+  ( EpochNo (..),
+    SlotNo (..),
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllIssuerKeys (..),
+  )
+import Test.Shelley.Spec.Ledger.Utils
+
+numCoreNodes :: Word64
+numCoreNodes = 7
+
+mkAllCoreNodeKeys ::
+  (Crypto c) =>
+  Word64 ->
+  AllIssuerKeys c r
+mkAllCoreNodeKeys w =
+  AllIssuerKeys
+    (KeyPair vkCold skCold)
+    (mkVRFKeyPair (w, 0, 0, 0, 2))
+    [(KESPeriod 0, mkKESKeyPair (w, 0, 0, 0, 3))]
+    (hashKey vkCold)
+  where
+    (skCold, vkCold) = mkKeyPair (w, 0, 0, 0, 1)
+
+coreNodes :: forall c. Crypto c => [((SignKeyDSIGN c, VKey 'Genesis c), AllIssuerKeys c 'GenesisDelegate)]
+coreNodes = [(mkGenKey (x, 0, 0, 0, 0), mkAllCoreNodeKeys x) | x <- [101 .. 100 + numCoreNodes]]
+
+coreNodeSK :: forall c. Crypto c => Int -> SignKeyDSIGN c
+coreNodeSK = fst . fst . (coreNodes @c !!)
+
+coreNodeVK :: forall c. Crypto c => Int -> VKey 'Genesis c
+coreNodeVK = snd . fst . (coreNodes @c !!)
+
+coreNodeIssuerKeys :: forall c. Crypto c => Int -> AllIssuerKeys c 'GenesisDelegate
+coreNodeIssuerKeys = snd . (coreNodes @c !!)
+
+coreNodeKeysForSlot ::
+  forall c.
+  (HasCallStack, Crypto c) =>
+  Map SlotNo (OBftSlot c) ->
+  Word64 ->
+  AllIssuerKeys c 'GenesisDelegate
+coreNodeKeysForSlot overlay slot = case Map.lookup (SlotNo slot) overlay of
+  Nothing -> error $ "coreNodesForSlot: Cannot find keys for slot " <> show slot
+  Just NonActiveSlot -> error $ "coreNodesForSlot: Non-active slot " <> show slot
+  Just (ActiveSlot gkh) ->
+    case Data.List.find (\((_, gk), _) -> hashKey gk == gkh) coreNodes of
+      Nothing -> error $ "coreNodesForSlot: Cannot find key hash in coreNodes: " <> show gkh
+      Just ((_, _), ak) -> ak
+
+overlayScheduleFor :: Crypto c => EpochNo -> PParams -> Map SlotNo (OBftSlot c)
+overlayScheduleFor e pp =
+  runShelleyBase $
+    overlaySchedule
+      e
+      (Map.keysSet genDelegs)
+      pp
+
+coreNodeKeysBySchedule ::
+  (HasCallStack, Crypto c) =>
+  PParams ->
+  Word64 ->
+  AllIssuerKeys c 'GenesisDelegate
+coreNodeKeysBySchedule = coreNodeKeysForSlot . fullOSched
+  where
+    fullOSched pp = Map.unions $ [overlayScheduleFor e pp | e <- [0 .. 10]]
+
+genDelegs :: forall c. Crypto c => Map (KeyHash 'Genesis c) (GenDelegPair c)
+genDelegs =
+  Map.fromList
+    [ ( hashKey $ snd gkey,
+        ( GenDelegPair
+            (coerceKeyRole . hashKey . vKey $ cold pkeys)
+            (hashVerKeyVRF . snd . vrf $ pkeys)
+        )
+      )
+      | (gkey, pkeys) <- coreNodes
+    ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Test.Shelley.Spec.Ledger.Examples.Init
+-- Description : Initial State for Shelley ledger examples
+--
+-- The initial state for Shelley Ledger Examples.
+module Test.Shelley.Spec.Ledger.Examples.Init
+  ( -- | = Initial State For Shelley Ledger Examples
+    --
+    -- === Initial Protocol Parameters
+    --
+    -- @
+    --   emptyPParams
+    --     { _maxBBSize = 50000,
+    --       _maxBHSize = 10000,
+    --       _maxTxSize = 10000,
+    --       _eMax = EpochNo 10000,
+    --       _keyDeposit = Coin 7,
+    --       _poolDeposit = Coin 250,
+    --       _d = unsafeMkUnitInterval 0.5,
+    --       _tau = unsafeMkUnitInterval 0.2,
+    --       _rho = unsafeMkUnitInterval 0.0021,
+    --       _minUTxOValue = 100
+    --     }
+    -- @
+    ppEx,
+    -- | === Initial Chain State
+    --
+    -- The initial state for the examples uses the function
+    -- 'initialShelleyState' with the genesis delegation
+    -- 'genDelegs' and any given starting 'UTxO' set.
+    initSt,
+    -- | === Initial Nonce
+    nonce0,
+    -- | === The hash of the last Bryon Header
+    --
+    -- The first block of the Shelley era will point back to the
+    -- last block of the Byron era.
+    -- For our purposes in the examples we can bootstrap the chain
+    -- by just coercing the value.
+    -- When this transition actually occurs,
+    -- the consensus layer will do the work of making
+    -- sure that the hash gets translated across the fork.
+    lastByronHeaderHash,
+  )
+where
+
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (..),
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( HashHeader (..),
+    LastAppliedBlock (..),
+    hashHeaderToNonce,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    PParams' (..),
+    emptyPParams,
+  )
+import Shelley.Spec.Ledger.STS.Chain
+  ( ChainState (..),
+    initialShelleyState,
+  )
+import Shelley.Spec.Ledger.Slot
+  ( BlockNo (..),
+    EpochNo (..),
+    SlotNo (..),
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
+import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs, overlayScheduleFor)
+import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash, unsafeMkUnitInterval)
+
+ppEx :: PParams
+ppEx =
+  emptyPParams
+    { _maxBBSize = 50000,
+      _maxBHSize = 10000,
+      _maxTxSize = 10000,
+      _eMax = EpochNo 10000,
+      _keyDeposit = Coin 7,
+      _poolDeposit = Coin 250,
+      _d = unsafeMkUnitInterval 0.5,
+      _tau = unsafeMkUnitInterval 0.2,
+      _rho = unsafeMkUnitInterval 0.0021,
+      _minUTxOValue = 100
+    }
+
+lastByronHeaderHash :: forall c. Crypto c => HashHeader c
+lastByronHeaderHash = HashHeader $ mkHash 0
+
+nonce0 :: forall c. Crypto c => Nonce
+nonce0 = hashHeaderToNonce (lastByronHeaderHash @c)
+
+initSt :: forall c. Crypto c => UTxO c -> ChainState c
+initSt utxo =
+  initialShelleyState
+    (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
+    (EpochNo 0)
+    utxo
+    (maxLLSupply - (balance utxo))
+    genDelegs
+    (overlayScheduleFor (EpochNo 0) ppEx)
+    ppEx
+    (nonce0 @c)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Shelley.Spec.Ledger.Examples.PoolLifetime
+  ( -- | = Pool Lifetime
+    --
+    -- Example demonstrating the creation of a new stake pool,
+    -- block production under Praos, rewards, and pool retirement.
+    --
+    -- === Example 2A
+    -- In the first block of this example, Alice, Bob, and Carl
+    -- all register stake credentials, and Alice registers a stake pool.
+    -- Additionall, a MIR certificate is issued to draw from the reserves
+    -- and give Carl and Daria (who is unregistered) rewards.
+    ex2A,
+  )
+where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import GHC.Stack (HasCallStack)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce,
+    StrictMaybe (..),
+  )
+import Shelley.Spec.Ledger.BlockChain (Block)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Credential (Ptr (..))
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.Hashing (hashAnnotated)
+import Shelley.Spec.Ledger.Keys (asWitness)
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
+import Shelley.Spec.Ledger.Slot
+  ( BlockNo (..),
+    SlotNo (..),
+  )
+import Shelley.Spec.Ledger.Tx
+  ( Tx (..),
+    WitnessSetHKD (..),
+  )
+import Shelley.Spec.Ledger.TxData
+  ( DCert (..),
+    DelegCert (..),
+    MIRCert (..),
+    MIRPot (..),
+    PoolCert (..),
+    TxBody (..),
+    TxIn (..),
+    TxOut (..),
+    Wdrl (..),
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
+import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..))
+import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
+import Test.Shelley.Spec.Ledger.Examples.Combinators
+  ( evolveNonceUnfrozen,
+    feesAndDeposits,
+    mir,
+    newLab,
+    newPool,
+    newStakeCred,
+    newUTxO,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Federation
+  ( coreNodeIssuerKeys,
+    coreNodeKeysBySchedule,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Init
+  ( initSt,
+    lastByronHeaderHash,
+    nonce0,
+    ppEx,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllIssuerKeys (..),
+    NatNonce (..),
+    genesisCoins,
+    genesisId,
+    mkBlock,
+    mkOCert,
+    zero,
+  )
+import Test.Shelley.Spec.Ledger.Utils (getBlockNonce)
+
+aliceInitCoin :: Coin
+aliceInitCoin = 10 * 1000 * 1000 * 1000 * 1000 * 1000
+
+bobInitCoin :: Coin
+bobInitCoin = 1 * 1000 * 1000 * 1000 * 1000 * 1000
+
+initUTxO :: Crypto c => UTxO c
+initUTxO =
+  genesisCoins
+    [ TxOut Cast.aliceAddr aliceInitCoin,
+      TxOut Cast.bobAddr bobInitCoin
+    ]
+
+initStEx2 :: forall c. Crypto c => ChainState c
+initStEx2 = initSt initUTxO
+
+-- SET UP BLOCK
+
+aliceCoinEx2A :: Coin
+aliceCoinEx2A = aliceInitCoin - (_poolDeposit ppEx) - 3 * (_keyDeposit ppEx) - 3
+
+carlMIR :: Coin
+carlMIR = Coin 110
+
+dariaMIR :: Coin
+dariaMIR = Coin 99
+
+feeTx2A :: Coin
+feeTx2A = Coin 3
+
+txbodyEx2A :: Crypto c => TxBody c
+txbodyEx2A =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.fromList [TxOut Cast.aliceAddr aliceCoinEx2A])
+    ( StrictSeq.fromList
+        ( [ DCertDeleg (RegKey Cast.aliceSHK),
+            DCertDeleg (RegKey Cast.bobSHK),
+            DCertDeleg (RegKey Cast.carlSHK),
+            DCertPool (RegPool Cast.alicePoolParams)
+          ]
+            ++ [ DCertMir
+                   ( MIRCert
+                       ReservesMIR
+                       ( Map.fromList
+                           [ (Cast.carlSHK, carlMIR),
+                             (Cast.dariaSHK, dariaMIR)
+                           ]
+                       )
+                   )
+               ]
+        )
+    )
+    (Wdrl Map.empty)
+    feeTx2A
+    (SlotNo 10)
+    SNothing
+    SNothing
+
+txEx2A :: forall c. Mock c => Tx c
+txEx2A =
+  Tx
+    txbodyEx2A
+    mempty
+      { addrWits =
+          makeWitnessesVKey
+            (hashAnnotated txbodyEx2A)
+            ( (asWitness <$> [Cast.alicePay, Cast.carlPay])
+                <> (asWitness <$> [Cast.aliceStake])
+                <> [asWitness $ cold Cast.alicePoolKeys]
+                <> ( asWitness
+                       <$> [ cold (coreNodeIssuerKeys 0),
+                             cold (coreNodeIssuerKeys 1),
+                             cold (coreNodeIssuerKeys 2),
+                             cold (coreNodeIssuerKeys 3),
+                             cold (coreNodeIssuerKeys 4)
+                           ]
+                   )
+            )
+      }
+    SNothing
+
+blockEx2A :: forall c. (HasCallStack, Mock c) => Block c
+blockEx2A =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeysBySchedule ppEx 10)
+    [txEx2A]
+    (SlotNo 10)
+    (BlockNo 1)
+    (nonce0 @c)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeysBySchedule ppEx 10) 0 (KESPeriod 0))
+
+blockNonce2A :: forall c. (HasCallStack, Mock c) => Nonce
+blockNonce2A = getBlockNonce (blockEx2A @c)
+
+expectedStEx2A :: forall c. Mock c => ChainState c
+expectedStEx2A =
+  (evolveNonceUnfrozen (blockNonce2A @c))
+    . (newLab blockEx2A)
+    . (feesAndDeposits feeTx2A (_keyDeposit ppEx * 3 + _poolDeposit ppEx))
+    . (newUTxO txbodyEx2A)
+    . (newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) 0 0))
+    . (newStakeCred Cast.bobSHK (Ptr (SlotNo 10) 0 1))
+    . (newStakeCred Cast.carlSHK (Ptr (SlotNo 10) 0 2))
+    . (newPool Cast.alicePoolParams)
+    . (mir Cast.carlSHK ReservesMIR carlMIR)
+    . (mir Cast.dariaSHK ReservesMIR dariaMIR)
+    $ initStEx2
+
+ex2A :: Mock c => CHAINExample c
+ex2A = CHAINExample initStEx2 blockEx2A (Right expectedStEx2A)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -82,14 +82,7 @@ import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey, txid)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( Mock,
   )
-import Test.Shelley.Spec.Ledger.Examples
-  ( aliceAddr,
-    alicePay,
-    bobAddr,
-    bobPay,
-    carlAddr,
-    dariaAddr,
-  )
+import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import Test.Shelley.Spec.Ledger.Generator.Core
   ( genesisCoins,
     genesisId,
@@ -104,25 +97,25 @@ singleKeyOnly (Addr _ (KeyHashObj pk) _) = RequireSignature $ asWitness pk
 singleKeyOnly _ = error "use VKey address"
 
 aliceOnly :: Crypto c => proxy c -> MultiSig c
-aliceOnly _ = singleKeyOnly aliceAddr
+aliceOnly _ = singleKeyOnly Cast.aliceAddr
 
 bobOnly :: Crypto c => proxy c -> MultiSig c
-bobOnly _ = singleKeyOnly bobAddr
+bobOnly _ = singleKeyOnly Cast.bobAddr
 
 aliceOrBob :: Crypto c => proxy c -> MultiSig c
-aliceOrBob p = RequireAnyOf [aliceOnly p, singleKeyOnly bobAddr]
+aliceOrBob p = RequireAnyOf [aliceOnly p, singleKeyOnly Cast.bobAddr]
 
 aliceAndBob :: Crypto c => proxy c -> MultiSig c
-aliceAndBob p = RequireAllOf [aliceOnly p, singleKeyOnly bobAddr]
+aliceAndBob p = RequireAllOf [aliceOnly p, singleKeyOnly Cast.bobAddr]
 
 aliceAndBobOrCarl :: Crypto c => proxy c -> MultiSig c
-aliceAndBobOrCarl p = RequireMOf 1 [aliceAndBob p, singleKeyOnly carlAddr]
+aliceAndBobOrCarl p = RequireMOf 1 [aliceAndBob p, singleKeyOnly Cast.carlAddr]
 
 aliceAndBobOrCarlAndDaria :: Crypto c => proxy c -> MultiSig c
 aliceAndBobOrCarlAndDaria p =
   RequireAnyOf
     [ aliceAndBob p,
-      RequireAllOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]
+      RequireAllOf [singleKeyOnly Cast.carlAddr, singleKeyOnly Cast.dariaAddr]
     ]
 
 aliceAndBobOrCarlOrDaria :: Crypto c => proxy c -> MultiSig c
@@ -130,7 +123,7 @@ aliceAndBobOrCarlOrDaria p =
   RequireMOf
     1
     [ aliceAndBob p,
-      RequireAnyOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]
+      RequireAnyOf [singleKeyOnly Cast.carlAddr, singleKeyOnly Cast.dariaAddr]
     ]
 
 initTxBody :: Crypto c => [(Addr c, Coin)] -> TxBody c
@@ -178,8 +171,8 @@ genesis = genesisState genDelegs0 utxo0
     genDelegs0 = Map.empty
     utxo0 =
       genesisCoins
-        [ TxOut aliceAddr aliceInitCoin,
-          TxOut bobAddr bobInitCoin
+        [ TxOut Cast.aliceAddr aliceInitCoin,
+          TxOut Cast.bobAddr bobInitCoin
         ]
 
 initPParams :: PParams
@@ -197,7 +190,7 @@ initialUTxOState ::
   (TxId c, Either [[PredicateFailure (UTXOW c)]] (UTxOState c))
 initialUTxOState aliceKeep msigs =
   let addresses =
-        [(aliceAddr, aliceKeep) | aliceKeep > 0]
+        [(Cast.aliceAddr, aliceKeep) | aliceKeep > 0]
           ++ map
             ( \(msig, c) ->
                 ( Addr
@@ -211,7 +204,7 @@ initialUTxOState aliceKeep msigs =
    in let tx =
             makeTx
               (initTxBody addresses)
-              (asWitness <$> [alicePay, bobPay])
+              (asWitness <$> [Cast.alicePay, Cast.bobPay])
               Map.empty
               Nothing
        in ( txid $ _body tx,
@@ -259,7 +252,7 @@ applyTxWithScript _ lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
     txbody =
       makeTxBody
         inputs
-        [(aliceAddr, aliceInitCoin + bobInitCoin + sum (unWdrl wdrl))]
+        [(Cast.aliceAddr, aliceInitCoin + bobInitCoin + sum (unWdrl wdrl))]
         wdrl
     inputs =
       [ TxIn txId (fromIntegral n)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -41,8 +41,6 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   )
 import Test.Shelley.Spec.Ledger.Examples
   ( CHAINExample (..),
-    ex1,
-    ex2A,
     ex2B,
     ex2C,
     ex2D,
@@ -76,6 +74,8 @@ import Test.Shelley.Spec.Ledger.Examples
     test5DReserves,
     test5DTreasury,
   )
+import Test.Shelley.Spec.Ledger.Examples.EmptyBlock (exEmptyBlock)
+import Test.Shelley.Spec.Ledger.Examples.PoolLifetime (ex2A)
 import Test.Shelley.Spec.Ledger.Utils
   ( applySTSTest,
     maxLLSupply,
@@ -145,8 +145,8 @@ stsTests :: TestTree
 stsTests =
   testGroup
     "STS Tests"
-    [ testCase "CHAIN example 1 - empty block" $ testCHAINExample (ex1 p),
-      testCase "CHAIN example 2A - register stake key" $ testCHAINExample (ex2A p),
+    [ testCase "CHAIN example 1 - empty block" $ testCHAINExample exEmptyBlock,
+      testCase "CHAIN example 2A - register stake key" $ testCHAINExample (ex2A),
       testCase "CHAIN example 2B - delegate stake and create reward update" $ testCHAINExample (ex2B p),
       testCase "CHAIN example 2C - new epoch changes" $ testCHAINExample (ex2C p),
       testCase "CHAIN example 2D - second reward update" $ testCHAINExample (ex2D p),
@@ -180,8 +180,8 @@ stsTests =
       testCase "CHAIN example 6A' - Late Pool Re-registration" $ testCHAINExample (ex6A' p),
       testCase "CHAIN example 6B - Adopt Early Pool Re-registration" $ testAdoptEarlyPoolRegistration,
       testCase "CHAIN example 6B' - Adopt Late Pool Re-registration" $ testAdoptLatePoolRegistration,
-      testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda (ex1 p),
-      testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda (ex2A p),
+      testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda exEmptyBlock,
+      testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda (ex2A),
       testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda (ex2B p),
       testCase "CHAIN example 2C - Preservation of ADA" $ testPreservationOfAda (ex2C p),
       testCase "CHAIN example 2D - Preservation of ADA" $ testPreservationOfAda (ex2D p),
@@ -274,7 +274,17 @@ testEverybodySigns =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOnly p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay, asWitness carlPay, asWitness dariaPay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOnly p]
+        (Wdrl Map.empty)
+        0
+        [ asWitness alicePay,
+          asWitness bobPay,
+          asWitness carlPay,
+          asWitness dariaPay
+        ]
     s = "problem: " ++ show utxoSt'
 
 testWrongScript :: Assertion
@@ -284,7 +294,13 @@ testWrongScript =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOrBob p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOrBob p]
+        (Wdrl Map.empty)
+        0
+        [asWitness alicePay, asWitness bobPay]
 
 testAliceOrBob :: Assertion
 testAliceOrBob =
@@ -313,7 +329,13 @@ testAliceAndBob =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBob p, 11000)] [aliceAndBob p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceAndBob p, 11000)]
+        [aliceAndBob p]
+        (Wdrl Map.empty)
+        0
+        [asWitness alicePay, asWitness bobPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBob' :: Assertion
@@ -341,7 +363,13 @@ testAliceAndBobOrCarl =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarl p, 11000)] [aliceAndBobOrCarl p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarl p, 11000)]
+        [aliceAndBobOrCarl p]
+        (Wdrl Map.empty)
+        0
+        [asWitness alicePay, asWitness bobPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarl' :: Assertion
@@ -361,7 +389,13 @@ testAliceAndBobOrCarlAndDaria =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarlAndDaria p, 11000)] [aliceAndBobOrCarlAndDaria p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarlAndDaria p, 11000)]
+        [aliceAndBobOrCarlAndDaria p]
+        (Wdrl Map.empty)
+        0
+        [asWitness alicePay, asWitness bobPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlAndDaria' :: Assertion
@@ -371,7 +405,13 @@ testAliceAndBobOrCarlAndDaria' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarlAndDaria p, 11000)] [aliceAndBobOrCarlAndDaria p] (Wdrl Map.empty) 0 [asWitness carlPay, asWitness dariaPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarlAndDaria p, 11000)]
+        [aliceAndBobOrCarlAndDaria p]
+        (Wdrl Map.empty)
+        0
+        [asWitness carlPay, asWitness dariaPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria :: Assertion
@@ -381,7 +421,13 @@ testAliceAndBobOrCarlOrDaria =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarlOrDaria p, 11000)] [aliceAndBobOrCarlOrDaria p] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarlOrDaria p, 11000)]
+        [aliceAndBobOrCarlOrDaria p]
+        (Wdrl Map.empty)
+        0
+        [asWitness alicePay, asWitness bobPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria' :: Assertion
@@ -391,7 +437,13 @@ testAliceAndBobOrCarlOrDaria' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarlOrDaria p, 11000)] [aliceAndBobOrCarlOrDaria p] (Wdrl Map.empty) 0 [asWitness carlPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarlOrDaria p, 11000)]
+        [aliceAndBobOrCarlOrDaria p]
+        (Wdrl Map.empty)
+        0
+        [asWitness carlPay]
     s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria'' :: Assertion
@@ -401,7 +453,13 @@ testAliceAndBobOrCarlOrDaria'' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceAndBobOrCarlOrDaria p, 11000)] [aliceAndBobOrCarlOrDaria p] (Wdrl Map.empty) 0 [asWitness dariaPay]
+      applyTxWithScript
+        p
+        [(aliceAndBobOrCarlOrDaria p, 11000)]
+        [aliceAndBobOrCarlOrDaria p]
+        (Wdrl Map.empty)
+        0
+        [asWitness dariaPay]
     s = "problem: " ++ show utxoSt'
 
 -- multiple script-locked outputs
@@ -525,7 +583,13 @@ testRwdAliceSignsAlone =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOnly p] (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (aliceOnly p))) 1000) 0 [asWitness alicePay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOnly p]
+        (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (aliceOnly p))) 1000)
+        0
+        [asWitness alicePay]
     s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone' :: Assertion
@@ -535,7 +599,13 @@ testRwdAliceSignsAlone' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOnly p, bobOnly p] (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000) 0 [asWitness alicePay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOnly p, bobOnly p]
+        (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000)
+        0
+        [asWitness alicePay]
 
 testRwdAliceSignsAlone'' :: Assertion
 testRwdAliceSignsAlone'' =
@@ -544,7 +614,13 @@ testRwdAliceSignsAlone'' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOnly p, bobOnly p] (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOnly p, bobOnly p]
+        (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000)
+        0
+        [asWitness alicePay, asWitness bobPay]
     s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone''' :: Assertion
@@ -554,5 +630,11 @@ testRwdAliceSignsAlone''' =
     p :: Proxy C
     p = Proxy
     utxoSt' =
-      applyTxWithScript p [(aliceOnly p, 11000)] [aliceOnly p] (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000) 0 [asWitness alicePay, asWitness bobPay]
+      applyTxWithScript
+        p
+        [(aliceOnly p, 11000)]
+        [aliceOnly p]
+        (Wdrl $ Map.singleton (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p))) 1000)
+        0
+        [asWitness alicePay, asWitness bobPay]
 -}

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -32,6 +32,7 @@ module Test.Shelley.Spec.Ledger.Utils
     applySTSTest,
     GenesisKeyPair,
     MultiSigPairs,
+    getBlockNonce,
   )
 where
 
@@ -48,6 +49,7 @@ import Cardano.Crypto.Hash
 import Cardano.Crypto.KES (KESAlgorithm, SignKeyKES, VerKeyKES, deriveVerKeyKES, genKeyKES)
 import Cardano.Crypto.KES.Class (ContextKES)
 import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
+import Cardano.Crypto.VRF (certifiedOutput)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Crypto.VRF
   ( CertifiedVRF,
@@ -78,11 +80,14 @@ import Shelley.Spec.Ledger.Address (Addr, pattern Addr)
 import Shelley.Spec.Ledger.BaseTypes
   ( Globals (..),
     Network (..),
+    Nonce,
     ShelleyBase,
     UnitInterval,
     mkActiveSlotCoeff,
+    mkNonceFromOutputVRF,
     mkUnitInterval,
   )
+import Shelley.Spec.Ledger.BlockChain (BHBody (..), Block, bhbody, bheader)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
 import Shelley.Spec.Ledger.Crypto (Crypto (..))
@@ -266,3 +271,7 @@ testSTS env initSt block predicateFailure@(Left _) = do
 
 mkHash :: forall a h. HashAlgorithm h => Int -> Hash h a
 mkHash i = coerce (hashWithSerialiser @h toCBOR i)
+
+getBlockNonce :: forall c. Crypto c => Block c -> Nonce
+getBlockNonce =
+  mkNonceFromOutputVRF . certifiedOutput . bheaderEta . bhbody . bheader

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -20,6 +20,12 @@ library
                      Test.Shelley.Spec.Ledger.Address.Bootstrap
                      Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
                      Test.Shelley.Spec.Ledger.Examples
+                     Test.Shelley.Spec.Ledger.Examples.Cast
+                     Test.Shelley.Spec.Ledger.Examples.Combinators
+                     Test.Shelley.Spec.Ledger.Examples.Federation
+                     Test.Shelley.Spec.Ledger.Examples.Init
+                     Test.Shelley.Spec.Ledger.Examples.EmptyBlock
+                     Test.Shelley.Spec.Ledger.Examples.PoolLifetime
                      Test.Shelley.Spec.Ledger.Fees
                      Test.Shelley.Spec.Ledger.Generator.Block
                      Test.Shelley.Spec.Ledger.Generator.Constants


### PR DESCRIPTION
This is the begging of #1680, splitting up the examples / unit tests. I have separated example 1 and the first block of example 2, and also pulled out some things into their own module.  In particular:

* The is a new module `Test.Shelley.Spec.Ledger.Examples.Init` for all the initial setup for the examples. Such as the initial protocol parameters, chain state, etc.
* The is a new module `Test.Shelley.Spec.Ledger.Example.Federation` for everything involving the core/genesis nodes.
* The is a new module `Test.Shelley.Spec.Ledger.Example.Cast` for stake keys and stake pools, things like Alice's pool stuff and Bob's keys, etc.
* The is a new module `Test.Shelley.Spec.Ledger.Example.Combinators` which aims to make the examples easier to follow. The idea in that they are a collection of functions `... -> ChainState -> ChainState` which mutate the chain state in particular ways, such as incrementing the fee pot or registering a stake pool. This way we can calculate the expected chain states (given another state and some block) in a way that is hopefully easier to read and less brittle.
* The is a new module `Test.Shelley.Spec.Ledger.Example.EmptyBlock` which replaces the old example 1, which just applies an empty block to an initial shelley chain state.
* The is a new module `Test.Shelley.Spec.Ledger.Example.PoolLifetime` which will eventually cover all of the example 2, which shows the lifetime of a pool (registration, rewards, retirement, etc). Right now it only covers the first block in that example.

I've also added a lot of haddocks to the new test modules. (you can build them with `stack haddock shelley-spec-ledger-test`).
