### PR TITLE
Parametrise the Shelley ledger over Value.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -18,8 +18,11 @@ flag development
 
 library
   exposed-modules:
+    Cardano.Ledger.Core
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Val
     Shelley.Spec.Ledger.Address
     Shelley.Spec.Ledger.Address.Bootstrap
     Shelley.Spec.Ledger.API
@@ -75,7 +78,6 @@ library
     Shelley.Spec.Ledger.Tx
     Shelley.Spec.Ledger.TxBody
     Shelley.Spec.Ledger.UTxO
-    Cardano.Ledger.Val
   other-modules:     Shelley.Spec.Ledger.API.Mempool
                      Shelley.Spec.Ledger.API.Wallet
                      Shelley.Spec.Ledger.API.Types

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module defines core type families which we know to vary from era to
+-- era.
+--
+-- Families in this module should be indexed on era.
+--
+-- It is intended for qualified import:
+-- > import qualified Cardano.Ledger.Core as Core
+module Cardano.Ledger.Core
+  ( Value,
+
+    -- * Compactible
+    Compactible (..),
+  )
+where
+
+import Data.Kind (Type)
+
+-- | A value is something which quantifies a transaction output.
+type family Value era :: Type
+
+--------------------------------------------------------------------------------
+
+-- * Compactible
+
+--
+-- Certain types may have a "presentation" form and a more compact
+-- representation that allows for more efficient memory usage. In this case,
+-- one should make instances of the 'Compactible' class for them.
+--------------------------------------------------------------------------------
+
+class Compactible a where
+  type CompactForm a :: Type
+  toCompact :: a -> CompactForm a
+  fromCompact :: CompactForm a -> a

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Shelley where
 
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
-import Shelley.Spec.Ledger.Coin
 
 --------------------------------------------------------------------------------
 -- Shelley Era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Interface to the Shelley ledger for the purposes of managing a Shelley
 -- mempool.
@@ -19,6 +23,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Era
+import Cardano.Ledger.Shelley (Shelley)
 import Control.Arrow (left)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -77,23 +82,31 @@ mkMempoolState LedgerState.NewEpochState {LedgerState.nesEs} =
   LedgerState.esLState nesEs
 
 data ApplyTxError era = ApplyTxError [PredicateFailure (LEDGERS era)]
-  deriving (Eq, Show)
+
+deriving stock instance
+  (Eq (PredicateFailure (LEDGERS era))) =>
+  Eq (ApplyTxError era)
+
+deriving stock instance
+  (Show (PredicateFailure (LEDGERS era))) =>
+  Show (ApplyTxError era)
 
 instance
-  (Typeable era, Era era) =>
+  (Typeable era, Era era, era ~ Shelley c) =>
   ToCBOR (ApplyTxError era)
   where
   toCBOR (ApplyTxError es) = toCBOR es
 
 instance
-  (Era era) =>
+  (Era era, era ~ Shelley c) =>
   FromCBOR (ApplyTxError era)
   where
   fromCBOR = ApplyTxError <$> fromCBOR
 
 applyTxs ::
-  forall era m.
+  forall era m c.
   ( Era era,
+    era ~ Shelley c,
     MonadError (ApplyTxError era) m,
     DSignable era (Hash era (Tx.TxBody era))
   ) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Hashing
 import Cardano.Ledger.Crypto (ADDRHASH)
 import Cardano.Ledger.Era
+import Cardano.Ledger.Shelley (Shelley)
 import qualified Cardano.Ledger.Val as Val
 import Control.Monad.Reader (runReader)
 import qualified Data.ByteString.Short as SBS
@@ -58,7 +59,7 @@ hashFromShortBytesE sbs = fromMaybe (error msg) $ Crypto.hashFromBytesShort sbs
       "hashFromBytesShort called with ShortByteString of the wrong length: "
         <> show sbs
 
-translateCompactTxOutByronToShelley :: Byron.CompactTxOut -> TxOut era
+translateCompactTxOutByronToShelley :: Byron.CompactTxOut -> TxOut (Shelley c)
 translateCompactTxOutByronToShelley (Byron.CompactTxOut compactAddr amount) =
   TxOutCompact
     (Byron.unsafeGetCompactAddress compactAddr)
@@ -74,8 +75,8 @@ translateCompactTxInByronToShelley (Byron.CompactTxInUtxo compactTxId idx) =
     (fromIntegral idx)
 
 translateUTxOByronToShelley ::
-  forall era.
-  (Era era, ADDRHASH (Crypto era) ~ Crypto.Blake2b_224) =>
+  forall era c.
+  (Era era, era ~ Shelley c, ADDRHASH (Crypto era) ~ Crypto.Blake2b_224) =>
   Byron.UTxO ->
   UTxO era
 translateUTxOByronToShelley (Byron.UTxO utxoByron) =
@@ -88,8 +89,8 @@ translateUTxOByronToShelley (Byron.UTxO utxoByron) =
       ]
 
 translateToShelleyLedgerState ::
