### PR TITLE
Moved the Coders tests to Test.Data.Coders

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -95,6 +95,7 @@ test-suite cardano-ledger-alonzo-test
     base16-bytestring,
     bytestring,
     cardano-binary,
+    cardano-data,
     cardano-ledger-alonzo,
     cardano-ledger-alonzo-test,
     cardano-ledger-shelley-ma,

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -22,9 +22,9 @@ import qualified Cardano.Ledger.Shelley.Tx as LTX
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Roundtrip (roundTrip, roundTrip', roundTripAnn)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (roundTrip, roundTrip', roundTripAnn)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -51,7 +51,6 @@ library
     Test.Cardano.Ledger.AllegraEraGen
     Test.Cardano.Ledger.Allegra.Examples.Consensus
     Test.Cardano.Ledger.ShelleyMA.TxBody
-    Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators
     Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip
   -- other-extensions:

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -12,14 +12,14 @@ import Cardano.Ledger.Shelley.API (ApplyTx, ApplyTxError)
 import Cardano.Ledger.Shelley.Constraints
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Proxy (Proxy (Proxy))
+import Data.Roundtrip
+  ( roundTrip,
+    roundTripAnn,
+  )
 import Data.Typeable (typeRep)
 import Test.Cardano.Ledger.EraBuffet
 import Test.Cardano.Ledger.Shelley.Generator.Metadata ()
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
-  ( roundTrip,
-    roundTripAnn,
-  )
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.QuickCheck (Arbitrary, Property, counterexample, (===))
 import Test.Tasty (TestTree, testGroup)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation.hs
@@ -3,7 +3,6 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation where
 import Test.Cardano.Ledger.Allegra.Translation (allegraEncodeDecodeTests)
 import Test.Cardano.Ledger.Mary.Translation (maryEncodeDecodeTests)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.CDDL (cddlTests)
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (codersTest)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Golden.Encoding (goldenEncodingTests)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip (allEraRoundtripTests)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Timelocks (timelockTests)
@@ -14,8 +13,7 @@ tests :: TestTree
 tests =
   testGroup
     "Serialisation tests"
