### PR TITLE
Bump cardano-base. Update hash constraints accordingly

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,8 +27,8 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
-  --sha256: 0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq
+  tag: 01e74a41bba11569d36a7296167aac4af86960e6
+  --sha256: 0vf9p1kqsccn5sfhxlfjlwzkfkcpcj1g3ka500vyw26gzm9w0gyf
   subdir:
     base-deriving-via
     binary

--- a/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash (..),
@@ -14,17 +16,26 @@ module Cardano.Ledger.AuxiliaryData
 where
 
 import Cardano.Binary (FromCBOR, ToCBOR)
+import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
 import Cardano.Ledger.Hashes (EraIndependentAuxiliaryData)
-import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.SafeHash (SafeHash, SafeToHash)
 import Control.DeepSeq (NFData (..))
 import NoThunks.Class (NoThunks (..))
 
 newtype AuxiliaryDataHash crypto = AuxiliaryDataHash
   { unsafeAuxiliaryDataHash :: SafeHash crypto EraIndependentAuxiliaryData
   }
-  deriving (Show, Eq, Ord, NoThunks, NFData)
+
+type HashConstraint c = Hash.HashAlgorithm (CC.HASH c)
+
+deriving instance HashConstraint c => Show (AuxiliaryDataHash c)
+deriving instance HashConstraint c => Eq (AuxiliaryDataHash c)
+deriving instance HashConstraint c => Ord (AuxiliaryDataHash c)
+deriving instance HashConstraint c => SafeToHash (AuxiliaryDataHash c)
+deriving instance HashConstraint c => NoThunks (AuxiliaryDataHash c)
+deriving instance HashConstraint c => NFData (AuxiliaryDataHash c)
 
 deriving instance
   CC.Crypto crypto =>

--- a/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -51,17 +51,17 @@ import Quiet
 -- parameter is a phantom, however, so in actuality the instances will remain
 -- the same.
 data Credential (kr :: KeyRole) crypto
