### PR TITLE
Consistent naming convention for self-serialising data.

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -22,7 +22,7 @@
 
 module Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (RequireSignature, RequireAllOf, RequireAnyOf, RequireMOf, RequireTimeExpire, RequireTimeStart),
-    pattern Timelock,
+    pattern TimelockConstr,
     inInterval,
     hashTimelockScript,
     showTimelock,
@@ -174,7 +174,7 @@ instance Era era => FromCBOR (Annotator (TimelockRaw era)) where
 -- They rely on memoBytes, and TimelockRaw to memoize each constructor of Timelock
 -- =================================================================
 
-newtype Timelock era = Timelock (MemoBytes (TimelockRaw era))
+newtype Timelock era = TimelockConstr (MemoBytes (TimelockRaw era))
   deriving (Eq, Ord, Show, Generic)
   deriving newtype (ToCBOR, NoThunks)
 
@@ -185,45 +185,45 @@ deriving via
 
 pattern RequireSignature :: Era era => KeyHash 'Witness (Crypto era) -> Timelock era
 pattern RequireSignature akh <-
-  Timelock (Memo (Signature akh) _)
+  TimelockConstr (Memo (Signature akh) _)
   where
     RequireSignature akh =
-      Timelock $ memoBytes (encRaw (Signature akh))
+      TimelockConstr $ memoBytes (encRaw (Signature akh))
 
 pattern RequireAllOf :: Era era => StrictSeq (Timelock era) -> Timelock era
 pattern RequireAllOf ms <-
-  Timelock (Memo (AllOf ms) _)
+  TimelockConstr (Memo (AllOf ms) _)
   where
     RequireAllOf ms =
-      Timelock $ memoBytes (encRaw (AllOf ms))
+      TimelockConstr $ memoBytes (encRaw (AllOf ms))
 
 pattern RequireAnyOf :: Era era => StrictSeq (Timelock era) -> Timelock era
 pattern RequireAnyOf ms <-
-  Timelock (Memo (AnyOf ms) _)
+  TimelockConstr (Memo (AnyOf ms) _)
   where
     RequireAnyOf ms =
-      Timelock $ memoBytes (encRaw (AnyOf ms))
+      TimelockConstr $ memoBytes (encRaw (AnyOf ms))
 
 pattern RequireMOf :: Era era => Int -> StrictSeq (Timelock era) -> Timelock era
 pattern RequireMOf n ms <-
-  Timelock (Memo (MOfN n ms) _)
+  TimelockConstr (Memo (MOfN n ms) _)
   where
     RequireMOf n ms =
-      Timelock $ memoBytes (encRaw (MOfN n ms))
+      TimelockConstr $ memoBytes (encRaw (MOfN n ms))
 
 pattern RequireTimeExpire :: Era era => StrictMaybe (SlotNo) -> Timelock era
 pattern RequireTimeExpire mslot <-
-  Timelock (Memo (TimeExpire mslot) _)
+  TimelockConstr (Memo (TimeExpire mslot) _)
   where
     RequireTimeExpire mslot =
-      Timelock $ memoBytes (encRaw (TimeExpire mslot))
+      TimelockConstr $ memoBytes (encRaw (TimeExpire mslot))
 
 pattern RequireTimeStart :: Era era => StrictMaybe (SlotNo) -> Timelock era
 pattern RequireTimeStart mslot <-
-  Timelock (Memo (TimeStart mslot) _)
+  TimelockConstr (Memo (TimeStart mslot) _)
   where
     RequireTimeStart mslot =
