### PR TITLE
Improvements to STS

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -67,7 +67,6 @@ import Cardano.Ledger.ShelleyMA.Timelocks (validateTimelock)
 import Cardano.Ledger.Tx (Tx (Tx))
 import Cardano.Ledger.Val (Val (inject), coin, (<->))
 import Control.Arrow (left)
-import Control.Monad (join)
 import Control.Monad.Except (liftEither, runExcept)
 import Control.Monad.Reader (runReader)
 import Control.State.Transition.Extended (TRC (TRC))
@@ -144,7 +143,7 @@ instance API.PraosCrypto c => API.ApplyTx (AlonzoEra c) where
       -- before.
       state' <-
         liftEither
-          . left (API.ApplyTxError . join)
+          . left API.ApplyTxError
           . flip runReader globals
           . applySTSValidateSuchThat
             @(Core.EraRule "LEDGER" (AlonzoEra c))
@@ -162,7 +161,7 @@ instance API.PraosCrypto c => API.ApplyTx (AlonzoEra c) where
             . applySTSNonStatic
               @(Core.EraRule "LEDGER" (AlonzoEra c))
             $ TRC (env, state, tx)
-     in liftEither . left (API.ApplyTxError . join) $ res
+     in liftEither . left API.ApplyTxError $ res
 
   extractTx ValidatedTx {body = b, wits = w, auxiliaryData = a} = Tx b w a
 

--- a/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
@@ -393,7 +393,7 @@ rejectDupSchedDelegs = withTests 300 $ property $ do
   let pfs = case applySTS @DELEG (TRC (tr ^. traceEnv, lastState tr, [dcert])) of
         Left res -> res
         Right _ -> []
-  assert $ SDelegSFailure (SDelegFailure IsAlreadyScheduled) `elem` concat pfs
+  assert $ SDelegSFailure (SDelegFailure IsAlreadyScheduled) `elem` pfs
 
 -- | Classify the traces.
 tracesAreClassified :: Property

--- a/byron/ledger/impl/test/Test/Cardano/Chain/Block/Model.hs
+++ b/byron/ledger/impl/test/Test/Cardano/Chain/Block/Model.hs
@@ -311,7 +311,7 @@ ts_prop_invalidDelegationCertificatesAreRejected =
 
     -- @mhueschen : this is lifted from adjacent coverage checkers and does not (at least intentionally)
     -- address the TODOs listed below.
