### PR TITLE
Parametrise the Shelley ledger over Value (see 1847)

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Value.hs
@@ -111,6 +111,7 @@ newtype PolicyID era = PolicyID {policyID :: ScriptHash era}
 data Value era = Value !Coin !(Map (PolicyID era) (Map AssetID Quantity))
   deriving (Eq, Show, Generic)
 
+-- TODO make these specific
 instance NFData (Value era)
 
 instance NoThunks (Value era)
@@ -144,7 +145,7 @@ instance Era era => Val (Value era) where
         where
           -- add assetIdLen and uint for each asset of that Policy ID
           accumIns _ ans1 = ans1 + assetIdLen + uint
-
+      -- TODO move these constants somewhere (they are also specified in CDDL)
       uint :: Integer
       uint = 5
 
@@ -153,7 +154,7 @@ instance Era era => Val (Value era) where
 
       -- address hash length is always same as Policy ID length
       addrHashLen :: Integer
-      addrHashLen = 2
+      addrHashLen = 28
 
 -- ============================================================================
 -- Operations on Map, specialised to comparable `Monoid` values.

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -18,9 +18,11 @@ flag development
 
 library
   exposed-modules:
+    Cardano.Ledger.Core
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
     Cardano.Ledger.Shelley
+    Cardano.Ledger.Val
     Shelley.Spec.Ledger.Address
     Shelley.Spec.Ledger.Address.Bootstrap
     Shelley.Spec.Ledger.API
@@ -77,7 +79,6 @@ library
     Shelley.Spec.Ledger.Tx
     Shelley.Spec.Ledger.TxBody
     Shelley.Spec.Ledger.UTxO
-    Cardano.Ledger.Val
   other-modules:     Shelley.Spec.Ledger.API.Mempool
                      Shelley.Spec.Ledger.API.Wallet
                      Shelley.Spec.Ledger.API.Types

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module defines core type families which we know to vary from era to
+-- era.
+--
+-- Families in this module should be indexed on era.
+--
+-- It is intended for qualified import:
+-- > import qualified Cardano.Ledger.Core as Core
+module Cardano.Ledger.Core
+  ( -- * Compactible
+    Compactible (..),
+    Compact (..),
+    Value,
+  )
+where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Data.Kind (Type)
+import Data.Typeable (Typeable)
+
+type family Value era :: Type
+
+-- | A value is something which quantifies a transaction output.
+
+--------------------------------------------------------------------------------
+
+-- * Compactible
+
+--
+-- Certain types may have a "presentation" form and a more compact
+-- representation that allows for more efficient memory usage. In this case,
+-- one should make instances of the 'Compactible' class for them.
+--------------------------------------------------------------------------------
+
+class Compactible a where
+  data CompactForm a :: Type
+  toCompact :: a -> CompactForm a
+  fromCompact :: CompactForm a -> a
+
+newtype Compact a = Compact {unCompact :: a}
+
+instance
+  (Typeable a, Compactible a, ToCBOR (CompactForm a)) =>
+  ToCBOR (Compact a)
+  where
+  toCBOR = toCBOR . toCompact . unCompact
+
+instance
+  (Typeable a, Compactible a, FromCBOR (CompactForm a)) =>
+  FromCBOR (Compact a)
+  where
+  fromCBOR = Compact . fromCompact <$> fromCBOR
+
+-- TODO: consider if this is better the other way around
+instance (Eq a, Compactible a) => Eq (CompactForm a) where
+  a == b = fromCompact a == fromCompact b

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -1,11 +1,20 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Ledger.Shelley where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Ledger.Core (Compactible (..), Value)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
+import Cardano.Ledger.Val (Val)
+import Control.DeepSeq (NFData)
+import Data.Typeable (Typeable)
+import NoThunks.Class (NoThunks)
+import Shelley.Spec.Ledger.Coin (Coin)
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -15,3 +24,20 @@ data Shelley c
 
 instance CryptoClass.Crypto c => Era (Shelley c) where
   type Crypto (Shelley c) = c
+
+type instance Value (Shelley c) = Coin
+
+type ShelleyBased era =
+  ( Era era,
+    Val (Value era),
+    Compactible (Value era),
+    Eq (Value era),
+    FromCBOR (CompactForm (Value era)),
+    FromCBOR (Value era),
+    NFData (Value era),
+    NoThunks (Value era),
+    Show (Value era),
+    ToCBOR (CompactForm (Value era)),
+    ToCBOR (Value era),
+    Typeable (Value era)
+  )

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
@@ -36,29 +36,15 @@ module Cardano.Ledger.Val
   )
 where
 
-import Cardano.Binary
-  ( FromCBOR (..),
-    ToCBOR (..),
-  )
-import Control.DeepSeq (NFData ())
-import Data.Group (Abelian)
+import Data.Group (Abelian, invert)
 import Data.PartialOrd hiding ((==))
 import qualified Data.PartialOrd
-import Data.Typeable (Typeable)
-import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
 
 class
   ( Abelian t,
     Eq t,
-    PartialOrd t,
-    -- Do we really need these?
-    Show t,
-    Typeable t,
-    NFData t,
-    NoThunks t,
-    ToCBOR t,
-    FromCBOR t
+    PartialOrd t
   ) =>
   Val t
   where
@@ -96,9 +82,6 @@ x <-> y = x <+> (invert y)
 
 (<×>) :: Val t => Int -> t -> t
 x <×> y = scale x y
-
-invert :: Val t => t -> t
-invert x = scale (-1 :: Int) x
 
 sumVal :: (Foldable t, Val v) => t v -> v
 sumVal xs = foldl (<+>) mempty xs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -6,6 +7,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Integration between the Shelley ledger and its corresponding (Transitional
 -- Praos) protocol.
@@ -33,6 +36,7 @@ import Cardano.Crypto.KES.Class
 import Cardano.Crypto.VRF.Class
 import Cardano.Ledger.Crypto hiding (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -174,7 +178,14 @@ currentLedgerView = view
 
 newtype FutureLedgerViewError era
   = FutureLedgerViewError [PredicateFailure (TICKF era)]
-  deriving (Eq, Show)
+
+deriving stock instance
+  (Eq (PredicateFailure (TICKF era))) =>
+  Eq (FutureLedgerViewError era)
+
+deriving stock instance
+  (Show (PredicateFailure (TICKF era))) =>
+  Show (FutureLedgerViewError era)
 
 -- | Anachronistic ledger view
 --
@@ -183,7 +194,7 @@ newtype FutureLedgerViewError era
 --   appropriate to that slot.
 futureLedgerView ::
   forall era m.
-  ( Era era,
+  ( ShelleyBased era,
     MonadError (FutureLedgerViewError era) m
   ) =>
   Globals ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Interface to the block validation and chain extension logic in the Shelley
 -- API.
@@ -17,11 +21,16 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Cardano.Ledger.Era
+import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
-import Control.State.Transition.Extended (TRC (..), applySTS, reapplySTS)
+import Control.State.Transition.Extended
+  ( TRC (..),
+    applySTS,
+    reapplySTS,
+  )
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..))
@@ -68,9 +77,19 @@ mkBbodyEnv
 
 newtype TickTransitionError era
   = TickTransitionError [STS.PredicateFailure (STS.TICK era)]
-  deriving (Eq, Show, Generic)
+  deriving (Generic)
 
-instance NoThunks (TickTransitionError era)
+instance
+  (NoThunks (STS.PredicateFailure (STS.TICK era))) =>
+  NoThunks (TickTransitionError era)
+
+deriving stock instance
+  (Eq (STS.PredicateFailure (STS.TICK era))) =>
+  Eq (TickTransitionError era)
+
+deriving stock instance
+  (Show (STS.PredicateFailure (STS.TICK era))) =>
+  Show (TickTransitionError era)
 
 -- | Apply the header level ledger transition.
 --
@@ -78,7 +97,7 @@ instance NoThunks (TickTransitionError era)
 -- header level checks, such as size constraints.
 applyTickTransition ::
   forall era.
-  (Era era) =>
+  ShelleyBased era =>
   Globals ->
   ShelleyState era ->
   SlotNo ->
@@ -93,14 +112,24 @@ applyTickTransition globals state hdr =
 
 newtype BlockTransitionError era
   = BlockTransitionError [STS.PredicateFailure (STS.BBODY era)]
-  deriving (Eq, Generic, Show)
+  deriving (Generic)
 
-instance (Era era) => NoThunks (BlockTransitionError era)
+deriving stock instance
+  (Eq (STS.PredicateFailure (STS.BBODY era))) =>
+  Eq (BlockTransitionError era)
+
+deriving stock instance
+  (Show (STS.PredicateFailure (STS.BBODY era))) =>
+  Show (BlockTransitionError era)
+
+instance
+  (NoThunks (STS.PredicateFailure (STS.BBODY era))) =>
+  NoThunks (BlockTransitionError era)
 
 -- | Apply the block level ledger transition.
 applyBlockTransition ::
   forall era m.
-  ( Era era,
+  ( ShelleyBased era,
     MonadError (BlockTransitionError era) m,
     DSignable era (Hash era (Tx.TxBody era))
   ) =>
@@ -135,7 +164,7 @@ applyBlockTransition globals state blk =
 --   `applyBlockTransition` on the same block and that this was successful.
 reapplyBlockTransition ::
   forall era.
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (Hash era (Tx.TxBody era))
   ) =>
   Globals ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -1,23 +1,29 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.Coin
   ( Coin (..),
+    Core.CompactForm (..),
+    DeltaCoin (..),
     word64ToCoin,
     coinToRational,
     rationalToCoinViaFloor,
+    addDelta,
+    toDelta,
   )
 where
 
-import Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
-import Cardano.Prelude (NFData, cborError)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import qualified Cardano.Ledger.Core as Core
+import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Group (Abelian, Group (..))
 import Data.Monoid (Sum (..))
 import Data.PartialOrd (PartialOrd)
-import Data.Text (pack)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -36,8 +42,21 @@ newtype Coin = Coin {unCoin :: Integer}
       NFData
     )
   deriving (Show) via Quiet Coin
