### PR TITLE
Expose TicknPredicateFailure.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tickn.hs
@@ -11,6 +11,7 @@ module Shelley.Spec.Ledger.STS.Tickn
   ( TICKN,
     TicknEnv (..),
     TicknState (..),
+    TicknPredicateFailure,
     PredicateFailure,
   )
 where


### PR DESCRIPTION
Needed for orphan instances in cardano-node.