### PR TITLE
Disable verbose cabal logging

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -101,7 +101,7 @@ jobs:
       run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
 
     - name: Build
-      run: cabal build all -v3 --builddir="$CABAL_BUILDDIR"
+      run: cabal build all --builddir="$CABAL_BUILDDIR"
 
     - name: Git clone
       run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror


### PR DESCRIPTION
Disabling verbose logging because it obscures actual errors, making it less than useful.

For example: https://github.com/input-output-hk/cardano-ledger-specs/runs/1343619857?check_suite_focus=true