### PR TITLE
Make header in `Block` a fully saturated type.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -134,7 +134,7 @@ bbodyTransition ::
   forall (someBBODY :: Type -> Type) era.
   ( -- Conditions that the Abstract someBBODY must meet
     STS (someBBODY era),
-    Signal (someBBODY era) ~ (Block BHeaderView era),
+    Signal (someBBODY era) ~ (Block (BHeaderView (Crypto era)) era),
     PredicateFailure (someBBODY era) ~ AlonzoBbodyPredFail era,
     BaseM (someBBODY era) ~ ShelleyBase,
     State (someBBODY era) ~ BbodyState era,
@@ -232,7 +232,7 @@ instance
 
   type
     Signal (AlonzoBBODY era) =
-      (Block BHeaderView era)
+      (Block (BHeaderView (Crypto era)) era)
 
   type Environment (AlonzoBBODY era) = BbodyEnv era
 

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -100,5 +100,5 @@ tests =
       testProperty "alonzo/Tx" $
         trippingAnn @(LTX.Tx (AlonzoEra C_Crypto)),
       testProperty "alonzo/Block" $
-        trippingAnn @(Block BHeader (AlonzoEra C_Crypto))
+        trippingAnn @(Block (BHeader C_Crypto) (AlonzoEra C_Crypto))
     ]

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -244,7 +244,7 @@ ledgerEnv = LedgerEnv (SlotNo 0) 0 def (AccountState (Coin 0) (Coin 0))
 genAlonzoTx :: Gen (Core.Tx A)
 genAlonzoTx = genstuff ap (\genv _cs _nep _ep _ls _pp utxo dp _d _p -> genTx genv ledgerEnv (utxo, dp))
 
-genAlonzoBlock :: Gen (Block BHeader A)
+genAlonzoBlock :: Gen (Block (BHeader TestCrypto) A)
 genAlonzoBlock = genstuff ap (\genv cs _nep _ep _ls _pp _utxo _dp _d _p -> genBlock genv cs)
 
 genShelleyTx :: Gen (Core.Tx (ShelleyEra TestCrypto))
@@ -253,7 +253,7 @@ genShelleyTx =
     (Proxy @(ShelleyEra TestCrypto))
     (\genv _cs _nep _ep _ls _pp utxo dp _d _p -> genTx genv ledgerEnv (utxo, dp))
 
-genShelleyBlock :: Gen (Block BHeader (ShelleyEra TestCrypto))
+genShelleyBlock :: Gen (Block (BHeader TestCrypto) (ShelleyEra TestCrypto))
 genShelleyBlock = genstuff (Proxy @(ShelleyEra TestCrypto)) (\genv cs _nep _ep _ls _pp _utxo _dp _d _p -> genBlock genv cs)
 
 -- ==================================================================================================

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -67,7 +67,7 @@ class
     BaseM (Core.EraRule "BBODY" era) ~ ShelleyBase,
     Environment (Core.EraRule "BBODY" era) ~ STS.BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ STS.BbodyState era,
-    Signal (Core.EraRule "BBODY" era) ~ (Block BHeaderView era),
+    Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     ToCBORGroup (TxSeq era)
   ) =>
   ApplyBlock era
@@ -104,7 +104,7 @@ class
     ApplySTSOpts ep ->
     Globals ->
     NewEpochState era ->
-    (Block BHeaderView era) ->
+    Block (BHeaderView (Crypto era)) era ->
     m (EventReturnType ep (Core.EraRule "BBODY" era) (NewEpochState era))
   default applyBlockOpts ::
     forall ep m.
@@ -112,7 +112,7 @@ class
     ApplySTSOpts ep ->
     Globals ->
     NewEpochState era ->
-    (Block BHeaderView era) ->
+    Block (BHeaderView (Crypto era)) era ->
     m (EventReturnType ep (Core.EraRule "BBODY" era) (NewEpochState era))
   applyBlockOpts opts globals state blk =
     liftEither
@@ -141,12 +141,12 @@ class
   reapplyBlock ::
     Globals ->
     NewEpochState era ->
-    (Block BHeaderView era) ->
+    Block (BHeaderView (Crypto era)) era ->
     NewEpochState era
   default reapplyBlock ::
     Globals ->
     NewEpochState era ->
-    (Block BHeaderView era) ->
+    Block (BHeaderView (Crypto era)) era ->
     NewEpochState era
   reapplyBlock globals state blk =
     updateNewEpochState state res
@@ -179,7 +179,7 @@ applyBlock ::
   ) =>
   Globals ->
   NewEpochState era ->
-  (Block BHeaderView era) ->
+  Block (BHeaderView (Crypto era)) era ->
   m (NewEpochState era)
 applyBlock =
   applyBlockOpts $
@@ -207,7 +207,7 @@ chainChecks ::
   STS.ChainChecksPParams ->
   BHeaderView (Crypto era) ->
   m ()
-chainChecks globals ccd bh = STS.chainChecks (maxMajorPV globals) ccd bh
+chainChecks globals = STS.chainChecks (maxMajorPV globals)
 
 {-------------------------------------------------------------------------------
   Applying blocks

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -125,7 +125,7 @@ instance
 
   type
     Signal (BBODY era) =
-      Block BHeaderView era
+      Block (BHeaderView (Crypto era)) era
 
   type Environment (BBODY era) = BbodyEnv era
 

--- a/eras/shelley/test-suite/bench/BenchValidation.hs
+++ b/eras/shelley/test-suite/bench/BenchValidation.hs
@@ -69,7 +69,7 @@ import Test.Cardano.Ledger.Shelley.Rules.Chain (ChainState (..))
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.Cardano.Ledger.Shelley.Utils (ShelleyTest, testGlobals)
 
-data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block BHeader era)
+data ValidateInput era = ValidateInput Globals (NewEpochState era) (Block (BHeader (Crypto era)) era)
 
 sizes :: ValidateInput era -> String
 sizes (ValidateInput _gs ss _blk) = "blockMap size=" ++ show (Map.size (unBlocksMade (nesBcur ss)))

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
@@ -99,7 +99,7 @@ genBlock ::
   ) =>
   GenEnv era ->
   ChainState era ->
