### PR TITLE
Abstract the update concern from Shelley

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -31,7 +31,7 @@ import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.LedgerState as LedgerState
-import Shelley.Spec.Ledger.MetaData (validMetaDatum)
+import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import Shelley.Spec.Ledger.STS.Ppup (PPUP)
 import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
 import Shelley.Spec.Ledger.Tx

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -30,13 +30,13 @@ import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.Metadata (validMetadatum)
+import Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.MetaData (validMetaDatum)
+import Shelley.Spec.Ledger.STS.Ppup (PPUP)
+import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
 import Shelley.Spec.Ledger.Tx
   ( ValidateScript (..),
   )
-import Shelley.Spec.Ledger.STS.Ppup (PPUP)
-import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
-import Shelley.Spec.Ledger.LedgerState as LedgerState
 
 -- | The Shelley Mary/Allegra eras
 --
@@ -78,8 +78,9 @@ type instance
   Core.AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c) =
     AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c)
 
-type instance Core.UpdateSTS (ShelleyMAEra (ma :: MaryOrAllegra) c)
-  = PPUP (ShelleyMAEra (ma :: MaryOrAllegra) c)
+type instance
+  Core.UpdateSTS (ShelleyMAEra (ma :: MaryOrAllegra) c) =
+    PPUP (ShelleyMAEra (ma :: MaryOrAllegra) c)
 
 instance Core.HasUpdateLogic (ShelleyMAEra (ma :: MaryOrAllegra) c) where
   initialUpdateState = LedgerState.emptyPPUPState

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -34,6 +34,9 @@ import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import Shelley.Spec.Ledger.Tx
   ( ValidateScript (..),
   )
+import Shelley.Spec.Ledger.STS.Ppup (PPUP)
+import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
+import Shelley.Spec.Ledger.LedgerState as LedgerState
 
 -- | The Shelley Mary/Allegra eras
 --
@@ -74,6 +77,16 @@ type instance
 type instance
   Core.AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c) =
     AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c)
+
+type instance Core.UpdateSTS (ShelleyMAEra (ma :: MaryOrAllegra) c)
+  = PPUP (ShelleyMAEra (ma :: MaryOrAllegra) c)
+
+instance Core.HasUpdateLogic (ShelleyMAEra (ma :: MaryOrAllegra) c) where
+  initialUpdateState = LedgerState.emptyPPUPState
+
+  registerProtocolParametersChange = Ppup.registerProtocolParametersChange
+
+  votedValue = Ppup.votedValue
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -162,6 +162,7 @@ utxoTransition ::
     State (UTXO era) ~ Shelley.UTxOState era,
     Signal (UTXO era) ~ Tx era,
     PredicateFailure (UTXO era) ~ UtxoPredicateFailure era,
+    State (Core.UpdateSTS era) ~ Shelley.PPUPState era,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "mint" (Core.TxBody era) (Core.Value era),

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -19,6 +20,11 @@ module Cardano.Ledger.Core
     Value,
     Script,
     AuxiliaryData,
+    UpdateSTS,
+    HasUpdateLogic
+      ( initialUpdateState,
+        registerProtocolParametersChange
+      ),
 
     -- * Constraint synonyms
     ChainData,
@@ -28,9 +34,13 @@ module Cardano.Ledger.Core
 where
 
 import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
+import Control.State.Transition (STS (State))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import NoThunks.Class (NoThunks)
+-- TODO: we need to make sure it is ok to postpone the abstraction of the era's
+-- update parameters.
+import Shelley.Spec.Ledger.PParams (PParams)
 
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type
@@ -43,6 +53,24 @@ type family Script era :: Type
 
 -- | AuxiliaryData which may be attached to a transaction
 type family AuxiliaryData era :: Type
+
+-- | Update transition system for the era.
+type family UpdateSTS era :: Type
+
+class HasUpdateLogic era where
+  initialUpdateState :: State (UpdateSTS era)
+
+  registerProtocolParametersChange ::
+    State (UpdateSTS era) -> PParams era -> State (UpdateSTS era)
+
+-- votedValue :: State (UpdateSTS era) ... hmmm I'm not sure how to abstract
+--   away the oter parameters of the concrete votedValue.
+--
+-- ... we might need a VOTEDVALUE transition that we make vary accross eras
+-- which might mean another STS :/
+--
+-- An easy way to solve this is to add the PParams era -> Int -> parameter,
+-- and simply discard the quorum in the Priviledge prototype.
 
 -- | Common constraints
 --

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -39,8 +39,8 @@ import Control.State.Transition (STS (State))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import NoThunks.Class (NoThunks)
--- TODO: we need to make sure it is ok to postpone the abstraction of the era's
--- update parameters.
+-- NOTE: all eras use the same type of protocol parameters, since at the moment
+-- there is no need of abstracting away the protocol parameters.
 import Shelley.Spec.Ledger.PParams (PParams)
 
 -- | A value is something which quantifies a transaction output.
@@ -65,9 +65,21 @@ type family UpdateSTS era :: Type
 class HasUpdateLogic era where
   initialUpdateState :: State (UpdateSTS era)
 
+  -- | Shelley requires that the update system registers a change in the
+  -- protocol parameters. Other update systems might chose to ignore this.
   registerProtocolParametersChange ::
     State (UpdateSTS era) -> PParams era -> State (UpdateSTS era)
 
