### PR TITLE
Add getUTxOSubset to the exported API

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -14,6 +14,7 @@ module Shelley.Spec.Ledger.API.Wallet
     getUTxOSubset,
     getFilteredUTxO,
     getLeaderSchedule,
+    getPools,
     getPoolParameters,
     getTotalStake,
     poolsByTotalStakeFraction,
@@ -279,12 +280,26 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
     epochSlots = Set.fromList [a .. b]
     (a, b) = runIdentity $ epochInfoRange ei currentEpoch
 
--- | Get the registered stake pool parameters for a given ID.
+-- | Get the /current/ registered stake pool parameters for a given set of
+-- stake pools. The result map will contain entries for all the given stake
+-- pools that are currently registered.
+--
+getPools ::
+  NewEpochState era ->
+  Set (KeyHash 'StakePool (Crypto era))
+getPools = Map.keysSet . f
+  where
+    f = _pParams . _pstate . _delegationState . esLState . nesEs
+
+-- | Get the /current/ registered stake pool parameters for a given set of
+-- stake pools. The result map will contain entries for all the given stake
+-- pools that are currently registered.
+--
 getPoolParameters ::
   NewEpochState era ->
-  KeyHash 'StakePool (Crypto era) ->
-  Maybe (PoolParams (Crypto era))
-getPoolParameters nes poolId = Map.lookup poolId (f nes)
+  Set (KeyHash 'StakePool (Crypto era)) ->
+  Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era))
+getPoolParameters = Map.restrictKeys . f
   where
     f = _pParams . _pstate . _delegationState . esLState . nesEs
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -11,6 +11,7 @@
 module Shelley.Spec.Ledger.API.Wallet
   ( getNonMyopicMemberRewards,
     getUTxO,
+    getUTxOSubset,
     getFilteredUTxO,
     getLeaderSchedule,
     getPoolParameters,
@@ -78,7 +79,7 @@ import Shelley.Spec.Ledger.Rewards
 import Shelley.Spec.Ledger.STS.NewEpoch (calculatePoolDistr)
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
 import Shelley.Spec.Ledger.Slot (epochInfoSize)
-import Shelley.Spec.Ledger.TxBody (PoolParams (..))
+import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxIn (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 -- | Get pool sizes, but in terms of total stake
@@ -235,6 +236,16 @@ getFilteredUTxO ss addrs =
     -- Instead of decompacting each address in the huge UTxO, compact each
     -- address in the small set of address.
     addrSBSs = Set.map compactAddr addrs
+
+getUTxOSubset ::
+  NewEpochState era ->
+  Set (TxIn (Crypto era)) ->
+  UTxO era
+getUTxOSubset ss txins =
+  UTxO $
+    fullUTxO `Map.restrictKeys` txins
+  where
+    UTxO fullUTxO = getUTxO ss
 
 -- | Get the (private) leader schedule for this epoch.
 --

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -283,7 +283,6 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
 -- | Get the /current/ registered stake pool parameters for a given set of
 -- stake pools. The result map will contain entries for all the given stake
 -- pools that are currently registered.
---
 getPools ::
   NewEpochState era ->
   Set (KeyHash 'StakePool (Crypto era))
@@ -294,7 +293,6 @@ getPools = Map.keysSet . f
 -- | Get the /current/ registered stake pool parameters for a given set of
 -- stake pools. The result map will contain entries for all the given stake
 -- pools that are currently registered.
---
 getPoolParameters ::
   NewEpochState era ->
   Set (KeyHash 'StakePool (Crypto era)) ->


### PR DESCRIPTION
This will be used for a new node query to get a subset of the UTxO by
TxId, which makes it an efficient query (in both time and space).

Initially this is needed for the CLI to automate tx construction, but it
is general purpose and will likely find other uses.