### PR TITLE
rename data_hash to datum_hash in alonzo CDDL

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -73,7 +73,7 @@ transaction_input = [ transaction_id : $hash32
 transaction_output =
   [ address
   , amount : value
-  , ? data_hash : $hash32 ; New
+  , ? datum_hash : $hash32 ; New
   ]
 
 script_data_hash = $hash32 ; New


### PR DESCRIPTION
Micro :microscope: PR to rename a CDDL variable to something more helpful: `data_hash` -> `datum_hash`.