### PR TITLE
Shrank epochs down to transactions

### DIFF
--- a/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/cardano-ledger-test/cardano-ledger-test.cabal
@@ -41,6 +41,17 @@ library
     Test.Cardano.Ledger.Generic.Indexed
     Test.Cardano.Ledger.Generic.Updaters
     Test.Cardano.Ledger.TestableEra
+    Test.Cardano.Ledger.ModelChain
+    Test.Cardano.Ledger.ModelChain.Properties
+    Test.Cardano.Ledger.ModelChain.FeatureSet
+    Test.Cardano.Ledger.ModelChain.Value
+    Test.Cardano.Ledger.ModelChain.Address
+    Test.Cardano.Ledger.ModelChain.Script
+    Test.Cardano.Ledger.ModelChain.Utils
+    Test.Cardano.Ledger.Elaborators
+    Test.Cardano.Ledger.Elaborators.Alonzo
+    Test.Cardano.Ledger.Elaborators.Shelley
+
   build-depends:
     aeson,
     bytestring,
@@ -49,12 +60,20 @@ library
     cardano-ledger-alonzo,
     cardano-ledger-core,
     cardano-ledger-shelley-ma,
+    cardano-ledger-shelley-ma-test,
     cardano-slotting,
     containers,
+    criterion,
     data-default-class,
+    deepseq,
     genvalidity,
     genvalidity-scientific,
+    groups,
+    lens,
+    mtl,
     plutus-ledger-api,
+    plutus-tx,
+    QuickCheck,
     scientific,
     shelley-spec-ledger,
     shelley-spec-ledger-test,
@@ -65,8 +84,7 @@ library
     tasty-hunit,
     tasty-quickcheck,
     time,
-    QuickCheck,
-
+    transformers,
 
 test-suite cardano-ledger-test
   import:             base, project-config

--- a/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/cardano-ledger-test/cardano-ledger-test.cabal
@@ -51,6 +51,7 @@ library
     Test.Cardano.Ledger.Elaborators
     Test.Cardano.Ledger.Elaborators.Alonzo
     Test.Cardano.Ledger.Elaborators.Shelley
+    Test.Cardano.Ledger.DependGraph
 
   build-depends:
     aeson,
@@ -66,14 +67,18 @@ library
     criterion,
     data-default-class,
     deepseq,
+    fgl,
     genvalidity,
     genvalidity-scientific,
     groups,
     lens,
+    monad-supply,
     mtl,
+    nonempty-containers,
     plutus-ledger-api,
     plutus-tx,
     QuickCheck,
+    QuickCheck-GenT,
     scientific,
     shelley-spec-ledger,
     shelley-spec-ledger-test,
@@ -85,6 +90,7 @@ library
     tasty-quickcheck,
     time,
     transformers,
+
 
 test-suite cardano-ledger-test
   import:             base, project-config

--- a/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/cardano-ledger-test/cardano-ledger-test.cabal
@@ -55,6 +55,7 @@ library
 
   build-depends:
     aeson,
+    random,
     bytestring,
     cardano-binary,
     cardano-crypto-class,

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -13,9 +14,11 @@ import Control.Lens hiding (elements)
 import Control.Monad
 import Control.Monad.State
 import Control.Monad.Supply
+import Data.Foldable
 import qualified Data.Graph.Inductive as FGL
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Semigroup
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
@@ -23,6 +26,7 @@ import qualified Data.Set.NonEmpty as NES
 import QuickCheck.GenT
 import Test.Cardano.Ledger.ModelChain
 import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.Value
 import Test.QuickCheck hiding (choose, elements, frequency, oneof, resize, shuffle, sized, variant)
 
 -- TODO: Handle anti-dependencies. e.g. retiring a pool precludes delegating to it
@@ -100,16 +104,18 @@ outputTo aId minOutputs maxOutputs spenders = do
   -- First decide how many and which actions to enable
   numOutputs <- choose (min minOutputs 0, max maxOutputs (Set.size spenders))
   chosenSpenders <- take numOutputs <$> shuffle (Set.toList spenders)
-  forM_ chosenSpenders $ \i ->
+  forM_ chosenSpenders $ \i -> do
     actionState_withDeps . at i . _Just . _3 . at aId .= Just Enables_Spending
-  -- Then, decide how many of those spenders should be removed from needing inputs
-  numDeleted <-
-    frequency
-      [ (4, pure 0),
-        (1, choose (0, numOutputs))
-      ]
-  chosenDeleted <- take numDeleted <$> shuffle chosenSpenders
-  actionState_needsInputs %= (`Set.difference` (Set.fromList chosenDeleted))
+    mdeps <- fmap (view _3) <$> use (actionState_withDeps . at i)
+    -- Decide whether or not this dependent is satisfied
+    case mdeps of
+      Nothing -> error "outputTo: impossible empty deps"
+      Just deps -> do
+        let numInputs = Map.size $ Map.filter (== Enables_Spending) deps
+        r <- choose (minInputs, maxInputs)
+        case r <= numInputs of
+          True -> actionState_needsInputs %= (Set.delete i)
+          False -> pure ()
 
 makeWithdrawal :: (MonadGen m, MonadState ActionState m) => Int -> Int -> Set Int -> m ()
 makeWithdrawal aId epoch withdrawals = do
@@ -119,6 +125,105 @@ makeWithdrawal aId epoch withdrawals = do
       wId <- elements (Set.toList withdrawals)
       actionState_withDeps . at wId . _Just . _3 . at aId .= Just Enables_Withdrawing
       actionState_needsDelegate . at epoch . _Just %= Set.delete wId
+
+-- TODO: Some of these actions should not be passed more than one dependent.
+chooseEnablement :: (MonadState ActionState m, MonadGen m) => Set Int -> Int -> Int -> Action -> m ()
+chooseEnablement targets _ i = \case
+  Action_Withdraw -> outputTo i 1 1 targets
+  Action_Delegate -> do
+    forM_ (Set.toList targets) $ \target -> fmap (view _1) <$> (use (actionState_withDeps . at target)) >>= \case
+      Nothing -> pure ()
+      Just targetEpoch -> makeWithdrawal i targetEpoch (Set.singleton target)
+  Action_Spend -> outputTo i (Set.size targets) (Set.size targets) targets
+  Action_RegisterPool -> do
+    forM_ (Set.toList targets) $ \target ->
+      actionState_withDeps . at target . _Just . _3 . at i .= Just Enables_PoolForDelegating
+    actionState_needsPool %= (`Set.difference` targets)
+  Action_RegisterStake -> do
+    forM_ (Set.toList targets) $ \target ->
+      actionState_withDeps . at target . _Just . _3 . at i .= Just Enables_StakeForDelegating
+    actionState_needsStake %= (`Set.difference` targets)
+
+randomEnablement :: (MonadState ActionState m, MonadGen m) => Int -> Int -> Action -> m ()
+randomEnablement epoch i = \case
+  Action_Withdraw -> do
+    -- Withdrawal produces an output that can be spent, so flip a coin if it's used
+    spenders <- use actionState_needsInputs
+    outputTo i 0 1 spenders
+  Action_Delegate -> do
+    -- Delegation can enable withdrawal of staking rewards
+    -- A particular delegation can only enable a withdrawal once per epoch
+    eligibleEpochs <- uses actionState_needsDelegate $ Map.filterWithKey (\e _ -> e >= epoch + 2)
+    iforM_ eligibleEpochs $ \e withdrawals ->
+      frequency
+        [ (1, pure ()),
+          (3, makeWithdrawal i e withdrawals)
+        ]
+  Action_Spend -> do
+    -- Spends create outputs which can then be used in later spends
+    spenders <- use actionState_needsInputs
+    outputTo i 0 4 spenders
+  Action_RegisterPool -> do
+    -- Delegations depend on pools
+    delegations <- use actionState_needsPool
+    numDelegations <- choose (0, 8)
+    poolDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
+    forM_ poolDelegs $ \dId -> do
+      actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_PoolForDelegating
+    actionState_needsPool %= (`Set.difference` Set.fromList poolDelegs)
+  Action_RegisterStake -> do
+    -- Delegations depend on a staking certificate, which can only justify one
+    -- delegation.
+    delegations <- use actionState_needsStake
+    numDelegations <-
+      frequency
+        [ (1, pure 0),
+          (1 + 2 * Set.size delegations, pure 1)
+        ]
+    stakeDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
+    forM_ stakeDelegs $ \dId -> do
+      actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_StakeForDelegating
+    actionState_needsStake %= (`Set.difference` Set.fromList stakeDelegs)
+
+addAction :: MonadState ActionState m => (Int -> Int -> Action -> m ()) -> Int -> Int -> Action -> m ()
+addAction enablement epoch i a = do
+  actionState_withDeps . at i .= Just (epoch, a, mempty)
+  -- Action specific logic. An action reports the dependencies it needs fulfilled
+  -- and also chooses to fulfill some dependencies that have been emitted by actions
+  -- that happen after it.
+  enablement epoch i a
+  case a of
+    Action_Withdraw -> do
+      -- Withdrawal can only occur if a delegation was made in the past
+      actionState_needsDelegate . at epoch %= Just . maybe (Set.singleton i) (Set.insert i)
+    Action_Delegate -> do
+      -- Delegation needs a staking certificate and registered pool
+      actionState_needsStake %= Set.insert i
+      actionState_needsPool %= Set.insert i
+    Action_Spend -> do
+      -- Spending requires inputs, which potentially could come from the genesis block
+      actionState_needsInputs %= Set.insert i
+    Action_RegisterPool -> pure ()
+    Action_RegisterStake -> pure ()
+
+fillDependencies :: (MonadState ActionState m, MonadSupply Int m, MonadGen m) => m ()
+fillDependencies = do
+  -- Delegations first
+  ds <- uses actionState_needsDelegate fold
+  forM_ (Set.toList ds) $ \i -> do
+    n <- supply
+    addAction (chooseEnablement (Set.singleton i)) 1 n Action_Delegate
+  -- Use one pool for all the hanging threads
+  do
+    n <- supply
+    ps <- use actionState_needsPool
+    addAction (chooseEnablement ps) 1 n Action_RegisterPool
+  -- One staking cert per delegation
+  ss <- use actionState_needsStake
+  forM_ (Set.toList ss) $ \i -> do
+    n <- supply
+    addAction (chooseEnablement (Set.singleton i)) 1 n Action_RegisterStake
+
 
 genEpoch :: (MonadGen m, MonadSupply Int m, MonadState ActionState m) => Int -> m ()
 genEpoch epoch = do
@@ -137,75 +242,159 @@ genEpoch epoch = do
           (if i > minActionsPerEpoch then 2 else 0, pure Action_Delegate),
           (24, pure Action_Spend)
         ]
-    actionState_withDeps . at i .= Just (epoch, a, mempty)
-    -- Action specific logic. An action reports the dependencies it needs fulfilled
-    -- and also chooses to fulfill some dependencies that have been emitted by actions
-    -- that happen after it.
-    case a of
-      Action_Withdraw -> do
-        -- Withdrawal produces an output that can be spent, so flip a coin if it's used
-        spenders <- use actionState_needsInputs
-        outputTo i 0 1 spenders
-
-        -- Withdrawal can only occur if a delegation was made in the past
-        actionState_needsDelegate . at epoch %= Just . maybe (Set.singleton i) (Set.insert i)
-      Action_Delegate -> do
-        -- Delegation can enable withdrawal of staking rewards
-        -- A particular delegation can only enable a withdrawal once per epoch
-        eligibleEpochs <- uses actionState_needsDelegate $ Map.filterWithKey (\e _ -> e >= epoch + 2)
-        iforM_ eligibleEpochs $ \e withdrawals ->
-          frequency
-            [ (1, pure ()),
-              (3, makeWithdrawal i e withdrawals)
-            ]
-
-        -- Delegation needs a staking certificate and registered pool
-        actionState_needsStake %= Set.insert i
-        actionState_needsPool %= Set.insert i
-      Action_Spend -> do
-        -- Spends create outputs which can then be used in later spends
-        spenders <- use actionState_needsInputs
-        outputTo i 0 4 spenders
-
-        -- Spending requires inputs, which potentially could come from the genesis block
-        actionState_needsInputs %= Set.insert i
-      Action_RegisterPool -> do
-        -- Delegations depend on pools
-        delegations <- use actionState_needsPool
-        numDelegations <- choose (0, 8)
-        poolDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
-        forM_ poolDelegs $ \dId -> do
-          actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_PoolForDelegating
-        actionState_needsPool %= (`Set.difference` Set.fromList poolDelegs)
-      Action_RegisterStake -> do
-        -- Delegations depend on a staking certificate, which can only justify one
-        -- delegation.
-        delegations <- use actionState_needsStake
-        numDelegations <-
-          frequency
-            [ (1, pure 0),
-              (1 + 2 * Set.size delegations, pure 1)
-            ]
-        stakeDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
-        forM_ stakeDelegs $ \dId -> do
-          actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_StakeForDelegating
-        actionState_needsStake %= (`Set.difference` Set.fromList stakeDelegs)
+    addAction randomEnablement epoch i a
   pure ()
 
-genGraph :: (MonadGen m, MonadSupply Int m, MonadState ActionState m) => m ()
-genGraph = do
+genActions :: (MonadGen m, MonadSupply Int m, MonadState ActionState m) => m ()
+genActions = do
   -- First figure out how many epochs we're aiming for.
   -- We need to do this here because delegation to a pool
   -- has to happen some number of epochs (2) before reward
   -- withdrawal.
   numEpochs <- choose (minEpochs, maxEpochs)
-  forM_ [numEpochs, numEpochs -1 .. 1] genEpoch
+  forM_ [numEpochs, numEpochs-1 .. 1] genEpoch
+  -- After random generation there might still be actions in the graph
+  -- that don't have their dependencies met. Fill those in now in the first epoch.
+  fillDependencies
   pure ()
 
-testGenGraph :: IO ActionState
-testGenGraph = do
-  s <- generate (execStateT genGraph initialActionState)
+testGenActions :: IO ActionState
+testGenActions = do
+  s <- generate (execStateT genActions initialActionState)
   pure $ s & actionState_freshNames .~ []
