### PR TITLE
Introduce 'MaryEra' and 'AllegraEra'

### DIFF
--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -2,10 +2,10 @@ cabal-version:       2.2
 
 name:                cardano-ledger-shelley-ma
 version:             0.1.0.0
-synopsis:            Shelley ledger with multiasset support.
+synopsis:            Shelley ledger with multiasset and time lock support.
 description:
   This package extends the Shelley ledger with support for
-  native tokens.
+  native tokens and timelocks.
 bug-reports:         https://github.com/input-output-hk/cardano-ledger-specs/issues
 license:             Apache-2.0
 author:              IOHK Formal Methods Team
@@ -20,9 +20,11 @@ source-repository head
 
 library
   exposed-modules:
-    Cardano.Ledger.ShelleyMA
+    Cardano.Ledger.Allegra
+    Cardano.Ledger.Mary
     Cardano.Ledger.ShelleyMA.Value
-  -- other-modules:
+  other-modules:
+    Cardano.Ledger.ShelleyMA
   -- other-extensions:
   build-depends:
     base >=4.9 && <4.15,

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Ledger.Allegra where
+
+import Cardano.Ledger.ShelleyMA
+
+type AllegraEra = ShelleyMAEra Allegra

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Ledger.Mary where
+
+import Cardano.Ledger.ShelleyMA
+
+type MaryEra = ShelleyMAEra Mary

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -17,7 +17,7 @@ data MaryOrAllegra = Mary | Allegra
 -- | The Shelley Mary/Allegra eras
 --
 -- Both eras are implemented within the same codebase, matching the formal
--- specification. They differ only in the `value` type. Due to some annoying
+-- specification. They differ only in the @value@ type. Due to some annoying
 -- issues with 'Coin' and 'Value' being of different kinds, we don't parametrise
 -- over the value but instead over a closed kind 'MaryOrAllegra'. But this
 -- should be transparent to the user.

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -1,12 +1,36 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.ShelleyMA where
 
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto
 import Cardano.Ledger.Era
+import Cardano.Ledger.ShelleyMA.Value (Value)
+import Data.Kind (Type)
+import Data.Typeable (Typeable)
+import Shelley.Spec.Ledger.Coin (Coin)
 
--- | The Shelley Multiasset era
-data ShelleyMA c
+data MaryOrAllegra = Mary | Allegra
 
-instance Cardano.Ledger.Crypto.Crypto c => Era (ShelleyMA c) where
-  type Crypto (ShelleyMA c) = c
+-- | The Shelley Mary/Allegra eras
+--
+-- Both eras are implemented within the same codebase, matching the formal
+-- specification. They differ only in the `value` type. Due to some annoying
+-- issues with 'Coin' and 'Value' being of different kinds, we don't parametrise
+-- over the value but instead over a closed kind 'MaryOrAllegra'. But this
+-- should be transparent to the user.
+data ShelleyMAEra (ma :: MaryOrAllegra) c
+
+instance
+  (Typeable ma, Cardano.Ledger.Crypto.Crypto c) =>
+  Era (ShelleyMAEra ma c)
+  where
+  type Crypto (ShelleyMAEra ma c) = c
+
+type family MAValue (x :: MaryOrAllegra) era :: Type where
+  MAValue Allegra era = Coin
+  MAValue Mary era = Value era
+
+type instance Core.Value (ShelleyMAEra m c) = MAValue m (ShelleyMAEra m c)

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -22,9 +22,8 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 
-type family Value era :: Type
-
 -- | A value is something which quantifies a transaction output.
+type family Value era :: Type
 
 --------------------------------------------------------------------------------
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -20,12 +20,12 @@ import Shelley.Spec.Ledger.Coin (Coin)
 -- Shelley Era
 --------------------------------------------------------------------------------
 
-data Shelley c
+data ShelleyEra c
 
-instance CryptoClass.Crypto c => Era (Shelley c) where
-  type Crypto (Shelley c) = c
+instance CryptoClass.Crypto c => Era (ShelleyEra c) where
+  type Crypto (ShelleyEra c) = c
 
-type instance Value (Shelley c) = Coin
+type instance Value (ShelleyEra c) = Coin
 
 type ShelleyBased era =
   ( Era era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -8,7 +8,7 @@ module Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation) whe
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Shelley.Spec.Ledger.API.ByronTranslation
 import Shelley.Spec.Ledger.Address
 import Shelley.Spec.Ledger.Coin
@@ -49,7 +49,7 @@ translateTxOutByronToShelley ::
   forall crypto.
   CryptoClass.Crypto crypto =>
   Byron.TxOut ->
-  TxOut (Shelley crypto)
+  TxOut (ShelleyEra crypto)
 translateTxOutByronToShelley (Byron.TxOut addr amount) =
   TxOut (translateAddr addr) (translateAmount amount)
   where


### PR DESCRIPTION
Addresses CAD-1999:

- Rename 'Shelley' to 'ShelleyEra'
- Add 'MaryEra' and 'AllegraEra'. These are both using the same codebase, but differ in the value type.