-  = ScriptHashObj {-# UNPACK #-} !(ScriptHash crypto)
-  | KeyHashObj {-# UNPACK #-} !(KeyHash kr crypto)
+  = ScriptHashObj !(ScriptHash crypto)
+  | KeyHashObj !(KeyHash kr crypto)
   deriving (Show, Eq, Generic, NFData, Ord)
 
 instance HasKeyRole Credential where
   coerceKeyRole (ScriptHashObj x) = ScriptHashObj x
   coerceKeyRole (KeyHashObj x) = KeyHashObj $ coerceKeyRole x
 
-instance NoThunks (Credential kr crypto)
+instance CC.Crypto crypto => NoThunks (Credential kr crypto)
 
-instance ToJSON (Credential kr crypto) where
+instance CC.Crypto crypto => ToJSON (Credential kr crypto) where
   toJSON (ScriptHashObj hash) =
     Aeson.object
       [ "script hash" .= hash
@@ -79,7 +79,7 @@ instance CC.Crypto crypto => FromJSON (Credential kr crypto) where
       parser1 obj = ScriptHashObj <$> obj .: "script hash"
       parser2 obj = KeyHashObj <$> obj .: "key hash"
 
-instance ToJSONKey (Credential kr crypto)
+instance CC.Crypto crypto => ToJSONKey (Credential kr crypto)
 
 instance CC.Crypto crypto => FromJSONKey (Credential kr crypto)
 
@@ -93,7 +93,7 @@ data StakeReference crypto
   | StakeRefNull
   deriving (Show, Eq, Generic, NFData, Ord)
 
-instance NoThunks (StakeReference crypto)
+instance CC.Crypto crypto => NoThunks (StakeReference crypto)
 
 type Ix = Word64
 
@@ -153,10 +153,10 @@ newtype GenesisCredential crypto = GenesisCredential
   deriving (Generic)
   deriving (Show) via Quiet (GenesisCredential crypto)
 
-instance Ord (GenesisCredential crypto) where
+instance CC.Crypto crypto => Ord (GenesisCredential crypto) where
   compare (GenesisCredential gh) (GenesisCredential gh') = compare gh gh'
 
-instance Eq (GenesisCredential crypto) where
+instance CC.Crypto crypto => Eq (GenesisCredential crypto) where
   (==) (GenesisCredential gh) (GenesisCredential gh') = gh == gh'
 
 instance

--- a/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Various identifiers in the ledger are hashes of particular structures.
 -- While the structures may change from era to era, the hash will remain the
@@ -72,8 +75,16 @@ type EraIndependentWitnessPPData = EraIndependentScriptIntegrity
 
 newtype ScriptHash crypto
   = ScriptHash (Hash.Hash (ADDRHASH crypto) EraIndependentScript)
-  deriving (Show, Eq, Ord, Generic)
-  deriving newtype (NFData, NoThunks)
+  deriving (Generic)
+
+type HashConstraint crypto = Hash.HashAlgorithm (ADDRHASH crypto)
+
+deriving instance HashConstraint crypto => Show (ScriptHash crypto)
+deriving instance HashConstraint crypto => Eq (ScriptHash crypto)
+deriving instance HashConstraint crypto => Ord (ScriptHash crypto)
+
+deriving newtype instance HashConstraint crypto => NFData (ScriptHash crypto)
+deriving newtype instance HashConstraint crypto => NoThunks (ScriptHash crypto)
 
 deriving newtype instance
   CC.Crypto crypto =>
@@ -83,6 +94,6 @@ deriving newtype instance
   CC.Crypto crypto =>
   FromCBOR (ScriptHash crypto)
 
-deriving newtype instance ToJSON (ScriptHash crypto)
+deriving newtype instance CC.Crypto crypto => ToJSON (ScriptHash crypto)
 
 deriving newtype instance CC.Crypto crypto => FromJSON (ScriptHash crypto)

--- a/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -230,8 +230,14 @@ hashSignature = Hash.hashWith (DSIGN.rawSerialiseSigDSIGN . coerce)
 -- | Discriminated hash of public Key
 newtype KeyHash (discriminator :: KeyRole) crypto
   = KeyHash (Hash.Hash (ADDRHASH crypto) (DSIGN.VerKeyDSIGN (DSIGN crypto)))
-  deriving (Show, Eq, Ord)
-  deriving newtype (NFData, NoThunks, Generic)
+  deriving (Generic)
+
+deriving instance Crypto crypto => Show (KeyHash disc crypto)
+deriving instance Crypto crypto => Eq (KeyHash disc crypto)
+deriving instance Crypto crypto => Ord (KeyHash disc crypto)
+
+deriving newtype instance Crypto crypto => NFData (KeyHash disc crypto)
+deriving newtype instance Crypto crypto => NoThunks (KeyHash disc crypto)
 
 deriving instance
   (Crypto crypto, Typeable disc) =>
@@ -241,13 +247,17 @@ deriving instance
   (Crypto crypto, Typeable disc) =>
   FromCBOR (KeyHash disc crypto)
 
-deriving newtype instance ToJSONKey (KeyHash disc crypto)
+deriving newtype instance
+  (Crypto crypto) =>
+  ToJSONKey (KeyHash disc crypto)
 
 deriving newtype instance
   (Crypto crypto) =>
   FromJSONKey (KeyHash disc crypto)
 
-deriving newtype instance ToJSON (KeyHash disc crypto)
+deriving newtype instance
+  (Crypto crypto) =>
+  ToJSON (KeyHash disc crypto)
 
 deriving newtype instance
   (Crypto crypto) =>
@@ -274,10 +284,6 @@ type KESignable c = KES.Signable (KES c)
 --------------------------------------------------------------------------------
 
 type VRFSignable c = VRF.Signable (VRF c)
-
---------------------------------------------------------------------------------
--- Genesis delegation
---
 -- TODO should this really live in here?
 --------------------------------------------------------------------------------
 
@@ -285,11 +291,15 @@ data GenDelegPair crypto = GenDelegPair
   { genDelegKeyHash :: !(KeyHash 'GenesisDelegate crypto),
     genDelegVrfHash :: !(Hash crypto (VerKeyVRF crypto))
   }
-  deriving (Show, Eq, Ord, Generic)
 
-instance NoThunks (GenDelegPair crypto)
+deriving instance Crypto crypto => Show (GenDelegPair crypto)
+deriving instance Crypto crypto => Eq (GenDelegPair crypto)
+deriving instance Crypto crypto => Ord (GenDelegPair crypto)
+deriving instance Crypto crypto => Generic (GenDelegPair crypto)
 
-instance NFData (GenDelegPair crypto)
+instance Crypto crypto => NoThunks (GenDelegPair crypto)
+
+instance Crypto crypto => NFData (GenDelegPair crypto)
 
 instance Crypto crypto => ToCBOR (GenDelegPair crypto) where
   toCBOR (GenDelegPair hk vrf) =
@@ -319,8 +329,16 @@ instance Crypto crypto => FromJSON (GenDelegPair crypto) where
 newtype GenDelegs crypto = GenDelegs
   { unGenDelegs :: Map (KeyHash 'Genesis crypto) (GenDelegPair crypto)
   }
-  deriving (Eq, FromCBOR, NoThunks, NFData, Generic)
+  deriving (Eq, FromCBOR, Generic)
   deriving (Show) via Quiet (GenDelegs crypto)
+
+deriving instance
+  (Crypto crypto) =>
+  NoThunks (GenDelegs crypto)
+
+deriving instance
+  (Crypto crypto) =>
+  NFData (GenDelegs crypto)
 
 deriving instance
   (Crypto crypto) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 -- | API to the Shelley ledger
@@ -12,6 +13,7 @@ where
 
 import Cardano.Ledger.Core (ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Constraints
@@ -48,4 +50,5 @@ class
   ) =>
   ShelleyBasedEra era
 
-instance PraosCrypto crypto => ShelleyBasedEra (ShelleyEra crypto)
+instance (CC.Crypto (ShelleyEra crypto), PraosCrypto crypto) =>
+  ShelleyBasedEra (ShelleyEra crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -25,6 +25,7 @@ where
 import Cardano.Ledger.BaseTypes (Globals (..), ShelleyBase)
 import Cardano.Ledger.Core (AnnotatedData, ChainData, SerialisableData)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Slot (SlotNo)
@@ -186,7 +187,7 @@ applyBlock =
         asoEvents = EPDiscard
       }
 
-instance PraosCrypto crypto => ApplyBlock (ShelleyEra crypto)
+instance (CC.Crypto (ShelleyEra crypto), PraosCrypto crypto) => ApplyBlock (ShelleyEra crypto)
 
 {-------------------------------------------------------------------------------
   CHAIN Transition checks

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/CompactAddr.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/CompactAddr.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -61,7 +62,7 @@ newtype CompactAddr crypto = UnsafeCompactAddr ShortByteString
 instance CC.Crypto c => Show (CompactAddr c) where
   show c = show (decompactAddr c)
 
-compactAddr :: Addr crypto -> CompactAddr crypto
+compactAddr :: Hash.HashAlgorithm (ADDRHASH crypto) => Addr crypto -> CompactAddr crypto
 compactAddr = UnsafeCompactAddr . SBS.toShort . serialiseAddr
 
 decompactAddr :: forall crypto. CC.Crypto crypto => CompactAddr crypto -> Addr crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -126,6 +126,7 @@ aggregateUtxoCoinByCredential ptrs (UTxO u) initial =
 
 -- | Get stake of one pool
 poolStake ::
+  CC.Crypto crypto =>
   KeyHash 'StakePool crypto ->
   Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto) ->
   Stake crypto ->
@@ -184,9 +185,9 @@ data SnapShot crypto = SnapShot
   }
   deriving (Show, Eq, Generic)
 
-instance NoThunks (SnapShot crypto)
+instance CC.Crypto crypto => NoThunks (SnapShot crypto)
 
-instance NFData (SnapShot crypto)
+instance CC.Crypto crypto => NFData (SnapShot crypto)
 
 instance
   CC.Crypto crypto =>
@@ -217,9 +218,9 @@ data SnapShots crypto = SnapShots
   }
   deriving (Show, Eq, Generic)
 
-instance NoThunks (SnapShots crypto)
+instance CC.Crypto crypto => NoThunks (SnapShots crypto)
 
-instance NFData (SnapShots crypto)
+instance CC.Crypto crypto => NFData (SnapShots crypto)
 
 instance
   CC.Crypto crypto =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Genesis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -95,7 +96,7 @@ data ShelleyGenesisStaking crypto = ShelleyGenesisStaking
   }
   deriving stock (Eq, Show, Generic)
 
-instance NoThunks (ShelleyGenesisStaking crypto)
+instance CC.Crypto crypto => NoThunks (ShelleyGenesisStaking crypto)
 
 instance CC.Crypto crypto => ToCBOR (ShelleyGenesisStaking crypto) where
   toCBOR (ShelleyGenesisStaking pools stake) =
@@ -139,9 +140,14 @@ data ShelleyGenesis era = ShelleyGenesis
     sgInitialFunds :: !(Map (Addr (Crypto era)) Coin),
     sgStaking :: !(ShelleyGenesisStaking (Crypto era))
   }
-  deriving stock (Eq, Show, Generic)
+  deriving stock Generic
 
-deriving instance Era era => NoThunks (ShelleyGenesis era)
+type HashConstraint crypto = CC.Crypto (Crypto crypto)
+
+deriving stock instance HashConstraint crypto => Show (ShelleyGenesis crypto)
+deriving stock instance HashConstraint crypto => Eq (ShelleyGenesis crypto)
+
+deriving instance (Era era, CC.Crypto era) => NoThunks (ShelleyGenesis era)
 
 sgActiveSlotCoeff :: ShelleyGenesis era -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
@@ -65,6 +65,7 @@ data OCertEnv crypto = OCertEnv
   deriving (Show, Eq)
 
 currentIssueNo ::
+  Crypto crypto =>
   OCertEnv crypto ->
   Map (KeyHash 'BlockIssuer crypto) Word64 ->
   -- | Pool hash

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OverlaySchedule.hs
@@ -62,9 +62,9 @@ instance
         pure NonActiveSlot
       _ -> ActiveSlot <$> fromCBOR
 
-instance NoThunks (OBftSlot crypto)
+instance Crypto crypto => NoThunks (OBftSlot crypto)
 
-instance NFData (OBftSlot crypto)
+instance Crypto crypto => NFData (OBftSlot crypto)
 
 isOverlaySlot ::
   SlotNo -> -- starting slot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -46,6 +46,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (PParamsDelta)
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
@@ -192,7 +193,7 @@ instance ToCBORGroup ProtVer where
 instance FromCBORGroup ProtVer where
   fromCBORGroup = ProtVer <$> fromCBOR <*> fromCBOR
 
-instance NoThunks (PParams era)
+instance CC.Crypto era => NoThunks (PParams era)
 
 instance (Era era) => ToCBOR (PParams era) where
   toCBOR
@@ -331,15 +332,15 @@ data Update era
   = Update !(ProposedPPUpdates era) !EpochNo
   deriving (Generic)
 
-deriving instance Eq (PParamsDelta era) => Eq (Update era)
+deriving instance (CC.Crypto (Crypto era), Eq (PParamsDelta era)) => Eq (Update era)
 
-deriving instance NFData (PParamsDelta era) => NFData (Update era)
+deriving instance (CC.Crypto (Crypto era), NFData (PParamsDelta era)) => NFData (Update era)
 
-deriving instance Show (PParamsDelta era) => Show (Update era)
+deriving instance (CC.Crypto (Crypto era), Show (PParamsDelta era)) => Show (Update era)
 
-instance NoThunks (PParamsDelta era) => NoThunks (Update era)
+instance (CC.Crypto (Crypto era), NoThunks (PParamsDelta era)) => NoThunks (Update era)
 
-instance (Era era, ToCBOR (PParamsDelta era)) => ToCBOR (Update era) where
+instance (Era era, CC.Crypto (Crypto era), ToCBOR (PParamsDelta era)) => ToCBOR (Update era) where
   toCBOR (Update ppUpdate e) =
     encodeListLen 2 <> toCBOR ppUpdate <> toCBOR e
 
@@ -352,7 +353,7 @@ instance
 data PPUpdateEnv era = PPUpdateEnv SlotNo (GenDelegs era)
   deriving (Show, Eq, Generic)
 
-instance NoThunks (PPUpdateEnv era)
+instance CC.Crypto era => NoThunks (PPUpdateEnv era)
 
 type PParamsUpdate era = PParams' StrictMaybe era
 
@@ -450,13 +451,13 @@ newtype ProposedPPUpdates era
   = ProposedPPUpdates (Map (KeyHash 'Genesis (Crypto era)) (PParamsDelta era))
   deriving (Generic)
 
-deriving instance Eq (PParamsDelta era) => Eq (ProposedPPUpdates era)
+deriving instance (CC.Crypto (Crypto era), Eq (PParamsDelta era)) => Eq (ProposedPPUpdates era)
 
-deriving instance NFData (PParamsDelta era) => NFData (ProposedPPUpdates era)
+deriving instance (CC.Crypto (Crypto era), NFData (PParamsDelta era)) => NFData (ProposedPPUpdates era)
 
-deriving instance Show (PParamsDelta era) => Show (ProposedPPUpdates era)
+deriving instance (CC.Crypto (Crypto era), Show (PParamsDelta era)) => Show (ProposedPPUpdates era)
 
-instance NoThunks (PParamsDelta era) => NoThunks (ProposedPPUpdates era)
+instance (CC.Crypto (Crypto era), NoThunks (PParamsDelta era)) => NoThunks (ProposedPPUpdates era)
 
 instance
   (Era era, ToCBOR (PParamsDelta era)) =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardProvenance.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/RewardProvenance.hs
@@ -19,6 +19,7 @@ import Cardano.Binary
     decodeDouble,
     encodeDouble,
   )
+import qualified Cardano.Crypto.Hash.Class as HS
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
 import qualified Cardano.Ledger.Crypto as CC
@@ -76,16 +77,19 @@ data RewardProvenancePool crypto = RewardProvenancePool
   }
   deriving (Eq, Generic)
 
-instance NoThunks (RewardProvenancePool crypto)
+instance CC.Crypto crypto => NoThunks (RewardProvenancePool crypto)
 
-instance NFData (RewardProvenancePool crypto)
+instance CC.Crypto crypto => NFData (RewardProvenancePool crypto)
 
 deriving instance (CC.Crypto crypto) => FromJSON (RewardProvenancePool crypto)
 
 deriving instance (CC.Crypto crypto) => ToJSON (RewardProvenancePool crypto)
 
-instance Default (RewardProvenancePool crypto) where
-  def = RewardProvenancePool 0 0 0 (Coin 0) def 0 (Coin 0) 0 (Coin 0) (Coin 0)
+instance ( HS.HashAlgorithm (CC.ADDRHASH crypto),
+           HS.HashAlgorithm (CC.HASH crypto)
+         ) => Default (RewardProvenancePool crypto)
+         where
+         def = RewardProvenancePool 0 0 0 (Coin 0) def 0 (Coin 0) 0 (Coin 0) (Coin 0)
 
 -- | The desirability score of a stake pool, as described
 -- in <https://arxiv.org/abs/1807.11218 "Reward Sharing Schemes for Stake Pools">.
@@ -169,9 +173,9 @@ deriving instance (CC.Crypto crypto) => FromJSON (RewardProvenance crypto)
 
 deriving instance (CC.Crypto crypto) => ToJSON (RewardProvenance crypto)
 
-instance NoThunks (RewardProvenance crypto)
+instance CC.Crypto crypto => NoThunks (RewardProvenance crypto)
 
-instance NFData (RewardProvenance crypto)
+instance CC.Crypto crypto => NFData (RewardProvenance crypto)
 
 instance Default (RewardProvenance crypto) where
   def =
@@ -193,16 +197,19 @@ instance Default (RewardProvenance crypto) where
       def
       def
 
-instance Default (PoolParams crypto) where
-  def = PoolParams def def (Coin 0) (Coin 0) def def def def def
+instance ( HS.HashAlgorithm (CC.ADDRHASH crypto),
+           HS.HashAlgorithm (CC.HASH crypto)
+         ) => Default (PoolParams crypto)
+         where
+         def = PoolParams def def (Coin 0) (Coin 0) def def def def def
 
-instance Default (Credential r e) where
+instance HS.HashAlgorithm (CC.ADDRHASH e) => Default (Credential r e) where
   def = KeyHashObj def
 
-instance Default (RewardAcnt crypto) where
+instance HS.HashAlgorithm (CC.ADDRHASH crypto) => Default (RewardAcnt crypto) where
   def = RewardAcnt def def
 
-instance Default (SafeHash c i) where
+instance HS.HashAlgorithm (CC.HASH c) => Default (SafeHash c i) where
   def = unsafeMakeSafeHash def
 
 -- =======================================================
@@ -211,7 +218,7 @@ instance Default (SafeHash c i) where
 mylines :: Int -> [String] -> String
 mylines n xs = unlines (map (replicate n ' ' ++) xs)
 
-instance Show (RewardProvenancePool crypto) where
+instance CC.Crypto crypto => Show (RewardProvenancePool crypto) where
   show t =
     "RewardProvenancePool\n"
       ++ mylines
@@ -228,7 +235,7 @@ instance Show (RewardProvenancePool crypto) where
           "lReward = " ++ show (lRewardP t)
         ]
 
-showPoolParams :: PoolParams crypto -> String
+showPoolParams :: CC.Crypto crypto => PoolParams crypto -> String
 showPoolParams x =
   "PoolParams\n"
     ++ mylines
@@ -244,7 +251,7 @@ showPoolParams x =
         "poolMD = " ++ show (_poolMD x)
       ]
 
-instance Show (RewardProvenance crypto) where
+instance CC.Crypto crypto => Show (RewardProvenance crypto) where
   show t =
     "RewardProvenance\n"
       ++ mylines

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -31,6 +31,7 @@ module Shelley.Spec.Ledger.STS.Chain
   )
 where
 
+import Cardano.Crypto.Hash.Blake2b (Blake2b_256)
 import Cardano.Ledger.BaseTypes
   ( Globals (..),
     Nonce (..),
@@ -40,6 +41,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import qualified Cardano.Ledger.Era as Era
 import Cardano.Ledger.Keys
@@ -191,7 +193,8 @@ instance
 
 -- | Creates a valid initial chain state
 initialShelleyState ::
-  ( Default (State (Core.EraRule "PPUP" era))
+  ( Default (State (Core.EraRule "PPUP" era)),
+    CC.Crypto (Crypto era)
   ) =>
   WithOrigin (LastAppliedBlock (Crypto era)) ->
   EpochNo ->
@@ -260,7 +263,8 @@ instance
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "_extraEntropy" (Core.PParams era) Nonce,
     HasField "_d" (Core.PParams era) UnitInterval,
-    ToCBORGroup (Era.TxSeq era)
+    ToCBORGroup (Era.TxSeq era),
+    CC.HASH (Crypto era) ~ Blake2b_256
   ) =>
   STS (CHAIN era)
   where
@@ -343,7 +347,8 @@ chainTransition ::
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "_extraEntropy" (Core.PParams era) Nonce,
     HasField "_d" (Core.PParams era) UnitInterval,
-    ToCBORGroup (Era.TxSeq era)
+    ToCBORGroup (Era.TxSeq era),
+    CC.HASH (Crypto era) ~ Blake2b_256
   ) =>
   TransitionRule (CHAIN era)
 chainTransition =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), addDeltaCoin, toDeltaCoin)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys
@@ -135,13 +136,17 @@ data DelegPredicateFailure era
       !Coin -- amount attempted to transfer
       !Coin -- amount available
   | MIRProducesNegativeUpdate
-  deriving (Show, Eq, Generic)
+  deriving Generic
+
+deriving instance CC.Crypto (Crypto era) => Show (DelegPredicateFailure era)
+deriving instance CC.Crypto (Crypto era) => Eq (DelegPredicateFailure era)
 
 newtype DelegEvent era = NewEpoch EpochNo
 
 instance
   ( Typeable era,
-    HasField "_protocolVersion" (Core.PParams era) ProtVer
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    CC.Crypto (Crypto era)
   ) =>
   STS (DELEG era)
   where
@@ -154,7 +159,7 @@ instance
 
   transitionRules = [delegationTransition]
 
-instance NoThunks (DelegPredicateFailure era)
+instance CC.Crypto (Crypto era) => NoThunks (DelegPredicateFailure era)
 
 instance
   (Typeable era, Era era, Typeable (Core.Script era)) =>
@@ -254,7 +259,8 @@ instance
 
 delegationTransition ::
   ( Typeable era,
-    HasField "_protocolVersion" (Core.PParams era) ProtVer
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    CC.Crypto (Crypto era)
   ) =>
   TransitionRule (DELEG era)
 delegationTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
