### PR TITLE
weaken `FromCBOR` for `TxOut` to `Annotator TxOut`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -111,6 +111,19 @@ instance
       dec 1 = SumD TooManyExUnits <! From <! From
       dec n = Invalid n
 
+instance
+  ( Typeable era,
+    FromCBOR (Annotator (BbodyPredicateFailure era)) -- TODO why is there no FromCBOR for (BbodyPredicateFailure era)
+  ) =>
+  FromCBOR (Annotator (AlonzoBbodyPredFail era))
+  where
+  fromCBOR = decode (Summands "AlonzoBbodyPredFail" dec)
+    where
+      dec :: (Word -> Decode 'Open (Annotator (AlonzoBbodyPredFail era)))
+      dec 0 = SumD (pure ShelleyInAlonzoPredFail) <*! From
+      dec 1 = Ann $ SumD TooManyExUnits <! From <! From
+      dec n = Invalid n
+
 -- ========================================
 -- The STS instance
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -55,6 +55,7 @@ import Control.State.Transition
     (?!),
   )
 import Data.Coders
+import Data.Functor.Identity (Identity (..))
 import Data.Kind (Type)
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -101,28 +102,27 @@ instance
 
 instance
   ( Typeable era,
-    FromCBOR (BbodyPredicateFailure era) -- TODO why is there no FromCBOR for (BbodyPredicateFailure era)
+    FromCBOR (BbodyPredicateFailure era)
   ) =>
   FromCBOR (AlonzoBbodyPredFail era)
   where
-  fromCBOR = decode (Summands "AlonzoBbodyPredFail" dec)
-    where
-      dec 0 = SumD ShelleyInAlonzoPredFail <! From
-      dec 1 = SumD TooManyExUnits <! From <! From
-      dec n = Invalid n
+  fromCBOR = runIdentity <$> decode (Summands "AlonzoBbodyPredFail" decAlonzoBbodyPredFail)
 
 instance
   ( Typeable era,
-    FromCBOR (Annotator (BbodyPredicateFailure era)) -- TODO why is there no FromCBOR for (BbodyPredicateFailure era)
+    FromCBOR (Annotator (BbodyPredicateFailure era))
   ) =>
   FromCBOR (Annotator (AlonzoBbodyPredFail era))
   where
-  fromCBOR = decode (Summands "AlonzoBbodyPredFail" dec)
-    where
-      dec :: (Word -> Decode 'Open (Annotator (AlonzoBbodyPredFail era)))
-      dec 0 = SumD (pure ShelleyInAlonzoPredFail) <*! From
-      dec 1 = Ann $ SumD TooManyExUnits <! From <! From
-      dec n = Invalid n
+  fromCBOR = decode (Summands "AlonzoBbodyPredFail" decAlonzoBbodyPredFail)
+
+decAlonzoBbodyPredFail ::
+  (Applicative f, FromCBOR (f (BbodyPredicateFailure era))) =>
+  Word ->
+  Decode 'Open (f (AlonzoBbodyPredFail era))
+decAlonzoBbodyPredFail 0 = SumD (pure ShelleyInAlonzoPredFail) <*! From
+decAlonzoBbodyPredFail 1 = Ann $ SumD TooManyExUnits <! From <! From
+decAlonzoBbodyPredFail n = Invalid n
 
 -- ========================================
 -- The STS instance

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -13,7 +13,7 @@
 
 module Cardano.Ledger.Alonzo.Rules.Utxo where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+import Cardano.Binary (Annotator (Annotator), FromCBOR (..), ToCBOR (..), serialize)
 import Cardano.Ledger.Address
   ( Addr (..),
     RewardAcnt,
@@ -76,12 +76,14 @@ import Data.Coders
     Encode (..),
     Wrapped (Open),
     decode,
+    decodeAnnList,
     decodeList,
     decodeSet,
     encode,
     encodeFoldable,
     (!>),
     (<!),
+    (<*!),
   )
 import Data.Coerce (coerce)
 import Data.Foldable (foldl', toList)
@@ -609,3 +611,52 @@ instance
   FromCBOR (UtxoPredicateFailure era)
   where
   fromCBOR = decode (Summands "UtxoPredicateFailure" decFail)
+
+decFailA ::
+  ( Era era,
+    FromCBOR (Annotator (Core.TxOut era)),
+    FromCBOR (Core.Value era),
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "UTXOS" era)))
+  ) =>
+  Word ->
+  Decode 'Open (Annotator (UtxoPredicateFailure era))
+decFailA 0 = Ann $ SumD BadInputsUTxO <! D (decodeSet fromCBOR)
+decFailA 1 = Ann $ SumD OutsideValidityIntervalUTxO <! From <! From
+decFailA 2 = Ann $ SumD MaxTxSizeUTxO <! From <! From
+decFailA 3 = Ann $ SumD InputSetEmptyUTxO
+decFailA 4 = Ann $ SumD FeeTooSmallUTxO <! From <! From
+decFailA 5 = Ann $ SumD ValueNotConservedUTxO <! From <! From
+decFailA 6 = SumD (pure OutputTooSmallUTxO) <*! D (decodeAnnList fromCBOR)
+decFailA 7 = SumD (pure UtxosFailure) <*! From
+decFailA 8 = Ann $ SumD WrongNetwork <! From <! D (decodeSet fromCBOR)
+decFailA 9 = Ann $ SumD WrongNetworkWithdrawal <! From <! D (decodeSet fromCBOR)
+decFailA 10 = SumD (pure OutputBootAddrAttrsTooBig) <*! D (decodeAnnList fromCBOR)
+decFailA 11 = Ann $ SumD TriesToForgeADA
+decFailA 12 =
+  SumD (pure OutputTooBigUTxO)
+    <*! D
+      ( do
+          xs <- decodeAnnList $ do
+            (a, b, Annotator fc) <- fromCBOR
+            pure $ Annotator $ \fbs -> (a, b, fc fbs)
+          pure xs
+      )
+decFailA 13 = Ann $ SumD InsufficientCollateral <! From <! From
+decFailA 14 = SumD (pure ScriptsNotPaidUTxO) <*! From
+decFailA 15 = Ann $ SumD ExUnitsTooBigUTxO <! From <! From
+decFailA 16 = Ann $ SumD CollateralContainsNonADA <! From
+decFailA 17 = Ann $ SumD WrongNetworkInTxBody <! From <! From
+decFailA 18 = Ann $ SumD OutsideForecast <! From
+decFailA 19 = Ann $ SumD TooManyCollateralInputs <! From <! From
+decFailA 20 = Ann $ SumD NoCollateralInputs
+decFailA n = Invalid n
+
+instance
+  ( Era era,
+    FromCBOR (Annotator (Core.TxOut era)),
+    FromCBOR (Core.Value era),
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "UTXOS" era)))
+  ) =>
+  FromCBOR (Annotator (UtxoPredicateFailure era))
+  where
+  fromCBOR = decode (Summands "UtxoPredicateFailure" decFailA)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -348,6 +349,19 @@ instance
       dec 1 = SumD (CollectErrors @era) <! From
       dec 2 = SumD UpdateFailure <! From
       dec n = Invalid n
