### PR TITLE
API Expansion

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -24,11 +24,11 @@ library
     Shelley.Spec.Ledger.Address
     Shelley.Spec.Ledger.Address.Bootstrap
     Shelley.Spec.Ledger.API
+    Shelley.Spec.Ledger.API.ByronTranslation
     Shelley.Spec.Ledger.API.Protocol
     Shelley.Spec.Ledger.API.Validation
     Shelley.Spec.Ledger.BaseTypes
     Shelley.Spec.Ledger.BlockChain
-    Shelley.Spec.Ledger.ByronTranslation
     Shelley.Spec.Ledger.Coin
     Shelley.Spec.Ledger.Credential
     Shelley.Spec.Ledger.Delegation.Certificates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -4,6 +4,7 @@ module Shelley.Spec.Ledger.API
   )
 where
 
+import Shelley.Spec.Ledger.API.ByronTranslation as X
 import Shelley.Spec.Ledger.API.Mempool as X
 import Shelley.Spec.Ledger.API.Protocol as X
 import Shelley.Spec.Ledger.API.Types as X

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
-module Shelley.Spec.Ledger.ByronTranslation
+module Shelley.Spec.Ledger.API.ByronTranslation
   ( mkInitialShelleyLedgerView,
     translateToShelleyLedgerState,
 
@@ -25,7 +25,9 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
-import Shelley.Spec.Ledger.API
+import Shelley.Spec.Ledger.API.Protocol
+import Shelley.Spec.Ledger.API.Types
+import Shelley.Spec.Ledger.API.Validation
 import Shelley.Spec.Ledger.Coin (word64ToCoin)
 import Shelley.Spec.Ledger.EpochBoundary
 import Shelley.Spec.Ledger.Genesis

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -28,13 +28,10 @@ import GHC.Stack (HasCallStack)
 import Shelley.Spec.Ledger.API.Protocol
 import Shelley.Spec.Ledger.API.Types
 import Shelley.Spec.Ledger.API.Validation
-import Shelley.Spec.Ledger.Coin (word64ToCoin)
 import Shelley.Spec.Ledger.EpochBoundary
-import Shelley.Spec.Ledger.Genesis
 import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.Rewards
 import Shelley.Spec.Ledger.Slot
-import Shelley.Spec.Ledger.UTxO
 
 -- | We use the same hashing algorithm so we can unwrap and rewrap the bytes.
 -- We don't care about the type that is hashed, which will differ going from

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 module Shelley.Spec.Ledger.API.Types
   ( module X,
   )
@@ -11,7 +13,9 @@ import Shelley.Spec.Ledger.Address.Bootstrap as X
   ( BootstrapWitness (..),
   )
 import Shelley.Spec.Ledger.BaseTypes as X
-  ( Network (..),
+  ( Globals (..),
+    Network (..),
+    Nonce (..),
     Port (..),
     StrictMaybe (..),
   )
@@ -22,9 +26,16 @@ import Shelley.Spec.Ledger.BlockChain as X
     HashHeader (..),
     LaxBlock (..),
     PrevHash (..),
+    bHeaderSize,
+    bbHash,
+    bbody,
+    bhHash,
+    bhbody,
+    bheader,
   )
 import Shelley.Spec.Ledger.Coin as X
   ( Coin (..),
+    word64ToCoin,
   )
 import Shelley.Spec.Ledger.Credential as X
   ( Credential (..),
@@ -35,16 +46,20 @@ import Shelley.Spec.Ledger.Delegation.Certificates as X
     DelegCert (..),
     PoolCert (..),
     PoolDistr (..),
+    individualPoolStake,
   )
 import Shelley.Spec.Ledger.EpochBoundary as X
-  ( SnapShot (SnapShot),
-    SnapShots (SnapShots),
-    Stake (Stake),
+  ( SnapShot (..),
+    SnapShots (..),
+    Stake (..),
   )
+import Shelley.Spec.Ledger.Genesis as X
 import Shelley.Spec.Ledger.Keys as X
   ( CertifiedVRF,
     GenDelegPair (..),
     GenDelegs (..),
+    Hash,
+    KESignable,
     KeyHash (..),
     KeyPair (..),
     KeyRole (..),
@@ -52,9 +67,12 @@ import Shelley.Spec.Ledger.Keys as X
     SignKeyKES,
     SignKeyVRF,
     SignedDSIGN,
+    SignedKES,
     VKey (..),
     VerKeyKES,
     VerKeyVRF,
+    coerceKeyRole,
+    hashKey,
     hashVerKeyVRF,
   )
 import Shelley.Spec.Ledger.LedgerState as X
@@ -70,37 +88,68 @@ import Shelley.Spec.Ledger.LedgerState as X
     UTxOState (..),
     WitHashes (..),
   )
-import Shelley.Spec.Ledger.OCert as X (OCert (..))
+import Shelley.Spec.Ledger.OCert as X (KESPeriod (..), OCert (..))
 import Shelley.Spec.Ledger.OverlaySchedule as X
   ( OBftSlot (..),
+    classifyOverlaySlot,
+    isOverlaySlot,
+    lookupInOverlaySchedule,
   )
 import Shelley.Spec.Ledger.PParams as X
   ( PParams,
     PParams' (..),
     ProposedPPUpdates (..),
+    ProtVer (..),
     Update (..),
   )
 import Shelley.Spec.Ledger.Rewards as X
   ( NonMyopic,
   )
-import Shelley.Spec.Ledger.STS.Chain as X (CHAIN, ChainState (..))
+import Shelley.Spec.Ledger.STS.Chain as X
+  ( CHAIN,
+    ChainState (..),
+    initialShelleyState,
+  )
 import Shelley.Spec.Ledger.STS.Deleg as X (DELEG, DelegEnv (..))
 import Shelley.Spec.Ledger.STS.Delegs as X (DELEGS, DelegsEnv (..))
 import Shelley.Spec.Ledger.STS.Delpl as X (DELPL, DelplEnv (..))
 import Shelley.Spec.Ledger.STS.Ledger as X (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.Ledgers as X (LEDGERS, LedgersEnv (..))
-import Shelley.Spec.Ledger.STS.NewEpoch as X (NEWEPOCH)
+import Shelley.Spec.Ledger.STS.NewEpoch as X
+  ( NEWEPOCH,
+    calculatePoolDistr,
+  )
 import Shelley.Spec.Ledger.STS.Ocert as X (OCertEnv (..))
 import Shelley.Spec.Ledger.STS.Pool as X (POOL, PoolEnv (..))
 import Shelley.Spec.Ledger.STS.PoolReap as X (POOLREAP)
 import Shelley.Spec.Ledger.STS.Ppup as X (PPUP, PPUPEnv (..))
+import Shelley.Spec.Ledger.STS.Prtcl as X
+  ( PrtclEnv (..),
+    PrtclPredicateFailure (..),
+    PrtclState (..),
+    PrtlSeqFailure (..),
+    prtlSeqChecks,
+  )
 import Shelley.Spec.Ledger.STS.Tick as X (TICK)
-import Shelley.Spec.Ledger.STS.Utxo as X (UTXO, UtxoEnv (..))
+import Shelley.Spec.Ledger.STS.Tickn as X
+  ( TICKN,
+    TicknEnv (..),
+    TicknPredicateFailure,
+    TicknState (..),
+  )
+import Shelley.Spec.Ledger.STS.Utxo as X
+  ( UTXO,
+    UtxoEnv (..),
+  )
 import Shelley.Spec.Ledger.STS.Utxow as X (UTXOW)
 import Shelley.Spec.Ledger.Scripts as X
   ( MultiSig (..),
     Script (..),
     ScriptHash (..),
+  )
+import Shelley.Spec.Ledger.StabilityWindow as X
+  ( computeRandomnessStabilisationWindow,
+    computeStabilityWindow,
   )
 import Shelley.Spec.Ledger.Tx as X
   ( Tx (..),
@@ -122,4 +171,8 @@ import Shelley.Spec.Ledger.TxBody as X
     TxId (..),
     Wdrl (..),
     WitVKey (..),
+  )
+import Shelley.Spec.Ledger.UTxO as X
+  ( UTxO (..),
+    balance,
   )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -28,10 +28,6 @@ import Data.Maybe (catMaybes, fromMaybe)
 import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.API
-import Shelley.Spec.Ledger.BaseTypes
-  ( Nonce (NeutralNonce),
-    activeSlotCoeff,
-  )
 import Shelley.Spec.Ledger.BlockChain
   ( LastAppliedBlock (..),
     checkLeaderValue,
@@ -39,15 +35,7 @@ import Shelley.Spec.Ledger.BlockChain
     mkSeed,
     seedL,
   )
-import Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..))
-import Shelley.Spec.Ledger.Keys
-  ( coerceKeyRole,
-    hashKey,
-  )
-import Shelley.Spec.Ledger.OCert (KESPeriod (..), currentIssueNo, kesPeriod)
-import Shelley.Spec.Ledger.OverlaySchedule (lookupInOverlaySchedule)
-import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
-import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
+import Shelley.Spec.Ledger.OCert (currentIssueNo, kesPeriod)
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC (choose)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -36,20 +36,13 @@ import qualified Data.Map.Strict as Map
 import Data.Proxy
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API
-import Shelley.Spec.Ledger.BaseTypes (Globals)
 import Shelley.Spec.Ledger.BlockChain
   ( LastAppliedBlock (..),
     hashHeaderToNonce,
   )
