### PR TITLE
Added EraGen instance for Alonzo

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -26,7 +26,6 @@ import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx (..))
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, TxInBlock)
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Control.State.Transition
   ( Assertion (..),
     AssertionViolation (..),
@@ -118,7 +117,7 @@ instance
     Show (Core.AuxiliaryData era),
     Show (Core.PParams era),
     Show (Core.Value era),
-    Show (PParamsDelta era),
+    Show (Core.PParamsDelta era),
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     Era era,
     TxInBlock era ~ ValidatedTx era,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -35,7 +35,6 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value)
 import Cardano.Ledger.Rules.ValidationMode ((?!#))
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import qualified Cardano.Ledger.Val as Val
 import Control.Iterate.SetAlgebra (eval, (∪), (⋪), (◁))
 import Control.Monad.Except (MonadError (throwError))
@@ -76,8 +75,8 @@ instance
   ( Era era,
     Eq (Core.PParams era),
     Show (Core.PParams era),
-    Show (PParamsDelta era),
-    Eq (PParamsDelta era),
+    Show (Core.PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Embed (Core.EraRule "PPUP" era) (UTXOS era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -111,8 +110,8 @@ utxosTransition ::
     Embed (Core.EraRule "PPUP" era) (UTXOS era),
     Eq (Core.PParams era),
     Show (Core.PParams era),
-    Show (PParamsDelta era),
-    Eq (PParamsDelta era),
+    Show (Core.PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Core.TxOut era ~ Alonzo.TxOut era,
     Core.Value era ~ Value (Crypto era),
     Core.TxBody era ~ Alonzo.TxBody era,
@@ -140,8 +139,8 @@ scriptsValidateTransition ::
     Embed (Core.EraRule "PPUP" era) (UTXOS era),
     Eq (Core.PParams era),
     Show (Core.PParams era),
-    Show (PParamsDelta era),
-    Eq (PParamsDelta era),
+    Show (Core.PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Core.Script era ~ Script era,
     Core.TxBody era ~ Alonzo.TxBody era,
     Core.TxOut era ~ Alonzo.TxOut era,
@@ -193,8 +192,8 @@ scriptsNotValidateTransition ::
   ( Era era,
     Eq (Core.PParams era),
     Show (Core.PParams era),
-    Show (PParamsDelta era),
-    Eq (PParamsDelta era),
+    Show (Core.PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
@@ -301,8 +300,8 @@ constructValidated ::
     Era era,
     Eq (Core.PParams era),
     Show (Core.PParams era),
-    Show (PParamsDelta era),
-    Eq (PParamsDelta era),
+    Show (Core.PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     ToCBOR (Core.AuxiliaryData era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -19,7 +19,7 @@ import Cardano.Binary
   )
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Language (Language)
-import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..), PParamsUpdate)
+import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate, extendPP)
 import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits, Prices)
 import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx (..))
 import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
@@ -207,64 +207,15 @@ translateTxOut ::
 translateTxOut (Shelley.TxOutCompact addr value) =
   TxOutCompact addr value SNothing
 
+-- extendPP with type: extendPP :: Shelley.PParams' f era1 -> ... -> PParams' f era2
+-- Is general enough to work for both
+-- (PParams era)       = (PParams' Identity era)    and
+-- (PParamsUpdate era) = (PParams' StrictMaybe era)
+
 translatePParams ::
   AlonzoGenesis -> Shelley.PParams (MaryEra c) -> PParams (AlonzoEra c)
-translatePParams ctx pp =
-  PParams
-    { _minfeeA = API._minfeeA pp,
-      _minfeeB = API._minfeeB pp,
-      _maxBBSize = API._maxBBSize pp,
-      _maxTxSize = API._maxTxSize pp,
-      _maxBHSize = API._maxBHSize pp,
-      _keyDeposit = API._keyDeposit pp,
-      _poolDeposit = API._poolDeposit pp,
-      _eMax = API._eMax pp,
-      _nOpt = API._nOpt pp,
-      _a0 = API._a0 pp,
-      _rho = API._rho pp,
-      _tau = API._tau pp,
-      _d = API._d pp,
-      _extraEntropy = API._extraEntropy pp,
-      _protocolVersion = API._protocolVersion pp,
-      _minPoolCost = API._minPoolCost pp,
-      --added in Alonzo
-      _adaPerUTxOWord = adaPerUTxOWord ctx,
-      _costmdls = costmdls ctx,
-      _prices = prices ctx,
-      _maxTxExUnits = maxTxExUnits ctx,
-      _maxBlockExUnits = maxBlockExUnits ctx,
-      _maxValSize = maxValSize ctx,
-      _collateralPercentage = collateralPercentage ctx,
-      _maxCollateralInputs = maxCollateralInputs ctx
-    }
+translatePParams (AlonzoGenesis ada cost price mxTx mxBl mxV c mxC) pp = extendPP pp ada cost price mxTx mxBl mxV c mxC
 
 translatePParamsUpdate ::
   Shelley.PParamsUpdate (MaryEra c) -> PParamsUpdate (AlonzoEra c)
-translatePParamsUpdate pp =
-  PParams
-    { _minfeeA = API._minfeeA pp,
-      _minfeeB = API._minfeeB pp,
-      _maxBBSize = API._maxBBSize pp,
-      _maxTxSize = API._maxTxSize pp,
-      _maxBHSize = API._maxBHSize pp,
-      _keyDeposit = API._keyDeposit pp,
-      _poolDeposit = API._poolDeposit pp,
-      _eMax = API._eMax pp,
-      _nOpt = API._nOpt pp,
-      _a0 = API._a0 pp,
-      _rho = API._rho pp,
-      _tau = API._tau pp,
-      _d = API._d pp,
-      _extraEntropy = API._extraEntropy pp,
-      _protocolVersion = API._protocolVersion pp,
-      _minPoolCost = API._minPoolCost pp,
-      --added in Alonzo
-      _adaPerUTxOWord = SNothing,
-      _costmdls = SNothing,
-      _prices = SNothing,
-      _maxTxExUnits = SNothing,
-      _maxBlockExUnits = SNothing,
-      _maxValSize = SNothing,
-      _collateralPercentage = SNothing,
-      _maxCollateralInputs = SNothing
-    }
+translatePParamsUpdate pp = extendPP pp SNothing SNothing SNothing SNothing SNothing SNothing SNothing SNothing

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -121,7 +121,6 @@ import Cardano.Ledger.SafeHash
     SafeToHash,
     hashAnnotated,
   )
-import Cardano.Ledger.Shelley.Constraints
 import Cardano.Ledger.Val (Val (coin, (<+>), (<×>)))
 import Control.DeepSeq (NFData (..))
 import qualified Data.ByteString.Lazy as LBS (toStrict)
@@ -175,7 +174,7 @@ deriving instance
     Eq (Core.Script era),
     Eq (Core.TxBody era),
     Eq (Core.Value era),
-    Eq (PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Compactible (Core.Value era)
   ) =>
   Eq (ValidatedTxRaw era)
@@ -187,7 +186,7 @@ deriving instance
     Show (Core.Script era),
     Show (Core.TxBody era),
     Show (Core.Value era),
-    Show (PParamsDelta era)
+    Show (Core.PParamsDelta era)
   ) =>
   Show (ValidatedTxRaw era)
 
@@ -197,7 +196,7 @@ instance
     NoThunks (Core.Script era),
     NoThunks (Core.TxBody era),
     NoThunks (Core.Value era),
-    NoThunks (PParamsDelta era)
+    NoThunks (Core.PParamsDelta era)
   ) =>
   NoThunks (ValidatedTxRaw era)
 
@@ -210,7 +209,7 @@ deriving newtype instance
     Eq (Core.Script era),
     Eq (Core.TxBody era),
     Eq (Core.Value era),
-    Eq (PParamsDelta era),
+    Eq (Core.PParamsDelta era),
     Compactible (Core.Value era)
   ) =>
   Eq (ValidatedTx era)
@@ -222,7 +221,7 @@ deriving newtype instance
     Show (Core.Script era),
     Show (Core.TxBody era),
     Show (Core.Value era),
-    Show (PParamsDelta era)
+    Show (Core.PParamsDelta era)
   ) =>
   Show (ValidatedTx era)
 
@@ -232,7 +231,7 @@ deriving newtype instance
     NoThunks (Core.Script era),
     NoThunks (Core.TxBody era),
     NoThunks (Core.Value era),
-    NoThunks (PParamsDelta era)
+    NoThunks (Core.PParamsDelta era)
   ) =>
   NoThunks (ValidatedTx era)
 
@@ -325,8 +324,8 @@ instance HasField "wits" (ValidatedTx era) (TxWitness era) where
 -- =========================================================
 -- Figure 2: Definitions for Transactions
 
-getCoin :: UsesValue era => TxOut era -> Coin
-getCoin (TxOut _ v _) = coin v
+getCoin :: (Era era) => TxOut era -> Coin
+getCoin txout = coin (getField @"value" txout)
 
 -- ========================================================================
 -- A WitnessPPDataHash is the hash of two things. The first part comes from

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -68,6 +68,7 @@ import Cardano.Binary
 import Cardano.Ledger.Alonzo.Data (AuxiliaryDataHash (..), DataHash)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
@@ -100,7 +101,6 @@ import Cardano.Ledger.SafeHash
     SafeHash,
     SafeToHash,
   )
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), ppValidityInterval)
 import Cardano.Ledger.Val
   ( DecodeNonNegative,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -33,11 +34,17 @@ import Cardano.Binary
   )
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Alonzo.Scripts (Script)
-import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx, segwitTx)
+import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx, ppTx, segwitTx)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, ValidateScript)
 import Cardano.Ledger.Hashes (EraIndependentBlockBody)
+import Cardano.Ledger.Pretty
+  ( PDoc,
+    PrettyA (prettyA),
+    ppSexp,
+    ppStrictSeq,
+  )
 import Cardano.Ledger.SafeHash (SafeToHash, originalBytes)
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
@@ -66,6 +73,8 @@ import Shelley.Spec.Ledger.Serialization
   ( ToCBORGroup (..),
     encodeFoldableMapEncoder,
   )
+
+-- =================================================
 
 -- $TxSeq
 --
