### PR TITLE
Value encoding

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -16,11 +16,11 @@ shadowing warnings for the named field puns when used with a pattern synonym.
 module Cardano.Ledger.Mary.Translation where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Compactible
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era hiding (Crypto)
 import Cardano.Ledger.Mary (MaryEra)
-import Cardano.Ledger.Mary.Value
+import Cardano.Ledger.Mary.Value (Value (..))
 import Cardano.Ledger.ShelleyMA.Metadata (Metadata (..), pattern Metadata)
 import Cardano.Ledger.ShelleyMA.Scripts (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody
@@ -29,6 +29,7 @@ import Control.Iterate.SetAlgebra (biMapFromList, lifo)
 import Data.Coerce (coerce)
 import Data.Foldable (Foldable (toList))
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import Shelley.Spec.Ledger.API hiding (TxBody)
@@ -362,4 +363,7 @@ translateValue :: Era era => Coin -> Value era
 translateValue = Val.inject
 
 translateCompactValue :: Era era => CompactForm Coin -> CompactForm (Value era)
-translateCompactValue = toCompact . translateValue . fromCompact
+translateCompactValue =
+  fromMaybe (error msg) . toCompact . translateValue . fromCompact
+  where
+    msg = "impossible error: compact coin is out of range"

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.Scripts ()
 import Cardano.Ledger.ShelleyMA.TxBody ()
 import Cardano.Ledger.Torsor (Torsor (..))
-import Cardano.Ledger.Val (Val)
+import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, Val)
 import Control.State.Transition.Extended
 import Data.Foldable (Foldable (toList))
 import qualified Data.Map.Strict as Map
@@ -120,6 +120,8 @@ instance
     Typeable ma,
     STS (UTXO (ShelleyMAEra ma c)),
     BaseM (UTXO (ShelleyMAEra ma c)) ~ ShelleyBase,
+    DecodeMint (Core.Value (ShelleyMAEra ma c)),
+    DecodeNonNegative (Core.Value (ShelleyMAEra ma c)),
     Compactible (Core.Value (ShelleyMAEra ma c)),
     Val (Core.Value (ShelleyMAEra ma c)),
     GetPolicies (Core.Value (ShelleyMAEra ma c)) (ShelleyMAEra ma c),

--- a/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
+++ b/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
@@ -260,3 +260,17 @@ genesishash           = $hash28
 
 vrf_keyhash           = $hash32
 metadata_hash         = $hash32
+
+; allegra differences
+transaction_body_allegra =
+  { 0 : set<transaction_input>
+  , 1 : [* transaction_output_allegra]
+  , 2 : coin ; fee
+  , ? 3 : uint ; ttl
+  , ? 4 : [* certificate]
+  , ? 5 : withdrawals
+  , ? 6 : update
+  , ? 7 : metadata_hash
+  , ? 8 : uint ; validity interval start
+  }
+transaction_output_allegra = [address, amount : coin]

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -49,7 +49,7 @@ import Test.Cardano.Ledger.EraBuffet (MaryTest)
 import Test.Cardano.Ledger.Mary.Examples (testMaryNoDelegLEDGER)
 import qualified Test.Cardano.Ledger.Mary.Examples.Cast as Cast
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
 
 ------------------------------
 -- Set Up the Initial State --
@@ -528,7 +528,7 @@ testNegEx2 :: Assertion
 testNegEx2 = do
   r <- try (evaluate $ txbodyNegEx2 == txbodyNegEx2)
   case r of
