### PR TITLE
Adding some instances needed for consensus.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -37,6 +39,8 @@ import qualified Cardano.Ledger.Tx as LTX
 import Control.Monad.Except (Except, throwError)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API
   ( EpochState (..),
@@ -73,7 +77,7 @@ data AlonzoGenesis = AlonzoGenesis
     collateralPercentage :: Natural,
     maxCollateralInputs :: Natural
   }
-  deriving (Eq)
+  deriving (Eq, Generic, NoThunks)
 
 type instance PreviousEra (AlonzoEra c) = MaryEra c
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (SupportsSegWit (..), ValidateScript (..))
-import qualified Cardano.Ledger.Era as E (Era (Crypto))
+import qualified Cardano.Ledger.Era as E (Era (Crypto), TranslationContext)
 import Cardano.Ledger.Hashes (EraIndependentAuxiliaryData)
 import Cardano.Ledger.SafeHash (makeHashWithExplicitProxys)
 import Cardano.Ledger.Shelley.Constraints
@@ -72,6 +72,8 @@ instance CryptoClass.Crypto c => UsesTxOut (ShelleyEra c) where
 
 instance CryptoClass.Crypto c => UsesPParams (ShelleyEra c) where
   mergePPUpdates _ = updatePParams
+
+type instance E.TranslationContext (ShelleyEra c) = ()
 
 --------------------------------------------------------------------------------
 -- Core instances


### PR DESCRIPTION
These instances necessary for integration with consensus because the era's translation context is stored in the `LedgerConfig`.