+  -- | Determine what is the voted value given the current update system state,
+  -- the current update parameters, and the number of nodes that need to agree
+  -- on the protocol parameters change.
+  --
+  -- TODO: at the moment this function is too Shelley-specific, since in general
+  -- all the update-sub-system should have access to is its environment and its
+  -- state. We should make sure we abstract away the protocol-parameters and
+  -- quorum parameters of this function. This will require modifying the Shelley
+  -- Epoch rule to call @votedValue@ with some environment instead, which we'll
+  -- have to build in an era-independent way.
   votedValue ::
     State (UpdateSTS era) -> PParams era -> Int -> Maybe (PParams era)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -55,11 +55,7 @@ type family Script era :: Type
 -- | AuxiliaryData which may be attached to a transaction
 type family AuxiliaryData era :: Type
 
--- | Update transition system for the era.
---
--- TODO: this is actually the update payload processing rule, so we need to name
--- it accordingly. We will need another rule to register slot changes in the
--- tick rule.
+-- | Transition system that processes the update payload for the era.
 type family UpdateSTS era :: Type
 
 class HasUpdateLogic era where

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -23,7 +23,8 @@ module Cardano.Ledger.Core
     UpdateSTS,
     HasUpdateLogic
       ( initialUpdateState,
-        registerProtocolParametersChange
+        registerProtocolParametersChange,
+        votedValue
       ),
 
     -- * Constraint synonyms
@@ -63,14 +64,8 @@ class HasUpdateLogic era where
   registerProtocolParametersChange ::
     State (UpdateSTS era) -> PParams era -> State (UpdateSTS era)
 
--- votedValue :: State (UpdateSTS era) ... hmmm I'm not sure how to abstract
---   away the oter parameters of the concrete votedValue.
---
--- ... we might need a VOTEDVALUE transition that we make vary accross eras
--- which might mean another STS :/
---
--- An easy way to solve this is to add the PParams era -> Int -> parameter,
--- and simply discard the quorum in the Priviledge prototype.
+  votedValue ::
+    State (UpdateSTS era) -> PParams era -> Int -> Maybe (PParams era)
 
 -- | Common constraints
 --

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -56,6 +56,10 @@ type family Script era :: Type
 type family AuxiliaryData era :: Type
 
 -- | Update transition system for the era.
+--
+-- TODO: this is actually the update payload processing rule, so we need to name
+-- it accordingly. We will need another rule to register slot changes in the
+-- tick rule.
 type family UpdateSTS era :: Type
 
 class HasUpdateLogic era where

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -24,9 +24,9 @@ import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (hashWithSerialiser)
 import Shelley.Spec.Ledger.LedgerState as LedgerState
-import Shelley.Spec.Ledger.MetaData
-  ( MetaData (MetaData),
-    validMetaDatum,
+import Shelley.Spec.Ledger.Metadata
+  ( Metadata (Metadata),
+    validMetadatum,
   )
 import Shelley.Spec.Ledger.STS.Ppup (PPUP)
 import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -52,6 +52,8 @@ type instance Core.AuxiliaryData (ShelleyEra c) = Metadata
 
 type instance Core.UpdateSTS (ShelleyEra c) = PPUP (ShelleyEra c)
 
+instance Core.HasUpdateLogic (ShelleyEra c) where
+
 --------------------------------------------------------------------------------
 -- Ledger data instances
 --------------------------------------------------------------------------------

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -31,6 +31,7 @@ import Shelley.Spec.Ledger.Tx
     hashMultiSigScript,
     validateNativeMultiSigScript,
   )
+import Shelley.Spec.Ledger.STS.Ppup (PPUP)
 
 data ShelleyEra c
 
@@ -48,6 +49,8 @@ type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
 type instance Core.Script (ShelleyEra c) = MultiSig c
 
 type instance Core.AuxiliaryData (ShelleyEra c) = Metadata
+
+type instance Core.UpdateSTS (ShelleyEra c) = PPUP (ShelleyEra c)
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -23,7 +23,13 @@ import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (hashWithSerialiser)
-import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
+import Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.MetaData
+  ( MetaData (MetaData),
+    validMetaDatum,
+  )
+import Shelley.Spec.Ledger.STS.Ppup (PPUP)
+import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
   ( TxBody,
@@ -31,9 +37,6 @@ import Shelley.Spec.Ledger.Tx
     hashMultiSigScript,
     validateNativeMultiSigScript,
   )
-import Shelley.Spec.Ledger.STS.Ppup (PPUP)
-import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
-import Shelley.Spec.Ledger.LedgerState as LedgerState
 
 data ShelleyEra c
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -32,6 +32,8 @@ import Shelley.Spec.Ledger.Tx
     validateNativeMultiSigScript,
   )
 import Shelley.Spec.Ledger.STS.Ppup (PPUP)
+import qualified Shelley.Spec.Ledger.STS.Ppup as Ppup
+import Shelley.Spec.Ledger.LedgerState as LedgerState
 
 data ShelleyEra c
 
@@ -53,6 +55,11 @@ type instance Core.AuxiliaryData (ShelleyEra c) = Metadata
 type instance Core.UpdateSTS (ShelleyEra c) = PPUP (ShelleyEra c)
 
 instance Core.HasUpdateLogic (ShelleyEra c) where
+  initialUpdateState = LedgerState.emptyPPUPState
+
+  registerProtocolParametersChange = Ppup.registerProtocolParametersChange
+
+  votedValue = Ppup.votedValue
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -15,7 +15,8 @@ import Cardano.Ledger.Core
     SerialisableData,
     TxBody,
     Value,
-    UpdateSTS
+    UpdateSTS,
+    HasUpdateLogic
   )
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Torsor (Torsor (..))
@@ -55,6 +56,7 @@ type ShelleyBased era =
     SerialisableData (Delta (Value era)),
     Torsor (Value era),
     -- STS Constraints
