### PR TITLE
Delegs: optimise the rewards calculation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -24,19 +24,25 @@ import Cardano.Binary
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.Iterate.SetAlgebra (dom, eval, (∈), (⨃))
 import Control.State.Transition (Embed (..), STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans, (?!), (?!:))
-import Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq (..))
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
-import Shelley.Spec.Ledger.Address (getRwdCred, mkRwdAcnt)
-import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, invalidKey, networkId)
+import Shelley.Spec.Ledger.Address (mkRwdAcnt)
+import Shelley.Spec.Ledger.BaseTypes
+  ( ShelleyBase,
+    invalidKey,
+    networkId,
+  )
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Crypto (Crypto)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
     DPState (..),
+    RewardAccounts,
     emptyDelegation,
     _dstate,
     _pParams,
@@ -53,7 +59,7 @@ import Shelley.Spec.Ledger.TxData
     Delegation (..),
     Ix,
     Ptr (..),
-    RewardAcnt,
+    RewardAcnt (..),
     TxBody (..),
     Wdrl (..),
   )
@@ -132,13 +138,25 @@ delegsTransition = do
     Empty -> do
       let ds = _dstate dpstate
           wdrls_ = unWdrl $ _wdrls (_body tx)
-          rewards = Map.mapKeys (mkRwdAcnt network) $ _rewards ds
+          rewards = _rewards ds
 
-      Map.isSubmapOfBy (==) wdrls_ rewards -- wdrls_ ⊆ rewards
+      isSubmapOf wdrls_ rewards -- wdrls_ ⊆ rewards
         ?! WithdrawalsNotInRewardsDELEGS
-          (Map.differenceWith (\x y -> if x /= y then Just x else Nothing) wdrls_ rewards)
+          ( Map.differenceWith
+              (\x y -> if x /= y then Just x else Nothing)
+              wdrls_
+              (Map.mapKeys (mkRwdAcnt network) rewards)
+          )
 
-      let rewards' = Map.mapKeys getRwdCred $ eval (rewards ⨃ (fmap (\_x -> 0) wdrls_))
+      let wdrls_' :: RewardAccounts crypto
+          wdrls_' =
+            Map.foldrWithKey
+              ( \(RewardAcnt _ cred) _coin ->
+                  Map.insert cred 0
+              )
+              Map.empty
+              wdrls_
+          rewards' = eval (rewards ⨃ wdrls_')
       pure $ dpstate {_dstate = ds {_rewards = rewards'}}
     gamma :|> c -> do
       dpstate' <-
@@ -157,6 +175,17 @@ delegsTransition = do
       let ptr = Ptr slot txIx (fromIntegral $ length gamma)
       trans @(DELPL crypto) $
         TRC (DelplEnv slot ptr pp acnt, dpstate', c)
+  where
+    -- @wdrls_@ is small and @rewards@ big, better to transform the former
+    -- than the latter into the right shape so we can call 'Map.isSubmapOf'.
+    isSubmapOf :: Map (RewardAcnt crypto) Coin -> RewardAccounts crypto -> Bool
+    isSubmapOf wdrls_ rewards = wdrls_' `Map.isSubmapOf` rewards
+      where
+        wdrls_' =
+          Map.fromList
+            [ (cred, coin)
+              | (RewardAcnt _ cred, coin) <- Map.toList wdrls_
+            ]
 
 instance
   Crypto crypto =>


### PR DESCRIPTION
From my profiling report of the validation of the first Shelley epoch (excluding the epoch transition):

```
 TOT   INH   IND
35.7  28.1    .4  Control.State.Transition.Extended liftSTS (7553)
13.0   9.8   7.8    Shelley.Spec.Ledger.STS.Delegs delegsTransition.rewards (8136)
 4.4   1.2    .6      Shelley.Spec.Ledger.Address >= (8607184)
 3.8    .6    .6        Shelley.Spec.Ledger.Address < (8607184)
 3.2     -     -          Shelley.Spec.Ledger.Credential < (8607184)
  .8    .8    .8      Shelley.Spec.Ledger.Address mkRwdAcnt (8615225)
11.3   9.0   8.6    Shelley.Spec.Ledger.STS.Delegs delegsTransition.rewards' (8136)
 2.7    .4    .3      Shelley.Spec.Ledger.Credential >= (8607184)
 2.3     -     -        Shelley.Spec.Ledger.Credential < (8607184)
```

The conversions (`Map.mapKeys`) of the rewards accounts is very costly, and
we're doing it twice. Instead, convert the `wdrls`, which is a much smaller map.

After this change, `rewards` and `rewards'` are no longer hotspots (0.0 time!).