### PR TITLE
Fix link to CDDL spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ following links:
 
 - [Shelley design specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec): the primary design document for Cardano Shelley.
 - [Shelley ledger formal specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec): the formal mathematical specification of the Shelley era ledger rules.
-- [Shelley binary format specification (CDDL)](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/executable-spec/cddl-files): the binary formats for the Shelley ledger using CBOR CDDL schema notation.
+- [Shelley binary format specification (CDDL)](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files/): the binary formats for the Shelley ledger using CBOR CDDL schema notation.
 - [Non-integer calculations specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/nonIntegerCalculations/latest/download-by-type/doc-pdf/non-integer-calculations): details on the parts of the Shelley specification that use real numbers.
 - [Byron chain specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronChainSpec/latest/download-by-type/doc-pdf/blockchain-spec): the formal mathematical specification of the Byron era chain-level rules.
 - [Byron ledger specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec): the formal mathematical specification of the Byron era ledger rules.


### PR DESCRIPTION
I noticed the path to the CDDL file changed again. I'm not sure if this is the correct path to point to, so please correct me if I'm wrong.