### PR TITLE
Removes excess constraints from selector functions defined by patterns

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -203,7 +203,6 @@ deriving via
     ) =>
     FromCBOR (Annotator (AuxiliaryData era))
 
-
 -- | Matches AuxiliaryData, and supplies 'selector' functions without annoying constraints.
 pattern AuxiliaryData' ::
   Set (Core.Script era) ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Alonzo.Data
     DataHash,
     hashData,
     -- $
-    AuxiliaryData (AuxiliaryData, scripts, dats, txMD),
+    AuxiliaryData (AuxiliaryData, AuxiliaryData', scripts, dats, txMD),
     AuxiliaryDataHash,
     -- $
     ppPlutusData,
@@ -203,13 +203,25 @@ deriving via
     ) =>
     FromCBOR (Annotator (AuxiliaryData era))
 
+
+-- | Matches AuxiliaryData, and supplies 'selector' functions without annoying constraints.
+pattern AuxiliaryData' ::
+  Set (Core.Script era) ->
+  Set (Data era) ->
+  Set (Metadata) ->
+  AuxiliaryData era
+pattern AuxiliaryData' {scripts, dats, txMD} <-
+  AuxiliaryDataConstr (Memo (AuxiliaryDataRaw scripts dats txMD) _)
+
+{-# COMPLETE AuxiliaryData' #-}
+
 pattern AuxiliaryData ::
   (Era era, ToCBOR (Core.Script era), Ord (Core.Script era)) =>
   Set (Core.Script era) ->
   Set (Data era) ->
   Set (Metadata) ->
   AuxiliaryData era
-pattern AuxiliaryData {scripts, dats, txMD} <-
+pattern AuxiliaryData scripts dats txMD <-
   AuxiliaryDataConstr (Memo (AuxiliaryDataRaw scripts dats txMD) _)
   where
     AuxiliaryData s d m =

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -239,6 +239,7 @@ pattern Tx' {body, wits, isValidating, auxiliaryData} <-
           }
         _
       )
+
 {-# COMPLETE Tx' #-}
 
 pattern Tx ::
@@ -261,7 +262,9 @@ pattern Tx body wits isValidating auxiliaryData <-
       )
   where
     Tx b w v a = TxConstr $ memoBytes (encodeTxRaw $ TxRaw b w v a)
