### PR TITLE
Specification for serialization

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -14,6 +14,12 @@ copyright:           2020 Input Output (Hong Kong) Ltd.
 category:            Network
 build-type:          Simple
 
+
+extra-source-files:
+  cddl-files/alonzo.cddl
+  cddl-files/mock/crypto.cddl
+  cddl-files/mock/extras.cddl
+
 common base                         { build-depends: base                             >= 4.12       && < 4.15     }
 
 common project-config
@@ -90,7 +96,7 @@ library test
   hs-source-dirs:
     test/lib
 
-test-suite tests
+test-suite cardano-ledger-alonzo-test
   import:             base, project-config
 
   type:                exitcode-stdio-1.0
@@ -99,11 +105,14 @@ test-suite tests
     test/test
   other-modules:
     Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
+    Test.Cardano.Ledger.Alonzo.Serialisation.CDDL
   build-depends:
     base16-bytestring,
     bytestring,
     cardano-binary,
     cardano-ledger-alonzo,
+    cardano-ledger-shelley-ma,
+    cardano-ledger-core,
     cardano-ledger-shelley-ma-test,
     QuickCheck,
     shelley-spec-ledger,

--- a/alonzo/impl/cddl-files/alonzo.cddl
+++ b/alonzo/impl/cddl-files/alonzo.cddl
@@ -1,0 +1,333 @@
+block =
+  [ header
+  , transaction_bodies         : [* transaction_body]
+  , transaction_witness_sets   : [* transaction_witness_set]
+  , auxiliary_data_set         : {* transaction_index => auxiliary_data }
+  , invalid_transactions       : [* transaction_index ]                    ; New
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+transaction =
+  [ transaction_body
+  , transaction_witness_set
+  , auxiliary_data / null
+  ]
+
+transaction_index = uint
+
+header =
+  [ header_body
+  , body_signature : $kes_signature
+  ]
+
+header_body =
+  [ block_number     : uint
+  , slot             : uint
+  , prev_hash        : $hash32 / null
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , nonce_vrf        : $vrf_cert
+  , leader_vrf       : $vrf_cert
+  , block_body_size  : uint
+  , block_body_hash  : $hash32 ; merkle triple root
+  , operational_cert
+  , protocol_version
+  ]
+
+operational_cert =
+  ( hot_vkey        : $kes_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  )
+
+protocol_version = (uint, uint)
+
+transaction_body =
+ { 0 : set<transaction_input>    ; Fee inputs (previously this was inputs)
+ , 1 : [* transaction_output]
+ , 2 : coin                      ; fee
+ , ? 3 : uint                    ; time to live
+ , ? 4 : [* certificate]
+ , ? 5 : withdrawals
+ , ? 6 : update
+ , ? 7 : metadata_hash
+ , ? 8 : uint                    ; validity interval start
+ , ? 9 : mint
+ , ? 11 : script_data_hash       ; New
+ , ? 13 : set<transaction_input> ; Non-fee inputs ; New
+ , ? 14 : required_signers       ; New
+ , ? 15 : network_id             ; New
+ }
+
+required_signers = set<$vkey>
+
+transaction_input = [ transaction_id : $hash32
+                    , index : uint
+                    ]
+
+transaction_output =
+  [ address
+  , amount : value
+  , data_hash : $hash32 / null ; New
+  ]
+
+script_data_hash = $hash32 ; New
+
+; address = bytes
+; reward_account = bytes
+
+; address format:
+; [ 8 bit header | payload ];
+;
+; shelley payment addresses:
+; bit 7: 0
+; bit 6: base/other
+; bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+; bit 4: payment cred is keyhash/scripthash
+; bits 3-0: network id
+;
+; reward addresses:
+; bits 7-5: 111
+; bit 4: credential is keyhash/scripthash
+; bits 3-0: network id
+;
+; byron addresses:
+; bits 7-4: 1000
+
+; 0000: base address: keyhash28,keyhash28
+; 0001: base address: scripthash28,keyhash28
+; 0010: base address: keyhash28,scripthash28
+; 0011: base address: scripthash28,scripthash28
+; 0100: pointer address: keyhash28, 3 variable length uint
+; 0101: pointer address: scripthash28, 3 variable length uint
+; 0110: enterprise address: keyhash28
+; 0111: enterprise address: scripthash28
+; 1000: byron address
+; 1110: reward account: keyhash28
+; 1111: reward account: scripthash28
+; 1001 - 1101: future formats
+
+certificate =
+  [ stake_registration
+  // stake_deregistration
+  // stake_delegation
+  // pool_registration
+  // pool_retirement
+  // genesis_key_delegation
+  // move_instantaneous_rewards_cert
+  ]
+
+stake_registration = (0, stake_credential)
+stake_deregistration = (1, stake_credential)
+stake_delegation = (2, stake_credential, pool_keyhash)
+pool_registration = (3, pool_params)
+pool_retirement = (4, pool_keyhash, epoch)
+genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
+
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin ]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
+; If the second field is a map, funds are moved to stake credentials,
+; otherwise the funds are given to the other accounting pot.
+
+delta_coin = int ; New
+
+stake_credential =
+  [  0, addr_keyhash
+  // 1, scripthash
+  ]
+
+pool_params = ( operator:       pool_keyhash
+              , vrf_keyhash:    vrf_keyhash
+              , pledge:         coin
+              , cost:           coin
+              , margin:         unit_interval
+              , reward_account: reward_account
+              , pool_owners:    set<addr_keyhash>
+              , relays:         [* relay]
+              , pool_metadata:  pool_metadata / null
+              )
+
+port = uint .le 65535
+ipv4 = bytes .size 4
+ipv6 = bytes .size 16
+dns_name = tstr .size (0..64)
+
+single_host_addr = ( 0
+                   , port / null
+                   , ipv4 / null
+                   , ipv6 / null
+                   )
+single_host_name = ( 1
+                   , port / null
+                   , dns_name ; An A or AAAA DNS record
+                   )
+multi_host_name = ( 2
+                   , dns_name ; A SRV DNS record
+                   )
+relay =
+  [  single_host_addr
+  // single_host_name
+  // multi_host_name
+  ]
+
+pool_metadata = [url, metadata_hash]
+url = tstr .size (0..64)
+
+withdrawals = { * reward_account => coin }
+
+update = [ proposed_protocol_parameter_updates
+         , epoch
+         ]
+
+proposed_protocol_parameter_updates =
+  { * genesishash => protocol_param_update }
+
+protocol_param_update =
+  { ? 0:  uint               ; minfee A
+  , ? 1:  uint               ; minfee B
+  , ? 2:  uint               ; max block body size
+  , ? 3:  uint               ; max transaction size
+  , ? 4:  uint               ; max block header size
+  , ? 5:  coin               ; key deposit
+  , ? 6:  coin               ; pool deposit
+  , ? 7: epoch               ; maximum epoch
+  , ? 8: uint                ; n_opt: desired number of stake pools
+  , ? 9: rational            ; pool pledge influence
+  , ? 10: unit_interval      ; expansion rate
+  , ? 11: unit_interval      ; treasury growth rate
+  , ? 12: unit_interval      ; d. decentralization constant
+  , ? 13: $nonce             ; extra entropy
+  , ? 14: [protocol_version] ; protocol version
+  , ? 16: coin               ; min pool cost ; New
+  , ? 17: coin               ; ada per utxo byte ; New
+  , ? 18: costmdls           ; cost models for script languages ; New
+  , ? 19: ex_unit_prices     ; execution costs ; New
+  , ? 20: ex_units           ; max tx ex units ; New
+  , ? 21: ex_units           ; max block ex units ; New
+  , ? 22: unsigned           ; max value size ; New
+  }
+
+transaction_witness_set =
+  { ? 0: [* vkeywitness ]
+  , ? 1: [* native_script ]
+  , ? 2: [* bootstrap_witness ]
+  , ? 3: [* plutus_script ] ;New
+  , ? 4: [* plutus_data ] ;New
+  , ? 5: [* redeemer ] ;New
+  }
+
+plutus_script = bytes ; New
+
+plutus_data =           ; New
+  [ plutus_data_constr
+  // plutus_data_map
+  // plutus_data_list
+  // plutus_data_int
+  // plutus_data_bytes
+  ]
+
+plutus_data_constr = (0, integer, [ * plutus_data ]) ; New
+plutus_data_map    = (1, { * plutus_data => plutus_data }) ; New
+plutus_data_list   = (2, [ * plutus_data ]) ; New
+plutus_data_int    = (3, integer) ; New
+plutus_data_bytes  = (4, bytes) ; New
+
+redeemer = [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ] ; New
+redeemer_tag = ; New
+    0 ; inputTag "Spend"
+  / 1 ; mintTag  "Mint"
+  / 2 ; certTag  "Cert"
+  / 3 ; wdrlTag  "Reward"
+ex_units = [mem: uint, steps: uint] ; New
+
+ex_unit_prices = ; New
+  [ mem_price: coin, step_price: coin ]
+
+; This is an enumeration. for now there's only one value ; New
+language = 0 ; Plutus v1
+
+costmdls = { * language => cost_model } ; New
+
+cost_model = { * bytes  => integer } ; New
+
+transaction_metadatum =
+    { * transaction_metadatum => transaction_metadatum }
+  / [ * transaction_metadatum ]
+  / int
+  / bytes .size (0..64)
+  / text .size (0..64)
+
+transaction_metadatum_label = uint
+metadata = { * transaction_metadatum_label => transaction_metadatum }
+
+auxiliary_data =
+  metadata ; Shelley
+  / [ transaction_metadata: metadata ; Shelley-ma
+    , auxiliary_scripts: [ * native_script ]
+    ]
+  / #6.259({ ? 0 => metadata         ; Alonzo and future ; New
+      , ? 1 => [ * native_script ]
+      , ? 2 => [ * plutus_script ]
+      , ? 3 => [ * plutus_data ]
+      })
+
+
+
+vkeywitness = [ $vkey, $signature ]
+
+bootstrap_witness =
+  [ public_key : $vkey
+  , signature  : $signature
+  , chain_code : bytes .size 32
+  , attributes : bytes
+  ]
+
+native_script =
+  [ script_pubkey
+  // script_all
+  // script_any
+  // script_n_of_k
+  // invalid_before
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the left (included) endpoint a.
+  // invalid_hereafter
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the right (excluded) endpoint b.
+  ]
+
+script_pubkey = (0, addr_keyhash)
+script_all = (1, [ * native_script ])
+script_any = (2, [ * native_script ])
+script_n_of_k = (3, n: uint, [ * native_script ])
+invalid_before = (4, uint)
+invalid_hereafter = (5, uint)
+
+coin = uint
+
+multiasset<a> = { * policy_id => { * asset_name => a } }
+policy_id = scripthash
+asset_name = bytes .size (0..32)
+
+value = coin / [coin,multiasset<uint>]
+mint = multiasset<int64>
+
+int64 = -9223372036854775808 .. 9223372036854775807
+
+network_id = 0 / 1 ; New
+
+epoch = uint
+
+addr_keyhash          = $hash28
+scripthash            = $hash28
+genesis_delegate_hash = $hash28
+pool_keyhash          = $hash28
+genesishash           = $hash28
+
+vrf_keyhash           = $hash32
+metadata_hash         = $hash32

