### PR TITLE
Ts tell rewards

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -85,8 +85,6 @@ module Cardano.Ledger.Shelley.LedgerState
     startStep,
     pulseStep,
     completeStep,
-    pulseOther,
-    --
     NewEpochState (..),
     getGKeys,
     updateNES,
@@ -191,15 +189,15 @@ import Cardano.Ledger.Shelley.RewardUpdate
     Pulser,
     PulsingRewUpdate (..),
     RewardAns (..),
+    RewardEvent,
     RewardPulser (..),
     RewardSnapShot (..),
     RewardUpdate (..),
     emptyRewardUpdate,
-    pulseOther,
   )
 import Cardano.Ledger.Shelley.Rewards
   ( PoolRewardInfo (..),
-    Reward,
+    Reward (..),
     StakeShare (..),
     aggregateRewards,
     filterRewards,
@@ -244,7 +242,7 @@ import Cardano.Prelude (rightToMaybe)
 import Control.DeepSeq (NFData)
 import Control.Monad.State.Strict (evalStateT)
 import Control.Monad.Trans
-import Control.Provenance (ProvM, liftProv, modifyM)
+import Control.Provenance (ProvM, modifyM, runProvM)
 import Control.SetAlgebra (dom, eval, (∈), (◁))
 import Control.State.Transition (STS (State))
 import Data.Coders
@@ -1524,7 +1522,7 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) max
           pulseSize
           free
           (unStake stake')
-          (RewardAns Map.empty)
+          (RewardAns Map.empty Map.empty)
       provenance =
         def
           { spe = case slotsPerEpoch of EpochSize n -> n,
@@ -1551,33 +1549,34 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) max
 -- | Run the pulser for a bit. If is has nothing left to do, complete it.
 pulseStep ::
   PulsingRewUpdate crypto ->
-  ProvM (RewardProvenance crypto) ShelleyBase (PulsingRewUpdate crypto)
-pulseStep (Complete r) = pure (Complete r)
+  ShelleyBase (PulsingRewUpdate crypto, RewardEvent crypto)
+pulseStep (Complete r) = pure (Complete r, mempty)
 pulseStep p@(Pulsing _ pulser) | done pulser = completeStep p
 pulseStep (Pulsing rewsnap pulser) = do
   -- The pulser computes one kind of provenance, pulseOther incorporates it
   -- into the current flavor of provenance: RewardProvenance.
-  p2 <- pulseOther pulser
-  pure (Pulsing rewsnap p2)
+  p2@(RSLP _ _ _ (RewardAns _ event)) <- pulseM pulser
+  pure (Pulsing rewsnap p2, event)
 
 -- Phase 3
 
 completeStep ::
   PulsingRewUpdate crypto ->
-  ProvM (RewardProvenance crypto) ShelleyBase (PulsingRewUpdate crypto)
-completeStep (Complete r) = pure (Complete r)
+  ShelleyBase (PulsingRewUpdate crypto, RewardEvent crypto)
+completeStep (Complete r) = pure (Complete r, mempty)
 completeStep (Pulsing rewsnap pulser) = do
-  p2 <- completeRupd (Pulsing rewsnap pulser)
-  pure (Complete p2)
+  (p2, event) <- runProvM (completeRupd (Pulsing rewsnap pulser))
+  pure (Complete p2, event)
 
 -- | Phase 3 of reward update has several parts
 --   a) completeM the pulser (in case there are still computions to run)
 --   b) Combine the pulser provenance with the RewardProvenance
 --   c) Construct the final RewardUpdate
+--   d) Add the leader rewards to both the events and the computed Rewards
 completeRupd ::
   PulsingRewUpdate crypto ->
