### PR TITLE
Fix Slow down on BadInputsUTxO error

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -325,7 +325,7 @@ utxoInductive = do
   minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
   eval (txins txb ⊆ dom utxo)
-    ?! BadInputsUTxO (txins txb `Set.difference` eval (dom utxo))
+    ?! BadInputsUTxO (Set.filter (\x -> not (Map.member x (unUTxO utxo))) (txins txb))
 
   ni <- liftSTS $ asks networkId
   let addrsWrongNetwork =


### PR DESCRIPTION
The BadInputsUTxO error computes an error report in a way that is very expensive.
This was first brought to my attention by this node issue.
https://github.com/input-output-hk/cardano-node/issues/2022

Further analysis showed that that it might be related to
https://github.com/input-output-hk/ouroboros-consensus/issues/732
because a high instance of BadInputsUTxO  failures were correlated with the slowdown.

Some analysis showed the computing the error report for BadInputsUTxO required computing this expression:      (txins txb `Set.difference` eval (dom utxo))

Computing the domain of utxo is very expensive.  Change this line to
(Set.filter (\ x -> not(Map.member x (unUTxO utxo))) (txins txb))
and things are fixed. This PR solves that problem. 

We have added an issue  input-output-hk/ouroboros-network#1942 to add set difference to the set algebra, using this mapping (set difference to set filter)  when time permits
