### PR TITLE
CLI helper functions for constructing transactions

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -43,6 +43,7 @@ library
     Cardano.Ledger.Alonzo.Rules.Utxos
     Cardano.Ledger.Alonzo.Rules.Utxow
     Cardano.Ledger.Alonzo.Scripts
+    Cardano.Ledger.Alonzo.Tools
     Cardano.Ledger.Alonzo.Translation
     Cardano.Ledger.Alonzo.Tx
     Cardano.Ledger.Alonzo.TxBody
@@ -51,6 +52,7 @@ library
     Cardano.Ledger.Alonzo.TxWitness
     Cardano.Ledger.DescribeEras
   build-depends:
+    array,
     bytestring,
     cardano-binary,
     cardano-crypto-class,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
@@ -11,6 +11,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord64)
 import Cardano.Ledger.Pretty (PDoc, PrettyA (..), ppString)
 import Control.DeepSeq (NFData (..))
 import Data.Coders
+import Data.Ix (Ix)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
@@ -26,7 +27,7 @@ import NoThunks.Class (NoThunks)
 -- We might add new languages in the futures.
 
 data Language = PlutusV1 --    | ADD-NEW-LANGUAGES-HERE
-  deriving (Eq, Generic, Show, Ord)
+  deriving (Eq, Generic, Show, Ord, Enum, Bounded, Ix)
 
 instance NoThunks Language
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -370,7 +370,7 @@ utxoTransition = do
 
   {-   consumedpp utxo txb = producedpp poolParams txb    -}
   let consumed_ = consumed @era pp utxo txb
