### PR TITLE
Add Skeleton shelley-ma project.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,6 +12,7 @@ packages:
   shelley/chain-and-ledger/dependencies/non-integer
   shelley/chain-and-ledger/executable-spec
   shelley/chain-and-ledger/shelley-spec-ledger-test
+  shelley-ma/impl
 
 
 -- Always wrtie GHC env files, because they are needed by the doctests.

--- a/scripts/ormolise.sh
+++ b/scripts/ormolise.sh
@@ -3,6 +3,6 @@
 
 set -euo pipefail
 
-ormolu -c -m inplace $(git ls-files -- 'shelley/chain-and-ledger/executable-spec/*.hs' | grep -v Setup.hs)
+ormolu -c -m inplace $(git ls-files -- 'shelley/chain-and-ledger/executable-spec/*.hs' 'shelley-ma/impl/*.hs' | grep -v Setup.hs)
 
 git diff --exit-code

--- a/shelley-ma/impl/Setup.hs
+++ b/shelley-ma/impl/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -1,0 +1,30 @@
+cabal-version:       2.2
+
+name:                cardano-ledger-shelley-ma
+version:             0.1.0.0
+synopsis:            Shelley ledger with multiasset support.
+description:
+  This package extends the Shelley ledger with support for
+  native tokens.
+bug-reports:         https://github.com/input-output-hk/cardano-ledger-specs/issues
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+copyright:           2020 Input Output (Hong Kong) Ltd.
+category:            Network
+build-type:          Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+
+library
+  exposed-modules:
+    Cardano.Ledger.ShelleyMA
+  -- other-modules:
+  -- other-extensions:
+  build-depends:
+    base >=4.9 && <4.15,
+    shelley-spec-ledger
+  hs-source-dirs: src
+  default-language:    Haskell2010

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.ShelleyMA where
+
+import qualified Cardano.Ledger.Crypto
+import Cardano.Ledger.Era
+
+-- | The Shelley Multiasset era
+data ShelleyMA c
+
+instance Cardano.Ledger.Crypto.Crypto c => Era (ShelleyMA c) where
+  type Crypto (ShelleyMA c) = c


### PR DESCRIPTION
Purely a skeleton; provides nothing but the `Era` declaration.

Two bikeshedding decisions:
- We previously used `executable-spec`, but our specs are now are
implementation, and `impl` is shorter. So prefer that.
- I have reverted to the `Cardano.Ledger.Foo` naming scheme, which (to
me, at least!) makes a lot more sense than "Foo.Spec.Ledger".