### PR TITLE
Move plutus data from aux data into witnesses

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -22,7 +22,7 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), getPlutusData)
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..))
 import Cardano.Ledger.Alonzo.Genesis
 import Cardano.Ledger.Alonzo.PParams
   ( PParams,
@@ -40,7 +40,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
 import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..))
 import Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut (..))
-import Cardano.Ledger.Alonzo.TxInfo (validPlutusdata, validScript)
+import Cardano.Ledger.Alonzo.TxInfo (validScript)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -221,10 +221,9 @@ instance (CC.Crypto c) => UsesPParams (AlonzoEra c) where
 
 instance CC.Crypto c => ValidateAuxiliaryData (AlonzoEra c) c where
   hashAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)
-  validateAuxiliaryData (AuxiliaryData metadata scrips plutusdata) =
+  validateAuxiliaryData (AuxiliaryData metadata scrips) =
     all validMetadatum metadata
       && all validScript scrips
-      && all (validPlutusdata . getPlutusData) plutusdata
 
 instance CC.Crypto c => EraModule.SupportsSegWit (AlonzoEra c) where
   type TxSeq (AlonzoEra c) = Alonzo.TxSeq (AlonzoEra c)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Alonzo.Tx
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody (..), TxOut (..), vldt')
 import Cardano.Ledger.Alonzo.TxInfo (runPLCScript, txInfo, valContext)
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), txscripts')
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), txscripts', unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
@@ -99,7 +99,7 @@ getData tx (UTxO m) sp = case sp of
         case getField @"datahash" txout of
           SNothing -> []
           SJust hash ->
