### PR TITLE
Sync scripts needed with spec

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -137,8 +137,9 @@ hashData :: Era era => Data era -> DataHash (Crypto era)
 hashData d = hashAnnotated d
 
 -- Size of the datum hash attached to the output (could be Nothing)
-dataHashSize :: (CC.Crypto c) => StrictMaybe (DataHash c) -> Integer
-dataHashSize dh = fromIntegral $ heapWords dh
+dataHashSize :: StrictMaybe (DataHash c) -> Integer
+dataHashSize SNothing = 0
+dataHashSize (SJust _) = 10
 
 instance (CC.Crypto c) => HeapWords (StrictMaybe (DataHash c)) where
   heapWords SNothing = heapWords0

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -49,7 +49,6 @@ module Cardano.Ledger.Alonzo.Tx
     ScriptPurpose (..),
     totExUnits,
     --  Figure 5
-    getValidatorHash,
     minfee,
     isTwoPhaseScriptAddress,
     Shelley.txouts,
@@ -119,7 +118,6 @@ import Cardano.Ledger.Alonzo.TxWitness
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era, ValidateScript (isNativeScript))
 import Cardano.Ledger.Keys (KeyRole (Witness))
@@ -320,7 +318,7 @@ isTwoPhaseScriptAddress ::
   Addr (Crypto era) ->
   Bool
 isTwoPhaseScriptAddress tx addr =
-  case getValidatorHash addr of
+  case Shelley.getScriptHash addr of
     Nothing -> False
     Just hash ->
       case Map.lookup hash (getField @"scriptWits" tx) of
@@ -381,14 +379,6 @@ totExUnits ::
   tx era ->
   ExUnits
 totExUnits = fold . snd . unzip . Map.elems . unRedeemers . getField @"txrdmrs" . getField @"wits"
-
--- The specification uses "validatorHash" to extract ScriptHash from
--- an Addr. But not every Addr has a ScriptHash. In particular KeyHashObj
--- do not. So we use getValidatorHash which returns a Maybe type.
-
-getValidatorHash :: Addr crypto -> Maybe (ScriptHash crypto)
-getValidatorHash (Addr _network (ScriptHashObj hash) _ref) = Just hash
-getValidatorHash _ = Nothing
 
 -- ===============================================================
 -- Operations on scripts from specification

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Val
     EncodeMint (..),
     Val (..),
   )
-import Cardano.Prelude (HeapWords (..), cborError)
+import Cardano.Prelude (cborError)
 import Control.DeepSeq (NFData (..))
 import Control.Monad (forM_)
 import Control.Monad.ST (runST)
@@ -163,7 +163,11 @@ instance CC.Crypto crypto => Val (Value crypto) where
   -- returns the size, in Word64's, of the CompactValue representation of Value
   size vv@(Value _ v)
     -- when Value contains only ada
-    | v == mempty = fromIntegral $ adaWords
+    -- !WARNING! This branch is INCORRECT in the Mary era and should ONLY be
+    -- used in the Alonzo ERA.
+    -- TODO - find a better way to reconcile the mistakes in Mary with what needs
+    -- to be the case in Alonzo.
+    | v == mempty = 2
     -- when Value contains ada as well as other tokens
     -- sums up :
     -- i) adaWords : the space taken up by the ada amount
@@ -173,9 +177,6 @@ instance CC.Crypto crypto => Val (Value crypto) where
       fromIntegral $
         (roundupBytesToWords $ representationSize (snd $ gettriples vv))
           + repOverhead
-
-instance CC.Crypto crypto => HeapWords (Value crypto) where
-  heapWords v = fromIntegral $ size v
 
 -- space (in Word64s) taken up by the ada amount
 adaWords :: Int

--- a/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -42,7 +42,6 @@ import Cardano.Ledger.Shelley.Constraints
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody)
 import qualified Cardano.Ledger.Val as Val
-import Cardano.Prelude (heapWordsUnpacked)
 import Cardano.Slotting.Slot (SlotNo)
 import Control.Iterate.SetAlgebra (dom, eval, (∪), (⊆), (⋪), (◁))
 import Control.Monad.Trans.Reader (asks)
@@ -125,7 +124,7 @@ scaledMinDeposit v (Coin mv)
 
     -- unpacked CompactCoin Word64 size in Word64s
     coinSize :: Integer
-    coinSize = fromIntegral $ heapWordsUnpacked (CompactCoin 0)
+    coinSize = 0
 
     utxoEntrySizeWithoutVal :: Integer
     utxoEntrySizeWithoutVal = 6 + txoutLenNoVal + txinLen

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -15,12 +15,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
--- |
--- Module      : UTxO
--- Description : Simple UTxO Ledger
---
--- This module defines the types and functions for a simple UTxO Ledger
--- as specified in /A Simplified Formal Specification of a UTxO Ledger/.
 module Shelley.Spec.Ledger.UTxO
   ( -- * Primitives
     UTxO (..),


### PR DESCRIPTION
Additionally, we removed `heapWords` from the value size calculations, but at the cost of leaving an ugly wart in the Mary value size calculation (in a code branch that is not used in Mary).

The changes are in two separate commits.