### PR TITLE
Remove usage of MD5 in favor of Blake in testing

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,8 +33,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
-  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
+  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
+  --sha256: 0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq
   subdir:
     base-deriving-via
     binary

--- a/cabal.project
+++ b/cabal.project
@@ -21,13 +21,7 @@ packages:
   shelley-ma/shelley-ma-test
   example-shelley/
 
-constraints:
-  -- bizarre issue: in earlier versions they define their own 'GEq', in newer
-  -- ones they reuse the one from 'some', but there isn't e.g. a proper version
-  -- constraint from dependent-sum-template (which is the library we actually use).
-  , dependent-sum > 0.6.2.0
-
--- Always wrtie GHC env files, because they are needed by the doctests.
+-- Always write GHC env files, because they are needed by the doctests.
 write-ghc-environment-files: always
 
 source-repository-package

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -873,7 +873,7 @@ validatingRedeemersEx9 =
     [ (RdmrPtr Tag.Spend 0, (Data (Plutus.I 101), ExUnits 5000 5000)),
       (RdmrPtr Tag.Cert 1, (Data (Plutus.I 102), ExUnits 5000 5000)),
       (RdmrPtr Tag.Rewrd 0, (Data (Plutus.I 103), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Mint 1, (Data (Plutus.I 104), ExUnits 5000 5000))
+      (RdmrPtr Tag.Mint 0, (Data (Plutus.I 104), ExUnits 5000 5000))
     ]
 
 mintEx9 :: forall era. (PostShelley era, HasTokens era) => Proof era -> Core.Value era
@@ -1604,7 +1604,7 @@ alonzoUTXOWexamples =
                       (alwaysSucceedsHash 2 pf),
                     -- these redeemers are associated with phase-1 scripts
                     ExtraRedeemers
-                      [ RdmrPtr Tag.Mint 1,
+                      [ RdmrPtr Tag.Mint 0,
                         RdmrPtr Tag.Cert 1,
                         RdmrPtr Tag.Rewrd 0
                       ]

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -61,7 +61,6 @@ library
     bytestring,
     cardano-binary,
     cardano-crypto-class,
-    cardano-crypto-praos,
     cardano-ledger-core,
     cardano-ledger-shelley-ma,
     cardano-prelude,

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/EraBuffet.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/EraBuffet.hs
@@ -38,7 +38,7 @@ module Test.Cardano.Ledger.EraBuffet
 where
 
 import Cardano.Crypto.DSIGN (Ed25519DSIGN, MockDSIGN)
-import Cardano.Crypto.Hash (Blake2b_224, Blake2b_256, MD5Prefix)
+import Cardano.Crypto.Hash (Blake2bPrefix, Blake2b_224, Blake2b_256)
 import Cardano.Crypto.KES (MockKES, Sum6KES)
 import Cardano.Crypto.VRF.Praos
 import Cardano.Ledger.Allegra (AllegraEra)
@@ -58,8 +58,8 @@ import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 data TestCrypto
 
 instance CryptoClass.Crypto TestCrypto where
-  type HASH TestCrypto = MD5Prefix 10
-  type ADDRHASH TestCrypto = MD5Prefix 8
+  type HASH TestCrypto = Blake2bPrefix 10
+  type ADDRHASH TestCrypto = Blake2bPrefix 8
   type DSIGN TestCrypto = MockDSIGN
   type KES TestCrypto = MockKES 10
   type VRF TestCrypto = FakeVRF

--- a/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/EraBuffet.hs
+++ b/shelley-ma/shelley-ma-test/src/Test/Cardano/Ledger/EraBuffet.hs
@@ -37,45 +37,12 @@ module Test.Cardano.Ledger.EraBuffet
   )
 where
 
-import Cardano.Crypto.DSIGN (Ed25519DSIGN, MockDSIGN)
-import Cardano.Crypto.Hash (Blake2bPrefix, Blake2b_224, Blake2b_256)
-import Cardano.Crypto.KES (MockKES, Sum6KES)
-import Cardano.Crypto.VRF.Praos
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Core (AuxiliaryData, Script, TxBody, Value)
-import Cardano.Ledger.Crypto (HASH)
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Shelley.Spec.Ledger.API (PraosCrypto)
-import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
-
-{------------------------------------------------------------------------------
- First construct concrete versions of Crypto where the Hashing
- is concrete. Without this we won't be able to Hash things
-------------------------------------------------------------------------------}
-data TestCrypto
-
-instance CryptoClass.Crypto TestCrypto where
-  type HASH TestCrypto = Blake2bPrefix 10
-  type ADDRHASH TestCrypto = Blake2bPrefix 8
-  type DSIGN TestCrypto = MockDSIGN
-  type KES TestCrypto = MockKES 10
-  type VRF TestCrypto = FakeVRF
-
-instance PraosCrypto TestCrypto
-
-data StandardCrypto
-
-instance CryptoClass.Crypto StandardCrypto where
-  type DSIGN StandardCrypto = Ed25519DSIGN
-  type KES StandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256
-  type VRF StandardCrypto = PraosVRF
-  type HASH StandardCrypto = Blake2b_256
-  type ADDRHASH StandardCrypto = Blake2b_224
-
-instance PraosCrypto StandardCrypto
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StandardCrypto, TestCrypto)
 
 {------------------------------------------------------------------------------
  Example concrete Eras:

--- a/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/shelley-ma/shelley-ma-test/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -334,6 +334,12 @@ goldenEncodingTestsMary =
                 . TkInteger 2
                 . TkMapLen 2
             )
