### PR TITLE
IntroduceSafeHash to all Eras

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -22,6 +22,7 @@ library
   exposed-modules:
     Cardano.Ledger.Alonzo
     Cardano.Ledger.Alonzo.Data
+     Cardano.Ledger.Alonzo.Language
     Cardano.Ledger.Alonzo.PParams
     Cardano.Ledger.Alonzo.Scripts
     Cardano.Ledger.Alonzo.Tx

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | This module provides data structures and operations for talking about
+--     Non-native Script languages. It is expected that new languages (or new
+--     versions of old languages) will be added here.
+module Cardano.Ledger.Alonzo.Language where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord64)
+import Control.DeepSeq (NFData (..))
+import Data.Coders
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+-- ==================================================================
+-- Non-Native Script language. This is an Enumerated type.
+-- This is expected to be an open type. We will add new Constuctors
+-- to this type as additional Non-Native scripting language as are added.
+-- We use an enumerated type for two reasons.
+-- 1) We can write total functions by case analysis over the constructors
+-- 2) We will use DataKinds to make some datatypes  indexed by Language
+-- For now, the only Non-Native Scriting language is Plutus
+-- We might add new languages in the futures.
+
+data Language = PlutusV1 --    | ADD-NEW-LANGUAGES-HERE
+  deriving (Eq, Generic, Show, Ord)
+
+instance NoThunks Language
+
+instance NFData Language
+
+instance ToCBOR Language where
+  toCBOR PlutusV1 = toCBOR (0 :: Int)
+
+instance FromCBOR Language where
+  fromCBOR = do n <- decodeWord64; case n of { 0 -> pure PlutusV1; m -> invalidKey (fromIntegral m) }
+
+nonNativeLanguages :: Set.Set Language
+nonNativeLanguages = Set.insert PlutusV1 Set.empty

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
@@ -27,21 +28,19 @@ module Cardano.Ledger.Alonzo.Tx
   ( Indexable (..),
     -- Figure 1
     CostModel,
-    PPHash,
-    hashLanguagePP,
+    getLanguageView,
     -- Figure 2
-    ScriptData,
-    ScriptDataHash,
     Data,
     DataHash,
     IsValidating (..),
     hashData,
     language,
-    plutusLanguage,
-    timelockLanguage,
     nonNativeLanguages,
-    hashScriptData,
+    hashWitnessPPData,
     getCoin,
+    EraIndependentWitnessPPData,
+    WitnessPPData,
+    WitnessPPDataHash,
     -- Figure 3
     Tx (Tx, body, wits, isValidating, auxiliaryData),
     TxBody (..),
@@ -75,18 +74,19 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
-import Cardano.Ledger.Alonzo.PParams (PPHash, PParams, PParams' (..), hashLanguagePP)
-import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..), Language (..), Prices (..))
+import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
+import Cardano.Ledger.Alonzo.PParams (LangDepView (..), PParams, PParams' (..), getLanguageView)
+import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..), Prices (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as AlonzoScript (Script (..), Tag (..))
 import Cardano.Ledger.Alonzo.TxBody
   ( AlonzoBody,
+    EraIndependentWitnessPPData,
     TxBody (..),
     TxOut (..),
+    WitnessPPDataHash,
   )
 import Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
-    ScriptData (..),
-    ScriptDataHash (..),
     TxWitness (..),
     hashSD,
     witsData,
@@ -97,6 +97,11 @@ import Cardano.Ledger.Compactible
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (AssetName, PolicyID (..), Value (..))
+import Cardano.Ledger.SafeHash
+  ( HashAnnotated,
+    SafeToHash,
+    hashAnnotated,
+  )
 import Cardano.Ledger.Shelley.Constraints
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, Val (coin, (<+>), (<×>)))
 import Control.SetAlgebra (eval, (◁))
@@ -111,14 +116,12 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
   ( elemAt,
-    empty,
     findIndex,
-    insert,
+    fromList,
     map,
     null,
     union,
   )
-import Data.Text.Encoding (encodeUtf8)
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -130,6 +133,7 @@ import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (ScriptHashObj))
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert (..))
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
+import Shelley.Spec.Ledger.Serialization (decodeMapTraverse)
 import Shelley.Spec.Ledger.Tx (ValidateScript (isNativeScript))
 import Shelley.Spec.Ledger.TxBody (DelegCert (..), Delegation (..), TxIn (..), Wdrl (..), unWdrl)
 import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
@@ -139,7 +143,8 @@ import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
 -- | Tag indicating whether non-native scripts in this transaction are expected
 -- to validate. This is added by the block creator when constructing the block.
 newtype IsValidating = IsValidating Bool
-  deriving (Eq, NoThunks, Show)
+  deriving (Eq, Show, Generic)
+  deriving newtype (NoThunks)
 
 data TxRaw era = TxRaw
   { _body :: !(TxBody era),
@@ -176,7 +181,7 @@ instance
   NoThunks (TxRaw era)
 
 newtype Tx era = TxConstr (MemoBytes (TxRaw era))
-  deriving (ToCBOR)
+  deriving newtype (ToCBOR)
 
 deriving newtype instance
   ( Era era,
@@ -290,58 +295,74 @@ deriving via
 -- =========================================================
 -- Figure 2: Definitions for Transactions
 
--- For now, the only Non-Native Scriting language is Plutus
--- We might add new languages in the futures.
-
-nonNativeLanguages :: Set Language
-nonNativeLanguages = Set.insert plutusLanguage Set.empty
-
-plutusLanguage :: Language
-plutusLanguage = Language (encodeUtf8 "Plutus")
-
-timelockLanguage :: Language
-timelockLanguage = Language (encodeUtf8 "Timelock")
-
-language :: AlonzoScript.Script era -> Language
-language (AlonzoScript.NativeScript _) = timelockLanguage
-language (AlonzoScript.PlutusScript) = plutusLanguage
-
 getCoin :: UsesValue era => TxOut era -> Coin
 getCoin (TxOut _ v _) = coin v
 
-{-
--- TODO fix this.  A ScriptDataHash is a hash of a Virtual triple.
--- See the selector function sdHash in TxWitness
--- In figure 14 we use this selector in the precondition
--- sdHash txb ==  hashScriptData pp ( languages txw ) ( txrdmrs txw )
--- We have two functions that produce a ScriptDataHash
--- 1) hashSD :: TxWitness -> Maybe(ScriptDataHash)  (Figure 12)
--- 2) hashScriptData :: PParams era -> Set Language ->
---       Map.Map RdmrPtr (Data era) -> Maybe (ScriptDataHash era) (Figure 2)
--- These two functions are not computing the same thing at all.
+-- ========================================================================
+-- A WitnessPPDataHash is the hash of two things. The first part comes from
+-- the witnesses and the second comes from the Protocol Parameters (PParams).
+-- In order to hash 2 things we make a newtype WitnessPPData which will be
+-- a MemoBytes of these two things (WitnessPPDataRaw), so that we can hash it.
 
-hashSD ::
-  (Era era, ToCBOR (Core.Script era)) =>
-  TxWitness era ->
-  Maybe (ScriptDataHash (Crypto era))
-hashSD (w@(TxWitnessConstr (Memo (TxWitnessRaw _ _ scriptdata) _))) =
-  if (Map.null (witsScript w) && Map.null (witsData w) && Map.null (witsRdmr w))
-    then Nothing
-    else Just (ScriptDataHash (hashAnnotated scriptdata))
--}
+data WitnessPPDataRaw era
+  = WitnessPPDataRaw
+      !(Map.Map RdmrPtr (Data era)) -- From the witnesses
+      !(Set (LangDepView era)) -- From the Porotocl parameters
+  deriving (Show, Eq, Generic, Typeable)
 
-hashScriptData ::
+deriving instance NoThunks (WitnessPPDataRaw era)
+
+instance Era era => ToCBOR (WitnessPPDataRaw era) where
+  toCBOR (WitnessPPDataRaw m s) = encode (Rec WitnessPPDataRaw !> To m !> To s)
+
+instance Era era => FromCBOR (Annotator (WitnessPPDataRaw era)) where
+  fromCBOR =
+    decode
+      ( Ann (RecD WitnessPPDataRaw)
+          <*! D (decodeMapTraverse (pure <$> fromCBOR) fromCBOR)
+          <*! D (decodeAnnSet fromCBOR)
+      )
+
+decodeAnnSet :: Ord t => Decoder s (Annotator t) -> Decoder s (Annotator (Set t))
+decodeAnnSet dec = do xs <- decodeList dec; pure (Set.fromList <$> (sequence xs))
+
+newtype WitnessPPData era = WitnessPPDataConstr (MemoBytes (WitnessPPDataRaw era))
+  deriving (Show, Eq)
+  deriving newtype (ToCBOR, SafeToHash)
+
+deriving via
+  (Mem (WitnessPPDataRaw era))
+  instance
+    Era era => FromCBOR (Annotator (WitnessPPData era))
+
+pattern WitnessPPData ::
+  Era era =>
+  Map.Map RdmrPtr (Data era) ->
+  Set (LangDepView era) ->
+  WitnessPPData era
+pattern WitnessPPData mp s <-
+  WitnessPPDataConstr (Memo (WitnessPPDataRaw mp s) _)
+  where
+    WitnessPPData mp s =
+      WitnessPPDataConstr
+        . memoBytes
+        $ (Rec WitnessPPDataRaw !> To mp !> To s)
+
+instance (c ~ Crypto era) => HashAnnotated (WitnessPPData era) EraIndependentWitnessPPData c
+
+hashWitnessPPData ::
+  forall era.
   Era era =>
   PParams era ->
   Set Language ->
   Map.Map RdmrPtr (Data era) ->
