### PR TITLE
CAD-1861: Abstract over TxBody

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -48,5 +48,8 @@ cradle:
     - path: "shelley/chain-and-ledger/shelley-spec-ledger-test/test"
       component: "shelley-spec-ledger-test:test:shelley-spec-ledger-test"
 
+    - path: "shelley/chain-and-ledger/shelley-spec-ledger-test/bench"
+      component: "shelley-spec-ledger-test:bench:mainbench"
+
     - path: "shelley-ma/impl/src"
       component: "lib:cardano-ledger-shelley-ma"

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.Core
   ( -- * Compactible
     Compactible (..),
     Compact (..),
+    TxBody,
     Value,
   )
 where
@@ -24,6 +25,9 @@ import Data.Typeable (Typeable)
 
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type
+
+-- | The body of a transaction.
+type family TxBody era :: Type
 
 --------------------------------------------------------------------------------
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -6,8 +6,8 @@
 
 module Cardano.Ledger.Shelley where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Core (Compactible (..), Value)
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
 import Cardano.Ledger.Val (Val)
@@ -15,6 +15,7 @@ import Control.DeepSeq (NFData)
 import Data.Typeable (Typeable)
 import NoThunks.Class (NoThunks)
 import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Hashing (HashAnnotated)
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -27,8 +28,18 @@ instance CryptoClass.Crypto c => Era (ShelleyEra c) where
 
 type instance Value (ShelleyEra c) = Coin
 
+type TxBodyConstraints era =
+  ( NoThunks (TxBody era),
+    Eq (TxBody era),
+    Show (TxBody era),
+    FromCBOR (Annotator (TxBody era)),
+    ToCBOR (TxBody era),
+    HashAnnotated (TxBody era) era
+  )
+
 type ShelleyBased era =
   ( Era era,
+    -- Value constraints
     Val (Value era),
     Compactible (Value era),
     Eq (Value era),
@@ -39,5 +50,6 @@ type ShelleyBased era =
     Show (Value era),
     ToCBOR (CompactForm (Value era)),
     ToCBOR (Value era),
-    Typeable (Value era)
+    Typeable (Value era),
+    TxBodyConstraints era
   )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -45,6 +45,7 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as WC
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (ADDRHASH, DSIGN)
 import Cardano.Ledger.Era
 import Cardano.Prelude (panic)
@@ -76,7 +77,7 @@ newtype ChainCode = ChainCode {unChainCode :: ByteString}
 
 data BootstrapWitness era = BootstrapWitness'
   { bwKey' :: !(VKey 'Witness era),
-    bwSig' :: !(Keys.SignedDSIGN era (Hash era (TxBody era))),
+    bwSig' :: !(Keys.SignedDSIGN era (Hash era (Core.TxBody era))),
     bwChainCode' :: !ChainCode,
     bwAttributes' :: !ByteString,
     bwBytes :: LBS.ByteString
@@ -89,7 +90,7 @@ data BootstrapWitness era = BootstrapWitness'
 pattern BootstrapWitness ::
   Era era =>
   (VKey 'Witness era) ->
-  (Keys.SignedDSIGN era (Hash era (TxBody era))) ->
+  (Keys.SignedDSIGN era (Hash era (Core.TxBody era))) ->
   ChainCode ->
   ByteString ->
   BootstrapWitness era
@@ -177,8 +178,8 @@ unpackByronVKey
 
 verifyBootstrapWit ::
   forall era.
-  (Era era, DSIGN.Signable (DSIGN (Crypto era)) (Hash era (TxBody era))) =>
-  Hash era (TxBody era) ->
+  (Era era, DSIGN.Signable (DSIGN (Crypto era)) (Hash era (Core.TxBody era))) =>
+  Hash era (Core.TxBody era) ->
   BootstrapWitness era ->
   Bool
 verifyBootstrapWit txbodyHash witness =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -78,6 +78,7 @@ import Cardano.Crypto.Util (SignableRepresentation (..))
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Era
 import Cardano.Ledger.Shelley (ShelleyBased)
+import qualified Cardano.Ledger.Shelley as Shelley
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
@@ -160,20 +161,25 @@ data TxSeq era = TxSeq'
     txSeqMetadataBytes :: BSL.ByteString
   }
   deriving (Generic)
