### PR TITLE
Benchmark and optimise reward calculation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -911,7 +911,12 @@ createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) ma
       Coin reserves = _reserves acnt
       ds = _dstate $ _delegationState ls
       -- reserves and rewards change
-      deltaR1 = (rationalToCoinViaFloor $ min 1 eta * unitIntervalToRational (_rho pr) * fromIntegral reserves)
+      deltaR1 =
+        ( rationalToCoinViaFloor $
+            min 1 eta
+              * unitIntervalToRational (_rho pr)
+              * fromIntegral reserves
+        )
       d = unitIntervalToRational (_d pr)
       expectedBlocks =
         floor $
@@ -926,7 +931,17 @@ createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) ma
       _R = Coin $ rPot - deltaT1
       totalStake = circulation es maxSupply
       (rs_, newLikelihoods) =
-        reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' totalStake asc slotsPerEpoch
+        reward
+          pr
+          b
+          _R
+          (Map.keysSet $ _rewards ds)
+          poolParams
+          stake'
+          delegs'
+          totalStake
+          asc
+          slotsPerEpoch
       deltaR2 = _R Val.~~ (Map.foldr (<>) mempty rs_)
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -45,7 +45,12 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Era
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (Generic, NFData, NoUnexpectedThunks (..))
-import Control.Iterate.SetAlgebra (BaseRep (MapR), Embed (..), Exp (Base), HasExp (toExp))
+import Control.Iterate.SetAlgebra
+  ( BaseRep (MapR),
+    Embed (..),
+    Exp (Base),
+    HasExp (toExp),
+  )
 import Data.Foldable (toList)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -159,7 +164,10 @@ txouts ::
   UTxO era
 txouts tx =
   UTxO $
-    Map.fromList [(TxIn transId idx, out) | (out, idx) <- zip (toList $ _outputs tx) [0 ..]]
+    Map.fromList
+      [ (TxIn transId idx, out)
+        | (out, idx) <- zip (toList $ _outputs tx) [0 ..]
+      ]
   where
     transId = txid tx
 
@@ -280,8 +288,15 @@ scriptsNeeded ::
   Set (ScriptHash era)
 scriptsNeeded u tx =
   Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
-    `Set.union` Set.fromList (Maybe.mapMaybe (scriptCred . getRwdCred) $ Map.keys withdrawals)
-    `Set.union` Set.fromList (Maybe.mapMaybe scriptStakeCred (filter requiresVKeyWitness certificates))
+    `Set.union` Set.fromList
+      ( Maybe.mapMaybe (scriptCred . getRwdCred) $
+          Map.keys withdrawals
+      )
+    `Set.union` Set.fromList
+      ( Maybe.mapMaybe
+          scriptStakeCred
+          (filter requiresVKeyWitness certificates)
+      )
   where
     unTxOut (TxOut a _) = a
     withdrawals = unWdrl $ _wdrls $ _body tx

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -78,17 +78,35 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 
 -- ==========================================================
 
-eqf :: String -> (Map.Map Int Int -> Map.Map Int Int -> Bool) -> Int -> Benchmark
-eqf name f n = bgroup (name ++ " " ++ show n) (map runat [n, n * 10, n * 100, n * 1000])
+eqf ::
+  String ->
+  (Map.Map Int Int -> Map.Map Int Int -> Bool) ->
+  Int ->
+  Benchmark
+eqf name f n =
+  bgroup
+    (name ++ " " ++ show n)
+    (map runat [n, n * 10, n * 100, n * 1000])
   where
-    runat m = env (return $ Map.fromList [(k, k) | k <- [1 .. m]]) (\state -> bench (show m) (whnf (f state) state))
+    runat m =
+      env
+        ( return $
+            Map.fromList
+              [ (k, k)
+                | k <- [1 .. m]
+              ]
+        )
+        (\state -> bench (show m) (whnf (f state) state))
 
 mainEq :: IO ()
 mainEq =
   defaultMain $
     [ bgroup "KeysEqual tests" $
         [ eqf "keysEqual" keysEqual (100 :: Int),
-          eqf "keys x == keys y" (\x y -> Map.keys x == Map.keys y) (100 :: Int)
+          eqf
+            "keys x == keys y"
+            (\x y -> Map.keys x == Map.keys y)
+            (100 :: Int)
         ]
     ]
 
