### PR TITLE
Make Properties and Block generation in tests polymorphic

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Val
 where
 
 import Data.Group (Abelian)
-import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Coin (Coin (..), DeltaCoin (..))
 
 class
   ( Abelian t,
@@ -91,6 +91,8 @@ instance Val Coin where
   size _ = 1
   modifyCoin f v = f v
   pointwise p (Coin x) (Coin y) = p x y
+
+deriving via Coin instance Val DeltaCoin
 
 {- The scaledMinDeposit calculation uses the minUTxOValue protocol parameter
 (passed to it as Coin mv) as a specification of "the cost of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -393,7 +393,7 @@ instance
       pure $ DPState ds ps
 
 data RewardUpdate era = RewardUpdate
-  { deltaT :: !Coin,
+  { deltaT :: !DeltaCoin,
     deltaR :: !DeltaCoin,
     rs :: !(Map (Credential 'Staking era) Coin),
     deltaF :: !DeltaCoin,
@@ -431,7 +431,7 @@ instance
       pure $ RewardUpdate dt (invert dr) rw (invert df) nm
 
 emptyRewardUpdate :: RewardUpdate era
-emptyRewardUpdate = RewardUpdate (Coin 0) (DeltaCoin 0) Map.empty (DeltaCoin 0) emptyNonMyopic
+emptyRewardUpdate = RewardUpdate (DeltaCoin 0) (DeltaCoin 0) Map.empty (DeltaCoin 0) emptyNonMyopic
 
 data AccountState = AccountState
   { _treasury :: !Coin,
@@ -1022,7 +1022,7 @@ applyRUpd ru (EpochState as ss ls pr pp _nm) = EpochState as' ss ls' pr pp nm'
         (rs ru)
     as' =
       as
-        { _treasury = _treasury as <> deltaT ru <> fold (range unregRU),
+        { _treasury = (addDeltaCoin (_treasury as) (deltaT ru)) <> fold (range unregRU),
           _reserves = addDeltaCoin (_reserves as) (deltaR ru)
         }
     ls' =
@@ -1109,7 +1109,7 @@ createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) ma
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $
     RewardUpdate
-      { deltaT = (Coin deltaT1),
+      { deltaT = (DeltaCoin deltaT1),
         deltaR = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
         rs = rs_,
         deltaF = (invert (toDeltaCoin $ _feeSS ss)),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -97,7 +97,7 @@ newEpochTransition = do
         SNothing -> pure es
         SJust ru' -> do
           let RewardUpdate dt dr rs_ df _ = ru'
-          Val.isZero (dt `addDeltaCoin` (dr <> (toDeltaCoin $ fold rs_) <> df)) ?! CorruptRewardUpdate ru'
+          Val.isZero (dt <> (dr <> (toDeltaCoin $ fold rs_) <> df)) ?! CorruptRewardUpdate ru'
           pure $ applyRUpd ru' es
 
       es'' <- trans @(MIR era) $ TRC ((), es', ())

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -98,7 +98,7 @@ validateInput ::
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era
   ) =>
-  Gen (Core.Value era) ->
+  Gen (Core.TxBody era) ->
   Int ->
   IO (ValidateInput era)
 validateInput gv utxoSize = genValidateInput gv utxoSize
@@ -118,7 +118,7 @@ genValidateInput ::
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era
   ) =>
-  Gen (Core.Value era) ->
+  Gen (Core.TxBody era) ->
   Int ->
   IO (ValidateInput era)
 genValidateInput gv n = do
@@ -206,7 +206,7 @@ genUpdateInputs ::
     Signal (LEDGER era) ~ Tx era,
     Mock (Crypto era)
   ) =>
-  Gen (Core.Value era) ->
+  Gen (Core.TxBody era) ->
   Int ->
   IO (UpdateInputs (Crypto era))
 genUpdateInputs gv utxoSize = do

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -72,6 +72,7 @@ import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals)
 import Test.QuickCheck (Gen)
+import Test.Shelley.Spec.Ledger.Generator.Utxo (GenTxFunc (..))
 
 -- ====================================================================
 
@@ -85,6 +86,7 @@ instance NFData (ValidateInput era) where
 
 validateInput ::
   ( ShelleyTest era,
+    GenTxFunc era,
     Mock (Crypto era),
     API.GetLedgerView era,
     API.ApplyBlock era,
@@ -98,13 +100,14 @@ validateInput ::
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era
   ) =>
-  Gen (Core.TxBody era) ->
+  Gen (Core.Value era) ->
   Int ->
   IO (ValidateInput era)
 validateInput gv utxoSize = genValidateInput gv utxoSize
 
 genValidateInput ::
   ( ShelleyTest era,
+    GenTxFunc era,
     Mock (Crypto era),
     API.GetLedgerView era,
     API.ApplyBlock era,
@@ -118,7 +121,7 @@ genValidateInput ::
     State (LEDGER era) ~ (UTxOState era, DPState era),
     Signal (LEDGER era) ~ Tx era
   ) =>
-  Gen (Core.TxBody era) ->
+  Gen (Core.Value era) ->
   Int ->
   IO (ValidateInput era)
 genValidateInput gv n = do
@@ -193,6 +196,7 @@ instance CryptoClass.Crypto c => NFData (UpdateInputs c) where
 genUpdateInputs ::
   forall era.
   ( ShelleyTest era,
+    GenTxFunc era,
     API.GetLedgerView era,
     API.ApplyBlock era,
     STS (LEDGERS era),
@@ -206,7 +210,7 @@ genUpdateInputs ::
     Signal (LEDGER era) ~ Tx era,
     Mock (Crypto era)
   ) =>
-  Gen (Core.TxBody era) ->
+  Gen (Core.Value era) ->
   Int ->
   IO (UpdateInputs (Crypto era))
 genUpdateInputs gv utxoSize = do

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -57,7 +57,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)
 genChainState ::
   ( ShelleyTest era
   ) =>
-  Gen (Core.Value era) ->
+  Gen (Core.TxBody era) ->
   Int ->
   GenEnv era ->
   IO (ChainState era)
@@ -109,7 +109,7 @@ genTriple ::
   ( Mock (Crypto era),
     ShelleyTest era
   ) =>
-  Gen (Core.Value era) ->
+  Gen (Core.TxBody era) ->
   Proxy era ->
   Int ->
   IO (GenEnv era, ChainState era, GenEnv era -> IO (Tx era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -64,7 +64,7 @@ import Cardano.Ledger.Era (Era(Crypto))
 -- | Generate a chain state at a given epoch. Since we are only concerned about
 -- rewards, this will populate the chain with empty blocks (only issued by the
 -- original genesis delegates).
-genChainInEpoch :: Gen (Core.Value B) -> EpochNo -> Gen (ChainState B)
+genChainInEpoch :: Gen (Core.TxBody B) -> EpochNo -> Gen (ChainState B)
 genChainInEpoch gv epoch = do
   genesisChainState <-
     fromRight (error "genChainState failed")

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -64,7 +64,7 @@ import Cardano.Ledger.Era (Era(Crypto))
 -- | Generate a chain state at a given epoch. Since we are only concerned about
 -- rewards, this will populate the chain with empty blocks (only issued by the
 -- original genesis delegates).
-genChainInEpoch :: Gen (Core.TxBody B) -> EpochNo -> Gen (ChainState B)
+genChainInEpoch :: Gen (Core.Value B) -> EpochNo -> Gen (ChainState B)
 genChainInEpoch gv epoch = do
   genesisChainState <-
     fromRight (error "genChainState failed")

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -61,6 +61,7 @@ import Test.Shelley.Spec.Ledger.Utils
     testGlobals,
   )
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Test.Shelley.Spec.Ledger.Generator.Utxo (GenTxFunc (..))
 
 -- | Type alias for a transaction generator
 type TxGen era =
@@ -73,7 +74,8 @@ type TxGen era =
 -- | Generate a valid block.
 genBlock ::
   forall era.
-  ( ShelleyTest era,
+  ( GenTxFunc era,
+    ShelleyTest era, 
     GetLedgerView era,
     ApplyBlock era,
     STS (LEDGER era),
@@ -97,6 +99,8 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
       sigGen @(LEDGERS era) ge ledgerEnv ls
 
+-- Still polymorphic over transaction type
+-- can reuse in ShelleyMA by passing TxGen for right era
 genBlockWithTxGen ::
   forall era.
   (ShelleyTest era, Mock (Crypto era), GetLedgerView era, ApplyBlock era) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -180,6 +180,7 @@ import qualified Shelley.Spec.Ledger.Tx as Ledger
 import Shelley.Spec.Ledger.TxBody
   ( DCert,
     TxOut,
+    Wdrl,
     unWdrl,
     pattern TxBody,
     pattern Wdrl,
@@ -507,6 +508,7 @@ genTxOut gv Constants {maxGenesisOutputVal, minGenesisOutputVal} addrs = do
 -- and with values between 'minCoin' and 'maxCoin'.
 -- NOTE we pass here a Value generator gv that is piped in from where
 -- it can be defined in the necessary context (see Tests.hs)
+-- TODO make sure this mostly generates values satisfying the min deposit condition
 genValList ::
   (ShelleyTest era) =>
   QC.Gen (Core.Value era) ->
@@ -777,6 +779,8 @@ genesisCoins outs =
 -- | Apply a transaction body as a state transition function on the ledger state.
 applyTxBody ::
   ( ShelleyTest era,
+    HasField "txfee" (Core.TxBody era) Coin,
+    HasField "wdrls" (Core.TxBody era) (Wdrl era),
     HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -52,6 +52,7 @@ import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( Mock,
   )
+import Test.Shelley.Spec.Ledger.Generator.Utxo (GenTxFunc (..))
 import Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
@@ -64,6 +65,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, maxLLSupply, mkHash)
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
   ( ShelleyTest era,
+    GenTxFunc era, 
     GetLedgerView era,
     ApplyBlock era,
     STS (CHAIN era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -19,6 +19,7 @@ module Test.Shelley.Spec.Ledger.Serialisation.Generators () where
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Generic.Random (genericArbitraryU)
 import Shelley.Spec.Ledger.API (TxBody (TxBody))
+import Shelley.Spec.Ledger.Hashing (HashIndex, EraIndependentTxBody)
 import qualified Shelley.Spec.Ledger.STS.Utxo as STS
 import Test.QuickCheck
   ( Arbitrary,
@@ -50,3 +51,4 @@ instance Mock c => Arbitrary (TxBody (ShelleyEra c)) where
 instance Mock c => Arbitrary (STS.UtxoPredicateFailure (ShelleyEra c)) where
   arbitrary = genericArbitraryU
   shrink _ = []
+  

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -19,7 +19,6 @@ module Test.Shelley.Spec.Ledger.Serialisation.Generators () where
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Generic.Random (genericArbitraryU)
 import Shelley.Spec.Ledger.API (TxBody (TxBody))
-import Shelley.Spec.Ledger.Hashing (HashIndex, EraIndependentTxBody)
 import qualified Shelley.Spec.Ledger.STS.Utxo as STS
 import Test.QuickCheck
   ( Arbitrary,
@@ -51,4 +50,3 @@ instance Mock c => Arbitrary (TxBody (ShelleyEra c)) where
 instance Mock c => Arbitrary (STS.UtxoPredicateFailure (ShelleyEra c)) where
   arbitrary = genericArbitraryU
   shrink _ = []
-  

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -118,18 +118,10 @@ import Shelley.Spec.Ledger.Keys
     vKey,
     pattern KeyPair,
   )
+import Shelley.Spec.Ledger.Hashing (HashIndex, EraIndependentTxBody)
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyPredicateFailure)
-import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainPredicateFailure)
-import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegPredicateFailure)
-import Shelley.Spec.Ledger.STS.Delegs (DELEGS, DelegsPredicateFailure)
-import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerPredicateFailure)
-import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersPredicateFailure)
-import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoPredicateFailure)
-import Shelley.Spec.Ledger.STS.Utxow (UTXOW, UtxowPredicateFailure)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
-import Shelley.Spec.Ledger.Tx (TxBody)
 import Test.Tasty.HUnit
   ( Assertion,
     (@?=),
@@ -138,16 +130,7 @@ import Test.Tasty.HUnit
 type ShelleyTest era =
   ( ShelleyBased era,
     Split (Core.Value era),
-    Core.TxBody era ~ TxBody era,
-    Core.Script era ~ MultiSig era,
-    PredicateFailure (CHAIN era) ~ ChainPredicateFailure era,
-    PredicateFailure (LEDGERS era) ~ LedgersPredicateFailure era,
-    PredicateFailure (LEDGER era) ~ LedgerPredicateFailure era,
-    PredicateFailure (BBODY era) ~ BbodyPredicateFailure era,
-    PredicateFailure (DELEGS era) ~ DelegsPredicateFailure era,
-    PredicateFailure (DELEG era) ~ DelegPredicateFailure era,
-    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
-    PredicateFailure (UTXO era) ~ UtxoPredicateFailure era
+    HashIndex (Core.TxBody era) ~ EraIndependentTxBody
   )
 
 class Split v where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -15,6 +15,7 @@ module Test.Shelley.Spec.Ledger.Examples.PoolLifetime
   )
 where
 
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
@@ -111,15 +112,14 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     zero,
   )
 import Test.Shelley.Spec.Ledger.Utils
-  ( ShelleyTest,
-    epochSize,
+  ( epochSize,
     getBlockNonce,
     maxLLSupply,
     testGlobals,
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
-import qualified Cardano.Ledger.Crypto as CryptoClass
+import qualified Cardano.Ledger.Crypto as Cr
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
@@ -127,14 +127,14 @@ aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 bobInitCoin :: Coin
 bobInitCoin = Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initUTxO :: ShelleyTest era => UTxO era
+initUTxO :: Cr.Crypto c => UTxO (ShelleyEra c)
 initUTxO =
   genesisCoins
     [ TxOut Cast.aliceAddr (Val.inject aliceInitCoin),
       TxOut Cast.bobAddr (Val.inject bobInitCoin)
     ]
 
-initStPoolLifetime :: forall era. ShelleyTest era => ChainState era
+initStPoolLifetime :: forall c. Cr.Crypto c => ChainState (ShelleyEra c)
 initStPoolLifetime = initSt initUTxO
 
 --
@@ -156,7 +156,7 @@ dariaMIR = Coin 99
 feeTx1 :: Coin
 feeTx1 = Coin 3
 
-txbodyEx1 :: ShelleyTest era => TxBody era
+txbodyEx1 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx1 =
   TxBody
     (Set.fromList [TxIn genesisId 0])
@@ -185,14 +185,14 @@ txbodyEx1 =
     SNothing
     SNothing
 
-txEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx1 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Tx (ShelleyEra c)
 txEx1 =
   Tx
     txbodyEx1
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx1 @era)
+            (hashAnnotated $ txbodyEx1 @c)
             ( (asWitness <$> [Cast.alicePay, Cast.carlPay])
                 <> (asWitness <$> [Cast.aliceStake])
                 <> [asWitness $ cold Cast.alicePoolKeys]
@@ -208,24 +208,24 @@ txEx1 =
       }
     SNothing
 
-blockEx1 :: forall era. (HasCallStack, ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx1 :: forall c. (HasCallStack, ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
-    (coreNodeKeysBySchedule @era ppEx 10)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 10)
     [txEx1]
     (SlotNo 10)
     (BlockNo 1)
-    (nonce0 @(Crypto era))
+    (nonce0 @(Crypto (ShelleyEra c)))
     (NatNonce 1)
     zero
     0
     0
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 10) 0 (KESPeriod 0))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 10) 0 (KESPeriod 0))
 
-expectedStEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx1 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx1 =
-  C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @era))
+  C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @c))
     . C.newLab blockEx1
     . C.feesAndDeposits feeTx1 (((3 :: Integer) <×> _keyDeposit ppEx) <+> _poolDeposit ppEx)
     . C.newUTxO txbodyEx1