--- a/alonzo/impl/cddl-files/mock/crypto.cddl
+++ b/alonzo/impl/cddl-files/mock/crypto.cddl
@@ -1,0 +1,16 @@
+$hash28 /= bytes .size 8
+$hash32 /= bytes .size 10
+
+$vkey /= bytes .size 8
+
+$vrf_vkey /= bytes .size 8
+$vrf_cert /= [bytes, bytes .size 10]
+natural = #6.2(bytes)
+
+$kes_vkey /= bytes .size 8
+$kes_signature /= bytes .size 32
+signkeyKES = bytes .size 16
+
+$signature /= bytes .size 16
+
+$nonce /= [ 0 // 1, bytes .size 32 ]

--- a/alonzo/impl/cddl-files/mock/extras.cddl
+++ b/alonzo/impl/cddl-files/mock/extras.cddl
@@ -1,0 +1,29 @@
+set<a> = [a]
+  ; real set is [* a]
+
+unit_interval = #6.30([1, 2])
+  ; real unit_interval is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+rational =  #6.30(
+   [ numerator   : 1
+   , denominator : 2
+   ])
+  ; real rational is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+
+address = h'0001020304010203040102030401020304' /
+  h'1005060708010203040506070801020304' /
+  h'2001020304050607080102030405060708' /
+  h'3005060708050607080607050404050607' /
+  h'40010203040506070887680203' /
+  h'50050607080102030487680203' /
+  h'600102030405060708' /
+  h'700506070805060403'
+
+reward_account =
+  h'E00102030405060708' /
+  h'F00506070806050403'