-    coverDcerts :: [[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ()
+    coverDcerts :: [PredicateFailure CHAIN]  -> ChainValidationError -> PropertyT IO ()
     -- TODO: Establish a mapping between concrete and abstract errors. See 'coverDelegationRegistration'
     coverDcerts abstractPfs _concretePfs =
       Delegation.Test.coverDelegFailures 1 abstractPfs
@@ -336,7 +336,7 @@ ts_prop_invalidDelegationCertificatesAreRejected =
 invalidChainTracesAreRejected
   :: TestLimit
   -> [(Int, SignalGenerator CHAIN)]
-  -> ([[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ())
+  -> ([PredicateFailure CHAIN]  -> ChainValidationError -> PropertyT IO ())
   -> TSProperty
 invalidChainTracesAreRejected numberOfTests failureProfile onFailureAgreement =
   withTestsTS numberOfTests $ property $ do
@@ -394,7 +394,7 @@ ts_prop_invalidUpdateRegistrationsAreRejected =
                     block
                     (\body -> body { Abstract._bUpdProp = Just tamperedUprop })
 
-    coverUpdateRegistration :: [[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ()
+    coverUpdateRegistration :: [PredicateFailure CHAIN]  -> ChainValidationError -> PropertyT IO ()
     -- TODO: Establish a mapping between concrete and abstract errors. See 'coverDelegationRegistration'
     coverUpdateRegistration abstractPfs _concretePfs =
       Update.Test.coverUpiregFailures 1 abstractPfs
@@ -451,7 +451,7 @@ ts_prop_invalidTxWitsAreRejected =
               block
               (\body -> body { Abstract._bUtxo = txWitsList })
 
-  coverTxWits :: [[PredicateFailure CHAIN]] -> ChainValidationError -> PropertyT IO ()
+  coverTxWits :: [PredicateFailure CHAIN] -> ChainValidationError -> PropertyT IO ()
   -- TODO: Establish a mapping between concrete and abstract errors. See 'coverDelegationRegistration'
   coverTxWits abstractPfs _concretePfs =
     coverUtxoFailure 1 abstractPfs
@@ -473,7 +473,7 @@ ts_prop_invalidVotesAreRejected =
                     block
                     (\body -> body { Abstract._bUpdVotes = tamperedVotes })
 
-    coverVotes :: [[PredicateFailure CHAIN]]  -> ChainValidationError -> PropertyT IO ()
+    coverVotes :: [PredicateFailure CHAIN]  -> ChainValidationError -> PropertyT IO ()
     -- TODO: Establish a mapping between concrete and abstract errors. See 'coverDelegationRegistration'
     coverVotes abstractPfs _concretePf =
       Update.Test.coverUpivoteFailures 1 abstractPfs
@@ -482,15 +482,15 @@ ts_prop_invalidBlockPayloadProofsAreRejected :: TSProperty
 ts_prop_invalidBlockPayloadProofsAreRejected =
   invalidChainTracesAreRejected 300 [(1, invalidProofsBlockGen)] coverFailures
   where
-    coverFailures :: [[PredicateFailure CHAIN]] -> ChainValidationError -> PropertyT IO ()
+    coverFailures :: [PredicateFailure CHAIN] -> ChainValidationError -> PropertyT IO ()
     coverFailures abstractPfs concretePf = do
       coverInvalidBlockProofs 15 abstractPfs
       -- Check that the concrete failures correspond with the abstract ones.
-      when (any (== InvalidDelegationHash) (extractValues abstractPfs))
+      when (any (== InvalidDelegationHash) $ extractValues abstractPfs)
         $ assert $ concretePf == ChainValidationProofValidationError DelegationProofValidationError
-      when (any (== InvalidUpdateProposalHash) (extractValues abstractPfs))
+      when (any (== InvalidUpdateProposalHash) $ extractValues abstractPfs)
         $ assert $ concretePf == ChainValidationProofValidationError UpdateProofValidationError
-      when (any (== InvalidUtxoHash) (extractValues abstractPfs))
+      when (any (== InvalidUtxoHash) $ extractValues abstractPfs)
         $ assert $ concretePf == ChainValidationProofValidationError UTxOProofValidationError
 
 -- | Output resulting from elaborating and validating an abstract trace with
@@ -546,13 +546,12 @@ ts_prop_invalidHeaderSizesAreRejected =
     checkMaxSizeFailure
   where
     checkMaxSizeFailure
-      :: [[PredicateFailure CHAIN]]
+      :: [PredicateFailure CHAIN]
       -> ChainValidationError
       -> PropertyT IO ()
     checkMaxSizeFailure abstractPfs ChainValidationHeaderTooLarge{} = do
       assert
-        $ any isHeaderSizeTooBigFailure
-              (extractValues abstractPfs)
+        $ any isHeaderSizeTooBigFailure abstractPfs
       footnote
         $ "HeaderSizeTooBig not found in the abstract predicate failures: "
         ++ show abstractPfs
@@ -574,7 +573,7 @@ invalidSizesAreRejected
   -- ^ Setter for the concrete protocol parameters.
   -> (ABlock ByteString -> Natural)
   -- ^ Function used to compute the size of the concrete-block's component.
-  -> ([[PredicateFailure CHAIN]] -> ChainValidationError -> PropertyT IO ())
+  -> ([PredicateFailure CHAIN] -> ChainValidationError -> PropertyT IO ())
   -- ^ Function to check agreement of concrete and abstract failures.
   -> TSProperty
 invalidSizesAreRejected
@@ -702,13 +701,12 @@ ts_prop_invalidBlockSizesAreRejected =
     checkMaxSizeFailure
   where
     checkMaxSizeFailure
-      :: [[PredicateFailure CHAIN]]
+      :: [PredicateFailure CHAIN]
       -> ChainValidationError
       -> PropertyT IO ()
     checkMaxSizeFailure abstractPfs ChainValidationBlockTooLarge{} = do
       assert
-        $ any (== InvalidBlockSize)
-              (extractValues abstractPfs)
+        $ any (== InvalidBlockSize) $ extractValues abstractPfs
       footnote
         $ "InvalidBlockSize not found in the abstract predicate failures: "
         ++ show abstractPfs

--- a/byron/ledger/impl/test/Test/Cardano/Chain/Delegation/Model.hs
+++ b/byron/ledger/impl/test/Test/Cardano/Chain/Delegation/Model.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Chain.Delegation.Model
   )
 where
 
+import Prelude (id)
 import Cardano.Prelude
 
 import Control.Arrow (left)
@@ -133,7 +134,7 @@ commandSDELEG concreteRef abstractEnv = Command gen execute callbacks
       let
         result =
           STS.applySTS @SDELEG (STS.TRC (abstractEnv, abstractState, cert))
-      in StateSDELEG (fromRight abstractState result) (left concat result)
+      in StateSDELEG (fromRight abstractState result) (left Prelude.id result)
     , Ensure $ \_ StateSDELEG { lastAbstractResult } _ result -> do
       annotateShow lastAbstractResult
       annotateShow result

--- a/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -26,7 +26,7 @@ applySTSValidateSuchThat ::
   (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
   ([Label] -> Bool) ->
   RuleContext rtype s ->
-  m (Either [[PredicateFailure s]] (State s))
+  m (Either [PredicateFailure s] (State s))
 applySTSValidateSuchThat cond = applySTSOptsEither opts
   where
     opts =
@@ -83,5 +83,5 @@ applySTSNonStatic ::
   forall s m rtype.
   (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
   RuleContext rtype s ->
-  m (Either [[PredicateFailure s]] (State s))
+  m (Either [PredicateFailure s] (State s))
 applySTSNonStatic = applySTSValidateSuchThat (notElem lblStatic)

--- a/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -20,7 +20,6 @@ module Cardano.Ledger.Rules.ValidationMode
 where
 
 import Control.State.Transition.Extended
-import Data.Functor ((<&>))
 
 applySTSValidateSuchThat ::
   forall s m rtype.
@@ -28,10 +27,7 @@ applySTSValidateSuchThat ::
   ([Label] -> Bool) ->
   RuleContext rtype s ->
   m (Either [[PredicateFailure s]] (State s))
-applySTSValidateSuchThat cond ctx =
-  applySTSOpts opts ctx <&> \case
-    (st, []) -> Right st
-    (_, pfs) -> Left pfs
+applySTSValidateSuchThat cond = applySTSOptsEither opts
   where
     opts =
       ApplySTSOpts

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -1412,7 +1412,7 @@ type A = AlonzoEra C_Crypto
 
 testUTXOW ::
   ValidatedTx A ->
-  Either [[PredicateFailure (Core.EraRule "UTXOW" A)]] (UTxOState A) ->
+  Either [PredicateFailure (Core.EraRule "UTXOW" A)] (UTxOState A) ->
   Assertion
 testUTXOW tx (Right expectedSt) =
   checkTrace @(AlonzoUTXOW A) runShelleyBase (utxoEnv (Alonzo Mock)) $
@@ -1480,197 +1480,184 @@ alonzoUTXOWexamples =
             testUTXOW
               (trustMe True $ incorrectNetworkIDTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure
-                        (UtxoFailure (WrongNetworkInTxBody Testnet Mainnet))
-                    ]
+                  [ WrappedShelleyEraFailure
+                      (UtxoFailure (WrongNetworkInTxBody Testnet Mainnet))
                   ]
               ),
           testCase "missing required key witness" $
             testUTXOW
               (trustMe True $ missingRequiredWitnessTx pf)
-              ( Left [[(MissingRequiredSigners . Set.singleton) extraneousKeyHash]]
+              ( Left [(MissingRequiredSigners . Set.singleton) extraneousKeyHash]
               ),
           testCase "missing redeemer" $
             testUTXOW
               (trustMe True $ missingRedeemerTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . UtxoFailure
-                        . UtxosFailure
-                        . CollectErrors
-                        $ [NoRedeemer (Spending (TxIn genesisId 1))],
-                      UnRedeemableScripts
-                        [ ( Spending (TxIn genesisId 1),
-                            (alwaysSucceedsHash 3 pf)
-                          )
-                        ]
-                    ]
+                  [ WrappedShelleyEraFailure . UtxoFailure
+                      . UtxosFailure
+                      . CollectErrors
+                      $ [NoRedeemer (Spending (TxIn genesisId 1))],
+                    UnRedeemableScripts
+                      [ ( Spending (TxIn genesisId 1),
+                          (alwaysSucceedsHash 3 pf)
+                        )
+                      ]
                   ]
               ),
           testCase "wrong wpp hash" $
             testUTXOW
               (trustMe True $ wrongWppHashTx pf)
               ( Left
-                  [ [ PPViewHashesDontMatch
-                        ( hashWitnessPPData
-                            (pp pf)
-                            (Set.singleton PlutusV1)
-                            (Redeemers mempty)
-                            txDatsExample1
-                        )
-                        ( hashWitnessPPData
-                            (pp pf)
-                            (Set.singleton PlutusV1)
-                            validatingRedeemersEx1
-                            txDatsExample1
-                        )
-                    ]
+                  [ PPViewHashesDontMatch
+                      ( hashWitnessPPData
+                          (pp pf)
+                          (Set.singleton PlutusV1)
+                          (Redeemers mempty)
+                          txDatsExample1
+                      )
+                      ( hashWitnessPPData
+                          (pp pf)
+                          (Set.singleton PlutusV1)
+                          validatingRedeemersEx1
+                          txDatsExample1
+                      )
                   ]
               ),
           testCase "missing 1-phase script witness" $
             testUTXOW
               (trustMe True $ missing1phaseScriptWitnessTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . UtxoFailure . UtxosFailure . CollectErrors $
-                        [ NoRedeemer (Spending (TxIn genesisId 100)),
-                          NoWitness (timelockHash 0 pf)
-                        ],
-                      WrappedShelleyEraFailure . MissingScriptWitnessesUTXOW . Set.singleton $
-                        (timelockHash 0 pf),
-                      UnRedeemableScripts [(Spending $ TxIn genesisId 100, timelockHash 0 pf)]
-                    ]
+                  [ WrappedShelleyEraFailure . UtxoFailure . UtxosFailure . CollectErrors $
+                      [ NoRedeemer (Spending (TxIn genesisId 100)),
+                        NoWitness (timelockHash 0 pf)
+                      ],
+                    WrappedShelleyEraFailure . MissingScriptWitnessesUTXOW . Set.singleton $
+                      (timelockHash 0 pf),
+                    UnRedeemableScripts [(Spending $ TxIn genesisId 100, timelockHash 0 pf)]
                   ]
               ),
           testCase "missing 2-phase script witness" $
             testUTXOW
               (trustMe True $ missing2phaseScriptWitnessTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . UtxoFailure . UtxosFailure . CollectErrors $
-                        [ NoWitness (alwaysSucceedsHash 2 pf),
-                          NoWitness (alwaysSucceedsHash 2 pf),
-                          NoWitness (alwaysSucceedsHash 2 pf)
-                        ],
-                      WrappedShelleyEraFailure . MissingScriptWitnessesUTXOW . Set.singleton $
-                        (alwaysSucceedsHash 2 pf),
-                      UnRedeemableScripts
-                        [ ( Rewarding
-                              ( RewardAcnt
-                                  { getRwdNetwork = Testnet,
-                                    getRwdCred = ScriptHashObj (alwaysSucceedsHash 2 pf)
-                                  }
-                              ),
-                            (alwaysSucceedsHash 2 pf)
-                          ),
-                          ( Certifying . DCertDeleg . DeRegKey . ScriptHashObj $
-                              (alwaysSucceedsHash 2 pf),
-                            (alwaysSucceedsHash 2 pf)
-                          ),
-                          ( Minting (PolicyID {policyID = (alwaysSucceedsHash 2 pf)}),
-                            (alwaysSucceedsHash 2 pf)
-                          )
-                        ]
-                    ]
+                  [ WrappedShelleyEraFailure . UtxoFailure . UtxosFailure . CollectErrors $
+                      [ NoWitness (alwaysSucceedsHash 2 pf),
+                        NoWitness (alwaysSucceedsHash 2 pf),
+                        NoWitness (alwaysSucceedsHash 2 pf)
+                      ],
+                    WrappedShelleyEraFailure . MissingScriptWitnessesUTXOW . Set.singleton $
+                      (alwaysSucceedsHash 2 pf),
+                    UnRedeemableScripts
+                      [ ( Rewarding
+                            ( RewardAcnt
+                                { getRwdNetwork = Testnet,
+                                  getRwdCred = ScriptHashObj (alwaysSucceedsHash 2 pf)
+                                }
+                            ),
+                          (alwaysSucceedsHash 2 pf)
+                        ),
+                        ( Certifying . DCertDeleg . DeRegKey . ScriptHashObj $
+                            (alwaysSucceedsHash 2 pf),
+                          (alwaysSucceedsHash 2 pf)
+                        ),
+                        ( Minting (PolicyID {policyID = (alwaysSucceedsHash 2 pf)}),
+                          (alwaysSucceedsHash 2 pf)
+                        )
+                      ]
                   ]
               ),
           testCase "redeemer with incorrect label" $
             testUTXOW
               (trustMe True $ wrongRedeemerLabelTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . UtxoFailure
-                        . UtxosFailure
-                        . CollectErrors
-                        $ [NoRedeemer (Spending (TxIn genesisId 1))],
-                      UnRedeemableScripts
-                        [ ( Spending (TxIn genesisId 1),
-                            (alwaysSucceedsHash 3 pf)
-                          )
-                        ]
-                    ]
+                  [ WrappedShelleyEraFailure . UtxoFailure
+                      . UtxosFailure
+                      . CollectErrors
+                      $ [NoRedeemer (Spending (TxIn genesisId 1))],
+                    UnRedeemableScripts
+                      [ ( Spending (TxIn genesisId 1),
+                          (alwaysSucceedsHash 3 pf)
+                        )
+                      ]
                   ]
               ),
           testCase "missing datum" $
             testUTXOW
               (trustMe True $ missingDatumTx pf)
               ( Left
-                  [ [ MissingRequiredDatums
-                        (Set.singleton $ hashData @A datumExample1)
-                        mempty
-                    ]
+                  [ MissingRequiredDatums
+                      (Set.singleton $ hashData @A datumExample1)
+                      mempty
                   ]
               ),
           testCase "phase 1 script failure" $
             testUTXOW
               (trustMe True $ phase1FailureTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . ScriptWitnessNotValidatingUTXOW $
-                        Set.fromList
-                          [ timelockHash 0 pf,
-                            timelockHash 1 pf,
-                            timelockHash 2 pf
-                          ]
-                    ]
+                  [ WrappedShelleyEraFailure . ScriptWitnessNotValidatingUTXOW $
+                      Set.fromList
+                        [ timelockHash 0 pf,
+                          timelockHash 1 pf,
+                          timelockHash 2 pf
+                        ]
                   ]
               ),
           testCase "valid transaction marked as invalid" $
             testUTXOW
               (trustMe False $ validatingTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure
-                        ( UtxoFailure
-                            (UtxosFailure (ValidationTagMismatch (IsValidating False)))
-                        )
-                    ]
+                  [ WrappedShelleyEraFailure
+                      ( UtxoFailure
+                          (UtxosFailure (ValidationTagMismatch (IsValidating False)))
+                      )
                   ]
               ),
           testCase "invalid transaction marked as valid" $
             testUTXOW
               (trustMe True $ notValidatingTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure
-                        (UtxoFailure (UtxosFailure (ValidationTagMismatch (IsValidating True))))
-                    ]
+                  [ WrappedShelleyEraFailure
+                      (UtxoFailure (UtxosFailure (ValidationTagMismatch (IsValidating True))))
                   ]
               ),
           testCase "too many execution units for tx" $
             testUTXOW
               (trustMe True $ tooManyExUnitsTx pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure . UtxoFailure $
-                        ExUnitsTooBigUTxO
-                          (ExUnits {exUnitsMem = 1000000, exUnitsSteps = 1000000})
-                          (ExUnits {exUnitsMem = 1000001, exUnitsSteps = 5000})
-                    ]
+                  [ WrappedShelleyEraFailure . UtxoFailure $
+                      ExUnitsTooBigUTxO
+                        (ExUnits {exUnitsMem = 1000000, exUnitsSteps = 1000000})
+                        (ExUnits {exUnitsMem = 1000001, exUnitsSteps = 5000})
                   ]
               ),
           testCase "missing signature for collateral input" $
             testUTXOW
               (trustMe True $ missingCollateralSig pf)
               ( Left
-                  [ [ WrappedShelleyEraFailure
-                        ( MissingVKeyWitnessesUTXOW
-                            ( WitHashes
-                                ( Set.fromList
-                                    [ asWitness $
-                                        hashKey (vKey $ someKeys pf)
-                                    ]
-                                )
-                            )
-                        )
-                    ]
+                  [ WrappedShelleyEraFailure
+                      ( MissingVKeyWitnessesUTXOW
+                          ( WitHashes
+                              ( Set.fromList
+                                  [ asWitness $
+                                      hashKey (vKey $ someKeys pf)
+                                  ]
+                              )
+                          )
+                      )
                   ]
               ),
           testCase "two-phase UTxO with no datum hash" $
             testUTXOW
               (trustMe True $ plutusOutputWithNoDataTx pf)
-              ( Left [[UnspendableUTxONoDatumHash . Set.singleton $ TxIn genesisId 101]]
+              ( Left [UnspendableUTxONoDatumHash . Set.singleton $ TxIn genesisId 101]
               ),
           testCase "unacceptable supplimentary datum" $
             testUTXOW
               (trustMe True $ notOkSupplimentaryDatumTx pf)
               ( Left
-                  [ [ NonOutputSupplimentaryDatums
-                        (Set.singleton $ hashData @A totallyIrrelevantDatum)
-                        mempty
-                    ]
+                  [ NonOutputSupplimentaryDatums
+                      (Set.singleton $ hashData @A totallyIrrelevantDatum)
+                      mempty
                   ]
               )
         ]
@@ -1826,7 +1813,7 @@ example1BBodyState =
 testBBODY ::
   BbodyState A ->
   Block A ->
-  Either [[PredicateFailure (AlonzoBBODY A)]] (BbodyState A) ->
+  Either [PredicateFailure (AlonzoBBODY A)] (BbodyState A) ->
   Assertion
 testBBODY initialSt block (Right expectedSt) =
   checkTrace @(AlonzoBBODY A) runShelleyBase (bbodyEnv $ Alonzo Mock) $
@@ -1848,10 +1835,9 @@ alonzoBBODYexamples =
         testBBODY
           (initialBBodyState pf)
           testAlonzoBadPMDHBlock
-          ( Left $
-              [ [ ShelleyInAlonzoPredFail . LedgersFailure . LedgerFailure . DelegsFailure . DelplFailure . PoolFailure $
-                    PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys pf) (hashsize @Mock + 1)
-                ]
+          ( Left
+              [ ShelleyInAlonzoPredFail . LedgersFailure . LedgerFailure . DelegsFailure . DelplFailure . PoolFailure $
+                  PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys pf) (hashsize @Mock + 1)
               ]
           )
     ]

--- a/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
+++ b/semantics/executable-spec/src/Control/Iterate/SetAlgebra.hs
@@ -1101,7 +1101,7 @@ runBoolExp e =
        then error ("In Testing mode, SetAlgebra expression: "++show e++" falls through to slow mode.")
        else runBool e
 
--- Only for use inthe SetAlgebra internal tests
+-- Only for use in the SetAlgebra internal tests
 runBool :: Exp Bool -> Bool
 runBool (Elem k v) = haskey k (compute v)
 runBool (NotElem k set) = not $ haskey k (compute set)
@@ -1124,7 +1124,7 @@ runBool (w@(Subset x y)) = runCollect (lifo left) True (\ (k,_v) ans -> haskey k
 -- ===============================================================================================
 
 
-compute:: Exp t -> t
+compute :: Exp t -> t
 compute (Base _rep relation) = relation
 
 compute (Dom (Base SetR rel)) = rel

--- a/semantics/executable-spec/src/Control/State/Transition/Simple.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Simple.hs
@@ -17,12 +17,12 @@ applySTSIndifferently ::
   forall s rtype.
   (STS s, RuleTypeRep rtype, Identity ~ BaseM s) =>
   RuleContext rtype s ->
-  (State s, [[PredicateFailure s]])
+  (State s, [PredicateFailure s])
 applySTSIndifferently ctx = runIdentity $ X.applySTSIndifferently ctx
 
 applySTS ::
   forall s rtype.
   (STS s, RuleTypeRep rtype, BaseM s ~ Identity) =>
   RuleContext rtype s ->
-  Either [[PredicateFailure s]] (State s)
+  Either [PredicateFailure s] (State s)
 applySTS ctx = runIdentity $ X.applySTS ctx

--- a/semantics/executable-spec/src/Control/State/Transition/Simple.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Simple.hs
@@ -1,28 +1,28 @@
-
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Simple state transition system over the Identity monad.
 module Control.State.Transition.Simple
-  ( applySTSIndifferently
-  , applySTS
-  , module Extended
+  ( applySTSIndifferently,
+    applySTS,
+    module Extended,
   )
 where
 
-import           Control.Monad.Identity (Identity(..))
+import Control.Monad.Identity (Identity (..))
+import Control.State.Transition.Extended as Extended hiding (applySTS, applySTSIndifferently)
 import qualified Control.State.Transition.Extended as X
-import           Control.State.Transition.Extended as Extended hiding (applySTS, applySTSIndifferently)
 
-applySTSIndifferently
-  :: forall s rtype
-   . (STS s, RuleTypeRep rtype, Identity ~ BaseM s)
-  => RuleContext rtype s
-  -> (State s, [[PredicateFailure s]])
+applySTSIndifferently ::
+  forall s rtype.
+  (STS s, RuleTypeRep rtype, Identity ~ BaseM s) =>
+  RuleContext rtype s ->
+  (State s, [[PredicateFailure s]])
 applySTSIndifferently ctx = runIdentity $ X.applySTSIndifferently ctx
 
-applySTS :: forall s rtype
-   . (STS s, RuleTypeRep rtype, BaseM s ~ Identity)
-  => RuleContext rtype s
-  -> Either [[PredicateFailure s]] (State s)
+applySTS ::
+  forall s rtype.
+  (STS s, RuleTypeRep rtype, BaseM s ~ Identity) =>
+  RuleContext rtype s ->
+  Either [[PredicateFailure s]] (State s)
 applySTS ctx = runIdentity $ X.applySTS ctx

--- a/semantics/small-steps-test/src/Control/State/Transition/Generator.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Generator.hs
@@ -700,7 +700,7 @@ invalidSignalsAreGenerated
   -- ^ Failure profile.
   -> Word64
   -- ^ Maximum trace length.
-  -> ([[PredicateFailure s]] -> PropertyT IO ())
+  -> ([PredicateFailure s] -> PropertyT IO ())
   -- ^ Action to run when the an invalid signal is generated.
   -> Property
 invalidSignalsAreGenerated baseEnv failureProfile maximumTraceLength checkFailures = property $ do

--- a/semantics/small-steps-test/src/Control/State/Transition/Invalid/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Invalid/Trace.hs
@@ -24,7 +24,7 @@ data Trace s
     -- ^ Last signal in the trace. This might cause a predicate failure, but it
     -- isn't guaranteed to do so, since invalid trace generation is
     -- probabilistic.
-    , errorOrLastState :: !(Either [[PredicateFailure s]] (State s))
+    , errorOrLastState :: !(Either [PredicateFailure s] (State s))
     } deriving Generic
 
 deriving instance

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -423,7 +423,7 @@ checkTrace
   => (forall a. m a -> a)
   -> Environment s
   -> ReaderT (State s ->
-        Signal s -> (Either [[PredicateFailure s]] (State s))) IO (State s)
+              Signal s -> Either [PredicateFailure s] (State s)) IO (State s)
   -> IO ()
 checkTrace interp env act =
   void $ runReaderT act (\st sig -> interp $ applySTSTest @s (TRC(env, st, sig)))
@@ -493,7 +493,7 @@ applySTSTest ::
   forall s m rtype.
   (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
   RuleContext rtype s ->
-  m (Either [[PredicateFailure s]] (State s))
+  m (Either [PredicateFailure s] (State s))
 applySTSTest = applySTSOptsEither defaultOpts
   where
     defaultOpts =

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -50,7 +50,6 @@ import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
 import           Data.Data (Data, Typeable, cast, gmapQ)
-import           Data.Functor ((<&>))
 import           Data.Maybe (catMaybes)
 import           Data.Sequence.Strict (StrictSeq ((:<|), Empty))
 import qualified Data.Sequence.Strict as StrictSeq
@@ -495,10 +494,7 @@ applySTSTest ::
   (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
   RuleContext rtype s ->
   m (Either [[PredicateFailure s]] (State s))
-applySTSTest ctx =
-  applySTSOpts defaultOpts ctx <&> \case
-    (st, []) -> Right st
-    (_, pfs) -> Left pfs
+applySTSTest = applySTSOptsEither defaultOpts
   where
     defaultOpts =
       ApplySTSOpts

--- a/semantics/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/semantics/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -129,7 +129,7 @@ traceFromInitState
   -> Word64
   -- ^ Maximum trace length.
   -> traceGenEnv
-  -> Maybe (IRC sts -> QuickCheck.Gen (Either [[STS.PredicateFailure sts]] (State sts)))
+  -> Maybe (IRC sts -> QuickCheck.Gen (Either [STS.PredicateFailure sts] (State sts)))
   -- ^ Optional generator of STS initial state
   -> QuickCheck.Gen (Trace sts)
 traceFromInitState baseEnv maxTraceLength traceGenEnv genSt0 = do
@@ -156,7 +156,7 @@ forAllTraceFromInitState
   -> Word64
   -- ^ Maximum trace length.
   -> traceGenEnv
-  -> Maybe (IRC sts -> QuickCheck.Gen (Either [[STS.PredicateFailure sts]] (State sts)))
+  -> Maybe (IRC sts -> QuickCheck.Gen (Either [STS.PredicateFailure sts] (State sts)))
   -- ^ Optional generator of STS initial state
   -> (Trace sts -> prop)
   -> QuickCheck.Property
@@ -249,7 +249,7 @@ onlyValidSignalsAreGeneratedFromInitState
   -> Word64
   -- ^ Maximum trace length.
   -> traceGenEnv
-  -> Maybe (IRC sts -> QuickCheck.Gen (Either [[STS.PredicateFailure sts]] (State sts)))
+  -> Maybe (IRC sts -> QuickCheck.Gen (Either [STS.PredicateFailure sts] (State sts)))
   -- ^ Optional generator of STS initial state
   -> QuickCheck.Property
 onlyValidSignalsAreGeneratedFromInitState baseEnv maxTraceLength traceGenEnv genSt0 =

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -29,16 +29,15 @@ import Test.Tasty.HUnit (Assertion, (@?=))
 type MaryTest = MaryEra TestCrypto
 
 ignoreAllButUTxO ::
-  Either [[PredicateFailure (LEDGER MaryTest)]] (UTxOState MaryTest, DPState TestCrypto) ->
-  Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
-ignoreAllButUTxO (Left e) = Left e
-ignoreAllButUTxO (Right (UTxOState utxo _ _ _, _)) = Right utxo
+  Either [PredicateFailure (LEDGER MaryTest)] (UTxOState MaryTest, DPState TestCrypto) ->
+  Either [PredicateFailure (LEDGER MaryTest)] (UTxO MaryTest)
+ignoreAllButUTxO = fmap (\(UTxOState utxo _ _ _, _) -> utxo)
 
 testMaryNoDelegLEDGER ::
   UTxO MaryTest ->
   Tx MaryTest ->
   LedgerEnv MaryTest ->
-  Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest) ->
+  Either [PredicateFailure (LEDGER MaryTest)] (UTxO MaryTest) ->
   Assertion
 testMaryNoDelegLEDGER utxo tx env (Right expectedUTxO) = do
   checkTrace @(LEDGER MaryTest) runShelleyBase env $

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -129,18 +129,16 @@ makeTxb ins outs interval minted =
     SNothing
     minted
 
-policyFailure :: PolicyID TestCrypto -> Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
+policyFailure :: PolicyID TestCrypto -> Either [PredicateFailure (LEDGER MaryTest)] (UTxO MaryTest)
 policyFailure p =
   Left
-    [ [ UtxowFailure
-          ( ScriptWitnessNotValidatingUTXOW
-              (Set.singleton (policyID p))
-          )
-      ]
+    [ UtxowFailure
+        (ScriptWitnessNotValidatingUTXOW (Set.singleton (policyID p)))
     ]
 
-outTooBigFailure :: TxOut MaryTest -> Either [[PredicateFailure (LEDGER MaryTest)]] (UTxO MaryTest)
-outTooBigFailure out = Left [[UtxowFailure (UtxoFailure (OutputTooBigUTxO [out]))]]
+
+outTooBigFailure :: TxOut MaryTest -> Either [PredicateFailure (LEDGER MaryTest)] (UTxO MaryTest)
+outTooBigFailure out = Left [UtxowFailure (UtxoFailure (OutputTooBigUTxO [out]))]
 
 ----------------------------------------------------
 -- Introduce a new Token Bundle, Purple Tokens

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -104,7 +104,7 @@ class
             . applySTS @(Core.EraRule "LEDGER" era)
             $ TRC (env, state, tx)
      in liftEither
-          . left (ApplyTxError . join)
+          . left ApplyTxError
           . right (,tx)
           $ res
 
@@ -140,7 +140,7 @@ class
             . applySTS @(Core.EraRule "LEDGER" era)
             $ TRC (env, state, tx)
      in liftEither
-          . left (ApplyTxError . join)
+          . left ApplyTxError
           $ res
 
   -- | Extract the underlying `Tx` from the `TxInBlock`.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -286,7 +286,7 @@ futureView ::
 futureView globals ss slot =
   liftEither
     . right view
-    . left (FutureLedgerViewError . join)
+    . left FutureLedgerViewError
     $ res
   where
     res =
@@ -427,7 +427,7 @@ updateChainDepState
                 csLabNonce = prevHashToNonce (bheaderPrev . bhbody $ bh)
               }
         )
-      . left (ChainTransitionError . join)
+      . left ChainTransitionError
       $ res
     where
       res =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -105,7 +105,7 @@ class
   applyBlock globals state blk =
     liftEither
       . right (updateNewEpochState state)
-      . left (BlockTransitionError . join)
+      . left BlockTransitionError
       $ res
     where
       res =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -70,18 +70,20 @@ import Cardano.Crypto.VRF
     genKeyVRF,
   )
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.Address (Addr, pattern Addr)
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( BoundedRational (..),
+    Globals (..),
     Network (..),
     Nonce,
     ShelleyBase,
-    BoundedRational (..),
     epochInfo,
     mkActiveSlotCoeff,
     mkNonceFromOutputVRF,
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto (..), SupportsSegWit (TxInBlock))
@@ -96,6 +98,7 @@ import Cardano.Ledger.Keys
     pattern KeyPair,
   )
 import Cardano.Ledger.Shelley.Constraints
