### PR TITLE
Compute rewards by folding/pulsing on stake credentials

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -14,7 +14,6 @@ where
 
 import Cardano.Ledger.BaseTypes (ProtVer (..))
 import GHC.Records
-import Numeric.Natural (Natural)
 
 aggregatedRewards ::
   (HasField "_protocolVersion" pp ProtVer) =>
@@ -46,9 +45,10 @@ validatePoolRewardAccountNetID pp = pvMajor (getField @"_protocolVersion" pp) > 
 -- | Starting with protocol version 5, Stake Credentials bound by scripts
 -- will be eligibile for staking rewards.
 allowScriptStakeCredsToEarnRewards ::
-  Natural ->
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
   Bool
-allowScriptStakeCredsToEarnRewards pvM = pvM > 4
+allowScriptStakeCredsToEarnRewards pp = pvMajor (getField @"_protocolVersion" pp) > 4
 
 -- | Starting with protocol version 6, we translate slots to time correctly for
 -- Plutus scripts.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -90,11 +90,14 @@ import Cardano.Ledger.Shelley.RewardUpdate
     RewardSnapShot (..),
   )
 import Cardano.Ledger.Shelley.Rewards
-  ( Likelihood (..),
+  ( LeaderOnlyReward (..),
+    Likelihood (..),
     LogWeight (..),
     PerformanceEstimate (..),
+    PoolRewardInfo (..),
     Reward (..),
     RewardType (..),
+    StakeShare (..),
   )
 import qualified Cardano.Ledger.Shelley.Rules.Deleg as STS
 import qualified Cardano.Ledger.Shelley.Rules.Delegs as STS
@@ -590,6 +593,10 @@ instance CC.Crypto crypto => Arbitrary (Reward crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
+instance CC.Crypto crypto => Arbitrary (LeaderOnlyReward crypto) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
 instance CC.Crypto crypto => Arbitrary (RewardUpdate crypto) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
@@ -980,6 +987,15 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+
+instance
+  Mock crypto =>
+  Arbitrary (PoolRewardInfo crypto)
+  where
+  arbitrary =
+    PoolRewardInfo
+      <$> (StakeShare <$> arbitrary)
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
@@ -990,23 +1006,14 @@ instance
   where
   arbitrary =
     FreeVars
-      <$> arbitrary {- b -}
-      <*> arbitrary {- delegs -}
-      <*> arbitrary {- stake -}
-      <*> arbitrary {- addrsRew -}
+      <$> arbitrary {- addrsRew -}
       <*> arbitrary {- totalStake -}
-      <*> arbitrary {- activeStake -}
-      <*> arbitrary {- asc -}
-      <*> arbitrary {- totalBlocks -}
-      <*> arbitrary {- r -}
-      <*> (EpochSize <$> arbitrary {- slotsPerEpoch -})
-      <*> arbitrary {- pp_d -}
-      <*> arbitrary {- pp_a0 -}
-      <*> arbitrary {- pp_nOpt -}
       <*> arbitrary {- pp_mv -}
+      <*> arbitrary {- poolRewardInfo -}
+      <*> arbitrary {- delegations -}
 
 instance
   Mock crypto =>
   Arbitrary (Pulser crypto)
   where
-  arbitrary = RSLP <$> arbitrary <*> arbitrary <*> arbitrary <*> (RewardAns <$> arbitrary <*> arbitrary)
+  arbitrary = RSLP <$> arbitrary <*> arbitrary <*> arbitrary <*> (RewardAns <$> arbitrary)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -61,14 +61,11 @@ import qualified Cardano.Ledger.Shelley.RewardProvenance as RP
 import Cardano.Ledger.Shelley.Rewards
   ( Likelihood (..),
     NonMyopic (..),
-    PerformanceEstimate (unPerformanceEstimate),
     Reward (..),
     RewardType (..),
     applyDecay,
-    desirability,
     leaderProbability,
     likelihood,
-    percentile',
   )
 import Cardano.Ledger.Shelley.Tx
   ( Tx (..),
@@ -821,41 +818,10 @@ rewardInfoTest = rewardInfoEx8 @?= expected
           RP.rPot = rpot,
           RP.deltaT1 = deltaT8',
           RP.activeStake = activestake,
-          RP.pools =
-            Map.singleton
-              (_poolId $ Cast.alicePoolParams)
-              ( RP.RewardProvenancePool
-                  { RP.poolBlocksP = 1,
-                    RP.sigmaP = (unCoin activestake) % (unCoin totstake),
-                    RP.sigmaAP = 1,
-                    RP.ownerStakeP = aliceCoinEx2Base <> aliceCoinEx2Ptr,
-                    RP.poolParamsP = Cast.alicePoolParams,
-                    RP.pledgeRatioP =
-                      (unCoin . _poolPledge $ Cast.alicePoolParams @C_Crypto)
-                        % (unCoin totstake),
-                    RP.maxPP = Coin 12693333333,
-                    RP.appPerfP = 1,
-                    RP.poolRP = Coin 12693333333,
-                    RP.lRewardP = aliceRAcnt8
-                  }
-              ),
-          RP.desirabilities =
-            Map.singleton
-              (_poolId $ Cast.alicePoolParams)
-              ( RP.Desirability
-                  { RP.hitRateEstimate = unPerformanceEstimate estimate,
-                    RP.desirabilityScore =
-                      desirability
-                        (_a0 ppEx, _nOpt ppEx)
-                        rpot
-                        (Cast.alicePoolParams @C_Crypto)
-                        estimate
-                        totstake
-                  }
-              )
+          RP.pools = mempty,
+          RP.desirabilities = mempty
         }
     rpot = Coin 1586666666666
-    estimate = percentile' alicePerfEx8
     supply = Coin . fromIntegral . maxLovelaceSupply $ testGlobals
     totstake = supply <-> reserves7
     activestake = aliceCoinEx2Base <> aliceCoinEx2Ptr <> bobInitCoin

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.BaseTypes
     BoundedRational (..),
     Globals (..),
     Network (..),
-    NonNegativeInterval,
     ProtVer (..),
     ShelleyBase,
     StrictMaybe (..),
@@ -88,6 +87,7 @@ import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rewards
   ( Likelihood,
     NonMyopic,
+    Reward (rewardAmount),
     StakeShare (..),
     aggregateRewards,
     leaderProbability,
@@ -95,11 +95,12 @@ import Cardano.Ledger.Shelley.Rewards
     likelihood,
     memberRew,
     mkApparentPerformance,
-    sumRewards,
+    mkPoolRewardInfo,
   )
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..), RewardAcnt (..))
 import Cardano.Ledger.Slot (epochInfoSize)
 import Cardano.Ledger.Val (invert, (<+>), (<->))
