### PR TITLE
Fix transaction cddl to include IsValid

### DIFF
--- a/alonzo/test/cddl-files/alonzo.cddl
+++ b/alonzo/test/cddl-files/alonzo.cddl
@@ -13,6 +13,7 @@ block =
 transaction =
   [ transaction_body
   , transaction_witness_set
+  , bool
   , auxiliary_data / null
   ]
 

--- a/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
+++ b/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
@@ -9,6 +9,7 @@ where
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data)
 import Cardano.Ledger.Alonzo.PParams (PParamsUpdate)
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx)
 import Cardano.Ledger.Alonzo.TxBody (TxOut)
 import Cardano.Ledger.Alonzo.TxWitness (Redeemers, TxWitness)
 import qualified Cardano.Ledger.Core as Core
@@ -34,7 +35,8 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlTest @(TxOut A) n "transaction_output",
       cddlTest' @(TxWitness A) n "transaction_witness_set",
       cddlTest @(PParamsUpdate A) n "protocol_param_update",
-      cddlTest' @(Redeemers A) n "[* redeemer]"
+      cddlTest' @(Redeemers A) n "[* redeemer]",
+      cddlTest' @(ValidatedTx A) n "transaction"
     ]
       <*> pure cddl
 


### PR DESCRIPTION
When we changed the mempool serialization of the transaction, we did not update the CDDL. cc @SebastienGllmt