-  Maybe (ScriptDataHash era)
-hashScriptData pp langs rdmrs =
+  Maybe (WitnessPPDataHash (Crypto era))
+hashWitnessPPData pp langs rdmrs =
   if Map.null rdmrs && Set.null langs
     then Nothing
     else
-      let _newset = Set.map (hashLanguagePP pp) langs
-       in undefined -- hash(rdmrs,_newset)
+      let newset = Set.map (getLanguageView pp) langs
+       in Just (hashAnnotated (WitnessPPData rdmrs newset))
 
 -- ===============================================================
 -- From the specification, Figure 5 "Functions related to fees"
@@ -547,8 +568,14 @@ collectNNScriptInputs _pp tx utxo =
     | (sp, scripthash) <- scriptsNeeded utxo tx, -- TODO, IN specification ORDER IS WRONG
       (d, eu) <- maybeToList (indexedRdmrs tx sp),
       script <- maybeToList (Map.lookup scripthash (txscripts (txwits tx))),
-      cost <- maybeToList (Map.lookup (language script) (_costmdls _pp))
+      cost <- case (language script) of
+        Nothing -> []
+        Just lang -> maybeToList (Map.lookup lang (_costmdls _pp))
   ]
+
+language :: AlonzoScript.Script era -> Maybe Language
+language (AlonzoScript.NativeScript _) = Nothing
+language (AlonzoScript.PlutusScript) = Just PlutusV1
 
 evalScripts :: (AlonzoScript.Script era, [Data era], ExUnits, CostModel) -> Bool
 evalScripts (AlonzoScript.NativeScript _timelock, _, _, _) = True
@@ -628,12 +655,6 @@ checkScriptData tx utxo (sp, _h) = any ok scripts
         || ( isJust (indexedRdmrs tx sp)
                && (not (isSpending sp) || not (null (getData tx utxo sp)))
            )
-
--- The function hashSD, specified in Figure 12
--- hashSD :: TxWitness era -> Maybe (ScriptDataHash (Crypto era))
--- is defined in Cardano.Ledger.Alonzo.TxWitness
-
--- languages:: TxWitness era -> Set Language  -- TODO
 
 txscripts ::
   (Era era, ToCBOR (Core.Script era)) =>

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -32,16 +32,17 @@ module Cardano.Ledger.Alonzo.TxBody
         txADhash,
         mint,
         exunits,
-        ppHash,
-        sdHash
+        sdHash,
+        scriptHash
       ),
     AlonzoBody,
+    EraIndependentWitnessPPData,
+    WitnessPPDataHash,
   )
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (DataHash)
-import Cardano.Ledger.Alonzo.PParams (PPHash (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits)
 import Cardano.Ledger.Alonzo.TxWitness (ScriptDataHash)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
@@ -50,6 +51,13 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value (..))
+import Cardano.Ledger.SafeHash
+  ( EraIndependentTxBody,
+    EraIndependentWitnessPPData,
+    HashAnnotated,
+    SafeHash,
+    SafeToHash,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.Val
   ( DecodeNonNegative,
@@ -76,7 +84,6 @@ import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.CompactAddr (CompactAddr, compactAddr, decompactAddr)
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
-import Shelley.Spec.Ledger.Hashing
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.TxBody (TxIn (..), Wdrl (Wdrl), unWdrl)
 import Prelude hiding (lookup)
@@ -141,6 +148,8 @@ pattern TxOut addr vl dh <-
 
 {-# COMPLETE TxOut #-}
 
+type WitnessPPDataHash crypto = SafeHash crypto EraIndependentWitnessPPData
+
 data TxBodyRaw era = TxBodyRaw
   { _inputs :: !(Set (TxIn (Crypto era))),
     _inputs_fee :: !(Set (TxIn (Crypto era))),
@@ -156,7 +165,7 @@ data TxBodyRaw era = TxBodyRaw
     -- Cardano.Ledger.Mary.Value.Value, not a Core.Value.
     -- Operations on the TxBody in the AlonzoEra depend upon this.
     _exunits :: !ExUnits,
-    _ppHash :: !(StrictMaybe (PPHash (Crypto era))),
+    _sdHash :: !(StrictMaybe (WitnessPPDataHash (Crypto era))),
     _scriptHash :: !(StrictMaybe (ScriptDataHash (Crypto era)))
   }
   deriving (Generic, Typeable)
@@ -178,6 +187,7 @@ deriving instance
 
 newtype TxBody era = TxBodyConstr (MemoBytes (TxBodyRaw era))
   deriving (ToCBOR)
+  deriving newtype (SafeToHash)
 
 deriving newtype instance
   ( Eq (Core.Value era),
@@ -230,7 +240,7 @@ pattern TxBody ::
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   Value (Crypto era) ->
   ExUnits ->
-  StrictMaybe (PPHash (Crypto era)) ->
+  StrictMaybe (WitnessPPDataHash (Crypto era)) ->
   StrictMaybe (ScriptDataHash (Crypto era)) ->
   TxBody era
 pattern TxBody
@@ -245,8 +255,8 @@ pattern TxBody
     txADhash,
     mint,
     exunits,
-    ppHash,
-    sdHash
+    sdHash,
+    scriptHash
   } <-
   TxBodyConstr
     ( Memo
@@ -262,8 +272,8 @@ pattern TxBody
             _adHash = txADhash,
             _mint = mint,
             _exunits = exunits,
-            _ppHash = ppHash,
-            _scriptHash = sdHash
+            _sdHash = sdHash,
+            _scriptHash = scriptHash
           }
         _
       )
@@ -280,7 +290,7 @@ pattern TxBody
       adHash'
       mint'
       exunits'
-      ppHash'
+      sdHash'
       scriptHash' =
         TxBodyConstr $
           memoBytes
@@ -297,14 +307,13 @@ pattern TxBody
                   adHash'
                   mint'
                   exunits'
-                  ppHash'
+                  sdHash'
                   scriptHash'
             )
 
 {-# COMPLETE TxBody #-}
 
-instance Era era => HashAnnotated (TxBody era) era where
-  type HashIndex (TxBody era) = EraIndependentTxBody
+instance (c ~ Crypto era, Era era) => HashAnnotated (TxBody era) EraIndependentTxBody c
 
 --------------------------------------------------------------------------------
 -- Serialisation
@@ -358,7 +367,7 @@ encodeTxBodyRaw
       _adHash,
       _mint,
       _exunits,
-      _ppHash,
+      _sdHash,
       _scriptHash
     } =
     Keyed
@@ -377,7 +386,7 @@ encodeTxBodyRaw
       !> encodeKeyedStrictMaybe 8 bot
       !> Omit isZero (Key 9 (E encodeMint _mint))
       !> Omit (== mempty) (Key 10 (To _exunits))
-      !> encodeKeyedStrictMaybe 11 _ppHash
+      !> encodeKeyedStrictMaybe 11 _sdHash
       !> encodeKeyedStrictMaybe 12 _scriptHash
     where
       encodeKeyedStrictMaybe key x =
@@ -421,6 +430,7 @@ instance
           mempty
           SNothing
           SNothing
+      bodyFields :: (Word -> Field (TxBodyRaw era))
       bodyFields 0 =
         field
           (\x tx -> tx {_inputs = x})
@@ -451,7 +461,7 @@ instance
           (D (SJust <$> fromCBOR))
       bodyFields 9 = field (\x tx -> tx {_mint = x}) (D decodeMint)
       bodyFields 10 = field (\x tx -> tx {_exunits = x}) From
-      bodyFields 11 = field (\x tx -> tx {_ppHash = x}) (D (SJust <$> fromCBOR))
+      bodyFields 11 = field (\x tx -> tx {_sdHash = x}) (D (SJust <$> fromCBOR))
       bodyFields 12 =
         field
           (\x tx -> tx {_scriptHash = x})

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -13,9 +13,10 @@
 module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (Data (..), DataHash (..), PlutusData (..))
-import Cardano.Ledger.Alonzo.PParams (PPHash (..))
-import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..), Tag (..))
+import Cardano.Ledger.Alonzo.Data (Data (..), PlutusData (..))
+import Cardano.Ledger.Alonzo.Language
+import Cardano.Ledger.Alonzo.PParams
+import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Prices (..), Script (..), Tag (..))
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( IsFee (..),
@@ -23,17 +24,19 @@ import Cardano.Ledger.Alonzo.TxBody
   )
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.SafeHash (HasAlgorithm, SafeHash, unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesValue)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
 
--- TODO correct arbitrary generator for Data
 instance Arbitrary (Data era) where
-  arbitrary = pure (Data NotReallyData)
+  arbitrary = Data <$> arbitrary
+
+instance Arbitrary PlutusData where
+  arbitrary = pure NotReallyData
 
 instance Arbitrary Tag where
   arbitrary = elements [Spend, Mint, Cert, Rewrd]
@@ -72,11 +75,8 @@ instance
   where
   arbitrary = ScriptData <$> arbitrary <*> arbitrary <*> arbitrary
 
-deriving newtype instance CC.Crypto c => Arbitrary (ScriptDataHash c)
-
-deriving newtype instance CC.Crypto c => Arbitrary (DataHash c)
-
-deriving newtype instance CC.Crypto c => Arbitrary (PPHash c)
+instance HasAlgorithm c => Arbitrary (SafeHash c i) where
+  arbitrary = unsafeMakeSafeHash <$> arbitrary
 
 deriving newtype instance Arbitrary IsFee
 
@@ -127,3 +127,65 @@ instance Mock c => Arbitrary (Tx (AlonzoEra c)) where
 
 instance Mock c => Arbitrary (Script (AlonzoEra c)) where
   arbitrary = frequency [(1, pure PlutusScript), (9, NativeScript <$> arbitrary)]
