### PR TITLE
Also export epochInfo function from API.Types

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -22,6 +22,7 @@ import Shelley.Spec.Ledger.BaseTypes as X
     Nonce (..),
     Port (..),
     StrictMaybe (..),
+    epochInfo,
   )
 import Shelley.Spec.Ledger.BlockChain as X
   ( BHBody (..),


### PR DESCRIPTION
Consensus has some code that expects `epochInfo :: Globals -> EpochInfo Identity`, so I think we should include the new `epochInfo` function in the `....API` re-exports.