### PR TITLE
Fix slow mode problems

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -258,9 +258,9 @@ delegationTransition = do
           futureOtherColdKeyHashes = Set.map genDelegKeyHash fod
           futureOtherVrfKeyHashes = Set.map genDelegVrfHash fod
 
-      eval (vkh ∉ (currentOtherColdKeyHashes `Set.union` futureOtherColdKeyHashes))
+      eval (vkh ∉ (currentOtherColdKeyHashes ∪ futureOtherColdKeyHashes))
         ?! DuplicateGenesisDelegateDELEG vkh
-      eval (vrf ∉ (currentOtherVrfKeyHashes `Set.union` futureOtherVrfKeyHashes))
+      eval (vrf ∉ (currentOtherVrfKeyHashes ∪ futureOtherVrfKeyHashes))
         ?! DuplicateGenesisVRFDELEG vrf
 
       pure $


### PR DESCRIPTION
The current SetAlgebra has two modes. Fast mode where we apply data-structure specific
algorithms for certain kinds of queries. And Slow mode where we apply slower, but
completely general algorithms that work for every query. When things are upto maybe 50,000
items. the slow mode works OK. At 10 of millions of items it really shows. I suspect that
is what was going on. I inspected the profiles made by Thomas Wynant and it became clear that something was running in slow mode.Functions like orStep, diffStep, materialize, fifo, are all giveaways. But I could not determine with 100% accuracy what query was slowing things down. So I applied a different tactic. I caused an abort whenever a query went into slow mode, and then ran the tests. I identified a bunch of exact queries that were going into slow mode, and wrote fast mode algorithms for each of them. In the end the whole test suite ran without causing an abort. So I am hopeful that this will fix the problem. I also made one change to the code that used set membership on the union of two sets. I rewrote the the query using Set algebra, and then optimized eval (vkh ∉ (x `Set.union` y))  to  eval (vkh ∉ (x ∪ y)). The fast rule for this now computes not(vkh ∈ x || vkh ∈ y), which avoids materializing the union, that might have caused the problem. I am not sure this affects any thing, but it looked shifty.
Try this out. I still need to write tests for the new fast algorithms, but you can run some profiles
before I do that.