### PR TITLE
draft of heapwords size estimate of utxos

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -463,6 +463,7 @@ data TxOut era
 instance (HeapWords (CompactForm (Core.Value era))) => HeapWords (TxOut era) where
   heapWords (TxOutCompact _ vl) = 3 + HW.heapWordsUnpacked packed57Bytestring + HW.heapWords vl
 
+-- the length of a shelley base address estimate (stake and payment are 28-long)
 packed57Bytestring :: ByteString
 packed57Bytestring = Char8.pack (replicate 57 'a')
 


### PR DESCRIPTION
In order to be able to gauge how much ada must be in a UTxO, we need to estimate the size of the UTxO

This draft PR uses `HeapWords` to get estimates of the sizes of real UTxO entries with the purpose of using the numbers produced by the `heapWords` function to create an somewhat accurate and transparent calculation of the min-ada-value (without actually using the exact size of the UTxO)

With the following simplifications:
- instead of defining HeapWords for each kind of address, look at the average case - the Shelley-type base address, made up of stake and payment addresses of 28 bytes
- count each policy ID and each asset name (instead of counting asset IDs)
- no overhead due to adding new UTxO map entry (only the size of the data in the UTxO itself)