### PR TITLE
Update nix infrastructure

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -8,7 +8,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc8102"
+, compiler ? config.haskellNix.compiler or "ghc8104"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 }:

--- a/nix/latex.nix
+++ b/nix/latex.nix
@@ -18,7 +18,13 @@
       buildPhase = ''
         runHook preBuild
         mkdir -p ${buildDir}
-        latexmk -outdir=${buildDir} -pdf ${toString texFiles}
+        # The bibtex_fudge setting is because our version of latexmk has an issue with bibtex
+        # and explicit output directories, which should be fixed in v4.70b: 
+        # https://tex.stackexchange.com/questions/564626/latexmk-4-70a-doesnt-compile-document-with-bibtex-citation
+        latexmk \
+          -e '$bibtex_fudge=1' \
+          -outdir=${buildDir} \
+          -pdf ${toString texFiles}
         runHook postBuild
       '';
       installPhase = ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,39 +1,51 @@
 {
-    "haskell.nix": {
-        "branch": "master",
-        "description": "Alternative Haskell Infrastructure for Nixpkgs",
-        "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "9aba1e299f6e7d6ccf1be41f64316567f845b9b7",
-        "sha256": "038xzhqxjx4xafwpa7w68cilq0iiz1wvx158yi87r70v1fk3dcr2",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/9aba1e299f6e7d6ccf1be41f64316567f845b9b7.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "iohk-nix": {
-        "branch": "master",
-        "description": "nix scripts shared across projects",
-        "homepage": null,
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "f2dee151a917aac96121246ed76fb17e3f9026b0",
-        "sha256": "1d8ygzczk4zbzz04j1yrwzbfld59bc6a6ar7bmlfx1j5m6fhjb8k",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/f2dee151a917aac96121246ed76fb17e3f9026b0.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "ormolu": {
-        "branch": "master",
-        "builtin": false,
-        "description": "A formatter for Haskell source code",
-        "homepage": null,
-        "owner": "tweag",
-        "repo": "ormolu",
-        "rev": "9cad22a2fec0ab0b416a46527fb7d22c69d07ef7",
-        "sha256": "1f8nqq8h3a414ip2chmr3zbhkzbb20zbk3h7y8z6qypxlv8asqls",
-        "type": "tarball",
-        "url": "https://github.com/tweag/ormolu/archive/9cad22a2fec0ab0b416a46527fb7d22c69d07ef7.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    }
+  "hackage.nix": {
+    "branch": "master",
+    "description": "Automatically generated Nix expressions for Hackage",
+    "homepage": "",
+    "owner": "input-output-hk",
+    "repo": "hackage.nix",
+    "rev": "b3c99d7f13df89a9a918c835ecb7114098912962",
+    "sha256": "1i5vg92s6g9zh0i35dm4a6hax7mdsqxbw8w2x63j0y6w57msv70g",
+    "type": "tarball",
+    "url": "https://github.com/input-output-hk/hackage.nix/archive/9f61382fad98e24fe8678db2ffb0c51a863a6023.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "haskell.nix": {
+    "branch": "master",
+    "description": "Alternative Haskell Infrastructure for Nixpkgs",
+    "homepage": "https://input-output-hk.github.io/haskell.nix",
+    "owner": "input-output-hk",
+    "repo": "haskell.nix",
+    "rev": "abe9243c255232a1ae1c93a03a0d3c79ed420ca0",
+    "sha256": "1vvwsr0klshzbvp88a45gpmx0lmm61cw8a046pmbbcsxyy08wf4m",
+    "type": "tarball",
+    "url": "https://github.com/input-output-hk/haskell.nix/archive/abe9243c255232a1ae1c93a03a0d3c79ed420ca0.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "iohk-nix": {
+    "branch": "master",
+    "description": "nix scripts shared across projects",
+    "homepage": null,
+    "owner": "input-output-hk",
+    "repo": "iohk-nix",
+    "rev": "f2dee151a917aac96121246ed76fb17e3f9026b0",
+    "sha256": "1d8ygzczk4zbzz04j1yrwzbfld59bc6a6ar7bmlfx1j5m6fhjb8k",
+    "type": "tarball",
+    "url": "https://github.com/input-output-hk/iohk-nix/archive/f2dee151a917aac96121246ed76fb17e3f9026b0.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "ormolu": {
+    "branch": "master",
+    "builtin": false,
+    "description": "A formatter for Haskell source code",
+    "homepage": null,
+    "owner": "tweag",
+    "repo": "ormolu",
+    "rev": "9cad22a2fec0ab0b416a46527fb7d22c69d07ef7",
+    "sha256": "1f8nqq8h3a414ip2chmr3zbhkzbb20zbk3h7y8z6qypxlv8asqls",
+    "type": "tarball",
+    "url": "https://github.com/tweag/ormolu/archive/9cad22a2fec0ab0b416a46527fb7d22c69d07ef7.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
     "homepage": null,
     "owner": "input-output-hk",
     "repo": "iohk-nix",
-    "rev": "f2dee151a917aac96121246ed76fb17e3f9026b0",
-    "sha256": "1d8ygzczk4zbzz04j1yrwzbfld59bc6a6ar7bmlfx1j5m6fhjb8k",
+    "rev": "60fe72cf807a4ec4409a53883d5c3af77f60f721",
+    "sha256": "0hpn4fsmnrrqzpj7j3fcmrjm5d3fb15vvbhjn825ipknjjvz6zwd",
     "type": "tarball",
-    "url": "https://github.com/input-output-hk/iohk-nix/archive/f2dee151a917aac96121246ed76fb17e3f9026b0.tar.gz",
+    "url": "https://github.com/input-output-hk/iohk-nix/archive/60fe72cf807a4ec4409a53883d5c3af77f60f721.tar.gz",
     "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
   },
   "ormolu": {

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ let
     ];
 
     tools = {
-      cabal = "3.2.0.0";
+      cabal = "3.4.0.0";
       ghcid = "0.8.7";
       haskell-language-server="latest";
     };


### PR DESCRIPTION
- Split out hackage.nix from haskell.nix. This will allow us to update
  haskell.nix in the future without forcing a rebuild of the world.
- Switch to using GHC 8.10.4
- Switch to using cabal 3.4. In particular, this means that
  source-repository-package libraries are no longer considered to be
  local, meaning we get better caching between builds.