### PR TITLE
Minor improvements to cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -90,8 +90,7 @@ source-repository-package
 -- when decoding invalid (e.g. malicious) text literals.
 source-repository-package
   type: git
-  -- location: https://github.com/Quid2/flat.git
-  location: https://github.com/michaelpj/flat.git
+  location: https://github.com/Quid2/flat.git
   tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
   --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm
 
@@ -141,15 +140,6 @@ package cardano-ledger-shelley-ma
   ghc-options: -Werror
 
 package cardano-ledger-shelley-ma-test
-  ghc-options: -Werror
-
-package shelley-spec-non-integral
-  ghc-options: -Werror
-
-package shelley-spec-ledger
-  ghc-options: -Werror
-
-package shelley-spec-ledger-test
   ghc-options: -Werror
 
 package cardano-ledger-shelley


### PR DESCRIPTION
Minor things I found while bumping dependencies elsewhere:
- Point flat back to its original repository (bug fix merged).
- Remove GHC options on removed packages.