### PR TITLE
Added reporting of why Plutus scripts fail.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Alonzo.Tx
     txouts,
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
+import Cardano.Ledger.Alonzo.TxInfo (ScriptResult (..))
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import Cardano.Ledger.BaseTypes
   ( Globals,
@@ -45,7 +46,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Crypto, Era, ValidateScript)
 import Cardano.Ledger.Mary.Value (Value)
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import qualified Cardano.Ledger.Val as Val
@@ -58,6 +59,7 @@ import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
+import Data.Text
 import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks)
@@ -90,6 +92,7 @@ instance
     Core.Value era ~ Value (Crypto era),
     Core.TxOut era ~ Alonzo.TxOut era,
     Core.TxBody era ~ Alonzo.TxBody era,
+    ValidateScript era,
     HasField "_keyDeposit" (Core.PParams era) Coin,
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
@@ -107,8 +110,7 @@ instance
 
 utxosTransition ::
   forall era.
-  ( Era era,
-    Core.Script era ~ Script era,
+  ( Core.Script era ~ Script era,
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
@@ -120,6 +122,7 @@ utxosTransition ::
     Core.TxOut era ~ Alonzo.TxOut era,
     Core.Value era ~ Value (Crypto era),
     Core.TxBody era ~ Alonzo.TxBody era,
+    ValidateScript era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "_keyDeposit" (Core.PParams era) Coin,
@@ -150,6 +153,7 @@ scriptsValidateTransition ::
     Core.TxBody era ~ Alonzo.TxBody era,
     Core.TxOut era ~ Alonzo.TxOut era,
     Core.Value era ~ Value (Crypto era),
+    ValidateScript era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "_keyDeposit" (Core.PParams era) Coin,
@@ -177,8 +181,9 @@ scriptsValidateTransition = do
   ei <- liftSTS $ asks epochInfo
   case collectTwoPhaseScriptInputs ei sysSt pp tx utxo of
     Right sLst ->
-      evalScripts @era tx sLst
-        ?!## ValidationTagMismatch (getField @"isValid" tx)
+      case evalScripts @era tx sLst of
+        Fails sss -> False ?!## ValidationTagMismatch (getField @"isValidating" tx) (pack (Prelude.unlines sss))
+        Passes -> pure ()
     Left info -> failBecause (CollectErrors info)
   pup' <-
     trans @(Core.EraRule "PPUP" era) $
@@ -203,6 +208,7 @@ scriptsNotValidateTransition ::
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
     Embed (Core.EraRule "PPUP" era) (UTXOS era),
+    ValidateScript era,
     Core.Script era ~ Script era,
     Core.TxBody era ~ Alonzo.TxBody era,
     Core.TxOut era ~ Alonzo.TxOut era,
@@ -220,8 +226,9 @@ scriptsNotValidateTransition = do
   ei <- liftSTS $ asks epochInfo
   case collectTwoPhaseScriptInputs ei sysSt pp tx utxo of
     Right sLst ->
-      not (evalScripts @era tx sLst)
-        ?!## ValidationTagMismatch (getField @"isValid" tx)
+      case (evalScripts @era tx sLst) of
+        Passes -> False ?!## ValidationTagMismatch (getField @"isValidating" tx) (pack ("Script expected to fail, passes."))
+        Fails _sss -> pure ()
     Left info -> failBecause (CollectErrors info)
   pure $
     us
@@ -232,8 +239,8 @@ scriptsNotValidateTransition = do
 data UtxosPredicateFailure era
   = -- | The 'isValid' tag on the transaction is incorrect. The tag given
     --   here is that provided on the transaction (whereas evaluation of the
-    --   scripts gives the opposite.)
-    ValidationTagMismatch IsValid
+    --   scripts gives the opposite.). The Text tries to explain why it failed.
+    ValidationTagMismatch IsValid Text
   | -- | We could not find all the necessary inputs for a Plutus Script.
     --         Previous PredicateFailure tests should make this impossible, but the
     --         consequences of not detecting this means scripts get dropped, so things
@@ -250,7 +257,7 @@ instance
   ) =>
   ToCBOR (UtxosPredicateFailure era)
   where
-  toCBOR (ValidationTagMismatch v) = encode (Sum ValidationTagMismatch 0 !> To v)
+  toCBOR (ValidationTagMismatch v txt) = encode (Sum ValidationTagMismatch 0 !> To v !> To txt)
   toCBOR (CollectErrors cs) =
     encode (Sum (CollectErrors @era) 1 !> To cs)
   toCBOR (UpdateFailure pf) = encode (Sum (UpdateFailure @era) 2 !> To pf)
