### PR TITLE
Compiler complaints

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -871,7 +871,7 @@ execution of the transition role is as follows:
 
   \nextdef
 
-  \begin{equation}\label{eq:no-reward-update}
+  \begin{equation}\label{eq:reward-update-exists}
     \inference[Reward-Update-Exists]
     {
       ru \neq \Nothing

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -531,7 +531,7 @@ concerns are independent of the ledger rules.
       }
       \\~\\
       {
-        \begin{array}{ l @{~\leteq~\{} c @{~\mid~\rule[-.5mm]{2mm}{.2mm}\mapsto} c @{\in~} l @{\}}}
+        \begin{array}{ l @{~\leteq~\{} c @{~\mid~\wcard\mapsto} c @{\in~} l @{\}}}
           \var{currentOtherColdKeyHashes} & \var{k} & (\var{k},~\wcard) & \var{cod}\\
           \var{currentOtherVrfKeyHashes}  & \var{v} & (\wcard,~\var{v}) & \var{cod}\\
           \var{futureOtherColdKeyHashes}  & \var{k} & (\var{k},~\wcard) & \var{fod}\\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -516,7 +516,7 @@ concerns are independent of the ledger rules.
 
   \begin{equation}\label{eq:deleg-gen}
     \inference[Deleg-Gen]
-    {
+{
       \var{c}\in \DCertGen
       & (\var{gkh},~\var{vkh},~\var{vrf})\leteq\fun{genesisDeleg}~{c}
       \\
@@ -531,13 +531,13 @@ concerns are independent of the ledger rules.
       }
       \\~\\
       {
-        \begin{array}{ l @{~\leteq~\{} c @{~\mid~\wcard\mapsto} c @{\in~} l @{\}}}
+        \begin{array}{ l @{~\leteq~\{} c @{~\mid~\rule[-.5mm]{2mm}{.2mm}\mapsto} c @{\in~} l @{\}}}
           \var{currentOtherColdKeyHashes} & \var{k} & (\var{k},~\wcard) & \var{cod}\\
           \var{currentOtherVrfKeyHashes}  & \var{v} & (\wcard,~\var{v}) & \var{cod}\\
           \var{futureOtherColdKeyHashes}  & \var{k} & (\var{k},~\wcard) & \var{fod}\\
           \var{futureOtherVrfKeyHashes}   & \var{v} & (\wcard,~\var{v}) & \var{fod}\\
       \end{array}
-      }
+      }      
       \\
       \var{vkh}\notin\var{currentOtherColdKeyHashes}\union\var{futureOtherColdKeyHashes} \\
       \var{vrf}\notin\var{currentOtherVrfKeyHashes}\union\var{futureOtherVrfKeyHashes} \\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -245,7 +245,7 @@
 \newcommand{\slotminus}[2]{\var{#1}~-_{s}~\var{#2}}
 \DeclarePairedDelimiter\floor{\lfloor}{\rfloor}
 % wildcard parameter
-\newcommand{\wcard}[0]{\underline{\phantom{a}}}
+\newcommand{\wcard}[0]{\rule[-.5mm]{2mm}{.2mm}}
 %% Adding ledgers...
 \newcommand{\utxo}[1]{\fun{utxo}~ #1}
 %% Delegation

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -190,7 +190,7 @@ This rule has the following predicate failures:
 
   \nextdef
 
-  \begin{equation}\label{eq:update-nonempty}
+  \begin{equation}\label{eq:update-nonempty-current}
     \inference[PP-Update-Current]
     {
       (\var{pup},~\var{e})\leteq\var{up}
@@ -229,7 +229,7 @@ This rule has the following predicate failures:
 
   \nextdef
 
-  \begin{equation}\label{eq:update-nonempty}
+  \begin{equation}\label{eq:update-nonempty-future}
     \inference[PP-Update-Future]
     {
       (\var{pup},~\var{e})\leteq\var{up}


### PR DESCRIPTION
Started working in the docs and found a compiler error and a few warnings:

* Error when calling `\wcard` macro in the alignment definition of the array. For some reason it does not like using `\underscore`. I've changed it with `\rule[-.5mm]{2mm}{.2mm}` just in the alignment definition, but would recommend changing the macro to avoid further errors. 
* Some labels where multiply defined. I changed those