### PR TITLE
Abstract over protocol parameters

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Alonzo where
 
+import Cardano.Binary (FromCBOR (..))
 import Cardano.Ledger.Alonzo.Data (AuxiliaryData)
+import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate, updatePParams)
 import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -12,7 +16,8 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
 import Cardano.Ledger.Mary.Value (Value)
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.Constraints (UsesPParams (..), UsesValue)
+import Data.Typeable (Typeable)
 
 -- | The Alonzo era
 data AlonzoEra c
@@ -31,7 +36,25 @@ type instance Core.Script (AlonzoEra c) = Script (AlonzoEra c)
 
 type instance Core.AuxiliaryData (AlonzoEra c) = AuxiliaryData (AlonzoEra c)
 
+type instance Core.PParams (AlonzoEra c) = PParams (AlonzoEra c)
+
 instance CC.Crypto c => UsesValue (AlonzoEra c)
+
+instance Typeable c => FromCBOR (PParams (AlonzoEra c)) where
+  fromCBOR = error "Need to work out how to deal with annotated/unannotated decoders"
+
+instance Typeable c => FromCBOR (PParamsUpdate (AlonzoEra c)) where
+  fromCBOR = error "Need to work out how to deal with annotated/unannotated decoders"
+
+instance
+  (CC.Crypto c) =>
+  UsesPParams (AlonzoEra c)
+  where
+  type
+    PParamsDelta (AlonzoEra c) =
+      PParamsUpdate (AlonzoEra c)
+
+  mergePPUpdates _ = updatePParams
 
 instance CC.Crypto c => ValidateAuxiliaryData (AlonzoEra c) where
   hashAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -295,10 +295,9 @@ deriving instance NFData (PParams' StrictMaybe era)
 instance NoThunks (PParamsUpdate era)
 
 -- =======================================================
--- A PParamsUpdate has StrictMaybe fields, we want to
--- Sparse encode it, by writing only those fields where
--- the field is (SJust x), that is the role of the local
--- function (omitStrictMaybe key x)
+-- A PParamsUpdate has StrictMaybe fields, we want to Sparse encode it, by
+-- writing only those fields where the field is (SJust x), that is the role of
+-- the local function (omitStrictMaybe key x)
 
 fromSJust :: StrictMaybe a -> a
 fromSJust (SJust x) = x
@@ -459,17 +458,18 @@ updatePParams pp ppup =
 -- ===================================================
 -- Figure 1: "Definitions Used in Protocol Parameters"
 
--- The Language Depenedent View type (LangDepView) is a GADT, it will have a different
--- Constructor for each Language. This way each language can have a different
--- view of the Protocol parameters. This is an intermediate type and we introduce
--- it only because we are interested in combining it with other things so we can hash
--- the combination. Thus this type (and the other things we combine it with) must
--- remember their original bytes. We make it a data type around a MemoBytes.
--- Unfortunately we can't use a newtype, because the constructor must existentially
--- hide the Language index. Instances on GADT's are a bit tricky so we are carefull
--- in the comments below to explain them. Because we intend to add new languages
--- the GADT will someday end up with more constructors. So we add some commented
--- out code that suggests how to extend the instances when that happens.
+-- The Language Depenedent View type (LangDepView) is a GADT, it will have a
+-- different Constructor for each Language. This way each language can have a
+-- different view of the Protocol parameters. This is an intermediate type and
+-- we introduce it only because we are interested in combining it with other
+-- things so we can hash the combination. Thus this type (and the other things
+-- we combine it with) must remember their original bytes. We make it a data
+-- type around a MemoBytes. Unfortunately we can't use a newtype, because the
+-- constructor must existentially hide the Language index. Instances on GADT's
+-- are a bit tricky so we are carefull in the comments below to explain them.
+-- Because we intend to add new languages the GADT will someday end up with more
+-- constructors. So we add some commented out code that suggests how to extend
+-- the instances when that happens.
 
 data RawView :: Type -> Language -> Type where
   RawPlutusView :: CostModel -> RawView era 'PlutusV1
@@ -518,8 +518,9 @@ instance (Typeable era) => FromCBOR (Annotator (LangDepView era)) where
 data LangDepView era where
   LangDepViewConstr :: (MemoBytes (RawView era lang)) -> LangDepView era
 
--- We can't derive SafeToHash via newtype deriving because LandDepViewConstr is a data
--- not a newtype. But it does remember its original bytes so we can add the instance manually.
+-- We can't derive SafeToHash via newtype deriving because LandDepViewConstr is
+-- a data not a newtype. But it does remember its original bytes so we can add
+-- the instance manually.
 
 instance SafeToHash (LangDepView era) where
   originalBytes (LangDepViewConstr (Memo _ bs)) = fromShort bs

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -74,6 +74,7 @@ import Cardano.Ledger.SafeHash
     SafeHash,
     SafeToHash,
   )
+import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), ppValidityInterval)
 import Cardano.Ledger.Val
   ( DecodeNonNegative,
@@ -173,16 +174,17 @@ data TxBodyRaw era = TxBodyRaw
 deriving instance
   ( Eq (Core.Value era),
     CC.Crypto (Crypto era),
-    Compactible (Core.Value era)
+    Compactible (Core.Value era),
+    Eq (PParamsDelta era)
   ) =>
   Eq (TxBodyRaw era)
 
 instance
-  (Typeable era, NoThunks (Core.Value era)) =>
+  (Typeable era, NoThunks (Core.Value era), NoThunks (PParamsDelta era)) =>
   NoThunks (TxBodyRaw era)
 
 deriving instance
-  (Era era, Show (Core.Value era)) =>
+  (Era era, Show (Core.Value era), Show (PParamsDelta era)) =>
   Show (TxBodyRaw era)
 
 newtype TxBody era = TxBodyConstr (MemoBytes (TxBodyRaw era))
@@ -192,18 +194,23 @@ newtype TxBody era = TxBodyConstr (MemoBytes (TxBodyRaw era))
 deriving newtype instance
   ( Eq (Core.Value era),
     Compactible (Core.Value era),
-    CC.Crypto (Crypto era)
+    CC.Crypto (Crypto era),
+    Eq (PParamsDelta era)
   ) =>
   Eq (TxBody era)
 
 deriving instance
-  (Typeable era, NoThunks (Core.Value era)) =>
+  ( Typeable era,
+    NoThunks (Core.Value era),
+    NoThunks (PParamsDelta era)
+  ) =>
   NoThunks (TxBody era)
 
 deriving instance
   ( Era era,
     Compactible (Core.Value era),
-    Show (Core.Value era)
+    Show (Core.Value era),
+    Show (PParamsDelta era)
   ) =>
   Show (TxBody era)
 
@@ -216,7 +223,8 @@ deriving via
       Compactible (Core.Value era),
       Show (Core.Value era),
       DecodeNonNegative (Core.Value era),
-      FromCBOR (Annotator (Core.Script era))
+      FromCBOR (Annotator (Core.Script era)),
+      Core.SerialisableData (PParamsDelta era)
     ) =>
     FromCBOR (Annotator (TxBody era))
 
@@ -224,7 +232,8 @@ deriving via
 type AlonzoBody era =
   ( Era era,
     Compactible (Core.Value era),
-    ToCBOR (Core.Script era)
+    ToCBOR (Core.Script era),
+    Core.SerialisableData (PParamsDelta era)
   )
 
 pattern TxBody ::
@@ -337,7 +346,8 @@ instance
   ( Era era,
     DecodeNonNegative (Core.Value era),
     Show (Core.Value era),
-    Compactible (Core.Value era)
+    Compactible (Core.Value era),
+    ToCBOR (PParamsDelta era)
   ) =>
   FromCBOR (TxOut era)
   where
@@ -350,7 +360,8 @@ instance
 
 encodeTxBodyRaw ::
   ( Era era,
-    Compactible (Core.Value era)
+    Compactible (Core.Value era),
+    ToCBOR (PParamsDelta era)
   ) =>
   TxBodyRaw era ->
   Encode ('Closed 'Sparse) (TxBodyRaw era)
@@ -408,7 +419,9 @@ instance
     Compactible (Core.Value era),
     Show (Core.Value era),
     DecodeNonNegative (Core.Value era),
-    FromCBOR (Annotator (Core.Script era))
+    FromCBOR (Annotator (Core.Script era)),
+    FromCBOR (PParamsDelta era),
+    ToCBOR (PParamsDelta era)
   ) =>
   FromCBOR (TxBodyRaw era)
   where
@@ -480,7 +493,9 @@ instance
     Compactible (Core.Value era),
     Show (Core.Value era),
     DecodeNonNegative (Core.Value era),
-    FromCBOR (Annotator (Core.Script era))
+    FromCBOR (Annotator (Core.Script era)),
+    FromCBOR (PParamsDelta era),
+    ToCBOR (PParamsDelta era)
   ) =>
   FromCBOR (Annotator (TxBodyRaw era))
   where
@@ -533,7 +548,8 @@ ppTxBody ::
   ( Era era,
     Compactible (Core.Value era),
     Show (Core.Value era),
-    PrettyA (Core.Value era)
+    PrettyA (Core.Value era),
+    PrettyA (PParamsDelta era)
   ) =>
   TxBody era ->
   PDoc
@@ -558,6 +574,7 @@ ppTxBody (TxBodyConstr (Memo (TxBodyRaw i ifee o c w fee vi u adh mnt exu sdh sc
 instance
   ( Era era,
     PrettyA (Core.Value era),
+    PrettyA (PParamsDelta era),
     Compactible (Core.Value era),
     Show (Core.Value era)
   ) =>

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -15,6 +15,7 @@ import Shelley.Spec.Ledger.API
     PraosCrypto,
     ShelleyBasedEra,
   )
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 
 type AllegraEra = ShelleyMAEra 'Allegra
 

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -16,6 +16,7 @@ import Shelley.Spec.Ledger.API
     PraosCrypto,
     ShelleyBasedEra,
   )
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 
 type MaryEra = ShelleyMAEra 'Mary
 

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -16,8 +16,16 @@ import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value)
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData, pattern AuxiliaryData)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesPParams (..),
+    UsesTxBody,
+    UsesTxOut (..),
+    UsesValue,
+  )
+import Cardano.Ledger.ShelleyMA.AuxiliaryData
+  ( AuxiliaryData,
+    pattern AuxiliaryData,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),
     ValidityInterval,
@@ -31,6 +39,7 @@ import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Metadata (validMetadatum)
+import qualified Shelley.Spec.Ledger.PParams as Shelley
 import Shelley.Spec.Ledger.Tx
   ( TxOut (..),
     ValidateScript (..),
@@ -68,6 +77,16 @@ instance CryptoClass.Crypto c => UsesTxOut (ShelleyMAEra 'Mary c) where
 instance CryptoClass.Crypto c => UsesTxOut (ShelleyMAEra 'Allegra c) where
   makeTxOut _ a v = TxOut a v
 
+instance
+  (CryptoClass.Crypto c, Typeable ma) =>
+  UsesPParams (ShelleyMAEra ma c)
+  where
+  type
+    PParamsDelta (ShelleyMAEra ma c) =
+      Shelley.PParamsUpdate (ShelleyMAEra ma c)
+
+  mergePPUpdates _ = Shelley.updatePParams
+
 --------------------------------------------------------------------------------
 -- Core instances
 --------------------------------------------------------------------------------
@@ -89,6 +108,10 @@ type instance
 type instance
   Core.AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c) =
     AuxiliaryData (ShelleyMAEra (ma :: MaryOrAllegra) c)
+
+type instance
+  Core.PParams (ShelleyMAEra (ma :: MaryOrAllegra) c) =
+    Shelley.PParams (ShelleyMAEra (ma :: MaryOrAllegra) c)
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -33,7 +33,7 @@ import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Delegation.Certificates (requiresVKeyWitness)
 import Shelley.Spec.Ledger.Keys (DSignable, Hash)
 import Shelley.Spec.Ledger.LedgerState (UTxOState)
-import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.PParams (ProtVer, Update)
 import qualified Shelley.Spec.Ledger.STS.Ledger as Shelley
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
 import Shelley.Spec.Ledger.STS.Utxow
@@ -138,7 +138,8 @@ instance
           (AuxiliaryDataHash (Crypto era))
       ),
     HasField "mint" (Core.TxBody era) (Core.Value era),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   STS (UTXOW era)
   where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -24,7 +24,11 @@ import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core (AuxiliaryData)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesPParams,
+    UsesValue,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody
   ( TxBody (..),
@@ -85,6 +89,7 @@ genTxBody ::
   forall era.
   ( UsesValue era,
     UsesAuxiliary era,
+    UsesPParams era,
     EraGen era
   ) =>
   SlotNo ->

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -21,7 +21,11 @@ import Cardano.Ledger.Mary.Value
     Value (..),
     policies,
   )
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesPParams,
+    UsesValue,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody (StrictMaybe, TxBody (..))
 import qualified Cardano.Ledger.Val as Val
@@ -111,7 +115,7 @@ coloredCoinMinMint :: Integer
 coloredCoinMinMint = 1000
 
 coloredCoinMaxMint :: Integer
-coloredCoinMaxMint = 1000*1000
+coloredCoinMaxMint = 1000 * 1000
 
 --------------------------------------------------------
 -- Red Coins                                          --
@@ -245,6 +249,7 @@ genTxBody ::
   forall era.
   ( UsesValue era,
     Core.Value era ~ Value (Crypto era),
+    UsesPParams era,
     UsesAuxiliary era,
     EraGen era
   ) =>

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -28,7 +28,12 @@ import Cardano.Ledger.Mary.Value
     PolicyID (..),
     Value (..),
   )
-import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesAuxiliary,
+    UsesPParams,
+    UsesScript,
+    UsesValue,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import Cardano.Ledger.ShelleyMA.TxBody
   ( TxBodyRaw (..),
@@ -159,7 +164,7 @@ embedTest = do
     Left s -> error (show s)
 
 getTxSparse ::
-  (UsesValue era, UsesScript era, UsesAuxiliary era) =>
+  (UsesValue era, UsesPParams era, UsesScript era, UsesAuxiliary era) =>
   Decode ('Closed 'Dense) (TxBodyRaw era)
 getTxSparse =
   SparseKeyed

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -12,18 +12,19 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
 import Control.State.Transition.Extended hiding (Assertion)
 import Control.State.Transition.Trace (checkTrace, (.-), (.->))
+import Data.Default.Class (def)
 import GHC.Records
 import Shelley.Spec.Ledger.API (LEDGER, LedgerEnv (..))
 import Shelley.Spec.Ledger.LedgerState
   ( DPState (..),
-    UTxOState (..)
+    UTxOState (..),
   )
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.Tx (Tx (..))
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.Shelley.Spec.Ledger.Utils (applySTSTest, runShelleyBase)
 import Test.Tasty.HUnit (Assertion, (@?=))
-import Data.Default.Class (def)
 
 type MaryTest = MaryEra TestCrypto
 

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -16,11 +16,12 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Mary.Value (AssetName (..), PolicyID (..), Value (..))
+import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (pattern AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),
     ValidityInterval (..),
-    hashTimelockScript
+    hashTimelockScript,
   )
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody (..))
 import qualified Cardano.Ledger.Val as Val
