### PR TITLE
Fix mempool

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -34,7 +34,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Bbody as Alonzo (AlonzoBBODY)
 import qualified Cardano.Ledger.Alonzo.Rules.Ledger as Alonzo (AlonzoLEDGER)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (UtxosFailure))
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
-import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS, constructValidated)
+import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS, constructValidated, lbl2Phase)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail (WrappedShelleyEraFailure))
 import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
@@ -51,7 +51,10 @@ import qualified Cardano.Ledger.Crypto as CC
 import qualified Cardano.Ledger.Era as EraModule
 import Cardano.Ledger.Keys (GenDelegs (GenDelegs))
 import qualified Cardano.Ledger.Mary.Value as V (Value)
-import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
+import Cardano.Ledger.Rules.ValidationMode
+  ( applySTSNonStatic,
+    applySTSValidateSuchThat,
+  )
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley (nativeMultiSigTag)
 import Cardano.Ledger.Shelley.Constraints
@@ -66,7 +69,7 @@ import Control.Arrow (left)
 import Control.Monad (join)
 import Control.Monad.Except (liftEither, runExcept)
 import Control.Monad.Reader (runReader)
-import Control.State.Transition.Extended (TRC (TRC), applySTS)
+import Control.State.Transition.Extended (TRC (TRC))
 import Data.Default (def)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
@@ -122,12 +125,17 @@ instance API.PraosCrypto c => API.ApplyTx (AlonzoEra c) where
             )
           . runExcept
           $ Alonzo.constructValidated globals utxoenv utxostate tx
+      -- Note here that we exclude checks of 2-phase validation, since we have
+      -- just constructed our own validating flag and can hence trust it! Other
+      -- static checks must be run, however, since we haven't computed them
+      -- before.
       state' <-
         liftEither
           . left (API.ApplyTxError . join)
           . flip runReader globals
-          . applySTS
+          . applySTSValidateSuchThat
             @(Core.EraRule "LEDGER" (AlonzoEra c))
+            (notElem Alonzo.lbl2Phase)
           $ TRC (env, st, vtx)
       pure (state', vtx)
     where

--- a/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -15,6 +15,7 @@ module Cardano.Ledger.Rules.ValidationMode
     (?!#:),
     failBecauseS,
     applySTSNonStatic,
+    applySTSValidateSuchThat,
   )
 where
 


### PR DESCRIPTION
Previously `constructValidated` was validating a Tx according to `UTXOS`
semantics. Unfortunately, `UTXOS` is not at the top of the Tx validation
hierarchy, which means that checks in `LEDGER`, `UTXO` and `UTXOW` were
being ignored. Whoops. This allowed unusual things like repeated
transactions being allowed. Subsequently transactions were being
rejected when included in the block and kicked out of the mempool
without taking effect.

This commit changes 'constructValidated' to only set the `IsValidating`
flag, and updates the Mempool API to run this validated Tx through the
full `LEDGER` rule.