### PR TITLE
Make STS rules above UTXO era-independent.

### DIFF
--- a/semantics/executable-spec/src/Control/State/Transition/Extended.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Extended.hs
@@ -196,7 +196,7 @@ class
     "AssertionViolation (" <> sts <> "): " <> msg
 
 -- | Embed one STS within another.
-class (STS sub, STS super, BaseM sub ~ BaseM super) => Embed sub super where
+class (STS sub, BaseM sub ~ BaseM super) => Embed sub super where
   -- | Wrap a predicate failure of the subsystem in a failure of the super-system.
   wrapFailed :: PredicateFailure sub -> PredicateFailure super
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -26,13 +26,17 @@ import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
-import Control.State.Transition.Extended (BaseM, Environment, PredicateFailure, STS, Signal, State, TRC (..), applySTS)
+import Control.State.Transition.Extended
+  ( PredicateFailure,
+    STS,
+    TRC (..),
+    applySTS,
+  )
 import Data.Sequence (Seq)
 import Shelley.Spec.Ledger.API.Validation
-import Shelley.Spec.Ledger.BaseTypes (Globals, ShelleyBase)
-import Shelley.Spec.Ledger.LedgerState (LedgerState)
+import Shelley.Spec.Ledger.BaseTypes (Globals)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
-import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv)
+import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
 import qualified Shelley.Spec.Ledger.STS.Ledgers as Ledgers
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx)
@@ -107,10 +111,6 @@ instance
 applyTxs ::
   forall era m.
   ( STS (LEDGERS era),
-    BaseM (LEDGERS era) ~ ShelleyBase,
-    Environment (LEDGERS era) ~ LedgersEnv era,
-    State (LEDGERS era) ~ LedgerState era,
-    Signal (LEDGERS era) ~ Seq (Tx era),
     MonadError (ApplyTxError era) m
   ) =>
   Globals ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -29,7 +29,7 @@ import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.BlockChain
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
@@ -46,7 +46,6 @@ type ShelleyState = LedgerState.NewEpochState
 chainChecks ::
   forall era m.
   ( Era era,
-    PredicateFailure (STS.CHAIN era) ~ STS.ChainPredicateFailure era,
     MonadError (STS.PredicateFailure (STS.CHAIN era)) m
   ) =>
   Globals ->
@@ -126,10 +125,6 @@ instance
 applyBlockTransition ::
   forall era m.
   ( STS (STS.BBODY era),
-    BaseM (STS.BBODY era) ~ ShelleyBase,
-    Environment (STS.BBODY era) ~ STS.BbodyEnv era,
-    State (STS.BBODY era) ~ STS.BbodyState era,
-    Signal (STS.BBODY era) ~ Block era,
     MonadError (BlockTransitionError era) m
   ) =>
   Globals ->
@@ -163,11 +158,7 @@ applyBlockTransition globals state blk =
 --   `applyBlockTransition` on the same block and that this was successful.
 reapplyBlockTransition ::
   forall era.
-  ( STS (STS.BBODY era),
-    BaseM (STS.BBODY era) ~ ShelleyBase,
-    Environment (STS.BBODY era) ~ STS.BbodyEnv era,
-    State (STS.BBODY era) ~ STS.BbodyState era,
-    Signal (STS.BBODY era) ~ Block era
+  ( STS (STS.BBODY era)
   ) =>
   Globals ->
   ShelleyState era ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -131,7 +131,8 @@ instance
 bbodyTransition ::
   forall era.
   ( ShelleyBased era,
-    Embed (LEDGERS era) (BBODY era)
+    Embed (LEDGERS era) (BBODY era),
+    STS (BBODY era)
   ) =>
   TransitionRule (BBODY era)
 bbodyTransition =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -20,9 +20,8 @@ module Shelley.Spec.Ledger.STS.Bbody
   )
 where
 
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
   ( Embed (..),
@@ -34,7 +33,6 @@ import Control.State.Transition
     trans,
     (?!),
   )
