### PR TITLE
Add Default instances for some Shelley states

### DIFF
--- a/semantics/executable-spec/small-steps.cabal
+++ b/semantics/executable-spec/small-steps.cabal
@@ -48,6 +48,7 @@ library
                      , cborg
                      , containers
                      , cryptonite
+                     , data-default-class
                      , deepseq
                      , free
                      , mtl

--- a/semantics/executable-spec/src/Control/State/Transition/Extended.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Extended.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -63,6 +64,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (modify, runStateT)
 import qualified Control.Monad.Trans.State.Strict as MonadState
 import Data.Data (Data, Typeable)
+import Data.Default.Class (Default, def)
 import Data.Foldable (find, traverse_)
 import Data.Functor ((<&>))
 import Data.Kind (Type)
@@ -180,6 +182,8 @@ class
 
   -- | Rules governing transition under this system.
   initialRules :: [InitialRule a]
+  default initialRules :: Default (State a) => [InitialRule a]
+  initialRules = [pure def]
 
   transitionRules :: [TransitionRule a]
 

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -104,6 +104,7 @@ test-suite cardano-ledger-shelley-ma-test
       "-with-rtsopts=-K4m -M250m"
     build-depends:
       cardano-ledger-shelley-ma,
+      data-default-class,
       shelley-spec-ledger-test,
       cardano-ledger-shelley-ma-test,
       base >=4.9 && <4.15,

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -18,7 +18,7 @@ import Shelley.Spec.Ledger.UTxO (txid)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCase)
 import Test.Shelley.Spec.Ledger.Utils (runShelleyBase, applySTSTest)
-import Shelley.Spec.Ledger.LedgerState (emptyUTxOState, emptyDPState)
+import Shelley.Spec.Ledger.LedgerState ()
 import Control.State.Transition.Extended (TRC (..))
 import Control.Monad.Except (runExcept)
 import Shelley.Spec.Ledger.Tx (hashScript, scriptWits)
@@ -29,6 +29,7 @@ import Test.Cardano.Ledger.EraBuffet
     ShelleyEra,
     StandardCrypto,
   )
+import Data.Default.Class (def)
 
 type Allegra = AllegraEra StandardCrypto
 
@@ -73,7 +74,7 @@ testScriptPostTranslation = testCase
           (S.TxIn bootstrapTxId 0)
           (S.TxOut addr (Val.inject (S.Coin 1)))
     env = S.LedgerEnv (SlotNo 0) 0 emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0))
-    utxoStShelley = emptyUTxOState {S._utxo = utxo}
+    utxoStShelley = def {S._utxo = utxo}
     utxoStAllegra = fromRight . runExcept $ translateEra @Allegra () utxoStShelley
     txb =
       S.TxBody
@@ -90,7 +91,7 @@ testScriptPostTranslation = testCase
     txa = fromRight . runExcept $ translateEra @Allegra () txs
     result = runShelleyBase $
       applySTSTest @(S.LEDGER Allegra)
-        (TRC (env, (utxoStAllegra, emptyDPState), txa))
+        (TRC (env, (utxoStAllegra, def), txa))
     in
     case result of
       Left e -> error $ show e

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -16,15 +16,14 @@ import GHC.Records
 import Shelley.Spec.Ledger.API (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.LedgerState
   ( DPState (..),
-    UTxOState (..),
-    emptyDPState,
-    emptyUTxOState,
+    UTxOState (..)
   )
 import Shelley.Spec.Ledger.Tx (Tx (..))
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.Shelley.Spec.Ledger.Utils (applySTSTest, runShelleyBase)
 import Test.Tasty.HUnit (Assertion, (@?=))
+import Data.Default.Class (def)
 
 type MaryTest = MaryEra TestCrypto
 
@@ -42,10 +41,10 @@ testMaryNoDelegLEDGER ::
   Assertion
 testMaryNoDelegLEDGER utxo tx env (Right expectedUTxO) = do
   checkTrace @(LEDGER MaryTest) runShelleyBase env $
-    pure (emptyUTxOState {_utxo = utxo}, emptyDPState) .- tx .-> expectedSt'
+    pure (def {_utxo = utxo}, def) .- tx .-> expectedSt'
   where
     txFee = getField @"txfee" (_body tx)
-    expectedSt' = (emptyUTxOState {_utxo = expectedUTxO, _fees = txFee}, emptyDPState)
+    expectedSt' = (def {_utxo = expectedUTxO, _fees = txFee}, def)
 testMaryNoDelegLEDGER utxo tx env predicateFailure@(Left _) = do
-  let st = runShelleyBase $ applySTSTest @(LEDGER MaryTest) (TRC (env, (emptyUTxOState {_utxo = utxo}, emptyDPState), tx))
+  let st = runShelleyBase $ applySTSTest @(LEDGER MaryTest) (TRC (env, (def {_utxo = utxo}, def), tx))
   (ignoreAllButUTxO st) @?= predicateFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -22,6 +22,7 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<->))
 import qualified Data.ByteString.Short as SBS