@@ -37,6 +38,7 @@ import Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..), hashKey)
 import qualified Shelley.Spec.Ledger.Metadata as SMD
 import Shelley.Spec.Ledger.PParams
   ( PParams' (..),
+    PParamsUpdate,
     Update,
     pattern ProposedPPUpdates,
     pattern Update,
@@ -108,7 +110,12 @@ testKeyHash = hashKey . snd $ mkKeyPair (0, 0, 0, 0, 2)
 testStakeCred :: Credential 'Staking TestCrypto
 testStakeCred = KeyHashObj . hashKey . snd $ mkKeyPair (0, 0, 0, 0, 3)
 
-testUpdate :: forall era. (Crypto era ~ TestCrypto) => Update era
+testUpdate ::
+  forall era.
+  ( Crypto era ~ TestCrypto,
+    PParamsDelta era ~ PParamsUpdate era
+  ) =>
+  Update era
 testUpdate =
   Update
     ( ProposedPPUpdates
@@ -196,6 +203,7 @@ metadataNoScritpsGoldenTest =
             . TkListLen 0 -- empty scripts
         )
     )
+
 -- CONTINUE also Scritps
 metadataWithScritpsGoldenTest :: forall era. (Era era, Core.Script era ~ Timelock (Crypto era)) => TestTree
 metadataWithScritpsGoldenTest =

--- a/shelley-ma/shelley-ma-test/test/Tests.hs
+++ b/shelley-ma/shelley-ma-test/test/Tests.hs
@@ -3,6 +3,7 @@
 
 module Main where
 
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Test.Cardano.Ledger.Allegra ()
 import Test.Cardano.Ledger.Allegra.ScriptTranslation (testScriptPostTranslation)
 import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Core
     Value,
     Script,
     AuxiliaryData,
+    PParams,
 
     -- * Constraint synonyms
     ChainData,
@@ -53,6 +54,9 @@ type family Script era :: Type
 
 -- | AuxiliaryData which may be attached to a transaction
 type family AuxiliaryData era :: Type
+
+-- | Protocol parameters
+type family PParams era :: Type
 
 -- | Common constraints
 --

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.SafeHash (SafeHash, extractHash)
+import Cardano.Ledger.Shelley.Constraints (UsesPParams (PParamsDelta))
 import Codec.Binary.Bech32
 import Control.Monad.Identity (Identity)
 import Control.SetAlgebra (forwards)
@@ -338,7 +339,10 @@ class PrettyA t where
 
 -- | Constraints needed to ensure that the ledger state can be pretty printed.
 type CanPrettyPrintLedgerState era =
-  (PrettyA (Core.TxOut era), PrettyA (State (Core.EraRule "PPUP" era)))
+  ( PrettyA (Core.TxOut era),
+    PrettyA (Core.PParams era),
+    PrettyA (State (Core.EraRule "PPUP" era))
+  )
 
 ppAccountState :: AccountState -> PDoc
 ppAccountState (AccountState tr re) =
@@ -382,7 +386,7 @@ ppInstantaneousRewards (InstantaneousRewards res treas) =
 ppIx :: Ix -> PDoc
 ppIx x = viaShow x
 
-ppPPUPState :: PPUPState era -> PDoc
+ppPPUPState :: PrettyA (PParamsDelta era) => PPUPState era -> PDoc
 ppPPUPState (PPUPState p fp) =
   ppRecord
     "Proposed PPUPState"
@@ -446,8 +450,8 @@ ppEpochState (EpochState acnt snap ls prev pp non) =
     [ ("accountState", ppAccountState acnt),
       ("snapShots", ppSnapShots snap),
       ("ledgerState", ppLedgerState ls),
-      ("prevPoolParams", ppPParams prev),
-      ("pooParams", ppPParams pp),
+      ("prevPParams", prettyA prev),
+      ("currentPParams", prettyA pp),
       ("nonMyopic", ppNonMyopic non)
     ]
 
@@ -488,7 +492,11 @@ instance
   where
   prettyA = ppLedgerState
 
-instance PrettyA (PPUPState era) where prettyA = ppPPUPState
+instance
+  PrettyA (PParamsDelta era) =>
+  PrettyA (PPUPState era)
+  where
+  prettyA = ppPPUPState
 
 instance PrettyA (PState crypto) where prettyA = ppPState
 
@@ -761,6 +769,7 @@ ppDCert (DCertMir x) = ppSexp "DCertMir" [ppMIRCert x]
 
 ppTxBody ::
   PrettyA (Core.TxOut era) =>
+  PrettyA (PParamsDelta era) =>
   TxBody era ->
   PDoc
 ppTxBody (TxBodyConstr (Memo (TxBodyRaw ins outs cs wdrls fee ttl upd mdh) _)) =
@@ -811,7 +820,7 @@ instance PrettyA (MIRCert c) where prettyA = ppMIRCert
 instance PrettyA (DCert c) where prettyA = ppDCert
 
 instance
-  PrettyA (Core.TxOut era) =>
+  (PrettyA (Core.TxOut era), PrettyA (PParamsDelta era)) =>
   PrettyA (TxBody era)
   where
   prettyA = ppTxBody
@@ -894,20 +903,27 @@ ppPParamsUpdate (PParams feeA feeB mbb mtx mbh kd pd em no a0 rho tau d ex pv mu
   where
     lift pp x = ppStrictMaybe pp x
 
-ppUpdate :: Update era -> PDoc
+ppUpdate :: PrettyA (PParamsDelta era) => Update era -> PDoc
 ppUpdate (Update prop epn) = ppSexp "Update" [ppProposedPPUpdates prop, ppEpochNo epn]
 
-ppProposedPPUpdates :: ProposedPPUpdates era -> PDoc
-ppProposedPPUpdates (ProposedPPUpdates m) = ppMap ppKeyHash ppPParamsUpdate m
+ppProposedPPUpdates :: PrettyA (PParamsDelta era) => ProposedPPUpdates era -> PDoc
+ppProposedPPUpdates (ProposedPPUpdates m) = ppMap ppKeyHash prettyA m
 
 ppPPUpdateEnv :: PPUpdateEnv c -> PDoc
-ppPPUpdateEnv (PPUpdateEnv slot gd) = ppSexp "PPUpdateEnv" [ppSlotNo slot, ppGenDelegs gd]
+ppPPUpdateEnv (PPUpdateEnv slot gd) =
+  ppSexp
+    "PPUpdateEnv"
+    [ppSlotNo slot, ppGenDelegs gd]
 
 instance PrettyA (PPUpdateEnv c) where prettyA = ppPPUpdateEnv
 
-instance PrettyA (ProposedPPUpdates e) where prettyA = ppProposedPPUpdates
+instance
+  PrettyA (PParamsDelta e) =>
+  PrettyA (ProposedPPUpdates e)
+  where
+  prettyA = ppProposedPPUpdates
 
-instance PrettyA (Update e) where prettyA = ppUpdate
+instance PrettyA (PParamsDelta e) => PrettyA (Update e) where prettyA = ppUpdate
 
 instance PrettyA (PParams' StrictMaybe e) where prettyA = ppPParamsUpdate
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -18,10 +18,16 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.SafeHash (EraIndependentAuxiliaryData, makeHashWithExplicitProxys)
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut (..), UsesValue)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesPParams (..),
+    UsesTxBody,
+    UsesTxOut (..),
+    UsesValue,
+  )
 import Data.Proxy
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
+import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, updatePParams)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
   ( TxBody,
@@ -41,6 +47,10 @@ instance CryptoClass.Crypto c => UsesValue (ShelleyEra c)
 instance CryptoClass.Crypto c => UsesTxOut (ShelleyEra c) where
   makeTxOut _ a v = TxOut a v
 
+instance CryptoClass.Crypto c => UsesPParams (ShelleyEra c) where
+  type PParamsDelta (ShelleyEra c) = PParamsUpdate (ShelleyEra c)
+  mergePPUpdates _ = updatePParams
+
 --------------------------------------------------------------------------------
 -- Core instances
 --------------------------------------------------------------------------------
@@ -54,6 +64,8 @@ type instance Core.TxOut (ShelleyEra c) = TxOut (ShelleyEra c)
 type instance Core.Script (ShelleyEra c) = MultiSig c
 
 type instance Core.AuxiliaryData (ShelleyEra c) = Metadata
+
+type instance Core.PParams (ShelleyEra c) = PParams (ShelleyEra c)
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Core
   ( AnnotatedData,
     AuxiliaryData,
     ChainData,
+    PParams,
     Script,
     SerialisableData,
     TxBody,
@@ -26,6 +27,7 @@ import Cardano.Ledger.SafeHash
     HashAnnotated,
   )
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
+import Control.DeepSeq (NFData)
 import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy)
 import GHC.Records (HasField)
@@ -82,6 +84,26 @@ type UsesAuxiliary era =
     ValidateAuxiliaryData era,
     AnnotatedData (AuxiliaryData era)
   )
+
+class
+  ( Era era,
+    Eq (PParams era),
+    Show (PParams era),
+    SerialisableData (PParams era),
+    ChainData (PParamsDelta era),
+    NFData (PParamsDelta era),
+    Ord (PParamsDelta era),
+    SerialisableData (PParamsDelta era)
+  ) =>
+  UsesPParams era
+  where
+  type PParamsDelta era :: Type
+
+  mergePPUpdates ::
+    proxy era ->
+    PParams era ->
+    PParamsDelta era ->
+    PParams era
 
 -- | Apply 'c' to all the types transitively involved with Value when
 -- (Core.Value era) is an instance of Compactible

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints
   ( UsesAuxiliary,
+    UsesPParams,
     UsesScript,
     UsesTxBody,
     UsesTxOut,
@@ -39,6 +40,7 @@ class
     UsesAuxiliary era,
     UsesTxBody era,
     UsesTxOut era,
+    UsesPParams era,
     ChainData (State (Core.EraRule "PPUP" era)),
     SerialisableData (State (Core.EraRule "PPUP" era))
   ) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -42,6 +42,7 @@ import Shelley.Spec.Ledger.API.Protocol (PraosCrypto)
 import Shelley.Spec.Ledger.BaseTypes (Globals, ShelleyBase)
 import Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv, LedgersPredicateFailure)
 import qualified Shelley.Spec.Ledger.STS.Ledgers as Ledgers
 import Shelley.Spec.Ledger.Slot (SlotNo)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -56,7 +56,9 @@ import Control.State.Transition.Extended
   )
 import Data.Either (fromRight)
 import GHC.Generics (Generic)
+import GHC.Records
 import NoThunks.Class (NoThunks (..))
+import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.BaseTypes
   ( Globals,
     Nonce,
@@ -81,7 +83,7 @@ import Shelley.Spec.Ledger.LedgerState
     _genDelegs,
   )
 import Shelley.Spec.Ledger.OCert (OCertSignable)
