### PR TITLE
Run property tests for 'Allegra TestCrypto'

### DIFF
--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Cardano.Ledger.Allegra
@@ -19,6 +21,7 @@ where
 
 import Cardano.Binary (serializeEncoding', toCBOR)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
+import qualified Cardano.Ledger.Core as Core (AuxiliaryData)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
@@ -29,7 +32,7 @@ import Cardano.Ledger.ShelleyMA.TxBody
   )
 import Cardano.Slotting.Slot (SlotNo (SlotNo))
 import Data.Hashable (hash)
-import Data.Sequence.Strict (StrictSeq, fromList)
+import Data.Sequence.Strict (StrictSeq (..), fromList)
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.API (KeyRole (Witness))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
@@ -38,7 +41,9 @@ import Shelley.Spec.Ledger.Keys (KeyHash)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.TxBody (DCert, TxIn, TxOut, Wdrl)
 import Test.Cardano.Ledger.EraBuffet (AllegraEra)
-import Test.QuickCheck (Gen, choose, frequency)
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
+import Test.QuickCheck (Gen, arbitrary, frequency)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), genCoin)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen (..))
@@ -61,15 +66,15 @@ import Test.Shelley.Spec.Ledger.Generator.ScriptClass
 instance (CryptoClass.Crypto c) => ScriptClass (AllegraEra c) where
   isKey _ (RequireSignature hk) = Just hk
   isKey _ _ = Nothing
-  basescript _proxy = someLeaf
+  basescript _proxy = someLeaf @(AllegraEra c)
   quantify _ = quantifyTL
   unQuantify _ = unQuantifyTL
 
-instance CryptoClass.Crypto c => EraGen (AllegraEra c) where
+instance (CryptoClass.Crypto c, Mock c) => EraGen (AllegraEra c) where
   genGenesisValue (GenEnv _keySpace Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
     genCoin minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody _ge = genTxBody
-  genEraAuxiliaryData = error "TODO @uroboros - implement genEraAuxiliaryData for Allegra"
+  genEraAuxiliaryData = genAuxiliaryData
   updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd ad forge) fee ins outs =
     TxBody ins outs cert wdrl fee vi upd ad forge
 
@@ -118,22 +123,77 @@ unQuantifyTL (AnyOf xs) = RequireAnyOf (fromList xs)
 unQuantifyTL (MOf n xs) = RequireMOf n (fromList xs)
 unQuantifyTL (Leaf t) = t
 
-genValidityInterval :: SlotNo -> Gen ValidityInterval
-genValidityInterval (SlotNo currentSlot) = do
-  start <- choose (currentSlot, currentSlot + 50)
-  end <- choose (start, start + 50)
-  validityStart <- frequency [(1, pure SNothing), (4, pure $ SJust (SlotNo start))]
-  validityEnd <- frequency [(1, pure SNothing), (4, pure $ SJust (SlotNo end))]
-  pure $
-    ValidityInterval validityStart validityEnd
+genAuxiliaryData ::
+  Mock crypto =>
+  Constants ->
+  Gen (StrictMaybe (Core.AuxiliaryData (AllegraEra crypto)))
+genAuxiliaryData Constants {frequencyTxWithMetadata} =
+  frequency
+    [ (frequencyTxWithMetadata, SJust <$> arbitrary),
+      (100 - frequencyTxWithMetadata, pure SNothing)
+    ]
 
