### PR TITLE
Upgrade to ghc-8.10.3 in Github Actions CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.2"]
+        ghc: ["8.6.5", "8.10.3"]
         os: [ubuntu-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-11-15T00:00:00Z
+index-state: 2021-02-15T00:00:00Z
 
 packages:
   alonzo/impl

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "505130bfdaa9ecff5f50c4c415d4cb7db7089716",
-        "sha256": "1j193vhc7gd22lsk6dd8lfkq64aj7xmas23sb3gkr1v6ihchpaj6",
+        "rev": "9aba1e299f6e7d6ccf1be41f64316567f845b9b7",
+        "sha256": "038xzhqxjx4xafwpa7w68cilq0iiz1wvx158yi87r70v1fk3dcr2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/505130bfdaa9ecff5f50c4c415d4cb7db7089716.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/9aba1e299f6e7d6ccf1be41f64316567f845b9b7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
This *should* fix `ListLike` build issues that have been observed over the past few weeks.