### PR TITLE
Benchmark custom maps

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -80,3 +80,9 @@ cradle:
 
     - path: "libs/compact-map"
       component: "lib:compact-map"
+
+    - path: "libs/compact-map"
+      component: "compact-map:test:tests"
+
+    - path: "libs/compact-map"
+      component: "compact-map:bench:bench"

--- a/libs/compact-map/bench/Bench.hs
+++ b/libs/compact-map/bench/Bench.hs
@@ -4,16 +4,16 @@ module Main where
 
 import Control.Monad
 import Criterion.Main
---import Data.Compact.HashMap as HMap
 import Data.Compact.KeyMap as KeyMap
 import Data.Compact.VMap as VMap
+import Data.Foldable as F
 import Data.Map.Strict as Map
 import System.Random.Stateful as Random
 
 main :: IO ()
 main = do
-  let !(std1, std2) = Random.split $ mkStdGen 2021
-      n = 10000
+  let (std1, std2) = Random.split $ mkStdGen 2021
+      n = 200000
       randList :: StdGen -> [(Key, Int)]
       randList gen = runStateGen_ gen (uniformListM n)
       prefixList :: StdGen -> [(Key, Int)]
@@ -38,7 +38,31 @@ main = do
           fromListBench "sequential" (sequentialList std1)
         ],
       bgroup
-        "union (same)"
+        "toList"
+        [ toListBench "uniform" (randList std1),
+          toListBench "prefixed" (prefixList std1),
+          toListBench "sequential" (sequentialList std1)
+        ],
+      bgroup
+        "toMapThroughList"
+        [ toMapThroughListBench "uniform" (randList std1),
+          toMapThroughListBench "prefixed" (prefixList std1),
+          toMapThroughListBench "sequential" (sequentialList std1)
+        ],
+      bgroup
+        "fromMap"
+        [ fromMapBench "uniform" (randList std1),
+          fromMapBench "prefixed" (prefixList std1),
+          fromMapBench "sequential" (sequentialList std1)
+        ],
+      bgroup
+        "foldlWithKey"
+        [ foldlWithKeyBench "uniform" (randList std1),
+          foldlWithKeyBench "prefixed" (prefixList std1),
+          foldlWithKeyBench "sequential" (sequentialList std1)
+        ],
+      bgroup
+        "union (with itself)"
         [ unionBench "uniform" (randList std1) (randList std1),
           unionBench "prefixed" (prefixList std1) (prefixList std1),
           unionBench "sequential" (sequentialList std1) (sequentialList std1)
@@ -50,7 +74,7 @@ main = do
           unionBench "sequential" (sequentialList std1) (sequentialList std2)
         ],
       bgroup
-        "intersection (same)"
+        "intersection (with itself)"
         [ intersectionBench "uniform" (randList std1) (randList std1),
           intersectionBench "prefixed" (prefixList std1) (prefixList std1),
           intersectionBench "sequential" (sequentialList std1) (sequentialList std1)
@@ -60,6 +84,68 @@ main = do
         [ intersectionBench "uniform" (randList std1) (randList std2),
           intersectionBench "prefixed" (prefixList std1) (prefixList std2),
           intersectionBench "sequential" (sequentialList std1) (sequentialList std2)
+        ],
+      env (pure $ randList std1) $ \xs ->
+        bgroup
+          "insert vs union"
+          [ bench "fromList" $ nf KeyMap.fromList xs,
+            bench "insert" $ nf (F.foldl' (\acc (k, v) -> KeyMap.insert k v acc) KeyMap.empty) xs,
+            bench "unionWith" $
+              nf (F.foldl' (\acc (k, v) -> KeyMap.union (KeyMap.singleton k v) acc) KeyMap.empty) xs
+          ]
+    ]
+
+fromMapBench :: String -> [(Key, Int)] -> Benchmark
+fromMapBench name xs =
+  env (pure $ Map.fromList xs) $ \xsMap ->
+    bgroup
+      name
+      [ bgroup
+          "fromMap"
+          [ bench "KeyMap" $ nf (KeyMap.fromList . Map.toList) xsMap,
+            bench "VMap" $ nf (VMap.fromMap :: Map Key Int -> VMap VB VP Key Int) xsMap
+          ]
+      ]
+
+toMapThroughListBench :: String -> [(Key, Int)] -> Benchmark
+toMapThroughListBench name xs =
+  bgroup
+    name
+    [ bgroup
+        "toMap"
+        [ env (pure (Map.fromList xs)) $
+            bench "Map" . nf (Map.fromDistinctAscList . Map.toList),
+          env (pure (KeyMap.fromList xs)) $
+            bench "KeyMap" . nf (Map.fromDistinctAscList . KeyMap.toList),
+          env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
+            bench "VMap" . nf VMap.toMap
+        ]
+    ]
+
+toListBench :: String -> [(Key, Int)] -> Benchmark
+toListBench name xs =
+  bgroup
+    name
+    [ bgroup
+        "toList"
+        [ env (pure (Map.fromList xs)) $ bench "Map" . nf Map.toList,
+          env (pure (KeyMap.fromList xs)) $ bench "KeyMap" . nf KeyMap.toList,
+          env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
+            bench "VMap" . nf VMap.toList
+        ],
+      bgroup
+        "keys"
+        [ env (pure (Map.fromList xs)) $ bench "Map" . nf Map.keys,
+          env (pure (KeyMap.fromList xs)) $ bench "KeyMap" . nf (fmap fst . KeyMap.toList),
+          env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
+            bench "VMap" . nf VMap.keys
+        ],
+      bgroup
+        "elems"
+        [ env (pure (Map.fromList xs)) $ bench "Map" . nf Map.elems,
+          env (pure (KeyMap.fromList xs)) $ bench "KeyMap" . nf (fmap snd . KeyMap.toList),
+          env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
+            bench "VMap" . nf VMap.elems
         ]
     ]
 
@@ -74,6 +160,18 @@ fromListBench name xs =
           nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) xsnf
       ]
 
