### PR TITLE
Fix broken link to extended utxo spec

### DIFF
--- a/alonzo/formal-spec/frontmatter.tex
+++ b/alonzo/formal-spec/frontmatter.tex
@@ -35,7 +35,7 @@ Integration}
 This document presents modifications to the Shelley ledger
 specification~\cite{shelley_spec} that will enable it to support the requirements for Plutus Foundation, within the context of the Goguen era
 of Cardano. This specification is based on the Plutus system and the extended
-UTxO specification of the mockchain on which it operates, as outlined in~\cite{plutus_eutxo}.
+UTxO specification of the mockchain on which it operates, as outlined in~\cite{chakravarty2020extended}.
 %
 We present a unified way to process both Plutus scripts and Shelley-style multi-signature scripts
 (see~\cite{multi_sig}).

--- a/alonzo/formal-spec/introduction.tex
+++ b/alonzo/formal-spec/introduction.tex
@@ -89,7 +89,7 @@ start of the Alonzo era.
 
 \subsection{Extended UTxO}
 
-The specification of the extended UTxO model follows the description that was given in~\cite{plutus_eutxo}.
+The specification of the extended UTxO model follows the description that was given in~\cite{chakravarty2020extended}.
 All transaction outputs that are locked by non-native scripts must include the hash of an additional ``datum''. The actual datum needs to be supplied by the transaction spending that output, and can be used to encode state, for example.
 While this datum could instead have been stored directly in the UTxO, our choice of storing it in the transaction body improves space efficiency in the implementation by reducing the UTxO storage requirements. The datum is passed to a script that validates that the output is spent correctly.
 