@@ -278,3 +287,27 @@ alignedValidFlags = alignedValidFlags' (-1)
       Seq.replicate (x - prev - 1) (IsValidating True)
         Seq.>< IsValidating False
         Seq.<| alignedValidFlags' x (n - (x - prev)) xs
+
+-- =======================================
+-- Pretty instances
+
+ppTxSeq ::
+  ( PrettyA (Core.Script era),
+    Era era,
+    PrettyA (Core.AuxiliaryData era),
+    PrettyA (Core.TxBody era)
+  ) =>
+  TxSeq era ->
+  PDoc
+ppTxSeq (TxSeq' xs _ _ _ _) =
+  ppSexp "Alonzo TxSeq" [ppStrictSeq ppTx xs]
+
+instance
+  ( PrettyA (Core.Script era),
+    Era era,
+    PrettyA (Core.AuxiliaryData era),
+    PrettyA (Core.TxBody era)
+  ) =>
+  PrettyA (TxSeq era)
+  where
+  prettyA = ppTxSeq

--- a/alonzo/test/cardano-ledger-alonzo-test.cabal
+++ b/alonzo/test/cardano-ledger-alonzo-test.cabal
@@ -38,15 +38,21 @@ library
 
   exposed-modules:
     Test.Cardano.Ledger.Alonzo.Serialisation.Generators
+    Test.Cardano.Ledger.Alonzo.AlonzoEraGen
   build-depends:
+    cardano-binary,
     cardano-ledger-alonzo,
     cardano-ledger-core,
     cardano-ledger-shelley-ma-test,
+    cardano-ledger-shelley-ma,
+    cardano-slotting,
     containers,
+    hashable,
     plutus-tx,
     QuickCheck,
     shelley-spec-ledger-test,
     shelley-spec-ledger,
+    strict-containers,
     text,
   hs-source-dirs:
     lib
@@ -59,6 +65,7 @@ test-suite cardano-ledger-alonzo-test
   hs-source-dirs:
     test
   other-modules:
+    Test.Cardano.Ledger.Alonzo.Trials
     Test.Cardano.Ledger.Alonzo.Golden
     Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
     Test.Cardano.Ledger.Alonzo.Examples.Bbody

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -138,10 +138,8 @@ genAlonzoTxBody _genenv pparams currentslot input txOuts certs wdrls fee updates
   validityInterval <- genValidityInterval currentslot
   return
     ( TxBody
-        -- non fee inputs
-        Set.empty -- TODO do something better here (use genenv ?)
-        -- inputs for fees
         input
+        Set.empty -- collaeral -- TODO do something better here (use genenv ?)
         txouts'
         certs
         wdrls
@@ -176,7 +174,7 @@ genAlonzoPParamsDelta constants pp = do
   price <- genM (Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000)))
   mxTx <- genM (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
   mxBl <- genM (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
-  mxV <- genM (genNatural 1 10000)
+  mxV <- genM (genNatural 4000 5000) -- Not too small
   let c = SJust 150
       mxC = SJust 10
   pure (Alonzo.extendPP shelleypp ada cost price mxTx mxBl mxV c mxC)
@@ -192,7 +190,7 @@ genAlonzoPParams constants = do
   price <- (Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000)))
   mxTx <- (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
   mxBl <- (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
-  mxV <- (genNatural 10000 50000) -- This can't be too small
+  mxV <- pure 10000 -- (genNatural 10000 50000) -- This can't be too small
   let c = 150
       mxC = 10
   pure (Alonzo.extendPP shelleypp ada cost price mxTx mxBl mxV c mxC)
@@ -205,8 +203,9 @@ instance Mock c => EraGen (AlonzoEra c) where
   genEraAuxiliaryData = genAux
   genGenesisValue = maryGenesisValue
   genEraTxBody = genAlonzoTxBody
-  updateEraTxBody txb coinx txin txout =
-    txb {inputs = txin, txfee = coinx, outputs = txout}
+  updateEraTxBody txb coinx txin txout = new
+    where
+      new = txb {inputs = txin, txfee = coinx, outputs = txout}
   genEraPParamsDelta = genAlonzoPParamsDelta
   genEraPParams = genAlonzoPParams
   genEraWitnesses setWitVKey mapScriptWit = TxWitness setWitVKey Set.empty mapScriptWit Map.empty (Redeemers Map.empty)

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -1,0 +1,236 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |  AlonzoEra instances for EraGen and ScriptClass
+module Test.Cardano.Ledger.Alonzo.AlonzoEraGen where
+
+import Cardano.Binary (serializeEncoding', toCBOR)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data as Alonzo (AuxiliaryData (..), Data (..))
+import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import qualified Cardano.Ledger.Alonzo.PParams as Alonzo (PParams, extendPP, retractPP)
+import Cardano.Ledger.Alonzo.Rules.Utxo (utxoEntrySize)
+import Cardano.Ledger.Alonzo.Scripts as Alonzo (CostModel (..), ExUnits (..), Prices (..), Script (..))
+import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx (..))
+import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..))
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxWitness (..))
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core (PParams, PParamsDelta, Script)
+import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Era (Crypto, Era (..))
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Mary.Value (policies)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary (pattern AuxiliaryData)
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
+import Cardano.Ledger.Tx (Tx (Tx))
+import Cardano.Ledger.Val ((<+>), (<×>))
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Monad (replicateM)
+import Data.Hashable (hash)
+import qualified Data.List as List
+import Data.Map as Map
+import Data.Proxy (Proxy (..))
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as Seq (fromList)
+import Data.Set as Set
+import GHC.Records (HasField (..))
+import qualified PlutusTx as Plutus
+import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe (..))
+import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (Witness))
+import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.TxBody (DCert, TxIn, Wdrl)
+import Test.Cardano.Ledger.AllegraEraGen (genValidityInterval)
+import Test.Cardano.Ledger.MaryEraGen (addTokens, genMint, maryGenesisValue, policyIndex)
+import Test.QuickCheck hiding ((><))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv, genNatural)
+import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen (..), MinGenTxout (..))
+import Test.Shelley.Spec.Ledger.Generator.ScriptClass (Quantifier (..), ScriptClass (..))
+import Test.Shelley.Spec.Ledger.Generator.Update (genM, genShelleyPParamsDelta)
+import qualified Test.Shelley.Spec.Ledger.Generator.Update as Shelley (genPParams)
+
+-- ================================================================
+
+genPair :: Gen a -> Gen b -> Gen (a, b)
+genPair x y = do a <- x; b <- y; pure (a, b)
+
+genPlutusData :: Gen Plutus.Data
+genPlutusData = resize 5 (sized gendata)
+  where
+    gendata n
+      | n > 0 =
+        oneof
+          [ (Plutus.I <$> arbitrary),
+            (Plutus.B <$> arbitrary),
+            (Plutus.Map <$> listOf (genPair (gendata (n `div` 2)) (gendata (n `div` 2)))),
+            (Plutus.Constr <$> arbitrary <*> listOf (gendata (n `div` 2))),
+            (Plutus.List <$> listOf (gendata (n `div` 2)))
+          ]
+    gendata _ = oneof [Plutus.I <$> arbitrary, Plutus.B <$> arbitrary]
+
+genSet :: Ord a => Gen a -> Gen (Set a)
+genSet gen =
+  frequency
+    [ (1, pure Set.empty),
+      (2, Set.fromList <$> sequence [gen]),
+      (1, Set.fromList <$> sequence [gen, gen])
+    ]
+
+genAux :: forall c. Mock c => Constants -> Gen (StrictMaybe (Alonzo.AuxiliaryData (AlonzoEra c)))
+genAux constants =
+  do
+    maybeAux <- genEraAuxiliaryData @(MaryEra c) constants
+    case maybeAux of
+      SNothing -> pure SNothing
+      SJust (Mary.AuxiliaryData x y) ->
+        SJust
+          <$> ( Alonzo.AuxiliaryData
+                  <$> pure x
+                  <*> pure (TimelockScript <$> y)
+                  <*> genSet (Alonzo.Data <$> genPlutusData)
+              )
+
+instance CC.Crypto c => ScriptClass (AlonzoEra c) where
+  -- basescript _ key = TimelockScript (basescript (Proxy @(MaryEra c)) key) -- The old style from Mary
+  basescript proxy key = TimelockScript (someLeaf proxy key)
+  isKey _ (TimelockScript x) = isKey (Proxy @(MaryEra c)) x
+  isKey _ (PlutusScript _) = Nothing
+  quantify _ (TimelockScript x) = fmap TimelockScript (quantify (Proxy @(MaryEra c)) x)
+  quantify _ x = Leaf x
+  unQuantify _ quant = TimelockScript $ unQuantify (Proxy @(MaryEra c)) (fmap unTime quant)
+
+unTime :: Alonzo.Script era -> Timelock (Crypto era)
+unTime (TimelockScript x) = x
+unTime (PlutusScript _) = error "Plutus in Timelock"
+
+genAlonzoTxBody ::
+  forall c.
+  Mock c =>
+  GenEnv (AlonzoEra c) ->
+  Core.PParams (AlonzoEra c) ->
+  SlotNo ->
+  Set.Set (TxIn c) ->
+  StrictSeq (TxOut (AlonzoEra c)) ->
+  StrictSeq (DCert c) ->
+  Wdrl c ->
+  Coin ->
+  StrictMaybe (Update (AlonzoEra c)) ->
+  StrictMaybe (AuxiliaryDataHash c) ->
+  Gen (TxBody (AlonzoEra c), [Core.Script (AlonzoEra c)])
+genAlonzoTxBody _genenv pparams currentslot input txOuts certs wdrls fee updates auxDHash = do
+  _low <- genM (genSlotAfter currentslot)
+  _high <- genM (genSlotAfter (currentslot + 50))
+  netid <- genM $ pure Testnet -- frequency [(2, pure Mainnet), (1, pure Testnet)]
+  minted <- genMint
+  let (minted2, txouts') = case addTokens (Proxy @(AlonzoEra c)) mempty pparams minted txOuts of
+        Nothing -> (mempty, txOuts)
+        Just os -> (minted, os)
+      scriptsFromPolicies = List.map (\p -> (Map.!) policyIndex p) (Set.toList $ policies minted)
+  validityInterval <- genValidityInterval currentslot
+  return
+    ( TxBody
+        -- non fee inputs
+        Set.empty -- TODO do something better here (use genenv ?)
+        -- inputs for fees
+        input
+        txouts'
+        certs
+        wdrls
+        fee
+        validityInterval -- (ValidityInterval SNothing SNothing) -- (ValidityInterval low high)
+        updates
+        -- reqSignerHashes
+        Set.empty -- TODO do something better here
+        minted2
+        -- wppHash
+        SNothing -- TODO do something better here
+        auxDHash
+        netid,
+      List.map TimelockScript scriptsFromPolicies
+    )
+
+genSlotAfter :: SlotNo -> Gen SlotNo
+genSlotAfter currentSlot = do
+  ttl <- genNatural 50 100
+  pure $ currentSlot + SlotNo (fromIntegral ttl)
+
+-- | Gen an Alonzo PParamsDelta, by adding to a Shelley PParamsData
+genAlonzoPParamsDelta ::
+  forall c.
+  Constants ->
+  Alonzo.PParams (AlonzoEra c) ->
+  Gen (Core.PParamsDelta (AlonzoEra c))
+genAlonzoPParamsDelta constants pp = do
+  shelleypp <- genShelleyPParamsDelta @(MaryEra c) constants (Alonzo.retractPP (Coin 100) pp)
+  ada <- genM (Coin <$> choose (1, 5))
+  cost <- genM (pure (Map.singleton PlutusV1 (CostModel Map.empty))) -- TODO what is a better assumption for this?
+  price <- genM (Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000)))
+  mxTx <- genM (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
+  mxBl <- genM (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
+  mxV <- genM (genNatural 1 10000)
+  let c = SJust 150
+      mxC = SJust 10
+  pure (Alonzo.extendPP shelleypp ada cost price mxTx mxBl mxV c mxC)
+
+genAlonzoPParams ::
+  forall c.
+  Constants ->
+  Gen (Core.PParams (AlonzoEra c))
+genAlonzoPParams constants = do
+  shelleypp <- Shelley.genPParams @(MaryEra c) constants -- This ensures that "_d" field is not 0.
+  ada <- (Coin <$> choose (1, 5))
+  cost <- pure (Map.singleton PlutusV1 (CostModel Map.empty)) -- There are no other Languages, and there must be something for PlutusV1
+  price <- (Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000)))
+  mxTx <- (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
+  mxBl <- (ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000)))
+  mxV <- (genNatural 10000 50000) -- This can't be too small
+  let c = 150
+      mxC = 10
+  pure (Alonzo.extendPP shelleypp ada cost price mxTx mxBl mxV c mxC)
+
+-- | Since Alonzo PParams don't have this field, we have to compute something here.
+instance HasField "_minUTxOValue" (Alonzo.PParams (AlonzoEra c)) Coin where
+  getField _ = Coin 4000
+
+instance Mock c => EraGen (AlonzoEra c) where
+  genEraAuxiliaryData = genAux
+  genGenesisValue = maryGenesisValue
+  genEraTxBody = genAlonzoTxBody
+  updateEraTxBody txb coinx txin txout =
+    txb {inputs = txin, txfee = coinx, outputs = txout}
+  genEraPParamsDelta = genAlonzoPParamsDelta
+  genEraPParams = genAlonzoPParams
+  genEraWitnesses setWitVKey mapScriptWit = TxWitness setWitVKey Set.empty mapScriptWit Map.empty (Redeemers Map.empty)
+  unsafeApplyTx (Tx bod wit auxdata) = ValidatedTx bod wit (IsValidating True) auxdata
+
+instance Mock c => MinGenTxout (AlonzoEra c) where
+  calcEraMinUTxO tout pp = (utxoEntrySize tout <×> getField @"_adaPerUTxOWord" pp)
+  addValToTxOut v (TxOut a u b) = TxOut a (v <+> u) b
+  genEraTxOut genVal addrs = do
+    values <- replicateM (length addrs) genVal
+    let pairs = zip addrs values
+        makeTxOut (addr, val) = TxOut addr val SNothing
+    pure (makeTxOut <$> pairs)
+
+someLeaf ::
+  forall era.
+  Era era =>
+  Proxy era ->
+  KeyHash 'Witness (Crypto era) ->
+  Timelock (Crypto era)
+someLeaf _proxy x =
+  let n = hash (serializeEncoding' (toCBOR x)) -- We don't really care about the hash, we only
+      slot = SlotNo (fromIntegral (mod n 200)) -- use it to pseudo-randomly pick a slot and mode
+      mode = mod n 3 -- mode==0 is a time leaf, mode=1 or 2 is a signature leaf
+   in case mode of
+        0 -> (RequireAnyOf . Seq.fromList) [RequireTimeStart slot, RequireTimeExpire slot]
+        _ -> RequireSignature x

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Translation.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Translation.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Era (TranslateEra (..))
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Shelley.Spec.Ledger.API as API
-import Test.Cardano.Ledger.Allegra ()
+import Test.Cardano.Ledger.AllegraEraGen ()
 import Test.Cardano.Ledger.EraBuffet
   ( MaryEra,
     StandardCrypto,

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+module Test.Cardano.Ledger.Alonzo.Trials where
+
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..), PParamsUpdate)
+import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY)
+import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUTXOW)
+import Cardano.Ledger.Alonzo.Scripts (Script (..), ppScript)
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Pretty (PDoc, PrettyA (prettyA))
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.Constraints (UsesTxBody, UsesTxOut)
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.State.Transition.Extended (Embed (..), IRC (..), STS (..))
+import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace, forAllTraceFromInitState)
+import Data.Default.Class (Default (def))
+import qualified Data.Map as Map
+import Data.Proxy (Proxy (..))
+import Shelley.Spec.Ledger.API (ApplyBlock)
+import Shelley.Spec.Ledger.API.Protocol (GetLedgerView)
+import Shelley.Spec.Ledger.API.Validation (ApplyBlock)
+import Shelley.Spec.Ledger.LedgerState (AccountState (..), DPState (..), DState, EpochState (..), LedgerState (..), NewEpochState (..), PState, UTxOState)
+import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainPredicateFailure (..), ChainState (..), initialShelleyState)
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER, LedgerEnv (..), LedgerPredicateFailure (UtxowFailure))
+import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
+import Test.Cardano.Ledger.Alonzo.Examples.Utxow (plutusScriptExamples, utxowExamples)
+import Test.Cardano.Ledger.Alonzo.Golden as Golden
+import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
+import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
+import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
+import Test.Cardano.Ledger.EraBuffet (TestCrypto)
+import Test.QuickCheck
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
+import Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), KeySpace (..), mkBlock)
+import Test.Shelley.Spec.Ledger.Generator.EraGen
+  ( EraGen (..),
+    genEraAuxiliaryData,
+    genEraPParamsDelta,
+    genEraTxBody,
+    genGenesisValue,
+    genUtxo0,
+    updateEraTxBody,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv, genesisDelegs0)
+import Test.Shelley.Spec.Ledger.Generator.ScriptClass (ScriptClass (..), baseScripts, keyPairs, mkScriptsFromKeyPair, someScripts)
+import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState, registerGenesisStaking)
+import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (genAccountState, mkGenesisLedgerState)
+import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
+import Test.Shelley.Spec.Ledger.PropertyTests
+  ( adaPreservationChain,
+    collisionFreeComplete,
+    delegProperties,
+    minimalPropertyTests,
+    onlyValidChainSignalsAreGenerated,
+    onlyValidLedgerSignalsAreGenerated,
+    poolProperties,
+    propCompactAddrRoundTrip,
+    propCompactSerializationAgree,
+    propDecompactAddrLazy,
+    propDecompactShelleyLazyAddr,
+    propertyTests,
+    relevantCasesAreCovered,
+    removedAfterPoolreap,
+  )
+import Test.Shelley.Spec.Ledger.Rules.TestChain
+  ( adaPreservationChain,
+    collisionFreeComplete,
+    delegProperties,
+    forAllChainTrace,
+    poolProperties,
+    removedAfterPoolreap,
+  )
+import Test.Shelley.Spec.Ledger.Utils
+  ( ChainProperty,
+    maxLLSupply,
+    mkHash,
+    testGlobals,
+  )
+import Test.Tasty
+
+kps = take 10 $ keyPairs @TestCrypto (geConstants ag)
+
+pretty :: PrettyA x => x -> PDoc
+pretty = prettyA
+
+ppS = ppScript
+
+ledgerEnv :: forall era. (Default (Core.PParams era)) => LedgerEnv era
+ledgerEnv = LedgerEnv (SlotNo 0) 0 def (AccountState (Coin 0) (Coin 0))
+
+baz = genTx ag ledgerEnv
+
+ap :: Proxy (AlonzoEra TestCrypto)
+ap = Proxy @(AlonzoEra TestCrypto)
+
+ag :: GenEnv (AlonzoEra TestCrypto)
+ag = genEnv ap
+
+genstuff ::
+  (EraGen era, Default (State (Core.EraRule "PPUP" era))) =>
+  proxy era ->
+  ( GenEnv era ->
+    ChainState era ->
+    NewEpochState era ->
+    EpochState era ->
+    LedgerState era ->
+    Core.PParams era ->
+    Shelley.Spec.Ledger.LedgerState.UTxOState era ->
+    DPState (Crypto era) ->
+    DState (Crypto era) ->
+    PState (Crypto era) ->
+    Gen b
+  ) ->
+  Gen b
+genstuff proxy f =
+  do
+    let genenv = (genEnv proxy)
+    either' <- mkGenesisChainState genenv (IRC ())
+    case either' of
+      Left _z -> error ("OOPS")
+      Right chainstate ->
+        let newepochstate = chainNes chainstate
+            epochstate = nesEs newepochstate
+            ledgerstate = esLState epochstate
+            pparams = esPp epochstate
+            utxostate = _utxoState ledgerstate
+            dpstate = _delegationState ledgerstate
+            dstate = _dstate dpstate
+            pstate = _pstate dpstate
+         in (f genenv chainstate newepochstate epochstate ledgerstate pparams utxostate dpstate dstate pstate)
+
+genAlonzoTx = genstuff ap (\genv _cs _nep _ep _ls _pp utxo dp _d _p -> genTx genv ledgerEnv (utxo, dp))
+
+genShelleyTx =
+  genstuff
+    (Proxy @(ShelleyEra TestCrypto))
+    (\genv _cs _nep _ep _ls _pp utxo dp _d _p -> genTx genv ledgerEnv (utxo, dp))
+
+genAlonzoBlock = genstuff ap (\genv cs _nep _ep _ls _pp _utxo _dp _d _p -> genBlock genv cs)
+
+genShelleyBlock = genstuff (Proxy @(ShelleyEra TestCrypto)) (\genv cs _nep _ep _ls _pp _utxo _dp _d _p -> genBlock genv cs)
+
+foo = do
+  either' <- mkGenesisChainState (genEnv ap) (IRC ())
+  case either' of
+    Left _z -> error ("OOPS")
+    Right chainstate ->
+      let newepochstate = chainNes chainstate
+          epochstate = nesEs newepochstate
+          ledgerstate = esLState epochstate
+          pparams = esPp epochstate
+          utxostate = _utxoState ledgerstate
+          dpstate = _delegationState ledgerstate
+          dstate = _dstate dpstate
+          pstate = _pstate dpstate
+       in pure chainstate
+
+chain = generate foo
+
+env@(GenEnv keys constants) = genEnv (Proxy @(AlonzoEra TestCrypto))
+
+-- in scripts n ranges over [0..149]
+scripts n = (\(x, y) -> (ppS x, ppS y)) ((ksMSigScripts keys) !! n)
+
+-- in payscript and stakescript n ranges over [0..29]
+payscript n = (\(x, (y, _z)) -> (show x, ppS y)) ((Map.toList (ksIndexedPayScripts keys)) !! n)
+
+stakescript n = (\(x, (y, _z)) -> (show x, ppS y)) ((Map.toList (ksIndexedStakeScripts keys)) !! n)
+
+test = defaultMain (minimalPropertyTests @AT)
+
+bar = do cs <- foo; genBlock ag cs
+
+acs = mkGenesisChainState ag
+
+als = mkGenesisLedgerState ag
+
+instance Embed (AlonzoBBODY (AlonzoEra TestCrypto)) (CHAIN (AlonzoEra TestCrypto)) where
+  wrapFailed = BbodyFailure
+
+instance Embed (AlonzoUTXOW (AlonzoEra TestCrypto)) (LEDGER (AlonzoEra TestCrypto)) where
+  wrapFailed = UtxowFailure
+
+-- ====================================================================================
+
+tests :: TestTree
+tests =
+  testGroup
+    "Alonzo tests"
+    [ Tripping.tests,
+      Translation.tests,
+      CDDL.tests 5,
+      Golden.goldenUTxOEntryMinAda,
+      plutusScriptExamples,
+      utxowExamples
+    ]
+
+{-
+alonzoProperty = testGroup
+    "Alonzo minimal property tests"
+    [ minimalPropertyTests @(AlonzoEra TestCrypto)
+    ]
+-}
+
+type AT = AlonzoEra TestCrypto
+
+type T = TestCrypto
+
+main :: IO ()
+main = defaultMain tests

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -31,6 +31,7 @@ import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace, forAllTrac
 import Data.Default.Class (Default (def))
 import qualified Data.Map as Map
 import Data.Proxy (Proxy (..))