-  ProvM (RewardProvenance crypto) ShelleyBase (RewardUpdate crypto)
-completeRupd (Complete x) = pure x
+  ProvM (RewardProvenance crypto) ShelleyBase (RewardUpdate crypto, RewardEvent crypto)
+completeRupd (Complete x) = pure (x, mempty)
 completeRupd
   ( Pulsing
       rewsnap@RewardSnapShot
@@ -1589,27 +1588,32 @@ completeRupd
           rewLikelihoods = newLikelihoods,
           rewLeaders = lrewards
         }
-      pulser
+      pulser@(RSLP _size _free _source (RewardAns prev _now)) -- If prev is Map.empty, we have never pulsed.
     ) = do
-    let ignore _ _ rewprov = rewprov
-    RewardAns rs_ <- liftProv (completeM pulser) Map.empty ignore
-    -- TODO the pulser is no longer supplying any proveance,
-    -- we can clean this up and make it pure.
+    RewardAns rs_ events <- lift (completeM pulser)
     let rs' = Map.map Set.singleton rs_
     let rs'' = Map.unionWith Set.union rs' lrewards
+    let events' = Map.unionWith Set.union events lrewards
 
     let deltaR2 = oldr <-> sumRewards rewsnap rs''
     modifyM (\rp -> rp {deltaR2 = deltaR2})
-    pure $
-      RewardUpdate
-        { deltaT = DeltaCoin deltaT1,
-          deltaR = invert (toDeltaCoin deltaR1) <> toDeltaCoin deltaR2,
-          rs = rs'',
-          deltaF = invert (toDeltaCoin feesSS),
-          nonMyopic = updateNonMyopic nm oldr newLikelihoods
-        }
+    let neverpulsed = Map.null prev
+        pair@(_, _event) =
+          ( RewardUpdate
+              { deltaT = DeltaCoin deltaT1,
+                deltaR = invert (toDeltaCoin deltaR1) <> toDeltaCoin deltaR2,
+                rs = rs'',
+                deltaF = invert (toDeltaCoin feesSS),
+                nonMyopic = updateNonMyopic nm oldr newLikelihoods
+              },
+            if neverpulsed -- If we have never pulsed then everything in the computed needs to added to the event
+              then Map.unionWith Set.union rs' events'
+              else events'
+          )
+    pure pair
 
 -- | To create a reward update, run all 3 phases
+--   This function is not used in the rules, so it ignores RewardEvents
 createRUpd ::
   forall era.
   (UsesPP era) =>
@@ -1623,10 +1627,10 @@ createRUpd ::
 createRUpd slotsPerEpoch blocksmade epstate maxSupply asc secparam = do
   let (step1, initialProvenance) = startStep slotsPerEpoch blocksmade epstate maxSupply asc secparam
   modifyM (\_ -> initialProvenance)
-  step2 <- pulseStep step1
+  (step2, _event) <- lift (pulseStep step1)
   case step2 of
     (Complete r) -> pure r
-    (Pulsing rewsnap pulser) -> completeRupd (Pulsing rewsnap pulser)
+    (Pulsing rewsnap pulser) -> fst <$> completeRupd (Pulsing rewsnap pulser)
 
 -- =====================================================================
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -39,13 +39,12 @@ import Cardano.Ledger.Shelley.LedgerState
     PulsingRewUpdate,
   )
 import Cardano.Ledger.Shelley.Rules.NewEpoch (NEWEPOCH, NewEpochEvent, NewEpochPredicateFailure)
-import Cardano.Ledger.Shelley.Rules.Rupd (RUPD, RupdEnv (..), RupdPredicateFailure)
+import Cardano.Ledger.Shelley.Rules.Rupd (RUPD, RupdEnv (..), RupdEvent, RupdPredicateFailure)
 import Cardano.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
@@ -214,7 +213,7 @@ instance
   ( Era era,
     STS (RUPD era),
     PredicateFailure (Core.EraRule "RUPD" era) ~ RupdPredicateFailure era,
-    Event (Core.EraRule "RUPD" era) ~ Void
+    Event (Core.EraRule "RUPD" era) ~ RupdEvent (Crypto era)
   ) =>
   Embed (RUPD era) (TICK era)
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -1036,4 +1036,4 @@ instance
   Mock crypto =>
   Arbitrary (Pulser crypto)
   where
