### PR TITLE
Get haskell-language-server working with c-l-s.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-09-15T00:00:00Z
+index-state: 2020-10-06T00:00:00Z
 
 packages:
   byron/chain/executable-spec
@@ -39,8 +39,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3376feb66f94e4a12ad0b51efa2f252cc7f52967
-  --sha256: 0m6f0m8dsyji1l4c4n8yr7axk8mljwfajk7qp07zaw5fzrsd4abf
+  tag: 53f963be6c4b19a6bb710f9fa5e34db1c5a33a01
+  --sha256: 06d21hbl800k018rpf9i8r83d7wjzfgsp3qj23k1mqr2031f55cc
 
 source-repository-package
   type: git

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,52 @@
+cradle:
+  cabal:
+    - path: "byron/chain/executable-spec/src"
+      component: "lib:byron-spec-chain"
+
+    - path: "byron/chain/executable-spec/test"
+      component: "byron-spec-chain:test:chain-rules-test"
+
+    - path: "byron/crypto/src"
+      component: "lib:cardano-crypto-wrapper"
+
+    - path: "byron/crypto/test/"
+      component: "lib:cardano-crypto-test"
+
+    - path: "byron/ledger/executable-spec/src"
+      component: "lib:byron-spec-ledger"
+
+    - path: "byron/ledger/executable-spec/test"
+      component: "byron-spec-ledger:test:byron-spec-ledger-test"
+
+    - path: "byron/ledger/impl/src"
+      component: "lib:cardano-ledger"
+
+    - path: "byron/ledger/impl/test"
+      component: "cardano-ledger:test:cardano-ledger-test"
+
+    - path: "semantics/executable-spec/src"
+      component: "lib:small-steps"
+
+    - path: "semantics/small-steps-test/src"
+      component: "lib:small-steps-test"
+
+    - path: "semantics/small-steps-test/test"
+      component: "small-steps-test:test:examples"
+
+    - path: "shelley/chain-and-ledger/dependencies/non-integer/src"
+      component: "lib:shelley-spec-non-integral"
+
+    - path: "shelley/chain-and-ledger/dependencies/non-integer/test"
+      component: "shelley-spec-non-integral:test:shelley-spec-non-integral-test"
+
+    - path: "shelley/chain-and-ledger/executable-spec/src"
+      component: "lib:shelley-spec-ledger"
+
+    - path: "shelley/chain-and-ledger/shelley-spec-ledger-test/src"
+      component: "lib:shelley-spec-ledger-test"
+
+    - path: "shelley/chain-and-ledger/shelley-spec-ledger-test/test"
+      component: "shelley-spec-ledger-test:test:shelley-spec-ledger-test"
+
+    - path: "shelley-ma/impl/src"
+      component: "lib:cardano-ledger-shelley-ma"

--- a/nix/haskell-extra.nix
+++ b/nix/haskell-extra.nix
@@ -1,0 +1,36 @@
+############################################################################
+# Extra Haskell packages which we build with haskell.nix, but which aren't
+# part of our project's package set themselves.
+#
+# Cribbed from https://github.com/input-output-hk/plutus/blob/master/nix/haskell-extra.nix
+############################################################################
+
+{ pkgs, index-state, checkMaterialization }:
+let compiler-nix-name = "ghc8102";
+in {
+  inherit (
+    let hspkgs = pkgs.haskell-nix.cabalProject {
+        src = pkgs.fetchFromGitHub {
+          name = "haskell-language-server";
+          owner = "haskell";
+          repo = "haskell-language-server";
+          rev = "0.5.0";
+          sha256 = "0vkh5ff6l5wr4450xmbki3cfhlwf041fjaalnwmj7zskd72s9p7p";
+          fetchSubmodules = true;
+        };
+        lookupSha256 = { location, tag, ... } : {
+          "https://github.com/bubba/brittany.git"."c59655f10d5ad295c2481537fc8abf0a297d9d1c" = "1rkk09f8750qykrmkqfqbh44dbx1p8aq1caznxxlw8zqfvx39cxl";
+          }."${location}"."${tag}";
+        inherit compiler-nix-name index-state checkMaterialization;
+        # Plan issues with the benchmarks, can try removing later
+        configureArgs = "--disable-benchmarks";
+        # Invalidate and update if you change the version
+        plan-sha256 = "1vyriqi905kl2yrx1xg04cy11wfm9nq1wswny7xm1cwv03gyj6y8";
+        modules = [{
+          # Tests don't pass for some reason, but this is a somewhat random revision.
+          packages.haskell-language-server.doCheck = false;
+        }];
+      };
+    in { haskell-language-server = hspkgs.haskell-language-server; hie-bios = hspkgs.hie-bios; })
+  hie-bios haskell-language-server;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c639cbe655725d6389b225af867cd413ca99c7d9",
-        "sha256": "0ri8w0s7925lpgq8jgijrgzwcpydx660mkskiqq02d3ac1lcq273",
+        "rev": "33cd29ee330d34c8c99a9ce56fb3529b44cf3224",
+        "sha256": "1jgwz2iahvn43w398aanm4djzjmr5a2hcv1ijzi9vh79circ7ffz",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/c639cbe655725d6389b225af867cd413ca99c7d9.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/33cd29ee330d34c8c99a9ce56fb3529b44cf3224.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "83109208047b07d5f0c103c87e6685c61c36a9f6",
-        "sha256": "1wfflfhd3jc8j49kgbvw0absvibkwm77wrjjc9ls8xkrcnprn4l7",
+        "rev": "774030b8dbefcdf13842a09a9f28c5bd762d8dc9",
+        "sha256": "16wjiwzhv6bxlnffqi669082l12a3k672811c8xfvcxh267sgvy3",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/83109208047b07d5f0c103c87e6685c61c36a9f6.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/774030b8dbefcdf13842a09a9f28c5bd762d8dc9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ormolu": {

--- a/scripts/haskell-language-server
+++ b/scripts/haskell-language-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#! nix-shell ../shell.nix -i bash
+
+haskell-language-server "$@"


### PR DESCRIPTION
haskell-language-server is the project which merges haskell-ide-engine
and ghcide, and is now looking pretty good. Sufficiently good that I
think it's now plausible to use it to replace a ghcid workflow.

This commit adds various things to support using it in cls:
- Updates the index state to one which contains haskell-language-server.
- Adds a nix expression in haskell-extra.nix to build it. This is
completely cribbed from the Plutus codebase.
- Update cardano-prelude to include a fix for a change in
base16-bytestring.
- Add a script which runs haskell-language-server with the appropriate
nix-shell.

The haskell-language-server page has some instructions for integration
with various editors: https://github.com/haskell/haskell-language-server#editor-integration

In my case, using vscode, I needed to alter the workspace settings to
set the haskell-language-server binary to
${workspaceFolder}/scripts/haskell-language-server.