--- a/alonzo/impl/cddl/alonzo.cddl
+++ b/alonzo/impl/cddl/alonzo.cddl
@@ -1,9 +1,0 @@
-; Alonzo Types
-
-move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin ]
-; The first field determines where the funds are drawn from.
-; 0 denotes the reserves, 1 denotes the treasury.
-; If the second field is a map, funds are moved to stake credentials,
-; otherwise the funds are given to the other accounting pot.
-
-delta_coin = int

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -114,7 +114,12 @@ import GHC.Records (HasField (..))
 import GHC.Stack (HasCallStack)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
 import Shelley.Spec.Ledger.Address (Addr)
-import Shelley.Spec.Ledger.BaseTypes (Network, StrictMaybe (..))
+import Shelley.Spec.Ledger.BaseTypes
+  ( Network,
+    StrictMaybe (..),
+    maybeToStrictMaybe,
+    strictMaybeToMaybe,
+  )
 import Shelley.Spec.Ledger.CompactAddr (CompactAddr, compactAddr, decompactAddr)
 import Shelley.Spec.Ledger.Delegation.Certificates (DCert)
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
@@ -407,14 +412,13 @@ instance
         (TxOutCompact @era)
         !> To addr
         !> To cv
-        !> To dh
+        !> E (encodeNullMaybe toCBOR . strictMaybeToMaybe) dh
 
 instance
   ( Era era,
     DecodeNonNegative (Core.Value era),
     Show (Core.Value era),
-    Compactible (Core.Value era),
-    ToCBOR (PParamsDelta era)
+    Compactible (Core.Value era)
   ) =>
   FromCBOR (TxOut era)
   where