+
+instance
+  ( Era era,
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "PPUP" era)))
+  ) =>
+  FromCBOR (Annotator (UtxosPredicateFailure era))
+  where
+  fromCBOR = decode (Summands "UtxosPredicateFailure" dec)
+    where
+      dec 0 = Ann $ SumD ValidationTagMismatch <! From <! From
+      dec 1 = Ann $ SumD (CollectErrors @era) <! From
+      dec 2 = SumD (pure UpdateFailure) <*! From
+      dec n = Ann $ Invalid n
 
 deriving stock instance
   ( Shelley.TransUTxOState Show era,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -193,6 +193,34 @@ decodePredFail 6 = SumD UnspendableUTxONoDatumHash <! From
 decodePredFail 7 = SumD ExtraRedeemers <! From
 decodePredFail n = Invalid n
 
+instance
+  ( Era era,
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "UTXO" era))),
+    Typeable (Core.Script era),
+    Typeable (Core.AuxiliaryData era)
+  ) =>
+  FromCBOR (Annotator (AlonzoPredFail era))
+  where
+  fromCBOR = decode (Summands "(AlonzoPredFail" decodePredFailA)
+
+decodePredFailA ::
+  ( Era era,
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "UTXO" era))), -- TODO, we should be able to get rid of this constraint
+    Typeable (Core.Script era),
+    Typeable (Core.AuxiliaryData era)
+  ) =>
+  Word ->
+  Decode 'Open (Annotator (AlonzoPredFail era))
+decodePredFailA 0 = SumD (pure WrappedShelleyEraFailure) <*! D fromCBOR
+decodePredFailA 1 = Ann $ SumD MissingRedeemers <! From
+decodePredFailA 2 = Ann $ SumD MissingRequiredDatums <! From <! From
+decodePredFailA 3 = Ann $ SumD NonOutputSupplimentaryDatums <! From <! From
+decodePredFailA 4 = Ann $ SumD PPViewHashesDontMatch <! From <! From
+decodePredFailA 5 = Ann $ SumD MissingRequiredSigners <! From
+decodePredFailA 6 = Ann $ SumD UnspendableUTxONoDatumHash <! From
+decodePredFailA 7 = Ann $ SumD ExtraRedeemers <! From
+decodePredFailA n = Ann $ Invalid n
+
 -- =============================================
 
 -- | given the "txscripts" field of the Witnesses, compute the set of languages used in a transaction

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -81,6 +81,7 @@ import Control.SetAlgebra (domain, eval, (⊆), (◁), (➖))
 import Control.State.Transition.Extended
 import Data.Coders
 import Data.Foldable (toList)
+import Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -173,25 +174,7 @@ instance
   ) =>
   FromCBOR (AlonzoPredFail era)
   where
-  fromCBOR = decode (Summands "(AlonzoPredFail" decodePredFail)
-
-decodePredFail ::
-  ( Era era,
-    FromCBOR (PredicateFailure (Core.EraRule "UTXO" era)), -- TODO, we should be able to get rid of this constraint
-    Typeable (Core.Script era),
-    Typeable (Core.AuxiliaryData era)
-  ) =>
-  Word ->
-  Decode 'Open (AlonzoPredFail era)
-decodePredFail 0 = SumD WrappedShelleyEraFailure <! D fromCBOR
-decodePredFail 1 = SumD MissingRedeemers <! From
-decodePredFail 2 = SumD MissingRequiredDatums <! From <! From
-decodePredFail 3 = SumD NonOutputSupplimentaryDatums <! From <! From
-decodePredFail 4 = SumD PPViewHashesDontMatch <! From <! From
-decodePredFail 5 = SumD MissingRequiredSigners <! From
-decodePredFail 6 = SumD UnspendableUTxONoDatumHash <! From
-decodePredFail 7 = SumD ExtraRedeemers <! From
-decodePredFail n = Invalid n
+  fromCBOR = runIdentity <$> decode (Summands "(AlonzoPredFail" decodePredFail)
 
 instance
   ( Era era,
@@ -201,25 +184,24 @@ instance
   ) =>
   FromCBOR (Annotator (AlonzoPredFail era))
   where
-  fromCBOR = decode (Summands "(AlonzoPredFail" decodePredFailA)
+  fromCBOR = decode (Summands "(AlonzoPredFail" decodePredFail)
 
-decodePredFailA ::
+decodePredFail ::
   ( Era era,
-    FromCBOR (Annotator (PredicateFailure (Core.EraRule "UTXO" era))), -- TODO, we should be able to get rid of this constraint
-    Typeable (Core.Script era),
-    Typeable (Core.AuxiliaryData era)
+    Applicative f,
+    FromCBOR (f (UtxowPredicateFailure era))
   ) =>
   Word ->
