### PR TITLE
Parameterize the type of epochInfoWithError

### DIFF
--- a/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -49,7 +49,8 @@ module Cardano.Ledger.BaseTypes
     activeSlotLog,
 
     -- * STS Base
-    Globals (..),
+    Globals,
+    Globals' (..),
     epochInfo,
     ShelleyBase,
   )
@@ -321,8 +322,10 @@ activeSlotLog f = (fromIntegral $ unActiveSlotLog f) / fpPrecision
 -- Base monad for all STS systems
 --------------------------------------------------------------------------------
 
-data Globals = Globals
-  { epochInfoWithErr :: !(EpochInfo (Either Text)),
+type Globals = Globals' (EpochInfo (Either Text))
+
+data Globals' ei = Globals
+  { epochInfoWithErr :: !ei,
     slotsPerKESPeriod :: !Word64,
     -- | The window size in which our chosen chain growth property
     --   guarantees at least k blocks. From the paper
@@ -353,7 +356,7 @@ data Globals = Globals
   }
   deriving (Show, Generic)
 
-instance NoThunks Globals
+instance NoThunks ei => NoThunks (Globals' ei)
 
 type ShelleyBase = ReaderT Globals Identity
 

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Pretty.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Address
     RewardAcnt (..),
   )
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
-import Cardano.Ledger.BaseTypes (ActiveSlotCoeff, DnsName, FixedPoint, Globals (..), Network (..), Nonce (..), Port (..), StrictMaybe (..), UnitInterval, Url (..), activeSlotLog, activeSlotVal, dnsToText)
+import Cardano.Ledger.BaseTypes (ActiveSlotCoeff, DnsName, FixedPoint, Globals, Globals' (..), Network (..), Nonce (..), Port (..), StrictMaybe (..), UnitInterval, Url (..), activeSlotLog, activeSlotVal, dnsToText)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core (PParamsDelta)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Types.hs
@@ -10,7 +10,7 @@ import Cardano.Ledger.Address as X
     RewardAcnt (..),
   )
 import Cardano.Ledger.BaseTypes as X
-  ( Globals (..),
+  ( Globals' (..),
     Network (..),
     Nonce (..),
     Port (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -20,7 +20,7 @@ module Shelley.Spec.Ledger.API.Validation
   )
 where
 
-import Cardano.Ledger.BaseTypes (Globals (..), ShelleyBase)
+import Cardano.Ledger.BaseTypes (Globals, Globals' (..), ShelleyBase)
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -24,7 +24,7 @@ where
 
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.BaseTypes (Globals (..), Seed, UnitInterval, epochInfo)
+import Cardano.Ledger.BaseTypes (Globals, Globals' (..), Seed, UnitInterval, epochInfo)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -32,7 +32,7 @@ module Shelley.Spec.Ledger.STS.Chain
 where
 
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals' (..),
     Nonce (..),
     ShelleyBase,
     StrictMaybe (..),

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -23,7 +23,7 @@ import Cardano.Binary
     encodeListLen,
   )
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals' (..),
     ShelleyBase,
     epochInfo,
     invalidKey,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -23,7 +23,7 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.BaseTypes (Globals (..), Network, ShelleyBase, epochInfo, invalidKey, networkId)
+import Cardano.Ledger.BaseTypes (Globals' (..), Network, ShelleyBase, epochInfo, invalidKey, networkId)
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Upec.hs
@@ -16,7 +16,7 @@
 -- handles the epoch transitions.
 module Shelley.Spec.Ledger.STS.Upec where
 
-import Cardano.Ledger.BaseTypes (Globals (..), ShelleyBase, StrictMaybe)
+import Cardano.Ledger.BaseTypes (Globals' (..), ShelleyBase, StrictMaybe)
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Shelley.Constraints

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -71,7 +71,7 @@ import Test.Shelley.Spec.Ledger.Utils
     mkHash,
   )
 import Cardano.Ledger.Era(SupportsSegWit(TxSeq))
-import Cardano.Ledger.BaseTypes(UnitInterval)
+import Cardano.Ledger.BaseTypes(Globals, UnitInterval)
 import Cardano.Ledger.Serialization(ToCBORGroup)
 import Test.Shelley.Spec.Ledger.Generator.EraGen
   ( EraGen (..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -71,7 +71,8 @@ import Cardano.Crypto.VRF
   )
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals,
+    Globals' (..),
     Network (..),
     Nonce,
     ShelleyBase,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Federation.hs
@@ -25,7 +25,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
-import Cardano.Ledger.BaseTypes (Globals (..))
+import Cardano.Ledger.BaseTypes (Globals' (..))
 import Cardano.Ledger.Keys
   ( GenDelegPair (..),
     KeyHash (..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolLifetime.hs
@@ -33,7 +33,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals' (..),
     Network (..),
     Nonce,
     StrictMaybe (..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/PoolReReg.hs
@@ -28,7 +28,7 @@ import qualified Data.Set as Set
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals' (..),
     Nonce,
     StrictMaybe (..),
   )

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/TwoPools.hs
@@ -42,7 +42,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( Globals' (..),
     Network (..),
     Nonce,
     StrictMaybe (..),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -49,7 +49,8 @@ import Numeric.Natural (Natural)
 import Shelley.Spec.Ledger.API.Wallet (getRewardInfo)
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
-    Globals (..),
+    Globals,
+    Globals' (..),
     Network (..),
     ShelleyBase,
     StrictMaybe (..),


### PR DESCRIPTION
The fundamental change is here: https://github.com/input-output-hk/cardano-ledger-specs/pull/2344/files#diff-3e75c353cc8150583a6fe776b1b9b0ec87aefbd08207698ad659da8dd11445f4R325