+    HasUpdateLogic era,
     Eq (State (UpdateSTS era)),
     Show (State (UpdateSTS era)),
     NFData (State (UpdateSTS era)),

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -11,23 +11,23 @@ import Cardano.Ledger.Core
   ( AnnotatedData,
     AuxiliaryData,
     ChainData,
+    HasUpdateLogic,
     Script,
     SerialisableData,
     TxBody,
-    Value,
     UpdateSTS,
-    HasUpdateLogic
+    Value,
   )
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val (DecodeNonNegative, Val)
+import Control.DeepSeq (NFData)
+import Control.State.Transition (STS (State))
+import NoThunks.Class (NoThunks)
 import Shelley.Spec.Ledger.Hashing
   ( EraIndependentTxBody,
     HashAnnotated (..),
   )
-import Control.State.Transition (STS(State))
-import Control.DeepSeq (NFData)
-import NoThunks.Class (NoThunks)
 
 --------------------------------------------------------------------------------
 -- Shelley Era

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Core
     SerialisableData,
     TxBody,
     Value,
+    UpdateSTS
   )
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Torsor (Torsor (..))
@@ -23,6 +24,9 @@ import Shelley.Spec.Ledger.Hashing
   ( EraIndependentTxBody,
     HashAnnotated (..),
   )
+import Control.State.Transition (STS(State))
+import Control.DeepSeq (NFData)
+import NoThunks.Class (NoThunks)
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -50,6 +54,12 @@ type ShelleyBased era =
     ChainData (Delta (Value era)),
     SerialisableData (Delta (Value era)),
     Torsor (Value era),
+    -- STS Constraints
+    Eq (State (UpdateSTS era)),
+    Show (State (UpdateSTS era)),
+    NFData (State (UpdateSTS era)),
+    NoThunks (State (UpdateSTS era)),
+    SerialisableData (State (UpdateSTS era)),
     -- TxBody constraints
     TxBodyConstraints era,
     -- Script constraints

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -111,6 +111,7 @@ import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (Bimap, biMapEmpty, dom, eval, forwards, range, (∈), (∪+), (▷), (◁))
+import Control.State.Transition (STS (State))
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Coerce (coerce)
 import Data.Foldable (fold, toList)
@@ -230,7 +231,6 @@ import Shelley.Spec.Ledger.UTxO
     txup,
     verifyWitVKey,
   )
-import Control.State.Transition (STS(State))
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
 type KeyPairs crypto = [(KeyPair 'Payment crypto, KeyPair 'Staking crypto)]
@@ -504,11 +504,14 @@ instance
 emptyPPUPState :: PPUPState era
 emptyPPUPState = PPUPState emptyPPPUpdates emptyPPPUpdates
 
-emptyUTxOState :: forall era . Core.HasUpdateLogic era => UTxOState era
+emptyUTxOState :: forall era. Core.HasUpdateLogic era => UTxOState era
 emptyUTxOState = initialUTxOState (UTxO Map.empty)
 
-initialUTxOState :: forall era . Core.HasUpdateLogic era
-  => UTxO era -> UTxOState era
+initialUTxOState ::
+  forall era.
+  Core.HasUpdateLogic era =>
+  UTxO era ->
+  UTxOState era
 initialUTxOState utxo =
   UTxOState utxo (Coin 0) (Coin 0) (Core.initialUpdateState @era)
 
@@ -576,11 +579,14 @@ pvCanFollow (ProtVer m n) (SJust (ProtVer m' n')) =
 -- The UTxO state contains the update state. Depending on the implementation of
 -- the update logic, a protocol-parameters change might cause a change in the
 -- update state as well.
-updatePpup
-  :: forall era . Core.HasUpdateLogic era
-  => UTxOState era -> PParams era -> UTxOState era
+updatePpup ::
+  forall era.
+  Core.HasUpdateLogic era =>
+  UTxOState era ->
+  PParams era ->
+  UTxOState era
 updatePpup utxoSt pp =
-  utxoSt {_ppups = Core.registerProtocolParametersChange @era (_ppups utxoSt) pp }
+  utxoSt {_ppups = Core.registerProtocolParametersChange @era (_ppups utxoSt) pp}
 
 data UTxOState era = UTxOState
   { _utxo :: !(UTxO era),
@@ -598,11 +604,13 @@ deriving stock instance
   ShelleyBased era =>
   Eq (UTxOState era)
 
-deriving instance (Era era, NFData (State (Core.UpdateSTS era)))
-  => NFData (UTxOState era)
+deriving instance
+  (Era era, NFData (State (Core.UpdateSTS era))) =>
+  NFData (UTxOState era)
 
-deriving instance (NoThunks (State (Core.UpdateSTS era)))
-  =>  NoThunks (UTxOState era)
+deriving instance
+  (NoThunks (State (Core.UpdateSTS era))) =>
+  NoThunks (UTxOState era)
 
 instance
   ShelleyBased era =>
@@ -722,7 +730,8 @@ instance
 -- | Creates the ledger state for an empty ledger which
 --  contains the specified transaction outputs.
 genesisState ::
-  forall era . Core.HasUpdateLogic era =>
+  forall era.
+  Core.HasUpdateLogic era =>
   Map (KeyHash 'Genesis (Crypto era)) (GenDelegPair (Crypto era)) ->
   UTxO era ->
   LedgerState era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -125,6 +125,7 @@ import Shelley.Spec.Ledger.STS.Tickn
 import Shelley.Spec.Ledger.Slot (EpochNo)
 import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
+import qualified Cardano.Ledger.Core as Core
 
 data CHAIN era
 
@@ -147,7 +148,7 @@ deriving stock instance
   ShelleyBased era =>
   Eq (ChainState era)
 
-instance (Era era) => NFData (ChainState era)
+instance (Era era, ShelleyBased era) => NFData (ChainState era)
 
 data ChainPredicateFailure era
   = HeaderSizeTooLargeCHAIN
@@ -186,6 +187,8 @@ instance
 
 -- | Creates a valid initial chain state
 initialShelleyState ::
+  forall era .
+  Core.HasUpdateLogic era =>
   WithOrigin (LastAppliedBlock (Crypto era)) ->
   EpochNo ->
   UTxO era ->
@@ -208,7 +211,7 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
                     utxo
                     (Coin 0)
                     (Coin 0)
-                    emptyPPUPState
+                    (Core.initialUpdateState @era)
                 )
                 (DPState (emptyDState {_genDelegs = (GenDelegs genDelegs)}) emptyPState)
             )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -100,7 +100,6 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     UTxOState (..),
     emptyDState,
