### PR TITLE
remove annotators from PParams FromCBOR instances

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -72,6 +72,7 @@ import Numeric.Natural (Natural)
 import qualified Plutus.V1.Ledger.Examples as Plutus (alwaysFailingNAryFunction, alwaysSucceedingNAryFunction)
 import qualified Plutus.V1.Ledger.Scripts as Plutus (Script)
 import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Serialization (mapFromCBOR)
 
 -- | Marker indicating the part of a transaction for which this script is acting
 -- as a validator.
@@ -181,14 +182,8 @@ instance NFData CostModel
 
 deriving instance ToCBOR CostModel
 
--- This is needed to derive the FromCBOR (Annotator CostModel) instance
-instance FromCBOR (Annotator (Map ByteString Integer)) where
-  fromCBOR = pure <$> fromCBOR
-
-deriving via
-  Mem (Map ByteString Integer)
-  instance
-    FromCBOR (Annotator CostModel)
+instance FromCBOR CostModel where
+  fromCBOR = CostModel <$> mapFromCBOR
 
 -- CostModel is not parameterized by Crypto or Era so we use the
 -- hashWithCrypto function, rather than hashAnnotated

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -333,7 +333,7 @@ instance Era era => FromCBOR (Annotator (WitnessPPDataRaw era)) where
     decode
       ( Ann (RecD WitnessPPDataRaw)
           <*! mapDecodeA (Ann From) From
-          <*! setDecodeA From
+          <*! setDecodeA (Ann From)
       )
 
 newtype WitnessPPData era = WitnessPPDataConstr (MemoBytes (WitnessPPDataRaw era))
@@ -752,7 +752,7 @@ instance
     FromCBOR (Annotator (Core.Script era)),
     FromCBOR (Annotator (Core.TxBody era)),
     FromCBOR (Annotator (Core.AuxiliaryData era)),
-    Core.AnnotatedData (PParamsDelta era),
+    FromCBOR (PParamsDelta era),
     ToCBOR (Core.Script era),
     Typeable (Core.Script era),
     Typeable (Core.AuxiliaryData era),
@@ -782,7 +782,7 @@ deriving via
       FromCBOR (Annotator (Core.Script era)),
       FromCBOR (Annotator (Core.TxBody era)),
       FromCBOR (Annotator (Core.AuxiliaryData era)),
-      Core.AnnotatedData (PParamsDelta era),
+      FromCBOR (PParamsDelta era),
       ToCBOR (Core.Script era),
       Typeable (Core.Script era),
       Typeable (Core.AuxiliaryData era),

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -78,11 +78,11 @@ tests =
       testProperty "alonzo/Tx" $
         trippingAnn @(Tx (AlonzoEra C_Crypto)),
       testProperty "alonzo/CostModel" $
-        trippingAnn @CostModel,
+        tripping @CostModel,
       testProperty "alonzo/PParams" $
-        trippingAnn @(PParams (AlonzoEra C_Crypto)),
-      testProperty "alonzo/PParamUpdate" $
-        trippingAnn @(PParamsUpdate (AlonzoEra C_Crypto)),
+        tripping @(PParams (AlonzoEra C_Crypto)),
+      testProperty "alonzo/PParamsUpdate" $
+        tripping @(PParamsUpdate (AlonzoEra C_Crypto)),
       testProperty "alonzo/AuxiliaryData" $
         trippingAnn @(AuxiliaryData (AlonzoEra C_Crypto)),
       -- TODO, this test does not work because of (FromCBOR(Annotator x)) issues

--- a/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -86,7 +86,7 @@ applyTxEra ::
   ( Era era,
     ApplyTx era,
     Default (Core.PParams era),
-    FromCBOR (Annotator (MempoolState era))
+    FromCBOR (MempoolState era)
   ) =>
   Proxy era ->
   FilePath ->
@@ -98,7 +98,7 @@ applyTxEra p lsFile txFile = env loadRes go
     loadRes = do
       state <-
         either (\err -> error $ "Failed to decode state: " <> show err) id
-          . decodeAnnotator "state" fromCBOR
+          . decodeFullDecoder "state" fromCBOR
           <$> BSL.readFile lsFile
       tx <-
         either (\err -> error $ "Failed to decode tx: " <> show err) id

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -89,11 +89,11 @@ class
   ( Era era,
     Eq (PParams era),
     Show (PParams era),
-    AnnotatedData (PParams era),
+    SerialisableData (PParams era),
     ChainData (PParamsDelta era),
     NFData (PParamsDelta era),
     Ord (PParamsDelta era),
-    AnnotatedData (PParamsDelta era)
+    SerialisableData (PParamsDelta era)
   ) =>
   UsesPParams era
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -10,7 +10,7 @@ module Shelley.Spec.Ledger.API
   )
 where
 