+  deriving (ToCBOR, FromCBOR) via Core.Compact Coin
   deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
   deriving newtype (PartialOrd)
+
+newtype DeltaCoin = DeltaCoin Integer
+  deriving (Eq, Ord, Generic, Enum, NoThunks, NFData, FromCBOR, ToCBOR)
+  deriving (Show) via Quiet DeltaCoin
+  deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
+  deriving newtype (PartialOrd)
+
+addDelta :: Coin -> DeltaCoin -> Coin
+addDelta (Coin x) (DeltaCoin y) = Coin (x + y)
+
+toDelta :: Coin -> DeltaCoin
+toDelta (Coin x) = DeltaCoin x
 
 word64ToCoin :: Word64 -> Coin
 word64ToCoin w = Coin $ fromIntegral w
@@ -48,18 +67,21 @@ coinToRational (Coin c) = fromIntegral c
 rationalToCoinViaFloor :: Rational -> Coin
 rationalToCoinViaFloor r = Coin . floor $ r
 
-isValidCoinValue :: Integer -> Bool
-isValidCoinValue c = 0 <= c && c <= (fromIntegral (maxBound :: Word64))
+-- FIXME:
+-- if coin is less than 0 or greater than (maxBound :: Word64), then
+-- fromIntegral constructs the incorrect value. for now this is handled
+-- with an erroring bounds check here. where should this really live?
+instance Core.Compactible Coin where
+  newtype CompactForm Coin = CompactCoin Word64
+  toCompact (Coin c)
+    | c < 0 = error $ "out of bounds : " ++ show c
+    | c > (fromIntegral (maxBound :: Word64)) =
+      error $ "out of bounds : " ++ show c
+    | otherwise = CompactCoin (fromIntegral c)
+  fromCompact (CompactCoin c) = word64ToCoin c
 
-instance ToCBOR Coin where
-  toCBOR (Coin c) =
-    if isValidCoinValue c
-      then toCBOR (fromInteger c :: Word64)
-      else toCBOR c
+instance ToCBOR (Core.CompactForm Coin) where
+  toCBOR (CompactCoin c) = toCBOR c
 
-instance FromCBOR Coin where
-  fromCBOR = do
-    c <- fromCBOR
-    if isValidCoinValue c
-      then pure (Coin c)
-      else cborError $ DecoderErrorCustom "Invalid Coin Value" (pack $ show c)
+instance FromCBOR (Core.CompactForm Coin) where
+  fromCBOR = CompactCoin <$> fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -3,12 +3,14 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.Genesis
@@ -29,6 +31,8 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.KES.Class (totalPeriodsKES)
 import Cardano.Ledger.Crypto (HASH, KES)
 import Cardano.Ledger.Era
+import Cardano.Ledger.Shelley (ShelleyBased)
+import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (forceElemsToWHNF)
 import Cardano.Slotting.EpochInfo
 import Cardano.Slotting.Slot (EpochSize (..))
@@ -189,14 +193,17 @@ instance Era era => FromJSON (ShelleyGenesisStaking era) where
   Genesis UTxO
 -------------------------------------------------------------------------------}
 
-genesisUtxO :: Era era => ShelleyGenesis era -> UTxO era
+genesisUtxO ::
+  ShelleyBased era =>
+  ShelleyGenesis era ->
+  UTxO era
 genesisUtxO genesis =
   UTxO $
     Map.fromList
       [ (txIn, txOut)
         | (addr, amount) <- Map.toList (sgInitialFunds genesis),
           let txIn = initialFundsPseudoTxIn addr
-              txOut = TxOut addr amount
+              txOut = TxOut addr (Val.inject amount)
       ]
 
 -- | Compute the 'TxIn' of the initial UTxO pseudo-transaction corresponding

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -25,6 +27,8 @@ where
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
+import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
@@ -128,7 +132,11 @@ data ChainState era = ChainState
     chainPrevEpochNonce :: Nonce,
     chainLastAppliedBlock :: WithOrigin (LastAppliedBlock era)
   }
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
+
+deriving stock instance
+  ShelleyBased era =>
+  Show (ChainState era)
 
 instance (Era era) => NFData (ChainState era)
 
@@ -147,7 +155,11 @@ data ChainPredicateFailure era
   | TicknFailure !(PredicateFailure (TICKN era)) -- Subtransition Failures
   | PrtclFailure !(PredicateFailure (PRTCL era)) -- Subtransition Failures
   | PrtclSeqFailure !(PrtlSeqFailure era) -- Subtransition Failures
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
+
+deriving stock instance ShelleyBased era => Show (ChainPredicateFailure era)
+
+deriving stock instance ShelleyBased era => Eq (ChainPredicateFailure era)
 
 -- | Creates a valid initial chain state
 initialShelleyState ::
@@ -194,7 +206,7 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
     cs = Map.fromList (fmap (\(GenDelegPair hk _) -> (coerceKeyRole hk, 0)) (Map.elems genDelegs))
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -218,7 +230,9 @@ instance
   initialRules = []
   transitionRules = [chainTransition]
 
-instance Era era => NoThunks (ChainPredicateFailure era)
+instance
+  ShelleyBased era =>
+  NoThunks (ChainPredicateFailure era)
 
 chainChecks ::
   (Era era, MonadError (PredicateFailure (CHAIN era)) m) =>
@@ -239,7 +253,7 @@ chainChecks maxpv pp bh = do
 
 chainTransition ::
   forall era.
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -248,64 +262,76 @@ chainTransition ::
   TransitionRule (CHAIN era)
 chainTransition =
   judgmentContext
-    >>= \(TRC ((), ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))) -> do
-      case prtlSeqChecks lab bh of
-        Right () -> pure ()
-        Left e -> failBecause $ PrtclSeqFailure e
+    >>= \( TRC
+             ( (),
+               ChainState
+                 nes
+                 cs
+                 eta0
+                 etaV
+                 etaC
+                 etaH
+                 lab,
+               block@(Block bh _)
+               )
+           ) -> do
+        case prtlSeqChecks lab bh of
+          Right () -> pure ()
+          Left e -> failBecause $ PrtclSeqFailure e
 
-      let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ = nes
+        let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ = nes
 
-      maxpv <- liftSTS $ asks maxMajorPV
-      case chainChecks maxpv pp bh of
-        Right () -> pure ()
-        Left e -> failBecause e
+        maxpv <- liftSTS $ asks maxMajorPV
+        case chainChecks maxpv pp bh of
+          Right () -> pure ()
+          Left e -> failBecause e
 
-      let s = bheaderSlotNo $ bhbody bh
+        let s = bheaderSlotNo $ bhbody bh
 
-      nes' <-
-        trans @(TICK era) $ TRC ((), nes, s)
+        nes' <-
+          trans @(TICK era) $ TRC ((), nes, s)
 
