### PR TITLE
Addressing recent audit issues

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -181,6 +181,7 @@ import Shelley.Spec.Ledger.Serialization (decodeRecordNamed, mapFromCBOR, mapToC
 import Shelley.Spec.Ledger.Slot
   ( Duration (..),
     EpochNo (..),
+    EpochSize,
     SlotNo (..),
     epochInfoFirst,
     epochInfoSize,
@@ -981,14 +982,12 @@ updateNonMypopic nm rPot newLikelihoods ss =
 
 -- | Create a reward update
 createRUpd ::
-  EpochNo ->
+  EpochSize ->
   BlocksMade crypto ->
   EpochState crypto ->
   Coin ->
   ShelleyBase (RewardUpdate crypto)
-createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
-  ei <- asks epochInfo
-  slotsPerEpoch <- epochInfoSize ei e
+createRUpd slotsPerEpoch b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
   asc <- asks activeSlotCoeff
   let SnapShot stake' delegs' poolParams = _pstakeGo ss
       Coin reserves = _reserves acnt

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -246,16 +246,16 @@ delegationTransition = do
       -- gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG gkh
       (case Map.lookup gkh genDelegs of Just _ -> True; Nothing -> False) ?! GenesisKeyNotInpMappingDELEG gkh
 
-      let currentOtherDelegations =
+      let cod =
             range $
-              Map.filterWithKey (\k _ -> k /= gkh) genDelegs
-          futureOtherDelegations =
+              Map.filterWithKey (\g _ -> g /= gkh) genDelegs
+          fod =
             range $
-              Map.filterWithKey (\(FutureGenDeleg _ k) _ -> k /= gkh) (_fGenDelegs ds)
-          currentOtherColdKeyHashes = Set.map genDelegKeyHash currentOtherDelegations
-          futureOtherColdKeyHashes = Set.map genDelegKeyHash futureOtherDelegations
-          currentOtherVrfKeyHashes = Set.map genDelegVrfHash currentOtherDelegations
-          futureOtherVrfKeyHashes = Set.map genDelegVrfHash futureOtherDelegations
+              Map.filterWithKey (\(FutureGenDeleg _ g) _ -> g /= gkh) (_fGenDelegs ds)
+          currentOtherColdKeyHashes = Set.map genDelegKeyHash cod
+          currentOtherVrfKeyHashes = Set.map genDelegVrfHash cod
+          futureOtherColdKeyHashes = Set.map genDelegKeyHash fod
+          futureOtherVrfKeyHashes = Set.map genDelegVrfHash fod
 
       eval (vkh ∉ (currentOtherColdKeyHashes `Set.union` futureOtherColdKeyHashes))
         ?! DuplicateGenesisDelegateDELEG vkh

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -125,7 +125,7 @@ delegsTransition ::
   Crypto crypto =>
   TransitionRule (DELEGS crypto)
 delegsTransition = do
-  TRC (env@(DelegsEnv slot txIx pp tx reserves), dpstate, certificates) <- judgmentContext
+  TRC (env@(DelegsEnv slot txIx pp tx acnt), dpstate, certificates) <- judgmentContext
   network <- liftSTS $ asks networkId
 
   case certificates of
@@ -156,7 +156,7 @@ delegsTransition = do
 
       let ptr = Ptr slot txIx (fromIntegral $ length gamma)
       trans @(DELPL crypto) $
-        TRC (DelplEnv slot ptr pp reserves, dpstate', c)
+        TRC (DelplEnv slot ptr pp acnt, dpstate', c)
 
 instance
   Crypto crypto =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -92,31 +92,31 @@ mirTransition = do
       ) <-
     judgmentContext
   let dpState = _delegationState ls
-      dState = _dstate dpState
-      rewards = _rewards dState
-      irwdR = eval $ (dom rewards) ◁ (iRReserves $ _irwd dState) :: RewardAccounts crypto
-      totFromReserves = sum irwdR
+      ds = _dstate dpState
+      rewards = _rewards ds
       reserves = _reserves acnt
-      irwdT = eval $ (dom rewards) ◁ (iRTreasury $ _irwd dState) :: RewardAccounts crypto
-      totFromTreasury = sum irwdT
       treasury = _treasury acnt
+      irwdR = eval $ (dom rewards) ◁ (iRReserves $ _irwd ds) :: RewardAccounts crypto
+      irwdT = eval $ (dom rewards) ◁ (iRTreasury $ _irwd ds) :: RewardAccounts crypto
+      totR = sum irwdR
+      totT = sum irwdT
       update = (eval (irwdR ∪+ irwdT)) :: RewardAccounts crypto
 
-  if totFromReserves <= reserves && totFromTreasury <= treasury
+  if totR <= reserves && totT <= treasury
     then
       pure $
         EpochState
           acnt
-            { _reserves = reserves - totFromReserves,
-              _treasury = treasury - totFromTreasury
+            { _reserves = reserves - totR,
+              _treasury = treasury - totT
             }
           ss
           ls
             { _delegationState =
                 dpState
                   { _dstate =
-                      dState
-                        { _rewards = eval ((_rewards dState) ∪+ update),
+                      ds
+                        { _rewards = eval ((_rewards ds) ∪+ update),
                           _irwd = emptyInstantaneousRewards
                         }
                   }
@@ -133,7 +133,7 @@ mirTransition = do
             { _delegationState =
                 dpState
                   { _dstate =
-                      dState {_irwd = emptyInstantaneousRewards}
+                      ds {_irwd = emptyInstantaneousRewards}
                   }
             }
           pr

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -110,13 +110,13 @@ bheadTransition = do
     trans @(NEWEPOCH crypto) $
       TRC (NewEpochEnv slot gkeys, nes, epoch)
 
-  ru' <- trans @(RUPD crypto) $ TRC (RupdEnv bprev es, nesRu nes', slot)
+  ru'' <- trans @(RUPD crypto) $ TRC (RupdEnv bprev es, nesRu nes', slot)
 
-  let es' = adoptGenesisDelegs (nesEs nes') slot
+  let es'' = adoptGenesisDelegs (nesEs nes') slot
       nes'' =
         nes'
-          { nesRu = ru',
-            nesEs = es'
+          { nesRu = ru'',
+            nesEs = es''
           }
   pure nes''
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -243,36 +243,11 @@ It has no environment or signal, and the state is $\EpochState$.
     \vdash \var{\_} \trans{mir}{} \var{\_} \subseteq
     \powerset (\EpochState \times \EpochState)
   \end{equation*}
-  %
-  \emph{Helper function}
-  \begin{align*}
-      & \fun{mirUpdates} \in \InstantaneousRewards \to (\StakeCredential\mapsto\Coin) \to \\
-      & ~~~(\AddrRWD \mapsto \Coin)\times(\AddrRWD \mapsto \Coin)
-      \\
-      & \fun{mirUpdates}~(\var{irReserves},~\var{irTreasury})~\var{rewards} =
-      (\var{updateR},~\var{updateT})\\
-      & ~~~~\where \\
-      & ~~~~~~~~~\var{updateR} =
-        \left\{
-        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
-        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irReserves}
-        \right\}
-        \\
-      & ~~~~~~~~~\var{updateT} =
-        \left\{
-        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
-        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irTreasury}
-        \right\}
-        \\
-  \end{align*}
   \caption{MIR transition-system types}
   \label{fig:ts-types:mir}
 \end{figure}
 
 Figure~\ref{fig:rules:mir} defines the MIR state transition.
-The transition uses the function $\fun{mirUpdates}$ to restrict
-the two instantaneous rewards mappings to the registered stake keys,
-and transforms the keys of the mappiing to reward accouts.
 
 If the reserve and treasury pots are large enough to cover the sum
 of the corresponding instantaneous rewards,
@@ -291,20 +266,29 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
       \\
       (\var{treasury},~\var{reserves})\leteq\var{acnt}
       &
-      (\var{updateR},~\var{updateT})\leteq\fun{mirUpdates}~\var{i_{rwd}}~\var{rewards}
+      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
+      \\~\\
+      \var{irwdR}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irReserves}
+        \right\}
       \\
-      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateR}}v
+      \var{irwdT}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irTreasury}
+        \right\}
+      \\~\\
+      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdR}}v
       &
