### PR TITLE
Added module Test.Shelley.Spec.Ledger.Generator.Scripts

### DIFF
--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -51,6 +51,7 @@ library
     containers,
     deepseq,
     groups,
+    hashable,
     nothunks,
     partial-order,
     shelley-spec-ledger,

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -26,6 +26,8 @@ source-repository head
 library
   exposed-modules:
     Test.Cardano.Ledger.EraBuffet
+    Test.Cardano.Ledger.Mary
+    Test.Cardano.Ledger.Allegra
     Test.Cardano.Ledger.ShelleyMA.TxBody
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Timelocks
     Test.Cardano.Ledger.ShelleyMA.Serialisation.CDDL

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -28,7 +28,7 @@ import Test.Cardano.Ledger.Mary
   )
 import Test.Shelley.Spec.Ledger.Generator.Core(EraGen (..))
 import Test.Shelley.Spec.Ledger.Generator.EraGen(genUtxo0)
-import Test.Shelley.Spec.Ledger.Generator.Scripts
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass(..),
     ValueClass(..),
     TxBodyClass(..),

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC  -fno-warn-orphans #-}
+
+
+-- | This module is meant to supply the Era independent testing instances for the AllegraEra
+--   use it something like this:   import Test.Cardano.Ledger.Allegra()
+
+module Test.Cardano.Ledger.Allegra where
+
+import Cardano.Ledger.ShelleyMA.Timelocks(Timelock(..))
+import Cardano.Ledger.ShelleyMA.TxBody(TxBody(..))
+import qualified Cardano.Ledger.Crypto as CryptoClass
+import qualified Cardano.Ledger.Core as Core(Script)
+import Test.Cardano.Ledger.EraBuffet( AllegraEra )
+import Test.Cardano.Ledger.Mary
+  ( genMATxBody,
+    txBodyZero,
+    someLeaf,
+    quantifyTL,
+    unQuantifyTL,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core(EraGen (..))
+import Test.Shelley.Spec.Ledger.Generator.EraGen(genUtxo0)
+import Test.Shelley.Spec.Ledger.Generator.Scripts
+  ( ScriptClass(..),
+    ValueClass(..),
+    TxBodyClass(..),
+    genCoin,
+  )
+
+-- =====================================
+-- EraGen instances for the AllegraEra
+-- =====================================
+
+instance ( CryptoClass.Crypto c) => ScriptClass (AllegraEra c) where
+  isKey _ (RequireSignature hk) = Just hk
+  isKey _ _ = Nothing
+  basescript _proxy = someLeaf
+  quantify _ = quantifyTL
+  unQuantify _ = unQuantifyTL
+
+type instance Core.Script (AllegraEra c) = Timelock (AllegraEra c)
+
+instance (CryptoClass.Crypto c) => ValueClass  (AllegraEra c) where
+   genValue _ = genCoin
+
+instance (CryptoClass.Crypto c) => TxBodyClass (AllegraEra c) where
+  emptyTxBody = txBodyZero
+  liftTxBody gen = do { _tx <- gen; pure undefined }
+
+instance CryptoClass.Crypto c => EraGen (AllegraEra c) where
+  genEraUtxo0 = genUtxo0
+  genEraTxBody = genMATxBody
+  updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta forge) fee ins outs =
+     (TxBody ins outs cert wdrl fee vi upd meta forge)

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC  -fno-warn-orphans #-}
+
+
+-- | This module is meant to supply the Era independent testing instances for the MaryEra
+--   use it something like this:   import Test.Cardano.Ledger.Mary()
+--   The exported functions are used by the AllegraEra, since these two Eras share some stuff.
+
+module Test.Cardano.Ledger.Mary
+ ( genMATxBody,
+    txBodyZero,
+    someLeaf,
+    quantifyTL,
+    unQuantifyTL,
+  ) where
+
+import Data.Sequence.Strict (StrictSeq,fromList)
+import Data.Hashable
+import Data.String(fromString)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Cardano.Binary (ToCBOR (..),serializeEncoding')
+import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Mary.Value(Value(..),AssetName(..),PolicyID(..),insert)
+import Cardano.Ledger.ShelleyMA.Timelocks(Timelock(..))
+import Cardano.Ledger.ShelleyMA.TxBody(TxBody(..),ValidityInterval(..),StrictMaybe(..),FamsTo)
+import Cardano.Ledger.Val (Val (zero))
+import qualified Cardano.Ledger.Core as Core(Script, Value)
+import qualified Cardano.Ledger.Crypto as CryptoClass
+import Shelley.Spec.Ledger.Coin(Coin(..))
+import Shelley.Spec.Ledger.Keys(KeyHash,KeyRole(..))
+import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.PParams(Update)
+import Shelley.Spec.Ledger.Tx(TxOut,TxIn)
+import Shelley.Spec.Ledger.TxBody(DCert,Wdrl(..))
+import Test.Cardano.Ledger.EraBuffet(MaryEra)
+import Test.Shelley.Spec.Ledger.Generator.Core(EraGen (..))
+import Test.Shelley.Spec.Ledger.Generator.EraGen(genUtxo0)
+import Test.Shelley.Spec.Ledger.Utils (Split (..))
+import Test.Shelley.Spec.Ledger.Generator.Scripts
+  ( ScriptClass(..),
+    Quantifier(..),
+    ValueClass(..),
+    TxBodyClass(..),
+    exponential,
+  )
+import Test.QuickCheck(Gen,frequency,elements,vectorOf,choose)
+
+-- =====================================
+-- EraGen instances for the MaryEra
+-- =====================================
+
+instance (CryptoClass.Crypto c) => ScriptClass (MaryEra c) where
+  isKey _ (RequireSignature hk) = Just hk
+  isKey _ _ = Nothing
+  basescript _proxy = someLeaf
+  quantify _ = quantifyTL
+  unQuantify _ = unQuantifyTL
+
+type instance Core.Script (MaryEra c) = Timelock (MaryEra c)
+
+instance (CryptoClass.Crypto c) => ValueClass  (MaryEra c) where
+   genValue scripthashes = genMaryValue assets (map PolicyID scripthashes)
+
+instance (CryptoClass.Crypto c) => TxBodyClass (MaryEra c) where
+  emptyTxBody = txBodyZero
+  liftTxBody gen = do { _tx <- gen; pure undefined }
+
+instance CryptoClass.Crypto c => EraGen (MaryEra c) where
+  genEraUtxo0 = genUtxo0
+  genEraTxBody = genMATxBody
+  updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta forge) fee ins outs =
+     (TxBody ins outs cert wdrl fee vi upd meta forge)
+
+-- ========================================================
+-- Reusable pieces for both Mary and Allegra
+
+quantifyTL:: Era era => Timelock era -> Quantifier (Timelock era)
+quantifyTL (RequireAllOf xs) = AllOf (foldr (:) [] xs)
+quantifyTL (RequireAnyOf xs) = AnyOf (foldr (:) [] xs)
+quantifyTL (RequireMOf n xs) = MOf n (foldr (:) [] xs)
+quantifyTL t = Leaf t
+
+unQuantifyTL:: Era era => Quantifier (Timelock era) -> Timelock era
+unQuantifyTL (AllOf xs) = (RequireAllOf (fromList xs))
+unQuantifyTL (AnyOf xs) = (RequireAnyOf (fromList xs))
+unQuantifyTL (MOf n xs) = (RequireMOf n (fromList xs))
+unQuantifyTL (Leaf t) = t
+
+-- | Generate some Leaf Timelock (i.e. a Signature or TimeStart or TimeExpire)
+someLeaf :: Era era => KeyHash 'Witness (Crypto era) -> Timelock era
+someLeaf x =
+    let n = mod (hash(serializeEncoding' (toCBOR x))) 200
+    in if n <= 50
+          then RequireTimeStart (SlotNo (fromIntegral n))
+          else if n > 150
+                  then RequireTimeExpire (SlotNo (fromIntegral n))
+                  else RequireSignature x
+
+assets :: [AssetName]
+assets = map (AssetName . fromString) ["Red","Blue","Green","Yellow","Orange","Purple","Black","White"]
+
+genMaryValue :: [AssetName] -> [PolicyID era] -> Integer -> Integer ->  Gen(Value era)
+genMaryValue ass policys minCoin maxCoin = do
+   coinN <- exponential minCoin maxCoin
+   size <- frequency [(6,pure 0),(4,pure 1),(2,pure 2),(1,pure 3)]
+   triples <- vectorOf size (do { p <- elements policys; n <- elements ass; i <- elements [1,2,3,4]; pure(p,n,i)})
+   pure $ foldr (\ (p,n,i) ans -> insert (+) p n i ans) (Value coinN Map.empty) triples
+
+txBodyZero ::  (Val (Core.Value era), FamsTo era) => TxBody era
+txBodyZero = TxBody
+    Set.empty
+    (fromList [])
+    (fromList [])
+    (Wdrl Map.empty)
+    (Coin 0)
+    (ValidityInterval  SNothing  SNothing)
+    SNothing
+    SNothing
+    zero
+
+genMATxBody :: forall era.
+  ( FamsTo era,
+    ValueClass era
+  ) =>
+    SlotNo ->
+    Set.Set (TxIn era) ->
+    StrictSeq (TxOut era) ->
+    StrictSeq (DCert era) ->
+    Wdrl era ->
+    Coin ->
+    StrictMaybe (Update era) ->
+    StrictMaybe (MetaDataHash era) ->
+    Gen (TxBody era)
+genMATxBody (ttl@(SlotNo n)) ins outs cert wdrl fee upd meta = do
+   m <- choose (5,n)
+   timeStart <- frequency [(1,pure SNothing),(4,pure $ SJust (SlotNo m))]
+   timeExpire <- frequency [(1,pure SNothing),(4, pure $ SJust ttl)]
+   forge <- genValue @era [] 0 0 -- TODO we need a [PolicyID era]  not the []
+   pure (TxBody
+          ins
+          outs
+          cert
+          wdrl
+          fee
+          (ValidityInterval timeStart timeExpire)
+          upd
+          meta
+          forge)
+
+instance Split (Value era) where
+  vsplit (Value n _) 0 = ([], Coin n)
+  vsplit (Value n mp) m
+    | m Prelude.<= 0 = error "must split coins into positive parts"
+    | otherwise = (take (fromIntegral m) ((Value (n `div` m) mp): (repeat (Value (n `div` m) Map.empty))),
+                   Coin (n `rem` m))

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -39,13 +39,14 @@ import Shelley.Spec.Ledger.Coin(Coin(..))
 import Shelley.Spec.Ledger.Keys(KeyHash,KeyRole(..))
 import Shelley.Spec.Ledger.MetaData (MetaDataHash)
 import Shelley.Spec.Ledger.PParams(Update)
+import Shelley.Spec.Ledger.Scripts(ScriptHash)
 import Shelley.Spec.Ledger.Tx(TxOut,TxIn)
 import Shelley.Spec.Ledger.TxBody(DCert,Wdrl(..))
 import Test.Cardano.Ledger.EraBuffet(MaryEra)
 import Test.Shelley.Spec.Ledger.Generator.Core(EraGen (..))
 import Test.Shelley.Spec.Ledger.Generator.EraGen(genUtxo0)
 import Test.Shelley.Spec.Ledger.Utils (Split (..))
-import Test.Shelley.Spec.Ledger.Generator.Scripts
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass(..),
     Quantifier(..),
     ValueClass(..),
@@ -131,6 +132,7 @@ genMATxBody :: forall era.
   ( FamsTo era,
     ValueClass era
   ) =>
+    [ScriptHash era] ->
     SlotNo ->
     Set.Set (TxIn era) ->
     StrictSeq (TxOut era) ->
@@ -140,11 +142,11 @@ genMATxBody :: forall era.
     StrictMaybe (Update era) ->
     StrictMaybe (MetaDataHash era) ->
     Gen (TxBody era)
-genMATxBody (ttl@(SlotNo n)) ins outs cert wdrl fee upd meta = do
+genMATxBody scriptHashes (ttl@(SlotNo n)) ins outs cert wdrl fee upd meta = do
    m <- choose (5,n)
    timeStart <- frequency [(1,pure SNothing),(4,pure $ SJust (SlotNo m))]
    timeExpire <- frequency [(1,pure SNothing),(4, pure $ SJust ttl)]
-   forge <- genValue @era [] 0 0 -- TODO we need a [PolicyID era]  not the []
+   forge <- genValue @era scriptHashes 0 0 -- TODO we need a [PolicyID era]  not the []
    pure (TxBody
           ins
           outs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -22,8 +22,8 @@ module Shelley.Spec.Ledger.Scripts
       ),
     getMultiSigBytes,
     ScriptHash (..),
-    getKeyCombination,
-    getKeyCombinations,
+    -- getKeyCombination,  GONE
+    -- getKeyCombinations, GONE
     hashMultiSigScript,
   )
 where
@@ -44,7 +44,7 @@ import Data.Aeson
 import qualified Data.ByteString as BS
 import Data.ByteString.Short (ShortByteString)
 import Data.Coders (Encode (..), (!>))
-import qualified Data.List as List (concat, concatMap, permutations)
+-- import qualified Data.List as List (concat, concatMap, permutations) GONE
 import Data.MemoBytes
   ( Mem,
     MemoBytes (..),
@@ -162,6 +162,7 @@ hashMultiSigScript =
     . Hash.castHash
     . Hash.hashWith (\x -> nativeMultiSigTag <> serialize' x)
 
+{-  GONE
 -- | Get one possible combination of keys for multi signature script
 getKeyCombination :: Era era => MultiSig era -> [KeyHash 'Witness (Crypto era)]
 getKeyCombination (RequireSignature hk) = [hk]
@@ -186,6 +187,7 @@ getKeyCombinations (RequireAnyOf msigs) = List.concatMap getKeyCombinations msig
 getKeyCombinations (RequireMOf m msigs) =
   let perms = map (take m) $ List.permutations msigs
    in map (concat . List.concatMap getKeyCombinations) perms
+-}
 
 -- CBOR
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -46,8 +46,8 @@ module Shelley.Spec.Ledger.Tx
     ValidateScript (..),
     txwitsScript,
     extractKeyHashWitnessSet,
-    getKeyCombinations,
-    getKeyCombination,
+    -- getKeyCombinations, GONE
+    -- getKeyCombination, GONE
     addrWits',
     evalNativeMultiSigScript,
     hashMultiSigScript,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -26,7 +26,6 @@ module BenchValidation
   )
 where
 
-import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (..))
 import Cardano.Prelude (NFData (rnf))
@@ -59,12 +58,11 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
-import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Core (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
-import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyLedgersSTS, ShelleyTest, testGlobals)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest, testGlobals)
 
 -- ==============================================================
 
@@ -82,13 +80,11 @@ validateInput ::
     Mock (Crypto era),
     API.GetLedgerView era,
     API.ApplyBlock era,
-    ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era
+    ShelleyLedgerSTS era
   ) =>
