### PR TITLE
deleted dead symlink "cddl-spec"

### DIFF
--- a/shelley/chain-and-ledger/cddl-spec
+++ b/shelley/chain-and-ledger/cddl-spec
@@ -1,1 +1,0 @@
-executable-spec/cddl-files/


### PR DESCRIPTION
`stack` was not able to compile and kept complaining about this dead symlink.

but, I don't know what else depends or depended on this symlink