### PR TITLE
MetaData -> Metadata

### DIFF
--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -101,7 +101,6 @@
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
 \newcommand{\SystemTag}{\ensuremath{\type{SystemTag}}}
 \newcommand{\InstallerHash}{\ensuremath{\type{InstallerHash}}}
-\newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 \newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Applications}{\type{Applications}}
 \newcommand{\AVUpdate}{\type{AVUpdate}}
@@ -160,8 +159,8 @@
 \newcommand{\AddrScrBase}{\type{Addr_{base}^{script}}}
 \newcommand{\AddrScrEnterprise}{\type{Addr_{enterprise}^{script}}}
 \newcommand{\AddrScrPtr}{\type{Addr_{ptr}^{script}}}
-\newcommand{\MetaDataHash}{\type{MetaDataHash}}
-\newcommand{\MetaData}{\type{MetaData}}
+\newcommand{\MetadataHash}{\type{MetadataHash}}
+\newcommand{\Metadata}{\type{Metadata}}
 \newcommand{\DataHash}{\type{DataHash}}
 \newcommand{\ScriptHash}{\type{ScriptHash}}
 \newcommand{\PolicyID}{\type{PolicyID}}

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -154,7 +154,7 @@ Shelley specification~\cite{XX}:
        & \times ~\Update^?  & \fun{txUpdates} & \text{Update proposals}\\
        & \times ~\PPHash^?  & \fun{ppHash} & \text{Hash of PPs}\\
        & \times ~\ScriptDataHash^? & \fun{sdHash} & \text{Hash of script-related data}\\
-       & \times ~\MetaDataHash^? & \fun{txMDhash} & \text{Metadata hash}\\
+       & \times ~\MetadataHash^? & \fun{txMDhash} & \text{Metadata hash}\\
     \end{array}
   \end{equation*}
   %
@@ -164,7 +164,7 @@ Shelley specification~\cite{XX}:
       & \TxBody & \fun{txbody} & \text{Body}\\
       & \times ~\TxWitness & \fun{txwits} & \text{Witnesses}\\
       & \times ~\IsValidating & \fun{txvaltag}&\text{Validation tag}\\
-      & \times ~\MetaData^? & \fun{txMD}&\text{Metadata}\\
+      & \times ~\Metadata^? & \fun{txMD}&\text{Metadata}\\
     \end{array}
   \end{equation*}
   %

--- a/shelley-ma/formal-spec/shelley-ma.tex
+++ b/shelley-ma/formal-spec/shelley-ma.tex
@@ -108,7 +108,6 @@
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
 \newcommand{\SystemTag}{\ensuremath{\type{SystemTag}}}
 \newcommand{\InstallerHash}{\ensuremath{\type{InstallerHash}}}
-\newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 \newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Applications}{\type{Applications}}
 \newcommand{\AVUpdate}{\type{AVUpdate}}
@@ -169,9 +168,9 @@
 \newcommand{\AddrScrBase}{\type{Addr_{base}^{script}}}
 \newcommand{\AddrScrEnterprise}{\type{Addr_{enterprise}^{script}}}
 \newcommand{\AddrScrPtr}{\type{Addr_{ptr}^{script}}}
-\newcommand{\MetaDataHash}{\type{MetaDataHash}}
-\newcommand{\MetaData}{\type{MetaData}}
-\newcommand{\MetaDataBlob}{\type{MetaDataBlob}}
+\newcommand{\MetadataHash}{\type{MetadataHash}}
+\newcommand{\Metadata}{\type{Metadata}}
+\newcommand{\MetadataBlob}{\type{MetadataBlob}}
 \newcommand{\DataHash}{\type{DataHash}}
 \newcommand{\ScriptHash}{\type{ScriptHash}}
 \newcommand{\PolicyID}{\type{PolicyID}}

--- a/shelley-ma/formal-spec/transactions.tex
+++ b/shelley-ma/formal-spec/transactions.tex
@@ -34,15 +34,15 @@
        & \times ~\hldiff{\Slot^? \times \Slot^?} & \hldiff{\fun{txvldt}} & \text{validity interval}\\
        & \times~ \Wdrl  & \fun{txwdrls} &\text{reward withdrawals}\\
        & \times ~\Update^?  & \fun{txUpdates} & \text{update proposals}\\
-       & \times ~\MetaDataHash^? & \fun{txMDhash} & \text{metadata hash}
+       & \times ~\MetadataHash^? & \fun{txMDhash} & \text{metadata hash}
     \end{array}
   \end{equation*}
   %
   \begin{equation*}
     \begin{array}{r@{~~}l@{~~}l@{\qquad}l}
-      \var{md} ~\in~ \MetaData ~=~
+      \var{md} ~\in~ \Metadata ~=~
       & \powerset{\Script} & \fun{scripts}& \text{Optional scripts}\\
-      & \times ~\MetaDataBlob^? & \fun{mdBlob} & \text{Blob metadata}
+      & \times ~\MetadataBlob^? & \fun{mdBlob} & \text{Blob metadata}
     \end{array}
   \end{equation*}
   %
@@ -51,7 +51,7 @@
       \var{tx} ~\in~ \Tx ~=~
       & \TxBody & \fun{txinputs}& \text{Transaction body}\\
       &\times ~\TxWitness & \fun{txouts}& \text{Witnesses}\\
