### PR TITLE
Generalized DelegsEnv, Added prototype Alonzo ledger rule.

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -45,6 +45,7 @@ library
     Cardano.Ledger.Alonzo.Rules.Utxo
     Cardano.Ledger.Alonzo.Rules.Utxos
     Cardano.Ledger.Alonzo.Rules.Utxow
+    Cardano.Ledger.Alonzo.Rules.Ledger
     Cardano.Ledger.Alonzo.Scripts
     Cardano.Ledger.Alonzo.Tx
     Cardano.Ledger.Alonzo.TxBody

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Alonzo.Rules.Ledger
+  ( AlonzoLEDGER,
+    ledgerTransition,
+  )
+where
+
+import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail, AlonzoUTXOW)
+import Cardano.Ledger.Alonzo.Tx (IsValidating (..), Tx (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
+import Control.State.Transition
+  ( Assertion (..),
+    AssertionViolation (..),
+    Embed (..),
+    STS (..),
+    TRC (..),
+    TransitionRule,
+    judgmentContext,
+    trans,
+  )
+import Data.Kind (Type)
+import Data.Sequence (Seq)
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import GHC.Records (HasField, getField)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.EpochBoundary (obligation)
+import Shelley.Spec.Ledger.Keys (DSignable, Hash)
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState (..),
+    DState (..),
+    PState (..),
+    UTxOState (..),
+  )
+import Shelley.Spec.Ledger.STS.Delegs (DELEGS, DelegsEnv (..), DelegsPredicateFailure)
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..), LedgerPredicateFailure (..))
+import Shelley.Spec.Ledger.STS.Utxo
+  ( UtxoEnv (..),
+  )
+import Shelley.Spec.Ledger.TxBody (DCert, EraIndependentTxBody)
+
+-- =======================================
+
+-- | The uninhabited type that marks the (STS Ledger) instance in the Alonzo Era.
+data AlonzoLEDGER era
+
+-- | An abstract Alonzo Era, Ledger transition. Fix 'someLedger' at a concrete type to
+--   make it concrete. Depends only on the "certs" and "isValidating" HasField instances.
+ledgerTransition ::
+  forall (someLEDGER :: Type -> Type) era.
+  ( Signal (someLEDGER era) ~ Core.Tx era,
+    State (someLEDGER era) ~ (UTxOState era, DPState (Crypto era)),
+    Environment (someLEDGER era) ~ LedgerEnv era,
+    Embed (Core.EraRule "UTXOW" era) (someLEDGER era),
+    Embed (Core.EraRule "DELEGS" era) (someLEDGER era),
+    Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
+    State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXOW" era) ~ UTxOState era,
+    Signal (Core.EraRule "UTXOW" era) ~ Core.Tx era,
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "isValidating" (Core.Tx era) IsValidating,
+    Era era
+  ) =>
+  TransitionRule (someLEDGER era)
+ledgerTransition = do
+  TRC (LedgerEnv slot txIx pp account, (utxoSt, dpstate), tx) <- judgmentContext
+  let txbody = getField @"body" tx
+
+  dpstate' <-
+    if getField @"isValidating" tx == IsValidating True
+      then
+        trans @(Core.EraRule "DELEGS" era) $
+          TRC
+            ( DelegsEnv slot txIx pp tx account,
+              dpstate,
+              StrictSeq.fromStrict $ getField @"certs" $ txbody
+            )
+      else pure dpstate
+
+  let DPState dstate pstate = dpstate
+      genDelegs = _genDelegs dstate
+      stpools = _pParams pstate
+
+  utxoSt' <-
+    trans @(Core.EraRule "UTXOW" era) $
+      TRC
+        ( UtxoEnv @era slot pp stpools genDelegs,
+          utxoSt,
+          tx
+        )
+  pure (utxoSt', dpstate')
+
+instance
+  ( Show (Core.Script era), -- All these Show instances arise because
+    Show (Core.TxBody era), -- renderAssertionViolation, turns them into strings
+    Show (Core.AuxiliaryData era),
+    Show (Core.PParams era),
+    Show (Core.Value era),
+    Show (PParamsDelta era),
+    Core.Tx era ~ Tx era,
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    Era era,
+    Embed (Core.EraRule "DELEGS" era) (AlonzoLEDGER era),
+    Embed (Core.EraRule "UTXOW" era) (AlonzoLEDGER era),
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXOW" era) ~ UTxOState era,
+    Signal (Core.EraRule "UTXOW" era) ~ Tx era,
+    Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
+    State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
+    Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    Show (UTxOState era)
+  ) =>
+  STS (AlonzoLEDGER era)
+  where
+  type
+    State (AlonzoLEDGER era) =
+      (UTxOState era, DPState (Crypto era))
+  type Signal (AlonzoLEDGER era) = Tx era
+  type Environment (AlonzoLEDGER era) = LedgerEnv era
+  type BaseM (AlonzoLEDGER era) = ShelleyBase
+  type PredicateFailure (AlonzoLEDGER era) = LedgerPredicateFailure era
+
+  initialRules = []
+  transitionRules = [ledgerTransition @AlonzoLEDGER]
+
+  renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
+    "AssertionViolation (" <> avSTS <> "): " <> avMsg
+      <> "\n"
+      <> show avCtx
+      <> "\n"
+      <> show avState
+
+  assertions =
+    [ PostCondition
+        "Deposit pot must equal obligation"
+        ( \(TRC (LedgerEnv {ledgerPp}, _, _))
+           (utxoSt, DPState {_dstate, _pstate}) ->
+              obligation ledgerPp (_rewards _dstate) (_pParams _pstate)
+                == _deposited utxoSt
+        )
+    ]
+
+instance
+  ( Era era,
+    STS (DELEGS era),
+    PredicateFailure (Core.EraRule "DELEGS" era) ~ DelegsPredicateFailure era
+  ) =>
+  Embed (DELEGS era) (AlonzoLEDGER era)
+  where
+  wrapFailed = DelegsFailure
+
+instance
+  ( Era era,
+    STS (AlonzoUTXOW era),
+    PredicateFailure (Core.EraRule "UTXOW" era) ~ AlonzoPredFail era
+  ) =>
+  Embed (AlonzoUTXOW era) (AlonzoLEDGER era)
+  where
+  wrapFailed = UtxowFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -28,7 +28,7 @@ import Cardano.Binary
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (ShelleyBased, UsesAuxiliary, UsesPParams, UsesScript, UsesTxBody)
+import Cardano.Ledger.Shelley.Constraints (ShelleyBased)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, (∈), (⨃))
 import Control.State.Transition