-  Decode 'Open (Annotator (AlonzoPredFail era))
-decodePredFailA 0 = SumD (pure WrappedShelleyEraFailure) <*! D fromCBOR
-decodePredFailA 1 = Ann $ SumD MissingRedeemers <! From
-decodePredFailA 2 = Ann $ SumD MissingRequiredDatums <! From <! From
-decodePredFailA 3 = Ann $ SumD NonOutputSupplimentaryDatums <! From <! From
-decodePredFailA 4 = Ann $ SumD PPViewHashesDontMatch <! From <! From
-decodePredFailA 5 = Ann $ SumD MissingRequiredSigners <! From
-decodePredFailA 6 = Ann $ SumD UnspendableUTxONoDatumHash <! From
-decodePredFailA 7 = Ann $ SumD ExtraRedeemers <! From
-decodePredFailA n = Ann $ Invalid n
+  Decode 'Open (f (AlonzoPredFail era))
+decodePredFail 0 = SumD (pure WrappedShelleyEraFailure) <*! D fromCBOR
+decodePredFail 1 = Ann $ SumD MissingRedeemers <! From
+decodePredFail 2 = Ann $ SumD MissingRequiredDatums <! From <! From
+decodePredFail 3 = Ann $ SumD NonOutputSupplimentaryDatums <! From <! From
+decodePredFail 4 = Ann $ SumD PPViewHashesDontMatch <! From <! From
+decodePredFail 5 = Ann $ SumD MissingRequiredSigners <! From
+decodePredFail 6 = Ann $ SumD UnspendableUTxONoDatumHash <! From
+decodePredFail 7 = Ann $ SumD ExtraRedeemers <! From
+decodePredFail n = Ann $ Invalid n
 
 -- =============================================
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -15,7 +15,7 @@
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxo where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, serialize)
+import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..), encodeListLen, serialize)
 import Cardano.Ledger.Address
   ( Addr (AddrBootstrap),
     bootstrapAddressAttrsSize,
@@ -500,4 +500,59 @@ instance
         12 -> do
           outs <- decodeList fromCBOR
           pure (2, OutputTooBigUTxO outs)
+        k -> invalidKey k
+
+instance
+  ( TransValue FromCBOR era,
+    Shelley.TransUTxO FromCBOR era,
+    Val.DecodeNonNegative (Core.Value era),
+    Show (Core.Value era),
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "PPUP" era)))
+  ) =>
+  FromCBOR (Annotator (UtxoPredicateFailure era))
+  where
+  fromCBOR =
+    decodeRecordSum "PredicateFailureUTXO" $
+      \case
+        0 -> do
+          ins <- decodeSet fromCBOR
+          pure (2, pure @Annotator $ BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
+        1 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, pure $ OutsideValidityIntervalUTxO a b)
+        2 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, pure $ MaxTxSizeUTxO a b)
+        3 -> pure (1, pure InputSetEmptyUTxO)
+        4 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, pure $ FeeTooSmallUTxO a b)
+        5 -> do
+          a <- fromCBOR
+          b <- fromCBOR
+          pure (3, pure $ ValueNotConservedUTxO a b)
+        6 -> do
+          outs <- decodeList fromCBOR
+          pure (2, pure $ OutputTooSmallUTxO outs)
+        7 -> do
+          a <- fromCBOR
+          pure (2, fmap UpdateFailure a)
+        8 -> do
+          right <- fromCBOR
+          wrongs <- decodeSet fromCBOR
+          pure (3, pure $ WrongNetwork right wrongs)
+        9 -> do
+          right <- fromCBOR
+          wrongs <- decodeSet fromCBOR
+          pure (3, pure $ WrongNetworkWithdrawal right wrongs)
+        10 -> do
+          outs <- decodeList fromCBOR
+          pure (2, pure $ OutputBootAddrAttrsTooBig outs)
+        11 -> pure (1, pure TriesToForgeADA)
+        12 -> do
+          outs <- decodeList fromCBOR
+          pure (2, pure $ OutputTooBigUTxO outs)
         k -> invalidKey k

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -15,7 +15,7 @@
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxo where
 
-import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..), encodeListLen, serialize)
+import Cardano.Binary (Annotator, Decoder, FromCBOR (..), ToCBOR (..), encodeListLen, serialize)
 import Cardano.Ledger.Address
   ( Addr (AddrBootstrap),
     bootstrapAddressAttrsSize,
@@ -77,6 +77,7 @@ import Data.Coders
     invalidKey,
   )
 import Data.Foldable (fold, toList)
+import Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -456,51 +457,7 @@ instance
   ) =>
   FromCBOR (UtxoPredicateFailure era)
   where
-  fromCBOR =
-    decodeRecordSum "PredicateFailureUTXO" $
-      \case
-        0 -> do
-          ins <- decodeSet fromCBOR
-          pure (2, BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
-        1 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, OutsideValidityIntervalUTxO a b)
-        2 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, MaxTxSizeUTxO a b)
-        3 -> pure (1, InputSetEmptyUTxO)
-        4 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, FeeTooSmallUTxO a b)
-        5 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, ValueNotConservedUTxO a b)
-        6 -> do
-          outs <- decodeList fromCBOR
-          pure (2, OutputTooSmallUTxO outs)
-        7 -> do
-          a <- fromCBOR
-          pure (2, UpdateFailure a)
-        8 -> do
-          right <- fromCBOR
-          wrongs <- decodeSet fromCBOR
-          pure (3, WrongNetwork right wrongs)
-        9 -> do
-          right <- fromCBOR
-          wrongs <- decodeSet fromCBOR
-          pure (3, WrongNetworkWithdrawal right wrongs)
-        10 -> do
-          outs <- decodeList fromCBOR
-          pure (2, OutputBootAddrAttrsTooBig outs)
-        11 -> pure (1, TriesToForgeADA)
-        12 -> do
-          outs <- decodeList fromCBOR
-          pure (2, OutputTooBigUTxO outs)
-        k -> invalidKey k
+  fromCBOR = runIdentity <$> decodeUtxoPredicateFailure
 
 instance
   ( TransValue FromCBOR era,
@@ -511,48 +468,56 @@ instance
   ) =>
   FromCBOR (Annotator (UtxoPredicateFailure era))
   where
