### PR TITLE
Add missing version bound on streaming-bytestring

### DIFF
--- a/byron/ledger/impl/cardano-ledger.cabal
+++ b/byron/ledger/impl/cardano-ledger.cabal
@@ -151,7 +151,7 @@ library
                      , quiet
                      , resourcet
                      , streaming
-                     , streaming-binary
+                     , streaming-binary >=0.2 && <0.3
                      , streaming-bytestring
                      , text
                      , time


### PR DESCRIPTION
In #2018, a `<0.2` bound was added on streaming-bytestring because the code was
not compatible with the new 0.2 release.

In #2020, the index state was updated to pick up the new 0.2 release, the code
was made compatible with 0.2, and the bound was *removed*.

Instead of removing the bound, it should have been changed to `>= 0.2`, since
the code is no longer compatible with versions older than 0.2. I suppose the
idea behind #2020 was to rely on the newer index state to pick up the new 0.2
version. But this is rather brittle and will cause confusion for people that
don't have the updated index state or that are still using a version older than
0.2 for some reason. It is much better to present these users a cabal version
conflict than non-compiling code.

For good measure, add an upper bound too, which may protect us against future
releases breaking backwards compatibility.