### PR TITLE
remove exunits from txbody

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -368,7 +368,7 @@ feesOK ::
     UsesTxOut era,
     ValidateScript era,
     HasField "txfee" (Core.TxBody era) Coin,
-    ToCBOR (Core.AuxiliaryData era)
+    ToCBOR (Core.AuxiliaryData era),
     HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   PParams era ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -371,7 +371,7 @@ feesOK ::
     ToCBOR (Core.AuxiliaryData era),
     HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "wits" (Tx era) (TxWitness era),
-    HasField "txrdmrs" (TxWitness era) (Map RdmrPtr (Data era, ExUnits))
+    HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))
   ) =>
   PParams era ->
   Tx era ->
@@ -403,7 +403,7 @@ txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 minfee ::
   (Era era, ToCBOR (Core.AuxiliaryData era),
   HasField "wits" (Tx era) (TxWitness era),
-  HasField "txrdmrs" (TxWitness era) (Map RdmrPtr (Data era, ExUnits))) =>
+  HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))) =>
   PParams era ->
   Tx era ->
   Coin

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -368,7 +368,6 @@ feesOK ::
     UsesTxOut era,
     ValidateScript era,
     HasField "txfee" (Core.TxBody era) Coin,
-    ToCBOR (Core.AuxiliaryData era),
     HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "wits" (Tx era) (TxWitness era),
     HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))
@@ -401,9 +400,7 @@ txsize :: Tx era -> Integer
 txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
 minfee ::
-  ( Era era,
-    ToCBOR (Core.AuxiliaryData era),
-    HasField "wits" (Tx era) (TxWitness era),
+  ( HasField "wits" (Tx era) (TxWitness era),
     HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))
   ) =>
   PParams era ->
@@ -417,8 +414,7 @@ minfee pp tx =
     a protparam = Coin (fromIntegral (_minfeeA protparam))
     b protparam = Coin (fromIntegral (_minfeeB protparam))
     totExunits = foldl (<>) mempty (snd $ unzip (Map.elems trd))
-    trd = getField @"txrdmrs" txw
-    txw = getField @"wits" tx
+    trd = getField @"txrdmrs" (getField @"wits" tx)
 
 -- The specification uses "validatorHash" to extract ScriptHash from
 -- an Addr. But not every Addr has a ScriptHash. In particular KeyHashObj

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -398,7 +398,7 @@ txins txb = Set.union (getField @"inputs" txb) (getField @"txinputs_fee" txb)
 txsize :: Tx era -> Integer
 txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
-minfee :: (AlonzoBody era, ToCBOR (Core.AuxiliaryData era)) => PParams era -> Tx era -> Coin
+minfee :: 
   ( ToCBOR (Core.AuxiliaryData era)
   ) =>
   PParams era ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -369,7 +369,9 @@ feesOK ::
     ValidateScript era,
     HasField "txfee" (Core.TxBody era) Coin,
     ToCBOR (Core.AuxiliaryData era),
-    HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era)))
+    HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "wits" (Tx era) (TxWitness era),
+    HasField "txrdmrs" (TxWitness era) (Map RdmrPtr (Data era, ExUnits))
   ) =>
   PParams era ->
   Tx era ->
@@ -399,7 +401,9 @@ txsize :: Tx era -> Integer
 txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
 minfee ::
-  (Era era, ToCBOR (Core.AuxiliaryData era)) =>
+  (Era era, ToCBOR (Core.AuxiliaryData era),
+  HasField "wits" (Tx era) (TxWitness era),
+  HasField "txrdmrs" (TxWitness era) (Map RdmrPtr (Data era, ExUnits))) =>
   PParams era ->
   Tx era ->
   Coin
@@ -410,7 +414,9 @@ minfee pp tx =
   where
     a protparam = Coin (fromIntegral (_minfeeA protparam))
     b protparam = Coin (fromIntegral (_minfeeB protparam))
-    totExunits = foldl (<>) mempty (snd $ unzip (Map.elems (txrdmrs . txwits $ tx)))
+    totExunits = foldl (<>) mempty (snd $ unzip (Map.elems trd))
+    trd = getField @"txrdmrs" txw
+    txw = getField @"wits" tx
 
 -- The specification uses "validatorHash" to extract ScriptHash from
 -- an Addr. But not every Addr has a ScriptHash. In particular KeyHashObj

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -398,9 +398,8 @@ txins txb = Set.union (getField @"inputs" txb) (getField @"txinputs_fee" txb)
 txsize :: Tx era -> Integer
 txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
-minfee :: 
-  ( ToCBOR (Core.AuxiliaryData era)
-  ) =>
+minfee ::
+  (Era era, ToCBOR (Core.AuxiliaryData era)) =>
   PParams era ->
   Tx era ->
   Coin

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -401,9 +401,11 @@ txsize :: Tx era -> Integer
 txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
 minfee ::
