### PR TITLE
CAD-1906: Alonzo transactions and serialisation

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -23,6 +23,7 @@ library
     Cardano.Ledger.Alonzo
     Cardano.Ledger.Alonzo.Data
     Cardano.Ledger.Alonzo.Scripts
+    Cardano.Ledger.Alonzo.Tx
     Cardano.Ledger.Alonzo.TxBody
     Cardano.Ledger.Alonzo.TxWitness
   build-depends:

--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -38,6 +38,13 @@ library
     small-steps
   hs-source-dirs:
     src
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
   default-language:    Haskell2010
 
 library test
@@ -62,6 +69,13 @@ library test
     small-steps
   hs-source-dirs:
     test/lib
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
   default-language:    Haskell2010
 
 test-suite tests
@@ -86,3 +100,11 @@ test-suite tests
     tasty,
     -- cardano-ledger-alonzo:test
     test
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+  default-language:    Haskell2010

--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -59,6 +59,7 @@ library test
     cardano-crypto-class,
     cardano-ledger-alonzo,
     cardano-ledger-shelley-ma,
+    cardano-ledger-shelley-ma-test,
     cardano-slotting,
     containers,
     deepseq,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -27,7 +27,9 @@ import Shelley.Spec.Ledger.Hashing (HashAnnotated (..))
 
 -- | TODO this should be isomorphic to the plutus type
 data Data era = NotReallyData
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Generic, Show)
+
+instance NoThunks (Data era)
 
 data EraIndependentData
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -3,12 +3,12 @@
 
 module Cardano.Ledger.Alonzo.Scripts
   ( Tag (..),
-    Script (..),
+    Script,
     ExUnits (..),
   )
 where
 
