### PR TITLE
Adding a new datatype to replace UTxO currently a Data.Map

### DIFF
--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -130,6 +130,7 @@ test-suite cardano-ledger-shelley-test
   main-is:             Tests.hs
   other-modules:
       Test.Control.Iterate.SetAlgebra
+      Test.Control.Iterate.SplitMapRules
       Test.Cardano.Ledger.Shelley.Examples
       Test.Cardano.Ledger.Shelley.Examples.Combinators
       Test.Cardano.Ledger.Shelley.Examples.EmptyBlock

--- a/eras/shelley/test-suite/test/Test/Control/Iterate/SplitMapRules.hs
+++ b/eras/shelley/test-suite/test/Test/Control/Iterate/SplitMapRules.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Control.Iterate.SplitMapRules where
+
+import Control.Iterate.BaseTypes (BaseRep (..), Sett (..))
+import Control.Iterate.Exp (Exp (..))
+import Control.Iterate.SetAlgebra (rewrite, runSet)
+import Data.Compact.KeyMap (Key (..))
+import Data.Compact.SplitMap
+import Data.Map.Strict (Map)
+import qualified Data.Set as Set
+import Data.Word (Word64)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Prelude hiding (lookup)
+
+-- ============================================================================
+-- The idea is to test that the fast path (rewrite) and the slowpath (runSet)
+-- compute the same thing. There is a test for every rewrite rule
+
+t01 :: SplitMap SS Int -> Exp (Sett SS ())
+t01 xs = Dom (Base SplitR xs)
+
+t02 :: SplitMap SS Int -> Int -> Exp (Sett SS ())
+t02 xs v = Dom (RRestrict (Base SplitR xs) (SetSingleton v))
+
+t03 :: SplitMap SS Int -> Sett Int () -> Exp (Sett SS ())
+t03 xs set = Dom (RRestrict (Base SplitR xs) (Base SetR set))
+
+t04 :: SplitMap SS Int -> Sett Int () -> Exp (Sett SS ())
+t04 xs set = Dom (RExclude (Base SplitR xs) (Base SetR set))
+
+t05 :: SplitMap SS Int -> Int -> Exp (Sett SS ())
+t05 xs v = Dom (RExclude (Base SplitR xs) (SetSingleton v))
+
+t06 :: SplitMap SS Int -> SS -> Exp (Sett SS ())
+t06 xs v = Dom (DRestrict (SetSingleton v) (Base SplitR xs))
+
+t07 :: SplitMap SS Int -> Sett SS () -> Exp (Sett SS ())
+t07 xs set = Dom (DRestrict (Base SetR set) (Base SplitR xs))
+
+t08 :: SplitMap SS Int -> SS -> Exp (Sett SS ())
+t08 xs v = Dom (DExclude (SetSingleton v) (Base SplitR xs))
+
+t09 :: SplitMap SS Int -> Sett SS () -> Exp (Sett SS ())
+t09 xs set = Dom (DExclude (Base SetR set) (Base SplitR xs))
+
+t10 :: SplitMap SS Int -> Sett SS () -> Exp (SplitMap SS Int)
+t10 xs set = DRestrict (Base SetR set) (Base SplitR xs)
+
+t11 :: SplitMap SS Int -> SS -> Exp (SplitMap SS Int)
+t11 xs k = DRestrict (SetSingleton k) (Base SplitR xs)
+
+t12 :: SplitMap SS Int -> SS -> () -> Exp (SplitMap SS Int)
+t12 xs k v = DRestrict (Singleton k v) (Base SplitR xs)
+
+t13 :: SplitMap SS Char -> Map SS Int -> Exp (SplitMap SS Char)
+t13 xs m = DRestrict (Dom (Base MapR m)) (Base SplitR xs)
+
+t14 :: SplitMap SS Int -> Map SS Char -> Exp (Map SS Char)
+t14 xs m = DRestrict (Dom (Base SplitR xs)) (Base MapR m)
+
+t15 :: SplitMap SS Int -> SplitMap SS Char -> Exp (SplitMap SS Char)
+t15 xs zs = DRestrict (Dom (Base SplitR xs)) (Base SplitR zs)
+
+t16 :: SplitMap SS Char -> Map SS Int -> Int -> Exp (SplitMap SS Char)
+t16 xs m k = DRestrict (Dom (RRestrict (Base MapR m) (SetSingleton k))) (Base SplitR xs)
+
+t17 :: SplitMap SS Char -> Map SS Int -> Map Int () -> Exp (SplitMap SS Char)
+t17 xs m1 m2 = DRestrict (Dom (RRestrict (Base MapR m1) (Base MapR m2))) (Base SplitR xs)
+
+t18 :: SplitMap SS Int -> Map SS () -> Exp (SplitMap SS Int)
+t18 xs set = DRestrict (Base MapR set) (Base SplitR xs)
+
+t19 :: SplitMap SS Int -> SS -> Exp (SplitMap SS Int)
+t19 xs k = DExclude (SetSingleton k) (Base SplitR xs)
+
+t20 :: SplitMap SS Int -> SS -> Char -> Exp (SplitMap SS Int)
+t20 xs k v = DExclude (Dom (Singleton k v)) (Base SplitR xs)
+
+t21 :: SplitMap SS Int -> Int -> SS -> Exp (SplitMap SS Int)
+t21 xs k v = DExclude (Rng (Singleton k v)) (Base SplitR xs)
+
+t22 :: SplitMap SS Int -> Set.Set SS -> Exp (SplitMap SS Int)
+t22 xs set = DExclude (Base SetR (Sett set)) (Base SplitR xs)
+
+t23 :: SplitMap SS Int -> Map SS Char -> Exp (SplitMap SS Int)
+t23 xs m = DExclude (Dom (Base MapR m)) (Base SplitR xs)
+
+t24 :: SplitMap SS Int -> SplitMap SS Char -> Exp (SplitMap SS Char)
+t24 xs zs = DExclude (Dom (Base SplitR xs)) (Base SplitR zs)
+
+t25 :: SplitMap SS Int -> Int -> Exp (SplitMap SS Int)
+t25 xs u = RExclude (Base SplitR xs) (SetSingleton u)
+
+t26 :: SplitMap SS Int -> Sett Int () -> Exp (SplitMap SS Int)
+t26 xs set = RExclude (Base SplitR xs) (Base SetR set)
+
+t27 :: SplitMap SS Int -> Int -> Exp (SplitMap SS Int)
+t27 xs k = RRestrict (Base SplitR xs) (SetSingleton k)
+
+t28 :: SplitMap SS Int -> Set.Set Int -> Exp (SplitMap SS Int)
+t28 xs s = RRestrict (Base SplitR xs) (Base SetR (Sett s))
+
+-- ============================================================================
+-- Abstractions for writing tests from rules. One for 1, 2, and 3 input tests
+
+rule1 ::
+  forall v a f.
+  (Show a, Show (f SS v), Eq (f SS v)) =>
+  String ->
+  (a -> Exp (f SS v)) ->
+  a ->
+  Property
+rule1 name f x =
+  case rewrite (f x) of
+    Just t ->
+      counterexample
+        ("1 input property " ++ name ++ "\n exp = " ++ show (f x) ++ "\n   " ++ show x)
+        (t === runSet (f x))
+    Nothing -> error ("1 input property " ++ name ++ "\n  exp = " ++ show (f x) ++ "\n  did not match any rule.")
+
+rule2 ::
+  forall v a1 a2 f.
+  (Show a1, Show a2, Show (f SS v), Eq (f SS v)) =>
+  String ->
+  (a1 -> a2 -> Exp (f SS v)) ->
+  a1 ->
+  a2 ->
+  Property
+rule2 name f x y =
+  case rewrite (f x y) of
+    Just t ->
+      counterexample
+        ("2 input property " ++ name ++ "\n exp = " ++ show (f x y) ++ "\n   x=" ++ show x ++ "\n  y=" ++ show y)
+        (t === runSet (f x y))
+    Nothing -> error ("2 input property " ++ name ++ "\n  exp = " ++ show (f x y) ++ "\n  did not match any rule.")
+
+rule3 ::
+  forall v a1 a2 a3 f.
+  (Show a1, Show a2, Show a3, Show (f SS v), Eq (f SS v)) =>
+  String ->
+  (a1 -> a2 -> a3 -> Exp (f SS v)) ->
+  a1 ->
+  a2 ->
+  a3 ->
+  Property
+rule3 name f x y z =
+  case rewrite (f x y z) of
+    Just t ->
+      counterexample
+        ("3 input property " ++ name ++ "\n exp = " ++ show (f x y z) ++ "\n   x=" ++ show x ++ "\n  y=" ++ show y ++ "\n  z=" ++ show z)
+        (t === runSet (f x y z))
+    Nothing -> error ("3 input property " ++ name ++ "\n  exp = " ++ show (f x y z) ++ "\n  did not match any rule.")
+
+-- ========================================================================================
+-- Abstractions for making TestTree's that report the 'name' and the formula being tested.
+-- This works because the Show instance for Exp is Lazy in its leaves, so we get the structure
+-- of the test, by passing undefined for all its inputs, and then showing the result.
+
+property2 ::
+  forall v a b f.
+  (Arbitrary a, Arbitrary b, Show (f SS v), Eq (f SS v), Show a, Show b) =>
+  String ->
+  (a -> b -> Exp (f SS v)) ->
+  TestTree
+property2 name tnn = testProperty (name ++ " " ++ show (tnn u u)) (rule2 @v name tnn)
+  where
+    u :: any
+    u = undefined
+
+property3 ::
+  forall v a b c f.
+  (Arbitrary a, Arbitrary b, Arbitrary c, Show (f SS v), Eq (f SS v), Show a, Show b, Show c) =>
+  String ->
+  (a -> b -> c -> Exp (f SS v)) ->
+  TestTree
+property3 name tnn = testProperty (name ++ " " ++ show (tnn u u u)) (rule3 @v name tnn)
+  where
+    u :: any
+    u = undefined
+
+fastSlow :: TestTree
+fastSlow =
+  testGroup
+    "SplitMap rewrites compute the same in fast or slow mode"
+    [ testProperty "t01" (rule1 "t01" t01),
+      property2 "t02" t02,
+      property2 "t03" t03,
+      property2 "t04" t04,
+      property2 "t05" t05,
+      property2 "t06" t06,
+      property2 "t07" t07,
+      property2 "t08" t08,
+      property2 "t09" t09,
+      property2 "t10" t10,
+      property2 "t11" t11,
+      property3 "t12" t12,
+      property2 "t13" t13,
+      property2 "t14" t14,
+      property2 "t15" t15,
+      property3 "t16" t16,
+      property3 "t17" t17,
+      property2 "t18" t18,
+      property2 "t19" t19,
+      property3 "t20" t20,
+      property3 "t21" t21,
+      property2 "t22" t22,
+      property2 "t23" t23,
+      property2 "t24" t24,
+      property2 "t25" t25,
+      property2 "t26" t26,
+      property2 "t27" t27,
+      property2 "t28" t28
+    ]
+
+test :: IO ()
+test = defaultMain fastSlow
+
+-- =================================================================
+-- A simple type with a Split instance
+
+data SS = SS Int Word64
+  deriving (Eq, Show)
+
+instance Ord SS where
+  compare (SS i n) (SS j m) =
+    case compare i j of
+      EQ -> compare n m
+      other -> other
+
+instance Split SS where
+  splitKey (SS n m) = (n, Key m 0 0 0)
+  joinKey n (Key m _ _ _) = SS n m
+
+instance Arbitrary SS where
+  arbitrary = joinKey <$> chooseInt (0, 25) <*> (Key <$> arbitrary <*> pure 0 <*> pure 0 <*> pure 0)
+
+instance (Split k, Arbitrary k, Arbitrary a) => Arbitrary (SplitMap k a) where
+  arbitrary = do
+    let go i m
+          | i > 0 = do
+            key <- arbitrary
+            val <- arbitrary
+            go (i - 1) $! insert key val m
+          | otherwise = pure m
+    NonNegative n <- arbitrary
+    go (n :: Int) empty
+
+instance (Ord t, Arbitrary t) => Arbitrary (Sett t ()) where
+  arbitrary = Sett <$> arbitrary

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -14,6 +14,7 @@ import Test.Cardano.Ledger.Shelley.SafeHash (safeHashTest)
 import qualified Test.Cardano.Ledger.Shelley.Serialisation as Serialisation
 import Test.Cardano.Ledger.Shelley.UnitTests (unitTests)
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
+import Test.Control.Iterate.SplitMapRules (fastSlow)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
 
