### PR TITLE
Formal Spec changes for recent audit

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -40,6 +40,7 @@ module Shelley.Spec.Ledger.BlockChain
     bheader,
     bhbody,
     bbody,
+    bnonce,
     hsig,
     --
     seedEta,
@@ -108,6 +109,7 @@ import Shelley.Spec.Ledger.BaseTypes
     activeSlotVal,
     intervalValue,
     mkNonceFromNumber,
+    mkNonceFromOutputVRF,
     strictMaybeToMaybe,
   )
 import Shelley.Spec.Ledger.Crypto
@@ -488,6 +490,10 @@ instance
 -- from the body of the block header.
 poolIDfromBHBody :: Crypto crypto => BHBody crypto -> KeyHash 'BlockIssuer crypto
 poolIDfromBHBody = hashKey . bheaderVk
+
+-- | Retrieve the new nonce from the block header body.
+bnonce :: BHBody crypto -> Nonce
+bnonce = mkNonceFromOutputVRF . VRF.certifiedOutput . bheaderEta
 
 data Block crypto
   = Block' !(BHeader crypto) !(TxSeq crypto) LByteString

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -80,9 +80,9 @@ data OVERLAY crypto
 data OverlayEnv crypto
   = OverlayEnv
       (OverlaySchedule crypto)
-      Nonce
       (PoolDistr crypto)
       (GenDelegs crypto)
+      Nonce
   deriving (Generic)
 
 instance NoUnexpectedThunks (OverlayEnv crypto)
@@ -238,7 +238,7 @@ overlayTransition ::
 overlayTransition =
   judgmentContext
     >>= \( TRC
-             ( OverlayEnv osched eta0 pd (GenDelegs genDelegs),
+             ( OverlayEnv osched pd (GenDelegs genDelegs) eta0,
                cs,
                bh@(BHeader bhb _)
                )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -38,7 +38,6 @@ import Shelley.Spec.Ledger.BaseTypes
   ( Nonce,
     Seed,
     ShelleyBase,
-    mkNonceFromOutputVRF,
   )
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
@@ -46,6 +45,7 @@ import Shelley.Spec.Ledger.BlockChain
     LastAppliedBlock (..),
     PrevHash,
     bhbody,
+    bnonce,
     lastAppliedHash,
   )
 import Shelley.Spec.Ledger.Crypto (Crypto, VRF)
@@ -161,7 +161,7 @@ prtclTransition = do
     judgmentContext
   let bhb = bhbody bh
       slot = bheaderSlotNo bhb
-      eta = mkNonceFromOutputVRF . VRF.certifiedOutput $ bheaderEta bhb
+      eta = bnonce bhb
 
   UpdnState etaV' etaC' <-
     trans @(UPDN crypto) $
@@ -172,7 +172,7 @@ prtclTransition = do
         )
   cs' <-
     trans @(OVERLAY crypto) $
-      TRC (OverlayEnv osched eta0 pd dms, cs, bh)
+      TRC (OverlayEnv osched pd dms eta0, cs, bh)
 
   pure $
     PrtclState

--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -156,7 +156,7 @@ which is also either a key hash or a script hash.
       \\
       \var{addr^{script}_{enterprise}}
                  & \Addr^{vkey}_{enterprise}
-                               & \Addr_{enterprise}\HashScr
+                               & \Addr_{enterprise}\cap\HashScr
       \\[0.5cm]
       \var{addr^{vkey}} &
              \Addr^{vkey} &
@@ -209,7 +209,7 @@ which is also either a key hash or a script hash.
   \emph{Constraints}
   %
   \begin{equation*}
-    \var{hk_1} = \var{hk_2} \iff \fun{addr_{rwd}}~\var{hk_2} = \fun{addr_{rwd}}~\var{hk_2}
+    \var{hk_1} = \var{hk_2} \iff \fun{addr_{rwd}}~\var{hk_1} = \fun{addr_{rwd}}~\var{hk_2}
     ~~~ \left( \fun{addr_{rwd}} \text{ is injective} \right)
   \end{equation*}
   \caption{Definitions used in Addresses}

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1342,9 +1342,9 @@ check the correct cold key hash and vrf key hash.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{osched} & \Slot\mapsto\KeyHashGen^? & \text{OBFT overlay schedule} \\
-        \eta_0 & \Seed & \text{epoch nonce} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
         \var{genDelegs} & \GenesisDelegation & \text{genesis key delegations} \\
+        \eta_0 & \Seed & \text{epoch nonce} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1476,6 +1476,7 @@ followed by the transition to update the evolving and candidate nonces.
         \var{osched} & \Slot\mapsto\KeyHashGen^? & \text{OBFT overlay schedule} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
         \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \eta_0 & \Seed & \text{epoch nonce} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1517,7 +1518,6 @@ The environments for this transition are:
 The states for this transition consists of:
 \begin{itemize}
   \item The operational certificate issue number mapping.
-  \item The last applied block information.
   \item The evolving nonce.
   \item The canditate nonce for the next epoch.
 \end{itemize}