-  fromCBOR =
-    decodeRecordSum "PredicateFailureUTXO" $
-      \case
-        0 -> do
-          ins <- decodeSet fromCBOR
-          pure (2, pure @Annotator $ BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
-        1 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, pure $ OutsideValidityIntervalUTxO a b)
-        2 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, pure $ MaxTxSizeUTxO a b)
-        3 -> pure (1, pure InputSetEmptyUTxO)
-        4 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, pure $ FeeTooSmallUTxO a b)
-        5 -> do
-          a <- fromCBOR
-          b <- fromCBOR
-          pure (3, pure $ ValueNotConservedUTxO a b)
-        6 -> do
-          outs <- decodeList fromCBOR
-          pure (2, pure $ OutputTooSmallUTxO outs)
-        7 -> do
-          a <- fromCBOR
-          pure (2, fmap UpdateFailure a)
-        8 -> do
-          right <- fromCBOR
-          wrongs <- decodeSet fromCBOR
-          pure (3, pure $ WrongNetwork right wrongs)
-        9 -> do
-          right <- fromCBOR
-          wrongs <- decodeSet fromCBOR
-          pure (3, pure $ WrongNetworkWithdrawal right wrongs)
-        10 -> do
-          outs <- decodeList fromCBOR
-          pure (2, pure $ OutputBootAddrAttrsTooBig outs)
-        11 -> pure (1, pure TriesToForgeADA)
-        12 -> do
-          outs <- decodeList fromCBOR
-          pure (2, pure $ OutputTooBigUTxO outs)
-        k -> invalidKey k
+  fromCBOR = decodeUtxoPredicateFailure
+
+decodeUtxoPredicateFailure ::
+  forall era f s.
+  ( TransValue FromCBOR era,
+    Shelley.TransUTxO FromCBOR era,
+    Applicative f,
+    FromCBOR (f (PredicateFailure (Core.EraRule "PPUP" era)))
+  ) =>
+  Decoder s (f (UtxoPredicateFailure era))
+decodeUtxoPredicateFailure = decodeRecordSum "PredicateFailureUTXO" $ \case
+  0 -> do
+    ins <- decodeSet fromCBOR
+    pure (2, pure @f $ BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
+  1 -> do
+    a <- fromCBOR
+    b <- fromCBOR
+    pure (3, pure $ OutsideValidityIntervalUTxO a b)
+  2 -> do
+    a <- fromCBOR
+    b <- fromCBOR
+    pure (3, pure $ MaxTxSizeUTxO a b)
+  3 -> pure (1, pure InputSetEmptyUTxO)
+  4 -> do
+    a <- fromCBOR
+    b <- fromCBOR
+    pure (3, pure $ FeeTooSmallUTxO a b)
+  5 -> do
+    a <- fromCBOR
+    b <- fromCBOR
+    pure (3, pure $ ValueNotConservedUTxO a b)
+  6 -> do
+    outs <- decodeList fromCBOR
+    pure (2, pure $ OutputTooSmallUTxO outs)
+  7 -> do
+    a <- fromCBOR
+    pure (2, fmap UpdateFailure a)
+  8 -> do
+    right <- fromCBOR
+    wrongs <- decodeSet fromCBOR
+    pure (3, pure $ WrongNetwork right wrongs)
+  9 -> do
+    right <- fromCBOR
+    wrongs <- decodeSet fromCBOR
+    pure (3, pure $ WrongNetworkWithdrawal right wrongs)
+  10 -> do
+    outs <- decodeList fromCBOR
+    pure (2, pure $ OutputBootAddrAttrsTooBig outs)
+  11 -> pure (1, pure TriesToForgeADA)
+  12 -> do
+    outs <- decodeList fromCBOR
+    pure (2, pure $ OutputTooBigUTxO outs)
+  k -> invalidKey k

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -87,7 +87,7 @@ allprops =
       testProperty "Metadata" $ propertyAnn @(Core.AuxiliaryData e),
       testProperty "Value" $ property @(Core.Value e),
       testProperty "Script" $ propertyAnn @(Core.Script e),
-      testProperty "ApplyTxError" $ property @(ApplyTxError e)
+      testProperty "ApplyTxError" $ propertyAnn @(ApplyTxError e)
     ]
 
 allEraRoundtripTests :: TestTree

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Shelley.Constraints
     UsesValue,
   )
 import Control.State.Transition (State)
+import Data.Coders (Annotator)
 import Data.Sharing (FromSharedCBOR, Interns, Share)
 
 class
@@ -49,8 +50,8 @@ class
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
     ChainData (State (Core.EraRule "PPUP" era)),
     SerialisableData (State (Core.EraRule "PPUP" era)),
-    Share (Core.TxOut era) ~ Interns (Credential 'Staking (Crypto era)),
-    FromSharedCBOR (Core.TxOut era)
+    Share (Annotator (Core.TxOut era)) ~ Interns (Credential 'Staking (Crypto era)),
+    FromSharedCBOR (Annotator (Core.TxOut era))
   ) =>
   ShelleyBasedEra era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.BHeaderView (BHeaderView)
 import Cardano.Ledger.BaseTypes (Globals (..), ShelleyBase)
 import Cardano.Ledger.Block (Block)
 import qualified Cardano.Ledger.Chain as STS
-import Cardano.Ledger.Core (ChainData, SerialisableData)
+import Cardano.Ledger.Core (AnnotatedData, ChainData)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, TxSeq)
@@ -55,7 +55,7 @@ import NoThunks.Class (NoThunks (..))
 
 class
   ( ChainData (NewEpochState era),
-    SerialisableData (NewEpochState era),
+    AnnotatedData (NewEpochState era),
     ChainData (BlockTransitionError era),
     ChainData (STS.ChainPredicateFailure era),
     STS (Core.EraRule "TICK" era),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -6,7 +6,6 @@
 
 module Cardano.Ledger.Shelley.Constraints where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import Cardano.Ledger.Compactible (Compactible (..))
@@ -57,8 +56,7 @@ class
 class
   ( Era era,
     ChainData (TxOut era),
-    ToCBOR (TxOut era),
-    FromCBOR (TxOut era),
+    AnnotatedData (TxOut era),
     HasField "address" (TxOut era) (Addr (Crypto era)),
     HasField "compactAddress" (TxOut era) (CompactAddr (Crypto era)),
     HasField "value" (TxOut era) (Value era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -531,7 +531,6 @@ decodeEpochState ::
   ( FromCBOR (Core.PParams era),
     TransValue FromCBOR era,
     FromSharedCBOR (f (LedgerState era)),
-    -- Share (f (Core.TxOut era)) ~ Interns (Credential 'Staking (Crypto era)),
     Share (f (LedgerState era)) ~ (Interns (Credential 'Staking (Crypto era)), Interns (KeyHash 'StakePool (Crypto era))),
     Applicative f
   ) =>
@@ -706,7 +705,7 @@ instance
   where
   type
     Share (Annotator (UTxOState era)) =
-      Interns (Credential 'Staking (Crypto era))
+      Share (UTxOState era)
   fromSharedCBOR = decodeUTxOState
 
 decodeUTxOState ::
@@ -872,9 +871,7 @@ instance
   ) =>
   FromSharedCBOR (Annotator (LedgerState era))
   where
-  type
-    Share (Annotator (LedgerState era)) =
-      (Interns (Credential 'Staking (Crypto era)), Interns (KeyHash 'StakePool (Crypto era)))
+  type Share (Annotator (LedgerState era)) = Share (LedgerState era)
   fromSharedPlusCBOR = decodeLedgerState
 
 decodeLedgerState ::

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -71,6 +71,7 @@ import Cardano.Ledger.Slot
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, range, setSingleton, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import Control.State.Transition
+import Data.Coders (Annotator)
 import Data.Foldable (fold)
 import Data.Group (Group (..))
 import qualified Data.Map.Strict as Map
@@ -245,6 +246,12 @@ instance
       14 -> do
         pure (1, MIRProducesNegativeUpdate)
       k -> invalidKey k
+
+instance
+  (Era era, Typeable (Core.Script era)) =>
+  FromCBOR (Annotator (DelegPredicateFailure era))
+  where
+  fromCBOR = pure <$> fromCBOR
 
 delegationTransition ::
   ( Typeable era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -22,7 +22,8 @@ module Cardano.Ledger.Shelley.Rules.Delpl
 where
 
 import Cardano.Binary
-  ( FromCBOR (..),
+  ( Annotator,
+    FromCBOR (..),
     ToCBOR (..),
     encodeListLen,
   )
@@ -147,6 +148,27 @@ instance
           1 -> do
             a <- fromCBOR
             pure (2, DelegFailure a)
+          k -> invalidKey k
+      )
+
+instance
+  ( Era era,
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "POOL" era))),
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "DELEG" era))),
+    Typeable (Core.Script era)
+  ) =>
+  FromCBOR (Annotator (DelplPredicateFailure era))
+  where
+  fromCBOR =
+    decodeRecordSum
+      "PredicateFailure (DELPL era)"
+      ( \case
+          0 -> do
+            a <- fromCBOR
+            pure (2, fmap PoolFailure a)
+          1 -> do
+            a <- fromCBOR
+            pure (2, fmap DelegFailure a)
           k -> invalidKey k
       )
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -49,6 +49,7 @@ import Control.State.Transition
     judgmentContext,
     trans,
   )
