### PR TITLE
Incorporate changes discussed with Michael

### DIFF
--- a/shelley-ma/formal-spec/shelley-ma.tex
+++ b/shelley-ma/formal-spec/shelley-ma.tex
@@ -148,6 +148,7 @@
 \newcommand{\UPIState}{\type{UPIState}}
 \newcommand{\UpdatePayload}{\type{UpdatePayload}}
 \newcommand{\NetworkId}{\mathsf{NetworkId}}
+\newcommand{\MemoryEstimate}{\type{MemoryEstimate}}
 
 % multi-signature
 \newcommand{\StakeCredential}{\type{Credential}_{stake}}
@@ -193,6 +194,7 @@
 \newcommand{\MSig}{\type{MSig}}
 \newcommand{\Credential}{\type{Credential}}
 \newcommand{\AssetID}{\type{AssetID}}
+\newcommand{\AssetName}{\type{AssetName}}
 \newcommand{\Quantity}{\type{Quantity}}
 \newcommand{\QuantityPM}{\type{Quantity}^{\pm}}
 \newcommand{\ValuePM}{\type{Value}^{\pm}}

--- a/shelley-ma/formal-spec/utxo.tex
+++ b/shelley-ma/formal-spec/utxo.tex
@@ -79,7 +79,7 @@ What does it mean to preserve the value of non-Ada tokens, since they
 are put in and taken out of circulation by the users themselves?
 
 For the following discussion, we focus on a single arbitrary
-$\var{pid}$ that is not $\mathsf{adaID}$. If a transaction $\var{tx}$
+$\var{pid}$ that is not $\mathsf{adaPolicy}$. If a transaction $\var{tx}$
 does not forge any tokens with policy ID $\var{pid}$, the preservation
 of value reduces to an equation that the sum of inputs and the sum of
 outputs are equal, which is exactly the same condition as for Shelley,
@@ -155,7 +155,7 @@ $\Coin$.
       \\
       ~
       \\
-      \hldiff{\mathsf{adaID}~\notin \supp{\fun{forge}~tx}} \\
+      \hldiff{\mathsf{adaPolicy}~\notin \supp{\fun{forge}~tx}} \\
       ~\\
       \hldiff{\forall txout \in \txouts{txb},} \\
       \hldiff{txout \geq \fun{coinToValue}(\fun{outputSize}~{txout} * \fun{minUTxOValue}~pp)} \\~

--- a/shelley-ma/formal-spec/utxo.tex
+++ b/shelley-ma/formal-spec/utxo.tex
@@ -217,7 +217,9 @@ $\Coin$.
     \cup & ~~\{ \fun{stakeCred_{r}}~\var{a} \mid a \in \dom (\AddrRWDScr
            \restrictdom \fun{txwdrls}~\var{txb}) \} \\
       \cup & ~~(\AddrScr \cap \fun{certWitsNeeded}~{txb}) \\
-      \cup & ~~\hldiff{\supp~(\fun{forge}~(\txbody{tx}))}
+      \cup & ~~\hldiff{\supp~(\fun{forge}~\var{txb})} \\
+    & \where \\
+    & ~~~~~~~ \var{txb}~=~\txbody{tx}
   \end{align*}
   \caption{Scripts Needed}
   \label{fig:functions-witnesses}

--- a/shelley-ma/formal-spec/utxo.tex
+++ b/shelley-ma/formal-spec/utxo.tex
@@ -4,6 +4,18 @@
 \subsection*{UTxO Helper Functions}
 
 \begin{figure}[htb]
+  \emph{Type Definition}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+      \var{mest} & \MemoryEstimate & \N
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Abstract Helper Function}
+  \begin{align*}
+    \fun{outputSize} \in& ~\TxOut \to \MemoryEstimate & \text{Memory estimate for}~\TxOut
+  \end{align*}
+  %
   \emph{Helper Functions}
   \begin{align*}
     & \fun{ininterval} \in \Slot \to (\Slot^? \times \Slot^?) \to \Bool \\
@@ -43,6 +55,10 @@ UTxO transition system with multi-assets:
 
 \begin{itemize}
 
+  \item The $\fun{outputSize}$ function provides a rough estimate of
+    the amount of memory the storage of an output will consume, which is used in the UTXO rule.
+    Its implementation is described in Appendix \ref{sec:value-size}.
+
   \item The function $\fun{ininterval}$ returns $\True$ whenever the given slot is
   inside the given interval. If an endpoint of the validity interval
   is $\Nothing$, the comparison of the slot to that endpoint is $\True$ by default.
