### PR TITLE
Avoid using Map.keysSet on nesOsched 

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -19,10 +19,10 @@ where
 
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Arrow (left, right)
-import Control.Iterate.SetAlgebra (dom, eval)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended (TRC (..), applySTS, reapplySTS)
+import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.BlockChain
@@ -69,7 +69,7 @@ mkBbodyEnv
       LedgerState.nesEs
     } =
     STS.BbodyEnv
-      { STS.bbodySlots = eval (dom nesOsched),
+      { STS.bbodySlots = (`Map.member` nesOsched),
         STS.bbodyPp = LedgerState.esPp nesEs,
         STS.bbodyAccount = LedgerState.esAccountState nesEs
       }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -295,7 +295,7 @@ chainTransition =
 
       BbodyState ls' bcur' <-
         trans @(BBODY crypto) $
-          TRC (BbodyEnv (Map.keysSet osched) pp' account, BbodyState ls bcur, block)
+          TRC (BbodyEnv (`Map.member` osched) pp' account, BbodyState ls bcur, block)
 
       let nes'' = updateNES nes' bcur' ls'
           bhb = bhbody bh


### PR DESCRIPTION
On mainnet, the `nesOsched` field of `NewEpochState` currently has 432000 entries. We had noticed in the past https://github.com/input-output-hk/ouroboros-network/issues/1404#issuecomment-663488414 that this adds ~24MB to the heap size of the ledgerState (not taking into account heap fragmentation, slop memory etc). I also recently noticed that the operations on this Map are not optimized for such a big Map. Operations like `Map.keysSet` are O(n) and can be avoided, since the Map can be directly queried, with O(logN). 

I tested the speedup by opening a chainDB, which applies blocks from the immutable and the volatile db. The total time to open the db dropped approximately from 7mins to 6mins. Also doing profiling I noticed that the total heap allocations dropped from 350GB to 290GB and the GC time dropped from 290s to 250s.