### PR TITLE
Fix a0 serialization

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     UnitInterval,
     fromSMaybe,
+    isSNothing,
   )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Era
@@ -402,10 +403,6 @@ encodePParamsUpdate ppup =
     fromSJust :: StrictMaybe a -> a
     fromSJust (SJust x) = x
     fromSJust SNothing = error "SNothing in fromSJust. This should never happen, it is guarded by isSNothing."
-
-    isSNothing :: StrictMaybe a -> Bool
-    isSNothing SNothing = True
-    isSNothing (SJust _) = False
 
 instance (Era era) => ToCBOR (PParamsUpdate era) where
   toCBOR ppup = encode (encodePParamsUpdate ppup)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -70,6 +70,7 @@ import Cardano.Ledger.Alonzo.Data (AuxiliaryDataHash (..), DataHash)
 import Cardano.Ledger.BaseTypes
   ( Network,
     StrictMaybe (..),
+    isSNothing,
   )
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible
@@ -515,10 +516,6 @@ encodeTxBodyRaw
     where
       encodeKeyedStrictMaybe key x =
         Omit isSNothing (Key key (E (toCBOR . fromSJust) x))
-
-      isSNothing :: StrictMaybe a -> Bool
-      isSNothing SNothing = True
-      isSNothing _ = False
 
       fromSJust :: StrictMaybe a -> a
       fromSJust (SJust x) = x

--- a/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -42,6 +42,7 @@ module Cardano.Ledger.BaseTypes
     strictMaybeToMaybe,
     maybeToStrictMaybe,
     fromSMaybe,
+    isSNothing,
     Url,
     urlToText,
     textToUrl,
@@ -602,3 +603,7 @@ instance FromCBOR Network where
     word8ToNetwork <$> fromCBOR >>= \case
       Nothing -> cborError $ DecoderErrorCustom "Network" "Unknown network id"
       Just n -> pure n
+
+isSNothing :: StrictMaybe a -> Bool
+isSNothing SNothing = True
+isSNothing _ = False

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/BaseTypes.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/BaseTypes.hs
@@ -93,7 +93,11 @@ boundedRationalTests badJSONValues =
                | (testName, invalidInput) <- badJSONValues
              ],
       testProperty "CBOR roundtrip" $ \(br :: a) ->
-        either (error . show) (br ==) $ Binary.decodeFull (Binary.serialize br)
+        either (error . show) (br ==) $ Binary.decodeFull (Binary.serialize br),
+      testProperty "CBOR BoundedRational roundtrip" $ \(br :: a) ->
+        either (error . show) (br ==) $
+          Binary.decodeFullDecoder "BoundedRational" boundedRationalFromCBOR $
+            Binary.serializeEncoding (boundedRationalToCBOR br)
     ]
   where
     boundedFromJSON = eitherDecode :: ByteString -> Either String a

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -38,7 +38,6 @@ module Cardano.Ledger.ShelleyMA.TxBody
     txSparse,
     bodyFields,
     StrictMaybe (..),
-    isSNothing,
     fromSJust,
     ValidityInterval (..),
     initial,
@@ -48,7 +47,7 @@ where
 
 import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
-import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
+import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing), isSNothing)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (PParamsDelta, Script, Value)
 import qualified Cardano.Ledger.Core as Core
@@ -190,10 +189,6 @@ instance
   FromCBOR (Annotator (TxBodyRaw era))
   where
   fromCBOR = pure <$> fromCBOR
-
-isSNothing :: StrictMaybe a -> Bool
-isSNothing SNothing = True
-isSNothing _ = False
 
 fromSJust :: StrictMaybe a -> a
 fromSJust (SJust x) = x

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardUpdate.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardUpdate.hs
@@ -26,6 +26,8 @@ import Cardano.Ledger.BaseTypes
     NonNegativeInterval,
     ShelleyBase,
     UnitInterval,
+    boundedRationalFromCBOR,
+    boundedRationalToCBOR,
   )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Credential (Credential (..))
@@ -178,7 +180,7 @@ instance NFData (RewardSnapShot crypto)
 instance CC.Crypto crypto => ToCBOR (RewardSnapShot crypto) where
   toCBOR (RewardSnapShot ss a0 nopt ver nm dr1 r dt1 tot pot) =
     encode
-      ( Rec RewardSnapShot !> To ss !> To a0 !> To nopt !> To ver !> To nm !> To dr1
+      ( Rec RewardSnapShot !> To ss !> E boundedRationalToCBOR a0 !> To nopt !> To ver !> To nm !> To dr1
           !> To r
           !> To dt1
           !> To tot
@@ -186,7 +188,7 @@ instance CC.Crypto crypto => ToCBOR (RewardSnapShot crypto) where
       )
 
 instance CC.Crypto crypto => FromCBOR (RewardSnapShot crypto) where
-  fromCBOR = decode (RecD RewardSnapShot <! From <! From <! From <! From <! From <! From <! From <! From <! From <! From)
+  fromCBOR = decode (RecD RewardSnapShot <! From <! D boundedRationalFromCBOR <! From <! From <! From <! From <! From <! From <! From <! From)
 
 -- Some functions that only need a subset of the PParams can be
 -- passed a RewardSnapShot, as it copies of some values from PParams
@@ -255,7 +257,7 @@ instance (CC.Crypto crypto) => ToCBOR (FreeVars crypto) where
             !> To r
             !> To slotsPerEpoch
             !> To pp_d
-            !> To pp_a0
+            !> E boundedRationalToCBOR pp_a0
             !> To pp_nOpt
         )
 
@@ -270,7 +272,7 @@ instance (CC.Crypto crypto) => FromCBOR (FreeVars crypto) where
           <! From {- r -}
           <! From {- slotsPerEpoch -}
           <! From {- pp_d -}
-          <! From {- pp_a0 -}
+          <! D boundedRationalFromCBOR {- pp_a0 -}
           <! From {- pp_nOpt -}
       )
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -101,6 +101,7 @@ import Cardano.Ledger.BaseTypes
     UnitInterval,
     Url,
     invalidKey,
+    isSNothing,
     maybeToStrictMaybe,
     strictMaybeToMaybe,
   )
@@ -742,10 +743,6 @@ instance
 --   Neither the Omit or the key is needed for Decoders.
 omitStrictNothingDual :: (FromCBOR t, ToCBOR t) => Dual (StrictMaybe t)
 omitStrictNothingDual = Dual (toCBOR . fromJust . strictMaybeToMaybe) (SJust <$> fromCBOR)
-
-isSNothing :: StrictMaybe a -> Bool
-isSNothing SNothing = True
-isSNothing _ = False
 
 -- | Choose a de-serialiser when given the key (of type Word).
 --   Wrap it in a Field which pairs it with its update function which


### PR DESCRIPTION
#2343 changed serialization of `a0` param in `FreeVars` and `RewardSnapShot` data types, which was an unintentional breaking change to CBOR serialization. `PParams`  have not been affected because correct serialization was used for the `a0` param.

This PR fixes this oversight. Also there is a separate commit that reduces some code duplication