### PR TITLE
Moved VRF abstraction to crypto primitives section

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1,65 +1,6 @@
 \section{Blockchain layer}
 \label{sec:chain}
 
-\newcommand{\Proof}{\type{Proof}}
-\newcommand{\Seedl}{\mathsf{Seed}_\ell}
-\newcommand{\Seede}{\mathsf{Seed}_\eta}
-\newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
-\newcommand{\prevHashToNonce}[1]{\fun{prevHashToNonce}~ \var{#1}}
-\newcommand{\isOverlaySlot}[3]{\fun{isOverlaySlot}~\var{#1}~\var{#2}~\var{#3}}
-\newcommand{\classifyOverlaySlot}[5]{\fun{classifyOverlaySlot}~\var{#1}~\var{#2}~\var{#3}~\var{#4}~\var{#5}}
-
-\newcommand{\T}{\type{T}}
-\newcommand{\vrf}[3]{\fun{vrf}_{#1} ~ #2 ~ #3}
-\newcommand{\verifyVrf}[4]{\fun{verifyVrf}_{#1} ~ #2 ~ #3 ~#4}
-
-\newcommand{\HashHeader}{\type{HashHeader}}
-\newcommand{\HashBBody}{\type{HashBBody}}
-\newcommand{\bhHash}[1]{\fun{bhHash}~ \var{#1}}
-\newcommand{\bHeaderSize}[1]{\fun{bHeaderSize}~ \var{#1}}
-\newcommand{\bSize}[1]{\fun{bSize}~ \var{#1}}
-\newcommand{\bBodySize}[1]{\fun{bBodySize}~ \var{#1}}
-\newcommand{\OCert}{\type{OCert}}
-\newcommand{\BHeader}{\type{BHeader}}
-\newcommand{\BHBody}{\type{BHBody}}
-
-\newcommand{\bheader}[1]{\fun{bheader}~\var{#1}}
-\newcommand{\hsig}[1]{\fun{hsig}~\var{#1}}
-\newcommand{\bprev}[1]{\fun{bprev}~\var{#1}}
-\newcommand{\bhash}[1]{\fun{bhash}~\var{#1}}
-\newcommand{\bvkcold}[1]{\fun{bvkcold}~\var{#1}}
-\newcommand{\bseedl}[1]{\fun{bseed}_{\ell}~\var{#1}}
-\newcommand{\bprfn}[1]{\fun{bprf}_{n}~\var{#1}}
-\newcommand{\bseedn}[1]{\fun{bseed}_{n}~\var{#1}}
-\newcommand{\bprfl}[1]{\fun{bprf}_{\ell}~\var{#1}}
-\newcommand{\bocert}[1]{\fun{bocert}~\var{#1}}
-\newcommand{\bnonce}[1]{\fun{bnonce}~\var{#1}}
-\newcommand{\bleader}[1]{\fun{bleader}~\var{#1}}
-\newcommand{\hBbsize}[1]{\fun{hBbsize}~\var{#1}}
-\newcommand{\bbodyhash}[1]{\fun{bbodyhash}~\var{#1}}
-\newcommand{\overlaySchedule}[3]{\fun{overlaySchedule}~\var{#1}~\var{#2}~\var{#3}}
-
-\newcommand{\OCertEnv}{\type{OCertEnv}}
-\newcommand{\PrtclState}{\type{PrtclState}}
-\newcommand{\PrtclEnv}{\type{PrtclEnv}}
-\newcommand{\OverlayEnv}{\type{OverlayEnv}}
-\newcommand{\VRFState}{\type{VRFState}}
-\newcommand{\TickNonceState}{\type{TickNonceState}}
-\newcommand{\TickNonceEnv}{\type{TickNonceEnv}}
-\newcommand{\NewEpochState}{\type{NewEpochState}}
-\newcommand{\UpdateNonceState}{\type{UpdateNonceState}}
-\newcommand{\UpdateNonceEnv}{\type{UpdateNonceEnv}}
-\newcommand{\PoolDistr}{\type{PoolDistr}}
-\newcommand{\BBodyEnv}{\type{BBodyEnv}}
-\newcommand{\BBodyState}{\type{BBodyState}}
-\newcommand{\RUpdEnv}{\type{RUpdEnv}}
-\newcommand{\ChainEnv}{\type{ChainEnv}}
-\newcommand{\ChainState}{\type{ChainState}}
-\newcommand{\ChainSig}{\type{ChainSig}}
-\newcommand{\LastAppliedBlock}{\type{LastAppliedBlock}}
-\newcommand{\lastAppliedHash}[1]{\fun{lastAppliedHash}~\var{#1}}
-
-
 This chapter introduces the view of the blockchain layer as required for the
 ledger. This includes in particular the information required for the epoch
 boundary and its rewards calculation as described in Section~\ref{sec:epoch}. It

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -10,59 +10,6 @@ calculate rewards and penalties for stake pools.
 The main transition rule is $\mathsf{CHAIN}$ which calls the subrules
 $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
 
-\subsection{Verifiable Random Functions (VRF)}
-\label{sec:defs-vrf}
-
-\begin{figure}[htb]
-  %
-  \emph{Abstract types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \var{seed} & \Seed  & \text{seed for pseudo-random number generator}\\
-      \var{prf} & \Proof  & \text{VRF proof}\\
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Abstract functions ($T$ an arbitrary type)}
-  %
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \seedOp & \Seed \to \Seed \to \Seed & \text{binary seed operation} \\
-      \vrf{\T}{}{} & \SKey \to \Seed \to \T\times\Proof
-                   & \text{verifiable random function} \\
-                   %
-      \verifyVrf{\T}{}{}{} & \VKey \to \Seed \to \Proof\times\T \to \Bool
-                           & \text{verify vrf proof} \\
-                           %
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Derived Types}
-  \begin{align*}
-    \PoolDistr = \KeyHash_{pool} \mapsto \left([0, 1]\times\KeyHash_{vrf}\right)
-      \text{ \hspace{1cm}stake pool distribution}
-  \end{align*}
-  %
-
-  \emph{Constraints}
-  \begin{align*}
-    & \forall (sk, vk) \in \KeyPair,~ seed \in \Seed,~
-    \verifyVrf{T}{vk}{seed}{\left(\vrf{T}{sk}{seed}\right)}
-  \end{align*}
-  %
-  \emph{Constants}
-  \begin{align*}
-    & 0_{seed} \in \Seed & \text{neutral seed element} \\
-    & \Seedl \in \Seed & \text{leader seed constant} \\
-    & \Seede \in \Seed & \text{nonce seed constant}\\
-  \end{align*}
-
-  \caption{VRF definitions}
-  \label{fig:defs-vrf}
-\end{figure}
-
-\clearpage
-
 \subsection{Block Definitions}
 \label{sec:defs-blocks}
 

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -82,7 +82,7 @@ type.
 \end{figure}
 
 When we get to the blockchain layer validation, we will use
-key evolving signatures (KES) according to the MMM scheme \cite{cryptoeprint:2001:034}.
+key evolving signatures (KES).
 This is another asymmetric key cryptographic scheme, also relying on
 the use of public and private key pairs.
 These signature schemes provide forward cryptographic security, meaning that a

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -211,4 +211,57 @@ are required to sign
   \label{fig:types-msig}
 \end{figure*}
 
+
+%\subsection{Verifiable Random Functions (VRF)}
+%\label{sec:defs-vrf}
+Figure~\ref{fig:defs-vrf} shows the cryptographic abstractions needed for Verifiable Random Functions (VRF). VRFs allow key-pair owners, $(sk, vk)\in \KeyPair$, to evaluate a pseudorandom function in a provable way given a randomness seed. Any party with access to the verification key, $vk$, the randomness seed, the proof and the generated randomness can indeed verify that the value is pseudorandom. 
+
+\begin{figure}[htb]
+  %
+  \emph{Abstract types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{seed} & \Seed  & \text{seed for pseudo-random number generator}\\
+      \var{prf} & \Proof  & \text{VRF proof}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Abstract functions ($T$ an arbitrary type)}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \seedOp & \Seed \to \Seed \to \Seed & \text{binary seed operation} \\
+      \vrf{\T}{}{} & \SKey \to \Seed \to \T\times\Proof
+                   & \text{verifiable random function} \\
+                   %
+      \verifyVrf{\T}{}{}{} & \VKey \to \Seed \to \Proof\times\T \to \Bool
+                           & \text{verify vrf proof} \\
+                           %
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Derived Types}
+  \begin{align*}
+    \PoolDistr = \KeyHash_{pool} \mapsto \left([0, 1]\times\KeyHash_{vrf}\right)
+      \text{ \hspace{1cm}stake pool distribution}
+  \end{align*}
+  %
+
+  \emph{Constraints}
+  \begin{align*}
+    & \forall (sk, vk) \in \KeyPair,~ seed \in \Seed,~
+    \verifyVrf{T}{vk}{seed}{\left(\vrf{T}{sk}{seed}\right)}
+  \end{align*}
+  %
+  \emph{Constants}
+  \begin{align*}
+    & 0_{seed} \in \Seed & \text{neutral seed element} \\
+    & \Seedl \in \Seed & \text{leader seed constant} \\
+    & \Seede \in \Seed & \text{nonce seed constant}\\
+  \end{align*}
+
+  \caption{VRF definitions}
+  \label{fig:defs-vrf}
+\end{figure}
+
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -194,6 +194,65 @@
 \newcommand{\LEnv}{\type{LEnv}}
 \newcommand{\LState}{\type{LState}}
 
+\newcommand{\Proof}{\type{Proof}}
+\newcommand{\Seedl}{\mathsf{Seed}_\ell}
+\newcommand{\Seede}{\mathsf{Seed}_\eta}
+\newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
+\newcommand{\prevHashToNonce}[1]{\fun{prevHashToNonce}~ \var{#1}}
+\newcommand{\isOverlaySlot}[3]{\fun{isOverlaySlot}~\var{#1}~\var{#2}~\var{#3}}
+\newcommand{\classifyOverlaySlot}[5]{\fun{classifyOverlaySlot}~\var{#1}~\var{#2}~\var{#3}~\var{#4}~\var{#5}}
+
+\newcommand{\T}{\type{T}}
+\newcommand{\vrf}[3]{\fun{vrf}_{#1} ~ #2 ~ #3}
+\newcommand{\verifyVrf}[4]{\fun{verifyVrf}_{#1} ~ #2 ~ #3 ~#4}
+
+\newcommand{\HashHeader}{\type{HashHeader}}
+\newcommand{\HashBBody}{\type{HashBBody}}
+\newcommand{\bhHash}[1]{\fun{bhHash}~ \var{#1}}
+\newcommand{\bHeaderSize}[1]{\fun{bHeaderSize}~ \var{#1}}
+\newcommand{\bSize}[1]{\fun{bSize}~ \var{#1}}
+\newcommand{\bBodySize}[1]{\fun{bBodySize}~ \var{#1}}
+\newcommand{\OCert}{\type{OCert}}
+\newcommand{\BHeader}{\type{BHeader}}
+\newcommand{\BHBody}{\type{BHBody}}
+
+\newcommand{\bheader}[1]{\fun{bheader}~\var{#1}}
+\newcommand{\hsig}[1]{\fun{hsig}~\var{#1}}
+\newcommand{\bprev}[1]{\fun{bprev}~\var{#1}}
+\newcommand{\bhash}[1]{\fun{bhash}~\var{#1}}
+\newcommand{\bvkcold}[1]{\fun{bvkcold}~\var{#1}}
+\newcommand{\bseedl}[1]{\fun{bseed}_{\ell}~\var{#1}}
+\newcommand{\bprfn}[1]{\fun{bprf}_{n}~\var{#1}}
+\newcommand{\bseedn}[1]{\fun{bseed}_{n}~\var{#1}}
+\newcommand{\bprfl}[1]{\fun{bprf}_{\ell}~\var{#1}}
+\newcommand{\bocert}[1]{\fun{bocert}~\var{#1}}
+\newcommand{\bnonce}[1]{\fun{bnonce}~\var{#1}}
+\newcommand{\bleader}[1]{\fun{bleader}~\var{#1}}
+\newcommand{\hBbsize}[1]{\fun{hBbsize}~\var{#1}}
+\newcommand{\bbodyhash}[1]{\fun{bbodyhash}~\var{#1}}
+\newcommand{\overlaySchedule}[3]{\fun{overlaySchedule}~\var{#1}~\var{#2}~\var{#3}}
+
+\newcommand{\OCertEnv}{\type{OCertEnv}}
+\newcommand{\PrtclState}{\type{PrtclState}}
+\newcommand{\PrtclEnv}{\type{PrtclEnv}}
+\newcommand{\OverlayEnv}{\type{OverlayEnv}}
+\newcommand{\VRFState}{\type{VRFState}}
+\newcommand{\TickNonceState}{\type{TickNonceState}}
+\newcommand{\TickNonceEnv}{\type{TickNonceEnv}}
+\newcommand{\NewEpochState}{\type{NewEpochState}}
+\newcommand{\UpdateNonceState}{\type{UpdateNonceState}}
+\newcommand{\UpdateNonceEnv}{\type{UpdateNonceEnv}}
+\newcommand{\PoolDistr}{\type{PoolDistr}}
+\newcommand{\BBodyEnv}{\type{BBodyEnv}}
+\newcommand{\BBodyState}{\type{BBodyState}}
+\newcommand{\RUpdEnv}{\type{RUpdEnv}}
+\newcommand{\ChainEnv}{\type{ChainEnv}}
+\newcommand{\ChainState}{\type{ChainState}}
+\newcommand{\ChainSig}{\type{ChainSig}}
+\newcommand{\LastAppliedBlock}{\type{LastAppliedBlock}}
+\newcommand{\lastAppliedHash}[1]{\fun{lastAppliedHash}~\var{#1}}
+
+
 %%
 %% Functions
 %%


### PR DESCRIPTION
In order to have all cryptographic abstractions in one place, I've moved the VRF abstraction to section `Cryptographic primitives`. I've also removed citations to specific constructions of Key Evolving Signatures to keep consistency of the section, where we present only abstractions and not specific constructions. We keep the details for Appendix A. Changes in this PR: 
* Removed the citation of the MMM scheme for KES
* Moved the `chain.tex` macros to `ledger-spec.tex`
* Moved the VRF abstraction to `crypto-primitives.tex`
* Added a small paragraph introducing VRFs. 