--- a/alonzo/formal-spec/references.bib
+++ b/alonzo/formal-spec/references.bib
@@ -71,12 +71,14 @@
     note = {\url{http://eprint.iacr.org/2016/889}},
 }
 
-@misc{plutus_eutxo,
-label = {CdoUTxoExt},
-author = {{Plutus Team, IOHK}},
-title = {{The Extended UTxO Model}},
-year  = {2019},
-url = {https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}
+@inproceedings{chakravarty2020extended,
+  title={The extended UTXO model},
+  author={Chakravarty, Manuel MT and Chapman, James and MacKenzie, Kenneth and Melkonian, Orestis and Jones, Michael Peyton and Wadler, Philip},
+  booktitle={International Conference on Financial Cryptography and Data Security},
+  pages={525--539},
+  year={2020},
+  organization={Springer},
+  url={https://iohk.io/en/research/library/papers/the-extended-utxo-model/}
 }
 
 @misc{formal_multicur,

--- a/shelley-ma/formal-spec/references.bib
+++ b/shelley-ma/formal-spec/references.bib
@@ -61,12 +61,14 @@
     note = {\url{http://eprint.iacr.org/2016/889}},
 }
 
-@misc{plutus_eutxo,
-label = {CdoUTxoExt},
-author = {{Plutus Team, IOHK}},
-title = {{The Extended UTxO Model}},
-year  = {2019},
-url = {https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}
+@inproceedings{chakravarty2020extended,
+  title={The extended UTXO model},
+  author={Chakravarty, Manuel MT and Chapman, James and MacKenzie, Kenneth and Melkonian, Orestis and Jones, Michael Peyton and Wadler, Philip},
+  booktitle={International Conference on Financial Cryptography and Data Security},
+  pages={525--539},
+  year={2020},
+  organization={Springer},
+  url={https://iohk.io/en/research/library/papers/the-extended-utxo-model/}
 }
 
 @misc{formal_multicur,

--- a/shelley/chain-and-ledger/dependencies/non-integer/doc/references.bib
+++ b/shelley/chain-and-ledger/dependencies/non-integer/doc/references.bib
@@ -85,12 +85,14 @@
     note = {\url{http://eprint.iacr.org/2016/889}},
 }
 
-@misc{plutus_eutxo,
-label = {Plutus-UTxoExt},
-author = {{IOHK Plutus Team}},
-title = {{The Extended UTxO Model, Unnumbered IOHK Technical Report}},
-year  = {2019},
-url = {https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}
+@inproceedings{chakravarty2020extended,
+  title={The extended UTXO model},
+  author={Chakravarty, Manuel MT and Chapman, James and MacKenzie, Kenneth and Melkonian, Orestis and Jones, Michael Peyton and Wadler, Philip},
+  booktitle={International Conference on Financial Cryptography and Data Security},
+  pages={525--539},
+  year={2020},
+  organization={Springer},
+  url={https://iohk.io/en/research/library/papers/the-extended-utxo-model/}
 }
 
 @conference{ouroboros_classic,

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -686,7 +686,7 @@ spent inputs that are locked by scripts and the consumed withdrawals that are lo
 
 There are different implementation possibilities for the introduced
 multi-signature scheme. Section~\ref{sec:plutus-scripts} describes an
-implementation based on Plutus~\cite{plutus_eutxo} which uses only simple
+implementation based on Plutus~\cite{chakravarty2020extended} which uses only simple
 scripts, without redeemer or data
 scripts. Section~\ref{sec:native-script-interp} describes an alternative
 implementation that supports validation using a
@@ -729,7 +729,7 @@ corresponds to such a Plutus validator script. Its type consists of two
 parameters of unit type and one parameter of type $\PendingTx$; its return type
 is Boolean. The first two input parameters correspond to the redeemer and the
 data scripts which are used in the full extended UTxO model for
-Plutus~\cite{plutus_eutxo}. As those values are not required for simple
+Plutus~\cite{chakravarty2020extended}. As those values are not required for simple
 multi-signature, we use the unit type for them. The Boolean return type signals
 whether the script succeeded in validating the transaction. The function
 $\fun{validateScript}$ specialized for $\ScriptPlutus$ takes a Plutus script

--- a/shelley/chain-and-ledger/formal-spec/references.bib
+++ b/shelley/chain-and-ledger/formal-spec/references.bib
@@ -85,12 +85,14 @@
     note = {\url{http://eprint.iacr.org/2016/889}},
 }
 
-@misc{plutus_eutxo,
-label = {Plutus-UTxoExt},
-author = {{IOHK Plutus Team}},
-title = {{The Extended UTxO Model, Unnumbered IOHK Technical Report}},
-year  = {2019},
-url = {https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}
+@inproceedings{chakravarty2020extended,
+  title={The extended UTXO model},
+  author={Chakravarty, Manuel MT and Chapman, James and MacKenzie, Kenneth and Melkonian, Orestis and Jones, Michael Peyton and Wadler, Philip},
+  booktitle={International Conference on Financial Cryptography and Data Security},
+  pages={525--539},
+  year={2020},
+  organization={Springer},
+  url={https://iohk.io/en/research/library/papers/the-extended-utxo-model/}
 }
 
 @conference{ouroboros_classic,

--- a/shelley/chain-and-ledger/formal-spec/scripts-multicurrency.tex
+++ b/shelley/chain-and-ledger/formal-spec/scripts-multicurrency.tex
@@ -546,7 +546,7 @@ part of transaction (perhaps $\outRefs tx$?).
 
 \section{Extended UTxO}
 
-The main documentation is \href{https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}{here}.
+The main documentation is \href{https://github.com/input-output-hk/plutus/blob/master/extended-utxo-spec/extended-utxo-specification.tex}{here}.
 We need to add the data script to TxOut:
 $$ \TxOut = \Addr \times \Value \times \Script $$
 We also need to provide the validator script with more information.  Is the $\TxBody$ enough?

--- a/shelley/design-spec/references.bib
+++ b/shelley/design-spec/references.bib
@@ -85,12 +85,14 @@
     note = {\url{http://eprint.iacr.org/2016/889}},
 }
 
-@misc{plutus_eutxo,
-label = {Plutus-UTxoExt},
-author = {{IOHK Plutus Team}},
-title = {{The Extended UTxO Model, Unnumbered IOHK Technical Report}},
-year  = {2019},
-url = {https://github.com/input-output-hk/plutus/tree/master/docs/extended-utxo}
+@inproceedings{chakravarty2020extended,
+  title={The extended UTXO model},
+  author={Chakravarty, Manuel MT and Chapman, James and MacKenzie, Kenneth and Melkonian, Orestis and Jones, Michael Peyton and Wadler, Philip},
+  booktitle={International Conference on Financial Cryptography and Data Security},
+  pages={525--539},
+  year={2020},
+  organization={Springer},
+  url={https://iohk.io/en/research/library/papers/the-extended-utxo-model/}
 }
 
 @conference{ouroboros_classic,


### PR DESCRIPTION
I wasn't sure if we can fix the link in a spec or not, but here is a PR that fixes a 404 on extended-utxo link.
An alternative or maybe together with this fix we can place a markdown file into the original directory: `docs/extended-utxo` in the plutus repo:

```markdown
[Extended Utxo Spec](../extended-utxo-spec/extended-utxo-specification.tex)
````
