### PR TITLE
"Added Sparse serialisation to Cardano.Ledger.ShelleyMA.TxBody

### DIFF
--- a/semantics/executable-spec/src/Data/MemoBytes.hs
+++ b/semantics/executable-spec/src/Data/MemoBytes.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE  DeriveAnyClass #-}
 
 -- | MemoBytes is an abstration for a datetype that encodes its own serialization.
 --   The idea is to use a newtype around a MemoBytes non-memoizing version.
@@ -44,6 +45,7 @@ import Data.ByteString.Lazy (toStrict,fromStrict)
 import Data.Typeable
 import Data.Coders(runE, Encode, encode,)
 import Codec.CBOR.Write (toLazyByteString)
+import Control.DeepSeq (NFData (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..),AllowThunksIn(..))
 import Prelude hiding (span)
@@ -53,6 +55,8 @@ import Codec.CBOR.Read(DeserialiseFailure,deserialiseFromBytes)
 
 data MemoBytes t = Memo {memotype :: !t, memobytes :: ShortByteString}
    deriving (NoThunks) via AllowThunksIn '["memobytes"] (MemoBytes t)
+
+deriving instance NFData t => NFData (MemoBytes t)
 
 deriving instance Generic (MemoBytes t)
 

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -47,6 +47,7 @@ import Cardano.Ledger.Era
 import qualified Cardano.Ledger.Shelley as Shelley
 import Cardano.Slotting.Slot (SlotNo (..))
 import Codec.CBOR.Read (deserialiseFromBytes)
+import Control.DeepSeq (NFData (..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as Lazy
 import Data.ByteString.Short (fromShort)
@@ -114,7 +115,7 @@ data ValidityInterval = ValidityInterval
   { validFrom :: !(StrictMaybe SlotNo),
     validTo :: !(StrictMaybe SlotNo)
   }
-  deriving (Ord, Eq, Generic, Show, NoThunks)
+  deriving (Ord, Eq, Generic, Show, NoThunks, NFData)
 
 encodeVI :: ValidityInterval -> Encode ( 'Closed 'Dense) ValidityInterval
 encodeVI (ValidityInterval f t) = Rec ValidityInterval !> To f !> To t

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -22,7 +22,16 @@
 
 module Cardano.Ledger.ShelleyMA.TxBody
   ( TxBody (TxBody, STxBody),
-    TxBody' (..),
+    TxBodyRaw (..),
+    FamsFrom,
+    FamsTo,
+    txSparse,
+    bodyFields,
+    StrictMaybe (..),
+    isSNothing,
+    fromSJust,
+    ValidityInterval (..),
+    initial,
   )
 where
 
@@ -32,23 +41,30 @@ import Cardano.Ledger.Core (Script, Value)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.ShelleyMA (MaryOrAllegra, ShelleyMAEra)
-import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), decodeVI, encodeVI)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import Cardano.Ledger.Val (Val (..))
+import Control.DeepSeq (NFData (..))
 import Data.Coders
   ( Decode (..),
+    Density (..),
     Encode (..),
+    Field,
+    Wrapped (..),
     decode,
+    decodeSet,
     decodeStrictSeq,
+    field,
     (!>),
-    (<!),
   )
+import qualified Data.Map as Map
 import Data.MemoBytes (Mem, MemoBytes (..), memoBytes)
-import Data.Sequence.Strict (StrictSeq)
-import Data.Set (Set)
+import Data.Sequence.Strict (StrictSeq, fromList)
+import Data.Set (Set, empty)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import GHC.Records
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
 import Shelley.Spec.Ledger.MetaData (MetaDataHash)
@@ -85,7 +101,7 @@ type FamsTo era =
 
 -- =======================================================
 
