### PR TITLE
Small formal spec things

### DIFF
--- a/alonzo/formal-spec/alonzo-changes.tex
+++ b/alonzo/formal-spec/alonzo-changes.tex
@@ -175,7 +175,7 @@
 \newcommand{\ScriptHash}{\type{ScriptHash}}
 \newcommand{\PolicyID}{\type{PolicyID}}
 \newcommand{\LangDepView}{\type{LangDepView}}
-\newcommand{\WitnessPPDataHash}{\type{WitnessPPDataHash}}
+\newcommand{\ScriptIntegrityHash}{\type{ScriptIntegrityHash}}
 \newcommand{\Script}{\type{Script}}
 \newcommand{\ScriptPlutus}{\type{Script}_{plc}}
 \newcommand{\PlutusVI}{\type{PlutusV1}}
@@ -197,6 +197,8 @@
 \newcommand{\AssetID}{\type{AssetID}}
 
 %% Adding witnesses
+\newcommand{\AssetName}{\type{AssetName}}
+\newcommand{\Quantity}{\type{Quantity}}
 \newcommand{\TxIn}{\type{TxIn}}
 \newcommand{\OutRef}{\type{OutRef}}
 \newcommand{\ShelleyTxIn}{\type{ShelleyTxIn}}
@@ -208,6 +210,7 @@
 \newcommand{\Info}{\type{Info}}
 \newcommand{\ExUnits}{\type{ExUnits}}
 \newcommand{\CostMod}{\type{CostModel}}
+\newcommand{\ByteString}{\type{ByteString}}
 \newcommand{\ValidityInterval}{\type{ValidityInterval}}
 \newcommand{\Network}{\type{Network}}
 \newcommand{\Prices}{\type{Prices}}
