### PR TITLE
Validate pool reward account net ID at major pv 5

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
@@ -5,6 +5,7 @@
 module Shelley.Spec.Ledger.HardForks
   ( aggregatedRewards,
     allowMIRTransfer,
+    validatePoolRewardAccountNetID,
   )
 where
 
@@ -29,3 +30,11 @@ allowMIRTransfer ::
   pp ->
   Bool
 allowMIRTransfer pp = pvMajor (getField @"_protocolVersion" pp) > 4
+
+-- | Starting with protocol version 5, we will validate the network ID
+-- for the reward account listed in stake pool registration certificates.
+validatePoolRewardAccountNetID ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+validatePoolRewardAccountNetID pp = pvMajor (getField @"_protocolVersion" pp) > 4

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -133,6 +133,7 @@ test-suite shelley-spec-ledger-test
       Test.Shelley.Spec.Ledger.Examples.Federation
       Test.Shelley.Spec.Ledger.Examples.Init
       Test.Shelley.Spec.Ledger.Examples.GenesisDelegation
+      Test.Shelley.Spec.Ledger.Examples.NetworkID
       Test.Shelley.Spec.Ledger.Examples.Mir
       Test.Shelley.Spec.Ledger.Examples.MirTransfer
       Test.Shelley.Spec.Ledger.Examples.PoolLifetime

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/NetworkID.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/NetworkID.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Shelley.Spec.Ledger.Examples.NetworkID
+  ( testPoolNetworkId,
+  )
+where
+
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Control.State.Transition.Extended hiding (Assertion)
+import Data.Default.Class (def)
+import Shelley.Spec.Ledger.API
+  ( DCert (..),
+    Network (..),
+    POOL,
+    PParams' (..),
+    PoolCert (..),
+    PoolEnv (..),
+    PoolParams (..),
+    ProtVer (..),
+    RewardAcnt (..),
+  )
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
+import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
+import Test.Shelley.Spec.Ledger.Utils (applySTSTest, runShelleyBase)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, testCase)
+
+type ShelleyTest = ShelleyEra C_Crypto
+
+shelleyPV :: ProtVer
+shelleyPV = ProtVer 2 0
+
+alonzoPV :: ProtVer
+alonzoPV = ProtVer 5 0
+
+data Expectation = ExpectSuccess | ExpectFailure
+  deriving (Show, Eq)
+
+testPoolNetworkID ::
+  ProtVer ->
+  PoolParams C_Crypto ->
+  Expectation ->
+  Assertion
+testPoolNetworkID pv poolParams e = do
+  let st =
+        runShelleyBase $
+          applySTSTest @(POOL ShelleyTest)
+            (TRC (PoolEnv (SlotNo 0) def {_protocolVersion = pv}, def, DCertPool (RegPool poolParams)))
+  case (st, e) of
+    (Right _, ExpectSuccess) -> assertBool "" True
+    (Left _, ExpectFailure) -> assertBool "" True
+    (Right _, ExpectFailure) -> assertBool "We expected failure." False
+    (Left _, ExpectSuccess) -> assertBool "We expected success." False
+
+matchingNetworkIDPoolParams :: PoolParams C_Crypto
+matchingNetworkIDPoolParams =
+  Cast.alicePoolParams {_poolRAcnt = RewardAcnt Testnet Cast.aliceSHK}
+
+-- test globals use Testnet
+
+mismatchingNetworkIDPoolParams :: PoolParams C_Crypto
+mismatchingNetworkIDPoolParams =
+  Cast.alicePoolParams {_poolRAcnt = RewardAcnt Mainnet Cast.aliceSHK}
+
+-- test globals use Testnet
+
+testPoolNetworkId :: TestTree
+testPoolNetworkId =
+  testGroup
+    "Network IDs"
+    [ testCase "Incorrect Network ID is allowed pre-Alonzo" $
+        testPoolNetworkID
+          shelleyPV
+          mismatchingNetworkIDPoolParams
+          ExpectSuccess,
+      testCase "Incorrect Network ID is NOT allowed in Alonzo" $
+        testPoolNetworkID
+          alonzoPV
+          mismatchingNetworkIDPoolParams
+          ExpectFailure,
+      testCase "Correct Network ID is allowed pre-Alonzo" $
+        testPoolNetworkID
+          shelleyPV
+          matchingNetworkIDPoolParams
+          ExpectSuccess,
+      testCase "Correct Network ID is allowed in Alonzo" $
+        testPoolNetworkID
+          alonzoPV
+          matchingNetworkIDPoolParams
+          ExpectSuccess
+    ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -25,6 +25,7 @@ import Test.Shelley.Spec.Ledger.Examples (testCHAINExample)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import Test.Shelley.Spec.Ledger.Examples.EmptyBlock (exEmptyBlock)
 import Test.Shelley.Spec.Ledger.Examples.GenesisDelegation (genesisDelegExample)
+import Test.Shelley.Spec.Ledger.Examples.NetworkID (testPoolNetworkId)
 import Test.Shelley.Spec.Ledger.Examples.Mir (mirExample)
 import Test.Shelley.Spec.Ledger.Examples.MirTransfer (testMIRTransfer)
 import Test.Shelley.Spec.Ledger.Examples.PoolLifetime (poolLifetimeExample)
@@ -55,7 +56,8 @@ chainExamples =
       updatesExample,
       genesisDelegExample,
       mirExample,
-      testMIRTransfer
+      testMIRTransfer,
+      testPoolNetworkId
     ]
 
 multisigExamples :: TestTree


### PR DESCRIPTION
When stake pools register the stake credential for the leader rewards, we probably should have used a stake credential instead of a stake address (called a `RewardAcnt` in the implementation) in order to be consistent with stake key registrations. The difference between these two types is that a `RewardAcnt` is a network ID and a stake credential. What this means is that a stake pool can register a stake address for the wrong network, but still get rewards corresponding to the stake credential (hopefully folks are not actually registering the same credentials on multiple networks).

There are basically three options to fix this at the alonzo hard fork. We could change the types, but this is probably a lot of work. We could instead validate the network ID when a pool registers (with a switch on the protocol version), which is what I have done in this PR. We could instead pass the network ID to the reward calculation and treat stake addresses from the wrong network the same as unregistered addresses (again switching on the protocol version).