-    Left (ErrorCall e) -> e @?= "out of bounds : -1"
+    Left (ErrorCall _) -> pure ()
     Right _ -> assertFailure $ "constructed negative TxOut Value"
 
 --

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/CDDL.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/CDDL.hs
@@ -25,9 +25,9 @@ cddlTests :: Int -> TestTree
 cddlTests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
     [ cddlTest @(Core.Value A) n "coin",
-      -- cddlTest @(Core.Value M) n "value",
-      -- cddlTest' @(Core.TxBody M) n "transaction_body",
-      -- cddlTest' @(Core.TxBody A) n "transaction_body",
+      cddlTest @(Core.Value M) n "value",
+      cddlTest' @(Core.TxBody M) n "transaction_body",
+      cddlTest' @(Core.TxBody A) n "transaction_body_allegra",
       cddlTest' @(Core.Script M) n "native_script",
       cddlTest' @(Core.Script A) n "native_script",
       cddlTest' @(Core.Metadata M) n "transaction_metadata",

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Compactible.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Compactible.hs
@@ -7,13 +7,10 @@
 module Cardano.Ledger.Compactible
   ( -- * Compactible
     Compactible (..),
-    Compact (..),
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Data.Kind (Type)
-import Data.Typeable (Typeable)
 
 --------------------------------------------------------------------------------
 
@@ -27,22 +24,8 @@ import Data.Typeable (Typeable)
 
 class Compactible a where
   data CompactForm a :: Type
-  toCompact :: a -> CompactForm a
+  toCompact :: a -> Maybe (CompactForm a)
   fromCompact :: CompactForm a -> a
-
-newtype Compact a = Compact {unCompact :: a}
-
-instance
-  (Typeable a, Compactible a, ToCBOR (CompactForm a)) =>
-  ToCBOR (Compact a)
-  where
-  toCBOR = toCBOR . toCompact . unCompact
-
-instance
-  (Typeable a, Compactible a, FromCBOR (CompactForm a)) =>
-  FromCBOR (Compact a)
-  where
-  fromCBOR = Compact . fromCompact <$> fromCBOR
 
 -- TODO: consider if this is better the other way around
 instance (Eq a, Compactible a) => Eq (CompactForm a) where

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era
 import Cardano.Ledger.Torsor (Torsor (..))
-import Cardano.Ledger.Val (Val)
+import Cardano.Ledger.Val (DecodeNonNegative, Val)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
 
@@ -38,6 +38,7 @@ type ShelleyBased era =
     -- Value constraints
     Val (Value era),
     Compactible (Value era),
+    DecodeNonNegative (Value era),
     ChainData (Value era),
     SerialisableData (Value era),
     SerialisableData (CompactForm (Value era)),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -44,9 +44,8 @@ newtype Coin = Coin {unCoin :: Integer}
       NFData
     )
   deriving (Show) via Quiet Coin
-  deriving (ToCBOR, FromCBOR) via Compact Coin
   deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
-  deriving newtype (PartialOrd)
+  deriving newtype (PartialOrd, FromCBOR, ToCBOR)
 
 newtype DeltaCoin = DeltaCoin Integer
   deriving (Eq, Ord, Generic, Enum, NoThunks, NFData, FromCBOR, ToCBOR)
@@ -80,9 +79,7 @@ rationalToCoinViaFloor r = Coin . floor $ r
 -- with an erroring bounds check here. where should this really live?
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin Word64
-  toCompact (Coin c) = case integerToWord64 c of
-    Nothing -> error $ "out of bounds : " ++ show c
-    Just x -> CompactCoin x
+  toCompact (Coin c) = CompactCoin <$> integerToWord64 c
   fromCompact (CompactCoin c) = word64ToCoin c
 
 -- It's odd for this to live here. Where should it go?

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
@@ -13,6 +13,7 @@ import Control.Iterate.SetAlgebra (compile, compute, run)
 import Control.SetAlgebra (Bimap, biMapFromList, dom, (▷), (◁))
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe (fromJust)
 import qualified Data.Sequence as Seq
 import Shelley.Spec.Ledger.Address
   ( Addr (..),
@@ -60,7 +61,7 @@ genTestCase numUTxO numAddr = do
       pure $
         TxOutCompact
           (compactAddr addr)
-          (toCompact $ Val.inject (Coin $ fromIntegral i))
+          (fromJust $ toCompact $ Val.inject (Coin $ fromIntegral i))
   let mktxid i = TxId $ mkDummyHash i
   let mktxin i = TxIn (mktxid i) (fromIntegral i)
   let utxo = Map.fromList $ zip (mktxin <$> [1 ..]) txOuts

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
@@ -40,13 +40,16 @@ import Cardano.Binary
     ToCBOR (..),
     toCBOR,
   )
+import Cardano.Ledger.Compactible (Compactible (..))
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding)
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import qualified Data.ByteString.Lazy as Lazy
+import Data.Maybe (fromJust)
 import qualified Shelley.Spec.Ledger.API as Ledger
 import Shelley.Spec.Ledger.Genesis (ShelleyGenesis)
+import Shelley.Spec.Ledger.Coin (Coin (..))
 import qualified Shelley.Spec.Ledger.STS.Ledgers as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS (PrtclState)
 import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as Mock
@@ -147,6 +150,13 @@ prop_roundtrip_metadata = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBO
 prop_roundtrip_ShelleyGenesis :: ShelleyGenesis Mock.C -> Property
 prop_roundtrip_ShelleyGenesis = roundtrip toCBOR fromCBOR
 
+prop_roundtrip_Coin_1 :: Coin -> Property
+prop_roundtrip_Coin_1 = roundtrip (toCBOR . fromJust . toCompact) fromCBOR
+
+prop_roundtrip_Coin_2 :: Coin -> Property
+prop_roundtrip_Coin_2 = roundtrip toCBOR (fromCompact <$> fromCBOR)
+
+
 -- TODO
 
 -- roundTripIpv4 :: Property
@@ -187,5 +197,7 @@ tests =
       testProperty "roundtrip NewEpoch State" prop_roundtrip_NewEpochState,
       testProperty "roundtrip MultiSig" prop_roundtrip_MultiSig,
       testProperty "roundtrip MetaData" prop_roundtrip_metadata,
-      testProperty "roundtrip Shelley Genesis" prop_roundtrip_ShelleyGenesis
+      testProperty "roundtrip Shelley Genesis" prop_roundtrip_ShelleyGenesis,
+      testProperty "roundtrip coin compactcoin cbor" prop_roundtrip_Coin_1,
+      testProperty "roundtrip coin cbor compactcoin" prop_roundtrip_Coin_2
     ]


### PR DESCRIPTION
Different serializations for Value
    
The Value type is used in both TxOuts and in the Mint field of the transaction body, but negative values are only allowed in the latter. The rules already enforce this, but now the serialization does too.
    
Resolves: CAD-1667 and CAD-2148
