### PR TITLE
Fix the min-ada calculation

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -135,7 +135,7 @@ instance Era era => Val (Value era) where
       assetNameLen :: Integer
       assetNameLen = 32
 
-      -- TODO dig up these constraints from Era 
+      -- TODO dig up these constraints from Era
       -- address hash length is always same as Policy ID length
       policyIdLen :: Integer
       policyIdLen = 28

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -124,20 +124,21 @@ instance Era era => Val (Value era) where
     foldr accum uint v
     where
       -- add addrHashLen for each Policy ID
-      accum u ans = foldr accumIns (ans + addrHashLen) u
+      accum u ans = foldr accumIns (ans + policyIdLen) u
         where
           -- add assetNameLen and uint for each asset of that Policy ID
           accumIns _ ans1 = ans1 + assetNameLen + uint
       -- TODO move these constants somewhere (they are also specified in CDDL)
       uint :: Integer
-      uint = 5
+      uint = 9
 
       assetNameLen :: Integer
       assetNameLen = 32
 
+      -- TODO dig up these constraints from Era 
       -- address hash length is always same as Policy ID length
-      addrHashLen :: Integer
-      addrHashLen = 28
+      policyIdLen :: Integer
+      policyIdLen = 28
 
 -- ==============================================================
 -- CBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Val.hs
@@ -122,7 +122,10 @@ See the formal specification for details.
 scaledMinDeposit :: (Val v) => v -> Coin -> Coin
 scaledMinDeposit v (Coin mv)
   | inject (coin v) == v = Coin mv -- without non-Coin assets, scaled deposit should be exactly minUTxOValue
-  | otherwise = Coin $ fst $ quotRem (mv * (utxoEntrySizeWithoutVal + uint)) (utxoEntrySizeWithoutVal + size v) -- round down
+  -- The calculation should represent this equation
+  -- minValueParameter / coinUTxOSize = actualMinValue / valueUTxOSize
+  -- actualMinValue = (minValueParameter / coinUTxOSize) * valueUTxOSize
+  | otherwise = Coin $ adaPerUTxOByte * (utxoEntrySizeWithoutVal + size v) -- round down
   where
     -- address hash length is always same as Policy ID length
     addrHashLen :: Integer
@@ -157,3 +160,7 @@ scaledMinDeposit v (Coin mv)
     -- size of the UTxO entry (ie the space the scaled minUTxOValue deposit pays)
     utxoEntrySizeWithoutVal :: Integer
     utxoEntrySizeWithoutVal = inputSize + outputSizeWithoutVal
+
+    -- parameter is implicit from the minAdaValue parameter
+    adaPerUTxOByte :: Integer
+    adaPerUTxOByte = quot mv (utxoEntrySizeWithoutVal + uint)


### PR DESCRIPTION
Clean up the min-ada value calculation 
- Potentially in preparation for making ada-per-UTxO-byte a protocol parameter next hard fork
- Still using magic numbers inside a `where` clause of a size calculation
- Eventually we want to use the `size` function on a UTxO entry to calculate the number of bytes, instead of over-approximating with constants