### PR TITLE
Type aliases, mandatory redeemers

### DIFF
--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -84,7 +84,7 @@
 \newcommand{\NewParams}{\type{NewParams}}
 \newcommand{\Slot}{\type{Slot}}
 \newcommand{\MemoryEstimate}{\type{MemoryEstimate}}
-\newcommand{\Time}{\type{Time}}
+\newcommand{\UTCTime}{\type{UTCTime}}
 \newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
@@ -166,6 +166,11 @@
 \newcommand{\AuxiliaryData}{\type{AuxiliaryData}}
 \newcommand{\Metadata}{\type{Metadata}}
 \newcommand{\DataHash}{\type{DataHash}}
+\newcommand{\TxInfo}{\type{TxInfo}}
+\newcommand{\Datum}{\type{Datum}}
+\newcommand{\Redeemer}{\type{Redeemer}}
+\newcommand{\EpochInfo}{\type{EpochInfo}}
+\newcommand{\SystemStart}{\type{SystemStart}}
 \newcommand{\ScriptHash}{\type{ScriptHash}}
 \newcommand{\PolicyID}{\type{PolicyID}}
 \newcommand{\LangDepView}{\type{LangDepView}}
@@ -177,8 +182,6 @@
 \newcommand{\ScriptNative}{\type{Script^{native}}}
 \newcommand{\ScriptNonNative}{\type{Script^{non-native}}}
 \newcommand{\ScriptV}{\type{Script_{v}}}
-\newcommand{\Datum}{\type{Datum}}
-\newcommand{\Rdmr}{\type{Rdmr}}
 \newcommand{\ScriptPurpose}{\type{ScriptPurpose}}
 \newcommand{\Rdmrs}{\type{Rdmrs}}
 \newcommand{\DorR}{\type{DorR}}

--- a/alonzo/formal-spec/properties.tex
+++ b/alonzo/formal-spec/properties.tex
@@ -22,7 +22,7 @@ This appendix collects the main formal properties that the new ledger rules are 
 \item
   \emph{Fee Movement.}
   If a transaction is accepted and marked as paying fees only
-  (i.e. $\fun{txvaltag}\, tx = \True$), then the only change to the ledger
+  (i.e. $\fun{txvaltag}\, tx = \False$), then the only change to the ledger
   when processing the transaction is that the inputs marked for paying
   fees are moved to the fee pot.
 \item
@@ -46,8 +46,23 @@ This appendix collects the main formal properties that the new ledger rules are 
 \item
   \todo{\emph{Cost consistency.} - no transaction exceeds the specified resource bounds.}
 \item
+  \emph{Cost Increase.} if a transaction is valid, it will remain valid if you increase the execution units
+\item
+  \emph{Cost Lower Bound.} if a transaction contains at least one valid script, it must have at least one execution unit
+\item
   \todo{\emph{Backwards Compatibility.} Any transaction that was accepted in a previous version of the ledger rules
     has exactly the same cost and effect, except that the transaction output is extended.}
+\item \emph{UTxO-changing transitions.} Only the UTXOS transition affects the ledger UTxO in Alonzo.
+For Shelley/ShelleyMA, only the UTXO transition does.
+\item \emph{Run all scripts.} All scripts attached to a transaction are run
+\item \emph{Scripts are run on correct inputs.}
+  A script is run for everything witnessed with a non-native script, and the script will
+get all the correct inputs, which must be present.
+\item \emph{Determinism of script validation.} In an otherwise valid transaction which remains valid
+  despite ledger state changes, the outcome
+  of script validation is not affected by these ledger state changes.
+\item \emph{Script inputs are fixed.} All data that a non-native script gets as input
+is fixed either by being signed in a transaction, or fixed by its hash living on the ledger
 \item
   ... \todo{Anything else?}
 \end{enumerate}

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -26,6 +26,12 @@ We make the following changes and additions:
   This tag is added by the block creator when
   constructing a block, and its correctness is verified as part of the script execution.
 
+  \item $\Datum$ is a type alias for the $\Data$ type, used to signify that
+  terms of this type are intended to be used strictly as datum objects.
+
+  \item $\Redeemer$ is also a type alias for the $\Data$ type, used to signify that
+  terms of this type are intended to be used strictly as redeemers.
+
   \item $\TxOut$ is the type of transaction outputs. These are extended to include
   an optional hash of a datum. Note that \emph{any} output can
   optionally include such a hash, even though only non-native scripts
