### PR TITLE
Remove usage of partial `decodeUtf8`

### DIFF
--- a/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
+++ b/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
@@ -86,6 +86,7 @@ import Data.ByteString.Base58
     decodeBase58,
     encodeBase58,
   )
+import Data.Text.Encoding (decodeLatin1)
 import Data.Text.Internal.Builder (Builder)
 import Formatting
   ( Format,
@@ -205,7 +206,7 @@ addrToBase58 :: Address -> ByteString
 addrToBase58 = encodeBase58 addrAlphabet . serialize'
 
 instance B.Buildable Address where
-  build = B.build . decodeUtf8 . addrToBase58
+  build = B.build . decodeLatin1 . addrToBase58
 
 -- | Specialized formatter for 'Address'
 addressF :: Format r (Address -> r)
@@ -232,7 +233,7 @@ decodeAddressBase58 = fromCBORTextAddress
 -- | Encode an address to Text.
 -- `decodeAddressBase58 (encodeAddressBase58 x) === Right x`
 encodeAddressBase58 :: Address -> Text
-encodeAddressBase58 = decodeUtf8 . addrToBase58
+encodeAddressBase58 = decodeLatin1 . addrToBase58
 
 --------------------------------------------------------------------------------
 -- Constructors

--- a/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -88,7 +88,7 @@ import Data.Ord (Down (..), comparing)
 import qualified Data.Primitive.ByteArray as BA
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
-import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Encoding (decodeLatin1)
 import Data.Typeable (Typeable)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic)
@@ -112,7 +112,7 @@ instance FromCBOR AssetName where
   fromCBOR = do
     an <- fromCBOR
     if BS.length an > 32
-      then cborError $ DecoderErrorCustom "asset name exceeds 32 bytes:" (decodeUtf8 $ BS16.encode an)
+      then cborError $ DecoderErrorCustom "asset name exceeds 32 bytes:" (decodeLatin1 $ BS16.encode an)
       else pure . AssetName $ an
 
 -- | Policy ID


### PR DESCRIPTION
It is widely advised against usage of `decodeUtf8`. In place were it is used we are decoding base 16 encoded text anyways, so we should be using faster and total `decodeLatin1`.


* [x] There are also two more uses in Byron code, these could also be swapped for `decodeLatin1`, but I am not sure how amendable is the old code. Done.

https://github.com/input-output-hk/cardano-ledger-specs/blob/6f070a120c8e5a35e773a95ce076e10a0727b419/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs#L208

https://github.com/input-output-hk/cardano-ledger-specs/blob/6f070a120c8e5a35e773a95ce076e10a0727b419/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs#L235