### PR TITLE
Add nix build for Shelley multi-currency formal specification

### DIFF
--- a/byron/cddl-spec/default.nix
+++ b/byron/cddl-spec/default.nix
@@ -1,36 +1,35 @@
-{ pkgs ? (import  ../../nix/default.nix  {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal, cddl, cbor-diag }:
 
-with pkgs;
-
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
-                    inherit (texlive)
-                      scheme-small
-
-                      # Fonts
-                      cm-super
-
-                      # libraries
-                      unicode-math lm-math amsmath
-                      enumitem bclogo xcolor newunicodechar
-                      appendix syntax
-
-                      # build tools
-                      latexmk
-                      ;
-                  })
-                  # CBOR scheme specification related tools
-                  cddl
-                  cbor-diag
-                ];
-  src = ./.;
-  buildPhase = "make";
-
+latex.buildLatex {
+  name = "blocks-cddl-spec";
+  texFiles = [ "binary" ];
   meta = with lib; {
     description = "Byron blocks CDDL specification";
-    license = licenses.bsd3;
+    license = licenses.asl20;
     platforms = platforms.linux;
   };
+  src = ./.;
+
+  texInputs = {
+    inherit (texlive)
+      scheme-small
+
+      # Fonts
+      cm-super
+
+      # libraries
+      unicode-math lm-math amsmath
+      enumitem bclogo xcolor newunicodechar
+      appendix syntax
+
+      # build tools
+      latexmk
+      ;
+  };
+  buildInputs = [
+    gitMinimal
+    # CBOR scheme specification related tools
+    cddl
+    cbor-diag
+  ];
 }

--- a/byron/chain/formal-spec/default.nix
+++ b/byron/chain/formal-spec/default.nix
@@ -1,11 +1,16 @@
-{ pkgs ? (import ../../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "byron-chain-spec";
+  texFiles = [ "blockchain-spec" ];
+  meta = with lib; {
+    description = "Byron Blockchain Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
+  texInputs = {
                     inherit (texlive)
                       scheme-small
 
@@ -26,14 +31,6 @@ stdenv.mkDerivation {
                       latexmk
 
                       ;
-                  })
-                ];
-  src = ./.;
-  buildPhase = "make";
-
-  meta = with lib; {
-    description = "Byron Blockchain Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }

--- a/byron/ledger/formal-spec/default.nix
+++ b/byron/ledger/formal-spec/default.nix
@@ -1,11 +1,16 @@
-{ pkgs ? (import  ../../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "byron-ledger-spec";
+  texFiles = [ "ledger-spec" ];
+  meta = with lib; {
+    description = "Byron Ledger Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
+  texInputs = {
                     inherit (texlive)
                       scheme-small
 
@@ -28,15 +33,6 @@ stdenv.mkDerivation {
                       # Referencing
                       zref
                       ;
-                  })
-
-                ];
-  src = ./.;
-  buildPhase = "make";
-
-  meta = with lib; {
-    description = "Byron Ledger Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }

--- a/default.nix
+++ b/default.nix
@@ -13,8 +13,8 @@
 , gitrev ? pkgs.iohkNix.commitIdFromGitRepoOrZero ./.git
 }:
 with pkgs; with commonLib;
-let
 
+let
   haskellPackages = recRecurseIntoAttrs
     # we are only interested in listing the project packages:
     (selectProjectPackages cardanoLedgerSpecsHaskellPackages);
@@ -41,14 +41,29 @@ let
       withHoogle = true;
     };
 
+    #
+    # PDF builds of LaTeX documentation.
+    #
+    # To download the latest PDF build from Hydra, use this link:
+    #   https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.NAME/latest/download/1/NAME.pdf
+    #
+    # To get a shell where you can run pdflatex to build it yourself, use:
+    #   nix-shell default.nix -A specs.NAME
+    #
+    # To build all specs locally with Nix:
+    #  nix-build -A specs -o spec
+    #
+    specs = recurseIntoAttrs {
+      byron-ledger = pkgs.callPackage ./byron/ledger/formal-spec {};
+      byron-chain = pkgs.callPackage ./byron/chain/formal-spec {};
+      small-step-semantics = pkgs.callPackage ./semantics/formal-spec {};
+      shelley-ledger = pkgs.callPackage ./shelley/chain-and-ledger/formal-spec {};
+      shelley-mc = pkgs.callPackage ./shelley-mc/formal-spec {};
+      delegation-design = pkgs.callPackage ./shelley/design-spec {};
+      non-integer-calculations = pkgs.callPackage ./shelley/chain-and-ledger/dependencies/non-integer/doc {};
+      blocks-cddl = pkgs.callPackage ./byron/cddl-spec {};
+    };
+  };
 
-    # Attributes of PDF builds of LaTeX documentation.
-    byronLedgerSpec = import ./byron/ledger/formal-spec { inherit pkgs; };
-    byronChainSpec = import ./byron/chain/formal-spec { inherit pkgs; };
-    semanticsSpec = import ./semantics/formal-spec { inherit pkgs; };
-    shelleyLedgerSpec = import ./shelley/chain-and-ledger/formal-spec { inherit pkgs; };
-    delegationDesignSpec = import ./shelley/design-spec { inherit pkgs; };
-    nonIntegerCalculations = import ./shelley/chain-and-ledger/dependencies/non-integer/doc {inherit pkgs; };
-    blocksCDDLSpec = import ./byron/cddl-spec {inherit pkgs; };
-};
-in self
+in
+  self

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,6 +36,9 @@ let
           // import ./util.nix { inherit haskell-nix; }
           # also expose our sources and overlays
           // { inherit overlays sources; };
+
+        # Functions for building LaTeX documents.
+        latex = import ./latex.nix { inherit (pkgs) stdenv lib texlive; };
       })
       # And, of course, our haskell-nix-ified cabal project:
       (import ./pkgs.nix)

