### PR TITLE
Abstract over building an era from genesis

### DIFF
--- a/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -44,6 +44,7 @@ library
     cardano-slotting,
     cborg,
     containers,
+    data-default-class,
     deepseq,
     groups,
     mtl,

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -5,17 +5,15 @@
 
 module Cardano.Ledger.Allegra where
 
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
 import Cardano.Ledger.ShelleyMA.TxBody ()
+import Cardano.Ledger.Val (Val ((<->)))
+import Data.Default.Class (def)
+import qualified Data.Map.Strict as Map
 import Shelley.Spec.Ledger.API
-  ( ApplyBlock,
-    ApplyTx,
-    GetLedgerView,
-    PraosCrypto,
-    ShelleyBasedEra,
-  )
-import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
 
 type AllegraEra = ShelleyMAEra 'Allegra
 
@@ -24,5 +22,42 @@ instance PraosCrypto c => ApplyTx (AllegraEra c)
 instance PraosCrypto c => ApplyBlock (AllegraEra c)
 
 instance PraosCrypto c => GetLedgerView (AllegraEra c)
+
+instance
+  ( Crypto c
+  ) =>
+  CanStartFromGenesis (AllegraEra c)
+  where
+  initialState sg () =
+    NewEpochState
+      initialEpochNo
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      ( EpochState
+          (AccountState (Coin 0) reserves)
+          emptySnapShots
+          ( LedgerState
+              ( UTxOState
+                  initialUtxo
+                  (Coin 0)
+                  (Coin 0)
+                  def
+              )
+              (DPState (def {_genDelegs = GenDelegs genDelegs}) def)
+          )
+          pp
+          pp
+          def
+      )
+      SNothing
+      (PoolDistr Map.empty)
+    where
+      initialEpochNo = 0
+      initialUtxo = genesisUTxO sg
+      reserves =
+        word64ToCoin (sgMaxLovelaceSupply sg)
+          <-> balance initialUtxo
+      genDelegs = sgGenDelegs sg
+      pp = sgProtocolParams sg
 
 instance PraosCrypto c => ShelleyBasedEra (AllegraEra c)

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -5,18 +5,16 @@
 
 module Cardano.Ledger.Mary where
 
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
+import Cardano.Ledger.Val (Val ((<->)), coin, inject)
+import Data.Default.Class (def)
+import qualified Data.Map.Strict as Map
 import Shelley.Spec.Ledger.API
-  ( ApplyBlock,
-    ApplyTx,
-    GetLedgerView,
-    PraosCrypto,
-    ShelleyBasedEra,
-  )
-import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
 
 type MaryEra = ShelleyMAEra 'Mary
 
@@ -25,5 +23,43 @@ instance PraosCrypto c => ApplyTx (MaryEra c)
 instance PraosCrypto c => ApplyBlock (MaryEra c)
 
 instance PraosCrypto c => GetLedgerView (MaryEra c)
+
+instance
+  ( Crypto c
+  ) =>
+  CanStartFromGenesis (MaryEra c)
+  where
+  initialState sg () =
+    NewEpochState
+      initialEpochNo
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      ( EpochState
+          (AccountState (Coin 0) reserves)
+          emptySnapShots
+          ( LedgerState
+              ( UTxOState
+                  initialUtxo
+                  (Coin 0)
+                  (Coin 0)
+                  def
+              )
+              (DPState (def {_genDelegs = GenDelegs genDelegs}) def)
+          )
+          pp
+          pp
+          def
+      )
+      SNothing
+      (PoolDistr Map.empty)
+    where
+      initialEpochNo = 0
+      initialUtxo = genesisUTxO sg
+      reserves =
+        coin $
+          inject (word64ToCoin (sgMaxLovelaceSupply sg))
+            <-> balance initialUtxo
+      genDelegs = sgGenDelegs sg
+      pp = sgProtocolParams sg
 
 instance PraosCrypto c => ShelleyBasedEra (MaryEra c)

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -33,6 +33,7 @@ library
     Shelley.Spec.Ledger.Address.Bootstrap
     Shelley.Spec.Ledger.API
     Shelley.Spec.Ledger.API.ByronTranslation
