### PR TITLE
Fix serialisation of Bimap

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,8 +21,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 72399b18f1bb7d91b21bc9e0e3c28715cde7d124
-  --sha256: 014jw9jkwq3z30hl5pc0in51hzxrdys4964vpppmn1nim994bykx
+  tag: acac87c7af2652b8d86d92c583b6c29234634866
+  --sha256: 1awxr663zgkn8dw13pjzzlzzz5y9y5l2fy14f87331gbrw6n2xdg
   subdir:
     binary
     binary/test

--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
@@ -1,22 +1,34 @@
-{-# LANGUAGE GADTs, MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies  #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DeriveGeneric           #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
 
 module Control.Iterate.SetAlgebra where
 
 import Cardano.Binary
-  ( FromCBOR (..),
+  ( Decoder,
+    FromCBOR (..),
     ToCBOR (..),
+    decodeListLen,
+    decodeMapSkel,
+    dropMap,
   )
-import Codec.CBOR.Decoding (decodeListLenOf)
 import Codec.CBOR.Encoding (encodeListLen)
-import Control.DeepSeq (NFData(rnf))
+import Control.DeepSeq (NFData (rnf))
 import Control.Iterate.Collect
+import Control.Monad (void)
+import Data.Coders (invalidKey)
 import Data.List (sortBy)
 import qualified Data.List as List
 import Data.Map.Internal (Map (..), link, link2)
@@ -137,15 +149,35 @@ data BiMap v a b where MkBiMap:: (v ~ b) => !(Map.Map a b) -> !(Map.Map b (Set.S
                                 --  ^   the 1st and 3rd parameter must be the same:             ^   ^
 
 -- ============== begin necessary Cardano.Binary instances ===============
-instance (Ord a, Ord b,ToCBOR a, ToCBOR b) => ToCBOR (BiMap b a b) where
-  toCBOR (MkBiMap l r) = encodeListLen 2 <> toCBOR l <> toCBOR r
+instance (Ord a, Ord b, ToCBOR a, ToCBOR b) => ToCBOR (BiMap b a b) where
+  -- The `toCBOR` instance encodes only the forward map. We wrap this in a
+  -- length-one list because a _previous_ encoding wrote out both maps, and we
+  -- can easily use the list length token to distinguish between them.
+  toCBOR (MkBiMap l _) = encodeListLen 1 <> toCBOR l
 
-instance (Ord a, Ord b,FromCBOR a, FromCBOR b) => FromCBOR (BiMap b a b) where
-  fromCBOR = do
-    decodeListLenOf 2
-    !x <- fromCBOR
-    !y <- fromCBOR
-    return (MkBiMap x y)
+instance
+  forall a b.
+  (Ord a, Ord b, FromCBOR a, FromCBOR b) =>
+  FromCBOR (BiMap b a b)
+  where
+  fromCBOR =
+    decodeListLen >>= \case
+      1 -> decodeMapAsBimap
+      -- Previous encoding of 'BiMap' encoded both the forward and reverse
+      -- directions. In this case we skip the reverse encoding. Note that,
+      -- further, the reverse encoding was from 'b' to 'a', not the current 'b'
+      -- to 'Set a', and hence the dropper reflects that.
+      2 -> do
+        !x <- decodeMapAsBimap
+        dropMap (void $ fromCBOR @b) (void $ fromCBOR @a)
+        return x
+      k -> invalidKey (fromIntegral k)
+
+-- | Decode a serialised CBOR Map as a Bimap
+decodeMapAsBimap ::
+  (FromCBOR a, FromCBOR b, Ord a, Ord b) =>
+  Decoder s (BiMap b a b)
+decodeMapAsBimap = decodeMapSkel (biMapFromList const)
 
 instance (NoThunks a,NoThunks b) => NoThunks(BiMap v a b) where
   showTypeOf _ = "BiMap"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Bench/Control/Iterate/SetAlgebra/Bimap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Bench/Control/Iterate/SetAlgebra/Bimap.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Benchmarks for Bimap
+module Bench.Control.Iterate.SetAlgebra.Bimap (fromList) where
+
+import Control.Iterate.SetAlgebra (biMapFromAscDistinctList, biMapFromList)
+import Criterion.Main
+import Test.QuickCheck (arbitrary, generate)
+
+-- | Benchmark ways to decode a bimap from a list
+fromList :: Benchmark
+fromList = env (generate arbitrary) $ \(lst :: [(Int, Int)]) ->
+  bgroup "fromList" $
+    [ bench "biMapFromList" $ nf (biMapFromList const) lst,
+      bench "biMapFromAscDistinctList" $ nf biMapFromAscDistinctList lst
+    ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -6,6 +6,7 @@
 
 module Main where
 
+import qualified Bench.Control.Iterate.SetAlgebra.Bimap as Bimap
 import BenchUTxOAggregate (expr, genTestCase)
 import BenchValidation
   ( applyBlock,
@@ -22,10 +23,11 @@ import Cardano.Crypto.KES
 import Cardano.Crypto.VRF.Praos
 import Cardano.Ledger.Crypto (Crypto (..))
 import qualified Cardano.Ledger.Crypto as CryptoClass
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Control.DeepSeq (NFData)
-import Control.SetAlgebra (dom, keysEqual, (▷), (◁))
 import Control.Iterate.SetAlgebra (compile, compute, run)
+import Control.SetAlgebra (dom, keysEqual, (▷), (◁))
 import Criterion.Main
   ( Benchmark,
     bench,
@@ -58,8 +60,8 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.Rewards (likelihood)
 import Shelley.Spec.Ledger.UTxO (UTxO)
-import Test.QuickCheck.Gen as QC
 import Test.QuickCheck (arbitrary)
+import Test.QuickCheck.Gen as QC
 import Test.Shelley.Spec.Ledger.BenchmarkFunctions
   ( initUTxO,
     ledgerDeRegisterStakeKeys,
@@ -76,7 +78,6 @@ import Test.Shelley.Spec.Ledger.BenchmarkFunctions
     ledgerStateWithNregisteredPools,
   )
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
-import Cardano.Ledger.Shelley (ShelleyEra)
 
 -- Generator for coin. This is required, but its ouput is completely discarded.
 -- What is going on here?
@@ -483,5 +484,6 @@ main = do
                 bench "createRUpd" $ whnf (createRUpd testGlobals) cs
             ),
           bench "likelihood" $ whnf (likelihood 1234 0.1) (EpochSize 10000)
-        ]
+        ],
+      bgroup "bimap" $ [Bimap.fromList]
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -212,6 +212,7 @@ benchmark mainbench
     test
   main-is:          Main.hs
   other-modules:
+    Bench.Control.Iterate.SetAlgebra.Bimap,
     BenchUTxOAggregate,
     BenchValidation,
     Shelley.Spec.Ledger.Bench.Gen


### PR DESCRIPTION
This PR addresses a number of issues related to Bimap serialisation:
- The existing serialisation format involved encoding both the forward
and reverse maps, leaving our on-disk state twice as large as it needed
to be.
- A change in #1886 resulted in the internal structure of Bimap
changing, and a consequent inadvertant change in the serialised format.
We want to avoid this wherever possible, since this entails all nodes
needing to rebuild the Ledger DB from scratch.

Consequently, we make the following changes:
- Newly serialised 'Bimap's will serialise only the forward map. This is
then decoded to populate both directions.
- The decoder will also accept the previously encoded format, except
that in this case it ignores the backwards encoding. This should allow
it to decode 'Bimap's encoded before #1886.

The current implementation of 'biMapFromList' does not look terribly
efficient; this commit does not (yet) address that.