### PR TITLE
STS Evolution

### DIFF
--- a/semantics/executable-spec/src/Control/State/Transition/Extended.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Extended.hs
@@ -176,7 +176,7 @@ class
   -- the disjunction of all rules' preconditions is equal to `True`. That is,
   -- either one rule will throw a structural `PredicateFailure` and the other
   -- will succeed, or vice-versa.
-  data PredicateFailure a :: Type
+  type PredicateFailure a = (b :: Type) | b -> a
 
   -- | Rules governing transition under this system.
   initialRules :: [InitialRule a]

--- a/semantics/small-steps-test/small-steps-test.cabal
+++ b/semantics/small-steps-test/small-steps-test.cabal
@@ -92,6 +92,8 @@ test-suite examples
                      , Control.State.Transition.Examples.GlobalSum
                      , Control.State.Transition.Examples.CommitReveal
                      , Control.State.Transition.Examples.Modular.Base
+                     , Control.State.Transition.Examples.Modular.Base.Types
+                     , Control.State.Transition.Examples.Modular.Extension
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base

--- a/semantics/small-steps-test/small-steps-test.cabal
+++ b/semantics/small-steps-test/small-steps-test.cabal
@@ -89,14 +89,18 @@ test-suite examples
   hs-source-dirs:      test
   main-is:             examples/Main.hs
   other-modules:       Control.State.Transition.Examples.Sum
-  other-modules:       Control.State.Transition.Examples.GlobalSum
+                     , Control.State.Transition.Examples.GlobalSum
                      , Control.State.Transition.Examples.CommitReveal
+                     , Control.State.Transition.Examples.Modular.Base
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base
+                     , acts
                      , containers
+                     , groups >= 0.4
                      , hedgehog >= 1.0
                      , mtl
+                     , optics
                      , tasty
                      , tasty-hedgehog
                      , tasty-expected-failure

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/CommitReveal.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/CommitReveal.hs
@@ -105,6 +105,10 @@ newtype Data = Data {getData :: (Id, Int)}
 newtype Id = Id {getId :: Int}
   deriving (Eq, Show, ToCBOR, Ord, QC.Arbitrary)
 