+
+minActions :: Int
+minActions = 1
+
+maxActions :: Int
+maxActions = 4
+
+minTxs :: Int
+minTxs = 1
+
+maxTxs :: Int
+maxTxs = 4
+
+data TransactionState era = TransactionState
+  { _transactionState_freshNames :: [Integer]
+  , _transactionState_livePaymentAddresses :: Set ModelAddress
+  , _transactionState_liveUtxos :: Map Int {- action id -} (Map ModelUTxOId (ModelTxOut era))
+  , _transactionState_txDependencies :: Map {- action id -} Int (Map ModelTxId (NESet Enables))
+  , _transactionState_genesisUtxo :: [(ModelUTxOId, ModelAddress, Coin)]
+  , _transactionState_transactionsInEpoch :: Map {- epoch -} Int (Map ModelTxId (ModelTx era))
+  }
+
+makeLenses ''TransactionState
+
+initialTransactionState :: TransactionState era
+initialTransactionState = TransactionState
+  { _transactionState_freshNames = [1..]
+  , _transactionState_livePaymentAddresses = mempty
+  , _transactionState_liveUtxos = mempty
+  , _transactionState_txDependencies = mempty
+  , _transactionState_genesisUtxo = mempty
+  , _transactionState_transactionsInEpoch = mempty
+  }
+
+freshTxId :: MonadSupply Integer m => m ModelTxId
+freshTxId = ModelTxId <$> supply
+
+freshUtxoId :: MonadSupply Integer m => m ModelUTxOId
+freshUtxoId = ModelUTxOId <$> supply
+
+freshPaymentAddress :: MonadSupply Integer m => m ModelAddress
+freshPaymentAddress = ModelAddress . ("pay_" <>) . show <$> supply
+
+freshPoolAddress :: MonadSupply Integer m => m ModelAddress
+freshPoolAddress = ModelAddress . ("pool_" <>) . show <$> supply
+
+genTransactions
+  :: ( MonadGen m
+     , MonadState (TransactionState era) m
+     , MonadSupply Integer m
+     )
+  => Set Int -> ActionGraph -> m ()
+genTransactions actionIds actionGraph = do
+  -- Here we exploit the fact that we generated our action graph in such a way that [1..]
+  -- is an antitone topological sort of the actions.
+  gr <- (\x y f -> foldlM f x y) (unActionGraph actionGraph) (Set.toDescList actionIds) $ \gr i -> do
+    let (mctx, gr') = FGL.match i gr
+    case mctx of
+      Nothing -> error "genTransactions: Passed invalid actionId"
+      Just (eIn, _, (epoch, action), eOut) -> do
+        case eIn of
+          [] -> pure ()
+          _:_ -> error "genTransactions: actionIds were not topsorted"
+        txDeps <- uses (transactionState_txDependencies . at i) (maybe mempty id)
+        myInputs <- uses (transactionState_liveUtxos . at i) (maybe mempty id)
+        -- TODO: Handle ModelValue properly
+        let Sum myTotalInput = flip foldMap myInputs $ \(ModelTxOut _ (ModelValue mv)) -> case mv of
+              ModelValue_Inject (Coin v) -> Sum v
+              _ -> Sum 0
+        case action of
+          -- Spends are the simplest. Since they represent an arbitrary exchange of inputs to outputs
+          -- each spend action is its own transaction. Other actions must be merged into
+          -- transactions with spends or require a genesis UTxO for fees
+          Action_Spend -> do
+            txId <- freshTxId
+            writeDependencies i txId eOut
+            let outs = [ aId | (Enables_Spending, aId) <- eOut ]
+            -- Generate UTxOs for my dependencies and then maybe a UTXO that lies inert
+            (leftoverValue, myUtxos) <- do
+              (lv, utxos) <- generateUtxosFor myTotalInput outs
+              case lv > 1 of
+                False -> pure (lv, utxos)
+                True -> do
+                  leftoverUtxo <- frequency
+                    [ (3, pure 0)
+                    , (1, choose (1, lv-1))
+                    ]
+                  case leftoverUtxo > 0 of
+                    False -> pure (lv, utxos)
+                    True -> do
+                      paddr <- generatePaymentAddress
+                      utxoId <- freshUtxoId
+                      pure $
+                        ( lv - leftoverUtxo
+                        , Map.insert utxoId (ModelTxOut paddr (ModelValue (ModelValue_Inject (Coin leftoverUtxo)))) utxos
+                        )
+            pure ()
+          Action_Withdraw -> pure ()
+          Action_Delegate -> pure ()
+          Action_RegisterStake -> pure ()
+          Action_RegisterPool -> pure ()
+        pure gr'
+  pure ()
+
+writeDependencies :: MonadState (TransactionState era) m => Int -> ModelTxId -> [(Enables, Int)] -> m ()
+writeDependencies aId txId eOut = do
+  let newDeps = Map.fromList $ flip fmap eOut $ \(enable, depId) -> (depId, Map.singleton txId (NES.singleton enable))
+  transactionState_txDependencies %= Map.unionWith (Map.unionWith (<>)) newDeps . Map.delete aId
+
+generatePaymentAddress
+  :: (MonadState (TransactionState era) m, MonadSupply Integer m, MonadGen m)
+  => m ModelAddress
+generatePaymentAddress = do
+  paddrs <- use transactionState_livePaymentAddresses
+  frequency $
+    [ (1, freshPaymentAddress >>= \paddr -> transactionState_livePaymentAddresses %= (Set.insert paddr) >> pure paddr)
+    , (Set.size paddrs, elements (Set.toList paddrs))
+    ]
+
+generateUtxosFor
+  :: (MonadState (TransactionState era) m, MonadSupply Integer m, MonadGen m)
+  => Integer
+  -> [Int] {- action ids -}
+  -> m (Integer, Map ModelUTxOId (ModelTxOut era))
+generateUtxosFor totalValue outs = do
+  (leftoverValue, newUtxos) <- (\x y f -> foldlM f x y) (totalValue, mempty) outs $ \(valueLeft, acc) aId -> do
+    utxoId <- freshUtxoId
+    amount <- choose (1, valueLeft `div` 4 + 1) -- TODO: Split up the value in a more sensible and robust way
+    paddr <- generatePaymentAddress
+    let newUtxo = Map.singleton aId (Map.singleton utxoId (ModelTxOut paddr (ModelValue (ModelValue_Inject (Coin amount)))))
+    pure (valueLeft - amount, Map.union newUtxo acc)
+  transactionState_liveUtxos %= Map.unionWith Map.union newUtxos
+  pure (leftoverValue, fold newUtxos)
 
 -- Orphans
 instance MonadFail Gen where
@@ -227,3 +416,13 @@ instance {-# OVERLAPPING #-} (Monad m, MonadFail m) => MonadSupply Int (StateT A
     x : _ <- use actionState_freshNames
     pure x
   exhausted = uses actionState_freshNames null
+
+instance {-# OVERLAPPING #-} (Monad m, MonadFail m) => MonadSupply Integer (StateT (TransactionState era) m) where
+  supply = do
+    x : xs <- use transactionState_freshNames
+    transactionState_freshNames .= xs
+    pure x
+  peek = do
+    x : _ <- use transactionState_freshNames
+    pure x
+  exhausted = uses transactionState_freshNames null

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Cardano.Ledger.DependGraph where
+
+import Cardano.Ledger.Coin
+import Control.Lens hiding (elements)
+import Control.Monad
+import Control.Monad.State
+import Control.Monad.Supply
+import qualified Data.Graph.Inductive as FGL
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Set.NonEmpty (NESet)
+import qualified Data.Set.NonEmpty as NES
+import QuickCheck.GenT
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.Address
+import Test.QuickCheck hiding (choose, elements, frequency, oneof, resize, shuffle, sized, variant)
+
+-- TODO: Handle anti-dependencies. e.g. retiring a pool precludes delegating to it
+-- or receiving rewards from it. likewise deregistering a staking cert precludes
+-- delegating or receiving rewards. Delegating the same staking cert again
+-- nullifies the previous delegation.
+
+-- | Nodes in an abstract graph of actions recorded in a ledger.
+-- This is finer grained than transactions since a transaction is a set
+-- of coherent actions.
+data Action
+  = Action_Withdraw
+  | Action_RegisterStake
+  | Action_RegisterPool
+  | Action_Delegate
+  | Action_Spend
+  deriving (Eq, Ord, Show)
+
+-- | Directed edges in an abstract graph of action recorded in a ledger.
+-- Edges record how an action enables a later action to be taken.
+-- For example, you cannot expect to withdraw a reward unless you're
+-- staked to an active pool.
+data Enables
+  = Enables_Spending
+  | Enables_StakeForDelegating
+  | Enables_PoolForDelegating
+  | Enables_Withdrawing
+  deriving (Eq, Ord, Show)
+
+-- Actually a node is an action in an epoch. We need the epoch to ensure consistency of
+-- stake pool rewards.
+newtype ActionGraph = ActionGraph {unActionGraph :: FGL.Gr (Int, Action) Enables}
+
+minEpochs :: Int
+minEpochs = 3
+
+maxEpochs :: Int
+maxEpochs = 3
+
+minActionsPerEpoch :: Int
+minActionsPerEpoch = 32
+
+maxActionsPerEpoch :: Int
+maxActionsPerEpoch = 2 * minActionsPerEpoch
+
+minInputs :: Int
+minInputs = 1
+
+maxInputs :: Int
+maxInputs = 5
+
+data ActionState = ActionState
+  { -- | Lazy supply of Ints
+    _actionState_freshNames :: [Int],
+    -- | Node ID to label
+    _actionState_withDeps :: Map Int (Int, Action, Map Int Enables),
+    -- | Epoch number to set of node ids
+    _actionState_needsDelegate :: Map Int (Set Int),
+    -- | Node IDs
+    _actionState_needsStake :: Set Int,
+    -- | Node IDs
+    _actionState_needsPool :: Set Int,
+    -- | Node ID to number of inputs needed
+    _actionState_needsInputs :: Set Int
+  }
+  deriving (Eq, Ord, Show)
+
+makeLenses ''ActionState
+
+initialActionState :: ActionState
+initialActionState = ActionState [1 ..] mempty mempty mempty mempty mempty
+
+outputTo :: (MonadGen m, MonadState ActionState m) => Int -> Int -> Int -> Set Int -> m ()
+outputTo aId minOutputs maxOutputs spenders = do
+  -- First decide how many and which actions to enable
+  numOutputs <- choose (min minOutputs 0, max maxOutputs (Set.size spenders))
+  chosenSpenders <- take numOutputs <$> shuffle (Set.toList spenders)
+  forM_ chosenSpenders $ \i ->
+    actionState_withDeps . at i . _Just . _3 . at aId .= Just Enables_Spending
+  -- Then, decide how many of those spenders should be removed from needing inputs
+  numDeleted <-
+    frequency
+      [ (4, pure 0),
+        (1, choose (0, numOutputs))
+      ]
+  chosenDeleted <- take numDeleted <$> shuffle chosenSpenders
+  actionState_needsInputs %= (`Set.difference` (Set.fromList chosenDeleted))
+
+makeWithdrawal :: (MonadGen m, MonadState ActionState m) => Int -> Int -> Set Int -> m ()
+makeWithdrawal aId epoch withdrawals = do
+  case Set.toList withdrawals of
+    [] -> pure ()
+    _ : _ -> do
+      wId <- elements (Set.toList withdrawals)
+      actionState_withDeps . at wId . _Just . _3 . at aId .= Just Enables_Withdrawing
+      actionState_needsDelegate . at epoch . _Just %= Set.delete wId
+
+genEpoch :: (MonadGen m, MonadSupply Int m, MonadState ActionState m) => Int -> m ()
+genEpoch epoch = do
+  numActions <- choose (minActionsPerEpoch, maxActionsPerEpoch)
+  replicateM_ numActions $ do
+    -- We assign IDs to actions so that the lower IDs depend on
+    -- higher IDs.
+    i <- supply
+    a <-
+      frequency
+        -- Can't ever withdraw rewards before rewards
+        -- could have been generated for a staking pool.
+        [ (if epoch > 2 then 1 else 0, pure Action_Withdraw),
+          (4, pure Action_RegisterStake),
+          (4, pure Action_RegisterPool),
+          (if i > minActionsPerEpoch then 2 else 0, pure Action_Delegate),
+          (24, pure Action_Spend)
+        ]
+    actionState_withDeps . at i .= Just (epoch, a, mempty)
+    -- Action specific logic. An action reports the dependencies it needs fulfilled
+    -- and also chooses to fulfill some dependencies that have been emitted by actions
+    -- that happen after it.
+    case a of
+      Action_Withdraw -> do
+        -- Withdrawal produces an output that can be spent, so flip a coin if it's used
+        spenders <- use actionState_needsInputs
+        outputTo i 0 1 spenders
+
+        -- Withdrawal can only occur if a delegation was made in the past
+        actionState_needsDelegate . at epoch %= Just . maybe (Set.singleton i) (Set.insert i)
+      Action_Delegate -> do
+        -- Delegation can enable withdrawal of staking rewards
+        -- A particular delegation can only enable a withdrawal once per epoch
+        eligibleEpochs <- uses actionState_needsDelegate $ Map.filterWithKey (\e _ -> e >= epoch + 2)
+        iforM_ eligibleEpochs $ \e withdrawals ->
+          frequency
+            [ (1, pure ()),
+              (3, makeWithdrawal i e withdrawals)
+            ]
+
+        -- Delegation needs a staking certificate and registered pool
+        actionState_needsStake %= Set.insert i
+        actionState_needsPool %= Set.insert i
+      Action_Spend -> do
+        -- Spends create outputs which can then be used in later spends
+        spenders <- use actionState_needsInputs
+        outputTo i 0 4 spenders
+
+        -- Spending requires inputs, which potentially could come from the genesis block
+        actionState_needsInputs %= Set.insert i
+      Action_RegisterPool -> do
+        -- Delegations depend on pools
+        delegations <- use actionState_needsPool
+        numDelegations <- choose (0, 8)
+        poolDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
+        forM_ poolDelegs $ \dId -> do
+          actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_PoolForDelegating
+        actionState_needsPool %= (`Set.difference` Set.fromList poolDelegs)
+      Action_RegisterStake -> do
+        -- Delegations depend on a staking certificate, which can only justify one
+        -- delegation.
+        delegations <- use actionState_needsStake
+        numDelegations <-
+          frequency
+            [ (1, pure 0),
+              (1 + 2 * Set.size delegations, pure 1)
+            ]
+        stakeDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
+        forM_ stakeDelegs $ \dId -> do
+          actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_StakeForDelegating
+        actionState_needsStake %= (`Set.difference` Set.fromList stakeDelegs)
+  pure ()
+
+genGraph :: (MonadGen m, MonadSupply Int m, MonadState ActionState m) => m ()
+genGraph = do
+  -- First figure out how many epochs we're aiming for.
+  -- We need to do this here because delegation to a pool
+  -- has to happen some number of epochs (2) before reward
+  -- withdrawal.
+  numEpochs <- choose (minEpochs, maxEpochs)
+  forM_ [numEpochs, numEpochs -1 .. 1] genEpoch
+  pure ()
+
+testGenGraph :: IO ActionState
+testGenGraph = do
+  s <- generate (execStateT genGraph initialActionState)
+  pure $ s & actionState_freshNames .~ []
+
+-- Orphans
+instance MonadFail Gen where
+  fail = error
+
+instance MonadGen g => MonadGen (StateT s g) where
+  liftGen = lift . liftGen
+  variant n a = StateT $ \s -> variant n (runStateT a s)
+  sized f = StateT $ \s -> sized (\i -> runStateT (f i) s)
+  resize n a = StateT $ \s -> resize n (runStateT a s)
+  choose = lift . choose
+
+instance {-# OVERLAPPING #-} (Monad m, MonadFail m) => MonadSupply Int (StateT ActionState m) where
+  supply = do
+    x : xs <- use actionState_freshNames
+    actionState_freshNames .= xs
+    pure x
+  peek = do
+    x : _ <- use actionState_freshNames
+    pure x
+  exhausted = uses actionState_freshNames null

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
@@ -99,7 +99,7 @@ type GenActionContext = GenActionContextF Gen
 
 defaultGenActionContext :: GenActionContext
 defaultGenActionContext = GenActionContext
-  (choose (1, 8))
+  (choose (1, 5))
   (choose (2, 8)) -- 128))
   (pure 1) -- (choose (1, 5))
 

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -5,15 +7,19 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Cardano.Ledger.DependGraph where
 
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Control.Lens hiding (elements)
 import Control.Monad
+import Data.Proxy
 import Control.Monad.State
 import Control.Monad.Supply
 import Data.Foldable
@@ -26,15 +32,24 @@ import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import QuickCheck.GenT
+import Test.Cardano.Ledger.Elaborators
+import Test.Cardano.Ledger.Elaborators.Shelley ()
 import Test.Cardano.Ledger.ModelChain
 import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.FeatureSet
 import Test.Cardano.Ledger.ModelChain.Value
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
 import Test.QuickCheck hiding (choose, elements, frequency, oneof, resize, shuffle, sized, variant)
 
 -- TODO: Handle anti-dependencies. e.g. retiring a pool precludes delegating to it
 -- or receiving rewards from it. likewise deregistering a staking cert precludes
 -- delegating or receiving rewards. Delegating the same staking cert again
 -- nullifies the previous delegation.
+
+-- TODO: Generate withdrawal actions that occur in different epochs but are part of the same
+-- stake delegation, i.e. they withdraw into the same rewards account.
+
+-- TODO: Model scenarios where pools make varying amounts of blocks (e.g. 0 or many)
 
 -- | Nodes in an abstract graph of actions recorded in a ledger.
 -- This is finer grained than transactions since a transaction is a set
@@ -51,16 +66,16 @@ data Action
 -- Edges record how an action enables a later action to be taken.
 -- For example, you cannot expect to withdraw a reward unless you're
 -- staked to an active pool.
-data Enables
-  = Enables_Spending
-  | Enables_StakeForDelegating
-  | Enables_PoolForDelegating
-  | Enables_Withdrawing
+data ActionEnables
+  = ActionEnables_Spending
+  | ActionEnables_StakeForDelegating
+  | ActionEnables_PoolForDelegating
+  | ActionEnables_Withdrawing
   deriving (Eq, Ord, Show)
 
--- Actually a node is an action in an epoch. We need the epoch to ensure consistency of
--- stake pool rewards.
-newtype ActionGraph = ActionGraph {unActionGraph :: FGL.Gr (Int, Action) Enables}
+-- A node in the graph is an action in an epoch. We need the epoch to ensure consistency of
+-- dependencies between rewards and delegation.
+newtype ActionGraph = ActionGraph {unActionGraph :: FGL.Gr (Int, Action) ActionEnables}
 
 minEpochs :: Int
 minEpochs = 3
@@ -69,7 +84,7 @@ maxEpochs :: Int
 maxEpochs = 3
 
 minActionsPerEpoch :: Int
-minActionsPerEpoch = 32
+minActionsPerEpoch = 64
 
 maxActionsPerEpoch :: Int
 maxActionsPerEpoch = 2 * minActionsPerEpoch
@@ -83,8 +98,8 @@ maxInputs = 5
 data ActionState = ActionState
   { -- | Lazy supply of Ints
     _actionState_freshNames :: [Int],
-    -- | Node ID to label and out-edges
-    _actionState_withDeps :: Map Int (Int, Action, Map Int Enables),
+    -- | Node ID to label and in-edges
+    _actionState_withDeps :: Map Int (Int, Action, Map Int ActionEnables),
     -- | Epoch number to set of node ids
     _actionState_needsDelegate :: Map Int (Set Int),
     -- | Node IDs
@@ -101,19 +116,31 @@ makeLenses ''ActionState
 initialActionState :: ActionState
 initialActionState = ActionState [1 ..] mempty mempty mempty mempty mempty
 
+testGenActions :: IO (Set Int, ActionGraph)
+testGenActions = do
+  s <- generate (execStateT genActions initialActionState)
+  pure $ (Map.keysSet (_actionState_withDeps s), materializeActionGraph s)
+
+materializeActionGraph :: ActionState -> ActionGraph
+materializeActionGraph s = ActionGraph $ FGL.buildGr $ flip fmap (Map.toAscList (_actionState_withDeps s)) $
+  \(aid, (epoch, alab, deps)) ->
+    let aIn = flip fmap (Map.toList deps) $ \(inId, inLab) -> (inLab, inId)
+     in (aIn, aid, (epoch, alab), [])
+
+-- TODO: this generation method doesn't produce long-lived UTxOs which are common in a realistic ledger
 outputTo :: (MonadGen m, MonadState ActionState m) => Int -> Int -> Int -> Set Int -> m ()
 outputTo aId minOutputs maxOutputs spenders = do
   -- First decide how many and which actions to enable
   numOutputs <- choose (min minOutputs 0, max maxOutputs (Set.size spenders))
   chosenSpenders <- take numOutputs <$> shuffle (Set.toList spenders)
   forM_ chosenSpenders $ \i -> do
-    actionState_withDeps . at i . _Just . _3 . at aId .= Just Enables_Spending
+    actionState_withDeps . at i . _Just . _3 . at aId .= Just ActionEnables_Spending
     mdeps <- fmap (view _3) <$> use (actionState_withDeps . at i)
     -- Decide whether or not this dependent is satisfied
     case mdeps of
       Nothing -> error "outputTo: impossible empty deps"
       Just deps -> do
-        let numInputs = Map.size $ Map.filter (== Enables_Spending) deps
+        let numInputs = Map.size $ Map.filter (== ActionEnables_Spending) deps
         r <- choose (minInputs, maxInputs)
         case r <= numInputs of
           True -> actionState_needsInputs %= (Set.delete i)
@@ -125,7 +152,7 @@ makeWithdrawal aId epoch withdrawals = do
     [] -> pure ()
     _ : _ -> do
       wId <- elements (Set.toList withdrawals)
-      actionState_withDeps . at wId . _Just . _3 . at aId .= Just Enables_Withdrawing
+      actionState_withDeps . at wId . _Just . _3 . at aId .= Just ActionEnables_Withdrawing
       actionState_needsDelegate . at epoch . _Just %= Set.delete wId
 
 -- TODO: Some of these actions should not be passed more than one dependent.
@@ -139,11 +166,11 @@ chooseEnablement targets _ i = \case
   Action_Spend -> outputTo i (Set.size targets) (Set.size targets) targets
   Action_RegisterPool -> do
     forM_ (Set.toList targets) $ \target ->
-      actionState_withDeps . at target . _Just . _3 . at i .= Just Enables_PoolForDelegating
+      actionState_withDeps . at target . _Just . _3 . at i .= Just ActionEnables_PoolForDelegating
     actionState_needsPool %= (`Set.difference` targets)
   Action_RegisterStake -> do
     forM_ (Set.toList targets) $ \target ->
-      actionState_withDeps . at target . _Just . _3 . at i .= Just Enables_StakeForDelegating
+      actionState_withDeps . at target . _Just . _3 . at i .= Just ActionEnables_StakeForDelegating
     actionState_needsStake %= (`Set.difference` targets)
 
 randomEnablement :: (MonadState ActionState m, MonadGen m) => Int -> Int -> Action -> m ()
@@ -171,7 +198,7 @@ randomEnablement epoch i = \case
     numDelegations <- choose (0, 8)
     poolDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
     forM_ poolDelegs $ \dId -> do
-      actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_PoolForDelegating
+      actionState_withDeps . at dId . _Just . _3 . at i .= Just ActionEnables_PoolForDelegating
     actionState_needsPool %= (`Set.difference` Set.fromList poolDelegs)
   Action_RegisterStake -> do
     -- Delegations depend on a staking certificate, which can only justify one
@@ -184,7 +211,7 @@ randomEnablement epoch i = \case
         ]
     stakeDelegs <- take numDelegations <$> shuffle (Set.toList delegations)
     forM_ stakeDelegs $ \dId -> do
-      actionState_withDeps . at dId . _Just . _3 . at i .= Just Enables_StakeForDelegating
+      actionState_withDeps . at dId . _Just . _3 . at i .= Just ActionEnables_StakeForDelegating
     actionState_needsStake %= (`Set.difference` Set.fromList stakeDelegs)
 
 addAction :: MonadState ActionState m => (Int -> Int -> Action -> m ()) -> Int -> Int -> Action -> m ()
@@ -239,10 +266,10 @@ genEpoch epoch = do
         -- Can't ever withdraw rewards before rewards
         -- could have been generated for a staking pool.
         [ (if epoch > 2 then 1 else 0, pure Action_Withdraw),
-          (4, pure Action_RegisterStake),
-          (4, pure Action_RegisterPool),
-          (if i > minActionsPerEpoch then 2 else 0, pure Action_Delegate),
-          (24, pure Action_Spend)
+          (2, pure Action_RegisterStake),
+          (2, pure Action_RegisterPool),
+          (if i > minActionsPerEpoch then 1 else 0, pure Action_Delegate),
+          (12, pure Action_Spend)
         ]
     addAction randomEnablement epoch i a
   pure ()
@@ -260,11 +287,6 @@ genActions = do
   fillDependencies
   pure ()
 
-testGenActions :: IO ActionState
-testGenActions = do
-  s <- generate (execStateT genActions initialActionState)
-  pure $ s & actionState_freshNames .~ []
-
 minActions :: Int
 minActions = 1
 
@@ -281,15 +303,31 @@ minFee :: Integer
 minFee = 1000
 
 maxFee :: Integer
-maxFee = 10000
+maxFee = 100000
+
+-- When we materialize actions into concrete transactions, we gain more information about
+-- how one action depends on another.
+--
+-- In particular, we know which reward address is used for withdrawals, delegation and staking
+-- TODO: Enrich the enablement relation with more information, like UTxOIds
+data TransactionEnables era
+  = TransactionEnables_Spending
+  | TransactionEnables_StakeForDelegating (ModelAddress (ScriptFeature era))
+  | TransactionEnables_PoolForDelegating
+  | TransactionEnables_Withdrawing (ModelAddress (ScriptFeature era))
+  deriving (Eq, Ord, Show)
 
 data TransactionState era = TransactionState
   { _transactionState_freshNames :: [Integer]
-  , _transactionState_livePaymentAddresses :: Set ModelAddress
+  , _transactionState_livePaymentAddresses :: Set (ModelAddress (ScriptFeature era))
+  , _transactionState_liveRewardAddresses :: Set (ModelAddress (ScriptFeature era))
   , _transactionState_utxos :: Map Int {- action id -} (Map ModelUTxOId (ModelTxOut era))
-  , _transactionState_txDependents :: Map {- action id -} Int (Map ModelTxId (NESet Enables))
-  , _transactionState_genesisUtxo :: [(ModelUTxOId, ModelAddress, Coin)]
-  , _transactionState_withDepsInEpoch :: Map {- epoch -} Int (Map ModelTxId (ModelTx era, Map ModelTxId (NESet Enables)))
+  , _transactionState_txDependents :: Map {- action id -} Int (Map ModelTxId (NESet (TransactionEnables era)))
+  , _transactionState_genesisUtxo :: [(ModelUTxOId, (ModelAddress (ScriptFeature era)), Coin)]
+  -- NB: In the action graph we recorded actions with their in-edges.
+  -- Here we record transactions with their out-edges.
+  -- It's a little more convenient for merging transactions together.
+  , _transactionState_withDepsInEpoch :: Map {- epoch -} Int (Map ModelTxId (ModelTx era, Map ModelTxId (NESet (TransactionEnables era))))
   }
 
 makeLenses ''TransactionState
@@ -298,11 +336,31 @@ initialTransactionState :: TransactionState era
 initialTransactionState = TransactionState
   { _transactionState_freshNames = [1..]
   , _transactionState_livePaymentAddresses = mempty
+  , _transactionState_liveRewardAddresses = mempty
   , _transactionState_utxos = mempty
   , _transactionState_txDependents = mempty
   , _transactionState_genesisUtxo = mempty
   , _transactionState_withDepsInEpoch = mempty
   }
+
+-- Nodes are labeled with an epoch and transaction body (which includes the tx id). Edges are labeled with the set of
+-- ways in which one transaction's actions enable the actions in another transaction.
+newtype TransactionGraph (era :: FeatureSet) = TransactionGraph { unTransactionGraph :: FGL.Gr (Int {-, ModelTx era -}) (NESet (TransactionEnables era)) }
+
+materializeTransactionGraph :: TransactionState era -> TransactionGraph era
+materializeTransactionGraph s = TransactionGraph $ FGL.buildGr $ do
+  (epoch, txs) <- Map.toDescList $ _transactionState_withDepsInEpoch s
+  (ModelTxId txId, (txBody, deps)) <- Map.toAscList txs
+  --TODO: Better than this. FGL uses Int for node IDs but our IDs are naturally integers
+  let tOut = flip fmap (Map.toList deps) $ \(ModelTxId outId, outLab) -> (outLab, fromIntegral outId)
+  pure $ ([], fromIntegral txId, (epoch{-, txBody-}), tOut)
+
+testGenTransactions :: IO ()
+testGenTransactions = do
+  actions <- testGenActions
+  s <- generate (execStateT (uncurry (genTransactions @(EraFeatureSet (ShelleyEra C_Crypto))) actions) initialTransactionState)
+  FGL.prettyPrint $ unTransactionGraph $ materializeTransactionGraph s
+  pure ()
 
 freshTxId :: MonadSupply Integer m => m ModelTxId
 freshTxId = ModelTxId <$> supply
@@ -310,16 +368,22 @@ freshTxId = ModelTxId <$> supply
 freshUtxoId :: MonadSupply Integer m => m ModelUTxOId
 freshUtxoId = ModelUTxOId <$> supply
 
-freshPaymentAddress :: MonadSupply Integer m => m ModelAddress
+freshPaymentAddress :: MonadSupply Integer m => m (ModelAddress era)
 freshPaymentAddress = ModelAddress . ("pay_" <>) . show <$> supply
 
-freshPoolAddress :: MonadSupply Integer m => m ModelAddress
+freshRewardAddress :: MonadSupply Integer m => m (ModelAddress era)
+freshRewardAddress = ModelAddress . ("reward_" <>) . show <$> supply
+
+freshPoolAddress :: MonadSupply Integer m => m (ModelAddress era)
 freshPoolAddress = ModelAddress . ("pool_" <>) . show <$> supply
 
 genTransactions
-  :: ( MonadGen m
+  :: forall era m.
+     ( MonadGen m
      , MonadState (TransactionState era) m
      , MonadSupply Integer m
+     , ValueFeature era ~ 'ExpectAdaOnly
+     , KnownScriptFeature (ScriptFeature era)
      )
   => Set Int -> ActionGraph -> m ()
 genTransactions actionIds actionGraph = do
@@ -333,7 +397,6 @@ genTransactions actionIds actionGraph = do
         case eOut of
           [] -> pure ()
           _:_ -> error "genTransactions: actionIds were not topsorted"
-        dependents <- uses (transactionState_txDependents . at i) (maybe mempty id)
         case action of
           -- Spends are the simplest. Since they represent an arbitrary exchange of inputs to outputs
           -- each spend action is its own transaction. Other actions must be merged into
@@ -347,39 +410,84 @@ genTransactions actionIds actionGraph = do
                 val <- choose (minFee, maxFee)
                 uncurry Map.singleton <$> generateUtxo val
             let myOutputs = Map.union depOutputs inertOutputs
-            let Sum sumMyOutputs = flip foldMap myOutputs $ \(ModelTxOut _ (ModelValue mv)) -> case mv of
+                Sum sumMyOutputs = flip foldMap myOutputs $ \(ModelTxOut _ (ModelValue mv) _) -> case mv of
                   ModelValue_Inject (Coin v) -> Sum v
                   _ -> error "genTransactions: utxo has abstract value"
             txId <- freshTxId
             -- Generate my fee and then ask my dependencies to cover my total outputs + fee
             myFee <- choose (minFee, maxFee)
-            let ins = [ aId | (Enables_Spending, aId) <- eIn ]
-            myInputs <- generateUtxosFor (sumMyOutputs + myFee) ins
+            let ins = [ (TransactionEnables_Spending, aId) | (ActionEnables_Spending, aId) <- eIn ]
+            -- Assert the action dependencies are well-formed
+            when (length ins /= length eIn) $ error "genTransactions: Spend action had non-spending dependencies"
+            myInputs <- generateUtxosFor (sumMyOutputs + myFee) (fmap snd ins)
             -- Tell my dependencies my transaction id
-            addDependent i txId eIn
+            dependents <- uses (transactionState_txDependents . at i) (maybe mempty id)
+            addDependent i txId ins
             -- Finally record the body of my transaction along with my dependents
             let newTx = ModelTx
                   { _mtxId = txId
+                  , _mtxCollateral = ifSupportsPlutus (Proxy @(ScriptFeature era)) () Set.empty
                   , _mtxInputs = myInputs
                   , _mtxOutputs = Map.toList myOutputs
                   , _mtxFee = ModelValue (ModelValue_Inject (Coin myFee))
                   , _mtxDCert = []
                   , _mtxWdrl = mempty
-                  , _mtxMint = undefined
+                  , _mtxMint = NoMintSupport ()
                   }
             transactionState_withDepsInEpoch . at epoch %= Just . Map.insert txId (newTx, dependents) .
               maybe mempty id
             pure ()
-          Action_Withdraw -> pure ()
+          -- Withdrawals are materialized in a similar way to spends. A withdrawal can live in its
+          -- own transaction, covering its own fees and UTxOs, but can also be part of a larger
+          -- spend that involves input UTxOs as well. TODO: Sometimes merge withdrawals into
+          -- other transactions instead of creating a new one.
+          Action_Withdraw -> do
+            depOutputs <- uses (transactionState_utxos . at i) (maybe mempty id)
+            myFee <- choose (minFee, maxFee)
+            -- We are going to generate an inert output with the abstract "leftover" reward value
+            let Sum sumMyOutputs = flip foldMap depOutputs $ \(ModelTxOut _ (ModelValue mv) _) -> case mv of
+                  ModelValue_Inject (Coin v) -> Sum v
+                  _ -> error "genTransactions: utxo has abstract value"
+            txId <- freshTxId
+            raddr <- generateRewardAddress
+            rutxo <- generateRewardsUtxo raddr (sumMyOutputs + myFee)
+            -- A withdrawal should only have one dependency, which enables withdrawal
+            ins <- case eIn of
+              [(ActionEnables_Withdrawing, aId)] -> pure [(TransactionEnables_Withdrawing raddr, aId)]
+              _ -> error "genTransactions: withdrawal has invalid dependencies"
+            -- Tell my dependencies my transaction id
+            dependents <- uses (transactionState_txDependents . at i) (maybe mempty id)
+            addDependent i txId ins
+            let newTx = ModelTx
+                  { _mtxId = txId
+                  , _mtxCollateral = ifSupportsPlutus (Proxy @(ScriptFeature era)) () Set.empty
+                  , _mtxInputs = mempty
+                  , _mtxOutputs = rutxo : Map.toList depOutputs
+                  , _mtxFee = ModelValue (ModelValue_Inject (Coin myFee))
+                  , _mtxDCert = []
+                  , _mtxWdrl = Map.singleton raddr (ModelValue (ModelValue_Var (ModelValue_Reward raddr)))
+                  , _mtxMint = NoMintSupport ()
+                  }
+            transactionState_withDepsInEpoch . at epoch %= Just . Map.insert txId (newTx, dependents) . maybe mempty id
+            pure ()
           Action_Delegate -> pure ()
           Action_RegisterStake -> pure ()
           Action_RegisterPool -> pure ()
         pure gr'
   pure ()
 
+-- TODO: Reuse reward addresses to simulate multiple epochs of rewards for the same stake
+generateRewardAddress
+  :: (MonadState (TransactionState era) m, MonadSupply Integer m)
+  => m (ModelAddress (ScriptFeature era))
+generateRewardAddress = do
+  raddr <- freshRewardAddress
+  transactionState_liveRewardAddresses %= (Set.insert raddr)
+  pure raddr
+
 generatePaymentAddress
   :: (MonadState (TransactionState era) m, MonadSupply Integer m, MonadGen m)
-  => m ModelAddress
+  => m (ModelAddress (ScriptFeature era))
 generatePaymentAddress = do
   paddrs <- use transactionState_livePaymentAddresses
   frequency $
@@ -387,8 +495,20 @@ generatePaymentAddress = do
     , (Set.size paddrs, elements (Set.toList paddrs))
     ]
 
+-- TODO: handle this more elegantly
+modelTxOut ::
+  forall era.
+  KnownScriptFeature (ScriptFeature era) =>
+  (ModelAddress (ScriptFeature era)) ->
+  (ModelValue (ValueFeature era) era) ->
+  ModelTxOut era
+modelTxOut x y = ModelTxOut x y
+  $ ifSupportsPlutus (Proxy @(ScriptFeature era)) () Nothing
+
+
 generateUtxosFor
-  :: (MonadState (TransactionState era) m, MonadSupply Integer m, MonadGen m)
+  :: (MonadState (TransactionState era) m, MonadSupply Integer m, MonadGen m,
+  KnownScriptFeature (ScriptFeature era))
   => Integer
   -> [Int] {- action ids -}
   -> m (Set ModelUTxOId)
@@ -404,29 +524,31 @@ generateUtxosFor totalValue = \case
       utxoId <- freshUtxoId
       amount <- choose (1, max 1 (valueLeft `div` 4)) -- TODO: Split up the value in a more sensible and robust way
       paddr <- generatePaymentAddress
-      let newUtxo = Map.singleton aId (Map.singleton utxoId (ModelTxOut paddr (ModelValue (ModelValue_Inject (Coin amount)))))
+      let newUtxo = Map.singleton aId (Map.singleton utxoId (modelTxOut paddr (ModelValue (ModelValue_Inject (Coin amount)))))
       pure (valueLeft - amount, Map.union newUtxo acc)
     xUtxos <- do
       utxoId <- freshUtxoId
       paddr <- generatePaymentAddress
       pure $ Map.singleton aId0 $ Map.singleton utxoId $
-        ModelTxOut paddr (ModelValue (ModelValue_Inject (Coin leftoverValue)))
+        modelTxOut paddr (ModelValue (ModelValue_Inject (Coin leftoverValue)))
     let allUtxos = Map.union newUtxos xUtxos
     transactionState_utxos %= Map.unionWith Map.union allUtxos
     pure $ mconcat $ fmap Map.keysSet $ Map.elems allUtxos
 
 generateUtxo
-  :: (MonadSupply Integer m, MonadState (TransactionState era) m, MonadGen m)
+  :: (MonadSupply Integer m, MonadState (TransactionState era) m, MonadGen m,
+  KnownScriptFeature (ScriptFeature era))
   => Integer
   -> m (ModelUTxOId, ModelTxOut era)
 generateUtxo value = do
   utxoId <- freshUtxoId
   paddr <- generatePaymentAddress
-  pure $ (utxoId, ModelTxOut paddr $ ModelValue (ModelValue_Inject (Coin value)))
+  pure $ (utxoId, modelTxOut paddr $ ModelValue (ModelValue_Inject (Coin value)))
 
 generateRewardsUtxo
-  :: (MonadSupply Integer m, MonadState (TransactionState era) m, MonadGen m)
-  => ModelAddress
+  :: (MonadSupply Integer m, MonadState (TransactionState era) m, MonadGen m,
+  KnownScriptFeature (ScriptFeature era))
+  => (ModelAddress (ScriptFeature era))
   -> Integer
   -> m (ModelUTxOId, ModelTxOut era)
 generateRewardsUtxo rewardAddr deficit = do
@@ -434,16 +556,16 @@ generateRewardsUtxo rewardAddr deficit = do
   paddr <- generatePaymentAddress
   pure $
     ( utxoId
-    , ModelTxOut paddr $ ModelValue $
+    , modelTxOut paddr $ ModelValue $
         ModelValue_Var (ModelValue_Reward rewardAddr) `ModelValue_Sub` ModelValue_Inject (Coin deficit)
     )
 
 -- When associating an action to a transaction id, add that transaction id to the set of dependents of all its enabling
--- depndencies
-addDependent :: MonadState (TransactionState era) m => Int -> ModelTxId -> [(Enables, Int)] -> m ()
+-- dependencies
+addDependent :: MonadState (TransactionState era) m => Int -> ModelTxId -> [(TransactionEnables era, Int)] -> m ()
 addDependent aId txId eIn = do
   let newDeps = Map.fromList $ flip fmap eIn $ \(enable, depId) -> (depId, Map.singleton txId (NES.singleton enable))
-  transactionState_txDependents %= Map.unionWith (Map.unionWith (<>)) newDeps . Map.delete aId
+  transactionState_txDependents %= Map.unionWith (Map.unionWith (<>)) newDeps
 
 -- Orphans
 instance MonadFail Gen where

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/DependGraph.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -112,7 +111,31 @@ data ActionState = ActionState
   }
   deriving (Eq, Ord, Show)
 
-makeLenses ''ActionState
+actionState_freshNames :: Lens' ActionState ([Int])
+actionState_freshNames a2fb s = (\b -> s {_actionState_freshNames = b}) <$> a2fb (_actionState_freshNames s)
+{-# INLINE actionState_freshNames #-}
+
+actionState_withDeps :: Lens' ActionState (Map Int (Int, Action, Map Int ActionEnables))
+actionState_withDeps a2fb s = (\b -> s {_actionState_withDeps = b}) <$> a2fb (_actionState_withDeps s)
+{-# INLINE actionState_withDeps #-}
+
+actionState_needsDelegate :: Lens' ActionState (Map Int (Set Int))
+actionState_needsDelegate a2fb s = (\b -> s {_actionState_needsDelegate = b}) <$> a2fb (_actionState_needsDelegate s)
+{-# INLINE actionState_needsDelegate #-}
+
+actionState_needsStake :: Lens' ActionState (Set Int)
+actionState_needsStake a2fb s = (\b -> s {_actionState_needsStake = b}) <$> a2fb (_actionState_needsStake s)
+{-# INLINE actionState_needsStake #-}
+
+actionState_needsPool :: Lens' ActionState (Set Int)
+actionState_needsPool a2fb s = (\b -> s {_actionState_needsPool = b}) <$> a2fb (_actionState_needsPool s)
+{-# INLINE actionState_needsPool #-}
+
+actionState_needsInputs :: Lens' ActionState (Set Int)
+actionState_needsInputs a2fb s = (\b -> s {_actionState_needsInputs = b}) <$> a2fb (_actionState_needsInputs s)
+{-# INLINE actionState_needsInputs #-}
+
+
 
 initialActionState :: ActionState
 initialActionState = ActionState [1 ..] mempty mempty mempty mempty mempty
@@ -332,7 +355,34 @@ data TransactionState era = TransactionState
   , _transactionState_withDepsInEpoch :: Map {- epoch -} Int (Map ModelTxId (ModelTx era, Map ModelTxId (NESet (TransactionEnables era))))
   }
 
-makeLenses ''TransactionState
+transactionState_freshNames :: Lens' (TransactionState era) ([Integer])
+transactionState_freshNames a2fb s = (\b -> s {_transactionState_freshNames = b}) <$> a2fb (_transactionState_freshNames s)
+{-# INLINE transactionState_freshNames #-}
+
+transactionState_livePaymentAddresses :: Lens' (TransactionState era) (Set (ModelAddress (ScriptFeature era)))
+transactionState_livePaymentAddresses a2fb s = (\b -> s {_transactionState_livePaymentAddresses = b}) <$> a2fb (_transactionState_livePaymentAddresses s)
+{-# INLINE transactionState_livePaymentAddresses #-}
+
+transactionState_liveRewardAddresses :: Lens' (TransactionState era) (Set (ModelAddress (ScriptFeature era)))
+transactionState_liveRewardAddresses a2fb s = (\b -> s {_transactionState_liveRewardAddresses = b}) <$> a2fb (_transactionState_liveRewardAddresses s)
+{-# INLINE transactionState_liveRewardAddresses #-}
+
+transactionState_utxos :: Lens' (TransactionState era) (Map Int {- action id -} (Map ModelUTxOId (ModelTxOut era)))
+transactionState_utxos a2fb s = (\b -> s {_transactionState_utxos = b}) <$> a2fb (_transactionState_utxos s)
+{-# INLINE transactionState_utxos #-}
+
+transactionState_txDependents :: Lens' (TransactionState era) (Map {- action id -} Int (Map ModelTxId (NESet (TransactionEnables era))))
+transactionState_txDependents a2fb s = (\b -> s {_transactionState_txDependents = b}) <$> a2fb (_transactionState_txDependents s)
+{-# INLINE transactionState_txDependents #-}
+
+transactionState_genesisUtxo :: Lens' (TransactionState era) ([(ModelUTxOId, (ModelAddress (ScriptFeature era)), Coin)])
+transactionState_genesisUtxo a2fb s = (\b -> s {_transactionState_genesisUtxo = b}) <$> a2fb (_transactionState_genesisUtxo s)
+{-# INLINE transactionState_genesisUtxo #-}
+
+transactionState_withDepsInEpoch :: Lens' (TransactionState era) (Map {- epoch -} Int (Map ModelTxId (ModelTx era, Map ModelTxId (NESet (TransactionEnables era)))))
+transactionState_withDepsInEpoch a2fb s = (\b -> s {_transactionState_withDepsInEpoch = b}) <$> a2fb (_transactionState_withDepsInEpoch s)
+{-# INLINE transactionState_withDepsInEpoch #-}
+
 
 initialTransactionState :: TransactionState era
 initialTransactionState = TransactionState

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators.hs
@@ -1,0 +1,1170 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Test.Cardano.Ledger.Elaborators where
+
+-- TODO use CPS'ed writer
+
+import qualified Cardano.Crypto.DSIGN.Class as DSIGN
+import qualified Cardano.Crypto.Hash.Class as Hash
+import qualified Cardano.Crypto.VRF.Class (VerKeyVRF)
+import Cardano.Ledger.Address
+import qualified Cardano.Ledger.Alonzo.Data as Alonzo
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import Cardano.Ledger.Alonzo.Tx (ScriptPurpose (..))
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential (Credential (..), StakeCredential, StakeReference (..))
+import qualified Cardano.Ledger.Crypto as C
+import Cardano.Ledger.Era
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Keys
+import Cardano.Ledger.Mary.Value (PolicyID (..))
+import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
+import Cardano.Ledger.Shelley.Constraints
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
+import qualified Cardano.Ledger.Val as Val
+import Cardano.Slotting.EpochInfo.API
+import Cardano.Slotting.Slot hiding (at)
+import Control.Lens
+import Control.Monad
+import qualified Control.Monad.Except as Except
+import Control.Monad.State (MonadState (..))
+import qualified Control.Monad.State.Class as State
+import Control.Monad.Trans.Class (lift)
+import qualified Control.Monad.Trans.State as State hiding (get, gets, state)
+import qualified Control.Monad.Writer as Writer
+import Data.Default.Class
+import Data.Foldable
+import Data.Function (on)
+import Data.Functor.Compose
+import qualified Data.Map as Map
+import Data.Proxy
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import Data.Traversable
+import Data.Tuple (swap)
+import Data.Typeable (Typeable)
+import Data.Void
+import Data.Word (Word64)
+import GHC.Records (HasField (..))
+import Numeric.Natural
+import qualified PlutusTx
+import Shelley.Spec.Ledger.API.Genesis
+import Shelley.Spec.Ledger.API.Mempool
+import Shelley.Spec.Ledger.API.Validation
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
+import Shelley.Spec.Ledger.Genesis
+import Shelley.Spec.Ledger.LedgerState (NewEpochState)
+import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.STS.EraMapping ()
+import qualified Shelley.Spec.Ledger.Tx as Shelley
+import Shelley.Spec.Ledger.TxBody
+  ( DCert (..),
+    DelegCert (..),
+    Delegation (..),
+    PoolCert (..),
+    PoolParams (..),
+  )
+import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import qualified Shelley.Spec.Ledger.UTxO as UTxO
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Script
+import Test.Cardano.Ledger.ModelChain.Value
+import Test.Shelley.Spec.Ledger.Generator.ScriptClass (mkKeyPairs)
+import Test.Shelley.Spec.Ledger.Utils (RawSeed (..), mkKeyPair, mkVRFKeyPair)
+import qualified Text.Show as Show
+
+data ExpectedValueTypeC era where
+  ExpectedValueTypeC_Simple ::
+    ( Core.Value era ~ Coin,
+      EraValueFeature era ~ 'ExpectAdaOnly
+    ) =>
+    ExpectedValueTypeC era
+  ExpectedValueTypeC_MA ::
+    ( ValueFromList (Core.Value era) (Crypto era),
+      EraValueFeature era ~ 'ExpectAnyOutput,
+      ValidateScript era
+    ) =>
+    ExpectedValueTypeC era
+
+newtype ElaboratedScriptsCache era = ElaboratedScriptsCache
+  {unElaboratedScriptsCache :: Map.Map (ScriptHash (Crypto era)) (Core.Script era)}
+
+instance Semigroup (ElaboratedScriptsCache era) where
+  ElaboratedScriptsCache a <> ElaboratedScriptsCache b = ElaboratedScriptsCache $ Map.unionWith const a b
+
+instance Monoid (ElaboratedScriptsCache era) where
+  mempty = ElaboratedScriptsCache Map.empty
+
+instance Show (ElaboratedScriptsCache era) where
+  showsPrec n (ElaboratedScriptsCache xs) =
+    Show.showParen (n >= 11) $
+      Show.showString "ElaboratedScriptsCache "
+        . showsPrec 11 (Map.keysSet xs)
+
+-- when creating outputs at "genesis", we know the txid's apriori; and recorde
+-- them immediately.  otherwise we don't know the txid's until we're done
+-- composing the txBody, and need a layer of indirection.
+type ModelTxId' c = Either (Shelley.TxIn c) (ModelTxId, Natural)
+
+data EraElaboratorState era = EraElaboratorState
+  { _eesUnusedKeyPairs :: Word64,
+    _eesKeys :: Map.Map (ModelAddress (EraScriptFeature era)) (TestAddrInfo era),
+    _eesPools :: Map.Map ModelPoolId (TestPoolKey era),
+    _eesTxIds :: Map.Map ModelTxId (Shelley.TxId (Crypto era)),
+    _eesCurrentEpoch :: EpochNo,
+    _eesUTxOs :: Map.Map ModelUTxOId (TestUTxOInfo era),
+    _eesCurrentSlot :: SlotNo,
+    _eesStakeCredentials :: Map.Map (StakeCredential (Crypto era)) (ModelAddress (EraScriptFeature era))
+  }
+
+deriving instance
+  (C.Crypto (Crypto era), Show (Core.Script era)) =>
+  Show (EraElaboratorState era)
+
+data TestUTxOInfo era = TestUTxOInfo
+  { _tuoi_txid :: ModelTxId' (Crypto era),
+    _tuoi_maddr :: ModelAddress (EraScriptFeature era),
+    _tuoi_data :: StrictMaybe (Alonzo.DataHash (Crypto era), (Alonzo.Data era))
+  }
+  deriving (Show)
+
+data EraElaboratorTxAccum era = EraElaboratorTxAccum
+  { _eesPendingWitnessKeys :: [KeyPair 'Witness (Crypto era)],
+    _eesScripts :: ElaboratedScriptsCache era,
+    _eesRedeemers :: [TestRedeemer era],
+    _eetaDats :: Alonzo.TxDats era
+  }
+
+instance Typeable era => Semigroup (EraElaboratorTxAccum era) where
+  EraElaboratorTxAccum a b c d <> EraElaboratorTxAccum a' b' c' d' =
+    EraElaboratorTxAccum
+      (a <> a')
+      (b <> b')
+      (c <> c')
+      (d <> d')
+
+instance Typeable era => Monoid (EraElaboratorTxAccum era) where
+  mempty = EraElaboratorTxAccum mempty mempty mempty mempty
+
+-- under normal circumstances, this arises during elaboration, at which time the
+-- era is already known
+data TestRedeemer era = TestRedeemer
+  { _trdmrPtr :: !(Alonzo.ScriptPurpose (Crypto era)),
+    _trdmData :: !PlutusTx.Data,
+    _trdmExUnits :: !ExUnits
+  }
+  deriving (Eq, Show)
+
+elaborateModelRedeemer ::
+  forall era.
+  ( HasField "inputs" (Core.TxBody era) (Set.Set (Shelley.TxIn (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Shelley.Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq.StrictSeq (DCert (Crypto era))),
+    HasField "minted" (Core.TxBody era) (Set.Set (ScriptHash (Crypto era)))
+  ) =>
+  Core.TxBody era ->
+  TestRedeemer era ->
+  StrictMaybe (Alonzo.RdmrPtr, (Alonzo.Data era, Alonzo.ExUnits))
+elaborateModelRedeemer tx (TestRedeemer scriptPurpose dat exUnits) =
+  (,) <$> (Alonzo.rdptr @era tx scriptPurpose) <*> pure (Alonzo.Data dat, exUnits)
+
+eesUnusedKeyPairs :: Functor f => (Word64 -> f Word64) -> EraElaboratorState era -> f (EraElaboratorState era)
+eesUnusedKeyPairs a2fb s = (\b -> s {_eesUnusedKeyPairs = b}) <$> a2fb (_eesUnusedKeyPairs s)
+
+eesKeys :: Lens' (EraElaboratorState era) (Map.Map (ModelAddress (ScriptFeature (EraFeatureSet era))) (TestAddrInfo era))
+eesKeys a2fb s = (\b -> s {_eesKeys = b}) <$> a2fb (_eesKeys s)
+
+eesPools :: Lens' (EraElaboratorState era) (Map.Map ModelPoolId (TestPoolKey era))
+eesPools a2fb s = (\b -> s {_eesPools = b}) <$> a2fb (_eesPools s)
+
+eesTxIds :: Functor f => (Map.Map ModelTxId (Shelley.TxId (Crypto era)) -> f (Map.Map ModelTxId (Shelley.TxId (Crypto era)))) -> EraElaboratorState era -> f (EraElaboratorState era)
+eesTxIds a2fb s = (\b -> s {_eesTxIds = b}) <$> a2fb (_eesTxIds s)
+
+eesCurrentEpoch :: Functor f => (EpochNo -> f EpochNo) -> EraElaboratorState era -> f (EraElaboratorState era)
+eesCurrentEpoch a2fb s = (\b -> s {_eesCurrentEpoch = b}) <$> a2fb (_eesCurrentEpoch s)
+
+eesStakeCredentials :: Lens' (EraElaboratorState era) (Map.Map (StakeCredential (Crypto era)) (ModelAddress (EraScriptFeature era)))
+eesStakeCredentials a2fb s = (\b -> s {_eesStakeCredentials = b}) <$> a2fb (_eesStakeCredentials s)
+
+eesUTxOs :: Lens' (EraElaboratorState era) (Map.Map ModelUTxOId (TestUTxOInfo era))
+eesUTxOs a2fb s = (\b -> s {_eesUTxOs = b}) <$> a2fb (_eesUTxOs s)
+
+eesCurrentSlot :: Lens' (EraElaboratorState era) SlotNo
+eesCurrentSlot a2fb s = (\b -> s {_eesCurrentSlot = b}) <$> a2fb (_eesCurrentSlot s)
+
+data TestAddrInfo era = TestAddrInfo
+  { _taiAddr :: Addr (Crypto era),
+    _taiPmt :: TestCredentialInfo 'Payment era,
+    _taiStk :: TestCredentialInfo 'Staking era
+  }
+
+deriving instance Eq (Core.Script era) => Eq (TestAddrInfo era)
+
+deriving instance Ord (Core.Script era) => Ord (TestAddrInfo era)
+
+deriving instance (C.Crypto (Crypto era), Show (Core.Script era)) => Show (TestAddrInfo era)
+
+data TestCredentialInfo k era = TestCredentialInfo
+  { _tciCred :: Credential k (Crypto era),
+    _tciKey :: TestKey k era
+  }
+
+deriving instance Eq (Core.Script era) => Eq (TestCredentialInfo k era)
+
+deriving instance Ord (Core.Script era) => Ord (TestCredentialInfo k era)
+
+deriving instance (C.Crypto (Crypto era), Show (Core.Script era)) => Show (TestCredentialInfo k era)
+
+data TestKey k era
+  = TestKey_Keyed (TestKeyKeyed k (Crypto era))
+  | TestKey_Script (TestKeyScript era)
+
+deriving instance Eq (Core.Script era) => Eq (TestKey k era)
+
+deriving instance Ord (Core.Script era) => Ord (TestKey k era)
+
+deriving instance (C.Crypto (Crypto era), Show (Core.Script era)) => Show (TestKey k era)
+
+data TestKeyKeyed (k :: KeyRole) c = TestKeyKeyed
+  { _tkkKeyPair :: KeyPair k c,
+    _tkkKeyHash :: KeyHash k c
+  }
+
+instance Eq (TestKeyKeyed k c) where (==) = (==) `on` _tkkKeyHash
+
+instance Ord (TestKeyKeyed k c) where compare = compare `on` _tkkKeyHash
+
+deriving instance C.Crypto c => Show (TestKeyKeyed k c)
+
+data TestKeyScript era = TestKeyScript (Core.Script era) (ScriptHash (Crypto era))
+
+deriving instance Eq (Core.Script era) => Eq (TestKeyScript era)
+
+deriving instance Ord (Core.Script era) => Ord (TestKeyScript era)
+
+deriving instance Show (Core.Script era) => Show (TestKeyScript era)
+
+elaborateModelAddress ::
+  forall era proxy.
+  ElaborateEraModel era =>
+  proxy era ->
+  Word64 ->
+  ModelAddress (EraScriptFeature era) ->
+  TestAddrInfo era
+elaborateModelAddress _ seed (ModelAddress _) =
+  let keyPair@(pmtKey, stakeKey) = mkKeyPairs @(Crypto era) seed
+      pmtHash = hashKey $ vKey pmtKey
+      stakeHash = hashKey $ vKey stakeKey
+   in TestAddrInfo
+        (toAddr Testnet keyPair)
+        (TestCredentialInfo (KeyHashObj pmtHash) (TestKey_Keyed $ TestKeyKeyed pmtKey pmtHash))
+        (TestCredentialInfo (KeyHashObj stakeHash) (TestKey_Keyed $ TestKeyKeyed stakeKey stakeHash))
+elaborateModelAddress proxy _ (ModelScriptAddress ms) =
+  let realPolicy = makePlutusScript proxy (SupportsPlutus $ elaborateModelScript ms)
+      pmtHash = hashScript @era realPolicy
+      stakeHash = hashScript @era realPolicy
+   in TestAddrInfo
+        (Addr Testnet (ScriptHashObj pmtHash) (StakeRefBase $ ScriptHashObj stakeHash))
+        (TestCredentialInfo (ScriptHashObj pmtHash) (TestKey_Script $ TestKeyScript realPolicy pmtHash))
+        (TestCredentialInfo (ScriptHashObj stakeHash) (TestKey_Script $ TestKeyScript realPolicy stakeHash))
+
+testStakeCredential ::
+  TestAddrInfo era ->
+  StakeCredential (Crypto era)
+testStakeCredential = _tciCred . _taiStk
+
+-- | get the TestKeyPair for a ModelAddress
+getKeyPairForImpl ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (TestAddrInfo era)
+getKeyPairForImpl proxy mAddr = do
+  st <- use id
+  case Map.lookup mAddr (_eesKeys st) of
+    Just k -> pure k
+    Nothing -> do
+      unusedKeyPairId <- eesUnusedKeyPairs <<%= succ
+      let k = elaborateModelAddress proxy unusedKeyPairId mAddr
+      eesKeys . at mAddr .= Just k
+      eesStakeCredentials . at (testStakeCredential k) .= Just mAddr
+      pure k
+
+getPmtKeyFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (TestKey 'Payment era)
+getPmtKeyFor proxy mAddr = _tciKey . _taiPmt <$> getKeyPairForImpl proxy mAddr
+
+getStakeKeyFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (TestKey 'Staking era)
+getStakeKeyFor proxy mAddr = _tciKey . _taiStk <$> getKeyPairForImpl proxy mAddr
+
+-- | get the Addr for a ModelAddress
+getAddrFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (Addr (Crypto era))
+getAddrFor proxy mAddr = _taiAddr <$> getKeyPairForImpl proxy mAddr
+
+-- | get the Addr for a ModelAddress
+getStakingKeyHashFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (KeyHash 'Staking (Crypto era))
+getStakingKeyHashFor proxy maddr =
+  let f (TestKey_Keyed (TestKeyKeyed _ k)) = k
+      f _ = error $ ("unexpected script address:" <> show maddr)
+   in f . _tciKey . _taiStk <$> getKeyPairForImpl proxy maddr
+
+data TestPoolKey era = TestPoolKey
+  { _tpkHash :: KeyHash 'StakePool (Crypto era),
+    _tpkVRFHash :: Hash.Hash (C.HASH (Crypto era)) (Cardano.Crypto.VRF.Class.VerKeyVRF (C.VRF (Crypto era))),
+    _tpkKey :: KeyPair 'StakePool (Crypto era)
+  }
+
+instance Eq (TestPoolKey era) where
+  a == b = compare a b == EQ
+
+instance Ord (TestPoolKey era) where
+  compare =
+    on compare _tpkHash
+      <> on compare _tpkVRFHash
+
+deriving instance (C.Crypto (Crypto era)) => Show (TestPoolKey era)
+
+getTestPoolKeyImpl ::
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelPoolId ->
+  m (TestPoolKey era)
+getTestPoolKeyImpl proxy poolId = do
+  st <- use id
+  case Map.lookup poolId (_eesPools st) of
+    Just k -> pure k
+    Nothing -> do
+      unusedKeyPairId <- eesUnusedKeyPairs <<%= succ
+      let k = elaboratePoolId proxy unusedKeyPairId poolId
+      eesPools . at poolId .= Just k
+      pure k
+
+elaboratePoolId ::
+  forall era proxy.
+  ( ElaborateEraModel era
+  ) =>
+  proxy era ->
+  Word64 ->
+  ModelPoolId ->
+  TestPoolKey era
+elaboratePoolId _ seed (ModelPoolId _) =
+  let {- vrf@ -}
+      (_, vrf') = mkVRFKeyPair @(C.VRF (Crypto era)) (RawSeed 1 0 0 0 seed)
+      poolKey@(KeyPair _ _) = uncurry KeyPair . swap . mkKeyPair @(Crypto era) $ RawSeed 1 1 0 0 seed
+      poolHash = hashKey $ vKey poolKey
+   in TestPoolKey
+        { _tpkHash = poolHash,
+          _tpkVRFHash = hashVerKeyVRF vrf',
+          _tpkKey = poolKey
+        }
+
+liftModelAddress ::
+  ModelAddress ('TyScriptFeature 'False 'False) ->
+  ModelAddress a
+liftModelAddress (ModelAddress a) = ModelAddress a
+
+-- | get the StakePool hash for a ModelAddress
+getScriptWitnessFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (KeyHash 'Witness (Crypto era))
+getScriptWitnessFor proxy maddr0 = case filterModelAddress (eraFeatureSet (Proxy @era)) maddr0 of
+  Nothing -> error $ "unexpectedly unupgradable address: " <> show maddr0
+  Just maddr ->
+    let f (TestKey_Keyed (TestKeyKeyed _ x)) = x
+        f (TestKey_Script _) = error $ "unexpected script addr in timelock" <> show maddr0
+     in coerceKeyRole @_ @_ @(Crypto era) . f . _tciKey . _taiPmt <$> getKeyPairForImpl proxy maddr
+
+-- | get the StakeCredential for a ModelAddress
+getStakeCredenetialFor ::
+  forall m era proxy.
+  ( MonadState (EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  ModelAddress (EraScriptFeature era) ->
+  m (StakeCredential (Crypto era))
+getStakeCredenetialFor proxy maddr = _tciCred . _taiStk <$> getKeyPairForImpl proxy maddr
+
+instance Default (EraElaboratorState era) where
+  def =
+    EraElaboratorState
+      { _eesUnusedKeyPairs = 1,
+        _eesKeys = Map.empty,
+        _eesPools = Map.empty,
+        _eesTxIds = Map.empty,
+        _eesCurrentEpoch = 0,
+        _eesCurrentSlot = 0,
+        _eesStakeCredentials = Map.empty,
+        _eesUTxOs = Map.empty
+      }
+
+tellMintWitness ::
+  ( ElaborateEraModel era,
+    MonadState (NewEpochState era, EraElaboratorState era) m
+  ) =>
+  proxy era ->
+  ModelScript (EraScriptFeature era) ->
+  ScriptHash (Crypto era) ->
+  Core.Script era ->
+  Writer.WriterT (EraElaboratorTxAccum era) m ()
+tellMintWitness _ modelPolicy policyHash realPolicy = do
+  Writer.tell $
+    mempty
+      { _eesScripts = ElaboratedScriptsCache $ Map.singleton policyHash realPolicy
+      }
+  myKeys :: [TestKey 'Payment era] <- case modelPolicy of
+    ModelScript_PlutusV1 _s1 ->
+      pure [TestKey_Script $ TestKeyScript realPolicy policyHash]
+    ModelScript_Timelock tl -> for (modelScriptNeededSigs tl) $ \mAddr -> do
+      State.state $ State.runState $ zoom _2 $ getPmtKeyFor (Proxy :: Proxy era) mAddr
+  for_ myKeys $ tellWitness (Minting $ PolicyID policyHash)
+
+noScriptAction ::
+  Applicative m =>
+  proxy era ->
+  ModelScript (EraScriptFeature era) ->
+  ScriptHash (Crypto era) ->
+  Core.Script era ->
+  m ()
+noScriptAction _ _ _ _ = pure ()
+
+lookupModelValue ::
+  forall era valF m.
+  ( Val.Val (ElaborateValueType valF (Crypto era)),
+    MonadState (NewEpochState era, EraElaboratorState era) m,
+    ElaborateEraModel era
+  ) =>
+  (Proxy era -> ModelScript (EraScriptFeature era) -> ScriptHash (Crypto era) -> Core.Script era -> m ()) ->
+  ModelValueVars (EraFeatureSet era) valF ->
+  m (ElaborateValueType valF (Crypto era))
+lookupModelValue scriptAction = \case
+  ModelValue_Reward maddr -> do
+    allRewards <- observeRewards <$> State.get
+    pure $ Val.inject $ maybe (Coin 0) id $ Map.lookup maddr allRewards
+  ModelValue_MA (Coin ad) x -> case reifyValueConstraint @era of
+    ExpectedValueTypeC_MA -> do
+      x' <- Writer.execWriterT $
+        ifor_ (Compose x) $ \(modelPolicy, assetName) qty -> do
+          realPolicy :: Core.Script era <- State.state $ elaborateScript modelPolicy
+          let policyHash = hashScript @era realPolicy
+          lift $ scriptAction (Proxy @era) modelPolicy policyHash realPolicy
+
+          Writer.tell $ [(PolicyID policyHash, assetName, qty)]
+      pure $ valueFromList ad x'
+
+mkTxOut ::
+  forall m era.
+  ( MonadState (NewEpochState era, EraElaboratorState era) m,
+    Except.MonadError (ElaborateBlockError era) m,
+    Era era,
+    UsesTxOut era,
+    ElaborateEraModel era
+  ) =>
+  ModelTxId ->
+  Natural ->
+  ModelUTxOId ->
+  ModelTxOut (EraFeatureSet era) ->
+  m (Core.TxOut era)
+mkTxOut mtxId idx mutxoId (ModelTxOut mAddr (ModelValue mValue) mDat) = (=<<) Except.liftEither $
+  State.state $
+    State.runState $
+      Except.runExceptT $ do
+        addr <- zoom _2 $ getAddrFor (Proxy :: Proxy era) mAddr
+        val :: Core.Value era <- either (Except.throwError . ElaborateBlockError_TxValue @era) pure =<< evalModelValue (lookupModelValue noScriptAction) mValue
+        let txo = makeTxOut (Proxy :: Proxy era) addr val
+            (dat, txo') = case mDat of
+              NoPlutusSupport () -> (SNothing, txo)
+              SupportsPlutus Nothing -> (SNothing, txo)
+              SupportsPlutus (Just dat') ->
+                let d = Alonzo.Data dat'
+                    dh = (Alonzo.hashData @era $ d)
+                 in (SJust (dh, d), makeExtendedTxOut (Proxy @era) txo $ SupportsPlutus dh)
+        _2 . eesUTxOs . at mutxoId .= Just (TestUTxOInfo (Right (mtxId, idx)) mAddr dat)
+        pure txo'
+
+mkTxIn ::
+  forall m era.
+  ( MonadState (EraElaboratorState era) m,
+    Writer.MonadWriter (EraElaboratorTxAccum era) m,
+    ElaborateEraModel era
+  ) =>
+  ModelTxIn ->
+  m (Set.Set (Shelley.TxIn (Crypto era)))
+mkTxIn moid = do
+  ses <- use id
+  mutxo <- use $ eesUTxOs . at moid
+  case mutxo of
+    -- TODO: handle missing txnIds more gracefully?
+    Nothing -> pure mempty
+    Just (TestUTxOInfo mutxo' mAddr mDat) -> do
+      myKeys <- getPmtKeyFor (Proxy :: Proxy era) mAddr
+
+      for_ mDat $ \(k, v) ->
+        Writer.tell $
+          mempty
+            { _eetaDats = Alonzo.TxDats $ Map.singleton k v
+            }
+
+      txins <- case mutxo' of
+        Left txin -> pure (Set.singleton txin)
+        Right (mtxId, idx) ->
+          pure . maybe Set.empty Set.singleton $ Shelley.TxIn <$> Map.lookup mtxId (_eesTxIds ses) <*> pure idx
+      for_ txins $ \txin -> tellWitness (Spending txin) myKeys
+      pure txins
+
+tellWitnessKey ::
+  forall kr m era.
+  Writer.MonadWriter (EraElaboratorTxAccum era) m =>
+  KeyPair kr (Crypto era) ->
+  m ()
+tellWitnessKey keyP = do
+  Writer.tell $
+    mempty
+      { _eesPendingWitnessKeys = [coerceKeyRole @_ @_ @(Crypto era) keyP]
+      }
+
+-- | accumulate a witness while elaborating a ModelTx.
+tellWitness ::
+  forall kr m era.
+  Writer.MonadWriter (EraElaboratorTxAccum era) m =>
+  ScriptPurpose (Crypto era) ->
+  TestKey kr era ->
+  m ()
+tellWitness _ (TestKey_Keyed (TestKeyKeyed keyP _)) = tellWitnessKey keyP
+tellWitness sp (TestKey_Script (TestKeyScript realPolicy policyHash)) = do
+  Writer.tell $
+    mempty
+      { _eesRedeemers = pure $ TestRedeemer sp (PlutusTx.I 1) (ExUnits 10 10),
+        _eesScripts = ElaboratedScriptsCache $ Map.singleton policyHash realPolicy
+      }
+
+-- | return all accumulated witnesses.
+elaborateWitnesses ::
+  forall kr proxy era.
+  ( DSIGN.Signable (C.DSIGN (Crypto era)) (Hash.Hash (C.HASH (Crypto era)) Shelley.EraIndependentTxBody),
+    C.Crypto (Crypto era)
+  ) =>
+  proxy era ->
+  [KeyPair kr (Crypto era)] ->
+  SafeHash (Crypto era) Shelley.EraIndependentTxBody ->
+  (Set.Set (Shelley.WitVKey 'Witness (Crypto era)))
+elaborateWitnesses _ witness bodyHash = flip foldMap witness $ \keyP ->
+  Set.singleton $ UTxO.makeWitnessVKey bodyHash keyP
+
+-- | lens to focus the ledger state from that used by ApplyBlock to that used by
+-- ApplyTx
+mempoolState :: Functor f => (MempoolState era -> f (MempoolState era)) -> (NewEpochState era -> f (NewEpochState era))
+mempoolState = \a2b s ->
+  let nesEs = LedgerState.nesEs s
+      esLState = LedgerState.esLState nesEs
+
+      mkNES (utxoState, delegationState) =
+        s
+          { LedgerState.nesEs =
+              nesEs
+                { LedgerState.esLState =
+                    esLState
+                      { LedgerState._utxoState = utxoState,
+                        LedgerState._delegationState = delegationState
+                      }
+                }
+          }
+   in mkNES <$> a2b (mkMempoolState s)
+{-# INLINE mempoolState #-}
+
+data ElaborateBlockError era
+  = ElaborateBlockError_ApplyTx (ApplyTxError era)
+  | ElaborateBlockError_Fee (ModelValueError Coin)
+  | ElaborateBlockError_TxValue (ModelValueError (Core.Value era))
+
+deriving instance
+  ( Show (ApplyTxError era),
+    Show (Core.Value era)
+  ) =>
+  Show (ElaborateBlockError era)
+
+data TxBodyArguments era = TxBodyArguments
+  { -- | ttl
+    _txBodyArguments_ttl :: !SlotNo,
+    -- | fee
+    _txBodyArguments_fee :: !Coin,
+    -- | inputs
+    _txBodyArguments_inputs :: !(Set.Set (Shelley.TxIn (Crypto era))),
+    -- | outputs
+    _txBodyArguments_outputs :: !(StrictSeq.StrictSeq (Core.TxOut era)),
+    -- | Deleg certs.
+    _txBodyArguments_delegCerts :: !(StrictSeq.StrictSeq (DCert (Crypto era))),
+    -- | withdrawals
+    _txBodyArguments_withdrawals :: !(Shelley.Wdrl (Crypto era)),
+    -- | mint
+    _txBodyArguments_mint :: !(IfSupportsMint () (Core.Value era) (EraValueFeature era)),
+    _txBodyArguments_redeemers :: !(IfSupportsPlutus () (StrictMaybe (Alonzo.Redeemers era, Alonzo.TxDats era)) (EraScriptFeature era)),
+    -- | collateral
+    _txBodyArguments_collateral :: !(IfSupportsPlutus () (Set.Set (Shelley.TxIn (Crypto era))) (EraScriptFeature era))
+  }
+
+data TxWitnessArguments era = TxWitnessArguments
+  { _txWitnessArguments_vkey :: !(Set.Set (Shelley.WitVKey 'Witness (Crypto era))),
+    _txWitnessArguments_scripts ::
+      !( IfSupportsScript
+           ()
+           (Map.Map (ScriptHash (Crypto era)) (Core.Script era))
+           (EraScriptFeature era)
+       ),
+    _txWitnessArguments_redeemers ::
+      !( IfSupportsPlutus
+           ()
+           (Alonzo.Redeemers era, Alonzo.TxDats era)
+           (EraScriptFeature era)
+       )
+  }
+
+mkTxWitnessArguments ::
+  forall era m.
+  ( Monad m,
+    C.Crypto (Crypto era),
+    ElaborateEraModel era,
+    HasField "certs" (Core.TxBody era) (StrictSeq.StrictSeq (DCert (Crypto era))),
+    HasField "inputs" (Core.TxBody era) (Set.Set (Shelley.TxIn (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Shelley.Wdrl (Crypto era)),
+    DSIGN.Signable (C.DSIGN (Crypto era)) (Hash.Hash (C.HASH (Crypto era)) Shelley.EraIndependentTxBody)
+  ) =>
+  NewEpochState era ->
+  EraElaboratorTxAccum era ->
+  TxBodyArguments era ->
+  m (Core.TxBody era, TxWitnessArguments era)
+mkTxWitnessArguments nes (EraElaboratorTxAccum pendingWits (ElaboratedScriptsCache pendingScripts) pendingRedeemers pendingDats) txBodyArguments = do
+  let fakeTxBody = makeTxBody @era nes $ txBodyArguments
+  redeemers <- case reifySupportsPlutus (Proxy @(EraScriptFeature era)) of
+    NoPlutusSupport () -> pure (NoPlutusSupport ())
+    SupportsPlutus () -> do
+      case traverse (elaborateModelRedeemer fakeTxBody) pendingRedeemers of
+        SNothing -> error "cant elaborate ptr"
+        SJust xs -> do
+          let redeemers = Alonzo.Redeemers $ Map.fromList xs
+          pure (SupportsPlutus (redeemers, pendingDats))
+  let bodyHash = hashAnnotated realTxBody
+      realTxBody = case redeemers of
+        SupportsPlutus (r, _)
+          | not (Alonzo.nullRedeemers r) ->
+            makeTxBody @era nes $
+              txBodyArguments
+                { _txBodyArguments_redeemers = mapSupportsPlutus SJust redeemers
+                }
+          | otherwise -> fakeTxBody
+        NoPlutusSupport () -> fakeTxBody
+      witVKey = elaborateWitnesses (Proxy :: Proxy era) pendingWits bodyHash
+
+      scripts :: IfSupportsScript () (Map.Map (ScriptHash (Crypto era)) (Core.Script era)) (EraScriptFeature era)
+      scripts = case reifyScriptFeature (Proxy @(EraScriptFeature era)) of
+        ScriptFeatureTag_None -> NoScriptSupport ()
+        tag@ScriptFeatureTag_Simple -> SupportsScript tag pendingScripts
+        tag@ScriptFeatureTag_PlutusV1 -> SupportsScript tag pendingScripts
+
+  pure $
+    (,) realTxBody $
+      TxWitnessArguments
+        { _txWitnessArguments_vkey = witVKey,
+          _txWitnessArguments_scripts = scripts,
+          _txWitnessArguments_redeemers = redeemers
+        }
+
+type EraValueFeature era = ValueFeature (EraFeatureSet era)
+
+type EraScriptFeature era = ScriptFeature (EraFeatureSet era)
+
+class
+  ( ElaborateValueType (EraValueFeature era) (Crypto era) ~ Core.Value era,
+    KnownRequiredFeatures (EraFeatureSet era),
+    ValidateScript era
+  ) =>
+  ElaborateEraModel era
+  where
+  type EraFeatureSet era :: FeatureSet
+  eraFeatureSet :: proxy era -> FeatureTag (EraFeatureSet era)
+
+  reifyValueConstraint ::
+    ExpectedValueTypeC era
+
+  -- | Apply a ModelBlock to a specific era's ledger.
+  elaborateBlock ::
+    Globals ->
+    ModelBlock (EraFeatureSet era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( Either (ElaborateBlockError era) (),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  default elaborateBlock ::
+    ( ApplyBlock era,
+      ApplyTx era
+    ) =>
+    Globals ->
+    ModelBlock (EraFeatureSet era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( Either (ElaborateBlockError era) (),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  elaborateBlock globals =
+    State.runState . Except.runExceptT . \case
+      ModelBlock mslot mtxSeq -> do
+        currentEpoch <- use $ _2 . eesCurrentEpoch
+        let slot = runIdentity (epochInfoFirst ei currentEpoch) + mslot
+            ei = epochInfo globals
+            ttl = succ slot
+
+        unless (currentEpoch == runIdentity (epochInfoEpoch ei slot)) $ error $ "model slot out of range: " <> show mslot
+        _2 . eesCurrentSlot .= slot
+        -- tick the model
+        lift $ zoom _1 $ State.state $ \nes0 -> ((), applyTick globals nes0 slot)
+        txSeq ::
+          [Core.Tx era] <-
+          for mtxSeq $ \tx -> Except.ExceptT $ State.state $ elaborateTx (Proxy :: Proxy era) globals ttl tx
+
+        mempoolEnv <- (\(nes0, _) -> mkMempoolEnv nes0 slot) <$> get
+
+        -- apply the transactions.
+        for_ txSeq $ \tx -> do
+          (nes0, ems) <- get
+          (mps', _) <- liftApplyTxError $ applyTx globals mempoolEnv (view mempoolState nes0) tx
+
+          let nes1 = set mempoolState mps' nes0
+          put (nes1, ems)
+
+        pure ()
+
+  -- | get a NewEpochState from genesis conditions.
+  elaborateInitialState ::
+    ShelleyGenesis era ->
+    AdditionalGenesisConfig era ->
+    -- | Initial coins present at time of genesis.  Each address will have its full balance in a single UTxO from a single "transaction"
+    [(ModelUTxOId, ModelAddress (EraScriptFeature era), Coin)] ->
+    EraElaboratorState era ->
+    ( NewEpochState era,
+      EraElaboratorState era
+    )
+  default elaborateInitialState ::
+    ( CanStartFromGenesis era
+    ) =>
+    ShelleyGenesis era ->
+    AdditionalGenesisConfig era ->
+    [(ModelUTxOId, ModelAddress (EraScriptFeature era), Coin)] ->
+    EraElaboratorState era ->
+    ( NewEpochState era,
+      EraElaboratorState era
+    )
+  elaborateInitialState sg additionalGenesesConfig genesisAccounts = State.runState $ do
+    utxo0 <- fmap Map.fromList $
+      for genesisAccounts $ \(oid, mAddr, coins) -> do
+        addr <- getAddrFor (Proxy :: Proxy era) mAddr
+        eesUTxOs . at oid .= Just (TestUTxOInfo (Left (initialFundsPseudoTxIn addr)) mAddr SNothing)
+        pure (addr, coins)
+
+    pure $ initialState sg {sgInitialFunds = Map.unionWith const utxo0 $ sgInitialFunds sg} additionalGenesesConfig
+
+  makeTimelockScript ::
+    proxy era ->
+    IfSupportsTimelock Void (Timelock (Crypto era)) (EraScriptFeature era) ->
+    Core.Script era
+
+  makePlutusScript ::
+    proxy era ->
+    IfSupportsPlutus Void (Alonzo.Script era) (EraScriptFeature era) ->
+    Core.Script era
+
+  makeExtendedTxOut ::
+    proxy era ->
+    Core.TxOut era ->
+    IfSupportsPlutus Void (Alonzo.DataHash (Crypto era)) (EraScriptFeature era) ->
+    Core.TxOut era
+
+  elaborateScript ::
+    ModelScript (EraScriptFeature era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( (Core.Script era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  default elaborateScript ::
+    ModelScript (EraScriptFeature era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( (Core.Script era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  elaborateScript ms0 = State.runState $ case ms0 of
+    ModelScript_PlutusV1 ms ->
+      pure $ makePlutusScript (Proxy :: Proxy era) (SupportsPlutus $ elaborateModelScript ms)
+    ModelScript_Timelock ms -> do
+      x <- elaborateModelTimelock (zoom _2 . getScriptWitnessFor (Proxy :: Proxy era) . liftModelAddress) ms
+      pure $ makeTimelockScript (Proxy :: Proxy era) $ SupportsTimelock x
+
+  -- | Construct a TxBody from some elaborated inputs.
+  makeTxBody ::
+    NewEpochState era ->
+    TxBodyArguments era ->
+    Core.TxBody era
+
+  -- | apply a single Model transaction to a specific eras ledger
+  elaborateTx ::
+    proxy era ->
+    Globals ->
+    -- | ttl
+    SlotNo ->
+    ModelTx (EraFeatureSet era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( Either (ElaborateBlockError era) (Core.Tx era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  default elaborateTx ::
+    ( DSIGN.Signable (C.DSIGN (Crypto era)) (Hash.Hash (C.HASH (Crypto era)) Shelley.EraIndependentTxBody),
+      UsesTxOut era,
+      HasField "inputs" (Core.TxBody era) (Set.Set (Shelley.TxIn (Crypto era))),
+      HasField "wdrls" (Core.TxBody era) (Shelley.Wdrl (Crypto era)),
+      HasField "certs" (Core.TxBody era) (StrictSeq.StrictSeq (DCert (Crypto era)))
+    ) =>
+    proxy era ->
+    Globals ->
+    SlotNo ->
+    ModelTx (EraFeatureSet era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( Either (ElaborateBlockError era) (Core.Tx era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  elaborateTx proxy _ maxTTL (ModelTx mtxId mtxInputs mtxOutputs (ModelValue mtxFee) mtxDCert mtxWdrl mtxMint mtxCollateral) = State.runState $
+    Except.runExceptT $ do
+      (txBodyArguments, txAccum) <- Writer.runWriterT $ do
+        let liftEvalModelValue ::
+              forall e a.
+              (e -> ElaborateBlockError era) ->
+              Writer.WriterT (EraElaboratorTxAccum era) (State.State (NewEpochState era, EraElaboratorState era)) (Either e a) ->
+              Writer.WriterT
+                (EraElaboratorTxAccum era)
+                ( Except.ExceptT
+                    (ElaborateBlockError era)
+                    (State.State (NewEpochState era, EraElaboratorState era))
+                )
+                a
+            liftEvalModelValue onErr xs =
+              Writer.WriterT $
+                Except.ExceptT $
+                  fmap (\(x, y) -> either (Left . onErr) (Right . (,y)) x) $
+                    Writer.runWriterT $
+                      xs
+
+        outs <- ifor mtxOutputs $ \idx (oid, o) -> mkTxOut mtxId (toEnum @Natural idx) oid o
+        ins :: Set.Set (Shelley.TxIn (Crypto era)) <- zoom _2 $ fmap fold $ traverse mkTxIn $ Set.toList mtxInputs
+        cins <- traverseSupportsPlutus (zoom _2 . fmap fold . traverse mkTxIn . Set.toList) mtxCollateral
+        dcerts <- traverse (mkDCerts (Proxy :: Proxy era)) mtxDCert
+        wdrl :: Map.Map (RewardAcnt (Crypto era)) Coin <-
+          fmap Map.fromList $
+            for (Map.toList mtxWdrl) $ \(mAddr, ModelValue mqty) -> do
+              stakeCredential <- zoom _2 $ getStakeCredenetialFor proxy mAddr
+              stakeKey <- zoom _2 $ getStakeKeyFor proxy mAddr
+              let ra = RewardAcnt Testnet stakeCredential
+              tellWitness (Rewarding ra) stakeKey
+              qty <- liftEvalModelValue ElaborateBlockError_Fee $ evalModelValue (lookupModelValue noScriptAction) mqty
+              pure (ra, qty)
+        fee :: Coin <-
+          liftEvalModelValue ElaborateBlockError_Fee $
+            evalModelValue (lookupModelValue noScriptAction) mtxFee
+
+        mint ::
+          IfSupportsMint () (Core.Value era) (EraValueFeature era) <-
+          case reifyValueConstraint @era of
+            ExpectedValueTypeC_Simple -> pure $ NoMintSupport ()
+            ExpectedValueTypeC_MA -> case mtxMint of
+              SupportsMint m' ->
+                fmap SupportsMint $
+                  liftEvalModelValue ElaborateBlockError_TxValue $
+                    evalModelValue (lookupModelValue (tellMintWitness @era)) (unModelValue m')
+
+        pure $
+          TxBodyArguments
+            { _txBodyArguments_ttl = maxTTL,
+              _txBodyArguments_fee = fee,
+              _txBodyArguments_inputs = ins,
+              _txBodyArguments_outputs = StrictSeq.fromList outs,
+              _txBodyArguments_delegCerts = StrictSeq.fromList dcerts,
+              _txBodyArguments_withdrawals = Shelley.Wdrl wdrl,
+              _txBodyArguments_mint = mint,
+              _txBodyArguments_redeemers = ifSupportsPlutus (Proxy @(EraScriptFeature era)) () SNothing,
+              _txBodyArguments_collateral = cins
+            }
+
+      nes <- State.gets fst
+      (realTxBody, txWitnessArguments) <- mkTxWitnessArguments nes txAccum txBodyArguments
+
+      _2 . eesTxIds . at mtxId .= Just (UTxO.txid @era realTxBody)
+      pure $ makeTx proxy realTxBody txWitnessArguments
+
+  -- | build a full tx from TxBody and set of witnesses.
+  makeTx ::
+    proxy era ->
+    Core.TxBody era ->
+    TxWitnessArguments era ->
+    Core.Tx era
+
+  -- | convert an expeced failure by the model to the concrete error that will
+  -- be produced.
+  toEraPredicateFailure ::
+    ModelPredicateFailure (EraFeatureSet era) ->
+    (NewEpochState era, EraElaboratorState era) ->
+    Either (ModelValueError (Core.Value era)) (ApplyBlockTransitionError era)
+
+  -- | apply the model New Epoch event to a specific eras ledger
+  elaborateBlocksMade ::
+    Globals ->
+    ModelBlocksMade ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( BlocksMade (Crypto era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  default elaborateBlocksMade ::
+    ApplyBlock era =>
+    Globals ->
+    ModelBlocksMade ->
+    (NewEpochState era, EraElaboratorState era) ->
+    ( BlocksMade (Crypto era),
+      (NewEpochState era, EraElaboratorState era)
+    )
+  elaborateBlocksMade globals (ModelBlocksMade mblocksMadeWeights) = State.runState $ do
+    prevEpoch <- use $ _2 . eesCurrentEpoch
+    epoch <- _2 . eesCurrentEpoch <%= succ
+    let ei = epochInfo globals
+        slotsInEpoch = runIdentity $ epochInfoSize ei prevEpoch
+
+    let mblocksMade = repartition (fromIntegral slotsInEpoch) mblocksMadeWeights
+    bs <- for (Map.toList mblocksMade) $ \(maddr, n) -> do
+      poolKey <- zoom _2 $ _tpkHash <$> getTestPoolKeyImpl (Proxy :: Proxy era) maddr
+      pure (poolKey, n)
+
+    let bs' = BlocksMade $ Map.fromList bs
+    _1 %= emulateBlocksMade bs'
+
+    let firstOfNew = runIdentity $ epochInfoFirst ei epoch
+
+        neededSlot =
+          SlotNo (randomnessStabilisationWindow globals)
+            + runIdentity (epochInfoFirst ei prevEpoch)
+
+    currentSlot <- _2 . eesCurrentSlot <<.= firstOfNew
+
+    unless (currentSlot > neededSlot) $
+      zoom _1 $ State.state $ \nes0 -> ((), applyTick globals nes0 (neededSlot + 1))
+    zoom _1 $ State.state $ \nes0 -> ((), applyTick globals nes0 firstOfNew)
+
+    pure bs'
+
+  -- | convert a model deleg certificate to a real DCert
+  elaborateDCert ::
+    proxy era ->
+    ModelDCert (EraFeatureSet era) ->
+    EraElaboratorState era ->
+    ((DCert (Crypto era), EraElaboratorTxAccum era), EraElaboratorState era)
+  default elaborateDCert ::
+    proxy era ->
+    ModelDCert (EraFeatureSet era) ->
+    EraElaboratorState era ->
+    ((DCert (Crypto era), EraElaboratorTxAccum era), EraElaboratorState era)
+  elaborateDCert proxy mdc = State.runState . Writer.runWriterT $ do
+    (dc, dcwits) <- Writer.runWriterT $ case mdc of
+      ModelRegisterStake maddr ->
+        DCertDeleg . RegKey
+          <$> getStakeCredenetialFor proxy maddr
+      ModelDeRegisterStake maddr ->
+        DCertDeleg . DeRegKey
+          <$> getStakeCredenetialFor proxy maddr
+      ModelDelegate (ModelDelegation mdelegator mdelegatee) -> do
+        dtor <- getStakeCredenetialFor proxy mdelegator
+        dtee <- _tpkHash <$> getTestPoolKeyImpl proxy mdelegatee
+        stakeKey <- getStakeKeyFor proxy mdelegator
+        Writer.tell [stakeKey]
+        pure $ (DCertDeleg . Delegate) $ Delegation dtor dtee
+      ModelRegisterPool (ModelPoolParams mPoolId pledge cost margin mRAcnt mOwners) -> do
+        TestPoolKey poolId poolVRF poolKey <- getTestPoolKeyImpl proxy mPoolId
+        lift $ tellWitnessKey poolKey
+        poolOwners <- Set.fromList <$> traverse (getStakingKeyHashFor proxy) mOwners
+        for_ mOwners $ Writer.tell . pure <=< getStakeKeyFor proxy
+        rAcnt <- RewardAcnt Testnet <$> getStakeCredenetialFor proxy mRAcnt
+        pure $
+          (DCertPool . RegPool) $
+            PoolParams
+              { _poolId = poolId,
+                _poolVrf = poolVRF,
+                _poolPledge = pledge,
+                _poolCost = cost,
+                _poolMargin = margin,
+                _poolRAcnt = rAcnt,
+                _poolOwners = poolOwners,
+                _poolRelays = StrictSeq.empty,
+                _poolMD = SNothing
+              }
+      ModelRetirePool maddr epochNo -> do
+        TestPoolKey pool _ _ <- getTestPoolKeyImpl proxy maddr
+        pure $ DCertPool $ RetirePool pool epochNo
+    for_ dcwits $ tellWitness (Certifying dc)
+    pure dc
+
+-- TODO: maybe useful someday
+-- ModelMIRCert srcPot mRewards ->
+--   fmap ( DCertMir . Shelley.MIRCert srcPot . Shelley.StakeAddressesMIR . Map.fromList) $
+--   for (Map.toList mRewards) $ \(maddr, reward) -> (,)
+--     <$> getStakeCredenetialFor proxy maddr
+--     <*> pure reward
+
+class AsApplyTxError era e | e -> era where
+  asApplyTxError :: Prism' e (ApplyTxError era)
+
+instance AsApplyTxError era (ApplyTxError era) where asApplyTxError = id
+
+instance AsApplyTxError era (ElaborateBlockError era) where
+  asApplyTxError = prism ElaborateBlockError_ApplyTx $ \case
+    ElaborateBlockError_ApplyTx x -> Right x
+    x -> Left x
+
+liftApplyTxError ::
+  (Except.MonadError e m, AsApplyTxError era e) =>
+  Except.Except (ApplyTxError era) a ->
+  m a
+liftApplyTxError = either (Except.throwError . review asApplyTxError) pure . Except.runExcept
+
+mkDCerts ::
+  (ElaborateEraModel era) =>
+  proxy era ->
+  ModelDCert (EraFeatureSet era) ->
+  Writer.WriterT
+    (EraElaboratorTxAccum era)
+    ( Except.ExceptT
+        (ElaborateBlockError era)
+        ( State.StateT
+            (NewEpochState era, EraElaboratorState era)
+            Identity
+        )
+    )
+    (DCert (Crypto era))
+mkDCerts proxy x = Writer.WriterT . lift . zoom _2 . State.state $ elaborateDCert proxy x
+
+-- | simulate blocks made in the current epoch.  this functions like ApplyBlock or
+-- ApplyTx, but without presenting real blocks to the ledger.  This is only
+-- useful in testing the correctness of specific aspects of the ledger rather
+-- than in normal use.
+emulateBlocksMade ::
+  forall era.
+  BlocksMade (Crypto era) ->
+  NewEpochState era ->
+  NewEpochState era
+emulateBlocksMade (BlocksMade newBlocksMade) nes@(LedgerState.NewEpochState {LedgerState.nesBcur = BlocksMade currentBlocksMade}) =
+  nes {LedgerState.nesBcur = BlocksMade (Map.unionWith (+) newBlocksMade currentBlocksMade)}
+
+-- | apply several epochs full of blocks to a ledger
+elaborateBlocks_ ::
+  forall era.
+  (ElaborateEraModel era) =>
+  Globals ->
+  [ModelEpoch (EraFeatureSet era)] ->
+  (NewEpochState era, EraElaboratorState era) ->
+  ( Either (ElaborateBlockError era) (),
+    (NewEpochState era, EraElaboratorState era)
+  )
+elaborateBlocks_ globals = State.runState . Except.runExceptT . traverse_ f
+  where
+    f (ModelEpoch blocks blocksMade) = do
+      for_ blocks (Except.ExceptT . State.state . elaborateBlock globals)
+      _ :: BlocksMade (Crypto era) <- lift $ State.state $ elaborateBlocksMade globals blocksMade
+      pure ()
+
+-- | get the current balance of rewards in terms of the model addresses that can
+-- spend them.
+observeRewards ::
+  forall era.
+  (NewEpochState era, EraElaboratorState era) ->
+  Map.Map (ModelAddress (EraScriptFeature era)) Coin
+observeRewards (nes, ems) =
+  let creds = _eesStakeCredentials ems
+   in Map.fromList $ do
+        (a, b) <- Map.toList . LedgerState._rewards . LedgerState._dstate . LedgerState._delegationState . LedgerState.esLState $ LedgerState.nesEs nes
+        a' <- case Map.lookup a creds of
+          Just a' -> pure a'
+          Nothing -> error $ "observeRewards: can't find " <> show a
+        pure (a', b)
+
+data ApplyBlockTransitionError era
+  = ApplyBlockTransitionError_Tx (ApplyTxError era)
+
+deriving instance
+  ( Show (ApplyTxError era)
+  ) =>
+  Show (ApplyBlockTransitionError era)
+
+deriving instance
+  ( Eq (ApplyTxError era)
+  ) =>
+  Eq (ApplyBlockTransitionError era)
+
+deriving instance
+  ( Ord (ApplyTxError era)
+  ) =>
+  Ord (ApplyBlockTransitionError era)

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators/Alonzo.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators/Alonzo.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fmax-relevant-binds=0 #-}
+
+module Test.Cardano.Ledger.Elaborators.Alonzo where
+
+import qualified Cardano.Crypto.DSIGN.Class as DSIGN
+import qualified Cardano.Crypto.KES.Class as KES
+import Cardano.Crypto.Util (SignableRepresentation)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.Rules.Utxo
+import Cardano.Ledger.Alonzo.Rules.Utxow
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices (..))
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import Cardano.Ledger.Alonzo.Translation ()
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
+import Cardano.Ledger.BaseTypes (boundRational)
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Crypto (DSIGN, KES)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import qualified Control.Monad.Except as Except
+import qualified Control.Monad.Trans.State as State hiding (state)
+import Data.Default.Class
+import qualified Data.Map as Map
+import Data.Maybe (fromJust)
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Set as Set
+import Shelley.Spec.Ledger.API.Mempool (ApplyTxError (..))
+import Shelley.Spec.Ledger.API.Protocol (PraosCrypto)
+import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import Shelley.Spec.Ledger.STS.Ledger
+import Shelley.Spec.Ledger.STS.Utxow
+import Test.Cardano.Ledger.Elaborators
+import Test.Cardano.Ledger.Examples.TwoPhaseValidation (freeCostModel)
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Value
+
+instance Default AlonzoGenesis where
+  def =
+    AlonzoGenesis
+      { coinsPerUTxOWord = Coin 10000,
+        costmdls = Map.fromSet (const freeCostModel) $ Set.fromList [minBound ..],
+        prices = Prices (fromJust $ boundRational 1000) (fromJust $ boundRational 1000),
+        maxTxExUnits = ExUnits 100 100,
+        maxBlockExUnits = ExUnits 100 100,
+        maxValSize = 100000,
+        collateralPercentage = 100,
+        maxCollateralInputs = 100
+      }
+
+instance
+  ( PraosCrypto crypto,
+    KES.Signable (KES crypto) ~ SignableRepresentation,
+    DSIGN.Signable (DSIGN crypto) ~ SignableRepresentation
+  ) =>
+  ElaborateEraModel (AlonzoEra crypto)
+  where
+  type EraFeatureSet (AlonzoEra crypto) = 'FeatureSet 'ExpectAnyOutput ('TyScriptFeature 'True 'True)
+  eraFeatureSet _ = FeatureTag ValueFeatureTag_AnyOutput ScriptFeatureTag_PlutusV1
+
+  reifyValueConstraint = ExpectedValueTypeC_MA
+
+  toEraPredicateFailure = \case
+    ModelValueNotConservedUTxO (ModelValue x) (ModelValue y) -> State.evalState $
+      Except.runExceptT $ do
+        x' <- Except.ExceptT $ evalModelValue (lookupModelValue noScriptAction) x
+        y' <- Except.ExceptT $ evalModelValue (lookupModelValue noScriptAction) y
+        pure $
+          ApplyBlockTransitionError_Tx $
+            ApplyTxError
+              [ UtxowFailure
+                  ( WrappedShelleyEraFailure
+                      (UtxoFailure (ValueNotConservedUTxO x' y'))
+                  )
+              ]
+
+  makeTimelockScript _ (SupportsTimelock x) = Alonzo.TimelockScript x
+  makePlutusScript _ (SupportsPlutus x) = x -- Alonzo.PlutusScript
+  makeExtendedTxOut _ (Alonzo.TxOut a v _) (SupportsPlutus dh) = Alonzo.TxOut a v (SJust dh)
+
+  makeTxBody nes (TxBodyArguments maxTTL fee ins outs dcerts wdrl (SupportsMint mint) (SupportsPlutus redeemers) (SupportsPlutus cins)) =
+    Alonzo.TxBody
+      { Alonzo.inputs = ins,
+        Alonzo.collateral = cins,
+        Alonzo.outputs = outs,
+        Alonzo.txcerts = dcerts,
+        Alonzo.txwdrls = wdrl,
+        Alonzo.txfee = fee,
+        Alonzo.txvldt = ValidityInterval SNothing $ SJust (1 + maxTTL),
+        Alonzo.txUpdates = SNothing,
+        Alonzo.reqSignerHashes = Set.empty,
+        Alonzo.mint = mint,
+        Alonzo.wppHash = redeemers >>= uncurry (Alonzo.hashWitnessPPData (LedgerState.esPp . LedgerState.nesEs $ nes) (Set.singleton PlutusV1)),
+        Alonzo.adHash = SNothing,
+        Alonzo.txnetworkid = SNothing -- SJust Testnet
+      }
+
+  makeTx _ realTxBody (TxWitnessArguments wits (SupportsScript ScriptFeatureTag_PlutusV1 scripts) (SupportsPlutus (rdmr, dats))) =
+    let witSet =
+          Alonzo.TxWitness
+            { Alonzo.txwitsVKey = wits,
+              Alonzo.txwitsBoot = Set.empty,
+              Alonzo.txscripts = scripts,
+              Alonzo.txdats = dats,
+              Alonzo.txrdmrs = rdmr
+            }
+     in (Alonzo.ValidatedTx realTxBody witSet (Alonzo.IsValidating True) SNothing)

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators/Shelley.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Elaborators/Shelley.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Elaborators.Shelley where
+
+import qualified Cardano.Crypto.DSIGN.Class as DSIGN
+import qualified Cardano.Crypto.KES.Class as KES
+import Cardano.Crypto.Util (SignableRepresentation)
+import Cardano.Ledger.Crypto (DSIGN, KES)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import qualified Control.Monad.Except as Except
+import qualified Control.Monad.Trans.State as State hiding (state)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Void
+import Shelley.Spec.Ledger.API.Mempool (ApplyTxError (..))
+import Shelley.Spec.Ledger.API.Protocol (PraosCrypto)
+import Shelley.Spec.Ledger.STS.EraMapping ()
+import Shelley.Spec.Ledger.STS.Ledger (LedgerPredicateFailure (..))
+import Shelley.Spec.Ledger.STS.Utxo (UtxoPredicateFailure (..))
+import Shelley.Spec.Ledger.STS.Utxow (UtxowPredicateFailure (..))
+import qualified Shelley.Spec.Ledger.Tx as Shelley
+import Test.Cardano.Ledger.Elaborators
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Value
+
+instance
+  ( PraosCrypto crypto,
+    KES.Signable (KES crypto) ~ SignableRepresentation,
+    DSIGN.Signable (DSIGN crypto) ~ SignableRepresentation
+  ) =>
+  ElaborateEraModel (ShelleyEra crypto)
+  where
+  type EraFeatureSet (ShelleyEra crypto) = 'FeatureSet 'ExpectAdaOnly ('TyScriptFeature 'False 'False)
+  eraFeatureSet _ = FeatureTag ValueFeatureTag_AdaOnly ScriptFeatureTag_None
+
+  reifyValueConstraint = ExpectedValueTypeC_Simple
+
+  makeTimelockScript _ (NoTimelockSupport x) = absurd x
+  makePlutusScript _ (NoPlutusSupport x) = absurd x
+  makeExtendedTxOut _ _ (NoPlutusSupport x) = absurd x
+
+  toEraPredicateFailure = \case
+    ModelValueNotConservedUTxO (ModelValue x) (ModelValue y) -> State.evalState $
+      Except.runExceptT $ do
+        x' <- Except.ExceptT $ evalModelValue (lookupModelValue noScriptAction) x
+        y' <- Except.ExceptT $ evalModelValue (lookupModelValue noScriptAction) y
+        pure $
+          ApplyBlockTransitionError_Tx $
+            ApplyTxError
+              [UtxowFailure (UtxoFailure (ValueNotConservedUTxO x' y'))]
+
+  makeTxBody _ (TxBodyArguments maxTTL fee ins outs dcerts wdrl (NoMintSupport ()) (NoPlutusSupport ()) (NoPlutusSupport ())) =
+    Shelley.TxBody
+      { Shelley._inputs = ins,
+        Shelley._outputs = outs,
+        Shelley._certs = dcerts,
+        Shelley._wdrls = wdrl,
+        Shelley._txfee = fee,
+        Shelley._ttl = maxTTL,
+        Shelley._txUpdate = SNothing,
+        Shelley._mdHash = SNothing
+      }
+
+  makeTx _ realTxBody (TxWitnessArguments wits (NoScriptSupport ()) (NoPlutusSupport ())) =
+    Shelley.Tx realTxBody (mempty {Shelley.addrWits = wits}) SNothing

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.ModelChain where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin
+import qualified Cardano.Ledger.Crypto as C
+import Cardano.Ledger.Mary.Value (AssetName, PolicyID (..))
+import qualified Cardano.Ledger.Mary.Value
+import qualified Cardano.Ledger.Val as Val
+import Cardano.Slotting.Slot hiding (at)
+import Control.Lens
+import qualified Control.Monad.State.Strict as State
+import Data.Foldable (fold)
+import Data.Kind (Type)
+import qualified Data.Map as Map
+import Data.Proxy
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Traversable
+import qualified GHC.Exts as GHC
+import qualified PlutusTx
+import Shelley.Spec.Ledger.STS.EraMapping ()
+import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Script
+import Test.Cardano.Ledger.ModelChain.Value
+
+class Val.Val val => ValueFromList val crypto | val -> crypto where
+  valueFromList :: Integer -> [(PolicyID crypto, AssetName, Integer)] -> val
+
+  insert :: (Integer -> Integer -> Integer) -> PolicyID crypto -> AssetName -> Integer -> val -> val
+
+  gettriples :: val -> (Integer, [(PolicyID crypto, AssetName, Integer)])
+
+instance C.Crypto crypto => ValueFromList (Cardano.Ledger.Mary.Value.Value crypto) crypto where
+  valueFromList = Cardano.Ledger.Mary.Value.valueFromList
+
+  insert = Cardano.Ledger.Mary.Value.insert
+
+  gettriples (Cardano.Ledger.Mary.Value.Value c m1) = (c, triples)
+    where
+      triples =
+        [ (policyId, aname, amount)
+          | (policyId, m2) <- Map.toList m1,
+            (aname, amount) <- Map.toList m2
+        ]
+
+-- TODO: this is a bit overconstrained, we probably want a more constraints
+-- based approach using ValueFromList
+type family ElaborateValueType (valF :: TyValueExpected) crypto :: Type where
+  ElaborateValueType 'ExpectAdaOnly _ = Coin
+  ElaborateValueType 'ExpectAnyOutput crypto = Cardano.Ledger.Mary.Value.Value crypto
+
+instance RequiredFeatures ModelTxOut where
+  filterFeatures tag@(FeatureTag v _) (ModelTxOut addr qty dat) =
+    hasKnownValueFeature v $
+      ModelTxOut
+        <$> filterModelAddress tag addr
+        <*> (filterFeatures tag =<< filterModelValue qty)
+        <*> (filterSupportsPlutus tag dat)
+
+filterModelValueVars ::
+  forall a b c d.
+  (KnownRequiredFeatures c, KnownValueFeature d) =>
+  ModelValueVars a b ->
+  Maybe (ModelValueVars c d)
+filterModelValueVars (ModelValue_Reward x) = ModelValue_Reward <$> filterModelAddress (reifyRequiredFeatures (Proxy @c)) x
+filterModelValueVars (ModelValue_MA x ys) = do
+  Refl <- reifyExpectAnyOutput (reifyValueFeature (Proxy @d))
+  Refl <- reifyExpectAnyOutput (reifyValueFeature (Proxy @(ValueFeature c)))
+
+  let f :: ModelScript (ScriptFeature a) -> Maybe (ModelScript (ScriptFeature c))
+      f = \case
+        ModelScript_Timelock t -> case reifyScriptFeature (Proxy @(ScriptFeature c)) of
+          ScriptFeatureTag_None -> Nothing
+          ScriptFeatureTag_Simple -> Just $ ModelScript_Timelock t
+          ScriptFeatureTag_PlutusV1 -> Just $ ModelScript_Timelock t
+        ModelScript_PlutusV1 t -> case reifyScriptFeature (Proxy @(ScriptFeature c)) of
+          ScriptFeatureTag_None -> Nothing
+          ScriptFeatureTag_Simple -> Nothing
+          ScriptFeatureTag_PlutusV1 -> Just $ ModelScript_PlutusV1 t
+
+  ModelValue_MA x . Map.fromList <$> (traverse . _1) f (Map.toList ys)
+
+-- change the "expected return type" of a ModelValue
+filterModelValue ::
+  forall a b c.
+  (KnownValueFeature b, KnownRequiredFeatures c) =>
+  ModelValue a c ->
+  Maybe (ModelValue b c)
+filterModelValue = \case
+  ModelValue x -> ModelValue <$> traverse filterModelValueVars x
+
+instance KnownValueFeature v => RequiredFeatures (ModelValue v) where
+  filterFeatures tag (ModelValue val) = ModelValue <$> traverse (hasKnownRequiredFeatures tag filterModelValueVars) val
+
+instance RequiredFeatures ModelTx where
+  filterFeatures :: forall a b. KnownRequiredFeatures a => FeatureTag b -> ModelTx a -> Maybe (ModelTx b)
+  filterFeatures tag (ModelTx a ins outs fee dcert wdrl g cins) =
+    ModelTx a ins
+      <$> (traverse . traverse) (filterFeatures tag) outs
+      <*> (filterFeatures tag fee)
+      <*> traverse (filterFeatures tag) dcert
+      <*> fmap Map.fromList (for (Map.toList wdrl) $ \(k, v) -> (,) <$> filterModelAddress tag k <*> filterFeatures tag v) -- traverse (filterFeatures tag) f
+      <*> case g of
+        NoMintSupport () -> case tag of
+          FeatureTag ValueFeatureTag_AdaOnly _ -> pure $ NoMintSupport ()
+          FeatureTag ValueFeatureTag_AnyOutput _ -> pure (SupportsMint . ModelValue . ModelValue_Inject $ Coin 0)
+        SupportsMint g' -> case tag of
+          FeatureTag ValueFeatureTag_AdaOnly _ | g' == ModelValue (ModelValue_Inject $ Val.zero) -> pure $ NoMintSupport ()
+          FeatureTag ValueFeatureTag_AdaOnly _ -> Nothing
+          FeatureTag ValueFeatureTag_AnyOutput _ -> SupportsMint <$> filterFeatures tag g'
+      <*> let setNotEmpty :: Set x -> Maybe (Set x)
+              setNotEmpty x
+                | Set.null x = Nothing
+                | otherwise = Just x
+           in (fmap (mapSupportsPlutus fold) $ filterSupportsPlutus tag $ mapSupportsPlutus setNotEmpty cins)
+
+filterModelAddress ::
+  FeatureTag b ->
+  ModelAddress a ->
+  Maybe (ModelAddress (ScriptFeature b))
+filterModelAddress (FeatureTag _ s) = \case
+  ModelAddress a -> Just (ModelAddress a)
+  ModelScriptAddress a -> case s of
+    ScriptFeatureTag_None -> Nothing
+    ScriptFeatureTag_Simple -> Nothing
+    ScriptFeatureTag_PlutusV1 -> Just (ModelScriptAddress a)
+
+instance RequiredFeatures ModelBlock where
+  filterFeatures tag (ModelBlock slotNo txns) =
+    ModelBlock slotNo
+      <$> traverse (filterFeatures tag) txns
+
+instance RequiredFeatures ModelEpoch where
+  filterFeatures tag (ModelEpoch blocks x) =
+    ModelEpoch
+      <$> traverse (filterFeatures tag) blocks
+      <*> pure x
+
+newtype ModelTxId = ModelTxId Integer
+  deriving (Eq, Ord, Show, Num)
+
+type ModelTxIn = ModelUTxOId
+
+type ModelMA era = Map.Map (ModelScript era) (Map.Map AssetName Integer)
+
+data ModelValueVars era (k :: TyValueExpected) where
+  ModelValue_Reward :: ModelAddress (ScriptFeature era) -> ModelValueVars era k
+  ModelValue_MA ::
+    ('ExpectAnyOutput ~ ValueFeature era) =>
+    Coin ->
+    ModelMA (ScriptFeature era) ->
+    ModelValueVars era 'ExpectAnyOutput
+
+deriving instance Show (ModelValueVars era valF)
+
+deriving instance Eq (ModelValueVars era valF)
+
+deriving instance Ord (ModelValueVars era valF)
+
+newtype ModelValue k era = ModelValue {unModelValue :: ModelValueF (ModelValueVars era k)}
+  deriving (Eq, Ord, Show)
+
+data ModelTxOut era = ModelTxOut
+  { _mtxo_address :: !(ModelAddress (ScriptFeature era)),
+    _mtxo_value :: !(ModelValue (ValueFeature era) era),
+    _mtxo_data :: !(IfSupportsPlutus () (Maybe PlutusTx.Data) (ScriptFeature era))
+  }
+  deriving (Eq, Ord, Show)
+
+newtype ModelUTxOId = ModelUTxOId {unModelUTxOId :: Integer}
+  deriving (Eq, Ord, Show, Num, Enum)
+
+data ModelTx (era :: FeatureSet) = ModelTx
+  { _mtxId :: !ModelTxId,
+    _mtxInputs :: !(Set ModelTxIn),
+    _mtxOutputs :: ![(ModelUTxOId, ModelTxOut era)],
+    _mtxFee :: !(ModelValue 'ExpectAdaOnly era),
+    _mtxDCert :: ![ModelDCert era],
+    _mtxWdrl :: !(Map.Map (ModelAddress (ScriptFeature era)) (ModelValue 'ExpectAdaOnly era)),
+    _mtxMint :: !(IfSupportsMint () (ModelValue (ValueFeature era) era) (ValueFeature era)),
+    _mtxCollateral :: !(IfSupportsPlutus () (Set ModelTxIn) (ScriptFeature era))
+  }
+
+data ModelBlock era = ModelBlock SlotNo [ModelTx era]
+
+newtype ModelPoolId = ModelPoolId {unModelPoolId :: String}
+  deriving (Eq, Ord, Show, GHC.IsString)
+
+data ModelBlocksMade = ModelBlocksMade (Map.Map ModelPoolId Rational)
+
+repartition :: forall a b t. (Traversable t, Integral a, RealFrac b) => a -> t b -> t a
+repartition total weights = State.evalState (traverse step weights) (0 :: b)
+  where
+    step weight = do
+      err <- State.get
+      let fracValue :: b
+          fracValue = err + fromIntegral total * weight
+          value :: a
+          value = round fracValue
+      State.put (fracValue - fromIntegral value)
+      pure value
+
+data ModelEpoch era = ModelEpoch [ModelBlock era] ModelBlocksMade
+
+data ModelDelegation era = ModelDelegation
+  { _mdDelegator :: !(ModelAddress (ScriptFeature era)),
+    _mdDelegatee :: !ModelPoolId
+  }
+
+instance RequiredFeatures ModelDelegation where
+  filterFeatures tag (ModelDelegation a b) =
+    ModelDelegation
+      <$> filterModelAddress tag a
+      <*> pure b
+
+data ModelPoolParams era = ModelPoolParams
+  { _mppId :: !ModelPoolId,
+    _mppPledge :: !Coin,
+    _mppCost :: !Coin,
+    _mppMargin :: !UnitInterval,
+    _mppRAcnt :: !(ModelAddress (ScriptFeature era)),
+    _mppOwners :: ![ModelAddress (ScriptFeature era)]
+  }
+
+instance RequiredFeatures ModelPoolParams where
+  filterFeatures tag (ModelPoolParams poolId pledge cost margin rAcnt owners) =
+    ModelPoolParams poolId pledge cost margin
+      <$> filterModelAddress tag rAcnt
+      <*> traverse (filterModelAddress tag) owners
+
+-- ignores genesis delegation details.
+data ModelDCert era
+  = ModelRegisterStake (ModelAddress (ScriptFeature era))
+  | ModelDeRegisterStake (ModelAddress (ScriptFeature era))
+  | ModelDelegate (ModelDelegation era)
+  | ModelRegisterPool (ModelPoolParams era)
+  | ModelRetirePool ModelPoolId EpochNo
+
+instance RequiredFeatures ModelDCert where
+  filterFeatures tag = \case
+    ModelRegisterStake a -> ModelRegisterStake <$> filterModelAddress tag a
+    ModelDeRegisterStake a -> ModelDeRegisterStake <$> filterModelAddress tag a
+    ModelDelegate a -> ModelDelegate <$> filterFeatures tag a
+    ModelRegisterPool a -> ModelRegisterPool <$> filterFeatures tag a
+    ModelRetirePool a b -> pure $ ModelRetirePool a b
+
+-- TODO: | ModelMIRCert Shelley.MIRPot (Map.Map ModelAddress DeltaCoin)
+
+instance Semigroup ModelBlocksMade where
+  ModelBlocksMade x <> ModelBlocksMade y = ModelBlocksMade $ Map.unionWith (+) x y
+
+instance Monoid ModelBlocksMade where
+  mempty = ModelBlocksMade Map.empty
+
+data ModelPredicateFailure era
+  = ModelValueNotConservedUTxO
+      !(ModelValue (ValueFeature era) era)
+      -- ^ the Coin consumed by this transaction
+      !(ModelValue (ValueFeature era) era)
+      -- ^ the Coin produced by this transaction

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
@@ -204,7 +204,7 @@ data ModelTx (era :: FeatureSet) = ModelTx
     _mtxWdrl :: !(Map.Map (ModelAddress (ScriptFeature era)) (ModelValue 'ExpectAdaOnly era)),
     _mtxMint :: !(IfSupportsMint () (ModelValue (ValueFeature era) era) (ValueFeature era)),
     _mtxCollateral :: !(IfSupportsPlutus () (Set ModelTxIn) (ScriptFeature era))
-  }
+  } deriving Show
 
 data ModelBlock era = ModelBlock SlotNo [ModelTx era]
 
@@ -230,7 +230,7 @@ data ModelEpoch era = ModelEpoch [ModelBlock era] ModelBlocksMade
 data ModelDelegation era = ModelDelegation
   { _mdDelegator :: !(ModelAddress (ScriptFeature era)),
     _mdDelegatee :: !ModelPoolId
-  }
+  } deriving Show
 
 instance RequiredFeatures ModelDelegation where
   filterFeatures tag (ModelDelegation a b) =
@@ -245,7 +245,7 @@ data ModelPoolParams era = ModelPoolParams
     _mppMargin :: !UnitInterval,
     _mppRAcnt :: !(ModelAddress (ScriptFeature era)),
     _mppOwners :: ![ModelAddress (ScriptFeature era)]
-  }
+  } deriving Show
 
 instance RequiredFeatures ModelPoolParams where
   filterFeatures tag (ModelPoolParams poolId pledge cost margin rAcnt owners) =
@@ -260,6 +260,7 @@ data ModelDCert era
   | ModelDelegate (ModelDelegation era)
   | ModelRegisterPool (ModelPoolParams era)
   | ModelRetirePool ModelPoolId EpochNo
+  deriving Show
 
 instance RequiredFeatures ModelDCert where
   filterFeatures tag = \case

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain.hs
@@ -164,7 +164,10 @@ instance RequiredFeatures ModelEpoch where
       <*> pure x
 
 newtype ModelTxId = ModelTxId {unModelTxId :: Integer}
-  deriving (Eq, Ord, Show, Num)
+  deriving (Eq, Ord, Num)
+
+instance Show ModelTxId where
+  showsPrec n (ModelTxId x) = showsPrec n x
 
 type ModelTxIn = ModelUTxOId
 
@@ -207,7 +210,10 @@ modelTxOut_data = lens _mtxo_data (\s b -> s {_mtxo_data = b})
 {-# INLINE modelTxOut_data #-}
 
 newtype ModelUTxOId = ModelUTxOId {unModelUTxOId :: Integer}
-  deriving (Eq, Ord, Show, Num, Enum)
+  deriving (Eq, Ord, Num, Enum)
+
+instance Show ModelUTxOId where
+  showsPrec n (ModelUTxOId x) = showsPrec n x
 
 data ModelTx (era :: FeatureSet) = ModelTx
   { _mtxId :: !ModelTxId,
@@ -284,7 +290,10 @@ modelBlock_txSeq = lens _modelBlock_txSeq (\s b -> s {_modelBlock_txSeq = b})
 {-# INLINE modelBlock_txSeq #-}
 
 newtype ModelPoolId = ModelPoolId {unModelPoolId :: String}
-  deriving (Eq, Ord, Show, GHC.IsString)
+  deriving (Eq, Ord, GHC.IsString)
+
+instance Show ModelPoolId where
+  showsPrec n (ModelPoolId x) = showsPrec n x
 
 data ModelBlocksMade = ModelBlocksMade (Map.Map ModelPoolId Rational)
   deriving (Show)

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Address.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Address.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Test.Cardano.Ledger.ModelChain.Address (ModelAddress (..)) where
+
+import Test.Cardano.Ledger.ModelChain.Script

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.ModelChain.FeatureSet where
+
+import Data.Kind (Type)
+import Data.Proxy
+import Data.Type.Bool
+import Data.Type.Equality ((:~:) (..))
+
+data TyValueExpected
+  = ExpectAdaOnly
+  | ExpectAnyOutput
+
+data TyScriptFeature = TyScriptFeature
+  { _tyScript_timelock :: !Bool,
+    _tyScript_plutus :: !Bool
+  }
+
+data ScriptFeatureTag (s :: TyScriptFeature) where
+  ScriptFeatureTag_None :: ScriptFeatureTag ('TyScriptFeature 'False 'False)
+  ScriptFeatureTag_Simple :: ScriptFeatureTag ('TyScriptFeature 'True 'False)
+  ScriptFeatureTag_PlutusV1 :: ScriptFeatureTag ('TyScriptFeature 'True 'True)
+
+class KnownScriptFeature (s :: TyScriptFeature) where reifyScriptFeature :: proxy s -> ScriptFeatureTag s
+
+instance KnownScriptFeature ('TyScriptFeature 'False 'False) where reifyScriptFeature _ = ScriptFeatureTag_None
+
+instance KnownScriptFeature ('TyScriptFeature 'True 'False) where reifyScriptFeature _ = ScriptFeatureTag_Simple
+
+instance KnownScriptFeature ('TyScriptFeature 'True 'True) where reifyScriptFeature _ = ScriptFeatureTag_PlutusV1
+
+hasKnownScriptFeature :: ScriptFeatureTag s -> (KnownScriptFeature s => c) -> c
+hasKnownScriptFeature = \case
+  ScriptFeatureTag_None -> \x -> x
+  ScriptFeatureTag_Simple -> \x -> x
+  ScriptFeatureTag_PlutusV1 -> \x -> x
+
+data IfSupportsTimelock a b (k :: TyScriptFeature) where
+  NoTimelockSupport :: a -> IfSupportsTimelock a b ('TyScriptFeature 'False x)
+  SupportsTimelock :: b -> IfSupportsTimelock a b ('TyScriptFeature 'True x)
+
+data IfSupportsPlutus a b (k :: TyScriptFeature) where
+  NoPlutusSupport :: a -> IfSupportsPlutus a b ('TyScriptFeature x 'False)
+  SupportsPlutus :: b -> IfSupportsPlutus a b ('TyScriptFeature x 'True)
+
+deriving instance (Show a, Show b) => Show (IfSupportsPlutus a b k)
+
+deriving instance (Eq a, Eq b) => Eq (IfSupportsPlutus a b k)
+
+deriving instance (Ord a, Ord b) => Ord (IfSupportsPlutus a b k)
+
+ifSupportsPlutus ::
+  KnownScriptFeature s =>
+  proxy s ->
+  a ->
+  b ->
+  IfSupportsPlutus a b s
+ifSupportsPlutus proxy x y = case reifySupportsPlutus proxy of
+  NoPlutusSupport () -> NoPlutusSupport x
+  SupportsPlutus () -> SupportsPlutus y
+
+mapSupportsPlutus ::
+  (a -> b) ->
+  IfSupportsPlutus x a s ->
+  IfSupportsPlutus x b s
+mapSupportsPlutus f = \case
+  NoPlutusSupport x -> NoPlutusSupport x
+  SupportsPlutus x -> SupportsPlutus (f x)
+
+traverseSupportsPlutus ::
+  Applicative m =>
+  (a -> m b) ->
+  IfSupportsPlutus x a s ->
+  m (IfSupportsPlutus x b s)
+traverseSupportsPlutus f = \case
+  NoPlutusSupport x -> pure $ NoPlutusSupport x
+  SupportsPlutus x -> SupportsPlutus <$> f x
+
+reifySupportsPlutus ::
+  KnownScriptFeature s => proxy s -> IfSupportsPlutus () () s
+reifySupportsPlutus proxy = case reifyScriptFeature proxy of
+  ScriptFeatureTag_None -> NoPlutusSupport ()
+  ScriptFeatureTag_Simple -> NoPlutusSupport ()
+  ScriptFeatureTag_PlutusV1 -> SupportsPlutus ()
+
+data IfSupportsScript a b (k :: TyScriptFeature) where
+  NoScriptSupport ::
+    a ->
+    IfSupportsScript a b ('TyScriptFeature 'False 'False)
+  SupportsScript ::
+    ((t || p) ~ 'True) =>
+    ScriptFeatureTag ('TyScriptFeature t p) ->
+    b ->
+    IfSupportsScript a b ('TyScriptFeature t p)
+
+-- same convention as Data.Bool.bool;  True case comes last
+data IfSupportsMint a b (valF :: TyValueExpected) where
+  NoMintSupport :: a -> IfSupportsMint a b 'ExpectAdaOnly
+  SupportsMint :: b -> IfSupportsMint a b 'ExpectAnyOutput
+
+type family ValueFeature (a :: FeatureSet) where
+  ValueFeature ('FeatureSet v _) = v
+
+type family ScriptFeature (a :: FeatureSet) where
+  ScriptFeature ('FeatureSet _ s) = s
+
+data FeatureSet = FeatureSet TyValueExpected TyScriptFeature
+
+data FeatureTag (tag :: FeatureSet) where
+  FeatureTag :: ValueFeatureTag v -> ScriptFeatureTag s -> FeatureTag ('FeatureSet v s)
+
+data ValueFeatureTag (v :: TyValueExpected) where
+  ValueFeatureTag_AdaOnly :: ValueFeatureTag 'ExpectAdaOnly
+  ValueFeatureTag_AnyOutput :: ValueFeatureTag 'ExpectAnyOutput
+
+type family MaxValueFeature (a :: TyValueExpected) (b :: TyValueExpected) :: TyValueExpected where
+  MaxValueFeature 'ExpectAdaOnly b = b
+  MaxValueFeature a 'ExpectAdaOnly = a
+  MaxValueFeature 'ExpectAnyOutput b = b
+  MaxValueFeature a 'ExpectAnyOutput = a
+
+-- law: () <$ filterFeatures (minFeatures x) y == () <$ filterFeatures x y
+class RequiredFeatures (f :: FeatureSet -> Type) where
+  -- minFeatures :: f a -> FeatureTag a
+  filterFeatures ::
+    KnownRequiredFeatures a =>
+    FeatureTag b ->
+    f a ->
+    Maybe (f b)
+
+class KnownValueFeature (v :: TyValueExpected) where reifyValueFeature :: proxy v -> ValueFeatureTag v
+
+instance KnownValueFeature 'ExpectAdaOnly where reifyValueFeature _ = ValueFeatureTag_AdaOnly
+
+instance KnownValueFeature 'ExpectAnyOutput where reifyValueFeature _ = ValueFeatureTag_AnyOutput
+
+hasKnownValueFeature :: ValueFeatureTag v -> (KnownValueFeature v => c) -> c
+hasKnownValueFeature = \case
+  ValueFeatureTag_AdaOnly -> \x -> x
+  ValueFeatureTag_AnyOutput -> \x -> x
+
+class
+  ( KnownValueFeature (ValueFeature a),
+    KnownScriptFeature (ScriptFeature a),
+    a ~ 'FeatureSet (ValueFeature a) (ScriptFeature a)
+  ) =>
+  KnownRequiredFeatures (a :: FeatureSet)
+  where
+  reifyRequiredFeatures :: proxy a -> FeatureTag a
+  reifyRequiredFeatures _ =
+    FeatureTag
+      (reifyValueFeature (Proxy :: Proxy (ValueFeature a)))
+      (reifyScriptFeature (Proxy :: Proxy (ScriptFeature a)))
+
+hasKnownRequiredFeatures :: FeatureTag a -> (KnownRequiredFeatures a => c) -> c
+hasKnownRequiredFeatures (FeatureTag v s) =
+  \x -> hasKnownValueFeature v (hasKnownScriptFeature s x)
+
+instance
+  ( KnownValueFeature v,
+    KnownScriptFeature s
+  ) =>
+  KnownRequiredFeatures ('FeatureSet v s)
+
+instance RequiredFeatures FeatureTag where
+  -- minFeatures = id
+  filterFeatures (FeatureTag v0 s0) (FeatureTag v1 s1) = FeatureTag <$> v <*> s
+    where
+      v = case (v0, v1) of
+        (ValueFeatureTag_AdaOnly, ValueFeatureTag_AdaOnly) -> Just v0
+        (ValueFeatureTag_AdaOnly, ValueFeatureTag_AnyOutput) -> Just v0
+        (ValueFeatureTag_AnyOutput, ValueFeatureTag_AdaOnly) -> Nothing
+        (ValueFeatureTag_AnyOutput, ValueFeatureTag_AnyOutput) -> Just v0
+
+      s = case (s0, s1) of
+        (ScriptFeatureTag_None, ScriptFeatureTag_None) -> Just s0
+        (ScriptFeatureTag_None, ScriptFeatureTag_Simple) -> Just s0
+        (ScriptFeatureTag_None, ScriptFeatureTag_PlutusV1) -> Just s0
+        (ScriptFeatureTag_Simple, ScriptFeatureTag_None) -> Nothing
+        (ScriptFeatureTag_Simple, ScriptFeatureTag_Simple) -> Just s0
+        (ScriptFeatureTag_Simple, ScriptFeatureTag_PlutusV1) -> Just s0
+        (ScriptFeatureTag_PlutusV1, ScriptFeatureTag_None) -> Nothing
+        (ScriptFeatureTag_PlutusV1, ScriptFeatureTag_Simple) -> Nothing
+        (ScriptFeatureTag_PlutusV1, ScriptFeatureTag_PlutusV1) -> Just s0
+
+filterSupportsPlutus ::
+  FeatureTag k ->
+  IfSupportsPlutus () (Maybe x) s' ->
+  Maybe (IfSupportsPlutus () (Maybe x) (ScriptFeature k))
+filterSupportsPlutus (FeatureTag _ s) = case s of
+  ScriptFeatureTag_None -> \case
+    NoPlutusSupport () -> Just (NoPlutusSupport ())
+    SupportsPlutus Nothing -> Just (NoPlutusSupport ())
+    SupportsPlutus (Just _) -> Nothing
+  ScriptFeatureTag_Simple -> \case
+    NoPlutusSupport () -> Just (NoPlutusSupport ())
+    SupportsPlutus Nothing -> Just (NoPlutusSupport ())
+    SupportsPlutus (Just _) -> Nothing
+  ScriptFeatureTag_PlutusV1 -> \case
+    NoPlutusSupport () -> Just (SupportsPlutus Nothing)
+    SupportsPlutus x -> Just (SupportsPlutus x)
+
+reifyExpectAnyOutput :: ValueFeatureTag a -> Maybe (a :~: 'ExpectAnyOutput)
+reifyExpectAnyOutput = \case
+  ValueFeatureTag_AnyOutput -> Just Refl
+  ValueFeatureTag_AdaOnly -> Nothing

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
@@ -2,13 +2,18 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Test.Cardano.Ledger.ModelChain.FeatureSet where
 
@@ -109,6 +114,16 @@ data IfSupportsMint a b (valF :: TyValueExpected) where
   SupportsMint :: b -> IfSupportsMint a b 'ExpectAnyOutput
 
 deriving instance (Show a, Show b) => Show (IfSupportsMint a b k)
+
+ifSupportsMint ::
+  KnownValueFeature s =>
+  proxy s ->
+  a ->
+  b ->
+  IfSupportsMint a b s
+ifSupportsMint proxy x y = case reifyValueFeature proxy of
+  ValueFeatureTag_AdaOnly -> NoMintSupport x
+  ValueFeatureTag_AnyOutput -> SupportsMint y
 
 type family ValueFeature (a :: FeatureSet) where
   ValueFeature ('FeatureSet v _) = v

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/FeatureSet.hs
@@ -108,6 +108,8 @@ data IfSupportsMint a b (valF :: TyValueExpected) where
   NoMintSupport :: a -> IfSupportsMint a b 'ExpectAdaOnly
   SupportsMint :: b -> IfSupportsMint a b 'ExpectAnyOutput
 
+deriving instance (Show a, Show b) => Show (IfSupportsMint a b k)
+
 type family ValueFeature (a :: FeatureSet) where
   ValueFeature ('FeatureSet v _) = v
 

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Properties.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Properties.hs
@@ -1,0 +1,536 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.ModelChain.Properties where
+
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.BaseTypes (boundRational)
+import Cardano.Ledger.Coin
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Control.State.Transition.Extended
+import qualified Data.ByteString.Char8 as BS
+import Data.Default.Class
+import Data.Foldable
+import qualified Data.Map as Map
+import Data.Maybe (fromJust)
+import Data.Ratio ((%))
+import qualified Data.Set as Set
+import Data.String (IsString (..))
+import Data.Typeable
+import GHC.Natural
+import qualified PlutusTx
+import Shelley.Spec.Ledger.API.Genesis
+import Test.Cardano.Ledger.Elaborators
+import Test.Cardano.Ledger.Elaborators.Alonzo ()
+import Test.Cardano.Ledger.Elaborators.Shelley ()
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Script
+import Test.Cardano.Ledger.ModelChain.Utils
+import Test.Cardano.Ledger.ModelChain.Value
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+modelMACoin ::
+  (ValueFeature era ~ 'ExpectAnyOutput) =>
+  ModelScript (ScriptFeature era) ->
+  [(AssetName, Integer)] ->
+  ModelValue 'ExpectAnyOutput era
+modelMACoin script assets =
+  ModelValue $
+    ModelValue_Var $
+      ModelValue_MA mempty $ Map.singleton script $ Map.fromList assets
+
+modelCoin :: Integer -> ModelValue era k
+modelCoin = ModelValue . ModelValue_Inject . Coin
+
+modelReward :: ModelAddress (ScriptFeature era) -> ModelValue k era
+modelReward = ModelValue . ModelValue_Var . ModelValue_Reward
+
+modelRewards :: [ModelAddress (ScriptFeature era)] -> Map.Map (ModelAddress (ScriptFeature era)) (ModelValue k era)
+modelRewards = foldMap $ \maddr -> Map.singleton maddr $ modelReward maddr
+
+infixl 6 $+
+
+infixl 6 $-
+
+infixl 7 $*
+
+($*) :: Natural -> ModelValue era k -> ModelValue era k
+x $* ModelValue y = ModelValue (ModelValue_Scale x y)
+
+($+) :: ModelValue era k -> ModelValue era k -> ModelValue era k
+ModelValue x $+ ModelValue y = ModelValue (ModelValue_Add x y)
+
+($-) :: ModelValue era k -> ModelValue era k -> ModelValue era k
+ModelValue x $- ModelValue y = ModelValue (ModelValue_Sub x y)
+
+purpleModelScript :: ModelScript ('TyScriptFeature 'True x)
+purpleModelScript = ModelScript_Timelock $ ModelTimelock_AllOf []
+
+bobCoinScript :: ModelScript ('TyScriptFeature 'True x)
+bobCoinScript = ModelScript_Timelock $ ModelTimelock_Signature "BobCoin"
+
+modelPlutusScript :: Natural -> ModelScript ('TyScriptFeature x 'True)
+modelPlutusScript = ModelScript_PlutusV1 . ModelPlutusScript_AlwaysSucceeds
+
+instance IsString AssetName where
+  fromString = AssetName . BS.pack
+
+modelTestDelegations ::
+  ( ElaborateEraModel era,
+    Default (AdditionalGenesisConfig era),
+    -- Eq (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (Core.Value era)
+  ) =>
+  proxy era ->
+  Bool ->
+  ModelAddress AllScriptFeatures ->
+  [TestTree]
+modelTestDelegations proxy needsCollateral stakeAddr =
+  let modelPool = ModelPoolParams "pool1" (Coin 0) (Coin 0) (fromJust $ boundRational $ 0 % 1) "rewardAcct" ["poolOwner"]
+      allAtOnce =
+        [ ModelBlock
+            0
+            [ (modelTx 1)
+                { _mtxInputs = Set.fromList [0],
+                  _mtxCollateral = SupportsPlutus $ Set.fromList [x | x <- [0], needsCollateral],
+                  _mtxOutputs =
+                    [ (100, modelTxOut "unstaked" (modelCoin 9_800_000_000_000)),
+                      (200, modelTxOut stakeAddr (modelCoin 100_000_000_000))
+                    ],
+                  _mtxFee = modelCoin 100_000_000_000,
+                  _mtxDCert =
+                    [ ModelRegisterStake stakeAddr,
+                      ModelRegisterPool modelPool,
+                      ModelDelegate (ModelDelegation stakeAddr "pool1")
+                    ]
+                }
+            ]
+        ]
+      oneAtATime =
+        [ ModelBlock
+            0
+            [ (modelTx 0)
+                { _mtxInputs = Set.fromList [0],
+                  _mtxOutputs =
+                    [ (1, modelTxOut "unstaked" (modelCoin 9_875_000_000_000)),
+                      (2, modelTxOut stakeAddr (modelCoin 100_000_000_000))
+                    ],
+                  _mtxFee = modelCoin 25_000_000_000
+                }
+            ],
+          ModelBlock
+            1
+            [ (modelTx 1)
+                { _mtxInputs = Set.fromList [1],
+                  _mtxOutputs =
+                    [ (2, modelTxOut "unstaked" (modelCoin 9_850_000_000_000))
+                    ],
+                  _mtxFee = modelCoin 25_000_000_000,
+                  _mtxDCert = [ModelRegisterStake stakeAddr]
+                }
+            ],
+          ModelBlock
+            2
+            [ (modelTx 2)
+                { _mtxInputs = Set.fromList [2],
+                  _mtxOutputs =
+                    [ (3, modelTxOut "unstaked" (modelCoin 9_825_000_000_000))
+                    ],
+                  _mtxFee = modelCoin 25_000_000_000,
+                  _mtxDCert = [ModelRegisterPool modelPool]
+                }
+            ],
+          ModelBlock
+            3
+            [ (modelTx 3)
+                { _mtxInputs = Set.fromList [3],
+                  _mtxCollateral = SupportsPlutus $ Set.fromList [x | x <- [3], needsCollateral],
+                  _mtxOutputs =
+                    [ (100, modelTxOut "unstaked" (modelCoin 9_800_000_000_000))
+                    ],
+                  _mtxFee = modelCoin 25_000_000_000,
+                  _mtxDCert =
+                    [ ModelDelegate (ModelDelegation stakeAddr "pool1")
+                    ]
+                }
+            ]
+        ]
+      genAct =
+        [ (0, "unstaked", Coin 10_000_000_000_000)
+        ]
+      checkAllWithdrawnRewards nes ems =
+        let rewards = observeRewards (nes, ems)
+         in counterexample (show rewards) $ Coin 0 === fold rewards
+      go reg =
+        testChainModelInteractionWith
+          proxy
+          checkAllWithdrawnRewards
+          genAct
+          [ ModelEpoch reg (ModelBlocksMade $ Map.fromList []),
+            ModelEpoch [] (ModelBlocksMade $ Map.fromList []),
+            ModelEpoch [] (ModelBlocksMade $ Map.fromList [("pool1", 1 % 1)]),
+            ModelEpoch [] (ModelBlocksMade $ Map.fromList []),
+            ModelEpoch
+              [ ModelBlock
+                  0
+                  [ (modelTx 100)
+                      { _mtxInputs = Set.fromList [100],
+                        _mtxCollateral = SupportsPlutus $ Set.fromList [x | x <- [100], needsCollateral],
+                        _mtxOutputs =
+                          [ (103, modelTxOut "unstaked" (modelCoin 9_700_000_000_000)),
+                            (104, modelTxOut "reward-less-minimum" (modelReward stakeAddr $- modelCoin 100_000_000)),
+                            (105, modelTxOut "minimum" (modelCoin 100_000_000))
+                          ],
+                        _mtxFee = modelCoin 100_000_000_000,
+                        _mtxWdrl = modelRewards [stakeAddr]
+                      }
+                  ]
+              ]
+              (ModelBlocksMade $ Map.fromList [])
+          ]
+   in [ testProperty "allAtOnce" $ go allAtOnce,
+        testProperty "oneAtATime" $ go oneAtATime
+      ]
+
+-- | some hand-written model based unit tests
+modelUnitTests ::
+  forall era proxy.
+  ( ElaborateEraModel era,
+    Default (AdditionalGenesisConfig era),
+    Eq (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (Core.Value era)
+  ) =>
+  proxy era ->
+  TestTree
+modelUnitTests proxy =
+  testGroup
+    (show $ typeRep proxy)
+    [ testProperty "noop" $ testChainModelInteraction proxy [] [],
+      testProperty "noop-2" $
+        testChainModelInteraction
+          proxy
+          ( [ (0, "alice", Coin 1_000_000),
+              (1, "bob", Coin 1_000_000)
+            ]
+          )
+          [ModelEpoch [] mempty],
+      testGroup "deleg-keyHash" $ modelTestDelegations proxy False "keyHashStake",
+      testGroup "deleg-plutus" $ modelTestDelegations proxy True (ModelScriptAddress $ ModelPlutusScript_AlwaysSucceeds 4),
+      testProperty "xfer" $
+        testChainModelInteraction
+          proxy
+          ( [ (0, "alice", Coin 1_000_000_000)
+            ]
+          )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ (1, modelTxOut "bob" (modelCoin 100_000_000)),
+                            (2, modelTxOut "alice" (modelCoin 1_000_000_000 $- (modelCoin 100_000_000 $+ modelCoin 1_000_000)))
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "unbalanced" $
+        testChainModelInteractionRejection
+          proxy
+          (ModelValueNotConservedUTxO (modelCoin 1_000_000_000) (modelCoin 101_000_000))
+          ( [ (0, "alice", Coin 1_000_000_000)
+            ]
+          )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = (Set.fromList [0]),
+                        _mtxOutputs = [(1, modelTxOut "bob" $ modelCoin 100_000_000)],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "xfer-2" $
+        testChainModelInteraction
+          proxy
+          ( [ (0, "alice", Coin 1_000_000_000)
+            ]
+          )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ (1, modelTxOut "bob" (modelCoin 100_000_000)),
+                            (2, modelTxOut "alice" (modelCoin 1_000_000_000 $- (modelCoin 100_000_000 $+ modelCoin 1_000_000)))
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ],
+                ModelBlock
+                  2
+                  [ (modelTx 2)
+                      { _mtxInputs = Set.fromList [2],
+                        _mtxOutputs =
+                          [ (3, modelTxOut "bob" (modelCoin 100_000_000)),
+                            (4, modelTxOut "alice" (modelCoin 1_000_000_000 $- 2 $* (modelCoin 100_000_000 $+ modelCoin 1_000_000)))
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "mint" $
+        ( testChainModelInteraction
+            proxy
+            ( [ (0, "alice", Coin 1_000_000_000)
+              ]
+            )
+        )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ ( 1,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (modelCoin 1_000_000)
+                                    $+ modelMACoin purpleModelScript [("purp", 1234)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000,
+                        _mtxMint = SupportsMint (modelMACoin purpleModelScript [("purp", 1234)])
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "mint-2" $
+        ( testChainModelInteraction
+            proxy
+            ( [ (0, "alice", Coin 1_000_000_000)
+              ]
+            )
+        )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ ( 1,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (modelCoin 1_000_000)
+                                    $+ modelMACoin bobCoinScript [("BOB", 1234)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000,
+                        _mtxMint = SupportsMint (modelMACoin bobCoinScript [("BOB", 1234)])
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "mint-3" $
+        ( testChainModelInteraction
+            proxy
+            ( [ (0, "alice", Coin 1_000_000_000)
+              ]
+            )
+        )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ ( 1,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (modelCoin 1_000_000)
+                                    $+ modelMACoin purpleModelScript [("BOB", 1234)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000,
+                        _mtxMint = SupportsMint (modelMACoin purpleModelScript [("BOB", 1234)])
+                      },
+                    (modelTx 2)
+                      { _mtxInputs = Set.fromList [1],
+                        _mtxOutputs =
+                          [ ( 2,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (3 $* modelCoin 1_000_000)
+                                    $+ modelMACoin purpleModelScript [("BOB", 1134)]
+                                )
+                            ),
+                            ( 3,
+                              modelTxOut
+                                "carol"
+                                ( modelCoin 1_000_000
+                                    $+ modelMACoin purpleModelScript [("BOB", 100)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "mint-4" $
+        ( testChainModelInteraction
+            proxy
+            ( [ (0, "alice", Coin 1_000_000_000)
+              ]
+            )
+        )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ ( 1,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (modelCoin 1_000_000)
+                                    $+ modelMACoin bobCoinScript [("BOB", 1234)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000,
+                        _mtxMint = SupportsMint (modelMACoin bobCoinScript [("BOB", 1234)])
+                      },
+                    (modelTx 2)
+                      { _mtxInputs = Set.fromList [1],
+                        _mtxOutputs =
+                          [ ( 2,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (3 $* modelCoin 1_000_000)
+                                    $+ modelMACoin bobCoinScript [("BOB", 1134)]
+                                )
+                            ),
+                            ( 3,
+                              modelTxOut
+                                "carol"
+                                ( modelCoin 1_000_000
+                                    $+ modelMACoin bobCoinScript [("BOB", 100)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "mint-plutus" $
+        testChainModelInteraction
+          proxy
+          ( [ (0, "alice", Coin 1_000_000_000)
+            ]
+          )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxCollateral = SupportsPlutus (Set.fromList [0]),
+                        _mtxOutputs =
+                          [ ( 1,
+                              modelTxOut
+                                "alice"
+                                ( modelCoin 1_000_000_000 $- (modelCoin 1_000_000)
+                                    $+ modelMACoin (modelPlutusScript 3) [("purp", 1234)]
+                                )
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000,
+                        _mtxMint = SupportsMint (modelMACoin (modelPlutusScript 3) [("purp", 1234)])
+                      }
+                  ]
+              ]
+              mempty
+          ],
+      testProperty "tx-plutus" $
+        testChainModelInteraction
+          proxy
+          ( [ (0, "alice", Coin 1_000_000_000)
+            ]
+          )
+          [ ModelEpoch
+              [ ModelBlock
+                  1
+                  [ (modelTx 1)
+                      { _mtxInputs = Set.fromList [0],
+                        _mtxOutputs =
+                          [ (1, modelTxOut "bob" (modelCoin 100_000_000)),
+                            ( 2,
+                              (modelTxOut (ModelScriptAddress $ ModelPlutusScript_AlwaysSucceeds 2) (modelCoin 1_000_000_000 $- (modelCoin 100_000_000 $+ modelCoin 1_000_000)))
+                                { _mtxo_data = SupportsPlutus $ Just $ PlutusTx.I 7
+                                }
+                            )
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ],
+                ModelBlock
+                  2
+                  [ (modelTx 2)
+                      { _mtxInputs = Set.fromList [2],
+                        _mtxCollateral = SupportsPlutus (Set.fromList [1]),
+                        _mtxOutputs =
+                          [ (3, modelTxOut "bob" (modelCoin 100_000_000)),
+                            (4, modelTxOut "alice" (modelCoin 1_000_000_000 $- 2 $* (modelCoin 100_000_000 $+ modelCoin 1_000_000)))
+                          ],
+                        _mtxFee = modelCoin 1_000_000
+                      }
+                  ]
+              ]
+              mempty
+          ]
+    ]
+
+modelUnitTests_ :: TestTree
+modelUnitTests_ =
+  testGroup
+    "model-unit-tests"
+    [ modelUnitTests (Proxy :: Proxy (ShelleyEra C_Crypto)),
+      modelUnitTests (Proxy :: Proxy (AlonzoEra C_Crypto))
+    ]
+
+modelTxOut :: ModelAddress AllScriptFeatures -> ModelValue 'ExpectAnyOutput AllModelFeatures -> ModelTxOut AllModelFeatures
+modelTxOut a v = ModelTxOut a v (SupportsPlutus Nothing)
+
+defaultTestMain :: IO ()
+defaultTestMain = defaultMain modelUnitTests_

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Properties.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Properties.hs
@@ -43,7 +43,7 @@ import Test.Cardano.Ledger.ModelChain.Value
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (C_Crypto)
 import Test.Tasty
 import Test.Tasty.QuickCheck
-import Data.List (tails)
+import qualified Data.List as List
 
 modelMACoin ::
   (ValueFeature era ~ 'ExpectAnyOutput) =>
@@ -226,8 +226,8 @@ shrinkModelSimple
   :: forall a.
       (a, [ModelEpoch AllModelFeatures])
   -> [(a, [ModelEpoch AllModelFeatures])]
-shrinkModelSimple (genesis, epochs) = (,) genesis <$> reverse (drop 1 $ tails epochs)
---
+shrinkModelSimple (genesis, epochs) = (,) genesis <$> tail (List.init $ ([]:) $ List.inits epochs)
+
 -- | some hand-written model based unit tests
 modelUnitTests ::
   forall era proxy.

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Script.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Script.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.ModelChain.Script where
+
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Crypto as C
+import Cardano.Ledger.Keys
+import Cardano.Ledger.ShelleyMA.Timelocks
+import Cardano.Slotting.Slot hiding (at)
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified GHC.Exts as GHC
+import Numeric.Natural (Natural)
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+
+data ModelAddress (k :: TyScriptFeature) where
+  ModelAddress :: String -> ModelAddress k
+  ModelScriptAddress :: ModelPlutusScript -> ModelAddress ('TyScriptFeature x 'True)
+
+deriving instance Eq (ModelAddress k)
+
+deriving instance Ord (ModelAddress k)
+
+deriving instance Show (ModelAddress k)
+
+instance GHC.IsString (ModelAddress k) where
+  fromString s = ModelAddress s
+
+data ModelScript (k :: TyScriptFeature) where
+  ModelScript_Timelock :: ModelTimelock -> ModelScript ('TyScriptFeature 'True x)
+  ModelScript_PlutusV1 :: ModelPlutusScript -> ModelScript ('TyScriptFeature x 'True)
+
+deriving instance Eq (ModelScript k)
+
+deriving instance Ord (ModelScript k)
+
+deriving instance Show (ModelScript k)
+
+data ModelPlutusScript
+  = ModelPlutusScript_AlwaysSucceeds Natural
+  | ModelPlutusScript_AlwaysFails Natural
+  deriving (Eq, Ord, Show)
+
+modelScriptNeededSigs :: ModelTimelock -> [ModelAddress k]
+modelScriptNeededSigs = go
+  where
+    go = \case
+      ModelTimelock_Signature (ModelAddress ma) -> [ModelAddress ma]
+      ModelTimelock_AllOf xs -> go =<< xs
+      ModelTimelock_AnyOf xs -> go =<< take 1 xs
+      ModelTimelock_MOfN n xs -> go =<< take n xs
+      ModelTimelock_TimeStart _ -> []
+      ModelTimelock_TimeExpire _ -> []
+
+-- modelScriptNeededSigs (ModelScript_PlutusV1 {}) = []
+-- TODO: start/expire are somewhat irritating since absolute slot numbers aren't
+-- visible in the model; it should probably be refactored to use epochs + slot
+-- in epoch
+data ModelTimelock
+  = ModelTimelock_Signature (ModelAddress ('TyScriptFeature 'False 'False))
+  | ModelTimelock_AllOf [ModelTimelock]
+  | ModelTimelock_AnyOf [ModelTimelock]
+  | ModelTimelock_MOfN Int [ModelTimelock] -- Note that the Int may be negative in which case (MOfN -2 [..]) is always True
+  | ModelTimelock_TimeStart SlotNo -- The start time
+  | ModelTimelock_TimeExpire SlotNo -- The time it expires
+  deriving (Eq, Ord, Show)
+
+elaborateModelTimelock ::
+  forall crypto m.
+  (C.Crypto crypto, Applicative m) =>
+  (ModelAddress ('TyScriptFeature 'False 'False) -> m (KeyHash 'Witness crypto)) ->
+  ModelTimelock ->
+  m (Timelock crypto)
+elaborateModelTimelock f = go
+  where
+    go :: ModelTimelock -> m (Timelock crypto)
+    go = \case
+      ModelTimelock_Signature maddr -> RequireSignature <$> f maddr
+      ModelTimelock_AllOf xs -> RequireAllOf . StrictSeq.fromList <$> traverse go xs
+      ModelTimelock_AnyOf xs -> RequireAnyOf . StrictSeq.fromList <$> traverse go xs
+      ModelTimelock_MOfN m xs -> RequireMOf m . StrictSeq.fromList <$> traverse go xs
+      ModelTimelock_TimeStart slotNo -> pure $ RequireTimeStart slotNo
+      ModelTimelock_TimeExpire slotNo -> pure $ RequireTimeExpire slotNo
+
+elaborateModelScript ::
+  ModelPlutusScript ->
+  Alonzo.Script era
+elaborateModelScript = \case
+  ModelPlutusScript_AlwaysSucceeds n -> Alonzo.alwaysSucceeds n
+  ModelPlutusScript_AlwaysFails n -> Alonzo.alwaysFails n

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Script.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Script.hs
@@ -26,6 +26,11 @@ data ModelAddress (k :: TyScriptFeature) where
   ModelAddress :: String -> ModelAddress k
   ModelScriptAddress :: ModelPlutusScript -> ModelAddress ('TyScriptFeature x 'True)
 
+liftModelAddress ::
+  ModelAddress ('TyScriptFeature 'False 'False) ->
+  ModelAddress a
+liftModelAddress (ModelAddress a) = ModelAddress a
+
 deriving instance Eq (ModelAddress k)
 
 deriving instance Ord (ModelAddress k)

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Utils.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Utils.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.ModelChain.Utils where
+
+import Cardano.Ledger.BaseTypes (Globals (..), activeSlotVal, boundRational, epochInfo)
+import Cardano.Ledger.Coin
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Slotting.EpochInfo.API (epochInfoSize)
+import Cardano.Slotting.Slot (EpochNo (..))
+import Control.State.Transition.Extended
+import Data.Default.Class
+import Data.Functor.Identity
+import Data.List (nub, (\\))
+import qualified Data.Map as Map
+import Data.Proxy
+import qualified Data.Set as Set
+import Data.Time.Clock (secondsToNominalDiffTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Shelley.Spec.Ledger.API.Genesis
+import Shelley.Spec.Ledger.API.Mempool (ApplyTxError (..))
+import Shelley.Spec.Ledger.Genesis
+import Shelley.Spec.Ledger.LedgerState (NewEpochState)
+import Shelley.Spec.Ledger.PParams (emptyPParams)
+import qualified Shelley.Spec.Ledger.PParams as PParams
+import Test.Cardano.Ledger.Elaborators
+import Test.Cardano.Ledger.ModelChain
+import Test.Cardano.Ledger.ModelChain.Address
+import Test.Cardano.Ledger.ModelChain.FeatureSet
+import Test.Cardano.Ledger.ModelChain.Value
+import Test.Shelley.Spec.Ledger.Utils (testGlobals)
+import Test.Tasty.QuickCheck
+
+-- type ApplyBlockError era = (ApplyBlockTransitionError era)
+
+type ModelAddress' = ModelAddress ('TyScriptFeature 'False 'False)
+
+-- | apply a list of ModelEpoch to an empty ledger and return the resulting
+-- state, or the error if one occured
+chainModelInteractionWith ::
+  forall era proxy.
+  ( Default (AdditionalGenesisConfig era),
+    ElaborateEraModel era
+  ) =>
+  proxy era ->
+  [(ModelUTxOId, ModelAddress', Coin)] ->
+  [ModelEpoch (EraFeatureSet era)] ->
+  (Either (ElaborateBlockError era) (), (NewEpochState era, EraElaboratorState era))
+chainModelInteractionWith _ genesisAccounts0 modelBlocks =
+  let -- TODO, pass this in as a generator.
+
+      globals = testGlobals
+      genesisAccounts = (\(a, b, c) -> (a, liftModelAddress b, c)) <$> genesisAccounts0
+
+      sg :: ShelleyGenesis era
+      sg =
+        ShelleyGenesis
+          { sgSystemStart = (posixSecondsToUTCTime 0),
+            sgNetworkMagic = 1, -- genNetworkMagic
+            sgNetworkId = networkId globals,
+            sgActiveSlotsCoeff = activeSlotVal $ activeSlotCoeff globals,
+            sgSecurityParam = securityParameter globals,
+            sgEpochLength = runIdentity $ flip epochInfoSize (EpochNo 1) $ epochInfo globals,
+            sgSlotsPerKESPeriod = slotsPerKESPeriod globals,
+            sgMaxKESEvolutions = maxKESEvo globals,
+            sgSlotLength = (secondsToNominalDiffTime 1),
+            sgUpdateQuorum = quorum globals,
+            sgMaxLovelaceSupply = maxLovelaceSupply globals,
+            sgProtocolParams =
+              emptyPParams
+                { PParams._rho = case boundRational 0.02 of
+                    Just rho -> rho
+                    Nothing -> error "boundRational 0.02 out of bounds"
+                }, -- genPParams
+            sgGenDelegs = mempty, --  genGenesisDelegationList
+            sgInitialFunds = mempty, -- genFundsList
+            sgStaking = emptyGenesisStaking -- genStaking
+          }
+
+      elabState = elaborateInitialState sg def genesisAccounts def
+   in elaborateBlocks_ globals modelBlocks elabState
+
+-- | Apply a list of ModelEpoch's to an empty ledger, then check the resulting
+-- ledger against a user supplied predicate.
+testChainModelInteractionWith ::
+  ( Testable prop,
+    ElaborateEraModel era,
+    Default (AdditionalGenesisConfig era),
+    Show (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (Core.Value era)
+  ) =>
+  proxy era ->
+  (NewEpochState era -> EraElaboratorState era -> prop) ->
+  [(ModelUTxOId, ModelAddress', Coin)] ->
+  [ModelEpoch AllModelFeatures] ->
+  Property
+testChainModelInteractionWith proxy p a = filterChainModelProp proxy $ \b ->
+  let (result, (nes, ees)) = chainModelInteractionWith proxy a b
+   in case result of
+        Right () -> property $! p nes ees
+        Left bad -> counterexample (show bad) False
+
+compareLists :: forall a. (Show a, Eq a) => [a] -> [a] -> Property
+compareLists a b = case nub a \\ nub b of
+  [] -> property True
+  _ -> a === b
+
+-- | Apply a list of ModelEpoch's to an empty ledger, then check the resulting
+-- error is the one predicted by the model.
+testChainModelInteractionRejection ::
+  forall era proxy.
+  ( ElaborateEraModel era,
+    Default (AdditionalGenesisConfig era),
+    Eq (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (PredicateFailure (Core.EraRule "LEDGER" era)),
+    Show (Core.Value era)
+  ) =>
+  proxy era ->
+  ModelPredicateFailure (EraFeatureSet era) ->
+  [(ModelUTxOId, ModelAddress', Coin)] ->
+  [ModelEpoch AllModelFeatures] ->
+  Property
+testChainModelInteractionRejection proxy e a = filterChainModelProp proxy $ \b ->
+  let (result, (nes, ees)) = chainModelInteractionWith proxy a b
+   in case result of
+        Left e' ->
+          let elaboratedError' = toEraPredicateFailure @era e (nes, ees)
+           in case elaboratedError' of
+                Left bad -> counterexample ("couldn't elaborate expected error:" <> show bad) False
+                Right elaboratedError -> case (e', elaboratedError) of
+                  (bad@(ElaborateBlockError_Fee {}), _) -> counterexample (show bad) False
+                  (bad@(ElaborateBlockError_TxValue {}), _) -> counterexample (show bad) False
+                  (ElaborateBlockError_ApplyTx (ApplyTxError te), ApplyBlockTransitionError_Tx (ApplyTxError te')) ->
+                    compareLists te te'
+        -- fallthrough if/when more error types are added
+        -- (te, te') -> te === te'
+
+        Right _ -> counterexample "no error encountered" False
+
+-- | Apply a list of ModelEpoch's to an empty ledger, and fail if there was an
+-- error
+testChainModelInteraction ::
+  ( Show (PredicateFailure (Core.EraRule "LEDGER" era)),
+    ElaborateEraModel era,
+    Default (AdditionalGenesisConfig era),
+    Show (Core.Value era)
+  ) =>
+  proxy era ->
+  [(ModelUTxOId, ModelAddress', Coin)] ->
+  [ModelEpoch AllModelFeatures] ->
+  Property
+testChainModelInteraction proxy = testChainModelInteractionWith proxy $ (\x y -> x `seq` y `seq` True)
+
+type AllScriptFeatures = ('TyScriptFeature 'True 'True)
+
+type AllModelFeatures = 'FeatureSet 'ExpectAnyOutput AllScriptFeatures
+
+filterChainModelProp ::
+  forall era proxy.
+  (ElaborateEraModel era) =>
+  proxy era ->
+  ([ModelEpoch (EraFeatureSet era)] -> Property) ->
+  [ModelEpoch AllModelFeatures] ->
+  Property
+filterChainModelProp proxy f xs =
+  case traverse (filterFeatures (eraFeatureSet proxy)) xs of
+    Nothing -> cover 0 True "feature absent in era" True -- todo, is there a nice way to report these?
+    Just xs' -> f xs'
+
+-- | helper to produce a "blank" ModelTx with most fields set to a reasonable
+-- "default"
+modelTx :: forall (era :: FeatureSet). KnownRequiredFeatures era => ModelTxId -> ModelTx era
+modelTx txId =
+  ModelTx
+    { _mtxId = txId,
+      _mtxInputs = Set.empty,
+      _mtxOutputs = [],
+      _mtxFee = ModelValue $ ModelValue_Inject $ Coin 0,
+      _mtxDCert = [],
+      _mtxWdrl = Map.empty,
+      _mtxMint = case reifyRequiredFeatures (Proxy :: Proxy era) of
+        FeatureTag v _ -> case v of
+          ValueFeatureTag_AdaOnly -> NoMintSupport ()
+          ValueFeatureTag_AnyOutput -> SupportsMint $ ModelValue $ ModelValue_Inject $ Coin 0,
+      _mtxCollateral = mapSupportsPlutus (const $ Set.empty) $ reifySupportsPlutus (Proxy :: Proxy (ScriptFeature era))
+    }

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Value.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/ModelChain/Value.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.ModelChain.Value where
+
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Val
+import Control.Monad
+import qualified Control.Monad.Except as Except
+import Data.Kind
+import Numeric.Natural
+
+data ModelValueF (a :: Type) where
+  ModelValue_Var :: a -> ModelValueF a
+  ModelValue_Inject :: Coin -> ModelValueF a
+  ModelValue_Scale :: Natural -> ModelValueF a -> ModelValueF a
+  ModelValue_Add :: ModelValueF a -> ModelValueF a -> ModelValueF a
+  ModelValue_Sub :: ModelValueF a -> ModelValueF a -> ModelValueF a
+
+deriving instance Show a => Show (ModelValueF a)
+
+deriving instance Eq a => Eq (ModelValueF a)
+
+deriving instance Ord a => Ord (ModelValueF a)
+
+deriving instance Functor ModelValueF
+
+deriving instance Foldable ModelValueF
+
+deriving instance Traversable ModelValueF
+
+data ModelValueError a
+  = ValueUnderflow a a
+  deriving (Show)
+
+evalModelValue ::
+  forall val m a.
+  (Val val, Monad m) =>
+  (a -> m val) ->
+  ModelValueF a ->
+  m (Either (ModelValueError val) val)
+evalModelValue env x = Except.runExceptT (go x)
+  where
+    go :: ModelValueF a -> Except.ExceptT (ModelValueError val) m val
+    go (ModelValue_Var a) = Except.lift $ env a
+    go (ModelValue_Inject c) = pure (inject c)
+    go (ModelValue_Add a b) = (<+>) <$> go a <*> go b
+    go (ModelValue_Scale n a) = (toInteger n <×>) <$> go a
+    go (ModelValue_Sub a b) = do
+      a' <- go a
+      b' <- go b
+      unless (pointwise (>=) a' b') $ Except.throwError $ ValueUnderflow a' b'
+      pure $ a' <-> b'

--- a/cardano-ledger-test/test/Tests.hs
+++ b/cardano-ledger-test/test/Tests.hs
@@ -14,6 +14,7 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
     alonzoUTXOWexamples,
     collectOrderingAlonzo,
   )
+import Test.Cardano.Ledger.ModelChain.Properties (modelUnitTests_)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
 
@@ -34,7 +35,8 @@ mainTests =
         "STS Tests"
         [ alonzoUTXOWexamples,
           alonzoBBODYexamples,
-          collectOrderingAlonzo
+          collectOrderingAlonzo,
+          modelUnitTests_
         ]
     ]
 

--- a/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
+++ b/shelley-ma/shelley-ma-test/cardano-ledger-shelley-ma-test.cabal
@@ -79,7 +79,7 @@ library
     tasty-hunit,
     tasty-quickcheck,
     tasty,
-    text
+    text,
   hs-source-dirs: src
 
 test-suite cardano-ledger-shelley-ma-test

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -46,10 +46,11 @@ library
     Shelley.Spec.Ledger.API
     Shelley.Spec.Ledger.API.ByronTranslation
     Shelley.Spec.Ledger.API.Genesis
+    Shelley.Spec.Ledger.API.Mempool
     Shelley.Spec.Ledger.API.Protocol
+    Shelley.Spec.Ledger.API.Types
     Shelley.Spec.Ledger.API.Validation
     Shelley.Spec.Ledger.API.Wallet
-    Shelley.Spec.Ledger.API.Mempool
     Shelley.Spec.Ledger.BaseTypes
     Shelley.Spec.Ledger.BlockChain
     Shelley.Spec.Ledger.CompactAddr
@@ -102,7 +103,6 @@ library
     Shelley.Spec.Ledger.Tx
     Shelley.Spec.Ledger.TxBody
     Shelley.Spec.Ledger.UTxO
-  other-modules:      Shelley.Spec.Ledger.API.Types
   hs-source-dirs: src
   build-depends:
     aeson,


### PR DESCRIPTION
Shrank the epochs down to transactions, while preserving the grouping. Each element in the final result has its own prefix of transactions. These changes were made to help in debugging  discovered errors easier.