### PR TITLE
overlay schedule functions to take a set of keys

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
@@ -29,6 +29,8 @@ import Cardano.Binary
 import Cardano.Ledger.Era (Era)
 import Cardano.Prelude (NFData, NoUnexpectedThunks)
 import Cardano.Slotting.Slot
+import qualified Data.Set as Set
+import Data.Set (Set)
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Keys
@@ -78,7 +80,7 @@ isOverlaySlot firstSlotNo dval slot = step s < step (s + 1)
 
 classifyOverlaySlot ::
   SlotNo -> -- first slot of the epoch
-  [KeyHash 'Genesis era] -> -- genesis Nodes
+  Set (KeyHash 'Genesis era) -> -- genesis Nodes
   UnitInterval -> -- decentralization parameter
   ActiveSlotCoeff -> -- active slot coefficent
   SlotNo -> -- overlay slot to classify
@@ -93,12 +95,12 @@ classifyOverlaySlot firstSlotNo gkeys dval ascValue slot =
     d = unitIntervalToRational dval
     position = ceiling (fromIntegral (slot -* firstSlotNo) * d)
     isActive = position `mod` ascInv == 0
-    getAtIndex ls i = if i < length ls then ActiveSlot (ls !! i) else NonActiveSlot
+    getAtIndex gs i = if i < length gs then ActiveSlot (Set.elemAt i gs) else NonActiveSlot
     ascInv = floor (1 / (unitIntervalToRational . activeSlotVal $ ascValue))
 
 lookupInOverlaySchedule ::
   SlotNo -> -- first slot of the epoch
-  [KeyHash 'Genesis era] -> -- genesis Nodes
+  Set (KeyHash 'Genesis era) -> -- genesis Nodes
   UnitInterval -> -- decentralization parameter
   ActiveSlotCoeff -> -- active slot coefficent
   SlotNo -> -- slot to lookup

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -261,7 +261,7 @@ overlayTransition =
           e <- epochInfoEpoch ei slot
           epochInfoFirst ei e
 
-        case lookupInOverlaySchedule firstSlotNo (Map.keys genDelegs) dval asc slot of
+        case lookupInOverlaySchedule firstSlotNo (Map.keysSet genDelegs) dval asc slot of
           Nothing ->
             praosVrfChecks eta0 pd asc bhb ?!: id
           Just NonActiveSlot ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -195,7 +195,7 @@ selectNextSlotWithLeader
         Maybe (ChainState era, AllIssuerKeys era 'BlockIssuer)
       selectLeaderForSlot slotNo =
         (chainSt,)
-          <$> case lookupInOverlaySchedule firstEpochSlot (Map.keys cores) d f slotNo of
+          <$> case lookupInOverlaySchedule firstEpochSlot (Map.keysSet cores) d f slotNo of
             Nothing ->
               coerce
                 <$> List.find
@@ -221,7 +221,7 @@ selectNextSlotWithLeader
           isLeader poolHash vrfKey =
             let y = VRF.evalCertified @(VRF (Crypto era)) () (mkSeed seedL slotNo epochNonce) vrfKey
                 stake = maybe 0 individualPoolStake $ Map.lookup poolHash poolDistr
-             in case lookupInOverlaySchedule firstEpochSlot (Map.keys cores) d f slotNo of
+             in case lookupInOverlaySchedule firstEpochSlot (Map.keysSet cores) d f slotNo of
                   Nothing -> checkLeaderValue (VRF.certifiedOutput y) stake f
                   Just (ActiveSlot x) | coerceKeyRole x == poolHash -> True
                   _ -> False

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
@@ -112,7 +112,7 @@ coreNodeKeysBySchedule ::
 coreNodeKeysBySchedule pp slot =
   case lookupInOverlaySchedule
          firstSlot
-         (Map.keys genDelegs)
+         (Map.keysSet genDelegs)
          (_d pp)
          (activeSlotCoeff testGlobals)
          slot' of

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
@@ -65,7 +65,7 @@ mainnetEpochSize = EpochSize 432000
 
 makeConcreteOverlay ::
   SlotNo -> -- first slot of the epoch
-  [KeyHash 'Genesis era] -> -- genesis Nodes
+  Set (KeyHash 'Genesis era) -> -- genesis Nodes
   UnitInterval -> -- decentralization parameter
   ActiveSlotCoeff -> -- active slot coefficent
   EpochSize -> -- slots per epoch
@@ -91,4 +91,4 @@ legacyOverlayTest = property $ do
           (Map.keysSet (genDelegs @C))
           dval
           asc
-  pure $ os === makeConcreteOverlay start (Map.keys (genDelegs @C)) dval asc mainnetEpochSize
+  pure $ os === makeConcreteOverlay start (Map.keysSet (genDelegs @C)) dval asc mainnetEpochSize


### PR DESCRIPTION
The overlay schedule relies on implicit ordering of genesis keys. So instead we now use a set, which has a canonical ordering.

closes #1856
