### PR TITLE
replace overlay schedule with arithmetic checks

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -64,7 +64,6 @@ import Shelley.Spec.Ledger.LedgerState as X
     EpochState (..),
     KeyPairs,
     LedgerState (..),
-    NewEpochEnv (..),
     NewEpochState (..),
     PState (..),
     RewardUpdate (..),
@@ -95,7 +94,7 @@ import Shelley.Spec.Ledger.STS.Ocert as X (OCertEnv (..))
 import Shelley.Spec.Ledger.STS.Pool as X (POOL, PoolEnv (..))
 import Shelley.Spec.Ledger.STS.PoolReap as X (POOLREAP)
 import Shelley.Spec.Ledger.STS.Ppup as X (PPUP, PPUPEnv (..))
-import Shelley.Spec.Ledger.STS.Tick as X (TICK, TickEnv (..))
+import Shelley.Spec.Ledger.STS.Tick as X (TICK)
 import Shelley.Spec.Ledger.STS.Utxo as X (UTXO, UtxoEnv (..))
 import Shelley.Spec.Ledger.STS.Utxow as X (UTXOW)
 import Shelley.Spec.Ledger.Scripts as X

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -54,22 +54,15 @@ chainChecks globals pp bh = STS.chainChecks (maxMajorPV globals) pp bh
   Applying blocks
 -------------------------------------------------------------------------------}
 
-mkTickEnv ::
-  ShelleyState era ->
-  STS.TickEnv era
-mkTickEnv = STS.TickEnv . LedgerState.getGKeys
-
 mkBbodyEnv ::
   ShelleyState era ->
   STS.BbodyEnv era
 mkBbodyEnv
   LedgerState.NewEpochState
