### PR TITLE
Trim dependencies of shelley-spec-ledger

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -102,8 +102,6 @@ library
     cborg,
     cborg-json,
     containers,
-    cryptonite,
-    hedgehog,
     iproute,
     mtl,
     network,
@@ -115,8 +113,4 @@ library
     stm,
     text,
     time,
-    transformers,
-    -- Added for clone of Core
-    bimap,
-    hashable,
-    goblins
+    transformers


### PR DESCRIPTION
In particular, this removes the accidental dependency on hedgehog.