+import Data.Coders (Annotator)
 import Data.Default.Class (Default)
 import Data.Foldable (toList)
 import Data.Sequence (Seq)
@@ -103,6 +104,14 @@ instance
   FromCBOR (LedgersPredicateFailure era)
   where
   fromCBOR = LedgerFailure <$> fromCBOR
+
+instance
+  ( Era era,
+    FromCBOR (Annotator (PredicateFailure (Core.EraRule "LEDGER" era)))
+  ) =>
+  FromCBOR (Annotator (LedgersPredicateFailure era))
+  where
+  fromCBOR = fmap LedgerFailure <$> fromCBOR
 
 instance
   ( Era era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -58,6 +58,7 @@ import Control.State.Transition
     (?!),
   )
 import qualified Data.ByteString as BS
+import Data.Coders (Annotator)
 import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import Data.Word (Word64, Word8)
@@ -170,6 +171,12 @@ instance
         s <- fromCBOR
         pure (3, PoolMedataHashTooBig poolID s)
       k -> invalidKey k
+
+instance
+  (Era era) =>
+  FromCBOR (Annotator (PoolPredicateFailure era))
+  where
+  fromCBOR = pure <$> fromCBOR
 
 poolDelegationTransition ::
   forall era.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Slot
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, (⊆), (⨃))
 import Control.State.Transition
+import Data.Coders (Annotator)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Data.Typeable (Typeable)
@@ -113,6 +114,12 @@ instance
     PPUpdateWrongEpoch ce e vp ->
       encodeListLen 4 <> toCBOR (1 :: Word8) <> toCBOR ce <> toCBOR e <> toCBOR vp
     PVCannotFollowPPUP p -> encodeListLen 2 <> toCBOR (2 :: Word8) <> toCBOR p
+
+instance
+  (Era era) =>
+  FromCBOR (Annotator (PpupPredicateFailure era))
+  where
+  fromCBOR = pure <$> fromCBOR
 
 instance
   (Era era) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -107,6 +107,7 @@ import Control.State.Transition
     wrapFailed,
     (?!),
   )
+import Data.Coders (Annotator)
 import Data.Foldable (foldl', toList)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -226,6 +227,17 @@ instance
     OutputBootAddrAttrsTooBig outs ->
       encodeListLen 2 <> toCBOR (10 :: Word8)
         <> encodeFoldable outs
+
+instance
+  ( TransValue FromCBOR era,
+    TransUTxO FromCBOR era,
+    Val.DecodeNonNegative (Core.Value era),
+    Show (Core.Value era),
+    FromCBOR (PredicateFailure (Core.EraRule "PPUP" era))
+  ) =>
+  FromCBOR (Annotator (UtxoPredicateFailure era))
+  where
+  fromCBOR = pure <$> fromCBOR
 
 instance
   ( TransValue FromCBOR era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -26,7 +26,8 @@ module Cardano.Ledger.Shelley.Rules.Utxow
 where
 
 import Cardano.Binary
-  ( FromCBOR (..),
+  ( Decoder,
+    FromCBOR (..),
     ToCBOR (..),
     encodeListLen,
   )
@@ -102,6 +103,7 @@ import Control.State.Transition
     (?!:),
   )
 import Data.Coders (Annotator)
+import Data.Functor.Identity (Identity (runIdentity))
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq (filter)
 import Data.Sequence.Strict (StrictSeq)
@@ -209,41 +211,50 @@ instance
   ) =>
   FromCBOR (Annotator (UtxowPredicateFailure era))
   where
-  fromCBOR = decodeRecordSum "PredicateFailure (UTXOW era)" $
-    \case
-      0 -> do
-        wits <- decodeList fromCBOR
-        pure (2, pure @Annotator $ InvalidWitnessesUTXOW wits)
-      1 -> do
-        missing <- decodeSet fromCBOR
-        pure (2, pure $ MissingVKeyWitnessesUTXOW $ WitHashes missing)
-      2 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, pure $ MissingScriptWitnessesUTXOW ss)
-      3 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, pure $ ScriptWitnessNotValidatingUTXOW ss)
-      4 -> do
-        a <- fromCBOR
-        pure (2, fmap UtxoFailure a)
-      5 -> do
-        s <- decodeSet fromCBOR
-        pure (2, pure $ MIRInsufficientGenesisSigsUTXOW s)
-      6 -> do
-        h <- fromCBOR
-        pure (2, pure $ MissingTxBodyMetadataHash h)
-      7 -> do
-        h <- fromCBOR
-        pure (2, pure $ MissingTxMetadata h)
-      8 -> do
-        bodyHash <- fromCBOR
-        fullMDHash <- fromCBOR
-        pure (3, pure $ ConflictingMetadataHash bodyHash fullMDHash)
-      9 -> pure (1, pure InvalidMetadata)
-      10 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, pure $ ExtraneousScriptWitnessesUTXOW ss)
-      k -> invalidKey k
+  fromCBOR = decodePredFail
+
+decodePredFail ::
+  forall era f s.
+  ( Era era,
+    FromCBOR (f (PredicateFailure (Core.EraRule "UTXO" era))),
+    Applicative f
+  ) =>
+  Decoder s (f (UtxowPredicateFailure era))
+decodePredFail = decodeRecordSum "PredicateFailure (UTXOW era)" $
+  \case
+    0 -> do
+      wits <- decodeList fromCBOR
+      pure (2, pure @f $ InvalidWitnessesUTXOW wits)
+    1 -> do
+      missing <- decodeSet fromCBOR
+      pure (2, pure $ MissingVKeyWitnessesUTXOW $ WitHashes missing)
+    2 -> do
+      ss <- decodeSet fromCBOR
+      pure (2, pure $ MissingScriptWitnessesUTXOW ss)
+    3 -> do
+      ss <- decodeSet fromCBOR
+      pure (2, pure $ ScriptWitnessNotValidatingUTXOW ss)
+    4 -> do
+      a <- fromCBOR
+      pure (2, fmap UtxoFailure a)
+    5 -> do
+      s <- decodeSet fromCBOR
+      pure (2, pure $ MIRInsufficientGenesisSigsUTXOW s)
+    6 -> do
+      h <- fromCBOR
+      pure (2, pure $ MissingTxBodyMetadataHash h)
+    7 -> do
+      h <- fromCBOR
+      pure (2, pure $ MissingTxMetadata h)
+    8 -> do
+      bodyHash <- fromCBOR
+      fullMDHash <- fromCBOR
+      pure (3, pure $ ConflictingMetadataHash bodyHash fullMDHash)
+    9 -> pure (1, pure InvalidMetadata)
+    10 -> do
+      ss <- decodeSet fromCBOR
+      pure (2, pure $ ExtraneousScriptWitnessesUTXOW ss)
+    k -> invalidKey k
 
 instance
   ( Era era,
@@ -253,41 +264,7 @@ instance
   ) =>
   FromCBOR (UtxowPredicateFailure era)
   where