+import GHC.Natural
 import Shelley.Spec.Ledger.API (ApplyBlock)
 import Shelley.Spec.Ledger.API.Protocol (GetLedgerView)
 import Shelley.Spec.Ledger.API.Validation (ApplyBlock)
@@ -46,6 +47,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.QuickCheck
+import Test.QuickCheck.Random (mkQCGen)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
@@ -96,6 +98,7 @@ import Test.Shelley.Spec.Ledger.Utils
     testGlobals,
   )
 import Test.Tasty
+import Test.Tasty.QuickCheck
 
 kps = take 10 $ keyPairs @TestCrypto (geConstants ag)
 
@@ -227,3 +230,21 @@ type T = TestCrypto
 
 main :: IO ()
 main = defaultMain tests
+
+cgen = mkQCGen 174256
+
+-- 174256 on 23 try
+-- 2 fails on 5 try
+-- 6 fails on 1st try
+
+go =
+  defaultMain
+    ( localOption
+        (QuickCheckReplay (Just 6))
+        (testProperty "ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))
+    )
+
+maxvalsize :: Natural
+maxvalsize = 10000
+
+testPropertyAdaPreservation = (testProperty "Property test preserves ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))

--- a/alonzo/test/test/Tests.hs
+++ b/alonzo/test/test/Tests.hs
@@ -1,12 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
 module Main where
 
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Test.Cardano.Ledger.Alonzo.Examples.Bbody (bbodyExamples)
 import Test.Cardano.Ledger.Alonzo.Examples.Utxow (plutusScriptExamples, utxowExamples)
 import Test.Cardano.Ledger.Alonzo.Golden as Golden
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
+import Test.Cardano.Ledger.EraBuffet (TestCrypto)
+import Test.QuickCheck
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Tasty
+
+-- ====================================================================================
 
 tests :: TestTree
 tests =

--- a/alonzo/test/test/Tests.hs
+++ b/alonzo/test/test/Tests.hs
@@ -19,10 +19,26 @@ import Test.Cardano.Ledger.Alonzo.Golden as Golden
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
+import Test.Cardano.Ledger.Alonzo.Trials (testPropertyAdaPreservation)
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.QuickCheck
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+{-
+import GHC.Records(HasField(..))
+import Test.Shelley.Spec.Ledger.PropertyTests
+  ( adaPreservationChain,
+    -- propertyTests,
+  )
+import Cardano.Ledger.Alonzo.PParams(PParams' (..))
+import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain
+import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
+import Test.Shelley.Spec.Ledger.Generator.Utxo
+-}
+
 import Test.Tasty
+import Test.Tasty.QuickCheck
 
 -- ====================================================================================
 
@@ -30,7 +46,9 @@ tests :: TestTree
 tests =
   testGroup
     "Alonzo tests"
-    [ Tripping.tests,
+    [ -- testProperty "Property test ada preserved" (adaPreservationChain @(AlonzoEra TestCrypto)),
+      testPropertyAdaPreservation,
+      Tripping.tests,
       Translation.tests,
       CDDL.tests 5,
       Golden.goldenUTxOEntryMinAda,

--- a/cardano-ledger-core/src/Cardano/Ledger/Era.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Era.hs
@@ -71,6 +71,8 @@ class
 -- Script Validation
 -----------------------------------------------------------------------------
 
+-- HasField "scriptWits" (ValidatedTx era) (Map.Map (ScriptHash c) script)
+
 -- | Typeclass for script data types. Allows for script validation and hashing.
 --   You must understand the role of SafeToHash and scriptPrefixTag to make new
 --   instances. 'scriptPrefixTag' is a magic number representing the tag of the
@@ -78,7 +80,10 @@ class
 --   and the tag is included in the script hash for a script. The safeToHash
 --   constraint ensures that Scripts are never reserialised.
 class
-  (Era era, SafeToHash (Core.Script era)) =>
+  ( Era era,
+    SafeToHash (Core.Script era),
+    HasField "body" (TxInBlock era) (Core.TxBody era)
+  ) =>
   ValidateScript era
   where
   scriptPrefixTag :: Core.Script era -> BS.ByteString
@@ -133,9 +138,10 @@ class SupportsSegWit era where
   hashTxSeq ::
     TxSeq era ->
     Hash.Hash (CryptoClass.HASH (Crypto era)) EraIndependentBlockBody
-
   -- | The number of segregated components
   numSegComponents :: Word64
+  -- | Use unsafeApplyTx only for Tests. The real applyTx is an STS rule
+  -- that performs phase 1 validation, as well as the injection into TxInBlock.
 
 --------------------------------------------------------------------------------
 -- Era translation

--- a/example-shelley/src/Cardano/Ledger/Example.hs
+++ b/example-shelley/src/Cardano/Ledger/Example.hs
@@ -22,6 +22,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Era (Crypto), SupportsSegWit (..), ValidateScript (..))
 import Cardano.Ledger.Hashes (EraIndependentAuxiliaryData)
+import Shelley.Spec.Ledger.PParams()
 import Cardano.Ledger.SafeHash (makeHashWithExplicitProxys)
 import Cardano.Ledger.Shelley.Constraints (UsesPParams (..), UsesTxOut (..), UsesValue, UsesTxBody)
 import Cardano.Ledger.Val (Val ((<->)))
@@ -119,6 +120,8 @@ type instance Core.AuxiliaryData (ExampleEra c) = Metadata (ExampleEra c)
 
 type instance Core.PParams (ExampleEra c) = SPP.PParams (ExampleEra c)
 
+type instance Core.PParamsDelta (ExampleEra c) = SPP.PParamsUpdate (ExampleEra c)
+
 type instance Core.Witnesses (ExampleEra c) = WitnessSet (ExampleEra c)
 
 --------------------------------------------------------------------------------
@@ -129,10 +132,6 @@ instance
   (CryptoClass.Crypto c) =>
   UsesPParams (ExampleEra c)
   where
-  type
-    PParamsDelta (ExampleEra c) =
-      SPP.PParamsUpdate (ExampleEra c)
-
   mergePPUpdates _ = SPP.updatePParams
 
 nativeMultiSigTag :: BS.ByteString

--- a/example-shelley/src/Cardano/Ledger/Example/Translation.hs
+++ b/example-shelley/src/Cardano/Ledger/Example/Translation.hs
@@ -33,6 +33,7 @@ import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import Shelley.Spec.Ledger.API
 import Shelley.Spec.Ledger.Tx (decodeWits)
+import Shelley.Spec.Ledger.PParams()
 
 --------------------------------------------------------------------------------
 -- Translation from Shelley to Example

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -44,7 +44,7 @@ import Cardano.Binary
   )
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Era
+import Cardano.Ledger.Era (Era (Crypto), TxInBlock)
 import Cardano.Ledger.Pretty
   ( PDoc,
     PrettyA (..),
@@ -92,10 +92,7 @@ import Shelley.Spec.Ledger.Serialization
   ( decodeStrictSeq,
     encodeFoldable,
   )
-import Shelley.Spec.Ledger.Tx
-  ( Tx (..),
-    WitVKey,
-  )
+import Shelley.Spec.Ledger.Tx (WitVKey)
 import Shelley.Spec.Ledger.TxBody
   ( witKeyHash,
   )
@@ -298,15 +295,13 @@ validateTimelock ::
   forall era.
   ( UsesTxBody era,
     HasField "vldt" (Core.TxBody era) ValidityInterval,
-    HasField "addrWits" (Core.Tx era) (Set (WitVKey 'Witness (Crypto era)))
+    HasField "addrWits" (TxInBlock era) (Set (WitVKey 'Witness (Crypto era)))
   ) =>
   Timelock (Crypto era) ->
-  Tx era ->
+  TxInBlock era ->
   Bool
 validateTimelock lock tx = evalFPS @era lock vhks (getField @"body" tx)
   where
-    -- THIS IS JUST A STUB. WHO KNOWS IF
-    -- IT COMPUTES THE RIGHT WITNESS SET.
     vhks = Set.map witKeyHash (getField @"addrWits" tx)
 
 showTimelock :: CC.Crypto crypto => Timelock crypto -> String

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -49,7 +49,7 @@ where
 import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (Script, Value)
+import Cardano.Ledger.Core (PParamsDelta, Script, Value)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
@@ -69,7 +69,7 @@ import Cardano.Ledger.Pretty
     ppWdrl,
   )
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash)
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta, TransValue)
+import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..), ppValidityInterval)
 import Cardano.Ledger.Val
   ( DecodeMint (..),

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -44,9 +44,9 @@ library
   exposed-modules:
     Test.Cardano.Ledger.TranslationTools
     Test.Cardano.Ledger.EraBuffet
-    Test.Cardano.Ledger.Mary
+    Test.Cardano.Ledger.MaryEraGen
     Test.Cardano.Ledger.Mary.Golden
-    Test.Cardano.Ledger.Allegra
+    Test.Cardano.Ledger.AllegraEraGen
     Test.Cardano.Ledger.ShelleyMA.TxBody
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Translation.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Translation.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Era (TranslateEra (..))
 import Cardano.Ledger.Mary.Translation ()
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Shelley.Spec.Ledger.API as S
-import Test.Cardano.Ledger.Allegra ()
+import Test.Cardano.Ledger.AllegraEraGen () -- import Allegra EraGen instance
 import Test.Cardano.Ledger.EraBuffet
   ( AllegraEra,
     MaryEra,

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto (..), ValidateScript (hashScript))
 import Cardano.Ledger.Mary.Value (AssetName (..), PolicyID (..), Value (..))
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
+import Cardano.Ledger.Core(PParamsDelta)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (pattern AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),

--- a/shelley-ma/shelley-ma-test/test/Tests.hs
+++ b/shelley-ma/shelley-ma-test/test/Tests.hs
@@ -4,11 +4,11 @@
 module Main where
 
 import Shelley.Spec.Ledger.PParams (PParams' (..))
-import Test.Cardano.Ledger.Allegra ()
+import Test.Cardano.Ledger.AllegraEraGen ()
 import Test.Cardano.Ledger.Allegra.ScriptTranslation (testScriptPostTranslation)
 import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)
 import Test.Cardano.Ledger.EraBuffet (AllegraEra, MaryEra, TestCrypto)
-import Test.Cardano.Ledger.Mary ()
+import Test.Cardano.Ledger.MaryEraGen ()
 import Test.Cardano.Ledger.Mary.Examples.MultiAssets (multiAssetsExample)
 import Test.Cardano.Ledger.Mary.Golden (goldenScaledMinDeposit)
 import Test.Cardano.Ledger.Mary.Translation (maryTranslationTests)

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -20,7 +20,7 @@ module Cardano.Ledger.Shelley
     Script,
     AuxiliaryData,
     PParams,
-    PParamsDelta,
+    Core.PParamsDelta,
     Tx,
     Witnesses,
     nativeMultiSigTag,
@@ -52,8 +52,7 @@ import qualified Shelley.Spec.Ledger.BlockChain as Shelley
     txSeqTxns,
   )
 import Shelley.Spec.Ledger.Metadata (Metadata (Metadata), validMetadatum)
-import Shelley.Spec.Ledger.PParams (PParamsUpdate, updatePParams)
-import qualified Shelley.Spec.Ledger.PParams as SPP (PParams)
+import Shelley.Spec.Ledger.PParams (PParams, PParamsUpdate, updatePParams)
 import Shelley.Spec.Ledger.Scripts (MultiSig)
 import Shelley.Spec.Ledger.Tx
   ( WitnessSet,
@@ -72,7 +71,6 @@ instance CryptoClass.Crypto c => UsesTxOut (ShelleyEra c) where
   makeTxOut _ a v = STx.TxOut a v
 
 instance CryptoClass.Crypto c => UsesPParams (ShelleyEra c) where
-  type PParamsDelta (ShelleyEra c) = PParamsUpdate (ShelleyEra c)
   mergePPUpdates _ = updatePParams
 
 --------------------------------------------------------------------------------
@@ -89,9 +87,11 @@ type instance Core.Script (ShelleyEra c) = MultiSig c
 
 type instance Core.AuxiliaryData (ShelleyEra c) = Metadata (ShelleyEra c)
 
-type instance Core.PParams (ShelleyEra c) = SPP.PParams (ShelleyEra c)
+type instance Core.PParams (ShelleyEra c) = PParams (ShelleyEra c)
 
 type instance Core.Witnesses (ShelleyEra c) = WitnessSet (ShelleyEra c)
+
+type instance Core.PParamsDelta (ShelleyEra c) = PParamsUpdate (ShelleyEra c)
 
 --------------------------------------------------------------------------------
 -- Ledger data instances
@@ -140,7 +140,5 @@ type Tx era = STx.Tx era
 type TxOut era = STx.TxOut era
 
 type TxBody era = STx.TxBody era
-
-type PParams era = SPP.PParams era
 
 type Witnesses era = WitnessSet (E.Crypto era)

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Core
     AuxiliaryData,
     ChainData,
     PParams,
+    PParamsDelta,
     Script,
     SerialisableData,
     TxBody,
@@ -25,7 +26,6 @@ import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.SafeHash (HashAnnotated)
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
-import Control.DeepSeq (NFData)
 import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy)
 import GHC.Records (HasField)
@@ -89,14 +89,11 @@ class
     Show (PParams era),
     SerialisableData (PParams era),
     ChainData (PParamsDelta era),
-    NFData (PParamsDelta era),
     Ord (PParamsDelta era),
     SerialisableData (PParamsDelta era)
   ) =>
   UsesPParams era
   where
-  type PParamsDelta era :: Type
-
   mergePPUpdates ::
     proxy era ->
     PParams era ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -32,7 +32,7 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Shelley.Spec.Ledger.API.Protocol (PraosCrypto)
 import Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase)
-import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.BlockChain (BHeader, Block)
 import Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import Shelley.Spec.Ledger.PParams (PParams' (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -113,14 +113,12 @@ import Cardano.Ledger.Coin
     toDeltaCoin,
   )
 import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.SafeHash (HashAnnotated, extractHash, hashAnnotated)
-import Cardano.Ledger.Shelley.Constraints
-  ( TransValue,
-    UsesPParams (PParamsDelta),
-  )
+import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq (NFData)
@@ -754,13 +752,16 @@ genesisState genDelegs0 utxo0 =
 -- | Convenience Function to bound the txsize function.
 -- | It can be helpful for coin selection.
 txsizeBound ::
-  forall era out.
+  forall era out tx.
   ( HasField "outputs" (Core.TxBody era) (StrictSeq out),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "body" tx (Core.TxBody era),
+    HasField "txsize" tx Integer
   ) =>
-  Tx era ->
+  Proxy era ->
+  tx ->
   Integer
-txsizeBound tx = numInputs * inputSize + numOutputs * outputSize + rest
+txsizeBound Proxy tx = numInputs * inputSize + numOutputs * outputSize + rest
   where
     uint = 5
     smallArray = 1

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -39,8 +39,8 @@ import Cardano.Binary
     encodeWord,
   )
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (PParamsDelta)
 import Cardano.Ledger.Era