-    { LedgerState.nesOsched,
-      LedgerState.nesEs
+    { LedgerState.nesEs
     } =
     STS.BbodyEnv
-      { STS.bbodySlots = nesOsched,
-        STS.bbodyPp = LedgerState.esPp nesEs,
+      { STS.bbodyPp = LedgerState.esPp nesEs,
         STS.bbodyAccount = LedgerState.esAccountState nesEs
       }
 
@@ -93,7 +86,7 @@ applyTickTransition ::
 applyTickTransition globals state hdr =
   (either err id) . flip runReader globals
     . applySTS @(STS.TICK era)
-    $ TRC (mkTickEnv state, state, hdr)
+    $ TRC ((), state, hdr)
   where
     err :: Show a => a -> b
     err msg = error $ "Panic! applyHeaderTransition failed: " <> (show msg)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
@@ -6,19 +6,15 @@
 
 module Shelley.Spec.Ledger.OverlaySchedule
   ( -- * Overlay schedule
-    OverlaySchedule,
-    compactOverlaySchedule,
-    decompactOverlaySchedule,
-    emptyOverlaySchedule,
     isOverlaySlot,
+    classifyOverlaySlot,
     lookupInOverlaySchedule,
-    overlaySchedule,
-    overlayScheduleHelper,
-    overlayScheduleIsEmpty,
-    overlayScheduleToMap,
 
     -- * OBftSlot
     OBftSlot (..),
+
+    -- * Testing
+    overlaySlots,
   )
 where
 
@@ -33,20 +29,12 @@ import Cardano.Binary
 import Cardano.Ledger.Era (Era)
 import Cardano.Prelude (NFData, NoUnexpectedThunks)
 import Cardano.Slotting.Slot
-import Control.Monad.Trans.Reader (asks)
-import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import Data.Set (Set)
-import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Keys
   ( KeyHash (..),
     KeyRole (..),
   )
-import Shelley.Spec.Ledger.PParams (PParams, _d)
 import Shelley.Spec.Ledger.Slot
 
 data OBftSlot era
@@ -76,109 +64,62 @@ instance NoUnexpectedThunks (OBftSlot era)
 
 instance NFData (OBftSlot era)
 
-newtype OverlaySchedule era = OverlaySchedule (Map SlotNo (OBftSlot era))
-  deriving stock (Show, Eq)
-  deriving newtype (NoUnexpectedThunks, NFData)
+isOverlaySlot ::
+  SlotNo -> -- starting slot
+  UnitInterval -> -- decentralization parameter
+  SlotNo -> -- slot to check
+  Bool
+isOverlaySlot firstSlotNo dval slot = step s < step (s + 1)
+  where
+    s = fromIntegral $ slot -* firstSlotNo
+    d = unitIntervalToRational dval
+    step :: Rational -> Integer
+    step x = ceiling (x * d)
 
-emptyOverlaySchedule :: OverlaySchedule era
-emptyOverlaySchedule = OverlaySchedule Map.empty
+classifyOverlaySlot ::
+  SlotNo -> -- first slot of the epoch
+  [KeyHash 'Genesis era] -> -- genesis Nodes
+  UnitInterval -> -- decentralization parameter
+  ActiveSlotCoeff -> -- active slot coefficent
+  SlotNo -> -- overlay slot to classify
+  OBftSlot era
+classifyOverlaySlot firstSlotNo gkeys dval ascValue slot =
+  if isActive
+    then
+      let genesisIdx = (position `div` ascInv) `mod` (fromIntegral $ length gkeys)
+       in gkeys `getAtIndex` genesisIdx
+    else NonActiveSlot
+  where
+    d = unitIntervalToRational dval
+    position = ceiling (fromIntegral (slot -* firstSlotNo) * d)
+    isActive = position `mod` ascInv == 0
+    getAtIndex ls i = if i < length ls then ActiveSlot (ls !! i) else NonActiveSlot
+    ascInv = floor (1 / (unitIntervalToRational . activeSlotVal $ ascValue))
 
 lookupInOverlaySchedule ::
-  SlotNo ->
-  OverlaySchedule era ->
+  SlotNo -> -- first slot of the epoch
+  [KeyHash 'Genesis era] -> -- genesis Nodes
+  UnitInterval -> -- decentralization parameter
+  ActiveSlotCoeff -> -- active slot coefficent
+  SlotNo -> -- slot to lookup
   Maybe (OBftSlot era)
-lookupInOverlaySchedule slot (OverlaySchedule oSched) = Map.lookup slot oSched
+lookupInOverlaySchedule firstSlotNo gkeys dval ascValue slot =
+  if isOverlaySlot firstSlotNo dval slot
+    then Just $ classifyOverlaySlot firstSlotNo gkeys dval ascValue slot
+    else Nothing
 
-overlayScheduleIsEmpty :: OverlaySchedule era -> Bool
-overlayScheduleIsEmpty (OverlaySchedule oSched) = Map.null oSched
-
--- | Overlay schedule
--- This is just a very simple round-robin, evenly spaced schedule.
-overlaySchedule ::
-  EpochNo ->
-  Set (KeyHash 'Genesis era) ->
-  PParams era ->
-  ShelleyBase (OverlaySchedule era)
-overlaySchedule e gkeys pp = do
-  ei <- asks epochInfo
-  slotsPerEpoch <- epochInfoSize ei e
-  firstSlotNo <- epochInfoFirst ei e
-  asc <- asks activeSlotCoeff
-  pure $ overlayScheduleHelper slotsPerEpoch firstSlotNo gkeys (_d pp) asc
-
-overlayScheduleHelper ::
+-- | Return the list of overlaySlots for a given epoch.
+-- Note that this linear in the size of the epoch, and should probably
+-- only be used for testing.
+-- If something more performant is needed, we could probably use
+-- [start + floor(x/d) | x <- [0 .. (spe -1)], floor(x/d) < spe]
+-- but we would need to make sure that this is equivalent.
+overlaySlots ::
+  SlotNo -> -- starting slot
+  UnitInterval -> -- decentralization parameter
   EpochSize ->
-  -- | First slot of the epoch
-  SlotNo ->
-  Set (KeyHash 'Genesis era) ->
-  -- | Decentralization parameter @d@
-  UnitInterval ->
-  ActiveSlotCoeff ->
-  OverlaySchedule era
-overlayScheduleHelper slotsPerEpoch firstSlotNo gkeys d asc
-  | dval == 0 =
-    OverlaySchedule $ Map.empty
-  | otherwise =
-    OverlaySchedule $ Map.union active inactive
+  [SlotNo]
+overlaySlots start d (EpochSize spe) =
+  [SlotNo x | x <- [unSlotNo start .. end], isOverlaySlot start d (SlotNo x)]
   where
-    dval = intervalValue d
-    numActive = dval * fromIntegral slotsPerEpoch
-    dInv = 1 / dval
-    ascValue = (intervalValue . activeSlotVal) asc
-    toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
-    toSlotNo x = firstSlotNo +* toRelativeSlotNo x
-    genesisSlots = [toSlotNo x | x <- [0 .. (floor numActive - 1)]]
-    numInactivePerActive = floor (1 / ascValue) - 1
-    activitySchedule = cycle (True : replicate numInactivePerActive False)
-    unassignedSched = zip activitySchedule genesisSlots
-    genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
-    active =
-      Map.fromList $
-        fmap
-          (\(gk, (_, s)) -> (s, ActiveSlot gk))
-          (zip genesisCycle (filter fst unassignedSched))
-    inactive =
-      Map.fromList $
-        fmap
-          (\x -> (snd x, NonActiveSlot))
-          (filter (not . fst) unassignedSched)
-
-overlayScheduleToMap :: OverlaySchedule era -> Map SlotNo (OBftSlot era)
-overlayScheduleToMap (OverlaySchedule oSched) = oSched
-
--- | Convert the overlay schedule to a representation that is more compact
--- when serialised to a bytestring, but less efficient for lookups.
---
--- Each genesis key hash will only be stored once, instead of each time it is
--- assigned to a slot.
-compactOverlaySchedule ::
-  OverlaySchedule era ->
-  Map (OBftSlot era) (NonEmpty SlotNo)
-compactOverlaySchedule (OverlaySchedule oSched) =
-  Map.foldrWithKey'
-    ( \slot obftSlot ->
-        Map.insertWith (<>) obftSlot (pure slot)
-    )
-    Map.empty
-    oSched
-
--- | Inverse of 'compactOverlaySchedule'
-decompactOverlaySchedule ::
-  Map (OBftSlot era) (NonEmpty SlotNo) ->
-  OverlaySchedule era
-decompactOverlaySchedule compact =
-  OverlaySchedule $
-    Map.fromList
-      [ (slot, obftSlot)
-        | (obftSlot, slots) <- Map.toList compact,
-          slot <- NonEmpty.toList slots
-      ]
-
-instance Era era => ToCBOR (OverlaySchedule era) where
-  toCBOR = toCBOR . compactOverlaySchedule
-
-instance Era era => FromCBOR (OverlaySchedule era) where
-  fromCBOR = decompactOverlaySchedule <$> fromCBOR
-
-isOverlaySlot :: SlotNo -> OverlaySchedule c -> Bool
-isOverlaySlot slot (OverlaySchedule oslots) = Map.member slot oslots
+    end = unSlotNo start + spe - 1

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -41,6 +41,7 @@ import Shelley.Spec.Ledger.BaseTypes
   ( Nonce,
     Seed,
     ShelleyBase,
+    UnitInterval,
   )
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
@@ -61,7 +62,6 @@ import Shelley.Spec.Ledger.Keys
     VRFSignable,
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
-import Shelley.Spec.Ledger.OverlaySchedule (OverlaySchedule)
 import Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
 import Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
@@ -103,7 +103,7 @@ instance Era era => NoUnexpectedThunks (PrtclState era)
 
 data PrtclEnv era
   = PrtclEnv
-      (OverlaySchedule era)
+      UnitInterval -- the decentralization paramater @d@ from the protocal parameters
       (PoolDistr era)
       (GenDelegs era)
       Nonce
@@ -161,7 +161,7 @@ prtclTransition ::
   TransitionRule (PRTCL era)
 prtclTransition = do
   TRC
-    ( PrtclEnv osched pd dms eta0,
+    ( PrtclEnv dval pd dms eta0,
       PrtclState cs etaV etaC,
       bh
       ) <-
@@ -179,7 +179,7 @@ prtclTransition = do
         )
   cs' <-
     trans @(OVERLAY era) $
-      TRC (OverlayEnv osched pd dms eta0, cs, bh)
+      TRC (OverlayEnv dval pd dms eta0, cs, bh)
 
   pure $
     PrtclState

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -172,7 +172,7 @@ instance Show UpdateInputs where
   show (UpdateInputs _globals vl bh st) = show vl ++ "\n" ++ show bh ++ "\n" ++ show st
 
 instance NFData (LedgerView era) where
-  rnf (LedgerView _pp _ov _pool _delegs) = ()
+  rnf (LedgerView _pp _pool _delegs) = ()
 
 instance Era era => NFData (BHeader era) where
   rnf (BHeader _ _) = ()

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -114,6 +114,7 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Examples.PoolReReg
       Test.Shelley.Spec.Ledger.Examples.Updates
       Test.Shelley.Spec.Ledger.Fees
+      Test.Shelley.Spec.Ledger.LegacyOverlay
       Test.Shelley.Spec.Ledger.MultiSigExamples
       Test.Shelley.Spec.Ledger.PropertyTests
       Test.Shelley.Spec.Ledger.Rewards

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -29,7 +29,7 @@ import Control.State.Transition.Trace.Generator.QuickCheck
   )
 import Data.Functor.Identity (runIdentity)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map (elems, fromList, keysSet)
+import qualified Data.Map.Strict as Map (elems, fromList)
 import Data.Proxy
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API
@@ -51,7 +51,6 @@ import Shelley.Spec.Ledger.Keys
     coerceKeyRole,
   )
 import Shelley.Spec.Ledger.LedgerState (esAccountState, nesEs, _treasury)
-import Shelley.Spec.Ledger.OverlaySchedule (overlaySchedule)
 import Shelley.Spec.Ledger.STS.Chain (chainNes, initialShelleyState)
 import qualified Shelley.Spec.Ledger.STS.Chain as STS (ChainState (ChainState))
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
@@ -67,7 +66,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
 import Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
 import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
-import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash, runShelleyBase)
+import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
@@ -105,12 +104,6 @@ mkGenesisChainState constants (IRC _slotNo) = do
   utxo0 <- genUtxo0 constants
 
   pParams <- genPParams constants
-  let osched_ =
-        runShelleyBase $
-          overlaySchedule
-            epoch0
-            (Map.keysSet delegs0)
-            pParams
 
   pure . Right . withRewards $
     initialShelleyState
@@ -119,7 +112,6 @@ mkGenesisChainState constants (IRC _slotNo) = do
       utxo0
       (maxLLSupply Val.~~ balance utxo0)
       delegs0
-      osched_
       pParams
       (hashHeaderToNonce (lastByronHeaderHash p))
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -38,7 +38,7 @@ import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Crypto (DSIGN)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Slotting.Block (BlockNo (..))
-import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Control.Iterate.SetAlgebra (biMapFromList)
 import qualified Data.ByteString.Char8 as BS
 import Data.Coerce (coerce)
@@ -85,7 +85,6 @@ import Shelley.Spec.Ledger.MetaData
   )
 import qualified Shelley.Spec.Ledger.MetaData as MD
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams (ProtVer)
 import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
@@ -577,16 +576,6 @@ instance Era era => Arbitrary (OBftSlot era) where
 
 instance Arbitrary ActiveSlotCoeff where
   arbitrary = mkActiveSlotCoeff <$> arbitrary
-
-instance Era era => Arbitrary (OverlaySchedule era) where
-  arbitrary =
-    -- Pick the parameters from specific random to avoid huge overlay schedules
-    overlayScheduleHelper
-      <$> (EpochSize <$> choose (1, 100))
-      <*> (SlotNo <$> choose (0, 100000))
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
 
 instance Arbitrary Likelihood where
   arbitrary = Likelihood <$> arbitrary

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -92,7 +92,6 @@ import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..), TxBody (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
 import qualified Cardano.Ledger.Val as Val
-import Test.Shelley.Spec.Ledger.Examples.Federation (overlayScheduleFor)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
 
 -- | = Evolve Nonces - Frozen
@@ -579,7 +578,6 @@ newEpoch b cs = cs'
     nes' =
       nes
         { nesEL = e,
-          nesOsched = overlayScheduleFor e pp,
           nesBprev = (nesBcur nes),
           nesBcur = BlocksMade Map.empty
         }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
@@ -42,7 +42,7 @@ import Shelley.Spec.Ledger.Slot
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
 import qualified Cardano.Ledger.Val as Val
-import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs, overlayScheduleFor)
+import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs)
 import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash, unsafeMkUnitInterval)
 
 -- === Initial Protocol Parameters
