### PR TITLE
No extra redeemers

### DIFF
--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -120,6 +120,9 @@ the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
   and $\Nothing$ if no associated data is found.
   It uses the script purpose to generate the $\RdmrPtr$ key,
   then find the corresponding entry in the redeemer structure.
+  \item $\fun{rdptr}$ builds a redeemer pointer from a script purpose by
+  setting the tag according to the type of the script purpose, and the index
+  according to the placement of script purpose inside its container (ie. by using $\fun{indexof}$)
 \end{itemize}
 
 
@@ -164,12 +167,14 @@ the Alonzo era, this is also constant, with value $\mathsf{systemTime}$
     &\fun{indexedRdmrs} \in \Tx \to \ScriptPurpose \to (\Redeemer~\times~\ExUnits)^?\\
     &\fun{indexedRdmrs}~tx~sp =
       \begin{cases}
-        (d, \var{eu}) & \var{rdptr} \mapsto (\var{d}, \var{eu}) \in \fun{txrdmrs}~(\fun{txwits}~{tx}) \} \\
+        (d, \var{eu}) & (\fun{rdptr}~txb~sp)~ \mapsto (\var{d}, \var{eu}) \in \fun{txrdmrs}~(\fun{txwits}~{tx}) \} \\
         \Nothing & \text{otherwise}
       \end{cases} \\
     & ~~\where \\
-    & ~~\quad \var{txb} = \txbody{tx} \\
-    & ~~\quad \var{rdptr} = \begin{cases}
+    & ~~\quad \var{txb} = \txbody{tx}
+    \nextdef
+    &\fun{rdptr} ~\in~\TxBody~\to~\ScriptPurpose~ \to~ \RdmrPtr \\
+    &\fun{rdptr}~txb~sp~ =~ \begin{cases}
         (\mathsf{Cert},\fun{indexof}~\var{sp}~(\fun{txcerts}~{txb}))   & \var{sp}~\in~\DCert \\
         (\mathsf{Rewrd},\fun{indexof}~\var{sp}~(\fun{txwdrls}~{txb}))   & \var{sp}~\in~\AddrRWD \\
         (\mathsf{Mint},\fun{indexof}~\var{sp}~(\dom~(\fun{mint}~{txb})))    & \var{sp}~\in~\PolicyID \\
@@ -833,10 +838,10 @@ additional ones;
     \item For every item that needs to be validated by a phase-2 script, the transaction contains
       an entry in the indexed redeemer structure (ie. the execution units and redeemer for it are specified);
 
-    \item The size of the set containing script purposes for all phase-2 scripts is the
-    same as the size of the indexed redeemer structure. Combined with the check above,
-    this ensures that there are no additional entries present in the indexed redeemer structure
-    (ie. those that are not associated with a specific script purpose);
+    \item Each redeemer pointer in the indexed redeemer structure corresponds to
+    a pointer constructed using $\fun{rdptr}$ from some script purpose of the transaction.
+    This ensures that there are no additional entries present in the structure
+    (ie. those that are not required for validation of any script);
 
     \item The signatures of the keys whose hashes are specified in the
     $\fun{reqSignerHashes}$ field in a transaction
@@ -881,8 +886,8 @@ by the UTXO transition (the application of which is also part of the conditions)
       \hldiff{\dom (\fun{txdats}~{txw}) \subseteq \var{inputHashes} \cup \{h~\mid~ (\wcard, \wcard, h)\in\fun{txouts}\}}
       \\~\\
       \hldiff{\forall sph \in \fun{scriptsNeeded}~\var{utxo}~\var{tx},~ \fun{checkScriptData}~tx~sph} \\
-      \hldiff{\|\{ (sp, h)~ \in~ \fun{scriptsNeeded}~\var{utxo}~\var{tx} ~\vert~h\mapsto s~\in~ \fun{txscripts}~{txw},~
-      \var{s} \in \ScriptPhTwo \}\|~=~\|\fun{txrdmrs}~tx\|}
+      \hldiff{\ \forall~(\var{ptr}\mapsto \wcard)~\in~\fun{txrdmrs}~tx, ~ \var{ptr}~\in~\{~\fun{rdptr}~txb~sp~
+       \vert~ (sp,\wcard)~\in~\fun{scriptsNeeded}~\var{utxo}~\var{tx}~\} }
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{txw},
       \mathcal{V}_{\var{vk}}{\serialised{txbodyHash}}_{\sigma} \\

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -796,8 +796,8 @@ We construct the following helper functions :
     & \where \\
     & ~~~~~~~ \var{txb}~=~\txbody{tx}
     \nextdef
