### PR TITLE
Fix `hashWitnessPPData`

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -269,11 +269,8 @@ hashWitnessPPData pp langs rdmrs dats =
   if (Map.null $ unRedeemers rdmrs) && Set.null langs
     then SNothing
     else
-      let newset = mapLangSet (getLanguageView pp) langs
+      let newset = Set.map (getLanguageView pp) langs
        in SJust (hashAnnotated (WitnessPPData rdmrs dats newset))
-  where
-    mapLangSet :: (Language -> LangDepView era) -> (Set Language -> Set (LangDepView era))
-    mapLangSet f = Set.foldr (\x acc -> Set.insert (f x) acc) mempty
 
 -- ===============================================================
 -- From the specification, Figure 5 "Functions related to fees"

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -98,6 +98,7 @@ import Cardano.Ledger.Alonzo.TxWitness
     TxDats (..),
     TxWitness (..),
     nullDats,
+    nullRedeemers,
     ppTxWitness,
     txrdmrs,
     unRedeemers,
@@ -266,7 +267,7 @@ hashWitnessPPData ::
   TxDats era ->
   StrictMaybe (WitnessPPDataHash (Crypto era))
 hashWitnessPPData pp langs rdmrs dats =
-  if (Map.null $ unRedeemers rdmrs) && Set.null langs
+  if nullRedeemers rdmrs && Set.null langs && nullDats dats
     then SNothing
     else
       let newset = Set.map (getLanguageView pp) langs

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -947,7 +947,8 @@ okSupplimentaryDatumTxBody pf =
     pf
     [ Inputs [TxIn genesisId 3],
       Outputs [outEx10 pf],
-      Txfee (Coin 5)
+      Txfee (Coin 5),
+      WppHash (newWppHash pf (pp pf) [] (Redeemers mempty) txDatsExample1)
     ]
 
 okSupplimentaryDatumTx ::
@@ -1332,8 +1333,11 @@ notOkSupplimentaryDatumTxBody pf =
     pf
     [ Inputs [TxIn genesisId 3],
       Outputs [outputWithNoDatum pf],
-      Txfee (Coin 5)
+      Txfee (Coin 5),
+      WppHash (newWppHash pf (pp pf) [] (Redeemers mempty) totallyIrrelevantTxDats)
     ]
+  where
+    totallyIrrelevantTxDats = TxDats $ keyBy hashData [totallyIrrelevantDatum]
 
 notOkSupplimentaryDatumTx ::
   forall era.

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -397,6 +397,7 @@ closure env st0 sigs = mkTrace env st0 <$> loop st0 (reverse sigs) []
    . ( MonadIO m
      , MonadReader (st -> sig -> Either err st) m
      , Show err
+     , HasCallStack
      )
   => m st -> sig -> m st
 mSt .- sig = do
@@ -410,7 +411,7 @@ mSt .- sig = do
 -- the expected state, given in the second argument.
 (.->)
   :: forall m st
-   . (MonadIO m, Eq st, Show st)
+   . (MonadIO m, Eq st, Show st, HasCallStack)
   => m st -> st -> m st
 mSt .-> stExpected = do
   stActual <- mSt


### PR DESCRIPTION
There seems to be a mismatch with the spec:

![image](https://user-images.githubusercontent.com/2333894/123842444-7416e780-d919-11eb-96f3-e2d48755c858.png)

In particular there is no check that the `TxDats` (`dats`) is an empty set.


Also `mapLangSet` was historically a `mapMaybe`, but not long ago was changed into what is a `Set.map`. Simplified current implementation.