+import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
@@ -30,8 +31,6 @@ import Shelley.Spec.Ledger.API.Types
 import Shelley.Spec.Ledger.Coin (CompactForm (CompactCoin))
 import Shelley.Spec.Ledger.CompactAddr (CompactAddr (UnsafeCompactAddr))
 import Shelley.Spec.Ledger.EpochBoundary
-import Shelley.Spec.Ledger.LedgerState
-import Shelley.Spec.Ledger.Rewards
 import Shelley.Spec.Ledger.STS.Chain (pparamsToChainChecksData)
 import Shelley.Spec.Ledger.Slot
 
@@ -130,7 +129,7 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
           esLState = ledgerState,
           esPrevPp = pparams,
           esPp = pparams,
-          esNonMyopic = emptyNonMyopic
+          esNonMyopic = def
         }
 
     utxoByron :: Byron.UTxO
@@ -147,12 +146,12 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
               { _utxo = utxoShelley,
                 _deposited = Coin 0,
                 _fees = Coin 0,
-                _ppups = emptyPPUPState
+                _ppups = def
               },
           _delegationState =
             DPState
-              { _dstate = emptyDState {_genDelegs = genDelegs},
-                _pstate = emptyPState
+              { _dstate = def {_genDelegs = genDelegs},
+                _pstate = def
               }
         }
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -41,6 +41,7 @@ import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq (NFData)
 import Control.SetAlgebra (dom, eval, setSingleton, (▷), (◁))
 import Data.Aeson
+import Data.Default.Class (Default, def)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
@@ -229,6 +230,9 @@ instance
       go <- fromCBOR
       f <- fromCBOR
       pure $ SnapShots mark set go f
+
+instance Default (SnapShots crypto) where
+  def = emptySnapShots
 
 emptySnapShot :: SnapShot crypto
 emptySnapShot = SnapShot (Stake Map.empty) Map.empty Map.empty

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -41,6 +41,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
+import Data.Default.Class (Default, def)
 import Data.Foldable (fold)
 import Data.Functor.Identity (Identity)
 import Data.List (nub)
@@ -299,6 +300,9 @@ instance FromJSON (PParams era) where
         <*> obj .: "protocolVersion"
         <*> obj .:? "minUTxOValue" .!= mempty
         <*> obj .:? "minPoolCost" .!= mempty
+
+instance Default (PParams era) where
+  def = emptyPParams
 
 -- | Returns a basic "empty" `PParams` structure with all zero values.
 emptyPParams :: PParams era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -12,7 +12,6 @@ module Shelley.Spec.Ledger.Rewards
   ( desirability,
     PerformanceEstimate (..),
     NonMyopic (..),
-    emptyNonMyopic,
     getTopRankedPools,
     StakeShare (..),
     mkApparentPerformance,
@@ -45,6 +44,7 @@ import Cardano.Slotting.Slot (EpochSize)
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra (eval, (◁))
 import Control.Provenance (ProvM, modifyM)
+import Data.Default.Class (Default, def)
 import Data.Foldable (find, fold)
 import Data.Function (on)
 import Data.List (sortBy)
@@ -90,8 +90,6 @@ import Shelley.Spec.Ledger.Serialization
     encodeFoldable,
   )
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), getRwdCred)
-
--- ==================================================================
 
 newtype LogWeight = LogWeight {unLogWeight :: Float}
   deriving (Eq, Generic, Ord, Num, NFData, NoThunks, ToCBOR, FromCBOR)
