### PR TITLE
Add FromCBOR/ToCBOR instances for Config and related types

### DIFF
--- a/byron/crypto/src/Cardano/Crypto/Signing/Redeem/Compact.hs
+++ b/byron/crypto/src/Cardano/Crypto/Signing/Redeem/Compact.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Crypto.Signing.Redeem.Compact
@@ -32,6 +34,12 @@ import NoThunks.Class (NoThunks (..), InspectHeap (..))
 import Text.JSON.Canonical
   (FromObjectKey(..), JSValue(..), ToObjectKey(..), toJSString)
 
+import Cardano.Binary
+  ( FromCBOR(..)
+  , ToCBOR(..)
+  , enforceSize
+  , encodeListLen
+  )
 import Cardano.Crypto.Signing.Redeem.VerificationKey
   ( RedeemVerificationKey (..)
   , fromAvvmVK
@@ -49,6 +57,25 @@ data CompactRedeemVerificationKey =
   deriving (Eq, Generic, Show)
   deriving NoThunks via InspectHeap CompactRedeemVerificationKey
   deriving anyclass NFData
+
+instance ToCBOR CompactRedeemVerificationKey where
+  toCBOR (CompactRedeemVerificationKey a b c d)
+    = mconcat [
+        encodeListLen 4
+      , toCBOR @Word64 a
+      , toCBOR @Word64 b
+      , toCBOR @Word64 c
+      , toCBOR @Word64 d
+      ]
+
+instance FromCBOR CompactRedeemVerificationKey where
+  fromCBOR = do
+    enforceSize "CompactRedeemVerificationKey" 1
+    CompactRedeemVerificationKey
+      <$> fromCBOR @Word64
+      <*> fromCBOR @Word64
+      <*> fromCBOR @Word64
+      <*> fromCBOR @Word64
 
 getCompactRedeemVerificationKey :: Get CompactRedeemVerificationKey
 getCompactRedeemVerificationKey =

--- a/byron/ledger/impl/src/Cardano/Chain/Genesis/KeyHashes.hs
+++ b/byron/ledger/impl/src/Cardano/Chain/Genesis/KeyHashes.hs
@@ -21,6 +21,7 @@ import Formatting.Buildable (Buildable(..))
 import NoThunks.Class (NoThunks (..))
 import Text.JSON.Canonical (FromJSON(..), ToJSON(..))
 
+import Cardano.Binary
 import Cardano.Chain.Common (KeyHash)
 
 
@@ -41,3 +42,11 @@ instance Monad m => ToJSON m GenesisKeyHashes where
 instance MonadError SchemaError m => FromJSON m GenesisKeyHashes where
   fromJSON =
     fmap (GenesisKeyHashes . M.keysSet) . fromJSON @m @(Map KeyHash Word16)
+
+instance ToCBOR GenesisKeyHashes where
+  toCBOR (GenesisKeyHashes gkh) = encodeListLen 1 <> toCBOR @(Set KeyHash) gkh
+
+instance FromCBOR GenesisKeyHashes where
+  fromCBOR = do
+    enforceSize "GenesisKeyHashes" 1
+    GenesisKeyHashes <$> fromCBOR @(Set KeyHash)

--- a/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxOConfiguration.hs
+++ b/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxOConfiguration.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Chain.UTxO.UTxOConfiguration
   ( UTxOConfiguration(..)
@@ -13,6 +15,12 @@ import Cardano.Prelude
 import qualified Data.Set as Set
 import NoThunks.Class (NoThunks (..))
 
+import Cardano.Binary
+  ( FromCBOR(..)
+  , ToCBOR(..)
+  , enforceSize
+  , encodeListLen
+  )
 import Cardano.Chain.Common.Address (Address)
 import Cardano.Chain.Common.Compact (CompactAddress, toCompactAddress)
 
@@ -23,6 +31,16 @@ data UTxOConfiguration = UTxOConfiguration
     -- use these addresses as transaction inputs will be deemed invalid.
     tcAssetLockedSrcAddrs :: !(Set CompactAddress)
   } deriving (Eq,Show,Generic,NoThunks)
+
+instance ToCBOR UTxOConfiguration where
+  toCBOR (UTxOConfiguration tcAssetLockedSrcAddrs_)
+    = encodeListLen 1
+    <> toCBOR @(Set CompactAddress) tcAssetLockedSrcAddrs_
+
+instance FromCBOR UTxOConfiguration where
+  fromCBOR = do
+    enforceSize "UTxOConfiguration" 1
+    UTxOConfiguration <$> fromCBOR @(Set CompactAddress)
 
 defaultUTxOConfiguration :: UTxOConfiguration
 defaultUTxOConfiguration =

--- a/cabal.project
+++ b/cabal.project
@@ -23,8 +23,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4251c0bb6e4f443f00231d28f5f70d42876da055
-  --sha256: 02a61ymvx054pcdcgvg5qj9kpybiajg993nr22iqiya196jmgciv
+  tag: 9fb4624269dbfe0fe472da0449e4a9bd6910746a
+  --sha256: 18zb22q1wc7ksq575mks0i6g72az1n9i1vy7n950q8q2lzawl8r9
   subdir:
     binary
     binary/test


### PR DESCRIPTION
This adds serialization instances for `Config`. This is blocked on merging serialization for UTCTime: https://github.com/input-output-hk/cardano-base/issues/208.