-    emptyPPUPState,
     emptyPState,
     updateNES,
     _genDelegs,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -30,6 +30,7 @@ module Shelley.Spec.Ledger.STS.Chain
 where
 
 import qualified Cardano.Crypto.VRF as VRF
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
@@ -124,7 +125,6 @@ import Shelley.Spec.Ledger.STS.Tickn
 import Shelley.Spec.Ledger.Slot (EpochNo)
 import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
-import qualified Cardano.Ledger.Core as Core
 
 data CHAIN era
 
@@ -186,7 +186,7 @@ instance
 
 -- | Creates a valid initial chain state
 initialShelleyState ::
-  forall era .
+  forall era.
   Core.HasUpdateLogic era =>
   WithOrigin (LastAppliedBlock (Crypto era)) ->
   EpochNo ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -101,7 +101,7 @@ initialEpoch =
 
 epochTransition ::
   forall era.
-  ShelleyBased era => -- TODO: should the HasUpdateLogic constraint be part of ShelleyBased?
+  ShelleyBased era =>
   TransitionRule (EPOCH era)
 epochTransition = do
   TRC

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -54,7 +54,7 @@ import Shelley.Spec.Ledger.LedgerState
     pattern DPState,
     pattern EpochState,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, ProposedPPUpdates (..), emptyPParams, updatePParams)
+import Shelley.Spec.Ledger.PParams (emptyPParams)
 import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppState (..))
 import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapState (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -14,22 +14,34 @@
 module Shelley.Spec.Ledger.STS.Epoch
   ( EPOCH,
     EpochPredicateFailure (..),
-    PredicateFailure
+    PredicateFailure,
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
-import Control.State.Transition (Embed (..), InitialRule
-                                , STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
+import Control.State.Transition
+  ( Embed (..),
+    InitialRule,
+    STS (..),
+    TRC (..),
+    TransitionRule,
+    judgmentContext,
+    liftSTS,
+    trans,
+  )
 import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState,
     PState (..),
+    emptyAccount,
+    emptyLedgerState,
     esAccountState,
     esLState,
     esNonMyopic,
@@ -39,8 +51,6 @@ import Shelley.Spec.Ledger.LedgerState
     _delegationState,
     _ppups,
     _utxoState,
-    emptyAccount,
-    emptyLedgerState,
     pattern DPState,
     pattern EpochState,
   )
@@ -50,8 +60,6 @@ import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppState (..))
 import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapState (..))
 import Shelley.Spec.Ledger.STS.Snap (SNAP)
 import Shelley.Spec.Ledger.Slot (EpochNo)
-import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
-import qualified Cardano.Ledger.Core as Core
 
 data EPOCH era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -75,21 +75,23 @@ instance ShelleyBased era => STS (EPOCH era) where
   type Environment (EPOCH era) = ()
   type BaseM (EPOCH era) = ShelleyBase
   type PredicateFailure (EPOCH era) = EpochPredicateFailure era
-  initialRules = [initialEpoch]
+  initialRules = [
+    -- initialEpoch
+    ]
   transitionRules = [epochTransition]
 
 instance NoThunks (EpochPredicateFailure era)
 
-initialEpoch :: InitialRule (EPOCH era)
-initialEpoch =
-  pure $
-    EpochState
-      emptyAccount
-      emptySnapShots
-      emptyLedgerState
-      emptyPParams
-      emptyPParams
-      emptyNonMyopic
+-- initialEpoch :: InitialRule (EPOCH era)
+-- initialEpoch =
+--   pure $
+--     EpochState
+--       emptyAccount
+--       emptySnapShots
+--       emptyLedgerState
+--       emptyPParams
+--       emptyPParams
+--       emptyNonMyopic
 
 votedValue ::
   ProposedPPUpdates era ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -75,9 +75,7 @@ instance ShelleyBased era => STS (EPOCH era) where
   type Environment (EPOCH era) = ()
   type BaseM (EPOCH era) = ShelleyBase
   type PredicateFailure (EPOCH era) = EpochPredicateFailure era
-  initialRules = [
-    initialEpoch
-    ]
+  initialRules = [initialEpoch]
   transitionRules = [epochTransition]
 
 instance NoThunks (EpochPredicateFailure era)
@@ -95,7 +93,7 @@ initialEpoch =
 
 epochTransition ::
   forall era.