+
+-- ==========================
+--
+
+instance Arbitrary Language where
+  arbitrary = elements [PlutusV1]
+
+instance Arbitrary Prices where
+  arbitrary = Prices <$> arbitrary <*> arbitrary
+
+instance Arbitrary CostModel where
+  arbitrary = CostModel <$> arbitrary
+
+instance Arbitrary (PParams era) where
+  arbitrary =
+    PParams
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance Arbitrary (PParamsUpdate era) where
+  arbitrary =
+    PParams
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -6,7 +6,8 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Tripping where
 import Cardano.Binary
 import Cardano.Ledger.Alonzo
 import Cardano.Ledger.Alonzo.Data
-import Cardano.Ledger.Alonzo.Tx (Tx)
+import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate)
+import Cardano.Ledger.Alonzo.Tx (CostModel, Tx)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Data.ByteString.Base16.Lazy as Base16
@@ -56,5 +57,11 @@ tests =
       testProperty "alonzo/TxBody" $
         trippingAnn @(TxBody (AlonzoEra C_Crypto)),
       testProperty "alonzo/Tx" $
-        trippingAnn @(Tx (AlonzoEra C_Crypto))
+        trippingAnn @(Tx (AlonzoEra C_Crypto)),
+      testProperty "alonzo/CostModel" $
+        trippingAnn @CostModel,
+      testProperty "alonzo/PParams" $
+        trippingAnn @(PParams (AlonzoEra C_Crypto)),
+      testProperty "alonzo/PParamUpdate" $
+        trippingAnn @(PParamsUpdate (AlonzoEra C_Crypto))
     ]

--- a/semantics/executable-spec/src/Data/Coders.hs
+++ b/semantics/executable-spec/src/Data/Coders.hs
@@ -41,6 +41,8 @@ module Data.Coders
     Dual(..),
     Field(..),
     field,
+    fieldA,
+    fieldAA,
     encode,
     decode,
     runE,            -- Used in testing
@@ -80,6 +82,7 @@ where
 
 import Cardano.Prelude (cborError)
 import Control.Monad (replicateM,unless)
+import Control.Applicative(liftA2)
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding)
 import Cardano.Binary
@@ -321,6 +324,16 @@ data Field t where
 
 field :: (x -> t -> t) -> Decode ('Closed d) x -> Field t
 field update dec = Field update (decode dec)
+
+-- In order to sparse decode something with a (FromCBOR (Annotator t)) instance
+-- we can use these 'field' like functions.
+
+fieldA  :: Applicative ann => (x -> t -> t) -> Decode ('Closed d) x -> Field (ann t)
+fieldA update dec  = Field (liftA2 update) (pure <$> decode dec)
+
+fieldAA :: Applicative ann => (x -> t -> t) -> Decode ('Closed d) (ann x) -> Field (ann t)
+fieldAA update dec  = Field (liftA2 update) (decode dec)
+
 
 -- ===========================================================
 -- The coders and the decoders as GADT datatypes

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -7,8 +7,6 @@
 
 module Cardano.Ledger.ShelleyMA where
 
-import Cardano.Binary (toCBOR)
-import Cardano.Crypto.Hash (castHash, hashWithSerialiser)
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
     ValidateAuxiliaryData (..),
@@ -17,6 +15,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value)
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData, pattern AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Timelocks
@@ -108,10 +107,9 @@ instance
 
 instance
   ( CryptoClass.Crypto c,
-    Typeable ma,
     Core.AnnotatedData (Core.Script (ShelleyMAEra ma c))
   ) =>
   ValidateAuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c)
   where
-  hashAuxiliaryData = AuxiliaryDataHash . castHash . hashWithSerialiser toCBOR
   validateAuxiliaryData (AuxiliaryData md as) = deepseq as $ all validMetadatum md
+  hashAuxiliaryData aux = AuxiliaryDataHash (hashAnnotated aux)

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -23,7 +24,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), peekTokenType)
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Pretty
   ( PDoc,
     PrettyA (..),
@@ -34,6 +35,7 @@ import Cardano.Ledger.Pretty
     ppWord64,
     text,
   )
+import Cardano.Ledger.SafeHash (EraIndependentAuxiliaryData, HashAnnotated, SafeToHash)
 import Codec.CBOR.Decoding
   ( TokenType
       ( TypeListLen,
@@ -82,7 +84,9 @@ deriving instance
 
 newtype AuxiliaryData era = AuxiliaryDataWithBytes (MemoBytes (AuxiliaryDataRaw era))
   deriving (Generic, Typeable)
-  deriving newtype (ToCBOR)
+  deriving newtype (ToCBOR, SafeToHash)
+
+instance (c ~ Crypto era) => HashAnnotated (AuxiliaryData era) EraIndependentAuxiliaryData c
 
 deriving newtype instance
   (Era era, Core.ChainData (Core.Script era)) =>

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -284,7 +284,7 @@ utxoTransition = do
   -- the check `adaPolicy ∉ supp mint tx` in the spec.
   Val.coin (getField @"mint" txb) == Val.zero ?! TriesToForgeADA
 
-  let outputs = Map.elems $ unUTxO (txouts txb)
+  let outputs = Map.elems $ unUTxO (txouts @era txb)
       minUTxOValue = _minUTxOValue pp
       outputsTooSmall =
         filter
@@ -332,7 +332,7 @@ utxoTransition = do
 
   pure
     Shelley.UTxOState
-      { Shelley._utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts txb),
+      { Shelley._utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts @era txb),
         Shelley._deposited = deposits' <> depositChange,
         Shelley._fees = fees <> getField @"txfee" txb,
         Shelley._ppups = ppup'

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -11,7 +11,7 @@
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash, ValidateAuxiliaryData)
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (PolicyID, Value, policies, policyID)
@@ -122,7 +122,6 @@ instance
     UsesAuxiliary era,
     UsesScript era,
     ValidateScript era,
-    ValidateAuxiliaryData era,
     GetPolicies (Core.Value era) (Crypto era),
     Embed (Core.EraRule "UTXO" era) (UTXOW era),
     Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.Pretty
     ppUpdate,
     ppWdrl,
   )
+import Cardano.Ledger.SafeHash (EraIndependentTxBody, HashAnnotated, SafeToHash)
 import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), ppValidityInterval)
 import Cardano.Ledger.Val
@@ -88,7 +89,6 @@ import GHC.Records
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (..))
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.Serialization (encodeFoldable)
 import Shelley.Spec.Ledger.TxBody
@@ -243,6 +243,7 @@ initial =
 
 newtype TxBody e = TxBodyConstr (MemoBytes (TxBodyRaw e))
   deriving (Typeable)
+  deriving newtype (SafeToHash)
 
 deriving instance
   TransValue Eq era =>
@@ -266,8 +267,7 @@ deriving via
     (FamsFrom era) =>
     FromCBOR (Annotator (TxBody era))
 
-instance Era era => HashAnnotated (TxBody era) era where
-  type HashIndex (TxBody era) = EraIndependentTxBody
+instance (c ~ Crypto era, Era era) => HashAnnotated (TxBody era) EraIndependentTxBody c
 
 -- Make a Pattern so the newtype and the MemoBytes are hidden
 

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -30,7 +30,7 @@ import qualified Data.Set as Set
 import Shelley.Spec.Ledger.API (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash(hashAnnotated)
 import Shelley.Spec.Ledger.Keys (KeyPair (..), asWitness, hashKey)
 import Shelley.Spec.Ledger.LedgerState (AccountState (..))
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams)
@@ -71,7 +71,7 @@ unboundedInterval :: ValidityInterval
 unboundedInterval = ValidityInterval SNothing SNothing
 
 bootstrapTxId :: TxId TestCrypto
-bootstrapTxId = txid txb
+bootstrapTxId = txid @(MaryEra TestCrypto) txb
   where
     txb :: TxBody MaryTest
     txb =
@@ -201,7 +201,7 @@ expectedUTxOSimpleEx1 :: UTxO MaryTest
 expectedUTxOSimpleEx1 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodySimpleEx1) 0, TxOut Cast.aliceAddr tokensSimpleEx1),
+      [ (TxIn (txid @MaryTest txbodySimpleEx1) 0, TxOut Cast.aliceAddr tokensSimpleEx1),
         (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
@@ -229,7 +229,7 @@ bobTokensSimpleEx2 =
 txbodySimpleEx2 :: TxBody MaryTest
 txbodySimpleEx2 =
   makeTxb
-    [TxIn (txid txbodySimpleEx1) 0]
+    [TxIn (txid @MaryTest txbodySimpleEx1) 0]
     [ TxOut Cast.aliceAddr aliceTokensSimpleEx2,
       TxOut Cast.bobAddr bobTokensSimpleEx2
     ]
@@ -247,8 +247,8 @@ expectedUTxOSimpleEx2 :: UTxO MaryTest
 expectedUTxOSimpleEx2 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodySimpleEx2) 0, TxOut Cast.aliceAddr aliceTokensSimpleEx2),
-        (TxIn (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2),
+      [ (TxIn (txid @MaryTest txbodySimpleEx2) 0, TxOut Cast.aliceAddr aliceTokensSimpleEx2),
+        (TxIn (txid @MaryTest txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2),
         (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
@@ -342,7 +342,7 @@ expectedUTxOTimeEx1 :: UTxO MaryTest
 expectedUTxOTimeEx1 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodyTimeEx1Valid) 0, TxOut Cast.aliceAddr tokensTimeEx1),
+      [ (TxIn (txid @MaryTest txbodyTimeEx1Valid) 0, TxOut Cast.aliceAddr tokensTimeEx1),
         (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
@@ -365,7 +365,7 @@ aliceCoinsTimeEx2 = aliceCoinSimpleEx1 <-> (feeEx <+> mintTimeEx2)
 txbodyTimeEx2 :: TxBody MaryTest
 txbodyTimeEx2 =
   makeTxb
-    [TxIn (txid txbodyTimeEx1Valid) 0]
+    [TxIn (txid @MaryTest txbodyTimeEx1Valid) 0]
     [ TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2),
       TxOut Cast.bobAddr bobTokensTimeEx2
     ]
@@ -386,8 +386,8 @@ expectedUTxOTimeEx2 :: UTxO MaryTest
 expectedUTxOTimeEx2 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodyTimeEx2) 0, TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2)),