+data CRPredicateFailure hashAlgo (hashToDataMap :: * -> * -> *) commitData
+  = InvalidReveal Data
+  | AlreadyComitted (Hash hashAlgo Data)
+  deriving (Eq, Show)
 instance
   ( HashAlgorithm hashAlgo,
     Typeable hashToDataMap,
@@ -120,10 +124,8 @@ instance
 
   type Signal (CR hashAlgo hashToDataMap commitData) = CRSignal hashAlgo commitData
 
-  data PredicateFailure (CR hashAlgo hashToDataMap commitData)
-    = InvalidReveal Data
-    | AlreadyComitted (Hash hashAlgo Data)
-    deriving (Eq, Show)
+  type PredicateFailure (CR hashAlgo hashToDataMap commitData)
+    = CRPredicateFailure hashAlgo hashToDataMap commitData
 
   initialRules =
     [ pure

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
@@ -1,21 +1,17 @@
-
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
- -- | Simple example of a transition system whose states contain the sum of the
- -- integers seen in the signals, where 'sum' is an abstract monoidal sum given
- -- in the enviroment.
- --
+-- | Simple example of a transition system whose states contain the sum of the
+-- integers seen in the signals, where 'sum' is an abstract monoidal sum given
+-- in the enviroment.
 module Control.State.Transition.Examples.GlobalSum where
 
-import           Control.State.Transition.Extended
 import Control.Monad.Reader
+import Control.State.Transition.Extended
 import Data.Foldable (foldl')
-
 import Test.Tasty
 import Test.Tasty.HUnit
-
 import Prelude hiding (sum)
 
 data Ops = Ops
@@ -24,9 +20,9 @@ data Ops = Ops
 
 data GSUM
 
+data NoFailure = NoFailure deriving (Eq, Show)
 
 instance STS GSUM where
-
   type Environment GSUM = ()
 
   type State GSUM = Int
@@ -35,7 +31,7 @@ instance STS GSUM where
 
   type BaseM GSUM = Reader Ops
 
-  data PredicateFailure GSUM = NoFailure deriving (Eq, Show)
+  type PredicateFailure GSUM = NoFailure
 
   initialRules = [pure 0]
 
@@ -47,12 +43,14 @@ instance STS GSUM where
     ]
 
 tests :: TestTree
-tests = testGroup "STS.Extended"
-    [ testCase "Sum" $ withSum @=? Right 55
-    , testCase "Product" $ withProduct @=? Right 3628800
+tests =
+  testGroup
+    "STS.Extended"
+    [ testCase "Sum" $ withSum @=? Right 55,
+      testCase "Product" $ withProduct @=? Right 3628800
     ]
   where
-    inputs = [1..10]
+    inputs = [1 .. 10]
     ctx = TRC ((), 0, inputs)
     withSum = runReader (applySTS @GSUM ctx) (Ops (foldl' (+) 0))
     withProduct = runReader (applySTS @GSUM ctx) (Ops (foldl' (*) 1))

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base.hs
@@ -1,0 +1,263 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Base for a modular STS example
+module Control.State.Transition.Examples.Modular.Base where
+
+import Control.State.Transition
+import Data.Group (Group, invert)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
+import Data.Monoid (Sum (..))
+import Optics
+
+newtype Coin = Coin Int
+  deriving newtype (Eq, Ord, Show)
+  deriving
+    (Group, Semigroup, Monoid)
+    via Sum Int
+
+newtype AccountName = AccountName String
+  deriving newtype (Eq, Ord, Show)
+
+data Account = Account
+  { name :: AccountName,
+    balance :: Coin
+  }
+  deriving stock (Eq, Show)
+
+data Tx = Tx
+  { fromAcnt :: AccountName,
+    toAcnt :: AccountName,
+    amount :: Coin
+  }
+
+data Admin
+  = OpenAccount AccountName Coin
+  | Withdraw AccountName Coin
+  | CloseAccount AccountName
+
+data Op
+  = OpTx Tx
+  | OpAdmin Admin
+
+newtype Accounting = Accounting {unAccounting :: Map AccountName Account}
+
+newtype BlockId = BlockId String
+
+data Block = Block
+  { blockId :: BlockId,
+    blockOps :: [Op]
+  }
+
+data ChainState = ChainState
+  { accountState :: Accounting,
+    lastBlock :: BlockId
+  }
+
+-------------------------------------------------------------------------------
+-- STS plumbing
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Transaction processing
+-------------------------------------------------------------------------------
+data TX
+
+instance STS TX where
+  type Environment TX = ()
+  type State TX = Accounting
+  type Signal TX = Tx
+
+  data PredicateFailure TX
+    = InsufficientMoney Account Coin
+    | NoSuchAccount AccountName
+    deriving stock (Eq, Show)
+
+  initialRules = []
+
+  transitionRules = [processTx]
+
+processTx :: TransitionRule TX
+processTx = do
+  TRC
+    ( (),
+      unAccounting -> accounting,
+      Tx {fromAcnt, toAcnt, amount}
+      ) <-
+    judgmentContext
+
+  accounting' <- case ( Map.lookup fromAcnt accounting,
+                        Map.lookup toAcnt accounting
+                      ) of
+    (Just f, Just t) -> do
+      balance f >= amount ?! InsufficientMoney f amount
+      pure $
+        Map.insert fromAcnt (f {balance = balance f <> invert amount})
+          . Map.insert toAcnt (t {balance = balance t <> amount})
+          $ accounting
+    (mf, mt) -> do
+      isJust mf ?! NoSuchAccount fromAcnt
+      isJust mt ?! NoSuchAccount toAcnt
+      pure accounting
+
+  pure $! Accounting accounting'
+
+data ADMIN
+
+instance STS ADMIN where
+  type Environment ADMIN = ()
+  type State ADMIN = Accounting
+  type Signal ADMIN = Admin
+
+  data PredicateFailure ADMIN
+    = AccountAlreadyExists AccountName
+    | CloseNonEmptyAccount Account
+    | NonExistingAccount AccountName
+    | WithdrawInsufficientBalance Account Coin
+    deriving stock (Eq, Show)
+
+  initialRules = []
+  transitionRules = [processAdmin]
+
+processAdmin :: TransitionRule ADMIN
+processAdmin = do
+  TRC ((), unAccounting -> accounting, admin) <- judgmentContext
+  case admin of
+    OpenAccount withName withBalance -> do
+      Map.notMember withName accounting ?! AccountAlreadyExists withName
+      pure . Accounting $
+        Map.insert
+          withName
+          (Account withName withBalance)
+          accounting
+    CloseAccount withName -> do
+      accounting' <- case Map.lookup withName accounting of
+        Nothing ->
+          (failBecause $ NonExistingAccount withName)
+            >> pure accounting
+        Just x
+          | balance x /= mempty ->
+            (failBecause $ CloseNonEmptyAccount x) >> pure accounting
+        _ -> pure $ Map.delete withName accounting
+
+      pure $! Accounting accounting'
+    Withdraw fromAcnt amt ->
+      Accounting <$> case Map.lookup fromAcnt accounting of
+        Nothing ->
+          (failBecause $ NonExistingAccount fromAcnt)
+            >> pure accounting
+        Just x
+          | balance x < amt ->
+            (failBecause $ WithdrawInsufficientBalance x amt)
+              >> pure accounting
+        Just x ->
+          pure $
+            Map.insert
+              fromAcnt
+              (x {balance = balance x <> invert amt})
+              accounting
+
+data OPS
+
+instance STS OPS where
+  type Environment OPS = ()
+  type State OPS = Accounting
+  type Signal OPS = [Op]
+
+  data PredicateFailure OPS
+    = TXFailure (PredicateFailure TX)
+    | ADMINFailure (PredicateFailure ADMIN)
+    deriving stock (Eq, Show)
+
+  initialRules = []
+
+  transitionRules = [processOps @OPS @TX @ADMIN]
+
+instance Embed TX OPS where
+  wrapFailed = TXFailure
+
+instance Embed ADMIN OPS where
+  wrapFailed = ADMINFailure
+
+class (HasGetter a b, HasSetter a b) => HasLens a b where
+  lensy :: Lens' a b
+  lensy = lens (view gettery) (flip $ set settery)
+
+extract :: HasGetter a b => a -> b
+extract = view gettery
+
+inject :: HasSetter a b => b -> a -> a
+inject = set settery
+
+class HasGetter a b where
+  gettery :: Getter a b
+
+class HasSetter a b where
+  settery :: Setter' a b
+
+instance HasGetter a a where
+  gettery = castOptic equality
+
+instance HasSetter a a where
+  settery = castOptic equality
+
+instance HasLens a a where
+  lensy = castOptic equality
+
+processOps ::
+  forall ops tx admin.
+  ( HasLens (Signal ops) [Op],
+    HasLens (State ops) Accounting,
+    HasGetter Tx (Signal tx),
+    HasGetter Accounting (State tx),
+    HasGetter (Environment ops) (Environment tx),
+    HasGetter Admin (Signal admin),
+    HasGetter Accounting (State admin),
+    HasGetter (Environment ops) (Environment admin),
+    HasSetter (State ops) (State tx),
+    HasSetter (State ops) (State admin),
+    Embed tx ops,
+    Embed admin ops
+  ) =>
+  TransitionRule ops
+processOps = do
+  TRC (env, st, ops) <-
+    judgmentContext
+
+  case extract ops of
+    x : xs -> case x of
+      OpTx tx ->
+        do
+          txs <- trans @tx (TRC (extract env, extract $ extract @_ @Accounting st, extract tx))
+          trans @ops (TRC (env, inject txs st, inject xs ops))
+      OpAdmin admin ->
+        do
+          st' <- trans @admin (TRC (extract env, extract $ extract @_ @Accounting st, extract admin))
+          trans @ops (TRC (env, inject st' st, inject xs ops))
+    [] -> pure st
+
+data CHAIN
+
+instance STS CHAIN where
+  type Environment CHAIN = ()
+  type State CHAIN = ChainState
+  type Signal CHAIN = Block
+
+  data PredicateFailure CHAIN
+    = OPFailure (PredicateFailure OPS)
+    deriving stock (Eq, Show)
+
+  initialRules = []
+
+  transitionRules = []

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base.hs
@@ -221,7 +221,7 @@ instance STS (OPS Era_0) where
   initialRules = []
 
   transitionRules =
-    [processOps @(OPS Era_0) @(TX Era_0) @(ADMIN Era_0)]
+    [processOps @(OPS Era_0) @(TX Era_0) @(ADMIN Era_0) @Era_0]
 
 instance Embed (TX Era_0) (OPS Era_0) where
   wrapFailed = TXFailure
@@ -255,14 +255,14 @@ instance HasLens a a where
   lensy = castOptic equality
 
 processOps ::
-  forall ops tx admin.
-  ( HasLens (Signal ops) [BT.Op Era_0],
-    HasLens (State ops) (BT.Accounting Era_0),
-    HasGetter (BT.Tx Era_0) (Signal tx),
-    HasGetter (BT.Accounting Era_0) (State tx),
+  forall ops tx admin e.
+  ( HasLens (Signal ops) [Op e],
+    HasLens (State ops) (BT.Accounting e),
+    HasGetter (BT.Tx e) (Signal tx),
+    HasGetter (BT.Accounting e) (State tx),
     HasGetter (Environment ops) (Environment tx),
-    HasGetter (BT.Admin Era_0) (Signal admin),
-    HasGetter (BT.Accounting Era_0) (State admin),
+    HasGetter (BT.Admin e) (Signal admin),
+    HasGetter (BT.Accounting e) (State admin),
     HasGetter (Environment ops) (Environment admin),
     HasSetter (State ops) (State tx),
     HasSetter (State ops) (State admin),
@@ -274,7 +274,7 @@ processOps = do
   TRC (env, st, ops) <-
     judgmentContext
 
-  case extract @_ @([BT.Op Era_0]) ops of
+  case extract @_ @([Op e]) ops of
     x : xs -> case x of
       OpTx tx ->
         do
@@ -283,7 +283,7 @@ processOps = do
               ( TRC
                   ( extract env,
                     extract $
-                      extract @_ @(BT.Accounting Era_0)
+                      extract @_ @(BT.Accounting e)
                         st,
                     extract tx
                   )
@@ -296,7 +296,7 @@ processOps = do
               ( TRC
                   ( extract env,
                     extract $
-                      extract @_ @(BT.Accounting Era_0)
+                      extract @_ @(BT.Accounting e)
                         st,
                     extract admin
                   )

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base/Types.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Base/Types.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module declares the types in the base module which are open to
+-- overriding in future modules.
+module Control.State.Transition.Examples.Modular.Base.Types where
+
+type family Coin era
+type family AccountName era
+type family Account era
+type family Tx era
+type family Admin era
+type family Op era
+type family Accounting era
+type family BlockId era
+type family Block era
+type family ChainState era

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
@@ -43,6 +43,14 @@ newtype Coin = Coin {unCoin :: Map Token Quantity}
 instance Group Coin where
   invert (Coin m) = Coin $! Map.map invert m
 
+-- | Override transaction to include a new field.
+data Tx e = Tx
+  { fromAcnt :: BT.AccountName e,
+    toAcnt :: BT.AccountName e,
+    amount :: BT.Coin e,
+    flibbertigibbet :: Int
+  }
+
 -------------------------------------------------------------------------------
 -- Era instances
 -------------------------------------------------------------------------------
@@ -53,7 +61,7 @@ type instance BT.AccountName Era_1 = Base.AccountName
 
 type instance BT.Account Era_1 = Base.Account Era_1
 
-type instance BT.Tx Era_1 = Base.Tx Era_1
+type instance BT.Tx Era_1 = Tx Era_1
 
 type instance BT.Admin Era_1 = Base.Admin Era_1
 
@@ -102,11 +110,7 @@ instance STS (TX) where
 
   initialRules = []
 
-  transitionRules = [processTx]
-
--- | This is the thing we actually want to override
-processTx :: TransitionRule TX
-processTx = undefined
+  transitionRules = [Base.processTx @TX @Era_1]
 
 data ADMIN
 
@@ -129,6 +133,7 @@ data OPS
 deriving stock instance Eq (Base.OPSPredicateFailure Era_1)
 
 deriving stock instance Show (Base.OPSPredicateFailure Era_1)
+
 instance STS OPS where
   type Environment (OPS) = ()
   type State (OPS) = (BT.Accounting Era_1)

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Control.State.Transition.Examples.Modular.Extension where
+
+import Control.State.Transition
+import qualified Control.State.Transition.Examples.Modular.Base as Base
+import qualified Control.State.Transition.Examples.Modular.Base.Types as BT
+import Data.Group (Group, invert)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
+import Data.Monoid (Sum (..))
+import Optics
+
+data Era_1
+
+-------------------------------------------------------------------------------
+-- New types for the era
+-------------------------------------------------------------------------------
+
+newtype Quantity = Quantity Int
+  deriving newtype (Eq, Ord, Show)
+  deriving
+    (Group, Semigroup, Monoid)
+    via Sum Int
+
+newtype Token = Token String
+  deriving newtype (Eq, Ord, Show)
+
+newtype Coin = Coin {unCoin :: Map Token Quantity}
+  deriving newtype (Eq, Ord, Show)
+
+-------------------------------------------------------------------------------
+-- Era instances
+-------------------------------------------------------------------------------
+
+type instance BT.Coin Era_1 = Coin
+type instance BT.AccountName Era_1 = Base.AccountName

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Modular/Extension.hs
@@ -6,8 +6,10 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Control.State.Transition.Examples.Modular.Extension where
@@ -18,9 +20,7 @@ import qualified Control.State.Transition.Examples.Modular.Base.Types as BT
 import Data.Group (Group, invert)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
 import Data.Monoid (Sum (..))
-import Optics
 
 data Era_1
 
@@ -38,11 +38,112 @@ newtype Token = Token String
   deriving newtype (Eq, Ord, Show)
 
 newtype Coin = Coin {unCoin :: Map Token Quantity}
-  deriving newtype (Eq, Ord, Show)
+  deriving newtype (Eq, Monoid, Ord, Semigroup, Show)
+
+instance Group Coin where
+  invert (Coin m) = Coin $! Map.map invert m
 
 -------------------------------------------------------------------------------
 -- Era instances
 -------------------------------------------------------------------------------
 
 type instance BT.Coin Era_1 = Coin
+
 type instance BT.AccountName Era_1 = Base.AccountName
+
+type instance BT.Account Era_1 = Base.Account Era_1
+
+type instance BT.Tx Era_1 = Base.Tx Era_1
+
+type instance BT.Admin Era_1 = Base.Admin Era_1
+
+type instance BT.Op Era_1 = Base.Op Era_1
+
+type instance BT.Accounting Era_1 = Base.Accounting Era_1
+
+type instance BT.BlockId Era_1 = Base.BlockId
+
+type instance BT.Block Era_1 = Base.Block Era_1
+
+type instance BT.ChainState Era_1 = Base.ChainState Era_1
+
+-------------------------------------------------------------------------------
+-- STS Plumbing
+-------------------------------------------------------------------------------
+
+{-
+newtype Clone a = Clone a
+
+instance STS a => STS (Clone a) where
+  type Environment (Clone a) = Environment a
+  type State (Clone a) = State a
+  type Signal (Clone a) = Signal a
+
+  initialRules = initialRules @a
+  transitionRules = transitionRules @a
+
+deriving via (Clone (Base.ADMIN))
+-}
+
+data TX
+
+deriving stock instance Eq (Base.TXPredicateFailure Era_1)
+
+deriving stock instance Show (Base.TXPredicateFailure Era_1)
+
+instance STS (TX) where
+  type Environment (TX) = ()
+  type State (TX) = BT.Accounting Era_1
+  type Signal (TX) = BT.Tx Era_1
+
+  type
+    PredicateFailure TX =
+      Base.TXPredicateFailure Era_1
+
+  initialRules = []
+
+  transitionRules = [processTx]
+
+-- | This is the thing we actually want to override
+processTx :: TransitionRule TX
+processTx = undefined
+
+data ADMIN
+
+deriving stock instance Eq (Base.AdminPredicateFailure Era_1)
+
+deriving stock instance Show (Base.AdminPredicateFailure Era_1)
+
+instance STS ADMIN where
+  type Environment (ADMIN) = ()
+  type State (ADMIN) = (BT.Accounting Era_1)
+  type Signal (ADMIN) = Base.Admin Era_1
+
+  type PredicateFailure (ADMIN) = Base.AdminPredicateFailure Era_1
+
+  initialRules = []
+  transitionRules = [Base.processAdmin @ADMIN @Era_1]
+
+data OPS
+
+deriving stock instance Eq (Base.OPSPredicateFailure Era_1)
+
+deriving stock instance Show (Base.OPSPredicateFailure Era_1)
+instance STS OPS where
+  type Environment (OPS) = ()
+  type State (OPS) = (BT.Accounting Era_1)
+  type Signal (OPS) = [BT.Op Era_1]
+
+  type
+    PredicateFailure OPS =
+      Base.OPSPredicateFailure Era_1
+
+  initialRules = []
+  transitionRules =
+    [Base.processOps @(OPS) @(TX) @ADMIN @Era_1]
+
+instance Embed TX OPS where
+  wrapFailed = Base.TXFailure
+
+instance Embed (ADMIN) (OPS) where
+  wrapFailed = Base.ADMINFailure

--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/Sum.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/Sum.hs
@@ -22,6 +22,8 @@ import qualified Control.State.Transition.Trace.Generator.QuickCheck as STS.Gen
 
 data SUM
 
+data NoFailure = NoFailure deriving (Eq, Show)
+
 instance STS SUM where
 
   type Environment SUM = ()
@@ -30,7 +32,7 @@ instance STS SUM where
 
   type Signal SUM = [Int]
 
-  data PredicateFailure SUM = NoFailure deriving (Eq, Show)
+  type PredicateFailure SUM = NoFailure
 
   initialRules = [pure 0]
 


### PR DESCRIPTION
Draft PR for discussion.

This presents a straw man for a means to extend base Shelley system with additional modules providing other features. It introduces a basic account based blockchain model, and then a separate module which overrides this to support multi-currency.

This demonstrates the following features:
- The base system does not need to know anything about the extension - dependencies flow entirely one way. This is not to say that the base code does not have to change, but the only change needed is being more specific about the strict requirements for the _base_ ledger.
- We allow type overloading on two levels, through having type families which resolve to era-indexed types. By changing the type family instance for a completely new type, we can completely change out types involved. But by simply changing the era parameter, anything which depends only on the _structure_ of the type will continue to work. We show examples of this both in `OPS` and `ADMIN` - `ADMIN` for example relies on the structure of `Accounting` and `Admin` but not their specific type:
```
HasLens (State admin) (Accounting e),
    HasGetter (Signal admin) (Admin e),
```

`processOps` relies on the _structure_ of `Op`, but is fully parametric over its `Accounting` provided that its `tx` and `admin` rules support it, since all `processOps` does is pass this down to a lower layer.

- The amount of code which needs to be copied is minimal - mostly just some plumbing code.
- Size of the extension module is generally small.
- We're actually closer to the formal ledger in being clear about what our state/signals _provide_, rather than what they _are_.
- Not too many changes needed to start adopting this framework - only the change from `data` to `type` for `PredicateFailure`.

Downsides:
- A bunch of extra constraints and type annotations to convince things to work.
- Relies on turning lots of things into type families to be instantiated later. This would be pretty large if we did this wholesale in the Shelley ledger.
- A lot of the plumbing code is formulaic.

Thoughts:
- Base monad might be annoying - I think we should aim not to change this.
- We could probably package a lot of the contraints on rules together.
- We might be able to auto-derive most of the STS instances, if we work out how to use the era parameter properly on the STS systems.
- I feel like the lens stuff should already exist somewhere.

Posting here for discussion; thoughts, ideas for how to make this better happily received, especially if they come with code!