### PR TITLE
nix: Make it possible to get a nix-shell in latex spec directory

### DIFF
--- a/byron/cddl-spec/default.nix
+++ b/byron/cddl-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal, cddl, cbor-diag }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "blocks-cddl-spec";

--- a/byron/chain/formal-spec/default.nix
+++ b/byron/chain/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "byron-chain-spec";

--- a/byron/ledger/formal-spec/default.nix
+++ b/byron/ledger/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "byron-ledger-spec";

--- a/default.nix
+++ b/default.nix
@@ -54,16 +54,16 @@ let
     #  nix-build -A specs -o spec
     #
     specs = recurseIntoAttrs {
-      byron-ledger = pkgs.callPackage ./byron/ledger/formal-spec {};
-      byron-chain = pkgs.callPackage ./byron/chain/formal-spec {};
-      small-step-semantics = pkgs.callPackage ./semantics/formal-spec {};
-      shelley-ledger = pkgs.callPackage ./shelley/chain-and-ledger/formal-spec {};
-      pool-ranking = pkgs.callPackage ./shelley/pool-ranking {};
-      shelley-ma = pkgs.callPackage ./shelley-ma/formal-spec {};
-      goguen-ledger = pkgs.callPackage ./goguen/formal-spec {};
-      delegation-design = pkgs.callPackage ./shelley/design-spec {};
-      non-integer-calculations = pkgs.callPackage ./shelley/chain-and-ledger/dependencies/non-integer/doc {};
-      blocks-cddl = pkgs.callPackage ./byron/cddl-spec {};
+      byron-ledger = pkgs.callPackage ./byron/ledger/formal-spec/default.nix {};
+      byron-chain = pkgs.callPackage ./byron/chain/formal-spec/default.nix {};
+      small-step-semantics = pkgs.callPackage ./semantics/formal-spec/default.nix {};
+      shelley-ledger = pkgs.callPackage ./shelley/chain-and-ledger/formal-spec/default.nix {};
+      pool-ranking = pkgs.callPackage ./shelley/pool-ranking/default.nix {};
+      shelley-ma = pkgs.callPackage ./shelley-ma/formal-spec/default.nix {};
+      goguen-ledger = pkgs.callPackage ./goguen/formal-spec/default.nix {};
+      delegation-design = pkgs.callPackage ./shelley/design-spec/default.nix {};
+      non-integer-calculations = pkgs.callPackage ./shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix {};
+      blocks-cddl = pkgs.callPackage ./byron/cddl-spec/default.nix {};
     };
 
     doc = {

--- a/goguen/formal-spec/default.nix
+++ b/goguen/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "goguen-spec";

--- a/semantics/formal-spec/default.nix
+++ b/semantics/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "small-step-semantics-spec";

--- a/shelley-ma/formal-spec/default.nix
+++ b/shelley-ma/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "shelley-ma-spec";

--- a/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
+++ b/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../../../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "non-integer-calculations-spec";

--- a/shelley/chain-and-ledger/formal-spec/default.nix
+++ b/shelley/chain-and-ledger/formal-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "shelley-ledger-spec";

--- a/shelley/design-spec/default.nix
+++ b/shelley/design-spec/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "delegation-design-spec";

--- a/shelley/pool-ranking/default.nix
+++ b/shelley/pool-ranking/default.nix
@@ -1,4 +1,6 @@
-{ lib, latex, texlive, gitMinimal }:
+{ pkgs ? import ../../nix/default.nix {} }:
+
+with pkgs;
 
 latex.buildLatex {
   name = "pool-ranking";


### PR DESCRIPTION
In #1758 I refactored the latex specs nix build. But this meant that it was no longer possible to use nix-shell from within the document directory. You instead needed to run something like `nix-shell -A specs.shelley-ledger`. This puts back the ability to run nix-shell from the document directory.

Tested with
1. `nix-build -A specs -o specs` (check that results are same as before)
2. Check the nix-shell works in each document directory:
   ```
   for d in $(dirname $(git ls-files '*.tex') | sort -u); do
     ( cd $d && nix-shell -Q --quiet --quiet --run "echo $d is OK" )
   done
   ```
