### PR TITLE
Mempool API changes for Alonzo.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -265,6 +265,8 @@ pattern ValidatedTx {body, wits, isValidating, auxiliaryData} <-
     ValidatedTx b w v a =
       ValidatedTxConstr $ memoBytes (encodeTxRaw $ ValidatedTxRaw b w v a)
 
+{-# COMPLETE ValidatedTx #-}
+
 -- We define these accessor functions manually, because if we define them using
 -- the record syntax in the Tx pattern, they inherit the constraints
 -- (Era era, ToCBOR (Core.AuxiliaryData era),ToCBOR (Core.TxBody era))

--- a/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -29,7 +30,7 @@ import Shelley.Spec.Ledger.API
     ApplyTx,
     Coin (..),
     Globals,
-    LedgersEnv (..),
+    LedgerEnv (..),
     MempoolEnv,
     MempoolState,
     Tx,
@@ -57,10 +58,11 @@ type MaryBench = MaryEra C_Crypto
 -- state shouldn't matter much.
 applyTxMempoolEnv :: Default (Core.PParams era) => MempoolEnv era
 applyTxMempoolEnv =
-  LedgersEnv
-    { ledgersSlotNo = SlotNo 71,
-      ledgersPp = def,
-      ledgersAccount = AccountState (Coin 45000000000) (Coin 45000000000)
+  LedgerEnv
+    { ledgerSlotNo = SlotNo 71,
+      ledgerIx = 0,
+      ledgerPp = def,
+      ledgerAccount = AccountState (Coin 45000000000) (Coin 45000000000)
     }
 
 data ApplyTxRes era = ApplyTxRes

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -857,7 +857,7 @@ instance
 
 instance
   ( Era era,
-    Arbitrary (STS.PredicateFailure (Core.EraRule "LEDGERS" era))
+    Arbitrary (STS.PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   Arbitrary (ApplyTxError era)
   where


### PR DESCRIPTION
We now expose two separate functions in the mempool:

- `validateTx`, which takes a transaction and returns a `TxInBlock`.
- `reapplyTx`, which applies a `TxInBlock` to a new ledger state.