### PR TITLE
move txbody network ID check to UTxO rule

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Alonzo.Tx
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo (ValidatedTx)
 import Cardano.Ledger.Alonzo.TxBody
   ( TxOut (..),
+    txnetworkid',
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody, TxOut)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq)
@@ -195,6 +196,10 @@ data UtxoPredicateFailure era
       -- ^ EXUnits supplied
   | -- | The inputs marked for use as fees contain non-ADA tokens
     FeeContainsNonADA !(Core.Value era)
+  | -- | Wrong Network ID in body
+    WrongNetworkInTxBody
+      !Network -- Actual Network ID
+      !Network -- Network ID in transaction body
   deriving (Generic)
 
 deriving stock instance
@@ -349,6 +354,9 @@ utxoTransition = do
     ?! WrongNetworkWithdrawal
       ni
       (Set.fromList wdrlsWrongNetwork)
+  case txnetworkid' txb of
+    SNothing -> pure ()
+    SJust bid -> ni == bid ?! WrongNetworkInTxBody ni bid
 
   -- pointwise is used because non-ada amounts must be >= 0 too
   let (Coin adaPerUTxOWord) = getField @"_adaPerUTxOWord" pp
@@ -501,6 +509,8 @@ encFail (ExUnitsTooBigUTxO a b) =
   Sum ExUnitsTooBigUTxO 15 !> To a !> To b
 encFail (FeeContainsNonADA a) =
   Sum FeeContainsNonADA 16 !> To a
+encFail (WrongNetworkInTxBody a b) =
+  Sum WrongNetworkInTxBody 17 !> To a !> To b
 
 decFail ::
   ( Era era,
@@ -527,6 +537,7 @@ decFail 13 = SumD FeeNotBalancedUTxO <! From <! From
 decFail 14 = SumD ScriptsNotPaidUTxO <! From
 decFail 15 = SumD ExUnitsTooBigUTxO <! From <! From
 decFail 16 = SumD FeeContainsNonADA <! From
+decFail 17 = SumD WrongNetworkInTxBody <! From <! From
 decFail n = Invalid n
 
 instance

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Alonzo.Tx
     minfee,
     txbody,
   )
-import qualified Cardano.Ledger.Alonzo.Tx as Alonzo (ValidatedTx)
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo (ValidatedTx, txins)
 import Cardano.Ledger.Alonzo.TxBody
   ( TxOut (..),
     txnetworkid',
@@ -91,7 +91,6 @@ import Shelley.Spec.Ledger.TxBody (unWdrl)
 import Shelley.Spec.Ledger.UTxO
   ( UTxO (..),
     balance,
-    txins,
     txouts,
     unUTxO,
   )
@@ -314,11 +313,11 @@ utxoTransition = do
   inInterval slot (getField @"vldt" txb)
     ?! OutsideValidityIntervalUTxO (getField @"vldt" txb) slot
 
-  not (Set.null (txins @era txb)) ?! InputSetEmptyUTxO
+  not (Set.null (Alonzo.txins @era txb)) ?! InputSetEmptyUTxO
 
   feesOK pp tx utxo -- Generalizes the fee to small from earlier Era's
-  eval (txins @era txb ⊆ dom utxo)
-    ?! BadInputsUTxO (eval (txins @era txb ➖ dom utxo))
+  eval (Alonzo.txins @era txb ⊆ dom utxo)
+    ?! BadInputsUTxO (eval (Alonzo.txins @era txb ➖ dom utxo))
 
   let consumed_ = consumed @era pp utxo txb
       produced_ = Shelley.produced @era pp stakepools txb

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.Hashes (EraIndependentData)
 import Cardano.Ledger.SafeHash (SafeHash)
 import Control.DeepSeq (NFData (..))
 import Control.Iterate.SetAlgebra (domain, eval, (⊆), (◁), (➖))
-import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
 import Data.Coders
 import qualified Data.Map.Strict as Map
@@ -47,12 +46,7 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import GHC.Records
 import NoThunks.Class
-import Shelley.Spec.Ledger.BaseTypes
-  ( Network,
-    ShelleyBase,
-    StrictMaybe (..),
-    networkId,
-  )
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..))
 import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
 import Shelley.Spec.Ledger.LedgerState (UTxOState (..), unWitHashes, witsFromTxWitnesses)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
@@ -86,10 +80,6 @@ data AlonzoPredFail era
   | -- | Scripts that failed
     Phase1ScriptWitnessNotValidating
       !(Set (Script era))
-  | -- | Wrong Network ID in body
-    WrongNetworkInTxBody
-      !Network -- Actual Network ID
-      !Network -- Network ID in transaction body
   deriving (Generic)
 
 deriving instance
@@ -139,7 +129,6 @@ encodePredFail (DataHashSetsDontAgree x y) = Sum DataHashSetsDontAgree 3 !> To x
 encodePredFail (PPViewHashesDontMatch x y) = Sum PPViewHashesDontMatch 4 !> To x !> To y
 encodePredFail (MissingRequiredSigners x) = Sum MissingRequiredSigners 5 !> To x
 encodePredFail (Phase1ScriptWitnessNotValidating x) = Sum Phase1ScriptWitnessNotValidating 6 !> To x
-encodePredFail (WrongNetworkInTxBody x y) = Sum WrongNetworkInTxBody 7 !> To x !> To y
 
 instance
   ( Era era,
@@ -169,7 +158,6 @@ decodePredFail 3 = SumD DataHashSetsDontAgree <! From <! From
 decodePredFail 4 = SumD PPViewHashesDontMatch <! From <! From
 decodePredFail 5 = SumD MissingRequiredSigners <! From
 decodePredFail 6 = SumD Phase1ScriptWitnessNotValidating <! From
-decodePredFail 7 = SumD WrongNetworkInTxBody <! From <! From
 decodePredFail n = Invalid n
 
 -- =============================================
@@ -192,8 +180,7 @@ type ShelleyStyleWitnessNeeds era =
 --   (in addition to ShelleyStyleWitnessNeeds)
 type AlonzoStyleAdditions era =
   ( HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))), -- BE SURE AND ADD THESE INSTANCES
-    HasField "wppHash" (Core.TxBody era) (StrictMaybe (WitnessPPDataHash (Crypto era))),
-    HasField "txnetworkid" (Core.TxBody era) (StrictMaybe Network)
+    HasField "wppHash" (Core.TxBody era) (StrictMaybe (WitnessPPDataHash (Crypto era)))
   )
 
 -- | A somewhat generic STS transitionRule function for the Alonzo Era.
@@ -276,12 +263,6 @@ alonzoStyleWitness = do
       computedPPhash = hashWitnessPPData pp (Set.fromList languages) (txrdmrs . wits' $ tx)
       bodyPPhash = getField @"wppHash" txbody
   bodyPPhash == computedPPhash ?! PPViewHashesDontMatch bodyPPhash computedPPhash
-
-  actualNetID <- liftSTS $ asks networkId
-  let bodyNetID = getField @"txnetworkid" txbody
-  case bodyNetID of
-    SNothing -> pure ()
-    SJust bid -> actualNetID == bid ?! WrongNetworkInTxBody actualNetID bid
 
   trans @(Core.EraRule "UTXO" era) $ TRC (ue, u', tx)
 


### PR DESCRIPTION
This is consistent with the other network ID checks now, and also with the spec.

I've also fix one small unrelated thing, namely using the correct `txins` in Alonzo (separate commit).