### PR TITLE
Properties, datums, collateral

### DIFF
--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -327,9 +327,17 @@
 \newcommand{\nonnegReals}{\ensuremath{[0,~\infty)}}
 \newcommand{\posReals}{\ensuremath{(0,~\infty)}}
 
+\newcommand{\Val}{\fun{Val}}
+\newcommand{\Utxo}{\fun{Utxo}}
+\newcommand{\field}{\fun{field}}
+
+
 \theoremstyle{definition}
 \newtheorem{definition}{Definition}[section]
 \newtheorem{property}{Property}[section]
+\newtheorem{lemma}[definition]{Lemma}
+\newtheorem{theorem}[definition]{Theorem}
+\newtheorem{corollary}[definition]{Corollary}
 
 \newcommand{\leteq}{\ensuremath{\mathrel{\mathop:}=}}
 

--- a/alonzo/formal-spec/properties.tex
+++ b/alonzo/formal-spec/properties.tex
@@ -6,28 +6,219 @@ This appendix collects the main formal properties that the new ledger rules are 
 \begin{enumerate}[label=P{\arabic*}:\ ]
 \item
   \emph{Consistency with Shelley.}
-  All formal properties that were defined for Shelley in \ref{XX} remain valid.\todo{Confirm this, or list any exceptions.}
+  \begin{itemize}
+    \item properties 15.6 - 15.16 (except 15.8 and 15.13) hold specifically in the $\fun{txValTag}~tx~=~\True$ case, because
+    the calculations refer to the UTxO as if it was updated by a scripts-validating transaction
+    \item other properties hold as-is
+  \end{itemize}
+
 \item
   \emph{Consistency with Multi-Asset.}
