### PR TITLE
rename _poolPubKey to _poolId

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -121,7 +121,7 @@ instance Crypto c => TranslateEra (AllegraEra c) PoolParams where
   translateEra ctxt poolParams =
     return $
       PoolParams
-        { _poolPubKey = _poolPubKey poolParams,
+        { _poolId = _poolId poolParams,
           _poolVrf = _poolVrf poolParams,
           _poolPledge = _poolPledge poolParams,
           _poolCost = _poolCost poolParams,

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -81,7 +81,7 @@ instance Crypto c => TranslateEra (MaryEra c) PoolParams where
   translateEra ctxt poolParams =
     return $
       PoolParams
-        { _poolPubKey = _poolPubKey poolParams,
+        { _poolId = _poolId poolParams,
           _poolVrf = _poolVrf poolParams,
           _poolPledge = _poolPledge poolParams,
           _poolCost = _poolCost poolParams,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -93,7 +93,7 @@ delegCWitness (DeRegKey hk) = hk
 delegCWitness (Delegate delegation) = _delegator delegation
 
 poolCWitness :: PoolCert era -> Credential 'StakePool era
-poolCWitness (RegPool pool) = KeyHashObj $ _poolPubKey pool
+poolCWitness (RegPool pool) = KeyHashObj $ _poolId pool
 poolCWitness (RetirePool k _) = KeyHashObj k
 
 genesisCWitness :: GenesisDelegCert era -> KeyHash 'Genesis (ERA.Crypto era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -134,7 +134,7 @@ poolDelegationTransition = do
           minPoolCost = _minPoolCost pp
       poolCost >= minPoolCost ?! StakePoolCostTooLowPOOL poolCost minPoolCost
 
-      let hk = _poolPubKey poolParam
+      let hk = _poolId poolParam
       if eval (hk ∉ (dom stpools))
         then -- register new, Pool-Reg
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -334,7 +334,7 @@ instance FromCBOR StakePoolRelay where
 
 -- | A stake pool.
 data PoolParams era = PoolParams
-  { _poolPubKey :: !(KeyHash 'StakePool (Crypto era)),
+  { _poolId :: !(KeyHash 'StakePool (Crypto era)),
     _poolVrf :: !(Hash (Crypto era) (VerKeyVRF (Crypto era))),
     _poolPledge :: !Coin,
     _poolCost :: !Coin,
@@ -365,7 +365,7 @@ instance Era era => FromCBOR (Wdrl era) where
 instance Era era => ToJSON (PoolParams era) where
   toJSON pp =
     Aeson.object
-      [ "publicKey" .= _poolPubKey pp,
+      [ "publicKey" .= _poolId pp, -- TODO publicKey is an unfortunate name, should be poolId
         "vrf" .= _poolVrf pp,
         "pledge" .= _poolPledge pp,
         "cost" .= _poolCost pp,
@@ -380,7 +380,7 @@ instance Era era => FromJSON (PoolParams era) where
   parseJSON =
     Aeson.withObject "PoolParams" $ \obj ->
       PoolParams
-        <$> obj .: "publicKey"
+        <$> obj .: "publicKey" -- TODO publicKey is an unfortunate name, should be poolId
         <*> obj .: "vrf"
         <*> obj .: "pledge"
         <*> obj .: "cost"
@@ -1014,7 +1014,7 @@ instance
   ToCBORGroup (PoolParams era)
   where
   toCBORGroup poolParams =
-    toCBOR (_poolPubKey poolParams)
+    toCBOR (_poolId poolParams)
       <> toCBOR (_poolVrf poolParams)
       <> toCBOR (_poolPledge poolParams)
       <> toCBOR (_poolCost poolParams)
@@ -1025,7 +1025,7 @@ instance
       <> encodeNullMaybe toCBOR (strictMaybeToMaybe (_poolMD poolParams))
 
   encodedGroupSizeExpr size' proxy =
-    encodedSizeExpr size' (_poolPubKey <$> proxy)
+    encodedSizeExpr size' (_poolId <$> proxy)
       + encodedSizeExpr size' (_poolVrf <$> proxy)
       + encodedSizeExpr size' (_poolPledge <$> proxy)
       + encodedSizeExpr size' (_poolCost <$> proxy)
@@ -1054,7 +1054,7 @@ instance
   FromCBORGroup (PoolParams era)
   where
   fromCBORGroup = do
-    vk <- fromCBOR
+    hk <- fromCBOR
     vrf <- fromCBOR
     pledge <- fromCBOR
     cost <- fromCBOR
@@ -1065,7 +1065,7 @@ instance
     md <- decodeNullMaybe fromCBOR
     pure $
       PoolParams
-        { _poolPubKey = vk,
+        { _poolId = hk,
           _poolVrf = vrf,
           _poolPledge = pledge,
           _poolCost = cost,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -287,7 +287,7 @@ totalDeposits pp stpools cs =
     numNewPools = length $ pools `Set.difference` (Map.keysSet stpools)
 
 getKeyHashFromRegPool :: DCert era -> Maybe (KeyHash 'StakePool (Crypto era))
-getKeyHashFromRegPool (DCertPool (RegPool p)) = Just . _poolPubKey $ p
+getKeyHashFromRegPool (DCertPool (RegPool p)) = Just . _poolId $ p
 getKeyHashFromRegPool _ = Nothing
 
 txup ::

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -134,7 +134,7 @@ genChainInEpoch gv epoch = do
                 | (AllIssuerKeys {vrf, hk}, (owner : _)) <- stakeMap,
                   let pp =
                         PoolParams
-                          { _poolPubKey = hk,
+                          { _poolId = hk,
                             _poolVrf = hashVerKeyVRF $ snd vrf,
                             _poolPledge = Coin 1,
                             _poolCost = Coin 1,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -83,7 +83,7 @@ import Shelley.Spec.Ledger.TxBody
     _poolMargin,
     _poolOwners,
     _poolPledge,
-    _poolPubKey,
+    _poolId,
     _poolRAcnt,
     _poolRelays,
     _poolVrf,
@@ -402,7 +402,7 @@ vrfKeyHash = hashVerKeyVRF . snd . mkVRFKeyPair $ (0, 0, 0, 0, 0)
 mkPoolParameters :: KeyPair 'StakePool B_Crypto -> PoolParams B
 mkPoolParameters keys =
   PoolParams
-    { _poolPubKey = (hashKey . vKey) keys,
+    { _poolId = (hashKey . vKey) keys,
       _poolVrf = vrfKeyHash,
       _poolPledge = Coin 0,
       _poolCost = Coin 0,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
@@ -121,7 +121,7 @@ alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) 0 0)
 alicePoolParams :: forall era. Era era => PoolParams era
 alicePoolParams =
   PoolParams
-    { _poolPubKey = (hashKey . vKey . cold) alicePoolKeys,
+    { _poolId = (hashKey . vKey . cold) alicePoolKeys,
       _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @(Crypto era)),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -287,7 +287,7 @@ newPool pool cs = cs {chainNes = nes'}
     ps = _pstate dps
     ps' =
       ps
-        { _pParams = Map.insert (_poolPubKey pool) pool (_pParams ps)
+        { _pParams = Map.insert (_poolId pool) pool (_pParams ps)
         }
     dps' = dps {_pstate = ps'}
     ls' = ls {_delegationState = dps'}
@@ -309,7 +309,7 @@ reregPool pool cs = cs {chainNes = nes'}
     ps = _pstate dps
     ps' =
       ps
-        { _fPParams = Map.insert (_poolPubKey pool) pool (_pParams ps)
+        { _fPParams = Map.insert (_poolId pool) pool (_pParams ps)
         }
     dps' = dps {_pstate = ps'}
     ls' = ls {_delegationState = dps'}
@@ -331,8 +331,8 @@ updatePoolParams pool cs = cs {chainNes = nes'}
     ps = _pstate dps
     ps' =
       ps
-        { _pParams = Map.insert (_poolPubKey pool) pool (_pParams ps),
-          _fPParams = Map.delete (_poolPubKey pool) (_pParams ps)
+        { _pParams = Map.insert (_poolId pool) pool (_pParams ps),
+          _fPParams = Map.delete (_poolId pool) (_pParams ps)
         }
     dps' = dps {_pstate = ps'}
     ls' = ls {_delegationState = dps'}
@@ -371,7 +371,7 @@ reapPool ::
   ChainState era
 reapPool pool cs = cs {chainNes = nes'}
   where
-    kh = _poolPubKey pool
+    kh = _poolId pool
     nes = chainNes cs
     es = nesEs nes
     ls = esLState es

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -321,8 +321,8 @@ expectedStEx2 =
     . C.newLab blockEx2
     . C.feesAndDeposits feeTx2 (Coin 0)
     . C.newUTxO txbodyEx2
-    . C.delegation Cast.aliceSHK (_poolPubKey $ Cast.alicePoolParams @era)
-    . C.delegation Cast.bobSHK (_poolPubKey $ Cast.alicePoolParams @era)
+    . C.delegation Cast.aliceSHK (_poolId $ Cast.alicePoolParams @era)
+    . C.delegation Cast.bobSHK (_poolId $ Cast.alicePoolParams @era)
     . C.rewardUpdate emptyRewardUpdate
     $ expectedStEx1
 
@@ -460,7 +460,7 @@ expectedStEx4 =
     . C.newLab blockEx4
     . C.feesAndDeposits feeTx4 (Coin 0)
     . C.newUTxO txbodyEx4
-    . C.delegation Cast.carlSHK (_poolPubKey $ Cast.alicePoolParams @era)
+    . C.delegation Cast.carlSHK (_poolId $ Cast.alicePoolParams @era)
     . C.rewardUpdate rewardUpdateEx4
     $ expectedStEx3
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -117,7 +117,7 @@ aliceVRF = mkVRFKeyPair (0, 0, 0, 0, 3)
 alicePoolParams :: forall era. Era era => PoolParams era
 alicePoolParams =
   PoolParams
-    { _poolPubKey = alicePoolKH,
+    { _poolId = alicePoolKH,
       _poolVrf = hashVerKeyVRF . snd $ aliceVRF @(CC.VRF (Crypto era)),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -188,7 +188,7 @@ genPoolInfo PoolSetUpArgs {poolPledge, poolCost, poolMargin, poolMembers} = do
   let members = Map.insert (KeyHashObj . hashKey . vKey $ ownerKey) ownerStake members'
       params =
         PoolParams
-          { _poolPubKey = hashKey . vKey $ coldKey,
+          { _poolId = hashKey . vKey $ coldKey,
             _poolVrf = Crypto.hashVerKeyVRF . snd $ vrfKey,
             _poolPledge = pledge,
             _poolCost = cost,
@@ -212,7 +212,7 @@ genRewardPPs = do
 genBlocksMade :: [PoolParams era] -> Gen (BlocksMade era)
 genBlocksMade pools = BlocksMade . Map.fromList <$> mapM f pools
   where
-    f p = (_poolPubKey p,) <$> genNatural 0 maxPoolBlocks
+    f p = (_poolId p,) <$> genNatural 0 maxPoolBlocks
 
 -- Properties --
 
@@ -231,13 +231,13 @@ rewardsBoundedByPot _ = property $ do
       delegs = fold $
         flip fmap pools $
           \PoolInfo {params, members} ->
-            Map.fromList $ (,_poolPubKey params) <$> Map.keys members
+            Map.fromList $ (,_poolId params) <$> Map.keys members
       rewardAcnts = Set.fromList $ Map.keys delegs
       poolParams =
         Map.fromList $
           fmap
             ( \PoolInfo {params} ->
-                (_poolPubKey params, params)
+                (_poolId params, params)
             )
             pools
       totalLovelace = undelegatedLovelace <> fold stake

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -37,7 +37,7 @@ poolRegistration
       source = sourceSt,
       target = targetSt
     } =
-    let hk = _poolPubKey poolParams
+    let hk = _poolId poolParams
         reRegistration = eval (hk ∈ dom (_pParams sourceSt))
      in if reRegistration
           then

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -174,7 +174,7 @@ import Shelley.Spec.Ledger.TxBody
     _poolMargin,
     _poolOwners,
     _poolPledge,
-    _poolPubKey,
+    _poolId,
     _poolRAcnt,
     _poolRelays,
     _poolVrf,
@@ -622,7 +622,7 @@ tests =
             ( DCertPool
                 ( RegPool
                     ( PoolParams
-                        { _poolPubKey = hashKey . vKey $ testStakePoolKey,
+                        { _poolId = hashKey . vKey $ testStakePoolKey,
                           _poolVrf = testVRFKH @C_Crypto,
                           _poolPledge = poolPledge,
                           _poolCost = poolCost,
@@ -1288,7 +1288,7 @@ tests =
               ps
           params =
             PoolParams
-              { _poolPubKey = (hashKey $ vKey testStakePoolKey),
+              { _poolId = (hashKey $ vKey testStakePoolKey),
                 _poolVrf = testVRFKH @C_Crypto,
                 _poolPledge = Coin 5,
                 _poolCost = Coin 4,
@@ -1333,7 +1333,7 @@ tests =
               ps
           params =
             PoolParams
-              { _poolPubKey = (hashKey $ vKey testStakePoolKey),
+              { _poolId = (hashKey $ vKey testStakePoolKey),
                 _poolVrf = testVRFKH @C_Crypto,
                 _poolPledge = Coin 5,
                 _poolCost = Coin 4,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
@@ -209,7 +209,7 @@ exampleShelleyGenesis =
     poolParams :: L.PoolParams era
     poolParams =
       L.PoolParams
-        { L._poolPubKey = hashKey . snd $ mkKeyPair (1, 0, 0, 0, 1),
+        { L._poolId = hashKey . snd $ mkKeyPair (1, 0, 0, 0, 1),
           L._poolVrf = hashVerKeyVRF . snd $ mkVRFKeyPair (1, 0, 0, 0, 2),
           L._poolPledge = L.Coin 1,
           L._poolCost = L.Coin 5,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -96,7 +96,7 @@ import Shelley.Spec.Ledger.TxBody
     _poolMargin,
     _poolOwners,
     _poolPledge,
-    _poolPubKey,
+    _poolId,
     _poolRAcnt,
     _poolRelays,
     _poolVrf,
@@ -659,7 +659,7 @@ alicePoolColdKeys = KeyPair vk sk
 alicePoolParamsSmallCost :: PoolParams C
 alicePoolParamsSmallCost =
   PoolParams
-    { _poolPubKey = hashKey . vKey $ alicePoolColdKeys,
+    { _poolId = hashKey . vKey $ alicePoolColdKeys,
       _poolVrf = hashVerKeyVRF vkVrf,
       _poolPledge = Coin 1,
       _poolCost = Coin 5, -- Too Small!


### PR DESCRIPTION
The record accessor `_poolPubKey` is a bad name, since it does not hold a public key, but in fact the hash of a public key. We use this field as the stake pool identifier, so I think that `_poolId` is a more descriptive name. One day we can remove the lensy names too :)

This is a low priority change, and it took next to no time to make, so if this is not a convenient time to make the change I am happy to save it for later.