@@ -35,7 +36,8 @@ mainTests =
       unitTests,
       setAlgTest,
       prettyTest,
-      safeHashTest
+      safeHashTest,
+      fastSlow
     ]
 
 nightlyTests :: TestTree
@@ -50,7 +52,8 @@ fastTests :: TestTree
 fastTests =
   testGroup
     "Ledger with Delegation fast"
-    [ Serialisation.tests 1,
+    [ fastSlow,
+      Serialisation.tests 1,
       chainExamples,
       multisigExamples,
       unitTests,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -99,7 +99,12 @@ pattern TxIn addr index <-
 
 {-# COMPLETE TxIn #-}
 
-deriving instance Ord (TxIn crypto)
+-- | This instance is crafted to agreee with TxIn as the domain of SplitMap
+instance Ord (TxIn crypto) where
+  compare (TxInCompact id1 n1) (TxInCompact id2 n2) =
+    case compare n1 n2 of
+      EQ -> compare id1 id2
+      other -> other
 
 deriving instance Eq (TxIn crypto)
 

--- a/libs/compact-map/compact-map.cabal
+++ b/libs/compact-map/compact-map.cabal
@@ -33,6 +33,7 @@ library
                      , Data.Compact.HashMap
                      , Data.Compact.VMap
                      , Data.Compact.SmallArray
+                     , Data.Compact.SplitMap
   other-modules:       Data.Compact.KVVector
   build-depends:       base >=4.11 && <5
                      , cardano-binary
@@ -53,7 +54,8 @@ test-suite tests
 
   hs-source-dirs:      test
   main-is:             Main.hs
-  other-modules:       Test.Compact.KeyMap
+  other-modules:       Test.Compact.SplitMap
+                     , Test.Compact.KeyMap
                      , Test.Compact.VMap
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010

--- a/libs/compact-map/src/Data/Compact/SplitMap.hs
+++ b/libs/compact-map/src/Data/Compact/SplitMap.hs
@@ -59,12 +59,22 @@ null (SplitMap imap) = IntMap.null imap
 -- Insert and delete operations
 
 insertWithKey :: forall k v. (k -> v -> v -> v) -> k -> v -> SplitMap k v -> SplitMap k v
+{- Maybe we should benchmark these two
+insertWithKey combine k v (SplitMap imap) =
+  SplitMap (IntMap.insertWith combine2 n (KeyMap.insert key v KeyMap.Empty) imap)
+ where
+    (n, key) = splitKey k
+    combine2 :: KeyMap v -> KeyMap v -> KeyMap v
+    combine2 km1 km2 = KeyMap.unionWith (combine k) km1 km2
+-}    
 insertWithKey combine k v (SplitMap imap) =
   SplitMap (IntMap.insertWith combine2 n (KeyMap.insert key v KeyMap.Empty) imap)
   where
     (n, key) = splitKey k
     combine2 :: KeyMap v -> KeyMap v -> KeyMap v
-    combine2 km1 _ = KeyMap.insertWith @v (combine k) key v km1
+    combine2 _km1 km2 = KeyMap.insertWith @v (combine k) key v km2
+
+
 
 insertWith :: forall k v. (v -> v -> v) -> k -> v -> SplitMap k v -> SplitMap k v
 insertWith comb k v mp = insertWithKey (\_ x y -> comb x y) k v mp

--- a/libs/compact-map/src/Data/Compact/SplitMap.hs
+++ b/libs/compact-map/src/Data/Compact/SplitMap.hs
@@ -1,0 +1,387 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | A SplitMap is a nested map, when the key can be broken into two parts: 1) an Int, and 2) a Key.
+--   Cutom designed for maps whose Domain is a TxIn. Should take up significantly less space than Data.Map
+module Data.Compact.SplitMap where
+
+import Data.Compact.KeyMap (Key (..), KeyMap, PDoc, ppKeyMap, ppList, ppSexp)
+import qualified Data.Compact.KeyMap as KeyMap
+import Data.Foldable (foldl')
+import qualified Data.IntMap as IntMap
+import Data.IntMap.Strict (IntMap)
+import Data.Map.Internal (Map (..), link, link2)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Set.Internal as IT
+import Data.Text (pack)
+import Prettyprinter
+import Prelude hiding (lookup)
+
+class Split k where
+  splitKey :: k -> (Int, Key)
+  joinKey :: Int -> Key -> k
+
+instance Split (Int, Key) where
+  splitKey = id
+  joinKey = (,)
+
+data SplitMap k v where
+  SplitMap :: Split k => IntMap (KeyMap v) -> SplitMap k v
+
+-- | There is an invariant that every Int in the IntMap has a non-null KeyMap
+--   this should hold for every 'k' and 'SplitMap k v'
+invariant :: k -> SplitMap k v -> Bool
+invariant k (SplitMap imap) =
+  let (n, _key) = splitKey k
+   in case IntMap.lookup n imap of
+        Just kmap -> KeyMap.notEmpty kmap
+        Nothing -> True
+
+-- | To maintain the invariant, we define 'insertNormForm'
+--   Insert a KeyMap into an IntMap, unless it is empty, if so, return the IntMap unchanged
+--   we assume the Int 'n' is not already in the IntMap 'imap', and each call site should check this invariant.
+insertNormForm :: Split k => IntMap.Key -> KeyMap.KeyMap v -> IntMap.IntMap (KeyMap.KeyMap v) -> SplitMap k v
+insertNormForm _ KeyMap.Empty imap = SplitMap imap
+insertNormForm n kmap imap = SplitMap (IntMap.insert n kmap imap)
+
+empty :: forall k v. Split k => SplitMap k v
+empty = SplitMap IntMap.empty
+
+null :: SplitMap k v -> Bool
+null (SplitMap imap) = IntMap.null imap
+
+-- ================================================
+-- Insert and delete operations
+
+insertWithKey :: forall k v. (k -> v -> v -> v) -> k -> v -> SplitMap k v -> SplitMap k v
+insertWithKey combine k v (SplitMap imap) =
+  SplitMap (IntMap.insertWith combine2 n (KeyMap.insert key v KeyMap.Empty) imap)
+  where
+    (n, key) = splitKey k
+    combine2 :: KeyMap v -> KeyMap v -> KeyMap v
+    combine2 km1 _ = KeyMap.insertWith @v (combine k) key v km1
+
+insertWith :: forall k v. (v -> v -> v) -> k -> v -> SplitMap k v -> SplitMap k v
+insertWith comb k v mp = insertWithKey (\_ x y -> comb x y) k v mp
+
+insert :: forall k v. k -> v -> SplitMap k v -> SplitMap k v
+insert k v mp = insertWithKey (\_k v1 _v2 -> v1) k v mp
+
+delete :: k -> SplitMap k v -> SplitMap k v
+delete k (SplitMap imap) = SplitMap (IntMap.update fix n imap)
+  where
+    (n, key) = splitKey k
+    fix keymap = case KeyMap.delete key keymap of
+      KeyMap.Empty -> Nothing
+      !other -> Just other
+
+-- ==================================================================
+-- lookup and map and Functor instance
+
+lookup :: k -> SplitMap k v -> Maybe v
+lookup k (SplitMap imap) =
+  case IntMap.lookup n imap of
+    Nothing -> Nothing
+    Just keymap -> KeyMap.lookupHM key keymap
+  where
+    (n, key) = splitKey k
+
+member :: k -> SplitMap k v -> Bool
+member k smap = case lookup k smap of
+  Nothing -> False
+  Just _ -> True
+
+mapWithKey :: forall k v u. (k -> v -> u) -> SplitMap k v -> SplitMap k u
+mapWithKey f (SplitMap imap) = SplitMap (IntMap.mapWithKey g imap)
+  where
+    g :: Int -> KeyMap v -> KeyMap u
+    g n kmap = KeyMap.mapWithKey (\key v -> f (joinKey n key) v) kmap
+
+instance Functor (SplitMap k) where
+  fmap f x = mapWithKey (\_ v -> f v) x
+
+filterWithKey :: (k -> v -> Bool) -> SplitMap k v -> SplitMap k v
+filterWithKey p smap@(SplitMap _) = foldlWithKey' accum empty smap
+  where
+    accum ans k v = if p k v then insert k v ans else ans
+
+-- =====================================================================
+-- Union operations
+
+unionWithKey :: forall k v. (k -> v -> v -> v) -> SplitMap k v -> SplitMap k v -> SplitMap k v
+unionWithKey combine (SplitMap imap1) (SplitMap imap2) = SplitMap (IntMap.unionWithKey comb imap1 imap2)
+  where
+    comb :: Int -> KeyMap v -> KeyMap v -> KeyMap v
+    comb n x y = KeyMap.unionWithKey (\key v1 v2 -> combine (joinKey n key) v1 v2) x y
+
+unionWith :: forall k v. (v -> v -> v) -> SplitMap k v -> SplitMap k v -> SplitMap k v
+unionWith combine (SplitMap imap1) (SplitMap imap2) = SplitMap (IntMap.unionWith comb imap1 imap2)
+  where
+    comb :: KeyMap v -> KeyMap v -> KeyMap v
+    comb x y = KeyMap.unionWith combine x y
+
+union :: forall k v. SplitMap k v -> SplitMap k v -> SplitMap k v
+union (SplitMap imap1) (SplitMap imap2) = SplitMap (IntMap.unionWith comb imap1 imap2)
+  where
+    comb :: KeyMap v -> KeyMap v -> KeyMap v
+    comb x y = KeyMap.unionWith (\v _ -> v) x y
+
+-- ============================================================================
+-- Intersection operations
+
+intersectionWithKey :: forall k u v w. (k -> u -> v -> w) -> SplitMap k u -> SplitMap k v -> SplitMap k w
+intersectionWithKey combine (SplitMap imap1) (SplitMap imap2) = SplitMap (IntMap.intersectionWithKey comb imap1 imap2)
+  where
+    comb :: Int -> KeyMap u -> KeyMap v -> KeyMap w
+    comb n x y = KeyMap.intersectionWithKey (\key v1 v2 -> combine (joinKey n key) v1 v2) x y
+
+-- | The intersection of 'x' and 'y', where the 'combine' function computes the range.
+intersectionWith :: forall k u v w. (u -> v -> w) -> SplitMap k u -> SplitMap k v -> SplitMap k w
+intersectionWith combine x y = intersectionWithKey (\_k u v -> combine u v) x y
+
+-- | The subset of 'x' with where the domain of 'x' appears in the domain of 'y'
+intersection :: forall k u v. SplitMap k u -> SplitMap k v -> SplitMap k u
+intersection x y = intersectionWithKey (\_ u _ -> u) x y
+
+-- | Like intersectionWithKey, except if the 'combine' function returns Nothing, the common
+--   key is NOT placed in the intersectionWhen result.
+intersectionWhen :: forall k u v w. (k -> u -> v -> Maybe w) -> SplitMap k u -> SplitMap k v -> SplitMap k w
+intersectionWhen combine (SplitMap imap1) (SplitMap imap2) = SplitMap (IntMap.intersectionWithKey comb imap1 imap2)
+  where
+    comb :: Int -> KeyMap u -> KeyMap v -> KeyMap w
+    comb n x y = KeyMap.intersectionWhen (\key v1 v2 -> combine (joinKey n key) v1 v2) x y
+
+foldOverIntersection :: forall ans k u v. (ans -> k -> u -> v -> ans) -> ans -> SplitMap k u -> SplitMap k v -> ans
+foldOverIntersection accum ans0 (SplitMap imap1) (SplitMap imap2) = foldIntersectIntMap accum2 ans0 imap1 imap2
+  where
+    accum2 :: Int -> KeyMap u -> KeyMap v -> ans -> ans
+    accum2 n km1 km2 ans1 = KeyMap.foldOverIntersection (accum3 n) ans1 km1 km2
+    accum3 :: Int -> ans -> Key -> u -> v -> ans
+    accum3 n ans2 key u v = accum ans2 (joinKey n key) u v
+
+foldIntersectIntMap :: (Int -> a -> b -> ans -> ans) -> ans -> IntMap a -> IntMap b -> ans
+foldIntersectIntMap accum ans0 imap1 imap2 =
+  case (IntMap.minViewWithKey imap1, IntMap.minViewWithKey imap2) of
+    (Nothing, _) -> ans0
+    (_, Nothing) -> ans0
+    (Just ((k1, v1), jmap1), Just ((k2, v2), jmap2)) ->
+      case compare k1 k2 of
+        EQ -> foldIntersectIntMap accum (accum k1 v1 v2 ans0) jmap1 jmap2
+        LT -> case IntMap.splitLookup k2 imap1 of
+          (_, Nothing, ys) -> foldIntersectIntMap accum ans0 ys jmap2
+          (_, Just v3, ys) -> foldIntersectIntMap accum (accum k2 v3 v2 ans0) ys jmap2
+        GT -> case IntMap.splitLookup k1 imap2 of
+          (_, Nothing, ys) -> foldIntersectIntMap accum ans0 jmap1 ys
+          (_, Just v3, ys) -> foldIntersectIntMap accum (accum k1 v1 v3 ans0) jmap1 ys
+
+-- | The intersection over the common domain 'k' of a Data.Map and a SplitMap
+--   Only those keys 'k' that meet the predicate 'p' are included.
+--   The result isa Data.Map
+intersectMapSplit :: (k -> v -> u -> Bool) -> Map.Map k v -> SplitMap k u -> Map.Map k v
+intersectMapSplit _ Tip _ = Tip
+intersectMapSplit p (Bin _ k v l r) sp =
+  case splitLookup k sp of
+    (sl, Nothing, sr) -> link2 (intersectMapSplit p l sl) (intersectMapSplit p r sr)
+    (sl, Just u, sr) ->
+      if p k v u
+        then link k v (intersectMapSplit p l sl) (intersectMapSplit p r sr)
+        else link2 (intersectMapSplit p l sl) (intersectMapSplit p r sr)
+
+-- | The intersection over the common domain 'k' of a Data.Set and a SplitMap
+--   Only those keys 'k' that meet the predicate 'p' are included.
+--   The result is a Data.Set
+intersectSetSplit :: (k -> u -> Bool) -> Set k -> SplitMap k u -> Set k
+intersectSetSplit _ IT.Tip _ = IT.Tip
+intersectSetSplit p (IT.Bin _ k l r) sp =
+  case splitLookup k sp of
+    (sl, Nothing, sr) -> IT.merge (intersectSetSplit p l sl) (intersectSetSplit p r sr)
+    (sl, Just u, sr) ->
+      if p k u
+        then IT.link k (intersectSetSplit p l sl) (intersectSetSplit p r sr)
+        else IT.merge (intersectSetSplit p l sl) (intersectSetSplit p r sr)
+
+-- | The intersection over the common domain 'k' of a SplitMap and a Data.Map.
+--   Only those keys 'k' that meet the predicate 'p' are included.
+--   The result isa SplitMap
+intersectSplitMap :: (k -> v -> u -> Bool) -> SplitMap k v -> Map.Map k u -> SplitMap k v
+intersectSplitMap _ (SplitMap _) Tip = empty
+intersectSplitMap p sp (Bin _ k u l r) =
+  case splitLookup k sp of
+    (sl, Nothing, sr) -> union (intersectSplitMap p sl l) (intersectSplitMap p sr r)
+    (sl, Just v, sr) ->
+      if p k v u
+        then insert k v (union (intersectSplitMap p sl l) (intersectSplitMap p sr r))
+        else union (intersectSplitMap p sl l) (intersectSplitMap p sr r)
+
+-- ============================================================================
+-- Fold operations
+
+-- | Strict fold over the pairs in descending order of keys.
+foldlWithKey' :: forall k v ans. (ans -> k -> v -> ans) -> ans -> SplitMap k v -> ans
+foldlWithKey' comb ans0 (SplitMap imap) = IntMap.foldlWithKey' comb2 ans0 imap
+  where
+    comb2 :: ans -> Int -> KeyMap v -> ans
+    comb2 ans1 n kmap = KeyMap.foldWithAscKey comb3 ans1 kmap
+      where
+        comb3 :: ans -> Key -> v -> ans
+        comb3 ans2 key v = comb ans2 (joinKey n key) v
+
+-- | Strict fold over the pairs in ascending order of keys.
+foldrWithKey' :: forall k v ans. (k -> ans -> v -> ans) -> ans -> SplitMap k v -> ans
+foldrWithKey' comb ans0 (SplitMap imap) = IntMap.foldrWithKey' comb2 ans0 imap
+  where
+    comb2 :: Int -> KeyMap v -> ans -> ans
+    comb2 n kmap ans1 = KeyMap.foldWithDescKey comb3 ans1 kmap
+      where
+        comb3 :: Key -> v -> ans -> ans
+        comb3 key v ans2 = comb (joinKey n key) ans2 v
+
+-- =================================================================================
+-- These 'restrictKeys' functions assume the structure holding the 'good' keys is small
+-- An alternate approach is to use cross-type 'intersection' operations
+
+restrictKeysSet :: forall k a. SplitMap k a -> Set k -> SplitMap k a
+restrictKeysSet splitmap@(SplitMap _) kset = Set.foldl' comb (SplitMap IntMap.empty) kset
+  where
+    comb :: SplitMap k a -> k -> SplitMap k a
+    comb smap k = case lookup k splitmap of
+      Nothing -> smap
+      Just a -> insert k a smap
+
+restrictKeysMap :: forall k a b. SplitMap k a -> Map k b -> SplitMap k a
+restrictKeysMap splitmap@(SplitMap _) kmap = Map.foldlWithKey' comb (SplitMap IntMap.empty) kmap
+  where
+    comb :: SplitMap k a -> k -> b -> SplitMap k a
+    comb smap k _ = case lookup k splitmap of
+      Nothing -> smap
+      Just a -> insert k a smap
+
+restrictKeysSplit :: forall k a b. SplitMap k a -> SplitMap k b -> SplitMap k a
+restrictKeysSplit splitmap@(SplitMap _) ksplit = foldlWithKey' comb (SplitMap IntMap.empty) ksplit
+  where
+    comb :: SplitMap k a -> k -> b -> SplitMap k a
+    comb smap k _ = case lookup k splitmap of
+      Nothing -> smap
+      Just a -> insert k a smap
+
+-- | Restrict the keys using the intersection operation
+restrictKeys :: forall k a b. Split k => SplitMap k a -> SplitMap k b -> SplitMap k a
+restrictKeys smap1 smap2 = foldOverIntersection comb empty smap1 smap2
+  where
+    comb ans k a _b = insert k a ans
+
+-- =================================================================================
+-- These 'withoutKeys' functions assume the structure holding the 'bad' keys is small
+-- An alternate approach is to use cross-type 'intersection' operations
+
+withoutKeysSet :: forall k a. SplitMap k a -> Set k -> SplitMap k a
+withoutKeysSet splitmap@(SplitMap _) kset = Set.foldl' comb splitmap kset
+  where
+    comb :: SplitMap k a -> k -> SplitMap k a
+    comb smap k = delete k smap
+
+withoutKeysMap :: forall k a b. SplitMap k a -> Map k b -> SplitMap k a
+withoutKeysMap splitmap@(SplitMap _) kset = Map.foldlWithKey' comb splitmap kset
+  where
+    comb :: SplitMap k a -> k -> b -> SplitMap k a
+    comb smap k _ = delete k smap
+
+withoutKeysSplit :: forall k a b. SplitMap k a -> SplitMap k b -> SplitMap k a
+withoutKeysSplit splitmap@(SplitMap _) kset = foldlWithKey' comb splitmap kset
+  where
+    comb :: SplitMap k a -> k -> b -> SplitMap k a
+    comb smap k _ = delete k smap
+
+-- | Remove the keys using the intersection operation. if 'smap2' is small use one of the other withoutKeysXX functions.
+withoutKeys :: forall k a b. SplitMap k a -> SplitMap k b -> SplitMap k a
+withoutKeys smap1 smap2 = foldOverIntersection comb smap1 smap1 smap2
+  where
+    comb ans k _a _b = delete k ans
+
+-- ==============================================================
+-- Min Max operations
+
+lookupMin :: SplitMap k v -> Maybe (k, v)
+lookupMin (SplitMap imap) =
+  case IntMap.minViewWithKey imap of
+    Nothing -> Nothing
+    Just ((n, kmap), _) ->
+      case KeyMap.lookupMin kmap of
+        Nothing -> Nothing
+        Just (k, v) -> Just (joinKey n k, v)
+
+lookupMax :: SplitMap k v -> Maybe (k, v)
+lookupMax (SplitMap imap) =
+  case IntMap.maxViewWithKey imap of
+    Nothing -> Nothing
+    Just ((n, kmap), _) ->
+      case KeyMap.lookupMax kmap of
+        Nothing -> Nothing
+        Just (k, v) -> Just (joinKey n k, v)
+
+minViewWithKey :: SplitMap k v -> Maybe ((k, v), SplitMap k v)
+minViewWithKey (SplitMap imap) =
+  case IntMap.minViewWithKey imap of
+    Nothing -> Nothing
+    Just ((n, kmap), imap2) ->
+      case KeyMap.minViewWithKey kmap of
+        Nothing -> Nothing
+        Just ((k, v), kmap2) -> Just ((joinKey n k, v), insertNormForm n kmap2 imap2)
+
+maxViewWithKey :: SplitMap k v -> Maybe ((k, v), SplitMap k v)
+maxViewWithKey (SplitMap imap) =
+  case IntMap.maxViewWithKey imap of
+    Nothing -> Nothing
+    Just ((n, kmap), imap2) ->
+      case KeyMap.maxViewWithKey kmap of
+        Nothing -> Nothing
+        Just ((k, v), kmap2) -> Just ((joinKey n k, v), insertNormForm n kmap2 imap2)
+
+-- ====================================================
+
+-- | Performs a split but also returns whether the pivot key was found in the original map.
+splitLookup :: k -> SplitMap k a -> (SplitMap k a, Maybe a, SplitMap k a)
+splitLookup k (SplitMap imap) =
+  let (n, key) = splitKey k
+   in case IntMap.splitLookup n imap of
+        (ileft, Nothing, iright) -> (SplitMap ileft, Nothing, SplitMap iright)
+        (ileft, Just x, iright) ->
+          case KeyMap.splitLookup key x of
+            (kleft, Nothing, kright) ->
+              (insertNormForm n kleft ileft, Nothing, insertNormForm n kright iright)
+            (kleft, Just a, kright) ->
+              (insertNormForm n kleft ileft, Just a, insertNormForm n kright iright)
+
+-- ===============================================================
+-- Interaction with lists
+
+-- | In case of duplicate keys, the pair closer to the end of the list wins.
+fromList :: Split k => [(k, v)] -> SplitMap k v
+fromList pairs = foldl' accum empty pairs
+  where
+    accum mp (k, v) = insert k v mp
+
+-- | Generates the list in ascending order of k
+toList :: SplitMap k v -> [(k, v)]
+toList mp = foldrWithKey' accum [] mp
+  where
+    accum k pairs v = (k, v) : pairs
+
+instance (Split k, Eq k, Eq v) => Eq (SplitMap k v) where
+  x == y = toList x == toList y
+
+instance (Split k, Show k, Show v) => Show (SplitMap k v) where
+  show x = show (ppSplitMap x)
+
+ppSplitMap :: forall k v. Show v => SplitMap k v -> PDoc
+ppSplitMap (SplitMap imap) = ppList ppitem (IntMap.toList imap)
+  where
+    ppitem :: (Int, KeyMap v) -> PDoc
+    ppitem (n, kmap) = ppSexp (pack "Split") [KeyMap.ppInt n, ppKeyMap KeyMap.ppKey ppv kmap]
+    ppv :: v -> PDoc
+    ppv x = viaShow x

--- a/libs/compact-map/src/Data/Compact/SplitMap.hs
+++ b/libs/compact-map/src/Data/Compact/SplitMap.hs
@@ -66,15 +66,13 @@ insertWithKey combine k v (SplitMap imap) =
     (n, key) = splitKey k
     combine2 :: KeyMap v -> KeyMap v -> KeyMap v
     combine2 km1 km2 = KeyMap.unionWith (combine k) km1 km2
--}    
+-}
 insertWithKey combine k v (SplitMap imap) =
   SplitMap (IntMap.insertWith combine2 n (KeyMap.insert key v KeyMap.Empty) imap)
   where
     (n, key) = splitKey k
     combine2 :: KeyMap v -> KeyMap v -> KeyMap v
     combine2 _km1 km2 = KeyMap.insertWith @v (combine k) key v km2
