### PR TITLE
Move ApplyTx benchmarks to using a fixed seed.

### DIFF
--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -20,7 +20,6 @@ import Bench.Cardano.Ledger.ApplyTx.Gen (generateForEra)
 import Cardano.Binary
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import Cardano.Ledger.Alonzo.Rules.Ledger ()
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era, ValidateScript)
@@ -125,7 +124,7 @@ benchApplyTx p = env genRes go
     go ~ApplyTxRes {atrGlobals, atrMempoolEnv, atrState, atrTx} =
       bench (show $ typeRep p) $
         whnf
-          ( either (error . show) id
+          ( either (error . show) (\(x, y) -> x `seq` y `seq` (x, y))
               . applyTxsTransition @era @(Either _)
                 atrGlobals
                 atrMempoolEnv

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Generates fixed transaction/state pairs for benchmarking.
+module Bench.Cardano.Ledger.ApplyTx.Gen (generateForEra) where
+
+import Cardano.Ledger.Core (EraRule)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto)
+import Cardano.Ledger.Shelley.API (Globals, ShelleyBasedEra)
+import Cardano.Ledger.Shelley.LedgerState (DPState, UTxOState)
+import Control.State.Transition (State)
+import Control.State.Transition.Trace
+import Control.State.Transition.Trace.Generator.QuickCheck
+import Data.Default.Class (Default)
+import Data.Proxy
+import Test.Cardano.Ledger.AllegraEraGen ()
+import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
+import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen)
+import Test.Cardano.Ledger.Shelley.Generator.Presets
+import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
+import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger (mkGenesisLedgerState)
+import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
+import Test.QuickCheck.Gen (unGen)
+import Test.QuickCheck.Random (mkQCGen)
+
+-- | Generate a ledger state and transaction in a given era, given a seed.
+generateForEra ::
+  forall era.
+  ( EraGen era,
+    HasTrace (EraRule "LEDGER" era) (GenEnv era),
+    Default (State (EraRule "PPUP" era)),
+    BaseEnv (EraRule "LEDGER" era) ~ Globals,
+    ShelleyBasedEra era
+  ) =>
+  Proxy era ->
+  Int ->
+  ((UTxOState era, DPState (Crypto era)), Core.Tx era)
+generateForEra eraProxy seed =
+  let ge = genEnv eraProxy
+      qcSeed = mkQCGen seed
+      tr =
+        unGen
+          ( traceFromInitState
+              @(EraRule "LEDGER" era)
+              testGlobals
+              20
+              ge
+              (Just $ mkGenesisLedgerState ge)
+          )
+          qcSeed
+          30
+      sst = last $ sourceSignalTargets tr
+   in (source sst, signal sst)

--- a/libs/cardano-ledger-test/bench/resources/DESCRIPTION.md
+++ b/libs/cardano-ledger-test/bench/resources/DESCRIPTION.md
@@ -40,3 +40,37 @@ let sst = last $ sourceSignalTargets tr
 BS.writeFile "/tmp/0_ledgerstate.cbor" $ serialize' (source sst)
 BS.writeFile "/tmp/0_tx.cbor" $ serialize' (signal sst)
 ```
+```
+:set -XTypeApplications
+
+import Data.Proxy
+
+import Cardano.Binary
+import Control.State.Transition.Trace
+import Control.State.Transition.Trace.Generator.QuickCheck
+import qualified Data.ByteString as BS
+import Cardano.Ledger.Shelley.Rules.Ledger
+import Cardano.Ledger.Shelley
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes
+
+import Test.Cardano.Ledger.Shelley.Utils
+import Test.Cardano.Ledger.Shelley.Generator.Presets
+import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger ()
+import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
+import Cardano.Ledger.Shelley.PParams (PParams'(..))
+import Test.QuickCheck (generate)
+
+import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger
+
+import Cardano.Ledger.Allegra
+import Test.Cardano.Ledger.AllegraEraGen ()
+
+
+let ge = genEnv (Proxy @(AllegraEra C_Crypto))
+initLs <- generate $ mkGenesisLedgerState @([LedgerPredicateFailure (AllegraEra C_Crypto)]) ge undefined
+tr <- generate $ traceFromInitState @(LEDGER (AllegraEra C_Crypto)) testGlobals 20 ge (Just $ \_ -> pure initLs)
+
+let sst = last $ sourceSignalTargets tr
+BS.writeFile "/tmp/0_ledgerstate.cbor" $ serialize' (source sst)
+BS.writeFile "/tmp/0_tx.cbor" $ serialize' (signal sst)
+```

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -91,7 +91,7 @@ test-suite cardano-ledger-test
     cardano-ledger-test,
     cardano-ledger-shelley-test,
     tasty,
-   
+
 
 
 benchmark bench
@@ -103,6 +103,7 @@ benchmark bench
   main-is:          Main.hs
   other-modules:
     Bench.Cardano.Ledger.ApplyTx
+    Bench.Cardano.Ledger.ApplyTx.Gen
     Bench.Cardano.Ledger.EpochBoundary
     Bench.Cardano.Ledger.Serialisation.Generators
   build-depends:
@@ -110,6 +111,7 @@ benchmark bench
     cardano-binary,
     cardano-crypto-class,
     cardano-ledger-alonzo,
+    cardano-ledger-alonzo-test,
     cardano-ledger-core,
     cardano-ledger-shelley-ma-test,
     cardano-ledger-shelley-ma,
@@ -121,6 +123,7 @@ benchmark bench
     cardano-ledger-shelley,
     cardano-ledger-shelley-test,
     small-steps,
+    small-steps-test
   ghc-options:
       -threaded
       -rtsopts


### PR DESCRIPTION
This should prevent problems where serialisation changes result in
broken benchmarks. Additionally, we now test Allegra and Mary era
transactions.

Unfortunately this means a discontinuity with existing benchmark runs,
but should prevent future discontinuities.