### PR TITLE
Update roundtrip tests

### DIFF
--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -22,9 +22,12 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 
 import Cardano.Binary (Annotator (..), FromCBOR, ToCBOR)
 import Cardano.Ledger.Core (SerialisableData)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.State.Transition
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Proxy (Proxy (Proxy))
+import Data.Typeable (typeRep)
 import Shelley.Spec.Ledger.API (ApplyTxError, UTXOW)
 import Test.Cardano.Ledger.EraBuffet
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
@@ -32,84 +35,43 @@ import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
     roundTripAnn,
   )
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import Test.QuickCheck (counterexample, forAll, (===))
+import Test.QuickCheck (Arbitrary, Property, counterexample, (===))
 import Test.Shelley.Spec.Ledger.Generator.Metadata ()
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (Gen, arbitrary, testProperty)
-
--- ======================================================================
--- Witnesses to each Era
-
-data EraIndex index where
-  Mary :: EraIndex (MaryEra StandardCrypto)
-  Shelley :: EraIndex (ShelleyEra StandardCrypto)
-  Allegra :: EraIndex (AllegraEra StandardCrypto)
-
-instance Show (EraIndex e) where
-  show Mary = "Mary Era"
-  show Shelley = "Shelley Era"
-  show Allegra = "Allegra Era"
-
--- ============================================================
--- EraIndex parameterized generators for each type family
-
-genTxBody :: EraIndex e -> Gen (TxBody e)
-genTxBody Shelley = arbitrary
-genTxBody Mary = arbitrary
-genTxBody Allegra = arbitrary
-
-genScript :: EraIndex e -> Gen (Script e)
-genScript Shelley = arbitrary
-genScript Mary = arbitrary
-genScript Allegra = arbitrary
-
-genValue :: EraIndex e -> Gen (Value e)
-genValue Shelley = arbitrary
-genValue Mary = arbitrary
-genValue Allegra = arbitrary
-
-genMeta :: EraIndex e -> Gen (Metadata e)
-genMeta Mary = arbitrary
-genMeta Allegra = arbitrary
-genMeta Shelley = arbitrary
-
-genApplyTxError :: EraIndex e -> Gen (ApplyTxError e)
-genApplyTxError Shelley = arbitrary
-genApplyTxError Mary = arbitrary
-genApplyTxError Allegra = arbitrary
-
--- ==========================================================
--- EraIndex parameterized property tests
+import Test.Tasty.QuickCheck (testProperty)
 
 propertyAnn ::
-  forall e t.
-  (Eq t, Show t, ToCBOR t, FromCBOR (Annotator t)) =>
-  String ->
-  EraIndex e ->
-  (EraIndex e -> Gen t) ->
-  TestTree
-propertyAnn name i gen = testProperty ("roundtripAnn " ++ name) $ do
-  forAll (gen i) $ \x -> case roundTripAnn x of
-    Right (remaining, y) | BSL.null remaining -> x === y
-    Right (remaining, _) ->
-      counterexample
-        ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
-        False
-    Left stuff ->
-      counterexample
-        ("Failed to decode: " <> show stuff)
-        False
+  forall t.
+  ( Eq t,
+    Show t,
+    ToCBOR t,
+    FromCBOR (Annotator t)
+  ) =>
+  t ->
+  Property
+propertyAnn x = case roundTripAnn x of
+  Right (remaining, y) | BSL.null remaining -> x === y
+  Right (remaining, _) ->
+    counterexample
+      ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
+      False
+  Left stuff ->
+    counterexample
+      ("Failed to decode: " <> show stuff)
+      False
 
 property ::
-  forall e t.
-  (Eq t, Show t, ToCBOR t, FromCBOR t) =>
-  String ->
-  EraIndex e ->
-  (EraIndex e -> Gen t) ->
-  TestTree
-property name i gen = testProperty ("roundtrip " ++ name) $
-  forAll (gen i) $ \x -> case roundTrip x of
+  forall t.
+  ( Eq t,
+    Show t,
+    ToCBOR t,
+    FromCBOR t
+  ) =>
+  t ->
+  Property
+property x =
+  case roundTrip x of
     Right (remaining, y) | BSL.null remaining -> x === y
     Right (remaining, _) ->
       counterexample
