### PR TITLE
Use MemoBytes to abstract Types that store their own serialization bytes.

### DIFF
--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -24,9 +24,9 @@ library
     Cardano.Ledger.Mary
     Cardano.Ledger.ShelleyMA.Value
     Cardano.Ledger.ShelleyMA.ValueInternal
+    Cardano.Ledger.ShelleyMA.Timelocks
   other-modules:
     Cardano.Ledger.ShelleyMA
-    Cardano.Ledger.ShelleyMA.Timelocks
 
   -- other-extensions:
   build-depends:

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -149,7 +149,7 @@ import Shelley.Spec.Ledger.STS.Utxo as X
 import Shelley.Spec.Ledger.STS.Utxow as X (UTXOW)
 import Shelley.Spec.Ledger.Scripts as X
   ( MultiSig (..),
-    Script (..),
+    Script,
     ScriptHash (..),
   )
 import Shelley.Spec.Ledger.StabilityWindow as X

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MemoBytes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MemoBytes.hs
@@ -5,9 +5,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | MemoBytes is an abstration for a datetype that encodes its own seriialization.
@@ -17,12 +20,16 @@
 --   can be derived for free.
 module Shelley.Spec.Ledger.MemoBytes
   ( MemoBytes (..),
-    Symbolic (..),
-    (<@>),
-    (<#>),
+    Encode (..),
+    Decode (..),
+    Wrapped (..),
+    (!>),
+    (<!),
     Mem,
-    encodeSym,
-    runSym,
+    encode,
+    decode,
+    runE,
+    decodeClosed,
     memoBytes,
     shorten,
     decodeList,
@@ -47,6 +54,7 @@ import Cardano.Binary
     encodeWord,
     withSlice,
   )
+import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding)
 import Codec.CBOR.Write (toLazyByteString)
 import Data.ByteString.Lazy (toStrict)
@@ -58,8 +66,11 @@ import Data.Set (Set)
 import Data.Typeable
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
+import Shelley.Spec.Ledger.BaseTypes (invalidKey)
 import Shelley.Spec.Ledger.Serialization
   ( decodeList,
+    decodeRecordNamed,
+    decodeRecordSum,
     decodeSeq,
     decodeSet,
     decodeStrictSeq,
@@ -102,53 +113,209 @@ printMemo :: Show t => MemoBytes t -> IO ()
 printMemo x = putStrLn (showMemo x)
 
 -- ===============================================================================
--- A Symbolic encoding is a data structure from which 3 things can be recovered
--- Given:    x :: Symbolic t
+-- Encode and Decode are typed data structures which specify encoders and decoders.
+-- The types keep one from making mistakes, and count the correct number fields
+-- in an encoding and decoding. They are somewhat dual, and are designed that visual
+-- inspection of a Encode and its dual Decode can help the user conclude that the
+-- two are self-consistent. They are also reusable abstractions that can be defined
+-- once, and then used many places.
+--
+-- (Encode t) is a data structure from which 3 things can be recovered
+-- Given:    x :: Encode t
 -- 1) get a value of type t
--- 2) get an Encoding for that value. (Care must be taken that the tags are correct)
+-- 2) get an Encoding for that value, which correctly encodes the number of "fields"
+--    written to the ByteString. Care must still be taken that the tags are correct.
 -- 3) get a (MemoBytes t)
--- The advantage of using Symbolic with a MemoBytes, is we don't have to make a ToCBOR
+-- The advantage of using Encode with a MemoBytes, is we don't have to make a ToCBOR
 -- instance. Instead the "instance" is spread amongst the pattern constuctors by using
