### PR TITLE
fix nightly cddl tests

### DIFF
--- a/.buildkite/nightly-tests.sh
+++ b/.buildkite/nightly-tests.sh
@@ -2,13 +2,13 @@
 set -e
 
 nix build -f `dirname $0`/.. haskellPackages.cardano-ledger-shelley-ma-test.components.tests.cardano-ledger-shelley-ma-test -o cardano-ledger-shelley-ma-test
-pushd shelley-ma/impl/
+pushd shelley-ma/shelley-ma-test/
 nix-shell ../../shell.nix --run \
   "../../cardano-ledger-shelley-ma-test/bin/cardano-ledger-shelley-ma-test --scenario=Nightly"
 popd
 
 nix build -f `dirname $0`/.. haskellPackages.shelley-spec-ledger-test.components.tests.shelley-spec-ledger-test -o shelley-spec-ledger-test
-pushd shelley/chain-and-ledger/executable-spec/
+pushd shelley/chain-and-ledger/shelley-spec-ledger-test/
 nix-shell ../../../shell.nix --run \
   "../../../shelley-spec-ledger-test/bin/shelley-spec-ledger-test --scenario=Nightly"
 popd


### PR DESCRIPTION
The nightly property test script was running in the wrong directory to have access to the CDDL files (and the genesis json file).