### PR TITLE
Update cardano-base and derive Measure for ExUnits

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -53,6 +53,7 @@ library
     Cardano.Ledger.DescribeEras
   build-depends:
     array,
+    base-deriving-via,
     bytestring,
     cardano-binary,
     cardano-crypto-class,
@@ -63,6 +64,7 @@ library
     containers,
     data-default,
     deepseq,
+    measures,
     mtl,
     nothunks,
     plutus-ledger-api,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -69,7 +69,9 @@ import Cardano.Ledger.ShelleyMA.Timelocks
 import Control.DeepSeq (NFData (..))
 import Data.ByteString.Short (ShortByteString, fromShort)
 import Data.Coders
+import Data.DerivingVia (InstantiatedAt (..))
 import Data.Map (Map)
+import Data.Measure (BoundedMeasure, Measure)
 import Data.Text (Text)
 import Data.Typeable
 import Data.Word (Word64, Word8)
@@ -134,16 +136,16 @@ data ExUnits = ExUnits
     exUnitsSteps :: !Word64
   }
   deriving (Eq, Generic, Show) -- It is deliberate that there is NO ORD instance.
+  deriving
+    (BoundedMeasure, Measure)
+    via (InstantiatedAt Generic ExUnits)
+  deriving
+    (Monoid, Semigroup)
+    via (InstantiatedAt Measure ExUnits)
 
 instance NoThunks ExUnits
 
 instance NFData ExUnits
-
-instance Semigroup ExUnits where
-  ExUnits a c <> ExUnits b d = ExUnits (a + b) (c + d)
-
-instance Monoid ExUnits where
-  mempty = ExUnits 0 0
 
 -- | It is deliberate that there is no ORD instace for EXUnits. Use this function
 --   to compare if one ExUnit is pointwise compareable to another.

--- a/cabal.project
+++ b/cabal.project
@@ -27,13 +27,15 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: eb58eebc16ee898980c83bc325ab37a2c77b2414
-  --sha256: 1v5algrsa3g6lphl1nfih54xkc2xa5q1yfa3kgclcp6sxj1yjnnl
+  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
+  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
   subdir:
+    base-deriving-via
     binary
     binary/test
     cardano-crypto-class
     cardano-crypto-praos
+    measures
     slotting
     strict-containers
 


### PR DESCRIPTION
`cardano-base` now defines the `Measure` class and the Consensus Layer needs `ExUnits` to instantiate it. This PR does so.