### PR TITLE
Fix nix-shell and nix-build

### DIFF
--- a/eras/shelley/test-suite/test/Golden/ShelleyGenesis
+++ b/eras/shelley/test-suite/test/Golden/ShelleyGenesis
@@ -1,70 +1,61 @@
 {
-    "activeSlotsCoeff": 0.259,
+    "maxKESEvolutions": 28899,
+    "updateQuorum": 16991,
     "protocolParams": {
-        "poolDeposit": 0,
-        "protocolVersion": {
-            "minor": 0,
-            "major": 0
-        },
-        "minUTxOValue": 0,
-        "decentralisationParam": 1.9e-2,
-        "maxTxSize": 2048,
-        "minPoolCost": 0,
-        "minFeeA": 0,
-        "maxBlockBodySize": 239857,
-        "minFeeB": 0,
-        "eMax": 0,
         "extraEntropy": {
             "tag": "NeutralNonce"
         },
         "maxBlockHeaderSize": 217569,
-        "keyDeposit": 0,
-        "nOpt": 100,
+        "poolDeposit": 0,
+        "minUTxOValue": 0,
+        "minFeeB": 0,
+        "a0": 0.0,
+        "minPoolCost": 0,
         "rho": 0.0,
         "tau": 0.0,
-        "a0": 0.0
+        "nOpt": 100,
+        "protocolVersion": {
+            "minor": 0,
+            "major": 0
+        },
+        "eMax": 0,
+        "keyDeposit": 0,
+        "decentralisationParam": 1.9e-2,
+        "maxTxSize": 2048,
+        "maxBlockBodySize": 239857,
+        "minFeeA": 0
     },
+    "slotsPerKESPeriod": 8541,
     "genDelegs": {
         "38e7c5986a34f334e19b712c0aa525146dab8f0ff889b2ad16894241": {
-            "delegate": "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a",
-            "vrf": "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d"
+            "vrf": "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d",
+            "delegate": "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a"
         }
     },
-    "updateQuorum": 16991,
-    "networkId": "Testnet",
-    "initialFunds": {
-        "00e1bade2ab9465a24fd5eaa4b7388303917338f853a48b11a5fc9964af5ca93fb6516ebde3d150b3e2acb1909532730de33832ffb229cb20d": 12157196
-    },
-    "maxLovelaceSupply": 71,
-    "networkMagic": 4036000900,
-    "epochLength": 1215,
     "staking": {
+        "stake": {
+            "83a192dec0e8da2188e520d0c536a69a747cf173a3df16a6daa94d86": "649eda82bf644d34a6925f24ea4c4c36d27e51de1b44ef47e3560be7"
+        },
         "pools": {
             "f583a45e4947c102091b96170ef50ef0cf8edb62666193a2163247bb": {
-                "owners": [
-                    "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
-                ],
-                "cost": 5,
-                "margin": 0.25,
-                "publicKey": "4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e",
-                "pledge": 1,
-                "vrf": "68f9cfd33ac8f044facc664db5aa1b73c0b0f5435b85e7b520bb2f1a92f02999",
-                "metadata": {
-                    "hash": "31303061627b7d31303061627b7d",
-                    "url": "best.pool.com"
+                "rewardAccount": {
+                    "network": "Testnet",
+                    "credential": {
+                        "key hash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
+                    }
                 },
                 "relays": [
                     {
                         "single host address": {
+                            "port": 1234,
                             "IPv6": "2001:db8:a::123",
-                            "IPv4": "0.0.0.0",
-                            "port": 1234
+                            "IPv4": "0.0.0.0"
                         }
                     },
                     {
                         "single host name": {
-                            "dnsName": "cool.domain.com",
-                            "port": null
+                            "port": null,
+                            "dnsName": "cool.domain.com"
                         }
                     },
                     {
@@ -73,21 +64,30 @@
                         }
                     }
                 ],
-                "rewardAccount": {
-                    "credential": {
-                        "key hash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
-                    },
-                    "network": "Testnet"
-                }
+                "vrf": "68f9cfd33ac8f044facc664db5aa1b73c0b0f5435b85e7b520bb2f1a92f02999",
+                "publicKey": "4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e",
+                "pledge": 1,
+                "cost": 5,
+                "margin": 0.25,
+                "metadata": {
+                    "hash": "31303061627b7d31303061627b7d",
+                    "url": "best.pool.com"
+                },
+                "owners": [
+                    "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
+                ]
             }
-        },
-        "stake": {
-            "83a192dec0e8da2188e520d0c536a69a747cf173a3df16a6daa94d86": "649eda82bf644d34a6925f24ea4c4c36d27e51de1b44ef47e3560be7"
         }
     },
+    "networkMagic": 4036000900,
+    "maxLovelaceSupply": 71,
     "systemStart": "2009-02-13T23:13:09Z",
-    "slotsPerKESPeriod": 8541,
+    "epochLength": 1215,
+    "networkId": "Testnet",
     "slotLength": 8,
-    "maxKESEvolutions": 28899,
-    "securityParam": 120842
+    "activeSlotsCoeff": 0.259,
+    "securityParam": 120842,
+    "initialFunds": {
+        "00e1bade2ab9465a24fd5eaa4b7388303917338f853a48b11a5fc9964af5ca93fb6516ebde3d150b3e2acb1909532730de33832ffb229cb20d": 12157196
+    }
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,10 @@ let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
   iohkNixMain = import sources.iohk-nix {};
-  haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
+  haskellNix = (import sources."haskell.nix"
+    { inherit system;
+      sourcesOverride = sourcesOverride // { hackage = sources."hackage.nix"; };
+    }).nixpkgsArgs;
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
   nixpkgs = if (sources ? nixpkgs)

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -8,7 +8,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc8104"
+, compiler ? config.haskellNix.compiler or "ghc8107"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 }:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,51 +1,51 @@
 {
-  "hackage.nix": {
-    "branch": "master",
-    "description": "Automatically generated Nix expressions for Hackage",
-    "homepage": "",
-    "owner": "input-output-hk",
-    "repo": "hackage.nix",
-    "rev": "b3c99d7f13df89a9a918c835ecb7114098912962",
-    "sha256": "1i5vg92s6g9zh0i35dm4a6hax7mdsqxbw8w2x63j0y6w57msv70g",
-    "type": "tarball",
-    "url": "https://github.com/input-output-hk/hackage.nix/archive/9f61382fad98e24fe8678db2ffb0c51a863a6023.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "haskell.nix": {
-    "branch": "master",
-    "description": "Alternative Haskell Infrastructure for Nixpkgs",
-    "homepage": "https://input-output-hk.github.io/haskell.nix",
-    "owner": "input-output-hk",
-    "repo": "haskell.nix",
-    "rev": "8aa77fdbd848fe043551e653d837248b4bb76afd",
-    "sha256": "0shqr33kjivb9g8l97rsfhfdqngqd0m5m70pzc06hq2ldf9z9n5i",
-    "type": "tarball",
-    "url": "https://github.com/input-output-hk/haskell.nix/archive/8aa77fdbd848fe043551e653d837248b4bb76afd.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "iohk-nix": {
-    "branch": "master",
-    "description": "nix scripts shared across projects",
-    "homepage": null,
-    "owner": "input-output-hk",
-    "repo": "iohk-nix",
-    "rev": "0068efb20a3cd74dae8dfaedefaa18ad72d4a1a9",
-    "sha256": "1pk76yca6l8yif6xmfn2p36n10p5p0pc204xrilnm5dfpqnkrsgs",
-    "type": "tarball",
-    "url": "https://github.com/input-output-hk/iohk-nix/archive/0068efb20a3cd74dae8dfaedefaa18ad72d4a1a9.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "ormolu": {
-    "branch": "master",
-    "builtin": false,
-    "description": "A formatter for Haskell source code",
-    "homepage": null,
-    "owner": "tweag",
-    "repo": "ormolu",
-    "rev": "560e2d309b9ec3382f92c1d34c778cca4ff7a546",
-    "sha256": "18bgvw2vkvffb438nlpq64zar57i9a6vh7ys7y10nw7bmwfdnzha",
-    "type": "tarball",
-    "url": "https://github.com/tweag/ormolu/archive/560e2d309b9ec3382f92c1d34c778cca4ff7a546.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  }
+    "hackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions for Hackage",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "0d5a13378159f6574e9b3e28b65fc0f2dd4a91e4",
+        "sha256": "1c5j52487rwvj3xgnbsa9d5fadavh3prca54agq2fqd2yj9lyby7",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/0d5a13378159f6574e9b3e28b65fc0f2dd4a91e4.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "haskell.nix": {
+        "branch": "master",
+        "description": "Alternative Haskell Infrastructure for Nixpkgs",
+        "homepage": "https://input-output-hk.github.io/haskell.nix",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "19052d83fda811dd39216e3fc197c980abd037fd",
+        "sha256": "17piis4a66a5x8l4xa6l5bwh02ap2f24hlxd389q9xlmvqrv902x",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/19052d83fda811dd39216e3fc197c980abd037fd.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "iohk-nix": {
+        "branch": "master",
+        "description": "nix scripts shared across projects",
+        "homepage": null,
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0068efb20a3cd74dae8dfaedefaa18ad72d4a1a9",
+        "sha256": "1pk76yca6l8yif6xmfn2p36n10p5p0pc204xrilnm5dfpqnkrsgs",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/0068efb20a3cd74dae8dfaedefaa18ad72d4a1a9.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "ormolu": {
+        "branch": "master",
+        "builtin": false,
+        "description": "A formatter for Haskell source code",
+        "homepage": null,
+        "owner": "tweag",
+        "repo": "ormolu",
+        "rev": "560e2d309b9ec3382f92c1d34c778cca4ff7a546",
+        "sha256": "18bgvw2vkvffb438nlpq64zar57i9a6vh7ys7y10nw7bmwfdnzha",
+        "type": "tarball",
+        "url": "https://github.com/tweag/ormolu/archive/560e2d309b9ec3382f92c1d34c778cca4ff7a546.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    }
 }


### PR DESCRIPTION
- Alters the nix configuration so as to actually make use of the
  separate hackage.nix pin.
- Update the hackage.nix and haskell.nix versions sufficiently for the
  new index-state. We bump haskell.nix only to the same version as
  cardano-node, to take advantage of the cache.