@@ -423,7 +427,7 @@ instance
       RecD TxOutCompact
         <! From
         <! D decodeNonNegative
-        <! From
+        <! D (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
 
 encodeTxBodyRaw ::
   ( Era era,
@@ -451,8 +455,12 @@ encodeTxBodyRaw
       ( \i ifee o f t c w u b rsh mi sh ah ni ->
           TxBodyRaw i ifee o c w f (ValidityInterval b t) u rsh mi sh ah ni
       )
-      !> Key 0 (E encodeFoldable _inputs)
-      !> Key 13 (E encodeFoldable _inputs_fee)
+      -- A note on key strangeness:
+      -- a Mary era input is expected to convert into an Alonzo era fee input.
+      -- Since Mary era inputs are on key 0, we're turning this into the key
+      -- used for fee inputs. A new key, 13, is being used for inputs in alonzo.
+      !> Key 13 (E encodeFoldable _inputs)
+      !> Key 0 (E encodeFoldable _inputs_fee)
       !> Key 1 (E encodeFoldable _outputs)
       !> Key 2 (To _txfee)
       !> encodeKeyedStrictMaybe 3 top
@@ -463,7 +471,7 @@ encodeTxBodyRaw
       !> Key 14 (E encodeFoldable _reqSignerHashes)
       !> Omit isZero (Key 9 (E encodeMint _mint))
       !> encodeKeyedStrictMaybe 11 _wppHash
-      !> encodeKeyedStrictMaybe 12 _adHash
+      !> encodeKeyedStrictMaybe 7 _adHash
       !> encodeKeyedStrictMaybe 15 _txnetworkid
     where
       encodeKeyedStrictMaybe key x =
@@ -516,11 +524,11 @@ instance
           SNothing
           SNothing
       bodyFields :: (Word -> Field (TxBodyRaw era))
-      bodyFields 0 =
+      bodyFields 13 =
         field
           (\x tx -> tx {_inputs = x})
           (D (decodeSet fromCBOR))
-      bodyFields 13 =
+      bodyFields 0 =
         field
           (\x tx -> tx {_inputs_fee = x})
           (D (decodeSet fromCBOR))
@@ -539,17 +547,14 @@ instance
           (D (decodeStrictSeq fromCBOR))
       bodyFields 5 = field (\x tx -> tx {_wdrls = x}) From
       bodyFields 6 = field (\x tx -> tx {_update = x}) (D (SJust <$> fromCBOR))
-      bodyFields 14 = field (\x tx -> tx {_reqSignerHashes = x}) (D (decodeSet fromCBOR))
+      bodyFields 7 = field (\x tx -> tx {_adHash = x}) (D (SJust <$> fromCBOR))
       bodyFields 8 =
         field
           (\x tx -> tx {_vldt = (_vldt tx) {invalidBefore = x}})
           (D (SJust <$> fromCBOR))
       bodyFields 9 = field (\x tx -> tx {_mint = x}) (D decodeMint)
       bodyFields 11 = field (\x tx -> tx {_wppHash = x}) (D (SJust <$> fromCBOR))
-      bodyFields 12 =
-        field
-          (\x tx -> tx {_adHash = x})
-          (D (SJust <$> fromCBOR))
+      bodyFields 14 = field (\x tx -> tx {_reqSignerHashes = x}) (D (decodeSet fromCBOR))
       bodyFields 15 = field (\x tx -> tx {_txnetworkid = x}) (D (SJust <$> fromCBOR))
       bodyFields n = field (\_ t -> t) (Invalid n)
       requiredFields =

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -31,10 +32,11 @@ import Cardano.Binary
     withSlice,
   )
 import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx, segwitTx)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Crypto, Era, ValidateScript)
 import Cardano.Ledger.Hashes (EraIndependentBlockBody)
 import Cardano.Ledger.SafeHash (SafeToHash, originalBytes)
 import Control.Monad (unless)
