### PR TITLE
Make Alonzo non-buildable in older GHC versions.

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -15,6 +15,10 @@ category:            Network
 build-type:          Simple
 
 library
+  -- We make use of features requiring ghc >= 8.10. In order to allow CI to
+  -- still build the 'all' component, simply make this non-buildable.
+  if impl(ghc < 8.10)
+    buildable: False
   exposed-modules:
     Cardano.Ledger.Alonzo
   build-depends:


### PR DESCRIPTION
By the time we release Alonzo, we expect to have dropped support for
older GHC versions. This allows us to keep the 8.6.5 CI while ignoring
this package in that case.

Alternative to #2026 