-    & \hspace{-1cm}\fun{checkScriptData} \in \Tx \to \UTxO \to (\ScriptPurpose \times \ScriptHash) \to \Bool \\
-    & \hspace{-1cm}\fun{checkScriptData}~\var{tx}~\var{utxo}~(\var{sp},\var{h})~=~ \forall s, (h\mapsto s) \in \fun{txscripts}~(\fun{txwits}~tx),\\
+    & \hspace{-1cm}\fun{checkScriptData} \in \Tx \to (\ScriptPurpose \times \ScriptHash) \to \Bool \\
+    & \hspace{-1cm}\fun{checkScriptData}~\var{tx}~(\var{sp},\var{h})~=~ \forall s, (h\mapsto s) \in \fun{txscripts}~(\fun{txwits}~tx),\\
     & (s \in \ScriptPhTwo~\Rightarrow \fun{txrdmrs}~tx~sp \neq \{\}) \\
     \nextdef
     & \hspace{-1cm}\fun{languages} \in \TxWitness \to \powerset{\Language} \\
@@ -835,7 +835,7 @@ additional ones;
 
     \item The size of the set containing script purposes for all phase-2 scripts is the
     same as the size of the indexed redeemer structure. Combined with the check above,
-    this ensures that there are no additional entries present in the indexed redeemer structure 
+    this ensures that there are no additional entries present in the indexed redeemer structure
     (ie. those that are not associated with a specific script purpose);
 
     \item The signatures of the keys whose hashes are specified in the
@@ -880,7 +880,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \hldiff{\var{inputHashes} \subseteq \dom (\fun{txdats}~{txw})} \\~\\
       \hldiff{\dom (\fun{txdats}~{txw}) \subseteq \var{inputHashes} \cup \{h~\mid~ (\wcard, \wcard, h)\in\fun{txouts}\}}
       \\~\\
-      \hldiff{\forall sph \in \fun{scriptsNeeded}~\var{utxo}~\var{tx},~ \fun{checkScriptData}~tx~utxo~sph} \\
+      \hldiff{\forall sph \in \fun{scriptsNeeded}~\var{utxo}~\var{tx},~ \fun{checkScriptData}~tx~sph} \\
       \hldiff{\|\{ (sp, h)~ \in~ \fun{scriptsNeeded}~\var{utxo}~\var{tx} ~\vert~h\mapsto s~\in~ \fun{txscripts}~{txw},~
       \var{s} \in \ScriptPhTwo \}\|~=~\|\fun{txrdmrs}~tx\|}
       \\~\\

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -247,10 +247,9 @@ checkScriptData ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   ValidatedTx era ->
-  -- UTxO era ->   -- TODO check that we really don't use the UTxO
   (ScriptPurpose (Crypto era), ScriptHash (Crypto era)) ->
   Bool
-checkScriptData tx {- utxo -} (sp, h) =
+checkScriptData tx (sp, h) =
   case Map.lookup h (txscripts' (getField @"wits" tx)) of
     Nothing -> False
     Just s -> if isNativeScript @era s then True else isJust (indexedRdmrs tx sp)

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -315,7 +315,7 @@ alonzoStyleWitness = do
       extraRdmrs =
         Map.keys $
           Map.filterWithKey
-            (\el _ -> elem (SJust el) [rdptr @era txbody sp | (sp, _) <- sphs])
+            (\el _ -> not $ elem (SJust el) [rdptr @era txbody sp | (sp, _) <- sphs])
             (unRedeemers $ txrdmrs . wits $ tx)
   null extraRdmrs ?! ExtraRedeemers extraRdmrs
 

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -311,12 +311,9 @@ alonzoStyleWitness = do
   null unredeemed ?! UnRedeemableScripts unredeemed
 
   {-  || { (sp, h) ∈ \fun{scriptsNeeded} utxo tx | h\mapsto s ∈ txscripts txw, s ∈ ScriptPhTwo } || = || fun{txrdmrs} tx ||  -}
-  let extraRdmrs :: [RdmrPtr]
-      extraRdmrs =
-        Map.keys $
-          Map.filterWithKey
-            (\el _ -> not $ elem (SJust el) [rdptr @era txbody sp | (sp, _) <- sphs])
-            (unRedeemers $ txrdmrs . wits $ tx)
+  let rdptrs = Set.fromList [el | (sp, _) <- sphs, SJust el <- [rdptr @era txbody sp]]
+      extraRdmrs :: [RdmrPtr]
+      extraRdmrs = Map.keys $ Map.withoutKeys (unRedeemers $ txrdmrs $ wits tx) rdptrs
   null extraRdmrs ?! ExtraRedeemers extraRdmrs
 
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -103,6 +103,13 @@ data RdmrPtr
 
 instance NoThunks RdmrPtr
 
+-- ToCBOR and FromCBOR for RdmrPtr is used in UTXOW for error reporting
+instance FromCBOR RdmrPtr where
+  fromCBOR = RdmrPtr <$> fromCBOR <*> fromCBOR
+
+instance ToCBOR RdmrPtr where
+  toCBOR (RdmrPtr t w) = toCBOR t <> toCBOR w
+
 instance ToCBORGroup RdmrPtr where
   listLen _ = 2
   listLenBound _ = 2

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -364,7 +364,7 @@ extraRedeemersTx pf =
     pf
     [ Body (extraRedeemersBody pf),
       Witnesses'
-        [ AddrWits [makeWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)],
+        [ AddrWits [makeWitnessVKey (hashAnnotated (extraRedeemersBody pf)) (someKeys pf)],
           ScriptWits [always 3 pf],
           DataWits [datumExample1],
           RdmrWits extraRedeemersEx

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -1573,6 +1573,8 @@ alonzoUTXOWexamples =
                       . UtxosFailure
                       . CollectErrors
                       $ [NoRedeemer (Spending (TxIn genesisId 1))],
+                    -- now "wrong redeemer label" means there are both unredeemable scripts and extra redeemers
+                    ExtraRedeemers [RdmrPtr Mint 0],
                     UnRedeemableScripts
                       [ ( Spending (TxIn genesisId 1),
                           (alwaysSucceedsHash 3 pf)

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -47,7 +47,7 @@ import Cardano.Ledger.Alonzo.Tx
     hashWitnessPPData,
   )
 import Cardano.Ledger.Alonzo.TxInfo (txInfo, valContext)
-import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..))
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), unRedeemers)
 import Cardano.Ledger.BaseTypes (Network (..), Seed, StrictMaybe (..), textToUrl)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (EraRule)
