### PR TITLE
Hide the Shelley update-epoch transition logic behind a UPEC rule.

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
@@ -17,6 +17,7 @@ import qualified Shelley.Spec.Ledger.STS.Overlay as Shelley
 import qualified Shelley.Spec.Ledger.STS.Rupd as Shelley
 import qualified Shelley.Spec.Ledger.STS.Snap as Shelley
 import qualified Shelley.Spec.Ledger.STS.Tick as Shelley
+import qualified Shelley.Spec.Ledger.STS.Upec as Shelley
 
 -- These rules are all inherited from Shelley
 
@@ -59,6 +60,8 @@ type instance Core.EraRule "TICK" (ShelleyMAEra ma c) = Shelley.TICK (ShelleyMAE
 type instance Core.EraRule "TICKF" (ShelleyMAEra ma c) = Shelley.TICKF (ShelleyMAEra ma c)
 
 type instance Core.EraRule "TICKN" (ShelleyMAEra _ma _c) = Shelley.TICKN
+
+type instance Core.EraRule "UPEC" (ShelleyMAEra ma c) = Shelley.UPEC (ShelleyMAEra ma c)
 
 -- These rules are defined anew in the ShelleyMA era(s)
 

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -84,6 +84,7 @@ library
     Shelley.Spec.Ledger.STS.Tick
     Shelley.Spec.Ledger.STS.Tickn
     Shelley.Spec.Ledger.STS.Updn
+    Shelley.Spec.Ledger.STS.Upec
     Shelley.Spec.Ledger.STS.Utxo
     Shelley.Spec.Ledger.STS.Utxow
     Shelley.Spec.Ledger.Tx

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -46,7 +46,6 @@ module Shelley.Spec.Ledger.LedgerState
     pvCanFollow,
     reapRewards,
     totalInstantaneousReservesRewards,
-    updatePpup,
 
     -- * Genesis State
     genesisState,
@@ -529,16 +528,6 @@ pvCanFollow :: ProtVer -> StrictMaybe ProtVer -> Bool
 pvCanFollow _ SNothing = True
 pvCanFollow (ProtVer m n) (SJust (ProtVer m' n')) =
   (m + 1, 0) == (m', n') || (m, n + 1) == (m', n')
-
--- | Update the protocol parameter updates by clearing out the proposals
--- and making the future proposals become the new proposals,
--- provided the new proposals can follow (otherwise reset them).
-updatePpup :: UTxOState era -> PParams era -> UTxOState era
-updatePpup utxoSt pp = utxoSt {_ppups = PPUPState ps emptyPPPUpdates}
-  where
-    (ProposedPPUpdates newProposals) = futureProposals . _ppups $ utxoSt
-    goodPV = pvCanFollow (_protocolVersion pp) . _protocolVersion
-    ps = if all goodPV newProposals then ProposedPPUpdates newProposals else emptyPPPUpdates
 
 data UTxOState era = UTxOState
   { _utxo :: !(UTxO era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -22,7 +22,6 @@ where
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
-import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
   ( Embed (..),
@@ -38,11 +37,11 @@ import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
-import Shelley.Spec.Ledger.EpochBoundary (SnapShots)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.EpochBoundary (SnapShots, obligation)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState,
     LedgerState,
-    PPUPState (..),
     PState (..),
     esAccountState,
     esLState,
@@ -64,7 +63,7 @@ import Shelley.Spec.Ledger.Rewards ()
 import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppPredicateFailure, NewppState (..))
 import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapPredicateFailure, PoolreapState (..))
 import Shelley.Spec.Ledger.STS.Snap (SNAP, SnapPredicateFailure)
-import Shelley.Spec.Ledger.STS.Upec (UPEC, UPECState (..))
+import Shelley.Spec.Ledger.STS.Upec (UPEC, UpecPredicateFailure, UpecState (..))
 import Shelley.Spec.Ledger.Slot (EpochNo)
 
 data EPOCH era
@@ -72,20 +71,20 @@ data EPOCH era
 data EpochPredicateFailure era
   = PoolReapFailure (PredicateFailure (Core.EraRule "POOLREAP" era)) -- Subtransition Failures
   | SnapFailure (PredicateFailure (Core.EraRule "SNAP" era)) -- Subtransition Failures
-  | NewPpFailure (PredicateFailure (Core.EraRule "UPEC" era)) -- Subtransition Failures
+  | UpecFailure (PredicateFailure (Core.EraRule "UPEC" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
   ( Eq (PredicateFailure (Core.EraRule "POOLREAP" era)),
     Eq (PredicateFailure (Core.EraRule "SNAP" era)),
-    Eq (PredicateFailure (Core.EraRule "NEWPP" era))
+    Eq (PredicateFailure (Core.EraRule "UPEC" era))
   ) =>
   Eq (EpochPredicateFailure era)
 
 deriving stock instance
   ( Show (PredicateFailure (Core.EraRule "POOLREAP" era)),
     Show (PredicateFailure (Core.EraRule "SNAP" era)),
-    Show (PredicateFailure (Core.EraRule "NEWPP" era))
+    Show (PredicateFailure (Core.EraRule "UPEC" era))
   ) =>
   Show (EpochPredicateFailure era)
 
@@ -100,10 +99,10 @@ instance
     Environment (Core.EraRule "POOLREAP" era) ~ PParams era,
     State (Core.EraRule "POOLREAP" era) ~ PoolreapState era,
     Signal (Core.EraRule "POOLREAP" era) ~ EpochNo,
-    Embed (Core.EraRule "NEWPP" era) (EPOCH era),
-    Environment (Core.EraRule "NEWPP" era) ~ NewppEnv era,
-    State (Core.EraRule "NEWPP" era) ~ NewppState era,
-    Signal (Core.EraRule "NEWPP" era) ~ Maybe (PParams era)
+    Embed (Core.EraRule "UPEC" era) (EPOCH era),
+    Environment (Core.EraRule "UPEC" era) ~ EpochState era,
+    State (Core.EraRule "UPEC" era) ~ UpecState era,
+    Signal (Core.EraRule "UPEC" era) ~ ()
   ) =>
   STS (EPOCH era)
   where
@@ -117,7 +116,7 @@ instance
 instance
   ( NoThunks (PredicateFailure (Core.EraRule "POOLREAP" era)),
     NoThunks (PredicateFailure (Core.EraRule "SNAP" era)),
-    NoThunks (PredicateFailure (Core.EraRule "NEWPP" era))
+    NoThunks (PredicateFailure (Core.EraRule "UPEC" era))
   ) =>
   NoThunks (EpochPredicateFailure era)
 
@@ -148,9 +147,7 @@ votedValue (ProposedPPUpdates pup) pps quorumN =
 
 epochTransition ::
   forall era.
-  ( UsesTxOut era,
-    UsesValue era,
-    Embed (Core.EraRule "SNAP" era) (EPOCH era),
+  ( Embed (Core.EraRule "SNAP" era) (EPOCH era),
     Environment (Core.EraRule "SNAP" era) ~ LedgerState era,
     State (Core.EraRule "SNAP" era) ~ SnapShots (Crypto era),
     Signal (Core.EraRule "SNAP" era) ~ (),
@@ -158,10 +155,10 @@ epochTransition ::
     Environment (Core.EraRule "POOLREAP" era) ~ PParams era,
     State (Core.EraRule "POOLREAP" era) ~ PoolreapState era,
     Signal (Core.EraRule "POOLREAP" era) ~ EpochNo,
-    Embed (Core.EraRule "NEWPP" era) (EPOCH era),
-    Environment (Core.EraRule "NEWPP" era) ~ NewppEnv era,
-    State (Core.EraRule "NEWPP" era) ~ NewppState era,
-    Signal (Core.EraRule "NEWPP" era) ~ Maybe (PParams era)
+    Embed (Core.EraRule "UPEC" era) (EPOCH era),
+    Environment (Core.EraRule "UPEC" era) ~ EpochState era,
+    State (Core.EraRule "UPEC" era) ~ UpecState era,
+    Signal (Core.EraRule "UPEC" era) ~ ()
   ) =>
   TransitionRule (EPOCH era)
 epochTransition = do
@@ -203,31 +200,22 @@ epochTransition = do
           pp
           nm
 
-  UPECState pp' ppupSt' <-
-    trans @(Core.EraRule "UPEC" era) $ TRC (epochState', UPECState pp (_ppups utxoSt'), ())
+  UpecState pp' ppupSt' <-
+    trans @(Core.EraRule "UPEC" era) $ TRC (epochState', UpecState pp (_ppups utxoSt'), ())
   let utxoSt'' = utxoSt' {_ppups = ppupSt'}
 
-  if pp /= pp'
-    then do
-      let Coin oblgCurr = obligation pp (_rewards dstate') (_pParams pstate'')
-          Coin oblgNew = obligation pp' (_rewards dstate') (_pParams pstate'')
-          Coin reserves = _reserves acnt'
-          utxoSt''' = utxoSt'' {_deposited = Coin oblgNew}
-          acnt'' = acnt' {_reserves = Coin $ reserves + oblgCurr - oblgNew}
-      pure $
-        epochState'
-          { esAccountState = acnt'',
-            esLState = (esLState epochState') {_utxoState = utxoSt'''},
-            esPrevPp = pp,
-            esPp = pp'
-          }
-    else
-      pure $
-        epochState'
-          { esLState = (esLState epochState') {_utxoState = utxoSt'}, -- do not update the protocol parameters.
-            esPrevPp = pp,
-            esPp = pp
-          }
+  let Coin oblgCurr = obligation pp (_rewards dstate') (_pParams pstate'')
+      Coin oblgNew = obligation pp' (_rewards dstate') (_pParams pstate'')
+      Coin reserves = _reserves acnt'
+      utxoSt''' = utxoSt'' {_deposited = Coin oblgNew}
+      acnt'' = acnt' {_reserves = Coin $ reserves + oblgCurr - oblgNew}
+  pure $
+    epochState'
+      { esAccountState = acnt'',
+        esLState = (esLState epochState') {_utxoState = utxoSt'''},
+        esPrevPp = pp,
+        esPp = pp'
+      }
 
 instance
   ( UsesTxOut era,
@@ -248,6 +236,7 @@ instance
 
 instance
   ( Era era,
+    STS (UPEC era),
     PredicateFailure (Core.EraRule "UPEC" era) ~ UpecPredicateFailure era
   ) =>
   Embed (UPEC era) (EPOCH era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
@@ -26,6 +26,7 @@ import Shelley.Spec.Ledger.STS.Rupd (RUPD)
 import Shelley.Spec.Ledger.STS.Snap (SNAP)
 import Shelley.Spec.Ledger.STS.Tick (TICK, TICKF)
 import Shelley.Spec.Ledger.STS.Tickn (TICKN)
+import Shelley.Spec.Ledger.STS.Upec (UPEC)
 import Shelley.Spec.Ledger.STS.Utxo (UTXO)
 import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
 
@@ -68,6 +69,8 @@ type instance Core.EraRule "TICK" (ShelleyEra c) = TICK (ShelleyEra c)
 type instance Core.EraRule "TICKF" (ShelleyEra c) = TICKF (ShelleyEra c)
 
 type instance Core.EraRule "TICKN" (ShelleyEra c) = TICKN
+
+type instance Core.EraRule "UPEC" (ShelleyEra c) = UPEC (ShelleyEra c)
 
 type instance Core.EraRule "UTXO" (ShelleyEra c) = UTXO (ShelleyEra c)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -32,23 +32,24 @@ import Shelley.Spec.Ledger.EpochBoundary (obligation)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
     DState (..),
+    PPUPState (..),
     PState (..),
     UTxOState,
+    pvCanFollow,
     totalInstantaneousReservesRewards,
-    updatePpup,
     _deposited,
     _irwd,
     _reserves,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates (..))
 
 data NEWPP era
 
 data NewppState era
-  = NewppState (UTxOState era) AccountState (PParams era)
+  = NewppState (PParams era) (PPUPState era)
 
 data NewppEnv era
-  = NewppEnv (DState (Crypto era)) (PState (Crypto era))
+  = NewppEnv (DState (Crypto era)) (PState (Crypto era)) (UTxOState era) AccountState
 
 data NewppPredicateFailure era
   = UnexpectedDepositPot
@@ -67,11 +68,16 @@ instance Typeable era => STS (NEWPP era) where
   transitionRules = [newPpTransition]
 
 instance Default (NewppState era) where
-  def = NewppState def def def
+  def = NewppState def def
 
 newPpTransition :: TransitionRule (NEWPP era)
 newPpTransition = do
-  TRC (NewppEnv dstate pstate, NewppState utxoSt acnt pp, ppNew) <- judgmentContext
+  TRC
+    ( NewppEnv dstate pstate utxoSt acnt,
+      NewppState pp ppupSt,
+      ppNew
+      ) <-
+    judgmentContext
 
   case ppNew of
     Just ppNew' -> do
@@ -84,12 +90,20 @@ newPpTransition = do
       (Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
 
       if reserves + diff >= requiredInstantaneousRewards
-        -- Note that instantaneous rewards from the treasury are irrelevant here,
-        -- since changes in the protocol parameters do not change how much is needed from the treasury
+        -- Note that instantaneous rewards from the treasury are irrelevant
+        -- here, since changes in the protocol parameters do not change how much
+        -- is needed from the treasury
         && (_maxTxSize ppNew' + _maxBHSize ppNew') < _maxBBSize ppNew'
-        then
-          let utxoSt' = utxoSt {_deposited = Coin oblgNew}
-           in let acnt' = acnt {_reserves = Coin $ reserves + diff}
-               in pure $ NewppState (updatePpup utxoSt' ppNew') acnt' ppNew'
-        else pure $ NewppState (updatePpup utxoSt pp) acnt pp
-    Nothing -> pure $ NewppState (updatePpup utxoSt pp) acnt pp
+        then pure $ NewppState ppNew' (updatePpup ppupSt ppNew')
+        else pure $ NewppState pp (updatePpup ppupSt pp)
+    Nothing -> pure $ NewppState pp (updatePpup ppupSt pp)
+
+-- | Update the protocol parameter updates by clearing out the proposals
+-- and making the future proposals become the new proposals,
+-- provided the new proposals can follow (otherwise reset them).
+updatePpup :: PPUPState era -> PParams era -> PPUPState era
+updatePpup ppupSt pp = PPUPState ps emptyPPPUpdates
+  where
+    (ProposedPPUpdates newProposals) = futureProposals ppupSt
+    goodPV = pvCanFollow (_protocolVersion pp) . _protocolVersion
+    ps = if all goodPV newProposals then ProposedPPUpdates newProposals else emptyPPPUpdates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -41,7 +41,12 @@ import Shelley.Spec.Ledger.LedgerState
     _irwd,
     _reserves,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates (..))
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    PParams' (..),
+    ProposedPPUpdates (..),
+    emptyPPPUpdates,
+  )
 
 data NEWPP era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Epoch change registration.
