### PR TITLE
Add the eval-time GC roots to release.nix so they're cached

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,8 @@ let
       withHoogle = true;
     };
 
+    roots = cardanoLedgerSpecsHaskellPackages.roots;
+
     #
     # PDF builds of LaTeX documentation.
     #

--- a/release.nix
+++ b/release.nix
@@ -78,6 +78,8 @@ let
     docSite = project.doc.site;
     # Ensure everything in the shell is cached
     shell = project.shell;
+    # Ensure that the project's eval-time GC roots are built and cached by Hydra
+    roots = project.roots;
   };
 
 in jobs


### PR DESCRIPTION
Otherwise they'll get GCd very quickly, which means people will need to
build a lot to even open the shell.