### PR TITLE
Align spec with code

### DIFF
--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -177,8 +177,8 @@
 \newcommand{\WitnessPPDataHash}{\type{WitnessPPDataHash}}
 \newcommand{\Script}{\type{Script}}
 \newcommand{\ScriptPlutus}{\type{Script}_{plc}}
-\newcommand{\PlutusV1}{\mathsf{PlutusV1}}
-\newcommand{\PlutusV1II}{\mathsf{PlutusV2}}
+\newcommand{\PlutusVI}{\type{PlutusV1}}
+\newcommand{\PlutusVII}{\type{PlutusV2}}
 \newcommand{\ScriptNative}{\type{Script^{native}}}
 \newcommand{\ScriptNonNative}{\type{Script^{non-native}}}
 \newcommand{\ScriptV}{\type{Script_{v}}}

--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -177,8 +177,8 @@
 \newcommand{\WitnessPPDataHash}{\type{WitnessPPDataHash}}
 \newcommand{\Script}{\type{Script}}
 \newcommand{\ScriptPlutus}{\type{Script}_{plc}}
-\newcommand{\Plutus}{\mathsf{Plutus}}
-\newcommand{\PlutusII}{\mathsf{PlutusV2}}
+\newcommand{\PlutusV1}{\mathsf{PlutusV1}}
+\newcommand{\PlutusV1II}{\mathsf{PlutusV2}}
 \newcommand{\ScriptNative}{\type{Script^{native}}}
 \newcommand{\ScriptNonNative}{\type{Script^{non-native}}}
 \newcommand{\ScriptV}{\type{Script_{v}}}
@@ -206,7 +206,8 @@
 \newcommand{\TxInScr}{\type{TxInScr}}
 \newcommand{\Info}{\type{Info}}
 \newcommand{\ExUnits}{\type{ExUnits}}
-\newcommand{\CostMod}{\type{CostMod}}
+\newcommand{\CostMod}{\type{CostModel}}
+\newcommand{\Network}{\type{Network}}
 \newcommand{\Prices}{\type{Prices}}
 \newcommand{\IsFee}{\type{IsFee}}
 \newcommand{\TxOut}{\type{TxOut}}
@@ -366,6 +367,8 @@
 \include{value-size}
 
 \include{txinfo}
+
+\include{constants}
 
 
 \addcontentsline{toc}{section}{References}

--- a/alonzo/formal-spec/constants.tex
+++ b/alonzo/formal-spec/constants.tex
@@ -1,0 +1,16 @@
+\section{Constants}
+
+This section specifies the values of the constants used in this document.
+
+\begin{note}
+  TODO specify these
+\end{note}
+
+\begin{itemize}
+  \item $\NetworkId$
+
+  \item $\SystemStart$
+
+  \item $\EpochInfo$
+
+\end{itemize}

--- a/alonzo/formal-spec/introduction.tex
+++ b/alonzo/formal-spec/introduction.tex
@@ -78,11 +78,11 @@ running scripts in all languages will be supported indefinitely whenever possibl
 Making it impossible to run a script in a particular scripting language
 makes UTxO entries locked by that script unspendable.
 
-We use the terms Plutus, $\PlutusV1$, and ``non-native scripting language'' in this specification
+We use the terms Plutus, $\PlutusVI$, and ``non-native scripting language'' in this specification
 somewhat interchangably. The reason for this is that while we intend for the infrastructure
 set up in this document to be somewhat language-agnostic (in particular,
 able to support multiple versions of Plutus), it only gives all the details for
-the first and (currenly only) non-native script language, $\PlutusV1$, 
+the first and (currenly only) non-native script language, $\PlutusVI$,
 the introduction of which represents the
 start of the Alonzo era.
 

--- a/alonzo/formal-spec/introduction.tex
+++ b/alonzo/formal-spec/introduction.tex
@@ -36,7 +36,7 @@ to have a budget in terms of a number of abstract $\ExUnits$.
 This budget gives a quantitative bound on resource usage in terms of a number of specific metrics, including memory usage or abstract execution steps.
 The budget is then used as part of the transaction fee calculation.
 
