### PR TITLE
Remove an unevaluated thunk in RewardPulser

### DIFF
--- a/semantics/executable-spec/src/Data/Pulse.hs
+++ b/semantics/executable-spec/src/Data/Pulse.hs
@@ -1,24 +1,27 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.Pulse
   ( -- * The class that defines operations on pulsers.
-    Pulsable(..),
+    Pulsable (..),
+
     -- * Two reusable types that have Pulsable instances
-    PulseMapM(..),
-    PulseListM(..),
+    PulseMapM (..),
+    PulseListM (..),
+
     -- * Virtual versions of PulseMapM and PulseListM specialized to be non-monadic.
     PulseMap,
     PulseList,
@@ -26,49 +29,51 @@ module Data.Pulse
     pulseMap,
     pulse,
     complete,
+
     -- * Monadic folds designed to be used inside pulsers.
     foldlM',
     foldlWithKeyM',
-  ) where
+  )
+where
 
-import qualified Data.List as List
+import Control.Monad.Identity (Identity (..))
+import qualified Data.Foldable as Foldable
 import Data.Kind
-import Data.Map(Map)
-import qualified Data.Map.Strict as Map
+import qualified Data.List as List
+import Data.Map (Map)
 import Data.Map.Internal (Map (..))
-import Control.Monad.Identity(Identity(..))
+import qualified Data.Map.Strict as Map
 
 -- ====================================================
 
-
-{- | let T be a Pulse structure. A Pulse struture
-   is abstracted over a monad: m, and an answer type: t,
-   so the concrete type of a pulse structure is written: (T m a).
-   The Pulsable class supplies operations on the structure
-   that allow its computation to be split into many discrete
-   steps. One does this by running: "pulse p" or "pulseM p",
-   depending upon whether the computation is monadic or not,
-   to run a discrete step.  The scheduling infrastructure needs
-   to know nothing about what is going on inside the pulse structure.
--}
+-- | let T be a Pulse structure. A Pulse struture
+--   is abstracted over a monad: m, and an answer type: t,
+--   so the concrete type of a pulse structure is written: (T m a).
+--   The Pulsable class supplies operations on the structure
+--   that allow its computation to be split into many discrete
+--   steps. One does this by running: "pulse p" or "pulseM p",
+--   depending upon whether the computation is monadic or not,
+--   to run a discrete step.  The scheduling infrastructure needs
+--   to know nothing about what is going on inside the pulse structure.
 class Pulsable (pulse :: (Type -> Type) -> Type -> Type) where
-   done ::  pulse m ans -> Bool
-   current :: pulse m ans -> ans
-   pulseM :: Monad m => pulse m ans -> m(pulse m ans)
-   completeM :: Monad m => pulse m ans -> m ans
-   completeM p = if done p
-                    then pure (current p)
-                    else  do p' <- pulseM p; completeM p'
+  done :: pulse m ans -> Bool
+  current :: pulse m ans -> ans
+  pulseM :: Monad m => pulse m ans -> m (pulse m ans)
+  completeM :: Monad m => pulse m ans -> m ans
+  completeM p =
+    if done p
+      then pure (current p)
+      else do p' <- pulseM p; completeM p'
 
 -- =================================
 -- Pulse structure for List in an arbitray monad
 
 -- | A List based pulser
 data PulseListM m ans where
-  PulseList:: !Int -> !(ans -> a -> m ans) -> ![a] -> !ans -> PulseListM m ans
+  PulseList :: !Int -> !(ans -> a -> m ans) -> ![a] -> !ans -> PulseListM m ans
 
 instance Show ans => Show (PulseListM m ans) where
-  show(PulseList n _ t a) = "(Pulse "++show n++status t++show a++")"
+  show (PulseList n _ t a) = "(Pulse " ++ show n ++ status t ++ show a ++ ")"
 
 status :: [a] -> String
 status x = if null x then " Done " else " More "
@@ -78,11 +83,11 @@ status x = if null x then " Done " else " More "
 
 -- | A Map based pulser.
 data PulseMapM m ans where
-  PulseMap:: !Int ->  !(ans -> k -> v -> m ans) -> !(Map k v) -> !ans -> PulseMapM m ans
+  PulseMap :: !Int -> !(ans -> k -> v -> m ans) -> !(Map k v) -> !ans -> PulseMapM m ans
 
 instance Show ans => Show (PulseMapM m ans) where
