### PR TITLE
Added about 100 tests to PR #1884

### DIFF
--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
@@ -32,10 +32,11 @@ where
 
 
 import Data.Map(Map)
+import Data.Set(Set)
 import Control.Iterate.SetAlgebraInternal
 
 forwards :: BiMap v k v -> Map k v
 forwards (MkBiMap l _r) = l
 
-backwards :: BiMap v k v -> Map v k
+backwards :: BiMap v k v -> Map v (Set k)
 backwards (MkBiMap _l r) = r

--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
@@ -457,6 +457,9 @@ intersectDomP p t1 t2@(Bin _ k v l2 r2) =
     !r1r2 = intersectDomP p r1 r2
 {-# INLINABLE intersectDomP #-}
 
+
+
+
 -- |- Similar to intersectDomP, except the Map returned has the same key as the first input map, rather than the second input map.
 intersectDomPLeft:: Ord k => (k -> v2 -> Bool) -> Map k v1 -> Map k v2 -> Map k v1
 intersectDomPLeft p Tip _ = Tip
@@ -993,7 +996,7 @@ compile (Rng (Singleton k v))  = (BaseD SetR (Sett(Set.singleton v)),SetR)
 compile (Rng (SetSingleton k)) = (BaseD SetR (Sett(Set.singleton ())),SetR)
 compile (Rng f) = (BaseD SetR (rngStep (fst(compile f))),SetR)  -- We really ought to memoize this. It might be computed many times.
 compile (DRestrict set rel) =  (projD (andD (fst(compile set)) reld) rngSnd,rep)
-   where (reld,rep) = compile rel
+    where (reld,rep) = compile rel
 compile (DExclude set rel) = (DiffD reld (fst(compile set)),rep)
        where (reld,rep) = compile rel
 compile (RRestrict rel set) =
@@ -1102,7 +1105,8 @@ compute (DRestrict (Base SetR (Sett set)) (Base MapR m)) = Map.restrictKeys m se
 compute (DRestrict (SetSingleton k) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
 compute (DRestrict (Singleton k v) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
 compute (DRestrict (Dom (Base MapR x)) (Base MapR y)) = Map.intersection y x
-   -- This case inspired by set expression in EpochBoundary.hs
+
+-- This case inspired by set expression in EpochBoundary.hs
    -- (dom (delegs ▷ Set.singleton hk) ◁ stake) in EpochBoundart.hs
    -- ((dom (Map(62)? ▷ (setSingleton _ ))) ◁ Map(63)?) which has this structure
    -- materialize MapR (do { (x,y,z) <- delegs `domEq` stake; when (y==hk); one(x,z) })

--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebraInternal.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-unused-matches #-}
+-- {-# OPTIONS_GHC -Wno-unused-matches #-}
 
 
 {-# LANGUAGE GADTs, MultiParamTypeClasses #-}
@@ -49,7 +49,7 @@ import Text.PrettyPrint.ANSI.Leijen(Doc,text,(<+>),align,vsep,parens)
 class Iter f => Basic f where
   -- | in addpair the new value always prevails, to make a choice use 'addkv' which has a combining function that allows choice.
   addpair:: (Ord k) => k -> v -> f k v -> f k v
-  addpair k v f = addkv (k,v) f (\ a b -> a)
+  addpair k v f = addkv (k,v) f (\ a _b -> a)
   -- | use (\ l r -> l) if you want the v in (k,v) to prevail, and use (\ l r -> r) if you want the v in (f k v) to prevail
   addkv :: Ord k => (k,v) -> f k v -> (v -> v -> v) -> f k v
   removekey:: (Ord k) => k -> f k v -> f k v
@@ -73,8 +73,8 @@ instance Basic List where
    removekey k (UnSafeList xs) = UnSafeList(remove xs) where
        remove [] = []
        remove ((key,u):ys) = if key==k then ys else (k,u):(remove ys)
-   domain (UnSafeList xs) = foldr (\ (k,v) ans -> Set.insert k ans) Set.empty xs
-   range (UnSafeList xs) = foldr (\ (k,v) ans -> Set.insert v ans) Set.empty xs
+   domain (UnSafeList xs) = foldr (\ (k,_v) ans -> Set.insert k ans) Set.empty xs
+   range (UnSafeList xs) = foldr (\ (_k,v) ans -> Set.insert v ans) Set.empty xs
    emptyc = (UnSafeList [])
 
 
@@ -82,8 +82,8 @@ fromPairs:: Ord k => (v -> v -> v) -> [(k,v)] -> List k v
 fromPairs combine xs = UnSafeList(normalize combine (sortBy (\ x y -> compare (fst x) (fst y)) xs))
 
 normalize :: Ord k => (v -> v -> v) -> [(k,v)] -> [(k,v)]
-normalize combine [] = []
-normalize combine [(k,v)] = [(k,v)]
+normalize _combine [] = []
+normalize _combine [(k,v)] = [(k,v)]
 normalize combine ((k1,v1):(k2,v2):more) | k1==k2 = normalize combine ((k1,combine v1 v2):more)
 normalize combine (p:pairs) = p : normalize combine pairs
 
@@ -110,39 +110,45 @@ instance Basic Single where
                Fail ->  Single k v
         else case set of
                (Single a b) -> if k==a then Single a (comb v b) else (Single k v)
-               (SetSingle a) -> SetSingle k
+               (SetSingle _a) -> SetSingle k
                Fail ->  Single k v
 
   removekey key (Single a b) = if key==a then Fail else (Single a b)
   removekey key (SetSingle a) = if key==a then Fail else (SetSingle a)
-  removekey key Fail = Fail
-  domain (Single a b) = Set.singleton a
+  removekey _key Fail = Fail
+  domain (Single a _b) = Set.singleton a
   domain (SetSingle a) = Set.singleton a
   domain Fail = Set.empty
-  range (Single a b) = Set.singleton b
-  range (SetSingle a) = Set.singleton ()
+  range (Single _a b) = Set.singleton b
+  range (SetSingle _a) = Set.singleton ()
   range Fail = Set.empty
   emptyc = Fail
 
 -- ============== Basic Map =========================
 
 instance Basic Map.Map where
-  addkv (k,v) m comb = Map.insertWith (\ old new -> comb new old) k v m  -- Map uses(\ new old -> ...) while our convention is (\ old new -> ...)
+  addkv (k,v) m comb = Map.insertWith (mapflip comb) k v m
   removekey k m = Map.delete k m
   domain x = Map.keysSet x
-  range xs = Map.foldrWithKey (\ k v  ans -> Set.insert v ans) Set.empty xs
+  range xs = Map.foldrWithKey (\ _k v  ans -> Set.insert v ans) Set.empty xs
   emptyc = Map.empty
+
+-- Data.Map uses(\ new old -> ...) while our convention is (\ old new -> ...)
+-- We also use this in the Basic instance for BiMap, which uses Data.Map
+mapflip :: (v -> v -> v) -> (v -> v -> v)
+mapflip f = (\old new -> f new old)
 
 -- =================== Basic BiMap =====================
 -- For Bijections we define (BiMap v k v).  Reasons we can't use (Data.Bimap k v)
 -- 1) We need to enforce that the second argument `v` is in the Ord class, when making it an Iter instance.
--- 2) The constructor MkBimap is not exported, so we can't roll our own operations necessary to get good asymptotic performance
+-- 2) The constructor for Data.BiMap is not exported, and it implements a Bijection
 -- 3) Missing operation 'restrictkeys' and 'withoutkeys' make performant versions of operations  ◁ ⋪ ▷ ⋫ hard.
 -- 4) Missing operation 'union', make performant versions of ∪ and ⨃ hard.
+-- 5) So we roll our own whic is really a (Data.Map k v) with an index map v to Set{k}
 
 
-data BiMap v a b where MkBiMap:: (v ~ b) => !(Map.Map a b) -> !(Map.Map b a) -> BiMap v a b
-                                --  ^   the 1st and 3rd parameter must be the same:   ^   ^
+data BiMap v a b where MkBiMap:: (v ~ b) => !(Map.Map a b) -> !(Map.Map b (Set.Set a)) -> BiMap v a b
+                                --  ^   the 1st and 3rd parameter must be the same:             ^   ^
 
 -- ============== begin necessary Cardano.Binary instances ===============
 instance (Ord a, Ord b,ToCBOR a, ToCBOR b) => ToCBOR (BiMap b a b) where
@@ -164,36 +170,46 @@ instance NFData(BiMap v a b) where
 -- ============== end Necessary Cardano.Binary instances ===================
 
 instance (Eq k,Eq v) => Eq (BiMap u k v) where
-  (MkBiMap l r) == (MkBiMap x y) = l==x
+  (MkBiMap l _) == (MkBiMap x _) = l==x
 
 instance (Show k, Show v) => Show (BiMap u k v) where
