### PR TITLE
make deserialiseAddrFull function

### DIFF
--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
@@ -195,7 +195,11 @@ goldenTests_ShelleyCrypto =
                 Byron.addrType = Byron.ATVerKey
               }
         )
-        "82d818582183581c4bf3c2ee56bfef278d65f7388c46efa12a1069698e474f77adf0cf6aa0001ab4aad9a5"
+        "82d818582183581c4bf3c2ee56bfef278d65f7388c46efa12a1069698e474f77adf0cf6aa0001ab4aad9a5",
+      T.testCase "fail on extraneous bytes" $
+        case deserialiseAddr @ShelleyCrypto addressWithExtraneousBytes of
+          Nothing -> pure ()
+          Just _a -> error $ "This should have failed"
     ]
   where
     paymentKey :: Credential 'Payment ShelleyCrypto
@@ -226,6 +230,16 @@ goldenTests_ShelleyCrypto =
             ++ show (BS.length bytes)
             ++ ", but expected to be "
             ++ show expectedLength
+
+addressWithExtraneousBytes :: BS.ByteString
+addressWithExtraneousBytes = bs
+  where
+    bs = case B16.decode hs of
+      Left e -> error $ show e
+      Right x -> x
+    hs =
+      "01AA5C8B35A934ED83436ABB56CDB44878DAC627529D2DA0B59CDA794405931B9359\
+      \46E9391CABDFFDED07EB727F94E9E0F23739FF85978905BD460158907C589B9F1A62"
 
 golden :: HasCallStack => String -> (a -> B.Put) -> a -> LBS.ByteString -> TestTree
 golden name put value expected =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -141,14 +141,19 @@ serialiseAddr = BSL.toStrict . B.runPut . putAddr
 deserialiseAddr :: CC.Crypto crypto => ByteString -> Maybe (Addr crypto)
 deserialiseAddr bs = case B.runGetOrFail getAddr (BSL.fromStrict bs) of
   Left (_remaining, _offset, _message) -> Nothing
-  Right (_remaining, _offset, result) -> Just result
+  Right (remaining, _offset, result) ->
+    if BSL.null remaining
+      then Just result
+      else Nothing
 
 -- | Deserialise a stake refence from a address. This will fail if this
 -- is a Bootstrap address (or malformed).
 deserialiseAddrStakeRef :: CC.Crypto crypto => ByteString -> Maybe (StakeReference crypto)
-deserialiseAddrStakeRef bs = case B.runGetOrFail getAddrStakeReference (BSL.fromStrict bs) of
-  Left (_remaining, _offset, _message) -> Nothing
-  Right (_remaining, _offset, result) -> result
+deserialiseAddrStakeRef bs =
+  case B.runGetOrFail getAddrStakeReference (BSL.fromStrict bs) of
+    Right (remaining, _offset, result)
+      | not (BSL.null remaining) -> result
+    _ -> Nothing
 
 -- | Serialise a reward account to the external format.
 serialiseRewardAcnt :: RewardAcnt crypto -> ByteString
@@ -159,7 +164,10 @@ serialiseRewardAcnt = BSL.toStrict . B.runPut . putRewardAcnt
 deserialiseRewardAcnt :: CC.Crypto crypto => ByteString -> Maybe (RewardAcnt crypto)
 deserialiseRewardAcnt bs = case B.runGetOrFail getRewardAcnt (BSL.fromStrict bs) of
   Left (_remaining, _offset, _message) -> Nothing
-  Right (_remaining, _offset, result) -> Just result
+  Right (remaining, _offset, result) ->
+    if BSL.null remaining
+      then Just result
+      else Nothing
 
 -- | An address for UTxO.
 data Addr crypto


### PR DESCRIPTION
This PR adds a function `deserialiseAddrFull`, which is nearly identical to `deserialiseAddr`, but does not allow for extra bytes.