### PR TITLE
add MIR changes to Alonzo spec

### DIFF
--- a/eras/alonzo/formal-spec/alonzo-changes.tex
+++ b/eras/alonzo/formal-spec/alonzo-changes.tex
@@ -379,6 +379,8 @@
 
 \include{chain}
 
+\include{mir}
+
 %\include{constants}
 
 

--- a/eras/alonzo/formal-spec/mir.tex
+++ b/eras/alonzo/formal-spec/mir.tex
@@ -1,0 +1,288 @@
+\section{MIR Certificates}
+\label{sec:mir}
+
+\newcommand{\InstantaneousRewards}{\type{InstantaneousRewards}}
+\newcommand{\MIRPot}{\type{MIRPot}}
+\newcommand{\ReservesMIR}{\type{ReservesMIR}}
+\newcommand{\TreasuryMIR}{\type{TreasuryMIR}}
+
+In the Alonzo era, MIR certs have:
+
+\begin{itemize}
+  \item Slightly different behavior -
+  prior to the Alonzo era, MIR certificates within the same epoch override
+  values for repeated stake addresses.
+  In the Alonzo era, repetitions are handled by adding the values.
+  Moreover, negative values are allowed, so long as the change never results in
+  an overall negative sum.
+  See Figure \ref{fig:dcert-mir}.
+  \item Extended functionality -
+  MIR certificates can now be used to transfer funds between the reserves and the treasury.
+  See Figure \ref{fig:dcert-mir-trans}.
+\end{itemize}
+
+Figure \ref{fig:defs:alonzo-mir} describes the necessary changes to the types.
+Note that $\fun{mirTarget}$ was named $\fun{credCoinMap}$ in the Shelley specification.
+Figure \ref{fig:dcert-mir} is a modification to the DELEG rule, and
+Figure \ref{fig:dcert-mir-trans} is an addition to the DELEG rule.
+Lastly, Figure \ref{fig:rules:mir} is the updated MIR rule.
+
+
+\begin{figure*}[htb]
+  \emph{Derived types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~~}l@{~~}l@{\qquad}l}
+      \InstantaneousRewards =
+      & (\StakeCredential \mapsto \Coin)
+      & \text{rewards from reserves}
+      \\
+      & \times (\StakeCredential \mapsto \Coin)
+      & \text{rewards from treasury}
+      \\
+      & \times \hldiff{\Coin}
+      & \text{pending modification to reserves}
+      \\
+      & \times \hldiff{\Coin}
+      & \text{pending modification to treasury}
+    \end{array}
+  \end{equation*}
+  %
+  \emph{New MIR Cert accessor}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~:~}lr}
+      \fun{mirTarget}
+      & \DCertMir \to (\StakeCredential \mapsto \Coin) \uniondistinct \hldiff{\MIRPot}
+    \end{array}
+  \end{equation*}
+  \caption{Alonzo Types for MIR updates}
+  \label{fig:defs:alonzo-mir}
+\end{figure*}
+
+\begin{figure}[htp]
+  \centering
+  \begin{equation}\label{eq:deleg-mir}
+    \inference[Deleg-Mir]
+    {
+      \var{c}\in \DCertMir
+      &
+      \hldiff{\fun{mirTarget}~\var{c}\in \StakeCredential \mapsto \Coin}
+      \\
+      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
+      (\var{irR},~\var{irT}\hldiff{,~\var{dR},~\var{dT}})\leteq\var{i_{rwd}}
+      &
+      (\var{treasury},~\var{reserves})\leteq\var{acnt}
+      \\
+      (\var{pot}\hldiff{,~\var{deltaPot}},~\var{irPot})\leteq
+      {\begin{cases}
+          (\var{reserves}\hldiff{,~\var{dR}},~\var{irR}) & \fun{mirPot}~\var{c}=\ReservesMIR \\
+          (\var{treasury}\hldiff{,~\var{dT}},~\var{irT}) & \fun{mirPot}~\var{c}=\TreasuryMIR
+       \end{cases}}
+      \\
+      \var{combined}\leteq(\fun{mirTarget}~\var{c})\hldiff{\unionoverridePlus}\var{irPot}
+      \\
+      \sum\limits_{\wcard\mapsto\var{val}\in\var{combined}} val \leq\var{pot} \hldiff{+ \var{deltaPot}}
+      \\
+      \forall \var{r}\in\range{\hldiff{\var{combinedR}}},~r\geq 0
+      \\
+      \var{i_{rwd}'}\leteq
+      {\begin{cases}
+          (\var{combined},~\var{irT}\hldiff{,~\var{dR},~\var{dT}}) & \fun{mirPot}~\var{c}=\ReservesMIR  \\
+          (\var{irR},~\var{combined}\hldiff{,~\var{dR},~\var{dT}}) & \fun{mirPot}~\var{c}=\TreasuryMIR
+      \end{cases}}
+    }
+    {
+      \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+        \var{acnt}
+      \end{array}
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
+        \var{i_{rwd}}
+      \end{array}
+      \right)
+      \trans{deleg}{c}
+      \left(
+      \begin{array}{c}
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs}\\
+        \var{genDelegs} \\
+        \varUpdate{\var{i_{rwd}'}} \\
+      \end{array}
+      \right)
+    }
+  \end{equation}
+
+  \caption{Move Instantaneous Rewards Inference Rule}
+  \label{fig:dcert-mir}
+\end{figure}
+
+\begin{figure}[htp]
+  \centering
+  \begin{equation}\label{eq:deleg-mir-transfer}
+    \inference[Deleg-Mir-Trans]
+    {
+      \var{c}\in \DCertMir
+      &
+      \fun{mirTarget}~\var{c}\in \Coin
+      \\
+      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
+      (\var{irR},~\var{irT},~\var{dR},~\var{dT})\leteq\var{i_{rwd}}
+      \\
+      \var{coin}\leteq\fun{mirTarget}~\var{c}
+      &
+      \var{coin} \geq 0
+      &
+      (\var{treasury},~\var{reserves})\leteq\var{acnt}
+      \\
+      \var{available}\leteq
+      {\begin{cases}
+          \var{reserves}+\var{dR}+
+          \left(\sum\limits_{\wcard\mapsto\var{val}\in\var{irR}} val\right)
+          & \fun{mirPot}~\var{c}=\ReservesMIR \\
+          \var{treasury}+\var{dT}+
+          \left(\sum\limits_{\wcard\mapsto\var{val}\in\var{irT}} val\right)
+          & \fun{mirPot}~\var{c}=\TreasuryMIR
+       \end{cases}
+      }
+      \\
+      \var{coin} \leq \var{available}
+      \\
+      \var{i_{rwd}'}\leteq
+      {\begin{cases}
+         (\var{irR},~\var{irT},~\var{dR}-\var{coin},~\var{dT}+\var{coin})
+          & \fun{mirPot}~\var{c}=\ReservesMIR \\
+         (\var{irR},~\var{irT},~\var{dR}+\var{coin},~\var{dT}-\var{coin})
+          & \fun{mirPot}~\var{c}=\TreasuryMIR
+       \end{cases}
+      }
+    }
+    {
+      \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+        \var{acnt}
+      \end{array}
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
+        \var{i_{rwd}}
+      \end{array}
+      \right)
+      \trans{deleg}{c}
+      \left(
+      \begin{array}{c}
+        \var{rewards} \\
+        \var{delegations} \\
+        \var{ptrs} \\
+        \var{fGenDelegs}\\
+        \var{genDelegs} \\
+        \varUpdate{\var{i_{rwd}'}} \\
+      \end{array}
+      \right)
+    }
+  \end{equation}
+
+  \caption{MIR transfer Inference Rule}
+  \label{fig:dcert-mir-trans}
+\end{figure}
+
+\begin{figure}[ht]
+  \begin{equation}\label{eq:mir}
+    \inference[MIR]
+    {
+      (\var{rewards},~\var{delegations},~
+      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})
+        \leteq \var{ds}
+      \\
+      (\var{treasury},~\var{reserves})\leteq\var{acnt}
+      \\
+      (\var{irReserves},~\var{irTreasury}\hldiff{,~\var{deltaReserves},~\var{deltaTreasury}})\leteq\var{i_{rwd}}
+      \\~\\
+      \var{irwdR}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irReserves}
+        \right\}
+      \\
+      \var{irwdT}\leteq
+        \left\{
+        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
+        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irTreasury}
+        \right\}
+      \\
+      \hldiff{\var{availableReserves}\leteq\var{reserves}+\var{deltaReserves}}
+      \\
+      \hldiff{\var{availableTreasury}\leteq\var{treasury}+\var{deltaTreasury}}
+      \\~\\
+      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdR}}v
+      &
+      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdT}}v
+      \\
+      \var{enough}\leteq
+          \var{totR}\leq\hldiff{\var{availableReserves}}
+          \land\var{totT}\leq\hldiff{\var{availableTreasury}}
+      \\
+      \var{acnt'}\leteq
+      {\begin{cases}
+          (\var{treasury}-\var{totT},~\var{reserves}-\var{totR})
+          & \var{enough}
+          \\
+          \var{acnt}
+          &
+          \text{otherwise}
+       \end{cases}}
+      \\~\\
+      \var{rewards'}\leteq
+      {\begin{cases}
+          \var{rewards}\unionoverridePlus\var{irwdR}\unionoverridePlus\var{irwdT}
+          & \var{enough}
+          \\
+          \var{rewards}
+          &
+          \text{otherwise}
+       \end{cases}}
+      \\
+      \var{ds'} \leteq
+      (\varUpdate{\var{rewards}'},~\var{delegations},~
+      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},
+      ~(\varUpdate{\emptyset},~\varUpdate{\emptyset},~\varUpdate{0},~\varUpdate{0}))
+    }
+    {
+      \vdash
+      {\left(\begin{array}{c}
+            \var{acnt} \\
+            \var{ss} \\
+            (\var{us},~(\var{ds},~\var{ps})) \\
+            \var{prevPP} \\
+            \var{pp} \\
+      \end{array}\right)}
+      \trans{mir}{}
+      {\left(\begin{array}{c}
+            \varUpdate{\var{acnt'}} \\
+            \var{ss} \\
+            (\var{us},~(\varUpdate{\var{ds'}},~\var{ps})) \\
+            \var{prevPP} \\
+            \var{pp} \\
+      \end{array}\right)}
+    }
+  \end{equation}
+
+  \caption{MIR rules}
+  \label{fig:rules:mir}
+\end{figure}

--- a/eras/shelley/formal-spec/chain.tex
+++ b/eras/shelley/formal-spec/chain.tex
@@ -174,11 +174,29 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
       &
       \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdT}}v
       \\
-      \var{totR}\leq\var{reserves}
-      &
-      \var{totT}\leq\var{treasury}
+      \var{enough}\leteq
+          \var{totR}\leq\var{reserves}
+          \land\var{totT}\leq\var{treasury}
+      \\
+      \var{acnt'}\leteq
+      {\begin{cases}
+          (\var{treasury}-\var{totT},~\var{reserves}-\var{totR})
+          & \var{enough}
+          \\
+          \var{acnt}
+          &
+          \text{otherwise}
+       \end{cases}}
       \\~\\
-      \var{rewards'}\leteq\var{rewards}\unionoverridePlus\var{irwdR}\unionoverridePlus\var{irwdT}
+      \var{rewards'}\leteq
+      {\begin{cases}
+          \var{rewards}\unionoverridePlus\var{irwdR}\unionoverridePlus\var{irwdT}
+          & \var{enough}
+          \\
+          \var{rewards}
+          &
+          \text{otherwise}
+       \end{cases}}
       \\
       \var{ds'} \leteq
       (\varUpdate{\var{rewards}'},~\var{delegations},~
@@ -196,7 +214,7 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
       \end{array}\right)}
       \trans{mir}{}
       {\left(\begin{array}{c}
-            \varUpdate{(\varUpdate{\var{treasury}-\var{totT}},~\varUpdate{\var{reserves}-\var{totR}})} \\
+            \varUpdate{\var{acnt'}} \\
             \var{ss} \\
             (\var{us},~(\varUpdate{\var{ds'}},~\var{ps})) \\
             \var{prevPP} \\
@@ -205,61 +223,6 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
     }
   \end{equation}
 
-  \nextdef
-
-  \begin{equation}\label{eq:mir-skip}
-    \inference[MIR-Skip]
-    {
-      (\var{rewards},~\var{delegations},~
-      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})
-        \leteq \var{ds}
-      \\
-      (\var{treasury},~\var{reserves})\leteq\var{acnt}
-      &
-      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
-      \\~\\
-      \var{irwdR}\leteq
-        \left\{
-        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
-        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irReserves}
-        \right\}
-      \\
-      \var{irwdT}\leteq
-        \left\{
-        \fun{addr_{rwd}}~\var{hk}\mapsto\var{val}
-        ~\vert~\var{hk}\mapsto\var{val}\in(\dom{rewards})\restrictdom\var{irTreasury}
-        \right\}
-      \\~\\
-      \var{totR}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdR}}v
-      &
-      \var{totT}\leteq\sum\limits_{\wcard\mapsto v\in\var{irwdT}}v
-      \\
-      \var{totR}>\var{reserves}~\lor~\var{totT}>\var{treasury}
-      \\~\\
-      \var{ds'} \leteq
-      (\var{rewards},~\var{delegations},~
-      \var{ptrs},~\var{fGenDelegs},~\var{genDelegs},
-      ~(\varUpdate{\emptyset},~\varUpdate{\emptyset}))
-    }
-    {
-      \vdash
-      {\left(\begin{array}{c}
-            \var{acnt} \\
-            \var{ss} \\
-            (\var{us},~(\var{ds},~\var{ps})) \\
-            \var{prevPP} \\
-            \var{pp} \\
-      \end{array}\right)}
-      \trans{mir}{}
-      {\left(\begin{array}{c}
-            \var{acnt} \\
-            \var{ss} \\
-            (\var{us},~(\varUpdate{\var{ds'}},~\var{ps})) \\
-            \var{prevPP} \\
-            \var{pp} \\
-      \end{array}\right)}
-    }
-  \end{equation}
   \caption{MIR rules}
   \label{fig:rules:mir}
 \end{figure}

--- a/eras/shelley/formal-spec/delegation.tex
+++ b/eras/shelley/formal-spec/delegation.tex
@@ -582,18 +582,33 @@ concerns are independent of the ledger rules.
 
 \begin{figure}[htp]
   \centering
-  \begin{equation}\label{eq:deleg-mir-reserves}
+  \begin{equation}\label{eq:deleg-mir}
     \inference[Deleg-Mir]
     {
       \var{c}\in \DCertMir
-      &
-      \fun{mirPot}~\var{c}=\ReservesMIR
       \\
       slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
-      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
+      (\var{irR},~\var{irT})\leteq\var{i_{rwd}}
       &
-      \var{combinedR}\leteq(\fun{credCoinMap}~\var{c})\unionoverrideLeft\var{irReserves} \\
-      \sum\limits_{\wcard\mapsto\var{val}\in\var{combinedR}} val \leq\var{reserves}
+      (\var{treasury},~\var{reserves})\leteq\var{acnt}
+      \\
+      (\var{pot},~\var{irPot})\leteq
+      {\begin{cases}
+          (\var{reserves},~\var{irR}) & \fun{mirPot}~\var{c}=\ReservesMIR \\
+          (\var{treasury},~\var{irT}) & \fun{mirPot}~\var{c}=\TreasuryMIR
+       \end{cases}}
+      \\
+      \var{combined}\leteq(\fun{mirTarget}~\var{c})\unionoverrideLeft\var{irPot}
+      \\
+      \sum\limits_{\wcard\mapsto\var{val}\in\var{combined}} val \leq\var{pot}
+      \\
+      \forall \var{r}\in\range{\var{irPot}},~r\geq 0
+      \\
+      \var{i_{rwd}'}\leteq
+      {\begin{cases}
+      (\var{combined},~\var{irT}) & \fun{mirPot}~\var{c}=\ReservesMIR  \\
+      (\var{irR},~\var{combined}) & \fun{mirPot}~\var{c}=\TreasuryMIR
+      \end{cases}}
     }
     {
       \begin{array}{r}
@@ -620,55 +635,12 @@ concerns are independent of the ledger rules.
         \var{ptrs} \\
         \var{fGenDelegs}\\
         \var{genDelegs} \\
-        (\varUpdate{\var{combinedR}},~\var{irTreasury}) \\
+        \varUpdate{\var{i_{rwd}'}} \\
       \end{array}
       \right)
     }
   \end{equation}
-  \\~\\
-  \begin{equation}\label{eq:deleg-mir-treasury}
-    \inference[Deleg-Mir]
-    {
-      \var{c}\in \DCertMir
-      &
-      \fun{mirPot}~\var{c}=\TreasuryMIR
-      \\
-      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
-      (\var{irReserves},~\var{irTreasury})\leteq\var{i_{rwd}}
-      &
-      \var{combinedT}\leteq(\fun{credCoinMap}~\var{c})\unionoverrideLeft\var{irTreasury} \\
-      \sum\limits_{\wcard\mapsto\var{val}\in\var{combinedT}} val \leq\var{treasury}
-    }
-    {
-      \begin{array}{r}
-        \var{slot} \\
-        \var{ptr} \\
-        \var{acnt}
-      \end{array}
-      \vdash
-      \left(
-      \begin{array}{r}
-        \var{rewards} \\
-        \var{delegations} \\
-        \var{ptrs} \\
-        \var{fGenDelegs} \\
-        \var{genDelegs} \\
-        \var{i_{rwd}}
-      \end{array}
-      \right)
-      \trans{deleg}{c}
-      \left(
-      \begin{array}{c}
-        \var{rewards} \\
-        \var{delegations} \\
-        \var{ptrs} \\
-        \var{fGenDelegs}\\
-        \var{genDelegs} \\
-        (\var{irReserves},~\varUpdate{\var{combinedT}}) \\
-      \end{array}
-      \right)
-    }
-  \end{equation}
+
   \caption{Move Instantaneous Rewards Inference Rule}
   \label{fig:dcert-mir}
 \end{figure}

--- a/eras/shelley/formal-spec/frontmatter.tex
+++ b/eras/shelley/formal-spec/frontmatter.tex
@@ -39,6 +39,7 @@
           should get the pool parameters from the go snapshot.
           The TICKN rule was missing from the dependency diagram.}
         \change{2021/11/08}{Jared Corduan}{FM (IOHK)}{Fixed typo in the description of variable length encodings.}
+        \change{2021/12/13}{Jared Corduan}{FM (IOHK)}{Re-wrote the MIR transitions to be more compact.}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -129,6 +129,9 @@ data DelegPredicateFailure era
       !Coin -- amount attempted to transfer
       !Coin -- amount available
   | MIRProducesNegativeUpdate
+  | MIRNegativeTransfer
+      !MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
+      !Coin -- amount attempted to transfer
   deriving (Show, Eq, Generic)
 
 newtype DelegEvent era = NewEpoch EpochNo
@@ -191,6 +194,10 @@ instance
         <> toCBOR available
     MIRProducesNegativeUpdate ->
       encodeListLen 1 <> toCBOR (14 :: Word8)
+    MIRNegativeTransfer pot amt ->
+      encodeListLen 3 <> toCBOR (15 :: Word8)
+        <> toCBOR pot
+        <> toCBOR amt
 
 instance
   (Era era, Typeable (Core.Script era)) =>
@@ -244,6 +251,10 @@ instance
         pure (4, InsufficientForTransferDELEG pot needed available)
       14 -> do
         pure (1, MIRProducesNegativeUpdate)
+      15 -> do
+        pot <- fromCBOR
+        amt <- fromCBOR
+        pure (3, MIRNegativeTransfer pot amt)
       k -> invalidKey k
 
 delegationTransition ::
@@ -382,6 +393,8 @@ delegationTransition = do
             ?! MIRCertificateTooLateinEpochDELEG slot tooLate
 
           let available = availableAfterMIR targetPot acnt (_irwd ds)
+          coin >= mempty
+            ?! MIRNegativeTransfer targetPot coin
           coin <= available
             ?! InsufficientForTransferDELEG targetPot coin available
 


### PR DESCRIPTION
Additionally, added a new check to the Alonzo MIR rule that ensures that the Coin valued used in transfers (reserves <-> treasury) is always non-negative. This does mean that the predicate serialization has changed, but as this is a governance feature we should be fine (cc @nc6).