### PR TITLE
Export empty predicate failures.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -11,6 +11,7 @@
 module Shelley.Spec.Ledger.STS.Mir
   ( MIR,
     PredicateFailure,
+    MirPredicateFailure,
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -8,6 +8,7 @@ module Shelley.Spec.Ledger.STS.PoolReap
   ( POOLREAP,
     PoolreapState (..),
     PredicateFailure,
+    PoolreapPredicateFailure,
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -8,6 +8,7 @@ module Shelley.Spec.Ledger.STS.Rupd
   ( RUPD,
     RupdEnv (..),
     PredicateFailure,
+    RupdPredicateFailure,
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -7,6 +7,7 @@
 module Shelley.Spec.Ledger.STS.Snap
   ( SNAP,
     PredicateFailure,
+    SnapPredicateFailure,
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
@@ -12,6 +12,7 @@ module Shelley.Spec.Ledger.STS.Updn
     UpdnEnv (..),
     UpdnState (..),
     PredicateFailure,
+    UpdnPredicateFailure,
   )
 where
 


### PR DESCRIPTION
Needed for orphan instances for cardano-node.