-import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -61,7 +59,6 @@ import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
 import Shelley.Spec.Ledger.Slot (epochInfoEpoch, epochInfoFirst)
-import Shelley.Spec.Ledger.Tx (Tx)
 import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 
 data BBODY era
@@ -107,24 +104,26 @@ instance
   NoThunks (BbodyPredicateFailure era)
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody)
+  ( Era era,
+    ShelleyBased era,
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    Embed (LEDGERS era) (BBODY era)
   ) =>
-  STS (BBODY (ShelleyEra c))
+  STS (BBODY era)
   where
   type
-    State (BBODY (ShelleyEra c)) =
-      BbodyState (ShelleyEra c)
+    State (BBODY era) =
+      BbodyState era
 
   type
-    Signal (BBODY (ShelleyEra c)) =
-      Block (ShelleyEra c)
+    Signal (BBODY era) =
+      Block era
 
-  type Environment (BBODY (ShelleyEra c)) = BbodyEnv (ShelleyEra c)
+  type Environment (BBODY era) = BbodyEnv era
 
-  type BaseM (BBODY (ShelleyEra c)) = ShelleyBase
+  type BaseM (BBODY era) = ShelleyBase
 
-  type PredicateFailure (BBODY (ShelleyEra c)) = BbodyPredicateFailure (ShelleyEra c)
+  type PredicateFailure (BBODY era) = BbodyPredicateFailure era
 
   initialRules = []
   transitionRules = [bbodyTransition]
@@ -132,15 +131,7 @@ instance
 bbodyTransition ::
   forall era.
   ( ShelleyBased era,
-    BaseM (BBODY era) ~ ShelleyBase,
-    Embed (LEDGERS era) (BBODY era),
-    Environment (BBODY era) ~ BbodyEnv era,
-    State (BBODY era) ~ BbodyState era,
-    Signal (BBODY era) ~ Block era,
-    PredicateFailure (BBODY era) ~ BbodyPredicateFailure era,
-    Environment (LEDGERS era) ~ LedgersEnv era,
-    State (LEDGERS era) ~ LedgerState era,
-    Signal (LEDGERS era) ~ Seq (Tx era)
+    Embed (LEDGERS era) (BBODY era)
   ) =>
   TransitionRule (BBODY era)
 bbodyTransition =
@@ -183,9 +174,11 @@ bbodyTransition =
             )
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody)
+  ( Era era,
+    STS (LEDGERS era),
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    ShelleyBased era
   ) =>
-  Embed (LEDGERS (ShelleyEra c)) (BBODY (ShelleyEra c))
+  Embed (LEDGERS era) (BBODY era)
   where
   wrapFailed = LedgersFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -30,9 +30,8 @@ where
 
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto (VRF)
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
@@ -225,26 +224,32 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
     cs = Map.fromList (fmap (\(GenDelegPair hk _) -> (coerceKeyRole hk, 0)) (Map.elems genDelegs))
 
 instance
