### PR TITLE
Document integrity hash in the case of no redeemer

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -118,6 +118,11 @@ script_data_hash = $hash32 ; New
 ;
 ; If there is no value for key 0, then the corresponding scripts cannot execute.
 ; Regardless of what the script integrity data is.
+;
+; Finally, note that in the case that a transaction includes datums but does not
+; include any redeemers, the script data format becomes (in hex):
+; [ 80 | datums | A0 ]
+; corresponding to a CBOR empty list and an empty map (our apologies).
 
 ; address = bytes
 ; reward_account = bytes


### PR DESCRIPTION
This PR documents an unfortunate mistake. Harmless, but ugly.

When we added the ability to supply auxiliary datums (but only in the case of datums in newly created transaction outputs) we introduced this wart which arbitrarily prepends `80` to the data and appends `A0`, corresponding to the CBOR empty list and empty map.

discovered by #2604 