-import Cardano.Ledger.Shelley.Constraints (UsesPParams (PParamsDelta))
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.!=), (.:), (.:?), (.=))
@@ -83,6 +83,8 @@ import Shelley.Spec.Ledger.Serialization
     ratioToCBOR,
   )
 import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
+
+-- ====================================================================
 
 -- | Higher Kinded Data
 type family HKD f a where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -25,7 +25,6 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto), SupportsSegWit (fromTxSeq, hashTxSeq))
 import qualified Cardano.Ledger.Era as Era
 import Cardano.Ledger.Hashes (EraIndependentBlockBody)
-import Cardano.Ledger.SafeHash (SafeToHash)
 import Cardano.Ledger.Shelley.Constraints (UsesAuxiliary, UsesTxBody)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
@@ -64,7 +63,6 @@ import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
 import Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv (..))
 import Shelley.Spec.Ledger.Serialization (ToCBORGroup)
 import Shelley.Spec.Ledger.Slot (epochInfoEpoch, epochInfoFirst)
-import Shelley.Spec.Ledger.Tx (WitnessSet)
 import Shelley.Spec.Ledger.TxBody (EraIndependentTxBody)
 
 data BBODY era
@@ -122,9 +120,7 @@ instance
     Environment (Core.EraRule "LEDGERS" era) ~ LedgersEnv era,
     State (Core.EraRule "LEDGERS" era) ~ LedgerState era,
     Signal (Core.EraRule "LEDGERS" era) ~ Seq (Era.TxInBlock era),
