### PR TITLE
Update minUTXO documentation to match the code

### DIFF
--- a/doc/explanations/min-utxo.rst
+++ b/doc/explanations/min-utxo.rst
@@ -23,7 +23,7 @@ A minUTxOValue amount of ada pays for ``adaOnlyUTxOSize`` bytes of UTxO storage 
 
 The min-ada calculation for any UTxO approximates the above formula. This uses the constants,
 
-  ``coinSize = 0``
+  ``coinSize = 0`` (note: this is an implementation error, and will be changed to the correct value, 2, in the next fork. This will decrease the minimum ada value by a small percentage)
 
   ``utxoEntrySizeWithoutVal = 27``
 

--- a/doc/explanations/min-utxo.rst
+++ b/doc/explanations/min-utxo.rst
@@ -23,7 +23,7 @@ A minUTxOValue amount of ada pays for ``adaOnlyUTxOSize`` bytes of UTxO storage 
 
 The min-ada calculation for any UTxO approximates the above formula. This uses the constants,
 
-  ``coinSize = 2``
+  ``coinSize = 0``
 
   ``utxoEntrySizeWithoutVal = 27``
 

--- a/doc/explanations/min-utxo.rst
+++ b/doc/explanations/min-utxo.rst
@@ -27,7 +27,7 @@ The min-ada calculation for any UTxO approximates the above formula. This uses t
 
   ``utxoEntrySizeWithoutVal = 27``
 
-  ``adaOnlyUTxOSize = utxoEntrySizeWithoutVal + coinSize = 29``
+  ``adaOnlyUTxOSize = utxoEntrySizeWithoutVal + coinSize = 27``
 
 The functions used in the formula below are :
 


### PR DESCRIPTION
(feel free to ignore this PR and remake the change yourself if that's easier. I'm just making this PR for visibility)

The documentation defines `coinSize = 2` but in the Haskell codebase, the `coinSize` is defined as follow:

```
-- unpacked CompactCoin Word64 size in Word64s
coinSize :: Integer
coinSize = fromIntegral $ heapWordsUnpacked (CompactCoin 0)
```

This in practice gives the value `0`.

# Impact

This has quite a large impact on the resulting minimum utxo

### Impact when tokens are present

Ex:
A test with a single asset with an empty name (first test in #2114) gives
- `1407406` when `coinSize = 0`
- `1310316` when `coinSize = 2`

### Impact when no tokens are present

Currently the Haskell codebase runs different code paths depending on whether or not tokens are present

```
scaledMinDeposit v (Coin mv)
  | Val.inject (Val.coin v) == v = Coin mv -- without non-Coin assets, scaled deposit should be exactly minUTxOValue
  -- The calculation should represent this equation
  -- minValueParameter / coinUTxOSize = actualMinValue / valueUTxOSize
  -- actualMinValue = (minValueParameter / coinUTxOSize) * valueUTxOSize
  | otherwise = Coin $ max mv (adaPerUTxOWord * (utxoEntrySizeWithoutVal + Val.size v))
```

However, ideally for simplicity you could do a single path

```
scaledMinDeposit v (Coin mv) = Coin $ max mv (adaPerUTxOWord * (utxoEntrySizeWithoutVal + Val.size v))
```

This works with `coinSize = 2` when no tokens are present since you end up with `max(1_000_000, 965_496)`, but because of this bug, this simplification no longer works. With `coinSize = 0` this instead gives `max(1_000_000, 1_037_036)`