@@ -243,7 +243,7 @@ expectedStEx1 =
 -- all register stake credentials, and Alice registers a stake pool.
 -- Additionally, a MIR certificate is issued to draw from the reserves
 -- and give Carl and Daria (who is unregistered) rewards.
-poolLifetime1 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime1 = CHAINExample initStPoolLifetime blockEx1 (Right expectedStEx1)
 
 --
@@ -261,7 +261,7 @@ aliceCoinEx2Ptr = aliceCoinEx1 <-> (aliceCoinEx2Base <+> feeTx2)
 
 -- | The transaction delegates Alice's and Bob's stake to Alice's pool.
 --   Additionally, we split Alice's ADA between a base address and a pointer address.
-txbodyEx2 :: forall era. ShelleyTest era => TxBody era
+txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
     { _inputs = Set.fromList [TxIn (txid txbodyEx1) 0],
@@ -282,14 +282,14 @@ txbodyEx2 =
       _mdHash = SNothing
     }
 
-txEx2 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Tx (ShelleyEra c)
 txEx2 =
   Tx
     txbodyEx2
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx2 @era)
+            (hashAnnotated $ txbodyEx2 @c)
             [ asWitness Cast.alicePay,
               asWitness Cast.aliceStake,
               asWitness Cast.bobStake
@@ -297,62 +297,62 @@ txEx2 =
       }
     SNothing
 
