### PR TITLE
Unbreak the build for GHC 8.6.5

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:
     Cardano.Ledger.Alonzo
   build-depends:
-    base >=4.14 && <4.15,
+    base >=4.9 && <4.15,
     shelley-spec-ledger
 
   -- hs-source-dirs:


### PR DESCRIPTION
In `cardano-ledger-alonzo.cabal`, the lower bound on `base` needlessly excluded
the version of `base` used by GHC 8.6.5.