-import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.PParams (PParams' (..), ProtVer)
 import Shelley.Spec.Ledger.STS.Chain (ChainChecksData, pparamsToChainChecksData)
 import Shelley.Spec.Ledger.STS.EraMapping ()
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
@@ -113,7 +115,12 @@ class
     Environment (Core.EraRule "TICKF" era) ~ (),
     State (Core.EraRule "TICKF" era) ~ NewEpochState era,
     Signal (Core.EraRule "TICKF" era) ~ SlotNo,
-    PredicateFailure (Core.EraRule "TICKF" era) ~ TickfPredicateFailure era
+    PredicateFailure (Core.EraRule "TICKF" era) ~ TickfPredicateFailure era,
+    HasField "_d" (Core.PParams era) UnitInterval,
+    HasField "_extraEntropy" (Core.PParams era) Nonce,
+    HasField "_maxBBSize" (Core.PParams era) Natural,
+    HasField "_maxBHSize" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   GetLedgerView era
   where
@@ -170,15 +177,23 @@ mkPrtclEnv
       lvPoolDistr
       lvGenDelegs
 
-view :: NewEpochState era -> LedgerView (Crypto era)
+view ::
+  ( HasField "_d" (Core.PParams era) UnitInterval,
+    HasField "_extraEntropy" (Core.PParams era) Nonce,
+    HasField "_maxBBSize" (Core.PParams era) Natural,
+    HasField "_maxBHSize" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
+  ) =>
+  NewEpochState era ->
+  LedgerView (Crypto era)
 view
   NewEpochState
     { nesPd,
       nesEs
     } =
     LedgerView
-      { lvD = _d . esPp $ nesEs,
-        lvExtraEntropy = _extraEntropy . esPp $ nesEs,
+      { lvD = getField @"_d" . esPp $ nesEs,
+        lvExtraEntropy = getField @"_extraEntropy" . esPp $ nesEs,
         lvPoolDistr = nesPd,
         lvGenDelegs =
           _genDelegs . _dstate
@@ -239,7 +254,12 @@ futureView ::
     Environment (Core.EraRule "TICKF" era) ~ (),
     State (Core.EraRule "TICKF" era) ~ NewEpochState era,
     Signal (Core.EraRule "TICKF" era) ~ SlotNo,
-    PredicateFailure (Core.EraRule "TICKF" era) ~ TickfPredicateFailure era
+    PredicateFailure (Core.EraRule "TICKF" era) ~ TickfPredicateFailure era,
+    HasField "_d" (Core.PParams era) UnitInterval,
+    HasField "_extraEntropy" (Core.PParams era) Nonce,
+    HasField "_maxBBSize" (Core.PParams era) Natural,
+    HasField "_maxBHSize" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   Globals ->
   NewEpochState era ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -35,6 +35,7 @@ import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
 import Shelley.Spec.Ledger.BlockChain
 import Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import Shelley.Spec.Ledger.STS.EraMapping ()

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
@@ -1,9 +1,17 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Shelley.Spec.Ledger.HardForks
   ( aggregatedRewards,
   )
 where
 
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
+import GHC.Records
+import Shelley.Spec.Ledger.PParams (ProtVer (..))
 
-aggregatedRewards :: PParams era -> Bool
-aggregatedRewards pp = pvMajor (_protocolVersion pp) > 2
+aggregatedRewards ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+aggregatedRewards pp = pvMajor (getField @"_protocolVersion" pp) > 2

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -45,7 +47,6 @@ import Cardano.Binary
     encodeWord,
   )
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Val ((<->))
 import Cardano.Slotting.Slot (EpochSize)
 import Control.DeepSeq (NFData)
@@ -65,6 +66,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
+import GHC.Records (HasField (getField))
 import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 import Quiet
@@ -90,7 +92,7 @@ import Shelley.Spec.Ledger.EpochBoundary
   )
 import qualified Shelley.Spec.Ledger.HardForks as HardForks
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
-import Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
+import Shelley.Spec.Ledger.PParams (ProtVer)
 import Shelley.Spec.Ledger.RewardProvenance (RewardProvenancePool (..))
 import Shelley.Spec.Ledger.Serialization
   ( decodeRecordNamed,
@@ -281,9 +283,12 @@ instance CC.Crypto crypto => FromCBOR (NonMyopic crypto) where
 -- corresponding to f^~ in section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
 desirability ::
-  PParams era ->
+  ( HasField "_nOpt" pp Natural,
+    HasField "_a0" pp Rational
+  ) =>
+  pp ->
   Coin ->
-  PoolParams (Crypto era) ->
+  PoolParams c ->
   PerformanceEstimate ->
   Coin ->
   Double
@@ -300,23 +305,24 @@ desirability pp r pool (PerformanceEstimate p) (Coin totalStake) =
     tot = max 1 (fromIntegral totalStake)
     Coin pledge = _poolPledge pool
     s = fromIntegral pledge % tot
-    a0 = _a0 pp
-    z0 = 1 % max 1 (fromIntegral (_nOpt pp))
+    a0 = getField @"_a0" pp
+    z0 = 1 % max 1 (fromIntegral (getField @"_nOpt" pp))
 
 -- | Computes the top ranked stake pools
 -- corresponding to section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
 getTopRankedPools ::
+  (HasField "_a0" pp Rational, HasField "_nOpt" pp Natural) =>
   Coin ->
   Coin ->
-  PParams era ->
-  Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)) ->
-  Map (KeyHash 'StakePool (Crypto era)) PerformanceEstimate ->
-  Set (KeyHash 'StakePool (Crypto era))
+  pp ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
+  Map (KeyHash 'StakePool crypto) PerformanceEstimate ->
+  Set (KeyHash 'StakePool crypto)
 getTopRankedPools rPot totalStake pp poolParams aps =
   Set.fromList $
-    fmap fst $
-      take (fromIntegral $ _nOpt pp) (sortBy (flip compare `on` snd) rankings)
+    fst
+      <$> take (fromIntegral $ getField @"_nOpt" pp) (sortBy (flip compare `on` snd) rankings)
   where
     pdata = Map.toList $ Map.intersectionWith (,) poolParams aps
     rankings =
@@ -425,17 +431,19 @@ instance CC.Crypto crypto => FromCBOR (Reward crypto) where
     decode $ RecD Reward <! From <! From <! From
 
 sumRewards ::
-  forall era.
-  PParams era ->
-  Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))) ->
+  forall crypto pp.
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Map (Credential 'Staking crypto) (Set (Reward crypto)) ->
   Coin
 sumRewards pp rs = fold $ aggregateRewards pp rs
 
 aggregateRewards ::
-  forall era.
-  PParams era ->
-  Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))) ->
-  Map (Credential 'Staking (Crypto era)) Coin
+  forall crypto pp.
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Map (Credential 'Staking crypto) (Set (Reward crypto)) ->
+  Map (Credential 'Staking crypto) Coin
 aggregateRewards pp rewards =
   if HardForks.aggregatedRewards pp
     then Map.map (Set.foldr addRewardToCoin mempty) rewards
@@ -447,22 +455,26 @@ aggregateRewards pp rewards =
 
 -- | Reward one pool
 rewardOnePool ::
-  forall era m.
-  Monad m =>
-  PParams era ->
+  forall c m pp.
+  ( Monad m,
+    HasField "_d" pp UnitInterval,
+    HasField "_a0" pp Rational,
+    HasField "_nOpt" pp Natural
+  ) =>
+  pp ->
   Coin ->
   Natural ->
   Natural ->
-  PoolParams (Crypto era) ->
-  Stake (Crypto era) ->
+  PoolParams c ->
+  Stake c ->
   Rational ->
   Rational ->
   Coin ->
-  Set (Credential 'Staking (Crypto era)) ->
+  Set (Credential 'Staking c) ->
   ProvM
-    (Map (KeyHash 'StakePool (Crypto era)) (RewardProvenancePool (Crypto era)))
+    (Map (KeyHash 'StakePool c) (RewardProvenancePool c))
     m
-    (Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))))
+    (Map (Credential 'Staking c) (Set (Reward c)))
 rewardOnePool
   pp
   r
@@ -486,7 +498,7 @@ rewardOnePool
         if pledge <= ostake
           then maxPool pp r sigma pr
           else mempty
-      appPerf = mkApparentPerformance (_d pp) sigmaA blocksN blocksTotal
+      appPerf = mkApparentPerformance (getField @"_d" pp) sigmaA blocksN blocksTotal
       poolR = rationalToCoinViaFloor (appPerf * fromIntegral maxP)
       tot = fromIntegral totalStake
       mRewards =
@@ -547,23 +559,27 @@ rewardOnePool
           }
 
 reward ::
-  forall m era.
-  Monad m =>
-  PParams era ->
-  BlocksMade (Crypto era) ->
+  forall m c pp.
+  ( Monad m,
+    HasField "_d" pp UnitInterval,
+    HasField "_a0" pp Rational,
+    HasField "_nOpt" pp Natural
+  ) =>
+  pp ->
+  BlocksMade c ->
   Coin ->
-  Set (Credential 'Staking (Crypto era)) ->
-  Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)) ->
-  Stake (Crypto era) ->
-  Map (Credential 'Staking (Crypto era)) (KeyHash 'StakePool (Crypto era)) ->
+  Set (Credential 'Staking c) ->
+  Map (KeyHash 'StakePool c) (PoolParams c) ->
+  Stake c ->
+  Map (Credential 'Staking c) (KeyHash 'StakePool c) ->
   Coin ->
   ActiveSlotCoeff ->
   EpochSize ->
   ProvM
-    (Map (KeyHash 'StakePool (Crypto era)) (RewardProvenancePool (Crypto era)))
+    (Map (KeyHash 'StakePool c) (RewardProvenancePool c))
     m
-    ( Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))),
-      Map (KeyHash 'StakePool (Crypto era)) Likelihood
+    ( Map (Credential 'Staking c) (Set (Reward c)),
+      Map (KeyHash 'StakePool c) Likelihood
     )
 reward
   pp
@@ -585,17 +601,34 @@ reward
           let blocksProduced = Map.lookup hk b
               actgr@(Stake s) = poolStake hk delegs stake
               Coin pstake = fold s
-              sigma = if totalStake == 0 then 0 else fromIntegral pstake % fromIntegral totalStake
-              sigmaA = if activeStake == 0 then 0 else fromIntegral pstake % fromIntegral activeStake
+              sigma =
+                if totalStake == 0
+                  then 0
+                  else fromIntegral pstake % fromIntegral totalStake
+              sigmaA =
+                if activeStake == 0
+                  then 0
+                  else fromIntegral pstake % fromIntegral activeStake
               ls =
                 likelihood
                   (fromMaybe 0 blocksProduced)
-                  (leaderProbability asc sigma (_d pp))
+                  (leaderProbability asc sigma (getField @"_d" pp))
                   slotsPerEpoch
           case blocksProduced of
             Nothing -> pure (m1, Map.insert hk ls m2)
             Just n -> do
-              m <- rewardOnePool pp r n totalBlocks pparams actgr sigma sigmaA (Coin totalStake) addrsRew
+              m <-
+                rewardOnePool
+                  pp
+                  r
+                  n
+                  totalBlocks
+                  pparams
+                  actgr
+                  sigma
+                  sigmaA
+                  (Coin totalStake)
+                  addrsRew
               pure (combine m m1, Map.insert hk ls m2)
     foldListM action (Map.empty, Map.empty) (Map.toList poolParams)
 
@@ -617,15 +650,16 @@ foldListM accum ans (k : more) = do ans1 <- foldListM accum ans more; accum k an
 --   Additionally, instead of passing a rank r to compare with k,
 --   we pass the top k desirable pools and check for membership.
 nonMyopicStake ::
-  PParams era ->
+  HasField "_nOpt" pp Natural =>
+  pp ->
   StakeShare ->
   StakeShare ->
   StakeShare ->
-  KeyHash 'StakePool (Crypto era) ->
-  Set (KeyHash 'StakePool (Crypto era)) ->
+  KeyHash 'StakePool c ->
+  Set (KeyHash 'StakePool c) ->
   StakeShare
 nonMyopicStake pp (StakeShare s) (StakeShare sigma) (StakeShare t) kh topPools =
-  let z0 = 1 % max 1 (fromIntegral (_nOpt pp))
+  let z0 = 1 % max 1 (fromIntegral (getField @"_nOpt" pp))
    in if kh `Set.member` topPools
         then StakeShare (max (sigma + t) z0)
         else StakeShare (s + t)
@@ -639,13 +673,16 @@ nonMyopicStake pp (StakeShare s) (StakeShare sigma) (StakeShare t) kh topPools =
 --   r to compare with k, we pass the top k desirable pools and
 --   check for membership.
 nonMyopicMemberRew ::
-  PParams era ->
+  ( HasField "_a0" pp Rational,
+    HasField "_nOpt" pp Natural
+  ) =>
+  pp ->
   Coin ->
-  PoolParams (Crypto era) ->
+  PoolParams c ->
   StakeShare ->
   StakeShare ->
   StakeShare ->
-  Set (KeyHash 'StakePool (Crypto era)) ->
+  Set (KeyHash 'StakePool c) ->
   PerformanceEstimate ->
   Coin
 nonMyopicMemberRew

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -109,8 +109,7 @@ instance
   NoThunks (BbodyPredicateFailure era)
 
 instance
-  ( STS (BBODY era),
-    UsesTxBody era,
+  ( UsesTxBody era,
     UsesScript era,
     UsesAuxiliary era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -38,8 +38,9 @@ import Control.State.Transition
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
+import GHC.Records
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, UnitInterval, epochInfo)
 import Shelley.Spec.Ledger.BlockChain
   ( BHBody (..),
     BHeader (..),
@@ -60,7 +61,6 @@ import Shelley.Spec.Ledger.LedgerState
     TransLedgerState,
   )
 import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..))
 import Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv (..))
 import Shelley.Spec.Ledger.Slot (epochInfoEpoch, epochInfoFirst)
 import Shelley.Spec.Ledger.Tx (Tx)
@@ -76,7 +76,7 @@ deriving stock instance
   Show (BbodyState era)
 
 data BbodyEnv era = BbodyEnv
-  { bbodyPp :: PParams era,
+  { bbodyPp :: Core.PParams era,
     bbodyAccount :: AccountState
   }
 
@@ -109,14 +109,16 @@ instance
   NoThunks (BbodyPredicateFailure era)
 
 instance
-  ( UsesTxBody era,
+  ( STS (BBODY era),
+    UsesTxBody era,
     UsesScript era,
     UsesAuxiliary era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     Embed (Core.EraRule "LEDGERS" era) (BBODY era),
     Environment (Core.EraRule "LEDGERS" era) ~ LedgersEnv era,
     State (Core.EraRule "LEDGERS" era) ~ LedgerState era,
-    Signal (Core.EraRule "LEDGERS" era) ~ Seq (Tx era)
+    Signal (Core.EraRule "LEDGERS" era) ~ Seq (Tx era),
+    HasField "_d" (Core.PParams era) UnitInterval
   ) =>
   STS (BBODY era)
   where
@@ -139,14 +141,15 @@ instance
 
 bbodyTransition ::
   forall era.
-  ( UsesTxBody era,
+  ( STS (BBODY era),
+    UsesTxBody era,
     UsesScript era,
     UsesAuxiliary era,
     Embed (Core.EraRule "LEDGERS" era) (BBODY era),
     Environment (Core.EraRule "LEDGERS" era) ~ LedgersEnv era,
     State (Core.EraRule "LEDGERS" era) ~ LedgerState era,
     Signal (Core.EraRule "LEDGERS" era) ~ Seq (Tx era),
-    STS (BBODY era)
+    HasField "_d" (Core.PParams era) UnitInterval
   ) =>
   TransitionRule (BBODY era)
 bbodyTransition =
@@ -183,7 +186,7 @@ bbodyTransition =
           BbodyState
             ls'
             ( incrBlocks
-                (isOverlaySlot firstSlotNo (_d pp) slot)
+                (isOverlaySlot firstSlotNo (getField @"_d" pp) slot)
                 hkAsStakePool
                 b
             )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -28,7 +28,7 @@ import Cardano.Binary
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased, UsesAuxiliary, UsesPParams, UsesScript, UsesTxBody)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, (∈), (⨃))
 import Control.State.Transition
@@ -66,7 +66,6 @@ import Shelley.Spec.Ledger.LedgerState
     _pParams,
     _rewards,
   )
-import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Delpl (DELPL, DelplEnv (..), DelplPredicateFailure)
 import Shelley.Spec.Ledger.Serialization
   ( decodeRecordSum,
@@ -90,13 +89,17 @@ data DELEGS era
 data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: SlotNo,
     delegsIx :: Ix,
-    delegspp :: PParams era,
+    delegspp :: Core.PParams era,
     delegsTx :: Tx era,
     delegsAccount :: AccountState
   }
 
 deriving stock instance
-  ShelleyBased era =>
+  ( UsesPParams era,
+    UsesScript era,
+    UsesTxBody era,
+    UsesAuxiliary era
+  ) =>
   Show (DelegsEnv era)
 
 data DelegsPredicateFailure era

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -42,7 +42,6 @@ import Shelley.Spec.Ledger.LedgerState
     _dstate,
     _pstate,
   )
-import Shelley.Spec.Ledger.PParams (PParams)
 import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..), DelegPredicateFailure)
 import Shelley.Spec.Ledger.STS.Pool (POOL, PoolEnv (..), PoolPredicateFailure)
 import Shelley.Spec.Ledger.Serialization (decodeRecordSum)
@@ -60,7 +59,7 @@ data DELPL era
 data DelplEnv era = DelplEnv
   { delplSlotNo :: SlotNo,
     delPlPtr :: Ptr,
-    delPlPp :: PParams era,
+    delPlPp :: Core.PParams era,
     delPlAcnt :: AccountState
   }
 
@@ -190,6 +189,7 @@ delplTransition = do
 
 instance
   ( Era era,
+    STS (POOL era),
     PredicateFailure (Core.EraRule "POOL" era) ~ PoolPredicateFailure era
   ) =>
   Embed (POOL era) (DELPL era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -47,8 +47,11 @@ import Shelley.Spec.Ledger.LedgerState
     _delegationState,
     _utxoState,
   )
-import Shelley.Spec.Ledger.PParams (PParams)
-import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..), LedgerPredicateFailure)
+import Shelley.Spec.Ledger.STS.Ledger
+  ( LEDGER,
+    LedgerEnv (..),
+    LedgerPredicateFailure,
+  )
 import Shelley.Spec.Ledger.Slot (SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx)
 import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
@@ -57,7 +60,7 @@ data LEDGERS era
 
 data LedgersEnv era = LedgersEnv
   { ledgersSlotNo :: SlotNo,
-    ledgersPp :: PParams era,
+    ledgersPp :: Core.PParams era,
     ledgersAccount :: AccountState
   }
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -29,12 +29,14 @@ import Data.Default.Class (Default, def)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import GHC.Generics (Generic)
+import GHC.Records
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin
 import Shelley.Spec.Ledger.Delegation.Certificates
 import Shelley.Spec.Ledger.EpochBoundary
 import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.PParams (ProtVer)
 import Shelley.Spec.Ledger.Rewards (sumRewards)
 import Shelley.Spec.Ledger.STS.Epoch
 import Shelley.Spec.Ledger.STS.Mir
@@ -79,7 +81,8 @@ instance
     Environment (Core.EraRule "EPOCH" era) ~ (),
     State (Core.EraRule "EPOCH" era) ~ EpochState era,
     Signal (Core.EraRule "EPOCH" era) ~ EpochNo,
-    Default (EpochState era)
+    Default (EpochState era),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   STS (NEWEPOCH era)
   where
@@ -114,7 +117,8 @@ newEpochTransition ::
     Signal (Core.EraRule "MIR" era) ~ (),
     Environment (Core.EraRule "EPOCH" era) ~ (),
     State (Core.EraRule "EPOCH" era) ~ EpochState era,
-    Signal (Core.EraRule "EPOCH" era) ~ EpochNo
+    Signal (Core.EraRule "EPOCH" era) ~ EpochNo,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Newpp
   ( NEWPP,
@@ -14,7 +18,9 @@ module Shelley.Spec.Ledger.STS.Newpp
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Control.State.Transition
   ( STS (..),
     TRC (..),
@@ -25,8 +31,10 @@ import Control.State.Transition
 import Data.Default.Class (Default, def)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
+import GHC.Natural (Natural)
+import GHC.Records
 import NoThunks.Class (NoThunks (..))
-import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.EpochBoundary (obligation)
 import Shelley.Spec.Ledger.LedgerState
@@ -42,19 +50,22 @@ import Shelley.Spec.Ledger.LedgerState
     _reserves,
   )
 import Shelley.Spec.Ledger.PParams
-  ( PParams,
-    PParams' (..),
-    ProposedPPUpdates (..),
+  ( ProposedPPUpdates (..),
+    ProtVer,
     emptyPPPUpdates,
   )
 
 data NEWPP era
 
 data NewppState era
-  = NewppState (PParams era) (PPUPState era)
+  = NewppState (Core.PParams era) (PPUPState era)
 
 data NewppEnv era
-  = NewppEnv (DState (Crypto era)) (PState (Crypto era)) (UTxOState era) AccountState
+  = NewppEnv
+      (DState (Crypto era))
+      (PState (Crypto era))
+      (UTxOState era)
+      AccountState
 
 data NewppPredicateFailure era
   = UnexpectedDepositPot
@@ -64,18 +75,40 @@ data NewppPredicateFailure era
 
 instance NoThunks (NewppPredicateFailure era)
 
-instance Typeable era => STS (NEWPP era) where
+instance
+  ( Default (Core.PParams era),
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_maxTxSize" (Core.PParams era) Natural,
+    HasField "_maxBHSize" (Core.PParams era) Natural,
+    HasField "_maxBBSize" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (PParamsDelta era) (StrictMaybe ProtVer),
+    Typeable era
+  ) =>
+  STS (NEWPP era)
+  where
   type State (NEWPP era) = NewppState era
-  type Signal (NEWPP era) = Maybe (PParams era)
+  type Signal (NEWPP era) = Maybe (Core.PParams era)
   type Environment (NEWPP era) = NewppEnv era
   type BaseM (NEWPP era) = ShelleyBase
   type PredicateFailure (NEWPP era) = NewppPredicateFailure era
   transitionRules = [newPpTransition]
 
-instance Default (NewppState era) where
+instance Default (Core.PParams era) => Default (NewppState era) where
   def = NewppState def def
 
-newPpTransition :: TransitionRule (NEWPP era)
+newPpTransition ::
+  forall era.
+  ( HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_maxTxSize" (Core.PParams era) Natural,
+    HasField "_maxBHSize" (Core.PParams era) Natural,
+    HasField "_maxBBSize" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (PParamsDelta era) (StrictMaybe ProtVer)
+  ) =>
+  TransitionRule (NEWPP era)
 newPpTransition = do
   TRC
     ( NewppEnv dstate pstate utxoSt acnt,
@@ -90,15 +123,18 @@ newPpTransition = do
           Coin oblgNew = obligation ppNew' (_rewards dstate) (_pParams pstate)
           diff = oblgCurr - oblgNew
           Coin reserves = _reserves acnt
-          Coin requiredInstantaneousRewards = totalInstantaneousReservesRewards (_irwd dstate)
+          Coin requiredInstantaneousRewards =
+            totalInstantaneousReservesRewards (_irwd dstate)
 
-      (Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
+      Coin oblgCurr == _deposited utxoSt
+        ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
 
       if reserves + diff >= requiredInstantaneousRewards
         -- Note that instantaneous rewards from the treasury are irrelevant
         -- here, since changes in the protocol parameters do not change how much
         -- is needed from the treasury
-        && (_maxTxSize ppNew' + _maxBHSize ppNew') < _maxBBSize ppNew'
+        && (getField @"_maxTxSize" ppNew' + getField @"_maxBHSize" ppNew')
+          < getField @"_maxBBSize" ppNew'
         then pure $ NewppState ppNew' (updatePpup ppupSt ppNew')
         else pure $ NewppState pp (updatePpup ppupSt pp)
     Nothing -> pure $ NewppState pp (updatePpup ppupSt pp)
@@ -106,9 +142,20 @@ newPpTransition = do
 -- | Update the protocol parameter updates by clearing out the proposals
 -- and making the future proposals become the new proposals,
 -- provided the new proposals can follow (otherwise reset them).
-updatePpup :: PPUPState era -> PParams era -> PPUPState era
+updatePpup ::
+  ( HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_protocolVersion" (PParamsDelta era) (StrictMaybe ProtVer)
+  ) =>
+  PPUPState era ->
+  Core.PParams era ->
+  PPUPState era
 updatePpup ppupSt pp = PPUPState ps emptyPPPUpdates
   where
     (ProposedPPUpdates newProposals) = futureProposals ppupSt
-    goodPV = pvCanFollow (_protocolVersion pp) . _protocolVersion
-    ps = if all goodPV newProposals then ProposedPPUpdates newProposals else emptyPPPUpdates
+    goodPV =
+      pvCanFollow (getField @"_protocolVersion" pp)
+        . getField @"_protocolVersion"
+    ps =
+      if all goodPV newProposals
+        then ProposedPPUpdates newProposals
+        else emptyPPPUpdates

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -195,6 +195,7 @@ instance
 
 instance
   ( Era era,
+    STS (RUPD era),
     PredicateFailure (Core.EraRule "RUPD" era) ~ RupdPredicateFailure era
   ) =>
   Embed (RUPD era) (TICK era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley.Constraints
   ( TransValue,
     UsesAuxiliary,
+    UsesPParams,
     UsesScript,
     UsesTxBody,
     UsesTxOut,
@@ -64,6 +65,7 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks (..))
+import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.Address
   ( Addr (AddrBootstrap),
     bootstrapAddressAttrsSize,
@@ -120,10 +122,11 @@ data UTXO era
 data UtxoEnv era
   = UtxoEnv
       SlotNo
-      (PParams era)
+      (Core.PParams era)
       (Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)))
       (GenDelegs (Crypto era))
-  deriving (Show)
+
+deriving instance Show (Core.PParams era) => Show (UtxoEnv era)
 
 data UtxoPredicateFailure era
   = BadInputsUTxO
@@ -274,7 +277,9 @@ instance
     UsesValue era,
     UsesScript era,
     UsesAuxiliary era,
+    UsesPParams era,
     Core.TxBody era ~ TxBody era,
+    Core.PParams era ~ PParams era,
     Core.Value era ~ Coin,
     Eq (PredicateFailure (Core.EraRule "PPUP" era)),
     Embed (Core.EraRule "PPUP" era) (UTXO era),
@@ -342,7 +347,13 @@ utxoInductive ::
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "ttl" (Core.TxBody era) SlotNo,
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minfeeB" (Core.PParams era) Natural,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_minUTxOValue" (Core.PParams era) Coin,
+    HasField "_maxTxSize" (Core.PParams era) Natural
   ) =>
   TransitionRule (utxo era)
 utxoInductive = do
@@ -376,14 +387,14 @@ utxoInductive = do
   null wdrlsWrongNetwork ?! WrongNetworkWithdrawal ni (Set.fromList wdrlsWrongNetwork)
 
   let consumed_ = consumed pp utxo txb
-      produced_ = produced pp stakepools txb
+      produced_ = produced @era pp stakepools txb
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Protocol Parameter Update Proposals
   ppup' <- trans @(Core.EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
   let outputs = Map.elems $ unUTxO (txouts @era txb)
-      minUTxOValue = _minUTxOValue pp
+      minUTxOValue = getField @"_minUTxOValue" pp
       -- minUTxOValue deposit comparison done as Coin because this rule
       -- is correct strictly in the Shelley era (in shelleyMA we would need to
       -- additionally check that all amounts are non-negative)
@@ -391,7 +402,7 @@ utxoInductive = do
         filter
           ( \x ->
               let c = getField @"value" x
-               in (Val.coin c) < minUTxOValue
+               in Val.coin c < minUTxOValue
           )
           outputs
   null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
@@ -407,7 +418,7 @@ utxoInductive = do
           outputs
   null outputsAttrsTooBig ?! OutputBootAddrAttrsTooBig outputsAttrsTooBig
 
-  let maxTxSize_ = fromIntegral (_maxTxSize pp)
+  let maxTxSize_ = fromIntegral (getField @"_maxTxSize" pp)
       txSize_ = txsize tx
   txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
 
@@ -425,6 +436,7 @@ utxoInductive = do
 
 instance
   ( Era era,
+    STS (PPUP era),
     PredicateFailure (Core.EraRule "PPUP" era) ~ PpupPredicateFailure era
   ) =>
   Embed (PPUP era) (UTXO era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -98,7 +98,7 @@ import Shelley.Spec.Ledger.LedgerState
     witsFromWitnessSet,
     witsVKeyNeeded,
   )
-import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.PParams (ProtVer, Update)
 import Shelley.Spec.Ledger.STS.Utxo (UTXO, UtxoEnv (..), UtxoPredicateFailure)
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
 import Shelley.Spec.Ledger.Serialization
@@ -173,7 +173,8 @@ instance
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "adHash" (Core.TxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era))),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   STS (UTXOW era)
   where
@@ -294,7 +295,8 @@ utxoWitnessed ::
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "adHash" (Core.TxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era))),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   (UTxO era -> Tx era -> Set (ScriptHash (Crypto era))) ->
   TransitionRule (utxow era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -1,9 +1,17 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Shelley.Spec.Ledger.SoftForks
   ( validMetadata,
   )
 where
 
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProtVer (..))
+import GHC.Records
+import Shelley.Spec.Ledger.PParams (ProtVer (..))
 
-validMetadata :: PParams era -> Bool
-validMetadata pp = _protocolVersion pp > ProtVer 2 0
+validMetadata ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+validMetadata pp = getField @"_protocolVersion" pp > ProtVer 2 0

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Prelude (NFData (rnf))
 import Cardano.Slotting.Slot (withOriginToMaybe)
 import Control.Monad.Except ()
+import Control.State.Transition (STS (State))
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import qualified Data.Map as Map
 import Data.Proxy
@@ -69,7 +70,6 @@ import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest, testGlobals)
-import Control.State.Transition (STS (State))
 
 data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block era)
 
@@ -127,6 +127,7 @@ applyBlock ::
     TransTxBody NFData era,
     TransValue NFData era,
     API.ApplyBlock era,
+    NFData (Core.PParams era),
     NFData (State (Core.EraRule "PPUP" era))
   ) =>
   ValidateInput era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Main.hs
@@ -58,6 +58,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState (..),
     stakeDistr,
   )
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.Rewards (likelihood)
 import Shelley.Spec.Ledger.UTxO (UTxO)
 import Test.QuickCheck (arbitrary)
@@ -486,7 +487,7 @@ main = do
             ( \cs ->
                 bench "createRUpd" $ whnf (createRUpd testGlobals) cs
             ),
-           env
+          env
             (generate $ genChainInEpoch 5)
             ( \cs ->
                 bench "createRUpdWithProvenance" $ whnf (createRUpdWithProv testGlobals) cs

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Rewards.hs
@@ -16,9 +16,9 @@ import Cardano.Crypto.VRF (hashVerKeyVRF)
 import Cardano.Slotting.EpochInfo
 import Cardano.Slotting.Slot (EpochNo)
 import Control.Monad.Reader (runReader, runReaderT)
-import Data.Default.Class(Default(def))
-import Control.Provenance(runProvM,runWithProvM)
+import Control.Provenance (runProvM, runWithProvM)
 import Control.State.Transition.Extended (IRC (..), TRC (..), applySTS)
+import Data.Default.Class (Default (def))
 import Data.Either (fromRight)
 import Data.Functor.Identity (runIdentity)
 import qualified Data.Map.Strict as Map
@@ -40,7 +40,8 @@ import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
 import Shelley.Spec.Ledger.Genesis (ShelleyGenesisStaking (..))
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (Staking))
 import qualified Shelley.Spec.Ledger.LedgerState as LS
-import Shelley.Spec.Ledger.RewardProvenance(RewardProvenance)
+import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.RewardProvenance (RewardProvenance)
 import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState, chainNes, totalAda)
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxOut (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
@@ -64,7 +65,6 @@ import Test.Shelley.Spec.Ledger.Generator.Trace.Chain
     registerGenesisStaking,
   )
 import Test.Shelley.Spec.Ledger.Utils (testGlobals)
-
 
 -- | Generate a chain state at a given epoch. Since we are only concerned about
 -- rewards, this will populate the chain with empty blocks (only issued by the
@@ -188,12 +188,11 @@ createRUpd globals cs =
       runIdentity $
         epochInfoSize (epochInfo globals) (LS.nesEL nes)
 
-
 -- | Benchmark creating a reward update.
 createRUpdWithProv ::
   Globals ->
   ChainState B ->
-  (LS.RewardUpdate B_Crypto,RewardProvenance B_Crypto)
+  (LS.RewardUpdate B_Crypto, RewardProvenance B_Crypto)
 createRUpdWithProv globals cs =
   runIdentity $
     runReaderT

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -30,10 +30,13 @@ where
 -- Cypto and Era stuff
 
 import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
+import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val (Val (inject))
 import Control.State.Transition.Extended (TRC (..), applySTS)
+import Data.Default.Class (def)
 import qualified Data.Map as Map
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -49,7 +52,6 @@ import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DelegCert (..))
-import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( Hash,
     KeyHash,
@@ -107,7 +109,6 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
     unsafeMkUnitInterval,
   )
-import Data.Default.Class (def)
 
 -- ===============================================
 -- A special Era to run the Benchmarks in
@@ -174,7 +175,7 @@ ppsBench =
       _tau = unsafeMkUnitInterval 0.2
     }
 
-ledgerEnv :: LedgerEnv era
+ledgerEnv :: (Core.PParams era ~ PParams era) => LedgerEnv era
 ledgerEnv = LedgerEnv (SlotNo 0) 0 ppsBench (AccountState (Coin 0) (Coin 0))
 
 testLEDGER ::

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -18,20 +18,17 @@ import qualified Cardano.Crypto.KES.Class as KES
 import Cardano.Crypto.Util (SignableRepresentation)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Crypto
-import Shelley.Spec.Ledger.BaseTypes (Seed)
-import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Shelley.Spec.Ledger.API (PraosCrypto)
+import Shelley.Spec.Ledger.BaseTypes (Seed)
+import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
 -- | Mocking constraints used in generators
 type Mock c =
   ( PraosCrypto c,
     KES.Signable (KES c) ~ SignableRepresentation,
-    DSIGN.Signable (DSIGN c)
-      ~ SignableRepresentation,
-    VRF.Signable
-      (VRF c)
-      Seed
+    DSIGN.Signable (DSIGN c) ~ SignableRepresentation,
+    VRF.Signable (VRF c) Seed
   )
 
 -- | Additional mocking constraints used in examples.
@@ -39,7 +36,7 @@ type ExMock c =
   ( Mock c,
     Num (DSIGN.SignKeyDSIGN (DSIGN c)),
     Num (VerKeyDSIGN (DSIGN c)),
-    (VRF c) ~ FakeVRF
+    VRF c ~ FakeVRF
   )
 
 type C = ShelleyEra C_Crypto

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -18,11 +18,6 @@ import qualified Cardano.Crypto.VRF as VRF
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (VRF)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints
-  ( UsesAuxiliary,
-    UsesScript,
-    UsesTxBody,
-  )
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.SetAlgebra (dom, eval)
 import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
@@ -57,10 +52,10 @@ import Test.Shelley.Spec.Ledger.Generator.Core
     mkBlock,
     mkOCert,
   )
-import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
 import Test.Shelley.Spec.Ledger.Utils
   ( ShelleyLedgerSTS,
+    ShelleyTest,
     epochFromSlotNo,
     maxKESIterations,
     runShelleyBase,
@@ -81,9 +76,7 @@ type TxGen era =
 -- | Generate a valid block.
 genBlock ::
   forall era.
-  ( EraGen era,
-    UsesTxBody era,
-    UsesAuxiliary era,
+  ( ShelleyTest era,
     ApplyBlock era,
     Mock (Crypto era),
     GetLedgerView era,
@@ -102,9 +95,7 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
 genBlockWithTxGen ::
   forall era.
-  ( UsesTxBody era,
-    UsesScript era,
-    UsesAuxiliary era,
+  ( ShelleyTest era,
     Mock (Crypto era),
     GetLedgerView era,
     ApplyBlock era
@@ -173,6 +164,7 @@ genBlockWithTxGen
 selectNextSlotWithLeader ::
   forall era.
   ( Mock (Crypto era),
+    ShelleyTest era,
     GetLedgerView era,
     ApplyBlock era
   ) =>

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ShelleyEraGen.hs
@@ -14,12 +14,10 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.KES as KES
 import Cardano.Crypto.Util (SignableRepresentation)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Shelley.Spec.Ledger.API
@@ -51,6 +49,7 @@ import Test.Shelley.Spec.Ledger.Generator.ScriptClass
     ScriptClass (..),
   )
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain ()
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)
 
 {------------------------------------------------------------------------------
   ShelleyEra instances for EraGen and ScriptClass
@@ -97,7 +96,7 @@ instance CC.Crypto c => ScriptClass (ShelleyEra c) where
  -----------------------------------------------------------------------------}
 
 genTxBody ::
-  (ShelleyBased era, Core.TxOut era ~ TxOut era) =>
+  (ShelleyTest era) =>
   SlotNo ->
   Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -77,7 +77,6 @@ import Test.Shelley.Spec.Ledger.Utils
     maxLLSupply,
     mkHash,
   )
-import Data.Default.Class (Default)
 
 -- ======================================================
 
@@ -85,6 +84,7 @@ import Data.Default.Class (Default)
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
   ( EraGen era,
+    ShelleyTest era,
     UsesTxBody era,
     UsesTxOut era,
     UsesValue era,
@@ -134,10 +134,8 @@ lastByronHeaderHash _ = HashHeader $ mkHash 0
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisChainState ::
   forall era a.
-  ( EraGen era,
-    UsesTxOut era,
-    UsesValue era,
-    Default (State (Core.EraRule "PPUP" era))
+  ( ShelleyTest era,
+    EraGen era
   ) =>
   GenEnv era ->
   IRC (CHAIN era) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -103,7 +103,8 @@ instance
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
-    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    Core.PParams era ~ PParams era
   ) =>
   STS (CERTS era)
   where
@@ -122,7 +123,8 @@ certsTransition ::
   ( Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
-    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    Core.PParams era ~ PParams era
   ) =>
   TransitionRule (CERTS era)
 certsTransition = do
@@ -159,7 +161,8 @@ instance
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
-    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    Core.PParams era ~ PParams era
   ) =>
   QC.HasTrace (CERTS era) (GenEnv era)
   where
@@ -193,6 +196,7 @@ genDCerts ::
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    Core.PParams era ~ PParams era,
     EraGen era
   ) =>
   GenEnv era ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -30,6 +30,7 @@ import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as TQC
+import Data.Default.Class (Default)
 import Data.Functor.Identity (runIdentity)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -44,6 +45,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState,
     genesisState,
   )
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.STS.Delegs (DelegsEnv)
 import Shelley.Spec.Ledger.STS.Delpl (DELPL, DelplEnv, DelplPredicateFailure)
 import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..))