-        (TxIn (txid txbodyTimeEx2) 1, TxOut Cast.bobAddr bobTokensTimeEx2),
+      [ (TxIn (txid @MaryTest txbodyTimeEx2) 0, TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2)),
+        (TxIn (txid @MaryTest txbodyTimeEx2) 1, TxOut Cast.bobAddr bobTokensTimeEx2),
         (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
@@ -446,7 +446,7 @@ expectedUTxOSingWitEx1 :: UTxO MaryTest
 expectedUTxOSingWitEx1 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodySingWitEx1) 0, TxOut Cast.bobAddr tokensSingWitEx1),
+      [ (TxIn (txid @MaryTest txbodySingWitEx1) 0, TxOut Cast.bobAddr tokensSingWitEx1),
         (TxIn bootstrapTxId 0, TxOut Cast.aliceAddr (Val.inject aliceInitCoin))
       ]
 
@@ -484,7 +484,7 @@ aliceTokensNegEx1 =
 txbodyNegEx1 :: TxBody MaryTest
 txbodyNegEx1 =
   makeTxb
-    [TxIn (txid txbodySimpleEx2) 0]
+    [TxIn (txid @MaryTest txbodySimpleEx2) 0]
     [TxOut Cast.aliceAddr aliceTokensNegEx1]
     unboundedInterval
     mintNegEx1
@@ -506,9 +506,9 @@ expectedUTxONegEx1 :: UTxO MaryTest
 expectedUTxONegEx1 =
   UTxO $
     Map.fromList
-      [ (TxIn (txid txbodyNegEx1) 0, TxOut Cast.aliceAddr aliceTokensNegEx1),
+      [ (TxIn (txid @MaryTest txbodyNegEx1) 0, TxOut Cast.aliceAddr aliceTokensNegEx1),
         (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin)),
-        (TxIn (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2)
+        (TxIn (txid @MaryTest txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2)
       ]
 
 --
@@ -529,7 +529,7 @@ aliceTokensNegEx2 =
 txbodyNegEx2 :: TxBody MaryTest
 txbodyNegEx2 =
   makeTxb
-    [TxIn (txid txbodySimpleEx2) 0]
+    [TxIn (txid @MaryTest txbodySimpleEx2) 0]
     [TxOut Cast.aliceAddr aliceTokensNegEx2]
     unboundedInterval
     mintNegEx2

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -25,6 +25,7 @@ library
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
     Cardano.Ledger.Pretty
+    Cardano.Ledger.SafeHash
     Cardano.Ledger.Shelley
     Cardano.Ledger.Shelley.Constraints
     Cardano.Ledger.Val
@@ -45,7 +46,6 @@ library
     Shelley.Spec.Ledger.EpochBoundary
     Shelley.Spec.Ledger.Genesis
     Shelley.Spec.Ledger.HardForks
-    Shelley.Spec.Ledger.Hashing
     Shelley.Spec.Ledger.Keys
     Shelley.Spec.Ledger.LedgerState
     Shelley.Spec.Ledger.Metadata

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/AuxiliaryData.hs
@@ -23,13 +23,15 @@ import Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.SafeHash
+  ( EraIndependentAuxiliaryData,
+    SafeHash,
+  )
 import Control.DeepSeq (NFData (..))
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentMetadata)
-import Shelley.Spec.Ledger.Keys (Hash)
 
 newtype AuxiliaryDataHash crypto = AuxiliaryDataHash
-  { unsafeAuxiliaryDataHash :: Hash crypto EraIndependentMetadata
+  { unsafeAuxiliaryDataHash :: SafeHash crypto EraIndependentAuxiliaryData
   }
   deriving (Show, Eq, Ord, NoThunks, NFData)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Compactible (Compactible (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.SafeHash (SafeHash, extractHash)
 import Codec.Binary.Bech32
 import Control.Monad.Identity (Identity)
 import Control.SetAlgebra (forwards)
@@ -648,10 +649,15 @@ instance (Era era, PrettyA (Core.Script era)) => PrettyA (WitnessSetHKD Identity
 -- ============================
 --  Cardano.Ledger.AuxiliaryData
 
+ppSafeHash :: SafeHash crypto index -> PDoc
+ppSafeHash x = ppHash (extractHash x)
+
 ppAuxiliaryDataHash :: AuxiliaryDataHash c -> PDoc
-ppAuxiliaryDataHash (AuxiliaryDataHash h) = ppSexp "AuxiliaryDataHash" [ppHash h]
+ppAuxiliaryDataHash (AuxiliaryDataHash h) = ppSexp "AuxiliaryDataHash" [ppSafeHash h]
 
 instance PrettyA (AuxiliaryDataHash c) where prettyA = ppAuxiliaryDataHash
+
+instance PrettyA (SafeHash c i) where prettyA = ppSafeHash
 
 -- ============================
 --  Cardano.Ledger.Compactible
@@ -699,7 +705,7 @@ ppWdrl :: Wdrl c -> PDoc
 ppWdrl (Wdrl m) = ppSexp "" [ppMap' (text "Wdr") ppRewardAcnt ppCoin m]
 
 ppTxId :: TxId c -> PDoc
-ppTxId (TxId x) = ppSexp "TxId" [ppHash x]
+ppTxId (TxId x) = ppSexp "TxId" [ppSafeHash x]
 
 ppTxIn :: TxIn c -> PDoc
 ppTxIn (TxInCompact txid word) = ppSexp "TxIn" [ppTxId txid, ppWord64 word]

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/SafeHash.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.SafeHash
+  ( SafeHash,
+    SafeToHash (..),
+    castSafeHash,
+    HashAnnotated,
+    hashAnnotated,
+    indexProxy,
+    HashWithCrypto (..),
+    HasAlgorithm,
+    extractHash,
+    EraIndependentTx,
+    EraIndependentTxBody,
+    EraIndependentBlockBody,
+    EraIndependentMetadata,
+    EraIndependentScript,
+    EraIndependentData,
+    EraIndependentScriptData,
+    EraIndependentAuxiliaryData,
+    EraIndependentPParamView,
+    EraIndependentWitnessPPData,
+    unsafeMakeSafeHash,
+  )
+where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import qualified Cardano.Crypto.Hash as Hash
+import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Prelude (HeapWords (..))
+import Control.DeepSeq (NFData)
+import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString, fromShort)
+import Data.MemoBytes (MemoBytes (..))
+import Data.Typeable
+import NoThunks.Class (NoThunks (..))
+
+-- ==========================================================
+
+-- | A SafeHash is a hash of something that is safe to hash. Such types store
+--     their own serialisation bytes. The prime example is (MemoBytes t), but other
+--     examples are things that consist of only ByteStrings.
+--
+--     We do NOT export the constructor SafeHash, but instead export other functions
+--     such as 'hashWithCrypto, 'hashAnnotated' and 'extractHash' which have constraints
+--     that limit their application to types which preserve their original serialization
+--     bytes.
+newtype SafeHash crypto index = SafeHash (Hash.Hash (CC.HASH crypto) index)
+  deriving (Show, Eq, Ord, SafeToHash, NoThunks, NFData)
+
+deriving newtype instance HeapWords (Hash.Hash (CC.HASH c) i) => HeapWords (SafeHash c i)
+
+deriving instance (Typeable index, CC.Crypto c) => ToCBOR (SafeHash c index)
+
+deriving instance (Typeable index, CC.Crypto c) => FromCBOR (SafeHash c index)
+
+type HasAlgorithm c = Hash.HashAlgorithm (CC.HASH c)
+
+extractHash :: SafeHash crypto i -> Hash.Hash (CC.HASH crypto) i
+extractHash (SafeHash h) = h
+
+-- | To change the index parameter of SafeHash (which is a phantom type) use castSafeHash
+castSafeHash :: forall i j c. SafeHash c i -> SafeHash c j
+castSafeHash (SafeHash h) = SafeHash (Hash.castHash h)
+
+-- Don't use this except in Testing to make Arbitrary instances, etc.
+unsafeMakeSafeHash :: (Hash.Hash (CC.HASH crypto) index) -> SafeHash crypto index
+unsafeMakeSafeHash x = SafeHash x
+
+-- =====================================================================
+
+-- | Only Types that preserve their serialisation bytes are members of the
+-- class SafeToHash. There are only a limited number of primitive direct
+-- instances of SafeToHash, all but two of them are present in this file. Instead
+-- of making explicit instances, we almost always use a newtype (around a type S)
+-- where their is already an instance (SafeToHash S). In that case the newtype
+-- has its SafeToHash instance derived using newtype deriving. The only exceptions
+-- are the legacy Shelley types Metadata and Tx that preserve their serialisation bytes
+-- using a different mechanism than MemoBytes.  SafeToHash is a superclass
+-- requirement of the classes HashAnnotated and HashWithCrypto (below) which
+-- provide more convenient ways to construct SafeHashes than using makeHashWithExplicitProxys.
+class SafeToHash t where
+  originalBytes :: t -> ByteString
+  makeHashWithExplicitProxys :: HasAlgorithm c => Proxy c -> Proxy index -> t -> SafeHash c index
+  makeHashWithExplicitProxys _ _ x = SafeHash $ Hash.castHash (Hash.hashWith originalBytes x)
+
+-- There are a limited number of direct instances. Everything else should come
+-- from newtype deriving.
+
+instance SafeToHash (MemoBytes t) where
+  originalBytes = fromShort . memobytes
+
+instance SafeToHash ShortByteString where
+  originalBytes x = fromShort x
+
+instance SafeToHash ByteString where
+  originalBytes x = x
+
+-- Note how SafeHash is SafeToHash. Its instance is derived because it is
+-- a newtype around (Hash.Hash c i) which is a primitive SafeToHash type.
+
+instance SafeToHash (Hash.Hash c i) where
+  originalBytes (Hash.UnsafeHash b) = fromShort b
+
+-- =====================================================================
+{-   Types that are SafeToHash, AND have both of the following two invariants,
+     are made members of the HashAnnotated class. The preconditions are:
+     1) The type uniquely determines the 'index' type tag of (SafeHash crypto index)
+     2) The type uniquely determines the 'crypto' type of (SafeHash crytop index)
+
+     The SafeToHash and the HashAnnotated classes are designed so that their
+     instances can be easily derived (because their methods have default methods
+     when the type is a newtype around a type that is SafeToHash). For example,
+     given (SafeToHash S) then:
+
+     newtype T era = T S
+        deriving Eq
+        deriving newtype SafeToHash   -- Uses {-# LANGUAGE DerivingStrategies #-}
+
+     instance HashAnnotated (T era) Index (Crypto era)
+
+     After these declarations. One specialization of 'hashAnnotated' is
+     hashAnnotated :: Era e => T e -> SafeHash (Crypto e) Index
+-}
+class SafeToHash x => HashAnnotated x i c | x -> i c where
+  indexProxy :: x -> Proxy i
+  indexProxy _ = Proxy @i
+
+hashAnnotated :: forall c i x. (HasAlgorithm c, HashAnnotated x i c) => x -> SafeHash c i
+hashAnnotated x = makeHashWithExplicitProxys (Proxy @c) (Proxy @i) x
+
+-- ========================================================================
+
+-- | When the type being hashed: 'x' determines the 'index' tag but not the 'crypto'
+--     make the type an instance of HashWithCrypto.
+class SafeToHash x => HashWithCrypto x index | x -> index where
+  hashWithCrypto :: forall crypto. HasAlgorithm crypto => Proxy crypto -> x -> SafeHash crypto index
+  hashWithCrypto proxy y = makeHashWithExplicitProxys proxy (Proxy @index) y
+
+-- ==============================================================
+-- We export a bunch of uninhabited types to use as
+-- idexes that are Era independent
+
+data EraIndependentTx
+
+data EraIndependentTxBody
+
+data EraIndependentBlockBody
+
+data EraIndependentMetadata
+
+data EraIndependentAuxiliaryData
+
+data EraIndependentScript
+
+data EraIndependentData
+
+data EraIndependentScriptData
+
+data EraIndependentPParamView
+
+data EraIndependentWitnessPPData

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -10,19 +10,17 @@
 -- exposed in @module Shelley.Spec.Ledger.API@.
 module Cardano.Ledger.Shelley where
 
-import Cardano.Binary (toCBOR)
-import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
     ValidateAuxiliaryData (..),
   )
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.SafeHash (EraIndependentAuxiliaryData, makeHashWithExplicitProxys)
 import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
+import Data.Proxy
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.Keys (hashWithSerialiser)
 import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
@@ -69,5 +67,7 @@ instance
   hashScript = hashMultiSigScript
 
 instance CryptoClass.Crypto c => ValidateAuxiliaryData (ShelleyEra c) where
-  hashAuxiliaryData = AuxiliaryDataHash . Hash.castHash . hashWithSerialiser @(HASH c) toCBOR
   validateAuxiliaryData (Metadata m) = all validMetadatum m
+  hashAuxiliaryData metadata = AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)
+    where
+      index = Proxy @EraIndependentAuxiliaryData

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -8,6 +8,7 @@
 module Cardano.Ledger.Shelley.Constraints where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
   ( AnnotatedData,
@@ -20,16 +21,16 @@ import Cardano.Ledger.Core
     Value,
   )
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.SafeHash
+  ( EraIndependentTxBody,
+    HashAnnotated,
+  )
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
 import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy)
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Address (Addr)
 import Shelley.Spec.Ledger.CompactAddr (CompactAddr)
-import Shelley.Spec.Ledger.Hashing
-  ( EraIndependentTxBody,
-    HashAnnotated (..),
-  )
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -39,8 +40,7 @@ type UsesTxBody era =
   ( Era era,
     ChainData (TxBody era),
     AnnotatedData (TxBody era),
-    HashAnnotated (TxBody era) era,
-    HashIndex (TxBody era) ~ EraIndependentTxBody
+    HashAnnotated (TxBody era) EraIndependentTxBody (Crypto era)
   )
 
 class
@@ -79,6 +79,7 @@ type UsesAuxiliary era =
   ( Era era,
     Eq (AuxiliaryData era),
     Show (AuxiliaryData era),
+    ValidateAuxiliaryData era,
     AnnotatedData (AuxiliaryData era)
   )
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/ByronTranslation.hs
@@ -19,6 +19,7 @@ import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Hashing
 import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<->))
 import qualified Data.ByteString.Short as SBS
