### PR TITLE
Use an era map to determine rules for the era

### DIFF
--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -27,6 +27,7 @@ library
     Cardano.Ledger.Mary.Value
     Cardano.Ledger.ShelleyMA
     Cardano.Ledger.ShelleyMA.AuxiliaryData
+    Cardano.Ledger.ShelleyMA.Rules.EraMapping
     Cardano.Ledger.ShelleyMA.Rules.Utxo
     Cardano.Ledger.ShelleyMA.Rules.Utxow
     Cardano.Ledger.ShelleyMA.Timelocks

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -6,9 +6,15 @@
 module Cardano.Ledger.Allegra where
 
 import Cardano.Ledger.ShelleyMA
-import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
+import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
 import Cardano.Ledger.ShelleyMA.TxBody ()
-import Shelley.Spec.Ledger.API (ApplyBlock, ApplyTx, GetLedgerView, PraosCrypto, ShelleyBasedEra)
+import Shelley.Spec.Ledger.API
+  ( ApplyBlock,
+    ApplyTx,
+    GetLedgerView,
+    PraosCrypto,
+    ShelleyBasedEra,
+  )
 
 type AllegraEra = ShelleyMAEra 'Allegra
 

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -6,6 +6,7 @@
 module Cardano.Ledger.Mary where
 
 import Cardano.Ledger.ShelleyMA
+import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
 import Shelley.Spec.Ledger.API

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.ShelleyMA.Rules.EraMapping () where
+
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.ShelleyMA (ShelleyMAEra)
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO)
+import Cardano.Ledger.ShelleyMA.Rules.Utxow (UTXOW)
+import qualified Shelley.Spec.Ledger.API as Shelley
+import qualified Shelley.Spec.Ledger.STS.Bbody as Shelley
+import qualified Shelley.Spec.Ledger.STS.Epoch as Shelley
+import qualified Shelley.Spec.Ledger.STS.Mir as Shelley
+import qualified Shelley.Spec.Ledger.STS.Newpp as Shelley
+import qualified Shelley.Spec.Ledger.STS.Ocert as Shelley
+import qualified Shelley.Spec.Ledger.STS.Overlay as Shelley
+import qualified Shelley.Spec.Ledger.STS.Rupd as Shelley
+import qualified Shelley.Spec.Ledger.STS.Snap as Shelley
+import qualified Shelley.Spec.Ledger.STS.Tick as Shelley
+
+-- These rules are all inherited from Shelley
+
+type instance Core.EraRule "BBODY" (ShelleyMAEra ma c) = Shelley.BBODY (ShelleyMAEra ma c)
+
+type instance Core.EraRule "CHAIN" (ShelleyMAEra ma c) = Shelley.CHAIN (ShelleyMAEra ma c)
+
+type instance Core.EraRule "DELEG" (ShelleyMAEra ma c) = Shelley.DELEG (ShelleyMAEra ma c)
+
+type instance Core.EraRule "DELEGS" (ShelleyMAEra ma c) = Shelley.DELEGS (ShelleyMAEra ma c)
+
+type instance Core.EraRule "DELPL" (ShelleyMAEra ma c) = Shelley.DELPL (ShelleyMAEra ma c)
+
+type instance Core.EraRule "EPOCH" (ShelleyMAEra ma c) = Shelley.EPOCH (ShelleyMAEra ma c)
+
+type instance Core.EraRule "LEDGER" (ShelleyMAEra ma c) = Shelley.LEDGER (ShelleyMAEra ma c)
+
+type instance Core.EraRule "LEDGERS" (ShelleyMAEra ma c) = Shelley.LEDGERS (ShelleyMAEra ma c)
+
+type instance Core.EraRule "MIR" (ShelleyMAEra ma c) = Shelley.MIR (ShelleyMAEra ma c)
+
+type instance Core.EraRule "NEWEPOCH" (ShelleyMAEra ma c) = Shelley.NEWEPOCH (ShelleyMAEra ma c)
+
+type instance Core.EraRule "NEWPP" (ShelleyMAEra ma c) = Shelley.NEWPP (ShelleyMAEra ma c)
+
+type instance Core.EraRule "OCERT" (ShelleyMAEra ma c) = Shelley.OCERT (ShelleyMAEra ma c)
+
+type instance Core.EraRule "OVERLAY" (ShelleyMAEra ma c) = Shelley.OVERLAY (ShelleyMAEra ma c)
+
+type instance Core.EraRule "POOL" (ShelleyMAEra ma c) = Shelley.POOL (ShelleyMAEra ma c)
+
+type instance Core.EraRule "POOLREAP" (ShelleyMAEra ma c) = Shelley.POOLREAP (ShelleyMAEra ma c)
+
+type instance Core.EraRule "PPUP" (ShelleyMAEra ma c) = Shelley.PPUP (ShelleyMAEra ma c)
+
+type instance Core.EraRule "RUPD" (ShelleyMAEra ma c) = Shelley.RUPD (ShelleyMAEra ma c)
+
+type instance Core.EraRule "SNAP" (ShelleyMAEra ma c) = Shelley.SNAP (ShelleyMAEra ma c)
+
+type instance Core.EraRule "TICK" (ShelleyMAEra ma c) = Shelley.TICK (ShelleyMAEra ma c)
+
+type instance Core.EraRule "TICKF" (ShelleyMAEra ma c) = Shelley.TICKF (ShelleyMAEra ma c)
+
+type instance Core.EraRule "TICKN" (ShelleyMAEra _ma _c) = Shelley.TICKN
+
+-- These rules are defined anew in the ShelleyMA era(s)
+
+type instance Core.EraRule "UTXO" (ShelleyMAEra ma c) = UTXO (ShelleyMAEra ma c)
+
+type instance Core.EraRule "UTXOW" (ShelleyMAEra ma c) = UTXOW (ShelleyMAEra ma c)

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/EraMapping.hs
@@ -22,8 +22,6 @@ import qualified Shelley.Spec.Ledger.STS.Tick as Shelley
 
 type instance Core.EraRule "BBODY" (ShelleyMAEra ma c) = Shelley.BBODY (ShelleyMAEra ma c)
 
-type instance Core.EraRule "CHAIN" (ShelleyMAEra ma c) = Shelley.CHAIN (ShelleyMAEra ma c)
-
 type instance Core.EraRule "DELEG" (ShelleyMAEra ma c) = Shelley.DELEG (ShelleyMAEra ma c)
 
 type instance Core.EraRule "DELEGS" (ShelleyMAEra ma c) = Shelley.DELEGS (ShelleyMAEra ma c)

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -17,8 +17,7 @@ module Cardano.Ledger.ShelleyMA.Rules.Utxo where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints
   ( TransValue,
     UsesAuxiliary,
@@ -27,7 +26,6 @@ import Cardano.Ledger.Shelley.Constraints
     UsesTxOut,
     UsesValue,
   )
-import Cardano.Ledger.ShelleyMA (MAValue, MaryOrAllegra, ShelleyMAEra)
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody)
 import Cardano.Ledger.Torsor (Torsor (..))
@@ -48,7 +46,6 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Typeable
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import GHC.Records
@@ -65,12 +62,12 @@ import Shelley.Spec.Ledger.BaseTypes
     networkId,
   )
 import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.LedgerState (PPUPState)
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), Update)
-import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..))
-import Shelley.Spec.Ledger.STS.Utxo (UTXO)
+import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
 import qualified Shelley.Spec.Ledger.STS.Utxo as Shelley