-  ( CryptoClass.Crypto c,
+  ( Era era,
+    c ~ Crypto era,
+    ShelleyBased era,
+    Embed (BBODY era) (CHAIN era),
+    Embed TICKN (CHAIN era),
+    Embed (TICK era) (CHAIN era),
+    Embed (PRTCL (Crypto era)) (CHAIN era),
     DSignable c (OCertSignable c),
     DSignable c (Hash c EraIndependentTxBody),
     KESignable c (BHBody c),
     VRF.Signable (VRF c) Seed
   ) =>
-  STS (CHAIN (ShelleyEra c))
+  STS (CHAIN era)
   where
   type
-    State (CHAIN (ShelleyEra c)) =
-      ChainState (ShelleyEra c)
+    State (CHAIN era) =
+      ChainState era
 
   type
-    Signal (CHAIN (ShelleyEra c)) =
-      Block (ShelleyEra c)
+    Signal (CHAIN era) =
+      Block era
 
-  type Environment (CHAIN (ShelleyEra c)) = ()
-  type BaseM (CHAIN (ShelleyEra c)) = ShelleyBase
+  type Environment (CHAIN era) = ()
+  type BaseM (CHAIN era) = ShelleyBase
 
-  type PredicateFailure (CHAIN (ShelleyEra c)) = ChainPredicateFailure (ShelleyEra c)
+  type PredicateFailure (CHAIN era) = ChainPredicateFailure era
 
   initialRules = []
   transitionRules = [chainTransition]
@@ -266,7 +271,6 @@ pparamsToChainChecksData pp =
 
 chainChecks ::
   ( Era era,
-    PredicateFailure (CHAIN era) ~ ChainPredicateFailure era,
     MonadError (PredicateFailure (CHAIN era)) m
   ) =>
   Natural ->
@@ -287,14 +291,7 @@ chainChecks maxpv ccd bh = do
 chainTransition ::
   forall era.
   ( ShelleyBased era,
-    BaseM (CHAIN era) ~ ShelleyBase,
-    State (CHAIN era) ~ ChainState era,
-    Signal (CHAIN era) ~ Block era,
-    PredicateFailure (CHAIN era) ~ ChainPredicateFailure era,
     Embed (BBODY era) (CHAIN era),
-    Environment (BBODY era) ~ BbodyEnv era,
-    State (BBODY era) ~ BbodyState era,
-    Signal (BBODY era) ~ Block era,
     Embed TICKN (CHAIN era),
     Embed (TICK era) (CHAIN era),
     Embed (PRTCL (Crypto era)) (CHAIN era)
@@ -372,46 +369,42 @@ chainTransition =
         pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (OCertSignable c),
-    DSignable c (Hash c EraIndependentTxBody),
-    KESignable c (BHBody c),
-    VRF.Signable (VRF c) Seed
+  ( Era era,
+    ShelleyBased era,
+    STS (CHAIN era),
+    STS (BBODY era)
   ) =>
-  Embed (BBODY (ShelleyEra c)) (CHAIN (ShelleyEra c))
+  Embed (BBODY era) (CHAIN era)
   where
   wrapFailed = BbodyFailure
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (OCertSignable c),
-    DSignable c (Hash c EraIndependentTxBody),
-    KESignable c (BHBody c),
-    VRF.Signable (VRF c) Seed
+  ( Era era,
+    ShelleyBased era,
+    STS (CHAIN era)
   ) =>
-  Embed TICKN (CHAIN (ShelleyEra c))
+  Embed TICKN (CHAIN era)
   where
   wrapFailed = TicknFailure
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (OCertSignable c),
-    DSignable c (Hash c EraIndependentTxBody),
-    KESignable c (BHBody c),
-    VRF.Signable (VRF c) Seed
+  ( Era era,
+    ShelleyBased era,
+    STS (CHAIN era),
+    STS (TICK era)
   ) =>
-  Embed (TICK (ShelleyEra c)) (CHAIN (ShelleyEra c))
+  Embed (TICK era) (CHAIN era)
   where
   wrapFailed = TickFailure
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (OCertSignable c),
-    DSignable c (Hash c EraIndependentTxBody),
-    KESignable c (BHBody c),
-    VRF.Signable (VRF c) Seed
+  ( Era era,
+    c ~ Crypto era,
+    ShelleyBased era,
+    STS (CHAIN era),
+    STS (PRTCL c)
   ) =>
-  Embed (PRTCL c) (CHAIN (ShelleyEra c))
+  Embed (PRTCL c) (CHAIN era)
   where
   wrapFailed = PrtclFailure
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -291,6 +291,7 @@ chainChecks maxpv ccd bh = do
 chainTransition ::
   forall era.
   ( ShelleyBased era,
+    STS (CHAIN era),
     Embed (BBODY era) (CHAIN era),
     Embed TICKN (CHAIN era),
     Embed (TICK era) (CHAIN era),
@@ -371,7 +372,6 @@ chainTransition =
 instance
   ( Era era,
     ShelleyBased era,
-    STS (CHAIN era),
     STS (BBODY era)
   ) =>
   Embed (BBODY era) (CHAIN era)
@@ -380,8 +380,7 @@ instance
 
 instance
   ( Era era,
-    ShelleyBased era,
-    STS (CHAIN era)
+    ShelleyBased era
   ) =>
   Embed TICKN (CHAIN era)
   where
@@ -390,7 +389,6 @@ instance
 instance
   ( Era era,
     ShelleyBased era,
-    STS (CHAIN era),
     STS (TICK era)
   ) =>
   Embed (TICK era) (CHAIN era)
@@ -401,7 +399,6 @@ instance
   ( Era era,
     c ~ Crypto era,
     ShelleyBased era,
-    STS (CHAIN era),
     STS (PRTCL c)
   ) =>
   Embed (PRTCL c) (CHAIN era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -210,20 +210,16 @@ ledgerTransition = do
   pure (utxoSt', dpstate')
 
 instance
-  ( Era era,
-    ShelleyBased era,
-    STS (DELEGS era),
-    STS (LEDGER era)
+  ( ShelleyBased era,
+    STS (DELEGS era)
   ) =>
   Embed (DELEGS era) (LEDGER era)
   where
   wrapFailed = DelegsFailure
 
 instance
-  ( Era era,
-    ShelleyBased era,
-    STS (UTXOW era),
-    STS (LEDGER era)
+  ( ShelleyBased era,
+    STS (UTXOW era)
   ) =>
   Embed (UTXOW era) (LEDGER era)
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -108,6 +108,7 @@ adoptGenesisDelegs es slot = es'
 validatingTickTransition ::
   forall tick era.
   ( Embed (NEWEPOCH era) (tick era),
+    STS (tick era),
     State (tick era) ~ NewEpochState era,
     BaseM (tick era) ~ ShelleyBase
   ) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -295,6 +295,7 @@ initialLedgerState = do
 utxoInductive ::
   forall era.
   ( ShelleyBased era,
+    STS (UTXO era),
     Embed (PPUP era) (UTXO era),
     BaseM (UTXO era) ~ ShelleyBase,
     Environment (UTXO era) ~ UtxoEnv era,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -26,9 +26,8 @@ import Cardano.Binary
     encodeListLen,
   )
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -143,16 +142,30 @@ deriving stock instance
   Show (UtxowPredicateFailure era)
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody)
+  ( Era era,
+    ShelleyBased era,
+    Embed (UTXO era) (UTXOW era),
+    Environment (UTXOW era) ~ UtxoEnv era,
+    State (UTXOW era) ~ UTxOState era,
+    Signal (UTXOW era) ~ Tx era,
+    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    Environment (UTXO era) ~ UtxoEnv era,
+    State (UTXO era) ~ UTxOState era,
+    Signal (UTXO era) ~ Tx era,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era)),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
-  STS (UTXOW (ShelleyEra c))
+  STS (UTXOW era)
   where
-  type State (UTXOW (ShelleyEra c)) = UTxOState (ShelleyEra c)
-  type Signal (UTXOW (ShelleyEra c)) = Tx (ShelleyEra c)
-  type Environment (UTXOW (ShelleyEra c)) = UtxoEnv (ShelleyEra c)
-  type BaseM (UTXOW (ShelleyEra c)) = ShelleyBase
-  type PredicateFailure (UTXOW (ShelleyEra c)) = UtxowPredicateFailure (ShelleyEra c)
+  type State (UTXOW era) = UTxOState era
+  type Signal (UTXOW era) = Tx era
+  type Environment (UTXOW era) = UtxoEnv era
+  type BaseM (UTXOW era) = ShelleyBase
+  type PredicateFailure (UTXOW era) = UtxowPredicateFailure era
   transitionRules = [utxoWitnessed]
   initialRules = [initialLedgerStateUTXOW]
 
@@ -220,8 +233,6 @@ instance
 initialLedgerStateUTXOW ::
   forall era.
   ( Embed (UTXO era) (UTXOW era),
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
     Environment (UTXO era) ~ UtxoEnv era,
     State (UTXO era) ~ UTxOState era
   ) =>
@@ -234,11 +245,6 @@ utxoWitnessed ::
   forall era.
   ( ShelleyBased era,
     Embed (UTXO era) (UTXOW era),
-    BaseM (UTXOW era) ~ ShelleyBase,
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
-    Signal (UTXOW era) ~ Tx era,
-    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     Environment (UTXO era) ~ UtxoEnv era,
     State (UTXO era) ~ UTxOState era,
@@ -310,9 +316,12 @@ utxoWitnessed =
         TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody)
+  ( Era era,
+    ShelleyBased era,
+    STS (UTXOW era),
+    STS (UTXO era),
+    BaseM (UTXO era) ~ ShelleyBase
   ) =>
-  Embed (UTXO (ShelleyEra c)) (UTXOW (ShelleyEra c))
+  Embed (UTXO era) (UTXOW era)
   where
   wrapFailed = UtxoFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -318,7 +318,6 @@ utxoWitnessed =
 instance
   ( Era era,
     ShelleyBased era,
-    STS (UTXOW era),
     STS (UTXO era),
     BaseM (UTXO era) ~ ShelleyBase
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -58,8 +58,8 @@ import Shelley.Spec.Ledger.BlockChain
   )
 import Shelley.Spec.Ledger.EpochBoundary (unBlocksMade)
 import Shelley.Spec.Ledger.LedgerState (DPState, LedgerState, UTxOState, nesBcur)
-import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyEnv, BbodyState)
-import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState (..))
+import Shelley.Spec.Ledger.STS.Bbody (BBODY)
+import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv)
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv)
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
@@ -89,11 +89,9 @@ validateInput ::
     State (LEDGERS era) ~ LedgerState era,
     Signal (LEDGERS era) ~ Seq (Tx era),
     STS (LEDGER era),