-  forall era.
-  (Era era, ADDRHASH (Crypto era) ~ Crypto.Blake2b_224) =>
+  forall era c.
+  (Era era, era ~ Shelley c, ADDRHASH (Crypto era) ~ Crypto.Blake2b_224) =>
   ShelleyGenesis era ->
   Globals ->
   EpochNo ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.Coin
   ( Coin (..),
@@ -12,6 +13,7 @@ module Shelley.Spec.Ledger.Coin
 where
 
 import Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..), cborError)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Group (Abelian, Group (..))
@@ -62,3 +64,8 @@ instance FromCBOR Coin where
     if isValidCoinValue c
       then pure (Coin c)
       else cborError $ DecoderErrorCustom "Invalid Coin Value" (pack $ show c)
+
+instance Core.Compactible Coin where
+  type CompactForm Coin = Word64
+  toCompact = fromIntegral . unCoin
+  fromCompact = word64ToCoin

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Module      : EpochBoundary
@@ -27,6 +30,7 @@ module Shelley.Spec.Ledger.EpochBoundary
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (NFData, NoUnexpectedThunks (..))
@@ -42,7 +46,6 @@ import Shelley.Spec.Ledger.Coin
   ( Coin (..),
     coinToRational,
     rationalToCoinViaFloor,
-    word64ToCoin,
   )
 import Shelley.Spec.Ledger.Credential (Credential, Ptr, StakeReference (..))
 import Shelley.Spec.Ledger.DeserializeShort (deserialiseAddrStakeRef)
@@ -78,7 +81,11 @@ newtype Stake era = Stake
 
 -- | Sum up all the Coin for each staking Credential
 aggregateUtxoCoinByCredential ::
-  Era era =>
+  forall era.
+  ( Era era,
+    Val.Val (Core.Value era),
+    Core.Compactible (Core.Value era)
+  ) =>
   Map Ptr (Credential 'Staking era) ->
   UTxO era ->
   Map (Credential 'Staking era) Coin ->
@@ -86,12 +93,14 @@ aggregateUtxoCoinByCredential ::
 aggregateUtxoCoinByCredential ptrs (UTxO u) initial =
   Map.foldr accum initial u
   where
-    accum (TxOutCompact addr c) ans = case deserialiseAddrStakeRef addr of
-      Just (StakeRefPtr p) -> case Map.lookup p ptrs of
-        Just cred -> Map.insertWith (<>) cred (word64ToCoin c) ans
-        Nothing -> ans
-      Just (StakeRefBase hk) -> Map.insertWith (<>) hk (word64ToCoin c) ans
-      _other -> ans
+    accum (TxOutCompact addr c) ans =
+      let c' = Val.coin . Core.fromCompact @(Core.Value era) $ c
+       in case deserialiseAddrStakeRef addr of
+            Just (StakeRefPtr p) -> case Map.lookup p ptrs of
+              Just cred -> Map.insertWith (<>) cred c' ans
+              Nothing -> ans
+            Just (StakeRefBase hk) -> Map.insertWith (<>) hk c' ans
+            _other -> ans
 
 -- | Get stake of one pool
 poolStake ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.Genesis
@@ -27,6 +28,7 @@ where
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.KES.Class (totalPeriodsKES)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH, KES)
 import Cardano.Ledger.Era
 import Cardano.Prelude (NoUnexpectedThunks, forceElemsToWHNF)
@@ -188,7 +190,10 @@ instance Era era => FromJSON (ShelleyGenesisStaking era) where
   Genesis UTxO
 -------------------------------------------------------------------------------}
 
