### PR TITLE
replace block header with block header view where appropriate

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -9,6 +9,7 @@ import Cardano.Ledger.Address as X
   ( Addr (..),
     RewardAcnt (..),
   )
+import Cardano.Ledger.BHeaderView as X (isOverlaySlot)
 import Cardano.Ledger.BaseTypes as X
   ( Globals (..),
     Network (..),
@@ -168,7 +169,6 @@ import Cardano.Protocol.TPraos.Rules.OCert as X (OCertEnv (..))
 import Cardano.Protocol.TPraos.Rules.Overlay as X
   ( OBftSlot (..),
     classifyOverlaySlot,
-    isOverlaySlot,
     lookupInOverlaySchedule,
   )
 import Cardano.Protocol.TPraos.Rules.Prtcl as X

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -33,6 +33,7 @@ import Cardano.Binary (ToCBOR (..), decodeFull, decodeFullDecoder, serialize)
 import Cardano.Crypto.DSIGN.Class (decodeSignedDSIGN, sizeSigDSIGN, sizeVerKeyDSIGN)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.BHeaderView (isOverlaySlot)
 import Cardano.Ledger.BaseTypes (Globals (..), NonNegativeInterval, Seed, UnitInterval, epochInfo)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
@@ -84,7 +85,6 @@ import Cardano.Protocol.TPraos
     PoolDistr (..),
   )
 import Cardano.Protocol.TPraos.BHeader (checkLeaderValue, mkSeed, seedL)