@@ -42,7 +43,7 @@ translateTxIdByronToShelley ::
   Byron.TxId ->
   TxId c
 translateTxIdByronToShelley =
-  TxId . hashFromShortBytesE . Hashing.abstractHashToShort
+  TxId . unsafeMakeSafeHash . hashFromShortBytesE . Hashing.abstractHashToShort
 
 hashFromShortBytesE ::
   forall h a.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -38,6 +38,7 @@ import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.SafeHash (EraIndependentTxBody)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.Arrow (left, right)
 import Control.Monad.Except
@@ -71,7 +72,6 @@ import Shelley.Spec.Ledger.BlockChain
     prevHashToNonce,
   )
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody)
 import Shelley.Spec.Ledger.Keys (DSignable, GenDelegs, Hash, KESignable, VRFSignable)
 import Shelley.Spec.Ledger.LedgerState
   ( EpochState (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -49,6 +49,7 @@ import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as WC
 import Cardano.Ledger.Crypto (ADDRHASH, DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.SafeHash (EraIndependentTxBody)
 import Cardano.Prelude (panic)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
@@ -59,7 +60,6 @@ import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import Quiet
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody)
 import Shelley.Spec.Ledger.Keys
   ( Hash,
     KeyHash (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -82,6 +82,7 @@ import qualified Cardano.Crypto.VRF as VRF
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
+import Cardano.Ledger.SafeHash (EraIndependentBlockBody)
 import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody)
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
@@ -119,7 +120,6 @@ import Shelley.Spec.Ledger.BaseTypes
     strictMaybeToMaybe,
   )
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentBlockBody)
 import Shelley.Spec.Ledger.Keys
   ( CertifiedVRF,
     Hash,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -33,6 +33,7 @@ import Cardano.Crypto.KES.Class (totalPeriodsKES)
 import Cardano.Ledger.Crypto (HASH, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
+import Cardano.Ledger.SafeHash (EraIndependentTxBody, unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut (..), UsesValue)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (forceElemsToWHNF)
@@ -56,7 +57,6 @@ import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.Address
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody)
 import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.PParams
 import Shelley.Spec.Ledger.Serialization
@@ -315,6 +315,7 @@ initialFundsPseudoTxIn addr =
   where
     pseudoTxId =
       TxId
+        . unsafeMakeSafeHash
         . ( Crypto.castHash ::
               Crypto.Hash (HASH crypto) (Addr crypto) ->
               Crypto.Hash (HASH crypto) EraIndependentTxBody

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Metadata.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Metadata.hs
@@ -8,14 +8,17 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.Metadata
   ( Metadatum (..),
     Metadata (Metadata),
+    hashMetadata,
     validMetadatum,
   )
 where
@@ -29,6 +32,13 @@ import Cardano.Binary
     serializeEncoding,
     withSlice,
   )
+import Cardano.Ledger.SafeHash
+  ( EraIndependentMetadata,
+    HasAlgorithm,
+    HashWithCrypto (..),
+    SafeHash,
+    SafeToHash (..),
+  )
 import Cardano.Prelude (cborError)
 import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as CBOR
@@ -37,6 +47,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
+import Data.Proxy
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Word (Word64)
@@ -62,6 +73,20 @@ data Metadata = Metadata'
   }
   deriving (Eq, Show, Generic)
   deriving (NoThunks) via AllowThunksIn '["mdBytes"] Metadata
+
+-- Usually we derive SafetToHash instances, but since Metadata preserves its serialisation
+-- bytes we can just extract them here, and make an explicit SafeToHash instance.
+
+instance SafeToHash Metadata where
+  originalBytes = LBS.toStrict . mdBytes
+
+-- We can't use hashAnnotated since Metadata doesn't determine the crypto
+-- so we use the class HashWithCrypto that makes just the index implicit
+-- but the crypto explicit.
+instance HashWithCrypto Metadata EraIndependentMetadata
+
+hashMetadata :: HasAlgorithm c => Proxy c -> Metadata -> SafeHash c EraIndependentMetadata
+hashMetadata p m = hashWithCrypto p m
 
 pattern Metadata :: Map Word64 Metadatum -> Metadata
 pattern Metadata m <-

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardProvenance.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardProvenance.hs
@@ -16,6 +16,7 @@ import Cardano.Binary
     encodeDouble,
   )
 import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.SafeHash (SafeHash, unsafeMakeSafeHash)
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Coders
@@ -141,6 +142,9 @@ instance Default (Credential r e) where
 
 instance Default (RewardAcnt crypto) where
   def = RewardAcnt def def
+
+instance Default (SafeHash c i) where
+  def = unsafeMakeSafeHash def
 
 -- =======================================================
 -- Show instances

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -382,7 +382,7 @@ utxoInductive = do
   -- process Protocol Parameter Update Proposals
   ppup' <- trans @(Core.EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