-  IO (Block BHeader era)
+  IO (Block (BHeader (Crypto era)) era)
 genBlock ge cs = generate $ GenBlock.genBlock ge cs
 
 -- The order one does this is important, since all these things must flow from the same

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Era
+import qualified Cardano.Ledger.Era as Era (Crypto)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.PoolDistr
 import Cardano.Ledger.SafeHash
@@ -80,7 +81,7 @@ data ShelleyResultExamples era = ShelleyResultExamples
   }
 
 data ShelleyLedgerExamples era = ShelleyLedgerExamples
-  { sleBlock :: Block BHeader era,
+  { sleBlock :: Block (BHeader (Era.Crypto era)) era,
     sleHashHeader :: HashHeader (Cardano.Ledger.Era.Crypto era),
     sleTx :: Core.Tx era,
     sleApplyTxError :: ApplyTxError era,
@@ -163,7 +164,7 @@ exampleShelleyLedgerBlock ::
   forall era.
   ShelleyBasedEra' era =>
   Core.Tx era ->
-  Block BHeader era
+  Block (BHeader (Era.Crypto era)) era
 exampleShelleyLedgerBlock tx = Block blockHeader blockBody
   where
     keys :: AllIssuerKeys (Cardano.Ledger.Era.Crypto era) 'StakePool

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -92,7 +92,7 @@ genBlock ::
   ) =>
   GenEnv era ->
   ChainState era ->
-  Gen (Block BHeader era)
+  Gen (Block (BHeader (Crypto era)) era)
 genBlock ge = genBlockWithTxGen genTxs ge
   where
     genTxs :: TxGen era
@@ -111,7 +111,7 @@ genBlockWithTxGen ::
   TxGen era ->
   GenEnv era ->
   ChainState era ->
-  Gen (Block BHeader era)
+  Gen (Block (BHeader (Crypto era)) era)
 genBlockWithTxGen
   genTxs
   ge@(GenEnv KeySpace_ {ksStakePools, ksIndexedGenDelegates} _scriptspace _)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -596,7 +596,7 @@ mkBlock ::
   Word ->
   -- | Operational certificate
   OCert (Crypto era) ->
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 mkBlock prev pkeys txns s blockNo enonce kesPeriod c0 oCert =
   let txseq = (toTxSeq @era . StrictSeq.fromList) txns
       bodySize = fromIntegral $ bBodySize $ txseq
@@ -633,7 +633,7 @@ mkBlockFakeVRF ::
   Word ->
   -- | Operational certificate
   OCert (Crypto era) ->
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 mkBlockFakeVRF prev pkeys txns s blockNo enonce (NatNonce bnonce) l kesPeriod c0 oCert =
   let (_, (sHot, _)) = head $ hot pkeys
       KeyPair vKeyCold _ = cold pkeys

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -138,7 +138,7 @@ type MinCHAIN_STS era =
     BaseM (CHAIN era) ~ ShelleyBase,
     Environment (CHAIN era) ~ (),
     State (CHAIN era) ~ ChainState era,
-    Signal (CHAIN era) ~ Block BHeader era
+    Signal (CHAIN era) ~ Block (BHeader (Crypto era)) era
   )
 
 -- | Minimal requirements on the UTxO instances

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -102,7 +102,7 @@ instance
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
     Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ BbodyState era,
-    Signal (Core.EraRule "BBODY" era) ~ (Block BHeaderView era),
+    Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),
     Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
     State (Core.EraRule "TICKN" era) ~ TicknState,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/LaxBlock.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/LaxBlock.hs
@@ -17,7 +17,7 @@ import Cardano.Binary
     annotatorSlice,
   )
 import Cardano.Ledger.Block (Block (..), BlockAnn)
-import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
+import Cardano.Ledger.Era (Era, ValidateScript (..))
 import qualified Cardano.Ledger.Era as Era
 import Cardano.Ledger.Serialization (decodeRecordNamed)
 import Cardano.Ledger.Shelley.BlockChain (TxSeq, txSeqDecoder)
@@ -31,7 +31,7 @@ newtype LaxBlock h era = LaxBlock (Block h era)
 blockDecoder ::
   ( BlockAnn era,
     Era.TxSeq era ~ TxSeq era,
-    FromCBOR (Annotator (h (Crypto era)))
+    FromCBOR (Annotator (h))
   ) =>
   Bool ->
   forall s. Decoder s (Annotator (Block h era))
@@ -45,7 +45,7 @@ instance (Era era, Typeable era, Typeable h) => ToCBOR (LaxBlock h era) where
   toCBOR (LaxBlock x) = toCBOR x
 
 deriving stock instance
-  (Era era, Show (Era.TxSeq era), Show (h (Crypto era))) =>
+  (Era era, Show (Era.TxSeq era), Show h) =>
   Show (LaxBlock h era)
 
 instance
@@ -54,7 +54,7 @@ instance
     BlockAnn era,
     ValidateScript era,
     Era.TxSeq era ~ TxSeq era,
-    FromCBOR (Annotator (h (Crypto era)))
+    FromCBOR (Annotator h)
   ) =>
   FromCBOR (Annotator (LaxBlock h era))
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -236,7 +234,7 @@ instance
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
     Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ BbodyState era,
-    Signal (Core.EraRule "BBODY" era) ~ (Block BHeaderView era),
+    Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),
     Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
     State (Core.EraRule "TICKN" era) ~ TicknState,
@@ -261,7 +259,7 @@ instance
 
   type
     Signal (CHAIN era) =
-      Block BHeader era
+      Block (BHeader (Crypto era)) era
 
   type Environment (CHAIN era) = ()
   type BaseM (CHAIN era) = ShelleyBase
@@ -279,7 +277,7 @@ chainTransition ::
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
     Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ BbodyState era,
-    Signal (Core.EraRule "BBODY" era) ~ (Block BHeaderView era),
+    Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),
     Environment (Core.EraRule "TICKN" era) ~ TicknEnv,
     State (Core.EraRule "TICKN" era) ~ TicknState,
