### PR TITLE
Remove error calls, export type families from Era defining modules.

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -104,7 +104,6 @@ test-suite tests
     bytestring,
     cardano-binary,
     cardano-ledger-alonzo,
-    cardano-ledger-core,
     cardano-ledger-shelley-ma-test,
     QuickCheck,
     shelley-spec-ledger,

--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -58,6 +58,7 @@ library
     containers,
     data-default,
     deepseq,
+    flat,
     nothunks,
     plutus-ledger-api,
     plutus-tx,

--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -47,6 +47,7 @@ library
     Cardano.Ledger.Alonzo.TxBody
     Cardano.Ledger.Alonzo.TxInfo
     Cardano.Ledger.Alonzo.TxWitness
+    Cardano.Ledger.DescribeEras
   build-depends:
     bytestring,
     cardano-binary,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -21,15 +21,15 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (getPlutusData,AuxiliaryData (..))
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), getPlutusData)
 import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..), PParamsUpdate, updatePParams)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
 import Cardano.Ledger.Alonzo.Tx (IsValidating (..), Tx, alonzoSeqTx, body', isValidating', wits')
-import Cardano.Ledger.Alonzo.TxInfo(validPlutusdata)
 import Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut (..), vldt')
+import Cardano.Ledger.Alonzo.TxInfo (validPlutusdata, validScript)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
 import qualified Cardano.Ledger.Core as Core
@@ -44,7 +44,6 @@ import Cardano.Ledger.Shelley.Constraints
     UsesValue,
   )
 import Cardano.Ledger.ShelleyMA.Timelocks (evalTimelock)
-import Control.DeepSeq (deepseq)
 import Control.State.Transition.Extended (STUB)
 import qualified Control.State.Transition.Extended as STS
 import qualified Data.Set as Set
@@ -139,10 +138,9 @@ instance
 instance CC.Crypto c => ValidateAuxiliaryData (AlonzoEra c) c where
   hashAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)
   validateAuxiliaryData (AuxiliaryData metadata scrips plutusdata) =
-    deepseq scrips $
-      ( all validMetadatum metadata
-          && all (validPlutusdata . getPlutusData) plutusdata
-      )
+    all validMetadatum metadata
+      && all validScript scrips
+      && all (validPlutusdata . getPlutusData) plutusdata
 
 instance CC.Crypto c => EraModule.BlockDecoding (AlonzoEra c) where
   seqTx body wit isval aux = alonzoSeqTx body wit isval aux

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -21,13 +21,14 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..))
+import Cardano.Ledger.Alonzo.Data (getPlutusData,AuxiliaryData (..))
 import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..), PParamsUpdate, updatePParams)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
 import Cardano.Ledger.Alonzo.Tx (IsValidating (..), Tx, alonzoSeqTx, body', isValidating', wits')
+import Cardano.Ledger.Alonzo.TxInfo(validPlutusdata)
 import Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut (..), vldt')
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -50,7 +51,7 @@ import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import qualified Shelley.Spec.Ledger.API as API
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
-import Shelley.Spec.Ledger.Metadata (Metadata (..), validMetadatum)
+import Shelley.Spec.Ledger.Metadata (validMetadatum)
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Bbody as Shelley
 import qualified Shelley.Spec.Ledger.STS.Epoch as Shelley
@@ -137,10 +138,10 @@ instance
 
 instance CC.Crypto c => ValidateAuxiliaryData (AlonzoEra c) c where
   hashAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)
-  validateAuxiliaryData (AuxiliaryData scrips plutusdata metadata) =
+  validateAuxiliaryData (AuxiliaryData metadata scrips plutusdata) =
     deepseq scrips $