-import Shelley.Spec.Ledger.EpochBoundary (_pstakeMark)
-import Shelley.Spec.Ledger.Genesis (ShelleyGenesisStaking (..))
-import Shelley.Spec.Ledger.Keys (coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState (stakeDistr)
-import Shelley.Spec.Ledger.STS.Chain (initialShelleyState)
 import qualified Shelley.Spec.Ledger.STS.Chain as STS (ChainState (ChainState))
-import Shelley.Spec.Ledger.STS.NewEpoch (calculatePoolDistr)
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
-import Shelley.Spec.Ledger.UTxO (balance)
 import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( Mock,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -61,7 +61,6 @@ import Shelley.Spec.Ledger.Address.Bootstrap
 import Shelley.Spec.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     DnsName,
-    Nonce (..),
     UnitInterval,
     Url,
     mkActiveSlotCoeff,
@@ -84,8 +83,6 @@ import Shelley.Spec.Ledger.MetaData
     MetaDatum,
   )
 import qualified Shelley.Spec.Ledger.MetaData as MD
-import Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import Shelley.Spec.Ledger.PParams (ProtVer)
 import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     LogWeight (..),
@@ -103,7 +100,6 @@ import qualified Shelley.Spec.Ledger.STS.Tickn as STS
 import qualified Shelley.Spec.Ledger.STS.Utxo as STS
 import qualified Shelley.Spec.Ledger.STS.Utxow as STS
 import Shelley.Spec.Ledger.Tx (WitnessSetHKD (WitnessSet), hashScript)
-import Shelley.Spec.Ledger.UTxO (UTxO)
 import Test.QuickCheck
   ( Arbitrary,
     arbitrary,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -7,8 +7,8 @@ module Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation) whe
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import Cardano.Ledger.Era
+import Shelley.Spec.Ledger.API.ByronTranslation
 import Shelley.Spec.Ledger.Address
-import Shelley.Spec.Ledger.ByronTranslation
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.TxBody
 import Test.Cardano.Chain.UTxO.Gen (genCompactTxOut)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -4,10 +4,10 @@
 
 module Test.Shelley.Spec.Ledger.PropertyTests (propertyTests, minimalPropertyTests) where
 
+import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
   ( bootstrapHashTest,
   )
-import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
 import Test.Shelley.Spec.Ledger.LegacyOverlay (legacyOverlayTest)
 import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
   ( onlyValidChainSignalsAreGenerated,


### PR DESCRIPTION
This PR makes two changes:

- Moves `ByronTranslation` under `API`. This just provides some clarity about where it sits with regards to other things - it doesn't actually form part of the Shelley ledger, just utility to help work with it.
- Adds a slew of new things to the API, that have been observed as being depended on downstream.

The aim with this is to make it easier for us to do internal refactoring, since we can keep the API constant and hopefully know what is being used by downstream projects.

This is an incremental change; there are likely other things being used downstream, but finding them all at once is exhausting!

For those wondering why the addition of `DuplicateRecordFields` to `EpochBoundary`, it's because of https://gitlab.haskell.org/ghc/ghc/-/issues/13352