@@ -309,7 +307,7 @@ chainTransition =
                  etaC
                  etaH
                  lab,
-               (Block bh txs)
+               Block bh txs
                )
            ) -> do
         case prtlSeqChecks lab bh of
@@ -356,7 +354,7 @@ chainTransition =
         let thouShaltNot = error "A block with a header view should never be hashed"
         BbodyState ls' bcur' <-
           trans @(Core.EraRule "BBODY" era) $
-            TRC (BbodyEnv pp' account, BbodyState ls bcur, (Block' bhView txs thouShaltNot))
+            TRC (BbodyEnv pp' account, BbodyState ls bcur, Block' bhView txs thouShaltNot)
 
         let nes'' = updateNES nes' bcur' ls'
             bhb = bhbody bh

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -136,7 +136,7 @@ relevantCasesAreCoveredForTrace ::
   Trace (CHAIN era) ->
   Property
 relevantCasesAreCoveredForTrace tr = do
-  let blockTxs :: Block BHeader era -> [Core.Tx era]
+  let blockTxs :: Block (BHeader (Crypto era)) era -> [Core.Tx era]
       blockTxs (UnserialisedBlock _ txSeq) = toList (fromTxSeq @era txSeq)
       bs = traceSignals OldestFirst tr
       txs = concat (blockTxs <$> bs)
@@ -416,7 +416,7 @@ onlyValidChainSignalsAreGenerated =
     genesisChainSt = Just $ mkGenesisChainState (genEnv p)
 
 -- | Counts the epochs spanned by this trace
-epochsInTrace :: forall era. Era era => [Block BHeader era] -> Int
+epochsInTrace :: forall era. Era era => [Block (BHeader (Crypto era)) era] -> Int
 epochsInTrace [] = 0
 epochsInTrace bs =
   fromIntegral $ toEpoch - fromEpoch + 1

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -829,7 +829,7 @@ withdrawals ::
   ( EraGen era,
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   Coin
 withdrawals (UnserialisedBlock _ txseq) =
   foldl'
@@ -1002,7 +1002,7 @@ ledgerTraceFromBlock ::
     TestingLedger era ledger
   ) =>
   ChainState era ->
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   (ChainState era, Trace ledger)
 ledgerTraceFromBlock chainSt block =
   ( tickedChainSt,
@@ -1022,7 +1022,7 @@ ledgerTraceFromBlockWithRestrictedUTxO ::
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
   ) =>
   ChainState era ->
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   (UTxO era, Trace ledger)
 ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
   ( UTxO irrelevantUTxO,
@@ -1046,7 +1046,7 @@ poolTraceFromBlock ::
     HasField "_minPoolCost" (Core.PParams era) Coin
   ) =>
   ChainState era ->
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   (ChainState era, Trace (POOL era))
 poolTraceFromBlock chainSt block =
   ( tickedChainSt,
@@ -1073,7 +1073,7 @@ delegTraceFromBlock ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
   ) =>
   ChainState era ->
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   (DelegEnv era, Trace (DELEG era))
 delegTraceFromBlock chainSt block =
   ( delegEnv,
@@ -1108,7 +1108,7 @@ ledgerTraceBase ::
     ApplyBlock era
   ) =>
   ChainState era ->
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   ( ChainState era,
     LedgerEnv era,
     (UTxOState era, DPState (Crypto era)),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -844,13 +844,14 @@ genTx =
     <*> arbitrary
 
 genBlock ::
-  forall era.
+  forall era h.
   ( Era era,
     ToCBORGroup (TxSeq era),
     Mock (Crypto era),
-    Arbitrary (Core.Tx era)
+    Arbitrary (Core.Tx era),
+    h ~ BHeader (Crypto era)
   ) =>
-  Gen (Block BHeader era)
+  Gen (Block h era)
 genBlock = Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary)
 
 -- | For some purposes, a totally random block generator may not be suitable.
@@ -862,14 +863,15 @@ genBlock = Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary)
 --
 -- This generator uses 'mkBlock' provide more coherent blocks.
 genCoherentBlock ::
-  forall era.
+  forall era h.
   ( EraGen era,
     ToCBORGroup (TxSeq era),
     Mock (Crypto era),
     UsesTxBody era,
-    Arbitrary (Core.Tx era)
+    Arbitrary (Core.Tx era),
+    h ~ BHeader (Crypto era)
   ) =>
-  Gen (Block BHeader era)
+  Gen (Block h era)
 genCoherentBlock = do
   let KeySpace_ {ksCoreNodes} = geKeySpace (genEnv p)
   prevHash <- arbitrary :: Gen (HashHeader (Crypto era))
@@ -916,9 +918,10 @@ instance
     ToCBORGroup (TxSeq era),
     SupportsSegWit era,
     Mock (Crypto era),
-    Arbitrary (Core.Tx era)
+    Arbitrary (Core.Tx era),
+    h ~ BHeader (Crypto era)
   ) =>
-  Arbitrary (Block BHeader era)
+  Arbitrary (Block h era)
   where
   arbitrary = genBlock
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -353,6 +353,6 @@ testSTS env initSt sig predicateFailure@(Left _) = do
 mkHash :: forall a h. HashAlgorithm h => Int -> Hash h a
 mkHash i = coerce (hashWithSerialiser @h toCBOR i)
 
-getBlockNonce :: forall era. Era era => Block BHeader era -> Nonce
+getBlockNonce :: forall era. Era era => Block (BHeader (Crypto era)) era -> Nonce
 getBlockNonce =
   mkNonceFromOutputVRF . certifiedOutput . bheaderEta . bhbody . bheader

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples.hs
@@ -13,7 +13,7 @@ import Cardano.Ledger.Shelley.Scripts ()
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Control.State.Transition.Extended hiding (Assertion)
 import Control.State.Transition.Trace (checkTrace, (.-), (.->))
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Cardano.Ledger.Shelley.Orphans ()
 import Test.Cardano.Ledger.Shelley.Rules.Chain (CHAIN, ChainState, totalAda)
 import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, maxLLSupply, runShelleyBase)
