### PR TITLE
Change the script hash algorithm to address hash

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -167,8 +167,8 @@ hashMultiSigScript ::
   ScriptHash crypto
 hashMultiSigScript =
   ScriptHash
-  . Hash.castHash
-  . Hash.hashWith (\x -> nativeMultiSigTag <> serialize' x)
+    . Hash.castHash
+    . Hash.hashWith (\x -> nativeMultiSigTag <> serialize' x)
 
 hashAnyScript ::
   Crypto crypto =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -135,7 +135,7 @@ pattern RequireMOf n ms <-
 {-# COMPLETE RequireSignature, RequireAllOf, RequireAnyOf, RequireMOf #-}
 
 newtype ScriptHash crypto
-  = ScriptHash (Hash.Hash (HASH crypto) (Script crypto))
+  = ScriptHash (Hash.Hash (ADDRHASH crypto) (Script crypto))
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NFData, NoUnexpectedThunks)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
@@ -7,7 +7,7 @@
 module Test.Shelley.Spec.Ledger.Serialisation.Generators.Genesis where
 
 import Cardano.Crypto.DSIGN.Class
-import Cardano.Crypto.Hash hiding (Hash)
+import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
 import Cardano.Crypto.VRF.Class
 import Cardano.Prelude (Natural, Word32, Word64, Word8)
@@ -143,14 +143,14 @@ genUrl = do
 genRewardAcnt :: Crypto c => Gen (RewardAcnt c)
 genRewardAcnt = RewardAcnt Testnet <$> genCredential
 
-genCredential :: forall c. Crypto c => Gen (Credential 'Staking c)
+genCredential :: Crypto c => Gen (Credential 'Staking c)
 genCredential =
   Gen.choice
-    [ ScriptHashObj . ScriptHash <$> genHash @c,
+    [ ScriptHashObj . ScriptHash <$> genHash,
       KeyHashObj <$> genKeyHash
     ]
 
-genHash :: forall c a. HashAlgorithm (HASH c) => Gen (Hash c a)
+genHash :: Hash.HashAlgorithm v => Gen (Hash.Hash v a)
 genHash = mkHash <$> Gen.int (Range.linear 0 1000)
 
 genWords :: Natural -> Gen [Word8]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -102,7 +102,7 @@ import Test.Shelley.Spec.Ledger.Utils
 --
 _assertScriptHashSizeMatchesAddrHashSize :: ScriptHash c -> KeyHash r c
 _assertScriptHashSizeMatchesAddrHashSize (ScriptHash h) =
-    KeyHash (Hash.castHash h)
+  KeyHash (Hash.castHash h)
 
 -- Multi-signature scripts
 singleKeyOnly :: Crypto c => Addr c -> MultiSig c

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -17,6 +17,7 @@ module Test.Shelley.Spec.Ledger.MultiSigExamples
   )
 where
 
+import qualified Cardano.Crypto.Hash as Hash
 import Control.State.Transition.Extended (PredicateFailure, TRC (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList)
@@ -46,6 +47,7 @@ import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Hashing (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( GenDelegs (..),
+    KeyHash (..),
     KeyPair,
     KeyRole (..),
     asWitness,
@@ -64,6 +66,7 @@ import Shelley.Spec.Ledger.Scripts
     pattern RequireAnyOf,
     pattern RequireMOf,
     pattern RequireSignature,
+    pattern ScriptHash,
   )
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx
@@ -90,6 +93,16 @@ import Test.Shelley.Spec.Ledger.Generator.Core
 import Test.Shelley.Spec.Ledger.Utils
 
 -- Multi-Signature tests
+
+-- This compile-time test asserts that the script hash and key hash use the
+-- same hash size and indeed hash function. We do this by checking we can
+-- type-check the following code that converts between them by using the hash
+-- casting function which changes what the hash is of, without changing the
+-- hashing algorithm.
+--
+_assertScriptHashSizeMatchesAddrHashSize :: ScriptHash c -> KeyHash r c
+_assertScriptHashSizeMatchesAddrHashSize (ScriptHash h) =
+    KeyHash (Hash.castHash h)
 
 -- Multi-signature scripts
 singleKeyOnly :: Crypto c => Addr c -> MultiSig c


### PR DESCRIPTION
Use the address hash algorithm rather than the normal hash algorithm,
to match the hash algorithm used in addresses for keys.