### PR TITLE
make TxOut a type family

### DIFF
--- a/alonzo/impl/.ghcid
+++ b/alonzo/impl/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../shell.nix --run \"cabal repl -f development cardano-ledger-alonzo\"" -o ghcid.txt

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -8,7 +8,13 @@ module Cardano.Ledger.Mary where
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
-import Shelley.Spec.Ledger.API (ApplyBlock, ApplyTx, GetLedgerView, PraosCrypto, ShelleyBasedEra)
+import Shelley.Spec.Ledger.API
+  ( ApplyBlock,
+    ApplyTx,
+    GetLedgerView,
+    PraosCrypto,
+    ShelleyBasedEra,
+  )
 
 type MaryEra = ShelleyMAEra 'Mary
 

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value)
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData, pattern AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),
@@ -33,7 +33,8 @@ import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import Shelley.Spec.Ledger.Tx
-  ( ValidateScript (..),
+  ( TxOut (..),
+    ValidateScript (..),
   )
 
 -- | The Shelley Mary/Allegra eras
@@ -62,11 +63,21 @@ instance CryptoClass.Crypto c => UsesValue (ShelleyMAEra 'Mary c)
 
 instance CryptoClass.Crypto c => UsesValue (ShelleyMAEra 'Allegra c)
 
+instance CryptoClass.Crypto c => UsesTxOut (ShelleyMAEra 'Mary c) where
+  makeTxOut _ a v = TxOut a v
+
+instance CryptoClass.Crypto c => UsesTxOut (ShelleyMAEra 'Allegra c) where
+  makeTxOut _ a v = TxOut a v
+
 --------------------------------------------------------------------------------
 -- Core instances
 --------------------------------------------------------------------------------
 
 type instance Core.Value (ShelleyMAEra m c) = MAValue m c
+
+type instance
+  Core.TxOut (ShelleyMAEra (ma :: MaryOrAllegra) c) =
+    TxOut (ShelleyMAEra ma c)
 
 type instance
   Core.TxBody (ShelleyMAEra (ma :: MaryOrAllegra) c) =

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -16,14 +16,20 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Mary.Value (PolicyID, Value, policies, policyID)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesScript,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue,
+  )
 import Cardano.Ledger.ShelleyMA (MaryOrAllegra, ShelleyMAEra)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.TxBody ()
 import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative)
-import Control.SetAlgebra (dom, eval, (◁))
+import Control.SetAlgebra (eval, (◁))
 import Control.State.Transition.Extended
 import Data.Foldable (Foldable (toList))
 import qualified Data.Map.Strict as Map
@@ -52,11 +58,10 @@ import Shelley.Spec.Ledger.TxBody
     EraIndependentTxBody,
     RewardAcnt (getRwdCred),
     TxIn,
-    TxOut (TxOut),
     Wdrl (unWdrl),
   )
 import Shelley.Spec.Ledger.UTxO
-  ( UTxO (UTxO),
+  ( UTxO,
     getScriptHash,
     scriptCred,
     scriptStakeCred,
@@ -83,8 +88,8 @@ instance GetPolicies (Value crypto) crypto where
 -- | Computes the set of script hashes required to unlock the transaction inputs
 -- and the withdrawals.
 scriptsNeeded ::
-  ( UsesValue era,
-    UsesScript era,
+  ( UsesScript era,
+    UsesTxOut era,
     UsesTxBody era,
     UsesAuxiliary era,
     GetPolicies (Core.Value era) (Crypto era),
@@ -97,7 +102,7 @@ scriptsNeeded ::
   Tx era ->
   Set (ScriptHash (Crypto era))
 scriptsNeeded u tx =
-  Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
+  Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . (getField @"address")) u'')
     `Set.union` Set.fromList
       ( Maybe.mapMaybe (scriptCred . getRwdCred) $
           Map.keys withdrawals
@@ -110,9 +115,8 @@ scriptsNeeded u tx =
     `Set.union` ((policyID `Set.map` (getPolicies $ getField @"mint" txb)))
   where
     txb = _body tx
-    unTxOut (TxOut a _) = a
     withdrawals = unWdrl $ getField @"wdrls" txb
-    UTxO u'' = eval (dom (txinsScript (getField @"inputs" txb) u) ◁ u)
+    u'' = eval ((txinsScript (getField @"inputs" $ _body tx) u) ◁ u)
     certificates = (toList . getField @"certs") txb
 
 --------------------------------------------------------------------------------
@@ -122,6 +126,7 @@ scriptsNeeded u tx =
 instance
   forall c (ma :: MaryOrAllegra).
   ( CryptoClass.Crypto c,
+    UsesTxOut (ShelleyMAEra ma c),
     UsesValue (ShelleyMAEra ma c),
     Typeable ma,
     STS (UTXO (ShelleyMAEra ma c)),

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -15,6 +15,7 @@
 -- > import qualified Cardano.Ledger.Core as Core
 module Cardano.Ledger.Core
   ( -- * Era-changing types
+    TxOut,
     TxBody,
     Value,
     Script,
@@ -31,6 +32,9 @@ import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import NoThunks.Class (NoThunks)
+
+-- | A transaction output.
+type family TxOut era :: Type
 
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -20,13 +20,14 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (hashWithSerialiser)
 import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
   ( TxBody,
+    TxOut (..),
     ValidateScript (hashScript, validateScript),
     hashMultiSigScript,
     validateNativeMultiSigScript,
@@ -39,6 +40,9 @@ instance CryptoClass.Crypto c => Era (ShelleyEra c) where
 
 instance CryptoClass.Crypto c => UsesValue (ShelleyEra c)
 
+instance CryptoClass.Crypto c => UsesTxOut (ShelleyEra c) where
+  makeTxOut _ a v = TxOut a v
+
 --------------------------------------------------------------------------------
 -- Core instances
 --------------------------------------------------------------------------------
@@ -46,6 +50,8 @@ instance CryptoClass.Crypto c => UsesValue (ShelleyEra c)
 type instance Core.Value (ShelleyEra _c) = Coin
 
 type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
+
+type instance Core.TxOut (ShelleyEra c) = TxOut (ShelleyEra c)
 
 type instance Core.Script (ShelleyEra c) = MultiSig c
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -6,6 +7,7 @@
 
 module Cardano.Ledger.Shelley.Constraints where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
   ( AnnotatedData,
@@ -14,12 +16,16 @@ import Cardano.Ledger.Core
     Script,
     SerialisableData,
     TxBody,
+    TxOut,
     Value,
   )
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
 import Data.Kind (Constraint, Type)
+import Data.Proxy (Proxy)
+import GHC.Records (HasField)
+import Shelley.Spec.Ledger.Address (Addr)
 import Shelley.Spec.Ledger.Hashing
   ( EraIndependentTxBody,
     HashAnnotated (..),
@@ -52,6 +58,19 @@ class
     Torsor (Value era)
   ) =>
   UsesValue era
+
+class
+  ( Era era,
+    Show (TxOut era),
+    Eq (TxOut era),
+    ToCBOR (TxOut era),
+    FromCBOR (TxOut era),
+    HasField "address" (TxOut era) (Addr (Crypto era)),
+    HasField "value" (TxOut era) (Value era)
+  ) =>
+  UsesTxOut era
+  where
+  makeTxOut :: Proxy era -> Addr (Crypto era) -> Value era -> TxOut era
 
 type UsesScript era =
   ( Era era,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -116,7 +116,7 @@ class
     SlotNo ->
     m (LedgerView (Crypto era))
   default futureLedgerView ::
-    (UsesValue era, MonadError (FutureLedgerViewError era) m) =>
+    (UsesTxOut era, UsesValue era, MonadError (FutureLedgerViewError era) m) =>
     Globals ->
     NewEpochState era ->
     SlotNo ->
@@ -219,7 +219,8 @@ deriving stock instance
 --   appropriate to that slot.
 futureView ::
   forall era m.
-  ( UsesValue era,
+  ( UsesTxOut era,
+    UsesValue era,
     MonadError (FutureLedgerViewError era) m
   ) =>
   Globals ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -22,7 +22,7 @@ where
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -65,7 +65,7 @@ class
     SlotNo ->
     NewEpochState era
   default applyTick ::
-    (UsesValue era) =>
+    (UsesTxOut era, UsesValue era) =>
     Globals ->
     NewEpochState era ->
     SlotNo ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -21,9 +21,10 @@ module Shelley.Spec.Ledger.API.Wallet
 where
 
 import qualified Cardano.Crypto.VRF as VRF
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (EpochSize, SlotNo)
 import Control.Monad.Trans.Reader (runReader)
@@ -37,12 +38,13 @@ import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
+import GHC.Records (HasField, getField)
 import Shelley.Spec.Ledger.API.Protocol (ChainDepState (..))
 import Shelley.Spec.Ledger.Address (Addr (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), Seed)
 import Shelley.Spec.Ledger.BlockChain (checkLeaderValue, mkSeed, seedL)
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.CompactAddr (compactAddr)
+import Shelley.Spec.Ledger.CompactAddr (CompactAddr, compactAddr)
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..), PoolDistr (..))
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
@@ -72,7 +74,7 @@ import Shelley.Spec.Ledger.Rewards
 import Shelley.Spec.Ledger.STS.NewEpoch (calculatePoolDistr)
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
 import Shelley.Spec.Ledger.Slot (epochInfoSize)
-import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxOut (..))
+import Shelley.Spec.Ledger.TxBody (PoolParams (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 -- | Get pool sizes, but in terms of total stake
@@ -85,7 +87,7 @@ import Shelley.Spec.Ledger.UTxO (UTxO (..))
 -- This is not based on any snapshot, but uses the current ledger state.
 poolsByTotalStakeFraction ::
   forall era.
-  UsesValue era =>
+  (UsesTxOut era, UsesValue era) =>
   Globals ->
   NewEpochState era ->
   PoolDistr (Crypto era)
@@ -116,7 +118,7 @@ getTotalStake globals ss =
 --
 -- This is not based on any snapshot, but uses the current ledger state.
 getNonMyopicMemberRewards ::
-  UsesValue era =>
+  (UsesTxOut era, UsesValue era) =>
   Globals ->
   NewEpochState era ->
   Set (Either Coin (Credential 'Staking (Crypto era))) ->
@@ -176,7 +178,8 @@ getNonMyopicMemberRewards globals ss creds =
 -- When ranking pools, and reporting their saturation level, in the wallet, we
 -- do not want to use one of the regular snapshots, but rather the most recent
 -- ledger state.
-currentSnapshot :: UsesValue era => NewEpochState era -> EB.SnapShot (Crypto era)
+currentSnapshot ::
+  (UsesTxOut era, UsesValue era) => NewEpochState era -> EB.SnapShot (Crypto era)
 currentSnapshot ss =
   stakeDistr utxo dstate pstate
   where
@@ -193,11 +196,15 @@ getUTxO = _utxo . _utxoState . esLState . nesEs
 
 -- | Get the UTxO filtered by address.
 getFilteredUTxO ::
+  HasField "compactAddress" (Core.TxOut era) (CompactAddr (Crypto era)) =>
   NewEpochState era ->
   Set (Addr (Crypto era)) ->
   UTxO era
 getFilteredUTxO ss addrs =
-  UTxO $ Map.filter (\(TxOutCompact addrSBS _) -> addrSBS `Set.member` addrSBSs) fullUTxO
+  UTxO $
+    Map.filter
+      (\out -> (getField @"compactAddress" out) `Set.member` addrSBSs)
+      fullUTxO
   where
     UTxO fullUTxO = getUTxO ss
     -- Instead of decompacting each address in the huge UTxO, compact each

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -80,7 +80,7 @@ rationalToCoinViaFloor r = Coin . floor $ r
 -- with an erroring bounds check here. where should this really live?
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin Word64
-    deriving (Eq, Show, NoThunks, Typeable)
+    deriving (Eq, Show, NoThunks, NFData, Typeable)
 
   toCompact (Coin c) = CompactCoin <$> integerToWord64 c
   fromCompact (CompactCoin c) = word64ToCoin c

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -33,7 +33,7 @@ import Cardano.Crypto.KES.Class (totalPeriodsKES)
 import Cardano.Ledger.Crypto (HASH, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut (..), UsesValue)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (forceElemsToWHNF)
 import Cardano.Slotting.EpochInfo
@@ -67,7 +67,7 @@ import Shelley.Spec.Ledger.Serialization
     utcTimeToCBOR,
   )
 import Shelley.Spec.Ledger.StabilityWindow
-import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxId (..), TxIn (..), TxOut (..))
+import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxId (..), TxIn (..))
 import Shelley.Spec.Ledger.UTxO
 
 -- | Genesis Shelley staking configuration.
@@ -287,7 +287,8 @@ instance Era era => FromCBOR (ShelleyGenesis era) where
 -------------------------------------------------------------------------------}
 
 genesisUTxO ::
-  (Era era, UsesValue era) =>
+  forall era.
+  (Era era, UsesValue era, UsesTxOut era) =>
   ShelleyGenesis era ->
   UTxO era
 genesisUTxO genesis =
@@ -296,7 +297,7 @@ genesisUTxO genesis =
       [ (txIn, txOut)
         | (addr, amount) <- Map.toList (sgInitialFunds genesis),
           let txIn = initialFundsPseudoTxIn addr
-              txOut = TxOut addr (Val.inject amount)
+              txOut = makeTxOut (Proxy @era) addr (Val.inject amount)
       ]
 
 -- | Compute the 'TxIn' of the initial UTxO pseudo-transaction corresponding

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -19,7 +19,7 @@ module Shelley.Spec.Ledger.STS.Epoch
 where
 
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition (Embed (..), InitialRule, STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
@@ -72,7 +72,7 @@ deriving stock instance
   (Show (PredicateFailure (SNAP era))) =>
   Show (EpochPredicateFailure era)
 
-instance (Era era, UsesValue era) => STS (EPOCH era) where
+instance (UsesTxOut era, UsesValue era) => STS (EPOCH era) where
   type State (EPOCH era) = EpochState era
   type Signal (EPOCH era) = EpochNo
   type Environment (EPOCH era) = ()
@@ -121,7 +121,8 @@ votedValue (ProposedPPUpdates pup) pps quorumN =
 
 epochTransition ::
   forall era.
-  ( UsesValue era
+  ( UsesTxOut era,
+    UsesValue era
   ) =>
   TransitionRule (EPOCH era)
 epochTransition = do
@@ -169,7 +170,7 @@ epochTransition = do
       pp'
       nm
 
-instance UsesValue era => Embed (SNAP era) (EPOCH era) where
+instance (UsesTxOut era, UsesValue era) => Embed (SNAP era) (EPOCH era) where
   wrapFailed = SnapFailure
 
 instance Era era => Embed (POOLREAP era) (EPOCH era) where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -30,7 +30,13 @@ import Cardano.Binary
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesScript,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue,
+  )
 import Control.State.Transition
   ( Assertion (..),
     AssertionViolation (..),
@@ -68,7 +74,7 @@ import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
 import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx (..))
-import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody)
+import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody, TransTxId)
 
 data LEDGER era
 
@@ -140,7 +146,9 @@ instance
   ( UsesValue era,
     UsesScript era,
     UsesTxBody era,
+    UsesTxOut era,
     UsesAuxiliary era,
+    TransTxId Show era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     Era era,
     Embed (DELEGS era) (LEDGER era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -20,7 +20,7 @@ module Shelley.Spec.Ledger.STS.NewEpoch
 where
 
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition
 import Data.Foldable (fold)
@@ -55,7 +55,7 @@ deriving stock instance
 
 instance NoThunks (NewEpochPredicateFailure era)
 
-instance (Era era, UsesValue era) => STS (NEWEPOCH era) where
+instance (UsesTxOut era, UsesValue era) => STS (NEWEPOCH era) where
   type State (NEWEPOCH era) = NewEpochState era
 
   type Signal (NEWEPOCH era) = EpochNo
@@ -80,7 +80,8 @@ instance (Era era, UsesValue era) => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ( UsesValue era
+  ( UsesTxOut era,
+    UsesValue era
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
@@ -127,7 +128,7 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-  (Era era, UsesValue era) =>
+  (UsesTxOut era, UsesValue era) =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.STS.PoolReap
 where
 
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Control.SetAlgebra (dom, eval, setSingleton, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 import Control.State.Transition
@@ -39,6 +38,7 @@ import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     DState (..),
     PState (..),
+    TransUTxOState,
     UTxOState (..),
     emptyAccount,
     emptyDState,
@@ -61,7 +61,7 @@ data PoolreapState era = PoolreapState
   }
 
 deriving stock instance
-  (TransValue Show era) =>
+  (TransUTxOState Show era) =>
   Show (PoolreapState era)
 
 data PoolreapPredicateFailure era -- No predicate Falures

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -14,7 +14,7 @@ module Shelley.Spec.Ledger.STS.Snap
 where
 
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.State.Transition
   ( STS (..),
     TRC (..),
@@ -39,7 +39,7 @@ data SnapPredicateFailure era -- No predicate failures
 
 instance NoThunks (SnapPredicateFailure era)
 
-instance (UsesValue era) => STS (SNAP era) where
+instance (UsesTxOut era, UsesValue era) => STS (SNAP era) where
   type State (SNAP era) = SnapShots (Crypto era)
   type Signal (SNAP era) = ()
   type Environment (SNAP era) = LedgerState era
@@ -49,7 +49,7 @@ instance (UsesValue era) => STS (SNAP era) where
   transitionRules = [snapTransition]
 
 snapTransition ::
-  (UsesValue era) =>
+  (UsesTxOut era, UsesValue era) =>
   TransitionRule (SNAP era)
 snapTransition = do
   TRC (lstate, s, _) <- judgmentContext

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -23,7 +23,7 @@ module Shelley.Spec.Ledger.STS.Tick
 where
 
 import Cardano.Ledger.Era (Era)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
@@ -60,7 +60,8 @@ deriving stock instance Eq (TickPredicateFailure era)
 instance NoThunks (TickPredicateFailure era)
 
 instance
-  ( UsesValue era
+  ( UsesTxOut era,
+    UsesValue era
   ) =>
   STS (TICK era)
   where
@@ -130,7 +131,8 @@ validatingTickTransition nes slot = do
 
 bheadTransition ::
   forall era.
-  ( UsesValue era
+  ( UsesTxOut era,
+    UsesValue era
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do
@@ -145,7 +147,7 @@ bheadTransition = do
   pure nes''
 
 instance
-  UsesValue era =>
+  (UsesTxOut era, UsesValue era) =>
   Embed (NEWEPOCH era) (TICK era)
   where
   wrapFailed = NewEpochFailure
@@ -172,7 +174,7 @@ data TickfPredicateFailure era
 instance NoThunks (TickfPredicateFailure era)
 
 instance
-  UsesValue era =>
+  (UsesTxOut era, UsesValue era) =>
   STS (TICKF era)
   where
   type
@@ -193,7 +195,7 @@ instance
     ]
 
 instance
-  UsesValue era =>
+  (UsesTxOut era, UsesValue era) =>
   Embed (NEWEPOCH era) (TICKF era)
   where
   wrapFailed = TickfNewEpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -36,7 +36,12 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesScript,
+    UsesTxBody,
+    UsesTxOut,
+  )
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -161,7 +166,8 @@ deriving stock instance
 
 instance
   ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody)
+    DSignable c (Hash c EraIndependentTxBody),
+    UsesTxOut (ShelleyEra c)
   ) =>
   STS (UTXOW (ShelleyEra c))
   where
@@ -266,7 +272,7 @@ utxoWitnessed ::
   ( UsesTxBody era,
     UsesAuxiliary era,
     UsesScript era,
-    UsesValue era,
+    UsesTxOut era,
     ValidateScript era,
     ValidateAuxiliaryData era,
     STS (UTXOW era),
@@ -359,7 +365,7 @@ utxoWitnessed scriptsNeeded =
         TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
 
 instance
-  (CryptoClass.Crypto c) =>
+  (UsesTxOut (ShelleyEra c), CryptoClass.Crypto c) =>
   Embed (UTXO (ShelleyEra c)) (UTXOW (ShelleyEra c))
   where
   wrapFailed = UtxoFailure

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -29,6 +29,7 @@ where
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Prelude (NFData (rnf))
 import Cardano.Slotting.Slot (withOriginToMaybe)
 import Control.Monad.Except ()
@@ -59,6 +60,7 @@ import Shelley.Spec.Ledger.LedgerState
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
+import Shelley.Spec.Ledger.TxBody (TransTxId, TransTxBody)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
@@ -115,7 +117,9 @@ benchValidate (ValidateInput globals state block) =
 
 applyBlock ::
   forall era.
-  ( Era era,
+  ( TransTxId Show era,
+    TransTxBody NFData era,
+    TransValue NFData era,
     API.ApplyBlock era
   ) =>
   ValidateInput era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -12,7 +12,7 @@ where
 
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.State.Transition.Extended
 import Data.Either (fromRight)
 import Data.Proxy
@@ -51,7 +51,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest)
 
 -- | Generate a genesis chain state given a UTxO size
 genChainState ::
-  (EraGen era, UsesValue era) =>
+  (EraGen era, UsesTxOut era, UsesValue era) =>
   Int ->
   GenEnv era ->
   IO (ChainState era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -19,7 +19,13 @@ import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesScript,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue
+  )
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.SetAlgebra (dom, eval)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
@@ -82,6 +88,7 @@ genBlock ::
   forall era.
   ( EraGen era,
     UsesTxBody era,
+    UsesTxOut era,
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
@@ -90,7 +97,7 @@ genBlock ::
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   GenEnv era ->
   ChainState era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (HASH)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesTxOut)
 import Cardano.Slotting.Slot (SlotNo)
 import Data.Coerce (coerce)
 import Data.Sequence.Strict (StrictSeq)
@@ -35,7 +35,7 @@ import Shelley.Spec.Ledger.Tx
   ( TxId (TxId),
     ValidateScript (..),
   )
-import Shelley.Spec.Ledger.TxBody (DCert, TxIn, TxOut, Wdrl)
+import Shelley.Spec.Ledger.TxBody (DCert, TxIn, Wdrl)
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
@@ -68,7 +68,7 @@ class
     GenEnv era ->
     SlotNo ->
     Set (TxIn (Crypto era)) ->
-    StrictSeq (TxOut era) ->
+    StrictSeq (Core.TxOut era) ->
     StrictSeq (DCert (Crypto era)) ->
     Wdrl (Crypto era) ->
     Coin ->
@@ -84,7 +84,7 @@ class
     Core.TxBody era ->
     Coin ->
     Set (TxIn (Crypto era)) ->
-    StrictSeq (TxOut era) ->
+    StrictSeq (Core.TxOut era) ->
     Core.TxBody era
 
 {------------------------------------------------------------------------------
@@ -93,14 +93,14 @@ class
 
 genUtxo0 ::
   forall era.
-  (EraGen era, UsesValue era) =>
+  (EraGen era, UsesTxOut era) =>
   GenEnv era ->
   Gen (UTxO era)
 genUtxo0 ge@(GenEnv _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
   genesisKeys <- someKeyPairs c minGenesisUTxOouts maxGenesisUTxOouts
   genesisScripts <- someScripts @era c minGenesisUTxOouts maxGenesisUTxOouts
   outs <-
-    genTxOut
+    (genTxOut @era)
       (genGenesisValue @era ge)
       (fmap (toAddr Testnet) genesisKeys ++ fmap (scriptsToAddr' Testnet) genesisScripts)
   return (genesisCoins genesisId outs)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -11,6 +11,7 @@
 module Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen (genCoin) where
 
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -79,7 +80,7 @@ instance CC.Crypto c => ScriptClass (ShelleyEra c) where
  -----------------------------------------------------------------------------}
 
 genTxBody ::
-  (ShelleyBased era) =>
+  (ShelleyBased era, Core.TxOut era ~ TxOut era) =>
   SlotNo ->
   Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -21,7 +21,12 @@ module Test.Shelley.Spec.Ledger.Generator.Trace.Chain where
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue
+  )
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (WithOrigin (..))
@@ -79,6 +84,7 @@ import Test.Shelley.Spec.Ledger.Utils
 instance
   ( EraGen era,
     UsesTxBody era,
+    UsesTxOut era,
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
@@ -88,7 +94,7 @@ instance
     ShelleyChainSTS era,
     ValidateAuxiliaryData era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   HasTrace (CHAIN era) (GenEnv era)
   where
@@ -115,6 +121,7 @@ lastByronHeaderHash _ = HashHeader $ mkHash 0
 mkGenesisChainState ::
   forall era a.
   ( EraGen era,
+    UsesTxOut era,
     UsesValue era
   ) =>
   GenEnv era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -19,7 +19,13 @@ module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesTxBody,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue
+  )
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition.Extended (IRC, TRC (..))
@@ -41,7 +47,7 @@ import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx)
-import Shelley.Spec.Ledger.TxBody (Ix, TxIn, TxOut)
+import Shelley.Spec.Ledger.TxBody (Ix, TxIn)
 import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
@@ -72,13 +78,14 @@ genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves})
 instance
   ( EraGen era,
     UsesTxBody era,
+    UsesTxOut era,
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   TQC.HasTrace (LEDGER era) (GenEnv era)
   where
@@ -99,13 +106,14 @@ instance
   forall era.
   ( EraGen era,
     UsesTxBody era,
+    UsesTxOut era,
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   TQC.HasTrace (LEDGERS era) (GenEnv era)
   where
@@ -159,6 +167,7 @@ instance
 mkGenesisLedgerState ::
   forall a era.
   ( UsesValue era,
+    UsesTxOut era,
     EraGen era
   ) =>
   GenEnv era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -46,7 +46,13 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesScript,
+    UsesTxBody,
+    UsesTxOut,
+    UsesValue
+  )
 import Cardano.Slotting.Block (BlockNo (..))
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import Control.SetAlgebra (biMapFromList)
@@ -375,7 +381,11 @@ instance CC.Crypto crypto => Arbitrary (STS.PrtclState crypto) where
   shrink = genericShrink
 
 instance
-  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    Mock (Crypto era),
+    Arbitrary (Core.TxOut era)
+  ) =>
   Arbitrary (UTxO era)
   where
   arbitrary = genericArbitraryU
@@ -444,21 +454,35 @@ instance CC.Crypto crypto => Arbitrary (DPState crypto) where
   shrink = genericShrink
 
 instance
-  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    Mock (Crypto era),
+    Arbitrary (Core.TxOut era)
+  ) =>
   Arbitrary (UTxOState era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era)) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    Mock (Crypto era),
+    Arbitrary (Core.TxOut era)
+  ) =>
   Arbitrary (LedgerState era)
   where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
 instance
-  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    Mock (Crypto era),
+    Arbitrary (Core.TxOut era),
+    Arbitrary (Core.Value era),
+    EraGen era
+  ) =>
   Arbitrary (NewEpochState era)
   where
   arbitrary = genericArbitraryU
@@ -475,7 +499,13 @@ instance CC.Crypto crypto => Arbitrary (PoolDistr crypto) where
       genVal = IndividualPoolStake <$> arbitrary <*> genHash
 
 instance
-  (UsesValue era, Mock (Crypto era), Arbitrary (Core.Value era), EraGen era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    Mock (Crypto era),
+    Arbitrary (Core.TxOut era),
+    Arbitrary (Core.Value era),
+    EraGen era
+  ) =>
   Arbitrary (EpochState era)
   where
   arbitrary =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -139,7 +139,7 @@ import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv)
 import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
-import Shelley.Spec.Ledger.Tx (Tx, TxBody)
+import Shelley.Spec.Ledger.Tx (Tx, TxBody, TxOut)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Tasty.HUnit
   ( Assertion,
@@ -149,10 +149,12 @@ import Test.Tasty.HUnit
 type ShelleyTest era =
   ( UsesTxBody era,
     UsesValue era,
+    UsesTxOut era,
     UsesScript era,
     UsesAuxiliary era,
     TxBody era ~ Core.TxBody era,
-    Core.Script era ~ MultiSig (Crypto era),
+    TxOut era ~ Core.TxOut era,
+    MultiSig (Crypto era) ~ Core.Script era,
     Split (Core.Value era)
   )
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -45,7 +45,7 @@ where
 
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Cardano.Slotting.Slot (EpochNo, WithOrigin (..))
 import Control.SetAlgebra (eval, setSingleton, singleton, (∪), (⋪), (⋫))
@@ -98,7 +98,7 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
-import Shelley.Spec.Ledger.Tx (TxIn, TxOut)
+import Shelley.Spec.Ledger.Tx (TxIn)
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
@@ -177,9 +177,9 @@ feesAndDeposits newFees depositChange cs = cs {chainNes = nes'}
 newUTxO ::
   forall era.
   ( UsesTxBody era,
-    UsesValue era,
+    UsesTxOut era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   Core.TxBody era ->
   ChainState era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -14,9 +14,11 @@ module Test.Shelley.Spec.Ledger.PropertyTests
   )
 where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash, ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Shelley.Constraints (TransValue, UsesTxOut)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import GHC.Records (HasField (..))
@@ -26,7 +28,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
 import Shelley.Spec.Ledger.PParams (Update (..))
-import Shelley.Spec.Ledger.TxBody (TxIn, TxOut, Wdrl)
+import Shelley.Spec.Ledger.TxBody (TxIn, Wdrl)
 import Test.Shelley.Spec.Ledger.Address.Bootstrap
   ( bootstrapHashTest,
   )
@@ -59,9 +61,11 @@ minimalPropertyTests ::
   forall era.
   ( EraGen era,
     ChainProperty era,
+    UsesTxOut era,
+    TransValue ToCBOR era,
     ValidateAuxiliaryData era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
@@ -89,10 +93,12 @@ minimalPropertyTests =
 propertyTests ::
   forall era.
   ( EraGen era,
+    UsesTxOut era,
+    TransValue ToCBOR era,
     ChainProperty era,
     ValidateAuxiliaryData era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (TxOut era)),
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -779,7 +779,7 @@ tests =
           tout = TxOut @C testAddrE (Coin 2)
        in checkEncodingCBORAnnotated
             "txbody"
-            ( TxBody -- minimal transaction body
+            ( TxBody @C -- minimal transaction body
                 (Set.fromList [tin])
                 (StrictSeq.singleton tout)
                 StrictSeq.empty
@@ -836,7 +836,7 @@ tests =
               (EpochNo 0)
        in checkEncodingCBORAnnotated
             "txbody_partial"
-            ( TxBody -- transaction body with some optional components
+            ( TxBody @C -- transaction body with some optional components
                 (Set.fromList [tin])
                 (StrictSeq.singleton tout)
                 StrictSeq.Empty
@@ -899,7 +899,7 @@ tests =
           mdh = hashAuxiliaryData @C $ MD.Metadata $ Map.singleton 13 (MD.I 17)
        in checkEncodingCBORAnnotated
             "txbody_full"
-            ( TxBody -- transaction body with all components
+            ( TxBody @C -- transaction body with all components
                 (Set.fromList [tin])
                 (StrictSeq.singleton tout)
                 (StrictSeq.fromList [reg])
@@ -932,7 +932,7 @@ tests =
             ),
       -- checkEncodingCBOR "minimal_txn"
       let txb =
-            TxBody
+            TxBody @C
               (Set.fromList [TxIn genesisId 1])
               (StrictSeq.singleton $ TxOut @C testAddrE (Coin 2))
               StrictSeq.empty
@@ -956,7 +956,7 @@ tests =
             ),
       -- checkEncodingCBOR "full_txn"
       let txb =
-            TxBody
+            TxBody @C
               (Set.fromList [TxIn genesisId 1])
               (StrictSeq.singleton $ TxOut @C testAddrE (Coin 2))
               StrictSeq.empty
@@ -1093,7 +1093,7 @@ tests =
           tin = Set.fromList [TxIn @C_Crypto genesisId 1]
           tout = StrictSeq.singleton $ TxOut @C testAddrE (Coin 2)
           txb s =
-            TxBody
+            TxBody @C
               tin
               tout
               StrictSeq.empty


### PR DESCRIPTION
The type `TxOut` will change for alonzo (it will include a `Maybe DataHash`), and this PR prepares the way.

Note: before this can be merged, I need to re-enable the `ApplyBlock (MaryEra c)` instance and figure out why the constraint `NoThunks (CompactForm (Cardano.Ledger.Mary.Value.Value c))` is now missing.