### PR TITLE
Slim down deps on Plutus

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -66,8 +66,6 @@ library
     mtl,
     nothunks,
     plutus-ledger-api,
-    plutus-tx,
-    plutus-core,
     serialise,
     shelley-spec-ledger,
     small-steps,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -85,7 +85,7 @@ import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
-import qualified PlutusTx as Plutus
+import qualified Plutus.V1.Ledger.Api as Plutus
 import Shelley.Spec.Ledger.Metadata (Metadatum)
 
 -- =====================================================================

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -56,9 +56,13 @@ import qualified Plutus.V1.Ledger.Address as P (Address (..))
 import qualified Plutus.V1.Ledger.Api as P
   ( DCert (..),
     ExBudget (..),
+    ExCPU (..),
+    ExMemory (..),
     VerboseMode (..),
     evaluateScriptRestricting,
     validateScript,
+    Data (..),
+    IsData (..)
   )
 import qualified Plutus.V1.Ledger.Contexts as P
   ( ScriptContext (..),
@@ -81,9 +85,6 @@ import qualified Plutus.V1.Ledger.Time as P (POSIXTime (..), POSIXTimeRange)
 import qualified Plutus.V1.Ledger.Tx as P (TxOutRef (..))
 import qualified Plutus.V1.Ledger.TxId as P (TxId (..))
 import qualified Plutus.V1.Ledger.Value as P (CurrencySymbol (..), TokenName (..), Value (..), singleton, unionWith)
-import qualified PlutusCore.Evaluation.Machine.ExMemory as P (ExCPU (..), ExMemory (..))
-import qualified PlutusTx as P (Data (..))
-import qualified PlutusTx.IsData.Class as P (IsData (..))
 import Shelley.Spec.Ledger.Scripts (ScriptHash (..))
 import Shelley.Spec.Ledger.TxBody
   ( DCert (..),

--- a/cabal.project
+++ b/cabal.project
@@ -61,8 +61,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 2d2a5da2a73a5d1789f8f789ec034ab978754f11
-  --sha256: 1chb3pwfs1g4q4ln5605v10dmbkvqsk6kcvylm0ak604gpjbd2n0
+  tag: c5288007b091760631764e860ad3bf7e4933f932
+  --sha256: 13incb43h8vb6vpc97wkzhj1iimisf7vsa6dvm1qgx3kla0b90a1
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/cardano-ledger-test/cardano-ledger-test.cabal
@@ -55,7 +55,6 @@ library
     genvalidity,
     genvalidity-scientific,
     plutus-ledger-api,
-    plutus-tx,
     scientific,
     shelley-spec-ledger,
     shelley-spec-ledger-test,

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -96,7 +96,7 @@ import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Numeric.Natural (Natural)
 import Plutus.V1.Ledger.Api (defaultCostModelParams)
-import qualified PlutusTx as Plutus
+import qualified Plutus.V1.Ledger.Api as Plutus
 import Shelley.Spec.Ledger.API
   ( BHBody (..),
     BHeader (..),

--- a/plutus-preprocessor/src/Main.hs
+++ b/plutus-preprocessor/src/Main.hs
@@ -17,7 +17,7 @@ import Flat (flat)
 import Data.ByteString.Short (ShortByteString, toShort, pack, unpack)
 import Codec.Serialise (serialise)
 import Data.ByteString.Lazy (toStrict)
-import qualified Plutus.V1.Ledger.Scripts as P
+import qualified Plutus.V1.Ledger.Api as P
 import qualified PlutusTx as P (Data (..), compile)
 import qualified PlutusTx.Prelude as P
 import Language.Haskell.TH.Ppr

--- a/plutus-preprocessor/src/PlutusScripts.hs
+++ b/plutus-preprocessor/src/PlutusScripts.hs
@@ -11,7 +11,7 @@ module PlutusScripts
     sumsTo10Decl,
   ) where
 
-import qualified Plutus.V1.Ledger.Scripts as P
+import qualified Plutus.V1.Ledger.Api as P
 import qualified PlutusTx as P (Data (..), compile)
 import qualified PlutusTx.Prelude as P
 import Language.Haskell.TH

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/shelley-spec-ledger-test.cabal
@@ -108,7 +108,7 @@ library
     iproute,
     nothunks,
     process-extras,
-    plutus-tx,
+    plutus-ledger-api,
     QuickCheck >= 2.13.2,
     serialise,
     shelley-spec-ledger,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -211,7 +211,7 @@ import Test.Shelley.Spec.Ledger.Utils
 import Cardano.Ledger.Serialization(ToCBORGroup)
 import Cardano.Ledger.Era(SupportsSegWit(toTxSeq,hashTxSeq))
 import qualified Cardano.Ledger.Era as Era(TxSeq)
-import qualified PlutusTx as Plutus
+import qualified Plutus.V1.Ledger.Api as Plutus
 import Cardano.Ledger.SafeHash(SafeHash)
 import Cardano.Ledger.Hashes(EraIndependentData)
 import qualified Cardano.Crypto.Hash as Hash


### PR DESCRIPTION
- Avoid a few needless deps on `plutus-tx`, keep all libraries in the main path depending only on `plutus-ledger-api`.
- Only import `Plutus.Ledger.V1.Api` and `Plutus.Ledger.V1.Examples`.
- Bump `plutus` to make the second change possible.

I'll probably follow this up with a change to make those two modules the only exposed modules in `plutus-ledger-api`, but this is a prerequisite for that.