### PR TITLE
Added the Utxo rule in the Alonzo era.

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -24,6 +24,7 @@ library
     Cardano.Ledger.Alonzo.Data
     Cardano.Ledger.Alonzo.Language
     Cardano.Ledger.Alonzo.PParams
+    Cardano.Ledger.Alonzo.Rules.Utxo
     Cardano.Ledger.Alonzo.Rules.Utxos
     Cardano.Ledger.Alonzo.Scripts
     Cardano.Ledger.Alonzo.Tx
@@ -36,6 +37,7 @@ library
     cardano-crypto-class,
     cardano-ledger-shelley-ma,
     cardano-prelude,
+    cardano-slotting,
     containers,
     data-default,
     deepseq,
@@ -44,7 +46,8 @@ library
     plutus-tx,
     shelley-spec-ledger,
     small-steps,
-    text
+    text,
+    transformers
   hs-source-dirs:
     src
   ghc-options:

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -1,0 +1,512 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Alonzo.Rules.Utxo where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+import Cardano.Ledger.Alonzo.Rules.Utxos (UTXOS, UtxosPredicateFailure)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices)
+import Cardano.Ledger.Alonzo.Tx
+  ( Tx (..),
+    isNonNativeScriptAddress,
+    minfee,
+    txbody,
+  )
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo (Tx)
+import Cardano.Ledger.Alonzo.TxBody
+  ( TxOut (..),
+  )
+import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody, TxOut)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era)
+import qualified Cardano.Ledger.Mary.Value as Alonzo (Value)
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesPParams,
+  )
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed, scaledMinDeposit)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), inInterval)
+import Cardano.Ledger.Val (coin, (<×>))
+import qualified Cardano.Ledger.Val as Val
+import Cardano.Slotting.Slot (SlotNo)
+import Control.Iterate.SetAlgebra (dom, eval, (⊆), (◁), (➖))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition.Extended
+import qualified Data.ByteString.Lazy as BSL (length)
+import Data.Coders
+  ( Decode (..),
+    Encode (..),
+    Wrapped (Open),
+    decode,
+    decodeList,
+    decodeSet,
+    encode,
+    encodeFoldable,
+    (!>),
+    (<!),
+  )
+import Data.Coerce (coerce)
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import GHC.Int (Int64)
+import GHC.Records
+import NoThunks.Class (NoThunks)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.Address
+  ( Addr (AddrBootstrap),
+    RewardAcnt,
+    bootstrapAddressAttrsSize,
+    getNetwork,
+    getRwdNetwork,
+  )
+import Shelley.Spec.Ledger.BaseTypes
+  ( Network,
+    ShelleyBase,
+    networkId,
+  )
+import Shelley.Spec.Ledger.Coin
+import qualified Shelley.Spec.Ledger.LedgerState as Shelley
+import qualified Shelley.Spec.Ledger.STS.Utxo as Shelley
+import Shelley.Spec.Ledger.Tx (TxIn, ValidateScript)
+import Shelley.Spec.Ledger.TxBody (unWdrl)
+import Shelley.Spec.Ledger.UTxO
+  ( UTxO (..),
+    balance,
+    txins,
+    txouts,
+    unUTxO,
+  )
+
+-- | Compute an estimate of the size of storing one UTxO entry.
+--
+-- We need to estimate the size of storing 1 extra entry in the UTxO
+-- @type UTxO = Map (TxIn (Crypto era)) (TxOut era)@
+-- TxIn = (SafeHash,Word64), so sizeTxIn = sizeSafeHash + 8 bytes
+-- So one extra entry adds ( sizeSafeHash + 8 + sizeTxOut + mapOverhead )
+-- All this is computed by outputSize. Remember this is an estimate that
+-- just needs to be proportional to the actual size.
+outputSize :: Era era => TxOut era -> Int64
+outputSize txout = sizeSafeHash + 8 + BSL.length (serialize txout) + mapOverhead
+  where
+    sizeSafeHash = 36
+    mapOverhead = 14
+
+-- ============================================
+
+-- | The uninhabited type that marks the Alonzo UTxO rule
+data AlonzoUTXO era
+
+-- ==========================================================
+
+data UtxoPredicateFailure era
+  = -- | The bad transaction inputs
+    BadInputsUTxO
+      !(Set (TxIn (Crypto era)))
+  | OutsideValidityIntervalUTxO
+      !ValidityInterval
+      -- ^ transaction's validity interval
+      !SlotNo
+      -- ^ current slot
+  | MaxTxSizeUTxO
+      !Integer
+      -- ^ the actual transaction size
+      !Integer
+      -- ^ the max transaction size
+  | InputSetEmptyUTxO
+  | FeeTooSmallUTxO
+      !Coin
+      -- ^ the minimum fee for this transaction
+      !Coin
+      -- ^ the fee supplied in this transaction
+  | ValueNotConservedUTxO
+      !(Core.Value era)
+      -- ^ the Coin consumed by this transaction
+      !(Core.Value era)
+      -- ^ the Coin produced by this transaction
+  | -- | the set of addresses with incorrect network IDs
+    WrongNetwork
+      !Network -- the expected network id
+      !(Set (Addr (Crypto era)))
+  | WrongNetworkWithdrawal
+      !Network
+      -- ^ the expected network id
+      !(Set (RewardAcnt (Crypto era)))
+      -- ^ the set of reward addresses with incorrect network IDs
+  | -- | list of supplied transaction outputs that are too small
+    OutputTooSmallUTxO
+      ![Core.TxOut era]
+  | -- | Subtransition Failures
+    UtxosFailure (PredicateFailure (Core.EraRule "UTXOS" era))
+  | -- | list of supplied bad transaction outputs
+    OutputBootAddrAttrsTooBig
+      ![Core.TxOut era]
+  | TriesToForgeADA
+  | -- | list of supplied bad transaction outputs
+    OutputTooBigUTxO
+      ![Core.TxOut era]
+  | FeeNotBalancedUTxO
+      !Coin
+      -- ^ balance computed
+      !Coin
+      -- ^ the fee supplied in this transaction
+  | -- | The UTxO entries which have the wrong kind of script
+    ScriptsNotPaidUTxO
+      !(UTxO era)
+  | ExUnitsTooSmallUTxO
+      !ExUnits
+      -- ^ Max EXUnits from the protocol parameters
+      !ExUnits
+      -- ^ EXUnits supplied
+  | -- | The inputs marked for use as fees contain non-ADA tokens
+    FeeContainsNonADA !(Core.Value era)
+  deriving (Generic)
+
+deriving stock instance
+  ( Era era,
+    Show (Core.Value era),
+    Show (Core.TxOut era),
+    Show (Core.TxBody era),
+    Show (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  Show (UtxoPredicateFailure era)
+
+deriving stock instance
+  ( Eq (Core.Value era),
+    Eq (Core.TxOut era),
+    Eq (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  Eq (UtxoPredicateFailure era)
+
+instance
+  ( Era era,
+    Shelley.TransUTxOState NoThunks era,
+    NoThunks (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  NoThunks (UtxoPredicateFailure era)
+
+-- | feesOK is a predicate with 4 parts:
+--   - Check that the fee is greater than the minimum fee for the transaction
+--   - The fee inputs do not belong to non-native script addresses
+--   - The fee inputs are sufficient to cover the fee marked in the transaction
+--   - The fee inputs do not contain any non-ADA part
+--
+--   As a TransitionRule it will return (), and raise an error (rather than
+--   return) if any of the 4 parts are False.
+feesOK ::
+  forall era.
+  ( Era era,
+    ValidateScript era, -- isNonNativeScriptAddress
+    Core.TxOut era ~ Alonzo.TxOut era, -- balance requires this,
+    HasField "totExunits" (Core.Tx era) ExUnits, -- minfee requires this
+    HasField
+      "txinputs_fee" -- to get inputs to pay the fees
+      (Core.TxBody era)
+      (Set (TxIn (Crypto era))),
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minfeeB" (Core.PParams era) Natural,
+    HasField "_prices" (Core.PParams era) Prices
+  ) =>
+  Core.PParams era ->
+  Core.Tx era ->
+  UTxO era ->
+  Rule (AlonzoUTXO era) 'Transition ()
+feesOK pp tx (UTxO m) = do
+  let txb = getField @"body" tx
+      theFee = getField @"txfee" txb -- Coin supplied to pay fees
+      fees = getField @"txinputs_fee" txb -- Inputs allocated to pay theFee
+      utxoFees = eval (fees ◁ m) -- restrict Utxo to those inputs we use to pay fees.
+      bal = balance @era (UTxO utxoFees)
+      nonNative txout = isNonNativeScriptAddress @era tx (getField @"address" txout)
+      minimumFee = minfee @era pp tx
+  -- Part 1
+  (Val.coin bal >= theFee) ?! FeeNotBalancedUTxO (Val.coin bal) theFee
+  -- Part 2
+  not (any nonNative utxoFees) ?! ScriptsNotPaidUTxO (UTxO (Map.filter nonNative utxoFees))
+  -- Part 3
+  (minimumFee <= theFee) ?! FeeTooSmallUTxO minimumFee theFee
+  -- Part 4
+  Val.inject (Val.coin bal) == bal ?! FeeContainsNonADA bal
+  pure ()
+
+-- ================================================================
+
+-- | The UTxO transition rule for the Alonzo eras.
+utxoTransition ::
+  forall era.
+  ( Era era,
+    ValidateScript era,
+    -- instructions for calling UTXOS from AlonzoUTXO
+    Embed (Core.EraRule "UTXOS" era) (AlonzoUTXO era),
+    Environment (Core.EraRule "UTXOS" era) ~ Shelley.UtxoEnv era,
+    State (Core.EraRule "UTXOS" era) ~ Shelley.UTxOState era,
+    Signal (Core.EraRule "UTXOS" era) ~ Tx era,
+    -- We leave Core.PParams abstract
+    UsesPParams era,
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minfeeB" (Core.PParams era) Natural,
+    HasField "vldt" (Alonzo.TxBody era) ValidityInterval,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_minUTxOValue" (Core.PParams era) Coin,
+    HasField "_maxTxSize" (Core.PParams era) Natural,
+    HasField "_prices" (Core.PParams era) Prices,
+    HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
+    HasField "_adaPerUTxOByte" (Core.PParams era) Coin,
+    -- We fix Core.Tx, Core.Value, Core.TxBody, and Core.TxOut
+    Core.TxOut era ~ Alonzo.TxOut era,
+    Core.Value era ~ Alonzo.Value (Crypto era),
+    Core.TxBody era ~ Alonzo.TxBody era,
+    Core.TxOut era ~ Alonzo.TxOut era,
+    Core.Tx era ~ Alonzo.Tx era
+  ) =>
+  TransitionRule (AlonzoUTXO era)
+utxoTransition = do
+  TRC (Shelley.UtxoEnv slot pp stakepools _genDelegs, u, tx) <- judgmentContext
+  let Shelley.UTxOState utxo _deposits _fees _ppup = u
+
+  let txb = txbody tx
+
+  inInterval slot (getField @"vldt" txb)
+    ?! OutsideValidityIntervalUTxO (getField @"vldt" txb) slot
+
+  not (Set.null (txins @era txb)) ?! InputSetEmptyUTxO
+
+  feesOK pp tx utxo -- Generalizes the fee to small from earlier Era's
+  eval (txins @era txb ⊆ dom utxo)
+    ?! BadInputsUTxO (eval (txins @era txb ➖ dom utxo))
+
+  let consumed_ = consumed pp utxo txb
+      produced_ = Shelley.produced @era pp stakepools txb
+  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
+
+  -- Check that the mint field does not try to mint ADA. This is equivalent to
+  -- the check `adaPolicy ∉ supp mint tx` in the spec.
+  Val.coin (getField @"mint" txb) == Val.zero ?! TriesToForgeADA
+
+  let outputs = Map.elems $ unUTxO (txouts @era txb)
+      ok out =
+        coin (getField @"value" out)
+          >= (outputSize out <×> getField @"_adaPerUTxOByte" pp)
+      outputsTooBig = filter (not . ok) outputs
+  null outputsTooBig ?! OutputTooBigUTxO outputsTooBig
+
+  ni <- liftSTS $ asks networkId
+  let addrsWrongNetwork =
+        filter
+          (\a -> getNetwork a /= ni)
+          (fmap (getField @"address") $ toList $ getField @"outputs" txb)
+  null addrsWrongNetwork ?! WrongNetwork ni (Set.fromList addrsWrongNetwork)
+  let wdrlsWrongNetwork =
+        filter
+          (\a -> getRwdNetwork a /= ni)
+          (Map.keys . unWdrl . getField @"wdrls" $ txb)
+  null wdrlsWrongNetwork
+    ?! WrongNetworkWithdrawal
+      ni
+      (Set.fromList wdrlsWrongNetwork)
+
+  -- TODO remove this?
+  -- This came from the ShelleyMA eras, I don't think it applies here.
+  -- It does not appear in the Alonzo specification
+  let minUTxOValue = getField @"_minUTxOValue" pp
+      outputsTooSmall =
+        filter
+          ( \out ->
+              let v = getField @"value" out
+               in not $
+                    Val.pointwise
+                      (>=)
+                      v
+                      (Val.inject $ scaledMinDeposit v minUTxOValue)
+          )
+          outputs
+  null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
+
+  let maxTxSize_ = fromIntegral (getField @"_maxTxSize" pp)
+      txSize_ = getField @"txsize" tx
+  txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
+
+  let maxTxEx = getField @"_maxTxExUnits" pp
+      totExunits = getField @"totExunits" tx
+  totExunits <= maxTxEx ?! ExUnitsTooSmallUTxO maxTxEx totExunits
+
+  -- TODO remove this?
+  -- This came from the ShelleyMA eras, I don't think it applies here.
+  -- It does not appear in the Alonzo specification
+  -- Bootstrap (i.e. Byron) addresses have variable sized attributes in them.
+  -- It is important to limit their overall size.
+  let outputsAttrsTooBig =
+        filter
+          ( \out -> case getField @"address" out of
+              AddrBootstrap addr -> bootstrapAddressAttrsSize addr > 64
+              _ -> False
+          )
+          outputs
+  null outputsAttrsTooBig ?! OutputBootAddrAttrsTooBig outputsAttrsTooBig
+
+  trans @(Core.EraRule "UTXOS" era) =<< coerce <$> judgmentContext
+
+--------------------------------------------------------------------------------
+-- AlonzoUTXO STS
+--------------------------------------------------------------------------------
+
+instance
+  forall era.
+  ( ValidateScript era,
+    -- Instructions needed to call the UTXOS transition from this one.
+    Embed (Core.EraRule "UTXOS" era) (AlonzoUTXO era),
+    Environment (Core.EraRule "UTXOS" era) ~ Shelley.UtxoEnv era,
+    State (Core.EraRule "UTXOS" era) ~ Shelley.UTxOState era,
+    Signal (Core.EraRule "UTXOS" era) ~ Tx era,
+    -- We leave Core.PParams abstract
+    UsesPParams era,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minfeeB" (Core.PParams era) Natural,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_minUTxOValue" (Core.PParams era) Coin,
+    HasField "_maxTxSize" (Core.PParams era) Natural,
+    HasField "_prices" (Core.PParams era) Prices,
+    HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
+    HasField "_adaPerUTxOByte" (Core.PParams era) Coin,
+    -- We fix Core.Value, Core.TxBody, and Core.TxOut
+    Core.Value era ~ Alonzo.Value (Crypto era),
+    Core.TxBody era ~ Alonzo.TxBody era,
+    Core.TxOut era ~ Alonzo.TxOut era,
+    Core.Tx era ~ Alonzo.Tx era
+  ) =>
+  STS (AlonzoUTXO era)
+  where
+  type State (AlonzoUTXO era) = Shelley.UTxOState era
+  type Signal (AlonzoUTXO era) = Tx era
+  type
+    Environment (AlonzoUTXO era) =
+      Shelley.UtxoEnv era
+  type BaseM (AlonzoUTXO era) = ShelleyBase
+  type
+    PredicateFailure (AlonzoUTXO era) =
+      UtxoPredicateFailure era
+
+  initialRules = []
+  transitionRules = [utxoTransition]
+
+instance
+  ( Era era,
+    STS (UTXOS era),
+    PredicateFailure (Core.EraRule "UTXOS" era) ~ UtxosPredicateFailure era
+  ) =>
+  Embed (UTXOS era) (AlonzoUTXO era)
+  where
+  wrapFailed = UtxosFailure
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+instance
+  ( Typeable era,
+    Era era,
+    ToCBOR (Core.TxOut era),
+    ToCBOR (Core.Value era),
+    ToCBOR (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  ToCBOR (UtxoPredicateFailure era)
+  where
+  toCBOR x = encode (encFail x)
+
+encFail ::
+  forall era.
+  ( Era era,
+    ToCBOR (Core.TxOut era),
+    ToCBOR (Core.Value era),
+    ToCBOR (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  UtxoPredicateFailure era ->
+  Encode 'Open (UtxoPredicateFailure era)
+encFail (BadInputsUTxO ins) =
+  Sum (BadInputsUTxO @era) 0 !> E encodeFoldable ins
+encFail (OutsideValidityIntervalUTxO a b) =
+  Sum OutsideValidityIntervalUTxO 1 !> To a !> To b
+encFail (MaxTxSizeUTxO a b) =
+  Sum MaxTxSizeUTxO 2 !> To a !> To b
+encFail (InputSetEmptyUTxO) =
+  Sum InputSetEmptyUTxO 3
+encFail (FeeTooSmallUTxO a b) =
+  Sum FeeTooSmallUTxO 4 !> To a !> To b
+encFail (ValueNotConservedUTxO a b) =
+  Sum (ValueNotConservedUTxO @era) 5 !> To a !> To b
+encFail (OutputTooSmallUTxO outs) =
+  Sum (OutputTooSmallUTxO @era) 6 !> E encodeFoldable outs
+encFail (UtxosFailure a) =
+  Sum (UtxosFailure @era) 7 !> To a
+encFail (WrongNetwork right wrongs) =
+  Sum (WrongNetwork @era) 8 !> To right !> E encodeFoldable wrongs
+encFail (WrongNetworkWithdrawal right wrongs) =
+  Sum (WrongNetworkWithdrawal @era) 9 !> To right !> E encodeFoldable wrongs
+encFail (OutputBootAddrAttrsTooBig outs) =
+  Sum (OutputBootAddrAttrsTooBig @era) 10 !> E encodeFoldable outs
+encFail (TriesToForgeADA) =
+  Sum TriesToForgeADA 11
+encFail (OutputTooBigUTxO outs) =
+  Sum (OutputTooBigUTxO @era) 12 !> E encodeFoldable outs
+encFail (FeeNotBalancedUTxO a b) =
+  Sum FeeNotBalancedUTxO 13 !> To a !> To b
+encFail (ScriptsNotPaidUTxO a) =
+  Sum ScriptsNotPaidUTxO 14 !> To a
+encFail (ExUnitsTooSmallUTxO a b) =
+  Sum ExUnitsTooSmallUTxO 15 !> To a !> To b
+encFail (FeeContainsNonADA a) =
+  Sum FeeContainsNonADA 16 !> To a
+
+decFail ::
+  ( Era era,
+    FromCBOR (Core.TxOut era),
+    FromCBOR (Core.Value era),
+    FromCBOR (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  Word ->
+  Decode 'Open (UtxoPredicateFailure era)
+decFail 0 = SumD (BadInputsUTxO) <! D (decodeSet fromCBOR)
+decFail 1 = SumD OutsideValidityIntervalUTxO <! From <! From
+decFail 2 = SumD MaxTxSizeUTxO <! From <! From
+decFail 3 = SumD InputSetEmptyUTxO
+decFail 4 = SumD FeeTooSmallUTxO <! From <! From
+decFail 5 = SumD (ValueNotConservedUTxO) <! From <! From
+decFail 6 = SumD (OutputTooSmallUTxO) <! D (decodeList fromCBOR)
+decFail 7 = SumD (UtxosFailure) <! From
+decFail 8 = SumD (WrongNetwork) <! From <! D (decodeSet fromCBOR)
+decFail 9 = SumD (WrongNetworkWithdrawal) <! From <! D (decodeSet fromCBOR)
+decFail 10 = SumD (OutputBootAddrAttrsTooBig) <! D (decodeList fromCBOR)
+decFail 11 = SumD TriesToForgeADA
+decFail 12 = SumD (OutputTooBigUTxO) <! D (decodeList fromCBOR)
+decFail 13 = SumD FeeNotBalancedUTxO <! From <! From
+decFail 14 = SumD ScriptsNotPaidUTxO <! From
+decFail 15 = SumD ExUnitsTooSmallUTxO <! From <! From
+decFail 16 = SumD FeeContainsNonADA <! From
+decFail n = Invalid n
+
+instance
+  ( Era era,
+    FromCBOR (Core.TxOut era),
+    FromCBOR (Core.Value era),
+    FromCBOR (PredicateFailure (Core.EraRule "UTXOS" era))
+  ) =>
+  FromCBOR (UtxoPredicateFailure era)
+  where
+  fromCBOR = decode (Summands "UtxoPredicateFailure" decFail)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -44,6 +44,10 @@ module Cardano.Ledger.Alonzo.Tx
     WitnessPPDataHash,
     -- Figure 3
     Tx (Tx, body, wits, isValidating, auxiliaryData),
+    body',
+    wits',
+    isValidating',
+    auxiliaryData',
     TxBody (..),
     -- Figure 4
     ScriptPurpose (..),
@@ -52,7 +56,8 @@ module Cardano.Ledger.Alonzo.Tx
     txbody,
     minfee,
     isNonNativeScriptAddress,
-    feesOK,
+    -- txsize,
+    -- totExunits,
     txins,
     Shelley.txouts,
     -- Figure 6
@@ -79,8 +84,8 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
-import Cardano.Ledger.Alonzo.PParams (LangDepView (..), PParams, PParams' (..), getLanguageView)
-import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..), scriptfee)
+import Cardano.Ledger.Alonzo.PParams (LangDepView (..), PParams, getLanguageView)
+import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..), Prices, scriptfee)
 import qualified Cardano.Ledger.Alonzo.Scripts as AlonzoScript (Script (..), Tag (..))
 import Cardano.Ledger.Alonzo.TxBody
   ( EraIndependentWitnessPPData,
@@ -114,7 +119,6 @@ import Cardano.Ledger.SafeHash
   )
 import Cardano.Ledger.Shelley.Constraints
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, Val (coin, (<+>), (<×>)))
-import Control.SetAlgebra (eval, (◁))
 import qualified Data.ByteString.Short as SBS (length)
 import Data.Coders
 import Data.List (foldl')
@@ -136,15 +140,18 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks)
+import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.Address (Addr (..), RewardAcnt, getRwdCred)
+import Shelley.Spec.Ledger.Address.Bootstrap (BootstrapWitness)
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe, maybeToStrictMaybe, strictMaybeToMaybe)
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Credential (Credential (ScriptHashObj))
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert (..))
+import Shelley.Spec.Ledger.Keys (KeyRole (Witness))
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
 import Shelley.Spec.Ledger.Tx (ValidateScript (isNativeScript))
-import Shelley.Spec.Ledger.TxBody (DelegCert (..), Delegation (..), TxIn (..), Wdrl (..), unWdrl)
-import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
+import Shelley.Spec.Ledger.TxBody (DelegCert (..), Delegation (..), TxIn (..), Wdrl (..), WitVKey, unWdrl)
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
 import qualified Shelley.Spec.Ledger.UTxO as Shelley
 
 -- ===================================================
@@ -254,27 +261,49 @@ pattern Tx {body, wits, isValidating, auxiliaryData} <-
   where
     Tx b w v a = TxConstr $ memoBytes (encodeTxRaw $ TxRaw b w v a)
 
+-- We define these accessor functions manually, because if we define them using
+-- the record syntax in the Tx pattern, they inherit the constraints
+-- (Era era, ToCBOR (Core.AuxiliaryData era),ToCBOR (Core.TxBody era))
+-- constraint as a precondition. This is unnecessary, as one can see below.
+
+body' :: Tx era -> Core.TxBody era
+body' (TxConstr (Memo (TxRaw b _ _ _) _)) = b
+
+wits' :: Tx era -> TxWitness era
+wits' (TxConstr (Memo (TxRaw _ x _ _) _)) = x
+
+isValidating' :: Tx era -> IsValidating
+isValidating' (TxConstr (Memo (TxRaw _ _ x _) _)) = x
+
+auxiliaryData' :: Tx era -> StrictMaybe (Core.AuxiliaryData era)
+auxiliaryData' (TxConstr (Memo (TxRaw _ _ _ x) _)) = x
+
 -- ===================================
 -- WellFormed instances
 
 instance aux ~ (Core.AuxiliaryData era) => HasField "auxiliaryData" (Tx era) (StrictMaybe aux) where
-  getField (TxConstr (Memo (TxRaw _body _wits _ aux) _)) = aux
+  getField txr = auxiliaryData' txr
 
 instance (body ~ Core.TxBody era) => HasField "body" (Tx era) body where
-  getField (TxConstr (Memo (TxRaw bod _wits _ _aux) _)) = bod
-
---------------------------------------------------------------------------------
--- HasField instances for the Tx
---------------------------------------------------------------------------------
-
--- Note that we do not use the pattern synonym in these instances, since we
--- don't want to drag in the CBOR constraints.
+  getField txr = body' txr
 
 instance HasField "wits" (Tx era) (TxWitness era) where
-  getField (TxConstr (Memo txr _)) = _wits txr
+  getField txr = wits' txr
 
 instance HasField "isValidating" (Tx era) IsValidating where
-  getField (TxConstr (Memo txr _)) = _isValidating txr
+  getField txr = isValidating' txr
+
+instance c ~ (Crypto era) => HasField "addrWits" (Tx era) (Set (WitVKey 'Witness c)) where
+  getField (TxConstr (Memo (TxRaw _ x _ _) _)) = txwitsVKey' x
+
+instance
+  (c ~ (Crypto era), script ~ Core.Script era) =>
+  HasField "scriptWits" (Tx era) (Map.Map (ScriptHash c) script)
+  where
+  getField (TxConstr (Memo (TxRaw _ x _ _) _)) = txscripts' x
+
+instance c ~ (Crypto era) => HasField "bootWits" (Tx era) (Set (BootstrapWitness c)) where
+  getField (TxConstr (Memo (TxRaw _ x _ _) _)) = txwitsBoot' x
 
 -- =========================================================
 -- Figure 2: Definitions for Transactions
@@ -351,36 +380,17 @@ hashWitnessPPData pp langs rdmrs =
 
 isNonNativeScriptAddress ::
   forall era.
-  ValidateScript era =>
-  Tx era ->
+  (Era era, ValidateScript era) =>
+  Core.Tx era ->
   Addr (Crypto era) ->
   Bool
-isNonNativeScriptAddress (TxConstr (Memo (TxRaw {_wits = w}) _)) addr =
+isNonNativeScriptAddress tx addr =
   case getValidatorHash addr of
     Nothing -> False
     Just hash ->
-      case Map.lookup hash (txscripts w) of
+      case Map.lookup hash (getField @"scriptWits" tx) of
         Nothing -> False
         Just scr -> not (isNativeScript @era scr)
-
-feesOK ::
-  forall era.
-  ( ValidateScript era,
-    HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era)))
-  ) =>
-  PParams era ->
-  Tx era ->
-  UTxO era ->
-  Bool
-feesOK pp tx (UTxO m) =
-  (bal >= getField @"txfee" txb)
-    && all (not . isNonNativeScriptAddress tx . getField @"address") utxoFees
-    && (minfee pp tx <= getField @"txfee" txb)
-  where
-    txb = txbody tx
-    fees = getField @"txinputs_fee" txb
-    utxoFees = eval (fees ◁ m) -- compute the domain restriction to those inputs where fees are paid
-    bal = coin (balance @era (UTxO utxoFees))
 
 -- | The keys of all the inputs of the TxBody (both the inputs for fees, and the normal inputs).
 txins ::
@@ -392,22 +402,37 @@ txins ::
 txins txb = Set.union (getField @"inputs" txb) (getField @"txinputs_fee" txb)
 
 -- | txsize computes the length of the serialised bytes
-txsize :: Tx era -> Integer
-txsize (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
+instance HasField "txsize" (Tx era) Integer where
+  getField (TxConstr (Memo _ bytes)) = fromIntegral (SBS.length bytes)
 
 minfee ::
-  PParams era ->
-  Tx era ->
+  ( HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minfeeB" (Core.PParams era) Natural,
+    HasField "_prices" (Core.PParams era) Prices,
+    HasField "totExunits" (Core.Tx era) ExUnits,
+    HasField "txsize" (Core.Tx era) Integer
+  ) =>
+  Core.PParams era ->
+  Core.Tx era ->
   Coin
 minfee pp tx =
-  (txsize tx <×> a pp)
+  (getField @"txsize" tx <×> a pp)
     <+> b pp
-    <+> (scriptfee (_prices pp) totExunits)
+    <+> (scriptfee (getField @"_prices" pp) allExunits)
   where
-    a protparam = Coin (fromIntegral (_minfeeA protparam))
-    b protparam = Coin (fromIntegral (_minfeeB protparam))
-    totExunits = foldl (<>) mempty (snd $ unzip (Map.elems trd))
-    trd = getField @"txrdmrs" (getField @"wits" tx)
+    a protparam = Coin (fromIntegral (getField @"_minfeeA" protparam))
+    b protparam = Coin (fromIntegral (getField @"_minfeeB" protparam))
+    allExunits = getField @"totExunits" tx
+
+-- The only thing that keeps minfee from working on Core.Tx is that
+-- not all eras can extract a ExUninits from a Core.Tx. For the Alonzo
+-- era, we use this function, specialized to the Alonzo Tx defined in this file.
+-- If we had instances (HasField "exUnits" (Core.Tx era) ExUnits) we'd be golden
+
+instance HasField "totExunits" (Tx era) ExUnits where
+  getField tx = foldl (<>) mempty (snd $ unzip (Map.elems trd))
+    where
+      trd = getField @"txrdmrs" (getField @"wits" tx)
 
 -- The specification uses "validatorHash" to extract ScriptHash from
 -- an Addr. But not every Addr has a ScriptHash. In particular KeyHashObj

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -20,7 +20,20 @@
 
 module Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
-    TxWitness (TxWitness, txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs),
+    TxWitness
+      ( TxWitness,
+        txwitsVKey,
+        txwitsBoot,
+        txscripts,
+        txdats,
+        txrdmrs,
+        TxWitness',
+        txwitsVKey',
+        txwitsBoot',
+        txscripts',
+        txdats',
+        txrdmrs'
+      ),
     ppRdmrPtr,
     ppTxWitness,
   )
@@ -132,6 +145,19 @@ deriving newtype instance
 
 -- =====================================================
 -- Pattern for TxWitness
+
+pattern TxWitness' ::
+  Set (WitVKey 'Witness (Crypto era)) ->
+  Set (BootstrapWitness (Crypto era)) ->
+  Map (ScriptHash (Crypto era)) (Core.Script era) ->
+  Map (DataHash (Crypto era)) (Data era) ->
+  Map RdmrPtr (Data era, ExUnits) ->
+  TxWitness era
+pattern TxWitness' {txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'} <-
+  TxWitnessConstr
+    (Memo (TxWitnessRaw txwitsVKey' txwitsBoot' txscripts' txdats' txrdmrs') _)
+
+{-# COMPLETE TxWitness' #-}
 
 pattern TxWitness ::
   (Era era, ToCBOR (Core.Script era)) =>

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -200,7 +200,7 @@ instance
 --   the mint field.
 consumed ::
   forall era.
-  ( UsesValue era,
+  ( Era era,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "mint" (Core.TxBody era) (Core.Value era),

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -339,11 +339,20 @@ instance HasField "vldt" (TxBody era) ValidityInterval where
 instance HasField "update" (TxBody era) (StrictMaybe (Update era)) where
   getField (TxBodyConstr (Memo m _)) = getField @"update" m
 
-instance Crypto era ~ crypto => HasField "adHash" (TxBody era) (StrictMaybe (AuxiliaryDataHash crypto)) where
+instance
+  Crypto era ~ crypto =>
+  HasField "adHash" (TxBody era) (StrictMaybe (AuxiliaryDataHash crypto))
+  where
   getField (TxBodyConstr (Memo m _)) = getField @"adHash" m
 
 instance Value era ~ value => HasField "mint" (TxBody era) value where
   getField (TxBodyConstr (Memo m _)) = getField @"mint" m
+
+instance
+  Crypto era ~ crypto =>
+  HasField "txinputs_fee" (TxBody era) (Set (TxIn crypto))
+  where
+  getField (TxBodyConstr (Memo m _)) = getField @"inputs" m
 
 -- ============================================
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Era.hs
@@ -32,12 +32,14 @@ import Cardano.Ledger.Val (Val)
 import Control.Monad.Except (Except, runExcept)
 import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
+import Data.Map (Map)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import Data.Void (Void, absurd)
 import GHC.Records (HasField (..))
 import Shelley.Spec.Ledger.Address (Addr)
+import Shelley.Spec.Ledger.Address.Bootstrap (BootstrapWitness)
 import Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
 import Shelley.Spec.Ledger.Coin (Coin)
 import Shelley.Spec.Ledger.Scripts (ScriptHash)
@@ -151,13 +153,20 @@ translateEraMaybe ctxt =
 
 -- | All Well Formed Eras have this minimal structure.
 type WellFormed era =
-  ( HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
+  ( -- TxBody
+    HasField "outputs" (Core.TxBody era) (StrictSeq (Core.TxOut era)),
     HasField "txfee" (Core.TxBody era) Coin,
     HasField "minted" (Core.TxBody era) (Set (ScriptHash (Crypto era))),
+    -- Tx
     HasField "body" (Core.Tx era) (Core.TxBody era),
     HasField "auxiliaryData" (Core.Tx era) (StrictMaybe (Core.AuxiliaryData era)),
+    HasField "scriptWits" (Core.Tx era) (Map (ScriptHash (Crypto era)) (Core.Script era)),
+    HasField "bootWits" (Core.Tx era) (Set (BootstrapWitness (Crypto era))),
+    HasField "txsize" (Core.Tx era) Integer,
+    -- TxOut
     HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "value" (Core.TxOut era) (Core.Value era),
+    -- HashAnnotated
     HashAnnotated (Core.AuxiliaryData era) EraIndependentAuxiliaryData (Crypto era),
     HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era),
     Val (Core.Value era),
@@ -166,16 +175,20 @@ type WellFormed era =
 
 {-  TODO, there are a few other constraints which are WellFormed and we should add
 them when time permits. Some are not added because the types they mentions reside
-in files that cause cirluar import dependencies.
-   -- import Shelley.Spec.Ledger.TxBody(DCert,Wdrl,)
+in files that cause circular import dependencies.
+   -- import Shelley.Spec.Ledger.TxBody(DCert,Wdrl,WitVKey)
    -- import Shelley.Spec.Ledger.Tx(TxIn)
 These would have to be moved into a module such as Cardano.Ledger.TxBase(TxIn,DCert,Wdrl)
-   -- HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+   -- HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),       -- all possible inputs
+   -- HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era)))  -- inputs that can be used to pay fees
    -- HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
    -- HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+   -- HasField "addrWits" (Core.Tx era) (Set (WitVKey 'Witness (Crypto era)))
 others where the concrete type (Update and WitnessSet) will have to be made into a type family
    -- import Shelley.Spec.Ledger.PParams (Update)
    -- import Shelley.Spec.Ledger.Tx(WitnessSet)
+   -- import Cardano.Ledger.Alonzo.Scripts (ExUnits)
    -- HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
    -- HasField "witnessSet" (Core.Tx era) (WitnessSet era),
+   -- HasField "exUnits" (Core.Tx era) ExUnits,
 -}

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -303,6 +303,21 @@ instance HasField "witnessSet" (Tx era) (WitnessSet era) where
 instance aux ~ (Core.AuxiliaryData era) => HasField "auxiliaryData" (Tx era) (StrictMaybe aux) where
   getField (Tx' _ _ auxdata _) = auxdata
 
+instance c ~ (Crypto era) => HasField "addrWits" (Tx era) (Set (WitVKey 'Witness c)) where
+  getField (Tx' _ (WitnessSet' a _b _c _) _ _) = a
+
+instance
+  (c ~ (Crypto era), script ~ Core.Script era) =>
+  HasField "scriptWits" (Tx era) (Map (ScriptHash c) script)
+  where
+  getField (Tx' _ (WitnessSet' _a b _c _) _ _) = b
+
+instance c ~ (Crypto era) => HasField "bootWits" (Tx era) (Set (BootstrapWitness c)) where
+  getField (Tx' _ (WitnessSet' _a _b c _) _ _) = c
+
+instance HasField "txsize" (Tx era) Integer where
+  getField x = (fromIntegral . BSL.length . txFullBytes) x
+
 -- =====================================
 
 segwitTx ::

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -880,6 +880,12 @@ instance
 instance c ~ Crypto era => HasField "minted" (TxBody era) (Set (ScriptHash c)) where
   getField _ = Set.empty
 
+instance
+  c ~ Crypto era =>
+  HasField "txinputs_fee" (TxBody era) (Set (TxIn c))
+  where
+  getField (TxBodyConstr (Memo m _)) = getField @"_inputsX" m
+
 -- ===============================================================
 
 -- | Proof/Witness that a transaction is authorized by the given key holder.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -143,21 +143,21 @@ deriving instance TransUTxO NoThunks era => NoThunks (UTxO era)
 deriving instance (Era era, NFData (Core.TxOut era)) => NFData (UTxO era)
 
 deriving newtype instance
-  TransUTxO Eq era =>
+  Eq (Core.TxOut era) =>
   Eq (UTxO era)
 
 deriving newtype instance
-  (TransUTxO ToCBOR era, Era era) =>
+  (Era era, ToCBOR (Core.TxOut era)) =>
   ToCBOR (UTxO era)
 
 deriving newtype instance
-  (TransUTxO FromCBOR era, Era era) =>
+  (FromCBOR (Core.TxOut era), Era era) =>
   FromCBOR (UTxO era)
 
 deriving via
   Quiet (UTxO era)
   instance
-    (TransUTxO Show era) =>
+    Show (Core.TxOut era) =>
     Show (UTxO era)
 
 -- | Compute the id of a transaction.


### PR DESCRIPTION
Generalized the types of some functions that took Shelley.Tx as
parameters, to ones that take Core.Tx as parameters, as The Alonzo
era uses a different notion of Tx (and TxBody, TxOut, etc).

Update various instances to refer to UTXOS rather than PPUP, since
UTXO now calls the former rather than the latter.
Create 'Embed' instances for PPUP->UTXOS->UTXO
Added  number of new HasField instances.