@@ -77,8 +93,8 @@ To balance the preservation of value equation, the $\fun{forge}$ field
 could be included in either $\fun{consumed}$ or $\fun{produced}$, with
 the only difference being the sign of the $\fun{forge}$ field. We
 include it on the $\fun{consumed}$ side, because this means that
-forging a positive amount increases the amount of tokens on the
-ledger, and forging a negative amount reduces the amount of tokens on
+forging a positive quantity increases the amount of tokens on the
+ledger, and forging a negative quantity reduces the amount of tokens on
 the ledger.
 
 Note that the UTXO rule specifically forbids the forging of Ada, and
@@ -142,7 +158,7 @@ $\Coin$.
       \hldiff{\mathsf{adaID}~\notin \supp{\fun{forge}~tx}} \\
       ~\\
       \hldiff{\forall txout \in \txouts{txb},} \\
-      \hldiff{txout \geq \fun{coinToValue}(\fun{valueSize}~(\fun{getValue}~txout) * \fun{minUTxOValue}~pp)} \\~
+      \hldiff{txout \geq \fun{coinToValue}(\fun{outputSize}~{txout} * \fun{minUTxOValue}~pp)} \\~
       \\
       \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, \fun{netId}~a =\NetworkId
       \\

--- a/shelley-ma/formal-spec/value-size.tex
+++ b/shelley-ma/formal-spec/value-size.tex
@@ -1,37 +1,34 @@
-\section{Value Size}
+\section{Output Size}
 \label{sec:value-size}
 
 In Shelley, the protocol parameter $\var{minUTxOValue}$ is used to
 disincentivize attacking nodes by putting many small outputs on the
 UTxO, permanently blocking memory. Because members of the $\Value$
-type can be arbitrary large in principle, the multi-asset ledger must
+type can be arbitrary large, the multi-asset ledger must
 accomodate by scaling the minimum amount of Ada in an output by the
-size of the output, which means that we need a function to determine
-the size of a member of $\Value$.
+size of the output.
 
 How much memory is used exactly is an implementation detail, but some facts are:
 \begin{itemize}
-  \item Every output contains Ada, so Ada can be regarded as part of the constant amount of space.
-  \item The size will scale linearly with the number of $\PolicyID$s and tokens.
+  \item Every output contains and address and Ada, which take a constant amount of space.
+  \item The size will scale linearly with the number of $\PolicyID$s and tokens in the $\Value$.
   \item The number of $\PolicyID$s is less than or equal to the number of tokens.
 \end{itemize}
 
-Because of the first two items in that list, we could use the following definition for $\fun{valueSize}$:
+Because of the first two items in that list, we could use the following definition for $\fun{outputSize}$:
 
 \begin{figure*}[h]
   \begin{align*}
-    & \fun{valueSize} \in \Value \to \N \\
-    & \fun{valueSize} ~\var{v} = k_0 + k_1 * |\{ (\var{pid}, \var{aid}) : \var{v}~\var{pid}~\var{aid} \neq 0
+    & \fun{outputSize} \in \TxOut \to \MemoryEstimate \\
+    & \fun{outputSize} ~\var{out} = k_0 + k_1 * |\{ (\var{pid}, \var{aid}) : \var{v}~\var{pid}~\var{aid} \neq 0
             \land (\var{pid}, \var{aid}) \neq (\mathsf{adaID}, \mathsf{adaToken}) \}| \\
-    & \phantom{\fun{valueSize} ~\var{v} = k_0} + k_2 * |\{ \var{pid} : \exists aid : v~pid~aid \neq 0 \}|
+    & \phantom{\fun{outputSize} ~\var{out} = k_0} + k_2 * |\{ \var{pid} : \exists aid : v~pid~aid \neq 0 \}|
   \end{align*}
   \caption{Value Size}
   \label{fig:test}
 \end{figure*}
 
-Here, $k_0$ reflects the constant part, i.e. Ada, but also everything
-in the output that is not included in the $\Value$ (i.e. the address)
-(maybe this means the function should be renamed). $k_1$ reflects the
+Here, $k_0$ reflects the constant part, i.e. Ada and the address, $k_1$ reflects the
 size of non-ada tokens, and $k_2$ the size of $\PolicyID$s.
 
 There are some trade-offs here. Because of the third item in the above

--- a/shelley-ma/formal-spec/value-size.tex
+++ b/shelley-ma/formal-spec/value-size.tex
@@ -4,9 +4,8 @@
 In Shelley, the protocol parameter $\var{minUTxOValue}$ is used to
 disincentivize attacking nodes by putting many small outputs on the
 UTxO, permanently blocking memory. Because members of the $\Value$
-type can be arbitrary large, the multi-asset ledger must
-accomodate by scaling the minimum amount of Ada in an output by the
-size of the output.
+type can be arbitrary large, the ledger requires a $\UTxO$ entry to
+contain a minimum amount of Ada, proportional to its size.
 
 How much memory is used exactly is an implementation detail, but some facts are:
 \begin{itemize}
@@ -21,14 +20,14 @@ Because of the first two items in that list, we could use the following definiti
   \begin{align*}
     & \fun{outputSize} \in \TxOut \to \MemoryEstimate \\
     & \fun{outputSize} ~\var{out} = k_0 + k_1 * |\{ (\var{pid}, \var{aid}) : \var{v}~\var{pid}~\var{aid} \neq 0
-            \land (\var{pid}, \var{aid}) \neq (\mathsf{adaID}, \mathsf{adaToken}) \}| \\
+            \land (\var{pid}, \var{aid}) \neq (\mathsf{adaPolicy}, \mathsf{adaName}) \}| \\
     & \phantom{\fun{outputSize} ~\var{out} = k_0} + k_2 * |\{ \var{pid} : \exists aid : v~pid~aid \neq 0 \}|
   \end{align*}
   \caption{Value Size}
   \label{fig:test}
 \end{figure*}
 