-      Timelock $ memoBytes (encRaw (TimeStart mslot))
+      TimelockConstr $ memoBytes (encRaw (TimeStart mslot))
 
 {-# COMPLETE RequireSignature, RequireAllOf, RequireAnyOf, RequireMOf, RequireTimeExpire, RequireTimeStart #-}
 

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -21,7 +21,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.ShelleyMA.TxBody
-  ( TxBody (TxBody, STxBody),
+  ( TxBody (TxBody, TxBodyConstr),
     TxBodyRaw (..),
     FamsFrom,
     FamsTo,
@@ -195,7 +195,7 @@ initial =
 -- ===========================================================================
 -- Wrap it all up in a newtype, hiding the insides with a pattern construtor.
 
-newtype TxBody e = STxBody (MemoBytes (TxBodyRaw e))
+newtype TxBody e = TxBodyConstr (MemoBytes (TxBodyRaw e))
   deriving (Typeable)
 
 type instance
@@ -238,10 +238,10 @@ pattern TxBody ::
   (Value era) ->
   TxBody era
 pattern TxBody i o d w fee vi u m forge <-
-  STxBody (Memo (TxBodyRaw i o d w fee vi u m forge) _)
+  TxBodyConstr (Memo (TxBodyRaw i o d w fee vi u m forge) _)
   where
     TxBody i o d w fee vi u m forge =
-      STxBody $
+      TxBodyConstr $
         memoBytes $ txSparse (TxBodyRaw i o d w fee vi u m forge)
 
 {-# COMPLETE TxBody #-}
@@ -252,7 +252,7 @@ pattern TxBody i o d w fee vi u m forge <-
 
 {-
 instance HasField tag (TxBodyRaw e) c => HasField (tag::Symbol) (TxBody e) c where
-   getField (STxBody (Memo x _)) = getField @tag x
+   getField (TxBodyConstr (Memo x _)) = getField @tag x
 
 -- The method above autmatically lifts the Hasfield instances from TxBodyRaw to TxBody
 -- the problem is, if some other file imports this file, it needs to import both
@@ -264,28 +264,28 @@ instance HasField tag (TxBodyRaw e) c => HasField (tag::Symbol) (TxBody e) c whe
 -}
 
 instance HasField "inputs" (TxBody e) (Set (TxIn e)) where
-  getField (STxBody (Memo m _)) = getField @"inputs" m
+  getField (TxBodyConstr (Memo m _)) = getField @"inputs" m
 
 instance HasField "outputs" (TxBody e) (StrictSeq (TxOut e)) where
-  getField (STxBody (Memo m _)) = getField @"outputs" m
+  getField (TxBodyConstr (Memo m _)) = getField @"outputs" m
 
 instance HasField "certs" (TxBody e) (StrictSeq (DCert e)) where
-  getField (STxBody (Memo m _)) = getField @"certs" m
+  getField (TxBodyConstr (Memo m _)) = getField @"certs" m
 
 instance HasField "wdrls" (TxBody e) (Wdrl e) where
-  getField (STxBody (Memo m _)) = getField @"wdrls" m
+  getField (TxBodyConstr (Memo m _)) = getField @"wdrls" m
 
 instance HasField "txfee" (TxBody e) Coin where
-  getField (STxBody (Memo m _)) = getField @"txfee" m
+  getField (TxBodyConstr (Memo m _)) = getField @"txfee" m
 
 instance HasField "vldt" (TxBody e) ValidityInterval where
-  getField (STxBody (Memo m _)) = getField @"vldt" m
+  getField (TxBodyConstr (Memo m _)) = getField @"vldt" m
 
 instance HasField "update" (TxBody e) (StrictMaybe (Update e)) where
-  getField (STxBody (Memo m _)) = getField @"update" m
+  getField (TxBodyConstr (Memo m _)) = getField @"update" m
 
 instance HasField "mdHash" (TxBody e) (StrictMaybe (MetaDataHash e)) where
-  getField (STxBody (Memo m _)) = getField @"mdHash" m
+  getField (TxBodyConstr (Memo m _)) = getField @"mdHash" m
 
 instance (Value e ~ vv) => HasField "forge" (TxBody e) vv where
-  getField (STxBody (Memo m _)) = getField @"forge" m
+  getField (TxBodyConstr (Memo m _)) = getField @"forge" m

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),
     showTimelock,
     translate,
-    pattern Timelock,
+    pattern TimelockConstr,
   )
 import Cardano.Slotting.Slot (SlotNo (..))
 import qualified Data.ByteString.Lazy as Lazy
@@ -77,7 +77,7 @@ checkTranslate :: MultiSig TestEra -> Bool
 checkTranslate multi = bytes == bytes2
   where
     bytes = getMultiSigBytes multi
-    (Timelock (Memo _ bytes2)) = translate @TestEra multi
+    (TimelockConstr (Memo _ bytes2)) = translate @TestEra multi
 
 timelockTests :: TestTree
 timelockTests =

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -92,7 +92,7 @@ txM =
     (inject (Coin 2))
 
 bytes :: Mary.TxBody era -> ShortByteString
-bytes (Mary.STxBody (Memo _ b)) = b
+bytes (Mary.TxBodyConstr (Memo _ b)) = b
 
 fieldTests :: TestTree
 fieldTests =
@@ -110,7 +110,7 @@ fieldTests =
     ]
 
 roundtrip :: Mary.TxBody TestEra -> Bool
-roundtrip (Mary.STxBody memo) =
+roundtrip (Mary.TxBodyConstr memo) =
   case roundTripMemo memo of
     Right ("", new) -> new == memo
     _other -> False


### PR DESCRIPTION
A number of types are self-serializing as we want their hashes to remain
consistent across Eras. This accomplished by defining them as a newtype
around the MemoBytes data structure. This way all the unique properties for
self-serializing data can be written just once in MemoBytes. This PR cleans
things up and uses a consistent naming convention for the underlying types
that MemoBytes hides. Suppose we need a self serializing type called T, then
we use the following conventions. T will be a newtye around (MemoBytes TRaw)
and the constructor of the newtype will be TConstr. We will make a Haskell
pattern using the name T to construct nad pattern match against this type.
data TRaw = TRaw X Y Z
newtype T = TConstr (MemoBytes TRaw)
pattern T x y z  <- TConstr (Memo (TRaw x y z) where ...