### PR TITLE
TestPoolReap properties - lift to chain level and consolidate

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -21,8 +21,6 @@ import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
 import Test.Shelley.Spec.Ledger.Rules.TestChain
   ( adaPreservationChain,
     collisionFreeComplete,
-    constantSumPots,
-    nonNegativeDeposits,
     poolProperties,
     removedAfterPoolreap,
   )
@@ -93,17 +91,11 @@ propertyTests =
       testGroup
         "STS Rules - Poolreap Properties"
         [ TQC.testProperty
-            "circulation+deposits+fees+treasury+rewards+reserves is constant."
-            constantSumPots,
-          TQC.testProperty
-            "deposits are always non-negative"
-            nonNegativeDeposits,
-          TQC.testProperty
             "pool is removed from stake pool and retiring maps"
             removedAfterPoolreap
         ],
       testGroup
-        "STS Rules - NewEpoch Properties"
+        "CHAIN level Properties"
         [ TQC.testProperty
             "collection of Ada preservation properties"
             adaPreservationChain,


### PR DESCRIPTION
Closes #1843

There were 3 properties in TestPoolReap (tested on CHAIN traces projected down to POOLREAP traces)

* `constantSumPots` - REMOVED
  * this property is a duplicate of `TestChain.checkPreservation` (which was written later) with some small differences...
  * `checkPreservation` uses `totalAda` while `constantSumPots` spells out the same calculation as `balance u + d + fees + treasury + reserves + fold rewards`
  * `checkPreservation` uses CHAIN state directly, while `constantSumPots` was using the same state but as an extraction of POOLREAP state from CHAIN
* `nonNegativeDeposits` - MOVED TO TestChain
  * this property had nothing to do with POOLREAP and is now part of the collection of ada preservation properties in TestChain
* `removedAfterPoolreap` - stays in TestPoolReap, but streamlined
  * removed the need for the `chainToPoolreapSst` projection from CHAIN -> POOLREAP state
  * simplified `chainSstWithTick` (was manually applying the TICK rule, now using `tickChainState`)

`TestPoolReap` is now a bit awkward, with one property, I suggest we re-group all properties after the "lifting to CHAIN" is complete



