### PR TITLE
Be less strict in STS rules.

### DIFF
--- a/semantics/executable-spec/src/Control/State/Transition/Extended.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Extended.hs
@@ -15,7 +15,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}


### PR DESCRIPTION
This has relatively minimal effect on application. But a massive effect
on reapplication - we get an order of magnitude speed-up.