### PR TITLE
Fix `WitVKey` instance for `Ord`

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.Serialization
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Short (fromShort)
 import Data.Coders
   ( decodeList,
     decodeMap,
@@ -180,16 +181,18 @@ hashTxSeq ::
   Hash (Crypto era) EraIndependentBlockBody
 hashTxSeq (TxSeq' _ bodies ws md vs) =
   coerce $
-    hashStrict
-      ( hashPart bodies
-          <> hashPart ws
-          <> hashPart md
-          <> hashPart vs
-      )
+    hashStrict $
+      fromShort $
+        mconcat
+          [ hashPart bodies,
+            hashPart ws,
+            hashPart md,
+            hashPart vs
+          ]
   where
     hashStrict :: ByteString -> Hash (Crypto era) ByteString
     hashStrict = Hash.hashWith id
-    hashPart = Hash.hashToBytes . hashStrict . BSL.toStrict
+    hashPart = Hash.hashToBytesShort . hashStrict . BSL.toStrict
 
 instance
   ( FromCBOR (Annotator (Core.AuxiliaryData era)),

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
 import Cardano.Ledger.Hashes (ScriptHash)
-import Cardano.Ledger.SafeHash (HasAlgorithm, SafeHash, unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesValue)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -128,9 +127,6 @@ genScripts = keyBy (hashScript @era) <$> (arbitrary :: Gen [Core.Script era])
 
 genData :: forall era. Era era => Gen (TxDats era)
 genData = TxDats <$> keyBy hashData <$> arbitrary
-
-instance HasAlgorithm c => Arbitrary (SafeHash c i) where
-  arbitrary = unsafeMakeSafeHash <$> arbitrary
 
 instance
   ( Era era,

--- a/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -29,6 +29,7 @@ module Cardano.Ledger.Keys
     KeyPair (..),
     signedDSIGN,
     verifySignedDSIGN,
+    hashSignature,
 
     -- * Key hashes
     KeyHash (..),
@@ -215,6 +216,13 @@ verifySignedDSIGN ::
   Bool
 verifySignedDSIGN (VKey vk) vd sigDSIGN =
   either (const False) (const True) $ DSIGN.verifySignedDSIGN () vk vd sigDSIGN
+
+-- | Hash a given signature
+hashSignature ::
+  (Crypto crypto) =>
+  SignedDSIGN crypto (Hash crypto h) ->
+  Hash crypto (SignedDSIGN crypto (Hash crypto h))
+hashSignature = Hash.hashWith (DSIGN.rawSerialiseSigDSIGN . coerce)
 
 --------------------------------------------------------------------------------
 -- Key Hashes

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -953,16 +953,6 @@ pattern WitVKey k s <-
           hash = asWitness $ hashKey k
        in WitVKey' k s hash bytes
 
-{-
--- | Compute an era-independent transaction body hash
-eraIndTxBodyHash ::
-  forall era.
-  Era era =>
-  TxBody era ->
-  SafeHash (Crypto era) EraIndependentTxBody
-eraIndTxBodyHash x = hashAnnotated x
--}
-
 {-# COMPLETE WitVKey #-}
 
 witKeyHash ::
@@ -972,6 +962,14 @@ witKeyHash (WitVKey' _ _ kh _) = kh
 
 instance (Typeable kr, CC.Crypto crypto) => Ord (WitVKey kr crypto) where
   compare x y =
+    -- It is advised against comparison on keys and signatures directly,
+    -- therefore we use hashes of verification keys and signatures for
+    -- implementing this Ord instance. Note that we do not need to memoize the
+    -- hash of a signature, like it is done with the hash of a key, because Ord
+    -- instance is only used for Sets of WitVKeys and it would be a mistake to
+    -- have two WitVKeys in a same Set for different transactions. Therefore
+    -- comparison on signatures is unlikely to happen and is only needed for
+    -- compliance with Ord laws.
     comparing wvkKeyHash x y <> comparing (hashSignature @crypto . wvkSig') x y
 
 newtype StakeCreds crypto = StakeCreds

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxBody.hs
@@ -128,6 +128,7 @@ import Cardano.Ledger.Keys
     decodeSignedDSIGN,
     encodeSignedDSIGN,
     hashKey,
+    hashSignature,
   )
 import Cardano.Ledger.SafeHash
   ( HashAnnotated,
@@ -969,11 +970,9 @@ witKeyHash ::
   KeyHash 'Witness crypto
 witKeyHash (WitVKey' _ _ kh _) = kh
 
-instance
-  (Typeable kr, CC.Crypto crypto) =>
-  Ord (WitVKey kr crypto)
-  where
-  compare = comparing wvkKeyHash
+instance (Typeable kr, CC.Crypto crypto) => Ord (WitVKey kr crypto) where
+  compare x y =
+    comparing wvkKeyHash x y <> comparing (hashSignature @crypto . wvkSig') x y
 
 newtype StakeCreds crypto = StakeCreds
   { unStakeCreds :: Map (Credential 'Staking crypto) SlotNo

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -161,7 +161,7 @@ showBalance
 -- need to be discarded. In that case we try to compute a Delta, that when
 -- added (applyDelta) to the transaction, repairs it. The repair is made
 -- by adding additional inputs from which more Ada can flow into the fee.
--- If that doesn't fix it, we add add more inputs to the Delta.
+-- If that doesn't fix it, we add more inputs to the Delta.
 -- Experience shows that this converges quite quickly (in traces we never saw
 -- more than 3 iterations).
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -167,8 +167,8 @@ genHash = mkDummyHash <$> arbitrary
 mkDummyHash :: forall h a. HashAlgorithm h => Int -> Hash.Hash h a
 mkDummyHash = coerce . hashWithSerialiser @h toCBOR
 
-genSafeHash :: HasAlgorithm c => Gen (SafeHash c i)
-genSafeHash = unsafeMakeSafeHash <$> arbitrary
+instance HasAlgorithm c => Arbitrary (SafeHash c i) where
+  arbitrary = unsafeMakeSafeHash <$> arbitrary
 
 {-------------------------------------------------------------------------------
   Generators
@@ -278,12 +278,12 @@ maxTxWits :: Int
 maxTxWits = 5
 
 instance CC.Crypto crypto => Arbitrary (TxId crypto) where
-  arbitrary = TxId <$> genSafeHash
+  arbitrary = TxId <$> arbitrary
 
 instance CC.Crypto crypto => Arbitrary (TxIn crypto) where
   arbitrary =
     TxIn
-      <$> (TxId <$> genSafeHash)
+      <$> (TxId <$> arbitrary)
       <*> arbitrary
 
 instance
@@ -404,7 +404,7 @@ instance CC.Crypto crypto => Arbitrary (ScriptHash crypto) where
   arbitrary = ScriptHash <$> genHash
 
 instance CC.Crypto crypto => Arbitrary (AuxiliaryDataHash crypto) where
-  arbitrary = AuxiliaryDataHash <$> genSafeHash
+  arbitrary = AuxiliaryDataHash <$> arbitrary
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where
   arbitrary = genHash

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Serialisation/EraIndepGenerators.hs
@@ -259,17 +259,14 @@ sizedMetadatum 0 =
       MD.S <$> (T.pack <$> arbitrary)
     ]
 sizedMetadatum n =
-  oneof
-    [ MD.Map
-        <$> ( zip
-                <$> (resize maxMetadatumListLens (listOf (sizedMetadatum (n -1))))
-                <*> (listOf (sizedMetadatum (n -1)))
-            ),
-      MD.List <$> resize maxMetadatumListLens (listOf (sizedMetadatum (n -1))),
-      MD.I <$> arbitrary,
-      MD.B <$> arbitrary,
-      MD.S <$> (T.pack <$> arbitrary)
-    ]
+  let xsGen = listOf (sizedMetadatum (n - 1))
+   in oneof
+        [ MD.Map <$> (zip <$> resize maxMetadatumListLens xsGen <*> xsGen),
+          MD.List <$> resize maxMetadatumListLens xsGen,
+          MD.I <$> arbitrary,
+          MD.B <$> arbitrary,
+          MD.S <$> (T.pack <$> arbitrary)
+        ]
 
 instance Arbitrary MD.Metadatum where
   arbitrary = sizedMetadatum maxMetadatumDepth

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Utils.hs
@@ -132,6 +132,7 @@ import Shelley.Spec.Ledger.BlockChain (BHBody (..), Block, TxSeq, bhbody, bheade
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import Shelley.Spec.Ledger.Tx (Tx, TxOut, WitnessSet)
+import Test.QuickCheck (Arbitrary (..))
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Mock)
 import Test.Tasty.HUnit
   ( Assertion,
@@ -178,6 +179,10 @@ type GenesisKeyPair crypto = KeyPair 'Genesis crypto
 
 data RawSeed = RawSeed !Word64 !Word64 !Word64 !Word64 !Word64
   deriving (Eq, Show)
+
+instance Arbitrary RawSeed where
+  arbitrary =
+    RawSeed <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance ToCBOR RawSeed where
   toCBOR (RawSeed w1 w2 w3 w4 w5) = toCBOR (w1, w2, w3, w4, w5)


### PR DESCRIPTION
Current Ord instance allows breakage of referential transparency  because this law doesn't hold: `compare x y == EQ ==> x == y` 
This PR fixes this problem and adds couple property tests that ensure the fix.

There are also a couple of other minor improvements included in the PR.