### PR TITLE
cardano-ledger-shelley-ma: Expose TxBody fields via pattern

### DIFF
--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.Shelley.Constraints
   )
 import Cardano.Ledger.ShelleyMA.Rules.Utxo (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
-import Cardano.Ledger.ShelleyMA.TxBody (StrictMaybe, TxBody (..))
+import Cardano.Ledger.ShelleyMA.TxBody (StrictMaybe, TxBody (TxBody))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
 import qualified Data.ByteString.Char8 as BS


### PR DESCRIPTION
This is needed to use ShelleyMA.TxBody in https://github.com/input-output-hk/cardano-node/pull/2465 the same way Shelley.TxBody is used.