-      & \times ~\MetaData^? & \fun{txMDhash} & \text{Metadata}
+      & \times ~\Metadata^? & \fun{txMDhash} & \text{Metadata}
     \end{array}
   \end{equation*}
   %

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -32,7 +32,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
-import Shelley.Spec.Ledger.API hiding (TxBody)
+import Shelley.Spec.Ledger.API hiding (Metadata, TxBody)
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import qualified Shelley.Spec.Ledger.LedgerState as LS
 import Shelley.Spec.Ledger.Rewards (NonMyopic (NonMyopic), likelihoodsNM, rewardPotNM)

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -26,10 +26,10 @@ import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.MetaData
-  ( MetaDataHash (..),
+import Shelley.Spec.Ledger.Metadata
+  ( MetadataHash (..),
     ValidateMetadata (..),
-    validMetaDatum,
+    validMetadatum,
   )
 import Shelley.Spec.Ledger.Tx
   ( ValidateScript (..),
@@ -98,6 +98,6 @@ instance
   ) =>
   ValidateMetadata (ShelleyMAEra (ma :: MaryOrAllegra) c)
   where
-  hashMetadata = MetaDataHash . hashWithSerialiser toCBOR
+  hashMetadata = MetadataHash . hashWithSerialiser toCBOR
 
-  validateMetadata (Metadata blob sp) = deepseq sp $ all validMetaDatum blob
+  validateMetadata (Metadata blob sp) = deepseq sp $ all validMetadatum blob

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Metadata.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Metadata.hs
@@ -42,15 +42,15 @@ import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
-import Shelley.Spec.Ledger.MetaData
-  ( MetaDatum,
+import Shelley.Spec.Ledger.Metadata
+  ( Metadatum,
   )
 import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
 -- | Raw, un-memoised metadata type
 data MetadataRaw era = MetadataRaw
   { -- | Unstructured metadata "blob"
-    mdBlob :: !(Map Word64 MetaDatum),
+    mdBlob :: !(Map Word64 Metadatum),
     -- | Pre-images of script hashes found within the TxBody, but which are not
     -- required as witnesses. Examples include:
     -- - Token policy IDs appearing in transaction outputs
@@ -87,7 +87,7 @@ pattern Metadata ::
   ( Core.AnnotatedData (Core.Script era),
     Ord (Core.Script era)
   ) =>
-  Map Word64 MetaDatum ->
+  Map Word64 Metadatum ->
   StrictSeq (Core.Script era) ->
   Metadata era
 pattern Metadata blob sp <-

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -71,7 +71,7 @@ import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
-import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Metadata (MetadataHash)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.Serialization (encodeFoldable)
 import Shelley.Spec.Ledger.TxBody
@@ -121,7 +121,7 @@ data TxBodyRaw era = TxBodyRaw
     txfee :: !Coin,
     vldt :: !ValidityInterval, -- imported from Timelocks
     update :: !(StrictMaybe (Update era)),
-    mdHash :: !(StrictMaybe (MetaDataHash era)),
+    mdHash :: !(StrictMaybe (MetadataHash era)),
     mint :: !(Value era)
   }
   deriving (Typeable)
@@ -267,7 +267,7 @@ pattern TxBody ::
   Coin ->
   ValidityInterval ->
   (StrictMaybe (Update era)) ->
-  (StrictMaybe (MetaDataHash era)) ->
+  (StrictMaybe (MetadataHash era)) ->
   (Value era) ->
   TxBody era
 pattern TxBody i o d w fee vi u m mint <-
@@ -317,7 +317,7 @@ instance HasField "vldt" (TxBody e) ValidityInterval where
 instance HasField "update" (TxBody e) (StrictMaybe (Update e)) where
   getField (TxBodyConstr (Memo m _)) = getField @"update" m
 
-instance HasField "mdHash" (TxBody e) (StrictMaybe (MetaDataHash e)) where
+instance HasField "mdHash" (TxBody e) (StrictMaybe (MetadataHash e)) where
   getField (TxBodyConstr (Memo m _)) = getField @"mdHash" m
 
 instance (Value e ~ vv) => HasField "mint" (TxBody e) vv where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -34,7 +34,7 @@ import Shelley.Spec.Ledger.API (KeyRole (Witness))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (KeyHash)
-import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Metadata (MetadataHash)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.TxBody (DCert, TxIn, TxOut, Wdrl)
 import Test.Cardano.Ledger.EraBuffet (AllegraEra)
@@ -69,7 +69,7 @@ instance CryptoClass.Crypto c => EraGen (AllegraEra c) where
   genGenesisValue (GenEnv _keySpace Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
     genCoin minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody _ge = genTxBody
-  genMetadata = error "TODO @uroboros - implement genMetaData for Allegra"
+  genEraMetadata = error "TODO @uroboros - implement genEraMetadata for Allegra"
   updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta forge) fee ins outs =
     TxBody ins outs cert wdrl fee vi upd meta forge
 
@@ -85,7 +85,7 @@ genTxBody ::
   Wdrl era ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetaDataHash era) ->
+  StrictMaybe (MetadataHash era) ->
   Gen (TxBody era)
 genTxBody slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -20,7 +20,7 @@ import qualified Data.Map as Map
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Metadata (MetadataHash)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.Tx (TxIn, TxOut)
 import Shelley.Spec.Ledger.TxBody (DCert, Wdrl)
@@ -63,7 +63,7 @@ instance (CryptoClass.Crypto c) => EraGen (MaryEra c) where
   genGenesisValue (GenEnv _ Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
     Val.inject . Coin <$> exponential minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody = genTxBody
-  genMetadata = error "TODO @uroboros - implement genMetaData for Mary"
+  genEraMetadata = error "TODO @uroboros - implement genMetadata for Mary"
   updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta forge) fee ins outs =
     TxBody ins outs cert wdrl fee vi upd meta forge
 
@@ -80,7 +80,7 @@ genTxBody ::
   Wdrl era ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetaDataHash era) ->
