### PR TITLE
Some general tidying of Alonzo

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Alonzo.Scripts
     CostModel (CostModel),
     Prices (..),
     hashCostModel,
+    scriptfee,
   )
 where
 
@@ -33,6 +34,7 @@ import Cardano.Ledger.SafeHash
     SafeToHash,
   )
 import Cardano.Ledger.ShelleyMA.Timelocks
+import Cardano.Ledger.Val (Val ((<+>), (<×>)))
 import Control.DeepSeq (NFData (..))
 import Data.ByteString (ByteString)
 import Data.Coders
@@ -139,6 +141,12 @@ data Prices = Prices
 instance NoThunks Prices
 
 instance NFData Prices
+
+-- | Compute the cost of a script based upon proces and the number of execution
+-- units.
+scriptfee :: Prices -> ExUnits -> Coin
+scriptfee (Prices pr_mem pr_steps) (ExUnits mem steps) =
+  (mem <×> pr_mem) <+> (steps <×> pr_steps)
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -102,7 +102,7 @@ newtype CostModel = CostModelConstr (MemoBytes (Map ByteString Integer))
 
 instance HashWithCrypto CostModel CostModel
 
-pattern CostModel :: (Map ByteString Integer) -> CostModel
+pattern CostModel :: Map ByteString Integer -> CostModel
 pattern CostModel m <-
   CostModelConstr (Memo m _)
   where
@@ -126,8 +126,13 @@ deriving via
 -- CostModel is not parameterized by Crypto or Era so we use the
 -- hashWithCrypto function, rather than hashAnnotated
 
-hashCostModel :: forall e. Era e => Proxy e -> CostModel -> SafeHash (Crypto e) CostModel
-hashCostModel _proxy cm = hashWithCrypto (Proxy @(Crypto e)) cm
+hashCostModel ::
+  forall e.
+  Era e =>
+  Proxy e ->
+  CostModel ->
+  SafeHash (Crypto e) CostModel
+hashCostModel _proxy = hashWithCrypto (Proxy @(Crypto e))
 
 -- ==================================
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -17,8 +17,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Alonzo.TxBody
-  ( IsFee (..),
-    TxOut (TxOut, TxOutCompact),
+  ( TxOut (TxOut, TxOutCompact),
     TxBody
       ( TxBody,
         txinputs,
@@ -87,21 +86,6 @@ import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.TxBody (TxIn (..), Wdrl (Wdrl), unWdrl)
 import Prelude hiding (lookup)
-
--- | Tag indicating whether an input should be used to pay transaction fees.
--- This is used to prevent the entirety of a script's inputs being used for fees
--- in the case that the script fails to validate.
-newtype IsFee = IsFee Bool
-  deriving
-    ( Eq,
-      NFData,
-      NoThunks,
-      Ord,
-      Show,
-      Typeable,
-      ToCBOR,
-      FromCBOR
-    )
 
 data TxOut era
   = TxOutCompact

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -19,8 +19,7 @@ import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Prices (..), Script (..), Tag (..))
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
-  ( IsFee (..),
-    TxOut (..),
+  ( TxOut (..),
   )
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Core as Core
@@ -77,8 +76,6 @@ instance
 
 instance HasAlgorithm c => Arbitrary (SafeHash c i) where
   arbitrary = unsafeMakeSafeHash <$> arbitrary
-
-deriving newtype instance Arbitrary IsFee
 
 instance
   ( Era era,


### PR DESCRIPTION
Minor changes:

- Remove defunct `IsFee` type
- Move 'scriptfee' to the 'Scripts' module
- Remove some redundant brackets, long lines etc.