### PR TITLE
Define interfaces for consensus

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -38,7 +38,7 @@ type instance PreviousEra (AllegraEra c) = ShelleyEra c
 -- to provide the context in the right place.
 type instance TranslationContext (AllegraEra c) = ()
 
-instance Crypto c => TranslateEra (AllegraEra c) ShelleyState where
+instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
   translateEra _ = error "TODO Shelley to Allegra translation"
 
 instance Crypto c => TranslateEra (AllegraEra c) Tx where

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -37,7 +37,7 @@ type instance PreviousEra (MaryEra c) = AllegraEra c
 -- to provide the context in the right place.
 type instance TranslationContext (MaryEra c) = ()
 
-instance Crypto c => TranslateEra (MaryEra c) ShelleyState where
+instance Crypto c => TranslateEra (MaryEra c) NewEpochState where
   translateEra _ = error "TODO Allegra to Mary translation"
 
 instance Crypto c => TranslateEra (MaryEra c) Tx where

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -16,12 +17,18 @@ module Cardano.Ledger.Core
     Compact (..),
     TxBody,
     Value,
+
+    -- * Constraint synonyms
+    ChainData,
+    SerialisableData,
+    AnnotatedData,
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
+import NoThunks.Class (NoThunks)
 
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type
@@ -61,3 +68,21 @@ instance
 -- TODO: consider if this is better the other way around
 instance (Eq a, Compactible a) => Eq (CompactForm a) where
   a == b = fromCompact a == fromCompact b
+
+-------------------------------------------------------------------------------
+
+-- * Constraint synonyms
+
+-------------------------------------------------------------------------------
+
+-- | Common constraints
+--
+-- NOTE: 'Ord' is not included, as 'Ord' for a 'Block' or a 'NewEpochState'
+-- doesn't make sense.
+type ChainData t = (Eq t, Show t, NoThunks t, Typeable t)
+
+-- | Constraints for serialising from/to CBOR
+type SerialisableData t = (FromCBOR t, ToCBOR t)
+
+-- | Constraints for serialising from/to CBOR using 'Annotator'
+type AnnotatedData t = (FromCBOR (Annotator t), ToCBOR t)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -27,7 +27,6 @@ import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
 import Shelley.Spec.Ledger.API.Protocol
 import Shelley.Spec.Ledger.API.Types
-import Shelley.Spec.Ledger.API.Validation
 import Shelley.Spec.Ledger.Coin (CompactForm (CompactCoin))
 import Shelley.Spec.Ledger.EpochBoundary
 import Shelley.Spec.Ledger.LedgerState
@@ -91,7 +90,7 @@ translateToShelleyLedgerState ::
   ShelleyGenesis (ShelleyEra c) ->
   EpochNo ->
   Byron.ChainValidationState ->
-  ShelleyState (ShelleyEra c)
+  NewEpochState (ShelleyEra c)
 translateToShelleyLedgerState genesisShelley epochNo cvs =
   NewEpochState
     { nesEL = epochNo,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -17,8 +17,9 @@ module Shelley.Spec.Ledger.API.Mempool
   )
 where
 
-import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import Cardano.Ledger.Crypto (Crypto, HASH)
 import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
 import Control.Arrow (left)
@@ -32,7 +33,6 @@ import Control.State.Transition.Extended
   )
 import Data.Sequence (Seq)
 import Data.Typeable (Typeable)
-import NoThunks.Class (NoThunks)
 import Shelley.Spec.Ledger.BaseTypes (Globals)
 import Shelley.Spec.Ledger.Keys (DSignable)
 import Shelley.Spec.Ledger.LedgerState (NewEpochState)
@@ -45,16 +45,12 @@ import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 
 -- TODO #1304: add reapplyTxs
 class