-      ( all (\(Metadata d) -> all validMetadatum d) metadata
-          && all (const False) plutusdata -- TODO what do we do with plutusdata?
+      ( all validMetadatum metadata
+          && all (validPlutusdata . getPlutusData) plutusdata
       )
 
 instance CC.Crypto c => EraModule.BlockDecoding (AlonzoEra c) where

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -47,13 +47,13 @@ import Cardano.Ledger.Pretty
     ppInteger,
     ppList,
     ppLong,
+    ppMap,
+    ppMetadatum,
     ppPair,
     ppSet,
     ppSexp,
     ppStrictSeq,
-    ppMap,
     ppWord64,
-    ppMetadatum,
   )
 import Cardano.Ledger.SafeHash
   ( HashAnnotated,
@@ -62,12 +62,12 @@ import Cardano.Ledger.SafeHash
     hashAnnotated,
   )
 import Data.Coders
+import Data.Map (Map)
 import Data.MemoBytes (Mem, MemoBytes (..), memoBytes)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
-import Data.Map(Map)
 import GHC.Generics (Generic)
 -- import Plutus.V1.Ledger.Scripts-- Supply the HasField and Validate instances for Alonzo
 import qualified Language.PlutusTx as Plutus
@@ -142,7 +142,6 @@ data AuxiliaryDataRaw era = AuxiliaryDataRaw
   { txMD' :: !(Map Word64 Metadatum),
     scripts' :: !(StrictSeq (Core.Script era)),
     dats' :: !(Set (Data era))
-
   }
   deriving (Generic)
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -104,7 +104,7 @@ instance NFData (ScriptRaw era)
 
 -- | Scripts in the Alonzo Era, a combination of Timelock and Plutus Scripts.
 newtype Script era = ScriptConstr (MemoBytes (ScriptRaw era))
-  deriving newtype (Eq, Show, Generic, Ord, NoThunks, ToCBOR, SafeToHash)
+  deriving newtype (Eq, Show, Generic, Ord, NoThunks, ToCBOR, SafeToHash, NFData)
 
 deriving via (Mem (ScriptRaw era)) instance (Era era) => FromCBOR (Annotator (Script era))
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -123,7 +123,6 @@ import qualified Data.ByteString.Lazy as LBS (toStrict)
 import qualified Data.ByteString.Short as SBS (length, toShort)
 import Data.Coders
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes)
 import Data.MemoBytes (Mem, MemoBytes (Memo), memoBytes)
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -26,7 +26,7 @@ import qualified Cardano.Ledger.Alonzo.FakePlutus as P
     TxInfo (..),
     TxOut (..),
   )
-import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Script (..))
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( certs',
@@ -49,12 +49,15 @@ import Cardano.Ledger.SafeHash
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.Val (Val (..))
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
+import Control.DeepSeq (deepseq)
 import Data.ByteString as BS (ByteString, length)
-import Data.ByteString.Short as SBS (ShortByteString,fromShort, toShort)
+import Data.ByteString.Short as SBS (ShortByteString, fromShort)
+import qualified Data.ByteString.Short as Short (ShortByteString, fromShort)
 import qualified Data.Map as Map
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
+import qualified Flat as Flat (unflat)
 import GHC.Records (HasField (..))
 import qualified Language.PlutusCore.Evaluation.Machine.ExMemory as P (ExCPU (..), ExMemory (..))
 import qualified Language.PlutusTx as P (Data (..))
@@ -68,7 +71,7 @@ import qualified Plutus.V1.Ledger.Interval as P
     LowerBound (..),
     UpperBound (..),
   )
-import qualified Plutus.V1.Ledger.Scripts as P (Datum (..), DatumHash (..), ValidatorHash (..))
+import qualified Plutus.V1.Ledger.Scripts as P (Datum (..), DatumHash (..), Script (..), ValidatorHash (..))
 import qualified Plutus.V1.Ledger.Slot as P (SlotRange)
 import qualified Plutus.V1.Ledger.Tx as P (TxOutRef (..))
 import qualified Plutus.V1.Ledger.TxId as P (TxId (..))
