### PR TITLE
Run ormolu in Github Actions instead

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,8 +6,3 @@ steps:
     command: "nix-build ./nix -A iohkNix.checkCabalProject -o check-cabal-project.sh && ./check-cabal-project.sh"
     agents:
       system: x86_64-linux
-
-  - label: 'ormolisation'
-    command: 'scripts/ormolise.sh'
-    agents:
-      system: x86_64-linux

--- a/.github/workflows/ormolu.yml
+++ b/.github/workflows/ormolu.yml
@@ -1,0 +1,29 @@
+name: Ormolu
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install ormolu
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        curl -sL https://github.com/tweag/ormolu/releases/download/0.1.4.1/ormolu-Linux -o "$HOME/.local/bin/ormolu"
+        chmod a+x "$HOME/.local/bin/ormolu"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Run ormolu
+      run: ./scripts/ormolise.sh

--- a/scripts/ormolise.sh
+++ b/scripts/ormolise.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#! nix-shell ../shell.nix -i bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Although this works, unfortunately the thing that's broken when `ormolu` doesn't work is `nix-shell`, so getting `ormolu` doesn't really solve the problem I was looking to solve, which is this sort of thing:

```
$ nix-shell
trace: Using IOHK default nixpkgs
error: Unknown index-state 2021-04-21T01:05:08Z, the latest index-state I know about is 2021-04-21T00:00:00Z. You may need to update to a newer hackage.nix.
(use '--show-trace' to show detailed location information)
```