+            <> S policyID2
+            <> T
+              ( TkMapLen 1
+                  . TkBytes assetName3
+                  . TkInteger 19
+              )
             <> S policyID1
             <> T
               ( TkMapLen 2
@@ -341,12 +347,6 @@ goldenEncodingTestsMary =
                   . TkInteger 13
                   . TkBytes assetName2
                   . TkInteger 17
-              )
-            <> S policyID2
-            <> T
-              ( TkMapLen 1
-                  . TkBytes assetName3
-                  . TkInteger 19
               )
         ),
       checkEncodingCBOR

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Cardano/Crypto/VRF/Fake.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Cardano/Crypto/VRF/Fake.hs
@@ -66,7 +66,7 @@ instance SneakilyContainResult Seed where
   sneakilyExtractResult s sk =
     OutputVRF
       . hashToBytes
-      . hashWithSerialiser @MD5 id
+      . hashWithSerialiser @Blake2b_224 id
       $ toCBOR s <> toCBOR sk
   unsneakilyExtractPayload = id
 
@@ -99,7 +99,7 @@ instance VRFAlgorithm FakeVRF where
   sizeVerKeyVRF _ = 8
   sizeSignKeyVRF _ = 8
   sizeCertVRF _ = 10
-  sizeOutputVRF _ = sizeHash (Proxy :: Proxy MD5)
+  sizeOutputVRF _ = sizeHash (Proxy :: Proxy Blake2b_224)
 
   rawSerialiseVerKeyVRF (VerKeyFakeVRF k) = writeBinaryWord64 k
   rawSerialiseSignKeyVRF (SignKeyFakeVRF k) = writeBinaryWord64 k
@@ -138,7 +138,7 @@ evalVRF' a sk@(SignKeyFakeVRF n) =
       p = unsneakilyExtractPayload a
       realValue =
         fromIntegral . bytesToNatural . hashToBytes
-          . hashWithSerialiser @MD5 id
+          . hashWithSerialiser @Blake2b_224 id
           $ toCBOR p <> toCBOR sk
    in (y, CertFakeVRF n realValue)
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -12,7 +12,7 @@ module Test.Shelley.Spec.Ledger.ConcreteCryptoTypes where
 
 import Cardano.Crypto.DSIGN (MockDSIGN, VerKeyDSIGN)
 import qualified Cardano.Crypto.DSIGN.Class as DSIGN
-import Cardano.Crypto.Hash (MD5Prefix)
+import Cardano.Crypto.Hash (Blake2bPrefix)
 import Cardano.Crypto.KES (MockKES)
 import qualified Cardano.Crypto.KES.Class as KES
 import Cardano.Crypto.Util (SignableRepresentation)
@@ -44,8 +44,8 @@ type C = ShelleyEra C_Crypto
 data C_Crypto
 
 instance Cardano.Ledger.Crypto.Crypto C_Crypto where
-  type HASH C_Crypto = MD5Prefix 10
-  type ADDRHASH C_Crypto = MD5Prefix 8
+  type HASH C_Crypto = Blake2bPrefix 10
+  type ADDRHASH C_Crypto = Blake2bPrefix 8
   type DSIGN C_Crypto = MockDSIGN
   type KES C_Crypto = MockKES 10
   type VRF C_Crypto = FakeVRF

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -8,7 +8,15 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Shelley.Spec.Ledger.ConcreteCryptoTypes where
+module Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Mock,
+    ExMock,
+    C_Crypto,
+    C,
+    TestCrypto,
+    StandardCrypto,
+  )
+where
 
 import Cardano.Crypto.DSIGN (MockDSIGN, VerKeyDSIGN)
 import qualified Cardano.Crypto.DSIGN.Class as DSIGN
@@ -40,6 +48,8 @@ type ExMock c =
   )
 
 type C = ShelleyEra C_Crypto
+
+type TestCrypto = C_Crypto
 
 data C_Crypto
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/GoldenUtils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/GoldenUtils.hs
@@ -32,11 +32,12 @@ import Cardano.Prelude (LByteString)
 import Codec.CBOR.Encoding (Encoding (..), Tokens (..))
 import qualified Data.ByteString.Base16.Lazy as Base16
 import Data.String (fromString)
+import GHC.Stack
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase, (@?=))
 
 roundTrip ::
-  (Show a, Eq a) =>
+  (HasCallStack, Show a, Eq a) =>
   (a -> Encoding) ->
   (LByteString -> Either DecoderError a) ->
   a ->
@@ -47,7 +48,7 @@ roundTrip encode decode x =
     Right y -> y @?= x
 
 checkEncoding ::
-  (Show a, Eq a) =>
+  (HasCallStack, Show a, Eq a) =>
   (a -> Encoding) ->
   (LByteString -> Either DecoderError a) ->
   String ->
@@ -55,17 +56,17 @@ checkEncoding ::
   ToTokens ->
   TestTree
 checkEncoding encode decode name x t =
-  testCase testName $
+  testCase testName $ do
     assertEqual
       testName
       (Base16.encode $ serialize t)
       (Base16.encode . serializeEncoding . encode $ x)
-      >> roundTrip encode decode x
+    roundTrip encode decode x
   where
     testName = "golden_serialize_" <> name
 
 checkEncodingCBOR ::
-  (FromCBOR a, ToCBOR a, Show a, Eq a) =>
+  (HasCallStack, FromCBOR a, ToCBOR a, Show a, Eq a) =>
   String ->
   a ->
   ToTokens ->
@@ -75,7 +76,7 @@ checkEncodingCBOR name x t =
    in checkEncoding toCBOR d name x t
 
 checkEncodingCBORAnnotated ::