@@ -90,8 +93,6 @@ import Shelley.Spec.Ledger.TxBody
     WitVKey (..),
   )
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
-import qualified Flat as Flat (unflat)
-import qualified Data.ByteString.Short as Short (ShortByteString, fromShort)
 
 -- =========================================================
 -- Translate Hashes, Credentials, Certificates etc.
@@ -336,15 +337,13 @@ runPLCScript cost scriptbytestring units ds =
     (_, Left _) -> False
     (_, Right ()) -> True
 
-
 validPlutusdata :: P.Data -> Bool
 validPlutusdata (P.Constr _n ds) = all validPlutusdata ds
 validPlutusdata (P.Map ds) =
-   all (\ (x,y) -> validPlutusdata x && validPlutusdata y) ds
+  all (\(x, y) -> validPlutusdata x && validPlutusdata y) ds
 validPlutusdata (P.List ds) = all validPlutusdata ds
 validPlutusdata (P.I _n) = True
 validPlutusdata (P.B bs) = BS.length bs <= 64
-
 
 -- | A ByteString represents a valid P.Script if it can be unflattened
 validPlutusScript :: Short.ShortByteString -> Bool
@@ -352,3 +351,11 @@ validPlutusScript flatBytes =
   case Flat.unflat (Short.fromShort flatBytes) of
     Right (_x :: P.Script) -> True
     Left _err -> False
+
+-- | Test that every Alonzo script represents a real Script.
+--     Run deepseq to see that there are no infinite computations and that
+--     every Plutus Script unflattens into a real P.Script
+validScript :: Era era => Script era -> Bool
+validScript scrip = deepseq scrip $ case scrip of
+  TimelockScript _ -> True
+  PlutusScript bytes -> validPlutusScript bytes

--- a/alonzo/impl/src/Cardano/Ledger/DescribeEras.hs
+++ b/alonzo/impl/src/Cardano/Ledger/DescribeEras.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.DescribeEras
+  ( Witness (..),
+    Checks (..),
+    DescribesShelley,
+    DescribesAllegra,
+    DescribesMary,
+    DescribesAlonzo,
+    StandardCrypto,
+  )
+where
+
+import qualified Cardano.Ledger.Allegra as Allegra
+import qualified Cardano.Ledger.Alonzo as Alonzo
+import Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Era (WellFormed)
+import qualified Cardano.Ledger.Mary as Mary
+import qualified Cardano.Ledger.Shelley as Shelley
+
+type DescribesShelley era =
+  ( WellFormed era,
+    Core.Value era ~ Shelley.Value era,
+    Core.TxBody era ~ Shelley.TxBody era,
+    Core.TxOut era ~ Shelley.TxOut era,
+    Core.Script era ~ Shelley.Script era,
+    Core.AuxiliaryData era ~ Shelley.AuxiliaryData era,
+    Core.PParams era ~ Shelley.PParams era,
+    Core.Tx era ~ Shelley.Tx era
+  )
+
+type DescribesAllegra era =
+  ( WellFormed era,
+    Core.Value era ~ Shelley.Value era,
+    Core.TxBody era ~ Allegra.TxBody era,
+    Core.TxOut era ~ Shelley.TxOut era,
+    Core.Script era ~ Allegra.Script era,
+    Core.AuxiliaryData era ~ Allegra.AuxiliaryData era,
+    Core.PParams era ~ Shelley.PParams era,
+    Core.Tx era ~ Shelley.Tx era
+  )
+
+type DescribesMary era =
+  ( WellFormed era,
+    Core.Value era ~ Mary.Value era,
+    Core.TxBody era ~ Allegra.TxBody era,
+    Core.TxOut era ~ Shelley.TxOut era,
+    Core.Script era ~ Allegra.Script era,
+    Core.AuxiliaryData era ~ Allegra.AuxiliaryData era,
+    Core.PParams era ~ Shelley.PParams era,
+    Core.Tx era ~ Shelley.Tx era
+  )
+
+type DescribesAlonzo era =
+  ( WellFormed era,
+    Core.Value era ~ Mary.Value era,
+    Core.TxBody era ~ Alonzo.TxBody era,
+    Core.TxOut era ~ Alonzo.TxOut era,
+    Core.Script era ~ Alonzo.Script era,
+    Core.AuxiliaryData era ~ Alonzo.AuxiliaryData era,
+    Core.PParams era ~ Alonzo.PParams era,
+    Core.Tx era ~ Alonzo.Tx era
+  )
+
+-- | If an instance for this class compiles, then era meets whatever superclass its given.
+class Checks era where
+  checks :: Witness era -> Bool
+
+instance DescribesShelley (Shelley.Self c) => Checks (Shelley.Self c) where
+  checks (Shelley) = True
+
+instance DescribesAllegra (Allegra.Self c) => Checks (Allegra.Self c) where
+  checks (Allegra) = True
+
+instance DescribesMary (Mary.Self c) => Checks (Mary.Self c) where
+  checks (Mary) = True
+
+instance DescribesAlonzo (Alonzo.Self c) => Checks (Alonzo.Self c) where
+  checks (Alonzo) = True
+
+-- ==========================================================
+
+-- | Witness of a valid (predefined) era
+data Witness era where
+  Shelley :: Witness (Shelley.ShelleyEra StandardCrypto)
+  Mary :: Witness (Mary.MaryEra StandardCrypto)
+  Allegra :: Witness (Allegra.AllegraEra StandardCrypto)
+  Alonzo :: Witness (Alonzo.AlonzoEra StandardCrypto)
+
+instance Show (Witness e) where
+  show (Shelley) = "Shelley"
+  show (Allegra) = "Allegra"
+  show (Mary) = "Mary"
+  show (Alonzo) = "Alonzo"