-Here, $k_0$ reflects the constant part, i.e. Ada and the address, $k_1$ reflects the
+Here, $k_0$ reflects the constant part, i.e. Ada, the key and the address, $k_1$ reflects the
 size of non-ada tokens, and $k_2$ the size of $\PolicyID$s.
 
 There are some trade-offs here. Because of the third item in the above

--- a/shelley-ma/formal-spec/value.tex
+++ b/shelley-ma/formal-spec/value.tex
@@ -15,7 +15,7 @@ fees, rewards, treasury, and the proof of stake protocol.
   \emph{Abstract Types}
   %
   \begin{align*}
-    \var{aid} \in& ~\AssetName & \text{Asset Names}
+    \var{aname} \in& ~\AssetName & \text{Asset Names}
   \end{align*}
   %
   \emph{Derived types}
@@ -35,20 +35,20 @@ fees, rewards, treasury, and the proof of stake protocol.
   %
   \begin{align*}
     \mathsf{adaID} \in& ~\PolicyID & \text{Ada Policy ID} \\
-    \mathsf{adaToken} \in& ~\AssetName & \text{Ada Asset Name} \\
+    \mathsf{adaName} \in& ~\AssetName & \text{Ada Asset Name} \\
   \end{align*}
   \emph{Helper Functions}
   %
   \begin{align*}
     & \fun{coinToValue} \in \Coin\to \Value \\
-    & \fun{coinToValue}~c = \lambda~\var{pid}~\var{aid}.
+    & \fun{coinToValue}~c = \lambda~\var{pid}~\var{aname}.
       \begin{cases}
-        c & \var{pid} = \mathsf{adaID}~\text{and}~\var{aid} = \mathsf{adaToken} \\
+        c & \var{pid} = \mathsf{adaID}~\text{and}~\var{aname} = \mathsf{adaName} \\
         0 & \text{otherwise}
       \end{cases}
     \nextdef
     & \fun{valueToCoin} \in \Value \to \Coin \\
-    & \fun{valueToCoin}~v = v~\mathsf{adaID}~\mathsf{adaToken}
+    & \fun{valueToCoin}~v = v~\mathsf{adaID}~\mathsf{adaName}
   \end{align*}
   \caption{Type Definitions and auxiliary functions for Value}
   \label{fig:defs:value}
@@ -56,15 +56,13 @@ fees, rewards, treasury, and the proof of stake protocol.
 
 \subsection*{Representing Multi-asset Types and Values}
 An \emph{Asset} comprises a set of different \emph{Asset Classes}, each of which has
-a unique identifier, $\AssetName$. We will informally refer to a pair $(\var{pid}, \var{aid})$ of a $\PolicyID$ and an $\AssetName$ as an $\AssetID$. The $\AssetID$ for Ada is $(\mathsf{adaID}, \mathsf{adaToken})$.
+a unique identifier, $\AssetName$. We will refer to a pair of a $\PolicyID$ and an
+$\AssetName$ as an $\AssetID$. The $\AssetID$ for Ada is $(\mathsf{adaID}, \mathsf{adaName})$.
 
