### PR TITLE
last moment reward aggregation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -108,6 +108,8 @@ import Shelley.Spec.Ledger.Rewards
     LogWeight (..),
     NonMyopic (..),
     PerformanceEstimate (..),
+    Reward (..),
+    RewardType (..),
     StakeShare (..),
   )
 import Shelley.Spec.Ledger.Scripts (MultiSig (..), ScriptHash (..))
@@ -393,13 +395,26 @@ ppPState (PState par fpar ret) =
 ppRewardAccounts :: Map.Map (Credential 'Staking crypto) Coin -> PDoc
 ppRewardAccounts m = ppMap' (text "RewardAccounts") ppCredential ppCoin m
 
+ppRewardType :: RewardType -> PDoc
+ppRewardType MemberReward = text "MemberReward"
+ppRewardType LeaderReward = text "LeaderReward"
+
+ppReward :: Reward crypto -> PDoc
+ppReward (Reward rt pool amt) =
+  ppRecord
+    "Reward"
+    [ ("rewardType", ppRewardType rt),
+      ("poolId", ppKeyHash pool),
+      ("rewardAmount", ppCoin amt)
+    ]
+
 ppRewardUpdate :: RewardUpdate crypto -> PDoc
 ppRewardUpdate (RewardUpdate dt dr rss df nonmyop) =
   ppRecord
     "RewardUpdate"
     [ ("deltaT", ppDeltaCoin dt),
       ("deltaR", ppDeltaCoin dr),
-      ("rs", ppMap' mempty ppCredential ppCoin rss),
+      ("rs", ppMap' mempty ppCredential (ppSet ppReward) rss),
       ("deltaF", ppDeltaCoin df),
       ("nonMyopic", ppNonMyopic nonmyop)
     ]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -83,7 +83,7 @@ module Shelley.Spec.Ledger.LedgerState
 
     -- * Remove Bootstrap Redeem Addresses
     returnRedeemAddrsToReserves,
-    updateNonMypopic,
+    updateNonMyopic,
 
     -- *
     TransUTxOState,
@@ -1050,12 +1050,12 @@ applyRUpd ru (EpochState as ss ls pr pp _nm) = EpochState as' ss ls' pr pp nm'
 decayFactor :: Float
 decayFactor = 0.9
 
-updateNonMypopic ::
+updateNonMyopic ::
   NonMyopic crypto ->
   Coin ->
   Map (KeyHash 'StakePool crypto) Likelihood ->
   NonMyopic crypto
-updateNonMypopic nm rPot newLikelihoods =
+updateNonMyopic nm rPot newLikelihoods =
   nm
     { likelihoodsNM = updatedLikelihoods,
       rewardPotNM = rPot
@@ -1171,7 +1171,7 @@ createRUpd slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) ma
         deltaR = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
         rs = rs_,
         deltaF = (invert (toDeltaCoin $ _feeSS ss)),
-        nonMyopic = (updateNonMypopic nm _R newLikelihoods)
+        nonMyopic = (updateNonMyopic nm _R newLikelihoods)
       }
 
 -- | Calculate the current circulation

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -103,6 +103,8 @@ import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     LogWeight (..),
     PerformanceEstimate (..),
+    Reward (..),
+    RewardType (..),
   )
 import qualified Shelley.Spec.Ledger.STS.Deleg as STS
 import qualified Shelley.Spec.Ledger.STS.Delegs as STS
@@ -523,6 +525,14 @@ instance
       <*> genPParams (Proxy @era)
       <*> genPParams (Proxy @era)
       <*> arbitrary
+
+instance Arbitrary RewardType where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
+instance CC.Crypto crypto => Arbitrary (Reward crypto) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
 
 instance CC.Crypto crypto => Arbitrary (RewardUpdate crypto) where
   arbitrary = genericArbitraryU

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -49,6 +49,7 @@ import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Cardano.Slotting.Slot (EpochNo, WithOrigin (..))
 import Control.SetAlgebra (eval, setSingleton, singleton, (∪), (⋪), (⋫))
+import Control.State.Transition (STS (State))
 import Data.Foldable (fold)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -93,7 +94,7 @@ import Shelley.Spec.Ledger.LedgerState
     PState (..),
     RewardUpdate (..),
     UTxOState (..),
-    applyRUpd
+    applyRUpd,
   )
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
@@ -102,7 +103,6 @@ import Shelley.Spec.Ledger.Tx (TxIn)
 import Shelley.Spec.Ledger.TxBody (MIRPot (..), PoolParams (..), RewardAcnt (..))
 import Shelley.Spec.Ledger.UTxO (txins, txouts)
 import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, getBlockNonce)
