### PR TITLE
Implement `applyTxInBlock` for Alonzo

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -46,7 +46,7 @@ import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks)
 import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), strictMaybeToMaybe)
-import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.LedgerState()
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
@@ -251,3 +251,25 @@ instance
   Embed (PPUP era) (UTXOS era)
   where
   wrapFailed = UpdateFailure
+
+
+-- =================================================================
+
+{-
+constructValidated :: UtxoEnv era -> UTxOState era -> Core.Tx era -> ValidatedTx era
+constructValidated env st tx = case collectTwoPhaseScriptInputs pp tx utxo of
+  Left errs -> error (show errs)
+  Right sLst ->
+    let scriptEvalResult = evalScripts @era tx sLst
+        newState =
+          runTransitionRule (TRC (env, st, tx)) $
+            if scriptEvalResult
+              then scriptsValidateTransition
+              else scriptsNotValidateTransition
+     in ValidatedTx
+          (getField @"body" tx)
+          (getField @"wits" tx)
+          (IsValidating scriptEvalResult)
+          (getField @"auxiliaryData" tx)
+
+-}

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary.Value (Value)
+import Cardano.Ledger.Rules.ValidationMode ((?!#))
 import Cardano.Ledger.Shelley.Constraints (PParamsDelta)
 import qualified Cardano.Ledger.Val as Val
 import Control.Iterate.SetAlgebra (eval, (∪), (⋪), (◁))
@@ -165,7 +166,7 @@ scriptsValidateTransition = do
         )
           Val.<-> refunded
   getField @"isValidating" tx == IsValidating True
-    ?! ValidationTagMismatch (getField @"isValidating" tx)
+    ?!# ValidationTagMismatch (getField @"isValidating" tx)
   pup' <-
     trans @(Core.EraRule "PPUP" era) $
       TRC
@@ -188,7 +189,7 @@ scriptsNotValidateTransition = do
   TRC (_, us@(UTxOState utxo _ fees _), tx) <- judgmentContext
   let txb = txbody tx
   getField @"isValidating" tx == IsValidating False
-    ?! ValidationTagMismatch (getField @"isValidating" tx)
+    ?!# ValidationTagMismatch (getField @"isValidating" tx)
   pure $
     us
       { _utxo = eval (getField @"txinputs_fee" txb ⋪ utxo),

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -55,7 +55,7 @@ import Shelley.Spec.Ledger.BaseTypes
     StrictMaybe (..),
     strictMaybeToMaybe,
   )
-import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.LedgerState (PPUPState (..), UTxOState (..), keyRefunds)
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.STS.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
@@ -313,7 +313,7 @@ constructValidated globals env@(UtxoEnv _ pp _ _) st tx =
                 then scriptsValidateTransition
                 else scriptsNotValidateTransition
        in case errs of
-            [] -> pure (vTx, newState)
+            [] -> pure (newState, vTx)
             _ -> throwError errs
   where
     runTransitionRule :: RuleInterpreter

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, SupportsSegWit (..), ValidateScript (..))
 import Cardano.Ledger.Hashes (EraIndependentData)
