### PR TITLE
Revert back accidental refactor of module `VMap` to `ViewMap`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -124,7 +124,7 @@ import Data.Coders
     (!>),
     (<!),
   )
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Default.Class (Default (..))
 import Data.Either (fromRight)
 import Data.Foldable (fold, foldMap')

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/EpochBoundary.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/EpochBoundary.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Shelley.TxBody (PoolParams)
 import Cardano.Ledger.Val ((<+>), (<×>))
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans (lift)
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import Data.Default.Class (Default, def)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -258,7 +258,7 @@ import Data.Coders
     (<!),
     (<*!),
   )
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Constraint (Constraint)
 import Data.Default.Class (Default, def)
 import Data.Foldable (fold, toList)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
@@ -54,7 +54,7 @@ import Data.Coders
     (!>),
     (<!),
   )
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import Data.Default.Class (def)
 import Data.Group (invert)
 import Data.Kind (Type)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
@@ -95,7 +95,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad (guard)
 import Control.Monad.Trans
 import Data.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Default.Class (Default, def)
 import Data.Foldable (find, fold)
 import Data.Function (on)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -39,7 +39,7 @@ import Cardano.Ledger.Slot
 import qualified Cardano.Ledger.Val as Val
 import Control.Provenance (runProvM)
 import Control.State.Transition
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import Data.Default.Class (Default, def)
 import qualified Data.Map.Strict as Map
 import Data.Ratio

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -103,7 +103,7 @@ import Control.State.Transition.Trace
 import qualified Control.State.Transition.Trace as Trace
 import Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Default.Class (Default)
 import Data.Foldable (fold, foldl', toList)
 import Data.Functor.Identity (Identity)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -120,7 +120,7 @@ import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 import Control.State.Transition (STS (State))
 import qualified Data.ByteString.Char8 as BS
 import Data.Coerce (coerce)
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.IP (IPv4, IPv6, toIPv4, toIPv6)
 import qualified Data.Map.Strict as Map (empty, fromList)
 import Data.Maybe (fromJust)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -108,7 +108,7 @@ import Control.Monad.Trans.Reader (asks, runReader)
 import Control.Provenance (ProvM, preservesJust, preservesNothing, runProvM, runWithProvM)
 import Control.SetAlgebra (eval, (◁))
 import Control.State.Transition.Trace (SourceSignalTarget (..), sourceSignalTargets)
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Default.Class (Default (def))
 import Data.Foldable (fold)
 import Data.Map (Map)

--- a/libs/cardano-data/src/Data/Coders.hs
+++ b/libs/cardano-data/src/Data/Coders.hs
@@ -138,7 +138,7 @@ import Control.Applicative (liftA2)
 import Control.Monad (replicateM, unless, when)
 import Control.Monad.Trans
 import Control.Monad.Trans.Identity
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Foldable (foldl')
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Identity (Identity (..))

--- a/libs/cardano-data/src/Data/Sharing.hs
+++ b/libs/cardano-data/src/Data/Sharing.hs
@@ -35,8 +35,8 @@ import Control.Monad.Trans
 import Control.Monad.Trans.State.Strict
 import Data.BiMap (BiMap (..), biMapFromMap)
 import Data.Coders (decodeMap, decodeVMap, invalidKey)
-import Data.Compact.ViewMap (VB, VMap, VP)
-import qualified Data.Compact.ViewMap as VMap
+import Data.Compact.VMap (VB, VMap, VP)
+import qualified Data.Compact.VMap as VMap
 import qualified Data.Foldable as F
 import Data.Functor.Identity
 import Data.Kind

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -176,7 +176,7 @@ import Control.Monad.Identity (Identity)
 import Control.State.Transition (STS (State))
 import qualified Data.ByteString as Long (ByteString)
 import qualified Data.ByteString.Lazy as Lazy (ByteString, toStrict)
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.IP (IPv4, IPv6)
 import qualified Data.Map.Strict as Map (Map, toList)
 import Data.MemoBytes (MemoBytes (..))

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/SumStake.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/SumStake.hs
@@ -6,7 +6,7 @@ import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Control.Monad
 import Criterion
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import Data.Foldable as F
 import Data.Map.Strict as Map
 import System.Random.Stateful

--- a/libs/compact-map/bench/Bench.hs
+++ b/libs/compact-map/bench/Bench.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Monad
 import Criterion.Main
 import Data.Compact.KeyMap as KeyMap
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import Data.Foldable as F
 import Data.Map.Strict as Map
 import System.Random.Stateful as Random

--- a/libs/compact-map/compact-map.cabal
+++ b/libs/compact-map/compact-map.cabal
@@ -31,7 +31,7 @@ library
 
   exposed-modules:     Data.Compact.KeyMap
                      , Data.Compact.HashMap
-                     , Data.Compact.ViewMap
+                     , Data.Compact.VMap
                      , Data.Compact.SmallArray
                      , Data.Compact.SplitMap
   other-modules:       Data.Compact.KVVector
@@ -57,7 +57,7 @@ test-suite tests
   main-is:             Main.hs
   other-modules:       Test.Compact.SplitMap
                      , Test.Compact.KeyMap
-                     , Test.Compact.ViewMap
+                     , Test.Compact.VMap
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base

--- a/libs/compact-map/src/Data/Compact/VMap.hs
+++ b/libs/compact-map/src/Data/Compact/VMap.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Data.Compact.ViewMap
+module Data.Compact.VMap
   ( VG.Vector,
     VB,
     VU,

--- a/libs/compact-map/test/Main.hs
+++ b/libs/compact-map/test/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Test.Compact.KeyMap (alltests)
 import Test.Compact.SplitMap (splitMapTests)
-import Test.Compact.ViewMap
+import Test.Compact.VMap
 import Test.Tasty
 
 -- ====================================================================================

--- a/libs/compact-map/test/Test/Compact/VMap.hs
+++ b/libs/compact-map/test/Test/Compact/VMap.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Compact.ViewMap where
+module Test.Compact.VMap where
 
-import Data.Compact.ViewMap as VMap
+import Data.Compact.VMap as VMap
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Proxy

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -25,7 +25,7 @@ import Control.Foldl (Fold (..))
 import Control.Monad
 import Control.Monad.Trans.Reader
 import qualified Data.Compact.KeyMap as KeyMap
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Conduit.Internal (zipSources)
 import Data.Conduit.List (sourceList)
 import Data.Functor

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -33,7 +33,7 @@ import Control.SetAlgebra (range)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Compact.HashMap (toKey)
 import Data.Compact.KeyMap as KeyMap
-import qualified Data.Compact.ViewMap as VMap
+import qualified Data.Compact.VMap as VMap
 import Data.Foldable as F
 import Data.Functor
 import qualified Data.IntMap.Strict as IntMap


### PR DESCRIPTION
In #2584 there was a new concept introduced called `ViewMap`. Accidentally unrelated `VMap` module got renamed to `ViewMap`. This PR reverts that change