### PR TITLE
total stake in reward calculation and API

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -12,7 +12,6 @@ where
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto, Era)
-import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (SlotNo)
 import qualified Data.ByteString.Short as BSS
@@ -35,12 +34,12 @@ import Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..), un
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..), SignKeyVRF)
 import Shelley.Spec.Ledger.LedgerState
-  ( AccountState (..),
-    DPState (..),
+  ( DPState (..),
     EpochState (..),
     LedgerState (..),
     NewEpochState (..),
     UTxOState (..),
+    circulation,
     stakeDistr,
   )
 import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
@@ -60,8 +59,8 @@ import Shelley.Spec.Ledger.UTxO (UTxO (..))
 getTotalStake :: Globals -> ShelleyState era -> Coin
 getTotalStake globals ss =
   let supply = Coin . fromIntegral $ maxLovelaceSupply globals
-      EpochState acnt _ _ _ _ _ = nesEs ss
-   in supply Val.~~ (_reserves acnt)
+      es = nesEs ss
+   in circulation es supply
 
 -- | Calculate the Non-Myopic Pool Member Rewards for a set of credentials.
 -- For each given credential, this function returns a map from each stake

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -86,6 +86,7 @@ module Shelley.Spec.Ledger.LedgerState
     NewEpochEnv (..),
     getGKeys,
     updateNES,
+    circulation,
   )
 where
 
@@ -918,7 +919,7 @@ createRUpd ::
   EpochState era ->
   Coin ->
   ShelleyBase (RewardUpdate era)
-createRUpd slotsPerEpoch b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
+createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) total = do
   asc <- asks activeSlotCoeff
   let SnapShot stake' delegs' poolParams = _pstakeGo ss
       Coin reserves = _reserves acnt
@@ -937,9 +938,9 @@ createRUpd slotsPerEpoch b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total
       Coin rPot = _feeSS ss <> deltaR1
       deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
       _R = Coin $ rPot - deltaT1
-      circulation = total Val.~~ (_reserves acnt)
+      totalStake = circulation es total
       (rs_, newLikelihoods) =
-        reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' circulation asc slotsPerEpoch
+        reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' totalStake asc slotsPerEpoch
       deltaR2 = _R Val.~~ (Map.foldr (<>) mempty rs_)
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $
@@ -950,6 +951,13 @@ createRUpd slotsPerEpoch b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total
         deltaF = (Val.invert (_feeSS ss)),
         nonMyopic = (updateNonMypopic nm _R newLikelihoods)
       }
+
+-- | Calculate the current circulation
+--
+-- This is used in the rewards calculation, and for API endpoints for pool ranking.
+circulation :: EpochState era -> Coin -> Coin
+circulation (EpochState acnt _ _ _ _ _) supply =
+  supply Val.~~ (_reserves acnt)
 
 -- | Update new epoch state
 updateNES ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -919,7 +919,7 @@ createRUpd ::
   EpochState era ->
   Coin ->
   ShelleyBase (RewardUpdate era)
-createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) total = do
+createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) maxSupply = do
   asc <- asks activeSlotCoeff
   let SnapShot stake' delegs' poolParams = _pstakeGo ss
       Coin reserves = _reserves acnt
@@ -938,7 +938,7 @@ createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) to
       Coin rPot = _feeSS ss <> deltaR1
       deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
       _R = Coin $ rPot - deltaT1
