### PR TITLE
Adjust how we decide when to activate soft forks

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -6,4 +6,4 @@ where
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
 
 validMetaData :: PParams era -> Bool
-validMetaData pp = pvMinor (_protocolVersion pp) > 0
+validMetaData pp = _protocolVersion pp >= ProtVer 2 1


### PR DESCRIPTION
We have changed our mind from saying that soft forks should be relative
to an era, to instead simply saying there is a known global mapping
between eras and protocol versions.

This makes a difference for the consensus mode that starts in the
Shelley era. We're not saying that has to start at version 2, rather
than at version 0. This allows us to say that Shelley is always protocol
version 2 rather than it depending on the consensus mode.