### PR TITLE
Introduce ShelleyLedgerExamples (moved from consensus)

### DIFF
--- a/cardano-ledger-core/src/Cardano/Ledger/Crypto.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Crypto.hs
@@ -36,9 +36,6 @@ class
 -- | The same crypto used on the net
 data StandardCrypto
 
--- This should match that defined at
--- https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
-
 instance Crypto StandardCrypto where
   type DSIGN StandardCrypto = Ed25519DSIGN
   type KES StandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -46,7 +46,9 @@ library
     Test.Cardano.Ledger.EraBuffet
     Test.Cardano.Ledger.MaryEraGen
     Test.Cardano.Ledger.Mary.Golden
+    Test.Cardano.Ledger.Mary.Examples.Consensus
     Test.Cardano.Ledger.AllegraEraGen
+    Test.Cardano.Ledger.Allegra.Examples.Consensus
     Test.Cardano.Ledger.ShelleyMA.TxBody
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
@@ -66,6 +68,7 @@ library
     cardano-slotting,
     cborg,
     containers,
+    data-default-class,
     generic-random,
     hashable,
     mtl,
@@ -78,6 +81,7 @@ library
     tasty-quickcheck,
     tasty,
     text,
+    time,
   hs-source-dirs: src
 
 test-suite cardano-ledger-shelley-ma-test

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Allegra.Examples.Consensus where
+
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.AuxiliaryData
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Era
+import Cardano.Ledger.ShelleyMA
+import Cardano.Ledger.ShelleyMA.AuxiliaryData
+import Cardano.Ledger.ShelleyMA.Timelocks
+import Cardano.Ledger.ShelleyMA.TxBody
+import Cardano.Slotting.Slot
+import Data.Proxy
+import qualified Data.Sequence.Strict as StrictSeq
+import Shelley.Spec.Ledger.API
+import Test.Shelley.Spec.Ledger.Examples.Consensus
+import Test.Shelley.Spec.Ledger.Orphans ()
+import Test.Shelley.Spec.Ledger.Utils hiding (mkVRFKeyPair)
+
+type StandardAllegra = AllegraEra StandardCrypto
+
+-- | ShelleyLedgerExamples for Allegra era
+ledgerExamplesAllegra :: ShelleyLedgerExamples StandardAllegra
+ledgerExamplesAllegra =
+  defaultShelleyLedgerExamples
+    (mkWitnessesPreAlonzo (Proxy @StandardAllegra))
+    id
+    exampleCoin
+    exampleTxBodyAllegra
+    exampleAuxiliaryDataMA
+
+exampleTxBodyAllegra :: Cardano.Ledger.ShelleyMA.TxBody.TxBody StandardAllegra
+exampleTxBodyAllegra = exampleTxBodyMA exampleCoin
+
+exampleTxBodyMA ::
+  forall era.
+  ( ShelleyBasedEra' era,
+    PParamsDelta era ~ PParams' StrictMaybe era
+  ) =>
+  Cardano.Ledger.Core.Value era ->
+  Cardano.Ledger.ShelleyMA.TxBody.TxBody era
+exampleTxBodyMA value =
+  Cardano.Ledger.ShelleyMA.TxBody.TxBody
+    exampleTxIns
+    ( StrictSeq.fromList
+        [ TxOut (mkAddr (examplePayKey, exampleStakeKey)) value
+        ]
+    )
+    exampleCerts
+    exampleWithdrawals
+    (Coin 3)
+    (ValidityInterval (SJust (SlotNo 2)) (SJust (SlotNo 4)))
+    (SJust (Update exampleProposedPPUpdates (EpochNo 0)))
+    (SJust auxiliaryDataHash)
+    value
+  where
+    -- Dummy hash to decouple from the auxiliary data in 'exampleTx'.
+    auxiliaryDataHash :: AuxiliaryDataHash (Cardano.Ledger.Era.Crypto era)
+    auxiliaryDataHash =
+      AuxiliaryDataHash $ mkDummySafeHash (Proxy @(Cardano.Ledger.Era.Crypto era)) 30
+
+exampleAuxiliaryDataMA :: Cardano.Ledger.Crypto.Crypto c => Cardano.Ledger.ShelleyMA.AuxiliaryData.AuxiliaryData (ShelleyMAEra ma c)
+exampleAuxiliaryDataMA =
+  AuxiliaryData
+    exampleMetadataMap
+    (StrictSeq.fromList [exampleScriptMA])
+
+exampleScriptMA :: Cardano.Ledger.Crypto.Crypto c => Script (ShelleyMAEra ma c)
+exampleScriptMA =
+  Cardano.Ledger.ShelleyMA.Timelocks.RequireMOf 2 $
+    StrictSeq.fromList
+      [ Cardano.Ledger.ShelleyMA.Timelocks.RequireAllOf $
+          StrictSeq.fromList
+            [ RequireTimeStart (SlotNo 0),
+              RequireTimeExpire (SlotNo 9)
+            ],
+        Cardano.Ledger.ShelleyMA.Timelocks.RequireAnyOf $
+          StrictSeq.fromList
+            [ Cardano.Ledger.ShelleyMA.Timelocks.RequireSignature (mkKeyHash 0),
+              Cardano.Ledger.ShelleyMA.Timelocks.RequireSignature (mkKeyHash 1)
+            ],
+        Cardano.Ledger.ShelleyMA.Timelocks.RequireSignature (mkKeyHash 100)
+      ]

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary/Examples/Consensus.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/Mary/Examples/Consensus.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Cardano.Ledger.Mary.Examples.Consensus where
+
+import qualified Data.Map.Strict as Map (singleton)
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary (MaryEra)
+import Data.Proxy
+import Test.Cardano.Ledger.Allegra.Examples.Consensus
+import Test.Shelley.Spec.Ledger.Examples.Consensus
+import Test.Shelley.Spec.Ledger.Orphans ()
+import Cardano.Ledger.Mary.Value
+
+type StandardMary = MaryEra StandardCrypto
+
+-- | ShelleyLedgerExamples for Allegra era
+ledgerExamplesMary :: ShelleyLedgerExamples StandardMary
+ledgerExamplesMary =
+    defaultShelleyLedgerExamples
+      (mkWitnessesPreAlonzo (Proxy @StandardMary))
+      id
+      exampleMultiAssetValue
+      exampleTxBodyMary
+      exampleAuxiliaryDataMA
+
+exampleMultiAssetValue :: forall c. Cardano.Ledger.Crypto.Crypto c => Cardano.Ledger.Mary.Value.Value c
+exampleMultiAssetValue =
+    Value 100 $ Map.singleton policyId $ Map.singleton couttsCoin 1000
+  where
+    policyId :: PolicyID c
+    policyId = PolicyID $ mkScriptHash 1
+
+    couttsCoin :: AssetName
+    couttsCoin = AssetName "couttsCoin"
+
+exampleTxBodyMary :: Cardano.Ledger.Core.TxBody StandardMary
+exampleTxBodyMary = exampleTxBodyMA exampleMultiAssetValue

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import qualified Cardano.Ledger.Crypto as CC (Crypto, StandardCrypto)
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys
@@ -115,6 +115,8 @@ class
     VRFSignable c Seed
   ) =>
   PraosCrypto c