-The set of tokens that are referred to by the underlying monetary policy represents the coinage that the asset supports.  A multi-asset value, $\Value$ is a map over zero or more assets
-to single asset values.  A single asset value is then a finite map from
-$\AssetName$s to quantities.
-
-For convenience, here and in the rest of the document, we
-will treat values of type $\Value$ also as non-partial functions where
-any omitted tokens in the domain are assumed to be zero.
+The set of tokens that are referred to by the underlying monetary
+policy represents the coinage that the asset supports. A multi-asset
+value, $\Value$ is a finitely supported function of two variables,
+$\PolicyID$ and $\AssetName$ to $Quantity$.
 
 \begin{itemize}
   \item $\PolicyID$ identifies monetary policies. A policy ID $\var{pid}$ is associated with a script
@@ -75,19 +73,19 @@ any omitted tokens in the domain are assumed to be zero.
     See sections \ref{sec:transactions} and \ref{sec:utxo} for details.
 
   \item $\AssetName$ is a type used to distinguish different tokens with the same $\PolicyID$.
-    Each $aid$ identifies a unique kind of token in $\var{pid}$.
+    Each $aname$ identifies a unique kind of token in $\var{pid}$.
 
   \item $\Quantity$ is an integer type that represents an amount of a specific $\AssetName$. We associate
     a term $q\in\Quantity$ with a specific token to track how much of that token is contained in a given asset value.
 
   \item $\Value$ is the multi-asset type that is used to represent
-    an amount of a collection of tokens, including Ada. If $(\var{pid}, \var{aid})$ is a token and $v \in \Value$,
-    the quantity in $v$ belonging to that token is $v~\var{pid}~\var{aid}$ if defined, or zero otherwise.
-    Token quantities are fungible with each other if and only if they belong to the same token,
+    a collection of tokens, including Ada. If $(\var{pid}, \var{aname})$ is an $\AssetID$ and $v \in \Value$,
+    the quantity in $v$ belonging to that $\AssetID$ is $v~\var{pid}~\var{aname}$.
+    Tokens are fungible with each other if and only if they belong to the same $\AssetID$,
     i.e. they have the same $\PolicyID$ and $\AssetName$. Terms of type $\Value$ are sometimes also referred to as
     \emph{token bundles}.
 
-  \item $\mathsf{adaID}$ and $\mathsf{adaToken}$ are the $\PolicyID$ and $\AssetName$ of Ada respectively.
+  \item $\mathsf{adaID}$ and $\mathsf{adaName}$ are the $\PolicyID$ and $\AssetName$ of Ada respectively.
 
   \item $\fun{coinToValue}$ and $\fun{valueToCoin}$ convert between the two types,
   by taking a $\Coin$ to a $\Value$ that only contains Ada, and extracting the amount of Ada from a $\Value$ respectively.
@@ -98,5 +96,5 @@ We require some operations on $\Value$, including equality, addition and $\leq$ 
 
 Addition and binary relations are extended pointwise from $\Coin$ to $\Value$, so if $R$ is a binary relation defined on $\Coin$, like $=$ or $\leq$, and $v, w$ are values, we define
 
-\[ v~R~w :\Leftrightarrow \forall~\var{pid}~\var{aid}, (v~\var{pid}~\var{aid})~R~(w~\var{pid}~\var{aid}) \]
-\[ (v + w)~\var{pid}~\var{aid} := (v~\var{pid}~\var{aid}) + (w~\var{pid}~\var{aid}). \]
+\[ v~R~w :\Leftrightarrow \forall~\var{pid}~\var{aname}, (v~\var{pid}~\var{aname})~R~(w~\var{pid}~\var{aname}) \]
+\[ (v + w)~\var{pid}~\var{aname} := (v~\var{pid}~\var{aname}) + (w~\var{pid}~\var{aname}). \]

--- a/shelley-ma/formal-spec/value.tex
+++ b/shelley-ma/formal-spec/value.tex
@@ -9,15 +9,13 @@ the most common type of token on the ledger.
 The $\Coin$ type is used to represent an amount of Ada.
 It is the only
 type of token that can be used for all non-UTxO ledger accounting, including deposits,
