### PR TITLE
WIP generalize utxow for all Eras

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -42,8 +42,18 @@ module Cardano.Ledger.Alonzo.Tx
     WitnessPPData,
     WitnessPPDataHash,
     -- Figure 3
-    Tx (Tx, body, wits, isValidating, auxiliaryData,
-        Tx', body', wits', isValidating', auxiliaryData'),
+    Tx
+      ( Tx,
+        body,
+        wits,
+        isValidating,
+        auxiliaryData,
+        Tx',
+        body',
+        wits',
+        isValidating',
+        auxiliaryData'
+      ),
     TxBody (..),
     -- Figure 4
     ScriptPurpose (..),
@@ -264,6 +274,7 @@ pattern Tx {body, wits, isValidating, auxiliaryData} <-
     Tx b w v a = TxConstr $ memoBytes (encodeTxRaw $ TxRaw b w v a)
 
 {-# COMPLETE Tx #-}
+
 --------------------------------------------------------------------------------
 -- Serialisation
 --------------------------------------------------------------------------------

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -242,11 +242,6 @@ deriving via
     ) =>
     FromCBOR (Annotator (TxBody era))
 
-
-
-
-
-
 pattern TxBody' ::
   Set (TxIn (Crypto era)) ->
   Set (TxIn (Crypto era)) ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -33,7 +33,21 @@ module Cardano.Ledger.Alonzo.TxBody
         mint,
         exunits,
         sdHash,
-        scriptHash
+        scriptHash,
+        TxBody',
+        txinputs',
+        txinputs_fee',
+        txouts',
+        txcerts',
+        txwdrls',
+        txfee',
+        txvldt',
+        txUpdates',
+        txADhash',
+        mint',
+        exunits',
+        sdHash',
+        scriptHash'
       ),
     AlonzoBody,
     EraIndependentWitnessPPData,
@@ -228,6 +242,63 @@ deriving via
     ) =>
     FromCBOR (Annotator (TxBody era))
 
