### PR TITLE
At PV6, translate time for Plutus correctly.

### DIFF
--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -24,6 +24,7 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (ProtVer)
 import Cardano.Ledger.Alonzo.Scripts (CostModel, ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as AlonzoScript (Script (..))
 import Cardano.Ledger.Alonzo.Tx
@@ -152,6 +153,7 @@ collectTwoPhaseScriptInputs ::
     Core.Value era ~ Mary.Value (Crypto era),
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
@@ -169,7 +171,7 @@ collectTwoPhaseScriptInputs ei sysS pp tx utxo =
     Nothing -> Left [NoCostModel PlutusV1]
     Just cost -> merge (apply cost) (map redeemer needed) (map getscript needed) (Right [])
   where
-    txinfo = runIdentity $ txInfo ei sysS utxo tx
+    txinfo = runIdentity $ txInfo pp ei sysS utxo tx
     needed = filter knownToNotBe1Phase $ scriptsNeeded utxo tx
     -- The formal spec achieves the same filtering as knownToNotBe1Phase
     -- by use of the (partial) language function, which is not defined

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -22,6 +22,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Language (Language)
+import Cardano.Ledger.Alonzo.PParams (ProtVer)
 import Cardano.Ledger.Alonzo.PlutusScriptApi
   ( CollectError,
     collectTwoPhaseScriptInputs,
@@ -97,6 +98,7 @@ instance
     HasField "_keyDeposit" (Core.PParams era) Coin,
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era)))
   ) =>
   STS (UTXOS era)
@@ -130,6 +132,7 @@ utxosTransition ::
     HasField "_keyDeposit" (Core.PParams era) Coin,
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel)
   ) =>
   TransitionRule (UTXOS era)
@@ -160,7 +163,8 @@ scriptsValidateTransition ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "_keyDeposit" (Core.PParams era) Coin,
     HasField "_poolDeposit" (Core.PParams era) Coin,
-    HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel)
+    HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   TransitionRule (UTXOS era)
 scriptsValidateTransition = do
@@ -218,7 +222,8 @@ scriptsNotValidateTransition ::
     HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
     HasField "_keyDeposit" (Core.PParams era) Coin,
-    HasField "_poolDeposit" (Core.PParams era) Coin
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
   ) =>
   TransitionRule (UTXOS era)
 scriptsNotValidateTransition = do
@@ -351,6 +356,7 @@ constructValidated ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Globals ->

--- a/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -13,6 +13,7 @@ where
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data, getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (_protocolVersion)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeeded)
 import Cardano.Ledger.Alonzo.Scripts
   ( CostModel (..),
@@ -72,6 +73,7 @@ evaluateTransactionExecutionUnits ::
   ( CC.Crypto c,
     Monad m
   ) =>
+  Core.PParams (AlonzoEra c) ->
   -- | The transaction.
   Core.Tx (AlonzoEra c) ->
   -- | The current UTxO set (or the relevant portion for the transaction).
@@ -85,8 +87,8 @@ evaluateTransactionExecutionUnits ::
   -- | A map from redeemer pointers to either a failure or a sufficient execution budget.
   --  The value is monadic, depending on the epoch info.
   m (Map RdmrPtr (Either (ScriptFailure c) ExUnits))
-evaluateTransactionExecutionUnits tx utxo ei sysS costModels = do
-  txinfo <- txInfo ei sysS utxo tx
+evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
+  txinfo <- txInfo pp ei sysS utxo tx
   pure $ Map.mapWithKey (findAndCount txinfo) (unRedeemers $ getField @"txrdmrs" ws)
   where
     txb = getField @"body" tx

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -158,7 +158,7 @@ updateTxExUnits tx utxo ei ss costmdls err = do
   -- rdmrs :: Map RdmrPtr ExUnits
   rdmrs <-
     traverse (failLeft err)
-      =<< evaluateTransactionExecutionUnits tx utxo ei ss costmdls
+      =<< evaluateTransactionExecutionUnits pparams tx utxo ei ss costmdls
   pure (replaceRdmrs tx rdmrs)
 
 replaceRdmrs :: Core.Tx A -> Map RdmrPtr ExUnits -> Core.Tx A

--- a/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -1911,7 +1911,7 @@ collectTwoPhaseScriptInputsOutputOrdering =
     apf = Alonzo Mock
     context =
       valContext
-        (runIdentity $ txInfo testEpochInfo testSystemStart (initUTxO apf) (validatingTx apf))
+        (runIdentity $ txInfo (pp apf) testEpochInfo testSystemStart (initUTxO apf) (validatingTx apf))
         (Spending $ TxIn genesisId 1)
 
 collectOrderingAlonzo :: TestTree

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/HardForks.hs
@@ -7,6 +7,7 @@ module Shelley.Spec.Ledger.HardForks
     allowMIRTransfer,
     validatePoolRewardAccountNetID,
     allowScriptStakeCredsToEarnRewards,
+    translateTimeForPlutusScripts,
   )
 where
 
@@ -47,3 +48,11 @@ allowScriptStakeCredsToEarnRewards ::
   Natural ->
   Bool
 allowScriptStakeCredsToEarnRewards pvM = pvM > 4
+
+-- | Starting with protocol version 6, we translate slots to time correctly for
+-- Plutus scripts.
+translateTimeForPlutusScripts ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+translateTimeForPlutusScripts pp = pvMajor (getField @"_protocolVersion" pp) > 5


### PR DESCRIPTION
The relevant part of this change is in TxInfo.hs (and the enabling switch in
HardForks.hs). The rest is required to plumb through the protocol parameters to
allow this switch.