@@ -110,12 +111,14 @@ data DelegsPredicateFailure era
 newtype DelegsEvent era = DelplEvent (Event (Core.EraRule "DELPL" era))
 
 deriving stock instance
-  ( Show (PredicateFailure (Core.EraRule "DELPL" era))
+  ( Show (PredicateFailure (Core.EraRule "DELPL" era)),
+    CC.Crypto (Crypto era)
   ) =>
   Show (DelegsPredicateFailure era)
 
 deriving stock instance
-  ( Eq (PredicateFailure (Core.EraRule "DELPL" era))
+  ( Eq (PredicateFailure (Core.EraRule "DELPL" era)),
+    CC.Crypto (Crypto era)
   ) =>
   Eq (DelegsPredicateFailure era)
 
@@ -125,7 +128,8 @@ instance
     Embed (Core.EraRule "DELPL" era) (DELEGS era),
     Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
-    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
+    Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
+    CC.Crypto (Crypto era)
   ) =>
   STS (DELEGS era)
   where
@@ -141,7 +145,8 @@ instance
   transitionRules = [delegsTransition]
 
 instance
-  ( NoThunks (PredicateFailure (Core.EraRule "DELPL" era))
+  ( NoThunks (PredicateFailure (Core.EraRule "DELPL" era)),
+    CC.Crypto (Crypto era)
   ) =>
   NoThunks (DelegsPredicateFailure era)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -22,6 +22,7 @@ where
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
 import Cardano.Ledger.Slot (EpochNo)
@@ -145,7 +146,8 @@ epochTransition ::
     State (Core.EraRule "UPEC" era) ~ UpecState era,
     Signal (Core.EraRule "UPEC" era) ~ (),
     HasField "_keyDeposit" (Core.PParams era) Coin,
-    HasField "_poolDeposit" (Core.PParams era) Coin
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    CC.Crypto (Crypto era)
   ) =>
   TransitionRule (EPOCH era)
 epochTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -19,6 +19,7 @@ where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Coin (Coin, addDeltaCoin)
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Val ((<->))
 import Control.SetAlgebra (dom, eval, (∪+), (◁))
@@ -68,7 +69,10 @@ data MirEvent era
 
 instance NoThunks (MirPredicateFailure era)
 
-instance (Typeable era, Default (EpochState era)) => STS (MIR era) where
+instance ( Typeable era,
+           Default (EpochState era),
+           CC.Crypto (Crypto era)
+         ) => STS (MIR era) where
   type State (MIR era) = EpochState era
   type Signal (MIR era) = ()
   type Environment (MIR era) = ()
@@ -87,7 +91,7 @@ instance (Typeable era, Default (EpochState era)) => STS (MIR era) where
         )
     ]
 