--- a/alonzo/impl/src/Cardano/Ledger/DescribeEras.hs
+++ b/alonzo/impl/src/Cardano/Ledger/DescribeEras.hs
@@ -34,7 +34,8 @@ type DescribesShelley era =
     Core.Script era ~ Shelley.Script era,
     Core.AuxiliaryData era ~ Shelley.AuxiliaryData era,
     Core.PParams era ~ Shelley.PParams era,
-    Core.Tx era ~ Shelley.Tx era
+    Core.Tx era ~ Shelley.Tx era,
+    Core.PParamsDelta era ~ Shelley.PParamsDelta era
   )
 
 type DescribesAllegra era =
@@ -45,7 +46,8 @@ type DescribesAllegra era =
     Core.Script era ~ Allegra.Script era,
     Core.AuxiliaryData era ~ Allegra.AuxiliaryData era,
     Core.PParams era ~ Shelley.PParams era,
-    Core.Tx era ~ Shelley.Tx era
+    Core.Tx era ~ Shelley.Tx era,
+    Core.PParamsDelta era ~ Shelley.PParamsDelta era
   )
 
 type DescribesMary era =
@@ -56,7 +58,8 @@ type DescribesMary era =
     Core.Script era ~ Allegra.Script era,
     Core.AuxiliaryData era ~ Allegra.AuxiliaryData era,
     Core.PParams era ~ Shelley.PParams era,
-    Core.Tx era ~ Shelley.Tx era
+    Core.Tx era ~ Shelley.Tx era,
+    Core.PParamsDelta era ~ Shelley.PParamsDelta era
   )
 
 type DescribesAlonzo era =
@@ -67,7 +70,8 @@ type DescribesAlonzo era =
     Core.Script era ~ Alonzo.Script era,
     Core.AuxiliaryData era ~ Alonzo.AuxiliaryData era,
     Core.PParams era ~ Alonzo.PParams era,