-      let NewEpochState e1 _ _ _ _ _ = nes
-          NewEpochState e2 _ bcur es _ _pd = nes'
-      let EpochState account _ ls _ pp' _ = es
-      let LedgerState _ (DPState (DState _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
+        let NewEpochState e1 _ _ _ _ _ = nes
+            NewEpochState e2 _ bcur es _ _pd = nes'
+        let EpochState account _ ls _ pp' _ = es
+        let LedgerState _ (DPState (DState _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
 
-      let ph = lastAppliedHash lab
-          etaPH = prevHashToNonce ph
+        let ph = lastAppliedHash lab
+            etaPH = prevHashToNonce ph
 
-      TicknState eta0' etaH' <-
-        trans @(TICKN era) $
-          TRC
-            ( TicknEnv pp' etaC etaPH,
-              TicknState eta0 etaH,
-              (e1 /= e2)
-            )
+        TicknState eta0' etaH' <-
+          trans @(TICKN era) $
+            TRC
+              ( TicknEnv pp' etaC etaPH,
+                TicknState eta0 etaH,
+                (e1 /= e2)
+              )
 
-      PrtclState cs' etaV' etaC' <-
-        trans @(PRTCL era) $
-          TRC
-            ( PrtclEnv (_d pp') _pd _genDelegs eta0',
-              PrtclState cs etaV etaC,
-              bh
-            )
+        PrtclState cs' etaV' etaC' <-
+          trans @(PRTCL era) $
+            TRC
+              ( PrtclEnv (_d pp') _pd _genDelegs eta0',
+                PrtclState cs etaV etaC,
+                bh
+              )
 
-      BbodyState ls' bcur' <-
-        trans @(BBODY era) $
-          TRC (BbodyEnv pp' account, BbodyState ls bcur, block)
+        BbodyState ls' bcur' <-
+          trans @(BBODY era) $
+            TRC (BbodyEnv pp' account, BbodyState ls bcur, block)
 
-      let nes'' = updateNES nes' bcur' ls'
-          bhb = bhbody bh
-          lab' =
-            At $
-              LastAppliedBlock
-                (bheaderBlockNo bhb)
-                (bheaderSlotNo bhb)
-                (bhHash bh)
+        let nes'' = updateNES nes' bcur' ls'
+            bhb = bhbody bh
+            lab' =
+              At $
+                LastAppliedBlock
+                  (bheaderBlockNo bhb)
+                  (bheaderSlotNo bhb)
+                  (bhHash bh)
 
-      pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
+        pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -316,7 +342,7 @@ instance
   wrapFailed = BbodyFailure
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -327,7 +353,7 @@ instance
   wrapFailed = TicknFailure
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -338,7 +364,7 @@ instance
   wrapFailed = TickFailure
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (OCertSignable era),
     DSignable era (Hash era (TxBody era)),
     KESignable era (BHBody era),
@@ -359,7 +385,10 @@ data AdaPots = AdaPots
   deriving (Show, Eq)
 
 -- | Calculate the total ada pots in the chain state
-totalAdaPots :: ChainState era -> AdaPots
+totalAdaPots ::
+  ShelleyBased era =>
+  ChainState era ->
+  AdaPots
 totalAdaPots (ChainState nes _ _ _ _ _ _) =
   AdaPots
     { treasuryAdaPot = treasury_,
@@ -374,10 +403,10 @@ totalAdaPots (ChainState nes _ _ _ _ _ _) =
     (UTxOState u deposits fees_ _) = _utxoState ls
     (DPState ds _) = _delegationState ls
     rewards_ = fold (Map.elems (_rewards ds))
-    circulation = balance u
+    circulation = Val.coin $ balance u
 
 -- | Calculate the total ada in the chain state
-totalAda :: ChainState era -> Coin
+totalAda :: ShelleyBased era => ChainState era -> Coin
 totalAda cs =
   treasuryAdaPot
     <> reservesAdaPot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Delegs
   ( DELEGS,
@@ -23,6 +27,7 @@ import Cardano.Binary
     encodeListLen,
   )
 import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Iterate.SetAlgebra (dom, eval, (∈), (⨃))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition (Embed (..), STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans, (?!), (?!:))
@@ -75,7 +80,10 @@ data DelegsEnv era = DelegsEnv
     delegsTx :: Tx era,
     delegsAccount :: AccountState
   }
-  deriving (Show)
+
+deriving stock instance
+  ShelleyBased era =>
+  Show (DelegsEnv era)
 
 data DelegsPredicateFailure era
   = DelegateeNotRegisteredDELEG
@@ -86,7 +94,7 @@ data DelegsPredicateFailure era
   deriving (Show, Eq, Generic)
 
 instance
-  Era era =>
+  ShelleyBased era =>
   STS (DELEGS era)
   where
   type State (DELEGS era) = DPState era
@@ -105,8 +113,14 @@ instance
   ToCBOR (DelegsPredicateFailure era)
   where
   toCBOR = \case
-    DelegateeNotRegisteredDELEG kh -> encodeListLen 2 <> toCBOR (0 :: Word8) <> toCBOR kh
-    WithdrawalsNotInRewardsDELEGS ws -> encodeListLen 2 <> toCBOR (1 :: Word8) <> mapToCBOR ws
+    DelegateeNotRegisteredDELEG kh ->
+      encodeListLen 2
+        <> toCBOR (0 :: Word8)
+        <> toCBOR kh
+    WithdrawalsNotInRewardsDELEGS ws ->
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
+        <> mapToCBOR ws
     (DelplFailure a) ->
       encodeListLen 2 <> toCBOR (2 :: Word8)
         <> toCBOR a
@@ -132,7 +146,9 @@ instance
 
 delegsTransition ::
   forall era.
-  Era era =>
+  ( ShelleyBased era,
+    Embed (DELPL era) (DELEGS era)
+  ) =>
   TransitionRule (DELEGS era)
 delegsTransition = do
   TRC (env@(DelegsEnv slot txIx pp tx acnt), dpstate, certificates) <- judgmentContext
@@ -192,7 +208,7 @@ delegsTransition = do
             ]
 
 instance
-  Era era =>
+  ShelleyBased era =>
   Embed (DELPL era) (DELEGS era)
   where
   wrapFailed = DelplFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -17,7 +19,7 @@ module Shelley.Spec.Ledger.STS.Ledgers
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Monad (foldM)
 import Control.State.Transition
   ( Embed (..),
@@ -29,7 +31,6 @@ import Control.State.Transition
   )
 import Data.Foldable (toList)
 import Data.Sequence (Seq)
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
@@ -56,12 +57,16 @@ data LedgersEnv era = LedgersEnv
 
 data LedgersPredicateFailure era
   = LedgerFailure (PredicateFailure (LEDGER era)) -- Subtransition Failures
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
 
-instance (Era era) => NoThunks (LedgersPredicateFailure era)
+deriving stock instance ShelleyBased era => Show (LedgersPredicateFailure era)
+
+deriving stock instance ShelleyBased era => Eq (LedgersPredicateFailure era)
+
+instance ShelleyBased era => NoThunks (LedgersPredicateFailure era)
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (Hash era (TxBody era))
   ) =>
   STS (LEDGERS era)
@@ -76,20 +81,20 @@ instance
   transitionRules = [ledgersTransition]
 
 instance
-  (Typeable era, Era era) =>
+  ShelleyBased era =>
   ToCBOR (LedgersPredicateFailure era)
   where
   toCBOR (LedgerFailure e) = toCBOR e
 
 instance
-  (Era era) =>
+  ShelleyBased era =>
   FromCBOR (LedgersPredicateFailure era)
   where
   fromCBOR = LedgerFailure <$> fromCBOR
 
 ledgersTransition ::
   forall era.
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (Hash era (TxBody era))
   ) =>
   TransitionRule (LEDGERS era)
@@ -109,7 +114,7 @@ ledgersTransition = do
   pure $ LedgerState u'' dp''
 
 instance
-  ( Era era,
+  ( ShelleyBased era,
     DSignable era (Hash era (TxBody era))
   ) =>
   Embed (LEDGER era) (LEDGERS era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.PoolReap
   ( POOLREAP,
@@ -12,6 +16,7 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Control.Iterate.SetAlgebra (dom, eval, setSingleton, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Control.State.Transition
@@ -51,7 +56,10 @@ data PoolreapState era = PoolreapState
     prDState :: DState era,
     prPState :: PState era
   }
-  deriving (Show, Eq)
+
+deriving stock instance
+  ShelleyBased era =>
+  Show (PoolreapState era)
 
 data PoolreapPredicateFailure era -- No predicate Falures
   deriving (Show, Eq, Generic)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -8,6 +9,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -25,8 +27,10 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.Era (Era)
-import Cardano.Ledger.Val (scaledMinDeposit, (<->))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Shelley (ShelleyBased)
+import Cardano.Ledger.Val ((<->))
+import qualified Cardano.Ledger.Val as Val
 import Control.Iterate.SetAlgebra (dom, eval, (∪), (⊆), (⋪))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
@@ -49,7 +53,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -120,8 +123,8 @@ data UtxoPredicateFailure era
       !Coin -- the minimum fee for this transaction
       !Coin -- the fee supplied in this transaction
   | ValueNotConservedUTxO
-      !Coin -- the Coin consumed by this transaction
-      !Coin -- the Coin produced by this transaction
+      !(Core.Value era) -- the Coin consumed by this transaction
+      !(Core.Value era) -- the Coin produced by this transaction
   | WrongNetwork
       !Network -- the expected network id
       !(Set (Addr era)) -- the set of addresses with incorrect network IDs
@@ -133,12 +136,20 @@ data UtxoPredicateFailure era
   | UpdateFailure (PredicateFailure (PPUP era)) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
       ![TxOut era] -- list of supplied bad transaction outputs
-  deriving (Eq, Show, Generic)
+  deriving (Generic)
 
-instance NoThunks (UtxoPredicateFailure era)
+deriving stock instance
+  ShelleyBased era =>
+  Show (UtxoPredicateFailure era)
+
+deriving stock instance
+  ShelleyBased era =>
+  Eq (UtxoPredicateFailure era)
+
+instance NoThunks (Core.Value era) => NoThunks (UtxoPredicateFailure era)
 
 instance
-  (Typeable era, Era era) =>
+  ShelleyBased era =>
   ToCBOR (UtxoPredicateFailure era)
   where
   toCBOR = \case
@@ -180,7 +191,7 @@ instance
         <> encodeFoldable outs
 
 instance
-  (Era era) =>
+  ShelleyBased era =>
   FromCBOR (UtxoPredicateFailure era)
   where
   fromCBOR =
@@ -226,7 +237,7 @@ instance
         k -> invalidKey k
 
 instance
-  (Era era) =>
+  (ShelleyBased era) =>
   STS (UTXO era)
   where
   type State (UTXO era) = UTxOState era
@@ -255,10 +266,11 @@ instance
       PostCondition
         "Deposit pot must not be negative (post)"
         (\_ st' -> _deposited st' >= mempty),
-      let utxoBalance us = _deposited us <> _fees us <> balance (_utxo us)
-          withdrawals txb = foldl' (<>) mempty $ unWdrl $ _wdrls txb
+      let utxoBalance us = (Val.inject $ _deposited us <> _fees us) <> balance (_utxo us)
+          withdrawals :: TxBody era -> Core.Value era
+          withdrawals txb = Val.inject $ foldl' (<>) mempty $ unWdrl $ _wdrls txb
        in PostCondition
-            "Should preserve ADA in the UTxO state"
+            "Should preserve value in the UTxO state"
             ( \(TRC (_, us, tx)) us' ->
                 utxoBalance us <> withdrawals (_body tx) == utxoBalance us'
             )
@@ -271,7 +283,7 @@ initialLedgerState = do
 
 utxoInductive ::
   forall era.
-  Era era =>
+  (ShelleyBased era) =>
   TransitionRule (UTXO era)
 utxoInductive = do
   TRC (UtxoEnv slot pp stakepools genDelegs, u, tx) <- judgmentContext
@@ -309,7 +321,10 @@ utxoInductive = do
 
   let outputs = Map.elems $ unUTxO (txouts txb)
       minUTxOValue = _minUTxOValue pp
-      outputsTooSmall = [out | out@(TxOut _ c) <- outputs, c < (scaledMinDeposit c minUTxOValue)]
+      -- minUTxOValue deposit comparison done as Coin because this rule
+      -- is correct strictly in the Shelley era (in shelleyMA we would need to
+      -- additionally check that all amounts are non-negative)
+      outputsTooSmall = [out | out@(TxOut _ c) <- outputs, (Val.coin c) < (Val.scaledMinDeposit c minUTxOValue)]
   null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
 
   -- Bootstrap (i.e. Byron) addresses have variable sized attributes in them.
@@ -335,7 +350,7 @@ utxoInductive = do
       }
 
 instance
-  Era era =>
+  (ShelleyBased era) =>
   Embed (PPUP era) (UTXO era)
   where
   wrapFailed = UpdateFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -17,6 +18,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Shelley.Spec.Ledger.TxBody
@@ -36,6 +38,7 @@ module Shelley.Spec.Ledger.TxBody
     StakePoolRelay (..),
     TxBody
       ( TxBody,
+        TxBody',
         _inputs,
         _outputs,
         _certs,
@@ -80,7 +83,9 @@ import Cardano.Binary
     szCases,
     withSlice,
   )
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Prelude
   ( cborError,
     panic,
@@ -133,7 +138,7 @@ import Shelley.Spec.Ledger.BaseTypes
     maybeToStrictMaybe,
     strictMaybeToMaybe,
   )
-import Shelley.Spec.Ledger.Coin (Coin (..), word64ToCoin)
+import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential
   ( Credential (..),
     Ix,
@@ -410,7 +415,7 @@ deriving instance Eq (TxIn era)
 
 deriving instance Show (TxIn era)
 
-deriving instance (Era era) => NFData (TxIn era)
+deriving instance Era era => NFData (TxIn era)
 
 instance NoThunks (TxIn era)
 
@@ -418,11 +423,17 @@ instance NoThunks (TxIn era)
 data TxOut era
   = TxOutCompact
       {-# UNPACK #-} !BSS.ShortByteString
-      {-# UNPACK #-} !Word64
+      !(Core.CompactForm (Core.Value era))
 
-deriving instance (Era era) => Show (TxOut era)
+instance
+  (ShelleyBased era) =>
+  Show (TxOut era)
+  where
+  show = show . viewCompactTxOut
 
-deriving instance (Era era) => Eq (TxOut era)
+deriving stock instance
+  ShelleyBased era =>
+  Eq (TxOut era)
 
 instance NFData (TxOut era) where
   rnf = (`seq` ())
@@ -430,25 +441,30 @@ instance NFData (TxOut era) where
 deriving via InspectHeapNamed "TxOut" (TxOut era) instance NoThunks (TxOut era)
 
 pattern TxOut ::
-  Era era =>
+  ShelleyBased era =>
   Addr era ->
-  Coin ->
+  Core.Value era ->
   TxOut era
-pattern TxOut addr coin <-
-  (viewCompactTxOut -> (addr, coin))
+pattern TxOut addr vl <-
+  (viewCompactTxOut -> (addr, vl))
   where
-    TxOut addr (Coin coin) =
-      TxOutCompact (BSS.toShort $ serialiseAddr addr) (fromIntegral coin)
+    TxOut addr vl =
+      -- TODO check this
+      TxOutCompact (BSS.toShort $ serialiseAddr addr) (Core.toCompact vl)
 
 {-# COMPLETE TxOut #-}
 
-viewCompactTxOut :: forall era. Era era => TxOut era -> (Addr era, Coin)
-viewCompactTxOut (TxOutCompact bs c) = (addr, coin)
+viewCompactTxOut ::
+  forall era.
+  ShelleyBased era =>
+  TxOut era ->
+  (Addr era, Core.Value era)
+viewCompactTxOut (TxOutCompact bs c) = (addr, val)
   where
     addr = case decompactAddr bs of
       Nothing -> panic "viewCompactTxOut: impossible"
       Just a -> a
-    coin = word64ToCoin c
+    val = Core.fromCompact c
 
 decompactAddr :: Era era => BSS.ShortByteString -> Maybe (Addr era)
 decompactAddr bs =
@@ -548,14 +564,16 @@ data TxBody era = TxBody'
     bodyBytes :: BSL.ByteString,
     extraSize :: !Int64 -- This is the contribution of inputs, outputs, and fees to the size of the transaction
   }
-  deriving (Show, Eq, Generic)
+  deriving (Generic)
+
+deriving instance (ShelleyBased era) => Show (TxBody era)
 
 deriving via AllowThunksIn '["bodyBytes"] (TxBody era) instance Era era => NoThunks (TxBody era)
 
 instance Era era => HashAnnotated (TxBody era) era
 
 pattern TxBody ::
-  Era era =>
+  ShelleyBased era =>
   Set (TxIn era) ->
   StrictSeq (TxOut era) ->
   StrictSeq (DCert era) ->
@@ -767,7 +785,7 @@ instance
       pure $ TxInCompact a b
 
 instance
-  (Typeable era, Era era) =>
+  ShelleyBased era =>
   ToCBOR (TxOut era)
   where
   toCBOR (TxOutCompact addr coin) =
@@ -776,7 +794,7 @@ instance
       <> toCBOR coin
 
 instance
-  (Era era) =>
+  ShelleyBased era =>
   FromCBOR (TxOut era)
   where
   fromCBOR = decodeRecordNamed "TxOut" (const 2) $ do
@@ -814,7 +832,7 @@ instance
   toCBOR = encodePreEncoded . BSL.toStrict . bodyBytes
 
 instance
-  (Era era) =>
+  ShelleyBased era =>
   FromCBOR (Annotator (TxBody era))
   where
   fromCBOR = annotatorSlice $ do

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
@@ -6,6 +6,8 @@
 
 module BenchUTxOAggregate where
 
+import Cardano.Ledger.Core (toCompact)
+import qualified Cardano.Ledger.Val as Val
 import Control.Iterate.SetAlgebra (Bimap, biMapFromList, dom, (▷), (◁))
 import Control.Iterate.SetAlgebraInternal (compile, compute, run)
 import qualified Data.ByteString.Short as SBS
@@ -53,7 +55,7 @@ genTestCase numUTxO numAddr = do
     replicate numUTxO $ do
       i <- choose (0, numAddr -1)
       let addr = Seq.index packedAddrs i
-      pure $ TxOutCompact (SBS.toShort $ serialiseAddr addr) (fromIntegral i)
+      pure $ TxOutCompact (SBS.toShort $ serialiseAddr addr) (toCompact $ Val.inject (Coin $ fromIntegral i))
   let mktxid i = TxId $ mkDummyHash i
   let mktxin i = TxIn (mktxid i) (fromIntegral i)
   let utxo = Map.fromList $ zip (mktxin <$> [1 ..]) txOuts

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -1,15 +1,14 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unused-binds #-}
 
@@ -26,11 +25,12 @@ module BenchValidation
   )
 where
 
-import Data.Proxy
+import Cardano.Ledger.Era (Era (..))
 import Cardano.Prelude (NFData (rnf))
 import Cardano.Slotting.Slot (withOriginToMaybe)
 import Control.Monad.Except ()
 import qualified Data.Map as Map
+import Data.Proxy
 import Shelley.Spec.Ledger.API.Protocol
   ( ChainDepState (..),
     ChainTransitionError,
@@ -45,25 +45,22 @@ import Shelley.Spec.Ledger.API.Validation
     reapplyBlockTransition,
   )
 import Shelley.Spec.Ledger.BaseTypes (Globals (..))
+import Shelley.Spec.Ledger.Bench.Gen (genBlock, genChainState)
 import Shelley.Spec.Ledger.BlockChain
   ( BHeader (..),
     Block (..),
     LastAppliedBlock (..),
     slotToNonce,
   )
-
-import Cardano.Ledger.Era(Era(..))
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes( Mock )
-
 import Shelley.Spec.Ledger.EpochBoundary (unBlocksMade)
 import Shelley.Spec.Ledger.LedgerState (nesBcur)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
-import Test.Shelley.Spec.Ledger.Utils (testGlobals)
-import Test.Shelley.Spec.Ledger.Serialisation.Generators()  -- Arbitrary Coin
-import Shelley.Spec.Ledger.Bench.Gen(genBlock,genChainState)
+import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
 
 -- ====================================================================
 
@@ -75,31 +72,29 @@ sizes (ValidateInput _gs ss _blk) = "blockMap size=" ++ show (Map.size (unBlocks
 instance NFData (ValidateInput era) where
   rnf (ValidateInput a b c) = seq a (seq b (seq c ()))
 
-validateInput ::  (Era era,Mock (Crypto era)) => Int -> IO (ValidateInput era)
+validateInput :: (ShelleyTest era, Mock (Crypto era)) => Int -> IO (ValidateInput era)
 validateInput utxoSize = genValidateInput utxoSize
 
-genValidateInput:: (Era era,Mock (Crypto era)) => Int -> IO (ValidateInput era)
+genValidateInput :: (ShelleyTest era, Mock (Crypto era)) => Int -> IO (ValidateInput era)
 genValidateInput n = do
   let ge = genEnv (Proxy :: Proxy era)
   chainstate <- genChainState n ge
   block <- genBlock ge chainstate
   pure (ValidateInput testGlobals (chainNes chainstate) block)
 
-
-
-benchValidate :: forall era.  (Era era,Mock (Crypto era)) => ValidateInput era -> IO (ShelleyState era)
+benchValidate :: forall era. (ShelleyTest era, Mock (Crypto era)) => ValidateInput era -> IO (ShelleyState era)
 benchValidate (ValidateInput globals state block) =
   case applyBlockTransition @era globals state block of
     Right x -> pure x
     Left x -> error (show x)
 
-applyBlock :: forall era.  (Era era,Mock (Crypto era)) => ValidateInput era -> Int -> Int
+applyBlock :: forall era. (ShelleyTest era, Mock (Crypto era)) => ValidateInput era -> Int -> Int
 applyBlock (ValidateInput globals state block) n =
   case applyBlockTransition @era globals state block of
-    Right x -> seq (rnf x) (n+1)
+    Right x -> seq (rnf x) (n + 1)
     Left x -> error (show x)
 
-benchreValidate ::  (Era era,Mock (Crypto era)) => ValidateInput era -> ShelleyState era
+benchreValidate :: (ShelleyTest era, Mock (Crypto era)) => ValidateInput era -> ShelleyState era
 benchreValidate (ValidateInput globals state block) =
   reapplyBlockTransition globals state block
 
@@ -133,7 +128,7 @@ instance NFData (ChainTransitionError c) where
 instance Era era => NFData (UpdateInputs era) where
   rnf (UpdateInputs g lv bh st) = seq (rnf g) (seq (rnf lv) (seq (rnf bh) (rnf st)))
 
-genUpdateInputs :: forall era. (Era era, Mock (Crypto era)) => Int -> IO (UpdateInputs era)
+genUpdateInputs :: forall era. (ShelleyTest era, Mock (Crypto era)) => Int -> IO (UpdateInputs era)
 genUpdateInputs utxoSize = do
   let ge = genEnv (Proxy :: Proxy era)
   chainstate <- genChainState utxoSize ge
@@ -147,12 +142,14 @@ genUpdateInputs utxoSize = do
         Nothing -> error "Empty Slot"
   pure (UpdateInputs testGlobals ledgerview blockheader (ChainDepState prtclState ticknState nonce))
 
-updateChain ::  (Era era,Mock (Crypto era)) =>
+updateChain ::
+  (Era era, Mock (Crypto era)) =>
   UpdateInputs era ->
   Either (ChainTransitionError era) (ChainDepState era)
 updateChain (UpdateInputs gl lv bh st) = updateChainDepState gl lv bh st
 
-updateAndTickChain ::  (Era era,Mock (Crypto era)) =>
+updateAndTickChain ::
+  (Era era, Mock (Crypto era)) =>
   UpdateInputs era ->
   Either (ChainTransitionError era) (ChainDepState era)
 updateAndTickChain (UpdateInputs gl lv bh st) =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -1,30 +1,34 @@
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE  FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Benchmarks for Shelley test generators.
 module Shelley.Spec.Ledger.Bench.Gen
   ( genTriple,
     genBlock,
     genChainState,
-  ) where
+  )
+where
 
-import Cardano.Ledger.Era(Crypto, Era)
-
+import Cardano.Ledger.Era (Crypto)
 import Control.State.Transition.Extended (IRC (..))
 import Data.Either (fromRight)
 import Data.Proxy
 import Shelley.Spec.Ledger.API
   ( Block,
-    ChainState(..),
+    ChainState (..),
     Tx,
   )
 import Shelley.Spec.Ledger.LedgerState
-  ( LedgerState(..),
-    NewEpochState(..),
-    EpochState(..),
+  ( EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
   )
 import Test.QuickCheck (generate)
+-- Arbitrary Coin
+
+import Test.Shelley.Spec.Ledger.BenchmarkFunctions (ledgerEnv)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import qualified Test.Shelley.Spec.Ledger.Generator.Block as GenBlock
 import Test.Shelley.Spec.Ledger.Generator.Constants
   ( Constants
@@ -34,17 +38,16 @@ import Test.Shelley.Spec.Ledger.Generator.Constants
       ),
   )
 import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv, geConstants)
-import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
-import Test.Shelley.Spec.Ledger.Serialisation.Generators()  -- Arbitrary Coin
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes(Mock)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
-import Test.Shelley.Spec.Ledger.Generator.Utxo(genTx)
-import Test.Shelley.Spec.Ledger.BenchmarkFunctions(ledgerEnv)
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
+import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
+import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)
 
 -- =============================================================================
 
 -- | Generate a genesis chain state given a UTxO size
-genChainState :: Era era => Int -> GenEnv era -> IO (ChainState era)
+genChainState :: ShelleyTest era => Int -> GenEnv era -> IO (ChainState era)
 genChainState n ge =
   let cs =
         (geConstants ge)
@@ -61,9 +64,8 @@ genChainState n ge =
             )
 
 -- | Benchmark generating a block given a chain state.
-genBlock :: (Mock (Crypto era),Era era) => GenEnv era -> ChainState era -> IO (Block era)
+genBlock :: (Mock (Crypto era), ShelleyTest era) => GenEnv era -> ChainState era -> IO (Block era)
 genBlock ge cs = generate $ GenBlock.genBlock ge cs
-
 
 -- The order one does this is important, since all these things must flow from the same
 -- GenEnv, so that the addresses ind signatures in the UTxO are known and consistent.
@@ -73,13 +75,12 @@ genBlock ge cs = generate $ GenBlock.genBlock ge cs
 -- 4) get a DPState from the ChainState
 -- 5) get a Transaction (Tx) from GenEnv and ChainState
 
-
-genTriple :: (Mock (Crypto era),Era era) => Proxy era -> Int -> IO(GenEnv era, ChainState era, GenEnv era -> IO (Tx era))
+genTriple :: (Mock (Crypto era), ShelleyTest era) => Proxy era -> Int -> IO (GenEnv era, ChainState era, GenEnv era -> IO (Tx era))
 genTriple proxy n = do
   let ge = genEnv proxy
   cs <- genChainState n ge
-  let nes = chainNes cs  -- NewEpochState
-  let es = nesEs nes     -- EpochState
-  let (LedgerState utxoS dpstate) = esLState es   -- LedgerState
-  let fun genenv = generate $ genTx genenv ledgerEnv (utxoS,dpstate)
-  pure (ge,cs,fun)
+  let nes = chainNes cs -- NewEpochState
+  let es = nesEs nes -- EpochState
+  let (LedgerState utxoS dpstate) = esLState es -- LedgerState
+  let fun genenv = generate $ genTx genenv ledgerEnv (utxoS, dpstate)
+  pure (ge, cs, fun)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -27,13 +27,12 @@ module Test.Shelley.Spec.Ledger.BenchmarkFunctions
 where
 
 -- Cypto and Era stuff
-import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as Original
-  ( C_Crypto,
-  )
-import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
-import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Era(Crypto, Era)
 
+import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Val (Val (inject))
 import Control.State.Transition.Extended (TRC (..), applySTS)
 import qualified Data.Map as Map
 import Data.Sequence.Strict (StrictSeq)
@@ -93,8 +92,9 @@ import Shelley.Spec.Ledger.TxBody
     _poolVrf,
   )
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
-import Cardano.Ledger.Val(Val(inject))
-
+import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as Original
+  ( C_Crypto,
+  )
 import Test.Shelley.Spec.Ledger.Generator.Core
   ( genesisCoins,
     genesisId,
@@ -124,6 +124,8 @@ instance Cardano.Ledger.Crypto.Crypto B_Crypto where
   type DSIGN B_Crypto = DSIGN Original.C_Crypto
   type HASH B_Crypto = Blake2b_256
   type ADDRHASH B_Crypto = Blake2b_256
+
+type instance Core.Value B = Coin
 
 -- =========================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -17,9 +17,11 @@ import Cardano.Crypto.KES (MockKES)
 import qualified Cardano.Crypto.KES.Class as KES
 import Cardano.Crypto.Util (SignableRepresentation)
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.Core (Value)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Era
 import Shelley.Spec.Ledger.BaseTypes (Seed)
+import Shelley.Spec.Ledger.Coin (Coin)
 import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
 -- | Mocking constraints used in generators
@@ -54,3 +56,5 @@ instance Cardano.Ledger.Crypto.Crypto C_Crypto where
   type DSIGN C_Crypto = MockDSIGN
   type KES C_Crypto = MockKES 10
   type VRF C_Crypto = FakeVRF
+
+type instance Value C = Coin

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -16,7 +16,7 @@ where
 
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto (VRF)
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.Iterate.SetAlgebra (dom, eval)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
@@ -52,7 +52,8 @@ import Test.Shelley.Spec.Ledger.Generator.Core
   )
 import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
 import Test.Shelley.Spec.Ledger.Utils
-  ( epochFromSlotNo,
+  ( ShelleyTest,
+    epochFromSlotNo,
     maxKESIterations,
     runShelleyBase,
     slotFromEpoch,
@@ -70,7 +71,7 @@ type TxGen era =
 -- | Generate a valid block.
 genBlock ::
   forall era.
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   GenEnv era ->
   ChainState era ->
   Gen (Block era)
@@ -83,7 +84,7 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
 genBlockWithTxGen ::
   forall era.
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   TxGen era ->
   GenEnv era ->
   ChainState era ->
@@ -147,7 +148,7 @@ genBlockWithTxGen
 
 selectNextSlotWithLeader ::
   forall era.
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   GenEnv era ->
   ChainState era ->
   -- Starting slot
@@ -217,7 +218,7 @@ selectNextSlotWithLeader
 -- | The chain state is a composite of the new epoch state and the chain dep
 -- state. We tick both.
 tickChainState ::
-  Era era =>
+  ShelleyTest era =>
   SlotNo ->
   ChainState era ->
   ChainState era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -191,6 +191,7 @@ import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils
   ( GenesisKeyPair,
     MultiSigPairs,
+    ShelleyTest,
     epochFromSlotNo,
     evolveKESUntil,
     maxKESIterations,
@@ -471,7 +472,7 @@ findPayScriptFromAddr _ _ =
   error "findPayScriptFromAddr: expects only base and pointer script addresses"
 
 -- | Select one random verification staking key from list of pairs of KeyPair.
-pickStakeKey ::  KeyPairs era -> Gen (VKey 'Staking era)
+pickStakeKey :: KeyPairs era -> Gen (VKey 'Staking era)
 pickStakeKey keys = vKey . snd <$> QC.elements keys
 
 -- | Generates a list of coins for the given 'Addr' and produced a 'TxOut' for each 'Addr'
@@ -479,7 +480,7 @@ pickStakeKey keys = vKey . snd <$> QC.elements keys
 -- Note: we need to keep the initial utxo coin sizes large enough so that
 -- when we simulate sequences of transactions, we have enough funds available
 -- to include certificates that require deposits.
-genTxOut :: (Era era) => Constants -> [Addr era] -> Gen [TxOut era]
+genTxOut :: (ShelleyTest era) => Constants -> [Addr era] -> Gen [TxOut era]
 genTxOut Constants {maxGenesisOutputVal, minGenesisOutputVal} addrs = do
   ys <- genCoinList minGenesisOutputVal maxGenesisOutputVal (length addrs) (length addrs)
   return (uncurry TxOut <$> zip addrs ys)
@@ -688,7 +689,7 @@ genesisAccountState =
 
 -- | The transaction Id for 'UTxO' included at the beginning of a new ledger.
 genesisId ::
-  (Era era) => Ledger.TxId era
+  (ShelleyTest era) => Ledger.TxId era
 genesisId =
   TxId $
     hashAnnotated
@@ -705,7 +706,7 @@ genesisId =
 
 -- | Creates the UTxO for a new ledger with the specified transaction outputs.
 genesisCoins ::
-  (Era era) =>
+  (ShelleyTest era) =>
   [TxOut era] ->
   UTxO era
 genesisCoins outs =
@@ -714,7 +715,7 @@ genesisCoins outs =
 
 -- | Apply a transaction body as a state transition function on the ledger state.
 applyTxBody ::
-  (Era era) =>
+  (ShelleyTest era) =>
   LedgerState era ->
   PParams era ->
   TxBody era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -43,7 +44,14 @@ import Test.Shelley.Spec.Ledger.Generator.Constants
     defaultConstants,
   )
 import Test.Shelley.Spec.Ledger.Generator.Core
-import Test.Shelley.Spec.Ledger.Utils (MultiSigPairs, maxKESIterations, mkKESKeyPair, mkVRFKeyPair, slotsPerKESIteration)
+import Test.Shelley.Spec.Ledger.Utils
+  ( MultiSigPairs,
+    ShelleyTest,
+    maxKESIterations,
+    mkKESKeyPair,
+    mkVRFKeyPair,
+    slotsPerKESIteration,
+  )
 
 -- | Example generator environment, consisting of default constants and an
 -- corresponding keyspace.
@@ -106,7 +114,7 @@ coreNodeKeys c@Constants {numCoreNodes} =
   where
     toKeyPair (sk, vk) = KeyPair vk sk
 
-genUtxo0 :: Era era => Constants -> Gen (UTxO era)
+genUtxo0 :: ShelleyTest era => Constants -> Gen (UTxO era)
 genUtxo0 c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts} = do
   genesisKeys <- someKeyPairs c minGenesisUTxOouts maxGenesisUTxOouts
   genesisScripts <- someScripts c minGenesisUTxOouts maxGenesisUTxOouts

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -18,7 +19,7 @@
 module Test.Shelley.Spec.Ledger.Generator.Trace.Chain where
 
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Val((<->))
+import Cardano.Ledger.Val ((<->))
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition (IRC (..))
@@ -53,12 +54,12 @@ import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
 import Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
 import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
-import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, maxLLSupply, mkHash)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   HasTrace (CHAIN era) (GenEnv era)
   where
   envGen _ = pure ()
@@ -83,7 +84,7 @@ lastByronHeaderHash _ = HashHeader $ mkHash 0
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisChainState ::
   forall era a.
-  Era era =>
+  ShelleyTest era =>
   Constants ->
   IRC (CHAIN era) ->
   Gen (Either a (ChainState era))
@@ -136,7 +137,7 @@ mkOCertIssueNos (GenDelegs delegs0) =
 -- This allows stake pools to produce blocks from genesis.
 registerGenesisStaking ::
   forall c.
-  Era c =>
+  ShelleyTest c =>
   ShelleyGenesisStaking c ->
   ChainState c ->
   ChainState c

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -15,7 +16,7 @@
 
 module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Crypto)
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition.Extended (IRC, TRC (..))
@@ -43,7 +44,7 @@ import Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
 import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Shrinkers (shrinkTx)
-import Test.Shelley.Spec.Ledger.Utils (applySTSTest, runShelleyBase)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, applySTSTest, runShelleyBase)
 
 genAccountState :: Constants -> Gen AccountState
 genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves}) =
@@ -54,7 +55,7 @@ genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves})
 -- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
 instance
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   TQC.HasTrace (LEDGER era) (GenEnv era)
   where
   envGen GenEnv {geConstants} =
