### PR TITLE
Make Mary generators pass the serialisation roundtrip tests

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Mary.Value
     insert,
     lookup,
     policies,
+    prune,
     showValue,
   )
 where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -142,7 +142,7 @@ instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
       pointwiseAbs = fmap (fmap abs)
 
 genMintValues :: Mock c => Gen (Mary.Value (MaryEra c))
-genMintValues = Mary.Value <$> arbitrary <*> arbitrary
+genMintValues = Mary.Value 0 <$> arbitrary
 
 instance Arbitrary Mary.AssetName where
   arbitrary = Mary.AssetName <$> arbitrary

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -137,12 +137,12 @@ instance Mock c => Arbitrary (Mary.PolicyID (MaryEra c)) where
   arbitrary = Mary.PolicyID <$> arbitrary
 
 instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
-  arbitrary = Mary.Value <$> (abs <$> arbitrary) <*> (pointwiseAbs <$> arbitrary)
+  arbitrary = Mary.Value <$> (abs <$> arbitrary) <*> (ConcreteValue.prune . pointwiseAbs <$> arbitrary)
     where
       pointwiseAbs = fmap (fmap abs)
 
 genMintValues :: Mock c => Gen (Mary.Value (MaryEra c))
-genMintValues = Mary.Value 0 <$> arbitrary
+genMintValues = Mary.Value 0 . ConcreteValue.prune <$> arbitrary
 
 instance Arbitrary Mary.AssetName where
   arbitrary = Mary.AssetName <$> arbitrary


### PR DESCRIPTION
Tweak the Mary generators so that the generated values will pass serialisation roundtrip tests.