### PR TITLE
Plutus V2 to fail phase 1 validation on Byron addr

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -91,6 +91,7 @@ test-suite cardano-ledger-alonzo-test
     Test.Cardano.Ledger.Alonzo.Translation
     Test.Cardano.Ledger.Alonzo.Trials
     Test.Cardano.Ledger.Alonzo.Trials
+    Test.Cardano.Ledger.Alonzo.TxInfo
   build-depends:
     base16-bytestring,
     bytestring,

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -1,0 +1,180 @@
+module Test.Cardano.Ledger.Alonzo.TxInfo where
+
+import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (Data (..))
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Tag (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..), ValidatedTx (..))
+import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..))
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..), txInfo)
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), txrdmrs)
+import Cardano.Ledger.BaseTypes (Network (..), ProtVer (..), StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (StakeReference (..))
+import Cardano.Ledger.Shelley.TxBody (Wdrl (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxIn (..), mkTxInPartial)
+import qualified Cardano.Ledger.Val as Val
+import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
+import Cardano.Slotting.Slot (EpochSize (..))
+import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Default.Class (def)
+import Data.Functor.Identity (Identity, runIdentity)
+import qualified Data.Map as Map
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import qualified PlutusTx as P (Data (..))
+import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
+import Test.Cardano.Ledger.Shelley.Address.Bootstrap (aliceByronAddr)
+import Test.Cardano.Ledger.Shelley.Examples.Cast (alicePHK)
+import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
+
+byronAddr :: Addr StandardCrypto
+byronAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
+
+shelleyAddr :: Addr StandardCrypto
+shelleyAddr = Addr Testnet alicePHK StakeRefNull
+
+ei :: EpochInfo Identity
+ei = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
+
+ss :: SystemStart
+ss = SystemStart $ posixSecondsToUTCTime 0
+
+type A = AlonzoEra StandardCrypto
+
+-- This input is only a "Byron input" in the sense
+-- that we attach it to a Byron output in the UTxO created below.
+byronInput :: TxIn StandardCrypto
+byronInput = mkTxInPartial genesisId 0
+
+-- This input is only a "Shelley input" in the sense
+-- that we attach it to a Shelley output in the UTxO created below.
+shelleyInput :: TxIn StandardCrypto
+shelleyInput = mkTxInPartial genesisId 1
+
+-- This input is only unknown in the sense
+-- that it is not present in the UTxO created below.
+unknownInput :: TxIn StandardCrypto
+unknownInput = mkTxInPartial genesisId 2
+
+byronOutput :: TxOut A
+byronOutput = TxOut byronAddr (Val.inject $ Coin 1) SNothing
+
+shelleyOutput :: TxOut A
+shelleyOutput = TxOut shelleyAddr (Val.inject $ Coin 2) SNothing
+
+utxo :: UTxO A
+utxo = UTxO $ SplitMap.fromList [(byronInput, byronOutput), (shelleyInput, shelleyOutput)]
+
+txb :: TxIn StandardCrypto -> TxOut A -> TxBody A
+txb i o =
+  TxBody
+    (Set.singleton i) -- inputs
+    mempty -- collateral
+    (StrictSeq.singleton o) --outputs
+    mempty -- certs
+    (Wdrl mempty) -- withdrawals
+    (Coin 2) -- txfee
+    (ValidityInterval SNothing SNothing) -- validity interval
+    SNothing -- updates
+    mempty -- required signers
+    mempty -- mint
+    SNothing -- script integrity hash
+    SNothing -- auxiliary data hash
+    SNothing -- network ID
+
+emptyRedeemers :: Redeemers A
+emptyRedeemers = Redeemers mempty
+
+-- This redeemer is unknown since 'txEx' does not mint any tokens
+unknownRedeemer :: Redeemers A
+unknownRedeemer = Redeemers $ Map.singleton (RdmrPtr Mint 0) (Data $ P.I 0, ExUnits 0 0)
+
+txEx :: TxIn StandardCrypto -> TxOut A -> Redeemers A -> ValidatedTx A
+txEx i o r = ValidatedTx (txb i o) (mempty {txrdmrs = r}) (IsValid True) SNothing
+
+ppV6 :: PParams A
+ppV6 = def {_protocolVersion = ProtVer 6 0}
+
+ppV7 :: PParams A
+ppV7 = def {_protocolVersion = ProtVer 7 0}
+
+silentlyIgnore :: ValidatedTx A -> Assertion
+silentlyIgnore tx =
+  case ctx of
+    Right _ -> pure ()
+    Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
+  where
+    ctx = runIdentity $ txInfo ppV6 PlutusV1 ei ss utxo tx
+
+expectTranslationError :: Language -> ValidatedTx A -> TranslationError -> Assertion
+expectTranslationError lang tx expected =
+  case ctx of
+    Right _ -> error "This translation was expected to fail, but it succeeded."
+    Left e -> e @?= expected
+  where
+    ctx = runIdentity $ txInfo ppV7 lang ei ss utxo tx
+
+txInfoTests :: TestTree
+txInfoTests =
+  testGroup
+    "txInfo translation"
+    [ testGroup
+        "Plutus V1, Protocol V6"
+        [ testCase "silently ignore byron txout" $
+            silentlyIgnore (txEx shelleyInput byronOutput emptyRedeemers),
+          testCase "silently ignore byron txin" $
+            silentlyIgnore (txEx byronInput shelleyOutput emptyRedeemers),
+          testCase "silently ignore unknown txin (logic error)" $
+            silentlyIgnore (txEx unknownInput shelleyOutput emptyRedeemers)
+        ],
+      testGroup
+        "Plutus V1, Protocol V7"
+        [ testCase "translation error byron txin" $
+            expectTranslationError
+              PlutusV1
+              (txEx byronInput shelleyOutput emptyRedeemers)
+              ByronInputInContext,
+          testCase "translation error byron txout" $
+            expectTranslationError
+              PlutusV1
+              (txEx shelleyInput byronOutput emptyRedeemers)
+              ByronOutputInContext,
+          testCase "translation error unknown txin (logic error)" $
+            expectTranslationError
+              PlutusV1
+              (txEx unknownInput shelleyOutput emptyRedeemers)
+              TranslationLogicErrorInput
+        ],
+      testGroup
+        "Plutus V2"
+        [ testCase "translation error byron txin" $
+            expectTranslationError
+              PlutusV2
+              (txEx byronInput shelleyOutput emptyRedeemers)
+              ByronInputInContext,
+          testCase "translation error byron txout" $
+            expectTranslationError
+              PlutusV2
+              (txEx shelleyInput byronOutput emptyRedeemers)
+              ByronOutputInContext,
+          testCase "translation error unknown txin (logic error)" $
+            expectTranslationError
+              PlutusV2
+              (txEx unknownInput shelleyOutput emptyRedeemers)
+              TranslationLogicErrorInput,
+          testCase "translation error unknown redeemer (logic error)" $
+            expectTranslationError
+              PlutusV2
+              (txEx shelleyInput shelleyOutput unknownRedeemer)
+              TranslationLogicErrorRedeemer
+        ]
+    ]

--- a/eras/alonzo/test-suite/test/Tests.hs
+++ b/eras/alonzo/test-suite/test/Tests.hs
@@ -15,6 +15,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Canonical as Canonical
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
 import Test.Cardano.Ledger.Alonzo.Trials (alonzoPropertyTests, fastPropertyTests)
+import Test.Cardano.Ledger.Alonzo.TxInfo (txInfoTests)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
 
@@ -37,7 +38,8 @@ mainTests =
       CDDL.tests 5,
       Golden.goldenUTxOEntryMinAda,
       Golden.goldenSerialization,
-      plutusScriptExamples
+      plutusScriptExamples,
+      txInfoTests
     ]
 
 fastTests :: TestTree
@@ -49,7 +51,8 @@ fastTests =
       CDDL.tests 1,
       Golden.goldenUTxOEntryMinAda,
       Golden.goldenSerialization,
-      plutusScriptExamples
+      plutusScriptExamples,
+      txInfoTests
     ]
 
 nightlyTests :: TestTree

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -10,6 +10,7 @@ module Cardano.Ledger.Shelley.HardForks
     translateTimeForPlutusScripts,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