-  (FromCBOR (Annotator a), ToCBOR a, Show a, Eq a) =>
+  (HasCallStack, FromCBOR (Annotator a), ToCBOR a, Show a, Eq a) =>
   String ->
   a ->
   ToTokens ->

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Golden/ShelleyGenesis
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Golden/ShelleyGenesis
@@ -25,30 +25,30 @@
         "a0": 0.0
     },
     "genDelegs": {
-        "23d51e9123d51e91": {
-            "delegate": "839b047f839b047f",
-            "vrf": "231391e7231391e70123"
+        "38e7c5986a34f334e19b712c0aa525146dab8f0ff889b2ad16894241": {
+            "delegate": "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a",
+            "vrf": "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d"
         }
     },
     "updateQuorum": 16991,
     "networkId": "Testnet",
     "initialFunds": {
-        "001c14ee8e1c14ee8ee37a65eae37a65ea": 12157196
+        "00e1bade2ab9465a24fd5eaa4b7388303917338f853a48b11a5fc9964af5ca93fb6516ebde3d150b3e2acb1909532730de33832ffb229cb20d": 12157196
     },
     "maxLovelaceSupply": 71,
     "networkMagic": 4036000900,
     "epochLength": 1215,
     "staking": {
         "pools": {
-            "3dbe00a13dbe00a1": {
+            "f583a45e4947c102091b96170ef50ef0cf8edb62666193a2163247bb": {
                 "owners": [
-                    "f868a1960a3fa043"
+                    "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
                 ],
                 "cost": 5,
                 "margin": 0.25,
-                "publicKey": "a084ba8f6c83c1a5",
+                "publicKey": "4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e",
                 "pledge": 1,
-                "vrf": "edc9079a4f371cac310f",
+                "vrf": "68f9cfd33ac8f044facc664db5aa1b73c0b0f5435b85e7b520bb2f1a92f02999",
                 "metadata": {
                     "hash": "31303061627b7d31303061627b7d",
                     "url": "best.pool.com"
@@ -75,14 +75,14 @@
                 ],
                 "rewardAccount": {
                     "credential": {
-                        "key hash": "f868a1960a3fa043"
+                        "key hash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
                     },
                     "network": "Testnet"
                 }
             }
         },
         "stake": {
-            "1c14ee8e1c14ee8e": "1c14ee8e1c14ee8e"
+            "83a192dec0e8da2188e520d0c536a69a747cf173a3df16a6daa94d86": "649eda82bf644d34a6925f24ea4c4c36d27e51de1b44ef47e3560be7"
         }
     },
     "systemStart": "2009-02-13T23:13:09Z",

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -49,6 +49,7 @@ import Data.Proxy
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import GHC.Records (HasField (..))
+import GHC.Stack
 import Shelley.Spec.Ledger.API
   ( Addr,
     Credential (..),
@@ -79,7 +80,7 @@ import Shelley.Spec.Ledger.TxBody
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StandardCrypto, Mock)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock, StandardCrypto)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
 import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
 import Test.Shelley.Spec.Ledger.Utils
@@ -93,14 +94,14 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 sizeTest ::
-  Cr.Crypto c =>
+  (HasCallStack, Cr.Crypto c) =>
   proxy c ->
   BSL.ByteString ->
   Tx (ShelleyEra c) ->
-  Integer ->
   Assertion
-sizeTest _ b16 tx s = do
-  (Base16.encode (serialize tx) @?= b16) >> (getField @"txsize" tx @?= s)
+sizeTest _ b16 tx = do
+  Base16.encode (serialize tx) @?= b16
+  getField @"txsize" tx @?= toInteger (BSL.length b16 `div` 2)
 
 alicePay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
 alicePay = KeyPair @'Payment @crypto vk sk
@@ -202,7 +203,7 @@ txSimpleUTxO =
     }
 
 txSimpleUTxOBytes16 :: BSL.ByteString
-txSimpleUTxOBytes16 = "83a40081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030aa10081824873ed39075e40d2a650cf86ddd23ec58b7d73ed39075e40d2a6f6"
+txSimpleUTxOBytes16 = "83a4008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030aa100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584089c20cb6246483bbd0b2006f658597eff3e8ab3b8a6e9b22cb3c5b95cf0d3a2b96107acef88319fa2dd0fb28adcfdb330bb99f1f0058918a75d951ca9b73660cf6"
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
@@ -247,7 +248,7 @@ txMutiUTxO =
     }
 
 txMutiUTxOBytes16 :: BSL.ByteString
-txMutiUTxOBytes16 = "83a40082824a93b885adfe0da089cdf600824a93b885adfe0da089cdf601018582510075c40f44e1c155bedab80d3ec7c2190b0a82510075c40f44e1c155bedab80d3ec7c2190b1482510075c40f44e1c155bedab80d3ec7c2190b181e8251009ed1f6c32150add8a084ba8f6c83c1a518288251009ed1f6c32150add8a084ba8f6c83c1a518320218c7030aa10082824873ed39075e40d2a6503b5864e893a7f79b73ed39075e40d2a682483e046f8a4a4eeda1503b5864e893a7f79b3e046f8a4a4eeda1f6"
+txMutiUTxOBytes16 = "83a4008282582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140082582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131401018582583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a82583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df761482583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76181e825839000d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e1828825839000d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e18320218c7030aa1008282582037139648f2c22bbf1d0ef9af37cfebc9014b1e0e2a55be87c4b3b231a8d84d2658405ef09b22172cd28678e76e600e899886852e03567e2e72b4815629471e736a0cd424dc71cdaa0d0403371d79ea3d0cb7f28cb0740ebfcd8947343eba99a6aa088258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840ea98ef8052776aa5c182621cfd2ec91011d327527fc2531be9e1a8356c10f25f3fe5a5a7f549a0dc3b17c4ad8e4b8673b63a87977ac899b675f3ce3d6badae01f6"
 
 -- | Transaction which registers a stake key
 txbRegisterStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
