### PR TITLE
Fixes haddock documentation

### DIFF
--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -244,11 +244,11 @@ data TwoPhaseInfo era = TwoPhaseInfo
   { getScript :: Core.Script era,    -- ^ A Plutus Script
     getHash :: ScriptHash (Crypto era),       -- ^ Its ScriptHash
     getData :: Plutus.Data,          -- ^ A Data that will make it succeed
-    getRedeemer ::                   -- ^ A Redeemer that will make it succeed
-      ( Plutus.Data,                 -- ^ The redeeming data
-        Word64,                      -- ^ The ExUnits memory count
-        Word64                       -- ^ The ExUnits steps count
-      )
+    getRedeemer ::
+      ( Plutus.Data,                 -- The redeeming data
+        Word64,                      -- The ExUnits memory count
+        Word64                       -- The ExUnits steps count
+      )                              -- ^ A Redeemer that will make it succeed
   }
 
 deriving instance Show (Core.Script era) => Show (TwoPhaseInfo era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -257,7 +257,8 @@ class
     (Core.TxOut era) ->              -- | This is to be Appended to the end of the existing TxOut
     Core.TxBody era
 
-  addInputs :: Core.TxBody era -> Set (TxIn (Crypto era)) -> Core.TxBody era  -- |  Union the TxIn with the existing TxIn in the TxBody
+  -- |  Union the TxIn with the existing TxIn in the TxBody
+  addInputs :: Core.TxBody era -> Set (TxIn (Crypto era)) -> Core.TxBody era
   addInputs txb _ins = txb
 
   genEraPParamsDelta :: Constants -> Core.PParams era -> Gen (Core.PParamsDelta era)


### PR DESCRIPTION
Some strings were malformed and that caused evaluation errors on the
ouroboros-consensus CI, see [this](https://hydra.iohk.io/build/6679378/nixlog/46/tail).