@@ -105,6 +105,5 @@ initSt utxo =
     utxo
     (maxLLSupply Val.~~ (balance utxo))
     genDelegs
-    (overlayScheduleFor (EpochNo 0) ppEx)
     ppEx
     (nonce0 @era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Shelley.Spec.Ledger.LegacyOverlay
+  ( legacyOverlayTest,
+  )
+where
+
+import Cardano.Slotting.Slot
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Ratio ((%))
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Keys
+  ( KeyHash (..),
+    KeyRole (..),
+  )
+import Shelley.Spec.Ledger.OverlaySchedule (OBftSlot (..), classifyOverlaySlot, overlaySlots)
+import Shelley.Spec.Ledger.Slot
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs)
+import Test.Shelley.Spec.Ledger.Utils
+import Test.Tasty.QuickCheck
+
+legacyOverlay ::
+  EpochSize ->
+  SlotNo ->
+  -- | First slot of the epoch
+  Set (KeyHash 'Genesis era) ->
+  UnitInterval ->
+  -- | Decentralization parameter @d@
+  ActiveSlotCoeff ->
+  Map SlotNo (OBftSlot era)
+legacyOverlay slotsPerEpoch firstSlotNo gkeys d asc
+  | dval == 0 = Map.empty
+  | otherwise = Map.union active inactive
+  where
+    dval = intervalValue d
+    numActive = dval * fromIntegral slotsPerEpoch
+    dInv = 1 / dval
+    ascValue = (intervalValue . activeSlotVal) asc
+    toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
+    toSlotNo x = firstSlotNo +* toRelativeSlotNo x
+    genesisSlots = [toSlotNo x | x <- [0 .. (floor numActive - 1)]]
+    numInactivePerActive = floor (1 / ascValue) - 1
+    activitySchedule = cycle (True : replicate numInactivePerActive False)
+    unassignedSched = zip activitySchedule genesisSlots
+    genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
+    active =
+      Map.fromList $
+        fmap
+          (\(gk, (_, s)) -> (s, ActiveSlot gk))
+          (zip genesisCycle (filter fst unassignedSched))
+    inactive =
+      Map.fromList $
+        fmap
+          (\x -> (snd x, NonActiveSlot))
+          (filter (not . fst) unassignedSched)
+
+mainnetEpochSize :: EpochSize
+mainnetEpochSize = EpochSize 432000
+
+makeConcreteOverlay ::
+  SlotNo -> -- first slot of the epoch
+  [KeyHash 'Genesis era] -> -- genesis Nodes
+  UnitInterval -> -- decentralization parameter
+  ActiveSlotCoeff -> -- active slot coefficent
+  EpochSize -> -- slots per epoch
+  Map SlotNo (OBftSlot era)
+makeConcreteOverlay start gkeys dval asc spe =
+  Map.fromList $
+    map
+      (\s -> (s, classifyOverlaySlot start gkeys dval asc s))
+      (overlaySlots start dval spe)
+
+legacyOverlayTest :: Property
+legacyOverlayTest = property $ do
+  d <- choose (0, 100)
+  e <- choose (0, 100)
+  let dval = unsafeMkUnitInterval (d % 100)
+      asc = mkActiveSlotCoeff . unsafeMkUnitInterval $ 1 % 20
+      EpochSize spe = mainnetEpochSize
+      start = SlotNo $ e * spe
+      os =
+        legacyOverlay
+          mainnetEpochSize
+          start
+          (Map.keysSet (genDelegs @C))
+          dval
+          asc
+  pure $ os === makeConcreteOverlay start (Map.keys (genDelegs @C)) dval asc mainnetEpochSize

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -8,6 +8,7 @@ import Test.Shelley.Spec.Ledger.Address.Bootstrap
   ( bootstrapHashTest,
   )
 import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
+import Test.Shelley.Spec.Ledger.LegacyOverlay (legacyOverlayTest)
 import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
   ( onlyValidChainSignalsAreGenerated,
     onlyValidLedgerSignalsAreGenerated,
@@ -55,7 +56,8 @@ minimalPropertyTests =
         "Deserialize stake address reference"
         [ TQC.testProperty "wstake reference from bytestrings" propDeserializeAddrStakeReference,
           TQC.testProperty "stake reference from short bytestring" propDeserializeAddrStakeReferenceShortIncrediblyLongName
-        ]
+        ],
+      TQC.testProperty "legacy overlay schedule" legacyOverlayTest
     ]
 
 -- | 'TestTree' of property-based testing properties.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -50,7 +50,6 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..), totalAda, totalAdaPots)
 import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