-  (Core.HasUpdateLogic era, ShelleyBased era) => -- TODO: should the HasUpdateLogic constraint be part of ShelleyBased?
+  ShelleyBased era => -- TODO: should the HasUpdateLogic constraint be part of ShelleyBased?
   TransitionRule (EPOCH era)
 epochTransition = do
   TRC
@@ -128,7 +126,6 @@ epochTransition = do
 
   coreNodeQuorum <- liftSTS $ asks quorum
 
-  -- let pup = proposals . _ppups $ utxoSt'
   let ppNew = Core.votedValue (_ppups utxoSt') pp (fromIntegral coreNodeQuorum)
   NewppState utxoSt'' acnt'' pp' <-
     trans @(NEWPP era) $

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -112,7 +112,7 @@ instance
   type PredicateFailure (LEDGERS era) = LedgersPredicateFailure era
 
   initialRules = [
-    -- pure emptyLedgerState
+    pure emptyLedgerState
     ]
   transitionRules = [ledgersTransition]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -111,7 +111,9 @@ instance
   type BaseM (LEDGERS era) = ShelleyBase
   type PredicateFailure (LEDGERS era) = LedgersPredicateFailure era
 
-  initialRules = [pure emptyLedgerState]
+  initialRules = [
+    -- pure emptyLedgerState
+    ]
   transitionRules = [ledgersTransition]
 
 ledgersTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -111,9 +111,7 @@ instance
   type BaseM (LEDGERS era) = ShelleyBase
   type PredicateFailure (LEDGERS era) = LedgersPredicateFailure era
 
-  initialRules = [
-    pure emptyLedgerState
-    ]
+  initialRules = [pure emptyLedgerState]
   transitionRules = [ledgersTransition]
 
 ledgersTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Mir
@@ -18,6 +18,7 @@ module Shelley.Spec.Ledger.STS.Mir
 where
 
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<->))
 import Control.SetAlgebra (dom, eval, (∪+), (◁))
 import Control.State.Transition
@@ -56,7 +57,6 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (emptyPParams)
 import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 
 data MIR era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -72,9 +72,7 @@ instance (Typeable era, ShelleyBased era) => STS (MIR era) where
   type BaseM (MIR era) = ShelleyBase
   type PredicateFailure (MIR era) = MirPredicateFailure era
 
-  initialRules = [
-    initialMir
-    ]
+  initialRules = [initialMir]
   transitionRules = [mirTransition]
 
   assertions =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Mir
   ( MIR,
@@ -54,6 +56,7 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (emptyPParams)
 import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 
 data MIR era
 
@@ -62,7 +65,7 @@ data MirPredicateFailure era
 
 instance NoThunks (MirPredicateFailure era)
 
-instance Typeable era => STS (MIR era) where
+instance (Typeable era, ShelleyBased era) => STS (MIR era) where
   type State (MIR era) = EpochState era
   type Signal (MIR era) = ()
   type Environment (MIR era) = ()
@@ -70,7 +73,7 @@ instance Typeable era => STS (MIR era) where
   type PredicateFailure (MIR era) = MirPredicateFailure era
 
   initialRules = [
-    -- initialMir
+    initialMir
     ]
   transitionRules = [mirTransition]
 
@@ -83,16 +86,16 @@ instance Typeable era => STS (MIR era) where
         )
     ]
 
--- initialMir :: InitialRule (MIR era)
--- initialMir =
---   pure $
---     EpochState
---       emptyAccount
---       emptySnapShots
---       emptyLedgerState
---       emptyPParams
---       emptyPParams
---       emptyNonMyopic
+initialMir :: ShelleyBased era => InitialRule (MIR era)
+initialMir =
+  pure $
+    EpochState
+      emptyAccount
+      emptySnapShots
+      emptyLedgerState
+      emptyPParams
+      emptyPParams
+      emptyNonMyopic
 
 mirTransition :: forall era. TransitionRule (MIR era)
 mirTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -69,7 +69,9 @@ instance Typeable era => STS (MIR era) where
   type BaseM (MIR era) = ShelleyBase
   type PredicateFailure (MIR era) = MirPredicateFailure era
 
-  initialRules = [initialMir]
+  initialRules = [
+    -- initialMir
+    ]
   transitionRules = [mirTransition]
 
   assertions =
@@ -81,16 +83,16 @@ instance Typeable era => STS (MIR era) where
         )
     ]
 
-initialMir :: InitialRule (MIR era)
-initialMir =
-  pure $
-    EpochState
-      emptyAccount
-      emptySnapShots
-      emptyLedgerState
-      emptyPParams
-      emptyPParams
-      emptyNonMyopic
+-- initialMir :: InitialRule (MIR era)
+-- initialMir =
+--   pure $
+--     EpochState
+--       emptyAccount
+--       emptySnapShots
+--       emptyLedgerState
+--       emptyPParams
+--       emptyPParams
+--       emptyNonMyopic
 
 mirTransition :: forall era. TransitionRule (MIR era)
 mirTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -19,6 +19,7 @@ module Shelley.Spec.Ledger.STS.NewEpoch
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import qualified Cardano.Ledger.Val as Val
@@ -37,7 +38,6 @@ import Shelley.Spec.Ledger.STS.Epoch
 import Shelley.Spec.Ledger.STS.Mir
 import Shelley.Spec.Ledger.Slot
 import Shelley.Spec.Ledger.TxBody
-import qualified Cardano.Ledger.Core as Core
 
 data NEWEPOCH era
 
@@ -81,8 +81,7 @@ instance ShelleyBased era => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ShelleyBased era
-   =>
+  ShelleyBased era =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
   TRC
