### PR TITLE
correct use of asset ID vs Name

### DIFF
--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Allegra (AllegraEra)
 import qualified Cardano.Ledger.Core as Abstract
 import Cardano.Ledger.Mary (MaryEra)
-import qualified Cardano.Ledger.Mary.Value as Mary (AssetID (..), PolicyID (..), Value (..))
+import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
 import Cardano.Ledger.Shelley (ShelleyBased)
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA.STS
 import qualified Cardano.Ledger.ShelleyMA.Scripts as MA (Timelock (..))
@@ -126,8 +126,8 @@ instance Mock c => Arbitrary (Mary.PolicyID (MaryEra c)) where
 instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
   arbitrary = Mary.Value <$> arbitrary <*> arbitrary
 
-instance Arbitrary Mary.AssetID where
-  arbitrary = Mary.AssetID <$> arbitrary
+instance Arbitrary Mary.AssetName where
+  arbitrary = Mary.AssetName <$> arbitrary
 
 instance Mock c => Arbitrary (MA.STS.UtxoPredicateFailure (MaryEra c)) where
   arbitrary = genericArbitraryU

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.Mary.Examples.MultiAssets
 where
 
 import Cardano.Ledger.Mary.Value
-  ( AssetID (..),
+  ( AssetName (..),
     PolicyID (..),
     Value (..),
   )
@@ -103,11 +103,11 @@ purplePolicy = RequireAllOf (StrictSeq.fromList [])
 purplePolicyId :: PolicyID MaryTest
 purplePolicyId = PolicyID $ hashScript purplePolicy
 
-plum :: AssetID
-plum = AssetID $ BS.pack "plum"
+plum :: AssetName
+plum = AssetName $ BS.pack "plum"
 
-amethyst :: AssetID
-amethyst = AssetID $ BS.pack "amethyst"
+amethyst :: AssetName
+amethyst = AssetName $ BS.pack "amethyst"
 
 ------------------------
 -- Mint Purple Tokens --


### PR DESCRIPTION
small PR to align formal spec and code naming of Value map keys
- AssetName is the key of the inner map in Value
- AssetID = (PolicyID, AssetName) , and is not used in the code yet