### PR TITLE
TestPool properties - lift to chain level and consolidate

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -89,9 +89,9 @@ data Constants = Constants
     maxReserves :: Integer,
     -- | When generating Tx, we want the UTxO size to fluctuate around this point. If
     --   it gets too small, we can't balance the fee, too large it gets too complicated.
-    genTxStableUtxoSize:: Int,
+    genTxStableUtxoSize :: Int,
     -- | If we need to grow the Utxo when generating a Tx, how much should it grow by.
-    genTxUtxoIncrement:: Int
+    genTxUtxoIncrement :: Int
   }
   deriving (Show)
 
@@ -129,7 +129,7 @@ defaultConstants =
       frequencyPotentiallyManyWithdrawals = 5,
       minSlotTrace = 1000,
       maxSlotTrace = 5000,
-      frequencyLowMaxEpoch = 6,
+      frequencyLowMaxEpoch = 200,
       maxMinFeeA = 1000,
       maxMinFeeB = 3,
       numCoreNodes = 7,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -7,10 +7,10 @@
 module Test.Shelley.Spec.Ledger.PropertyTests (propertyTests, minimalPropertyTests) where
 
 import Data.Proxy
-import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
   ( bootstrapHashTest,
   )
+import Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.LegacyOverlay (legacyOverlayTest)
 import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
@@ -23,6 +23,7 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
     collisionFreeComplete,
     constantSumPots,
     nonNegativeDeposits,
+    poolProperties,
     removedAfterPoolreap,
   )
 import Test.Shelley.Spec.Ledger.Rules.TestLedger
@@ -30,14 +31,9 @@ import Test.Shelley.Spec.Ledger.Rules.TestLedger
     credentialMappingAfterDelegation,
     credentialRemovedAfterDereg,
     feesNonDecreasing,
-    pStateIsInternallyConsistent,
-    poolIsMarkedForRetirement,
-    poolRetireInEpoch,
     prop_MIRValuesEndUpInMap,
     prop_MIRentriesEndUpInMap,
-    registeredPoolIsAdded,
     rewardZeroAfterRegKey,
-    rewardZeroAfterRegPool,
     rewardsDecreasesByWithdrawals,
     rewardsSumInvariant,
   )
@@ -91,23 +87,8 @@ propertyTests =
       testGroup
         "STS Rules - Pool Properties"
         [ TQC.testProperty
-            "newly registered stake pool is added to \
-            \appropriate state mappings"
-            registeredPoolIsAdded,
-          TQC.testProperty
-            "newly registered pool key is not in the retiring map"
-            rewardZeroAfterRegPool,
-          TQC.testProperty
-            "retired stake pool is removed from \
-            \appropriate state mappings and marked \
-            \ for retiring"
-            poolIsMarkedForRetirement,
-          TQC.testProperty
-            "pool state is internally consistent"
-            pStateIsInternallyConsistent,
-          TQC.testProperty
-            "executing a pool retirement certificate adds to 'retiring'"
-            poolRetireInEpoch
+            "properties of the POOL STS"
+            poolProperties
         ],
       testGroup
         "STS Rules - Poolreap Properties"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -5,221 +5,100 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module Test.Shelley.Spec.Ledger.Rules.TestPool where
+module Test.Shelley.Spec.Ledger.Rules.TestPool
+  ( poolRegistration,
+    poolStateIsInternallyConsistent,
+    poolRetirement,
+  )
+where
 
 import Control.Iterate.SetAlgebra (dom, eval, (∈), (∉))
-import Control.State.Transition (Environment, State)
+import Control.State.Transition (State)
 import Control.State.Transition.Trace
-  ( SourceSignalTarget,
-    signal,
-    source,
-    target,
-    pattern SourceSignalTarget,
+  ( SourceSignalTarget (..),
   )
-import Data.Map (Map)
-import qualified Data.Map as M
-import qualified Data.Set as S
-import Data.Word (Word64)
-import Shelley.Spec.Ledger.API
-  ( LEDGER,
-    POOL,
-  )
-import Shelley.Spec.Ledger.BaseTypes ((==>))
-import Shelley.Spec.Ledger.Credential (Credential (..))
-import Shelley.Spec.Ledger.Delegation.Certificates (poolCWitness)
-import Shelley.Spec.Ledger.Keys
-  ( KeyHash,
-    KeyRole (..),
-  )
+import qualified Data.Map.Strict as Map (keysSet, lookup)
+import qualified Data.Set as Set (isSubsetOf)
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolCert (RegPool, RetirePool))
 import Shelley.Spec.Ledger.LedgerState
   ( PState (..),
+    _fPParams,
+    _pParams,
   )
