### PR TITLE
Ts minimize c

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -82,7 +82,6 @@ library
     hedgehog,
     iproute,
     multiset,
-    nonempty-containers,
     process-extras,
     QuickCheck >= 2.13.2,
     scientific,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -82,6 +82,7 @@ library
     hedgehog,
     iproute,
     multiset,
+    nonempty-containers,
     process-extras,
     QuickCheck >= 2.13.2,
     scientific,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -147,7 +147,7 @@ mkGenKey seed =
    in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic key pair given a seed.
-mkKeyPair ::
+mkKeyPair :: forall era kd.
   DSIGNAlgorithm (DSIGN (Crypto era)) =>
   (Word64, Word64, Word64, Word64, Word64) ->
   (SignKeyDSIGN (DSIGN (Crypto era)), VKey kd era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -4,13 +4,24 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds #-}
+
+
 module Test.Shelley.Spec.Ledger.Fees
   ( sizeTests,
+    runLocalTest,
   )
 where
 
+import Cardano.Crypto.VRF(VRFAlgorithm)
+import qualified Cardano.Ledger.Crypto as CC
+import qualified Cardano.Crypto.VRF as VV
 import Cardano.Binary (serialize)
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Era (Era(..))
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.ByteString.Lazy as BSL
@@ -29,12 +40,12 @@ import Shelley.Spec.Ledger.API
     PoolCert (..),
     PoolParams (..),
     RewardAcnt (..),
-    SignKeyVRF,
+    -- SignKeyVRF,  -- Not sure we are importing the right SignKeyVRF
     Tx (..),
     TxBody (..),
     TxIn (..),
     TxOut (..),
-    VerKeyVRF,
+    -- VerKeyVRF,  -- or the right VerKeyVRF
     hashVerKeyVRF,
   )
 import Shelley.Spec.Ledger.BaseTypes
@@ -52,6 +63,8 @@ import Shelley.Spec.Ledger.Keys
     asWitness,
     hashKey,
     vKey,
+    DSignable,
+    Hash,
   )
 import Shelley.Spec.Ledger.LedgerState (txsize)
 import qualified Shelley.Spec.Ledger.MetaData as MD
@@ -68,8 +81,8 @@ import Shelley.Spec.Ledger.TxBody
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Generator.Core (genesisId)
-import Test.Shelley.Spec.Ledger.Utils
-import Test.Tasty (TestTree, testGroup)
+import Test.Shelley.Spec.Ledger.Utils( mkKeyPair, mkAddr,  mkVRFKeyPair, unsafeMkUnitInterval )
+import Test.Tasty (TestTree, testGroup, defaultMain)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 sizeTest ::
@@ -82,35 +95,36 @@ sizeTest ::
 sizeTest _ b16 tx s = do
   (Base16.encode (serialize tx) @?= b16) >> (txsize tx @?= s)
 
-alicePay :: KeyPair 'Payment C
-alicePay = KeyPair vk sk
-  where
-    (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
 
-aliceStake :: KeyPair 'Staking C
+alicePay :: forall era. Era era => KeyPair 'Payment era
+alicePay = KeyPair @'Payment @era vk sk
+  where
+    (sk, vk) = mkKeyPair @era (0, 0, 0, 0, 0)
+
+aliceStake :: forall era. Era era => KeyPair 'Staking era
 aliceStake = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair (0, 0, 0, 0, 1)
+    (sk, vk) = mkKeyPair @era (0, 0, 0, 0, 1)
 
-aliceSHK :: Credential 'Staking C
+aliceSHK :: forall era . Era era => Credential 'Staking era
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
-alicePool :: KeyPair 'StakePool C
+alicePool :: forall era . Era era => KeyPair 'StakePool era
 alicePool = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair (0, 0, 0, 0, 2)
+    (sk, vk) = mkKeyPair @era (0, 0, 0, 0, 2)
 
-alicePoolKH :: KeyHash 'StakePool C
+alicePoolKH ::  forall era . Era era => KeyHash 'StakePool era
 alicePoolKH = (hashKey . vKey) alicePool
 
-aliceVRF :: (SignKeyVRF C, VerKeyVRF C)
+aliceVRF:: forall v. VRFAlgorithm v => (VV.SignKeyVRF v, VV.VerKeyVRF v)
 aliceVRF = mkVRFKeyPair (0, 0, 0, 0, 3)
 
-alicePoolParams :: PoolParams C
+alicePoolParams ::  forall era . Era era => PoolParams era
 alicePoolParams =
   PoolParams
     { _poolPubKey = alicePoolKH,
-      _poolVrf = hashVerKeyVRF . snd $ aliceVRF,
+      _poolVrf = hashVerKeyVRF . snd $ aliceVRF  @(CC.VRF (Crypto era)),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,
       _poolMargin = unsafeMkUnitInterval 0.1,
@@ -128,33 +142,33 @@ alicePoolParams =
             }
     }
 
