### PR TITLE
fix poolsByTotalStakeFraction

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -53,6 +53,7 @@ import Shelley.Spec.Ledger.Rewards
     nonMyopicStake,
     percentile',
   )
+import Shelley.Spec.Ledger.STS.NewEpoch (calculatePoolDistr)
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxOut (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
@@ -69,11 +70,11 @@ poolsByTotalStakeFraction :: Era era => Globals -> ShelleyState era -> PoolDistr
 poolsByTotalStakeFraction globals ss =
   PoolDistr poolsByTotalStake
   where
-    EB.SnapShot stake _ _ = currentSnapshot ss
+    snap@(EB.SnapShot stake _ _) = currentSnapshot ss
     Coin totalStake = getTotalStake globals ss
     Coin activeStake = fold . EB.unStake $ stake
     stakeRatio = activeStake % totalStake
-    PoolDistr poolsByActiveStake = nesPd $ ss
+    PoolDistr poolsByActiveStake = calculatePoolDistr snap
     poolsByTotalStake = Map.map toTotalStakeFrac poolsByActiveStake
     toTotalStakeFrac :: IndividualPoolStake era -> IndividualPoolStake era
     toTotalStakeFrac (IndividualPoolStake s vrf) =


### PR DESCRIPTION
The wallet API function `poolsByTotalStakeFraction` was creating a current snapshot in order to calculate the ratio between the active stake and the total stake, but the ratio was then used to adjust the the stake pool distribution which is used for leader election instead of the distribution corresponding to the newly created snapshot. This PR corrects this.