### PR TITLE
Few minor improvements and a fix for 'Reward Provenance' property test:

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -489,12 +489,12 @@ rewardOnePool
     where
       Coin ostake =
         Set.foldl'
-          (\c o -> c <> fromMaybe mempty (Map.lookup (KeyHashObj o) stake))
+          (\c o -> c <> Map.findWithDefault mempty (KeyHashObj o) stake)
           mempty
           (_poolOwners pool)
       Coin pledge = _poolPledge pool
       pr = fromIntegral pledge % fromIntegral totalStake
-      (Coin maxP) =
+      Coin maxP =
         if pledge <= ostake
           then maxPool' pp_a0 pp_nOpt r sigma pr
           else mempty


### PR DESCRIPTION
This PR fixes occasional test failure that is caused by the `genBlocksMade` producing an empty map sometimes, which in turn causes no reward provenance produced either. Also:

* Turns printer into generator
* Get rid of non-reproducable `generate` action
* Consolidate `reward` and `rewardPulser` functions into one reducing clutter.