@@ -128,7 +127,7 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-   ShelleyBased era =>
+  ShelleyBased era =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -19,7 +19,6 @@ module Shelley.Spec.Ledger.STS.NewEpoch
   )
 where
 
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import qualified Cardano.Ledger.Val as Val

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -37,6 +37,7 @@ import Shelley.Spec.Ledger.STS.Epoch
 import Shelley.Spec.Ledger.STS.Mir
 import Shelley.Spec.Ledger.Slot
 import Shelley.Spec.Ledger.TxBody
+import qualified Cardano.Ledger.Core as Core
 
 data NEWEPOCH era
 
@@ -55,7 +56,7 @@ deriving stock instance
 
 instance NoThunks (NewEpochPredicateFailure era)
 
-instance ShelleyBased era => STS (NEWEPOCH era) where
+instance (Core.HasUpdateLogic era, ShelleyBased era) => STS (NEWEPOCH era) where
   type State (NEWEPOCH era) = NewEpochState era
 
   type Signal (NEWEPOCH era) = EpochNo
@@ -80,7 +81,7 @@ instance ShelleyBased era => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ( ShelleyBased era
+  ( Core.HasUpdateLogic era, ShelleyBased era
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
@@ -127,7 +128,7 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-  ShelleyBased era =>
+  (Core.HasUpdateLogic era, ShelleyBased era) =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -128,7 +128,7 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-  (Core.HasUpdateLogic era, ShelleyBased era) =>
+   ShelleyBased era =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -56,7 +56,7 @@ deriving stock instance
 
 instance NoThunks (NewEpochPredicateFailure era)
 
-instance (Core.HasUpdateLogic era, ShelleyBased era) => STS (NEWEPOCH era) where
+instance ShelleyBased era => STS (NEWEPOCH era) where
   type State (NEWEPOCH era) = NewEpochState era
 
   type Signal (NEWEPOCH era) = EpochNo
@@ -81,8 +81,8 @@ instance (Core.HasUpdateLogic era, ShelleyBased era) => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ( Core.HasUpdateLogic era, ShelleyBased era
-  ) =>
+  ShelleyBased era
+   =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
   TRC

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -76,9 +76,7 @@ instance (Typeable era, ShelleyBased era) => STS (NEWPP era) where
   type Environment (NEWPP era) = NewppEnv era
   type BaseM (NEWPP era) = ShelleyBase
   type PredicateFailure (NEWPP era) = NewppPredicateFailure era
-  initialRules = [
-    initialNewPp
-                 ]
+  initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
 initialNewPp :: forall era . ShelleyBased era => InitialRule (NEWPP era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -43,7 +43,6 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     UTxOState,
     emptyAccount,
-    emptyPPUPState,
     totalInstantaneousReservesRewards,
     updatePpup,
     _deposited,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -46,6 +46,7 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams)
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
+import Cardano.Ledger.Core as Core
 
 data NEWPP era
 
@@ -63,24 +64,27 @@ data NewppPredicateFailure era
 
 instance NoThunks (NewppPredicateFailure era)
 
-instance Typeable era => STS (NEWPP era) where
+instance (Typeable era, Core.HasUpdateLogic era) => STS (NEWPP era) where
   type State (NEWPP era) = NewppState era
   type Signal (NEWPP era) = Maybe (PParams era)
   type Environment (NEWPP era) = NewppEnv era
   type BaseM (NEWPP era) = ShelleyBase
   type PredicateFailure (NEWPP era) = NewppPredicateFailure era
-  initialRules = [initialNewPp]
+  initialRules = [
+    -- initialNewPp
+                 ]
   transitionRules = [newPpTransition]
 
-initialNewPp :: InitialRule (NEWPP era)
-initialNewPp =
-  pure $
-    NewppState
-      (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPUPState)
-      emptyAccount
-      emptyPParams
+-- initialNewPp :: InitialRule (NEWPP era)
+-- initialNewPp =
+--   pure $
+--     NewppState
+--       (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPUPState)
+--       emptyAccount
+--       emptyPParams
 
-newPpTransition :: TransitionRule (NEWPP era)
+newPpTransition ::
+  Core.HasUpdateLogic era => TransitionRule (NEWPP era)
 newPpTransition = do
   TRC (NewppEnv dstate pstate, NewppState utxoSt acnt pp, ppNew) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Newpp
@@ -19,7 +19,9 @@ module Shelley.Spec.Ledger.STS.Newpp
   )
 where
 
+import Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.State.Transition
   ( InitialRule,
     STS (..),
@@ -51,8 +53,6 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams)
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
-import Cardano.Ledger.Core as Core
 
 data NEWPP era
 
@@ -79,7 +79,7 @@ instance (Typeable era, ShelleyBased era) => STS (NEWPP era) where
   initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
-initialNewPp :: forall era . ShelleyBased era => InitialRule (NEWPP era)
+initialNewPp :: forall era. ShelleyBased era => InitialRule (NEWPP era)
 initialNewPp =
   pure $
     NewppState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -48,6 +48,7 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..))
 import Shelley.Spec.Ledger.TxBody (getRwdCred, _poolRAcnt)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 
 data POOLREAP era
 
@@ -67,15 +68,15 @@ data PoolreapPredicateFailure era -- No predicate Falures
 
 instance NoThunks (PoolreapPredicateFailure era)
 