@@ -66,10 +68,10 @@ import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Utils
   ( ShelleyLedgerSTS,
+    ShelleyTest,
     applySTSTest,
     runShelleyBase,
   )
-import Data.Default.Class (Default)
 
 -- ======================================================
 
@@ -83,6 +85,7 @@ genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves})
 -- with meaningful delegation certificates.
 instance
   ( EraGen era,
+    ShelleyTest era,
     UsesTxBody era,
     UsesTxOut era,
     UsesValue era,
@@ -126,6 +129,7 @@ instance
 instance
   forall era.
   ( EraGen era,
+    ShelleyTest era,
     UsesTxBody era,
     UsesTxOut era,
     UsesValue era,
@@ -140,8 +144,7 @@ instance
     Embed (Core.EraRule "DELEG" era) (DELPL era),
     Embed (Core.EraRule "LEDGER" era) (LEDGERS era),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
-    Default (State (Core.EraRule "PPUP" era))
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era))
   ) =>
   TQC.HasTrace (LEDGERS era) (GenEnv era)
   where

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
@@ -14,6 +15,7 @@ module Test.Shelley.Spec.Ledger.Generator.Update
   )
 where
 
+import Cardano.Ledger.Era (Crypto)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
@@ -32,8 +34,6 @@ import Shelley.Spec.Ledger.BaseTypes
     mkNonceFromNumber,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
