### PR TITLE
Rename genesisUtxO to genesisUTxO

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -19,7 +19,7 @@ module Shelley.Spec.Ledger.Genesis
     ValidationErr (..),
     emptyGenesisStaking,
     sgActiveSlotCoeff,
-    genesisUtxO,
+    genesisUTxO,
     initialFundsPseudoTxIn,
     validateGenesis,
     describeValidationErr,
@@ -286,11 +286,11 @@ instance Era era => FromCBOR (ShelleyGenesis era) where
   Genesis UTxO
 -------------------------------------------------------------------------------}
 
-genesisUtxO ::
+genesisUTxO ::
   ShelleyBased era =>
   ShelleyGenesis era ->
   UTxO era
-genesisUtxO genesis =
+genesisUTxO genesis =
   UTxO $
     Map.fromList
       [ (txIn, txOut)


### PR DESCRIPTION
Either `Utxo` or `UTxO`, but not `UtxO` :exploding_head:

I knew this function existed, but I couldn't find it with a case-sensitive grep
because of this strange capitalisation.

It might very well be that I'm the one to blame for this :shushing_face:.