### PR TITLE
Soft fork mechanism to reference major version

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -6,4 +6,4 @@ where
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
 
 validMetaData :: PParams era -> Bool
-validMetaData pp = pvMinor (_protocolVersion pp) > 0
+validMetaData pp = _protocolVersion pp > ProtVer 2 0


### PR DESCRIPTION
Soft forks need reference to the major version, so that, for instance,
version (3,0) does not revert changes made in version (2,1).

Originally we had thougth that we would introduce a notion of a
"starting major version", so that a testnet starting in the shelley era
would not have to start at version 2 0.  But this may lead to more
confusion, and now we propose just to hard code the version pair.