-mirTransition :: forall era. TransitionRule (MIR era)
+mirTransition :: forall era. CC.Crypto (Crypto era) => TransitionRule (MIR era)
 mirTransition = do
   TRC
     ( _,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -23,6 +23,7 @@ where
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (KeyRole (Staking))
@@ -57,19 +58,22 @@ data NewEpochPredicateFailure era
 
 deriving stock instance
   ( Show (PredicateFailure (Core.EraRule "EPOCH" era)),
-    Show (PredicateFailure (Core.EraRule "MIR" era))
+    Show (PredicateFailure (Core.EraRule "MIR" era)),
+    CC.Crypto (Crypto era)
   ) =>
   Show (NewEpochPredicateFailure era)
 
 deriving stock instance
   ( Eq (PredicateFailure (Core.EraRule "EPOCH" era)),
-    Eq (PredicateFailure (Core.EraRule "MIR" era))
+    Eq (PredicateFailure (Core.EraRule "MIR" era)),
+    CC.Crypto (Crypto era)
   ) =>
   Eq (NewEpochPredicateFailure era)
 
 instance
   ( NoThunks (PredicateFailure (Core.EraRule "EPOCH" era)),
-    NoThunks (PredicateFailure (Core.EraRule "MIR" era))
+    NoThunks (PredicateFailure (Core.EraRule "MIR" era)),
+    CC.Crypto (Crypto era)
   ) =>
   NoThunks (NewEpochPredicateFailure era)
 
@@ -169,7 +173,7 @@ newEpochTransition = do
           SNothing
           pd'
 
-calculatePoolDistr :: SnapShot crypto -> PoolDistr crypto
+calculatePoolDistr :: CC.Crypto crypto => SnapShot crypto -> PoolDistr crypto
 calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
   let Coin total = Map.foldl' (<>) mempty stake
       sd =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -52,7 +52,7 @@ data OcertPredicateFailure crypto
       !(KeyHash 'BlockIssuer crypto) -- stake pool key hash
   deriving (Show, Eq, Generic)
 
-instance NoThunks (OcertPredicateFailure crypto)
+instance Crypto crypto => NoThunks (OcertPredicateFailure crypto)
 
 instance
   ( Crypto crypto,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -84,7 +84,7 @@ data OverlayEnv crypto
       Nonce
   deriving (Generic)
 
-instance NoThunks (OverlayEnv crypto)
+instance Crypto crypto => NoThunks (OverlayEnv crypto)
 
 data OverlayPredicateFailure crypto
   = VRFKeyUnknown
@@ -146,11 +146,11 @@ instance
   transitionRules = [overlayTransition]
 
 deriving instance
-  (VRF.VRFAlgorithm (VRF crypto)) =>
+  (Crypto crypto, VRF.VRFAlgorithm (VRF crypto)) =>
   Show (OverlayPredicateFailure crypto)
 
 deriving instance
-  (VRF.VRFAlgorithm (VRF crypto)) =>
+  (Crypto crypto, VRF.VRFAlgorithm (VRF crypto)) =>
   Eq (OverlayPredicateFailure crypto)
 
 vrfChecks ::
@@ -279,7 +279,7 @@ overlayTransition =
         trans @(OCERT crypto) $ TRC (oce, cs, bh)
 
 instance
-  (VRF.VRFAlgorithm (VRF crypto)) =>
+  (Crypto crypto, VRF.VRFAlgorithm (VRF crypto)) =>
   NoThunks (OverlayPredicateFailure crypto)
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -102,9 +102,12 @@ data PoolPredicateFailure era
   | PoolMedataHashTooBig
       !(KeyHash 'StakePool (Crypto era)) -- Stake Pool ID
       !Int -- Size of the metadata hash
-  deriving (Show, Eq, Generic)
+  deriving Generic
 
-instance NoThunks (PoolPredicateFailure era)
+deriving instance CC.Crypto (Crypto era) => Show (PoolPredicateFailure era)
+deriving instance CC.Crypto (Crypto era) => Eq (PoolPredicateFailure era)
+
+instance CC.Crypto (Crypto era) => NoThunks (PoolPredicateFailure era)
 
 instance
   ( Era era,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -21,6 +21,7 @@ where
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Ledger.Val ((<+>), (<->))
@@ -75,7 +76,8 @@ instance
   ( Typeable era,
     Default (PoolreapState era),
     HasField "_poolDeposit" (Core.PParams era) Coin,
-    HasField "_keyDeposit" (Core.PParams era) Coin
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    CC.Crypto (Crypto era)
   ) =>
   STS (POOLREAP era)
   where
@@ -101,7 +103,9 @@ instance
     ]
 
 poolReapTransition ::
-  HasField "_poolDeposit" (Core.PParams era) Coin =>
+  ( HasField "_poolDeposit" (Core.PParams era) Coin,
+    CC.Crypto (Crypto era)
+  ) =>
   TransitionRule (POOLREAP era)
 poolReapTransition = do
   TRC (pp, PoolreapState us a ds ps, e) <- judgmentContext

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -27,6 +27,7 @@ import Cardano.Binary
     ToCBOR (toCBOR),
     encodeListLen,
   )
+import Cardano.Crypto.Hash.Class (HashAlgorithm)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes
   ( Nonce,
@@ -34,7 +35,7 @@ import Cardano.Ledger.BaseTypes
     ShelleyBase,
     UnitInterval,
   )
-import Cardano.Ledger.Crypto (Crypto, VRF)
+import Cardano.Ledger.Crypto (Crypto, HASH, VRF)
 import Cardano.Ledger.Keys
   ( DSignable,
     GenDelegs (..),
@@ -110,7 +111,7 @@ data PrtclEnv crypto
       Nonce
   deriving (Generic)
 
-instance NoThunks (PrtclEnv crypto)
+instance Crypto crypto => NoThunks (PrtclEnv crypto)
 
 data PrtclPredicateFailure crypto
   = OverlayFailure (PredicateFailure (OVERLAY crypto)) -- Subtransition Failures
@@ -122,11 +123,11 @@ data PrtclEvent crypto
   | NoEvent Void
 
 deriving instance
-  (VRF.VRFAlgorithm (VRF crypto)) =>
+  (Crypto crypto, VRF.VRFAlgorithm (VRF crypto)) =>
   Show (PrtclPredicateFailure crypto)
 
 deriving instance
-  (VRF.VRFAlgorithm (VRF crypto)) =>
+  (Crypto crypto, VRF.VRFAlgorithm (VRF crypto)) =>
   Eq (PrtclPredicateFailure crypto)
 
 instance
@@ -233,7 +234,10 @@ data PrtlSeqFailure crypto
       -- ^ Last applied hash
       (PrevHash crypto)
       -- ^ Current block's previous hash
-  deriving (Show, Eq, Generic)
+  deriving Generic
+
+deriving instance HashAlgorithm (HASH crypto) => Show (PrtlSeqFailure crypto)
+deriving instance HashAlgorithm (HASH crypto) => Eq (PrtlSeqFailure crypto)
 
 instance Crypto crypto => NoThunks (PrtlSeqFailure crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -25,6 +25,7 @@ where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfo)
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue)
@@ -111,6 +112,7 @@ instance
   transitionRules = [bheadTransition]
 
 adoptGenesisDelegs ::
+  CC.Crypto (Crypto era) =>
   EpochState era ->
   SlotNo ->
   EpochState era
@@ -149,7 +151,8 @@ validatingTickTransition ::
     BaseM (tick era) ~ ShelleyBase,
     Environment (Core.EraRule "NEWEPOCH" era) ~ (),
     State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
-    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo,
+    CC.Crypto (Crypto era)
   ) =>
   NewEpochState era ->
   SlotNo ->
@@ -176,7 +179,8 @@ bheadTransition ::
     Signal (Core.EraRule "RUPD" era) ~ SlotNo,
     Environment (Core.EraRule "NEWEPOCH" era) ~ (),
     State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
-    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo,
+    CC.Crypto (Crypto era)
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
@@ -127,7 +128,7 @@ data UtxoEnv era
       (Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)))
       (GenDelegs (Crypto era))
 