-    [ codersTest,
-      allegraEncodeDecodeTests,
+    [ allegraEncodeDecodeTests,
       maryEncodeDecodeTests,
       txBodyTest,
       timelockTests,

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Timelocks.hs
@@ -23,10 +23,10 @@ import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Slotting.Slot (SlotNo (..))
 import qualified Data.ByteString.Lazy as Lazy
 import Data.MemoBytes (MemoBytes (Memo))
+import Data.Roundtrip (embedTripAnn, roundTripAnn)
 import Data.Sequence.Strict (fromList)
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders (embedTripAnn, roundTripAnn)
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -41,6 +41,7 @@ library
                      , Data.Sharing
                      , Data.BiMap
                      , Data.MapExtras
+                     , Data.Roundtrip
                      , Data.UMap
 
   build-depends:       base >=4.11 && <5
@@ -70,15 +71,20 @@ test-suite cardano-data-tests
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Test.Data.UMap
+                     , Test.Data.Coders
                      
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base
-                    -- , cardano-prelude
+                     , bytestring
+                     , cardano-binary
+                     , cborg
                      , containers
+                     , strict-containers
                      , tasty
                      , tasty-quickcheck
-                     -- , tasty-hunit
+                     , tasty-hunit
+                     , text
                      , cardano-data
                      , QuickCheck
                      -- , quickcheck-classes-base

--- a/libs/cardano-data/src/Data/Roundtrip.hs
+++ b/libs/cardano-data/src/Data/Roundtrip.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Defines reusable abstractions for testing Roundtrip properties of CBOR instances
+module Data.Roundtrip
+  ( roundTrip,
+    roundTrip',
+    embedTrip,
+    embedTrip',
+    roundTripAnn,
+    embedTripAnn,
+    RoundTripResult,
+  )
+where
+
+import Cardano.Binary
+  ( Annotator (..),
+    FromCBOR (fromCBOR),
+    FullByteString (Full),
+    ToCBOR (toCBOR),
+  )
+import Codec.CBOR.Decoding (Decoder)
+import Codec.CBOR.Encoding (Encoding)
+import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import Codec.CBOR.Write (toLazyByteString)
+import qualified Data.ByteString.Lazy as Lazy
+
+-- =====================================================================
+
+type RoundTripResult t = Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
+
+roundTrip :: (ToCBOR t, FromCBOR t) => t -> RoundTripResult t
+roundTrip s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
+
+roundTrip' :: (t -> Encoding) -> (forall s. Decoder s t) -> t -> RoundTripResult t
+roundTrip' enc dec t = deserialiseFromBytes dec (toLazyByteString (enc t))
+
+roundTripAnn :: (ToCBOR t, FromCBOR (Annotator t)) => t -> RoundTripResult t
+roundTripAnn s =
+  let bytes = toLazyByteString (toCBOR s)
+   in case deserialiseFromBytes fromCBOR bytes of
+        Left err -> Left err
+        Right (leftover, Annotator f) -> Right (leftover, f (Full bytes))
+
+-- | Can we serialise a type, and then deserialise it as something else?
+embedTrip :: (ToCBOR t, FromCBOR s) => t -> RoundTripResult s
+embedTrip s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
+
+embedTrip' :: (s -> Encoding) -> (forall x. Decoder x t) -> s -> RoundTripResult t
+embedTrip' enc dec s = deserialiseFromBytes dec (toLazyByteString (enc s))
+
+embedTripAnn :: forall s t. (ToCBOR t, FromCBOR (Annotator s)) => t -> RoundTripResult s
+embedTripAnn s =
+  let bytes = toLazyByteString (toCBOR s)
+   in case deserialiseFromBytes fromCBOR bytes of
+        Left err -> Left err
+        Right (leftover, Annotator f) -> Right (leftover, f (Full bytes))

--- a/libs/cardano-data/test/Main.hs
+++ b/libs/cardano-data/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Test.Data.Coders (codersTest)
 import Test.Data.UMap (alltests)
 import Test.Tasty
 
@@ -9,7 +10,8 @@ tests :: TestTree
 tests =
   testGroup
     "cardano-data"
-    [ alltests
+    [ alltests,
+      codersTest
     ]
 
 main :: IO ()

--- a/libs/cardano-data/test/Test/Data/Coders.hs
+++ b/libs/cardano-data/test/Test/Data/Coders.hs
@@ -6,27 +6,17 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Cardano.Ledger.ShelleyMA.Serialisation.Coders
+module Test.Data.Coders
   ( codersTest,
-    roundTrip,
-    roundTrip',
-    embedTrip,
-    embedTrip',
-    roundTripAnn,
-    embedTripAnn,
-    RoundTripResult,
   )
 where
 
 import Cardano.Binary
-  ( Annotator (..),
-    FromCBOR (fromCBOR),
-    FullByteString (Full),
+  ( FromCBOR (fromCBOR),
     ToCBOR (toCBOR),
     encodeListLen,
     encodeWord,
   )
-import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding)
 import Codec.CBOR.FlatTerm (TermToken, toFlatTerm)
 import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
@@ -51,43 +41,13 @@ import Data.Coders
     (!>),
     (<!),
   )
+import Data.Roundtrip (roundTrip')
 import Data.Sequence.Strict (StrictSeq, fromList)
 import Data.Text (Text, pack)
 import Data.Typeable
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck hiding (scale)
-
--- =====================================================================
-
-type RoundTripResult t = Either Codec.CBOR.Read.DeserialiseFailure (Lazy.ByteString, t)
-
-roundTrip :: (ToCBOR t, FromCBOR t) => t -> RoundTripResult t
-roundTrip s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
-
-roundTrip' :: (t -> Encoding) -> (forall s. Decoder s t) -> t -> RoundTripResult t
-roundTrip' enc dec t = deserialiseFromBytes dec (toLazyByteString (enc t))
-
-roundTripAnn :: (ToCBOR t, FromCBOR (Annotator t)) => t -> RoundTripResult t
-roundTripAnn s =
-  let bytes = toLazyByteString (toCBOR s)
-   in case deserialiseFromBytes fromCBOR bytes of
-        Left err -> Left err
-        Right (leftover, Annotator f) -> Right (leftover, f (Full bytes))
-
--- | Can we serialise a type, and then deserialise it as something else?
-embedTrip :: (ToCBOR t, FromCBOR s) => t -> RoundTripResult s
-embedTrip s = deserialiseFromBytes fromCBOR (toLazyByteString (toCBOR s))
-
-embedTrip' :: (s -> Encoding) -> (forall x. Decoder x t) -> s -> RoundTripResult t
-embedTrip' enc dec s = deserialiseFromBytes dec (toLazyByteString (enc s))
-
-embedTripAnn :: forall s t. (ToCBOR t, FromCBOR (Annotator s)) => t -> RoundTripResult s
-embedTripAnn s =
-  let bytes = toLazyByteString (toCBOR s)
-   in case deserialiseFromBytes fromCBOR bytes of
-        Left err -> Left err
-        Right (leftover, Annotator f) -> Right (leftover, f (Full bytes))
 
 -- ==========================================================================
 


### PR DESCRIPTION
Moved the Coders tests from shelley-ma-test to Test.Data,Coders .
We also extracted a few operators that deal with writing CBOR roundtrip tests in to the module  Data.Roundtrip. These are used in about 5 places, and are now accessible without requiring dependencies on things like Test.Cardano.Ledger.ShelleyMA