-  let outputs = Map.elems $ unUTxO (txouts txb)
+  let outputs = Map.elems $ unUTxO (txouts @era txb)
       minUTxOValue = _minUTxOValue pp
       -- minUTxOValue deposit comparison done as Coin because this rule
       -- is correct strictly in the Shelley era (in shelleyMA we would need to
@@ -417,7 +417,7 @@ utxoInductive = do
 
   pure
     UTxOState
-      { _utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts txb),
+      { _utxo = eval ((txins @era txb ⋪ utxo) ∪ txouts @era txb),
         _deposited = deposits' <> depositChange,
         _fees = fees <> getField @"txfee" txb,
         _ppups = ppup'

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -31,6 +31,7 @@ import Cardano.Binary
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash,
     ValidateAuxiliaryData (..),
+    hashAuxiliaryData,
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
@@ -162,7 +163,6 @@ instance
     UsesAuxiliary era,
     UsesTxBody era,
     ValidateScript era,
-    ValidateAuxiliaryData era,
     Embed (Core.EraRule "UTXO" era) (UTXOW era),
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
@@ -279,7 +279,6 @@ utxoWitnessed ::
     UsesTxBody era,
     UsesTxOut era,
     ValidateScript era,
-    ValidateAuxiliaryData era,
     STS (utxow era),
     BaseM (utxow era) ~ ShelleyBase,
     Embed (Core.EraRule "UTXO" era) (utxow era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -36,6 +36,7 @@ import Cardano.Binary
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Crypto (ADDRHASH)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.SafeHash (EraIndependentScript)
 import Control.DeepSeq (NFData)
 import Data.Aeson
 import qualified Data.ByteString as BS
@@ -49,7 +50,6 @@ import Data.MemoBytes
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes (invalidKey)
-import Shelley.Spec.Ledger.Hashing (EraIndependentScript)
 import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (Witness))
 import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordSum, encodeFoldable)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
@@ -47,6 +47,7 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Shelley.Spec.Ledger.Examples.Cast (alicePoolParams)
 import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators (mkDummyHash)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
+import Cardano.Ledger.SafeHash(unsafeMakeSafeHash)
 
 genTestCase ::
   Int -> -- The size of the utxo
@@ -62,7 +63,7 @@ genTestCase numUTxO numAddr = do
         TxOutCompact
           (compactAddr addr)
           (fromJust $ toCompact $ Val.inject (Coin $ fromIntegral i))
-  let mktxid i = TxId $ mkDummyHash i
+  let mktxid i = TxId (unsafeMakeSafeHash (mkDummyHash i))
   let mktxin i = TxIn (mktxid i) (fromIntegral i)
   let utxo = Map.fromList $ zip (mktxin <$> [1 ..]) txOuts
       liveptrs :: [Ptr]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -11,7 +11,6 @@ module Shelley.Spec.Ledger.Bench.Gen
   )
 where
 