@@ -73,7 +79,9 @@ We add the following helper functions:
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{sc} & \ScriptNonNative & \ScriptPlutus \\
       \var{sc} & \Script & \ScriptNative \uniondistinct \ScriptNonNative \\
-      \var{isv} & \IsValidating & \Bool
+      \var{isv} & \IsValidating & \Bool \\
+      \var{d} & \Datum & \Data \\
+      \var{r} & \Redeemer & \Data
     \end{array}
   \end{equation*}
 %
@@ -103,7 +111,7 @@ We add the following helper functions:
     \fun{language}& \in \ScriptNonNative \to \Language\\
     \fun{hashData}& \in \Data \to \DataHash
     \nextdef
-    \fun{hashWitnessPPData}&\in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Data \times \ExUnits) \to \WitnessPPDataHash^? \\
+    \fun{hashWitnessPPData}&\in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Redeemer \times \ExUnits) \to \WitnessPPDataHash^? \\
     \fun{hashWitnessPPData}&~{pp}~{langs}~{rdmrs}~=~ \\
                           &\begin{cases}
                             \Nothing & rdmrs~=~\emptyset \land langs~=~\emptyset \\
@@ -126,8 +134,8 @@ We add the following helper functions:
       \var{wits} ~\in~ \TxWitness ~=~
        & (\VKey \mapsto \Sig) & \fun{txwitsVKey} & \text{VKey signatures}\\
        & \times ~(\ScriptHash \mapsto \Script)  & \fun{txscripts} & \text{All scripts}\\
-       & \times~ \hldiff{(\DataHash \mapsto \Data)} & \hldiff{\fun{txdats}} & \text{All datum objects}\\
-       & \times ~\hldiff{(\RdmrPtr \mapsto \Data^? \times \ExUnits)}& \hldiff{\fun{txrdmrs}}& \text{Redeemers/budget}\\
+       & \times~ \hldiff{(\DataHash \mapsto \Datum)} & \hldiff{\fun{txdats}} & \text{All datum objects}\\
+       & \times ~\hldiff{(\RdmrPtr \mapsto \Redeemer \times \ExUnits)}& \hldiff{\fun{txrdmrs}}& \text{Redeemers/budget}\\
     \end{array}
   \end{equation*}
   %
@@ -153,7 +161,7 @@ We add the following helper functions:
     \begin{array}{r@{~~}l@{~~}l@{\qquad}l}
       \var{ad} ~\in~ \AuxiliaryData ~=~
       & \powerset{\Script} & \fun{scripts}& \text{Optional scripts}\\
-      & \times \hldiff{\powerset{\Data}} & \hldiff{\fun{dats}}& \text{Optional data}\\
+      & \times \hldiff{\powerset{\Datum}} & \hldiff{\fun{dats}}& \text{Optional datum objects}\\
       & \times ~\Metadata^? & \fun{txMD}&\text{Metadata}
     \end{array}
   \end{equation*}
@@ -178,10 +186,9 @@ in a transaction that is needed for witnessing, namely:
 \begin{itemize}
   \item VKey signatures;
   \item a map of scripts indexed by their hashes, including non-native scripts;
-  \item a map of terms of type $\Data$ indexed by their hashes, containing all required datum objects; and
-  \item a map of a part of a $\Data^?$ object and an $\ExUnits$ value indexed by $\RdmrPtr$,
-  containing the redeemers and execution units budgets. Note that redeemers are optional, while
-  execution units are not. 
+  \item a map of terms of type $\Datum$ indexed by their hashes, containing all required datum objects; and
+  \item a map of a pair of a $\Redeemer$ object and an $\ExUnits$ value indexed by $\RdmrPtr$,
+  containing the redeemers and execution units budgets.
 \end{itemize}
 
 Note that there is a difference between the way scripts and datum objects are included in

--- a/alonzo/formal-spec/txinfo.tex
+++ b/alonzo/formal-spec/txinfo.tex
@@ -3,5 +3,5 @@
 
 This section specifies exactly what parts of the transaction and ledger
 state are used by the $\fun{txInfo}$ function to construct the