+  StrictMaybe (MetadataHash era) ->
   Gen (TxBody era)
 genTxBody _ge slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -63,7 +63,7 @@ import Test.QuickCheck
     vectorOf,
   )
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
-import Test.Shelley.Spec.Ledger.Generator.MetaData (genMetaData')
+import Test.Shelley.Spec.Ledger.Generator.Metadata (genMetadata')
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty.QuickCheck (Gen)
@@ -120,7 +120,7 @@ instance
   --
   -- @
   -- arbitrary = do
-  --   MetaData m <- genMetaData'
+  --   Metadata m <- genMetadata'
   --   pure $ MA.Metadata m StrictSeq.empty
   -- @
   --
@@ -128,8 +128,8 @@ instance
   -- pattern, despite the pattern being COMPLETE, resulting
   -- in an unsatisfied `MonadFail` constraint.
   arbitrary =
-    genMetaData' >>= \case
-      MetaData m ->
+    genMetadata' >>= \case
+      Metadata m ->
         do ss <- genScriptSeq; pure (MA.Metadata m ss)
 
 genScriptSeq ::

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -31,7 +31,7 @@ import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
 import qualified Data.ByteString.Lazy as Lazy (null)
 import Data.Sequence.Strict (StrictSeq, fromList)
 import Data.String (fromString)
-import Shelley.Spec.Ledger.MetaData (MetaData (..))
+import qualified Shelley.Spec.Ledger.Metadata as Shelley (Metadata (..))
 import Shelley.Spec.Ledger.Scripts (ScriptHash (..))
 import Test.Cardano.Ledger.EraBuffet
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
@@ -39,7 +39,7 @@ import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
     roundTripAnn,
   )
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import Test.Shelley.Spec.Ledger.Generator.MetaData ()
+import Test.Shelley.Spec.Ledger.Generator.Metadata ()
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators (genHash)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty (TestTree, testGroup)
@@ -85,7 +85,7 @@ genMeta Allegra = do
   m <- arbitrary
   s <- genScriptSeq Allegra
   pure (MA.Metadata m s)
-genMeta Shelley = MetaData <$> arbitrary
+genMeta Shelley = Shelley.Metadata <$> arbitrary
 
 -- ==========================================================
 -- Parameterized helper functions for generating Mary style Values

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
@@ -42,7 +42,7 @@ allegraEncodeDecodeTests =
     "encoded shelley types can be decoded as allegra types"
     [ testProperty
         "decoding metadata"
-        (decodeTestAnn @S.MetaData ([] :: [MA.Metadata Allegra]))
+        (decodeTestAnn @S.Metadata ([] :: [MA.Metadata Allegra]))
     ]
 
 allegraTranslationTests :: TestTree

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -28,7 +28,7 @@ import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..), hashKey)
-import qualified Shelley.Spec.Ledger.MetaData as SMD
+import qualified Shelley.Spec.Ledger.Metadata as SMD
 import Shelley.Spec.Ledger.PParams
   ( PParams' (..),
     Update,

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -46,7 +46,7 @@ library
     Shelley.Spec.Ledger.Hashing
     Shelley.Spec.Ledger.Keys
     Shelley.Spec.Ledger.LedgerState
-    Shelley.Spec.Ledger.MetaData
+    Shelley.Spec.Ledger.Metadata
     Shelley.Spec.Ledger.OCert
     Shelley.Spec.Ledger.Orphans
     Shelley.Spec.Ledger.OverlaySchedule

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -15,11 +15,11 @@ import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (hashWithSerialiser)
-import Shelley.Spec.Ledger.MetaData
-  ( MetaData (MetaData),
-    MetaDataHash (MetaDataHash),
+import Shelley.Spec.Ledger.Metadata
+  ( Metadata (Metadata),
+    MetadataHash (MetadataHash),
     ValidateMetadata (hashMetadata, validateMetadata),
-    validMetaDatum,
+    validMetadatum,
   )
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
@@ -44,7 +44,7 @@ type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
 
 type instance Core.Script (ShelleyEra c) = MultiSig (ShelleyEra c)
 
-type instance Core.Metadata (ShelleyEra c) = MetaData
+type instance Core.Metadata (ShelleyEra c) = Metadata
 
 --------------------------------------------------------------------------------
 -- Ledger data instances
@@ -58,5 +58,5 @@ instance
   hashScript = hashMultiSigScript
 
 instance CryptoClass.Crypto c => ValidateMetadata (ShelleyEra c) where
-  hashMetadata = MetaDataHash . hashWithSerialiser toCBOR
-  validateMetadata (MetaData m) = all validMetaDatum m
+  hashMetadata = MetadataHash . hashWithSerialiser toCBOR
+  validateMetadata (Metadata m) = all validMetadatum m

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -91,9 +91,9 @@ import Shelley.Spec.Ledger.LedgerState as X
     UTxOState (..),
     WitHashes (..),
   )
-import Shelley.Spec.Ledger.MetaData as X
-  ( MetaData (..),
-    MetaDatum (..),
+import Shelley.Spec.Ledger.Metadata as X
+  ( Metadata (..),
+    Metadatum (..),
   )
 import Shelley.Spec.Ledger.OCert as X (KESPeriod (..), OCert (..))
 import Shelley.Spec.Ledger.OverlaySchedule as X
@@ -169,7 +169,7 @@ import Shelley.Spec.Ledger.TxBody as X
     GenesisDelegCert (..),
     MIRCert (..),
     MIRPot (..),
-    PoolMetaData (..),
+    PoolMetadata (..),
     PoolParams (..),
     Ptr (..),
     StakeCreds (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -550,8 +550,8 @@ pattern Block h txns <-
 -- | Given a size and a mapping from indices to maybe metadata,
 --  return a sequence whose size is the size paramater and
 --  whose non-Nothing values correspond no the values in the mapping.
-constructMetaData :: Int -> Map Int a -> Seq (Maybe a)
-constructMetaData n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n -1])
+constructMetadata :: Int -> Map Int a -> Seq (Maybe a)
+constructMetadata n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n -1])
 
 instance
   Era era =>
@@ -581,7 +581,7 @@ txSeqDecoder lax = do
 
   (metadata, metadataAnn) <-
     withSlice $
-      constructMetaData b
+      constructMetadata b
         <$> decodeMap fromCBOR fromCBOR
   let m = length metadata
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -1,9 +1,9 @@
 module Shelley.Spec.Ledger.SoftForks
