### PR TITLE
Drop injectivity requirement for PredicateFailure

### DIFF
--- a/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/Chain.hs
@@ -371,7 +371,7 @@ coverInvalidBlockProofs
   -- ^ Structure containing the failures
   -> m ()
 coverInvalidBlockProofs coverPercentage =
-  coverFailures coverPercentage
+  coverFailures @_ @BBODY coverPercentage
     [ InvalidDelegationHash
     , InvalidUpdateProposalHash
     , InvalidUtxoHash

--- a/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation/Test.hs
+++ b/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation/Test.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -21,7 +23,7 @@ coverDelegFailures
   -> a
   -> m ()
 coverDelegFailures coverPercentage =
-  Generator.coverFailures
+  Generator.coverFailures @_ @SDELEG
     coverPercentage
     [ EpochInThePast (EpochDiff 0 0) -- The value here is ignored, only the constructor is compared
     , EpochPastNextEpoch (EpochDiff 0 0 ) -- The value here is ignored, only the constructor is compared

--- a/byron/ledger/executable-spec/src/Byron/Spec/Ledger/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Byron/Spec/Ledger/STS/UTXOW.hs
@@ -150,13 +150,13 @@ coverUtxoFailure
   -- ^ Structure containing the failures
   -> m ()
 coverUtxoFailure coverPercentage someData = do
-  coverFailures
+  coverFailures @_ @UTXOW
     coverPercentage
     [ InsufficientWitnesses
     ]
     someData
 
-  coverFailures
+  coverFailures @_ @UTXO
     coverPercentage
     [ FeeTooLow
     , InputsNotInUTxO

--- a/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Update/Test.hs
+++ b/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Update/Test.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -28,7 +30,7 @@ coverUpiregFailures
   -- ^ Structure containing the failures
   -> m ()
 coverUpiregFailures coverPercentage someData = do
-  Generator.coverFailures
+  Generator.coverFailures @_ @UPPVV
     coverPercentage
     [ CannotFollowPv
     , CannotUpdatePv []
@@ -36,7 +38,7 @@ coverUpiregFailures coverPercentage someData = do
     ]
     someData
 
-  Generator.coverFailures
+  Generator.coverFailures @_ @UPSVV
     coverPercentage
     [ AlreadyProposedSv
     , CannotFollowSv
@@ -45,7 +47,7 @@ coverUpiregFailures coverPercentage someData = do
     ]
     someData
 
-  Generator.coverFailures
+  Generator.coverFailures @_ @UPREG
     coverPercentage
     [ NotGenesisDelegate
     , DoesNotVerify
@@ -64,7 +66,7 @@ coverUpivoteFailures
   -> a
   -> m ()
 coverUpivoteFailures coverPercentage =
-  Generator.coverFailures
+  Generator.coverFailures @_ @ADDVOTE
     coverPercentage
     [ AVSigDoesNotVerify
     , NoUpdateProposal (UpId 0) -- We need to pass a dummy update id here.

--- a/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
@@ -390,7 +390,7 @@ rejectDupSchedDelegs = withTests 300 $ property $ do
     epo <- Epoch <$> Gen.integral (Range.linear 0 100)
     let dcert = mkDCert vkS (Sig (vkD, epo) (owner vkS)) vkD epo
     return (tr, dcert)
-  let pfs = case applySTS (TRC (tr ^. traceEnv, lastState tr, [dcert])) of
+  let pfs = case applySTS @DELEG (TRC (tr ^. traceEnv, lastState tr, [dcert])) of
         Left res -> res
         Right _ -> []
   assert $ SDelegSFailure (SDelegFailure IsAlreadyScheduled) `elem` concat pfs

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -420,10 +420,11 @@ checkTrace
    . (STS s, BaseM s ~ m)
   => (forall a. m a -> a)
   -> Environment s
-  -> ReaderT (State s -> Signal s -> (Either [[PredicateFailure s]] (State s))) IO (State s)
+  -> ReaderT (State s ->
+        Signal s -> (Either [[PredicateFailure s]] (State s))) IO (State s)
   -> IO ()
 checkTrace interp env act =
-  void $ runReaderT act (\st sig -> interp $ applySTSTest (TRC(env, st, sig)))
+  void $ runReaderT act (\st sig -> interp $ applySTSTest @s (TRC(env, st, sig)))
 
 -- | Extract all the values of a given type.
 --

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}


### PR DESCRIPTION
This is split apart from #2060, since it's logically distinct. The
motivation is that we will need this to have multiple UTXO rules in
different eras sharing the same failure.