### PR TITLE
Add infrastructure for translations between eras

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
@@ -1,16 +1,28 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Support for multiple (Shelley-based) eras in the ledger.
 module Cardano.Ledger.Era
   ( Era,
     Crypto,
+    PreviousEra,
+    TranslateEra (..),
+    translateEra',
   )
 where
 
 import qualified Cardano.Ledger.Crypto as CryptoClass
+import Control.Monad.Except (Except, runExcept)
+import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
+import Data.Void (Void, absurd)
+
+--------------------------------------------------------------------------------
+-- Era
+--------------------------------------------------------------------------------
 
 class
   ( CryptoClass.Crypto (Crypto e),
@@ -19,3 +31,88 @@ class
   Era e
   where
   type Crypto e :: Type
+
+--------------------------------------------------------------------------------
+-- Era translation
+--------------------------------------------------------------------------------
+
+-- | Map an era to its predecessor.
+--
+-- For example:
+--
+-- > type instance PreviousEra (AllegraEra c) = ShelleyEra c
+type family PreviousEra era :: Type
+
+-- | Per-era context used for 'TranslateEra'.
+--
+-- This context will be passed to the translation instances of /all/ types of
+-- that particular era. In practice, most instances won't need the context, but
+-- this approach makes the translation composable (as opposed to having a
+-- separate context per type).
+type family TranslationContext era :: Type
+
+-- | Translation of types between eras, e.g., from Shelley to Allegra.
+--
+-- In most cases, an empty standalone deriving can be used:
+--
+-- > newtype KeyHash (discriminator :: KeyRole) era
+-- >   = KeyHash
+-- >       ( Hash.Hash
+-- >           (ADDRHASH (Crypto era))
+-- >           (DSIGN.VerKeyDSIGN (DSIGN (Crypto era)))
+-- >       )
+-- >
+-- > instance CryptoClass.Crypto c => TranslateEra (Allegra c) (KeyHash discriminator)
+--
+-- Note that one could use @DerivingAnyClass@ (@deriving (TranslateEra (Allegra
+-- c))@), but this would introduce an undesired coupling between the
+-- era-parametric type and (a) particular era(s). The intention is to have a
+-- module with orphan instances per era.
+--
+-- In some cases, e.g., when the keys of a @Map@ or @Set@ are parameterised by
+-- the era, a manual instance will have to be written:
+--
+-- > newtype GenDelegs era = GenDelegs
+-- >   { unGenDelegs :: Map (KeyHash 'Genesis era) (GenDelegPair era)
+-- >   }
+-- >
+-- > instance CryptoClass.Crypto c => TranslateEra (Allegra c) GenDelegs where
+-- >     translateEra _ctxt =
+-- >       return . GenDelegs . Map.fromList . coerce . Map.toList . unGenDelegs
+--
+-- Note: we use 'PreviousEra' instead of @NextEra@ as an era definitely knows
+-- its predecessor, but not necessarily its successor. Moreover, one could argue
+-- that it makes more sense to define the translation from era A to era B where
+-- era B is defined, than where era A is defined.
+class (Era era, Era (PreviousEra era)) => TranslateEra era f where
+  -- | Most translations should be infallible (default instance), but we leave
+  -- the door open for partial translations.
+  --
+  -- For a partial translation, override the default type to be '()' or a
+  -- concrete error type.
+  type TranslationError era f :: Type
+
+  type TranslationError era f = Void
+
+  -- | Translate a type @f@ parameterised by the era from an era to the era
+  -- after it.
+  --
+  -- The translation is a given the translation context of @era@.
+  --
+  -- A default instance is provided for when the two types are 'Coercible'.
+  translateEra :: TranslationContext era -> f (PreviousEra era) -> Except (TranslationError era f) (f era)
+  default translateEra ::
+    Coercible (f (PreviousEra era)) (f era) =>
+    TranslationContext era ->
+    f (PreviousEra era) ->
+    Except (TranslationError era f) (f era)
+  translateEra _ = return . coerce
+
+-- | Variant of 'translateEra' for when 'TranslationError' is 'Void' and the
+-- translation thus cannot fail.
+translateEra' ::
+  (TranslateEra era f, TranslationError era f ~ Void) =>
+  TranslationContext era ->
+  f (PreviousEra era) ->
+  f era
+translateEra' ctxt = either absurd id . runExcept . translateEra ctxt


### PR DESCRIPTION
This introduces the `TranslateEra` type class (see its documentation) for
translating era-parameterised types from an era to the era after it.

The consensus layer will use this class and its instances to translate the final
Shelley (ledger/protocol) state to the initial Allegra state (same for
Allegra/Mary and subsequent eras). But also to translate some configuration
data, e.g., the Shelley genesis config to the Allegra genesis
config (`ShelleyGenesis era`). We currently intend to keep the Shelley and
Allegra genesis config representationally equal, yet the era tag mentioned in
the two types is different, requiring a translation.

We allow for passing per-era context to the translation as well as choosing the
error type per era/type combination. For example, hash translation could be
total, but transaction translation could be partial, but both can use the same
infrastructure.

The goal is to have a module for Allegra and a module for Mary with a bunch of
empty (using the defaults) and non-empty standalone instances of this class.