-  ( validMetaData,
+  ( validMetadata,
   )
 where
 
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
 
-validMetaData :: PParams era -> Bool
-validMetaData pp = _protocolVersion pp > ProtVer 2 0
+validMetadata :: PParams era -> Bool
+validMetadata pp = _protocolVersion pp > ProtVer 2 0

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -94,9 +94,9 @@
 \newcommand{\seedOp}{\star}
 \newcommand{\Ppm}{\type{Ppm}}
 \newcommand{\ProtVer}{\ensuremath{\type{ProtVer}}}
-\newcommand{\MetaDatum}{\ensuremath{\type{MetaDatum}}}
-\newcommand{\MetaData}{\ensuremath{\type{MetaData}}}
-\newcommand{\MetaDataHash}{\ensuremath{\type{MetaDataHash}}}
+\newcommand{\Metadatum}{\ensuremath{\type{Metadatum}}}
+\newcommand{\Metadata}{\ensuremath{\type{Metadata}}}
+\newcommand{\MetadataHash}{\ensuremath{\type{MetadataHash}}}
 \newcommand{\Update}{\type{Update}}
 \newcommand{\GenesisDelegation}{\type{GenesisDelegation}}
 \newcommand{\FutGenesisDelegation}{\type{FutGenesisDelegation}}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -54,8 +54,8 @@ This function must produce a unique id for each unique transaction body.
       \var{gkey} & \VKeyGen & \text{genesis public keys}\\
       \var{gkh} & \KeyHashGen & \text{genesis key hash}\\
       \var{txid} & \TxId & \text{transaction id}\\
-      \var{m} & \MetaDatum & \text{metadatum}\\
-      \var{mdh} & \MetaDataHash & \text{hash of transaction metadata}\\
+      \var{m} & \Metadatum & \text{metadatum}\\
+      \var{mdh} & \MetadataHash & \text{hash of transaction metadata}\\
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -83,8 +83,8 @@ This function must produce a unique id for each unique transaction body.
       & \text{reward withdrawal}
       \\
       \var{md}
-      & \MetaData
-      & \N \mapsto \MetaDatum
+      & \Metadata
+      & \N \mapsto \Metadatum
       & \text{metadata}
     \end{array}
   \end{equation*}
@@ -113,14 +113,14 @@ This function must produce a unique id for each unique transaction body.
       & \begin{array}{l}
         \powerset{\TxIn} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
         \times \Coin \times \Slot \times \Wdrl
-        \\ ~~~~\times \Update^? \times \MetaDataHash^?
+        \\ ~~~~\times \Update^? \times \MetadataHash^?
         \end{array}
       \\
       \var{wit} & \TxWitness & (\VKey \mapsto \Sig) \times (\HashScr \mapsto \Script)
       \\
       \var{tx}
       & \Tx
-      & \TxBody \times \TxWitness \times \MetaData^?
+      & \TxBody \times \TxWitness \times \Metadata^?
     \end{array}
   \end{equation*}
   %
@@ -137,8 +137,8 @@ This function must produce a unique id for each unique transaction body.
       \fun{txwitsVKey} & \Tx \to (\VKey \mapsto \Sig) & \text{VKey witnesses} \\
       \fun{txwitsScript} & \Tx \to (\HashScr \mapsto \Script) & \text{script witnesses}\\
       \fun{txup} & \Tx \to \Update^? & \text{protocol parameter update}\\
-      \fun{txMD} & \Tx \to \MetaData^? & \text{metadata}\\
-      \fun{txMDhash} & \Tx \to \MetaDataHash^? & \text{metadata hash}\\
+      \fun{txMD} & \Tx \to \Metadata^? & \text{metadata}\\
+      \fun{txMDhash} & \Tx \to \MetadataHash^? & \text{metadata hash}\\
     \end{array}
   \end{equation*}
   %
@@ -147,7 +147,7 @@ This function must produce a unique id for each unique transaction body.
     \begin{array}{r@{~\in~}lr}
       \txid{} & \TxBody \to \TxId & \text{compute transaction id}\\
       \fun{validateScript} & \Script \to \Tx \to \Bool & \text{script interpreter}\\
-      \fun{hashMD} & \MetaData \to \MetaDataHash & \text{hash the metadata}\\
+      \fun{hashMD} & \Metadata \to \MetadataHash & \text{hash the metadata}\\
       \fun{bootstrapAttrSize} & \AddrBS \to \N & \text{bootstrap attribute size}\\
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -598,13 +598,13 @@ The UTXOW rule has eight predicate failures:
   there is a \emph{MIRInsufficientGenesisSigs} failure.
 \item In the case the transaction contains metadata,
   but the transaction body does not contain a metadata hash,
-  there is a \emph{MissingTxBodyMetaDataHash} failure.
+  there is a \emph{MissingTxBodyMetadataHash} failure.
 \item In the case that the transaction body contains a metadata hash,
   but there is no metadata outside the body,
-  there is a \emph{MissingTxMetaData} failure.
+  there is a \emph{MissingTxMetadata} failure.
 \item In the case that the metadata hash in the transaction body
   is not equal to the hash of the metadata outside the body,
-  there is a \emph{ConflictingMetaDataHash} failure.
+  there is a \emph{ConflictingMetadataHash} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -55,7 +55,7 @@ import Shelley.Spec.Ledger.LedgerState
   ( NewEpochState,
     nesBcur,
   )
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -26,7 +26,7 @@ import Shelley.Spec.Ledger.LedgerState
     LedgerState (..),
     NewEpochState (..),
   )
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import Test.QuickCheck (generate)
 import Test.Shelley.Spec.Ledger.BenchmarkFunctions (ledgerEnv)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -31,7 +31,7 @@ library
     Test.Shelley.Spec.Ledger.Generator.Constants
     Test.Shelley.Spec.Ledger.Generator.Core
     Test.Shelley.Spec.Ledger.Generator.Delegation
-    Test.Shelley.Spec.Ledger.Generator.MetaData
+    Test.Shelley.Spec.Ledger.Generator.Metadata
     Test.Shelley.Spec.Ledger.Generator.Presets
     Test.Shelley.Spec.Ledger.Generator.Trace.Chain
     Test.Shelley.Spec.Ledger.Generator.Trace.DCert

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -40,7 +40,7 @@ import Shelley.Spec.Ledger.BlockChain
     mkSeed,
     seedL,
   )
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import Shelley.Spec.Ledger.OCert (currentIssueNo, kesPeriod)
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Test.QuickCheck (Gen)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -47,7 +47,7 @@ data Constants = Constants
     -- | Relative frequency of Prototol/Application Updates in a transaction
     frequencyTxUpdates :: Int,
     -- | Relative frequency of Metadata in a transaction
-    frequencyTxWithMetaData :: Int,
+    frequencyTxWithMetadata :: Int,
     -- | minimal number of genesis UTxO outputs
     minGenesisUTxOouts :: Int,
     -- | maximal number of genesis UTxO outputs
@@ -114,7 +114,7 @@ defaultConstants =
       frequencyScriptCredDelegation = 1,
       frequencyKeyCredDelegation = 2,
       frequencyTxUpdates = 10,