@@ -258,7 +261,7 @@
 \newcommand{\ubalance}[1]{\fun{ubalance}~ \var{#1}}
 \newcommand{\txttl}[1]{\fun{txttl}~ \var{#1}}
 \newcommand{\firstSlot}[1]{\fun{firstSlot}~ \var{#1}}
-\newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
+\newcommand{\deposited}[2]{\fun{deposited}~ \var{#1} ~ \var{#2}}
 \newcommand{\decayedKey}[4]{\fun{decayedKey}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\keyRefund}[6]{\fun{keyRefund}~ {#1}~{#2}~{#3}~\var{#4}~\var{#5}~\var{#6}}

--- a/alonzo/formal-spec/properties.tex
+++ b/alonzo/formal-spec/properties.tex
@@ -217,9 +217,9 @@ the collateral is required to cover.
 
   The $\fun{feesOK}$ check enforces that if a transaction has a non-empty
   $\fun{txrdmrs}$ field, the balance of the realized collateral inputs
-  (which $\field_{fees}~(s)$ is increased by as part of processing $tx$) is 
+  (which $\field_{fees}~(s)$ is increased by as part of processing $tx$) is
 
-  \[\fun{ubalance}~(\fun{collateral}~{txb} \restrictdom \var{utxo})~\geq~\fun{quot}~(\txfee~{txb} * (\fun{collateralPercent}~pp))~100))\]
+  \[\fun{ubalance}~(\fun{collateral}~{txb} \restrictdom \var{utxo})~\geq~\fun{quot}~(\txfee~{txb} * (\fun{collateralPercent}~pp))~100\]
 
   which, since $\txfee~{txb}~\geq~\fun{minfee}~{txb}$, gives
 
@@ -231,6 +231,33 @@ the collateral is required to cover.
 
   \[\field_{fees}~(s')~\geq~\field_{fees}~(s)~+~\fun{quot}~(\fun{minfee}~{txb} * (\fun{collateralPercent}~pp))~100))\]
 \end{proof}
+
+An immediate corollary to this property is that when the $\fun{collateralPercent}$ is set to 100 or more,
+the transaction always pays at least the minimum fee. This, in turn, implies that it
+pays at least the fee that it has stated in the $\fun{txfee}$ field.
+
+\begin{corollary}
+  For all environments $e$, transactions $tx$ and states $s, s'$ such that
+  \begin{equation*}
+    e\vdash s\trans{ledger}{tx}s'~~\wedge~~\fun{collateralPercent}~(\field_{pp}~(s)) \geq 100
+  \end{equation*}
+  The following holds :
+  \[\field_{fees}~(s')~\geq~\field_{fees}~(s)~+~\fun{minfee}~{tx} \]
+\end{corollary}
+
+\begin{proof}
+  In both two cases in the lemma above, the $\field_{fees}$ field in the ledger state
+  is increased by at least $\fun{minfee}~{tx}$ :
+  \begin{itemize}
+    \item when $\fun{txValTag} = \True$, the lemma states already that
+    \[\field_{fees}~(s')~\geq~\field_{fees}~(s)~+~\fun{minfee}~{tx}\]
+    \item when $\fun{txValTag} = \False$, we have
+    $ \field_{fees}~(s')~\geq~\field_{fees}~(s)~+~\fun{quot}~(\fun{minfee}~{txb} * (\fun{collateralPercent}~pp))~100$ \\
+    $~~~\geq~\field_{fees}~(s)~+~\fun{quot}~(\fun{minfee}~{tx}~*~100)~100$ \\
+    $~~~=~\field_{fees}~(s)~+~\fun{minfee}~{tx}$
+  \end{itemize}
+\end{proof}
+
 \end{property}
 
 \begin{property}[Correct tag]
@@ -450,17 +477,17 @@ We split this result into a lemma and its corollary :
       examines four fields fixed by the transaction body ($\fun{mint}$, $\fun{txwdrls}$,
       $\fun{txcerts}$, and $\fun{txinputs}$).
       It also looks at data in the $\fun{txrdmrs}$ field, which is fixed
-      by the transaction body via the $\fun{wppHash}$
+      by the transaction body via the $\fun{scriptIntegrityHash}$
       hash. This is done as follows: the $\mathsf{UTXOW}$ rule verifies that this
       hash-containing field matches the computed hash
       of the preimage constructed from several fields of the transaction,
       including $\fun{txrdmrs}$ (this calculation
-      is done by the $\fun{hashWitnessPPData}$ function).
+      is done by the $\fun{hashScriptIntegrity}$ function).
 
       \item $\fun{language}$ : this is directly conveyed by the type of a script.
 
-      \item $\fun{costmdls}$ : The hash calculated by the $\fun{hashWitnessPPData}$
-      function and compared to the hash value in the $\fun{wppHash}$ field
+      \item $\fun{costmdls}$ : The hash calculated by the $\fun{hashScriptIntegrity}$
+      function and compared to the hash value in the $\fun{scriptIntegrityHash}$ field
       must include in the preimage the current cost models of
       all script languages of scripts carried by the transaction. Recall that
       if a cost model changed between when a transaction was submitted and the
@@ -496,7 +523,7 @@ We split this result into a lemma and its corollary :
 
         \item $\fun{txInfoData}$ : this field is populated with the datums (and their
         hashes) in the transaction field $\fun{txdats}$, which are fixed by the body
-        via the $\fun{wppHash}$ field.
+        via the $\fun{scriptIntegrityHash}$ field.
 
         \item $\fun{txInfoId}$ : this field contains the hash of the transaction body,
         which is clearly the same for transactions with the same body.
@@ -575,8 +602,6 @@ as in Lemma \ref{lem:inputs}.
   the same as apply to MA ledger, then translate the ledger.
 \item
   \emph{Zero ExUnits.} If a script is run (there’s a redeemer/exunits) , it will fail with 0 units
-\item
-  \emph{Zipper property.}
 \item
   \emph{Cost Increase.} if a transaction is valid, it will remain valid if you increase the execution units
 \item

--- a/alonzo/formal-spec/protocol-parameters.tex
+++ b/alonzo/formal-spec/protocol-parameters.tex
@@ -6,28 +6,38 @@ in addition to those that are already defined in the Shelley specification~\cite
 
 \vspace{12pt}
 \begin{tabular}{lp{5in}}
+  $\CostMod$ &
+  $c\in\CostMod$ is the vector of coefficients that are used to compute
+  a value $exu\in\ExUnits$ given a vector of some resource primitives. The mapping is defined
+  concretely by the specific version of the Plutus interpreter that is associated with $\Language$.
+  We keep this type as abstract in the specification, see \cite{plutuscore} and \cite{plutustech}
+  for details.
+  \\
   $\Language$ &
-  This represents the language name/tag, including the
-  version number.
+  This represents phase-2 language types. Currently there is only $\PlutusVI$.
+  \\
+  $\Prices$ &
+  $\var{(pr_{mem}, pr_{steps})}\in \Prices$ consists of two rational numbers
+  that correspond to the components of $\ExUnits$:
+  $pr_{mem}$ is the price per unit of memory, and $pr_{steps}$ is the price per
+  reduction step. This is used to calculate the cost for a specific script execution.
   \\
   $\ExUnits$ &
-  A term of this type contains two integer values,
-  $(mem, steps)$.
+  $(mem, steps)\in \ExUnits$ is made up of two integer values.
   These represent abstract notions of the relative memory usage and script execution steps,
   respectively.
   \\
-  $\CostMod$ &
-  A term of this type represents the vector of coefficients that are used to generate
-  a term of type $\ExUnits$ given a vector of some resource primitives. The mapping is defined
-  concretely by the specific version of the Plutus interpreter that is associated with $\Language$.
-  We keep this type as abstract in the specification.
-  \\
-  $\Prices$ &
-  A term of this type comprises two integer values that correspond to the components of $\ExUnits$,
-  $\var{(pr_{mem}, pr_{steps})}$:
-  $pr_{mem}$ is the price (in Ada) per unit of memory, and $pr_{steps}$ is the price (in Ada) per
-  reduction step. This is used to calculate the Ada cost for a specific script execution.
+  $\LangDepView$ &
+  A pair of two byte strings, where the first represents the serialized language tag (eg. the tag for $\PlutusVI$),
+  and the second, the protocol parameters that must be fixed (by the transaction) when carrying a phase-2 script
+  in that language.
 \end{tabular}
+
+The function $\fun{serialize}$ is left abstract, as
+these is an implementation-dependent serialization function. It must
+be implemented for all serializable types, including all
+collections of protocol parameters needed to construct a $\LangDepView$ for
+each existing language.
 
 \subsection{Language Versions and Backwards Compatibility Requirements}
 \label{sec:versions}
@@ -58,13 +68,16 @@ The transaction body therefore includes a hash of any such data that is not uniq
 When the transaction is processed, as part of the UTXOW rule, this hash is compared with a hash of the data that is passed to the interpreter. This
 ensures that scripts are only executed if they have been provided with the intended data.
 
-The $\fun{getLanguageView}$ function (Figure~\ref{fig:defs:protocol-parameters}) filters the data relvant
-to a given language from the protocol parameters. Recall here that $\Tppm$ is the type of the
-protocol parameter $\var{ppm}~\in~\Ppm$, and that $\PParams~=~\Ppm~\mapsto~\Tppm$.
-The type $\LangDepView$ is a subrecord of $\PParams$.
-%
-At the time of writing, the only parameter that needs to be passed to the $\PlutusVI$
-interpreter is the cost model, specifically only the cost model for the $\PlutusVI$ language.
+The $\fun{getLanguageView}$ function is used in the computation of this integrity hash.
+Shown in (Figure~\ref{fig:defs:protocol-parameters}), it filters the data relvant
+to a given language from the protocol parameters, and returns a pair of byte strings :
+the serialized representation of
+the language tag, and the serialized representation of the relevant data in the protocol
+parameters, which, for
+$\PlutusVI$, is just its cost model, $\fun{costmdls}~{pp}~\{\PlutusVI\}$.
+This function must be defined for all
+existing script languages that require a cost model (are phase-2), which, in Alonzo, is only $\PlutusVI$.
+The only relevant parameter for $\PlutusVI$ is the cost model for this language.
 
 \subsection{Script Evaluation Cost Model and Prices}
 \label{sec:cost-mod}
@@ -126,7 +139,7 @@ signatures that must be checked during validation.
       \\
       \var{(pr_{mem}, pr_{steps})}
       & \Prices
-      & \Coin \times \Coin
+      & \mathsf{Rational} \times \mathsf{Rational}
       & \text {Coefficients for $\ExUnits$ prices}
       \\
       \var{(mem, steps)}
@@ -136,8 +149,8 @@ signatures that must be checked during validation.
       \\
       \var{ldv}
       & \LangDepView
-      & \Ppm~\mapsto~\Tppm
-      & \text{PParams view}
+      & \ByteString~\times~\ByteString
+      & \text{Language Tag and PParams view}
     \end{array}
   \end{equation*}
   %
@@ -182,9 +195,8 @@ signatures that must be checked during validation.
   %
   \begin{align*}
     & \fun{getLanguageView} \in \PParams \to \Language \to \LangDepView \\
-    & \fun{getLanguageView}~\var{pp}~\PlutusVI = \var{costmdls}~\mapsto~ (\fun{costmdls}~{pp}~\{\PlutusVI\})
+    & \fun{getLanguageView}~\var{pp}~\PlutusVI = (\fun{serialize}~\PlutusVI, ~ (\fun{serialize}~(\fun{costmdls}~{pp}~\{\PlutusVI\})))
   \end{align*}
-  %
   \caption{Definitions Used in Protocol Parameters}
   \label{fig:defs:protocol-parameters}
 \end{figure*}

--- a/alonzo/formal-spec/references.bib
+++ b/alonzo/formal-spec/references.bib
@@ -104,3 +104,17 @@ url = {https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shell
   year  = {2019},
   url = {https://hydra.iohk.io/build/779843/download/1/non-integer-calculations.pdf}
 }
+
+@misc{plutustech,
+  author = {{Plutus Team}},
+  title = {{The Plutus Platform: An IOHK technical report}},
+  year  = {2021},
+  url = {https://hydra.iohk.io/build/7244348/download/1/plutus.pdf}
+}
+
+@misc{plutuscore,
+  author = {{Plutus Team}},
+  title = {{Formal Specification of the Plutus Core Language}},
+  year  = {2021},
+  url = {https://hydra.iohk.io/build/7244320/download/1/plutus-core-specification.pdf}
+}

--- a/alonzo/formal-spec/transactions.tex
+++ b/alonzo/formal-spec/transactions.tex
@@ -10,7 +10,7 @@ Figure \ref{fig:defs:utxo-shelley-1} gives the modified transaction types and he
 We make the following changes and additions:
 
 \begin{itemize}
-  \item $\WitnessPPDataHash$ is the type of a hash of script execution
+  \item $\ScriptIntegrityHash$ is the type of a hash of script execution
   related data. It is the hash of $\fun{txrdmrs}$ and relevant protocol parameters.
 
   \item $\ScriptPhOne$ is the type of phase-1 scripts.
@@ -60,7 +60,7 @@ We add the following helper functions:
   \item $\fun{language}$ selects the language of a phase-2 script, and $\Nothing$ in case
   the script is phase-1.
   \item $\fun{hashData}$ hashes a value of type $\Data$.
-  \item $\fun{hashWitnessPPData}$ hashes the protocol parameters and data relevant to script execution.
+  \item $\fun{hashScriptIntegrity}$ hashes the protocol parameters and data relevant to script execution.
   In particular, the redeemer structure, and the datum objects.
 \end{itemize}
 
@@ -69,7 +69,7 @@ We add the following helper functions:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\quad\quad\quad\quad}r}
-      \var{wph} &\WitnessPPDataHash & \text{Script data hash}\\
+      \var{wph} &\ScriptIntegrityHash & \text{Script data hash}\\
       \var{plc} & \ScriptPlutus & \text{Plutus core scripts} \\
       \var{d} & \Data & \text{Generic script data}
     \end{array}
@@ -123,9 +123,9 @@ We add the following helper functions:
   \end{align*}
   %
   \begin{align*}
-  &\fun{hashWitnessPPData} \in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Redeemer \times \ExUnits) \\
-  &~~~~ \to (\DataHash \mapsto \Datum) \to \WitnessPPDataHash^? \\
-  &\fun{hashWitnessPPData}~{pp}~{langs}~{rdmrs}~{dats}~=~ \\
+  &\fun{hashScriptIntegrity} \in\PParams \to \powerset{\Language} \to (\RdmrPtr \mapsto \Redeemer \times \ExUnits) \\
+  &~~~~ \to (\DataHash \mapsto \Datum) \to \ScriptIntegrityHash^? \\
+  &\fun{hashScriptIntegrity}~{pp}~{langs}~{rdmrs}~{dats}~=~ \\
                     &~~~~ \begin{cases}
                           \Nothing & rdmrs~=~\emptyset \land langs~=~\emptyset \land dats~=~\emptyset \\
                           \fun{hash} (rdmrs, dats, \{ \fun{getLanguageView}~pp~l \mid l \in langs \}) & \text{otherwise}
@@ -162,7 +162,7 @@ We add the following helper functions:
        & \times~ \Wdrl  & \fun{txwdrls} &\text{Reward withdrawals}\\
        & \times ~\Update^?  & \fun{txUpdates} & \text{Update proposals}\\
        & \times ~\hldiff{\powerset{\KeyHash}} & \hldiff{\fun{reqSignerHashes}} & \text{Hashes of VKeys passed to scripts}\\
-       & \times ~\hldiff{\WitnessPPDataHash^?} & \hldiff{\fun{wppHash}} & \text{Hash of script-related data}\\
+       & \times ~\hldiff{\ScriptIntegrityHash^?} & \hldiff{\fun{scriptIntegrityHash}} & \text{Hash of script-related data}\\
        & \times ~\AuxiliaryDataHash^? & \fun{txADhash} & \text{Auxiliary data hash}\\
        & \times ~\hldiff{\Network^?} & \hldiff{\fun{txnetworkid}} & \text{Tx network ID}\\
     \end{array}
@@ -246,7 +246,7 @@ the body of the transaction:
   the transaction and the ledger are otherwise unaware of what signatures are expected by these scripts.
 
   \item We include a hash of some script-related data, specifically the redeemers and protocol parameters,
-    with accessor $\fun{wppHash}$.
+    with accessor $\fun{scriptIntegrityHash}$.
 
   \item We include the ID of the network on which the transaction lives, $\fun{txnetworkid}$.
   This is in addition to the network ID's already included in the reward and output addresses.

--- a/alonzo/formal-spec/utxo.tex
+++ b/alonzo/formal-spec/utxo.tex
@@ -20,15 +20,15 @@
     &~~      \minfee{pp}~{tx} \leq \txfee{txb} \wedge (\fun{txrdmrs}~tx \neq \Nothing \Rightarrow \\
     &~~~~~~((\forall (a, \wcard, \_) \in \fun{range}~(\fun{collateral}~{txb} \restrictdom \var{utxo}), \fun{paymentHK}~a \in \AddrVKey) \\
     &~~~~~~\wedge~ \fun{adaOnly}~\var{balance} \\
-    &~~~~~~\wedge~ \var{balance} \geq \fun{quot}~(\txfee~{txb} * (\fun{collateralPercent}~pp))~100)) \\
-    &~~~~~~\fun{collateral}~{tx}~ \neq~\{\} \\
+    &~~~~~~\wedge~ \var{balance}~*~100 \geq \txfee~{txb} * (\fun{collateralPercent}~pp))) \\
+    &~~~~~~\wedge~ \fun{collateral}~{tx}~ \neq~\{\} \\
     &~~      \where \\
     & ~~~~~~~ \var{txb}~=~\txbody{tx} \\
     & ~~~~~~~ \var{balance}~=~\fun{ubalance}~(\fun{collateral}~{txb} \restrictdom \var{utxo}) \\
     \nextdef
     & \fun{txscriptfee} \in \Prices \to \ExUnits \to \Coin \\
     & \fun{txscriptfee}~(pr_{mem}, pr_{steps})~ (\var{mem, steps})
-    = \var{pr_{mem}}*\var{mem} + \var{pr_{steps}}*\var{steps}
+    = \fun{ceiling}~(\var{pr_{mem}}*\var{mem} + \var{pr_{steps}}*\var{steps})
     \nextdef
     &\fun{minfee} \in \PParams \to \Tx \to \Coin \\
     &\fun{minfee}~\var{pp}~\var{tx} = \\
@@ -63,7 +63,8 @@ We have added or changed several functions that deal with fees and collateral as
   calling the $\fun{feesOK}$ function that ensure that this is the case.
   \item $\fun{txscriptfee}$ calculates the fee that a transaction must pay for script
   execution based on the amount of $\ExUnits$ it has budgeted, and the prices in the current protocol parameters
-  for each component of $\ExUnits$.
+  for each component of $\ExUnits$. The prices are expressed as rational numbers,
+  so we take the ceiling of the result of the calculation to get an integer-valued $\Coin$.
   \item The minimum fee calculation, $\fun{minfee}$, includes the script
   fees that the transaction is obligated to pay in order to run its scripts.
 \end{itemize}
@@ -544,7 +545,7 @@ In this case, the states of the UTxO, fee
     \var{refunded} \leteq \keyRefunds{pp}{txb}
     \\
     \var{depositChange} \leteq
-      (\deposits{pp}~{poolParams}~{(\txcerts{txb})}) - \var{refunded}
+      (\fun{totalDeposits}~{pp}~\var{poolParams}~\txcerts{txb})~-~\var{refunded}
     }
     {
     \begin{array}{l}
@@ -672,11 +673,11 @@ UTXOS rule.
       \forall txout \in \txouts{txb},\\
       \hldiff{\fun{serSize}~(\fun{getValue}~txout) ~\leq ~ \fun{maxValSize}~pp} \\~
       \\
-      \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, a \in \AddrBS \to \fun{bootstrapAttrsSize}~a \leq 64 \\
+      \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, a \in \AddrBS \Rightarrow \fun{bootstrapAttrsSize}~a \leq 64 \\
       \forall (\wcard\mapsto (a,~\wcard)) \in \txouts{txb}, \fun{netId}~a = \NetworkId
       \\
       \forall (a\mapsto\wcard) \in \txwdrls{txb}, \fun{netId}~a = \NetworkId \\
-      \hldiff{\fun{txnetworkid}~\var{txb}~=~\NetworkId}
+      \hldiff{(\fun{txnetworkid}~\var{txb}~=~\NetworkId) ~\vee~(\fun{txnetworkid}~\var{txb}~=~\Nothing)}
       \\~\\
       \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp} \\~\\
       \hldiff{\fun{totExunits}~{tx} \leq \fun{maxTxExUnits}~{pp}} &  \hldiff{\| \fun{collateral}~{tx} \| \leq \fun{maxCollInputs}~{pp}}
@@ -909,7 +910,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \lor
       (\var{adh}=\fun{hashAD}~\var{ad})
       \\~\\
-      \hldiff{\fun{wppHash}~{txb}~=~\fun{hashWitnessPPData}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})~(\fun{txdats}~{txw})}
+      \hldiff{\fun{scriptIntegrityHash}~{txb}~=~\fun{hashScriptIntegrity}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})~(\fun{txdats}~{txw})}
       \\~\\
       {
         \begin{array}{r}


### PR DESCRIPTION
- rename `wppHash` to `scriptIntegrityHash` and change its calculation to match the code
- add corollary saying that if the collateral percent parameter is greater than 100, the transaction always pays at least the `minfee`
- change `Prices` from `Integer` to `Rational`