### PR TITLE
Added TxBody for advanced Era. WIP

### DIFF
--- a/semantics/executable-spec/src/Data/MemoBytes.hs
+++ b/semantics/executable-spec/src/Data/MemoBytes.hs
@@ -54,19 +54,6 @@ import Codec.CBOR.Read(DeserialiseFailure,deserialiseFromBytes)
 data MemoBytes t = Memo {memotype :: !t, memobytes :: ShortByteString}
    deriving (NoThunks) via AllowThunksIn '["memobytes"] (MemoBytes t)
 
-{-
-deriving via AllowThunksIn '["memobytes"] (MemoBytes t)
-         instance (Typeable t, NoThunks t)  => NoThunks(MemoBytes t)
-
-data MemoBytes t = Memo { memotype :: {-# UNPACK #-} !t, memobytes:: ShortByteString }
-  deriving (NoThunks) via AllowThunksIn '["memobytes"] (MemoBytes t)
-
-
-instance NoThunks t => NoThunks(MemoBytes t) where
-  wNoThunks ctxt (Memo x _) = noThunks ("Memo":ctxt) x
-  -- We deliberately allow thunks in the bytes
--}
-
 deriving instance Generic (MemoBytes t)
 
 instance (Typeable t) => ToCBOR (MemoBytes t) where
@@ -82,11 +69,6 @@ instance Eq t => Eq (MemoBytes t) where (Memo x _) == (Memo y _) = x == y
 instance Show t => Show (MemoBytes t) where show (Memo y _) = show y
 
 instance Ord t => Ord (MemoBytes t) where compare (Memo x _) (Memo y _) = compare x y
-
-{-
-instance HasField tag t c => HasField (tag::Symbol) (MemoBytes t) c where
-   getField (Memo x _) = getField @tag x
--}
 
 shorten :: Lazy.ByteString -> ShortByteString
 shorten x = toShort (toStrict x)

--- a/semantics/executable-spec/src/Data/MemoBytes.hs
+++ b/semantics/executable-spec/src/Data/MemoBytes.hs
@@ -12,6 +12,9 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | MemoBytes is an abstration for a datetype that encodes its own serialization.
 --   The idea is to use a newtype around a MemoBytes non-memoizing version.
@@ -25,7 +28,7 @@ module Data.MemoBytes
     shorten,
     showMemo,
     printMemo,
-
+    roundTripMemo,
   )
 where
 import Cardano.Binary
@@ -37,18 +40,32 @@ import Cardano.Binary
   )
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import qualified Data.ByteString.Lazy as Lazy
-import Data.ByteString.Lazy (toStrict)
+import Data.ByteString.Lazy (toStrict,fromStrict)
 import Data.Typeable
 import Data.Coders(runE, Encode, encode,)
 import Codec.CBOR.Write (toLazyByteString)
 import GHC.Generics (Generic)
-import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
+import NoThunks.Class (NoThunks (..),AllowThunksIn(..))
 import Prelude hiding (span)
+import Codec.CBOR.Read(DeserialiseFailure,deserialiseFromBytes)
 
 -- ========================================================================
 
