### PR TITLE
Don't create a reward update in the future view.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -66,7 +66,7 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
-import Shelley.Spec.Ledger.STS.Tick (TICK)
+import Shelley.Spec.Ledger.STS.Tick (TICKF)
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (SlotNo)
@@ -173,7 +173,7 @@ currentLedgerView = view
 --  application of the TICK rule at the target slot to the curernt ledger state.
 
 newtype FutureLedgerViewError era
-  = FutureLedgerViewError [PredicateFailure (TICK era)]
+  = FutureLedgerViewError [PredicateFailure (TICKF era)]
   deriving (Eq, Show)
 
 -- | Anachronistic ledger view
@@ -198,7 +198,7 @@ futureLedgerView globals ss slot =
   where
     res =
       flip runReader globals
-        . applySTS @(TICK era)
+        . applySTS @(TICKF era)
         $ TRC ((), ss, slot)
 
 -- $chainstate


### PR DESCRIPTION
The future ledger view carries out the TICK transition, which calls
RUPD. However, the result of the RUPD transition is thrown away
immediately. Since this is a potentially expensive computation, it's
nice to avoid.

This should address https://jira.iohk.io/browse/CAD-1897

This is implemented using a separate TICKF rule, outside of the normal
rule hierarchy. This is done to avoid changing the hierarchy, which
would result in a change to things which get serialised (the error
stack).