### PR TITLE
Ts fix fee too small

### DIFF
--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -326,6 +326,7 @@ instance Mock c => EraGen (AlonzoEra c) where
   unsafeApplyTx (Tx bod wit auxdata) = ValidatedTx bod wit (IsValidating True) auxdata
 
   genEraGoodTxOut = vKeyLocked
+
   genEraScriptCost pp script =
     if isPlutusScript script
       then case List.find (\info -> (getScript @(AlonzoEra c) info) == script) genEraTwoPhaseScripts of
@@ -333,8 +334,9 @@ instance Mock c => EraGen (AlonzoEra c) where
           scriptfee (getField @"_prices" pp) (ExUnits mems steps)
             <+> storageCost 10 pp (rdmr, ExUnits mems steps) -- Extra 10 for the RdmrPtr
             <+> storageCost 32 pp inputdata -- Extra 32 for the hash
-        Nothing -> Coin 0
-      else Coin 0
+            <+> storageCost 0 pp script
+        Nothing -> storageCost 0 pp script
+      else storageCost 0 pp script
 
   genEraDone x = x -- ptrace "\nDone " x x
 

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -250,40 +250,9 @@ fastPropertyTests =
       testProperty "total amount of Ada is preserved (Chain)" (withMaxSuccess 50 (adaPreservationChain @(AlonzoEra TestCrypto)))
     ]
 
--- ============================================================================
--- When debugging property tests failures, it is usefull to run a test
--- with a given replay value. go is a template for how to do this.
-
--- go :: Int -> IO (Maybe ())
-go n =
-  -- timeout 20000000 $
-  defaultMain
-    ( localOption
-        (QuickCheckReplay (Just n))
-        -- some properties we might use
-        -- (testProperty "preserves ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))
-        -- (testProperty "Delegation Properties" (delegProperties @(AlonzoEra TestCrypto)))
-        -- fastPropertyTests
-        -- (propertyTests @(AlonzoEra TestCrypto))
-        (testProperty "Only valid CHAIN STS signals are generated" (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
-    )
-
-localOptions :: Test.Tasty.Options.IsOption v => [v] -> TestTree -> TestTree
-localOptions [] t = t
-localOptions (x : xs) t = localOptions xs (localOption x t)
-
-replay :: Int -> IO ()
-replay n =
-  defaultMain
-    ( localOption
-        (QuickCheckReplay (Just n))
-        -- some properties we might use
-        -- (testProperty "preserves ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))
-        -- (testProperty "Delegation Properties" (delegProperties @(AlonzoEra TestCrypto)))
-        -- fastPropertyTests
-        -- (propertyTests @(AlonzoEra TestCrypto))
-        (testProperty "Only valid CHAIN STS signals are generated" (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
-    )
+-- ==========================================================================================
+-- When debugging property tests failures, it is usefull to run a test with a given replay
+-- value, or a certain number of times. manytimes is a template for how to do this.
 
 -- | Run a a single testmany times. Uncomment out  QuickCheckReplay or QuickCheckVerbose to control things.
 manytimes :: String -> Int -> Int -> IO ()

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -31,7 +31,6 @@ module Test.Cardano.Ledger.Alonzo.Trials
     propertyTests,
     relevantCasesAreCovered,
     removedAfterPoolreap,
-    go,
     payscript,
     stakescript,
     scripts,
@@ -42,6 +41,8 @@ module Test.Cardano.Ledger.Alonzo.Trials
     d2,
     d3,
     d4,
+    manytimes,
+    search,
   )
 where
 
@@ -110,7 +111,6 @@ import Test.Shelley.Spec.Ledger.PropertyTests
     removedAfterPoolreap,
   )
 import Test.Tasty
-import Test.Tasty.Options (IsOption (..))
 import Test.Tasty.QuickCheck
 
 -- ======================================================================
@@ -256,7 +256,7 @@ fastPropertyTests =
 
 -- | Run a a single testmany times. Uncomment out  QuickCheckReplay or QuickCheckVerbose to control things.
 manytimes :: String -> Int -> Int -> IO ()
-manytimes prop count seed =
+manytimes prop count _seed =
   defaultMain $
     ( -- localOption (QuickCheckReplay (Just seed)) $
       localOption (QuickCheckShowReplay True) $
@@ -277,6 +277,7 @@ manytimes prop count seed =
                 "STS Rules - Delegation Properties"
                 (withMaxSuccess count (delegProperties @(AlonzoEra TestCrypto)))
             )
+          other -> error ("unknown test: " ++ other)
     )
 
 -- ==============================================================================


### PR DESCRIPTION
Fixed the estimate of transaction size, by addingthe cost of storing scripts, in addition to the cost of executing the, and storing their additional data and redeemers.