### PR TITLE
fix Mary generators to respect the minUTxOValue

### DIFF
--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -43,7 +43,7 @@ import Shelley.Spec.Ledger.API (KeyRole (Witness))
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Keys (KeyHash)
-import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.PParams (PParams, Update)
 import Shelley.Spec.Ledger.TxBody (DCert, TxIn, TxOut, Wdrl)
 import Test.Cardano.Ledger.EraBuffet (AllegraEra)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
@@ -92,6 +92,7 @@ genTxBody ::
     UsesPParams era,
     EraGen era
   ) =>
+  PParams era ->
   SlotNo ->
   Set.Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
@@ -101,7 +102,7 @@ genTxBody ::
   StrictMaybe (Update era) ->
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   Gen (TxBody era, [Timelock (Crypto era)])
-genTxBody slot ins outs cert wdrl fee upd ad = do
+genTxBody _pparams slot ins outs cert wdrl fee upd ad = do
   validityInterval <- genValidityInterval slot
   let mint = zero -- the mint field is always empty for an Allegra TxBody
   pure $

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -26,6 +26,7 @@ import Cardano.Ledger.Shelley.Constraints
     UsesPParams,
     UsesValue,
   )
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody (StrictMaybe, TxBody (..))
 import qualified Cardano.Ledger.Val as Val
@@ -33,12 +34,12 @@ import Cardano.Slotting.Slot (SlotNo)
 import qualified Data.ByteString.Char8 as BS
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Sequence.Strict (StrictSeq (..), (<|))
+import Data.Sequence.Strict (StrictSeq (..), (<|), (><))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), Update)
 import Shelley.Spec.Ledger.Tx (TxIn, TxOut (..), hashScript)
 import Shelley.Spec.Ledger.TxBody (DCert, Wdrl)
 import Test.Cardano.Ledger.Allegra
@@ -232,18 +233,24 @@ genMint = do
 -- END Permissionless Tokens --
 -------------------------------
 
--- | Add tokens to a non-empty list of transaction outputs.
--- NOTE: this function will raise an error if given an empty sequence.
-addTokensToFirstOutput ::
+-- | Attempt to Add tokens to a non-empty list of transaction outputs.
+-- It will add them to the first output that has enough lovelace
+-- to meet the minUTxO requirment, if such an output exists.
+addTokens ::
   ( Core.Value era ~ Value (Crypto era),
     EraGen era
   ) =>
+  PParams era ->
   Value (Crypto era) ->
   StrictSeq (TxOut era) ->
-  StrictSeq (TxOut era)
-addTokensToFirstOutput ts ((TxOut a v) :<| os) = TxOut a (v <> ts) <| os
-addTokensToFirstOutput _ StrictSeq.Empty =
-  error "addTokensToFirstOutput was given an empty sequence"
+  Maybe (StrictSeq (TxOut era))
+addTokens = addTokens' StrictSeq.Empty
+  where
+    addTokens' tooLittleLovelace pparams ts (o@(TxOut a v) :<| os) =
+      if Val.coin v < scaledMinDeposit v (_minUTxOValue pparams)
+        then addTokens' (o :<| tooLittleLovelace ) pparams ts os
+        else (Just $ tooLittleLovelace >< TxOut a (v <> ts) <| os)
+    addTokens' _ _ _ StrictSeq.Empty = Nothing
 
 genTxBody ::
   forall era.
@@ -253,6 +260,7 @@ genTxBody ::
     UsesAuxiliary era,
     EraGen era
   ) =>
+  PParams era ->
   SlotNo ->
   Set.Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
@@ -262,10 +270,12 @@ genTxBody ::
   StrictMaybe (Update era) ->
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   Gen (TxBody era, [Timelock (Crypto era)])
-genTxBody slot ins outs cert wdrl fee upd meta = do
+genTxBody pparams slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot
   mint <- genMint
-  let outs' = addTokensToFirstOutput (mint) outs
+  let (mint', outs') = case addTokens pparams mint outs of
+                         Nothing -> (mempty, outs)
+                         Just os -> (mint, os)
       ps = map (\p -> (Map.!) policyIndex p) (Set.toList $ policies mint)
   pure $
     ( TxBody
@@ -277,7 +287,7 @@ genTxBody slot ins outs cert wdrl fee upd meta = do
         validityInterval
         upd
         meta
-        mint,
+        mint',
       ps -- These additional scripts are for the minting policies.
     )
 

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -153,7 +153,11 @@ blueCoinId :: forall c. CryptoClass.Crypto c => PolicyID c
 blueCoinId = PolicyID $ hashScript @(MaryEra c) blueCoins
 
 maxBlueMint :: Int
