### PR TITLE
Test era translation preserves bytes

### DIFF
--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -46,6 +46,7 @@ library
     containers,
     deepseq,
     groups,
+    mtl,
     nothunks,
     shelley-spec-ledger,
     small-steps,

--- a/shelley-ma/shelley-ma-test/.ghcid
+++ b/shelley-ma/shelley-ma-test/.ghcid
@@ -1,1 +1,1 @@
--c "nix-shell ../../shell.nix --run \"cabal repl -f development cardano-ledger-shelley-ma-test\"" -o ghcid.txt
+-c "nix-shell ../../shell.nix --run \"cabal repl -f development test:cardano-ledger-shelley-ma-test\"" -o ghcid.txt

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+    Test.Cardano.Ledger.TranslationTools
     Test.Cardano.Ledger.EraBuffet
     Test.Cardano.Ledger.Mary
     Test.Cardano.Ledger.Allegra
@@ -52,6 +53,7 @@ library
     deepseq,
     groups,
     hashable,
+    mtl,
     nothunks,
     partial-order,
     shelley-spec-ledger,
@@ -83,6 +85,7 @@ test-suite cardano-ledger-shelley-ma-test
       Test.Cardano.Ledger.Mary.Examples.Cast
       Test.Cardano.Ledger.Mary.Examples.MultiAssets
       Test.Cardano.Ledger.Mary.Value