@@ -71,7 +72,7 @@ instance
   interpretSTS globals act = runIdentity $ runReaderT act globals
 
 instance
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   TQC.HasTrace (LEDGERS era) (GenEnv era)
   where
   envGen GenEnv {geConstants} =
@@ -122,7 +123,7 @@ instance
 -- To achieve this we (1) use 'IRC LEDGER' (the "initial rule context") instead of simply 'LedgerEnv'
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisLedgerState ::
-  Era era =>
+  ShelleyTest era =>
   Constants ->
   IRC (LEDGER era) ->
   Gen (Either a (UTxOState era, DPState era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Orphans.hs
@@ -10,8 +10,44 @@ module Test.Shelley.Spec.Ledger.Orphans () where
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import Cardano.Ledger.Crypto (DSIGN)
 import Cardano.Ledger.Era
+import Cardano.Ledger.Shelley (ShelleyBased)
+import Shelley.Spec.Ledger.BlockChain (Block (..), TxSeq (..))
 import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState
+  ( EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    UTxOState (..),
+  )
+import Shelley.Spec.Ledger.STS.Chain
+  ( ChainState (..),
+  )
+import Shelley.Spec.Ledger.Tx (Tx (..))
+import Shelley.Spec.Ledger.TxBody (TxBody (..))
+import Shelley.Spec.Ledger.UTxO
+  ( UTxO (..),
+  )
 
 -- We need this here for the tests, but should not be in the actual library because
 -- a Num instance for this type does not make sense in the general case.
 deriving instance Num (DSIGN.VerKeyDSIGN (DSIGN (Crypto era))) => Num (VKey kd era)
+
+deriving instance ShelleyBased era => Eq (UTxOState era)
+
+deriving instance ShelleyBased era => Eq (UTxO era)
+
+deriving instance ShelleyBased era => Eq (ChainState era)
+
+deriving instance ShelleyBased era => Eq (NewEpochState era)
+
+deriving instance ShelleyBased era => Eq (EpochState era)
+
+deriving instance ShelleyBased era => Eq (LedgerState era)
+
+deriving instance ShelleyBased era => Eq (Tx era)
+
+deriving instance ShelleyBased era => Eq (TxBody era)
+
+deriving instance ShelleyBased era => Eq (Block era)
+
+deriving instance ShelleyBased era => Eq (TxSeq era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -121,6 +121,7 @@ import Test.Shelley.Spec.Ledger.Serialisation.Generators.Bootstrap
   ( genBootstrapAddress,
     genSignature,
   )
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)
 import Test.Tasty.QuickCheck (Gen, choose, elements)
 
 genHash :: forall a h. HashAlgorithm h => Gen (Hash.Hash h a)
@@ -139,7 +140,7 @@ mkDummyHash = coerce . hashWithSerialiser @h toCBOR
 type MockGen era = (Mock (Crypto era), Arbitrary (VerKeyDSIGN (DSIGN (Crypto era))))
 
 instance
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   Arbitrary (Block era)
   where
   arbitrary = do
@@ -168,7 +169,7 @@ instance
       p :: Proxy era
       p = Proxy
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (BHeader era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (BHeader era) where
   arbitrary = do
     res <- arbitrary :: Gen (Block era)
     return $ case res of
@@ -224,7 +225,7 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (Update era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (TxBody era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (TxBody era) where
   -- Our arbitrary instance constructs things using the pattern in order to have
   -- the correct serialised bytes.
   arbitrary =
@@ -273,7 +274,7 @@ instance Arbitrary MD.MetaData where
 maxTxWits :: Int
 maxTxWits = 5
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (Tx era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (Tx era) where
   -- Our arbitrary instance constructs things using the pattern in order to have
   -- the correct serialised bytes.
   arbitrary =
@@ -291,7 +292,7 @@ instance Era era => Arbitrary (TxIn era) where
       <$> (TxId <$> genHash)
       <*> arbitrary
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (TxOut era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (TxOut era) where
   arbitrary = TxOut <$> arbitrary <*> arbitrary
 
 instance Arbitrary Nonce where
@@ -328,14 +329,14 @@ instance Era era => Arbitrary (STS.PpupPredicateFailure era) where
   shrink = genericShrink
 
 instance
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   Arbitrary (STS.UtxoPredicateFailure era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (Era era, MockGen era) =>
+  (ShelleyTest era, MockGen era) =>
   Arbitrary (STS.UtxowPredicateFailure era)
   where
   arbitrary = genericArbitraryU
@@ -370,14 +371,14 @@ instance
   shrink = genericShrink
 
 instance
-  (Era era, MockGen era) =>
+  (ShelleyTest era, MockGen era) =>
   Arbitrary (STS.LedgerPredicateFailure era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (Era era, MockGen era) =>
+  (ShelleyTest era, MockGen era) =>
   Arbitrary (STS.LedgersPredicateFailure era)
   where
   arbitrary = genericArbitraryU
@@ -453,7 +454,7 @@ instance Era era => Arbitrary (STS.PrtclState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (UTxO era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (UTxO era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -519,15 +520,15 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (DPState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (UTxOState era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (UTxOState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (LedgerState era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (LedgerState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (NewEpochState era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (NewEpochState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -541,7 +542,7 @@ instance Era era => Arbitrary (PoolDistr era) where
     where
       genVal = IndividualPoolStake <$> arbitrary <*> genHash
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (EpochState era) where
+instance (ShelleyTest era, Mock (Crypto era)) => Arbitrary (EpochState era) where
   arbitrary =
     EpochState
       <$> arbitrary

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Bootstrap.hs
@@ -27,7 +27,7 @@ import Test.Cardano.Prelude (genBytes)
 import Test.QuickCheck (Gen)
 import Test.QuickCheck.Hedgehog (hedgehog)
 
-genSignature :: forall a b. DSIGN.DSIGNAlgorithm a => Gen (DSIGN.SignedDSIGN a b)
+genSignature :: forall a b. (DSIGN.DSIGNAlgorithm a) => Gen (DSIGN.SignedDSIGN a b)
 genSignature =
   DSIGN.SignedDSIGN
     . fromJust

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -34,6 +35,7 @@ module Test.Shelley.Spec.Ledger.Utils
     GenesisKeyPair,
     MultiSigPairs,
     getBlockNonce,
+    ShelleyTest,
   )
 where
 
@@ -61,8 +63,10 @@ import Cardano.Crypto.VRF
     genKeyVRF,
   )
 import qualified Cardano.Crypto.VRF as VRF
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import Cardano.Ledger.Era (Crypto (..))
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Prelude (Coercible, asks)
 import Cardano.Slotting.EpochInfo
   ( epochInfoEpoch,
@@ -108,14 +112,14 @@ import Shelley.Spec.Ledger.Keys
     pattern KeyPair,
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
--- import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
-
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
 import Test.Tasty.HUnit
   ( Assertion,
     (@?=),
   )
+
+type ShelleyTest era = (ShelleyBased era, Core.Value era ~ Coin)
 
 -- =======================================================
 
@@ -148,7 +152,8 @@ mkGenKey seed =
    in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic key pair given a seed.
-mkKeyPair :: forall era kd.
+mkKeyPair ::
+  forall era kd.
   DSIGNAlgorithm (DSIGN (Crypto era)) =>
   (Word64, Word64, Word64, Word64, Word64) ->
   (SignKeyDSIGN (DSIGN (Crypto era)), VKey kd era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -23,8 +23,10 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Byron
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Era
+import Cardano.Ledger.Val ((<->))
 import Cardano.Prelude
   ( ByteString,
   )
@@ -88,7 +90,6 @@ import Shelley.Spec.Ledger.TxBody
 import Shelley.Spec.Ledger.UTxO
   ( UTxO (..),
   )
-import Cardano.Ledger.Val((<->))
 import qualified Test.Cardano.Chain.Common.Gen as Byron
 import qualified Test.Cardano.Crypto.Gen as Byron
 import Test.Cardano.Prelude (genBytes)
@@ -98,6 +99,7 @@ import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as Original
   ( C_Crypto,
   )
 import Test.Shelley.Spec.Ledger.Generator.Core (genesisId)
+import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils (testSTS)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit
@@ -276,3 +278,5 @@ instance Cardano.Ledger.Crypto.Crypto C_crypto where
   type DSIGN C_crypto = DSIGN.Ed25519DSIGN
   type HASH C_crypto = HASH Original.C_Crypto
   type ADDRHASH C_crypto = Hash.Blake2b_224
+
+type instance Core.Value C = Coin

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -11,8 +11,9 @@ import Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import Shelley.Spec.Ledger.BlockChain (Block)
 import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState, totalAda)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
-import Test.Shelley.Spec.Ledger.Utils (runShelleyBase, maxLLSupply, applySTSTest)
-import Test.Tasty.HUnit ((@?=), Assertion)
+import Test.Shelley.Spec.Ledger.Orphans ()
+import Test.Shelley.Spec.Ledger.Utils (applySTSTest, maxLLSupply, runShelleyBase)
+import Test.Tasty.HUnit (Assertion, (@?=))
 
 data CHAINExample h = CHAINExample
   { -- | State to start testing with

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
@@ -40,6 +41,8 @@ module Test.Shelley.Spec.Ledger.Examples.Combinators
 where
 
 import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley (ShelleyBased)
+import Cardano.Ledger.Val ((<+>), (<->))
 import Cardano.Slotting.Slot (EpochNo, WithOrigin (..))
 import Control.Iterate.SetAlgebra (eval, setSingleton, singleton, (∪), (⋪), (⋫))
 import Data.Foldable (fold)
@@ -90,7 +93,6 @@ import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..), TxBody (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
-import Cardano.Ledger.Val((<->),(<+>))
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
 
 -- | = Evolve Nonces - Frozen
@@ -121,7 +123,7 @@ evolveNonceUnfrozen n cs =
 -- instead use 'newEpoch'.
 newLab ::
   forall era.
-  Era era =>
+  (Era era) =>
   Block era ->
   ChainState era ->
   ChainState era
@@ -164,7 +166,7 @@ feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
 -- Update the UTxO for given transaction body.
 newUTxO ::
   forall era.
-  Era era =>
+  ShelleyBased era =>
   TxBody era ->
   ChainState era ->
   ChainState era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -40,9 +40,9 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     mkOCert,
     zero,
   )
-import Test.Shelley.Spec.Ledger.Utils (getBlockNonce)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, getBlockNonce)
 
-initStEx1 :: forall era. Era era => ChainState era
+initStEx1 :: forall era. ShelleyTest era => ChainState era
 initStEx1 = initSt (UTxO Map.empty)
 
 blockEx1 ::
@@ -69,7 +69,7 @@ blockEx1 =
 blockNonce :: forall era. (HasCallStack, Era era, ExMock (Crypto era)) => Nonce
 blockNonce = getBlockNonce (blockEx1 @era)
 
-expectedStEx1 :: forall era. (Era era, ExMock (Crypto era)) => ChainState era
+expectedStEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
 expectedStEx1 =
   (evolveNonceUnfrozen (blockNonce @era))
     . (newLab blockEx1)
@@ -82,5 +82,5 @@ expectedStEx1 =
 --
 -- The only things that change in the chain state are the
 -- evolving and candidate nonces, and the last applied block.
-exEmptyBlock :: (Era era, ExMock (Crypto era)) => CHAINExample era
+exEmptyBlock :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
 exEmptyBlock = CHAINExample initStEx1 blockEx1 (Right expectedStEx1)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
@@ -18,6 +18,7 @@ import Cardano.Crypto.Hash (HashAlgorithm)
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Era (Crypto (..))
+import Cardano.Ledger.Val ((<->))
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -47,7 +48,6 @@ import Shelley.Spec.Ledger.TxBody
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey)
-import Cardano.Ledger.Val((<->))
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
@@ -71,7 +71,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     mkOCert,
     zero,
   )
-import Test.Shelley.Spec.Ledger.Utils (getBlockNonce, mkKeyPair, mkVRFKeyPair)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, getBlockNonce, mkKeyPair, mkVRFKeyPair)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
@@ -81,14 +81,14 @@ aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 bobInitCoin :: Coin
 bobInitCoin = Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initUTxO :: Era era => UTxO era
+initUTxO :: ShelleyTest era => UTxO era
 initUTxO =
   genesisCoins
     [ TxOut Cast.aliceAddr aliceInitCoin,
       TxOut Cast.bobAddr bobInitCoin
     ]
 
-initStGenesisDeleg :: forall era. Era era => ChainState era
+initStGenesisDeleg :: forall era. ShelleyTest era => ChainState era
 initStGenesisDeleg = initSt initUTxO
 
 --
@@ -112,7 +112,7 @@ feeTx1 = Coin 1
 aliceCoinEx1 :: Coin
 aliceCoinEx1 = aliceInitCoin <-> feeTx1
 
-txbodyEx1 :: Era era => TxBody era
+txbodyEx1 :: ShelleyTest era => TxBody era
 txbodyEx1 =
   TxBody
     (Set.fromList [TxIn genesisId 0])
@@ -134,7 +134,7 @@ txbodyEx1 =
 
 txEx1 ::
   forall era.
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   Tx era
 txEx1 =
   Tx
@@ -151,7 +151,7 @@ txEx1 =
 
 blockEx1 ::
   forall era.
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   Block era
 blockEx1 =
   mkBlockFakeVRF
@@ -175,7 +175,7 @@ newGenDeleg =
 
 expectedStEx1 ::
   forall era.
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   ChainState era
 expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @era))
@@ -189,7 +189,7 @@ expectedStEx1 =
 --
 -- In the first block, stage a new future genesis delegate
 genesisDelegation1 ::
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   CHAINExample era
 genesisDelegation1 = CHAINExample initStGenesisDeleg blockEx1 (Right expectedStEx1)
 
@@ -199,7 +199,7 @@ genesisDelegation1 = CHAINExample initStGenesisDeleg blockEx1 (Right expectedStE
 
 blockEx2 ::
   forall era.
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   Block era
 blockEx2 =
   mkBlockFakeVRF
@@ -217,7 +217,7 @@ blockEx2 =
 
 expectedStEx2 ::
   forall era.
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   ChainState era
 expectedStEx2 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx2 @era))
@@ -230,7 +230,7 @@ expectedStEx2 =
 --
 -- Submit an empty block to trigger adopting the genesis delegation.
 genesisDelegation2 ::
-  (Era era, ExMock (Crypto era)) =>
+  (ShelleyTest era, ExMock (Crypto era)) =>
   CHAINExample era
 genesisDelegation2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Init.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -16,6 +18,7 @@ module Test.Shelley.Spec.Ledger.Examples.Init
 where
 
 import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Val ((<->))
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Shelley.Spec.Ledger.BaseTypes
   ( Nonce (..),
@@ -41,9 +44,8 @@ import Shelley.Spec.Ledger.Slot
     SlotNo (..),
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
-import Cardano.Ledger.Val((<->))
 import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs)
-import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, mkHash, unsafeMkUnitInterval)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, maxLLSupply, mkHash, unsafeMkUnitInterval)
 
 -- === Initial Protocol Parameters
 --
@@ -97,7 +99,7 @@ nonce0 = hashHeaderToNonce (lastByronHeaderHash @era)
 -- The initial state for the examples uses the function
 -- 'initialShelleyState' with the genesis delegation
 -- 'genDelegs' and any given starting 'UTxO' set.
-initSt :: forall era. Era era => UTxO era -> ChainState era
+initSt :: forall era. ShelleyTest era => UTxO era -> ChainState era
 initSt utxo =
   initialShelleyState
     (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
@@ -15,6 +15,7 @@ module Test.Shelley.Spec.Ledger.Examples.Updates
 where
 
 import Cardano.Ledger.Era (Crypto (..))
+import Cardano.Ledger.Val ((<+>), (<->))
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -55,7 +56,6 @@ import Shelley.Spec.Ledger.TxBody
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey, txid)
-import Cardano.Ledger.Val((<->), (<+>))
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
@@ -80,7 +80,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     mkOCert,
     zero,
   )
-import Test.Shelley.Spec.Ledger.Utils (getBlockNonce)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, getBlockNonce)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
@@ -90,14 +90,14 @@ aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 bobInitCoin :: Coin
 bobInitCoin = Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initUTxO :: Era era => UTxO era
+initUTxO :: ShelleyTest era => UTxO era
 initUTxO =
   genesisCoins
     [ TxOut Cast.aliceAddr aliceInitCoin,
       TxOut Cast.bobAddr bobInitCoin
     ]
 
-initStUpdates :: forall era. Era era => ChainState era
+initStUpdates :: forall era. ShelleyTest era => ChainState era
 initStUpdates = initSt initUTxO
 
 --
@@ -139,7 +139,7 @@ feeTx1 = Coin 1
 aliceCoinEx1 :: Coin
 aliceCoinEx1 = aliceInitCoin <-> feeTx1
 
-txbodyEx1 :: Era era => TxBody era
+txbodyEx1 :: ShelleyTest era => TxBody era
 txbodyEx1 =
   TxBody
     (Set.fromList [TxIn genesisId 0])
@@ -151,7 +151,7 @@ txbodyEx1 =
     (SJust (Update ppVotes1 (EpochNo 0)))
     SNothing
 
-txEx1 :: (Era era, ExMock (Crypto era)) => Tx era
+txEx1 :: (ShelleyTest era, ExMock (Crypto era)) => Tx era
 txEx1 =
   Tx
     txbodyEx1
@@ -168,7 +168,7 @@ txEx1 =
       }
     SNothing
 
-blockEx1 :: forall era. (Era era, ExMock (Crypto era)) => Block era
+blockEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -183,7 +183,7 @@ blockEx1 =
     0
     (mkOCert (coreNodeKeysBySchedule ppEx 10) 0 (KESPeriod 0))
 
-expectedStEx1 :: forall era. (Era era, ExMock (Crypto era)) => ChainState era
+expectedStEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
 expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @era))
     . C.newLab blockEx1
@@ -195,7 +195,7 @@ expectedStEx1 =
 -- === Block 1, Slot 10, Epoch 0
 --
 -- In the first block, three genesis keys vote on the same new parameters.
-updates1 :: (Era era, ExMock (Crypto era)) => CHAINExample era
+updates1 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
 updates1 = CHAINExample initStUpdates blockEx1 (Right expectedStEx1)
 
 --
@@ -214,7 +214,7 @@ feeTx2 = Coin 1
 aliceCoinEx2 :: Coin
 aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 
-txbodyEx2 :: Era era => TxBody era
+txbodyEx2 :: ShelleyTest era => TxBody era
 txbodyEx2 =
   TxBody
     (Set.fromList [TxIn (txid txbodyEx1) 0])
@@ -226,7 +226,7 @@ txbodyEx2 =
     (SJust updateEx3B)
     SNothing
 
-txEx2 :: (Era era, ExMock (Crypto era)) => Tx era
+txEx2 :: (ShelleyTest era, ExMock (Crypto era)) => Tx era
 txEx2 =
   Tx
     txbodyEx2
@@ -242,7 +242,7 @@ txEx2 =
       }
     SNothing
 
-blockEx2 :: forall era. (Era era, ExMock (Crypto era)) => Block era
+blockEx2 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
 blockEx2 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx1)
@@ -257,7 +257,7 @@ blockEx2 =
     0
     (mkOCert (coreNodeKeysBySchedule ppEx 20) 0 (KESPeriod 0))
 
-expectedStEx2 :: forall era. (Era era, ExMock (Crypto era)) => ChainState era
+expectedStEx2 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
 expectedStEx2 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx2 @era))
     . C.newLab blockEx2
