### PR TITLE
Ts minimize c part2

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -4,6 +4,7 @@
 
 module Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation) where
 
+import Data.Proxy
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import Cardano.Ledger.Era
@@ -13,7 +14,6 @@ import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.TxBody
 import Test.Cardano.Chain.UTxO.Gen (genCompactTxOut)
 import Test.QuickCheck.Hedgehog (hedgehog)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
@@ -21,21 +21,21 @@ import Test.Tasty.QuickCheck
   Top-level tests
 ------------------------------------------------------------------------------}
 
-testGroupByronTranslation :: TestTree
-testGroupByronTranslation =
+testGroupByronTranslation :: forall era. Era era => Proxy era -> TestTree
+testGroupByronTranslation proxy =
   testGroup
     "Translation from Byron to Shelley"
-    [ testProperty "translateTxOut correctness" prop_translateTxOut_correctness
+    [ testProperty "translateTxOut correctness" (prop_translateTxOut_correctness proxy)
     ]
 
 {------------------------------------------------------------------------------
   Properties
 ------------------------------------------------------------------------------}
 
-prop_translateTxOut_correctness :: Byron.CompactTxOut -> Property
-prop_translateTxOut_correctness compactTxOut =
+prop_translateTxOut_correctness :: forall era. Era era => Proxy era -> Byron.CompactTxOut -> Property
+prop_translateTxOut_correctness _proxy compactTxOut =
   translateTxOutByronToShelley
-    @C
+    @era
     (Byron.fromCompactTxOut compactTxOut)
     === translateCompactTxOutByronToShelley compactTxOut
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/LegacyOverlay.hs
@@ -8,8 +8,10 @@ module Test.Shelley.Spec.Ledger.LegacyOverlay
 where
 
 import Cardano.Slotting.Slot
+import Cardano.Ledger.Era (Era)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import Data.Proxy
 import Data.Ratio ((%))
 import qualified Data.Set as Set
 import Data.Set (Set)
@@ -20,7 +22,6 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.OverlaySchedule (OBftSlot (..), classifyOverlaySlot, overlaySlots)
 import Shelley.Spec.Ledger.Slot
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Examples.Federation (genDelegs)
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty.QuickCheck
@@ -76,8 +77,8 @@ makeConcreteOverlay start gkeys dval asc spe =
       (\s -> (s, classifyOverlaySlot start gkeys dval asc s))
       (overlaySlots start dval spe)
 
-legacyOverlayTest :: Property
-legacyOverlayTest = property $ do
+legacyOverlayTest :: forall era. Era era => Proxy era -> Property
+legacyOverlayTest _proxy = property $ do
   d <- choose (0, 100)
   e <- choose (0, 100)
   let dval = unsafeMkUnitInterval (d % 100)
@@ -88,7 +89,7 @@ legacyOverlayTest = property $ do
         legacyOverlay
           mainnetEpochSize
           start
-          (Map.keysSet (genDelegs @C))
+          (Map.keysSet (genDelegs @era))
           dval
           asc
-  pure $ os === makeConcreteOverlay start (Map.keysSet (genDelegs @C)) dval asc mainnetEpochSize
+  pure $ os === makeConcreteOverlay start (Map.keysSet (genDelegs @era)) dval asc mainnetEpochSize

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.PropertyTests (propertyTests, minimalPropertyTests) where
 
+import Data.Proxy
 import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
   ( bootstrapHashTest,
   )
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.LegacyOverlay (legacyOverlayTest)
 import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
   ( onlyValidChainSignalsAreGenerated,
@@ -39,10 +43,13 @@ import Test.Shelley.Spec.Ledger.Rules.TestLedger
   )
 import Test.Shelley.Spec.Ledger.Serialisation.StakeRef
   ( propDeserializeAddrStakeReference,
-    propDeserializeAddrStakeReferenceShortIncrediblyLongName,
+    propDeserializeAddrStakeReferenceShort,
   )
 import Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as TQC
+
+proxyC :: Proxy C
+proxyC = Proxy
 
 minimalPropertyTests :: TestTree
 minimalPropertyTests =
@@ -54,10 +61,10 @@ minimalPropertyTests =
       bootstrapHashTest,
       testGroup
         "Deserialize stake address reference"
-        [ TQC.testProperty "wstake reference from bytestrings" propDeserializeAddrStakeReference,
-          TQC.testProperty "stake reference from short bytestring" propDeserializeAddrStakeReferenceShortIncrediblyLongName
+        [ TQC.testProperty "wstake reference from bytestrings" (propDeserializeAddrStakeReference @C),
+          TQC.testProperty "stake reference from short bytestring" (propDeserializeAddrStakeReferenceShort @C)
         ],
-      TQC.testProperty "legacy overlay schedule" legacyOverlayTest
+      TQC.testProperty "legacy overlay schedule" (legacyOverlayTest proxyC)
     ]
 
 -- | 'TestTree' of property-based testing properties.
@@ -143,5 +150,5 @@ propertyTests =
             "Only valid CHAIN STS signals are generated"
             onlyValidChainSignalsAreGenerated
         ],