-  (Era era, ToCBOR (Core.AuxiliaryData era),
-  HasField "wits" (Tx era) (TxWitness era),
-  HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))) =>
+  ( Era era,
+    ToCBOR (Core.AuxiliaryData era),
+    HasField "wits" (Tx era) (TxWitness era),
+    HasField "txrdmrs" (TxWitness era) (Map.Map RdmrPtr (Data era, ExUnits))
+  ) =>
   PParams era ->
   Tx era ->
   Coin

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -31,7 +31,7 @@ module Cardano.Ledger.Alonzo.TxBody
         txUpdates,
         mint,
         sdHash,
-        auxdHash
+        adHash
       ),
     AlonzoBody,
     EraIndependentWitnessPPData,
@@ -163,7 +163,7 @@ data TxBodyRaw era = TxBodyRaw
     -- Cardano.Ledger.Mary.Value.Value, not a Core.Value.
     -- Operations on the TxBody in the AlonzoEra depend upon this.
     _sdHash :: !(StrictMaybe (WitnessPPDataHash (Crypto era))),
-    _auxdHash :: !(StrictMaybe (AuxiliaryDataHash (Crypto era)))
+    _adHash :: !(StrictMaybe (AuxiliaryDataHash (Crypto era)))
   }
   deriving (Generic, Typeable)
 
@@ -257,7 +257,7 @@ pattern TxBody
     txUpdates,
     mint,
     sdHash,
-    auxdHash
+    adHash
   } <-
   TxBodyConstr
     ( Memo
@@ -272,7 +272,7 @@ pattern TxBody
             _update = txUpdates,
             _mint = mint,
             _sdHash = sdHash,
-            _auxdHash = auxdHash
+            _adHash = adHash
           }
         _
       )
@@ -288,7 +288,7 @@ pattern TxBody
       update'
       mint'
       sdHash'
-      auxdHash' =
+      adHash' =
         TxBodyConstr $
           memoBytes
             ( encodeTxBodyRaw $
@@ -303,7 +303,7 @@ pattern TxBody
                   update'
                   mint'
                   sdHash'
-                  auxdHash'
+                  adHash'
             )
 
 {-# COMPLETE TxBody #-}
@@ -363,7 +363,7 @@ encodeTxBodyRaw
       _update,
       _mint,
       _sdHash,
-      _auxdHash
+      _adHash
     } =
     Keyed
       ( \i ifee o f t c w u b mi sh ah ->
@@ -380,7 +380,7 @@ encodeTxBodyRaw
       !> encodeKeyedStrictMaybe 8 bot
       !> Omit isZero (Key 9 (E encodeMint _mint))
       !> encodeKeyedStrictMaybe 11 _sdHash
-      !> encodeKeyedStrictMaybe 12 _auxdHash
+      !> encodeKeyedStrictMaybe 12 _adHash
     where
       encodeKeyedStrictMaybe key x =
         Omit isSNothing (Key key (E (toCBOR . fromSJust) x))
@@ -461,7 +461,7 @@ instance
       bodyFields 11 = fieldA (\x tx -> tx {_sdHash = x}) (D (SJust <$> fromCBOR))
       bodyFields 12 =
         fieldA
-          (\x tx -> tx {_auxdHash = x})
+          (\x tx -> tx {_adHash = x})
           (D (SJust <$> fromCBOR))
       bodyFields n = fieldA (\_ t -> t) (Invalid n)
       requiredFields =
@@ -544,7 +544,7 @@ ppTxBody (TxBodyConstr (Memo (TxBodyRaw i ifee o c w fee vi u mnt sdh axh) _)) =
       ("update", ppStrictMaybe ppUpdate u),
       ("mint", ppValue mnt),
       ("sdHash", ppStrictMaybe ppSafeHash sdh),
-      ("auxdHash", ppStrictMaybe ppSafeHash axh)
+      ("adHash", ppStrictMaybe ppSafeHash axh)
     ]
 
 instance

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -544,7 +544,7 @@ ppTxBody (TxBodyConstr (Memo (TxBodyRaw i ifee o c w fee vi u mnt sdh axh) _)) =
       ("update", ppStrictMaybe ppUpdate u),
       ("mint", ppValue mnt),
       ("sdHash", ppStrictMaybe ppSafeHash sdh),
-      ("auxdHash", ppStrictMaybe ppSafeHash sch)
+      ("auxdHash", ppStrictMaybe ppSafeHash axh)
     ]
 
 instance

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -123,7 +123,6 @@ instance
       <*> genMintValues @c
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
 
 deriving newtype instance Arbitrary IsValidating
 

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -119,7 +119,6 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
       <*> genMintValues @c
       <*> arbitrary
       <*> arbitrary


### PR DESCRIPTION
- removing `ExUnits` field in the body of the tx because they are already tracked in the indexed redeemer structure inside the witness section of the transaction
- removing `adHash` from the body because the body contained 2 hashes of auxiliary data, and only needs 1, and renaming `scriptHash` (the other aux. data hash) to `auxdHash` to match the order in the spec