@@ -275,7 +276,7 @@ txRegisterStake =
     }
 
 txRegisterStakeBytes16 :: BSL.ByteString
-txRegisterStakeBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818200820048dab80d3ec7c2190ba10081824873ed39075e40d2a650a18ed3946743381b73ed39075e40d2a6f6"
+txRegisterStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048182008200581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e58403271792b002eb39bcb133668e851a5ffba9c13ad2b5c5a7bbc850a17de8309cbb9649d9e90eb4c9cc82f28f204408d513ccc575ce1f61808f67793429ff1880ef6"
 
 -- | Transaction which delegates a stake key
 txbDelegateStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
@@ -310,7 +311,7 @@ txDelegateStake =
     }
 
 txDelegateStakeBytes16 :: BSL.ByteString
-txDelegateStakeBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818302820048a084ba8f6c83c1a548bc5edd0d46d5e843a10082824873ed39075e40d2a650a7e8c512200a5d6273ed39075e40d2a68248244ad6b5eb5665c750a7e8c512200a5d62244ad6b5eb5665c7f6"
+txDelegateStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048183028200581c4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e581c5d43e1f1048b2619f51abc0cf505e4d4f9cb84becefd468d1a2fe335a100828258209921fa37a7d167aab519bb937d7ac6e522ad6d259a6173523357b971e05f41ff58403bad563c201b4f62448db12711af2d916776194b5176e9d312d07a328ce7780a63032dce887abc67985629b7aeabb0c334e84094f44d7e51ae51b5c799a83c0d8258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584064aef85b046d2d0072cd64844e9f13d86651a1db74d356a10ecd7fb35a664fc466e543ea55cfbffd74025dc092d62c4b22d7e2de4decb4f049df354cfae9790af6"
 
 -- | Transaction which de-registers a stake key
 txbDeregisterStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
@@ -341,7 +342,7 @@ txDeregisterStake =
     }
 
 txDeregisterStakeBytes16 :: BSL.ByteString
-txDeregisterStakeBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818201820048dab80d3ec7c2190ba10081824873ed39075e40d2a6506e33cc1c6bf6608373ed39075e40d2a6f6"
+txDeregisterStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048182018200581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840409db925fa592b7f4c76e44d738789f4b0ffb2b9cf4567af127121d635491b4eb736e8c92571f1329f14d06aad7ec42ca654ae65eb63b0b01d30cc4454aee80cf6"
 
 -- | Transaction which registers a stake pool
 txbRegisterPool :: Cr.Crypto c => TxBody (ShelleyEra c)
@@ -369,7 +370,7 @@ txRegisterPool =
     }
 
 txRegisterPoolBytes16 :: BSL.ByteString
-txRegisterPoolBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a04818a0348bc5edd0d46d5e8434a3d64a89de764031618600105d81e82010a49e0dab80d3ec7c2190b8148dab80d3ec7c2190b818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081824873ed39075e40d2a6504f0cbb2cb5efa62473ed39075e40d2a6f6"
+txRegisterPoolBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a04818a03581c5d43e1f1048b2619f51abc0cf505e4d4f9cb84becefd468d1a2fe33558208e61e1fa4855ea3aa0b8881a9e2e453c8c73536bdaabb64d36de86ee5a02519a0105d81e82010a581de0c6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df7681581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840165c6aa107571daafb1f9093d3cdc184a4068e8ff9243715c13335feb3652dc0d817b3b015a9929c9d83a0dd406fe71658fdccbf7925d2fff316237b499c2003f6"
 
 -- | Transaction which retires a stake pool
 txbRetirePool :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
@@ -397,7 +398,7 @@ txRetirePool =
     }
 
 txRetirePoolBytes16 :: BSL.ByteString
-txRetirePoolBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a0481830448bc5edd0d46d5e84305a10081824873ed39075e40d2a650bd18ec483637eceb73ed39075e40d2a6f6"
+txRetirePoolBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a04818304581c5d43e1f1048b2619f51abc0cf505e4d4f9cb84becefd468d1a2fe33505a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e58404ad8f782368857f26db548d4ef6eca276639db9f1e8536f505c049ec94e0f6325c5f9f62a5187eb077f51bcd51cdff7d142415796442f2631081b90bf74f7204f6"
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
@@ -429,7 +430,7 @@ txWithMD =
     }
 
 txWithMDBytes16 :: BSL.ByteString
-txWithMDBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a074a4eece6527f366cfa5e71a10081824873ed39075e40d2a65010b0506a2911469873ed39075e40d2a6a10082056568656c6c6f"
+txWithMDBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a075820e2d7de09439ab222111cecd21545c5f9c338fd6653539031eb311d34fc97e718a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840ab05c3933f5c7281386309a374f45eeee28b6f3a01bc76a5fa3bc9efdc603dd63059d0aebfd198e23bf848dae43a23be3e6f85149bca2f27d0e7f4f63be38e02a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
 msig :: forall crypto. Cr.Crypto crypto => MultiSig crypto
@@ -470,7 +471,7 @@ txWithMultiSig =
     }
 
 txWithMultiSigBytes16 :: BSL.ByteString