-import Shelley.Spec.Ledger.STS.Tick (TickEnv (TickEnv))
 import Shelley.Spec.Ledger.Tx
 import Shelley.Spec.Ledger.TxBody
 import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern UTxO)
@@ -465,7 +464,7 @@ chainSstWithTick ledgerTr =
           _
           b@(Block bh _)
         ) =
-        case runShelleyBase (applySTSTest @(TICK C) (TRC (TickEnv (getGKeys nes), nes, (bheaderSlotNo . bhbody) bh))) of
+        case runShelleyBase (applySTSTest @(TICK C) (TRC ((), nes, (bheaderSlotNo . bhbody) bh))) of
           Left pf ->
             error ("chainSstWithTick.applyTick Predicate failure " <> show pf)
           Right nes' ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -33,7 +33,6 @@ import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Coerce (coerce)
 import Data.IP (toIPv4)
-import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe (fromJust)
 import Data.Proxy
@@ -131,7 +130,6 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import qualified Shelley.Spec.Ledger.MetaData as MD
 import Shelley.Spec.Ledger.OCert (KESPeriod (..), OCertSignable (..), pattern OCert)
-import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams
   ( PParams' (..),
     PParamsUpdate,
@@ -1296,8 +1294,6 @@ tests =
             ) ::
               StrictMaybe (RewardUpdate C)
           pd = (PoolDistr Map.empty) :: PoolDistr C