-import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
@@ -107,7 +106,6 @@ genBlock ge cs = generate $ GenBlock.genBlock ge cs
 genTriple ::
   ( EraGen era,
     Mock (Crypto era),
-    ValidateAuxiliaryData era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -84,6 +84,7 @@ library
     cardano-crypto-test,
     cardano-crypto-wrapper,
     cardano-crypto,
+    cardano-crypto-praos,
     cardano-ledger-test,
     cardano-ledger,
     cardano-prelude-test,
@@ -141,6 +142,7 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Rules.TestDeleg
       Test.Shelley.Spec.Ledger.Rules.TestPool
       Test.Shelley.Spec.Ledger.Rules.TestPoolreap
+      Test.Shelley.Spec.Ledger.SafeHash
       Test.Shelley.Spec.Ledger.Serialisation
       Test.Shelley.Spec.Ledger.Serialisation.CDDL
       Test.Shelley.Spec.Ledger.Serialisation.Golden.Address

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -49,7 +49,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DelegCert (..))
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( Hash,
     KeyHash,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -689,7 +689,7 @@ applyTxBody ls pp tx =
   ls
     { _utxoState =
         us
-          { _utxo = eval (txins @era tx ⋪ (_utxo us) ∪ txouts tx),
+          { _utxo = eval (txins @era tx ⋪ (_utxo us) ∪ txouts @era tx),
             _deposited = depositPoolChange ls pp tx,
             _fees = (getField @"txfee" tx) <> (_fees . _utxoState $ ls)
           },

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -47,6 +47,7 @@ import Test.Shelley.Spec.Ledger.Generator.Core
 import Test.Shelley.Spec.Ledger.Generator.Presets (someKeyPairs)
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass (ScriptClass, someScripts)
 import Test.Shelley.Spec.Ledger.Utils (Split (..))
+import Cardano.Ledger.SafeHash(unsafeMakeSafeHash)
 
 {------------------------------------------------------------------------------
  An EraGen instance makes it possible to run the Shelley property tests
@@ -119,7 +120,7 @@ genUtxo0 ge@(GenEnv _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
 genesisId ::
   Hash.HashAlgorithm (CC.HASH crypto) =>
   TxId crypto
-genesisId = TxId (mkDummyHash 0)
+genesisId = TxId (unsafeMakeSafeHash (mkDummyHash 0))
   where
     mkDummyHash :: forall h a. Hash.HashAlgorithm h => Int -> Hash.Hash h a
     mkDummyHash = coerce . Hash.hashWithSerialiser @h toCBOR

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -17,7 +17,6 @@
 module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 
 import Cardano.Binary (ToCBOR)
-import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints
@@ -89,7 +88,6 @@ instance
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
-    ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
@@ -133,7 +131,6 @@ instance
     UsesValue era,
     UsesAuxiliary era,
     Mock (Crypto era),
-    ValidateAuxiliaryData era,
     ShelleyLedgerSTS era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -20,7 +20,7 @@ module Test.Shelley.Spec.Ledger.Generator.Utxo
 where
 
 import Cardano.Binary (serialize)
-import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData (hashAuxiliaryData))
+import Cardano.Ledger.AuxiliaryData (hashAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.Constraints
@@ -62,10 +62,9 @@ import Shelley.Spec.Ledger.BaseTypes
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (SafeHash, EraIndependentTxBody, hashAnnotated)
 import Shelley.Spec.Ledger.Keys
-  ( Hash,
-    KeyHash,
+  ( KeyHash,
     KeyPair,
     KeyRole (..),
     asWitness,
@@ -171,7 +170,6 @@ genTx ::
     UsesTxOut era,
     UsesValue era,
     UsesAuxiliary era,
-    ValidateAuxiliaryData era,
     Mock (Crypto era),
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
@@ -427,7 +425,7 @@ genNextDelta
                         ksIndexedStakingKeys
                         vkeyPairs
                         (mkScriptWits @era msigPairs mempty)
-                        (hashAnnotated $ _body tx)
+                        (hashAnnotated (_body tx))
                 pure $
                   delta
                     { extraWitnesses = extraWitnesses <> newWits,
@@ -596,7 +594,7 @@ mkTxWits ::
   Map (KeyHash 'Staking (Crypto era)) (KeyPair 'Staking (Crypto era)) ->
   [KeyPair 'Witness (Crypto era)] ->
   Map (ScriptHash (Crypto era)) (Core.Script era) ->
-  Hash (Crypto era) EraIndependentTxBody ->
+  SafeHash (Crypto era) EraIndependentTxBody ->
   WitnessSet era
 mkTxWits
   indexedPaymentKeys

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -138,6 +138,7 @@ import Test.Shelley.Spec.Ledger.Serialisation.Generators.Bootstrap
   )
 import Test.Tasty.QuickCheck (Gen, choose, elements)
 import Control.State.Transition (STS (State))
+import Cardano.Ledger.SafeHash(SafeHash, HasAlgorithm, unsafeMakeSafeHash)
 
 -- =======================================================
 
@@ -146,6 +147,10 @@ genHash = mkDummyHash <$> arbitrary
 
 mkDummyHash :: forall h a. HashAlgorithm h => Int -> Hash.Hash h a
 mkDummyHash = coerce . hashWithSerialiser @h toCBOR
+
+genSafeHash :: HasAlgorithm c => Gen (SafeHash c i)
+genSafeHash = unsafeMakeSafeHash <$> arbitrary
+
 
 {-------------------------------------------------------------------------------
   Generators
@@ -261,12 +266,12 @@ maxTxWits :: Int
 maxTxWits = 5
 
 instance CC.Crypto crypto => Arbitrary (TxId crypto) where
-  arbitrary = TxId <$> genHash
+  arbitrary = TxId <$> genSafeHash
 
 instance CC.Crypto crypto => Arbitrary (TxIn crypto) where
   arbitrary =
     TxIn
-      <$> (TxId <$> genHash)
+      <$> (TxId <$> genSafeHash)
       <*> arbitrary
 
 instance
@@ -359,7 +364,7 @@ instance CC.Crypto crypto => Arbitrary (ScriptHash crypto) where
   arbitrary = ScriptHash <$> genHash
 
 instance CC.Crypto crypto => Arbitrary (AuxiliaryDataHash crypto) where
-  arbitrary = AuxiliaryDataHash <$> genHash
+  arbitrary = AuxiliaryDataHash <$> genSafeHash
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where
   arbitrary = genHash

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -48,7 +48,7 @@ import Shelley.Spec.Ledger.Credential
   ( Credential (..),
     StakeReference (..),
   )
-import Shelley.Spec.Ledger.Hashing (hashAnnotated)
+import Cardano.Ledger.SafeHash (extractHash, hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( GenDelegs (..),
     KeyRole (..),
@@ -217,14 +217,14 @@ aliceAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
 aliceWitness :: BootstrapWitness C_crypto
 aliceWitness =
   makeBootstrapWitness
-    (hashAnnotated txBody)
+    (extractHash (hashAnnotated txBody))
     aliceSigningKey
     (Byron.addrAttributes aliceByronAddr)
 
 aliceBadWitness :: BootstrapWitness C_crypto
 aliceBadWitness =
   makeBootstrapWitness
-    (hashAnnotated txBody {_ttl = SlotNo 100000000})
+    (extractHash (hashAnnotated txBody {_ttl = SlotNo 100000000}))
     aliceSigningKey
     (Byron.addrAttributes aliceByronAddr)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -192,7 +192,7 @@ newUTxO txb cs = cs {chainNes = nes'}
     ls = esLState es
     utxoSt = _utxoState ls
     utxo = _utxo utxoSt
-    utxo' = eval ((txins @era txb ⋪ utxo) ∪ txouts txb)
+    utxo' = eval ((txins @era txb ⋪ utxo) ∪ txouts @era txb)
     utxoSt' = utxoSt {_utxo = utxo'}
     ls' = ls {_utxoState = utxoSt'}
     es' = es {esLState = ls'}

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -30,7 +30,7 @@ import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential, Ptr (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DelegCert (..), MIRCert (..))
 import Shelley.Spec.Ledger.EpochBoundary (emptySnapShot)
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( KeyPair (..),
     KeyRole (..),
@@ -155,10 +155,8 @@ sufficientMIRWits = mirWits [0 .. 4]
 insufficientMIRWits :: (CryptoClass.Crypto c) => [KeyPair 'Witness c]
 insufficientMIRWits = mirWits [0 .. 3]
 
-txEx1 ::
-  forall c.
-  (Mock (Crypto (ShelleyEra c))) =>
-  [KeyPair 'Witness (Crypto (ShelleyEra c))] ->
+txEx1 :: forall c. (Mock c) =>
+  [KeyPair 'Witness c] ->
   MIRPot ->
   Tx (ShelleyEra c)
 txEx1 wits pot =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -47,7 +47,7 @@ import Shelley.Spec.Ledger.Delegation.Certificates
     PoolDistr (..),
   )
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys (asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..),
@@ -194,7 +194,7 @@ txEx1 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx1 @c)
+            (hashAnnotated (txbodyEx1 @c))
             ( (asWitness <$> [Cast.alicePay, Cast.carlPay])
                 <> (asWitness <$> [Cast.aliceStake])
                 <> [asWitness $ cold Cast.alicePoolKeys]
@@ -266,7 +266,7 @@ aliceCoinEx2Ptr = aliceCoinEx1 <-> (aliceCoinEx2Base <+> feeTx2)
 txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    { _inputs = Set.fromList [TxIn (txid txbodyEx1) 0],
+    { _inputs = Set.fromList [TxIn (txid @(ShelleyEra c) (txbodyEx1 @c)) 0],
       _outputs =
         StrictSeq.fromList
           [ TxOut Cast.aliceAddr (Val.inject aliceCoinEx2Base),
@@ -291,7 +291,7 @@ txEx2 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx2 @c)
+            (hashAnnotated (txbodyEx2 @c))
             [ asWitness Cast.alicePay,
               asWitness Cast.aliceStake,
               asWitness Cast.bobStake
@@ -404,7 +404,7 @@ aliceCoinEx4Base = aliceCoinEx2Base <-> feeTx4
 txbodyEx4 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx4 =
   TxBody
-    { _inputs = Set.fromList [TxIn (txid txbodyEx2) 0],
+    { _inputs = Set.fromList [TxIn (txid @(ShelleyEra c) txbodyEx2) 0],
       _outputs = StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx4Base)],
       _certs =
         StrictSeq.fromList
@@ -423,7 +423,7 @@ txEx4 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx4 @c)
+            (hashAnnotated (txbodyEx4 @c))
             [asWitness Cast.alicePay, asWitness Cast.carlStake]
       }
     SNothing
@@ -797,7 +797,7 @@ txEx10 =
     txbodyEx10
     mempty
       { addrWits =
-          makeWitnessesVKey (hashAnnotated $ txbodyEx10 @c) [asWitness Cast.bobPay, asWitness Cast.bobStake]
+          makeWitnessesVKey (hashAnnotated (txbodyEx10 @c)) [asWitness Cast.bobPay, asWitness Cast.bobStake]
       }
     SNothing
 
@@ -844,10 +844,10 @@ aliceCoinEx11Ptr = aliceCoinEx4Base <-> feeTx11
 aliceRetireEpoch :: EpochNo
 aliceRetireEpoch = EpochNo 5
 
-txbodyEx11 :: Cr.Crypto c => TxBody (ShelleyEra c)
+txbodyEx11 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx11 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx4) 0])
+    (Set.fromList [TxIn (txid @(ShelleyEra c) txbodyEx4) 0])
     (StrictSeq.singleton $ TxOut Cast.alicePtrAddr (Val.inject aliceCoinEx11Ptr))
     (StrictSeq.fromList [DCertPool (RetirePool (hk Cast.alicePoolKeys) aliceRetireEpoch)])
     (Wdrl Map.empty)
@@ -863,7 +863,7 @@ txEx11 =
     mempty
       { addrWits =
           makeWitnessesVKey
-            (hashAnnotated $ txbodyEx11 @c)
+            (hashAnnotated (txbodyEx11 @c))
             ( [asWitness Cast.alicePay]
                 <> [asWitness $ cold Cast.alicePoolKeys]
             )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -33,7 +33,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain (Block, bhHash, bheader)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.EpochBoundary (SnapShot (_poolParams), emptySnapShot)
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys (asWitness)
 import Shelley.Spec.Ledger.LedgerState (emptyRewardUpdate)
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
@@ -175,10 +175,10 @@ aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 newPoolParams :: Cr.Crypto c => PoolParams c
 newPoolParams = Cast.alicePoolParams {_poolCost = Coin 500}
 
-txbodyEx2 :: Cr.Crypto c => TxBody (ShelleyEra c)
+txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx1) 0])
+    (Set.fromList [TxIn (txid @(ShelleyEra c) txbodyEx1) 0])
     (StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx2)])
     ( StrictSeq.fromList
         ( [ DCertPool (RegPool newPoolParams)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
@@ -57,7 +57,7 @@ import Shelley.Spec.Ledger.Delegation.Certificates
     PoolDistr (..),
   )
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Updates.hs
@@ -31,7 +31,7 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.BlockChain (Block, bhHash, bheader)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys (asWitness, hashKey)
 import Shelley.Spec.Ledger.LedgerState (emptyRewardUpdate)
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
@@ -219,10 +219,10 @@ feeTx2 = Coin 1
 aliceCoinEx2 :: Coin
 aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 
-txbodyEx2 :: Cr.Crypto c => TxBody (ShelleyEra c)
+txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx1) 0])
+    (Set.fromList [TxIn (txid @(ShelleyEra c) txbodyEx1) 0])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr (Val.inject aliceCoinEx2))
     StrictSeq.empty
     (Wdrl Map.empty)
@@ -312,10 +312,10 @@ feeTx3 = Coin 1
 aliceCoinEx3 :: Coin
 aliceCoinEx3 = aliceCoinEx2 <-> feeTx3
 
-txbodyEx3 :: Cr.Crypto c => TxBody (ShelleyEra c)
+txbodyEx3 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx3 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx2) 0])
+    (Set.fromList [TxIn (txid @(ShelleyEra c) txbodyEx2) 0])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr (Val.inject aliceCoinEx3))
     StrictSeq.empty
     (Wdrl Map.empty)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -51,7 +51,7 @@ import Shelley.Spec.Ledger.BaseTypes
     textToUrl,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Hashing (EraIndependentTxBody, HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (EraIndependentTxBody, hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( DSignable,
     Hash,
@@ -177,7 +177,7 @@ txbSimpleUTxO =
       _mdHash = SNothing
     }
 
--- | to use makeWitnessVKey, we need to know we can sign the TxBody for that (ShelleyEra c)
+-- | to use makeWitnessesVKey, we need to know we can sign the TxBody for that (ShelleyEra c)
 type BodySignable era = DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody)
 
 txSimpleUTxO :: forall c. (Cr.Crypto c, BodySignable (ShelleyEra c)) => Tx (ShelleyEra c)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -24,7 +24,6 @@ import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition.Extended (PredicateFailure, TRC (..))
-import Data.Coerce (coerce)
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList)
@@ -50,7 +49,7 @@ import Shelley.Spec.Ledger.Credential
     pattern ScriptHashObj,
     pattern StakeRefBase,
   )
