### PR TITLE
Bump iohk-nix to bump nixpkgs

### DIFF
--- a/nix/latex.nix
+++ b/nix/latex.nix
@@ -18,7 +18,13 @@
       buildPhase = ''
         runHook preBuild
         mkdir -p ${buildDir}
-        latexmk -outdir=${buildDir} -pdf ${toString texFiles}
+        # The bibtex_fudge setting is because our version of latexmk has an issue with bibtex
+        # and explicit output directories, which should be fixed in v4.70b: 
+        # https://tex.stackexchange.com/questions/564626/latexmk-4-70a-doesnt-compile-document-with-bibtex-citation
+        latexmk \
+          -e '$bibtex_fudge=1' \
+          -outdir=${buildDir} \
+          -pdf ${toString texFiles}
         runHook postBuild
       '';
       installPhase = ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f2dee151a917aac96121246ed76fb17e3f9026b0",
-        "sha256": "1d8ygzczk4zbzz04j1yrwzbfld59bc6a6ar7bmlfx1j5m6fhjb8k",
+        "rev": "60fe72cf807a4ec4409a53883d5c3af77f60f721",
+        "sha256": "0hpn4fsmnrrqzpj7j3fcmrjm5d3fb15vvbhjn825ipknjjvz6zwd",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/f2dee151a917aac96121246ed76fb17e3f9026b0.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/60fe72cf807a4ec4409a53883d5c3af77f60f721.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ormolu": {


### PR DESCRIPTION
We need to go to an unstable nixpkgs in order to get the compatibility
fixes for Big Sur, so things will work on upgraded Macs. Fortunately,
the iohk-nix nixpkgs pin recently switched to nixos-unstable, so we can
just keep using that if we bump iohk-nix.