@@ -135,7 +153,11 @@ profileCreateRegKeys = do
 profileNkeysMPools :: IO ()
 profileNkeysMPools = do
   putStrLn "Enter N keys and M Pools"
-  let unit = ledgerDelegateManyKeysOnePool 50 500 (ledgerStateWithNkeysMpools 5000 500)
+  let unit =
+        ledgerDelegateManyKeysOnePool
+          50
+          500
+          (ledgerStateWithNkeysMpools 5000 500)
   putStrLn ("Exit profiling " ++ show unit)
 
 -- ==========================================
@@ -176,12 +198,17 @@ action2m (dstate, pstate, utxo) = stakeDistr utxo dstate pstate
 dstate' :: DState C
 pstate' :: PState C
 utxo' :: UTxO C
-(dstate', pstate', utxo') = unsafePerformIO $ QC.generate (genTestCase 1000000 (5000 :: Int))
+(dstate', pstate', utxo') =
+  unsafePerformIO $
+    QC.generate (genTestCase 1000000 (5000 :: Int))
 
 profile_Maps :: Int -> IO ()
 profile_Maps _x = do
   let snap = stakeDistr utxo' dstate' pstate'
-  putStrLn ("Size = " ++ show (Map.size (EB._delegations snap)) ++ " " ++ show (Map.size (_poolParams snap)))
+  putStrLn
+    ( "Size = " ++ show (Map.size (EB._delegations snap)) ++ " "
+        ++ show (Map.size (_poolParams snap))
+    )
 
 {- At least while running in GHCI Maps use less allocation than lists
 *Main> profile_Lists 1
@@ -225,7 +252,9 @@ validGroup =
             bgroup
               "protocol"
               [ bench "updateChainDepState" (nf updateChain arg),
-                bench "updateAndTickChainDepState" (nf updateAndTickChain arg)
+                bench
+                  "updateAndTickChainDepState"
+                  (nf updateAndTickChain arg)
               ]
         ]
 
@@ -335,25 +364,101 @@ main :: IO ()
 main =
   defaultMain $
     [ bgroup "vary input size" $
-        [ varyInput "deregister key" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
-          varyInput "register key" (20001, 25001) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
-          varyInput "withdrawal" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredKeys ledgerRewardWithdrawals,
-          varyInput "register pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerRegisterStakePools,
-          varyInput "reregister pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerReRegisterStakePools,
-          varyInput "retire pool" (1, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNregisteredPools ledgerRetireStakePools,
-          varyInput "manyKeysOnePool" (5000, 5000) [(1, 50), (1, 500), (1, 5000)] ledgerStateWithNkeysMpools ledgerDelegateManyKeysOnePool
+        [ varyInput
+            "deregister key"
+            (1, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredKeys
+            ledgerDeRegisterStakeKeys,
+          varyInput
+            "register key"
+            (20001, 25001)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredKeys
+            ledgerRegisterStakeKeys,
+          varyInput
+            "withdrawal"
+            (1, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredKeys
+            ledgerRewardWithdrawals,
+          varyInput
+            "register pool"
+            (1, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredPools
+            ledgerRegisterStakePools,
+          varyInput
+            "reregister pool"
+            (1, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredPools
+            ledgerReRegisterStakePools,
+          varyInput
+            "retire pool"
+            (1, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNregisteredPools
+            ledgerRetireStakePools,
+          varyInput
+            "manyKeysOnePool"
+            (5000, 5000)
+            [(1, 50), (1, 500), (1, 5000)]
+            ledgerStateWithNkeysMpools
+            ledgerDelegateManyKeysOnePool
         ],
       bgroup "vary initial state" $
-        [ varyState "spendOne" 1 [50, 500, 5000] (\_m n -> initUTxO (fromIntegral n)) (\_m _ -> ledgerSpendOneGivenUTxO),
-          varyState "register key" 5001 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerRegisterStakeKeys,
-          varyState "deregister key" 50 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerDeRegisterStakeKeys,
-          varyState "withdrawal" 50 [50, 500, 5000] ledgerStateWithNregisteredKeys ledgerRewardWithdrawals,
-          varyState "register pool" 5001 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerRegisterStakePools,
-          varyState "reregister pool" 5001 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerReRegisterStakePools,
-          varyState "retire pool" 50 [50, 500, 5000] ledgerStateWithNregisteredPools ledgerRetireStakePools,
-          varyDelegState "manyKeysOnePool" 50 [50, 500, 5000] ledgerStateWithNkeysMpools ledgerDelegateManyKeysOnePool
+        [ varyState
+            "spendOne"
+            1
+            [50, 500, 5000]
+            (\_m n -> initUTxO (fromIntegral n))
+            (\_m _ -> ledgerSpendOneGivenUTxO),
+          varyState
+            "register key"
+            5001
+            [50, 500, 5000]
+            ledgerStateWithNregisteredKeys
+            ledgerRegisterStakeKeys,
+          varyState
+            "deregister key"
+            50
+            [50, 500, 5000]
+            ledgerStateWithNregisteredKeys
+            ledgerDeRegisterStakeKeys,
+          varyState
+            "withdrawal"
+            50
+            [50, 500, 5000]
+            ledgerStateWithNregisteredKeys
+            ledgerRewardWithdrawals,
+          varyState
+            "register pool"
+            5001
+            [50, 500, 5000]
+            ledgerStateWithNregisteredPools
+            ledgerRegisterStakePools,
+          varyState
+            "reregister pool"
+            5001
+            [50, 500, 5000]
+            ledgerStateWithNregisteredPools
+            ledgerReRegisterStakePools,
+          varyState
+            "retire pool"
+            50
+            [50, 500, 5000]
+            ledgerStateWithNregisteredPools
+            ledgerRetireStakePools,
+          varyDelegState
+            "manyKeysOnePool"
+            50
+            [50, 500, 5000]
+            ledgerStateWithNkeysMpools
+            ledgerDelegateManyKeysOnePool
         ],
-      bgroup "vary utxo at epoch boundary" $ (epochAt <$> [5000, 50000, 500000]),
+      bgroup "vary utxo at epoch boundary" $
+        (epochAt <$> [5000, 50000, 500000]),
       bgroup "domain-range restict" $ drrAt <$> [10000, 100000, 1000000],
       validGroup,
       -- Benchmarks for the various generators

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -22,6 +22,7 @@ import BenchValidation
 -- How to compute an initial state with N StakePools
 
 import Cardano.Ledger.Era (Crypto (..))
+import Cardano.Slotting.Slot (EpochSize (..))
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra (dom, forwards, keysEqual, (▷), (◁))
 import Control.Iterate.SetAlgebraInternal (compile, compute, run)
@@ -57,6 +58,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState (..),
     stakeDistr,
   )
+import Shelley.Spec.Ledger.Rewards (likelihood)
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Gen as QC
@@ -483,6 +485,7 @@ main =
             (generate $ genChainInEpoch 5)
             ( \cs ->
                 bench "createRUpd" $ whnf (createRUpd testGlobals) cs
-            )
+            ),
+          bench "likelihood" $ whnf (likelihood 1234 0.1) (EpochSize 10000)
         ]
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -44,6 +44,7 @@ import Shelley.Spec.Ledger.Bench.Gen
     genChainState,
     genTx,
   )
+import Shelley.Spec.Ledger.Bench.Rewards (createRUpd, genChainInEpoch)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.EpochBoundary (SnapShot (..))
@@ -75,6 +76,7 @@ import Test.Shelley.Spec.Ledger.BenchmarkFunctions
     ledgerStateWithNregisteredPools,
   )
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.Utils (testGlobals)
 
 -- ==========================================================
 
@@ -475,5 +477,12 @@ main =
             "genTx"
             [ bench "1000" $ whnfIO $ genTx 1000
             ]
+        ],
+      bgroup "rewards" $
+        [ env
+            (generate $ genChainInEpoch 5)
+            ( \cs ->
+                bench "createRUpd" $ whnf (createRUpd testGlobals) cs
+            )
         ]
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -59,8 +59,6 @@ import Test.Shelley.Spec.Ledger.Generator.Trace.Chain
   )
 import Test.Shelley.Spec.Ledger.Utils (testGlobals)
 
-import Debug.Trace
-
 -- | Generate a chain state at a given epoch. Since we are only concerned about
 -- rewards, this will populate the chain with empty blocks (only issued by the
 -- original genesis delegates).

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Shelley.Spec.Ledger.Bench.Rewards
+  ( createRUpd,
+    genChainInEpoch,
+  )
+where
+
+import Cardano.Crypto.VRF (hashVerKeyVRF)
+import Cardano.Slotting.EpochInfo
+import Cardano.Slotting.Slot (EpochNo)
+import Control.Monad.Reader (runReader, runReaderT)
+import Control.State.Transition.Extended (IRC (..), TRC (..), applySTS)
+import Data.Either (fromRight)
+import Data.Functor.Identity (runIdentity)
+import qualified Data.Map.Strict as Map
+import Data.Proxy (Proxy (..))
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import Shelley.Spec.Ledger.Address
+  ( Addr (..),
+    mkRwdAcnt,
+  )
+import Shelley.Spec.Ledger.BaseTypes
+  ( Globals (epochInfo),
+    Network (Testnet),
+    StrictMaybe (..),
+    truncateUnitInterval,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
+import Shelley.Spec.Ledger.Genesis (ShelleyGenesisStaking (..))
+import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (Staking))
+import qualified Shelley.Spec.Ledger.LedgerState as LS
+import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState, chainNes, totalAda)
+import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxOut (..))
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
+import Test.QuickCheck (Gen)
+import Test.Shelley.Spec.Ledger.BenchmarkFunctions (B)
+import Test.Shelley.Spec.Ledger.Generator.Block (genBlockWithTxGen)
+import Test.Shelley.Spec.Ledger.Generator.Constants
+  ( maxGenesisUTxOouts,
+    minGenesisUTxOouts,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllIssuerKeys (..),
+    geConstants,
+    geKeySpace,
+    ksStakePools,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain
+  ( mkGenesisChainState,
+    registerGenesisStaking,
+  )
+import Test.Shelley.Spec.Ledger.Utils (testGlobals)
+
+import Debug.Trace
+
+-- | Generate a chain state at a given epoch. Since we are only concerned about
+-- rewards, this will populate the chain with empty blocks (only issued by the
+-- original genesis delegates).
+genChainInEpoch :: EpochNo -> Gen (ChainState B)
+genChainInEpoch epoch = do
+  genesisChainState <-
+    fromRight (error "genChainState failed")
+      <$> mkGenesisChainState @B cs (IRC ())
+  -- Our genesis chain state contains no registered staking. Since we want to
+  -- calculate a reward update, we will set some up.
+  -- What do we want to do here?
+  -- - We find all the addresses which are present in the initial UTxO, and
+  --   register them all for staking
+  -- - We group them into 50 groups (number of stake pools). The first one in
+  --   each group becomes the pool owner, with pledge set to the value in that
+  --   address.
+  let initUtxo =
+        LS._utxo
+          . LS._utxoState
+          . LS.esLState
+          . LS.nesEs
+          $ chainNes genesisChainState
+      initUtxoAddrs =
+        Map.elems
+          . Map.mapMaybe (\(TxOut addr _) -> addrToKeyHash addr)
+          . unUTxO
+          $ initUtxo
+      stakeMap =
+        zip stakePools $
+          chunk (length initUtxoAddrs `div` length stakePools) initUtxoAddrs
+
+  let chainState =
+        registerGenesisStaking
+          (mkGenesisStaking stakeMap)
+          genesisChainState
+  -- Now run the empty block generator over the chain state until we hit the
+  -- desired epoch.
+  applyUntil
+    chainState
+    ( \x ->
+        if (LS.nesEL $ chainNes x) >= epoch
+          then Nothing
+          else Just $ applyBlk x <$> genEmptyBlock x
+    )
+  where
+    applyUntil :: Monad m => a -> (a -> Maybe (m a)) -> m a
+    applyUntil x f = case f x of
+      Nothing -> pure x
+      Just x' -> x' >>= flip applyUntil f
+    applyBlk cs' blk =
+      (either err id) . flip runReader testGlobals
+        . applySTS @(CHAIN B)
+        $ TRC ((), cs', blk)
+      where
+        err :: Show a => a -> b
+        err msg = error $ "Panic! applyBlk failed: " <> (show msg)
+    ge = genEnv (Proxy @B)
+    -- Small UTxO set; we just want enough to stake to pools
+    cs =
+      (geConstants ge)
+        { minGenesisUTxOouts = 5000,
+          maxGenesisUTxOouts = 5000
+        }
+    ks = geKeySpace ge
+    genEmptyBlock = genBlockWithTxGen @B (\_ _ _ _ -> pure mempty) ge
+    mkGenesisStaking stakeMap =
+      ShelleyGenesisStaking
+        { sgsPools =
+            Map.fromList
+              [ (hk, pp)
+                | (AllIssuerKeys {vrf, hk}, (owner : _)) <- stakeMap,
+                  let pp =
+                        PoolParams
+                          { _poolPubKey = hk,
+                            _poolVrf = hashVerKeyVRF $ snd vrf,
+                            _poolPledge = Coin 1,
+                            _poolCost = Coin 1,
+                            _poolMargin = truncateUnitInterval 0,
+                            _poolRAcnt = mkRwdAcnt Testnet $ KeyHashObj owner,
+                            _poolOwners = Set.singleton owner,
+                            _poolRelays = StrictSeq.empty,
+                            _poolMD = SNothing
+                          }
+              ],
+          sgsStake =
+            Map.fromList
+              [ (dlg, hk)
+                | (AllIssuerKeys {hk}, dlgs) <- stakeMap,
+                  dlg <- dlgs
+              ]
+        }
+    stakePools = ksStakePools ks
+    chunk :: Int -> [a] -> [[a]]
+    chunk n _ | n <= 0 = []
+    chunk n xs = go [] xs where
+      go !acc [] = acc
+      go !acc xs' = let (a,b) = splitAt n xs' in go (a : acc) b
+
+    addrToKeyHash :: Addr era -> Maybe (KeyHash 'Staking era)
+    addrToKeyHash (Addr _ _ (StakeRefBase (KeyHashObj kh))) = Just kh
+    addrToKeyHash _ = Nothing
+
+-- | Benchmark creating a reward update.
+createRUpd ::
+  Globals ->
+  ChainState B ->
+  LS.RewardUpdate B
+createRUpd globals cs =
+  runIdentity $
+    runReaderT
+      (LS.createRUpd epochSize bm es total)
+      globals
+  where
+    nes = chainNes cs
+    bm = LS.nesBprev nes
+    es = LS.nesEs nes
+    total = totalAda cs
+    epochSize =
+      runIdentity $
+        epochInfoSize (epochInfo globals) (LS.nesEL nes)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -211,6 +211,7 @@ benchmark mainbench
     BenchUTxOAggregate,
     BenchValidation,
     Shelley.Spec.Ledger.Bench.Gen
+    Shelley.Spec.Ledger.Bench.Rewards
     Test.Shelley.Spec.Ledger.Examples.Cast
 
   build-depends:


### PR DESCRIPTION
This PR adds a micro-benchmark for the reward update creation and subsequently optimises that operation.

Along the way, we do a few things:
- Make some formatting changes (mostly splitting very long lines)
- Add an ability to plug in a custom TX generator to the block generator (we use this to generate empty blocks).
- Add a function in the benchmarks package to generate a long chain of empty blocks, with delegation initiated at genesis. This moves one function from ouroboros-consensus into shelley-spec-ledger-test.
- Adds two benchmarks:
  - One for `createRUpd`, built upon a generated chain with some praos blocks issued.
  - One for `likelihood`, which was the majority of the reward calculation
- Optimise the `likelihood` calculation. This brings the micro-benchmark down from 50-60ms to around 1. 