### PR TITLE
Disable doctests on ghc 8.10.x

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.3"]
+        ghc: ["8.6.5", "8.10.4"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -61,11 +61,18 @@ jobs:
         echo "LIBSODIUM_PATH=$LIBSODIUM_PATH"
         echo "$LIBSODIUM_PATH" >> $GITHUB_PATH
 
-    - uses: actions/setup-haskell@v1
+    - name: Select optimal cabal version
+      run: |
+        case "$OS" in
+          Windows_NT)   echo "CABAL_VERSION=3.4.0.0-rc5"  >> $GITHUB_ENV;;
+          *)            echo "CABAL_VERSION=3.4.0.0"      >> $GITHUB_ENV;;
+        esac
+
+    - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2.0.0'
+        cabal-version: ${{ env.CABAL_VERSION }}
 
     - name: Patch GHC 8.10.2 linker
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,6 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # WARNING Do not remove ghc-8.6.5 until doctests are working for ghc-8.10.x.
+        # Doctests for ghc-8.10.x are currently disabled via the CPP in DoctestDiscover.hs files
+        # See See https://gitlab.haskell.org/ghc/ghc/-/issues/19421
         ghc: ["8.6.5", "8.10.4"]
         os: [ubuntu-latest]
 

--- a/byron/ledger/executable-spec/test/DoctestDiscover.hs
+++ b/byron/ledger/executable-spec/test/DoctestDiscover.hs
@@ -1,1 +1,12 @@
+{-# LANGUAGE CPP #-}
+
+#if !MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) || MIN_VERSION_GLASGOW_HASKELL(8,11,0,0)
 {-# OPTIONS_GHC -F -pgmF doctest-discover #-}
+#else
+module Main where
+
+import qualified System.IO as IO
+
+main :: IO ()
+main = IO.putStrLn "WARNING: doctest will not run on GHC 8.10.x.\nSee https://gitlab.haskell.org/ghc/ghc/-/issues/19421"
+#endif

--- a/semantics/executable-spec/test/DoctestDiscover.hs
+++ b/semantics/executable-spec/test/DoctestDiscover.hs
@@ -1,1 +1,12 @@
+{-# LANGUAGE CPP #-}
+
+#if !MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) || MIN_VERSION_GLASGOW_HASKELL(8,11,0,0)
 {-# OPTIONS_GHC -F -pgmF doctest-discover #-}
+#else
+module Main where
+
+import qualified System.IO as IO
+
+main :: IO ()
+main = IO.putStrLn "WARNING: doctest will not run on GHC 8.10.x.\nSee https://gitlab.haskell.org/ghc/ghc/-/issues/19421"
+#endif

--- a/semantics/small-steps-test/test/DoctestDiscover.hs
+++ b/semantics/small-steps-test/test/DoctestDiscover.hs
@@ -1,1 +1,12 @@
+{-# LANGUAGE CPP #-}
+
+#if !MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) || MIN_VERSION_GLASGOW_HASKELL(8,11,0,0)
 {-# OPTIONS_GHC -F -pgmF doctest-discover #-}
+#else
+module Main where
+
+import qualified System.IO as IO
+
+main :: IO ()
+main = IO.putStrLn "WARNING: doctest will not run on GHC 8.10.x.\nSee https://gitlab.haskell.org/ghc/ghc/-/issues/19421"
+#endif


### PR DESCRIPTION
This is a temporary work around.  The work around disable `doctests` on `ghc-8.10.3` in Github Actions only.

The work around is needed because an upstream issue in GHC or doctest is causing doctests to fail https://gitlab.haskell.org/ghc/ghc/-/issues/19421

Doctests are currently running okay on `ghc-8.6.5` so we can rely on those until this is fixed upstream .