### PR TITLE
BBODY examples

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -11,7 +11,6 @@
 module Cardano.Ledger.Alonzo.PlutusScriptApi
   ( -- Figure 8
     getData,
-    collectNNScriptInputs,
     evalScripts,
     -- Figure 12
     scriptsNeeded,
@@ -48,7 +47,7 @@ import Cardano.Ledger.ShelleyMA.Timelocks (evalTimelock)
 import Data.Coders
 import Data.List (foldl')
 import qualified Data.Map as Map
-import Data.Maybe (isJust, maybeToList)
+import Data.Maybe (isJust)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -100,32 +99,6 @@ getData tx (UTxO m) sp = case sp of
             case Map.lookup hash (txdats' (getField @"wits" tx)) of
               Nothing -> []
               Just d -> [d]
-
--- | Collect the inputs (Data, execution budget, costModel) for all twoPhase scripts.
-collectNNScriptInputs ::
-  ( Era era,
-    Core.Script era ~ AlonzoScript.Script era,
-    Core.TxOut era ~ Alonzo.TxOut era,
-    Core.TxBody era ~ Alonzo.TxBody era,
-    Core.Value era ~ Mary.Value (Crypto era),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
-    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
-  ) =>
-  Core.PParams era ->
-  ValidatedTx era ->
-  UTxO era ->
-  [(AlonzoScript.Script era, [Data era], ExUnits, CostModel)]
-collectNNScriptInputs pp tx utxo =
-  let txinfo = transTx utxo tx
-   in [ (script, d : (valContext txinfo sp : getData tx utxo sp), eu, cost)
-        | (sp, scripthash) <- scriptsNeeded utxo tx, -- TODO, IN specification ORDER IS WRONG
-          (d, eu) <- maybeToList (indexedRdmrs tx sp),
-          script <- maybeToList (Map.lookup scripthash (txscripts' (getField @"wits" tx))),
-          cost <- maybeToList (Map.lookup PlutusV1 (getField @"_costmdls" pp))
-      ]
 
 -- ========================================================================
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -189,7 +189,8 @@ collectTwoPhaseScriptInputs pp tx utxo =
       case Map.lookup hash (txscripts' (getField @"wits" tx)) of
         Just script -> Right script
         Nothing -> Left (NoWitness hash)
-    apply cost (sp, d, eu) script = (script, d : (valContext txinfo sp) : (getData tx utxo sp), eu, cost)
+    apply cost (sp, d, eu) script =
+      (script, getData tx utxo sp ++ (d : [valContext txinfo sp]), eu, cost)
 
 -- | Merge two lists (either of which may have failures, i.e. (Left _)), collect all the failures
 --   but if there are none, use 'f' to construct a success.

--- a/alonzo/test/cardano-ledger-alonzo-test.cabal
+++ b/alonzo/test/cardano-ledger-alonzo-test.cabal
@@ -68,6 +68,7 @@ test-suite cardano-ledger-alonzo-test
     base16-bytestring,
     bytestring,
     cardano-binary,
+    cardano-crypto-class,
     cardano-ledger-alonzo,
     cardano-ledger-alonzo-test,
     cardano-ledger-shelley-ma,

--- a/alonzo/test/cardano-ledger-alonzo-test.cabal
+++ b/alonzo/test/cardano-ledger-alonzo-test.cabal
@@ -61,6 +61,7 @@ test-suite cardano-ledger-alonzo-test
   other-modules:
     Test.Cardano.Ledger.Alonzo.Golden
     Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
+    Test.Cardano.Ledger.Alonzo.Examples.Bbody
     Test.Cardano.Ledger.Alonzo.Examples.Utxow
     Test.Cardano.Ledger.Alonzo.Translation
     Test.Cardano.Ledger.Alonzo.Serialisation.CDDL

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Examples.Bbody
+  ( bbodyExamples,
+  )
+where
+
+import Cardano.Crypto.VRF (evalCertified)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
+import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY)
+import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx)
+import Cardano.Ledger.Alonzo.TxSeq (TxSeq (..), hashTxSeq)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Crypto (Crypto (..))
+import Control.State.Transition.Extended hiding (Assertion)
+import Control.State.Transition.Trace (checkTrace, (.-), (.->))
+import Data.Coerce (coerce)
+import Data.Default.Class (def)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as StrictSeq
+import Shelley.Spec.Ledger.API
+  ( BHBody (..),
+    BHeader (..),
+    Block (..),
+    DPState (..),
+    DState (..),
+    KESPeriod (..),
+    LedgerState (..),
+    Nonce (NeutralNonce),
+    OCert (..),
+    PrevHash (GenesisHash),
+    ProtVer (..),
+    UTxO (..),
+  )
+import Shelley.Spec.Ledger.BlockChain (bBodySize, mkSeed, seedEta, seedL)
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
+import Shelley.Spec.Ledger.Keys (KeyPair (..), KeyRole (..), coerceKeyRole, hashKey, signedDSIGN, signedKES)
+import Shelley.Spec.Ledger.LedgerState (UTxOState (..))
+import Shelley.Spec.Ledger.OCert (OCertSignable (..))
+import Shelley.Spec.Ledger.STS.Bbody (BbodyEnv (..), BbodyState (..))
+import Shelley.Spec.Ledger.Slot (BlockNo (..), SlotNo (..))
+import Shelley.Spec.Ledger.TxBody (TxIn (..))
+import Shelley.Spec.Ledger.UTxO (txid)
+import qualified Test.Cardano.Ledger.Alonzo.Examples.Utxow as UTXOW
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
+import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
+import Test.Shelley.Spec.Ledger.Utils
+  ( applySTSTest,
+    mkKESKeyPair,
+    mkKeyPair,
+    mkVRFKeyPair,
+    runShelleyBase,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+type A = AlonzoEra C_Crypto
+
+-- =======================
+-- Setup the initial state
+-- =======================
+
+pp :: PParams A
+pp =
+  def
+    { _costmdls = Map.singleton PlutusV1 (CostModel mempty),
+      _maxValSize = 1000000000,
+      _maxTxExUnits = ExUnits 1000000 1000000,
+      _maxBlockExUnits = ExUnits 1000000 1000000
+    }
+
+bbodyEnv :: BbodyEnv A
+bbodyEnv = BbodyEnv pp def
+
+-- =======
+--  Tests
+-- =======
+
+dpstate :: DPState C_Crypto
+dpstate = def {_dstate = def {_rewards = Map.singleton UTXOW.scriptStakeCredSuceed (Coin 1000)}}
+
+initialBBodyState :: BbodyState A
+initialBBodyState = BbodyState (LedgerState UTXOW.initialUtxoSt dpstate) (BlocksMade mempty)
+
+coldKeys :: KeyPair 'BlockIssuer C_Crypto
+coldKeys = KeyPair skCold vkCold
+  where
+    (vkCold, skCold) = mkKeyPair @C_Crypto (0, 0, 0, 0, 1)
+
+makeNaiveBlock :: [ValidatedTx A] -> Block A
+makeNaiveBlock txs = Block (BHeader bhb sig) txs'
+  where
+    bhb =
+      BHBody
+        { bheaderBlockNo = BlockNo 0,
+          bheaderSlotNo = SlotNo 0,
+          bheaderPrev = GenesisHash,
+          bheaderVk = vKey coldKeys,
+          bheaderVrfVk = vvrf,
+          bheaderEta = coerce $ evalCertified () nonceNonce svrf,
+          bheaderL = coerce $ evalCertified () leaderNonce svrf,
+          bsize = fromIntegral $ bBodySize txs',
+          bhash = hashTxSeq txs',
+          bheaderOCert =
+            OCert
+              vkes
+              0
+              (KESPeriod 0)
+              (signedDSIGN @C_Crypto (sKey coldKeys) (OCertSignable vkes 0 (KESPeriod 0))),
+          bprotver = ProtVer 5 0
+        }
+    sig = signedKES () 0 bhb skes
+    nonceNonce = mkSeed seedEta (SlotNo 0) NeutralNonce
+    leaderNonce = mkSeed seedL (SlotNo 0) NeutralNonce
+    txs' = TxSeq . StrictSeq.fromList $ txs
+    (svrf, vvrf) = mkVRFKeyPair @(VRF C_Crypto) (0, 0, 0, 0, 2)
+    (skes, vkes) = mkKESKeyPair @(KES C_Crypto) (0, 0, 0, 0, 3)
+
+testBlock :: Block A
+testBlock =
+  makeNaiveBlock
+    [ UTXOW.validatingTx,
+      UTXOW.notValidatingTx,
+      UTXOW.validatingTxWithWithdrawal,
+      UTXOW.notValidatingTxWithWithdrawal,
+      UTXOW.validatingTxWithCert,
+      UTXOW.notValidatingTxWithCert,
+      UTXOW.validatingTxWithMint,
+      UTXOW.notValidatingTxWithMint
+    ]
+
+example1UTxO :: UTxO A
+example1UTxO =
+  UTxO $
+    Map.fromList
+      [ (TxIn genesisId 9, UTXOW.alwaysFailsOutput),
+        (TxIn (txid @A UTXOW.validatingBody) 0, UTXOW.outEx1),
+        (TxIn (txid @A UTXOW.validatingBodyWithCert) 0, UTXOW.outEx3),
+        (TxIn (txid @A UTXOW.validatingBodyWithWithdrawal) 0, UTXOW.outEx5),
+        (TxIn (txid @A UTXOW.validatingBodyWithMint) 0, UTXOW.outEx7)
+      ]
+
+example1UtxoSt :: UTxOState A
+example1UtxoSt = UTxOState example1UTxO (Coin 0) (Coin 4020) def
+
+example1BBodyState :: BbodyState A
+example1BBodyState =
+  BbodyState (LedgerState example1UtxoSt def) (BlocksMade $ Map.singleton poolID 1)
+  where
+    poolID = hashKey . vKey . coerceKeyRole $ coldKeys
+
+testBBODY ::
+  BbodyState A ->
+  Block A ->
+  Either [[PredicateFailure (AlonzoBBODY A)]] (BbodyState A) ->
+  Assertion
+testBBODY initialSt block (Right expectedSt) =
+  checkTrace @(AlonzoBBODY A) runShelleyBase bbodyEnv $
+    pure initialSt .- block .-> expectedSt
+testBBODY initialSt block predicateFailure@(Left _) = do
+  let st = runShelleyBase $ applySTSTest @(AlonzoBBODY A) (TRC (bbodyEnv, initialSt, block))
+  st @?= predicateFailure
+
+bbodyExamples :: TestTree
+bbodyExamples =
+  testGroup
+    "bbody examples"
+    [ testCase "eight plutus scripts cases" $
+        testBBODY initialBBodyState testBlock (Right example1BBodyState)
+    ]

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Utxow.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Utxow.hs
@@ -733,7 +733,7 @@ collectTwoPhaseScriptInputsOutputOrdering =
   collectTwoPhaseScriptInputs pp validatingTx initUTxO
     @?= Right
       [ ( alwaysSucceeds 3,
-          [redeemerExample1, context, datumExample1],
+          [datumExample1, redeemerExample1, context],
           ExUnits 5000 5000,
           CostModel mempty
         )

--- a/alonzo/test/test/Tests.hs
+++ b/alonzo/test/test/Tests.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Test.Cardano.Ledger.Alonzo.Examples.Bbody (bbodyExamples)
 import Test.Cardano.Ledger.Alonzo.Examples.Utxow (plutusScriptExamples, utxowExamples)
 import Test.Cardano.Ledger.Alonzo.Golden as Golden
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
@@ -16,6 +17,7 @@ tests =
       CDDL.tests 5,
       Golden.goldenUTxOEntryMinAda,
       plutusScriptExamples,
+      bbodyExamples,
       utxowExamples
     ]
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -76,6 +76,10 @@ deriving stock instance
   TransLedgerState Show era =>
   Show (BbodyState era)
 
+deriving stock instance
+  TransLedgerState Eq era =>
+  Eq (BbodyState era)
+
 data BbodyEnv era = BbodyEnv
   { bbodyPp :: Core.PParams era,
     bbodyAccount :: AccountState


### PR DESCRIPTION
This PR makes an `BBODY` example by packing the 8 transactions from the `UTXOW` examples into a single block. This is the top-most rule changed in the Alonzo era.

This involved a bit of reorganizing the UTXOW examples.

Additionally, I changed the `collectTwoPhaseScriptInputs` function to supply Plutus data in this order: datum, redeemer, context. See https://github.com/input-output-hk/cardano-ledger-specs/pull/2248#discussion_r620097540.

I also removed the unused function `collectNNScriptInputs` which was previously replaced by `collectTwoPhaseScriptInputs`.