-    BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
-    Signal (LEDGER era) ~ Tx era,
-    Environment (CHAIN era) ~ ()
+    Signal (LEDGER era) ~ Tx era
   ) =>
   Int ->
   IO (ValidateInput era)
@@ -108,11 +106,9 @@ genValidateInput ::
     State (LEDGERS era) ~ LedgerState era,
     Signal (LEDGERS era) ~ Seq (Tx era),
     STS (LEDGER era),
-    BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
-    Signal (LEDGER era) ~ Tx era,
-    Environment (CHAIN era) ~ ()
+    Signal (LEDGER era) ~ Tx era
   ) =>
   Int ->
   IO (ValidateInput era)
@@ -124,11 +120,7 @@ genValidateInput n = do
 
 benchValidate ::
   forall era.
-  ( STS (BBODY era),
-    BaseM (BBODY era) ~ ShelleyBase,
-    Environment (BBODY era) ~ BbodyEnv era,
-    State (BBODY era) ~ BbodyState era,
-    Signal (BBODY era) ~ Block era
+  ( STS (BBODY era)
   ) =>
   ValidateInput era ->
   IO (ShelleyState era)
@@ -140,11 +132,7 @@ benchValidate (ValidateInput globals state block) =
 applyBlock ::
   forall era.
   ( Era era,
-    STS (BBODY era),
-    BaseM (BBODY era) ~ ShelleyBase,
-    Environment (BBODY era) ~ BbodyEnv era,
-    State (BBODY era) ~ BbodyState era,
-    Signal (BBODY era) ~ Block era
+    STS (BBODY era)
   ) =>
   ValidateInput era ->
   Int ->
@@ -155,11 +143,7 @@ applyBlock (ValidateInput globals state block) n =
     Left x -> error (show x)
 
 benchreValidate ::
-  ( STS (BBODY era),
-    BaseM (BBODY era) ~ ShelleyBase,
-    Environment (BBODY era) ~ BbodyEnv era,
-    State (BBODY era) ~ BbodyState era,
-    Signal (BBODY era) ~ Block era
+  ( STS (BBODY era)
   ) =>
   ValidateInput era ->
   ShelleyState era
@@ -201,14 +185,12 @@ instance CryptoClass.Crypto c => NFData (UpdateInputs c) where
 genUpdateInputs ::
   forall era.
   ( ShelleyTest era,
-    Environment (CHAIN era) ~ (),
     STS (LEDGERS era),
     BaseM (LEDGERS era) ~ ShelleyBase,
     Environment (LEDGERS era) ~ LedgersEnv era,
     State (LEDGERS era) ~ LedgerState era,
     Signal (LEDGERS era) ~ Seq (Tx era),
     STS (LEDGER era),
-    BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -28,7 +28,6 @@ import Shelley.Spec.Ledger.LedgerState
     NewEpochState (..),
     UTxOState (..),
   )
-import Shelley.Spec.Ledger.STS.Chain (CHAIN)
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv)
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv)
 import Test.QuickCheck (generate)