+--
+-- The rules of this module determine how the update subsystem of the ledger
+-- handles the epoch transitions.
+module Shelley.Spec.Ledger.STS.Upec where
+
+import GHC.Generics (Generic)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Control.State.Transition
+  (Embed (..), STS (..), TRC (..), judgmentContext, liftSTS, trans)
+import Shelley.Spec.Ledger.LedgerState
+  ( EpochState, pattern EpochState,     esAccountState,     esLState, esPp, esNonMyopic, esSnapshots, esPrevPp,     _utxoState,     _delegationState,     PPUPState (..)    ,_ppups,     pattern DPState)
+import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
+import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppState (..))
+import Control.Monad.Trans.Reader (asks)
+import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, ProposedPPUpdates (..), updatePParams)
+import NoThunks.Class (NoThunks (..))
+
+-- | Update epoch change
+data UPEC era
+
+data UpecPredicateFailure era =
+  NewPpFailure (PredicateFailure (NEWPP era))
+  deriving (Eq, Show, Generic)
+
+instance NoThunks (UpecPredicateFailure era)
+
+instance ShelleyBased era => STS (UPEC era) where
+  type State (UPEC era) = EpochState era
+  type Signal (UPEC era) = ()
+  type Environment (UPEC era) = ()
+  type BaseM (UPEC era) = ShelleyBase
+  type PredicateFailure (UPEC era) = UpecPredicateFailure era
+  initialRules = []
+  transitionRules = [
+    do
+      TRC (_,
+           EpochState
+           { esAccountState = acnt,
+             esSnapshots = ss,
+             esLState = ls,
+             esPrevPp = _pr,
+             esPp = pp,
+             esNonMyopic = nm
+           }
+          , _
+          ) <- judgmentContext
+
+      coreNodeQuorum <- liftSTS $ asks quorum
+
+      let utxoSt = _utxoState ls
+          DPState dstate pstate = _delegationState ls
+          pup = proposals . _ppups $ utxoSt
+          ppNew = votedValue pup pp (fromIntegral coreNodeQuorum)
+      NewppState utxoSt' acnt' pp' <-
+        trans @(NEWPP era) $
+          TRC (NewppEnv dstate pstate, NewppState utxoSt acnt pp, ppNew)
+      pure $
+        EpochState
+        acnt'
+        ss
+        (ls {_utxoState = utxoSt'})
+        pp
+        pp'
+        nm
+    ]
+
+-- | If at least @n@ nodes voted to change __the same__ protocol parameters to
+-- __the same__ values, return the given protocol parameters updated to these
+-- values. Here @n@ is the quorum needed.
+votedValue ::
+  ProposedPPUpdates era ->
+  -- | Protocol parameters to which the change will be applied.
+  PParams era ->
+  -- | Quorum needed to change the protocol parameters.
+  Int ->
+  Maybe (PParams era)
+votedValue (ProposedPPUpdates pup) pps quorumN =
+  let incrTally vote tally = 1 + Map.findWithDefault 0 vote tally
+      votes =
+        Map.foldr
+          (\vote tally -> Map.insert vote (incrTally vote tally) tally)
+          (Map.empty :: Map (PParamsUpdate era) Int)
+          pup
+      consensus = Map.filter (>= quorumN) votes
+   in case length consensus of
+        -- NOTE that `quorumN` is a global constant, and that we require
+        -- it to be strictly greater than half the number of genesis nodes.
+        -- The keys in the `pup` correspond to the genesis nodes,
+        -- and therefore either:
+        --   1) `consensus` is empty, or
+        --   2) `consensus` has exactly one element.
+        1 -> (Just . updatePParams pps . fst . head . Map.toList) consensus
+        -- NOTE that `updatePParams` corresponds to the union override right
+        -- operation in the formal spec.
+        _ -> Nothing
+
+
+instance ShelleyBased era => Embed (NEWPP era) (UPEC era) where
+  wrapFailed = NewPpFailure


### PR DESCRIPTION
This will allow us to easily change this aspect from era to era.