### PR TITLE
small fixes to alonzo UTXOW rule

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -83,7 +83,7 @@ instance (CC.Crypto c) => Shelley.ValidateScript (AlonzoEra c) where
   validateScript (TimelockScript timelock) tx = evalTimelock vhks (vldt' (body' tx)) timelock
     where
       vhks = Set.map witKeyHash (txwitsVKey' (wits' tx))
-  validateScript (PlutusScript _) _tx = False -- Plutus scripts are stripped out an run in function evalScripts
+  validateScript (PlutusScript _) _tx = True -- Plutus scripts are stripped out an run in function evalScripts
   -- hashScript x = ...  We use the default method for hashScript
 
 instance


### PR DESCRIPTION
* the `languages` should be collected from 2-phase scripts
* the `UTXOW` rule needs to call the `UTXO` rule
* `validateScript` should not fail on plutus scripts. ideally it would passed to this function, but fixing that would be more involved. we should consider how to do this better.