-  fromCBOR = decodeRecordSum "PredicateFailure (UTXOW era)" $
-    \case
-      0 -> do
-        wits <- decodeList fromCBOR
-        pure (2, InvalidWitnessesUTXOW wits)
-      1 -> do
-        missing <- decodeSet fromCBOR
-        pure (2, MissingVKeyWitnessesUTXOW $ WitHashes missing)
-      2 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, MissingScriptWitnessesUTXOW ss)
-      3 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, ScriptWitnessNotValidatingUTXOW ss)
-      4 -> do
-        a <- fromCBOR
-        pure (2, UtxoFailure a)
-      5 -> do
-        s <- decodeSet fromCBOR
-        pure (2, MIRInsufficientGenesisSigsUTXOW s)
-      6 -> do
-        h <- fromCBOR
-        pure (2, MissingTxBodyMetadataHash h)
-      7 -> do
-        h <- fromCBOR
-        pure (2, MissingTxMetadata h)
-      8 -> do
-        bodyHash <- fromCBOR
-        fullMDHash <- fromCBOR
-        pure (3, ConflictingMetadataHash bodyHash fullMDHash)
-      9 -> pure (1, InvalidMetadata)
-      10 -> do
-        ss <- decodeSet fromCBOR
-        pure (2, ExtraneousScriptWitnessesUTXOW ss)
-      k -> invalidKey k
+  fromCBOR = runIdentity <$> decodePredFail
 
 -- =================================================
 --  State Transition System Instances

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -1017,6 +1017,19 @@ instance
   where
   fromCBOR = fromNotSharedCBOR
 