-
-import Cardano.Ledger.Era (Crypto, Era)
 import Shelley.Spec.Ledger.Keys
   ( GenDelegPair (..),
     GenDelegs (..),
@@ -70,8 +70,9 @@ import Test.Shelley.Spec.Ledger.Generator.Core
   )
 import Test.Shelley.Spec.Ledger.Utils
   ( GenesisKeyPair,
+    ShelleyTest,
     epochFromSlotNo,
-    unsafeMkUnitInterval
+    unsafeMkUnitInterval,
   )
 
 genRationalInThousands :: HasCallStack => Integer -> Integer -> Gen Rational
@@ -207,6 +208,7 @@ genNextProtocolVersion pp = do
 -- Return an empty update if it is too late in the epoch for updates.
 genPPUpdate ::
   HasCallStack =>
+  ShelleyTest era =>
   Constants ->
   PParams era ->
   [KeyHash 'Genesis (Crypto era)] ->
@@ -255,7 +257,7 @@ genPPUpdate (c@Constants {maxMinFeeA, maxMinFeeB}) pp genesisKeys = do
 
 -- | Generate an @Update (where all the given nodes participate)
 genUpdateForNodes ::
-  (HasCallStack, Era era) =>
+  (HasCallStack, ShelleyTest era) =>
   Constants ->
   SlotNo ->
   EpochNo -> -- current epoch
@@ -271,7 +273,7 @@ genUpdateForNodes c s e coreKeys pp =
 
 -- | Occasionally generate an update and return with the witness keys
 genUpdate ::
-  (HasCallStack, Era era) =>
+  (HasCallStack, ShelleyTest era) =>
   Constants ->
   SlotNo ->
   [(GenesisKeyPair (Crypto era), AllIssuerKeys (Crypto era) 'GenesisDelegate)] ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -23,6 +23,7 @@ import Cardano.Binary (serialize)
 import Cardano.Ledger.AuxiliaryData (hashAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.SafeHash (EraIndependentTxBody, SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.Constraints
   ( TransValue,
     UsesAuxiliary,
@@ -62,7 +63,6 @@ import Shelley.Spec.Ledger.BaseTypes
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
-import Cardano.Ledger.SafeHash (SafeHash, EraIndependentTxBody, hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( KeyHash,
     KeyPair,
@@ -122,6 +122,7 @@ import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, Split (..))
 -- =======================================================
 
 showBalance ::
+  forall era.
   ( ShelleyTest era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
@@ -141,7 +142,7 @@ showBalance
   (Tx body _ _) =
     "\n\nConsumed: " ++ show (consumed pparams utxo body)
       ++ "  Produced: "
-      ++ show (produced pparams stakepools body)
+      ++ show (produced @era pparams stakepools body)
 
 --  ========================================================================
 
@@ -165,11 +166,8 @@ showBalance
 genTx ::
   forall era.
   ( HasCallStack,
+    ShelleyTest era,
     EraGen era,
-    UsesTxBody era,
-    UsesTxOut era,
-    UsesValue era,
-    UsesAuxiliary era,
     Mock (Crypto era),
     Embed (Core.EraRule "DELPL" era) (CERTS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -16,8 +16,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators
-  ( genPParams,
-    mkDummyHash,
+  ( mkDummyHash,
     genHash,
     genShelleyAddress,
     genByronAddress,
@@ -46,16 +45,18 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.SafeHash (HasAlgorithm, SafeHash, unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Constraints
   ( UsesAuxiliary,
     UsesScript,
     UsesTxBody,
     UsesTxOut,
-    UsesValue
+    UsesValue,
   )
 import Cardano.Slotting.Block (BlockNo (..))
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import Control.SetAlgebra (biMapFromList)
+import Control.State.Transition (STS (State))
 import qualified Data.ByteString.Char8 as BS
 import Data.Coerce (coerce)
 import Data.IP (IPv4, IPv6, toIPv4, toIPv6)
@@ -123,7 +124,6 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (defaultConstants)
 import Test.Shelley.Spec.Ledger.Generator.Core
   ( KeySpace (KeySpace_),
-    geConstants,
     geKeySpace,
     ksCoreNodes,
     mkBlock,
@@ -133,14 +133,11 @@ import Test.Shelley.Spec.Ledger.Generator.Core
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (coreNodeKeys, genEnv)
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass (ScriptClass)
-import qualified Test.Shelley.Spec.Ledger.Generator.Update as Update
 import Test.Shelley.Spec.Ledger.Serialisation.Generators.Bootstrap
   ( genBootstrapAddress,
     genSignature,
   )
 import Test.Tasty.QuickCheck (Gen, choose, elements)
-import Control.State.Transition (STS (State))
-import Cardano.Ledger.SafeHash(SafeHash, HasAlgorithm, unsafeMakeSafeHash)
 
 -- =======================================================
 
@@ -152,7 +149,6 @@ mkDummyHash = coerce . hashWithSerialiser @h toCBOR
 
 genSafeHash :: HasAlgorithm c => Gen (SafeHash c i)
 genSafeHash = unsafeMakeSafeHash <$> arbitrary
-
 
 {-------------------------------------------------------------------------------
   Generators
@@ -463,17 +459,18 @@ instance
   where
   arbitrary = genericArbitraryU
   shrink = recursivelyShrink
-  -- The 'genericShrink' function returns first the immediate subterms of a
-  -- value (in case it is a recursive data-type), and then shrinks the value
-  -- itself. Since 'UTxOState' is not a recursive data-type, there are no
-  -- subterms, and we can use `recursivelyShrink` directly. This is particularly
-  -- important when abstracting away the different fields of the ledger state,
-  -- since the generic subterms instances will overlap due to GHC not having
-  -- enough context to infer if 'a' and 'b' are the same types (since in this
-  -- case this will depend on the definition of 'era').
-  --
-  -- > instance OVERLAPPING_ GSubtermsIncl (K1 i a) a where
-  -- > instance OVERLAPPING_ GSubtermsIncl (K1 i a) b where
+
+-- The 'genericShrink' function returns first the immediate subterms of a
+-- value (in case it is a recursive data-type), and then shrinks the value
+-- itself. Since 'UTxOState' is not a recursive data-type, there are no
+-- subterms, and we can use `recursivelyShrink` directly. This is particularly
+-- important when abstracting away the different fields of the ledger state,
+-- since the generic subterms instances will overlap due to GHC not having
+-- enough context to infer if 'a' and 'b' are the same types (since in this
+-- case this will depend on the definition of 'era').
+--
+-- > instance OVERLAPPING_ GSubtermsIncl (K1 i a) a where
+-- > instance OVERLAPPING_ GSubtermsIncl (K1 i a) b where
 
 instance
   ( UsesTxOut era,
@@ -493,6 +490,7 @@ instance
     Mock (Crypto era),
     Arbitrary (Core.TxOut era),
     Arbitrary (Core.Value era),
+    Arbitrary (Core.PParams era),
     Arbitrary (State (Core.EraRule "PPUP" era)),
     EraGen era
   ) =>
@@ -517,6 +515,7 @@ instance
     Mock (Crypto era),
     Arbitrary (Core.TxOut era),
     Arbitrary (Core.Value era),
+    Arbitrary (Core.PParams era),
     Arbitrary (State (Core.EraRule "PPUP" era)),
     EraGen era
   ) =>
@@ -527,8 +526,8 @@ instance
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> genPParams (Proxy @era)
-      <*> genPParams (Proxy @era)
+      <*> arbitrary
+      <*> arbitrary
       <*> arbitrary
 
 instance Arbitrary RewardType where
@@ -546,12 +545,6 @@ instance CC.Crypto crypto => Arbitrary (RewardUpdate crypto) where
 instance Arbitrary a => Arbitrary (StrictMaybe a) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
-
-genPParams ::
-  EraGen era =>
-  proxy era ->
-  Gen (PParams era)
-genPParams p = Update.genPParams (geConstants (genEnv p))
 
 instance CC.Crypto crypto => Arbitrary (OBftSlot crypto) where
   arbitrary = genericArbitraryU
@@ -664,7 +657,7 @@ genUTCTime = do
       (Time.picosecondsToDiffTime diff)
 
 instance
-  (Mock (Crypto era), EraGen era) =>
+  (Mock (Crypto era), EraGen era, Arbitrary (PParams era)) =>
   Arbitrary (ShelleyGenesis era)
   where
   arbitrary =
@@ -680,7 +673,7 @@ instance
       <*> (fromInteger <$> arbitrary) -- sgSlotLength
       <*> arbitrary -- sgUpdateQuorum
       <*> arbitrary -- sgMaxLovelaceSupply
-      <*> genPParams (Proxy @era) -- sgProtocolParams
+      <*> arbitrary -- sgProtocolParams
       <*> arbitrary -- sgGenDelegs
       <*> arbitrary -- sgInitialFunds
       <*> (ShelleyGenesisStaking <$> arbitrary <*> arbitrary) -- sgStaking

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/Generators.hs
@@ -19,6 +19,7 @@ module Test.Shelley.Spec.Ledger.Serialisation.Generators () where
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Generic.Random (genericArbitraryU)
 import Shelley.Spec.Ledger.API (TxBody (TxBody))
+import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Utxo as STS
 import Test.QuickCheck
   ( Arbitrary,
@@ -50,3 +51,10 @@ instance Mock c => Arbitrary (TxBody (ShelleyEra c)) where
 instance Mock c => Arbitrary (STS.UtxoPredicateFailure (ShelleyEra c)) where
   arbitrary = genericArbitraryU
   shrink _ = []
+
+-- | Note that this instance is a little off - it is an era-independent
+-- generator for something which is only valid in certain eras. Its sole use is
+-- for `ShelleyGenesis`, a somewhat confusing type which is in fact used as the
+-- genesis for multiple eras.
+instance Arbitrary (PParams era) where
+  arbitrary = genericArbitraryU

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Shrinkers.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Shrinkers.hs
@@ -36,7 +36,7 @@ shrinkBlock _ = []
 
 shrinkTx ::
   forall era.
-  ShelleyTest era =>
+  (ShelleyTest era, Core.TxBody era ~ TxBody era) =>
   Tx era ->
   [Tx era]
 shrinkTx (Tx _b _ws _md) =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -137,9 +137,8 @@ import Shelley.Spec.Ledger.LedgerState (UTxOState (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
-import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
-import Shelley.Spec.Ledger.Tx (Tx, TxBody, TxOut)
+import Shelley.Spec.Ledger.Tx (Tx, TxOut)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Tasty.HUnit
   ( Assertion,
@@ -153,11 +152,9 @@ type ShelleyTest era =
     UsesScript era,
     UsesAuxiliary era,
     UsesPParams era,
-    TxBody era ~ Core.TxBody era,
     TxOut era ~ Core.TxOut era,
     PParams era ~ Core.PParams era,
     PParamsDelta era ~ PParamsUpdate era,
-    MultiSig (Crypto era) ~ Core.Script era,
     Split (Core.Value era),
     Default (State (Core.EraRule "PPUP" era))
   )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -92,6 +92,7 @@ import Control.State.Transition.Trace
     (.->),
   )
 import Data.Coerce (coerce)
+import Data.Default.Class (Default)
 import Data.Functor ((<&>))
 import Data.Functor.Identity (runIdentity)
 import Data.Maybe (fromMaybe)
@@ -107,6 +108,7 @@ import Shelley.Spec.Ledger.API
     LedgerEnv,
     LedgerState,
     LedgersEnv,
+    PParams,
   )
 import Shelley.Spec.Ledger.Address (Addr, pattern Addr)
 import Shelley.Spec.Ledger.BaseTypes
@@ -133,6 +135,7 @@ import Shelley.Spec.Ledger.Keys
   )
 import Shelley.Spec.Ledger.LedgerState (UTxOState (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
@@ -142,8 +145,6 @@ import Test.Tasty.HUnit
   ( Assertion,
     (@?=),
   )
-import Data.Default.Class (Default)
-
 
 type ShelleyTest era =
   ( UsesTxBody era,
@@ -151,8 +152,11 @@ type ShelleyTest era =
     UsesTxOut era,
     UsesScript era,
     UsesAuxiliary era,
+    UsesPParams era,
     TxBody era ~ Core.TxBody era,
     TxOut era ~ Core.TxOut era,
+    PParams era ~ Core.PParams era,
+    PParamsDelta era ~ PParamsUpdate era,
     MultiSig (Crypto era) ~ Core.Script era,
     Split (Core.Value era),
     Default (State (Core.EraRule "PPUP" era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -6,15 +6,17 @@ module Test.Shelley.Spec.Ledger.Examples
   )
 where
 
+import Cardano.Ledger.Shelley ()
 import Control.State.Transition.Extended hiding (Assertion)
 import Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import Shelley.Spec.Ledger.BlockChain (Block)
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainState, totalAda)
+import Shelley.Spec.Ledger.Scripts ()
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Orphans ()
 import Test.Shelley.Spec.Ledger.Utils (applySTSTest, maxLLSupply, runShelleyBase)
 import Test.Tasty.HUnit (Assertion, (@?=))
-import Shelley.Spec.Ledger.Scripts ()
 
 data CHAINExample h = CHAINExample
   { -- | State to start testing with

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -96,7 +96,7 @@ import Shelley.Spec.Ledger.LedgerState
     UTxOState (..),
     applyRUpd,
   )
-import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates)
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), ProposedPPUpdates, ProtVer)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Shelley.Spec.Ledger.STS.Mir (emptyInstantaneousRewards)
 import Shelley.Spec.Ledger.Tx (TxIn)
@@ -372,6 +372,7 @@ stageRetirement kh e cs = cs {chainNes = nes'}
 -- Remove a stake pool.
 reapPool ::
   forall era.
+  (Core.PParams era ~ PParams era) =>
   PoolParams (Crypto era) ->
   ChainState era ->
   ChainState era
@@ -488,6 +489,7 @@ rewardUpdate ru cs = cs {chainNes = nes'}
 -- Apply the given reward update to the chain state
 applyRewardUpdate ::
   forall era.
+  HasField "_protocolVersion" (Core.PParams era) ProtVer =>
   RewardUpdate (Crypto era) ->
   ChainState era ->
   ChainState era
@@ -573,6 +575,7 @@ incrBlockCount kh cs = cs {chainNes = nes'}
 -- 'newLab', 'evolveNonceUnfrozen', and 'evolveNonceFrozen'.
 newEpoch ::
   forall era.
+  (Core.PParams era ~ PParams era) =>
   Era era =>
   Block era ->
   ChainState era ->
@@ -657,6 +660,7 @@ setFutureProposals ps cs = cs {chainNes = nes'}
 -- Set the protocol parameters.
 setPParams ::
   forall era.
+  (Core.PParams era ~ PParams era) =>
   PParams era ->
   ChainState era ->
   ChainState era
@@ -672,6 +676,7 @@ setPParams pp cs = cs {chainNes = nes'}
 -- Set the previous protocol parameters.
 setPrevPParams ::
   forall era.
+  (Core.PParams era ~ PParams era) =>
   PParams era ->
   ChainState era ->
   ChainState era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
@@ -20,6 +20,7 @@ where
 
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto (..))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
 import Data.Default.Class (def)
@@ -59,7 +60,6 @@ import Shelley.Spec.Ledger.Delegation.Certificates
     PoolDistr (..),
   )
 import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, coerceKeyRole)
 import Shelley.Spec.Ledger.LedgerState
   ( RewardUpdate (..),
@@ -108,7 +108,7 @@ import Shelley.Spec.Ledger.TxBody
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..), makeWitnessesVKey)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, ExMock)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, C_Crypto, ExMock)
 import Test.Shelley.Spec.Ledger.Examples (CHAINExample (..), testCHAINExample)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import qualified Test.Shelley.Spec.Ledger.Examples.Combinators as C
@@ -770,12 +770,12 @@ twoPools9Agg = CHAINExample expectedStEx8Agg blockEx9 (Right expectedStEx9Agg)
 
 testAggregateRewardsLegacy :: Assertion
 testAggregateRewardsLegacy =
-  (aggregateRewards @C) ppEx rsEx9Agg
+  (aggregateRewards @C_Crypto) ppEx rsEx9Agg
     @?= Map.singleton Cast.carlSHK (carlLeaderRewardsFromBob @(Crypto C))
 
 testAggregateRewardsNew :: Assertion
 testAggregateRewardsNew =
-  (aggregateRewards @C) ppProtVer3 rsEx9Agg
+  (aggregateRewards @C_Crypto) ppProtVer3 rsEx9Agg
     @?= Map.singleton
       Cast.carlSHK
       ( carlLeaderRewardsFromAlice @(Crypto C)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -18,6 +19,7 @@ module Test.Shelley.Spec.Ledger.Examples.TwoPools
   )
 where
 
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
@@ -141,6 +143,14 @@ import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
+-- | Type local to this module expressing the various constraints assumed
+-- amongst all tests in this module.
+type TwoPoolsConstraints era =
+  ( ShelleyTest era,
+    ExMock (Crypto era),
+    Core.TxBody era ~ TxBody era
+  )
+
 aliceInitCoin :: Coin
 aliceInitCoin = Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
 
@@ -150,7 +160,7 @@ bobInitCoin = Coin $ 1 * 1000 * 1000 * 1000 * 1000 * 1000
 carlInitCoin :: Coin
 carlInitCoin = Coin $ 5 * 1000 * 1000 * 1000 * 1000 * 1000
 
-initUTxO :: ShelleyTest era => UTxO era
+initUTxO :: TwoPoolsConstraints era => UTxO era
 initUTxO =
   genesisCoins
     genesisId
@@ -159,7 +169,7 @@ initUTxO =
       TxOut Cast.carlAddr (Val.inject carlInitCoin)
     ]
 
-initStTwoPools :: forall era. ShelleyTest era => ChainState era
+initStTwoPools :: forall era. TwoPoolsConstraints era => ChainState era
 initStTwoPools = initSt initUTxO
 
 --
@@ -182,7 +192,7 @@ alicePoolParams' = Cast.alicePoolParams {_poolRAcnt = RewardAcnt Testnet Cast.ca
 bobPoolParams' :: CryptoClass.Crypto c => PoolParams c
 bobPoolParams' = Cast.bobPoolParams {_poolRAcnt = RewardAcnt Testnet Cast.carlSHK}
 
-txbodyEx1 :: forall era. ShelleyTest era => TxBody era
+txbodyEx1 :: forall era. TwoPoolsConstraints era => TxBody era
 txbodyEx1 =
   TxBody
     (Set.fromList [TxIn genesisId 0])
@@ -204,7 +214,11 @@ txbodyEx1 =
     SNothing
     SNothing
 
-txEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Tx era
+txEx1 ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  Tx era
 txEx1 =
   Tx
     txbodyEx1
@@ -219,7 +233,12 @@ txEx1 =
       }
     SNothing
 
-blockEx1 :: forall era. (HasCallStack, ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx1 ::
+  forall era.
+  ( HasCallStack,
+    TwoPoolsConstraints era
+  ) =>
+  Block era
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -234,7 +253,11 @@ blockEx1 =
     0
     (mkOCert (coreNodeKeysBySchedule @era ppEx 10) 0 (KESPeriod 0))
 
-expectedStEx1 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx1 ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  ChainState era
 expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce (blockEx1 @era))
     . C.newLab blockEx1
@@ -259,14 +282,18 @@ expectedStEx1 =
 -- This is the only block in this example that includes a transaction,
 -- and after this block is processed, the UTxO will consist entirely
 -- of Alice's new coin aliceCoinEx1, and Bob and Carls initial genesis coins.
-twoPools1 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools1 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools1 = CHAINExample initStTwoPools blockEx1 (Right expectedStEx1)
 
 --
 -- Block 2, Slot 90, Epoch 0
 --
 
-blockEx2 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx2 ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  Block era
 blockEx2 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx1)
@@ -283,7 +310,8 @@ blockEx2 =
 
 expectedStEx2 ::
   forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
+  ( TwoPoolsConstraints era
+  ) =>
   ChainState era
 expectedStEx2 =
   C.evolveNonceFrozen (getBlockNonce (blockEx2 @era))
@@ -294,17 +322,28 @@ expectedStEx2 =
 -- === Block 2, Slot 90, Epoch 0
 --
 -- Create an empty block near the end of epoch 0 to close out the epoch.
-twoPools2 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools2 ::
+  ( TwoPoolsConstraints era
+  ) =>
+  CHAINExample era
 twoPools2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
 -- Block 3, Slot 110, Epoch 1
 --
 
-epoch1Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch1Nonce ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  Nonce
 epoch1Nonce = chainCandidateNonce (expectedStEx2 @era)
 
-blockEx3 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx3 ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  Block era
 blockEx3 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx2)
@@ -344,7 +383,8 @@ snapEx3 =
 
 expectedStEx3 ::
   forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
+  ( TwoPoolsConstraints era
+  ) =>
   ChainState era
 expectedStEx3 =
   C.newEpoch blockEx3
@@ -355,14 +395,21 @@ expectedStEx3 =
 -- === Block 3, Slot 110, Epoch 1
 --
 -- Create an empty block at the begining of epoch 1 to trigger the epoch change.
-twoPools3 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools3 ::
+  ( TwoPoolsConstraints era
+  ) =>
+  CHAINExample era
 twoPools3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
 -- Block 4, Slot 190, Epoch 1
 --
 
-blockEx4 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx4 ::
+  forall era.
+  ( TwoPoolsConstraints era
+  ) =>
+  Block era
 blockEx4 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx3)
@@ -392,7 +439,7 @@ rewardUpdateEx4 =
 
 expectedStEx4 ::
   forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
+  (TwoPoolsConstraints era) =>
   ChainState era
 expectedStEx4 =
   C.evolveNonceFrozen (getBlockNonce (blockEx4 @era))
@@ -404,10 +451,10 @@ expectedStEx4 =
 --
 -- Create an empty block near the end of epoch 0 to close out the epoch,
 -- preparing the way for the first non-empty pool distribution.
-twoPools4 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools4 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
-epoch2Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch2Nonce :: forall era. (TwoPoolsConstraints era) => Nonce
 epoch2Nonce =
   chainCandidateNonce (expectedStEx4 @era)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx2 @era))
@@ -416,7 +463,7 @@ epoch2Nonce =
 -- Block 5, Slot 221, Epoch 2
 --
 
-blockEx5 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx5 :: forall era. (TwoPoolsConstraints era) => Block era
 blockEx5 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx4)
@@ -454,7 +501,7 @@ pdEx5 =
 
 expectedStEx5 ::
   forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
+  (TwoPoolsConstraints era) =>
   ChainState era
 expectedStEx5 =
   C.incrBlockCount (hk Cast.alicePoolKeys)
@@ -469,14 +516,14 @@ expectedStEx5 =
 --
 -- Create the first non-empty pool distribution by starting the epoch 2.
 -- Moreover, Alice's pool produces the block.
-twoPools5 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools5 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 
 --
 -- Block 6, Slot 295, Epoch 2
 --
 
-blockEx6 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx6 :: forall era. (TwoPoolsConstraints era) => Block era
 blockEx6 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx5)
@@ -491,7 +538,7 @@ blockEx6 =
     14
     (mkOCert Cast.alicePoolKeys 0 (KESPeriod 14))
 
-expectedStEx6 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx6 :: forall era. (TwoPoolsConstraints era) => ChainState era
 expectedStEx6 =
   C.evolveNonceFrozen (getBlockNonce (blockEx6 @era))
     . C.newLab blockEx6
@@ -503,14 +550,14 @@ expectedStEx6 =
 -- === Block 6, Slot 295, Epoch 2
 --
 -- Alice's pool produces a second block.
-twoPools6 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools6 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools6 = CHAINExample expectedStEx5 blockEx6 (Right expectedStEx6)
 
 --
 -- Block 7, Slot 297, Epoch 2
 --
 
-blockEx7 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx7 :: forall era. (TwoPoolsConstraints era) => Block era
 blockEx7 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx6)
@@ -525,7 +572,7 @@ blockEx7 =
     14
     (mkOCert Cast.bobPoolKeys 0 (KESPeriod 14))
 
-expectedStEx7 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx7 :: forall era. (TwoPoolsConstraints era) => ChainState era
 expectedStEx7 =
   C.evolveNonceFrozen (getBlockNonce (blockEx7 @era))
     . C.newLab blockEx7
@@ -536,19 +583,19 @@ expectedStEx7 =
 -- === Block 7, Slot 295, Epoch 2
 --
 -- Bob's pool produces a block.
-twoPools7 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools7 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 
 --
 -- Block 8, Slot 310, Epoch 3
 --
 
-epoch3Nonce :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Nonce
+epoch3Nonce :: forall era. (TwoPoolsConstraints era) => Nonce
 epoch3Nonce =
   chainCandidateNonce (expectedStEx7 @era)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx4 @era))
 
-blockEx8 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx8 :: forall era. (TwoPoolsConstraints era) => Block era
 blockEx8 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx7)