@@ -243,8 +241,8 @@ data NonMyopic crypto = NonMyopic
   }
   deriving (Show, Eq, Generic)
 
-emptyNonMyopic :: NonMyopic crypto
-emptyNonMyopic = NonMyopic Map.empty (Coin 0)
+instance Default (NonMyopic crypto) where
+  def = NonMyopic Map.empty (Coin 0)
 
 instance NoThunks (NonMyopic crypto)
 
@@ -271,7 +269,7 @@ instance CC.Crypto crypto => FromCBOR (NonMyopic crypto) where
             rewardPotNM = rp
           }
 
--- | Desirability calculation for non-myopic utily,
+-- | Desirability calculation for non-myopic utility,
 -- corresponding to f^~ in section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
 desirability ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -48,6 +48,7 @@ import Control.State.Transition
     liftSTS,
     trans,
   )
+import Data.Default.Class (def)
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -94,9 +95,6 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     TransUTxOState,
     UTxOState (..),
-    emptyDState,
-    emptyPPUPState,
-    emptyPState,
     updateNES,
     _genDelegs,
   )
@@ -105,7 +103,6 @@ import Shelley.Spec.Ledger.PParams
     PParams' (..),
     ProtVer (..),
   )
-import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyEnv (..), BbodyPredicateFailure, BbodyState (..))
 import Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL,
@@ -207,13 +204,13 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
                     utxo
                     (Coin 0)
                     (Coin 0)
-                    emptyPPUPState
+                    def
                 )
-                (DPState (emptyDState {_genDelegs = (GenDelegs genDelegs)}) emptyPState)
+                (DPState (def {_genDelegs = (GenDelegs genDelegs)}) def)
             )
             pp
             pp
-            emptyNonMyopic
+            def
         )
         SNothing
         (PoolDistr Map.empty)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -52,7 +52,6 @@ import Shelley.Spec.Ledger.LedgerState
     DState,
     FutureGenDeleg (..),
     InstantaneousRewards (..),
-    emptyDState,
     _delegations,
     _fGenDelegs,
     _genDelegs,
@@ -126,7 +125,6 @@ instance Typeable era => STS (DELEG era) where
   type BaseM (DELEG era) = ShelleyBase
   type PredicateFailure (DELEG era) = DelegPredicateFailure era
 
-  initialRules = [pure emptyDState]
   transitionRules = [delegationTransition]
 
 instance NoThunks (DelegPredicateFailure era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -62,7 +62,6 @@ import Shelley.Spec.Ledger.LedgerState
   ( AccountState,
     DPState (..),
     RewardAccounts,
-    emptyDelegation,
     _dstate,
     _pParams,
     _rewards,
@@ -136,7 +135,6 @@ instance
     PredicateFailure (DELEGS era) =
       DelegsPredicateFailure era
 
-  initialRules = [pure emptyDelegation]
   transitionRules = [delegsTransition]
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -39,7 +39,6 @@ import Shelley.Spec.Ledger.LedgerState
     DPState,
     DState,
     PState,
-    emptyDelegation,
     _dstate,
     _pstate,
   )
@@ -107,7 +106,6 @@ instance
   type BaseM (DELPL era) = ShelleyBase
   type PredicateFailure (DELPL era) = DelplPredicateFailure era
 
-  initialRules = [pure emptyDelegation]
   transitionRules = [delplTransition]
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -24,20 +24,26 @@ import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
-import Control.State.Transition (Embed (..), InitialRule, STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans)
+import Control.State.Transition
+  ( Embed (..),
+    STS (..),
+    TRC (..),
+    TransitionRule,
+    judgmentContext,
+    liftSTS,
+    trans,
+  )
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
-import Shelley.Spec.Ledger.EpochBoundary (SnapShots, emptySnapShots)
+import Shelley.Spec.Ledger.EpochBoundary (SnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState,
     LedgerState,
     PPUPState (..),
     PState (..),
-    emptyAccount,
-    emptyLedgerState,
     esAccountState,
     esLState,
     esNonMyopic,
@@ -50,14 +56,12 @@ import Shelley.Spec.Ledger.LedgerState
     pattern DPState,
     pattern EpochState,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, ProposedPPUpdates (..), emptyPParams, updatePParams)
-import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, ProposedPPUpdates (..), updatePParams)
+import Shelley.Spec.Ledger.Rewards ()
 import Shelley.Spec.Ledger.STS.Newpp (NEWPP, NewppEnv (..), NewppPredicateFailure, NewppState (..))
 import Shelley.Spec.Ledger.STS.PoolReap (POOLREAP, PoolreapPredicateFailure, PoolreapState (..))
 import Shelley.Spec.Ledger.STS.Snap (SNAP, SnapPredicateFailure)
 import Shelley.Spec.Ledger.Slot (EpochNo)
