### PR TITLE
Split ShelleyEra away from ShelleyBased

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -12,7 +12,6 @@ module Cardano.Ledger.Allegra.Translation where
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era hiding (Crypto)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.Iterate.SetAlgebra (biMapFromList, lifo)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
@@ -20,6 +19,7 @@ import Shelley.Spec.Ledger.API
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import qualified Shelley.Spec.Ledger.LedgerState as LS (returnRedeemAddrsToReserves, _delegations)
 import Shelley.Spec.Ledger.Rewards (NonMyopic (..))
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 
 --------------------------------------------------------------------------------
 -- Translation from Shelley to Allegra

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -52,6 +52,7 @@ library
     Shelley.Spec.Ledger.Serialization
     Shelley.Spec.Ledger.Slot
     Shelley.Spec.Ledger.SoftForks
+    Shelley.Spec.Ledger.ShelleyEra
     Shelley.Spec.Ledger.StabilityWindow
     Shelley.Spec.Ledger.STS.Bbody
     Shelley.Spec.Ledger.STS.Chain

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -8,22 +7,13 @@ module Cardano.Ledger.Shelley where
 
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
 import Cardano.Ledger.Val (Val)
-import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
 
 --------------------------------------------------------------------------------
 -- Shelley Era
 --------------------------------------------------------------------------------