-      produced_ = Shelley.produced @era pp stakepools txb
+      produced_ = Shelley.produced @era pp (`Map.notMember` stakepools) txb
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   {-   adaID  ∉ supp mint tx   -}

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -169,7 +169,7 @@ scriptsValidateTransition = do
       depositChange =
         ( totalDeposits
             pp
-            poolParams
+            (`Map.notMember` poolParams)
             (toList $ getField @"certs" txb)
         )
           Val.<-> refunded

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Alonzo.Tools
+  ( evaluateTransactionExecutionUnits,
+    ScriptFailure (..),
+  )
+where
+
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (Data, getPlutusData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeeded)
+import Cardano.Ledger.Alonzo.Scripts
+  ( CostModel (..),
+    ExUnits (..),
+    Script (..),
+  )
+import Cardano.Ledger.Alonzo.Tx (DataHash, ScriptPurpose (Spending), rdptr)
+import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
+import Cardano.Ledger.Alonzo.TxInfo (txInfo, valContext)
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), unRedeemers, unTxDats)
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Slotting.EpochInfo.API (EpochInfo)
+import Cardano.Slotting.Time (SystemStart)
+import Data.Array (Array, (!))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import GHC.Records (HasField (..))
+import qualified Plutus.V1.Ledger.Api as P
+import Shelley.Spec.Ledger.Tx (TxIn)
+import Shelley.Spec.Ledger.UTxO (UTxO (..), unUTxO)
+
+-- | Failures that can be returned by 'evaluateTransactionExecutionUnits'.
+data ScriptFailure c
+  = -- | A redeemer was supplied that does not point to a
+    --  valid plutus evaluation site in the given transaction.
+    RedeemerNotNeeded RdmrPtr
+  | -- | Missing redeemer.
+    MissingScript RdmrPtr
+  | -- | Missing datum.
+    MissingDatum (DataHash c)
+  | -- | Plutus evaluation error.
+    ValidationFailed P.EvaluationError
+  | -- | A redeemer points to a transaction input which is not
+    --  present in the current UTxO.
+    UnknownTxIn (TxIn c)
+  | -- | A redeemer points to a transaction input which is not
+    --  plutus locked.
+    InvalidTxIn (TxIn c)
+  | -- | The execution budget that was calculated by the Plutus
+    --  evaluator is out of bounds.
+    IncompatibleBudget P.ExBudget
+
+note :: e -> Maybe a -> Either e a
+note _ (Just x) = Right x
+note e Nothing = Left e
+
+safeFromInteger :: forall a. (Integral a, Bounded a) => Integer -> Maybe a
+safeFromInteger i
+  | toInteger (minBound :: a) <= i && i <= toInteger (maxBound :: a) = Just $ fromInteger i
+  | otherwise = Nothing
+
+exBudgetToExUnits :: P.ExBudget -> Maybe ExUnits
+exBudgetToExUnits (P.ExBudget (P.ExCPU cpu) (P.ExMemory memory)) =
+  ExUnits <$> safeFromInteger (toInteger cpu) <*> safeFromInteger (toInteger memory)
+
+-- | Evaluate the execution budgets needed for all the redeemers in
+--  a given transaction. If a redeemer is invalid, a failure is returned instead.
+--
+--  The execution budgets in the supplied transaction are completely ignored.
+--  The results of 'evaluateTransactionExecutionUnits' are intended to replace them.
+evaluateTransactionExecutionUnits ::
+  forall c m.
+  ( CC.Crypto c,
+    Monad m
+  ) =>
+  -- | The transaction.
+  Core.Tx (AlonzoEra c) ->
+  -- | The current UTxO set (or the relevant portion for the transaction).
+  UTxO (AlonzoEra c) ->
+  -- | The epoch info, used to translate slots to POSIX time for plutus.
+  EpochInfo m ->
+  -- | The start time of the given block chain.
+  SystemStart ->
+  -- | The array of cost models, indexed by the supported languages.
+  Array Language CostModel ->
+  -- | A map from redeemer pointers to either a failure or a sufficient execution budget.
+  --  The value is monadic, depending on the epoch info.
+  m (Map RdmrPtr (Either (ScriptFailure c) ExUnits))
+evaluateTransactionExecutionUnits tx utxo ei sysS costModels = do
+  txinfo <- txInfo ei sysS utxo tx
+  pure $ Map.mapWithKey (findAndCount txinfo) (unRedeemers $ getField @"txrdmrs" ws)
+  where
+    txb = getField @"body" tx
+    ws = getField @"wits" tx
+    dats = unTxDats $ getField @"txdats" ws
+    scripts = getField @"txscripts" ws
+
+    ptrToPlutusScript = Map.fromList $ do
+      (sp, sh) <- scriptsNeeded utxo tx
+      msb <- case Map.lookup sh scripts of
+        Nothing -> pure Nothing
+        Just (TimelockScript _) -> []
+        Just (PlutusScript bytes) -> pure $ Just bytes
+      pointer <- case rdptr @(AlonzoEra c) txb sp of
+        SNothing -> []
+        -- Since scriptsNeeded used the transaction to create script purposes,
+        -- it would be a logic error if rdptr was not able to find sp.
+        SJust p -> pure p
+      pure (pointer, (sp, msb))
+
+    (CostModel costModel) = costModels ! PlutusV1
+
+    findAndCount ::
+      P.TxInfo ->
+      RdmrPtr ->
+      (Data (AlonzoEra c), ExUnits) ->
+      Either (ScriptFailure c) ExUnits
+    findAndCount inf pointer (rdmr, _) = do
+      (sp, mscript) <- note (RedeemerNotNeeded pointer) $ Map.lookup pointer ptrToPlutusScript
+      script <- note (MissingScript pointer) mscript
+      args <- case sp of
+        (Spending txin) -> do
+          txOut <- note (UnknownTxIn txin) $ Map.lookup txin (unUTxO utxo)
+          let TxOut _ _ mdh = txOut
+          dh <- note (InvalidTxIn txin) $ strictMaybeToMaybe mdh
+          dat <- note (MissingDatum dh) $ Map.lookup dh dats
+          pure [dat, rdmr, valContext inf sp]
+        _ -> pure [rdmr, valContext inf sp]
+      let pArgs = map getPlutusData args
+
+      case snd $ P.evaluateScriptCounting P.Quiet costModel script pArgs of
+        Left e -> Left $ ValidationFailed e
+        Right exBudget -> note (IncompatibleBudget exBudget) $ exBudgetToExUnits exBudget

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -37,9 +37,10 @@ import Cardano.Ledger.Alonzo.Tx
     hashWitnessPPData,
     minfee,
     rdptr,