-  deriving
-    (NoThunks)
-    via AllowThunksIn
-          '[ "txSeqBodyBytes",
-             "txSeqWitsBytes",
-             "txSeqMetadataBytes"
-           ]
-          (TxSeq era)
+
+deriving via
+  AllowThunksIn
+    '[ "txSeqBodyBytes",
+       "txSeqWitsBytes",
+       "txSeqMetadataBytes"
+     ]
+    (TxSeq era)
+  instance
+    ShelleyBased era => NoThunks (TxSeq era)
 
 deriving stock instance
   ShelleyBased era =>
   Show (TxSeq era)
 
-pattern TxSeq :: Era era => StrictSeq (Tx era) -> TxSeq era
+pattern TxSeq ::
+  (Era era, Shelley.TxBodyConstraints era) =>
+  StrictSeq (Tx era) ->
+  TxSeq era
 pattern TxSeq xs <-
   TxSeq' xs _ _ _
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -29,6 +29,7 @@ where
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.KES.Class (totalPeriodsKES)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH, KES)
 import Cardano.Ledger.Era
 import Cardano.Ledger.Shelley (ShelleyBased)
@@ -223,7 +224,7 @@ initialFundsPseudoTxIn addr =
       TxId
         . ( Crypto.castHash ::
               Crypto.Hash (HASH (Crypto era)) (Addr era) ->
-              Crypto.Hash (HASH (Crypto era)) (TxBody era)
+              Crypto.Hash (HASH (Crypto era)) (Core.TxBody era)
           )
         . Crypto.hashWith serialiseAddr
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -20,10 +20,8 @@ import Cardano.Crypto.DSIGN
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import Cardano.Crypto.VRF.Praos
-import Cardano.Ledger.Core (Value)
 import Cardano.Ledger.Crypto (Crypto (..))
 import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Era (Era (..))
 import Cardano.Slotting.Slot (EpochSize (..))
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra (dom, keysEqual, (▷), (◁))
@@ -76,6 +74,7 @@ import Test.Shelley.Spec.Ledger.BenchmarkFunctions
     ledgerStateWithNregisteredPools,
   )
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
+import Cardano.Ledger.Shelley (ShelleyEra)
 
 -- ==========================================================
 
@@ -88,12 +87,7 @@ instance CryptoClass.Crypto BenchCrypto where
   type HASH BenchCrypto = Blake2b_256
   type ADDRHASH BenchCrypto = Blake2b_224
 
-data BenchEra
-
-instance Era BenchEra where
-  type Crypto BenchEra = BenchCrypto
-
-type instance Value BenchEra = Coin
+type BenchEra = ShelleyEra BenchCrypto
 
 -- ============================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -29,9 +29,7 @@ where
 -- Cypto and Era stuff
 
 import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Val (Val (inject))
 import Control.State.Transition.Extended (TRC (..), applySTS)
 import qualified Data.Map as Map
@@ -107,14 +105,12 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
+import Cardano.Ledger.Shelley (ShelleyEra)
 
 -- ===============================================
 -- A special Era to run the Benchmarks in
 
-data B
-
-instance Era B where
-  type Crypto B = B_Crypto
+type B = ShelleyEra B_Crypto
 
 data B_Crypto
 
@@ -124,8 +120,6 @@ instance Cardano.Ledger.Crypto.Crypto B_Crypto where
   type DSIGN B_Crypto = DSIGN Original.C_Crypto
   type HASH B_Crypto = Blake2b_256
   type ADDRHASH B_Crypto = Blake2b_256
-
-type instance Core.Value B = Coin
 
 -- =========================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -17,12 +17,10 @@ import Cardano.Crypto.KES (MockKES)
 import qualified Cardano.Crypto.KES.Class as KES
 import Cardano.Crypto.Util (SignableRepresentation)
 import qualified Cardano.Crypto.VRF as VRF
-import Cardano.Ledger.Core (Value)
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Era
 import Shelley.Spec.Ledger.BaseTypes (Seed)
-import Shelley.Spec.Ledger.Coin (Coin)
 import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
+import Cardano.Ledger.Shelley (ShelleyEra)
 
 -- | Mocking constraints used in generators
 type Mock c =
@@ -43,10 +41,7 @@ type ExMock c =
     (VRF c) ~ FakeVRF
   )
 
-data C
-
-instance Era C where
-  type Crypto C = C_Crypto
+type C = ShelleyEra C_Crypto
 
 data C_Crypto
 
@@ -56,5 +51,3 @@ instance Cardano.Ledger.Crypto.Crypto C_Crypto where
   type DSIGN C_Crypto = MockDSIGN
   type KES C_Crypto = MockKES 10
   type VRF C_Crypto = FakeVRF