-
--- ================================================
 
 data EPOCH era
 
@@ -104,7 +108,6 @@ instance
   type Environment (EPOCH era) = ()
   type BaseM (EPOCH era) = ShelleyBase
   type PredicateFailure (EPOCH era) = EpochPredicateFailure era
-  initialRules = [initialEpoch]
   transitionRules = [epochTransition]
 
 instance
@@ -113,17 +116,6 @@ instance
     NoThunks (PredicateFailure (Core.EraRule "NEWPP" era))
   ) =>
   NoThunks (EpochPredicateFailure era)
-
-initialEpoch :: InitialRule (EPOCH era)
-initialEpoch =
-  pure $
-    EpochState
-      emptyAccount
-      emptySnapShots
-      emptyLedgerState
-      emptyPParams
-      emptyPParams
-      emptyNonMyopic
 
 votedValue ::
   ProposedPPUpdates era ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -43,7 +43,6 @@ import Shelley.Spec.Ledger.LedgerState
     DPState,
     LedgerState (..),
     UTxOState,
-    emptyLedgerState,
     _delegationState,
     _utxoState,
   )
@@ -116,7 +115,6 @@ instance
   type BaseM (LEDGERS era) = ShelleyBase
   type PredicateFailure (LEDGERS era) = LedgersPredicateFailure era
 
-  initialRules = [pure emptyLedgerState]
   transitionRules = [ledgersTransition]
 
 ledgersTransition ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -12,6 +12,7 @@ module Shelley.Spec.Ledger.STS.Mir
   ( MIR,
     PredicateFailure,
     MirPredicateFailure,
+    emptyInstantaneousRewards,
   )
 where
 
@@ -20,26 +21,22 @@ import Cardano.Ledger.Val ((<->))
 import Control.SetAlgebra (dom, eval, (∪+), (◁))
 import Control.State.Transition
   ( Assertion (..),
-    InitialRule,
     STS (..),
     TRC (..),
     TransitionRule,
     judgmentContext,
   )
 import Data.Foldable (fold)
+import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
-import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
 import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     EpochState,
     InstantaneousRewards (..),
     RewardAccounts,
-    emptyAccount,
-    emptyInstantaneousRewards,
-    emptyLedgerState,
     esAccountState,
     esLState,
     esNonMyopic,
@@ -52,8 +49,6 @@ import Shelley.Spec.Ledger.LedgerState
     _rewards,
     pattern EpochState,
   )
-import Shelley.Spec.Ledger.PParams (emptyPParams)
-import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 
 data MIR era
 
@@ -69,7 +64,6 @@ instance Typeable era => STS (MIR era) where
   type BaseM (MIR era) = ShelleyBase
   type PredicateFailure (MIR era) = MirPredicateFailure era
 
-  initialRules = [initialMir]
   transitionRules = [mirTransition]
 
   assertions =
@@ -80,17 +74,6 @@ instance Typeable era => STS (MIR era) where
              in length (r st) == length (r st')
         )
     ]
-
-initialMir :: InitialRule (MIR era)
-initialMir =
-  pure $
-    EpochState
-      emptyAccount
-      emptySnapShots
-      emptyLedgerState
-      emptyPParams
-      emptyPParams
-      emptyNonMyopic
 
 mirTransition :: forall era. TransitionRule (MIR era)
 mirTransition = do
@@ -155,3 +138,6 @@ mirTransition = do
           pr
           pp
           nm
