### PR TITLE
Canonical creation of WitnessPPdata

### DIFF
--- a/alonzo/test/cardano-ledger-alonzo-test.cabal
+++ b/alonzo/test/cardano-ledger-alonzo-test.cabal
@@ -74,6 +74,7 @@ test-suite cardano-ledger-alonzo-test
   other-modules:
     Test.Cardano.Ledger.Alonzo.Trials
     Test.Cardano.Ledger.Alonzo.Golden
+    Test.Cardano.Ledger.Alonzo.Serialisation.Canonical
     Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
     Test.Cardano.Ledger.Alonzo.Examples
     Test.Cardano.Ledger.Alonzo.Translation

--- a/alonzo/test/cddl-files/alonzo.cddl
+++ b/alonzo/test/cddl-files/alonzo.cddl
@@ -76,6 +76,41 @@ transaction_output =
   ]
 
 script_data_hash = $hash32 ; New
+; This is a hash of data which may affect evaluation of a script.
+; This data consists of:
+;   - The redeemers from the transaction_witness_set (the value of field 5).
+;   - The datums from the transaction_witness_set (the value of field 4).
+;   - The value in the costmdls map corresponding to the script's language
+;     (in field 18 of protocol_param_update.)
+; (In the future it may contain additional protocol parameters.)
+;
+; Since this data does not exist in contiguous form inside a transaction, it needs
+; to be independently constructed by each recipient.
+;
+; script data format:
+; [ redeemers | datums | language views ]
+; The redeemers are exactly the data present in the transaction witness set.
+; Similarly for the datums, if present. If no datums are provided, the middle
+; field is an empty string.
+;
+; language views CDDL:
+; { * language => script_integrity_data }
+;
+; This must be encoded canonically, using the same scheme as in
+; RFC7049 section 3.9:
+;  - Maps, strings, and bytestrings must use a definite-length encoding
+;  - Integers must be as small as possible.
+;  - The expressions for map length, string length, and bytestring length
+;    must be as short as possible.
+;  - The keys in the map must be sorted as follows:
+;     -  If two keys have different lengths, the shorter one sorts earlier.
+;     -  If two keys have the same length, the one with the lower value
+;        in (byte-wise) lexical order sorts earlier.
+;
+; For PlutusV1 (language id 0), the script integrity data is a cost_model.
+; This is the value of the costmdls map at key 0.
+; If there is no value for key 0, then the corresponding scripts cannot execute.
+; Regardless of what the script integrity data is.
 
 ; address = bytes
 ; reward_account = bytes

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Canonical.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Canonical.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Cardano.Ledger.Alonzo.Serialisation.Canonical (tests) where
+
+import Cardano.Binary
+  ( Annotator (..),
+    Decoder,
+    TokenType (..),
+    decodeAnnotator,
+    decodeBytesCanonical,
+    decodeDoubleCanonical,
+    decodeIntegerCanonical,
+    decodeMapLenCanonical,
+    decodeSimpleCanonical,
+    decodeStringCanonical,
+    peekTokenType,
+    serializeEncoding,
+    withSlice,
+  )
+import Cardano.Ledger.Alonzo.Language (Language)
+import Cardano.Ledger.Alonzo.PParams
+import Control.Monad (replicateM, unless)
+import qualified Data.ByteString.Base16 as B16
+import Data.ByteString.Lazy as LBS
+import Data.Functor.Compose (Compose (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import qualified Test.QuickCheck.Property as QCP
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testProperty "LangDepView encoding is canonical" canonicalLangDepView
+
+canonicalLangDepView :: PParams era -> Set Language -> Property
+canonicalLangDepView pparams langs =
+  let langViews = Set.fromList $ getLanguageView pparams <$> Set.toList langs
+      encodedViews = serializeEncoding $ encodeLangViews langViews
+      base16String = show (B16.encode $ LBS.toStrict encodedViews)
+   in counterexample base16String $ case isCanonical encodedViews of
+        Right () -> QCP.succeeded
+        Left message -> QCP.failed {QCP.reason = message}
+
+isCanonical :: LBS.ByteString -> Either String ()
+isCanonical bytes =
+  case decodeAnnotator "canonicity check" checkCanonicalTerm bytes of
+    Left err -> Left (show err)
+    Right x -> x
+
+checkCanonicalTerm :: Decoder s (Annotator (Either String ()))
+checkCanonicalTerm = do
+  tt <- peekTokenType
+  let t _ = pure (Right ())
+  case tt of
+    TypeUInt -> t <$> decodeIntegerCanonical
+    TypeUInt64 -> t <$> decodeIntegerCanonical
+    TypeNInt -> t <$> decodeIntegerCanonical
+    TypeNInt64 -> t <$> decodeIntegerCanonical
+    TypeInteger -> t <$> decodeIntegerCanonical
+    TypeFloat16 -> t <$> decodeDoubleCanonical
+    TypeFloat32 -> t <$> decodeDoubleCanonical
+    TypeFloat64 -> t <$> decodeDoubleCanonical
+    TypeBytes -> t <$> decodeBytesCanonical
+    TypeBytesIndef -> fail "indefinite bytes encoding"
+    TypeString -> t <$> decodeStringCanonical
+    TypeStringIndef -> fail "indefinite string encoding"
+    --TypeListLen ->
+    --TypeListLen64 ->
+    TypeListLenIndef -> fail "indefinite list encoding"
+    TypeMapLen -> checkCanonicalMap
+    TypeMapLen64 -> checkCanonicalMap
+    TypeMapLenIndef -> fail "indefinite map encoding"
+    --TypeTag ->
+    --TypeTag64 ->
+    --TypeBool ->
+    --TypeNull ->
+    TypeSimple -> t <$> decodeSimpleCanonical
+    --TypeBreak ->
+    --TypeInvalid ->
+    _ -> fail "canonicity check not implemented"
+
+{-
+- The keys in the map must be sorted as follows:
+   -  If two keys have different lengths, the shorter one sorts earlier.
+   -  If two keys have the same length, the one with the lower value
+      in (byte-wise) lexical order sorts earlier.
+-}
+
+shortLex :: ByteString -> ByteString -> Ordering
+shortLex x y = case compare (LBS.length x) (LBS.length y) of
+  LT -> LT
+  GT -> GT
+  EQ -> compare (LBS.unpack x) (LBS.unpack y)
+
+checkCanonicalMap :: Decoder s (Annotator (Either String ()))
+checkCanonicalMap = do
+  n <- decodeMapLenCanonical
+  keys <- replicateM n checkCanonicalKVPair
+  let keys' :: Annotator (Either String [ByteString])
+      keys' = (getCompose . sequenceA . fmap Compose) keys
+  pure $
+    Annotator $ \fullBytes -> do
+      ks <- runAnnotator keys' fullBytes
+      unless (isSorted ks) (Left "map keys out of order")
+
+isSorted :: [ByteString] -> Bool
+isSorted [] = True
+isSorted [_] = True
+isSorted (x : (xs@(y : _))) = case shortLex x y of
+  GT -> False
+  _ -> isSorted xs
+
+checkCanonicalKVPair :: Decoder s (Annotator (Either String ByteString))
+checkCanonicalKVPair = do
+  (key, keyBytes) <- withSlice checkCanonicalTerm
+  value <- checkCanonicalTerm
+  pure $ getCompose (Compose key *> Compose value *> Compose (Right <$> keyBytes))

--- a/alonzo/test/test/Tests.hs
+++ b/alonzo/test/test/Tests.hs
@@ -11,6 +11,7 @@ module Main where
 import Test.Cardano.Ledger.Alonzo.Examples (plutusScriptExamples)
 import Test.Cardano.Ledger.Alonzo.Golden as Golden
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.CDDL as CDDL
+import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Canonical as Canonical
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
 import Test.Cardano.Ledger.Alonzo.Trials (alonzoPropertyTests, fastPropertyTests)
@@ -32,6 +33,7 @@ mainTests =
     [ fastPropertyTests, -- These are still pretty slow (it is just that a few are omitted)
       Tripping.tests,
       Translation.tests,
+      Canonical.tests,
       CDDL.tests 5,
       Golden.goldenUTxOEntryMinAda,
       plutusScriptExamples


### PR DESCRIPTION
- Removed annotations from LangDepView, since these are intermediate
  values which are never transmitted/decoded.
- Changed LangDepView representation to a pair of ByteStrings.
- Test for canonicity of encoded lang dep view.
- Added explanation of WitnessPPData data hash to CDDL.