### PR TITLE
Value serialisation fixes

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -182,11 +182,13 @@ decodeValue = do
   tt <- peekTokenType
   case tt of
     TypeUInt -> inject . Coin <$> decodeInteger
+    TypeUInt64 -> inject . Coin <$> decodeInteger
     TypeNInt -> inject . Coin <$> decodeInteger
+    TypeNInt64 -> inject . Coin <$> decodeInteger
     TypeListLen -> decodeValuePair decodeInteger
     TypeListLen64 -> decodeValuePair decodeInteger
     TypeListLenIndef -> decodeValuePair decodeInteger
-    _ -> fail $ "Value: expected array or int"
+    _ -> fail $ "Value: expected array or int, got " ++ show tt
 
 decodeValuePair ::
   ( Typeable (Core.Script era),
@@ -229,10 +231,11 @@ decodeNonNegativeValue = do
   tt <- peekTokenType
   case tt of
     TypeUInt -> inject . Coin <$> decodeNonNegativeInteger
+    TypeUInt64 -> inject . Coin <$> decodeNonNegativeInteger
     TypeListLen -> decodeValuePair decodeNonNegativeInteger
     TypeListLen64 -> decodeValuePair decodeNonNegativeInteger
     TypeListLenIndef -> decodeValuePair decodeNonNegativeInteger
-    _ -> fail $ "Value: expected array or int"
+    _ -> fail $ "Value: expected array or int, got " ++ show tt
 
 instance
   (Era era, Typeable (Core.Script era)) =>
@@ -409,7 +412,10 @@ prune assets =
 -- | Rather than using prune to remove 0 assets, when can avoid adding them in the
 --   first place by using valueFromList to construct a Value.
 valueFromList :: Integer -> [(PolicyID era, AssetName, Integer)] -> Value era
-valueFromList ada triples = foldr (\(p, n, i) ans -> insert (+) p n i ans) (Value ada Map.empty) triples
+valueFromList ada =
+  foldr
+    (\(p, n, i) ans -> insert (+) p n i ans)
+    (Value ada Map.empty)
 
 -- | Display a Value as a String, one token per line
 showValue :: Value era -> String

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -21,6 +21,7 @@
 module Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
   ( sizedTimelock,
     maxTimelockDepth,
+    genMintValues,
   )
 where
 

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
@@ -30,7 +31,11 @@ import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Mary (MaryEra)
 import qualified Cardano.Ledger.Mary.Value as ConcreteValue
-import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
+import qualified Cardano.Ledger.Mary.Value as Mary
+  ( AssetName (..),
+    PolicyID (..),
+    Value (..),
+  )
 import Cardano.Ledger.ShelleyMA (ShelleyMAEra)
 import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA.STS
@@ -38,8 +43,11 @@ import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA (Timelock (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA (TxBody (..))
 import Data.Coerce (coerce)
-import Data.Sequence.Strict (StrictSeq,fromList)
+import Data.Int (Int64)
+import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq, fromList)
 import Data.Typeable (Typeable)
+import Data.Word (Word64)
 import Generic.Random (genericArbitraryU)
 import Shelley.Spec.Ledger.API hiding (SignedDSIGN, TxBody (..))
 import Test.QuickCheck
@@ -48,17 +56,16 @@ import Test.QuickCheck
     choose,
     genericShrink,
     listOf,
-    vectorOf,
     oneof,
     resize,
     shrink,
+    vectorOf,
   )
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.MetaData (genMetaData')
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty.QuickCheck (Gen)
-
 
 {-------------------------------------------------------------------------------
   ShelleyMAEra Generators
@@ -83,8 +90,18 @@ sizedTimelock 0 = (MA.RequireSignature . KeyHash . mkDummyHash) <$> arbitrary
 sizedTimelock n =
   oneof
     [ (MA.RequireSignature . KeyHash . mkDummyHash) <$> arbitrary,
-      MA.RequireAllOf <$> (fromList <$> resize maxTimelockListLens (listOf (sizedTimelock (n -1)))),
-      MA.RequireAnyOf <$> (fromList <$> resize maxTimelockListLens (listOf (sizedTimelock (n -1)))),
+      MA.RequireAllOf
+        <$> ( fromList
+                <$> resize
+                  maxTimelockListLens
+                  (listOf (sizedTimelock (n -1)))
+            ),
+      MA.RequireAnyOf
+        <$> ( fromList
+                <$> resize
+                  maxTimelockListLens
+                  (listOf (sizedTimelock (n -1)))
+            ),
       do
         subs <- resize maxTimelockListLens (listOf (sizedTimelock (n -1)))
         let i = length subs
@@ -112,14 +129,15 @@ instance
   arbitrary =
     genMetaData' >>= \case
       MetaData m ->
-        do ss <- genScriptSeq ; pure (MA.Metadata m ss)
+        do ss <- genScriptSeq; pure (MA.Metadata m ss)
 
-genScriptSeq :: (Arbitrary (Timelock (ShelleyMAEra ma c))) => Gen(StrictSeq (Timelock (ShelleyMAEra ma c)))
+genScriptSeq ::
+  (Arbitrary (Timelock (ShelleyMAEra ma c))) =>
+  Gen (StrictSeq (Timelock (ShelleyMAEra ma c)))
 genScriptSeq = do
-  n <- choose (0,3)
+  n <- choose (0, 3)
   l <- vectorOf n arbitrary
   pure (fromList l)
-
 
 {-------------------------------------------------------------------------------
   MaryEra Generators
@@ -145,12 +163,43 @@ instance Mock c => Arbitrary (Mary.PolicyID (MaryEra c)) where
   arbitrary = Mary.PolicyID <$> arbitrary
 
 instance Mock c => Arbitrary (Mary.Value (MaryEra c)) where
-  arbitrary = Mary.Value <$> (abs <$> arbitrary) <*> (ConcreteValue.prune . pointwiseAbs <$> arbitrary)
-    where
-      pointwiseAbs = fmap (fmap abs)
+  arbitrary = valueFromListBounded @Word64 <$> arbitrary <*> arbitrary
 
-genMintValues :: Mock c => Gen (Mary.Value (MaryEra c))
-genMintValues = Mary.Value 0 . ConcreteValue.prune <$> arbitrary
+  shrink (Mary.Value ada assets) =
+    concat
+      [ -- Shrink the ADA value
+        flip Mary.Value assets <$> shrink ada,
+        -- Shrink the non-ADA assets by reducing the list length
+        Mary.Value
+          ada
+          <$> shrink assets
+      ]
+
+-- | When generating values for the mint field, we do two things:
+--
+-- - Fix the ADA value to 0
+-- - Allow both positive and negative quantities
+genMintValues :: forall c. Mock c => Gen (Mary.Value (MaryEra c))
+genMintValues = valueFromListBounded @Int64 0 <$> arbitrary
+
+-- | Variant on @valueFromList@ that makes sure that generated values stay
+-- bounded within the range of a given integral type.
+valueFromListBounded ::
+  forall i era.
+  (Bounded i, Integral i) =>
+  i ->
+  [(Mary.PolicyID era, Mary.AssetName, i)] ->
+  Mary.Value era
+valueFromListBounded (fromIntegral -> ada) =
+  foldr
+    (\(p, n, fromIntegral -> i) ans -> ConcreteValue.insert comb p n i ans)
+    (Mary.Value ada Map.empty)
+  where
+    comb :: Integer -> Integer -> Integer
+    comb a b =
+      max
+        (fromIntegral $ minBound @i)
+        (min (fromIntegral $ maxBound @i) (a + b))
 
 instance Arbitrary Mary.AssetName where
   arbitrary = Mary.AssetName <$> arbitrary

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -15,28 +16,34 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE GADTs #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip
-  where
+module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 
-import Data.String(fromString)
-import Data.Sequence.Strict (StrictSeq,fromList)
-import qualified Data.ByteString.Lazy as Lazy(null)
-import Cardano.Binary( Annotator (..), FromCBOR, ToCBOR )
+import Cardano.Binary (Annotator (..), FromCBOR, ToCBOR)
+import qualified Cardano.Ledger.Mary.Value as Mary
+  ( AssetName (..),
+    PolicyID (..),
+    Value (..),
+    valueFromList,
+  )
 import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
-import qualified Cardano.Ledger.Mary.Value as Mary(Value(..),AssetName(..),PolicyID(..),valueFromList)
-import Shelley.Spec.Ledger.Scripts(ScriptHash(..))
-import Shelley.Spec.Ledger.MetaData(MetaData(..))
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators() -- import Arbitrary instances
-import Test.Shelley.Spec.Ledger.Generator.MetaData() -- import Arbitrary instances
+import qualified Data.ByteString.Lazy as Lazy (null)
+import Data.Sequence.Strict (StrictSeq, fromList)
+import Data.String (fromString)
+import Shelley.Spec.Ledger.MetaData (MetaData (..))
+import Shelley.Spec.Ledger.Scripts (ScriptHash (..))
+import Test.Cardano.Ledger.EraBuffet
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
+  ( roundTrip,
+    roundTripAnn,
+  )
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
+import Test.Shelley.Spec.Ledger.Generator.MetaData ()
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators (genHash)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders(roundTrip, roundTripAnn)
-import Test.Cardano.Ledger.EraBuffet
-import Test.Tasty.QuickCheck (Gen,arbitrary, choose, vectorOf, testProperty)
-import Test.Tasty(TestTree, testGroup)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Gen, arbitrary, choose, testProperty, vectorOf)
 
 -- ======================================================================
 -- Witnesses to each Era
@@ -45,34 +52,31 @@ data EraIndex index where
   Mary :: EraIndex (MaryEra StandardCrypto)
   Shelley :: EraIndex (ShelleyEra StandardCrypto)
   Allegra :: EraIndex (AllegraEra StandardCrypto)
-  -- Add new Era's here, like this:
-  -- Alonzo :: EraIndex (AlonzoEra StandardCrypto)
 
 instance Show (EraIndex e) where
   show Mary = "Mary Era"
   show Shelley = "Shelley Era"
   show Allegra = "Allegra Era"
-  -- Show Alonzo = "Alonzo Era"
 
 -- ============================================================
 -- EraIndex parameterized generators for each type family
 
-genTxBody :: EraIndex e -> Gen(TxBody e)
+genTxBody :: EraIndex e -> Gen (TxBody e)
 genTxBody Shelley = arbitrary
 genTxBody Mary = arbitrary
 genTxBody Allegra = arbitrary
 
-genScript :: EraIndex e -> Gen(Script e)
+genScript :: EraIndex e -> Gen (Script e)
 genScript Shelley = arbitrary
 genScript Mary = arbitrary
 genScript Allegra = arbitrary
 
-genValue :: EraIndex e -> Gen(Value e)
+genValue :: EraIndex e -> Gen (Value e)
 genValue Shelley = arbitrary
 genValue Mary = genMaryValue Mary
 genValue Allegra = arbitrary
 
-genMeta :: EraIndex e -> Gen(Metadata e)
+genMeta :: EraIndex e -> Gen (Metadata e)
 genMeta Mary = do
   m <- arbitrary
   s <- genScriptSeq Mary
@@ -81,61 +85,86 @@ genMeta Allegra = do
   m <- arbitrary
   s <- genScriptSeq Allegra
   pure (MA.Metadata m s)
-genMeta Shelley = do
-  m <- arbitrary
-  pure (MetaData m)
+genMeta Shelley = MetaData <$> arbitrary
 
 -- ==========================================================
 -- Parameterized helper functions for generating Mary style Values
 
 genAssetName :: Gen Mary.AssetName
-genAssetName = (Mary.AssetName . fromString) <$> arbitrary
+genAssetName = Mary.AssetName . fromString <$> arbitrary
 
 genPolicyID :: EraIndex e -> Gen (Mary.PolicyID e)
 genPolicyID index = Mary.PolicyID <$> genScriptHash index
 
-genScriptHash :: EraIndex e -> Gen(ScriptHash e)
+genScriptHash :: EraIndex e -> Gen (ScriptHash e)
 genScriptHash Shelley = ScriptHash <$> genHash
 genScriptHash Mary = ScriptHash <$> genHash
 genScriptHash Allegra = ScriptHash <$> genHash
 
-genMaryValue :: EraIndex era -> Gen(Mary.Value era)
+genMaryValue :: EraIndex era -> Gen (Mary.Value era)
 genMaryValue index = do
-   ada <- arbitrary
-   size <- choose (0,10)
-   triples <- vectorOf size (do { p <- genPolicyID index; n <- genAssetName; i <- choose (-3,50); pure(p,n,i)})
-   pure $ Mary.valueFromList ada triples
+  ada <- arbitrary
+  size <- choose (0, 10)
+  triples <-
+    vectorOf
+      size
+      ( do
+          p <- genPolicyID index
+          n <- genAssetName
+          i <- choose (-3, 50)
+          pure (p, n, i)
+      )
+  pure $ Mary.valueFromList ada triples
 
 -- ==========================================================
 -- Parameterized helper function for generating MA style Metadata
 
-genScriptSeq :: EraIndex e -> Gen(StrictSeq (Script e))
+genScriptSeq :: EraIndex e -> Gen (StrictSeq (Script e))
 genScriptSeq index = do
-  n <- choose (0,6)
+  n <- choose (0, 6)
   l <- vectorOf n (genScript index)
   pure (fromList l)
 
 -- ==========================================================
 -- EraIndex parameterized property tests
 
-propertyAnn :: forall e t. (Eq t, Show t, ToCBOR t, FromCBOR(Annotator t)) =>
-  String -> EraIndex e -> (EraIndex e -> Gen t) -> TestTree
-propertyAnn name i gen = testProperty ("roundtripAnn "++name) $ do
+propertyAnn ::
+  forall e t.
+  (Eq t, Show t, ToCBOR t, FromCBOR (Annotator t)) =>
+  String ->
+  EraIndex e ->
+  (EraIndex e -> Gen t) ->
+  TestTree
+propertyAnn name i gen = testProperty ("roundtripAnn " ++ name) $ do
   x <- gen i
   case roundTripAnn x of
-    Right(left,_) | not(Lazy.null left) -> error("unconsumed trailing bytes: "++show left)
-    Right(_,y) -> if (x==y) then pure True else error("Unequal\n   "++show x++"\n   "++show y)
-    Left s -> error (show s)
+    Right (left, _)
+      | not (Lazy.null left) ->
+        error ("unconsumed trailing bytes: " ++ show left)
+    Right (_, y) ->
+      if x == y
+        then pure True
+        else error ("Unequal\n   " ++ show x ++ "\n   " ++ show y)
+    Left s -> error (show (s, x))
 
-property :: forall e t. (Eq t, Show t, ToCBOR t, FromCBOR t) =>
-  String -> EraIndex e -> (EraIndex e -> Gen t) -> TestTree
-property name i gen = testProperty ("roundtrip "++name) $ do
+property ::
+  forall e t.
+  (Eq t, Show t, ToCBOR t, FromCBOR t) =>
+  String ->
+  EraIndex e ->
+  (EraIndex e -> Gen t) ->
+  TestTree
+property name i gen = testProperty ("roundtrip " ++ name) $ do
   x <- gen i
   case roundTrip x of
-    Right(left,_) | not(Lazy.null left) -> error("unconsumed trailing bytes: "++show left)
-    Right(_,y) -> if (x==y) then pure True else error("Unequal\n   "++show x++"\n   "++show y)
+    Right (left, _)
+      | not (Lazy.null left) ->
+        error ("unconsumed trailing bytes: " ++ show left)
+    Right (_, y) ->
+      if x == y
+        then pure True
+        else error ("Unequal\n   " ++ show x ++ "\n   " ++ show y)
     Left s -> error (show s)
-
 
 allprops ::
   ( ToCBOR (TxBody e),
@@ -154,15 +183,20 @@ allprops ::
     FromCBOR (Annotator (TxBody e)),
     FromCBOR (Annotator (Metadata e)),
     FromCBOR (Annotator (Script e))
-  ) => EraIndex e -> TestTree
-allprops index = testGroup (show index)
-        [ propertyAnn "TxBody" index genTxBody
-        , propertyAnn "Metadata" index genMeta
-        , property "Value" index genValue
-        , propertyAnn "Script" index genScript
-        ]
+  ) =>
+  EraIndex e ->
+  TestTree
+allprops index =
+  testGroup
+    (show index)
+    [ propertyAnn "TxBody" index genTxBody,
+      propertyAnn "Metadata" index genMeta,
+      property "Value" index genValue,
+      propertyAnn "Script" index genScript
+    ]
 
 allEraRoundtripTests :: TestTree
 allEraRoundtripTests =
-  testGroup "All Era Roundtrip Tests"
-    [ allprops Shelley, allprops Allegra, allprops Mary ]
+  testGroup
+    "All Era Roundtrip Tests"
+    [allprops Shelley, allprops Allegra, allprops Mary]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -304,6 +304,7 @@ instance Arbitrary STS.VotingPeriod where
 instance Arbitrary Coin where
   -- Cannot be negative even though it is an 'Integer'
   arbitrary = Coin <$> choose (0, 1000)
+  shrink (Coin i) = Coin <$> shrink i
 
 instance Arbitrary DeltaCoin where
   arbitrary = DeltaCoin <$> choose (-1000, 1000)


### PR DESCRIPTION
This PR does a few things:

- Speeds up the generation of values for the serialisation tests (time for `roundtripAnn TxBody` in Mary goes from ~10s to ~1s)
- Add some shrinkers for values
- Fixes an issue where integers encoded as `UInt64` would not decode as coins.