### PR TITLE
Update haskell-language-server to 0.6.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "800b536c97e58fe7e403b957941dd26ade0fe28f",
-        "sha256": "0zy6ss7qkz6997a62n0kvkdx4hqnr0ym9xn59c1isvlginn54wly",
+        "rev": "401c1d7cc26314e75ae557a701577ad49999d8ea",
+        "sha256": "0r569s0snwdi8rlp61dybjjq66wb300fmrr6m7shaxqv5hrzkb7p",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/800b536c97e58fe7e403b957941dd26ade0fe28f.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/401c1d7cc26314e75ae557a701577ad49999d8ea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@ let
   ormolu = import pkgs.commonLib.sources.ormolu {};
 
   # For building the sphinx doc
-  pyEnv = 
+  pyEnv =
     # TODO: deduplicate with default.nix
     let
       sphinx-markdown-tables = pkgs.python3Packages.callPackage ./nix/python/sphinx-markdown-tables.nix {};
@@ -38,7 +38,7 @@ let
 
     tools = {
       cabal = "3.2.0.0";
-      haskell-language-server="0.5.1";
+      haskell-language-server="0.6.0";
     };
 
     # Prevents cabal from choosing alternate plans, so that


### PR DESCRIPTION
This gets us:
- hlint support
- "Remove all redundant imports" code action

And some other stuff:
https://www.reddit.com/r/haskell/comments/jsfq35/ann_haskelllanguageserver060_has_been_released/