### PR TITLE
Shelley Spec errata and cleanup

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -786,20 +786,26 @@ mkSeed ucNonce (SlotNo slot) eNonce =
 -- | Check that the certified input natural is valid for being slot leader. This
 -- means we check that
 --
--- fromNat (certNat) < 1 - (1 - f)^σ
+-- p < 1 - (1 - f)^σ
 --
--- where fromNat creates an appropriate value in [0;1] from the certified
--- natural. The calculation is done using the following optimization:
+-- where p = certNat / certNatMax.
 --
--- let p = fromNat (certNat) and c = ln(1 - f)
+-- The calculation is done using the following optimization:
+--
+-- let q = 1 - p and c = ln(1 - f)
 --
 -- then           p < 1 - (1 - f)^σ
 -- <=>  1 / (1 - p) < exp(-σ * c)
+-- <=>  1 / q       < exp(-σ * c)
 --
--- this can be efficiently be computed by `taylorExpCmp` which returns `ABOVE`
+-- This can be efficiently be computed by `taylorExpCmp` which returns `ABOVE`
 -- in case the reference value `1 / (1 - p)` is above the exponential function
 -- at `-σ * c`, `BELOW` if it is below or `MaxReached` if it couldn't
 -- conclusively compute this within the given iteration bounds.