-  All formal properties that were defined for multi-asset tokens in \ref{XX} also remain valid.\todo{Confirm this, or list any exceptions.}
-\item
-  \emph{Ada Consistency.}
-  Any token with the $\PolicyID$ of Ada is an Ada token, i.e. it
-  also has the $\AssetID$ of Ada.
-\item
-  \emph{General Accounting.}
-  The \emph{general accounting} property\todo{Reference or explain this} holds for any transaction,
-  whether it is fully processed or just paying collateral. In particular,
-  this implies that the total amount of Ada in the system is constant.
-\item
-  \emph{Fee Movement.}
+  \begin{itemize}
+    \item properties 8.1 and 8.2 hold specifically in the $\fun{txValTag}~tx~=~\True$ case, because
+    the calculations refer to the UTxO as if it was updated by a scripts-validating transaction
+    \item other properties hold as-is
+  \end{itemize}
+\end{enumerate}
+
+
+\begin{definition}
+  For a state $s$ that is used in any subtransaction of
+  $\mathsf{CHAIN}$, we define $\Utxo(s) \in \UTxO$ to be the $\UTxO$
+  contained in $s$, or an empty map if it does not exist. This is
+  similar to the definition of $\Val$ in the Shelley specification.
+
+  Similarly, we also define $\field_{v}~(s)$ for the field $v$ that is part of
+  the ledger state $s$, referenced by the typical variable name (eg. $\var{fees}$
+  for the fee pot on the ledger).
+\end{definition}
+
+We also define a helper function $\varphi$ as follows:
+\[\varphi(x, tx) :=
+  \begin{cases}
+    x & \fun{txValTag}~tx = \True \\
+    0 & \fun{txValTag}~tx = \False
+  \end{cases}\]
+This function is useful to distinguish between the two
+cases where a transaction can mint tokens or not, depending on whether
+its scripts validate.
+
+\begin{property}[General Accounting]
+  \label{prop:pov}
+  The \emph{general accounting} property in Alonzo encompasses two parts
+  \begin{itemize}
+    \item preservation of value property expressed via the $\fun{produced}$ and $\fun{consumed}$
+    calculations, applicable for transactions with $\fun{txValTag}~tx~=~\True$, which
+    is specified as in the ShelleMA POV.
+    \item the preservation of value for $\fun{txValTag}~tx~=~\False$, when
+    only the collateral fees are collected into the fee pot.
+  \end{itemize}
+
+Both of these are expressed in the following lemma.
+
+\begin{lemma}
+  For all environments $e$, transactions $tx$ and states $s, s'$, if
+  \begin{equation*}
+    e\vdash s\trans{utxos}{tx}s'
+  \end{equation*}
+  then
+  \begin{equation*}
+    \Val(s) + \varphi(\fun{mint}~(\fun{txbody}~tx), tx) = \Val(s')
+  \end{equation*}
+\end{lemma}
+
+\begin{proof}
+  In the case that $\fun{txValTag}~tx = \True$ holds, the proof is
+  identical to the proof of Lemma 9.1 of the multi-asset
+  specification. Otherwise, the transition must have been done via the
+  $\mathsf{Scripts-No}$ rule, which removes
+  $\fun{collateral}~(\fun{txbody}~tx)$ from the UTxO, and increases the fee pot by the amount of the sum of Ada in the
+  collateral UTxO entries. The value contained in $s$ is not changed.
+
+  Note that in the $\fun{feesOK}$ function, there is a check that verifies
+  that, in the case that there are non-native scripts, there are no non-Ada tokens in the UTxOs
+  which the collateral inputs reference, so non-Ada tokens do not get minted, burned, or transfered
+  in this case.
+\end{proof}
+\end{property}
+
+\begin{property}[No Changes Except Fees]
+  \label{prop:fees-only}
   If a transaction is accepted and marked as paying collateral only
-  (i.e. $\fun{isValidating}\, tx = \False$), then the only change to the ledger
+  (i.e. $\fun{txValTag}~tx = \False$), then the only change to the ledger
   when processing the transaction is that the collateral inputs
   are moved to the fee pot.
+
+  \begin{lemma}
+    For all environments $e$, transactions $tx$ and states $s, s'$, if $\fun{txvaltag}~tx = \False$ and
+    \begin{equation*}
+      e\vdash s\trans{ledger}{tx}s'
+    \end{equation*}
+    then
+    \begin{itemize}
+      \item $\Utxo(s') = \fun{collateral}~{tx} \subtractdom \Utxo(s)$
+      \item $\field_{fees}~(s') = \field~\var{fees}~(s) + \fun{coin}~(\Val~(\fun{collateral}~{tx} \subtractdom \Utxo(s)))$
+      \item $\field_{v}~(s') = \field_{v}~(s)$ for all $v~\neq~{fees}, ~v~\neq~{utxo}$
+    \end{itemize}
+  \end{lemma}
+
+  \begin{proof}
+  The top-level single-transaction processing transition is $\mathsf{LEDGER}$.
+   In the case that $\fun{txValTag}~tx = \False$, this transition calls the rule
+   that does not update $\DPState$ at all, only the $\UTxOState$. This state update is specified
+   in the $\mathsf{UTXOS}$ transition (and applied via the $\mathsf{UTXO}$ and $\mathsf{UTXOW}$ transitions).
+
+   The only parts of the state that are updated are the UTxO, where the collateral entries
+   are removed, and the fee pot, which is increased by the amount of the sum of Ada in the
+   collateral UTxO entries.
+  \end{proof}
+\end {property}
+
+\begin{property}[Validating when No NN Scripts]
+  \label{prop:is-valid}
+
+Whenever a valid transaction does not have any non-native scripts, its
+$\fun{txValTag} = \True$.
+
+\begin{lemma}
+  For all environments $e$, transactions $tx$ and states $s, s'$ such that
+  \begin{equation*}
+    e\vdash s\trans{ledger}{tx}s',
+  \end{equation*}
+  If $\range (\fun{txscripts}~tx) \cap \ScriptNonNative = \emptyset$
+  then $\fun{txValTag} = \True$.
+\end{lemma}
+\begin{proof}
+  With the same argument as previously, we only need to discuss the
+  equivalent claim for the $\mathsf{UTXOS}$ transition. Under these
+  assumptions, $\var{sLst} := \fun{collectTwoPhaseScriptInputs}$ is an empty
+  list. Thus $\fun{evalScripts}~sLst = \True$, and the transition rule
+  had to be $\mathsf{Scripts{-}Yes}$.
+\end{proof}
+\end{property}
+
+\begin{property}[Paying fees]
+  \label{prop:pay-fees}
+
+A transaction always pays into the fee pot.
+
+\begin{lemma}
+  For all environments $e$, transactions $tx$ and states $s, s'$ such that
+  \begin{equation*}
+    e\vdash s\trans{ledger}{tx}s',
+  \end{equation*}
+  The following holds : $\field_{fees}~(s)~<~\field_{fees}~(s')$.
+\end{lemma}
+\begin{proof}
+  The fee pot is updated by the $\mathsf{Scripts{-}Yes}$ and the $\mathsf{Scripts{-}No}$
+  rules, one of which is necessarily called by a valid transaction.
+\end{proof}
+\end{property}
+
+\begin{property}[Replay protection]
+  \label{prop:replay}
+
+A transaction always removes at least one UTxO entry from the ledger, which provides
+replay protection.
+
+\begin{lemma}
+  For all environments $e$, transactions $tx$ and states $s, s'$ such that
+  \begin{equation*}
+    e\vdash s\trans{ledger}{tx}s',
+  \end{equation*}
+  The following holds : $\Utxo~(s)~\nsubseteq~\Utxo~(s')$.
+\end{lemma}
+\begin{proof}
+  The UTxO is updated by the $\mathsf{Scripts{-}Yes}$ and the $\mathsf{Scripts{-}No}$
+  rules, on of which is necessarily called by a valid transaction. Both of these
+  rules remove UTxOs corresponding to a set of inputs.
+
+  In both cases, there is a check that the removed inputs set is non-empty.
+  The $\mathsf{Scripts{-}Yes}$ rule of the $\mathsf{UTXOS}$ transition
+  removes the UTxOs associated with the input set $\fun{txinputs}~{tx}$ from the ledger.
+  The $\fun{txinputs}~{tx}$ set must be non-empty because there is a check in the
+  $\mathsf{UTXO}$ rule (which calls $\mathsf{UTXOS}$) that ensure this is true.
+
+  For the $\mathsf{Scripts{-}No}$ rule of the $\mathsf{UTXOS}$ transition
+  removes the UTxOs associated with the input set $\fun{collateral}~{tx}$ from the ledger.
+  The $\fun{collateral}~{tx}$ set must be non-empty because
+  the $\fun{feesOK}$ function (called by the same rule that calls $\mathsf{UTXO},
+  \mathsf{UTXOS}$) ensures that in the case that the $tx$ contains non-native scripts,
+  $\fun{collateral}~{tx}$ must be non-empty.
+
+  Note that by property~\ref{prop:is-valid}, non-native scripts must always be present
+  if $\fun{txValTag}~tx = \False$ (that is, whenever $\mathsf{Scripts{-}No}$ rule is used).
+\end{proof}
+\end{property}
+
+\begin{property}[UTxO-changing transitions]
+  \label{prop:utxo-change}
+
+Only the $\mathsf{UTXOS}$ transition affects the ledger UTxO in Alonzo.
+
+\begin{lemma}
+  For all environments $e$, transitions $\mathsf{TRNS}$, transactions $tx$ and states $s, s'$ such that
+  \begin{equation*}
+    e\vdash s\trans{trns}{tx}s',
+  \end{equation*}
+  The following holds for some states $u, u'$ and environment $e'$ :
+  \begin{equation*}
+    \Utxo(s) \neq \Utxo (s')~ \Rightarrow~e'\vdash u\trans{utxos}{tx}u'~\wedge~\Utxo(s)=\Utxo (u)~\wedge~\Utxo(s')=\Utxo (u')
+  \end{equation*}
+\end{lemma}
+\begin{proof}
+  The $\mathsf{UTXOS}$ transition is the only one that updates the UTxO, but not via
+  the result of another transition, so any update from the UTxO of $s$ to that of $s'$
+  must be done by $\mathsf{UTXOS}$.
+\end{proof}
+\end{property}
+
+\begin{enumerate}
 \item
   \emph{Transaction Validation.}
-  If a Shelley transaction is accepted, it is fully processed.\todo{What does this mean? Is this: Transaction consistency - any transaction that is successfully validated can be executed successfully by the interpreter.}
+  If a Shelley transaction is accepted, it is fully processed.
+
+  What does this mean? Is this: Transaction consistency - any transaction that is successfully validated can be executed successfully by the interpreter.
 \item
   \emph{Extended UTxO Validation.}
   If a transaction extends the UTxO, all its scripts validate, and
@@ -39,21 +230,19 @@ This appendix collects the main formal properties that the new ledger rules are 
   accounting property of the Shelley ledger where the type $\Coin$ is
   replaced by $\Value$.
 \item
-  \todo{\emph{Script consistency.} Scripts are only processed by valid version of the interpreter.}
+  \emph{Script consistency.} Scripts are only processed by valid version of the interpreter.
 \item
-  \todo{\emph{Script backwards compatibility.} All scripts that could be processed by any previous version of the interpreter
-    remain valid indefinitely.}
+  \emph{Script backwards compatibility.} All scripts that could be processed by any previous version of the interpreter
+    remain valid indefinitely.
 \item
-  \todo{\emph{Cost consistency.} - no transaction exceeds the specified resource bounds.}
+  \emph{Cost consistency.} - no transaction exceeds the specified resource bounds.
 \item
   \emph{Cost Increase.} if a transaction is valid, it will remain valid if you increase the execution units
 \item
   \emph{Cost Lower Bound.} if a transaction contains at least one valid script, it must have at least one execution unit
 \item
-  \todo{\emph{Tx backwards Compatibility.} Any transaction that was accepted in a previous version of the ledger rules
-    has exactly the same cost and effect, except that the transaction output is extended.}
-\item \emph{UTxO-changing transitions.} Only the UTXOS transition affects the ledger UTxO in Alonzo.
-For Shelley/ShelleyMA, only the UTXO transition does.
+  \emph{Tx backwards Compatibility.} Any transaction that was accepted in a previous version of the ledger rules
+    has exactly the same cost and effect, except that the transaction output is extended.
 \item \emph{Run all scripts.} All scripts attached to a transaction are run
 \item \emph{Scripts are run on correct inputs.}
   A script is run for everything witnessed with a non-native script, and the script will
@@ -63,7 +252,6 @@ get all the correct inputs, which must be present.
   of script validation is not affected by these ledger state changes.
 \item \emph{Script inputs are fixed.} All data that a non-native script gets as input
 is fixed either by being signed in a transaction, or fixed by its hash living on the ledger
-\item \emph{Paying fees.} A transaction always pays into the fee pot
 \item
   ... \todo{Anything else?}
 \end{enumerate}

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -60,7 +60,8 @@ We add the following helper functions:
   \item $\fun{language}$ selects the language of a non-native script, and $\Nothing$ in case
   the script is native.
   \item $\fun{hashData}$ hashes a value of type $\Data$.
-  \item $\fun{hashWitnessPPData}$ hashes the protocol parameters and witnesses relevant to script execution.
+  \item $\fun{hashWitnessPPData}$ hashes the protocol parameters and data relevant to script execution.
+  In particular, the redeemer structure, and the datum objects.
 \end{itemize}
 
 \begin{figure*}[htb]
@@ -117,16 +118,18 @@ We add the following helper functions:
     \fun{language}& \in \Script \to \Language^?\\
     \fun{hashData}& \in \Data \to \DataHash
     \nextdef
-    \fun{hashWitnessPPData}&\in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Redeemer \times \ExUnits)\\
-    & ~~~~ \to \WitnessPPDataHash^? \\
-    \fun{hashWitnessPPData}&~{pp}~{langs}~{rdmrs}~=~ \\
-                          &\begin{cases}
-                            \Nothing & rdmrs~=~\emptyset \land langs~=~\emptyset \\
-                            \fun{hash} (rdmrs, \{ \fun{getLanguageView}~pp~l \mid l \in langs \}) & \text{otherwise}
-                          \end{cases}
-    \nextdef
     \fun{getCoin}& \in \TxOut \to \Coin \\
     \fun{getCoin}&~\hldiff{{(\_, \var{v}, \_)}} ~=~\fun{valueToCoin}~{v}
+  \end{align*}
+  %
+  \begin{align*}
+  &\fun{hashWitnessPPData} \in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Redeemer \times \ExUnits) \\
+  &~~~~ \to (\DataHash \mapsto \Datum) \to \WitnessPPDataHash^? \\
+  &\fun{hashWitnessPPData}~{pp}~{langs}~{rdmrs}~{dats}~=~ \\
+                    &~~~~ \begin{cases}
+                          \Nothing & rdmrs~=~\emptyset \land langs~=~\emptyset \land dats~=~\emptyset \\
+                          \fun{hash} (rdmrs, dats, \{ \fun{getLanguageView}~pp~l \mid l \in langs \}) & \text{otherwise}
+                        \end{cases}
   \end{align*}
   \caption{Definitions for Transactions}
   \label{fig:defs:utxo-shelley-1}
@@ -167,15 +170,6 @@ We add the following helper functions:
   %
   \begin{equation*}
     \begin{array}{r@{~~}l@{~~}l@{\qquad}l}
-      \var{ad} ~\in~ \AuxiliaryData ~=~
-      & \seqof{\Script} & \fun{scripts}& \text{Optional scripts}\\
-      & \times \hldiff{\powerset{\Datum}} & \hldiff{\fun{dats}}& \text{Optional datum objects}\\
-      & \times ~\Metadata^? & \fun{txMD}&\text{Metadata}
-    \end{array}
-  \end{equation*}
-  %
-  \begin{equation*}
-    \begin{array}{r@{~~}l@{~~}l@{\qquad}l}
       \var{tx} ~\in~ \Tx ~=~
       & \TxBody & \fun{txbody} & \text{Body}\\
       & \times ~\TxWitness & \fun{txwits} & \text{Witnesses}\\
@@ -187,10 +181,8 @@ We add the following helper functions:
   \label{fig:defs:utxo-shelley-2}
 \end{figure*}
 
-\textbf{Auxiliary Data. }
-Figure \ref{fig:defs:utxo-shelley-2} gives the Alonzo era auxiliary data found in a transaction.
-In addition to a list of scripts and a metadata object, transaction auxiliary data now
-contains a set of datum objects.
+\textbf{Auxiliary Data. } The auxiliary data in an Alonzo transaction has the same structure as
+in a ShelleMA transaction, but can additionally contain non-native scripts.
 
 \subsection{Witnessing}
 Figure \ref{fig:defs:utxo-shelley-2} defines the witness type, $\TxWitness$.  This contains everything
@@ -199,7 +191,8 @@ in a transaction that is needed for witnessing, namely:
 \begin{itemize}
   \item VKey signatures;
   \item a map of scripts indexed by their hashes, including non-native scripts;
-  \item a map of terms of type $\Datum$ indexed by their hashes, containing all required datum objects; and
+  \item a map of terms of type $\Datum$ indexed by their hashes, containing all required datum objects
+  as well as any optional ones that are posted for communication; and
   \item a map of a pair of a $\Redeemer$ object and an $\ExUnits$ value indexed by $\RdmrPtr$,
   containing the redeemers and execution units budgets.
 \end{itemize}
@@ -284,12 +277,29 @@ This is so that the signatures can ensure that this data is not tampered with.
 As before, a transaction that does not include the correct signatures is completely invalid.
 Thus, all data that influences script validation outcomes must also be determined by the body.
 
-Scripts and datum objects need not be included in the body,
-since a hash of every script that is needed
-is included in the body of the transaction or the UTxO (depending on what the script is validating),
-and the hash of every datum that is needed is recorded in the UTxO.
+Scripts and datum objects whose hashes are specified on-chain do not require to be
+signed when included in a transaction. That is, script hashes locking UTxOs (as well as
+with the datum hashes these UTxOs contain), and also the posted
+certificates, minting policies, and reward addresses do not need to be signed.
+The optional datum objects, however, could be stripped from the transaction without making
+it invalid. The optional datums are stored in the same map the required ones, so,
+for this reason, we do include all datum objects in the witness and PP hash calculation.
 %
 The hash of the indexed redeemer structure and the protocol parameters that are used by
-script interpreters are included in the body of the transaction. In the future, other parts of the ledger
+script interpreters are included in the body of the transaction, as these are composed
+by the transaction author rather than
+fixed via a hash on the ledger. In the future, other parts of the ledger
 state may also need to be included in this hash, if they are passed as
 arguments to new script interpreter.
+
+\subsection{Data required for script validation.}
+\label{sec:script-data}
+
+The body of the transaction, alongside the witness data, are required for script validation.
+Script validation should not depend on the auxiliary data in any way. Script validation
+may require certain optional datums to be posted. For this reason, we include optional
+datums in the part of the transaction (the witnesses) which scripts do see.
+Any metadata that a user wants to expose to a transaction can be included in the
+redeemer, whose purpose is to contain all user-supplied data relevant to validation.
+
+For more about what scripts do and do not inspect, see Section~\ref{sec:txinfo}.

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -21,9 +21,10 @@
     &~~~~~~((\forall (a, \wcard, \_) \in \fun{range}~(\fun{collateral}~{txb} \restrictdom \var{utxo}), \fun{paymentHK}~a \in \AddrVKey) \\
     &~~~~~~\wedge~ \fun{adaOnly}~\var{balance} \\
     &~~~~~~\wedge~ \var{balance} \geq \fun{quot}~(\txfee~{txb} * (\fun{collateralPercent}~pp))~100)) \\
+    &~~~~~~\fun{collateral}~{tx}~ \neq~\{\} \\
     &~~      \where \\
     & ~~~~~~~ \var{txb}~=~\txbody{tx} \\
-    & ~~~~~~~ \var{balance}~=~\fun{ubalance}~(\fun{collateral}~{txb} \restrictdom \var{utxo})
+    & ~~~~~~~ \var{balance}~=~\fun{ubalance}~(\fun{collateral}~{txb} \restrictdom \var{utxo}) \\
     \nextdef
     & \fun{txscriptfee} \in \Prices \to \ExUnits \to \Coin \\
     & \fun{txscriptfee}~(pr_{mem}, pr_{steps})~ (\var{mem, steps})
@@ -55,6 +56,7 @@ We have added or changed several functions that deal with fees and collateral as
     \item all the collateral inputs refer to UTxOs containing Ada only and no other kinds of token; and
     \item the collateral provided is sufficient to cover the percentage of the
     transaction fee amount specified by the protocol parameter $\fun{collateralPercent}$
+    \item the set of collateral inputs is non-empty
   \end{enumerate}
   Note that checking that a transaction is carrying redeemers is the most simple way to
   check that it is carrying non-native scripts. A separate check is done in the rule prior to
@@ -760,6 +762,9 @@ additional ones;
     the datum hash fields of such UTxOs are $\Nothing$, as $\Nothing$ is not a
     hash of a datum (and therefore is not a key of the $\DataHash$-indexed map).
 
+    This check is a subset equality check, rather than an equality check, because optional datum objects
+    can be added to the datum map for the purpose of posting them on chain for communication;
+
     \item For every item that needs to be validated by a non-native script, the transaction contains
       an entry in the indexed redeemer structure (ie. the execution units and redeemer for it are specified);
 
@@ -768,8 +773,9 @@ additional ones;
     have all indeed signed it;
 
     \item
-    The hash of the subset of protocol parameter values that have been included in the transaction body is the same as
-    the hash of the same subset of protocol parameters that are currently contained in the ledger;
+    The hash of the subset of protocol parameter values and witnessing data that have been included in the
+    transaction body is the same as
+    the hash of the witness data and the subset of protocol parameters that are currently contained in the ledger;
 
     \item A check that ensures that the list of scripts paired with their input data (context, datum and redeemer)
     has the same number of elements as the set of scripts needed for each script purpose. Note that the same
@@ -810,9 +816,9 @@ by the UTXO transition (the application of which is also part of the conditions)
       \dom (\txwitsVKey{txw}) \}\\~\\
       \hldiff{\forall \var{s} \in \range (\fun{txscripts}~{txw}) \cap \ScriptNative,
       \fun{runNativeScript}~\var{s}~\var{tx}}\\~\\
-      \hldiff{\{ s \mid (\_, s) \in \fun{scriptsNeeded}~\var{utxo}~\var{tx}\} = \dom (\fun{txscripts}~{txw})} \\
-      \hldiff{\{ h \mid (\_ \mapsto (a, \_, h)) \in \txins{txb} \restrictdom \var{utxo}, \fun{isNonNativeScriptAddress}~{tx}~{a}\} =} \\
-      \hldiff{\dom (\fun{txdats}~{txw})} \\
+      \hldiff{\{ s \mid (\_, s) \in \fun{scriptsNeeded}~\var{utxo}~\var{tx}\} = \dom (\fun{txscripts}~{txw})} \\~\\
+      \hldiff{\{ h \mid (\_ \mapsto (a, \_, h)) \in \txins{txb} \restrictdom \var{utxo}, \fun{isNonNativeScriptAddress}~{tx}~{a}\} } \\
+      \hldiff{\subseteq \dom (\fun{txdats}~{txw})} \\~\\
       \hldiff{\forall sph \in \fun{scriptsNeeded}~\var{utxo}~\var{tx},~ \fun{checkScriptData}~tx~utxo~sph}
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{txw},
@@ -839,7 +845,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \lor
       (\var{adh}=\fun{hashAD}~\var{ad})
       \\~\\
-      \hldiff{\fun{wppHash}~{txb}~=~\fun{hashWitnessPPData}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})}
+      \hldiff{\fun{wppHash}~{txb}~=~\fun{hashWitnessPPData}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})~(\fun{txdats}~{txw})}
       \\~\\
       \hldiff{\|~\fun{scriptsNeeded}~\var{utxo}~\var{tx}~\|~=~\|~\fun{collectTwoPhaseScriptInputs} ~\var{pp}~\var{tx}~ \var{utxo}~\|}
       \\~\\


### PR DESCRIPTION
- match the collaterals-non-empty check in https://github.com/input-output-hk/cardano-ledger-specs/pull/2302
- combine optional datums (remove from aux data) with the required ones (and add this structure to the integrity hash computation)
- prove some properties in the properties section, add the existing proofs in it's in 
https://github.com/input-output-hk/cardano-ledger-specs/tree/andre/alonzo-spec-properties

Question:
Of the properties left to prove in the list at the bottom of properties.tex, what ones should I prove, and what ones are redundant/weird/non-formalizable/ok to remove?