+import Cardano.Ledger.Rules.ValidationMode ((?!#))
 import Cardano.Ledger.SafeHash (SafeHash)
 import Control.DeepSeq (NFData (..))
 import Control.Iterate.SetAlgebra (domain, eval, (⊆), (◁), (➖))
@@ -220,7 +221,7 @@ alonzoStyleWitness = do
               then bad
               else (hashScript @era script) : bad
           accum (PlutusScript _) bad = bad
-  null failedScripts ?! (Phase1ScriptWitnessNotValidating $ Set.fromList failedScripts)
+  null failedScripts ?!# Phase1ScriptWitnessNotValidating (Set.fromList failedScripts)
 
   let utxo = _utxo u'
       sphs :: [(ScriptPurpose (Crypto era), ScriptHash (Crypto era))]
@@ -251,7 +252,7 @@ alonzoStyleWitness = do
   let reqSignerHashes' = getField @"reqSignerHashes" txbody
       witsKeyHashes = unWitHashes $ witsFromTxWitnesses @era tx
   eval (reqSignerHashes' ⊆ witsKeyHashes)
-    ?! MissingRequiredSigners (eval $ reqSignerHashes' ➖ witsKeyHashes)
+    ?!# MissingRequiredSigners (eval $ reqSignerHashes' ➖ witsKeyHashes)
 
   let languages =
         [ l

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -532,13 +532,15 @@ getMapFromValue (Value _ m) = m
 
 -- | Find the Data and ExUnits assigned to a script.
 indexedRdmrs ::
-  forall era.
+  forall era tx.
   ( Era era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wits" tx (TxWitness era), -- Generalized over tx, so tx can be Tx or TxInBlock
+    HasField "body" tx (Core.TxBody era)
   ) =>
-  ValidatedTx era ->
+  tx ->
   ScriptPurpose (Crypto era) ->
   Maybe (Data era, ExUnits)
 indexedRdmrs tx sp = case rdptr @era (getField @"body" tx) sp of

--- a/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/cardano-ledger-core/cardano-ledger-core.cabal
@@ -47,6 +47,7 @@ library
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
     Cardano.Ledger.Hashes
+    Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.SafeHash
     Cardano.Ledger.Tx
     Cardano.Ledger.Val

--- a/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Describes modes under which we might validate certain rules in the ledger.
+--
+--   What does this mean? Sometimes, we will want to check only certain
+--   conditions specified in the rules. For example, when replaying a previously
+--   validated chain, we do not care about rerunning _any_ checks, only making
+--   the relevant changes to the ledger state.
+module Cardano.Ledger.Rules.ValidationMode
+  ( -- $static
+    lblStatic,
+    (?!#),
+    (?!#:),
+    failBecauseS,
+    applySTSNonStatic,
+  )
+where
+
+import Control.State.Transition.Extended
+import Data.Functor ((<&>))
+
+applySTSValidateSuchThat ::
+  forall s m rtype.
+  (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
+  ([Label] -> Bool) ->
+  RuleContext rtype s ->
+  m (Either [[PredicateFailure s]] (State s))
+applySTSValidateSuchThat cond ctx =
+  applySTSOpts opts ctx <&> \case
+    (st, []) -> Right st
+    (_, pfs) -> Left pfs
+  where
+    opts =
+      ApplySTSOpts
+        { asoAssertions = AssertionsOff,
+          asoValidation = ValidateSuchThat cond
+        }
+
+--------------------------------------------------------------------------------
+-- Static checks
+--------------------------------------------------------------------------------
+
+-- * Static checks
+
+--
+
+-- $static
+--
+-- Static checks are used to indicate that a particular predicate depends only
+-- on the signal to the transition, rather than the state or environment. This
+-- is particularly relevant where the signal is something such as a transaction,
+-- which is fixed, whereas the state and environment depend upon the chain tip
+-- upon which we are trying to build a block.
+
+-- | Indicates that this check depends only upon the signal to the transition,
+-- not the state or environment.
+lblStatic :: Label
+lblStatic = "static"
+
+-- | Construct a static predicate check.
+--
+--   The choice of '#' as a postfix here is made because often these are crypto
+--   checks.
+(?!#) :: Bool -> PredicateFailure sts -> Rule sts ctx ()
+(?!#) = labeledPred [lblStatic]
+
+infix 1 ?!#
+
+-- | Construct a static predicate check with an explanation.
+--
+--   The choice of '#' as a postfix here is made because often these are crypto
+--   checks.
+(?!#:) :: Either e () -> (e -> PredicateFailure sts) -> Rule sts ctx ()
+(?!#:) = labeledPredE [lblStatic]
+
+infix 1 ?!#:
+
+-- | Fail, if static checks are enabled.
+failBecauseS :: PredicateFailure sts -> Rule sts ctx ()
+failBecauseS = (False ?!#)
+
+-- | Apply an STS system and do not validate any static checks.
+applySTSNonStatic ::
+  forall s m rtype.
+  (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
+  RuleContext rtype s ->
+  m (Either [[PredicateFailure s]] (State s))
+applySTSNonStatic = applySTSValidateSuchThat (notElem lblStatic)

--- a/semantics/executable-spec/src/Control/State/Transition/Extended.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Extended.hs
@@ -51,9 +51,14 @@ module Control.State.Transition.Extended
     applySTSIndifferently,
     reapplySTS,
 
+    -- * Exported to allow running rules independently
+    applySTSInternal,
+    applyRuleInternal,
+    RuleInterpreter,
+    STSInterpreter,
+
     -- * Random thing
     Threshold (..),
-
     sfor_,
   )
 where
@@ -502,20 +507,21 @@ newtype Threshold a = Threshold a
 -- Utils
 ------------------------------------------------------------------------------}
 
-
 -- | A stub rule with no transitions to use as a placeholder
 data STUB (e :: Type) (st :: Type) (si :: Type) (f :: Type) (m :: Type -> Type)
 
 instance
-  ( Eq f
-  , Monad m
-  , Show f
-  , Typeable e
-  , Typeable f
-  , Typeable si
-  , Typeable st
-  , Typeable m
-  ) => STS (STUB e st si f m) where
+  ( Eq f,
+    Monad m,
+    Show f,
+    Typeable e,
+    Typeable f,
+    Typeable si,
+    Typeable st,
+    Typeable m
+  ) =>
+  STS (STUB e st si f m)
+  where
   type Environment (STUB e st si f m) = e
   type State (STUB e st si f m) = st
   type Signal (STUB e st si f m) = si
@@ -524,7 +530,6 @@ instance
 
   transitionRules = []
   initialRules = []
-
 
 -- | Map each element of a structure to an action, evaluate these actions from
 -- left to right, and ignore the results. For a version that doesn't ignore the

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -49,6 +49,7 @@ library
     Shelley.Spec.Ledger.API.Protocol
     Shelley.Spec.Ledger.API.Validation
     Shelley.Spec.Ledger.API.Wallet
+    Shelley.Spec.Ledger.API.Mempool
     Shelley.Spec.Ledger.BaseTypes
     Shelley.Spec.Ledger.BlockChain
     Shelley.Spec.Ledger.CompactAddr
@@ -102,8 +103,7 @@ library
     Shelley.Spec.Ledger.Tx
     Shelley.Spec.Ledger.TxBody
     Shelley.Spec.Ledger.UTxO
-  other-modules:     Shelley.Spec.Ledger.API.Mempool
-                     Shelley.Spec.Ledger.API.Types
+  other-modules:      Shelley.Spec.Ledger.API.Types
   hs-source-dirs: src
   build-depends:
     aeson,


### PR DESCRIPTION
This is built atop #2264, which should be merged first.

We introduce a few things in this PR:
- The ability to label predicates is introduced in the core STS framework.
- We add to `cardano-ledger-core` a specific use of this to identify "static" predicates. (Those that rely only on the signal -e.g. the tx - rather than the state/environment)
- We mark a bunch of checks, both in Alonzo and Shelley (which are still used in Alonzo) as being static.
- We change slightly the order of processing in UTXOS in order to allow for skipping more checks in reapplication.
- Finally, we use all of this to implement `applyTxInBlock`.

This closes CAD-2881