-fees, rewards, treasury, and the proof of stake protocol. Under no circumstances
-are these administrative fields and calculations ever expected to operate on
-any types of tokens besides Ada, and this will continue to have the type $\Coin$.
+fees, rewards, treasury, and the proof of stake protocol.
 
 \begin{figure*}[t!]
   \emph{Abstract Types}
   %
   \begin{align*}
-    \var{aid} \in& ~\AssetID & \text{Asset IDs}
+    \var{aid} \in& ~\AssetName & \text{Asset Names}
   \end{align*}
   %
   \emph{Derived types}
@@ -28,7 +26,7 @@ any types of tokens besides Ada, and this will continue to have the type $\Coin$
       \var{quan} & \Quantity & \Z \\
       %\text{quantity of a token}\\
       \var{v}, \var{w} & \Value
-      & \PolicyID \to_0 ( \AssetID \to_0 \Quantity )
+      & \PolicyID \to_0 ( \AssetName \to_0 \Quantity )
 %      & \text{a collection of tokens}
     \end{array}
   \end{equation*}
@@ -36,9 +34,8 @@ any types of tokens besides Ada, and this will continue to have the type $\Coin$
   \emph{Abstract Functions and Values}
   %
   \begin{align*}
-    \mathsf{adaID} \in& ~\PolicyID & \text{Ada asset ID} \\
-    \mathsf{adaToken} \in& ~\AssetID & \text{Ada Token} \\
-    \fun{valueSize} \in& ~\Value \to \N & \text{Memory estimate for}~\Value
+    \mathsf{adaID} \in& ~\PolicyID & \text{Ada Policy ID} \\
+    \mathsf{adaToken} \in& ~\AssetName & \text{Ada Asset Name} \\
   \end{align*}
   \emph{Helper Functions}
   %
@@ -59,11 +56,11 @@ any types of tokens besides Ada, and this will continue to have the type $\Coin$
 
 \subsection*{Representing Multi-asset Types and Values}
 An \emph{Asset} comprises a set of different \emph{Asset Classes}, each of which has
-a unique identifier, $\AssetID$. We will informally refer to a pair $(\var{pid}, \var{aid})$ of a Policy ID and an Asset ID as a ``token''. The token for Ada is $(\mathsf{adaID}, \mathsf{adaToken})$.
+a unique identifier, $\AssetName$. We will informally refer to a pair $(\var{pid}, \var{aid})$ of a $\PolicyID$ and an $\AssetName$ as an $\AssetID$. The $\AssetID$ for Ada is $(\mathsf{adaID}, \mathsf{adaToken})$.
 
 The set of tokens that are referred to by the underlying monetary policy represents the coinage that the asset supports.  A multi-asset value, $\Value$ is a map over zero or more assets
 to single asset values.  A single asset value is then a finite map from
-$\AssetID$s to quantities.
+$\AssetName$s to quantities.
 
 For convenience, here and in the rest of the document, we
 will treat values of type $\Value$ also as non-partial functions where
@@ -77,24 +74,20 @@ any omitted tokens in the domain are assumed to be zero.
     respects the restrictions that are imposed by the monetary policy.
     See sections \ref{sec:transactions} and \ref{sec:utxo} for details.
 
-  \item $\AssetID$ is a type used to distinguish different tokens with the same $\PolicyID$.
+  \item $\AssetName$ is a type used to distinguish different tokens with the same $\PolicyID$.
     Each $aid$ identifies a unique kind of token in $\var{pid}$.
 
-  \item $\Quantity$ is an integer type that represents an amount of a specific $\AssetID$. We associate
+  \item $\Quantity$ is an integer type that represents an amount of a specific $\AssetName$. We associate
     a term $q\in\Quantity$ with a specific token to track how much of that token is contained in a given asset value.
 
   \item $\Value$ is the multi-asset type that is used to represent
     an amount of a collection of tokens, including Ada. If $(\var{pid}, \var{aid})$ is a token and $v \in \Value$,
-    the amount in $v$ belonging to that token is $v~\var{pid}~\var{aid}$ if defined, or zero otherwise.
-    Token amounts are fungible with each other if and only if they belong to the same token,
-    i.e. they have the same $\PolicyID$ and $\AssetID$. Terms of type $\Value$ are sometimes also referred to as
+    the quantity in $v$ belonging to that token is $v~\var{pid}~\var{aid}$ if defined, or zero otherwise.
+    Token quantities are fungible with each other if and only if they belong to the same token,
+    i.e. they have the same $\PolicyID$ and $\AssetName$. Terms of type $\Value$ are sometimes also referred to as
     \emph{token bundles}.
 