--- (memoBytes symbolic) in the where clause of the pattern contructor.
--- See some examples in the EXAMPLE Section below.
+-- (memoBytes encoding) in the where clause of the pattern contructor.
+-- See some examples of this see the file Timelocks.hs
+--
+-- The Encode and Decode mechanism can also be used to encode Algebraic datatypes
+-- in a uniform way. (Decode t) is dual to (Encode t). A decoder can be extracted
+-- from it. And it will consistently decode it's dual. We now give some examples.
+-- In the examples Let  Int and C have ToCBOR instances, and
+-- encodeB :: B -> Encoding, and decodeB :: Decoder s B
+{-
+-- An example with 1 constructor (a record) uses Rec and RecD
 
-data Symbolic t where
-  Con :: t -> Word -> Symbolic t
-  App :: ToCBOR a => Symbolic (a -> t) -> a -> Symbolic t
-  AppE :: Symbolic (a -> t) -> (a -> Encoding, a) -> Symbolic t
+data A = ACon Int B C
 
-infixl 5 <@>
+encodeA :: A -> Encode 'Closed A
+encodeA (ACon i b c) = Rec ACon !> To i !> E encodeB b !> To c
 
-infixl 5 <#>
+decodeA :: Decode 'Closed A
+decodeA = RecD ACon <! From <! D decodeB <! From
 
-(<@>) :: ToCBOR a => Symbolic (a -> t) -> a -> Symbolic t
-x <@> y = App x y
+instance ToCBOR A   where toCBOR x = encode(encodeA x)
+instance FromCBOR A where fromCBOR = decode decodeA
 
-(<#>) :: Symbolic (a -> t) -> (a -> Encoding, a) -> Symbolic t
-x <#> y = AppE x y
+-- An example with multiple constructors uses Sum, SumD, and Summands
 
-runSym :: Symbolic t -> t
-runSym (Con constr _tag) = constr
-runSym (App f x) = runSym f x
-runSym (AppE f (_e, x)) = runSym f x
+data M = M1 Int | M2 B Bool | M3 A
 
-encodeSym :: Symbolic t -> Encoding
-encodeSym sym = encodeHelp 1 sym
+encodeM :: M -> Encode 'Open M
+encodeM (M1 i)    = Sum M1 0 !> To i
+encodeM (M2 b tf) = Sum M2 1 !> E encodeB b  !> To tf
+encodeM (M3 a)    = Sum M3 2 !> To a
+
+decodeM :: Decode 'Closed M
+decodeM = Summands "M" decodeMx
+  where decodeMx 0 = SumD M1 <! From
+        decodeMx 1 = SumD M2 <! D decodeB <! From
+        decodeMx 3 = SumD M3 <! From
+        decodeMx k = Invalid k
+
+instance ToCBOR M   where toCBOR x = encode(encodeM x)
+instance FromCBOR M where fromCBOR = decode decodeM
+-}
+-- For more examples writing CBOR instances using Encode and Decode see the test file
+-- shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MemoBytes.hs
+
+-- ========================================================
+
+-- | Some CBOR instances wrap encoding sequences with prefixes and suffixes. I.e.
+--  prefix , encode, encode, encode , ... , suffix
+--  A type that MUST do this is called 'Open. Other types are called 'Closed.
+--  The point is that a Closed type may have a prefix, but it can still be 'inlined'
+--  by using the context it appears in, inside another Closed type. It does so by
+--  sharing the prefix of its containing type, and using positional context.
+--  In terms of Open and Closed, a datatype with more than one constructor is Open,
+--  and one with only one constructor is Closed (we call these records). Primitive
+--  types with no constructors can also be inlined, so we mark them as closed.
+data Wrapped = Open | Closed
+
+-- ===========================================================
+
+data Encode (w :: Wrapped) t where
+  Sum :: t -> Word -> Encode 'Open t
+  Rec :: t -> Encode 'Closed t
+  To :: ToCBOR a => a -> Encode 'Closed a
+  E :: (t -> Encoding) -> t -> Encode 'Closed t
+  ApplyE :: Encode w (a -> t) -> Encode 'Closed a -> Encode w t
+
+-- The Wrapped index of ApplyE is determined by the index
+-- at the bottom of its left spine. The LEFT arg of ApplyE
+-- must be a function type, and the only Encode with function
+-- types are (Sum c tag) and (Rec c). So if the leftmost spine
+-- is (Sum c tag) it is 'Open, and if is (Rec c) it is 'Closed.
+-- The RIGHT arg of ApplyE must be 'Closed. This allows us to
+-- inline anything in a RIGHT arg, supporting CBORGroup capability.
+
+infixl 4 !>
+
+(!>) :: Encode w (a -> t) -> Encode 'Closed a -> Encode w t
+x !> y = ApplyE x y
+
+runE :: Encode w t -> t
+runE (Sum c _) = c
+runE (Rec c) = c
+runE (ApplyE f x) = runE f (runE x)
+runE (To x) = x
+runE (E _ x) = x
+
+gsize :: Encode w t -> Word
+gsize (Sum _ _) = 0
+gsize (Rec _) = 0
+gsize (To _) = 1
+gsize (E _ _) = 1
+gsize (ApplyE f x) = gsize f + gsize x
+
+encode :: Encode w t -> Encoding
+encode sym = encodeCountPrefix 0 sym
   where
-    encodeHelp :: Word -> Symbolic t -> Encoding
-    encodeHelp n (Con _constr tag) = encodeListLen n <> encodeWord tag
-    encodeHelp n (App f x) = encodeHelp (n + 1) f <> toCBOR x
-    encodeHelp n (AppE f (encode, x)) = encodeHelp (n + 1) f <> encode x
+    encodeCountPrefix :: Word -> Encode w t -> Encoding
+    encodeCountPrefix n (Sum _ tag) = encodeListLen (n + 1) <> encodeWord tag
+    encodeCountPrefix n (Rec _) = encodeListLen n
+    -- n is the number of fields we must write in the prefx.
+    encodeCountPrefix _ (To x) = toCBOR x
+    encodeCountPrefix _ (E enc x) = enc x
+    encodeCountPrefix n (ApplyE f x) =
+      encodeCountPrefix (n + gsize x) f <> encodeClosed x
+    -- The RIGHT arg may be any 'Closed Encode, and is inlined
+    -- by design. Its left spine must end in a (Rec c). We count (gsize x)
+    -- the 'fields' in x, and add them to the number things we
+    -- must add to the prefix of the enclosing type.
 
-memoBytes :: Symbolic t -> MemoBytes t
-memoBytes t = Memo (runSym t) (shorten (toLazyByteString (encodeSym t)))
+    encodeClosed :: Encode 'Closed t -> Encoding
+    -- encodeClosed (Sum _ _) -- By design this case is unreachable by type considerations.
+    encodeClosed (Rec _) = mempty
+    encodeClosed (To x) = toCBOR x
+    encodeClosed (E enc x) = enc x
+    encodeClosed (ApplyE f x) = encodeClosed f <> encodeClosed x
+
+memoBytes :: Encode w t -> MemoBytes t
+memoBytes t = Memo (runE t) (shorten (toLazyByteString (encode t)))
+
+-- =====================
+
+data Decode (w :: Wrapped) t where
+  Summands :: String -> (Word -> Decode 'Open t) -> Decode 'Closed t
+  SumD :: t -> Decode 'Open t
+  RecD :: t -> Decode 'Closed t
+  From :: FromCBOR t => Decode 'Closed t
+  D :: (forall s. Decoder s t) -> Decode 'Closed t
+  ApplyD :: Decode w (a -> t) -> Decode 'Closed a -> Decode w t
+  Invalid :: Word -> Decode w t
+  Map :: (a -> b) -> Decode w a -> Decode w b
+
+infixl 4 <!
+
+(<!) :: Decode w (a -> t) -> Decode 'Closed a -> Decode w t
+x <! y = ApplyD x y
+
+hsize :: Decode w t -> Int
+hsize (Summands _ _) = 1
+hsize (SumD _) = 0
+hsize (RecD _) = 0
+hsize From = 1
+hsize (D _) = 1
+hsize (ApplyD f x) = hsize f + hsize x
+hsize (Invalid _) = 0
+hsize (Map _ x) = hsize x
+
+decode :: Decode w t -> Decoder s t
+decode x = fmap snd (decodE x)
+
+decodE :: Decode w t -> Decoder s (Int, t)
+decodE x = decodeCount x 0
+
+decodeCount :: Decode w t -> Int -> Decoder s (Int, t)
+decodeCount (Summands nm f) n = (n + 1,) <$> decodeRecordSum nm (\x -> decodE (f x))
+decodeCount (SumD c) n = pure (n + 1, c)
+decodeCount (RecD c) n = decodeRecordNamed "RecD" (const n) (pure (n, c))
+decodeCount From n = do x <- fromCBOR; pure (n, x)
+decodeCount (D dec) n = do x <- dec; pure (n, x)
+decodeCount (ApplyD c g) n = do
+  (i, f) <- decodeCount c (n + hsize g)
+  y <- decodeClosed g
+  pure (i, f y)
+decodeCount (Invalid k) _ = invalidKey k
+decodeCount (Map f x) n = do (m, y) <- decodeCount x n; pure (m, f y)
+
+decodeClosed :: Decode 'Closed t -> Decoder s t
+decodeClosed (Summands nm f) = decodeRecordSum nm (\x -> decodE (f x))
+-- decodeClosed (SumD _) = undefined -- This case, by design, is unreachable by type considerations
+decodeClosed (RecD c) = pure c
+decodeClosed From = do x <- fromCBOR; pure x
+decodeClosed (D dec) = do x <- dec; pure x
+decodeClosed (ApplyD c g) = do
+  f <- decodeClosed c
+  y <- decodeClosed g
+  pure (f y)
+decodeClosed (Invalid k) = invalidKey k
+decodeClosed (Map f x) = f <$> decodeClosed x
+
+instance Functor (Decode w) where
+  fmap f (Map g x) = Map (f . g) x
+  fmap f x = Map f x
 
 -- ===========================================================================================
--- These functions are the analogs to
+-- These functions are the dual analogs to
 -- Shelley.Spec.Ledger.Serialization(decodeList, decodeSeq, decodeStrictSeq, decodeSet)
 -- It is not well documented how to use encodeFoldable.
--- They are provided here as compatible pairs for use with the symbolic constructor AppE (<#>)
--- If we use decodeX in the fromCBOR we must use encodeX in the ToCOBOR or (Symbolic t) values
+-- They are provided here as compatible pairs for use with the (E x) and (D x) constructors
+-- of the Encode and Decode types. (E encodeList xs) and (D (decodeList fromCBOR)) should be duals.
 
 encodeList :: ToCBOR a => [a] -> Encoding
 encodeList = encodeFoldable

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
@@ -142,7 +142,7 @@ decodeRecordNamed name getRecordSize decode = do
   lenOrIndef <- decodeListLenOrIndef
   x <- decode
   case lenOrIndef of
-    Just n -> matchSize name (getRecordSize x) n
+    Just n -> matchSize (Text.pack "\nRecord " <> name) n (getRecordSize x)
     Nothing -> do
       isBreak <- decodeBreakOr
       unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
@@ -154,7 +154,7 @@ decodeRecordSum name decode = do
   tag <- decodeWord
   (size, x) <- decode tag -- we decode all the stuff we want
   case lenOrIndef of
-    Just n -> matchSize (Text.pack (name ++ " tag=" ++ show size)) size n
+    Just n -> matchSize (Text.pack ("\nSum " ++ name ++ "\nreturned=" ++ show size ++ " actually read= " ++ show n)) size n
     Nothing -> do
       isBreak <- decodeBreakOr -- if there is stuff left, it is unnecessary extra stuff
       unless isBreak $ cborError $ DecoderErrorCustom (Text.pack name) "Excess terms in array"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -702,12 +702,6 @@ instance
   where
   arbitrary = sizedMultiSig maxMultiSigDepth
 
-instance
-  (Era era, Mock (Crypto era)) =>
-  Arbitrary (Script era)
-  where
-  arbitrary = MultiSigScript <$> arbitrary
-
 -- |
 -- Generate a byte string of a given size.
 genByteString :: Int -> Gen BS.ByteString

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MemoBytes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MemoBytes.hs
@@ -1,37 +1,44 @@
-
+{-# LANGUAGE LambdaCase  #-}
+{-# LANGUAGE  FlexibleContexts  #-}
+{-# LANGUAGE DataKinds #-}
 
 module Test.Shelley.Spec.Ledger.MemoBytes
   ( memoBytesTest,
+    testT,
   )
 where
 
-import Data.Sequence.Strict (StrictSeq,fromList)
-import qualified Data.ByteString.Lazy as Lazy
-import Shelley.Spec.Ledger.MemoBytes
-import Shelley.Spec.Ledger.BaseTypes (invalidKey)
-import Shelley.Spec.Ledger.Serialization( decodeRecordSum )
 import Cardano.Binary
   ( FromCBOR (fromCBOR),
     ToCBOR (toCBOR),
     encodeListLen,
     encodeWord,
+    Annotator(..),
+    FullByteString(Full),
   )
+import Cardano.Ledger.ShelleyMA.Timelocks
+import Cardano.Slotting.Slot (SlotNo (..))
+import Codec.CBOR.FlatTerm(TermToken,toFlatTerm)
 import Codec.CBOR.Read(DeserialiseFailure,deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
-
+import qualified Data.ByteString.Lazy as Lazy
+import Data.Sequence.Strict (StrictSeq,fromList)
+import Shelley.Spec.Ledger.MemoBytes
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing),invalidKey)
+import Shelley.Spec.Ledger.Serialization( decodeRecordSum )
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes(C)
 import Test.Tasty
 import Test.Tasty.QuickCheck hiding (scale)
 
-
-data TT = A Int | B Int Bool | C [Int] | D (StrictSeq Bool) deriving (Show)
+data TT = A Int | B Int Bool | G [Int] | H (StrictSeq Bool) deriving (Show)
 
 instance FromCBOR TT where
   fromCBOR = decodeRecordSum "TT" $
     \n -> case n of
       0 -> do i <- fromCBOR; pure (2, A i)                  -- Tag for A is 0
       1 -> do i <- fromCBOR; b <- fromCBOR; pure (3, B i b) -- Tag for B is 1
-      2 -> do l <- decodeList fromCBOR; pure (2, C l)       -- Tag for C is 2
-      3 -> do i <- decodeStrictSeq fromCBOR; pure (2, D i)  -- Tag for D is 3
+      2 -> do l <- decodeList fromCBOR; pure (2, G l)       -- Tag for G is 2
+      3 -> do i <- decodeStrictSeq fromCBOR; pure (2, H i)  -- Tag for H is 3
       k -> invalidKey k
 
 -- =============================================================================================
@@ -43,45 +50,216 @@ instance FromCBOR TT where
 -- but the decoder (decodeList fromCBOR) will recognize both styles of encoding. So in a decoder
 -- or FromCBOR instance it is always preferable to use (decodeList fromCBOR) over (fromCBOR)
 -- For example in the instance above, we could write either of these 2 lines
---       2 -> do { l <- decodeList fromCBOR; pure(2,C l) }
---       2 -> do { l <- fromCBOR; pure(2,C l) }
+--       2 -> do { l <- decodeList fromCBOR; pure(2,G l) }
+--       2 -> do { l <- fromCBOR; pure(2,G l) }
 -- BUT THE FIRST IS MORE GENERAL. The following instance should be replaced
 -- instance FromCBOR a => FromCBOR [a]  -- Defined in ‘cardano-binary-1.5.0:Cardano.Binary.FromCBOR’
 
 instance ToCBOR TT where
   toCBOR (A i) = encodeListLen 2 <> encodeWord 0 <> toCBOR i
   toCBOR (B i b) = encodeListLen 3 <> encodeWord 1 <> toCBOR i <> toCBOR b
-  toCBOR (C is) = encodeListLen 2 <> encodeWord 2 <> toCBOR is
-  toCBOR (D bs) = encodeListLen 2 <> encodeWord 3 <> encodeStrictSeq bs
+  toCBOR (G is) = encodeListLen 2 <> encodeWord 2 <> toCBOR is
+  toCBOR (H bs) = encodeListLen 2 <> encodeWord 3 <> encodeStrictSeq bs
 
--- The Key is that in (C constr tag <@> ...)
+-- The Key is that in (G constr tag <@> ...)
 -- The 'tag' for 'constr' aligns with the Tag in the case match
 -- in the FromCBOR instance for TT above.
 
-sA, sB, sC, sCa, sD :: Symbolic TT
-sA = Con A 0 <@> 7                                            -- Tag for A is 0
-sB = Con B 1 <@> 13 <@> True                                  -- Tag for B is 1
-sC = Con C 2 <@> [3, 4, 5]                                    -- Tag for C is 2
-sCa = Con C 2 <#> (encodeList, [2, 5])                        -- Tag for C is 2
-sD = Con D 3 <#> (encodeStrictSeq, fromList [False, True])    -- Tag for D is 3
+sA, sB, sG, sGa, sH :: Encode 'Open TT
+sA  = Sum A 0 !> To 7                                        -- Tag for A is 0
+sB  = Sum B 1 !> To 13 !> To True                            -- Tag for B is 1
+sG  = Sum G 2 !> To  [3, 4, 5]                               -- Tag for G is 2
+sGa = Sum G 2 !> E encodeList [2, 5]                         -- Tag for G is 2
+sH =  Sum H 3 !> E encodeStrictSeq (fromList [False, True])    -- Tag for H is 3
 
-testSym ::
+-- ===============================================================
+
+-- ===================================
+-- Examples
+
+data Two = Two Int Bool
+  deriving Show
+
+decTwo :: Decode 'Closed Two
+encTwo :: Two -> Encode 'Closed Two
+
+decTwo           = (RecD Two <! From <! From)
+encTwo (Two a b) = (Rec Two  !> To a !> To b)
+
+instance ToCBOR Two where
+  toCBOR two = encode $ encTwo two
+
+instance FromCBOR Two where
+  fromCBOR = decode decTwo
+
+-- ============
+
+data Test = Test Int Two Integer
+  deriving Show
+
+test1 :: Test
+test1 = Test 3 (Two 9 True) 33
+
+decTestWithGroupForTwo :: Decode 'Closed Test
+encTestWithGroupForTwo :: Test -> Encode 'Closed Test
+
+decTestWithGroupForTwo =              (RecD Test <! From <! decTwo   <! From)
+encTestWithGroupForTwo (Test a b c) = (Rec Test  !> To a !> encTwo b !> To c)
+
+instance ToCBOR Test where
+  toCBOR = encode . encTestWithGroupForTwo
+
+instance FromCBOR Test where
+  fromCBOR = decode decTestWithGroupForTwo
+
+-- ===========
+
+data Three = M Int | N Bool Integer | F Two
+  deriving Show
+
+three1, three2 , three3 :: Three
+three1 = M 7
+three2 = N True 22
+three3 = F (Two 1 False)
+
+-- The following values 'decThree' and 'encThree' are meant to simulate the following instances
+{-
+instance ToCBOR Three where
+  toCBOR (M x) = encodeListLen 2 <> encodeWord 0 <> toCBOR x
+  toCBOR (N b i) = encodeListLen 3 <> encodeWord 1 <> toCBOR b <> toCBOR i
+  toCBOR (F (Two i b)) = encodeListLen 3 <> encodeWord 2 <> toCBOR i <>  toCBOR b
+     -- even though F has only 1 argument, we inline the two parts of Two,
+     -- so it appears to have 2 arguments. This mimics CBORGROUP instances
+
+
+instance FromCBOR Three where
+  fromCBOR = decodeRecordSum "Three" $
+    \case
+      0 -> do
+        x <- fromCBOR
+        pure (2, M x)
+      1 -> do
+        b <- fromCBOR
+        i <- fromCBOR
+        pure (3, N b i)
+      2 -> do
+        i <- fromCBOR
+        b <- fromCBOR
+        pure (3,F (Two i b))
+      k -> invalidKey k
+-}
+
+decThree :: Word -> Decode 'Open Three
+decThree 0 = (SumD M <! From)
+decThree 1 = (SumD N <! From <! From)
+decThree 2 = (SumD F <! decTwo)
+decThree k = Invalid k
+
+encThree :: Three -> Encode 'Open Three
+encThree (M x)   = (Sum M 0) !> To x
+encThree (N b i) = (Sum N 1) !> To b !> To i
+encThree (F t)   = (Sum F 2) !> encTwo t
+
+
+instance FromCBOR Three where
+   fromCBOR = decode (Summands "Three" decThree)
+
+
+instance ToCBOR Three where
+   toCBOR x = encode (encThree x)
+
+
+-- ================================================================
+-- In this test we nest many Records, and flatten out everything
+
+data Big = Big Int Bool Integer deriving Show
+data Bigger = Bigger Test Two Big  deriving Show
+
+bigger :: Bigger
+bigger = Bigger (Test 2 (Two 4 True) 99) (Two 7 False) (Big 5 False 102)
+
+-- Note there are 9 individual items, each which fits in one CBOR Token
+-- So we expect the encoding to have 10 items, 1 prefix and 9 others
+
+biggerItems :: [ TermToken ]
+biggerItems = toFlatTerm (encode (encBigger bigger))
+
+decBigger :: Decode 'Closed Bigger
+decBigger = RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From) <!
+                           (RecD Two <! From <! From) <!
+                           (RecD Big <! From <! From <! From)
+
+encBigger :: Bigger -> Encode 'Closed Bigger
+encBigger (Bigger (Test a (Two b c) d) (Two e f) (Big g h i)) =
+            Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c ) !> To d) !>
+                          (Rec Two !> To e !> To f) !>
+                          (Rec Big !> To g !> To h !> To i)
+
+instance ToCBOR Bigger where
+  toCBOR = encode .encBigger
+
+instance FromCBOR Bigger where
+  fromCBOR = decode decBigger
+
+
+
+-- ================================================================
+
+s1 :: Timelock C
+s1 = Interval (SJust (SlotNo 12)) SNothing
+
+s2 :: Timelock C
+s2 = Interval (SJust (SlotNo 12)) (SJust(SlotNo 23))
+
+s4 :: Timelock C
+s4 = TimelockAnd (fromList [s1,s2])
+
+
+-- ================================================================
+
+testEncode ::
   (FromCBOR t) =>
-  Symbolic t ->
+  Encode w t ->
   Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
-testSym s = deserialiseFromBytes fromCBOR (toLazyByteString (encodeSym s))
+testEncode s = deserialiseFromBytes fromCBOR (toLazyByteString (encode s))
 
-deCodeTest :: (FromCBOR t, Show t) => Symbolic t -> TestTree
-deCodeTest sym = testProperty ("Decoding "++show(runSym sym)) $
-                    case testSym sym of
+testT :: (ToCBOR t,FromCBOR t) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
+testT s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
+
+testAnn :: (ToCBOR t,FromCBOR (Annotator t)) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
+testAnn s = let bytes = (toLazyByteString (toCBOR s))
+            in case deserialiseFromBytes fromCBOR bytes of
+                Left err -> Left err
+                Right(leftover,Annotator f) -> Right(leftover,f (Full bytes))
+
+
+deCodeTest :: (FromCBOR t, Show t) => String -> Encode w t -> TestTree
+deCodeTest name sym =
+   testProperty (name++": Decoding "++show(runE sym)) $
+     case testEncode sym of
+       Right _ -> True
+       Left s -> error ("Fail to decode "++show(runE sym)++" with error "++show s)
+
+annTest :: (FromCBOR (Annotator t), ToCBOR t,Show t) => String -> t -> TestTree
+annTest nm t = testProperty ("RoundTrip: "++nm) $
+                    case testAnn t of
                       Right _ -> True
-                      Left s -> error ("Fail to decode "++show(runSym sym)++" with error "++show s)
+                      Left s -> error ("Fail to roundtrip "++show t++" with error "++show s)
 
 memoBytesTest :: TestTree
 memoBytesTest = testGroup "MemoBytesTest"
-    [ deCodeTest sA,
-      deCodeTest sB,
-      deCodeTest sC,
-      deCodeTest sCa,
-      deCodeTest sD
+    [ deCodeTest "sA" sA,
+      deCodeTest "sB" sB,
+      deCodeTest "sG" sG,
+      deCodeTest "sGA" sGa,
+      deCodeTest "sH" sH,
+      deCodeTest "Three1" (encThree three1),
+      deCodeTest "Three2" (encThree three2),
+      deCodeTest "Three3" (encThree three3),
+      deCodeTest "test1"  (encTestWithGroupForTwo test1),
+      testProperty "encode Bigger is compact" (length biggerItems === 10),
+      deCodeTest "Bigger inlines" (encBigger bigger),
+      annTest ("s1 "++showTimelock s1) s1,
+      annTest ("s2 "++showTimelock s2) s2,
+      annTest ("s4 "++showTimelock s4) s4
     ]


### PR DESCRIPTION
We use the MemoBytes tools to replace the definition of MultiSig in Script.hs.
A simple PR to show the usefulness of this approach. If people approve can can
simplify other types that store their own serialization bytes.

In the MemoBytes tool set, we improved the Encode and Decode types, so that one
cannot encode schemes that cannot be inlined. We added many new tests to the
MemoBytes test file, including deeply nested inlining.