+foldlWithKeyBench :: String -> [(Key, Int)] -> Benchmark
+foldlWithKeyBench name xs =
+  bgroup
+    name
+    [ env (pure (Map.fromList xs)) $
+        bench "Map" . nf (Map.foldlWithKey (\a !_ -> (a +)) 0),
+      env (pure (KeyMap.fromList xs)) $
+        bench "KeyMap" . nf (KeyMap.foldWithAscKey (\a !_ -> (a +)) 0),
+      env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
+        bench "VMap" . nf (VMap.foldlWithKey (\a !_ -> (a +)) 0)
+    ]
+
 unionBench :: String -> [(Key, Int)] -> [(Key, Int)] -> Benchmark
 unionBench name xs1 xs2 =
   bgroup
@@ -82,10 +180,10 @@ unionBench name xs1 xs2 =
         bench "Map" . nf (uncurry Map.union),
       env (pure (KeyMap.fromList xs1, KeyMap.fromList xs2)) $
         bench "KeyMap" . nf (uncurry KeyMap.union)
-      -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
-      --   bench "VMap" . nf (uncurry VMap.union)
+        -- uncomment when implemented:
+        -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
+        --   bench "VMap" . nf (uncurry VMap.union)
     ]
-
 
 intersectionBench :: String -> [(Key, Int)] -> [(Key, Int)] -> Benchmark
 intersectionBench name xs1 xs2 =
@@ -95,6 +193,7 @@ intersectionBench name xs1 xs2 =
         bench "Map" . nf (uncurry Map.intersection),
       env (pure (KeyMap.fromList xs1, KeyMap.fromList xs2)) $
         bench "KeyMap" . nf (uncurry KeyMap.intersection)
-      -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
-      --   bench "VMap" . nf (uncurry VMap.intersection)
+        -- uncomment when implemented:
+        -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
+        --   bench "VMap" . nf (uncurry VMap.intersection)
     ]

--- a/libs/compact-map/bench/Bench.hs
+++ b/libs/compact-map/bench/Bench.hs
@@ -43,7 +43,7 @@ main = do
               , bench "KeyMap" $ nf KeyMap.fromList rxsnf
               , bench "HashMap" $ nf HMap.fromList rxsnf
               , bench "VMap" $
-                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) rxsnf
+                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VB Key Int) rxsnf
               ]
           ]
     ]

--- a/libs/compact-map/bench/Bench.hs
+++ b/libs/compact-map/bench/Bench.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE BangPatterns #-}
+module Main where
+
+import Criterion.Main
+import Control.Monad
+import Data.Compact.KeyMap as KeyMap
+import Data.Compact.HashMap as HMap
+import Data.Compact.VMap as VMap
+import Data.Map.Strict as Map
+import System.Random.Stateful
+
+main :: IO ()
+main = do
+  let !stdGen = mkStdGen 2021
+      n = 10000
+      randList :: [(Key, Int)]
+      randList = runStateGen_ stdGen (uniformListM n)
+      zeroPrefixList :: [(Key, Int)]
+      zeroPrefixList = runStateGen_ stdGen $ \g ->
+        replicateM n $ do
+          key <- Key 0 0 0 <$> uniformM g
+          val <- uniformM g
+          pure (key, val)
+  defaultMain
+    [ env (pure randList) $ \rxsnf ->
+        bgroup
+          "uniform"
+          [ bgroup
+              "fromList"
+              [ bench "Map" $ nf Map.fromList rxsnf
+              , bench "KeyMap" $ nf KeyMap.fromList rxsnf
+              , bench "HashMap" $ nf HMap.fromList rxsnf
+              , bench "VMap" $
+                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) rxsnf
+              ]
+          ]
+    , env (pure zeroPrefixList) $ \rxsnf ->
+        bgroup
+          "uniform"
+          [ bgroup
+              "fromList"
+              [ bench "Map" $ nf Map.fromList rxsnf
+              , bench "KeyMap" $ nf KeyMap.fromList rxsnf
+              , bench "HashMap" $ nf HMap.fromList rxsnf
+              , bench "VMap" $
+                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) rxsnf
+              ]
+          ]
+    ]