@@ -563,7 +610,7 @@ blockEx8 =
     15
     (mkOCert (coreNodeKeysBySchedule @era ppEx 310) 1 (KESPeriod 15))
 
-expectedStEx8 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx8 :: forall era. (TwoPoolsConstraints era) => ChainState era
 expectedStEx8 =
   C.newEpoch blockEx8
     . C.newSnapshot snapEx3 (Coin 0)
@@ -576,14 +623,14 @@ expectedStEx8 =
 -- === Block 8, Slot 310, Epoch 3
 --
 -- Create an empty block to start epoch 3.
-twoPools8 :: (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools8 :: (TwoPoolsConstraints era) => CHAINExample era
 twoPools8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 
 --
 -- Block 9, Slot 390, Epoch 3
 --
 
-blockEx9 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => Block era
+blockEx9 :: forall era. (TwoPoolsConstraints era) => Block era
 blockEx9 =
   mkBlockFakeVRF
     (bhHash $ bheader @era blockEx8)
@@ -719,7 +766,7 @@ rewardUpdateEx9 pp rewards =
 
 expectedStEx9 ::
   forall era.
-  (ShelleyTest era, ExMock (Crypto era)) =>
+  (TwoPoolsConstraints era) =>
   PParams era ->
   Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))) ->
   ChainState era
