### PR TITLE
Examples of negative minting

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -219,10 +219,11 @@ utxoTransition = do
       outputsTooSmall =
         [ out
           | out@(TxOut _ c) <- outputs,
-            Val.pointwise
-              (<)
-              c
-              (Val.inject $ Val.scaledMinDeposit c minUTxOValue)
+            not $
+              Val.pointwise
+                (>=)
+                c
+                (Val.inject $ Val.scaledMinDeposit c minUTxOValue)
         ]
   null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
 


### PR DESCRIPTION
I set out to write tests involving minting with negative values, and caught a bug.

In the new `UTxO` rule, we collect examples of failures of the `minUTxOValue` check. There is an implicit negation here (looking for failures), and the negation of the partial pointwise `<` is not the same as the point wise success of `>=`.

The bug is fixed (first commit), and the examples are all now properly using outputs with a large enough lovelace component (second commit). I also tried to make the variable names in the examples more descriptive.

I've also added two new examples (third commit), one that removes native tokens from the supply, and one that attempts to create a negative output for a native token and yields an error.