-  ( Eq (Tx era),
-    Show (Tx era),
-    NoThunks (Tx era),
-    FromCBOR (Annotator (Tx era)),
-    ToCBOR (Tx era),
+  ( ChainData (Tx era),
+    AnnotatedData (Tx era),
     Eq (ApplyTxError era),
     Show (ApplyTxError era),
-    FromCBOR (ApplyTxError era),
-    ToCBOR (ApplyTxError era),
-    Typeable (ApplyTxError era)
+    Typeable (ApplyTxError era),
+    SerialisableData (ApplyTxError era)
   ) =>
   ApplyTx era
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,11 +17,9 @@
 -- In particular, this code supports extracting the components of the ledger
 -- state needed for protocol execution, both now and in a 2k-slot window.
 module Shelley.Spec.Ledger.API.Protocol
-  ( STS.Prtcl.PrtclEnv,
+  ( GetLedgerView (..),
     LedgerView (..),
-    currentLedgerView,
-    -- $timetravel
-    futureLedgerView,
+    FutureLedgerViewError (..),
     -- $chainstate
     ChainDepState (..),
     ChainTransitionError (..),
@@ -31,13 +30,9 @@ module Shelley.Spec.Ledger.API.Protocol
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
-import Cardano.Crypto.DSIGN.Class
-import Cardano.Crypto.KES.Class
-import Cardano.Crypto.VRF.Class
-import Cardano.Ledger.Crypto hiding (Crypto)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyBased)
+import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -65,7 +60,7 @@ import Shelley.Spec.Ledger.BlockChain
     prevHashToNonce,
   )
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
-import Shelley.Spec.Ledger.Keys (GenDelegs)
+import Shelley.Spec.Ledger.Keys (DSignable, GenDelegs, KESignable, VRFSignable)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState (..),
     NewEpochState (..),
@@ -81,6 +76,39 @@ import Shelley.Spec.Ledger.STS.Tick (TICKF)
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (SlotNo)
+
+class
+  ( Eq (ChainDepState (Crypto era)),
+    Show (ChainDepState (Crypto era)),
+    NoThunks (ChainDepState (Crypto era)),
+    Eq (ChainTransitionError (Crypto era)),
+    Show (ChainTransitionError (Crypto era)),
+    Show (LedgerView (Crypto era)),
+    Show (FutureLedgerViewError era)
+  ) =>
+  GetLedgerView era
+  where
+  currentLedgerView ::
+    ShelleyState era ->
+    LedgerView (Crypto era)
+  currentLedgerView = view
+
+  -- $timetravel
+  futureLedgerView ::
+    MonadError (FutureLedgerViewError era) m =>
+    Globals ->
+    ShelleyState era ->
+    SlotNo ->
+    m (LedgerView (Crypto era))
+  default futureLedgerView ::
+    (ShelleyBased era, MonadError (FutureLedgerViewError era) m) =>
+    Globals ->
+    ShelleyState era ->
+    SlotNo ->
+    m (LedgerView (Crypto era))
+  futureLedgerView = futureView
+
+instance CC.Crypto crypto => GetLedgerView (ShelleyEra crypto)
 
 -- | Data required by the Transitional Praos protocol from the Shelley ledger.
 data LedgerView crypto = LedgerView
@@ -130,10 +158,6 @@ view
         lvChainChecks = pparamsToChainChecksData . esPp $ nesEs
       }
 
--- | Alias of 'view' for export
-currentLedgerView :: ShelleyState era -> LedgerView (Crypto era)
-currentLedgerView = view
-
 -- $timetravel
 --
 --  Time Travel (or the anachronistic ledger view)
@@ -178,7 +202,7 @@ deriving stock instance
 --   Given a slot within the future stability window from our current slot (the
 --   slot corresponding to the passed-in 'ShelleyState'), return a 'LedgerView'
 --   appropriate to that slot.