-import Shelley.Spec.Ledger.PParams (_eMax)
-import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (ledgerPp, ledgerSlotNo))
+import Shelley.Spec.Ledger.STS.Pool (POOL)
 import Shelley.Spec.Ledger.Slot (EpochNo (..))
-import Shelley.Spec.Ledger.TxBody
-  ( PoolParams,
-    _poolPubKey,
-    pattern DCertPool,
-    pattern RegPool,
-    pattern RetirePool,
-  )
+import Shelley.Spec.Ledger.TxBody (DCert (DCertPool), PoolParams (..))
 import Test.QuickCheck (Property, conjoin, counterexample, property, (===))
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-  ( C,
-  )
-import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
 
--------------------------------
--- helper accessor functions --
--------------------------------
+poolRegistration :: SourceSignalTarget (POOL era) -> Property
+poolRegistration
+  SourceSignalTarget
+    { signal = (DCertPool (RegPool poolParams)),
+      source = sourceSt,
+      target = targetSt
+    } =
+    let hk = _poolPubKey poolParams
+        reRegistration = eval (hk ∈ dom (_pParams sourceSt))
+     in if reRegistration
+          then
+            conjoin
+              [ counterexample
+                  "Pre-existing PoolParams must still be registered in pParams"
+                  ((eval (hk ∈ dom (_pParams targetSt))) :: Bool),
+                counterexample
+                  "New PoolParams are registered in future Params map"
+                  (Map.lookup hk (_fPParams targetSt) === Just poolParams),
+                counterexample
+                  "PoolParams are removed in 'retiring'"
+                  ((eval (hk ∉ dom (_retiring targetSt))) :: Bool)
+              ]
+          else -- first registration
 