-  Gen (Core.Value era) ->
   Int ->
   IO (ValidateInput era)
-validateInput gv utxoSize = genValidateInput gv utxoSize
+validateInput utxoSize = genValidateInput utxoSize
 
 genValidateInput ::
   ( EraGen era,
@@ -96,15 +92,13 @@ genValidateInput ::
     Mock (Crypto era),
     API.GetLedgerView era,
     API.ApplyBlock era,
-    ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era
+    ShelleyLedgerSTS era
   ) =>
-  Gen (Core.Value era) ->
   Int ->
   IO (ValidateInput era)
-genValidateInput gv n = do
+genValidateInput n = do
   let ge = genEnv (Proxy :: Proxy era)
-  chainstate <- genChainState gv n ge
+  chainstate <- genChainState n ge
   block <- genBlock ge chainstate
   pure (ValidateInput testGlobals (chainNes chainstate) block)
 
@@ -178,15 +172,13 @@ genUpdateInputs ::
     Mock (Crypto era),
     API.GetLedgerView era,
     API.ApplyBlock era,
-    ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era
+    ShelleyLedgerSTS era
   ) =>
-  Gen (Core.Value era) ->
   Int ->
   IO (UpdateInputs (Crypto era))
-genUpdateInputs gv utxoSize = do
+genUpdateInputs utxoSize = do
   let ge = genEnv (Proxy :: Proxy era)
