### PR TITLE
fix alonzo block serialization

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -214,6 +214,7 @@ instance CC.Crypto c => EraModule.SupportsSegWit (AlonzoEra c) where
   fromTxSeq = Alonzo.txSeqTxns
   toTxSeq = Alonzo.TxSeq
   hashTxSeq = Alonzo.hashTxSeq
+  numSegComponents = 4
 
 instance API.PraosCrypto c => API.ShelleyBasedEra (AlonzoEra c)
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
@@ -271,8 +271,10 @@ nonValidatingIndices (StrictSeq.fromStrict -> xs) =
 --
 -- This function operates much as the inverse of 'nonValidatingIndices'.
 alignedValidFlags :: Int -> [Int] -> Seq.Seq IsValidating
-alignedValidFlags n [] = Seq.replicate n $ IsValidating True
-alignedValidFlags n (x : xs) =
-  Seq.replicate (n - x) (IsValidating True)
-    Seq.>< IsValidating False
-    Seq.<| alignedValidFlags (n - x - 1) xs
+alignedValidFlags = alignedValidFlags' (-1)
+  where
+    alignedValidFlags' _ n [] = Seq.replicate n $ IsValidating True
+    alignedValidFlags' prev n (x : xs) =
+      Seq.replicate (x - prev - 1) (IsValidating True)
+        Seq.>< IsValidating False
+        Seq.<| alignedValidFlags' x (n - (x - prev)) xs

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -17,10 +17,12 @@ import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.Alonzo.Tx (CostModel, WitnessPPData)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness
+import qualified Cardano.Ledger.Tx as LTX
 import qualified Data.ByteString as BS (ByteString)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified PlutusTx as Plutus
+import Shelley.Spec.Ledger.BlockChain (Block)
 import Shelley.Spec.Ledger.Metadata (Metadata)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (roundTrip, roundTripAnn)
@@ -111,5 +113,9 @@ tests =
       testProperty "Script" $
         trippingAnn @(Script (AlonzoEra C_Crypto)),
       testProperty "WitnessPPData" $
-        trippingAnn @(WitnessPPData (AlonzoEra C_Crypto))
+        trippingAnn @(WitnessPPData (AlonzoEra C_Crypto)),
+      testProperty "alonzo/Tx" $
+        trippingAnn @(LTX.Tx (AlonzoEra C_Crypto)),
+      testProperty "alonzo/Block" $
+        trippingAnn @(Block (AlonzoEra C_Crypto))
     ]

--- a/cardano-ledger-core/src/Cardano/Ledger/Era.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Era.hs
@@ -51,6 +51,7 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import Data.Void (Void, absurd)
+import Data.Word (Word64)
 import GHC.Records (HasField (..))
 
 --------------------------------------------------------------------------------
@@ -132,6 +133,9 @@ class SupportsSegWit era where
   hashTxSeq ::
     TxSeq era ->
     Hash.Hash (CryptoClass.HASH (Crypto era)) EraIndependentBlockBody
+
+  -- | The number of segregated components
+  numSegComponents :: Word64
 
 --------------------------------------------------------------------------------
 -- Era translation

--- a/example-shelley/src/Cardano/Ledger/Example.hs
+++ b/example-shelley/src/Cardano/Ledger/Example.hs
@@ -151,6 +151,7 @@ instance CryptoClass.Crypto c => SupportsSegWit (ExampleEra c) where
   fromTxSeq = Shelley.txSeqTxns
   toTxSeq = Shelley.TxSeq
   hashTxSeq = Shelley.bbHash
+  numSegComponents = 3
 
 instance CryptoClass.Crypto c => ValidateAuxiliaryData (ExampleEra c) c where
   hashAuxiliaryData metadata = AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -192,6 +192,7 @@ instance
   fromTxSeq = Shelley.txSeqTxns
   toTxSeq = Shelley.TxSeq
   hashTxSeq = Shelley.bbHash
+  numSegComponents = 3
 
 instance
   ( CryptoClass.Crypto c,

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -117,6 +117,7 @@ instance CryptoClass.Crypto c => SupportsSegWit (ShelleyEra c) where
   fromTxSeq = Shelley.txSeqTxns
   toTxSeq = Shelley.TxSeq
   hashTxSeq = bbHash
+  numSegComponents = 3
 
 instance CryptoClass.Crypto c => ValidateAuxiliaryData (ShelleyEra c) c where
   validateAuxiliaryData (Metadata m) = all validMetadatum m

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -679,17 +679,23 @@ instance
   fromCBOR = txSeqDecoder False
 
 instance
+  forall era.
   ( BlockAnn era,
     ValidateScript era,
+    Era.SupportsSegWit era,
     FromCBOR (Annotator (Era.TxSeq era))
   ) =>
   FromCBOR (Annotator (Block era))
   where
   fromCBOR = annotatorSlice $
-    decodeRecordNamed "Block" (const 4) $ do
+    decodeRecordNamed "Block" (const blockSize) $ do
       header <- fromCBOR
       txns <- fromCBOR
       pure $ Block' <$> header <*> txns
+    where
+      blockSize =
+        1 -- header
+          + fromIntegral (Era.numSegComponents @era)
 
 -- | A block in which we do not validate the matched encoding of parts of the
 --   segwit. TODO This is purely a test concern, and as such should be moved out


### PR DESCRIPTION
The Alonzo blocks now pass the roundtrip serialization tests.  I had to:

* Remove the `PreAlonzo` constraint from the block generator. (Now that I have looked at that generator in detail, I see more cleanup that I want to do, but I will do that in a follow up PR. generators for serialization should be much more "white noise" than what we have).
* Add a method to the `SupportsSegWit` class to return the number of non-body segments. This is used in the Block serialization to enforce the number of items in a Block.
* Fix the `alignedValidFlags` function that is used in Alonzo `TxSeq` decoding. It is supposed to be the moral dual of `nonValidatingIndices`, but the recursive step was not taking into account the index of the last `False` that it had seen.