+    Shelley.Spec.Ledger.API.Genesis
     Shelley.Spec.Ledger.API.Protocol
     Shelley.Spec.Ledger.API.Validation
     Shelley.Spec.Ledger.API.Wallet

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/SafeHash.hs
@@ -80,8 +80,8 @@ castSafeHash :: forall i j c. SafeHash c i -> SafeHash c j
 castSafeHash (SafeHash h) = SafeHash (Hash.castHash h)
 
 -- Don't use this except in Testing to make Arbitrary instances, etc.
-unsafeMakeSafeHash :: (Hash.Hash (CC.HASH crypto) index) -> SafeHash crypto index
-unsafeMakeSafeHash x = SafeHash x
+unsafeMakeSafeHash :: Hash.Hash (CC.HASH crypto) index -> SafeHash crypto index
+unsafeMakeSafeHash = SafeHash
 
 -- =====================================================================
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Shelley.Constraints
   )
 import Control.State.Transition (State)
 import Shelley.Spec.Ledger.API.ByronTranslation as X
+import Shelley.Spec.Ledger.API.Genesis as X
 import Shelley.Spec.Ledger.API.Mempool as X
 import Shelley.Spec.Ledger.API.Protocol as X
 import Shelley.Spec.Ledger.API.Types as X
@@ -35,6 +36,7 @@ class
     GetLedgerView era,
     ApplyBlock era,
     ApplyTx era,
+    CanStartFromGenesis era,
     UsesValue era,
     UsesScript era,
     UsesAuxiliary era,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Genesis.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Shelley.Spec.Ledger.API.Genesis where
+
+import Cardano.Ledger.Core (EraRule)
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Val (Val ((<->)))
+import Control.State.Transition (STS (State))
+import Data.Default.Class (Default, def)
+import Data.Kind (Type)
+import qualified Data.Map.Strict as Map
+import Shelley.Spec.Ledger.API.Types
+  ( AccountState (AccountState),
+    Coin (Coin),
+    DPState (DPState),
+    DState (_genDelegs),
+    EpochState (EpochState),
+    GenDelegs (GenDelegs),
+    LedgerState (LedgerState),
+    NewEpochState (NewEpochState),
+    PoolDistr (PoolDistr),
+    ShelleyGenesis (sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams),
+    StrictMaybe (SNothing),
+    UTxOState (UTxOState),
+    balance,
+    genesisUTxO,
+    word64ToCoin,
+  )
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
+
+-- | Indicates that this era may be bootstrapped from 'ShelleyGenesis'.
+class CanStartFromGenesis era where
+  -- | Additional genesis configuration necessary for this era.
+  type AdditionalGenesisConfig era :: Type
+
+  type AdditionalGenesisConfig era = ()
+
+  -- | Construct an initial state given a 'ShelleyGenesis' and any appropriate
+  -- 'AdditionalGenesisConfig' for the era.
+  initialState ::
+    ShelleyGenesis era ->
+    AdditionalGenesisConfig era ->
+    NewEpochState era
+
+instance
+  ( Crypto c,
+    Default (State (EraRule "PPUP" (ShelleyEra c)))
+  ) =>
+  CanStartFromGenesis (ShelleyEra c)
+  where
+  initialState sg () =
+    NewEpochState
+      initialEpochNo
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      ( EpochState
+          (AccountState (Coin 0) reserves)
+          emptySnapShots
+          ( LedgerState
+              ( UTxOState
+                  initialUtxo
+                  (Coin 0)
+                  (Coin 0)
+                  def
+              )
+              (DPState (def {_genDelegs = GenDelegs genDelegs}) def)
+          )
+          pp
+          pp
+          def
+      )
+      SNothing
+      (PoolDistr Map.empty)
+    where
+      initialEpochNo = 0
+      initialUtxo = genesisUTxO sg
+      reserves =
+        word64ToCoin (sgMaxLovelaceSupply sg)
+          <-> balance initialUtxo
+      genDelegs = sgGenDelegs sg
+      pp = sgProtocolParams sg


### PR DESCRIPTION
This adds a class to the ledger API which governs the ability to construct an initial chain state from 'ShelleyGenesis' and (optionally) some additional configuration. This is needed to support consensus.

In addition, we add the ability to construct the initial `ChainDepState` (which is basically the full state of the "protocol" concerns). This was previously extracted from the `ChainState`, which we now do not use.