-import Cardano.Ledger.Core (AnnotatedData, ChainData)
+import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -44,7 +44,7 @@ class
     UsesTxOut era,
     UsesPParams era,
     ChainData (State (Core.EraRule "PPUP" era)),
-    AnnotatedData (State (Core.EraRule "PPUP" era))
+    SerialisableData (State (Core.EraRule "PPUP" era))
   ) =>
   ShelleyBasedEra era
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -20,7 +20,7 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Cardano.Ledger.Core (AnnotatedData, ChainData)
+import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -51,7 +51,7 @@ class
     ChainData (BHeader (Crypto era)),
     AnnotatedData (BHeader (Crypto era)),
     ChainData (NewEpochState era),
-    AnnotatedData (NewEpochState era),
+    SerialisableData (NewEpochState era),
     ChainData (BlockTransitionError era),
     ChainData (STS.PredicateFailure (STS.CHAIN era)),
     STS (Core.EraRule "TICK" era),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -123,12 +123,10 @@ import Control.SetAlgebra (Bimap, biMapEmpty, dom, eval, forwards, range, (∈),
 import Control.State.Transition (STS (State))
 import qualified Data.ByteString.Lazy as BSL (length)
 import Data.Coders
-  ( Annotator (..),
-    Decode (Ann, From, RecD),
+  ( Decode (From, RecD),
     decode,
     decodeRecordNamed,
     (<!),
-    (<*!),
   )
 import Data.Constraint (Constraint)
 import Data.Default.Class (Default, def)
@@ -256,8 +254,7 @@ import Shelley.Spec.Ledger.TxBody
     witKeyHash,
   )
 import Shelley.Spec.Ledger.UTxO
-  ( TransUTxO,
-    UTxO (..),
+  ( UTxO (..),
     balance,
     totalDeposits,
     txinLookup,
@@ -502,30 +499,10 @@ instance (TransEpoch ToCBOR era) => ToCBOR (EpochState era) where
     encodeListLen 6 <> toCBOR a <> toCBOR s <> toCBOR l <> toCBOR r <> toCBOR p <> toCBOR n
 
 instance
-  ( FromCBOR (Annotator (Core.PParams era)),
-    TransValue FromCBOR era,
-    TransUTxO FromCBOR era,
-    HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era),
-    FromCBOR (Annotator (State (Core.EraRule "PPUP" era))),
-    Era era
-  ) =>
-  FromCBOR (Annotator (EpochState era))
-  where
-  fromCBOR =
-    decode $
-      Ann (RecD EpochState)
-        <*! Ann From
-        <*! Ann From
-        <*! From
-        <*! From
-        <*! From
-        <*! Ann From
-
-instance
   ( FromCBOR (Core.PParams era),
     TransValue FromCBOR era,
-    TransUTxO FromCBOR era,
     HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era),
+    FromCBOR (Core.TxOut era),
     FromCBOR (State (Core.EraRule "PPUP" era)),
     Era era
   ) =>
@@ -571,16 +548,6 @@ instance NoThunks (PParamsDelta era) => NoThunks (PPUPState era)
 instance (Era era, ToCBOR (PParamsDelta era)) => ToCBOR (PPUPState era) where
   toCBOR (PPUPState ppup fppup) =
     encodeListLen 2 <> toCBOR ppup <> toCBOR fppup
-
-instance
-  (Era era, FromCBOR (Annotator (PParamsDelta era))) =>
-  FromCBOR (Annotator (PPUPState era))
-  where
-  fromCBOR =
-    decode $
-      Ann (RecD PPUPState)
-        <*! From
-        <*! From
 
 instance
   (Era era, FromCBOR (PParamsDelta era)) =>
@@ -639,24 +606,8 @@ instance
 
 instance
   ( TransValue FromCBOR era,
-    TransUTxO FromCBOR era,
-    FromCBOR (Annotator (State (Core.EraRule "PPUP" era))),
-    HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era)
-  ) =>
-  FromCBOR (Annotator (UTxOState era))
-  where
-  fromCBOR =
-    decode $
-      Ann (RecD UTxOState)
-        <*! Ann From
-        <*! Ann From
-        <*! Ann From
-        <*! From
-
-instance
-  ( TransValue FromCBOR era,
-    TransUTxO FromCBOR era,
     FromCBOR (State (Core.EraRule "PPUP" era)),
+    FromCBOR (Core.TxOut era),
     HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era)
   ) =>
   FromCBOR (UTxOState era)