+
+
+
+
+
+pattern TxBody' ::
+  Set (TxIn (Crypto era)) ->
+  Set (TxIn (Crypto era)) ->
+  StrictSeq (TxOut era) ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
+  Coin ->
+  ValidityInterval ->
+  StrictMaybe (Update era) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  Value (Crypto era) ->
+  ExUnits ->
+  StrictMaybe (WitnessPPDataHash (Crypto era)) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  TxBody era
+pattern TxBody'
+  { txinputs',
+    txinputs_fee',
+    txouts',
+    txcerts',
+    txwdrls',
+    txfee',
+    txvldt',
+    txUpdates',
+    txADhash',
+    mint',
+    exunits',
+    sdHash',
+    scriptHash'
+  } <-
+  TxBodyConstr
+    ( Memo
+        TxBodyRaw
+          { _inputs = txinputs',
+            _inputs_fee = txinputs_fee',
+            _outputs = txouts',
+            _certs = txcerts',
+            _wdrls = txwdrls',
+            _txfee = txfee',
+            _vldt = txvldt',
+            _update = txUpdates',
+            _adHash = txADhash',
+            _mint = mint',
+            _exunits = exunits',
+            _sdHash = sdHash',
+            _scriptHash = scriptHash'
+          }
+        _
+      )
+
+{-# COMPLETE TxBody #-}
+
 -- The Set of constraints necessary to use the TxBody pattern
 type AlonzoBody era =
   ( Era era,
@@ -288,36 +359,36 @@ pattern TxBody
       )
   where
     TxBody
-      inputs'
-      inputs_fee'
-      outputs'
-      certs'
-      wdrls'
-      txfee'
-      vldt'
-      update'
-      adHash'
-      mint'
-      exunits'
-      sdHash'
-      scriptHash' =
+      inputsX
+      inputs_feeX
+      outputsX
+      certsX
+      wdrlsX
+      txfeeX
+      vldtX
+      updateX
+      adHashX
+      mintX
+      exunitsX
+      sdHashX
+      scriptHashX =
         TxBodyConstr $
           memoBytes
             ( encodeTxBodyRaw $
                 TxBodyRaw
-                  inputs'
-                  inputs_fee'
-                  outputs'
-                  certs'
-                  wdrls'
-                  txfee'
-                  vldt'
-                  update'
-                  adHash'
-                  mint'
-                  exunits'
-                  sdHash'
-                  scriptHash'
+                  inputsX
+                  inputs_feeX
+                  outputsX
+                  certsX
+                  wdrlsX
+                  txfeeX
+                  vldtX
+                  updateX
+                  adHashX
+                  mintX
+                  exunitsX
+                  sdHashX
+                  scriptHashX
             )
 
 {-# COMPLETE TxBody #-}

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -20,7 +20,11 @@
 
 module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
-    TxWitness (TxWitness, txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs),
+    TxWitness
+       ( TxWitness,
+         TxWitness',
+         txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs,
+         txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'),
     ppRdmrPtr,
     ppTxWitness,
   )
@@ -132,6 +136,19 @@ deriving newtype instance
 
 -- =====================================================
 -- Pattern for TxWitness
+
+pattern TxWitness' ::
+  Set (WitVKey 'Witness (Crypto era)) ->
+  Set (BootstrapWitness (Crypto era)) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
+  Map (DataHash (Crypto era)) (Data era) ->
+  Map RdmrPtr (Data era, ExUnits) ->
+  TxWitness era
+pattern TxWitness' {txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'} <-
+  TxWitnessConstr
+    (Memo (TxWitnessRaw txwitsVKey' txwitsBoot' txscripts' txdats' txrdmrs') _)
+
+{-# COMPLETE TxWitness' #-}
 
 pattern TxWitness ::
   (Era era, ToCBOR (Core.Script era)) =>

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -21,10 +21,19 @@
 module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
     TxWitness
-       ( TxWitness,
-         TxWitness',
-         txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs,
-         txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'),
+      ( TxWitness,
+        TxWitness',
+        txwitsVKey,
+        txwitsBoot,
+        txscripts,
+        txdats,
+        txrdmrs,
+        txwitsVKey',
+        txwitsBoot',
+        txscripts',
+        txdats',
+        txrdmrs'
+      ),
     ppRdmrPtr,
     ppTxWitness,
   )

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra where
 
+import Cardano.Ledger.CoreUtxow (CoreUtxow (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
@@ -15,12 +16,11 @@ import Cardano.Ledger.Val (Val ((<->)))
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import GHC.Records(HasField(..))
-import Shelley.Spec.Ledger.API hiding(TxBody)
-import Shelley.Spec.Ledger.CompactAddr( decompactAddr )
+import GHC.Records (HasField (..))
+import Shelley.Spec.Ledger.API hiding (TxBody)
+import Shelley.Spec.Ledger.CompactAddr (decompactAddr)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
-import Shelley.Spec.Ledger.Tx (WitnessSetHKD(..))
-import Cardano.Ledger.CoreUtxow(CoreUtxow(..))
+import Shelley.Spec.Ledger.Tx (WitnessSetHKD (..))
 
 type AllegraEra = ShelleyMAEra 'Allegra
 
@@ -69,18 +69,17 @@ instance
 
 instance PraosCrypto c => ShelleyBasedEra (AllegraEra c)
 
-
 instance Crypto c => CoreUtxow (ShelleyMAEra 'Allegra c) Tx TxBody WitnessSet TxOut where
-   bodyTx (Tx' body _wit _meta _) = body
-   witTx (Tx' _body wit _meta _) = wit
-   metaTx (Tx' _body _wit meta _) = meta
-   addrWit x = addrWits' x
-   bootWit x = bootWits' x
-   scriptWit x = scriptWits' x
-   updateBody x = getField @"update" x
-   wdrlsBody x = getField @"wdrls" x
-   certsBody x = getField @"certs" x
-   inputsBody x = getField @"inputs" x
-   mintBody _ = Set.empty
-   adHashBody x = getField @"adHash" x
-   addressOut (TxOutCompact ca _) = decompactAddr ca
+  bodyTx (Tx' body _wit _meta _) = body
+  witTx (Tx' _body wit _meta _) = wit
+  metaTx (Tx' _body _wit meta _) = meta
+  addrWit x = addrWits' x
+  bootWit x = bootWits' x
+  scriptWit x = scriptWits' x
+  updateBody x = getField @"update" x
+  wdrlsBody x = getField @"wdrls" x
+  certsBody x = getField @"certs" x
+  inputsBody x = getField @"inputs" x
+  mintBody _ = Set.empty
+  adHashBody x = getField @"adHash" x
+  addressOut (TxOutCompact ca _) = decompactAddr ca

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Cardano.Ledger.ShelleyMA where
 
@@ -14,9 +14,10 @@ import Cardano.Ledger.AuxiliaryData
     ValidateAuxiliaryData (..),
   )
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.CoreUtxow (CoreUtxow (..))
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Mary.Value (Value,policies,PolicyID(..))
+import Cardano.Ledger.Mary.Value (PolicyID (..), Value, policies)
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.Constraints
   ( UsesPParams (..),
@@ -36,24 +37,21 @@ import Cardano.Ledger.ShelleyMA.Timelocks
   )
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody)
 import Control.DeepSeq (deepseq)
-import qualified Data.Set as Set
 import Data.Kind (Type)
+import qualified Data.Set as Set
 import Data.Typeable (Typeable)
-import GHC.Records (HasField(..))
+import GHC.Records (HasField (..))
 import Shelley.Spec.Ledger.Coin (Coin)
-import Shelley.Spec.Ledger.CompactAddr( decompactAddr )
+import Shelley.Spec.Ledger.CompactAddr (decompactAddr)
 import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import qualified Shelley.Spec.Ledger.PParams as Shelley
 import Shelley.Spec.Ledger.Tx
-  ( Tx(..),
+  ( Tx (..),
     TxOut (..),
     ValidateScript (..),
     WitnessSet,
-    WitnessSetHKD(..),
+    WitnessSetHKD (..),
   )
-
-import Cardano.Ledger.CoreUtxow(CoreUtxow(..))
-
 
 -- | The Shelley Mary/Allegra eras
 --
@@ -151,18 +149,17 @@ instance
   validateAuxiliaryData (AuxiliaryData md as) = deepseq as $ all validMetadatum md
   hashAuxiliaryData aux = AuxiliaryDataHash (hashAnnotated aux)
 
-
 instance CryptoClass.Crypto c => CoreUtxow (ShelleyMAEra 'Mary c) Tx TxBody WitnessSet TxOut where
-   bodyTx (Tx' body _wit _meta _) = body
-   witTx (Tx' _body wit _meta _) = wit
-   metaTx (Tx' _body _wit meta _) = meta
-   addrWit x = addrWits' x
-   bootWit x = bootWits' x
-   scriptWit x = scriptWits' x
-   updateBody x = getField @"update" x
-   wdrlsBody x = getField @"wdrls" x
-   certsBody x = getField @"certs" x
-   inputsBody x = getField @"inputs" x
-   mintBody x = Set.map policyID (policies (getField @"mint" x))
-   adHashBody x = getField @"adHash" x
-   addressOut (TxOutCompact ca _) = decompactAddr ca
+  bodyTx (Tx' body _wit _meta _) = body
+  witTx (Tx' _body wit _meta _) = wit
+  metaTx (Tx' _body _wit meta _) = meta
+  addrWit x = addrWits' x
+  bootWit x = bootWits' x
+  scriptWit x = scriptWits' x
+  updateBody x = getField @"update" x
+  wdrlsBody x = getField @"wdrls" x
+  certsBody x = getField @"certs" x
+  inputsBody x = getField @"inputs" x
+  mintBody x = Set.map policyID (policies (getField @"mint" x))
+  adHashBody x = getField @"adHash" x
+  addressOut (TxOutCompact ca _) = decompactAddr ca

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -41,7 +41,8 @@ import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import qualified Shelley.Spec.Ledger.PParams as Shelley
 import Shelley.Spec.Ledger.Tx
-  ( TxOut (..),
+  ( Tx,
+    TxOut (..),
     ValidateScript (..),
   )
 
@@ -112,6 +113,10 @@ type instance
 type instance
   Core.PParams (ShelleyMAEra (ma :: MaryOrAllegra) c) =
     Shelley.PParams (ShelleyMAEra (ma :: MaryOrAllegra) c)
+
+type instance
+  Core.Tx (ShelleyMAEra (ma :: MaryOrAllegra) c) =
+    Shelley.Tx (ShelleyMAEra (ma :: MaryOrAllegra) c)
 
 --------------------------------------------------------------------------------
 -- Ledger data instances

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -12,25 +12,34 @@
 module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 
 -- import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
-import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+
 -- import Cardano.Ledger.Mary.Value (PolicyID, Value, policies, policyID)
 -- import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesScript, UsesTxBody, UsesTxOut, UsesValue)
-import Cardano.Ledger.ShelleyMA.AuxiliaryData ()
-import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO, UtxoPredicateFailure)
-import Cardano.Ledger.ShelleyMA.TxBody ()
+
 -- import Control.SetAlgebra (eval, (◁))
-import Control.State.Transition.Extended
+
 -- import Data.Foldable (Foldable (toList))
 -- import qualified Data.Map.Strict as Map
 -- import qualified Data.Maybe as Maybe
 -- import Data.Sequence.Strict (StrictSeq)
 -- import Data.Set (Set)
 -- import qualified Data.Set as Set
-import GHC.Records (HasField (..))
-import Shelley.Spec.Ledger.BaseTypes
+
 -- import Shelley.Spec.Ledger.Coin (Coin)
 -- import Shelley.Spec.Ledger.Delegation.Certificates (requiresVKeyWitness)
+
+-- import Shelley.Spec.Ledger.Scripts (ScriptHash)
+
+import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.CoreUtxow (CoreUtxow (..))
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData ()
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO, UtxoPredicateFailure)
+import Cardano.Ledger.ShelleyMA.TxBody ()
+import Control.State.Transition.Extended
+import GHC.Records (HasField (..))
+import Shelley.Spec.Ledger.BaseTypes
 import Shelley.Spec.Ledger.Keys (DSignable, Hash)
 import Shelley.Spec.Ledger.LedgerState (UTxOState)
 import Shelley.Spec.Ledger.PParams (ProtVer)
@@ -40,14 +49,11 @@ import Shelley.Spec.Ledger.STS.Utxow
   ( UtxowPredicateFailure (..),
     utxoWitnessed,
   )
--- import Shelley.Spec.Ledger.Scripts (ScriptHash)
-import Shelley.Spec.Ledger.Tx (Tx(..), ValidateScript)
+import Shelley.Spec.Ledger.Tx (Tx (..), ValidateScript)
 import Shelley.Spec.Ledger.TxBody
   ( EraIndependentTxBody,
   )
 
-import Cardano.Ledger.CoreUtxow(CoreUtxow(..))
-import Cardano.Ledger.AuxiliaryData(ValidateAuxiliaryData)
 -- ==========================================================
 
 {-

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -22,6 +22,7 @@ library
     Cardano.Ledger.AuxiliaryData
     Cardano.Ledger.Compactible
     Cardano.Ledger.Core
+    Cardano.Ledger.CoreUtxow
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
     Cardano.Ledger.Pretty

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Core.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Core
     Script,
     AuxiliaryData,
     PParams,
+    Tx,
 
     -- * Constraint synonyms
     ChainData,
@@ -57,6 +58,9 @@ type family AuxiliaryData era :: Type
 
 -- | Protocol parameters
 type family PParams era :: Type
+
+-- | Transaction
+type family Tx era :: Type
 
 -- | Common constraints
 --

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/CoreUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/CoreUtxow.hs
@@ -56,6 +56,6 @@ class
   wdrlsBody :: body era -> Wdrl (Crypto era)
   certsBody :: body era -> StrictSeq (DCert (Crypto era))
   inputsBody :: body era -> Set (TxIn (Crypto era))
-  mintBody :: body era -> Set (ScriptHash crypto)
+  mintBody :: body era -> Set (ScriptHash (Crypto era))
   adHashBody :: body era -> StrictMaybe (AuxiliaryDataHash (Crypto era))
   addressOut :: txout era -> Addr (Crypto era)

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/CoreUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/CoreUtxow.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Common basis for the Utxow rule
+module Cardano.Ledger.CoreUtxow
+  ( CoreUtxow (..),
+    ValidateScript (..),
+  )
+where
+
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.SafeHash (HashAnnotated)
+import qualified Data.Map as Map
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import Shelley.Spec.Ledger.Address (Addr (..))
+import Shelley.Spec.Ledger.Address.Bootstrap (BootstrapWitness)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.Keys (KeyRole (Witness))
+import Shelley.Spec.Ledger.PParams (Update (..))
+import Shelley.Spec.Ledger.Scripts (ScriptHash)
+import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody, TxIn, Wdrl, WitVKey)
+
+-- ==============================
+
+-- | Typeclass for Script data types. Supports script validation and hashing.
+class Era era => ValidateScript era where
+  validateScript :: Core.Script era -> Core.Tx era -> Bool
+  hashScript :: Core.Script era -> ScriptHash (Crypto era)
+  isNativeScript :: Core.Script era -> Bool
+  isNativeScript _ = True
+
+class
+  ( Era era,
+    HashAnnotated (body era) EraIndependentTxBody (Crypto era),
+    ValidateScript era, -- So we can Validate
+    Core.Tx era ~ tx era, -- So (Core.Tx era) in ValidateScript aligns with tx in this class
+    Core.TxOut era ~ txout era -- So addressOut can be applied to Core.TxOut
+  ) =>
+  CoreUtxow era tx body wit txout
+    | era -> tx body wit txout
+  where
+  bodyTx :: tx era -> body era
+  witTx :: tx era -> wit era
+  metaTx :: tx era -> StrictMaybe (Core.AuxiliaryData era)
+  addrWit :: wit era -> Set (WitVKey 'Witness (Crypto era))
+  bootWit :: wit era -> Set (BootstrapWitness (Crypto era))
+  scriptWit :: wit era -> Map.Map (ScriptHash (Crypto era)) (Core.Script era)
+  updateBody :: body era -> StrictMaybe (Update era)
+  wdrlsBody :: body era -> Wdrl (Crypto era)
+  certsBody :: body era -> StrictSeq (DCert (Crypto era))
+  inputsBody :: body era -> Set (TxIn (Crypto era))
+  mintBody :: body era -> Set (ScriptHash crypto)
+  adHashBody :: body era -> StrictMaybe (AuxiliaryDataHash (Crypto era))
+  addressOut :: txout era -> Addr (Crypto era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -829,6 +829,7 @@ diffWitHashes (WitHashes x) (WitHashes x') =
   WitHashes (x `Set.difference` x')
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+-- | Extract the witness hashes from the Witness set.
 witsFromWitnessSet ::
   forall era tx body wits txout.
   (CoreUtxow era tx body wits txout) =>
@@ -839,19 +840,11 @@ witsFromWitnessSet wits =
     Set.map witKeyHash (addrWit wits)
       `Set.union` Set.map bootstrapWitKeyHash (bootWit wits)
 
-{- TODO DELETE ME
--- | Extract the witness hashes from the Witness set.
-witsFromWitnessSet ::
-  (Era era, Core.AnnotatedData (Core.Script era)) =>
-  WitnessSet era ->
-  WitHashes (Crypto era)
-witsFromWitnessSet (WitnessSet aWits _ bsWits) =
-  WitHashes $
-    Set.map witKeyHash aWits
-      `Set.union` Set.map bootstrapWitKeyHash bsWits
--}
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+-- | Collect the set of hashes of keys that needs to sign a
+--  given transaction. This set consists of the txin owners,
+--  certificate authors, and withdrawal reward accounts.
 witsVKeyNeeded ::
   forall era tx body wits txout.
   CoreUtxow era tx body wits txout =>
@@ -908,77 +901,9 @@ witsVKeyNeeded utxo' tx genDelegs =
     updateKeys :: Set (KeyHash 'Witness (Crypto era))
     updateKeys = asWitness `Set.map` propWits @era (updateBody txbody) genDelegs
 
-{- TODO DELETE ME
--- | Collect the set of hashes of keys that needs to sign a
---  given transaction. This set consists of the txin owners,
---  certificate authors, and withdrawal reward accounts.
-witsVKeyNeeded ::
-  forall era.
-  ( Era era,
-    UsesAuxiliary era,
-    UsesTxBody era,
-    UsesTxOut era,
-    UsesScript era,
-    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
-  ) =>
-  UTxO era ->
-  Tx era ->
-  GenDelegs (Crypto era) ->
-  WitHashes (Crypto era)
-witsVKeyNeeded utxo' tx@(Tx txbody _ _) genDelegs =
-  WitHashes $
-    certAuthors
-      `Set.union` inputAuthors
-      `Set.union` owners
-      `Set.union` wdrlAuthors
-      `Set.union` updateKeys
-  where
-    inputAuthors :: Set (KeyHash 'Witness (Crypto era))
-    inputAuthors = foldr accum Set.empty (getField @"inputs" txbody)
-      where
-        accum txin ans =
-          case txinLookup txin utxo' of
-            Just out ->
-              case getField @"address" out of
-                Addr _ (KeyHashObj pay) _ -> Set.insert (asWitness pay) ans
-                AddrBootstrap bootAddr ->
-                  Set.insert (asWitness (bootstrapKeyHash bootAddr)) ans
-                _ -> ans
-            Nothing -> ans
 
-    wdrlAuthors :: Set (KeyHash 'Witness (Crypto era))
-    wdrlAuthors = Map.foldrWithKey accum Set.empty (unWdrl (getField @"wdrls" txbody))
-      where
-        accum key _ ans = Set.union (extractKeyHashWitnessSet [getRwdCred key]) ans
-    owners :: Set (KeyHash 'Witness (Crypto era))
-    owners = foldr accum Set.empty (getField @"certs" txbody)
-      where
-        accum (DCertPool (RegPool pool)) ans =
-          Set.union
-            (Set.map asWitness (_poolOwners pool))
-            ans
-        accum _cert ans = ans
-    cwitness (DCertDeleg dc) = extractKeyHashWitnessSet [delegCWitness dc]
-    cwitness (DCertPool pc) = extractKeyHashWitnessSet [poolCWitness pc]
-    cwitness (DCertGenesis gc) = Set.singleton (asWitness $ genesisCWitness gc)
-    cwitness c = error $ show c ++ " does not have a witness"
-    -- key reg requires no witness but this is already filtered outby requiresVKeyWitness
-    -- before the call to `cwitness`, so this error should never be reached.
-
-    certAuthors :: Set (KeyHash 'Witness (Crypto era))
-    certAuthors = foldr accum Set.empty (getField @"certs" txbody)
-      where
-        accum cert ans | requiresVKeyWitness cert = Set.union (cwitness cert) ans
-        accum _cert ans = ans
-    updateKeys :: Set (KeyHash 'Witness (Crypto era))
-    updateKeys = asWitness `Set.map` propWits (maybeToStrictMaybe(txup tx)) genDelegs
--}
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
-
 -- | Given a ledger state, determine if the UTxO witnesses in a given
 --  transaction are correct.
 verifiedWits ::
@@ -1008,35 +933,6 @@ verifiedWits tx =
           (not . verifyBootstrapWit (extractHash (hashAnnotated @(Crypto era) txbody)))
           (Set.toList $ bootWit wits)
 
-{- TODO DELETE ME
--- | Given a ledger state, determine if the UTxO witnesses in a given
---  transaction are correct.
-verifiedWits ::
-  forall era.
-  ( UsesTxBody era,
-    Core.AnnotatedData (Core.Script era),
-    ToCBOR (Core.AuxiliaryData era),
-    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody)
-  ) =>
-  Tx era ->
-  Either [VKey 'Witness (Crypto era)] ()
-verifiedWits (Tx txbody wits _) =
-  case (failed <> failedBootstrap) of
-    [] -> Right ()
-    nonEmpty -> Left nonEmpty
-  where
-    wvkKey (WitVKey k _) = k
-    failed =
-      wvkKey
-        <$> filter
-          (not . verifyWitVKey (extractHash (hashAnnotated @(Crypto era) txbody)))
-          (Set.toList $ addrWits wits)
-    failedBootstrap =
-      bwKey
-        <$> filter
-          (not . verifyBootstrapWit (extractHash (hashAnnotated @(Crypto era) txbody)))
-          (Set.toList $ bootWits wits)
--}
 
 -- | Calculate the set of hash keys of the required witnesses for update
 -- proposals.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -829,6 +829,7 @@ diffWitHashes (WitHashes x) (WitHashes x') =
   WitHashes (x `Set.difference` x')
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+
 -- | Extract the witness hashes from the Witness set.
 witsFromWitnessSet ::
   forall era tx body wits txout.
@@ -840,8 +841,8 @@ witsFromWitnessSet wits =
     Set.map witKeyHash (addrWit wits)
       `Set.union` Set.map bootstrapWitKeyHash (bootWit wits)
 
-
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+
 -- | Collect the set of hashes of keys that needs to sign a
 --  given transaction. This set consists of the txin owners,
 --  certificate authors, and withdrawal reward accounts.
@@ -901,9 +902,8 @@ witsVKeyNeeded utxo' tx genDelegs =
     updateKeys :: Set (KeyHash 'Witness (Crypto era))
     updateKeys = asWitness `Set.map` propWits @era (updateBody txbody) genDelegs
 
-
-
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+
 -- | Given a ledger state, determine if the UTxO witnesses in a given
 --  transaction are correct.
 verifiedWits ::
@@ -932,7 +932,6 @@ verifiedWits tx =
         <$> filter
           (not . verifyBootstrapWit (extractHash (hashAnnotated @(Crypto era) txbody)))
           (Set.toList $ bootWit wits)
-
 
 -- | Calculate the set of hash keys of the required witnesses for update
 -- proposals.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -322,6 +322,7 @@ scriptCred (KeyHashObj _) = Nothing
 scriptCred (ScriptHashObj hs) = Just hs
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+
 -- | Computes the set of script hashes required to unlock the transcation inputs
 -- and the withdrawals.
 scriptsNeeded ::
@@ -351,6 +352,7 @@ scriptsNeeded u tx =
     certificates = (toList . certsBody) txb
 
 -- This function has only one use in Shelley.Spec.Ledger.STS.Utxow
+
 -- | Compute the subset of inputs of the set 'txInps' for which each input is
 -- locked by a script in the UTxO 'u'.
 txinsScript ::


### PR DESCRIPTION
By collecting the appropriate operations into one class (CoreUtxow era tx body wit txout)
which allows each Era to choose different data types for Tx, TxBody WitnessSet and TxOut
and then supplying the 13 opertaions sufficient to generalize the Utxow rule. Instances
are given for all known Eras: Shelley, Allegra, Mary, and Alonzo."