-$\Data$ term that gets passed as an
+$\TxInfo$ term that gets passed as an
 argument to the Plutus interpreter.

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -276,7 +276,7 @@ which has the information to do this correctly for
      &\text{Translate slot number to system time or fail} \\~\\
      &\fun{txInfo} \in \Language \to \UTxO \to \Tx \to \TxInfo \\
      &\text{Summarizes transaction data} \\~\\
-     &\fun{valContext} \in \Data \to \ScriptPurpose \to \Data \\
+     &\fun{valContext} \in \TxInfo \to \ScriptPurpose \to \Data \\
      &\text{Pairs transaction data with a script purpose} \\~\\
      &\fun{runPLCScript} \in \CostMod \to\ScriptPlutus \to
     \seqof{\Data} \to \ExUnits \to \IsValidating \\
@@ -316,7 +316,8 @@ evaluator.
   wrapped in a list type instead of a $\Data^?$ type).
 
   \item a pair, returned by the $\fun{indexedRdmrs}$ function, of a redeemer
-  and an $\ExUnits$ amount.
+  and an $\ExUnits$ amount. We are assuming this pair is not $\Nothing$ here
+  because that must have already been checked by the UTXOW rule.
 
   \item $\fun{evalScripts}$ evaluates a whole list of scripts paired with all their
   inputs by calling the native script validator function, $\fun{runPLCScript}$

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -80,8 +80,10 @@ These include:
 
 \begin{itemize}
 \item $\UTCTime$ is the system time (UTC time zone)
-\item $\EpochInfo$ is a consensus-level parameter needed to compute the system time
-\item $\SystemStart$ is another consensus-level parameter needed to compute the system time
+\item $\EpochInfo$ is a consensus-level parameter needed to compute the system time. Within
+the Alonzo era, this is constant, with value $\mathsf{epochInfo}$
+\item $\SystemStart$ is another consensus-level parameter needed to compute the system time. Within
+the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
 \item
   $\ScriptPurpose$ is a sum type of all parts of a transaction that may
   require a script witness to validate. Note that this contains the data
@@ -102,19 +104,19 @@ These include:
 
 
 \begin{figure}[htb]
-  \emph{Abstract types}
+  \emph{Abstract types and constants of these types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{}lr}
       \var{tm}
       & \UTCTime
-      & \text{System time} \\
-      \var{ei}
+      & \text{System time (variable)} \\
+      \mathsf{epochInfo}
       & \EpochInfo
-      & \text{Epoch info} \\
-      \var{st}
+      & \text{Epoch info (constant within Alonzo)} \\
+      \mathsf{systemTime}
       & \SystemStart
-      & \text{System start time}
+      & \text{System start time (constant within Alonzo)}
     \end{array}
   \end{equation*}
   %
@@ -575,7 +577,8 @@ UTXOS rule.
     {
       \var{txb}\leteq\txbody{tx} &
       \fun{ininterval}~\var{slot}~(\fun{txvldt}~{tx}) \\
-      \hldiff{\var{(\wcard, i_f)}\leteq\fun{txvldt}~{tx}} & \hldiff{\fun{epochInfoSlotToUTCTime}~\wcard~\wcard~i_f \neq \Nothing} \\
+      \hldiff{\var{(\wcard, i_f)}\leteq\fun{txvldt}~{tx}} &
+      \hldiff{\fun{epochInfoSlotToUTCTime}~\mathsf{epochInfo}~\mathsf{systemTime}~i_f \neq \Nothing} \\
       \txins{txb} \neq \emptyset
       & \hldiff{\fun{feesOK}~pp~tx~utxo}
       & \txins{txb} \subseteq \dom \var{utxo}
@@ -726,7 +729,7 @@ additional ones;
     hash of a datum (and therefore is not a key of the $\DataHash$-indexed map).
 
     \item For every item that needs to be validated by a non-native script, the transaction contains
-      an entry in the indexed redeemer structure (ie. the execution units are redeemer for it are specified);
+      an entry in the indexed redeemer structure (ie. the execution units and redeemer for it are specified);
 
     \item The signatures of the keys whose hashes are specified in the
     $\fun{reqSignerHashes}$ field in a transaction

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -79,7 +79,9 @@ retrieve all the data that is relevant to Plutus script validation.
 These include:
 
 \begin{itemize}
-\item $\Time$ is the system time
+\item $\UTCTime$ is the system time (UTC time zone)
+\item $\EpochInfo$ is a consensus-level parameter needed to compute the system time
+\item $\SystemStart$ is another consensus-level parameter needed to compute the system time
 \item
   $\ScriptPurpose$ is a sum type of all parts of a transaction that may
   require a script witness to validate. Note that this contains the data
@@ -92,7 +94,10 @@ These include:
   It assumes there is some ordering on each of these structures.
 \item
   $\fun{indexedRdmrs}$ indexes the pair of a redeemer and an $\ExUnits$ value
-  for a given script by its script purpose (eg. the input, or certificate, etc.)
+  for a given script by its script purpose (eg. the input, or certificate, etc.),
+  and $\Nothing$ if no associated data is found.
+  It uses the script purpose to generate the $\RdmrPtr$ key,
+  then find the corresponding entry in the redeemer structure.
 \end{itemize}
 
 
@@ -102,8 +107,14 @@ These include:
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{}lr}
       \var{tm}
