### PR TITLE
Create a more compact TxOut using unpacked Word64s

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -181,7 +181,9 @@ instance Crypto c => TranslateEra (AlonzoEra c) API.ProposedPPUpdates where
     return $ API.ProposedPPUpdates $ fmap translatePParamsUpdate ppup
 
 translateTxOut ::
-  Core.TxOut (MaryEra c) -> Core.TxOut (AlonzoEra c)
+  Crypto c =>
+  Core.TxOut (MaryEra c) ->
+  Core.TxOut (AlonzoEra c)
 translateTxOut (Shelley.TxOutCompact addr value) = TxOutCompact addr value
 
 -- extendPP with type: extendPP :: Shelley.PParams' f era1 -> ... -> PParams' f era2

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     isSNothing,
   )
-import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
@@ -320,7 +320,6 @@ pattern TxOut ::
   ( Era era,
     Compactible (Core.Value era),
     Val (Core.Value era),
-    Show (Core.Value era),
     HasCallStack
   ) =>
   Addr (Crypto era) ->
@@ -340,7 +339,7 @@ pattern TxOut addr vl dh <-
         Just (Refl, e, f, g, h) <- encodeDataHash32 dh =
         TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef a b c d adaCompact e f g h
     TxOut addr vl mdh =
-      let v = fromMaybe (error $ "Illegal value in txout: " <> show vl) $ toCompact vl
+      let v = fromMaybe (error "Illegal value in txout") $ toCompact vl
           a = compactAddr addr
        in case mdh of
             SNothing -> TxOutCompact' a v
@@ -359,7 +358,7 @@ pattern TxOutCompact ::
 pattern TxOutCompact addr vl <-
   (viewCompactTxOut -> (addr, vl, SNothing))
   where
-    TxOutCompact = TxOutCompact'
+    TxOutCompact cAddr cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) SNothing
 
 -- TODO deprecate
 pattern TxOutCompactDH ::
@@ -373,7 +372,7 @@ pattern TxOutCompactDH ::
 pattern TxOutCompactDH addr vl dh <-
   (viewCompactTxOut -> (addr, vl, SJust dh))
   where
-    TxOutCompactDH = TxOutCompactDH'
+    TxOutCompactDH cAddr cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) . SJust
 
 {-# COMPLETE TxOutCompact, TxOutCompactDH #-}
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -175,22 +175,12 @@ ppPParams (PParams feeA feeB mbb mtx mbh kd pd em no a0 rho tau d ex pv mpool ad
       ("maxCollateralInputs", ppNatural mxC)
     ]
 
-ppTxOut ::
-  ( Era era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era)
-  ) =>
-  TxOut era ->
-  PDoc
+ppTxOut :: (Era era, PrettyA (Core.Value era)) => TxOut era -> PDoc
 ppTxOut (TxOut addr val dhash) =
   ppSexp "TxOut" [ppAddr addr, prettyA val, ppStrictMaybe ppSafeHash dhash]
 
 ppTxBody ::
-  ( AlonzoBody era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era),
-    PrettyA (Core.PParamsDelta era)
-  ) =>
+  (AlonzoBody era, PrettyA (Core.Value era), PrettyA (Core.PParamsDelta era)) =>
   TxBody era ->
   PDoc
 ppTxBody (TxBody i ifee o c w fee vi u rsh mnt sdh axh ni) =
@@ -215,22 +205,12 @@ ppAuxDataHash :: Core.AuxiliaryDataHash crypto -> PDoc
 ppAuxDataHash (Core.AuxiliaryDataHash axh) = ppSafeHash axh
 
 instance
-  ( AlonzoBody era,
-    PrettyA (Core.Value era),
-    PrettyA (Core.PParamsDelta era),
-    Show (Core.Value era)
-  ) =>
+  (AlonzoBody era, PrettyA (Core.Value era), PrettyA (Core.PParamsDelta era)) =>
   PrettyA (TxBody era)
   where
   prettyA = ppTxBody
 
-instance
-  ( Era era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era)
-  ) =>
-  PrettyA (TxOut era)
-  where
+instance (Era era, PrettyA (Core.Value era)) => PrettyA (TxOut era) where
   prettyA x = ppTxOut x
 
 ppRdmrPtr :: RdmrPtr -> PDoc


### PR DESCRIPTION
I've special cased when the address hash size is 28 bytes and the data
hash size is 32 bytes and the value is Ada only.