### PR TITLE
renaming last _poolPubKey to _poolId

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -533,7 +533,7 @@ nonMyopicMemberRew
   t
   topPools
   (PerformanceEstimate p) =
-    let nm = nonMyopicStake pp s sigma t (_poolPubKey pool) topPools
+    let nm = nonMyopicStake pp s sigma t (_poolId pool) topPools
         f = maxPool pp rPot (unStakeShare nm) (unStakeShare s)
         fHat = floor (p * (fromRational . coinToRational) f)
      in memberRew (Coin fHat) pool t nm


### PR DESCRIPTION
This should have been a part of #1945 

It is not clear how #1945 passed CI.