@@ -1544,9 +1544,9 @@ The states for this transition consists of:
       {
         {\begin{array}{c}
           \var{osched} \\
-          \eta_0 \\
           \var{pd} \\
           \var{dms} \\
+          \eta_0 \\
         \end{array}
         }
         \vdash \var{cs}\trans{\hyperref[fig:rules:overlay]{overlay}}{\var{bh}} \var{cs}'
@@ -1577,7 +1577,7 @@ The states for this transition consists of:
   \label{fig:rules:prtcl}
 \end{figure}
 
-The PRTCL rule has no predicate failures.
+The PRTCL rule has no predicate failures, besides those of the two sub-transitons.
 
 \clearpage
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -984,7 +984,7 @@ slot is removed. The helper function $\fun{adoptGenesisDelegs}$ accomplishes the
           \right\}
       \\
       & ~~~~~~~~~~\var{ds'}\leteq
-          (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
+          (\var{rewards},~\var{delegations},~\var{ptrs},
           ~\var{fGenDelegs'},~\var{genDelegs}\unionoverrideRight\var{genDelegs'},~\var{i_{rwd}})
       \\
       & ~~~~~~~~~~\var{es'}\leteq

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -491,8 +491,10 @@ and is present only for extra assurance and for help in proving
 that Ada is preserved by this transition.
 The second rule deals with the case when the epoch signal $e$ is not one greater than the
 current epoch \var{e_\ell}. This rule does not change the state.
-The third one deals with the case when the reward update is equal to $\Nothing$.
-This rule also does not change the state.
+The third rule is nearly the same as the first rule, only there is no reward update to apply.
+This third rule is defined for completeness, but in practice we hope that it is never used,
+since it only applies in the case that epoch $e$ processed no blocks after the first
+$\StabilityWindow$-many slots.
 
 In the first case, the new epoch state is updated as follows:
 
@@ -600,13 +602,51 @@ In the first case, the new epoch state is updated as follows:
       e = e_\ell + 1
       &
       \var{ru} = \Nothing
+      \\
+      {
+        \vdash
+        \var{es}
+          \trans{\hyperref[fig:rules:mir]{mir}}{}\var{es''}
+      }
+      &
+      {
+        \vdash
+        \var{es''}
+          \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es'''}
+      }
+      \\~\\
+      {\begin{array}{r@{~\leteq~}l}
+         (\var{acnt},~\var{ss},~\wcard,~\wcard,~\var{pp}) & \var{es'''} \\
+         (\wcard,~\var{pstake_{set}},~\wcard,~\wcard) & \var{ss} \\
+         \var{pd'} & \fun{calculatePoolDistr}~\var{pstake_{set}} \\
+         \var{osched'} & \overlaySchedule{e}{gkeys}{pp} \\
+       \end{array}}
     }
     {
       {\begin{array}{c}
-          \var{s} \\
-          \var{gkeys} \\
-      \end{array}}
-      \vdash\var{nes}\trans{newepoch}{\var{e}} \var{nes}
+         \var{s} \\
+         \var{gkeys} \\
+       \end{array}}
+      \vdash
+      {\left(\begin{array}{c}
+            \var{e_\ell} \\
+            \var{b_{prev}} \\
+            \var{b_{cur}} \\
+            \var{es} \\
+            \var{ru} \\
+            \var{pd} \\
+            \var{osched} \\
+      \end{array}\right)}
+      \trans{newepoch}{\var{e}}
+      {\left(\begin{array}{c}
+            \varUpdate{\var{e}} \\
+            \varUpdate{\var{b_{cur}}} \\
+            \varUpdate{\emptyset} \\
+            \varUpdate{\var{es'''}} \\
+            \var{ru} \\
+            \varUpdate{\var{pd}'} \\
+            \varUpdate{\var{osched}'} \\
+      \end{array}\right)}
     }
   \end{equation}
   \caption{New Epoch rules}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -260,7 +260,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       & \where \\
       & ~~~~ (~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard,~\wcard)
         = \var{dstate} \\
-      & ~~~~ (~\var{poolParams}~\wcard,~\wcard) = \var{pstate} \\
+      & ~~~~ (~\var{poolParams},~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
         \left(\fun{stakeCred_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
         \circ\left(\range{\var{utxo}}\right)
@@ -1320,7 +1320,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\left(
       \wcard,~
       \left(
-      \left(\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\wcard\right)~
+      \left(\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\wcard\right),~
       \wcard
       \right)
       \right) = \var{ls} \\

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -404,7 +404,7 @@ each output of a transition is spent at most once.
   \begin{align*}
     \fun{getStDelegs} & \in & \DState \to \powerset \Credential \\
     \fun{getStDelegs} & \coloneqq &
-                                    ((\var{stkCreds}, \wcard,
+                                    (\var{stkCreds}, \wcard,
                                     \wcard,\wcard,\wcard,\wcard) \to \var{stkCreds} \\
                       &&\\
     \fun{getRewards} & \in & \DState \to (\AddrRWD \mapsto \Coin) \\


### PR DESCRIPTION
This PR addresses the last several audit issues. I have skipped #1776 for now, though, since it is a bit more involved.

I made a couple of very small code changes, but I think that they are worth it:
* The overlay and prtcl environments had the same data, but in different orders, so I made them the same
* I made the (very simple) function that gets the block nonce from the block header body a helper function

closes #1791 
closes #1797 
closes #1800 
closes #1805 
closes #1806 