-import Shelley.Spec.Ledger.Hashing (hashAnnotated)
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( GenDelegs (..),
     KeyHash (..),
@@ -189,7 +188,7 @@ makeTx txBody keyPairs msigs = Tx txBody wits . maybeToStrictMaybe
   where
     wits =
       mempty
-        { addrWits = makeWitnessesVKey (coerce . hashAnnotated $ txBody) keyPairs,
+        { addrWits = makeWitnessesVKey (hashAnnotated $ txBody) keyPairs,
           scriptWits = msigs
         }
 
@@ -246,7 +245,7 @@ initialUTxOState aliceKeep msigs =
               (asWitness <$> [Cast.alicePay, Cast.bobPay])
               Map.empty
               Nothing
-       in ( txid $ _body tx,
+       in ( txid @(ShelleyEra c) $ _body tx,
             runShelleyBase $
               applySTSTest @(UTXOW (ShelleyEra c))
                 ( TRC

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -508,11 +508,11 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
             <> fold (unWdrl (getField @"wdrls" txb))
         outs =
           let certs = toList (getField @"certs" txb)
-           in Val.coin (balance (txouts txb))
+           in Val.coin (balance (txouts @era txb))
                 <> getField @"txfee" txb
                 <> totalDeposits pp_ pools certs
 
-preserveOutputsTx ::
+preserveOutputsTx :: forall era.
   ( ChainProperty era,
     UsesTxOut era,
     TransValue ToCBOR era,
@@ -537,7 +537,7 @@ preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
   where
     (_, ledgerTr) = ledgerTraceFromBlock chainSt block
     outputPreserved SourceSignalTarget {target = (UTxOState {_utxo = (UTxO u')}, _), signal = tx} =
-      let UTxO outs = txouts (_body tx)
+      let UTxO outs = txouts @era (_body tx)
        in property $
             outs `Map.isSubmapOf` u'
 
@@ -573,7 +573,7 @@ eliminateTxInputs SourceSignalTarget {source = chainSt, signal = block} =
 
 -- | Collision-Freeness of new TxIds - checks that all new outputs of a Tx are
 -- included in the new UTxO and that all TxIds are new.
-newEntriesAndUniqueTxIns ::
+newEntriesAndUniqueTxIns :: forall era.
   ( ChainProperty era,
     UsesTxOut era,
     TransValue ToCBOR era,
@@ -603,7 +603,7 @@ newEntriesAndUniqueTxIns SourceSignalTarget {source = chainSt, signal = block} =
           signal = tx,
           target = (UTxOState {_utxo = (UTxO u')}, _)
         } =
-        let UTxO outs = txouts (_body tx)
+        let UTxO outs = txouts @era (_body tx)
             outIds = Set.map (\(TxIn _id _) -> _id) (domain outs)
             oldIds = Set.map (\(TxIn _id _) -> _id) (domain u)
          in property $

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Test.Shelley.Spec.Ledger.SafeHash (safeHashTest) where
+
+import Cardano.Ledger.SafeHash
+
+-- Crypto imports
+import Cardano.Crypto.DSIGN (Ed25519DSIGN, MockDSIGN)
+import Cardano.Crypto.Hash (Blake2b_224, Blake2b_256, MD5Prefix)
+import Cardano.Crypto.KES (MockKES, Sum6KES)
+import Cardano.Crypto.VRF.Praos
+import qualified Cardano.Ledger.Crypto as CryptoClass
+import Shelley.Spec.Ledger.API (PraosCrypto)
+import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
+
+-- ByteString imports
+import Data.ByteString.Short (ShortByteString,toShort)
+import Data.ByteString(ByteString)
+import Data.String(fromString)
+
+-- Testing imports
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Proxy
+
+
+-- =======================================================
+
+data TestCrypto
+
+instance CryptoClass.Crypto TestCrypto where
+  type HASH TestCrypto = MD5Prefix 10
+  type ADDRHASH TestCrypto = MD5Prefix 8
+  type DSIGN TestCrypto = MockDSIGN
+  type KES TestCrypto = MockKES 10
+  type VRF TestCrypto = FakeVRF
+
+instance PraosCrypto TestCrypto
+
+data StandardCrypto
+
+instance CryptoClass.Crypto StandardCrypto where
+  type DSIGN StandardCrypto = Ed25519DSIGN
+  type KES StandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256
+  type VRF StandardCrypto = PraosVRF
+  type HASH StandardCrypto = Blake2b_256
+  type ADDRHASH StandardCrypto = Blake2b_224
+
+instance PraosCrypto StandardCrypto
+
+-- =========================
+-- Some examples
+
+data FooI  -- HashAnnotated indexes which are analogs of our EraIndependentXXX
+
+long :: ByteString
+long = (fromString "abc")
+
+short :: ShortByteString
+short = toShort long
+
+-- Any newtype over some type that is SafeToHash can easily
+-- derive SafeToHash and also assign its HashAnnotated type, and
+-- thus become a client of 'hashAnnotated'
+
+newtype Foo c = Foo ShortByteString
+   deriving (Show,SafeToHash)
+instance HashAnnotated (Foo c) FooI c
+
+foo:: Foo c
+foo = Foo short
+
+-- ===================================
+-- Lets run some examples, we'll need some concrete Crypto
+
+
+foohash :: SafeHash StandardCrypto FooI
+foohash = hashAnnotated foo
+
+shorthash :: SafeHash StandardCrypto ShortByteString
+shorthash = makeHashWithExplicitProxys (Proxy @StandardCrypto) (Proxy @ShortByteString) short
+
+longhash :: SafeHash StandardCrypto ByteString
+longhash = makeHashWithExplicitProxys (Proxy @StandardCrypto) (Proxy @ByteString) long
+
+foohashT :: SafeHash TestCrypto FooI
+foohashT = hashAnnotated foo
+
+shorthashT :: SafeHash TestCrypto ShortByteString
+shorthashT = makeHashWithExplicitProxys (Proxy @TestCrypto) (Proxy @ShortByteString) short
+
+longhashT :: SafeHash TestCrypto ByteString
+longhashT = makeHashWithExplicitProxys (Proxy @TestCrypto) (Proxy @ByteString) long
+
+test1,test2,test3,test4 :: TestTree
+test1 = testCase "short==long" (assertEqual "ShortByteString and ByteString don't hash the same" shorthash (castSafeHash longhash))
+test2 = testCase "newtype==underlyingtype" (assertEqual "A newtype and its underlying type dont hash the same" shorthash (castSafeHash foohash))
+
+test3 = testCase "short==long" (assertEqual "ShortByteString and ByteString don't hash the same" shorthashT (castSafeHash longhashT))
+test4 = testCase "newtype==underlyingtype" (assertEqual "A newtype and its underlying type dont hash the same" shorthashT (castSafeHash foohashT))
+
+safeHashTest :: TestTree
+safeHashTest = testGroup "SafeHash"
+                    [testGroup "StandardCrypto" [test1,test2]
+                    ,testGroup "TestCrypto" [test3,test4]
+                    ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -48,7 +48,7 @@ import Shelley.Spec.Ledger.Credential
     StakeReference (..),
   )
 import Shelley.Spec.Ledger.Delegation.Certificates (pattern RegPool)
-import Shelley.Spec.Ledger.Hashing (HashAnnotated (hashAnnotated))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( KeyPair (..),
     KeyRole (..),
@@ -82,6 +82,7 @@ import Shelley.Spec.Ledger.Tx
     TxIn (..),
     TxOut (..),
     WitnessSetHKD (..),
+    WitnessSet,
     _ttl,
   )
 import Shelley.Spec.Ledger.TxBody
@@ -574,6 +575,7 @@ testInvalidWintess =
           SNothing
           SNothing
       txb' = txb {_ttl = SlotNo 2}
+      wits :: Shelley.Spec.Ledger.Tx.WitnessSet C
       wits = mempty {addrWits = makeWitnessesVKey (hashAnnotated txb') [alicePay]}
       tx = Tx @C txb wits SNothing
       errs =
@@ -599,6 +601,7 @@ testWithdrawalNoWit =
           (SlotNo 0)
           SNothing
           SNothing
+      wits :: Shelley.Spec.Ledger.Tx.WitnessSet C
       wits = mempty {addrWits = Set.singleton $ makeWitnessVKey (hashAnnotated txb) alicePay}
       tx = Tx @C txb wits SNothing
       missing = Set.singleton (asWitness $ hashKey $ vKey bobStake)
@@ -627,7 +630,7 @@ testWithdrawalWrongAmt =
       wits =
         mempty
           { addrWits =
-              makeWitnessesVKey
+              makeWitnessesVKey @C_Crypto
                 (hashAnnotated txb)
                 [asWitness alicePay, asWitness bobStake]
           }
@@ -720,7 +723,7 @@ testProducedOverMaxWord64 =
           (SlotNo 100)
           SNothing
           SNothing
-      wits = mempty {addrWits = makeWitnessesVKey (hashAnnotated txbody) [alicePay]}
+      wits = mempty {addrWits = makeWitnessesVKey @C_Crypto (hashAnnotated txbody) [alicePay]}
       tx = Tx @C txbody wits SNothing
       st = runShelleyBase $ applySTSTest @(LEDGER C) (TRC (ledgerEnv, (utxoState, dpState), tx))
    in -- We test that the serialization of the predicate failure does not return bottom

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -9,6 +9,7 @@ import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTes
 import Test.Shelley.Spec.Ledger.Rewards (rewardTests)
 import Test.Shelley.Spec.Ledger.STSTests (chainExamples, multisigExamples)
 import Test.Shelley.Spec.Ledger.Pretty(prettyTest)
+import Test.Shelley.Spec.Ledger.SafeHash (safeHashTest)
 import qualified Test.Shelley.Spec.Ledger.Serialisation as Serialisation
 import Test.Shelley.Spec.Ledger.UnitTests (unitTests)
 import Test.Tasty
@@ -31,7 +32,8 @@ mainTests =
       multisigExamples,
       unitTests,
       setAlgTest,
-      prettyTest
+      prettyTest,
+      safeHashTest
     ]
 
 nightlyTests :: TestTree
@@ -51,7 +53,8 @@ fastTests =
       multisigExamples,
       unitTests,
       setAlgTest,
-      prettyTest
+      prettyTest,
+      safeHashTest
     ]
 
 -- main entry point


### PR DESCRIPTION
This PR introduces the type SafeHash, which ensures only types that preserve their serialization bytes can be Hashed.
It touches many files, but most of the changes are simply changing imports, to get to the new SafeHash, it also makes
SafeToHash, and AnnotatedHash  instances to the types that need to be hashed.

Things still to do
1) Address the last TODO's in the Alonzo Directories
2) Make the Spec consistent with the code
3) Roundtrip tests that test that things that are hashed, really preserve their bytes
4) Replace:  Shelley/Spec/Ledger/Metadata, Shelley/Spec/Ledger/Tx, with a MemoBytes

 