### PR TITLE
Change how we enforce metadata sizes

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -48,6 +48,7 @@ library
     Shelley.Spec.Ledger.Scripts
     Shelley.Spec.Ledger.Serialization
     Shelley.Spec.Ledger.Slot
+    Shelley.Spec.Ledger.SoftForks
     Shelley.Spec.Ledger.StabilityWindow
     Shelley.Spec.Ledger.STS.Bbody
     Shelley.Spec.Ledger.STS.Chain

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -91,7 +91,7 @@ import Shelley.Spec.Ledger.LedgerState as X
 import Shelley.Spec.Ledger.MetaData as X
   ( MetaData (..),
     MetaDatum (..),
-import Shelley.Spec.Ledger.OCert as X (OCert (..))
+  )
 import Shelley.Spec.Ledger.OCert as X (KESPeriod (..), OCert (..))
 import Shelley.Spec.Ledger.OverlaySchedule as X
   ( OBftSlot (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -88,6 +88,10 @@ import Shelley.Spec.Ledger.LedgerState as X
     UTxOState (..),
     WitHashes (..),
   )
+import Shelley.Spec.Ledger.MetaData as X
+  ( MetaData (..),
+    MetaDatum (..),
+import Shelley.Spec.Ledger.OCert as X (OCert (..))
 import Shelley.Spec.Ledger.OCert as X (KESPeriod (..), OCert (..))
 import Shelley.Spec.Ledger.OverlaySchedule as X
   ( OBftSlot (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -14,6 +15,7 @@ module Shelley.Spec.Ledger.MetaData
     MetaData (MetaData),
     MetaDataHash (..),
     hashMetaData,
+    validMetaData,
   )
 where
 
@@ -28,27 +30,28 @@ import Cardano.Binary
   )
 import Cardano.Ledger.Era (Era)
 import Cardano.Prelude (AllowThunksIn (..), LByteString, NoUnexpectedThunks (..), Word64, cborError)
-import qualified Codec.CBOR.Term as CBOR
-import Data.Bifunctor (bimap)
-import Data.Bitraversable (bitraverse)
-import Data.ByteString as B
-import Data.ByteString.Lazy as BL
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Decoding as CBOR
+import Codec.CBOR.Decoding (Decoder)
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Encoding as T
 import GHC.Generics (Generic)
 import Shelley.Spec.Ledger.Keys (Hash, hashWithSerialiser)
 import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
 -- | A generic metadatum type.
 --
--- TODO make strict
 data MetaDatum
+-- TODO make strict:
   = Map [(MetaDatum, MetaDatum)]
   | List [MetaDatum]
-  | I Integer
-  | B B.ByteString
-  | S T.Text
+  | I !Integer
+  | B !BS.ByteString
+  | S !T.Text
   deriving stock (Show, Eq, Ord, Generic)
 
 instance NoUnexpectedThunks MetaDatum
@@ -71,55 +74,18 @@ pattern MetaData m <-
 {-# COMPLETE MetaData #-}
 
 instance ToCBOR MetaData where
-  toCBOR = encodePreEncoded . BL.toStrict . mdBytes
+  toCBOR = encodePreEncoded . LBS.toStrict . mdBytes
 
 instance FromCBOR (Annotator MetaData) where
   fromCBOR = do
     (m, bytesAnn) <- withSlice mapFromCBOR
     pure $ MetaData' m <$> bytesAnn
 
-type CBORToDataError = String
-
-{- Note [Permissive decoding]
-We're using a canonical representation of lists, maps, bytes, and integers. However,
-the CBOR library does not guarantee that a TInteger gets encoded as a big integer,
-so we can't rely on getting back our canonical version when we decode (see
-https://github.com/well-typed/cborg/issues/222). So we need to be permissive
-when we decode.
--}
-
-fromTerm :: CBOR.Term -> Either CBORToDataError MetaDatum
-fromTerm t =
-  case t of
-    CBOR.TInt i -> Right $ I (fromIntegral i)
-    CBOR.TInteger i -> Right $ I i
-    CBOR.TBytes b -> Right $ B b
-    CBOR.TBytesI b -> Right $ B (BL.toStrict b)
-    CBOR.TString s -> Right $ S s
-    CBOR.TStringI s -> Right $ S (TL.toStrict s)
-    CBOR.TMap m -> Map <$> traverse (bitraverse fromTerm fromTerm) m
-    CBOR.TMapI m -> Map <$> traverse (bitraverse fromTerm fromTerm) m
-    CBOR.TList l -> List <$> traverse fromTerm l
-    CBOR.TListI l -> List <$> traverse fromTerm l
-    _ -> Left $ "Unsupported CBOR term: " ++ show t
-
-toTerm :: MetaDatum -> CBOR.Term
-toTerm = \case
-  I i -> CBOR.TInteger i
-  B b -> CBOR.TBytes b
-  S s -> CBOR.TString s
-  Map entries -> CBOR.TMap (fmap (bimap toTerm toTerm) entries)
-  List ts -> CBOR.TList (fmap toTerm ts)
-
 instance ToCBOR MetaDatum where
-  toCBOR = CBOR.encodeTerm . toTerm
+  toCBOR = encodeMetaDatum
 
 instance FromCBOR MetaDatum where
-  fromCBOR = do
-    t <- CBOR.decodeTerm
-    case fromTerm t of
-      Right d -> pure d
-      Left e -> (cborError . DecoderErrorCustom "metadata" . T.pack) e
+  fromCBOR = decodeMetaDatum
 
 newtype MetaDataHash era = MetaDataHash {unsafeMetaDataHash :: Hash era MetaData}
   deriving (Show, Eq, Ord, NoUnexpectedThunks)
@@ -133,3 +99,154 @@ hashMetaData ::
   MetaData ->
   MetaDataHash era
 hashMetaData = MetaDataHash . hashWithSerialiser toCBOR
+
+
+--------------------------------------------------------------------------------
+-- Validation of sizes
+
+validMetaData :: MetaData -> Bool
+validMetaData (MetaData m) = all validMetaDatum m
+
+validMetaDatum :: MetaDatum -> Bool
+-- The integer size/representation checks are enforced in the decoder.
+validMetaDatum (I _)     = True
+validMetaDatum (B b)     = BS.length b <= 64
+validMetaDatum (S s)     = BS.length (T.encodeUtf8 s) <= 64
+validMetaDatum (List xs) = all validMetaDatum xs
+validMetaDatum (Map kvs) = all (\(k,v) -> validMetaDatum k
+                                       && validMetaDatum v) kvs
+
+
+--------------------------------------------------------------------------------
+-- CBOR encoding and decoding
+
+encodeMetaDatum :: MetaDatum -> CBOR.Encoding
+encodeMetaDatum (I n)     = CBOR.encodeInteger n
+encodeMetaDatum (B b)     = CBOR.encodeBytes b
+encodeMetaDatum (S s)     = CBOR.encodeString s
+encodeMetaDatum (List xs) = CBOR.encodeListLen (fromIntegral (length xs))
+                         <> mconcat [ encodeMetaDatum x
+                                    | x <- xs ]
+encodeMetaDatum (Map kvs) = CBOR.encodeMapLen (fromIntegral (length kvs))
+                         <> mconcat [ encodeMetaDatum k <> encodeMetaDatum v
+                                    | (k, v) <- kvs ]
+
+
+-- | Decode a transaction matadatum value from its CBOR representation.
+--
+-- The CDDL for the CBOR is
+--
+-- > transaction_metadatum =
+-- >     int
+-- >   / bytes .size (0..64)
+-- >   / text .size (0..64)
+-- >   / [ * transaction_metadatum ]
+-- >   / { * transaction_metadatum => transaction_metadatum }
+--
+-- We do not require canonical representations, just like everywhere else
+-- on the chain. We accept both definte and indefinite representations.
+--
+-- The byte and string length checks are not enforced in this decoder, but
+--
+decodeMetaDatum :: Decoder s MetaDatum
+decodeMetaDatum = do
+    tkty <- CBOR.peekTokenType
+    case tkty of
+      -- We support -(2^64-1) .. 2^64-1, but not big integers
+      -- not even big integer representation of values within range
+      CBOR.TypeUInt         -> I <$> CBOR.decodeInteger
+      CBOR.TypeUInt64       -> I <$> CBOR.decodeInteger
+      CBOR.TypeNInt         -> I <$> CBOR.decodeInteger
+      CBOR.TypeNInt64       -> I <$> CBOR.decodeInteger
+
+      -- Note that we do not enforce byte and string lengths here in the
+      -- decoder. We enforce that in the tx validation rules.
+      CBOR.TypeBytes        -> do !x <- CBOR.decodeBytes
+                                  return (B x)
+      CBOR.TypeBytesIndef   -> do CBOR.decodeBytesIndef
+                                  !x <- decodeBytesIndefLen []
+                                  return (B x)
+
+      CBOR.TypeString       -> do !x <- CBOR.decodeString
+                                  return (S x)
+      CBOR.TypeStringIndef  -> do CBOR.decodeStringIndef
+                                  !x <- decodeStringIndefLen []
+                                  return (S x)
+
+      -- Why does it work to do the same thing here for 32 and 64bit list len
+      -- tokens? On 32bit systems the decodeListLen will fail if the value
+      -- really is bigger than maxBound :: Int, and on 64bit systems if a value
+      -- that big is provided, then it'll fail when it runs out of input for
+      -- such a big list. Hence we can do exactly the same for the 32bit and
+      -- 64bit cases.
+      CBOR.TypeListLen      -> do n <- CBOR.decodeListLen
+                                  xs <- decodeListN n []
+                                  return (List xs)
+      CBOR.TypeListLen64    -> do n <- CBOR.decodeListLen
+                                  xs <- decodeListN n []
+                                  return (List xs)
+
+      CBOR.TypeListLenIndef -> do CBOR.decodeListLenIndef
+                                  xs <- decodeListIndefLen []
+                                  return (List xs)
+
+      -- Same logic applies as above for large lists.
+      CBOR.TypeMapLen       -> do n <- CBOR.decodeMapLen
+                                  xs <- decodeMapN n []
+                                  return (Map xs)
+      CBOR.TypeMapLen64     -> do n <- CBOR.decodeMapLen
+                                  xs <- decodeMapN n []
+                                  return (Map xs)
+
+      CBOR.TypeMapLenIndef  -> do CBOR.decodeMapLenIndef
+                                  xs <- decodeMapIndefLen []
+                                  return (Map xs)
+
+      _ -> decodeError ("Unsupported CBOR token type " <> T.pack (show tkty))
+  where
+    decodeError msg = cborError (DecoderErrorCustom "metadata" msg)
+
+decodeBytesIndefLen :: [BS.ByteString] -> CBOR.Decoder s ByteString
+decodeBytesIndefLen acc = do
+    stop <- CBOR.decodeBreakOr
+    if stop then return $! BS.concat (reverse acc)
+            else do !bs <- CBOR.decodeBytes
+                    decodeBytesIndefLen (bs : acc)
+
+decodeStringIndefLen :: [T.Text] -> Decoder s T.Text
+decodeStringIndefLen acc = do
+    stop <- CBOR.decodeBreakOr
+    if stop then return $! T.concat (reverse acc)
+            else do !str <- CBOR.decodeString
+                    decodeStringIndefLen (str : acc)
+
+decodeListN :: Int -> [MetaDatum] -> Decoder s [MetaDatum]
+decodeListN !n acc =
+    case n of
+      0 -> return $! reverse acc
+      _ -> do !t <- decodeMetaDatum
+              decodeListN (n-1) (t : acc)
+
+decodeListIndefLen :: [MetaDatum] -> Decoder s [MetaDatum]
+decodeListIndefLen acc = do
+    stop <- CBOR.decodeBreakOr
+    if stop then return $! reverse acc
+            else do !tm <- decodeMetaDatum
+                    decodeListIndefLen (tm : acc)
+
+decodeMapN :: Int -> [(MetaDatum, MetaDatum)] -> Decoder s [(MetaDatum, MetaDatum)]
+decodeMapN !n acc =
+    case n of
+      0 -> return $! reverse acc
+      _ -> do !tm   <- decodeMetaDatum
+              !tm'  <- decodeMetaDatum
+              decodeMapN (n-1) ((tm, tm') : acc)
+
+decodeMapIndefLen :: [(MetaDatum, MetaDatum)] -> Decoder s [(MetaDatum, MetaDatum)]
+decodeMapIndefLen acc = do
+    stop <- CBOR.decodeBreakOr
+    if stop then return $! reverse acc
+            else do !tm  <- decodeMetaDatum
+                    !tm' <- decodeMetaDatum
+                    decodeMapIndefLen ((tm, tm') : acc)
+

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -148,7 +148,7 @@ deriving instance Show (PParams' Identity era)
 
 deriving instance NFData (PParams' Identity era)
 
-data ProtVer = ProtVer !Natural !Natural
+data ProtVer = ProtVer {pvMajor :: !Natural, pvMinor :: !Natural}
   deriving (Show, Eq, Generic, Ord, NFData)
   deriving (ToCBOR) via (CBORGroup ProtVer)
   deriving (FromCBOR) via (CBORGroup ProtVer)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -26,6 +26,7 @@ import Cardano.Binary
 import Cardano.Ledger.Era (Era)
 import Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import Control.Iterate.SetAlgebra (eval, (∩))
+import Control.Monad (when)
 import Control.State.Transition
   ( Embed,
     IRC (..),
@@ -80,6 +81,7 @@ import Shelley.Spec.Ledger.MetaData (MetaDataHash, hashMetaData, validMetaData)
 import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv (..))
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
 import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordSum, decodeSet, encodeFoldable)
+import qualified Shelley.Spec.Ledger.SoftForks as SoftForks
 import Shelley.Spec.Ledger.Tx
   ( Tx (..),
     hashScript,
@@ -244,7 +246,7 @@ utxoWitnessed =
         (SJust mdh, SJust md') -> do
           hashMetaData md' == mdh ?! ConflictingMetaDataHash mdh (hashMetaData md')
           -- check metadata value sizes
-          validMetaData md' ?! InvalidMetaData
+          when (SoftForks.validMetaData pp) $ validMetaData md' ?! InvalidMetaData
 
       -- check genesis keys signatures for instantaneous rewards certificates
       let genDelegates = Set.fromList $ fmap (asWitness . genDelegKeyHash) $ Map.elems genMapping

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -112,7 +112,7 @@ data UtxowPredicateFailure era
   | ConflictingMetaDataHash
       !(MetaDataHash era) -- hash of the metadata included in the transaction body
       !(MetaDataHash era) -- hash of the full metadata
-    -- Contains out of range values (strings too long)
+      -- Contains out of range values (strings too long)
   | InvalidMetaData
   deriving (Eq, Generic, Show)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -1,0 +1,9 @@
+module Shelley.Spec.Ledger.SoftForks
+  ( validMetaData,
+  )
+where
+
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
+
+validMetaData :: PParams era -> Bool
+validMetaData pp = pvMinor (_protocolVersion pp) > 0

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -77,11 +77,6 @@ import Shelley.Spec.Ledger.LedgerState
     PPUPState,
     emptyRewardUpdate,
   )
-import Shelley.Spec.Ledger.MetaData
-  ( MetaData,
-    MetaDataHash (..),
-    MetaDatum,
-  )
 import qualified Shelley.Spec.Ledger.MetaData as MD
 import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
@@ -249,7 +244,7 @@ maxMetaDatumDepth = 2
 maxMetaDatumListLens :: Int
 maxMetaDatumListLens = 5
 
-sizedMetaDatum :: Int -> Gen MetaDatum
+sizedMetaDatum :: Int -> Gen MD.MetaDatum
 sizedMetaDatum 0 =
   oneof
     [ MD.I <$> arbitrary,
@@ -269,10 +264,10 @@ sizedMetaDatum n =
       MD.S <$> (T.pack <$> arbitrary)
     ]
 
-instance Arbitrary MetaDatum where
+instance Arbitrary MD.MetaDatum where
   arbitrary = sizedMetaDatum maxMetaDatumDepth
 
-instance Arbitrary MetaData where
+instance Arbitrary MD.MetaData where
   arbitrary = MD.MetaData <$> arbitrary
 
 maxTxWits :: Int
@@ -444,8 +439,8 @@ instance Arbitrary ProtVer where
 instance Era era => Arbitrary (ScriptHash era) where
   arbitrary = ScriptHash <$> genHash
 
-instance Era era => Arbitrary (MetaDataHash era) where
-  arbitrary = MetaDataHash <$> genHash
+instance Era era => Arbitrary (MD.MetaDataHash era) where
+  arbitrary = MD.MetaDataHash <$> genHash
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where
   arbitrary = genHash

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
@@ -139,6 +139,9 @@ prop_roundtrip_MultiSig = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBO
 prop_roundtrip_Script :: Ledger.Script Mock.C -> Property
 prop_roundtrip_Script = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
+prop_roundtrip_metadata :: Ledger.MetaData -> Property
+prop_roundtrip_metadata = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
+
 -- TODO
 
 -- roundTripIpv4 :: Property
@@ -174,5 +177,6 @@ tests =
       testProperty "roundtrip Ledger State" prop_roundtrip_LedgerState,
       testProperty "roundtrip NewEpoch State" prop_roundtrip_NewEpochState,
       testProperty "roundtrip MultiSig" prop_roundtrip_MultiSig,
-      testProperty "roundtrip Script" prop_roundtrip_Script
+      testProperty "roundtrip Script" prop_roundtrip_Script,
+      testProperty "roundtrip MetaData" prop_roundtrip_metadata
     ]


### PR DESCRIPTION
The first patch changes the decoder to be more pedantic and depend only on low-level CBOR lib functionality, not the higher level Term (which accepts big ints which we do not want).

The second introduces extra validation checks in the UTXOW rule.

TODO:

* [x] review encoding/decoding round-trip tests for the metadata
* [x] adjust the extra validation in the UTXOW rule to do so conditionally on the protocol minor version, so that this restriction can be brought in as a soft fork for minimum disruption.
* [x] adjust my beautifully formatted code to make it sufficiently ugly to pass the CI checks