+instance
+  (Era era, TransTxOut DecodeNonNegative era, Show (Core.Value era)) =>
+  FromCBOR (Annotator (TxOut era))
+  where
+  fromCBOR = pure <$> fromCBOR
+
+instance
+  (Era era, TransTxOut DecodeNonNegative era, Show (Core.Value era)) =>
+  FromSharedCBOR (Annotator (TxOut era))
+  where
+  type Share (Annotator (TxOut era)) = Share (TxOut era)
+  fromSharedCBOR x = pure <$> fromSharedCBOR x
+
 -- This instance does not do any sharing and is isomorphic to FromCBOR
 -- use the weakest constraint necessary
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -40,7 +40,7 @@ module Cardano.Ledger.Shelley.UTxO
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary (Annotator (..), FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Crypto.Hash as CH
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe, strictMaybeToMaybe)
@@ -149,6 +149,20 @@ deriving newtype instance
 
 instance
   ( CC.Crypto (Crypto era),
+    FromSharedCBOR (Annotator (Core.TxOut era)),
+    Share (Annotator (Core.TxOut era)) ~ Interns (Credential 'Staking (Crypto era))
+  ) =>
+  FromSharedCBOR (Annotator (UTxO era))
+  where
+  type
+    Share (Annotator (UTxO era)) =
+      Interns (Credential 'Staking (Crypto era))
+  fromSharedCBOR credsInterns = do
+    !theMap <- decodeMap fromCBOR (fromSharedCBOR credsInterns)
+    pure $ UTxO <$!> (sequenceA theMap)
+
+instance
+  ( CC.Crypto (Crypto era),
     FromSharedCBOR (Core.TxOut era),
     Share (Core.TxOut era) ~ Interns (Credential 'Staking (Crypto era))
   ) =>
@@ -159,6 +173,17 @@ instance
       Interns (Credential 'Staking (Crypto era))
   fromSharedCBOR credsInterns =
     UTxO <$!> decodeMap fromCBOR (fromSharedCBOR credsInterns)
+
+instance
+  ( CC.Crypto (Crypto era),
+    Typeable era,
+    FromCBOR (Annotator (Core.TxOut era))
+  ) =>
+  FromCBOR (Annotator (UTxO era))
+  where
+  fromCBOR = do
+    !theMap <- decodeMap fromCBOR fromCBOR
+    pure $ UTxO <$!> (sequenceA theMap)
 
 deriving via
   Quiet (UTxO era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -156,7 +156,7 @@ instance
   where
   type
     Share (Annotator (UTxO era)) =
-      Interns (Credential 'Staking (Crypto era))
+      Share (UTxO era)
   fromSharedCBOR credsInterns = do
     !theMap <- decodeMap fromCBOR (fromSharedCBOR credsInterns)
     pure $ UTxO <$!> (sequenceA theMap)

--- a/hie.yaml
+++ b/hie.yaml
@@ -63,6 +63,9 @@ cradle:
     - path: "libs/small-steps/src"
       component: "lib:small-steps"
 
+    - path: "libs/cardano-data/src"
+      component: "lib:cardano-data"
+
     - path: "libs/small-steps/src"
       component: "lib:small-steps-test"
 

--- a/libs/cardano-data/src/Data/Coders.hs
+++ b/libs/cardano-data/src/Data/Coders.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
@@ -20,6 +21,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | MemoBytes is an abstration for a datetype that encodes its own seriialization.
 --   The idea is to use a newtype around a MemoBytes non-memoizing version.
@@ -139,6 +141,7 @@ import Control.Monad.Trans.Identity
 import qualified Data.Compact.VMap as VMap
 import Data.Foldable (foldl')
 import Data.Functor.Compose (Compose (..))
+import Data.Functor.Identity (Identity (..))
 import qualified Data.Map as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -230,8 +233,8 @@ unusedRequiredKeys used required name =
 decodeList :: Decoder s a -> Decoder s [a]
 decodeList = decodeCollection decodeListLenOrIndef
 
-decodeAnnList :: Decoder s (Annotator t) -> Decoder s (Annotator [t])
-decodeAnnList dec = do xs <- decodeList dec; pure (sequence xs)
+decodeAnnList :: Applicative f => Decoder s (f t) -> Decoder s (f [t])
+decodeAnnList dec = do xs <- decodeList dec; pure (sequenceA xs)
 
 decodeSeq :: Decoder s a -> Decoder s (Seq a)
 decodeSeq decoder = Seq.fromList <$> decodeList decoder
@@ -239,14 +242,14 @@ decodeSeq decoder = Seq.fromList <$> decodeList decoder
 decodeStrictSeq :: Decoder s a -> Decoder s (StrictSeq a)
 decodeStrictSeq decoder = StrictSeq.fromList <$> decodeList decoder
 
-decodeAnnStrictSeq :: Decoder s (Annotator a) -> Decoder s (Annotator (StrictSeq a))
-decodeAnnStrictSeq dec = do xs <- decodeList dec; pure (StrictSeq.fromList <$> (sequence xs))
+decodeAnnStrictSeq :: Applicative f => Decoder s (f a) -> Decoder s (f (StrictSeq a))
+decodeAnnStrictSeq dec = do xs <- decodeList dec; pure (StrictSeq.fromList <$> (sequenceA xs))
 
 decodeSet :: Ord a => Decoder s a -> Decoder s (Set a)
 decodeSet decoder = Set.fromList <$> decodeList decoder
 
-decodeAnnSet :: Ord t => Decoder s (Annotator t) -> Decoder s (Annotator (Set t))
-decodeAnnSet dec = do xs <- decodeList dec; pure (Set.fromList <$> (sequence xs))
+decodeAnnSet :: (Ord t, Applicative f) => Decoder s (f t) -> Decoder s (f (Set t))
+decodeAnnSet dec = do xs <- decodeList dec; pure (Set.fromList <$> (sequenceA xs))
 
 decodeCollection :: Decoder s (Maybe Int) -> Decoder s a -> Decoder s [a]
 decodeCollection lenOrIndef el = snd <$> decodeCollectionWithLen lenOrIndef el
@@ -278,7 +281,7 @@ encodeFoldableAsDefinite f = encodeFoldableEncoderAs wrapArray toCBOR f
   where
     wrapArray len contents = encodeListLen len <> contents
 
--- Encodes a sequence of pairs as a cbor map
+-- Encodes a sequenceA of pairs as a cbor map
 encodeFoldableMapPairs :: (ToCBOR a, ToCBOR b, Foldable f) => f (a, b) -> Encoding
 encodeFoldableMapPairs = encodeFoldableEncoderAs wrapCBORMap $
   \(a, b) -> toCBOR a <> toCBOR b
@@ -586,9 +589,9 @@ data Decode (w :: Wrapped) t where
   DD :: Dual t -> Decode ('Closed 'Dense) t
   TagD :: Word -> Decode ('Closed x) t -> Decode ('Closed x) t
   Emit :: t -> Decode w t
-  -- The next two could be generalized to any (Applicative f) rather than Annotator
-  Ann :: Decode w t -> Decode w (Annotator t)
-  ApplyAnn :: Decode w1 (Annotator (a -> t)) -> Decode ('Closed d) (Annotator a) -> Decode w1 (Annotator t)
+  -- 'f' is usually 'Annotator' or 'Identity'
+  Ann :: Applicative f => Decode w t -> Decode w (f t)
+  ApplyAnn :: Applicative f => Decode w1 (f (a -> t)) -> Decode ('Closed d) (f a) -> Decode w1 (f t)
   -- A function to Either can raise an error when applied by returning (Left errorMessage)
   ApplyErr :: Decode w1 (a -> Either String t) -> Decode ('Closed d) a -> Decode w1 t
 
@@ -601,7 +604,7 @@ infixl 4 <?
 (<!) :: Decode w1 (a -> t) -> Decode ('Closed w) a -> Decode w1 t
 x <! y = ApplyD x y
 
-(<*!) :: Decode w1 (Annotator (a -> t)) -> Decode ('Closed d) (Annotator a) -> Decode w1 (Annotator t)
+(<*!) :: Applicative f => Decode w1 (f (a -> t)) -> Decode ('Closed d) (f a) -> Decode w1 (f t)
 x <*! y = ApplyAnn x y
 
 (<?) :: Decode w1 (a -> Either String t) -> Decode ('Closed d) a -> Decode w1 t
@@ -625,12 +628,15 @@ hsize (Ann x) = hsize x
 hsize (ApplyAnn f x) = hsize f + hsize x
 hsize (ApplyErr f x) = hsize f + hsize x
 
+{-# INLINE decode #-}
 decode :: Decode w t -> Decoder s t
 decode x = fmap snd (decodE x)
 
+{-# INLINE decodE #-}
 decodE :: Decode w t -> Decoder s (Int, t)
 decodE x = decodeCount x 0
 
+{-# INLINE decodeCount #-}
 decodeCount :: forall (w :: Wrapped) s t. Decode w t -> Int -> Decoder s (Int, t)
 decodeCount (Summands nm f) n = (n + 1,) <$> decodeRecordSum nm (\x -> decodE (f x))
 decodeCount (SumD cn) n = pure (n + 1, cn)
@@ -665,6 +671,7 @@ decodeCount (ApplyErr cn g) n = do
 
 -- The type of DecodeClosed precludes pattern match against (SumD c) as the types are different.
 
+{-# INLINE decodeClosed #-}
 decodeClosed :: Decode ('Closed d) t -> Decoder s t
 decodeClosed (Summands nm f) = decodeRecordSum nm (\x -> decodE (f x))
 decodeClosed (KeyedD cn) = pure cn
@@ -696,6 +703,7 @@ decodeClosed (ApplyErr cn g) = do
     Right z -> pure z
     Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack $ message)
 
+{-# INLINE decodeSparse #-}
 decodeSparse ::
   Typeable a =>
   String ->
@@ -865,20 +873,20 @@ listDecode = D (decodeList fromCBOR)
 --                                             ^^^^^^^^
 -- One can always lift x::(Decode w T) by using Ann. so (Ann x)::(Decode w (Annotator T)).
 
-pairDecodeA :: Decode ('Closed 'Dense) (Annotator x) -> Decode ('Closed 'Dense) (Annotator y) -> Decode ('Closed 'Dense) (Annotator (x, y))
+pairDecodeA :: Applicative f => Decode ('Closed 'Dense) (f x) -> Decode ('Closed 'Dense) (f y) -> Decode ('Closed 'Dense) (f (x, y))
 pairDecodeA x y = D (do (xA, yA) <- decodePair (decode x) (decode y); pure (do x' <- xA; y' <- yA; pure (x', y')))
 
-listDecodeA :: Decode ('Closed 'Dense) (Annotator x) -> Decode ('Closed 'Dense) (Annotator [x])
-listDecodeA dx = D (do listXA <- decodeList (decode dx); pure (sequence listXA))
+listDecodeA :: Applicative f => Decode ('Closed 'Dense) (f x) -> Decode ('Closed 'Dense) (f [x])
+listDecodeA dx = D (do listXA <- decodeList (decode dx); pure (sequenceA listXA))
 
-setDecodeA :: Ord x => Decode ('Closed 'Dense) (Annotator x) -> Decode ('Closed 'Dense) (Annotator (Set x))
+setDecodeA :: (Ord x, Applicative f) => Decode ('Closed 'Dense) (f x) -> Decode ('Closed 'Dense) (f (Set x))
 setDecodeA dx = D (decodeAnnSet (decode dx))
 
 mapDecodeA ::
-  Ord k =>
-  Decode ('Closed 'Dense) (Annotator k) ->
-  Decode ('Closed 'Dense) (Annotator v) ->
-  Decode ('Closed 'Dense) (Annotator (Map.Map k v))
+  (Ord k, Applicative f) =>
+  Decode ('Closed 'Dense) (f k) ->
+  Decode ('Closed 'Dense) (f v) ->
+  Decode ('Closed 'Dense) (f (Map.Map k v))
 mapDecodeA k v = D (decodeMapTraverse (decode k) (decode v))
 
 -- ==================================================================
@@ -914,3 +922,7 @@ assertTag tag = do
 -- | Convert a @Buildable@ error into a 'cborg' decoder error
 cborError :: Buildable e => e -> Decoder s a
 cborError = fail . formatToString build
+
+-- Orphan
+instance FromCBOR a => FromCBOR (Identity a) where
+  fromCBOR = Identity <$> fromCBOR

--- a/libs/cardano-data/src/Data/Coders.hs
+++ b/libs/cardano-data/src/Data/Coders.hs
@@ -45,9 +45,11 @@ module Data.Coders
     decode,
     runE, -- Used in testing
     decodeList,
+    decodeAnnList,
     decodePair,
     decodeSeq,
     decodeStrictSeq,
+    decodeAnnStrictSeq,
     decodeSet,
     decodeAnnSet,
     decodeRecordNamed,
@@ -228,11 +230,17 @@ unusedRequiredKeys used required name =
 decodeList :: Decoder s a -> Decoder s [a]
 decodeList = decodeCollection decodeListLenOrIndef
 
+decodeAnnList :: Decoder s (Annotator t) -> Decoder s (Annotator [t])
+decodeAnnList dec = do xs <- decodeList dec; pure (sequence xs)
+
 decodeSeq :: Decoder s a -> Decoder s (Seq a)
 decodeSeq decoder = Seq.fromList <$> decodeList decoder
 
 decodeStrictSeq :: Decoder s a -> Decoder s (StrictSeq a)
 decodeStrictSeq decoder = StrictSeq.fromList <$> decodeList decoder
+
+decodeAnnStrictSeq :: Decoder s (Annotator a) -> Decoder s (Annotator (StrictSeq a))
+decodeAnnStrictSeq dec = do xs <- decodeList dec; pure (StrictSeq.fromList <$> (sequence xs))
 
 decodeSet :: Ord a => Decoder s a -> Decoder s (Set a)
 decodeSet decoder = Set.fromList <$> decodeList decoder

--- a/libs/cardano-data/src/Data/Sharing.hs
+++ b/libs/cardano-data/src/Data/Sharing.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -9,6 +10,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -35,6 +37,7 @@ import Data.Coders (decodeMap, decodeVMap, invalidKey)
 import Data.Compact.VMap (VB, VMap, VP)
 import qualified Data.Compact.VMap as VMap
 import qualified Data.Foldable as F
+import Data.Functor.Identity
 import Data.Kind
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict.Internal
@@ -181,6 +184,8 @@ fromSharedPlusLensCBOR l = do
 -- | Use `FromSharedCBOR` class while ignoring sharing
 fromNotSharedCBOR :: FromSharedCBOR a => Decoder s a
 fromNotSharedCBOR = fromSharedCBOR mempty
+
+deriving newtype instance FromSharedCBOR a => FromSharedCBOR (Identity a)
 
 instance (Ord k, FromCBOR k, FromCBOR v) => FromSharedCBOR (Map k v) where
   type Share (Map k v) = (Interns k, Interns v)

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -38,6 +39,7 @@ import Data.Functor
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import Data.Typeable
 import Numeric.Natural
 import Prettyprinter
@@ -49,14 +51,20 @@ type CurrentEra = AlonzoEra C
 
 --- Loading
 readNewEpochState :: FilePath -> IO (NewEpochState CurrentEra)
-readNewEpochState = readFromCBOR
+readNewEpochState = readFromCBORA
 
 readEpochState :: FilePath -> IO (EpochState CurrentEra)
-readEpochState = readFromCBOR
+readEpochState = readFromCBORA
 
 readFromCBOR :: FromCBOR a => FilePath -> IO a
 readFromCBOR fp =
   LBS.readFile fp <&> decodeFull >>= \case
+    Left exc -> throwIO exc
+    Right res -> pure res
+
+readFromCBORA :: FromCBOR (Annotator a) => FilePath -> IO a
+readFromCBORA fp = do
+  LBS.readFile fp <&> decodeAnnotator (T.pack fp) fromCBOR >>= \case
     Left exc -> throwIO exc
     Right res -> pure res
 


### PR DESCRIPTION
required for https://github.com/input-output-hk/cardano-ledger/pull/2560

babbage's `TxOut` will only be an instance of `FromCBOR (Annotator TxOut)`, so this pr adds instances for `FromCBOR (Annotator..` as it bubbles up from `TxOut` and `FromCBOR` constraints where necessary in code that's reused in babbage