@@ -269,7 +269,7 @@ expectedStEx2 =
 -- === Block 2, Slot 20, Epoch 0
 --
 -- In the second block, two more genesis keys vote for the same new parameters.
-updates2 :: (Era era, ExMock (Crypto era)) => CHAINExample era
+updates2 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
 updates2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
@@ -307,7 +307,7 @@ feeTx3 = Coin 1
 aliceCoinEx3 :: Coin
 aliceCoinEx3 = aliceCoinEx2 <-> feeTx3
 
-txbodyEx3 :: Era era => TxBody era
+txbodyEx3 :: ShelleyTest era => TxBody era
 txbodyEx3 =
   TxBody
     (Set.fromList [TxIn (txid txbodyEx2) 0])
@@ -319,7 +319,7 @@ txbodyEx3 =
     (SJust (Update ppVotes3 (EpochNo 1)))
     SNothing
 
-txEx3 :: (Era era, ExMock (Crypto era)) => Tx era
+txEx3 :: (ShelleyTest era, ExMock (Crypto era)) => Tx era
 txEx3 =
   Tx
     txbodyEx3
@@ -331,7 +331,7 @@ txEx3 =
       }
     SNothing
 
-blockEx3 :: forall era. (Era era, ExMock (Crypto era)) => Block era
+blockEx3 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
 blockEx3 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx2)