-          compactOs = Map.singleton (ActiveSlot (testGKeyHash p)) (SlotNo 1 :| [])
-          os = decompactOverlaySchedule compactOs
           nes =
             NewEpochState
               e
@@ -1306,18 +1302,16 @@ tests =
               es
               ru
               pd
-              os
        in checkEncodingCBOR
             "new_epoch_state"
             nes
-            ( T (TkListLen 7)
+            ( T (TkListLen 6)
                 <> S e
                 <> S (BlocksMade bs)
                 <> S (BlocksMade bs)
                 <> S es
                 <> S ru
                 <> S pd
-                <> S compactOs
             )
     ]
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -60,7 +60,6 @@ import Shelley.Spec.Ledger.LedgerState
     _dstate,
     _rewards,
   )
-import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams
 import Shelley.Spec.Ledger.STS.Delegs (DelegsPredicateFailure (..))
 import Shelley.Spec.Ledger.STS.Delpl (DelplPredicateFailure (..))
@@ -155,26 +154,6 @@ pp =
       _minPoolCost = Coin 100
     }
 
-testOverlayScheduleZero :: Assertion
-testOverlayScheduleZero =
-  let os =
-        runShelleyBase $
-          overlaySchedule
-            (EpochNo 0)
-            mempty
-            (emptyPParams {_d = unsafeMkUnitInterval 0})
-   in assertBool "Overlay schedule is not empty" (overlayScheduleIsEmpty os)
-
-testNoGenesisOverlay :: Assertion
-testNoGenesisOverlay =
-  let os =
-        runShelleyBase $
-          overlaySchedule
-            (EpochNo 0)
-            mempty
-            (emptyPParams {_d = unsafeMkUnitInterval 0.5})
-   in assertBool "Overlay schedule is not empty" (overlayScheduleIsEmpty os)
-
 testVRFCheckWithActiveSlotCoeffOne :: Assertion
 testVRFCheckWithActiveSlotCoeffOne =
   checkLeaderValue