-      testGroupByronTranslation
+      testGroupByronTranslation proxyC
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestDelegs.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestDelegs.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestDelegs where
 
@@ -18,7 +19,6 @@ import Shelley.Spec.Ledger.Coin (pattern Coin)
 import Shelley.Spec.Ledger.LedgerState (_dstate, _rewards)
 import qualified Shelley.Spec.Ledger.TxBody as T
 import Test.QuickCheck (Property, conjoin)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 
 ---------------------------
 -- Properties for DELEGS --
@@ -26,8 +26,8 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 
 -- | Check that the rewards pot decreases by the sum of withdrawals in the
 -- transaction.
-rewardsDecreasesByWithdrawals ::
-  [(T.Wdrl C, SourceSignalTarget (DELEGS C))] ->
+rewardsDecreasesByWithdrawals :: forall era.
+  [(T.Wdrl era, SourceSignalTarget (DELEGS era))] ->
   Property
 rewardsDecreasesByWithdrawals tr =
   conjoin $

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
   ( constantSumPots,
@@ -45,7 +46,6 @@ import Shelley.Spec.Ledger.STS.PoolReap
   )
 import Shelley.Spec.Ledger.UTxO (balance)
 import Test.QuickCheck (Property, conjoin)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring)
 
 -----------------------------
@@ -54,8 +54,8 @@ import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring)
 
 -- | Check that after a POOLREAP certificate transition the pool is removed from
 -- the stake pool and retiring maps.
-removedAfterPoolreap ::
-  [SourceSignalTarget (POOLREAP C)] ->
+removedAfterPoolreap :: forall era.
+  [SourceSignalTarget (POOLREAP era)] ->
   Property
 removedAfterPoolreap tr =
   conjoin $
@@ -72,7 +72,7 @@ removedAfterPoolreap tr =
             stp' = _pParams p'
             retiring = getRetiring p
             retiring' = getRetiring p'
