### PR TITLE
More Alonzo unit tests & clean-up

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -136,8 +135,7 @@ instance API.PraosCrypto c => API.ApplyTx (AlonzoEra c) where
             $ TRC (env, state, tx)
      in liftEither . left (API.ApplyTxError . join) $ res
 
-  extractTx ValidatedTx {body, wits, auxiliaryData} =
-    Tx body wits auxiliaryData
+  extractTx ValidatedTx {body = b, wits = w, auxiliaryData = a} = Tx b w a
 
 instance API.PraosCrypto c => API.ApplyBlock (AlonzoEra c)
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -209,8 +209,7 @@ alonzoStyleWitness ::
   ) =>
   TransitionRule (utxow era)
 alonzoStyleWitness = do
-  _u <- shelleyStyleWitness WrappedShelleyEraFailure
-  (TRC (ue@(UtxoEnv _slot pp _stakepools _genDelegs), u', tx)) <- judgmentContext
+  (TRC (UtxoEnv _slot pp _stakepools _genDelegs, u', tx)) <- judgmentContext
   let txbody = getField @"body" (tx :: TxInBlock era)
 
   let scriptWitMap = getField @"scriptWits" tx
@@ -264,7 +263,9 @@ alonzoStyleWitness = do
       bodyPPhash = getField @"wppHash" txbody
   bodyPPhash == computedPPhash ?! PPViewHashesDontMatch bodyPPhash computedPPhash
 
-  trans @(Core.EraRule "UTXO" era) $ TRC (ue, u', tx)
+  -- The shelleyStyleWitness calls the UTXO rule
+  shelleyStyleWitness WrappedShelleyEraFailure
+
 
 -- ====================================
 -- Make the STS instance

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -291,7 +291,6 @@ instance Mock c => Arbitrary (AlonzoPredFail (AlonzoEra c)) where
     oneof
       [ WrappedShelleyEraFailure <$> arbitrary,
         UnRedeemableScripts <$> arbitrary,
-        MissingNeededScriptHash <$> arbitrary,
         DataHashSetsDontAgree <$> arbitrary <*> arbitrary,
         PPViewHashesDontMatch <$> arbitrary <*> arbitrary
       ]

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
@@ -140,7 +140,8 @@ example1UTxO =
         (TxIn genesisId 15, UTXOW.collateralOutput),
         (TxIn genesisId 6, UTXOW.someOutput),
         (TxIn genesisId 17, UTXOW.collateralOutput),
-        (TxIn genesisId 8, UTXOW.someOutput)
+        (TxIn genesisId 8, UTXOW.someOutput),
+        (TxIn genesisId 100, UTXOW.timelockOut)
       ]
 
 example1UtxoSt :: UTxOState A

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -11,8 +11,7 @@ import Cardano.Ledger.Alonzo.Data (AuxiliaryData, Data (..))
 import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure)
--- TODO resolve the problem with the Utxow predicate failure type, so we will need this import
--- import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
+import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
 import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.Alonzo.Tx (CostModel, WitnessPPData)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
@@ -101,11 +100,8 @@ tests =
         tripping @(PParamsUpdate (AlonzoEra C_Crypto)),
       testProperty "alonzo/AuxiliaryData" $
         trippingAnn @(AuxiliaryData (AlonzoEra C_Crypto)),
-      -- TODO, this test does not work because of (FromCBOR(Annotator x)) issues
-      -- when we get that ironed out, we should put the test back in.
-      -- testProperty "alonzo/AlonzoPredFail" $
-      --   trippingAnn @(AlonzoPredFail (AlonzoEra C_Crypto)),
-
+      testProperty "alonzo/AlonzoPredFail" $
+        tripping @(AlonzoPredFail (AlonzoEra C_Crypto)),
       testProperty "alonzo/UtxoPredicateFailure" $
         tripping @(UtxoPredicateFailure (AlonzoEra C_Crypto)),
       testProperty "alonzo/UtxosPredicateFailure" $


### PR DESCRIPTION
This PR might be easiest to review commit by commit.

### :straight_ruler: New examples / unit tests
* A transaction with scripts (both 1-phase and 2-phase) in every spot that is allowed
* Invalid transactions with expected predicate failures

### :broom: Cleanup
* re-enable the `AlonzoPredFail` round trip serialization test
* The Alonzo `UTXOW` rule was sneakily calling the `UTXO` rule twice. In alonzo, all the predicates that are in common with the previous eras are checked via the `shelleyStyleWitness`, which calls the `UTXO` rule. But the Alonzo `UTXOW` was also calling `UTXO` directly. This was only noticeable in the predicate failures, since they were repeated twice (the the state transformation was happen twice, the first results of which were discarded).
* The evaluation of 1-phase scripts were being checked twice in the Alonzo era. Once directly with the `Phase1ScriptWitnessNotValidating` failure, and once in the `shelleyStyleWitness` function.
* The check for all needed 1-phase script hashes in the witness set was also being done twice in Alonzo. Once directly with the `MissingNeededScriptHash` failure, and once in the `shelleyStyleWitness` function.
* Rename the predicate failure `ShouldNeverHappenScriptInputsNotFound` to `CollectErrors`. This error should never happen in isolation, that would indicate a logic error in the rules.  It does, however, occur alongside other errors. Though (hopefully) redundant, it is a nice sanity check.
* We hit the field puns & pattern synonyms GHC bug, so I removed the pun to get rid of the warning.

### :beetle: Bug
* The `collectTwoPhaseScriptInputs` function needs to filter out script hashes for every one that is known to not be a 1-phase script, ie those in the script witnesses which are 1-phase. The formal spec does this in a slightly sneaky way right now by applying a function `language` to the script hashes, which is not defined on 1-phase script hashes.

### :books: Verbosity
The current examples are very verbose and much of what is visible is noise. My next goal is to find a way to make them much more concise, in a way that highlights what is interesting about each example.