-aliceAddr :: Addr C
+aliceAddr :: forall era. Era era => Addr era
 aliceAddr = mkAddr (alicePay, aliceStake)
 
-bobPay :: KeyPair 'Payment C
+bobPay :: forall era. Era era => KeyPair 'Payment era
 bobPay = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair (1, 0, 0, 0, 0)
+    (sk, vk) = mkKeyPair @era (1, 0, 0, 0, 0)
 
-bobStake :: KeyPair 'Staking C
+bobStake :: forall era. Era era => KeyPair 'Staking era
 bobStake = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair (1, 0, 0, 0, 1)
+    (sk, vk) = mkKeyPair @era (1, 0, 0, 0, 1)
 
-bobSHK :: Credential 'Staking C
+bobSHK :: forall era. Era era => Credential 'Staking era
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
-bobAddr :: Addr C
+bobAddr ::forall era. Era era => Addr era
 bobAddr = mkAddr (bobPay, bobStake)
 
-carlPay :: KeyPair 'Payment C
+carlPay :: forall era. Era era => KeyPair 'Payment era
 carlPay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (2, 0, 0, 0, 0)
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-txbSimpleUTxO :: TxBody C
+txbSimpleUTxO :: forall era. Era era => TxBody era
 txbSimpleUTxO =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -167,23 +181,29 @@ txbSimpleUTxO =
       _mdHash = SNothing
     }
 
-txSimpleUTxO :: Tx C
+
+-- | to use makeWitnessVKey, we need to know we can sign the TxBody for that era
+
+type BodySignable era = DSignable era (Hash era (TxBody era))
+
+txSimpleUTxO :: forall era. (Era era, BodySignable  era) => Tx era
 txSimpleUTxO =
   Tx
     { _body = txbSimpleUTxO,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbSimpleUTxO) [alicePay]
+          { addrWits = makeWitnessesVKey @era (hashAnnotated txbSimpleUTxO) [alicePay @era ]
           },
       _metadata = SNothing
     }
+
 
 txSimpleUTxOBytes16 :: BSL.ByteString
 txSimpleUTxOBytes16 = "83a40081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030aa10081824873ed39075e40d2a650ecca0b99fca3d8d173ed39075e40d2a6f6"
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
-txbMutiUTxO :: TxBody C
+txbMutiUTxO :: forall era. Era era => TxBody era
 txbMutiUTxO =
   TxBody
     { _inputs =
@@ -207,7 +227,7 @@ txbMutiUTxO =
       _mdHash = SNothing
     }
 
