### PR TITLE
Increase number of epochs spanned by CHAIN traces

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -83,7 +83,9 @@ genBlock
   ge@(GenEnv KeySpace_ {ksStakePools, ksIndexedGenDelegates} _)
   origChainState = do
     -- Firstly, we must choose a slot in which to lead.
-    firstConsideredSlot <- (slot +) . SlotNo <$> QC.choose (1, 5)
+    -- Caution: the number of slots we jump here will affect the number
+    -- of epochs that a chain of blocks will span
+    firstConsideredSlot <- (slot +) . SlotNo <$> QC.choose (5, 10)
     let (nextSlot, chainSt, issuerKeys) =
           fromMaybe
             (error "Cannot find a slot to create a block in")


### PR DESCRIPTION
Closes #1759 

* increase "slot jumps" in genBlock to increase epochs spanned by a chain of blocks
* retuned, cleaned up and fixed some issues with the trace classifier
* we're now checking coverage for "4 or more epoch boundaries in at least 20% of traces" (for a smaller % of traces we're now generating chains that span up to 9 epochs)