-txWithMultiSigBytes16 = "83a40081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030aa20082824873ed39075e40d2a650cf86ddd23ec58b7d73ed39075e40d2a682483e046f8a4a4eeda150cf86ddd23ec58b7d3e046f8a4a4eeda101818303028382004875c40f44e1c155be8200489ed1f6c32150add8820048b59ebd7e616fad7ef6"
+txWithMultiSigBytes16 = "83a4008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030aa2008282582037139648f2c22bbf1d0ef9af37cfebc9014b1e0e2a55be87c4b3b231a8d84d265840e3b8f50632325fbd1f82202ce5a8b4672bd96c50a338d70c0aa96720f6f7fbf60e0ce708f3a7e28faa0d78dc437a0b61e02205ddb1db22d02ba35b37a7fe03068258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584089c20cb6246483bbd0b2006f658597eff3e8ab3b8a6e9b22cb3c5b95cf0d3a2b96107acef88319fa2dd0fb28adcfdb330bb99f1f0058918a75d951ca9b73660c0181830302838200581ce9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371f8200581c0d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd8200581cd0671052191a58c554eee27808b2b836a03ca369ca7a847f8c37d6f9f6"
 
 -- | Transaction with a Reward Withdrawal
 txbWithWithdrawal :: Cr.Crypto c => TxBody (ShelleyEra c)
@@ -501,7 +502,7 @@ txWithWithdrawal =
     }
 
 txWithWithdrawalBytes16 :: BSL.ByteString
-txWithWithdrawalBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e1c155bedab80d3ec7c2190b0a02185e030a05a149e0dab80d3ec7c2190b1864a10082824873ed39075e40d2a6509543f3cca5c77bce73ed39075e40d2a682489ac25c873e2248cc509543f3cca5c77bce9ac25c873e2248ccf6"
+txWithWithdrawalBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a05a1581de0c6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df761864a100828258208f40b25c9987eeb9c7f75eaf4f461f16384872a94dc353a4fb5c95bb657c59f85840c52adcbc184a497d1746ee962a762427e79e3f600a356378ffda6294c658ed91c0f0c7815cbaefb22bdabc09c5bf6c5f6724c0136701da26c77882f739f109038258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584012d30a6d3dbe0223e772dc183c138779449cd5fd9aac817b63af945b0a8e9f85be3bcc4457ad1a27f08fd36205717f8bafea1b1328f3a074febcfc62b6b99f06f6"
 
 -- | The transaction fee of txSimpleUTxO if one key witness were to be added,
 -- given minfeeA and minfeeB are set to 1.
@@ -522,28 +523,29 @@ testEvaluateTransactionFee =
           auxiliaryData = SNothing
         }
 
--- NOTE the txsize function takes into account which actual crypto parameter is use.
--- These tests are using Blake2bPrefix and MockDSIGN so that:
---       the regular hash length is ----> 10
---       the address hash length is ---->  8
---       the verification key size is -->  8
---       the signature size is ---------> 13
+
+-- NOTE the txsize function takes into account which actual crypto parameter is in use.
+-- These tests are using Blake2b and Ed25519 so that:
+--       the regular hash length is ----> 32
+--       the address hash length is ----> 28
+--       the verification key size is --> 32
+--       the signature size is ---------> 64
 
 sizeTests :: TestTree
 sizeTests =
   testGroup
     "Fee Tests"
-    [ testCase "simple utxo" $ sizeTest p txSimpleUTxOBytes16 txSimpleUTxO 75,
-      testCase "multiple utxo" $ sizeTest p txMutiUTxOBytes16 txMutiUTxO 198,
-      testCase "register stake key" $ sizeTest p txRegisterStakeBytes16 txRegisterStake 90,
-      testCase "delegate stake key" $ sizeTest p txDelegateStakeBytes16 txDelegateStake 126,
-      testCase "deregister stake key" $ sizeTest p txDeregisterStakeBytes16 txDeregisterStake 90,
-      testCase "register stake pool" $ sizeTest p txRegisterPoolBytes16 txRegisterPool 154,
-      testCase "retire stake pool" $ sizeTest p txRetirePoolBytes16 txRetirePool 89,
-      testCase "auxiliaryData" $ sizeTest p txWithMDBytes16 txWithMD 96,
-      testCase "multisig" $ sizeTest p txWithMultiSigBytes16 txWithMultiSig 141,
-      testCase "reward withdrawal" $ sizeTest p txWithWithdrawalBytes16 txWithWithdrawal 116,
-      testCase "evaluate transaction fee" $ testEvaluateTransactionFee
+    [ testCase "simple utxo" $ sizeTest p txSimpleUTxOBytes16 txSimpleUTxO,
+      testCase "multiple utxo" $ sizeTest p txMutiUTxOBytes16 txMutiUTxO,
+      testCase "register stake key" $ sizeTest p txRegisterStakeBytes16 txRegisterStake,
+      testCase "delegate stake key" $ sizeTest p txDelegateStakeBytes16 txDelegateStake,
+      testCase "deregister stake key" $ sizeTest p txDeregisterStakeBytes16 txDeregisterStake,
+      testCase "register stake pool" $ sizeTest p txRegisterPoolBytes16 txRegisterPool,
+      testCase "retire stake pool" $ sizeTest p txRetirePoolBytes16 txRetirePool,
+      testCase "auxiliaryData" $ sizeTest p txWithMDBytes16 txWithMD,
+      testCase "multisig" $ sizeTest p txWithMultiSigBytes16 txWithMultiSig,
+      testCase "reward withdrawal" $ sizeTest p txWithWithdrawalBytes16 txWithWithdrawal,
+      testCase "evaluate transaction fee" testEvaluateTransactionFee
     ]
   where
     p :: Proxy StandardCrypto

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -523,7 +523,6 @@ testEvaluateTransactionFee =
           auxiliaryData = SNothing
         }
 