@@ -30,7 +30,7 @@ data CHAINExample h era = CHAINExample
 
 -- | Runs example, applies chain state transition system rule (STS),
 --   and checks that trace ends with expected state or expected error.
-testCHAINExample :: CHAINExample BHeader C -> Assertion
+testCHAINExample :: CHAINExample (BHeader C_Crypto) C -> Assertion
 testCHAINExample (CHAINExample initSt block (Right expectedSt)) = do
   (checkTrace @(CHAIN C) runShelleyBase () $ pure initSt .- block .-> expectedSt)
     >> (totalAda expectedSt @?= maxLLSupply)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -162,7 +162,7 @@ evolveNonceUnfrozen n cs =
 newLab ::
   forall era.
   (Era era) =>
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   ChainState era ->
   ChainState era
 newLab b cs =
@@ -620,7 +620,7 @@ newEpoch ::
   forall era.
   (Core.PParams era ~ PParams era) =>
   Era era =>
-  Block BHeader era ->
+  Block (BHeader (Crypto era)) era ->
   ChainState era ->
   ChainState era
 newEpoch b cs = cs'

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/EmptyBlock.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/EmptyBlock.hs
@@ -55,7 +55,7 @@ blockEx1 ::
     ShelleyTest era,
     ExMock (Crypto era)
   ) =>
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -96,5 +96,5 @@ expectedStEx1 =
 --
 -- The only things that change in the chain state are the
 -- evolving and candidate nonces, and the last applied block.
-exEmptyBlock :: (ShelleyTest era, ExMock (Crypto era), PreAlonzo era) => CHAINExample BHeader era
+exEmptyBlock :: (ShelleyTest era, ExMock (Crypto era), PreAlonzo era) => CHAINExample (BHeader (Crypto era)) era
 exEmptyBlock = CHAINExample initStEx1 blockEx1 (Right expectedStEx1)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -179,7 +179,7 @@ txEx1 = Tx txbodyEx1 txwits SNothing
 blockEx1 ::
   forall c.
   (ExMock (Crypto (ShelleyEra c))) =>
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx1 =
   mkBlockFakeVRF @(ShelleyEra c)
     lastByronHeaderHash
@@ -220,7 +220,7 @@ expectedStEx1 =
 -- In the first block, stage a new future genesis delegate
 genesisDelegation1 ::
   (ExMock c) =>
-  CHAINExample BHeader (ShelleyEra c)
+  CHAINExample (BHeader c) (ShelleyEra c)
 genesisDelegation1 = CHAINExample initStGenesisDeleg blockEx1 (Right expectedStEx1)
 
 --
@@ -230,7 +230,7 @@ genesisDelegation1 = CHAINExample initStGenesisDeleg blockEx1 (Right expectedStE
 blockEx2 ::
   forall c.
   (ExMock (Crypto (ShelleyEra c))) =>
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx2 =
   mkBlockFakeVRF @(ShelleyEra c)
     (bhHash $ bheader blockEx1)
@@ -264,7 +264,7 @@ expectedStEx2 =
 -- Submit an empty block to trigger adopting the genesis delegation.
 genesisDelegation2 ::
   (ExMock c, C.UsesPP (ShelleyEra c)) =>
-  CHAINExample BHeader (ShelleyEra c)
+  CHAINExample (BHeader c) (ShelleyEra c)
 genesisDelegation2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -179,7 +179,7 @@ blockEx1' ::
   (ExMock (Crypto (ShelleyEra c))) =>
   [KeyPair 'Witness (Crypto (ShelleyEra c))] ->
   MIRPot ->
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx1' txwits pot =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -198,7 +198,7 @@ blockEx1 ::
   forall c.
   (ExMock (Crypto (ShelleyEra c))) =>
   MIRPot ->
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx1 = blockEx1' sufficientMIRWits
 
 expectedStEx1' ::
@@ -226,7 +226,7 @@ expectedStEx1 = expectedStEx1' sufficientMIRWits
 -- === Block 1, Slot 10, Epoch 0, Successful MIR Reserves Example
 --
 -- In the first block, submit a MIR cert drawing from the reserves.
-mir1 :: (ExMock (Crypto (ShelleyEra c))) => MIRPot -> CHAINExample BHeader (ShelleyEra c)
+mir1 :: (ExMock (Crypto (ShelleyEra c))) => MIRPot -> CHAINExample (BHeader c) (ShelleyEra c)
 mir1 pot =
   CHAINExample
     (initStMIR (Coin 1000))
@@ -241,7 +241,7 @@ mirFailWits ::
   ( ExMock (Crypto (ShelleyEra c))
   ) =>
   MIRPot ->
-  CHAINExample BHeader (ShelleyEra c)
+  CHAINExample (BHeader c) (ShelleyEra c)
 mirFailWits pot =
   CHAINExample
     (initStMIR (Coin 1000))
@@ -269,7 +269,7 @@ mirFailFunds ::
   Coin ->
   Coin ->
   Coin ->
-  CHAINExample BHeader (ShelleyEra c)
+  CHAINExample (BHeader c) (ShelleyEra c)
 mirFailFunds pot treasury llNeeded llReceived =
   CHAINExample
     (initStMIR treasury)
@@ -301,10 +301,10 @@ blockEx2 ::
   forall c.
   (ExMock (Crypto (ShelleyEra c))) =>
   MIRPot ->
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx2 pot =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) (blockEx1 pot))
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) (blockEx1 pot))
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 50)
     []
     (SlotNo 50)
@@ -340,7 +340,7 @@ expectedStEx2 pot =
 mir2 ::
   (ExMock (Crypto (ShelleyEra c))) =>
   MIRPot ->
-  CHAINExample BHeader (ShelleyEra c)
+  CHAINExample (BHeader c) (ShelleyEra c)
 mir2 pot =
   CHAINExample
     (expectedStEx1 pot)
@@ -362,10 +362,10 @@ blockEx3 ::
   forall c.
   (ExMock (Crypto (ShelleyEra c))) =>
   MIRPot ->
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx3 pot =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) (blockEx2 pot))
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) (blockEx2 pot))
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110)
     []
     (SlotNo 110)