+import Cardano.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
 import Cardano.Prelude (Coercible, asks)
 import Cardano.Slotting.EpochInfo
   ( epochInfoEpoch,
@@ -107,13 +110,13 @@ import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition.Extended hiding (Assertion)
 import Control.State.Transition.Trace
-  ( checkTrace,
+  ( applySTSTest,
+    checkTrace,
     (.-),
     (.->),
   )
 import Data.Coerce (coerce)
 import Data.Default.Class (Default)
-import Data.Functor ((<&>))
 import Data.Functor.Identity (runIdentity)
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX
@@ -125,12 +128,9 @@ import Shelley.Spec.Ledger.API
     GetLedgerView,
     PParams,
   )
-import Cardano.Ledger.Address (Addr, pattern Addr)
 import Shelley.Spec.Ledger.BlockChain (BHBody (..), Block, TxSeq, bhbody, bheader)
-import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParamsUpdate)
-import Cardano.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
 import Shelley.Spec.Ledger.Tx (Tx, TxOut, WitnessSet)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Tasty.HUnit
@@ -267,7 +267,6 @@ unsafeBoundRational :: (HasCallStack, BoundedRational r) => Rational -> r
 unsafeBoundRational r =
   fromMaybe (error $ "Could not convert from Rational: " ++ show r) $ boundRational r
 