@@ -346,7 +346,7 @@ blockEx3 =
     0
     (mkOCert (coreNodeKeysBySchedule ppEx 80) 0 (KESPeriod 0))
 
-expectedStEx3 :: forall era. (Era era, ExMock (Crypto era)) => ChainState era
+expectedStEx3 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
 expectedStEx3 =
   C.evolveNonceFrozen (getBlockNonce (blockEx3 @era))
     . C.newLab blockEx3
@@ -359,17 +359,17 @@ expectedStEx3 =
 -- === Block 3, Slot 80, Epoch 0
 --
 -- In the third block, one genesis keys votes for the next epoch
-updates3 :: (Era era, ExMock (Crypto era)) => CHAINExample era
+updates3 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
 updates3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
 -- Block 4, Slot 110, Epoch 1
 --
 
-epoch1Nonce :: forall era. (Era era, ExMock (Crypto era)) => Nonce
+epoch1Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
 epoch1Nonce = (chainCandidateNonce (expectedStEx3 @era)) ⭒ mkNonceFromNumber 123
 
-blockEx4 :: forall era. (Era era, ExMock (Crypto era)) => Block era
+blockEx4 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
 blockEx4 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx3)
@@ -387,7 +387,7 @@ blockEx4 =
 ppExUpdated :: PParams era
 ppExUpdated = ppEx {_poolDeposit = Coin 200, _extraEntropy = mkNonceFromNumber 123}
 
