### PR TITLE
Debug help for failed Plutus scripts

### DIFF
--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -54,6 +54,7 @@ library
   build-depends:
     array,
     base-deriving-via,
+    base16-bytestring,
     bytestring,
     cardano-binary,
     cardano-crypto-class,
@@ -77,6 +78,7 @@ library
     strict-containers,
     text,
     time,
-    transformers
+    transformers,
+    utf8-string,
   hs-source-dirs:
     src

--- a/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -54,7 +54,7 @@ library
   build-depends:
     array,
     base-deriving-via,
-    base16-bytestring,
+    base64-bytestring,
     bytestring,
     cardano-binary,
     cardano-crypto-class,

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -35,7 +35,14 @@ import Cardano.Ledger.Alonzo.Tx
     txdats',
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody (..), TxOut (..), vldt')
-import Cardano.Ledger.Alonzo.TxInfo (ScriptResult (..), andResult, runPLCScript, txInfo, valContext)
+import Cardano.Ledger.Alonzo.TxInfo
+  ( FailureDescription (..),
+    ScriptResult (..),
+    andResult,
+    runPLCScript,
+    txInfo,
+    valContext,
+  )
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), txscripts', unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
@@ -56,6 +63,7 @@ import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Text (pack)
 import GHC.Generics
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks)
@@ -225,7 +233,7 @@ evalScripts tx ((AlonzoScript.TimelockScript timelock, _, _, _) : rest) =
   where
     vhks = Set.map witKeyHash (txwitsVKey' (getField @"wits" tx))
     lift True = Passes
-    lift False = Fails ["Timelock: " ++ show timelock ++ " fails."]
+    lift False = Fails [OnePhaseFailure . pack . show $ timelock]
 evalScripts tx ((AlonzoScript.PlutusScript pscript, ds, units, cost) : rest) =
   runPLCScript (Proxy @era) cost pscript units (map getPlutusData ds) `andResult` evalScripts tx rest
 

--- a/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/alonzo/test/lib/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), Data (..))
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
-import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail (..))
 import Cardano.Ledger.Alonzo.Scripts
   ( CostModel (..),
@@ -33,6 +33,7 @@ import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( TxOut (..),
   )
+import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..), ScriptResult (..))
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
@@ -252,10 +253,25 @@ instance Arbitrary (PParamsUpdate era) where
       <*> arbitrary
       <*> arbitrary
 
+instance Arbitrary FailureDescription where
+  arbitrary =
+    oneof
+      [ (OnePhaseFailure . pack) <$> arbitrary,
+        PlutusFailure <$> (pack <$> arbitrary) <*> arbitrary
+      ]
+
+instance Arbitrary ScriptResult where
+  arbitrary =
+    oneof [pure Passes, Fails <$> arbitrary]
+
+instance Arbitrary TagMismatchDescription where
+  arbitrary =
+    oneof [pure PassedUnexpectedly, FailedUnexpectedly <$> arbitrary]
+
 instance Mock c => Arbitrary (UtxosPredicateFailure (AlonzoEra c)) where
   arbitrary =
     oneof
-      [ ValidationTagMismatch <$> arbitrary <*> (pack <$> arbitrary),
+      [ ValidationTagMismatch <$> arbitrary <*> arbitrary,
         UpdateFailure <$> arbitrary
       ]
 

--- a/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/plutus-preprocessor/plutus-preprocessor.cabal
@@ -37,3 +37,11 @@ executable plutus-preprocessor
       template-haskell
     hs-source-dirs:   src
     default-language: Haskell2010
+
+executable plutus-debug
+    main-is:          Debug.hs
+    build-depends:
+      base,
+      cardano-ledger-alonzo,
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/plutus-preprocessor/src/Debug.hs
+++ b/plutus-preprocessor/src/Debug.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Cardano.Ledger.Alonzo.TxInfo (debugPlutus)
+import System.Environment (getArgs)
+import System.IO
+
+main :: IO ()
+main = getArgs >>= (print . debugPlutus . head)


### PR DESCRIPTION
This adds all the necessary information for re-runing a failed plutus script inside the `ValidationTagMismatch` predicate failure.

Additionally, I've replaced the `[Text]` field in `ValidationTagMismatch` with descriptive types for all the different scenarios.  Previously, the `Eq` instance for `ValidationTagMismatch` was ignoring this field, I suspect to make testing easier. I've made the `Eq` instance care about all the fields, and gave the tests a way to ignore the inner details of the plutus error message.