### PR TITLE
Added constraint free selectors in Alonzo era.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -23,7 +23,16 @@ module Cardano.Ledger.Alonzo.Data
     DataHash,
     hashData,
     -- $
-    AuxiliaryData (AuxiliaryData, scripts, dats, txMD),
+    AuxiliaryData
+      ( AuxiliaryData,
+        scripts,
+        dats,
+        txMD,
+        AuxiliaryData',
+        scripts',
+        dats',
+        txMD'
+      ),
     AuxiliaryDataHash,
     -- $
     ppPlutusData,
@@ -128,9 +137,9 @@ hashData d = hashAnnotated d
 -- Version without serialized bytes
 
 data AuxiliaryDataRaw era = AuxiliaryDataRaw
-  { scripts' :: Set (Core.Script era),
-    dats' :: Set (Data era),
-    txMD' :: Set (Metadata)
+  { scriptsR :: Set (Core.Script era),
+    datsR :: Set (Data era),
+    txMDR :: Set (Metadata)
   }
   deriving (Generic)
 
@@ -202,6 +211,16 @@ deriving via
       FromCBOR (Annotator (Core.Script era))
     ) =>
     FromCBOR (Annotator (AuxiliaryData era))
+
+pattern AuxiliaryData' ::
+  Set (Core.Script era) ->
+  Set (Data era) ->
+  Set (Metadata) ->
+  AuxiliaryData era
+pattern AuxiliaryData' {scripts', dats', txMD'} <-
+  AuxiliaryDataConstr (Memo (AuxiliaryDataRaw scripts' dats' txMD') _)
+
+{-# COMPLETE AuxiliaryData' #-}
 
 pattern AuxiliaryData ::
   (Era era, ToCBOR (Core.Script era), Ord (Core.Script era)) =>

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -33,7 +33,21 @@ module Cardano.Ledger.Alonzo.TxBody
         mint,
         exunits,
         sdHash,
-        scriptHash
+        scriptHash,
+        TxBody',
+        txinputs',
+        txinputs_fee',
+        txouts',
+        txcerts',
+        txwdrls',
+        txfee',
+        txvldt',
+        txUpdates',
+        txADhash',
+        mint',
+        exunits',
+        sdHash',
+        scriptHash'
       ),
     AlonzoBody,
     EraIndependentWitnessPPData,
@@ -228,6 +242,60 @@ deriving via
     ) =>
     FromCBOR (Annotator (TxBody era))
 
+-- | Defines primed selectors for TxBody, without (AlonzoBody era) constraints
+--  needed for constrauction, but not for accessing fields.
+pattern TxBody' ::
+  Set (TxIn (Crypto era)) ->
+  Set (TxIn (Crypto era)) ->
+  StrictSeq (TxOut era) ->
+  StrictSeq (DCert (Crypto era)) ->
+  Wdrl (Crypto era) ->
+  Coin ->
+  ValidityInterval ->
+  StrictMaybe (Update era) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  Value (Crypto era) ->
+  ExUnits ->
+  StrictMaybe (WitnessPPDataHash (Crypto era)) ->
+  StrictMaybe (AuxiliaryDataHash (Crypto era)) ->
+  TxBody era
+pattern TxBody'
+  { txinputs',
+    txinputs_fee',
+    txouts',
+    txcerts',
+    txwdrls',
+    txfee',
+    txvldt',
+    txUpdates',
+    txADhash',
+    mint',
+    exunits',
+    sdHash',
+    scriptHash'
+  } <-
+  TxBodyConstr
+    ( Memo
+        TxBodyRaw
+          { _inputs = txinputs',
+            _inputs_fee = txinputs_fee',
+            _outputs = txouts',
+            _certs = txcerts',
+            _wdrls = txwdrls',
+            _txfee = txfee',
+            _vldt = txvldt',
+            _update = txUpdates',
+            _adHash = txADhash',
+            _mint = mint',
+            _exunits = exunits',
+            _sdHash = sdHash',
+            _scriptHash = scriptHash'
+          }
+        _
+      )
+
+{-# COMPLETE TxBody' #-}
+
 -- The Set of constraints necessary to use the TxBody pattern
 type AlonzoBody era =
   ( Era era,
@@ -288,36 +356,36 @@ pattern TxBody
       )
   where
     TxBody
-      inputs'
-      inputs_fee'
-      outputs'
-      certs'
-      wdrls'
-      txfee'
-      vldt'
-      update'
-      adHash'
-      mint'
-      exunits'
-      sdHash'
-      scriptHash' =
+      inputsX
+      inputs_feeX
+      outputsX
+      certsX
+      wdrlsX
+      txfeeX
+      vldtX
+      updateX
+      adHashX
+      mintX
+      exunitsX
+      sdHashX
+      scriptHashX =
         TxBodyConstr $
           memoBytes
             ( encodeTxBodyRaw $
                 TxBodyRaw
-                  inputs'
-                  inputs_fee'
-                  outputs'
-                  certs'
-                  wdrls'
-                  txfee'
-                  vldt'
-                  update'
-                  adHash'
-                  mint'
-                  exunits'
-                  sdHash'
-                  scriptHash'
+                  inputsX
+                  inputs_feeX
+                  outputsX
+                  certsX
+                  wdrlsX
+                  txfeeX
+                  vldtX
+                  updateX
+                  adHashX
+                  mintX
+                  exunitsX
+                  sdHashX
+                  scriptHashX
             )
 
 {-# COMPLETE TxBody #-}

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -20,7 +20,20 @@
 
 module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
-    TxWitness (TxWitness, txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs),
+    TxWitness
+      ( TxWitness,
+        txwitsVKey,
+        txwitsBoot,
+        txscripts,
+        txdats,
+        txrdmrs,
+        TxWitness',
+        txwitsVKey',
+        txwitsBoot',
+        txscripts',
+        txdats',
+        txrdmrs'
+      ),
     ppRdmrPtr,
     ppTxWitness,
   )
@@ -132,6 +145,21 @@ deriving newtype instance
 
 -- =====================================================
 -- Pattern for TxWitness
+
+-- | Defines primed selectors without  ToCBOR (Core.Script era) constraints
+--  needed for construction, but not for accessing fields.
+pattern TxWitness' ::
+  Set (WitVKey 'Witness (Crypto era)) ->
+  Set (BootstrapWitness (Crypto era)) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
+  Map (DataHash (Crypto era)) (Data era) ->
+  Map RdmrPtr (Data era, ExUnits) ->
+  TxWitness era
+pattern TxWitness' {txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'} <-
+  TxWitnessConstr
+    (Memo (TxWitnessRaw txwitsVKey' txwitsBoot' txscripts' txdats' txrdmrs') _)
+
+{-# COMPLETE TxWitness' #-}
 
 pattern TxWitness ::
   (Era era, ToCBOR (Core.Script era)) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -55,8 +55,8 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
 import Cardano.Ledger.Era
 import Cardano.Ledger.SafeHash (SafeHash, extractHash, hashAnnotated)
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut, UsesValue)
-import Cardano.Ledger.Val ((<+>), (<×>))
+import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut)
+import Cardano.Ledger.Val (Val (zero, (<+>), (<×>)))
 import Control.DeepSeq (NFData)
 import Control.Iterate.SetAlgebra
   ( BaseRep (MapR),
@@ -256,14 +256,14 @@ makeWitnessesFromScriptKeys txbodyHash hashKeyMap scriptHashes =
   let witKeys = Map.restrictKeys hashKeyMap scriptHashes
    in makeWitnessesVKey txbodyHash (Map.elems witKeys)
 
--- | Determine the total balance contained in the UTxO.
+-- | Determine the total balance contained in the UTxO. Use minimal constraints
 balance ::
-  ( UsesValue era,
-    UsesTxOut era
+  ( Val (Core.Value era),
+    HasField "value" (Core.TxOut era) (Core.Value era)
   ) =>
   UTxO era ->
   Core.Value era
-balance (UTxO utxo) = Map.foldl' addTxOuts mempty utxo
+balance (UTxO utxo) = Map.foldl' addTxOuts zero utxo
   where
     addTxOuts !b out = (getField @"value" out) <+> b
 


### PR DESCRIPTION
This PR replaces "Removes excess constraints from selector functions defined by patterns"  #2158 which will be closed.  This PR applies those transformations only in the Alonzo era (as opposed to all eras). The transformation used in this PR is slightly different, but more useful.  Live and learn my mother always told me.

The Alonzo Era has a number of patterns that introduce selectors that
have unnecessary constraints. The GHC pattern for these types must serialize
arguments to construct a Memoized bytestring. Selectors decompose already constructed
objects and do not need these constraints, which the GHC pattern construct imposes.

For each pattern
pattern T :: Foo a => a -> b -> T
pattern T {a, b} <- TRaw a b where ...

we create an additional pattern, which primes the constructor and selectors.
pattern T' :: a -> b -> T
pattern T' {a', b'} <- TRaw a b

Thus selectors: a' and b' do not have the unnecceasary Foo constraint.
The module exports are also revised from:
T(T,a,b)   to   T(T,a,b,T',a',b').

By replacing many a with a', many functions have fewer constraints.
This commit handles all such cases in the Alonzo era code.

We had to lessen the constraints on the function
Shelley.Spec.Ledger.UTxO(balance) which was heavily over-constrained.
This required changing a few lines in only that file, since 'balance'
is now less-constrained it is still useable at all its old call sites.