+import Cardano.Prelude (rightToMaybe)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Control.Iterate.SetAlgebra (eval, (◁))
 import Control.Monad (replicateM)
@@ -141,11 +142,9 @@ import Test.Tasty.QuickCheck
     choose,
     counterexample,
     elements,
-    forAll,
     property,
     testProperty,
     withMaxSuccess,
-    (.||.),
     (===),
   )
 
@@ -297,7 +296,11 @@ toCompactCoinError :: HasCallStack => Coin -> CompactForm Coin
 toCompactCoinError c =
   fromMaybe (error $ "Invalid Coin: " <> show c) $ toCompact c
 
-rewardsBoundedByPot :: forall era. Era era => Proxy era -> Property
+rewardsBoundedByPot ::
+  forall era.
+  (Era era, Core.PParams era ~ PParams era) =>
+  Proxy era ->
+  Property
 rewardsBoundedByPot _ = property $ do
   numPools <- choose (0, maxNumPools)
   pools <- sequence $ genPoolInfo @(Crypto era) <$> replicate numPools emptySetupArgs
@@ -319,11 +322,11 @@ rewardsBoundedByPot _ = property $ do
           [(_poolId params, params) | PoolInfo {params} <- pools]
       totalLovelace = undelegatedLovelace <> fold stake
       slotsPerEpoch = EpochSize . fromIntegral $ totalBlocks + silentSlots