-futureLedgerView ::
+futureView ::
   forall era m.
   ( ShelleyBased era,
     MonadError (FutureLedgerViewError era) m
@@ -187,7 +211,7 @@ futureLedgerView ::
   ShelleyState era ->
   SlotNo ->
   m (LedgerView (Crypto era))
-futureLedgerView globals ss slot =
+futureView globals ss slot =
   liftEither
     . right view
     . left (FutureLedgerViewError . join)
@@ -204,8 +228,8 @@ futureLedgerView globals ss slot =
 --
 -- The chain state is an amalgam of the protocol state and the ticked nonce.
 
-data ChainDepState c = ChainDepState
-  { csProtocol :: !(STS.Prtcl.PrtclState c),
+data ChainDepState crypto = ChainDepState
+  { csProtocol :: !(STS.Prtcl.PrtclState crypto),
     csTickn :: !STS.Tickn.TicknState,
     -- | Nonce constructed from the hash of the last applied block header.
     csLabNonce :: !Nonce
@@ -284,15 +308,9 @@ updateChainDepState ::
   forall crypto m.
   ( CC.Crypto crypto,
     MonadError (ChainTransitionError crypto) m,
-    Cardano.Crypto.DSIGN.Class.Signable
-      (DSIGN crypto)
-      (Shelley.Spec.Ledger.OCert.OCertSignable crypto),
-    Cardano.Crypto.KES.Class.Signable
-      (KES crypto)
-      (Shelley.Spec.Ledger.BlockChain.BHBody crypto),
-    Cardano.Crypto.VRF.Class.Signable
-      (VRF crypto)
-      Shelley.Spec.Ledger.BaseTypes.Seed
+    DSignable crypto (OCertSignable crypto),
+    KESignable crypto (BHBody crypto),
+    VRFSignable crypto Seed
   ) =>
   Globals ->
   LedgerView crypto ->
@@ -333,15 +351,9 @@ updateChainDepState
 reupdateChainDepState ::
   forall crypto.
   ( CC.Crypto crypto,
-    Cardano.Crypto.DSIGN.Class.Signable
-      (DSIGN crypto)
-      (Shelley.Spec.Ledger.OCert.OCertSignable crypto),
-    Cardano.Crypto.KES.Class.Signable
-      (KES crypto)
-      (Shelley.Spec.Ledger.BlockChain.BHBody crypto),
-    Cardano.Crypto.VRF.Class.Signable
-      (VRF crypto)
-      Shelley.Spec.Ledger.BaseTypes.Seed
+    DSignable crypto (OCertSignable crypto),
+    KESignable crypto (BHBody crypto),
+    VRFSignable crypto Seed
   ) =>
   Globals ->
   LedgerView crypto ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -45,7 +45,6 @@ import Control.State.Transition.Extended
 import Data.Either (fromRight)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.API.Validation
 import Shelley.Spec.Ledger.BaseTypes
   ( Globals,
     Nonce,
@@ -89,7 +88,7 @@ class
   GetLedgerView era
   where
   currentLedgerView ::
-    ShelleyState era ->
+    NewEpochState era ->
     LedgerView (Crypto era)
   currentLedgerView = view
 
@@ -97,13 +96,13 @@ class
   futureLedgerView ::
     MonadError (FutureLedgerViewError era) m =>
     Globals ->
-    ShelleyState era ->
+    NewEpochState era ->
     SlotNo ->
     m (LedgerView (Crypto era))
   default futureLedgerView ::
     (ShelleyBased era, MonadError (FutureLedgerViewError era) m) =>
     Globals ->
-    ShelleyState era ->
+    NewEpochState era ->
     SlotNo ->
     m (LedgerView (Crypto era))
   futureLedgerView = futureView
@@ -141,7 +140,7 @@ mkPrtclEnv
       lvPoolDistr
       lvGenDelegs
 
-view :: ShelleyState era -> LedgerView (Crypto era)
+view :: NewEpochState era -> LedgerView (Crypto era)
 view
   NewEpochState
     { nesPd,
@@ -200,7 +199,7 @@ deriving stock instance
 -- | Anachronistic ledger view
 --
 --   Given a slot within the future stability window from our current slot (the
---   slot corresponding to the passed-in 'ShelleyState'), return a 'LedgerView'
+--   slot corresponding to the passed-in 'NewEpochState'), return a 'LedgerView'
 --   appropriate to that slot.
 futureView ::
   forall era m.
@@ -208,7 +207,7 @@ futureView ::
     MonadError (FutureLedgerViewError era) m
   ) =>
   Globals ->
-  ShelleyState era ->
+  NewEpochState era ->
   SlotNo ->
   m (LedgerView (Crypto era))
 futureView globals ss slot =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -30,6 +30,7 @@ module Shelley.Spec.Ledger.API.Protocol
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
+import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
@@ -77,9 +78,8 @@ import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
 class
-  ( Eq (ChainDepState (Crypto era)),
-    Show (ChainDepState (Crypto era)),
-    NoThunks (ChainDepState (Crypto era)),
+  ( ChainData (ChainDepState (Crypto era)),
+    SerialisableData (ChainDepState (Crypto era)),
     Eq (ChainTransitionError (Crypto era)),
     Show (ChainTransitionError (Crypto era)),
     Show (LedgerView (Crypto era)),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -12,17 +13,19 @@
 -- API.
 module Shelley.Spec.Ledger.API.Validation
   ( ShelleyState,
+    ApplyBlock (..),
     TickTransitionError (..),
     BlockTransitionError (..),
     chainChecks,
-    applyTickTransition,
-    applyBlockTransition,
-    reapplyBlockTransition,
   )
 where
 
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Crypto (HASH)
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyBased)
+import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -31,18 +34,147 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Keys (DSignable)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Tick as STS
 import Shelley.Spec.Ledger.Slot (SlotNo)
+import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
+
+{-------------------------------------------------------------------------------
+  Block validation API
+-------------------------------------------------------------------------------}
 
 -- | Type alias for the state updated by TICK and BBODY rules
 type ShelleyState = LedgerState.NewEpochState
 
+class
+  ( Eq (Block era),
+    Show (Block era),
+    NoThunks (Block era),
+    FromCBOR (Annotator (Block era)),
+    ToCBOR (Block era),
+    Eq (BHeader (Crypto era)),
+    Show (BHeader (Crypto era)),
+    NoThunks (BHeader (Crypto era)),
+    FromCBOR (Annotator (BHeader (Crypto era))),
+    ToCBOR (Block era),
+    Eq (ShelleyState era),
+    Show (ShelleyState era),
+    NoThunks (ShelleyState era),
+    FromCBOR (ShelleyState era),
+    ToCBOR (ShelleyState era),
+    Eq (BlockTransitionError era),
+    Show (BlockTransitionError era),
+    NoThunks (BlockTransitionError era),
+    Eq (STS.PredicateFailure (STS.CHAIN era)),
+    Show (STS.PredicateFailure (STS.CHAIN era)),
+    NoThunks (STS.PredicateFailure (STS.CHAIN era))
+  ) =>
+  ApplyBlock era
+  where
+  -- | Apply the header level ledger transition.
+  --
+  -- This handles checks and updates that happen on a slot tick, as well as a
+  -- few header level checks, such as size constraints.
+  applyTick ::
+    Globals ->
+    ShelleyState era ->
+    SlotNo ->
+    ShelleyState era
+  default applyTick ::
+    ShelleyBased era =>
+    Globals ->
+    ShelleyState era ->
+    SlotNo ->
+    ShelleyState era
+  applyTick globals state hdr =
+    (either err id) . flip runReader globals
+      . applySTS @(STS.TICK era)
+      $ TRC ((), state, hdr)
+    where
+      err :: Show a => a -> b
+      err msg = error $ "Panic! applyTick failed: " <> (show msg)
+
+  -- | Apply the block level ledger transition.
+  applyBlock ::
+    MonadError (BlockTransitionError era) m =>
+    Globals ->
+    ShelleyState era ->
+    Block era ->
+    m (ShelleyState era)
+  default applyBlock ::
+    ( STS (STS.BBODY era),
+      MonadError (BlockTransitionError era) m
+    ) =>
+    Globals ->
+    ShelleyState era ->
+    Block era ->
+    m (ShelleyState era)
+  applyBlock globals state blk =
+    liftEither
+      . right (updateShelleyState state)
+      . left (BlockTransitionError . join)
+      $ res
+    where
+      res =
+        flip runReader globals . applySTS @(STS.BBODY era) $
+          TRC (mkBbodyEnv state, bbs, blk)
+      updateShelleyState ::
+        ShelleyState era ->
+        STS.BbodyState era ->
+        ShelleyState era
+      updateShelleyState ss (STS.BbodyState ls bcur) =
+        LedgerState.updateNES ss bcur ls
+      bbs =
+        STS.BbodyState
+          (LedgerState.esLState $ LedgerState.nesEs state)
+          (LedgerState.nesBcur state)
+
+  -- | Re-apply a ledger block to the same state it has been applied to before.
+  --
+  -- This function does no validation of whether the block applies successfully;
+  -- the caller implicitly guarantees that they have previously called
+  -- 'applyBlockTransition' on the same block and that this was successful.
+  reapplyBlock ::
+    Globals ->
+    ShelleyState era ->
+    Block era ->
+    ShelleyState era
+  default reapplyBlock ::
+    STS (STS.BBODY era) =>
+    Globals ->
+    ShelleyState era ->
+    Block era ->
+    ShelleyState era
+  reapplyBlock globals state blk =
+    updateShelleyState state res
+    where
+      res =
+        flip runReader globals . reapplySTS @(STS.BBODY era) $
+          TRC (mkBbodyEnv state, bbs, blk)
+      updateShelleyState ::
+        ShelleyState era ->
+        STS.BbodyState era ->
+        ShelleyState era
+      updateShelleyState ss (STS.BbodyState ls bcur) =
+        LedgerState.updateNES ss bcur ls
+      bbs =
+        STS.BbodyState
+          (LedgerState.esLState $ LedgerState.nesEs state)
+          (LedgerState.nesBcur state)
+
+instance
+  ( CC.Crypto crypto,
+    DSignable crypto (Hash (HASH crypto) EraIndependentTxBody)
+  ) =>
+  ApplyBlock (ShelleyEra crypto)
+
 {-------------------------------------------------------------------------------
   CHAIN Transition checks
 -------------------------------------------------------------------------------}
+
 chainChecks ::
   forall era m.
   ( Era era,
@@ -86,25 +218,6 @@ deriving stock instance
   (Show (STS.PredicateFailure (STS.TICK era))) =>
   Show (TickTransitionError era)
 
--- | Apply the header level ledger transition.
---
--- This handles checks and updates that happen on a slot tick, as well as a few
--- header level checks, such as size constraints.
-applyTickTransition ::
-  forall era.
-  ShelleyBased era =>
-  Globals ->
-  ShelleyState era ->
-  SlotNo ->
-  ShelleyState era
-applyTickTransition globals state hdr =
-  (either err id) . flip runReader globals
-    . applySTS @(STS.TICK era)
-    $ TRC ((), state, hdr)
-  where
-    err :: Show a => a -> b
-    err msg = error $ "Panic! applyHeaderTransition failed: " <> (show msg)
-
 newtype BlockTransitionError era
   = BlockTransitionError [STS.PredicateFailure (STS.BBODY era)]
   deriving (Generic)
@@ -120,63 +233,3 @@ deriving stock instance
 instance
   (NoThunks (STS.PredicateFailure (STS.BBODY era))) =>
   NoThunks (BlockTransitionError era)
-
--- | Apply the block level ledger transition.
-applyBlockTransition ::
-  forall era m.
-  ( STS (STS.BBODY era),
-    MonadError (BlockTransitionError era) m
-  ) =>
-  Globals ->
-  ShelleyState era ->
-  Block era ->
-  m (ShelleyState era)
-applyBlockTransition globals state blk =
-  liftEither
-    . right (updateShelleyState state)
-    . left (BlockTransitionError . join)
-    $ res
-  where
-    res =
-      flip runReader globals . applySTS @(STS.BBODY era) $
-        TRC (mkBbodyEnv state, bbs, blk)
-    updateShelleyState ::
-      ShelleyState era ->
-      STS.BbodyState era ->
-      ShelleyState era
-    updateShelleyState ss (STS.BbodyState ls bcur) =
-      LedgerState.updateNES ss bcur ls
-    bbs =
-      STS.BbodyState
-        (LedgerState.esLState $ LedgerState.nesEs state)
-        (LedgerState.nesBcur state)
-
--- | Re-apply a ledger block to the same state it has been applied to before.
---
---   This function does no validation of whether the block applies successfully;
---   the caller implicitly guarantees that they have previously called
---   `applyBlockTransition` on the same block and that this was successful.
-reapplyBlockTransition ::
-  forall era.
-  ( STS (STS.BBODY era)
-  ) =>
-  Globals ->
-  ShelleyState era ->
-  Block era ->
-  ShelleyState era
-reapplyBlockTransition globals state blk =
-  updateShelleyState state res
-  where
-    res =
-      flip runReader globals . reapplySTS @(STS.BBODY era) $
-        TRC (mkBbodyEnv state, bbs, blk)
-    updateShelleyState ::
-      ShelleyState era ->
-      STS.BbodyState era ->
-      ShelleyState era
-    updateShelleyState ss (STS.BbodyState ls bcur) =
-      LedgerState.updateNES ss bcur ls
-    bbs =
-      STS.BbodyState
-        (LedgerState.esLState $ LedgerState.nesEs state)
-        (LedgerState.nesBcur state)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -19,8 +19,8 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
@@ -47,27 +47,14 @@ import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 -------------------------------------------------------------------------------}
 
 class
-  ( Eq (Block era),
-    Show (Block era),
-    NoThunks (Block era),
-    FromCBOR (Annotator (Block era)),
-    ToCBOR (Block era),
-    Eq (BHeader (Crypto era)),
-    Show (BHeader (Crypto era)),
-    NoThunks (BHeader (Crypto era)),
-    FromCBOR (Annotator (BHeader (Crypto era))),
-    ToCBOR (Block era),
-    Eq (NewEpochState era),
-    Show (NewEpochState era),
-    NoThunks (NewEpochState era),
-    FromCBOR (NewEpochState era),
-    ToCBOR (NewEpochState era),
-    Eq (BlockTransitionError era),
-    Show (BlockTransitionError era),
-    NoThunks (BlockTransitionError era),
-    Eq (STS.PredicateFailure (STS.CHAIN era)),
-    Show (STS.PredicateFailure (STS.CHAIN era)),
-    NoThunks (STS.PredicateFailure (STS.CHAIN era))
+  ( ChainData (Block era),
+    AnnotatedData (Block era),
+    ChainData (BHeader (Crypto era)),
+    AnnotatedData (BHeader (Crypto era)),
+    ChainData (NewEpochState era),
+    SerialisableData (NewEpochState era),
+    ChainData (BlockTransitionError era),
+    ChainData (STS.PredicateFailure (STS.CHAIN era))
   ) =>
   ApplyBlock era
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -32,7 +32,6 @@ import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.API.Protocol (ChainDepState (..))
-import Shelley.Spec.Ledger.API.Validation (ShelleyState)
 import Shelley.Spec.Ledger.Address (Addr (..), serialiseAddr)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), Seed)
 import Shelley.Spec.Ledger.BlockChain (checkLeaderValue, mkSeed, seedL)
@@ -77,7 +76,7 @@ poolsByTotalStakeFraction ::
   forall era.
   ShelleyBased era =>
   Globals ->
-  ShelleyState era ->
+  NewEpochState era ->
   PoolDistr (Crypto era)
 poolsByTotalStakeFraction globals ss =
   PoolDistr poolsByTotalStake
@@ -93,7 +92,7 @@ poolsByTotalStakeFraction globals ss =
       IndividualPoolStake (s * stakeRatio) vrf
 
 -- | Calculate the current total stake.
-getTotalStake :: Globals -> ShelleyState era -> Coin
+getTotalStake :: Globals -> NewEpochState era -> Coin
 getTotalStake globals ss =
   let supply = Coin . fromIntegral $ maxLovelaceSupply globals
       es = nesEs ss
@@ -108,7 +107,7 @@ getTotalStake globals ss =
 getNonMyopicMemberRewards ::
   ShelleyBased era =>
   Globals ->
-  ShelleyState era ->
+  NewEpochState era ->
   Set (Either Coin (Credential 'Staking era)) ->
   Map (Either Coin (Credential 'Staking era)) (Map (KeyHash 'StakePool (Crypto era)) Coin)
 getNonMyopicMemberRewards globals ss creds =
@@ -167,7 +166,7 @@ getNonMyopicMemberRewards globals ss creds =
 -- When ranking pools, and reporting their saturation level, in the wallet, we
 -- do not want to use one of the regular snapshots, but rather the most recent
 -- ledger state.
-currentSnapshot :: ShelleyBased era => ShelleyState era -> EB.SnapShot era
+currentSnapshot :: ShelleyBased era => NewEpochState era -> EB.SnapShot era
 currentSnapshot ss =
   stakeDistr utxo dstate pstate
   where
@@ -178,13 +177,13 @@ currentSnapshot ss =
 
 -- | Get the full UTxO.
 getUTxO ::
-  ShelleyState era ->
+  NewEpochState era ->
   UTxO era
 getUTxO = _utxo . _utxoState . esLState . nesEs
 
 -- | Get the UTxO filtered by address.
 getFilteredUTxO ::
-  ShelleyState era ->
+  NewEpochState era ->
   Set (Addr era) ->
   UTxO era
 getFilteredUTxO ss addrs =
@@ -206,7 +205,7 @@ getLeaderSchedule ::
       Seed
   ) =>
   Globals ->
-  ShelleyState era ->
+  NewEpochState era ->
   ChainDepState (Crypto era) ->
   KeyHash 'StakePool (Crypto era) ->
   SignKeyVRF (Crypto era) ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
@@ -148,12 +149,12 @@ import Shelley.Spec.NonIntegral (CompareResult (..), taylorExpCmp)
 
 -- | The hash of a Block Header
 newtype HashHeader crypto = HashHeader {unHashHeader :: (Hash crypto (BHeader crypto))}
-  deriving (Show, Eq, Generic, Ord)
+  deriving stock (Show, Eq, Generic, Ord)
   deriving newtype (NFData, NoThunks)
 
-deriving instance CC.Crypto crypto => ToCBOR (HashHeader crypto)
+deriving newtype instance CC.Crypto crypto => ToCBOR (HashHeader crypto)
 
-deriving instance CC.Crypto crypto => FromCBOR (HashHeader crypto)
+deriving newtype instance CC.Crypto crypto => FromCBOR (HashHeader crypto)
 
 data TxSeq era = TxSeq'
   { txSeqTxns' :: !(StrictSeq (Tx era)),
@@ -228,11 +229,12 @@ data EraIndependentBlockBody
 
 -- | Hash of block body
 newtype HashBBody crypto = UnsafeHashBBody {unHashBody :: (Hash crypto EraIndependentBlockBody)}
-  deriving (Show, Eq, Ord, NoThunks)
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (NoThunks)
 
-deriving instance CC.Crypto crypto => ToCBOR (HashBBody crypto)
+deriving newtype instance CC.Crypto crypto => ToCBOR (HashBBody crypto)
 
-deriving instance CC.Crypto crypto => FromCBOR (HashBBody crypto)
+deriving newtype instance CC.Crypto crypto => FromCBOR (HashBBody crypto)
 
 -- | Hash a given block header
 bhHash ::
@@ -520,6 +522,7 @@ bnonce = mkNonceFromOutputVRF . VRF.certifiedOutput . bheaderEta
 
 data Block era
   = Block' !(BHeader (Crypto era)) !(TxSeq era) BSL.ByteString
+  deriving (Generic)
 
 deriving stock instance
   ShelleyBased era =>
@@ -528,6 +531,10 @@ deriving stock instance
 deriving stock instance
   ShelleyBased era =>
   Eq (Block era)
+
+deriving anyclass instance
+  ShelleyBased era =>
+  NoThunks (Block era)
 
 pattern Block :: Era era => BHeader (Crypto era) -> TxSeq era -> Block era
 pattern Block h txns <-

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -44,7 +44,6 @@ import Shelley.Spec.Ledger.API.Protocol
     updateChainDepState,
   )
 import qualified Shelley.Spec.Ledger.API as API
-import Shelley.Spec.Ledger.API (ShelleyState)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
 import Shelley.Spec.Ledger.Bench.Gen (genBlock, genChainState)
 import Shelley.Spec.Ledger.BlockChain
@@ -54,7 +53,13 @@ import Shelley.Spec.Ledger.BlockChain
     slotToNonce,
   )
 import Shelley.Spec.Ledger.EpochBoundary (unBlocksMade)
-import Shelley.Spec.Ledger.LedgerState (DPState, LedgerState, UTxOState, nesBcur)
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState,
+    LedgerState,
+    NewEpochState,
+    UTxOState,
+    nesBcur
+  )
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv)
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv)
@@ -68,7 +73,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
 
 -- ====================================================================
 