-      & \Time
-      & \text{System time}
+      & \UTCTime
+      & \text{System time} \\
+      \var{ei}
+      & \EpochInfo
+      & \text{Epoch info} \\
+      \var{st}
+      & \SystemStart
+      & \text{System start time}
     \end{array}
   \end{equation*}
   %
@@ -128,11 +139,10 @@ These include:
   %
   \emph{Indexing functions}
   \begin{align*}
-    &\fun{indexedRdmrs} \in \Tx \to \ScriptPurpose \to (\seqof{\Data}~\times~\ExUnits)\\
+    &\fun{indexedRdmrs} \in \Tx \to \ScriptPurpose \to (\Redeemer~\times~\ExUnits)^?\\
     &\fun{indexedRdmrs}~tx~sp =
       \begin{cases}
-        ([], \var{eu}) & rdptr \mapsto (\Nothing, \var{eu}) \in \fun{txrdmrs}~(\fun{txwits}~{tx}) \} \\
-        ([d], \var{eu}) & rdptr \mapsto (\var{d}, \var{eu}) \in \fun{txrdmrs}~(\fun{txwits}~{tx}) \} \\
+        (d, \var{eu}) & \var{rdptr} \mapsto (\var{d}, \var{eu}) \in \fun{txrdmrs}~(\fun{txwits}~{tx}) \} \\
         \Nothing & \text{otherwise}
       \end{cases} \\
     & ~~\where \\
@@ -153,7 +163,10 @@ These include:
 Figure~\ref{fig:defs:functions-valid} shows the abstract functions that are used for script validation.
 
 \begin{itemize}
-\item $\fun{slotToTime}$ translates a slot number to system time if possible.
+\item $\fun{epochInfoSlotToUTCTime}$ translates a slot number to system time if possible.
+This translation is implemented by the consensus algorithm (not the ledger), and requires
+two additional parameters to do this.
+
 If it is not possible to do this translation, $\Nothing$ is returned.
 The reason it may not be possible to translate is that the slot number
 is too far in the future for the system to accurately
@@ -162,7 +175,7 @@ predict the exact time to which it refers.
 \item $\fun{txInfo}$ summarizes all the necessary transaction and chain state info
   that needs to be passed to the script interpreter. The $\Language$ argument
   is required because different languages have different expectations of the
-  format and contents of the summary $\Data$ term.
+  format and contents of the $\TxInfo$ summary.
   It has a $\UTxO$ as its argument to recover the full information of the inputs of the transaction,
   but only the inputs of the transaction are provided to scripts. For details, see~\ref{sec:txinfo}
 
@@ -240,13 +253,26 @@ which has the information to do this correctly for
   Script authors must keep this in mind when writing scripts, since the ledger call to the interpreter is oblivious to what
   arguments are required.
 
+  Datum objects are required for all output-locking non-native scripts. That is, a
+  non-native script-locked output that does not include a datum hash is unspendable.
+  Non-output scripts do not expect datum objects - that is, it is not possible to pass
+  a datum to a script used for another purpose (certificate, etc.). Redeemers
+  are required for all non-native scripts.
+
 \begin{figure*}[htb]
+  \emph{Abstract Script Validation Types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\quad\quad\quad\quad}r}
+      \var{txinfo} &\TxInfo & \text{Language-specific summary of transaction data}\\
+    \end{array}
+  \end{equation*}
   \emph{Abstract Script Validation Functions}
   %
   \begin{align*}