@@ -189,6 +191,8 @@ instance
     ToCBOR (Core.Script era),
     ToCBOR (Core.TxBody era),
     ToCBOR (Core.Witnesses era),
+    ValidateScript era,
+    Core.Script era ~ Script era,
     Era era
   ) =>
   FromCBOR (Annotator (TxSeq era))

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Serialisation.CDDL
+  ( tests,
+  )
+where
+
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (Data)
+import Cardano.Ledger.Alonzo.PParams (PParamsUpdate)
+import Cardano.Ledger.Alonzo.TxBody (TxOut)
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers, TxWitness)
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
+import qualified Data.ByteString.Lazy as BSL
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
+import Test.Shelley.Spec.Ledger.Serialisation.CDDLUtils
+  ( cddlTest,
+    cddlTest',
+  )
+import Test.Tasty (TestTree, testGroup, withResource)
+
+type A = AlonzoEra C_Crypto
+
+tests :: Int -> TestTree
+tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
+  testGroup "CDDL roundtrip tests" $
+    [ cddlTest @(Core.Value A) n "coin",
+      cddlTest' @(Core.TxBody A) n "transaction_body",
+      cddlTest' @(Core.AuxiliaryData A) n "auxiliary_data",
+      cddlTest' @(MA.Timelock C_Crypto) n "native_script",
+      cddlTest' @(Data A) n "plutus_data",
+      cddlTest @(TxOut A) n "transaction_output",
+      cddlTest' @(TxWitness A) n "transaction_witness_set",
+      cddlTest @(PParamsUpdate A) n "protocol_param_update",
+      cddlTest' @(Redeemers A) n "[* redeemer]"
+    ]
+      <*> pure cddl
+
+combinedCDDL :: IO BSL.ByteString
+combinedCDDL = do
+  base <- BSL.readFile "cddl-files/alonzo.cddl"
+  crypto <- BSL.readFile "cddl-files/mock/crypto.cddl"
+  extras <- BSL.readFile "cddl-files/mock/extras.cddl"
+  pure $ base <> crypto <> extras

