### PR TITLE
adjust prior distribution and percentile for pool ranking

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -196,9 +196,9 @@ percentile p prior likelihoods =
     cdf = Seq.zip samplePositions $ Seq.scanl (+) 0 (fromLogWeight <$> values)
 
 percentile' :: Likelihood -> PerformanceEstimate
-percentile' = percentile 0.1 h
+percentile' = percentile 0.5 h
   where
-    h = normalize . Histogram $ logBeta 40 3 <$> samplePositions
+    h = normalize . Histogram $ logBeta 40 1 <$> samplePositions
     -- Beta(n,m)(x) = C * x^(n-1)*(1-x)^(m-1)
     -- log( Beta(n,m)(x) ) = (n-1) * log x + (m-1) * log (1-x)
     logBeta n m x = LogWeight . realToFrac $ (n -1) * log x + (m -1) * log (1 - x)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -19,6 +19,7 @@ module Shelley.Spec.Ledger.Rewards
     Histogram (..),
     LogWeight (..),
     likelihood,
+    applyDecay,
     Likelihood (..),
     leaderProbability,
   )
@@ -168,12 +169,16 @@ likelihood blocks t slotsPerEpoch =
     l x = n * log x + m * log (1 - t * x)
     sample position = LogWeight (realToFrac $ l position)
 
+-- | Decay previous likelihood
+applyDecay :: Float -> Likelihood -> Likelihood
+applyDecay decay (Likelihood logWeights) = Likelihood $ mul decay <$> logWeights
+  where
+    mul x (LogWeight f) = LogWeight (x * f)
+
 posteriorDistribution :: Histogram -> Likelihood -> Histogram
 posteriorDistribution (Histogram points) (Likelihood likelihoods) =
   normalize $
     Histogram $ Seq.zipWith (+) points likelihoods
-
--- TODO decay the histogram
 
 -- | Normalize the histogram so that the total area is 1
 normalize :: Histogram -> Histogram

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -48,12 +48,14 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import Shelley.Spec.Ledger.Keys (asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..),
+    decayFactor,
     emptyRewardUpdate,
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.Rewards
-  ( Likelihood (..),
+  ( applyDecay,
+    Likelihood (..),
     NonMyopic (..),
     emptyNonMyopic,
     leaderProbability,
@@ -885,7 +887,7 @@ reserves12 :: Coin
 reserves12 = addDelta reserves7 deltaR8
 
 alicePerfEx11 :: forall era. ShelleyTest era => Likelihood
-alicePerfEx11 = alicePerfEx8 <> epoch4Likelihood
+alicePerfEx11 = applyDecay decayFactor alicePerfEx8 <> epoch4Likelihood
   where
     epoch4Likelihood = likelihood blocks t (epochSize $ EpochNo 4)
     blocks = 0


### PR DESCRIPTION
For the hit-rate estimation, we are adjusting the prior distribution from `Beta(40,3)` to `Beta(40,1)` and the percentile from `0.1` to `0.5`.

We want a prior that gives a pool that has only produced a few blocks a near perfect hit rate. But we don't want it to be so sticky as to mask when a pool with a lot of produced blocks is noticeably missing blocks. See #1892.