-deriving instance Show (Core.PParams era) => Show (UtxoEnv era)
+deriving instance (CC.Crypto (Crypto era), Show (Core.PParams era)) => Show (UtxoEnv era)
 
 data UtxoEvent era
   = TotalDeposits Coin

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -559,6 +559,7 @@ txwitsScript = getField @"scriptWits"
 
 extractKeyHashWitnessSet ::
   forall (r :: KeyRole) crypto.
+  CC.Crypto crypto =>
   [Credential r crypto] ->
   Set (KeyHash 'Witness crypto)
 extractKeyHashWitnessSet = foldr accum Set.empty


### PR DESCRIPTION
Reference: https://github.com/input-output-hk/cardano-base/commit/01e74a41bba11569d36a7296167aac4af86960e6.

Changes:
- `Hash` has extended the fixed `ShortByteString` representation to a `type HashRep h :: Type` in `HashAlgorithm`.
- This leads to the need to add many `HashAlgorithm` constraints to related functions and instances.
- Also requires removing the `UNPACK` pragmas on `Hash`.
- Also requires more `Cardano.Ledger.Crypto.Crypto` constraints.
- Also leads to `Cardano.Ledger.Crypto.HASH crypto ~ Blake2b_256` at some places related to the "rigid" type `Nonce`.

This is only halfway through, might as well be far from half.

Disclaimer: WIP code, still need another full review after completion to fix formatting and mistakes in comments, etc.