-import Control.State.Transition (STS (State))
 
 -- ======================================================
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE DataKinds #-}
 
 module Test.Shelley.Spec.Ledger.Examples.EmptyBlock
   ( exEmptyBlock,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
@@ -25,6 +25,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
+import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.Keys
   ( GenDelegPair (..),
     KeyHash (..),
@@ -37,7 +38,6 @@ import Shelley.Spec.Ledger.Keys
     hashVerKeyVRF,
     vKey,
   )
-import Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.OverlaySchedule
 import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -40,7 +40,7 @@ import Shelley.Spec.Ledger.LedgerState
   ( AccountState (..),
     EpochState (..),
     NewEpochState (..),
-    emptyRewardUpdate
+    emptyRewardUpdate,
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
+import Data.Default.Class (def)
 import Data.Foldable (fold)
 import Data.Group (invert)
 import qualified Data.Map.Strict as Map
@@ -52,13 +53,15 @@ import Shelley.Spec.Ledger.Keys (asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..),
     decayFactor,
-    emptyRewardUpdate
+    emptyRewardUpdate,
   )
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.Rewards
   ( Likelihood (..),
     NonMyopic (..),
+    Reward (..),
+    RewardType (..),
     applyDecay,
     leaderProbability,
     likelihood,
@@ -120,7 +123,6 @@ import Test.Shelley.Spec.Ledger.Utils
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
-import Data.Default.Class (def)
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
@@ -690,8 +692,12 @@ rewardUpdateEx8 =
       deltaR = deltaR8,
       rs =
         Map.fromList
-          [ (Cast.aliceSHK, aliceRAcnt8),
-            (Cast.bobSHK, bobRAcnt8)
+          [ ( Cast.aliceSHK,
+              Set.singleton $ Reward LeaderReward (hk Cast.alicePoolKeys) aliceRAcnt8
+            ),
+            ( Cast.bobSHK,
+              Set.singleton $ Reward MemberReward (hk Cast.alicePoolKeys) bobRAcnt8
+            )
           ],
       deltaF = DeltaCoin 0,
       nonMyopic = nonMyopicEx8

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -79,7 +79,6 @@ import Test.Shelley.Spec.Ledger.Utils (getBlockNonce, testGlobals)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
-
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -115,7 +115,7 @@ import Shelley.Spec.Ledger.LedgerState
     AccountState(..),
     LedgerState(..),
     circulation,
-    updateNonMypopic,
+    updateNonMyopic,
   )
 import Shelley.Spec.Ledger.API.Wallet(getRewardInfo)
 import qualified Shelley.Spec.Ledger.HardForks as HardForks

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -64,10 +64,12 @@ import Shelley.Spec.Ledger.Keys
 import Shelley.Spec.Ledger.PParams
   ( PParams,
     PParams' (..),
+    ProtVer (..),
     emptyPParams,
   )
 import Shelley.Spec.Ledger.Rewards
-  ( reward,
+  ( aggregateRewards,
+    reward,
     Likelihood,
     mkApparentPerformance,
     memberRew,
@@ -75,6 +77,8 @@ import Shelley.Spec.Ledger.Rewards
     likelihood,
     leaderRew,
     leaderProbability,
+    NonMyopic,
+    sumRewards,
   )
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), RewardAcnt (..))
 import Test.Shelley.Spec.Ledger.Generator.Core (genCoin, genNatural)
@@ -330,7 +334,7 @@ rewardsBoundedByPot _ = property $ do
             show slotsPerEpoch
           ]
       )
