### PR TITLE
fix division by zero edge case in reward calc

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -448,8 +448,8 @@ reward
       Coin activeStake = fold . unStake $ stake
       results = do
         (hk, pparams) <- Map.toList poolParams
-        let sigma = fromIntegral pstake % fromIntegral totalStake
-            sigmaA = fromIntegral pstake % fromIntegral activeStake
+        let sigma = if totalStake == 0 then 0 else fromIntegral pstake % fromIntegral totalStake
+            sigmaA = if activeStake == 0 then 0 else fromIntegral pstake % fromIntegral activeStake
             blocksProduced = Map.lookup hk b
             actgr@(Stake s) = poolStake hk delegs stake
             Coin pstake = fold s


### PR DESCRIPTION
If the total stake is zero (which would only happen if the reserves held all the ada, ie 45B on mainnet), or if the active stake is zero (if, for instance, every stake key was deregistered), the reward calculation would attempt to divide by zero. But not after this PR!