### PR TITLE
Expose hidden Cardano.Ledger.Shelley module

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -20,6 +20,7 @@ library
   exposed-modules:
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
+    Cardano.Ledger.Shelley
     Shelley.Spec.Ledger.Address
     Shelley.Spec.Ledger.Address.Bootstrap
     Shelley.Spec.Ledger.API

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Shelley where
 
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
-import Shelley.Spec.Ledger.Coin
 
 --------------------------------------------------------------------------------
 -- Shelley Era


### PR DESCRIPTION
In the following commit:

    commit 56a63a591860282ca0faf60071e5d25891ef5aa8
    Author: polinavino <polina.vino@gmail.com>
    Date:   Fri Sep 4 10:30:00 2020 -0400

        Generalise deposit calculation (#1834)

        Also move `splitCoin` into the tests, which are the only place it's used.

The `Shelley` era tag was moved from `Shelley.Spec.Ledger.BaseTypes` to the new
`Cardano.Ledger.Shelley` module, without adding the new module to the list of
`exposed-modules`. Since consensus and the node rely on this `Shelley` era tag,
this breaks our build.

Expose the new module and remove a redundant import in it.