-import Shelley.Spec.Ledger.Tx (Tx (..), TxIn)
+import Shelley.Spec.Ledger.Tx (Tx (..), TxIn, TxOut)
 import Shelley.Spec.Ledger.TxBody
   ( DCert,
     RewardAcnt (getRwdNetwork),
@@ -113,22 +110,30 @@ data UtxoPredicateFailure era
       !(Set (RewardAcnt (Crypto era))) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
       ![Core.TxOut era] -- list of supplied transaction outputs that are too small
-  | UpdateFailure (PredicateFailure (PPUP era)) -- Subtransition Failures
+  | UpdateFailure (PredicateFailure (Core.EraRule "PPUP" era)) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
       ![Core.TxOut era] -- list of supplied bad transaction outputs
   | TriesToForgeADA
   deriving (Generic)
 
 deriving stock instance
-  (Shelley.TransUTxOState Show era) =>
+  ( Shelley.TransUTxOState Show era,
+    TransValue Show era,
+    Show (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   Show (UtxoPredicateFailure era)
 
 deriving stock instance
-  (Shelley.TransUTxOState Eq era, TransValue Eq era) =>
+  ( Shelley.TransUTxOState Eq era,
+    TransValue Eq era,
+    Eq (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   Eq (UtxoPredicateFailure era)
 
 instance
-  (Shelley.TransUTxOState NoThunks era) =>
+  ( Shelley.TransUTxOState NoThunks era,
+    NoThunks (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   NoThunks (UtxoPredicateFailure era)
 
 -- | Calculate the value consumed by the transation.
@@ -171,12 +176,10 @@ utxoTransition ::
     UsesValue era,
     UsesScript era,
     STS (UTXO era),
-    Embed (PPUP era) (UTXO era),
-    BaseM (UTXO era) ~ ShelleyBase,
-    Environment (UTXO era) ~ Shelley.UtxoEnv era,
-    State (UTXO era) ~ Shelley.UTxOState era,
-    Signal (UTXO era) ~ Tx era,
-    PredicateFailure (UTXO era) ~ UtxoPredicateFailure era,
+    Embed (Core.EraRule "PPUP" era) (UTXO era),
+    Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
+    State (Core.EraRule "PPUP" era) ~ PPUPState era,
+    Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "mint" (Core.TxBody era) (Core.Value era),
@@ -224,7 +227,9 @@ utxoTransition = do
   consumed_ == produced_ ?! ValueNotConservedUTxO (toDelta consumed_) (toDelta produced_)
 
   -- process Protocol Parameter Update Proposals
-  ppup' <- trans @(PPUP era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
+  ppup' <-
+    trans @(Core.EraRule "PPUP" era) $
+      TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
   -- Check that the mint field does not try to mint ADA. This is equivalent to
   -- the check `adaPolicy ∉ supp mint tx` in the spec.
@@ -268,42 +273,51 @@ utxoTransition = do
     Shelley.UTxOState
       { Shelley._utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts txb),
         Shelley._deposited = deposits' <> depositChange,
-        Shelley._fees = fees <> (getField @"txfee" txb),
+        Shelley._fees = fees <> getField @"txfee" txb,
         Shelley._ppups = ppup'
       }
 
 --------------------------------------------------------------------------------
 -- UTXO STS
 --------------------------------------------------------------------------------
+data UTXO era
 
 instance
-  forall c (ma :: MaryOrAllegra).
-  ( CryptoClass.Crypto c,
-    Typeable ma,
-    UsesTxOut (ShelleyMAEra ma c),
-    UsesValue (ShelleyMAEra ma c),
-    TransValue ToCBOR (ShelleyMAEra ma c),
-    Show (Delta (MAValue ma c)),
-    Core.TxBody (ShelleyMAEra ma c) ~ TxBody (ShelleyMAEra ma c)
+  forall era.
+  ( Era era,
+    UsesAuxiliary era,
+    UsesScript era,
+    UsesTxOut era,
+    UsesValue era,
+    TransValue ToCBOR era,
+    Show (Delta (Core.Value era)),
+    Core.TxBody era ~ TxBody era,
+    Core.TxOut era ~ TxOut era,
+    Embed (Core.EraRule "PPUP" era) (UTXO era),
+    Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
+    State (Core.EraRule "PPUP" era) ~ PPUPState era,
+    Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era)
   ) =>
-  STS (UTXO (ShelleyMAEra ma c))
+  STS (UTXO era)
   where
-  type State (UTXO (ShelleyMAEra ma c)) = Shelley.UTxOState (ShelleyMAEra ma c)
-  type Signal (UTXO (ShelleyMAEra ma c)) = Tx (ShelleyMAEra ma c)
+  type State (UTXO era) = Shelley.UTxOState era
+  type Signal (UTXO era) = Tx era
   type
-    Environment (UTXO (ShelleyMAEra ma c)) =
-      Shelley.UtxoEnv (ShelleyMAEra ma c)
-  type BaseM (UTXO (ShelleyMAEra ma c)) = ShelleyBase
+    Environment (UTXO era) =
+      Shelley.UtxoEnv era
+  type BaseM (UTXO era) = ShelleyBase
   type
-    PredicateFailure (UTXO (ShelleyMAEra ma c)) =
-      UtxoPredicateFailure (ShelleyMAEra ma c)
+    PredicateFailure (UTXO era) =
+      UtxoPredicateFailure era
 
   initialRules = []
   transitionRules = [utxoTransition]
 
 instance
-  (CryptoClass.Crypto c, Typeable ma) =>
-  Embed (PPUP (ShelleyMAEra (ma :: MaryOrAllegra) c)) (UTXO (ShelleyMAEra ma c))
+  ( Era era,
+    PredicateFailure (Core.EraRule "PPUP" era) ~ PpupPredicateFailure era
+  ) =>
+  Embed (PPUP era) (UTXO era)
   where
   wrapFailed = UpdateFailure
 
@@ -311,7 +325,10 @@ instance
 -- Serialisation
 --------------------------------------------------------------------------------
 instance
-  Shelley.TransUTxOState ToCBOR era =>
+  ( TransValue ToCBOR era,
+    Shelley.TransUTxOState ToCBOR era,
+    ToCBOR (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   ToCBOR (UtxoPredicateFailure era)
   where
   toCBOR = \case
@@ -357,7 +374,8 @@ instance
   ( TransValue FromCBOR era,
     Shelley.TransUTxOState FromCBOR era,
     Val.DecodeNonNegative (Core.Value era),
-    Show (Core.Value era)
+    Show (Core.Value era),
+    FromCBOR (PredicateFailure (Core.EraRule "PPUP" era))
   ) =>
   FromCBOR (UtxoPredicateFailure era)
   where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -21,14 +21,12 @@
 module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 
 import Cardano.Binary (Annotator (..), FromCBOR, ToCBOR)
-import Cardano.Ledger.Core (SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
-import Control.State.Transition
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Proxy (Proxy (Proxy))
 import Data.Typeable (typeRep)
-import Shelley.Spec.Ledger.API (ApplyTxError, UTXOW)
+import Shelley.Spec.Ledger.API (ApplyTx, ApplyTxError)
 import Test.Cardano.Ledger.EraBuffet
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
   ( roundTrip,
@@ -85,14 +83,12 @@ property x =
 allprops ::
   forall e.
   ( ShelleyBased e,
+    ApplyTx e,
     Arbitrary (Core.TxBody e),
     Arbitrary (Core.AuxiliaryData e),
     Arbitrary (Core.Value e),
     Arbitrary (Core.Script e),
-    Arbitrary (ApplyTxError e),
-    SerialisableData (ApplyTxError e),
-    Eq (PredicateFailure (UTXOW e)),
-    Show (PredicateFailure (UTXOW e))
+    Arbitrary (ApplyTxError e)
   ) =>
   TestTree
 allprops =

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -66,6 +66,7 @@ library
     Shelley.Spec.Ledger.STS.Delegs
     Shelley.Spec.Ledger.STS.Delpl
     Shelley.Spec.Ledger.STS.Epoch
+    Shelley.Spec.Ledger.STS.EraMapping
     Shelley.Spec.Ledger.STS.Ledger
     Shelley.Spec.Ledger.STS.Ledgers
     Shelley.Spec.Ledger.STS.Mir

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -25,12 +27,16 @@ module Cardano.Ledger.Core
     ChainData,
     SerialisableData,
     AnnotatedData,
+
+    -- * Era STS
+    EraRule,
   )
 where
 
 import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
+import GHC.TypeLits (Symbol)
 import NoThunks.Class (NoThunks)
 
 -- | A transaction output.
@@ -59,3 +65,6 @@ type SerialisableData t = (FromCBOR t, ToCBOR t)
 
 -- | Constraints for serialising from/to CBOR using 'Annotator'
 type AnnotatedData t = (FromCBOR (Annotator t), ToCBOR t)
+
+-- | Era STS map
+type family EraRule (k :: Symbol) era :: Type

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -61,8 +61,7 @@ class
 
 class
   ( Era era,
-    Show (TxOut era),
-    Eq (TxOut era),
+    ChainData (TxOut era),
     ToCBOR (TxOut era),
     FromCBOR (TxOut era),
     HasField "address" (TxOut era) (Addr (Crypto era)),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -52,7 +52,7 @@ class
     ChainData (NewEpochState era),
     SerialisableData (NewEpochState era),
     ChainData (BlockTransitionError era),
-    ChainData (STS.PredicateFailure (Core.EraRule "CHAIN" era)),
+    ChainData (STS.PredicateFailure (STS.CHAIN era)),
     STS (Core.EraRule "TICK" era),
     BaseM (Core.EraRule "TICK" era) ~ ShelleyBase,
     Environment (Core.EraRule "TICK" era) ~ (),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -20,9 +21,9 @@ module Shelley.Spec.Ledger.API.Validation
 where
 
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Arrow (left, right)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
@@ -30,13 +31,13 @@ import Control.State.Transition.Extended
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.API.Protocol (PraosCrypto)
-import Shelley.Spec.Ledger.BaseTypes (Globals (..))
+import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
 import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
-import qualified Shelley.Spec.Ledger.STS.Tick as STS
+import Shelley.Spec.Ledger.STS.EraMapping ()
 import Shelley.Spec.Ledger.Slot (SlotNo)
 
 {-------------------------------------------------------------------------------
@@ -51,7 +52,17 @@ class
     ChainData (NewEpochState era),
     SerialisableData (NewEpochState era),
     ChainData (BlockTransitionError era),
-    ChainData (STS.PredicateFailure (STS.CHAIN era))
+    ChainData (STS.PredicateFailure (Core.EraRule "CHAIN" era)),
+    STS (Core.EraRule "TICK" era),
+    BaseM (Core.EraRule "TICK" era) ~ ShelleyBase,
+    Environment (Core.EraRule "TICK" era) ~ (),
+    State (Core.EraRule "TICK" era) ~ NewEpochState era,
+    Signal (Core.EraRule "TICK" era) ~ SlotNo,
+    STS (Core.EraRule "BBODY" era),
+    BaseM (Core.EraRule "BBODY" era) ~ ShelleyBase,
+    Environment (Core.EraRule "BBODY" era) ~ STS.BbodyEnv era,
+    State (Core.EraRule "BBODY" era) ~ STS.BbodyState era,
+    Signal (Core.EraRule "BBODY" era) ~ Block era
   ) =>
   ApplyBlock era
   where
@@ -65,18 +76,17 @@ class
     SlotNo ->
     NewEpochState era
   default applyTick ::
-    (UsesTxOut era, UsesValue era) =>
     Globals ->
     NewEpochState era ->
     SlotNo ->
     NewEpochState era
   applyTick globals state hdr =
-    (either err id) . flip runReader globals
-      . applySTS @(STS.TICK era)
+    either err id . flip runReader globals
+      . applySTS @(Core.EraRule "TICK" era)
       $ TRC ((), state, hdr)
     where
       err :: Show a => a -> b
-      err msg = error $ "Panic! applyTick failed: " <> (show msg)
+      err msg = error $ "Panic! applyTick failed: " <> show msg
 
   -- | Apply the block level ledger transition.
   applyBlock ::
@@ -86,9 +96,7 @@ class
     Block era ->
     m (NewEpochState era)
   default applyBlock ::
-    ( STS (STS.BBODY era),
-      MonadError (BlockTransitionError era) m
-    ) =>
+    (MonadError (BlockTransitionError era) m) =>
     Globals ->
     NewEpochState era ->
     Block era ->
@@ -100,7 +108,7 @@ class
       $ res
     where
       res =
-        flip runReader globals . applySTS @(STS.BBODY era) $
+        flip runReader globals . applySTS @(Core.EraRule "BBODY" era) $
           TRC (mkBbodyEnv state, bbs, blk)
       bbs =
         STS.BbodyState
@@ -118,7 +126,6 @@ class
     Block era ->
     NewEpochState era
   default reapplyBlock ::
-    STS (STS.BBODY era) =>
     Globals ->
     NewEpochState era ->
     Block era ->
@@ -127,7 +134,7 @@ class
     updateNewEpochState state res
     where
       res =
-        flip runReader globals . reapplySTS @(STS.BBODY era) $
+        flip runReader globals . reapplySTS @(Core.EraRule "BBODY" era) $
           TRC (mkBbodyEnv state, bbs, blk)
       bbs =
         STS.BbodyState
@@ -175,33 +182,33 @@ updateNewEpochState ss (STS.BbodyState ls bcur) =
   LedgerState.updateNES ss bcur ls
 
 newtype TickTransitionError era
-  = TickTransitionError [STS.PredicateFailure (STS.TICK era)]
+  = TickTransitionError [STS.PredicateFailure (Core.EraRule "TICK" era)]
   deriving (Generic)
 
 instance
-  (NoThunks (STS.PredicateFailure (STS.TICK era))) =>
+  (NoThunks (STS.PredicateFailure (Core.EraRule "TICK" era))) =>
   NoThunks (TickTransitionError era)
 
 deriving stock instance
-  (Eq (STS.PredicateFailure (STS.TICK era))) =>
+  (Eq (STS.PredicateFailure (Core.EraRule "TICK" era))) =>
   Eq (TickTransitionError era)
 
 deriving stock instance
-  (Show (STS.PredicateFailure (STS.TICK era))) =>
+  (Show (STS.PredicateFailure (Core.EraRule "TICK" era))) =>
   Show (TickTransitionError era)
 
 newtype BlockTransitionError era
-  = BlockTransitionError [STS.PredicateFailure (STS.BBODY era)]
+  = BlockTransitionError [STS.PredicateFailure (Core.EraRule "BBODY" era)]
   deriving (Generic)
 
 deriving stock instance
-  (Eq (STS.PredicateFailure (STS.BBODY era))) =>
+  (Eq (STS.PredicateFailure (Core.EraRule "BBODY" era))) =>
   Eq (BlockTransitionError era)
 
 deriving stock instance
-  (Show (STS.PredicateFailure (STS.BBODY era))) =>
+  (Show (STS.PredicateFailure (Core.EraRule "BBODY" era))) =>
   Show (BlockTransitionError era)
 
 instance
-  (NoThunks (STS.PredicateFailure (STS.BBODY era))) =>
+  (NoThunks (STS.PredicateFailure (Core.EraRule "BBODY" era))) =>
   NoThunks (BlockTransitionError era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -29,12 +29,11 @@ module Shelley.Spec.Ledger.STS.Chain
   )
 where
 
-import qualified Cardano.Crypto.VRF as VRF
-import Cardano.Ledger.Crypto (VRF)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import qualified Cardano.Ledger.Val as Val
-import Cardano.Slotting.Slot (WithOrigin (..))
+import Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Control.Monad.Except (MonadError, throwError)
@@ -59,13 +58,11 @@ import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.BaseTypes
   ( Globals (..),
     Nonce (..),
-    Seed (..),
     ShelleyBase,
     StrictMaybe (..),
   )
 import Shelley.Spec.Ledger.BlockChain
-  ( BHBody,
-    BHeader,
+  ( BHeader,
     Block (..),
     LastAppliedBlock (..),
     bHeaderSize,
@@ -81,11 +78,8 @@ import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
 import Shelley.Spec.Ledger.Keys
-  ( DSignable,
-    GenDelegPair (..),
+  ( GenDelegPair (..),
     GenDelegs (..),
-    Hash,
-    KESignable,
     KeyHash,
     KeyRole (..),
     coerceKeyRole,
@@ -106,14 +100,13 @@ import Shelley.Spec.Ledger.LedgerState
     updateNES,
     _genDelegs,
   )
-import Shelley.Spec.Ledger.OCert (OCertSignable)
 import Shelley.Spec.Ledger.PParams
   ( PParams,
     PParams' (..),
     ProtVer (..),
   )
 import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyEnv (..), BbodyState (..))
+import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyEnv (..), BbodyPredicateFailure, BbodyState (..))
 import Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL,
     PrtclEnv (..),
@@ -121,10 +114,9 @@ import Shelley.Spec.Ledger.STS.Prtcl
     PrtlSeqFailure,
     prtlSeqChecks,
   )
-import Shelley.Spec.Ledger.STS.Tick (TICK)
+import Shelley.Spec.Ledger.STS.Tick (TICK, TickPredicateFailure)
 import Shelley.Spec.Ledger.STS.Tickn
 import Shelley.Spec.Ledger.Slot (EpochNo)
-import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
 
 data CHAIN era
@@ -160,28 +152,34 @@ data ChainPredicateFailure era
   | ObsoleteNodeCHAIN
       !Natural -- protocol version used
       !Natural -- max protocol version
-  | BbodyFailure !(PredicateFailure (BBODY era)) -- Subtransition Failures
-  | TickFailure !(PredicateFailure (TICK era)) -- Subtransition Failures
-  | TicknFailure !(PredicateFailure TICKN) -- Subtransition Failures
+  | BbodyFailure !(PredicateFailure (Core.EraRule "BBODY" era)) -- Subtransition Failures
+  | TickFailure !(PredicateFailure (Core.EraRule "TICK" era)) -- Subtransition Failures
+  | TicknFailure !(PredicateFailure (Core.EraRule "TICKN" era)) -- Subtransition Failures
   | PrtclFailure !(PredicateFailure (PRTCL (Crypto era))) -- Subtransition Failures
   | PrtclSeqFailure !(PrtlSeqFailure (Crypto era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
   ( Era era,
-    Show (PredicateFailure (BBODY era))
+    Show (PredicateFailure (Core.EraRule "BBODY" era)),
+    Show (PredicateFailure (Core.EraRule "TICK" era)),
+    Show (PredicateFailure (Core.EraRule "TICKN" era))
   ) =>
   Show (ChainPredicateFailure era)
 
 deriving stock instance
   ( Era era,
-    Eq (PredicateFailure (BBODY era))
+    Eq (PredicateFailure (Core.EraRule "BBODY" era)),
+    Eq (PredicateFailure (Core.EraRule "TICK" era)),
+    Eq (PredicateFailure (Core.EraRule "TICKN" era))
   ) =>
   Eq (ChainPredicateFailure era)
 
 instance
   ( Era era,
-    NoThunks (PredicateFailure (BBODY era))
+    NoThunks (PredicateFailure (Core.EraRule "BBODY" era)),
+    NoThunks (PredicateFailure (Core.EraRule "TICK" era)),
+    NoThunks (PredicateFailure (Core.EraRule "TICKN" era))
   ) =>
   NoThunks (ChainPredicateFailure era)
 
@@ -231,16 +229,19 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
 
 instance
   ( Era era,
-    c ~ Crypto era,
-    Era era,
-    Embed (BBODY era) (CHAIN era),
-    Embed TICKN (CHAIN era),
-    Embed (TICK era) (CHAIN era),
-    Embed (PRTCL (Crypto era)) (CHAIN era),
-    DSignable c (OCertSignable c),
-    DSignable c (Hash c EraIndependentTxBody),
-    KESignable c (BHBody c),
-    VRF.Signable (VRF c) Seed
+    Embed (Core.EraRule "BBODY" era) (CHAIN era),
+    Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
+    State (Core.EraRule "BBODY" era) ~ BbodyState era,
+    Signal (Core.EraRule "BBODY" era) ~ Block era,
+    Embed (Core.EraRule "TICKN" era) (CHAIN era),
+    Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
+    State (Core.EraRule "TICKN" era) ~ TicknState,
+    Signal (Core.EraRule "TICKN" era) ~ Bool,
+    Embed (Core.EraRule "TICK" era) (CHAIN era),
+    Environment (Core.EraRule "TICK" era) ~ (),
+    State (Core.EraRule "TICK" era) ~ NewEpochState era,
+    Signal (Core.EraRule "TICK" era) ~ SlotNo,
+    Embed (PRTCL (Crypto era)) (CHAIN era)
   ) =>
   STS (CHAIN era)
   where
@@ -298,9 +299,18 @@ chainTransition ::
   forall era.
   ( Era era,
     STS (CHAIN era),
-    Embed (BBODY era) (CHAIN era),
-    Embed TICKN (CHAIN era),
-    Embed (TICK era) (CHAIN era),
+    Embed (Core.EraRule "BBODY" era) (CHAIN era),
+    Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
+    State (Core.EraRule "BBODY" era) ~ BbodyState era,
+    Signal (Core.EraRule "BBODY" era) ~ Block era,
+    Embed (Core.EraRule "TICKN" era) (CHAIN era),
+    Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
+    State (Core.EraRule "TICKN" era) ~ TicknState,
+    Signal (Core.EraRule "TICKN" era) ~ Bool,
+    Embed (Core.EraRule "TICK" era) (CHAIN era),
+    Environment (Core.EraRule "TICK" era) ~ (),
+    State (Core.EraRule "TICK" era) ~ NewEpochState era,
+    Signal (Core.EraRule "TICK" era) ~ SlotNo,
     Embed (PRTCL (Crypto era)) (CHAIN era)
   ) =>
   TransitionRule (CHAIN era)
@@ -333,8 +343,7 @@ chainTransition =
 
         let s = bheaderSlotNo $ bhbody bh
 
-        nes' <-
-          trans @(TICK era) $ TRC ((), nes, s)
+        nes' <- trans @(Core.EraRule "TICK" era) $ TRC ((), nes, s)
 
         let NewEpochState e1 _ _ _ _ _ = nes
             NewEpochState e2 _ bcur es _ _pd = nes'
@@ -345,7 +354,7 @@ chainTransition =
             etaPH = prevHashToNonce ph
 
         TicknState eta0' etaH' <-
-          trans @TICKN $
+          trans @(Core.EraRule "TICKN" era) $
             TRC
               ( TicknEnv (_extraEntropy pp') etaC etaPH,
                 TicknState eta0 etaH,
@@ -361,7 +370,7 @@ chainTransition =
               )
 
         BbodyState ls' bcur' <-
-          trans @(BBODY era) $
+          trans @(Core.EraRule "BBODY" era) $
             TRC (BbodyEnv pp' account, BbodyState ls bcur, block)
 
         let nes'' = updateNES nes' bcur' ls'
@@ -378,7 +387,8 @@ chainTransition =
 instance
   ( Era era,
     Era era,
-    STS (BBODY era)
+    STS (BBODY era),
+    PredicateFailure (Core.EraRule "BBODY" era) ~ BbodyPredicateFailure era
   ) =>
   Embed (BBODY era) (CHAIN era)
   where
@@ -386,7 +396,8 @@ instance
 
 instance
   ( Era era,
-    Era era
+    Era era,
+    PredicateFailure (Core.EraRule "TICKN" era) ~ TicknPredicateFailure
   ) =>
   Embed TICKN (CHAIN era)
   where
@@ -395,7 +406,8 @@ instance
 instance
   ( Era era,
     Era era,
-    STS (TICK era)
+    STS (TICK era),
+    PredicateFailure (Core.EraRule "TICK" era) ~ TickPredicateFailure era
   ) =>
   Embed (TICK era) (CHAIN era)
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -114,7 +114,7 @@ data DelegPredicateFailure era
       !Coin -- size of the pot from which the lovelace is drawn
   | MIRCertificateTooLateinEpochDELEG
       !SlotNo -- current slot
-      !SlotNo -- MIR must be submitted before this slot
+      !SlotNo -- Core.EraRule "MIR" must be submitted before this slot
   | DuplicateGenesisVRFDELEG
       !(Hash (Crypto era) (VerKeyVRF (Crypto era))) --VRF KeyHash which is already delegated to
   deriving (Show, Eq, Generic)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -6,8 +8,10 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Delpl
   ( DELPL,
@@ -33,13 +37,15 @@ import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, invalidKey)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
     DPState,
+    DState,
+    PState,
     emptyDelegation,
     _dstate,
     _pstate,
   )
 import Shelley.Spec.Ledger.PParams (PParams)
-import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..))
-import Shelley.Spec.Ledger.STS.Pool (POOL, PoolEnv (..))
+import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..), DelegPredicateFailure)
+import Shelley.Spec.Ledger.STS.Pool (POOL, PoolEnv (..), PoolPredicateFailure)
 import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.TxBody
@@ -60,12 +66,39 @@ data DelplEnv era = DelplEnv
   }
 
 data DelplPredicateFailure era
-  = PoolFailure (PredicateFailure (POOL era)) -- Subtransition Failures
-  | DelegFailure (PredicateFailure (DELEG era)) -- Subtransition Failures
-  deriving (Show, Eq, Generic)
+  = PoolFailure (PredicateFailure (Core.EraRule "POOL" era)) -- Subtransition Failures
+  | DelegFailure (PredicateFailure (Core.EraRule "DELEG" era)) -- Subtransition Failures
+  deriving (Generic)
+
+deriving stock instance
+  ( Eq (PredicateFailure (Core.EraRule "DELEG" era)),
+    Eq (PredicateFailure (Core.EraRule "POOL" era))
+  ) =>
+  Eq (DelplPredicateFailure era)
+
+deriving stock instance
+  ( Show (PredicateFailure (Core.EraRule "DELEG" era)),
+    Show (PredicateFailure (Core.EraRule "POOL" era))
+  ) =>
+  Show (DelplPredicateFailure era)
 
 instance
-  Era era =>
+  ( NoThunks (PredicateFailure (Core.EraRule "DELEG" era)),
+    NoThunks (PredicateFailure (Core.EraRule "POOL" era))
+  ) =>
+  NoThunks (DelplPredicateFailure era)
+
+instance
+  ( Era era,
+    Embed (Core.EraRule "DELEG" era) (DELPL era),
+    Environment (Core.EraRule "DELEG" era) ~ DelegEnv,
+    State (Core.EraRule "DELEG" era) ~ DState (Crypto era),
+    Signal (Core.EraRule "DELEG" era) ~ DCert (Crypto era),
+    Embed (Core.EraRule "POOL" era) (DELPL era),
+    Environment (Core.EraRule "POOL" era) ~ PoolEnv era,
+    State (Core.EraRule "POOL" era) ~ PState (Crypto era),
+    Signal (Core.EraRule "POOL" era) ~ DCert (Crypto era)
+  ) =>
   STS (DELPL era)
   where
   type State (DELPL era) = DPState (Crypto era)
@@ -77,10 +110,12 @@ instance
   initialRules = [pure emptyDelegation]
   transitionRules = [delplTransition]
 
-instance NoThunks (DelplPredicateFailure era)
-
 instance
-  (Typeable era, Era era, Typeable (Core.Script era)) =>
+  ( Era era,
+    ToCBOR (PredicateFailure (Core.EraRule "POOL" era)),
+    ToCBOR (PredicateFailure (Core.EraRule "DELEG" era)),
+    Typeable (Core.Script era)
+  ) =>
   ToCBOR (DelplPredicateFailure era)
   where
   toCBOR = \case
@@ -92,7 +127,11 @@ instance
         <> toCBOR a
 
 instance
-  (Era era, Typeable (Core.Script era)) =>
+  ( Era era,
+    FromCBOR (PredicateFailure (Core.EraRule "POOL" era)),
+    FromCBOR (PredicateFailure (Core.EraRule "DELEG" era)),
+    Typeable (Core.Script era)
+  ) =>
   FromCBOR (DelplPredicateFailure era)
   where
   fromCBOR =
@@ -110,47 +149,59 @@ instance
 
 delplTransition ::
   forall era.
-  Era era =>
+  ( Embed (Core.EraRule "DELEG" era) (DELPL era),
+    Environment (Core.EraRule "DELEG" era) ~ DelegEnv,
+    State (Core.EraRule "DELEG" era) ~ DState (Crypto era),
+    Signal (Core.EraRule "DELEG" era) ~ DCert (Crypto era),
+    Embed (Core.EraRule "POOL" era) (DELPL era),
+    Environment (Core.EraRule "POOL" era) ~ PoolEnv era,
+    State (Core.EraRule "POOL" era) ~ PState (Crypto era),
+    Signal (Core.EraRule "POOL" era) ~ DCert (Crypto era)
+  ) =>
   TransitionRule (DELPL era)
 delplTransition = do
   TRC (DelplEnv slot ptr pp acnt, d, c) <- judgmentContext
   case c of
     DCertPool (RegPool _) -> do
       ps <-
-        trans @(POOL era) $ TRC (PoolEnv slot pp, _pstate d, c)
+        trans @(Core.EraRule "POOL" era) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d {_pstate = ps}
     DCertPool (RetirePool _ _) -> do
       ps <-
-        trans @(POOL era) $ TRC (PoolEnv slot pp, _pstate d, c)
+        trans @(Core.EraRule "POOL" era) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d {_pstate = ps}
     DCertGenesis (GenesisDelegCert {}) -> do
       ds <-
-        trans @(DELEG era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
+        trans @(Core.EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
       pure $ d {_dstate = ds}
     DCertDeleg (RegKey _) -> do
       ds <-
-        trans @(DELEG era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
+        trans @(Core.EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
       pure $ d {_dstate = ds}
     DCertDeleg (DeRegKey _) -> do
       ds <-
-        trans @(DELEG era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
+        trans @(Core.EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
       pure $ d {_dstate = ds}
     DCertDeleg (Delegate _) -> do
       ds <-
-        trans @(DELEG era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
+        trans @(Core.EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
       pure $ d {_dstate = ds}
     DCertMir _ -> do
-      ds <- trans @(DELEG era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
+      ds <- trans @(Core.EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt, _dstate d, c)
       pure $ d {_dstate = ds}
 
 instance
-  Era era =>
+  ( Era era,
+    PredicateFailure (Core.EraRule "POOL" era) ~ PoolPredicateFailure era
+  ) =>
   Embed (POOL era) (DELPL era)
   where
   wrapFailed = PoolFailure
 
 instance
-  Era era =>
+  ( Era era,
+    PredicateFailure (Core.EraRule "DELEG" era) ~ DelegPredicateFailure era
+  ) =>
   Embed (DELEG era) (DELPL era)
   where
   wrapFailed = DelegFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -18,7 +19,8 @@ module Shelley.Spec.Ledger.STS.Epoch
   )
 where
 
-import Cardano.Ledger.Era
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
@@ -28,9 +30,10 @@ import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
-import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
+import Shelley.Spec.Ledger.EpochBoundary (SnapShots, emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState,
+    LedgerState,
     PPUPState (..),
     PState (..),
     emptyAccount,
@@ -49,9 +52,9 @@ import Shelley.Spec.Ledger.LedgerState
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, ProposedPPUpdates (..), emptyPParams, updatePParams)
 import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppState (..))
-import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapState (..))
-import Shelley.Spec.Ledger.STS.Snap (SNAP)
+import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppPredicateFailure, NewppState (..))
+import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapPredicateFailure, PoolreapState (..))
+import Shelley.Spec.Ledger.STS.Snap (SNAP, SnapPredicateFailure)
 import Shelley.Spec.Ledger.Slot (EpochNo)
 
 -- ================================================
@@ -59,20 +62,43 @@ import Shelley.Spec.Ledger.Slot (EpochNo)
 data EPOCH era
 
 data EpochPredicateFailure era
-  = PoolReapFailure (PredicateFailure (POOLREAP era)) -- Subtransition Failures
-  | SnapFailure (PredicateFailure (SNAP era)) -- Subtransition Failures
-  | NewPpFailure (PredicateFailure (NEWPP era)) -- Subtransition Failures
+  = PoolReapFailure (PredicateFailure (Core.EraRule "POOLREAP" era)) -- Subtransition Failures
+  | SnapFailure (PredicateFailure (Core.EraRule "SNAP" era)) -- Subtransition Failures
+  | NewPpFailure (PredicateFailure (Core.EraRule "NEWPP" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
-  (Eq (PredicateFailure (SNAP era))) =>
+  ( Eq (PredicateFailure (Core.EraRule "POOLREAP" era)),
+    Eq (PredicateFailure (Core.EraRule "SNAP" era)),
+    Eq (PredicateFailure (Core.EraRule "NEWPP" era))
+  ) =>
   Eq (EpochPredicateFailure era)
 
 deriving stock instance
-  (Show (PredicateFailure (SNAP era))) =>
+  ( Show (PredicateFailure (Core.EraRule "POOLREAP" era)),
+    Show (PredicateFailure (Core.EraRule "SNAP" era)),
+    Show (PredicateFailure (Core.EraRule "NEWPP" era))
+  ) =>
   Show (EpochPredicateFailure era)
 
-instance (UsesTxOut era, UsesValue era) => STS (EPOCH era) where
+instance
+  ( UsesTxOut era,
+    UsesValue era,
+    Embed (Core.EraRule "SNAP" era) (EPOCH era),
+    Environment (Core.EraRule "SNAP" era) ~ LedgerState era,
+    State (Core.EraRule "SNAP" era) ~ SnapShots (Crypto era),
+    Signal (Core.EraRule "SNAP" era) ~ (),
+    Embed (Core.EraRule "POOLREAP" era) (EPOCH era),
+    Environment (Core.EraRule "POOLREAP" era) ~ PParams era,
+    State (Core.EraRule "POOLREAP" era) ~ PoolreapState era,
+    Signal (Core.EraRule "POOLREAP" era) ~ EpochNo,
+    Embed (Core.EraRule "NEWPP" era) (EPOCH era),
+    Environment (Core.EraRule "NEWPP" era) ~ NewppEnv era,
+    State (Core.EraRule "NEWPP" era) ~ NewppState era,
+    Signal (Core.EraRule "NEWPP" era) ~ Maybe (PParams era)
+  ) =>
+  STS (EPOCH era)
+  where
   type State (EPOCH era) = EpochState era
   type Signal (EPOCH era) = EpochNo
   type Environment (EPOCH era) = ()
@@ -81,7 +107,12 @@ instance (UsesTxOut era, UsesValue era) => STS (EPOCH era) where
   initialRules = [initialEpoch]
   transitionRules = [epochTransition]
 
-instance NoThunks (EpochPredicateFailure era)
+instance
+  ( NoThunks (PredicateFailure (Core.EraRule "POOLREAP" era)),
+    NoThunks (PredicateFailure (Core.EraRule "SNAP" era)),
+    NoThunks (PredicateFailure (Core.EraRule "NEWPP" era))
+  ) =>
+  NoThunks (EpochPredicateFailure era)
 
 initialEpoch :: InitialRule (EPOCH era)
 initialEpoch =
@@ -122,7 +153,19 @@ votedValue (ProposedPPUpdates pup) pps quorumN =
 epochTransition ::
   forall era.
   ( UsesTxOut era,
-    UsesValue era
+    UsesValue era,
+    Embed (Core.EraRule "SNAP" era) (EPOCH era),
+    Environment (Core.EraRule "SNAP" era) ~ LedgerState era,
+    State (Core.EraRule "SNAP" era) ~ SnapShots (Crypto era),
+    Signal (Core.EraRule "SNAP" era) ~ (),
+    Embed (Core.EraRule "POOLREAP" era) (EPOCH era),
+    Environment (Core.EraRule "POOLREAP" era) ~ PParams era,
+    State (Core.EraRule "POOLREAP" era) ~ PoolreapState era,
+    Signal (Core.EraRule "POOLREAP" era) ~ EpochNo,
+    Embed (Core.EraRule "NEWPP" era) (EPOCH era),
+    Environment (Core.EraRule "NEWPP" era) ~ NewppEnv era,
+    State (Core.EraRule "NEWPP" era) ~ NewppState era,
+    Signal (Core.EraRule "NEWPP" era) ~ Maybe (PParams era)
   ) =>
   TransitionRule (EPOCH era)
 epochTransition = do
@@ -142,7 +185,7 @@ epochTransition = do
   let utxoSt = _utxoState ls
   let DPState dstate pstate = _delegationState ls
   ss' <-
-    trans @(SNAP era) $ TRC (ls, ss, ())
+    trans @(Core.EraRule "SNAP" era) $ TRC (ls, ss, ())
 
   let PState pParams fPParams _ = pstate
       ppp = eval (pParams ⨃ fPParams)
@@ -152,14 +195,14 @@ epochTransition = do
             _fPParams = Map.empty
           }
   PoolreapState utxoSt' acnt' dstate' pstate'' <-
-    trans @(POOLREAP era) $ TRC (pp, PoolreapState utxoSt acnt dstate pstate', e)
+    trans @(Core.EraRule "POOLREAP" era) $ TRC (pp, PoolreapState utxoSt acnt dstate pstate', e)
 
   coreNodeQuorum <- liftSTS $ asks quorum
 
   let pup = proposals . _ppups $ utxoSt'
   let ppNew = votedValue pup pp (fromIntegral coreNodeQuorum)
   NewppState utxoSt'' acnt'' pp' <-
-    trans @(NEWPP era) $
+    trans @(Core.EraRule "NEWPP" era) $
       TRC (NewppEnv dstate' pstate'', NewppState utxoSt' acnt' pp, ppNew)
   pure $
     EpochState
@@ -170,11 +213,27 @@ epochTransition = do
       pp'
       nm
 
-instance (UsesTxOut era, UsesValue era) => Embed (SNAP era) (EPOCH era) where
+instance
+  ( UsesTxOut era,
+    UsesValue era,
+    PredicateFailure (Core.EraRule "SNAP" era) ~ SnapPredicateFailure era
+  ) =>
+  Embed (SNAP era) (EPOCH era)
+  where
   wrapFailed = SnapFailure
 
-instance Era era => Embed (POOLREAP era) (EPOCH era) where
+instance
+  ( Era era,
+    PredicateFailure (Core.EraRule "POOLREAP" era) ~ PoolreapPredicateFailure era
+  ) =>
+  Embed (POOLREAP era) (EPOCH era)
+  where
   wrapFailed = PoolReapFailure
 
-instance Era era => Embed (NEWPP era) (EPOCH era) where
+instance
+  ( Era era,
+    PredicateFailure (Core.EraRule "NEWPP" era) ~ NewppPredicateFailure era
+  ) =>
+  Embed (NEWPP era) (EPOCH era)
+  where
   wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
@@ -8,7 +8,6 @@ module Shelley.Spec.Ledger.STS.EraMapping () where
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Shelley.Spec.Ledger.STS.Bbody (BBODY)
-import Shelley.Spec.Ledger.STS.Chain (CHAIN)
 import Shelley.Spec.Ledger.STS.Deleg (DELEG)
 import Shelley.Spec.Ledger.STS.Delegs (DELEGS)
 import Shelley.Spec.Ledger.STS.Delpl (DELPL)
@@ -31,8 +30,6 @@ import Shelley.Spec.Ledger.STS.Utxo (UTXO)
 import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
 
 type instance Core.EraRule "BBODY" (ShelleyEra c) = BBODY (ShelleyEra c)
-
-type instance Core.EraRule "CHAIN" (ShelleyEra c) = CHAIN (ShelleyEra c)
 
 type instance Core.EraRule "DELEG" (ShelleyEra c) = DELEG (ShelleyEra c)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/EraMapping.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module provides the mapping from conceptual rule names to concrete
+-- rules for the Shelley era.
+module Shelley.Spec.Ledger.STS.EraMapping () where
+
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Shelley.Spec.Ledger.STS.Bbody (BBODY)
+import Shelley.Spec.Ledger.STS.Chain (CHAIN)
+import Shelley.Spec.Ledger.STS.Deleg (DELEG)
+import Shelley.Spec.Ledger.STS.Delegs (DELEGS)
+import Shelley.Spec.Ledger.STS.Delpl (DELPL)
+import Shelley.Spec.Ledger.STS.Epoch (EPOCH)
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER)
+import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
+import Shelley.Spec.Ledger.STS.Mir (MIR)
+import Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
+import Shelley.Spec.Ledger.STS.Newpp (NEWPP)
+import Shelley.Spec.Ledger.STS.Ocert (OCERT)
+import Shelley.Spec.Ledger.STS.Overlay (OVERLAY)
+import Shelley.Spec.Ledger.STS.Pool (POOL)
+import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP)
+import Shelley.Spec.Ledger.STS.Ppup (PPUP)
+import Shelley.Spec.Ledger.STS.Rupd (RUPD)
+import Shelley.Spec.Ledger.STS.Snap (SNAP)
+import Shelley.Spec.Ledger.STS.Tick (TICK, TICKF)
+import Shelley.Spec.Ledger.STS.Tickn (TICKN)
+import Shelley.Spec.Ledger.STS.Utxo (UTXO)
+import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
+
+type instance Core.EraRule "BBODY" (ShelleyEra c) = BBODY (ShelleyEra c)
+
+type instance Core.EraRule "CHAIN" (ShelleyEra c) = CHAIN (ShelleyEra c)
+
+type instance Core.EraRule "DELEG" (ShelleyEra c) = DELEG (ShelleyEra c)
+
+type instance Core.EraRule "DELEGS" (ShelleyEra c) = DELEGS (ShelleyEra c)
+
+type instance Core.EraRule "DELPL" (ShelleyEra c) = DELPL (ShelleyEra c)
+
+type instance Core.EraRule "EPOCH" (ShelleyEra c) = EPOCH (ShelleyEra c)
+
+type instance Core.EraRule "LEDGER" (ShelleyEra c) = LEDGER (ShelleyEra c)
+
+type instance Core.EraRule "LEDGERS" (ShelleyEra c) = LEDGERS (ShelleyEra c)
+
+type instance Core.EraRule "MIR" (ShelleyEra c) = MIR (ShelleyEra c)
+
+type instance Core.EraRule "NEWEPOCH" (ShelleyEra c) = NEWEPOCH (ShelleyEra c)
+
+type instance Core.EraRule "NEWPP" (ShelleyEra c) = NEWPP (ShelleyEra c)
+
+type instance Core.EraRule "OCERT" (ShelleyEra c) = OCERT (ShelleyEra c)
+
+type instance Core.EraRule "OVERLAY" (ShelleyEra c) = OVERLAY (ShelleyEra c)
+
+type instance Core.EraRule "POOL" (ShelleyEra c) = POOL (ShelleyEra c)
+
+type instance Core.EraRule "POOLREAP" (ShelleyEra c) = POOLREAP (ShelleyEra c)
+
+type instance Core.EraRule "PPUP" (ShelleyEra c) = PPUP (ShelleyEra c)
+
+type instance Core.EraRule "RUPD" (ShelleyEra c) = RUPD (ShelleyEra c)
+
+type instance Core.EraRule "SNAP" (ShelleyEra c) = SNAP (ShelleyEra c)
+
+type instance Core.EraRule "TICK" (ShelleyEra c) = TICK (ShelleyEra c)
+
+type instance Core.EraRule "TICKF" (ShelleyEra c) = TICKF (ShelleyEra c)
+
+type instance Core.EraRule "TICKN" (ShelleyEra c) = TICKN
+
+type instance Core.EraRule "UTXO" (ShelleyEra c) = UTXO (ShelleyEra c)
+
+type instance Core.EraRule "UTXOW" (ShelleyEra c) = UTXOW (ShelleyEra c)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -19,6 +20,7 @@ module Shelley.Spec.Ledger.STS.Ledgers
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era
 import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Monad (foldM)
@@ -38,6 +40,7 @@ import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 import Shelley.Spec.Ledger.Keys (DSignable, Hash)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
+    DPState,
     LedgerState (..),
     UTxOState,
     emptyLedgerState,
@@ -45,7 +48,7 @@ import Shelley.Spec.Ledger.LedgerState
     _utxoState,
   )
 import Shelley.Spec.Ledger.PParams (PParams)
-import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..), LedgerPredicateFailure)
 import Shelley.Spec.Ledger.STS.Utxo
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx)
@@ -60,30 +63,30 @@ data LedgersEnv era = LedgersEnv
   }
 
 data LedgersPredicateFailure era
-  = LedgerFailure (PredicateFailure (LEDGER era)) -- Subtransition Failures
+  = LedgerFailure (PredicateFailure (Core.EraRule "LEDGER" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
   ( ShelleyBased era,
-    Show (PredicateFailure (LEDGER era))
+    Show (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   Show (LedgersPredicateFailure era)
 
 deriving stock instance
   ( ShelleyBased era,
-    Eq (PredicateFailure (LEDGER era))
+    Eq (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   Eq (LedgersPredicateFailure era)
 
 instance
   ( ShelleyBased era,
-    NoThunks (PredicateFailure (LEDGER era))
+    NoThunks (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   NoThunks (LedgersPredicateFailure era)
 
 instance
   ( ShelleyBased era,
-    ToCBOR (PredicateFailure (LEDGER era))
+    ToCBOR (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   ToCBOR (LedgersPredicateFailure era)
   where
@@ -91,7 +94,7 @@ instance
 
 instance
   ( ShelleyBased era,
-    FromCBOR (PredicateFailure (LEDGER era))
+    FromCBOR (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   FromCBOR (LedgersPredicateFailure era)
   where
@@ -100,7 +103,10 @@ instance
 instance
   ( Era era,
     ShelleyBased era,
-    Embed (LEDGER era) (LEDGERS era),
+    Embed (Core.EraRule "LEDGER" era) (LEDGERS era),
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    State (Core.EraRule "LEDGER" era) ~ (UTxOState era, DPState (Crypto era)),
+    Signal (Core.EraRule "LEDGER" era) ~ Tx era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody)
   ) =>
   STS (LEDGERS era)
@@ -116,7 +122,10 @@ instance
 
 ledgersTransition ::
   forall era.
-  ( Embed (LEDGER era) (LEDGERS era)
+  ( Embed (Core.EraRule "LEDGER" era) (LEDGERS era),
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    State (Core.EraRule "LEDGER" era) ~ (UTxOState era, DPState (Crypto era)),
+    Signal (Core.EraRule "LEDGER" era) ~ Tx era
   ) =>
   TransitionRule (LEDGERS era)
 ledgersTransition = do
@@ -125,7 +134,7 @@ ledgersTransition = do
   (u'', dp'') <-
     foldM
       ( \(u', dp') (ix, tx) ->
-          trans @(LEDGER era) $
+          trans @(Core.EraRule "LEDGER" era) $
             TRC (LedgerEnv slot ix pp account, (u', dp'), tx)
       )
       (u, dp)
@@ -137,10 +146,7 @@ ledgersTransition = do
 instance
   ( Era era,
     STS (LEDGER era),
-    ShelleyBased era,
-    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
-    Environment (UTXO era) ~ UtxoEnv era,
-    State (UTXO era) ~ UTxOState era
+    PredicateFailure (Core.EraRule "LEDGER" era) ~ LedgerPredicateFailure era
   ) =>
   Embed (LEDGER era) (LEDGERS era)
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -19,6 +20,7 @@ module Shelley.Spec.Ledger.STS.NewEpoch
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import qualified Cardano.Ledger.Val as Val
@@ -41,21 +43,44 @@ import Shelley.Spec.Ledger.TxBody
 data NEWEPOCH era
 
 data NewEpochPredicateFailure era
-  = EpochFailure (PredicateFailure (EPOCH era)) -- Subtransition Failures
+  = EpochFailure (PredicateFailure (Core.EraRule "EPOCH" era)) -- Subtransition Failures
   | CorruptRewardUpdate
       !(RewardUpdate (Crypto era)) -- The reward update which violates an invariant
-  | MirFailure (PredicateFailure (MIR era)) -- Subtransition Failures
+  | MirFailure (PredicateFailure (Core.EraRule "MIR" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
+  ( Show (PredicateFailure (Core.EraRule "EPOCH" era)),
+    Show (PredicateFailure (Core.EraRule "MIR" era))
+  ) =>
   Show (NewEpochPredicateFailure era)
 
 deriving stock instance
+  ( Eq (PredicateFailure (Core.EraRule "EPOCH" era)),
+    Eq (PredicateFailure (Core.EraRule "MIR" era))
+  ) =>
   Eq (NewEpochPredicateFailure era)
 
-instance NoThunks (NewEpochPredicateFailure era)
+instance
+  ( NoThunks (PredicateFailure (Core.EraRule "EPOCH" era)),
+    NoThunks (PredicateFailure (Core.EraRule "MIR" era))
+  ) =>
+  NoThunks (NewEpochPredicateFailure era)
 
-instance (UsesTxOut era, UsesValue era) => STS (NEWEPOCH era) where
+instance
+  ( UsesTxOut era,
+    UsesValue era,
+    Embed (Core.EraRule "MIR" era) (NEWEPOCH era),
+    Embed (Core.EraRule "EPOCH" era) (NEWEPOCH era),
+    Environment (Core.EraRule "MIR" era) ~ (),
+    State (Core.EraRule "MIR" era) ~ EpochState era,
+    Signal (Core.EraRule "MIR" era) ~ (),
+    Environment (Core.EraRule "EPOCH" era) ~ (),
+    State (Core.EraRule "EPOCH" era) ~ EpochState era,
+    Signal (Core.EraRule "EPOCH" era) ~ EpochNo
+  ) =>
+  STS (NEWEPOCH era)
+  where
   type State (NEWEPOCH era) = NewEpochState era
 
   type Signal (NEWEPOCH era) = EpochNo
@@ -80,8 +105,14 @@ instance (UsesTxOut era, UsesValue era) => STS (NEWEPOCH era) where
 
 newEpochTransition ::
   forall era.
-  ( UsesTxOut era,
-    UsesValue era
+  ( Embed (Core.EraRule "MIR" era) (NEWEPOCH era),
+    Embed (Core.EraRule "EPOCH" era) (NEWEPOCH era),
+    Environment (Core.EraRule "MIR" era) ~ (),
+    State (Core.EraRule "MIR" era) ~ EpochState era,
+    Signal (Core.EraRule "MIR" era) ~ (),
+    Environment (Core.EraRule "EPOCH" era) ~ (),
+    State (Core.EraRule "EPOCH" era) ~ EpochState era,
+    Signal (Core.EraRule "EPOCH" era) ~ EpochNo
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
@@ -101,8 +132,8 @@ newEpochTransition = do
           Val.isZero (dt <> (dr <> (toDeltaCoin $ fold rs_) <> df)) ?! CorruptRewardUpdate ru'
           pure $ applyRUpd ru' es
 
-      es'' <- trans @(MIR era) $ TRC ((), es', ())
-      es''' <- trans @(EPOCH era) $ TRC ((), es'', e)
+      es'' <- trans @(Core.EraRule "MIR" era) $ TRC ((), es', ())
+      es''' <- trans @(Core.EraRule "EPOCH" era) $ TRC ((), es'', e)
       let EpochState _acnt ss _ls _pr _ _ = es'''
           pd' = calculatePoolDistr (_pstakeSet ss)
       pure $
@@ -128,13 +159,19 @@ calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
    in PoolDistr $ Map.intersectionWith IndividualPoolStake sd (Map.map _poolVrf poolParams)
 
 instance
-  (UsesTxOut era, UsesValue era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    STS (EPOCH era),
+    PredicateFailure (Core.EraRule "EPOCH" era) ~ EpochPredicateFailure era
+  ) =>
   Embed (EPOCH era) (NEWEPOCH era)
   where
   wrapFailed = EpochFailure
 
 instance
-  Era era =>
+  ( Era era,
+    PredicateFailure (Core.EraRule "MIR" era) ~ MirPredicateFailure era
+  ) =>
   Embed (MIR era) (NEWEPOCH era)
   where
   wrapFailed = MirFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -22,7 +22,8 @@ module Shelley.Spec.Ledger.STS.Tick
   )
 where
 
-import Cardano.Ledger.Era (Era)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
@@ -30,7 +31,7 @@ import Control.State.Transition
 import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe, epochInfo)
 import Shelley.Spec.Ledger.Keys (GenDelegs (..))
 import Shelley.Spec.Ledger.LedgerState
   ( DPState (..),
@@ -39,29 +40,51 @@ import Shelley.Spec.Ledger.LedgerState
     FutureGenDeleg (..),
     LedgerState (..),
     NewEpochState (..),
+    RewardUpdate,
   )
-import Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
-import Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..))
-import Shelley.Spec.Ledger.Slot (SlotNo, epochInfoEpoch)
+import Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH, NewEpochPredicateFailure)
+import Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..), RupdPredicateFailure)
+import Shelley.Spec.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
 
 -- ==================================================
 
 data TICK era
 
 data TickPredicateFailure era
-  = NewEpochFailure (PredicateFailure (NEWEPOCH era)) -- Subtransition Failures
-  | RupdFailure (PredicateFailure (RUPD era)) -- Subtransition Failures
+  = NewEpochFailure (PredicateFailure (Core.EraRule "NEWEPOCH" era)) -- Subtransition Failures
+  | RupdFailure (PredicateFailure (Core.EraRule "RUPD" era)) -- Subtransition Failures
   deriving (Generic)
 
-deriving stock instance Show (TickPredicateFailure era)
+deriving stock instance
+  ( Show (PredicateFailure (Core.EraRule "NEWEPOCH" era)),
+    Show (PredicateFailure (Core.EraRule "RUPD" era))
+  ) =>
+  Show (TickPredicateFailure era)
 
-deriving stock instance Eq (TickPredicateFailure era)
-
-instance NoThunks (TickPredicateFailure era)
+deriving stock instance
+  ( Eq (PredicateFailure (Core.EraRule "NEWEPOCH" era)),
+    Eq (PredicateFailure (Core.EraRule "RUPD" era))
+  ) =>
+  Eq (TickPredicateFailure era)
 
 instance
-  ( UsesTxOut era,
-    UsesValue era
+  ( NoThunks (PredicateFailure (Core.EraRule "NEWEPOCH" era)),
+    NoThunks (PredicateFailure (Core.EraRule "RUPD" era))
+  ) =>
+  NoThunks (TickPredicateFailure era)
+
+instance
+  ( Era era,
+    Embed (Core.EraRule "NEWEPOCH" era) (TICK era),
+    Embed (Core.EraRule "RUPD" era) (TICK era),
+    State (TICK era) ~ NewEpochState era,
+    BaseM (TICK era) ~ ShelleyBase,
+    Environment (Core.EraRule "RUPD" era) ~ RupdEnv era,
+    State (Core.EraRule "RUPD" era) ~ StrictMaybe (RewardUpdate (Crypto era)),
+    Signal (Core.EraRule "RUPD" era) ~ SlotNo,
+    Environment (Core.EraRule "NEWEPOCH" era) ~ (),
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
   ) =>
   STS (TICK era)
   where
@@ -111,10 +134,13 @@ adoptGenesisDelegs es slot = es'
 -- future ledger view.
 validatingTickTransition ::
   forall tick era.
-  ( Embed (NEWEPOCH era) (tick era),
+  ( Embed (Core.EraRule "NEWEPOCH" era) (tick era),
     STS (tick era),
     State (tick era) ~ NewEpochState era,
-    BaseM (tick era) ~ ShelleyBase
+    BaseM (tick era) ~ ShelleyBase,
+    Environment (Core.EraRule "NEWEPOCH" era) ~ (),
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
   ) =>
   NewEpochState era ->
   SlotNo ->
@@ -124,36 +150,53 @@ validatingTickTransition nes slot = do
     ei <- asks epochInfo
     epochInfoEpoch ei slot
 
-  nes' <- trans @(NEWEPOCH era) $ TRC ((), nes, epoch)
+  nes' <- trans @(Core.EraRule "NEWEPOCH" era) $ TRC ((), nes, epoch)
   let es'' = adoptGenesisDelegs (nesEs nes') slot
 
   pure $ nes' {nesEs = es''}
 
 bheadTransition ::
   forall era.
-  ( UsesTxOut era,
-    UsesValue era
+  ( Embed (Core.EraRule "NEWEPOCH" era) (TICK era),
+    Embed (Core.EraRule "RUPD" era) (TICK era),
+    STS (TICK era),
+    State (TICK era) ~ NewEpochState era,
+    BaseM (TICK era) ~ ShelleyBase,
+    Environment (Core.EraRule "RUPD" era) ~ RupdEnv era,
+    State (Core.EraRule "RUPD" era) ~ StrictMaybe (RewardUpdate (Crypto era)),
+    Signal (Core.EraRule "RUPD" era) ~ SlotNo,
+    Environment (Core.EraRule "NEWEPOCH" era) ~ (),
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do
   TRC ((), nes@(NewEpochState _ bprev _ es _ _), slot) <-
     judgmentContext
 
-  nes' <- validatingTickTransition nes slot
+  nes' <- validatingTickTransition @TICK nes slot
 
-  ru'' <- trans @(RUPD era) $ TRC (RupdEnv bprev es, nesRu nes', slot)
+  ru'' <-
+    trans @(Core.EraRule "RUPD" era) $
+      TRC (RupdEnv bprev es, nesRu nes', slot)
 
   let nes'' = nes' {nesRu = ru''}
   pure nes''
 
 instance
-  (UsesTxOut era, UsesValue era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    STS (NEWEPOCH era),
+    PredicateFailure (Core.EraRule "NEWEPOCH" era) ~ NewEpochPredicateFailure era
+  ) =>
   Embed (NEWEPOCH era) (TICK era)
   where
   wrapFailed = NewEpochFailure
 
 instance
-  (Era era) =>
+  ( Era era,
+    PredicateFailure (Core.EraRule "RUPD" era) ~ RupdPredicateFailure era
+  ) =>
   Embed (RUPD era) (TICK era)
   where
   wrapFailed = RupdFailure
@@ -167,14 +210,36 @@ to tick the ledger state to a future slot.
 
 data TICKF era
 
-data TickfPredicateFailure era
-  = TickfNewEpochFailure (PredicateFailure (NEWEPOCH era)) -- Subtransition Failures
-  deriving (Show, Generic, Eq)
+newtype TickfPredicateFailure era
+  = TickfNewEpochFailure (PredicateFailure (Core.EraRule "NEWEPOCH" era)) -- Subtransition Failures
+  deriving (Generic)
 
-instance NoThunks (TickfPredicateFailure era)
+deriving stock instance
+  ( Era era,
+    Show (PredicateFailure (Core.EraRule "NEWEPOCH" era))
+  ) =>
+  Show (TickfPredicateFailure era)
+
+deriving stock instance
+  ( Era era,
+    Eq (PredicateFailure (Core.EraRule "NEWEPOCH" era))
+  ) =>
+  Eq (TickfPredicateFailure era)
 
 instance
-  (UsesTxOut era, UsesValue era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    NoThunks (PredicateFailure (Core.EraRule "NEWEPOCH" era))
+  ) =>
+  NoThunks (TickfPredicateFailure era)
+
+instance
+  ( Era era,
+    Embed (Core.EraRule "NEWEPOCH" era) (TICKF era),
+    Environment (Core.EraRule "NEWEPOCH" era) ~ (),
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
+  ) =>
   STS (TICKF era)
   where
   type
@@ -195,7 +260,12 @@ instance
     ]
 
 instance
-  (UsesTxOut era, UsesValue era) =>
+  ( UsesTxOut era,
+    UsesValue era,
+    STS (NEWEPOCH era),
+    PredicateFailure (Core.EraRule "NEWEPOCH" era)
+      ~ NewEpochPredicateFailure era
+  ) =>
   Embed (NEWEPOCH era) (TICKF era)
   where
   wrapFailed = TickfNewEpochFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -28,9 +28,7 @@ import Cardano.Binary
     encodeListLen,
   )
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints
   ( TransValue,
     UsesAuxiliary,
@@ -85,7 +83,8 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState
-  ( TransUTxOState,
+  ( PPUPState,
+    TransUTxOState,
     UTxOState (..),
     consumed,
     emptyPPUPState,
@@ -95,7 +94,7 @@ import Shelley.Spec.Ledger.LedgerState
     txsize,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), Update)
-import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..))
+import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
 import Shelley.Spec.Ledger.Serialization
   ( decodeList,
     decodeRecordSum,
@@ -119,8 +118,6 @@ import Shelley.Spec.Ledger.UTxO
     txouts,
     txup,
   )
-
--- =======================================
 
 data UTXO era
 
@@ -156,25 +153,35 @@ data UtxoPredicateFailure era
       !(Set (RewardAcnt (Crypto era))) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
       ![Core.TxOut era] -- list of supplied transaction outputs that are too small
-  | UpdateFailure (PredicateFailure (PPUP era)) -- Subtransition Failures
+  | UpdateFailure (PredicateFailure (Core.EraRule "PPUP" era)) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
       ![Core.TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
 
 deriving stock instance
-  (TransUTxOState Show era) =>
+  ( UsesValue era,
+    TransUTxOState Show era,
+    Show (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   Show (UtxoPredicateFailure era)
 
 deriving stock instance
-  (TransUTxOState Eq era, TransValue Eq era) =>
+  ( TransUTxOState Eq era,
+    TransValue Eq era,
+    Eq (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   Eq (UtxoPredicateFailure era)
 
 instance
-  (TransUTxOState NoThunks era) =>
+  ( TransUTxOState NoThunks era,
+    NoThunks (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   NoThunks (UtxoPredicateFailure era)
 
 instance
-  (TransUTxOState ToCBOR era) =>
+  ( TransUTxOState ToCBOR era,
+    ToCBOR (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
   ToCBOR (UtxoPredicateFailure era)
   where
   toCBOR = \case
@@ -219,7 +226,8 @@ instance
   ( TransValue FromCBOR era,
     TransUTxOState FromCBOR era,
     Val.DecodeNonNegative (Core.Value era),
-    Show (Core.Value era)
+    Show (Core.Value era),
+    FromCBOR (PredicateFailure (Core.EraRule "PPUP" era))
   ) =>
   FromCBOR (UtxoPredicateFailure era)
   where
@@ -266,17 +274,25 @@ instance
         k -> invalidKey k
 
 instance
-  ( CryptoClass.Crypto c,
-    Core.TxBody (ShelleyEra c) ~ TxBody (ShelleyEra c),
-    UsesTxOut (ShelleyEra c)
+  ( UsesTxOut era,
+    UsesValue era,
+    UsesScript era,
+    UsesAuxiliary era,
+    Core.TxBody era ~ TxBody era,
+    Core.Value era ~ Coin,
+    Eq (PredicateFailure (Core.EraRule "PPUP" era)),
+    Embed (Core.EraRule "PPUP" era) (UTXO era),
+    Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
+    State (Core.EraRule "PPUP" era) ~ PPUPState era,
+    Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era)
   ) =>
-  STS (UTXO (ShelleyEra c))
+  STS (UTXO era)
   where
-  type State (UTXO (ShelleyEra c)) = UTxOState (ShelleyEra c)
-  type Signal (UTXO (ShelleyEra c)) = Tx (ShelleyEra c)
-  type Environment (UTXO (ShelleyEra c)) = UtxoEnv (ShelleyEra c)
-  type BaseM (UTXO (ShelleyEra c)) = ShelleyBase
-  type PredicateFailure (UTXO (ShelleyEra c)) = UtxoPredicateFailure (ShelleyEra c)
+  type State (UTXO era) = UTxOState era
+  type Signal (UTXO era) = Tx era
+  type Environment (UTXO era) = UtxoEnv era
+  type BaseM (UTXO era) = ShelleyBase
+  type PredicateFailure (UTXO era) = UtxoPredicateFailure era
 
   transitionRules = [utxoInductive]
   initialRules = [initialLedgerState]
@@ -298,8 +314,8 @@ instance
       PostCondition
         "Deposit pot must not be negative (post)"
         (\_ st' -> _deposited st' >= mempty),
-      let utxoBalance us = (Val.inject $ _deposited us <> _fees us) <> balance (_utxo us)
-          withdrawals :: TxBody (ShelleyEra c) -> Core.Value (ShelleyEra c)
+      let utxoBalance us = Val.inject (_deposited us <> _fees us) <> balance (_utxo us)
+          withdrawals :: TxBody era -> Core.Value era
           withdrawals txb = Val.inject $ foldl' (<>) mempty $ unWdrl $ _wdrls txb
        in PostCondition
             "Should preserve value in the UTxO state"
@@ -308,35 +324,37 @@ instance
             )
     ]
 
-initialLedgerState :: InitialRule (UTXO (ShelleyEra c))
+initialLedgerState :: InitialRule (UTXO era)
 initialLedgerState = do
   IRC _ <- judgmentContext
   pure $ UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPUPState
 
 utxoInductive ::
-  forall era out.
-  ( UsesTxBody era,
-    UsesValue era,
-    UsesAuxiliary era,
+  forall era utxo.
+  ( UsesAuxiliary era,
     UsesScript era,
+    UsesTxBody era,
     UsesTxOut era,
-    STS (UTXO era),
-    Embed (PPUP era) (UTXO era),
-    BaseM (UTXO era) ~ ShelleyBase,
-    Environment (UTXO era) ~ UtxoEnv era,
-    State (UTXO era) ~ UTxOState era,
-    Signal (UTXO era) ~ Tx era,
-    Core.TxOut era ~ out,
-    PredicateFailure (UTXO era) ~ UtxoPredicateFailure era,
+    UsesValue era,
+    STS (utxo era),
+    Embed (Core.EraRule "PPUP" era) (utxo era),
+    BaseM (utxo era) ~ ShelleyBase,
+    Environment (utxo era) ~ UtxoEnv era,
+    State (utxo era) ~ UTxOState era,
+    Signal (utxo era) ~ Tx era,
+    PredicateFailure (utxo era) ~ UtxoPredicateFailure era,
+    Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
+    State (Core.EraRule "PPUP" era) ~ PPUPState era,
+    Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq out),
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "ttl" (Core.TxBody era) SlotNo,
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
-  TransitionRule (UTXO era)
+  TransitionRule (utxo era)
 utxoInductive = do
   TRC (UtxoEnv slot pp stakepools genDelegs, u, tx) <- judgmentContext
   let UTxOState utxo deposits' fees ppup = u
@@ -372,7 +390,7 @@ utxoInductive = do
   consumed_ == produced_ ?! ValueNotConservedUTxO (toDelta consumed_) (toDelta produced_)
 
   -- process Protocol Parameter Update Proposals
-  ppup' <- trans @(PPUP era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
+  ppup' <- trans @(Core.EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
   let outputs = Map.elems $ unUTxO (txouts txb)
       minUTxOValue = _minUTxOValue pp
@@ -411,12 +429,14 @@ utxoInductive = do
     UTxOState
       { _utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts txb),
         _deposited = deposits' <> depositChange,
-        _fees = fees <> (getField @"txfee" txb),
+        _fees = fees <> getField @"txfee" txb,
         _ppups = ppup'
       }
 
 instance
-  (CryptoClass.Crypto c) =>
-  Embed (PPUP (ShelleyEra c)) (UTXO (ShelleyEra c))
+  ( Era era,
+    PredicateFailure (Core.EraRule "PPUP" era) ~ PpupPredicateFailure era
+  ) =>
+  Embed (PPUP era) (UTXO era)
   where
   wrapFailed = UpdateFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -32,16 +32,17 @@ import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash,
     ValidateAuxiliaryData (..),
   )
+import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints
   ( UsesAuxiliary,
     UsesScript,
     UsesTxBody,
     UsesTxOut,
+    UsesValue,
   )
+import Cardano.Ledger.Torsor (Torsor (Delta))
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -99,7 +100,7 @@ import Shelley.Spec.Ledger.LedgerState
     witsVKeyNeeded,
   )
 import Shelley.Spec.Ledger.PParams (Update)
-import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv (..))
+import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv (..), UtxoPredicateFailure)
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
 import Shelley.Spec.Ledger.Serialization
   ( decodeList,
@@ -108,18 +109,10 @@ import Shelley.Spec.Ledger.Serialization
     encodeFoldable,
   )
 import qualified Shelley.Spec.Ledger.SoftForks as SoftForks
-import Shelley.Spec.Ledger.Tx
-  ( Tx (..),
-    ValidateScript,
-    hashScript,
-    txwitsScript,
-    validateScript,
-  )
+import Shelley.Spec.Ledger.Tx (Tx (..), ValidateScript, hashScript, txwitsScript, validateScript)
 import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody, TxIn, Wdrl)
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import qualified Shelley.Spec.Ledger.UTxO as UTxO
-
--- =================================================
 
 data UTXOW era
 
@@ -133,7 +126,7 @@ data UtxowPredicateFailure era
       !(Set (ScriptHash (Crypto era))) -- missing scripts
   | ScriptWitnessNotValidatingUTXOW
       !(Set (ScriptHash (Crypto era))) -- failed scripts
-  | UtxoFailure (PredicateFailure (UTXO era))
+  | UtxoFailure (PredicateFailure (Core.EraRule "UTXO" era))
   | MIRInsufficientGenesisSigsUTXOW (Set (KeyHash 'Witness (Crypto era)))
   | MissingTxBodyMetadataHash
       !(AuxiliaryDataHash (Crypto era)) -- hash of the full metadata
@@ -147,35 +140,52 @@ data UtxowPredicateFailure era
   deriving (Generic)
 
 instance
-  ( NoThunks (PredicateFailure (UTXO era)),
+  ( NoThunks (PredicateFailure (Core.EraRule "UTXO" era)),
     Era era
   ) =>
   NoThunks (UtxowPredicateFailure era)
 
 deriving stock instance
-  ( Eq (PredicateFailure (UTXO era)),
+  ( Eq (PredicateFailure (Core.EraRule "UTXO" era)),
     Era era
   ) =>
   Eq (UtxowPredicateFailure era)
 
 deriving stock instance
-  ( Show (PredicateFailure (UTXO era)),
+  ( Show (PredicateFailure (Core.EraRule "UTXO" era)),
     Era era
   ) =>
   Show (UtxowPredicateFailure era)
 
 instance
-  ( CryptoClass.Crypto c,
-    DSignable c (Hash c EraIndependentTxBody),
-    UsesTxOut (ShelleyEra c)
+  ( UsesTxOut era,
+    UsesValue era,
+    UsesScript era,
+    UsesAuxiliary era,
+    UsesTxBody era,
+    ChainData (Delta (Core.Value era)),
+    SerialisableData (Delta (Core.Value era)),
+    ValidateScript era,
+    ValidateAuxiliaryData era,
+    Embed (Core.EraRule "UTXO" era) (UTXOW era),
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era,
+    Signal (Core.EraRule "UTXO" era) ~ Tx era,
+    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "adHash" (Core.TxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era))),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
-  STS (UTXOW (ShelleyEra c))
+  STS (UTXOW era)
   where
-  type State (UTXOW (ShelleyEra c)) = UTxOState (ShelleyEra c)
-  type Signal (UTXOW (ShelleyEra c)) = Tx (ShelleyEra c)
-  type Environment (UTXOW (ShelleyEra c)) = UtxoEnv (ShelleyEra c)
-  type BaseM (UTXOW (ShelleyEra c)) = ShelleyBase
-  type PredicateFailure (UTXOW (ShelleyEra c)) = UtxowPredicateFailure (ShelleyEra c)
+  type State (UTXOW era) = UTxOState era
+  type Signal (UTXOW era) = Tx era
+  type Environment (UTXOW era) = UtxoEnv era
+  type BaseM (UTXOW era) = ShelleyBase
+  type PredicateFailure (UTXOW era) = UtxowPredicateFailure era
   transitionRules = [utxoWitnessed UTxO.scriptsNeeded]
   initialRules = [initialLedgerStateUTXOW]
 
@@ -183,7 +193,7 @@ instance
   ( Era era,
     Typeable (Core.Script era),
     Typeable (Core.AuxiliaryData era),
-    ToCBOR (PredicateFailure (UTXO era))
+    ToCBOR (PredicateFailure (Core.EraRule "UTXO" era))
   ) =>
   ToCBOR (UtxowPredicateFailure era)
   where
@@ -215,7 +225,7 @@ instance
 
 instance
   ( Era era,
-    FromCBOR (PredicateFailure (UTXO era)),
+    FromCBOR (PredicateFailure (Core.EraRule "UTXO" era)),
     Typeable (Core.Script era),
     Typeable (Core.AuxiliaryData era)
   ) =>
@@ -256,36 +266,35 @@ instance
 
 initialLedgerStateUTXOW ::
   forall era.
-  ( Embed (UTXO era) (UTXOW era),
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
-    Environment (UTXO era) ~ UtxoEnv era,
-    State (UTXO era) ~ UTxOState era
+  ( Embed (Core.EraRule "UTXO" era) (UTXOW era),
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era
   ) =>
   InitialRule (UTXOW era)
 initialLedgerStateUTXOW = do
   IRC (UtxoEnv slots pp stakepools genDelegs) <- judgmentContext
-  trans @(UTXO era) $ IRC (UtxoEnv slots pp stakepools genDelegs)
+  trans @(Core.EraRule "UTXO" era) $ IRC (UtxoEnv slots pp stakepools genDelegs)
 
 utxoWitnessed ::
-  forall era.
-  ( UsesTxBody era,
-    UsesAuxiliary era,
+  forall era utxow.
+  ( UsesValue era,
     UsesScript era,
+    UsesAuxiliary era,
+    UsesTxBody era,
     UsesTxOut era,
     ValidateScript era,
     ValidateAuxiliaryData era,
-    STS (UTXOW era),
-    BaseM (UTXOW era) ~ ShelleyBase,
-    Embed (UTXO era) (UTXOW era),
+    STS (utxow era),
+    BaseM (utxow era) ~ ShelleyBase,
+    Embed (Core.EraRule "UTXO" era) (utxow era),
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
-    Environment (UTXO era) ~ UtxoEnv era,
-    State (UTXO era) ~ UTxOState era,
-    Signal (UTXO era) ~ Tx era,
-    Environment (UTXOW era) ~ UtxoEnv era,
-    State (UTXOW era) ~ UTxOState era,
-    Signal (UTXOW era) ~ Tx era,
-    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era,
+    Signal (Core.EraRule "UTXO" era) ~ Tx era,
+    Environment (utxow era) ~ UtxoEnv era,
+    State (utxow era) ~ UTxOState era,
+    Signal (utxow era) ~ Tx era,
+    PredicateFailure (utxow era) ~ UtxowPredicateFailure era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
@@ -293,7 +302,7 @@ utxoWitnessed ::
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
   ) =>
   (UTxO era -> Tx era -> Set (ScriptHash (Crypto era))) ->
-  TransitionRule (UTXOW era)
+  TransitionRule (utxow era)
 utxoWitnessed scriptsNeeded =
   judgmentContext
     >>= \(TRC (UtxoEnv slot pp stakepools genDelegs, u, tx@(Tx txbody wits md))) -> do
@@ -361,11 +370,14 @@ utxoWitnessed scriptsNeeded =
         )
         ?! MIRInsufficientGenesisSigsUTXOW genSig
 
-      trans @(UTXO era) $
+      trans @(Core.EraRule "UTXO" era) $
         TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
 
 instance
-  (UsesTxOut (ShelleyEra c), CryptoClass.Crypto c) =>
-  Embed (UTXO (ShelleyEra c)) (UTXOW (ShelleyEra c))
+  ( Era era,
+    STS (UTXO era),
+    PredicateFailure (Core.EraRule "UTXO" era) ~ UtxoPredicateFailure era
+  ) =>
+  Embed (UTXO era) (UTXOW era)
   where
   wrapFailed = UtxoFailure

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -11,16 +12,22 @@ module Shelley.Spec.Ledger.Bench.Gen
 where
 
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.State.Transition.Extended
+import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Data.Either (fromRight)
 import Data.Proxy
 import Shelley.Spec.Ledger.API
   ( ApplyBlock,
     Block,
     ChainState (..),
+    DCert,
+    DPState,
+    DelplEnv,
     GetLedgerView,
+    LEDGERS,
     Tx,
   )
 import Shelley.Spec.Ledger.LedgerState
@@ -43,6 +50,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
+import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (CERTS)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest)
@@ -78,7 +86,6 @@ genBlock ::
     ShelleyTest era,
     ShelleyLedgerSTS era,
     GetLedgerView era,
-    ValidateAuxiliaryData era,
     Core.EraRule "LEDGERS" era ~ LEDGERS era,
     QC.HasTrace (LEDGERS era) (GenEnv era),
     ApplyBlock era
@@ -100,8 +107,10 @@ genTriple ::
   ( EraGen era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
-    Core.EraRule "LEDGERS" era ~ LEDGERS era,
-    QC.HasTrace (LEDGERS era) (GenEnv era),
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     ShelleyTest era
   ) =>
   Proxy era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -79,6 +79,8 @@ genBlock ::
     ShelleyLedgerSTS era,
     GetLedgerView era,
     ValidateAuxiliaryData era,
+    Core.EraRule "LEDGERS" era ~ LEDGERS era,
+    QC.HasTrace (LEDGERS era) (GenEnv era),
     ApplyBlock era
   ) =>
   GenEnv era ->
@@ -98,6 +100,8 @@ genTriple ::
   ( EraGen era,
     Mock (Crypto era),
     ValidateAuxiliaryData era,
+    Core.EraRule "LEDGERS" era ~ LEDGERS era,
+    QC.HasTrace (LEDGERS era) (GenEnv era),
     ShelleyTest era
   ) =>
   Proxy era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -237,6 +237,7 @@ benchmark mainbench
     shelley-spec-ledger-test,
     shelley-spec-ledger,
     small-steps,
+    small-steps-test,
     transformers
   ghc-options:
       -threaded

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -56,7 +56,8 @@ class
   ( UsesScript era,
     ValidateScript era,
     Split (Core.Value era),
-    ScriptClass era
+    ScriptClass era,
+    Show (Core.Script era)
   ) =>
   EraGen era
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -10,8 +10,12 @@
 
 module Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen (genCoin) where
 
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import qualified Cardano.Crypto.KES as KES
+import Cardano.Crypto.Util (SignableRepresentation)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (DSIGN, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -21,9 +25,11 @@ import Data.Set (Set)
 import Shelley.Spec.Ledger.API
   ( Coin (..),
     DCert,
+    PraosCrypto,
     Update,
   )
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.STS.EraMapping ()
 import Shelley.Spec.Ledger.Scripts (MultiSig (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx
@@ -44,14 +50,25 @@ import Test.Shelley.Spec.Ledger.Generator.ScriptClass
   ( Quantifier (..),
     ScriptClass (..),
   )
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain ()
 
 {------------------------------------------------------------------------------
   ShelleyEra instances for EraGen and ScriptClass
  -----------------------------------------------------------------------------}
 
-instance CC.Crypto c => EraGen (ShelleyEra c) where
-  genGenesisValue (GenEnv _keySpace Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
-    genCoin minGenesisOutputVal maxGenesisOutputVal
+instance
+  ( PraosCrypto c,
+    DSIGN.Signable (DSIGN c) ~ SignableRepresentation,
+    KES.Signable (KES c) ~ SignableRepresentation
+  ) =>
+  EraGen (ShelleyEra c)
+  where
+  genGenesisValue
+    ( GenEnv
+        _keySpace
+        Constants {minGenesisOutputVal, maxGenesisOutputVal}
+      ) =
+      genCoin minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody _ge = genTxBody
   genEraAuxiliaryData = genMetadata
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -7,12 +8,17 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts) where
+module Test.Shelley.Spec.Ledger.Generator.Trace.DCert
+  ( CERTS,
+    genDCerts,
+  )
+where
 
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
@@ -62,6 +68,7 @@ import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Delegation.Certificates (isDeRegKey)
 import Shelley.Spec.Ledger.Keys (HasKeyRole (coerceKeyRole), asWitness)
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
+import Shelley.Spec.Ledger.STS.Delpl (DelplPredicateFailure)
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.TxBody (Ix)
 import Shelley.Spec.Ledger.UTxO (totalDeposits)
@@ -77,11 +84,29 @@ import Test.Shelley.Spec.Ledger.Utils (testGlobals)
 -- witnesses.
 data CERTS era
 
-data CertsPredicateFailure era
-  = CertsFailure (PredicateFailure (DELPL era))
-  deriving (Show, Eq, Generic)
+newtype CertsPredicateFailure era
+  = CertsFailure (PredicateFailure (Core.EraRule "DELPL" era))
+  deriving (Generic)
 
-instance Era era => STS (CERTS era) where
+deriving stock instance
+  ( Eq (PredicateFailure (Core.EraRule "DELPL" era))
+  ) =>
+  Eq (CertsPredicateFailure era)
+
+deriving stock instance
+  ( Show (PredicateFailure (Core.EraRule "DELPL" era))
+  ) =>
+  Show (CertsPredicateFailure era)
+
+instance
+  ( Era era,
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+  ) =>
+  STS (CERTS era)
+  where
   type Environment (CERTS era) = (SlotNo, Ix, PParams era, AccountState)
   type State (CERTS era) = (DPState (Crypto era), Ix)
   type Signal (CERTS era) = Maybe (DCert (Crypto era), CertCred era)
@@ -92,7 +117,14 @@ instance Era era => STS (CERTS era) where
   initialRules = []
   transitionRules = [certsTransition]
 
-certsTransition :: forall era. Era era => TransitionRule (CERTS era)
+certsTransition ::
+  forall era.
+  ( Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+  ) =>
+  TransitionRule (CERTS era)
 certsTransition = do
   TRC
     ( (slot, txIx, pp, acnt),
@@ -104,16 +136,33 @@ certsTransition = do
   case c of
     Just (cert, _wits) -> do
       let ptr = Ptr slot txIx nextCertIx
-      dpState' <- trans @(DELPL era) $ TRC (DelplEnv slot ptr pp acnt, dpState, cert)
+      dpState' <-
+        trans @(Core.EraRule "DELPL" era) $
+          TRC (DelplEnv slot ptr pp acnt, dpState, cert)
 
       pure (dpState', nextCertIx + 1)
     Nothing ->
       pure (dpState, nextCertIx)
 
-instance Era era => Embed (DELPL era) (CERTS era) where
+instance
+  ( Era era,
+    STS (DELPL era),
+    PredicateFailure (Core.EraRule "DELPL" era) ~ DelplPredicateFailure era
+  ) =>
+  Embed (DELPL era) (CERTS era)
+  where
   wrapFailed = CertsFailure
 
-instance (Era era, EraGen era) => QC.HasTrace (CERTS era) (GenEnv era) where
+instance
+  ( Era era,
+    EraGen era,
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+  ) =>
+  QC.HasTrace (CERTS era) (GenEnv era)
+  where
   envGen _ = error "HasTrace CERTS - envGen not required"
 
   sigGen
@@ -140,7 +189,12 @@ instance (Era era, EraGen era) => QC.HasTrace (CERTS era) (GenEnv era) where
 -- deposits and refunds required.
 genDCerts ::
   forall era.
-  EraGen era =>
+  ( Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    EraGen era
+  ) =>
   GenEnv era ->
   PParams era ->
   DPState (Crypto era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -16,21 +16,23 @@
 
 module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints
-  ( UsesAuxiliary,
-    UsesTxBody,
+  ( TransValue,
+    UsesAuxiliary,
     UsesTxBody,
     UsesTxOut,
-    UsesValue
+    UsesValue,
   )
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (runReaderT)
-import Control.State.Transition.Extended (IRC, TRC (..))
+import Control.State.Transition
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as TQC
 import Data.Functor.Identity (runIdentity)
+import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -43,11 +45,14 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState,
     genesisState,
   )
+import Shelley.Spec.Ledger.STS.Delegs (DelegsEnv)
+import Shelley.Spec.Ledger.STS.Delpl (DELPL, DelplEnv, DelplPredicateFailure)
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS, LedgersEnv (..))
+import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx)
-import Shelley.Spec.Ledger.TxBody (Ix, TxIn)
+import Shelley.Spec.Ledger.TxBody (DCert, Ix, TxIn)
 import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
@@ -57,6 +62,7 @@ import Test.Shelley.Spec.Ledger.Generator.EraGen
     genUtxo0,
   )
 import Test.Shelley.Spec.Ledger.Generator.Presets (genesisDelegs0)
+import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (CERTS)
 import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Utils
@@ -84,8 +90,23 @@ instance
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
+    TransValue ToCBOR era,
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    PredicateFailure (Core.EraRule "DELPL" era) ~ DelplPredicateFailure era,
+    Embed (Core.EraRule "DELEGS" era) (LEDGER era),
+    Embed (Core.EraRule "UTXOW" era) (LEDGER era),
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXOW" era) ~ UTxOState era,
+    Signal (Core.EraRule "UTXOW" era) ~ Tx era,
+    Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
+    State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   TQC.HasTrace (LEDGER era) (GenEnv era)
   where
@@ -112,6 +133,13 @@ instance
     Mock (Crypto era),
     ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    PredicateFailure (Core.EraRule "DELPL" era) ~ DelplPredicateFailure era,
+    Embed (Core.EraRule "DELEG" era) (DELPL era),
+    Embed (Core.EraRule "LEDGER" era) (LEDGERS era),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
@@ -145,7 +173,7 @@ instance
 
           let res =
                 runShelleyBase $
-                  applySTSTest @(LEDGER era)
+                  applySTSTest @(Core.EraRule "LEDGER" era)
                     (TRC (ledgerEnv, (u, dp), tx))
           pure $ case res of
             Left pf ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Shelley.Constraints
 import Cardano.Ledger.Val (Val (..), sumVal, (<+>), (<->), (<×>))
 import Control.Monad (when)
 import Control.SetAlgebra (forwards)
+import Control.State.Transition
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Either as Either (partitionEithers)
 import Data.List (foldl', nub)
@@ -83,6 +84,7 @@ import Shelley.Spec.Ledger.LedgerState
     _rewards,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
+import Shelley.Spec.Ledger.STS.Delpl (DelplEnv)
 import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
 import Shelley.Spec.Ledger.Tx
   ( Tx (..),
@@ -114,7 +116,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
   )
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen (..))
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass (scriptKeyCombination)
-import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
+import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (CERTS, genDCerts)
 import Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, Split (..))
 
@@ -171,6 +173,10 @@ genTx ::
     UsesAuxiliary era,
     ValidateAuxiliaryData era,
     Mock (Crypto era),
+    Embed (Core.EraRule "DELPL" era) (CERTS era),
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
+    State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -115,16 +115,7 @@ import qualified Shelley.Spec.Ledger.STS.Prtcl as STS (PrtclState)
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS
 import qualified Shelley.Spec.Ledger.STS.Utxow as STS
 import Shelley.Spec.Ledger.Tx (ValidateScript, WitnessSetHKD (WitnessSet), hashScript)
-import Test.QuickCheck
-  ( Arbitrary,
-    arbitrary,
-    genericShrink,
-    listOf,
-    oneof,
-    resize,
-    shrink,
-    vectorOf,
-  )
+import Test.QuickCheck (Arbitrary, arbitrary, genericShrink, listOf, oneof, recursivelyShrink, resize, shrink, vectorOf)
 import Test.QuickCheck.Gen (chooseAny)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (defaultConstants)
@@ -688,11 +679,15 @@ instance Era era => Arbitrary (STS.PoolPredicateFailure era) where
   shrink = genericShrink
 
 instance
-  (Era era, Mock (Crypto era)) =>
+  ( Era era,
+    Mock (Crypto era),
+    Arbitrary (STS.PredicateFailure (Core.EraRule "POOL" era)),
+    Arbitrary (STS.PredicateFailure (Core.EraRule "DELEG" era))
+  ) =>
   Arbitrary (STS.DelplPredicateFailure era)
   where
   arbitrary = genericArbitraryU
-  shrink = genericShrink
+  shrink = recursivelyShrink
 
 instance
   (Era era, Mock (Crypto era)) =>
@@ -702,15 +697,18 @@ instance
   shrink = genericShrink
 
 instance
-  (Era era, Mock (Crypto era)) =>
+  ( Era era,
+    Mock (Crypto era),
+    Arbitrary (STS.PredicateFailure (Core.EraRule "DELPL" era))
+  ) =>
   Arbitrary (STS.DelegsPredicateFailure era)
   where
   arbitrary = genericArbitraryU
-  shrink = genericShrink
+  shrink = recursivelyShrink
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (LEDGER era))
+    Arbitrary (STS.PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   Arbitrary (STS.LedgersPredicateFailure era)
   where
@@ -719,8 +717,8 @@ instance
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (DELEGS era)),
-    Arbitrary (STS.PredicateFailure (UTXOW era))
+    Arbitrary (STS.PredicateFailure (Core.EraRule "DELEGS" era)),
+    Arbitrary (STS.PredicateFailure (Core.EraRule "UTXOW" era))
   ) =>
   Arbitrary (STS.LedgerPredicateFailure era)
   where
@@ -729,7 +727,7 @@ instance
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (UTXO era))
+    Arbitrary (STS.PredicateFailure (Core.EraRule "UTXO" era))
   ) =>
   Arbitrary (STS.UtxowPredicateFailure era)
   where
@@ -821,7 +819,7 @@ instance
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (LEDGER era))
+    Arbitrary (STS.PredicateFailure (Core.EraRule "LEDGERS" era))
   ) =>
   Arbitrary (ApplyTxError era)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -104,8 +104,6 @@ import Shelley.Spec.Ledger.API
     ChainState,
     DPState,
     GetLedgerView,
-    LEDGER,
-    LEDGERS,
     LedgerEnv,
     LedgerState,
     LedgersEnv,
@@ -135,8 +133,7 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.LedgerState (UTxOState (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv)
-import Shelley.Spec.Ledger.STS.Utxow (UTXOW)
+import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx, TxBody, TxOut)
@@ -167,26 +164,26 @@ type ChainProperty era =
   )
 
 type ShelleyUtxoSTS era =
-  ( STS (UTXOW era),
-    BaseM (UTXOW era) ~ ShelleyBase,
-    State (UTXO era) ~ UTxOState era,
-    State (UTXOW era) ~ UTxOState era,
-    Environment (UTXOW era) ~ UtxoEnv era,
-    Environment (UTXO era) ~ UtxoEnv era,
-    Signal (UTXOW era) ~ Tx era
+  ( STS (Core.EraRule "UTXOW" era),
+    BaseM (Core.EraRule "UTXOW" era) ~ ShelleyBase,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era,
+    State (Core.EraRule "UTXOW" era) ~ UTxOState era,
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    Signal (Core.EraRule "UTXOW" era) ~ Tx era
   )
 
 type ShelleyLedgerSTS era =
-  ( STS (LEDGER era),
-    BaseM (LEDGER era) ~ ShelleyBase,
-    Environment (LEDGER era) ~ LedgerEnv era,
-    State (LEDGER era) ~ (UTxOState era, DPState (Crypto era)),
-    Signal (LEDGER era) ~ Tx era,
-    STS (LEDGERS era),
-    BaseM (LEDGERS era) ~ ShelleyBase,
-    Environment (LEDGERS era) ~ LedgersEnv era,
-    State (LEDGERS era) ~ LedgerState era,
-    Signal (LEDGERS era) ~ Seq (Tx era)
+  ( STS (Core.EraRule "LEDGER" era),
+    BaseM (Core.EraRule "LEDGER" era) ~ ShelleyBase,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    State (Core.EraRule "LEDGER" era) ~ (UTxOState era, DPState (Crypto era)),
+    Signal (Core.EraRule "LEDGER" era) ~ Tx era,
+    STS (Core.EraRule "LEDGERS" era),
+    BaseM (Core.EraRule "LEDGERS" era) ~ ShelleyBase,
+    Environment (Core.EraRule "LEDGERS" era) ~ LedgersEnv era,
+    State (Core.EraRule "LEDGERS" era) ~ LedgerState era,
+    Signal (Core.EraRule "LEDGERS" era) ~ Seq (Tx era)
   )
 
 type ShelleyChainSTS era =


### PR DESCRIPTION
Replaces #2060 

Builds atop #2078 

The way we implement the era-parametrised rules leads to a somewhat
annoying situation. We have two choices when creating an STS "instance".
We can either declare it's specific to a given era:

```
instance STS UTXO (ShelleyEra c)
```

Or we can declare it's valid for _all_ eras:

```
instance STS UTXO era
```

Of course, what we'd really like is to say "this instance should be
valid for all eras going forth, until it's overridden". But this is a
little tricky to do at the type level, and we'd have to introduce some
dependently-typed wizardry to manage it.

This problem shows itself particularly with the update system, for
example. The update system is not modified in Allegra, Mary or Alonzo.
However, to support overriding it in a future era (which we need), we
would have to move from the "all era" style to the "current era only"
style. So the Shelley declaration would become valid for Shelley only,
and we'd have to introduce (identical) instances in Allegra, Mary and
Alonzo. This would both be substantial duplication and would muddy the
waters of what's actually overridden in each era.

This PR presents an alternative, "lightweight" solution to this problem,
based upon Damian's work in #2041. We add an additional layer of
indirection in the form of a type family which maps symbols (e.g.
"UTXO") into a specific implementation of the rule. We then have a map
of these per era (the `EraMap`). In future eras, we provide exactly this
same map, which identifies which rules come from which era. Obviously,
constraints guide which rules can be connected to each other.

This approach also removes the need for orphan STS instances in future
eras, since we would now define a "new" UTXO rule in a future era, for
example.