@@ -333,6 +333,43 @@ validatingRedeemersEx1 :: Era era => Redeemers era
 validatingRedeemersEx1 =
   Redeemers $
     Map.singleton (RdmrPtr Tag.Spend 0) (redeemerExample1, ExUnits 5000 5000)
+
+extraRedeemersEx :: Era era => Redeemers era
+extraRedeemersEx =
+  Redeemers $
+    Map.insert (RdmrPtr Tag.Spend 7) (redeemerExample1, ExUnits 432 444) (unRedeemers validatingRedeemersEx1)
+
+extraRedeemersBody :: Scriptic era => Proof era -> Core.TxBody era
+extraRedeemersBody pf =
+  newTxBody
+    Override
+    pf
+    [ Inputs [TxIn genesisId 1],
+      Collateral [TxIn genesisId 11],
+      Outputs [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newWppHash pf (pp pf) [PlutusV1] extraRedeemersEx txDatsExample1)
+    ]
+
+extraRedeemersTx ::
+  forall era.
+  ( Scriptic era,
+    SignBody era
+  ) =>
+  Proof era ->
+  Core.Tx era
+extraRedeemersTx pf =
+  newTx
+    Override
+    pf
+    [ Body (extraRedeemersBody pf),
+      Witnesses'
+        [ AddrWits [makeWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)],
+          ScriptWits [always 3 pf],
+          DataWits [datumExample1],
+          RdmrWits extraRedeemersEx
+        ]
+    ]
 
 outEx1 :: Scriptic era => Proof era -> Core.TxOut era
 outEx1 pf = newTxOut Override pf [Address (someAddr pf), Amount (inject $ Coin 4995)]
@@ -1574,7 +1611,7 @@ alonzoUTXOWexamples =
                       . CollectErrors
                       $ [NoRedeemer (Spending (TxIn genesisId 1))],
                     -- now "wrong redeemer label" means there are both unredeemable scripts and extra redeemers
-                    ExtraRedeemers [RdmrPtr Mint 0],
+                    ExtraRedeemers [RdmrPtr Tag.Mint 0],
                     UnRedeemableScripts
                       [ ( Spending (TxIn genesisId 1),
                           (alwaysSucceedsHash 3 pf)
@@ -1659,6 +1696,14 @@ alonzoUTXOWexamples =
                   [ NonOutputSupplimentaryDatums
                       (Set.singleton $ hashData @A totallyIrrelevantDatum)
                       mempty
+                  ]
+              ),
+          testCase "unacceptable extra redeemer" $
+            testUTXOW
+              (trustMe True $ extraRedeemersTx pf)
+              ( Left
+                  [ ExtraRedeemers
+                      [RdmrPtr Tag.Spend 7]
                   ]
               )
         ]


### PR DESCRIPTION
Add a check to the UTXOW rule that forbids redeemers that have pointers that do not point to script purposes required for validation of the Tx's contracts