-txMutiUTxO :: Tx C
+txMutiUTxO :: forall era. (Era era, BodySignable  era) => Tx era
 txMutiUTxO =
   Tx
     { _body = txbMutiUTxO,
@@ -216,7 +236,7 @@ txMutiUTxO =
           { addrWits =
               makeWitnessesVKey
                 (hashAnnotated txbMutiUTxO)
-                [ alicePay,
+                [ alicePay ,
                   bobPay
                 ]
           },
@@ -227,7 +247,7 @@ txMutiUTxOBytes16 :: BSL.ByteString
 txMutiUTxOBytes16 = "83a40082824a9db8a41713ad20245f4e00824a9db8a41713ad20245f4e01018582510075c40f44e1c155bedab80d3ec7c2190b0a82510075c40f44e1c155bedab80d3ec7c2190b1482510075c40f44e1c155bedab80d3ec7c2190b181e8251009ed1f6c32150add8a084ba8f6c83c1a518288251009ed1f6c32150add8a084ba8f6c83c1a518320218c7030aa10082824873ed39075e40d2a650f44dc9848e2c0aea73ed39075e40d2a682483e046f8a4a4eeda150f44dc9848e2c0aea3e046f8a4a4eeda1f6"
 
 -- | Transaction which registers a stake key
-txbRegisterStake :: TxBody C
+txbRegisterStake :: forall era. Era era => TxBody era
 txbRegisterStake =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -240,7 +260,7 @@ txbRegisterStake =
       _mdHash = SNothing
     }
 
-txRegisterStake :: Tx C
+txRegisterStake :: forall era. (Era era, BodySignable  era) => Tx era
 txRegisterStake =
   Tx
     { _body = txbRegisterStake,
@@ -255,7 +275,7 @@ txRegisterStakeBytes16 :: BSL.ByteString
 txRegisterStakeBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818200820048dab80d3ec7c2190ba10081824873ed39075e40d2a650e4d2720634c8e8ab73ed39075e40d2a6f6"
 
 -- | Transaction which delegates a stake key
-txbDelegateStake :: TxBody C
+txbDelegateStake :: forall era. Era era => TxBody era
 txbDelegateStake =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -272,7 +292,7 @@ txbDelegateStake =
       _mdHash = SNothing
     }
 
-txDelegateStake :: Tx C
+txDelegateStake :: forall era. (Era era, BodySignable  era) => Tx era
 txDelegateStake =
   Tx
     { _body = txbDelegateStake,
@@ -281,7 +301,7 @@ txDelegateStake =
           { addrWits =
               makeWitnessesVKey
                 (hashAnnotated txbDelegateStake)
-                [asWitness alicePay, asWitness bobStake]
+                [asWitness (alicePay @era), asWitness bobStake]
           },
       _metadata = SNothing
     }
@@ -290,7 +310,7 @@ txDelegateStakeBytes16 :: BSL.ByteString
 txDelegateStakeBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818302820048a084ba8f6c83c1a548bc5edd0d46d5e843a10082824873ed39075e40d2a650a0f42ce9b916eb9d73ed39075e40d2a68248244ad6b5eb5665c750a0f42ce9b916eb9d244ad6b5eb5665c7f6"
 
 -- | Transaction which de-registers a stake key
-txbDeregisterStake :: TxBody C
+txbDeregisterStake :: forall era. Era era => TxBody era
 txbDeregisterStake =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -303,13 +323,13 @@ txbDeregisterStake =
       _mdHash = SNothing
     }
 
-txDeregisterStake :: Tx C
+txDeregisterStake :: forall era. (Era era, BodySignable  era) => Tx era
 txDeregisterStake =
   Tx
     { _body = txbDeregisterStake,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbDeregisterStake) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated txbDeregisterStake) [alicePay @era]
           },
       _metadata = SNothing
     }
@@ -318,7 +338,7 @@ txDeregisterStakeBytes16 :: BSL.ByteString
 txDeregisterStakeBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818201820048dab80d3ec7c2190ba10081824873ed39075e40d2a650be9cfdc830b8cb5173ed39075e40d2a6f6"
 
 -- | Transaction which registers a stake pool
-txbRegisterPool :: TxBody C
+txbRegisterPool :: forall era. Era era => TxBody era
 txbRegisterPool =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -331,13 +351,13 @@ txbRegisterPool =
       _mdHash = SNothing
     }
 
-txRegisterPool :: Tx C
+txRegisterPool :: forall era. (Era era, BodySignable  era) => Tx era
 txRegisterPool =
   Tx
     { _body = txbRegisterPool,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbRegisterPool) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated txbRegisterPool) [alicePay @era]
           },
       _metadata = SNothing
     }
@@ -346,7 +366,7 @@ txRegisterPoolBytes16 :: BSL.ByteString
 txRegisterPoolBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818a0348bc5edd0d46d5e8434a3d64a89de764031618600105d81e82010a49e0dab80d3ec7c2190b8148dab80d3ec7c2190b818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081824873ed39075e40d2a650d744f1f7d47c27e473ed39075e40d2a6f6"
 
 -- | Transaction which retires a stake pool
-txbRetirePool :: TxBody C
+txbRetirePool :: forall era. Era era => TxBody era
 txbRetirePool =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -359,13 +379,13 @@ txbRetirePool =
       _mdHash = SNothing
     }
 
-txRetirePool :: Tx C
+txRetirePool :: forall era. (Era era, BodySignable  era) => Tx era
 txRetirePool =
   Tx
     { _body = txbRetirePool,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbRetirePool) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated txbRetirePool) [alicePay @era]
           },
       _metadata = SNothing
     }
@@ -378,7 +398,7 @@ txRetirePoolBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c15
 md :: MD.MetaData
 md = MD.MetaData $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 
-txbWithMD :: TxBody C
+txbWithMD :: forall era. Era era => TxBody era
 txbWithMD =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -391,13 +411,13 @@ txbWithMD =
       _mdHash = SJust $ MD.hashMetaData md
     }
 