-    Core.Tx era ~ Alonzo.Tx era
+    Core.Tx era ~ Alonzo.Tx era,
+    Core.PParamsDelta era ~ Alonzo.PParamsDelta era
   )
 
 -- | If an instance for this class compiles, then era meets whatever superclass its given.

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -5,7 +5,7 @@
 module Test.Cardano.Ledger.Alonzo.Serialisation.Tripping where
 
 import Cardano.Binary
-import Cardano.Ledger.Alonzo
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (AuxiliaryData, Data)
 import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)

--- a/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/cardano-ledger-core/cardano-ledger-core.cabal
@@ -55,6 +55,7 @@ library
     bytestring,
     cardano-binary,
     cardano-crypto-class,
+    cardano-crypto-praos,
     cardano-prelude,
     containers,
     deepseq,

--- a/cardano-ledger-core/src/Cardano/Ledger/Crypto.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Crypto.hs
@@ -8,6 +8,7 @@ import Cardano.Crypto.DSIGN
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import Cardano.Crypto.VRF
+import Cardano.Crypto.VRF.Praos
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 
@@ -29,3 +30,18 @@ class
   type DSIGN c :: Type
   type KES c :: Type
   type VRF c :: Type
+
+-- ================================
+
+-- | The same crypto used on the net
+data StandardCrypto
+
+-- This should match that defined at
+-- https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+
+instance Crypto StandardCrypto where
+  type DSIGN StandardCrypto = Ed25519DSIGN
+  type KES StandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256
+  type VRF StandardCrypto = PraosVRF
+  type HASH StandardCrypto = Blake2b_256
+  type ADDRHASH StandardCrypto = Blake2b_224

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -3,17 +3,34 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Allegra where
+module Cardano.Ledger.Allegra
+  ( AllegraEra,
+    Self,
+    TxOut,
+    TxBody,
+    Value,
+    Script,
+    AuxiliaryData,
+    PParams,
+    PParamsDelta,
+    Tx,
+    Witnesses,
+  )
+where
 
 import Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Era as E (Era (Crypto))
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody ()
 import Cardano.Ledger.Val (Val ((<->)))
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
-import Shelley.Spec.Ledger.API
+import Shelley.Spec.Ledger.API hiding (PParams, Tx, TxBody, TxOut, WitnessSet)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
+import qualified Shelley.Spec.Ledger.PParams as Shelley (PParamsUpdate)
+import Shelley.Spec.Ledger.Tx (WitnessSet)
 
 type AllegraEra = ShelleyMAEra 'Allegra
 
@@ -61,3 +78,15 @@ instance
       pp = sgProtocolParams sg
 
 instance PraosCrypto c => ShelleyBasedEra (AllegraEra c)
+
+-- Self-Describing type synomyms
+
+type Self c = ShelleyMAEra 'Allegra c
+
+type Script era = Timelock (E.Crypto era)
+
+type Value era = Coin
+
+type Witnesses era = WitnessSet (E.Crypto era)
+
+type PParamsDelta era = Shelley.PParamsUpdate era

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -3,20 +3,34 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Mary where
+module Cardano.Ledger.Mary
+  ( MaryEra,
+    Self,
+    TxOut,
+    Value,
+    TxBody,
+    Script,
+    AuxiliaryData,
+    PParams,
+    PParamsDelta,
+    Tx,
+  )
+where
 
 import Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Era as E (Era (Crypto))
+import qualified Cardano.Ledger.Mary.Value as V (Value)
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxo ()
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.Val (Val ((<->)), coin, inject)
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
-import Shelley.Spec.Ledger.API
+import Shelley.Spec.Ledger.API hiding (TxBody)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
-
-type MaryEra = ShelleyMAEra 'Mary
+import qualified Shelley.Spec.Ledger.PParams as Shelley (PParamsUpdate)
 
 instance PraosCrypto c => ApplyTx (MaryEra c)
 
