### PR TITLE
Utilities for using ghcid.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ specs/**/.ghc.environment.x86_64-linux-*
 
 ## Ignore PDFs
 *.pdf
-
-## GHCID control files
-**/.ghcid

--- a/byron/chain/executable-spec/.ghcid
+++ b/byron/chain/executable-spec/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../../shell.nix --run \"cabal repl -f development byron-spec-chain\"" -o ghcid.txt

--- a/byron/ledger/executable-spec/.ghcid
+++ b/byron/ledger/executable-spec/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../../shell.nix --run \"cabal repl -f development byron-spec-ledger\"" -o ghcid.txt

--- a/scripts/ghcid
+++ b/scripts/ghcid
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euC
+
+SNAME=cardano-ledger-ghcid
+
+PACKAGES=(
+  semantics/executable-spec
+  semantics/small-steps-test
+  shelley/chain-and-ledger/executable-spec
+  shelley/chain-and-ledger/shelley-spec-ledger-test
+  shelley-ma/impl
+)
+
+ghcid_for_package () {
+  local wd="$(pwd)/$1"
+  PACKAGE_NAME=$(get_package_name $wd | xargs basename | sed -e "s/.cabal//")
+  echo $PACKAGE_NAME
+  tmux new-window -d -t "=$SNAME" -n $PACKAGE_NAME -c "$wd"
+  tmux send-keys -t "=$SNAME:=$PACKAGE_NAME" 'ghcid' Enter
+}
+
+# Get the package name for a given directory
+get_package_name () {
+  CABAL_FILE=$(find $1 -maxdepth 1 -name "*.cabal")
+  echo $CABAL_FILE
+}
+
+att() {
+    [ -n "${TMUX:-}" ] &&
+        tmux switch-client -t "=$SNAME" ||
+        tmux attach-session -t "=$SNAME"
+}
+
+if tmux has-session -t "=$SNAME" 2> /dev/null; then
+    att
+    exit 0
+fi
+
+tmux new-session -d -s $SNAME
+tmux rename-window -t "=$SNAME:0" "cls"
+
+for t in ${PACKAGES[@]}; do
+  ghcid_for_package $t
+done
+
+att

--- a/semantics/executable-spec/.ghcid
+++ b/semantics/executable-spec/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../shell.nix --run \"cabal repl -f development small-steps\"" -o ghcid.txt

--- a/semantics/small-steps-test/.ghcid
+++ b/semantics/small-steps-test/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../shell.nix --run \"cabal repl -f development small-steps-test:examples\"" -o ghcid.txt

--- a/shelley-ma/impl/.ghcid
+++ b/shelley-ma/impl/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../shell.nix --run \"cabal repl -f development cardano-ledger-shelley-ma\"" -o ghcid.txt

--- a/shelley/chain-and-ledger/executable-spec/.ghcid
+++ b/shelley/chain-and-ledger/executable-spec/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../../shell.nix --run \"cabal repl -f development shelley-spec-ledger\"" -o ghcid.txt

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/.ghcid
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../../shell.nix --run \"cabal repl -f development shelley-spec-ledger-test\"" -o ghcid.txt


### PR DESCRIPTION
Alex Byaly commented yesterday that various people may have been having
trouble recovering their ghcid workflows from before we deprecated stack
support. This PR adds some utilities for making working with ghcid
easier:

- In most packages, there is now a .ghcid file. This allows you to enter
that package directory, type 'ghcid' and get a ghcid instance working
for that package. Errors are written to ghcid.txt, whence editors can be
configured to read them.

- There is an additional 'scripts/ghcid'. Running this will start a tmux
session with 'ghcid' for each of the major packages we work on running
in separate windows. If you have editor integration set up, you may not
need to actually view these windows, though ghcid sessions will need
restarting if e.g. the cabal file changes.

At present there is no support for multiple build targets within a given
package - e.g. test suites will not be checked by this.