+    totExUnits,
   )
 import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..), inputs')
-import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), TxWitness (..), unRedeemers)
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
@@ -280,11 +281,6 @@ bigStep, bigMem :: Word64
 bigStep = 999 -- 9999999990
 bigMem = 500 -- 50000000
 
-instance HasField "totExunits" (Tx (AlonzoEra c)) ExUnits where
-  getField tx = Prelude.foldl (<>) mempty (snd $ unzip (Map.elems trd))
-    where
-      trd = unRedeemers $ (getField @"txrdmrs" (getField @"wits" tx))
-
 instance Mock c => EraGen (AlonzoEra c) where
   genEraAuxiliaryData = genAux
   genGenesisValue = maryGenesisValue
@@ -362,7 +358,7 @@ instance Mock c => EraGen (AlonzoEra c) where
 
   genEraTweakBlock pp txns =
     let txTotal, ppMax :: ExUnits
-        txTotal = Prelude.foldr (<>) mempty (fmap (getField @"totExunits") txns)
+        txTotal = Prelude.foldr (<>) mempty (fmap totExUnits txns)
         ppMax = getField @"_maxBlockExUnits" pp
      in if pointWiseExUnits (<=) txTotal ppMax
           then pure txns

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -84,7 +84,7 @@ import Control.State.Transition.Extended hiding (Assertion)
 import Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import Data.Coerce (coerce)
 import Data.Default.Class (Default (..))
-import Data.Functor.Identity (Identity)
+import Data.Functor.Identity (Identity, runIdentity)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
@@ -1630,7 +1630,7 @@ collectTwoPhaseScriptInputsOutputOrdering =
     apf = Alonzo Mock
     context =
       valContext
-        (txInfo testEpochInfo testSystemStart (initUTxO apf) (validatingTx apf))
+        (runIdentity $ txInfo testEpochInfo testSystemStart (initUTxO apf) (validatingTx apf))
         (Spending $ TxIn genesisId 1)
 
 collectOrderingAlonzo :: TestTree

--- a/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -19,9 +21,11 @@ module Cardano.Ledger.Allegra
 where
 
 import Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Crypto as CC
 import qualified Cardano.Ledger.Era as E (Era (Crypto))
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.Rules.EraMapping ()
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody ()
 import Cardano.Ledger.Val (Val ((<->)))
@@ -29,6 +33,7 @@ import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import Shelley.Spec.Ledger.API hiding (PParams, Tx, TxBody, TxOut, WitnessSet)
 import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
+import Shelley.Spec.Ledger.LedgerState (minfee)
 import qualified Shelley.Spec.Ledger.PParams as Shelley (PParamsUpdate)
 import Shelley.Spec.Ledger.Tx (WitnessSet)
 
@@ -78,6 +83,15 @@ instance
       pp = sgProtocolParams sg
 
 instance PraosCrypto c => ShelleyBasedEra (AllegraEra c)
+
+instance CC.Crypto c => CLI (AllegraEra c) where
+  evaluateMinFee = minfee
+
+  evaluateConsumed = consumed
+
+  addKeyWitnesses = addShelleyKeyWitnesses
+
+  evaluateMinLovelaceOutput pp _out = _minUTxOValue pp
 
 -- Self-Describing type synomyms
 

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -278,7 +278,7 @@ utxoTransition = do
       (Set.fromList wdrlsWrongNetwork)
 
   let consumed_ = consumed pp utxo txb
-      produced_ = Shelley.produced @era pp stakepools txb
+      produced_ = Shelley.produced @era pp (`Map.notMember` stakepools) txb
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Protocol Parameter Update Proposals
@@ -334,7 +334,7 @@ utxoTransition = do
 
   let refunded = Shelley.keyRefunds pp txb
   let txCerts = toList $ getField @"certs" txb