-data TxBody' era = TxBody'
+data TxBodyRaw era = TxBodyRaw
   { inputs :: !(Set (TxIn era)),
     outputs :: !(StrictSeq (TxOut era)),
     certs :: !(StrictSeq (DCert era)),
@@ -102,41 +118,84 @@ data TxBody' era = TxBody'
 -- The surprising (Compactible (Value era))) constraint comes from the fact that TxOut
 -- stores a (Value era) in a compactible form.
 
-deriving instance (Compactible (Value era), Eq (Value era)) => Eq (TxBody' era)
+deriving instance (NFData (Value era), Era era) => NFData (TxBodyRaw era)
 
-deriving instance (Era era, Compactible (Value era), Show (Value era)) => Show (TxBody' era)
+deriving instance (Compactible (Value era), Eq (Value era)) => Eq (TxBodyRaw era)
 
-deriving instance Generic (TxBody' era)
+deriving instance (Era era, Compactible (Value era), Show (Value era)) => Show (TxBodyRaw era)
 
-deriving instance NoThunks (Value era) => NoThunks (TxBody' era)
+deriving instance Generic (TxBodyRaw era)
 
-instance
-  (FamsFrom era) =>
-  FromCBOR (TxBody' era)
-  where
-  fromCBOR =
-    decode $
-      RecD TxBody'
-        <! From
-        <! D (decodeStrictSeq fromCBOR)
-        <! D (decodeStrictSeq fromCBOR)
-        <! From
-        <! From
-        <! decodeVI -- CBOR Group decoding
-        <! From
-        <! From
-        <! From
+deriving instance NoThunks (Value era) => NoThunks (TxBodyRaw era)
+
+instance (Val (Value era), FamsFrom era) => FromCBOR (TxBodyRaw era) where
+  fromCBOR = decode (SparseKeyed "TxBodyRaw" initial bodyFields [(0, "inputs"), (1, "outputs"), (2, "txfee")])
 
 instance
-  (FamsFrom era) =>
-  FromCBOR (Annotator (TxBody' era))
+  (Val (Value era), FamsFrom era) =>
+  FromCBOR (Annotator (TxBodyRaw era))
   where
   fromCBOR = pure <$> fromCBOR
+
+isSNothing :: StrictMaybe a -> Bool
+isSNothing SNothing = True
+isSNothing _ = False
+
+fromSJust :: StrictMaybe a -> a
+fromSJust (SJust x) = x
+fromSJust SNothing = error "SNothing in fromSJust"
+
+encodeKeyedStrictMaybe :: ToCBOR a => Word -> StrictMaybe a -> Encode ( 'Closed 'Sparse) (StrictMaybe a)
+encodeKeyedStrictMaybe key x = Omit isSNothing (Key key (E (toCBOR . fromSJust) x))
+
+-- Sparse encodings of TxBodyRaw, the key values are fixed by backwarad compatibility
+-- concerns as we want the Shelley era TxBody to deserialise as a Shelley-ma TxBody.
+-- txXparse and bodyFields should be Duals, visual inspection helps ensure this.
+
+txSparse :: (Val (Value era), FamsTo era) => TxBodyRaw era -> Encode ( 'Closed 'Sparse) (TxBodyRaw era)
+txSparse (TxBodyRaw inp out cert wdrl fee (ValidityInterval bot top) up hash frge) =
+  Keyed (\i o f topx c w u h botx forg -> TxBodyRaw i o c w f (ValidityInterval botx topx) u h forg)
+    !> Key 0 (E encodeFoldable inp) -- We don't have to send these in TxBodyX order
+    !> Key 1 (E encodeFoldable out) -- Just hack up a fake constructor with the lambda.
+    !> Key 2 (To fee)
+    !> encodeKeyedStrictMaybe 3 top
+    !> Omit null (Key 4 (E encodeFoldable cert))
+    !> Omit (null . unWdrl) (Key 5 (To wdrl))
+    !> encodeKeyedStrictMaybe 6 up
+    !> encodeKeyedStrictMaybe 7 hash
+    !> encodeKeyedStrictMaybe 8 bot
+    !> Omit isZero (Key 9 (To frge))
+
+bodyFields :: FamsFrom era => Word -> Field (TxBodyRaw era)
+bodyFields 0 = field (\x tx -> tx {inputs = x}) (D (decodeSet fromCBOR))
+bodyFields 1 = field (\x tx -> tx {outputs = x}) (D (decodeStrictSeq fromCBOR))
+bodyFields 2 = field (\x tx -> tx {txfee = x}) From
+bodyFields 3 = field (\x tx -> tx {vldt = (vldt tx) {validTo = x}}) (D (SJust <$> fromCBOR))
+bodyFields 4 = field (\x tx -> tx {certs = x}) (D (decodeStrictSeq fromCBOR))
+bodyFields 5 = field (\x tx -> tx {wdrls = x}) From
+bodyFields 6 = field (\x tx -> tx {update = x}) (D (SJust <$> fromCBOR))
+bodyFields 7 = field (\x tx -> tx {mdHash = x}) (D (SJust <$> fromCBOR))
+bodyFields 8 = field (\x tx -> tx {vldt = (vldt tx) {validFrom = x}}) (D (SJust <$> fromCBOR))
+bodyFields 9 = field (\x tx -> tx {forge = x}) From
+bodyFields n = field (\_ t -> t) (Invalid n)
+
+initial :: (Val (Value era)) => TxBodyRaw era
+initial =
+  TxBodyRaw
+    empty
+    (fromList [])
+    (fromList [])
+    (Wdrl Map.empty)
+    (Coin 0)
+    (ValidityInterval SNothing SNothing)
+    SNothing
+    SNothing
+    zero
 
 -- ===========================================================================
 -- Wrap it all up in a newtype, hiding the insides with a pattern construtor.
 
-newtype TxBody e = STxBody (MemoBytes (TxBody' e))
+newtype TxBody e = STxBody (MemoBytes (TxBodyRaw e))
   deriving (Typeable)
 
 type instance
@@ -151,12 +210,14 @@ deriving instance Generic (TxBody era)
 
 deriving newtype instance (Typeable era, NoThunks (Value era)) => NoThunks (TxBody era)
 
+deriving newtype instance (NFData (Value era), Era era) => NFData (TxBody era)
+
 deriving newtype instance (Typeable era) => ToCBOR (TxBody era)
 
 deriving via
-  (Mem (TxBody' era))
+  (Mem (TxBodyRaw era))
   instance
-    (FamsFrom era) =>
+    (Val (Value era), FamsFrom era) =>
     FromCBOR (Annotator (TxBody era))
 
 instance Era era => HashAnnotated (TxBody era) era where
@@ -165,7 +226,7 @@ instance Era era => HashAnnotated (TxBody era) era where
 -- Make a Pattern so the newtype and the MemoBytes are hidden
 
 pattern TxBody ::
-  (FamsTo era) =>
+  (Val (Value era), FamsTo era) =>
   (Set (TxIn era)) ->
   (StrictSeq (TxOut era)) ->
   (StrictSeq (DCert era)) ->
@@ -177,38 +238,28 @@ pattern TxBody ::
   (Value era) ->
   TxBody era
 pattern TxBody i o d w fee vi u m forge <-
-  STxBody (Memo (TxBody' i o d w fee vi u m forge) _)
+  STxBody (Memo (TxBodyRaw i o d w fee vi u m forge) _)
   where
     TxBody i o d w fee vi u m forge =
       STxBody $
-        memoBytes $
-          Rec TxBody'
-            !> To i
-            !> E encodeFoldable o
-            !> E encodeFoldable d
-            !> To w
-            !> To fee
-            !> (encodeVI vi) -- CBOR Group encoding
-            !> To u
-            !> To m
-            !> To forge
+        memoBytes $ txSparse (TxBodyRaw i o d w fee vi u m forge)
 
 {-# COMPLETE TxBody #-}
 
 -- ==================================================================
--- Promote the fields of TxBody' to be fields of TxBody. Either
+-- Promote the fields of TxBodyRaw to be fields of TxBody. Either
 -- automatically or by hand. Both methods have drawbacks.
 
 {-
-instance HasField tag (TxBody' e) c => HasField (tag::Symbol) (TxBody e) c where
+instance HasField tag (TxBodyRaw e) c => HasField (tag::Symbol) (TxBody e) c where
    getField (STxBody (Memo x _)) = getField @tag x
 
--- The method above autmatically lifts the Hasfield instances from TxBody' to TxBody
+-- The method above autmatically lifts the Hasfield instances from TxBodyRaw to TxBody
 -- the problem is, if some other file imports this file, it needs to import both
--- the hidden type TxBody' and its constructors like this
--- import Cardano.Ledger.ShelleyMA.TxBody(TxBody'(..))     OR
+-- the hidden type TxBodyRaw and its constructors like this
+-- import Cardano.Ledger.ShelleyMA.TxBody(TxBodyRaw(..))     OR
 -- import qualified Cardano.Ledger.ShelleyMA.TxBody as XXX
--- Both are very ugly, but at least in the second way, one doesn't need to know the name of TxBody'
+-- Both are very ugly, but at least in the second way, one doesn't need to know the name of TxBodyRaw
 -- So instead we tediously write by hand explicit HasField instances for TxBody
 -}
 

--- a/shelley-ma/shelley-ma-test/bench/Main.hs
+++ b/shelley-ma/shelley-ma-test/bench/Main.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | This benchmark file is a placholder for benchmarks
+module Main where
+
+import Criterion.Main
+  ( -- bench, bgroup, nf,
+    defaultMain,
+  )
+
+main :: IO ()
+main = defaultMain []

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -114,3 +114,46 @@ test-suite cardano-ledger-shelley-ma-test
       tasty,
       text,
       QuickCheck,
+
+
+benchmark marybench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:
+    bench
+  main-is:          Main.hs
+  default-language:    Haskell2010
+  other-modules:
+
+  build-depends:
+   cardano-ledger-shelley-ma-test,
+      base >=4.9 && <4.15,
+      criterion,
+      bytestring,
+      cardano-ledger-shelley-ma,
+      cardano-binary,
+      cardano-crypto-class,
+      cardano-crypto-praos,
+      cardano-prelude,
+      cardano-slotting,
+      cborg,
+      containers,
+      deepseq,
+      groups,
+      nothunks,
+      partial-order,
+      shelley-spec-ledger,
+      small-steps,
+      tasty-hedgehog,
+      tasty-hunit,
+      tasty-quickcheck,
+      tasty
+  ghc-options:
+      -threaded
+      -rtsopts
+      -with-rtsopts=-N
+      -Wall
+      -Wcompat
+      -Wincomplete-record-updates
+      -Wincomplete-uni-patterns
+      -Wredundant-constraints
+      -O2

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -22,20 +22,18 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
   )
 where
 
-import Cardano.Binary
-  ( toCBOR,
-  )
+import Cardano.Binary(toCBOR)
+import Cardano.Ledger.Era(Era(..))
+import Cardano.Ledger.ShelleyMA.Timelocks(Timelock(..), ValidityInterval(..))
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Allegra (AllegraEra)
 import qualified Cardano.Ledger.Core as Abstract
-import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Mary (MaryEra)
 import qualified Cardano.Ledger.Mary.Value as Mary (AssetID (..), PolicyID (..), Value (..))
 import Cardano.Ledger.Shelley (ShelleyBased)
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA.STS
 import qualified Cardano.Ledger.ShelleyMA.Scripts as MA (Timelock (..))
-import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval)
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA (TxBody (..))
 import Data.Coerce (coerce)
 import Data.Sequence.Strict (fromList)
@@ -54,10 +52,11 @@ import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
 import Test.Tasty.QuickCheck (Gen)
+import qualified Cardano.Ledger.Mary.Value as ConcreteValue
+import Test.Shelley.Spec.Ledger.Serialisation.Generators() -- imports arbitray instance for MultiSig
 
 {-------------------------------------------------------------------------------
   ShelleyMAEra Generators
-
   Generators used for roundtrip tests, generated values are not
   necessarily valid
 -------------------------------------------------------------------------------}
@@ -120,6 +119,7 @@ instance Mock c => Arbitrary (MA.TxBody (MaryEra c)) where
 instance Mock c => Arbitrary (Timelock (MaryEra c)) where
   arbitrary = sizedTimelock maxTimelockDepth
 
+
 instance Mock c => Arbitrary (Mary.PolicyID (MaryEra c)) where
   arbitrary = Mary.PolicyID <$> arbitrary
 
@@ -148,3 +148,9 @@ instance Arbitrary ValidityInterval where
 
 instance Mock c => Arbitrary (MA.STS.UtxoPredicateFailure (AllegraEra c)) where
   arbitrary = genericArbitraryU
+
+instance Mock c => Arbitrary (ConcreteValue.PolicyID  (AllegraEra c)) where
+  arbitrary = ConcreteValue.PolicyID <$> arbitrary
+
+instance Mock c => Arbitrary (ConcreteValue.Value  (AllegraEra c)) where
+  arbitrary = ConcreteValue.Value <$> arbitrary <*> arbitrary

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
@@ -29,15 +29,10 @@ import Data.Sequence.Strict (fromList)
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Shelley.Spec.Ledger.Scripts (MultiSig, getMultiSigBytes)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (embedTripAnn, roundTripAnn)
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (maxTimelockDepth, sizedTimelock)
 import Test.Cardano.Ledger.ShelleyMA.TxBody (TestEra)
-import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty
-import Test.Tasty.QuickCheck (Arbitrary, arbitrary, testProperty)
-
-instance Arbitrary (Timelock TestEra) where
-  arbitrary = sizedTimelock maxTimelockDepth
+import Test.Tasty.QuickCheck (testProperty)
 
 -- ================================================================
 

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -6,13 +6,20 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_GHC  -fno-warn-orphans #-} -- Arbitrary instances
 -- =========================
 
-module Test.Cardano.Ledger.ShelleyMA.TxBody (txBodyTest, TestEra) where
+module Test.Cardano.Ledger.ShelleyMA.TxBody
+  ( txBodyTest,
+    TestEra,
+    genShelleyBody,
+    genMaryBody,
+    genMaryTxBody,
+    oldStyleRoundTrip,
+  ) where
 
-import Cardano.Ledger.Core (Script, TxBody, Value)
-import qualified Cardano.Ledger.Mary.Value ()
-import qualified Cardano.Ledger.Mary.Value as ConcreteValue
+import Cardano.Binary(ToCBOR(..))
+import Cardano.Ledger.Core (Value)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
 import Cardano.Ledger.Val (Val (..))
@@ -27,21 +34,43 @@ import GHC.Records
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.TxBody (Wdrl (..))
+import qualified Shelley.Spec.Ledger.TxBody as Shelley
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Cardano.Ledger.ShelleyMA.TestEra(TestEra,TestScript)
-
+import Test.Cardano.Ledger.ShelleyMA.TestEra(TestCrypto)
+import Cardano.Ledger.ShelleyMA.TxBody
+  ( TxBodyRaw(..),
+    FamsFrom,
+    txSparse,
+    bodyFields,
+    initial,
+   )
+import Data.Coders
+  ( Wrapped(..),
+    Density(..),
+    encode,
+    Decode(..),
+    decode,
+  )
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators() -- Arbitrary instances
+import Test.Shelley.Spec.Ledger.Serialisation.Generators() -- Arbitrary instances
+import Test.Tasty.QuickCheck
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
+  ( roundTrip',
+    embedTrip',
+    roundTripAnn,
+    RoundTripResult
+  )
+import Cardano.Ledger.Mary (MaryEra)
 -- ============================================================================================
 -- make an example
 -- ============================================================================================
 
 -- First make a fully concrete Era where the Hashing is concrete
 -- without this we won't be able to Serialize or Hash TxID. We use
---the tools supplied by Test.Cardano.Ledger.ShelleyMA.TestEra(TestEra,TestScript)
+-- TestCrypto from Test.Cardano.Ledger.ShelleyMA.TestEra(TestCrypto)
 
-type instance Value TestEra = ConcreteValue.Value TestEra
-type instance Script TestEra = TestScript
-type instance TxBody TestEra = Mary.TxBody TestEra
+type TestEra = MaryEra TestCrypto
 
 -- ====================================================================================================
 -- Make a TxBody to test with
@@ -49,8 +78,8 @@ type instance TxBody TestEra = Mary.TxBody TestEra
 eseq :: StrictSeq a
 eseq = fromList []
 
-tx :: Mary.TxBody TestEra
-tx =
+txM :: Mary.TxBody TestEra
+txM =
   Mary.TxBody
     empty
     eseq
@@ -69,15 +98,15 @@ fieldTests :: TestTree
 fieldTests =
   testGroup
     "getField tests"
-    [ testCase "inputs" (assertEqual "inputs" (getField @"inputs" tx) empty),
-      testCase "outputs" (assertEqual "outputs" (getField @"outputs" tx) eseq),
-      testCase "certs" (assertEqual "certs" (getField @"certs" tx) eseq),
-      testCase "wdrls" (assertEqual "wdrls" (getField @"wdrls" tx) (Wdrl Map.empty)),
-      testCase "txfree" (assertEqual "txfree" (getField @"txfee" tx) (Coin 6)),
-      testCase "vldt" (assertEqual "vldt" (getField @"vldt" tx) (ValidityInterval (SJust (SlotNo 3)) (SJust (SlotNo 42)))),
-      testCase "update" (assertEqual "update" (getField @"update" tx) SNothing),
-      testCase "mdHash" (assertEqual "mdHash" (getField @"mdHash" tx) SNothing),
-      testCase "forge" (assertEqual "forge" (getField @"forge" tx) (inject (Coin 2)))
+    [ testCase "inputs" (assertEqual "inputs" (getField @"inputs" txM) empty),
+      testCase "outputs" (assertEqual "outputs" (getField @"outputs" txM) eseq),
+      testCase "certs" (assertEqual "certs" (getField @"certs" txM) eseq),
+      testCase "wdrls" (assertEqual "wdrls" (getField @"wdrls" txM) (Wdrl Map.empty)),
+      testCase "txfree" (assertEqual "txfree" (getField @"txfee" txM) (Coin 6)),
+      testCase "vldt" (assertEqual "vldt" (getField @"vldt" txM) (ValidityInterval (SJust (SlotNo 3)) (SJust (SlotNo 42)))),
+      testCase "update" (assertEqual "update" (getField @"update" txM) SNothing),
+      testCase "mdHash" (assertEqual "mdHash" (getField @"mdHash" txM) SNothing),
+      testCase "forge" (assertEqual "forge" (getField @"forge" txM) (inject (Coin 2)))
     ]
 
 roundtrip :: Mary.TxBody TestEra -> Bool
@@ -86,11 +115,60 @@ roundtrip (Mary.STxBody memo) =
     Right ("", new) -> new == memo
     _other -> False
 
+-- =====================================================================
+-- Now some random property tests
+
+checkSparse :: TxBodyRaw TestEra -> Bool
+checkSparse tx = case oldStyleRoundTrip tx of
+    Right("",_) -> True
+    Right(left,_) -> error ("left over input: "++show left)
+    Left s -> error (show s)
+
+embedTest :: Gen Bool
+embedTest = do
+  shelleybody <- genShelleyBody
+  case embedTrip' toCBOR (decode (getTxSparse @TestEra)) shelleybody of
+     Right("",_) -> pure True
+     Right(left,_) -> error ("left over input: "++show left)
+     Left s -> error (show s)
+
+getTxSparse ::  (Val (Value era),FamsFrom era) => Decode ('Closed 'Dense) (TxBodyRaw era)
+getTxSparse = SparseKeyed "TxBodyRaw" initial bodyFields [(0,"inputs"),(1,"outputs"),(2,"txfee")]
+
+oldStyleRoundTrip:: TxBodyRaw TestEra -> RoundTripResult (TxBodyRaw TestEra)
+oldStyleRoundTrip x = roundTrip' (encode . txSparse) (decode getTxSparse) x
+
+genShelleyBody :: Gen (Shelley.TxBody TestEra)
+genShelleyBody = Shelley.TxBody <$> arbitrary <*> pure eseq <*> arbitrary <*> arbitrary
+                                <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+genMaryBody :: Gen (TxBodyRaw TestEra)
+genMaryBody = TxBodyRaw <$> arbitrary <*> pure eseq <*> arbitrary <*> arbitrary
+                      <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary (TxBodyRaw TestEra) where
+  arbitrary = genMaryBody
+
+genMaryTxBody :: Gen (Mary.TxBody TestEra)
+genMaryTxBody = Mary.TxBody <$> arbitrary <*> pure eseq <*> arbitrary <*> arbitrary
+                      <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+checkSparseAnn :: Mary.TxBody TestEra -> Bool
+checkSparseAnn tx = case roundTripAnn tx of
+    Right("",_) -> True
+    Right(left,_) -> error ("left over input: "++show left)
+    Left s -> error (show s)
+
+-- ======================================================
+
 txBodyTest :: TestTree
 txBodyTest =
   testGroup
     "TxBody"
-    [ fieldTests,
-      testCase "length" (assertEqual "length" (Short.length (bytes tx)) 19),
-      testCase "roundtrip" (assertBool "rountrip" (roundtrip tx))
+    [ fieldTests
+    , testCase "length" (assertEqual "length" 16 (Short.length (bytes txM)))
+    , testCase "roundtrip txM" (assertBool "rountrip" (roundtrip txM))
+    , testProperty "roundtrip sparse TxBodyRaw" checkSparse
+    , testProperty "embed Shelley sparse TxBodyRaw" embedTest
+    , testProperty "routrip sparse TxBody" checkSparseAnn
     ]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
@@ -33,6 +33,7 @@ import Cardano.Prelude (cborError)
 import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
+import Control.DeepSeq (NFData (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -89,7 +90,7 @@ instance FromCBOR MetaDatum where
   fromCBOR = decodeMetaDatum
 
 newtype MetaDataHash era = MetaDataHash {unsafeMetaDataHash :: Hash (Crypto era) MetaData}
-  deriving (Show, Eq, Ord, NoThunks)
+  deriving (Show, Eq, Ord, NoThunks, NFData)
 
 deriving instance Era era => ToCBOR (MetaDataHash era)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -325,7 +325,7 @@ emptyPParams =
 -- | Update Proposal
 data Update era
   = Update !(ProposedPPUpdates era) !EpochNo
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, NFData)
 
 instance NoThunks (Update era)
 


### PR DESCRIPTION
We added sparse (one field at a time) serialiation for Cardano.Ledger.ShelleyMA.TxBody.
This was carefully designed so that is backward comaptible with Shelley.Spec.Ledger.TxBody.
Shelley.Spec.Ledger.TxBody should deserialise as Cardano.Ledger.ShelleyMA.TxBody.
We added roundtrip property tests for Cardano.Ledger.ShelleyMA.TxBody, and rountrip
embedding tests for Shelley.Spec.Ledger.TxBody. While benchmarking during development
we needed to add a few NFData instances."