-      frequencyTxWithMetaData = 10,
+      frequencyTxWithMetadata = 10,
       minGenesisUTxOouts = 10,
       maxGenesisUTxOouts = 100,
       maxCertsPerTx = 3,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -29,7 +29,7 @@ import Shelley.Spec.Ledger.API
 import Shelley.Spec.Ledger.Address (toAddr)
 import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Metadata (MetadataHash)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.Tx
   ( TxId (TxId),
@@ -74,11 +74,11 @@ class
     Wdrl era ->
     Coin ->
     StrictMaybe (Update era) ->
-    StrictMaybe (MetaDataHash era) ->
+    StrictMaybe (MetadataHash era) ->
     Gen (Core.TxBody era)
 
   -- | Generate era-specific metadata
-  genMetadata :: Constants -> Gen (StrictMaybe (Core.Metadata era))
+  genEraMetadata :: Constants -> Gen (StrictMaybe (Core.Metadata era))
 
   -- | Update an era-specific TxBody
   updateEraTxBody ::

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Metadata.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Metadata.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Test.Shelley.Spec.Ledger.Generator.MetaData
-  ( genMetaData,
-    genMetaData'
+module Test.Shelley.Spec.Ledger.Generator.Metadata
+  ( genMetadata,
+    genMetadata'
   )
 where
 
@@ -15,51 +15,51 @@ import Data.Word (Word64)
 import Shelley.Spec.Ledger.BaseTypes
   ( StrictMaybe (..),
   )
-import Shelley.Spec.Ledger.MetaData
-  ( MetaData (..),
-    MetaDatum (..),
+import Shelley.Spec.Ledger.Metadata
+  ( Metadata (..),
+    Metadatum (..),
   )
 import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 
--- | Max size of generated MetaDatum List and Map
+-- | Max size of generated Metadatum List and Map
 collectionDatumMaxSize :: Int
 collectionDatumMaxSize = 5
 
--- | Max size of generated MetaData map
+-- | Max size of generated Metadata map
 metadataMaxSize :: Int
 metadataMaxSize = 3
 
--- | Generate Metadata (and compute hash) with frequency 'frequencyTxWithMetaData'
-genMetaData :: Constants -> Gen (StrictMaybe MetaData)
-genMetaData (Constants {frequencyTxWithMetaData}) =
+-- | Generate Metadata (and compute hash) with frequency 'frequencyTxWithMetadata'
+genMetadata :: Constants -> Gen (StrictMaybe Metadata)
+genMetadata (Constants {frequencyTxWithMetadata}) =
   QC.frequency
-    [ (frequencyTxWithMetaData, SJust <$> genMetaData'),
-      (100 - frequencyTxWithMetaData, pure SNothing)
+    [ (frequencyTxWithMetadata, SJust <$> genMetadata'),
+      (100 - frequencyTxWithMetadata, pure SNothing)
     ]
 
 -- | Generate Metadata (and compute hash) of size up to 'metadataMaxSize'
-genMetaData' :: Gen MetaData
-genMetaData' = do
+genMetadata' :: Gen Metadata
+genMetadata' = do
   n <- QC.choose (1, metadataMaxSize)
-  MetaData . Map.fromList
-    <$> QC.vectorOf n genMetaDatum
+  Metadata . Map.fromList
+    <$> QC.vectorOf n genMetadatum
 
--- | Generate one of the MetaDatum
-genMetaDatum :: Gen (Word64, MetaDatum)
-genMetaDatum = do
+-- | Generate one of the Metadatum
+genMetadatum :: Gen (Word64, Metadatum)
+genMetadatum = do
   (,) <$> QC.arbitrary
     <*> ( QC.oneof
             [ genDatumInt,
               genDatumString,
               genDatumBytestring,
-              genMetaDatumList,
-              genMetaDatumMap
+              genMetadatumList,
+              genMetadatumMap
             ]
         )
 
-genDatumInt :: Gen MetaDatum
+genDatumInt :: Gen Metadatum
 genDatumInt =
   I
     <$> QC.frequency
@@ -72,7 +72,7 @@ genDatumInt =
     minVal = - maxVal
     maxVal = fromIntegral (maxBound :: Word64)
 
-genDatumString :: Gen MetaDatum
+genDatumString :: Gen Metadatum
 genDatumString =
   QC.sized $ \sz -> do
     n <- QC.choose (0, min sz 64)
@@ -100,27 +100,27 @@ genUtf8StringOfSize n = do
   cs <- genUtf8StringOfSize (n - cz)
   return (c : cs)
 
-genDatumBytestring :: Gen MetaDatum
+genDatumBytestring :: Gen Metadatum
 genDatumBytestring =
   QC.sized $ \sz -> do
     n <- QC.choose (0, min sz 64)
     B . BS.pack <$> QC.vectorOf n QC.arbitrary
 
--- | Generate a 'MD.List [MetaDatum]'
+-- | Generate a 'MD.List [Metadatum]'
 --
 -- Note: to limit generated metadata size, impact on transaction fees and
 -- cost of hashing, we generate only lists of "simple" Datums, not lists
 -- of list or map Datum.
-genMetaDatumList :: Gen MetaDatum
-genMetaDatumList = List <$> vectorOfMetaDatumSimple
+genMetadatumList :: Gen Metadatum
+genMetadatumList = List <$> vectorOfMetadatumSimple
 
--- | Generate a 'MD.Map ('[(MetaDatum, MetaDatum)]')
-genMetaDatumMap :: Gen MetaDatum
-genMetaDatumMap =
-  Map <$> (zip <$> vectorOfMetaDatumSimple <*> vectorOfMetaDatumSimple)
+-- | Generate a 'MD.Map ('[(Metadatum, Metadatum)]')
+genMetadatumMap :: Gen Metadatum
+genMetadatumMap =
+  Map <$> (zip <$> vectorOfMetadatumSimple <*> vectorOfMetadatumSimple)
 
-vectorOfMetaDatumSimple :: Gen [MetaDatum]
-vectorOfMetaDatumSimple = do
+vectorOfMetadatumSimple :: Gen [Metadatum]
+vectorOfMetadatumSimple = do
   n <- QC.choose (1, collectionDatumMaxSize)
   QC.vectorOf
     n

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -21,7 +21,7 @@ import Shelley.Spec.Ledger.API
     Update,
   )
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
-import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Metadata (MetadataHash)
 import Shelley.Spec.Ledger.Scripts (MultiSig (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx
@@ -37,7 +37,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     genNatural,
   )
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen (..))
-import Test.Shelley.Spec.Ledger.Generator.MetaData (genMetaData)
+import Test.Shelley.Spec.Ledger.Generator.Metadata (genMetadata)
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass
   ( Quantifier (..),
     ScriptClass (..),
@@ -51,7 +51,7 @@ instance CC.Crypto c => EraGen (ShelleyEra c) where
   genGenesisValue (GenEnv _keySpace Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
     genCoin minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody _ge = genTxBody
-  genMetadata = genMetaData
+  genEraMetadata = genMetadata
 
   updateEraTxBody body fee ins outs =
     body
@@ -86,7 +86,7 @@ genTxBody ::
   Wdrl era ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetaDataHash era) ->
+  StrictMaybe (MetadataHash era) ->
   Gen (TxBody era)
 genTxBody slot inputs outputs certs wdrls fee update mdHash = do
   ttl <- genTimeToLive slot

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -47,7 +47,7 @@ import Shelley.Spec.Ledger.BlockChain
     hashHeaderToNonce,
   )
 import Shelley.Spec.Ledger.LedgerState (stakeDistr)
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import qualified Shelley.Spec.Ledger.STS.Chain as STS (ChainState (ChainState))
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Test.QuickCheck (Gen)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -35,7 +35,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState,
     genesisState,
   )
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -73,7 +73,7 @@ import Shelley.Spec.Ledger.LedgerState
     _ptrs,
     _rewards,
   )
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata (hashMetadata))
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata (hashMetadata))
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
 import Shelley.Spec.Ledger.Tx
@@ -207,7 +207,7 @@ genTx
           (utxoSt, dpState)
       (certs, deposits, refunds, dpState', (certWits, certScripts)) <-
         genDCerts ge pparams dpState slot txIx reserves
-      metadata <- genMetadata @era constants
+      metadata <- genEraMetadata @era constants
       -------------------------------------------------------------------------
       -- Gather Key Witnesses and Scripts, prepare a constructor for Tx Wits
       -------------------------------------------------------------------------

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -87,7 +87,7 @@ import Shelley.Spec.Ledger.LedgerState
   ( FutureGenDeleg,
     emptyRewardUpdate,
   )
-import qualified Shelley.Spec.Ledger.MetaData as MD
+import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     LogWeight (..),
@@ -222,37 +222,37 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (Update era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-maxMetaDatumDepth :: Int
-maxMetaDatumDepth = 2
+maxMetadatumDepth :: Int
+maxMetadatumDepth = 2
 
-maxMetaDatumListLens :: Int
-maxMetaDatumListLens = 5
+maxMetadatumListLens :: Int
+maxMetadatumListLens = 5
 
-sizedMetaDatum :: Int -> Gen MD.MetaDatum
-sizedMetaDatum 0 =
+sizedMetadatum :: Int -> Gen MD.Metadatum
+sizedMetadatum 0 =
   oneof
     [ MD.I <$> arbitrary,
       MD.B <$> arbitrary,
       MD.S <$> (T.pack <$> arbitrary)
     ]
-sizedMetaDatum n =
+sizedMetadatum n =
   oneof
     [ MD.Map
         <$> ( zip
-                <$> (resize maxMetaDatumListLens (listOf (sizedMetaDatum (n -1))))
-                <*> (listOf (sizedMetaDatum (n -1)))
+                <$> (resize maxMetadatumListLens (listOf (sizedMetadatum (n -1))))
+                <*> (listOf (sizedMetadatum (n -1)))
             ),
-      MD.List <$> resize maxMetaDatumListLens (listOf (sizedMetaDatum (n -1))),
+      MD.List <$> resize maxMetadatumListLens (listOf (sizedMetadatum (n -1))),
       MD.I <$> arbitrary,
       MD.B <$> arbitrary,
       MD.S <$> (T.pack <$> arbitrary)
     ]
 
-instance Arbitrary MD.MetaDatum where
-  arbitrary = sizedMetaDatum maxMetaDatumDepth
+instance Arbitrary MD.Metadatum where
+  arbitrary = sizedMetadatum maxMetadatumDepth
 
-instance Arbitrary MD.MetaData where
-  arbitrary = MD.MetaData <$> arbitrary
+instance Arbitrary MD.Metadata where
+  arbitrary = MD.Metadata <$> arbitrary
 
 maxTxWits :: Int
 maxTxWits = 5
@@ -358,8 +358,8 @@ instance Arbitrary ProtVer where
 instance Era era => Arbitrary (ScriptHash era) where
   arbitrary = ScriptHash <$> genHash
 
-instance Era era => Arbitrary (MD.MetaDataHash era) where
-  arbitrary = MD.MetaDataHash <$> genHash
+instance Era era => Arbitrary (MD.MetadataHash era) where
+  arbitrary = MD.MetadataHash <$> genHash
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where
   arbitrary = genHash
@@ -542,8 +542,8 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (PoolParams era) where
       <*> arbitrary
       <*> arbitrary
 
-instance Arbitrary PoolMetaData where
-  arbitrary = (`PoolMetaData` BS.pack "bytestring") <$> arbitrary
+instance Arbitrary PoolMetadata where
+  arbitrary = (`PoolMetadata` BS.pack "bytestring") <$> arbitrary
 
 instance Arbitrary Url where
   arbitrary = return . fromJust $ textToUrl "text"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
@@ -105,7 +105,7 @@ genPoolParams =
     <*> genRewardAcnt
     <*> (Set.fromList <$> (Gen.list (Range.linear 1 10) $ genKeyHash))
     <*> (StrictSeq.fromList <$> (Gen.list (Range.linear 1 10) $ genStakePoolRelay))
-    <*> genStrictMaybe genPoolMetaData
+    <*> genStrictMaybe genPoolMetadata
 
 genStakePoolRelay :: Gen StakePoolRelay
 genStakePoolRelay =
@@ -125,9 +125,9 @@ genDnsName = do
     Nothing -> error "wrong generator for DnsName"
     Just dns -> return dns
 
-genPoolMetaData :: Gen PoolMetaData
-genPoolMetaData =
-  PoolMetaData
+genPoolMetadata :: Gen PoolMetadata
+genPoolMetadata =
+  PoolMetadata
     <$> genUrl
     <*> Gen.bytes (Range.linear 1 30)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
@@ -67,7 +67,7 @@ import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.TxBody
-  ( PoolMetaData (..),
+  ( PoolMetadata (..),
     PoolParams (..),
     RewardAcnt (..),
   )
@@ -134,7 +134,7 @@ alicePoolParams =
       _poolRelays = StrictSeq.empty,
       _poolMD =
         SJust $
-          PoolMetaData
+          PoolMetadata
             { _poolMDUrl = fromJust $ textToUrl "alice.pool",
               _poolMDHash = BS.pack "{}"
             }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -62,14 +62,14 @@ import Shelley.Spec.Ledger.Keys
     vKey,
   )
 import Shelley.Spec.Ledger.LedgerState (txsize)
-import qualified Shelley.Spec.Ledger.MetaData as MD
+import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx
   ( WitnessSetHKD (..),
     hashScript,
   )
 import Shelley.Spec.Ledger.TxBody
-  ( PoolMetaData (..),
+  ( PoolMetadata (..),
     StakePoolRelay (..),
     Wdrl (..),
   )
@@ -131,7 +131,7 @@ alicePoolParams =
             fromJust $ textToDns "relay.io",
       _poolMD =
         SJust $
-          PoolMetaData
+          PoolMetadata
             { _poolMDUrl = fromJust $ textToUrl "alice.pool",
               _poolMDHash = BS.pack "{}"
             }
@@ -390,8 +390,8 @@ txRetirePoolBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c15
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-md :: MD.MetaData
-md = MD.MetaData $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
+md :: MD.Metadata
+md = MD.Metadata $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 
 txbWithMD :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbWithMD =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -62,7 +62,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState,
     genesisState,
   )
-import Shelley.Spec.Ledger.MetaData (MetaData)
+import Shelley.Spec.Ledger.Metadata (Metadata)
 import Shelley.Spec.Ledger.PParams (PParams, emptyPParams, _maxTxSize)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
 import Shelley.Spec.Ledger.Scripts
@@ -182,7 +182,7 @@ makeTx ::
   Core.TxBody (ShelleyEra c) ->
   [KeyPair 'Witness c] ->
   Map (ScriptHash (ShelleyEra c)) (MultiSig (ShelleyEra c)) ->
-  Maybe MetaData ->
+  Maybe Metadata ->
   Tx (ShelleyEra c)
 makeTx txBody keyPairs msigs = Tx txBody wits . maybeToStrictMaybe
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -24,7 +24,7 @@ import Shelley.Spec.Ledger.BaseTypes
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
-import Shelley.Spec.Ledger.MetaData (MetaDataHash, ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (MetadataHash, ValidateMetadata)
 import Shelley.Spec.Ledger.PParams (Update (..))
 import Shelley.Spec.Ledger.TxBody (TxIn, TxOut, Wdrl)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
@@ -66,7 +66,7 @@ minimalPropertyTests ::
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl era),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era)),
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
   TestTree
@@ -101,7 +101,7 @@ propertyTests ::
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl era),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era)),
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
   TestTree

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -71,7 +71,7 @@ import Shelley.Spec.Ledger.Delegation.Certificates
 import Shelley.Spec.Ledger.LedgerState
   ( txsizeBound,
   )
