### PR TITLE
Retire NonTrace tests, lift related STS Utxo(W) properties

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -115,11 +115,6 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Examples.Updates
       Test.Shelley.Spec.Ledger.Fees
       Test.Shelley.Spec.Ledger.MultiSigExamples
-      Test.Shelley.Spec.Ledger.NonTraceProperties.Generator
-      Test.Shelley.Spec.Ledger.NonTraceProperties.Mutator
-      Test.Shelley.Spec.Ledger.NonTraceProperties.PropertyTests
-      Test.Shelley.Spec.Ledger.NonTraceProperties.Serialization
-      Test.Shelley.Spec.Ledger.NonTraceProperties.Validity
       Test.Shelley.Spec.Ledger.PropertyTests
       Test.Shelley.Spec.Ledger.Rewards
       Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
@@ -136,6 +131,7 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Serialisation.Golden.Address
       Test.Shelley.Spec.Ledger.Serialisation.Golden.Encoding
       Test.Shelley.Spec.Ledger.Serialisation.Golden.Genesis
+      Test.Shelley.Spec.Ledger.Serialisation.StakeRef
       Test.Shelley.Spec.Ledger.Serialisation.Tripping.CBOR
       Test.Shelley.Spec.Ledger.Serialisation.Tripping.JSON
       Test.Shelley.Spec.Ledger.STSTests

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -9,6 +9,7 @@
 
 module Test.Shelley.Spec.Ledger.Generator.Block
   ( genBlock,
+    tickChainState,
   )
 where
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -11,26 +12,34 @@ module Test.Shelley.Spec.Ledger.Rules.TestChain
     removedAfterPoolreap,
     -- TestNewEpoch
     adaPreservationChain,
+    collisionFreeComplete,
   )
 where
 
+import qualified Cardano.Ledger.Val as Val
+import Control.Iterate.SetAlgebra (dom, domain, eval, (<|), (∩), (⊆))
 import Control.State.Transition.Extended (TRC (TRC))
 import Control.State.Transition.Trace
   ( SourceSignalTarget (..),
     Trace (..),
     sourceSignalTargets,
   )
+import qualified Control.State.Transition.Trace as Trace
 import Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