-  chainstate <- genChainState gv utxoSize ge
+  chainstate <- genChainState utxoSize ge
   (Block blockheader _) <- genBlock ge chainstate
   let ledgerview = currentLedgerView (chainNes chainstate)
   let (ChainState _newepochState keys eta0 etaV etaC etaH slot) = chainstate

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -242,13 +242,13 @@ validGroup =
   where
     runAtUTxOSize n =
       bgroup (show n) $
-        [ env (validateInput @BenchEra genVl n) $ \arg ->
+        [ env (validateInput @BenchEra n) $ \arg ->
             bgroup
               "block"
               [ bench "applyBlockTransition" (nfIO $ benchValidate arg),
                 bench "reapplyBlockTransition" (nf benchreValidate arg)
               ],
-          env (genUpdateInputs @BenchEra genVl n) $ \arg ->
+          env (genUpdateInputs @BenchEra n) $ \arg ->
             bgroup
               "protocol"
               [ bench "updateChainDepState" (nf updateChain arg),
@@ -260,7 +260,7 @@ validGroup =
 
 profileValid :: IO ()
 profileValid = do
-  state <- validateInput @BenchEra genVl 10000
+  state <- validateInput @BenchEra 10000
   let ans = sum [applyBlock @BenchEra state n | n <- [1 .. 10000 :: Int]]
   putStrLn (show ans)
   pure ()
@@ -362,7 +362,7 @@ varyDelegState tag fixed changes initstate action =
 main :: IO ()
 -- main=profileValid
 main = do
-  (genenv, chainstate, genTxfun) <- genTriple genVl (Proxy :: Proxy BenchEra) 1000
+  (genenv, chainstate, genTxfun) <- genTriple (Proxy :: Proxy BenchEra) 1000
   defaultMain $
     [ bgroup "vary input size" $
         [ varyInput
@@ -479,7 +479,7 @@ main = do
         ],
       bgroup "rewards" $
         [ env
-            (generate $ genChainInEpoch genVl 5)
+            (generate $ genChainInEpoch 5)
             ( \cs ->
                 bench "createRUpd" $ whnf (createRUpd testGlobals) cs
             ),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -10,7 +10,6 @@ module Shelley.Spec.Ledger.Bench.Gen
   )
 where
 
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Control.State.Transition.Extended
 import Data.Either (fromRight)
@@ -27,7 +26,7 @@ import Shelley.Spec.Ledger.LedgerState
     LedgerState (..),
     NewEpochState (..),
   )
-import Test.QuickCheck (Gen, generate)
+import Test.QuickCheck (generate)
 import Test.Shelley.Spec.Ledger.BenchmarkFunctions (ledgerEnv)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import qualified Test.Shelley.Spec.Ledger.Generator.Block as GenBlock
@@ -43,18 +42,17 @@ import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
-import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyLedgersSTS, ShelleyTest)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest)
 
 -- =============================================================================
 
 -- | Generate a genesis chain state given a UTxO size
 genChainState ::
   EraGen era =>
-  Gen (Core.Value era) ->
   Int ->
   GenEnv era ->
   IO (ChainState era)
-genChainState _gv n ge =
+genChainState n ge =
   let cs =
         (geConstants ge)
           { minGenesisUTxOouts = n,
@@ -75,7 +73,6 @@ genBlock ::
     Mock (Crypto era),
     ShelleyTest era,
     ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era,
     GetLedgerView era,
     ApplyBlock era
   ) =>
@@ -97,13 +94,12 @@ genTriple ::
     Mock (Crypto era),
     ShelleyTest era
   ) =>
