### PR TITLE
add two missing params to alonzo cddl

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -251,6 +251,8 @@ protocol_param_update =
   , ? 20: ex_units           ; max tx ex units ; New
   , ? 21: ex_units           ; max block ex units ; New
   , ? 22: uint               ; max value size ; New
+  , ? 23: uint               ; collateral percentage ; New
+  , ? 24: uint               ; max collateral inputs ; New
   }
 
 transaction_witness_set =


### PR DESCRIPTION
The following two protocol parameters were missing from the CDDL spec:
* collateral percentage
* max collateral inputs

closes #2588 