-  show (MkBiMap l r) = show l
+  show (MkBiMap l _r) = show l
+
+addBack :: (Ord v,Ord k) => v -> k -> Map.Map v (Set.Set k) -> Map.Map v (Set.Set k)
+addBack newv k m = Map.insertWith Set.union newv (Set.singleton k) m
+
+retract :: (Ord v,Ord k) => v -> k -> Map.Map v (Set.Set k) -> Map.Map v (Set.Set k)
+retract oldv k m = Map.adjust (Set.delete k) oldv m
+
+insertBackwards:: (Ord k,Ord v) => v -> v -> k -> Map.Map v (Set.Set k) -> Map.Map v (Set.Set k)
+insertBackwards oldv newv k m = addBack newv k (retract oldv k m)
 
 instance Ord v => Basic (BiMap v) where
-  addkv (k,v) (MkBiMap f b) comb =
-     case Map.lookup k f of
-       Nothing -> MkBiMap (Map.insert k v f) (Map.insert v k b)
-       Just v2 -> MkBiMap (Map.insert k v3 f) (Map.insert v3 k (Map.delete v2 b))
-          where v3 = comb v v2
+  addkv (k,v) (MkBiMap f b) comb = MkBiMap (Map.insertWith (mapflip comb) k v f) (insertBackwards oldv newv k b)
+     where (oldv,newv) = case Map.lookup k f of { Nothing -> (v,v); Just v2 -> (v2,comb v2 v)}
   removekey k (m@(MkBiMap m1 m2)) =  -- equality constraint (a ~ v) from (BiMap a k v) into scope.
      case Map.lookup k m1 of
-        Just v -> MkBiMap (Map.delete k m1) (Map.delete v m2)
+        Just v -> MkBiMap (Map.delete k m1) (retract v k m2)
         Nothing -> m
-  domain (MkBiMap left right) = Map.keysSet left
-  range (MkBiMap left right) = Map.keysSet right
+  domain (MkBiMap left _right) = Map.keysSet left
+  range (MkBiMap _left right) = Map.keysSet right
   emptyc = error ("emptyc cannot be defined for BiMap, use the variable: biMapEmpty :: BiMap v k v")
 
 biMapEmpty :: BiMap v k v
 biMapEmpty = MkBiMap Map.empty Map.empty
 
+-- Make a BiMap from a list of pairs.
+-- The combine function comb=(\ earlier later -> later) will let elements
+-- later in the list override ones earlier in the list, and comb =
+-- (\ earlier later -> earlier) will keep the vaue that appears first in the list
+
 biMapFromList:: (Ord k,Ord v) => (v -> v -> v) -> [(k,v)] -> BiMap v k v
-biMapFromList combine xs = foldr add biMapEmpty xs
-  where add (k,v) (ans@(MkBiMap forward backward)) =
-          case (Map.lookup k forward, Map.lookup v backward) of
-               (Nothing,Nothing) -> addkv (k,v) ans combine
-               (Just v2, Just k2) -> addkv (k,v) ans combine -- Let combine decide
-               other -> ans -- Should never happen if its is truly a bijection.
-  -- The map must be a bijection.
+biMapFromList comb xs = foldr addEntry biMapEmpty xs
+  where addEntry (k,v) (MkBiMap forward backward) =
+          case Map.lookup k forward of
+            Nothing -> MkBiMap (addkv (k,v) forward comb) (addBack v k backward)
+            Just oldv -> MkBiMap (addkv (k,v) forward comb) (insertBackwards oldv newv k backward)
+               where newv = comb oldv v
 
 
 -- This synonym makes (BiMap v k v) appear as an ordinary Binary type contructor: (Bimap k v)
@@ -203,7 +219,7 @@ type Bimap k v = BiMap v k v
 removeval:: (Ord k, Ord v) => v -> BiMap v k v -> BiMap v k v
 removeval v (m@(MkBiMap m1 m2)) =
      case Map.lookup v m2 of
-        Just k -> MkBiMap (Map.delete k m1) (Map.delete v m2)
+        Just kset -> MkBiMap (foldr (\k set -> Map.delete k set) m1 kset) (Map.delete v m2)
         Nothing -> m
 
 -- ================= Basic Set =====================
@@ -211,11 +227,11 @@ removeval v (m@(MkBiMap m1 m2)) =
 data Sett k v where Sett :: (Set.Set k) -> Sett k ()
 
 instance Basic Sett where
-  addpair key unit (Sett m) = Sett(Set.insert key m)
-  addkv (k,unit) (Sett m) comb = Sett(Set.insert k m)  -- We can ignore comb since there is only one function at type: () -> () -> ()
+  addpair key _unit (Sett m) = Sett(Set.insert key m)
+  addkv (k,_unit) (Sett m) _comb = Sett(Set.insert k m)  -- We can ignore comb since there is only one function at type: () -> () -> ()
   removekey k (Sett m) = Sett(Set.delete k m)
   domain (Sett xs) = xs
-  range (Sett xs) = Set.singleton ()
+  range (Sett _xs) = Set.singleton ()
   emptyc = error ("Sett Set.empty has type (Sett k ()) and it needs type (Sett k v)")
 
 instance Show key => Show (Sett key ()) where
@@ -302,7 +318,7 @@ deriving instance (Eq k,Eq v) => Eq (List k v)
 instance Iter List where                      -- List is the only basic instance with non-linear nxt and lub. It also depends on
    nxt (UnSafeList []) = none                 -- key-value pairs being stored in ascending order. For small Lists (10 or so elements) this is OK.
    nxt (UnSafeList ((k,v):xs)) = one(k,v,UnSafeList xs)
-   lub k (UnSafeList xs) = case dropWhile (\ (key,v) -> key < k) xs of
+   lub k (UnSafeList xs) = case dropWhile (\ (key,_v) -> key < k) xs of
                        [] -> none
                        ((key,v):ys) -> one (key,v,UnSafeList ys)
    isnull (UnSafeList xs) = null xs
@@ -318,18 +334,18 @@ instance (Show k,Show v) => Show (List k v) where
 instance Iter Single where
   nxt (Single k v) = Collect(\ ans f -> f (k,v,Fail) ans)
   nxt (SetSingle k) = Collect(\ ans f ->  f (k,(),Fail) ans)
-  nxt Fail = Collect(\ ans f -> ans)
+  nxt Fail = Collect(\ ans _f -> ans)
   lub key (Single k v) = Collect(\ ans f -> if k<=key then f (k,v,Fail) ans else ans)
   lub key (SetSingle k) = Collect(\ ans f -> if k<=key then f(k,(),Fail) ans else ans)
-  lub key Fail = Collect(\ ans f -> ans)
+  lub _key Fail = Collect(\ ans _f -> ans)
   haskey k (SetSingle a) = k==a
-  haskey k (Single a b) = k==a
-  haskey k Fail = False
+  haskey k (Single a _b) = k==a
+  haskey _k Fail = False
   isnull Fail = True
   isnull _ = False
   lookup k (SetSingle a) = if k==a then Just() else Nothing
   lookup k (Single a b) = if k==a then Just b else Nothing
-  lookup k Fail = Nothing
+  lookup _k Fail = Nothing
 
 instance (Show k,Show v) => Show (Single k v) where
   show (Single k v) = "(Single "++show k ++ " "++show v++")"
@@ -400,12 +416,12 @@ noKeys m (Bin _ k _ ls rs) = case Map.split k m of
 
 keysEqual:: Ord k => Map k v1 -> Map k v2 -> Bool
 keysEqual Tip Tip = True
-keysEqual Tip (Bin _ k _ ls rs) = False
-keysEqual (Bin _ k _ ls rs) Tip = False
+keysEqual Tip (Bin _ _ _ _ _) = False
+keysEqual (Bin _ _ _ _ _) Tip = False
 keysEqual m (Bin _ k _ ls rs) =
    case splitMember k m of
       (lm,True,rm) -> keysEqual ls lm && keysEqual rs rm
-      other -> False
+      _ -> False
 
 -- cost O(min (size m) (size n) * log(max (size m) (size n))), BUT the constants are high, too slow except for small maps.
 sameDomain:: (Ord k,Iter f,Iter g) =>  f k b -> g k c -> Bool
@@ -445,9 +461,9 @@ data StrictTriple a b c = StrictTriple !a !b !c
 
 -- | intersetDomP p m1 m2 == Keep the key and value from m2, iff (the key is in the dom of m1) && ((p key value) is true)
 intersectDomP:: Ord k => (k -> v2 -> Bool) -> Map k v1 -> Map k v2 -> Map k v2
-intersectDomP p Tip _ = Tip
-intersectDomP p  _ Tip = Tip
-intersectDomP p t1 t2@(Bin _ k v l2 r2) =
+intersectDomP _ Tip _ = Tip
+intersectDomP _  _ Tip = Tip
+intersectDomP p t1 (Bin _ k v l2 r2) =
    if mb && (p k v)
       then link k v l1l2 r1r2
       else link2 l1l2 r1r2