@@ -736,7 +783,7 @@ expectedStEx9 pp rewards =
 --
 -- Create the first non-trivial reward update. The rewards demonstrate the
 -- results of the delegation scenario that was constructed in the first and only transaction.
-twoPools9 :: forall era. (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools9 :: forall era. (TwoPoolsConstraints era) => CHAINExample era
 twoPools9 = CHAINExample expectedStEx8 blockEx9 (Right $ expectedStEx9 ppEx rsEx9Agg)
 
 --
@@ -757,15 +804,15 @@ rsEx9Agg =
 ppProtVer3 :: PParams era
 ppProtVer3 = ppEx {_protocolVersion = ProtVer 3 0}
 
-expectedStEx8Agg :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx8Agg :: forall era. (TwoPoolsConstraints era) => ChainState era
 expectedStEx8Agg = C.setPrevPParams ppProtVer3 expectedStEx8
 
-expectedStEx9Agg :: forall era. (ShelleyTest era, ExMock (Crypto era)) => ChainState era
+expectedStEx9Agg :: forall era. (TwoPoolsConstraints era) => ChainState era
 expectedStEx9Agg = C.setPrevPParams ppProtVer3 (expectedStEx9 ppProtVer3 rsEx9Agg)
 
 -- Create the first non-trivial reward update. The rewards demonstrate the
 -- results of the delegation scenario that was constructed in the first and only transaction.
-twoPools9Agg :: forall era. (ShelleyTest era, ExMock (Crypto era)) => CHAINExample era
+twoPools9Agg :: forall era. (TwoPoolsConstraints era) => CHAINExample era
 twoPools9Agg = CHAINExample expectedStEx8Agg blockEx9 (Right expectedStEx9Agg)
 
 testAggregateRewardsLegacy :: Assertion

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -21,6 +21,7 @@ import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition.Extended (PredicateFailure, TRC (..))
@@ -49,7 +50,6 @@ import Shelley.Spec.Ledger.Credential
     pattern ScriptHashObj,
     pattern StakeRefBase,
   )
-import Cardano.Ledger.SafeHash (hashAnnotated)
 import Shelley.Spec.Ledger.Keys
   ( GenDelegs (..),
     KeyHash (..),
@@ -63,7 +63,7 @@ import Shelley.Spec.Ledger.LedgerState
     genesisState,
   )
 import Shelley.Spec.Ledger.Metadata (Metadata)
-import Shelley.Spec.Ledger.PParams (PParams, emptyPParams, _maxTxSize)
+import Shelley.Spec.Ledger.PParams (PParams, PParams' (..), emptyPParams, _maxTxSize)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
 import Shelley.Spec.Ledger.Scripts
   ( MultiSig,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -18,7 +18,7 @@ import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (TransValue, UsesTxOut)
+import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Control.State.Transition
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Data.Sequence (Seq)
@@ -59,15 +59,14 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
     removedAfterPoolreap,
   )
 import Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation)
-import Test.Shelley.Spec.Ledger.Utils (ChainProperty)
+import Test.Shelley.Spec.Ledger.Utils (ChainProperty, ShelleyTest)
 import Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as TQC
-import Data.Default.Class (Default)
 
 minimalPropertyTests ::
   forall era.
   ( EraGen era,
-    UsesTxOut era,
+    ShelleyTest era,
     TransValue ToCBOR era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),
@@ -86,7 +85,6 @@ minimalPropertyTests ::
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "adHash" (Core.TxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era))),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
-    Default (State (Core.EraRule "PPUP" era)),
     Show (State (Core.EraRule "PPUP" era))
   ) =>
   TestTree
@@ -110,7 +108,7 @@ minimalPropertyTests =
 propertyTests ::
   forall era.
   ( EraGen era,
-    UsesTxOut era,
+    ShelleyTest era,
     TransValue ToCBOR era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),
@@ -130,7 +128,6 @@ propertyTests ::
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "adHash" (Core.TxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era))),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
-    Default (State (Core.EraRule "PPUP" era)),
     Show (State (Core.EraRule "PPUP" era))
   ) =>
   TestTree

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -1,65 +1,91 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FlexibleContexts #-}
 
-module Test.Shelley.Spec.Ledger.Rewards (rewardTests,C,defaultMain) where
+module Test.Shelley.Spec.Ledger.Rewards (rewardTests, C, defaultMain) where
 
 import Cardano.Binary (toCBOR)
 import qualified Cardano.Crypto.DSIGN as Crypto
 import Cardano.Crypto.Hash (MD5, hashToBytes)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
 import qualified Cardano.Crypto.VRF as Crypto
+-- Arbitrary(NewEpochState era)
+-- instance (EraGen (ShelleyEra C))
+
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (VRF)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Crypto (VRF)
+import Cardano.Ledger.Val (invert, (<+>), (<->))
 import Cardano.Slotting.Slot (EpochSize (..))
+import Control.Iterate.SetAlgebra (eval, (◁))
 import Control.Monad (replicateM)
+import Control.Monad.Identity (Identity (..))
+import Control.Monad.Trans.Reader (asks, runReader)
+import Control.Provenance (preservesJust, preservesNothing, runProvM, runWithProvM)
+import Data.Default.Class (Default (def))
 import Data.Foldable (fold)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Proxy
 import Data.Ratio (Ratio, (%))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.API.Wallet (getRewardInfo)
 import Shelley.Spec.Ledger.BaseTypes
