### PR TITLE
Optimise DeserializeShort.substring

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,8 +15,7 @@ packages:
 
 
 constraints:
-  hashable < 1.3,
-  primitive < 0.7
+  hashable < 1.3
 
 -- Always wrtie GHC env files, because they are needed by the doctests.
 write-ghc-environment-files: always

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -106,6 +106,7 @@ library
     iproute,
     mtl,
     network,
+    primitive >= 0.7.1.0,
     quiet,
     scientific,
     shelley-spec-non-integral,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/DeserializeShort.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/DeserializeShort.hs
@@ -13,6 +13,8 @@ import Control.Monad (ap)
 import Control.Monad (join)
 import Data.Bits (testBit, (.&.))
 import Data.ByteString.Short as SBS
+import Data.ByteString.Short.Internal (ShortByteString (SBS))
+import qualified Data.Primitive.ByteArray as BA
 import Data.Word (Word8)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.Address
@@ -105,7 +107,9 @@ getHash = GetShort $ \i sbs ->
         else Nothing
 
 substring :: ShortByteString -> Int -> Int -> ShortByteString
-substring sbs start stop = SBS.pack [SBS.index sbs n | n <- [start .. stop -1]]
+substring (SBS ba) start stop =
+  case BA.cloneByteArray (BA.ByteArray ba) start (stop - start) of
+    BA.ByteArray ba' -> SBS ba'
 
 skip :: Int -> GetShort ()
 skip n = GetShort $ \i sbs ->


### PR DESCRIPTION
In my microbenchmark, this brings down the cost of deserialising a Shelley
address in `viewCompactTxOut` from ~360ns to ~60ns.

The `cloneByteArray` function was introduced in version 0.7.1.0 of the
`primitive` package, so update the lower bound accordingly.

I believe the old `primitive < 0.7` constraint in `cabal.project` was due to
older versions of the `cborg` package having `>=0.5 && <0.7.1.0` as bounds for
`primitive`, but `cborg-0.2.4.0` bumped the upper bound to 0.8.

This will likely require similar changes to downstream repos.