### PR TITLE
fix the relevantCasesAreCovered test that fails because of too many discards.

### DIFF
--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -310,3 +310,16 @@ search low high = mapM_ zzz [low .. high]
       case ans of
         Nothing -> putStrLn ("OK " ++ show n) >> pure (Right ())
         Just () -> putStrLn ("Fails " ++ show n) >> pure (Left n)
+
+-- ==============================
+
+go :: IO ()
+go =
+  defaultMain $
+    testGroup
+      "Fast Alonzo Property Tests"
+      [ testProperty
+          "Chain and Ledger traces cover the relevant cases"
+          -- (withDiscardRatio 0
+          (withMaxSuccess 10 (relevantCasesAreCovered @(AlonzoEra TestCrypto)))
+      ]

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -246,7 +246,9 @@ fastPropertyTests :: TestTree
 fastPropertyTests =
   testGroup
     "Fast Alonzo Property Tests"
-    [ testProperty "Chain and Ledger traces cover the relevant cases" (withMaxSuccess 10 (relevantCasesAreCovered @(AlonzoEra TestCrypto))),
+    [ ( localOption (QuickCheckMaxRatio 45) $
+          testProperty "Chain and Ledger traces cover the relevant cases" (withMaxSuccess 10 (relevantCasesAreCovered @(AlonzoEra TestCrypto)))
+      ),
       testProperty "total amount of Ada is preserved (Chain)" (withMaxSuccess 50 (adaPreservationChain @(AlonzoEra TestCrypto)))
     ]
 
@@ -318,8 +320,9 @@ go =
   defaultMain $
     testGroup
       "Fast Alonzo Property Tests"
-      [ testProperty
-          "Chain and Ledger traces cover the relevant cases"
-          -- (withDiscardRatio 0
-          (withMaxSuccess 10 (relevantCasesAreCovered @(AlonzoEra TestCrypto)))
+      [ ( localOption (QuickCheckMaxRatio 45) $
+            testProperty
+              "Chain and Ledger traces cover the relevant cases"
+              (withMaxSuccess 10 (relevantCasesAreCovered @(AlonzoEra TestCrypto)))
+        )
       ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -116,6 +116,11 @@ import Test.Shelley.Spec.Ledger.Utils (Split (..))
 import Cardano.Ledger.Era(Era)
 import NoThunks.Class()  -- Instances only
 
+import Debug.Trace(trace)
+
+myDiscard :: [Char] -> a
+myDiscard message = trace ("\nDiscarded trace: "++message) discard
+
 -- ====================================================
 
 showBalance ::
@@ -258,7 +263,8 @@ genTx
       -- Occasionally we have a transaction generated with insufficient inputs
       -- to cover the deposits. In this case we discard the test case.
       let enough = (length outputAddrs) <×> (getField @"_minUTxOValue" pparams)
-      !_ <- when (coin spendingBalance < coin enough) discard
+      !_ <- when (coin spendingBalance < coin enough)
+              (myDiscard ("not enough coin in outputs. needed: "++show enough++", available: "++show spendingBalance) discard)
 
       -------------------------------------------------------------------------
       -- Build a Draft Tx and repeatedly add to Delta until all fees are
@@ -441,7 +447,7 @@ genNextDelta
                 -- testing framework to generate almost-random transactions that always succeed every time.
                 -- Experience suggests that this happens less than 1% of the time, and does not lead to backtracking.
 
-                !_ <- when (null inputs) discard
+                !_ <- when (null inputs) (myDiscard ("Can't generate a new input, the Utxo is empty") discard)
 
                 let newWits =
                       mkTxWits @era

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -73,7 +73,7 @@ import Test.Shelley.Spec.Ledger.Rules.TestChain
 import Test.Shelley.Spec.Ledger.ShelleyTranslation (testGroupShelleyTranslation)
 import Test.Shelley.Spec.Ledger.Utils (ChainProperty)
 import Cardano.Ledger.Era(SupportsSegWit(TxInBlock))
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestTree, testGroup, localOption)
 import qualified Test.Tasty.QuickCheck as TQC
 
 import Cardano.Ledger.Keys(KeyRole(Witness))
@@ -108,7 +108,7 @@ minimalPropertyTests ::
 minimalPropertyTests =
   testGroup
     "Minimal Property Tests"
-    [ (localOption (QuickCheckMaxRatio 45) $ TQC.testProperty "Chain and Ledger traces cover the relevant cases" (relevantCasesAreCovered @era)),
+    [ (localOption (TQC.QuickCheckMaxRatio 50) $ TQC.testProperty "Chain and Ledger traces cover the relevant cases" (relevantCasesAreCovered @era)),
       TQC.testProperty "total amount of Ada is preserved (Chain)" (adaPreservationChain @era),
       TQC.testProperty "Only valid CHAIN STS signals are generated" (onlyValidChainSignalsAreGenerated @era),
       bootstrapHashTest,
@@ -153,7 +153,7 @@ propertyTests =
     "Property-Based Testing"
     [ testGroup
         "Classify Traces"
-        [  (localOption (QuickCheckMaxRatio 45) $
+        [  (localOption (TQC.QuickCheckMaxRatio 50) $
             TQC.testProperty
             "Chain and Ledger traces cover the relevant cases"
             (relevantCasesAreCovered @era))

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -108,7 +108,7 @@ minimalPropertyTests ::
 minimalPropertyTests =
   testGroup
     "Minimal Property Tests"
-    [ TQC.testProperty "Chain and Ledger traces cover the relevant cases" (relevantCasesAreCovered @era),
+    [ (localOption (QuickCheckMaxRatio 45) $ TQC.testProperty "Chain and Ledger traces cover the relevant cases" (relevantCasesAreCovered @era)),
       TQC.testProperty "total amount of Ada is preserved (Chain)" (adaPreservationChain @era),
       TQC.testProperty "Only valid CHAIN STS signals are generated" (onlyValidChainSignalsAreGenerated @era),
       bootstrapHashTest,
@@ -153,9 +153,10 @@ propertyTests =
     "Property-Based Testing"
     [ testGroup
         "Classify Traces"
-        [ TQC.testProperty
+        [  (localOption (QuickCheckMaxRatio 45) $
+            TQC.testProperty
             "Chain and Ledger traces cover the relevant cases"
-            (relevantCasesAreCovered @era)
+            (relevantCasesAreCovered @era))
         ],
       testGroup
         "STS Rules - Delegation Properties"


### PR DESCRIPTION
It looks as if the limit on the number of discards is 40. We are now getting failures where the discards is 40, and we are 1 test away from suceeding. 
I changed the local limit on the number of discards, for just the one test relevantCasesAreCovered, to 45.