@@ -462,9 +478,9 @@ intersectDomP p t1 t2@(Bin _ k v l2 r2) =
 
 -- |- Similar to intersectDomP, except the Map returned has the same key as the first input map, rather than the second input map.
 intersectDomPLeft:: Ord k => (k -> v2 -> Bool) -> Map k v1 -> Map k v2 -> Map k v1
-intersectDomPLeft p Tip _ = Tip
-intersectDomPLeft p  _ Tip = Tip
-intersectDomPLeft p (t1@(Bin _ k v1 l1 r1)) t2 =
+intersectDomPLeft _ Tip _ = Tip
+intersectDomPLeft _  _ Tip = Tip
+intersectDomPLeft p (Bin _ k v1 l1 r1) t2 =
    case mb of
       Just v2 | p k v2 -> link k v1 l1l2 r1r2
       _other -> link2 l1l2 r1r2
@@ -476,22 +492,22 @@ intersectDomPLeft p (t1@(Bin _ k v1 l1 r1)) t2 =
 
 -- |- fold over the intersection of a Map and a Set
 intersectMapSetFold:: Ord k => (k -> v -> ans -> ans) -> Map k v -> Set k -> ans -> ans
-intersectMapSetFold accum Tip _ !ans = ans
-intersectMapSetFold accum _ set !ans | Set.null set = ans
+intersectMapSetFold _accum Tip _ !ans = ans
+intersectMapSetFold _accum _ set !ans | Set.null set = ans
 intersectMapSetFold accum (Bin _ k v l1 l2) set !ans =
-    intersectMapSetFold accum l1 s1 (add k v (intersectMapSetFold accum l2 s2 ans))
+    intersectMapSetFold accum l1 s1 (addKV k v (intersectMapSetFold accum l2 s2 ans))
   where (s1,found,s2) = Set.splitMember k set
-        add k1 v1 !ans1 = if found then accum k1 v1 ans1 else ans1
+        addKV k1 v1 !ans1 = if found then accum k1 v1 ans1 else ans1
 {-# INLINABLE intersectMapSetFold #-}
 
 -- | Fold with 'accum' all those pairs in the map, not appearing in the set.
 disjointMapSetFold:: Ord k => (k -> v -> ans -> ans) -> Map k v -> Set k -> ans -> ans
-disjointMapSetFold accum Tip _ !ans = ans
+disjointMapSetFold _accum Tip _ !ans = ans
 disjointMapSetFold accum m set !ans | Set.null set = Map.foldrWithKey' accum ans m
 disjointMapSetFold accum (Bin _ k v l1 l2) set !ans =
-    disjointMapSetFold accum l1 s1 (add k v (disjointMapSetFold accum l2 s2 ans))
+    disjointMapSetFold accum l1 s1 (addKV k v (disjointMapSetFold accum l2 s2 ans))
   where (s1,found,s2) = Set.splitMember k set
-        add k1 v1 !ans1 = if not found then accum k1 v1 ans1 else ans1
+        addKV k1 v1 !ans1 = if not found then accum k1 v1 ans1 else ans1
 
 -- ============== Iter BiMap ====================
 
@@ -506,9 +522,9 @@ instance Ord v => Iter (BiMap v) where
        (_left,Nothing,Tip) -> ans
        (_left,Nothing,right) -> f (k,v,MkBiMap m3 backward) ans
            where ((k,v),m3) = Map.deleteFindMin right )
-  isnull (MkBiMap f g) = isnull f
-  lookup x (MkBiMap left right) = Map.lookup x left
-  haskey k (MkBiMap left right) = haskey k left
+  isnull (MkBiMap f _g) = isnull f
+  lookup x (MkBiMap left _right) = Map.lookup x left
+  haskey k (MkBiMap left _right) = haskey k left
 
 
 -- ===============================================================================================
@@ -736,40 +752,40 @@ data Lam t where
 type StringEnv = (String,String,String,String)
 
 bindE :: Pat (a,b,c,d) t -> Expr (w,x,y,z) t -> StringEnv -> StringEnv
-bindE P1 v (e@(d,c,b,a)) = (showE e v,c,b,a)
-bindE P2 v (e@(d,c,b,a)) = (d,showE e v,b,a)
-bindE P3 v (e@(d,c,b,a)) = (d,c,showE e v,a)
-bindE P4 v (e@(d,c,b,a)) = (d,c,b,showE e v)
+bindE P1 v (e@(_,c,b,a)) = (showE e v,c,b,a)
+bindE P2 v (e@(d,_,b,a)) = (d,showE e v,b,a)
+bindE P3 v (e@(d,c,_,a)) = (d,c,showE e v,a)
+bindE P4 v (e@(d,c,b,_)) = (d,c,b,showE e v)
 bindE (PPair p1 p2) (EPair e1 e2) env = bindE p1 e1 (bindE p2 e2 env)
 bindE (PPair p1 p2) e env = bindE p2 (SND e) (bindE p1 (FST e) env)
 
 showE :: StringEnv -> (Expr (a,b,c,d) t) -> String
-showE (x,y,z,w) X1 = x
-showE (x,y,z,w) X2 = y
-showE (x,y,z,w) X3 = z
-showE (x,y,z,w) X4 = w
+showE (x,_,_,_) X1 = x
+showE (_,y,_,_) X2 = y
+showE (_,_,z,_) X3 = z
+showE (_,_,_,w) X4 = w
 showE e (EPair a b) = "("++showE e a++","++showE e b++")"
 showE e (Ap (Lam p1 p2 expr) x y) = showE (bindE p2 y (bindE p1 x e)) expr
 showE e (FST f) = "(fst " ++ showE e f ++ ")"
 showE e (SND f) = "(snd " ++ showE e f ++ ")"
 showE e (Ap oper a b) = "("++showE e a++showL e oper++showE e b++")"
-showE e (HasKey k datum) = "(haskey "++showE e k++" ?)"
+showE e (HasKey k _datum) = "(haskey "++showE e k++" ?)"
 showE e (Neg x) = "(not "++showE e x++")"
-showE e (Lit n) = show n
+showE _ (Lit n) = show n
 
 showL :: StringEnv -> Lam t -> String
 showL e (Lam p1 p2 expr) = "\\ "++showP e p1++" "++showP e p2++" -> "++showE e expr
-showL e Add = " + "
-showL e Cat = " <> "
-showL e Eql = " == "
-showL e Both = " && "
-showL e (Lift f) = "<lifted function>"
+showL _e Add = " + "
+showL _e Cat = " <> "
+showL _e Eql = " == "
+showL _e Both = " && "
+showL _e (Lift _f) = "<lifted function>"
 
 showP :: StringEnv -> (Pat any t) -> String
-showP (x,y,z,w) P1 = x
-showP (x,y,z,w) P2 = y
-showP (x,y,z,w) P3 = z
-showP (x,y,z,w) P4 = w
+showP (x,_,_,_) P1 = x
+showP (_,y,_,_) P2 = y
+showP (_,_,z,_) P3 = z
+showP (_,_,_,w) P4 = w
 showP env (PPair p1 p2) = "("++showP env p1++","++showP env p2++")"
 
 instance Show (Expr (a,b,c,d) t) where
@@ -796,7 +812,7 @@ instance Show (Fun t) where
 
 -- Used in projectStep, chainStep, andPStep, orStep and guardStep
 apply :: Fun t -> t
-apply (Fun e f) = f
+apply (Fun _e f) = f
 
 -- Used in compile (UnionOverrideLeft case)
 first :: Fun (v -> s -> v)
@@ -814,20 +830,20 @@ eql :: Eq t => Fun (t -> t -> Bool)
 eql = (Fun Eql (==))
 
 constant:: Show c => c -> Fun(a -> b -> c)
-constant c = Fun (Lam P1 P2 (Lit c)) (\ x y -> c)
+constant c = Fun (Lam P1 P2 (Lit c)) (\ _x _y -> c)
 
 -- Used in compile (RExclude RRestrict cases)
 rngElem:: (Ord rng,Iter f) => f rng v -> Fun(dom -> rng -> Bool)
-rngElem realset = Fun  (Lam P1 P2 (HasKey X2 realset)) (\ x y -> haskey y realset)  -- x is ignored and realset is supplied
+rngElem realset = Fun  (Lam P1 P2 (HasKey X2 realset)) (\ _x y -> haskey y realset)  -- x is ignored and realset is supplied
 
 domElem:: (Ord dom,Iter f) => f dom v -> Fun(dom -> rng -> Bool)