-import Cardano.Binary
+import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Data.Coders

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Alonzo.Tx
+  ( IsValidating (..),
+    Tx (Tx, body, wits, isValidating, auxiliaryData),
+  )
+where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Ledger.Alonzo.TxBody (TxBody)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
+import Cardano.Ledger.Compactible
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, Val)
+import Data.Coders
+import Data.MemoBytes (Mem, MemoBytes (Memo), memoBytes)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe, maybeToStrictMaybe, strictMaybeToMaybe)
+
+-- | Tag indicating whether non-native scripts in this transaction are expected
+-- to validate. This is added by the block creator when constructing the block.
+newtype IsValidating = IsValidating Bool
+  deriving (Eq, NoThunks, Show)
+
+data TxRaw era = TxRaw
+  { _body :: !(TxBody era),
+    _wits :: !(TxWitness era),
+    _isValidating :: !IsValidating,
+    _auxiliaryData :: !(StrictMaybe (Core.AuxiliaryData era))
+  }
+  deriving (Generic, Typeable)
+
+deriving instance
+  ( Era era,
+    Eq (Core.AuxiliaryData era),
+    Eq (Core.Script era),
+    Eq (Core.Value era),
+    Eq (CompactForm (Core.Value era))
+  ) =>
+  Eq (TxRaw era)
+
+deriving instance
+  ( Era era,
+    Compactible (Core.Value era),
+    Show (Core.AuxiliaryData era),
+    Show (Core.Script era),
+    Show (Core.Value era),
+    Show (CompactForm (Core.Value era))
+  ) =>
+  Show (TxRaw era)
+
+instance
+  ( Era era,
+    NoThunks (Core.AuxiliaryData era),
+    NoThunks (Core.Script era),
+    NoThunks (Core.Value era)
+  ) =>
+  NoThunks (TxRaw era)
+
+newtype Tx era = TxConstr (MemoBytes (TxRaw era))
+  deriving (ToCBOR)
+
+deriving newtype instance
+  ( Era era,
+    Eq (Core.AuxiliaryData era),
+    Eq (Core.Script era),
+    Eq (Core.Value era),
+    Eq (CompactForm (Core.Value era))
+  ) =>
+  Eq (Tx era)
+
+deriving newtype instance
+  ( Era era,
+    Compactible (Core.Value era),
+    Show (Core.AuxiliaryData era),
+    Show (Core.Script era),
+    Show (Core.Value era),
+    Show (CompactForm (Core.Value era))
+  ) =>
+  Show (Tx era)
+
+deriving newtype instance
+  ( Era era,
+    NoThunks (Core.AuxiliaryData era),
+    NoThunks (Core.Script era),
+    NoThunks (Core.Value era)
+  ) =>
+  NoThunks (Tx era)
+
+pattern Tx ::
+  (Era era, ToCBOR (Core.AuxiliaryData era)) =>
+  TxBody era ->
+  TxWitness era ->
+  IsValidating ->
+  StrictMaybe (Core.AuxiliaryData era) ->
+  Tx era
+pattern Tx {body, wits, isValidating, auxiliaryData} <-
+  TxConstr
+    ( Memo
+        TxRaw
+          { _body = body,
+            _wits = wits,
+            _isValidating = isValidating,
+            _auxiliaryData = auxiliaryData
+          }
+        _
+      )
+  where
+    Tx b w v a = TxConstr $ memoBytes (encodeTxRaw $ TxRaw b w v a)
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+deriving newtype instance FromCBOR IsValidating
+
+deriving newtype instance ToCBOR IsValidating
+
+encodeTxRaw ::
+  (Era era, ToCBOR (Core.AuxiliaryData era)) =>
+  TxRaw era ->
+  Encode ('Closed 'Dense) (TxRaw era)
+encodeTxRaw TxRaw {_body, _wits, _isValidating, _auxiliaryData} =
+  Rec TxRaw
+    !> To _body
+    !> To _wits
+    !> To _isValidating
+    !> E (encodeNullMaybe toCBOR . strictMaybeToMaybe) _auxiliaryData
+
+instance
+  ( Era era,
+    FromCBOR (Annotator (Core.Script era)),
+    FromCBOR (Annotator (Core.AuxiliaryData era)),
+    ToCBOR (Core.Script era),
+    Typeable (Core.Script era),
+    Typeable (Core.AuxiliaryData era),
+    Compactible (Core.Value era),
+    DecodeNonNegative (Core.Value era),
+    DecodeMint (Core.Value era),
+    Show (Core.Value era),
+    Val (Core.Value era)
+  ) =>
+  FromCBOR (Annotator (TxRaw era))
+  where
+  fromCBOR =
+    decode $
+      Ann (RecD TxRaw)
+        <*! From
+        <*! From
+        <*! Ann From
+        <*! D
+          ( sequence . maybeToStrictMaybe
+              <$> decodeNullMaybe fromCBOR
+          )
+
+deriving via
+  Mem (TxRaw era)
+  instance
+    ( Era era,
+      FromCBOR (Annotator (Core.Script era)),
+      FromCBOR (Annotator (Core.AuxiliaryData era)),
+      ToCBOR (Core.Script era),
+      Typeable (Core.Script era),
+      Typeable (Core.AuxiliaryData era),
+      Compactible (Core.Value era),
+      DecodeNonNegative (Core.Value era),
+      DecodeMint (Core.Value era),
+      Show (Core.Value era),
+      Val (Core.Value era)
+    ) =>
+    FromCBOR (Annotator (Tx era))

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -12,11 +12,12 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Alonzo.TxBody
   ( IsFee (..),
     TxIn (..),
-    TxOut (..),
+    TxOut (TxOut, TxOutCompact),
     TxBody
       ( TxBody,
         inputs,
@@ -57,6 +58,7 @@ import Cardano.Ledger.Val
   )
 import Control.DeepSeq (NFData)
 import Data.Coders
+import Data.Maybe (fromMaybe)
 import Data.MemoBytes (Mem, MemoBytes (..), memoBytes)
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -64,10 +66,12 @@ import Data.Set (Set)
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import GHC.Stack (HasCallStack)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
+import Shelley.Spec.Ledger.Address (Addr)
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.CompactAddr (CompactAddr)
+import Shelley.Spec.Ledger.CompactAddr (CompactAddr, compactAddr, decompactAddr)
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
 import Shelley.Spec.Ledger.Hashing
 import Shelley.Spec.Ledger.PParams (Update)
@@ -130,6 +134,29 @@ instance
   show = error "Not yet implemented"
 
 deriving via InspectHeapNamed "TxOut" (TxOut era) instance NoThunks (TxOut era)
+
+pattern TxOut ::
+  ( Era era,
+    Compactible (Core.Value era),
+    Show (Core.Value era),
+    HasCallStack
+  ) =>
+  Addr (Crypto era) ->
+  Core.Value era ->
+  StrictMaybe (DataHash era) ->
+  TxOut era
+pattern TxOut addr vl dh <-
+  TxOutCompact (decompactAddr -> addr) (fromCompact -> vl) dh
+  where
+    TxOut addr vl dh =
+      TxOutCompact
+        (compactAddr addr)
+        ( fromMaybe (error $ "Illegal value in txout: " <> show vl) $
+            toCompact vl
+        )
+        dh
+
+{-# COMPLETE TxOut #-}
 
 data TxBodyRaw era = TxBodyRaw
   { _inputs :: !(Set (TxIn (Crypto era))),

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -226,7 +226,6 @@ deriving via
 pattern TxBody ::
   ( Era era,
     Typeable (Core.AuxiliaryData era),
-    Typeable (Core.Script era),
     ToCBOR (CompactForm (Core.Value era)),
     ToCBOR (Core.Script era),
     EncodeMint (Core.Value era),
@@ -276,32 +275,32 @@ pattern TxBody
       )
   where
     TxBody
-      inputs
-      outputs
-      certs
-      wdrls
-      txfee
-      vldt
-      update
-      adHash
-      mint
-      exunits
-      scriptHash =
+      inputs'
+      outputs'
+      certs'
+      wdrls'
+      txfee'
+      vldt'
+      update'
+      adHash'
+      mint'
+      exunits'
+      scriptHash' =
         TxBodyConstr $
           memoBytes
             ( encodeTxBodyRaw $
                 TxBodyRaw
-                  inputs
-                  outputs
-                  certs
-                  wdrls
-                  txfee
-                  vldt
-                  update
-                  adHash
-                  mint
-                  exunits
-                  scriptHash
+                  inputs'
+                  outputs'
+                  certs'
+                  wdrls'
+                  txfee'
+                  vldt'
+                  update'
+                  adHash'
+                  mint'
+                  exunits'
+                  scriptHash'
             )
 
 {-# COMPLETE TxBody #-}
@@ -350,10 +349,7 @@ encodeTxBodyRaw ::
   ( Era era,
     EncodeMint (Core.Value era),
     Val (Core.Value era),
-    Typeable (Core.AuxiliaryData era),
-    Typeable (Core.Script era),
-    ToCBOR (CompactForm (Core.Value era)),
-    ToCBOR (Core.Script era)
+    ToCBOR (CompactForm (Core.Value era))
   ) =>
   TxBodyRaw era ->
   Encode ('Closed 'Sparse) (TxBodyRaw era)
@@ -413,10 +409,10 @@ instance
   ) =>
   FromCBOR (TxBodyRaw era)
   where
-  fromCBOR = decode $ SparseKeyed "TxBodyRaw" init bodyFields requiredFields
+  fromCBOR = decode $ SparseKeyed "TxBodyRaw" initial bodyFields requiredFields
     where
-      init :: TxBodyRaw era
-      init =
+      initial :: TxBodyRaw era
+      initial =
         TxBodyRaw
           mempty
           StrictSeq.empty

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -75,6 +75,8 @@ deriving stock instance
   (Era era, Show (Core.Script era)) =>
   Show (TxWitnessRaw era)
 
+instance (Era era, NoThunks (Core.Script era)) => NoThunks (TxWitnessRaw era)
+
 newtype TxWitness era = TxWitnessConstr (MemoBytes (TxWitnessRaw era))
   deriving newtype (ToCBOR)
 
@@ -83,6 +85,10 @@ deriving newtype instance (Era era, Eq (Core.Script era)) => Eq (TxWitness era)
 deriving newtype instance
   (Era era, Show (Core.Script era)) =>
   Show (TxWitness era)
+
+deriving newtype instance
+  (Era era, NoThunks (Core.Script era)) =>
+  NoThunks (TxWitness era)
 
 pattern TxWitness ::
   (Era era, ToCBOR (Core.Script era)) =>
@@ -182,10 +188,15 @@ data ScriptDataRaw era = ScriptDataRaw
     _scriptDataData :: Set (Data era),
     _scriptDataRdmrs :: Map RdmrPtr (Data era)
   }
+  deriving (Generic)
 
 deriving stock instance (Eq (Core.Script era)) => Eq (ScriptDataRaw era)
 
 deriving stock instance (Show (Core.Script era)) => Show (ScriptDataRaw era)
+
+instance
+  (NoThunks (Core.Script era)) =>
+  NoThunks (ScriptDataRaw era)
 
 -- | 'ScriptData' is a projection of the parts of 'TxWitness' which may be
 -- hashed to include in the transaction body. Note that this cannot be the hash
@@ -204,6 +215,10 @@ newtype ScriptData era = ScriptDataConstr
 deriving newtype instance (Eq (Core.Script era)) => Eq (ScriptData era)
 
 deriving newtype instance (Show (Core.Script era)) => Show (ScriptData era)
+
+deriving newtype instance
+  (Era era, NoThunks (Core.Script era)) =>
+  NoThunks (ScriptData era)
 
 pattern ScriptData ::
   (Era era, ToCBOR (Core.Script era)) =>

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -20,7 +20,7 @@ module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
     TxWitness (TxWitness, witsVKey, witsBoot, witsScript, witsData, witsRdmr),
     EraIndependentScriptData,
-    ScriptDataHash,
+    ScriptDataHash (..),
   )
 where
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -118,10 +118,12 @@ pattern TxWitness
         _
       )
   where
