### PR TITLE
two minor alonzo tweaks

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -112,7 +112,7 @@ collectNNScriptInputs ::
   [(AlonzoScript.Script era, [Data era], ExUnits, CostModel)]
 collectNNScriptInputs pp tx utxo =
   let txinfo = transTx utxo tx
-   in [ (script, d : (valContext txinfo sp ++ getData tx utxo sp), eu, cost)
+   in [ (script, d : (valContext txinfo sp : getData tx utxo sp), eu, cost)
         | (sp, scripthash) <- scriptsNeeded utxo tx, -- TODO, IN specification ORDER IS WRONG
           (d, eu) <- maybeToList (indexedRdmrs tx sp),
           script <- maybeToList (Map.lookup scripthash (txscripts' (getField @"wits" tx))),

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -523,10 +523,10 @@ indexedRdmrs ::
   Tx era ->
   ScriptPurpose (Crypto era) ->
   Maybe (Data era, ExUnits)
-indexedRdmrs tx sp = Map.lookup policyid rdmrs
+indexedRdmrs tx sp = Map.lookup rdptr' rdmrs
   where
     rdmrs = unRedeemers $ txrdmrs' . getField @"wits" $ tx
-    policyid = rdptr @era (getField @"body" tx) sp
+    rdptr' = rdptr @era (getField @"body" tx) sp
 
 -- =======================================================
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -318,8 +318,8 @@ valContext ::
   Era era =>
   P.TxInfo ->
   ScriptPurpose (Crypto era) ->
-  [Data era]
-valContext txinfo sp = [Data (P.toData (P.Context txinfo (transScriptPurpose sp)))]
+  Data era
+valContext txinfo sp = Data (P.toData (P.Context txinfo (transScriptPurpose sp)))
 
 -- The runPLCScript in the Specification has a slightly different type
 -- than the one in the implementation below. Made necessary by the the type


### PR DESCRIPTION
:microscope: Small PR with two tweaks to sync the Alonzo implementation with the spec.

* Fix the parameter name `policyid` given to the `indexedRdmrs` function.
* `valContext` should return `Data`, not `[Data]`.