### PR TITLE
Add benchmarks for generation of transactions.

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -58,4 +58,7 @@ cradle:
       component: "lib:cardano-ledger-shelley-ma-test"
 
     - path: "shelley-ma/shelley-ma-test/test"
+      component: "cardano-ledger-shelley-ma-test:bench:bench"
+
+    - path: "shelley-ma/shelley-ma-test/bench"
       component: "cardano-ledger-shelley-ma-test:test:cardano-ledger-shelley-ma-test"

--- a/shelley-ma/shelley-ma-test/bench/Bench/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/bench/Bench/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -1,0 +1,31 @@
+-- | Benchmarks for the serialisation generators
+module Bench.Cardano.Ledger.ShelleyMA.Serialisation.Generators
+  ( benchTxGeneration,
+  )
+where
+
+import Criterion.Main
+import Shelley.Spec.Ledger.Tx
+import Test.Cardano.Ledger.EraBuffet
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
+import Test.QuickCheck
+
+genTxShelley :: IO (Tx (ShelleyEra TestCrypto))
+genTxShelley = generate arbitrary
+
+-- | Generate an arbitrary Allegra transaction
+genTxAllegra :: IO (Tx (AllegraEra TestCrypto))
+genTxAllegra = generate arbitrary
+
+-- | Generate an arbitrary Mary transaction
+genTxMary :: IO (Tx (MaryEra TestCrypto))
+genTxMary = generate arbitrary
+
+benchTxGeneration :: Benchmark
+benchTxGeneration =
+  bgroup
+    "txgen"
+    [ bench "genTxShelley" (whnfIO genTxShelley),
+      bench "genTxAllegra" (whnfIO genTxAllegra),
+      bench "genTxMary" (whnfIO genTxMary)
+    ]

--- a/shelley-ma/shelley-ma-test/bench/Main.hs
+++ b/shelley-ma/shelley-ma-test/bench/Main.hs
@@ -4,10 +4,11 @@
 -- | This benchmark file is a placholder for benchmarks
 module Main where
 
+import qualified Bench.Cardano.Ledger.ShelleyMA.Serialisation.Generators as SerGen
 import Criterion.Main
   ( -- bench, bgroup, nf,
     defaultMain,
   )
 
 main :: IO ()
-main = defaultMain []
+main = defaultMain [SerGen.benchTxGeneration]

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -135,37 +135,38 @@ test-suite cardano-ledger-shelley-ma-test
       QuickCheck,
 
 
-benchmark marybench
+benchmark bench
   type:             exitcode-stdio-1.0
   hs-source-dirs:
     bench
   main-is:          Main.hs
   default-language:    Haskell2010
   other-modules:
-
+    Bench.Cardano.Ledger.ShelleyMA.Serialisation.Generators
   build-depends:
-   cardano-ledger-shelley-ma-test,
-      base >=4.9 && <4.15,
-      criterion,
-      bytestring,
-      cardano-ledger-shelley-ma,
-      cardano-binary,
-      cardano-crypto-class,
-      cardano-crypto-praos,
-      cardano-prelude,
-      cardano-slotting,
-      cborg,
-      containers,
-      deepseq,
-      groups,
-      nothunks,
-      partial-order,
-      shelley-spec-ledger,
-      small-steps,
-      tasty-hedgehog,
-      tasty-hunit,
-      tasty-quickcheck,
-      tasty
+    base >=4.9 && <4.15,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class,
+    cardano-crypto-praos,
+    cardano-ledger-shelley-ma-test,
+    cardano-ledger-shelley-ma,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    containers,
+    criterion,
+    deepseq,
+    groups,
+    nothunks,
+    partial-order,
+    shelley-spec-ledger,
+    small-steps,
+    tasty,
+    tasty-hedgehog,
+    tasty-hunit,
+    tasty-quickcheck,
+    QuickCheck
   ghc-options:
       -threaded
       -rtsopts


### PR DESCRIPTION
Aim is to debug slow transaction round-trip test performance in
consensus.