### PR TITLE
Add a test that events are sufficiently lazy.

### DIFF
--- a/semantics/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
+++ b/semantics/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
@@ -7,9 +7,11 @@
 -- in the enviroment.
 module Control.State.Transition.Examples.GlobalSum where
 
+import Control.Arrow (right)
 import Control.Monad.Reader
 import Control.State.Transition.Extended
 import Data.Foldable (foldl')
+import Data.Void (Void)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Prelude hiding (sum)
@@ -19,6 +21,8 @@ data Ops = Ops
   }
 
 data GSUM
+
+newtype GSUMEvent = ErrorEvent Void deriving (Eq, Show)
 
 data NoFailure = NoFailure deriving (Eq, Show)
 
@@ -33,12 +37,15 @@ instance STS GSUM where
 
   type PredicateFailure GSUM = NoFailure
 
+  type Event _ = GSUMEvent
+
   initialRules = [pure 0]
 
   transitionRules =
     [ do
         TRC ((), st, xs) <- judgmentContext
         sum <- liftSTS $ reader opSum
+        tellEvent $ ErrorEvent (error "Event has been evaluated!")
         return $! st + sum xs
     ]
 
@@ -47,10 +54,21 @@ tests =
   testGroup
     "STS.Extended"
     [ testCase "Sum" $ withSum @=? Right 55,
-      testCase "Product" $ withProduct @=? Right 3628800
+      testCase "Product" $ withProduct @=? Right 3628800,
+      testCase "Sum/Lazy Events" $ withLazyEventsSum @=? Right 55
     ]
   where
     inputs = [1 .. 10]
     ctx = TRC ((), 0, inputs)
     withSum = runReader (applySTS @GSUM ctx) (Ops (foldl' (+) 0))
     withProduct = runReader (applySTS @GSUM ctx) (Ops (foldl' (*) 1))
+    withLazyEventsSum =
+      right fst $
+        runReader (applySTSOptsEither @GSUM evtOpts ctx) (Ops (foldl' (+) 0))
+      where
+        evtOpts =
+          ApplySTSOpts
+            { asoAssertions = AssertionsOff,
+              asoValidation = ValidateAll,
+              asoEvents = EPReturn
+            }


### PR DESCRIPTION
We want to ensure that events are not prematurely evaluated, even when
using the `EPReturn` policy.