### PR TITLE
New MIR cert features in Alonzo

### DIFF
--- a/alonzo/impl/cddl/alonzo.cddl
+++ b/alonzo/impl/cddl/alonzo.cddl
@@ -1,0 +1,9 @@
+; Alonzo Types
+
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin ]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
+; If the second field is a map, funds are moved to stake credentials,
+; otherwise the funds are given to the other accounting pot.
+
+delta_coin = int

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -134,6 +134,7 @@ import Shelley.Spec.Ledger.TxBody
     GenesisDelegCert (..),
     MIRCert (..),
     MIRPot (..),
+    MIRTarget (..),
     PoolCert (..),
     PoolMetadata (..),
     PoolParams (..),
@@ -376,11 +377,13 @@ ppFutureGenDeleg (FutureGenDeleg sl kh) =
     ]
 
 ppInstantaneousRewards :: InstantaneousRewards crypto -> PDoc
-ppInstantaneousRewards (InstantaneousRewards res treas) =
+ppInstantaneousRewards (InstantaneousRewards res treas dR dT) =
   ppRecord
     "InstantaneousRewards"
     [ ("reserves", ppMap' mempty ppCredential ppCoin res),
-      ("treasury", ppMap' mempty ppCredential ppCoin treas)
+      ("treasury", ppMap' mempty ppCredential ppCoin treas),
+      ("deltaReserves", ppDeltaCoin dR),
+      ("deltaTreasury", ppDeltaCoin dT)
     ]
 
 ppIx :: Ix -> PDoc
@@ -758,8 +761,12 @@ ppMIRPot :: MIRPot -> PDoc
 ppMIRPot ReservesMIR = text "Reserves"
 ppMIRPot TreasuryMIR = text "Treasury"
 
+ppMIRTarget :: MIRTarget c -> PDoc
+ppMIRTarget (StakeAddressesMIR rews) = ppMap ppCredential ppDeltaCoin rews
+ppMIRTarget (SendToOppositePotMIR c) = ppCoin c
+
 ppMIRCert :: MIRCert c -> PDoc
-ppMIRCert (MIRCert pot rew) = ppSexp "MirCert" [ppMIRPot pot, ppMap ppCredential ppCoin rew]
+ppMIRCert (MIRCert pot vs) = ppSexp "MirCert" [ppMIRPot pot, ppMIRTarget vs]
 
 ppDCert :: DCert c -> PDoc
 ppDCert (DCertDeleg x) = ppSexp "DCertDeleg" [ppDelegCert x]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -169,6 +169,7 @@ import Shelley.Spec.Ledger.TxBody as X
     GenesisDelegCert (..),
     MIRCert (..),
     MIRPot (..),
+    MIRTarget (..),
     PoolMetadata (..),
     PoolParams (..),
     Ptr (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
@@ -4,6 +4,7 @@
 
 module Shelley.Spec.Ledger.HardForks
   ( aggregatedRewards,
+    allowMIRTransfer,
   )
 where
 
@@ -15,3 +16,16 @@ aggregatedRewards ::
   pp ->
   Bool
 aggregatedRewards pp = pvMajor (getField @"_protocolVersion" pp) > 2
+
+-- | Starting with protocol version 5, the MIR certs will also be
+-- able to transfer funds between the reserves and the treasury.
+-- Additionally, the semantics for the pervious functionality will
+-- change a bit. Before version 5 redundancies in the instantaneous
+-- reward mapping were handled by overriding. Now they are handled
+-- by adding the values and allowing for negatives updates, provided
+-- the sum for each key remains positive.
+allowMIRTransfer ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+allowMIRTransfer pp = pvMajor (getField @"_protocolVersion" pp) > 4

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -43,17 +43,17 @@ import Shelley.Spec.Ledger.LedgerState
     PPUPState (..),
     PState (..),
     UTxOState,
+    availableAfterMIR,
     pvCanFollow,
-    totalInstantaneousReservesRewards,
     _deposited,
     _irwd,
-    _reserves,
   )
 import Shelley.Spec.Ledger.PParams
   ( ProposedPPUpdates (..),
     ProtVer,
     emptyPPPUpdates,
   )
+import Shelley.Spec.Ledger.TxBody (MIRPot (..))
 
 data NEWPP era
 
@@ -122,14 +122,12 @@ newPpTransition = do
       let Coin oblgCurr = obligation pp (_rewards dstate) (_pParams pstate)
           Coin oblgNew = obligation ppNew' (_rewards dstate) (_pParams pstate)
           diff = oblgCurr - oblgNew
-          Coin reserves = _reserves acnt
-          Coin requiredInstantaneousRewards =
-            totalInstantaneousReservesRewards (_irwd dstate)
+          Coin availableReserves = availableAfterMIR ReservesMIR acnt (_irwd dstate)
 
       Coin oblgCurr == _deposited utxoSt
         ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
 
-      if reserves + diff >= requiredInstantaneousRewards
+      if availableReserves + diff >= 0
         -- Note that instantaneous rewards from the treasury are irrelevant
         -- here, since changes in the protocol parameters do not change how much
         -- is needed from the treasury

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -32,6 +32,7 @@ module Shelley.Spec.Ledger.TxBody
     Ix,
     MIRCert (..),
     MIRPot (..),
+    MIRTarget (..),
     PoolCert (..),
     PoolMetadata (..),
     PoolParams (..),
@@ -78,10 +79,12 @@ import Cardano.Binary
     FromCBOR (fromCBOR),
     Size,
     ToCBOR (..),
+    TokenType (TypeMapLen, TypeMapLen64, TypeMapLenIndef),
     annotatorSlice,
     decodeWord,
     encodeListLen,
     encodePreEncoded,
+    peekTokenType,
     serializeEncoding,
     szCases,
   )
@@ -157,7 +160,7 @@ import Shelley.Spec.Ledger.BaseTypes
     maybeToStrictMaybe,
     strictMaybeToMaybe,
   )
-import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Coin (Coin (..), DeltaCoin)
 import Shelley.Spec.Ledger.CompactAddr
   ( CompactAddr,
     compactAddr,
@@ -604,10 +607,38 @@ instance FromCBOR MIRPot where
       1 -> pure TreasuryMIR
       k -> invalidKey k
 
+-- | MIRTarget specifies if funds from either the reserves
+-- or the treasury are to be handed out to a collection of
+-- reward accounts or instead transfered to the oppososite pot.
+data MIRTarget crypto
+  = StakeAddressesMIR (Map (Credential 'Staking crypto) DeltaCoin)
+  | SendToOppositePotMIR Coin
+  deriving (Show, Generic, Eq)
+
+deriving instance NoThunks (MIRTarget crypto)
+
+instance
+  CC.Crypto crypto =>
+  FromCBOR (MIRTarget crypto)
+  where
+  fromCBOR = do
+    peekTokenType >>= \case
+      TypeMapLen -> StakeAddressesMIR <$> mapFromCBOR
+      TypeMapLen64 -> StakeAddressesMIR <$> mapFromCBOR
+      TypeMapLenIndef -> StakeAddressesMIR <$> mapFromCBOR
+      _ -> SendToOppositePotMIR <$> fromCBOR
+
+instance
+  CC.Crypto crypto =>
+  ToCBOR (MIRTarget crypto)
+  where
+  toCBOR (StakeAddressesMIR m) = mapToCBOR m
+  toCBOR (SendToOppositePotMIR c) = toCBOR c
+
 -- | Move instantaneous rewards certificate
 data MIRCert crypto = MIRCert
   { mirPot :: MIRPot,
-    mirRewards :: Map (Credential 'Staking crypto) Coin
+    mirRewards :: MIRTarget crypto
   }
   deriving (Show, Generic, Eq)
 
@@ -615,19 +646,19 @@ instance
   CC.Crypto crypto =>
   FromCBOR (MIRCert crypto)
   where
-  fromCBOR = decodeRecordNamed "SingleHostAddr" (const 2) $ do
+  fromCBOR = decodeRecordNamed "MIRCert" (const 2) $ do
     pot <- fromCBOR
-    values <- mapFromCBOR
+    values <- fromCBOR
     pure $ MIRCert pot values
 
 instance
   CC.Crypto crypto =>
   ToCBOR (MIRCert crypto)
   where
-  toCBOR (MIRCert pot values) =
+  toCBOR (MIRCert pot targets) =
     encodeListLen 2
       <> toCBOR pot
-      <> mapToCBOR values
+      <> toCBOR targets
 
 -- | A heavyweight certificate.
 data DCert crypto

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchUTxOAggregate.hs
@@ -97,7 +97,7 @@ makeStatePair rewards' delegs ptrs' poolParams =
       ptrs'
       Map.empty
       (GenDelegs Map.empty)
-      (InstantaneousRewards Map.empty Map.empty),
+      (InstantaneousRewards Map.empty Map.empty mempty mempty),
     PState poolParams Map.empty Map.empty
   )
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -94,6 +94,7 @@ library
     containers,
     data-default-class,
     directory,
+    groups,
     generic-random,
     hedgehog-quickcheck,
     hedgehog,
@@ -128,6 +129,7 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Examples.Init
       Test.Shelley.Spec.Ledger.Examples.GenesisDelegation
       Test.Shelley.Spec.Ledger.Examples.Mir
+      Test.Shelley.Spec.Ledger.Examples.MirTransfer
       Test.Shelley.Spec.Ledger.Examples.PoolLifetime
       Test.Shelley.Spec.Ledger.Examples.PoolReReg
       Test.Shelley.Spec.Ledger.Examples.TwoPools

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -297,6 +297,13 @@ instance CC.Crypto crypto => Arbitrary (WitHashes crypto) where
 instance Arbitrary MIRPot where
   arbitrary = genericArbitraryU
 
+instance CC.Crypto crypto => Arbitrary (MIRTarget crypto) where
+  arbitrary =
+    oneof
+      [ StakeAddressesMIR <$> arbitrary,
+        SendToOppositePotMIR <$> arbitrary
+      ]
+
 instance Arbitrary Natural where
   arbitrary = fromInteger <$> choose (0, 1000)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Combinators.hs
@@ -429,11 +429,13 @@ mir cred pot amnt cs = cs {chainNes = nes'}
     ds = _dstate dps
     InstantaneousRewards
       { iRReserves = ir,
-        iRTreasury = it
+        iRTreasury = it,
+        deltaReserves = dr,
+        deltaTreasury = dt
       } = _irwd ds
     irwd' = case pot of
-      ReservesMIR -> InstantaneousRewards (Map.insert cred amnt ir) it
-      TreasuryMIR -> InstantaneousRewards ir (Map.insert cred amnt it)
+      ReservesMIR -> InstantaneousRewards (Map.insert cred amnt ir) it dr dt
+      TreasuryMIR -> InstantaneousRewards ir (Map.insert cred amnt it) dr dt
     ds' = ds {_irwd = irwd'}
     dps' = dps {_dstate = ds'}
     ls' = ls {_delegationState = dps'}

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -20,14 +20,13 @@ import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Val ((<+>), (<->))
 import qualified Cardano.Ledger.Val as Val
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Shelley.Spec.Ledger.BaseTypes (Nonce, StrictMaybe (..))
 import Shelley.Spec.Ledger.BlockChain (Block, bhHash, bheader)
-import Shelley.Spec.Ledger.Coin (Coin (..))
-import Shelley.Spec.Ledger.Credential (Credential, Ptr (..))
+import Shelley.Spec.Ledger.Coin (Coin (..), toDeltaCoin)
+import Shelley.Spec.Ledger.Credential (Ptr (..))
 import Shelley.Spec.Ledger.Delegation.Certificates (DelegCert (..), MIRCert (..))
 import Shelley.Spec.Ledger.EpochBoundary (emptySnapShot)
 import Cardano.Ledger.SafeHash (hashAnnotated)
@@ -57,6 +56,7 @@ import Shelley.Spec.Ledger.Tx (Tx (..), WitnessSetHKD (..))
 import Shelley.Spec.Ledger.TxBody
   ( DCert (..),
     MIRPot (..),
+    MIRTarget (..),
     TxBody (..),
     TxIn (..),
     TxOut (..),
@@ -121,8 +121,8 @@ initStMIR treasury = cs {chainNes = (chainNes cs) {nesEs = es'}}
 aliceMIRCoin :: Coin
 aliceMIRCoin = Coin 100
 
-ir :: CryptoClass.Crypto c => Map (Credential 'Staking c) Coin
-ir = Map.fromList [(Cast.aliceSHK, aliceMIRCoin)]
+ir :: CryptoClass.Crypto c => MIRTarget c
+ir = StakeAddressesMIR $ Map.fromList [(Cast.aliceSHK, toDeltaCoin aliceMIRCoin)]
 
 feeTx1 :: Coin
 feeTx1 = Coin 1

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/MirTransfer.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/MirTransfer.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Shelley.Spec.Ledger.Examples.MirTransfer
+  ( testMIRTransfer,
+  )
+where
+
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Control.State.Transition.Extended hiding (Assertion)
+import Control.State.Transition.Trace (checkTrace, (.-), (.->))
+import Data.Default.Class (def)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Shelley.Spec.Ledger.API
+  ( AccountState (..),
+    Credential (..),
+    DCert (..),
+    DELEG,
+    DState (..),
+    DelegEnv (..),
+    InstantaneousRewards (..),
+    MIRCert (..),
+    MIRPot (..),
+    MIRTarget (..),
+    Ptr (..),
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..), DeltaCoin (..))
+import Shelley.Spec.Ledger.Keys
+  ( KeyRole (..),
+    hashKey,
+  )
+import Shelley.Spec.Ledger.PParams (PParams' (..), ProtVer (..), emptyPParams)
+import Shelley.Spec.Ledger.STS.Deleg (DelegPredicateFailure (..))
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
+import Test.Shelley.Spec.Ledger.Utils (applySTSTest, mkKeyPair, runShelleyBase)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+type ShelleyTest = ShelleyEra C_Crypto
+
+ignoreAllButIRWD ::
+  Either [[PredicateFailure (DELEG ShelleyTest)]] (DState C_Crypto) ->
+  Either [[PredicateFailure (DELEG ShelleyTest)]] (InstantaneousRewards C_Crypto)
+ignoreAllButIRWD (Left e) = Left e
+ignoreAllButIRWD (Right dstate) = Right (_irwd dstate)
+
+env :: ProtVer -> AccountState -> DelegEnv ShelleyTest
+env pv acnt =
+  DelegEnv
+    { slotNo = SlotNo 50,
+      ptr_ = Ptr (SlotNo 50) 0 0,
+      acnt_ = acnt,
+      ppDE = emptyPParams {_protocolVersion = pv}
+    }
+
+shelleyPV :: ProtVer
+shelleyPV = ProtVer 2 0
+
+alonzoPV :: ProtVer
+alonzoPV = ProtVer 5 0
+
+testMirTransfer ::
+  ProtVer ->
+  MIRPot ->
+  MIRTarget C_Crypto ->
+  InstantaneousRewards C_Crypto ->
+  AccountState ->
+  Either [[PredicateFailure (DELEG ShelleyTest)]] (InstantaneousRewards C_Crypto) ->
+  Assertion
+testMirTransfer pv pot target ir acnt (Right expected) = do
+  checkTrace @(DELEG ShelleyTest) runShelleyBase (env pv acnt) $
+    (pure (def {_irwd = ir})) .- (DCertMir (MIRCert pot target)) .-> (def {_irwd = expected})
+testMirTransfer pv pot target ir acnt predicateFailure@(Left _) = do
+  let st =
+        runShelleyBase $
+          applySTSTest @(DELEG ShelleyTest)
+            (TRC (env pv acnt, def {_irwd = ir}, DCertMir (MIRCert pot target)))
+  (ignoreAllButIRWD st) @?= predicateFailure
+
+alice :: Credential 'Staking C_Crypto
+alice = (KeyHashObj . hashKey . snd) $ mkKeyPair (0, 0, 0, 0, 1)
+
+aliceOnlyReward :: Integer -> Map (Credential 'Staking C_Crypto) Coin
+aliceOnlyReward c = Map.fromList [(alice, Coin c)]
+
+aliceOnlyDelta :: Integer -> Map (Credential 'Staking C_Crypto) DeltaCoin
+aliceOnlyDelta c = Map.fromList [(alice, DeltaCoin c)]
+
+bob :: Credential 'Staking C_Crypto
+bob = (KeyHashObj . hashKey . snd) $ mkKeyPair (0, 0, 0, 0, 2)
+
+bobOnlyReward :: Integer -> Map (Credential 'Staking C_Crypto) Coin
+bobOnlyReward c = Map.fromList [(bob, Coin c)]
+
+bobOnlyDelta :: Integer -> Map (Credential 'Staking C_Crypto) DeltaCoin
+bobOnlyDelta c = Map.fromList [(bob, DeltaCoin c)]
+
+testMIRTransfer :: TestTree
+testMIRTransfer =
+  testGroup
+    "MIR cert transfers"
+    [ testGroup
+        "MIR cert embargos"
+        [ testCase "embargo reserves to treasury transfer" $
+            testMirTransfer
+              shelleyPV
+              ReservesMIR
+              (SendToOppositePotMIR $ Coin 1)
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 1, _treasury = Coin 0})
+              (Left [[MIRTransferNotCurrentlyAllowed]]),
+          testCase "embargo treasury to reserves transfer" $
+            testMirTransfer
+              shelleyPV
+              TreasuryMIR
+              (SendToOppositePotMIR $ Coin 1)
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 1})
+              (Left [[MIRTransferNotCurrentlyAllowed]]),
+          testCase "embargo decrements from reserves" $
+            testMirTransfer
+              shelleyPV
+              ReservesMIR
+              (StakeAddressesMIR $ aliceOnlyDelta (-1))
+              (InstantaneousRewards (aliceOnlyReward 1) mempty mempty mempty)
+              (AccountState {_reserves = Coin 1, _treasury = Coin 0})
+              (Left [[MIRNegativesNotCurrentlyAllowed]]),
+          testCase "embargo decrements from treasury" $
+            testMirTransfer
+              shelleyPV
+              TreasuryMIR
+              (StakeAddressesMIR $ aliceOnlyDelta (-1))
+              (InstantaneousRewards mempty (aliceOnlyReward 1) mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 1})
+              (Left [[MIRNegativesNotCurrentlyAllowed]])
+        ],
+      testGroup
+        "MIR cert alonzo"
+        [ testCase "increment reserves too much" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (StakeAddressesMIR $ aliceOnlyDelta 1)
+              (InstantaneousRewards (aliceOnlyReward 1) mempty mempty mempty)
+              (AccountState {_reserves = Coin 1, _treasury = Coin 0})
+              (Left [[InsufficientForInstantaneousRewardsDELEG ReservesMIR (Coin 2) (Coin 1)]]),
+          testCase "increment treasury too much" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (StakeAddressesMIR $ aliceOnlyDelta 1)
+              (InstantaneousRewards mempty (aliceOnlyReward 1) mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 1})
+              (Left [[InsufficientForInstantaneousRewardsDELEG TreasuryMIR (Coin 2) (Coin 1)]]),
+          testCase "increment reserves too much with delta" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (StakeAddressesMIR $ aliceOnlyDelta 1)
+              (InstantaneousRewards (aliceOnlyReward 1) mempty (DeltaCoin (-1)) (DeltaCoin 1))
+              (AccountState {_reserves = Coin 2, _treasury = Coin 0})
+              (Left [[InsufficientForInstantaneousRewardsDELEG ReservesMIR (Coin 2) (Coin 1)]]),
+          testCase "increment treasury too much with delta" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (StakeAddressesMIR $ aliceOnlyDelta 1)
+              (InstantaneousRewards mempty (aliceOnlyReward 1) (DeltaCoin 1) (DeltaCoin (-1)))
+              (AccountState {_reserves = Coin 0, _treasury = Coin 2})
+              (Left [[InsufficientForInstantaneousRewardsDELEG TreasuryMIR (Coin 2) (Coin 1)]]),
+          testCase "negative balance in reserves mapping" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (StakeAddressesMIR $ aliceOnlyDelta (-1))
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 1, _treasury = Coin 0})
+              (Left [[MIRProducesNegativeUpdate]]),
+          testCase "negative balance in treasury mapping" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (StakeAddressesMIR $ aliceOnlyDelta (-1))
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 1})
+              (Left [[MIRProducesNegativeUpdate]]),
+          testCase "transfer reserves to treasury" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (SendToOppositePotMIR (Coin 1))
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 1, _treasury = Coin 0})
+              (Right (InstantaneousRewards mempty mempty (DeltaCoin (-1)) (DeltaCoin 1))),
+          testCase "transfer treasury to reserves" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (SendToOppositePotMIR (Coin 1))
+              (InstantaneousRewards mempty mempty mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 1})
+              (Right (InstantaneousRewards mempty mempty (DeltaCoin 1) (DeltaCoin (-1)))),
+          testCase "insufficient transfer reserves to treasury" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (SendToOppositePotMIR (Coin 1))
+              (InstantaneousRewards (aliceOnlyReward 1) mempty (DeltaCoin (-1)) (DeltaCoin 1))
+              (AccountState {_reserves = Coin 2, _treasury = Coin 0})
+              (Left [[InsufficientForTransferDELEG ReservesMIR (Coin 1) (Coin 0)]]),
+          testCase "insufficient transfer treasury to reserves" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (SendToOppositePotMIR (Coin 1))
+              (InstantaneousRewards mempty (aliceOnlyReward 1) (DeltaCoin 1) (DeltaCoin (-1)))
+              (AccountState {_reserves = Coin 0, _treasury = Coin 2})
+              (Left [[InsufficientForTransferDELEG TreasuryMIR (Coin 1) (Coin 0)]]),
+          testCase "increment reserves mapping" $
+            testMirTransfer
+              alonzoPV
+              ReservesMIR
+              (StakeAddressesMIR $ (aliceOnlyDelta 1 `Map.union` bobOnlyDelta 1))
+              (InstantaneousRewards (aliceOnlyReward 1) mempty mempty mempty)
+              (AccountState {_reserves = Coin 3, _treasury = Coin 0})
+              ( Right
+                  ( InstantaneousRewards
+                      (aliceOnlyReward 2 `Map.union` bobOnlyReward 1)
+                      mempty
+                      mempty
+                      mempty
+                  )
+              ),
+          testCase "increment treasury mapping" $
+            testMirTransfer
+              alonzoPV
+              TreasuryMIR
+              (StakeAddressesMIR $ (aliceOnlyDelta 1 `Map.union` bobOnlyDelta 1))
+              (InstantaneousRewards mempty (aliceOnlyReward 1) mempty mempty)
+              (AccountState {_reserves = Coin 0, _treasury = Coin 3})
+              ( Right
+                  ( InstantaneousRewards
+                      mempty
+                      (aliceOnlyReward 2 `Map.union` bobOnlyReward 1)
+                      mempty
+                      mempty
+                  )
+              )
+        ]
+    ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -82,6 +82,7 @@ import Shelley.Spec.Ledger.TxBody
     Delegation (..),
     MIRCert (..),
     MIRPot (..),