-  let depositChange = totalDeposits pp stakepools txCerts Val.<-> refunded
+  let depositChange = totalDeposits pp (`Map.notMember` stakepools) txCerts Val.<-> refunded
 
   pure
     Shelley.UTxOState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -19,34 +21,46 @@ module Shelley.Spec.Ledger.API.Wallet
     getTotalStake,
     poolsByTotalStakeFraction,
     getRewardInfo,
+    CLI (..),
+    addShelleyKeyWitnesses,
   )
 where
 
+import Cardano.Binary (ToCBOR (..), decodeFull, decodeFullDecoder, serialize)
+import Cardano.Crypto.DSIGN.Class (decodeSignedDSIGN, sizeSigDSIGN, sizeVerKeyDSIGN)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.BaseTypes (Globals (..), Seed, UnitInterval, epochInfo)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Crypto (VRF)
+import Cardano.Ledger.Crypto (DSIGN, VRF)
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..), SignKeyVRF)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints (UsesValue)
 import Cardano.Ledger.Slot (epochInfoSize)
+import Cardano.Ledger.Tx (Tx (..))
+import Cardano.Ledger.Val ((<->))
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (EpochSize, SlotNo)
 import Control.Monad.Trans.Reader (runReader)
 import Control.Provenance (runWithProvM)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Default.Class (Default (..))
+import Data.Either (fromRight)
 import Data.Foldable (fold)
 import Data.Functor.Identity (runIdentity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (..))
 import Data.Ratio ((%))
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import GHC.Records (HasField, getField)
+import GHC.Records (HasField (..), getField)
 import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API.Protocol (ChainDepState (..))
 import Shelley.Spec.Ledger.BlockChain (checkLeaderValue, mkSeed, seedL)
@@ -65,7 +79,10 @@ import Shelley.Spec.Ledger.LedgerState
     RewardUpdate,
     UTxOState (..),
     circulation,
+    consumed,
     createRUpd,
+    minfee,
+    produced,
     stakeDistr,
   )
 import Shelley.Spec.Ledger.OverlaySchedule (isOverlaySlot)
@@ -80,7 +97,8 @@ import Shelley.Spec.Ledger.Rewards
   )
 import Shelley.Spec.Ledger.STS.NewEpoch (calculatePoolDistr)
 import Shelley.Spec.Ledger.STS.Tickn (TicknState (..))
-import Shelley.Spec.Ledger.TxBody (PoolParams (..), TxIn (..))
+import Shelley.Spec.Ledger.Tx (WitnessSet, WitnessSetHKD (..))
+import Shelley.Spec.Ledger.TxBody (DCert, PoolParams (..), TxIn (..), WitVKey (..))
 import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 -- | Get pool sizes, but in terms of total stake
@@ -330,3 +348,103 @@ getRewardInfo globals newepochstate =
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
     asc = activeSlotCoeff globals
     secparam = securityParameter globals
