### PR TITLE
Allegra to Mary tx translation preserves encoding

### DIFF
--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -85,6 +85,7 @@ test-suite cardano-ledger-shelley-ma-test
       Test.Cardano.Ledger.Mary.Examples
       Test.Cardano.Ledger.Mary.Examples.Cast
       Test.Cardano.Ledger.Mary.Examples.MultiAssets
+      Test.Cardano.Ledger.Mary.Translation
       Test.Cardano.Ledger.Mary.Value
       Test.Cardano.Ledger.Allegra.Translation
       Test.Cardano.Ledger.ShelleyMA.Serialisation

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation.hs
@@ -1,6 +1,7 @@
 module Test.Cardano.Ledger.ShelleyMA.Serialisation where
 
 import Test.Cardano.Ledger.Allegra.Translation (allegraEncodeDecodeTests)
+import Test.Cardano.Ledger.Mary.Translation (maryEncodeDecodeTests)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (codersTest)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.CDDL (cddlTests)
 import Test.Cardano.Ledger.ShelleyMA.TxBody (txBodyTest)
@@ -15,6 +16,7 @@ tests =
     "Serialisation tests"
     [ codersTest,
       allegraEncodeDecodeTests,
+      maryEncodeDecodeTests,
       txBodyTest,
       timelockTests,
       cddlTests 10,

--- a/shelley-ma/shelley-ma-test/test/Tests.hs
+++ b/shelley-ma/shelley-ma-test/test/Tests.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)
 import Test.Cardano.Ledger.Mary.Examples.MultiAssets (multiAssetsExample)
+import Test.Cardano.Ledger.Mary.Translation (maryTranslationTests)
 import qualified Test.Cardano.Ledger.ShelleyMA.Serialisation as Serialisation
 import Test.Cardano.Ledger.Mary.Value (valTests)
 import Test.Tasty
@@ -20,6 +21,7 @@ tests =
     "Cardano-Legder-Tests"
     [ Serialisation.tests,
       allegraTranslationTests,
+      maryTranslationTests,
       maryChainExamples,
       valTests
     ]


### PR DESCRIPTION
The transaction translation from Allegra to Mary was reserializing, and now it is not. I've added the Allegra to Mary translation tests.

closes #2053 