### PR TITLE
Drop Ord instances for ExUnits.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -281,14 +281,55 @@ emptyPParams =
       _maxValSize = 0
     }
 
+-- | Since ExUnits does not have an Ord instance, we have to roll this Ord instance by hand.
+-- IF THE ORDER OR TYPES OF THE FIELDS OF PParams changes, this instance may need adusting.
+instance Ord (PParams' StrictMaybe era) where
+  compare x y =
+    (_minfeeA x, _minfeeA y)
+      <== (_minfeeB x, _minfeeB y)
+      <== (_maxBBSize x, _maxBBSize y)
+      <== (_maxTxSize x, _maxTxSize y)
+      <== (_maxBHSize x, _maxBHSize y)
+      <== (_keyDeposit x, _keyDeposit y)
+      <== (_poolDeposit x, _poolDeposit y)
+      <== (_eMax x, _eMax y)
+      <== (_nOpt x, _nOpt y)
+      <== (_a0 x, _a0 y)
+      <== (_rho x, _rho y)
+      <== (_tau x, _tau y)
+      <== (_d x, _d y)
+      <== (_extraEntropy x, _extraEntropy y)
+      <== (_protocolVersion x, _protocolVersion y)
+      <== (_minPoolCost x, _minPoolCost y)
+      <== (_adaPerUTxOByte x, _adaPerUTxOByte y)
+      <== (_costmdls x, _costmdls y)
+      <== (_prices x, _prices y)
+      <== ( case compareEx (_maxTxExUnits x) (_maxTxExUnits y) of
+              LT -> LT
+              GT -> GT
+              EQ -> case compareEx (_maxBlockExUnits x) (_maxBlockExUnits y) of
+                LT -> LT
+                GT -> GT
+                EQ -> (_maxValSize x, _maxValSize y) <== EQ
+          )
+
+infixr 4 <==
+
+(<==) :: Ord a => (a, a) -> Ordering -> Ordering
+(x, y) <== z = case compare x y of LT -> LT; GT -> GT; EQ -> z
+
+compareEx :: StrictMaybe ExUnits -> StrictMaybe ExUnits -> Ordering
+compareEx SNothing SNothing = EQ
+compareEx SNothing (SJust _) = LT
+compareEx (SJust _) SNothing = GT
+compareEx (SJust (ExUnits m1 s1)) (SJust (ExUnits m2 s2)) = compare (m1, s1) (m2, s2)
+
 instance Default (PParams era) where
   def = emptyPParams
 
 deriving instance Eq (PParams' StrictMaybe era)
 
 deriving instance Show (PParams' StrictMaybe era)
-
-deriving instance Ord (PParams' StrictMaybe era)
 
 deriving instance NFData (PParams' StrictMaybe era)
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -19,7 +19,7 @@ module Cardano.Ledger.Alonzo.Rules.Bbody
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), pointWiseExUnits)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo (Tx)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (BlockDecoding, Era (Crypto))
@@ -175,7 +175,7 @@ bbodyTransition =
         let txTotal, ppMax :: ExUnits
             txTotal = foldr (<>) mempty (fmap (getField @"totExunits") txs)
             ppMax = getField @"_maxBlockExUnits" pp
-        txTotal <= ppMax ?! TooManyExUnits txTotal ppMax
+        pointWiseExUnits (<=) txTotal ppMax ?! TooManyExUnits txTotal ppMax
 
         pure $
           BbodyState @era

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -17,7 +17,7 @@ module Cardano.Ledger.Alonzo.Rules.Utxo where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UTXOS, UtxosPredicateFailure)
-import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices, pointWiseExUnits)
 import Cardano.Ledger.Alonzo.Tx
   ( Tx (..),
     isTwoPhaseScriptAddress,
@@ -369,7 +369,7 @@ utxoTransition = do
 
   let maxTxEx = getField @"_maxTxExUnits" pp
       totExunits = getField @"totExunits" tx
-  totExunits <= maxTxEx ?! ExUnitsTooSmallUTxO maxTxEx totExunits
+  pointWiseExUnits (<=) totExunits maxTxEx ?! ExUnitsTooSmallUTxO maxTxEx totExunits
 
   -- This does not appear in the Alonzo specification. But the test should be in every Era.
   -- Bootstrap (i.e. Byron) addresses have variable sized attributes in them.

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -31,6 +31,7 @@ module Cardano.Ledger.Alonzo.Scripts
     isPlutusScript,
     alwaysSucceeds,
     alwaysFails,
+    pointWiseExUnits,
   )
 where
 
@@ -137,7 +138,7 @@ data ExUnits = ExUnits
   { exUnitsMem :: !Word64,
     exUnitsSteps :: !Word64
   }
-  deriving (Eq, Generic, Show, Ord)
+  deriving (Eq, Generic, Show) -- It is deliberate thate there is NO ORD instance.
 
 instance NoThunks ExUnits
 
@@ -148,6 +149,11 @@ instance Semigroup ExUnits where
 
 instance Monoid ExUnits where
   mempty = ExUnits 0 0
+
+-- | It is deliberate that there is no ORD instace for EXUnits. Use this function
+--   to compare if one ExUnit is pointwise compareable to another.
+pointWiseExUnits :: (Word64 -> Word64 -> Bool) -> ExUnits -> ExUnits -> Bool
+pointWiseExUnits oper (ExUnits m1 s1) (ExUnits m2 s2) = (m1 `oper` m2) && (s1 `oper` s2)
 
 -- =====================================
 -- Cost Model needs to preserve its serialization bytes as


### PR DESCRIPTION
Addresses CAD 2929

The Ord instance for ExUnits is problematic, since when we want to compare
if one ExUnits is less than another we want the partial pointwise ordering,
not the lexigraphic ordering one gets when deriving Ord. 

1) we drop the Ord instance for ExUnits
2) We provide a pointwise comparision pointWiseExUnits
3) We replace calls of (ex1 <= ex2) with (pointWiseExUnits (<=) ex1 ex2)
4) We roll an Ord instance of (PParams StrictMaybe era) by hand since its
   needs a lexographic ordering in ExUnits.