@@ -392,7 +392,7 @@ expectedStEx3 pot =
 -- === Block 3, Slot 110, Epoch 1
 --
 -- Submit an empty block in the next epoch to apply the MIR rewards.
-mir3 :: (ExMock (Crypto (ShelleyEra c))) => MIRPot -> CHAINExample BHeader (ShelleyEra c)
+mir3 :: (ExMock (Crypto (ShelleyEra c))) => MIRPot -> CHAINExample (BHeader c) (ShelleyEra c)
 mir3 pot = CHAINExample (expectedStEx2 pot) (blockEx3 pot) (Right $ expectedStEx3 pot)
 
 --

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -244,7 +244,7 @@ txEx1 =
       }
     SNothing
 
-blockEx1 :: forall c. (HasCallStack, ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx1 :: forall c. (HasCallStack, ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -279,7 +279,7 @@ expectedStEx1 =
 -- all register stake credentials, and Alice registers a stake pool.
 -- Additionally, a MIR certificate is issued to draw from the reserves
 -- and give Carl and Daria (who is unregistered) rewards.
-poolLifetime1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime1 = CHAINExample initStPoolLifetime blockEx1 (Right expectedStEx1)
 
 --
@@ -333,10 +333,10 @@ txEx2 =
       }
     SNothing
 
-blockEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx1)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx1)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 90)
     [txEx2]
     (SlotNo 90)
@@ -400,7 +400,7 @@ expectedStEx2 =
 -- === Block 2, Slot 90, Epoch 0
 --
 -- In the second block Alice and Bob both delegation to Alice's Pool.
-poolLifetime2 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime2 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
@@ -410,10 +410,10 @@ poolLifetime2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 epoch1Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch1Nonce = chainCandidateNonce (expectedStEx2 @c)
 
-blockEx3 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx3 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx2)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx2)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110)
     []
     (SlotNo 110)
@@ -455,7 +455,7 @@ expectedStEx3 =
 --
 -- In the third block, an empty block in a new epoch, the first snapshot is created.
 -- The rewards accounts from the MIR certificate in block 1 are now increased.
-poolLifetime3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
@@ -495,10 +495,10 @@ txEx4 =
       }
     SNothing
 
-blockEx4 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx4 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx3)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx3)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 190)
     [txEx4]
     (SlotNo 190)
@@ -541,7 +541,7 @@ expectedStEx4 =
 -- We process a block late enough in the epoch in order to create a second reward update,
 -- preparing the way for the first non-empty pool distribution in this running example.
 -- Additionally, in order to have the stake distribution change, Carl delegates his stake.
-poolLifetime4 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime4 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
 epoch2Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
@@ -553,10 +553,10 @@ epoch2Nonce =
 -- Block 5, Slot 220, Epoch 2
 --
 
-blockEx5 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx5 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx5 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx4)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx4)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 220)
     []
     (SlotNo 220)
@@ -610,17 +610,17 @@ expectedStEx5 =
 --
 -- Create the first non-empty pool distribution
 -- by creating a block in the third epoch of this running example.
-poolLifetime5 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime5 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 
 --
 -- Block 6, Slot 295, Epoch 2
 --
 
-blockEx6 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx6 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx6 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx5)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx5)
     Cast.alicePoolKeys
     []
     (SlotNo 295) -- odd slots open for decentralization
@@ -657,7 +657,7 @@ expectedStEx6 =
 -- === Block 6, Slot 295, Epoch 2
 --
 -- Create a decentralized Praos block (ie one not in the overlay schedule)
-poolLifetime6 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime6 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime6 = CHAINExample expectedStEx5 blockEx6 (Right expectedStEx6)
 
 --
@@ -669,10 +669,10 @@ epoch3Nonce =
   chainCandidateNonce (expectedStEx6 @c)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx4 @c))
 
-blockEx7 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx7 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx7 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx6)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx6)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 310)
     []
     (SlotNo 310)
@@ -698,17 +698,17 @@ expectedStEx7 =
 --
 -- Create an empty block in the next epoch
 -- to prepare the way for the first non-trivial reward update
-poolLifetime7 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime7 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 
 --
 -- Block 8, Slot 390, Epoch 3
 --
 
-blockEx8 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx8 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx8 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx7)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx7)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 390)
     []
     (SlotNo 390)
@@ -791,7 +791,7 @@ expectedStEx8 =
 -- === Block 8, Slot 390, Epoch 3
 --
 -- Create the first non-trivial reward update.
-poolLifetime8 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime8 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 
 rewardInfoEx8 :: RP.RewardProvenance C_Crypto
@@ -835,10 +835,10 @@ epoch4Nonce =
   chainCandidateNonce (expectedStEx8 @c)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx6 @c))
 
-blockEx9 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx9 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx9 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx8)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx8)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 410)
     []
     (SlotNo 410)
@@ -874,7 +874,7 @@ expectedStEx9 =
 -- === Block 9, Slot 410, Epoch 4
 --
 -- Apply the first non-trivial reward update.
-poolLifetime9 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime9 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime9 = CHAINExample expectedStEx8 blockEx9 (Right expectedStEx9)
 
 --
@@ -913,10 +913,10 @@ txEx10 =
       }
     SNothing
 
-blockEx10 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx10 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx10 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx9)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx9)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 420)
     [txEx10]
     (SlotNo 420)
@@ -940,7 +940,7 @@ expectedStEx10 =
 -- === Block 10, Slot 420, Epoch 4
 --
 -- Drain Bob's reward account and de-register Bob's stake key.
-poolLifetime10 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime10 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime10 = CHAINExample expectedStEx9 blockEx10 (Right expectedStEx10)
 
 --
@@ -982,10 +982,10 @@ txEx11 =
       }
     SNothing
 
-blockEx11 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx11 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx11 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx10)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx10)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 490)
     [txEx11]
     (SlotNo 490)
@@ -1044,7 +1044,7 @@ expectedStEx11 =
 -- === Block 11, Slot 490, Epoch 4
 --
 -- Stage the retirement of Alice's stake pool.
