### PR TITLE
Eq for MemoBytes should compare the bytes.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -246,7 +246,7 @@ newtype AuxiliaryData era = AuxiliaryDataConstr (MemoBytes (AuxiliaryDataRaw era
 
 instance (Crypto era ~ c) => HashAnnotated (AuxiliaryData era) EraIndependentAuxiliaryData c
 
-deriving instance Eq (Core.Script era) => Eq (AuxiliaryData era)
+deriving instance Eq (AuxiliaryData era)
 
 deriving instance Show (Core.Script era) => Show (AuxiliaryData era)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -254,7 +254,7 @@ deriving stock instance
 
 instance (Era era, NoThunks (Core.Script era)) => NoThunks (TxWitnessRaw era)
 
-deriving newtype instance (Era era, Eq (Core.Script era)) => Eq (TxWitness era)
+deriving newtype instance Eq (TxWitness era)
 
 deriving newtype instance
   (Era era, Show (Core.Script era)) =>

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
@@ -74,7 +74,7 @@ newtype AuxiliaryData era = AuxiliaryDataWithBytes (MemoBytes (AuxiliaryDataRaw 
 instance (c ~ Crypto era) => HashAnnotated (AuxiliaryData era) EraIndependentAuxiliaryData c
 
 deriving newtype instance
-  (Era era, Core.ChainData (Core.Script era)) =>
+  (Era era) =>
   Eq (AuxiliaryData era)
 
 deriving newtype instance

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -239,9 +239,7 @@ newtype TxBody e = TxBodyConstr (MemoBytes (TxBodyRaw e))
   deriving (Typeable)
   deriving newtype (SafeToHash)
 
-deriving instance
-  (TransValue Eq era, Eq (PParamsDelta era)) =>
-  Eq (TxBody era)
+deriving instance Eq (TxBody era)
 
 deriving instance
   (TransValue Show era, Show (PParamsDelta era)) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -143,13 +143,7 @@ instance
 newtype Tx era = TxConstr (MemoBytes (TxRaw era))
   deriving newtype (SafeToHash, ToCBOR)
 
-deriving newtype instance
-  ( Era era,
-    Eq (Core.AuxiliaryData era),
-    Eq (Core.TxBody era),
-    Eq (Core.Witnesses era)
-  ) =>
-  Eq (Tx era)
+deriving newtype instance Eq (Tx era)
 
 deriving newtype instance
   ( Era era,

--- a/libs/small-steps/src/Data/MemoBytes.hs
+++ b/libs/small-steps/src/Data/MemoBytes.hs
@@ -69,7 +69,7 @@ instance (Typeable t, FromCBOR (Annotator t)) => FromCBOR (Annotator (MemoBytes 
     (Annotator getT, Annotator getBytes) <- withSlice fromCBOR
     pure (Annotator (\fullbytes -> Memo (getT fullbytes) (toShort (toStrict (getBytes fullbytes)))))
 
-instance Eq t => Eq (MemoBytes t) where (Memo x _) == (Memo y _) = x == y
+instance Eq (MemoBytes t) where (Memo _ x) == (Memo _ y) = x == y
 
 instance Show t => Show (MemoBytes t) where show (Memo y _) = show y
 


### PR DESCRIPTION
Two instances of a memoised type are equal iff they have the same bytes.
Justification:
- We require that deserialisation is left inverse to serialisation. So
  if we have
  `serialise x == serialise y`
  `deserialise (serialise x) == deserialise (serialise y)`
  `x == y`
- `Eq` should be compatible with hashing (e.g. if `a == b`, then
  `hash a == hash b`). Currently, this is broken. If I serialise a
  `TxBodyRaw` in two different valid ways (as is perfectly allowed),
  then the resulting `TxBody` will currently compare as equal but hash
  to a different value.
- In choosing not to require a canonical serialisation, the serialised
  bytes are an integral part of the type, and must be considered in
  comparing for equality.