-            case Map.lookup hash (txdats' (getField @"wits" tx)) of
+            case Map.lookup hash (unTxDats $ txdats' (getField @"wits" tx)) of
               Nothing -> []
               Just d -> [d]
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.Alonzo.TxBody
     wdrls',
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody (..), TxOut (..))
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness, unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core as Core (TxBody, TxOut, Value)
@@ -316,7 +316,7 @@ txInfo ei sysS utxo tx =
     fee = txfee' tbody
     forge = mint' tbody
     interval = vldt' tbody
-    datpairs = Map.toList (txdats' _witnesses)
+    datpairs = Map.toList (unTxDats $ txdats' _witnesses)
 
 -- ===============================================================
 -- From the specification, Figure 7 "Script Validation, cont."

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -26,6 +26,7 @@ module Cardano.Ledger.Alonzo.TxWitness
       ),
     unRedeemers,
     nullRedeemers,
+    TxDats (TxDats, TxDats'),
     TxWitness
       ( TxWitness,
         txwitsVKey,
@@ -42,6 +43,8 @@ module Cardano.Ledger.Alonzo.TxWitness
       ),
     ppRdmrPtr,
     ppTxWitness,
+    unTxDats,
+    nullDats,
   )
 where
 
@@ -116,7 +119,7 @@ newtype RedeemersRaw era = RedeemersRaw (Map RdmrPtr (Data era, ExUnits))
   deriving newtype (NoThunks)
 
 newtype Redeemers era = RedeemersConstr (MemoBytes (RedeemersRaw era))
-  deriving newtype (Eq, Show, ToCBOR, NoThunks, Typeable)
+  deriving newtype (Eq, Show, ToCBOR, NoThunks, SafeToHash, Typeable)
 
 -- =====================================================
 -- Pattern for Redeemers
@@ -168,7 +171,7 @@ nullRedeemers = Map.null . unRedeemers
 --      (Set (WitVKey 'Witness (Crypto era)))
 --      (Set (BootstrapWitness (Crypto era)))
 --      (Map (ScriptHash (Crypto era)) (Core.Script era))
---      (Map (DataHash (Crypto era)) (Data era))
+--      (TxDats era)
 --      (Map RdmrPtr (Data era, ExUnits))
 
 -- | Internal 'TxWitness' type, lacking serialised bytes.
@@ -176,7 +179,7 @@ data TxWitnessRaw era = TxWitnessRaw
   { _txwitsVKey :: Set (WitVKey 'Witness (Crypto era)),
     _txwitsBoot :: Set (BootstrapWitness (Crypto era)),
     _txscripts :: Map (ScriptHash (Crypto era)) (Core.Script era),
-    _txdats :: Map (DataHash (Crypto era)) (Data era),
+    _txdats :: TxDats era,
     _txrdmrs :: Redeemers era
   }
   deriving (Generic, Typeable)
@@ -186,10 +189,10 @@ newtype TxWitness era = TxWitnessConstr (MemoBytes (TxWitnessRaw era))
 
 instance (Era era, Core.Script era ~ Script era) => Semigroup (TxWitness era) where
   (<>) (TxWitnessConstr (Memo (TxWitnessRaw a b c d (Redeemers' e)) _)) y
-    | (Set.null a && Set.null b && Map.null c && Map.null d && Map.null e) =
+    | (Set.null a && Set.null b && Map.null c && nullDats d && Map.null e) =
       y
   (<>) y (TxWitnessConstr (Memo (TxWitnessRaw a b c d (Redeemers' e)) _))
-    | (Set.null a && Set.null b && Map.null c && Map.null d && Map.null e) =
+    | (Set.null a && Set.null b && Map.null c && nullDats d && Map.null e) =
       y
   (<>)
     (TxWitnessConstr (Memo (TxWitnessRaw a b c d (Redeemers' e)) _))
@@ -198,6 +201,55 @@ instance (Era era, Core.Script era ~ Script era) => Semigroup (TxWitness era) wh
 
 instance (Era era, Core.Script era ~ Script era) => Monoid (TxWitness era) where
   mempty = TxWitness mempty mempty mempty mempty (Redeemers mempty)
+
+-- =====================================================
+newtype TxDatsRaw era = TxDatsRaw (Map (DataHash (Crypto era)) (Data era))
+  deriving (Generic, Typeable, Eq, Show)
+  deriving newtype (NoThunks)
+
+encodeTxDatsRaw ::
+  ToCBOR (Data era) =>
+  TxDatsRaw era ->
+  Encode ('Closed 'Dense) (TxDatsRaw era)
+encodeTxDatsRaw t = E (encodeFoldable . Map.elems . unTxDatsRaw) t
+  where
+    unTxDatsRaw (TxDatsRaw m) = m
+
+pattern TxDats' :: Map (DataHash (Crypto era)) (Data era) -> TxDats era
+pattern TxDats' m <- TxDatsConstr (Memo (TxDatsRaw m) _)
+
+{-# COMPLETE TxDats' #-}
+
+pattern TxDats :: Typeable era => Map (DataHash (Crypto era)) (Data era) -> TxDats era
+pattern TxDats m <-
+  TxDatsConstr (Memo (TxDatsRaw m) _)
+  where
+    TxDats m = TxDatsConstr $ memoBytes (encodeTxDatsRaw (TxDatsRaw m))
+
+{-# COMPLETE TxDats #-}
+
+unTxDats :: TxDats era -> Map (DataHash (Crypto era)) (Data era)
+unTxDats (TxDats' m) = m
+
+nullDats :: TxDats era -> Bool
+nullDats (TxDats' d) = Map.null d
+
+instance (Typeable era, Era era) => FromCBOR (Annotator (TxDatsRaw era)) where
+  fromCBOR = decode $ fmap (TxDatsRaw . keyBy hashData) <$> listDecodeA From
+
+newtype TxDats era = TxDatsConstr (MemoBytes (TxDatsRaw era))
+  deriving newtype (SafeToHash, ToCBOR, Eq, Show, NoThunks)
+
+instance Typeable era => Semigroup (TxDats era) where
+  (TxDats m) <> (TxDats m') = TxDats (m <> m')
+
+instance Typeable era => Monoid (TxDats era) where
+  mempty = TxDats mempty
+
+deriving via
+  (Mem (TxDatsRaw era))
+  instance
+    (Era era) => FromCBOR (Annotator (TxDats era))
 
 -- =====================================================
 -- TxWitness instances
@@ -231,7 +283,7 @@ pattern TxWitness' ::
   Set (WitVKey 'Witness (Crypto era)) ->
   Set (BootstrapWitness (Crypto era)) ->
   Map (ScriptHash (Crypto era)) (Core.Script era) ->
-  Map (DataHash (Crypto era)) (Data era) ->
+  TxDats era ->
   Redeemers era ->
   TxWitness era
 pattern TxWitness' {txwitsVKey', txwitsBoot', txscripts', txdats', txrdmrs'} <-
@@ -245,7 +297,7 @@ pattern TxWitness ::
   Set (WitVKey 'Witness (Crypto era)) ->
   Set (BootstrapWitness (Crypto era)) ->
   Map (ScriptHash (Crypto era)) (Core.Script era) ->
-  Map (DataHash (Crypto era)) (Data era) ->
+  TxDats era ->
   Redeemers era ->
   TxWitness era
 pattern TxWitness {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs} <-
@@ -269,10 +321,7 @@ instance
   where
   getField (TxWitnessConstr (Memo (TxWitnessRaw _ _ s _ _) _)) = s
 
-instance
-  (Crypto era ~ crypto) =>
-  HasField "txdats" (TxWitness era) (Map (DataHash crypto) (Data era))
-  where
+instance HasField "txdats" (TxWitness era) (TxDats era) where
   getField (TxWitnessConstr (Memo (TxWitnessRaw _ _ _ d _) _)) = d
 
 instance HasField "txrdmrs" (TxWitness era) (Redeemers era) where
@@ -295,11 +344,11 @@ instance
 --------------------------------------------------------------------------------
 
 encodeWitnessRaw ::
-  (Era era, Core.Script era ~ Script era, ToCBOR (Data era)) =>
+  (Era era, Core.Script era ~ Script era) =>
   Set (WitVKey 'Witness (Crypto era)) ->
   Set (BootstrapWitness (Crypto era)) ->
   Map (ScriptHash (Crypto era)) (Core.Script era) ->
-  Map (DataHash (Crypto era)) (Data era) ->
+  TxDats era ->
   Redeemers era ->
   Encode ('Closed 'Sparse) (TxWitnessRaw era)
 encodeWitnessRaw vkeys boots scripts dats rdmrs =
@@ -313,7 +362,7 @@ encodeWitnessRaw vkeys boots scripts dats rdmrs =
     !> Omit
       null
       (Key 3 $ E (encodeFoldable . mapMaybe unwrapPS . Map.elems) plutusScripts)
-    !> Omit null (Key 4 $ E (encodeFoldable . Map.elems) dats)
+    !> Omit nullDats (Key 4 $ E toCBOR dats)
     !> Omit nullRedeemers (Key 5 $ To rdmrs)
   where
     unwrapTS (TimelockScript x) = Just x
@@ -386,7 +435,7 @@ instance
       txWitnessField 4 =
         fieldAA
           (\x wits -> wits {_txdats = x})
-          (fmap (keyBy hashData) <$> listDecodeA From)
+          From
       txWitnessField 5 = fieldAA (\x wits -> wits {_txrdmrs = x}) From
       txWitnessField n = field (\_ t -> t) (Invalid n)
 
@@ -400,8 +449,8 @@ instance
         Map (ScriptHash (Crypto e)) (Core.Script e)
       getKeys _ = keyBy (hashScript @e)
 
-      keyBy :: forall a b. Ord b => (a -> b) -> [a] -> Map b a
-      keyBy f xs = Map.fromList $ (\x -> (f x, x)) <$> xs
+keyBy :: forall a b. Ord b => (a -> b) -> [a] -> Map b a
+keyBy f xs = Map.fromList $ (\x -> (f x, x)) <$> xs
 
 deriving via
   (Mem (TxWitnessRaw era))
@@ -427,7 +476,7 @@ ppTxWitness (TxWitnessConstr (Memo (TxWitnessRaw vk wb sc da (Redeemers rd)) _))
     [ ("txwitsVKey", ppSet ppWitVKey vk),
       ("txwitsBoot", ppSet ppBootstrapWitness wb),
       ("txscripts", ppMap ppScriptHash prettyA sc),
-      ("txdats", ppMap ppSafeHash ppData da),
+      ("txdats", ppMap ppSafeHash ppData (unTxDats da)),
       ("txrdmrs", ppMap ppRdmrPtr (ppPair ppData ppExUnits) rd)
     ]
 

--- a/alonzo/test/cddl-files/alonzo.cddl
+++ b/alonzo/test/cddl-files/alonzo.cddl
@@ -278,7 +278,6 @@ auxiliary_data =
   / #6.259({ ? 0 => metadata         ; Alonzo and future ; New
       , ? 1 => [ * native_script ]
       , ? 2 => [ * plutus_script ]
-      , ? 3 => [ * plutus_data ]
       })
 
 

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -12,7 +12,7 @@ module Test.Cardano.Ledger.Alonzo.AlonzoEraGen where
 
 import Cardano.Binary (serializeEncoding', toCBOR)
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data as Alonzo (AuxiliaryData (..), Data (..))
+import Cardano.Ledger.Alonzo.Data as Alonzo (AuxiliaryData (..))
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
 import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo (PParams, extendPP, retractPP)
@@ -20,7 +20,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (utxoEntrySize)
 import Cardano.Ledger.Alonzo.Scripts as Alonzo (CostModel (..), ExUnits (..), Prices (..), Script (..))
 import Cardano.Ledger.Alonzo.Tx (IsValidating (..), ValidatedTx (..))
 import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..))
-import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxWitness (..))
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxDats (..), TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
@@ -96,7 +96,6 @@ genAux constants =
           <$> ( Alonzo.AuxiliaryData
                   <$> pure x
                   <*> pure (TimelockScript <$> y)
-                  <*> genSet (Alonzo.Data <$> genPlutusData)
               )
 
 instance CC.Crypto c => ScriptClass (AlonzoEra c) where
@@ -210,7 +209,7 @@ instance Mock c => EraGen (AlonzoEra c) where
       new = txb {inputs = txin, txfee = coinx, outputs = txout}
   genEraPParamsDelta = genAlonzoPParamsDelta
   genEraPParams = genAlonzoPParams
-  genEraWitnesses setWitVKey mapScriptWit = TxWitness setWitVKey Set.empty mapScriptWit Map.empty (Redeemers Map.empty)
+  genEraWitnesses setWitVKey mapScriptWit = TxWitness setWitVKey Set.empty mapScriptWit (TxDats Map.empty) (Redeemers Map.empty)
   unsafeApplyTx (Tx bod wit auxdata) = ValidatedTx bod wit (IsValidating True) auxdata
 
 instance Mock c => MinGenTxout (AlonzoEra c) where

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -78,7 +78,7 @@ instance
   ) =>
   Arbitrary (AuxiliaryData era)
   where
-  arbitrary = AuxiliaryData <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = AuxiliaryData <$> arbitrary <*> arbitrary
 
 instance Arbitrary Tag where
   arbitrary = elements [Spend, Mint, Cert, Rewrd]
@@ -123,8 +123,8 @@ genScripts ::
   Gen (Map (ScriptHash (Crypto era)) (Core.Script era))
 genScripts = keyBy (hashScript @era) <$> (arbitrary :: Gen [Core.Script era])
 
-genData :: forall era. Era era => Gen (Map (DataHash (Crypto era)) (Data era))
-genData = keyBy hashData <$> arbitrary
+genData :: forall era. Era era => Gen (TxDats era)
+genData = TxDats <$> keyBy hashData <$> arbitrary
 
 instance HasAlgorithm c => Arbitrary (SafeHash c i) where
   arbitrary = unsafeMakeSafeHash <$> arbitrary
@@ -290,7 +290,7 @@ instance Mock c => Arbitrary (AlonzoPredFail (AlonzoEra c)) where
     oneof
       [ WrappedShelleyEraFailure <$> arbitrary,
         UnRedeemableScripts <$> arbitrary,
-        DataHashSetsDontAgree <$> arbitrary <*> arbitrary,
+        MissingRequiredDatums <$> arbitrary,
         PPViewHashesDontMatch <$> arbitrary <*> arbitrary
       ]
 
@@ -307,4 +307,5 @@ instance Mock c => Arbitrary (WitnessPPData (AlonzoEra c)) where
   arbitrary =
     WitnessPPData
       <$> arbitrary
+      <*> genData
       <*> (Set.singleton <$> (getLanguageView <$> arbitrary <*> arbitrary))

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -13,7 +13,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
 import Cardano.Ledger.Alonzo.Scripts (Script)
-import Cardano.Ledger.Alonzo.Tx (CostModel, WitnessPPData)
+import Cardano.Ledger.Alonzo.Tx (CostModel)
 import Cardano.Ledger.Alonzo.TxBody (TxBody)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Tx as LTX
@@ -108,8 +108,6 @@ tests =
         tripping @(UtxosPredicateFailure (AlonzoEra C_Crypto)),
       testProperty "Script" $
         trippingAnn @(Script (AlonzoEra C_Crypto)),
-      testProperty "WitnessPPData" $
-        trippingAnn @(WitnessPPData (AlonzoEra C_Crypto)),
       testProperty "alonzo/Tx" $
         trippingAnn @(LTX.Tx (AlonzoEra C_Crypto)),
       testProperty "alonzo/Block" $


### PR DESCRIPTION
- Get rid of plutus data from auxiliary data.
- Introduce TxDats type to preserve the bytes of the txdats witness
  field. This field now has type TxDats.
- Use TxDats in calculation of WitnessPPData.
- Get rid of MemoBytes in WitnessPPData.
- Replace DataSetsDontAgree error with MissingRequiredDatums error.