@@ -90,15 +90,13 @@ data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: SlotNo,
     delegsIx :: Ix,
     delegspp :: Core.PParams era,
-    delegsTx :: Tx era,
+    delegsTx :: Core.Tx era,
     delegsAccount :: AccountState
   }
 
 deriving stock instance
-  ( UsesPParams era,
-    UsesScript era,
-    UsesTxBody era,
-    UsesAuxiliary era
+  ( Show (Core.Tx era),
+    Show (Core.PParams era)
   ) =>
   Show (DelegsEnv era)
 
@@ -122,6 +120,7 @@ deriving stock instance
 
 instance
   ( ShelleyBased era,
+    Core.Tx era ~ Tx era,
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     Embed (Core.EraRule "DELPL" era) (DELEGS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
@@ -190,6 +189,7 @@ instance
 delegsTransition ::
   forall era.
   ( ShelleyBased era,
+    Core.Tx era ~ Tx era,
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     Embed (Core.EraRule "DELPL" era) (DELEGS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -85,6 +85,7 @@ genAccountState (Constants {minTreasury, maxTreasury, minReserves, maxReserves})
 -- with meaningful delegation certificates.
 instance
   ( EraGen era,
+    Core.Tx era ~ Tx era,
     ShelleyTest era,
     UsesTxBody era,
     UsesTxOut era,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -65,6 +65,7 @@ minimalPropertyTests ::
   forall era.
   ( EraGen era,
     ShelleyTest era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),
@@ -104,6 +105,7 @@ propertyTests ::
   forall era.
   ( EraGen era,
     ShelleyTest era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -129,6 +129,7 @@ collisionFreeComplete ::
   ( EraGen era,
     ShelleyTest era,
     TransValue ToCBOR era,
+    Core.Tx era ~ Tx era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
@@ -162,6 +163,7 @@ adaPreservationChain ::
   forall era.
   ( EraGen era,
     ShelleyTest era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     ChainProperty era,
     QC.HasTrace (CHAIN era) (GenEnv era),
@@ -293,6 +295,7 @@ potsSumIncreaseWdrlsPerBlock SourceSignalTarget {source, signal, target} =
 potsSumIncreaseWdrlsPerTx ::
   forall era.
   ( ChainProperty era,
+    Core.Tx era ~ Tx era,
     UsesTxOut era,
     UsesPParams era,
     TransValue ToCBOR era,
@@ -332,6 +335,7 @@ potsSumIncreaseWdrlsPerTx SourceSignalTarget {source = chainSt, signal = block} 
 potsSumIncreaseByRewardsPerTx ::
   ( ChainProperty era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     UsesPParams era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
@@ -376,6 +380,7 @@ potsRewardsDecreaseByWdrlsPerTx ::
   ( ChainProperty era,
     UsesPParams era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
     Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
@@ -427,6 +432,7 @@ preserveBalance ::
   ( ChainProperty era,
     UsesPParams era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
     Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
@@ -477,6 +483,7 @@ preserveBalanceRestricted ::
   ( ChainProperty era,
     UsesPParams era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
     Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
@@ -522,6 +529,7 @@ preserveOutputsTx ::
   forall era.
   ( ChainProperty era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     UsesPParams era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
@@ -555,6 +563,7 @@ eliminateTxInputs ::
   forall era.
   ( ChainProperty era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     UsesPParams era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
@@ -589,6 +598,7 @@ newEntriesAndUniqueTxIns ::
   forall era.
   ( ChainProperty era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     UsesPParams era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
@@ -633,6 +643,7 @@ requiredMSigSignaturesSubset ::
   forall era.
   ( EraGen era,
     UsesTxOut era,
+    Core.Tx era ~ Tx era,
     UsesPParams era,
     TransValue ToCBOR era,
     ChainProperty era,
@@ -867,6 +878,7 @@ ledgerTraceFromBlock ::
   ( ChainProperty era,
     UsesTxOut era,
     UsesPParams era,
+    Core.Tx era ~ Tx era,
     TransValue ToCBOR era,
     Embed (Core.EraRule "DELEGS" era) (LEDGER era),
     Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,


### PR DESCRIPTION
This adds a Ledger rule for the Alonzo Era.
Generalize DelegsEnv  to take a Core.Tx rather than a Shelley.Tx
Had to add quite a few  Core.Tx era ~ Shelley.Tx era  in the tests
