### PR TITLE
Add minimal constraints for each type family

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -12,6 +13,7 @@ import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
     ValidateAuxiliaryData (..),
   )
+import Cardano.Ledger.Constraints (UsesValue)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
@@ -56,6 +58,10 @@ instance
 type family MAValue (x :: MaryOrAllegra) c :: Type where
   MAValue 'Allegra _ = Coin
   MAValue 'Mary c = Value c
+
+instance CryptoClass.Crypto c => UsesValue (ShelleyMAEra 'Mary c)
+
+instance CryptoClass.Crypto c => UsesValue (ShelleyMAEra 'Allegra c)
 
 --------------------------------------------------------------------------------
 -- Core instances

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -42,10 +42,10 @@ import Cardano.Binary
     serialize',
   )
 import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.Constraints (UsesScript, UsesTxBody)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Control.DeepSeq (NFData (..))
@@ -286,7 +286,8 @@ evalFPS timelock vhks txb = evalTimelock vhks (getField @"vldt" txb) timelock
 
 validateTimelock ::
   forall era.
-  ( TxBodyConstraints era,
+  ( UsesTxBody era,
+    UsesScript era,
     HasField "vldt" (Core.TxBody era) ValidityInterval,
     ToCBOR (Core.AuxiliaryData era)
   ) =>

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -26,10 +26,10 @@ import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody
-  ( FamsTo,
-    TxBody (..),
+  ( TxBody (..),
     ValidityInterval (ValidityInterval),
   )
+import Cardano.Ledger.Val(Val(zero))
 import Cardano.Slotting.Slot (SlotNo (SlotNo))
 import Data.Hashable (hash)
 import Data.Sequence.Strict (StrictSeq (..), fromList)
@@ -51,6 +51,8 @@ import Test.Shelley.Spec.Ledger.Generator.ScriptClass
   ( Quantifier (..),
     ScriptClass (..),
   )
+import Cardano.Ledger.Constraints (UsesValue,UsesAuxiliary)
+-- ==========================================================
 
 {------------------------------------------------------------------------------
  EraGen instance for AllegraEra - This instance makes it possible to run the
@@ -80,7 +82,8 @@ instance (CryptoClass.Crypto c, Mock c) => EraGen (AllegraEra c) where
 
 genTxBody ::
   forall era.
-  ( FamsTo era,
+  ( UsesValue era,
+    UsesAuxiliary era,
     EraGen era
   ) =>
   SlotNo ->
@@ -94,7 +97,7 @@ genTxBody ::
   Gen (TxBody era)
 genTxBody slot ins outs cert wdrl fee upd ad = do
   validityInterval <- genValidityInterval slot
-  let mint = mempty -- the mint field is always empty for an Allegra TxBody
+  let mint = zero -- the mint field is always empty for an Allegra TxBody
   pure $
     TxBody
       ins

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -16,7 +16,7 @@ import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Mary.Value (Value (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
-import Cardano.Ledger.ShelleyMA.TxBody (FamsTo, StrictMaybe, TxBody (..))
+import Cardano.Ledger.ShelleyMA.TxBody (StrictMaybe, TxBody (..))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
 import qualified Data.Map as Map
@@ -43,6 +43,7 @@ import Test.Shelley.Spec.Ledger.Generator.ScriptClass
     exponential,
   )
 import Test.Shelley.Spec.Ledger.Utils (Split (..))
+import Cardano.Ledger.Constraints (UsesValue,UsesAuxiliary)
 
 {------------------------------------------------------------------------------
  EraGen instance for MaryEra - This instance makes it possible to run the
@@ -72,7 +73,8 @@ instance (CryptoClass.Crypto c, Mock c) => EraGen (MaryEra c) where
 
 genTxBody ::
   forall era.
-  ( FamsTo era,
+  ( UsesValue era,
+    UsesAuxiliary era,
     EraGen era
   ) =>
   SlotNo ->

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -19,7 +19,6 @@ module Test.Cardano.Ledger.ShelleyMA.TxBody
 where
 
 import Cardano.Binary (ToCBOR (..))
-import qualified Cardano.Ledger.Core as Core
 -- Arbitrary instances
 -- Arbitrary instances
 
@@ -31,14 +30,12 @@ import Cardano.Ledger.Mary.Value
   )
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import Cardano.Ledger.ShelleyMA.TxBody
-  ( FamsFrom,
-    TxBodyRaw (..),
+  ( TxBodyRaw (..),
     bodyFields,
     initial,
     txSparse,
   )
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
-import Cardano.Ledger.Val (Val (..))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
@@ -73,6 +70,7 @@ import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+import Cardano.Ledger.Constraints (UsesValue,UsesScript,UsesAuxiliary)
 
 -- ============================================================================================
 -- make an example
@@ -161,7 +159,7 @@ embedTest = do
     Left s -> error (show s)
 
 getTxSparse ::
-  (Val (Core.Value era), FamsFrom era) =>
+  (UsesValue era, UsesScript era, UsesAuxiliary era) =>
   Decode ('Closed 'Dense) (TxBodyRaw era)
 getTxSparse =
   SparseKeyed

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -26,6 +26,7 @@ library
     Cardano.Ledger.Era
     Cardano.Ledger.Shelley
     Cardano.Ledger.Shelley.Constraints
+    Cardano.Ledger.Constraints
     Cardano.Ledger.Torsor
     Cardano.Ledger.Val
     Shelley.Spec.Ledger.Address
@@ -114,6 +115,8 @@ library
     cardano-prelude,
     cardano-slotting,
     cborg,
+    cborg-json,
+    constraints,
     containers,
     data-default-class,
     deepseq,

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Constraints.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Constraints
+  ( AnnotatedData,
+    ChainData,
+    SerialisableData,
+    UsesTxBody,
+    UsesValue,
+    UsesScript,
+    UsesAuxiliary,
+    UsesTx,
+    TransValue,
+    NoThunks,
+  )
+where
+
+import Cardano.Binary (Annotator, FromCBOR, ToCBOR)
+import Cardano.Ledger.Compactible (Compactible (..))
+import Cardano.Ledger.Core
+  ( AnnotatedData,
+    ChainData,
+    SerialisableData,
+  )
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Torsor (Torsor (..))
+import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
+import Data.Kind (Constraint, Type)
+import NoThunks.Class (NoThunks (..))
+import Shelley.Spec.Ledger.Hashing
+  ( EraIndependentTxBody,
+    HashAnnotated (..),
+  )
+
+-- import Cardano.Ledger.Constraints(UsesTxBody,UsesValue,UsesScript,UsesTx,UsesAuxiliary,TransValue)
+-- ===========================================================================
+-- One constraint for each abstract type family. Think of these as the
+-- minimum properties that each type family instance must support.
+-- There is nothing magic about these, they were picked by trial and error,
+-- and seem to be sufficient for the current state of affairs.
+
+type UsesTxBody era =
+  ( Era era,
+    HashIndex (Core.TxBody era) ~ EraIndependentTxBody,
+    HashAnnotated (Core.TxBody era) era,
+    Eq (Core.TxBody era),
+    Show (Core.TxBody era),
+    FromCBOR (Annotator (Core.TxBody era)),
+    ToCBOR (Core.TxBody era)
+  )
+
+{-
+type UsesValue era =
+  ( Era era,
+    Val (Core.Value era),
+    Compactible (Core.Value era),
+    Show (Core.Value era),
+    Show (CompactForm (Core.Value era)),
+    DecodeNonNegative (Core.Value era),
+    EncodeMint (Core.Value era),
+    DecodeMint (Core.Value era),
+    Torsor (Core.Value era),
+    Eq (Delta (Core.Value era)),
+    Eq (CompactForm (Core.Value era)),
+    ToCBOR(Core.Value era),
+    ToCBOR (CompactForm (Core.Value era)),
+    FromCBOR(Core.Value era),
+    FromCBOR (CompactForm (Core.Value era))
+  )
+-}
+
+class
+  ( Era era,
+    Val (Core.Value era),
+    Compactible (Core.Value era),
+    Show (Core.Value era),
+    Show (CompactForm (Core.Value era)),
+    DecodeNonNegative (Core.Value era),
+    EncodeMint (Core.Value era),
+    DecodeMint (Core.Value era),
+    Torsor (Core.Value era),
+    Eq (Delta (Core.Value era)),
+    Eq (CompactForm (Core.Value era)),
+    ToCBOR (Core.Value era),
+    ToCBOR (CompactForm (Core.Value era)),
+    FromCBOR (Core.Value era),
+    FromCBOR (CompactForm (Core.Value era))
+  ) =>
+  UsesValue era
+
+type UsesTx era = (Era era, ToCBOR (Core.AuxiliaryData era))
+
+type UsesScript era =
+  ( Era era,
+    Eq (Core.Script era),
+    Show (Core.Script era),
+    ToCBOR (Core.Script era),
+    FromCBOR (Annotator (Core.Script era))
+  )
+
+type UsesAuxiliary era =
+  ( Era era,
+    Show (Core.AuxiliaryData era),
+    ToCBOR (Core.AuxiliaryData era),
+    FromCBOR (Annotator (Core.AuxiliaryData era))
+  )
+
+-- | Apply 'c' to all the types transitively involved with Value when
+-- (Core.Value era) is an instance of Compactible and Torsor
+type TransValue (c :: Type -> Constraint) era =
+  ( Era era,
+    Compactible (Core.Value era),
+    Torsor (Core.Value era),
+    c (Core.Value era),
+    c (CompactForm (Core.Value era)),
+    c (Delta (Core.Value era))
+  )

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
     ValidateAuxiliaryData (..),
   )
+import Cardano.Ledger.Constraints (UsesValue)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CryptoClass
@@ -36,6 +37,8 @@ data ShelleyEra c
 
 instance CryptoClass.Crypto c => Era (ShelleyEra c) where
   type Crypto (ShelleyEra c) = c
+
+instance CryptoClass.Crypto c => UsesValue (ShelleyEra c)
 
 --------------------------------------------------------------------------------
 -- Core instances

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -9,6 +9,7 @@ module Shelley.Spec.Ledger.API
   )
 where
 
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
@@ -24,7 +25,8 @@ class
     ShelleyBased era,
     GetLedgerView era,
     ApplyBlock era,
-    ApplyTx era
+    ApplyTx era,
+    UsesValue era
   ) =>
   ShelleyBasedEra era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -33,11 +33,11 @@ module Shelley.Spec.Ledger.API.Protocol
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -82,6 +82,8 @@ import qualified Shelley.Spec.Ledger.STS.Tickn as STS.Tickn
 import Shelley.Spec.Ledger.Serialization (decodeRecordNamed)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
+-- =======================================================
+
 class
   ( CC.Crypto c,
     DSignable c (OCertSignable c),
@@ -114,7 +116,7 @@ class
     SlotNo ->
     m (LedgerView (Crypto era))
   default futureLedgerView ::
-    (ShelleyBased era, MonadError (FutureLedgerViewError era) m) =>
+    (UsesValue era, MonadError (FutureLedgerViewError era) m) =>
     Globals ->
     NewEpochState era ->
     SlotNo ->
@@ -217,7 +219,7 @@ deriving stock instance
 --   appropriate to that slot.
 futureView ::
   forall era m.
-  ( ShelleyBased era,
+  ( UsesValue era,
     MonadError (FutureLedgerViewError era) m
   ) =>
   Globals ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -19,10 +19,10 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -65,7 +65,7 @@ class
     SlotNo ->
     NewEpochState era
   default applyTick ::
-    ShelleyBased era =>
+    (UsesValue era) =>
     Globals ->
     NewEpochState era ->
     SlotNo ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -21,9 +21,9 @@ module Shelley.Spec.Ledger.API.Wallet
 where
 
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (EpochSize, SlotNo)
 import Control.Monad.Trans.Reader (runReader)
@@ -85,7 +85,7 @@ import Shelley.Spec.Ledger.UTxO (UTxO (..))
 -- This is not based on any snapshot, but uses the current ledger state.
 poolsByTotalStakeFraction ::
   forall era.
-  ShelleyBased era =>
+  UsesValue era =>
   Globals ->
   NewEpochState era ->
   PoolDistr (Crypto era)
@@ -116,7 +116,7 @@ getTotalStake globals ss =
 --
 -- This is not based on any snapshot, but uses the current ledger state.
 getNonMyopicMemberRewards ::
-  ShelleyBased era =>
+  UsesValue era =>
   Globals ->
   NewEpochState era ->
   Set (Either Coin (Credential 'Staking (Crypto era))) ->
@@ -176,7 +176,7 @@ getNonMyopicMemberRewards globals ss creds =
 -- When ranking pools, and reporting their saturation level, in the wallet, we
 -- do not want to use one of the regular snapshots, but rather the most recent
 -- ledger state.
-currentSnapshot :: ShelleyBased era => NewEpochState era -> EB.SnapShot (Crypto era)
+currentSnapshot :: UsesValue era => NewEpochState era -> EB.SnapShot (Crypto era)
 currentSnapshot ss =
   stakeDistr utxo dstate pstate
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -78,10 +79,10 @@ import qualified Cardano.Crypto.Hash.Class as Hash
 import qualified Cardano.Crypto.KES as KES
 import Cardano.Crypto.Util (SignableRepresentation (..))
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.Constraints (UsesAuxiliary, UsesScript, UsesTxBody)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased, TxBodyConstraints)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
@@ -91,14 +92,16 @@ import qualified Data.ByteString.Builder.Extra as BS
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
+import Data.Constraint (Constraint)
+import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Proxy (Proxy (..))
 import Data.Ratio ((%))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
+import Data.Typeable
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
@@ -145,8 +148,10 @@ import Shelley.Spec.Ledger.Serialization
     runByteBuilder,
   )
 import Shelley.Spec.Ledger.Slot (BlockNo (..), SlotNo (..))
-import Shelley.Spec.Ledger.Tx (Tx (..), ValidateScript, decodeWits, segwitTx, txWitsBytes)
+import Shelley.Spec.Ledger.Tx (TransTx, Tx (..), ValidateScript, decodeWits, segwitTx, txWitsBytes)
 import Shelley.Spec.NonIntegral (CompareResult (..), taylorExpCmp)
+
+-- =======================================================
 
 -- | The hash of a Block Header
 newtype HashHeader crypto = HashHeader {unHashHeader :: (Hash crypto (BHeader crypto))}
@@ -165,6 +170,12 @@ data TxSeq era = TxSeq'
   }
   deriving (Generic)
 
+type TransTxSeq (c :: Type -> Constraint) era =
+  ( c (Core.Script era),
+    c (Core.TxBody era),
+    c (Core.AuxiliaryData era)
+  )
+
 deriving via
   AllowThunksIn
     '[ "txSeqBodyBytes",
@@ -173,18 +184,18 @@ deriving via
      ]
     (TxSeq era)
   instance
-    ShelleyBased era => NoThunks (TxSeq era)
+    TransTx NoThunks era => NoThunks (TxSeq era)
 
 deriving stock instance
-  ShelleyBased era =>
+  (Era era, TransTxSeq Show era) =>
   Show (TxSeq era)
 
 deriving stock instance
-  ShelleyBased era =>
+  (Era era, TransTxSeq Eq era) =>
   Eq (TxSeq era)
 
 pattern TxSeq ::
-  (Era era, TxBodyConstraints era, ToCBOR (Core.AuxiliaryData era)) =>
+  (UsesTxBody era, UsesAuxiliary era, UsesScript era) =>
   StrictSeq (Tx era) ->
   TxSeq era
 pattern TxSeq xs <-
@@ -523,16 +534,18 @@ data Block era
   = Block' !(BHeader (Crypto era)) !(TxSeq era) BSL.ByteString
   deriving (Generic)
 
+type TransBlock c era = TransTxSeq c era
+
 deriving stock instance
-  ShelleyBased era =>
+  (Era era, TransBlock Show era) =>
   Show (Block era)
 
 deriving stock instance
-  ShelleyBased era =>
+  (Era era, TransBlock Eq era) =>
   Eq (Block era)
 
 deriving anyclass instance
-  ShelleyBased era =>
+  (Era era, TransBlock NoThunks era) =>
   NoThunks (Block era)
 
 pattern Block :: Era era => BHeader (Crypto era) -> TxSeq era -> Block era
@@ -554,13 +567,23 @@ constructMetadata :: Int -> Map Int a -> Seq (Maybe a)
 constructMetadata n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n -1])
 
 instance
-  Era era =>
+  (Era era, TransBlock ToCBOR era) =>
   ToCBOR (Block era)
   where
   toCBOR (Block' _ _ blockBytes) = encodePreEncoded $ BSL.toStrict blockBytes
 
+type BlockAnn era =
+  ( FromCBOR (Annotator (Core.Script era)),
+    FromCBOR (Annotator (Core.TxBody era)),
+    FromCBOR (Annotator (Core.AuxiliaryData era))
+  )
+
 blockDecoder ::
-  (ShelleyBased era, ValidateScript era) =>
+  ( ToCBOR (Core.TxBody era),
+    ToCBOR (Core.AuxiliaryData era),
+    BlockAnn era,
+    ValidateScript era
+  ) =>
   Bool ->
   forall s. Decoder s (Annotator (Block era))
 blockDecoder lax = annotatorSlice $
@@ -570,7 +593,11 @@ blockDecoder lax = annotatorSlice $
     pure $ Block' <$> header <*> txns
 
 txSeqDecoder ::
-  (ShelleyBased era, ValidateScript era) =>
+  ( ToCBOR (Core.TxBody era),
+    ToCBOR (Core.AuxiliaryData era),
+    BlockAnn era,
+    ValidateScript era
+  ) =>
   Bool ->
   forall s. Decoder s (Annotator (TxSeq era))
 txSeqDecoder lax = do
@@ -607,21 +634,31 @@ txSeqDecoder lax = do
   pure $ TxSeq' <$> txns <*> bodiesAnn <*> witsAnn <*> metadataAnn
 
 instance
-  (ShelleyBased era, ValidateScript era) =>
+  ( BlockAnn era,
+    ToCBOR (Core.TxBody era),
+    ToCBOR (Core.AuxiliaryData era),
+    ValidateScript era
+  ) =>
   FromCBOR (Annotator (Block era))
   where
   fromCBOR = blockDecoder False
 
-newtype LaxBlock era
-  = LaxBlock (Block era)
-  deriving (ToCBOR) via (Block era)
+newtype LaxBlock era = LaxBlock (Block era)
+
+instance (Era era, TransBlock ToCBOR era, Typeable era) => ToCBOR (LaxBlock era) where
+  toCBOR (LaxBlock x) = toCBOR x
 
 deriving stock instance
-  ShelleyBased era =>
+  (Era era, TransBlock Show era) =>
   Show (LaxBlock era)
 
 instance
-  (ShelleyBased era, ValidateScript era) =>
+  ( Era era,
+    BlockAnn era,
+    ToCBOR (Core.TxBody era),
+    ToCBOR (Core.AuxiliaryData era),
+    ValidateScript era
+  ) =>
   FromCBOR (Annotator (LaxBlock era))
   where
   fromCBOR = fmap LaxBlock <$> blockDecoder True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -33,9 +33,9 @@ module Shelley.Spec.Ledger.EpochBoundary
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
+import Cardano.Ledger.Constraints (UsesValue)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<×>))
 import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq (NFData)
@@ -102,7 +102,7 @@ deriving newtype instance
 -- | Sum up all the Coin for each staking Credential
 aggregateUtxoCoinByCredential ::
   forall era.
-  ShelleyBased era =>
+  UsesValue era =>
   Map Ptr (Credential 'Staking (Crypto era)) ->
   UTxO era ->
   Map (Credential 'Staking (Crypto era)) Coin ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -30,10 +30,10 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.KES.Class (totalPeriodsKES)
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Crypto (HASH, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (forceElemsToWHNF)
 import Cardano.Slotting.EpochInfo
@@ -287,7 +287,7 @@ instance Era era => FromCBOR (ShelleyGenesis era) where
 -------------------------------------------------------------------------------}
 
 genesisUTxO ::
-  ShelleyBased era =>
+  (Era era, UsesValue era) =>
   ShelleyGenesis era ->
   UTxO era
 genesisUTxO genesis =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -18,7 +18,8 @@ module Shelley.Spec.Ledger.STS.Epoch
   )
 where
 
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
+import Cardano.Ledger.Constraints (UsesValue)
+import Cardano.Ledger.Era
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition (Embed (..), InitialRule, STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
@@ -53,6 +54,8 @@ import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapState (..))
 import Shelley.Spec.Ledger.STS.Snap (SNAP)
 import Shelley.Spec.Ledger.Slot (EpochNo)
 
+-- ================================================
+
 data EPOCH era
 
 data EpochPredicateFailure era
@@ -69,7 +72,7 @@ deriving stock instance
   (Show (PredicateFailure (SNAP era))) =>
   Show (EpochPredicateFailure era)
 
-instance ShelleyBased era => STS (EPOCH era) where
+instance UsesValue era => STS (EPOCH era) where
   type State (EPOCH era) = EpochState era
   type Signal (EPOCH era) = EpochNo
   type Environment (EPOCH era) = ()
@@ -118,7 +121,7 @@ votedValue (ProposedPPUpdates pup) pps quorumN =
 
 epochTransition ::
   forall era.
-  ShelleyBased era =>
+  UsesValue era =>
   TransitionRule (EPOCH era)
 epochTransition = do
   TRC
@@ -165,11 +168,11 @@ epochTransition = do
       pp'
       nm
 
-instance ShelleyBased era => Embed (SNAP era) (EPOCH era) where
+instance UsesValue era => Embed (SNAP era) (EPOCH era) where
   wrapFailed = SnapFailure
 
-instance ShelleyBased era => Embed (POOLREAP era) (EPOCH era) where
+instance Era era => Embed (POOLREAP era) (EPOCH era) where
   wrapFailed = PoolReapFailure
 
-instance ShelleyBased era => Embed (NEWPP era) (EPOCH era) where
+instance Era era => Embed (NEWPP era) (EPOCH era) where
   wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -28,9 +28,9 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
+import Cardano.Ledger.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.State.Transition
   ( Assertion (..),
     AssertionViolation (..),
@@ -88,28 +88,28 @@ data LedgerPredicateFailure era
 deriving stock instance
   ( Show (PredicateFailure (DELEGS era)),
     Show (PredicateFailure (UTXOW era)),
-    ShelleyBased era
+    Era era
   ) =>
   Show (LedgerPredicateFailure era)
 
 deriving stock instance
   ( Eq (PredicateFailure (DELEGS era)),
     Eq (PredicateFailure (UTXOW era)),
-    ShelleyBased era
+    Era era
   ) =>
   Eq (LedgerPredicateFailure era)
 
 instance
   ( NoThunks (PredicateFailure (DELEGS era)),
     NoThunks (PredicateFailure (UTXOW era)),
-    ShelleyBased era
+    Era era
   ) =>
   NoThunks (LedgerPredicateFailure era)
 
 instance
   ( ToCBOR (PredicateFailure (DELEGS era)),
     ToCBOR (PredicateFailure (UTXOW era)),
-    ShelleyBased era
+    Era era
   ) =>
   ToCBOR (LedgerPredicateFailure era)
   where
@@ -120,7 +120,7 @@ instance
 instance
   ( FromCBOR (PredicateFailure (DELEGS era)),
     FromCBOR (PredicateFailure (UTXOW era)),
-    ShelleyBased era
+    Era era
   ) =>
   FromCBOR (LedgerPredicateFailure era)
   where
@@ -137,9 +137,12 @@ instance
       )
 
 instance
-  ( Era era,
+  ( UsesValue era,
+    UsesScript era,
+    UsesTxBody era,
+    UsesAuxiliary era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
-    ShelleyBased era,
+    Era era,
     Embed (DELEGS era) (LEDGER era),
     Embed (UTXOW era) (LEDGER era),
     Environment (UTXOW era) ~ UtxoEnv era,
@@ -182,7 +185,9 @@ instance
 
 ledgerTransition ::
   forall era.
-  ( ShelleyBased era,
+  ( UsesScript era,
+    UsesTxBody era,
+    UsesAuxiliary era,
     Embed (DELEGS era) (LEDGER era),
     Embed (UTXOW era) (LEDGER era),
     Environment (UTXOW era) ~ UtxoEnv era,
@@ -216,7 +221,7 @@ ledgerTransition = do
   pure (utxoSt', dpstate')
 
 instance
-  ( ShelleyBased era,
+  ( Era era,
     STS (DELEGS era)
   ) =>
   Embed (DELEGS era) (LEDGER era)
@@ -224,7 +229,7 @@ instance
   wrapFailed = DelegsFailure
 
 instance
-  ( ShelleyBased era,
+  ( Era era,
     STS (UTXOW era),
     BaseM (UTXOW era) ~ ShelleyBase
   ) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -19,8 +19,8 @@ module Shelley.Spec.Ledger.STS.NewEpoch
   )
 where
 
-import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
+import Cardano.Ledger.Constraints (UsesValue)
+import Cardano.Ledger.Era (Crypto, Era)
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition
 import Data.Foldable (fold)
@@ -55,7 +55,7 @@ deriving stock instance
 
 instance NoThunks (NewEpochPredicateFailure era)
 
-instance ShelleyBased era => STS (NEWEPOCH era) where
+instance UsesValue era => STS (NEWEPOCH era) where
   type State (NEWEPOCH era) = NewEpochState era
 
   type Signal (NEWEPOCH era) = EpochNo
@@ -80,7 +80,7 @@ instance ShelleyBased era => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ( ShelleyBased era
+  ( UsesValue era
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
@@ -127,13 +127,13 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-  ShelleyBased era =>
+  UsesValue era =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure
 
 instance
-  ShelleyBased era =>
+  Era era =>
   Embed (MIR era) (NEWEPOCH era)
   where
   wrapFailed = MirFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -16,8 +16,8 @@ module Shelley.Spec.Ledger.STS.PoolReap
   )
 where
 
+import Cardano.Ledger.Constraints (TransValue)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Control.SetAlgebra (dom, eval, setSingleton, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Control.State.Transition
@@ -49,6 +49,8 @@ import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..))
 import Shelley.Spec.Ledger.TxBody (getRwdCred, _poolRAcnt)
 
+-- =================================================================
+
 data POOLREAP era
 
 data PoolreapState era = PoolreapState
@@ -59,7 +61,7 @@ data PoolreapState era = PoolreapState
   }
 
 deriving stock instance
-  ShelleyBased era =>
+  (TransValue Show era) =>
   Show (PoolreapState era)
 
 data PoolreapPredicateFailure era -- No predicate Falures

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -13,8 +13,8 @@ module Shelley.Spec.Ledger.STS.Snap
   )
 where
 
+import Cardano.Ledger.Constraints (UsesValue)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.State.Transition
   ( STS (..),
     TRC (..),
@@ -39,7 +39,7 @@ data SnapPredicateFailure era -- No predicate failures
 
 instance NoThunks (SnapPredicateFailure era)
 
-instance ShelleyBased era => STS (SNAP era) where
+instance (UsesValue era) => STS (SNAP era) where
   type State (SNAP era) = SnapShots (Crypto era)
   type Signal (SNAP era) = ()
   type Environment (SNAP era) = LedgerState era
@@ -49,7 +49,7 @@ instance ShelleyBased era => STS (SNAP era) where
   transitionRules = [snapTransition]
 
 snapTransition ::
-  ShelleyBased era =>
+  (UsesValue era) =>
   TransitionRule (SNAP era)
 snapTransition = do
   TRC (lstate, s, _) <- judgmentContext

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -22,7 +22,8 @@ module Shelley.Spec.Ledger.STS.Tick
   )
 where
 
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
+import Cardano.Ledger.Constraints (UsesValue)
+import Cardano.Ledger.Era (Era)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
@@ -43,6 +44,8 @@ import Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
 import Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..))
 import Shelley.Spec.Ledger.Slot (SlotNo, epochInfoEpoch)
 
+-- ==================================================
+
 data TICK era
 
 data TickPredicateFailure era
@@ -57,7 +60,7 @@ deriving stock instance Eq (TickPredicateFailure era)
 instance NoThunks (TickPredicateFailure era)
 
 instance
-  ( ShelleyBased era
+  ( UsesValue era
   ) =>
   STS (TICK era)
   where
@@ -127,7 +130,7 @@ validatingTickTransition nes slot = do
 
 bheadTransition ::
   forall era.
-  ( ShelleyBased era
+  ( UsesValue era
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do
@@ -142,13 +145,13 @@ bheadTransition = do
   pure nes''
 
 instance
-  ShelleyBased era =>
+  UsesValue era =>
   Embed (NEWEPOCH era) (TICK era)
   where
   wrapFailed = NewEpochFailure
 
 instance
-  (ShelleyBased era) =>
+  (Era era) =>
   Embed (RUPD era) (TICK era)
   where
   wrapFailed = RupdFailure
@@ -169,7 +172,7 @@ data TickfPredicateFailure era
 instance NoThunks (TickfPredicateFailure era)
 
 instance
-  ShelleyBased era =>
+  UsesValue era =>
   STS (TICKF era)
   where
   type
@@ -190,7 +193,7 @@ instance
     ]
 
 instance
-  ShelleyBased era =>
+  UsesValue era =>
   Embed (NEWEPOCH era) (TICKF era)
   where
   wrapFailed = TickfNewEpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -32,11 +32,11 @@ import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash,
     ValidateAuxiliaryData (..),
   )
+import Cardano.Ledger.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -114,6 +114,8 @@ import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody, TxIn, Wdrl)
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import qualified Shelley.Spec.Ledger.UTxO as UTxO
 
+-- =================================================
+
 data UTXOW era
 
 data UtxowPredicateFailure era
@@ -141,19 +143,19 @@ data UtxowPredicateFailure era
 
 instance
   ( NoThunks (PredicateFailure (UTXO era)),
-    ShelleyBased era
+    Era era
   ) =>
   NoThunks (UtxowPredicateFailure era)
 
 deriving stock instance
   ( Eq (PredicateFailure (UTXO era)),
-    ShelleyBased era
+    Era era
   ) =>
   Eq (UtxowPredicateFailure era)
 
 deriving stock instance
   ( Show (PredicateFailure (UTXO era)),
-    ShelleyBased era
+    Era era
   ) =>
   Show (UtxowPredicateFailure era)
 
@@ -261,7 +263,10 @@ initialLedgerStateUTXOW = do
 
 utxoWitnessed ::
   forall era.
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesAuxiliary era,
+    UsesScript era,
+    UsesValue era,
     ValidateScript era,
     ValidateAuxiliaryData era,
     STS (UTXOW era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -45,10 +45,12 @@ import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest)
+import Cardano.Ledger.Constraints (UsesValue)
+-- ===============================================================
 
 -- | Generate a genesis chain state given a UTxO size
 genChainState ::
-  EraGen era =>
+  (EraGen era, UsesValue era) =>
   Int ->
   GenEnv era ->
   IO (ChainState era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -19,7 +19,6 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.SetAlgebra (dom, eval)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
@@ -66,6 +65,10 @@ import Test.Shelley.Spec.Ledger.Utils
     slotFromEpoch,
     testGlobals,
   )
+import Cardano.Ledger.Constraints(UsesTxBody,UsesValue,UsesScript,UsesAuxiliary)
+
+-- ======================================================
+
 
 -- | Type alias for a transaction generator
 type TxGen era =
@@ -79,6 +82,9 @@ type TxGen era =
 genBlock ::
   forall era.
   ( EraGen era,
+    UsesTxBody era,
+    UsesValue era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     ApplyBlock era,
     GetLedgerView era,
@@ -99,7 +105,9 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
 genBlockWithTxGen ::
   forall era.
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     GetLedgerView era,
     ApplyBlock era
@@ -167,8 +175,7 @@ genBlockWithTxGen
 
 selectNextSlotWithLeader ::
   forall era.
-  ( ShelleyBased era,
-    Mock (Crypto era),
+  ( Mock (Crypto era),
     GetLedgerView era,
     ApplyBlock era
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -17,7 +17,6 @@ import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (HASH)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Slotting.Slot (SlotNo)
 import Data.Coerce (coerce)
 import Data.Sequence.Strict (StrictSeq)
@@ -48,15 +47,16 @@ import Test.Shelley.Spec.Ledger.Generator.Presets (someKeyPairs)
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass (ScriptClass, someScripts)
 import Test.Shelley.Spec.Ledger.Utils (Split (..))
 
+import Cardano.Ledger.Constraints(UsesValue,UsesScript)
+
 {------------------------------------------------------------------------------
  An EraGen instance makes it possible to run the Shelley property tests
  -----------------------------------------------------------------------------}
 
 class
-  ( ShelleyBased era,
+  ( UsesScript era,
     ValidateScript era,
     Split (Core.Value era),
-    Show (Core.Script era),
     ScriptClass era
   ) =>
   EraGen era
@@ -94,7 +94,7 @@ class
 
 genUtxo0 ::
   forall era.
-  EraGen era =>
+  (EraGen era, UsesValue era) =>
   GenEnv era ->
   Gen (UTxO era)
 genUtxo0 ge@(GenEnv _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -70,11 +70,17 @@ import Test.Shelley.Spec.Ledger.Utils
     maxLLSupply,
     mkHash,
   )
+import Cardano.Ledger.Constraints(UsesTxBody,UsesValue,UsesAuxiliary)
+
+-- ======================================================
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
   ( EraGen era,
+    UsesTxBody era,
+    UsesValue era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     ApplyBlock era,
     GetLedgerView era,
@@ -108,7 +114,9 @@ lastByronHeaderHash _ = HashHeader $ mkHash 0
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisChainState ::
   forall era a.
-  EraGen era =>
+  ( EraGen era,
+    UsesValue era
+  ) =>
   GenEnv era ->
   IRC (CHAIN era) ->
   Gen (Either a (ChainState era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -57,6 +57,10 @@ import Test.Shelley.Spec.Ledger.Utils
     applySTSTest,
     runShelleyBase,
   )
+import Cardano.Ledger.Constraints(UsesTxBody,UsesValue,UsesAuxiliary)
+
+-- ======================================================
+
 
 genAccountState :: Constants -> Gen AccountState
 genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves}) =
@@ -68,6 +72,9 @@ genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves})
 -- with meaningful delegation certificates.
 instance
   ( EraGen era,
+    UsesTxBody era,
+    UsesValue era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
@@ -92,6 +99,9 @@ instance
 instance
   forall era.
   ( EraGen era,
+    UsesTxBody era,
+    UsesValue era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
@@ -149,7 +159,9 @@ instance
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisLedgerState ::
   forall a era.
-  EraGen era =>
+  ( UsesValue era,
+    EraGen era
+  ) =>
   GenEnv era ->
   IRC (LEDGER era) ->
   Gen (Either a (UTxOState era, DPState (Crypto era)))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -46,7 +46,6 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Slotting.Block (BlockNo (..))
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import Control.SetAlgebra (biMapFromList)
@@ -134,6 +133,10 @@ import Test.Shelley.Spec.Ledger.Serialisation.Generators.Bootstrap
     genSignature,
   )
 import Test.Tasty.QuickCheck (Gen, choose, elements)
+
+import Cardano.Ledger.Constraints(UsesValue,UsesScript,UsesTxBody,UsesAuxiliary)
+import Test.Shelley.Spec.Ledger.Generator.ScriptClass(ScriptClass)
+-- =======================================================
 
 genHash :: forall a h. HashAlgorithm h => Gen (Hash.Hash h a)
 genHash = mkDummyHash <$> arbitrary
@@ -264,7 +267,7 @@ instance CC.Crypto crypto => Arbitrary (TxIn crypto) where
       <*> arbitrary
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
   Arbitrary (TxOut era)
   where
   arbitrary = TxOut <$> arbitrary <*> arbitrary
@@ -367,7 +370,7 @@ instance CC.Crypto crypto => Arbitrary (STS.PrtclState crypto) where
   shrink = genericShrink
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
   Arbitrary (UTxO era)
   where
   arbitrary = genericArbitraryU
@@ -436,21 +439,21 @@ instance CC.Crypto crypto => Arbitrary (DPState crypto) where
   shrink = genericShrink
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
   Arbitrary (UTxOState era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
   Arbitrary (LedgerState era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
   Arbitrary (NewEpochState era)
   where
   arbitrary = genericArbitraryU
@@ -467,7 +470,7 @@ instance CC.Crypto crypto => Arbitrary (PoolDistr crypto) where
       genVal = IndividualPoolStake <$> arbitrary <*> genHash
 
 instance
-  (ShelleyBased era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
+  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
   Arbitrary (EpochState era)
   where
   arbitrary =
@@ -604,7 +607,7 @@ genUTCTime = do
       (Time.picosecondsToDiffTime diff)
 
 instance
-  (ShelleyBased era, Mock (Crypto era), EraGen era) =>
+  (Mock (Crypto era), EraGen era) =>
   Arbitrary (ShelleyGenesis era)
   where
   arbitrary =
@@ -626,7 +629,7 @@ instance
       <*> (ShelleyGenesisStaking <$> arbitrary <*> arbitrary) -- sgStaking
 
 instance
-  ( ShelleyBased era,
+  ( UsesScript era,
     Mock (Crypto era),
     ValidateScript era,
     Arbitrary (Core.Script era)
@@ -699,7 +702,9 @@ instance
   shrink _ = []
 
 genTx ::
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era,
     Arbitrary (WitnessSet era),
     Arbitrary (Core.TxBody era),
     Arbitrary (Core.AuxiliaryData era)
@@ -713,8 +718,10 @@ genTx =
 
 genBlock ::
   forall era.
-  ( ShelleyBased era,
-    EraGen era,
+  ( UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era,
+    ScriptClass era,
     Mock (Crypto era),
     Arbitrary (WitnessSet era),
     Arbitrary (Core.TxBody era),
@@ -748,7 +755,9 @@ genBlock = do
     p = Proxy
 
 instance
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era,
     Mock (Crypto era),
     ValidateScript era,
     Arbitrary (Core.TxBody era),
@@ -761,7 +770,8 @@ instance
   arbitrary = genTx
 
 instance
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesAuxiliary era,
     EraGen era,
     Mock (Crypto era),
     ValidateScript era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -124,7 +124,6 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain (BHBody (..), Block, bhbody, bheader)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashIndex)
 import Shelley.Spec.Ledger.Keys
   ( KeyPair,
     KeyRole (..),
@@ -146,13 +145,16 @@ import Test.Tasty.HUnit
   ( Assertion,
     (@?=),
   )
+import Cardano.Ledger.Constraints
 
 type ShelleyTest era =
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesValue era,
+    UsesScript era,
+    UsesAuxiliary era,
     TxBody era ~ Core.TxBody era,
     Core.Script era ~ MultiSig (Crypto era),
-    Split (Core.Value era),
-    HashIndex (Core.TxBody era) ~ EraIndependentTxBody
+    Split (Core.Value era)
   )
 
 type ChainProperty era =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -45,7 +45,6 @@ where
 
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Cardano.Slotting.Slot (EpochNo, WithOrigin (..))
 import Control.SetAlgebra (eval, setSingleton, singleton, (∪), (⋪), (⋫))
@@ -102,6 +101,10 @@ import Shelley.Spec.Ledger.Tx (TxIn, TxOut)
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
+import Cardano.Ledger.Constraints(UsesTxBody,UsesValue)
+
+-- ======================================================
+
 
 -- | = Evolve Nonces - Frozen
 --
@@ -174,7 +177,8 @@ feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
 -- Update the UTxO for given transaction body.
 newUTxO ::
   forall era.
-  ( ShelleyBased era,
+  ( UsesTxBody era,
+    UsesValue era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -9,10 +9,7 @@ module Test.Shelley.Spec.Ledger.Examples.EmptyBlock
   )
 where
 
-import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Era (Crypto (..))
-import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import qualified Data.Map.Strict as Map
 import GHC.Stack (HasCallStack)
 import Shelley.Spec.Ledger.BaseTypes (Nonce)
@@ -44,6 +41,8 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     zero,
   )
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, getBlockNonce)
+import Cardano.Ledger.Constraints(UsesTxBody,UsesScript,UsesAuxiliary)
+-- =============================================================
 
 initStEx1 :: forall era. ShelleyTest era => ChainState era
 initStEx1 = initSt (UTxO Map.empty)
@@ -52,8 +51,9 @@ blockEx1 ::
   forall era.
   ( HasCallStack,
     ExMock (Crypto era),
-    TxBodyConstraints era,
-    ToCBOR (Core.AuxiliaryData era)
+    UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era
   ) =>
   Block era
 blockEx1 =
@@ -74,8 +74,9 @@ blockNonce ::
   forall era.
   ( HasCallStack,
     ExMock (Crypto era),
-    TxBodyConstraints era,
-    ToCBOR (Core.AuxiliaryData era)
+    UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era
   ) =>
   Nonce
 blockNonce = getBlockNonce (blockEx1 @era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -79,6 +79,7 @@ import Test.Shelley.Spec.Ledger.Utils (getBlockNonce, testGlobals)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
+
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 
@@ -145,7 +146,7 @@ blockEx1 =
 
 expectedStEx1 ::
   forall c.
-  (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) =>
+  (ExMock (Crypto (ShelleyEra c))) =>
   ChainState (ShelleyEra c)
 expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @c))
@@ -227,7 +228,7 @@ blockEx2 slot =
 blockEx2A :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (ShelleyEra c)
 blockEx2A = blockEx2 20
 
-expectedStEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
+expectedStEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx2 =
   C.feesAndDeposits feeTx2 (Coin 0)
     . C.newUTxO txbodyEx2

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
@@ -262,7 +262,7 @@ blockEx2 =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 20) 0 (KESPeriod 0))
 
-expectedStEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
+expectedStEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx2 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx2 @c))
     . C.newLab blockEx2
@@ -351,7 +351,7 @@ blockEx3 =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 80) 0 (KESPeriod 0))
 
-expectedStEx3 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
+expectedStEx3 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx3 =
   C.evolveNonceFrozen (getBlockNonce (blockEx3 @c))
     . C.newLab blockEx3

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -54,11 +54,13 @@ import Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation)
 import Test.Shelley.Spec.Ledger.Utils (ChainProperty)
 import Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as TQC
+import Cardano.Ledger.Constraints(UsesValue)
 
 minimalPropertyTests ::
   forall era.
   ( EraGen era,
     ChainProperty era,
+    UsesValue era,
     ValidateAuxiliaryData era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
@@ -89,6 +91,7 @@ minimalPropertyTests =
 propertyTests ::
   forall era.
   ( EraGen era,
+    UsesValue era,
     ChainProperty era,
     ValidateAuxiliaryData era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -26,11 +26,9 @@ import qualified Cardano.Crypto.Hash as Monomorphic
 import Cardano.Crypto.KES (SignedKES)
 import Cardano.Crypto.VRF (CertifiedVRF)
 import Cardano.Ledger.AuxiliaryData (hashAuxiliaryData)
-import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (TxBodyConstraints)
 import Cardano.Prelude (LByteString)
 import Codec.CBOR.Encoding (Encoding (..), Tokens (..))
 import Data.ByteString (ByteString)
@@ -196,6 +194,9 @@ import Test.Shelley.Spec.Ledger.Serialisation.GoldenUtils
   )
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
+import Cardano.Ledger.Constraints(UsesTxBody,UsesScript,UsesAuxiliary)
+
+-- ============================================
 
 type MultiSigMap = Map.Map (ScriptHash C_Crypto) (MultiSig C_Crypto)
 
@@ -357,8 +358,9 @@ testHeaderHash =
 testBHB ::
   forall era crypto.
   ( Era era,
-    TxBodyConstraints era,
-    ToCBOR (Core.AuxiliaryData era),
+    UsesTxBody era,
+    UsesScript era,
+    UsesAuxiliary era,
     ExMock crypto,
     crypto ~ Crypto era
   ) =>
@@ -402,8 +404,9 @@ testBHBSigTokens ::
   forall era.
   ( Era era,
     ExMock (Crypto era),
-    ToCBOR (Core.AuxiliaryData era),
-    TxBodyConstraints era
+    UsesTxBody era,
+    UsesAuxiliary era,
+    UsesScript era
   ) =>
   Tokens ->
   Tokens


### PR DESCRIPTION
The idea is to put some structure on the constraints we use. This PR organizes new constraints in two dimensions.

1) For some types declare a higher order constraint that applies its argument constraint (c) to every type family embedded inside a data type declaration. For example for the datatype TxOut we have
```
type TransTxOut (c :: Type -> Constraint) era =
  ( c (Core.Value era),
    c (CompactForm (Core.Value era)),
    Compactible (Core.Value era) )

```
2) Add a minimal constraint (UsesXXX for each family XXX) for each type family.
```
type UsesScript era =
  ( Era era,
    Eq (Core.Script era),
    Show (Core.Script era),
    ToCBOR (Core.Script era),
    FromCBOR (Annotator (Core.Script era))
  )
```

Then reorganized the whole repo to uses these new constraints.