-getRetiring :: PState era -> Map (KeyHash 'StakePool era) EpochNo
-getRetiring = _retiring
+            conjoin
+              [ counterexample
+                  "New PoolParams are registered in pParams"
+                  (Map.lookup hk (_pParams targetSt) === Just poolParams),
+                counterexample
+                  "PoolParams are not present in 'future pool params'"
+                  ((eval (hk ∉ dom (_fPParams targetSt))) :: Bool),
+                counterexample
+                  "PoolParams are removed in 'retiring'"
+                  ((eval (hk ∉ dom (_retiring targetSt))) :: Bool)
+              ]
+poolRegistration _ = property ()
 
-------------------------------
--- Constants for Properties --
-------------------------------
+poolRetirement :: EpochNo -> EpochNo -> SourceSignalTarget (POOL era) -> Property
+poolRetirement
+  currentEpoch@(EpochNo ce)
+  (EpochNo maxEpoch)
+  (SourceSignalTarget {source = sourceSt, target = targetSt, signal = (DCertPool (RetirePool hk e))}) =
+    conjoin
+      [ counterexample
+          ("epoch must be well formed " <> show ce <> " " <> show e <> " " <> show maxEpoch)
+          (currentEpoch < e && e < EpochNo (ce + maxEpoch)),
+        counterexample
+          "hk must be in source stPools"
+          ((eval (hk ∈ dom (_pParams sourceSt))) :: Bool),
+        counterexample
+          "hk must be in target stPools"
+          ((eval (hk ∈ dom (_pParams targetSt))) :: Bool),
+        counterexample
+          "hk must be in target's retiring"
+          ((eval (hk ∈ dom (_retiring targetSt))) :: Bool)
+      ]
+poolRetirement _ _ _ = property ()
 
-numberOfTests :: Word64
-numberOfTests = 300
+poolStateIsInternallyConsistent :: State (POOL era) -> Property
+poolStateIsInternallyConsistent (PState pParams_ _ retiring_) = do
+  let poolKeys = Map.keysSet pParams_
+      pParamKeys = Map.keysSet pParams_
+      retiringKeys = Map.keysSet retiring_
 
-traceLen :: Word64
-traceLen = 100
-
--------------------------
--- Properties for POOL --
--------------------------
-
--- | Check that a newly registered pool key is not in the retiring map.
-rewardZeroAfterReg ::
-  [SourceSignalTarget (POOL C)] ->
-  Property
-rewardZeroAfterReg ssts =
-  conjoin $
-    map registeredPoolNotRetiring ssts
-  where
-    registeredPoolNotRetiring
-      SourceSignalTarget
-        { signal = (DCertPool c@(RegPool _)),
-          target = p'
-        } =
-        case poolCWitness c of
-          KeyHashObj certWit ->
-            let stp = _pParams p'
-             in ( eval (certWit ∈ dom stp)
-                    && eval (certWit ∉ dom (getRetiring p'))
-                )
-          _ -> False
-    registeredPoolNotRetiring _ = True
-
--- | Check that if a pool retirement certificate is executed in the correct
--- epoch interval, then the pool key will be added to the retiring map but stays
--- in the set of stake pools.
-poolRetireInEpoch ::
-  Environment (LEDGER C) ->
-  [SourceSignalTarget (POOL C)] ->
-  Property
-poolRetireInEpoch env ssts =
-  conjoin $
-    map (registeredPoolRetired (ledgerSlotNo env) (ledgerPp env)) ssts
-  where
-    registeredPoolRetired
-      s
-      pp
-      SourceSignalTarget
-        { source = p,
-          target = p',
-          signal = (DCertPool c@(RetirePool _ e))
-        } =
-        case poolCWitness c of
-          KeyHashObj certWit ->
-            let stp = _pParams p
-                stp' = _pParams p'
-                cepoch = epochFromSlotNo s
-                EpochNo ce = cepoch
-                EpochNo emax' = _eMax pp
-             in ( cepoch < e
-                    && e < EpochNo (ce + emax')
-                )
-                  ==> ( eval (certWit ∈ dom stp)
-                          && eval (certWit ∈ dom stp')
-                      )
-          _ -> False
-    registeredPoolRetired _ _ _ = True
-
--- | Check that a `RegPool` certificate properly adds a stake pool.
-registeredPoolIsAdded :: forall era.
-  [SourceSignalTarget (POOL era)] ->
-  Property
-registeredPoolIsAdded ssts =
-  conjoin $
-    map addedRegPool ssts
-  where
-    addedRegPool ::
-      SourceSignalTarget (POOL era) ->
-      Property
-    addedRegPool sst =
-      case signal sst of
-        DCertPool (RegPool poolParams) -> check poolParams
-        _ -> property ()
-      where
-        check :: PoolParams era -> Property
-        check poolParams = do
-          let hk = _poolPubKey poolParams
-              sSt = source sst
-              tSt = target sst
-
-          conjoin
-            [ -- If this is a pool re-registration (indicated by presence in `stPools`)...
-              if eval (hk ∈ dom (_pParams sSt))
-                then
-                  conjoin
-                    [ counterexample
-                        "Pool re-registration: pool should not be in 'retiring' after signal"
-                        ((eval (hk ∉ dom (_retiring tSt))) :: Bool),
-                      counterexample
-                        "PoolParams are registered in future Params map"
-                        (M.lookup hk (_fPParams tSt) === Just poolParams)
-                    ]
-                else -- This is the first registration of a pool...
-
-                  conjoin
-                    [ counterexample
-                        "PoolParams are registered in pParams map"
-                        (M.lookup hk (_pParams tSt) === Just poolParams)
-                    ]
-            ]
-
--- | Check that a `RetirePool` certificate properly marks a stake pool for
--- retirement.
-poolIsMarkedForRetirement :: forall era.
-  [SourceSignalTarget (POOL era)] ->
-  Property
-poolIsMarkedForRetirement ssts =
-  conjoin (map check ssts)
-  where
-    check ::
-      SourceSignalTarget (POOL era) ->
-      Property
-    check sst =
-      case signal sst of
-        -- We omit a well-formedness check for `epoch`, because the executable
-        -- spec will throw a PredicateFailure in that case.
-        DCertPool (RetirePool hk _epoch) -> wasRemoved hk
-        _ -> property ()
-      where
-        wasRemoved :: KeyHash 'StakePool era -> Property
-        wasRemoved hk =
-          conjoin
-            [ counterexample
-                "hk not in stPools"
-                ((eval (hk ∈ dom (_pParams (source sst)))) :: Bool),
-              counterexample
-                "hk is not in target's retiring"
-                ((eval (hk ∈ dom (_retiring $ target sst))) :: Bool)
-            ]
-
--- | Assert that PState maps are in sync with each other after each `Signal
--- POOL` transition.
-pStateIsInternallyConsistent :: forall era.
-  [SourceSignalTarget (POOL era)] ->
-  Property
-pStateIsInternallyConsistent ssts =
-  conjoin $
-    map isConsistent (concatMap (\sst -> [source sst, target sst]) ssts)
-  where
-    isConsistent :: State (POOL era) -> Property
-    isConsistent (PState pParams_ _ retiring_) = do
-      let poolKeys = M.keysSet pParams_
-          pParamKeys = M.keysSet pParams_
-          retiringKeys = M.keysSet retiring_
-
-      conjoin
-        [ counterexample
-            "All pool keys should be in both stPools and pParams"
-            (poolKeys === pParamKeys),
-          counterexample
-            "A retiring pool should still be registered in `stPools`"
-            ((retiringKeys `S.isSubsetOf` poolKeys) === True)
-        ]
+  conjoin
+    [ counterexample
+        "All pool keys should be in both stPools and pParams"
+        (poolKeys === pParamKeys),
+      counterexample
+        "A retiring pool should still be registered in `stPools`"
+        ((retiringKeys `Set.isSubsetOf` poolKeys) === True)
+    ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
   ( constantSumPots,
@@ -26,7 +26,8 @@ import qualified Data.Set as Set (Set, null)
 import Shelley.Spec.Ledger.API (POOLREAP)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (StakePool))
 import Shelley.Spec.Ledger.LedgerState
-  ( _deposited,
+  ( PState (..),
+    _deposited,
     _fees,
     _pParams,
     _reserves,
@@ -46,7 +47,6 @@ import Shelley.Spec.Ledger.STS.PoolReap
   )
 import Shelley.Spec.Ledger.UTxO (balance)
 import Test.QuickCheck (Property, conjoin)
-import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring)
 
 -----------------------------
 -- Properties for POOLREAP --
@@ -54,7 +54,8 @@ import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring)
 
 -- | Check that after a POOLREAP certificate transition the pool is removed from
 -- the stake pool and retiring maps.
-removedAfterPoolreap :: forall era.
+removedAfterPoolreap ::
+  forall era.
   [SourceSignalTarget (POOLREAP era)] ->
   Property
 removedAfterPoolreap tr =
@@ -70,8 +71,8 @@ removedAfterPoolreap tr =
         ) =
         let stp = _pParams p
             stp' = _pParams p'
-            retiring = getRetiring p
-            retiring' = getRetiring p'
+            retiring = _retiring p
+            retiring' = _retiring p'
             retire :: Set.Set (KeyHash 'StakePool era) -- This declaration needed to disambiguate 'eval'
             retire = eval (dom (retiring ▷ setSingleton e))
          in eval (retire ⊆ dom stp)


### PR DESCRIPTION
Part 1/2 of #1843 

* the TestPool properties were being tested on Ledger Traces, by lifting this to Chain Traces we get to test these properties in the presence of Epoch Boundary transitions
* the naming and arrangement of the TestPool properties had become out of date - this PR consolidates 
  * `rewardZeroAfterReg + poolRetireInEpoch + registeredPoolIsAdded + poolIsMarkedForRetirement + pStateIsInternallyConsistent`
  * ...into 3 properties that test the same (and more): `poolRegistration + poolRetirement + poolStateIsInternallyConsistent`
* as was done with the "ada preservation properties", we now test multiple properties on a (expensive) generated Chain trace

This PR leaves TestChain a bit more messy than before - I suggest we refactor that once all properties that have been lifted to chain level. 