+      Test.Cardano.Ledger.Allegra.Translation
       Test.Cardano.Ledger.ShelleyMA.Serialisation.CDDL
       Test.Cardano.Ledger.ShelleyMA.Serialisation.Timelocks
     default-language:    Haskell2010

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/TranslationTools.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/TranslationTools.hs
@@ -1,0 +1,79 @@
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cardano.Ledger.TranslationTools
+  ( translationCompat
+  , translationCompatToCBOR
+  , decodeTest
+  , decodeTestAnn
+  ) where
+
+
+import Cardano.Ledger.Era (PreviousEra, TranslateEra (..), TranslationContext)
+
+import Cardano.Binary
+   (Encoding, ToCBOR (..), FromCBOR (..), serializeEncoding
+   , decodeFull
+   , serialize
+   , Annotator
+   , decodeAnnotator
+   , DecoderError
+   )
+import Test.Tasty.HUnit (Assertion, assertFailure)
+import Control.Monad.Except (runExcept)
+
+translate ::
+  forall era f.
+  (TranslateEra era f, Show (TranslationError era f)) =>
+  TranslationContext era ->
+  f (PreviousEra era) ->
+  f era
+translate tc fe = right . runExcept $ translateEra @era tc fe
+  where
+    right = either (\x -> (error $ "translation failure: " <> show x)) id
+
+-- Tests that the serializing before translation or after translating
+-- does not change the result
+translationCompat ::
+  forall era f.
+  (TranslateEra era f, Show (TranslationError era f)) =>
+  TranslationContext era ->
+  (f era -> Encoding) ->
+  (f (PreviousEra era) -> Encoding) ->
+  f (PreviousEra era) ->
+  Bool
+translationCompat tc encodeThisEra encodePreviousEra x =
+  (serializeEncoding $ encodePreviousEra x)
+    == (serializeEncoding . encodeThisEra $ translate @era tc x)
+
+-- Tests that the serializing before translation or after translating
+-- does not change the result
+translationCompatToCBOR ::
+  forall proxy era f.
+  ( TranslateEra era f,
+    ToCBOR (f era),
+    ToCBOR (f (PreviousEra era)),
+    Show (TranslationError era f)
+  ) =>
+  proxy era ->
+  TranslationContext era ->
+  f (PreviousEra era) ->
+  Bool
+translationCompatToCBOR _ tc = translationCompat @era tc toCBOR toCBOR
+
+-- Tests that the type a can be decoded as b
+decodeTest :: forall a b proxy. (ToCBOR a, FromCBOR b)
+   => proxy b -> a -> Assertion
+decodeTest _ x = case decodeFull (serialize x) :: Either DecoderError b of
+  Left e -> assertFailure $ show e
+  Right _ -> return ()
+
+-- Tests that the type a can be decoded as b
+decodeTestAnn :: forall a b proxy. (ToCBOR a, FromCBOR (Annotator b))
+   => proxy b -> a -> Assertion
+decodeTestAnn _ x = case decodeAnnotator mempty fromCBOR (serialize x) :: Either DecoderError b of
+  Left e -> assertFailure $ show e
+  Right _ -> return ()

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Allegra.Translation
+  ( allegraTranslationTests,
+    allegraEncodeDecodeTests,
+  )
+where
+
+import Cardano.Binary
+  ( ToCBOR (..),
+  )
+import Cardano.Ledger.Allegra.Translation ()
+import Cardano.Ledger.Era (TranslateEra (..))
+import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
+import qualified Shelley.Spec.Ledger.API as S
+import qualified Shelley.Spec.Ledger.EpochBoundary as EB
+import Test.Cardano.Ledger.EraBuffet
+  ( AllegraEra,
+    ShelleyEra,
+    StandardCrypto,
+  )
+import Test.Cardano.Ledger.TranslationTools
+  ( decodeTestAnn,
+    translationCompatToCBOR,
+  )
+-- instance EraGen ShelleyEra
+import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
+import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+type Allegra = AllegraEra StandardCrypto
+
+type Shelley = ShelleyEra StandardCrypto
+
+allegraEncodeDecodeTests :: TestTree
+allegraEncodeDecodeTests =
+  testGroup
+    "encoded shelley types can be decoded as allegra types"
+    [ testProperty
+        "decoding metadata"
+        (decodeTestAnn @S.MetaData ([] :: [MA.Metadata Allegra]))
+    ]
+
+allegraTranslationTests :: TestTree
+allegraTranslationTests =
+  testGroup
+    "Allegra translation binary compatibiliby tests"
+    [ testProperty "Tx compatibility" (test @S.Tx),
+      testProperty "ShelleyGenesis compatibility" (test @S.ShelleyGenesis),
+      testProperty "RewardAcnt compatibility" (test @S.RewardAcnt),
+      testProperty "PoolParams compatibility" (test @S.PoolParams),
+      testProperty "Addr compatibility" (test @S.Addr),
+      testProperty "NonMyopic compatibility" (test @S.NonMyopic),
+      testProperty "ScriptHash compatibility" (test @S.ScriptHash),
+      testProperty "RewardUpdate compatibility" (test @S.RewardUpdate),
+      testProperty "SnapShot compatibility" (test @S.SnapShot),
+      testProperty "SnapShots compatibility" (test @S.SnapShots),
+      testProperty "ProposedPPUpdates compatibility" (test @S.ProposedPPUpdates),
+      testProperty "PPUPState compatibility" (test @S.PPUPState),
+      testProperty "TxId compatibility" (test @S.TxId),
+      testProperty "TxIn compatibility" (test @S.TxIn),
+      testProperty "TxOut compatibility" (test @S.TxOut),
+      testProperty "UTxO compatibility" (test @S.UTxO),
+      testProperty "UTxOState compatibility" (test @S.UTxOState),
+      testProperty "InstantaneousRewards compatibility" (test @S.InstantaneousRewards),
+      testProperty "DState compatibility" (test @S.DState),
+      testProperty "PState compatibility" (test @S.PState),
+      testProperty "DPState compatibility" (test @S.DPState),
+      testProperty "LedgerState compatibility" (test @S.LedgerState),
+      testProperty "EpochState compatibility" (test @S.EpochState),
+      testProperty "WitnessSet compatibility" (test @S.WitnessSet),
+      testProperty "BootstrapWitness compatibility" (test @S.BootstrapWitness),
+      testProperty "Wdrl compatibility" (test @S.Wdrl),
+      testProperty "DCert compatibility" (test @S.DCert),
+      testProperty "MIRCert compatibility" (test @S.MIRCert),
+      testProperty "Update compatibility" (test @S.Update),
+      testProperty "Credential compatibility" (test @(S.Credential 'S.Witness)),
+      testProperty "WitVKey compatibility" (test @(S.WitVKey 'S.Witness)),
+      testProperty "BlocksMade compatibility" (test @EB.BlocksMade)
+    ]
+
+test ::
+  forall f.
+  ( ToCBOR (f Allegra),
+    ToCBOR (f Shelley),
+    TranslateEra Allegra f,
+    Show (TranslationError Allegra f)
+  ) =>
+  f Shelley ->
+  Bool
+test x = translationCompatToCBOR ([] :: [Allegra]) () x

--- a/shelley-ma/shelley-ma-test/test/Tests.hs
+++ b/shelley-ma/shelley-ma-test/test/Tests.hs
@@ -6,6 +6,8 @@ import Test.Cardano.Ledger.ShelleyMA.Serialisation.Timelocks (timelockTests)
 import Test.Cardano.Ledger.ShelleyMA.TxBody (txBodyTest)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (codersTest)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.CDDL (cddlTests)
+import Test.Cardano.Ledger.Allegra.Translation
+   (allegraTranslationTests, allegraEncodeDecodeTests)
 import Test.Tasty
 import Test.Tasty.HUnit ()
 
@@ -21,6 +23,8 @@ tests =
   testGroup
     "Cardano-Legder-Tests"
     [ codersTest,
+      allegraTranslationTests,
+      allegraEncodeDecodeTests,
       txBodyTest,
       timelockTests,
       cddlTests 10,


### PR DESCRIPTION
- added tests that make sure the binary encoding is not changed by
      translateEra (for allegra)
- changed allegra tx translation so that this would be true
- added a test that ensures encoded shelley metaData decodes as allegra
      metadata
- changed medatada decoding so that this would be true