### PR TITLE
remove vague sentence from Shelley spec prose

### DIFF
--- a/eras/shelley/formal-spec/utxo.tex
+++ b/eras/shelley/formal-spec/utxo.tex
@@ -15,9 +15,7 @@ The preservation of value is expressed as an equality that uses values in
 the ledger state and the environment, as well as the values in the body of
 the signal transaction.
 We have defined the rules of the delegation protocol in a way that should
-consistently satisfy the preservation of value. In the future, we hope to
-give a formally-verified proof that every \textit{valid} ledger state satisfies
-this property.
+consistently satisfy the preservation of value.
 
 In this section, we discuss the relevant accounting that needs to be done
 as a result of processing a transaction, i.e.~the deposits for all certificates,


### PR DESCRIPTION
Very small PR to remove a vague and unneeded sentence from the prose of the Shelley ledger specification.

closes #1732