-blockEx2 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx1)
-    (coreNodeKeysBySchedule @era ppEx 90)
+    (bhHash $ bheader @(ShelleyEra c) blockEx1)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 90)
     [txEx2]
     (SlotNo 90)
     (BlockNo 2)
-    (nonce0 @(Crypto era))
+    (nonce0 @(Crypto (ShelleyEra c)))
     (NatNonce 2)
     zero
     4
     0
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 90) 0 (KESPeriod 0))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 90) 0 (KESPeriod 0))
 
 expectedStEx2 ::
-  forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
-  ChainState era
+  forall c.
+  (ExMock (Crypto (ShelleyEra c))) =>
+  ChainState (ShelleyEra c)
 expectedStEx2 =
-  C.evolveNonceFrozen (getBlockNonce (blockEx2 @era))
+  C.evolveNonceFrozen (getBlockNonce (blockEx2 @c))
     . C.newLab blockEx2
     . C.feesAndDeposits feeTx2 (Coin 0)
     . C.newUTxO txbodyEx2
-    . C.delegation Cast.aliceSHK (_poolId $ Cast.alicePoolParams @era)
-    . C.delegation Cast.bobSHK (_poolId $ Cast.alicePoolParams @era)
+    . C.delegation Cast.aliceSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
+    . C.delegation Cast.bobSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
     . C.rewardUpdate emptyRewardUpdate
     $ expectedStEx1
 
 -- === Block 2, Slot 90, Epoch 0
 --
 -- In the second block Alice and Bob both delegation to Alice's Pool.