-import Data.Foldable (fold, foldl')
+import Data.Foldable (fold, foldl', toList)
+import qualified Data.Map.Strict as Map (isSubmapOf)
 import Data.Proxy
+import qualified Data.Set as Set (intersection, map, null)
 import Data.Word (Word64)
 import Shelley.Spec.Ledger.API
   ( CHAIN,
+    LEDGER,
     POOLREAP,
     TICK,
   )
 import Shelley.Spec.Ledger.BlockChain
-  ( Block (..),
+  ( BHeader (..),
+    Block (..),
     TxSeq (..),
     bbody,
     bhbody,
@@ -39,15 +48,17 @@ import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..), totalAda, totalAdaPots)
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
 import Shelley.Spec.Ledger.STS.Tick (TickEnv (TickEnv))
 import Shelley.Spec.Ledger.Tx
 import Shelley.Spec.Ledger.TxBody
-import qualified Cardano.Ledger.Val as Val
+import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern UTxO)
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( C,
   )
+import Test.Shelley.Spec.Ledger.Generator.Block (tickChainState)
 import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
@@ -73,74 +84,297 @@ traceLen = 100
 -- Properties for Chain
 ---------------------------------------------------------------------
 
+-- | Tx inputs are eliminated, outputs added to utxo and TxIds are unique
+collisionFreeComplete :: Property
+collisionFreeComplete =
+  forAllChainTrace traceLen $ \tr -> do
+    let ssts = sourceSignalTargets tr
+    conjoin . concat $
+      [ -- collision freeness
+        map eliminateTxInputs ssts,
+        map newEntriesAndUniqueTxIns ssts,
+        -- no double spend
+        map noDoubleSpend ssts
+      ]
+
+-- | Various preservation properties, tested on longer traces (double the
+-- default length)
 adaPreservationChain :: Property
 adaPreservationChain =
-  forAllChainTrace $ \tr -> do
+  forAllChainTrace (traceLen * 2) $ \tr -> do
     let ssts = sourceSignalTargets tr
-    conjoin $
-      [ conjoin (map checkPreservation ssts),
-        conjoin (map checkWithdrawlBound (filter sameEpoch ssts))
+        noEpochBoundarySsts = filter sameEpoch ssts
+
+    conjoin . concat $
+      [ -- preservation properties
+        map checkPreservation ssts,
+        map potsSumIncreaseWdrlsPerTx ssts,
+        map preserveBalance ssts,
+        map preserveBalanceRestricted ssts,
+        map preserveOutputsTx ssts,
+        -- non-epoch-boundary preservation properties
+        map checkWithdrawlBound noEpochBoundarySsts,
+        map utxoDepositsIncreaseByFeesWithdrawals noEpochBoundarySsts,
+        map potsSumIncreaseWdrlsPerBlock noEpochBoundarySsts
       ]
   where
     epoch s = nesEL . chainNes $ s
     sameEpoch :: SourceSignalTarget (CHAIN C) -> Bool
     sameEpoch (SourceSignalTarget {source, target}) =
       epoch source == epoch target
-    -- ADA should be preserved for all state transitions in the generated trace
-    checkPreservation SourceSignalTarget {source, signal, target} =
-      counterexample
-        ( mconcat
-            [ "source\n",
-              show source,
-              "\nsignal\n",
-              show signal,
-              "\ntarget\n",
-              show target,
-              "\nsource pots\n",
-              show sourcePots,
-              "\ntarget pots\n",
-              show targetPots
-            ]
+
+-- ADA should be preserved for all state transitions in the generated trace
+checkPreservation :: SourceSignalTarget (CHAIN C) -> Property
+checkPreservation SourceSignalTarget {source, signal, target} =
+  counterexample
+    ( mconcat
+        [ "source\n",
+          show source,
+          "\nsignal\n",
+          show signal,
+          "\ntarget\n",
+          show target,
+          "\nsource pots\n",
+          show sourcePots,
+          "\ntarget pots\n",
+          show targetPots
+        ]
+    )
+    $ totalAda source === totalAda target
+  where
+    sourcePots = totalAdaPots source
+    targetPots = totalAdaPots target
+
+-- If we are not at an Epoch Boundary (i.e. epoch source == epoch target)
+-- then the total rewards should change only by withdrawals
+checkWithdrawlBound :: SourceSignalTarget (CHAIN C) -> Property
+checkWithdrawlBound SourceSignalTarget {source, signal, target} =
+  rewardDelta === withdrawals signal
+  where
+    rewardDelta :: Coin
+    rewardDelta =
+      fold
+        ( _rewards . _dstate
+            . _delegationState
+            . esLState
+            . nesEs
+            . chainNes
+            $ source
         )
-        $ totalAda source === totalAda target
+        Val.~~ fold
+          ( _rewards . _dstate
+              . _delegationState
+              . esLState
+              . nesEs
+              . chainNes
+              $ target
+          )
+
+-- | If we are not at an Epoch Boundary , then (Utxo + Deposits)
+-- increases by Withdrawals min Fees (for all transactions in a block)
+utxoDepositsIncreaseByFeesWithdrawals :: SourceSignalTarget (CHAIN C) -> Property
+utxoDepositsIncreaseByFeesWithdrawals SourceSignalTarget {source, signal, target} =
+  circulation target Val.~~ circulation source
+    === withdrawals signal Val.~~ txFees signal
+  where
+    circulation chainSt =
+      let es = (nesEs . chainNes) chainSt
+          (UTxOState {_utxo = u, _deposited = d}) = (_utxoState . esLState) es
+       in balance u <> d
+
+-- | Reconstruct a LEDGER trace from the transactions in a Block and ChainState
+--
+-- NOTE: we need to tick the slot before processing transactions
+-- (in the same way that the CHAIN rule TICKs the slot before processing
+-- transactions with the LEDGERS rule)
+ledgerTraceFromBlock :: ChainState C -> Block C -> (ChainState C, Trace (LEDGER C))
+ledgerTraceFromBlock chainSt block =
+  ( tickedChainSt,
+    runShelleyBase $
+      Trace.closure @(LEDGER C) ledgerEnv ledgerSt0 (reverse txs) -- Oldest to Newest first
+  )
+  where
+    (Block (BHeader bhb _) txSeq) = block
+    slot = bheaderSlotNo bhb
+    tickedChainSt = tickChainState slot chainSt
+    nes = (nesEs . chainNes) tickedChainSt
+    pp_ = esPp nes
+    LedgerState utxoSt0 delegSt0 = esLState nes
+    ledgerEnv = LedgerEnv slot 0 pp_ (esAccountState nes)
+    ledgerSt0 = (utxoSt0, delegSt0)
+    txs = (toList . txSeqTxns') txSeq
+
+-- | If we are not at an Epoch Boundary , then (Utxo + Deposits + Fees)
+-- increases by sum of withdrawals for all transactions in a block
+potsSumIncreaseWdrlsPerBlock :: SourceSignalTarget (CHAIN C) -> Property
+potsSumIncreaseWdrlsPerBlock SourceSignalTarget {source, signal, target} =
+  potsSum target Val.~~ potsSum source === withdrawals signal
+  where
+    potsSum chainSt =
+      let (UTxOState {_utxo = u, _deposited = d, _fees = f}) =
+            _utxoState . esLState . nesEs . chainNes $ chainSt
+       in balance u <> d <> f
+
+-- | If we are not at an Epoch Boundary , then (Utxo + Deposits + Fees)
+-- increases by sum of withdrawals in a transaction
+potsSumIncreaseWdrlsPerTx :: SourceSignalTarget (CHAIN C) -> Property
+potsSumIncreaseWdrlsPerTx SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map sumIncreaseWdrls $
+      sourceSignalTargets ledgerTr
+  where
+    (_, ledgerTr) = ledgerTraceFromBlock chainSt block
+    sumIncreaseWdrls
+      SourceSignalTarget
+        { source = (UTxOState {_utxo = u, _deposited = d, _fees = f}, _),
+          signal = tx,
+          target = (UTxOState {_utxo = u', _deposited = d', _fees = f'}, _)
+        } =
+        (balance u' <> d' <> f') Val.~~ (balance u <> d <> f) === fold (unWdrl . _wdrls $ _body tx)
+
+-- | Preserve the balance in a transaction, i.e., the sum of the consumed value
+-- equals the sum of the created value.
+preserveBalance :: SourceSignalTarget (CHAIN C) -> Property
+preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map createdIsConsumed $
+      sourceSignalTargets ledgerTr
+  where
+    (tickedChainSt, ledgerTr) = ledgerTraceFromBlock chainSt block
+    pp_ = (esPp . nesEs . chainNes) tickedChainSt
+
+    createdIsConsumed SourceSignalTarget {source = ledgerSt, signal = tx, target = ledgerSt'} =
+      counterexample
+        ("preserveBalance created /= consumed ... " <> show created <> " /= " <> show consumed_)
+        (created === consumed_)
       where
-        sourcePots = totalAdaPots source
-        targetPots = totalAdaPots target
-    -- If we are not at an Epoch Boundary (i.e. epoch source == epoch target)
-    -- then the total rewards should change only by withdrawals
-    checkWithdrawlBound SourceSignalTarget {source, signal, target} =
-      rewardDelta === withdrawls
+        (UTxOState {_utxo = u}, dstate) = ledgerSt
+        (UTxOState {_utxo = u'}, _) = ledgerSt'
+        txb = _body tx
+        certs = toList . _certs $ txb
+        pools = _pParams . _pstate $ dstate
+        created =
+          balance u'
+            <> _txfee txb
+            <> totalDeposits pp_ pools certs
+        consumed_ =
+          balance u
+            <> keyRefunds pp_ txb
+            <> fold (unWdrl . _wdrls $ txb)
+
+-- | Preserve balance restricted to TxIns and TxOuts of the Tx
+preserveBalanceRestricted :: SourceSignalTarget (CHAIN C) -> Property
+preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map createdIsConsumed $
+      sourceSignalTargets ledgerTr
+  where
+    (tickedChainSt, ledgerTr) = ledgerTraceFromBlock chainSt block
+    pp_ = (esPp . nesEs . chainNes) tickedChainSt
+
+    createdIsConsumed SourceSignalTarget {source = (UTxOState {_utxo = u}, dstate), signal = tx} =
+      inps === outs
       where
-        withdrawls :: Coin
-        withdrawls =
-          foldl'
-            ( \c tx ->
-                let wdrls =
-                      unWdrl . _wdrls . _body $
-                        tx
-                 in c <> fold wdrls
+        txb = _body tx
+        pools = _pParams . _pstate $ dstate
+        inps =
+          balance (eval ((_inputs txb) <| u))
+            <> keyRefunds pp_ txb
+            <> fold (unWdrl . _wdrls $ txb)
+        outs =
+          let certs = toList (_certs txb)
+           in balance (txouts txb)
+                <> _txfee txb
+                <> totalDeposits pp_ pools certs
+
+preserveOutputsTx :: SourceSignalTarget (CHAIN C) -> Property
+preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map outputPreserved $
+      sourceSignalTargets ledgerTr
+  where
+    (_, ledgerTr) = ledgerTraceFromBlock chainSt block
+    outputPreserved SourceSignalTarget {target = (UTxOState {_utxo = (UTxO u')}, _), signal = tx} =
+      let UTxO outs = txouts (_body tx)
+       in property $
+            outs `Map.isSubmapOf` u'
+
+-- | Check that consumed inputs are eliminated from the resulting UTxO
+eliminateTxInputs :: SourceSignalTarget (CHAIN C) -> Property
+eliminateTxInputs SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map inputsEliminated $
+      sourceSignalTargets ledgerTr
+  where
+    (_, ledgerTr) = ledgerTraceFromBlock chainSt block
+    inputsEliminated SourceSignalTarget {target = (UTxOState {_utxo = (UTxO u')}, _), signal = tx} =
+      property $
+        Set.null $ eval (txins (_body tx) ∩ dom u')
+
+-- | Collision-Freeness of new TxIds - checks that all new outputs of a Tx are
+-- included in the new UTxO and that all TxIds are new.
+newEntriesAndUniqueTxIns :: SourceSignalTarget (CHAIN C) -> Property
+newEntriesAndUniqueTxIns SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map newEntryPresent $
+      sourceSignalTargets ledgerTr
+  where
+    (_, ledgerTr) = ledgerTraceFromBlock chainSt block
+    newEntryPresent
+      SourceSignalTarget
+        { source = (UTxOState {_utxo = (UTxO u)}, _),
+          signal = tx,
+          target = (UTxOState {_utxo = (UTxO u')}, _)
+        } =
+        let UTxO outs = txouts (_body tx)
+            outIds = Set.map (\(TxIn _id _) -> _id) (domain outs)
+            oldIds = Set.map (\(TxIn _id _) -> _id) (domain u)
+         in property $
+              null (outIds `Set.intersection` oldIds)
+                && eval ((dom outs) ⊆ (dom u'))
+
+--- | Check for absence of double spend in a block
+noDoubleSpend :: SourceSignalTarget (CHAIN C) -> Property
+noDoubleSpend SourceSignalTarget {signal} =
+  [] === getDoubleInputs txs
+  where
+    txs = toList $ (txSeqTxns' . bbody) signal
+
+    getDoubleInputs :: [Tx C] -> [(Tx C, [Tx C])]
+    getDoubleInputs [] = []
+    getDoubleInputs (t : ts) = lookForDoubleSpends t ts ++ getDoubleInputs ts
+    lookForDoubleSpends :: Tx C -> [Tx C] -> [(Tx C, [Tx C])]
+    lookForDoubleSpends _ [] = []
+    lookForDoubleSpends tx_j ts =
+      if null doubles then [] else [(tx_j, doubles)]
+      where
+        doubles =
+          filter
+            ( \tx_i ->
+                (not . Set.null)
+                  (inps_j `Set.intersection` _inputs (_body tx_i))
             )
-            (Coin 0)
-            $ txSeqTxns' . bbody $
-              signal
-        rewardDelta :: Coin
-        rewardDelta =
-          fold
-            ( _rewards . _dstate
-                . _delegationState
-                . esLState
-                . nesEs
-                . chainNes
-                $ source
-            )
-            Val.~~ fold
-              ( _rewards . _dstate
-                  . _delegationState
-                  . esLState
-                  . nesEs
-                  . chainNes
-                  $ target
-              )
+            ts
+        inps_j = _inputs $ _body tx_j
+
+withdrawals :: Block C -> Coin
+withdrawals block =
+  foldl'
+    ( \c tx ->
+        let wdrls =
+              unWdrl . _wdrls . _body $
+                tx
+         in c <> fold wdrls
+    )
+    (Coin 0)
+    $ (txSeqTxns' . bbody) block
+
+txFees :: Block C -> Coin
+txFees block =
+  foldl'
+    (\c tx -> c <> (_txfee . _body $ tx))
+    (Coin 0)
+    $ (txSeqTxns' . bbody) block
 
 ----------------------------------------------------------------------
 -- Properties for PoolReap (using the CHAIN Trace) --
@@ -148,19 +382,19 @@ adaPreservationChain =
 
 constantSumPots :: Property
 constantSumPots =
-  forAllChainTrace $ \tr ->
+  forAllChainTrace traceLen $ \tr ->
     let sst = map chainToPoolreapSst (sourceSignalTargets tr)
      in TestPoolreap.constantSumPots sst
 
 nonNegativeDeposits :: Property
 nonNegativeDeposits =
-  forAllChainTrace $ \tr ->
+  forAllChainTrace traceLen $ \tr ->
     let sst = map chainToPoolreapSst (sourceSignalTargets tr)
      in TestPoolreap.nonNegativeDeposits sst
 
 removedAfterPoolreap :: Property
 removedAfterPoolreap =
-  forAllChainTrace $ \tr ->
+  forAllChainTrace traceLen $ \tr ->
     let ssts = map chainToPoolreapSst (chainSstWithTick tr)
      in TestPoolreap.removedAfterPoolreap ssts
 
@@ -170,11 +404,12 @@ removedAfterPoolreap =
 
 forAllChainTrace ::
   (Testable prop) =>
+  Word64 -> -- trace length
   (Trace (CHAIN C) -> prop) ->
   Property
-forAllChainTrace prop =
+forAllChainTrace n prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
-    forAllTraceFromInitState testGlobals traceLen (Preset.genEnv p) (Just $ mkGenesisChainState (geConstants (Preset.genEnv p))) prop
+    forAllTraceFromInitState testGlobals n (Preset.genEnv p) (Just $ mkGenesisChainState (geConstants (Preset.genEnv p))) prop
   where
     p :: Proxy C
     p = Proxy

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
@@ -7,57 +7,28 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestUtxow
-  ( preserveBalance,
-    preserveBalanceRestricted,
-    preserveOutputsTx,
-    eliminateTxInputs,
-    newEntriesAndUniqueTxIns,
-    noDoubleSpend,
-    requiredMSigSignaturesSubset,
+  ( requiredMSigSignaturesSubset,
   )
 where
 
-import Control.Iterate.SetAlgebra (dom, domain, eval, (<|), (∩), (⊆))
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,
-    source,
-    target,
-    pattern SourceSignalTarget,
   )
-import Data.Foldable (toList)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map (isSubmapOf)
-import qualified Data.Set as Set (fromList, intersection, isSubsetOf, map, null)
+import qualified Data.Set as Set (fromList, isSubsetOf, map)
 import Shelley.Spec.Ledger.API
-  ( UTXO,
-    UTXOW,
+  ( UTXOW,
   )
-import Shelley.Spec.Ledger.Keys
-  ( KeyHash (..),
-    KeyRole (..),
-  )
-import Shelley.Spec.Ledger.LedgerState (keyRefunds, pattern UTxOState)
-import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.Tx
-  ( Tx,
-    addrWits,
+  ( addrWits,
     getKeyCombinations,
     msigWits,
-    _body,
     _witnessSet,
   )
 import Shelley.Spec.Ledger.TxBody
-  ( PoolParams (..),
-    TxIn (..),
-    witKeyHash,
-    _certs,
-    _inputs,
-    _txfee,
+  ( witKeyHash,
   )
-import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern UTxO)
-import qualified Cardano.Ledger.Val as Val
-import Test.QuickCheck (Property, conjoin, (===))
+import Test.QuickCheck (Property, conjoin)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( C,
   )
@@ -65,143 +36,6 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 --------------------------
 -- Properties for UTXOW --
 --------------------------
-
--- | Preserve the balance in a transaction, i.e., the sum of the consumed value
--- equals the sum of the created value.
-preserveBalance ::
-  PParams ->
-  [ ( Map (KeyHash 'StakePool C) (PoolParams C),
-      SourceSignalTarget (UTXOW C)
-    )
-  ] ->
-  Property
-preserveBalance pp tr =
-  conjoin $
-    map createdIsConsumed tr
-  where
-    createdIsConsumed
-      ( stp,
-        SourceSignalTarget
-          { source = UTxOState u _ _ _,
-            signal = tx,
-            target = UTxOState u' _ _ _
-          }
-        ) =
-        created u' stp tx == consumed u tx
-    created u stp_ tx =
-      balance u
-        <> _txfee (_body tx)
-        <> totalDeposits pp stp_ (toList $ _certs $ _body tx)
-    consumed u tx =
-      balance u
-        <> keyRefunds pp (_body tx)
-
--- | Preserve balance restricted to TxIns and TxOuts of the Tx
-preserveBalanceRestricted ::
-  PParams ->
-  [ ( Map (KeyHash 'StakePool C) (PoolParams C),
-      SourceSignalTarget (UTXOW C)
-    )
-  ] ->
-  Property
-preserveBalanceRestricted pp tr =
-  conjoin $
-    map createdIsConsumed tr
-  where
-    createdIsConsumed
-      ( stp,
-        SourceSignalTarget
-          { source = UTxOState u _ _ _,
-            signal = tx,
-            target = UTxOState _ _ _ _
-          }
-        ) =
-        inps u tx == outs stp (_body tx)
-    inps u tx = balance $ eval ((_inputs $ _body tx) <| u)
-    outs stp_ tx =
-      balance (txouts tx)
-        <> _txfee tx
-        <> depositChange stp_ (toList $ _certs tx) tx
-    depositChange stp_ certs txb =
-      totalDeposits pp stp_ certs
-        Val.~~ (keyRefunds pp txb)
-
--- | Preserve outputs of Txs
-preserveOutputsTx ::
-  [SourceSignalTarget (UTXO C)] ->
-  Property
-preserveOutputsTx tr =
-  conjoin $
-    map outputPreserved tr
-  where
-    outputPreserved
-      SourceSignalTarget
-        { signal = tx,
-          target = UTxOState (UTxO utxo') _ _ _
-        } =
-        let UTxO outs = txouts (_body tx)
-         in outs `Map.isSubmapOf` utxo'
-
--- | Check that consumed inputs are eliminated from the resulting UTxO
-eliminateTxInputs ::
-  [SourceSignalTarget (UTXO C)] ->
-  Property
-eliminateTxInputs tr =
-  conjoin $
-    map inputsEliminated tr
-  where
-    inputsEliminated
-      SourceSignalTarget
-        { signal = tx,
-          target = UTxOState (UTxO utxo') _ _ _
-        } =
-        Set.null $ eval (txins (_body tx) ∩ dom utxo')
-
--- | Check that all new entries of a Tx are included in the new UTxO and that
--- all TxIds are new.
-newEntriesAndUniqueTxIns ::
-  [SourceSignalTarget (UTXO C)] ->
-  Property
-newEntriesAndUniqueTxIns tr =
-  conjoin $
-    map newEntryPresent tr
-  where
-    newEntryPresent
-      SourceSignalTarget
-        { source = (UTxOState (UTxO utxo) _ _ _),
-          signal = tx,
-          target = (UTxOState (UTxO utxo') _ _ _)
-        } =
-        let UTxO outs = txouts (_body tx)
-            outIds = Set.map (\(TxIn _id _) -> _id) (domain outs)
-            oldIds = Set.map (\(TxIn _id _) -> _id) (domain utxo)
-         in null (outIds `Set.intersection` oldIds)
-              && eval ((dom outs) ⊆ (dom utxo'))
-
--- | Check for absence of double spend
-noDoubleSpend ::
-  [SourceSignalTarget (UTXO C)] ->
-  Property
-noDoubleSpend tr =
-  [] === getDoubleInputs (map sig tr)
-  where
-    sig (SourceSignalTarget _ _ s) = s
-    getDoubleInputs :: [Tx C] -> [(Tx C, [Tx C])]
-    getDoubleInputs [] = []
-    getDoubleInputs (t : ts) = lookForDoubleSpends t ts ++ getDoubleInputs ts
-    lookForDoubleSpends :: Tx C -> [Tx C] -> [(Tx C, [Tx C])]
-    lookForDoubleSpends _ [] = []
-    lookForDoubleSpends tx_j ts =
-      if null doubles then [] else [(tx_j, doubles)]
-      where
-        doubles =
-          filter
-            ( \tx_i ->
-                (not . Set.null)
-                  (inps_j `Set.intersection` _inputs (_body tx_i))
-            )
-            ts
-        inps_j = _inputs $ _body tx_j
 
 -- | Check for required signatures in case of Multi-Sig. There has to be one set
 -- of possible signatures for a multi-sig script which is a sub-set of the

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/StakeRef.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/StakeRef.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Shelley.Spec.Ledger.NonTraceProperties.Serialization where
+module Test.Shelley.Spec.Ledger.Serialisation.StakeRef where
 
 import qualified Data.ByteString.Short as SBS
 import Shelley.Spec.Ledger.Address (Addr (..), deserialiseAddrStakeRef, serialiseAddr)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
-import Test.Shelley.Spec.Ledger.NonTraceProperties.PropertyTests (nonTracePropertyTests)
 import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Shelley.Spec.Ledger.Rewards (rewardTests)
 import Test.Shelley.Spec.Ledger.STSTests (chainExamples)
@@ -34,7 +33,6 @@ nightlyTests =
   testGroup
     "Ledger with Delegation nightly"
     [ propertyTests,
-      nonTracePropertyTests,
       Serialisation.tests 50
     ]
 


### PR DESCRIPTION
… from Ledger to Chain level.

Closes #880 

The NonTrace tests (using lower resolution generators) are replaced by existing TestUtxo/W tests (based on Ledger Traces).

As a further piece of technical debt, this PR 

* lifts the TestUtxo/W properties from LEDGER to CHAIN trace level - this is important because some coin Pots only change at Epoch Boundary - a property can hold trivially true at Ledger level
* Further work: similar "lifting" needs to be done for some properties in TestPOOL/Ledger/PoolReap
* TestUtxo/W properties lifted to Chain are mainly grouped into a single preservation property - this is an experiment in running more properties on longer (expensive) traces

NonTrace properties mapped to TestChain

* propBalanceTxInTxOut -> preserveBalanceRestricted
* propPreserveOutputs -> propPreserveOutputs
* propEliminateInputs -> eliminateTxInputs
* propNoDoubleSpend -> noDoubleSpend
* propUniqueTxIds -> newEntriesAndUniqueTxIns + preserveOutputsTx

NonTrace properties discarded

* propPositiveBalance (this is defunct since `minUtxo`)
* propNonNegativeTxOuts (also defunct)
* classifyInvalidDoubleSpend (property of an old generator)

Perhaps worth saving reviving as examples?

* propCheckRedundantWitnessSet - redundant witnesses in a Tx are valid 
* propCheckMissingWitness - missing witnesses raise a `MissingWitness` predicate fail
