### PR TITLE
Tighten mint field bound in decoder

### DIFF
--- a/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
+++ b/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
@@ -252,7 +252,9 @@ policy_id = scripthash
 asset_name = bytes .size (0..32)
 
 value = coin / [coin,multiasset<uint>]
-mint = multiasset<int>
+mint = multiasset<int64>
+
+int64 = -9223372036854775808 .. 9223372036854775807
 
 epoch = uint
 


### PR DESCRIPTION
This is a candidate solution to CAD-2404.
The cddl currently states that the values in a mint field are
represented by the cddl 'int' type, which has a range
-2^64 .. 2^64 - 1

The Int64 type available in most languages has the range
-2^63 .. 2^63 - 1
which can make such a value awkward to represent.

In this changeset, the bound is tightetened to the Int64 range in the
cddl, and the decoder enforces this.
It also now enforces that the value is major type 0 or 1 as the cddl
states (unlike decodeInteger, which permits other things).