### PR TITLE
fix byron nightly script

### DIFF
--- a/.buildkite/nightly-tests.sh
+++ b/.buildkite/nightly-tests.sh
@@ -15,5 +15,5 @@ popd
 
 nix build -f `dirname $0`/.. haskellPackages.cardano-ledger-byron.components.tests.cardano-ledger-byron-test -o cardano-ledger-byron-test
 pushd byron/ledger/impl
-../../../cardano-ledger-byron/test/bin/cardano-ledger-byron-test --scenario=QualityAssurance
+../../../cardano-ledger-byron-test/bin/cardano-ledger-byron-test --scenario=QualityAssurance
 popd


### PR DESCRIPTION
single character typo in `.buildkite/nightly-tests.sh`