### PR TITLE
Make the overlay schedule abstract

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -35,6 +35,7 @@ library
                      Shelley.Spec.Ledger.MetaData
                      Shelley.Spec.Ledger.OCert
                      Shelley.Spec.Ledger.Orphans
+                     Shelley.Spec.Ledger.OverlaySchedule
                      Shelley.Spec.Ledger.PParams
                      Shelley.Spec.Ledger.Rewards
                      Shelley.Spec.Ledger.Scripts

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -36,7 +36,6 @@ import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import Data.Either (fromRight)
-import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.API.Validation
 import Shelley.Spec.Ledger.BaseTypes (Globals, Nonce, Seed)
@@ -47,7 +46,7 @@ import Shelley.Spec.Ledger.Keys (GenDelegs)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState (..),
     NewEpochState (..),
-    OBftSlot,
+    OverlaySchedule,
     getGKeys,
     _delegationState,
     _dstate,
@@ -64,7 +63,7 @@ import Shelley.Spec.Ledger.Slot (SlotNo)
 -- | Data required by the Transitional Praos protocol from the Shelley ledger.
 data LedgerView crypto = LedgerView
   { lvProtParams :: PParams,
-    lvOverlaySched :: Map SlotNo (OBftSlot crypto),
+    lvOverlaySched :: OverlaySchedule crypto,
     lvPoolDistr :: PoolDistr crypto,
     lvGenDelegs :: GenDelegs crypto
   }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -46,13 +46,15 @@ import Shelley.Spec.Ledger.Keys (GenDelegs)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState (..),
     NewEpochState (..),
-    OverlaySchedule,
     getGKeys,
     _delegationState,
     _dstate,
     _genDelegs,
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
+import Shelley.Spec.Ledger.OverlaySchedule
+  ( OverlaySchedule,
+  )
 import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
 import Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -66,19 +66,19 @@ import Shelley.Spec.Ledger.LedgerState as X
     LedgerState (..),
     NewEpochEnv (..),
     NewEpochState (..),
-    OBftSlot (..),
     PState (..),
     RewardUpdate (..),
     UTxOState (..),
     WitHashes (..),
   )
 import Shelley.Spec.Ledger.OCert as X (OCert (..))
+import Shelley.Spec.Ledger.OverlaySchedule as X
+  ( OBftSlot (..),
+  )
 import Shelley.Spec.Ledger.PParams as X
   ( PParams,
     PParams' (..),
-  )
-import Shelley.Spec.Ledger.PParams as X
-  ( ProposedPPUpdates (..),
+    ProposedPPUpdates (..),
     Update (..),
   )
 import Shelley.Spec.Ledger.Rewards as X

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -28,7 +28,6 @@ import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
-import Shelley.Spec.Ledger.OverlaySchedule (overlaySlots)
 import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
@@ -62,14 +61,14 @@ mkTickEnv = STS.TickEnv . LedgerState.getGKeys
 
 mkBbodyEnv ::
   ShelleyState crypto ->
-  STS.BbodyEnv
+  STS.BbodyEnv crypto
 mkBbodyEnv
   LedgerState.NewEpochState
     { LedgerState.nesOsched,
       LedgerState.nesEs
     } =
     STS.BbodyEnv
-      { STS.bbodySlots = overlaySlots nesOsched,
+      { STS.bbodySlots = nesOsched,
         STS.bbodyPp = LedgerState.esPp nesEs,
         STS.bbodyAccount = LedgerState.esAccountState nesEs
       }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -19,7 +19,6 @@ where
 
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Arrow (left, right)
-import Control.Iterate.SetAlgebra (dom, eval)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended (TRC (..), applySTS, reapplySTS)
@@ -69,7 +68,7 @@ mkBbodyEnv
       LedgerState.nesEs
     } =
     STS.BbodyEnv
-      { STS.bbodySlots = eval (dom nesOsched),
+      { STS.bbodySlots = LedgerState.overlaySlots nesOsched,
         STS.bbodyPp = LedgerState.esPp nesEs,
         STS.bbodyAccount = LedgerState.esAccountState nesEs
       }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -28,6 +28,7 @@ import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.OverlaySchedule (overlaySlots)
 import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
@@ -68,7 +69,7 @@ mkBbodyEnv
       LedgerState.nesEs
     } =
     STS.BbodyEnv
