### PR TITLE
Adjust the CBOR decoder for Rational to match CDDL

### DIFF
--- a/cardano-ledger-core/src/Cardano/Ledger/Serialization.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Serialization.hs
@@ -62,9 +62,9 @@ import Cardano.Binary
     FromCBOR (..),
     Size,
     ToCBOR (..),
-    decodeInt64,
     decodeListLenOrIndef,
     decodeTag,
+    decodeWord64,
     encodeListLen,
     encodeTag,
     withWordSize,
@@ -203,9 +203,10 @@ ratioToCBOR r =
 ratioFromCBOR :: (Bounded a, Integral a, FromCBOR a) => Decoder s (Ratio a)
 ratioFromCBOR = decodeFraction fromCBOR
 
+-- | Decode a non-negative rational with a bounded representation.
 rationalFromCBOR :: Decoder s Rational
 rationalFromCBOR = do
-  x <- decodeFraction decodeInt64
+  x <- decodeFraction decodeWord64
   pure $ fromIntegral (numerator x) % fromIntegral (denominator x)
 
 decodeFraction :: Integral a => Decoder s a -> Decoder s (Ratio a)


### PR DESCRIPTION
We use UnitInterval for several protocol params, but Rational for a_0
since it can be above 1.

For UnitInterval we use Ratio Word64 so that we stick to a bounded size
for the external representation.

For Rational we need to stick to a bounded external representation too,
and things are simpler if we use exactly the same one as for
UnitInterval. This is also the representation specified in the CDDL.

rational = #6.30([uint, uint])

This inconsistency was found by the generators and CBOR round trip tests
for the API package. It was using a Word64 ratio based generator for all
the Rational parameters. This failed for the a_0 param, since it only
accepts Int64 range. The a_0 param is not signed, so it does not need
signed integer support.

The name is now a bit of a misnoymer however. It might be better to make
a newtype wrapper for the a_0 param.