### PR TITLE
Formal Spec - correct chainChecks and positional arguments in NewEpochState and EpochState

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -430,7 +430,11 @@ data EpochState era = EpochState
     esLState :: !(LedgerState era),
     esPrevPp :: !(PParams era),
     esPp :: !(PParams era),
-    esNonMyopic :: !(NonMyopic era) -- TODO document this in the formal spec, see github #1319
+    esNonMyopic :: !(NonMyopic era)
+    -- ^ This field, esNonMyopic, does not appear in the formal spec
+    -- and is not a part of the protocol. It is only used for providing
+    -- data to the stake pool ranking calculation @getNonMyopicMemberRewards@.
+    -- See https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.pool-ranking/latest/download-by-type/doc-pdf/pool-ranking
   }
   deriving (Generic)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -430,11 +430,11 @@ data EpochState era = EpochState
     esLState :: !(LedgerState era),
     esPrevPp :: !(PParams era),
     esPp :: !(PParams era),
-    esNonMyopic :: !(NonMyopic era)
-    -- ^ This field, esNonMyopic, does not appear in the formal spec
+    -- | This field, esNonMyopic, does not appear in the formal spec
     -- and is not a part of the protocol. It is only used for providing
     -- data to the stake pool ranking calculation @getNonMyopicMemberRewards@.
     -- See https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.pool-ranking/latest/download-by-type/doc-pdf/pool-ranking
+    esNonMyopic :: !(NonMyopic era)
   }
   deriving (Generic)
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1809,10 +1809,10 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
       &
       \begin{array}{lr@{~=~}l}
         \where
-          & (\wcard,~\wcard,~\wcard,~\wcard,~\var{es},~\wcard,~\wcard)
+          & (\wcard,~\wcard,~\wcard,~\var{es},~\wcard,~\wcard)
           & \var{nes}
           \\
-          & (\wcard,~\wcard,~\var{ls},~\wcard)
+          & (\wcard,~\wcard,~\var{ls},~\wcard,~\wcard)
           & \var{es}
           \\
           & (\wcard,~((\wcard,~\wcard,~\wcard,~\wcard,~\var{genDelegs},~\wcard),~\wcard))
@@ -1823,12 +1823,12 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \begin{align*}
       & \fun{updateNES} \in \NewEpochState \to \BlocksMade \to \LState \to \NewEpochState \\
       & \fun{updateNES}~
-      (\var{e_\ell},~\var{b_{prev}},~\wcard,~(\var{acnt},~\var{ss},~\wcard,~\var{pp}),
+      (\var{e_\ell},~\var{b_{prev}},~\wcard,~(\var{acnt},~\var{ss},~\wcard,~\var{prevPp},~\var{pp}),
        ~\var{ru},~\var{pd})
           ~\var{b_{cur}}~\var{ls} = \\
       & ~~~~
       (\var{e_\ell},~\var{b_{prev}},~\var{b_{cur}},
-       ~(\var{acnt},~\var{ss},~\var{ls},~\var{pp}),~\var{ru},~\var{pd})
+       ~(\var{acnt},~\var{ss},~\var{ls},~\var{prevPp},~\var{pp}),~\var{ru},~\var{pd})
   \end{align*}
   %
   \begin{align*}
@@ -1884,7 +1884,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
       &
       \var{s} \leteq \bslot{bhb}
       \\
-      (\wcard,~\wcard,~\wcard,~(\wcard,~\wcard,~\wcard,~\var{pp}),~\wcard,~\wcard) \leteq \var{nes}
+      (\wcard,~\wcard,~\wcard,~(\wcard,~\wcard,~\wcard,~\wcard,~\var{pp}),~\wcard,~\wcard) \leteq \var{nes}
       \\~\\
       \fun{prtlSeqChecks}~\var{lab}~\var{bh}\\
       \fun{chainChecks}~
@@ -1896,7 +1896,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
       } \\~\\
       (\var{e_1},~\wcard,~\wcard,~\wcard,~\wcard,~\wcard)
         \leteq\var{nes} \\
-      (\var{e_2},~\wcard,~\var{b_{cur}},~\var{es},~\wcard,~\var{pd})
+      (\var{e_2},~\wcard,~\var{b_{cur}},~\var{es},~\wcard,~\wcard,~\var{pd})
         \leteq\var{nes'} \\
         (\var{acnt},~\wcard,\var{ls},~\wcard,~\var{pp'})\leteq\var{es}\\
         ( \wcard,

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1832,12 +1832,12 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \end{align*}
   %
   \begin{align*}
-      & \fun{chainChecks} \in \PParams \to \BHeader \to \Bool \\
-      & \fun{chainChecks}~\var{pp}~\var{bh} = \\
-      & ~~~~ m \leq \MaxMajorPV \\
-      & ~~~~ \land~\bHeaderSize{bh} \leq \fun{maxHeaderSize}~\var{pp} \\
-      & ~~~~ \land~\hBbsize{(\bhbody{bh})} \leq \fun{maxBlockSize}~\var{pp} \\
-      & ~~~~ \where (m,~\wcard)\leteq\fun{pv}~\var{pp}
+      & \fun{chainChecks} \in \N \to (\N,\N, \ProtVer) \to \BHeader \to \Bool \\
+      & \fun{chainChecks}~\var{maxpv}~(\var{maxBHSize},~\var{maxBBSize},~\var{protocolVersion})~\var{bh} = \\
+      & ~~~~ m \leq \var{maxpv} \\
+      & ~~~~ \land~\bHeaderSize{bh} \leq \var{maxBHSize} \\
+      & ~~~~ \land~\hBbsize{(\bhbody{bh})} \leq \var{maxBBSize} \\
+      & ~~~~ \where (m,~\wcard)\leteq\var{protocolVersion}
   \end{align*}
   %
   \begin{align*}
@@ -1887,7 +1887,9 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
       (\wcard,~\wcard,~\wcard,~(\wcard,~\wcard,~\wcard,~\var{pp}),~\wcard,~\wcard) \leteq \var{nes}
       \\~\\
       \fun{prtlSeqChecks}~\var{lab}~\var{bh}\\
-      \fun{chainChecks}~\var{pp}~\var{bh}
+      \fun{chainChecks}~
+        \MaxMajorPV~(\fun{maxHeaderSize}~\var{pp},~\fun{maxBlockSize}~\var{pp},~\fun{pv}~\var{pp})~
+        \var{bh}
       \\~\\
       {
         \vdash\var{nes}\trans{\hyperref[fig:rules:tick]{tick}}{\var{s}}\var{nes'}


### PR DESCRIPTION
This PR gets the helper function `chainChecks` in the formal spec sync with the implementation. It also corrects some mistakes with the positional arguments in `NewEpochState` and `EpochState`.

In particular:

* `chainChecks` is now passed in the global variable `MaxMajorPV` as is done in the implementation.
* `chainChecks` now takes a subset of the protocol parameters, which was changed in #1915 .
* Figure 75 and 76 now correctly use 6 parameters for `NewEpochState` and 5 parameters for `EpochState`.
* I made a comment in the implementation that the field `esNonMyopic` in the implementation is not a part of the formal spec, since it is not a part of the protocol.

closes #1907

cc @nankeen @jmhrpr 