-data ValidateInput era = ValidateInput Globals (ShelleyState era) (Block era)
+data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block era)
 
 sizes :: ValidateInput era -> String
 sizes (ValidateInput _gs ss _blk) = "blockMap size=" ++ show (Map.size (unBlocksMade (nesBcur ss)))
@@ -122,7 +127,7 @@ benchValidate ::
   forall era.
   API.ApplyBlock era =>
   ValidateInput era ->
-  IO (ShelleyState era)
+  IO (NewEpochState era)
 benchValidate (ValidateInput globals state block) =
   case API.applyBlock @era globals state block of
     Right x -> pure x
@@ -145,7 +150,7 @@ benchreValidate ::
   ( API.ApplyBlock era
   ) =>
   ValidateInput era ->
-  ShelleyState era
+  NewEpochState era
 benchreValidate (ValidateInput globals state block) =
   API.reapplyBlock globals state block
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -16,8 +16,10 @@ import Data.Either (fromRight)
 import Data.Proxy
 import Data.Sequence (Seq)
 import Shelley.Spec.Ledger.API
-  ( Block,
+  ( ApplyBlock,
+    Block,
     ChainState (..),
+    GetLedgerView,
     Tx,
   )
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
@@ -84,7 +86,9 @@ genBlock ::
     STS (LEDGER era),
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
-    Signal (LEDGER era) ~ Tx era
+    Signal (LEDGER era) ~ Tx era,
+    GetLedgerView era,
+    ApplyBlock era
   ) =>
   GenEnv era ->
   ChainState era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -74,6 +74,8 @@ type TxGen era =
 genBlock ::
   forall era.
   ( ShelleyTest era,
+    GetLedgerView era,
+    ApplyBlock era,
     STS (LEDGER era),
     BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
@@ -97,7 +99,7 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
 genBlockWithTxGen ::
   forall era.
-  (ShelleyTest era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era), GetLedgerView era, ApplyBlock era) =>
   TxGen era ->
   GenEnv era ->
   ChainState era ->