-      { STS.bbodySlots = LedgerState.overlaySlots nesOsched,
+      { STS.bbodySlots = overlaySlots nesOsched,
         STS.bbodyPp = LedgerState.esPp nesEs,
         STS.bbodyAccount = LedgerState.esAccountState nesEs
       }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -14,7 +14,7 @@ import Cardano.Slotting.Slot (SlotNo)
 import Data.Functor.Identity (runIdentity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -35,9 +35,9 @@ import Shelley.Spec.Ledger.LedgerState
     LedgerState (..),
     NewEpochState (..),
     UTxOState (..),
-    lookupInOverlaySchedule,
     stakeDistr,
   )
+import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
 import Shelley.Spec.Ledger.Rewards
   ( NonMyopic (..),
     StakeShare (..),
@@ -138,7 +138,7 @@ getLeaderSchedule globals ss cds poolHash key = Set.filter isLeader epochSlots
   where
     isLeader slotNo =
       let y = VRF.evalCertified () (mkSeed seedL slotNo epochNonce) key
-       in isNothing (lookupInOverlaySchedule slotNo overlaySched)
+       in not (isOverlaySlot slotNo overlaySched)
             && checkLeaderValue (VRF.certifiedOutput y) stake f
     stake = maybe 0 individualPoolStake $ Map.lookup poolHash poolDistr
     overlaySched = nesOsched ss

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -14,7 +14,7 @@ import Cardano.Slotting.Slot (SlotNo)
 import Data.Functor.Identity (runIdentity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -35,6 +35,7 @@ import Shelley.Spec.Ledger.LedgerState
     LedgerState (..),
     NewEpochState (..),
     UTxOState (..),
+    lookupInOverlaySchedule,
     stakeDistr,
   )
 import Shelley.Spec.Ledger.Rewards
@@ -137,7 +138,7 @@ getLeaderSchedule globals ss cds poolHash key = Set.filter isLeader epochSlots
   where
     isLeader slotNo =
       let y = VRF.evalCertified () (mkSeed seedL slotNo epochNonce) key
-       in Map.notMember slotNo overlaySched
+       in isNothing (lookupInOverlaySchedule slotNo overlaySched)
             && checkLeaderValue (VRF.certifiedOutput y) stake f
     stake = maybe 0 individualPoolStake $ Map.lookup poolHash poolDistr
     overlaySched = nesOsched ss

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
@@ -7,7 +7,6 @@
 module Shelley.Spec.Ledger.OverlaySchedule
   ( -- * Overlay schedule
     OverlaySchedule,
-    OverlaySlots,
     compactOverlaySchedule,
     decompactOverlaySchedule,
     emptyOverlaySchedule,
@@ -17,7 +16,6 @@ module Shelley.Spec.Ledger.OverlaySchedule
     overlayScheduleHelper,
     overlayScheduleIsEmpty,
     overlayScheduleToMap,
-    overlaySlots,
 
     -- * OBftSlot
     OBftSlot (..),
@@ -182,10 +180,5 @@ instance Crypto crypto => ToCBOR (OverlaySchedule crypto) where
 instance Crypto crypto => FromCBOR (OverlaySchedule crypto) where
   fromCBOR = decompactOverlaySchedule <$> fromCBOR
 
-newtype OverlaySlots = OverlaySlots (Set SlotNo)
-
-overlaySlots :: OverlaySchedule crypto -> OverlaySlots
-overlaySlots (OverlaySchedule oSched) = OverlaySlots (Map.keysSet oSched)
-
-isOverlaySlot :: SlotNo -> OverlaySlots -> Bool
-isOverlaySlot slot (OverlaySlots oslots) = Set.member slot oslots
+isOverlaySlot :: SlotNo -> OverlaySchedule c -> Bool
+isOverlaySlot slot (OverlaySchedule oslots) = Map.member slot oslots

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Shelley.Spec.Ledger.OverlaySchedule
+  ( -- * Overlay schedule
+    OverlaySchedule,
+    OverlaySlots,
+    compactOverlaySchedule,
+    decompactOverlaySchedule,
+    emptyOverlaySchedule,
+    isOverlaySlot,
+    lookupInOverlaySchedule,
+    overlaySchedule,
+    overlayScheduleHelper,
+    overlayScheduleIsEmpty,
+    overlayScheduleToMap,
+    overlaySlots,
+
+    -- * OBftSlot
+    OBftSlot (..),
+  )
+where
+
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    TokenType (TypeNull),
+    decodeNull,
+    encodeNull,
+    peekTokenType,
+  )
+import Cardano.Prelude (NFData, NoUnexpectedThunks)
+import Cardano.Slotting.Slot
+import Control.Monad.Trans.Reader (asks)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.Keys
+  ( KeyHash (..),
+    KeyRole (..),
+  )
+import Shelley.Spec.Ledger.PParams (PParams, _d)
+import Shelley.Spec.Ledger.Slot
+
+data OBftSlot crypto
+  = NonActiveSlot
+  | ActiveSlot !(KeyHash 'Genesis crypto)
+  deriving (Show, Eq, Ord, Generic)
+
+instance
+  Crypto crypto =>
+  ToCBOR (OBftSlot crypto)
+  where
+  toCBOR NonActiveSlot = encodeNull
+  toCBOR (ActiveSlot k) = toCBOR k
+
+instance
+  Crypto crypto =>
+  FromCBOR (OBftSlot crypto)
+  where
+  fromCBOR = do
+    peekTokenType >>= \case
+      TypeNull -> do
+        decodeNull
+        pure NonActiveSlot
+      _ -> ActiveSlot <$> fromCBOR
+
+instance NoUnexpectedThunks (OBftSlot crypto)
+
+instance NFData (OBftSlot crypto)
+
+newtype OverlaySchedule crypto = OverlaySchedule (Map SlotNo (OBftSlot crypto))
+  deriving stock (Show, Eq)
+  deriving newtype (NoUnexpectedThunks, NFData)
+
+emptyOverlaySchedule :: OverlaySchedule crypto
+emptyOverlaySchedule = OverlaySchedule Map.empty
+
+lookupInOverlaySchedule ::
+  SlotNo ->
+  OverlaySchedule crypto ->
+  Maybe (OBftSlot crypto)
+lookupInOverlaySchedule slot (OverlaySchedule oSched) = Map.lookup slot oSched
+
+overlayScheduleIsEmpty :: OverlaySchedule crypto -> Bool
+overlayScheduleIsEmpty (OverlaySchedule oSched) = Map.null oSched
+
+-- | Overlay schedule
+-- This is just a very simple round-robin, evenly spaced schedule.
+overlaySchedule ::
+  EpochNo ->
+  Set (KeyHash 'Genesis crypto) ->
+  PParams ->
+  ShelleyBase (OverlaySchedule crypto)
+overlaySchedule e gkeys pp = do
+  ei <- asks epochInfo
+  slotsPerEpoch <- epochInfoSize ei e
+  firstSlotNo <- epochInfoFirst ei e
+  asc <- asks activeSlotCoeff
+  pure $ overlayScheduleHelper slotsPerEpoch firstSlotNo gkeys (_d pp) asc
+
+overlayScheduleHelper ::
+  EpochSize ->
+  -- | First slot of the epoch
+  SlotNo ->
+  Set (KeyHash 'Genesis crypto) ->
+  -- | Decentralization parameter @d@
+  UnitInterval ->
+  ActiveSlotCoeff ->
+  OverlaySchedule crypto
+overlayScheduleHelper slotsPerEpoch firstSlotNo gkeys d asc
+  | dval == 0 =
+    OverlaySchedule $ Map.empty
+  | otherwise =
+    OverlaySchedule $ Map.union active inactive
+  where
+    dval = intervalValue d
+    numActive = dval * fromIntegral slotsPerEpoch
+    dInv = 1 / dval
+    ascValue = (intervalValue . activeSlotVal) asc
+    toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
+    toSlotNo x = firstSlotNo +* toRelativeSlotNo x
+    genesisSlots = [toSlotNo x | x <- [0 .. (floor numActive - 1)]]
+    numInactivePerActive = floor (1 / ascValue) - 1
+    activitySchedule = cycle (True : replicate numInactivePerActive False)
+    unassignedSched = zip activitySchedule genesisSlots
+    genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
+    active =
+      Map.fromList $
+        fmap
+          (\(gk, (_, s)) -> (s, ActiveSlot gk))
+          (zip genesisCycle (filter fst unassignedSched))
+    inactive =
+      Map.fromList $
+        fmap
+          (\x -> (snd x, NonActiveSlot))
+          (filter (not . fst) unassignedSched)
+
+overlayScheduleToMap :: OverlaySchedule crypto -> Map SlotNo (OBftSlot crypto)
+overlayScheduleToMap (OverlaySchedule oSched) = oSched
+
+-- | Convert the overlay schedule to a representation that is more compact
+-- when serialised to a bytestring, but less efficient for lookups.
+--
+-- Each genesis key hash will only be stored once, instead of each time it is
+-- assigned to a slot.
+compactOverlaySchedule ::
+  OverlaySchedule crypto ->
+  Map (OBftSlot crypto) (NonEmpty SlotNo)
+compactOverlaySchedule (OverlaySchedule oSched) =
+  Map.foldrWithKey'
+    ( \slot obftSlot ->
+        Map.insertWith (<>) obftSlot (pure slot)
+    )
+    Map.empty
+    oSched
+
+-- | Inverse of 'compactOverlaySchedule'
+decompactOverlaySchedule ::
+  Map (OBftSlot crypto) (NonEmpty SlotNo) ->
+  OverlaySchedule crypto
+decompactOverlaySchedule compact =
+  OverlaySchedule $
+    Map.fromList
+      [ (slot, obftSlot)
+        | (obftSlot, slots) <- Map.toList compact,
+          slot <- NonEmpty.toList slots
+      ]
+
+instance Crypto crypto => ToCBOR (OverlaySchedule crypto) where
+  toCBOR = toCBOR . compactOverlaySchedule
+
+instance Crypto crypto => FromCBOR (OverlaySchedule crypto) where
+  fromCBOR = decompactOverlaySchedule <$> fromCBOR
+
+newtype OverlaySlots = OverlaySlots (Set SlotNo)
+
+overlaySlots :: OverlaySchedule crypto -> OverlaySlots
+overlaySlots (OverlaySchedule oSched) = OverlaySlots (Map.keysSet oSched)
+
+isOverlaySlot :: SlotNo -> OverlaySlots -> Bool
+isOverlaySlot slot (OverlaySlots oslots) = Set.member slot oslots

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -48,7 +48,9 @@ import Shelley.Spec.Ledger.Keys (DSignable, Hash, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
     LedgerState,
-    OverlaySlots,
+  )
+import Shelley.Spec.Ledger.OverlaySchedule
+  ( OverlaySlots,
     isOverlaySlot,
   )
 import Shelley.Spec.Ledger.PParams (PParams)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -50,7 +50,7 @@ import Shelley.Spec.Ledger.LedgerState
     LedgerState,
   )
 import Shelley.Spec.Ledger.OverlaySchedule
-  ( OverlaySlots,
+  ( OverlaySchedule,
     isOverlaySlot,
   )
 import Shelley.Spec.Ledger.PParams (PParams)
@@ -63,8 +63,8 @@ data BbodyState crypto
   = BbodyState (LedgerState crypto) (BlocksMade crypto)
   deriving (Eq, Show)
 
-data BbodyEnv = BbodyEnv
-  { bbodySlots :: OverlaySlots,
+data BbodyEnv crypto = BbodyEnv
+  { bbodySlots :: OverlaySchedule crypto,
     bbodyPp :: PParams,
     bbodyAccount :: AccountState
   }
@@ -83,7 +83,7 @@ instance
     Signal (BBODY crypto) =
       Block crypto
 
-  type Environment (BBODY crypto) = BbodyEnv
+  type Environment (BBODY crypto) = BbodyEnv crypto
 
   type BaseM (BBODY crypto) = ShelleyBase
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -18,7 +18,6 @@ module Shelley.Spec.Ledger.STS.Bbody
 where
 
 import Cardano.Prelude (NoUnexpectedThunks (..))
-import Control.Iterate.SetAlgebra (eval, (∈))
 import Control.State.Transition
   ( Embed (..),
     STS (..),
@@ -29,7 +28,6 @@ import Control.State.Transition
     (?!),
   )
 import qualified Data.Sequence.Strict as StrictSeq
-import Data.Set (Set)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 import Shelley.Spec.Ledger.BlockChain
@@ -47,10 +45,14 @@ import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
 import Shelley.Spec.Ledger.Keys (DSignable, Hash, coerceKeyRole)
-import Shelley.Spec.Ledger.LedgerState (AccountState, LedgerState)
+import Shelley.Spec.Ledger.LedgerState
+  ( AccountState,
+    LedgerState,
+    OverlaySlots,
+    isOverlaySlot,
+  )
 import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
-import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (TxBody)
 
 data BBODY crypto
@@ -60,7 +62,7 @@ data BbodyState crypto
   deriving (Eq, Show)
 
 data BbodyEnv = BbodyEnv
-  { bbodySlots :: (Set SlotNo),
+  { bbodySlots :: OverlaySlots,
     bbodyPp :: PParams,
     bbodyAccount :: AccountState
   }
@@ -129,7 +131,7 @@ bbodyTransition =
         -- delegate. However, this would only entail an overhead of 7 counts, and it's
         -- easier than differentiating here.
         let hkAsStakePool = coerceKeyRole . poolIDfromBHBody $ bhb
-        pure $ BbodyState ls' (incrBlocks (eval (bheaderSlotNo bhb ∈ oslots)) hkAsStakePool b)
+        pure $ BbodyState ls' (incrBlocks (isOverlaySlot (bheaderSlotNo bhb) oslots) hkAsStakePool b)
 
 instance
   ( Crypto crypto,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -87,13 +87,14 @@ import Shelley.Spec.Ledger.LedgerState
     EpochState (..),
     LedgerState (..),
     NewEpochState (..),
-    OBftSlot,
+    OverlaySchedule,
     PState (..),
     UTxOState (..),
     emptyDState,
     emptyPPUPState,
     emptyPState,
     getGKeys,
+    overlaySlots,
     updateNES,
     _genDelegs,
   )
@@ -116,7 +117,7 @@ import Shelley.Spec.Ledger.STS.Prtcl
   )
 import Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))
 import Shelley.Spec.Ledger.STS.Tickn
-import Shelley.Spec.Ledger.Slot (EpochNo, SlotNo)
+import Shelley.Spec.Ledger.Slot (EpochNo)
 import Shelley.Spec.Ledger.Tx (TxBody)
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
 
@@ -142,7 +143,7 @@ initialShelleyState ::
   UTxO crypto ->
   Coin ->
   Map (KeyHash 'Genesis crypto) (GenDelegPair crypto) ->
-  Map SlotNo (OBftSlot crypto) ->
+  OverlaySchedule crypto ->
   PParams ->
   Nonce ->
   ChainState crypto
@@ -295,7 +296,7 @@ chainTransition =
 
       BbodyState ls' bcur' <-
         trans @(BBODY crypto) $
-          TRC (BbodyEnv (Map.keysSet osched) pp' account, BbodyState ls bcur, block)
+          TRC (BbodyEnv (overlaySlots osched) pp' account, BbodyState ls bcur, block)
 
       let nes'' = updateNES nes' bcur' ls'
           bhb = bhbody bh

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -87,18 +87,17 @@ import Shelley.Spec.Ledger.LedgerState
     EpochState (..),
     LedgerState (..),
     NewEpochState (..),
-    OverlaySchedule,
     PState (..),
     UTxOState (..),
     emptyDState,
     emptyPPUPState,
     emptyPState,
     getGKeys,
-    overlaySlots,
     updateNES,
     _genDelegs,
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams
   ( PParams,
     ProtVer (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -295,7 +295,7 @@ chainTransition =
 
       BbodyState ls' bcur' <-
         trans @(BBODY crypto) $
-          TRC (BbodyEnv (overlaySlots osched) pp' account, BbodyState ls bcur, block)
+          TRC (BbodyEnv osched pp' account, BbodyState ls bcur, block)
 
       let nes'' = updateNES nes' bcur' ls'
           bhb = bhbody bh

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -25,6 +25,7 @@ import Shelley.Spec.Ledger.Crypto
 import Shelley.Spec.Ledger.Delegation.Certificates
 import Shelley.Spec.Ledger.EpochBoundary
 import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.STS.Epoch
 import Shelley.Spec.Ledger.STS.Mir
 import Shelley.Spec.Ledger.Slot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -60,7 +60,7 @@ instance
           emptyEpochState
           SNothing
           (PoolDistr Map.empty)
-          Map.empty
+          emptyOverlaySchedule
     ]
 
   transitionRules = [newEpochTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -66,12 +66,12 @@ import Shelley.Spec.Ledger.Keys
     hashKey,
     hashVerKeyVRF,
   )
-import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.OCert (OCertSignable)
+import Shelley.Spec.Ledger.OverlaySchedule
   ( OBftSlot (..),
     OverlaySchedule,
     lookupInOverlaySchedule,
   )
-import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.STS.Ocert (OCERT, OCertEnv (..))
 import Shelley.Spec.Ledger.Slot (SlotNo)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -66,7 +66,11 @@ import Shelley.Spec.Ledger.Keys
     hashKey,
     hashVerKeyVRF,
   )
-import Shelley.Spec.Ledger.LedgerState (OBftSlot (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( OBftSlot (..),
+    OverlaySchedule,
+    lookupInOverlaySchedule,
+  )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.STS.Ocert (OCERT, OCertEnv (..))
 import Shelley.Spec.Ledger.Slot (SlotNo)
@@ -75,7 +79,7 @@ data OVERLAY crypto
 
 data OverlayEnv crypto
   = OverlayEnv
-      (Map SlotNo (OBftSlot crypto))
+      (OverlaySchedule crypto)
       Nonce
       (PoolDistr crypto)
       (GenDelegs crypto)
@@ -244,7 +248,7 @@ overlayTransition =
 
         asc <- liftSTS $ asks activeSlotCoeff
 
-        case Map.lookup (bheaderSlotNo bhb) osched of
+        case lookupInOverlaySchedule (bheaderSlotNo bhb) osched of
           Nothing ->
             praosVrfChecks eta0 pd asc bhb ?!: id
           Just NonActiveSlot ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -58,7 +58,7 @@ import Shelley.Spec.Ledger.Keys
     KeyRole (..),
     VRFSignable,
   )
-import Shelley.Spec.Ledger.LedgerState (OBftSlot)
+import Shelley.Spec.Ledger.LedgerState (OverlaySchedule)
 import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
 import Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
@@ -101,7 +101,7 @@ instance Crypto crypto => NoUnexpectedThunks (PrtclState crypto)
 
 data PrtclEnv crypto
   = PrtclEnv
-      (Map SlotNo (OBftSlot crypto))
+      (OverlaySchedule crypto)
       (PoolDistr crypto)
       (GenDelegs crypto)
       Nonce

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -58,8 +58,8 @@ import Shelley.Spec.Ledger.Keys
     KeyRole (..),
     VRFSignable,
   )
-import Shelley.Spec.Ledger.LedgerState (OverlaySchedule)
 import Shelley.Spec.Ledger.OCert (OCertSignable)
+import Shelley.Spec.Ledger.OverlaySchedule (OverlaySchedule)
 import Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
 import Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -44,6 +44,7 @@ import Shelley.Spec.Ledger.Keys
     hashKey,
     vKey,
   )
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.OCert (KESPeriod (..), currentIssueNo, kesPeriod)
 import Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv (..))
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
@@ -174,7 +175,7 @@ selectNextSlotWithLeader
         Maybe (ChainState c, AllIssuerKeys c 'BlockIssuer)
       selectLeaderForSlot slotNo =
         (chainSt,)
-          <$> case Map.lookup slotNo overlaySched of
+          <$> case lookupInOverlaySchedule slotNo overlaySched of
             Nothing ->
               coerce
                 <$> List.find
@@ -199,7 +200,7 @@ selectNextSlotWithLeader
             let y = VRF.evalCertified @(VRF c) () (mkSeed seedL slotNo epochNonce) vrfKey
                 stake = maybe 0 individualPoolStake $ Map.lookup poolHash poolDistr
                 f = activeSlotCoeff testGlobals
-             in case Map.lookup slotNo overlaySched of
+             in case lookupInOverlaySchedule slotNo overlaySched of
                   Nothing -> checkLeaderValue (VRF.certifiedOutput y) stake f
                   Just (ActiveSlot x) | coerceKeyRole x == poolHash -> True
                   _ -> False

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -49,7 +49,8 @@ import Shelley.Spec.Ledger.Keys
     KeyRole (BlockIssuer),
     coerceKeyRole,
   )
-import Shelley.Spec.Ledger.LedgerState (esAccountState, nesEs, overlaySchedule, _treasury)
+import Shelley.Spec.Ledger.LedgerState (esAccountState, nesEs, _treasury)
+import Shelley.Spec.Ledger.OverlaySchedule (overlaySchedule)
 import Shelley.Spec.Ledger.STS.Chain (chainNes, initialShelleyState)
 import qualified Shelley.Spec.Ledger.STS.Chain as STS (ChainState (ChainState))
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -37,7 +37,7 @@ import Cardano.Crypto.DSIGN.Mock (VerKeyDSIGN (..))
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Slotting.Block (BlockNo (..))
-import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import Control.Iterate.SetAlgebra (biMapFromList)
 import qualified Data.ByteString.Char8 as BS
 import Data.Coerce (coerce)
@@ -59,13 +59,15 @@ import Shelley.Spec.Ledger.Address.Bootstrap
     ChainCode (..),
   )
 import Shelley.Spec.Ledger.BaseTypes
-  ( DnsName,
+  ( ActiveSlotCoeff,
+    DnsName,
     Network,
     Nonce (..),
     Port,
     StrictMaybe,
     UnitInterval,
     Url,
+    mkActiveSlotCoeff,
     mkNonceFromNumber,
     mkUnitInterval,
     textToDns,
@@ -93,9 +95,11 @@ import Shelley.Spec.Ledger.LedgerState
     NewEpochState (..),
     OBftSlot,
     PPUPState,
+    OverlaySchedule,
     RewardUpdate,
     WitHashes (..),
     emptyRewardUpdate,
+    overlayScheduleHelper,
   )
 import Shelley.Spec.Ledger.MetaData
   ( MetaData,
@@ -564,12 +568,25 @@ instance Arbitrary a => Arbitrary (StrictMaybe a) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
+genPParams :: Mock c => proxy c -> Gen PParams
+genPParams p = Update.genPParams (geConstants (genEnv p))
+
 instance Crypto c => Arbitrary (OBftSlot c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-genPParams :: Mock c => proxy c -> Gen PParams
-genPParams p = Update.genPParams (geConstants (genEnv p))
+instance Arbitrary ActiveSlotCoeff where
+  arbitrary = mkActiveSlotCoeff <$> arbitrary
+
+instance Crypto c => Arbitrary (OverlaySchedule c) where
+  arbitrary =
+    -- Pick the parameters from specific random to avoid huge overlay schedules
+    overlayScheduleHelper
+      <$> (EpochSize <$> choose (1, 100))
+      <*> (SlotNo <$> choose (0, 100000))
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary Likelihood where
   arbitrary = Likelihood <$> arbitrary

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -93,14 +93,12 @@ import Shelley.Spec.Ledger.LedgerState
     InstantaneousRewards,
     LedgerState,
     NewEpochState (..),
-    OBftSlot,
     PPUPState,
-    OverlaySchedule,
     RewardUpdate,
     WitHashes (..),
     emptyRewardUpdate,
-    overlayScheduleHelper,
   )
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.MetaData
   ( MetaData,
     MetaDataHash (..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
@@ -37,11 +37,8 @@ import Shelley.Spec.Ledger.Keys
     hashVerKeyVRF,
     vKey,
   )
-import Shelley.Spec.Ledger.LedgerState
-  ( OBftSlot (..),
-    overlaySchedule,
-  )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams
   ( PParams,
   )
@@ -109,7 +106,7 @@ coreNodeKeysForSlot overlay slot = case Map.lookup (SlotNo slot) overlay of
 
 -- | === Overlay Schedule
 -- Retrieve the overlay schedule for a given epoch and protocol parameters.
-overlayScheduleFor :: Crypto c => EpochNo -> PParams -> Map SlotNo (OBftSlot c)
+overlayScheduleFor :: Crypto c => EpochNo -> PParams -> OverlaySchedule c
 overlayScheduleFor e pp =
   runShelleyBase $
     overlaySchedule
@@ -129,7 +126,12 @@ coreNodeKeysBySchedule ::
   AllIssuerKeys c 'GenesisDelegate
 coreNodeKeysBySchedule = coreNodeKeysForSlot . fullOSched
   where
-    fullOSched pp = Map.unions $ [overlayScheduleFor e pp | e <- [0 .. 10]]
+    fullOSched pp =
+      Map.unions $
+        [ overlayScheduleToMap $
+            overlayScheduleFor e pp
+          | e <- [0 .. 10]
+        ]
 
 -- | === Genesis Delegation Mapping
 -- The map from genesis/core node (verification) key hashes

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -122,14 +122,13 @@ import Shelley.Spec.Ledger.Keys
     signedKES,
     vKey,
   )
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     EpochState (..),
     NewEpochState (..),
     RewardUpdate (..),
-    decompactOverlaySchedule,
     emptyLedgerState,
-    pattern ActiveSlot,
   )
 import qualified Shelley.Spec.Ledger.MetaData as MD
 import Shelley.Spec.Ledger.OCert (KESPeriod (..), OCertSignable (..), pattern OCert)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -127,6 +127,7 @@ import Shelley.Spec.Ledger.LedgerState
     EpochState (..),
     NewEpochState (..),
     RewardUpdate (..),
+    decompactOverlaySchedule,
     emptyLedgerState,
     pattern ActiveSlot,
   )
@@ -1286,8 +1287,8 @@ tests =
             ) ::
               StrictMaybe (RewardUpdate C)
           pd = (PoolDistr Map.empty) :: PoolDistr C
-          os = Map.singleton (SlotNo 1) (ActiveSlot (testGKeyHash p))
           compactOs = Map.singleton (ActiveSlot (testGKeyHash p)) (SlotNo 1 :| [])
+          os = decompactOverlaySchedule compactOs
           nes =
             NewEpochState
               e

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -58,6 +58,7 @@ import Shelley.Spec.Ledger.LedgerState
     emptyPPUPState,
     emptyPState,
     overlaySchedule,
+    overlayScheduleIsEmpty,
     _dstate,
     _rewards,
   )
@@ -164,7 +165,7 @@ testOverlayScheduleZero =
             (EpochNo 0)
             mempty
             (emptyPParams {_d = unsafeMkUnitInterval 0})
-   in os @?= Map.empty
+   in assertBool "Overlay schedule is not empty" (overlayScheduleIsEmpty os)
 
 testNoGenesisOverlay :: Assertion
 testNoGenesisOverlay =
@@ -174,7 +175,7 @@ testNoGenesisOverlay =
             (EpochNo 0)
             mempty
             (emptyPParams {_d = unsafeMkUnitInterval 0.5})
-   in os @?= Map.empty
+   in assertBool "Overlay schedule is not empty" (overlayScheduleIsEmpty os)
 
 testVRFCheckWithActiveSlotCoeffOne :: Assertion
 testVRFCheckWithActiveSlotCoeffOne =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -49,6 +49,7 @@ import Shelley.Spec.Ledger.Keys
     hashVerKeyVRF,
     vKey,
   )
+import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     DPState (..),
@@ -57,8 +58,6 @@ import Shelley.Spec.Ledger.LedgerState
     emptyDState,
     emptyPPUPState,
     emptyPState,
-    overlaySchedule,
-    overlayScheduleIsEmpty,
     _dstate,
     _rewards,
   )


### PR DESCRIPTION
This will allow us to replace its implementation/representation by something
more compact and efficient.

On mainnet, the epoch size is 432,000, which means we're creating a map of
nearly half a million of entries just to implement a spaced round-robin scheme.

When writing ledger snapshots, we're also writing this map, albeit in a slightly
more compact representation (see `compactOverlaySchedule`), to disk.

Note that the size of this map will shrink when `d` goes down.

It should be enough to keep the arguments passed to `overlayScheduleHelper` in
memory and implement the current API of `OverlaySchedule` as a function instead
of a mapping. Similarly for serialising an `OverlaySchedule`, just de/serialise
these arguments.

To test this approach, the function-based implementation can be compared against
the current map-based implementation (e.g., by implementing
`overlayScheduleToMap`).