### PR TITLE
Downgrade cabal file version to 2.4

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 
 name:                cardano-ledger-alonzo
 version:             0.1.0.0

--- a/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/cardano-ledger-test/cardano-ledger-test.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 
 name:                cardano-ledger-test
 version:             0.1.0.0


### PR DESCRIPTION
It turns out `3.0` is incompatible with stack, which is used by `cardano-wallet` downstream.