--- a/libs/compact-map/bench/Bench.hs
+++ b/libs/compact-map/bench/Bench.hs
@@ -1,49 +1,100 @@
 {-# LANGUAGE BangPatterns #-}
+
 module Main where
 
-import Criterion.Main
 import Control.Monad
+import Criterion.Main
+--import Data.Compact.HashMap as HMap
 import Data.Compact.KeyMap as KeyMap
-import Data.Compact.HashMap as HMap
 import Data.Compact.VMap as VMap
 import Data.Map.Strict as Map
-import System.Random.Stateful
+import System.Random.Stateful as Random
 
 main :: IO ()
 main = do
-  let !stdGen = mkStdGen 2021
+  let !(std1, std2) = Random.split $ mkStdGen 2021
       n = 10000
-      randList :: [(Key, Int)]
-      randList = runStateGen_ stdGen (uniformListM n)
-      zeroPrefixList :: [(Key, Int)]
-      zeroPrefixList = runStateGen_ stdGen $ \g ->
-        replicateM n $ do
-          key <- Key 0 0 0 <$> uniformM g
-          val <- uniformM g
-          pure (key, val)
+      randList :: StdGen -> [(Key, Int)]
+      randList gen = runStateGen_ gen (uniformListM n)
+      prefixList :: StdGen -> [(Key, Int)]
+      prefixList gen =
+        runStateGen_ gen $ \g ->
+          replicateM n $ do
+            key <- Key 0 0 0 <$> uniformM g
+            val <- uniformM g
+            pure (key, val)
+      sequentialList :: StdGen -> [(Key, Int)]
+      sequentialList gen =
+        runStateGen_ gen $ \g -> do
+          (p1, p2, p3) <- uniformM g
+          forM [1 .. fromIntegral n] $ \k -> do
+            val <- uniformM g
+            pure (Key p1 p2 p3 k, val)
   defaultMain
-    [ env (pure randList) $ \rxsnf ->
-        bgroup
-          "uniform"
-          [ bgroup
-              "fromList"
-              [ bench "Map" $ nf Map.fromList rxsnf
-              , bench "KeyMap" $ nf KeyMap.fromList rxsnf
-              , bench "HashMap" $ nf HMap.fromList rxsnf
-              , bench "VMap" $
-                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) rxsnf
-              ]
-          ]
-    , env (pure zeroPrefixList) $ \rxsnf ->
-        bgroup
-          "uniform"
-          [ bgroup
-              "fromList"
-              [ bench "Map" $ nf Map.fromList rxsnf
-              , bench "KeyMap" $ nf KeyMap.fromList rxsnf
-              , bench "HashMap" $ nf HMap.fromList rxsnf
-              , bench "VMap" $
-                nf (VMap.fromList :: [(Key, Int)] -> VMap VB VB Key Int) rxsnf
-              ]
-          ]
+    [ bgroup
+        "fromList"
+        [ fromListBench "uniform" (randList std1),
+          fromListBench "prefixed" (prefixList std1),
+          fromListBench "sequential" (sequentialList std1)
+        ],
+      bgroup
+        "union (same)"
+        [ unionBench "uniform" (randList std1) (randList std1),
+          unionBench "prefixed" (prefixList std1) (prefixList std1),
+          unionBench "sequential" (sequentialList std1) (sequentialList std1)
+        ],
+      bgroup
+        "union (distinct)"
+        [ unionBench "uniform" (randList std1) (randList std2),
+          unionBench "prefixed" (prefixList std1) (prefixList std2),
+          unionBench "sequential" (sequentialList std1) (sequentialList std2)
+        ],
+      bgroup
+        "intersection (same)"
+        [ intersectionBench "uniform" (randList std1) (randList std1),
+          intersectionBench "prefixed" (prefixList std1) (prefixList std1),
+          intersectionBench "sequential" (sequentialList std1) (sequentialList std1)
+        ],
+      bgroup
+        "intersection (distinct)"
+        [ intersectionBench "uniform" (randList std1) (randList std2),
+          intersectionBench "prefixed" (prefixList std1) (prefixList std2),
+          intersectionBench "sequential" (sequentialList std1) (sequentialList std2)
+        ]
+    ]
+
+fromListBench :: String -> [(Key, Int)] -> Benchmark
+fromListBench name xs =
+  env (pure xs) $ \xsnf ->
+    bgroup
+      name
+      [ bench "Map" $ nf Map.fromList xsnf,
+        bench "KeyMap" $ nf KeyMap.fromList xsnf,
+        bench "VMap" $
+          nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) xsnf
+      ]
+
+unionBench :: String -> [(Key, Int)] -> [(Key, Int)] -> Benchmark
+unionBench name xs1 xs2 =
+  bgroup
+    name
+    [ env (pure (Map.fromList xs1, Map.fromList xs2)) $
+        bench "Map" . nf (uncurry Map.union),
+      env (pure (KeyMap.fromList xs1, KeyMap.fromList xs2)) $
+        bench "KeyMap" . nf (uncurry KeyMap.union)
+      -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
+      --   bench "VMap" . nf (uncurry VMap.union)
+    ]
+
+
+intersectionBench :: String -> [(Key, Int)] -> [(Key, Int)] -> Benchmark
+intersectionBench name xs1 xs2 =
+  bgroup
+    name
+    [ env (pure (Map.fromList xs1, Map.fromList xs2)) $
+        bench "Map" . nf (uncurry Map.intersection),
+      env (pure (KeyMap.fromList xs1, KeyMap.fromList xs2)) $
+        bench "KeyMap" . nf (uncurry KeyMap.intersection)
+      -- env (pure (VMap.fromList xs1 :: VMap VB VP Key Int, VMap.fromList xs2)) $
+      --   bench "VMap" . nf (uncurry VMap.intersection)
     ]

