### PR TITLE
fix bug in taylorExpCmp

### DIFF
--- a/libs/non-integral/src/Cardano/Ledger/NonIntegral.hs
+++ b/libs/non-integral/src/Cardano/Ledger/NonIntegral.hs
@@ -203,7 +203,7 @@ taylorExpCmp boundX cmp x = go 1000 0 x 1 1
       | cmp < acc' - errorTerm = BELOW acc' (n + 1)
       | otherwise = go maxN (n + 1) err' acc' divisor'
       where
-        errorTerm = err' * boundX
+        errorTerm = abs (err' * boundX)
         divisor' = divisor + 1
         nextX = err
         err' = (err * x) / divisor'

--- a/libs/non-integral/test/Tests.hs
+++ b/libs/non-integral/test/Tests.hs
@@ -6,6 +6,7 @@ import Tests.Cardano.Ledger.NonIntegral
 
 main :: IO ()
 main = do
+  property_negative_taylorExpCmp_comparison
   property_exponential_is_monotonic_db
   property_logarithm_is_monotonic_db
   property_exp_maps_unit_interval_to_unit_interval_db


### PR DESCRIPTION
When checking a negative value with `taylorExpCmp`, the error term `errorTerm` needs to be an absolute value.

The ledger code [never calls](https://github.com/input-output-hk/cardano-ledger/blob/1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs#L423) `taylorExpCmp` with a negative value (note that c is negative, it is the [natural log](https://github.com/input-output-hk/cardano-ledger/blob/1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs#L561) of a number less than one), but the hazard needs to be removed for the saftey of the future.

It's nice to know that the property test that I wrote for this change fails with the absolute value is not taken. :)