-instance Typeable era => STS (POOLREAP era) where
+instance (Typeable era, ShelleyBased era) => STS (POOLREAP era) where
   type State (POOLREAP era) = PoolreapState era
   type Signal (POOLREAP era) = EpochNo
   type Environment (POOLREAP era) = PParams era
   type BaseM (POOLREAP era) = ShelleyBase
   type PredicateFailure (POOLREAP era) = PoolreapPredicateFailure era
   initialRules =
-    [ -- pure $
-      --   PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState
+    [ pure $
+        PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState
     ]
   transitionRules = [poolReapTransition]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -48,7 +48,6 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..))
 import Shelley.Spec.Ledger.TxBody (getRwdCred, _poolRAcnt)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 
 data POOLREAP era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -74,8 +74,8 @@ instance Typeable era => STS (POOLREAP era) where
   type BaseM (POOLREAP era) = ShelleyBase
   type PredicateFailure (POOLREAP era) = PoolreapPredicateFailure era
   initialRules =
-    [ pure $
-        PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState
+    [ -- pure $
+      --   PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState
     ]
   transitionRules = [poolReapTransition]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -163,3 +163,16 @@ ppupTransitionNonEmpty = do
             PPUPState
               (ProposedPPUpdates pupS)
               (ProposedPPUpdates (eval (fpupS ⨃ pup)))
+
+-- | Update the protocol parameter updates by clearing out the proposals and
+-- making the future proposals become the new proposals, provided __all of__ the
+-- new proposals can follow, or otherwise reset them.
+registerProtocolParametersChange
+  :: PPUPState era -> PParams era -> PPUPState era
+registerProtocolParametersChange ppupState pp =  PPUPState ps emptyPPPUpdates
+  where
+    (ProposedPPUpdates newProposals) = futureProposals ppupState
+    goodPV = pvCanFollow (_protocolVersion pp) . _protocolVersion
+    ps = if all goodPV newProposals
+         then ProposedPPUpdates newProposals
+         else emptyPPPUpdates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -182,10 +182,15 @@ registerProtocolParametersChange ppupState pp =  PPUPState ps emptyPPPUpdates
          then ProposedPPUpdates newProposals
          else emptyPPPUpdates
 
+-- | If at least @n@ nodes voted to change __the same__ protocol parameters to
+-- __the same__ values, return the given protocol parameters updated to these
+-- values. Here @n@ is the quorum needed.
 votedValue ::
   PPUPState era ->
   PParams era ->
+  -- ^ Protocol parameters to which the change will be applied.
   Int ->
+  -- ^ Quorum needed to change the protocol parameters.
   Maybe (PParams era)
 votedValue PPUPState {proposals} pps quorumN =
   let incrTally vote tally = 1 + Map.findWithDefault 0 vote tally

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -260,9 +260,7 @@ instance
   type BaseM (UTXO (ShelleyEra c)) = ShelleyBase
   type PredicateFailure (UTXO (ShelleyEra c)) = UtxoPredicateFailure (ShelleyEra c)
 
-  transitionRules =
-    [ utxoInductive
-    ]
+  transitionRules = [utxoInductive]
   initialRules = [initialLedgerState]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -261,73 +261,7 @@ instance
   type PredicateFailure (UTXO (ShelleyEra c)) = UtxoPredicateFailure (ShelleyEra c)
 
   transitionRules =
-    [ -- do
-      --  TRC (UtxoEnv slot pp stakepools genDelegs, u, tx) <- judgmentContext
-      --  let UTxOState utxo deposits' fees ppup = u
-      --  let txb = _body tx
-
-      --  getField @"ttl" txb >= slot ?! ExpiredUTxO (getField @"ttl" txb) slot
-      --  -- the ttl field marks the top of an open interval, so it must be
-      --  -- strictly less than the slot, so raise an error if it is (>=).
-
-      --  txins txb /= Set.empty ?! InputSetEmptyUTxO
-
-      --  let minFee = minfee pp tx
-      --      txFee = getField @"txfee" txb
-      --  minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
-
-      --  eval (txins txb ⊆ dom utxo)
-      --    ?! BadInputsUTxO (eval (txins txb ➖ dom utxo))
-
-      --  ni <- liftSTS $ asks networkId
-      --  let addrsWrongNetwork =
-      --        filter
-      --          (\a -> getNetwork a /= ni)
-      --          (fmap (\(TxOut a _) -> a) $ toList $ getField @"outputs" txb)
-      --  null addrsWrongNetwork ?! WrongNetwork ni (Set.fromList addrsWrongNetwork)
-      --  let wdrlsWrongNetwork =
-      --        filter
-      --          (\a -> getRwdNetwork a /= ni)
-      --          (Map.keys . unWdrl . getField @"wdrls" $ txb)
-      --  null wdrlsWrongNetwork ?! WrongNetworkWithdrawal ni (Set.fromList wdrlsWrongNetwork)
-
-      --  let consumed_ = consumed pp utxo txb
-      --      produced_ = produced pp stakepools txb
-      --  consumed_ == produced_ ?! ValueNotConservedUTxO (toDelta consumed_) (toDelta produced_)
-
-      --  -- process Protocol Parameter Update Proposals
-      --  ppup' <- trans @(PPUP (ShelleyEra c)) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
-
-      --  let outputs = Map.elems $ unUTxO (txouts txb)
-      --      minUTxOValue = _minUTxOValue pp
-      --      -- minUTxOValue deposit comparison done as Coin because this rule
-      --      -- is correct strictly in the Shelley era (in shelleyMA we would need to
-      --      -- additionally check that all amounts are non-negative)
-      --      outputsTooSmall = [out | out@(TxOut _ c) <- outputs, (Val.coin c) < (Val.scaledMinDeposit c minUTxOValue)]
-      --  null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
-
-      --  -- Bootstrap (i.e. Byron) addresses have variable sized attributes in them.
-      --  -- It is important to limit their overall size.
-      --  let outputsAttrsTooBig =
-      --        [out | out@(TxOut (AddrBootstrap addr) _) <- outputs, bootstrapAddressAttrsSize addr > 64]
-      --  null outputsAttrsTooBig ?! OutputBootAddrAttrsTooBig outputsAttrsTooBig
-
-      --  let maxTxSize_ = fromIntegral (_maxTxSize pp)
-      --      txSize_ = txsize tx
-      --  txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
-
-      --  let refunded = keyRefunds pp txb
-      --  let txCerts = toList $ getField @"certs" txb
-      --  let depositChange = totalDeposits pp stakepools txCerts <-> refunded
-
-      --  pure
-      --    UTxOState
-      --      { _utxo = eval ((txins txb ⋪ utxo) ∪ txouts txb),
-      --        _deposited = deposits' <> depositChange,
-      --        _fees = fees <> (getField @"txfee" txb),
-      --        _ppups = ppup'
-      --      }
-      utxoInductive
+    [ utxoInductive
     ]
   initialRules = [initialLedgerState]
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -64,6 +64,7 @@ import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest, testGlobals)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 
 data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block era)
 
