### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,8 +22,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 980e6ca052c8dbad91336b6230c58b78ac1032f5
-  --sha256: 0vid3qi20pfadjxqmklanbh701avjbclx549cqb38dvmz5p0g0xi
+  tag: 6a6ea9695ee898dd7d4fd7a5d2cc639d7d5764f7
+  --sha256: 1hkq5i9fjjr4picx3plq3s09isrmx6jifpqf57c7viqfdrwlhjnj
   subdir:
     binary
     binary/test
@@ -40,8 +40,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: ed3cea18898eeb1f0c9166885f14c543341e59a4
-  --sha256: 0dsrrqnc47d455x9z1alj4m9cclv4qy99gsdjjj5v5s23giagnmm
+  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
   subdir:
     cardano-prelude
     cardano-prelude-test

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -293,11 +293,11 @@ traceLength tr = tr ^. traceTrans . to length
 --
 -- >>> tr01 = mkTrace True 0 [(1, "one")] :: Trace DUMMY
 -- >>> traceInit tr01
--- Trace {_traceEnv = True, _traceInitState = 0, _traceTrans = StrictSeq {getSeq = fromList []}}
+-- Trace {_traceEnv = True, _traceInitState = 0, _traceTrans = StrictSeq {fromStrict = fromList []}}
 --
 -- >>> tr012 = mkTrace True 0 [(2, "two"), (1, "one")] :: Trace DUMMY
 -- >>> traceInit tr012
--- Trace {_traceEnv = True, _traceInitState = 0, _traceTrans = StrictSeq {getSeq = fromList [SigState 1 "one"]}}
+-- Trace {_traceEnv = True, _traceInitState = 0, _traceTrans = StrictSeq {fromStrict = fromList [SigState 1 "one"]}}
 --
 traceInit :: HasCallStack => Trace s -> Trace s
 traceInit tr@Trace { _traceTrans } =
@@ -361,10 +361,10 @@ preStatesAndSignals NewestFirst tr
 -- :}
 --
 -- >>> runIdentity $ closure @ADDER () 0 [3, 2, 1]
--- Trace {_traceEnv = (), _traceInitState = 0, _traceTrans = StrictSeq {getSeq = fromList [SigState 6 3,SigState 3 2,SigState 1 1]}}
+-- Trace {_traceEnv = (), _traceInitState = 0, _traceTrans = StrictSeq {fromStrict = fromList [SigState 6 3,SigState 3 2,SigState 1 1]}}
 --
 -- >>> runIdentity $ closure @ADDER () 10 [-3, -2, -1]
--- Trace {_traceEnv = (), _traceInitState = 10, _traceTrans = StrictSeq {getSeq = fromList [SigState 4 (-3),SigState 7 (-2),SigState 9 (-1)]}}
+-- Trace {_traceEnv = (), _traceInitState = 10, _traceTrans = StrictSeq {fromStrict = fromList [SigState 4 (-3),SigState 7 (-2),SigState 9 (-1)]}}
 --
 closure
   :: forall s m

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -603,7 +603,7 @@ txSeqDecoder lax = do
           <> show w
           <> ")"
     )
-  let txns = sequenceA $ StrictSeq.toStrict $ Seq.zipWith3 segwitTx bodies wits metadata
+  let txns = sequenceA $ StrictSeq.forceToStrict $ Seq.zipWith3 segwitTx bodies wits metadata
   pure $ TxSeq' <$> txns <*> bodiesAnn <*> witsAnn <*> metadataAnn
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
@@ -11,7 +11,7 @@ import Control.DeepSeq (NFData (rnf))
 import Data.Aeson
 import Data.Foldable
 import Data.IP (IPv4, IPv6)
-import Data.Sequence.Strict (StrictSeq, fromList, getSeq)
+import Data.Sequence.Strict (StrictSeq, fromList, fromStrict)
 import qualified Data.Text as Text
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.Slot (BlockNo, EpochNo)
@@ -52,7 +52,7 @@ instance NFData IPv6
 instance NFData EpochNo
 
 instance NFData (StrictSeq a) where
-  rnf x = case getSeq x of _any -> ()
+  rnf x = case fromStrict x of _any -> ()
 
 -- By defintion it is strict, so as long as the (hidden) constructor is evident, it is in normal form
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -154,7 +154,7 @@ bbodyTransition =
 
         ls' <-
           trans @(LEDGERS era) $
-            TRC (LedgersEnv (bheaderSlotNo bhb) pp account, ls, StrictSeq.getSeq txs)
+            TRC (LedgersEnv (bheaderSlotNo bhb) pp account, ls, StrictSeq.fromStrict txs)
 
         -- Note that this may not actually be a stake pool - it could be a genesis key
         -- delegate. However, this would only entail an overhead of 7 counts, and it's

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -199,7 +199,7 @@ ledgerTransition = do
       TRC
         ( DelegsEnv slot txIx pp tx account,
           dpstate,
-          StrictSeq.getSeq $ getField @"certs" $ _body tx
+          StrictSeq.fromStrict $ getField @"certs" $ _body tx
         )
 
   let DPState dstate pstate = dpstate

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -335,9 +335,9 @@ utxoWitnessed scriptsNeeded =
           (WitHashes khAsSet) = witsKeyHashes
           genSig = eval (genDelegates ∩ khAsSet)
           mirCerts =
-            StrictSeq.toStrict
+            StrictSeq.forceToStrict
               . Seq.filter isInstantaneousRewards
-              . StrictSeq.getSeq
+              . StrictSeq.fromStrict
               $ getField @"certs" txbody
           GenDelegs genMapping = genDelegs
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -1045,7 +1045,7 @@ instance
       <> toCBOR (_poolMargin poolParams)
       <> toCBOR (_poolRAcnt poolParams)
       <> encodeFoldable (_poolOwners poolParams)
-      <> toCBOR (CborSeq (StrictSeq.getSeq (_poolRelays poolParams)))
+      <> toCBOR (CborSeq (StrictSeq.fromStrict (_poolRelays poolParams)))
       <> encodeNullMaybe toCBOR (strictMaybeToMaybe (_poolMD poolParams))
 
   encodedGroupSizeExpr size' proxy =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -549,8 +549,8 @@ instance Arbitrary Url where
   arbitrary = return . fromJust $ textToUrl "text"
 
 instance Arbitrary a => Arbitrary (StrictSeq a) where
-  arbitrary = StrictSeq.toStrict <$> arbitrary
-  shrink = map StrictSeq.toStrict . shrink . StrictSeq.getSeq
+  arbitrary = StrictSeq.forceToStrict <$> arbitrary
+  shrink = map StrictSeq.forceToStrict . shrink . StrictSeq.fromStrict
 
 instance Arbitrary StakePoolRelay where
   arbitrary = genericArbitraryU


### PR DESCRIPTION
Notable changes:
* https://github.com/input-output-hk/cardano-prelude/pull/146
* https://github.com/input-output-hk/cardano-prelude/pull/145
  This PR removed the `Cardano.Prelude.Base16` module that exported the
  `Base16ParseError` type used in `Cardano.Crypto.Signing.Signature`