-poolLifetime11 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime11 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime11 = CHAINExample expectedStEx10 blockEx11 (Right expectedStEx11)
 
 --
@@ -1056,10 +1056,10 @@ epoch5Nonce =
   chainCandidateNonce (expectedStEx11 @c)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx8 @c))
 
-blockEx12 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx12 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx12 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx11)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx11)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 510)
     []
     (SlotNo 510)
@@ -1099,7 +1099,7 @@ expectedStEx12 =
 -- === Block 12, Slot 510, Epoch 5
 --
 -- Reap Alice's stake pool.
-poolLifetime12 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolLifetime12 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolLifetime12 = CHAINExample expectedStEx11 blockEx12 (Right expectedStEx12)
 
 --

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -131,7 +131,7 @@ txEx1 =
 blockEx1 ::
   forall c.
   (HasCallStack, Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) =>
-  Block BHeader (ShelleyEra c)
+  Block (BHeader c) (ShelleyEra c)
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -161,7 +161,7 @@ expectedStEx1 =
 -- === Block 1, Slot 10, Epoch 0
 --
 -- In the first block Alice registers a stake pool.
-poolReReg1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolReReg1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolReReg1 = CHAINExample initStPoolReReg blockEx1 (Right expectedStEx1)
 
 --
@@ -212,10 +212,10 @@ word64SlotToKesPeriodWord :: Word64 -> Word
 word64SlotToKesPeriodWord slot =
   (fromIntegral $ toInteger slot) `div` (fromIntegral $ toInteger $ slotsPerKESPeriod testGlobals)
 
-blockEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Word64 -> Block BHeader (ShelleyEra c)
+blockEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Word64 -> Block (BHeader c) (ShelleyEra c)
 blockEx2 slot =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx1)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx1)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx slot)
     [txEx2]
     (SlotNo slot)
@@ -227,7 +227,7 @@ blockEx2 slot =
     0
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 20) 0 (KESPeriod 0))
 
-blockEx2A :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx2A :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx2A = blockEx2 20
 
 expectedStEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
@@ -247,7 +247,7 @@ expectedStEx2A =
 --
 -- In the second block Alice re-registers with new pool parameters
 -- early in the epoch.
-poolReReg2A :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolReReg2A :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolReReg2A = CHAINExample expectedStEx1 blockEx2A (Right expectedStEx2A)
 
 pulserEx2 :: forall c. (ExMock c) => PulsingRewUpdate c
@@ -260,14 +260,14 @@ expectedStEx2B =
     . C.pulserUpdate pulserEx2
     $ expectedStEx2
 
-blockEx2B :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx2B :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx2B = blockEx2 90
 
 -- === Block 2, Slot 90, Epoch 0
 --
 -- In the second block Alice re-registers with new pool parameters
 -- late in the epoch.
-poolReReg2B :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolReReg2B :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolReReg2B = CHAINExample expectedStEx1 blockEx2B (Right expectedStEx2B)
 
 --
@@ -277,10 +277,10 @@ poolReReg2B = CHAINExample expectedStEx1 blockEx2B (Right expectedStEx2B)
 epoch1Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch1Nonce = chainCandidateNonce (expectedStEx2B @c)
 
-blockEx3 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx3 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx2B)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx2B)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110)
     []
     (SlotNo 110)
@@ -308,7 +308,7 @@ expectedStEx3 =
 --
 -- The third block is empty and trigger the epoch change,
 -- and Alice's new pool parameters are adopted.
-poolReReg3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+poolReReg3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 poolReReg3 = CHAINExample expectedStEx2B blockEx3 (Right expectedStEx3)
 
 --

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -242,7 +242,7 @@ blockEx1 ::
   ( HasCallStack,
     TwoPoolsConstraints era
   ) =>
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -286,7 +286,7 @@ expectedStEx1 =
 -- This is the only block in this example that includes a transaction,
 -- and after this block is processed, the UTxO will consist entirely
 -- of Alice's new coin aliceCoinEx1, and Bob and Carls initial genesis coins.
-twoPools1 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools1 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools1 = CHAINExample initStTwoPools blockEx1 (Right expectedStEx1)
 
 --
@@ -297,10 +297,10 @@ blockEx2 ::
   forall era.
   ( TwoPoolsConstraints era
   ) =>
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx1)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx1)
     (coreNodeKeysBySchedule @era ppEx 90)
     []
     (SlotNo 90)
@@ -329,7 +329,7 @@ expectedStEx2 =
 twoPools2 ::
   ( TwoPoolsConstraints era
   ) =>
-  CHAINExample BHeader era
+  CHAINExample (BHeader (Crypto era)) era
 twoPools2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
@@ -347,10 +347,10 @@ blockEx3 ::
   forall era.
   ( TwoPoolsConstraints era
   ) =>
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx2)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx2)
     (coreNodeKeysBySchedule @era ppEx 110)
     []
     (SlotNo 110)
@@ -399,7 +399,7 @@ expectedStEx3 =
 twoPools3 ::
   ( TwoPoolsConstraints era
   ) =>
-  CHAINExample BHeader era
+  CHAINExample (BHeader (Crypto era)) era
 twoPools3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
@@ -410,10 +410,10 @@ blockEx4 ::
   forall era.
   ( TwoPoolsConstraints era
   ) =>
-  Block BHeader era
+  Block (BHeader (Crypto era)) era
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx3)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx3)
     (coreNodeKeysBySchedule @era ppEx 190)
     []
     (SlotNo 190)
@@ -452,7 +452,7 @@ expectedStEx4 =
 --
 -- Create an empty block near the end of epoch 0 to close out the epoch,
 -- preparing the way for the first non-empty pool distribution.
-twoPools4 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools4 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
 epoch2Nonce :: forall era. (TwoPoolsConstraints era) => Nonce
@@ -464,10 +464,10 @@ epoch2Nonce =
 -- Block 5, Slot 221, Epoch 2
 --
 