-expectedStEx4 :: forall era. (Era era, ExMock (Crypto era)) => ChainState era
+expectedStEx4 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
 expectedStEx4 =
   C.newEpoch blockEx4
     . C.newSnapshot EB.emptySnapShot (feeTx1 <+> feeTx2 <+> feeTx3)
@@ -403,7 +403,7 @@ expectedStEx4 =
 -- and the future vote becomes a current vote.
 -- Since the extra entropy was voted on, notice that it is a part
 -- of the new epoch nonce.
-updates4 :: (Era era, ExMock (Crypto era)) => CHAINExample era
+updates4 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
 updates4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
 --

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -140,7 +140,7 @@ aliceAndBobOrCarlOrDaria p =
       RequireAnyOf [singleKeyOnly Cast.carlAddr, singleKeyOnly Cast.dariaAddr]
     ]
 
-initTxBody :: Era era => [(Addr era, Coin)] -> TxBody era
+initTxBody :: ShelleyTest era => [(Addr era, Coin)] -> TxBody era
 initTxBody addrs =
   TxBody
     (Set.fromList [TxIn genesisId 0, TxIn genesisId 1])
@@ -152,7 +152,7 @@ initTxBody addrs =
     SNothing
     SNothing
 
-makeTxBody :: Era era => [TxIn era] -> [(Addr era, Coin)] -> Wdrl era -> TxBody era
+makeTxBody :: ShelleyTest era => [TxIn era] -> [(Addr era, Coin)] -> Wdrl era -> TxBody era
 makeTxBody inp addrCs wdrl =
   TxBody
     (Set.fromList inp)