@@ -263,7 +270,7 @@ instance
   where
   fromCBOR = decode (Summands "UtxosPredicateFailure" dec)
     where
-      dec 0 = SumD ValidationTagMismatch <! From
+      dec 0 = SumD ValidationTagMismatch <! From <! From
       dec 1 = SumD (CollectErrors @era) <! From
       dec 2 = SumD UpdateFailure <! From
       dec n = Invalid n
@@ -274,11 +281,16 @@ deriving stock instance
   ) =>
   Show (UtxosPredicateFailure era)
 
-deriving stock instance
+instance
   ( Shelley.TransUTxOState Eq era,
     Eq (PredicateFailure (Core.EraRule "PPUP" era))
   ) =>
   Eq (UtxosPredicateFailure era)
+  where
+  (ValidationTagMismatch a _) == (ValidationTagMismatch b _) = a == b -- Do not compare the Text in an Eq check.
+  (CollectErrors x) == (CollectErrors y) = x == y
+  (UpdateFailure x) == (UpdateFailure y) = x == y
+  _ == _ = False
 
 instance
   ( Shelley.TransUTxOState NoThunks era,
@@ -306,12 +318,12 @@ instance
 constructValidated ::
   forall era m.
   ( MonadError [UtxosPredicateFailure era] m,
-    Era era,
     Core.Script era ~ Script era,
     Core.TxOut era ~ Alonzo.TxOut era,
     Core.Value era ~ Value (Crypto era),
     Core.TxBody era ~ Alonzo.TxBody era,
     Core.Witnesses era ~ Alonzo.TxWitness era,
+    ValidateScript era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
@@ -332,13 +344,15 @@ constructValidated globals (UtxoEnv _ pp _ _) st tx =
             ValidatedTx
               (getField @"body" tx)
               (getField @"wits" tx)
-              (IsValid scriptEvalResult)
+              (IsValid (lift scriptEvalResult))
               (getField @"auxiliaryData" tx)
        in pure vTx
   where
     utxo = _utxo st
     sysS = systemStart globals
     ei = epochInfo globals
+    lift Passes = True -- Convert a ScriptResult into a Bool
+    lift (Fails _) = False
 
 --------------------------------------------------------------------------------
 -- 2-phase checks

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesValue)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Data.Text (pack)
 import qualified Data.Text as T (pack)
 import Numeric.Natural (Natural)
 import qualified PlutusTx as Plutus
@@ -261,7 +262,7 @@ instance Arbitrary (PParamsUpdate era) where
 instance Mock c => Arbitrary (UtxosPredicateFailure (AlonzoEra c)) where
   arbitrary =
     oneof
-      [ ValidationTagMismatch <$> arbitrary,
+      [ ValidationTagMismatch <$> arbitrary <*> (pack <$> arbitrary),
         UpdateFailure <$> arbitrary
       ]
 

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -1646,7 +1646,7 @@ alonzoUTXOWexamples =
               ( Left
                   [ WrappedShelleyEraFailure
                       ( UtxoFailure
-                          (UtxosFailure (ValidationTagMismatch (IsValid False)))
+                          (UtxosFailure (ValidationTagMismatch (IsValid False) ("Script expected to fail, passes.")))
                       )
                   ]
               ),
@@ -1655,7 +1655,7 @@ alonzoUTXOWexamples =
               (trustMe True $ notValidatingTx pf)
               ( Left
                   [ WrappedShelleyEraFailure
-                      (UtxoFailure (UtxosFailure (ValidationTagMismatch (IsValid True))))
+                      (UtxoFailure (UtxosFailure (ValidationTagMismatch (IsValid True) (""))))
                   ]
               ),
           testCase "too many execution units for tx" $


### PR DESCRIPTION
Exended  UtxosPredicateFailure, by adding a Text field to its constructor  ValidationTagMismatch.
Altered the functions runPLCScript  and  evalScripts return a ScriptResult rather than a Bool.

data ScriptResult = Passes | Fails ![String]

So when evalScripts fails in the Utxos rule, we add the reason why to ValidationTagMismatch.
Right now the text string is a rather crude concatenation of a bunch of show results. In the next step we will construct the Text object by using the PrettyA class, so the result is more informative.