### PR TITLE
dont bang the mark for merging

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -216,7 +216,7 @@ instance
 
 -- | Snapshots of the stake distribution.
 data SnapShots crypto = SnapShots
-  { _pstakeMark :: !(SnapShot crypto),
+  { _pstakeMark :: SnapShot crypto,
     _pstakeSet :: !(SnapShot crypto),
     _pstakeGo :: !(SnapShot crypto),
     _feeSS :: !Coin


### PR DESCRIPTION
This PR removes strictness from the "mark" snapshot in the ledger state. We also force evaluation in the `TICK` rule. We do *not* force evaluation in the `TICKF` and `TICKN` rule so that it can remain a thunk when the consensus layer computes the ledger view across the epoch boundary.

These two new commits are the same as the ones in the branch https://github.com/input-output-hk/cardano-ledger-specs/tree/jc/dont-bang-the-mark`, but _this_ branch (`jc/dont-bang-the-mark-for-merging`) sits on top of master, while `jc/dont-bang-the-mark` sits on top of the version of cardano-ledger-specs that was in the 1.26.1 release of cardano-node.

This PR should be merged so that these changes are included in future releases, while `jc/dont-bang-the-mark` should not be merged (I don't want github to delete it just yet).