+
+-- | A collection of functons to help construction transactions
+--  from the cardano-cli.
+class
+  ( Era era,
+    HasField "_minfeeA" (Core.PParams era) Natural,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
+  ) =>
+  CLI era
+  where
+  -- | The minimum fee calculation.
+  -- Used for the default implentation of 'evaluateTransactionFee'.
+  evaluateMinFee :: Core.PParams era -> Core.Tx era -> Coin
+
+  -- | The consumed calculation.
+  -- Used for the default implentation of 'evaluateTransactionBalance'.
+  evaluateConsumed :: Core.PParams era -> UTxO era -> Core.TxBody era -> Core.Value era
+
+  addKeyWitnesses :: Core.Tx era -> Set (WitVKey 'Witness (Crypto era)) -> Core.Tx era
+
+  -- | Evaluate the difference between the value currently being consumed by
+  -- a transaction and the number of lovelace being produced.
+  -- This value will be zero for a valid transaction.
+  evaluateTransactionBalance ::
+    -- | The current protocol parameters.
+    Core.PParams era ->
+    -- | The UTxO relevant to the transaction.
+    UTxO era ->
+    -- | A predicate that a stake pool ID is new (i.e. unregistered).
+    -- Typically this will be:
+    --
+    -- @
+    --   (`Map.notMember` stakepools)
+    -- @
+    (KeyHash 'StakePool (Crypto era) -> Bool) ->
+    -- | The transaction being evaluated for balance.
+    Core.TxBody era ->
+    -- | The difference between what the transaction consumes and what it produces.
+    Core.Value era
+  evaluateTransactionBalance pp u isNewPool txb =
+    evaluateConsumed pp u txb <-> produced @era pp isNewPool txb
+
+  -- | Evaluate the fee for a given transaction.
+  evaluateTransactionFee ::
+    -- | The current protocol parameters.
+    Core.PParams era ->
+    -- | The transaction.
+    Core.Tx era ->
+    -- | The number of key witnesses still be be added to the transaction.
+    Word ->
+    -- | The required fee.
+    Coin
+  evaluateTransactionFee pp tx numKeyWits =
+    evaluateMinFee pp tx'
+    where
+      sigSize = fromIntegral $ sizeSigDSIGN (Proxy @(DSIGN (Crypto era)))
+      dummySig =
+        fromRight
+          (error "corrupt dummy signature")
+          (decodeFullDecoder "dummy signature" decodeSignedDSIGN (LBS.replicate sigSize 0))
+      vkeySize = fromIntegral $ sizeVerKeyDSIGN (Proxy @(DSIGN (Crypto era)))
+      dummyVKey w =
+        let padding = LBS.replicate paddingSize 0
+            paddingSize = vkeySize - LBS.length sw
+            sw = serialize w
+            keyBytes = padding <> sw
+         in fromRight (error "corrupt dummy vkey") (decodeFull keyBytes)
+      dummyKeyWits = Set.fromList $
+        flip map [0 .. numKeyWits] $
+          \x -> WitVKey (dummyVKey x) dummySig
+
+      tx' = addKeyWitnesses tx dummyKeyWits
+
+  -- | Evaluate the minimum lovelace that a given transaciton output must contain.
+  evaluateMinLovelaceOutput :: Core.PParams era -> Core.TxOut era -> Coin
+
+addShelleyKeyWitnesses ::
+  ( Era era,
+    Core.Witnesses era ~ WitnessSet era,
+    Core.AnnotatedData (Core.Script era),
+    ToCBOR (Core.AuxiliaryData era),
+    ToCBOR (Core.TxBody era)
+  ) =>
+  Core.Tx era ->
+  Set (WitVKey 'Witness (Crypto era)) ->
+  Core.Tx era
+addShelleyKeyWitnesses (Tx b ws aux) newWits = Tx b ws' aux
+  where
+    ws' = ws {addrWits = Set.union newWits (addrWits ws)}
+
+instance CC.Crypto c => CLI (ShelleyEra c) where
+  evaluateMinFee = minfee
+
+  evaluateConsumed = consumed
+
+  addKeyWitnesses = addShelleyKeyWitnesses
+
+  evaluateMinLovelaceOutput pp _out = _minUTxOValue pp

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -383,7 +383,7 @@ utxoInductive = do
   null wdrlsWrongNetwork ?! WrongNetworkWithdrawal ni (Set.fromList wdrlsWrongNetwork)
 
   let consumed_ = consumed pp utxo txb
-      produced_ = produced @era pp stakepools txb
+      produced_ = produced @era pp (`Map.notMember` stakepools) txb
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Protocol Parameter Update Proposals
@@ -420,7 +420,7 @@ utxoInductive = do
 
   let refunded = keyRefunds pp txb
   let txCerts = toList $ getField @"certs" txb
-  let depositChange = totalDeposits pp stakepools txCerts <-> refunded
+  let depositChange = totalDeposits pp (`Map.notMember` stakepools) txCerts <-> refunded
 
   pure
     UTxOState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -274,16 +274,16 @@ totalDeposits ::
     HasField "_keyDeposit" pp Coin
   ) =>
   pp ->
-  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
+  (KeyHash 'StakePool crypto -> Bool) ->
   [DCert crypto] ->
   Coin
-totalDeposits pp stpools cs =
+totalDeposits pp isNewPool cs =
   (numKeys <×> getField @"_keyDeposit" pp)
     <+> (numNewPools <×> getField @"_poolDeposit" pp)
   where
     numKeys = length $ filter isRegKey cs
     pools = Set.fromList $ Maybe.mapMaybe getKeyHashFromRegPool cs
-    numNewPools = length $ pools `Set.difference` Map.keysSet stpools
+    numNewPools = length $ Set.filter isNewPool pools
 
 getKeyHashFromRegPool :: DCert crypto -> Maybe (KeyHash 'StakePool crypto)
 getKeyHashFromRegPool (DCertPool (RegPool p)) = Just . _poolId $ p

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -45,7 +45,7 @@ import Control.State.Transition.Trace (TraceOrder (OldestFirst), lastState, trac
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Data.Functor.Identity (runIdentity)
 import Data.List (partition)
-import qualified Data.Map.Strict as Map (lookup)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -233,7 +233,7 @@ genDCerts
 
     pure
       ( StrictSeq.fromList certs,
-        totalDeposits pparams (_pParams (_pstate dpState)) certs,
+        totalDeposits pparams (`Map.notMember` pools) certs,
         (length deRegStakeCreds) <×> (getField @"_keyDeposit" pparams),
         lastState_,
         ( concat (keyCredAsWitness <$> keyCreds'),
@@ -241,6 +241,7 @@ genDCerts
         )
       )
     where
+      pools = _pParams (_pstate dpState)
       isScript (ScriptCred _) = True
       isScript _ = False
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -139,7 +139,7 @@ showBalance
   (DPState _ (PState stakepools _ _))
   tx =  "\n\nConsumed: " ++ show (consumed pparams utxo txBody)
          ++ "  Produced: "
-         ++ show (produced @era pparams stakepools txBody)
+         ++ show (produced @era pparams (`Map.notMember` stakepools) txBody)
     where txBody = getField @"body" tx
 
 --  ========================================================================

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -583,7 +583,7 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
         created =
           Val.coin (balance u')
             <+> getField @"txfee" txb
-            <+> totalDeposits pp_ pools certs
+            <+> totalDeposits pp_ (`Map.notMember` pools) certs
         consumed_ =
           Val.coin (balance u)
             <+> keyRefunds pp_ txb
@@ -632,7 +632,7 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
           let certs = toList (getField @"certs" txb)
            in Val.coin (balance (txouts @era txb))
                 <> getField @"txfee" txb
-                <> totalDeposits pp_ pools certs
+                <> totalDeposits pp_ (`Map.notMember` pools) certs
 
 preserveOutputsTx ::
   forall era.


### PR DESCRIPTION
This PR adds four new functions to be used by the cardano-cli for constructing transactions.

Three of the new functions live in a class, `CLIHelpers`, and are supported in all eras: `evaluateTransactionBalance`, `evaluateTransactionBalance`, `evaluateTransactionFee`. The first two contain default implementations, the class just needs to know the proper `minfee` and `consumed` function to use. Finally, there is an Alonzo-specific function `evaluateTransactionExecutionUnits` which computes the minimal execution budget for the redeemers in an Alonzo transaction.

Additionally, I changed some of the surrounding code (changes separated by commit):
* the `Languages` type is bounded and inflexible
* `txInfo` now returns a monadic value, as given by `EpochInfo m` when converting slots to POSIX time for plutus.
* the `totalDeposits` function that has been used since Shelley for determining the deposits needed by a given transaction now takes a predicate instead of a mapping of stake pools. Instead of providing the map, you can now use `(Map.notMember pools)`.
* `totExUnits` is now a standalone function instead of a `HasField` instance.
