### PR TITLE
Revert the use of libsodium for KES

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,8 +21,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: acac87c7af2652b8d86d92c583b6c29234634866
-  --sha256: 1awxr663zgkn8dw13pjzzlzzz5y9y5l2fy14f87331gbrw6n2xdg
+  tag: 6226a0feb1d74f50a430242a1b4608fd48e10aad
+  --sha256: 034q2anpbc7bgp5draykz6lkzznxk31wy4nbgr4jv4f7778yls6b
   subdir:
     binary
     binary/test
@@ -39,24 +39,24 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a5519e09958ad1605ed438d26dd7aad39167d0f9
-  --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
+  tag: 58e146c14e1349553d0ed75dd5245bbe65f0533e
+  --sha256: 166rm0sxldnf0g2g9jp4k0rgd01wcbm0g54fcw3bxilzr1dvwqfi
   subdir:
     cardano-prelude
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a5519e09958ad1605ed438d26dd7aad39167d0f9
-  --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
+  tag: 58e146c14e1349553d0ed75dd5245bbe65f0533e
+  --sha256: 166rm0sxldnf0g2g9jp4k0rgd01wcbm0g54fcw3bxilzr1dvwqfi
   subdir:
     cardano-prelude-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 034962a2729e0afff82c367121c1cc9637c7f45a
-  --sha256: 0ga5j9r55r3ika48x2w39clp4qh8kjp27qanxsg1s6jrl125yjac
+  tag: 65834fcfde3d86461a8f8525b04e4bdf9cc06e41
+  --sha256: 0vlxfbfa4skagngwirx5fnyhl8bycskgk0gnhaawrbi3w9qxbd1s
   subdir:   contra-tracer
 
 source-repository-package

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -57,8 +57,7 @@ import Cardano.Crypto.KES
     genKeyKES,
   )
 import Cardano.Crypto.KES.Class (ContextKES)
-import Cardano.Crypto.Libsodium.MLockedBytes (mlsbFromByteString)
-import Cardano.Crypto.Seed (Seed, getSeedBytes, mkSeedFromBytes)
+import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
 import Cardano.Crypto.VRF
   ( CertifiedVRF,
     SignKeyVRF,
@@ -231,7 +230,7 @@ mkKESKeyPair ::
   (Word64, Word64, Word64, Word64, Word64) ->
   (SignKeyKES v, VerKeyKES v)
 mkKESKeyPair seed =
-  let sk = genKeyKES $ mlsbFromByteString $ getSeedBytes (mkSeedFromWords seed)
+  let sk = genKeyKES $ mkSeedFromWords seed
    in (sk, deriveVerKeyKES sk)
 
 mkAddr ::


### PR DESCRIPTION
This was causing a segfault in the node. This commit reverts these changes until we can identify the cause of the problem.