@@ -187,11 +166,7 @@ testsPParams :: TestTree
 testsPParams =
   testGroup
     "Test the protocol parameters."
-    [ testCase "Overlay Schedule when d is zero" $
-        testOverlayScheduleZero,
-      testCase "generate overlay schedule without genesis nodes" $
-        testNoGenesisOverlay,
-      testCase "VRF checks when the activeSlotCoeff is one" $
+    [ testCase "VRF checks when the activeSlotCoeff is one" $
         testVRFCheckWithActiveSlotCoeffOne
     ]
 


### PR DESCRIPTION
This PR replaces the overlay schedule mapping with a couple arithmetic checks. **Note** that this PR does break the ledger state serialization (the overlay schedule is now gone).

Checking if a relative slot `s` is an overlay slot amounts to checking:
```
ceiling (s*d) < ceiling ((s+1)*d)
```
ie the next multiple of `d` (the decentralization parameter) raises the ceiling.

If a relative slot `s` is indeed an overlay slot, then it is an active slot if `1/f` (where `f` is the active slot coefficient) divides `ceiling (s * d)`. And we can find the core node for a given active overlay slot by checking it's remainder mod the number of core nodes (after dividing by `1/f`, which is 20 on mainnet).

---

We no longer store the overlay schedule in the ledger state, the mapping is replaced by performing the checks above in the appropriate changes. The formal spec will need to be updated to match. 

A few of the STS environments changed as a result. The `NEWEPOCH` and `TICK` environments are now empty/unit. The `OVERLAY` and `PRTCL` environment now takes the decentralization parameter `d` in place of the overlayschedule.

Removing the overlay schedule and the above changes caused several of the API methods to change.

---

Lastly, I added more validation when updating the `d` parameter. We now require that `d` be in hundredths.

closes input-output-hk/ouroboros-network#1825 