+--
+-- Note that  1       1               1                         certNatMax
+--           --- =  ----- = ---------------------------- = ----------------------
+--            q     1 - p    1 - (certNat / certNatMax)    (certNatMax - certNat)
 checkLeaderValue ::
   forall v.
   (VRF.VRFAlgorithm v) =>

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -642,7 +642,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:update-both}
     \inference[Update-Both]
     {
-      s < \fun{firstSlot}~((\epoch{s}) + 1) - \RandomnessStabilisationWindow
+      s < \fun{firstSlot}~((\epoch{s}) + 1) - \StabilityWindow
     }
     {
       {\begin{array}{c}
@@ -666,7 +666,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:only-evolve}
     \inference[Only-Evolve]
     {
-      s \geq \fun{firstSlot}~((\epoch{s}) + 1) - \RandomnessStabilisationWindow
+      s \geq \fun{firstSlot}~((\epoch{s}) + 1) - \StabilityWindow
     }
     {
       {\begin{array}{c}
@@ -728,12 +728,13 @@ execution of the transition role is as follows:
 
 \begin{itemize}
 \item If the current reward update \var{ru} is empty and \var{s} is greater than
-  the sum of the first slot of its epoch and the duration \StabilityWindow, then a
+  the sum of the first slot of its epoch and the duration \RandomnessStabilisationWindow, then a
   new rewards update is calculated and the state is updated.
+  (Note the errata in Section~\ref{sec:errata:stability-windows}.)
 \item If the current reward update \var{ru} is not \Nothing, i.e., a reward
   update has already been calculated but not yet applied, then the state is not updated.
 \item If the current reward update \var{ru} is empty and \var{s} is less than or equal to the sum
-  of the first slot of its epoch and the duration to start rewards \StabilityWindow,
+  of the first slot of its epoch and the duration to start rewards \RandomnessStabilisationWindow,
   then the state is not updated.
 \end{itemize}
 
@@ -741,7 +742,7 @@ execution of the transition role is as follows:
   \begin{equation}\label{eq:reward-update}
     \inference[Create-Reward-Update]
     {
-      s > \fun{firstSlot}~(\epoch{s}) + \StabilityWindow
+      s > \fun{firstSlot}~(\epoch{s}) + \RandomnessStabilisationWindow
       &
       ru = \Nothing
       \\~\\
@@ -781,7 +782,7 @@ execution of the transition role is as follows:
     {
       ru = \Nothing
       \\
-      s \leq \fun{firstSlot}~(\epoch{s}) + \StabilityWindow
+      s \leq \fun{firstSlot}~(\epoch{s}) + \RandomnessStabilisationWindow
     }
     {
       {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1450,7 +1450,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\eta =
       \begin{cases}
         1 & (\fun{d}~\var{prevPp})\geq 0.8 \\
-        \frac{blocksMade}{\floor{(\fun{d}~\var{prevPp})\cdot\var{slotsPerEpoch} \cdot \ActiveSlotCoeff}}
+        \frac{blocksMade}{\floor{(1-\fun{d}~\var{prevPp})\cdot\var{slotsPerEpoch} \cdot \ActiveSlotCoeff}}
           & \text{otherwise} \\
       \end{cases} \\
     & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r_1 \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -17,8 +17,6 @@
 \newcommand{\obligation}[3]{\fun{obligation}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\reward}[8]{\fun{reward}
   ~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}~ \var{#6}~ \var{#7}~ \var{#8}}
-\newcommand{\rewardOnePool}[9]{\fun{rewardOnePool}
-  ~\var{#1}~\var{#2}~\var{#3}~\var{#4}~\var{#5}~\var{#6}~\var{#7}~\var{#8}~\var{#9}}
 \newcommand{\isActive}[4]{\fun{isActive}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\activeStake}[5]{\fun{activeStake}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}}
 \newcommand{\poolRefunds}[2]{\fun{poolRefunds}~ \var{#1}~ \var{#2}}
@@ -26,7 +24,7 @@
 \newcommand{\stakeDistr}[3]{\fun{stakeDistr}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\lReward}[4]{\fun{r_{operator}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\mReward}[4]{\fun{r_{member}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
-\newcommand{\poolReward}[5]{\fun{poolReward}~\var{#1}~{#2}~\var{#3}~\var{#4}~\var{#5}}
+\newcommand{\mkApparentPerformance}[4]{\fun{mkApparentPerformance}~\var{#1}~{#2}~\var{#3}~\var{#4}}
 \newcommand{\createRUpd}[4]{\fun{createRUpd}~\var{#1}~\var{#2}~\var{#3}~\var{#4}}
 \newcommand{\getIR}[1]{\fun{getIR}~\var{#1}}
 
@@ -1068,10 +1066,10 @@ Figure~\ref{fig:functions:rewards} defines the pool reward as described in secti
       \item $\var{a_0}$, the leader-stake influence
       \item $n_{opt}$, the optimal number of saturated stake pools
     \end{itemize}
-  \item The function $\fun{poolReward}$ gives the total rewards available to be
-    distributed to the members of the given pool. It depends on the protocol parameter $d$,
-    the relative stake $\sigma$, the number $n$ of blocks the pool added to the chain and the
-    total number $\overline{N}$ of blocks added to the chain in the last epoch.
+  \item The function $\fun{mkApparentPerformance}$ computes the apparent performance of a stake pool.
+    It depends on the protocol parameter $d$, the relative stake $\sigma$, the number $n$ of blocks
+    the pool added to the chain and the total number $\overline{N}$ of blocks added to the chain in
+    the last epoch.
 
 \end{itemize}
 
@@ -1098,18 +1096,16 @@ Figure~\ref{fig:functions:rewards} defines the pool reward as described in secti
       & ~~~~~~~p'=\min(p_r,~z_0) \\
   \end{align*}
 
-  \emph{Actual Reward Function, called $\hat{f}$ in section 5.5.2 of~\cite{delegation_design}}
+  \emph{Apparent Performance, called $\hat{p}$ in section 5.5.2 of~\cite{delegation_design}}
   %
   \begin{align*}
-      & \fun{poolReward} \in \unitInterval \to \unitInterval \to \N \to \N \to \Coin \to \Coin \\
-      & \poolReward{d}{\sigma}{n}{\overline{N}}{f} =
-      \floor*{\overline{p}\cdot\var{f}}\\
-      & ~~~\where \\
-      & ~~~~~~~\overline{p} =
+      & \fun{mkApparentPerformance} \in \unitInterval \to \unitInterval \to \N \to \N \to \Q \\
+      & \mkApparentPerformance{d}{\sigma}{n}{\overline{N}} =
         \begin{cases}
           \frac{\beta}{\sigma} & \text{if } d < 0.8 \\
           1 & \text{otherwise}
         \end{cases} \\
+      & ~~~\where \\
       & ~~~~~~~\beta = \frac{n}{\max(1, \overline{N})} \\
   \end{align*}
   \caption{Functions used in the Reward Calculation}
@@ -1205,17 +1201,15 @@ The calculation is done pool-by-pool.
   %
   \begin{align*}
     & \fun{rewardOnePool} \in \PParams \to \Coin \to \N \to \N \to \KeyHash \to \PoolParam\\
-      & ~~~\to \Stake \to \Coin \to \powerset{\AddrRWD}
+      & ~~~\to \Stake \to \Q \to \Q \to \Coin \to \powerset{\AddrRWD}
            \to (\AddrRWD \mapsto \Coin) \\
-      & \rewardOnePool{pp}{R}{n}{\overline{N}}{poolHK}{pool}{stake}{tot}{addrs_{rew}} =
+      & \fun{rewardOnePool}~\var{pp}~\var{R}~\var{n}~\var{\overline{N}}~\var{poolHK}~\var{pool}~\var{stake}~{\sigma}~{\sigma_a}~\var{tot}~\var{addrs_{rew}} =
           \var{rewards}\\
       & ~~~\where \\
-      & ~~~~~~~\var{pstake} = \sum_{\_\mapsto c\in\var{stake}} c \\
       & ~~~~~~~\var{ostake} = \sum_{\substack{
         hk_\mapsto c\in\var{stake}\\
         hk\in(\fun{poolOwners}~\var{pool})\\
         }} c \\
-      & ~~~~~~~\sigma = \var{pstake} / tot \\
       & ~~~~~~~\var{pledge} = \fun{poolPledge}~pool \\
       & ~~~~~~~p_{r} = \var{pledge} / \var{tot} \\
       & ~~~~~~~maxP =
@@ -1224,12 +1218,14 @@ The calculation is done pool-by-pool.
         \var{pledge} \leq \var{ostake}\\
         0 & \text{otherwise.}
       \end{cases} \\
-      & ~~~~~~~\var{poolR} = \poolReward{(\fun{d}~pp)}{\sigma}{n}{\overline{N}}{maxP} \\
-      & ~~~~~~~\var{mRewards} = \left\{
-                                  \addrRw~hk\mapsto\mReward{poolR}{pool}{\frac{c}{tot}}{\sigma}
-                                  ~\Big\vert~
-                                  hk\mapsto c\in\var{stake},~~hk \neq\var{poolHK}
-                               \right\}\\
+      & ~~~~~~~\var{appPerf} = \mkApparentPerformance{(\fun{d}~pp)}{\sigma}{n}{\overline{N}} \\
+      & ~~~~~~~\var{poolR} = \floor{\var{appPerf}\cdot\var{maxP}} \\
+      & ~~~~~~~\var{mRewards} = \\
+      & ~~~~~~~~~~\left\{
+                    \addrRw~hk\mapsto\mReward{poolR}{pool}{\frac{c}{tot}}{\sigma}
+                    ~\Big\vert~
+                    hk\mapsto c\in\var{stake},~~hk \not\in(\fun{poolOwners}~\var{pool})
+                  \right\}\\
       & ~~~~~~~\var{lReward} = \lReward{poolR}{pool}{\frac{\var{ostake}}{tot}}{\sigma} \\
       & ~~~~~~~\var{potentialRewards} =
                  \var{mRewards} \cup
@@ -1247,7 +1243,7 @@ The calculation is done pool-by-pool.
       & \reward{pp}{blocks}{R}{addrs_{rew}}{poolParams}{stake}{delegs}{total}
           = \var{rewards}\\
       & ~~~\where \\
-      & ~~~~~~~tot = \sum_{\_\mapsto c\in \var{stake}}c \\
+      & ~~~~~~~\var{total}_a = \sum_{\_\mapsto c\in \var{stake}}c \\
       & ~~~~~~~\var{\overline{N}} = \sum_{\_\mapsto m\in blocks}m \\
       & ~~~~~~~pdata = \left\{
         hk\mapsto \left(p,~n,~\poolStake{hk}{delegs}{stake}\right)
@@ -1257,8 +1253,20 @@ The calculation is done pool-by-pool.
           hk & \var{n} & \var{blocks} \\
         \end{array}
       \right\} \\
-      & ~~~~~~~\var{results} = \left\{
-        hk \mapsto \rewardOnePool{pp}{R}{n}{\overline{N}}{hk}{p}{s}{tot}{addrs_{rew}}
+      & ~~~~~~~\var{results} = \\
+      & ~~~~~~~\left\{
+        hk \mapsto \fun{rewardOnePool}~
+                     \var{pp}~
+                     \var{R}~
+                     \var{n}~
+                     \var{\overline{N}}~
+                     \var{hk}~
+                     \var{p}~
+                     \var{s}~
+                     \frac{\sum s}{total}~
+                     \frac{\sum s}{\var{total}_a}~
+                     \var{tot}~
+                     \var{addrs_{rew}}
                  \mid
         hk\mapsto(p, n, s)\in\var{pdata} \right\} \\
       & ~~~~~~~\var{rewards} = \bigcup_{\wcard\mapsto\var{r}\in\var{results}}\var{r}

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -1,0 +1,18 @@
+\section{Errata}
+\label{sec:errata}
+
+We list issues found within the Shelley ledger which will be corrected in future eras.
+
+\subsection{Total stake calculation}
+
+As described in \cite[3.4.3]{delegation_design}, stake is sometimes considered
+relative to all the delegated stake, and sometimes relative to the
+totally supply less the amount held by the reserves.
+The former is called active stake, the latter total stake.
+
+
+The $\fun{createRUpd}$ function from Figure~\ref{fig:rules:reward-update} uses the
+current value of the reserve pot, named $\var{reserves}$, to calculate the total stake.
+It should, however, use the value of the reserve pot as it was during the previous
+epoch, since $\fun{createRUpd}$ is creating the rewards earned during the previous epoch
+(see the overview in Section~\ref{sec:reward-overview}).

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -85,4 +85,4 @@ to include the Byron era redeem addresses
 (those with addrtype 2, see the Byron CDDL spec).
 These addresses were, however, not spendable in the Shelley era.
 At the Allegra hard fork they were removed from the UTxO
-and the Ada contained in them was be returned to the reserves.
+and the Ada contained in them was returned to the reserves.

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -62,3 +62,13 @@ $a01b9fe136e5703668c9c7776a76cc8541b84824635d237e270670a8ca56a392$,
 and the registered addresses were reimbursed in transaction
 \newline
 $8cab8049e3b8c4802d7d11277b21afc74056223a596c39ef00e002c2d1f507ad$.
+
+\subsection{Byron redeem addresses}
+\label{sec:errata:byron-redeem-addresses}
+
+The bootstrap addresses from Figure~\ref{fig:defs:addresses} were not intended
+to include the Byron era redeem addresses
+(those with addrtype 2, see the Byron CDDL spec).
+These addresses were, however, not spendable in the Shelley era.
+At the Allegra hard fork they were removed from the UTxO
+and the Ada contained in them was be returned to the reserves.

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -4,6 +4,7 @@
 We list issues found within the Shelley ledger which will be corrected in future eras.
 
 \subsection{Total stake calculation}
+\label{sec:errata:total-stake}
 
 As described in \cite[3.4.3]{delegation_design}, stake is sometimes considered
 relative to all the delegated stake, and sometimes relative to the
@@ -16,3 +17,22 @@ current value of the reserve pot, named $\var{reserves}$, to calculate the total
 It should, however, use the value of the reserve pot as it was during the previous
 epoch, since $\fun{createRUpd}$ is creating the rewards earned during the previous epoch
 (see the overview in Section~\ref{sec:reward-overview}).
+
+\subsection{Stability Windows}
+\label{sec:errata:stability-windows}
+
+The constant $RandomnessStabilisationWindow$ was intended to be used only
+for freezing the candidate nonce in the $\mathsf{UPDN}$ rule
+from Figure~\ref{fig:rules:update-nonce}.
+This was chosen as a good value for both Ouroboros Praos and Ouroboros Genesis.
+The implementation mistakenly used the constant in the $\mathsf{RUPD}$ rule
+from Figure~\ref{fig:rules:reward-update}, and used $\StabilityWindow$
+in for the $\mathsf{UPDN}$ transition.
+
+The constant $\StabilityWindow$ is a good choice for the $\mathsf{UPDN}$
+transition while we remain using Ouroboros Praos, but it will be changed before
+adopting Ouroboros Genesis in the consensus layer.
+
+There is no problem with using $RandomnessStabilisationWindow$ for the
+$\mathsf{RUPD}$ transition, since anything after $\StabilityWindow$ would work,
+but there is no reason to do so.

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -18,6 +18,20 @@ It should, however, use the value of the reserve pot as it was during the previo
 epoch, since $\fun{createRUpd}$ is creating the rewards earned during the previous epoch
 (see the overview in Section~\ref{sec:reward-overview}).
 
+\subsection{Active stake registrations and the Reward Calculation}
+\label{sec:errata:active-accounts-and-reward-calc}
+
+The reward calculation takes the set of active reward accounts as a parameter
+(the forth parameter of $\fun{reward}$ in Figure~\ref{fig:functions:reward-calc}).
+It is only used at the end of the calculation for filtering out unregistered accounts.
+Therefore, if a stake credential is deregistered just before the reward calculation starts,
+it cannot reregister before the end of the epoch in order to get the rewards.
+The time within the epoch when the reward calculation starts should not make any difference.
+Note that this does not affect the earnings that stake pools make from their margin,
+since each pool's total stake is summed before filtering.
+The solution is to not filter by the current active reward accounts, since rewards for
+unregistered accounts go to the treasury already anyway.
+
 \subsection{Stability Windows}
 \label{sec:errata:stability-windows}
 

--- a/shelley/chain-and-ledger/formal-spec/errata.tex
+++ b/shelley/chain-and-ledger/formal-spec/errata.tex
@@ -36,3 +36,29 @@ adopting Ouroboros Genesis in the consensus layer.
 There is no problem with using $RandomnessStabilisationWindow$ for the
 $\mathsf{RUPD}$ transition, since anything after $\StabilityWindow$ would work,
 but there is no reason to do so.
+
+\subsection{Reward aggregation}
+\label{sec:errata:reward-aggregation}
+
+On any given epoch, a reward account can earn rewards by being a member of a stake pool,
+and also by being the registered reward account for a stake pool (to receive leader rewards).
+A reward account can be registered to receive leader rewards from multiple stake pools.
+It was intended that reward accounts receive the sum of all such rewards,
+but a mistake caused reward accounts to receive at most one of them.
+
+In Figure~\ref{fig:functions:reward-calc}, the value of $\var{potentialRewards}$ in the
+$\fun{rewardOnePool}$ function should be computed using an aggregating union
+$\unionoverridePlus$, so that member rewards are not overridden by leader rewards.
+Similarly, the value of $\var{rewards}$ in the $\fun{reward}$ function should be computed
+using an aggregating union so that leader rewards from multiple sources are aggregated.
+
+This was corrected at the Allegra hard fork.
+There were sixty-four stake addresses that were affected,
+each of which was reimbursed for the exact amount lost using a MIR certificate.
+Four of the stake address were unregistered and had to be re-registered.
+The unregistered addresses were reimbursed in transaction
+\newline
+$a01b9fe136e5703668c9c7776a76cc8541b84824635d237e270670a8ca56a392$,
+and the registered addresses were reimbursed in transaction
+\newline
+$8cab8049e3b8c4802d7d11277b21afc74056223a596c39ef00e002c2d1f507ad$.

--- a/shelley/chain-and-ledger/formal-spec/frontmatter.tex
+++ b/shelley/chain-and-ledger/formal-spec/frontmatter.tex
@@ -26,6 +26,10 @@
            and changed the reward calculation so that $\eta$
              takes $d$ into account.}
         \change{2021/05/17}{Jared Corduan}{FM (IOHK)}{Added Example Illustration.}
+        \change{2021/06/14}{Jared Corduan}{FM (IOHK)}
+          {Added an errata section,
+           fixed a typo in leader check and in the LEDGERS rule index,
+           and synced the reward calculation with the implementation}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}

--- a/shelley/chain-and-ledger/formal-spec/frontmatter.tex
+++ b/shelley/chain-and-ledger/formal-spec/frontmatter.tex
@@ -69,4 +69,6 @@ Yun Lu,
 Philipp Kant,
 Jean-Christophe Mincke,
 Damian Nadales,
-Nicolas Di Prima.
+Ashish Prajapati,
+Nicolas Di Prima,
+Andrew Westberg.

--- a/shelley/chain-and-ledger/formal-spec/leader-value.tex
+++ b/shelley/chain-and-ledger/formal-spec/leader-value.tex
@@ -24,14 +24,14 @@ this as a natural number $\var{certNat}$ in the range $[0,2^{512})$.
 \subsection{Node eligibility}
 
 As per \cite{ouroboros_praos}, a node is eligible to lead when its leader value
-$\ell < 1 - (1 - f)^\sigma$. We have
+$p < 1 - (1 - f)^\sigma$. We have
 
 \begin{align*}
-  \ell & < 1 - (1 -f)^\sigma \\
-  \iff \left(\frac{1}{1-\ell}\right) & < \exp{(-\sigma \cdot \ln{(1-f)})}
+  p & < 1 - (1 -f)^\sigma \\
+  \iff \left(\frac{1}{1-p}\right) & < \exp{(-\sigma \cdot \ln{(1-f)})}
 \end{align*}
 
-The latter inquality can be efficiently computed through use of its Taylor
+The latter inequality can be efficiently computed through use of its Taylor
 expansion and error estimation to stop computing terms once we are certain that
 the result will be either above or below the target value.
 
@@ -42,7 +42,8 @@ of a single lovelace.)
 As such, we define the following:
 
 \begin{align*}
-  q & = \frac{2^{512}}{2^{512} - \var{certNat}} \\
+  p & = \frac{\var{certNat}}{2^{512}} \\
+  q & = 1 - p \\
   c & = \ln{(1 - f)}
 \end{align*}
 
@@ -53,7 +54,7 @@ and define the function \textit{checkLeaderVal} as follows:
     \left\{
       \begin{array}{l@{~}r}
         \mathsf{True}, & f = 1 \\
-        q > \exp{(-\sigma \cdot c)}, & \text{otherwise}
+        \frac{1}{q} < \exp{(-\sigma \cdot c)}, & \text{ otherwise}
       \end{array}
     \right.
 \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -364,6 +364,7 @@
 \include{properties}
 \include{non-integral}
 \include{leader-value}
+\include{errata}
 
 \clearpage
 

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -61,6 +61,7 @@
 \newcommand{\Bool}{\type{Bool}}
 \newcommand{\Npos}{\ensuremath{\mathbb{N}^{>0}}}
 \newcommand{\Z}{\ensuremath{\mathbb{Z}}}
+\newcommand{\Q}{\ensuremath{\mathbb{Q}}}
 \newcommand{\R}{\ensuremath{\mathbb{R}}}
 \newcommand{\Rnn}{\ensuremath{\mathbb{R}^{\geq 0}}}
 \newcommand{\Tx}{\type{Tx}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -168,7 +168,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
       {
         \begin{array}{r}
           \var{slot}\\
-          \mathsf{len}~\Gamma - 1\\
+          \mathsf{len}~\Gamma\\
           \var{pp}\\
           \var{acnt}
         \end{array}


### PR DESCRIPTION
A new **Errata** section is added to the Shelley ledger spec, which addresses:
* reward calculation & stake addresses registration timing (thank you @ashisherc !)
* Byron redeem addresses
* reward aggregation
* stability window discrepancy (thank you @AndrewWestberg !)
* mistimed reserve pot

Several **audit issues** have been addressed:
* #2040 
* #2043 
* #2113
* the index in the LEDGERS rule was off by one (no GH issue)

Each fix is contained in a single commit, so it may be easier to review commit by commit.