+
+emptyInstantaneousRewards :: InstantaneousRewards crypto
+emptyInstantaneousRewards = InstantaneousRewards Map.empty Map.empty

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition
+import Data.Default.Class (def)
 import Data.Foldable (fold)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
@@ -96,7 +97,7 @@ instance
           (EpochNo 0)
           (BlocksMade Map.empty)
           (BlocksMade Map.empty)
-          emptyEpochState
+          def
           SNothing
           (PoolDistr Map.empty)
     ]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -16,14 +16,13 @@ where
 
 import Cardano.Ledger.Era (Crypto)
 import Control.State.Transition
-  ( InitialRule,
-    STS (..),
+  ( STS (..),
     TRC (..),
     TransitionRule,
     judgmentContext,
     (?!),
   )
-import qualified Data.Map.Strict as Map
+import Data.Default.Class (Default, def)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -35,17 +34,13 @@ import Shelley.Spec.Ledger.LedgerState
     DState (..),
     PState (..),
     UTxOState,
-    emptyAccount,
-    emptyPPUPState,
     totalInstantaneousReservesRewards,
     updatePpup,
     _deposited,
     _irwd,
     _reserves,
-    pattern UTxOState,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams)
-import Shelley.Spec.Ledger.UTxO (UTxO (..))
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 
 data NEWPP era
 
@@ -69,16 +64,10 @@ instance Typeable era => STS (NEWPP era) where
   type Environment (NEWPP era) = NewppEnv era
   type BaseM (NEWPP era) = ShelleyBase
   type PredicateFailure (NEWPP era) = NewppPredicateFailure era
-  initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
-initialNewPp :: InitialRule (NEWPP era)
-initialNewPp =
-  pure $
-    NewppState
-      (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPUPState)
-      emptyAccount
-      emptyPParams
+instance Default (NewppState era) where
+  def = NewppState def def def
 
 newPpTransition :: TransitionRule (NEWPP era)
 newPpTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -39,7 +39,7 @@ import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, invalidKey)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Shelley.Spec.Ledger.LedgerState (PState (..), emptyPState)
+import Shelley.Spec.Ledger.LedgerState (PState (..))
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo, epochInfoEpoch)
@@ -80,8 +80,6 @@ instance Typeable era => STS (POOL era) where
 
   type BaseM (POOL era) = ShelleyBase
   type PredicateFailure (POOL era) = PoolPredicateFailure era
-
-  initialRules = [pure emptyPState]
 
   transitionRules = [poolDelegationTransition]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -26,6 +26,7 @@ import Control.State.Transition
     TransitionRule,
     judgmentContext,
   )
+import Data.Default.Class (Default, def)
 import Data.Foldable (fold)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -40,16 +41,10 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     TransUTxOState,
     UTxOState (..),
-    emptyAccount,
-    emptyDState,
-    emptyPState,
-    emptyUTxOState,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.Slot (EpochNo (..))
 import Shelley.Spec.Ledger.TxBody (getRwdCred, _poolRAcnt)
-
--- =================================================================
 
 data POOLREAP era
 
@@ -69,16 +64,16 @@ data PoolreapPredicateFailure era -- No predicate Falures
 
 instance NoThunks (PoolreapPredicateFailure era)
 
+instance Default (PoolreapState era) where
+  def = PoolreapState def def def def
+
 instance Typeable era => STS (POOLREAP era) where
   type State (POOLREAP era) = PoolreapState era
   type Signal (POOLREAP era) = EpochNo
   type Environment (POOLREAP era) = PParams era
   type BaseM (POOLREAP era) = ShelleyBase
   type PredicateFailure (POOLREAP era) = PoolreapPredicateFailure era
-  initialRules =
-    [ pure $
-        PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState
-    ]
+
   transitionRules = [poolReapTransition]
 
   assertions =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -44,8 +44,6 @@ import Shelley.Spec.Ledger.Slot
     (+*),
   )
 