-            retire :: Set.Set (KeyHash 'StakePool C) -- This declaration needed to disambiguate 'eval'
+            retire :: Set.Set (KeyHash 'StakePool era) -- This declaration needed to disambiguate 'eval'
             retire = eval (dom (retiring ▷ setSingleton e))
          in eval (retire ⊆ dom stp)
               && Set.null (eval (retire ∩ dom stp'))
@@ -80,7 +80,7 @@ removedAfterPoolreap tr =
 
 -- | Check that deposits are always non-negative
 nonNegativeDeposits ::
-  [SourceSignalTarget (POOLREAP C)] ->
+  [SourceSignalTarget (POOLREAP era)] ->
   Property
 nonNegativeDeposits tr =
   conjoin $
@@ -95,7 +95,7 @@ nonNegativeDeposits tr =
 -- | Check that the sum of circulation, deposits, fees, treasury, rewards and
 -- reserves is constant.
 constantSumPots ::
-  [SourceSignalTarget (POOLREAP C)] ->
+  [SourceSignalTarget (POOLREAP era)] ->
   Property
 constantSumPots tr =
   conjoin $

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxo.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestUtxo
   ( feesNonDecreasing,
@@ -17,15 +18,14 @@ import Control.State.Transition.Trace
 import Shelley.Spec.Ledger.API (UTXO)
 import Shelley.Spec.Ledger.LedgerState (_fees, pattern UTxOState)
 import Test.QuickCheck (Property, conjoin)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 
 --------------------------
 -- Properties for UTXOW --
 --------------------------
 
 -- | Property that checks that the fees are non-decreasing
-feesNonDecreasing ::
-  [SourceSignalTarget (UTXO C)] ->
+feesNonDecreasing :: forall era.
+  [SourceSignalTarget (UTXO era)] ->
   Property
 feesNonDecreasing ssts =
   conjoin $

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
@@ -5,12 +5,15 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 
 module Test.Shelley.Spec.Ledger.Rules.TestUtxow
   ( requiredMSigSignaturesSubset,
   )
 where
 
+import Cardano.Ledger.Era(Era)
 import Control.State.Transition.Trace
   ( SourceSignalTarget,
     signal,
@@ -29,9 +32,6 @@ import Shelley.Spec.Ledger.TxBody
   ( witKeyHash,
   )
 import Test.QuickCheck (Property, conjoin)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-  ( C,
-  )
 
 --------------------------
 -- Properties for UTXOW --
@@ -44,7 +44,7 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 -- TODO @mgudemann
 -- This property is currenty disabled du to time-out problems with getting all
 -- possible combinations for multi-sig.
-requiredMSigSignaturesSubset :: [SourceSignalTarget (UTXOW C)] -> Property
+requiredMSigSignaturesSubset :: forall era. Era era => [SourceSignalTarget (UTXOW era)] -> Property
 requiredMSigSignaturesSubset tr =
   conjoin $
     map signaturesSubset tr

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/StakeRef.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/StakeRef.hs
@@ -6,18 +6,18 @@ module Test.Shelley.Spec.Ledger.Serialisation.StakeRef where
 import qualified Data.ByteString.Short as SBS
 import Shelley.Spec.Ledger.Address (Addr (..), deserialiseAddrStakeRef, serialiseAddr)
 import qualified Shelley.Spec.Ledger.DeserializeShort as Short
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
+import Cardano.Ledger.Era (Era(..))
 
-propDeserializeAddrStakeReference :: Addr C -> Bool
+propDeserializeAddrStakeReference :: forall era. Era era => Addr era -> Bool
 propDeserializeAddrStakeReference addr =
   let bytes = serialiseAddr addr
    in case addr of
-        AddrBootstrap _ -> deserialiseAddrStakeRef @C bytes == Nothing
-        Addr _ _ stakeRef -> deserialiseAddrStakeRef @C bytes == Just stakeRef
+        AddrBootstrap _ -> deserialiseAddrStakeRef @era bytes == Nothing
+        Addr _ _ stakeRef -> deserialiseAddrStakeRef @era bytes == Just stakeRef
 
-propDeserializeAddrStakeReferenceShortIncrediblyLongName :: Addr C -> Bool
-propDeserializeAddrStakeReferenceShortIncrediblyLongName addr =
+propDeserializeAddrStakeReferenceShort::  forall era. Era era => Addr era -> Bool
+propDeserializeAddrStakeReferenceShort addr =
   let bytes = serialiseAddr addr
       sbs = SBS.toShort bytes
-   in deserialiseAddrStakeRef @C bytes == Short.deserialiseAddrStakeRef @C sbs
+   in deserialiseAddrStakeRef @era bytes == Short.deserialiseAddrStakeRef @era sbs

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE LambdaCase #-}
 
+import Data.Proxy
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Shelley.Spec.Ledger.Rewards (rewardTests)
 import Test.Shelley.Spec.Ledger.STSTests (chainExamples)
@@ -20,7 +22,7 @@ mainTests =
   testGroup
     "Ledger with Delegation"
     [ minimalPropertyTests,
-      rewardTests,
+      rewardTests (Proxy :: Proxy C),
       Serialisation.tests 5,
       chainExamples,
       --multisigExamples, - TODO re-enable after the script embargo has been lifted


### PR DESCRIPTION
This continues the work of minimizing the use of C, the concrete crypto class instance.
It basically abstracts over C. So a function with type:   
f :: Tx C -> KeyPair 'StakePool C
f :: forall era . Era era =>  Tx  era -> KeyPair 'StakePool era