### PR TITLE
Remove the Torsor class

### DIFF
--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -42,7 +42,6 @@ import qualified Cardano.Crypto.Hash.Class as Hash
 import Cardano.Ledger.Compactible (Compactible (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Pretty (PDoc, PrettyA (..), ppCoin, ppInteger, ppList, ppLong, ppScriptHash, ppSexp)
-import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val
   ( DecodeMint (..),
     DecodeNonNegative (..),
@@ -675,12 +674,6 @@ byteArrayToSbs (BA.ByteArray bah) = SBS bah
 readShortByteString :: ShortByteString -> Int -> Int -> ShortByteString
 readShortByteString sbs start len =
   byteArrayToSbs $ BA.cloneByteArray (sbsToByteArray sbs) start len
-
-instance CC.Crypto crypto => Torsor (Value crypto) where
-  -- TODO a proper torsor form
-  type Delta (Value crypto) = (Value crypto)
-  addDelta = (<+>)
-  toDelta = id
 
 -- ========================================================================
 -- Operations on Values

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Shelley.Constraints
   )
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody)
-import Cardano.Ledger.Torsor (Torsor (..))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Prelude (heapWordsUnpacked)
 import Cardano.Slotting.Slot (SlotNo)
@@ -148,8 +147,8 @@ data UtxoPredicateFailure era
       !Coin -- the minimum fee for this transaction
       !Coin -- the fee supplied in this transaction
   | ValueNotConservedUTxO
-      !(Delta (Core.Value era)) -- the Coin consumed by this transaction
-      !(Delta (Core.Value era)) -- the Coin produced by this transaction
+      !(Core.Value era) -- the Coin consumed by this transaction
+      !(Core.Value era) -- the Coin produced by this transaction
   | WrongNetwork
       !Network -- the expected network id
       !(Set (Addr (Crypto era))) -- the set of addresses with incorrect network IDs
@@ -274,7 +273,7 @@ utxoTransition = do
 
   let consumed_ = consumed pp utxo txb
       produced_ = Shelley.produced pp stakepools txb
-  consumed_ == produced_ ?! ValueNotConservedUTxO (toDelta consumed_) (toDelta produced_)
+  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Protocol Parameter Update Proposals
   ppup' <-
@@ -352,7 +351,6 @@ instance
     UsesTxOut era,
     UsesValue era,
     TransValue ToCBOR era,
-    Show (Delta (Core.Value era)),
     Core.TxBody era ~ TxBody era,
     Core.TxOut era ~ TxOut era,
     Embed (Core.EraRule "PPUP" era) (UTXO era),

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -12,7 +12,6 @@
 module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash, ValidateAuxiliaryData)
-import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (PolicyID, Value, policies, policyID)
@@ -20,7 +19,6 @@ import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody
 import Cardano.Ledger.ShelleyMA.AuxiliaryData ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO, UtxoPredicateFailure)
 import Cardano.Ledger.ShelleyMA.TxBody ()
-import Cardano.Ledger.Torsor (Torsor (Delta))
 import Control.SetAlgebra (eval, (◁))
 import Control.State.Transition.Extended
 import Data.Foldable (Foldable (toList))
@@ -123,8 +121,6 @@ instance
     UsesTxOut era,
     UsesAuxiliary era,
     UsesScript era,
-    ChainData (Delta (Core.Value era)),
-    SerialisableData (Delta (Core.Value era)),
     ValidateScript era,
     ValidateAuxiliaryData era,
     GetPolicies (Core.Value era) (Crypto era),

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -27,7 +27,6 @@ library
     Cardano.Ledger.Pretty
     Cardano.Ledger.Shelley
     Cardano.Ledger.Shelley.Constraints
-    Cardano.Ledger.Torsor
     Cardano.Ledger.Val
     Shelley.Spec.Ledger.Address
     Shelley.Spec.Ledger.Address.Bootstrap

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -20,7 +20,6 @@ import Cardano.Ledger.Core
     Value,
   )
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
 import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy)
@@ -49,13 +48,10 @@ class
     Val (Value era),
     Compactible (Value era),
     ChainData (Value era),
-    ChainData (Delta (Value era)),
     SerialisableData (Value era),
-    SerialisableData (Delta (Value era)),
     DecodeNonNegative (Value era),
     EncodeMint (Value era),
-    DecodeMint (Value era),
-    Torsor (Value era)
+    DecodeMint (Value era)
   ) =>
   UsesValue era
 
