### PR TITLE
Fix cddl link in formal spec

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/cddl.tex
+++ b/shelley/chain-and-ledger/formal-spec/cddl.tex
@@ -6,7 +6,7 @@ serialization scheme is specified using
 CDDL (RFC 8610 \cite{rfcCDDL}).
 
 The CDDL specification is located at
-\url{https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/executable-spec/cddl-files}.
+\url{https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files}.
 
 % TODO - Include the CDDL spec inline?
 % \lstinputlisting[backgroundcolor = \color{lightgray}]{../executable-spec/cddl-files/shelley.cddl}


### PR DESCRIPTION
When we moved the CDDL files from the shelley-spec-ledger package
to the shelley-spec-ledger-test package, we did not update the
link in the formal spec.