-domElem realset = Fun  (Lam P1 P2 (HasKey X1 realset)) (\ x y -> haskey x realset)  -- x is ignored and realset is supplied
+domElem realset = Fun  (Lam P1 P2 (HasKey X1 realset)) (\ x _y -> haskey x realset)  -- y is ignored and realset is supplied
 
 rngFst:: Fun(x -> (a,b) -> a)
-rngFst = Fun (Lam P1 (PPair P2 P3) X2) (\ x (a,b) -> a)
+rngFst = Fun (Lam P1 (PPair P2 P3) X2) (\ _x (a,_b) -> a)
 
 rngSnd:: Fun(x -> (a,b) -> b)
-rngSnd = Fun (Lam P1 (PPair P2 P3) X3) (\ x y -> snd y)
+rngSnd = Fun (Lam P1 (PPair P2 P3) X3) (\ _x y -> snd y)
 
 compose1 :: Fun (t1 -> t2 -> t3) -> Fun (t1 -> t4 -> t2) -> Fun (t1 -> t4 -> t3)
 compose1 (Fun e1 f1) (Fun e2 f2) = Fun (Lam P1 P2 (Ap e1 X1 (Ap e2 X1 X2))) (\ a b -> f1 a (f2 a b))
@@ -864,7 +880,7 @@ lift f = Fun (Lift f) f
 -- =============================================================================================
 
 materialize :: (Ord k) => BaseRep f k v -> Collect (k,v) -> f k v
-materialize ListR x = fromPairs (\ l r -> l) (runCollect x [] (:))
+materialize ListR x = fromPairs (\ l _r -> l) (runCollect x [] (:))
 materialize MapR x = runCollect x Map.empty (\ (k,v) ans -> Map.insert k v ans)
 materialize SetR x = Sett (runCollect x Set.empty (\ (k,_) ans -> Set.insert k ans))
 materialize BiMapR x = runCollect x  biMapEmpty (\ (k,v) ans -> addpair k v ans)
@@ -879,6 +895,10 @@ materialize SingleR x = runCollect x Fail (\ (k,v) _ignore -> Single k v)
 
 addp :: (Ord k,Basic f) => (v -> v -> v) -> (k,v) -> f k v -> f k v
 addp combine (k,v) xs = addkv (k,v) xs combine
+
+-- The combine function comb = (\ earlier later -> later) will let values
+-- later in the list override ones earlier in the list, and comb =
+-- (\ earlier later -> earlier) will keep the value that appears first in the list
 
 fromList:: Ord k => BaseRep f k v -> (v -> v -> v) -> [(k,v)] -> f k v
 fromList MapR combine xs = Map.fromListWith combine xs
@@ -981,19 +1001,19 @@ guardD qry test = GuardD qry test
 -- ================================================================================
 
 compileSubterm :: Exp a -> Exp (f k v) -> Query k v
-compileSubterm whole sub = fst(compile sub)
+compileSubterm _whole sub = fst(compile sub)
 
 compile:: Exp (f k v) -> (Query k v,BaseRep f k v)
 compile (Base rep relation) = (BaseD rep relation,rep)
 compile (Singleton d r) = (BaseD SingleR (Single d r),SingleR)
 compile (SetSingleton d  ) = (BaseD SingleR (SetSingle d  ),SingleR)
 compile (Dom (Base SetR rel)) = (BaseD SetR rel,SetR)
-compile (Dom (Singleton k v)) = (BaseD SetR (Sett(Set.singleton k)),SetR)
+compile (Dom (Singleton k _v)) = (BaseD SetR (Sett(Set.singleton k)),SetR)
 compile (Dom (SetSingleton k)) = (BaseD SetR (Sett(Set.singleton k)),SetR)
 compile (Dom x) = (projD (fst(compile x)) (constant ()),SetR)
-compile (Rng (Base SetR rel))  = (BaseD SetR (Sett(Set.singleton ())),SetR)
-compile (Rng (Singleton k v))  = (BaseD SetR (Sett(Set.singleton v)),SetR)
-compile (Rng (SetSingleton k)) = (BaseD SetR (Sett(Set.singleton ())),SetR)
+compile (Rng (Base SetR _rel))  = (BaseD SetR (Sett(Set.singleton ())),SetR)
+compile (Rng (Singleton _k v))  = (BaseD SetR (Sett(Set.singleton v)),SetR)
+compile (Rng (SetSingleton _k)) = (BaseD SetR (Sett(Set.singleton ())),SetR)
 compile (Rng f) = (BaseD SetR (rngStep (fst(compile f))),SetR)  -- We really ought to memoize this. It might be computed many times.
 compile (DRestrict set rel) =  (projD (andD (fst(compile set)) reld) rngSnd,rep)
     where (reld,rep) = compile rel
@@ -1029,14 +1049,18 @@ runSetExp e =
       then error ("In Testing mode, SetAlgebra expression: "++show e++" falls through to slow mode.")
       else run(compile e)
 