-
 -- NOTE the txsize function takes into account which actual crypto parameter is in use.
 -- These tests are using Blake2b and Ed25519 so that:
 --       the regular hash length is ----> 32

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -523,7 +523,7 @@ testEvaluateTransactionFee =
         }
 
 -- NOTE the txsize function takes into account which actual crypto parameter is use.
--- These tests are using MD5Prefix and MockDSIGN so that:
+-- These tests are using Blake2bPrefix and MockDSIGN so that:
 --       the regular hash length is ----> 10
 --       the address hash length is ---->  8
 --       the verification key size is -->  8

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -79,7 +79,7 @@ import Shelley.Spec.Ledger.TxBody
     Wdrl (..),
   )
 import Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C, C_Crypto, Mock)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StandardCrypto, Mock)
 import Test.Shelley.Spec.Ledger.Generator.EraGen (genesisId)
 import Test.Shelley.Spec.Ledger.Generator.ShelleyEraGen ()
 import Test.Shelley.Spec.Ledger.Utils
@@ -94,7 +94,7 @@ import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 sizeTest ::
   Cr.Crypto c =>
-  proxy (ShelleyEra c) ->
+  proxy c ->
   BSL.ByteString ->
   Tx (ShelleyEra c) ->
   Integer ->
@@ -507,11 +507,11 @@ txWithWithdrawalBytes16 = "83a50081824a93b885adfe0da089cdf600018182510075c40f44e
 -- given minfeeA and minfeeB are set to 1.
 testEvaluateTransactionFee :: Assertion
 testEvaluateTransactionFee =
-  API.evaluateTransactionFee @(ShelleyEra C_Crypto)
+  API.evaluateTransactionFee @(ShelleyEra StandardCrypto)
     pp
     txSimpleUTxONoWit
     1
-    @?= minfee pp (txSimpleUTxO @C_Crypto)
+    @?= minfee pp (txSimpleUTxO @StandardCrypto)
   where
     pp = emptyPParams {_minfeeA = 1, _minfeeB = 1}
 
@@ -546,5 +546,5 @@ sizeTests =
       testCase "evaluate transaction fee" $ testEvaluateTransactionFee
     ]
   where