-      (RewardAns rs _) =
+      (RewardAns rs) =
         runShelleyBase $
           runProvM $
-            reward
-              (_d pp, _a0 pp, _nOpt pp, pvMajor (_protocolVersion pp))
+            reward @era
+              pp
               bs
               rewardPot
               rewardAcnts
@@ -331,8 +334,6 @@ rewardsBoundedByPot _ = property $ do
               (Stake (VMap.fromMap (toCompactCoinError <$> stake)))
               (VMap.fromMap delegs)
               totalLovelace
-              asc
-              slotsPerEpoch
   pure $
     counterexample
       ( mconcat
@@ -356,50 +357,10 @@ rewardsBoundedByPot _ = property $ do
             show slotsPerEpoch
           ]
       )
-      (sumRewards pp rs < rewardPot)
+      (fold (fmap rewardAmount rs) < rewardPot)
 
 -- =================================================
 -- tests when running rewards with provenance
-
-rewardsProvenance ::
-  forall era.
-  Era era =>
-  Proxy era ->
-  Gen (KeyHashPoolProvenance (Crypto era), BlocksMade (Crypto era))
-rewardsProvenance _ = do
-  numPools <- choose (0, maxNumPools)
-  pools <- sequence $ genPoolInfo @(Crypto era) <$> replicate numPools emptySetupArgs
-  pp <- genRewardPPs
-  rewardPot <- genCoin 0 (fromIntegral $ maxLovelaceSupply testGlobals)
-  undelegatedLovelace <- genCoin 0 (fromIntegral $ maxLovelaceSupply testGlobals)
-  asc <- mkActiveSlotCoeff . unsafeBoundRational <$> elements [0.1, 0.2, 0.3]
-  bs@(BlocksMade blocks) <- genBlocksMade (fmap params pools)
-  let totalBlocks = sum blocks
-  silentSlots <- genNatural 0 (3 * totalBlocks) -- the '3 * sum blocks' is pretty arbitrary
-  let stake = foldMap members pools
-      delegs =
-        VMap.fromMap $
-          foldMap (\PoolInfo {params, members} -> _poolId params <$ members) pools
-      rewardAcnts = Set.fromDistinctAscList $ VMap.keys delegs
-      poolParams =
-        VMap.fromList [(_poolId params, params) | PoolInfo {params} <- pools]
-      totalLovelace = undelegatedLovelace <> fold stake
-      slotsPerEpoch = EpochSize . fromIntegral $ totalBlocks + silentSlots
-      (_, prov) =
-        runShelleyBase $
-          runWithProvM def $
-            reward
-              (_d pp, _a0 pp, _nOpt pp, pvMajor (_protocolVersion pp))
-              bs
-              rewardPot
-              rewardAcnts
-              poolParams
-              (Stake (VMap.fromMap (fmap toCompactCoinError stake)))
-              delegs
-              totalLovelace
-              asc
-              slotsPerEpoch
-  pure (prov, bs)
 
 -- Analog to getRewardProvenance, but does not produce Provenance
 justRewardInfo ::
@@ -537,7 +498,7 @@ rewardOnePool
               notPoolOwner hk
           ]
       notPoolOwner (KeyHashObj hk) = hk `Set.notMember` _poolOwners pool
-      notPoolOwner (ScriptHashObj _) = False
+      notPoolOwner (ScriptHashObj _) = HardForks.allowScriptStakeCredsToEarnRewards pp
       lReward =
         leaderRew
           poolR
@@ -683,20 +644,32 @@ createRUpdOld slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm)
         nonMyopicOld = updateNonMyopic nm _R newLikelihoods
       }
 