-poolLifetime2 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime2 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
 -- Block 3, Slot 110, Epoch 1
 --
 
-epoch1Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
-epoch1Nonce = chainCandidateNonce (expectedStEx2 @era)
+epoch1Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
+epoch1Nonce = chainCandidateNonce (expectedStEx2 @c)
 
-blockEx3 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx3 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx2)
-    (coreNodeKeysBySchedule @era ppEx 110)
+    (bhHash $ bheader @(ShelleyEra c) blockEx2)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110)
     []
     (SlotNo 110)
     (BlockNo 3)
-    (epoch1Nonce @era)
+    (epoch1Nonce @c)
     (NatNonce 3)
     zero
     5
     0
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 110) 0 (KESPeriod 0))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110) 0 (KESPeriod 0))
 
 snapEx3 :: Era era => EB.SnapShot era
 snapEx3 =
@@ -372,9 +372,9 @@ snapEx3 =
     }
 
 expectedStEx3 ::
-  forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
-  ChainState era
+  forall c.
+  (ExMock (Crypto (ShelleyEra c))) =>
+  ChainState (ShelleyEra c)
 expectedStEx3 =
   C.newEpoch blockEx3
     . C.newSnapshot snapEx3 (feeTx1 <> feeTx2)
@@ -386,7 +386,7 @@ expectedStEx3 =
 --
 -- In the third block, an empty block in a new epoch, the first snapshot is created.
 -- The rewards accounts from the MIR certificate in block 1 are now increased.
-poolLifetime3 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
@@ -399,7 +399,7 @@ feeTx4 = Coin 5
 aliceCoinEx4Base :: Coin
 aliceCoinEx4Base = aliceCoinEx2Base <-> feeTx4
 
-txbodyEx4 :: forall era. ShelleyTest era => TxBody era
+txbodyEx4 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx4 =
   TxBody
     { _inputs = Set.fromList [TxIn (txid txbodyEx2) 0],
@@ -414,37 +414,37 @@ txbodyEx4 =
       _mdHash = SNothing
     }
 
-txEx4 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx4 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Tx (ShelleyEra c)
 txEx4 =
   Tx
     txbodyEx4
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx4 @era)
+            (hashAnnotated $ txbodyEx4 @c)
             [asWitness Cast.alicePay, asWitness Cast.carlStake]
       }
     SNothing
 
-blockEx4 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx4 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx3)
-    (coreNodeKeysBySchedule @era ppEx 190)
+    (bhHash $ bheader @(ShelleyEra c) blockEx3)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 190)
     [txEx4]
     (SlotNo 190)
     (BlockNo 4)
-    (epoch1Nonce @era)
+    (epoch1Nonce @c)
     (NatNonce 4)
     zero
     9
     0
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 190) 0 (KESPeriod 0))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 190) 0 (KESPeriod 0))
 
-rewardUpdateEx4 :: forall era. RewardUpdate era
+rewardUpdateEx4 :: forall c. RewardUpdate (ShelleyEra c)
 rewardUpdateEx4 =
   RewardUpdate
-    { deltaT = Coin 1,
+    { deltaT = DeltaCoin 1,
       deltaR = DeltaCoin 6,
       rs = Map.empty,
       deltaF = DeltaCoin (-7),
@@ -452,15 +452,15 @@ rewardUpdateEx4 =
     }
 
 expectedStEx4 ::
-  forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
-  ChainState era
+  forall c.
+  (ExMock (Crypto (ShelleyEra c))) =>
+  ChainState (ShelleyEra c)
 expectedStEx4 =
-  C.evolveNonceFrozen (getBlockNonce (blockEx4 @era))
+  C.evolveNonceFrozen (getBlockNonce (blockEx4 @c))
     . C.newLab blockEx4
     . C.feesAndDeposits feeTx4 (Coin 0)
     . C.newUTxO txbodyEx4
-    . C.delegation Cast.carlSHK (_poolId $ Cast.alicePoolParams @era)
+    . C.delegation Cast.carlSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
     . C.rewardUpdate rewardUpdateEx4
     $ expectedStEx3
 
@@ -469,34 +469,34 @@ expectedStEx4 =
 -- We process a block late enough in the epoch in order to create a second reward update,
 -- preparing the way for the first non-empty pool distribution in this running example.
 -- Additionally, in order to have the stake distribution change, Carl delegates his stake.
-poolLifetime4 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime4 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
-epoch2Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch2Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch2Nonce =
-  chainCandidateNonce (expectedStEx4 @era)
-    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx2 @era))
+  chainCandidateNonce (expectedStEx4 @c)
+    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx2 @c))
 
 --
 -- Block 5, Slot 220, Epoch 2
 --
 
