### PR TITLE
remove MemoBytes from cost model

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -72,7 +72,6 @@ import Cardano.Ledger.SafeHash
 import Cardano.Ledger.Serialization (mapFromCBOR)
 import Cardano.Prelude (HeapWords (..), heapWords0, heapWords1)
 import qualified Codec.Serialise as Cborg (Serialise (..))
-import qualified Data.ByteString as BS (ByteString, length)
 import Data.ByteString.Lazy (toStrict)
 import Data.ByteString.Short (toShort)
 import Data.Coders
@@ -99,12 +98,6 @@ import Shelley.Spec.Ledger.Metadata (Metadatum)
 
 instance FromCBOR (Annotator Plutus.Data) where
   fromCBOR = pure <$> Cborg.decode
-
-checkPlutusByteString :: BS.ByteString -> Either String Plutus.Data
-checkPlutusByteString s =
-  if BS.length s <= 64
-    then Right (Plutus.B s)
-    else Left ("Plutus Bytestring in Plutus Data has length greater than 64: " ++ show (BS.length s) ++ "\n  " ++ show s)
 
 instance ToCBOR Plutus.Data where
   toCBOR = Cborg.encode

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -301,7 +301,6 @@ constructValidated ::
     Show (Core.PParams era),
     Show (Core.PParamsDelta era),
     Eq (Core.PParamsDelta era),
-    ToCBOR (Core.AuxiliaryData era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -72,9 +72,6 @@ import Cardano.Binary
   ( FromCBOR (..),
     ToCBOR (toCBOR),
     encodeListLen,
-    encodeNull,
-    serialize,
-    serialize',
     serializeEncoding,
   )
 import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
@@ -122,9 +119,7 @@ import Cardano.Ledger.SafeHash
   )
 import Cardano.Ledger.Val (Val (coin, (<+>), (<×>)))
 import Control.DeepSeq (NFData (..))
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Short as SBS (length, toShort)
 import Data.Coders
 import qualified Data.Map as Map
 import Data.Maybe.Strict
@@ -508,10 +503,6 @@ deriving newtype instance FromCBOR IsValidating
 deriving newtype instance ToCBOR IsValidating
 
 segwitTx ::
-  ( Era era,
-    ToCBOR (Core.TxBody era),
-    ToCBOR (Core.AuxiliaryData era)
-  ) =>
   Annotator (Core.TxBody era) ->
   Annotator (TxWitness era) ->
   IsValidating ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
@@ -178,11 +178,11 @@ hashTxSeq ::
   (Era era) =>
   TxSeq era ->
   Hash (Crypto era) EraIndependentBlockBody
-hashTxSeq (TxSeq' _ bodies wits md vs) =
+hashTxSeq (TxSeq' _ bodies ws md vs) =
   coerce $
     hashStrict
       ( hashPart bodies
-          <> hashPart wits
+          <> hashPart ws
           <> hashPart md
           <> hashPart vs
       )
@@ -208,10 +208,10 @@ instance
   where
   fromCBOR = do
     (bodies, bodiesAnn) <- withSlice $ decodeSeq fromCBOR
-    (wits, witsAnn) <- withSlice $ decodeSeq fromCBOR
+    (ws, witsAnn) <- withSlice $ decodeSeq fromCBOR
     let b = length bodies
         inRange x = (0 <= x) && (x <= (b -1))
-        w = length wits
+        w = length ws
     (metadata, metadataAnn) <- withSlice $
       do
         m <- decodeMap fromCBOR fromCBOR
@@ -247,7 +247,7 @@ instance
     let txns =
           sequenceA $
             StrictSeq.forceToStrict $
-              Seq.zipWith4 segwitTx bodies wits vs metadata
+              Seq.zipWith4 segwitTx bodies ws vs metadata
     pure $
       TxSeq'
         <$> txns


### PR DESCRIPTION
The current implementation does not preserve the cost model bytes anyway, so the `MemoBytes` type is spurious.

Also addressed some unrelated warnings that somehow our CI isn't catching.