### PR TITLE
Mary era Value serialisation

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -29,7 +29,7 @@ import Cardano.Binary
     FromCBOR,
     ToCBOR,
     TokenType (..),
-    decodeInt64,
+    decodeInteger,
     decodeWord64,
     fromCBOR,
     peekTokenType,
@@ -169,9 +169,6 @@ instance Era era => Val (Value era) where
 -- TODO filter out 0s at deserialization
 -- TODO Probably the actual serialization will be of the formal Coin OR Value type
 -- Maybe better to make this distinction in the TxOut de/serialization
-
-decodeInteger :: Decoder s Integer
-decodeInteger = fromIntegral <$> decodeInt64
 
 decodeValue ::
   ( Typeable (Core.Script era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -782,3 +782,12 @@ instance
   Arbitrary (Block era)
   where
   arbitrary = genBlock
+
+instance
+  ( Era era,
+    Arbitrary (STS.PredicateFailure (LEDGER era))
+  ) =>
+  Arbitrary (ApplyTxError era)
+  where
+  arbitrary = ApplyTxError <$> arbitrary
+  shrink (ApplyTxError xs) = [ApplyTxError xs' | xs' <- shrink xs]


### PR DESCRIPTION
This PR has two commits. The first adds correct round-trip testing for `ApplyTxError` and `Value`. The second fixes a bug which was causing these tests to fail.