-blockEx5 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx5 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx5 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx4)
-    (coreNodeKeysBySchedule @era ppEx 220)
+    (bhHash $ bheader @(ShelleyEra c) blockEx4)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 220)
     []
     (SlotNo 220)
     (BlockNo 5)
-    (epoch2Nonce @era)
+    (epoch2Nonce @c)
     (NatNonce 5)
     zero
     11
     10
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 220) 1 (KESPeriod 10))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 220) 1 (KESPeriod 10))
 
-snapEx5 :: forall era. ShelleyTest era => EB.SnapShot era
+snapEx5 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
 snapEx5 =
   EB.SnapShot
     { EB._stake =
@@ -515,7 +515,7 @@ snapEx5 =
       EB._poolParams = Map.singleton (hk Cast.alicePoolKeys) Cast.alicePoolParams
     }
 
-pdEx5 :: forall c. CryptoClass.Crypto c => PoolDistr c
+pdEx5 :: forall c. Cr.Crypto c => PoolDistr c
 pdEx5 =
   PoolDistr $
     Map.singleton
@@ -523,9 +523,9 @@ pdEx5 =
       (IndividualPoolStake 1 (Cast.aliceVRFKeyHash @c))
 
 expectedStEx5 ::
-  forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
-  ChainState era
+  forall c.
+  (ExMock (Crypto (ShelleyEra c))) =>
+  ChainState (ShelleyEra c)
 expectedStEx5 =
   C.newEpoch blockEx5
     . C.newSnapshot snapEx5 feeTx4
@@ -534,47 +534,47 @@ expectedStEx5 =
     . C.setOCertCounter coreNodeHK 1
     $ expectedStEx4
   where
-    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @era ppEx 220
+    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @(ShelleyEra c) ppEx 220
 
 -- === Block 5, Slot 220, Epoch 2
 --
 -- Create the first non-empty pool distribution
 -- by creating a block in the third epoch of this running example.
-poolLifetime5 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime5 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 
 --
 -- Block 6, Slot 295, Epoch 2
 --
 
-blockEx6 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx6 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx6 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx5)
+    (bhHash $ bheader @(ShelleyEra c) blockEx5)
     Cast.alicePoolKeys
     []
     (SlotNo 295) -- odd slots open for decentralization
     (BlockNo 6)
-    (epoch2Nonce @era)
+    (epoch2Nonce @c)
     (NatNonce 6)
     zero
     14
     14
     (mkOCert Cast.alicePoolKeys 0 (KESPeriod 14))
 
-rewardUpdateEx6 :: forall era. RewardUpdate era
+rewardUpdateEx6 :: forall c. RewardUpdate (ShelleyEra c)
 rewardUpdateEx6 =
   RewardUpdate
-    { deltaT = Coin 1,
+    { deltaT = DeltaCoin 1,
       deltaR = DeltaCoin 4,
       rs = Map.empty,
       deltaF = invert $ toDeltaCoin feeTx4,
       nonMyopic = emptyNonMyopic {rewardPotNM = Coin 4}
     }
 
-expectedStEx6 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx6 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx6 =
-  C.evolveNonceFrozen (getBlockNonce (blockEx6 @era))
+  C.evolveNonceFrozen (getBlockNonce (blockEx6 @c))
     . C.newLab blockEx6
     . C.setOCertCounter (coerceKeyRole $ hk Cast.alicePoolKeys) 0
     . C.incrBlockCount (hk Cast.alicePoolKeys)
@@ -584,34 +584,34 @@ expectedStEx6 =
 -- === Block 6, Slot 295, Epoch 2
 --
 -- Create a decentralized Praos block (ie one not in the overlay schedule)
-poolLifetime6 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime6 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime6 = CHAINExample expectedStEx5 blockEx6 (Right expectedStEx6)
 
 --
 -- Block 7, Slot 310, Epoch 3
 --
 
-epoch3Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch3Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch3Nonce =
-  chainCandidateNonce (expectedStEx6 @era)
-    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx4 @era))
+  chainCandidateNonce (expectedStEx6 @c)
+    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx4 @c))
 
-blockEx7 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx7 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx7 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx6)
-    (coreNodeKeysBySchedule @era ppEx 310)
+    (bhHash $ bheader @(ShelleyEra c) blockEx6)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 310)
     []
     (SlotNo 310)
     (BlockNo 7)
-    (epoch3Nonce @era)
+    (epoch3Nonce @c)
     (NatNonce 7)
     zero
     15
     15
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 310) 1 (KESPeriod 15))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 310) 1 (KESPeriod 15))
 
-expectedStEx7 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx7 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx7 =
   C.newEpoch blockEx7
     . C.newSnapshot snapEx5 (Coin 0)
@@ -619,33 +619,33 @@ expectedStEx7 =
     . C.setOCertCounter coreNodeHK 1
     $ expectedStEx6
   where
-    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @era ppEx 310
+    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @(ShelleyEra c) ppEx 310
 
 -- === Block 7, Slot 310, Epoch 3
 --
 -- Create an empty block in the next epoch
 -- to prepare the way for the first non-trivial reward update
-poolLifetime7 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime7 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 
 --
 -- Block 8, Slot 390, Epoch 3
 --
 
-blockEx8 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx8 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx8 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx7)
-    (coreNodeKeysBySchedule @era ppEx 390)
+    (bhHash $ bheader @(ShelleyEra c) blockEx7)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 390)
     []
     (SlotNo 390)
     (BlockNo 8)
-    (epoch3Nonce @era)
+    (epoch3Nonce @c)
     (NatNonce 8)
     zero
     19
     19
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 390) 2 (KESPeriod 19))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 390) 2 (KESPeriod 19))
 
 aliceRAcnt8 :: Coin
 aliceRAcnt8 = Coin 11654787878
@@ -653,8 +653,8 @@ aliceRAcnt8 = Coin 11654787878
 bobRAcnt8 :: Coin
 bobRAcnt8 = Coin 1038545454
 