-Every scripting language
+Every non-native scripting language
 converts the calculated execution cost into a number of $\ExUnits$ using a cost model,
 $\CostMod$, which depends on the language and is provided as a protocol parameter.
 This allows execution costs (and so transaction fees) to be varied without requiring a major protocol version change (``hard fork'').
@@ -77,6 +77,15 @@ Another important point to make about both native and non-native scripts on Card
 running scripts in all languages will be supported indefinitely whenever possible.
 Making it impossible to run a script in a particular scripting language
 makes UTxO entries locked by that script unspendable.
+
+We use the terms Plutus, $\PlutusV1$, and ``non-native scripting language'' in this specification
+somewhat interchangably. The reason for this is that while we intend for the infrastructure
+set up in this document to be somewhat language-agnostic (in particular,
+able to support multiple versions of Plutus), it only gives all the details for
+the first and (currenly only) non-native script language, $\PlutusV1$, 
+the introduction of which represents the
+start of the Alonzo era.
+
 
 \subsection{Extended UTxO}
 

--- a/alonzo/formal-spec/ledger.tex
+++ b/alonzo/formal-spec/ledger.tex
@@ -16,7 +16,7 @@ validation tag is verified, and where script fees are collected.
     \label{eq:ledger}
     \inference[ledger-V]
     {
-      \fun{txvaltag}~{tx} = \True \\~\\
+      \fun{isValidating}~{tx} = \True \\~\\
       {
         \begin{array}{c}
           \var{slot} \\
@@ -74,7 +74,7 @@ validation tag is verified, and where script fees are collected.
     \label{eq:ledger}
     \inference[ledger-NV]
     {
-      \fun{txvaltag}~{tx} = \False \\~\\
+      \fun{isValidating}~{tx} = \False \\~\\
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
       (\_, \_, \_, \_, \_, \var{genDelegs}, \_) \leteq \var{dstate} \\
       (\var{poolParams}, \_, \_) \leteq \var{pstate} \\

--- a/alonzo/formal-spec/properties.tex
+++ b/alonzo/formal-spec/properties.tex
@@ -22,7 +22,7 @@ This appendix collects the main formal properties that the new ledger rules are 
 \item
   \emph{Fee Movement.}
   If a transaction is accepted and marked as paying fees only
-  (i.e. $\fun{txvaltag}\, tx = \False$), then the only change to the ledger
+  (i.e. $\fun{isValidating}\, tx = \False$), then the only change to the ledger
   when processing the transaction is that the inputs marked for paying
   fees are moved to the fee pot.
 \item
@@ -41,7 +41,7 @@ This appendix collects the main formal properties that the new ledger rules are 
 \item
   \todo{\emph{Script consistency.} Scripts are only processed by valid version of the interpreter.}
 \item
-  \todo{\emph{Backwards compatibility.} All scripts that could be processed by any previous version of the interpreter
+  \todo{\emph{Script backwards compatibility.} All scripts that could be processed by any previous version of the interpreter
     remain valid indefinitely.}
 \item
   \todo{\emph{Cost consistency.} - no transaction exceeds the specified resource bounds.}
@@ -50,7 +50,7 @@ This appendix collects the main formal properties that the new ledger rules are 
 \item
   \emph{Cost Lower Bound.} if a transaction contains at least one valid script, it must have at least one execution unit
 \item
-  \todo{\emph{Backwards Compatibility.} Any transaction that was accepted in a previous version of the ledger rules
+  \todo{\emph{Tx backwards Compatibility.} Any transaction that was accepted in a previous version of the ledger rules
     has exactly the same cost and effect, except that the transaction output is extended.}
 \item \emph{UTxO-changing transitions.} Only the UTXOS transition affects the ledger UTxO in Alonzo.
 For Shelley/ShelleyMA, only the UTXO transition does.
@@ -63,6 +63,7 @@ get all the correct inputs, which must be present.
   of script validation is not affected by these ledger state changes.
 \item \emph{Script inputs are fixed.} All data that a non-native script gets as input
 is fixed either by being signed in a transaction, or fixed by its hash living on the ledger
+\item \emph{Paying fees.} A transaction always pays into the fee pot
 \item
   ... \todo{Anything else?}
 \end{enumerate}

--- a/alonzo/formal-spec/protocol-parameters.tex
+++ b/alonzo/formal-spec/protocol-parameters.tex
@@ -105,7 +105,7 @@ serialised transaction.
     \begin{array}{r@{~\in~}l@{\quad=\quad}l@{\qquad}r}
       \var{lg}
       & \Language
-      & \{\PlutusV1, \dotsb\}
+      & \{\PlutusVI, \dotsb\}
       & \text{Script Language}
       \\
       \var{(pr_{mem}, pr_{steps})}
@@ -157,7 +157,7 @@ serialised transaction.
   %
   \begin{align*}
     & \fun{getLanguageView} \in \PParams \to \Language \to \LangDepView \\
-    & \fun{getLanguageView}~\var{pp}~\PlutusV1 = \{\PlutusV1\} \restrictdom \fun{costmdls}~{pp}
+    & \fun{getLanguageView}~\var{pp}~\PlutusVI = \{\PlutusVI\} \restrictdom \fun{costmdls}~{pp}
   \end{align*}
   %
   \caption{Definitions Used in Protocol Parameters}

--- a/alonzo/formal-spec/protocol-parameters.tex
+++ b/alonzo/formal-spec/protocol-parameters.tex
@@ -105,7 +105,7 @@ serialised transaction.
     \begin{array}{r@{~\in~}l@{\quad=\quad}l@{\qquad}r}
       \var{lg}
       & \Language
-      & \{\Plutus, \dotsb\}
+      & \{\PlutusV1, \dotsb\}
       & \text{Script Language}
       \\
       \var{(pr_{mem}, pr_{steps})}
@@ -157,7 +157,7 @@ serialised transaction.
   %
   \begin{align*}
     & \fun{getLanguageView} \in \PParams \to \Language \to \LangDepView \\
-    & \fun{getLanguageView}~\var{pp}~\Plutus = \{\Plutus\} \restrictdom \fun{costmdls}~{pp}
+    & \fun{getLanguageView}~\var{pp}~\PlutusV1 = \{\PlutusV1\} \restrictdom \fun{costmdls}~{pp}
   \end{align*}
   %
   \caption{Definitions Used in Protocol Parameters}

--- a/alonzo/formal-spec/references.bib
+++ b/alonzo/formal-spec/references.bib
@@ -42,7 +42,8 @@
      title = {{The Cardano Consensus and Storage Layer}},
      author = {Edsko de Vries and Thomas Winant and Duncan Coutts},
      year = {2021},
-     institution = {IOHK}
+     institution = {IOHK},
+     url = {https://hydra.iohk.io/build/5265971/download/1/report.pdf}
 }
 
 @misc{shelley_spec,

--- a/alonzo/formal-spec/references.bib
+++ b/alonzo/formal-spec/references.bib
@@ -38,10 +38,11 @@
   year    = {2018},
 }
 
-@article{shelley_consensus,
-  author = {{Formal Methods Team, IOHK}},
-  title   = {{?? - Shelley Consensus}},
-  year    = {TODO},
+@techreport{cardano_consensus,
+     title = {{The Cardano Consensus and Storage Layer}},
+     author = {Edsko de Vries and Thomas Winant and Duncan Coutts},
+     year = {2021},
+     institution = {IOHK}
 }
 
 @misc{shelley_spec,

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -42,10 +42,10 @@ We make the following changes and additions:
   \item $\Tag$ lets us differentiate what a script
   can validate, i.e. \\
   \begin{tabular}{l@{~to validate~}l}
-  $\mathsf{inputTag}$ & spending a script UTxO entry; \\
-  $\mathsf{mintTag}$ & minting tokens; \\
-  $\mathsf{certTag}$  & certificates with script credentials; and  \\
-  $\mathsf{wdrlTag}$ & reward withdrawals from script addresses.
+  $\mathsf{Spend}$ & spending a script UTxO entry; \\
+  $\mathsf{Mint}$ & minting tokens; \\
+  $\mathsf{Cert}$  & certificates with script credentials; and  \\
+  $\mathsf{Rewrd}$ & reward withdrawals from script addresses.
   \end{tabular}
 
   \item $\RdmrPtr$ is a pair of a tag and an index. This type is
@@ -96,7 +96,7 @@ We add the following helper functions:
       \\
       \var{tag}
       & \Tag
-      & \{\mathsf{inputTag},~\mathsf{mintTag},~\mathsf{certTag},~\mathsf{wdrlTag}\}
+      & \{\mathsf{Spend},~\mathsf{Mint},~\mathsf{Cert},~\mathsf{Rewrd}\}
       \\
       \var{rdptr}
       & \RdmrPtr
@@ -154,6 +154,7 @@ We add the following helper functions:
        & \times ~\hldiff{\powerset{\KeyHash}} & \hldiff{\fun{reqSignerHashes}} & \text{Hashes of VKeys passed to scripts}\\
        & \times ~\hldiff{\WitnessPPDataHash^?} & \hldiff{\fun{wppHash}} & \text{Hash of script-related data}\\
        & \times ~\AuxiliaryDataHash^? & \fun{txADhash} & \text{Auxiliary data hash}\\
+       & \times ~\hldiff{\Network^?} & \hldiff{\fun{txnetworkid}} & \text{Tx network ID}\\
     \end{array}
   \end{equation*}
   %
@@ -171,8 +172,8 @@ We add the following helper functions:
       \var{tx} ~\in~ \Tx ~=~
       & \TxBody & \fun{txbody} & \text{Body}\\
       & \times ~\TxWitness & \fun{txwits} & \text{Witnesses}\\
-      & \times ~\hldiff{\IsValidating} & \hldiff{\fun{txvaltag}}&\text{Validation tag}\\
-      & \times ~\AuxiliaryData^? & \fun{txAD}&\text{Auxiliary data}\\
+      & \times ~\hldiff{\IsValidating} & \hldiff{\fun{isValidating}}&\text{Validation tag}\\
+      & \times ~\AuxiliaryData^? & \fun{auxiliaryData}&\text{Auxiliary data}\\
     \end{array}
   \end{equation*}
   \caption{Definitions for transactions, cont.}
@@ -228,6 +229,9 @@ the body of the transaction:
     the hashes of the signing keys are listed inside the signed body.
   \item We include a hash of some script-related data, specifically the redeemers and protocol parameters,
     with accessor $\fun{wppHash}$.
+
+  \item We include the ID of the network on which the transaction lives, $\fun{txnetworkid}$. 
+  This is in addition to the network ID's already included in the reward and output addresses.
 \end{itemize}
 
 A complete transaction comprises:
@@ -239,10 +243,17 @@ A complete transaction comprises:
   that are executed during the script execution phase validate.
   The correctness of the tag is verified as part of the ledger rules, and the block is
   deemed to be invalid if it is applied incorrectly.
-  If it is set to \emph{false}, then the block can be re-applied without script re-validation.
+  If it is set to \False, then the block can be re-applied without script re-validation.
   This tag cannot be signed, since it is applied by the block producer.
   \item any transaction metadata.
 \end{enumerate}
+
+Note that unlike in Shelley or ShelleyMA eras, transactions inside blocks and transactions
+a user submits are now of different types. A transaction inside a block is composed of
+the user-submitted transaction paired with the $\IsValidating$ tag, which is
+added by the block producer. The user cannot
+add their own tag because of how this tag is used in transaction validation, see
+Section~\ref{sec:two-phase}.
 
 \subsection{Additional Role of Signatures on TxBody}
 

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -230,7 +230,7 @@ the body of the transaction:
   \item We include a hash of some script-related data, specifically the redeemers and protocol parameters,
     with accessor $\fun{wppHash}$.
 
-  \item We include the ID of the network on which the transaction lives, $\fun{txnetworkid}$. 
+  \item We include the ID of the network on which the transaction lives, $\fun{txnetworkid}$.
   This is in addition to the network ID's already included in the reward and output addresses.
 \end{itemize}
 
@@ -243,7 +243,7 @@ A complete transaction comprises:
   that are executed during the script execution phase validate.
   The correctness of the tag is verified as part of the ledger rules, and the block is
   deemed to be invalid if it is applied incorrectly.
-  If it is set to \False, then the block can be re-applied without script re-validation.
+  If it is set to $\False$, then the block can be re-applied without script re-validation.
   This tag cannot be signed, since it is applied by the block producer.
   \item any transaction metadata.
 \end{enumerate}

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -17,7 +17,7 @@
     \nextdef
     & \fun{feesOK} \in \PParams \to \Tx \to \UTxO \to \Bool  \\
     & \fun{feesOK}~\var{pp}~tx~utxo~= \\
-    &~~      \minfee{pp}~{tx} \leq \txfee{txb} \wedge (\fun{totExunits}~tx \neq (0, 0) \Rightarrow \\
+    &~~      \minfee{pp}~{tx} \leq \txfee{txb} \wedge (\fun{txrdmrs}~tx \neq \Nothing \Rightarrow \\
     &~~~~~~((\forall (a, \wcard, \_) \in \fun{range}~(\fun{txinputs_{fee}}~{txb} \restrictdom \var{utxo}), \neg \fun{isNonNativeScriptAddress}~tx~a) \\
     &~~~~~~\wedge~ \fun{adaOnly}~\var{balance} \\
     &~~~~~~      \wedge~ \var{balance} \geq \txfee{txb})) \\
@@ -54,11 +54,15 @@ We have added or changed several functions that deal with fees as shown in Figur
   \begin{enumerate}[label=({\roman*})]
     \item the fee amount that the transaction states it is paying suffices to cover
     the minimum fee that the transaction is obligated to pay; and if the transaction uses non-native scripts, that
-    \item the fee-marked inputs do not belong to non-native script addresses;
+    \item the fee-marked inputs do not belong to non-native script addresses (that is, they
+    belong to either a native script address, or a key hash one);
     \item all the fee-marked inputs contain strictly Ada and no other kinds of token; and
     \item the fee-marked inputs are sufficient to cover the fee amount that is stated
     in the transaction.
   \end{enumerate}
+  Note that checking that a transaction is carrying redeemers is the most simple way to
+  check that it is carrying non-native scripts. A separate check is done in the rule prior to
+  calling the $\fun{feesOK}$ function that ensure that this is the case.
   \item The function $\fun{txins}$ returns the UTxO keys of transaction inputs.
   \item $\fun{txscriptfee}$ calculates the fee that a transaction must pay for script
   execution based on the amount of $\ExUnits$ it has budgeted, and the prices in the current protocol parameters
@@ -126,7 +130,7 @@ the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{sp}
       & \ScriptPurpose
-      & \PolicyID \uniondistinct \UTxOIn \uniondistinct \AddrRWD \uniondistinct \DCert
+      & \PolicyID \uniondistinct \TxIn \uniondistinct \AddrRWD \uniondistinct \DCert
 %      & \text{item the script is validated for}
     \end{array}
   \end{equation*}
@@ -135,7 +139,7 @@ the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
   \begin{align*}
     &\fun{indexof} \in \DCert \to \seqof{\DCert} \to \Ix\\
     &\fun{indexof} \in \AddrRWD \to \Wdrl \to \Ix\\
-    &\fun{indexof} \in \UTxOIn \to \powerset{\TxIn} \to \Ix\\
+    &\fun{indexof} \in \TxIn \to \powerset{\TxIn} \to \Ix\\
     &\fun{indexof} \in \PolicyID \to \Value \to \Ix
   \end{align*}
   %
@@ -150,10 +154,10 @@ the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
     & ~~\where \\
     & ~~\quad \var{txb} = \txbody{tx} \\
     & ~~\quad \var{rdptr} = \begin{cases}
-        (\mathsf{certTag},\fun{indexof}~\var{sp}~(\fun{txcerts}~{txb}))   & \var{sp}~\in~\DCert \\
-        (\mathsf{wdrlTag},\fun{indexof}~\var{sp}~(\fun{txwdrls}~{txb}))   & \var{sp}~\in~\AddrRWD \\
-        (\mathsf{mintTag},\fun{indexof}~\var{sp}~(\fun{mint}~{txb}))    & \var{sp}~\in~\PolicyID \\
-        (\mathsf{inputTag},\fun{indexof}~\var{sp}~(\fun{txinputs}~{txb})) & \var{sp}~\in~\UTxOIn
+        (\mathsf{Cert},\fun{indexof}~\var{sp}~(\fun{txcerts}~{txb}))   & \var{sp}~\in~\DCert \\
+        (\mathsf{Rewrd},\fun{indexof}~\var{sp}~(\fun{txwdrls}~{txb}))   & \var{sp}~\in~\AddrRWD \\
+        (\mathsf{Mint},\fun{indexof}~\var{sp}~(\fun{mint}~{txb}))    & \var{sp}~\in~\PolicyID \\
+        (\mathsf{Spend},\fun{indexof}~\var{sp}~(\fun{txinputs}~{txb})) & \var{sp}~\in~\TxIn
       \end{cases}
   \end{align*}
   \caption{Indexing script and data objects}
@@ -192,8 +196,8 @@ predict the exact time to which it refers.
   \begin{itemize}
   \item A cost model, that is used to calculate the $\ExUnits$ that are needed for script execution;
   \item A script to execute;
-  \item A list of terms of type $\Data$ that will be passed to the script; and
-  \item the execution unit budget.
+  \item the execution unit budget; and
+  \item A list of terms of type $\Data$ that will be passed to the script.
   \end{itemize}
   It outputs the validation result.
   Note that script execution stops if the full budget has been spent before validation is complete.
@@ -221,7 +225,7 @@ map differently onto points in time. The ledger does not have access to data (or
 that is needed to convert transaction validity interval slots numbers to slots numbers
 that correspond to the contracts world view. To address this, we decided to pass
 non-native contracts (in all languages and all eras) the system time instead of slot numbers.
-The conversion function is implemented by consensus (see~\cite{shelley_consensus}),
+The conversion function is implemented by consensus (see~\cite{cardano_consensus}),
 which has the information to do this correctly for
 
 \begin{itemize}
@@ -278,8 +282,8 @@ which has the information to do this correctly for
      &\text{Summarizes transaction data} \\~\\
      &\fun{valContext} \in \TxInfo \to \ScriptPurpose \to \Data \\
      &\text{Pairs transaction data with a script purpose} \\~\\
-     &\fun{runPLCScript} \in \CostMod \to\ScriptPlutus \to
-    \seqof{\Data} \to \ExUnits \to \IsValidating \\
+     &\fun{runPLCScript} \in \CostMod \to\ScriptPlutus \to \ExUnits \to
+    \seqof{\Data} \to \IsValidating \\
      &\text{Validate a Plutus script, taking resource limits into account}
   \end{align*}
   %
@@ -287,7 +291,7 @@ which has the information to do this correctly for
   %
   \begin{align*}
     \llbracket \var{script_v} \rrbracket_{\var{cm},\var{eu}}~\var{d}
-    &=& \fun{runPLCScript} ~{cm}~\var{script_v}~\var{d}~\var{eu}
+    &=& \fun{runPLCScript} ~{cm}~\var{script_v}~\var{eu}~\var{d}
   \end{align*}
   \caption{Script Validation, cont.}
   \label{fig:defs:functions-valid}
@@ -345,7 +349,7 @@ are caught during the application of the UTXOW rule (before these functions are 
     \nextdef
     & \fun{collectNNScriptInputs} \in \PParams \to \Tx \to \UTxO \to \seqof{(\ScriptNonNative \times \seqof{\Data} \times \ExUnits \times \CostMod)} \\
     & \fun{collectNNScriptInputs} ~\var{pp}~\var{tx}~ \var{utxo} ~=~ \\
-    & ~~\fun{toList} \{ (\var{script}, (\fun{valContext}~\var{txinfo}~\var{sp}~++~ \fun{getData}~tx~utxo~sp~++~[\var{d}]), \var{eu}, \var{cm}) \mid \\
+    & ~~\fun{toList} \{ (\var{script}, ([\fun{valContext}~\var{txinfo}~\var{sp}]~++~ \fun{getData}~tx~utxo~sp~++~[\var{d}]), \var{eu}, \var{cm}) \mid \\
     & ~~~~(\var{sp}, \var{scriptHash}) \in \fun{scriptsNeeded}~{utxo}~{tx}, \\
     & ~~~~\var{scriptHash}\mapsto \var{script}\in \fun{txscripts}~(\fun{txwits}~tx), \\
     & ~~~~(\var{d}, \var{eu}) := \fun{indexedRdmrs}~tx~sp, \\
@@ -456,7 +460,7 @@ In this case, the states of the UTxO, fee
     \\
     ~
     \\
-    \fun{txvaltag}~\var{tx} = \fun{evalScripts}~\var{sLst} = \True
+    \fun{isValidating}~\var{tx} = \fun{evalScripts}~\var{sLst} = \True
     \\~\\
     {
       \begin{array}{r}
@@ -507,7 +511,7 @@ In this case, the states of the UTxO, fee
     \\
     ~
     \\
-    \fun{txvaltag}~\var{tx} = \fun{evalScripts}~\var{sLst} = \False
+    \fun{isValidating}~\var{tx} = \fun{evalScripts}~\var{sLst} = \False
     }
     {
     \begin{array}{l}
@@ -562,6 +566,9 @@ This rule has the following changes:
   size that the size of a $\Value$ in an output can be. Otherwise, this check is
   the same as in ShelleyMA.
 
+  \item The network ID field in the transaction body must match the
+  network ID constant 
+
  \item The execution unit budget for a transaction is within the maximum
   permitted number of units for a transaction;
 
@@ -595,8 +602,9 @@ UTXOS rule.
       \\
       \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, \fun{netId}~a = \NetworkId
       \\
-      \forall (a\mapsto\wcard) \in \txwdrls{txb}, \fun{netId}~a = \NetworkId
-      \\
+      \forall (a\mapsto\wcard) \in \txwdrls{txb}, \fun{netId}~a = \NetworkId \\
+      \hldiff{\fun{txnetworkid}~\var{txb}~=~\NetworkId}
+      \\~\\
       \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp} \\
       \hldiff{\fun{totExunits}~{tx} \leq \fun{maxTxExUnits}~{pp}}
       \\
@@ -802,7 +810,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \\~\\
       \var{adh}\leteq\fun{txADhash}~\var{txb}
       &
-      \var{ad}\leteq\fun{txAD}~\var{tx}
+      \var{ad}\leteq\fun{auxiliaryData}~\var{tx}
       \\
       (\var{adh}=\Nothing \land \var{ad}=\Nothing)
       \lor

--- a/alonzo/formal-spec/value-size.tex
+++ b/alonzo/formal-spec/value-size.tex
@@ -44,6 +44,6 @@ There is a change of constant value from the ShelleyMA era, specifically:
 Additionally, the new constants used in Alonzo have values :
 
 \begin{itemize}
-  \item $\mathsf{JustDataHashSize} = $ words
-  \item $\mathsf{NothingSize} = $ words
+  \item $\mathsf{JustDataHashSize} = 10$ words
+  \item $\mathsf{NothingSize} = 0$ words
 \end{itemize}


### PR DESCRIPTION
Some scratch notes about code which came up during review (PR with details about these to follow):

Word64 vs natural use
597 Params :   Maybe (LangDepView era)
PlutusScript Script_plc
Datum/redeemer aliases
newset = mapMaybeSet (getLanguageView pp) langs — needs type signature
Match txbody field names and order!
Validity interval
Auxiliary data - script and metadata type mismatch
ValidatedTx vs Tx in spec?
Bootstrap witnesses, key witnesses - these are sets
feesOK - check that there are redeemers instead of non-0 ExUnits
Replace Val.inject (Val.coin with function
Txins is JUST txins like in Shelley, does not also include fee inputs - use ones defined in alonzo Tx, not Shelley
System time conversion check is not implemented
indexof ∈ PolicyID → Value → Ix takes set of PolicyIDs instead
txInfo doesn’t take Language, and is called transTx
collectNNScriptInputs order wrong
collectTwoPhaseScriptInputs should have noData error
evalScripts should only be for non native scripts
Check also validateScript
collectNNScriptInputs vs collectTwoPhaseScriptInputs why are they both there and different?
TODO add spec constants - network ID , system time, and epoch info
Move network id body check to UTXO
Add outputsAttrsTooBig to spec?