### PR TITLE
reverting use of the optimized isBootstrapRedeemer

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/CompactAddr.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/CompactAddr.hs
@@ -215,6 +215,8 @@ getPayCred header = case testBit header payCredIsScript of
   True -> getScriptHash
   False -> getKeyHash
 
+-- | WARNING: This optimized version of isBootstrapRedeemer does not agree
+-- with the one in Cardano.Ledger.Address
 isBootstrapRedeemer :: CompactAddr crypto -> Bool
 isBootstrapRedeemer (UnsafeCompactAddr bytes) =
   testBit header byron -- AddrBootstrap

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -106,7 +106,7 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.Address (Addr (..), bootstrapKeyHash)
+import Cardano.Ledger.Address (Addr (..), bootstrapKeyHash, isBootstrapRedeemer)
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     ShelleyBase,
@@ -187,7 +187,6 @@ import Shelley.Spec.Ledger.Address.Bootstrap
     bootstrapWitKeyHash,
     verifyBootstrapWit,
   )
-import Shelley.Spec.Ledger.CompactAddr (CompactAddr (..), isBootstrapRedeemer)
 import Shelley.Spec.Ledger.Delegation.Certificates
   ( DCert (..),
     PoolDistr (..),
@@ -1326,7 +1325,7 @@ updateNES
 
 returnRedeemAddrsToReserves ::
   forall era.
-  (Era era, HasField "compactAddress" (Core.TxOut era) (CompactAddr (Crypto era))) =>
+  (Era era, HasField "address" (Core.TxOut era) (Addr (Crypto era))) =>
   EpochState era ->
   EpochState era
 returnRedeemAddrsToReserves es = es {esAccountState = acnt', esLState = ls'}
@@ -1337,7 +1336,7 @@ returnRedeemAddrsToReserves es = es {esAccountState = acnt', esLState = ls'}
     (redeemers, nonredeemers) =
       Map.partition
         ( \out ->
-            isBootstrapRedeemer (getField @"compactAddress" out)
+            isBootstrapRedeemer (getField @"address" out)
         )
         utxo
     acnt = esAccountState es

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/CompactAddr.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/CompactAddr.hs
@@ -62,6 +62,7 @@ propDecompactShelleyLazyAddr = do
       keyHash1 = unsafeGetHash . CA.decompactAddr . mangle . CA.compactAddr $ addr
    in pure $ keyHash0 == keyHash1
 
+-- | TODO This property test is failing to find a discrepancy that was found on mainnet.
 propIsBootstrapRedeemer :: Addr crypto -> Property
 propIsBootstrapRedeemer addr =
   Addr.isBootstrapRedeemer addr === CA.isBootstrapRedeemer (CA.compactAddr addr)


### PR DESCRIPTION
A discrepancy was found on mainnet with the optimized `isBootstrapRedeemer`.