-import Shelley.Spec.Ledger.MetaData (MetaDataHash, ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (MetadataHash, ValidateMetadata)
 import Shelley.Spec.Ledger.PParams
   ( Update (..),
     pattern ProposedPPUpdates,
@@ -110,7 +110,7 @@ relevantCasesAreCovered ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl era),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
   ) =>
   Property
 relevantCasesAreCovered = do
@@ -131,7 +131,7 @@ relevantCasesAreCoveredForTrace ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl era),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
   ) =>
   Trace (CHAIN era) ->
   Property
@@ -197,7 +197,7 @@ relevantCasesAreCoveredForTrace tr = do
             60
           ),
           ( "at least 1 in 20 transactions have metadata",
-            length txs < 20 * length (filter hasMetaData txs),
+            length txs < 20 * length (filter hasMetadata txs),
             60
           ),
           ( "at least 5 epochs in a trace, 20% of the time",
@@ -292,14 +292,14 @@ hasPParamUpdate tx =
     ppUpdates SNothing = False
     ppUpdates (SJust (Update (ProposedPPUpdates ppUpd) _)) = Map.size ppUpd > 0
 
-hasMetaData ::
+hasMetadata ::
   ( TxBodyConstraints era,
     ToCBOR (Core.Metadata era),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetaDataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
   ) =>
   Tx era ->
   Bool
-hasMetaData tx =
+hasMetadata tx =
   f . (getField @"mdHash") . _body $ tx
   where
     f SNothing = False

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -60,7 +60,7 @@ import Shelley.Spec.Ledger.BlockChain
   )
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.LedgerState hiding (circulation)
-import Shelley.Spec.Ledger.MetaData (ValidateMetadata)
+import Shelley.Spec.Ledger.Metadata (ValidateMetadata)
 import Shelley.Spec.Ledger.PParams (_eMax)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..), totalAda, totalAdaPots)
 import Shelley.Spec.Ledger.STS.Deleg (DelegEnv (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
@@ -35,7 +35,7 @@ import Shelley.Spec.Ledger.BlockChain
     LaxBlock,
   )
 import Shelley.Spec.Ledger.Keys (KeyRole (Staking))
-import Shelley.Spec.Ledger.MetaData (MetaData)
+import Shelley.Spec.Ledger.Metadata (Metadata)
 import Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import Shelley.Spec.Ledger.TxBody
   ( StakePoolRelay,
@@ -88,7 +88,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlTest @StakePoolRelay n "relay",
       cddlTest @(DCert ShelleyE) n "certificate",
       cddlTest @(TxIn ShelleyE) n "transaction_input",
-      cddlTest' @MetaData n "transaction_metadata",
+      cddlTest' @Metadata n "transaction_metadata",
       cddlTest' @(MultiSig ShelleyE) n "multisig_script",
       cddlTest @(Update ShelleyE) n "update",
       cddlTest @(ProposedPPUpdates ShelleyE) n "proposed_protocol_parameter_updates",

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -129,7 +129,7 @@ import Shelley.Spec.Ledger.LedgerState
     RewardUpdate (..),
     emptyLedgerState,
   )
-import qualified Shelley.Spec.Ledger.MetaData as MD
+import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.OCert
   ( KESPeriod (..),
     OCert,
@@ -156,7 +156,7 @@ import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx (..), WitnessSetHKD (..), hashScript)
 import Shelley.Spec.Ledger.TxBody
   ( MIRPot (..),
-    PoolMetaData (..),
+    PoolMetadata (..),
     StakePoolRelay (..),
     TxBody (..),
     TxId,
@@ -568,7 +568,7 @@ tests =
                           _poolRelays = poolRelays,
                           _poolMD =
                             SJust $
-                              PoolMetaData
+                              PoolMetadata
                                 { _poolMDUrl = Maybe.fromJust $ textToUrl poolUrl,
                                   _poolMDHash = poolMDHash
                                 }
@@ -896,7 +896,7 @@ tests =
                   )
               )
               (EpochNo 0)