-      totalStake = circulation es total
+      totalStake = circulation es maxSupply
       (rs_, newLikelihoods) =
         reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' totalStake asc slotsPerEpoch
       deltaR2 = _R Val.~~ (Map.foldr (<>) mempty rs_)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -274,10 +274,10 @@ getTopRankedPools ::
   Map (KeyHash 'StakePool era) (PoolParams era) ->
   Map (KeyHash 'StakePool era) PerformanceEstimate ->
   Set (KeyHash 'StakePool era)
+getTopRankedPools rPot totalStake pp poolParams aps =
   Set.fromList $
     fmap fst $
       take (fromIntegral $ _nOpt pp) (sortBy (flip compare `on` snd) rankings)
-getTopRankedPools rPot totalStake pp poolParams aps =
   where
     pdata = Map.toList $ Map.intersectionWith (,) poolParams aps
     rankings =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -248,7 +248,7 @@ desirability ::
   PerformanceEstimate ->
   Coin ->
   Double
-desirability pp r pool (PerformanceEstimate p) (Coin total) =
+desirability pp r pool (PerformanceEstimate p) (Coin totalStake) =
   if fTilde <= cost
     then 0
     else (fTilde - cost) * (1 - margin)
@@ -258,7 +258,7 @@ desirability pp r pool (PerformanceEstimate p) (Coin total) =
     fTildeDenom = fromRational $ 1 + a0
     cost = (fromRational . coinToRational . _poolCost) pool
     margin = (fromRational . unitIntervalToRational . _poolMargin) pool
-    tot = max 1 (fromIntegral total)
+    tot = max 1 (fromIntegral totalStake)
     Coin pledge = _poolPledge pool
     s = fromIntegral pledge % tot
     a0 = _a0 pp
@@ -274,15 +274,15 @@ getTopRankedPools ::
   Map (KeyHash 'StakePool era) (PoolParams era) ->
   Map (KeyHash 'StakePool era) PerformanceEstimate ->
   Set (KeyHash 'StakePool era)
-getTopRankedPools rPot total pp poolParams aps =
   Set.fromList $
     fmap fst $
       take (fromIntegral $ _nOpt pp) (sortBy (flip compare `on` snd) rankings)
+getTopRankedPools rPot totalStake pp poolParams aps =
   where
     pdata = Map.toList $ Map.intersectionWith (,) poolParams aps
     rankings =
       [ ( hk,
-          desirability pp rPot pool ap total
+          desirability pp rPot pool ap totalStake
         )
         | (hk, (pool, ap)) <- pdata
       ]
@@ -350,7 +350,7 @@ rewardOnePool ::
   Coin ->
   Set (Credential 'Staking era) ->
   Map (Credential 'Staking era) Coin
-rewardOnePool pp r blocksN blocksTotal pool (Stake stake) sigma sigmaA (Coin total) addrsRew =
+rewardOnePool pp r blocksN blocksTotal pool (Stake stake) sigma sigmaA (Coin totalStake) addrsRew =
   rewards'
   where
     Coin ostake =
@@ -359,14 +359,14 @@ rewardOnePool pp r blocksN blocksTotal pool (Stake stake) sigma sigmaA (Coin tot
         mempty
         (_poolOwners pool)
     Coin pledge = _poolPledge pool
-    pr = fromIntegral pledge % fromIntegral total
+    pr = fromIntegral pledge % fromIntegral totalStake
     (Coin maxP) =
       if pledge <= ostake
         then maxPool pp r sigma pr
         else mempty
     appPerf = mkApparentPerformance (_d pp) sigmaA blocksN blocksTotal
     poolR = rationalToCoinViaFloor (appPerf * fromIntegral maxP)
-    tot = fromIntegral total
+    tot = fromIntegral totalStake
     mRewards =
       Map.fromList
         [ ( hk,
@@ -401,16 +401,16 @@ reward
   poolParams
   stake
   delegs
-  (Coin total)
+  (Coin totalStake)
   asc
   slotsPerEpoch = (rewards', hs)
     where
       totalBlocks = sum b
-      Coin totalActive = fold . unStake $ stake
+      Coin activeStake = fold . unStake $ stake
       results = do
         (hk, pparams) <- Map.toList poolParams
-        let sigma = fromIntegral pstake % fromIntegral total
-            sigmaA = fromIntegral pstake % fromIntegral totalActive
+        let sigma = fromIntegral pstake % fromIntegral totalStake
+            sigmaA = fromIntegral pstake % fromIntegral activeStake
             blocksProduced = Map.lookup hk b
             actgr@(Stake s) = poolStake hk delegs stake
             Coin pstake = fold s
@@ -427,7 +427,7 @@ reward
                     actgr
                     sigma
                     sigmaA
-                    (Coin total)
+                    (Coin totalStake)
                     addrsRew
             ls =
               likelihood

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -46,7 +46,7 @@ import Shelley.Spec.Ledger.BlockChain
     bheaderSlotNo,
   )
 import Shelley.Spec.Ledger.Coin
-import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.LedgerState hiding (circulation)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..), totalAda, totalAdaPots)
 import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))


### PR DESCRIPTION
This PR does four things:

- a slight refactoring in the ledger, using one function to calculate the current circulation (and total stake), and using it wherever we need it.
- rename some function arguments, to make it clearer where we use max supply vs total stake.
- make a correction in the getNonMyopicMemberRewards function, where we had previously used max supply instead of total stake.
- add a function to get stake pools with their fraction of total stake, which the wallet can use to display saturation levels.