-     &\fun{slotToTime} \in \Slot \to \Time^? \\
+     &\fun{epochInfoSlotToUTCTime} \in \EpochInfo \to \SystemStart \to \Slot \to \UTCTime^? \\
      &\text{Translate slot number to system time or fail} \\~\\
-     &\fun{txInfo} \in \Language \to \UTxO \to \Tx \to \Data \\
+     &\fun{txInfo} \in \Language \to \UTxO \to \Tx \to \TxInfo \\
      &\text{Summarizes transaction data} \\~\\
      &\fun{valContext} \in \Data \to \ScriptPurpose \to \Data \\
      &\text{Pairs transaction data with a script purpose} \\~\\
@@ -287,13 +313,8 @@ evaluator.
   \item the hash of the required datum, if any (returned by the $\fun{getData}$ function,
   wrapped in a list type instead of a $\Data^?$ type).
 
-  \item a pair, returned by the $\fun{indexedRdmrs}$ function, of
-  \begin{itemize}
-    \item a list of $\Data$, containing exactly one or zero elements (this
-    is not checked here, however, see~\ref{fig:functions:script1}). This list
-    contains the optional redeemer if there is one.
-    \item an $\ExUnits$ value, which is mandatory for all scripts
-  \end{itemize}
+  \item a pair, returned by the $\fun{indexedRdmrs}$ function, of a redeemer
+  and an $\ExUnits$ amount.
 
   \item $\fun{evalScripts}$ evaluates a whole list of scripts paired with all their
   inputs by calling the native script validator function, $\fun{runPLCScript}$
