### PR TITLE
Fix deserialiseAddrStakeRef

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/DeserializeShort.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/DeserializeShort.hs
@@ -54,7 +54,7 @@ getAddrStakeReference = do
   header <- getWord
   if testBit header byron
     then pure Nothing
-    else skipHash ([] @(HASH crypto)) >> Just <$> getStakeReference header
+    else skipHash ([] @(ADDRHASH crypto)) >> Just <$> getStakeReference header
 
 getWord :: GetShort Word8
 getWord = GetShort $ \i sbs ->


### PR DESCRIPTION
`deserialiseAddrStakeRef` should skip `ADDRHASH`-many bytes for payment credential. The tests did not catch this since we use `ShortHash` for both `HASH` and `ADDRHASH`. I have made #1782 so that we do not get bit by this again.