### PR TITLE
Remove partial functions

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     isSNothing,
   )
-import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core (PParamsDelta)
 import qualified Cardano.Ledger.Core as Core
@@ -320,7 +320,6 @@ pattern TxOut ::
   ( Era era,
     Compactible (Core.Value era),
     Val (Core.Value era),
-    Show (Core.Value era),
     HasCallStack
   ) =>
   Addr (Crypto era) ->
@@ -340,7 +339,7 @@ pattern TxOut addr vl dh <-
         Just (Refl, e, f, g, h) <- encodeDataHash32 dh =
         TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef a b c d adaCompact e f g h
     TxOut addr vl mdh =
-      let v = fromMaybe (error $ "Illegal value in txout: " <> show vl) $ toCompact vl
+      let v = fromMaybe (error "Illegal value in txout") $ toCompact vl
           a = compactAddr addr
        in case mdh of
             SNothing -> TxOutCompact' a v
@@ -359,7 +358,7 @@ pattern TxOutCompact ::
 pattern TxOutCompact addr vl <-
   (viewCompactTxOut -> (addr, vl, SNothing))
   where
-    TxOutCompact = TxOutCompact'
+    TxOutCompact cAddr cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) SNothing
 
 -- TODO deprecate
 pattern TxOutCompactDH ::
@@ -373,7 +372,7 @@ pattern TxOutCompactDH ::
 pattern TxOutCompactDH addr vl dh <-
   (viewCompactTxOut -> (addr, vl, SJust dh))
   where
-    TxOutCompactDH = TxOutCompactDH'
+    TxOutCompactDH cAddr cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) . SJust
 
 {-# COMPLETE TxOutCompact, TxOutCompactDH #-}
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -175,22 +175,12 @@ ppPParams (PParams feeA feeB mbb mtx mbh kd pd em no a0 rho tau d ex pv mpool ad
       ("maxCollateralInputs", ppNatural mxC)
     ]
 
-ppTxOut ::
-  ( Era era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era)
-  ) =>
-  TxOut era ->
-  PDoc
+ppTxOut :: (Era era, PrettyA (Core.Value era)) => TxOut era -> PDoc
 ppTxOut (TxOut addr val dhash) =
   ppSexp "TxOut" [ppAddr addr, prettyA val, ppStrictMaybe ppSafeHash dhash]
 
 ppTxBody ::
-  ( AlonzoBody era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era),
-    PrettyA (Core.PParamsDelta era)
-  ) =>
+  (AlonzoBody era, PrettyA (Core.Value era), PrettyA (Core.PParamsDelta era)) =>
   TxBody era ->
   PDoc
 ppTxBody (TxBody i ifee o c w fee vi u rsh mnt sdh axh ni) =
@@ -215,22 +205,12 @@ ppAuxDataHash :: Core.AuxiliaryDataHash crypto -> PDoc
 ppAuxDataHash (Core.AuxiliaryDataHash axh) = ppSafeHash axh
 
 instance
-  ( AlonzoBody era,
-    PrettyA (Core.Value era),
-    PrettyA (Core.PParamsDelta era),
-    Show (Core.Value era)
-  ) =>
+  (AlonzoBody era, PrettyA (Core.Value era), PrettyA (Core.PParamsDelta era)) =>
   PrettyA (TxBody era)
   where
   prettyA = ppTxBody
 
-instance
-  ( Era era,
-    Show (Core.Value era),
-    PrettyA (Core.Value era)
-  ) =>
-  PrettyA (TxOut era)
-  where
+instance (Era era, PrettyA (Core.Value era)) => PrettyA (TxOut era) where
   prettyA x = ppTxOut x
 
 ppRdmrPtr :: RdmrPtr -> PDoc


### PR DESCRIPTION
Also fixes `TxOutCompact` and  `TxOutCompactDH`  pattern synonyms

Removes `Show` constraint for `TxOut` pattern, since there is no reason to carry extra constraint for reporting errors on impossible cases.


Also does no uncompacting on Null and Ptr staking credentials.


Overall this gives us no memory overhead when compared with previous uncompacting, but allows us to share `Credential 'Staking`:

```
  Case                                   Max          MaxOS           Live        Allocated      GCs
  Original TxOut               1,091,506,912  2,864,709,632  1,091,506,912  196,483,571,888  173,309
  Adjusted TxOut no sharing    1,091,506,728  2,831,155,200  1,091,506,728  175,260,154,776  164,113
  Adjusted TxOut with sharing    969,811,552  2,312,110,080    969,811,552  179,412,416,608  168,094
```