### PR TITLE
few adjustments to shelley spec to align with code

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1200,10 +1200,10 @@ The calculation is done pool-by-pool.
   \emph{Calculation to reward a single stake pool}
   %
   \begin{align*}
-    & \fun{rewardOnePool} \in \PParams \to \Coin \to \N \to \N \to \KeyHash \to \PoolParam\\
+    & \fun{rewardOnePool} \in \PParams \to \Coin \to \N \to \N \to \PoolParam\\
       & ~~~\to \Stake \to \Q \to \Q \to \Coin \to \powerset{\AddrRWD}
            \to (\AddrRWD \mapsto \Coin) \\
-      & \fun{rewardOnePool}~\var{pp}~\var{R}~\var{n}~\var{\overline{N}}~\var{poolHK}~\var{pool}~\var{stake}~{\sigma}~{\sigma_a}~\var{tot}~\var{addrs_{rew}} =
+      & \fun{rewardOnePool}~\var{pp}~\var{R}~\var{n}~\var{\overline{N}}~\var{pool}~\var{stake}~{\sigma}~{\sigma_a}~\var{tot}~\var{addrs_{rew}} =
           \var{rewards}\\
       & ~~~\where \\
       & ~~~~~~~\var{ostake} = \sum_{\substack{
@@ -1218,7 +1218,7 @@ The calculation is done pool-by-pool.
         \var{pledge} \leq \var{ostake}\\
         0 & \text{otherwise.}
       \end{cases} \\
-      & ~~~~~~~\var{appPerf} = \mkApparentPerformance{(\fun{d}~pp)}{\sigma}{n}{\overline{N}} \\
+      & ~~~~~~~\var{appPerf} = \mkApparentPerformance{(\fun{d}~pp)}{\sigma_a}{n}{\overline{N}} \\
       & ~~~~~~~\var{poolR} = \floor{\var{appPerf}\cdot\var{maxP}} \\
       & ~~~~~~~\var{mRewards} = \\
       & ~~~~~~~~~~\left\{
@@ -1260,12 +1260,11 @@ The calculation is done pool-by-pool.
                      \var{R}~
                      \var{n}~
                      \var{\overline{N}}~
-                     \var{hk}~
                      \var{p}~
                      \var{s}~
                      \frac{\sum s}{total}~
                      \frac{\sum s}{\var{total}_a}~
-                     \var{tot}~
+                     \var{total}~
                      \var{addrs_{rew}}
                  \mid
         hk\mapsto(p, n, s)\in\var{pdata} \right\} \\


### PR DESCRIPTION
This corrects three spec/code differences (only the spec is edited) in the Shelley ledger spec.

Thank you @csoroz for spotting these! See https://github.com/input-output-hk/cardano-ledger-specs/pull/2332#issuecomment-861552039 https://github.com/input-output-hk/cardano-ledger-specs/pull/2332#issuecomment-861578015 https://github.com/input-output-hk/cardano-ledger-specs/pull/2332#issuecomment-861786752

* `tot` -> `total` in the reward calculation.
* `mkApparentPerformance` should take the _active_ stake `σ_a`.
* The `rewardOnePool` function does _not_ need to take the pool id (ie operator keyhash) as a parameter. The pool id is actually contained in the `PoolParams`. Moreover, it is not needed for the computation in the spec. Unfortunately, it is becoming harder and harder to keep perfect visual alignment with the code due to implementation details like the reward provenance and the reward pulser. The code does make use of the pool id (which it gets from the pool parameters), but only for these new implementation details... (I would very much like to resurrect an executable specification!)