-deltaT8 :: Coin
-deltaT8 = Coin 317333333333
+deltaT8 :: DeltaCoin
+deltaT8 = DeltaCoin 317333333333
 
 deltaR8 :: DeltaCoin
 deltaR8 = DeltaCoin (-330026666665)
@@ -695,47 +695,47 @@ rewardUpdateEx8 =
       nonMyopic = nonMyopicEx8
     }
 
-expectedStEx8 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx8 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx8 =
-  C.evolveNonceFrozen (getBlockNonce (blockEx8 @era))
+  C.evolveNonceFrozen (getBlockNonce (blockEx8 @c))
     . C.newLab blockEx8
     . C.setOCertCounter coreNodeHK 2
     . C.rewardUpdate rewardUpdateEx8
     $ expectedStEx7
   where
-    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @era ppEx 390
+    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @(ShelleyEra c) ppEx 390
 
 -- === Block 8, Slot 390, Epoch 3
 --
 -- Create the first non-trivial reward update.
-poolLifetime8 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime8 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 
 --
 -- Block 9, Slot 410, Epoch 4
 --
 
-epoch4Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch4Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch4Nonce =
-  chainCandidateNonce (expectedStEx8 @era)
-    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx6 @era))
+  chainCandidateNonce (expectedStEx8 @c)
+    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx6 @c))
 
-blockEx9 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx9 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx9 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx8)
-    (coreNodeKeysBySchedule @era ppEx 410)
+    (bhHash $ bheader @(ShelleyEra c) blockEx8)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 410)
     []
     (SlotNo 410)
     (BlockNo 9)
-    (epoch4Nonce @era)
+    (epoch4Nonce @c)
     (NatNonce 9)
     zero
     20
     20
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 410) 2 (KESPeriod 20))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 410) 2 (KESPeriod 20))
 
-snapEx9 :: forall era. ShelleyTest era => EB.SnapShot era
+snapEx9 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
 snapEx9 =
   snapEx5
     { EB._stake =
@@ -747,7 +747,7 @@ snapEx9 =
             ]
     }
 
-expectedStEx9 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx9 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx9 =
   C.newEpoch blockEx9
     . C.newSnapshot snapEx9 (Coin 0)
@@ -755,12 +755,12 @@ expectedStEx9 =
     . C.setOCertCounter coreNodeHK 2
     $ expectedStEx8
   where
-    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @era ppEx 410
+    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @(ShelleyEra c) ppEx 410
 
 -- === Block 9, Slot 410, Epoch 4
 --
 -- Apply the first non-trivial reward update.
-poolLifetime9 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime9 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime9 = CHAINExample expectedStEx8 blockEx9 (Right expectedStEx9)
 
 --
@@ -777,7 +777,7 @@ bobAda10 =
     <+> _keyDeposit ppEx
     <-> feeTx10
 
-txbodyEx10 :: ShelleyTest era => TxBody era
+txbodyEx10 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx10 =
   TxBody
     (Set.fromList [TxIn genesisId 1])
@@ -789,34 +789,34 @@ txbodyEx10 =
     SNothing
     SNothing
 
-txEx10 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx10 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Tx (ShelleyEra c)
 txEx10 =
   Tx
     txbodyEx10
     mempty
       { addrWits =
-          makeWitnessesVKey (hashAnnotated $ txbodyEx10 @era) [asWitness Cast.bobPay, asWitness Cast.bobStake]
+          makeWitnessesVKey (hashAnnotated $ txbodyEx10 @c) [asWitness Cast.bobPay, asWitness Cast.bobStake]
       }
     SNothing
 
-blockEx10 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx10 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx10 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx9)
-    (coreNodeKeysBySchedule @era ppEx 420)
+    (bhHash $ bheader @(ShelleyEra c) blockEx9)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 420)
     [txEx10]
     (SlotNo 420)
     (BlockNo 10)
-    (epoch4Nonce @era)
+    (epoch4Nonce @c)
     (NatNonce 10)
     zero
     21
     19
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 420) 2 (KESPeriod 19))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 420) 2 (KESPeriod 19))
 
-expectedStEx10 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx10 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx10 =
-  C.evolveNonceUnfrozen (getBlockNonce (blockEx10 @era))
+  C.evolveNonceUnfrozen (getBlockNonce (blockEx10 @c))
     . C.newLab blockEx10
     . C.feesAndDeposits feeTx10 (invert (_keyDeposit ppEx))
     . C.deregStakeCred Cast.bobSHK
@@ -826,7 +826,7 @@ expectedStEx10 =
 -- === Block 10, Slot 420, Epoch 4
 --
 -- Drain Bob's reward account and de-register Bob's stake key.
-poolLifetime10 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime10 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime10 = CHAINExample expectedStEx9 blockEx10 (Right expectedStEx10)
 
 --
@@ -842,7 +842,7 @@ aliceCoinEx11Ptr = aliceCoinEx4Base <-> feeTx11
 aliceRetireEpoch :: EpochNo
 aliceRetireEpoch = EpochNo 5
 
-txbodyEx11 :: ShelleyTest era => TxBody era
+txbodyEx11 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx11 =
   TxBody
     (Set.fromList [TxIn (txid txbodyEx4) 0])
@@ -854,68 +854,68 @@ txbodyEx11 =
     SNothing
     SNothing
 
-txEx11 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx11 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Tx (ShelleyEra c)
 txEx11 =
   Tx
     txbodyEx11
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx11 @era)
+            (hashAnnotated $ txbodyEx11 @c)
             ( [asWitness Cast.alicePay]
                 <> [asWitness $ cold Cast.alicePoolKeys]
             )
       }
     SNothing
 
-blockEx11 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx11 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx11 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx10)
-    (coreNodeKeysBySchedule @era ppEx 490)
+    (bhHash $ bheader @(ShelleyEra c) blockEx10)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 490)
     [txEx11]
     (SlotNo 490)
     (BlockNo 11)
