### PR TITLE
used cached protocol parameters when aggregating

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -1031,7 +1031,7 @@ applyRUpd ru (EpochState as ss ls pr pp _nm) = EpochState as' ss ls' pr pp nm'
     (regRU, unregRU) =
       Map.partitionWithKey
         (\k _ -> eval (k ∈ dom (_rewards dState)))
-        (aggregateRewards pp $ rs ru)
+        (aggregateRewards pr $ rs ru)
     as' =
       as
         { _treasury = (addDeltaCoin (_treasury as) (deltaT ru)) <> fold (range unregRU),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -131,7 +131,7 @@ newEpochTransition = do
         SNothing -> pure es
         SJust ru' -> do
           let RewardUpdate dt dr rs_ df _ = ru'
-              totRs = sumRewards (esPp es) rs_
+              totRs = sumRewards (esPrevPp es) rs_
           Val.isZero (dt <> (dr <> (toDeltaCoin totRs) <> df)) ?! CorruptRewardUpdate ru'
           pure $ applyRUpd ru' es
 


### PR DESCRIPTION
Hooray for property tests! They caught a bug introduced yesterday in #2117 (It got past CI since it can take a few runs to trigger the bug.)

In two places we were aggregating the rewards using the wrong protocol parameters. Rewards are calculated using a cached set of the parameters so that if they change do to an update we are still using the correct values. The cached values should be supplied to the aggregating function instead of the current values.