@@ -87,13 +83,11 @@ type UsesAuxiliary era =
   )
 
 -- | Apply 'c' to all the types transitively involved with Value when
--- (Core.Value era) is an instance of Compactible and Torsor
+-- (Core.Value era) is an instance of Compactible
 type TransValue (c :: Type -> Constraint) era =
   ( Era era,
     Compactible (Value era),
-    Torsor (Value era),
-    c (Value era),
-    c (Delta (Value era))
+    c (Value era)
   )
 
 -- | General constraints that will hold true for ledgers which are based on

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -20,7 +20,6 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Compactible
-import qualified Cardano.Ledger.Torsor as Torsor
 import Cardano.Prelude (HeapWords)
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
@@ -61,11 +60,6 @@ addDeltaCoin (Coin x) (DeltaCoin y) = Coin (x + y)
 toDeltaCoin :: Coin -> DeltaCoin
 toDeltaCoin (Coin x) = DeltaCoin x
 
-instance Torsor.Torsor Coin where
-  type Delta Coin = DeltaCoin
-  addDelta = addDeltaCoin
-  toDelta = toDeltaCoin
-
 word64ToCoin :: Word64 -> Coin
 word64ToCoin w = Coin $ fromIntegral w
 
@@ -75,10 +69,6 @@ coinToRational (Coin c) = fromIntegral c
 rationalToCoinViaFloor :: Rational -> Coin
 rationalToCoinViaFloor r = Coin . floor $ r
 
--- FIXME:
--- if coin is less than 0 or greater than (maxBound :: Word64), then
--- fromIntegral constructs the incorrect value. for now this is handled
--- with an erroring bounds check here. where should this really live?
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin Word64
     deriving (Eq, Show, NoThunks, NFData, Typeable, HeapWords)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.Shelley.Constraints
     UsesTxOut,
     UsesValue,
   )
-import Cardano.Ledger.Torsor (Torsor (..))
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.Monad.Trans.Reader (asks)
@@ -140,8 +139,8 @@ data UtxoPredicateFailure era
       !Coin -- the minimum fee for this transaction
       !Coin -- the fee supplied in this transaction
   | ValueNotConservedUTxO
-      !(Delta (Core.Value era)) -- the Coin consumed by this transaction
-      !(Delta (Core.Value era)) -- the Coin produced by this transaction
+      !(Core.Value era) -- the Coin consumed by this transaction
+      !(Core.Value era) -- the Coin produced by this transaction
   | WrongNetwork
       !Network -- the expected network id
       !(Set (Addr (Crypto era))) -- the set of addresses with incorrect network IDs
@@ -378,7 +377,7 @@ utxoInductive = do
 
   let consumed_ = consumed pp utxo txb
       produced_ = produced pp stakepools txb
-  consumed_ == produced_ ?! ValueNotConservedUTxO (toDelta consumed_) (toDelta produced_)
+  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Protocol Parameter Update Proposals
   ppup' <- trans @(Core.EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -32,7 +32,6 @@ import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash,
     ValidateAuxiliaryData (..),
   )
-import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints
@@ -42,7 +41,6 @@ import Cardano.Ledger.Shelley.Constraints
     UsesTxOut,
     UsesValue,
   )
-import Cardano.Ledger.Torsor (Torsor (Delta))
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (∩))
@@ -163,8 +161,6 @@ instance
     UsesScript era,
     UsesAuxiliary era,
     UsesTxBody era,
-    ChainData (Delta (Core.Value era)),
-    SerialisableData (Delta (Core.Value era)),
     ValidateScript era,
     ValidateAuxiliaryData era,
     Embed (Core.EraRule "UTXO" era) (UTXOW era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -404,7 +404,7 @@ testInvalidTx errs tx =
 testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
   testInvalidTx
-    [ UtxowFailure (UtxoFailure (ValueNotConservedUTxO (DeltaCoin 0) (DeltaCoin 10000))),
+    [ UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Coin 0) (Coin 10000))),
       UtxowFailure (UtxoFailure $ BadInputsUTxO (Set.singleton $ TxIn genesisId 42))
     ]
     $ aliceGivesBobLovelace $


### PR DESCRIPTION
This purpose of this class was to enable type level distinctions between
values in TxOuts (which are always nonnegative) and values elsewhere
which may have either no constraints or other constraints.

We do not currently assign different types to these and don't have
plans to do so.

Instead there are runtime checks in the deserializers for the mint field
(no ada) and the txout field (no negative numbers).