-
-
 
 insertWith :: forall k v. (v -> v -> v) -> k -> v -> SplitMap k v -> SplitMap k v
 insertWith comb k v mp = insertWithKey (\_ x y -> comb x y) k v mp

--- a/libs/compact-map/test/Main.hs
+++ b/libs/compact-map/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Test.Compact.KeyMap (alltests)
+import Test.Compact.SplitMap (splitMapTests)
 import Test.Compact.VMap
 import Test.Tasty
 
@@ -9,9 +10,10 @@ import Test.Tasty
 tests :: TestTree
 tests =
   testGroup
-    "compcat-map"
+    "compact-map"
     [ alltests,
-      vMapTests
+      vMapTests,
+      splitMapTests
     ]
 
 main :: IO ()

--- a/libs/compact-map/test/Test/Compact/KeyMap.hs
+++ b/libs/compact-map/test/Test/Compact/KeyMap.hs
@@ -40,9 +40,9 @@ instance Uniform Key where
 
 instance Arbitrary Key where
   arbitrary =
-    oneof
-      [ Key <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary,
-        Key <$> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny
+    frequency
+      [ (1, Key <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary),
+        (20, Key <$> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny)
       ]
 
 instance HM.Keyed Key where
@@ -113,9 +113,9 @@ setprop ::
   m k v ->
   m k v ->
   Property
-setprop unionWithF intersect a b c =
-  intersect a (unionWithF (\_k x _y -> x) b c)
-    === unionWithF (\_k x _y -> x) (intersect a b) (intersect a c)
+setprop unionWithF intersct a b c =
+  intersct a (unionWithF (\_k x _y -> x) b c)
+    === unionWithF (\_k x _y -> x) (intersct a b) (intersct a c)
 
 lookupinsert ::
   forall k a t.

--- a/libs/compact-map/test/Test/Compact/SplitMap.hs
+++ b/libs/compact-map/test/Test/Compact/SplitMap.hs
@@ -25,11 +25,11 @@ newtype MockTxIn = MockTxIn (Int, Key)
   deriving (Show, Eq, Ord)
 
 instance Split MockTxIn where
-  split (MockTxIn pair) = pair
-  join n k = MockTxIn (n, k)
+  splitKey (MockTxIn pair) = pair
+  joinKey n k = MockTxIn (n, k)
 
 instance Arbitrary MockTxIn where
-  arbitrary = join <$> chooseInt (0, 25) <*> arbitrary
+  arbitrary = joinKey <$> chooseInt (0, 25) <*> arbitrary
 
 -- =================================================================
 -- A simple type with a Split instance
@@ -44,11 +44,11 @@ instance Ord SS where
       other -> other
 
 instance Split SS where
-  split (SS n m) = (n, Key m 0 0 0)
-  join n (Key m _ _ _) = SS n m
+  splitKey (SS n m) = (n, Key m 0 0 0)
+  joinKey n (Key m _ _ _) = SS n m
 
 instance Arbitrary SS where
-  arbitrary = join <$> chooseInt (0, 25) <*> (Key <$> arbitrary <*> pure 0 <*> pure 0 <*> pure 0)
+  arbitrary = joinKey <$> chooseInt (0, 25) <*> (Key <$> arbitrary <*> pure 0 <*> pure 0 <*> pure 0)
 
 -- ===============================================
 

--- a/libs/compact-map/test/Test/Compact/SplitMap.hs
+++ b/libs/compact-map/test/Test/Compact/SplitMap.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Compact.SplitMap where
+
+import Data.Compact.KeyMap (Key (..))
+import Data.Compact.SplitMap
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import Data.Word (Word64)
+import Test.Compact.KeyMap
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Prelude hiding (lookup)
+
+-- ==============================================================
+-- All the features of TxIn, but we don't need to import it
+
+newtype MockTxIn = MockTxIn (Int, Key)
+  deriving (Show, Eq, Ord)
+
+instance Split MockTxIn where
+  split (MockTxIn pair) = pair
+  join n k = MockTxIn (n, k)
+
+instance Arbitrary MockTxIn where
+  arbitrary = join <$> chooseInt (0, 25) <*> arbitrary
+
+-- =================================================================
+-- A simple type with a Split instance
+
+data SS = SS Int Word64
+  deriving (Eq, Show)
+
+instance Ord SS where
+  compare (SS i n) (SS j m) =
+    case compare i j of
+      EQ -> compare n m
+      other -> other
+
+instance Split SS where
+  split (SS n m) = (n, Key m 0 0 0)
+  join n (Key m _ _ _) = SS n m
+
+instance Arbitrary SS where
+  arbitrary = join <$> chooseInt (0, 25) <*> (Key <$> arbitrary <*> pure 0 <*> pure 0 <*> pure 0)
+
+-- ===============================================
+
+instance (Split k, Arbitrary k, Arbitrary a) => Arbitrary (SplitMap k a) where
+  arbitrary = do
+    let go i m
+          | i > 0 = do
+            key <- arbitrary
+            val <- arbitrary
+            go (i - 1) $! insert key val m
+          | otherwise = pure m
+    NonNegative n <- arbitrary
+    go (n :: Int) empty
+
+-- ===============================================
+-- Property tests between SplitMaps
+
+ascFoldDescFoldx :: SplitMap k Int -> Property
+ascFoldDescFoldx x = foldrWithKey' (\_key ans v -> ans + v) 0 x === foldlWithKey' (\ans _key v -> v + ans) 0 x
+
+allKeyx :: (k -> Bool) -> SplitMap k t -> Bool
+allKeyx p = foldlWithKey' (\ans key _v -> p key && ans) True
+
+allValx :: (t -> Bool) -> SplitMap k t -> Bool
+allValx p = foldlWithKey' (\ans _key v -> p v && ans) True
+
+minKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
+minKeyx x = do
+  (k, _v) <- lookupMin x
+  pure $ counterexample ("min=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 >= k) x)
+
+maxKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
+maxKeyx x = case lookupMax x of
+  Nothing -> True === True
+  Just (k, _v) -> counterexample ("max=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 <= k) x === True)
+
+mapWorksx :: SplitMap k Int -> Property
+mapWorksx x = allValx (== (99 :: Int)) (mapWithKey (\_key _x -> 99) x) === True
+
+foldintersectS :: forall k. SplitMap k Int -> SplitMap k Int -> Property
+foldintersectS x y = foldOverIntersection (\ans _key u _v -> ans + u) 0 x y === foldlWithKey' (\ans _key u -> ans + u) 0 (intersection x y)
+
+withoutRestrictS :: (Eq k, Split k, Show k) => SplitMap k Int -> Set k -> Property
+withoutRestrictS m domset = union (withoutKeysSet m domset) (restrictKeysSet m domset) === m
+
+withoutRestrictM :: (Eq k, Split k, Show k) => SplitMap k Int -> Map k Char -> Property
+withoutRestrictM m domset = union (withoutKeysMap m domset) (restrictKeysMap m domset) === m
+
+withoutRestrictSp :: (Eq k, Split k, Show k) => SplitMap k Int -> SplitMap k Char -> Property
+withoutRestrictSp m domset = union (withoutKeysSplit m domset) (restrictKeysSplit m domset) === m
+
+withoutRestrictSp2 :: (Eq k, Split k, Show k) => SplitMap k Int -> SplitMap k Char -> Property
+withoutRestrictSp2 m domset = union (withoutKeys m domset) (restrictKeys m domset) === m
+
+splitwholeS :: (Eq k, Show k, Split k) => k -> SplitMap k Int -> Property
+splitwholeS k m =
+  case splitLookup k m of
+    (m1, Nothing, m2) -> m === union m1 m2
+    (m1, Just v, m2) -> m === (insert k v (union m1 m2))
+
+testWhen :: Test k => SplitMap k Int -> SplitMap k Int -> Bool
+testWhen xs ys = intersectionWhen p xs ys == filterWithKey q (intersectionWith r xs ys)
+  where
+    q _k v = even v
+    r _u v = v
+    p k u v = if (q k v) then Just (r u v) else Nothing
+
+-- ===============================================
+
+testp :: IO (SplitMap SS Int)
+testp = do
+  ss <- generate (vectorOf 100 (arbitrary :: Gen SS))
+  let pairs = zip ss [0 .. 30]
+  pure (fromList pairs)
+
+splitIsMapTests :: TestTree
+splitIsMapTests =
+  testGroup
+    "SpitMap operations have map-like properties"
+    [ testProperty "to/fromList SS" (roundtripFromList @SS @Int toList fromList),
+      testProperty "to/fromList MockTxIn" (roundtripFromList @MockTxIn @Int toList fromList),
+      testProperty "SplitMap SS insert-delete" $ insertDelete @SS @Int insert delete,
+      testProperty "SplitMap MockTxIn insert-delete" $ insertDelete @MockTxIn @Int insert delete,
+      testProperty "SplitMap SS foldl" $ foldlkey @SS @Int toList foldlWithKey',
+      testProperty "SplitMap MockTxIn foldl" $ foldlkey @MockTxIn @Int toList foldlWithKey',
+      testProperty "union-intersect-property" $ setprop @SS @Int unionWithKey intersection,
+      testPropertyN 1000 "union-intersect-property" $ setprop @MockTxIn @Int unionWithKey intersection,
+      testProperty "lookup-insert SS" $ lookupinsert @SS @Int SplitMap.lookup insert,
+      testProperty "lookup-insert MockTxIn" $ lookupinsert @MockTxIn @Int SplitMap.lookup insert,
+      testProperty "lookup-delete SS" $ lookupdelete @SS @Int SplitMap.lookup delete,
+      testProperty "lookup-delete MockTxIn" $ lookupdelete @MockTxIn @Int SplitMap.lookup delete,
+      testPropertyN 1000 "union is associative" $ assoc @MockTxIn @Int union,
+      testPropertyN 1000 "unionWith is commutative" $ commutes @MockTxIn @Int (unionWith (+)),
+      -- (unionwith f) is commutative if 'f' is commutative
+      testPropertyN 1000 "intersect is associative" $ assoc @MockTxIn @Int intersection,
+      testPropertyN 1000 "intersectWith is commutative" $ commutes @SS @Int (intersectionWith (+)),
+      -- (unionwith f) is commutative if 'f' is commutative
+      testProperty "ascending fold == descending fold with commutative operator" (ascFoldDescFoldx @SS),
+      testProperty "lookupMin finds the smallest key" (minKeyx @SS @Int),
+      testProperty "lookupMax finds the largest key" (maxKeyx @SS @Int),
+      testProperty "(mapWithKey f) applies 'f' to every value" (mapWorksx @MockTxIn),
+      testProperty "foldOverIntersection folds over the intersection" (foldintersectS @MockTxIn),
+      testProperty "restrictKeysSet and withoutKeysSet partition a KeyMap" (withoutRestrictS @MockTxIn),
+      testProperty "restrictKeysMap and withoutKeysMap partition a KeyMap" (withoutRestrictM @MockTxIn),
+      testProperty "restrictKeysSplit and withoutKeysSplit partition a KeyMap" (withoutRestrictSp @MockTxIn),
+      testProperty "restrictKeys and withoutKeys partition a KeyMap" (withoutRestrictSp2 @SS),
+      testPropertyN 500 "splitLookup pieces add to the whole" (splitwholeS @SS),
+      testProperty "intersectWhen is filter after intersection" (testWhen @SS)
+    ]
+
+-- =========================================================
+-- SplitMap functions behave the same as Data.Map
+
+infix 4 %==%
+
+(%==%) :: (Split k, Eq k, Eq v, Show k, Show v) => SplitMap k v -> Map.Map k v -> Property
+(%==%) x y =
+  counterexample
+    ("\nkeymap\n" ++ show x ++ "\ndatamap\n" ++ show y)
+    (toList x === Map.toList y)
+
+type Test k = (Split k, Eq k, Show k, Ord k)
+
+insertSPLITDATA :: forall k v. (Test k, Eq v, Show v) => k -> v -> [(k, v)] -> Property
+insertSPLITDATA k v m = insert k v (fromList m) %==% Map.insert k v (Map.fromList m)
+
+deleteSPLITDATA :: forall k v. (Test k, Eq v, Show v) => k -> [(k, v)] -> Property
+deleteSPLITDATA k m = delete k (fromList m) %==% Map.delete k (Map.fromList m)
+
+unionSPLITDATA :: forall k v. (Test k, Eq v, Show v) => [(k, v)] -> [(k, v)] -> Property
+unionSPLITDATA n m = union (fromList n) (fromList m) %==% Map.union (Map.fromList n) (Map.fromList m)
+
+intersectSPLITDATA :: forall k v. (Test k, Eq v, Show v) => [(k, v)] -> [(k, v)] -> Property
+intersectSPLITDATA n m = intersection (fromList n) (fromList m) %==% Map.intersection (Map.fromList n) (Map.fromList m)
+
+lookupSPLITDATA :: forall k v. (Test k, Eq v, Show v) => k -> [(k, v)] -> Property
+lookupSPLITDATA k m = lookup k (fromList m) === Map.lookup k (Map.fromList m)
+
+restrictSPLITDATA :: (Test k, Show a, Eq a) => [(k, a)] -> Set k -> Property
+restrictSPLITDATA m s = restrictKeysSet (fromList m) s %==% Map.restrictKeys (Map.fromList m) s
+
+withoutSPLITDATA :: (Test k, Show a, Eq a) => [(k, a)] -> Set k -> Property
+withoutSPLITDATA m s = withoutKeysSet (fromList m) s %==% Map.withoutKeys (Map.fromList m) s
+
+minSPLITDATA :: (Test k, Eq a, Show a) => [(k, a)] -> Property
+minSPLITDATA m = lookupMin (fromList m) === Map.lookupMin (Map.fromList m)
+
+maxSPLITDATA :: (Test k, Eq a, Show a) => [(k, a)] -> Property
+maxSPLITDATA m = lookupMax (fromList m) === Map.lookupMax (Map.fromList m)
+
+splitSPLITDATA :: (Test k, Eq a, Show a) => k -> [(k, a)] -> Property
+splitSPLITDATA k m = case Map.splitLookup k (Map.fromList m) of
+  (a, b, c) -> (fromList (Map.toList a), b, fromList (Map.toList c)) === splitLookup k (fromList m)
+
+minViewSPLITDATA :: Test k => [(k, Int)] -> Property
+minViewSPLITDATA m = case Map.minViewWithKey (Map.fromList m) of
+  Nothing -> minViewWithKey (fromList m) === Nothing
+  Just (b, c) -> Just (b, fromList (Map.toList c)) === minViewWithKey (fromList m)
+
+maxViewSPLITDATA :: Test k => [(k, Int)] -> Property
+maxViewSPLITDATA m = case Map.maxViewWithKey (Map.fromList m) of
+  Nothing -> maxViewWithKey (fromList m) === Nothing
+  Just (b, c) -> Just (b, fromList (Map.toList c)) === maxViewWithKey (fromList m)
+
+splitMapEquivDataMap :: TestTree
+splitMapEquivDataMap =
+  testGroup
+    "SplitMap behaves like Data.Map"
+    [ testPropertyN 500 "insert" (insertSPLITDATA @SS @Int),
+      testPropertyN 500 "delete" (deleteSPLITDATA @SS @Int),
+      testPropertyN 500 "union" (unionSPLITDATA @SS @Int),
+      testPropertyN 500 "intersection" (intersectSPLITDATA @SS @Int),
+      testPropertyN 500 "lookup" (lookupSPLITDATA @SS @Int),
+      testPropertyN 500 "withoutKeys" (withoutSPLITDATA @SS @Int),
+      testPropertyN 500 "restrictKeys" (restrictSPLITDATA @SS @Int),
+      testPropertyN 500 "lookupMin" (minSPLITDATA @SS @Int),
+      testPropertyN 500 "lookupMax" (maxSPLITDATA @SS @Int),
+      testPropertyN 500 "splitLookup" (splitSPLITDATA @SS @Int),
+      testPropertyN 500 "minViewWithKey" (minViewSPLITDATA @SS),
+      testPropertyN 500 "maxViewWithKey" (maxViewSPLITDATA @SS)
+    ]
+
+splitMapTests :: TestTree
+splitMapTests = testGroup "SplitMap tests" [splitIsMapTests, splitMapEquivDataMap]

--- a/libs/compact-map/test/Test/Compact/SplitMap.hs
+++ b/libs/compact-map/test/Test/Compact/SplitMap.hs
@@ -78,8 +78,8 @@ allValx p = foldlWithKey' (\ans _key v -> p v && ans) True
 minKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
 minKeyx x =
   case lookupMin x of
-   Just (k, _v) -> counterexample ("min=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 >= k) x)
-   Nothing -> True ===True
+    Just (k, _v) -> counterexample ("min=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 >= k) x)
+    Nothing -> True === True
 
 maxKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
 maxKeyx x = case lookupMax x of

--- a/libs/compact-map/test/Test/Compact/SplitMap.hs
+++ b/libs/compact-map/test/Test/Compact/SplitMap.hs
@@ -76,9 +76,10 @@ allValx :: (t -> Bool) -> SplitMap k t -> Bool
 allValx p = foldlWithKey' (\ans _key v -> p v && ans) True
 
 minKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
-minKeyx x = do
-  (k, _v) <- lookupMin x
-  pure $ counterexample ("min=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 >= k) x)
+minKeyx x =
+  case lookupMin x of
+   Just (k, _v) -> counterexample ("min=" ++ show k ++ "map=\n" ++ show x) (allKeyx (\x1 -> x1 >= k) x)
+   Nothing -> True ===True
 
 maxKeyx :: (Split k, Show k, Show a, Ord k) => SplitMap k a -> Property
 maxKeyx x = case lookupMax x of

--- a/libs/small-steps/src/Control/Iterate/SetAlgebra.hs
+++ b/libs/small-steps/src/Control/Iterate/SetAlgebra.hs
@@ -46,11 +46,26 @@ import Control.Iterate.Exp
     rngStep,
     second,
   )
+import Data.Compact.SplitMap
+  ( filterWithKey,
+    foldlWithKey',
+    intersectMapSplit,
+    intersectSplitMap,
+    intersection,
+    member,
+    restrictKeysSet,
+    withoutKeysMap,
+    withoutKeysSet,
+    withoutKeysSplit,
+  )
+import qualified Data.Compact.SplitMap as Split
 import Data.Map.Internal (Map (..), link, link2)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Prelude hiding (lookup)
+
+-- ===============================================================================
 
 -- | Compile the (Exp (f k v)) to a Query iterator, and a BaseRep that indicates
 --   how to materialize the iterator to the correct type. Recall the iterator
@@ -113,6 +128,7 @@ compileSubterm _whole sub = fst (compile sub)
 run :: (Ord k) => (Query k v, BaseRep f k v) -> f k v
 run (BaseD SetR x, SetR) = x -- If it is already data (BaseD)
 run (BaseD MapR x, MapR) = x -- and in the right form (the BaseRep's match)
+run (BaseD SplitR x, SplitR) = x
 run (BaseD SingleR x, SingleR) = x -- just return the data
 run (BaseD BiMapR x, BiMapR) = x -- only need to materialize data
 run (BaseD ListR x, ListR) = x -- if the forms do not match.
@@ -197,12 +213,10 @@ compute (Dom (DExclude (SetSingleton v) (Base MapR xs))) = Sett (disjointMapSetF
 compute (Dom (DExclude (Base SetR (Sett set)) (Base MapR xs))) = Sett (disjointMapSetFold accum xs set Set.empty)
   where
     accum k _u ans = Set.insert k ans
-compute (e@(Dom _)) = runSetExp e
 compute (Rng (Base SetR _rel)) = Sett (Set.singleton ())
 compute (Rng (Singleton _k v)) = Sett (Set.singleton v)
 compute (Rng (SetSingleton _k)) = Sett (Set.singleton ())
 compute (Rng (Base _rep rel)) = Sett (range rel)
-compute (e@(Rng _)) = runSetExp e
 compute (DRestrict (Base SetR (Sett set)) (Base MapR m)) = Map.restrictKeys m set
 compute (DRestrict (SetSingleton k) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
 compute (DRestrict (Singleton k _v) (Base MapR m)) = Map.restrictKeys m (Set.singleton k)
@@ -224,7 +238,6 @@ compute (DRestrict (Dom (Base _ x1)) (Base rep x2)) = materialize rep $ do (x, _
 compute (DRestrict (SetSingleton k) (Base rep x2)) = materialize rep $ do (x, _, z) <- (SetSingle k) `domEq` x2; one (x, z)
 compute (DRestrict (Dom (Singleton k _)) (Base rep x2)) = materialize rep $ do (x, _, z) <- (SetSingle k) `domEq` x2; one (x, z)
 compute (DRestrict (Rng (Singleton _ v)) (Base rep x2)) = materialize rep $ do (x, _, z) <- (SetSingle v) `domEq` x2; one (x, z)
-compute (e@(DRestrict _ _)) = runSetExp e
 compute (DExclude (SetSingleton n) (Base MapR m)) = Map.withoutKeys m (Set.singleton n)
 compute (DExclude (Dom (Singleton n _v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton n)
 compute (DExclude (Rng (Singleton _n v)) (Base MapR m)) = Map.withoutKeys m (Set.singleton v)
@@ -233,7 +246,6 @@ compute (DExclude (Dom (Base MapR x1)) (Base MapR x2)) = noKeys x2 x1
 compute (DExclude (SetSingleton k) (Base BiMapR x)) = removekey k x
 compute (DExclude (Dom (Singleton k _)) (Base BiMapR x)) = removekey k x
 compute (DExclude (Rng (Singleton _ v)) (Base BiMapR x)) = removekey v x
-compute (e@(DExclude _ _)) = runSetExp e
 compute (RExclude (Base BiMapR x) (SetSingleton k)) = removeval k x
 compute (RExclude (Base BiMapR x) (Dom (Singleton k _v))) = removeval k x
 compute (RExclude (Base BiMapR x) (Rng (Singleton _k v))) = removeval v x
@@ -245,14 +257,13 @@ compute (RExclude (Base rep lhs) y) =
   materialize rep $ do (a, b) <- lifo lhs; when (not (haskey b rhs)); one (a, b)
   where
     (rhs, _) = compile y
-compute (e@(RExclude _ _)) = runSetExp e
+
 -- (dom (Map(16)? ▷ (setSingleton _ )))
 compute (RRestrict (Base MapR xs) (SetSingleton k)) = Map.filter (\x -> x == k) xs
 -- ((dom rewards' ◁ delegs) ▷ dom poolParams)  in LedgerState.hs
 compute (RRestrict (DRestrict (Dom (Base MapR x)) (Base MapR y)) (Dom (Base MapR z))) = intersectDomP (\_k v -> Map.member v z) x y
 compute (RRestrict (DRestrict (Dom (Base _r1 stkcreds)) (Base r2 delegs)) (Dom (Base _r3 stpools))) =
   materialize r2 $ do (x, _, y) <- stkcreds `domEq` delegs; y `element` stpools; one (x, y)
-compute (e@(RRestrict _ _)) = runSetExp e
 compute (Elem k (Dom (Base _rep x))) = haskey k x
 compute (Elem k (Base _rep rel)) = haskey k rel
 compute (Elem k (Dom (Singleton key _v))) = k == key
@@ -264,7 +275,6 @@ compute (Elem k (UnionPlus (Base SetR (Sett x)) (Base SetR (Sett y)))) = (Set.me
 compute (Elem k (Intersect (Base SetR (Sett x)) (Base SetR (Sett y)))) = (Set.member k x && Set.member k y)
 compute (Elem k (DRestrict s1 m1)) = compute (Elem k s1) && compute (Elem k m1)
 compute (Elem k (DExclude s1 m1)) = not (compute (Elem k s1)) && compute (Elem k m1)
-compute (e@(Elem _ _)) = runBoolExp e
 compute (NotElem k (Dom (Base _rep x))) = not $ haskey k x
 compute (NotElem k (Base _rep rel)) = not $ haskey k rel
 compute (NotElem k (Dom (Singleton key _v))) = not $ k == key
@@ -274,7 +284,6 @@ compute (NotElem k (UnionOverrideLeft (Base SetR (Sett x)) (Base SetR (Sett y)))
 compute (NotElem k (UnionOverrideRight (Base SetR (Sett x)) (Base SetR (Sett y)))) = not (Set.member k x || Set.member k y)
 compute (NotElem k (UnionPlus (Base SetR (Sett x)) (Base SetR (Sett y)))) = not (Set.member k x || Set.member k y)
 compute (NotElem k (Intersect (Base SetR (Sett x)) (Base SetR (Sett y)))) = not (Set.member k x && Set.member k y)
-compute (e@(NotElem _ _)) = runBoolExp e
 compute (Subset (Base SetR (Sett x)) (Base SetR (Sett y))) = Set.isSubsetOf x y
 compute (Subset (Base SetR (Sett x)) (Base MapR y)) = all (`Map.member` y) x
 compute (Subset (Base SetR (Sett x)) (Dom (Base MapR y))) = all (`Map.member` y) x
@@ -284,30 +293,24 @@ compute (Subset (Base MapR x) (Base MapR y)) = Map.foldrWithKey accum True x
 compute (Subset (Dom (Base MapR x)) (Dom (Base MapR y))) = Map.foldrWithKey accum True x
   where
     accum k _a ans = Map.member k y && ans
-compute (e@(Subset _ _)) = runBoolExp e
 compute (Intersect (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.intersection x y)
 compute (Intersect (Base MapR x) (Base MapR y)) = Sett (Map.keysSet (Map.intersection x y))
-compute (e@(Intersect _ _)) = runSetExp e
 compute (SetDiff (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.difference x y)
 compute (SetDiff (Base SetR (Sett x)) (Base MapR y)) = Sett (Set.filter (\e -> not (Map.member e y)) x)
 compute (SetDiff (Base SetR (Sett x)) (Dom (Base MapR y))) = Sett (Set.filter (\e -> not (Map.member e y)) x)
 compute (SetDiff (Base MapR x) (Dom (Base MapR y))) = Map.difference x y
 compute (SetDiff (Base MapR x) (Base MapR y)) = (Map.difference x y)
 compute (SetDiff (Base MapR x) (Base SetR (Sett y))) = (Map.withoutKeys x y)
-compute (e@(SetDiff _ _)) = runSetExp e
 compute (UnionOverrideLeft (Base _rep x) (Singleton k v)) = addkv (k, v) x (\old _new -> old) -- The value on the left is preferred over the right, so 'addkv' chooses 'old'
 compute (UnionOverrideLeft (Base MapR d0) (Base MapR d1)) = Map.union d0 d1 -- 'Map.union' is left biased, just what we want.
 compute (UnionOverrideLeft (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y)
 compute (UnionOverrideLeft (DExclude (SetSingleton k) (Base MapR xs)) (Base MapR ys)) = Map.union (Map.delete k xs) ys
 compute (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m2)) (Base MapR m3)) = Map.union (Map.withoutKeys m2 s1) m3
-compute (e@(UnionOverrideLeft _ _)) = runSetExp e
 compute (UnionOverrideRight (Base _rep x) (Singleton k v)) = addkv (k, v) x (\_old new -> new) -- The value on the right is preferred over the left, so 'addkv' chooses 'new'
 compute (UnionOverrideRight (Base MapR d0) (Base MapR d1)) = Map.union d1 d0 -- we pass @d1@ as first argument, since 'Map.union' is left biased.
 compute (UnionOverrideRight (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y)
-compute (e@(UnionOverrideRight _ _)) = runSetExp e
 compute (UnionPlus (Base MapR x) (Base MapR y)) = Map.unionWith (<>) x y
 compute (UnionPlus (Base SetR (Sett x)) (Base SetR (Sett y))) = Sett (Set.union x y) -- Recall (Sett k):: f k (), so () <> () = ()
-compute (e@(UnionPlus _ _)) = runSetExp e
 compute (Singleton k v) = Single k v
 compute (SetSingleton k) = (SetSingle k)
 compute (KeyEqual (Base MapR m) (Base MapR n)) = keysEqual m n
@@ -316,10 +319,125 @@ compute (KeyEqual (Dom (Base MapR m)) (Dom (Base MapR n))) = keysEqual m n
 compute (KeyEqual (Dom (Base BiMapR (MkBiMap m _))) (Dom (Base BiMapR (MkBiMap n _)))) = keysEqual m n
 compute (KeyEqual (Base SetR (Sett m)) (Base SetR (Sett n))) = n == m
 compute (KeyEqual (Base MapR xs) (Base SetR (Sett ys))) = Map.keysSet xs == ys
-compute (e@(KeyEqual _ _)) = runBoolExp e
+compute x =
+  case rewrite x of
+    Just t -> t
+    Nothing -> computeSlow x
 
 eval :: Embed s t => Exp t -> s
 eval x = fromBase (compute x)
+
+computeSlow :: Exp t -> t
+computeSlow (Base _ t) = t
+computeSlow (e@(Dom _)) = runSetExp e
+computeSlow (e@(Rng _)) = runSetExp e
+computeSlow (e@(DRestrict _ _)) = runSetExp e
+computeSlow (e@(DExclude _ _)) = runSetExp e
+computeSlow (e@(RExclude _ _)) = runSetExp e
+computeSlow (e@(RRestrict _ _)) = runSetExp e
+computeSlow (e@(Elem _ _)) = runBoolExp e
+computeSlow (e@(NotElem _ _)) = runBoolExp e
+computeSlow (e@(Subset _ _)) = runBoolExp e
+computeSlow (e@(Intersect _ _)) = runSetExp e
+computeSlow (e@(SetDiff _ _)) = runSetExp e
+computeSlow (e@(UnionOverrideLeft _ _)) = runSetExp e
+computeSlow (e@(UnionOverrideRight _ _)) = runSetExp e
+computeSlow (e@(UnionPlus _ _)) = runSetExp e
+computeSlow (Singleton k v) = Single k v
+computeSlow (SetSingleton k) = (SetSingle k)
+computeSlow (e@(KeyEqual _ _)) = runBoolExp e
+
+-- =========================================================================
+-- Apply rewrite rules for SplitMap
+
+rewrite :: Exp t -> Maybe t
+rewrite (Base _rep relation) = Just relation
+-- t01
+rewrite (Dom (Base SplitR x)) = Just $ Sett (foldlWithKey' (\ans k _ -> Set.insert k ans) Set.empty x)
+-- t02
+rewrite (Dom (RRestrict (Base SplitR xs) (SetSingleton v))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k u = if u == v then Set.insert k ans else ans
+-- t03
+rewrite (Dom (RRestrict (Base SplitR xs) (Base SetR (Sett set)))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k u = if Set.member u set then Set.insert k ans else ans
+-- t04
+rewrite (Dom (RExclude (Base SplitR xs) (Base SetR (Sett set)))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k u = if not (Set.member u set) then Set.insert k ans else ans
+-- t05
+rewrite (Dom (RExclude (Base SplitR xs) (SetSingleton v))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k u = if not (u == v) then Set.insert k ans else ans
+-- t06
+rewrite (Dom (DRestrict (SetSingleton v) (Base SplitR xs))) =
+  if member v xs
+    then Just (Sett (Set.singleton v))
+    else Just (Sett (Set.empty))
+-- t07
+rewrite (Dom (DRestrict (Base SetR (Sett set)) (Base SplitR xs))) = Just $ Sett (Set.foldl' accum Set.empty set)
+  where
+    accum ans k = if member k xs then Set.insert k ans else ans
+-- t08
+rewrite (Dom (DExclude (SetSingleton v) (Base SplitR xs))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k _v = if k == v then ans else Set.insert k ans
+-- t09
+rewrite (Dom (DExclude (Base SetR (Sett set)) (Base SplitR xs))) = Just $ Sett (foldlWithKey' accum Set.empty xs)
+  where
+    accum ans k _v = if Set.member k set then ans else Set.insert k ans
+-- t10
+rewrite (DRestrict (Base SetR (Sett set)) (Base SplitR m)) = Just $ restrictKeysSet m set
+-- t11
+rewrite (DRestrict (SetSingleton k) (Base SplitR m)) = Just $ restrictKeysSet m (Set.singleton k)
+-- t12
+rewrite (DRestrict (Singleton k _v) (Base SplitR m)) = Just $ restrictKeysSet m (Set.singleton k)
+-- t13
+rewrite (DRestrict (Dom (Base MapR x)) (Base SplitR y)) = Just $ intersectSplitMap always y x
+  where
+    always _ _ _ = True
+-- t14
+rewrite (DRestrict (Dom (Base SplitR x)) (Base MapR y)) = Just $ intersectMapSplit always y x
+  where
+    always _ _ _ = True
+-- t15
+rewrite (DRestrict (Dom (Base SplitR x)) (Base SplitR y)) = Just $ intersection y x
+-- t16
+rewrite (DRestrict (Dom (RRestrict (Base MapR delegs) (SetSingleton hk))) (Base SplitR stake)) =
+  Just $
+    intersectSplitMap (\_k _u v2 -> v2 == hk) stake delegs
+-- t17
+rewrite (DRestrict (Dom (RRestrict (Base MapR delegs) (Base _ rngf))) (Base SplitR stake)) =
+  Just $
+    intersectSplitMap (\_k _u v2 -> haskey v2 rngf) stake delegs
+-- t18
+rewrite (DRestrict set (Base SplitR ys)) = Just $ restrictKeysSet ys set2
+  where
+    -- Pay the cost of materializing set to use O(n* log n) restictKeys
+    Sett set2 = materialize SetR (lifo (compute set))
+-- t19
+rewrite (DExclude (SetSingleton n) (Base SplitR m)) = Just $ withoutKeysSet m (Set.singleton n)
+-- t20
+rewrite (DExclude (Dom (Singleton n _v)) (Base SplitR m)) = Just $ withoutKeysSet m (Set.singleton n)
+-- t21
+rewrite (DExclude (Rng (Singleton _n v)) (Base SplitR m)) = Just $ withoutKeysSet m (Set.singleton v)
+-- t22
+rewrite (DExclude (Base SetR (Sett x1)) (Base SplitR x2)) = Just $ withoutKeysSet x2 x1
+-- t23
+rewrite (DExclude (Dom (Base MapR x1)) (Base SplitR x2)) = Just $ withoutKeysMap x2 x1
+-- t24
+rewrite (DExclude (Dom (Base SplitR x1)) (Base SplitR x2)) = Just $ withoutKeysSplit x2 x1
+-- t25
+rewrite (RExclude (Base SplitR xs) (SetSingleton u)) = Just $ filterWithKey (\_k v -> not (v == u)) xs
+-- t26
+rewrite (RExclude (Base SplitR xs) (Base SetR (Sett set))) = Just $ filterWithKey (\_k v -> not (Set.member v set)) xs
+-- t27
+rewrite (RRestrict (Base SplitR xs) (SetSingleton k)) = Just $ filterWithKey (\_ x -> x == k) xs
+-- t28
+rewrite (RRestrict (Base SplitR xs) (Base SetR (Sett s))) = Just $ filterWithKey (\_ x -> Set.member x s) xs
+-- Additional rewrites to be added on a demand basis.
+rewrite _ = Nothing
 
 -- ===========================================================
 -- Some times we need to write our own version of functions
@@ -476,6 +594,7 @@ fromList ListR combine xs = fromPairs combine xs
 fromList SetR combine xs = foldr (addp combine) (Sett (Set.empty)) xs
 fromList BiMapR combine xs = biMapFromList combine xs
 fromList SingleR combine xs = foldr (addp combine) Fail xs
+fromList SplitR combine xs = foldr (addp combine) Split.empty xs
 
 -- =========================================================================================
 -- Now we make an iterator that collects triples, on the intersection


### PR DESCRIPTION
Introduces the SplitMap. Added basic operations for SplitMap that
every Map should supply (insert, delete, union, intersection etc).
Added Basic and Iter instances for Control.SetAlgebra.