-
-type instance Value C = Coin

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.Iterate.SetAlgebra (dom, eval)
+import Control.State.Transition.Extended (BaseM, Environment, STS (Signal), State)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
 import Data.Coerce (coerce)
 import Data.Foldable (toList)
@@ -59,6 +60,7 @@ import Test.Shelley.Spec.Ledger.Utils
     slotFromEpoch,
     testGlobals,
   )
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 
 -- | Type alias for a transaction generator
 type TxGen era =
@@ -71,7 +73,19 @@ type TxGen era =
 -- | Generate a valid block.
 genBlock ::
   forall era.
-  (ShelleyTest era, Mock (Crypto era)) =>
+  ( ShelleyTest era,
+    STS (LEDGER era),
+    BaseM (LEDGER era) ~ ShelleyBase,
+    Environment (LEDGER era) ~ LedgerEnv era,
+    State (LEDGER era) ~ (UTxOState era, DPState era),
+    Signal (LEDGER era) ~ Tx era,
+    STS (LEDGERS era),
+    Mock (Crypto era),
+    BaseM (LEDGERS era) ~ ShelleyBase,
+    Environment (LEDGERS era) ~ LedgersEnv era,
+    State (LEDGERS era) ~ LedgerState era,
+    Signal (LEDGERS era) ~ Seq (Tx era)
+  ) =>
   GenEnv era ->
   ChainState era ->
   Gen (Block era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -45,24 +45,27 @@ import Test.Shelley.Spec.Ledger.Generator.Constants
   )
 import Test.Shelley.Spec.Ledger.Generator.Core
 import Test.Shelley.Spec.Ledger.Utils
-  ( MultiSigPairs,
-    ShelleyTest,
+  (ShelleyTest,  MultiSigPairs,
     maxKESIterations,
     mkKESKeyPair,
     mkVRFKeyPair,
     slotsPerKESIteration,
   )
+import qualified Cardano.Ledger.Shelley as Shelley
 
 -- | Example generator environment, consisting of default constants and an
 -- corresponding keyspace.
-genEnv :: Era era => proxy era -> GenEnv era
+genEnv :: Shelley.TxBodyConstraints era => proxy era -> GenEnv era
 genEnv _ =
   GenEnv
     (keySpace defaultConstants)
     defaultConstants
 
 -- | Example keyspace for use in generators
-keySpace :: Era era => Constants -> KeySpace era
+keySpace ::
+  (Shelley.TxBodyConstraints era) =>
+  Constants ->
+  KeySpace era
 keySpace c =
   KeySpace
     (coreNodeKeys c)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Orphans.hs
@@ -23,7 +23,6 @@ import Shelley.Spec.Ledger.STS.Chain
   ( ChainState (..),
   )
 import Shelley.Spec.Ledger.Tx (Tx (..))
-import Shelley.Spec.Ledger.TxBody (TxBody (..))
 import Shelley.Spec.Ledger.UTxO
   ( UTxO (..),
   )
@@ -45,8 +44,6 @@ deriving instance ShelleyBased era => Eq (EpochState era)
 deriving instance ShelleyBased era => Eq (LedgerState era)
 
 deriving instance ShelleyBased era => Eq (Tx era)
-
-deriving instance ShelleyBased era => Eq (TxBody era)
 
 deriving instance ShelleyBased era => Eq (Block era)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -112,14 +112,35 @@ import Shelley.Spec.Ledger.Keys
     pattern KeyPair,
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyPredicateFailure)
+import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainPredicateFailure)
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerPredicateFailure)
+import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersPredicateFailure)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
+import Shelley.Spec.Ledger.Tx (TxBody)
 import Test.Tasty.HUnit
   ( Assertion,
     (@?=),
   )
+import Shelley.Spec.Ledger.STS.Utxow (UtxowPredicateFailure, UTXOW)
+import Shelley.Spec.Ledger.STS.Utxo (UtxoPredicateFailure, UTXO)
+import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegPredicateFailure)
+import Shelley.Spec.Ledger.STS.Delegs (DELEGS, DelegsPredicateFailure)
 