-
 testGlobals :: Globals
 testGlobals =
   Globals
@@ -323,22 +322,6 @@ slotsPerKESIteration = runShelleyBase (asks slotsPerKESPeriod)
 
 maxLLSupply :: Coin
 maxLLSupply = Coin $ fromIntegral $ runShelleyBase (asks maxLovelaceSupply)
-
-applySTSTest ::
-  forall s m rtype.
-  (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
-  RuleContext rtype s ->
-  m (Either [[PredicateFailure s]] (State s))
-applySTSTest ctx =
-  applySTSOpts defaultOpts ctx <&> \case
-    (st, []) -> Right st
-    (_, pfs) -> Left pfs
-  where
-    defaultOpts =
-      ApplySTSOpts
-        { asoAssertions = AssertionsAll,
-          asoValidation = ValidateAll
-        }
 
 testSTS ::
   forall s.

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -329,7 +329,7 @@ testSTS ::
   Environment s ->
   State s ->
   Signal s ->
-  Either [[PredicateFailure s]] (State s) ->
+  Either [PredicateFailure s] (State s) ->
   Assertion
 testSTS env initSt signal (Right expectedSt) = do
   checkTrace @s runShelleyBase env $ pure initSt .- signal .-> expectedSt

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Address/Bootstrap.hs
@@ -266,7 +266,7 @@ testBootstrapNotSpending =
     utxoEnv
     utxoState0
     txBad
-    (Left [[InvalidWitnessesUTXOW [aliceVKey]]])
+    (Left [InvalidWitnessesUTXOW [aliceVKey]])
 
 type C = ShelleyEra C_crypto
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -24,7 +24,7 @@ data CHAINExample h = CHAINExample
     -- | Block to run chain state transition system on
     newBlock :: Block h,
     -- | type of fatal error, if failure expected and final chain state if success expected
-    intendedResult :: Either [[PredicateFailure (CHAIN h)]] (ChainState h)
+    intendedResult :: Either [PredicateFailure (CHAIN h)] (ChainState h)
   }
 
 -- | Runs example, applies chain state transition system rule (STS),

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Examples/Mir.hs
@@ -246,7 +246,7 @@ mirFailWits pot =
     (initStMIR (Coin 1000))
     (blockEx1' insufficientMIRWits pot)
     ( Left
-        [ [ BbodyFailure @(ShelleyEra c)
+        [ BbodyFailure @(ShelleyEra c)
               ( LedgersFailure
                   ( LedgerFailure
                       ( UtxowFailure $
@@ -255,7 +255,6 @@ mirFailWits pot =
                   )
               )
           ]
-        ]
     )
   where
     ws = Set.fromList $ asWitness <$> map (\x -> hk . coreNodeIssuerKeys $ x) [0 .. 3]
@@ -275,22 +274,21 @@ mirFailFunds pot treasury llNeeded llReceived =
     (initStMIR treasury)
     (blockEx1' sufficientMIRWits pot)
     ( Left
-        [ [ BbodyFailure
-              ( LedgersFailure
-                  ( LedgerFailure
-                      ( DelegsFailure
-                          ( DelplFailure
-                              ( DelegFailure $
-                                  InsufficientForInstantaneousRewardsDELEG
-                                    pot
-                                    llNeeded
-                                    llReceived
-                              )
-                          )
-                      )
-                  )
-              )
-          ]
+        [ BbodyFailure
+            ( LedgersFailure
+                ( LedgerFailure
+                    ( DelegsFailure
+                        ( DelplFailure
+                            ( DelegFailure $
+                                InsufficientForInstantaneousRewardsDELEG
+                                  pot
+                                  llNeeded
+                                  llReceived
+                            )
+                        )
+                    )
+                )
+            )
         ]
     )
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/MultiSigExamples.hs
@@ -224,7 +224,7 @@ initialUTxOState ::
   [(MultiSig c, Coin)] ->
   ( TxId c,
     Either
-      [[PredicateFailure (UTXOW (ShelleyEra c))]]
+      [PredicateFailure (UTXOW (ShelleyEra c))]
       (UTxOState (ShelleyEra c))
   )
 initialUTxOState aliceKeep msigs =
@@ -276,7 +276,7 @@ applyTxWithScript ::
   Wdrl c ->
   Coin ->
   [KeyPair 'Witness c] ->
-  Either [[PredicateFailure (UTXOW (ShelleyEra c))]] (UTxOState (ShelleyEra c))
+  Either [PredicateFailure (UTXOW (ShelleyEra c))] (UTxOState (ShelleyEra c))
 applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
   where
     (txId, initUtxo) = initialUTxOState aliceKeep lockScripts

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -9,13 +9,13 @@ module Test.Shelley.Spec.Ledger.STSTests
   )
 where
 
+import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (pattern ScriptHashObj)
+import Cardano.Ledger.Keys (asWitness, hashKey, vKey)
 import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Cardano.Ledger.BaseTypes (Network (..))
-import Cardano.Ledger.Credential (pattern ScriptHashObj)
-import Cardano.Ledger.Keys (asWitness, hashKey, vKey)
 import Shelley.Spec.Ledger.LedgerState (WitHashes (..))
 import Shelley.Spec.Ledger.STS.Utxow (UtxowPredicateFailure (..))
 import Shelley.Spec.Ledger.Tx (hashScript)
@@ -108,7 +108,7 @@ testAliceSignsAlone =
 
 testAliceDoesntSign :: Assertion
 testAliceDoesntSign =
-  utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW (Set.singleton $ hashScript @C aliceOnly)]]
+  utxoSt' @?= Left [ScriptWitnessNotValidatingUTXOW (Set.singleton $ hashScript @C aliceOnly)]
   where
     utxoSt' =
       applyTxWithScript
@@ -139,7 +139,7 @@ testEverybodySigns =
 
 testWrongScript :: Assertion
 testWrongScript =
-  utxoSt' @?= Left [[MissingScriptWitnessesUTXOW (Set.singleton $ hashScript @C aliceOnly)]]
+  utxoSt' @?= Left [MissingScriptWitnessesUTXOW (Set.singleton $ hashScript @C aliceOnly)]
   where
     utxoSt' =
       applyTxWithScript
@@ -196,9 +196,8 @@ testAliceAndBob' :: Assertion
 testAliceAndBob' =
   utxoSt'
     @?= Left
-      [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript @C aliceAndBob)
-        ]
+      [ ScriptWitnessNotValidatingUTXOW
+          (Set.singleton $ hashScript @C aliceAndBob)
       ]
   where
     utxoSt' =
@@ -214,9 +213,8 @@ testAliceAndBob'' :: Assertion
 testAliceAndBob'' =
   utxoSt'
     @?= Left
-      [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript @C aliceAndBob)
-        ]
+      [ ScriptWitnessNotValidatingUTXOW
+          (Set.singleton $ hashScript @C aliceAndBob)
       ]
   where
     utxoSt' =
@@ -350,9 +348,8 @@ testTwoScripts' :: Assertion
 testTwoScripts' =
   utxoSt'
     @?= Left
-      [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript @C aliceAndBob)
-        ]
+      [ ScriptWitnessNotValidatingUTXOW
+          (Set.singleton $ hashScript @C aliceAndBob)
       ]
   where
     utxoSt' =
