### PR TITLE
Fixing leader calculation equations

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/leader-value.tex
+++ b/shelley/chain-and-ledger/formal-spec/leader-value.tex
@@ -9,7 +9,7 @@ calculation.
   \emph{Values associated with the leader value calculations}
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-    \var{certNat} & \{n | n \in \N, n \in [0,2^{256})\} & \text{Certified natural value from VRF} \\
+    \var{certNat} & \{n | n \in \N, n \in [0,2^{512})\} & \text{Certified natural value from VRF} \\
     \var{f} & [0,1] & \text{Active slot coefficient} \\
     \sigma & [0,1] & \text{Stake proportion}
   \end{array}
@@ -18,8 +18,8 @@ calculation.
 
 \subsection{Computing the leader value}
 
-The verifiable random function gives us a 32-byte random output. We interpret
-this as a natural number $\var{certNat}$ in the range $[0,2^{256})$.
+The verifiable random function gives us a 64-byte random output. We interpret
+this as a natural number $\var{certNat}$ in the range $[0,2^{512})$.
 
 \subsection{Node eligibility}
 
@@ -42,7 +42,7 @@ of a single lovelace.)
 As such, we define the following:
 
 \begin{align*}
-  q & = \frac{2^{256}}{2^{256} - \var{certNat}} \\
+  q & = \frac{2^{512}}{2^{512} - \var{certNat}} \\
   c & = \ln{(1 - f)}
 \end{align*}
 


### PR DESCRIPTION
The leader calculations in the spec are not correct based on the code. In the below code, VRF.sizeOutputVRF == 64 which makes `certNatMax = 2^512`. I've confirmed with logging that the VRF.OutputVRF value that comes into this function is in-fact, 64 bytes long and not 32.

```
checkLeaderValue ::
  forall v.
  (VRF.VRFAlgorithm v) =>
  VRF.OutputVRF v ->
  Rational ->
  ActiveSlotCoeff ->
  Bool
checkLeaderValue certVRF σ f =
  if (intervalValue $ activeSlotVal f) == 1
    then -- If the active slot coefficient is equal to one,
    -- then nearly every stake pool can produce a block every slot.
    -- In this degenerate case, where ln (1-f) is not defined,
    -- we let the VRF leader check always succeed.
    -- This is a testing convenience, the active slot coefficient should not
    -- bet set above one half otherwise.
      True
    else case taylorExpCmp 3 recip_q x of
      ABOVE _ _ -> False
      BELOW _ _ -> True
      MaxReached _ -> False
  where
    certNatMax :: Natural
    certNatMax = (2 :: Natural) ^ (8 * VRF.sizeOutputVRF (Proxy @v))
    c, recip_q, x :: FixedPoint
    c = activeSlotLog f
    recip_q = (trace("certNat = " ++ show certNat ++ ", certNatMax = " ++ show certNatMax) $ fromRational (toInteger certNatMax % toInteger (certNatMax - certNat)))
    x = (- fromRational σ * c)
    certNat :: Natural
    certNat = VRF.getOutputVRFNatural certVRF
```