@@ -711,8 +662,9 @@ instance
 
 instance
   ( Era era,
-    TransUTxO FromCBOR era,
     FromCBOR (Core.PParams era),
+    FromCBOR (Core.TxOut era),
+    FromCBOR (Core.Value era),
     FromCBOR (State (Core.EraRule "PPUP" era))
   ) =>
   FromCBOR (NewEpochState era)
@@ -726,24 +678,6 @@ instance
         <! From
         <! From
         <! From
-
-instance
-  ( Era era,
-    TransUTxO FromCBOR era,
-    FromCBOR (Annotator (Core.PParams era)),
-    FromCBOR (Annotator (State (Core.EraRule "PPUP" era)))
-  ) =>
-  FromCBOR (Annotator (NewEpochState era))
-  where
-  fromCBOR = do
-    decode $
-      Ann (RecD NewEpochState)
-        <*! Ann From
-        <*! Ann From
-        <*! Ann From
-        <*! From
-        <*! Ann From
-        <*! Ann From
 
 getGKeys ::
   NewEpochState era ->
@@ -787,21 +721,8 @@ instance
 instance
   ( Era era,
     HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era),
-    TransUTxO FromCBOR era,
-    FromCBOR (Annotator (State (Core.EraRule "PPUP" era)))
-  ) =>
-  FromCBOR (Annotator (LedgerState era))
-  where
-  fromCBOR =
-    decode $
-      Ann (RecD LedgerState)
-        <*! From
-        <*! Ann From
-
-instance
-  ( Era era,
-    HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era),
-    TransUTxO FromCBOR era,
+    FromCBOR (Core.TxOut era),
+    FromCBOR (Core.Value era),
     FromCBOR (State (Core.EraRule "PPUP" era))
   ) =>
   FromCBOR (LedgerState era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/CDDL.hs
@@ -89,8 +89,8 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlTest @(TxIn ShelleyC) n "transaction_input",
       cddlTest' @(Metadata ShelleyE) n "transaction_metadata",
       cddlTest' @(MultiSig ShelleyC) n "multisig_script",
-      cddlTest' @(Update ShelleyE) n "update",
-      cddlTest' @(ProposedPPUpdates ShelleyE) n "proposed_protocol_parameter_updates",
+      cddlTest @(Update ShelleyE) n "update",
+      cddlTest @(ProposedPPUpdates ShelleyE) n "proposed_protocol_parameter_updates",
       cddlTest @(PParamsUpdate ShelleyE) n "protocol_param_update",
       cddlTest' @(Tx ShelleyE) n "transaction",
       cddlTest' @(LaxBlock ShelleyE) n "block"

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -769,7 +769,7 @@ tests =
                   )
               )
           e = EpochNo 0
-       in checkEncodingCBORAnnotated
+       in checkEncodingCBOR
             "full_update"
             (Update ppup e)
             ( (T $ TkListLen 2)
@@ -1314,7 +1314,7 @@ tests =
               es
               (SJust ru)
               pd
-       in checkEncodingCBORAnnotated
+       in checkEncodingCBOR
             "new_epoch_state"
             nes
             ( T (TkListLen 6)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Tripping/CBOR.hs
@@ -179,7 +179,7 @@ prop_roundtrip_PrtclState :: STS.PrtclState Mock.C_Crypto -> Property
 prop_roundtrip_PrtclState = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_LedgerState :: Ledger.LedgerState Mock.C -> Property
-prop_roundtrip_LedgerState = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
+prop_roundtrip_LedgerState = roundtrip toCBOR fromCBOR
 
 prop_roundtrip_NewEpochState :: Ledger.NewEpochState Mock.C -> Property
 prop_roundtrip_NewEpochState = roundtrip2 toCBOR fromCBOR


### PR DESCRIPTION
I have exchanged all the `FromCBOR (Annotator PParams)` instances for `FromCBOR PParams` instances, in all eras. And similarly all the type up to `NewEpochState` that were forced to be annotated due to the `PParams`.

(This PR does _not_ make the change so that the language view of the parameters stores it's own hash, I'll do that next).