-      (fold (fst rs) < rewardPot)
+      (sumRewards pp (fst rs) < rewardPot)
 
 -- =================================================
 -- tests when running rewards with provenance
@@ -571,12 +575,21 @@ rewardOld
       rewards' = f . catMaybes $ fmap (\(_, x, _) -> x) results
       hs = Map.fromList $ fmap (\(hk, _, l) -> (hk, l)) results
 
+data RewardUpdateOld crypto = RewardUpdateOld
+  { deltaTOld :: !DeltaCoin,
+    deltaROld :: !DeltaCoin,
+    rsOld :: !(Map (Credential 'Staking crypto) Coin),
+    deltaFOld :: !DeltaCoin,
+    nonMyopicOld :: !(NonMyopic crypto)
+  }
+  deriving (Show, Eq)
+
 createRUpdOld ::
   EpochSize ->
   BlocksMade (Crypto era) ->
   EpochState era ->
   Coin ->
-  ShelleyBase (RewardUpdate (Crypto era))
+  ShelleyBase (RewardUpdateOld (Crypto era))
 createRUpdOld slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) maxSupply = do
   asc <- asks activeSlotCoeff
   let SnapShot stake' delegs' poolParams = _pstakeGo ss
@@ -617,12 +630,12 @@ createRUpdOld slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm)
       deltaR2 = _R <-> (Map.foldr (<+>) mempty rs_)
       blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
   pure $
-    RewardUpdate
-      { deltaT = (DeltaCoin deltaT1),
-        deltaR = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
-        rs = rs_,
-        deltaF = (invert (toDeltaCoin $ _feeSS ss)),
-        nonMyopic = (updateNonMypopic nm _R newLikelihoods)
+    RewardUpdateOld
+      { deltaTOld = (DeltaCoin deltaT1),
+        deltaROld = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
+        rsOld = rs_,
+        deltaFOld = (invert (toDeltaCoin $ _feeSS ss)),
+        nonMyopicOld = (updateNonMyopic nm _R newLikelihoods)
       }
 
 
@@ -638,8 +651,9 @@ oldEqualsNew  newepochstate  = old == new
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
-    new = runReader (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
-    old = runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
+    unAggregated = runReader (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
+    old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
+    new = aggregateRewards @era (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
 
 oldEqualsNewOn:: forall era. NewEpochState era -> Bool
 oldEqualsNewOn  newepochstate  = old == new
@@ -653,8 +667,9 @@ oldEqualsNewOn  newepochstate  = old == new
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
-    (new,_) = runReader (runWithProvM def $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
-    old = runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
+    (unAggregated,_) = runReader (runWithProvM def $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
+    old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
+    new = aggregateRewards @era (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
 
 
 -- ==================================================================
@@ -670,7 +685,7 @@ rewardTests =
     , testProperty "provenance does not affect result" (sameWithOrWithoutProvenance @C testGlobals)
     , testProperty "ProvM preserves Nothing" (nothingInNothingOut @C)
     , testProperty "ProvM preserves Just" (justInJustOut @C)
-    , testProperty "oldstyle matches provenance off style" (oldEqualsNew @C)
-    , testProperty "oldstyle matches provenance on style" (oldEqualsNewOn @C)
+    , testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance off style" (oldEqualsNew @C)
+    , testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance on style" (oldEqualsNewOn @C)
     , testCaseInfo "Reward Provenance works" (rewardsProvenance (Proxy @C))
     ]


### PR DESCRIPTION
Rewards are now separated by whether they are member or leader rewards, and by which pool the reward is associated with (a reward account can get rewards from multiple pools). The rewards are now aggregated when applying a reward update instead of when creating a reward update. This should make it a lot easier for applications such as db-sync to be able to track reward provenance.