@@ -63,3 +77,15 @@ instance
       pp = sgProtocolParams sg
 
 instance PraosCrypto c => ShelleyBasedEra (MaryEra c)
+
+-- Self-Describing type synomyms
+
+type MaryEra c = ShelleyMAEra 'Mary c
+
+type Self c = ShelleyMAEra 'Mary c
+
+type Script era = Timelock (E.Crypto era)
+
+type Value era = V.Value (E.Crypto era)
+
+type PParamsDelta era = Shelley.PParamsUpdate era

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -9,7 +9,16 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Cardano.Ledger.ShelleyMA where
+module Cardano.Ledger.ShelleyMA
+  ( ShelleyMAEra,
+    MaryOrAllegra (..),
+    TxOut,
+    TxBody,
+    AuxiliaryData,
+    Shelley.PParams,
+    Tx,
+  )
+where
 
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -114,7 +114,6 @@ library
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class,
-    cardano-crypto-praos,
     cardano-crypto-wrapper,
     cardano-ledger-byron,
     cardano-ledger-core,

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -114,6 +114,7 @@ library
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class,
+    cardano-crypto-praos,
     cardano-crypto-wrapper,
     cardano-ledger-byron,
     cardano-ledger-core,

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -11,7 +11,21 @@
 -- | Definition of the shelley era, along with instances ot the @Core@ types
 -- defined in @module Cardano.Ledger.Core@, and instances of the @API@ classes
 -- exposed in @module Shelley.Spec.Ledger.API@.
-module Cardano.Ledger.Shelley where
+module Cardano.Ledger.Shelley
+  ( ShelleyEra,
+    Self,
+    TxOut,
+    TxBody,
+    Value,
+    Script,
+    AuxiliaryData,
+    PParams,
+    PParamsDelta,
+    Tx,
+    Witnesses,
+    nativeMultiSigTag,
+  )
+where
 
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
@@ -20,7 +34,8 @@ import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Era (BlockDecoding (..), Era (Crypto), ValidateScript (..))
+import Cardano.Ledger.Era (BlockDecoding (..), ValidateScript (..))
+import qualified Cardano.Ledger.Era as E (Era (Crypto))
 import Cardano.Ledger.Hashes (EraIndependentAuxiliaryData)
 import Cardano.Ledger.SafeHash (makeHashWithExplicitProxys)
 import Cardano.Ledger.Shelley.Constraints
@@ -32,26 +47,25 @@ import Cardano.Ledger.Shelley.Constraints
 import qualified Data.ByteString as BS
 import Data.Proxy
 import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
-import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, updatePParams)
+import Shelley.Spec.Ledger.PParams (PParamsUpdate, updatePParams)
+import qualified Shelley.Spec.Ledger.PParams as SPP (PParams)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
-  ( Tx,
-    TxBody,
-    TxOut (..),
-    WitnessSet,
+  ( WitnessSet,
     segwitTx,
     validateNativeMultiSigScript,
   )
+import qualified Shelley.Spec.Ledger.Tx as STx (Tx, TxBody, TxOut (..))
 
 data ShelleyEra c
 
-instance CryptoClass.Crypto c => Era (ShelleyEra c) where
+instance CryptoClass.Crypto c => E.Era (ShelleyEra c) where
   type Crypto (ShelleyEra c) = c
 
 instance CryptoClass.Crypto c => UsesValue (ShelleyEra c)
 
 instance CryptoClass.Crypto c => UsesTxOut (ShelleyEra c) where
-  makeTxOut _ a v = TxOut a v
+  makeTxOut _ a v = STx.TxOut a v
 
 instance CryptoClass.Crypto c => UsesPParams (ShelleyEra c) where
   type PParamsDelta (ShelleyEra c) = PParamsUpdate (ShelleyEra c)
@@ -63,17 +77,17 @@ instance CryptoClass.Crypto c => UsesPParams (ShelleyEra c) where
 
 type instance Core.Value (ShelleyEra _c) = Coin
 
-type instance Core.TxBody (ShelleyEra c) = TxBody (ShelleyEra c)
+type instance Core.TxBody (ShelleyEra c) = STx.TxBody (ShelleyEra c)
 
-type instance Core.TxOut (ShelleyEra c) = TxOut (ShelleyEra c)
+type instance Core.TxOut (ShelleyEra c) = STx.TxOut (ShelleyEra c)
 
 type instance Core.Script (ShelleyEra c) = MultiSig c
 
 type instance Core.AuxiliaryData (ShelleyEra c) = Metadata (ShelleyEra c)
 
-type instance Core.PParams (ShelleyEra c) = PParams (ShelleyEra c)
+type instance Core.PParams (ShelleyEra c) = SPP.PParams (ShelleyEra c)
 
-type instance Core.Tx (ShelleyEra c) = Tx (ShelleyEra c)
+type instance Core.Tx (ShelleyEra c) = STx.Tx (ShelleyEra c)
 
 type instance Core.Witnesses (ShelleyEra c) = WitnessSet (ShelleyEra c)
 
@@ -107,3 +121,23 @@ instance CryptoClass.Crypto c => ValidateAuxiliaryData (ShelleyEra c) c where
   hashAuxiliaryData metadata = AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)
     where
       index = Proxy @EraIndependentAuxiliaryData
