### PR TITLE
Functionality for Alonzo scripts, and fixed Fast forward problem.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -36,7 +36,7 @@ import Cardano.Binary
     encodeWord,
   )
 import qualified Cardano.Crypto.Hash as Hash
-import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..), Language, Prices (..))
 import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,7 +15,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data (..), DataHash (..))
 import Cardano.Ledger.Alonzo.PParams (PPHash (..))
-import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..), Tag (..))
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( IsFee (..),
@@ -37,7 +38,7 @@ instance Arbitrary (Data era) where
   arbitrary = pure NotReallyData
 
 instance Arbitrary Tag where
-  arbitrary = elements [Input, Mint, Cert, Wdrl]
+  arbitrary = elements [Spend, Mint, Cert, Rewrd]
 
 instance Arbitrary RdmrPtr where
   arbitrary = RdmrPtr <$> arbitrary <*> arbitrary
@@ -117,10 +118,13 @@ instance
 
 deriving newtype instance Arbitrary IsValidating
 
-instance (Mock c) => Arbitrary (Tx (AlonzoEra c)) where
+instance Mock c => Arbitrary (Tx (AlonzoEra c)) where
   arbitrary =
     Tx
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+
+instance Mock c => Arbitrary (Script (AlonzoEra c)) where
+  arbitrary = frequency [(1, pure PlutusScript), (9, NativeScript <$> arbitrary)]

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -25,7 +25,7 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
   )
 where
 
-import Cardano.Binary (toCBOR)
+import Cardano.Binary (ToCBOR(toCBOR),FromCBOR,Annotator)
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Allegra (AllegraEra)
@@ -113,12 +113,14 @@ sizedTimelock n =
     ]
 
 -- TODO Generate metadata with script preimages
-instance
+instance forall era c.
   ( Era era,
     c ~ Crypto era,
     Mock c,
-    Arbitrary (Timelock c),
-    Core.Script era ~ Timelock c
+    FromCBOR (Annotator (Core.Script era)),
+    ToCBOR (Core.Script era),
+    Ord(Core.Script era),
+    Arbitrary (Core.Script era)
   ) =>
   Arbitrary (MA.AuxiliaryData era)
   where
@@ -135,11 +137,10 @@ instance
   -- in an unsatisfied `MonadFail` constraint.
   arbitrary =
     genMetadata' >>= \case
-      Metadata m -> MA.AuxiliaryData m <$> genScriptSeq
+      Metadata m -> MA.AuxiliaryData m <$> (genScriptSeq @era)
 
 genScriptSeq ::
-  (Arbitrary (Timelock c)) =>
-  Gen (StrictSeq (Timelock c))
+  forall era. Arbitrary (Core.Script era) => Gen(StrictSeq (Core.Script era))
 genScriptSeq = do
   n <- choose (0, 3)
   l <- vectorOf n arbitrary


### PR DESCRIPTION
Added operations on Scripts and TxBody in Aonzo. Mostly Figure 5 and 6
Also fixed the fast forward problem of merging the pretty printer on
top of the change of TxBody to a type family.