-type ShelleyTest era = (ShelleyBased era, Core.Value era ~ Coin)
+type ShelleyTest era =
+  ( ShelleyBased era,
+    Core.Value era ~ Coin,
+    Core.TxBody era ~ TxBody era,
+    PredicateFailure (CHAIN era) ~ ChainPredicateFailure era,
+    PredicateFailure (LEDGERS era) ~ LedgersPredicateFailure era,
+    PredicateFailure (LEDGER era) ~ LedgerPredicateFailure era,
+    PredicateFailure (BBODY era) ~ BbodyPredicateFailure era,
+    PredicateFailure (DELEGS era) ~ DelegsPredicateFailure era,
+    PredicateFailure (DELEG era) ~ DelegPredicateFailure era,
+    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
+    PredicateFailure (UTXO era) ~ UtxoPredicateFailure era
+  )
 
 -- =======================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -23,9 +23,7 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Byron
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Era
 import Cardano.Ledger.Val ((<->))
 import Cardano.Prelude
   ( ByteString,
@@ -106,6 +104,7 @@ import Test.Tasty.HUnit
   ( Assertion,
   )
 import Test.Tasty.QuickCheck (testProperty, (===))
+import Cardano.Ledger.Shelley (ShelleyEra)
 
 bootstrapHashTest :: TestTree
 bootstrapHashTest = testProperty "rebuild the 'addr root' using a bootstrap witness" $
@@ -265,10 +264,7 @@ testBootstrapNotSpending =
     txBad
     (Left [[InvalidWitnessesUTXOW [aliceVKey]]])
 
-data C
-
-instance Era C where
-  type Crypto C = C_crypto
+type C = ShelleyEra C_crypto
 
 data C_crypto
 
@@ -278,5 +274,3 @@ instance Cardano.Ledger.Crypto.Crypto C_crypto where
   type DSIGN C_crypto = DSIGN.Ed25519DSIGN
   type HASH C_crypto = HASH Original.C_Crypto
   type ADDRHASH C_crypto = Hash.Blake2b_224
-
-type instance Core.Value C = Coin

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -40,6 +40,7 @@ module Test.Shelley.Spec.Ledger.Examples.Combinators
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
@@ -48,7 +49,10 @@ import Control.Iterate.SetAlgebra (eval, setSingleton, singleton, (∪), (⋪), 
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
 import Data.Word (Word64)
+import GHC.Records (HasField)
 import Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), (⭒))
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
@@ -91,7 +95,8 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
-import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..), TxBody (..))
+import Shelley.Spec.Ledger.Tx (TxIn, TxOut)
+import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
 
@@ -166,8 +171,11 @@ feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
 -- Update the UTxO for given transaction body.
 newUTxO ::
   forall era.