+    MIRTarget (..),
     PoolCert (..),
     PoolParams (..),
     RewardAcnt (..),
@@ -174,9 +175,9 @@ txbodyEx1 =
             ++ [ DCertMir
                    ( MIRCert
                        ReservesMIR
-                       ( Map.fromList
-                           [ (Cast.carlSHK, carlMIR),
-                             (Cast.dariaSHK, dariaMIR)
+                       ( StakeAddressesMIR $ Map.fromList
+                           [ (Cast.carlSHK, toDeltaCoin carlMIR),
+                             (Cast.dariaSHK, toDeltaCoin dariaMIR)
                            ]
                        )
                    )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -951,10 +951,10 @@ delegTraceFromBlock chainSt block =
     certs = concatMap (reverse . toList . (getField @"certs") . _body)
     blockCerts = filter delegCert (certs txs)
     delegEnv =
-      let (LedgerEnv s txIx _ reserves) = ledgerEnv
+      let (LedgerEnv s txIx pp reserves) = ledgerEnv
           dummyCertIx = 0
           ptr = Ptr s txIx dummyCertIx
-       in DelegEnv s ptr reserves
+       in DelegEnv s ptr reserves pp
     delegSt0 =
       let (_, DPState delegSt0_ _) = ledgerSt0
        in delegSt0_

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -26,6 +26,7 @@ import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import Test.Shelley.Spec.Ledger.Examples.EmptyBlock (exEmptyBlock)
 import Test.Shelley.Spec.Ledger.Examples.GenesisDelegation (genesisDelegExample)
 import Test.Shelley.Spec.Ledger.Examples.Mir (mirExample)
+import Test.Shelley.Spec.Ledger.Examples.MirTransfer (testMIRTransfer)
 import Test.Shelley.Spec.Ledger.Examples.PoolLifetime (poolLifetimeExample)
 import Test.Shelley.Spec.Ledger.Examples.PoolReReg (poolReRegExample)
 import Test.Shelley.Spec.Ledger.Examples.TwoPools (twoPoolsExample)
@@ -53,7 +54,8 @@ chainExamples =
       poolReRegExample,
       updatesExample,
       genesisDelegExample,
-      mirExample
+      mirExample,
+      testMIRTransfer
     ]
 
 multisigExamples :: TestTree

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -155,6 +155,7 @@ import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.Tx (Tx (..), WitnessSetHKD (..), WitnessSet, hashScript)
 import Shelley.Spec.Ledger.TxBody
   ( MIRPot (..),
+    MIRTarget (..),
     PoolMetadata (..),
     StakePoolRelay (..),
     TxBody (..),
@@ -627,7 +628,7 @@ tests =
             <> S (testVRFKH @C_Crypto) -- delegatee vrf key hash
         ),
       -- checkEncodingCBOR "mir"
-      let rws = Map.singleton (testStakeCred @C_Crypto) (Coin 77)
+      let rws = StakeAddressesMIR $ Map.singleton (testStakeCred @C_Crypto) (DeltaCoin 77)
        in checkEncodingCBOR
             "mir"
             (DCertMir (MIRCert ReservesMIR rws))


### PR DESCRIPTION
In the Alonzo era, MIR certs can be used to transfer funds between the reserves and the treasury. Additionally, the semantics of the MIR certs has changed when moving funds to stake accounts. Previously, if a reward account was already in the `_irwd` mapping, it was overridden by new MIR certs. Now, repetitions are handled by adding the values. Moreover, negative values are allowed, so long as the change never results in a negative value in the sum (ie so that the final update itself can only increment accounts).

The type has changed for the MIR certs to accommodate the new features, and predicate failures use used to prevent the new features from being used before the Alonzo era.  We could, if we want to and have time, make the MIR certs a type family and remove the predicate failures.

We probably want to update the Alonzo spec to reflect the change.

This is the type of PR that makes sense to go over in person.