### PR TITLE
Collateral inputs

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -69,7 +69,9 @@ data AlonzoGenesis = AlonzoGenesis
     prices :: Prices,
     maxTxExUnits :: ExUnits,
     maxBlockExUnits :: ExUnits,
-    maxValSize :: Natural
+    maxValSize :: Natural,
+    collateralPercentage :: Natural,
+    maxCollateralInputs :: Natural
   }
   deriving (Eq)
 
@@ -231,7 +233,9 @@ translatePParams ctx pp =
       _prices = prices ctx,
       _maxTxExUnits = maxTxExUnits ctx,
       _maxBlockExUnits = maxBlockExUnits ctx,
-      _maxValSize = maxValSize ctx
+      _maxValSize = maxValSize ctx,
+      _collateralPercentage = collateralPercentage ctx,
+      _maxCollateralInputs = maxCollateralInputs ctx
     }
 
 translatePParamsUpdate ::
@@ -260,5 +264,7 @@ translatePParamsUpdate pp =
       _prices = SNothing,
       _maxTxExUnits = SNothing,
       _maxBlockExUnits = SNothing,
-      _maxValSize = SNothing
+      _maxValSize = SNothing,
+      _collateralPercentage = SNothing,
+      _maxCollateralInputs = SNothing
     }

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -57,7 +57,6 @@ module Cardano.Ledger.Alonzo.Tx
     txbody,
     minfee,
     isTwoPhaseScriptAddress,
-    txins,
     Shelley.txouts,
     -- Figure 6
     txrdmrs,
@@ -411,15 +410,6 @@ isTwoPhaseScriptAddress tx addr =
       case Map.lookup hash (getField @"scriptWits" tx) of
         Nothing -> False
         Just scr -> not (isNativeScript @era scr)