--- a/libs/compact-map/compact-map.cabal
+++ b/libs/compact-map/compact-map.cabal
@@ -43,6 +43,7 @@ library
                      , deepseq
                      , prettyprinter
                      , primitive
+                     , random
                      , text
                      , nothunks
                      , vector
@@ -71,3 +72,16 @@ test-suite tests
                      , quickcheck-classes-base
                      , random
   ghc-options:        -threaded -O
+
+benchmark bench
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             Bench.hs
+  ghc-options:         -Wall -threaded -O2 -rtsopts
+  build-depends:       base
+                     , criterion
+                     , compact-map
+                     , containers
+                     , random
+  default-language:    Haskell2010
+

--- a/libs/compact-map/compact-map.cabal
+++ b/libs/compact-map/compact-map.cabal
@@ -71,7 +71,7 @@ test-suite tests
                      , QuickCheck
                      , quickcheck-classes-base
                      , random
-  ghc-options:        -threaded -O
+  ghc-options:        -threaded
 
 benchmark bench
   type:                exitcode-stdio-1.0

--- a/libs/compact-map/src/Data/Compact/HashMap.hs
+++ b/libs/compact-map/src/Data/Compact/HashMap.hs
@@ -53,7 +53,7 @@ instance NFData v => NFData (HashMap k v) where
   rnf (HashMap km) = rnf km
 
 lookup :: k -> HashMap k v -> Maybe v
-lookup k (HashMap m) = KM.lookupHM (toKey k) m
+lookup k (HashMap m) = KM.lookup (toKey k) m
 
 insert :: k -> v -> HashMap k v -> HashMap k v
 insert k v (HashMap m) = HashMap (KM.insert (toKey k) v m)
@@ -79,11 +79,11 @@ splitLookup k (HashMap m) = (HashMap a, b, HashMap c)
     key = toKey k
 
 intersection :: HashMap k v -> HashMap k v -> HashMap k v
-intersection (HashMap m1) (HashMap m2) = HashMap (KM.intersect3 0 (\_k x _y -> x) m1 m2)
+intersection (HashMap m1) (HashMap m2) = HashMap (KM.intersection m1 m2)
 
 intersectionWith :: (v -> v -> v) -> HashMap k v -> HashMap k v -> HashMap k v
 intersectionWith combine (HashMap m1) (HashMap m2) =
-  HashMap (KM.intersect3 0 (\_k x y -> combine x y) m1 m2)
+  HashMap (KM.intersectionWith combine m1 m2)
 
 unionWithKey :: (Keyed k) => (k -> v -> v -> v) -> HashMap k v -> HashMap k v -> HashMap k v
 unionWithKey combine (HashMap m1) (HashMap m2) = HashMap (KM.unionWithKey combine2 m1 m2)
@@ -106,10 +106,11 @@ foldlWithKey' accum a (HashMap m) = KM.foldWithAscKey accum2 a m
     accum2 ans k v = accum ans (fromKey k) v
 
 size :: HashMap k v -> Int
-size (HashMap m) = KM.sizeKeyMap m
+size (HashMap m) = KM.size m
 
 fromList :: Keyed k => [(k, v)] -> HashMap k v
 fromList xs = HashMap (KM.fromList (map (first toKey) xs))