--- a/nix/latex.nix
+++ b/nix/latex.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, texlive }:
+{
+  # Build a latex derivation using latexmk.
+  buildLatex = {
+    texFiles ? [], # The specific tex files to build, will try and build all of them if absent
+    texInputs ? { inherit (texlive) scheme-small; }, # Tex dependencies as an attrset
+    buildInputs ? [], # Additional build inputs
+    ...}@attrs :
+
+    let
+      tex = texlive.combine (texInputs // { inherit (texlive) latexmk; });
+      # mkDerivation doesn't like having this as an attr, and we don't need to pass it through
+      filteredAttrs = builtins.removeAttrs attrs ["texInputs" ];
+      buildDir = ".nix-build";
+    in
+    stdenv.mkDerivation (filteredAttrs // {
+      buildInputs = [ tex ] ++ buildInputs;
+      buildPhase = ''
+        runHook preBuild
+        mkdir -p ${buildDir}
+        latexmk -outdir=${buildDir} -pdf ${toString texFiles}
+        runHook postBuild
+      '';
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out
+        install -t $out ${buildDir}/*.pdf
+
+        mkdir -p $out/nix-support
+        for pdf in $out/*.pdf; do
+          echo "doc-pdf $(basename $pdf .pdf) $pdf" >> $out/nix-support/hydra-build-products
+        done
+        runHook postInstall
+      '';
+    });
+  # A typical good filter for latex sources.
+  filterLatex = src: lib.sourceFilesBySuffices src [
+     ".tex" ".bib" ".bst"
+     ".cls" ".sty"
+     ".jpg" ".png"
+     ".pdf"
+     ".pfb" ".enc"
+     "TODO"
+  ];
+}

--- a/release.nix
+++ b/release.nix
@@ -58,25 +58,20 @@ let
   } // (mkRequiredJob (
       collectTests jobs.native.checks.tests ++
       collectTests jobs.native.benchmarks ++
-      [ jobs.native.byronLedgerSpec.x86_64-linux
-        jobs.native.byronChainSpec.x86_64-linux
-        jobs.native.semanticsSpec.x86_64-linux
-        jobs.native.shelleyLedgerSpec.x86_64-linux
-        jobs.native.delegationDesignSpec.x86_64-linux
-        jobs.native.nonIntegerCalculations.x86_64-linux
-        jobs.native.blocksCDDLSpec.x86_64-linux
-      ]
+      mapAttrsToList (_: spec: spec.x86_64-linux or null) jobs.native.specs
     ))
 
-  # Collect all spec PDFs, without system suffix
-  // { inherit (project)
-         byronLedgerSpec
-         byronChainSpec
-         semanticsSpec
-         shelleyLedgerSpec
-         delegationDesignSpec
-         nonIntegerCalculations
-         blocksCDDLSpec
-       ; };
+  // {
+    # Collect all spec PDFs, without system suffix.
+    specs = removeAttrs project.specs ["recurseForDerivations"];
+    # Compatibility with old names
+    byronLedgerSpec = project.specs.byron-ledger;
+    byronChainSpec = project.specs.byron-chain;
+    semanticsSpec = project.specs.small-step-semantics;
+    shelleyLedgerSpec = project.specs.shelley-ledger;
+    delegationDesignSpec = project.specs.delegation-design;
+    nonIntegerCalculations = project.specs.non-integer-calculations;
+    blocksCDDLSpec = project.specs.blocks-cddl;
+  };
 
 in jobs

--- a/semantics/formal-spec/default.nix
+++ b/semantics/formal-spec/default.nix
@@ -1,11 +1,16 @@
-{ pkgs ? (import ../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "small-step-semantics-spec";
+  texFiles = [ "small-step-semantics" ];
+  meta = with lib; {
+    description = "Small Step Semantics Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
+  texInputs = {
                     inherit (texlive)
                       scheme-small
 
@@ -27,14 +32,7 @@ stdenv.mkDerivation {
                       # Referencing
                       zref
                       ;
-                  })
-                ];
-  src = ./.;
-  buildPhase = "make";
 
-  meta = with lib; {
-    description = "Small Steps Semantics Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }

--- a/shelley-mc/formal-spec/default.nix
+++ b/shelley-mc/formal-spec/default.nix
@@ -1,0 +1,22 @@
+{ lib, latex, texlive }:
+
+latex.buildLatex {
+  name = "shelley-mc-spec";
+  texFiles = [ "multi-asset" ];
+  meta = with lib; {
+    description = "Shelley multi-currency specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
+
+  texInputs = {
+    inherit (texlive)
+      scheme-small
+      collection-latexextra
+      collection-latexrecommended
+      collection-mathscience
+      bclogo
+      ;
+  };
+}

--- a/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
+++ b/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
@@ -1,11 +1,16 @@
-{ pkgs ? (import  ../../../../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "non-integer-calculations-spec";
+  texFiles = [ "non-integer-calculations" ];
+  meta = with lib; {
+    description = "Non-integer Calculations Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
+  texInputs = {
                     inherit (texlive)
                       scheme-small
 
@@ -29,14 +34,6 @@ stdenv.mkDerivation {
                       zref
 
                       ;
-                  })
-                ];
-  src = ./.;
-  buildPhase = "make";
-
-  meta = with lib; {
-    description = "Non-integer Calculations Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }

--- a/shelley/chain-and-ledger/formal-spec/default.nix
+++ b/shelley/chain-and-ledger/formal-spec/default.nix
@@ -1,11 +1,16 @@
-{ pkgs ? (import  ../../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "shelley-ledger-spec";
+  texFiles = [ "ledger-spec" ];
+  meta = with lib; {
+    description = "Shelley Ledger Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
+  texInputs = {
                     inherit (texlive)
                       scheme-small
 
@@ -31,15 +36,7 @@ stdenv.mkDerivation {
                       zref
 
                       ;
-                  })
-                  gitMinimal
-                ];
-  src = ./.;
-  buildPhase = "make";
 
-  meta = with lib; {
-    description = "Shelley Ledger Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }

--- a/shelley/design-spec/default.nix
+++ b/shelley/design-spec/default.nix
@@ -1,12 +1,17 @@
-{ pkgs ? (import  ../../nix/default.nix {}).pkgs
-}:
+{ lib, latex, texlive, gitMinimal }:
 
-with pkgs;
+latex.buildLatex {
+  name = "delegation-design-spec";
+  texFiles = [ "delegation_design_spec" ];
+  meta = with lib; {
+    description = "Delegation Design Specification";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+  src = latex.filterLatex ./.;
 
-stdenv.mkDerivation {
-  name = "docsEnv";
-  buildInputs = [ (texlive.combine {
-                    inherit (texlive)
+  texInputs = {
+    inherit (texlive)
                       scheme-small
 
                       # fonts
@@ -32,15 +37,7 @@ stdenv.mkDerivation {
                       # Referencing
                       zref
                       ;
-                  })
-                  gitMinimal
-                ];
-  src = ./.;
-  buildPhase = "make";
 
-  meta = with lib; {
-    description = "Delegation Design Specification";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
   };
+  buildInputs = [ gitMinimal ];
 }


### PR DESCRIPTION
### Overview

- Add nix build for Shelley multi-currency formal specification - so that it can be built easily, or downloaded from Hydra.
- adds the buildLatex function from the Plutus repo.
- reduce duplication in existing builds.
- organise specs under the specs attrset.
- provide backwards-compatible attr names so that existing Hydra links are not broken.
- fix nix store filenames of specs.
- provide information on hydra links and building locally.


### Comments
- [PDF](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs-pr-1758/specs.shelley-mc/latest/download/1/multi-asset.pdf)
- [Hydra jobset PR #1758](https://hydra.iohk.io/jobset/Cardano/cardano-ledger-specs-pr-1758#tabs-jobs)
- [Hydra jobset master branch](https://hydra.iohk.io/jobset/Cardano/cardano-ledger-specs#tabs-jobs)
