### PR TITLE
Add reqSignerHashes to Alonzo tx body

### DIFF
--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -706,7 +706,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \lor
       (\var{adh}=\fun{hashAD}~\var{ad})
       \\~\\
-      \hldiff{\fun{sdHash}~{txb}~=~\fun{hashWitnessPPData}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})}
+      \hldiff{\fun{wppHash}~{txb}~=~\fun{hashWitnessPPData}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})}
       \\~\\
       {
         \begin{array}{r}

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -160,7 +160,7 @@ type ShelleyStyleWitnessNeeds era =
 type AlonzoStyleAdditions era =
   ( HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))), -- BE SURE AND ADD THESE INSTANCES
     HasField "txdatahash" (Core.Tx era) (Map.Map (DataHash (Crypto era)) (Data era)),
-    HasField "sdHash" (Core.TxBody era) (StrictMaybe (WitnessPPDataHash (Crypto era)))
+    HasField "wppHash" (Core.TxBody era) (StrictMaybe (WitnessPPDataHash (Crypto era)))
   )
 
 -- | A somewhat generic STS transitionRule function for the Alonzo Era.
@@ -232,7 +232,7 @@ alonzoStyleWitness = do
         ]
       rdmrs wit = Map.map fst (txrdmrs wit)
       computedPPhash = hashWitnessPPData pp (Set.fromList languages) (rdmrs (wits' tx))
-      bodyPPhash = getField @"sdHash" txbody
+      bodyPPhash = getField @"wppHash" txbody
   bodyPPhash == computedPPhash ?! PPViewHashesDontMatch bodyPPhash computedPPhash
   pure u'
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -30,7 +30,7 @@ module Cardano.Ledger.Alonzo.TxBody
         txvldt,
         txUpdates,
         mint,
-        sdHash,
+        wppHash,
         adHash
       ),
     inputs',
@@ -42,7 +42,7 @@ module Cardano.Ledger.Alonzo.TxBody
     vldt',
     update',
     mint',
-    sdHash',
+    wppHash',
     adHash',
     AlonzoBody,
     EraIndependentWitnessPPData,
@@ -176,7 +176,7 @@ data TxBodyRaw era = TxBodyRaw
     -- The spec makes it clear that the mint field is a
     -- Cardano.Ledger.Mary.Value.Value, not a Core.Value.
     -- Operations on the TxBody in the AlonzoEra depend upon this.
-    _sdHash :: !(StrictMaybe (WitnessPPDataHash (Crypto era))),
+    _wppHash :: !(StrictMaybe (WitnessPPDataHash (Crypto era))),
     _adHash :: !(StrictMaybe (AuxiliaryDataHash (Crypto era)))
   }
   deriving (Generic, Typeable)
@@ -270,7 +270,7 @@ pattern TxBody
     txvldt,
     txUpdates,
     mint,
-    sdHash,
+    wppHash,
     adHash
   } <-
   TxBodyConstr
@@ -285,7 +285,7 @@ pattern TxBody
             _vldt = txvldt,
             _update = txUpdates,
             _mint = mint,
-            _sdHash = sdHash,
+            _wppHash = wppHash,
             _adHash = adHash
           }
         _
@@ -301,7 +301,7 @@ pattern TxBody
       vldtX
       updateX
       mintX
-      sdHashX
+      wppHashX
       adHashX =
         TxBodyConstr $
           memoBytes
@@ -316,7 +316,7 @@ pattern TxBody
                   vldtX
                   updateX
                   mintX
-                  sdHashX
+                  wppHashX
                   adHashX
             )
 
@@ -340,7 +340,7 @@ vldt' :: TxBody era -> ValidityInterval
 update' :: TxBody era -> StrictMaybe (Update era)
 adHash' :: TxBody era -> StrictMaybe (AuxiliaryDataHash (Crypto era))
 mint' :: TxBody era -> Value (Crypto era)
-sdHash' :: TxBody era -> StrictMaybe (WitnessPPDataHash (Crypto era))
+wppHash' :: TxBody era -> StrictMaybe (WitnessPPDataHash (Crypto era))
 inputs' (TxBodyConstr (Memo raw _)) = _inputs raw
 
 inputs_fee' (TxBodyConstr (Memo raw _)) = _inputs_fee raw
@@ -361,7 +361,7 @@ adHash' (TxBodyConstr (Memo raw _)) = _adHash raw
 
 mint' (TxBodyConstr (Memo raw _)) = _mint raw
 
-sdHash' (TxBodyConstr (Memo raw _)) = _sdHash raw
+wppHash' (TxBodyConstr (Memo raw _)) = _wppHash raw
 
 --------------------------------------------------------------------------------
 -- Serialisation
@@ -414,7 +414,7 @@ encodeTxBodyRaw
       _vldt = ValidityInterval bot top,
       _update,
       _mint,
-      _sdHash,
+      _wppHash,
       _adHash
     } =
     Keyed
@@ -431,7 +431,7 @@ encodeTxBodyRaw
       !> encodeKeyedStrictMaybe 6 _update
       !> encodeKeyedStrictMaybe 8 bot
       !> Omit isZero (Key 9 (E encodeMint _mint))
-      !> encodeKeyedStrictMaybe 11 _sdHash
+      !> encodeKeyedStrictMaybe 11 _wppHash
       !> encodeKeyedStrictMaybe 12 _adHash
     where
       encodeKeyedStrictMaybe key x =
@@ -510,7 +510,7 @@ instance
           (\x tx -> tx {_vldt = (_vldt tx) {invalidBefore = x}})
           (D (SJust <$> fromCBOR))
       bodyFields 9 = field (\x tx -> tx {_mint = x}) (D decodeMint)
-      bodyFields 11 = field (\x tx -> tx {_sdHash = x}) (D (SJust <$> fromCBOR))
+      bodyFields 11 = field (\x tx -> tx {_wppHash = x}) (D (SJust <$> fromCBOR))
       bodyFields 12 =
         field
           (\x tx -> tx {_adHash = x})
@@ -578,9 +578,9 @@ instance
 
 instance
   c ~ (Crypto era) =>
-  HasField "sdHash" (TxBody era) (StrictMaybe (WitnessPPDataHash c))
+  HasField "wppHash" (TxBody era) (StrictMaybe (WitnessPPDataHash c))
   where
-  getField (TxBodyConstr (Memo m _)) = _sdHash m
+  getField (TxBodyConstr (Memo m _)) = _wppHash m
 
 instance (Crypto era ~ c) => HasField "compactAddress" (TxOut era) (CompactAddr c) where
   getField (TxOutCompact a _ _) = a
@@ -626,7 +626,7 @@ ppTxBody (TxBodyConstr (Memo (TxBodyRaw i ifee o c w fee vi u mnt sdh axh) _)) =
       ("vldt", ppValidityInterval vi),
       ("update", ppStrictMaybe ppUpdate u),
       ("mint", ppValue mnt),
-      ("sdHash", ppStrictMaybe ppSafeHash sdh),
+      ("wppHash", ppStrictMaybe ppSafeHash sdh),
       ("adHash", ppStrictMaybe ppAuxDataHash axh)
     ]
 

--- a/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/impl/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -131,6 +131,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
       <*> genMintValues @c
       <*> arbitrary
       <*> arbitrary


### PR DESCRIPTION
Add `reqSignerHashes` to Alonzo tx body, and perform the corresponding validation in the `UTxOW` rule.

additionally (and unrelated, but in a separate commit), consistently use the name `wppHash` instead of `sdHash` (as per the new version of the spec).