### PR TITLE
Check that collateral inputs must be signed

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -18,7 +18,11 @@ module Cardano.Ledger.Alonzo.Rules.Utxow where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (DataHash)
 import Cardano.Ledger.Alonzo.PParams (PParams)
-import Cardano.Ledger.Alonzo.PlutusScriptApi (checkScriptData, language, scriptsNeeded)
+import Cardano.Ledger.Alonzo.PlutusScriptApi
+  ( checkScriptData,
+    language,
+    scriptsNeeded,
+  )
 import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUTXO)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (UtxoPredicateFailure)
 import Cardano.Ledger.Alonzo.Scripts (Script (..))
@@ -41,15 +45,35 @@ import Control.Iterate.SetAlgebra (domain, eval, (⊆), (◁), (➖))
 import Control.State.Transition.Extended
 import Data.Coders
 import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import GHC.Records
 import NoThunks.Class
-import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..))
-import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
-import Shelley.Spec.Ledger.LedgerState (UTxOState (..), unWitHashes, witsFromTxWitnesses)
+import Shelley.Spec.Ledger.Address (Addr (..), bootstrapKeyHash, getRwdCred)
+import Shelley.Spec.Ledger.BaseTypes
+  ( ShelleyBase,
+    StrictMaybe (..),
+    strictMaybeToMaybe,
+  )
+import Shelley.Spec.Ledger.Credential (Credential (KeyHashObj))
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( delegCWitness,
+    genesisCWitness,
+    poolCWitness,
+    requiresVKeyWitness,
+  )
+import Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..), asWitness)
+import Shelley.Spec.Ledger.LedgerState
+  ( UTxOState (..),
+    WitHashes (..),
+    propWits,
+    unWitHashes,
+    witsFromTxWitnesses,
+  )
+import Shelley.Spec.Ledger.PParams (Update)
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
 import Shelley.Spec.Ledger.STS.Utxow
   ( ShelleyStyleWitnessNeeds,
@@ -57,7 +81,15 @@ import Shelley.Spec.Ledger.STS.Utxow
     shelleyStyleWitness,
   )
 import Shelley.Spec.Ledger.Scripts (ScriptHash (..))
-import Shelley.Spec.Ledger.Tx (TxIn (..))
+import Shelley.Spec.Ledger.Tx (TxIn (..), extractKeyHashWitnessSet)
+import Shelley.Spec.Ledger.TxBody
+  ( DCert (DCertDeleg, DCertGenesis, DCertPool),
+    PoolCert (RegPool),
+    PoolParams (..),
+    Wdrl,
+    unWdrl,
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO, txinLookup)
 
 -- =====================================================
 
@@ -197,7 +229,8 @@ alonzoStyleWitness ::
     ShelleyStyleWitnessNeeds era,
     AlonzoStyleAdditions era,
     -- New transaction body fields needed for Alonzo
-    HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era)))
+    HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
+    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   TransitionRule (utxow era)
 alonzoStyleWitness = do
@@ -242,7 +275,89 @@ alonzoStyleWitness = do
   bodyPPhash == computedPPhash ?! PPViewHashesDontMatch bodyPPhash computedPPhash
 
   -- The shelleyStyleWitness calls the UTXO rule