-    TxWitness witsVKey witsBoot witsScript witsDat witsRdmr =
+    TxWitness witsVKey' witsBoot' witsScript' witsDat' witsRdmr' =
       TxWitnessConstr
         . memoBytes
-        $ encodeWitnessRaw witsVKey witsBoot witsScript witsDat witsRdmr
+        $ encodeWitnessRaw witsVKey' witsBoot' witsScript' witsDat' witsRdmr'
+
+{-# COMPLETE TxWitness #-}
 
 -- | Right-biased semigroup - if there are (somehow) multiple entries either for
 -- a given 'ScriptHash' or a given 'Data', this will bias to the entry on the
@@ -225,6 +227,8 @@ instance
     <> (ScriptData s' d' r') =
       ScriptData (s <> s') (d `Set.union` d') (r <> r')
 
+{-# COMPLETE ScriptData #-}
+
 instance
   (Era era, ToCBOR (Core.Script era)) =>
   Monoid (ScriptData era)
@@ -295,7 +299,7 @@ encodeWitnessRaw ::
   Map (ScriptHash (Crypto era)) (Core.Script era) ->
   Set (Data era) ->
   Map RdmrPtr (Data era) ->
-  Encode ('Closed Dense) (TxWitnessRaw era)
+  Encode ('Closed 'Dense) (TxWitnessRaw era)
 encodeWitnessRaw a b s d r =
   Rec TxWitnessRaw
     !> E encodeFoldable a
@@ -322,8 +326,6 @@ deriving via
   (Mem (TxWitnessRaw era))
   instance
     ( Era era,
-      FromCBOR
-        (Annotator (Core.Script era)),
       FromCBOR (Data era),
       FromCBOR (Annotator (Core.Script era)),
       ToCBOR (Core.Script era)

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 
@@ -18,14 +19,10 @@ import Cardano.Ledger.Alonzo.TxBody
     TxOut (..),
   )
 import Cardano.Ledger.Alonzo.TxWitness
-import Cardano.Ledger.Compactible (Compactible (toCompact))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
-import Cardano.Ledger.ShelleyMA.Timelocks
-import Cardano.Ledger.Val (EncodeMint)
-import Cardano.Slotting.Slot (SlotNo (..))
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -1,19 +1,32 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 
-import Cardano.Ledger.Alonzo.Data (Data (..))
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (Data (..), DataHash (..))
 import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.TxBody
+  ( IsFee (..),
+    TxBody (TxBody),
+    TxIn (..),
+    TxOut (..),
+  )
 import Cardano.Ledger.Alonzo.TxWitness
+import Cardano.Ledger.Compactible (Compactible (toCompact))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
-import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.ShelleyMA.Timelocks
+import Cardano.Ledger.Val (EncodeMint)
 import Cardano.Slotting.Slot (SlotNo (..))
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
@@ -28,6 +41,9 @@ instance Arbitrary Tag where
 instance Arbitrary RdmrPtr where
   arbitrary = RdmrPtr <$> arbitrary <*> arbitrary
 
+instance Arbitrary ExUnits where
+  arbitrary = ExUnits <$> arbitrary <*> arbitrary
+
 instance
   ( ShelleyBased era,
     Mock (Crypto era),
@@ -40,5 +56,53 @@ instance
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+deriving newtype instance CC.Crypto c => Arbitrary (ScriptDataHash c)
+
+deriving newtype instance Era era => Arbitrary (DataHash era)
+
+deriving newtype instance Arbitrary IsFee
+
+instance
+  ( CC.Crypto c
+  ) =>
+  Arbitrary (TxIn c)
+  where
+  arbitrary =
+    TxInCompact
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance
+  ( ShelleyBased era,
+    Mock (Crypto era),
+    Arbitrary (Core.Value era)
+  ) =>
+  Arbitrary (TxOut era)
+  where
+  arbitrary =
+    TxOut
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance
+  (Mock c) =>
+  Arbitrary (TxBody (AlonzoEra c))
+  where
+  arbitrary =
+    TxBody
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> genMintValues
       <*> arbitrary
       <*> arbitrary

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data (..), DataHash (..))
 import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( IsFee (..),
     TxBody (TxBody),
@@ -101,5 +102,15 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> genMintValues
+      <*> arbitrary
+      <*> arbitrary
+
+deriving newtype instance Arbitrary IsValidating
+
+instance Mock c => Arbitrary (Tx (AlonzoEra c)) where
+  arbitrary =
+    Tx
+      <$> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -5,6 +5,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Tripping where
 
 import Cardano.Binary
 import Cardano.Ledger.Alonzo
+import Cardano.Ledger.Alonzo.Tx (Tx)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -41,5 +42,7 @@ tests =
     [ testProperty "alonzo/TxWitness" $
         trippingAnn @(TxWitness (AlonzoEra C_Crypto)),
       testProperty "alonzo/TxBody" $
-        trippingAnn @(TxBody (AlonzoEra C_Crypto))
+        trippingAnn @(TxBody (AlonzoEra C_Crypto)),
+      testProperty "alonzo/Tx" $
+        trippingAnn @(Tx (AlonzoEra C_Crypto))
     ]

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -5,6 +5,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Tripping where
 
 import Cardano.Binary
 import Cardano.Ledger.Alonzo
+import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
@@ -38,5 +39,7 @@ tests =
   testGroup
     "Alonzo CBOR round-trip"
     [ testProperty "alonzo/TxWitness" $
-        trippingAnn @(TxWitness (AlonzoEra C_Crypto))
+        trippingAnn @(TxWitness (AlonzoEra C_Crypto)),
+      testProperty "alonzo/TxBody" $
+        trippingAnn @(TxBody (AlonzoEra C_Crypto))
     ]

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -29,7 +29,9 @@ import Cardano.Binary (toCBOR)
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Allegra (AllegraEra)
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary (MaryEra)
 import qualified Cardano.Ledger.Mary.Value as ConcreteValue
 import qualified Cardano.Ledger.Mary.Value as Mary
@@ -37,7 +39,6 @@ import qualified Cardano.Ledger.Mary.Value as Mary
     PolicyID (..),
     Value (..),
   )
-import Cardano.Ledger.ShelleyMA (ShelleyMAEra)
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA.STS
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
@@ -47,7 +48,6 @@ import Data.Coerce (coerce)
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq, fromList)
-import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import Generic.Random (genericArbitraryU)
 import Shelley.Spec.Ledger.API hiding (SignedDSIGN, TxBody (..))
@@ -113,8 +113,13 @@ sizedTimelock n =
 
 -- TODO Generate metadata with script preimages
 instance
-  (Mock c, Typeable ma, Arbitrary (Timelock c)) =>
-  Arbitrary (MA.AuxiliaryData (ShelleyMAEra ma c))
+  ( Era era,
+    c ~ Crypto era,
+    Mock c,
+    Arbitrary (Timelock c),
+    Core.Script era ~ Timelock c
+  ) =>
+  Arbitrary (MA.AuxiliaryData era)
   where
   -- Why do we use the \case instead of a do statement? like this:
   --


### PR DESCRIPTION
This PR adds:

- Alonzo era transactions
- Serialisation and tests for Tx and TxBody

Also it fixes a bunch of warnings.