+{-# INLINE fromList #-}
 
 toList :: HashMap k v -> [(k, v)]
 toList (HashMap m) = KM.foldWithDescKey (\k v ans -> (fromKey k, v) : ans) [] m

--- a/libs/compact-map/src/Data/Compact/HashMap.hs
+++ b/libs/compact-map/src/Data/Compact/HashMap.hs
@@ -7,6 +7,7 @@
 module Data.Compact.HashMap where
 
 import Cardano.Crypto.Hash.Class
+import Control.DeepSeq
 import Data.Compact.KeyMap (Key, KeyMap)
 import qualified Data.Compact.KeyMap as KM
 import Data.Proxy
@@ -21,6 +22,10 @@ import Prettyprinter (viaShow)
 class Keyed t where
   toKey :: t -> Key
   fromKey :: Key -> t
+
+instance Keyed Key where
+  toKey = id
+  fromKey = id
 
 instance HashAlgorithm h => Keyed (Hash h a) where
   toKey h =
@@ -43,6 +48,9 @@ instance HashAlgorithm h => Keyed (Hash h a) where
 
 data HashMap k v where
   HashMap :: Keyed k => KeyMap v -> HashMap k v
+
+instance NFData v => NFData (HashMap k v) where
+  rnf (HashMap km) = rnf km
 
 lookup :: k -> HashMap k v -> Maybe v
 lookup k (HashMap m) = KM.lookupHM (toKey k) m

--- a/libs/compact-map/src/Data/Compact/HashMap.hs
+++ b/libs/compact-map/src/Data/Compact/HashMap.hs
@@ -7,6 +7,7 @@ module Data.Compact.HashMap where
 
 import Cardano.Crypto.Hash.Class
 import Control.DeepSeq
+import Data.Bifunctor (first)
 import Data.Compact.KeyMap (Key, KeyMap)
 import qualified Data.Compact.KeyMap as KM
 import Data.Proxy
@@ -15,7 +16,6 @@ import qualified Data.Set as Set
 import Data.Typeable
 import GHC.TypeLits
 import Prettyprinter (viaShow)
-import Data.Bifunctor (first)
 
 -- ==========================================================================
 

--- a/libs/compact-map/src/Data/Compact/KVVector.hs
+++ b/libs/compact-map/src/Data/Compact/KVVector.hs
@@ -62,11 +62,13 @@ toMap ::
   KVVector kv vv (k, v) ->
   Map.Map k v
 toMap = Map.fromDistinctAscList . VG.toList
+{-# INLINE toMap #-}
 
 -- | Convert a `Map.Map` into a sorted key/value vector.
 fromMap ::
   (VG.Vector kv k, VG.Vector vv v) => Map.Map k v -> KVVector kv vv (k, v)
 fromMap m = fromDistinctAscListN (Map.size m) $ Map.toAscList m
+{-# INLINE fromMap #-}
 
 -- | Convert a possibly unsorted assoc list into a KVVector.
 fromList ::

--- a/libs/compact-map/src/Data/Compact/KeyMap.hs
+++ b/libs/compact-map/src/Data/Compact/KeyMap.hs
@@ -46,6 +46,7 @@ import Data.Word (Word64)
 import GHC.Exts (isTrue#, reallyUnsafePtrEquality#, (==#))
 import Prettyprinter
 import qualified Prettyprinter.Internal as Pretty
+import System.Random.Stateful (Uniform (..))
 
 -- =============================
 
@@ -105,6 +106,15 @@ data Key
       {-# UNPACK #-} !Word64
       {-# UNPACK #-} !Word64
   deriving (Eq, Ord, Show, NFData, Generic)
+
+
+instance Uniform Key where
+  uniformM g = do
+    w0 <- uniformM g
+    w1 <- uniformM g
+    w2 <- uniformM g
+    w3 <- uniformM g
+    pure (Key w0 w1 w2 w3)
 
 -- | The number of Word64 per key
 wordsPerKey :: Int

--- a/libs/compact-map/src/Data/Compact/KeyMap.hs
+++ b/libs/compact-map/src/Data/Compact/KeyMap.hs
@@ -418,10 +418,10 @@ filterArrayWithBitmap p bm0 arr =
     -- i ranges over all possible elements of a Bitmap [0..63], only some are found in 'bm'
     -- j ranges over the slots in the new array [0..n-1]
     loop i j bm marr
-      | i < 63 && not (testBit bm0 i) =
+      | i <= 63 && not (testBit bm0 i) =
         loop (i + 1) j bm marr -- Skip over those not in 'bm'
     loop i j bm marr
-      | i < 63 =
+      | i <= 63 =
         let slot = indexFromSegment bm0 i -- what is the index in 'arr' for this Bitmap element?
             item = index arr slot -- Get the array item
          in if not (p item) -- if it does not meet the 'p' then move it to the answer.
@@ -429,7 +429,7 @@ filterArrayWithBitmap p bm0 arr =
               else -- if it meets 'p' then don't copy, and clear it from 'bm'
                 loop (i + 1) j (clearBit bm i) marr
     loop _i j _bm _marr
-      | j /= n = error $ "Left over plank space at. j= " ++ show j ++ ", n= " ++ show n
+      | j /= n = error $ "Left over blank space at. j= " ++ show j ++ ", n= " ++ show n
     loop _i _j bm _marr = pure bm
 
 -- ================================================================

--- a/libs/compact-map/src/Data/Compact/KeyMap.hs
+++ b/libs/compact-map/src/Data/Compact/KeyMap.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Data.Compact.KeyMap
-  ( KeyMap(..),
+  ( KeyMap (..),
     Key (..),
     empty,
     size,
@@ -39,7 +39,7 @@ module Data.Compact.KeyMap
     minViewWithKey,
     foldOverIntersection,
     -- Pretty printing helpers
-    PrettyA(..),
+    PrettyA (..),
     ppKeyMap,
     equate,
     ppArray,
@@ -79,7 +79,6 @@ import Data.Compact.SmallArray
     withMutArray_,
   )
 import Data.Foldable (foldl')
-import Data.Primitive.SmallArray ()
 import qualified Data.Primitive.SmallArray as Small
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -409,18 +408,13 @@ filterArrayWithBitmap _p bm arr
   | popCount bm /= isize arr =
     error $
       concat
-        [ "array size ",
-          show (isize arr),
-          " and bitmap ",
-          show (bitmapToList bm),
-          " don't agree."
-        ]
+        ["array size ", show (isize arr), " and bitmap ", show (bitmapToList bm), " don't agree."]
 filterArrayWithBitmap p bm0 arr =
   if n == isize arr
     then (arr, bm0)
     else withMutArray n (loop 0 0 bm0)
   where
-    n = foldl' (\ans x -> if not (p x) then ans + 1 else ans) 0 arr
+    n = foldl' (\ans x -> if p x then ans else ans + 1) 0 arr
     -- i ranges over all possible elements of a Bitmap [0..63], only some are found in 'bm'
     -- j ranges over the slots in the new array [0..n-1]
     loop i j bm marr
@@ -434,6 +428,8 @@ filterArrayWithBitmap p bm0 arr =
               then mwrite marr j item >> loop (i + 1) (j + 1) bm marr
               else -- if it meets 'p' then don't copy, and clear it from 'bm'
                 loop (i + 1) j (clearBit bm i) marr
+    loop _i j _bm _marr
+      | j /= n = error $ "Left over plank space at. j= " ++ show j ++ ", n= " ++ show n
     loop _i _j bm _marr = pure bm
 
 -- ================================================================

--- a/libs/compact-map/src/Data/Compact/SmallArray.hs
+++ b/libs/compact-map/src/Data/Compact/SmallArray.hs
@@ -52,11 +52,11 @@ mcopy = Small.copySmallArray
 
 mboundsCheck :: (MArray s a -> Int -> p) -> MArray s a -> Int -> p
 mboundsCheck indexf arr i | i >= 0 && i < msize arr = indexf arr i
-mboundsCheck _ arr i = error ("mboundscheck error, " ++ show i ++ ", not in bounds (0.." ++ show (msize arr - 1) ++ ").")
+mboundsCheck _ arr i = error $ boundsMessage "mboundscheck" i (msize arr - 1)
 
 boundsCheck :: (PArray a -> Int -> p) -> PArray a -> Int -> p
 boundsCheck indexf arr i | i >= 0 && i < isize arr = indexf arr i
-boundsCheck _ arr i = error ("boundscheck error, " ++ show i ++ ", not in bounds (0.." ++ show (isize arr - 1) ++ ").")
+boundsCheck _ arr i = error $ boundsMessage "boundscheck" i (isize arr - 1)
 
 withMutArray :: Int -> (forall s. MArray s a -> ST s x) -> (PArray a, x)
 withMutArray n process = runST $ do
@@ -64,3 +64,17 @@ withMutArray n process = runST $ do
   x <- process marr
   arr <- mfreeze marr
   pure (arr, x)
+
+
+boundsMessage :: String -> Int -> Int -> String
+boundsMessage funcName i n =
+  concat
+    [ "Index out of bounds in '",
+      funcName,
+      "' ",
+      show i,
+      " not in range (0,",
+      show n,
+      ")"
+    ]
+{-# NOINLINE boundsMessage #-}

--- a/libs/compact-map/src/Data/Compact/SmallArray.hs
+++ b/libs/compact-map/src/Data/Compact/SmallArray.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Data.Compact.SmallArray where
@@ -5,6 +6,7 @@ module Data.Compact.SmallArray where
 import Control.Monad.ST (ST, runST)
 import qualified Data.Foldable as Fold (toList)
 import qualified Data.Primitive.SmallArray as Small
+import GHC.Stack
 
 -- import Debug.Trace
 
@@ -14,52 +16,58 @@ type PArray = Small.SmallArray
 
 type MArray = Small.SmallMutableArray
 
-index :: PArray a -> Int -> a
+index :: HasCallStack => PArray a -> Int -> a
 isize :: PArray a -> Int
 fromlist :: [a] -> PArray a
 tolist :: PArray a -> [a]
 index = boundsCheck Small.indexSmallArray
+{-# INLINE index #-}
 
 isize = Small.sizeofSmallArray
+{-# INLINE isize #-}
 
 fromlist = Small.smallArrayFromList
+{-# INLINE fromlist #-}
 
 tolist = Fold.toList
+{-# INLINE tolist #-}
 
--- catenate = catArray
--- merge = mergeArray
-
-mindex :: MArray s a -> Int -> ST s a
+mindex :: HasCallStack => MArray s a -> Int -> ST s a
 msize :: MArray s a -> Int
-mnew :: Int -> ST s (MArray s a)
-mnewInit :: Int -> a -> ST s (MArray s a)
+mnew :: HasCallStack => Int -> ST s (MArray s a)
 mfreeze :: MArray s a -> ST s (PArray a) -- This should be the unsafe version that does not copy
-mwrite :: MArray s a -> Int -> a -> ST s ()
+mwrite :: HasCallStack => MArray s a -> Int -> a -> ST s ()
 mcopy :: forall s. (forall a. MArray s a -> Int -> PArray a -> Int -> Int -> ST s ())
 mindex = mboundsCheck Small.readSmallArray
+{-# INLINE mindex #-}
 
 msize = Small.sizeofSmallMutableArray
+{-# INLINE msize #-}
 
 mnew size = Small.newSmallArray size (error "uninitialized index, allocated by 'mnew', is referenced")
-
-mnewInit size = Small.newSmallArray size
+{-# INLINE mnew #-}
 
 mfreeze = Small.unsafeFreezeSmallArray
+{-# INLINE mfreeze #-}
 
-mwrite arr i a =
+mwrite arr i !a =
   if i >= 0 && i < msize arr
     then Small.writeSmallArray arr i a
     else error $ boundsMessage "mwrite" i (msize arr - 1)
+{-# INLINE mwrite #-}
 
 mcopy = Small.copySmallArray
+{-# INLINE mcopy #-}
 
-mboundsCheck :: (MArray s a -> Int -> p) -> MArray s a -> Int -> p
+mboundsCheck :: HasCallStack => (MArray s a -> Int -> p) -> MArray s a -> Int -> p
 mboundsCheck indexf arr i | i >= 0 && i < msize arr = indexf arr i
 mboundsCheck _ arr i = error $ boundsMessage "mboundscheck" i (msize arr - 1)
+{-# INLINE mboundsCheck #-}
 
-boundsCheck :: (PArray a -> Int -> p) -> PArray a -> Int -> p
+boundsCheck :: HasCallStack => (PArray a -> Int -> p) -> PArray a -> Int -> p
 boundsCheck indexf arr i | i >= 0 && i < isize arr = indexf arr i
 boundsCheck _ arr i = error $ boundsMessage "boundscheck" i (isize arr - 1)
+{-# INLINE boundsCheck #-}
 
 withMutArray :: Int -> (forall s. MArray s a -> ST s x) -> (PArray a, x)
 withMutArray n process = runST $ do
@@ -67,9 +75,11 @@ withMutArray n process = runST $ do
   x <- process marr
   arr <- mfreeze marr
   pure (arr, x)
+{-# INLINE withMutArray #-}
 
 withMutArray_ :: Int -> (forall s. MArray s a -> ST s x) -> PArray a
 withMutArray_ n process = fst $ withMutArray n process
+{-# INLINE withMutArray_ #-}
 
 boundsMessage :: String -> Int -> Int -> String
 boundsMessage funcName i n =

--- a/libs/compact-map/src/Data/Compact/SplitMap.hs
+++ b/libs/compact-map/src/Data/Compact/SplitMap.hs
@@ -39,7 +39,7 @@ invariant :: k -> SplitMap k v -> Bool
 invariant k (SplitMap imap) =
   let (n, _key) = splitKey k
    in case IntMap.lookup n imap of
-        Just kmap -> KeyMap.notEmpty kmap
+        Just kmap -> KeyMap.isNotEmpty kmap
         Nothing -> True
 
 -- | To maintain the invariant, we define 'insertNormForm'
@@ -95,7 +95,7 @@ lookup :: k -> SplitMap k v -> Maybe v
 lookup k (SplitMap imap) =
   case IntMap.lookup n imap of
     Nothing -> Nothing
-    Just keymap -> KeyMap.lookupHM key keymap
+    Just keymap -> KeyMap.lookup key keymap
   where
     (n, key) = splitKey k
 
@@ -390,6 +390,6 @@ ppSplitMap :: forall k v. Show v => SplitMap k v -> PDoc
 ppSplitMap (SplitMap imap) = ppList ppitem (IntMap.toList imap)
   where
     ppitem :: (Int, KeyMap v) -> PDoc
-    ppitem (n, kmap) = ppSexp (pack "Split") [KeyMap.ppInt n, ppKeyMap KeyMap.ppKey ppv kmap]
+    ppitem (n, kmap) = ppSexp (pack "Split") [viaShow n, ppKeyMap viaShow ppv kmap]
     ppv :: v -> PDoc
     ppv x = viaShow x

--- a/libs/compact-map/src/Data/Compact/VMap.hs
+++ b/libs/compact-map/src/Data/Compact/VMap.hs
@@ -25,6 +25,7 @@ module Data.Compact.VMap
     toMap,
     fromList,
     fromListN,
+    toList,
     toAscList,
     keys,
     elems,
@@ -91,6 +92,7 @@ empty = VMap VG.empty
 
 size :: (VG.Vector kv k) => VMap kv vv k v -> Int
 size = VG.length . KV.keysVector . unVMap
+{-# INLINE size #-}
 
 lookup ::
   (Ord k, VG.Vector kv k, VG.Vector vv v) => k -> VMap kv vv k v -> Maybe v
@@ -109,6 +111,10 @@ fromMap = VMap . KV.fromMap
 toMap :: (VG.Vector kv k, VG.Vector vv v) => VMap kv vv k v -> Map.Map k v
 toMap = KV.toMap . unVMap
 {-# INLINE toMap #-}
+
+toList :: (VG.Vector kv k, VG.Vector vv v) => VMap kv vv k v -> [(k, v)]
+toList = VG.toList . unVMap
+{-# INLINE toList #-}
 
 toAscList :: (VG.Vector kv k, VG.Vector vv v) => VMap kv vv k v -> [(k, v)]
 toAscList = VG.toList . unVMap

--- a/libs/compact-map/test/Test/Compact/KeyMap.hs
+++ b/libs/compact-map/test/Test/Compact/KeyMap.hs
@@ -30,24 +30,12 @@ import Test.Tasty.QuickCheck
 
 -- ==============================================================
 
-instance Uniform Key where
-  uniformM g = do
-    w0 <- uniformM g
-    w1 <- uniformM g
-    w2 <- uniformM g
-    w3 <- uniformM g
-    pure (Key w0 w1 w2 w3)
-
 instance Arbitrary Key where
   arbitrary =
     frequency
       [ (1, Key <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary),
         (20, Key <$> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny)
       ]
-
-instance HM.Keyed Key where
-  toKey = id
-  fromKey = id
 
 instance Arbitrary a => Arbitrary (KeyMap a) where
   arbitrary = do

--- a/libs/compact-map/test/Test/Compact/KeyMap.hs
+++ b/libs/compact-map/test/Test/Compact/KeyMap.hs
@@ -254,18 +254,18 @@ keyMapEquivDataMap :: TestTree
 keyMapEquivDataMap =
   testGroup
     "KeyMap behaves like Data.Map"
-    [ testPropertyN 500 "insert" (insertHMDATA @Int),
-      testPropertyN 500 "delete" (deleteHMDATA @Int),
-      testPropertyN 500 "union" (unionHMDATA @Int),
-      testPropertyN 500 "intersection" (intersectHMDATA @Int),
-      testPropertyN 500 "lookup" (lookupHMDATA @Int),
-      testPropertyN 500 "withoutKeys" (withoutHMDATA @Int),
-      testPropertyN 500 "restrictKeys" (restrictHMDATA @Int),
-      testPropertyN 500 "lookupMin" (minHMDATA @Int),
-      testPropertyN 500 "lookupMax" (maxHMDATA @Int),
-      testPropertyN 500 "splitLookup" (splitHMDATA @Int),
-      testPropertyN 500 "minViewWithKey" minViewHMDATA,
-      testPropertyN 500 "maxViewWithKey" maxViewHMDATA
+    [ testPropertyN 5 "insert" (insertHMDATA @Int),
+      testPropertyN 5 "delete" (deleteHMDATA @Int),
+      testPropertyN 5 "union" (unionHMDATA @Int),
+      testPropertyN 5 "intersection" (intersectHMDATA @Int),
+      testPropertyN 5 "lookup" (lookupHMDATA @Int),
+      testPropertyN 5 "withoutKeys" (withoutHMDATA @Int),
+      testPropertyN 5 "restrictKeys" (restrictHMDATA @Int),
+      testPropertyN 5 "lookupMin" (minHMDATA @Int),
+      testPropertyN 5 "lookupMax" (maxHMDATA @Int),
+      testPropertyN 5 "splitLookup" (splitHMDATA @Int),
+      testPropertyN 5 "minViewWithKey" minViewHMDATA,
+      testPropertyN 5 "maxViewWithKey" maxViewHMDATA
     ]
 
 -- ====================================================

--- a/libs/compact-map/test/Test/Compact/KeyMap.hs
+++ b/libs/compact-map/test/Test/Compact/KeyMap.hs
@@ -22,7 +22,7 @@ import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import System.Random (mkStdGen)
-import System.Random.Stateful (Uniform (..), runStateGen_, uniformListM)
+import System.Random.Stateful (runStateGen_, uniformListM)
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.HUnit (testCaseInfo)

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -159,7 +159,7 @@ testKeyMap km m =
       KeyMap.KeyMap (IntMap.IntMap (Alonzo.TxOut CurrentEra))
     test acc txIn@(TxInCompact txId txIx) txOut =
       let !key = toKey txId
-       in case KeyMap.lookupHM key acc of
+       in case KeyMap.lookup key acc of
             Nothing -> error $ "Can't find txId: " <> show txIn
             Just im ->
               let txIx' = fromIntegral txIx


### PR DESCRIPTION
This PR adds benchmarks, applies hlint and some renameing for consistency.

Most importantly it also improves speed of insertion into the KeyMap and fixes a bug in `filterArrayWithBitmap` that resulted in `intersection` throwing an exception on some input.


