### PR TITLE
Minor bugfixes

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Properties.hs
@@ -766,7 +766,7 @@ genTxAndLEDGERState = do
   txIx <- arbitrary
   maxTxExUnits <- arbitrary
   Positive maxCollateralInputs <- arbitrary
-  collateralPercentage <- fromIntegral <$> chooseInt (0, 10000)
+  collateralPercentage <- fromIntegral <$> chooseInt (1, 10000)
   minfeeA <- fromIntegral <$> chooseInt (0, 1000)
   minfeeB <- fromIntegral <$> chooseInt (0, 10000)
   let genT = do


### PR DESCRIPTION
This PR fixes two bugs:

1. utxow property tests failed recently on CI: https://github.com/input-output-hk/cardano-ledger/runs/4311566920?check_suite_focus=true
  Reason is `collateralPercentage` was genrated to be 0, which caused the test to not generate any collateral, despite that it was required.
* Deserialization of BiMap expects keys to be distinct and ordered. Ensure that this is indeed the case and produce deserialization error when it is violated.