@@ -121,25 +83,33 @@ property name i gen = testProperty ("roundtrip " ++ name) $
         False
 
 allprops ::
+  forall e.
   ( ShelleyBased e,
+    Arbitrary (Core.TxBody e),
+    Arbitrary (Core.Metadata e),
+    Arbitrary (Core.Value e),
+    Arbitrary (Core.Script e),
+    Arbitrary (ApplyTxError e),
     SerialisableData (ApplyTxError e),
     Eq (PredicateFailure (UTXOW e)),
     Show (PredicateFailure (UTXOW e))
   ) =>
-  EraIndex e ->
   TestTree
-allprops index =
+allprops =
   testGroup
-    (show index)
-    [ propertyAnn "TxBody" index genTxBody,
-      propertyAnn "Metadata" index genMeta,
-      property "Value" index genValue,
-      propertyAnn "Script" index genScript,
-      property "ApplyTxError" index genApplyTxError
+    (show $ typeRep (Proxy @e))
+    [ testProperty "TxBody" $ propertyAnn @(Core.TxBody e),
+      testProperty "Metadata" $ propertyAnn @(Core.Metadata e),
+      testProperty "Value" $ property @(Core.Value e),
+      testProperty "Script" $ propertyAnn @(Core.Script e),
+      testProperty "ApplyTxError" $ property @(ApplyTxError e)
     ]
 
 allEraRoundtripTests :: TestTree
 allEraRoundtripTests =
   testGroup
     "All Era Roundtrip Tests"
-    [allprops Shelley, allprops Allegra, allprops Mary]
+    [ allprops @(ShelleyEra StandardCrypto),
+      allprops @(AllegraEra StandardCrypto),
+      allprops @(MaryEra StandardCrypto)
+    ]

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -23,13 +23,9 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 import Cardano.Binary (Annotator (..), FromCBOR, ToCBOR)
 import Cardano.Ledger.Core (SerialisableData)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
-import qualified Cardano.Ledger.ShelleyMA.Metadata as MA
 import Control.State.Transition
-import qualified Data.ByteString.Lazy as Lazy (null)
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import Data.Sequence.Strict (StrictSeq, fromList)
 import Shelley.Spec.Ledger.API (ApplyTxError, UTXOW)
-import qualified Shelley.Spec.Ledger.Metadata as Shelley (Metadata (..))
 import Test.Cardano.Ledger.EraBuffet
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
   ( roundTrip,
@@ -40,7 +36,7 @@ import Test.QuickCheck (counterexample, forAll, (===))
 import Test.Shelley.Spec.Ledger.Generator.Metadata ()
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (Gen, arbitrary, choose, testProperty, vectorOf)
+import Test.Tasty.QuickCheck (Gen, arbitrary, testProperty)
 
 -- ======================================================================
 -- Witnesses to each Era
@@ -74,29 +70,14 @@ genValue Mary = arbitrary
 genValue Allegra = arbitrary
 
 genMeta :: EraIndex e -> Gen (Metadata e)
-genMeta Mary = do
-  m <- arbitrary
-  s <- genScriptSeq Mary
-  pure (MA.Metadata m s)
-genMeta Allegra = do
-  m <- arbitrary
-  s <- genScriptSeq Allegra
-  pure (MA.Metadata m s)
-genMeta Shelley = Shelley.Metadata <$> arbitrary
+genMeta Mary = arbitrary
+genMeta Allegra = arbitrary
+genMeta Shelley = arbitrary
 
 genApplyTxError :: EraIndex e -> Gen (ApplyTxError e)
 genApplyTxError Shelley = arbitrary
 genApplyTxError Mary = arbitrary
 genApplyTxError Allegra = arbitrary
-
--- ==========================================================
--- Parameterized helper function for generating MA style Metadata
-
-genScriptSeq :: EraIndex e -> Gen (StrictSeq (Script e))
-genScriptSeq index = do
-  n <- choose (0, 6)
-  l <- vectorOf n (genScript index)
-  pure (fromList l)
 
 -- ==========================================================
 -- EraIndex parameterized property tests


### PR DESCRIPTION
This PR updates the MA roundtrip tests in order to:

- Use the `Arbitrary` serialisation generators
- Fail rather than error when the roundtrip fails, thus giving us access to the failing values, and
- Get shrinking for the generated values.