--- a/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/impl/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -31,22 +31,25 @@ trippingF ::
   (src -> Either target (BSL.ByteString, src)) ->
   src ->
   Property
-trippingF f x = case f x of
-  Right (remaining, y) | BSL.null remaining -> x === y
-  Right (remaining, _) ->
-    counterexample
-      ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
-      False
-  Left stuff ->
-    counterexample
-      ( concat
-          [ "Failed to decode: ",
-            show stuff,
-            "\nbytes: ",
-            show (Base16.encode (serialize x))
-          ]
-      )
-      False
+trippingF f x =
+  case f x of
+    Right (remaining, y)
+      | BSL.null remaining ->
+        x === y
+    Right (remaining, _) ->
+      counterexample
+        ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
+        False
+    Left stuff ->
+      counterexample
+        ( concat
+            [ "Failed to decode: ",
+              show stuff,
+              "\nbytes: ",
+              show (Base16.encode (serialize x))
+            ]
+        )
+        False
 
 trippingAnn ::
   ( Eq t,

--- a/alonzo/impl/test/test/Tests.hs
+++ b/alonzo/impl/test/test/Tests.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import Test.Tasty
 
@@ -7,7 +8,8 @@ tests :: TestTree
 tests =
   testGroup
     "Alonzo tests"
-    [ Tripping.tests
+    [ Tripping.tests,
+      CDDL.tests 5
     ]
 
 main :: IO ()

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -39,6 +39,7 @@ let
         packages.cardano-ledger-shelley-ma-test.components.tests.cardano-ledger-shelley-ma-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
         packages.small-steps.configureFlags = [ "--ghc-option=-Werror" ];
         packages.shelley-spec-ledger-test.components.tests.shelley-spec-ledger-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
+        packages.cardano-ledger-alonzo.components.tests.cardano-ledger-alonzo-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
         enableLibraryProfiling = profiling;
         # Disable doctests for now (waiting for https://github.com/input-output-hk/haskell.nix/pull/427):
         packages.small-steps.components.tests.doctests.buildable = lib.mkForce false;


### PR DESCRIPTION
  - conformance tests
  - changed serialization implementation to match
  - changed implementations:
    - sparse encoding for txwitness compatible with mary
    - auxiliary data made compatible with mary
    - cbor map instead of array of pairs for plutus data
    - stripped out union discriminators from scripts
    - redeemer tags are numbers instad of arrays
    - swapped keys of inputs and fee_inputs in transaction body
    - optional data hash in txout is value/null rather than []/[value]
    - droped untrusted hashes of witness scripts, witness data
    - changed redeemers into an array of [pointer, exuint, data]