-genesisUtxO :: Era era => ShelleyGenesis era -> UTxO era
+genesisUtxO ::
+  (Era era, Core.Value era ~ Coin) =>
+  ShelleyGenesis era ->
+  UTxO era
 genesisUtxO genesis =
   UTxO $
     Map.fromList

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -18,7 +20,10 @@ module Shelley.Spec.Ledger.STS.Bbody
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.State.Transition
   ( Embed (..),
@@ -62,7 +67,10 @@ data BBODY era
 
 data BbodyState era
   = BbodyState (LedgerState era) (BlocksMade era)
-  deriving (Eq, Show)
+
+deriving stock instance
+  (Era era, Core.Compactible (Core.Value era), Show (Core.Value era)) =>
+  Show (BbodyState era)
 
 data BbodyEnv era = BbodyEnv
   { bbodySlots :: OverlaySchedule era,
@@ -78,10 +86,15 @@ data BbodyPredicateFailure era
       !(HashBBody era) -- Actual Hash
       !(HashBBody era) -- Claimed Hash
   | LedgersFailure (PredicateFailure (LEDGERS era)) -- Subtransition Failures
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
+
+deriving stock instance Crypto c => Show (BbodyPredicateFailure (Shelley c))
+
+deriving stock instance Crypto c => Eq (BbodyPredicateFailure (Shelley c))
 
 instance
   ( Era era,
+    era ~ Shelley c,
     DSignable era (Hash era (TxBody era))
   ) =>
   STS (BBODY era)
@@ -103,11 +116,12 @@ instance
   initialRules = []
   transitionRules = [bbodyTransition]
 
-instance (Era era) => NoUnexpectedThunks (BbodyPredicateFailure era)
+instance (Crypto c) => NoUnexpectedThunks (BbodyPredicateFailure (Shelley c))
 
 bbodyTransition ::
-  forall era.
+  forall era c.
   ( Era era,
+    era ~ Shelley c,
     DSignable era (Hash era (TxBody era))
   ) =>
   TransitionRule (BBODY era)
@@ -140,6 +154,7 @@ bbodyTransition =
 
 instance
   ( Era era,
+    era ~ Shelley c,
     DSignable era (Hash era (TxBody era))
   ) =>
   Embed (LEDGERS era) (BBODY era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.PoolReap
   ( POOLREAP,
@@ -11,6 +15,8 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (NoUnexpectedThunks (..))
 import Control.Iterate.SetAlgebra (dom, eval, (∈), (∪+), (⋪), (⋫), (▷), (◁))
@@ -50,7 +56,13 @@ data PoolreapState era = PoolreapState
     prDState :: DState era,
     prPState :: PState era
   }
-  deriving (Show, Eq)
+
+deriving stock instance
+  ( Era era,
+    Core.Compactible (Core.Value era),
+    Show (Core.Value era)
+  ) =>
+  Show (PoolreapState era)
 
 data PoolreapPredicateFailure era -- No predicate Falures
   deriving (Show, Eq, Generic)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -14,6 +15,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.Tx
   ( -- transaction
@@ -66,6 +68,7 @@ import Cardano.Binary
     serializeEncoding,
     withSlice,
   )
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era
 import Cardano.Prelude
   ( AllowThunksIn (..),
@@ -184,13 +187,20 @@ data Tx era = Tx'
     _metadata' :: !(StrictMaybe MetaData),
     txFullBytes :: LByteString
   }
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
   deriving
     (NoUnexpectedThunks)
     via AllowThunksIn
           '[ "txFullBytes"
            ]
           (Tx era)
+
+deriving instance
+  ( Era era,
+    Core.Compactible (Core.Value era),
+    Show (Core.Value era)
+  ) =>
+  Show (Tx era)
 
 pattern Tx ::
   Era era =>
@@ -291,7 +301,10 @@ instance
   where
   toCBOR tx = encodePreEncoded . BSL.toStrict $ txFullBytes tx
 
-instance Era era => FromCBOR (Annotator (Tx era)) where
+instance
+  (Era era, FromCBOR (Core.CompactForm (Core.Value era))) =>
+  FromCBOR (Annotator (Tx era))
+  where
   fromCBOR = annotatorSlice $
     decodeRecordNamed "Tx" (const 3) $ do
       body <- fromCBOR


### PR DESCRIPTION
This PR demonstrates a way to parametrise the ledger over value. It
paves the way for overriding this type in subsequent eras, without
making any semantic changes to the Shelley ledger.

Functions in the ledger are now classfied into three groups:
- Those that remain universally quantified over eras.
- Those that have specific requirements on certain era-parametrised
types to work (e.g. that they can be serialised), and
- Those that are specific to Shelley.

There are two examples of the latter: `consumed` and `produced`.

The STS rules are likewise split in two:
- Those that remain universally quantified over eras.
- Those that are specific to Shelley.

The intention is that many will transition to the third (missing)
category, where the actual rules specify their exact requirements on the
era (see #1804 for an example of how to do this). This was not done
because I wanted to get this ready for the meeting and I didn't have
time.

This PR makes some very deliberate design choices:
- The 'Value' type family and any constraints thereon are _not_ lifted
into the 'Era' class. Such would imply universality over eras, which is
too strong a constraint. They would prevent us, for example, from adding to
the `Val` class in future eras, which seems quite plausible.
Furthermore, having more explicit constraints at the use site helps our
understanding of the code; it is much more obvious _when_ we are relying
on certain things, which can be a tool to spot bugs. Note that these
constraints do not propogate wildly, because in general they are
dispatched through the instantiation of the type family to a specific
type in a given era.
- It deliberately removes some instances (`Eq` for example) where it
seems there is no strong reason to have it. The presence of an `Eq`
instance everywhere has bitten us in the past, where for example we have
ended up calling `(==)` on a large part of state in the consensus
integration, which is an expensive operation. Honestly, I suspect I'll
have to add these back to get the tests working, since they rely on
them, but I think there's a decent case for making these instances
orphans in the testing code instead.

This is a *draft* PR for discussion. It does not yet touch the testing
code, and is inconsistent about various things (in particular, I stuck
`era ~ Shelley c` in a lot of places in a hurry).