-  arbitrary = RSLP <$> arbitrary <*> arbitrary <*> arbitrary <*> (RewardAns <$> arbitrary)
+  arbitrary = RSLP <$> arbitrary <*> arbitrary <*> arbitrary <*> (RewardAns <$> arbitrary <*> arbitrary)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -377,7 +377,7 @@ makeCompletedPulser ::
   BlocksMade (Crypto era) ->
   ChainState era ->
   PulsingRewUpdate (Crypto era)
-makeCompletedPulser bs cs = Complete . runShelleyBase . runProvM . completeRupd $ makePulser bs cs
+makeCompletedPulser bs cs = Complete . fst . runShelleyBase . runProvM . completeRupd $ makePulser bs cs
 
 pulserEx2 :: forall c. (ExMock (Crypto (ShelleyEra c))) => PulsingRewUpdate c
 pulserEx2 = makeCompletedPulser (BlocksMade mempty) expectedStEx1

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -101,7 +101,6 @@ import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Protocol.TPraos.BHeader (BHeader, bhHash, hashHeaderToNonce)
 import Cardano.Protocol.TPraos.OCert (KESPeriod (..))
-import Control.Provenance (runProvM)
 import Data.Default.Class (def)
 import Data.Group (invert)
 import Data.Map.Strict (Map)
@@ -851,15 +850,13 @@ twoPoolsExample =
   testGroup
     "two pools"
     [ testCase "create non-aggregated pulser" $ testCHAINExample twoPools9,
-      testCase
-        "non-aggregated pulser is correct"
-        ( Complete (rewardUpdateEx9 @C ppEx rsEx9Agg)
-            @?= (runShelleyBase . runProvM . completeStep $ pulserEx9 @C ppEx)
+      testCase "non-aggregated pulser is correct" $
+        ( (Complete (rewardUpdateEx9 @C ppEx rsEx9Agg))
+            @?= (fst . runShelleyBase . completeStep $ pulserEx9 @C ppEx)
         ),
-      testCase
-        "aggregated pulser is correct"
-        ( Complete (rewardUpdateEx9 @C ppProtVer3 rsEx9Agg)
-            @?= (runShelleyBase . runProvM . completeStep $ pulserEx9 @C ppProtVer3)
+      testCase "aggregated pulser is correct" $
+        ( (Complete (rewardUpdateEx9 @C ppProtVer3 rsEx9Agg))
+            @?= (fst . runShelleyBase . completeStep $ pulserEx9 @C ppProtVer3)
         ),
       testCase "create aggregated pulser" $ testCHAINExample twoPools9Agg,
       testCase "create legacy aggregatedRewards" testAggregateRewardsLegacy,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -568,8 +568,8 @@ ppFreeVars (FreeVars ds addrs total pv pri) =
     ]
 
 ppAns :: RewardAns crypto -> PDoc
-ppAns (RewardAns x) =
-  ppSexp' mempty [ppMap ppCredential ppReward x]
+ppAns (RewardAns x y) =
+  ppRecord "RewardAns" [("allEvents", ppMap ppCredential ppReward x), ("recentEvents", ppMap ppCredential (ppSet ppReward) y)]
 
 ppRewardPulser :: Pulser crypto -> PDoc
 ppRewardPulser (RSLP n free items ans) =


### PR DESCRIPTION
We have added incremental telling of reward updates. On every pulse we tell the member rewards we computed in that pulse. We still compute the accumulated rewards so that we can apply them to the LedgerState. But the telling should help the DB-Synch folks.  

We maintain and test an invariant that the two ways of doing things compute the same result.
We develop a new testing framework to run property tests on Traces for a single epoch extracted from bigger traces.

