### PR TITLE
fix the integrity hash starting in plutus V2

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -179,7 +179,7 @@ newtype CostModel = CostModel (Map Text Integer)
 -- NOTE: Since cost model serializations need to be independently reproduced,
 -- we use the 'canonical' serialization approach used in Byron.
 instance ToCBOR CostModel where
-  toCBOR (CostModel cm) = toCBOR $ Map.elems cm
+  toCBOR (CostModel cm) = encodeFoldableAsDefinite $ Map.elems cm
 
 instance SafeToHash CostModel where
   originalBytes = serialize'

--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -113,6 +113,8 @@ script_data_hash = $hash32 ; New
 ;     list and the result is encoded as a bytestring. (our apologies)
 ;   - the language ID tag is also encoded twice. first as a uint then as
 ;     a bytestring. (our apologies)
+; For PlutusV2 (language id 1), the language view is the following:
+;   - the value of costmdls map at key 1 is encoded as an definite length list.
 ;
 ; If there is no value for key 0, then the corresponding scripts cannot execute.
 ; Regardless of what the script integrity data is.

--- a/libs/cardano-data/src/Data/Coders.hs
+++ b/libs/cardano-data/src/Data/Coders.hs
@@ -59,6 +59,8 @@ module Data.Coders
     wrapCBORArray,
     encodePair,
     encodeFoldable,
+    encodeFoldableAsDefinite,
+    encodeFoldableAsIndefinite,
     encodeFoldableMapPairs,
     decodeCollectionWithLen,
     decodeCollection,
@@ -257,6 +259,16 @@ decodeCollectionWithLen lenOrIndef el = do
 
 encodeFoldable :: (ToCBOR a, Foldable f) => f a -> Encoding
 encodeFoldable = encodeFoldableEncoder toCBOR
+
+encodeFoldableAsIndefinite :: (ToCBOR a, Foldable f) => f a -> Encoding
+encodeFoldableAsIndefinite f = encodeFoldableEncoderAs wrapArray toCBOR f
+  where
+    wrapArray _len contents = encodeListLenIndef <> contents <> encodeBreak
+
+encodeFoldableAsDefinite :: (ToCBOR a, Foldable f) => f a -> Encoding
+encodeFoldableAsDefinite f = encodeFoldableEncoderAs wrapArray toCBOR f
+  where
+    wrapArray len contents = encodeListLen len <> contents
 
 -- Encodes a sequence of pairs as a cbor map
 encodeFoldableMapPairs :: (ToCBOR a, ToCBOR b, Foldable f) => f (a, b) -> Encoding


### PR DESCRIPTION
Correct the unintentional encoding used in the Plutus V1 integrity hash.

closes #2512 