-    (epoch4Nonce @era)
+    (epoch4Nonce @c)
     (NatNonce 11)
     zero
     24
     19
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 490) 2 (KESPeriod 19))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 490) 2 (KESPeriod 19))
 
 reserves12 :: Coin
 reserves12 = addDeltaCoin reserves7 deltaR8
 
-alicePerfEx11 :: forall era. ShelleyTest era => Likelihood
+alicePerfEx11 :: forall c. Cr.Crypto c => Likelihood
 alicePerfEx11 = applyDecay decayFactor alicePerfEx8 <> epoch4Likelihood
   where
     epoch4Likelihood = likelihood blocks t (epochSize $ EpochNo 4)
     blocks = 0
     t = leaderProbability f relativeStake (_d ppEx)
-    (Coin stake) = fold (EB.unStake . EB._stake $ snapEx5 @era) -- everyone has delegated to Alice's Pool
+    (Coin stake) = fold (EB.unStake . EB._stake $ snapEx5 @c) -- everyone has delegated to Alice's Pool
     relativeStake = fromRational (stake % supply)
     (Coin supply) = maxLLSupply <-> reserves12
     f = activeSlotCoeff testGlobals
 
-nonMyopicEx11 :: forall era. ShelleyTest era => NonMyopic era
+nonMyopicEx11 :: forall c. Cr.Crypto c => NonMyopic (ShelleyEra c)
 nonMyopicEx11 =
   NonMyopic
-    (Map.singleton (hk Cast.alicePoolKeys) (alicePerfEx11 @era))
+    (Map.singleton (hk Cast.alicePoolKeys) (alicePerfEx11 @c))
     (Coin 0)
 
-rewardUpdateEx11 :: forall era. ShelleyTest era => RewardUpdate era
+rewardUpdateEx11 :: forall c. Cr.Crypto c => RewardUpdate (ShelleyEra c)
 rewardUpdateEx11 =
   RewardUpdate
-    { deltaT = Coin 0,
+    { deltaT = DeltaCoin 0,
       deltaR = DeltaCoin 0,
       rs = Map.empty,
       deltaF = DeltaCoin 0,
       nonMyopic = nonMyopicEx11
     }
 
-expectedStEx11 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx11 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx11 =
-  C.evolveNonceFrozen (getBlockNonce (blockEx11 @era))
+  C.evolveNonceFrozen (getBlockNonce (blockEx11 @c))
     . C.newLab blockEx11
     . C.feesAndDeposits feeTx11 (Coin 0)
     . C.newUTxO txbodyEx11
@@ -926,34 +926,34 @@ expectedStEx11 =
 -- === Block 11, Slot 490, Epoch 4
 --
 -- Stage the retirement of Alice's stake pool.
-poolLifetime11 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime11 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime11 = CHAINExample expectedStEx10 blockEx11 (Right expectedStEx11)
 
 --
 -- Block 12, Slot 510, Epoch 5
 --
 
-epoch5Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch5Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch5Nonce =
-  chainCandidateNonce (expectedStEx11 @era)
-    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx8 @era))
+  chainCandidateNonce (expectedStEx11 @c)
+    ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx8 @c))
 
-blockEx12 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx12 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx12 =
   mkBlockFakeVRF
-    (bhHash $ bheader @era blockEx11)
-    (coreNodeKeysBySchedule @era ppEx 510)
+    (bhHash $ bheader @(ShelleyEra c) blockEx11)
+    (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 510)
     []
     (SlotNo 510)
     (BlockNo 12)
-    (epoch5Nonce @era)
+    (epoch5Nonce @c)
     (NatNonce 12)
     zero
     25
     25
-    (mkOCert (coreNodeKeysBySchedule @era ppEx 510) 3 (KESPeriod 25))
+    (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 510) 3 (KESPeriod 25))
 
-snapEx12 :: forall era. ShelleyTest era => EB.SnapShot era
+snapEx12 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
 snapEx12 =
   snapEx9
     { EB._stake =
@@ -969,7 +969,7 @@ snapEx12 =
           ]
     }
 
-expectedStEx12 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx12 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx12 =
   C.newEpoch blockEx12
     . C.newSnapshot snapEx12 (Coin 11)
@@ -978,12 +978,12 @@ expectedStEx12 =
     . C.reapPool Cast.alicePoolParams
     $ expectedStEx11
   where
-    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @era ppEx 510
+    coreNodeHK = coerceKeyRole . hk $ coreNodeKeysBySchedule @(ShelleyEra c) ppEx 510
 
 -- === Block 12, Slot 510, Epoch 5
 --
 -- Reap Alice's stake pool.
-poolLifetime12 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+poolLifetime12 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime12 = CHAINExample expectedStEx11 blockEx12 (Right expectedStEx12)
 
 --

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DataKinds #-}
 
 module Test.Shelley.Spec.Ledger.PropertyTests (propertyTests, minimalPropertyTests) where
 
@@ -35,11 +37,17 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
 import Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation)
 import Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as TQC
+import GHC.Records (HasField)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.PParams
+  ( Update (..)
+  )
 
 proxyC :: Proxy C
 proxyC = Proxy
 
-minimalPropertyTests :: TQC.Gen (Core.Value C) -> TestTree
+minimalPropertyTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
+  TQC.Gen (Core.Value C) -> TestTree
 minimalPropertyTests gv =
   testGroup
     "Minimal Property Tests"
@@ -58,7 +66,9 @@ minimalPropertyTests gv =
     ]
 
 -- | 'TestTree' of property-based testing properties.
-propertyTests :: TQC.Gen (Core.Value C) -> TestTree
+propertyTests ::
+  (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
+  TQC.Gen (Core.Value C) -> TestTree
 propertyTests gv =
   testGroup
     "Property-Based Testing"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -37,17 +37,11 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
 import Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation)
 import Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as TQC
-import GHC.Records (HasField)
-import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
-import Shelley.Spec.Ledger.PParams
-  ( Update (..)
-  )
 
 proxyC :: Proxy C
 proxyC = Proxy
 
-minimalPropertyTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
-  TQC.Gen (Core.Value C) -> TestTree
+minimalPropertyTests :: TQC.Gen (Core.Value C) -> TestTree
 minimalPropertyTests gv =
   testGroup
     "Minimal Property Tests"
@@ -67,7 +61,6 @@ minimalPropertyTests gv =
 
 -- | 'TestTree' of property-based testing properties.
 propertyTests ::
-  (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
   TQC.Gen (Core.Value C) -> TestTree
 propertyTests gv =
   testGroup

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -78,8 +78,7 @@ import Shelley.Spec.Ledger.PParams
 import Shelley.Spec.Ledger.Slot (SlotNo (..), epochInfoSize)
 import Shelley.Spec.Ledger.Tx (Tx (..))
 import Shelley.Spec.Ledger.TxBody
-  ( TxBody (..),
-    Wdrl (..),
+  ( Wdrl (..),
   )
 import Test.QuickCheck
   ( Property,
@@ -143,7 +142,6 @@ genesisLedgerState gv = Just $ mkGenesisLedgerState gv (geConstants (genEnv p))
     p = Proxy
 
 relevantCasesAreCovered ::
-  (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
   Gen (Core.Value C) -> Property
 relevantCasesAreCovered gv = do
   let tl = 100
@@ -161,7 +159,7 @@ relevantCasesAreCoveredForTrace ::
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl era),
-    HasField "txUpdate" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
     HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era))
   ) =>
   Trace (CHAIN era) ->
@@ -303,10 +301,10 @@ hasWithdrawal tx = (not . null . unWdrl) $ getField @"wdrls" (_body tx)
 
 hasPParamUpdate ::
   ( ShelleyTest era,
-    HasField "txUpdate" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) => Tx era -> Bool
 hasPParamUpdate tx =
-  ppUpdates (getField @"txUpdate" $ _body tx)
+  ppUpdates (getField @"update" $ _body tx)
   where
     ppUpdates SNothing = False
     ppUpdates (SJust (Update (ProposedPPUpdates ppUpd) _)) = Map.size ppUpd > 0

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -1359,7 +1359,7 @@ tests =
           ru =
             ( SJust
                 RewardUpdate
-                  { deltaT = Coin 100,
+                  { deltaT = DeltaCoin 100,
                     deltaR = DeltaCoin (-200),
                     rs = Map.empty,
                     deltaF = DeltaCoin (-10),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds #-}
 
 import Cardano.Crypto.Libsodium (sodiumInit)
 import qualified Cardano.Ledger.Core as Core
@@ -16,14 +17,21 @@ import Test.Shelley.Spec.Ledger.UnitTests (unitTests)
 import Test.Shelley.Spec.Ledger.ValProp (valTests)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
+import GHC.Records (HasField)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.PParams
+  ( Update (..)
+  )
 
-tests :: Gen (Core.Value C) -> TestTree
+tests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
+  Gen (Core.Value C) -> TestTree
 tests gv = askOption $ \case
   Nightly -> (nightlyTests gv)
   Fast -> fastTests
   _ -> (mainTests gv)
 
-mainTests :: Gen (Core.Value C) -> TestTree
+mainTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
+  Gen (Core.Value C) -> TestTree
 mainTests gv =
   testGroup
     "Ledger with Delegation"
@@ -37,7 +45,8 @@ mainTests gv =
       valTests
     ]
 
-nightlyTests :: Gen (Core.Value C) -> TestTree
+nightlyTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
+  Gen (Core.Value C) -> TestTree
 nightlyTests gv =
   testGroup
     "Ledger with Delegation nightly"
@@ -81,5 +90,5 @@ genVl :: Gen Coin
 genVl = arbitrary
 
 -- main entry point
-main :: IO ()
+main :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) => IO ()
 main = sodiumInit >> mainWithTestScenario (tests genVl)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -17,21 +17,14 @@ import Test.Shelley.Spec.Ledger.UnitTests (unitTests)
 import Test.Shelley.Spec.Ledger.ValProp (valTests)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
-import GHC.Records (HasField)
-import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
-import Shelley.Spec.Ledger.PParams
-  ( Update (..)
-  )
 
-tests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
-  Gen (Core.Value C) -> TestTree
+tests :: Gen (Core.Value C) -> TestTree
 tests gv = askOption $ \case
   Nightly -> (nightlyTests gv)
   Fast -> fastTests
   _ -> (mainTests gv)
 
-mainTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
-  Gen (Core.Value C) -> TestTree
+mainTests :: Gen (Core.Value C) -> TestTree
 mainTests gv =
   testGroup
     "Ledger with Delegation"
@@ -45,8 +38,7 @@ mainTests gv =
       valTests
     ]
 
-nightlyTests :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) =>
-  Gen (Core.Value C) -> TestTree
+nightlyTests :: Gen (Core.Value C) -> TestTree
 nightlyTests gv =
   testGroup
     "Ledger with Delegation nightly"
@@ -90,5 +82,5 @@ genVl :: Gen Coin
 genVl = arbitrary
 
 -- main entry point
-main :: (HasField "txUpdate" (Core.TxBody C) (StrictMaybe (Update C))) => IO ()
+main :: IO ()
 main = sodiumInit >> mainWithTestScenario (tests genVl)


### PR DESCRIPTION
This PR : 
- makes all three variables in LedgerState's `RewardUpdate` into `DeltaCoin` to allow them to be negative
- in the `src` directory of the testing package, removes the constraint that the `era ~ ShelleyEra c`, and all the constraints that imply this from the `ShelleyTest` constraint bundle
- leaves most code in `scr` polymorphic *except* the actual generators of the transactions (`genTx`) so that most of it is re-usable for ShelleyMA
- introduces the class `GenFuncTx era` which contains a map `genFuncTx`, which, given relevant context, produces a transaction generator for transactions of a specific era
- allows block generation to be polymorphic by using the `genFuncTx` class function instead of `genTx` 
- Properties are polymorphic 
- Examples are constrained to `ShelleyEra c`