-          mdh = MD.hashMetadata $ MD.MetaData $ Map.singleton 13 (MD.I 17)
+          mdh = MD.hashMetadata $ MD.Metadata $ Map.singleton 13 (MD.I 17)
        in checkEncodingCBORAnnotated
             "txbody_full"
             ( TxBody -- transaction body with all components
@@ -969,7 +969,7 @@ tests =
           w = makeWitnessVKey txbh testKey1
           s = Map.singleton (hashScript $ testScript @C) (testScript @C)
           wits = mempty {addrWits = Set.singleton w, scriptWits = s}
-          md = MD.MetaData $ Map.singleton 17 (MD.I 42)
+          md = MD.Metadata $ Map.singleton 17 (MD.I 42)
        in checkEncodingCBORAnnotated
             "tx_full"
             (Tx txb wits (SJust md))
@@ -1126,7 +1126,7 @@ tests =
                 (hashScript (testScript2 @C), testScript2 @C)
               ]
           tx4 = Tx txb4 mempty {scriptWits = ss} SNothing
-          tx5MD = MD.MetaData $ Map.singleton 17 (MD.I 42)
+          tx5MD = MD.Metadata $ Map.singleton 17 (MD.I 42)
           tx5 = Tx txb5 mempty {addrWits = ws, scriptWits = ss} (SJust tx5MD)
           txns = TxSeq $ StrictSeq.fromList [tx1, tx2, tx3, tx4, tx5]
        in checkEncodingCBORAnnotated
