### PR TITLE
Legacy encoder/decoder for MultiSig.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -351,8 +351,8 @@ class
 
 -- | instance of MultiSignatureScript type class
 instance CryptoClass.Crypto c => ValidateScript (ShelleyEra c) where
-  validateScript = validateNativeMultiSigScript
-  hashScript = hashMultiSigScript
+  validateScript = validateNativeMultiSigScript . unWrappedMultiSig
+  hashScript = hashMultiSigScript . unWrappedMultiSig
 
 -- | Script evaluator for native multi-signature scheme. 'vhks' is the set of
 -- key hashes that signed the transaction to be validated.


### PR DESCRIPTION
In #1917 the `Script` type, which had wrapped `MultiSig`, was changed
for a type alias. On the surface this made perfect sense, since the
intended purpose of the `Script` type was to eventually encompass other
types of scripts, which extension is now managed by other means (see
the upcoming #1931). Unfortunately, this resulted in a change to the
serialisation of scripts.

This commit therefore introduces a similar wrapper, now more
appropriately named. This is only used in the Shelley era (and, indeed,
its type enforces this), and replicates the To/From CBOR instances for
the old `Script` type.

For future eras, we instead use the unwrapped 'MultiSig' type directly.