@@ -388,9 +385,8 @@ testScriptAndSKey' :: Assertion
 testScriptAndSKey' =
   utxoSt'
     @?= Left
-      [ [ MissingVKeyWitnessesUTXOW $
-            WitHashes wits
-        ]
+      [ MissingVKeyWitnessesUTXOW $
+          WitHashes wits
       ]
   where
     utxoSt' =
@@ -458,9 +454,8 @@ testRwdAliceSignsAlone' :: Assertion
 testRwdAliceSignsAlone' =
   utxoSt'
     @?= Left
-      [ [ ScriptWitnessNotValidatingUTXOW
-            (Set.singleton $ hashScript @C bobOnly)
-        ]
+      [ ScriptWitnessNotValidatingUTXOW
+          (Set.singleton $ hashScript @C bobOnly)
       ]
   where
     utxoSt' =
@@ -508,11 +503,10 @@ testRwdAliceSignsAlone''' :: Assertion
 testRwdAliceSignsAlone''' =
   utxoSt'
     @?= Left
-      [ [ MissingScriptWitnessesUTXOW
-            ( Set.singleton $
-                hashScript @C bobOnly
-            )
-        ]
+      [ MissingScriptWitnessesUTXOW
+          ( Set.singleton $
+              hashScript @C bobOnly
+          )
       ]
   where
     utxoSt' =

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/UnitTests.hs
@@ -312,7 +312,7 @@ testLEDGER ::
   (UTxOState C, DPState C_Crypto) ->
   Tx C ->
   LedgerEnv C ->
-  Either [[PredicateFailure (LEDGER C)]] (UTxOState C, DPState C_Crypto) ->
+  Either [PredicateFailure (LEDGER C)] (UTxOState C, DPState C_Crypto) ->
   Assertion
 testLEDGER initSt tx env (Right expectedSt) = do
   checkTrace @(LEDGER C) runShelleyBase env $ pure initSt .- tx .-> expectedSt
@@ -394,7 +394,7 @@ testInvalidTx ::
   Tx C ->
   Assertion
 testInvalidTx errs tx =
-  testLEDGER (utxoState, dpState) tx ledgerEnv (Left [errs])
+  testLEDGER (utxoState, dpState) tx ledgerEnv (Left errs)
 
 testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
@@ -516,7 +516,7 @@ testEmptyInputSet =
         (utxoState, dpState')
         tx
         ledgerEnv
-        (Left [[UtxowFailure (UtxoFailure InputSetEmptyUTxO)]])
+        (Left [UtxowFailure (UtxoFailure InputSetEmptyUTxO)])
 
 testFeeTooSmall :: Assertion
 testFeeTooSmall =
@@ -550,7 +550,7 @@ testExpiredTx =
               signers = ([asWitness alicePay])
             }
       ledgerEnv' = LedgerEnv (SlotNo 1) 0 pp (AccountState (Coin 0) (Coin 0))
-   in testLEDGER (utxoState, dpState) tx ledgerEnv' (Left [errs])
+   in testLEDGER (utxoState, dpState) tx ledgerEnv' (Left errs)
 
 testInvalidWintess :: Assertion
 testInvalidWintess =
@@ -577,7 +577,7 @@ testInvalidWintess =
             InvalidWitnessesUTXOW
               [asWitness $ vKey alicePay]
         ]
-   in testLEDGER (utxoState, dpState) tx ledgerEnv (Left [errs])
+   in testLEDGER (utxoState, dpState) tx ledgerEnv (Left errs)
 
 testWithdrawalNoWit :: Assertion
 testWithdrawalNoWit =
@@ -603,7 +603,7 @@ testWithdrawalNoWit =
         [ UtxowFailure . MissingVKeyWitnessesUTXOW $ WitHashes missing
         ]
       dpState' = addReward dpState (getRwdCred $ mkVKeyRwdAcnt Testnet bobStake) (Coin 10)
-   in testLEDGER (utxoState, dpState') tx ledgerEnv (Left [errs])
+   in testLEDGER (utxoState, dpState') tx ledgerEnv (Left errs)
 
 testWithdrawalWrongAmt :: Assertion
 testWithdrawalWrongAmt =
@@ -632,7 +632,7 @@ testWithdrawalWrongAmt =
       dpState' = addReward dpState (getRwdCred rAcnt) (Coin 10)
       tx = Tx @C txb txwits SNothing
       errs = [DelegsFailure (WithdrawalsNotInRewardsDELEGS (Map.singleton rAcnt (Coin 11)))]
-   in testLEDGER (utxoState, dpState') tx ledgerEnv (Left [errs])
+   in testLEDGER (utxoState, dpState') tx ledgerEnv (Left errs)
 
 testOutputTooSmall :: Assertion
 testOutputTooSmall =


### PR DESCRIPTION
None of the improvements here change the outcome of computation. Most of the diff is just outcome minor, but very useful improvements. There are two improvements logically separated by two commits (if need be can be split into two separate PRs):

1. Improve assertion reporting by utilizing ExceptT to trigger short-circuiting of assertions and rely on monad for sequencing vs the tricky to get right imprecise exception triggered by forcing evaluation. Also addition of `AssertionException`, which is much easier to catch, if it is ever necessary (for example during testing). Catching `AssertionViolation sts` is not always possible to catch because `sts`  might not be known at the catch site.
2. Flatten `[[PredicateFailure s]]` list. At every place it is handled it is `concat`ed, so there is no point in dragging the nested list around. Especially since upon handling nested `STS` are flattened when being interpreted. 