-  shelleyStyleWitness WrappedShelleyEraFailure
+  shelleyStyleWitness witsVKeyNeeded WrappedShelleyEraFailure
+
+-- | Collect the set of hashes of keys that needs to sign a given transaction.
+--  This set consists of the txin owners, certificate authors, and withdrawal
+--  reward accounts.
+--
+--  Compared to pre-Alonzo eras, we additionally gather the certificates
+--  required to authenticate collateral witnesses.
+witsVKeyNeeded ::
+  forall era tx.
+  ( Era era,
+    HasField "body" tx (Core.TxBody era),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "address" (Core.TxOut era) (Addr (Crypto era))
+  ) =>
+  UTxO era ->
+  tx ->
+  GenDelegs (Crypto era) ->
+  WitHashes (Crypto era)
+witsVKeyNeeded utxo' tx genDelegs =
+  WitHashes $
+    certAuthors
+      `Set.union` inputAuthors
+      `Set.union` owners
+      `Set.union` wdrlAuthors
+      `Set.union` updateKeys
+  where
+    txbody = getField @"body" tx
+    inputAuthors :: Set (KeyHash 'Witness (Crypto era))
+    inputAuthors =
+      foldr
+        accum
+        Set.empty
+        ( getField @"inputs" txbody
+            `Set.union` getField @"collateral" txbody
+        )
+      where
+        accum txin ans =
+          case txinLookup txin utxo' of
+            Just out ->
+              case getField @"address" out of
+                Addr _ (KeyHashObj pay) _ -> Set.insert (asWitness pay) ans
+                AddrBootstrap bootAddr ->
+                  Set.insert (asWitness (bootstrapKeyHash bootAddr)) ans
+                _ -> ans
+            Nothing -> ans
+
+    wdrlAuthors :: Set (KeyHash 'Witness (Crypto era))
+    wdrlAuthors = Map.foldrWithKey accum Set.empty (unWdrl (getField @"wdrls" txbody))
+      where
+        accum key _ ans = Set.union (extractKeyHashWitnessSet [getRwdCred key]) ans
+    owners :: Set (KeyHash 'Witness (Crypto era))
+    owners = foldr accum Set.empty (getField @"certs" txbody)
+      where
+        accum (DCertPool (RegPool pool)) ans =
+          Set.union
+            (Set.map asWitness (_poolOwners pool))
+            ans
+        accum _cert ans = ans
+    cwitness (DCertDeleg dc) = extractKeyHashWitnessSet [delegCWitness dc]
+    cwitness (DCertPool pc) = extractKeyHashWitnessSet [poolCWitness pc]
+    cwitness (DCertGenesis gc) = Set.singleton (asWitness $ genesisCWitness gc)
+    cwitness c = error $ show c ++ " does not have a witness"
+    -- key reg requires no witness but this is already filtered outby requiresVKeyWitness
+    -- before the call to `cwitness`, so this error should never be reached.
+
+    certAuthors :: Set (KeyHash 'Witness (Crypto era))
+    certAuthors = foldr accum Set.empty (getField @"certs" txbody)
+      where
+        accum cert ans | requiresVKeyWitness cert = Set.union (cwitness cert) ans
+        accum _cert ans = ans
+    updateKeys :: Set (KeyHash 'Witness (Crypto era))
+    updateKeys =
+      asWitness
+        `Set.map` propWits
+          ( strictMaybeToMaybe $
+              getField @"update" txbody
+          )
+          genDelegs
 
 -- ====================================
 -- Make the STS instance
@@ -262,6 +377,7 @@ instance
     Signal (Core.EraRule "UTXO" era) ~ ValidatedTx era,
     -- New transaction body fields needed for Alonzo
     HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
+    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
     -- Supply the HasField and Validate instances for Alonzo
     ShelleyStyleWitnessNeeds era, -- supplies a subset of those needed. All the old Shelley Needs still apply.
     AlonzoStyleAdditions era

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
--- The STS instance for UTXOW is technically an orphan.
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 
@@ -19,7 +17,10 @@ import Control.State.Transition.Extended
 import GHC.Records (HasField)
 import Shelley.Spec.Ledger.Address (Addr)
 import Shelley.Spec.Ledger.BaseTypes
-import Shelley.Spec.Ledger.LedgerState (UTxOState)
+import Shelley.Spec.Ledger.LedgerState
+  ( UTxOState,
+    witsVKeyNeeded,
+  )
 import qualified Shelley.Spec.Ledger.STS.Ledger as Shelley
 import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv)
 import Shelley.Spec.Ledger.STS.Utxow
@@ -65,7 +66,7 @@ instance
   type
     PredicateFailure (UTXOW era) =
       UtxowPredicateFailure era
-  transitionRules = [shelleyStyleWitness id]
+  transitionRules = [shelleyStyleWitness witsVKeyNeeded id]
 
   -- The ShelleyMA Era uses the same PredicateFailure type
   -- as Shelley, so the 'embed' function is identity

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -68,6 +68,7 @@ module Shelley.Spec.Ledger.LedgerState
     verifiedWits,
     witsVKeyNeeded,
     witsFromTxWitnesses,
+    propWits,
 
     -- * DelegationState
     keyRefunds,


### PR DESCRIPTION
This PR overrides the `witsVKeyNeeded` function in Alonzo, in line with the updated Alonzo spec.