--- ============================================
-
 data RUPD era
 
 data RupdEnv era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -46,8 +46,6 @@ import Control.State.Transition
   ( Assertion (..),
     AssertionViolation (..),
     Embed,
-    IRC (..),
-    InitialRule,
     STS (..),
     TRC (..),
     TransitionRule,
@@ -87,7 +85,6 @@ import Shelley.Spec.Ledger.LedgerState
     TransUTxOState,
     UTxOState (..),
     consumed,
-    emptyPPUPState,
     keyRefunds,
     minfee,
     produced,
@@ -295,7 +292,6 @@ instance
   type PredicateFailure (UTXO era) = UtxoPredicateFailure era
 
   transitionRules = [utxoInductive]
-  initialRules = [initialLedgerState]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
     "AssertionViolation (" <> avSTS <> "): " <> avMsg
@@ -323,11 +319,6 @@ instance
                 utxoBalance us <> withdrawals (_body tx) == utxoBalance us'
             )
     ]
-
-initialLedgerState :: InitialRule (UTXO era)
-initialLedgerState = do
-  IRC _ <- judgmentContext
-  pure $ UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPUPState
 
 utxoInductive ::
   forall era utxo.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -91,6 +91,7 @@ library
     cardano-slotting,
     cborg,
     containers,
+    data-default-class,
     directory,
     generic-random,
     hedgehog-quickcheck,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -65,8 +65,6 @@ import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     DPState,
     UTxOState (..),
-    emptyDPState,
-    emptyPPUPState,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams)
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
@@ -109,6 +107,7 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
+import Data.Default.Class (def)
 
 -- ===============================================
 -- A special Era to run the Benchmarks in
@@ -153,7 +152,7 @@ initUTxO n =
     (genesisCoins genesisId (injcoins n))
     (Coin 0)
     (Coin 0)
-    emptyPPUPState
+    def
 
 -- Protocal Parameters used for the benchmarknig tests.
 -- Note that the fees and deposits are set to zero for
@@ -211,10 +210,10 @@ txSpendOneUTxO =
     SNothing
 
 ledgerSpendOneUTxO :: Integer -> ()
-ledgerSpendOneUTxO n = testLEDGER (initUTxO n, emptyDPState) txSpendOneUTxO ledgerEnv
+ledgerSpendOneUTxO n = testLEDGER (initUTxO n, def) txSpendOneUTxO ledgerEnv
 
 ledgerSpendOneGivenUTxO :: UTxOState B -> ()
-ledgerSpendOneGivenUTxO state = testLEDGER (state, emptyDPState) txSpendOneUTxO ledgerEnv
+ledgerSpendOneGivenUTxO state = testLEDGER (state, def) txSpendOneUTxO ledgerEnv
 
 -- ===========================================================================
 --
@@ -275,7 +274,7 @@ txRegStakeKeys ix keys =
     [asWitness alicePay]
 
 initLedgerState :: Integer -> (UTxOState B, DPState B_Crypto)
-initLedgerState n = (initUTxO n, emptyDPState)
+initLedgerState n = (initUTxO n, def)
 
 makeLEDGERState ::
   (UTxOState B, DPState B_Crypto) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -93,11 +93,11 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     RewardUpdate (..),
     UTxOState (..),
-    applyRUpd,
-    emptyInstantaneousRewards,
+    applyRUpd
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
+import Shelley.Spec.Ledger.STS.Mir (emptyInstantaneousRewards)
 import Shelley.Spec.Ledger.Tx (TxIn)
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -40,7 +40,7 @@ import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     EpochState (..),
     NewEpochState (..),
-    emptyRewardUpdate,
+    emptyRewardUpdate
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -52,7 +52,7 @@ import Shelley.Spec.Ledger.Keys (asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..),
     decayFactor,
-    emptyRewardUpdate,
+    emptyRewardUpdate
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..))
@@ -60,7 +60,6 @@ import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     NonMyopic (..),
     applyDecay,
-    emptyNonMyopic,
     leaderProbability,
     likelihood,
   )
@@ -121,6 +120,7 @@ import Test.Shelley.Spec.Ledger.Utils
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
+import Data.Default.Class (def)
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
@@ -450,7 +450,7 @@ rewardUpdateEx4 =
       deltaR = DeltaCoin 6,
       rs = Map.empty,
       deltaF = DeltaCoin (-7),