+
+instance PraosCrypto CC.StandardCrypto
 
 class
   ( ChainData (ChainDepState (Crypto era)),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -47,6 +47,7 @@ library
     Test.Shelley.Spec.Ledger.BenchmarkFunctions
     Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
     Test.Shelley.Spec.Ledger.Examples.Cast
+    Test.Shelley.Spec.Ledger.Examples.Consensus
     Test.Shelley.Spec.Ledger.Generator.Block
     Test.Shelley.Spec.Ledger.Generator.Constants
     Test.Shelley.Spec.Ledger.Generator.Core

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Examples/Consensus.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Examples/Consensus.hs
@@ -1,0 +1,539 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Shelley.Spec.Ledger.Examples.Consensus where
+
+import Cardano.Binary
+import Cardano.Crypto.DSIGN as DSIGN
+import Cardano.Crypto.Hash as Hash
+import Cardano.Crypto.Seed as Seed
+import Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.AuxiliaryData
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Era
+import Cardano.Ledger.Keys
+import Cardano.Ledger.SafeHash
+import Cardano.Ledger.Serialization
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.Constraints
+import Cardano.Slotting.Block
+import Cardano.Slotting.EpochInfo
+import Cardano.Slotting.Slot
+import Control.State.Transition.Extended
+import qualified Data.ByteString as Strict
+import Data.Coerce (coerce)
+import Data.Default.Class
+import Data.Functor.Identity (Identity (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust)
+import Data.Proxy
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Time
+import Data.Word (Word64, Word8)
+import Shelley.Spec.Ledger.API
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.EpochBoundary
+import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.STS.Delegs
+import Shelley.Spec.Ledger.STS.Ledger
+import Shelley.Spec.Ledger.Tx
+import Shelley.Spec.Ledger.UTxO
+import Test.Shelley.Spec.Ledger.Generator.Core
+import Test.Shelley.Spec.Ledger.Orphans ()
+import Test.Shelley.Spec.Ledger.Utils hiding (mkVRFKeyPair)
+
+type KeyPairWits era = [KeyPair 'Witness (Cardano.Ledger.Era.Crypto era)]
+
+{-------------------------------------------------------------------------------
+  ShelleyLedgerExamples
+-------------------------------------------------------------------------------}
+
+data ShelleyResultExamples era = ShelleyResultExamples
+  { srePParams :: Shelley.Spec.Ledger.PParams.PParams era,
+    sreProposedPPUpdates :: ProposedPPUpdates era,
+    srePoolDistr :: PoolDistr (Cardano.Ledger.Era.Crypto era),
+    sreNonMyopicRewards ::
+      Map
+        (Either Coin (Credential 'Staking (Cardano.Ledger.Era.Crypto era)))
+        (Map (KeyHash 'StakePool (Cardano.Ledger.Era.Crypto era)) Coin),
+    sreShelleyGenesis :: ShelleyGenesis era
+  }
+
+data ShelleyLedgerExamples era = ShelleyLedgerExamples
+  { sleBlock :: Block era,
+    sleHashHeader :: HashHeader (Cardano.Ledger.Era.Crypto era),
+    sleTx :: Tx era,
+    sleApplyTxError :: ApplyTxError era,
+    sleRewardsCredentials :: Set (Either Coin (Credential 'Staking (Cardano.Ledger.Era.Crypto era))),
+    sleResultExamples :: ShelleyResultExamples era,
+    sleNewEpochState :: NewEpochState era,
+    sleChainDepState :: ChainDepState (Cardano.Ledger.Era.Crypto era)
+  }
+
+{-------------------------------------------------------------------------------
+  Default constructor
+-------------------------------------------------------------------------------}
+
+type ShelleyBasedEra' era =
+  ( ShelleyBasedEra era,
+    ToCBORGroup (TxSeq era),
+    ToCBOR (Witnesses era),
+    Witnesses era ~ WitnessSet era,
+    Default (State (EraRule "PPUP" era))
+  )
+
+defaultShelleyLedgerExamples ::
+  forall era.
+  ( ShelleyBasedEra' era,
+    PredicateFailure (EraRule "DELEGS" era)
+      ~ DelegsPredicateFailure era,
+    Cardano.Ledger.Core.PParams era ~ Shelley.Spec.Ledger.PParams.PParams era,
+    PParamsDelta era ~ PParams' StrictMaybe era
+  ) =>
+  (Cardano.Ledger.Core.TxBody era -> KeyPairWits era -> Witnesses era) ->
+  (Tx era -> TxInBlock era) ->
+  Value era ->
+  Cardano.Ledger.Core.TxBody era ->
+  AuxiliaryData era ->
+  ShelleyLedgerExamples era
+defaultShelleyLedgerExamples mkWitnesses mkValidatedTx value txBody auxData =
+  ShelleyLedgerExamples
+    { sleBlock = exampleShelleyLedgerBlock (mkValidatedTx tx),
+      sleHashHeader = exampleHashHeader (Proxy @era),
+      sleTx = tx,
+      sleApplyTxError =
+        ApplyTxError $
+          pure $
+            DelegsFailure $
+              DelegateeNotRegisteredDELEG @era (mkKeyHash 1),
+      sleRewardsCredentials =
+        Set.fromList
+          [ Left (Coin 100),
+            Right (ScriptHashObj (mkScriptHash 1)),
+            Right (KeyHashObj (mkKeyHash 2))
+          ],
+      sleResultExamples = resultExamples,
+      sleNewEpochState = exampleNewEpochState value,
+      sleChainDepState = exampleLedgerChainDepState 1
+    }
+  where
+    tx = exampleTx mkWitnesses txBody auxData
+
+    resultExamples =
+      ShelleyResultExamples
+        { srePParams = def,
+          sreProposedPPUpdates = exampleProposedPParamsUpdates,
+          srePoolDistr = examplePoolDistr,
+          sreNonMyopicRewards =
+            Map.fromList
+              [ (Left (Coin 100), Map.singleton (mkKeyHash 2) (Coin 3)),
+                (Right (ScriptHashObj (mkScriptHash 1)), Map.empty),
+                (Right (KeyHashObj (mkKeyHash 2)), Map.singleton (mkKeyHash 3) (Coin 9))
+              ],
+          sreShelleyGenesis = testShelleyGenesis
+        }
+
+{-------------------------------------------------------------------------------
+  Helper constructors
+-------------------------------------------------------------------------------}
+
+exampleShelleyLedgerBlock ::
+  forall era.
+  ShelleyBasedEra' era =>
+  TxInBlock era ->
+  Block era
+exampleShelleyLedgerBlock tx = Block blockHeader blockBody
+  where
+    keys :: AllIssuerKeys (Cardano.Ledger.Era.Crypto era) 'StakePool
+    keys = exampleKeys
+
+    (_, (hotKey, _)) = head $ hot keys
+    KeyPair vKeyCold _ = cold keys
+
+    blockHeader :: BHeader (Cardano.Ledger.Era.Crypto era)
+    blockHeader = BHeader blockHeaderBody (signedKES () 0 blockHeaderBody hotKey)
+
+    blockHeaderBody :: BHBody (Cardano.Ledger.Era.Crypto era)
+    blockHeaderBody =
+      BHBody
+        { bheaderBlockNo = BlockNo 3,
+          bheaderSlotNo = SlotNo 9,
+          bheaderPrev = BlockHash (HashHeader (mkDummyHash Proxy 2)),
+          bheaderVk = coerceKeyRole vKeyCold,
+          bheaderVrfVk = snd $ vrf keys,
+          bheaderEta = mkCertifiedVRF (mkBytes 0) (fst $ vrf keys),
+          bheaderL = mkCertifiedVRF (mkBytes 1) (fst $ vrf keys),
+          bsize = 2345,
+          bhash = hashTxSeq @era blockBody,
+          bheaderOCert = mkOCert keys 0 (KESPeriod 0),
+          bprotver = ProtVer 2 0
+        }
+
+    blockBody = toTxSeq @era (StrictSeq.fromList [tx])
+
+    mkBytes :: Int -> Cardano.Ledger.BaseTypes.Seed
+    mkBytes = Seed . mkDummyHash (Proxy @Blake2b_256)
+
+exampleHashHeader ::
+  forall era.
+  ShelleyBasedEra' era =>
+  Proxy era ->
+  HashHeader (Cardano.Ledger.Era.Crypto era)
+exampleHashHeader _ = coerce $ mkDummyHash (Proxy @(HASH (Cardano.Ledger.Era.Crypto era))) 0
+
+mkKeyHash :: forall c discriminator. Cardano.Ledger.Crypto.Crypto c => Int -> KeyHash discriminator c
+mkKeyHash = KeyHash . mkDummyHash (Proxy @(ADDRHASH c))
+
+mkScriptHash :: forall c. Cardano.Ledger.Crypto.Crypto c => Int -> ScriptHash c
+mkScriptHash = ScriptHash . mkDummyHash (Proxy @(ADDRHASH c))
+
+-- | This is not a valid transaction. We don't care, we are only interested in
+-- serialisation, not validation.
+exampleTx ::
+  forall era.
+  ShelleyBasedEra' era =>
+  (Cardano.Ledger.Core.TxBody era -> KeyPairWits era -> Witnesses era) ->
+  Cardano.Ledger.Core.TxBody era ->
+  AuxiliaryData era ->
+  Tx era
+exampleTx mkWitnesses txBody auxData =
+  Tx txBody (mkWitnesses txBody keyPairWits) (SJust auxData)
+  where
+    keyPairWits :: KeyPairWits era
+    keyPairWits =
+      [ asWitness examplePayKey,
+        asWitness exampleStakeKey,
+        asWitness $ cold (exampleKeys @(Cardano.Ledger.Era.Crypto era) @'StakePool)
+      ]
+
+exampleProposedPParamsUpdates ::
+  ( ShelleyBasedEra' era,
+    PParamsDelta era ~ PParams' StrictMaybe era
+  ) =>
+  ProposedPPUpdates era
+exampleProposedPParamsUpdates =
+  ProposedPPUpdates $
+    Map.singleton
+      (mkKeyHash 0)
+      (emptyPParamsUpdate {_keyDeposit = SJust (Coin 100)})
+
+examplePoolDistr :: forall c. PraosCrypto c => PoolDistr c
+examplePoolDistr =
+  PoolDistr $
+    Map.fromList
+      [ ( mkKeyHash 1,
+          IndividualPoolStake
+            1
+            (hashVerKeyVRF (snd (vrf (exampleKeys @c))))
+        )
+      ]
+
+-- | These are dummy values.
+testShelleyGenesis :: ShelleyGenesis era
+testShelleyGenesis =
+  ShelleyGenesis
+    { sgSystemStart = UTCTime (fromGregorian 2020 5 14) 0,
+      sgNetworkMagic = 0,
+      sgNetworkId = Testnet,
+      -- Chosen to match activeSlotCoeff
+      sgActiveSlotsCoeff = 0.9,
+      sgSecurityParam = securityParameter testGlobals,
+      sgEpochLength = runIdentity $ epochInfoSize testEpochInfo 0,
+      sgSlotsPerKESPeriod = slotsPerKESPeriod testGlobals,
+      sgMaxKESEvolutions = maxKESEvo testGlobals,
+      -- Not important
+      sgSlotLength = secondsToNominalDiffTime 2,
+      sgUpdateQuorum = quorum testGlobals,
+      sgMaxLovelaceSupply = maxLovelaceSupply testGlobals,
+      sgProtocolParams = emptyPParams,
+      sgGenDelegs = Map.empty,
+      sgInitialFunds = Map.empty,
+      sgStaking = emptyGenesisStaking
+    }
+
+-- | This is probably not a valid ledger. We don't care, we are only
+-- interested in serialisation, not validation.
+exampleNewEpochState ::
+  forall era.
+  ( ShelleyBasedEra' era,
+    Cardano.Ledger.Core.PParams era ~ Shelley.Spec.Ledger.PParams.PParams era
+  ) =>
+  Value era ->
+  NewEpochState era
+exampleNewEpochState value =
+  NewEpochState
+    { nesEL = EpochNo 0,
+      nesBprev = BlocksMade (Map.singleton (mkKeyHash 1) 10),
+      nesBcur = BlocksMade (Map.singleton (mkKeyHash 2) 3),
+      nesEs = epochState,
+      nesRu = SJust rewardUpdate,
+      nesPd = examplePoolDistr
+    }
+  where
+    epochState :: EpochState era
+    epochState =
+      EpochState
+        { esAccountState =
+            AccountState
+              { _treasury = Coin 10000,
+                _reserves = Coin 1000
+              },
+          esSnapshots = emptySnapShots,
+          esLState =
+            LedgerState
+              { _utxoState =
+                  UTxOState
+                    { _utxo =
+                        UTxO $
+                          Map.fromList
+                            [ ( TxIn (TxId (mkDummySafeHash Proxy 1)) 0,
+                                makeTxOut (Proxy @era) addr value
+                              )
+                            ],
+                      _deposited = Coin 1000,
+                      _fees = Coin 1,
+                      _ppups = def
+                    },
+                _delegationState = def
+              },
+          esPrevPp = emptyPParams,
+          esPp = emptyPParams {_minUTxOValue = Coin 1},
+          esNonMyopic = def
+        }
+      where
+        addr :: Addr (Cardano.Ledger.Era.Crypto era)
+        addr =
+          Addr
+            Testnet
+            (keyToCredential examplePayKey)
+            (StakeRefBase (keyToCredential exampleStakeKey))
+
+    rewardUpdate :: PulsingRewUpdate (Cardano.Ledger.Era.Crypto era)
+    rewardUpdate =
+      startStep @era
+        (EpochSize 432000)
+        (BlocksMade (Map.singleton (mkKeyHash 1) 10))
+        epochState
+        (Coin 45)
+        (activeSlotCoeff testGlobals)
+        10
+
+exampleLedgerChainDepState :: forall c. PraosCrypto c => Word64 -> ChainDepState c
+exampleLedgerChainDepState seed =
+  ChainDepState
+    { csProtocol =
+        PrtclState
+          ( Map.fromList
+              [ (mkKeyHash 1, 1),
+                (mkKeyHash 2, 2)
+              ]
+          )
+          (mkNonceFromNumber seed)
+          (mkNonceFromNumber seed),
+      csTickn =
+        TicknState
+          NeutralNonce
+          (mkNonceFromNumber seed),
+      csLabNonce =
+        mkNonceFromNumber seed
+    }
+
+testEpochInfo :: EpochInfo Identity
+testEpochInfo = epochInfo testGlobals
+
+mkDummyHash :: forall h a. HashAlgorithm h => Proxy h -> Int -> Hash.Hash h a
+mkDummyHash _ = coerce . hashWithSerialiser @h toCBOR
+
+mkDummySafeHash :: forall c a. Cardano.Ledger.Crypto.Crypto c => Proxy c -> Int -> SafeHash c a
+mkDummySafeHash _ =
+  unsafeMakeSafeHash
+    . mkDummyHash (Proxy @(HASH c))
+
+{-------------------------------------------------------------------------------
+  Shelley era specific functions
+-------------------------------------------------------------------------------}
+
+type StandardShelley = ShelleyEra StandardCrypto
+
+-- | ShelleyLedgerExamples for Shelley era
+ledgerExamplesShelley :: ShelleyLedgerExamples StandardShelley
+ledgerExamplesShelley =
+  defaultShelleyLedgerExamples
+    (mkWitnessesPreAlonzo (Proxy @StandardShelley))
+    id
+    exampleCoin
+    exampleTxBodyShelley
+    exampleAuxiliaryDataShelley
+
+mkWitnessesPreAlonzo ::
+  ShelleyBasedEra' era =>
+  Proxy era ->
+  Cardano.Ledger.Core.TxBody era ->
+  KeyPairWits era ->
+  WitnessSet era
+mkWitnessesPreAlonzo _ txBody keyPairWits =
+  mempty
+    { addrWits =
+        makeWitnessesVKey (coerce (hashAnnotated txBody)) keyPairWits
+    }
+
+exampleCoin :: Coin
+exampleCoin = Coin 10
+
+
+exampleTxBodyShelley :: Shelley.Spec.Ledger.API.TxBody StandardShelley
+exampleTxBodyShelley =
+  Shelley.Spec.Ledger.API.TxBody
+    exampleTxIns
+    ( StrictSeq.fromList
+        [ TxOut (mkAddr (examplePayKey, exampleStakeKey)) (Coin 100000)
+        ]
+    )
+    exampleCerts
+    exampleWithdrawals
+    (Coin 3)
+    (SlotNo 10)
+    (SJust (Update exampleProposedPPUpdates (EpochNo 0)))
+    (SJust auxiliaryDataHash)
+  where
+    -- Dummy hash to decouple from the auxiliaryData in 'exampleTx'.
+    auxiliaryDataHash :: AuxiliaryDataHash StandardCrypto
+    auxiliaryDataHash =
+      AuxiliaryDataHash $ mkDummySafeHash (Proxy @StandardCrypto) 30
+
+exampleMetadataMap :: Map Word64 Metadatum
+exampleMetadataMap =
+  Map.fromList
+    [ (1, S "string"),
+      (2, B "bytes"),
+      (3, List [I 1, I 2]),
+      (4, Map [(I 3, B "b")])
+    ]
+
+exampleAuxiliaryDataShelley :: AuxiliaryData StandardShelley
+exampleAuxiliaryDataShelley = Metadata exampleMetadataMap
+
+exampleTxIns :: Cardano.Ledger.Crypto.Crypto c => Set (TxIn c)
+exampleTxIns =
+  Set.fromList
+    [ TxIn (TxId (mkDummySafeHash Proxy 1)) 0
+    ]
+
+exampleCerts :: Cardano.Ledger.Crypto.Crypto c => StrictSeq (DCert c)
+exampleCerts =
+  StrictSeq.fromList
+    [ DCertDeleg (RegKey (keyToCredential exampleStakeKey)),
+      DCertPool (RegPool examplePoolParams),
+      DCertMir $
+        MIRCert ReservesMIR $
+          StakeAddressesMIR $
+            Map.fromList
+              [ (keyToCredential (mkDSIGNKeyPair 2), DeltaCoin 110)
+              ]
+    ]
+
+exampleWithdrawals :: Cardano.Ledger.Crypto.Crypto c => Wdrl c
+exampleWithdrawals =
+  Wdrl $
+    Map.fromList
+      [ (_poolRAcnt examplePoolParams, Coin 100)
+      ]
+
+exampleProposedPPUpdates ::
+  ( PParamsDelta era ~ PParams' StrictMaybe era,
+    ShelleyBasedEra' era
+  ) =>
+  ProposedPPUpdates era
+exampleProposedPPUpdates =
+  ProposedPPUpdates $
+    Map.singleton
+      (mkKeyHash 1)
+      (emptyPParamsUpdate {_maxBHSize = SJust 4000})
+
+examplePayKey :: Cardano.Ledger.Crypto.Crypto c => KeyPair 'Payment c
+examplePayKey = mkDSIGNKeyPair 0
+
+exampleStakeKey :: Cardano.Ledger.Crypto.Crypto c => KeyPair 'Staking c
+exampleStakeKey = mkDSIGNKeyPair 1
+
+exampleKeys :: forall c r. Cardano.Ledger.Crypto.Crypto c => AllIssuerKeys c r
+exampleKeys =
+  AllIssuerKeys
+    coldKey
+    (mkVRFKeyPair (Proxy @c) 1)
+    [(KESPeriod 0, mkKESKeyPair (1, 0, 0, 0, 3))]
+    (hashKey (vKey coldKey))
+  where
+    coldKey = mkDSIGNKeyPair 1
+
+keyToCredential :: Cardano.Ledger.Crypto.Crypto c => KeyPair r c -> Credential r c
+keyToCredential = KeyHashObj . hashKey . vKey
+
+-- | @mkKeyPair'@ from @Test.Shelley.Spec.Ledger.Utils@ doesn't work for real
+-- crypto:
+-- <https://github.com/input-output-hk/cardano-ledger-specs/issues/1770>
+mkDSIGNKeyPair ::
+  forall c kd.
+  DSIGNAlgorithm (DSIGN c) =>
+  Word8 ->
+  KeyPair kd c
+mkDSIGNKeyPair byte = KeyPair (VKey $ DSIGN.deriveVerKeyDSIGN sk) sk
+  where
+    seed =
+      Seed.mkSeedFromBytes $
+        Strict.replicate
+          (fromIntegral (DSIGN.seedSizeDSIGN (Proxy @(DSIGN c))))
+          byte
+
+    sk = DSIGN.genKeyDSIGN seed
+
+mkVRFKeyPair ::
+  forall c.
+  VRFAlgorithm (VRF c) =>
+  Proxy c ->
+  Word8 ->
+  (Cardano.Ledger.Keys.SignKeyVRF c, Cardano.Ledger.Keys.VerKeyVRF c)
+mkVRFKeyPair _ byte = (sk, VRF.deriveVerKeyVRF sk)
+  where
+    seed =
+      Seed.mkSeedFromBytes $
+        Strict.replicate
+          (fromIntegral (VRF.seedSizeVRF (Proxy @(VRF c))))
+          byte
+
+    sk = VRF.genKeyVRF seed
+
+examplePoolParams :: forall c. Cardano.Ledger.Crypto.Crypto c => PoolParams c
+examplePoolParams =
+  PoolParams
+    { _poolId = hashKey $ vKey $ cold poolKeys,
+      _poolVrf = hashVerKeyVRF $ snd $ vrf poolKeys,
+      _poolPledge = Coin 1,
+      _poolCost = Coin 5,
+      _poolMargin = unsafeMkUnitInterval 0.1,
+      _poolRAcnt = RewardAcnt Testnet (keyToCredential exampleStakeKey),
+      _poolOwners = Set.singleton $ hashKey $ vKey exampleStakeKey,
+      _poolRelays = StrictSeq.empty,
+      _poolMD =
+        SJust $
+          PoolMetadata
+            { _poolMDUrl = fromJust $ textToUrl "consensus.pool",
+              _poolMDHash = "{}"
+            }
+    }
+  where
+    poolKeys = exampleKeys @c @'StakePool


### PR DESCRIPTION
As a followup PR to [this other one in ouroboros-network](https://github.com/input-output-hk/ouroboros-network/pull/3170), this PR moves all the relevant ShelleyLedgerExamples code to cardano-ledger-specs.

Consensus is running Golden tests where it is using some example datum that is mainly made up from ledger-specs datatypes. This PR moves the generation of those example values from consensus to ledger-specs.