-  Gen (Core.Value era) ->
   Proxy era ->
   Int ->
   IO (GenEnv era, ChainState era, GenEnv era -> IO (Tx era))
-genTriple gv proxy n = do
+genTriple proxy n = do
   let ge = genEnv proxy
-  cs <- genChainState gv n ge
+  cs <- genChainState n ge
   let nes = chainNes cs -- NewEpochState
   let es = nesEs nes -- EpochState
   let (LedgerState utxoS dpstate) = esLState es -- LedgerState

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -11,7 +11,6 @@ module Shelley.Spec.Ledger.Bench.Rewards
 where
 
 import Cardano.Crypto.VRF (hashVerKeyVRF)
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Slotting.EpochInfo
 import Cardano.Slotting.Slot (EpochNo)
@@ -64,8 +63,8 @@ import Test.Shelley.Spec.Ledger.Utils (testGlobals)
 -- | Generate a chain state at a given epoch. Since we are only concerned about
 -- rewards, this will populate the chain with empty blocks (only issued by the
 -- original genesis delegates).
-genChainInEpoch :: Gen (Core.Value B) -> EpochNo -> Gen (ChainState B)
-genChainInEpoch _gv epoch = do
+genChainInEpoch :: EpochNo -> Gen (ChainState B)
+genChainInEpoch epoch = do
   genesisChainState <-
     fromRight (error "genChainState failed")
       <$> mkGenesisChainState @B cs (IRC ())

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -34,7 +34,7 @@ library
     Test.Shelley.Spec.Ledger.Generator.Presets
     Test.Shelley.Spec.Ledger.Generator.Trace.Chain
     Test.Shelley.Spec.Ledger.Generator.Trace.DCert
-    Test.Shelley.Spec.Ledger.Generator.Scripts
+    Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
     Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
     Test.Shelley.Spec.Ledger.Generator.Update
     Test.Shelley.Spec.Ledger.Generator.Utxo

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -34,6 +34,7 @@ library
     Test.Shelley.Spec.Ledger.Generator.Presets
     Test.Shelley.Spec.Ledger.Generator.Trace.Chain
     Test.Shelley.Spec.Ledger.Generator.Trace.DCert
