### PR TITLE
Alonzo specific properties

### DIFF
--- a/alonzo/test/cardano-ledger-alonzo-test.cabal
+++ b/alonzo/test/cardano-ledger-alonzo-test.cabal
@@ -72,13 +72,14 @@ test-suite cardano-ledger-alonzo-test
   hs-source-dirs:
     test
   other-modules:
-    Test.Cardano.Ledger.Alonzo.Trials
-    Test.Cardano.Ledger.Alonzo.Golden
-    Test.Cardano.Ledger.Alonzo.Serialisation.Canonical
-    Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
     Test.Cardano.Ledger.Alonzo.Examples
-    Test.Cardano.Ledger.Alonzo.Translation
+    Test.Cardano.Ledger.Alonzo.Golden
+    Test.Cardano.Ledger.Alonzo.PropertyTests
+    Test.Cardano.Ledger.Alonzo.Serialisation.Canonical
     Test.Cardano.Ledger.Alonzo.Serialisation.CDDL
+    Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
+    Test.Cardano.Ledger.Alonzo.Translation
+    Test.Cardano.Ledger.Alonzo.Trials
     Test.Cardano.Ledger.Alonzo.Trials
   build-depends:
     base16-bytestring,
@@ -97,9 +98,12 @@ test-suite cardano-ledger-alonzo-test
     plutus-ledger-api,
     QuickCheck,
     small-steps,
+    small-steps-test,
     shelley-spec-ledger,
     shelley-spec-ledger-test,
     strict-containers,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
