### PR TITLE
Formal spec typos - audit issue #1878

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -102,7 +102,7 @@ data DelegPredicateFailure era
   | StakeDelegationImpossibleDELEG
       !(Credential 'Staking era) -- Credential that is not registered
   | WrongCertificateTypeDELEG -- The DCertPool constructor should not be used by this transition
-  | GenesisKeyNotInpMappingDELEG
+  | GenesisKeyNotInMappingDELEG
       !(KeyHash 'Genesis era) -- Unknown Genesis KeyHash
   | DuplicateGenesisDelegateDELEG
       !(KeyHash 'GenesisDelegate era) -- Keyhash which is already delegated to
@@ -146,7 +146,7 @@ instance
       encodeListLen 2 <> toCBOR (3 :: Word8) <> toCBOR cred
     WrongCertificateTypeDELEG ->
       encodeListLen 1 <> toCBOR (4 :: Word8)
-    GenesisKeyNotInpMappingDELEG gkh ->
+    GenesisKeyNotInMappingDELEG gkh ->
       encodeListLen 2 <> toCBOR (5 :: Word8) <> toCBOR gkh
     DuplicateGenesisDelegateDELEG kh ->
       encodeListLen 2 <> toCBOR (6 :: Word8) <> toCBOR kh
@@ -185,7 +185,7 @@ instance
         pure (1, WrongCertificateTypeDELEG)
       5 -> do
         gkh <- fromCBOR
-        pure (2, GenesisKeyNotInpMappingDELEG gkh)
+        pure (2, GenesisKeyNotInMappingDELEG gkh)
       6 -> do
         kh <- fromCBOR
         pure (2, DuplicateGenesisDelegateDELEG kh)
@@ -244,8 +244,8 @@ delegationTransition = do
       let s' = slot +* Duration sp
           (GenDelegs genDelegs) = _genDelegs ds
 
-      -- gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG gkh
-      (case Map.lookup gkh genDelegs of Just _ -> True; Nothing -> False) ?! GenesisKeyNotInpMappingDELEG gkh
+      -- gkh ∈ dom genDelegs ?! GenesisKeyNotInMappingDELEG gkh
+      (case Map.lookup gkh genDelegs of Just _ -> True; Nothing -> False) ?! GenesisKeyNotInMappingDELEG gkh
 
       let cod =
             range $

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -66,7 +66,7 @@ The following derived types are introduced:
     \item the pool reward account.
     \item the hash of the VRF verification key.
     \item the pool relays.
-    \item optional pool medata (a url and a hash).
+    \item optional pool metadata (a url and a hash).
   \end{itemize}
   The idea of pool owners is explained in Section 4.4.4 of \cite{delegation_design}.
   The pool cost and margin indicate how much more of the rewards pool leaders
@@ -348,18 +348,13 @@ concerns are independent of the ledger rules.
   the equations in $\mathsf{DELEG}$ and $\mathsf{POOL}$ follow this same pattern
   of matching on certificate type.
 
-  There are also preconditions on registration that the hashkey associated with
+  There is also a precondition on registration that the hashkey associated with
   the certificate witness of the certificate is not already found in the current
-  list of stake credentials or the current reward accounts.
-  We expect that the stake credentials and the reward accounts contain the
-  same key hashes, making one of the checks redundant.
+  reward accounts (which is the source of truth for which stake credentials are registered).
 
     Registration causes the following state transformation:
     \begin{itemize}
-    \item The key is added to the set of registered stake credentials.
       \item A reward account is created for this key, with a starting balance of zero.
-        Note that \cref{eq:deleg-reg} uses a union override left to add
-        a zero balance reward account.
       \item The certificate pointer is mapped to the new stake credential.
     \end{itemize}
 
@@ -757,7 +752,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     change of current slot number in the environment), along with all other transitions
     that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
 
-    Reregistration causes the following state transformation:
+    Retirement causes the following state transformation:
     \begin{itemize}
       \item The pool is marked to retire on the given epoch.
         If it was previously retiring, the retirement epoch is now updated.


### PR DESCRIPTION
This PR fixes a few inconsistencies with the delegation section of the Shelley ledger formal spec, mostly prose that was incorrect due to removing the old `stkCreds` mapping.

closes  #1878