### PR TITLE
better collateral predicate failure

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -78,6 +78,7 @@ import Data.Coders
 import Data.Coerce (coerce)
 import Data.Foldable (foldl', toList)
 import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
@@ -185,7 +186,7 @@ data UtxoPredicateFailure era
       !Coin
       -- ^ balance computed
       !Coin
-      -- ^ the fee supplied in this transaction
+      -- ^ the required collateral for the given fee
   | -- | The UTxO entries which have the wrong kind of script
     ScriptsNotPaidUTxO
       !(UTxO era)
@@ -292,7 +293,9 @@ feesOK pp tx (UTxO m) = do
           (UTxO (Map.filter (not . vKeyLocked) utxoCollateral))
       -- Part 4
       (Val.scale (100 :: Natural) (Val.coin bal) >= Val.scale collPerc theFee)
-        ?! InsufficientCollateral (Val.coin bal) theFee
+        ?! InsufficientCollateral
+          (Val.coin bal)
+          (rationalToCoinViaCeiling $ (fromIntegral collPerc * (unCoin theFee)) % 100)
       -- Part 5
       Val.inject (Val.coin bal) == bal ?! CollateralContainsNonADA bal
       -- Part 6

--- a/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Coin
     word64ToCoin,
     coinToRational,
     rationalToCoinViaFloor,
+    rationalToCoinViaCeiling,
     addDeltaCoin,
     toDeltaCoin,
     integerToWord64,
@@ -68,6 +69,9 @@ coinToRational (Coin c) = fromIntegral c
 
 rationalToCoinViaFloor :: Rational -> Coin
 rationalToCoinViaFloor r = Coin . floor $ r
+
+rationalToCoinViaCeiling :: Rational -> Coin
+rationalToCoinViaCeiling r = Coin . ceiling $ r
 
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin Word64

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Alonzo.Tx
     ScriptPurpose (..),
     ValidatedTx (..),
     hashWitnessPPData,
+    minfee,
   )
 import Cardano.Ledger.Alonzo.TxInfo (txInfo, valContext)
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), unRedeemers)
@@ -100,6 +101,7 @@ import Shelley.Spec.Ledger.API
   ( BHBody (..),
     BHeader (..),
     Block (..),
+    CLI (..),
     DPState (..),
     DState (..),
     KESPeriod (..),
@@ -1927,3 +1929,29 @@ alonzoBBODYexamples =
     ]
   where
     pf = Alonzo Mock
+
+testEvaluateTransactionFee :: Assertion
+testEvaluateTransactionFee =
+  evaluateTransactionFee @A
+    pparams
+    validatingTxNoWits
+    1
+    @?= minfee pparams (validatingTx pf)
+  where
+    pf = Alonzo Mock
+    pparams = newPParams pf $ defaultPPs ++ [MinfeeA 1]
+    validatingTxNoWits =
+      newTx
+        Override
+        pf
+        [ Body (validatingBody pf),
+          Witnesses'
+            [ ScriptWits [always 3 pf],
+              DataWits [datumExample1],
+              RdmrWits validatingRedeemersEx1
+            ]
+        ]
+
+alonzoAPITests :: TestTree
+alonzoAPITests =
+  testGroup "Alonzo API" [testCase "evaluateTransactionFee" testEvaluateTransactionFee]

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -569,6 +569,8 @@ data PParamsField era
     MaxBlockExUnits (ExUnits)
   | -- | Max size of a Value in an output
     MaxValSize (Natural)
+  | -- | The scaling percentage of the collateral relative to the fee
+    CollateralPercentage (Natural)
 
 -- | An updater specialized to the Shelley PParams (also used in Allegra and Mary)
 updateShelleyPP :: PP.PParams era -> PParamsField era -> PP.PParams era
@@ -617,6 +619,7 @@ updatePParams (Alonzo _) pp dpp = case dpp of
   MaxValSize n -> pp {Alonzo._maxValSize = n}
   MaxTxExUnits n -> pp {Alonzo._maxTxExUnits = n}
   MaxBlockExUnits n -> pp {Alonzo._maxBlockExUnits = n}
+  CollateralPercentage perc -> pp {Alonzo._collateralPercentage = perc}
   _ -> pp
 
 newPParams :: Proof era -> [PParamsField era] -> Core.PParams era

--- a/cardano-ledger-test/test/Tests.hs
+++ b/cardano-ledger-test/test/Tests.hs
@@ -11,7 +11,8 @@ module Main where
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
 import Test.Cardano.Ledger.BaseTypes (baseTypesTests)
 import Test.Cardano.Ledger.Examples.TwoPhaseValidation
-  ( alonzoBBODYexamples,
+  ( alonzoAPITests,
+    alonzoBBODYexamples,
     alonzoUTXOWexamples,
     collectOrderingAlonzo,
   )
@@ -36,6 +37,7 @@ mainTests =
         "STS Tests"
         [ alonzoUTXOWexamples,
           alonzoBBODYexamples,
+          alonzoAPITests,
           collectOrderingAlonzo
         ]
     ]

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Test/Shelley/Spec/Ledger/Fees.hs
@@ -65,6 +65,7 @@ import Shelley.Spec.Ledger.API
     hashVerKeyVRF,
   )
 import qualified Shelley.Spec.Ledger.API as API
+import Shelley.Spec.Ledger.LedgerState (minfee)
 import qualified Shelley.Spec.Ledger.Metadata as MD
 import Shelley.Spec.Ledger.PParams (PParams' (..), emptyPParams)
 import Shelley.Spec.Ledger.Tx
@@ -508,11 +509,18 @@ testEvaluateTransactionFee :: Assertion
 testEvaluateTransactionFee =
   API.evaluateTransactionFee @(ShelleyEra C_Crypto)
     pp
-    (txSimpleUTxO @C_Crypto)
+    txSimpleUTxONoWit
     1
-    @?= Coin 103
+    @?= minfee pp (txSimpleUTxO @C_Crypto)
   where
     pp = emptyPParams {_minfeeA = 1, _minfeeB = 1}
+
+    txSimpleUTxONoWit =
+      Tx
+        { body = txbSimpleUTxO,
+          wits = mempty,
+          auxiliaryData = SNothing
+        }
 
 -- NOTE the txsize function takes into account which actual crypto parameter is use.
 -- These tests are using MD5Prefix and MockDSIGN so that:


### PR DESCRIPTION
The previous `InsufficientCollateral` predicate failure was reporting the given fee, not the required collateral, which is confusing. We now report the required collateral.

The golden/example test changes are a bit noisy since I made it now possible to use different protocol parameters, and I also change the amount in the collateral output.

Additionally, in a separate commit, I added an unrelated test. While debugging a separate issue, I made the test for the API function `evaluateTransactionFee` better and I also now test it in alonzo.

closes #2408