-blockEx5 :: forall era. (TwoPoolsConstraints era) => Block BHeader era
+blockEx5 :: forall era. (TwoPoolsConstraints era) => Block (BHeader (Crypto era)) era
 blockEx5 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx4)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx4)
     Cast.alicePoolKeys
     []
     (SlotNo 221) -- odd slots open for decentralization
@@ -517,17 +517,17 @@ expectedStEx5 =
 --
 -- Create the first non-empty pool distribution by starting the epoch 2.
 -- Moreover, Alice's pool produces the block.
-twoPools5 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools5 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 
 --
 -- Block 6, Slot 295, Epoch 2
 --
 
-blockEx6 :: forall era. (TwoPoolsConstraints era) => Block BHeader era
+blockEx6 :: forall era. (TwoPoolsConstraints era) => Block (BHeader (Crypto era)) era
 blockEx6 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx5)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx5)
     Cast.alicePoolKeys
     []
     (SlotNo 295) -- odd slots open for decentralization
@@ -551,17 +551,17 @@ expectedStEx6 =
 -- === Block 6, Slot 295, Epoch 2
 --
 -- Alice's pool produces a second block.
-twoPools6 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools6 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools6 = CHAINExample expectedStEx5 blockEx6 (Right expectedStEx6)
 
 --
 -- Block 7, Slot 297, Epoch 2
 --
 
-blockEx7 :: forall era. (TwoPoolsConstraints era) => Block BHeader era
+blockEx7 :: forall era. (TwoPoolsConstraints era) => Block (BHeader (Crypto era)) era
 blockEx7 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx6)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx6)
     Cast.bobPoolKeys
     []
     (SlotNo 297) -- odd slots open for decentralization
@@ -584,7 +584,7 @@ expectedStEx7 =
 -- === Block 7, Slot 295, Epoch 2
 --
 -- Bob's pool produces a block.
-twoPools7 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools7 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 
 --
@@ -596,10 +596,10 @@ epoch3Nonce =
   chainCandidateNonce (expectedStEx7 @era)
     ⭒ hashHeaderToNonce (bhHash $ bheader (blockEx4 @era))
 
-blockEx8 :: forall era. (TwoPoolsConstraints era) => Block BHeader era
+blockEx8 :: forall era. (TwoPoolsConstraints era) => Block (BHeader (Crypto era)) era
 blockEx8 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx7)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx7)
     (coreNodeKeysBySchedule @era ppEx 310)
     []
     (SlotNo 310)
@@ -624,17 +624,17 @@ expectedStEx8 =
 -- === Block 8, Slot 310, Epoch 3
 --
 -- Create an empty block to start epoch 3.
-twoPools8 :: (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools8 :: (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 
 --
 -- Block 9, Slot 390, Epoch 3
 --
 
-blockEx9 :: forall era. (TwoPoolsConstraints era) => Block BHeader era
+blockEx9 :: forall era. (TwoPoolsConstraints era) => Block (BHeader (Crypto era)) era
 blockEx9 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @era blockEx8)
+    (bhHash $ bheader @(BHeader (Crypto era)) @era blockEx8)
     (coreNodeKeysBySchedule @era ppEx 390)
     []
     (SlotNo 390)
@@ -798,7 +798,7 @@ expectedStEx9 pp =
 --
 -- Create the first non-trivial reward update. The rewards demonstrate the
 -- results of the delegation scenario that was constructed in the first and only transaction.
-twoPools9 :: forall era. (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools9 :: forall era. (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools9 = CHAINExample expectedStEx8 blockEx9 (Right $ expectedStEx9 ppEx)
 
 --
@@ -827,7 +827,7 @@ expectedStEx9Agg = C.setPrevPParams ppProtVer3 (expectedStEx9 ppProtVer3)
 
 -- Create the first non-trivial reward update. The rewards demonstrate the
 -- results of the delegation scenario that was constructed in the first and only transaction.
-twoPools9Agg :: forall era. (TwoPoolsConstraints era) => CHAINExample BHeader era
+twoPools9Agg :: forall era. (TwoPoolsConstraints era) => CHAINExample (BHeader (Crypto era)) era
 twoPools9Agg = CHAINExample expectedStEx8Agg blockEx9 (Right expectedStEx9Agg)
 
 testAggregateRewardsLegacy :: Assertion

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -175,7 +175,7 @@ txEx1 =
       }
     SNothing
 
-blockEx1 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx1 :: forall c. (ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
@@ -202,7 +202,7 @@ expectedStEx1 =
 -- === Block 1, Slot 10, Epoch 0
 --
 -- In the first block, three genesis keys vote on the same new parameters.
-updates1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+updates1 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 updates1 = CHAINExample initStUpdates blockEx1 (Right expectedStEx1)
 
 --
@@ -249,10 +249,10 @@ txEx2 =
       }
     SNothing
 
-blockEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx2 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx1)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx1)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 20)
     [txEx2]
     (SlotNo 20)
@@ -276,7 +276,7 @@ expectedStEx2 =
 -- === Block 2, Slot 20, Epoch 0
 --
 -- In the second block, two more genesis keys vote for the same new parameters.
-updates2 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+updates2 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 updates2 = CHAINExample expectedStEx1 blockEx2 (Right expectedStEx2)
 
 --
@@ -338,10 +338,10 @@ txEx3 =
       }
     SNothing
 
-blockEx3 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx3 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx2)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx2)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 80)
     [txEx3]
     (SlotNo 80)
@@ -369,7 +369,7 @@ expectedStEx3 =
 -- === Block 3, Slot 80, Epoch 0
 --
 -- In the third block, one genesis keys votes for the next epoch
-updates3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+updates3 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 updates3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 
 --
@@ -379,10 +379,10 @@ updates3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 epoch1Nonce :: forall c. (ExMock (Crypto (ShelleyEra c))) => Nonce
 epoch1Nonce = (chainCandidateNonce (expectedStEx3 @c)) ⭒ mkNonceFromNumber 123
 