-data MemoBytes t = Memo {memotype :: !t, memobytes :: {-# UNPACK #-} !ShortByteString}
+data MemoBytes t = Memo {memotype :: !t, memobytes :: ShortByteString}
+   deriving (NoThunks) via AllowThunksIn '["memobytes"] (MemoBytes t)
+
+{-
+deriving via AllowThunksIn '["memobytes"] (MemoBytes t)
+         instance (Typeable t, NoThunks t)  => NoThunks(MemoBytes t)
+
+data MemoBytes t = Memo { memotype :: {-# UNPACK #-} !t, memobytes:: ShortByteString }
   deriving (NoThunks) via AllowThunksIn '["memobytes"] (MemoBytes t)
+
+
+instance NoThunks t => NoThunks(MemoBytes t) where
+  wNoThunks ctxt (Memo x _) = noThunks ("Memo":ctxt) x
+  -- We deliberately allow thunks in the bytes
+-}
 
 deriving instance Generic (MemoBytes t)
 
@@ -66,6 +83,11 @@ instance Show t => Show (MemoBytes t) where show (Memo y _) = show y
 
 instance Ord t => Ord (MemoBytes t) where compare (Memo x _) (Memo y _) = compare x y
 
+{-
+instance HasField tag t c => HasField (tag::Symbol) (MemoBytes t) c where
+   getField (Memo x _) = getField @tag x
+-}
+
 shorten :: Lazy.ByteString -> ShortByteString
 shorten x = toShort (toStrict x)
 
@@ -82,3 +104,10 @@ printMemo x = putStrLn (showMemo x)
 
 memoBytes :: Encode w t -> MemoBytes t
 memoBytes t = Memo (runE t) (shorten (toLazyByteString (encode t)))
+
+
+roundTripMemo:: (FromCBOR t) => MemoBytes t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, MemoBytes t)
+roundTripMemo (Memo _t bytes) =
+             case deserialiseFromBytes fromCBOR (fromStrict (fromShort bytes)) of
+                Left err -> Left err
+                Right(leftover, newt) -> Right(leftover,Memo newt bytes)

--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -26,6 +26,7 @@ library
     Cardano.Ledger.Mary.Translation
     Cardano.Ledger.ShelleyMA.Value
     Cardano.Ledger.ShelleyMA.Timelocks
+    Cardano.Ledger.ShelleyMA.TxBody
   other-modules:
     Cardano.Ledger.ShelleyMA
 
@@ -35,6 +36,7 @@ library
     bytestring,
     cardano-binary,
     cardano-crypto-class,
+    cardano-crypto-praos,
     cardano-prelude,
     cardano-slotting,
     containers,
@@ -43,7 +45,7 @@ library
     nothunks,
     partial-order,
     shelley-spec-ledger,
-    small-steps
+    small-steps,
   hs-source-dirs: src
   ghc-options:
     -Wall
@@ -53,3 +55,50 @@ library
     -Wredundant-constraints
     -Wpartial-fields
   default-language:    Haskell2010
+
+
+test-suite cardano-ledger-test
+    type:                exitcode-stdio-1.0
+    main-is:             Tests.hs
+    other-modules:
+      Test.Cardano.Ledger.ShelleyMA.TxBody
+      Test.Cardano.Ledger.ShelleyMA.Timelocks
+
+    hs-source-dirs:      test
+    default-language:    Haskell2010
+    ghc-options:
+      -threaded
+      -rtsopts
+      -with-rtsopts=-N
+      -Wall
+      -Wcompat
+      -Wincomplete-record-updates
+      -Wincomplete-uni-patterns
+      -Wredundant-constraints
+      -- We set a bound here so that we're alerted of potential space
+      -- leaks in our generators (or test) code.
+      --
+      -- The 4 megabytes stack bound and 200 megabytes heap bound were
+      -- determined ad-hoc.
+      "-with-rtsopts=-K4m -M250m"
+    build-depends:
+      cardano-ledger-shelley-ma,
+      base >=4.9 && <4.15,
+      bytestring,
+      cardano-binary,
+      cardano-crypto-class,
+      cardano-crypto-praos,
+      cardano-prelude,
+      cardano-slotting,
+      cborg,
+      containers,
+      deepseq,
+      groups,
+      nothunks,
+      partial-order,
+      shelley-spec-ledger,
+      small-steps,
+      tasty-hedgehog,
+      tasty-hunit,
+      tasty-quickcheck,
+      tasty,

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -247,18 +247,6 @@ hashTimelockScript =
     . Hash.castHash
     . Hash.hashWith (\x -> nativeTimelockTag <> serialize' x)
 
-{-
-instance
-  ( Era era,
-    HasField "vldt" (Core.TxBody era) ValidityInterval,
-    Shelley.TxBodyConstraints era
-  ) =>
-  MultiSignatureScript (Timelock era) era
-  where
-  validateScript = validateTimelock
-  hashScript = hashTimelockScript
--}
-
 showTimelock :: Era era => Timelock era -> String
 showTimelock (Interval (ValidityInterval SNothing SNothing)) = "(Interval -inf .. +inf)"
 showTimelock (Interval (ValidityInterval (SJust (SlotNo x)) SNothing)) = "(Interval " ++ show x ++ " .. +inf)"

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Cardano.Ledger.ShelleyMA.TxBody
+  ( TxBody (TxBody, STxBody),
+    TxBody' (..),
+  )
+where
+
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Cardano.Ledger.Compactible (CompactForm (..), Compactible (..))
+import Cardano.Ledger.Core (Script, Value)
+import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), decodeVI, encodeVI)
+import Data.Coders
+  ( Decode (..),
+    Encode (..),
+    decode,
+    decodeStrictSeq,
+    (!>),
+    (<!),
+  )
+import Data.MemoBytes (Mem, MemoBytes (..), memoBytes)
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import GHC.Records
+import NoThunks.Class (NoThunks (..))
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.Serialization (encodeFoldable)
+import Shelley.Spec.Ledger.TxBody
+  ( DCert (..),
+    TxIn (..),
+    TxOut (..),
+    Wdrl (..),
+  )
+
+-- =====================================================
+-- TxBody has two Era dependent type families
+-- (Value era) and (Script era) (hidden in DCert) in
+-- order to make CBOR instances of things we are going to
+-- have to assume some properties about these.
+
+type FamsFrom era =
+  ( Era era,
+    Typeable era,
+    Typeable (Script era),
+    FromCBOR (CompactForm (Value era)), -- Arises because TxOut uses Compact form
+    FromCBOR (Value era),
+    FromCBOR (Annotator (Script era)), -- Arises becaause DCert memoizes its bytes
+    FromCBOR (Script era)
+  )
+
+type FamsTo era =
+  ( Era era,
+    ToCBOR (Value era),
+    ToCBOR (CompactForm (Value era)), -- Arises because TxOut uses Compact form
+    ToCBOR (Script era)
+  )
+
+-- =======================================================
+
+data TxBody' era = TxBody'
+  { inputs :: !(Set (TxIn era)),
+    outputs :: !(StrictSeq (TxOut era)),
+    dcerts :: !(StrictSeq (DCert era)),
+    wdrls :: !(Wdrl era),
+    txfee :: !Coin,
+    vldt :: !ValidityInterval, -- imported from Timelocks
+    txupdate :: !(StrictMaybe (Update era)),
+    mdhash :: !(StrictMaybe (MetaDataHash era)),
+    forge :: !(Value era)
+  }
+  deriving (Typeable)
+
+-- For each instance we try and use the weakest constraint possible
+-- The surprising (Compactible (Value era))) constraint comes from the fact that TxOut
+-- stores a (Value era) in a compactible form.
+
+deriving instance (Compactible (Value era), Eq (Value era)) => Eq (TxBody' era)
+
+deriving instance (Era era, Compactible (Value era), Show (Value era)) => Show (TxBody' era)
+
+deriving instance Generic (TxBody' era)
+
+deriving instance NoThunks (Value era) => NoThunks (TxBody' era)
+
+instance
+  (FamsFrom era) =>
+  FromCBOR (TxBody' era)
+  where
+  fromCBOR =
+    decode $
+      RecD TxBody'
+        <! From
+        <! D (decodeStrictSeq fromCBOR)
+        <! D (decodeStrictSeq fromCBOR)
+        <! From
+        <! From
+        <! decodeVI -- CBOR Group decoding
+        <! From
+        <! From
+        <! From
+
+instance
+  (FamsFrom era) =>
+  FromCBOR (Annotator (TxBody' era))
+  where
+  fromCBOR = pure <$> fromCBOR
+
+-- ===========================================================================
+-- Wrap it all up in a newtype, hiding the insides with a pattern construtor.
+
+newtype TxBody e = STxBody (MemoBytes (TxBody' e))
+  deriving (Typeable)
+
+deriving instance (Compactible (Value era), Eq (Value era)) => Eq (TxBody era)
+
+deriving instance (Era era, Compactible (Value era), Show (Value era)) => Show (TxBody era)
+
+deriving instance Generic (TxBody era)
+
+deriving newtype instance (Typeable era, NoThunks (Value era)) => NoThunks (TxBody era)
+
+deriving newtype instance (Typeable era) => ToCBOR (TxBody era)
+
+deriving via
+  (Mem (TxBody' era))
+  instance
+    (FamsFrom era) =>
+    FromCBOR (Annotator (TxBody era))
+
+-- Make a Pattern so the newtype and the MemoBytes are hidden
+
+pattern TxBody ::
+  (FamsTo era) =>
+  (Set (TxIn era)) ->
+  (StrictSeq (TxOut era)) ->
+  (StrictSeq (DCert era)) ->
+  (Wdrl era) ->
+  Coin ->
+  ValidityInterval ->
+  (StrictMaybe (Update era)) ->
+  (StrictMaybe (MetaDataHash era)) ->
+  (Value era) ->
+  TxBody era
+pattern TxBody i o d w fee vi u m forge <-
+  STxBody (Memo (TxBody' i o d w fee vi u m forge) _)
+  where
+    TxBody i o d w fee vi u m forge =
+      STxBody $
+        memoBytes $
+          Rec TxBody'
+            !> To i
+            !> E encodeFoldable o
+            !> E encodeFoldable d
+            !> To w
+            !> To fee
+            !> (encodeVI vi) -- CBOR Group encoding
+            !> To u
+            !> To m
+            !> To forge
+
+{-# COMPLETE TxBody #-}
+
+-- ==================================================================
+-- Promote the fields of TxBody' to be fields of TxBody. Either
+-- automatically or by hand. Both methods have drawbacks.
+
+{-
+instance HasField tag (TxBody' e) c => HasField (tag::Symbol) (TxBody e) c where
+   getField (STxBody (Memo x _)) = getField @tag x
+
+-- The method above autmatically lifts the Hasfield instances from TxBody' to TxBody
+-- the problem is, if some other file imports this file, it needs to import both
+-- the hidden type TxBody' and its constructors like this
+-- import Cardano.Ledger.ShelleyMA.TxBody(TxBody'(..))     OR
+-- import qualified Cardano.Ledger.ShelleyMA.TxBody as XXX
+-- Both are very ugly, but at least in the second way, one doesn't need to know the name of TxBody'
+-- So instead we tediously write by hand explicit HasField instances for TxBody
+-}
+
+instance HasField "inputs" (TxBody e) (Set (TxIn e)) where
+  getField (STxBody (Memo m _)) = getField @"inputs" m
+
+instance HasField "outputs" (TxBody e) (StrictSeq (TxOut e)) where
+  getField (STxBody (Memo m _)) = getField @"outputs" m
+
+instance HasField "dcerts" (TxBody e) (StrictSeq (DCert e)) where
+  getField (STxBody (Memo m _)) = getField @"dcerts" m
+
+instance HasField "wdrls" (TxBody e) (Wdrl e) where
+  getField (STxBody (Memo m _)) = getField @"wdrls" m
+
+instance HasField "txfee" (TxBody e) Coin where
+  getField (STxBody (Memo m _)) = getField @"txfee" m
+
+instance HasField "vldt" (TxBody e) ValidityInterval where
+  getField (STxBody (Memo m _)) = getField @"vldt" m
+
+instance HasField "txupdate" (TxBody e) (StrictMaybe (Update e)) where
+  getField (STxBody (Memo m _)) = getField @"txupdate" m
+
+instance HasField "mdhash" (TxBody e) (StrictMaybe (MetaDataHash e)) where
+  getField (STxBody (Memo m _)) = getField @"mdhash" m
+
+instance (Value e ~ vv) => HasField "forge" (TxBody e) vv where
+  getField (STxBody (Memo m _)) = getField @"forge" m

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Value.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -151,6 +152,8 @@ instance
 
 -- ========================================================================
 -- Compactible
+-- This is used in the TxOut which stores the (CompactForm Value). For now that is just Value
+-- We may revisit this, and make it some kind serialized bytes.
 
 instance Compactible (Value era) where
   -- TODO a proper compact form

--- a/shelley-ma/impl/test/Test/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/test/Test/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -1,57 +1,59 @@
-{-# LANGUAGE LambdaCase  #-}
-{-# LANGUAGE  FlexibleContexts  #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 
-module Test.Shelley.Spec.Ledger.MemoBytes
-  ( memoBytesTest,
+module Test.Cardano.Ledger.ShelleyMA.Timelocks
+  ( timelockAndDecodeTests,
     testT,
   )
 where
 
 import Cardano.Binary
-  ( FromCBOR (fromCBOR),
+  ( Annotator (..),
+    FromCBOR (fromCBOR),
+    FullByteString (Full),
     ToCBOR (toCBOR),
     encodeListLen,
     encodeWord,
-    Annotator(..),
-    FullByteString(Full),
   )
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Slotting.Slot (SlotNo (..))
-import Codec.CBOR.FlatTerm(TermToken,toFlatTerm)
-import Codec.CBOR.Read(DeserialiseFailure,deserialiseFromBytes)
+import Codec.CBOR.FlatTerm (TermToken, toFlatTerm)
+import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import qualified Data.ByteString.Lazy as Lazy
-import Data.Sequence.Strict (StrictSeq,fromList)
 import Data.Coders
-  ( Encode(..),
-    Decode(..),
+  ( Decode (..),
+    Encode (..),
+    Wrapped (..),
+    decode,
+    decodeList,
+    decodeStrictSeq,
+    encode,
+    encodeList,
+    encodeStrictSeq,
+    runE,
     (!>),
     (<!),
-    Wrapped(..),
-    runE,
-    encode,
-    decode,
-    encodeList,
-    decodeList,
-    encodeStrictSeq,
-    decodeStrictSeq,
   )
-import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing),invalidKey)
-import Shelley.Spec.Ledger.Serialization( decodeRecordSum )
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes(C)
+import Data.Sequence.Strict (StrictSeq, fromList)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing), invalidKey)
+import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
+import Test.Cardano.Ledger.ShelleyMA.TxBody (TestEra)
 import Test.Tasty
 import Test.Tasty.QuickCheck hiding (scale)
+
+-- ==========================================================================
 
 data TT = A Int | B Int Bool | G [Int] | H (StrictSeq Bool) deriving (Show)
 
 instance FromCBOR TT where
   fromCBOR = decodeRecordSum "TT" $
     \n -> case n of
-      0 -> do i <- fromCBOR; pure (2, A i)                  -- Tag for A is 0
+      0 -> do i <- fromCBOR; pure (2, A i) -- Tag for A is 0
       1 -> do i <- fromCBOR; b <- fromCBOR; pure (3, B i b) -- Tag for B is 1
-      2 -> do l <- decodeList fromCBOR; pure (2, G l)       -- Tag for G is 2
-      3 -> do i <- decodeStrictSeq fromCBOR; pure (2, H i)  -- Tag for H is 3
+      2 -> do l <- decodeList fromCBOR; pure (2, G l) -- Tag for G is 2
+      3 -> do i <- decodeStrictSeq fromCBOR; pure (2, H i) -- Tag for H is 3
       k -> invalidKey k
 
 -- =============================================================================================
@@ -79,11 +81,11 @@ instance ToCBOR TT where
 -- in the FromCBOR instance for TT above.
 
 sA, sB, sG, sGa, sH :: Encode 'Open TT
-sA  = Sum A 0 !> To 7                                        -- Tag for A is 0
-sB  = Sum B 1 !> To 13 !> To True                            -- Tag for B is 1
-sG  = Sum G 2 !> To  [3, 4, 5]                               -- Tag for G is 2
-sGa = Sum G 2 !> E encodeList [2, 5]                         -- Tag for G is 2
-sH =  Sum H 3 !> E encodeStrictSeq (fromList [False, True])    -- Tag for H is 3
+sA = Sum A 0 !> To 7 -- Tag for A is 0
+sB = Sum B 1 !> To 13 !> To True -- Tag for B is 1
+sG = Sum G 2 !> To [3, 4, 5] -- Tag for G is 2
+sGa = Sum G 2 !> E encodeList [2, 5] -- Tag for G is 2
+sH = Sum H 3 !> E encodeStrictSeq (fromList [False, True]) -- Tag for H is 3
 
 -- ===============================================================
 
@@ -91,13 +93,13 @@ sH =  Sum H 3 !> E encodeStrictSeq (fromList [False, True])    -- Tag for H is 3
 -- Examples
 
 data Two = Two Int Bool
-  deriving Show
+  deriving (Show)
 
 decTwo :: Decode 'Closed Two
 encTwo :: Two -> Encode 'Closed Two
+decTwo = (RecD Two <! From <! From)
 
-decTwo           = (RecD Two <! From <! From)
-encTwo (Two a b) = (Rec Two  !> To a !> To b)
+encTwo (Two a b) = (Rec Two !> To a !> To b)
 
 instance ToCBOR Two where
   toCBOR two = encode $ encTwo two
@@ -108,16 +110,16 @@ instance FromCBOR Two where
 -- ============
 
 data Test = Test Int Two Integer
-  deriving Show
+  deriving (Show)
 
 test1 :: Test
 test1 = Test 3 (Two 9 True) 33
 
 decTestWithGroupForTwo :: Decode 'Closed Test
 encTestWithGroupForTwo :: Test -> Encode 'Closed Test
+decTestWithGroupForTwo = (RecD Test <! From <! decTwo <! From)
 
-decTestWithGroupForTwo =              (RecD Test <! From <! decTwo   <! From)
-encTestWithGroupForTwo (Test a b c) = (Rec Test  !> To a !> encTwo b !> To c)
+encTestWithGroupForTwo (Test a b c) = (Rec Test !> To a !> encTwo b !> To c)
 
 instance ToCBOR Test where
   toCBOR = encode . encTestWithGroupForTwo
@@ -128,9 +130,9 @@ instance FromCBOR Test where
 -- ===========
 
 data Three = M Int | N Bool Integer | F Two
-  deriving Show
+  deriving (Show)
 
-three1, three2 , three3 :: Three
+three1, three2, three3 :: Three
 three1 = M 7
 three2 = N True 22
 three3 = F (Two 1 False)
@@ -143,7 +145,6 @@ instance ToCBOR Three where
   toCBOR (F (Two i b)) = encodeListLen 3 <> encodeWord 2 <> toCBOR i <>  toCBOR b
      -- even though F has only 1 argument, we inline the two parts of Two,
      -- so it appears to have 2 arguments. This mimics CBORGROUP instances
-
 
 instance FromCBOR Three where
   fromCBOR = decodeRecordSum "Three" $
@@ -169,24 +170,22 @@ decThree 2 = (SumD F <! decTwo)
 decThree k = Invalid k
 
 encThree :: Three -> Encode 'Open Three
-encThree (M x)   = (Sum M 0) !> To x
+encThree (M x) = (Sum M 0) !> To x
 encThree (N b i) = (Sum N 1) !> To b !> To i
-encThree (F t)   = (Sum F 2) !> encTwo t
-
+encThree (F t) = (Sum F 2) !> encTwo t
 
 instance FromCBOR Three where
-   fromCBOR = decode (Summands "Three" decThree)
-
+  fromCBOR = decode (Summands "Three" decThree)
 
 instance ToCBOR Three where
-   toCBOR x = encode (encThree x)
-
+  toCBOR x = encode (encThree x)
 
 -- ================================================================
 -- In this test we nest many Records, and flatten out everything
 
-data Big = Big Int Bool Integer deriving Show
-data Bigger = Bigger Test Two Big  deriving Show
+data Big = Big Int Bool Integer deriving (Show)
+
+data Bigger = Bigger Test Two Big deriving (Show)
 
 bigger :: Bigger
 bigger = Bigger (Test 2 (Two 4 True) 99) (Two 7 False) (Big 5 False 102)
@@ -194,39 +193,37 @@ bigger = Bigger (Test 2 (Two 4 True) 99) (Two 7 False) (Big 5 False 102)
 -- Note there are 9 individual items, each which fits in one CBOR Token
 -- So we expect the encoding to have 10 items, 1 prefix and 9 others
 
-biggerItems :: [ TermToken ]
+biggerItems :: [TermToken]
 biggerItems = toFlatTerm (encode (encBigger bigger))
 
 decBigger :: Decode 'Closed Bigger
-decBigger = RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From) <!
-                           (RecD Two <! From <! From) <!
-                           (RecD Big <! From <! From <! From)
+decBigger =
+  RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
+    <! (RecD Two <! From <! From)
+    <! (RecD Big <! From <! From <! From)
 
 encBigger :: Bigger -> Encode 'Closed Bigger
 encBigger (Bigger (Test a (Two b c) d) (Two e f) (Big g h i)) =
-            Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c ) !> To d) !>
-                          (Rec Two !> To e !> To f) !>
-                          (Rec Big !> To g !> To h !> To i)
+  Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
+    !> (Rec Two !> To e !> To f)
+    !> (Rec Big !> To g !> To h !> To i)
 
 instance ToCBOR Bigger where
-  toCBOR = encode .encBigger
+  toCBOR = encode . encBigger
 
 instance FromCBOR Bigger where
   fromCBOR = decode decBigger
 
-
-
 -- ================================================================
 
-s1 :: Timelock C
-s1 = Interval (SJust (SlotNo 12)) SNothing
+s1 :: Timelock TestEra
+s1 = Interval (ValidityInterval (SJust (SlotNo 12)) SNothing)
 
-s2 :: Timelock C
-s2 = Interval (SJust (SlotNo 12)) (SJust(SlotNo 23))
+s2 :: Timelock TestEra
+s2 = Interval (ValidityInterval (SJust (SlotNo 12)) (SJust (SlotNo 23)))
 
-s4 :: Timelock C
-s4 = TimelockAnd (fromList [s1,s2])
-
+s4 :: Timelock TestEra
+s4 = TimelockAnd (fromList [s1, s2])
 
 -- ================================================================
 
@@ -236,31 +233,42 @@ testEncode ::
   Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
 testEncode s = deserialiseFromBytes fromCBOR (toLazyByteString (encode s))
 
-testT :: (ToCBOR t,FromCBOR t) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
+testT :: (ToCBOR t, FromCBOR t) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
 testT s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
 
-testAnn :: (ToCBOR t,FromCBOR (Annotator t)) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
-testAnn s = let bytes = (toLazyByteString (toCBOR s))
-            in case deserialiseFromBytes fromCBOR bytes of
-                Left err -> Left err
-                Right(leftover,Annotator f) -> Right(leftover,f (Full bytes))
-
+testAnn :: (ToCBOR t, FromCBOR (Annotator t)) => t -> Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
+testAnn s =
+  let bytes = (toLazyByteString (toCBOR s))
+   in case deserialiseFromBytes fromCBOR bytes of
+        Left err -> Left err
+        Right (leftover, Annotator f) -> Right (leftover, f (Full bytes))
 
 deCodeTest :: (FromCBOR t, Show t) => String -> Encode w t -> TestTree
 deCodeTest name sym =
-   testProperty (name++": Decoding "++show(runE sym)) $
-     case testEncode sym of
-       Right _ -> True
-       Left s -> error ("Fail to decode "++show(runE sym)++" with error "++show s)
+  testProperty (name ++ ": Decoding " ++ show (runE sym)) $
+    case testEncode sym of
+      Right _ -> True
+      Left s -> error ("Fail to decode " ++ show (runE sym) ++ " with error " ++ show s)
 
-annTest :: (FromCBOR (Annotator t), ToCBOR t,Show t) => String -> t -> TestTree
-annTest nm t = testProperty ("RoundTrip: "++nm) $
-                    case testAnn t of
-                      Right _ -> True
-                      Left s -> error ("Fail to roundtrip "++show t++" with error "++show s)
+annTest :: (FromCBOR (Annotator t), ToCBOR t, Show t) => String -> t -> TestTree
+annTest nm t = testProperty ("RoundTrip: " ++ nm) $
+  case testAnn t of
+    Right _ -> True
+    Left s -> error ("Fail to roundtrip " ++ show t ++ " with error " ++ show s)
 
-memoBytesTest :: TestTree
-memoBytesTest = testGroup "MemoBytesTest"
+timelocktests :: TestTree
+timelocktests =
+  testGroup
+    "Timelock tests"
+    [ annTest ("s1 " ++ showTimelock s1) s1,
+      annTest ("s2 " ++ showTimelock s2) s2,
+      annTest ("s4 " ++ showTimelock s4) s4
+    ]
+
+timelockAndDecodeTests :: TestTree
+timelockAndDecodeTests =
+  testGroup
+    "MemoBytesTest"
     [ deCodeTest "sA" sA,
       deCodeTest "sB" sB,
       deCodeTest "sG" sG,
@@ -269,10 +277,8 @@ memoBytesTest = testGroup "MemoBytesTest"
       deCodeTest "Three1" (encThree three1),
       deCodeTest "Three2" (encThree three2),
       deCodeTest "Three3" (encThree three3),
-      deCodeTest "test1"  (encTestWithGroupForTwo test1),
+      deCodeTest "test1" (encTestWithGroupForTwo test1),
       testProperty "encode Bigger is compact" (length biggerItems === 10),
       deCodeTest "Bigger inlines" (encBigger bigger),
-      annTest ("s1 "++showTimelock s1) s1,
-      annTest ("s2 "++showTimelock s2) s2,
-      annTest ("s4 "++showTimelock s4) s4
+      timelocktests
     ]

--- a/shelley-ma/impl/test/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/test/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- =========================
+
+module Test.Cardano.Ledger.ShelleyMA.TxBody (txBodyTest, TestEra) where
+
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Cardano.Crypto.DSIGN
+import Cardano.Crypto.Hash (Blake2b_224, Blake2b_256)
+import Cardano.Crypto.KES
+import Cardano.Crypto.VRF.Praos
+import Cardano.Ledger.Core (Script, TxBody, Value)
+import Cardano.Ledger.Crypto (HASH)
+import qualified Cardano.Ledger.Crypto as CryptoClass
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
+import qualified Cardano.Ledger.ShelleyMA.Value ()
+import qualified Cardano.Ledger.ShelleyMA.Value as ConcreteValue
+import Cardano.Ledger.Val (Val (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
+import qualified Data.Map.Strict as Map
+import Data.MemoBytes (MemoBytes (Memo), roundTripMemo)
+import Data.Sequence.Strict (StrictSeq, fromList)
+import Data.Set (empty)
+import GHC.Records
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.TxBody (Wdrl (..))
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- ============================================================================================
+-- make an example
+-- ============================================================================================
+
+-- First make a fully concrete Era where the Hashing is concrete
+-- without this we won't be able to Serialize or Hash TxID.
+
+data TestCrypto
+
+instance CryptoClass.Crypto TestCrypto where
+  type DSIGN TestCrypto = Ed25519DSIGN
+  type KES TestCrypto = Sum6KES Ed25519DSIGN Blake2b_256
+  type VRF TestCrypto = PraosVRF
+  type HASH TestCrypto = Blake2b_256
+  type ADDRHASH TestCrypto = Blake2b_224
+
+-- Now make a new Era instance. We needtochoose type family instances for Value, Script, and TxBody
+
+data TestEra
+
+instance Era TestEra where
+  type Crypto TestEra = TestCrypto
+
+type instance Value TestEra = ConcreteValue.Value TestEra
+
+type instance Script TestEra = TestScript
+
+type instance TxBody TestEra = Mary.TxBody TestEra
+
+data TestScript = TestScript
+
+instance FromCBOR TestScript where fromCBOR = pure TestScript
+
+instance ToCBOR TestScript where toCBOR TestScript = mempty
+
+instance FromCBOR (Annotator TestScript) where fromCBOR = pure <$> fromCBOR
+
+-- ====================================================================================================
+-- Make a TxBody to test with
+
+eseq :: StrictSeq a
+eseq = fromList []
+
+tx :: Mary.TxBody TestEra
+tx =
+  Mary.TxBody
+    empty
+    eseq
+    eseq
+    (Wdrl Map.empty)
+    (Coin 6)
+    (ValidityInterval (SJust (SlotNo 3)) (SJust (SlotNo 42)))
+    SNothing
+    SNothing
+    (inject (Coin 2))
+
+bytes :: Mary.TxBody era -> ShortByteString
+bytes (Mary.STxBody (Memo _ b)) = b
+
+fieldTests :: TestTree
+fieldTests =
+  testGroup
+    "getField tests"
+    [ testCase "inputs" (assertEqual "inputs" (getField @"inputs" tx) empty),
+      testCase "outputs" (assertEqual "outputs" (getField @"outputs" tx) eseq),
+      testCase "dcerts" (assertEqual "dcerts" (getField @"dcerts" tx) eseq),
+      testCase "wdrls" (assertEqual "wdrls" (getField @"wdrls" tx) (Wdrl Map.empty)),
+      testCase "txfree" (assertEqual "txfree" (getField @"txfee" tx) (Coin 6)),
+      testCase "vldt" (assertEqual "vldt" (getField @"vldt" tx) (ValidityInterval (SJust (SlotNo 3)) (SJust (SlotNo 42)))),
+      testCase "txupdate" (assertEqual "txupdate" (getField @"txupdate" tx) SNothing),
+      testCase "mdhash" (assertEqual "mdhash" (getField @"mdhash" tx) SNothing),
+      testCase "forge" (assertEqual "forge" (getField @"forge" tx) (inject (Coin 2)))
+    ]
+
+roundtrip :: Mary.TxBody TestEra -> Bool
+roundtrip (Mary.STxBody memo) =
+  case roundTripMemo memo of
+    Right ("", new) -> new == memo
+    _other -> False
+
+txBodyTest :: TestTree
+txBodyTest =
+  testGroup
+    "TxBody"
+    [ fieldTests,
+      testCase "length" (assertEqual "length" (Short.length (bytes tx)) 19),
+      testCase "roundtrip" (assertBool "rountrip" (roundtrip tx))
+    ]

--- a/shelley-ma/impl/test/Tests.hs
+++ b/shelley-ma/impl/test/Tests.hs
@@ -1,0 +1,18 @@
+module Main where
+
+import Test.Cardano.Ledger.ShelleyMA.Timelocks (timelockAndDecodeTests)
+import Test.Cardano.Ledger.ShelleyMA.TxBody (txBodyTest)
+import Test.Tasty
+import Test.Tasty.HUnit ()
+
+tests :: TestTree
+tests =
+  testGroup
+    "Cardano-Legder-Tests"
+    [ txBodyTest,
+      timelockAndDecodeTests
+    ]
+
+-- main entry point
+main :: IO ()
+main = defaultMain tests

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -12,7 +12,7 @@ import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
 import Cardano.Ledger.Val (Val)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.Hashing (HashAnnotated)
+import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -28,7 +28,8 @@ type instance Value (ShelleyEra c) = Coin
 type TxBodyConstraints era =
   ( ChainData (TxBody era),
     AnnotatedData (TxBody era),
-    HashAnnotated (TxBody era) era
+    HashAnnotated (TxBody era) era,
+    HashIndex (TxBody era) ~ EraIndependentTxBody
   )
 
 type ShelleyBased era =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -47,7 +47,6 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as WC
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (ADDRHASH, DSIGN)
 import Cardano.Ledger.Era
 import Cardano.Prelude (panic)
@@ -60,6 +59,7 @@ import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import Quiet
+import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody)
 import Shelley.Spec.Ledger.Keys
   ( Hash,
     KeyHash (..),
@@ -69,10 +69,6 @@ import Shelley.Spec.Ledger.Keys
   )
 import qualified Shelley.Spec.Ledger.Keys as Keys
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
-import Shelley.Spec.Ledger.TxBody
-  ( EraIndependentTxBody,
-    TxBody,
-  )
 
 newtype ChainCode = ChainCode {unChainCode :: ByteString}
   deriving (Eq, Generic)
@@ -84,7 +80,7 @@ data BootstrapWitness era = BootstrapWitness'
     bwSig' ::
       !( Keys.SignedDSIGN
            (Crypto era)
-           (Hash (Crypto era) (Core.TxBody era))
+           (Hash (Crypto era) EraIndependentTxBody)
        ),
     bwChainCode' :: !ChainCode,
     bwAttributes' :: !ByteString,
@@ -104,7 +100,7 @@ deriving via
 pattern BootstrapWitness ::
   Era era =>
   (VKey 'Witness (Crypto era)) ->
-  (Keys.SignedDSIGN (Crypto era) (Hash (Crypto era) (Core.TxBody era))) ->
+  (Keys.SignedDSIGN (Crypto era) (Hash (Crypto era) EraIndependentTxBody)) ->
   ChainCode ->
   ByteString ->
   BootstrapWitness era
@@ -215,7 +211,7 @@ makeBootstrapWitness ::
   ( DSIGN (Crypto era) ~ DSIGN.Ed25519DSIGN,
     Era era
   ) =>
-  Hash (Crypto era) (TxBody era) ->
+  Hash (Crypto era) EraIndependentTxBody ->
   Byron.SigningKey ->
   Byron.Attributes Byron.AddrAttributes ->
   BootstrapWitness era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -116,6 +116,7 @@ import Shelley.Spec.Ledger.BaseTypes
     strictMaybeToMaybe,
   )
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
+import Shelley.Spec.Ledger.Hashing (EraIndependentBlockBody)
 import Shelley.Spec.Ledger.Keys
   ( CertifiedVRF,
     Hash,
@@ -224,8 +225,6 @@ instance
       + encodedSizeExpr size (Proxy :: Proxy ByteString)
   listLen _ = 3
   listLenBound _ = 3
-
-data EraIndependentBlockBody
 
 -- | Hash of block body
 newtype HashBBody crypto = UnsafeHashBBody {unHashBody :: (Hash crypto EraIndependentBlockBody)}

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -30,7 +30,6 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.KES.Class (totalPeriodsKES)
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH, KES)
 import Cardano.Ledger.Era
 import Cardano.Ledger.Shelley (ShelleyBased)
@@ -56,6 +55,7 @@ import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.Address
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody)
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.PParams
 import Shelley.Spec.Ledger.Serialization
@@ -66,7 +66,7 @@ import Shelley.Spec.Ledger.Serialization
     utcTimeToCBOR,
   )
 import Shelley.Spec.Ledger.StabilityWindow
-import Shelley.Spec.Ledger.TxBody
+import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxId (..), TxIn (..), TxOut (..))
 import Shelley.Spec.Ledger.UTxO
 
 -- | Genesis Shelley staking configuration.
@@ -315,7 +315,7 @@ initialFundsPseudoTxIn addr =
       TxId
         . ( Crypto.castHash ::
               Crypto.Hash (HASH (Crypto era)) (Addr era) ->
-              Crypto.Hash (HASH (Crypto era)) (Core.TxBody era)
+              Crypto.Hash (HASH (Crypto era)) EraIndependentTxBody
           )
         . Crypto.hashWith serialiseAddr
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.Hashing
   ( HashAnnotated (..),
+    EraIndependentTx,
+    EraIndependentTxBody,
+    EraIndependentBlockBody,
+    EraIndependentWitVKey,
   )
 where
 
@@ -13,8 +19,19 @@ import Cardano.Binary (ToCBOR (..))
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Crypto (HASH)
 import Cardano.Ledger.Era (Crypto (..))
+import Data.Kind
+
+--  Uninhabited types used as HashIndex ranges for HashAnnotated instances
+data EraIndependentTx
+
+data EraIndependentTxBody
+
+data EraIndependentBlockBody
+
+data EraIndependentWitVKey
 
 class Era e => HashAnnotated a e | a -> e where
-  hashAnnotated :: a -> Hash.Hash (HASH (Crypto e)) a
-  default hashAnnotated :: ToCBOR a => a -> Hash.Hash (HASH (Crypto e)) a
-  hashAnnotated = Hash.hashWithSerialiser @(HASH (Crypto e)) toCBOR
+  type HashIndex a :: Type
+  hashAnnotated :: a -> Hash.Hash (HASH (Crypto e)) (HashIndex a)
+  default hashAnnotated :: ToCBOR a => a -> Hash.Hash (HASH (Crypto e)) (HashIndex a)
+  hashAnnotated x = Hash.castHash (Hash.hashWithSerialiser @(HASH (Crypto e)) toCBOR x)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -92,7 +92,7 @@ import Shelley.Spec.Ledger.BaseTypes
     strictMaybeToMaybe,
   )
 import Shelley.Spec.Ledger.Credential (Credential (..))
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (..))
+import Shelley.Spec.Ledger.Hashing (EraIndependentTx, HashAnnotated (..))
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.MetaData (MetaData)
 import Shelley.Spec.Ledger.Scripts
@@ -244,7 +244,8 @@ pattern Tx {_body, _witnessSet, _metadata} <-
 
 {-# COMPLETE Tx #-}
 
-instance ShelleyBased era => HashAnnotated (Tx era) era
+instance ShelleyBased era => HashAnnotated (Tx era) era where
+  type HashIndex (Tx era) = EraIndependentTx
 
 segwitTx ::
   (Shelley.TxBodyConstraints era) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -177,7 +177,7 @@ txid ::
   (Shelley.TxBodyConstraints era) =>
   Core.TxBody era ->
   TxId era
-txid = TxId . hashAnnotated @_ @era
+txid = TxId . hashAnnotated @(Core.TxBody era) @era
 
 -- | Compute the UTxO inputs of a transaction.
 txins ::

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -118,7 +118,6 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Examples.Updates
       Test.Shelley.Spec.Ledger.Fees
       Test.Shelley.Spec.Ledger.LegacyOverlay
-      Test.Shelley.Spec.Ledger.MemoBytes
       Test.Shelley.Spec.Ledger.MultiSigExamples
       Test.Shelley.Spec.Ledger.PropertyTests
       Test.Shelley.Spec.Ledger.Rewards

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -87,8 +87,8 @@ import Shelley.Spec.Ledger.TxBody
     _poolRAcnt,
     _poolRelays,
     _poolVrf,
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
 import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as Original
   ( C_Crypto,
@@ -201,7 +201,7 @@ txSpendOneUTxO =
   Tx
     txbSpendOneUTxO
     mempty
-      { addrWits = makeWitnessesVKey (eraIndTxBodyHash txbSpendOneUTxO) [asWitness alicePay]
+      { addrWits = makeWitnessesVKey (hashAnnotated txbSpendOneUTxO) [asWitness alicePay]
       }
     SNothing
 
@@ -258,7 +258,7 @@ makeSimpleTx body keysAddr =
   Tx
     body
     mempty
-      { addrWits = makeWitnessesVKey (eraIndTxBodyHash body) keysAddr
+      { addrWits = makeWitnessesVKey (hashAnnotated body) keysAddr
       }
     SNothing
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -749,12 +749,12 @@ genesisAccountState =
     }
 
 -- | The transaction Id for 'UTxO' included at the beginning of a new ledger.
-genesisId ::
+genesisId :: forall era.
   (ShelleyTest era) => Ledger.TxId era
 genesisId =
   TxId $
     hashAnnotated
-      ( TxBody
+      ( (TxBody @era)
           Set.empty
           StrictSeq.Empty
           StrictSeq.Empty

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -87,11 +87,8 @@ import Shelley.Spec.Ledger.Tx
     WitnessSetHKD (..),
     getKeyCombination,
   )
-import Shelley.Spec.Ledger.TxBody
-  ( EraIndependentTxBody,
-    Wdrl (..),
-    eraIndTxBodyHash,
-  )
+import Shelley.Spec.Ledger.TxBody( Wdrl (..) )
+import Shelley.Spec.Ledger.Hashing(EraIndependentTxBody,HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO
   ( UTxO (..),
     balance,
@@ -221,7 +218,7 @@ genTx
           scripts = mkScriptWits spendScripts (certScripts ++ wdrlScripts)
           mkTxWits' =
             mkTxWits ksIndexedPaymentKeys ksIndexedStakingKeys wits scripts
-              . eraIndTxBodyHash
+              . hashAnnotated
       -------------------------------------------------------------------------
       -- SpendingBalance, Output Addresses (including some Pointer addresses)
       -- and a Outputs builder that distributes the given balance over addresses.
@@ -365,7 +362,7 @@ genNextDelta
                         ksIndexedStakingKeys
                         vkeyPairs
                         (mkScriptWits msigPairs mempty)
-                        (eraIndTxBodyHash $ _body tx)
+                        (hashAnnotated $ _body tx)
                 pure $
                   delta
                     { extraWitnesses = extraWitnesses <> newWits,
@@ -434,7 +431,7 @@ applyDelta
             ksIndexedStakingKeys
             kw
             sw
-            (eraIndTxBodyHash body')
+            (hashAnnotated body')
      in tx {_body = body', _witnessSet = newWitnessSet}
 
 fix :: (Eq d, Monad m) => (d -> m d) -> d -> m d

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Module      : Test.Shelley.Spec.Ledger.Examples.Combinators

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
@@ -47,8 +47,8 @@ import Shelley.Spec.Ledger.TxBody
     TxIn (..),
     TxOut (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
@@ -148,7 +148,7 @@ txEx1 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ (txbodyEx1 @era))
+            (hashAnnotated $ (txbodyEx1 @era))
             ( [asWitness Cast.alicePay]
                 <> [ asWitness $
                        KeyPair

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -59,8 +59,8 @@ import Shelley.Spec.Ledger.TxBody
     TxIn (..),
     TxOut (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock, Mock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
@@ -165,7 +165,7 @@ txEx1 wits pot =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx1 @era pot)
+            (hashAnnotated $ txbodyEx1 @era pot)
             ([asWitness Cast.alicePay] <> wits)
       }
     SNothing

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -82,8 +82,8 @@ import Shelley.Spec.Ledger.TxBody
     TxIn (..),
     TxOut (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey, txid)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
@@ -190,7 +190,7 @@ txEx1 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx1 @era)
+            (hashAnnotated $ txbodyEx1 @era)
             ( (asWitness <$> [Cast.alicePay, Cast.carlPay])
                 <> (asWitness <$> [Cast.aliceStake])
                 <> [asWitness $ cold Cast.alicePoolKeys]
@@ -287,7 +287,7 @@ txEx2 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx2 @era)
+            (hashAnnotated $ txbodyEx2 @era)
             [ asWitness Cast.alicePay,
               asWitness Cast.aliceStake,
               asWitness Cast.bobStake
@@ -419,7 +419,7 @@ txEx4 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx4 @era)
+            (hashAnnotated $ txbodyEx4 @era)
             [asWitness Cast.alicePay, asWitness Cast.carlStake]
       }
     SNothing
@@ -793,7 +793,7 @@ txEx10 =
     txbodyEx10
     mempty
       { addrWits =
-          makeWitnessesVKey (eraIndTxBodyHash $ txbodyEx10 @era) [asWitness Cast.bobPay, asWitness Cast.bobStake]
+          makeWitnessesVKey (hashAnnotated $ txbodyEx10 @era) [asWitness Cast.bobPay, asWitness Cast.bobStake]
       }
     SNothing
 
@@ -859,7 +859,7 @@ txEx11 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx11 @era)
+            (hashAnnotated $ txbodyEx11 @era)
             ( [asWitness Cast.alicePay]
                 <> [asWitness $ cold Cast.alicePoolKeys]
             )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -49,8 +49,8 @@ import Shelley.Spec.Ledger.TxBody
     TxIn (..),
     TxOut (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey, txid)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
@@ -114,7 +114,7 @@ txEx1 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx1 @era)
+            (hashAnnotated $ txbodyEx1 @era)
             ( [asWitness $ Cast.alicePay]
                 <> [asWitness $ Cast.aliceStake]
                 <> [asWitness $ cold Cast.alicePoolKeys]
@@ -194,7 +194,7 @@ txEx2 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx2 @era)
+            (hashAnnotated $ txbodyEx2 @era)
             ( (asWitness <$> [Cast.alicePay])
                 <> (asWitness <$> [Cast.aliceStake])
                 <> [asWitness $ cold Cast.alicePoolKeys]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
@@ -54,8 +54,8 @@ import Shelley.Spec.Ledger.TxBody
     TxIn (..),
     TxOut (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey, txid)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
@@ -159,7 +159,7 @@ txEx1 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx1 @era)
+            (hashAnnotated $ txbodyEx1 @era)
             ( [asWitness Cast.alicePay]
                 <> [ asWitness . cold $ coreNodeIssuerKeys 0,
                      asWitness . cold $ coreNodeIssuerKeys 3,
@@ -234,7 +234,7 @@ txEx2 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx2 @era)
+            (hashAnnotated $ txbodyEx2 @era)
             ( [asWitness Cast.alicePay]
                 <> [ asWitness . cold $ coreNodeIssuerKeys 1,
                      asWitness . cold $ coreNodeIssuerKeys 5
@@ -327,7 +327,7 @@ txEx3 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (eraIndTxBodyHash $ txbodyEx3 @era)
+            (hashAnnotated $ txbodyEx3 @era)
             [asWitness Cast.alicePay, asWitness . cold $ coreNodeIssuerKeys 1]
       }
     SNothing

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -68,12 +68,11 @@ import Shelley.Spec.Ledger.Tx
     hashScript,
   )
 import Shelley.Spec.Ledger.TxBody
-  ( EraIndependentTxBody,
-    PoolMetaData (..),
+  ( PoolMetaData (..),
     StakePoolRelay (..),
     Wdrl (..),
-    eraIndTxBodyHash,
   )
+import Shelley.Spec.Ledger.Hashing(EraIndependentTxBody,HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock, C)
 import Test.Shelley.Spec.Ledger.Generator.Core (genesisId)
@@ -185,7 +184,7 @@ txSimpleUTxO =
     { _body = txbSimpleUTxO,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (eraIndTxBodyHash $ txbSimpleUTxO @era) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated $ txbSimpleUTxO @era) [alicePay]
           },
       _metadata = SNothing
     }
@@ -227,7 +226,7 @@ txMutiUTxO =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash $ txbMutiUTxO @era)
+                (hashAnnotated $ txbMutiUTxO @era)
                 [ alicePay,
                   bobPay
                 ]
@@ -258,7 +257,7 @@ txRegisterStake =
     { _body = txbRegisterStake,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (eraIndTxBodyHash $ txbRegisterStake @era) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated $ txbRegisterStake @era) [alicePay]
           },
       _metadata = SNothing
     }
@@ -292,7 +291,7 @@ txDelegateStake =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash $ txbDelegateStake @era)
+                (hashAnnotated $ txbDelegateStake @era)
                 [asWitness (alicePay), asWitness bobStake]
           },
       _metadata = SNothing
@@ -323,7 +322,7 @@ txDeregisterStake =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash $ txbDeregisterStake @era)
+                (hashAnnotated $ txbDeregisterStake @era)
                 [alicePay @(Crypto era)]
           },
       _metadata = SNothing
@@ -352,7 +351,7 @@ txRegisterPool =
     { _body = txbRegisterPool,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (eraIndTxBodyHash $ txbRegisterPool @era) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated $ txbRegisterPool @era) [alicePay]
           },
       _metadata = SNothing
     }
@@ -380,7 +379,7 @@ txRetirePool =
     { _body = txbRetirePool,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (eraIndTxBodyHash $ txbRetirePool @era) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated $ txbRetirePool @era) [alicePay]
           },
       _metadata = SNothing
     }
@@ -412,7 +411,7 @@ txWithMD =
     { _body = txbWithMD,
       _witnessSet =
         mempty
-          { addrWits = makeWitnessesVKey (eraIndTxBodyHash $ txbWithMD @era) [alicePay]
+          { addrWits = makeWitnessesVKey (hashAnnotated $ txbWithMD @era) [alicePay]
           },
       _metadata = SJust md
     }
@@ -451,7 +450,7 @@ txWithMultiSig =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash $ txbWithMultiSig @(ShelleyEra c))
+                (hashAnnotated $ txbWithMultiSig @(ShelleyEra c))
                 [alicePay, bobPay],
             scriptWits = Map.singleton (hashScript @(ShelleyEra c) msig) msig
           },
@@ -483,7 +482,7 @@ txWithWithdrawal =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash $ txbWithWithdrawal @era)
+                (hashAnnotated $ txbWithWithdrawal @era)
                 [asWitness (alicePay), asWitness aliceStake]
           },
       _metadata = SNothing

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -156,9 +156,9 @@ import Shelley.Spec.Ledger.Serialization
   )
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx (..), WitnessSetHKD (..), hashScript)
+import Shelley.Spec.Ledger.Hashing(EraIndependentTxBody,HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.TxBody
-  ( EraIndependentTxBody,
-    MIRPot (..),
+  ( MIRPot (..),
     PoolMetaData (..),
     StakePoolRelay (..),
     TxBody (..),
@@ -167,7 +167,6 @@ import Shelley.Spec.Ledger.TxBody
     TxOut (..),
     Wdrl (..),
     WitVKey (..),
-    eraIndTxBodyHash,
     _poolCost,
     _poolMD,
     _poolMDHash,
@@ -302,7 +301,7 @@ testTxbHash ::
   forall era.
   ShelleyTest era =>
   Hash (Crypto era) EraIndependentTxBody
-testTxbHash = eraIndTxBodyHash $ testTxb @era
+testTxbHash = hashAnnotated $ testTxb @era
 
 testKey1 :: CC.Crypto crypto => KeyPair 'Payment crypto
 testKey1 = KeyPair vk sk
@@ -1006,7 +1005,7 @@ tests =
               (SlotNo 500)
               SNothing
               SNothing
-          txbh = eraIndTxBodyHash txb
+          txbh = hashAnnotated txb
           w = makeWitnessVKey txbh testKey1
        in checkEncodingCBORAnnotated
             "tx_min"
@@ -1030,7 +1029,7 @@ tests =
               (SlotNo 500)
               SNothing
               SNothing
-          txbh = eraIndTxBodyHash txb
+          txbh = hashAnnotated txb
           w = makeWitnessVKey txbh testKey1
           s = Map.singleton (hashScript $ testScript @C) (testScript @C)
           wits = mempty {addrWits = Set.singleton w, scriptWits = s}
@@ -1172,8 +1171,8 @@ tests =
           txb3 = txb 502
           txb4 = txb 503
           txb5 = txb 504
-          w1 = makeWitnessVKey (eraIndTxBodyHash txb1) testKey1
-          w2 = makeWitnessVKey (eraIndTxBodyHash txb1) (testKey2 :: KeyPair 'Payment C_Crypto)
+          w1 = makeWitnessVKey (hashAnnotated txb1) testKey1
+          w2 = makeWitnessVKey (hashAnnotated txb1) (testKey2 :: KeyPair 'Payment C_Crypto)
           ws = Set.fromList [w1, w2]
           tx1 = Tx @C txb1 mempty {addrWits = Set.singleton w1} SNothing
           tx2 = Tx @C txb2 mempty {addrWits = ws} SNothing

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -84,8 +84,9 @@ import Shelley.Spec.Ledger.Tx
     WitnessSetHKD (..),
     _ttl,
   )
+import Shelley.Spec.Ledger.Hashing(HashAnnotated(hashAnnotated))
 import Shelley.Spec.Ledger.TxBody
-  (eraIndTxBodyHash,  PoolMetaData (..),
+  ( PoolMetaData (..),
     PoolParams (..),
     Wdrl (..),
     _poolCost,
@@ -365,7 +366,7 @@ aliceGivesBobLovelace
           ttl
           SNothing
           SNothing
-      awits = makeWitnessesVKey (eraIndTxBodyHash txbody) signers
+      awits = makeWitnessesVKey (hashAnnotated txbody) signers
 
 utxoState :: UTxOState C
 utxoState =
@@ -453,7 +454,7 @@ testSpendNotOwnedUTxO =
           (SlotNo 100)
           SNothing
           SNothing
-      aliceWit = makeWitnessVKey (eraIndTxBodyHash txbody) alicePay
+      aliceWit = makeWitnessVKey (hashAnnotated txbody) alicePay
       tx = Tx @C txbody mempty {addrWits = Set.fromList [aliceWit]} SNothing
       wits = Set.singleton (asWitness $ hashKey $ vKey bobPay)
    in testInvalidTx
@@ -485,7 +486,7 @@ testWitnessWrongUTxO =
           (SlotNo 101)
           SNothing
           SNothing
-      aliceWit = makeWitnessVKey (eraIndTxBodyHash tx2body) alicePay
+      aliceWit = makeWitnessVKey (hashAnnotated tx2body) alicePay
       tx = Tx @C txbody mempty {addrWits = Set.fromList [aliceWit]} SNothing
       wits = Set.singleton (asWitness $ hashKey $ vKey bobPay)
    in testInvalidTx
@@ -511,7 +512,7 @@ testEmptyInputSet =
           (SlotNo 0)
           SNothing
           SNothing
-      wits = mempty {addrWits = makeWitnessesVKey (eraIndTxBodyHash txb) [aliceStake]}
+      wits = mempty {addrWits = makeWitnessesVKey (hashAnnotated txb) [aliceStake]}
       tx = Tx txb wits SNothing
       dpState' = addReward dpState (getRwdCred $ mkVKeyRwdAcnt Testnet aliceStake) (Coin 2000)
    in testLEDGER
@@ -571,7 +572,7 @@ testInvalidWintess =
           SNothing
           SNothing
       txb' = txb {_ttl = SlotNo 2}
-      wits = mempty {addrWits = makeWitnessesVKey (eraIndTxBodyHash txb') [alicePay]}
+      wits = mempty {addrWits = makeWitnessesVKey (hashAnnotated txb') [alicePay]}
       tx = Tx @C txb wits SNothing
       errs =
         [ UtxowFailure $
@@ -596,7 +597,7 @@ testWithdrawalNoWit =
           (SlotNo 0)
           SNothing
           SNothing
-      wits = mempty {addrWits = Set.singleton $ makeWitnessVKey (eraIndTxBodyHash txb) alicePay}
+      wits = mempty {addrWits = Set.singleton $ makeWitnessVKey (hashAnnotated txb) alicePay}
       tx = Tx @C txb wits SNothing
       missing = Set.singleton (asWitness $ hashKey $ vKey bobStake)
       errs =
@@ -625,7 +626,7 @@ testWithdrawalWrongAmt =
         mempty
           { addrWits =
               makeWitnessesVKey
-                (eraIndTxBodyHash txb)
+                (hashAnnotated txb)
                 [asWitness alicePay, asWitness bobStake]
           }
       rAcnt = mkVKeyRwdAcnt Testnet bobStake

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -8,7 +8,6 @@ import Shelley.Spec.Ledger.Coin (Coin)
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
 import Test.QuickCheck (Arbitrary (..), Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
-import Test.Shelley.Spec.Ledger.MemoBytes (memoBytesTest)
 import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Shelley.Spec.Ledger.Rewards (rewardTests)
 import Test.Shelley.Spec.Ledger.STSTests (chainExamples)
@@ -35,7 +34,6 @@ mainTests gv =
       --multisigExamples, - TODO re-enable after the script embargo has been lifted
       unitTests,
       setAlgTest,
-      memoBytesTest,
       valTests
     ]
 
@@ -56,7 +54,6 @@ fastTests =
       --multisigExamples, - TODO re-enable after the script embargo has been lifted
       unitTests,
       setAlgTest,
-      memoBytesTest,
       valTests
     ]
 


### PR DESCRIPTION
"Added the TxBody type with validity intervals and forge fields. Tied together with the Timelocks scripts. TxBody is newtype wrapped around a MemoBytes.
It exports a set of HasField instances appropriate for a TxBody. Also created a
test file with a minimum number of test, testing the HasField use and round-trip
CBOR properties. Pay close attention to the discussion about Mutually recursive
data types where this is a type family in the recursion cycle."