-      nonMyopic = emptyNonMyopic {rewardPotNM = Coin 6}
+      nonMyopic = def {rewardPotNM = Coin 6}
     }
 
 expectedStEx4 ::
@@ -571,7 +571,7 @@ rewardUpdateEx6 =
       deltaR = DeltaCoin 4,
       rs = Map.empty,
       deltaF = invert $ toDeltaCoin feeTx4,
-      nonMyopic = emptyNonMyopic {rewardPotNM = Coin 4}
+      nonMyopic = def {rewardPotNM = Coin 4}
     }
 
 expectedStEx6 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
@@ -60,8 +60,8 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as EB
 import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
 import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
-  ( RewardUpdate (..),
-    emptyRewardUpdate,
+  ( RewardUpdate (..)
+  , emptyRewardUpdate
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..), ProtVer (..))
@@ -69,7 +69,6 @@ import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     NonMyopic (..),
     StakeShare (..),
-    emptyNonMyopic,
     leaderProbability,
     leaderRew,
     likelihood,
@@ -131,6 +130,7 @@ import Test.Shelley.Spec.Ledger.Utils
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
+import Data.Default.Class (def)
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
@@ -378,7 +378,7 @@ rewardUpdateEx4 =
       deltaR = toDeltaCoin deltaREx4, -- No rewards paid out, fees go to reserves
       rs = Map.empty,
       deltaF = invert $ toDeltaCoin feeTx1,
-      nonMyopic = emptyNonMyopic {rewardPotNM = feeTx1}
+      nonMyopic = def {rewardPotNM = feeTx1}
     }
 
 expectedStEx4 ::

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -127,7 +127,6 @@ import Shelley.Spec.Ledger.LedgerState
     EpochState (..),
     NewEpochState (..),
     RewardUpdate (..),
-    emptyLedgerState,
   )
 import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.OCert
@@ -144,7 +143,7 @@ import Shelley.Spec.Ledger.PParams
     pattern ProposedPPUpdates,
     pattern Update,
   )
-import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Shelley.Spec.Ledger.Rewards ()
 import Shelley.Spec.Ledger.Scripts (pattern RequireSignature)
 import Shelley.Spec.Ledger.Serialization
   ( FromCBORGroup (..),
@@ -195,6 +194,7 @@ import Test.Shelley.Spec.Ledger.Serialisation.GoldenUtils
   )
 import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
+import Data.Default.Class (def)
 
 -- ============================================
 
@@ -1287,10 +1287,10 @@ tests =
           ps = Map.singleton (hashKey $ vKey testStakePoolKey) params
           fs = Coin 123
           ss = SnapShots mark set go fs
-          ls = emptyLedgerState
+          ls = def
           pps = emptyPParams
           bs = Map.singleton (hashKey $ vKey testStakePoolKey) 1
-          nm = emptyNonMyopic
+          nm = def
           es = EpochState @C ac ss ls pps pps nm
           ru =
             ( SJust

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -62,9 +62,6 @@ import Shelley.Spec.Ledger.LedgerState
     DPState (..),
     UTxOState (..),
     WitHashes (..),
-    emptyDState,
-    emptyPPUPState,
-    emptyPState,
     _dstate,
     _rewards,
   )
@@ -122,6 +119,7 @@ import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+import Data.Default.Class (def)
 
 -- ========================================================================================
 
@@ -382,10 +380,10 @@ utxoState =
     )
     (Coin 0)
     (Coin 0)
-    emptyPPUPState
+    def
 
 dpState :: DPState C_Crypto
-dpState = DPState emptyDState emptyPState
+dpState = DPState def def
 
 addReward :: DPState C_Crypto -> Credential 'Staking C_Crypto -> Coin -> DPState C_Crypto
 addReward dp ra c = dp {_dstate = ds {_rewards = rewards}}


### PR DESCRIPTION
Shelley states (most of which can be found in `module Shelley.Spec.Ledger.LedgerState`) have now a `Default` instance, which means that they have a default value. This default value is what it was previously know as "empty" state. Furthermore, the STS class provides a `default` definition for initial rules of STS whose state has a `Default` instance:

```haskell
default initialRules :: Default (State a) => [InitialRule a]
initialRules = [pure def]
```