-    HasField "_d" (Core.PParams era) UnitInterval,
-    Core.Witnesses era ~ WitnessSet era,
-    SafeToHash (WitnessSet era)
+    HasField "_d" (Core.PParams era) UnitInterval
   ) =>
   STS (BBODY era)
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -103,10 +103,7 @@ import Shelley.Spec.Ledger.LedgerState
     updateNES,
     _genDelegs,
   )
-import Shelley.Spec.Ledger.PParams
-  ( PParams,
-    ProtVer (..),
-  )
+import Shelley.Spec.Ledger.PParams (ProtVer (..))
 import Shelley.Spec.Ledger.STS.Bbody (BBODY, BbodyEnv (..), BbodyPredicateFailure, BbodyState (..))
 import Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL,
@@ -187,15 +184,14 @@ instance
 
 -- | Creates a valid initial chain state
 initialShelleyState ::
-  ( Default (State (Core.EraRule "PPUP" era)),
-    Core.PParams era ~ PParams era
+  ( Default (State (Core.EraRule "PPUP" era))
   ) =>
   WithOrigin (LastAppliedBlock (Crypto era)) ->
   EpochNo ->
   UTxO era ->
   Coin ->
   Map (KeyHash 'Genesis (Crypto era)) (GenDelegPair (Crypto era)) ->
-  PParams era ->
+  Core.PParams era ->
   Nonce ->
   ChainState era
 initialShelleyState lab e utxo reserves genDelegs pp initNonce =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -19,9 +19,9 @@ module Shelley.Spec.Ledger.STS.Newpp
 where
 
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Control.State.Transition
   ( STS (..),
     TRC (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -25,9 +25,9 @@ import Cardano.Binary
     decodeWord,
     encodeListLen,
   )
+import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, (⊆), (⨃))
 import Control.State.Transition

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
@@ -21,7 +21,7 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley.Constraints
   ( ShelleyBased,
     UsesAuxiliary,
-    UsesPParams (PParamsDelta, mergePPUpdates),
+    UsesPParams (mergePPUpdates),
     UsesScript,
     UsesTxBody,
     UsesValue,
@@ -82,7 +82,7 @@ instance
     HasField "_maxBHSize" (Core.PParams era) Natural,
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    HasField "_protocolVersion" (PParamsDelta era) (StrictMaybe ProtVer)
+    HasField "_protocolVersion" (Core.PParamsDelta era) (StrictMaybe ProtVer)
   ) =>
   STS (UPEC era)
   where
@@ -134,7 +134,7 @@ votedValue (ProposedPPUpdates pup) pps quorumN =
       votes =
         Map.foldr
           (\vote tally -> Map.insert vote (incrTally vote tally) tally)
-          (Map.empty :: Map (PParamsDelta era) Int)
+          (Map.empty :: Map (Core.PParamsDelta era) Int)
           pup
       consensus = Map.filter (>= quorumN) votes
    in case length consensus of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -158,6 +158,8 @@ instance
   (Era era, Core.AnnotatedData (Core.Script era)) =>
   Semigroup (WitnessSetHKD Identity era)
   where
+  (WitnessSet' a b c _) <> y | Set.null a && Map.null b && Set.null c = y
+  y <> (WitnessSet' a b c _) | Set.null a && Map.null b && Set.null c = y
   (WitnessSet a b c) <> (WitnessSet a' b' c') =
     WitnessSet (a <> a') (b <> b') (c <> c')
 
@@ -220,6 +222,12 @@ instance
   getField = addrWits' . getField @"wits"
 
 instance
+  (c ~ Crypto era, Core.Witnesses era ~ WitnessSet era) =>
+  HasField "addrWits" (WitnessSet era) (Set (WitVKey 'Witness c))
+  where
+  getField = addrWits'
+
+instance
   ( c ~ Crypto era,
     script ~ Core.Script era,
     Core.Witnesses era ~ WitnessSet era
@@ -227,6 +235,15 @@ instance
   HasField "scriptWits" (Tx era) (Map (ScriptHash c) script)
   where
   getField = scriptWits' . getField @"wits"
+
+instance
+  ( c ~ Crypto era,
+    script ~ Core.Script era,
+    Core.Witnesses era ~ WitnessSet era
+  ) =>
+  HasField "scriptWits" (WitnessSet era) (Map (ScriptHash c) script)
+  where
+  getField = scriptWits'
 
 instance
   (c ~ Crypto era, Core.Witnesses era ~ WitnessSet era) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -101,7 +101,7 @@ import Cardano.Ledger.SafeHash
     SafeHash,
     SafeToHash,
   )
-import Cardano.Ledger.Shelley.Constraints (PParamsDelta, TransValue)
+import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.Val (DecodeNonNegative (..))
 import Cardano.Prelude
   ( HeapWords (..),
@@ -693,12 +693,12 @@ deriving instance TransTxBody NoThunks era => NoThunks (TxBodyRaw era)
 
 type TransTxBody (c :: Type -> Constraint) era =
   ( c (Core.TxOut era),
-    c (PParamsDelta era),
+    c (Core.PParamsDelta era),
     HashAnnotated (Core.TxBody era) EraIndependentTxBody (Crypto era)
   )
 
 deriving instance
-  (CC.Crypto (Crypto era), NFData (PParamsDelta era)) =>
+  (CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
   NFData (TxBodyRaw era)
 
 deriving instance (Era era, TransTxBody Eq era) => Eq (TxBodyRaw era)
@@ -708,8 +708,8 @@ deriving instance (Era era, TransTxBody Show era) => Show (TxBodyRaw era)
 instance
   ( FromCBOR (Core.TxOut era),
     Era era,
-    FromCBOR (PParamsDelta era),
-    ToCBOR (PParamsDelta era)
+    FromCBOR (Core.PParamsDelta era),
+    ToCBOR (Core.PParamsDelta era)
   ) =>
   FromCBOR (TxBodyRaw era)
   where
@@ -723,7 +723,7 @@ instance
       )
 
 instance
-  (TransTxBody FromCBOR era, ToCBOR (PParamsDelta era), Era era) =>
+  (TransTxBody FromCBOR era, ToCBOR (Core.PParamsDelta era), Era era) =>
   FromCBOR (Annotator (TxBodyRaw era))
   where
   fromCBOR = pure <$> fromCBOR
@@ -753,8 +753,8 @@ isSNothing _ = False
 boxBody ::
   ( Era era,
     FromCBOR (Core.TxOut era),
-    FromCBOR (PParamsDelta era),
-    ToCBOR (PParamsDelta era)
+    FromCBOR (Core.PParamsDelta era),
+    ToCBOR (Core.PParamsDelta era)
   ) =>
   Word ->
   Field (TxBodyRaw era)
@@ -772,7 +772,7 @@ boxBody n = field (\_ t -> t) (Invalid n)
 --   serialisation. boxBody and txSparse should be Duals, visually inspect
 --   The key order looks strange but was choosen for backward compatibility.
 txSparse ::
-  (TransTxBody ToCBOR era, FromCBOR (PParamsDelta era), Era era) =>
+  (TransTxBody ToCBOR era, FromCBOR (Core.PParamsDelta era), Era era) =>
   TxBodyRaw era ->
   Encode ('Closed 'Sparse) (TxBodyRaw era)
 txSparse (TxBodyRaw input output cert wdrl fee ttl update hash) =
@@ -803,7 +803,7 @@ baseTxBodyRaw =
 
 instance
   ( Era era,
-    FromCBOR (PParamsDelta era),
+    FromCBOR (Core.PParamsDelta era),
     TransTxBody ToCBOR era
   ) =>
   ToCBOR (TxBodyRaw era)
@@ -821,7 +821,7 @@ deriving newtype instance
   (TransTxBody NoThunks era, Typeable era) => NoThunks (TxBody era)
 
 deriving newtype instance
-  (CC.Crypto (Crypto era), NFData (PParamsDelta era)) =>
+  (CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
   NFData (TxBody era)
 
 deriving instance (Era era, TransTxBody Show era) => Show (TxBody era)
@@ -833,14 +833,14 @@ deriving via
   instance
     ( Era era,
       FromCBOR (Core.TxOut era),
-      FromCBOR (PParamsDelta era),
-      ToCBOR (PParamsDelta era)
+      FromCBOR (Core.PParamsDelta era),
+      ToCBOR (Core.PParamsDelta era)
     ) =>
     FromCBOR (Annotator (TxBody era))
 
 -- | Pattern for use by external users
 pattern TxBody ::
-  (Era era, FromCBOR (PParamsDelta era), TransTxBody ToCBOR era) =>
+  (Era era, FromCBOR (Core.PParamsDelta era), TransTxBody ToCBOR era) =>
   Set (TxIn (Crypto era)) ->
   StrictSeq (Core.TxOut era) ->
   StrictSeq (DCert (Crypto era)) ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/BenchValidation.hs
@@ -65,11 +65,13 @@ import Shelley.Spec.Ledger.STS.Prtcl (PrtclState (..))
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
 import Shelley.Spec.Ledger.TxBody (TransTxBody, TransTxId)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
-import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv, PreAlonzo)
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
-import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest, testGlobals)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest, testGlobals) -- Use Another constraint, so this works in all Eras
+import Test.Shelley.Spec.Ledger.Generator.EraGen(MinLEDGER_STS)
+
 
 data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block era)
 
@@ -82,13 +84,12 @@ instance NFData (ValidateInput era) where
 validateInput ::
   ( EraGen era,
     ShelleyTest era,
-    PreAlonzo era,
     Mock (Crypto era),
     Core.EraRule "LEDGERS" era ~ API.LEDGERS era,
     QC.HasTrace (API.LEDGERS era) (GenEnv era),
     API.ApplyBlock era,
     API.GetLedgerView era,
-    ShelleyLedgerSTS era
+    MinLEDGER_STS era
   ) =>
   Int ->
   IO (ValidateInput era)
@@ -97,13 +98,12 @@ validateInput utxoSize = genValidateInput utxoSize
 genValidateInput ::
   ( EraGen era,
     ShelleyTest era,
-    PreAlonzo era,
     Mock (Crypto era),
     Core.EraRule "LEDGERS" era ~ API.LEDGERS era,
     QC.HasTrace (API.LEDGERS era) (GenEnv era),
     API.ApplyBlock era,
     API.GetLedgerView era,
-    ShelleyLedgerSTS era
+    MinLEDGER_STS era
   ) =>
   Int ->
   IO (ValidateInput era)
@@ -185,8 +185,7 @@ genUpdateInputs ::
   ( EraGen era,
     Mock (Crypto era),
     ShelleyTest era,
-    PreAlonzo era,
-    ShelleyLedgerSTS era,
+    MinLEDGER_STS era,
     API.GetLedgerView era,
     Core.EraRule "LEDGERS" era ~ API.LEDGERS era,
     QC.HasTrace (API.LEDGERS era) (GenEnv era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/bench/Shelley/Spec/Ledger/Bench/Gen.hs
@@ -47,14 +47,15 @@ import Test.Shelley.Spec.Ledger.Generator.Constants
         minGenesisUTxOouts
       ),
   )
-import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..),PreAlonzo)
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
 import Test.Shelley.Spec.Ledger.Generator.EraGen (EraGen)
 import Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (CERTS)
 import Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import Test.Shelley.Spec.Ledger.Serialisation.Generators ()
-import Test.Shelley.Spec.Ledger.Utils (ShelleyLedgerSTS, ShelleyTest)
+import Test.Shelley.Spec.Ledger.Utils (ShelleyTest)  -- Use Another constraint, so this works in all Eras
+import Test.Shelley.Spec.Ledger.Generator.EraGen(MinLEDGER_STS)
 
 -- ===============================================================
 
@@ -85,9 +86,9 @@ genChainState n ge =
 -- | Benchmark generating a block given a chain state.
 genBlock ::
   ( Mock (Crypto era),
-    PreAlonzo era,
     ShelleyTest era,
-    ShelleyLedgerSTS era,
+    EraGen era,
+    MinLEDGER_STS era,
     GetLedgerView era,
     Core.EraRule "LEDGERS" era ~ LEDGERS era,
     QC.HasTrace (LEDGERS era) (GenEnv era),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -7,55 +7,206 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Shelley.Spec.Ledger.Generator.EraGen (genUtxo0, genesisId, EraGen (..)) where
+-- | Infrastructure for generating STS Traces over any Era
+module Test.Shelley.Spec.Ledger.Generator.EraGen
+ ( genUtxo0,
+   genesisId,
+   EraGen (..),
+   MinLEDGER_STS,
+   MinCHAIN_STS,
+   MinUTXO_STS,
+   MinGenTxBody,
+   MinGenTxout(..),
+   Label(..),
+   Sets(..),
+ ) where
 
-import Cardano.Binary (ToCBOR (toCBOR))
+import Cardano.Binary (ToCBOR (toCBOR),FromCBOR,Annotator)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (HASH)
-import Cardano.Ledger.Era (Crypto, ValidateScript (..))
+import Cardano.Ledger.Era (Crypto, ValidateScript (..),TxInBlock)
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
-import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesTxOut)
+import Cardano.Ledger.Shelley.Constraints (UsesPParams(..))
+import Shelley.Spec.Ledger.PParams(Update)
 import Cardano.Slotting.Slot (SlotNo)
 import Data.Coerce (coerce)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
+import Data.Default.Class(Default)
 import Shelley.Spec.Ledger.API
   ( Addr (Addr),
     Credential (ScriptHashObj),
     StakeReference (StakeRefBase),
+    Block(..),
   )
 import Shelley.Spec.Ledger.Address (toAddr)
-import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe)
-import Shelley.Spec.Ledger.PParams (PParams, Update)
+import Shelley.Spec.Ledger.BaseTypes (Network (..), StrictMaybe,ShelleyBase)
 import Shelley.Spec.Ledger.Tx (TxId (TxId))
-import Shelley.Spec.Ledger.TxBody (DCert, TxIn, Wdrl)
+import Shelley.Spec.Ledger.TxBody (DCert, TxIn, Wdrl, WitVKey)
 import Shelley.Spec.Ledger.UTxO (UTxO)
+import Shelley.Spec.Ledger.Keys(KeyRole(Witness))
 import Test.QuickCheck (Gen)
 import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import Test.Shelley.Spec.Ledger.Generator.Core
   ( GenEnv (..),
-    genTxOut,
     genesisCoins,
   )
 import Test.Shelley.Spec.Ledger.Generator.Presets (someKeyPairs)
 import Test.Shelley.Spec.Ledger.Generator.ScriptClass (ScriptClass, someScripts)
 import Test.Shelley.Spec.Ledger.Utils (Split (..))
+import Data.Sequence (Seq)
+import Shelley.Spec.Ledger.API
+  ( DPState,
+    LedgerEnv,
+    LedgerState,
+    LedgersEnv,
+  )
+import Shelley.Spec.Ledger.LedgerState (UTxOState (..))
+import Shelley.Spec.Ledger.STS.Chain(CHAIN,ChainState)
+import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
+import Control.State.Transition.Extended(STS(..))
+
+import GHC.Records(HasField(..))
+import Shelley.Spec.Ledger.BaseTypes(UnitInterval)
+import Shelley.Spec.Ledger.PParams(ProtVer)
+import Shelley.Spec.Ledger.Slot (EpochNo)
+import Shelley.Spec.Ledger.Scripts (ScriptHash)
+import Cardano.Ledger.Era (Era)
+import GHC.Natural(Natural)
+import Cardano.Ledger.AuxiliaryData(ValidateAuxiliaryData(..))
+import NoThunks.Class(NoThunks)
+import Data.Map(Map)
+
 
 {------------------------------------------------------------------------------
- An EraGen instance makes it possible to run the Shelley property tests
+ An EraGen instance makes it possible to run the Shelley property tests. The idea
+ is to generate (not fully) random Transactions, i.e. with enough coherency to be
+ a real transaction, but which are strung together into Traces. In each step of the trace
+ one of these (not fully) random transactions is applied. The idea is that some property should
+ hold on any trace. Because we want these tests to work in any Era there are two things
+ to consider:
+ 1) A Transaction generator needs to be parametric over all Eras.
+ 2) Since the Internals of the STS rules differ from Era to Era, the STS instances
+    must also adapt to many Eras.
+
+ To account for the "not fully" random nature of tranactions we use the type GenEnv which
+ holds enough information to build "not fully" random transactions that are still coherent.
+
+ For Transactions, we account for these differences by using the type families found in
+ Cardano.Ledger.Core and other modules, and by a set of Era specific generators encoded
+ in the EraGen class. Generally there is some "method" in the class for each type family.
+
+ For traces we use the "class HasTrace (CHAIN era) (GenEnv era)"
+
+ The following constraints encode the minimal properties needed to build a chain for
+ any Era. It should be an invariant that these properties hold for all Eras (Shelley, Allegra, Mary, Alonzo ...)
+ If we introduce a new Era, where they do not hold, we must adjust these things, so they do.
+ 1) Add a new type family
+ 2) Add new methods to EraGen
+ 3) Change the minimal constraints, so that they now hold for all Eras
+ 4) Change the generators to use the new methods.
+
  -----------------------------------------------------------------------------}
 
