### PR TITLE
Make Alonzo TxOut a sum type to save memory

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -183,8 +183,7 @@ instance Crypto c => TranslateEra (AlonzoEra c) API.ProposedPPUpdates where
 
 translateTxOut ::
   Core.TxOut (MaryEra c) -> Core.TxOut (AlonzoEra c)
-translateTxOut (Shelley.TxOutCompact addr value) =
-  TxOutCompact addr value SNothing
+translateTxOut (Shelley.TxOutCompact addr value) = TxOutCompact addr value
 
 -- extendPP with type: extendPP :: Shelley.PParams' f era1 -> ... -> PParams' f era2
 -- Is general enough to work for both


### PR DESCRIPTION
While investigating our options to save memory for the hashes, @redxaxder noticed that we can save memory in Alonzo by making the TxOut a ~GADT~ sum type. (I have regrets about this branch name now :) ).