-    p :: Proxy C
+    p :: Proxy StandardCrypto
     p = Proxy

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Rewards.hs
@@ -17,7 +17,7 @@ module Test.Shelley.Spec.Ledger.Rewards (rewardTests, C, defaultMain, newEpochPr
 
 import Cardano.Binary (toCBOR)
 import qualified Cardano.Crypto.DSIGN as Crypto
-import Cardano.Crypto.Hash (MD5, hashToBytes)
+import Cardano.Crypto.Hash (Blake2b_256, hashToBytes)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
 import qualified Cardano.Crypto.VRF as Crypto
 import Cardano.Ledger.BaseTypes
@@ -194,7 +194,7 @@ keyPair seed = KeyPair vk sk
     sk =
       Crypto.genKeyDSIGN $
         mkSeedFromBytes . hashToBytes $
-          hashWithSerialiser @MD5 toCBOR seed
+          hashWithSerialiser @Blake2b_256 toCBOR seed
 
 vrfKeyPair :: forall v. Crypto.VRFAlgorithm v => Int -> (Crypto.SignKeyVRF v, Crypto.VerKeyVRF v)
 vrfKeyPair seed = (sk, vk)
@@ -203,7 +203,7 @@ vrfKeyPair seed = (sk, vk)
     sk =
       Crypto.genKeyVRF $
         mkSeedFromBytes . hashToBytes $
-          hashWithSerialiser @MD5 toCBOR seed
+          hashWithSerialiser @Blake2b_256 toCBOR seed
 
 data PoolSetUpArgs crypto f = PoolSetUpArgs
   { poolPledge :: f Coin,

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
@@ -11,7 +11,7 @@ module Test.Shelley.Spec.Ledger.SafeHash (safeHashTest) where
 
 -- Crypto imports
 import Cardano.Crypto.DSIGN (Ed25519DSIGN, MockDSIGN)
-import Cardano.Crypto.Hash (Blake2b_224, Blake2b_256, MD5Prefix)
+import Cardano.Crypto.Hash (Blake2bPrefix, Blake2b_224, Blake2b_256)
 import Cardano.Crypto.KES (MockKES, Sum6KES)
 import Cardano.Crypto.VRF.Praos
 import qualified Cardano.Ledger.Crypto as CryptoClass
@@ -34,8 +34,8 @@ import Test.Tasty.HUnit
 data TestCrypto
 
 instance CryptoClass.Crypto TestCrypto where
-  type HASH TestCrypto = MD5Prefix 10
-  type ADDRHASH TestCrypto = MD5Prefix 8
+  type HASH TestCrypto = Blake2bPrefix 10
+  type ADDRHASH TestCrypto = Blake2bPrefix 8
   type DSIGN TestCrypto = MockDSIGN
   type KES TestCrypto = MockKES 10
   type VRF TestCrypto = FakeVRF

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
@@ -22,7 +22,6 @@ import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 import Test.Tasty
 import Test.Tasty.HUnit
 
-
 -- =========================
 -- Some examples
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/SafeHash.hs
@@ -9,12 +9,6 @@
 
 module Test.Shelley.Spec.Ledger.SafeHash (safeHashTest) where
 
--- Crypto imports
-import Cardano.Crypto.DSIGN (Ed25519DSIGN, MockDSIGN)
-import Cardano.Crypto.Hash (Blake2bPrefix, Blake2b_224, Blake2b_256)
-import Cardano.Crypto.KES (MockKES, Sum6KES)
-import Cardano.Crypto.VRF.Praos
-import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.SafeHash
 -- ByteString imports
 
@@ -24,34 +18,10 @@ import Data.ByteString.Short (ShortByteString, toShort)
 
 import Data.Proxy
 import Data.String (fromString)
-import Shelley.Spec.Ledger.API (PraosCrypto)
-import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- =======================================================
-
-data TestCrypto
-
-instance CryptoClass.Crypto TestCrypto where
-  type HASH TestCrypto = Blake2bPrefix 10
-  type ADDRHASH TestCrypto = Blake2bPrefix 8
-  type DSIGN TestCrypto = MockDSIGN
-  type KES TestCrypto = MockKES 10
-  type VRF TestCrypto = FakeVRF
-
-instance PraosCrypto TestCrypto
-
-data StandardCrypto
-
-instance CryptoClass.Crypto StandardCrypto where
-  type DSIGN StandardCrypto = Ed25519DSIGN
-  type KES StandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256
-  type VRF StandardCrypto = PraosVRF
-  type HASH StandardCrypto = Blake2b_256
-  type ADDRHASH StandardCrypto = Blake2b_224
-
-instance PraosCrypto StandardCrypto
 
 -- =========================
 -- Some examples

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Encoding.hs
@@ -1170,8 +1170,8 @@ tests =
                 -- tx 4, two scripts
                 <> T (TkMapLen 1 . TkWord 1)
                 <> T (TkListLen 2)
-                <> S (testScript2 @C_Crypto)
                 <> S (testScript @C_Crypto)
+                <> S (testScript2 @C_Crypto)
                 -- tx 5, two keys and two scripts
                 <> T (TkMapLen 2)
                 <> T (TkWord 0)
@@ -1180,8 +1180,8 @@ tests =
                 <> S w1
                 <> T (TkWord 1)
                 <> T (TkListLen 2)
-                <> S (testScript2 @C_Crypto)
                 <> S (testScript @C_Crypto)
+                <> S (testScript2 @C_Crypto)
                 -- metadata
                 <> T (TkMapLen 1)
                 <> T (TkInt 4)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
@@ -60,7 +60,7 @@ prop_golden_cbor_ShelleyGenesis =
         mconcat
           [ "\nexpected:\n",
             show expected,
-            "\nexpected:\n",
+            "\nreceived:\n",
             show received,
             "\n"
           ]
@@ -123,28 +123,36 @@ prop_golden_cbor_ShelleyGenesis =
         . TkInt 0
         . TkInt 0
         . TkMapLen 1 -- sgGenDelegs
-        . TkBytes "#\213\RS\145#\213\RS\145"
+        . TkBytes
+          "8\231\197\152j4\243\&4\225\155q,\n\165%\DC4m\171\143\SI\248\137\178\173\SYN\137BA"
         . TkListLen 2
-        . TkBytes "\131\155\EOT\DEL\131\155\EOT\DEL"
-        . TkBytes "#\DC3\145\231#\DC3\145\231\SOH#"
+        . TkBytes
+          "\230\150\r\214q\238\141s\222\SUB\131\209\&4[f\DC1e\220\221\235\169\150#\190\239/\NAKz"
+        . TkBytes
+          "\252\227\FSo1\135S\RS\228\163\154\167C\194M\"'_AZ\136\149\233\205\"\195\f\138%\205\239\r"
         . TkMapLen 1 -- sgInitialFunds
-        . TkBytes "\NUL\FS\DC4\238\142\FS\DC4\238\142\227ze\234\227ze\234"
+        . TkBytes
+          "\NUL\225\186\222*\185FZ$\253^\170Ks\136\&09\ETB3\143\133:H\177\SUB_\201\150J\245\202\147\251e\SYN\235\222=\NAK\v>*\203\EM\tS'0\222\&3\131/\251\"\156\178\r"
         . TkInt 12157196
         . TkListLen 2 -- sgStaking
         . TkMapLen 1 -- sgsPools
-        . TkBytes "=\190\NUL\161=\190\NUL\161"
+        . TkBytes
+          "\245\131\164^IG\193\STX\t\ESC\150\ETB\SO\245\SO\240\207\142\219bfa\147\162\SYN2G\187"
         . TkListLen 9 -- PoolParams
-        . TkBytes "\160\132\186\143l\131\193\165"
-        . TkBytes "\237\201\a\154O7\FS\172\&1\SI"
+        . TkBytes
+          "N\DC3\f\v\222\183v\142\223.\143\133\NUL\DEL\213 s\227\220\CANq\244\196\DEL\157\252\169."
+        . TkBytes
+          "h\249\207\211:\200\240D\250\204fM\181\170\ESCs\192\176\245C[\133\231\181 \187/\SUB\146\240)\153"
         . TkInt 1
         . TkInt 5
         . TkTag 30
         . TkListLen 2
         . TkInt 1
         . TkInt 4
-        . TkBytes "\224\248h\161\150\n?\160C"
+        . TkBytes
+          "\224N\136\204-'\195d\170\249\ACKH\168}\251\149\248\238\DLE;\166\DEL\161\241/^\134\196*"
         . TkListLen 1
-        . TkBytes "\248h\161\150\n?\160C"
+        . TkBytes "N\136\204-'\195d\170\249\ACKH\168}\251\149\248\238\DLE;\166\DEL\161\241/^\134\196*"
         . TkListLen 3
         . TkListLen 4
         . TkInt 0
@@ -162,8 +170,9 @@ prop_golden_cbor_ShelleyGenesis =
         . TkString "best.pool.com"
         . TkBytes "100ab{}100ab{}"
         . TkMapLen 1 -- sgsStake
-        . TkBytes "\FS\DC4\238\142\FS\DC4\238\142"
-        . TkBytes "\FS\DC4\238\142\FS\DC4\238\142"
+        . TkBytes
+          "\131\161\146\222\192\232\218!\136\229 \208\197\&6\166\154t|\241s\163\223\SYN\166\218\169M\134"
+        . TkBytes "d\158\218\130\191dM4\166\146_$\234LL6\210~Q\222\ESCD\239G\227V\v\231"
 
 -- TODO - return a CBOR diff in the case of failure
 
@@ -205,13 +214,13 @@ exampleShelleyGenesis =
   where
     -- hash of the genesis verification key
     genesisVerKeyHash :: L.KeyHash 'L.Genesis (Crypto era)
-    genesisVerKeyHash = L.KeyHash "23d51e9123d51e91"
+    genesisVerKeyHash = L.KeyHash "38e7c5986a34f334e19b712c0aa525146dab8f0ff889b2ad16894241"
     -- hash of the delegators verififation key
     genDelegPair = L.GenDelegPair delegVerKeyHash delegVrfKeyHash
     delegVerKeyHash :: L.KeyHash 'L.GenesisDelegate (Crypto era)
-    delegVerKeyHash = L.KeyHash "839b047f839b047f"
+    delegVerKeyHash = L.KeyHash "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a"
     delegVrfKeyHash :: Hash.Hash (HASH (Crypto era)) (L.VerKeyVRF (Crypto era))
-    delegVrfKeyHash = "231391e7231391e70123"
+    delegVrfKeyHash = "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d"
     initialFundedAddress :: L.Addr (Crypto era)
     initialFundedAddress =
       L.Addr
@@ -222,11 +231,11 @@ exampleShelleyGenesis =
         paymentCredential =
           L.KeyHashObj $
             L.KeyHash
-              "1c14ee8e1c14ee8e"
+              "e1bade2ab9465a24fd5eaa4b7388303917338f853a48b11a5fc9964a"
         stakingCredential =
           L.KeyHashObj $
             L.KeyHash
-              "e37a65eae37a65ea"
+              "f5ca93fb6516ebde3d150b3e2acb1909532730de33832ffb229cb20d"
     initialFunds :: L.Coin
     initialFunds = L.Coin 12157196
     relays =
@@ -258,6 +267,14 @@ exampleShelleyGenesis =
         }
     staking =
       ShelleyGenesisStaking
-        { sgsPools = Map.fromList [(L.KeyHash "3dbe00a13dbe00a1", poolParams)],
-          sgsStake = Map.fromList [(L.KeyHash "1c14ee8e1c14ee8e", L.KeyHash "1c14ee8e1c14ee8e")]
+        { sgsPools =
+            Map.fromList
+              [ (L.KeyHash "f583a45e4947c102091b96170ef50ef0cf8edb62666193a2163247bb", poolParams)
+              ],
+          sgsStake =
+            Map.fromList
+              [ ( L.KeyHash "83a192dec0e8da2188e520d0c536a69a747cf173a3df16a6daa94d86",
+                  L.KeyHash "649eda82bf644d34a6925f24ea4c4c36d27e51de1b44ef47e3560be7"
+                )
+              ]
         }

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Serialisation/Golden/Genesis.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.BaseTypes (textToDns, textToUrl)
 import Cardano.Ledger.Crypto (HASH)
 import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Keys (hashKey, hashVerKeyVRF, vKey)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Slotting.Slot (EpochSize (..))
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.Map.Strict as Map
@@ -33,7 +34,7 @@ import qualified Shelley.Spec.Ledger.API as L
 import Shelley.Spec.Ledger.Genesis
 import Shelley.Spec.Ledger.PParams (PParams' (..), emptyPParams)
 import Test.Cardano.Prelude
-import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StandardCrypto)
 import qualified Test.Shelley.Spec.Ledger.Examples.Cast as Cast
 import Test.Shelley.Spec.Ledger.Utils
   ( RawSeed (..),
@@ -48,7 +49,7 @@ import Test.Tasty.Hedgehog
 prop_golden_json_ShelleyGenesis :: Property
 prop_golden_json_ShelleyGenesis = goldenTestJSONPretty example "test/Golden/ShelleyGenesis"
   where
-    example :: ShelleyGenesis C
+    example :: ShelleyGenesis (ShelleyEra StandardCrypto)
     example = exampleShelleyGenesis
 
 prop_golden_cbor_ShelleyGenesis :: Assertion
@@ -65,7 +66,7 @@ prop_golden_cbor_ShelleyGenesis =
           ]
     else return ()
   where
-    example :: ShelleyGenesis C
+    example :: ShelleyGenesis (ShelleyEra StandardCrypto)
     example = exampleShelleyGenesis
 
     received = Encoding expectedTokens


### PR DESCRIPTION
There is an effort in progress of dropping usage of cryptonite in favor of libsodium and thus dropping support of MD5 in input-output-hk/cardano-base#226

This PR uses changes from the aforementioned effort to drop MD5 in favor of Blake2b and MD5Prefix in favor of Blake2bPrefix

Don't merge until the input-output-hk/cardano-base#226 PR has been merged.