@@ -115,7 +116,7 @@ benchValidate (ValidateInput globals state block) =
 
 applyBlock ::
   forall era.
-  ( Era era,
+  ( ShelleyBased era,
     API.ApplyBlock era
   ) =>
   ValidateInput era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -443,7 +443,7 @@ instance
   Arbitrary (UTxOState era)
   where
   arbitrary = genericArbitraryU
-  shrink utxoState = recursivelyShrink
+  shrink = recursivelyShrink
     -- The 'genericShrink' function returns first the immediate subterms of a
     -- value (in case it is a recursive data-type), and then shrinks the value
     -- itself. Since 'UTxOState' is not a recursive data-type, there are no

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -437,7 +437,7 @@ instance CC.Crypto crypto => Arbitrary (DPState crypto) where
   shrink = genericShrink
 
 instance
-  (ShelleyBased era, Mock (Crypto era),
+  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era),
   Arbitrary (State (Core.UpdateSTS era)) ) =>
   Arbitrary (UTxOState era)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -458,7 +458,7 @@ instance
     | ppups' <- shrink (_ppups utxoState)]
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era)
+  (ShelleyBased era, Mock (Crypto era)
   , Arbitrary (UTxOState era)) =>
   Arbitrary (LedgerState era)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -113,6 +113,7 @@ import Test.QuickCheck
     resize,
     shrink,
     vectorOf,
+    recursivelyShrink
   )
 import Test.QuickCheck.Gen (chooseAny)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -87,14 +87,13 @@ import Shelley.Spec.Ledger.LedgerState
     InstantaneousRewards (..),
     LedgerState (..),
     NewEpochState (..),
-    PPUPState (..),
     PState (..),
     RewardUpdate (..),
     UTxOState (..),
     applyRUpd,
     emptyInstantaneousRewards,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.Tx (TxIn, TxOut)
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -34,8 +34,6 @@ module Test.Shelley.Spec.Ledger.Examples.Combinators
     newSnapshot,
     incrBlockCount,
     newEpoch,
-    setCurrentProposals,
-    setFutureProposals,
     setPParams,
     setPrevPParams,
     setFutureGenDeleg,
@@ -603,48 +601,6 @@ newEpoch b cs = cs'
           chainPrevEpochNonce = prevHashToNonce . lastAppliedHash $ lab,
           chainLastAppliedBlock = At $ LastAppliedBlock bn sn (bhHash bh)
         }
-
--- | = Set Current Proposals
---
--- Set the current protocol parameter proposals.
-setCurrentProposals ::
-  forall era.
-  ProposedPPUpdates era ->
-  ChainState era ->
-  ChainState era
-setCurrentProposals ps cs = cs {chainNes = nes'}
-  where
-    nes = chainNes cs
-    es = nesEs nes
-    ls = esLState es
-    utxoSt = _utxoState ls
-    ppupSt = _ppups utxoSt
-    ppupSt' = ppupSt {proposals = ps}
-    utxoSt' = utxoSt {_ppups = ppupSt'}
-    ls' = ls {_utxoState = utxoSt'}
-    es' = es {esLState = ls'}
-    nes' = nes {nesEs = es'}
-
--- | = Set Future Proposals
---
--- Set the future protocol parameter proposals.
-setFutureProposals ::
-  forall era.
-  ProposedPPUpdates era ->
-  ChainState era ->
-  ChainState era
-setFutureProposals ps cs = cs {chainNes = nes'}
-  where
-    nes = chainNes cs
-    es = nesEs nes
-    ls = esLState es
-    utxoSt = _utxoState ls
-    ppupSt = _ppups utxoSt
-    ppupSt' = ppupSt {futureProposals = ps}
-    utxoSt' = utxoSt {_ppups = ppupSt'}
-    ls' = ls {_utxoState = utxoSt'}
-    es' = es {esLState = ls'}
-    nes' = nes {nesEs = es'}
 
 -- | = Set the Protocol Proposals
 --


### PR DESCRIPTION
- Abstract away the update state from the ledger state. Now it is dependent of the era.
- Introduce an `UpdateSTS` type, indexed over eras.
- Introduce the `HasUpdateLogic` class, to abstract away the Shelley specific functions.