-  ShelleyBased era =>
-  TxBody era ->
+  ( ShelleyBased era,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+  ) =>
+  Core.TxBody era ->
   ChainState era ->
   ChainState era
 newUTxO txb cs = cs {chainNes = nes'}

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -10,6 +10,7 @@ module Test.Shelley.Spec.Ledger.Examples.EmptyBlock
 where
 
 import Cardano.Ledger.Era (Crypto (..))
+import qualified Cardano.Ledger.Shelley as Shelley
 import qualified Data.Map.Strict as Map
 import GHC.Stack (HasCallStack)
 import Shelley.Spec.Ledger.BaseTypes (Nonce)
@@ -48,8 +49,8 @@ initStEx1 = initSt (UTxO Map.empty)
 blockEx1 ::
   forall era.
   ( HasCallStack,
-    Era era,
-    ExMock (Crypto era)
+    ExMock (Crypto era),
+    Shelley.TxBodyConstraints era
   ) =>
   Block era
 blockEx1 =
@@ -66,7 +67,13 @@ blockEx1 =
     0
     (mkOCert (coreNodeKeysBySchedule ppEx 10) 0 (KESPeriod 0))
 
-blockNonce :: forall era. (HasCallStack, Era era, ExMock (Crypto era)) => Nonce
+blockNonce ::
+  forall era.
+  ( HasCallStack,
+    ExMock (Crypto era),
+    Shelley.TxBodyConstraints era
+  ) =>
+  Nonce
 blockNonce = getBlockNonce (blockEx1 @era)
 
 expectedStEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -103,7 +103,7 @@ initUTxO =
 initStMIR :: forall era. ShelleyTest era => Coin -> ChainState era
 initStMIR treasury = cs {chainNes = (chainNes cs) {nesEs = es'}}
   where
-    cs = initSt initUTxO
+    cs = initSt @era initUTxO
     as = esAccountState . nesEs . chainNes $ cs
     as' =
       as
@@ -227,13 +227,19 @@ mir1 pot =
 -- === Block 1, Slot 10, Epoch 0, Insufficient MIR Wits, Reserves Example
 --
 -- In the first block, submit a MIR cert drawing from the reserves.
-mirFailWits :: (ShelleyTest era, ExMock (Crypto era)) => MIRPot -> CHAINExample era
+mirFailWits ::
+  forall era.
+  ( ShelleyTest era,
+    ExMock (Crypto era)
+  ) =>
+  MIRPot ->
+  CHAINExample era
 mirFailWits pot =
   CHAINExample
     (initStMIR (Coin 1000))
     (blockEx1' insufficientMIRWits pot)
     ( Left
-        [ [ BbodyFailure
+        [ [ BbodyFailure @era
               ( LedgersFailure
                   ( LedgerFailure
                       ( UtxowFailure $

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -641,7 +641,7 @@ chainSstWithTick ledgerTr =
     applyTick sst@(SourceSignalTarget {source = chainSt, signal = block}) =
       let (Block bh _) = block
           slot = (bheaderSlotNo . bhbody) bh
-       in sst {target = tickChainState slot chainSt}
+       in sst {target = tickChainState @C slot chainSt}
 
 ----------------------------------------------------------------------
 -- Properties for PoolReap (using the CHAIN Trace) --

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -418,7 +419,7 @@ testSpendNonexistentInput =
 testWitnessNotIncluded :: Assertion
 testWitnessNotIncluded =
   let txbody =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 0])
           ( StrictSeq.fromList
               [ TxOut aliceAddr (Coin 6404),
@@ -431,7 +432,7 @@ testWitnessNotIncluded =
           (SlotNo 100)
           SNothing
           SNothing
-      tx = Tx txbody mempty SNothing
+      tx = Tx @C txbody mempty SNothing
       wits = Set.singleton (asWitness $ hashKey $ vKey alicePay)
    in testInvalidTx
         [ UtxowFailure $
@@ -443,7 +444,7 @@ testWitnessNotIncluded =
 testSpendNotOwnedUTxO :: Assertion
 testSpendNotOwnedUTxO =
   let txbody =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 1])
           (StrictSeq.singleton $ TxOut aliceAddr (Coin 232))
           Empty
@@ -465,7 +466,7 @@ testSpendNotOwnedUTxO =
 testWitnessWrongUTxO :: Assertion
 testWitnessWrongUTxO =
   let txbody =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 1])
           (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
           Empty
@@ -475,7 +476,7 @@ testWitnessWrongUTxO =
           SNothing
           SNothing
       tx2body =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 1])
           (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
           Empty
@@ -556,7 +557,7 @@ testExpiredTx =
 testInvalidWintess :: Assertion
 testInvalidWintess =
   let txb =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 0])
           ( StrictSeq.fromList
               [ TxOut aliceAddr (Coin 6000),
@@ -582,7 +583,7 @@ testInvalidWintess =
 testWithdrawalNoWit :: Assertion
 testWithdrawalNoWit =
   let txb =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 0])
           ( StrictSeq.fromList
               [ TxOut aliceAddr (Coin 6000),
@@ -607,7 +608,7 @@ testWithdrawalNoWit =
 testWithdrawalWrongAmt :: Assertion
 testWithdrawalWrongAmt =
   let txb =
-        TxBody
+        TxBody @C
           (Set.fromList [TxIn genesisId 0])
           ( StrictSeq.fromList
               [ TxOut aliceAddr (Coin 6000),


### PR DESCRIPTION
This PR makes the transaction body abstract and prepares for overriding
it in subsequent eras.

- TxBody is now a type family, instantiated in Shelley to the existing
TxBody type.
- A new "package" type TxBodyConstraints is introduced, which collects a
bunch of the "utility" instances (NoThunks, Eq, CBOR etc) for TxBody.
- Where we have specific dependencies on parts of the TxBody, we use
'HasField' constraints. This will allow a future 'TxBody' to define
these fields and continue to work. The cost is that we must be much more
explicit in terms of our requirements.

  One may ask why these are not done as part of `TxBodyConstraints`.
  There are two reasons - one prosaic (it would cause import cycles) and
  one principled - we already know that some of these are going to need
  to change in Allegra (txfee becomes optional), so packaging them
  together requires us to re-define these in future.
- Various of the STS infrastructure is now specific to `ShelleyEra`,
because at the point of declaring the STS instances we must be
monomorphic. These will therefore need to be redeclared for future eras.
- As yet, we do not introduce lenses for state modifications, since we
have not abstracted over any state, merely part of the signal (i.e. the
TxBody). So we instead fix the state, environment etc of subsystems.
- At present the API is still general, so could be used for future eras.
- The tests are updated with appropriate constraints that should allow
them to continue to be used for any Shelley-like era.