-      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateT}}v
+      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdT}}v
       \\
       \var{totR}\leq\var{reserves}
       &
       \var{totT}\leq\var{treasury}
       \\~\\
-      \var{acnt'}\leteq
-        (\varUpdate{\var{treasury}-\var{totT}},~\varUpdate{\var{reserves}-\var{totR}})
-      \\
-      \var{rewards'}\leteq\var{rewards}\unionoverridePlus\var{updateR}\unionoverridePlus\var{updateT}
+      \var{rewards'}\leteq\var{rewards}\unionoverridePlus\var{irwdR}\unionoverridePlus\var{irwdT}
       \\
       \var{ds'} \leteq
       (\varUpdate{\var{rewards}'},~\var{delegations},~
@@ -322,7 +306,7 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
       \end{array}\right)}
       \trans{mir}{}
       {\left(\begin{array}{c}
-            \varUpdate{\var{acnt'}} \\
+            \varUpdate{(\varUpdate{\var{treasury}-\var{totT}},~\varUpdate{\var{reserves}-\var{totR}})} \\
             \var{ss} \\
             (\var{us},~(\varUpdate{\var{ds'}},~\var{ps})) \\
             \var{prevPP} \\
@@ -342,11 +326,23 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
       \\
       (\var{treasury},~\var{reserves})\leteq\var{acnt}
       &
-      (\var{updateR},~\var{updateT})\leteq\fun{mirUpdates}~\var{i_{rwd}}~\var{rewards}
+      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
+      \\~\\
+      \var{irwdR}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irReserves}
+        \right\}
       \\
-      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateR}}v
+      \var{irwdT}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irTreasury}
+        \right\}
+      \\~\\
+      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdR}}v
       &
-      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{updateT}}v
+      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdT}}v
       \\
       \var{totR}>\var{reserves}~\lor~\var{totT}>\var{treasury}
       \\~\\
@@ -403,7 +399,7 @@ of
 
 Figure~\ref{fig:ts-types:newepoch} also defines an abstract pseudorandom function
 $\fun{overlaySchedule}$ for creating the OBFT overlay schedule for each new epoch,
-as explained in section 3.9.2 of~\cite{delegation_design}.
+as explained in section 3.8.2 of~\cite{delegation_design}.
 The function takes a set of genesis keys, a seed, and the protocol parameters
 (of which the decentralization parameter $d$ and the active slot coeffient $f$ are used).
 It must create $(d\cdot\SlotsPerEpoch)$-many OBFT slots, $(f\cdot d\cdot \SlotsPerEpoch)$
@@ -458,6 +454,30 @@ of which are active.
     \_ \vdash \var{\_} \trans{newepoch}{\_} \var{\_} \subseteq
     \powerset (\NewEpochEnv \times \NewEpochState \times \Epoch \times \NewEpochState)
   \end{equation*}
+  %
+  \emph{Helper function}
+  \begin{align*}
+      & \fun{calculatePoolDistr} \in \Snapshot \to \PoolDistr \\
+      & \fun{calculatePoolDistr}~(\var{stake},~\var{delegs},~\var{poolParams}) = \\
+      & ~~~\left\{\var{hk_p}\mapsto(\sigma,~\fun{poolVRF}~\var{p})
+            ~\Big\vert~
+            {
+              \begin{array}{r@{~\in~}l}
+                \var{hk_p}\mapsto\sigma & \var{sd} \\
+                \var{hk_p}\mapsto\var{p} & \var{poolParams}
+              \end{array}
+            }
+            \right\}\\
+      & ~~~~\where \\
+      & ~~~~~~~~~\var{total} = \sum_{\_ \mapsto c\in\var{stake}} c \\
+      & ~~~~~~~~~\var{sd} = \fun{aggregate_{+}}~\left(\var{delegs}^{-1}\circ
+                     \left\{\left(
+                       \var{hk}, \frac{\var{c}}{\var{total}}
+                     \right) \vert (\var{hk},
+                     \var{c}) \in \var{stake}
+                     \right\}\right) \\
+  \end{align*}
+
   \caption{NewEpoch transition-system types}
   \label{fig:ts-types:newepoch}
 \end{figure}
@@ -518,26 +538,10 @@ In the first case, the new epoch state is updated as follows:
       }
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
-          (\var{acnt},~\var{ss},~\wcard,~\wcard,~\var{pp}) & \var{es'''} \\
+         (\var{acnt},~\var{ss},~\wcard,~\wcard,~\var{pp}) & \var{es'''} \\
          (\wcard,~\var{pstake_{set}},~\wcard,~\wcard) & \var{ss} \\