+overrideProtocolVersionUsedInRewardCalc ::
+  Core.PParams era ~ PParams era =>
+  ProtVer ->
+  EpochState era ->
+  EpochState era
+overrideProtocolVersionUsedInRewardCalc pv es =
+  es {esPrevPp = pp'}
+  where
+    pp = esPrevPp $ es
+    pp' = pp {_protocolVersion = pv}
+
 oldEqualsNew ::
   forall era.
   ( era ~ C,
     Core.PParams era ~ PParams era
   ) =>
+  ProtVer ->
   NewEpochState era ->
   Property
-oldEqualsNew newepochstate =
+oldEqualsNew pv newepochstate =
   counterexample
     (show (prettyA newepochstate) ++ "\n new = " ++ show new ++ "\n old = " ++ show old)
     (old === new)
   where
     globals = testGlobals
-    epochstate = nesEs newepochstate
+    epochstate = overrideProtocolVersionUsedInRewardCalc pv $ nesEs newepochstate
     maxsupply :: Coin
     maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
     blocksmade :: BlocksMade (Crypto era)
@@ -706,18 +679,24 @@ oldEqualsNew newepochstate =
     slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
     unAggregated =
       runReader (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc k) globals
-    old :: Map (Credential 'Staking (Crypto era)) Coin
     old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
-    new_with_zeros = aggregateRewards @(Crypto era) (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
+    new_with_zeros = aggregateRewards @(Crypto era) (emptyPParams {_protocolVersion = pv}) (rs unAggregated)
     new = Map.filter (/= Coin 0) new_with_zeros
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
 
-oldEqualsNewOn :: forall era. (Core.PParams era ~ PParams era) => NewEpochState era -> Property
-oldEqualsNewOn newepochstate = old === new
+oldEqualsNewOn ::
+  forall era.
+  ( era ~ C,
+    Core.PParams era ~ PParams era
+  ) =>
+  ProtVer ->
+  NewEpochState era ->
+  Property
+oldEqualsNewOn pv newepochstate = old === new
   where
     globals = testGlobals
-    epochstate = nesEs newepochstate
+    epochstate = overrideProtocolVersionUsedInRewardCalc pv $ nesEs newepochstate
     maxsupply :: Coin
     maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
     blocksmade :: BlocksMade (Crypto era)
@@ -730,7 +709,7 @@ oldEqualsNewOn newepochstate = old === new
     old :: Map (Credential 'Staking (Crypto era)) Coin
     old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
     new_with_zeros =
-      aggregateRewards @(Crypto era) (emptyPParams {_protocolVersion = ProtVer 2 0}) (rs unAggregated)
+      aggregateRewards @(Crypto era) (emptyPParams {_protocolVersion = pv}) (rs unAggregated)
     new = Map.filter (/= Coin 0) new_with_zeros
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
@@ -751,57 +730,58 @@ newEpochProp tracelen propf = withMaxSuccess 100 $
 -- ================================================================
 
 reward ::
-  forall crypto.
-  (UnitInterval, NonNegativeInterval, Natural, Natural) ->
-  BlocksMade crypto ->
+  forall era.
+  (Core.PParams era ~ PParams era) =>
+  Core.PParams era ->
+  BlocksMade (Crypto era) ->
   Coin ->
-  Set (Credential 'Staking crypto) ->
-  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool crypto) (PoolParams crypto) ->
-  Stake crypto ->
-  VMap.VMap VMap.VB VMap.VB (Credential 'Staking crypto) (KeyHash 'StakePool crypto) ->
+  Set (Credential 'Staking (Crypto era)) ->
+  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)) ->
+  Stake (Crypto era) ->
+  VMap.VMap VMap.VB VMap.VB (Credential 'Staking (Crypto era)) (KeyHash 'StakePool (Crypto era)) ->
   Coin ->
-  ActiveSlotCoeff ->
-  EpochSize ->
-  ProvM (KeyHashPoolProvenance crypto) ShelleyBase (RewardAns crypto)
+  ProvM (KeyHashPoolProvenance (Crypto era)) ShelleyBase (RewardAns (Crypto era))
 reward
-  (pp_d, pp_a0, pp_nOpt, pp_mv)
+  pp
   (BlocksMade b)
   r
   addrsRew
   poolParams
   stake
   delegs
-  (Coin totalStake)
-  asc
-  slotsPerEpoch = completeM pulser
+  (Coin totalStake) = completeM pulser
     where
       totalBlocks = sum b
       Coin activeStake = sumAllStake stake
+      mkPoolRewardInfo' =
+        mkPoolRewardInfo
+          pp
+          r
+          (BlocksMade b)
+          totalBlocks
+          stake
+          delegs
+          (Coin totalStake)
+          (Coin activeStake)
+      poolRewardInfo = VMap.toMap $ VMap.mapMaybe (rightToMaybe . mkPoolRewardInfo') poolParams
+      pp_pv = _protocolVersion pp
       free =
         FreeVars
-          { b,
-            delegs,
-            stake,
-            addrsRew,
+          { addrsRew,
             totalStake,
-            activeStake,
-            asc,
-            totalBlocks,
-            r,
-            slotsPerEpoch,
-            pp_d,
-            pp_a0,
-            pp_nOpt,
-            pp_mv
+            pp_pv,
+            poolRewardInfo,
+            delegs
           }
-      pps = StrictSeq.fromList $ VMap.elems poolParams
-      pulser :: Pulser crypto
-      pulser = RSLP 2 free pps (RewardAns Map.empty Map.empty)
+      pulser :: Pulser (Crypto era)
+      pulser = RSLP 2 free (unStake stake) (RewardAns Map.empty)
 
 -- ==================================================================
 
+-- | Note that chainlen must be set high enough so that enough epochs
+-- have passed to get non-trivial rewards.
 chainlen :: Word64
-chainlen = 20 -- 50 -- 43 -- 37 -- 25 -- 50 -- 100
+chainlen = 200
 
 rewardTests :: TestTree
 rewardTests =
@@ -811,9 +791,6 @@ rewardTests =
       testProperty "provenance does not affect result" (newEpochProp 100 (sameWithOrWithoutProvenance @C testGlobals)),
       testProperty "ProvM preserves Nothing" (newEpochProp 100 (nothingInNothingOut @C)),
       testProperty "ProvM preserves Just" (newEpochProp 100 (justInJustOut @C)),
-      testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance off style" (newEpochProp chainlen (oldEqualsNew @C)),
-      testProperty "oldstyle (aggregate immediately) matches newstyle (late aggregation) with provenance on style" (newEpochProp chainlen (oldEqualsNewOn @C)),
-      testProperty "Reward Provenance works" $
-        forAll (rewardsProvenance (Proxy @C)) $ \(provsMap, BlocksMade m) ->
-          Map.null m .||. not (Map.null provsMap)
+      testProperty "compare with reference impl, no provenance" (newEpochProp chainlen (oldEqualsNew @C (ProtVer 3 0))),
+      testProperty "compare with reference impl, with provenance" (newEpochProp chainlen (oldEqualsNewOn @C (ProtVer 3 0)))
     ]


### PR DESCRIPTION
Currently the reward calculation is performed by computing the rewards for a single stake pool each time a block is validated within a certain range (between slot 4k/f and slot 8k/f in the epoch). In practice, on mainnet, we finish the calculation with a lot of time to spare (about a day). Moreover, since some stake pools have many more members than other, the calculation has a lot of spikes.  This PR rearranges the calculation to instead compute `numStakeCreds / (4k/f)` stake credentials per block. We hope that this helps with  https://github.com/input-output-hk/cardano-node/issues/3167 This change will also be necessary when we move the stake credential maps on disk.

Additionally, I have started removing support for the reward provenance. It has, unfortunately, not been a usable feature for the wallet. I have talked this over with @HeinrichApfelmus to confirm that it is okay to stop populating some of the values. This lets me clean up some of the calculation.