@@ -321,7 +342,7 @@ are caught during the application of the UTXOW rule (before these functions are 
     \nextdef
     & \fun{collectNNScriptInputs} \in \PParams \to \Tx \to \UTxO \to \seqof{(\ScriptNonNative \times \seqof{\Data} \times \ExUnits \times \CostMod)} \\
     & \fun{collectNNScriptInputs} ~\var{pp}~\var{tx}~ \var{utxo} ~=~ \\
-    & ~~\fun{toList} \{ (\var{script}, (\fun{valContext}~\var{txinfo}~\var{sp}~++~ \fun{getData}~tx~utxo~sp~++~\var{d}), \var{eu}, \var{cm}) \mid \\
+    & ~~\fun{toList} \{ (\var{script}, (\fun{valContext}~\var{txinfo}~\var{sp}~++~ \fun{getData}~tx~utxo~sp~++~[\var{d}]), \var{eu}, \var{cm}) \mid \\
     & ~~~~(\var{sp}, \var{scriptHash}) \in \fun{scriptsNeeded}~{utxo}~{tx}, \\
     & ~~~~\var{scriptHash}\mapsto \var{script}\in \fun{txscripts}~(\fun{txwits}~tx), \\
     & ~~~~(\var{d}, \var{eu}) := \fun{indexedRdmrs}~tx~sp, \\
@@ -525,7 +546,7 @@ This rule has the following changes:
 
   \item The end of the transaction validity interval is translatable into
   system time (ie. within the consensus's forecast window). This is checked
-  by $\fun{slotToTime}$, which returns $\Nothing$ if the end slot is outside.
+  by $\fun{epochInfoSlotToUTCTime}$, which returns $\Nothing$ if the end slot is outside.
   Note that we do not need to check that the start slot can be converted to
   time, because all pasts slots can be converted into time correctly.
 
@@ -554,7 +575,7 @@ UTXOS rule.
     {
       \var{txb}\leteq\txbody{tx} &
       \fun{ininterval}~\var{slot}~(\fun{txvldt}~{tx}) \\
-      \hldiff{\var{(\wcard, i_f)}\leteq\fun{txvldt}~{tx}} & \hldiff{\fun{slotToTime}~i_f \neq \Nothing} \\
+      \hldiff{\var{(\wcard, i_f)}\leteq\fun{txvldt}~{tx}} & \hldiff{\fun{epochInfoSlotToUTCTime}~\wcard~\wcard~i_f \neq \Nothing} \\
       \txins{txb} \neq \emptyset
       & \hldiff{\fun{feesOK}~pp~tx~utxo}
       & \txins{txb} \subseteq \dom \var{utxo}
@@ -658,9 +679,6 @@ We construct the following helper functions :
   \item $\fun{checkRedeemers}$ returns $\True$ if, for the given script purpose,
   whenever the script it points to is non-native, the transaction contains an associated entry
   in the indexed redeemers structure.
-  Recall that redeemers are optional to include, so there may be a $\Nothing$ in place of
-  a redeemer. Execution units are mandatory for all scripts, so each script purpose
-  should have an associated entry specifying the $\ExUnits$ value.
 
   \item $\fun{languages}$ returns the set of (non-native) script languages
   of all the scripts included in the transaction
@@ -701,10 +719,14 @@ We have made the following changes and additions to the UTXOW preconditions:
 \item The transaction contains exactly those scripts that are required for witnessing and no
 additional ones;
 
-    \item The datums included in the witnesses are exactly those that are required for validating;
+    \item The datums included in the witnesses are exactly those that are required for validating. That is,
+    datums for all output-locking non-native scripts for the payment credentials of the addresses of the
+    UTxOs the transaction is spending must have attached datum objects. This check will also fail if
+    the datum hash fields of such UTxOs are $\Nothing$, as $\Nothing$ is not a
+    hash of a datum (and therefore is not a key of the $\DataHash$-indexed map).
 
     \item For every item that needs to be validated by a non-native script, the transaction contains
-      an entry in the indexed redeemer structure (ie. the execution units for it are specified);
+      an entry in the indexed redeemer structure (ie. the execution units are redeemer for it are specified);
 
     \item The signatures of the keys whose hashes are specified in the
     $\fun{reqSignerHashes}$ field in a transaction

--- a/alonzo/formal-spec/value-size.tex
+++ b/alonzo/formal-spec/value-size.tex
@@ -9,7 +9,7 @@ is accounted for in the size calculation.
 \begin{figure*}[h]
   \emph{Constants}
   \begin{align*}
-  & \mathsf{JustDatHashSize} \in \MemoryEstimate \\
+  & \mathsf{JustDataHashSize} \in \MemoryEstimate \\
   & \text{The size of a datum hash wrapped in $\DataHash^?$} \\~
   \\
   & \mathsf{NothingSize} \in \MemoryEstimate \\
@@ -18,12 +18,12 @@ is accounted for in the size calculation.
   %
   \emph{Helper Functions}
   \begin{align*}
-    & \fun{datHashSize} \in \DataHash^? \to \MemoryEstimate \\
-    & \fun{datHashSize}~ \Nothing = \mathsf{NothingSize} \\
-    & \fun{datHashSize}~ \wcard = \mathsf{JustDatHashSize} \\
+    & \fun{dataHashSize} \in \DataHash^? \to \MemoryEstimate \\
+    & \fun{dataHashSize}~ \Nothing = \mathsf{NothingSize} \\
+    & \fun{dataHashSize}~ \wcard = \mathsf{JustDataHashSize} \\
     & \text{Return the size of $\DataHash^?$} \\~\\
     & \fun{utxoEntrySize} \in \TxOut \to \MemoryEstimate \\
-    & \fun{utxoEntrySize}~\var{(tout, d)} = \mathsf{utxoEntrySizeWithoutVal} + (\fun{size} (\fun{getValue}~tout)) + \mathsf{datHashSize}~d \\
+    & \fun{utxoEntrySize}~\var{(tout, d)} = \mathsf{utxoEntrySizeWithoutVal} + (\fun{size} (\fun{getValue}~tout)) + \mathsf{dataHashSize}~d \\
     & \text{Calculate the size of a UTxO entry}
   \end{align*}
   \caption{Value Size}
@@ -31,7 +31,7 @@ is accounted for in the size calculation.
 \end{figure*}
 
 \begin{note}
-  Get datHashSize from heapwords on the code
+  Get dataHashSize from heapwords on the code
 \end{note}
 
 There is a change of constant value from the ShelleyMA era, specifically:
@@ -44,6 +44,6 @@ There is a change of constant value from the ShelleyMA era, specifically:
 Additionally, the new constants used in Alonzo have values :
 
 \begin{itemize}
-  \item $\mathsf{JustDatHashSize} = $ words
+  \item $\mathsf{JustDataHashSize} = $ words
   \item $\mathsf{NothingSize} = $ words
 \end{itemize}


### PR DESCRIPTION
- `Datum` and `Redeemer` are now type aliases
- Redeemers now mandatory for all scripts
- `epochInfoSlotToUTCTime` function to match implementation
- Some properties