+    time,
+    transformers,

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+-- Embed instances for (AlonzoEra TestCrypto)
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Cardano.Ledger.Alonzo.PropertyTests where
+
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import Cardano.Ledger.Alonzo.PlutusScriptApi (collectTwoPhaseScriptInputs, evalScripts)
+import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY)
+import Cardano.Ledger.Alonzo.Rules.Ledger (AlonzoLEDGER)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..), ValidatedTx (..), totExUnits)
+import Cardano.Ledger.Alonzo.TxInfo (ScriptResult (..))
+import Cardano.Ledger.Era (ValidateScript (..))
+import Cardano.Ledger.Slot (EpochSize (..))
+import Cardano.Slotting.EpochInfo (fixedEpochInfo)
+import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
+import Control.State.Transition
+import Control.State.Transition.Trace (SourceSignalTarget (..), sourceSignalTargets)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Word (Word64)
+import GHC.Records (HasField (..))
+import Shelley.Spec.Ledger.LedgerState hiding (circulation)
+import Shelley.Spec.Ledger.STS.Chain (CHAIN, ChainEvent (..), ChainPredicateFailure (..), ChainState (..))
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
+import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (sumCollateral)
+import Test.Cardano.Ledger.EraBuffet (TestCrypto)
+import Test.QuickCheck (Property, conjoin, counterexample, (.&&.))
+import Test.Shelley.Spec.Ledger.Rules.TestChain (forAllChainTrace, ledgerTraceFromBlock)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck ((===))
+import qualified Test.Tasty.QuickCheck as TQC
+
+type A = AlonzoEra TestCrypto
+
+instance Embed (AlonzoBBODY A) (CHAIN A) where
+  wrapFailed = BbodyFailure
+  wrapEvent = BbodyEvent
+
+traceLen :: Word64
+traceLen = 100
+
+data HasPlutus = HasPlutus | NoPlutus
+  deriving (Show)
+
+alonzoSpecificProps ::
+  SourceSignalTarget (CHAIN A) ->
+  Property
+alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
+  conjoin $
+    map alonzoSpecificPropsLEDGER $
+      sourceSignalTargets ledgerTr
+  where
+    (tickedChainSt, ledgerTr) = ledgerTraceFromBlock chainSt block
+    pp = (esPp . nesEs . chainNes) tickedChainSt
+    alonzoSpecificPropsLEDGER :: SourceSignalTarget (AlonzoLEDGER A) -> Property
+    alonzoSpecificPropsLEDGER
+      SourceSignalTarget
+        { source = (UTxOState {_utxo = UTxO u, _deposited = dp, _fees = f}, ds),
+          signal = tx,
+          target = (UTxOState {_utxo = UTxO u', _deposited = dp', _fees = f'}, ds')
+        } =
+        let isValid' = getField @"isValid" tx
+            noNewUTxO = u' `Map.isSubmapOf` u
+            collateralInFees = f <> sumCollateral tx (UTxO u) == f'
+            utxoConsumed = not $ u `Map.isSubmapOf` u'
+            allScripts = getField @"txscripts" $ getField @"wits" tx
+            hasPlutus = if all (isNativeScript @A) allScripts then NoPlutus else HasPlutus
+            totEU = totExUnits tx
+            nonTrivialExU = exUnitsMem totEU > 0 && exUnitsSteps totEU > 0
+            collected =
+              -- Note that none of our plutus scripts use validity intervals,
+              -- so it is safe to use anything for the epech info and the system start.
+              case collectTwoPhaseScriptInputs
+                (fixedEpochInfo (EpochSize 100) (mkSlotLength 1)) -- arbitrary
+                (SystemStart $ posixSecondsToUTCTime 0) -- arbitrary
+                pp
+                tx
+                (UTxO u) of
+                Left e -> error $ "Plutus script collection error: " <> show e
+                Right c -> c
+            collectedScripts = Set.fromList $ map (\(s, _, _, _) -> s) collected
+            suppliedPScrpts = Set.fromList [PlutusScript s | PlutusScript s <- Map.elems allScripts]
+            expectedPScripts = collectedScripts == suppliedPScrpts
+            allPlutusTrue = case evalScripts tx collected of
+              Fails _ -> False
+              Passes -> True
+         in counterexample
+              ( mconcat
+                  [ "\nHas plutus scripts: ",
+                    show hasPlutus,
+                    "\nIs valid: ",
+                    show isValid',
+                    "\nAt least one UTxO is consumed: ",
+                    show utxoConsumed,
+                    "\nNon trivial execution units: ",
+                    show nonTrivialExU,
+                    "\nReceived the expected plutus scripts: ",
+                    show expectedPScripts,
+                    "\nPlutus scripts all evaluate to true: ",
+                    show allPlutusTrue,
+                    "\nNo new UTxO: ",
+                    show noNewUTxO,
+                    "\nThe collateral amount was added to the fees: ",
+                    show collateralInFees,
+                    "\nThe deposit pot is unchanged: ",
+                    show (dp == dp'),
+                    "\nThe delegation state is unchanged: ",
+                    show (ds == ds')
+                  ]
+              )
+              ( counterexample "At least one UTxO is consumed" utxoConsumed
+                  .&&. ( case (hasPlutus, isValid') of
+                           (NoPlutus, IsValid True) -> totEU === ExUnits 0 0
+                           (NoPlutus, IsValid False) -> counterexample "No Plutus scripts, but isValid == False" False
+                           (HasPlutus, IsValid True) ->
+                             conjoin
+                               [ counterexample "Non trivial execution units" nonTrivialExU,
+                                 counterexample "Received the expected plutus scripts" expectedPScripts,
+                                 counterexample "Plutus scripts all evaluate to true" allPlutusTrue
+                               ]
+                           (HasPlutus, IsValid False) ->
+                             conjoin
+                               [ counterexample "No new UTxO" noNewUTxO,
+                                 counterexample "The collateral amount was added to the fees" collateralInFees,
+                                 dp === dp',
+                                 ds === ds',
+                                 counterexample "No failing Plutus scripts" $ not allPlutusTrue
+                               ]
+                       )
+              )
+
+alonzoTraceTests :: Property
+alonzoTraceTests =
+  forAllChainTrace @A traceLen $ \tr ->
+    conjoin $ map alonzoSpecificProps (sourceSignalTargets tr)
+
+propertyTests :: TestTree
+propertyTests =
+  TQC.testProperty "alonzo specific" alonzoTraceTests

--- a/example-shelley/test/Tests.hs
+++ b/example-shelley/test/Tests.hs
@@ -6,12 +6,17 @@ module Main where
 import Cardano.Ledger.Example (ExampleEra)
 import Shelley.Spec.Ledger.PParams (PParams' (..))
 import Shelley.Spec.Ledger.RewardUpdate ()
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER)
 import Test.Cardano.Ledger.Example ()
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
 import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
 import Test.Tasty
 import Test.Tasty.HUnit ()
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
+
+type E = ExampleEra C_Crypto
+
+type L = LEDGER E
 
 tests :: TestTree
 tests = askOption $ \case
@@ -23,7 +28,7 @@ mainTests :: TestTree
 mainTests =
   testGroup
     "Example Consensus Tests"
-    [ minimalPropertyTests @(ExampleEra C_Crypto)
+    [ minimalPropertyTests @E @L
     ]
 
 nightlyTests :: TestTree
@@ -32,7 +37,7 @@ nightlyTests =
     "Example Consensus - nightly"
     [ testGroup
         "Example Era - nightly"
-        [ propertyTests @(ExampleEra C_Crypto)
+        [ propertyTests @E @L
         ]
     ]
 

--- a/shelley-ma/shelley-ma-test/test/Tests.hs
+++ b/shelley-ma/shelley-ma-test/test/Tests.hs
@@ -4,6 +4,7 @@
 module Main where
 
 import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER)
 import Test.Cardano.Ledger.Allegra.ScriptTranslation (testScriptPostTranslation)
 import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)
 import Test.Cardano.Ledger.AllegraEraGen ()
@@ -18,6 +19,14 @@ import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTes
 import Test.Tasty
 import Test.Tasty.HUnit ()
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
+
+type A = AllegraEra TestCrypto
+
+type AL = LEDGER (AllegraEra TestCrypto)
+
+type M = MaryEra TestCrypto
+
+type ML = LEDGER (MaryEra TestCrypto)
 
 tests :: TestTree
 tests = askOption $ \case
@@ -42,7 +51,7 @@ allegraTests =
   testGroup
     "Allegra Ledger Tests"
     [ allegraTranslationTests,
-      minimalPropertyTests @(AllegraEra TestCrypto),
+      minimalPropertyTests @A @AL,
       testScriptPostTranslation
     ]
 
@@ -62,11 +71,11 @@ nightlyTests =
     "ShelleyMA Ledger - nightly"
     [ testGroup
         "Allegra Ledger - nightly"
-        [ propertyTests @(AllegraEra TestCrypto)
+        [ propertyTests @A @AL
         ],
       testGroup
         "Mary Ledger - nightly"
-        [ propertyTests @(MaryEra TestCrypto)
+        [ propertyTests @M @ML
         ]
     ]
 

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -250,7 +250,8 @@ data TwoPhase3ArgInfo era = TwoPhase3ArgInfo
       ( Plutus.Data, -- The redeeming data
         Word64, -- The ExUnits memory count
         Word64 -- The ExUnits steps count
-      )
+      ),
+    getSucceeds3 :: Bool
   }
 
 data TwoPhase2ArgInfo era = TwoPhase2ArgInfo
@@ -263,7 +264,8 @@ data TwoPhase2ArgInfo era = TwoPhase2ArgInfo
       ( Plutus.Data, -- The redeeming data
         Word64, -- The ExUnits memory count
         Word64 -- The ExUnits steps count
-      )
+      ),
+    getSucceeds2 :: Bool
   }
 
 deriving instance Show (Core.Script era) => Show (TwoPhase3ArgInfo era)

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/EraGen.hs
@@ -186,7 +186,8 @@ type MinGenTxBody era =
     ToCBOR (Core.TxBody era),
     NoThunks (Core.TxBody era),
     Show (Core.TxBody era),
-    FromCBOR (Annotator (Core.TxBody era)) -- arises because some pattern Constructors deserialize
+    FromCBOR (Annotator (Core.TxBody era)), -- arises because some pattern Constructors deserialize
+    HasField "txfee" (Core.TxBody era) Coin
   )
 
 class Show (Core.TxOut era) => MinGenTxout era where
@@ -206,6 +207,7 @@ class
     MinGenWitnesses era,
     MinGenAuxData era,
     MinGenTxBody era,
+    HasField "body" (Core.Tx era) (Core.TxBody era),
     MinGenTxout era,
     PrettyA (Core.Tx era),
     PrettyA (Core.TxBody era),
@@ -301,6 +303,12 @@ class
   --   2) Run a test that might decide to 'discard' the test, because we got unlucky, and a rare unfixible condition has occurred.
   genEraTweakBlock :: Core.PParams era -> Seq (Core.Tx era) -> Gen (Seq (Core.Tx era))
   genEraTweakBlock _pp seqTx = pure seqTx
