### PR TITLE
DataHash size via HeapWords of the min-utxo-value calculation

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Alonzo.Data
     DataHash,
     hashData,
     getPlutusData,
+    datHashSize,
     -- $
     AuxiliaryData (AuxiliaryData, scripts, dats, txMD),
     AuxiliaryDataHash (..),
@@ -36,6 +37,7 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Hashes
   ( EraIndependentAuxiliaryData,
@@ -61,6 +63,7 @@ import Cardano.Ledger.SafeHash
     SafeToHash,
     hashAnnotated,
   )
+import Cardano.Prelude (HeapWords (..), heapWords0, heapWords1)
 import Data.Coders
 import Data.Map (Map)
 import Data.MemoBytes (Mem, MemoBytes (..), memoBytes)
@@ -72,6 +75,7 @@ import GHC.Generics (Generic)
 -- import Plutus.V1.Ledger.Scripts-- Supply the HasField and Validate instances for Alonzo
 import qualified Language.PlutusTx as Plutus
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import Shelley.Spec.Ledger.Metadata (Metadatum)
 
 -- =====================================================================
@@ -134,6 +138,14 @@ type DataHash crypto = SafeHash crypto EraIndependentData
 
 hashData :: Era era => Data era -> DataHash (Crypto era)
 hashData d = hashAnnotated d
+
+-- Size of the datum hash attached to the output (could be Nothing)
+datHashSize :: (CC.Crypto c) => StrictMaybe (DataHash c) -> Integer
+datHashSize dh = fromIntegral $ heapWords dh
+
+instance (CC.Crypto c) => HeapWords (StrictMaybe (DataHash c)) where
+  heapWords SNothing = heapWords0
+  heapWords (SJust a) = heapWords1 a
 
 -- =============================================================================
 -- Version without serialized bytes

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Alonzo.Data
     DataHash,
     hashData,
     getPlutusData,
-    datHashSize,
+    dataHashSize,
     -- $
     AuxiliaryData (AuxiliaryData, scripts, dats, txMD),
     AuxiliaryDataHash (..),
@@ -140,8 +140,8 @@ hashData :: Era era => Data era -> DataHash (Crypto era)
 hashData d = hashAnnotated d
 
 -- Size of the datum hash attached to the output (could be Nothing)
-datHashSize :: (CC.Crypto c) => StrictMaybe (DataHash c) -> Integer
-datHashSize dh = fromIntegral $ heapWords dh
+dataHashSize :: (CC.Crypto c) => StrictMaybe (DataHash c) -> Integer
+dataHashSize dh = fromIntegral $ heapWords dh
 
 instance (CC.Crypto c) => HeapWords (StrictMaybe (DataHash c)) where
   heapWords SNothing = heapWords0

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -16,6 +16,7 @@
 module Cardano.Ledger.Alonzo.Rules.Utxo where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+import Cardano.Ledger.Alonzo.Data (datHashSize)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UTXOS, UtxosPredicateFailure)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices)
 import Cardano.Ledger.Alonzo.Tx
@@ -92,12 +93,6 @@ import Shelley.Spec.Ledger.UTxO
     unUTxO,
   )
 
--- Size of the datum hash attached to the output (could be Nothing)
-datHashSize :: TxOut era -> Integer
-datHashSize out = error "need heapwords instance"
-  where
-    _ = getField @"datahash" out
-
 -- | Compute an estimate of the size of storing one UTxO entry.
 -- This function implements the UTxO entry size estimate done by scaledMinDeposit in the ShelleyMA era
 utxoEntrySize :: Era era => TxOut era -> Integer
@@ -106,10 +101,10 @@ utxoEntrySize txout
     -- no non-ada assets, no hash datum case
     case dh of
       SNothing -> adaOnlyUTxOSize
-      _ -> adaOnlyUTxOSize + datHashSize txout
+      _ -> adaOnlyUTxOSize + datHashSize dh
   -- add the size of Value and the size of datum hash (if present) to base UTxO size
   -- max function is a safeguard (in case calculation returns a smaller size than an ada-only entry)
-  | otherwise = max adaOnlyUTxOSize (utxoEntrySizeWithoutVal + Val.size v + datHashSize txout)
+  | otherwise = max adaOnlyUTxOSize (utxoEntrySizeWithoutVal + Val.size v + datHashSize dh)
   where
     v = getField @"value" txout
     dh = getField @"datahash" txout

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -16,7 +16,7 @@
 module Cardano.Ledger.Alonzo.Rules.Utxo where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
-import Cardano.Ledger.Alonzo.Data (datHashSize)
+import Cardano.Ledger.Alonzo.Data (dataHashSize)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UTXOS, UtxosPredicateFailure)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices)
 import Cardano.Ledger.Alonzo.Tx
@@ -101,10 +101,10 @@ utxoEntrySize txout
     -- no non-ada assets, no hash datum case
     case dh of
       SNothing -> adaOnlyUTxOSize
-      _ -> adaOnlyUTxOSize + datHashSize dh
+      _ -> adaOnlyUTxOSize + dataHashSize dh
   -- add the size of Value and the size of datum hash (if present) to base UTxO size
   -- max function is a safeguard (in case calculation returns a smaller size than an ada-only entry)
-  | otherwise = max adaOnlyUTxOSize (utxoEntrySizeWithoutVal + Val.size v + datHashSize dh)
+  | otherwise = max adaOnlyUTxOSize (utxoEntrySizeWithoutVal + Val.size v + dataHashSize dh)
   where
     v = getField @"value" txout
     dh = getField @"datahash" txout


### PR DESCRIPTION
Actually compute the size of the `StrictMaybe (DataHash crypto)` part of the `TxOut`, using `HeapWords` defined the same way as for `Maybe (DataHash crypto)`. 

No examples yet. 