-  \item $\mathsf{adaID}$ and $\mathsf{adaToken}$ are the $\PolicyID$ and $\AssetID$ of Ada respectively.
-
-  \item The $\fun{valueSize}$ function provides a rough estimate of
-    the amount of memory the storage of a certain value will consume, which is used in the UTXO rule.
-    Its implementation is described in Appendix \ref{sec:value-size}.
+  \item $\mathsf{adaID}$ and $\mathsf{adaToken}$ are the $\PolicyID$ and $\AssetName$ of Ada respectively.
 
   \item $\fun{coinToValue}$ and $\fun{valueToCoin}$ convert between the two types,
   by taking a $\Coin$ to a $\Value$ that only contains Ada, and extracting the amount of Ada from a $\Value$ respectively.

--- a/shelley-ma/formal-spec/value.tex
+++ b/shelley-ma/formal-spec/value.tex
@@ -34,7 +34,7 @@ fees, rewards, treasury, and the proof of stake protocol.
   \emph{Abstract Functions and Values}
   %
   \begin{align*}
-    \mathsf{adaID} \in& ~\PolicyID & \text{Ada Policy ID} \\
+    \mathsf{adaPolicy} \in& ~\PolicyID & \text{Ada Policy ID} \\
     \mathsf{adaName} \in& ~\AssetName & \text{Ada Asset Name} \\
   \end{align*}
   \emph{Helper Functions}
@@ -43,12 +43,12 @@ fees, rewards, treasury, and the proof of stake protocol.
     & \fun{coinToValue} \in \Coin\to \Value \\
     & \fun{coinToValue}~c = \lambda~\var{pid}~\var{aname}.
       \begin{cases}
-        c & \var{pid} = \mathsf{adaID}~\text{and}~\var{aname} = \mathsf{adaName} \\
+        c & \var{pid} = \mathsf{adaPolicy}~\text{and}~\var{aname} = \mathsf{adaName} \\
         0 & \text{otherwise}
       \end{cases}
     \nextdef
     & \fun{valueToCoin} \in \Value \to \Coin \\
-    & \fun{valueToCoin}~v = v~\mathsf{adaID}~\mathsf{adaName}
+    & \fun{valueToCoin}~v = v~\mathsf{adaPolicy}~\mathsf{adaName}
   \end{align*}
   \caption{Type Definitions and auxiliary functions for Value}
   \label{fig:defs:value}
@@ -57,12 +57,12 @@ fees, rewards, treasury, and the proof of stake protocol.
 \subsection*{Representing Multi-asset Types and Values}
 An \emph{Asset} comprises a set of different \emph{Asset Classes}, each of which has
 a unique identifier, $\AssetName$. We will refer to a pair of a $\PolicyID$ and an
-$\AssetName$ as an $\AssetID$. The $\AssetID$ for Ada is $(\mathsf{adaID}, \mathsf{adaName})$.
+$\AssetName$ as an $\AssetID$. The $\AssetID$ for Ada is $(\mathsf{adaPolicy}, \mathsf{adaName})$.
 
 The set of tokens that are referred to by the underlying monetary
 policy represents the coinage that the asset supports. A multi-asset
 value, $\Value$ is a finitely supported function of two variables,
-$\PolicyID$ and $\AssetName$ to $Quantity$.
+$\PolicyID$ and $\AssetName$ to $\Quantity$.
 
 \begin{itemize}
   \item $\PolicyID$ identifies monetary policies. A policy ID $\var{pid}$ is associated with a script
@@ -85,7 +85,7 @@ $\PolicyID$ and $\AssetName$ to $Quantity$.
     i.e. they have the same $\PolicyID$ and $\AssetName$. Terms of type $\Value$ are sometimes also referred to as
     \emph{token bundles}.
 
-  \item $\mathsf{adaID}$ and $\mathsf{adaName}$ are the $\PolicyID$ and $\AssetName$ of Ada respectively.
+  \item $\mathsf{adaPolicy}$ and $\mathsf{adaName}$ are the $\PolicyID$ and $\AssetName$ of Ada respectively.
 
   \item $\fun{coinToValue}$ and $\fun{valueToCoin}$ convert between the two types,
   by taking a $\Coin$ to a $\Value$ that only contains Ada, and extracting the amount of Ada from a $\Value$ respectively.


### PR DESCRIPTION
Update MA terminology, rename `valueSize` to `outputSize` and some other minor changes.