+
+  hasFailedScripts :: Core.Tx era -> Bool
+  hasFailedScripts = const False
+
+  feeOrCollateral :: Core.Tx era -> UTxO era -> Coin
+  feeOrCollateral tx _ = getField @"txfee" $ getField @"body" tx
 
 {------------------------------------------------------------------------------
   Generators shared across eras

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/src/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -191,13 +191,13 @@ instance
 -- To achieve this we (1) use 'IRC LEDGER' (the "initial rule context") instead of simply 'LedgerEnv'
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisLedgerState ::
-  forall a era.
+  forall a era ledger.
   ( UsesValue era,
     EraGen era,
     Default (State (Core.EraRule "PPUP" era))
   ) =>
   GenEnv era ->
-  IRC (LEDGER era) ->
+  IRC ledger ->
   Gen (Either a (UTxOState era, DPState (Crypto era)))
 mkGenesisLedgerState ge@(GenEnv _ _ c) _ = do
   utxo0 <- genUtxo0 ge

--- a/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
+++ b/shelley/chain-and-ledger/shelley-spec-ledger-test/test/Tests.hs
@@ -4,6 +4,7 @@
 
 import Cardano.Crypto.Libsodium (sodiumInit)
 import Shelley.Spec.Ledger.PParams (PParams' (..))
+import Shelley.Spec.Ledger.STS.Ledger (LEDGER)
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C)
 import Test.Shelley.Spec.Ledger.Pretty (prettyTest)
@@ -26,7 +27,7 @@ mainTests :: TestTree
 mainTests =
   testGroup
     "Ledger with Delegation"
-    [ minimalPropertyTests @C,
+    [ minimalPropertyTests @C @(LEDGER C),
       rewardTests,
       Serialisation.tests 5,
       chainExamples,
@@ -41,7 +42,7 @@ nightlyTests :: TestTree
 nightlyTests =
   testGroup
     "Ledger with Delegation nightly"
-    [ propertyTests @C,
+    [ propertyTests @C @(LEDGER C),
       Serialisation.tests 50
     ]
 


### PR DESCRIPTION
# Alonzo Specific Property Tests

A new testing module `Test.Cardano.Ledger.Alonzo.PropertyTests` is added, which tests nearly all of the properties listed in the Formal Properties appendix of the [Alonzo spec](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.alonzo-ledger/latest/download-by-type/doc-pdf/alonzo-changes). The main omission is "A.8 deterministic script evaluation", which I could not find a great way to implement using our existing trace generation testing framework.

Additionally, the Alonzo transaction generators now produce valid transactions with failing scripts, which exercises all the collateral logic.

Lastly, I fixed an onerous problem with the Alonzo trace tests, which were in a split-brain state. We were using the Alonzo rules to generate a `CHAIN` trace of blocks, but then to inspect the underlying `LEDGER` trace, we were replaying the rules using the Shelley `LEDGER` rule, and not the `AlonzoLEDGER` rule. This made for some interesting failures!

## Updates to `EraGen`

In order to re-use the Shelley accounting property tests in Alonzo, in the presence of transactions marked with `IsValid False`, I needed to add two new methods to the `EraGen` class, namely `hasFailedScripts` and `amountToFees`. Prior to Alonzo, `hasFailedScripts` is just const false, and `amountToFees` is the fee in the transaction body. In Alonzo, `hasFailedScripts` is the opposite of `IsValid`, and `amountToFees` is either the fee in the body (for transaction with `IsValid True`) or the sum of the collateral. These two methods let us adapt all the Shelley accounting properties to how they are described in the Alonzo property section.