-         (\var{stake},~\var{delegs},~\var{poolPrms}) & \var{pstake_{set}} \\
-         total & \sum_{\_ \mapsto c\in\var{stake}} c \\
-          \var{sd} & \fun{aggregate_{+}}~\left(\var{delegs}^{-1}\circ
-                     \left\{
-                     (\var{hk}, \frac{\var{c}}{\var{total}}) \vert (\var{hk},
-                     \var{c}) \in \var{stake}
-                 \right\}\right) \\
-          \var{pd'} &
-            \left\{\var{hk_p}\mapsto(\sigma,~\fun{poolVRF}~\var{p})
-            ~\Big\vert~
-            {
-              \begin{array}{r@{~\in~}l}
-                \var{hk_p}\mapsto\sigma & \var{sd} \\
-                \var{hk_p}\mapsto\var{p} & \var{poolPrms}
-              \end{array}
-            }
-            \right\}\\
-          \var{osched'} & \overlaySchedule{e}{gkeys}{pp} \\
+         \var{pd'} & \fun{calculatePoolDistr}~\var{pstake_{set}} \\
+         \var{osched'} & \overlaySchedule{e}{gkeys}{pp} \\
        \end{array}}
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -871,7 +871,7 @@ execution of the transition role is as follows:
       &
       ru = \Nothing
       \\~\\
-      ru' \leteq \createRUpd{b}{es}{\MaxLovelaceSupply}
+      ru' \leteq \createRUpd{\SlotsPerEpoch}{b}{es}{\MaxLovelaceSupply}
     }
     {
       {\begin{array}{c}
@@ -1012,12 +1012,12 @@ Three transitions are done:
     {
       {
         {\begin{array}{c}
-           \var{s} \\
+           \var{slot} \\
            \var{gkeys} \\
          \end{array}}
         \vdash
         \var{nes}
-        \trans{\hyperref[fig:rules:new-epoch]{newepoch}}{\epoch{s}}
+        \trans{\hyperref[fig:rules:new-epoch]{newepoch}}{\epoch{slot}}
         \var{nes}'
       }
       \\~\\
@@ -1028,13 +1028,13 @@ Three transitions are done:
            \var{b_{prev}} \\
            \var{es} \\
          \end{array}}
-        \vdash \var{ru'}\trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{s}} \var{ru''}
+        \vdash \var{ru'}\trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{slot}} \var{ru''}
       }
       \\~\\
       (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru'},~\var{pd'},\var{osched'})
       \leteq\var{nes'}
       \\
-      \var{es''}\leteq\fun{adoptGenesisDelegs}~\var{es'}~\var{s}
+      \var{es''}\leteq\fun{adoptGenesisDelegs}~\var{es'}~\var{slot}
       \\
       \var{nes''}\leteq
       (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es''},~\var{ru''},~\var{pd'},\var{osched'})
@@ -1044,7 +1044,7 @@ Three transitions are done:
       {\begin{array}{c}
          \var{gkeys} \\
        \end{array}}
-      \vdash\var{nes}\trans{tick}{\var{s}}\varUpdate{\var{nes''}}
+      \vdash\var{nes}\trans{tick}{\var{slot}}\varUpdate{\var{nes''}}
     }
   \end{equation}
   \caption{Tick rules}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -433,7 +433,7 @@ concerns are independent of the ledger rules.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \varUpdate{\var{rewards}} & \varUpdate{\unionoverrideLeft} & \varUpdate{\{\var{hk} \mapsto 0\}}\\
+        \varUpdate{\var{rewards}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto 0\}}\\
         \var{delegations} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}} \\
         \var{fGenDelegs} \\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -106,7 +106,6 @@ It does the following:
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \var{url} & \URL & \text{a url}\\
-      \var{pmd} & \PoolMD & \text{pool metadata}\\
       \var{mp} & \MIRPot & \text{either $\ReservesMIR$ or $\TreasuryMIR$}\\
     \end{array}
   \end{equation*}
@@ -530,16 +529,23 @@ concerns are independent of the ledger rules.
       & \var{gkh}\in\dom{genDelegs}
       \\~\\
       {
-        \begin{array}{ l @{~\leteq~\{} c @{~\mid~} r @{\mapsto} l @{,~\var{g}\neq\var{gkh}\}} }
-          \var{currentOtherColdKeyHashes} & \var{k}  & \var{g} & (\var{k},~\wcard) \\
-          \var{currentOtherVrfKeyHashes}  & \var{v} & \var{g} & (\wcard,~\var{v}) \\
-          \var{futureOtherColdKeyHashes}  & \var{k}  & (\var{g},~\wcard) & (\var{k},~\wcard) \\
-          \var{futureOtherVrfKeyHashe}    & \var{v} & (\var{g},~\wcard) & (\wcard,~\var{v}) \\
+        \begin{array}{ l @{\leteq \{(k,~v) ~\mid~(} c @{\mapsto(k,~v))\in~} l @{,~\var{g}\neq\var{gkh}\}} }
+          \var{cod} & \var{g} & \var{genDelegs} \\
+          \var{fod} & (\wcard,~\var{g}) & \var{fGenDelegs}
+        \end{array}
+      }
+      \\~\\
+      {
+        \begin{array}{ l @{~\leteq~\{} c @{~\mid~\wcard\mapsto} c @{\in~} l @{\}}}
+          \var{currentOtherColdKeyHashes} & \var{k} & (\var{k},~\wcard) & \var{cod}\\
+          \var{currentOtherVrfKeyHashes}  & \var{v} & (\wcard,~\var{v}) & \var{cod}\\
+          \var{futureOtherColdKeyHashes}  & \var{k} & (\var{k},~\wcard) & \var{fod}\\
+          \var{futureOtherVrfKeyHashes}   & \var{v} & (\wcard,~\var{v}) & \var{fod}\\
       \end{array}
       }
       \\
       \var{vkh}\notin\var{currentOtherColdKeyHashes}\union\var{futureOtherColdKeyHashes} \\
-      \var{vrf}\notin\var{currentOtherVrfKeyHashes}\union\var{futureOtherVrfKeyHashe} \\
+      \var{vrf}\notin\var{currentOtherVrfKeyHashes}\union\var{futureOtherVrfKeyHashes} \\
       \var{fdeleg}\leteq\{(\var{s'},~\var{gkh}) \mapsto (\var{vkh},~\var{vrf})\}
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -27,7 +27,7 @@
 \newcommand{\lReward}[4]{\fun{r_{operator}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\mReward}[4]{\fun{r_{member}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\poolReward}[5]{\fun{poolReward}~\var{#1}~{#2}~\var{#3}~\var{#4}~\var{#5}}
-\newcommand{\createRUpd}[3]{\fun{createRUpd}~\var{#1}~\var{#2}~\var{#3}}
+\newcommand{\createRUpd}[4]{\fun{createRUpd}~\var{#1}~\var{#2}~\var{#3}~\var{#4}}
 \newcommand{\getIR}[1]{\fun{getIR}~\var{#1}}
 
 This chapter introduces the epoch boundary transition system and the related reward calculation.
@@ -1309,8 +1309,8 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \emph{Calculation to create a reward update}
   %
   \begin{align*}
-    & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
-    & \createRUpd{b}{es}{total} = \left(
+    & \fun{createRUpd} \in \N \to \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
+    & \createRUpd{slotsPerEpoch}{b}{es}{total} = \left(
       \Delta t_1,-~\Delta r_1+\Delta r_2,~\var{rs},~-\var{feeSS}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{prevPp},~\wcard) = \var{es} \\
@@ -1327,7 +1327,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\Delta r_1 = \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
       \var{reserves}}
     \\
-    & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \ActiveSlotCoeff} \\
+    & ~~~~~~~\eta = \frac{blocksMade}{\var{slotsPerEpoch} \cdot \ActiveSlotCoeff} \\
     & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r_1 \\
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -880,8 +880,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
       \right)
       \\~\\~\\
       \var{(\wcard,~\wcard,~\wcard,~(\var{pup},\wcard))}\leteq\var{utxoSt'}\\
-      \var{pp_{new}}\leteq\var{pp}\unionoverrideRight
-      \fun{votedValue}~\var{pup}~\var{pp}~\Quorum\\
+      \var{pp_{new}}\leteq\fun{votedValue}~\var{pup}~\var{pp}~\Quorum\\
       {
         \begin{array}{r}
           \var{dstate'}\\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -97,7 +97,6 @@
 \newcommand{\MetaDatum}{\ensuremath{\type{MetaDatum}}}
 \newcommand{\MetaData}{\ensuremath{\type{MetaData}}}
 \newcommand{\MetaDataHash}{\ensuremath{\type{MetaDataHash}}}
-\newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Update}{\type{Update}}
 \newcommand{\GenesisDelegation}{\type{GenesisDelegation}}
 \newcommand{\FutGenesisDelegation}{\type{FutGenesisDelegation}}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -94,7 +94,7 @@ This function must produce a unique id for each unique transaction body.
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{pup}
       & \ProposedPPUpdates
-      & \KeyHashGen \mapsto \PPUpdate
+      & \KeyHashGen \mapsto \PParamsUpdate
       & \text{proposed updates}
       \\
       \var{up}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -148,6 +148,7 @@ This function must produce a unique id for each unique transaction body.
       \txid{} & \TxBody \to \TxId & \text{compute transaction id}\\
       \fun{validateScript} & \Script \to \Tx \to \Bool & \text{script interpreter}\\
       \fun{hashMD} & \MetaData \to \MetaDataHash & \text{hash the metadata}\\
+      \fun{bootstrapAttrSize} & \AddrBS \to \N & \text{bootstrap attribute size}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -585,7 +585,7 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
 \end{figure}
 
 The UTXOW rule has eight predicate failures:
-\begin{itemize}                 %TODO: add multi-sig script failure predicates
+\begin{itemize}
 \item In the case of an incorrect witness,
   there is a \emph{InvalidWitnesses} failure.
 \item In the case of a missing witness,
@@ -594,12 +594,17 @@ The UTXOW rule has eight predicate failures:
   there is a \emph{MissingScriptWitnesses} failure.
 \item In the case of an invalid script,
   there is a \emph{ScriptWitnessNotValidating} failure.
-\item In the case that the $\mathsf{}$ rule fails,
-  there is a \emph{UtxoFailure} failure.
 \item In the case of a lack of quorum on an instantaneous reward certificate,
   there is a \emph{MIRInsufficientGenesisSigs} failure.
-\item In the case of inconsist metadata hashes,
-  there is a \emph{BadMetaDataHash} failure.
+\item In the case the transaction contains metadata,
+  but the transaction body does not contain a metadata hash,
+  there is a \emph{MissingTxBodyMetaDataHash} failure.
+\item In the case that the transaction body contains a metadata hash,
+  but there is no metadata outside the body,
+  there is a \emph{MissingTxMetaData} failure.
+\item In the case that the metadata hash in the transaction body
+  is not equal to the hash of the metadata outside the body,
+  there is a \emph{ConflictingMetaDataHash} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -292,6 +292,8 @@ accounts where a reward is accumulated to a specific address.
       \\
       \forall (\wcard\mapsto (\wcard,~c)) \in \txouts{txb}, c \geq (\fun{minUTxOValue}~\var{pp})
       \\
+      \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, a \in \AddrBS \to \fun{bootstrapAttrsSize}~a \leq 64
+      \\
       \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, \fun{netId}~a =\NetworkId
       \\
       \forall (a\mapsto\wcard) \in \txwdrls{txb}, \fun{netId}~a =\NetworkId
@@ -336,7 +338,7 @@ accounts where a reward is accumulated to a specific address.
   \label{fig:rules:utxo-shelley}
 \end{figure}
 
-The UTXO rule has seven predicate failures:
+The UTXO rule has ten predicate failures:
 \begin{itemize}
 \item In the case of any input not being valid, there is a \emph{BadInput}
   failure.
@@ -350,8 +352,14 @@ The UTXO rule has seven predicate failures:
   \emph{FeeTooSmall} failure.
 \item If the transaction does not correctly conserve the balance, there is a
   \emph{ValueNotConserved} failure.
+\item If the transaction creates any outputs with the wrong network ID,
+  there is a \emph{WrongNetwork} failure.
+\item If the transaction contains any withdrawals with the wrong network ID,
+  there is a \emph{WrongNetworkWithdrawal} failure.
 \item If the transaction creates an output below the allowed minimum value,
   there is a \emph{OutputTooSmall} failure.
+\item If the transaction creates any boostrap outputs whose attributes have
+  size bigger than 64, there is a \emph{OutputBootAddrAttrsTooBig} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -134,5 +134,5 @@ defaultConstants =
       maxTreasury = 10000000,
       minReserves = 1000000,
       maxReserves = 10000000,
-      genTxRetries = 5
+      genTxRetries = 6
     }


### PR DESCRIPTION
This PR addresses several recent audit issues, all concerned with syncing the formal spec to the implementation. No semantic changes are made. I always preferred to change the formal spec over the implementation, but in a few places it was better to change the implementation.

The changes to the implementation were:
* a few variable name changes
* the function `createRUpd` was previously taking the epoch in the implementation but not the formal spec. It was only used to get the "global constant" `slotsPerEpoch` (the hard fork combinator can change this). Now both the spec and the implementation are passed this constant.

closes #1728 
closes #1745 
closes #1748 
closes #1751 
closes #1752 
closes #1753 
closes #1764 
closes #1765