### PR TITLE
expose HKD to allow consumers to operate on PParams' in a more generic manner

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -24,6 +24,7 @@ module Shelley.Spec.Ledger.PParams
     emptyPParamsUpdate,
     Update (..),
     updatePParams,
+    HKD,
   )
 where
 


### PR DESCRIPTION
For example, I'd like to be able to write:

```hs
foo
  :: (forall a. (a -> T) -> HKD f a -> T)
  -> PParams' f era
  -> T
```

I've tried to define my own HKD locally but GHC is unable to resolve the following:

```
Could not deduce: Shelley.Spec.Ledger.PParams.HKD f a ~ HKD f a
```

In hope, I also tried to trick GHC into thinking that everything was fine by adding an extra constraint:

```hs
Elem f '[Identity, StrictMaybe] ~ 'True
```

in vain... So the easiest remains to simply expose the type familyfrom the `PParams` module so that it can be referenced.


Please :pray: 