### PR TITLE
Restrict pool metadata hash

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/SoftForks.hs
@@ -4,6 +4,7 @@
 
 module Shelley.Spec.Ledger.SoftForks
   ( validMetadata,
+    restrictPoolMetadataHash,
   )
 where
 
@@ -15,3 +16,9 @@ validMetadata ::
   pp ->
   Bool
 validMetadata pp = getField @"_protocolVersion" pp > ProtVer 2 0
+
+restrictPoolMetadataHash ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+restrictPoolMetadataHash pp = getField @"_protocolVersion" pp > ProtVer 4 0


### PR DESCRIPTION
As per the CDDL, this should be 32 bytes. This adds a rule to start enforcing the restriction starting at major PV 5.