+-- Only for use in the SetAlgebra internal tests
+runSet ::  Ord k => Exp (f k v) -> f k v
+runSet e = run(compile e)
+
 run ::(Ord k) => (Query k v,BaseRep f k v) -> f k v
 run (BaseD SetR x,SetR) = x               -- If it is already data (BaseD)
 run (BaseD MapR x,MapR) = x               -- and in the right form (the BaseRep's match)
 run (BaseD SingleR x,SingleR) = x         -- just return the data
 run (BaseD BiMapR x,BiMapR) = x           -- only need to materialize data
 run (BaseD ListR x,ListR) = x             -- if the forms do not match.
-run (BaseD source x,ListR) = materialize ListR (fifo x)       -- use fifo, since the order matters for Lists.
-run (BaseD source x,target) = materialize target (lifo x)     -- use lifo, for others
+run (BaseD _source x,ListR) = materialize ListR (fifo x)       -- use fifo, since the order matters for Lists.
+run (BaseD _source x,target) = materialize target (lifo x)     -- use lifo, for others
 run (other,ListR) = materialize ListR (fifo other)            -- If it is a compund Iterator, for List, than materialize it using fifo
 run (other,target) = materialize target (lifo other)          -- If it is a compund Iterator, for anything else than materialize it using lifo
 
@@ -1045,13 +1069,15 @@ runBoolExp e =
     if testing
        then error ("In Testing mode, SetAlgebra expression: "++show e++" falls through to slow mode.")
        else runBool e
-  where runBool :: Exp Bool -> Bool
-        runBool (Elem k v) = haskey k (compute v)
-        runBool (NotElem k set) = not $ haskey k (compute set)
-        runBool (w@(KeyEqual x y)) = sameDomain (compileSubterm w x) (compileSubterm w y)
-        runBool (w@(Subset x y)) = runCollect (lifo left) True (\ (k,v) ans -> haskey k right && ans)
-           where left = compileSubterm w x
-                 right = compileSubterm w y
+
+-- Only for use inthe SetAlgebra internal tests
+runBool :: Exp Bool -> Bool
+runBool (Elem k v) = haskey k (compute v)
+runBool (NotElem k set) = not $ haskey k (compute set)
+runBool (w@(KeyEqual x y)) = sameDomain (compileSubterm w x) (compileSubterm w y)
+runBool (w@(Subset x y)) = runCollect (lifo left) True (\ (k,_v) ans -> haskey k right && ans)
+    where left = compileSubterm w x
+          right = compileSubterm w y
 
 
 -- ==============================================================================================
@@ -1068,13 +1094,13 @@ runBoolExp e =
 
 
 compute:: Exp t -> t
-compute (Base rep relation) = relation
+compute (Base _rep relation) = relation
 
 compute (Dom (Base SetR rel)) = rel
 compute (Dom (Base MapR x)) = Sett (Map.keysSet x)
-compute (Dom (Singleton k v)) = Sett (Set.singleton k)
+compute (Dom (Singleton k _v)) = Sett (Set.singleton k)
 compute (Dom (SetSingleton k)) = Sett (Set.singleton k)
-compute (Dom (Base rep rel)) = Sett(domain rel)
+compute (Dom (Base _rep rel)) = Sett(domain rel)
   -- (dom (Map(62)? ▷ (setSingleton _ )))
 compute (Dom (RRestrict (Base MapR xs) (SetSingleton v))) = Sett(Map.foldlWithKey' accum Set.empty xs)
    where accum ans k u = if u==v then Set.insert k ans else ans
@@ -1085,25 +1111,25 @@ compute (Dom (RExclude (Base MapR xs) (SetSingleton v))) = Sett(Map.foldlWithKey
 compute (Dom (RExclude (Base MapR xs) (Base SetR (Sett set)))) = Sett(Map.foldlWithKey' accum Set.empty xs)
    where accum ans k u = if not(Set.member u set) then Set.insert k ans else ans
 compute (Dom (DRestrict (SetSingleton v) (Base MapR xs))) = Sett(intersectMapSetFold accum xs (Set.singleton v) Set.empty)
-   where accum k u ans = Set.insert k ans
+   where accum k _u ans = Set.insert k ans
 compute (Dom (DRestrict (Base SetR (Sett set)) (Base MapR xs))) = Sett(intersectMapSetFold accum xs set Set.empty)
-   where accum k u ans = Set.insert k ans
+   where accum k _u ans = Set.insert k ans
 
 compute (Dom (DExclude (SetSingleton v) (Base MapR xs))) = Sett(disjointMapSetFold accum xs (Set.singleton v) Set.empty)
-   where accum k u ans = Set.insert k ans
+   where accum k _u ans = Set.insert k ans
 compute (Dom (DExclude (Base SetR (Sett set)) (Base MapR xs))) = Sett(disjointMapSetFold accum xs set Set.empty)
-   where accum k u ans = Set.insert k ans
+   where accum k _u ans = Set.insert k ans
 compute (e@(Dom _)) = runSetExp e
 
-compute (Rng (Base SetR rel)) = Sett (Set.singleton ())
-compute (Rng (Singleton k v)) = Sett (Set.singleton v)
-compute (Rng (SetSingleton k)) = Sett (Set.singleton ())
-compute (Rng (Base rep rel)) = Sett(range rel)
+compute (Rng (Base SetR _rel)) = Sett (Set.singleton ())
+compute (Rng (Singleton _k v)) = Sett (Set.singleton v)
+compute (Rng (SetSingleton _k)) = Sett (Set.singleton ())
+compute (Rng (Base _rep rel)) = Sett(range rel)
 compute (e@(Rng _ )) = runSetExp e
 
 compute (DRestrict (Base SetR (Sett set)) (Base MapR m)) = Map.restrictKeys m set
 compute (DRestrict (SetSingleton k) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
-compute (DRestrict (Singleton k v) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
+compute (DRestrict (Singleton k _v) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
 compute (DRestrict (Dom (Base MapR x)) (Base MapR y)) = Map.intersection y x
 
 -- This case inspired by set expression in EpochBoundary.hs
@@ -1118,16 +1144,16 @@ compute (DRestrict set (Base MapR ys)) = Map.restrictKeys ys set2 -- Pay the cos
    where Sett set2 = materialize SetR (lifo (compute set))
 
 compute (DRestrict (Base SetR (Sett s1)) (Base SetR (Sett s2))) = Sett(Set.intersection s1 s2)
-compute (DRestrict (Base SetR x1) (Base rep x2)) = materialize rep $ do { (x,y,z) <- x1 `domEq` x2; one (x,z) }
-compute (DRestrict (Dom (Base _ x1)) (Base rep x2)) = materialize rep $ do { (x,y,z) <- x1 `domEq` x2; one (x,z) }
-compute (DRestrict (SetSingleton k) (Base rep x2)) = materialize rep $  do { (x,y,z) <- (SetSingle k) `domEq` x2; one (x,z) }
-compute (DRestrict (Dom (Singleton k _)) (Base rep x2)) = materialize rep $  do { (x,y,z) <- (SetSingle k) `domEq` x2; one (x,z) }
-compute (DRestrict (Rng (Singleton _ v)) (Base rep x2)) = materialize rep $  do { (x,y,z) <- (SetSingle v) `domEq` x2; one (x,z) }
+compute (DRestrict (Base SetR x1) (Base rep x2)) = materialize rep $ do { (x,_,z) <- x1 `domEq` x2; one (x,z) }
+compute (DRestrict (Dom (Base _ x1)) (Base rep x2)) = materialize rep $ do { (x,_,z) <- x1 `domEq` x2; one (x,z) }
+compute (DRestrict (SetSingleton k) (Base rep x2)) = materialize rep $  do { (x,_,z) <- (SetSingle k) `domEq` x2; one (x,z) }
+compute (DRestrict (Dom (Singleton k _)) (Base rep x2)) = materialize rep $  do { (x,_,z) <- (SetSingle k) `domEq` x2; one (x,z) }
+compute (DRestrict (Rng (Singleton _ v)) (Base rep x2)) = materialize rep $  do { (x,_,z) <- (SetSingle v) `domEq` x2; one (x,z) }
 compute (e@(DRestrict _ _)) = runSetExp e
 
 compute (DExclude (SetSingleton n) (Base MapR m)) = Map.withoutKeys m (Set.singleton n)
-compute (DExclude (Dom (Singleton n v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton n)
-compute (DExclude (Rng (Singleton n v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton v)
+compute (DExclude (Dom (Singleton n _v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton n)
+compute (DExclude (Rng (Singleton _n v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton v)
 compute (DExclude (Base SetR (Sett x1)) (Base MapR x2)) =  Map.withoutKeys x2 x1
 compute (DExclude (Dom (Base MapR x1)) (Base MapR x2)) = noKeys x2 x1
 compute (DExclude (SetSingleton k) (Base BiMapR x)) = removekey k x
@@ -1136,27 +1162,27 @@ compute (DExclude (Rng (Singleton _ v)) (Base BiMapR x)) = removekey v x
 compute (e@(DExclude _ _ )) = runSetExp e
 
 compute (RExclude (Base BiMapR x) (SetSingleton k)) = removeval k x
-compute (RExclude (Base BiMapR x) (Dom (Singleton k v))) = removeval k x
-compute (RExclude (Base BiMapR x) (Rng (Singleton k v))) = removeval v x
+compute (RExclude (Base BiMapR x) (Dom (Singleton k _v))) = removeval k x
+compute (RExclude (Base BiMapR x) (Rng (Singleton _k v))) = removeval v x
 compute (RExclude (Base MapR xs) (Base SetR (Sett y))) = Map.filter (\ x -> not (Set.member x y)) xs
 compute (RExclude (Base MapR xs) (SetSingleton k)) = Map.filter (not . ( == k)) xs
-compute (RExclude (Base rep lhs) (Base SetR (Sett rhs))) | Set.null rhs = lhs
-compute (RExclude (Base rep lhs) (Base SingleR Fail)) = lhs
-compute (e@(RExclude (Base rep lhs) y)) =
+compute (RExclude (Base _rep lhs) (Base SetR (Sett rhs))) | Set.null rhs = lhs
+compute (RExclude (Base _rep lhs) (Base SingleR Fail)) = lhs
+compute (RExclude (Base rep lhs) y) =
    materialize rep $ do { (a,b) <- lifo lhs; when (not(haskey b rhs)); one (a,b)} where (rhs,_) = compile y
 compute (e@(RExclude _ _ )) = runSetExp e
 
 -- (dom (Map(16)? ▷ (setSingleton _ )))
-compute (e@(RRestrict (Base MapR xs) (SetSingleton k))) = Map.filter (\ x -> x==k) xs
+compute (RRestrict (Base MapR xs) (SetSingleton k)) = Map.filter (\ x -> x==k) xs
 -- ((dom rewards' ◁ delegs) ▷ dom poolParams)  in LedgerState.hs
 compute (RRestrict (DRestrict (Dom (Base MapR x)) (Base MapR y)) (Dom (Base MapR z))) = intersectDomP (\ _k v -> Map.member v z) x y
-compute (e@(RRestrict (DRestrict (Dom (Base r1 stkcreds)) (Base r2 delegs)) (Dom (Base r3 stpools)))) =
-   materialize r2 $ do { (x,z,y) <- stkcreds `domEq` delegs; y `element` stpools; one (x,y)}
+compute (RRestrict (DRestrict (Dom (Base _r1 stkcreds)) (Base r2 delegs)) (Dom (Base _r3 stpools))) =
+   materialize r2 $ do { (x,_,y) <- stkcreds `domEq` delegs; y `element` stpools; one (x,y)}
 compute (e@(RRestrict _ _ )) = runSetExp e
 
-compute (Elem k (Dom (Base rep x))) = haskey k x
-compute (Elem k (Base rep rel)) = haskey k rel
-compute (Elem k (Dom (Singleton key v))) = k==key
+compute (Elem k (Dom (Base _rep x))) = haskey k x
+compute (Elem k (Base _rep rel)) = haskey k rel
+compute (Elem k (Dom (Singleton key _v))) = k==key
 compute (Elem k (Rng (Singleton _ key))) = k==key
 compute (Elem k (SetSingleton key)) = k==key
 compute (Elem k (UnionOverrideLeft  (Base SetR (Sett x)) (Base SetR (Sett y)))) = (Set.member k x || Set.member k y)
@@ -1165,47 +1191,47 @@ compute (Elem k (UnionPlus          (Base SetR (Sett x)) (Base SetR (Sett y)))) 
 compute (Elem k (Intersect (Base SetR (Sett x)) (Base SetR (Sett y)))) = (Set.member k x && Set.member k y)
 compute (Elem k (DRestrict s1 m1)) = compute (Elem k s1) && compute (Elem k m1)
 compute (Elem k (DExclude s1 m1)) = not (compute(Elem k s1)) && compute(Elem k m1)
-compute (e@(Elem k set)) = runBoolExp e
+compute (e@(Elem _ _)) = runBoolExp e
 
-compute (NotElem k (Dom (Base rep x))) = not $ haskey k x
-compute (NotElem k (Base rep rel)) = not $ haskey k rel
-compute (NotElem k (Dom (Singleton key v))) = not $ k==key
+compute (NotElem k (Dom (Base _rep x))) = not $ haskey k x
+compute (NotElem k (Base _rep rel)) = not $ haskey k rel
+compute (NotElem k (Dom (Singleton key _v))) = not $ k==key
 compute (NotElem k (Rng (Singleton _ key))) = not $ k==key
 compute (NotElem k (SetSingleton key)) = not $ k==key
 compute (NotElem k (UnionOverrideLeft  (Base SetR (Sett x)) (Base SetR (Sett y)))) = not(Set.member k x || Set.member k y)
 compute (NotElem k (UnionOverrideRight (Base SetR (Sett x)) (Base SetR (Sett y)))) = not(Set.member k x || Set.member k y)
 compute (NotElem k (UnionPlus          (Base SetR (Sett x)) (Base SetR (Sett y)))) = not(Set.member k x || Set.member k y)
 compute (NotElem k (Intersect (Base SetR (Sett x)) (Base SetR (Sett y)))) = not (Set.member k x && Set.member k y)
-compute (e@(NotElem k set)) = runBoolExp e
+compute (e@(NotElem _ _)) = runBoolExp e
 
 compute (Subset (Base SetR (Sett x)) (Base SetR (Sett y))) = Set.isSubsetOf x y
 compute (Subset (Base SetR (Sett x)) (Base MapR y)) = all (`Map.member` y) x
 compute (Subset (Base SetR (Sett x)) (Dom (Base MapR y))) = all (`Map.member` y) x
 compute (Subset (Base MapR x) (Base MapR y)) = Map.foldrWithKey accum True x
-   where accum k a ans = Map.member k y && ans
+   where accum k _a ans = Map.member k y && ans
 compute (Subset (Dom (Base MapR x)) (Dom (Base MapR y))) = Map.foldrWithKey accum True x
-   where accum k a ans = Map.member k y && ans
-compute (e@(Subset x y)) = runBoolExp e
+   where accum k _a ans = Map.member k y && ans
+compute (e@(Subset _ _)) = runBoolExp e
 
 compute (Intersect (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.intersection x y)
 compute (Intersect (Base MapR x) (Base MapR y)) = Sett (Map.keysSet(Map.intersection x y))
-compute (e@(Intersect a b)) = runSetExp e
+compute (e@(Intersect _ _)) = runSetExp e
 
-compute (UnionOverrideLeft (Base rep x) (Singleton k v))  = addkv (k,v) x (\ old new -> old) -- The value on the left is preferred over the right, so 'addkv' chooses 'old'
+compute (UnionOverrideLeft (Base _rep x) (Singleton k v))  = addkv (k,v) x (\ old _new -> old) -- The value on the left is preferred over the right, so 'addkv' chooses 'old'
 compute (UnionOverrideLeft (Base MapR d0) (Base MapR d1)) = Map.union d0 d1  -- 'Map.union' is left biased, just what we want.
 compute (UnionOverrideLeft (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y)
 compute (UnionOverrideLeft (DExclude (SetSingleton k) (Base MapR xs)) (Base MapR ys)) = Map.union (Map.delete k xs) ys
 compute (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m2)) (Base MapR m3)) =  Map.union (Map.withoutKeys m2 s1) m3
-compute (e@(UnionOverrideLeft a b)) = runSetExp e
+compute (e@(UnionOverrideLeft _ _)) = runSetExp e
 
-compute (UnionOverrideRight (Base rep x) (Singleton k v)) = addkv (k,v) x (\ old new -> new) -- The value on the right is preferred over the left, so 'addkv' chooses 'new'
+compute (UnionOverrideRight (Base _rep x) (Singleton k v)) = addkv (k,v) x (\ _old new -> new) -- The value on the right is preferred over the left, so 'addkv' chooses 'new'
 compute (UnionOverrideRight (Base MapR d0) (Base MapR d1)) = Map.union d1 d0   -- we pass @d1@ as first argument, since 'Map.union' is left biased.
 compute (UnionOverrideRight (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y)
-compute (e@(UnionOverrideRight a b)) = runSetExp e
+compute (e@(UnionOverrideRight _ _)) = runSetExp e
 
 compute (UnionPlus (Base MapR x) (Base MapR y)) = Map.unionWith (<>) x y
 compute (UnionPlus (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y)  -- Recall (Sett k):: f k (), so () <> () = ()
-compute (e@(UnionPlus a b)) = runSetExp e
+compute (e@(UnionPlus _ _)) = runSetExp e
 
 compute (Singleton k v) = Single k v
 compute (SetSingleton k) = (SetSingle k)
@@ -1216,7 +1242,7 @@ compute (KeyEqual (Dom (Base MapR m)) (Dom (Base MapR n))) = keysEqual m n
 compute (KeyEqual (Dom (Base BiMapR (MkBiMap m _))) (Dom (Base BiMapR (MkBiMap n _)))) = keysEqual m n
 compute (KeyEqual (Base SetR (Sett m)) (Base SetR (Sett n))) = n==m
 compute (KeyEqual (Base MapR xs) (Base SetR (Sett ys))) = Map.keysSet xs == ys
-compute (e@(KeyEqual x y )) = runBoolExp e
+compute (e@(KeyEqual _ _ )) = runBoolExp e
 
 eval :: Embed s t => Exp t -> s
 eval x = fromBase (compute x)
@@ -1248,7 +1274,7 @@ chainStep
   :: (Ord b, Ord a) =>
      (a, b, Query a b)
      -> Query b w -> Fun (a -> (b, w) -> u) -> Collect (a, u, Query a u)
-chainStep (f@(d,r1,f1)) g comb =
+chainStep (d,r1,f1) g comb =
    case lookup r1 g of   -- recall that the values 'r1' from f, are not iterated in ascending order, only the keys 'd' are ascending
      Just w -> one(d,apply comb d (r1,w),ChainD f1 g comb)
      Nothing -> do { trip <- nxtQuery f1; chainStep trip g comb}
@@ -1296,10 +1322,10 @@ guardStep next p f = do { triple <- next f; loop triple }
 
 -- ===== Difference by key =====
 diffStep :: Ord k => (k, v, Query k v) -> Query k u -> Collect (k, v, Query k v)
-diffStep (t1@(k1,u1,f1)) g =
+diffStep (k1,u1,f1) g =
    case hasElem (lubQuery k1 g) of
       Nothing -> one (k1,u1,DiffD f1 g)  -- g has nothing to subtract
-      Just (t2@(k2,u2,g2)) -> case compare k1 k2 of
+      Just (k2,_u2,g2) -> case compare k1 k2 of
           EQ -> do { tup <- nxtQuery f1; diffStep tup g2 }
           LT -> one (k1,u1,DiffD f1 g)
           GT -> one (k1,u1,DiffD f1 g)   -- the hasLub guarantees k1 <= k2, so this case is dead code
@@ -1307,7 +1333,7 @@ diffStep (t1@(k1,u1,f1)) g =
 -- ========== Rng ====================
 rngStep :: Ord v => Query k v -> Sett v ()
 rngStep dat = materialize SetR (loop dat)
-  where loop x = do { (k,v,x2) <- nxt x; front (v,()) (loop x2) }
+  where loop x = do { (_k,v,x2) <- nxt x; front (v,()) (loop x2) }
 
 -- =========================== Now the Iter instance for Query ======================
 
@@ -1377,7 +1403,7 @@ instance HasQuery (Query k v) k v where
    query xs = xs
 
 instance Ord k => HasQuery [(k,v)] k v where
-   query xs = BaseD ListR (fromPairs (\ l r -> l) xs)
+   query xs = BaseD ListR (fromPairs (\ l _r -> l) xs)
 
 instance Ord k => HasQuery (Set.Set k) k () where
    query xs = BaseD SetR (Sett xs)
@@ -1408,7 +1434,7 @@ instance Show (Exp t) where
   show (Base ListR xs) = "List("++show(length (unList xs))++")?"
   show (Base SingleR (Single _ _)) = "Single(_ _)"
   show (Base SingleR (SetSingle _ )) = "SetSingle(_)"
-  show (Base rep x) = show rep++"?"
+  show (Base rep _x) = show rep++"?"
   show (Dom x) = "(dom "++show x++")"
   show (Rng x) = "(rng "++show x++")"
   show (DRestrict x y) = "("++show x++" ◁ "++show y++")"
@@ -1422,12 +1448,12 @@ instance Show (Exp t) where
   show (UnionOverrideLeft x y) = "("++show x++" ∪ "++show y++")"
   show (UnionPlus x y) = "("++show x++" ∪+ "++show y++")"
   show (UnionOverrideRight x y) = "("++show x++" ⨃ "++show y++")"
-  show (Singleton x y) = "(singleton _ _ )"
-  show (SetSingleton x) = "(setSingleton _ )"
+  show (Singleton _ _) = "(singleton _ _ )"
+  show (SetSingleton _) = "(setSingleton _ )"
   show (KeyEqual x y) = "("++show x++" ≍ "++show y++")"
 
 ppQuery :: Query k v -> Doc
-ppQuery (BaseD rep f) = parens $ text(show rep)
+ppQuery (BaseD rep _f) = parens $ text(show rep)
 ppQuery (ProjectD f p) = parens $ text "Proj" <+> align(vsep[ppQuery f,text(show p)])
 ppQuery (AndD f g) = parens $ text "And" <+> align(vsep[ppQuery f,ppQuery g])
 ppQuery (ChainD f g p) = parens $ text "Chain" <+> align(vsep[ppQuery f,ppQuery g,text(show p)])

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
@@ -1,31 +1,36 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
+
+-- {-# OPTIONS_GHC -Wno-orphans #-}
+-- {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module Test.Control.Iterate.SetAlgebra where
 
 import Control.Iterate.Collect
 import Control.Iterate.SetAlgebra
 import Control.Iterate.SetAlgebraInternal
-  ( BiMap (..),
-    Bimap,
-    Exp (..),
+  ( Exp (..),
     List (..),
+    fromPairs,
     Query (..),
     Sett (..),
-    Single (..),
     compile,
     compute,
     domElem,
-    eval,
     fifo,
     lifo,
     lift,
     rngSnd,
     run,
+    runBoolExp,
     sameDomain,
     (⨝),
-    materialize,
     intersectDomPLeft,
     intersectDomP,
     domEq,
@@ -36,8 +41,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck(testProperty)
-import Test.Tasty(defaultMain)
+import Test.Tasty.QuickCheck
 
 -- =========================================================
 -- Some examples of Exp and tests
@@ -85,6 +89,11 @@ deleg = Map.fromList [(n, chars !! n) | n <- [1 .. 10]]
 
 stpool = Map.fromList [('A', 99), ('C', 12), ('F', 42), ('R', 33), ('Z', 99)]
 
+
+
+--  ((txins txb ⋪ utxo) ∪ txouts txb)
+test33 :: () -> Exp (Map Int Char)
+test33 () = ((Set.fromList [4,7,9] ⋪ m1) ∪ m2)
 -- =============== Build a few maps ===================
 
 chars :: String
@@ -126,12 +135,12 @@ evens :: Sett Int ()
 evens = fromList SetR (\l _r -> l) [(n, ()) | n <- [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26]]
 
 l4 :: [(Int, String)]
-l4 = [(1, "m"), (2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "a"), (50, "q"), (51, "l"), (105, "Z")]
+l4 = [(1, "m"), (2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "v"), (50, "q"), (51, "l"), (105, "Z")]
 
 l5 :: [(String, Int)]
 l5 = [("a", 101), ("b", 102), ("c", 103), ("f", 104), ("m", 105), ("q", 107), ("s", 106), ("w", 108), ("y", 109), ("zz", 110)]
 
--- Chain l4 l5 =  [(1,(1,"m",105)),(2,(2,"a",101)),(6,(6,"b",102)),(12,(12,"w",108)),(34,(34,"a",101)),(50,(50,"q",107))]
+-- Chain l4 l5 =  [(1,(1,"m",105)),(2,(2,"a",101)),(6,(6,"b",102)),(12,(12,"w",108)),(50,(50,"q",107))]
 -- Chain l5 l4 =  [("m",("m",105,"Z"))]
 
 -- =================== Some sample (Exp t) =============================
@@ -191,14 +200,15 @@ eval_tests =
       evalTest "m0" ((setSingleton 2) ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
       evalTest "m0" (dom (singleton 2 'z') ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
       evalTest "m0" (rng (singleton 'z' 2) ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
-      -- , evalTest "m0"  ((Map.fromList [(1,'a'),(2,'n'),(3,'r')]) ∪ (singleton 2 'b')) (Map.fromList[(1::Int,'a'),(2,'n'),(3,'r')])
-      --  , evalTest "m0"  ([(1,'a'),(3,'r')] ∪ (singleton 3 'b')) (UnSafeList[(1::Int,'a'),(2,'n'),(3,'r')])
+      evalTest "m0"  ((Map.fromList [(1,'a'),(2,'n'),(3,'r')]) ∪ (singleton 2 'b')) (Map.fromList[(1::Int,'a'),(2,'n'),(3,'r')]),
+      evalTest "m0"  ([(1,'a'),(3,'r')] ∪ (singleton 3 'b')) (UnSafeList[(1::Int,'a'),(3,'r')]),
 
       evalTest "m0" (70 ∉ (dom m1)) True,
       evalTest "((dom stkcred) ◁ deleg) ▷ (dom stpool)" (((dom stkcred) ◁ deleg) ▷ (dom stpool)) (Map.fromList [(5, 'F')]),
       evalTest "Range exclude 1" (l4 ⋫ Set.empty) (UnSafeList l4),
       evalTest "Range exclude 2" (l4 ⋫ Fail) (UnSafeList l4),
-      evalTest "Range exclude 3" (l4 ⋫ (Set.fromList ["m", "Z"])) (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "a"), (50, "q"), (51, "l")]),
+      evalTest "Range exclude 3" (l4 ⋫ (Set.fromList ["m", "Z"]))
+                                 (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "v"), (50, "q"), (51, "l")]),
       evalTest "DomExclude Union" ((z2 ⋪ z1) ∪ z3) z4,
       eval_compile (((dom stkcred) ◁ deleg) ▷ (dom stpool)),
       eval_compile (l4 ⋫ (Set.fromList ["m", "Z"])),
@@ -308,7 +318,12 @@ testChain nm rep1 rep2 =
   testcase
     nm
     (ChainD (fromListD rep1 l4) (fromListD rep2 l5) (lift (\x (y, v) -> (x, y, v))))
-    [(1, (1, "m", 105)), (2, (2, "a", 101)), (6, (6, "b", 102)), (12, (12, "w", 108)), (34, (34, "a", 101)), (50, (50, "q", 107))]
+    [(1, (1, "m", 105)), (2, (2, "a", 101)), (6, (6, "b", 102)), (12, (12, "w", 108)), (50, (50, "q", 107))]
+
+-- L14 = [(1,"m"),(5,"z"),(6,"b"),(7,"r"),(12,"w"),(34,"v"),(50,"q"),(51,"l"),(105,"Z")]
+-- L15 = [("a",101),("b",102),("c",103),("f",104),("m",105),("q",107),("s",106),("w",108),("y",109),("zz",110)]
+
+
 
 testChain2 :: (Iter f, Iter g) => String -> BaseRep f String Int -> BaseRep g Int String -> TestTree
 testChain2 nm rep1 rep2 =
@@ -378,10 +393,6 @@ iter_tests =
       testEpochEx
     ]
 
-setAlgTest :: TestTree
-setAlgTest =
-  testGroup "Set Algebra Tests" [eval_tests, keysEqTests, iter_tests, intersectDomPLeftTest,
-                                 ledgerStateTest, threeWayTest]
 
 intersect2ways :: Map Int Char -> Map Int String -> Char -> Bool
 intersect2ways delegs stake hk =
@@ -409,6 +420,237 @@ threeWay delegs stake hk =
 
 threeWayTest :: TestTree
 threeWayTest = testProperty "eval-materialize-intersectDom" threeWay
+
+
+-- ================================================
+-- slow property tests
+-- ================================================
+
+newtype Key = Key Int
+  deriving (Eq,Ord)
+
+instance Show Key where
+   show (Key n) = "k"++show n
+
+-- ----------------------------
+newtype Range = Range Int
+  deriving (Eq,Ord,Num)
+
+instance Show Range where
+  show (Range n) = show n
+
+instance Semigroup Range where (Range x) <> (Range y) = Range (x + y)
+instance Monoid Range where mempty = Range 0
+
+
+-- ===========================================================
+flip_rng :: (Ord b, Num b) => List a b -> List b b
+flip_rng (UnSafeList xs) = fromPairs (+) (map (\ (a,b) -> (b,b)) xs)
+
+bimap:: (Ord k,Ord v) => Map k v -> BiMap v k v
+bimap xs = biMapFromList (\ old new -> new) (Map.toList xs)
+
+duplicate :: Ord a => Set.Set a -> Map.Map a a
+duplicate s = foldr (\ a m -> Map.insert a a m) Map.empty s
+
+btest :: Exp Bool -> Property
+btest exp = (compute exp) === (runBoolExp exp)
+
+qtest :: (Ord key,Eq(f key a),Show(f key a)) => Exp (f key a) -> Property
+qtest exp =  (compute exp) === (run (compile exp))
+
+-- ======================================================
+
+slowFastEquiv :: TestTree
+slowFastEquiv = testGroup "slowFastEquiv" (map f many)
+  where f (prop,name) = testProperty name prop
+
+
+type STest =
+   Key ->             -- k
+   Range ->           -- v
+   Map Key Range ->   -- m1
+   Map Key Range ->   -- m2
+   Set.Set Key ->     -- s1
+   Set.Set Key ->     -- s2
+   Set.Set Range ->   -- rs
+   List Key Range ->  -- ls
+   Property
+
+many :: [(STest,String)]
+many =
+  [( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base SetR (Sett s1))), "slow1")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow2")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base SetR (Sett s1))), "slow3")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow4")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Singleton k v)), "slow5")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (SetSingleton k)), "slow6")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow7")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (RRestrict (Base MapR m1) (SetSingleton v))), "slow8")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))), "slow9")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (RExclude (Base MapR m1) (SetSingleton v))), "slow10")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (RExclude (Base MapR m1) (Base SetR (Sett rs)))), "slow11")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (DRestrict (SetSingleton k) (Base MapR m1))), "slow12")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (DRestrict (Base SetR (Sett s1)) (Base MapR m1))), "slow13")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (DExclude (SetSingleton k) (Base MapR m1))), "slow14")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Dom (DExclude (Base SetR (Sett s1)) (Base MapR m1))), "slow15")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Rng (Base SetR (Sett s1))), "slow16")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Rng (Singleton k v)), "slow17")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Rng (SetSingleton k)), "slow18")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Rng (Base MapR m1)), "slow19")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow21")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (SetSingleton k) (Base MapR m1)), "slow22")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Singleton k ()) (Base MapR m1)), "slow23")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Base MapR m2)) (Base MapR m1)), "slow24")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (RRestrict (Base MapR m1) (SetSingleton v))) (Base MapR m2)), "slow25")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))) (Base MapR m2)), "slow26")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow27")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow28")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base ListR ls)), "slow29")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Base MapR m1)) (Base ListR ls)), "slow30")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (SetSingleton k) (Base ListR ls)), "slow31")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Singleton k v)) (Base ListR ls)), "slow32")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Rng (Singleton k v)) (Base ListR (flip_rng ls))), "slow33")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (SetSingleton k) (Base MapR m1)), "slow35")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Singleton k v)) (Base MapR m1)), "slow36")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Rng (Singleton v k)) (Base MapR m1)), "slow37")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Base SetR (Sett s1)) (Base MapR m1)), "slow38")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Base MapR m1)) (Base MapR m2)), "slow39")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (SetSingleton k) (Base BiMapR (bimap m1))), "slow40")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Singleton k v)) (Base BiMapR (bimap m1))), "slow41")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Rng (Singleton v k)) (Base BiMapR (bimap m1))), "slow42")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (SetSingleton v)), "slow44")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (Dom (Singleton v k))), "slow45")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (Rng (Singleton k v))), "slow46")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base MapR m1) (Base SetR (Sett rs))), "slow47")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base MapR m1) (SetSingleton v)), "slow48")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base ListR ls) (Base SetR (Sett rs))), "slow49")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base ListR ls) (Base SingleR Fail)), "slow50")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (Base MapR m1) (SetSingleton v)), "slow52")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m1)) (Dom (Base MapR (duplicate rs)))), "slow53")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m2)) (Dom (Base ListR (flip_rng ls)))), "slow54")
+
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (Dom (Base ListR ls))), "slow56")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (Base SetR (Sett s1))), "slow57")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (Dom (Singleton k v))), "slow58")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (Rng (Singleton v k))), "slow59")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (SetSingleton k)), "slow60")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionOverrideLeft  (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow61")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow62")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionPlus          (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow63")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow64")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (DRestrict (Dom (Base SetR (Sett s1))) (Dom(Base MapR m1)))), "slow106")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Elem k (DExclude (Dom (Base SetR (Sett s1))) (Dom(Base MapR m1)))), "slow107")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Dom (Base ListR ls))), "slow66")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Base SetR (Sett s1))), "slow67")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Dom (Singleton k v))), "slow68")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Rng (Singleton v k))), "slow69")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (SetSingleton k)), "slow70")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionOverrideLeft  (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow71")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow72")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionPlus          (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow73")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow74")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow76")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Base MapR m1)), "slow77")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Dom (Base MapR m1))), "slow78")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Subset (Base MapR m1) (Base MapR m2)), "slow79")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (Subset (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow80")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow82")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Intersect (Base MapR m1) (Base MapR m2)), "slow83")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base ListR ls) (Singleton k v)), "slow85")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base MapR m1) (Base MapR m2)), "slow86")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow87")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (DExclude (SetSingleton k) (Base MapR m1)) (Base MapR m2)), "slow88")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m1)) (Base MapR m2)), "slow89")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base ListR ls) (Singleton k v)), "slow91")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base MapR m1) (Base MapR m2)), "slow92")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow93")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionPlus (Base MapR m1) (Base MapR m2)), "slow95")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow96")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (Singleton k v), "slow98")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetSingleton k), "slow99")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base MapR m1) (Base MapR m2)), "slow100")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base BiMapR (bimap m1)) (Base BiMapR (bimap m2))), "slow101")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow102")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Dom (Base BiMapR (bimap m1))) (Dom (Base BiMapR (bimap m2)))), "slow103")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow104")
+  ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base MapR m1) (Base SetR (Sett s1))), "slow105")
+
+  ]
+
+
+ints :: Gen Int
+ints = oneof $ map pure [1..12] :: Gen Int
+
+genKey :: Gen Key
+genKey = fmap Key ints
+
+genRange :: Gen Range
+genRange = fmap Range ints
+
+genSize :: Gen Int
+genSize = frequency [(1,return 0),(2,return 1),(5,return 2),(5, return 3),(4,return 4),(3,return 5),(2, return 6),(1, return 7)]
+
+genPair :: Gen k -> Gen v -> Gen (k,v)
+genPair k v = (,) <$> k <*> v
+
+genList :: Ord k => Gen k -> Gen v -> Gen (List k v)
+genList k v = do
+   n <- genSize
+   xs <- vectorOf n (genPair k v)
+   pure $ fromPairs (\ old new -> new) xs
+
+genMap :: Ord k => Gen k -> Gen v -> Gen (Map k v)
+genMap k v = do
+   n <- genSize
+   xs <- vectorOf n (genPair k v)
+   pure (Map.fromList xs)
+
+genSett :: Ord k => Gen k -> Gen (Sett k ())
+genSett k = do
+   n <- genSize
+   xs <- vectorOf n k
+   pure (Sett (Set.fromList xs))
+
+genBiMap :: (Ord k,Ord v) => Gen k -> Gen v -> Gen (Bimap k v)
+genBiMap k v = do
+   m <- genMap k v
+   pure(bimap m)
+
+instance Arbitrary Key where
+  arbitrary = genKey
+
+instance Arbitrary Range where
+  arbitrary = genRange
+
+instance Arbitrary (List Key Range) where
+  arbitrary = genList genKey genRange
+
+instance Arbitrary (Sett Key ()) where
+  arbitrary = genSett genKey
+
+-- ====================================================
+-- Tie all the tests together
+-- ====================================================
+
+setAlgTest :: TestTree
+setAlgTest =
+  testGroup "Set Algebra Tests" [eval_tests, keysEqTests, iter_tests, intersectDomPLeftTest,
+                                 ledgerStateTest, threeWayTest, slowFastEquiv]
 
 -- go :: IO()
 -- go = defaultMain setAlgTest

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
@@ -3,9 +3,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving  #-}
-
--- {-# OPTIONS_GHC -Wno-orphans #-}
--- {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -88,8 +85,6 @@ stkcred = Map.fromList [(5, "a"), (6, "q"), (12, "r")]
 deleg = Map.fromList [(n, chars !! n) | n <- [1 .. 10]]
 
 stpool = Map.fromList [('A', 99), ('C', 12), ('F', 42), ('R', 33), ('Z', 99)]
-
-
 
 --  ((txins txb ⋪ utxo) ∪ txouts txb)
 test33 :: () -> Exp (Map Int Char)


### PR DESCRIPTION
This is a follow on fro PR #1884, that fixed problems when queries slipped into slow-mode.
We added about 100 tests. Each test shows that a query computes the same thing in slow-mode and in fast-mode. The tests discovered a bunch of errors in the code. Fixed all the tests, and cleaned up the code.