@@ -179,7 +179,7 @@ aliceInitCoin = Coin 10000
 bobInitCoin :: Coin
 bobInitCoin = Coin 1000
 
-genesis :: Era era => LedgerState era
+genesis :: ShelleyTest era => LedgerState era
 genesis = genesisState genDelegs0 utxo0
   where
     genDelegs0 = Map.empty
@@ -198,7 +198,7 @@ initPParams = emptyPParams {_maxTxSize = 1000}
 -- locked by a script for each pair of script, coin value in 'msigs'.
 initialUTxOState ::
   forall era.
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   Coin ->
   [(MultiSig era, Coin)] ->
   (TxId era, Either [[PredicateFailure (UTXOW era)]] (UTxOState era))
@@ -245,7 +245,7 @@ initialUTxOState aliceKeep msigs =
 -- Alice. Return resulting UTxO state or collected errors
 applyTxWithScript ::
   forall proxy era.
-  (Era era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era)) =>
   proxy era ->
   [(MultiSig era, Coin)] ->
   [MultiSig era] ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -121,5 +121,5 @@ propertyTests =
             "Only valid CHAIN STS signals are generated"
             onlyValidChainSignalsAreGenerated
         ],
-      testGroupByronTranslation proxyC
+      testGroupByronTranslation
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -66,6 +66,7 @@ import qualified Test.Shelley.Spec.Ledger.Rules.TestPool as TestPool
     poolRetirement,
     poolStateIsInternallyConsistent,
   )
+import Test.Shelley.Spec.Ledger.Orphans ()
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
 import Test.Shelley.Spec.Ledger.Utils
   ( epochFromSlotNo,
@@ -325,7 +326,7 @@ requiredMSigSignaturesSubset SourceSignalTarget {source = chainSt, signal = bloc
     signaturesSubset :: SourceSignalTarget (LEDGER C) -> Property
     signaturesSubset SourceSignalTarget {signal = tx} =
       let khs = keyHashSet tx
-       in property $ 
+       in property $
             all (existsReqKeyComb khs) (msigWits . _witnessSet $ tx)
 
     existsReqKeyComb keyHashes msig =
@@ -390,11 +391,11 @@ nonNegativeDeposits SourceSignalTarget {source = chainSt} =
 -- | Checks that the fees are non-decreasing when not at an epoch boundary
 feesNonDecreasing :: SourceSignalTarget (CHAIN C) -> Property
 feesNonDecreasing SourceSignalTarget {source, target} =
-  property $ 
+  property $
     fees_ source <= fees_ target
   where
     fees_ chainSt =
-      let (UTxOState {_fees = fees}) = 
+      let (UTxOState {_fees = fees}) =
             _utxoState . esLState . nesEs . chainNes $ chainSt
       in fees
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}


### PR DESCRIPTION
- Introducing Value type as a replacement for Coin in TxOut
- Test run as before (operating only on Coin)

This PR is a continuation of "Parametrise the Shelley ledger over Value."
https://github.com/input-output-hk/cardano-ledger-specs/pull/1847