+
 {-# COMPLETE Tx #-}
+
 --------------------------------------------------------------------------------
 -- Serialisation
 --------------------------------------------------------------------------------
@@ -539,7 +542,8 @@ runPLCScript _cost _script _data _exunits = (IsValidating True, ExUnits 0 0) -- 
 -- ===============================================================
 
 getData ::
-  forall era. HasField "datahash" (Core.TxOut era) (Maybe (DataHash (Crypto era))) =>
+  forall era.
+  HasField "datahash" (Core.TxOut era) (Maybe (DataHash (Crypto era))) =>
   Tx era ->
   UTxO era ->
   ScriptPurpose (Crypto era) ->
@@ -595,7 +599,8 @@ evalScripts (AlonzoScript.PlutusScript, ds, units, cost) = b
 
 -- THE SPEC CALLS FOR A SET, BUT THAT NEEDS A BUNCH OF ORD INSTANCES (DCert)
 scriptsNeeded ::
-  forall era. UsesTxOut era =>
+  forall era.
+  UsesTxOut era =>
   UTxO era ->
   Tx era ->
   [(ScriptPurpose (Crypto era), ScriptHash (Crypto era))]

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Alonzo.TxBody
   ( TxOut (TxOut, TxOutCompact),
     TxBody
       ( TxBody,
+        TxBody',
         txinputs,
         txinputs_fee,
         txouts,
@@ -228,6 +229,58 @@ deriving via
     ) =>
     FromCBOR (Annotator (TxBody era))
 
+-- | Matches TxBody, and supplies 'selector' functions without (AlonzoBody era) constraints.
+pattern TxBody' ::
+  Set (TxIn (Crypto era)) ->
+  Set (TxIn (Crypto era)) ->
+  StrictSeq (TxOut era) ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
+  Coin ->
+  ValidityInterval ->
+  StrictMaybe (Update era) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  Value (Crypto era) ->
+  ExUnits ->
+  StrictMaybe (WitnessPPDataHash (Crypto era)) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  TxBody era
+pattern TxBody'
+  { txinputs,
+    txinputs_fee,
+    txouts,
+    txcerts,
+    txwdrls,
+    txfee,
+    txvldt,
+    txUpdates,
+    txADhash,
+    mint,
+    exunits,
+    sdHash,
+    scriptHash
+  } <-
+  TxBodyConstr
+    ( Memo
+        TxBodyRaw
+          { _inputs = txinputs,
+            _inputs_fee = txinputs_fee,
+            _outputs = txouts,
+            _certs = txcerts,
+            _wdrls = txwdrls,
+            _txfee = txfee,
+            _vldt = txvldt,
+            _update = txUpdates,
+            _adHash = txADhash,
+            _mint = mint,
+            _exunits = exunits,
+            _sdHash = sdHash,
+            _scriptHash = scriptHash
+          }
+        _
+      )
+{-# COMPLETE TxBody' #-}
+
 -- The Set of constraints necessary to use the TxBody pattern
 type AlonzoBody era =
   ( Era era,
@@ -253,20 +306,20 @@ pattern TxBody ::
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   TxBody era
 pattern TxBody
-  { txinputs,
-    txinputs_fee,
-    txouts,
-    txcerts,
-    txwdrls,
-    txfee,
-    txvldt,
-    txUpdates,
-    txADhash,
-    mint,
-    exunits,
-    sdHash,
+    txinputs
+    txinputs_fee
+    txouts
+    txcerts
+    txwdrls
+    txfee
+    txvldt
+    txUpdates
+    txADhash
+    mint
+    exunits
+    sdHash
     scriptHash
-  } <-
+  <-
   TxBodyConstr
     ( Memo
         TxBodyRaw

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -279,6 +279,7 @@ pattern TxBody'
           }
         _
       )
+
 {-# COMPLETE TxBody' #-}
 
 -- The Set of constraints necessary to use the TxBody pattern
@@ -306,20 +307,19 @@ pattern TxBody ::
   StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
   TxBody era
 pattern TxBody
-    txinputs
-    txinputs_fee
-    txouts
-    txcerts
-    txwdrls
-    txfee
-    txvldt
-    txUpdates
-    txADhash
-    mint
-    exunits
-    sdHash
-    scriptHash
-  <-
+  txinputs
+  txinputs_fee
+  txouts
+  txcerts
+  txwdrls
+  txfee
+  txvldt
+  txUpdates
+  txADhash
+  mint
+  exunits
+  sdHash
+  scriptHash <-
   TxBodyConstr
     ( Memo
         TxBodyRaw

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -20,7 +20,7 @@
 
 module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
-    TxWitness (TxWitness, txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs),
+    TxWitness (TxWitness, TxWitness', txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs),
     ppRdmrPtr,
     ppTxWitness,
   )
@@ -133,6 +133,20 @@ deriving newtype instance
 -- =====================================================
 -- Pattern for TxWitness
 
+-- | Matches TxWitness, and supplies 'selector' functions without annoying constraints.
+pattern TxWitness' ::
+  Set (WitVKey 'Witness (Crypto era)) ->
+  Set (BootstrapWitness (Crypto era)) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
+  Map (DataHash (Crypto era)) (Data era) ->
+  Map RdmrPtr (Data era, ExUnits) ->
+  TxWitness era
+pattern TxWitness' {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs} <-
+  TxWitnessConstr
+    (Memo (TxWitnessRaw txwitsVKey txwitsBoot txscripts txdats txrdmrs) _)
+
+{-# COMPLETE TxWitness' #-}
+
 pattern TxWitness ::
   (Era era, ToCBOR (Core.Script era)) =>
   Set (WitVKey 'Witness (Crypto era)) ->
@@ -141,7 +155,7 @@ pattern TxWitness ::
   Map (DataHash (Crypto era)) (Data era) ->
   Map RdmrPtr (Data era, ExUnits) ->
   TxWitness era
-pattern TxWitness {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs} <-
+pattern TxWitness txwitsVKey txwitsBoot txscripts txdats txrdmrs <-
   TxWitnessConstr
     (Memo (TxWitnessRaw txwitsVKey txwitsBoot txscripts txdats txrdmrs) _)
   where

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra.hs
@@ -104,7 +104,7 @@ genTxBody ::
   Gen (TxBody era, [Timelock (Crypto era)])
 genTxBody _pparams slot ins outs cert wdrl fee upd ad = do
   validityInterval <- genValidityInterval slot
-  let mint = zero -- the mint field is always empty for an Allegra TxBody
+  let minted = zero -- the mint field is always empty for an Allegra TxBody
   pure $
     ( TxBody
         ins
@@ -115,7 +115,7 @@ genTxBody _pparams slot ins outs cert wdrl fee upd ad = do
         validityInterval
         upd
         ad
-        mint,
+        minted,
       [] -- Allegra does not need any additional script witnesses
     )
 

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -84,8 +84,8 @@ instance (CryptoClass.Crypto c, Mock c) => EraGen (MaryEra c) where
     Val.inject . Coin <$> exponential minGenesisOutputVal maxGenesisOutputVal
   genEraTxBody _ge = genTxBody
   genEraAuxiliaryData = genAuxiliaryData
-  updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta mint) fee ins outs =
-    TxBody ins outs cert wdrl fee vi upd meta mint
+  updateEraTxBody (TxBody _in _out cert wdrl _txfee vi upd meta _mint) fee ins outs =
+    TxBody ins outs cert wdrl fee vi upd meta _mint
 
 genAuxiliaryData ::
   Mock crypto =>
@@ -276,11 +276,11 @@ genTxBody ::
   Gen (TxBody era, [Timelock (Crypto era)])
 genTxBody pparams slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot
-  mint <- genMint
-  let (mint', outs') = case addTokens pparams mint outs of
+  minted <- genMint
+  let (mint', outs') = case addTokens pparams minted outs of
                          Nothing -> (mempty, outs)
-                         Just os -> (mint, os)
-      ps = map (\p -> (Map.!) policyIndex p) (Set.toList $ policies mint)
+                         Just os -> (minted, os)
+      ps = map (\p -> (Map.!) policyIndex p) (Set.toList $ policies minted)
   pure $
     ( TxBody
         ins

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -314,11 +314,11 @@ txbodyTimeEx1Valid :: TxBody MaryTest
 txbodyTimeEx1Valid = txbodyTimeEx1 (SJust startInterval) (SJust stopInterval)
 
 txTimeEx1 :: TxBody MaryTest -> Tx MaryTest
-txTimeEx1 body =
+txTimeEx1 body' =
   Tx
-    body
+    body'
     mempty
-      { addrWits = makeWitnessesVKey (hashAnnotated body) [asWitness Cast.alicePay],
+      { addrWits = makeWitnessesVKey (hashAnnotated body') [asWitness Cast.alicePay],
         scriptWits = Map.fromList [(policyID boundedTimePolicyId, boundedTimePolicy)]
       }
     SNothing

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -401,7 +401,7 @@ goldenEncodingTestsMary =
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
           mdh = hashAuxiliaryData @A $ AuxiliaryData Map.empty StrictSeq.empty
-          mint = Map.singleton policyID1 $ Map.singleton (AssetName assetName1) 13
+          minted = Map.singleton policyID1 $ Map.singleton (AssetName assetName1) 13
        in checkEncodingCBORAnnotated
             "full_txn_body"
             ( TxBody
@@ -413,7 +413,7 @@ goldenEncodingTestsMary =
                 (ValidityInterval (SJust $ SlotNo 500) (SJust $ SlotNo 600))
                 (SJust up)
                 (SJust mdh)
-                (Value 0 mint)
+                (Value 0 minted)
             )
             ( T (TkMapLen 10)
                 <> T (TkWord 0) -- Tx Ins
@@ -438,7 +438,7 @@ goldenEncodingTestsMary =
                 <> T (TkWord 8) -- Tx Validity Start
                 <> S (SlotNo 500)
                 <> T (TkWord 9) -- Tx Mint
-                <> S mint
+                <> S minted
             )
     ]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -36,7 +36,6 @@ import qualified Data.ByteString as Long (ByteString)
 import qualified Data.ByteString.Lazy as Lazy (ByteString, toStrict)
 import Data.IP (IPv4, IPv6)
 import qualified Data.Map.Strict as Map (Map, toList)
-import Data.MemoBytes (MemoBytes (..))
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set, toList)
@@ -155,7 +154,6 @@ import Shelley.Spec.Ledger.TxBody
     StakeCreds (..),
     StakePoolRelay (..),
     TxBody (..),
-    TxBodyRaw (..),
     TxId (..),
     TxIn (..),
     TxOut (..),
@@ -799,10 +797,10 @@ ppTx ::
   ) =>
   Tx era ->
   PDoc
-ppTx (Tx' body witset meta _) =
+ppTx (Tx' bod witset meta) =
   ppRecord
     "Tx"
-    [ ("body", prettyA body),
+    [ ("body", prettyA bod),
       ("witnessSet", ppWitnessSetHKD witset),
       ("metadata", ppStrictMaybe prettyA meta)
     ]
@@ -938,7 +936,7 @@ ppTxBody ::
   PrettyA (PParamsDelta era) =>
   TxBody era ->
   PDoc
-ppTxBody (TxBodyConstr (Memo (TxBodyRaw ins outs cs wdrls fee ttl upd mdh) _)) =
+ppTxBody (TxBody' ins outs cs wdrls fee ttl upd mdh) =
   ppRecord
     "TxBody"
     [ ("inputs", ppSet ppTxIn ins),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -723,10 +723,7 @@ txsize = fromIntegral . BSL.length . txFullBytes
 -- | It can be helpful for coin selection.
 txsizeBound ::
   forall era out.
-  ( UsesTxBody era,
-    UsesScript era,
-    UsesAuxiliary era,
-    HasField "outputs" (Core.TxBody era) (StrictSeq out),
+  ( HasField "outputs" (Core.TxBody era) (StrictSeq out),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   Tx era ->
@@ -740,7 +737,7 @@ txsizeBound tx = numInputs * inputSize + numOutputs * outputSize + rest
     addrHashLen = 28
     addrHeader = 1
     address = 2 + addrHeader + 2 * addrHashLen
-    txbody = _body tx
+    txbody = body tx
     numInputs = toInteger . length . getField @"inputs" $ txbody
     inputSize = smallArray + uint + hashObj
     numOutputs = toInteger . length . getField @"outputs" $ txbody

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -199,10 +199,7 @@ instance
 
 ledgerTransition ::
   forall era.
-  ( UsesScript era,
-    UsesTxBody era,
-    UsesAuxiliary era,
-    Embed (Core.EraRule "DELEGS" era) (LEDGER era),
+  ( Embed (Core.EraRule "DELEGS" era) (LEDGER era),
     Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
     State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
@@ -221,7 +218,7 @@ ledgerTransition = do
       TRC
         ( DelegsEnv slot txIx pp tx account,
           dpstate,
-          StrictSeq.fromStrict $ getField @"certs" $ _body tx
+          StrictSeq.fromStrict $ getField @"certs" $ body tx
         )
 
   let DPState dstate pstate = dpstate

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -325,7 +325,6 @@ scriptCred (ScriptHashObj hs) = Just hs
 scriptsNeeded ::
   forall era.
   ( UsesTxOut era,
-    TransTx ToCBOR era,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
@@ -345,9 +344,9 @@ scriptsNeeded u tx =
           (filter requiresVKeyWitness certificates)
       )
   where
-    withdrawals = unWdrl $ getField @"wdrls" $ _body tx
-    u'' = eval ((txinsScript (getField @"inputs" $ _body tx) u) ◁ u)
-    certificates = (toList . getField @"certs" . _body) tx
+    withdrawals = unWdrl $ getField @"wdrls" $ body tx
+    u'' = eval ((txinsScript (getField @"inputs" $ body tx) u) ◁ u)
+    certificates = (toList . getField @"certs" . body) tx
 
 -- | Compute the subset of inputs of the set 'txInps' for which each input is
 -- locked by a script in the UTxO 'u'.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/BenchmarkFunctions.hs
@@ -259,11 +259,11 @@ makeSimpleTx ::
   TxBody B ->
   [KeyPair 'Witness B_Crypto] ->
   Tx B
-makeSimpleTx body keysAddr =
+makeSimpleTx body' keysAddr =
   Tx
-    body
+    body'
     mempty
-      { addrWits = makeWitnessesVKey (hashAnnotated body) keysAddr
+      { addrWits = makeWitnessesVKey (hashAnnotated body') keysAddr
       }
     SNothing
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -139,10 +139,10 @@ showBalance
   (LedgerEnv _ _ pparams _)
   (UTxOState utxo _ _ _)
   (DPState _ (PState stakepools _ _))
-  (Tx body _ _) =
-    "\n\nConsumed: " ++ show (consumed pparams utxo body)
+  (Tx' bod _ _) =
+    "\n\nConsumed: " ++ show (consumed pparams utxo bod)
       ++ "  Produced: "
-      ++ show (produced @era pparams stakepools body)
+      ++ show (produced @era pparams stakepools bod)
 
 --  ========================================================================
 
@@ -223,7 +223,7 @@ genTx
           (utxoSt, dpState)
       (certs, deposits, refunds, dpState', (certWits, certScripts)) <-
         genDCerts ge pparams dpState slot txIx reserves
-      metadata <- genEraAuxiliaryData @era constants
+      metad <- genEraAuxiliaryData @era constants
       -------------------------------------------------------------------------
       -- Gather Key Witnesses and Scripts, prepare a constructor for Tx Wits
       -------------------------------------------------------------------------
@@ -278,8 +278,8 @@ genTx
           (Wdrl (Map.fromList wdrls))
           draftFee
           (maybeToStrictMaybe update)
-          (hashAuxiliaryData @era <$> metadata)
-      let draftTx = Tx draftTxBody (mkTxWits' draftTxBody) metadata
+          (hashAuxiliaryData @era <$> metad)
+      let draftTx = Tx draftTxBody (mkTxWits' draftTxBody) metad
           scripts' = Map.fromList $ map (\s -> (hashScript @era s, s)) additionalScripts
       -- We add now repeatedly add inputs until the process converges.
       converge
@@ -493,16 +493,16 @@ applyDelta
   neededKeys
   neededScripts
   KeySpace_ {ksIndexedPaymentKeys, ksIndexedStakingKeys}
-  tx@(Tx body _wits _md)
+  tx@(Tx bod _wits _md)
   (Delta deltafees extraIn _extraWits change extraKeys extraScripts) =
     --fix up the witnesses here?
     -- Adds extraInputs, extraWitnesses, and change from delta to tx
-    let outputs' = (getField @"outputs" body) StrictSeq.|> change
+    let outputs' = (getField @"outputs" bod) StrictSeq.|> change
         body' =
           (updateEraTxBody @era)
-            body
+            bod
             deltafees
-            (getField @"inputs" body <> extraIn)
+            (getField @"inputs" bod <> extraIn)
             outputs'
         kw = neededKeys <> extraKeys
         sw = neededScripts <> mkScriptWits @era extraScripts mempty

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -467,12 +467,12 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
         (UTxOState {_utxo = u}, dstate) = ledgerSt
         (UTxOState {_utxo = u'}, _) = ledgerSt'
         txb = _body tx
-        certs = toList (getField @"certs" txb)
+        certs' = toList (getField @"certs" txb)
         pools = _pParams . _pstate $ dstate
         created =
           Val.coin (balance u')
             <+> getField @"txfee" txb
-            <+> totalDeposits pp_ pools certs
+            <+> totalDeposits pp_ pools certs'
         consumed_ =
           Val.coin (balance u)
             <+> keyRefunds pp_ txb
@@ -522,10 +522,10 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
             <> keyRefunds pp_ txb
             <> fold (unWdrl (getField @"wdrls" txb))
         outs =
-          let certs = toList (getField @"certs" txb)
+          let certs' = toList (getField @"certs" txb)
            in Val.coin (balance (txouts @era txb))
                 <> getField @"txfee" txb
-                <> totalDeposits pp_ pools certs
+                <> totalDeposits pp_ pools certs'
 
 preserveOutputsTx ::
   forall era.
@@ -718,8 +718,8 @@ withdrawals ::
 withdrawals block =
   foldl'
     ( \c tx ->
-        let wdrls = unWdrl $ getField @"wdrls" (_body tx)
-         in c <> fold wdrls
+        let wdrls' = unWdrl $ getField @"wdrls" (_body tx)
+         in c <> fold wdrls'
     )
     (Coin 0)
     $ (txSeqTxns' . bbody) block
@@ -921,8 +921,8 @@ poolTraceFromBlock chainSt block =
   )
   where
     (tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
-    certs = concatMap (toList . (getField @"certs") . _body)
-    poolCerts = filter poolCert (certs txs)
+    certs' = concatMap (toList . (getField @"certs") . _body)
+    poolCerts = filter poolCert (certs' txs)
     poolEnv =
       let (LedgerEnv s _ pp _) = ledgerEnv
        in PoolEnv s pp
@@ -948,8 +948,8 @@ delegTraceFromBlock chainSt block =
   )
   where
     (tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
-    certs = concatMap (reverse . toList . (getField @"certs") . _body)
-    blockCerts = filter delegCert (certs txs)
+    certs' = concatMap (reverse . toList . (getField @"certs") . _body)
+    blockCerts = filter delegCert (certs' txs)
     delegEnv =
       let (LedgerEnv s txIx _ reserves) = ledgerEnv
           dummyCertIx = 0


### PR DESCRIPTION
For each pattern
pattern T :: Foo a => a -> b -> T
pattern T {a, b} <- TRaw a b where ...

we create two patterns
pattern T' :: a -> b -> T
pattern T {a, b} <- TRaw a b

pattern T :: Foo a => a -> b -> T
pattern T a b <- TRaw a b where ...

Thus selectors: 'a' and 'b' do not have the unneccesary Foo constraint.
The module exports are also revised from:
T(T,a,b)   to   T(T,T',a,b).

This commit handles al such cases in the Alonzo era code.