+-- | Minimal requirements on the LEDGER and LEDGERS instances
+type MinLEDGER_STS era =
+  ( Environment (Core.EraRule "LEDGERS" era) ~ LedgersEnv era,
+    BaseM (Core.EraRule "LEDGER" era) ~ ShelleyBase,
+    Signal (Core.EraRule "LEDGER" era) ~ TxInBlock era,
+    State (Core.EraRule "LEDGER" era) ~ (UTxOState era, DPState (Crypto era)),
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    BaseM (Core.EraRule "LEDGERS" era) ~ ShelleyBase,
+    State (Core.EraRule "LEDGERS" era) ~ LedgerState era,
+    Signal (Core.EraRule "LEDGERS" era) ~ Seq (TxInBlock era),
+    STS (Core.EraRule "LEDGER" era)
+  )
+
+-- | Minimal requirements on the CHAIN instances
+type MinCHAIN_STS era =
+  ( STS (CHAIN era),
+    BaseM (CHAIN era) ~ ShelleyBase,
+    Environment (CHAIN era) ~ (),
+    State (CHAIN era) ~ ChainState era,
+    Signal (CHAIN era) ~ Block era
+  )
+
+-- | Minimal requirements on the UTxO instances
+type MinUTXO_STS era =
+  ( STS (Core.EraRule "UTXOW" era),
+    BaseM (Core.EraRule "UTXOW" era) ~ ShelleyBase,
+    State (Core.EraRule "UTXOW" era) ~ UTxOState era,
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
+    Signal (Core.EraRule "UTXOW" era) ~ TxInBlock era,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era,
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    Signal (Core.EraRule "UTXO" era) ~ TxInBlock era
+  )
+
+-- | Minimal requirements on Core.PParams to generate random stuff
+type MinGenPParams era =
+  ( UsesPParams era,
+    Default (Core.PParams era),
+    HasField "_minPoolCost" (Core.PParams era) Coin,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_eMax" (Core.PParams era) EpochNo,
+    HasField "_d" (Core.PParams era) UnitInterval,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_minUTxOValue" (Core.PParams era) Coin,
+    HasField "_minfeeB" (Core.PParams era) Natural
+  )
+
+type MinGenWitnesses era =
+  ( ToCBOR (Core.Witnesses era),
+    Eq (Core.Witnesses era),
+    Monoid (Core.Witnesses era)
+  )
+
+type MinGenAuxData era =
+  ( ValidateAuxiliaryData era (Crypto era),
+    ToCBOR (Core.AuxiliaryData era), -- Needs to be serialized
+    Eq (Core.AuxiliaryData era),
+    Show (Core.AuxiliaryData era),
+    FromCBOR(Annotator (Core.AuxiliaryData era)) -- arises because some pattern Constructors deserialize
+  )
+
+type MinGenTxBody era =
+  ( Eq (Core.TxBody era),
+    ToCBOR (Core.TxBody era),
+    NoThunks (Core.TxBody era),
+    Show (Core.TxBody era),
+    FromCBOR(Annotator (Core.TxBody era)) -- arises because some pattern Constructors deserialize
+  )
+
+class MinGenTxout era where
+  calcEraMinUTxO :: Core.TxOut era -> Core.PParams era -> Coin
+  addValToTxOut :: Core.Value era -> Core.TxOut era -> Core.TxOut era
+  genEraTxOut :: Gen (Core.Value era) -> [Addr (Crypto era)] -> Gen [Core.TxOut era]
+
+-- ======================================================================================
+-- The EraGen class. Generally one method for each type family in Cardano.Ledger.Core
+-- ======================================================================================
+
 class