-  show(PulseMap n _ t a) =
-    "(Pulse "++show n++(if Map.null t then " Done " else " More ")++show a++")"
+  show (PulseMap n _ t a) =
+    "(Pulse " ++ show n ++ (if Map.null t then " Done " else " More ") ++ show a ++ ")"
 
 -- ===============================================================
 -- Pulse structures can be Specialize to the Identity Monad
@@ -97,13 +102,13 @@ type PulseMap ans = PulseListM Identity ans
 -- the identity monad. They automatically lift the accumulating function
 
 -- | Create List pulser structure in the Identity monad, a pure accumulator is lifted to a monadic one.
-pulseList:: Int -> (t1 -> t2 -> t1) -> [t2] -> t1 -> PulseListM Identity t1
+pulseList :: Int -> (t1 -> t2 -> t1) -> [t2] -> t1 -> PulseListM Identity t1
 pulseList n accum xs zero =
-   PulseList n (\ ans x -> Identity(accum ans x)) xs zero
+  PulseList n (\ans x -> Identity (accum ans x)) xs zero
 
 -- | Create Map pulser structure in the Identity monad, a pure accumulator is lifted to a monadic one.
-pulseMap:: Int -> (a -> k -> v -> a) -> Map k v -> a -> PulseMapM Identity a
-pulseMap n accum ts zero = PulseMap n  (\ ans k v -> Identity(accum ans k v)) ts zero
+pulseMap :: Int -> (a -> k -> v -> a) -> Map k v -> a -> PulseMapM Identity a
+pulseMap n accum ts zero = PulseMap n (\ans k v -> Identity (accum ans k v)) ts zero
 
 -- run Pulse structures in the Identity monad.
 
@@ -119,23 +124,23 @@ complete p = runIdentity (completeM p)
 -- Some instances
 
 instance Pulsable PulseListM where