-blockEx4 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block BHeader (ShelleyEra c)
+blockEx4 :: forall c. (Cr.Crypto c, ExMock (Crypto (ShelleyEra c))) => Block (BHeader c) (ShelleyEra c)
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader @BHeader @(ShelleyEra c) blockEx3)
+    (bhHash $ bheader @(BHeader c) @(ShelleyEra c) blockEx3)
     (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 110)
     []
     (SlotNo 110)
@@ -413,7 +413,7 @@ expectedStEx4 =
 -- and the future vote becomes a current vote.
 -- Since the extra entropy was voted on, notice that it is a part
 -- of the new epoch nonce.
-updates4 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (ShelleyEra c)
+updates4 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (BHeader c) (ShelleyEra c)
 updates4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 
 --

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/CDDL.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/CDDL.hs
@@ -87,7 +87,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlTest @(ProposedPPUpdates ShelleyE) n "proposed_protocol_parameter_updates",
       cddlTest @(PParamsUpdate ShelleyE) n "protocol_param_update",
       cddlTest' @(Tx ShelleyE) n "transaction",
-      cddlTest' @(LaxBlock BHeader ShelleyE) n "block"
+      cddlTest' @(LaxBlock (BHeader ShelleyC) ShelleyE) n "block"
     ]
       <*> pure cddl
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
@@ -144,7 +144,7 @@ prop_roundtrip_Addr = roundtrip toCBOR fromCBOR
 prop_roundtrip_RewardAcnt :: Ledger.RewardAcnt Mock.C_Crypto -> Property
 prop_roundtrip_RewardAcnt = roundtrip toCBOR fromCBOR
 
-prop_roundtrip_Block :: Ledger.Block TP.BHeader Mock.C -> Property
+prop_roundtrip_Block :: Ledger.Block (TP.BHeader Mock.C_Crypto) Mock.C -> Property
 prop_roundtrip_Block = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
 prop_roundtrip_Header :: TP.BHeader Mock.C_Crypto -> Property

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
@@ -50,30 +50,30 @@ import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks (..))
 
 data Block h era
-  = Block' !(h (Crypto era)) !(Era.TxSeq era) BSL.ByteString
+  = Block' !h !(Era.TxSeq era) BSL.ByteString
   deriving (Generic)
 
 deriving stock instance
-  (Era era, Show (Era.TxSeq era), Show (h (Crypto era))) =>
+  (Era era, Show (Era.TxSeq era), Show h) =>
   Show (Block h era)
 
 deriving stock instance
-  (Era era, Eq (Era.TxSeq era), Eq (h (Crypto era))) =>
+  (Era era, Eq (Era.TxSeq era), Eq h) =>
   Eq (Block h era)
 
 deriving anyclass instance
   ( Era era,
     NoThunks (Era.TxSeq era),
-    NoThunks (h (Crypto era))
+    NoThunks h
   ) =>
   NoThunks (Block h era)
 
 pattern Block ::
   ( Era era,
     ToCBORGroup (Era.TxSeq era),
-    ToCBOR (h (Crypto era))
+    ToCBOR h
   ) =>
-  h (Crypto era) ->
+  h ->
   Era.TxSeq era ->
   Block h era
 pattern Block h txns <-
@@ -90,7 +90,7 @@ pattern Block h txns <-
 -- | Access a block without its serialised bytes. This is often useful when
 -- we're using a 'BHeaderView' in place of the concrete header.
 pattern UnserialisedBlock ::
-  h (Crypto era) ->
+  h ->
   Era.TxSeq era ->
   Block h era
 pattern UnserialisedBlock h txns <- Block' h txns _
@@ -103,7 +103,7 @@ pattern UnserialisedBlock h txns <- Block' h txns _
 --   serialised. Any uses of this pattern outside of testing code should be
 --   regarded with suspicion.
 pattern UnsafeUnserialisedBlock ::
-  h (Crypto era) ->
+  h ->
   Era.TxSeq era ->
   Block h era
 pattern UnsafeUnserialisedBlock h txns <-
@@ -136,7 +136,7 @@ instance
     ValidateScript era,
     Era.SupportsSegWit era,
     FromCBOR (Annotator (Era.TxSeq era)),
-    FromCBOR (Annotator (h (Crypto era))),
+    FromCBOR (Annotator (h)),
     Typeable h
   ) =>
   FromCBOR (Annotator (Block h era))
@@ -153,7 +153,7 @@ instance
 
 bheader ::
   Block h era ->
-  h (Crypto era)
+  h
 bheader (Block' bh _ _) = bh
 
 bbody :: Block h era -> Era.TxSeq era

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -57,7 +57,6 @@ import Cardano.Ledger.Credential
   )
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era (Era)
-import qualified Cardano.Ledger.Era as E (Crypto)
 import qualified Cardano.Ledger.Era as Era (TxSeq)
 import Cardano.Ledger.Keys
   ( GKeys (..),
@@ -447,7 +446,7 @@ ppBHeader (BHeader bh sig) =
       ("Sig", viaShow sig)
     ]
 
-ppBlock :: (PrettyA (Era.TxSeq era), PrettyA (h (E.Crypto era))) => Block h era -> PDoc
+ppBlock :: (PrettyA (Era.TxSeq era), PrettyA (h)) => Block h era -> PDoc
 ppBlock (UnserialisedBlock bh seqx) =
   ppRecord
     "Block"
@@ -464,7 +463,7 @@ instance Crypto c => PrettyA (BHeader c) where
 instance PrettyA (PrevHash c) where
   prettyA = ppPrevHash
 
-instance (Era era, PrettyA (Era.TxSeq era), PrettyA (h (E.Crypto era))) => PrettyA (Block h era) where
+instance (Era era, PrettyA (Era.TxSeq era), PrettyA h) => PrettyA (Block h era) where
   prettyA = ppBlock
 
 -- =================================


### PR DESCRIPTION
This is mostly needed to allow injectivity when trying to vary the
header type with the protocol in consensus.

Almost all changes here are mechanical - the root of the change is at https://github.com/input-output-hk/cardano-ledger/compare/nc/bheader?expand=1#diff-85dc0c0efc44545250fd1786e3d95f10603f2ef8953361439adb99e908efb2ddL53