-  ( Globals (..),
+  ( ActiveSlotCoeff,
+    Globals (..),
     Network (..),
+    ShelleyBase,
     StrictMaybe (..),
     UnitInterval,
-    mkActiveSlotCoeff,
-    ActiveSlotCoeff,
-    ShelleyBase,
-    unitIntervalToRational,
     activeSlotVal,
     intervalValue,
+    mkActiveSlotCoeff,
+    unitIntervalToRational,
   )
-import Shelley.Spec.Ledger.Coin (Coin (..), DeltaCoin(..), rationalToCoinViaFloor, toDeltaCoin)
+import Shelley.Spec.Ledger.Coin (Coin (..), DeltaCoin (..), rationalToCoinViaFloor, toDeltaCoin)
 import Shelley.Spec.Ledger.Credential (Credential (..))
 import Shelley.Spec.Ledger.EpochBoundary
   ( BlocksMade (..),
+    SnapShot (..),
+    SnapShots (..),
     Stake (..),
     maxPool,
     poolStake,
-    SnapShot(..),
-    SnapShots(..),
   )
+import qualified Shelley.Spec.Ledger.EpochBoundary as EB
+import qualified Shelley.Spec.Ledger.HardForks as HardForks
 import Shelley.Spec.Ledger.Keys
-  ( KeyPair (..),
+  ( KeyHash,
+    KeyPair (..),
     KeyRole (..),
     VKey (..),
     hashKey,
     hashWithSerialiser,
     vKey,
-    KeyHash,
+  )
+import Shelley.Spec.Ledger.LedgerState
+  ( AccountState (..),
+    DPState (..),
+    DState (..),
+    EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    RewardUpdate (..),
+    circulation,
+    createRUpd,
+    updateNonMyopic,
   )
 import Shelley.Spec.Ledger.PParams
   ( PParams,
@@ -68,25 +94,31 @@ import Shelley.Spec.Ledger.PParams
     emptyPParams,
   )
 import Shelley.Spec.Ledger.Rewards
-  ( aggregateRewards,
-    reward,
-    Likelihood,
-    mkApparentPerformance,
-    memberRew,
-    StakeShare(..),
-    likelihood,
-    leaderRew,
-    leaderProbability,
+  ( Likelihood,
     NonMyopic,
+    StakeShare (..),
+    aggregateRewards,
+    leaderProbability,
+    leaderRew,
+    likelihood,
+    memberRew,
+    mkApparentPerformance,
+    reward,
     sumRewards,
   )
+import Shelley.Spec.Ledger.Slot (epochInfoSize)
 import Shelley.Spec.Ledger.TxBody (PoolParams (..), RewardAcnt (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Generator.Core (genCoin, genNatural)
+import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
+import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators ()
+import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 import Test.Shelley.Spec.Ledger.Utils
   ( testGlobals,
     unsafeMkUnitInterval,
   )
-import Test.Tasty (TestTree, testGroup,defaultMain)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCaseInfo)
 import Test.Tasty.QuickCheck
   ( Gen,
     Property,
@@ -94,40 +126,11 @@ import Test.Tasty.QuickCheck
     choose,
     counterexample,
     elements,
+    generate,
     property,
     testProperty,
     withMaxSuccess,
-    generate,
   )
-import Test.Tasty.HUnit(testCaseInfo)
-import Control.Monad.Identity(Identity(..))
-import Data.Default.Class(Default(def))
-import Control.Provenance(runProvM,runWithProvM, preservesNothing, preservesJust)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
-import Test.Shelley.Spec.Ledger.Serialisation.EraIndepGenerators() -- Arbitrary(NewEpochState era)
-import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen() -- instance (EraGen (ShelleyEra C))
-import Control.Monad.Trans.Reader (runReader, asks)
-import qualified Shelley.Spec.Ledger.EpochBoundary as EB
-import Shelley.Spec.Ledger.Slot(epochInfoSize)
-import Shelley.Spec.Ledger.LedgerState
-  ( NewEpochState(..),
-    EpochState(..),
-    RewardUpdate(..),
-    DPState(..),
-    DState(..),
-    createRUpd,
-    AccountState(..),
-    LedgerState(..),
-    circulation,
-    updateNonMyopic,
-  )
-import Shelley.Spec.Ledger.API.Wallet(getRewardInfo)
-import qualified Shelley.Spec.Ledger.HardForks as HardForks
-import Data.Maybe(fromMaybe, catMaybes)
-import Control.Iterate.SetAlgebra (eval, (◁))
-import Cardano.Ledger.Val ((<+>), (<->), invert)
-
-
 
 -- ========================================================================
 -- Bounds and Constants --
@@ -299,18 +302,19 @@ rewardsBoundedByPot _ = property $ do
             pools
       totalLovelace = undelegatedLovelace <> fold stake
       slotsPerEpoch = EpochSize . fromIntegral $ totalBlocks + silentSlots
-      Identity rs = runProvM $
-        reward @Identity @era
-          pp
-          bs
-          rewardPot
-          rewardAcnts
-          poolParams
-          (Stake stake)
-          delegs
-          totalLovelace
-          asc
-          slotsPerEpoch
+      Identity rs =
+        runProvM $
+          reward
+            pp
+            bs
+            rewardPot
+            rewardAcnts
+            poolParams
+            (Stake stake)
+            delegs
+            totalLovelace
+            asc
+            slotsPerEpoch
   pure $
     counterexample
       ( mconcat
@@ -365,27 +369,29 @@ rewardsProvenance _ = generate $ do
             pools
       totalLovelace = undelegatedLovelace <> fold stake
       slotsPerEpoch = EpochSize . fromIntegral $ totalBlocks + silentSlots
-      Identity (_,prov) = runWithProvM def $
-        reward @Identity @era
-          pp
-          bs
-          rewardPot
-          rewardAcnts
-          poolParams
-          (Stake stake)
-          delegs
-          totalLovelace
-          asc
-          slotsPerEpoch
-  pure (show(snd(Map.findMin prov)))
+      Identity (_, prov) =
+        runWithProvM def $
+          reward @Identity @(Crypto era)
+            pp
+            bs
+            rewardPot
+            rewardAcnts
+            poolParams
+            (Stake stake)
+            delegs
+            totalLovelace
+            asc
+            slotsPerEpoch
+  pure (show (snd (Map.findMin prov)))
 
 -- Analog to getRewardInfo, but does not produce Provenance
 justRewardInfo ::
   forall era.
+  (Core.PParams era ~ PParams era) =>
   Globals ->
   NewEpochState era ->
   RewardUpdate (Crypto era)
-justRewardInfo globals newepochstate  =
+justRewardInfo globals newepochstate =
   runReader
     (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply)
     globals
@@ -400,15 +406,22 @@ justRewardInfo globals newepochstate  =
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
 
 sameWithOrWithoutProvenance ::
- forall era.
+  forall era.
+  (Core.PParams era ~ PParams era) =>
   Globals ->
-  NewEpochState era -> Bool
+  NewEpochState era ->
+  Bool
 sameWithOrWithoutProvenance globals newepochstate = with == without
-  where (with,_) = getRewardInfo globals newepochstate
-        without = justRewardInfo globals newepochstate
+  where
+    (with, _) = getRewardInfo globals newepochstate
+    without = justRewardInfo globals newepochstate
 
-nothingInNothingOut :: forall era. NewEpochState era -> Bool
-nothingInNothingOut newepochstate  =
+nothingInNothingOut ::
+  forall era.
+  (Core.PParams era ~ PParams era) =>
+  NewEpochState era ->
+  Bool
+nothingInNothingOut newepochstate =
   runReader
     (preservesNothing $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply)
     globals
@@ -423,8 +436,12 @@ nothingInNothingOut newepochstate  =
     slotsPerEpoch :: EpochSize
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
 
-justInJustOut :: forall era. NewEpochState era -> Bool
-justInJustOut newepochstate  =
+justInJustOut ::
+  forall era.
+  (Core.PParams era ~ PParams era) =>
+  NewEpochState era ->
+  Bool
+justInJustOut newepochstate =
   runReader
     (preservesJust def $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply)
     globals
@@ -585,95 +602,116 @@ data RewardUpdateOld crypto = RewardUpdateOld
   deriving (Show, Eq)
 
 createRUpdOld ::
+  forall era.
+  (Core.PParams era ~ PParams era) =>
   EpochSize ->
   BlocksMade (Crypto era) ->
   EpochState era ->
   Coin ->
   ShelleyBase (RewardUpdateOld (Crypto era))
-createRUpdOld slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) maxSupply = do
-  asc <- asks activeSlotCoeff
-  let SnapShot stake' delegs' poolParams = _pstakeGo ss
-      Coin reserves = _reserves acnt
-      ds = _dstate $ _delegationState ls
-      -- reserves and rewards change
-      deltaR1 =
-        ( rationalToCoinViaFloor $
-            min 1 eta
-              * unitIntervalToRational (_rho pr)
-              * fromIntegral reserves
+createRUpdOld
+  slotsPerEpoch
+  b@(BlocksMade b')
+  es@(EpochState acnt ss ls pr _ nm)
+  maxSupply = do
+    asc <- asks activeSlotCoeff
+    let SnapShot stake' delegs' poolParams = _pstakeGo ss
+        Coin reserves = _reserves acnt
+        ds = _dstate $ _delegationState ls
+        -- reserves and rewards change
+        deltaR1 =
+          ( rationalToCoinViaFloor $
+              min 1 eta
+                * unitIntervalToRational (_rho pr)
+                * fromIntegral reserves
+          )
+        d = unitIntervalToRational (_d pr)
+        expectedBlocks =
+          floor $
+            (1 - d) * unitIntervalToRational (activeSlotVal asc)
+              * fromIntegral slotsPerEpoch
+        -- TODO asc is a global constant, and slotsPerEpoch should not change
+        -- often at all, it would be nice to not have to compute expectedBlocks
+        -- every epoch
+        eta
+          | intervalValue (_d pr) >= 0.8 = 1
+          | otherwise = blocksMade % expectedBlocks
+        Coin rPot = _feeSS ss <> deltaR1
+        deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
+        _R = Coin $ rPot - deltaT1
+        totalStake = circulation es maxSupply
+        (rs_, newLikelihoods) =
+          rewardOld @era
+            pr
+            b
+            _R
+            (Map.keysSet $ _rewards ds)
+            poolParams
+            stake'
+            delegs'
+            totalStake
+            asc
+            slotsPerEpoch
+        deltaR2 = _R <-> (Map.foldr (<+>) mempty rs_)
+        blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
+    pure $
+      RewardUpdateOld
+        { deltaTOld = (DeltaCoin deltaT1),
+          deltaROld = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
+          rsOld = rs_,
+          deltaFOld = (invert (toDeltaCoin $ _feeSS ss)),
+          nonMyopicOld = (updateNonMyopic nm _R newLikelihoods)
+        }
+
+oldEqualsNew ::
+  forall era.
+  (Core.PParams era ~ PParams era) =>
+  NewEpochState era ->
+  Bool
+oldEqualsNew newepochstate = old == new
+  where
+    globals = testGlobals
+    epochstate = nesEs newepochstate
+    maxsupply :: Coin
+    maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
+    blocksmade :: EB.BlocksMade (Crypto era)
+    blocksmade = nesBprev newepochstate
+    epochnumber = nesEL newepochstate
+    slotsPerEpoch :: EpochSize
+    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    unAggregated =
+      runReader
+        (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply)
+        globals
+    old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
+    new = aggregateRewards (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
+
+oldEqualsNewOn ::
+  forall era.
+  (Core.PParams era ~ PParams era) =>
+  NewEpochState era ->
+  Bool
+oldEqualsNewOn newepochstate = old == new
+  where
+    globals = testGlobals
+    epochstate = nesEs newepochstate
+    maxsupply :: Coin
+    maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
+    blocksmade :: EB.BlocksMade (Crypto era)
+    blocksmade = nesBprev newepochstate
+    epochnumber = nesEL newepochstate
+    slotsPerEpoch :: EpochSize
+    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    (unAggregated, _) =
+      runReader
+        ( runWithProvM def $
+            createRUpd slotsPerEpoch blocksmade epochstate maxsupply
         )
-      d = unitIntervalToRational (_d pr)
-      expectedBlocks =
-        floor $
-          (1 - d) * unitIntervalToRational (activeSlotVal asc) * fromIntegral slotsPerEpoch
-      -- TODO asc is a global constant, and slotsPerEpoch should not change often at all,
-      -- it would be nice to not have to compute expectedBlocks every epoch
-      eta
-        | intervalValue (_d pr) >= 0.8 = 1
-        | otherwise = blocksMade % expectedBlocks
-      Coin rPot = _feeSS ss <> deltaR1
-      deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
-      _R = Coin $ rPot - deltaT1
-      totalStake = circulation es maxSupply
-      (rs_, newLikelihoods) =
-        rewardOld
-          pr
-          b
-          _R
-          (Map.keysSet $ _rewards ds)
-          poolParams
-          stake'
-          delegs'
-          totalStake
-          asc
-          slotsPerEpoch
-      deltaR2 = _R <-> (Map.foldr (<+>) mempty rs_)
-      blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
-  pure $
-    RewardUpdateOld
-      { deltaTOld = (DeltaCoin deltaT1),
-        deltaROld = ((invert $ toDeltaCoin deltaR1) <> toDeltaCoin deltaR2),
-        rsOld = rs_,
-        deltaFOld = (invert (toDeltaCoin $ _feeSS ss)),
-        nonMyopicOld = (updateNonMyopic nm _R newLikelihoods)
-      }
-
-
-oldEqualsNew:: forall era. NewEpochState era -> Bool
-oldEqualsNew  newepochstate  = old == new
-  where
-    globals = testGlobals
-    epochstate = nesEs newepochstate
-    maxsupply :: Coin
-    maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
-    blocksmade :: EB.BlocksMade (Crypto era)
-    blocksmade = nesBprev newepochstate
-    epochnumber = nesEL newepochstate
-    slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
-    unAggregated = runReader (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
+        globals
     old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
-    new = aggregateRewards @era (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
-
-oldEqualsNewOn:: forall era. NewEpochState era -> Bool
-oldEqualsNewOn  newepochstate  = old == new
-  where
-    globals = testGlobals
-    epochstate = nesEs newepochstate
-    maxsupply :: Coin
-    maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
-    blocksmade :: EB.BlocksMade (Crypto era)
-    blocksmade = nesBprev newepochstate
-    epochnumber = nesEL newepochstate
-    slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
-    (unAggregated,_) = runReader (runWithProvM def $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply) globals
-    old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
-    new = aggregateRewards @era (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
-
+    new = aggregateRewards (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
 
 -- ==================================================================
-
 
 rewardTests :: TestTree
 rewardTests =
@@ -681,11 +719,11 @@ rewardTests =
     "Reward Tests"
     [ testProperty
         "Sum of rewards is bounded by reward pot"
-        (withMaxSuccess numberOfTests (rewardsBoundedByPot (Proxy @C)))
-    , testProperty "provenance does not affect result" (sameWithOrWithoutProvenance @C testGlobals)
-    , testProperty "ProvM preserves Nothing" (nothingInNothingOut @C)
-    , testProperty "ProvM preserves Just" (justInJustOut @C)
-    , testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance off style" (oldEqualsNew @C)
-    , testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance on style" (oldEqualsNewOn @C)
-    , testCaseInfo "Reward Provenance works" (rewardsProvenance (Proxy @C))
+        (withMaxSuccess numberOfTests (rewardsBoundedByPot (Proxy @C))),
+      testProperty "provenance does not affect result" (sameWithOrWithoutProvenance @C testGlobals),
+      testProperty "ProvM preserves Nothing" (nothingInNothingOut @C),
+      testProperty "ProvM preserves Just" (justInJustOut @C),
+      testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance off style" (oldEqualsNew @C),
+      testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance on style" (oldEqualsNewOn @C),
+      testCaseInfo "Reward Provenance works" (rewardsProvenance (Proxy @C))
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -3,12 +3,13 @@
 {-# LANGUAGE TypeApplications #-}
 
 import Cardano.Crypto.Libsodium (sodiumInit)
+import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.Pretty (prettyTest)
 import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Shelley.Spec.Ledger.Rewards (rewardTests)
 import Test.Shelley.Spec.Ledger.STSTests (chainExamples, multisigExamples)
-import Test.Shelley.Spec.Ledger.Pretty(prettyTest)
 import Test.Shelley.Spec.Ledger.SafeHash (safeHashTest)
 import qualified Test.Shelley.Spec.Ledger.Serialisation as Serialisation
 import Test.Shelley.Spec.Ledger.UnitTests (unitTests)


### PR DESCRIPTION
This is needed for Alonzo, which will modify these.

This can be reviewed commit by commit, since one may care less about the changes to test files.

- The first commit makes the relevant changes in the Shelley ledger
- The second commit updates the shelley era tests
- The third commit makes all Shelley-MA changes. I can split this out into two commits (lib and test) if this is helpful.