### PR TITLE
rename CDDL timelock variable names

### DIFF
--- a/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
+++ b/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
@@ -230,16 +230,20 @@ native_script =
   // script_all
   // script_any
   // script_n_of_k
-  // timelock_start
-  // timelock_expiry
+  // invalid_before
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the left (included) endpoint a.
+  // invalid_hereafter
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the right (excluded) endpoint b.
   ]
 
 script_pubkey = (0, addr_keyhash)
 script_all = (1, [ * native_script ])
 script_any = (2, [ * native_script ])
 script_n_of_k = (3, n: uint, [ * native_script ])
-timelock_start = (4, uint)
-timelock_expiry = (5, uint)
+invalid_before = (4, uint)
+invalid_hereafter = (5, uint)
 
 coin = uint
 


### PR DESCRIPTION
For consistency, we are going to uniformly use `invalid_before` and `invalid_hereafter` to denote the half open validity intervals
`[invalid_before, invalid_hereafter)`. I know that folks have strong and contrary opinions about these names, but right now consistency is what we need most.