+    Test.Shelley.Spec.Ledger.Generator.Scripts
     Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
     Test.Shelley.Spec.Ledger.Generator.Update
     Test.Shelley.Spec.Ledger.Generator.Utxo

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -59,7 +59,6 @@ import Test.Shelley.Spec.Ledger.Generator.Core
 import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
 import Test.Shelley.Spec.Ledger.Utils
   ( ShelleyLedgerSTS,
-    ShelleyLedgersSTS,
     epochFromSlotNo,
     maxKESIterations,
     runShelleyBase,
@@ -83,7 +82,6 @@ genBlock ::
     ApplyBlock era,
     GetLedgerView era,
     ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -198,12 +198,16 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
+import Test.Shelley.Spec.Ledger.Generator.Scripts(ScriptClass, mkPayScriptHashMap,mkStakeScriptHashMap)
+
+-- ===================================
 
 class
   ( ShelleyBased era,
     ValidateScript era,
     Split (Core.Value era),
-    Show (Core.Script era)
+    Show (Core.Script era),
+    ScriptClass era
   ) =>
   EraGen era
   where
@@ -220,9 +224,9 @@ class
     StrictMaybe (MetaDataHash era) ->
     Gen (Core.TxBody era)
 
-  eraScriptWitnesses :: Core.Script era -> [[KeyHash 'Witness (Crypto era)]]
+  -- eraScriptWitnesses :: Core.Script era -> [[KeyHash 'Witness (Crypto era)]] GONE
 
-  eraKeySpaceScripts :: Constants -> [(Core.Script era, Core.Script era)]
+  -- eraKeySpaceScripts :: Constants -> [(Core.Script era, Core.Script era)]   GONE
 
   updateEraTxBody ::
     Core.TxBody era ->
@@ -272,7 +276,7 @@ data KeySpace era = KeySpace_
 deriving instance (Era era, Show (Core.Script era)) => Show (KeySpace era)
 
 pattern KeySpace ::
-  EraGen era =>
+  ScriptClass era =>
   [(GenesisKeyPair (Crypto era), AllIssuerKeys (Crypto era) 'GenesisDelegate)] ->
   [AllIssuerKeys (Crypto era) 'GenesisDelegate] ->
   [AllIssuerKeys (Crypto era) 'StakePool] ->
@@ -359,6 +363,7 @@ mkStakeKeyHashMap keyPairs =
   where
     f (_payK, stakeK) = ((hashKey . vKey) stakeK, stakeK)
 
+
 -- | Generate a mapping from payment key hash to keypair
 -- from a list of (payment, staking) key pairs.
 mkPayKeyHashMap ::
@@ -370,6 +375,7 @@ mkPayKeyHashMap keyPairs =
   where
     f (payK, _stakeK) = ((hashKey . vKey) payK, payK)
 
+{-
 -- | Generate a mapping from pay script hash to multisig pair.
 mkPayScriptHashMap ::
   EraGen era =>
@@ -389,6 +395,7 @@ mkStakeScriptHashMap scripts =
   Map.fromList (f <$> scripts)
   where
     f script@(_pay, stake) = (hashScript stake, script)
+-}
 
 -- | Find first matching key pair for a credential. Returns the matching key pair
 -- where the first element of the pair matched the hash in 'addr'.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -198,7 +198,7 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
-import Test.Shelley.Spec.Ledger.Generator.Scripts
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass,
     ValueClass,
     TxBodyClass,
@@ -223,6 +223,7 @@ class
   genEraUtxo0 :: Constants -> Gen (UTxO era)
 
   genEraTxBody ::
+    [ScriptHash era] ->
     SlotNo ->
     Set (TxIn era) ->
     StrictSeq (TxOut era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -37,7 +37,7 @@ import Shelley.Spec.Ledger.LedgerState (KeyPairs)
 import Shelley.Spec.Ledger.MetaData (MetaDataHash)
 import Shelley.Spec.Ledger.Scripts
   ( MultiSig,
-    getKeyCombinations,
+    -- getKeyCombinations,
     pattern RequireAllOf,
     pattern RequireAnyOf,
     pattern RequireMOf,
@@ -64,9 +64,9 @@ instance CC.Crypto c => EraGen (ShelleyEra c) where
   genEraUtxo0 = genUtxo0
   genEraTxBody = genTxBody
 
-  eraScriptWitnesses = getKeyCombinations
+  -- eraScriptWitnesses = getKeyCombinations
 
-  eraKeySpaceScripts = mSigCombinedScripts
+  -- eraKeySpaceScripts = mSigCombinedScripts
 
   updateEraTxBody body fee ins outs =
     body

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -39,7 +39,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     genesisCoins,
   )
 import Test.Shelley.Spec.Ledger.Generator.Presets(someKeyPairs)
-import Test.Shelley.Spec.Ledger.Generator.Scripts
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass,
     ValueClass(..),
     TxBodyClass(..),
@@ -51,7 +51,7 @@ import Data.Proxy(Proxy(..))
 
 instance CC.Crypto c => EraGen (ShelleyEra c) where
   genEraUtxo0 = genUtxo0
-  genEraTxBody = genTxBody
+  genEraTxBody _scriptHashes = genTxBody
 
   updateEraTxBody body fee ins outs =
     body

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId) where
+module Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId,genUtxo0) where
 
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
@@ -102,9 +102,10 @@ genUtxo0 ::
 genUtxo0 c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts, maxGenesisOutputVal, minGenesisOutputVal} = do
   genesisKeys <- someKeyPairs c minGenesisUTxOouts maxGenesisUTxOouts
   genesisScripts <- someScripts (Proxy @era) c minGenesisUTxOouts maxGenesisUTxOouts
+  let scriptHashList = map (hashScript . fst) genesisScripts
   outs <-
     genTxOut
-      (genValue @era minGenesisOutputVal maxGenesisOutputVal)
+      (genValue @era scriptHashList minGenesisOutputVal maxGenesisOutputVal)
       (fmap (toAddr Testnet) genesisKeys ++ fmap (scriptsToAddr' Testnet) genesisScripts)
   return (genesisCoins (genesisId @era)  outs)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -51,11 +51,19 @@ import Test.Shelley.Spec.Ledger.Utils
     mkVRFKeyPair,
     slotsPerKESIteration,
   )
+import Data.Proxy
+import Test.Shelley.Spec.Ledger.Generator.Scripts
+  ( ScriptClass(..),
+    keyPairs,
+    combinedScripts,
+  )
+
+-- ==================================================================
 
 -- | Example generator environment, consisting of default constants and an
 -- corresponding keyspace.
 genEnv ::
-  EraGen era =>
+  ScriptClass era =>
   proxy era ->
   GenEnv era
 genEnv _ =
@@ -66,7 +74,7 @@ genEnv _ =
 -- | Example keyspace for use in generators
 keySpace ::
   forall era.
-  EraGen era =>
+  ScriptClass era =>
   Constants ->
   KeySpace era
 keySpace c =
@@ -75,11 +83,14 @@ keySpace c =
     (genesisDelegates c)
     (stakePoolKeys c)
     (keyPairs c)
-    (eraKeySpaceScripts @era c)
+    -- (eraKeySpaceScripts @era c)   GONE
+    (combinedScripts (Proxy :: Proxy era) c)
 
+{- GONE
 -- | Constant list of KeyPairs intended to be used in the generators.
 keyPairs :: CC.Crypto crypto => Constants -> KeyPairs crypto
 keyPairs Constants {maxNumKeyPairs} = mkKeyPairs <$> [1 .. maxNumKeyPairs]
+-}
 
 -- | Select between _lower_ and _upper_ keys from 'keyPairs'
 someKeyPairs :: CC.Crypto crypto => Constants -> Int -> Int -> Gen (KeyPairs crypto)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -52,7 +52,7 @@ import Test.Shelley.Spec.Ledger.Utils
     slotsPerKESIteration,
   )
 import Data.Proxy
-import Test.Shelley.Spec.Ledger.Generator.Scripts
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass(..),
     keyPairs,
     combinedScripts,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Scripts.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Scripts.hs
@@ -1,0 +1,266 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+-- =============================================================================
+
+-- | We gather together all the operations on the type family Script that are
+--   necessary to generate consistent transactions to run property tests.
+--   The key component is the class ScriptClass.
+module Test.Shelley.Spec.Ledger.Generator.Scripts
+  ( ScriptClass(..),
+    Quantifier(..),
+    anyOf, allOf, mOf,
+    ScriptPairs,
+    keyPairs,
+    mkPayScriptHashMap,
+    mkStakeScriptHashMap,
+    mkScriptsFromKeyPair,
+    mkKeyPairs,
+    mkScripts,
+    mkScriptCombinations,
+    combinedScripts,
+    someScripts,
+    scriptKeyCombinations,
+    scriptKeyCombination,
+  )
+  where
+
+import Shelley.Spec.Ledger.Scripts(MultiSig(..),ScriptHash,hashMultiSigScript)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Core(Script,Value,TxBody,ChainData, SerialisableData, AnnotatedData)
+import Cardano.Ledger.Era (Era(..))
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Shelley.Spec.Ledger.Keys (Hash, KeyHash, KeyRole (..),VKey(..), hashKey, asWitness, KeyPair(..), vKey)
+import Cardano.Binary(ToCBOR(..),FromCBOR(..),Annotator)
+import Cardano.Ledger.Torsor (Torsor (..))
+import Cardano.Ledger.Compactible(Compactible(..),CompactForm(..))
+import NoThunks.Class (NoThunks (..))
+import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
+import Data.Proxy
+import qualified Data.Map as Map
+import qualified Data.List as List
+import Cardano.Ledger.Val(Val(..))
+import qualified Cardano.Crypto.Hash as Hash
+import Shelley.Spec.Ledger.TxBody() -- import instances only
+import Data.List(concatMap,permutations)
+import Shelley.Spec.Ledger.LedgerState( KeyPairs )
+import Test.Shelley.Spec.Ledger.Generator.Constants
+  ( Constants (..),
+    defaultConstants,
+  )
+import Test.QuickCheck (Gen)
+import qualified Test.QuickCheck as QC
+import Test.Shelley.Spec.Ledger.Utils( mkKeyPair )
+import Data.Word(Word64)
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
+import Cardano.Ledger.Crypto (DSIGN)
+import Data.Tuple (swap)
+import Shelley.Spec.Ledger.Tx( ValidateScript (..) )
+
+
+-- ==============================================================================
+
+class ( Show (Script era),
+        Eq (Script era),
+        ValidateScript era,
+        HashIndex (Core.TxBody era) ~ EraIndependentTxBody,
+        Eq (Core.TxBody era),
+        Show (Core.TxBody era),
+        CC.Crypto(Crypto era),
+        Era era ) => ScriptClass era where
+  basescript :: Proxy era -> KeyHash 'Witness (Crypto era) -> Script era
+  isKey :: Proxy era -> Script era -> Maybe (KeyHash 'Witness (Crypto era))
+  quantify :: Proxy era -> Script era -> Quantifier (Script era)
+  unQuantify:: Proxy era -> Quantifier (Script era) -> Script era
+
+type ScriptPairs era = [(Core.Script era, Core.Script era)]
+
+-- ====================================
+
+-- | Abstracts the quantifier structure of (Script era)
+--   used in the 'quantify' and 'unQuantify' methods of ScriptClass.
+data Quantifier t = AllOf [t] | AnyOf [t] | MOf Int [t] | Leaf t
+
+anyOf :: forall era. ScriptClass era => Proxy era -> [Script era] -> Script era
+anyOf prox xs = unQuantify prox $ AnyOf xs
+
+allOf :: forall era. ScriptClass era => Proxy era -> [Script era] -> Script era
+allOf prox xs = unQuantify prox $ AllOf xs
+
+mOf :: forall era. ScriptClass era => Proxy era -> Int -> [Script era] -> Script era
+mOf prox m xs = unQuantify prox $ MOf m xs
+
+-- =======================================================================
+-- Compute lists of keyHashes
+
+-- | return the first sublist that meets the predicate p.
+getFirst :: ([a] -> Bool) -> [[a]] -> [a]
+getFirst _p [] = []
+getFirst p (xs:xss) = if p xs then xs else getFirst p xss
+
+-- | Return some valid list of KeyHashes that appear in a Script
+--   Try not to return the empty list if there is at least on
+--   Leaf that requires a key hash.
+scriptKeyCombination :: forall era. ScriptClass era =>
+   Proxy era -> Script era -> [KeyHash 'Witness (Crypto era)]
+scriptKeyCombination prox script = case quantify prox script of
+  AllOf xs ->  concatMap (scriptKeyCombination prox) xs
+  AnyOf xs -> getFirst (not . null) (map (scriptKeyCombination prox) xs)
+  MOf m xs -> concatMap (scriptKeyCombination prox) (take m xs)
+  Leaf t -> case isKey prox t of
+              Just hk -> [ hk ]
+              Nothing -> []
+
+-- | Return all valid lists of KeyHashes that appear in a Script
+--   used in testing.
+scriptKeyCombinations :: forall era. ScriptClass era =>
+   Proxy era -> Script era -> [[KeyHash 'Witness (Crypto era)]]
+scriptKeyCombinations prox script = case quantify prox script of
+  AllOf xs -> [concat $ concatMap (scriptKeyCombinations prox) xs]
+  AnyOf xs ->  concatMap (scriptKeyCombinations prox) xs
+  MOf m xs ->
+     let perms = map (take m) $ permutations xs
+     in map (concat . concatMap (scriptKeyCombinations prox)) perms
+  Leaf t -> case isKey prox t of
+              Just hk -> [[hk]]
+              Nothing -> [[]]
+
+-- ================================================================
+
+mkScriptFromKey :: forall era. (ScriptClass era) => KeyPair 'Witness (Crypto era) -> Core.Script era
+mkScriptFromKey = (basescript (Proxy :: Proxy era) . hashKey . vKey)
+
+mkScriptsFromKeyPair :: forall era.
+  (ScriptClass era) =>
+  (KeyPair 'Payment (Crypto era), KeyPair 'Staking (Crypto era)) ->
+  (Core.Script era, Core.Script era)
+mkScriptsFromKeyPair (k0, k1) =
+  (mkScriptFromKey @era $ asWitness k0, mkScriptFromKey @era $ asWitness k1)
+
+
+-- | make Scripts based on the given key pairs
+mkScripts :: forall era. (ScriptClass era) => KeyPairs (Crypto era) -> ScriptPairs era
+mkScripts = map (mkScriptsFromKeyPair @era)
+
+mkPayScriptHashMap ::
+  (ScriptClass era) =>
+  [(Core.Script era, Core.Script era)] ->
+  Map.Map (ScriptHash era) (Core.Script era, Core.Script era)
+mkPayScriptHashMap scripts =
+  Map.fromList (f <$> scripts)
+  where
+    f script@(pay, _stake) = (hashScript pay, script)
+
+-- | Generate a mapping from stake script hash to multisig pair.
+mkStakeScriptHashMap ::
+  (ScriptClass era) =>
+  [(Core.Script era, Core.Script era)] ->
+  Map.Map (ScriptHash era) (Core.Script era, Core.Script era)
+mkStakeScriptHashMap scripts =
+  Map.fromList (f <$> scripts)
+  where
+    f script@(_pay, stake) = (hashScript stake, script)
+
+
+-- =========================================================================
+
+-- | Combine a list of ScriptPairs into hierarchically structured multi-sig
+-- scripts, list must have at least length 3. Be careful not to call with too
+-- many pairs in order not to create too many of the possible combinations.
+mkScriptCombinations :: forall era. (ScriptClass era) => ScriptPairs era -> ScriptPairs era
+mkScriptCombinations msigs =
+  if length msigs < 3
+    then error "length of input msigs must be at least 3"
+    else (List.foldl' (++) [] $
+      do
+        (k1, k2) <- msigs
+        (k3, k4) <- msigs List.\\ [(k1, k2)]
+        (k5, k6) <- msigs List.\\ [(k1, k2), (k3, k4)]
+
+        pure
+          [ (pay, stake)
+            | pay <-
+                [ anyOf (Proxy @era) [k1, k3, k5],
+                  allOf (Proxy @era) [k1, k3, k5],
+                  mOf (Proxy @era) 1 [k1, k3, k5],
+                  mOf (Proxy @era) 2 [k1, k3, k5],
+                  mOf (Proxy @era) 3 [k1, k3, k5]
+                ],
+              stake <-
+                [ anyOf (Proxy @era) [k2, k4, k6],
+                  allOf (Proxy @era) [k2, k4, k6],
+                  mOf (Proxy @era) 1 [k2, k4, k6],
+                  mOf (Proxy @era) 2 [k2, k4, k6],
+                  mOf (Proxy @era) 3 [k2, k4, k6]
+                ]
+          ]) :: ScriptPairs era
+
+
+
+baseScripts :: forall era. ScriptClass era => Proxy era -> Constants -> ScriptPairs era
+baseScripts _proxy c = mkScripts @era (keyPairs c)
+
+combinedScripts :: forall era. ScriptClass era => Proxy era -> Constants -> ScriptPairs era
+combinedScripts proxy c@(Constants {numBaseScripts}) =
+  mkScriptCombinations @era . take numBaseScripts $ baseScripts proxy c
+
+-- | Select between _lower_ and _upper_ scripts from the possible combinations
+-- of the first `numBaseScripts` multi-sig scripts of `mSigScripts`.
+someScripts :: ScriptClass era => Proxy era -> Constants -> Int -> Int -> Gen (ScriptPairs era)
+someScripts proxy c lower upper =
+  take
+    <$> QC.choose (lower, upper)
+    <*> QC.shuffle (combinedScripts proxy c)
+
+
+-- | Constant list of KeyPairs intended to be used in the generators.
+keyPairs :: CC.Crypto crypto => Constants -> KeyPairs crypto
+keyPairs Constants {maxNumKeyPairs} = mkKeyPairs <$> [1 .. maxNumKeyPairs]
+
+mkKeyPairs ::
+  (DSIGNAlgorithm (DSIGN crypto)) =>
+  Word64 ->
+  (KeyPair kr crypto, KeyPair kr' crypto)
+mkKeyPairs n =
+  (mkKeyPair_ (2 * n), mkKeyPair_ (2 * n + 1))
+  where
+    mkKeyPair_ n_ =
+      (uncurry KeyPair . swap)
+        (mkKeyPair (n_, n_, n_, n_, n_))
+
+-- ==========================================================
+-- The (ShelleyEra c) instance of ScriptClass and EraGen
+
+instance CC.Crypto c => ScriptClass (ShelleyEra c) where
+  basescript _proxy = RequireSignature
+  isKey _ (RequireSignature hk) = Just hk
+  isKey _ _ = Nothing
+  quantify _ (RequireAllOf xs) = AllOf xs
+  quantify _ (RequireAnyOf xs) = AnyOf xs
+  quantify _ (RequireMOf n xs) = MOf n xs
+  quantify _ t = Leaf t
+  unQuantify _  (AllOf xs) = (RequireAllOf xs)
+  unQuantify _  (AnyOf xs) = (RequireAnyOf xs)
+  unQuantify _  (MOf n xs) = (RequireMOf n xs)
+  unQuantify _  (Leaf t) = t

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Scripts.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Scripts.hs
@@ -172,7 +172,7 @@ mkPayScriptHashMap scripts =
   where
     f script@(pay, _stake) = (hashScript pay, script)
 
--- | Generate a mapping from stake script hash to multisig pair.
+-- | Generate a mapping from stake script hash to script pair.
 mkStakeScriptHashMap ::
   (ScriptClass era) =>
   [(Core.Script era, Core.Script era)] ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -62,7 +62,6 @@ import Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
 import Test.Shelley.Spec.Ledger.Utils
   ( ShelleyChainSTS,
     ShelleyLedgerSTS,
-    ShelleyLedgersSTS,
     ShelleyTest,
     maxLLSupply,
     mkHash,
@@ -76,7 +75,6 @@ instance
     ApplyBlock era,
     GetLedgerView era,
     ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era,
     ShelleyChainSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -69,6 +69,8 @@ import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Shelley.Spec.Ledger.Generator.Core (EraGen (..), GenEnv (..), KeySpace (..))
 import Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..), genDCert)
 import Test.Shelley.Spec.Ledger.Utils (testGlobals)
+import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombination)
+import Data.Proxy(Proxy(..))
 
 -- | This is a non-spec STS used to generate a sequence of certificates with
 -- witnesses.
@@ -191,15 +193,17 @@ genDCerts
       scriptWitnesses (ScriptCred (_, stakeScript)) =
         StakeCred <$> witnessHashes''
         where
-          witnessHashes = eraScriptWitness stakeScript
+          -- witnessHashes = eraScriptWitness stakeScript
+          witnessHashes = scriptKeyCombination (Proxy @era) stakeScript
           witnessHashes' = fmap coerceKeyRole witnessHashes
           witnessHashes'' = fmap coerceKeyRole (catMaybes (map lookupWit witnessHashes'))
       scriptWitnesses _ = []
-
+{-
       eraScriptWitness s =
         case (eraScriptWitnesses @era s) of
           [] -> error "genDCerts - empty eraScriptWitnesses"
           (k : _) -> k
+-}
 
       lookupWit = flip Map.lookup ksIndexedStakingKeys
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -69,7 +69,7 @@ import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Shelley.Spec.Ledger.Generator.Core (EraGen (..), GenEnv (..), KeySpace (..))
 import Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..), genDCert)
 import Test.Shelley.Spec.Ledger.Utils (testGlobals)
-import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombination)
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(scriptKeyCombination)
 import Data.Proxy(Proxy(..))
 
 -- | This is a non-spec STS used to generate a sequence of certificates with

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -49,7 +49,6 @@ import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Utils
   ( ShelleyLedgerSTS,
-    ShelleyLedgersSTS,
     applySTSTest,
     runShelleyBase,
   )
@@ -90,7 +89,6 @@ instance
   ( EraGen era,
     Mock (Crypto era),
     ShelleyLedgerSTS era,
-    ShelleyLedgersSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/TypeFamilyClasses.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/TypeFamilyClasses.hs
@@ -26,7 +26,7 @@
 -- | We gather together all the operations on the type family Script that are
 --   necessary to generate consistent transactions to run property tests.
 --   The key component is the class ScriptClass.
-module Test.Shelley.Spec.Ledger.Generator.Scripts
+module Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses
   ( ScriptClass(..),
     Quantifier(..),
     ValueClass(..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -106,6 +106,10 @@ import Test.Shelley.Spec.Ledger.Generator.MetaData (genMetaData)
 import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
 import Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, Split (..))
+import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombination)
+import Data.Proxy(Proxy(..))
+
+-- ======================================================
 
 showBalance ::
   ( ShelleyTest era,
@@ -530,12 +534,13 @@ mkTxWits
           . map (\(a, b) -> (asWitness a, asWitness b))
           . Map.toAscList
           $ indexedStakingKeys
-      keysLists = map eraScriptWitness (Map.elems msigs)
-
-      eraScriptWitness s =
+      keysLists = map (scriptKeyCombination (Proxy @era)) (Map.elems msigs)
+{-
+      eraScriptWitness s =   GONE
         case (eraScriptWitnesses @era s) of
           [] -> error "mkTxWits - empty eraScriptWitnesses"
           (k : _) -> k
+-}
       msigSignatures = foldl' Set.union Set.empty $ map Set.fromList keysLists
 
 -- | Distribute the sum of `balance_` and `fee` over the addresses, return the

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -106,7 +106,7 @@ import Test.Shelley.Spec.Ledger.Generator.MetaData (genMetaData)
 import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
 import Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, Split (..))
-import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombination)
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(scriptKeyCombination)
 import Data.Proxy(Proxy(..))
 
 -- ======================================================
@@ -246,6 +246,7 @@ genTx
               draftFee
       draftTxBody <-
         genEraTxBody @era
+          (Map.keys scripts)
           slot
           (Set.fromList inputs)
           draftOutputs

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -33,12 +33,10 @@ module Test.Shelley.Spec.Ledger.Utils
     maxLLSupply,
     applySTSTest,
     GenesisKeyPair,
-    MultiSigPairs,
     getBlockNonce,
     ShelleyTest,
     ShelleyUtxoSTS,
     ShelleyLedgerSTS,
-    ShelleyLedgersSTS,
     ShelleyChainSTS,
     ChainProperty,
     Split (..),
@@ -180,11 +178,8 @@ type ShelleyLedgerSTS era =
     BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
     State (LEDGER era) ~ (UTxOState era, DPState era),
-    Signal (LEDGER era) ~ Tx era
-  )
-
-type ShelleyLedgersSTS era =
-  ( STS (LEDGERS era),
+    Signal (LEDGER era) ~ Tx era,
+    STS (LEDGERS era),
     BaseM (LEDGERS era) ~ ShelleyBase,
     Environment (LEDGERS era) ~ LedgersEnv era,
     State (LEDGERS era) ~ LedgerState era,
@@ -205,8 +200,6 @@ class Split v where
 -- =======================================================
 
 type GenesisKeyPair crypto = KeyPair 'Genesis crypto
-
-type MultiSigPairs era = [(MultiSig era, MultiSig era)]
 
 -- ================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/GenesisDelegation.hs
@@ -83,8 +83,11 @@ import Test.Shelley.Spec.Ledger.Utils
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(TxBodyClass(..))
 
-initUTxO :: ShelleyTest era => UTxO era
+-- ===============================================================
+
+initUTxO :: (TxBodyClass era,ShelleyTest era) => UTxO era
 initUTxO =
   genesisCoins
     genesisId
@@ -95,7 +98,7 @@ initUTxO =
     aliceInitCoin = Val.inject $ Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
     bobInitCoin = Val.inject $ Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initStGenesisDeleg :: forall era. ShelleyTest era => ChainState era
+initStGenesisDeleg :: forall era. (TxBodyClass era,ShelleyTest era) => ChainState era
 initStGenesisDeleg = initSt initUTxO
 
 --

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -89,8 +89,10 @@ import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, getBlockNonce)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(TxBodyClass(..))
 
-initUTxO :: ShelleyTest era => UTxO era
+
+initUTxO :: (TxBodyClass era,ShelleyTest era) => UTxO era
 initUTxO =
   genesisCoins
     genesisId
@@ -101,7 +103,7 @@ initUTxO =
     aliceInitCoin = Val.inject $ Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
     bobInitCoin = Val.inject $ Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initStMIR :: forall era. (ShelleyTest era) => Coin -> ChainState era
+initStMIR :: forall era. (TxBodyClass era,ShelleyTest era) => Coin -> ChainState era
 initStMIR treasury = cs {chainNes = (chainNes cs) {nesEs = es'}}
   where
     cs = initSt @era initUTxO
@@ -126,7 +128,7 @@ ir = Map.fromList [(Cast.aliceSHK, aliceMIRCoin)]
 feeTx1 :: Coin
 feeTx1 = Coin 1
 
-txbodyEx1 :: ShelleyTest era => MIRPot -> TxBody era
+txbodyEx1 :: (TxBodyClass era,ShelleyTest era) => MIRPot -> TxBody era
 txbodyEx1 pot =
   TxBody
     (Set.fromList [TxIn genesisId 0])

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -96,6 +96,8 @@ import Test.Shelley.Spec.Ledger.Generator.Core
   )
 import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
 import Test.Shelley.Spec.Ledger.Utils
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(TxBodyClass(..))
+
 
 -- Multi-Signature tests
 
@@ -146,7 +148,7 @@ aliceAndBobOrCarlOrDaria p =
       RequireAnyOf [singleKeyOnly Cast.carlAddr, singleKeyOnly Cast.dariaAddr]
     ]
 
-initTxBody :: ShelleyTest era => [(Addr era, Core.Value era)] -> TxBody era
+initTxBody :: (TxBodyClass era,ShelleyTest era) => [(Addr era, Core.Value era)] -> TxBody era
 initTxBody addrs =
   TxBody
     (Set.fromList [TxIn genesisId 0, TxIn genesisId 1])
@@ -197,7 +199,7 @@ aliceInitCoin = Coin 10000
 bobInitCoin :: Coin
 bobInitCoin = Coin 1000
 
-genesis :: forall era. ShelleyTest era => LedgerState era
+genesis :: forall era. (TxBodyClass era,ShelleyTest era) => LedgerState era
 genesis = genesisState genDelegs0 utxo0
   where
     genDelegs0 = Map.empty

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -71,7 +71,7 @@ import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern 
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.Generator.Block (tickChainState)
 import Test.Shelley.Spec.Ledger.Generator.Core (EraGen (..), GenEnv (geConstants))
-import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombinations)
+import Test.Shelley.Spec.Ledger.Generator.TypeFamilyClasses(scriptKeyCombinations)
 import Test.Shelley.Spec.Ledger.Generator.EraGen ()
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -71,6 +71,7 @@ import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern 
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.Generator.Block (tickChainState)
 import Test.Shelley.Spec.Ledger.Generator.Core (EraGen (..), GenEnv (geConstants))
+import Test.Shelley.Spec.Ledger.Generator.Scripts(scriptKeyCombinations)
 import Test.Shelley.Spec.Ledger.Generator.EraGen ()
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
@@ -508,7 +509,8 @@ requiredMSigSignaturesSubset SourceSignalTarget {source = chainSt, signal = bloc
             all (existsReqKeyComb khs) (scriptWits . _witnessSet $ tx)
 
     existsReqKeyComb keyHashes msig =
-      any (\kl -> (Set.fromList kl) `Set.isSubsetOf` keyHashes) (eraScriptWitnesses @era msig)
+      -- any (\kl -> (Set.fromList kl) `Set.isSubsetOf` keyHashes) (eraScriptWitnesses @era msig)  GONE
+      any (\kl -> (Set.fromList kl) `Set.isSubsetOf` keyHashes) (scriptKeyCombinations (Proxy @era) msig)
 
     keyHashSet tx_ =
       Set.map witKeyHash (addrWits . _witnessSet $ tx_)


### PR DESCRIPTION
This module collects together all the operations that operate on the type family (Core.Script era) to write property tests.
The ScriptClass is made a superclass of GenEra
  class ScriptClass era => EraGen era where ...
Small changes are made to 7 files, to call these generic Script operations.