+
+-- Self describing synonyms
+
+type Value era = Coin
+
+type Script era = MultiSig (E.Crypto era)
+
+type AuxiliaryData era = Metadata era
+
+type Self c = ShelleyEra c
+
+type Tx era = STx.Tx era
+
+type TxOut era = STx.TxOut era
+
+type TxBody era = STx.TxBody era
+
+type PParams era = SPP.PParams era
+
+type Witnesses era = WitnessSet (E.Crypto era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Address.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Address.hs
@@ -15,12 +15,9 @@ module Test.Shelley.Spec.Ledger.Serialisation.Golden.Address
 where
 
 import qualified Cardano.Chain.Common as Byron
-import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import Cardano.Crypto.Hash (Hash (..), HashAlgorithm (..), hashFromBytes, sizeHash)
-import Cardano.Crypto.Hash.Blake2b (Blake2b_224, Blake2b_256)
-import Cardano.Crypto.KES.Sum
-import Cardano.Crypto.VRF.Simple (SimpleVRF)
-import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Crypto.Hash.Blake2b (Blake2b_224)
+import Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Data.Binary as B
 import qualified Data.Binary.Put as B
 import qualified Data.ByteString as BS
@@ -55,16 +52,9 @@ import Cardano.Ledger.Shelley(ShelleyEra)
 -- Crypto family as used in production Shelley
 -- This should match that defined at https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
 
-data ShelleyCrypto
+type ShelleyCrypto = StandardCrypto
 
-instance Cardano.Ledger.Crypto.Crypto ShelleyCrypto where
-  type DSIGN ShelleyCrypto = Ed25519DSIGN
-  type KES ShelleyCrypto = Sum7KES Ed25519DSIGN Blake2b_256
-  type VRF ShelleyCrypto = SimpleVRF
-  type HASH ShelleyCrypto = Blake2b_256
-  type ADDRHASH ShelleyCrypto = Blake2b_224
-
-type Shelley = ShelleyEra ShelleyCrypto
+type Shelley = ShelleyEra StandardCrypto
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
Filled in two calls to error in the Alonzo.hs file.
Made the Shelley, Allegra, Mary, and Alonzo files export type synonyms for
their type familes. So  Alonzo.TxBody  is the TxBody in the Alonzo era.
Added the file DescribeEras that adds descriptions of each Era. This file
won't compile if the descriptions are not accurate. Adds a much needed level
of documentation, about the reltinship between Eras.
Added a Ledger description of StandardCrypto in Cardano.Ledger.Crypto.