-txWithMD :: Tx C
+txWithMD :: forall era. (Era era, BodySignable  era) => Tx era
 txWithMD =
   Tx
     { _body = txbWithMD,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbWithMD) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated txbWithMD) [alicePay @era]
           },
       _metadata = SJust md
     }
@@ -406,16 +426,16 @@ txWithMDBytes16 :: BSL.ByteString
 txWithMDBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a074a4eece6527f366cfa5e71a10081824873ed39075e40d2a650203cdabf7e292c0673ed39075e40d2a6a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
-msig :: MultiSig C
+msig :: forall era. Era era => MultiSig era
 msig =
   RequireMOf
     2
-    [ (RequireSignature . asWitness . hashKey . vKey) alicePay,
+    [ (RequireSignature . asWitness . hashKey . vKey) (alicePay @era),
       (RequireSignature . asWitness . hashKey . vKey) bobPay,
       (RequireSignature . asWitness . hashKey . vKey) carlPay
     ]
 
-txbWithMultiSig :: TxBody C
+txbWithMultiSig :: forall era. Era era => TxBody era
 txbWithMultiSig =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0], -- acting as if this is multi-sig
@@ -428,14 +448,14 @@ txbWithMultiSig =
       _mdHash = SNothing
     }
 
-txWithMultiSig :: Tx C
+txWithMultiSig :: forall era. (Era era, BodySignable  era) => Tx era
 txWithMultiSig =
   Tx
     { _body = txbWithMultiSig,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (hashAnnotated txbWithMultiSig) [alicePay, bobPay],
-            msigWits = Map.singleton (hashScript msig) msig
+          { addrWits = makeWitnessesVKey (hashAnnotated txbWithMultiSig) [alicePay @era, bobPay],
+            msigWits = Map.singleton (hashScript @(MultiSig era) msig) msig
           },
       _metadata = SNothing
     }
@@ -444,7 +464,7 @@ txWithMultiSigBytes16 :: BSL.ByteString
 txWithMultiSigBytes16 = "83a40081824a9db8a41713ad20245f4e00018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030aa20082824873ed39075e40d2a650ecca0b99fca3d8d173ed39075e40d2a682483e046f8a4a4eeda150ecca0b99fca3d8d13e046f8a4a4eeda101818303028382004875c40f44e1c155be8200489ed1f6c32150add8820048b59ebd7e616fad7ef6"
 
 -- | Transaction with a Reward Withdrawal
-txbWithWithdrawal :: TxBody C
+txbWithWithdrawal :: forall era. Era era => TxBody era
 txbWithWithdrawal =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -457,7 +477,7 @@ txbWithWithdrawal =
       _mdHash = SNothing
     }
 
-txWithWithdrawal :: Tx C
+txWithWithdrawal :: forall era. (Era era, BodySignable  era) => Tx era
 txWithWithdrawal =
   Tx
     { _body = txbWithWithdrawal,
@@ -466,7 +486,7 @@ txWithWithdrawal =
           { addrWits =
               makeWitnessesVKey
                 (hashAnnotated txbWithWithdrawal)
-                [asWitness alicePay, asWitness aliceStake]
+                [asWitness (alicePay @era), asWitness aliceStake]
           },
       _metadata = SNothing
     }
@@ -481,9 +501,9 @@ txWithWithdrawalBytes16 = "83a50081824a9db8a41713ad20245f4e00018182510075c40f44e
 --       the verification key size is -->  8
 --       the signature size is ---------> 13
 
+
 sizeTests :: TestTree
-sizeTests =
-  testGroup
+sizeTests = testGroup
     "Fee Tests"
     [ testCase "simple utxo" $ sizeTest p txSimpleUTxOBytes16 txSimpleUTxO 75,
       testCase "multiple utxo" $ sizeTest p txMutiUTxOBytes16 txMutiUTxO 198,
@@ -499,3 +519,6 @@ sizeTests =
   where
     p :: Proxy C
     p = Proxy
+
+runLocalTest :: IO ()
+runLocalTest = defaultMain sizeTests


### PR DESCRIPTION
This is a small 2 file PR, that minimizes the use of the concrete crypto type era C. 
This is meant to address issue  #1822 .
In the file Test.Shelley.Spec.Ledger.Fees  
We have made every thing parametric over the era, except the final object of type TestTree, that is fixed in the era C.
