### PR TITLE
Revert "Remove unused type variables."

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -42,7 +42,7 @@ type instance PreviousEra (AllegraEra c) = ShelleyEra c
 --
 -- Note: if context is needed, please coordinate with consensus, who will have
 -- to provide the context in the right place.
-type instance TranslationContext (AllegraEra _) = ()
+type instance TranslationContext (AllegraEra c) = ()
 
 instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
   translateEra ctxt nes =

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -35,7 +35,7 @@ type instance PreviousEra (MaryEra c) = AllegraEra c
 --
 -- Note: if context is needed, please coordinate with consensus, who will have
 -- to provide the context in the right place.
-type instance TranslationContext (MaryEra _) = ()
+type instance TranslationContext (MaryEra c) = ()
 
 instance Crypto c => TranslateEra (MaryEra c) NewEpochState where
   translateEra _ = error "TODO Allegra to Mary translation"

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
@@ -89,7 +89,7 @@ class (Era era, Era (PreviousEra era)) => TranslateEra era f where
   -- concrete error type.
   type TranslationError era f :: Type
 
-  type TranslationError _ _ = Void
+  type TranslationError era f = Void
 
   -- | Translate a type @f@ parameterised by the era from an era to the era
   -- after it.

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -23,7 +23,7 @@ data ShelleyEra c
 instance CryptoClass.Crypto c => Era (ShelleyEra c) where
   type Crypto (ShelleyEra c) = c
 
-type instance Value (ShelleyEra _) = Coin
+type instance Value (ShelleyEra c) = Coin
 
 type TxBodyConstraints era =
   ( ChainData (TxBody era),


### PR DESCRIPTION
Revert "Remove unused type variables."

This reverts commit 156e38b7ae0e4ea7941dc1d2dbc9b4aeb515f1f6.

This change was not compatible with GHC 8.6.5:

    src/Cardano/Ledger/Era.hs:92:25: error:
        Unexpected type ‘_’
        In the default declaration for ‘TranslationError’
        A default declaration should have form
          default TranslationError a b = ...
       |
    92 |   type TranslationError _ _ = Void

I don't think we (read: all downstream repos) are ready yet to burn that bridge,
at least not for something so trivial as this.