### PR TITLE
Parameterise era-independent types over the crypto instead of era

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -29,20 +29,13 @@ import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era hiding (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.ShelleyMA.Timelocks (translate)
-import Control.Iterate.SetAlgebra (biMapFromList, lifo)
 import Control.Monad.Except (throwError)
 import Data.Coerce (coerce)
-import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import Data.Typeable (Typeable)
 import Shelley.Spec.Ledger.API
-import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import qualified Shelley.Spec.Ledger.LedgerState as LS
   ( returnRedeemAddrsToReserves,
-    _delegations,
   )
-import Shelley.Spec.Ledger.Rewards (NonMyopic (..))
 import Shelley.Spec.Ledger.Tx (WitnessSetHKD (..))
 
 --------------------------------------------------------------------------------
@@ -73,10 +66,10 @@ instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
     return $
       NewEpochState
         { nesEL = nesEL nes,
-          nesBprev = translateEra' ctxt $ nesBprev nes,
-          nesBcur = translateEra' ctxt $ nesBcur nes,
+          nesBprev = nesBprev nes,
+          nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ LS.returnRedeemAddrsToReserves . nesEs $ nes,
-          nesRu = translateEra' ctxt <$> nesRu nes,
+          nesRu = nesRu nes,
           nesPd = nesPd nes
         }
 
@@ -104,8 +97,8 @@ instance Crypto c => TranslateEra (AllegraEra c) ShelleyGenesis where
           sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis,
           sgProtocolParams = translateEra' ctxt (sgProtocolParams genesis),
           sgGenDelegs = sgGenDelegs genesis,
-          sgInitialFunds = Map.mapKeys (translateEra' ctxt) $ sgInitialFunds genesis,
-          sgStaking = translateEra' ctxt $ sgStaking genesis
+          sgInitialFunds = sgInitialFunds genesis,
+          sgStaking = sgStaking genesis
         }
 
 --------------------------------------------------------------------------------
@@ -135,86 +128,6 @@ instance Crypto c => TranslateEra (AllegraEra c) (PParams' f) where
           _minPoolCost = _minPoolCost pp
         }
 
-instance Crypto c => TranslateEra (AllegraEra c) RewardAcnt where
-  translateEra ctxt ra =
-    return $
-      RewardAcnt
-        { getRwdNetwork = getRwdNetwork ra,
-          getRwdCred = translateEra' ctxt $ getRwdCred ra
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) PoolParams where
-  translateEra ctxt poolParams =
-    return $
-      PoolParams
-        { _poolId = _poolId poolParams,
-          _poolVrf = _poolVrf poolParams,
-          _poolPledge = _poolPledge poolParams,
-          _poolCost = _poolCost poolParams,
-          _poolMargin = _poolMargin poolParams,
-          _poolRAcnt = translateEra' ctxt (_poolRAcnt poolParams),
-          _poolOwners = _poolOwners poolParams,
-          _poolRelays = _poolRelays poolParams,
-          _poolMD = _poolMD poolParams
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) ShelleyGenesisStaking where
-  translateEra ctxt sgs =
-    return $
-      ShelleyGenesisStaking
-        { sgsPools = Map.map (translateEra' ctxt) (sgsPools sgs),
-          sgsStake = sgsStake sgs
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) Addr
-
-instance Crypto c => TranslateEra (AllegraEra c) EB.BlocksMade where
-  translateEra _ bm = return . EB.BlocksMade . EB.unBlocksMade $ bm
-
-instance Crypto c => TranslateEra (AllegraEra c) NonMyopic where
-  translateEra _ nm =
-    return
-      NonMyopic
-        { likelihoodsNM = likelihoodsNM nm,
-          rewardPotNM = rewardPotNM nm
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) ScriptHash
-
-instance Crypto c => TranslateEra (AllegraEra c) (Credential kr) where
-  translateEra ctxt (ScriptHashObj h) = return (ScriptHashObj (translateEra' ctxt h))
-  translateEra _ (KeyHashObj h) = return (KeyHashObj h)
-
-instance Crypto c => TranslateEra (AllegraEra c) RewardUpdate where
-  translateEra ctxt ru =
-    return
-      RewardUpdate
-        { deltaT = deltaT ru,
-          deltaR = deltaR ru,
-          rs = Map.mapKeys (translateEra' ctxt) $ rs ru,
-          deltaF = deltaF ru,
-          nonMyopic = translateEra' ctxt $ nonMyopic ru
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) SnapShot where
-  translateEra ctxt snap =
-    return
-      SnapShot
-        { _stake = Stake $ Map.mapKeys (translateEra' ctxt) $ unStake . _stake $ snap,
-          EB._delegations = Map.mapKeys (translateEra' ctxt) $ EB._delegations snap,
-          _poolParams = Map.map (translateEra' ctxt) $ _poolParams snap
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) SnapShots where
-  translateEra ctxt snaps =
-    return
-      SnapShots
-        { _pstakeMark = translateEra' ctxt $ _pstakeMark snaps,
-          _pstakeSet = translateEra' ctxt $ _pstakeSet snaps,
-          _pstakeGo = translateEra' ctxt $ _pstakeGo snaps,
-          _feeSS = _feeSS snaps
-        }
-
 instance Crypto c => TranslateEra (AllegraEra c) ProposedPPUpdates where
   translateEra ctxt (ProposedPPUpdates ppup) =
     return $ ProposedPPUpdates $ Map.map (translateEra' ctxt) ppup
@@ -227,22 +140,13 @@ instance Crypto c => TranslateEra (AllegraEra c) PPUPState where
           futureProposals = translateEra' ctxt $ futureProposals ps
         }
 
-instance Crypto c => TranslateEra (AllegraEra c) TxId
-
-instance Crypto c => TranslateEra (AllegraEra c) TxIn where
-  translateEra ctxt (TxIn txid ix) = return $ TxIn (translateEra' ctxt txid) ix
-
 instance Crypto c => TranslateEra (AllegraEra c) TxOut where
   translateEra () (TxOutCompact addr cfval) =
     pure $ TxOutCompact (coerce addr) cfval
 
 instance Crypto c => TranslateEra (AllegraEra c) UTxO where
   translateEra ctxt utxo =
-    return $
-      UTxO $
-        Map.mapKeys (translateEra' ctxt) $
-          Map.map (translateEra' ctxt) $
-            unUTxO utxo
+    return $ UTxO $ Map.map (translateEra' ctxt) $ unUTxO utxo
 
 instance Crypto c => TranslateEra (AllegraEra c) UTxOState where
   translateEra ctxt us =
@@ -254,54 +158,12 @@ instance Crypto c => TranslateEra (AllegraEra c) UTxOState where
           _ppups = translateEra' ctxt $ _ppups us
         }
 
-instance Crypto c => TranslateEra (AllegraEra c) InstantaneousRewards where
-  translateEra ctxt ir =
-    return
-      InstantaneousRewards
-        { iRReserves = Map.mapKeys (translateEra' ctxt) (iRReserves ir),
-          iRTreasury = Map.mapKeys (translateEra' ctxt) (iRTreasury ir)
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) DState where
-  translateEra ctxt ds =
-    return
-      DState
-        { _rewards = Map.mapKeys (translateEra' ctxt) (_rewards ds),
-          LS._delegations = Map.mapKeys (translateEra' ctxt) (LS._delegations ds),
-          _ptrs =
-            biMapFromList const $
-              toList $
-                fmap
-                  (\(ptr, cred) -> (ptr, translateEra' ctxt cred))
-                  (lifo (_ptrs ds)),
-          _fGenDelegs = _fGenDelegs ds,
-          _genDelegs = _genDelegs ds,
-          _irwd = translateEra' ctxt $ _irwd ds
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) PState where
-  translateEra ctxt ps =
-    return
-      PState
-        { _pParams = Map.map (translateEra' ctxt) (_pParams ps),
-          _fPParams = Map.map (translateEra' ctxt) (_fPParams ps),
-          _retiring = _retiring ps
-        }
-
-instance Crypto c => TranslateEra (AllegraEra c) DPState where
-  translateEra ctxt dp =
-    return
-      DPState
-        { _dstate = translateEra' ctxt $ _dstate dp,
-          _pstate = translateEra' ctxt $ _pstate dp
-        }
-
 instance Crypto c => TranslateEra (AllegraEra c) LedgerState where
   translateEra ctxt ls =
     return
       LedgerState
         { _utxoState = translateEra' ctxt $ _utxoState ls,
-          _delegationState = translateEra' ctxt $ _delegationState ls
+          _delegationState = _delegationState ls
         }
 
 instance Crypto c => TranslateEra (AllegraEra c) EpochState where
@@ -309,60 +171,21 @@ instance Crypto c => TranslateEra (AllegraEra c) EpochState where
     return
       EpochState
         { esAccountState = esAccountState es,
-          esSnapshots = translateEra' ctxt $ esSnapshots es,
+          esSnapshots = esSnapshots es,
           esLState = translateEra' ctxt $ esLState es,
           esPrevPp = translateEra' ctxt $ esPrevPp es,
           esPp = translateEra' ctxt $ esPp es,
-          esNonMyopic = translateEra' ctxt $ esNonMyopic es
+          esNonMyopic = esNonMyopic es
         }
 
 instance Crypto c => TranslateEra (AllegraEra c) WitnessSet where
-  translateEra ctxt WitnessSet {addrWits, scriptWits, bootWits} =
+  translateEra _ctxt WitnessSet {addrWits, scriptWits, bootWits} =
     pure $
       WitnessSet
-        { addrWits = Set.map (translateEra' @(AllegraEra c) ctxt) addrWits,
-          scriptWits =
-            Map.map translate
-              . Map.mapKeysMonotonic coerce
-              $ scriptWits,
-          bootWits = Set.map (translateEra' @(AllegraEra c) ctxt) bootWits
+        { addrWits = addrWits,
+          scriptWits = Map.map translate scriptWits,
+          bootWits = bootWits
         }
-
-instance Crypto c => TranslateEra (AllegraEra c) BootstrapWitness where
-  translateEra _ BootstrapWitness {bwKey, bwSig, bwChainCode, bwAttributes} =
-    pure
-      BootstrapWitness
-        { bwKey = bwKey,
-          bwSig = coerce bwSig,
-          bwChainCode,
-          bwAttributes
-        }
-
-instance
-  (Crypto c, Typeable kr) =>
-  TranslateEra (AllegraEra c) (WitVKey kr)
-  where
-  translateEra _ (WitVKey k s) =
-    pure $
-      WitVKey k s
-
-instance Crypto c => TranslateEra (AllegraEra c) Wdrl where
-  translateEra _ (Wdrl w) = pure . Wdrl $ Map.mapKeysMonotonic coerce w
-
-instance Crypto c => TranslateEra (AllegraEra c) DCert where
-  translateEra _ (DCertDeleg c) = pure . DCertDeleg $ coerce c
-  translateEra ctx (DCertPool c) = DCertPool <$> translateEra ctx c
-  translateEra _ (DCertGenesis c) = pure . DCertGenesis $ coerce c
-  translateEra ctx (DCertMir c) = DCertMir <$> translateEra ctx c
-
-instance Crypto c => TranslateEra (AllegraEra c) PoolCert where
-  translateEra ctx (RegPool pp) = pure . RegPool $ translateEra' ctx pp
-  translateEra _ (RetirePool kh e) = pure $ RetirePool (coerce kh) e
-
-instance Crypto c => TranslateEra (AllegraEra c) MIRCert where
-  translateEra _ (MIRCert pot rewards) =
-    pure $
-      MIRCert pot (Map.mapKeysMonotonic coerce rewards)
 
 instance Crypto c => TranslateEra (AllegraEra c) Update where
   translateEra _ (Update pp en) = pure $ Update (coerce pp) en

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -27,7 +27,7 @@ import qualified Cardano.Ledger.Val as Val
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
-import Shelley.Spec.Ledger.API hiding (TxBody)
+import Shelley.Spec.Ledger.API hiding (Metadata, TxBody)
 import Shelley.Spec.Ledger.Tx
   ( WitnessSetHKD (WitnessSet, addrWits, bootWits, scriptWits),
   )

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -22,20 +22,12 @@ import Cardano.Ledger.Era hiding (Crypto)
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Value (Value (..))
 import Cardano.Ledger.ShelleyMA.Metadata (Metadata (..), pattern Metadata)
-import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody
 import qualified Cardano.Ledger.Val as Val
-import Control.Iterate.SetAlgebra (biMapFromList, lifo)
 import Data.Coerce (coerce)
-import Data.Foldable (Foldable (toList))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
-import qualified Data.Set as Set
-import Data.Typeable (Typeable)
-import Shelley.Spec.Ledger.API hiding (Metadata, TxBody)
-import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import qualified Shelley.Spec.Ledger.LedgerState as LS
-import Shelley.Spec.Ledger.Rewards (NonMyopic (NonMyopic), likelihoodsNM, rewardPotNM)
+import Shelley.Spec.Ledger.API hiding (TxBody)
 import Shelley.Spec.Ledger.Tx
   ( WitnessSetHKD (WitnessSet, addrWits, bootWits, scriptWits),
   )
@@ -68,10 +60,10 @@ instance Crypto c => TranslateEra (MaryEra c) NewEpochState where
     return $
       NewEpochState
         { nesEL = nesEL nes,
-          nesBprev = translateEra' ctxt $ nesBprev nes,
-          nesBcur = translateEra' ctxt $ nesBcur nes,
+          nesBprev = nesBprev nes,
+          nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ nesEs nes,
-          nesRu = translateEra' ctxt <$> nesRu nes,
+          nesRu = nesRu nes,
           nesPd = nesPd nes
         }
 
@@ -103,8 +95,8 @@ instance Crypto c => TranslateEra (MaryEra c) ShelleyGenesis where
           sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis,
           sgProtocolParams = translateEra' ctxt (sgProtocolParams genesis),
           sgGenDelegs = sgGenDelegs genesis,
-          sgInitialFunds = Map.mapKeys (translateEra' ctxt) $ sgInitialFunds genesis,
-          sgStaking = translateEra' ctxt $ sgStaking genesis
+          sgInitialFunds = sgInitialFunds genesis,
+          sgStaking = sgStaking genesis
         }
 
 --------------------------------------------------------------------------------
@@ -113,120 +105,16 @@ instance Crypto c => TranslateEra (MaryEra c) ShelleyGenesis where
 
 instance (Crypto c, Functor f) => TranslateEra (MaryEra c) (PParams' f)
 
-instance Crypto c => TranslateEra (MaryEra c) RewardAcnt
-
-instance Crypto c => TranslateEra (MaryEra c) PoolParams where
-  translateEra ctxt poolParams =
-    return $
-      PoolParams
-        { _poolId = _poolId poolParams,
-          _poolVrf = _poolVrf poolParams,
-          _poolPledge = _poolPledge poolParams,
-          _poolCost = _poolCost poolParams,
-          _poolMargin = _poolMargin poolParams,
-          _poolRAcnt = translateEra' ctxt (_poolRAcnt poolParams),
-          _poolOwners = _poolOwners poolParams,
-          _poolRelays = _poolRelays poolParams,
-          _poolMD = _poolMD poolParams
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) ShelleyGenesisStaking where
-  translateEra ctxt sgs =
-    return $
-      ShelleyGenesisStaking
-        { sgsPools = Map.map (translateEra' ctxt) (sgsPools sgs),
-          sgsStake = sgsStake sgs
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) Addr
-
-instance Crypto c => TranslateEra (MaryEra c) EB.BlocksMade
-
-instance Crypto c => TranslateEra (MaryEra c) SnapShot where
-  translateEra ctxt snap =
-    return
-      SnapShot
-        { _stake = Stake $ Map.mapKeys (translateEra' ctxt) $ unStake . _stake $ snap,
-          EB._delegations = Map.mapKeys (translateEra' ctxt) $ EB._delegations snap,
-          _poolParams = Map.map (translateEra' ctxt) $ _poolParams snap
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) SnapShots where
-  translateEra ctxt snaps =
-    return
-      SnapShots
-        { _pstakeMark = translateEra' ctxt $ _pstakeMark snaps,
-          _pstakeSet = translateEra' ctxt $ _pstakeSet snaps,
-          _pstakeGo = translateEra' ctxt $ _pstakeGo snaps,
-          _feeSS = _feeSS snaps
-        }
-
 instance Crypto c => TranslateEra (MaryEra c) EpochState where
   translateEra ctxt es =
     return
       EpochState
         { esAccountState = esAccountState es,
-          esSnapshots = translateEra' ctxt $ esSnapshots es,
+          esSnapshots = esSnapshots es,
           esLState = translateEra' ctxt $ esLState es,
           esPrevPp = translateEra' ctxt $ esPrevPp es,
           esPp = translateEra' ctxt $ esPp es,
-          esNonMyopic = translateEra' ctxt $ esNonMyopic es
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) NonMyopic where
-  translateEra _ nm =
-    return
-      NonMyopic
-        { likelihoodsNM = likelihoodsNM nm,
-          rewardPotNM = rewardPotNM nm
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) (Credential kr) where
-  translateEra ctxt (ScriptHashObj h) = return (ScriptHashObj (translateEra' ctxt h))
-  translateEra _ (KeyHashObj h) = return (KeyHashObj h)
-
-instance Crypto c => TranslateEra (MaryEra c) ScriptHash
-
-instance Crypto c => TranslateEra (MaryEra c) InstantaneousRewards where
-  translateEra ctxt ir =
-    return
-      InstantaneousRewards
-        { iRReserves = Map.mapKeys (translateEra' ctxt) (iRReserves ir),
-          iRTreasury = Map.mapKeys (translateEra' ctxt) (iRTreasury ir)
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) DState where
-  translateEra ctxt ds =
-    return
-      DState
-        { _rewards = Map.mapKeys (translateEra' ctxt) (_rewards ds),
-          LS._delegations = Map.mapKeys (translateEra' ctxt) (LS._delegations ds),
-          _ptrs =
-            biMapFromList const $
-              toList $
-                fmap
-                  (\(ptr, cred) -> (ptr, translateEra' ctxt cred))
-                  (lifo (_ptrs ds)),
-          _fGenDelegs = _fGenDelegs ds,
-          _genDelegs = _genDelegs ds,
-          _irwd = translateEra' ctxt $ _irwd ds
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) PState where
-  translateEra ctxt ps =
-    return
-      PState
-        { _pParams = Map.map (translateEra' ctxt) (_pParams ps),
-          _fPParams = Map.map (translateEra' ctxt) (_fPParams ps),
-          _retiring = _retiring ps
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) DPState where
-  translateEra ctxt dp =
-    return
-      DPState
-        { _dstate = translateEra' ctxt $ _dstate dp,
-          _pstate = translateEra' ctxt $ _pstate dp
+          esNonMyopic = esNonMyopic es
         }
 
 instance Crypto c => TranslateEra (MaryEra c) LedgerState where
@@ -234,7 +122,7 @@ instance Crypto c => TranslateEra (MaryEra c) LedgerState where
     return
       LedgerState
         { _utxoState = translateEra' ctxt $ _utxoState ls,
-          _delegationState = translateEra' ctxt $ _delegationState ls
+          _delegationState = _delegationState ls
         }
 
 instance Crypto c => TranslateEra (MaryEra c) ProposedPPUpdates where
@@ -259,81 +147,22 @@ instance Crypto c => TranslateEra (MaryEra c) UTxOState where
           _ppups = translateEra' ctxt $ _ppups us
         }
 
-instance Crypto c => TranslateEra (MaryEra c) RewardUpdate where
-  translateEra ctxt ru =
-    return
-      RewardUpdate
-        { deltaT = deltaT ru,
-          deltaR = deltaR ru,
-          rs = Map.mapKeys (translateEra' ctxt) $ rs ru,
-          deltaF = deltaF ru,
-          nonMyopic = translateEra' ctxt $ nonMyopic ru
-        }
-
-instance Crypto c => TranslateEra (MaryEra c) TxId
-
-instance Crypto c => TranslateEra (MaryEra c) TxIn where
-  translateEra ctxt (TxIn txid ix) = return $ TxIn (translateEra' ctxt txid) ix
-
 instance Crypto c => TranslateEra (MaryEra c) TxOut where
   translateEra () (TxOutCompact addr cfval) =
     pure $ TxOutCompact (coerce addr) (translateCompactValue cfval)
 
 instance Crypto c => TranslateEra (MaryEra c) UTxO where
   translateEra ctxt utxo =
-    return $
-      UTxO $
-        Map.mapKeys (translateEra' ctxt) $
-          Map.map (translateEra' ctxt) $
-            unUTxO utxo
+    return $ UTxO $ Map.map (translateEra' ctxt) $ unUTxO utxo
 
 instance Crypto c => TranslateEra (MaryEra c) WitnessSet where
-  translateEra ctxt WitnessSet {addrWits, scriptWits, bootWits} =
+  translateEra _ WitnessSet {addrWits, scriptWits, bootWits} =
     pure $
       WitnessSet
-        { addrWits = Set.map (translateEra' @(MaryEra c) ctxt) addrWits,
-          scriptWits =
-            Map.map coerce
-              . Map.mapKeysMonotonic coerce
-              $ scriptWits,
-          bootWits = Set.map (translateEra' @(MaryEra c) ctxt) bootWits
+        { addrWits = addrWits,
+          scriptWits = Map.map coerce scriptWits,
+          bootWits = bootWits
         }
-
-instance Crypto c => TranslateEra (MaryEra c) BootstrapWitness where
-  translateEra _ BootstrapWitness {bwKey, bwSig, bwChainCode, bwAttributes} =
-    pure
-      BootstrapWitness
-        { bwKey = bwKey,
-          bwSig = coerce bwSig,
-          bwChainCode,
-          bwAttributes
-        }
-
-instance
-  (Crypto c, Typeable kr) =>
-  TranslateEra (MaryEra c) (WitVKey kr)
-  where
-  translateEra _ (WitVKey k s) =
-    pure $
-      WitVKey k s
-
-instance Crypto c => TranslateEra (MaryEra c) Wdrl where
-  translateEra _ (Wdrl w) = pure . Wdrl $ Map.mapKeysMonotonic coerce w
-
-instance Crypto c => TranslateEra (MaryEra c) DCert where
-  translateEra _ (DCertDeleg c) = pure . DCertDeleg $ coerce c
-  translateEra ctx (DCertPool c) = DCertPool <$> translateEra ctx c
-  translateEra _ (DCertGenesis c) = pure . DCertGenesis $ coerce c
-  translateEra ctx (DCertMir c) = DCertMir <$> translateEra ctx c
-
-instance Crypto c => TranslateEra (MaryEra c) PoolCert where
-  translateEra ctx (RegPool pp) = pure . RegPool $ translateEra' ctx pp
-  translateEra _ (RetirePool kh e) = pure $ RetirePool (coerce kh) e
-
-instance Crypto c => TranslateEra (MaryEra c) MIRCert where
-  translateEra _ (MIRCert pot rewards) =
-    pure $
-      MIRCert pot (Map.mapKeysMonotonic coerce rewards)
 
 instance Crypto c => TranslateEra (MaryEra c) Update where
   translateEra _ (Update pp en) = pure $ Update (coerce pp) en
@@ -342,10 +171,10 @@ instance Crypto c => TranslateEra (MaryEra c) TxBody where
   translateEra ctx (TxBody i o d w fee vi u m mint) =
     pure $
       TxBody
-        (Set.map (translateEra' ctx) i)
+        i
         (translateEra' ctx <$> o)
-        (translateEra' ctx <$> d)
-        (translateEra' ctx w)
+        d
+        w
         fee
         vi
         (translateEra' ctx <$> u)
@@ -353,16 +182,13 @@ instance Crypto c => TranslateEra (MaryEra c) TxBody where
         (translateValue mint)
 
 instance Crypto c => TranslateEra (MaryEra c) Metadata where
-  translateEra ctx (Metadata blob sp) =
-    pure $
-      Metadata blob (translateEra' ctx <$> sp)
+  translateEra _ (Metadata blob sp) =
+    pure $ Metadata blob sp
 
-instance Crypto c => TranslateEra (MaryEra c) Timelock
-
-translateValue :: Era era => Coin -> Value era
+translateValue :: Crypto c => Coin -> Value c
 translateValue = Val.inject
 
-translateCompactValue :: Era era => CompactForm Coin -> CompactForm (Value era)
+translateCompactValue :: Crypto c => CompactForm Coin -> CompactForm (Value c)
 translateCompactValue =
   fromMaybe (error msg) . toCompact . translateValue . fromCompact
   where

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -53,23 +53,23 @@ instance
   where
   type Crypto (ShelleyMAEra ma c) = c
 
-type family MAValue (x :: MaryOrAllegra) era :: Type where
+type family MAValue (x :: MaryOrAllegra) c :: Type where
   MAValue 'Allegra _ = Coin
-  MAValue 'Mary era = Value era
+  MAValue 'Mary c = Value c
 
 --------------------------------------------------------------------------------
 -- Core instances
 --------------------------------------------------------------------------------
 
-type instance Core.Value (ShelleyMAEra m c) = MAValue m (ShelleyMAEra m c)
+type instance Core.Value (ShelleyMAEra m c) = MAValue m c
 
 type instance
   Core.TxBody (ShelleyMAEra (ma :: MaryOrAllegra) c) =
     TxBody (ShelleyMAEra ma c)
 
 type instance
-  Core.Script (ShelleyMAEra (ma :: MaryOrAllegra) c) =
-    Timelock (ShelleyMAEra ma c)
+  Core.Script (ShelleyMAEra (_ma :: MaryOrAllegra) c) =
+    Timelock c
 
 type instance
   Core.Metadata (ShelleyMAEra (ma :: MaryOrAllegra) c) =

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -7,7 +7,7 @@
 module Cardano.Ledger.ShelleyMA where
 
 import Cardano.Binary (toCBOR)
-import Cardano.Crypto.Hash (hashWithSerialiser)
+import Cardano.Crypto.Hash (castHash, hashWithSerialiser)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
@@ -98,6 +98,6 @@ instance
   ) =>
   ValidateMetadata (ShelleyMAEra (ma :: MaryOrAllegra) c)
   where
-  hashMetadata = MetadataHash . hashWithSerialiser toCBOR
+  hashMetadata = MetadataHash . castHash . hashWithSerialiser toCBOR
 
   validateMetadata (Metadata blob sp) = deepseq sp $ all validMetadatum blob

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -121,7 +121,7 @@ data TxBodyRaw era = TxBodyRaw
     txfee :: !Coin,
     vldt :: !ValidityInterval, -- imported from Timelocks
     update :: !(StrictMaybe (Update era)),
-    mdHash :: !(StrictMaybe (MetadataHash era)),
+    mdHash :: !(StrictMaybe (MetadataHash (Crypto era))),
     mint :: !(Value era)
   }
   deriving (Typeable)
@@ -267,7 +267,7 @@ pattern TxBody ::
   Coin ->
   ValidityInterval ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetadataHash era) ->
+  StrictMaybe (MetadataHash (Crypto era)) ->
   Value era ->
   TxBody era
 pattern TxBody i o d w fee vi u m mint <-
@@ -317,7 +317,7 @@ instance HasField "vldt" (TxBody era) ValidityInterval where
 instance HasField "update" (TxBody era) (StrictMaybe (Update era)) where
   getField (TxBodyConstr (Memo m _)) = getField @"update" m
 
-instance HasField "mdHash" (TxBody era) (StrictMaybe (MetadataHash era)) where
+instance Crypto era ~ crypto => HasField "mdHash" (TxBody era) (StrictMaybe (MetadataHash crypto)) where
   getField (TxBodyConstr (Memo m _)) = getField @"mdHash" m
 
 instance Value era ~ value => HasField "mint" (TxBody era) value where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -85,7 +85,7 @@ genTxBody ::
   Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetadataHash era) ->
+  StrictMaybe (MetadataHash (Crypto era)) ->
   Gen (TxBody era)
 genTxBody slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -79,10 +79,10 @@ genTxBody ::
     EraGen era
   ) =>
   SlotNo ->
-  Set.Set (TxIn era) ->
+  Set.Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
-  StrictSeq (DCert era) ->
-  Wdrl era ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
   StrictMaybe (MetadataHash era) ->
@@ -106,13 +106,13 @@ genTxBody slot ins outs cert wdrl fee upd meta = do
   ShelleyMA helpers, shared by Allegra and Mary
 ------------------------------------------------------------------------------}
 
-quantifyTL :: Era era => Timelock era -> Quantifier (Timelock era)
+quantifyTL :: CryptoClass.Crypto crypto => Timelock crypto -> Quantifier (Timelock crypto)
 quantifyTL (RequireAllOf xs) = AllOf (foldr (:) [] xs)
 quantifyTL (RequireAnyOf xs) = AnyOf (foldr (:) [] xs)
 quantifyTL (RequireMOf n xs) = MOf n (foldr (:) [] xs)
 quantifyTL t = Leaf t
 
-unQuantifyTL :: Era era => Quantifier (Timelock era) -> Timelock era
+unQuantifyTL :: CryptoClass.Crypto crypto => Quantifier (Timelock crypto) -> Timelock crypto
 unQuantifyTL (AllOf xs) = RequireAllOf (fromList xs)
 unQuantifyTL (AnyOf xs) = RequireAnyOf (fromList xs)
 unQuantifyTL (MOf n xs) = RequireMOf n (fromList xs)
@@ -128,7 +128,7 @@ genValidityInterval (SlotNo currentSlot) = do
     ValidityInterval validityStart validityEnd
 
 -- | Generate some Leaf Timelock (i.e. a Signature or TimeStart or TimeExpire)
-someLeaf :: Era era => KeyHash 'Witness (Crypto era) -> Timelock era
+someLeaf :: CryptoClass.Crypto crypto => KeyHash 'Witness crypto -> Timelock crypto
 someLeaf x =
   let n = mod (hash (serializeEncoding' (toCBOR x))) 200
    in if n <= 50

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -11,6 +11,7 @@
 module Test.Cardano.Ledger.Mary () where -- export the EraGen instance for MaryEra
 
 import qualified Cardano.Ledger.Crypto as CryptoClass
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Mary.Value (Value (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody (FamsTo, StrictMaybe, TxBody (..))
@@ -74,10 +75,10 @@ genTxBody ::
   ) =>
   GenEnv era ->
   SlotNo ->
-  Set.Set (TxIn era) ->
+  Set.Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
-  StrictSeq (DCert era) ->
-  Wdrl era ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
   StrictMaybe (MetadataHash era) ->

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -81,7 +81,7 @@ genTxBody ::
   Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetadataHash era) ->
+  StrictMaybe (MetadataHash (Crypto era)) ->
   Gen (TxBody era)
 genTxBody _ge slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -128,7 +128,7 @@ instance
   -- pattern, despite the pattern being COMPLETE, resulting
   -- in an unsatisfied `MonadFail` constraint.
   arbitrary =
-    genMetaData' >>= \case
+    genMetadata' >>= \case
       Metadata m -> MA.Metadata m <$> genScriptSeq
 
 genScriptSeq ::

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -29,7 +29,7 @@ import Cardano.Binary (toCBOR)
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Era (Era (..))
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Mary (MaryEra)
 import qualified Cardano.Ledger.Mary.Value as ConcreteValue
 import qualified Cardano.Ledger.Mary.Value as Mary
@@ -84,9 +84,9 @@ maxTimelockListLens :: Int
 maxTimelockListLens = 5
 
 sizedTimelock ::
-  Era era =>
+  CC.Crypto crypto =>
   Int ->
-  Gen (Timelock era)
+  Gen (Timelock crypto)
 sizedTimelock 0 = (MA.RequireSignature . KeyHash . mkDummyHash) <$> arbitrary
 sizedTimelock n =
   oneof
@@ -113,7 +113,7 @@ sizedTimelock n =
 
 -- TODO Generate metadata with script preimages
 instance
-  (Mock c, Typeable ma, Arbitrary (Timelock (ShelleyMAEra ma c))) =>
+  (Mock c, Typeable ma, Arbitrary (Timelock c)) =>
   Arbitrary (MA.Metadata (ShelleyMAEra ma c))
   where
   -- Why do we use the \case instead of a do statement? like this:
@@ -121,20 +121,19 @@ instance
   -- @
   -- arbitrary = do
   --   Metadata m <- genMetadata'
-  --   pure $ MA.Metadata m StrictSeq.empty
+  --   MA.Metadata m <$> genScriptSeq
   -- @
   --
   -- The above leads to an error about a failable
   -- pattern, despite the pattern being COMPLETE, resulting
   -- in an unsatisfied `MonadFail` constraint.
   arbitrary =
-    genMetadata' >>= \case
-      Metadata m ->
-        do ss <- genScriptSeq; pure (MA.Metadata m ss)
+    genMetaData' >>= \case
+      Metadata m -> MA.Metadata m <$> genScriptSeq
 
 genScriptSeq ::
-  (Arbitrary (Timelock (ShelleyMAEra ma c))) =>
-  Gen (StrictSeq (Timelock (ShelleyMAEra ma c)))
+  (Arbitrary (Timelock c)) =>
+  Gen (StrictSeq (Timelock c))
 genScriptSeq = do
   n <- choose (0, 3)
   l <- vectorOf n arbitrary
@@ -157,13 +156,10 @@ instance Mock c => Arbitrary (MA.TxBody (MaryEra c)) where
       <*> arbitrary
       <*> genMintValues
 
-instance Mock c => Arbitrary (Timelock (MaryEra c)) where
-  arbitrary = sizedTimelock maxTimelockDepth
-
-instance Mock c => Arbitrary (Mary.PolicyID (MaryEra c)) where
+instance Mock c => Arbitrary (Mary.PolicyID c) where
   arbitrary = Mary.PolicyID <$> arbitrary
 
-instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
+instance Mock c => Arbitrary (Mary.Value c) where
   arbitrary = valueFromListBounded @Word64 <$> arbitrary <*> arbitrary
 
   shrink (Mary.Value ada assets) =
@@ -180,17 +176,17 @@ instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
 --
 -- - Fix the ADA value to 0
 -- - Allow both positive and negative quantities
-genMintValues :: forall c. Mock c => Gen (Mary.Value (MaryEra c))
+genMintValues :: forall c. Mock c => Gen (Mary.Value c)
 genMintValues = valueFromListBounded @Int64 0 <$> arbitrary
 
 -- | Variant on @valueFromList@ that makes sure that generated values stay
 -- bounded within the range of a given integral type.
 valueFromListBounded ::
-  forall i era.
+  forall i crypto.
   (Bounded i, Integral i) =>
   i ->
-  [(Mary.PolicyID era, Mary.AssetName, i)] ->
-  Mary.Value era
+  [(Mary.PolicyID crypto, Mary.AssetName, i)] ->
+  Mary.Value crypto
 valueFromListBounded (fromIntegral -> ada) =
   foldr
     (\(p, n, fromIntegral -> i) ans -> ConcreteValue.insert comb p n i ans)
@@ -225,7 +221,7 @@ instance Mock c => Arbitrary (MA.TxBody (AllegraEra c)) where
       <*> arbitrary
       <*> pure (Coin 0)
 
-instance Mock c => Arbitrary (Timelock (AllegraEra c)) where
+instance Mock c => Arbitrary (Timelock c) where
   arbitrary = sizedTimelock maxTimelockDepth
 
 instance Arbitrary ValidityInterval where
@@ -234,9 +230,3 @@ instance Arbitrary ValidityInterval where
 
 instance Mock c => Arbitrary (MA.STS.UtxoPredicateFailure (AllegraEra c)) where
   arbitrary = genericArbitraryU
-
-instance Mock c => Arbitrary (ConcreteValue.PolicyID (AllegraEra c)) where
-  arbitrary = ConcreteValue.PolicyID <$> arbitrary
-
-instance Mock c => Arbitrary (ConcreteValue.Value (AllegraEra c)) where
-  arbitrary = ConcreteValue.Value <$> arbitrary <*> arbitrary

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -100,10 +100,10 @@ txM =
     SNothing
     testmint
 
-testmint :: Value TestEra
+testmint :: Value TestCrypto
 testmint = Value 0 (Map.singleton policyId (Map.singleton aname 2))
   where
-    policyId = PolicyID . hashScript . RequireAnyOf $ fromList []
+    policyId = PolicyID . hashScript @TestEra . RequireAnyOf $ fromList []
     aname = AssetName $ fromString "asset name"
 
 bytes :: Mary.TxBody era -> ShortByteString

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/Translation.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Allegra.Translation ()
 import Cardano.Ledger.Era (TranslateEra (..))
 import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
 import qualified Shelley.Spec.Ledger.API as S
-import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import Test.Cardano.Ledger.EraBuffet
   ( AllegraEra,
     ShelleyEra,
@@ -51,36 +50,15 @@ allegraTranslationTests =
     "Allegra translation binary compatibiliby tests"
     [ testProperty "Tx compatibility" (test @S.Tx),
       testProperty "ShelleyGenesis compatibility" (test @S.ShelleyGenesis),
-      testProperty "RewardAcnt compatibility" (test @S.RewardAcnt),
-      testProperty "PoolParams compatibility" (test @S.PoolParams),
-      testProperty "Addr compatibility" (test @S.Addr),
-      testProperty "NonMyopic compatibility" (test @S.NonMyopic),
-      testProperty "ScriptHash compatibility" (test @S.ScriptHash),
-      testProperty "RewardUpdate compatibility" (test @S.RewardUpdate),
-      testProperty "SnapShot compatibility" (test @S.SnapShot),
-      testProperty "SnapShots compatibility" (test @S.SnapShots),
       testProperty "ProposedPPUpdates compatibility" (test @S.ProposedPPUpdates),
       testProperty "PPUPState compatibility" (test @S.PPUPState),
-      testProperty "TxId compatibility" (test @S.TxId),
-      testProperty "TxIn compatibility" (test @S.TxIn),
       testProperty "TxOut compatibility" (test @S.TxOut),
       testProperty "UTxO compatibility" (test @S.UTxO),
       testProperty "UTxOState compatibility" (test @S.UTxOState),
-      testProperty "InstantaneousRewards compatibility" (test @S.InstantaneousRewards),
-      testProperty "DState compatibility" (test @S.DState),
-      testProperty "PState compatibility" (test @S.PState),
-      testProperty "DPState compatibility" (test @S.DPState),
       testProperty "LedgerState compatibility" (test @S.LedgerState),
       testProperty "EpochState compatibility" (test @S.EpochState),
       testProperty "WitnessSet compatibility" (test @S.WitnessSet),
-      testProperty "BootstrapWitness compatibility" (test @S.BootstrapWitness),
-      testProperty "Wdrl compatibility" (test @S.Wdrl),
-      testProperty "DCert compatibility" (test @S.DCert),
-      testProperty "MIRCert compatibility" (test @S.MIRCert),
-      testProperty "Update compatibility" (test @S.Update),
-      testProperty "Credential compatibility" (test @(S.Credential 'S.Witness)),
-      testProperty "WitVKey compatibility" (test @(S.WitVKey 'S.Witness)),
-      testProperty "BlocksMade compatibility" (test @EB.BlocksMade)
+      testProperty "Update compatibility" (test @S.Update)
     ]
 
 test ::

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -29,7 +29,7 @@ import Test.Tasty.HUnit (Assertion, (@?=))
 type MaryTest = MaryEra TestCrypto
 
 ignoreAllButUTxO ::
-  Either [[PredicateFailure (LEDGER MaryTest)]] (UTxOState MaryTest, DPState MaryTest) ->
+  Either [[PredicateFailure (LEDGER MaryTest)]] (UTxOState MaryTest, DPState TestCrypto) ->
   Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
 ignoreAllButUTxO (Left e) = Left e
 ignoreAllButUTxO (Right (UTxOState utxo _ _ _, _)) = Right utxo

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/Cast.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/Cast.hs
@@ -21,7 +21,6 @@ module Test.Cardano.Ledger.Mary.Examples.Cast
   )
 where
 
-import Cardano.Ledger.Mary (MaryEra)
 import Shelley.Spec.Ledger.Address (Addr (..))
 import Shelley.Spec.Ledger.Keys
   ( KeyPair (..),
@@ -29,8 +28,6 @@ import Shelley.Spec.Ledger.Keys
   )
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.Shelley.Spec.Ledger.Utils (mkAddr, mkKeyPair)
-
-type MaryTest = MaryEra TestCrypto
 
 -- | Alice's payment key pair
 alicePay :: KeyPair 'Payment TestCrypto
@@ -45,7 +42,7 @@ aliceStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (1, 1, 1, 1, 1)
 
 -- | Alice's base address
-aliceAddr :: Addr MaryTest
+aliceAddr :: Addr TestCrypto
 aliceAddr = mkAddr (alicePay, aliceStake)
 
 -- | Bob's payment key pair
@@ -61,7 +58,7 @@ bobStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (3, 3, 3, 3, 3)
 
 -- | Bob's address
-bobAddr :: Addr MaryTest
+bobAddr :: Addr TestCrypto
 bobAddr = mkAddr (bobPay, bobStake)
 
 -- Carl's payment key pair
@@ -77,7 +74,7 @@ carlStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (5, 5, 5, 5, 5)
 
 -- | Carl's address
-carlAddr :: Addr MaryTest
+carlAddr :: Addr TestCrypto
 carlAddr = mkAddr (carlPay, carlStake)
 
 -- | Daria's payment key pair
@@ -93,5 +90,5 @@ dariaStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (7, 7, 7, 7, 7)
 
 -- | Daria's address
-dariaAddr :: Addr MaryTest
+dariaAddr :: Addr TestCrypto
 dariaAddr = mkAddr (dariaPay, dariaStake)

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 -- |
 -- Module      : Test.Cardano.Ledger.Mary.Examples.MultiAssets
 -- Description : Multi-Assets Examples
@@ -67,9 +68,10 @@ bobInitCoin = Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 unboundedInterval :: ValidityInterval
 unboundedInterval = ValidityInterval SNothing SNothing
 
-bootstrapTxId :: TxId MaryTest
+bootstrapTxId :: TxId TestCrypto
 bootstrapTxId = txid txb
   where
+    txb :: TxBody MaryTest
     txb =
       TxBody
         Set.empty
@@ -108,10 +110,10 @@ feeEx = Coin 3
 -- These examples do not use several of the transaction components,
 -- so we can simplify building them.
 makeTxb ::
-  [TxIn MaryTest] ->
+  [TxIn TestCrypto] ->
   [TxOut MaryTest] ->
   ValidityInterval ->
-  Value MaryTest ->
+  Value TestCrypto ->
   TxBody MaryTest
 makeTxb ins outs interval minted =
   TxBody
@@ -125,7 +127,7 @@ makeTxb ins outs interval minted =
     SNothing
     minted
 
-policyFailure :: PolicyID MaryTest -> Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
+policyFailure :: PolicyID TestCrypto -> Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
 policyFailure p =
   Left
     [ [ UtxowFailure
@@ -143,11 +145,11 @@ policyFailure p =
 ----------------------------------------------------
 
 -- This is the most lax policy possible, requiring no authorization at all.
-purplePolicy :: Timelock MaryTest
+purplePolicy :: Timelock TestCrypto
 purplePolicy = RequireAllOf (StrictSeq.fromList [])
 
-purplePolicyId :: PolicyID MaryTest
-purplePolicyId = PolicyID $ hashScript purplePolicy
+purplePolicyId :: PolicyID TestCrypto
+purplePolicyId = PolicyID $ hashScript @MaryTest purplePolicy
 
 plum :: AssetName
 plum = AssetName $ BS.pack "plum"
@@ -159,7 +161,7 @@ amethyst = AssetName $ BS.pack "amethyst"
 -- Mint Purple Tokens --
 ------------------------
 
-mintSimpleEx1 :: Value MaryTest
+mintSimpleEx1 :: Value TestCrypto
 mintSimpleEx1 =
   Value 0 $
     Map.singleton purplePolicyId (Map.fromList [(plum, 13), (amethyst, 2)])
@@ -167,7 +169,7 @@ mintSimpleEx1 =
 aliceCoinSimpleEx1 :: Coin
 aliceCoinSimpleEx1 = aliceInitCoin <-> feeEx
 
-tokensSimpleEx1 :: Value MaryTest
+tokensSimpleEx1 :: Value TestCrypto
 tokensSimpleEx1 = mintSimpleEx1 <+> (Val.inject aliceCoinSimpleEx1)
 
 -- Mint a purple token bundle, consisting of thirteen plums and two amethysts.
@@ -208,12 +210,12 @@ minUtxoSimpleEx2 = Coin 100
 aliceCoinsSimpleEx2 :: Coin
 aliceCoinsSimpleEx2 = aliceCoinSimpleEx1 <-> (feeEx <+> minUtxoSimpleEx2)
 
-aliceTokensSimpleEx2 :: Value MaryTest
+aliceTokensSimpleEx2 :: Value TestCrypto
 aliceTokensSimpleEx2 =
   Value (unCoin aliceCoinsSimpleEx2) $
     Map.singleton purplePolicyId (Map.fromList [(plum, 8), (amethyst, 2)])
 
-bobTokensSimpleEx2 :: Value MaryTest
+bobTokensSimpleEx2 :: Value TestCrypto
 bobTokensSimpleEx2 =
   Value (unCoin minUtxoSimpleEx2) $
     Map.singleton purplePolicyId (Map.singleton plum 5)
@@ -264,7 +266,7 @@ stopInterval = SlotNo 19
 afterStop :: SlotNo
 afterStop = SlotNo 20
 
-boundedTimePolicy :: Timelock MaryTest
+boundedTimePolicy :: Timelock TestCrypto
 boundedTimePolicy =
   RequireAllOf
     ( StrictSeq.fromList
@@ -273,8 +275,8 @@ boundedTimePolicy =
         ]
     )
 
-boundedTimePolicyId :: PolicyID MaryTest
-boundedTimePolicyId = PolicyID $ hashScript boundedTimePolicy
+boundedTimePolicyId :: PolicyID TestCrypto
+boundedTimePolicyId = PolicyID $ hashScript @MaryTest boundedTimePolicy
 
 tokenTimeEx :: AssetName
 tokenTimeEx = AssetName $ BS.pack "tokenTimeEx"
@@ -283,7 +285,7 @@ tokenTimeEx = AssetName $ BS.pack "tokenTimeEx"
 -- Mint Bounded Time Range Tokens --
 ------------------------------------
 
-mintTimeEx1 :: Value MaryTest
+mintTimeEx1 :: Value TestCrypto
 mintTimeEx1 =
   Value 0 $
     Map.singleton boundedTimePolicyId (Map.singleton tokenTimeEx 1)
@@ -291,7 +293,7 @@ mintTimeEx1 =
 aliceCoinsTimeEx1 :: Coin
 aliceCoinsTimeEx1 = aliceInitCoin <-> feeEx
 
-tokensTimeEx1 :: Value MaryTest
+tokensTimeEx1 :: Value TestCrypto
 tokensTimeEx1 = mintTimeEx1 <+> (Val.inject aliceCoinsTimeEx1)
 
 -- Mint tokens
@@ -346,7 +348,7 @@ expectedUTxOTimeEx1 =
 mintTimeEx2 :: Coin
 mintTimeEx2 = Coin 100
 
-bobTokensTimeEx2 :: Value MaryTest
+bobTokensTimeEx2 :: Value TestCrypto
 bobTokensTimeEx2 =
   Value (unCoin mintTimeEx2) $
     Map.singleton boundedTimePolicyId (Map.singleton tokenTimeEx 1)
@@ -391,11 +393,11 @@ expectedUTxOTimeEx2 =
 -- refer to this example.
 --------------------------------------------------------------
 
-alicePolicy :: Timelock MaryTest
+alicePolicy :: Timelock TestCrypto
 alicePolicy = RequireSignature . asWitness . hashKey . vKey $ Cast.alicePay
 
-alicePolicyId :: PolicyID MaryTest
-alicePolicyId = PolicyID $ hashScript alicePolicy
+alicePolicyId :: PolicyID TestCrypto
+alicePolicyId = PolicyID $ hashScript @MaryTest alicePolicy
 
 tokenSingWitEx1 :: AssetName
 tokenSingWitEx1 = AssetName $ BS.pack "tokenSingWitEx1"
@@ -404,7 +406,7 @@ tokenSingWitEx1 = AssetName $ BS.pack "tokenSingWitEx1"
 -- Mint Alice Tokens --
 -----------------------
 
-mintSingWitEx1 :: Value MaryTest
+mintSingWitEx1 :: Value TestCrypto
 mintSingWitEx1 =
   Value 0 $
     Map.singleton alicePolicyId (Map.singleton tokenSingWitEx1 17)
@@ -412,7 +414,7 @@ mintSingWitEx1 =
 bobCoinsSingWitEx1 :: Coin
 bobCoinsSingWitEx1 = bobInitCoin <-> feeEx
 
-tokensSingWitEx1 :: Value MaryTest
+tokensSingWitEx1 :: Value TestCrypto
 tokensSingWitEx1 = mintSingWitEx1 <+> (Val.inject bobCoinsSingWitEx1)
 
 -- Bob pays the fees, but only alice can witness the minting
@@ -464,12 +466,12 @@ txSingWitEx1Invalid =
 ------------------------
 
 -- Mint negative valued tokens
-mintNegEx1 :: Value MaryTest
+mintNegEx1 :: Value TestCrypto
 mintNegEx1 =
   Value 0 $
     Map.singleton purplePolicyId (Map.singleton plum (-8))
 
-aliceTokensNegEx1 :: Value MaryTest
+aliceTokensNegEx1 :: Value TestCrypto
 aliceTokensNegEx1 =
   Value (unCoin $ aliceCoinsSimpleEx2 <-> feeEx) $
     Map.singleton purplePolicyId (Map.singleton amethyst 2)
@@ -508,12 +510,12 @@ expectedUTxONegEx1 =
 -- Now attempt to produce negative outputs
 --
 
-mintNegEx2 :: Value MaryTest
+mintNegEx2 :: Value TestCrypto
 mintNegEx2 =
   Value 0 $
     Map.singleton purplePolicyId (Map.singleton plum (-9))
 
-aliceTokensNegEx2 :: Value MaryTest
+aliceTokensNegEx2 :: Value TestCrypto
 aliceTokensNegEx2 =
   Value (unCoin $ aliceCoinsSimpleEx2 <-> feeEx) $
     Map.singleton purplePolicyId (Map.fromList [(plum, (-1)), (amethyst, 2)])

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -256,7 +256,7 @@ goldenEncodingTestsAllegra =
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
-          mdh = SMD.hashMetadata $ Metadata Map.empty StrictSeq.empty
+          mdh = SMD.hashMetadata @A $ Metadata Map.empty StrictSeq.empty
        in checkEncodingCBORAnnotated
             "full_txn_body"
             ( TxBody
@@ -389,7 +389,7 @@ goldenEncodingTestsMary =
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
-          mdh = SMD.hashMetadata $ Metadata Map.empty StrictSeq.empty
+          mdh = SMD.hashMetadata @M $ Metadata Map.empty StrictSeq.empty
           mint = Map.singleton policyID1 $ Map.singleton (AssetName assetName1) 13
        in checkEncodingCBORAnnotated
             "full_txn_body"

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
@@ -69,13 +69,13 @@ type family TranslationContext era :: Type
 -- In most cases, the @era@ parameter won't be phantom, and a manual instance
 -- will have to be written:
 --
--- > newtype Bar era = Bar (Addr era)
+-- > newtype Bar era = Bar (TxBody era)
 -- >
 -- > instance CryptoClass.Crypto c => TranslateEra (Allegra c) Bar where
 -- >     translateEra ctxt = Bar <$> translateEra ctxt
 -- >
 -- > -- With the following instance being in scope:
--- > instance CryptoClass.Crypto c => TranslatEra (Allegra c) Addr
+-- > instance CryptoClass.Crypto c => TranslatEra (Allegra c) TxBody
 --
 -- Note: we use 'PreviousEra' instead of @NextEra@ as an era definitely knows
 -- its predecessor, but not necessarily its successor. Moreover, one could argue

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -42,7 +42,7 @@ type instance Core.Value (ShelleyEra _c) = Coin
 
 type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
 
-type instance Core.Script (ShelleyEra c) = MultiSig (ShelleyEra c)
+type instance Core.Script (ShelleyEra c) = MultiSig c
 
 type instance Core.Metadata (ShelleyEra c) = Metadata
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -9,7 +11,9 @@
 module Cardano.Ledger.Shelley where
 
 import Cardano.Binary (toCBOR)
+import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
@@ -58,5 +62,5 @@ instance
   hashScript = hashMultiSigScript
 
 instance CryptoClass.Crypto c => ValidateMetadata (ShelleyEra c) where
-  hashMetadata = MetadataHash . hashWithSerialiser toCBOR
+  hashMetadata = MetadataHash . Hash.castHash . hashWithSerialiser @(HASH c) toCBOR
   validateMetadata (Metadata m) = all validMetadatum m

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -41,7 +41,7 @@ import Shelley.Spec.Ledger.Slot
 translateTxIdByronToShelley ::
   (CC.Crypto c, CC.ADDRHASH c ~ Crypto.Blake2b_224) =>
   Byron.TxId ->
-  TxId (ShelleyEra c)
+  TxId c
 translateTxIdByronToShelley =
   TxId . hashFromShortBytesE . Hashing.abstractHashToShort
 
@@ -65,7 +65,7 @@ translateCompactTxOutByronToShelley (Byron.CompactTxOut compactAddr amount) =
 translateCompactTxInByronToShelley ::
   (CC.Crypto c, CC.ADDRHASH c ~ Crypto.Blake2b_224) =>
   Byron.CompactTxIn ->
-  TxIn (ShelleyEra c)
+  TxIn c
 translateCompactTxInByronToShelley (Byron.CompactTxInUtxo compactTxId idx) =
   TxInCompact
     (translateTxIdByronToShelley (Byron.fromCompactTxId compactTxId))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -109,8 +109,8 @@ getNonMyopicMemberRewards ::
   ShelleyBased era =>
   Globals ->
   NewEpochState era ->
-  Set (Either Coin (Credential 'Staking era)) ->
-  Map (Either Coin (Credential 'Staking era)) (Map (KeyHash 'StakePool (Crypto era)) Coin)
+  Set (Either Coin (Credential 'Staking (Crypto era))) ->
+  Map (Either Coin (Credential 'Staking (Crypto era))) (Map (KeyHash 'StakePool (Crypto era)) Coin)
 getNonMyopicMemberRewards globals ss creds =
   Map.fromList $
     fmap
@@ -166,7 +166,7 @@ getNonMyopicMemberRewards globals ss creds =
 -- When ranking pools, and reporting their saturation level, in the wallet, we
 -- do not want to use one of the regular snapshots, but rather the most recent
 -- ledger state.
-currentSnapshot :: ShelleyBased era => NewEpochState era -> EB.SnapShot era
+currentSnapshot :: ShelleyBased era => NewEpochState era -> EB.SnapShot (Crypto era)
 currentSnapshot ss =
   stakeDistr utxo dstate pstate
   where
@@ -184,7 +184,7 @@ getUTxO = _utxo . _utxoState . esLState . nesEs
 -- | Get the UTxO filtered by address.
 getFilteredUTxO ::
   NewEpochState era ->
-  Set (Addr era) ->
+  Set (Addr (Crypto era)) ->
   UTxO era
 getFilteredUTxO ss addrs =
   UTxO $ Map.filter (\(TxOutCompact addrSBS _) -> addrSBS `Set.member` addrSBSs) fullUTxO
@@ -230,7 +230,7 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
 getPoolParameters ::
   NewEpochState era ->
   KeyHash 'StakePool (Crypto era) ->
-  Maybe (PoolParams era)
+  Maybe (PoolParams (Crypto era))
 getPoolParameters nes poolId = Map.lookup poolId (f nes)
   where
     f = _pParams . _pstate . _delegationState . esLState . nesEs

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -734,14 +734,14 @@ seedEta = mkNonceFromNumber 0
 seedL :: Nonce
 seedL = mkNonceFromNumber 1
 
-hBbsize :: BHBody era -> Natural
+hBbsize :: BHBody crypto -> Natural
 hBbsize = bsize
 
 incrBlocks ::
   Bool ->
-  KeyHash 'StakePool (Crypto era) ->
-  BlocksMade era ->
-  BlocksMade era
+  KeyHash 'StakePool crypto ->
+  BlocksMade crypto ->
+  BlocksMade crypto
 incrBlocks isOverlay hk b'@(BlocksMade b)
   | isOverlay = b'
   | otherwise = BlocksMade $ case hkVal of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -38,7 +38,6 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import qualified Cardano.Ledger.Crypto as CC
-import qualified Cardano.Ledger.Era as ERA
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra
   ( BaseRep (MapR),
@@ -87,45 +86,45 @@ instance
   fromBase x = (PoolDistr x)
 
 -- | Determine the certificate author
-delegCWitness :: DelegCert era -> Credential 'Staking era
+delegCWitness :: DelegCert crypto -> Credential 'Staking crypto
 delegCWitness (RegKey _) = error "no witness in key registration certificate"
 delegCWitness (DeRegKey hk) = hk
 delegCWitness (Delegate delegation) = _delegator delegation
 
-poolCWitness :: PoolCert era -> Credential 'StakePool era
+poolCWitness :: PoolCert crypto -> Credential 'StakePool crypto
 poolCWitness (RegPool pool) = KeyHashObj $ _poolId pool
 poolCWitness (RetirePool k _) = KeyHashObj k
 
-genesisCWitness :: GenesisDelegCert era -> KeyHash 'Genesis (ERA.Crypto era)
+genesisCWitness :: GenesisDelegCert crypto -> KeyHash 'Genesis crypto
 genesisCWitness (GenesisDelegCert gk _ _) = gk
 
--- | Check for `RegKey` constructor
-isRegKey :: DCert era -> Bool
+-- | Check for 'RegKey' constructor
+isRegKey :: DCert crypto -> Bool
 isRegKey (DCertDeleg (RegKey _)) = True
 isRegKey _ = False
 
--- | Check for `DeRegKey` constructor
-isDeRegKey :: DCert era -> Bool
+-- | Check for 'DeRegKey' constructor
+isDeRegKey :: DCert crypto -> Bool
 isDeRegKey (DCertDeleg (DeRegKey _)) = True
 isDeRegKey _ = False
 
--- | Check for `Delegation` constructor
-isDelegation :: DCert era -> Bool
+-- | Check for 'Delegation' constructor
+isDelegation :: DCert crypto -> Bool
 isDelegation (DCertDeleg (Delegate _)) = True
 isDelegation _ = False
 
--- | Check for `GenesisDelegate` constructor
-isGenesisDelegation :: DCert era -> Bool
+-- | Check for 'GenesisDelegate' constructor
+isGenesisDelegation :: DCert crypto -> Bool
 isGenesisDelegation (DCertGenesis (GenesisDelegCert {})) = True
 isGenesisDelegation _ = False
 
--- | Check for `RegPool` constructor
-isRegPool :: DCert era -> Bool
+-- | Check for 'RegPool' constructor
+isRegPool :: DCert crypto -> Bool
 isRegPool (DCertPool (RegPool _)) = True
 isRegPool _ = False
 
--- | Check for `RetirePool` constructor
-isRetirePool :: DCert era -> Bool
+-- | Check for 'RetirePool' constructor
+isRetirePool :: DCert crypto -> Bool
 isRetirePool (DCertPool (RetirePool _ _)) = True
 isRetirePool _ = False
 
@@ -158,22 +157,22 @@ instance CC.Crypto crypto => FromCBOR (IndividualPoolStake crypto) where
         <$> fromCBOR
         <*> fromCBOR
 
-isInstantaneousRewards :: DCert era -> Bool
+isInstantaneousRewards :: DCert crypto -> Bool
 isInstantaneousRewards (DCertMir _) = True
 isInstantaneousRewards _ = False
 
-isReservesMIRCert :: DCert era -> Bool
+isReservesMIRCert :: DCert crypto -> Bool
 isReservesMIRCert (DCertMir (MIRCert ReservesMIR _)) = True
 isReservesMIRCert _ = False
 
-isTreasuryMIRCert :: DCert era -> Bool
+isTreasuryMIRCert :: DCert crypto -> Bool
 isTreasuryMIRCert (DCertMir (MIRCert TreasuryMIR _)) = True
 isTreasuryMIRCert _ = False
 
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure
--- that calling a variant of `cwitness` is safe.
-requiresVKeyWitness :: DCert era -> Bool
+-- that calling a variant of 'cwitness' is safe.
+requiresVKeyWitness :: DCert crypto -> Bool
 requiresVKeyWitness (DCertMir (MIRCert _ _)) = False
 requiresVKeyWitness (DCertDeleg (RegKey _)) = False
 requiresVKeyWitness _ = True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/PoolParams.hs
@@ -7,5 +7,5 @@ import Shelley.Spec.Ledger.BaseTypes (UnitInterval)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.TxBody (PoolParams (..))
 
-poolSpec :: PoolParams era -> (Coin, UnitInterval, Coin)
+poolSpec :: PoolParams crypto -> (Coin, UnitInterval, Coin)
 poolSpec pool = (_poolCost pool, _poolMargin pool, _poolPledge pool)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
@@ -11,6 +11,7 @@ module Shelley.Spec.Ledger.Hashing
     EraIndependentTx,
     EraIndependentTxBody,
     EraIndependentBlockBody,
+    EraIndependentMetadata,
     EraIndependentScript,
   )
 where
@@ -27,6 +28,8 @@ data EraIndependentTx
 data EraIndependentTxBody
 
 data EraIndependentBlockBody
+
+data EraIndependentMetadata
 
 data EraIndependentScript
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Hashing.hs
@@ -11,7 +11,7 @@ module Shelley.Spec.Ledger.Hashing
     EraIndependentTx,
     EraIndependentTxBody,
     EraIndependentBlockBody,
-    EraIndependentWitVKey,
+    EraIndependentScript,
   )
 where
 
@@ -28,7 +28,7 @@ data EraIndependentTxBody
 
 data EraIndependentBlockBody
 
-data EraIndependentWitVKey
+data EraIndependentScript
 
 class Era e => HashAnnotated a e | a -> e where
   type HashIndex a :: Type

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Metadata.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Metadata.hs
@@ -32,7 +32,8 @@ import Cardano.Binary
     withSlice,
   )
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Prelude (cborError)
 import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as CBOR
@@ -44,10 +45,10 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
+import Shelley.Spec.Ledger.Hashing (EraIndependentMetadata)
 import Shelley.Spec.Ledger.Keys (Hash)
 import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
@@ -94,20 +95,19 @@ instance ToCBOR Metadatum where
 instance FromCBOR Metadatum where
   fromCBOR = decodeMetadatum
 
-newtype MetadataHash era = MetadataHash
-  { unsafeMetadataHash :: Hash (Crypto era) (Core.Metadata era)
+newtype MetadataHash crypto = MetadataHash
+  { unsafeMetadataHash :: Hash crypto EraIndependentMetadata
   }
   deriving (Show, Eq, Ord, NoThunks, NFData)
 
 deriving instance
-  (Era era, Typeable (Core.Metadata era)) =>
-  ToCBOR (MetadataHash era)
+  CC.Crypto crypto =>
+  ToCBOR (MetadataHash crypto)
 
 deriving instance
-  (Era era, Typeable (Core.Metadata era)) =>
-  FromCBOR (MetadataHash era)
+  CC.Crypto crypto =>
+  FromCBOR (MetadataHash crypto)
 
---------------------------------------------------------------------------------
 -- Validation of sizes
 
 validMetadatum :: Metadatum -> Bool
@@ -125,7 +125,7 @@ validMetadatum (Map kvs) =
     kvs
 
 class ValidateMetadata era where
-  hashMetadata :: Core.Metadata era -> MetadataHash era
+  hashMetadata :: Core.Metadata era -> MetadataHash (Crypto era)
   validateMetadata :: Core.Metadata era -> Bool
 
 --------------------------------------------------------------------------------

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -64,7 +64,7 @@ import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 data BBODY era
 
 data BbodyState era
-  = BbodyState (LedgerState era) (BlocksMade era)
+  = BbodyState (LedgerState era) (BlocksMade (Crypto era))
 
 deriving stock instance
   ShelleyBased era =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -91,18 +91,18 @@ data DelegEnv = DelegEnv
 
 data DelegPredicateFailure era
   = StakeKeyAlreadyRegisteredDELEG
-      !(Credential 'Staking era) -- Credential which is already registered
+      !(Credential 'Staking (Crypto era)) -- Credential which is already registered
   | -- | Indicates that the stake key is somehow already in the rewards map.
     --   This error is now redundant with StakeKeyAlreadyRegisteredDELEG.
     --   We should remove it and replace its one use with StakeKeyAlreadyRegisteredDELEG.
     StakeKeyInRewardsDELEG
-      !(Credential 'Staking era) -- DEPRECATED, now redundant with StakeKeyAlreadyRegisteredDELEG
+      !(Credential 'Staking (Crypto era)) -- DEPRECATED, now redundant with StakeKeyAlreadyRegisteredDELEG
   | StakeKeyNotRegisteredDELEG
-      !(Credential 'Staking era) -- Credential which is not registered
+      !(Credential 'Staking (Crypto era)) -- Credential which is not registered
   | StakeKeyNonZeroAccountBalanceDELEG
       !(Maybe Coin) -- The remaining reward account balance, if it exists
   | StakeDelegationImpossibleDELEG
-      !(Credential 'Staking era) -- Credential that is not registered
+      !(Credential 'Staking (Crypto era)) -- Credential that is not registered
   | WrongCertificateTypeDELEG -- The DCertPool constructor should not be used by this transition
   | GenesisKeyNotInMappingDELEG
       !(KeyHash 'Genesis (Crypto era)) -- Unknown Genesis KeyHash
@@ -120,8 +120,8 @@ data DelegPredicateFailure era
   deriving (Show, Eq, Generic)
 
 instance Typeable era => STS (DELEG era) where
-  type State (DELEG era) = DState era
-  type Signal (DELEG era) = DCert era
+  type State (DELEG era) = DState (Crypto era)
+  type Signal (DELEG era) = DCert (Crypto era)
   type Environment (DELEG era) = DelegEnv
   type BaseM (DELEG era) = ShelleyBase
   type PredicateFailure (DELEG era) = DelegPredicateFailure era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -23,7 +23,7 @@ import Cardano.Binary
     encodeListLen,
   )
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Era (Crypto, Era)
 import Control.State.Transition
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
@@ -68,8 +68,8 @@ instance
   Era era =>
   STS (DELPL era)
   where
-  type State (DELPL era) = DPState era
-  type Signal (DELPL era) = DCert era
+  type State (DELPL era) = DPState (Crypto era)
+  type Signal (DELPL era) = DCert (Crypto era)
   type Environment (DELPL era) = DelplEnv era
   type BaseM (DELPL era) = ShelleyBase
   type PredicateFailure (DELPL era) = DelplPredicateFailure era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -75,7 +75,7 @@ data LEDGER era
 data LedgerEnv era = LedgerEnv
   { ledgerSlotNo :: SlotNo,
     ledgerIx :: Ix,
-    ledgerPp :: (PParams era),
+    ledgerPp :: PParams era,
     ledgerAccount :: AccountState
   }
   deriving (Show)
@@ -146,15 +146,15 @@ instance
     State (UTXOW era) ~ UTxOState era,
     Signal (UTXOW era) ~ Tx era,
     Environment (DELEGS era) ~ DelegsEnv era,
-    State (DELEGS era) ~ DPState era,
-    Signal (DELEGS era) ~ Seq (DCert era),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    State (DELEGS era) ~ DPState (Crypto era),
+    Signal (DELEGS era) ~ Seq (DCert (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   STS (LEDGER era)
   where
   type
     State (LEDGER era) =
-      (UTxOState era, DPState era)
+      (UTxOState era, DPState (Crypto era))
   type Signal (LEDGER era) = Tx era
   type Environment (LEDGER era) = LedgerEnv era
   type BaseM (LEDGER era) = ShelleyBase
@@ -188,7 +188,7 @@ ledgerTransition ::
     Environment (UTXOW era) ~ UtxoEnv era,
     State (UTXOW era) ~ UTxOState era,
     Signal (UTXOW era) ~ Tx era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   TransitionRule (LEDGER era)
 ledgerTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -15,6 +15,7 @@ module Shelley.Spec.Ledger.STS.Mir
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Val ((<->))
 import Control.SetAlgebra (dom, eval, (∪+), (◁))
 import Control.State.Transition
@@ -111,11 +112,11 @@ mirTransition = do
       rewards = _rewards ds
       reserves = _reserves acnt
       treasury = _treasury acnt
-      irwdR = eval $ (dom rewards) ◁ (iRReserves $ _irwd ds) :: RewardAccounts era
-      irwdT = eval $ (dom rewards) ◁ (iRTreasury $ _irwd ds) :: RewardAccounts era
+      irwdR = eval $ (dom rewards) ◁ (iRReserves $ _irwd ds) :: RewardAccounts (Crypto era)
+      irwdT = eval $ (dom rewards) ◁ (iRTreasury $ _irwd ds) :: RewardAccounts (Crypto era)
       totR = fold irwdR
       totT = fold irwdT
-      update = (eval (irwdR ∪+ irwdT)) :: RewardAccounts era
+      update = (eval (irwdR ∪+ irwdT)) :: RewardAccounts (Crypto era)
 
   if totR <= reserves && totT <= treasury
     then

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -43,7 +43,7 @@ data NEWEPOCH era
 data NewEpochPredicateFailure era
   = EpochFailure (PredicateFailure (EPOCH era)) -- Subtransition Failures
   | CorruptRewardUpdate
-      !(RewardUpdate era) -- The reward update which violates an invariant
+      !(RewardUpdate (Crypto era)) -- The reward update which violates an invariant
   | MirFailure (PredicateFailure (MIR era)) -- Subtransition Failures
   deriving (Generic)
 
@@ -113,7 +113,7 @@ newEpochTransition = do
           SNothing
           pd'
 
-calculatePoolDistr :: SnapShot era -> PoolDistr (Crypto era)
+calculatePoolDistr :: SnapShot crypto -> PoolDistr crypto
 calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
   let Coin total = Map.foldl' (<>) mempty stake
       sd =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -14,6 +14,7 @@ module Shelley.Spec.Ledger.STS.Newpp
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Control.State.Transition
   ( InitialRule,
     STS (..),
@@ -52,7 +53,7 @@ data NewppState era
   = NewppState (UTxOState era) AccountState (PParams era)
 
 data NewppEnv era
-  = NewppEnv (DState era) (PState era)
+  = NewppEnv (DState (Crypto era)) (PState (Crypto era))
 
 data NewppPredicateFailure era
   = UnexpectedDepositPot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -72,9 +72,9 @@ data PoolPredicateFailure era
 instance NoThunks (PoolPredicateFailure era)
 
 instance Typeable era => STS (POOL era) where
-  type State (POOL era) = PState era
+  type State (POOL era) = PState (Crypto era)
 
-  type Signal (POOL era) = DCert era
+  type Signal (POOL era) = DCert (Crypto era)
 
   type Environment (POOL era) = PoolEnv era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -16,6 +16,7 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Control.SetAlgebra (dom, eval, setSingleton, (∈), (∪+), (⋪), (⋫), (▷), (◁))
@@ -53,8 +54,8 @@ data POOLREAP era
 data PoolreapState era = PoolreapState
   { prUTxOSt :: UTxOState era,
     prAcnt :: AccountState,
-    prDState :: DState era,
-    prPState :: PState era
+    prDState :: DState (Crypto era),
+    prPState :: PState (Crypto era)
   }
 
 deriving stock instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -12,6 +12,7 @@ module Shelley.Spec.Ledger.STS.Rupd
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
   ( STS (..),
@@ -46,7 +47,7 @@ import Shelley.Spec.Ledger.Slot
 data RUPD era
 
 data RupdEnv era
-  = RupdEnv (BlocksMade era) (EpochState era)
+  = RupdEnv (BlocksMade (Crypto era)) (EpochState era)
 
 data RupdPredicateFailure era -- No predicate failures
   deriving (Show, Eq, Generic)
@@ -54,7 +55,7 @@ data RupdPredicateFailure era -- No predicate failures
 instance NoThunks (RupdPredicateFailure era)
 
 instance Typeable era => STS (RUPD era) where
-  type State (RUPD era) = StrictMaybe (RewardUpdate era)
+  type State (RUPD era) = StrictMaybe (RewardUpdate (Crypto era))
   type Signal (RUPD era) = SlotNo
   type Environment (RUPD era) = RupdEnv era
   type BaseM (RUPD era) = ShelleyBase

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -13,6 +13,7 @@ module Shelley.Spec.Ledger.STS.Snap
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.State.Transition
   ( STS (..),
@@ -39,7 +40,7 @@ data SnapPredicateFailure era -- No predicate failures
 instance NoThunks (SnapPredicateFailure era)
 
 instance ShelleyBased era => STS (SNAP era) where
-  type State (SNAP era) = SnapShots era
+  type State (SNAP era) = SnapShots (Crypto era)
   type Signal (SNAP era) = ()
   type Environment (SNAP era) = LedgerState era
   type BaseM (SNAP era) = ShelleyBase

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -628,7 +628,7 @@ data TxBodyRaw era = TxBodyRaw
     _txfeeX :: !Coin,
     _ttlX :: !SlotNo,
     _txUpdateX :: !(StrictMaybe (Update era)),
-    _mdHashX :: !(StrictMaybe (MetadataHash era))
+    _mdHashX :: !(StrictMaybe (MetadataHash (Crypto era)))
   }
   deriving (Generic, NoThunks, Typeable)
 
@@ -739,7 +739,7 @@ pattern TxBody ::
   Coin ->
   SlotNo ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetadataHash era) ->
+  StrictMaybe (MetadataHash (Crypto era)) ->
   TxBody era
 pattern TxBody {_inputs, _outputs, _certs, _wdrls, _txfee, _ttl, _txUpdate, _mdHash} <-
   TxBodyConstr
@@ -790,7 +790,7 @@ instance HasField "ttl" (TxBody era) SlotNo where
 instance HasField "update" (TxBody era) (StrictMaybe (Update era)) where
   getField (TxBodyConstr (Memo m _)) = getField @"_txUpdateX" m
 
-instance HasField "mdHash" (TxBody era) (StrictMaybe (MetadataHash era)) where
+instance Crypto era ~ crypto => HasField "mdHash" (TxBody era) (StrictMaybe (MetadataHash crypto)) where
   getField (TxBodyConstr (Memo m _)) = getField @"_mdHashX" m
 
 -- ===============================================================

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -21,8 +21,8 @@ import Cardano.Crypto.DSIGN
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import Cardano.Crypto.VRF.Praos
-import Cardano.Ledger.Crypto (Crypto (..))
 import qualified Cardano.Ledger.Crypto as CryptoClass
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Control.DeepSeq (NFData)
@@ -165,7 +165,7 @@ profileUTxO = do
 -- ==========================================
 -- Registering Stake Keys
 
-touchDPState :: DPState era -> Int
+touchDPState :: DPState crypto -> Int
 touchDPState (DPState _x _y) = 1
 
 touchUTxOState :: Shelley.Spec.Ledger.LedgerState.UTxOState cryto -> Int
@@ -226,7 +226,10 @@ epochAt x =
         [ bench "Using maps" (whnf action2m arg)
         ]
 
-action2m :: ShelleyTest era => (DState era, PState era, UTxO era) -> EB.SnapShot era
+action2m ::
+  ShelleyTest era =>
+  (DState (Crypto era), PState (Crypto era), UTxO era) ->
+  EB.SnapShot (Crypto era)
 action2m (dstate, pstate, utxo) = stakeDistr utxo dstate pstate
 
 -- =================================================================

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Shelley.Spec.Ledger.Bench.Rewards
@@ -11,7 +12,6 @@ module Shelley.Spec.Ledger.Bench.Rewards
 where
 
 import Cardano.Crypto.VRF (hashVerKeyVRF)
-import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Slotting.EpochInfo
 import Cardano.Slotting.Slot (EpochNo)
 import Control.Monad.Reader (runReader, runReaderT)
@@ -41,7 +41,7 @@ import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState, chainNes, totalAda)
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxOut (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
 import Test.QuickCheck (Gen)
-import Test.Shelley.Spec.Ledger.BenchmarkFunctions (B)
+import Test.Shelley.Spec.Ledger.BenchmarkFunctions (B, B_Crypto)
 import Test.Shelley.Spec.Ledger.Generator.Block (genBlockWithTxGen)
 import Test.Shelley.Spec.Ledger.Generator.Constants
   ( maxGenesisUTxOouts,
@@ -160,7 +160,7 @@ genChainInEpoch epoch = do
         go !acc [] = acc
         go !acc xs' = let (a, b) = splitAt n xs' in go (a : acc) b
 
-    addrToKeyHash :: Addr era -> Maybe (KeyHash 'Staking (Crypto era))
+    addrToKeyHash :: Addr crypto -> Maybe (KeyHash 'Staking crypto)
     addrToKeyHash (Addr _ _ (StakeRefBase (KeyHashObj kh))) = Just kh
     addrToKeyHash _ = Nothing
 
@@ -168,7 +168,7 @@ genChainInEpoch epoch = do
 createRUpd ::
   Globals ->
   ChainState B ->
-  LS.RewardUpdate B
+  LS.RewardUpdate B_Crypto
 createRUpd globals cs =
   runIdentity $
     runReaderT

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -84,7 +84,7 @@ genBlock ::
     GetLedgerView era,
     ValidateMetadata era,
     ShelleyLedgerSTS era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   GenEnv era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -74,7 +74,7 @@ class
     Wdrl (Crypto era) ->
     Coin ->
     StrictMaybe (Update era) ->
-    StrictMaybe (MetadataHash era) ->
+    StrictMaybe (MetadataHash (Crypto era)) ->
     Gen (Core.TxBody era)
 
   -- | Generate era-specific metadata

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -68,10 +68,10 @@ class
   genEraTxBody ::
     GenEnv era ->
     SlotNo ->
-    Set (TxIn era) ->
+    Set (TxIn (Crypto era)) ->
     StrictSeq (TxOut era) ->
-    StrictSeq (DCert era) ->
-    Wdrl era ->
+    StrictSeq (DCert (Crypto era)) ->
+    Wdrl (Crypto era) ->
     Coin ->
     StrictMaybe (Update era) ->
     StrictMaybe (MetadataHash era) ->
@@ -84,7 +84,7 @@ class
   updateEraTxBody ::
     Core.TxBody era ->
     Coin ->
-    Set (TxIn era) ->
+    Set (TxIn (Crypto era)) ->
     StrictSeq (TxOut era) ->
     Core.TxBody era
 
@@ -106,15 +106,17 @@ genUtxo0 ge@(GenEnv _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
       (fmap (toAddr Testnet) genesisKeys ++ fmap (scriptsToAddr' Testnet) genesisScripts)
   return (genesisCoins genesisId outs)
   where
-    scriptsToAddr' :: Network -> (Core.Script era, Core.Script era) -> Addr era
+    scriptsToAddr' :: Network -> (Core.Script era, Core.Script era) -> Addr (Crypto era)
     scriptsToAddr' n (payScript, stakeScript) =
       Addr n (scriptToCred' payScript) (StakeRefBase $ scriptToCred' stakeScript)
-    scriptToCred' = ScriptHashObj . hashScript
+
+    scriptToCred' :: Core.Script era -> Credential kr (Crypto era)
+    scriptToCred' = ScriptHashObj . hashScript @era
 
 -- | We share this dummy TxId as genesis transaction id across eras
 genesisId ::
-  Hash.HashAlgorithm (CC.HASH (Crypto era)) =>
-  TxId era
+  Hash.HashAlgorithm (CC.HASH crypto) =>
+  TxId crypto
 genesisId = TxId (mkDummyHash 0)
   where
     mkDummyHash :: forall h a. Hash.HashAlgorithm h => Int -> Hash.Hash h a

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
@@ -159,23 +159,25 @@ mkScripts ::
 mkScripts = map (mkScriptsFromKeyPair @era)
 
 mkPayScriptHashMap ::
+  forall era.
   (ScriptClass era) =>
   [(Core.Script era, Core.Script era)] ->
-  Map.Map (ScriptHash era) (Core.Script era, Core.Script era)
+  Map.Map (ScriptHash (Crypto era)) (Core.Script era, Core.Script era)
 mkPayScriptHashMap scripts =
   Map.fromList (f <$> scripts)
   where
-    f script@(pay, _stake) = (hashScript pay, script)
+    f script@(pay, _stake) = (hashScript @era pay, script)
 
 -- | Generate a mapping from stake script hash to script pair.
 mkStakeScriptHashMap ::
+  forall era.
   (ScriptClass era) =>
   [(Core.Script era, Core.Script era)] ->
-  Map.Map (ScriptHash era) (Core.Script era, Core.Script era)
+  Map.Map (ScriptHash (Crypto era)) (Core.Script era, Core.Script era)
 mkStakeScriptHashMap scripts =
   Map.fromList (f <$> scripts)
   where
-    f script@(_pay, stake) = (hashScript stake, script)
+    f script@(_pay, stake) = (hashScript @era stake, script)
 
 -- | Combine a list of script pairs into hierarchically structured multi-sig
 -- scripts, list must have at least length 3. Be careful not to call with too

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -87,7 +87,7 @@ genTxBody ::
   Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe (MetadataHash era) ->
+  StrictMaybe (MetadataHash (Crypto era)) ->
   Gen (TxBody era)
 genTxBody slot inputs outputs certs wdrls fee update mdHash = do
   ttl <- genTimeToLive slot

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -11,6 +11,7 @@
 module Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen (genCoin) where
 
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Data.Sequence.Strict (StrictSeq)
@@ -80,10 +81,10 @@ instance CC.Crypto c => ScriptClass (ShelleyEra c) where
 genTxBody ::
   (ShelleyBased era) =>
   SlotNo ->
-  Set (TxIn era) ->
+  Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
-  StrictSeq (DCert era) ->
-  Wdrl era ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
   Coin ->
   StrictMaybe (Update era) ->
   StrictMaybe (MetadataHash era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -81,7 +81,7 @@ instance
     ShelleyLedgerSTS era,
     ShelleyChainSTS era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   HasTrace (CHAIN era) (GenEnv era)
@@ -160,11 +160,11 @@ mkOCertIssueNos (GenDelegs delegs0) =
 --
 -- This allows stake pools to produce blocks from genesis.
 registerGenesisStaking ::
-  forall c.
-  ShelleyTest c =>
-  ShelleyGenesisStaking c ->
-  ChainState c ->
-  ChainState c
+  forall era.
+  ShelleyTest era =>
+  ShelleyGenesisStaking (Crypto era) ->
+  ChainState era ->
+  ChainState era
 registerGenesisStaking
   ShelleyGenesisStaking {sgsPools, sgsStake}
   cs@(STS.ChainState {chainNes = oldChainNes}) =
@@ -207,7 +207,7 @@ registerGenesisStaking
       -- about updating the '_delegations' field.
       --
       -- See STS DELEG for details
-      newDState :: DState c
+      newDState :: DState (Crypto era)
       newDState =
         (_dstate oldDPState)
           { _rewards =
@@ -219,7 +219,7 @@ registerGenesisStaking
 
       -- We consider pools as having been registered in slot 0
       -- See STS POOL for details
-      newPState :: PState c
+      newPState :: PState (Crypto era)
       newPState =
         (_pstate oldDPState)
           { _pParams = sgsPools
@@ -229,7 +229,7 @@ registerGenesisStaking
       -- during the previous epoch. We create a "fake" snapshot in order to
       -- establish an initial stake distribution.
       initSnapShot =
-        stakeDistr @c
+        stakeDistr @era
           (_utxo . _utxoState . esLState $ oldEpochState)
           newDState
           newPState

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -83,8 +83,8 @@ data CertsPredicateFailure era
 
 instance Era era => STS (CERTS era) where
   type Environment (CERTS era) = (SlotNo, Ix, PParams era, AccountState)
-  type State (CERTS era) = (DPState era, Ix)
-  type Signal (CERTS era) = Maybe (DCert era, CertCred era)
+  type State (CERTS era) = (DPState (Crypto era), Ix)
+  type Signal (CERTS era) = Maybe (DCert (Crypto era), CertCred era)
   type PredicateFailure (CERTS era) = CertsPredicateFailure era
 
   type BaseM (CERTS era) = ShelleyBase
@@ -143,15 +143,15 @@ genDCerts ::
   EraGen era =>
   GenEnv era ->
   PParams era ->
-  DPState era ->
+  DPState (Crypto era) ->
   SlotNo ->
   Natural ->
   AccountState ->
   Gen
-    ( StrictSeq (DCert era),
+    ( StrictSeq (DCert (Crypto era)),
       Coin,
       Coin,
-      DPState era,
+      DPState (Crypto era),
       ([KeyPair 'Witness (Crypto era)], [(Core.Script era, Core.Script era)])
     )
 genDCerts

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -71,7 +71,7 @@ instance
     Mock (Crypto era),
     ValidateMetadata era,
     ShelleyLedgerSTS era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   TQC.HasTrace (LEDGER era) (GenEnv era)
@@ -95,7 +95,7 @@ instance
     Mock (Crypto era),
     ValidateMetadata era,
     ShelleyLedgerSTS era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   TQC.HasTrace (LEDGERS era) (GenEnv era)
@@ -119,9 +119,9 @@ instance
       pure $ Seq.fromList (reverse txs') -- reverse Newest first to Oldest first
       where
         genAndApplyTx ::
-          (UTxOState era, DPState era, [Tx era]) ->
+          (UTxOState era, DPState (Crypto era), [Tx era]) ->
           Ix ->
-          Gen (UTxOState era, DPState era, [Tx era])
+          Gen (UTxOState era, DPState (Crypto era), [Tx era])
         genAndApplyTx (u, dp, txs) ix = do
           let ledgerEnv = LedgerEnv slotNo ix pParams reserves
           tx <- genTx ge ledgerEnv (u, dp)
@@ -152,7 +152,7 @@ mkGenesisLedgerState ::
   EraGen era =>
   GenEnv era ->
   IRC (LEDGER era) ->
-  Gen (Either a (UTxOState era, DPState era))
+  Gen (Either a (UTxOState era, DPState (Crypto era)))
 mkGenesisLedgerState ge@(GenEnv _ c) _ = do
   utxo0 <- genUtxo0 ge
   let (LedgerState utxoSt dpSt) = genesisState (genesisDelegs0 c) utxo0

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -277,7 +277,7 @@ genUpdate ::
   [(GenesisKeyPair (Crypto era), AllIssuerKeys (Crypto era) 'GenesisDelegate)] ->
   Map (KeyHash 'GenesisDelegate (Crypto era)) (AllIssuerKeys (Crypto era) 'GenesisDelegate) ->
   PParams era ->
-  (UTxOState era, DPState era) ->
+  (UTxOState era, DPState (Crypto era)) ->
   Gen (Maybe (Update era), [KeyPair 'Witness (Crypto era)])
 genUpdate
   c@(Constants {frequencyTxUpdates})

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -263,7 +263,7 @@ genTx
           (Wdrl (Map.fromList wdrls))
           draftFee
           (maybeToStrictMaybe update)
-          (hashMetadata <$> metadata)
+          (hashMetadata @era <$> metadata)
       let draftTx = Tx draftTxBody (mkTxWits' draftTxBody) metadata
       -- We add now repeatedly add inputs until the process converges.
       converge

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -113,15 +114,15 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, Split (..))
 
 showBalance ::
   ( ShelleyTest era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   LedgerEnv era ->
   UTxOState era ->
-  DPState era ->
+  DPState (Crypto era) ->
   Tx era ->
   String
 showBalance
@@ -158,12 +159,12 @@ genTx ::
     EraGen era,
     ValidateMetadata era,
     Mock (Crypto era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   GenEnv era ->
   LedgerEnv era ->
-  (UTxOState era, DPState era) ->
+  (UTxOState era, DPState (Crypto era)) ->
   Gen (Tx era)
 genTx
   ge@( GenEnv
@@ -193,6 +194,7 @@ genTx
           utxo
       (wdrls, (wdrlWits, wdrlScripts)) <-
         genWithdrawals
+          @era
           constants
           ksIndexedStakeScripts
           ksIndexedStakingKeys
@@ -212,7 +214,7 @@ genTx
       -- Gather Key Witnesses and Scripts, prepare a constructor for Tx Wits
       -------------------------------------------------------------------------
       let wits = spendWits ++ wdrlWits ++ certWits ++ updateWits
-          scripts = mkScriptWits spendScripts (certScripts ++ wdrlScripts)
+          scripts = mkScriptWits @era spendScripts (certScripts ++ wdrlScripts)
           mkTxWits' =
             mkTxWits ksIndexedPaymentKeys ksIndexedStakingKeys wits scripts
               . hashAnnotated
@@ -239,7 +241,7 @@ genTx
       -- to cover the deposits. In this case we discard the test case.
       !_ <- when (coin spendingBalance <= Coin 0) discard
       outputAddrs <-
-        genRecipients (length inputs + n) ksKeyPairs ksMSigScripts
+        genRecipients @era (length inputs + n) ksKeyPairs ksMSigScripts
           >>= genPtrAddrs (_dstate dpState')
       -------------------------------------------------------------------------
       -- Build a Draft Tx and repeatedly add to Delta until all fees are
@@ -252,7 +254,7 @@ genTx
               outputAddrs
               draftFee
       draftTxBody <-
-        genEraTxBody @era
+        genEraTxBody
           ge
           slot
           (Set.fromList inputs)
@@ -279,7 +281,7 @@ genTx
 -- the transaction balance.
 data Delta era = Delta
   { dfees :: Coin,
-    extraInputs :: Set.Set (TxIn era),
+    extraInputs :: Set.Set (TxIn (Crypto era)),
     extraWitnesses :: WitnessSet era,
     change :: TxOut era,
     deltaVKeys :: [KeyPair 'Witness (Crypto era)],
@@ -298,7 +300,7 @@ instance ShelleyBased era => Eq (Delta era) where
       -- equality, at least in the use case below.
       && change a == change b
 
-deltaZero :: ShelleyBased era => Coin -> Coin -> Addr era -> Delta era
+deltaZero :: ShelleyBased era => Coin -> Coin -> Addr (Crypto era) -> Delta era
 deltaZero initialfee minAda addr =
   Delta
     (initialfee <-> minAda)
@@ -314,7 +316,7 @@ genNextDelta ::
   forall era.
   ( EraGen era,
     Mock (Crypto era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era))
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   UTxO era ->
   PParams era ->
@@ -390,7 +392,7 @@ genNextDelta
                         ksIndexedPaymentKeys
                         ksIndexedStakingKeys
                         vkeyPairs
-                        (mkScriptWits msigPairs mempty)
+                        (mkScriptWits @era msigPairs mempty)
                         (hashAnnotated $ _body tx)
                 pure $
                   delta
@@ -414,9 +416,10 @@ genNextDelta
 -- genNextDelta repeatedly until genNextDelta delta = delta
 
 genNextDeltaTilFixPoint ::
+  forall era.
   ( EraGen era,
     Mock (Crypto era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era))
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   Coin ->
   KeyPairs (Crypto era) ->
@@ -427,7 +430,7 @@ genNextDeltaTilFixPoint ::
   Tx era ->
   Gen (Delta era)
 genNextDeltaTilFixPoint initialfee keys scripts utxo pparams keySpace tx = do
-  addr <- genRecipients 1 keys scripts
+  addr <- genRecipients @era 1 keys scripts
   fix
     (genNextDelta utxo pparams keySpace tx)
     (deltaZero initialfee (safetyOffset <+> _minUTxOValue pparams) (head addr))
@@ -436,13 +439,14 @@ genNextDeltaTilFixPoint initialfee keys scripts utxo pparams keySpace tx = do
     safetyOffset = Coin 5
 
 applyDelta ::
+  forall era.
   ( EraGen era,
     Mock (Crypto era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   [KeyPair 'Witness (Crypto era)] ->
-  Map (ScriptHash era) (Core.Script era) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
   KeySpace era ->
   Tx era ->
   Delta era ->
@@ -463,7 +467,7 @@ applyDelta
             (getField @"inputs" body <> extraIn)
             outputs'
         kw = neededKeys <> extraKeys
-        sw = neededScripts <> mkScriptWits extraScripts mempty
+        sw = neededScripts <> mkScriptWits @era extraScripts mempty
         newWitnessSet =
           mkTxWits
             ksIndexedPaymentKeys
@@ -479,12 +483,12 @@ fix f d = do d1 <- f d; if d1 == d then pure d else fix f d1
 converge ::
   ( EraGen era,
     Mock (Crypto era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   Coin ->
   [KeyPair 'Witness (Crypto era)] ->
-  Map (ScriptHash era) (Core.Script era) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
   KeyPairs (Crypto era) ->
   [(Core.Script era, Core.Script era)] ->
   UTxO era ->
@@ -519,7 +523,7 @@ mkScriptWits ::
   EraGen era =>
   [(Core.Script era, Core.Script era)] ->
   [(Core.Script era, Core.Script era)] ->
-  Map (ScriptHash era) (Core.Script era)
+  Map (ScriptHash (Crypto era)) (Core.Script era)
 mkScriptWits payScripts stakeScripts =
   Map.fromList $
     (hashPayScript <$> payScripts)
@@ -527,14 +531,15 @@ mkScriptWits payScripts stakeScripts =
   where
     hashPayScript ::
       (Core.Script era, Core.Script era) ->
-      (ScriptHash era, Core.Script era)
+      (ScriptHash (Crypto era), Core.Script era)
     hashPayScript (payScript, _) =
-      (hashScript payScript :: ScriptHash era, payScript)
+      (hashScript @era payScript, payScript)
+
     hashStakeScript ::
       (Core.Script era, Core.Script era) ->
-      (ScriptHash era, Core.Script era)
+      (ScriptHash (Crypto era), Core.Script era)
     hashStakeScript (_, sScript) =
-      (hashScript sScript :: ScriptHash era, sScript)
+      (hashScript @era sScript, sScript)
 
 mkTxWits ::
   forall era.
@@ -544,7 +549,7 @@ mkTxWits ::
   Map (KeyHash 'Payment (Crypto era)) (KeyPair 'Payment (Crypto era)) ->
   Map (KeyHash 'Staking (Crypto era)) (KeyPair 'Staking (Crypto era)) ->
   [KeyPair 'Witness (Crypto era)] ->
-  Map (ScriptHash era) (Core.Script era) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
   Hash (Crypto era) EraIndependentTxBody ->
   WitnessSet era
 mkTxWits
@@ -593,7 +598,7 @@ calcOutputsFromBalance ::
     Split (Core.Value era)
   ) =>
   Core.Value era ->
-  [Addr era] ->
+  [Addr (Crypto era)] ->
   Coin ->
   (Coin, StrictSeq (TxOut era))
 calcOutputsFromBalance balance_ addrs fee =
@@ -622,10 +627,10 @@ genInputs ::
   (ShelleyBased era) =>
   (Int, Int) ->
   Map (KeyHash 'Payment (Crypto era)) (KeyPair 'Payment (Crypto era)) ->
-  Map (ScriptHash era) (Core.Script era, Core.Script era) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era, Core.Script era) ->
   UTxO era ->
   Gen
-    ( [TxIn era],
+    ( [TxIn (Crypto era)],
       Core.Value era,
       ([KeyPair 'Witness (Crypto era)], [(Core.Script era, Core.Script era)])
     )
@@ -641,19 +646,20 @@ genInputs (minNumGenInputs, maxNumGenInputs) keyHashMap payScriptMap (UTxO utxo)
     )
   where
     witnessedInput (input, TxOut addr@(Addr _ (KeyHashObj _) _) _) =
-      (input, Left . asWitness $ findPayKeyPairAddr addr keyHashMap)
+      (input, Left . asWitness $ findPayKeyPairAddr @era addr keyHashMap)
     witnessedInput (input, TxOut addr@(Addr _ (ScriptHashObj _) _) _) =
-      (input, Right $ findPayScriptFromAddr addr payScriptMap)
+      (input, Right $ findPayScriptFromAddr @era addr payScriptMap)
     witnessedInput _ = error "unsupported address"
 
 -- | Select a subset of the reward accounts to use for reward withdrawals.
 genWithdrawals ::
+  forall era.
   Constants ->
-  Map (ScriptHash era) (Core.Script era, Core.Script era) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era, Core.Script era) ->
   Map (KeyHash 'Staking (Crypto era)) (KeyPair 'Staking (Crypto era)) ->
-  Map (Credential 'Staking era) Coin ->
+  Map (Credential 'Staking (Crypto era)) Coin ->
   Gen
-    ( [(RewardAcnt era, Coin)],
+    ( [(RewardAcnt (Crypto era), Coin)],
       ([KeyPair 'Witness (Crypto era)], [(Core.Script era, Core.Script era)])
     )
 genWithdrawals
@@ -684,7 +690,7 @@ genWithdrawals
       genWrdls wdrls_ = do
         selectedWrdls <- map toRewardAcnt <$> QC.sublistOf wdrls_
         let wits =
-              mkWdrlWits ksIndexedStakeScripts ksIndexedStakingKeys
+              mkWdrlWits @era ksIndexedStakeScripts ksIndexedStakingKeys
                 . getRwdCred
                 . fst
                 <$> selectedWrdls
@@ -692,26 +698,28 @@ genWithdrawals
 
 -- | Collect witnesses needed for reward withdrawals.
 mkWdrlWits ::
-  Map (ScriptHash era) (Core.Script era, Core.Script era) ->
+  forall era.
+  Map (ScriptHash (Crypto era)) (Core.Script era, Core.Script era) ->
   Map (KeyHash 'Staking (Crypto era)) (KeyPair 'Staking (Crypto era)) ->
-  Credential 'Staking era ->
+  Credential 'Staking (Crypto era) ->
   Either (KeyPair 'Witness (Crypto era)) (Core.Script era, Core.Script era)
 mkWdrlWits scriptsByStakeHash _ c@(ScriptHashObj _) =
   Right $
-    findStakeScriptFromCred (asWitness c) scriptsByStakeHash
+    findStakeScriptFromCred @era (asWitness c) scriptsByStakeHash
 mkWdrlWits _ keyHashMap c@(KeyHashObj _) =
   Left $
     asWitness $
-      findPayKeyPairCred c keyHashMap
+      findPayKeyPairCred @era c keyHashMap
 
 -- | Select recipient addresses that will serve as output targets for a new
 -- transaction.
 genRecipients ::
+  forall era.
   EraGen era =>
   Int ->
   KeyPairs (Crypto era) ->
   [(Core.Script era, Core.Script era)] ->
-  Gen [Addr era]
+  Gen [Addr (Crypto era)]
 genRecipients len keys scripts = do
   n' <-
     QC.frequency
@@ -741,9 +749,10 @@ genRecipients len keys scripts = do
 
   return (zipWith (Addr Testnet) payCreds stakeCreds')
   where
-    scriptToCred' = ScriptHashObj . hashScript
+    scriptToCred' :: Core.Script era -> Credential kr (Crypto era)
+    scriptToCred' = ScriptHashObj . hashScript @era
 
-genPtrAddrs :: DState h -> [Addr h] -> Gen [Addr h]
+genPtrAddrs :: DState crypto -> [Addr crypto] -> Gen [Addr crypto]
 genPtrAddrs ds addrs = do
   let pointers = forwards (_ptrs ds)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -84,7 +84,7 @@ import Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..))
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
 import Shelley.Spec.Ledger.LedgerState
-  ( FutureGenDeleg
+  ( FutureGenDeleg,
   )
 import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.Rewards
@@ -351,7 +351,7 @@ instance Arbitrary ProtVer where
 instance CC.Crypto crypto => Arbitrary (ScriptHash crypto) where
   arbitrary = ScriptHash <$> genHash
 
-instance Era era => Arbitrary (MD.MetadataHash era) where
+instance CC.Crypto crypto => Arbitrary (MD.MetadataHash crypto) where
   arbitrary = MD.MetadataHash <$> genHash
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -84,8 +84,7 @@ import Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..))
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
 import Shelley.Spec.Ledger.LedgerState
-  ( FutureGenDeleg,
-    emptyRewardUpdate,
+  ( FutureGenDeleg
   )
 import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.Rewards
@@ -188,10 +187,7 @@ instance DSIGNAlgorithm crypto => Arbitrary (VerKeyDSIGN crypto) where
     fromJust . rawDeserialiseVerKeyDSIGN
       <$> (genByteString . fromIntegral $ sizeVerKeyDSIGN (Proxy @crypto))
 
-instance
-  (Era era, MockGen era) =>
-  Arbitrary (BootstrapWitness era)
-  where
+instance CC.Crypto crypto => Arbitrary (BootstrapWitness crypto) where
   arbitrary = do
     key <- arbitrary
     sig <- genSignature
@@ -205,13 +201,13 @@ instance CC.Crypto crypto => Arbitrary (HashHeader crypto) where
 instance CC.Crypto crypto => Arbitrary (HashBBody crypto) where
   arbitrary = UnsafeHashBBody <$> genHash
 
-instance (Typeable kr, Era era, Mock (Crypto era)) => Arbitrary (WitVKey kr era) where
+instance (Typeable kr, CC.Crypto crypto) => Arbitrary (WitVKey kr crypto) where
   arbitrary =
     WitVKey
       <$> arbitrary
       <*> arbitrary
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (Wdrl era) where
+instance CC.Crypto crypto => Arbitrary (Wdrl crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -257,10 +253,10 @@ instance Arbitrary MD.Metadata where
 maxTxWits :: Int
 maxTxWits = 5
 
-instance Era era => Arbitrary (TxId era) where
+instance CC.Crypto crypto => Arbitrary (TxId crypto) where
   arbitrary = TxId <$> genHash
 
-instance Era era => Arbitrary (TxIn era) where
+instance CC.Crypto crypto => Arbitrary (TxIn crypto) where
   arbitrary =
     TxIn
       <$> (TxId <$> genHash)
@@ -282,13 +278,10 @@ instance Arbitrary Nonce where
 instance Arbitrary UnitInterval where
   arbitrary = fromJust . mkUnitInterval . (% 100) <$> choose (1, 99)
 
-instance
-  (CC.Crypto crypto) =>
-  Arbitrary (KeyHash a crypto)
-  where
+instance CC.Crypto crypto => Arbitrary (KeyHash a crypto) where
   arbitrary = KeyHash <$> genHash
 
-instance Era era => Arbitrary (WitHashes era) where
+instance CC.Crypto crypto => Arbitrary (WitHashes crypto) where
   arbitrary = genericArbitraryU
 
 instance Arbitrary MIRPot where
@@ -317,20 +310,20 @@ instance Arbitrary EpochNo where
   -- Cannot be negative even though it is an 'Integer'
   arbitrary = EpochNo <$> choose (1, 100000)
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (Addr era) where
+instance CC.Crypto crypto => Arbitrary (Addr crypto) where
   arbitrary = oneof [genShelleyAddress, genByronAddress]
 
-genShelleyAddress :: (Era era, Mock (Crypto era)) => Gen (Addr era)
+genShelleyAddress :: CC.Crypto crypto => Gen (Addr crypto)
 genShelleyAddress = Addr <$> arbitrary <*> arbitrary <*> arbitrary
 
-genByronAddress :: Gen (Addr era)
+genByronAddress :: Gen (Addr crypto)
 genByronAddress = AddrBootstrap <$> genBootstrapAddress
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (StakeReference era) where
+instance CC.Crypto crypto => Arbitrary (StakeReference crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Era era => Arbitrary (Credential r era) where
+instance CC.Crypto crypto => Arbitrary (Credential r crypto) where
   arbitrary =
     oneof
       [ ScriptHashObj . ScriptHash <$> genHash,
@@ -341,7 +334,7 @@ instance Arbitrary Ptr where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (RewardAcnt era) where
+instance CC.Crypto crypto => Arbitrary (RewardAcnt crypto) where
   arbitrary = RewardAcnt <$> arbitrary <*> arbitrary
 
 instance Arbitrary Network where
@@ -355,7 +348,7 @@ instance Arbitrary ProtVer where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Era era => Arbitrary (ScriptHash era) where
+instance CC.Crypto crypto => Arbitrary (ScriptHash crypto) where
   arbitrary = ScriptHash <$> genHash
 
 instance Era era => Arbitrary (MD.MetadataHash era) where
@@ -379,27 +372,27 @@ instance
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (PState era) where
+instance CC.Crypto crypto => Arbitrary (PState crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (InstantaneousRewards era) where
+instance CC.Crypto crypto => Arbitrary (InstantaneousRewards crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Mock crypto) => Arbitrary (FutureGenDeleg crypto) where
+instance CC.Crypto crypto => Arbitrary (FutureGenDeleg crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Mock crypto) => Arbitrary (GenDelegs crypto) where
+instance CC.Crypto crypto => Arbitrary (GenDelegs crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Mock crypto) => Arbitrary (GenDelegPair crypto) where
+instance CC.Crypto crypto => Arbitrary (GenDelegPair crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (DState era) where
+instance CC.Crypto crypto => Arbitrary (DState crypto) where
   arbitrary =
     DState
       <$> arbitrary
@@ -409,27 +402,27 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (DState era) where
       <*> arbitrary
       <*> arbitrary
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (DelegCert era) where
+instance CC.Crypto crypto => Arbitrary (DelegCert crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (Delegation era) where
+instance CC.Crypto crypto => Arbitrary (Delegation crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (PoolCert era) where
+instance CC.Crypto crypto => Arbitrary (PoolCert crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (GenesisDelegCert era) where
+instance CC.Crypto crypto => Arbitrary (GenesisDelegCert crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (MIRCert era) where
+instance CC.Crypto crypto => Arbitrary (MIRCert crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (DCert era) where
+instance CC.Crypto crypto => Arbitrary (DCert crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -437,7 +430,7 @@ instance (Era era, Mock (Crypto era)) => Arbitrary (PPUPState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (DPState era) where
+instance CC.Crypto crypto => Arbitrary (DPState crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -462,7 +455,7 @@ instance
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Era era => Arbitrary (BlocksMade era) where
+instance CC.Crypto crypto => Arbitrary (BlocksMade crypto) where
   arbitrary = BlocksMade <$> arbitrary
 
 instance CC.Crypto crypto => Arbitrary (PoolDistr crypto) where
@@ -485,8 +478,9 @@ instance
       <*> genPParams (Proxy @era)
       <*> arbitrary
 
-instance Arbitrary (RewardUpdate era) where
-  arbitrary = return emptyRewardUpdate
+instance CC.Crypto crypto => Arbitrary (RewardUpdate crypto) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
 
 instance Arbitrary a => Arbitrary (StrictMaybe a) where
   arbitrary = genericArbitraryU
@@ -511,25 +505,25 @@ instance Arbitrary Likelihood where
 instance Arbitrary LogWeight where
   arbitrary = LogWeight <$> arbitrary
 
-instance Era era => Arbitrary (NonMyopic era) where
+instance CC.Crypto crypto => Arbitrary (NonMyopic crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (SnapShot era) where
+instance CC.Crypto crypto => Arbitrary (SnapShot crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (SnapShots era) where
+instance CC.Crypto crypto => Arbitrary (SnapShots crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance Arbitrary PerformanceEstimate where
   arbitrary = PerformanceEstimate <$> arbitrary
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (Stake era) where
+instance CC.Crypto crypto => Arbitrary (Stake crypto) where
   arbitrary = Stake <$> arbitrary
 
-instance (Era era, Mock (Crypto era)) => Arbitrary (PoolParams era) where
+instance CC.Crypto crypto => Arbitrary (PoolParams crypto) where
   arbitrary =
     PoolParams
       <$> arbitrary
@@ -578,7 +572,7 @@ maxMultiSigDepth = 3
 maxMultiSigListLens :: Int
 maxMultiSigListLens = 5
 
-sizedMultiSig :: Era era => Int -> Gen (MultiSig era)
+sizedMultiSig :: CC.Crypto crypto => Int -> Gen (MultiSig crypto)
 sizedMultiSig 0 = RequireSignature <$> arbitrary
 sizedMultiSig n =
   oneof
@@ -588,10 +582,7 @@ sizedMultiSig n =
       RequireMOf <$> arbitrary <*> resize maxMultiSigListLens (listOf (sizedMultiSig (n -1)))
     ]
 
-instance
-  (Era era, Mock (Crypto era)) =>
-  Arbitrary (MultiSig era)
-  where
+instance CC.Crypto crypto => Arbitrary (MultiSig crypto) where
   arbitrary = sizedMultiSig maxMultiSigDepth
 
 -- |
@@ -647,7 +638,7 @@ instance
       <*> (mscriptsToWits <$> arbitrary)
       <*> arbitrary
     where
-      mscriptsToWits = Map.fromList . map (\s -> (hashScript s, s))
+      mscriptsToWits = Map.fromList . map (\s -> (hashScript @era s, s))
 
 instance Era era => Arbitrary (STS.PpupPredicateFailure era) where
   arbitrary = genericArbitraryU
@@ -699,8 +690,7 @@ instance
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (UTXO era)),
-    Arbitrary (WitHashes era)
+    Arbitrary (STS.PredicateFailure (UTXO era))
   ) =>
   Arbitrary (STS.UtxowPredicateFailure era)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Bootstrap.hs
@@ -31,6 +31,6 @@ genSignature =
     . DSIGN.rawDeserialiseSigDSIGN
     <$> hedgehog (genBytes . fromIntegral $ DSIGN.sizeSigDSIGN ([] @a))
 
-genBootstrapAddress :: Gen (BootstrapAddress era)
+genBootstrapAddress :: Gen (BootstrapAddress crypto)
 genBootstrapAddress = BootstrapAddress <$> hedgehog Byron.genAddress
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators/Genesis.hs
@@ -66,17 +66,17 @@ genShelleyGenesis =
     <*> fmap Map.fromList genFundsList
     <*> genStaking
 
-genStaking :: Era era => Gen (ShelleyGenesisStaking era)
+genStaking :: CC.Crypto crypto => Gen (ShelleyGenesisStaking crypto)
 genStaking =
   ShelleyGenesisStaking
     <$> fmap Map.fromList genPools
     <*> fmap Map.fromList genStake
 
 genPools ::
-  Era era =>
+  CC.Crypto crypto =>
   Gen
-    [ ( KeyHash 'StakePool (Crypto era),
-        PoolParams era
+    [ ( KeyHash 'StakePool crypto,
+        PoolParams crypto
       )
     ]
 genPools =
@@ -94,11 +94,11 @@ genStake =
   Gen.list (Range.linear 1 10) $
     (,) <$> genKeyHash <*> genKeyHash
 
-genPoolParams :: forall era. Era era => Gen (PoolParams era)
+genPoolParams :: forall crypto. CC.Crypto crypto => Gen (PoolParams crypto)
 genPoolParams =
   PoolParams
     <$> genKeyHash
-    <*> genVRFKeyHash @(Crypto era)
+    <*> genVRFKeyHash @crypto
     <*> genCoin
     <*> genCoin
     <*> genUnitInterval
@@ -141,10 +141,10 @@ genUrl = do
     Nothing -> error "wrong generator for Url"
     Just url -> return url
 
-genRewardAcnt :: Era era => Gen (RewardAcnt era)
+genRewardAcnt :: CC.Crypto crypto => Gen (RewardAcnt crypto)
 genRewardAcnt = RewardAcnt Testnet <$> genCredential
 
-genCredential :: Era era => Gen (Credential 'Staking era)
+genCredential :: CC.Crypto crypto => Gen (Credential 'Staking crypto)
 genCredential =
   Gen.choice
     [ ScriptHashObj . ScriptHash <$> genHash,
@@ -240,7 +240,7 @@ genVRFKeyPair = do
   where
     seedSize = fromIntegral (seedSizeVRF (Proxy :: Proxy (VRF crypto)))
 
-genFundsList :: Era era => Gen [(Addr era, Coin)]
+genFundsList :: CC.Crypto crypto => Gen [(Addr crypto, Coin)]
 genFundsList = Gen.list (Range.linear 1 100) genGenesisFundPair
 
 genSeed :: Int -> Gen Seed
@@ -275,11 +275,11 @@ genKeyPair = do
             )
         )
 
-genGenesisFundPair :: Era era => Gen (Addr era, Coin)
+genGenesisFundPair :: CC.Crypto crypto => Gen (Addr crypto, Coin)
 genGenesisFundPair =
   (,) <$> genAddress <*> genCoin
 
-genAddress :: Era era => Gen (Addr era)
+genAddress :: CC.Crypto crypto => Gen (Addr crypto)
 genAddress = do
   (secKey1, verKey1) <- genKeyPair
   (secKey2, verKey2) <- genKeyPair

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Shrinkers.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Shrinkers.hs
@@ -88,7 +88,7 @@ shrinkTxBody (TxBody is os@((:<|) (TxOut a vs) _) cs ws tf tl tu md) =
 outputBalance :: ShelleyTest era => StrictSeq (TxOut era) -> Core.Value era
 outputBalance = foldl' (\v (TxOut _ c) -> v <+> c) mempty
 
-shrinkTxIn :: TxIn era -> [TxIn era]
+shrinkTxIn :: TxIn crypto -> [TxIn crypto]
 shrinkTxIn = const []
 
 shrinkTxOut :: ShelleyTest era => TxOut era -> [TxOut era]
@@ -101,13 +101,13 @@ shrinkTxOut (TxOut addr vl) =
 shrinkCoin :: Coin -> [Coin]
 shrinkCoin (Coin x) = Coin <$> shrinkIntegral x
 
-shrinkDCert :: DCert era -> [DCert era]
+shrinkDCert :: DCert crypto -> [DCert crypto]
 shrinkDCert = const []
 
-shrinkWdrl :: Wdrl era -> [Wdrl era]
+shrinkWdrl :: Wdrl crypto -> [Wdrl crypto]
 shrinkWdrl (Wdrl m) = Wdrl <$> shrinkMap shrinkRewardAcnt shrinkCoin m
 
-shrinkRewardAcnt :: RewardAcnt era -> [RewardAcnt era]
+shrinkRewardAcnt :: RewardAcnt crypto -> [RewardAcnt crypto]
 shrinkRewardAcnt = const []
 
 shrinkSlotNo :: SlotNo -> [SlotNo]
@@ -116,13 +116,13 @@ shrinkSlotNo (SlotNo x) = SlotNo <$> shrinkIntegral x
 shrinkUpdate :: Update era -> [Update era]
 shrinkUpdate = const []
 
-shrinkWitVKey :: WitVKey kr era -> [WitVKey kr era]
+shrinkWitVKey :: WitVKey kr crypto -> [WitVKey kr crypto]
 shrinkWitVKey = const []
 
-shrinkScriptHash :: ScriptHash era -> [ScriptHash era]
+shrinkScriptHash :: ScriptHash crypto -> [ScriptHash crypto]
 shrinkScriptHash = const []
 
-shrinkMultiSig :: MultiSig era -> [MultiSig era]
+shrinkMultiSig :: MultiSig crypto -> [MultiSig crypto]
 shrinkMultiSig = const []
 
 shrinkSet :: Ord a => (a -> [a]) -> Set a -> [Set a]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -73,6 +73,7 @@ import Cardano.Crypto.VRF
 import qualified Cardano.Crypto.VRF as VRF
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Prelude (Coercible, asks)
@@ -148,7 +149,7 @@ import Test.Tasty.HUnit
 type ShelleyTest era =
   ( ShelleyBased era,
     TxBody era ~ Core.TxBody era,
-    Core.Script era ~ MultiSig era,
+    Core.Script era ~ MultiSig (Crypto era),
     Split (Core.Value era),
     HashIndex (Core.TxBody era) ~ EraIndependentTxBody
   )
@@ -175,7 +176,7 @@ type ShelleyLedgerSTS era =
   ( STS (LEDGER era),
     BaseM (LEDGER era) ~ ShelleyBase,
     Environment (LEDGER era) ~ LedgerEnv era,
-    State (LEDGER era) ~ (UTxOState era, DPState era),
+    State (LEDGER era) ~ (UTxOState era, DPState (Crypto era)),
     Signal (LEDGER era) ~ Tx era,
     STS (LEDGERS era),
     BaseM (LEDGERS era) ~ ShelleyBase,
@@ -268,9 +269,9 @@ mkKESKeyPair seed =
    in (sk, deriveVerKeyKES sk)
 
 mkAddr ::
-  Era era =>
-  (KeyPair 'Payment (Crypto era), KeyPair 'Staking (Crypto era)) ->
-  Addr era
+  CC.Crypto crypto =>
+  (KeyPair 'Payment crypto, KeyPair 'Staking crypto) ->
+  Addr crypto
 mkAddr (payKey, stakeKey) =
   Addr
     Testnet

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -114,7 +114,7 @@ bootstrapHashTest = testProperty "rebuild the 'addr root' using a bootstrap witn
     sig <- genSignature
     let addr = BootstrapAddress byronAddr
         (shelleyVKey, chainCode) = unpackByronVKey @C_crypto byronVKey
-        witness :: BootstrapWitness C
+        witness :: BootstrapWitness C_crypto
         witness =
           BootstrapWitness
             { bwKey = shelleyVKey,
@@ -123,7 +123,7 @@ bootstrapHashTest = testProperty "rebuild the 'addr root' using a bootstrap witn
               bwAttributes = serialize' $ Byron.addrAttributes byronAddr
             }
     pure $
-      (coerceKeyRole $ bootstrapKeyHash @C addr)
+      (coerceKeyRole $ bootstrapKeyHash @C_crypto addr)
         === bootstrapWitKeyHash witness
 
 genSignature :: forall a b. DSIGN.DSIGNAlgorithm a => Gen (DSIGN.SignedDSIGN a b)
@@ -133,7 +133,7 @@ genSignature =
     . DSIGN.rawDeserialiseSigDSIGN
     <$> hedgehog (genBytes . fromIntegral $ DSIGN.sizeSigDSIGN ([] @a))
 
-genBootstrapAddress :: Gen (BootstrapAddress era)
+genBootstrapAddress :: Gen (BootstrapAddress crypto)
 genBootstrapAddress = BootstrapAddress . snd <$> genByronVKeyAddr
 
 genByronVKeyAddr :: Gen (Byron.VerificationKey, Byron.Address)
@@ -211,24 +211,24 @@ aliceByronAddr = Byron.makeAddress asd attrs
         (Byron.NetworkTestnet 0)
     byronVerificationKey = Byron.toVerification aliceSigningKey
 
-aliceAddr :: Addr C
+aliceAddr :: Addr C_crypto
 aliceAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
 
-aliceWitness :: BootstrapWitness C
+aliceWitness :: BootstrapWitness C_crypto
 aliceWitness =
   makeBootstrapWitness
     (hashAnnotated txBody)
     aliceSigningKey
     (Byron.addrAttributes aliceByronAddr)
 
-aliceBadWitness :: BootstrapWitness C
+aliceBadWitness :: BootstrapWitness C_crypto
 aliceBadWitness =
   makeBootstrapWitness
     (hashAnnotated txBody {_ttl = SlotNo 100000000})
     aliceSigningKey
     (Byron.addrAttributes aliceByronAddr)
 
-bobAddr :: Addr C
+bobAddr :: Addr C_crypto
 bobAddr = Addr Testnet (KeyHashObj k) StakeRefNull
   where
     k = coerceKeyRole $ hashKey aliceVKey

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/ByronTranslation.hs
@@ -56,7 +56,7 @@ translateTxOutByronToShelley (Byron.TxOut addr amount) =
     translateAmount :: Byron.Lovelace -> Coin
     translateAmount = Coin . Byron.lovelaceToInteger
 
-    translateAddr :: Byron.Address -> Addr era
+    translateAddr :: Byron.Address -> Addr crypto
     translateAddr = AddrBootstrap . BootstrapAddress
 
 {------------------------------------------------------------------------------

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Cast.hs
@@ -39,7 +39,6 @@ module Test.Shelley.Spec.Ledger.Examples.Cast
 where
 
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Era
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -106,26 +105,26 @@ alicePoolKeys =
     (skCold, vkCold) = mkKeyPair (1, 0, 0, 0, 1)
 
 -- | Alice's base address
-aliceAddr :: Era era => Addr era
+aliceAddr :: CC.Crypto crypto => Addr crypto
 aliceAddr = mkAddr (alicePay, aliceStake)
 
-alicePHK :: Era era => Credential 'Payment era
+alicePHK :: CC.Crypto crypto => Credential 'Payment crypto
 alicePHK = (KeyHashObj . hashKey . vKey) alicePay
 
 -- | Alice's stake credential
-aliceSHK :: Era era => Credential 'Staking era
+aliceSHK :: CC.Crypto crypto => Credential 'Staking crypto
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 -- | Alice's base address
-alicePtrAddr :: Era era => Addr era
+alicePtrAddr :: CC.Crypto crypto => Addr crypto
 alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) 0 0)
 
 -- | Alice's stake pool parameters
-alicePoolParams :: forall era. Era era => PoolParams era
+alicePoolParams :: forall crypto. CC.Crypto crypto => PoolParams crypto
 alicePoolParams =
   PoolParams
     { _poolId = (hashKey . vKey . cold) alicePoolKeys,
-      _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @(Crypto era)),
+      _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @crypto),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,
       _poolMargin = unsafeMkUnitInterval 0.1,
@@ -160,11 +159,11 @@ bobStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (3, 3, 3, 3, 3)
 
 -- | Bob's address
-bobAddr :: Era era => Addr era
+bobAddr :: CC.Crypto crypto => Addr crypto
 bobAddr = mkAddr (bobPay, bobStake)
 
 -- | Bob's stake credential
-bobSHK :: Era era => Credential 'Staking era
+bobSHK :: CC.Crypto crypto => Credential 'Staking crypto
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
 -- | Bob's stake pool keys (cold keys, VRF keys, hot KES keys)
@@ -179,11 +178,11 @@ bobPoolKeys =
     (skCold, vkCold) = mkKeyPair (2, 0, 0, 0, 1)
 
 -- | Bob's stake pool parameters
-bobPoolParams :: forall era. Era era => PoolParams era
+bobPoolParams :: forall crypto. CC.Crypto crypto => PoolParams crypto
 bobPoolParams =
   PoolParams
     { _poolId = (hashKey . vKey . cold) bobPoolKeys,
-      _poolVrf = hashVerKeyVRF . snd $ vrf (bobPoolKeys @(Crypto era)),
+      _poolVrf = hashVerKeyVRF . snd $ vrf (bobPoolKeys @crypto),
       _poolPledge = Coin 2,
       _poolCost = Coin 1,
       _poolMargin = unsafeMkUnitInterval 0.1,
@@ -213,11 +212,11 @@ carlStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (5, 5, 5, 5, 5)
 
 -- | Carl's address
-carlAddr :: Era era => Addr era
+carlAddr :: CC.Crypto crypto => Addr crypto
 carlAddr = mkAddr (carlPay, carlStake)
 
 -- | Carl's stake credential
-carlSHK :: Era era => Credential 'Staking era
+carlSHK :: CC.Crypto crypto => Credential 'Staking crypto
 carlSHK = (KeyHashObj . hashKey . vKey) carlStake
 
 -- | Daria's payment key pair
@@ -233,9 +232,9 @@ dariaStake = KeyPair vk sk
     (sk, vk) = mkKeyPair (7, 7, 7, 7, 7)
 
 -- | Daria's address
-dariaAddr :: Era era => Addr era
+dariaAddr :: CC.Crypto crypto => Addr crypto
 dariaAddr = mkAddr (dariaPay, dariaStake)
 
 -- | Daria's stake credential
-dariaSHK :: Era era => Credential 'Staking era
+dariaSHK :: CC.Crypto crypto => Credential 'Staking crypto
 dariaSHK = (KeyHashObj . hashKey . vKey) dariaStake

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -174,7 +175,7 @@ feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
 newUTxO ::
   forall era.
   ( ShelleyBased era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>
   Core.TxBody era ->
@@ -187,7 +188,7 @@ newUTxO txb cs = cs {chainNes = nes'}
     ls = esLState es
     utxoSt = _utxoState ls
     utxo = _utxo utxoSt
-    utxo' = eval ((txins txb ⋪ utxo) ∪ txouts txb)
+    utxo' = eval ((txins @era txb ⋪ utxo) ∪ txouts txb)
     utxoSt' = utxoSt {_utxo = utxo'}
     ls' = ls {_utxoState = utxoSt'}
     es' = es {esLState = ls'}
@@ -198,7 +199,7 @@ newUTxO txb cs = cs {chainNes = nes'}
 -- Add a newly registered stake credential
 newStakeCred ::
   forall era.
-  Credential 'Staking era ->
+  Credential 'Staking (Crypto era) ->
   Ptr ->
   ChainState era ->
   ChainState era
@@ -224,7 +225,7 @@ newStakeCred cred ptr cs = cs {chainNes = nes'}
 -- De-register a stake credential and all associated data.
 deregStakeCred ::
   forall era.
-  Credential 'Staking era ->
+  Credential 'Staking (Crypto era) ->
   ChainState era ->
   ChainState era
 deregStakeCred cred cs = cs {chainNes = nes'}
@@ -251,7 +252,7 @@ deregStakeCred cred cs = cs {chainNes = nes'}
 -- stake pool.
 delegation ::
   forall era.
-  Credential 'Staking era ->
+  Credential 'Staking (Crypto era) ->
   KeyHash 'StakePool (Crypto era) ->
   ChainState era ->
   ChainState era
@@ -276,7 +277,7 @@ delegation cred pool cs = cs {chainNes = nes'}
 -- Add a newly registered stake pool
 newPool ::
   forall era.
-  PoolParams era ->
+  PoolParams (Crypto era) ->
   ChainState era ->
   ChainState era
 newPool pool cs = cs {chainNes = nes'}
@@ -298,7 +299,7 @@ newPool pool cs = cs {chainNes = nes'}
 -- | = Re-Register Stake Pool
 reregPool ::
   forall era.
-  PoolParams era ->
+  PoolParams (Crypto era) ->
   ChainState era ->
   ChainState era
 reregPool pool cs = cs {chainNes = nes'}
@@ -320,7 +321,7 @@ reregPool pool cs = cs {chainNes = nes'}
 -- | = Re-Register Stake Pool
 updatePoolParams ::
   forall era.
-  PoolParams era ->
+  PoolParams (Crypto era) ->
   ChainState era ->
   ChainState era
 updatePoolParams pool cs = cs {chainNes = nes'}
@@ -367,7 +368,7 @@ stageRetirement kh e cs = cs {chainNes = nes'}
 -- Remove a stake pool.
 reapPool ::
   forall era.
-  PoolParams era ->
+  PoolParams (Crypto era) ->
   ChainState era ->
   ChainState era
 reapPool pool cs = cs {chainNes = nes'}
@@ -409,7 +410,7 @@ reapPool pool cs = cs {chainNes = nes'}
 -- Add a credential to the MIR mapping for the given pot (reserves or treasury)
 mir ::
   forall era.
-  Credential 'Staking era ->
+  Credential 'Staking (Crypto era) ->
   MIRPot ->
   Coin ->
   ChainState era ->
@@ -440,7 +441,7 @@ mir cred pot amnt cs = cs {chainNes = nes'}
 applyMIR ::
   forall era.
   MIRPot ->
-  Map (Credential 'Staking era) Coin ->
+  Map (Credential 'Staking (Crypto era)) Coin ->
   ChainState era ->
   ChainState era
 applyMIR pot rewards cs = cs {chainNes = nes'}
@@ -471,7 +472,7 @@ applyMIR pot rewards cs = cs {chainNes = nes'}
 -- Update the chain state with the given reward update
 rewardUpdate ::
   forall era.
-  RewardUpdate era ->
+  RewardUpdate (Crypto era) ->
   ChainState era ->
   ChainState era
 rewardUpdate ru cs = cs {chainNes = nes'}
@@ -483,7 +484,7 @@ rewardUpdate ru cs = cs {chainNes = nes'}
 -- Apply the given reward update to the chain state
 applyRewardUpdate ::
   forall era.
-  RewardUpdate era ->
+  RewardUpdate (Crypto era) ->
   ChainState era ->
   ChainState era
 applyRewardUpdate ru cs = cs {chainNes = nes'}
@@ -497,7 +498,7 @@ applyRewardUpdate ru cs = cs {chainNes = nes'}
 -- Add a new snapshot and rotate the others
 newSnapshot ::
   forall era.
-  SnapShot era ->
+  SnapShot (Crypto era) ->
   Coin ->
   ChainState era ->
   ChainState era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -121,7 +121,7 @@ initStMIR treasury = cs {chainNes = (chainNes cs) {nesEs = es'}}
 aliceMIRCoin :: Coin
 aliceMIRCoin = Coin 100
 
-ir :: Era era => Map (Credential 'Staking era) Coin
+ir :: CryptoClass.Crypto c => Map (Credential 'Staking c) Coin
 ir = Map.fromList [(Cast.aliceSHK, aliceMIRCoin)]
 
 feeTx1 :: Coin

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -323,8 +323,8 @@ expectedStEx2 =
     . C.newLab blockEx2
     . C.feesAndDeposits feeTx2 (Coin 0)
     . C.newUTxO txbodyEx2
-    . C.delegation Cast.aliceSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
-    . C.delegation Cast.bobSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
+    . C.delegation Cast.aliceSHK (_poolId $ Cast.alicePoolParams @c)
+    . C.delegation Cast.bobSHK (_poolId $ Cast.alicePoolParams @c)
     . C.rewardUpdate emptyRewardUpdate
     $ expectedStEx1
 
@@ -356,7 +356,7 @@ blockEx3 =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110) 0 (KESPeriod 0))
 
-snapEx3 :: Era era => EB.SnapShot era
+snapEx3 :: Cr.Crypto c => EB.SnapShot c
 snapEx3 =
   EB.SnapShot
     { EB._stake =
@@ -443,7 +443,7 @@ blockEx4 =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 190) 0 (KESPeriod 0))
 
-rewardUpdateEx4 :: forall c. RewardUpdate (ShelleyEra c)
+rewardUpdateEx4 :: forall c. RewardUpdate c
 rewardUpdateEx4 =
   RewardUpdate
     { deltaT = DeltaCoin 1,
@@ -462,7 +462,7 @@ expectedStEx4 =
     . C.newLab blockEx4
     . C.feesAndDeposits feeTx4 (Coin 0)
     . C.newUTxO txbodyEx4
-    . C.delegation Cast.carlSHK (_poolId $ Cast.alicePoolParams @(ShelleyEra c))
+    . C.delegation Cast.carlSHK (_poolId $ Cast.alicePoolParams @c)
     . C.rewardUpdate rewardUpdateEx4
     $ expectedStEx3
 
@@ -498,7 +498,7 @@ blockEx5 =
     10
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 220) 1 (KESPeriod 10))
 
-snapEx5 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
+snapEx5 :: forall c. Cr.Crypto c => EB.SnapShot c
 snapEx5 =
   EB.SnapShot
     { EB._stake =
@@ -564,7 +564,7 @@ blockEx6 =
     14
     (mkOCert Cast.alicePoolKeys 0 (KESPeriod 14))
 
-rewardUpdateEx6 :: forall c. RewardUpdate (ShelleyEra c)
+rewardUpdateEx6 :: forall c. RewardUpdate c
 rewardUpdateEx6 =
   RewardUpdate
     { deltaT = DeltaCoin 1,
@@ -677,13 +677,13 @@ alicePerfEx8 = likelihood blocks t (epochSize $ EpochNo 3)
     relativeStake = fromRational (stake % tot)
     f = activeSlotCoeff testGlobals
 
-nonMyopicEx8 :: forall era. Era era => NonMyopic era
+nonMyopicEx8 :: forall c. Cr.Crypto c => NonMyopic c
 nonMyopicEx8 =
   NonMyopic
     (Map.singleton (hk Cast.alicePoolKeys) alicePerfEx8)
     rewardPot8
 
-rewardUpdateEx8 :: forall era. Era era => RewardUpdate era
+rewardUpdateEx8 :: forall c. Cr.Crypto c => RewardUpdate c
 rewardUpdateEx8 =
   RewardUpdate
     { deltaT = deltaT8,
@@ -737,7 +737,7 @@ blockEx9 =
     20
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 410) 2 (KESPeriod 20))
 
-snapEx9 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
+snapEx9 :: forall c. Cr.Crypto c => EB.SnapShot c
 snapEx9 =
   snapEx5
     { EB._stake =
@@ -899,13 +899,13 @@ alicePerfEx11 = applyDecay decayFactor alicePerfEx8 <> epoch4Likelihood
     (Coin supply) = maxLLSupply <-> reserves12
     f = activeSlotCoeff testGlobals
 
-nonMyopicEx11 :: forall c. Cr.Crypto c => NonMyopic (ShelleyEra c)
+nonMyopicEx11 :: forall c. Cr.Crypto c => NonMyopic c
 nonMyopicEx11 =
   NonMyopic
     (Map.singleton (hk Cast.alicePoolKeys) (alicePerfEx11 @c))
     (Coin 0)
 
-rewardUpdateEx11 :: forall c. Cr.Crypto c => RewardUpdate (ShelleyEra c)
+rewardUpdateEx11 :: forall c. Cr.Crypto c => RewardUpdate c
 rewardUpdateEx11 =
   RewardUpdate
     { deltaT = DeltaCoin 0,
@@ -955,7 +955,7 @@ blockEx12 =
     25
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 510) 3 (KESPeriod 25))
 
-snapEx12 :: forall c. Cr.Crypto c => EB.SnapShot (ShelleyEra c)
+snapEx12 :: forall c. Cr.Crypto c => EB.SnapShot c
 snapEx12 =
   snapEx9
     { EB._stake =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -171,7 +171,7 @@ feeTx2 = Coin 3
 aliceCoinEx2 :: Coin
 aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 
-newPoolParams :: (Cr.Crypto c) => PoolParams (ShelleyEra c)
+newPoolParams :: Cr.Crypto c => PoolParams c
 newPoolParams = Cast.alicePoolParams {_poolCost = Coin 500}
 
 txbodyEx2 :: Cr.Crypto c => TxBody (ShelleyEra c)
@@ -286,7 +286,7 @@ blockEx3 =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110) 0 (KESPeriod 0))
 
-snapEx3 :: (Cr.Crypto c) => SnapShot (ShelleyEra c)
+snapEx3 :: Cr.Crypto c => SnapShot c
 snapEx3 =
   emptySnapShot {_poolParams = Map.singleton (hk Cast.alicePoolKeys) Cast.alicePoolParams}
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -101,7 +101,7 @@ aliceStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair @crypto (0, 0, 0, 0, 1)
 
-aliceSHK :: forall c. Era (ShelleyEra c) => Credential 'Staking (ShelleyEra c)
+aliceSHK :: forall crypto. Cr.Crypto crypto => Credential 'Staking crypto
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 alicePool :: forall crypto. Cr.Crypto crypto => KeyPair 'StakePool crypto
@@ -115,11 +115,11 @@ alicePoolKH = (hashKey . vKey) alicePool
 aliceVRF :: forall v. VRFAlgorithm v => (VRF.SignKeyVRF v, VRF.VerKeyVRF v)
 aliceVRF = mkVRFKeyPair (0, 0, 0, 0, 3)
 
-alicePoolParams :: forall c. Era (ShelleyEra c) => PoolParams (ShelleyEra c)
+alicePoolParams :: forall crypto. Cr.Crypto crypto => PoolParams crypto
 alicePoolParams =
   PoolParams
     { _poolId = alicePoolKH,
-      _poolVrf = hashVerKeyVRF . snd $ aliceVRF @(Cr.VRF (Crypto (ShelleyEra c))),
+      _poolVrf = hashVerKeyVRF . snd $ aliceVRF @(Cr.VRF crypto),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,
       _poolMargin = unsafeMkUnitInterval 0.1,
@@ -137,7 +137,7 @@ alicePoolParams =
             }
     }
 
-aliceAddr :: forall c. Era (ShelleyEra c) => Addr (ShelleyEra c)
+aliceAddr :: forall crypto. Cr.Crypto crypto => Addr crypto
 aliceAddr = mkAddr (alicePay, aliceStake)
 
 bobPay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
@@ -150,10 +150,10 @@ bobStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair @crypto (1, 0, 0, 0, 1)
 
-bobSHK :: forall c. Era (ShelleyEra c) => Credential 'Staking (ShelleyEra c)
+bobSHK :: forall crypto. Cr.Crypto crypto => Credential 'Staking crypto
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
-bobAddr :: forall c. Era (ShelleyEra c) => Addr (ShelleyEra c)
+bobAddr :: forall crypto. Cr.Crypto crypto => Addr crypto
 bobAddr = mkAddr (bobPay, bobStake)
 
 carlPay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
@@ -293,7 +293,7 @@ txDelegateStake =
           { addrWits =
               makeWitnessesVKey
                 (hashAnnotated $ txbDelegateStake @c)
-                [asWitness (alicePay), asWitness bobStake]
+                [asWitness alicePay, asWitness bobStake]
           },
       _metadata = SNothing
     }
@@ -421,11 +421,11 @@ txWithMDBytes16 :: BSL.ByteString
 txWithMDBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a074a4eece6527f366cfa5e71a10081824873ed39075e40d2a65010b0506a2911469873ed39075e40d2a6a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
-msig :: forall c. Era (ShelleyEra c) => MultiSig (ShelleyEra c)
+msig :: forall crypto. Cr.Crypto crypto => MultiSig crypto
 msig =
   RequireMOf
     2
-    [ (RequireSignature . asWitness . hashKey . vKey) (alicePay),
+    [ (RequireSignature . asWitness . hashKey . vKey) alicePay,
       (RequireSignature . asWitness . hashKey . vKey) bobPay,
       (RequireSignature . asWitness . hashKey . vKey) carlPay
     ]
@@ -484,7 +484,7 @@ txWithWithdrawal =
           { addrWits =
               makeWitnessesVKey
                 (hashAnnotated $ txbWithWithdrawal @c)
-                [asWitness (alicePay), asWitness aliceStake]
+                [asWitness alicePay, asWitness aliceStake]
           },
       _metadata = SNothing
     }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -393,7 +393,7 @@ txRetirePoolBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c15
 md :: MD.Metadata
 md = MD.Metadata $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 
-txbWithMD :: Cr.Crypto c => TxBody (ShelleyEra c)
+txbWithMD :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbWithMD =
   TxBody
     { _inputs = Set.fromList [TxIn genesisId 0],
@@ -403,7 +403,7 @@ txbWithMD =
       _txfee = Coin 94,
       _ttl = SlotNo 10,
       _txUpdate = SNothing,
-      _mdHash = SJust $ MD.hashMetadata md
+      _mdHash = SJust $ MD.hashMetadata @(ShelleyEra c) md
     }
 
 txWithMD :: forall c. (Cr.Crypto c, BodySignable (ShelleyEra c)) => Tx (ShelleyEra c)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -67,7 +67,7 @@ minimalPropertyTests ::
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash (Crypto era))),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
   TestTree
@@ -102,7 +102,7 @@ propertyTests ::
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash (Crypto era))),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
   TestTree

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -15,6 +15,7 @@ module Test.Shelley.Spec.Ledger.PropertyTests
 where
 
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto)
 import Data.Proxy
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -61,11 +62,11 @@ minimalPropertyTests ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
@@ -79,10 +80,10 @@ minimalPropertyTests =
       bootstrapHashTest,
       testGroup
         "Compact Address Tests"
-        [ TQC.testProperty "Compact address round trip" (propCompactAddrRoundTrip @era),
-          TQC.testProperty "Compact address binary representation" (propCompactSerializationAgree @era),
-          TQC.testProperty "determining address type doesn't force contents" (propDecompactAddrLazy @era),
-          TQC.testProperty "reading the keyhash doesn't force the stake reference" (propDecompactShelleyLazyAddr @era)
+        [ TQC.testProperty "Compact address round trip" (propCompactAddrRoundTrip @(Crypto era)),
+          TQC.testProperty "Compact address binary representation" (propCompactSerializationAgree @(Crypto era)),
+          TQC.testProperty "determining address type doesn't force contents" (propDecompactAddrLazy @(Crypto era)),
+          TQC.testProperty "reading the keyhash doesn't force the stake reference" (propDecompactShelleyLazyAddr @(Crypto era))
         ],
       TQC.testProperty "legacy overlay schedule" (legacyOverlayTest p)
     ]
@@ -96,11 +97,11 @@ propertyTests ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -110,7 +110,7 @@ relevantCasesAreCovered ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash (Crypto era)))
   ) =>
   Property
 relevantCasesAreCovered = do
@@ -131,7 +131,7 @@ relevantCasesAreCoveredForTrace ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash (Crypto era)))
   ) =>
   Trace (CHAIN era) ->
   Property
@@ -295,7 +295,7 @@ hasPParamUpdate tx =
 hasMetadata ::
   ( TxBodyConstraints era,
     ToCBOR (Core.Metadata era),
-    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
+    HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash (Crypto era)))
   ) =>
   Tx era ->
   Bool

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -21,7 +21,7 @@ where
 
 import Cardano.Binary (ToCBOR, serialize')
 import qualified Cardano.Ledger.Core as Core (Metadata, TxBody)
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased, TxBodyConstraints)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Control.State.Transition.Trace
@@ -105,10 +105,10 @@ relevantCasesAreCovered ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
     HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
   ) =>
@@ -128,8 +128,8 @@ relevantCasesAreCoveredForTrace ::
   forall era.
   ( ChainProperty era,
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (PParams.Update era)),
     HasField "mdHash" (Core.TxBody era) (StrictMaybe (MetadataHash era))
   ) =>
@@ -213,7 +213,7 @@ relevantCasesAreCoveredForTrace tr = do
 
 -- | Ratio of certificates with script credentials to the number of certificates
 -- that could have script credentials.
-scriptCredentialCertsRatio :: [DCert era] -> Double
+scriptCredentialCertsRatio :: [DCert crypto] -> Double
 scriptCredentialCertsRatio certs =
   ratioInt haveScriptCerts couldhaveScriptCerts
   where
@@ -242,10 +242,10 @@ certsByTx ::
   forall era.
   ( TxBodyConstraints era,
     ToCBOR (Core.Metadata era),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   [Tx era] ->
-  [[DCert era]]
+  [[DCert (Crypto era)]]
 certsByTx txs = toList . (getField @"certs") . _body <$> txs
 
 ratioInt :: Int -> Int -> Double
@@ -274,7 +274,7 @@ txScriptOutputsRatio txoutsList =
 hasWithdrawal ::
   ( TxBodyConstraints era,
     ToCBOR (Core.Metadata era),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Tx era ->
   Bool
@@ -310,10 +310,10 @@ onlyValidLedgerSignalsAreGenerated ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 onlyValidLedgerSignalsAreGenerated =
@@ -332,10 +332,10 @@ propAbstractSizeBoundsBytes ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 propAbstractSizeBoundsBytes = property $ do
@@ -357,10 +357,10 @@ propAbstractSizeNotTooBig ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 propAbstractSizeNotTooBig = property $ do
@@ -387,10 +387,10 @@ onlyValidChainSignalsAreGenerated ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 onlyValidChainSignalsAreGenerated =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -22,6 +22,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestChain
 where
 
 import qualified Cardano.Ledger.Core as Core (TxBody)
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
 import qualified Cardano.Ledger.Val as Val (coin)
@@ -115,10 +116,10 @@ collisionFreeComplete ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 collisionFreeComplete =
@@ -140,11 +141,11 @@ adaPreservationChain ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 adaPreservationChain =
@@ -197,7 +198,7 @@ checkPreservation SourceSignalTarget {source, target} =
 -- then the total rewards should change only by withdrawals
 checkWithdrawlBound ::
   ( ChainProperty era,
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -228,7 +229,7 @@ checkWithdrawlBound SourceSignalTarget {source, signal, target} =
 utxoDepositsIncreaseByFeesWithdrawals ::
   ( ChainProperty era,
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -245,7 +246,7 @@ utxoDepositsIncreaseByFeesWithdrawals SourceSignalTarget {source, signal, target
 -- increases by sum of withdrawals for all transactions in a block
 potsSumIncreaseWdrlsPerBlock ::
   ( ChainProperty era,
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -262,8 +263,8 @@ potsSumIncreaseWdrlsPerBlock SourceSignalTarget {source, signal, target} =
 potsSumIncreaseWdrlsPerTx ::
   forall era.
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -286,8 +287,8 @@ potsSumIncreaseWdrlsPerTx SourceSignalTarget {source = chainSt, signal = block} 
 -- | (Utxo + Deposits + Fees) increases by the reward delta
 potsSumIncreaseByRewardsPerTx ::
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -316,8 +317,8 @@ potsSumIncreaseByRewardsPerTx SourceSignalTarget {source = chainSt, signal = blo
 -- | The Rewards pot decreases by the sum of withdrawals in a transaction
 potsRewardsDecreaseByWdrlsPerTx ::
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -354,8 +355,8 @@ potsRewardsDecreaseByWdrlsPerTx SourceSignalTarget {source = chainSt, signal = b
 preserveBalance ::
   ( ChainProperty era,
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -389,11 +390,11 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
 -- | Preserve balance restricted to TxIns and TxOuts of the Tx
 preserveBalanceRestricted ::
   ( ChainProperty era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -423,8 +424,8 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
 preserveOutputsTx ::
   ( ChainProperty era,
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -441,10 +442,11 @@ preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
 
 -- | Check that consumed inputs are eliminated from the resulting UTxO
 eliminateTxInputs ::
+  forall era.
   ( ChainProperty era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -456,15 +458,15 @@ eliminateTxInputs SourceSignalTarget {source = chainSt, signal = block} =
     (_, ledgerTr) = ledgerTraceFromBlock chainSt block
     inputsEliminated SourceSignalTarget {target = (UTxOState {_utxo = (UTxO u')}, _), signal = tx} =
       property $
-        Set.null $ eval (txins (_body tx) ∩ dom u')
+        Set.null $ eval (txins @era (_body tx) ∩ dom u')
 
 -- | Collision-Freeness of new TxIds - checks that all new outputs of a Tx are
 -- included in the new UTxO and that all TxIds are new.
 newEntriesAndUniqueTxIns ::
   ( ChainProperty era,
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -494,8 +496,8 @@ requiredMSigSignaturesSubset ::
   forall era.
   ( EraGen era,
     ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -521,7 +523,7 @@ requiredMSigSignaturesSubset SourceSignalTarget {source = chainSt, signal = bloc
 noDoubleSpend ::
   forall era.
   ( ChainProperty era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era))
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -549,7 +551,7 @@ noDoubleSpend SourceSignalTarget {signal} =
 
 withdrawals ::
   ( ChainProperty era,
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Block era ->
   Coin
@@ -607,10 +609,10 @@ poolProperties ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 poolProperties =
@@ -626,7 +628,7 @@ poolProperties =
 -- retirement.
 poolRetirement ::
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -643,7 +645,7 @@ poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
 -- in the retiring map.
 poolRegistration ::
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -657,7 +659,7 @@ poolRegistration (SourceSignalTarget {source = chainSt, signal = block}) =
 -- POOL` transition.
 poolStateIsInternallyConsistent ::
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -678,10 +680,10 @@ delegProperties ::
   ( EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 delegProperties =
@@ -712,8 +714,8 @@ delegProperties =
 ledgerTraceFromBlock ::
   forall era.
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   ChainState era ->
   Block era ->
@@ -730,7 +732,7 @@ ledgerTraceFromBlock chainSt block =
 poolTraceFromBlock ::
   forall era.
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   ChainState era ->
   Block era ->
@@ -757,7 +759,7 @@ poolTraceFromBlock chainSt block =
 delegTraceFromBlock ::
   forall era.
   ( ChainProperty era,
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   ChainState era ->
   Block era ->
@@ -794,7 +796,7 @@ ledgerTraceBase ::
   Block era ->
   ( ChainState era,
     LedgerEnv era,
-    (UTxOState era, DPState era),
+    (UTxOState era, DPState (Crypto era)),
     [Tx era]
   )
 ledgerTraceBase chainSt block =
@@ -846,10 +848,10 @@ removedAfterPoolreap ::
   ( ChainProperty era,
     EraGen era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era)
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Property
 removedAfterPoolreap =
@@ -875,10 +877,10 @@ forAllChainTrace ::
     EraGen era,
     ChainProperty era,
     ValidateMetadata era,
-    HasField "inputs" (Core.TxBody era) (Set (TxIn era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
-    HasField "wdrls" (Core.TxBody era) (Wdrl era),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert era))
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   Word64 -> -- trace length
   (Trace (CHAIN era) -> prop) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -13,7 +13,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestPool
 where
 
 import Control.SetAlgebra (dom, eval, (∈), (∉))
-import Control.State.Transition (State)
 import Control.State.Transition.Trace
   ( SourceSignalTarget (..),
   )
@@ -88,7 +87,7 @@ poolRetirement
       ]
 poolRetirement _ _ _ = property ()
 
-poolStateIsInternallyConsistent :: State (POOL era) -> Property
+poolStateIsInternallyConsistent :: PState crypto -> Property
 poolStateIsInternallyConsistent (PState pParams_ _ retiring_) = do
   let poolKeys = Map.keysSet pParams_
       pParamKeys = Map.keysSet pParams_

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -13,7 +13,6 @@ module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
 where
 
 import Control.SetAlgebra (dom, eval, setSingleton, (∩), (⊆), (▷))
-import Cardano.Ledger.Era (Crypto)
 import qualified Data.Set as Set (Set, null)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (StakePool))
 import Shelley.Spec.Ledger.LedgerState
@@ -30,9 +29,9 @@ import Test.QuickCheck (Property, property)
 -- | Check that after a POOLREAP certificate transition the pool is removed from
 -- the stake pool and retiring maps.
 removedAfterPoolreap ::
-  forall era.
-  PState era ->
-  PState era ->
+  forall crypto.
+  PState crypto ->
+  PState crypto ->
   EpochNo ->
   Property
 removedAfterPoolreap p p' e =
@@ -45,5 +44,5 @@ removedAfterPoolreap p p' e =
     stp' = _pParams p'
     retiring = _retiring p
     retiring' = _retiring p'
-    retire :: Set.Set (KeyHash 'StakePool (Crypto era)) -- This declaration needed to disambiguate 'eval'
+    retire :: Set.Set (KeyHash 'StakePool crypto) -- This declaration needed to disambiguate 'eval'
     retire = eval (dom (retiring ▷ setSingleton e))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -11,7 +11,6 @@ where
 
 import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
-import Data.Proxy
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.BaseTypes (Network (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
@@ -21,7 +20,7 @@ import Shelley.Spec.Ledger.LedgerState (WitHashes (..))
 import Shelley.Spec.Ledger.STS.Utxow (UtxowPredicateFailure (..))
 import Shelley.Spec.Ledger.Tx (hashScript)
 import Shelley.Spec.Ledger.TxBody (RewardAcnt (..), Wdrl (..))
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Shelley.Spec.Ledger.Examples (testCHAINExample)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import Test.Shelley.Spec.Ledger.Examples.EmptyBlock (exEmptyBlock)
@@ -93,12 +92,11 @@ testAliceSignsAlone :: Assertion
 testAliceSignsAlone =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay]
@@ -106,14 +104,13 @@ testAliceSignsAlone =
 
 testAliceDoesntSign :: Assertion
 testAliceDoesntSign =
-  utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW (Set.singleton $ hashScript (aliceOnly p))]]
+  utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW (Set.singleton $ hashScript @C aliceOnly)]]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay, asWitness Cast.carlPay, asWitness Cast.dariaPay]
@@ -122,12 +119,11 @@ testEverybodySigns :: Assertion
 testEverybodySigns =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly]
         (Wdrl Map.empty)
         (Coin 0)
         [ asWitness Cast.alicePay,
@@ -139,14 +135,13 @@ testEverybodySigns =
 
 testWrongScript :: Assertion
 testWrongScript =
-  utxoSt' @?= Left [[MissingScriptWitnessesUTXOW (Set.singleton $ hashScript (aliceOnly p))]]
+  utxoSt' @?= Left [[MissingScriptWitnessesUTXOW (Set.singleton $ hashScript @C aliceOnly)]]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOrBob p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOrBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -155,12 +150,11 @@ testAliceOrBob :: Assertion
 testAliceOrBob =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOrBob p, Coin 11000)]
-        [aliceOrBob p]
+        @C_Crypto
+        [(aliceOrBob, Coin 11000)]
+        [aliceOrBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay]
@@ -170,12 +164,11 @@ testAliceOrBob' :: Assertion
 testAliceOrBob' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOrBob p, Coin 11000)]
-        [aliceOrBob p]
+        @C_Crypto
+        [(aliceOrBob, Coin 11000)]
+        [aliceOrBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay]
@@ -185,12 +178,11 @@ testAliceAndBob :: Assertion
 testAliceAndBob =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBob p, Coin 11000)]
-        [aliceAndBob p]
+        @C_Crypto
+        [(aliceAndBob, Coin 11000)]
+        [aliceAndBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -201,16 +193,15 @@ testAliceAndBob' =
   utxoSt'
     @?= Left
       [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript (aliceAndBob p))
+            (Set.singleton $ hashScript @C aliceAndBob)
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBob p, Coin 11000)]
-        [aliceAndBob p]
+        @C_Crypto
+        [(aliceAndBob, Coin 11000)]
+        [aliceAndBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay]
@@ -220,16 +211,15 @@ testAliceAndBob'' =
   utxoSt'
     @?= Left
       [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript (aliceAndBob p))
+            (Set.singleton $ hashScript @C aliceAndBob)
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBob p, Coin 11000)]
-        [aliceAndBob p]
+        @C_Crypto
+        [(aliceAndBob, Coin 11000)]
+        [aliceAndBob]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay]
@@ -238,12 +228,11 @@ testAliceAndBobOrCarl :: Assertion
 testAliceAndBobOrCarl =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarl p, Coin 11000)]
-        [aliceAndBobOrCarl p]
+        @C_Crypto
+        [(aliceAndBobOrCarl, Coin 11000)]
+        [aliceAndBobOrCarl]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -253,12 +242,11 @@ testAliceAndBobOrCarl' :: Assertion
 testAliceAndBobOrCarl' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarl p, Coin 11000)]
-        [aliceAndBobOrCarl p]
+        @C_Crypto
+        [(aliceAndBobOrCarl, Coin 11000)]
+        [aliceAndBobOrCarl]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.carlPay]
@@ -268,12 +256,11 @@ testAliceAndBobOrCarlAndDaria :: Assertion
 testAliceAndBobOrCarlAndDaria =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarlAndDaria p, Coin 11000)]
-        [aliceAndBobOrCarlAndDaria p]
+        @C_Crypto
+        [(aliceAndBobOrCarlAndDaria, Coin 11000)]
+        [aliceAndBobOrCarlAndDaria]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -283,12 +270,11 @@ testAliceAndBobOrCarlAndDaria' :: Assertion
 testAliceAndBobOrCarlAndDaria' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarlAndDaria p, Coin 11000)]
-        [aliceAndBobOrCarlAndDaria p]
+        @C_Crypto
+        [(aliceAndBobOrCarlAndDaria, Coin 11000)]
+        [aliceAndBobOrCarlAndDaria]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.carlPay, asWitness Cast.dariaPay]
@@ -298,12 +284,11 @@ testAliceAndBobOrCarlOrDaria :: Assertion
 testAliceAndBobOrCarlOrDaria =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarlOrDaria p, Coin 11000)]
-        [aliceAndBobOrCarlOrDaria p]
+        @C_Crypto
+        [(aliceAndBobOrCarlOrDaria, Coin 11000)]
+        [aliceAndBobOrCarlOrDaria]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -313,12 +298,11 @@ testAliceAndBobOrCarlOrDaria' :: Assertion
 testAliceAndBobOrCarlOrDaria' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarlOrDaria p, Coin 11000)]
-        [aliceAndBobOrCarlOrDaria p]
+        @C_Crypto
+        [(aliceAndBobOrCarlOrDaria, Coin 11000)]
+        [aliceAndBobOrCarlOrDaria]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.carlPay]
@@ -328,12 +312,11 @@ testAliceAndBobOrCarlOrDaria'' :: Assertion
 testAliceAndBobOrCarlOrDaria'' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarlOrDaria p, Coin 11000)]
-        [aliceAndBobOrCarlOrDaria p]
+        @C_Crypto
+        [(aliceAndBobOrCarlOrDaria, Coin 11000)]
+        [aliceAndBobOrCarlOrDaria]
         (Wdrl Map.empty)
         (Coin 0)
         [asWitness Cast.dariaPay]
@@ -345,15 +328,14 @@ testTwoScripts :: Assertion
 testTwoScripts =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [ (aliceOrBob p, Coin 10000),
-          (aliceAndBobOrCarl p, Coin 1000)
+        @C_Crypto
+        [ (aliceOrBob, Coin 10000),
+          (aliceAndBobOrCarl, Coin 1000)
         ]
-        [ aliceOrBob p,
-          aliceAndBobOrCarl p
+        [ aliceOrBob,
+          aliceAndBobOrCarl
         ]
         (Wdrl Map.empty)
         (Coin 0)
@@ -365,19 +347,18 @@ testTwoScripts' =
   utxoSt'
     @?= Left
       [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript (aliceAndBob p))
+            (Set.singleton $ hashScript @C aliceAndBob)
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [ (aliceAndBob p, Coin 10000),
-          (aliceAndBobOrCarl p, Coin 1000)
+        @C_Crypto
+        [ (aliceAndBob, Coin 10000),
+          (aliceAndBobOrCarl, Coin 1000)
         ]
-        [ aliceAndBob p,
-          aliceAndBobOrCarl p
+        [ aliceAndBob,
+          aliceAndBobOrCarl
         ]
         (Wdrl Map.empty)
         (Coin 0)
@@ -389,12 +370,11 @@ testScriptAndSKey :: Assertion
 testScriptAndSKey =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBob p, Coin 10000)]
-        [aliceAndBob p]
+        @C_Crypto
+        [(aliceAndBob, Coin 10000)]
+        [aliceAndBob]
         (Wdrl Map.empty)
         (Coin 1000)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
@@ -409,12 +389,11 @@ testScriptAndSKey' =
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOrBob p, Coin 10000)]
-        [aliceOrBob p]
+        @C_Crypto
+        [(aliceOrBob, Coin 10000)]
+        [aliceOrBob]
         (Wdrl Map.empty)
         (Coin 1000)
         [asWitness Cast.bobPay]
@@ -424,12 +403,11 @@ testScriptAndSKey'' :: Assertion
 testScriptAndSKey'' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOrBob p, Coin 10000)]
-        [aliceOrBob p]
+        @C_Crypto
+        [(aliceOrBob, Coin 10000)]
+        [aliceOrBob]
         (Wdrl Map.empty)
         (Coin 1000)
         [asWitness Cast.alicePay]
@@ -439,12 +417,11 @@ testScriptAndSKey''' :: Assertion
 testScriptAndSKey''' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceAndBobOrCarl p, Coin 10000)]
-        [aliceAndBobOrCarl p]
+        @C_Crypto
+        [(aliceAndBobOrCarl, Coin 10000)]
+        [aliceAndBobOrCarl]
         (Wdrl Map.empty)
         (Coin 1000)
         [asWitness Cast.alicePay, asWitness Cast.carlPay]
@@ -456,17 +433,16 @@ testRwdAliceSignsAlone :: Assertion
 testRwdAliceSignsAlone =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly]
         ( Wdrl $
             Map.singleton
               ( RewardAcnt
                   Testnet
-                  (ScriptHashObj $ hashScript (aliceOnly p))
+                  (ScriptHashObj $ hashScript @C aliceOnly)
               )
               (Coin 1000)
         )
@@ -479,22 +455,21 @@ testRwdAliceSignsAlone' =
   utxoSt'
     @?= Left
       [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript (bobOnly p))
+            (Set.singleton $ hashScript @C bobOnly)
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p, bobOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly, bobOnly]
         ( Wdrl $
             Map.singleton
               ( RewardAcnt
                   Testnet
                   ( ScriptHashObj $
-                      hashScript (bobOnly p)
+                      hashScript @C bobOnly
                   )
               )
               (Coin 1000)
@@ -506,18 +481,17 @@ testRwdAliceSignsAlone'' :: Assertion
 testRwdAliceSignsAlone'' =
   assertBool s (isRight utxoSt')
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p, bobOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly, bobOnly]
         ( Wdrl $
             Map.singleton
               ( RewardAcnt
                   Testnet
                   ( ScriptHashObj $
-                      hashScript (bobOnly p)
+                      hashScript @C bobOnly
                   )
               )
               (Coin 1000)
@@ -532,20 +506,19 @@ testRwdAliceSignsAlone''' =
     @?= Left
       [ [ MissingScriptWitnessesUTXOW
             ( Set.singleton $
-                hashScript (bobOnly p)
+                hashScript @C bobOnly
             )
         ]
       ]
   where
-    p :: Proxy C
-    p = Proxy
     utxoSt' =
       applyTxWithScript
-        [(aliceOnly p, Coin 11000)]
-        [aliceOnly p]
+        @C_Crypto
+        [(aliceOnly, Coin 11000)]
+        [aliceOnly]
         ( Wdrl $
             Map.singleton
-              (RewardAcnt Testnet (ScriptHashObj $ hashScript (bobOnly p)))
+              (RewardAcnt Testnet (ScriptHashObj $ hashScript @C bobOnly))
               (Coin 1000)
         )
         (Coin 0)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
@@ -14,6 +14,12 @@ module Test.Shelley.Spec.Ledger.Serialisation.CDDL
   )
 where
 
+import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
+import Cardano.Crypto.Hash.Blake2b (Blake2b_224, Blake2b_256)
+import Cardano.Crypto.KES.Sum
+import Cardano.Crypto.VRF.Praos (PraosVRF)
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Data.ByteString.Lazy as BSL
 import Shelley.Spec.Ledger.API
   ( Credential,
@@ -43,19 +49,12 @@ import Shelley.Spec.Ledger.TxBody
     TxIn,
     TxOut,
   )
-import Test.Tasty (TestTree, withResource, testGroup)
 import Test.Shelley.Spec.Ledger.Serialisation.CDDLUtils
   ( cddlGroupTest,
     cddlTest,
     cddlTest',
   )
-
-import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
-import Cardano.Crypto.KES.Sum
-import Cardano.Crypto.Hash.Blake2b (Blake2b_224, Blake2b_256)
-import Cardano.Crypto.VRF.Praos (PraosVRF)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Test.Tasty (TestTree, testGroup, withResource)
 
 -- Crypto family as used in production Shelley
 -- TODO: we really need a central location for all the Crypto and Era families.
@@ -77,19 +76,19 @@ tests :: Int -> TestTree
 tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
     [ cddlTest' @(BHeader ShelleyC) n "header",
-      cddlTest' @(BootstrapWitness ShelleyE) n "bootstrap_witness",
+      cddlTest' @(BootstrapWitness ShelleyC) n "bootstrap_witness",
       cddlTest @(BHBody ShelleyC) n "header_body",
       cddlGroupTest @(OCert ShelleyC) n "operational_cert",
-      cddlTest @(Addr ShelleyE) n "address",
-      cddlTest @(RewardAcnt ShelleyE) n "reward_account",
-      cddlTest @(Credential 'Staking ShelleyE) n "stake_credential",
+      cddlTest @(Addr ShelleyC) n "address",
+      cddlTest @(RewardAcnt ShelleyC) n "reward_account",
+      cddlTest @(Credential 'Staking ShelleyC) n "stake_credential",
       cddlTest' @(TxBody ShelleyE) n "transaction_body",
       cddlTest @(TxOut ShelleyE) n "transaction_output",
       cddlTest @StakePoolRelay n "relay",
-      cddlTest @(DCert ShelleyE) n "certificate",
-      cddlTest @(TxIn ShelleyE) n "transaction_input",
+      cddlTest @(DCert ShelleyC) n "certificate",
+      cddlTest @(TxIn ShelleyC) n "transaction_input",
       cddlTest' @Metadata n "transaction_metadata",
-      cddlTest' @(MultiSig ShelleyE) n "multisig_script",
+      cddlTest' @(MultiSig ShelleyC) n "multisig_script",
       cddlTest @(Update ShelleyE) n "update",
       cddlTest @(ProposedPPUpdates ShelleyE) n "proposed_protocol_parameter_updates",
       cddlTest @(PParamsUpdate ShelleyE) n "protocol_param_update",

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Address.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Address.hs
@@ -45,7 +45,7 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.Scripts (pattern ScriptHash)
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
 import Test.Tasty (TestTree)
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
@@ -121,11 +121,11 @@ goldenTests_MockCrypto =
         "f005060708"
     ]
   where
-    keyHash :: Credential kh C
+    keyHash :: Credential kh C_Crypto
     keyHash =
       KeyHashObj . KeyHash . UnsafeHash $
         SBS.toShort . fromRight (error "Unable to decode") . B16.decode $ "01020304"
-    scriptHash :: Credential kh C
+    scriptHash :: Credential kh C_Crypto
     scriptHash =
       ScriptHashObj . ScriptHash . UnsafeHash $
         SBS.toShort . fromRight (error "Unable to decode") . B16.decode $ "05060708"
@@ -155,32 +155,32 @@ goldenTests_ShelleyCrypto =
     [ golden
         "addrEnterpriseK for network id = 0"
         putAddr
-        (Addr Testnet (paymentKey) StakeRefNull)
+        (Addr Testnet paymentKey StakeRefNull)
         "608a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d4",
       golden
         "addrBaseKK for network id = 0"
         putAddr
-        (Addr Testnet (paymentKey) (StakeRefBase (stakeKey)))
+        (Addr Testnet paymentKey (StakeRefBase stakeKey))
         "008a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4",
       golden
         "addrPtrK for network id = 0"
         putAddr
-        (Addr Testnet (paymentKey) (StakeRefPtr ptr))
+        (Addr Testnet paymentKey (StakeRefPtr ptr))
         "408a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d481000203",
       golden
         "addrEnterpriseK for network id = 1"
         putAddr
-        (Addr Mainnet (paymentKey) StakeRefNull)
+        (Addr Mainnet paymentKey StakeRefNull)
         "618a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d4",
       golden
         "addrBaseKK for network id = 1"
         putAddr
-        (Addr Mainnet (paymentKey) (StakeRefBase (stakeKey)))
+        (Addr Mainnet paymentKey (StakeRefBase stakeKey))
         "018a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d408b2d658668c2e341ee5bda4477b63c5aca7ec7ae4e3d196163556a4",
       golden
         "addrPtrK for network id = 1"
         putAddr
-        (Addr Mainnet (paymentKey) (StakeRefPtr ptr))
+        (Addr Mainnet paymentKey (StakeRefPtr ptr))
         "418a4d111f71a79169c50bcbc27e1e20b6e13e87ff8f33edc3cab419d481000203",
       golden
         "rewardAcntK"
@@ -208,16 +208,16 @@ goldenTests_ShelleyCrypto =
         "82d818582183581c4bf3c2ee56bfef278d65f7388c46efa12a1069698e474f77adf0cf6aa0001ab4aad9a5"
     ]
   where
-    paymentKey :: Credential 'Payment Shelley
+    paymentKey :: Credential 'Payment ShelleyCrypto
     paymentKey = keyBlake2b224 $ B16.encode "1a2a3a4a5a6a7a8a"
-    stakeKey :: Credential 'Staking Shelley
+    stakeKey :: Credential 'Staking ShelleyCrypto
     stakeKey = keyBlake2b224 $ B16.encode "1c2c3c4c5c6c7c8c"
     ptr :: Ptr
     ptr = Ptr (SlotNo 128) 2 3
     -- 32-byte verification key is expected, vk, ie., public key without chain code.
     -- The verification key undergoes Blake2b_224 hashing
     -- and should be 28-byte in the aftermath
-    keyBlake2b224 :: BS.ByteString -> Credential kh Shelley
+    keyBlake2b224 :: BS.ByteString -> Credential kh ShelleyCrypto
     keyBlake2b224 vk =
       KeyHashObj . KeyHash . fromJust . hashFromBytes $ hk
       where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -25,6 +25,7 @@ import Cardano.Crypto.DSIGN (encodeSignedDSIGN, encodeVerKeyDSIGN)
 import qualified Cardano.Crypto.Hash as Monomorphic
 import Cardano.Crypto.KES (SignedKES)
 import Cardano.Crypto.VRF (CertifiedVRF)
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -187,14 +188,13 @@ import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, C_Crypto, ExMock, Mock)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
 import Test.Shelley.Spec.Ledger.Serialisation.GoldenUtils
-  ( checkEncoding,
+  ( ToTokens (..),
+    checkEncoding,
     checkEncodingCBOR,
     checkEncodingCBORAnnotated,
-    ToTokens (..),
   )
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
-import qualified Cardano.Ledger.Core as Core
 
 type MultiSigMap = Map.Map (ScriptHash C_Crypto) (MultiSig C_Crypto)
 
@@ -892,7 +892,7 @@ tests =
                   )
               )
               (EpochNo 0)
-          mdh = MD.hashMetadata $ MD.Metadata $ Map.singleton 13 (MD.I 17)
+          mdh = MD.hashMetadata @C $ MD.Metadata $ Map.singleton 13 (MD.I 17)
        in checkEncodingCBORAnnotated
             "txbody_full"
             ( TxBody -- transaction body with all components

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -44,7 +44,6 @@ import Data.String (fromString)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API
   ( MultiSig,
-    PoolDistr,
     ScriptHash,
   )
 import Shelley.Spec.Ledger.Address
@@ -197,13 +196,13 @@ import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
 import qualified Cardano.Ledger.Core as Core
 
-type MultiSigMap = Map.Map (ScriptHash C) (MultiSig C)
+type MultiSigMap = Map.Map (ScriptHash C_Crypto) (MultiSig C_Crypto)
 
 decodeMultiSigMap :: Decoder s (Annotator MultiSigMap)
 decodeMultiSigMap = decodeMapTraverse (pure <$> fromCBOR) fromCBOR
 
 deserializeMultiSigMap :: LByteString -> Either DecoderError MultiSigMap
-deserializeMultiSigMap = decodeAnnotator ("Map ScriptHash MultiSig") decodeMultiSigMap
+deserializeMultiSigMap = decodeAnnotator "Map ScriptHash MultiSig" decodeMultiSigMap
 
 checkEncodingCBORCBORGroup ::
   (FromCBORGroup a, ToCBORGroup a, Show a, Eq a) =>
@@ -323,30 +322,27 @@ testKeyHash2 = (hashKey . vKey) testKey2
 testKESKeys :: CC.Crypto crypto => (SignKeyKES crypto, VerKeyKES crypto)
 testKESKeys = mkKESKeyPair (0, 0, 0, 0, 3)
 
-testAddrE :: forall era. Era era => Addr era
+testAddrE :: CC.Crypto crypto => Addr crypto
 testAddrE =
   Addr
     Testnet
     (KeyHashObj testKeyHash1)
     StakeRefNull
 
-testPayCred :: forall era. Era era => Credential 'Payment era
-testPayCred = KeyHashObj (testKeyHash1 @(Crypto era))
+testPayCred :: forall crypto. CC.Crypto crypto => Credential 'Payment crypto
+testPayCred = KeyHashObj (testKeyHash1 @crypto)
 
-testStakeCred :: forall era. Era era => Credential 'Staking era
-testStakeCred = KeyHashObj $ testKeyHash2 @(Crypto era)
+testStakeCred :: forall crypto. CC.Crypto crypto => Credential 'Staking crypto
+testStakeCred = KeyHashObj $ testKeyHash2 @crypto
 
-testScript :: forall era. Era era => MultiSig era
-testScript = RequireSignature $ asWitness (testKeyHash1 @(Crypto era))
+testScript :: forall crypto. CC.Crypto crypto => MultiSig crypto
+testScript = RequireSignature $ asWitness (testKeyHash1 @crypto)
 
-testScriptHash ::
-  forall c.
-  CC.Crypto c =>
-  ScriptHash (ShelleyEra c)
-testScriptHash = hashScript $ testScript @(ShelleyEra c)
+testScriptHash :: forall crypto. CC.Crypto crypto => ScriptHash crypto
+testScriptHash = hashScript @(ShelleyEra crypto) testScript
 
-testScript2 :: forall era. Era era => MultiSig era
-testScript2 = RequireSignature $ asWitness (testKeyHash2 @(Crypto era))
+testScript2 :: forall crypto. CC.Crypto crypto => MultiSig crypto
+testScript2 = RequireSignature $ asWitness (testKeyHash2 @crypto)
 
 testHeaderHash ::
   forall crypto.
@@ -462,21 +458,21 @@ tests =
         (T (TkBytes (getRawKeyHash (testKeyHash1 @C_Crypto)))),
       checkEncodingCBOR
         "credential_key_hash"
-        (testPayCred @C)
+        (testPayCred @C_Crypto)
         (T (TkListLen 2 . TkWord 0) <> S (testKeyHash1 @C_Crypto)),
       checkEncodingCBOR
         "txin"
-        (TxIn genesisId 0 :: TxIn C)
-        (T (TkListLen 2) <> S (genesisId :: TxId C) <> T (TkWord64 0)),
-      let a = Addr Testnet (testPayCred @C) StakeRefNull
+        (TxIn @C_Crypto genesisId 0)
+        (T (TkListLen 2) <> S (genesisId :: TxId C_Crypto) <> T (TkWord64 0)),
+      let a = Addr Testnet testPayCred StakeRefNull
        in checkEncodingCBOR
             "txout"
-            (TxOut a (Coin 2))
+            (TxOut @C a (Coin 2))
             ( T (TkListLen 2)
                 <> S a
                 <> S (Coin 2)
             ),
-      case makeWitnessVKey @C (testTxbHash @C) (testKey1 @C_Crypto) of
+      case makeWitnessVKey @C_Crypto (testTxbHash @C) testKey1 of
         w@(WitVKey vk _sig) ->
           checkEncodingCBORAnnotated
             "vkey_witnesses"
@@ -489,13 +485,13 @@ tests =
         toCBOR
         deserializeMultiSigMap
         "script_hash_to_scripts"
-        (Map.singleton (hashScript (testScript @C) :: ScriptHash C) (testScript @C)) -- Transaction _witnessMSigMap
+        (Map.singleton (hashScript @C testScript) testScript) -- Transaction _witnessMSigMap
         ( T (TkMapLen 1)
-            <> S (hashScript (testScript @C) :: ScriptHash C)
-            <> S (testScript @C)
+            <> S (hashScript @C testScript)
+            <> S (testScript @C_Crypto)
         ),
       -- checkEncodingCBOR "withdrawal_key"
-      let r = (RewardAcnt Testnet (testStakeCred @C))
+      let r = RewardAcnt Testnet (testStakeCred @C_Crypto)
        in checkEncodingCBOR
             "withdrawal"
             (Map.singleton r (Coin 123))
@@ -515,32 +511,32 @@ tests =
             ),
       checkEncodingCBOR
         "register_stake_reference"
-        (DCertDeleg (RegKey (testStakeCred @C)))
+        (DCertDeleg (RegKey (testStakeCred @C_Crypto)))
         ( T (TkListLen 2)
             <> T (TkWord 0) -- Reg cert
-            <> S (testStakeCred @C) -- keyhash
+            <> S (testStakeCred @C_Crypto) -- keyhash
         ),
       checkEncodingCBOR
         "deregister_stake_reference"
-        (DCertDeleg (DeRegKey (testStakeCred @C)))
+        (DCertDeleg (DeRegKey (testStakeCred @C_Crypto)))
         ( T (TkListLen 2)
             <> T (TkWord 1) -- DeReg cert
-            <> S (testStakeCred @C) -- keyhash
+            <> S (testStakeCred @C_Crypto) -- keyhash
         ),
       checkEncodingCBOR
         "stake_delegation"
-        (DCertDeleg (Delegate (Delegation (testStakeCred @C) (hashKey . vKey $ testStakePoolKey))))
+        (DCertDeleg (Delegate (Delegation (testStakeCred @C_Crypto) (hashKey . vKey $ testStakePoolKey))))
         ( T
             ( TkListLen 3
                 . TkWord 2 -- delegation cert with key
             )
-            <> S (testStakeCred @C)
+            <> S (testStakeCred @C_Crypto)
             <> S (hashKey . vKey $ testStakePoolKey @C_Crypto)
         ),
       -- checkEncodingCBOR "register-pool"
       let poolOwner = testKeyHash2 @C_Crypto
           poolMargin = unsafeMkUnitInterval 0.7
-          poolRAcnt = RewardAcnt Testnet (testStakeCred @C)
+          poolRAcnt = RewardAcnt Testnet (testStakeCred @C_Crypto)
           poolPledge = Coin 11
           poolCost = Coin 55
           poolUrl = "pool.io"
@@ -597,7 +593,7 @@ tests =
       checkEncodingCBOR
         "retire_pool"
         ( DCertPool
-            ( RetirePool @C
+            ( RetirePool @C_Crypto
                 (hashKey . vKey $ testStakePoolKey @C_Crypto)
                 (EpochNo 1729)
             )
@@ -612,7 +608,7 @@ tests =
       checkEncodingCBOR
         "genesis_delegation"
         ( DCertGenesis
-            ( GenesisDelegCert @C
+            ( GenesisDelegCert @C_Crypto
                 testGKeyHash
                 (hashKey . vKey $ testGenesisDelegateKey @C_Crypto)
                 (testVRFKH @C_Crypto)
@@ -627,7 +623,7 @@ tests =
             <> S (testVRFKH @C_Crypto) -- delegatee vrf key hash
         ),
       -- checkEncodingCBOR "mir"
-      let rws = Map.singleton (testStakeCred @C) (Coin 77)
+      let rws = Map.singleton (testStakeCred @C_Crypto) (Coin 77)
        in checkEncodingCBOR
             "mir"
             (DCertMir (MIRCert ReservesMIR rws))
@@ -775,8 +771,8 @@ tests =
                 <> S e
             ),
       -- checkEncodingCBOR "minimal_txn_body"
-      let tin = TxIn @C genesisId 1
-          tout = TxOut (testAddrE @C) (Coin 2)
+      let tin = TxIn @C_Crypto genesisId 1
+          tout = TxOut @C testAddrE (Coin 2)
        in checkEncodingCBORAnnotated
             "txbody"
             ( TxBody -- minimal transaction body
@@ -802,8 +798,8 @@ tests =
                 <> T (TkWord64 500)
             ),
       -- checkEncodingCBOR "transaction_mixed"
-      let tin = TxIn @C genesisId 1
-          tout = TxOut (testAddrE @C) (Coin 2)
+      let tin = TxIn @C_Crypto genesisId 1
+          tout = TxOut @C testAddrE (Coin 2)
           ra = RewardAcnt Testnet (KeyHashObj testKeyHash2)
           ras = Map.singleton ra (Coin 123)
           up =
@@ -863,9 +859,9 @@ tests =
                 <> S up
             ),
       -- checkEncodingCBOR "full_txn_body"
-      let tin = TxIn @C genesisId 1
-          tout = TxOut (testAddrE @C) (Coin 2)
-          reg = DCertDeleg (RegKey (testStakeCred @C))
+      let tin = TxIn @C_Crypto genesisId 1
+          tout = TxOut @C testAddrE (Coin 2)
+          reg = DCertDeleg (RegKey (testStakeCred @C_Crypto))
           ra = RewardAcnt Testnet (KeyHashObj testKeyHash2)
           ras = Map.singleton ra (Coin 123)
           up =
@@ -934,7 +930,7 @@ tests =
       let txb =
             TxBody
               (Set.fromList [TxIn genesisId 1])
-              (StrictSeq.singleton $ TxOut (testAddrE @C) (Coin 2))
+              (StrictSeq.singleton $ TxOut @C testAddrE (Coin 2))
               StrictSeq.empty
               (Wdrl Map.empty)
               (Coin 9)
@@ -958,7 +954,7 @@ tests =
       let txb =
             TxBody
               (Set.fromList [TxIn genesisId 1])
-              (StrictSeq.singleton $ TxOut (testAddrE @C) (Coin 2))
+              (StrictSeq.singleton $ TxOut @C testAddrE (Coin 2))
               StrictSeq.empty
               (Wdrl Map.empty)
               (Coin 9)
@@ -967,7 +963,7 @@ tests =
               SNothing
           txbh = hashAnnotated txb
           w = makeWitnessVKey txbh testKey1
-          s = Map.singleton (hashScript $ testScript @C) (testScript @C)
+          s = Map.singleton (hashScript @C testScript) (testScript @C_Crypto)
           wits = mempty {addrWits = Set.singleton w, scriptWits = s}
           md = MD.Metadata $ Map.singleton 17 (MD.I 42)
        in checkEncodingCBORAnnotated
@@ -981,7 +977,7 @@ tests =
                 <> S w
                 <> T (TkWord 1)
                 <> T (TkListLen 1)
-                <> S (testScript @C)
+                <> S (testScript @C_Crypto)
                 <> S md
             ),
       -- checkEncodingCBOR "block_header_body"
@@ -1090,8 +1086,8 @@ tests =
       let sig :: (SignedKES (CC.KES C_Crypto) (BHBody C_Crypto))
           sig = signedKES () 0 (testBHB @C) (fst $ testKESKeys @C_Crypto)
           bh = BHeader (testBHB @C) sig
-          tin = Set.fromList [TxIn @C genesisId 1]
-          tout = StrictSeq.singleton $ TxOut (testAddrE @C) (Coin 2)
+          tin = Set.fromList [TxIn @C_Crypto genesisId 1]
+          tout = StrictSeq.singleton $ TxOut @C testAddrE (Coin 2)
           txb s =
             TxBody
               tin
@@ -1108,7 +1104,7 @@ tests =
           txb4 = txb 503
           txb5 = txb 504
           w1 = makeWitnessVKey (hashAnnotated txb1) testKey1
-          w2 = makeWitnessVKey (hashAnnotated txb1) (testKey2 :: KeyPair 'Payment C_Crypto)
+          w2 = makeWitnessVKey (hashAnnotated txb1) testKey2
           ws = Set.fromList [w1, w2]
           tx1 = Tx @C txb1 mempty {addrWits = Set.singleton w1} SNothing
           tx2 = Tx @C txb2 mempty {addrWits = ws} SNothing
@@ -1117,13 +1113,13 @@ tests =
               txb3
               mempty
                 { scriptWits =
-                    Map.singleton (hashScript (testScript @C)) (testScript @C)
+                    Map.singleton (hashScript @C testScript) testScript
                 }
               SNothing
           ss =
             Map.fromList
-              [ (hashScript (testScript @C), testScript @C),
-                (hashScript (testScript2 @C), testScript2 @C)
+              [ (hashScript @C testScript, testScript),
+                (hashScript @C testScript2, testScript2)
               ]
           tx4 = Tx txb4 mempty {scriptWits = ss} SNothing
           tx5MD = MD.Metadata $ Map.singleton 17 (MD.I 42)
@@ -1158,12 +1154,12 @@ tests =
                 -- tx 3, one script
                 <> T (TkMapLen 1 . TkWord 1)
                 <> T (TkListLen 1)
-                <> S (testScript @C)
+                <> S (testScript @C_Crypto)
                 -- tx 4, two scripts
                 <> T (TkMapLen 1 . TkWord 1)
                 <> T (TkListLen 2)
-                <> S (testScript2 @C)
-                <> S (testScript @C)
+                <> S (testScript2 @C_Crypto)
+                <> S (testScript @C_Crypto)
                 -- tx 5, two keys and two scripts
                 <> T (TkMapLen 2)
                 <> T (TkWord 0)
@@ -1172,8 +1168,8 @@ tests =
                 <> S w1
                 <> T (TkWord 1)
                 <> T (TkListLen 2)
-                <> S (testScript2 @C)
-                <> S (testScript @C)
+                <> S (testScript2 @C_Crypto)
+                <> S (testScript @C_Crypto)
                 -- metadata
                 <> T (TkMapLen 1)
                 <> T (TkInt 4)
@@ -1187,7 +1183,7 @@ tests =
           bs = Map.singleton (hashKey . vKey $ testStakePoolKey @C_Crypto) n
        in checkEncodingCBOR
             "blocks_made"
-            (BlocksMade @C bs)
+            (BlocksMade bs)
             ( T (TkMapLen 1)
                 <> S (hashKey . vKey $ testStakePoolKey @C_Crypto)
                 <> S n
@@ -1199,37 +1195,37 @@ tests =
             <> S (Coin 1)
             <> S (Coin 2)
         ),
-      let stk = Map.singleton (testStakeCred @C) (Coin 13)
+      let stk = Map.singleton (testStakeCred @C_Crypto) (Coin 13)
        in checkEncodingCBOR
             "stake"
             (Stake stk)
             ( T (TkMapLen 1)
-                <> S (testStakeCred @C)
+                <> S (testStakeCred @C_Crypto)
                 <> S (Coin 13)
             ),
       let mark =
             SnapShot
-              (Stake $ Map.singleton (testStakeCred @C) (Coin 11))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Stake $ Map.singleton (testStakeCred @C_Crypto) (Coin 11))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           set =
             SnapShot
               (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           go =
             SnapShot
-              (Stake $ Map.singleton (testStakeCred @C) (Coin 33))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Stake $ Map.singleton (testStakeCred @C_Crypto) (Coin 33))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           params =
             PoolParams
-              { _poolId = (hashKey $ vKey testStakePoolKey),
+              { _poolId = hashKey $ vKey testStakePoolKey,
                 _poolVrf = testVRFKH @C_Crypto,
                 _poolPledge = Coin 5,
                 _poolCost = Coin 4,
                 _poolMargin = unsafeMkUnitInterval 0.7,
-                _poolRAcnt = RewardAcnt Testnet (testStakeCred @C),
+                _poolRAcnt = RewardAcnt Testnet (testStakeCred @C_Crypto),
                 _poolOwners = Set.singleton testKeyHash2,
                 _poolRelays = StrictSeq.empty,
                 _poolMD =
@@ -1254,27 +1250,27 @@ tests =
           ac = AccountState (Coin 100) (Coin 100)
           mark =
             SnapShot
-              (Stake $ Map.singleton (testStakeCred @C) (Coin 11))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Stake $ Map.singleton (testStakeCred @C_Crypto) (Coin 11))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           set =
             SnapShot
               (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           go =
             SnapShot
-              (Stake $ Map.singleton (testStakeCred @C) (Coin 33))
-              (Map.singleton (testStakeCred @C) (hashKey $ vKey testStakePoolKey))
+              (Stake $ Map.singleton (testStakeCred @C_Crypto) (Coin 33))
+              (Map.singleton (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey))
               ps
           params =
             PoolParams
-              { _poolId = (hashKey $ vKey testStakePoolKey),
+              { _poolId = hashKey $ vKey testStakePoolKey,
                 _poolVrf = testVRFKH @C_Crypto,
                 _poolPledge = Coin 5,
                 _poolCost = Coin 4,
                 _poolMargin = unsafeMkUnitInterval 0.7,
-                _poolRAcnt = RewardAcnt Testnet (testStakeCred @C),
+                _poolRAcnt = RewardAcnt Testnet (testStakeCred @C_Crypto),
                 _poolOwners = Set.singleton testKeyHash2,
                 _poolRelays = StrictSeq.empty,
                 _poolMD =
@@ -1291,7 +1287,7 @@ tests =
           pps = emptyPParams
           bs = Map.singleton (hashKey $ vKey testStakePoolKey) 1
           nm = emptyNonMyopic
-          es = EpochState ac ss ls pps pps nm
+          es = EpochState @C ac ss ls pps pps nm
           ru =
             ( SJust
                 RewardUpdate
@@ -1302,8 +1298,8 @@ tests =
                     nonMyopic = nm
                   }
             ) ::
-              StrictMaybe (RewardUpdate C)
-          pd = (PoolDistr Map.empty) :: PoolDistr C_Crypto
+              StrictMaybe (RewardUpdate C_Crypto)
+          pd = PoolDistr @C_Crypto Map.empty
           nes =
             NewEpochState
               e
@@ -1317,8 +1313,8 @@ tests =
             nes
             ( T (TkListLen 6)
                 <> S e
-                <> S (BlocksMade @C bs)
-                <> S (BlocksMade @C bs)
+                <> S (BlocksMade @C_Crypto bs)
+                <> S (BlocksMade @C_Crypto bs)
                 <> S es
                 <> S ru
                 <> S pd

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
@@ -145,7 +145,7 @@ tests =
 
 exampleShelleyGenesis ::
   forall era.
-  (Era era) =>
+  Era era =>
   ShelleyGenesis era
 exampleShelleyGenesis =
   ShelleyGenesis
@@ -180,7 +180,7 @@ exampleShelleyGenesis =
     delegVerKeyHash = L.KeyHash "839b047f839b047f"
     delegVrfKeyHash :: Hash.Hash (HASH (Crypto era)) (L.VerKeyVRF (Crypto era))
     delegVrfKeyHash = "231391e7231391e70123"
-    initialFundedAddress :: L.Addr era
+    initialFundedAddress :: L.Addr (Crypto era)
     initialFundedAddress =
       L.Addr
         L.Testnet
@@ -206,7 +206,7 @@ exampleShelleyGenesis =
           L.SingleHostName L.SNothing (fromJust $ textToDns "cool.domain.com"),
           L.MultiHostName (fromJust $ textToDns "cool.domain.com")
         ]
-    poolParams :: L.PoolParams era
+    poolParams :: L.PoolParams (Crypto era)
     poolParams =
       L.PoolParams
         { L._poolId = hashKey . snd $ mkKeyPair (1, 0, 0, 0, 1),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
@@ -96,10 +96,10 @@ roundtrip' enc dec a = case deserialiseFromBytes dec bs of
   Serialization Properties
 -------------------------------------------------------------------------------}
 
-prop_roundtrip_Addr :: Ledger.Addr Mock.C -> Property
+prop_roundtrip_Addr :: Ledger.Addr Mock.C_Crypto -> Property
 prop_roundtrip_Addr = roundtrip toCBOR fromCBOR
 
-prop_roundtrip_RewardAcnt :: Ledger.RewardAcnt Mock.C -> Property
+prop_roundtrip_RewardAcnt :: Ledger.RewardAcnt Mock.C_Crypto -> Property
 prop_roundtrip_RewardAcnt = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_Block :: Ledger.Block Mock.C -> Property
@@ -117,14 +117,14 @@ prop_roundtrip_TxBody = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 prop_roundtrip_Tx :: Ledger.Tx Mock.C -> Property
 prop_roundtrip_Tx = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
-prop_roundtrip_TxId :: Ledger.TxId Mock.C -> Property
+prop_roundtrip_TxId :: Ledger.TxId Mock.C_Crypto -> Property
 prop_roundtrip_TxId = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_TxOut :: Ledger.TxOut Mock.C -> Property
 prop_roundtrip_TxOut = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_BootstrapWitness ::
-  Ledger.BootstrapWitness Mock.C -> Property
+  Ledger.BootstrapWitness Mock.C_Crypto -> Property
 prop_roundtrip_BootstrapWitness =
   roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
@@ -132,7 +132,7 @@ prop_roundtrip_LEDGER_PredicateFails ::
   [STS.PredicateFailure (STS.LEDGERS Mock.C)] -> Property
 prop_roundtrip_LEDGER_PredicateFails = roundtrip toCBOR fromCBOR
 
-prop_roundtrip_PrtclState :: STS.PrtclState (Mock.C_Crypto) -> Property
+prop_roundtrip_PrtclState :: STS.PrtclState Mock.C_Crypto -> Property
 prop_roundtrip_PrtclState = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_LedgerState :: Ledger.LedgerState Mock.C -> Property
@@ -141,7 +141,7 @@ prop_roundtrip_LedgerState = roundtrip toCBOR fromCBOR
 prop_roundtrip_NewEpochState :: Ledger.NewEpochState Mock.C -> Property
 prop_roundtrip_NewEpochState = roundtrip toCBOR fromCBOR
 
-prop_roundtrip_MultiSig :: Ledger.MultiSig Mock.C -> Property
+prop_roundtrip_MultiSig :: Ledger.MultiSig Mock.C_Crypto -> Property
 prop_roundtrip_MultiSig = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
 prop_roundtrip_metadata :: Ledger.Metadata -> Property

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/JSON.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/JSON.hs
@@ -24,14 +24,14 @@ import Test.Tasty
 import Test.Tasty.Hedgehog
 
 prop_roundtrip_Address_JSON ::
-  forall era.
-  Era era =>
-  Proxy era ->
+  forall crypto.
+  CC.Crypto crypto =>
+  Proxy crypto ->
   Property
 prop_roundtrip_Address_JSON _ =
   -- If this fails, FundPair and ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    addr <- Hedgehog.forAll $ genAddress @era
+    addr <- Hedgehog.forAll $ genAddress @crypto
 
     Hedgehog.tripping addr toJSON fromJSON
     Hedgehog.tripping addr encode decode
@@ -49,14 +49,14 @@ prop_roundtrip_GenesisDelegationPair_JSON _ =
     Hedgehog.tripping dp encode decode
 
 prop_roundtrip_FundPair_JSON ::
-  forall era.
-  Era era =>
-  Proxy era ->
+  forall crypto.
+  CC.Crypto crypto =>
+  Proxy crypto ->
   Property
 prop_roundtrip_FundPair_JSON _ =
   -- If this fails, ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    fp <- Hedgehog.forAll $ genGenesisFundPair @era
+    fp <- Hedgehog.forAll $ genGenesisFundPair @crypto
 
     Hedgehog.tripping fp toJSON fromJSON
     Hedgehog.tripping fp encode decode
@@ -78,11 +78,11 @@ tests =
   testGroup
     "Shelley Genesis"
     [ testProperty "Adress round trip" $
-        prop_roundtrip_Address_JSON @C Proxy,
+        prop_roundtrip_Address_JSON @C_Crypto Proxy,
       testProperty "Genesis round trip" $
         prop_roundtrip_ShelleyGenesis_JSON @C Proxy,
       testProperty "fund pair round trip" $
-        prop_roundtrip_FundPair_JSON @C Proxy,
+        prop_roundtrip_FundPair_JSON @C_Crypto Proxy,
       testProperty "delegation pair round trip" $
         prop_roundtrip_GenesisDelegationPair_JSON @C_Crypto Proxy
     ]


### PR DESCRIPTION
A bunch of types were parameterised over the era, while they were really
era-independent. It is confusing to parameterise something over the era while it
really is era-independent. Moreover, it requires much more needless
conversions/coercions.

The change that made it all possible is to parameterise `ScriptHash` by the
crypto instead of the era, using the `EraIndependentScript` tag. This meant
`EraIndependentWitVKey` was no longer needed.

By pushing this through, we get to the following (possibly incomplete) list of
all the types that were parameterised over the crypto instead of the era:

* Addr
* BlocksMade
* BootstrapAddress
* BootstrapWitness
* CompactAddr
* Credential
* DCert
* DPState
* DState
* DelegCert
* Delegation
* GenesisDelegCert
* InstantaneousRewards
* MIRCert
* MultiSig
* MultiSigRaw
* NonMyopic
* PState
* PaymentCredential
* PoolCert
* PoolParams
* RewardAccounts
* RewardAcnt
* RewardUpdate
* ScriptHash
* ShelleyGenesisStaking
* SnapShot
* SnapShots
* Stake
* StakeCredential
* StakeReference
* Timelock
* TimelockRaw
* TxId
* TxIn
* Value era
* Wdrl
* WitHashes
* WitVKey