@@ -1234,7 +1234,7 @@ tests =
                 _poolRelays = StrictSeq.empty,
                 _poolMD =
                   SJust $
-                    PoolMetaData
+                    PoolMetadata
                       { _poolMDUrl = Maybe.fromJust $ textToUrl "web.site",
                         _poolMDHash = BS.pack "{}"
                       }
@@ -1279,7 +1279,7 @@ tests =
                 _poolRelays = StrictSeq.empty,
                 _poolMD =
                   SJust $
-                    PoolMetaData
+                    PoolMetadata
                       { _poolMDUrl = Maybe.fromJust $ textToUrl "web.site",
                         _poolMDHash = BS.pack "{}"
                       }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
@@ -219,7 +219,7 @@ exampleShelleyGenesis =
           L._poolRelays = relays,
           L._poolMD =
             L.SJust $
-              L.PoolMetaData
+              L.PoolMetadata
                 { L._poolMDUrl = fromJust $ textToUrl "best.pool.com",
                   L._poolMDHash = BS.pack "100ab{}100ab{}"
                 }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
@@ -144,7 +144,7 @@ prop_roundtrip_NewEpochState = roundtrip toCBOR fromCBOR
 prop_roundtrip_MultiSig :: Ledger.MultiSig Mock.C -> Property
 prop_roundtrip_MultiSig = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
-prop_roundtrip_metadata :: Ledger.MetaData -> Property
+prop_roundtrip_metadata :: Ledger.Metadata -> Property
 prop_roundtrip_metadata = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
 prop_roundtrip_ShelleyGenesis :: ShelleyGenesis Mock.C -> Property
@@ -195,7 +195,7 @@ tests =
       testProperty "roundtrip Ledger State" prop_roundtrip_LedgerState,
       testProperty "roundtrip NewEpoch State" prop_roundtrip_NewEpochState,
       testProperty "roundtrip MultiSig" prop_roundtrip_MultiSig,
-      testProperty "roundtrip MetaData" prop_roundtrip_metadata,
+      testProperty "roundtrip Metadata" prop_roundtrip_metadata,
       testProperty "roundtrip Shelley Genesis" prop_roundtrip_ShelleyGenesis,
       testProperty "roundtrip coin compactcoin cbor" prop_roundtrip_Coin_1,
       testProperty "roundtrip coin cbor compactcoin" prop_roundtrip_Coin_2

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -88,7 +88,7 @@ import Shelley.Spec.Ledger.Tx
     _ttl,
   )
 import Shelley.Spec.Ledger.TxBody
-  ( PoolMetaData (..),
+  ( PoolMetadata (..),
     PoolParams (..),
     Wdrl (..),
     _poolCost,
@@ -673,7 +673,7 @@ alicePoolParamsSmallCost =
       _poolRelays = StrictSeq.empty,
       _poolMD =
         SJust $
-          PoolMetaData
+          PoolMetadata
             { _poolMDUrl = fromJust $ textToUrl "alice.pool",
               _poolMDHash = BS.pack "{}"
             }


### PR DESCRIPTION
Makes the spelling consistent.

```
git ls-files -z | xargs -0 sed -i -e 's/MetaData/Metadata/g' -e 's/MetaDatum/Metadatum/g'
rename MetaData Metadata `git ls-files '*.hs'`
```