-
-data ShelleyEra c
-
-instance CryptoClass.Crypto c => Era (ShelleyEra c) where
-  type Crypto (ShelleyEra c) = c
-
-type instance Value (ShelleyEra _) = Coin
 
 type TxBodyConstraints era =
   ( ChainData (TxBody era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -10,13 +10,14 @@ module Shelley.Spec.Ledger.API
 where
 
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Shelley.Spec.Ledger.API.ByronTranslation as X
 import Shelley.Spec.Ledger.API.Mempool as X
 import Shelley.Spec.Ledger.API.Protocol as X
 import Shelley.Spec.Ledger.API.Types as X
 import Shelley.Spec.Ledger.API.Validation as X
 import Shelley.Spec.Ledger.API.Wallet as X
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 
 class
   ( PraosCrypto (Crypto era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -19,7 +19,6 @@ import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Hashing
 import qualified Cardano.Ledger.Crypto as CC
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<->))
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
@@ -33,6 +32,7 @@ import Shelley.Spec.Ledger.EpochBoundary
 import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.Rewards
 import Shelley.Spec.Ledger.STS.Chain (pparamsToChainChecksData)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Slot
 
 -- | We use the same hashing algorithm so we can unwrap and rewrap the bytes.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -19,7 +19,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -37,6 +37,7 @@ import Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
 import qualified Shelley.Spec.Ledger.STS.Ledgers as Ledgers
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -36,7 +36,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -79,6 +79,7 @@ import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
 import Shelley.Spec.Ledger.STS.Tick (TICKF)
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
 class

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -21,7 +21,7 @@ where
 
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -36,6 +36,7 @@ import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Tick as STS
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
 {-------------------------------------------------------------------------------

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -30,7 +30,7 @@ import Cardano.Binary
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.Monad.Trans.Reader (asks)
@@ -92,6 +92,7 @@ import Shelley.Spec.Ledger.Serialization
     decodeSet,
     encodeFoldable,
   )
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..), TxIn, TxOut (..))
 import Shelley.Spec.Ledger.TxBody

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -31,7 +31,7 @@ import Cardano.Binary
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -98,6 +98,7 @@ import Shelley.Spec.Ledger.Serialization
     decodeSet,
     encodeFoldable,
   )
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import qualified Shelley.Spec.Ledger.SoftForks as SoftForks
 import Shelley.Spec.Ledger.Tx
   ( Tx (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -37,7 +37,6 @@ import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (ADDRHASH)
 import Cardano.Ledger.Era (Crypto (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.DeepSeq (NFData)
 import Data.Aeson
 import qualified Data.ByteString as BS
@@ -144,8 +143,6 @@ deriving newtype instance
 deriving newtype instance (Era era) => ToJSON (ScriptHash era)
 
 deriving newtype instance Era era => FromJSON (ScriptHash era)
-
-type instance Core.Script (ShelleyEra c) = MultiSig (ShelleyEra c)
 
 -- | Hashes native multi-signature script.
 hashMultiSigScript ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/ShelleyEra.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/ShelleyEra.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Shelley.Spec.Ledger.ShelleyEra where
+
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto as CryptoClass
+import Cardano.Ledger.Era (Era (..))
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Scripts (MultiSig)
+import Shelley.Spec.Ledger.Tx
+  ( ValidateScript (..),
+    hashMultiSigScript,
+    validateNativeMultiSigScript,
+  )
+import Shelley.Spec.Ledger.TxBody (TxBody)
+
+data ShelleyEra c
+
+instance CryptoClass.Crypto c => Era (ShelleyEra c) where
+  type Crypto (ShelleyEra c) = c
+
+type instance Core.Value (ShelleyEra _) = Coin
+
+type instance Core.Script (ShelleyEra c) = MultiSig (ShelleyEra c)
+
+type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
+
+-- | instance of MultiSignatureScript type class
+instance CryptoClass.Crypto c => ValidateScript (ShelleyEra c) where
+  validateScript = validateNativeMultiSigScript
+  hashScript = hashMultiSigScript

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -72,9 +72,8 @@ import Cardano.Binary
     withSlice,
   )
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import qualified Cardano.Ledger.Shelley as Shelley
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (fold)
@@ -350,11 +349,6 @@ class
   where
   validateScript :: Core.Script era -> Tx era -> Bool
   hashScript :: Core.Script era -> ScriptHash era
-
--- | instance of MultiSignatureScript type class
-instance CryptoClass.Crypto c => ValidateScript (ShelleyEra c) where
-  validateScript = validateNativeMultiSigScript
-  hashScript = hashMultiSigScript
 
 -- | Script evaluator for native multi-signature scheme. 'vhks' is the set of
 -- key hashes that signed the transaction to be validated.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -87,7 +87,7 @@ import Cardano.Binary
 import Cardano.Ledger.Compactible
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley (ShelleyBased, ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyBased)
 import Cardano.Prelude
   ( decodeEitherBase16,
     panic,
@@ -617,8 +617,6 @@ instance HasField "update" (TxBody era) (StrictMaybe (Update era)) where
 
 instance HasField "mdHash" (TxBody era) (StrictMaybe (MetaDataHash era)) where
   getField = _mdHash'
-
-type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
 
 deriving instance (ShelleyBased era) => Eq (TxBody era)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -76,7 +76,7 @@ import Test.Shelley.Spec.Ledger.BenchmarkFunctions
     ledgerStateWithNregisteredPools,
   )
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 
 -- Generator for coin. This is required, but its ouput is completely discarded.
 -- What is going on here?

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -106,7 +106,7 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 
 -- ===============================================
 -- A special Era to run the Benchmarks in

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -20,7 +20,7 @@ import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto
 import Shelley.Spec.Ledger.BaseTypes (Seed)
 import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.API (PraosCrypto)
 
 -- | Mocking constraints used in generators

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -19,8 +19,8 @@ module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.Monad (foldM)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition.Extended (BaseM, Environment, IRC, STS, Signal, State, TRC (..))
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as TQC

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -41,7 +41,7 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import qualified Cardano.Ledger.Shelley as Shelley
 import Cardano.Slotting.Block (BlockNo (..))
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -24,8 +24,8 @@ import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Byron
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<->))
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Cardano.Prelude
   ( ByteString,
   )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -8,8 +8,8 @@ module Test.Shelley.Spec.Ledger.ByronTranslation (testGroupByronTranslation) whe
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Shelley.Spec.Ledger.API.ByronTranslation
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.Address
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.TxBody

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -18,8 +18,8 @@ import qualified Cardano.Crypto.VRF as VRF
 import qualified Cardano.Ledger.Val as Val
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Era (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Data.ByteString.Base16.Lazy as Base16
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map.Strict as Map (empty, singleton)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -21,8 +21,8 @@ import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.State.Transition.Extended (PredicateFailure, TRC (..))
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Data.Coerce (coerce)
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -95,8 +95,8 @@ import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
 import Test.Shelley.Spec.Ledger.Utils
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import qualified Cardano.Ledger.Core as Core
 import Test.QuickCheck.Gen (Gen (..))
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -193,7 +193,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core (genesisId)
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase, (@?=))
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 
 roundTrip ::
   (Show a, Eq a) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ShelleyTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ShelleyTranslation.hs
@@ -1,6 +1,6 @@
 module Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation) where
 
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.ShelleyEra (ShelleyEra)
 import Shelley.Spec.Ledger.LedgerState (EpochState, returnRedeemAddrsToReserves)
 import Shelley.Spec.Ledger.STS.Chain (totalAdaES)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)


### PR DESCRIPTION
The ShelleyEra data type is now located in
Shelley.Spec.Ledger.ShelleyEra. The type family instances
have also been moved into this module.