-  ( UsesScript era,
-    ValidateScript era,
+  ( Era era,
     Split (Core.Value era),
     ScriptClass era,
-    Show (Core.Script era)
+    MinGenPParams era,
+    MinGenWitnesses era,
+    MinGenAuxData era,
+    MinGenTxBody era,
+    MinGenTxout era
   ) =>
   EraGen era
   where
@@ -67,7 +218,7 @@ class
   -- additional script witnessing.
   genEraTxBody ::
     GenEnv era ->
-    PParams era ->
+    Core.PParams era ->
     SlotNo ->
     Set (TxIn (Crypto era)) ->
     StrictSeq (Core.TxOut era) ->
@@ -89,20 +240,32 @@ class
     StrictSeq (Core.TxOut era) ->
     Core.TxBody era
 
+  genEraPParamsDelta :: Constants -> Core.PParams era -> Gen (Core.PParamsDelta era)
+
+  genEraPParams :: Constants -> Gen (Core.PParams era)
+   -- Its is VERY IMPORTANT that the decentralisation parameter "_d" be non-zero and less than 1.
+   -- The system will deadlock if d==0 and there are no registered stake pools.
+   -- use Test.Shelley.Spec.Ledger.Generator.Update(genDecentralisationParam) in your instance.
+
+  genEraWitnesses ::
+     (Set (WitVKey 'Witness (Crypto era))) ->
+     Map (ScriptHash (Crypto era)) (Core.Script era) ->
+     Core.Witnesses era
+
+  unsafeApplyTx :: Core.Tx era -> TxInBlock era
+
+
+
 {------------------------------------------------------------------------------
   Generators shared across eras
  -----------------------------------------------------------------------------}
 
-genUtxo0 ::
-  forall era.
-  (EraGen era, UsesTxOut era) =>
-  GenEnv era ->
-  Gen (UTxO era)
+genUtxo0 :: forall era. EraGen era => GenEnv era -> Gen (UTxO era)
 genUtxo0 ge@(GenEnv _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
   genesisKeys <- someKeyPairs c minGenesisUTxOouts maxGenesisUTxOouts
   genesisScripts <- someScripts @era c minGenesisUTxOouts maxGenesisUTxOouts
   outs <-
-    (genTxOut @era)
+    (genEraTxOut @era)
       (genGenesisValue @era ge)
       (fmap (toAddr Testnet) genesisKeys ++ fmap (scriptsToAddr' Testnet) genesisScripts)
   return (genesisCoins genesisId outs)
@@ -122,3 +285,14 @@ genesisId = TxId (unsafeMakeSafeHash (mkDummyHash 0))
   where
     mkDummyHash :: forall h a. Hash.HashAlgorithm h => Int -> Hash.Hash h a
     mkDummyHash = coerce . Hash.hashWithSerialiser @h toCBOR
+
+
+-- =========================================================
+
+
+data Label t where
+  Body' :: Label (Core.TxBody era)
+  Wits' :: Label (Core.Witnesses era)
+
+class Sets (x :: Label t) y where
+  set :: Label t -> y -> y

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -189,7 +189,7 @@ type MinGenTxBody era =
     FromCBOR(Annotator (Core.TxBody era)) -- arises because some pattern Constructors deserialize
   )
 
-class MinGenTxout era where
+class Show (Core.TxOut era) => MinGenTxout era where
   calcEraMinUTxO :: Core.TxOut era -> Core.PParams era -> Coin
   addValToTxOut :: Core.Value era -> Core.TxOut era -> Core.TxOut era
   genEraTxOut :: Gen (Core.Value era) -> [Addr (Crypto era)] -> Gen [Core.TxOut era]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/ScriptClass.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 module Test.Shelley.Spec.Ledger.Generator.ScriptClass
   ( ScriptClass (..),
@@ -33,6 +34,7 @@ module Test.Shelley.Spec.Ledger.Generator.ScriptClass
     mkScriptCombinations,
     combinedScripts,
     someScripts,
+    baseScripts,
     scriptKeyCombinations,
     scriptKeyCombination,
   )
@@ -59,6 +61,7 @@ import Test.Shelley.Spec.Ledger.Generator.Constants
   ( Constants (..),
   )
 import Test.Shelley.Spec.Ledger.Utils (mkKeyPair)
+import Cardano.Ledger.Shelley.Constraints (UsesScript)
 
 {------------------------------------------------------------------------------
   ScriptClass defines the operations that enable an Era's scripts to
@@ -66,10 +69,9 @@ import Test.Shelley.Spec.Ledger.Utils (mkKeyPair)
 ------------------------------------------------------------------------------}
 
 class
-  ( Eq (Script era),
+  ( UsesScript era,
     ValidateScript era,
-    CC.Crypto (Crypto era),
-    Era era
+    CC.Crypto (Crypto era)
   ) =>
   ScriptClass era
   where
@@ -84,6 +86,7 @@ class
  -----------------------------------------------------------------------------}
 
 data Quantifier t = AllOf [t] | AnyOf [t] | MOf Int [t] | Leaf t
+  deriving Functor
 
 anyOf :: forall era. ScriptClass era => Proxy era -> [Script era] -> Script era
 anyOf prox xs = unQuantify prox $ AnyOf xs
@@ -93,6 +96,8 @@ allOf prox xs = unQuantify prox $ AllOf xs
 
 mOf :: forall era. ScriptClass era => Proxy era -> Int -> [Script era] -> Script era
 mOf prox m xs = unQuantify prox $ MOf m xs
+
+
 
 {------------------------------------------------------------------------------
   Compute lists of keyHashes

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -71,7 +71,7 @@ import Test.Shelley.Spec.Ledger.Utils
     runShelleyBase,
   )
 import Cardano.Ledger.Era(SupportsSegWit(TxInBlock))
-
+import Debug.Trace
 -- ======================================================
 
 genAccountState :: Constants -> Gen AccountState
@@ -179,7 +179,7 @@ instance
                     (TRC (ledgerEnv, (u, dp), tx))
           pure $ case res of
             Left pf ->
-              error ("LEDGERS sigGen: " <> show pf)
+              trace ("\nPF = "++show pf) (error ("LEDGER sigGen: " <> show pf))
             Right (u', dp') ->
               (u', dp', tx : txs)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}  -- TODO FIX ME
+
 module Test.Shelley.Spec.Ledger.Generator.Utxo
   ( genTx,
     Delta (..),
@@ -366,7 +368,8 @@ genNextDelta
         draftSize =
           sum
             [ 5 :: Integer, -- safety net in case the coin or a list prefix rolls over into a larger encoding
-              12 :: Integer, -- TODO the size calculation somehow needs extra buffer when minting tokens
+              --12 :: Integer, -- TODO the size calculation somehow needs extra buffer when minting tokens
+              20 :: Integer, -- TODO the size calculation somehow needs extra buffer when minting tokens  THIS IS NEW FIX ME
               encodedLen (max dfees (Coin 0)) - 1,
               foldr (\a b -> b + encodedLen a) 0 extraInputs,
               encodedLen change,
@@ -374,6 +377,7 @@ genNextDelta
             ]
 
         deltaFee = draftSize <×> Coin (fromIntegral (getField @"_minfeeA" pparams))
+                   <+> Coin (fromIntegral (getField @"_minfeeB" pparams))  -- TODO THIS IS NEW FIX ME
         totalFee = baseTxFee <+> deltaFee :: Coin
         remainingFee = totalFee <-> dfees :: Coin
         changeAmount = getChangeAmount change
@@ -488,7 +492,7 @@ applyDelta
     --fix up the witnesses here?
     -- Adds extraInputs, extraWitnesses, and change from delta to tx
     let txBody = getField @"body" tx
-        outputs' = getField @"outputs" txBody StrictSeq.|> change
+        outputs' = (getField @"outputs" txBody) StrictSeq.|> change
         body2 =
           (updateEraTxBody @era)
             txBody

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/EmptyBlock.hs
@@ -11,7 +11,6 @@ module Test.Shelley.Spec.Ledger.Examples.EmptyBlock
 where
 
 import Cardano.Ledger.Era (Crypto (..))
-import Cardano.Ledger.Shelley.Constraints (UsesTxBody)
 import qualified Data.Map.Strict as Map
 import GHC.Stack (HasCallStack)
 import Shelley.Spec.Ledger.BaseTypes (Nonce)
@@ -53,9 +52,8 @@ initStEx1 = initSt (UTxO Map.empty)
 blockEx1 ::
   forall era.
   ( HasCallStack,
-    PreAlonzo era,
-    ExMock (Crypto era),
-    UsesTxBody era
+    ShelleyTest era,
+    ExMock (Crypto era)
   ) =>
   Block era
 blockEx1 =
@@ -76,8 +74,8 @@ blockNonce ::
   forall era.
   ( HasCallStack,
     PreAlonzo era,
-    ExMock (Crypto era),
-    UsesTxBody era
+    ShelleyTest era,
+    ExMock (Crypto era)
   ) =>
   Nonce
 blockNonce = getBlockNonce (blockEx1 @era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -9,6 +9,12 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+
+{- | Currently this uses the trace mechansim to check that computing rewards has
+a required set of properties. It works only in the Shelley Era. It could be
+generalized, and then moved to the Generator/Trace/ directory which computes
+property tests in all eras.
+-}
 module Test.Shelley.Spec.Ledger.Rewards (rewardTests, C, defaultMain, newEpochProp) where
 
 import Cardano.Binary (toCBOR)
@@ -142,6 +148,7 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain(forAllChainTrace)
 import Control.State.Transition.Trace(SourceSignalTarget (..), sourceSignalTargets)
 import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import Cardano.Ledger.Pretty(PrettyA(..))
+
 
 -- ========================================================================
 -- Bounds and Constants --
@@ -728,6 +735,7 @@ lastElem :: [a] -> Maybe a
 lastElem [a] = Just a
 lastElem [] = Nothing
 lastElem (_ : xs) = lastElem xs
+
 
 -- | Provide a legitimate NewEpochState to make an test Property
 newEpochProp :: Word64 -> (NewEpochState C -> Property) -> Property


### PR DESCRIPTION
Aded an EraGen instance for Alonzo in the Tests:   Test.Cardano.Ledger.Alonzo.EraGenInstance

I had to generalize the EraGen class slightly to make an Alonzo instance adding the method genEraPParamsDelta
because the type family PParamsDelta  is different in Alonzo than in earlier Eras.
I had to export a few functions in a few files where they were no exported before, because they were needed in the Alonzo instance.  Made few other small changes to a number of files.