@@ -161,7 +163,7 @@ genBlockWithTxGen
 
 selectNextSlotWithLeader ::
   forall era.
-  (ShelleyTest era, Mock (Crypto era)) =>
+  (ShelleyTest era, Mock (Crypto era), GetLedgerView era, ApplyBlock era) =>
   GenEnv era ->
   ChainState era ->
   -- Starting slot
@@ -231,7 +233,7 @@ selectNextSlotWithLeader
 -- | The chain state is a composite of the new epoch state and the chain dep
 -- state. We tick both.
 tickChainState ::
-  ShelleyTest era =>
+  (GetLedgerView era, ApplyBlock era) =>
   SlotNo ->
   ChainState era ->
   ChainState era
@@ -259,7 +261,7 @@ tickChainState
         ChainDepState {csProtocol, csTickn} =
           tickChainDepState testGlobals lv isNewEpoch cds
         PrtclState ocertIssue evNonce candNonce = csProtocol
-        nes' = applyTickTransition testGlobals chainNes slotNo
+        nes' = applyTick testGlobals chainNes slotNo
      in ChainState
           { chainNes = nes',
             chainOCertIssue = ocertIssue,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -62,6 +62,8 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, maxLLSupply, mkHash)
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
   ( ShelleyTest era,
+    GetLedgerView era,
+    ApplyBlock era,
     STS (CHAIN era),
     BaseM (CHAIN era) ~ ShelleyBase,
     STS (LEDGERS era),


### PR DESCRIPTION
In the `Shelley.Spec.Ledger.API.*` modules, define type classes for the most
important functionality consensus. These classes are parametric in the era.
Instances should be provided for each era (Shelley, Allegra, Mary, etc.). At the
moment, only instances for `ShelleyEra` are provided.

These classes list a bunch of super-class constraints that consensus relies on.
I have tried to be complete, but there's a good chance I forgot to add a few
constraints that are currently already satisfied.

Default implementations are provided for each method so that an empty instance
declaration should be enough for each class + era combination. The constraints
on these instances are what matters, they should be minimal, e.g., just `Crypto
crypto` and `DSignable ..`.

Note: the super-class constraints of the classes are what consensus needs, *not*
what the default implementations of the methods need. If a default
implementation needs more constraints, add them to the *default signature*.