### PR TITLE
Debug FeeTooSmall even after genEraTweakBlock

### DIFF
--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -258,33 +258,33 @@ fastPropertyTests =
 manytimes :: String -> Int -> Int -> IO ()
 manytimes prop count _seed =
   defaultMain $
-    ( -- localOption (QuickCheckReplay (Just seed)) $
-      localOption (QuickCheckShowReplay True) $
-        -- localOption (QuickCheckVerbose True) $
-        case prop of
-          "valid" ->
-            ( testProperty
-                "Only valid CHAIN STS signals are generated"
-                (withMaxSuccess count (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
-            )
-          "ada" ->
-            ( testProperty
-                "collection of Ada preservation properties:"
-                (withMaxSuccess count (adaPreservationChain @(AlonzoEra TestCrypto)))
-            )
-          "deleg" ->
-            ( testProperty
-                "STS Rules - Delegation Properties"
-                (withMaxSuccess count (delegProperties @(AlonzoEra TestCrypto)))
-            )
-          other -> error ("unknown test: " ++ other)
+    ( localOption (QuickCheckReplay (Just _seed)) $
+        localOption (QuickCheckShowReplay True) $
+          -- localOption (QuickCheckVerbose True) $
+          case prop of
+            "valid" ->
+              ( testProperty
+                  "Only valid CHAIN STS signals are generated"
+                  (withMaxSuccess count (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
+              )
+            "ada" ->
+              ( testProperty
+                  "collection of Ada preservation properties:"
+                  (withMaxSuccess count (adaPreservationChain @(AlonzoEra TestCrypto)))
+              )
+            "deleg" ->
+              ( testProperty
+                  "STS Rules - Delegation Properties"
+                  (withMaxSuccess count (delegProperties @(AlonzoEra TestCrypto)))
+              )
+            other -> error ("unknown test: " ++ other)
     )
 
 -- ==============================================================================
 -- try to find a quick failure. A quick failure helps debugging turnaround time.
 
--- | run the test, using replay 'seed', timeing out after 'seconds', return 'Nothing' if it timesout.
---   This means the test did not complete in the time alloted. If all tests suceed, it does not return at all,
+-- | Run the test, using replay 'seed', timeing out after 'seconds', return 'Nothing' if it timesout.
+--   This means the test did not complete in the time alloted. If all tests succeed, it does not return at all,
 --   it raises the Exception: ExitSuccess, if it fails in the time allotted it returns (Just ()).
 --   Which is what we are looking for.
 searchForQuickFailure :: Int -> Int -> IO (Maybe ())
@@ -294,11 +294,11 @@ searchForQuickFailure seconds seed = do
       ( localOption
           (QuickCheckReplay (Just seed))
           -- some properties we might use
-          -- (testProperty "preserves ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))
+          (testProperty "preserves ADA" $ adaPreservationChain @(AlonzoEra TestCrypto))
           -- (testProperty "Delegation Properties" (delegProperties @(AlonzoEra TestCrypto)))
           -- fastPropertyTests
           -- (propertyTests @(AlonzoEra TestCrypto))
-          (testProperty "Only valid CHAIN STS signals are generated" (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
+          -- (testProperty "Only valid CHAIN STS signals are generated" (onlyValidLedgerSignalsAreGenerated @(AlonzoEra TestCrypto)))
       )
 
 -- | search for a quick failure using replay seeds 'low' .. 'high'
@@ -306,7 +306,7 @@ search :: Int -> Int -> IO ()
 search low high = mapM_ zzz [low .. high]
   where
     zzz n = do
-      ans <- searchForQuickFailure 10 n
+      ans <- searchForQuickFailure 20 n
       case ans of
         Nothing -> putStrLn ("OK " ++ show n) >> pure (Right ())
         Just () -> putStrLn ("Fails " ++ show n) >> pure (Left n)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -96,7 +96,8 @@ genBlock ge = genBlockWithTxGen genTxs ge
     genTxs :: TxGen era
     genTxs pp reserves ls s = do
       let ledgerEnv = LedgersEnv @era s pp reserves
-      sigGen @(Core.EraRule "LEDGERS" era) ge ledgerEnv ls
+      block <- sigGen @(Core.EraRule "LEDGERS" era) ge ledgerEnv ls
+      genEraTweakBlock @era pp block
 
 genBlockWithTxGen ::
   forall era.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -280,11 +280,19 @@ class
 
   unsafeApplyTx :: Core.Tx era -> TxInBlock era
 
+  -- | compute the delta cost of an additional script on  per Era basis.
   genEraScriptCost :: Core.PParams era -> Core.Script era -> Coin
   genEraScriptCost _pp _script = Coin 0
 
-  genEraDone ::  (Core.Tx era) ->  (Core.Tx era)
-  genEraDone x = x
+  -- | A final opportunity to tweak things when the generator is done. Possible uses
+  --   1) Add tracing when debugging on a per Era basis
+  genEraDone :: Core.PParams era -> (Core.Tx era) -> Gen (Core.Tx era)
+  genEraDone _pp x = pure x
+
+  -- | A final opportunity to tweak things at the block level. Possible uses
+  --   2) Run a test that might decide to 'discard' the test, because we got unlucky, and a rare unfixible condition has occurred.
+  genEraTweakBlock :: Core.PParams era -> Seq (TxInBlock era) -> Gen (Seq (TxInBlock era))
+  genEraTweakBlock _pp seqTx = pure seqTx
 
 
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -298,8 +298,7 @@ genTx
         keySpace
         draftTx
 
-
--- | - Collect additional inputs (and witnesses and keys and scripts) to make
+-- | Collect additional inputs (and witnesses and keys and scripts) to make
 -- the transaction balance.
 data Delta era = Delta
   { dfees :: Coin,
@@ -585,7 +584,7 @@ converge
   keySpace
   tx = do
     delta <- genNextDeltaTilFixPoint scriptinfo initialfee keys scripts utxo pparams keySpace tx
-    pure (genEraDone (applyDelta utxo scriptinfo pparams neededKeys neededScripts keySpace tx delta))
+    genEraDone pparams (applyDelta utxo scriptinfo pparams neededKeys neededScripts keySpace tx delta)
 
 -- | Return up to /k/ random elements from /items/
 -- (instead of the less efficient /take k <$> QC.shuffle items/)


### PR DESCRIPTION
Trying to debug 

    CHAIN level Properties
        collection of Ada preservation properties:                         FAIL (5970.12s)
          *** Failed! (after 222 tests):
          Exception while generating shrink-list:
            LEDGER sigGen: [[UtxowFailure (WrappedShelleyEraFailure (UtxoFailure (FeeTooSmallUTxO (Coin 502) (Coin 2))))]]
            CallStack (from HasCallStack):
              error, called at src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs:181:25 in shelley-spec-ledger-test-0.1.0.0-inplace:Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