--- | Generate some Leaf Timelock (i.e. a Signature or TimeStart or TimeExpire)
-someLeaf :: CryptoClass.Crypto crypto => KeyHash 'Witness crypto -> Timelock crypto
+-- | Generates a trivial validity interval that is valid for the current slot.
+--
+-- Note: the validity interval must be a subset of all timelock
+-- script intervals that apply to the transaction. This depends on
+-- which generated scripts are actually required to validate the transaction
+-- (which is itself not always deterministic, e.g. 'RequireMOf n scripts').
+--
+-- A more sophisticated generator would compute which set of scripts
+-- would validate the transaction, and from that compute a minimal
+-- ValidityInterval that fits into all timelock slot ranges.
+genValidityInterval :: SlotNo -> Gen ValidityInterval
+genValidityInterval cs@(SlotNo currentSlot) =
+  pure $
+    ValidityInterval
+      (SJust cs)
+      (SJust . SlotNo $ currentSlot + 1)
+
+-- | Generate some Leaf Timelock (i.e. a Signature or TimeStart or TimeExpire).
+--
+-- Because we don't know how these "leaf scripts" will be situated in larger scripts
+-- (e.g. the script generated here might form part of a 'RequireAll' or 'RequireMOf' script)
+-- we must make sure that all timelocks generated here are valid for all slots.
+--
+-- To achieve this we arrange the timelock scripts like so:
+--  RequireAnyOf [
+--     RequireAllOf [RequireTimeExpire k, RequireSignature x],
+--     RequireAllOf [RequireTimeStart k, RequireSignature x]
+--  ]
+-- where k is arbitrary. This means that regardless of slot, there will be a
+-- valid sub-branch of script.
+someLeaf ::
+  forall era.
+  Era era =>
+  KeyHash 'Witness (Crypto era) ->
+  Timelock (Crypto era)
 someLeaf x =
   let n = mod (hash (serializeEncoding' (toCBOR x))) 200
-   in if n <= 50
-        then RequireTimeStart (SlotNo (fromIntegral n))
-        else
-          if n > 150
-            then RequireTimeExpire (SlotNo (fromIntegral n))
-            else RequireSignature x
+   in partition @era [n] [RequireSignature x]
+
+partition ::
+  forall era.
+  Era era =>
+  [Int] ->
+  [Timelock (Crypto era)] ->
+  Timelock (Crypto era)
+partition splits scripts =
+  RequireAnyOf . fromList $
+    zipWith pair (intervals @era splits) (cycle scripts)
+  where
+    pair a b = RequireAllOf $ fromList [a, b]
+
+intervals ::
+  forall era.
+  Era era =>
+  [Int] ->
+  [Timelock (Crypto era)]
+intervals xs = zipWith mkInterval padded (tail padded)
+  where
+    padded = Nothing : (Just . SlotNo . fromIntegral <$> xs) ++ [Nothing]
+    start Nothing = []
+    start (Just x) = [RequireTimeStart x]
+    end Nothing = []
+    end (Just x) = [RequireTimeExpire x]
+    mkInterval s e = RequireAllOf . fromList $ start s ++ end e

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Translation.hs
@@ -12,24 +12,24 @@ where
 import Cardano.Binary
   ( ToCBOR (..),
   )
-import Cardano.Ledger.Mary.Translation ()
 import Cardano.Ledger.Era (TranslateEra (..))
+import Cardano.Ledger.Mary.Translation ()
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Shelley.Spec.Ledger.API as S
+import Test.Cardano.Ledger.Allegra ()
 import Test.Cardano.Ledger.EraBuffet
   ( AllegraEra,
     MaryEra,
     StandardCrypto,
   )
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.Cardano.Ledger.TranslationTools
   ( decodeTestAnn,
     translationCompatToCBOR,
   )
 import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
-import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import Test.Cardano.Ledger.Allegra ()
+import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -22,7 +22,9 @@ flag development
     manual: True
 
 library
-  hs-source-dirs:    src
+  hs-source-dirs:
+      src
+      test
   exposed-modules:
     Test.Cardano.Crypto.VRF.Fake
     Test.Shelley.Spec.Ledger.BenchmarkFunctions
@@ -50,7 +52,20 @@ library
     Test.Shelley.Spec.Ledger.Serialisation.GoldenUtils
     Test.Shelley.Spec.Ledger.Shrinkers
     Test.Shelley.Spec.Ledger.Utils
-
+    Test.Shelley.Spec.Ledger.PropertyTests
+    Test.TestScenario
+  other-modules:
+      Test.Shelley.Spec.Ledger.Address.Bootstrap
+      Test.Shelley.Spec.Ledger.Address.CompactAddr
+      Test.Shelley.Spec.Ledger.ByronTranslation
+      Test.Shelley.Spec.Ledger.Examples.Federation
+      Test.Shelley.Spec.Ledger.LegacyOverlay
+      Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
+      Test.Shelley.Spec.Ledger.Rules.TestChain
+      Test.Shelley.Spec.Ledger.Rules.TestDeleg
+      Test.Shelley.Spec.Ledger.Rules.TestPool
+      Test.Shelley.Spec.Ledger.Rules.TestPoolreap
+      Test.Shelley.Spec.Ledger.ShelleyTranslation
   ghc-options:
     -Wall
     -Wcompat

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -11,9 +11,9 @@
 
 module Test.Shelley.Spec.Ledger.Generator.EraGen (genUtxo0, genesisId, EraGen (..)) where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Binary (ToCBOR (toCBOR))
 import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (HASH)
 import Cardano.Ledger.Era (Crypto)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
@@ -104,9 +104,11 @@ getFirst :: ([a] -> Bool) -> [[a]] -> [a]
 getFirst _p [] = []
 getFirst p (xs : xss) = if p xs then xs else getFirst p xss
 
--- | Return some valid list of KeyHashes that appear in a Script
---   Try not to return the empty list if there is at least on
---   Leaf that requires a key hash.
+-- | Produce a valid list of key hashes that appear in a Script.
+-- Note: in the case of AnyOf, we just take the first script in the expression.
+-- This only works if we generate AnyOf scripts such that all script options
+-- are valid scripts (that is, valid in the context of a transaction, at generation time
+-- and execution/spend time).
 scriptKeyCombination ::
   forall era.
   ScriptClass era =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -39,7 +39,7 @@ import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Data.Functor.Identity (runIdentity)
 import Data.List (partition)
 import qualified Data.Map.Strict as Map (lookup)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -194,9 +194,8 @@ genDCerts
       scriptWitnesses (ScriptCred (_, stakeScript)) =
         StakeCred <$> witnessHashes''
         where
-          witnessHashes = scriptKeyCombination (Proxy @era) stakeScript
-          witnessHashes' = fmap coerceKeyRole witnessHashes
-          witnessHashes'' = fmap coerceKeyRole (catMaybes (map lookupWit witnessHashes'))
+          witnessHashes = coerceKeyRole <$> scriptKeyCombination (Proxy @era) stakeScript
+          witnessHashes'' = coerceKeyRole <$> mapMaybe lookupWit witnessHashes
       scriptWitnesses _ = []
 
       lookupWit = flip Map.lookup ksIndexedStakingKeys


### PR DESCRIPTION
Wire up minimal and nightly property tests for 'Allegra TestCrypto'.

Note: as it stands, the ValidityInterval generator is trivial (valid only for the current Tx slot). There are plans for smarter generation of Validity intervals that match the generated time lock scripts, this will be left for a subsequent PR.