-maxBlueMint = 10
+maxBlueMint = 5
+
+-- TODO these blue coins are actually problematic since our
+-- current coin selection algorithm does not prevent creating
+-- a multi-asset that is too large.
 
 genBlue :: CryptoClass.Crypto c => Gen (Value c)
 genBlue = do
@@ -214,7 +218,7 @@ redFreq :: Int
 redFreq = 10
 
 blueFreq :: Int
-blueFreq = 5
+blueFreq = 1
 
 yellowFreq :: Int
 yellowFreq = 20

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Golden.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Golden.hs
@@ -150,19 +150,19 @@ goldenScaledMinDeposit =
           @?= Coin 1629628,
       testCase "three policies, ninety-six (small) names" $
         scaledMinDeposit
-          ( Value 7592585 $
+          ( Value 7407400 $
               Map.fromList
                 [ ( pid1,
-                    (Map.fromList $ map ((,1) . smallName . chr) [32 .. 64])
+                    (Map.fromList $ map ((,1) . smallName . chr) [32 .. 63])
                   ),
                   ( pid2,
-                    (Map.fromList $ map ((,1) . smallName . chr) [64 .. 96])
+                    (Map.fromList $ map ((,1) . smallName . chr) [64 .. 95])
                   ),
                   ( pid3,
-                    (Map.fromList $ map ((,1) . smallName . chr) [96 .. 128])
+                    (Map.fromList $ map ((,1) . smallName . chr) [96 .. 127])
                   )
                 ]
           )
           minUTxO
-          @?= Coin 7592585
+          @?= Coin 7407400
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -30,7 +30,7 @@ import Shelley.Spec.Ledger.API
 import Shelley.Spec.Ledger.Address (toAddr)
 import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe)
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.PParams (PParams, Update)
 import Shelley.Spec.Ledger.Tx
   ( TxId (TxId),
     ValidateScript (..),
@@ -70,6 +70,7 @@ class
   -- additional script witnessing.
   genEraTxBody ::
     GenEnv era ->
+    PParams era ->
     SlotNo ->
     Set (TxIn (Crypto era)) ->
     StrictSeq (Core.TxOut era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -27,6 +27,7 @@ import Shelley.Spec.Ledger.API
     Update,
   )
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.EraMapping ()
 import Shelley.Spec.Ledger.Scripts (MultiSig (..))
 import Shelley.Spec.Ledger.Slot (SlotNo (..))
@@ -97,6 +98,7 @@ instance CC.Crypto c => ScriptClass (ShelleyEra c) where
 
 genTxBody ::
   (ShelleyTest era) =>
+  PParams era ->
   SlotNo ->
   Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
@@ -106,7 +108,7 @@ genTxBody ::
   StrictMaybe (Update era) ->
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   Gen (TxBody era, [MultiSig (Crypto era)])
-genTxBody slot inputs outputs certs wdrls fee update adHash = do
+genTxBody _pparams slot inputs outputs certs wdrls fee update adHash = do
   ttl <- genTimeToLive slot
   return
     ( TxBody

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -270,6 +270,7 @@ genTx
       (draftTxBody, additionalScripts) <-
         genEraTxBody
           ge
+          pparams
           slot
           (Set.fromList inputs)
           draftOutputs


### PR DESCRIPTION
The generators for the Mary property tests were not scaling the `minUTxOValue` parameter for multi-assets, and hence they sometimes generated an invalid trace. The fix was just to pass the protocol parameters to the appropriate place and not construct any outputs that would violate the invariant.

Additionally, I did two other small things (each in their own commit).
* One of the golden tests claimed that it had "ninety-six" asset names, but in fact it had ninety-nine.
* One of the three different multi-asset generators was clogging the UTxO set and every so often causing a massive transaction output to be created. I did not do the proper fix (adjusting coin selection to not ever create these) but instead put on a band-aid (generate less of the problematic asset). We have already started a better overall plan for the testing, and a band-aid is fine for now.