### PR TITLE
Update to new cardano-base

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,8 +27,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 0f409343c3655c4bacd7fab385d392ec5d5cca98
-  --sha256: 0js76inb7avg8c39c9k2zsr77sycg2vadylgvsswdsba808p6hr9
+  tag: eb58eebc16ee898980c83bc325ab37a2c77b2414
+  --sha256: 1v5algrsa3g6lphl1nfih54xkc2xa5q1yfa3kgclcp6sxj1yjnnl
   subdir:
     binary
     binary/test

--- a/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -38,11 +38,6 @@ module Cardano.Ledger.BaseTypes
     invalidKey,
     mkNonceFromOutputVRF,
     mkNonceFromNumber,
-    StrictMaybe (..),
-    strictMaybeToMaybe,
-    maybeToStrictMaybe,
-    fromSMaybe,
-    isSNothing,
     Url,
     urlToText,
     textToUrl,
@@ -54,6 +49,7 @@ module Cardano.Ledger.BaseTypes
     mkActiveSlotCoeff,
     activeSlotVal,
     activeSlotLog,
+    module Data.Maybe.Strict,
 
     -- * STS Base
     Globals (..),
@@ -600,7 +596,3 @@ instance FromCBOR Network where
     word8ToNetwork <$> fromCBOR >>= \case
       Nothing -> cborError $ DecoderErrorCustom "Network" "Unknown network id"
       Just n -> pure n
-
-isSNothing :: StrictMaybe a -> Bool
-isSNothing SNothing = True
-isSNothing _ = False


### PR DESCRIPTION
Recently `StrictMaybe` helper functions were migrated to `strict-containers` in input-output-hk/cardano-base#223 This PR fixes compatibility