### PR TITLE
Add set difference to Control.SetAlgebra

### DIFF
--- a/semantics/executable-spec/src/Control/SetAlgebra.hs
+++ b/semantics/executable-spec/src/Control/SetAlgebra.hs
@@ -14,7 +14,7 @@ module Control.SetAlgebra
    -- with the operators in the specification, except here sets are thought of as a map with a Unit value. (Map k ())
    dom, rng, dexclude, drestrict, rexclude, rrestrict, unionleft, unionright, unionplus,
    singleton, setSingleton, intersect, subset, keyeq,
-   (◁), (⋪), (▷), (⋫), (∈), (∉), (∪), (⨃), (∪+), (∩), (⊆), (≍), (<|), (|>),
+   (◁), (⋪), (▷), (⋫), (∈), (∉), (∪), (⨃), (∪+), (∩), (⊆), (≍), (<|), (|>), (➖),
    -- The only exported concrete Constructor of Set Algebra Expressons. Needed to make 'HasExp' and 'Embed'
    -- instances of new kinds of sets (Basically,  Data.Map's wrapped in a newtype).
    -- See: Shelley.Spec.Ledger.TxBody and Shelley/Spec/Ledger/UTxO.hs and helley/Spec/Ledger/Delegation/Certificates.hs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.Monad.Trans.Reader (asks)
-import Control.SetAlgebra (dom, eval, (∪), (⊆), (⋪))
+import Control.SetAlgebra (dom, eval, (∪), (⊆), (⋪), (➖))
 import Control.State.Transition
   ( Assertion (..),
     AssertionViolation (..),
@@ -328,7 +328,7 @@ utxoInductive = do
   minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
   eval (txins txb ⊆ dom utxo)
-    ?! BadInputsUTxO (Set.filter (\x -> not (Map.member x (unUTxO utxo))) (txins txb))
+    ?! BadInputsUTxO (eval (txins txb ➖ dom utxo))
 
   ni <- liftSTS $ asks networkId
   let addrsWrongNetwork =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Control/Iterate/SetAlgebra.hs
@@ -150,6 +150,9 @@ z3 = Map.fromList [(9, "3"), (10, "j"), (30, "a")]
 z4 :: Map Int String
 z4 = Map.fromList [(3, "c"), (5, "e"), (10, "j"), (21, "v"), (9, "3"), (30, "a")]
 
+ex8 :: Set.Set Int
+ex8 = (eval (z2 ➖ dom z1))
+
 -- ===================== test that compute works ======================
 
 -- Test that computing  x::(Exp t) computes to the given object with type t.
@@ -186,6 +189,7 @@ eval_tests =
       evalTest "Range exclude 3" (l4 ⋫ (Set.fromList ["m", "Z"]))
                                  (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "v"), (50, "q"), (51, "l")]),
       evalTest "DomExclude Union" ((z2 ⋪ z1) ∪ z3) z4,
+      evalTest "Set difference"  (z2 ➖ dom z1) (Sett(Set.fromList [2::Int,13])),
       eval_compile (((dom stkcred) ◁ deleg) ▷ (dom stpool)),
       eval_compile (l4 ⋫ (Set.fromList ["m", "Z"])),
       eval_compile (m0 ∪ (singleton 3 'b')),
@@ -574,6 +578,13 @@ many =
   ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Dom (Base BiMapR (bimap m1))) (Dom (Base BiMapR (bimap m2)))), "slow103")
   ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow104")
   ,( \ k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base MapR m1) (Base SetR (Sett s1))), "slow105")
+
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow108")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Base MapR m2)), "slow109")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Dom (Base MapR m2))), "slow110")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Dom (Base MapR m2))), "slow111")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Base MapR m2)), "slow112")
+  ,( \ k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Base SetR (Sett s2))),"slow113")
 
   ]
 


### PR DESCRIPTION
This PR addresses issue #1942, The set algebra had set union, and set intersection,
but lacked set difference. We added set difference using the infix operator (➖), and
added a bunch of slowFastEquiv tests. We also changed Shelley.Spec.Ledger.STS.Utxo
to call set difference instead of hand encoding the condition.