-   done (PulseList _ _ zs _) = null zs
-   current (PulseList _ _ _ ans) = ans
-   pulseM (ll@(PulseList _ _ balance _)) | null balance = pure ll
-   pulseM (PulseList n accum balance ans) = do
-       let (steps, balance') = List.splitAt n balance
-       ans' <- foldlM' accum ans steps
-       pure (PulseList n accum balance' ans')
-   completeM (PulseList _ accum balance ans) = foldlM' accum ans balance
+  done (PulseList _ _ zs _) = null zs
+  current (PulseList _ _ _ ans) = ans
+  pulseM (ll@(PulseList _ _ balance _)) | null balance = pure ll
+  pulseM (PulseList n accum balance ans) = do
+    let (steps, balance') = List.splitAt n balance
+    ans' <- foldlM' accum ans steps
+    pure (PulseList n accum balance' ans')
+  completeM (PulseList _ accum balance ans) = foldlM' accum ans balance
 
 instance Pulsable PulseMapM where
-   done (PulseMap _ _ m _) = Map.null m
-   current (PulseMap _ _ _ ans) = ans
-   pulseM (ll@(PulseMap _ _ balance _)) | Map.null balance = pure ll
-   pulseM (PulseMap n accum balance ans) = do
-      let (steps, balance') = Map.splitAt n balance
-      ans' <-  foldlWithKeyM' accum ans steps
-      pure (PulseMap n accum balance' ans')
+  done (PulseMap _ _ m _) = Map.null m
+  current (PulseMap _ _ _ ans) = ans
+  pulseM (ll@(PulseMap _ _ balance _)) | Map.null balance = pure ll
+  pulseM (PulseMap n accum balance ans) = do
+    let (steps, balance') = Map.splitAt n balance
+    ans' <- foldlWithKeyM' accum ans steps
+    pure (PulseMap n accum balance' ans')
 
 -- ================================================================
 -- Special monadic folds for use with PulseListM and PulseMapM
@@ -143,10 +148,11 @@ instance Pulsable PulseMapM where
 -- These functions should appear somewhere in Data.List or Data.List or
 -- Data.Foldable or Data.Traversable, or Control.Monad, but they don't.
 
--- | A strict, monadic, version of 'foldl' for lists. It  associates to the left.
-foldlM' :: Monad m => (ans -> k -> m ans) -> ans -> [k] -> m ans
-foldlM' _accum !ans [] = pure ans
-foldlM' accum !ans (k:more) = do { ans1 <- accum ans k; foldlM' accum ans1 more }
+-- | A strict, monadic, version of 'foldl'. It  associates to the left.
+foldlM' :: (Foldable t, Monad m) => (ans -> k -> m ans) -> ans -> t k -> m ans
+foldlM' accum !ans acc = case Foldable.toList acc of
+  [] -> pure ans
+  (k : more) -> do ans1 <- accum ans k; foldlM' accum ans1 more
 
 -- | /O(n)/. A strict, monadic, version of 'foldlWithKey'. Each application of the
 --   operator is evaluated before using the result in the next application. This
@@ -154,11 +160,12 @@ foldlM' accum !ans (k:more) = do { ans1 <- accum ans k; foldlM' accum ans1 more 
 foldlWithKeyM' :: Monad m => (a -> k -> b -> m a) -> a -> Map k b -> m a
 foldlWithKeyM' f z = go z
   where
-    go !z' Tip              = pure z'
+    go !z' Tip = pure z'
     go z' (Bin _ kx x l r) =
-      do !ans1 <- (go z' l)
-         !ans2 <- (f ans1 kx x)
-         go ans2 r
+      do
+        !ans1 <- (go z' l)
+        !ans2 <- (f ans1 kx x)
+        go ans2 r
 
 -- ===================================
 -- We could probably generalise this to PulseFoldableM over any

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -110,7 +110,6 @@ import Shelley.Spec.Ledger.PParams
   )
 import Shelley.Spec.Ledger.RewardUpdate
   ( FreeVars (..),
-    PulseItem,
     Pulser,
     PulsingRewUpdate (..),
     RewardAns,
@@ -464,9 +463,6 @@ ppFreeVars (FreeVars b1 del stake1 addrs total active asc1 blocks r1 slots d a0 
       ("nOpt", ppNatural nOpt)
     ]
 
-ppPulseItem :: PulseItem crypto -> PDoc
-ppPulseItem (keyhash, poolparams) = ppPair ppKeyHash ppPoolParams (keyhash, poolparams)
-
 ppAns :: RewardAns crypto -> PDoc
 ppAns mappair =
   ppPair
@@ -476,7 +472,13 @@ ppAns mappair =
 
 ppRewardPulser :: Pulser crypto -> PDoc
 ppRewardPulser (RSLP n free items ans) =
-  ppSexp "RewardPulser" [ppInt n, ppFreeVars free, ppList ppPulseItem items, ppAns ans]
+  ppSexp
+    "RewardPulser"
+    [ ppInt n,
+      ppFreeVars free,
+      ppStrictSeq ppPoolParams items,
+      ppAns ans
+    ]
 
 ppPulsingRewUpdate :: PulsingRewUpdate crypto -> PDoc
 ppPulsingRewUpdate (Pulsing snap pulser) =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -141,6 +141,7 @@ import Data.Maybe (fromMaybe)
 import Data.Pulse (Pulsable (..), completeM)
 import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable
@@ -1258,7 +1259,12 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) max
           (getField @"_a0" pr)
           (getField @"_nOpt" pr)
       pulser :: Pulser (Crypto era)
-      pulser = RSLP pulseSize free (Map.toList poolParams) (Map.empty, Map.empty)
+      pulser =
+        RSLP
+          pulseSize
+          free
+          (StrictSeq.fromList $ Map.elems poolParams)
+          (Map.empty, Map.empty)
    in (Pulsing rewsnap pulser)
 
 -- Phase 2


### PR DESCRIPTION
Spotted while looking through the reward pulsing code. The set of items
to pulse is stored as a list of tuples, and created by a call to
`Map.toList`. This list is then evaluated to WHNF by the strict bang in
`RewardPulser`, but this will only force the first list constructor.
Thus the thunks will remain for the majority of the reward computation.

This PR changes a couple of things to avoid this. Firstly, the
'RewardPulser' now stores its list of items to pulse as a `StrictSeq`.
Then we discard the tuple and store only the `PoolParams`, since the
other element of the tuple (the pool ID) is stored in the '`PoolParams`
anyway. Thus the bang in `RewardUpdate` should now be sufficient to
force evaluation to NF.

As part of this change, we generalise the `foldlM'` function to work
over any foldable structure. Note that since `toList` is lazy, the call
to `toList` should be O(1) via Data.Sequence.

Unfortunately Data.Coders had not been formatted and I accidentally
formatted it during this commit (I have format on save set). I'll
disentangle the formatting changes.

Note that this change will result in a change to the on-disk
serialisation format for `LedgerState`, and as such we should be careful
about when we merge it.