-import Cardano.Protocol.TPraos.Rules.Overlay (isOverlaySlot)
 import Cardano.Protocol.TPraos.Rules.Tickn (TicknState (..))
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (EpochSize, SlotNo)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -19,8 +19,7 @@ import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes (UnitInterval)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (VRF)
-import Cardano.Ledger.Era (Crypto, SupportsSegWit (TxSeq))
-import Cardano.Ledger.Serialization (ToCBORGroup)
+import Cardano.Ledger.Era (Crypto)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Protocol.TPraos.BHeader
@@ -80,7 +79,6 @@ type TxGen era =
 genBlock ::
   forall era.
   ( MinLEDGER_STS era,
-    ToCBORGroup (TxSeq era),
     ApplyBlock era,
     Mock (Crypto era),
     GetLedgerView era,
@@ -100,8 +98,7 @@ genBlock ge = genBlockWithTxGen genTxs ge
 
 genBlockWithTxGen ::
   forall era.
-  ( ToCBORGroup (TxSeq era),
-    Mock (Crypto era),
+  ( Mock (Crypto era),
     GetLedgerView era,
     ApplyBlock era,
     EraGen era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -20,10 +20,10 @@ module Test.Cardano.Ledger.Shelley.Generator.Trace.Chain where
 
 -- import Test.Cardano.Ledger.Shelley.Shrinkers (shrinkBlock) -- TODO FIX ME
 
+import Cardano.Ledger.BHeaderView (BHeaderView (..))
 import Cardano.Ledger.BaseTypes (UnitInterval)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, SupportsSegWit (TxSeq))
-import Cardano.Ledger.Serialization (ToCBORGroup)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Constraints
   ( UsesAuxiliary,
@@ -85,11 +85,11 @@ import Test.QuickCheck (Gen)
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance
-  ( EraGen era,
+  ( Era era,
+    EraGen era,
     UsesTxBody era,
     UsesTxOut era,
     UsesValue era,
-    ToCBORGroup (TxSeq era),
     UsesAuxiliary era,
     Mock (Crypto era),
     ApplyBlock era,
@@ -99,7 +99,7 @@ instance
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
     Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ BbodyState era,
-    Signal (Core.EraRule "BBODY" era) ~ Block era,
+    Signal (Core.EraRule "BBODY" era) ~ (BHeaderView (Crypto era), TxSeq era),
     Embed (Core.EraRule "TICKN" era) (CHAIN era),
     Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
     State (Core.EraRule "TICKN" era) ~ TicknState,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -30,7 +30,7 @@ where
 import Cardano.Ledger.BaseTypes (Globals, StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Era (Era (Crypto), TxSeq)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash, KeyRole (Witness))
 import Cardano.Ledger.SafeHash (SafeHash)
@@ -113,7 +113,8 @@ minimalPropertyTests ::
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    Show (TxSeq era)
   ) =>
   TestTree
 minimalPropertyTests =
@@ -155,7 +156,8 @@ propertyTests ::
     QC.BaseEnv ledger ~ Globals,
     BaseM ledger ~ ReaderT Globals Identity,
     State ledger ~ (UTxOState era, DPState (Crypto era)),
-    Signal ledger ~ Core.Tx era
+    Signal ledger ~ Core.Tx era,
+    Show (TxSeq era)
   ) =>
   TestTree
 propertyTests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -22,7 +22,7 @@ where
 import Cardano.Binary (ToCBOR, serialize')
 import Cardano.Ledger.BaseTypes (Globals, StrictMaybe (..), epochInfo)
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era, SupportsSegWit (fromTxSeq))
+import Cardano.Ledger.Era (Crypto, Era, SupportsSegWit (fromTxSeq), TxSeq)
 import Cardano.Ledger.Shelley.API
   ( Addr (..),
     Credential (..),
@@ -399,8 +399,8 @@ onlyValidChainSignalsAreGenerated ::
   forall era.
   ( EraGen era,
     Default (State (Core.EraRule "PPUP" era)),
-    ChainProperty era,
-    QC.HasTrace (CHAIN era) (GenEnv era)
+    QC.HasTrace (CHAIN era) (GenEnv era),
+    Show (TxSeq era)
   ) =>
   Property
 onlyValidChainSignalsAreGenerated =

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Ledger.Address
     Cardano.Ledger.AuxiliaryData
     Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BHeaderView
     Cardano.Ledger.Coin
     Cardano.Ledger.Compactible
     Cardano.Ledger.Core

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Cardano.Ledger.BHeaderView where
+
+import Cardano.Ledger.BaseTypes (BoundedRational (..), UnitInterval)
+import Cardano.Ledger.Hashes (EraIndependentBlockBody)
+import Cardano.Ledger.Keys (Hash, KeyHash, KeyRole (..))
+import Cardano.Ledger.Slot (SlotNo (..), (-*))
+import Numeric.Natural (Natural)
+
+-- | 'BHeaderView' provides an interface between block headers
+-- from different Cardano protocols and packages that should be
+-- agnostic of Cardano protocol specific details,
+-- such as those in TPraos, Praos, Genesis, etc.
+--
+-- In particular, the 'BBODY' rule comprises most of the ledger logic
+-- and should work independently of the protocol. The values in
+-- 'BHeaderView' provide 'BBODY' all the data that it needs from the
+-- block headers.
+data BHeaderView crypto = BHeaderView
+  { -- | The block issuer. In the TPraos protocol, this can be a
+    --  Genesis delegate, everywhere else it is the stake pool ID.
+    bhviewID :: KeyHash 'BlockIssuer crypto,
+    -- | The purported size (in bytes) of the block body.
+    bhviewBSize :: Natural,
+    -- | The purported size (in bytes) of the block header.
+    bhviewHSize :: Int,
+    -- | The purported hash of the block body.
+    bhviewBHash :: Hash crypto EraIndependentBlockBody,
+    -- | The slot for which this block was submitted to the chain.
+    bhviewSlot :: SlotNo
+  }
+
+-- | Determine if the given slot is reserved for the overlay schedule.
+isOverlaySlot ::
+  -- | The first slot of the given epoch.
+  SlotNo ->
+  -- | The decentralization parameter.
+  UnitInterval ->
+  -- | The slot to check.
+  SlotNo ->
+  Bool
+isOverlaySlot firstSlotNo dval slot = step s < step (s + 1)
+  where
+    s = fromIntegral $ slot -* firstSlotNo
+    d = unboundRational dval
+    step :: Rational -> Integer
+    step x = ceiling (x * d)

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -35,6 +35,7 @@ module Cardano.Protocol.TPraos.BHeader
     seedL,
     mkSeed,
     bnonce,
+    makeHeaderView,
   )
 where
 
@@ -59,6 +60,7 @@ import qualified Cardano.Crypto.Hash.Class as Hash
 import qualified Cardano.Crypto.KES as KES
 import Cardano.Crypto.Util (SignableRepresentation (..))
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.BHeaderView (BHeaderView (..))
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     FixedPoint,
@@ -494,3 +496,14 @@ lastAppliedHash (At lab) = BlockHash $ labHash lab
 -- | Retrieve the new nonce from the block header body.
 bnonce :: BHBody crypto -> Nonce
 bnonce = mkNonceFromOutputVRF . VRF.certifiedOutput . bheaderEta
+
+makeHeaderView :: CC.Crypto crypto => BHeader crypto -> BHeaderView crypto
+makeHeaderView bh =
+  BHeaderView
+    (hashKey . bheaderVk $ bhb)
+    (bsize $ bhb)
+    (bHeaderSize bh)
+    (bhash bhb)
+    (bheaderSlotNo bhb)
+  where
+    bhb = bHeaderBody' bh

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -16,7 +16,6 @@ module Cardano.Protocol.TPraos.Rules.Overlay
     OverlayEnv (..),
     OverlayPredicateFailure (..),
     OBftSlot (..),
-    isOverlaySlot,
     classifyOverlaySlot,
     lookupInOverlaySchedule,
     overlaySlots,
@@ -32,6 +31,7 @@ import Cardano.Binary
     peekTokenType,
   )
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.BHeaderView (isOverlaySlot)
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     BoundedRational (..),
@@ -333,18 +333,6 @@ instance
 instance NoThunks (OBftSlot crypto)
 
 instance NFData (OBftSlot crypto)
-
-isOverlaySlot ::
-  SlotNo -> -- starting slot
-  UnitInterval -> -- decentralization parameter
-  SlotNo -> -- slot to check
-  Bool
-isOverlaySlot firstSlotNo dval slot = step s < step (s + 1)
-  where
-    s = fromIntegral $ slot -* firstSlotNo
-    d = unboundRational dval
-    step :: Rational -> Integer
-    step x = ceiling (x * d)
 
 classifyOverlaySlot ::
   SlotNo -> -- first slot of the epoch


### PR DESCRIPTION
A new type `BHeaderView` has been added to `cardano-ledger-core`, it contains the information from the block header that the `BBODY` rule needs. The function `isOverlaySlot` has also been moved next to the `BHeaderView`  definition (it would be nice to move it to `cardano-protocol-tpraos`, but it is still needed in the `BBODY` rule).

The BBODY rule no longer takes a `Block` as a signal, but a pair of a `BHeaderView` and a `TxSeq`. Additionally, the `applyBlock` API function now uses the `BHeaderView` as well. The `cardano-protocol-tpraos` package provides a translation from transitional-praos block headers to the view.

closes #2460