-
--- | The keys of all the inputs of the TxBody (both the inputs for fees, and the normal inputs).
-txins ::
-  ( HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "txinputs_fee" (Core.TxBody era) (Set (TxIn (Crypto era)))
-  ) =>
-  Core.TxBody era ->
-  Set (TxIn (Crypto era))
-txins txb = Set.union (getField @"inputs" txb) (getField @"txinputs_fee" txb)
 
 -- | txsize computes the length of the serialised bytes
 instance HasField "txsize" (ValidatedTx era) Integer where

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( certs',
     inputs',
-    inputs_fee',
     mint',
     outputs',
     reqSignerHashes',
@@ -314,7 +313,9 @@ txInfo ::
 txInfo ei sysS utxo tx =
   P.TxInfo
     { P.txInfoInputs = mapMaybe (txInfoIn utxo) (Set.toList (inputs' tbody)),
-      P.txInfoInputsFees = mapMaybe (txInfoIn utxo) (Set.toList (inputs_fee' tbody)),
+      -- TODO There are now no fee inputs, and collateral inputs will not be
+      -- provided to Plutus, so this field can be removed.
+      P.txInfoInputsFees = mempty,
       P.txInfoOutputs = mapMaybe txInfoOut (foldr (:) [] outs),
       P.txInfoFee = (transValue (inject @(Mary.Value (Crypto era)) fee)),
       P.txInfoForge = (transValue forge),

--- a/alonzo/test/cddl-files/alonzo.cddl
+++ b/alonzo/test/cddl-files/alonzo.cddl
@@ -47,7 +47,7 @@ operational_cert =
 protocol_version = (uint, uint)
 
 transaction_body =
- { 0 : set<transaction_input>    ; Fee inputs (previously this was inputs)
+ { 0 : set<transaction_input>    ; inputs
  , 1 : [* transaction_output]
  , 2 : coin                      ; fee
  , ? 3 : uint                    ; time to live
@@ -58,7 +58,7 @@ transaction_body =
  , ? 8 : uint                    ; validity interval start
  , ? 9 : mint
  , ? 11 : script_data_hash       ; New
- , ? 13 : set<transaction_input> ; Non-fee inputs ; New
+ , ? 13 : set<transaction_input> ; Collateral ; new
  , ? 14 : required_signers       ; New
  , ? 15 : network_id             ; New
  }

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -226,11 +226,15 @@ instance Arbitrary (PParams era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary (PParamsUpdate era) where
   arbitrary =
     PParams
       <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
@@ -276,10 +280,10 @@ instance Mock c => Arbitrary (UtxoPredicateFailure (AlonzoEra c)) where
         (OutputBootAddrAttrsTooBig) <$> arbitrary,
         pure TriesToForgeADA,
         (OutputTooBigUTxO) <$> arbitrary,
-        FeeNotBalancedUTxO <$> arbitrary <*> arbitrary,
+        InsufficientCollateral <$> arbitrary <*> arbitrary,
         ScriptsNotPaidUTxO <$> arbitrary,
         ExUnitsTooBigUTxO <$> arbitrary <*> arbitrary,
-        FeeContainsNonADA <$> arbitrary
+        CollateralContainsNonADA <$> arbitrary
       ]
 
 instance Mock c => Arbitrary (AlonzoPredFail (AlonzoEra c)) where

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Examples/Bbody.hs
@@ -11,10 +11,8 @@ where
 
 import Cardano.Crypto.VRF (evalCertified)
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY)
-import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..))
 import Cardano.Ledger.Alonzo.Tx (ValidatedTx)
 import Cardano.Ledger.Alonzo.TxSeq (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Coin (Coin (..))
@@ -67,17 +65,8 @@ type A = AlonzoEra C_Crypto
 -- Setup the initial state
 -- =======================
 
-pp :: PParams A
-pp =
-  def
-    { _costmdls = Map.singleton PlutusV1 (CostModel mempty),
-      _maxValSize = 1000000000,
-      _maxTxExUnits = ExUnits 1000000 1000000,
-      _maxBlockExUnits = ExUnits 1000000 1000000
-    }
-
 bbodyEnv :: BbodyEnv A
-bbodyEnv = BbodyEnv pp def
+bbodyEnv = BbodyEnv UTXOW.pp def
 
 -- =======
 --  Tests
@@ -140,11 +129,18 @@ example1UTxO :: UTxO A
 example1UTxO =
   UTxO $
     Map.fromList
-      [ (TxIn genesisId 9, UTXOW.alwaysFailsOutput),
-        (TxIn (txid @A UTXOW.validatingBody) 0, UTXOW.outEx1),
+      [ (TxIn (txid @A UTXOW.validatingBody) 0, UTXOW.outEx1),
         (TxIn (txid @A UTXOW.validatingBodyWithCert) 0, UTXOW.outEx3),
         (TxIn (txid @A UTXOW.validatingBodyWithWithdrawal) 0, UTXOW.outEx5),
-        (TxIn (txid @A UTXOW.validatingBodyWithMint) 0, UTXOW.outEx7)
+        (TxIn (txid @A UTXOW.validatingBodyWithMint) 0, UTXOW.outEx7),
+        (TxIn genesisId 11, UTXOW.collateralOutput),
+        (TxIn genesisId 2, UTXOW.alwaysFailsOutput),
+        (TxIn genesisId 13, UTXOW.collateralOutput),
+        (TxIn genesisId 4, UTXOW.someOutput),
+        (TxIn genesisId 15, UTXOW.collateralOutput),
+        (TxIn genesisId 6, UTXOW.someOutput),
+        (TxIn genesisId 17, UTXOW.collateralOutput),
+        (TxIn genesisId 8, UTXOW.someOutput)
       ]
 
 example1UtxoSt :: UTxOState A


### PR DESCRIPTION
This should correspond to the changes made to the spec in #2271.

- Fee inputs have now been dropped. Fees may be paid from any TxOut,
  including Plutus script addresses, and are included in the main inputs
  as with all previous eras.
- Instead, we have "collateral" which must be posted with transactions
  spending from script addresses. This collateral is only collected if a
  script fails to validate (e.g. a second phase validation). This
  collateral must be provided by VKey-locked inputs.
- Two new protocol parameters govern this:
  - The collateral percentage determins the percentage of the fee which
    must be posted as collateral.
  - The max collateral inputs determines the maximum number of inputs
    which must be posted as collateral.
- The CDDL is now updated in order to reflect that inputs remain at key
  '0'. This is OK because collateral is only required for Plutus locked
  addresses.

The limit on the number of collateral inputs, and the restriction to
VKey addresses, is done in order to bound the amount of work which may
be involved in verifying collateral.