### PR TITLE
Use wire encoding of redeemers in WitnessPPData

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -79,6 +79,7 @@ library test
   build-depends:
     cardano-ledger-alonzo,
     cardano-ledger-shelley-ma-test,
+    containers,
     plutus-tx,
     QuickCheck,
     shelley-spec-ledger-test,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
@@ -36,10 +36,14 @@ instance ToCBOR Language where
   toCBOR PlutusV1 = toCBOR (0 :: Int)
 
 instance FromCBOR Language where
-  fromCBOR = do n <- decodeWord64; case n of { 0 -> pure PlutusV1; m -> invalidKey (fromIntegral m) }
+  fromCBOR = do
+    n <- decodeWord64
+    case n of
+      0 -> pure PlutusV1
+      m -> invalidKey (fromIntegral m)
 
 nonNativeLanguages :: Set.Set Language
-nonNativeLanguages = Set.insert PlutusV1 Set.empty
+nonNativeLanguages = Set.singleton PlutusV1
 
 -- ==================================
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -543,8 +543,5 @@ getLanguageView ::
   forall era.
   PParams era ->
   Language ->
-  LangDepView era
-getLanguageView pp PlutusV1 =
-  case Map.lookup PlutusV1 (_costmdls pp) of
-    Just x -> (PlutusView x)
-    Nothing -> error ("CostModel map does not have cost for language: " ++ show PlutusV1)
+  Maybe (LangDepView era)
+getLanguageView pp PlutusV1 = PlutusView <$> Map.lookup PlutusV1 (_costmdls pp)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -240,8 +240,7 @@ alonzoStyleWitness = do
             isNativeScript @era script,
             Just l <- [language @era script]
         ]
-      rdmrs wit = Map.map fst (txrdmrs wit)
-      computedPPhash = hashWitnessPPData pp (Set.fromList languages) (rdmrs (wits' tx))
+      computedPPhash = hashWitnessPPData pp (Set.fromList languages) (txrdmrs . wits' $ tx)
       bodyPPhash = getField @"wppHash" txbody
   bodyPPhash == computedPPhash ?! PPViewHashesDontMatch bodyPPhash computedPPhash
   pure u'

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -13,7 +13,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure)
 -- TODO resolve the problem with the Utxow predicate failure type, so we will need this import
 -- import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
 import Cardano.Ledger.Alonzo.Scripts (Script)
-import Cardano.Ledger.Alonzo.Tx (CostModel, Tx)
+import Cardano.Ledger.Alonzo.Tx (CostModel, Tx, WitnessPPData)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Data.ByteString.Base16.Lazy as Base16
@@ -95,5 +95,7 @@ tests =
       testProperty "alonzo/UtxosPredicateFailure" $
         tripping @(UtxosPredicateFailure (AlonzoEra C_Crypto)),
       testProperty "Script" $
-        trippingAnn @(Script (AlonzoEra C_Crypto))
+        trippingAnn @(Script (AlonzoEra C_Crypto)),
+      testProperty "WitnessPPData" $
+        trippingAnn @(WitnessPPData (AlonzoEra C_Crypto))
     ]


### PR DESCRIPTION
`WitnessPPData` is used in phase 1 validation to ensure that a script is deterministic with respect to changes in protocol parameters. In particular, it is hashed and checked against a hash in the transaction body.

`WitnessPPData` consists of two main parts, the redeemers that are included in the transaction and a language specific view of the protocol parameters. When we construct the `WitnessPPData`, we need to preserve the encoding of the redeemers from the original transaction, so that the hash that we construct will compare properly with the hash in the body. This is what this PR accomplishes.