+    failInPresenceOfByronAddress,
   )
 where
 
@@ -75,3 +76,11 @@ forgoRewardPrefilter ::
   pp ->
   Bool
 forgoRewardPrefilter pp = pvMajor (getField @"_protocolVersion" pp) > 6
+
+-- | Starting with protocol version 7, Plutus V1 scripts will fail if the transaction
+-- it is included in contains a Byron address.
+failInPresenceOfByronAddress ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+failInPresenceOfByronAddress pp = pvMajor (getField @"_protocolVersion" pp) > 6

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Ledger.Shelley.Address.Bootstrap
     testBootstrapNotSpending,
     bootstrapHashTest,
     genSignature,
+    aliceByronAddr,
   )
 where
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -14,6 +14,7 @@
 module Test.Cardano.Ledger.Shelley.Examples.Cast
   ( alicePay,
     aliceStake,
+    alicePHK,
     aliceSHK,
     aliceAddr,
     alicePtrAddr,
@@ -109,6 +110,7 @@ alicePoolKeys =
 aliceAddr :: CC.Crypto crypto => Addr crypto
 aliceAddr = mkAddr (alicePay, aliceStake)
 
+-- | Alice's payment credential
 alicePHK :: CC.Crypto crypto => Credential 'Payment crypto
 alicePHK = (KeyHashObj . hashKey . vKey) alicePay
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -108,6 +108,8 @@ exampleInvalidExUnitCalc = do
       costmodels
   case res of
     Left (UnknownTxIns _) -> pure ()
+    Left (BadTranslation _) ->
+      assertFailure "evaluateTransactionExecutionUnits should not fail from BadTranslation"
     Right _ -> assertFailure "evaluateTransactionExecutionUnits should have failed"
 
 exampleTx :: Core.Tx A

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -116,6 +116,7 @@ import Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import qualified Data.ByteString as BS (replicate)
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Default.Class (Default (..))
+import Data.Either (fromRight)
 import Data.Functor.Identity (Identity, runIdentity)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -2041,7 +2042,7 @@ collectTwoPhaseScriptInputsOutputOrdering =
     apf = Alonzo Mock
     context =
       valContext
-        ( runIdentity $
+        ( fromRight (error "translation error") . runIdentity $
             txInfo
               (pp apf)
               PlutusV1


### PR DESCRIPTION
In Plutus V1, we do not pass Byron addresses to the transaction context which is passed to Plutus, they are silently omitted. This includes both transaction inputs and outputs. Starting at major protocol version 7, we want to instead cause a phase 1 validation error instead. This PR does exactly that.

Additionally, this PR introduces a policy change for the `TxInfo` creation code: any time it sees something it can't deal with it forces a phase 1 validation error instead of ignoring it. In particular, two new logic errors are introduced, one for unknown transaction inputs (this is a logic error since the ledger already checks this) and one for unknown redeemer pointers (also something that the ledger already checks).

Note that with the introduction of the babbage, it will probably not make sense for alonzo to have logic for Plutus V2. This is because the Plutus V2 context will probably contain a new field, namely reference inputs (as opposed to just combining them with the usual inputs). We can adapt accordingly when the time comes.

closes #2612