@@ -53,8 +52,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)
 
 -- | Generate a genesis chain state given a UTxO size
 genChainState ::
-  ( ShelleyTest era,
-    Environment (CHAIN era) ~ ()
+  ( ShelleyTest era
   ) =>
   Int ->
   GenEnv era ->
@@ -84,7 +82,6 @@ genBlock ::
     State (LEDGERS era) ~ LedgerState era,
     Signal (LEDGERS era) ~ Seq (Tx era),
     STS (LEDGER era),
-    BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era
@@ -104,8 +101,7 @@ genBlock ge cs = generate $ GenBlock.genBlock ge cs
 
 genTriple ::
   ( Mock (Crypto era),
-    ShelleyTest era,
-    Environment (CHAIN era) ~ ()
+    ShelleyTest era
   ) =>
   Proxy era ->
   Int ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -81,7 +81,6 @@ genBlock ::
     Signal (LEDGER era) ~ Tx era,
     STS (LEDGERS era),
     Mock (Crypto era),
-    BaseM (LEDGERS era) ~ ShelleyBase,
     Environment (LEDGERS era) ~ LedgersEnv era,
     State (LEDGERS era) ~ LedgerState era,
     Signal (LEDGERS era) ~ Seq (Tx era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -21,7 +21,7 @@ import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import qualified Cardano.Ledger.Shelley as Shelley
-import Control.State.Transition.Extended (BaseM, Environment, PredicateFailure, STS, Signal, State, TRC (..))
+import Control.State.Transition.Extended (BaseM, PredicateFailure, STS, TRC (..))
 import Data.Coerce (coerce)
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)
@@ -219,9 +219,6 @@ initialUTxOState ::
   ( ShelleyTest era,
     STS (UTXOW era),
     BaseM (UTXOW era) ~ ShelleyBase,
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
-    Signal (UTXOW era) ~ Tx era,
     Mock (Crypto era)
   ) =>
   Coin ->
@@ -273,9 +270,6 @@ applyTxWithScript ::
   ( ShelleyTest era,
     STS (UTXOW era),
     BaseM (UTXOW era) ~ ShelleyBase,
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
-    Signal (UTXOW era) ~ Tx era,
     Mock (Crypto era)
   ) =>
   proxy era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -97,7 +97,6 @@ import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
 import Test.Shelley.Spec.Ledger.Utils
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Crypto (Crypto)
-import Control.State.Transition.Extended (STS(Signal))
 
 genesisChainState ::
   forall era a.
@@ -146,7 +145,7 @@ relevantCasesAreCovered = do
 
 relevantCasesAreCoveredForTrace ::
   forall era.
-  (ShelleyTest era, Signal (CHAIN era) ~ Block era) =>
+  (ShelleyTest era) =>
   Trace (CHAIN era) ->
   Property
 relevantCasesAreCoveredForTrace tr = do


### PR DESCRIPTION
Honestly it's embarassing that I failed to notice that this worked. We
carry a few more constraints in the STS instances and Embed instances.
But the payoff is that we only have to override the specific rules we
want to change in each era, and not re-plumb everything.

Obviously this means that, in the future, if we make a change in a
different rule then we have to go back and turn the era-independent one
into an era-dependent version (and add instances for all intermediate
eras). But still, this feels like a definite improvement.