### PR TITLE
Export 'checkLeaderValue' from API.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -31,6 +31,8 @@ module Shelley.Spec.Ledger.API.Protocol
     updateChainDepState,
     reupdateChainDepState,
     initialChainDepState,
+    -- Re-exports
+    checkLeaderValue,
   )
 where
 
@@ -86,6 +88,7 @@ import Shelley.Spec.Ledger.BlockChain
     BHeader,
     bhbody,
     bheaderPrev,
+    checkLeaderValue,
     prevHashToNonce,
   )
 import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)


### PR DESCRIPTION
This can then be used downstream to test for future slot ownership.