### PR TITLE
Babbage: Era mapping

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -92,7 +92,6 @@ import Cardano.Ledger.Alonzo.TxBody
   ( EraIndependentScriptIntegrity,
     ScriptIntegrityHash,
     TxBody (..),
-    TxOut (..),
   )
 import Cardano.Ledger.Alonzo.TxWitness
   ( RdmrPtr (..),
@@ -222,7 +221,7 @@ instance
 -- =========================================================
 -- Figure 2: Definitions for Transactions
 
-getCoin :: (Era era) => TxOut era -> Coin
+getCoin :: (Era era) => Core.TxOut era -> Coin
 getCoin txout = coin (getField @"value" txout)
 
 -- | A ScriptIntegrityHash is the hash of three things.  The first two come

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -75,8 +75,6 @@ import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
 import Cardano.Ledger.Alonzo.PParams
   ( LangDepView (..),
-    PParams,
-    PParams' (..),
     encodeLangViews,
     getLanguageView,
   )
@@ -250,9 +248,9 @@ instance (Era era, c ~ Crypto era) => HashAnnotated (ScriptIntegrity era) EraInd
 hashScriptIntegrity ::
   forall era.
   ( Era era,
-    Core.PParams era ~ PParams era
+    HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel)
   ) =>
-  PParams era ->
+  Core.PParams era ->
   Set Language ->
   Redeemers era ->
   TxDats era ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -185,7 +185,8 @@ txInfoIn ::
   forall era c i.
   ( Era era,
     Value era ~ Mary.Value (Crypto era),
-    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash c i))
+    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash c i)),
+    HasField "address" (TxOut era) (Addr c)
   ) =>
   UTxO era ->
   TxIn (Crypto era) ->
@@ -210,7 +211,8 @@ txInfoOut ::
   forall era c.
   ( Era era,
     Value era ~ Mary.Value (Crypto era),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash c))
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash c)),
+    HasField "address" (TxOut era) (Addr c)
   ) =>
   Core.TxOut era ->
   Maybe PV1.TxOut
@@ -342,7 +344,8 @@ txInfo ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "mint" (Core.TxBody era) (Mary.Value (Crypto era)),
-    HasField "vldt" (Core.TxBody era) ValidityInterval
+    HasField "vldt" (Core.TxBody era) ValidityInterval,
+    HasField "address" (TxOut era) (Addr (Crypto era))
   ) =>
   Core.PParams era ->
   Language ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -18,17 +18,6 @@ import Cardano.Ledger.Alonzo.Data (Data (..), getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Script (..), decodeCostModel)
 import Cardano.Ledger.Alonzo.Tx
-import Cardano.Ledger.Alonzo.TxBody
-  ( certs',
-    inputs',
-    mint',
-    outputs',
-    reqSignerHashes',
-    txfee',
-    vldt',
-    wdrls',
-  )
-import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxBody (..), TxOut (..))
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr, TxWitness (..), unRedeemers, unTxDats)
 import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
@@ -36,7 +25,8 @@ import Cardano.Ledger.Core as Core (PParams, TxBody, TxOut, Value)
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj), Ptr (..), StakeReference (..))
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Keys (KeyHash (..), hashKey)
+import Cardano.Ledger.Hashes (EraIndependentData)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness), hashKey)
 import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
 import Cardano.Ledger.SafeHash
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
@@ -192,10 +182,10 @@ txInfoIn' (TxIn txid nat) = PV1.TxOutRef (txInfoId txid) (fromIntegral nat)
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it and return
 --   (Just translation). If does not exist in the UTxO, return Nothing.
 txInfoIn ::
-  forall era.
+  forall era c i.
   ( Era era,
     Value era ~ Mary.Value (Crypto era),
-    Core.TxOut era ~ Alonzo.TxOut era
+    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash c i))
   ) =>
   UTxO era ->
   TxIn (Crypto era) ->
@@ -217,16 +207,18 @@ txInfoIn (UTxO mp) txin =
 --   possible the address part is a Bootstrap Address, in that case return Nothing
 --   I.e. don't include Bootstrap Addresses in the answer.
 txInfoOut ::
-  forall era.
+  forall era c.
   ( Era era,
-    Value era ~ Mary.Value (Crypto era)
+    Value era ~ Mary.Value (Crypto era),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash c))
   ) =>
-  Alonzo.TxOut era ->
+  Core.TxOut era ->
   Maybe PV1.TxOut
-txInfoOut (Alonzo.TxOut addr val datahash) =
-  case transAddr addr of
-    Just ad -> Just (PV1.TxOut ad (transValue @(Crypto era) val) (transDataHash datahash))
-    Nothing -> Nothing
+txInfoOut txo =
+  let (addr, val, datahash) = (getField @"address" txo, getField @"value" txo, getField @"datahash" txo)
+   in case transAddr addr of
+        Just ad -> Just (PV1.TxOut ad (transValue @(Crypto era) val) (transDataHash datahash))
+        Nothing -> Nothing
 
 -- ==================================
 -- translate Values
@@ -340,12 +332,17 @@ txInfo ::
   forall era tx m.
   ( Era era,
     Monad m,
-    Core.TxOut era ~ Alonzo.TxOut era,
-    Core.TxBody era ~ Alonzo.TxBody era,
     Value era ~ Mary.Value (Crypto era),
     HasField "body" tx (Core.TxBody era),
     HasField "wits" tx (TxWitness era),
-    HasField "_protocolVersion" (PParams era) ProtVer
+    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash (Crypto era) EraIndependentData)),
+    HasField "_protocolVersion" (PParams era) ProtVer,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "mint" (Core.TxBody era) (Mary.Value (Crypto era)),
+    HasField "vldt" (Core.TxBody era) ValidityInterval
   ) =>
   Core.PParams era ->
   Language ->
@@ -361,39 +358,41 @@ txInfo pp lang ei sysS utxo tx = do
       PlutusV1 ->
         TxInfoPV1 $
           PV1.TxInfo
-            { PV1.txInfoInputs = mapMaybe (txInfoIn utxo) (Set.toList (inputs' tbody)),
-              PV1.txInfoOutputs = mapMaybe txInfoOut (foldr (:) [] outs),
+            { PV1.txInfoInputs = mapMaybe (txInfoIn utxo) (Set.toList (getField @"inputs" tbody)),
+              PV1.txInfoOutputs = mapMaybe (txInfoOut @era) (foldr (:) [] outs),
               PV1.txInfoFee = transValue (inject @(Mary.Value (Crypto era)) fee),
               PV1.txInfoMint = transValue forge,
-              PV1.txInfoDCert = foldr (\c ans -> transDCert c : ans) [] (certs' tbody),
-              PV1.txInfoWdrl = Map.toList (transWdrl (wdrls' tbody)),
+              PV1.txInfoDCert = foldr (\c ans -> transDCert c : ans) [] (getField @"certs" tbody),
+              PV1.txInfoWdrl = Map.toList (transWdrl (getField @"wdrls" tbody)),
               PV1.txInfoValidRange = timeRange,
-              PV1.txInfoSignatories = map transKeyHash (Set.toList (reqSignerHashes' tbody)),
+              PV1.txInfoSignatories = map transKeyHash (Set.toList (getField @"reqSignerHashes" tbody)),
               PV1.txInfoData = map transDataPair datpairs,
               PV1.txInfoId = PV1.TxId (transSafeHash (hashAnnotated @(Crypto era) tbody))
             }
       PlutusV2 ->
         TxInfoPV2 $
           PV2.TxInfo
-            { PV2.txInfoInputs = mapMaybe (txInfoIn utxo) (Set.toList (inputs' tbody)),
+            { PV2.txInfoInputs = mapMaybe (txInfoIn utxo) (Set.toList (getField @"inputs" tbody)),
               PV2.txInfoOutputs = mapMaybe txInfoOut (foldr (:) [] outs),
               PV2.txInfoFee = transValue (inject @(Mary.Value (Crypto era)) fee),
               PV2.txInfoMint = transValue forge,
-              PV2.txInfoDCert = foldr (\c ans -> transDCert c : ans) [] (certs' tbody),
-              PV2.txInfoWdrl = PV2.fromList $ Map.toList (transWdrl (wdrls' tbody)),
+              PV2.txInfoDCert = foldr (\c ans -> transDCert c : ans) [] (getField @"certs" tbody),
+              PV2.txInfoWdrl = PV2.fromList $ Map.toList (transWdrl (getField @"wdrls" tbody)),
               PV2.txInfoValidRange = timeRange,
-              PV2.txInfoSignatories = map transKeyHash (Set.toList (reqSignerHashes' tbody)),
+              PV2.txInfoSignatories = map transKeyHash (Set.toList (getField @"reqSignerHashes" tbody)),
               PV2.txInfoRedeemers = PV2.fromList $ mapMaybe (transRedeemerPtr tbody) rdmrs,
               PV2.txInfoData = PV2.fromList $ map transDataPair datpairs,
               PV2.txInfoId = PV2.TxId (transSafeHash (hashAnnotated @(Crypto era) tbody))
             }
   where
+    tbody :: Core.TxBody era
     tbody = getField @"body" tx
     _witnesses = getField @"wits" tx
-    outs = outputs' tbody
-    fee = txfee' tbody
-    forge = mint' tbody
-    interval = vldt' tbody
+    outs = getField @"outputs" tbody
+    fee = getField @"txfee" tbody
+    forge = getField @"mint" tbody
+    interval = getField @"vldt" tbody
+
     datpairs = Map.toList (unTxDats $ txdats' _witnesses)
     rdmrs = Map.toList (unRedeemers $ txrdmrs' _witnesses)
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -34,9 +34,11 @@ common project-config
 library
   import:             base, project-config
   exposed-modules:
+    Cardano.Ledger.Babbage.Genesis
     Cardano.Ledger.Babbage.PParams
     Cardano.Ledger.Babbage.Tx
     Cardano.Ledger.Babbage.TxBody
+    Cardano.Ledger.Babbage
   build-depends:
     array,
     base-deriving-via,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -35,6 +35,7 @@ library
   import:             base, project-config
   exposed-modules:
     Cardano.Ledger.Babbage.PParams
+    Cardano.Ledger.Babbage.Tx
     Cardano.Ledger.Babbage.TxBody
   build-depends:
     array,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -1,0 +1,281 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Babbage
+  ( BabbageEra,
+    Self,
+    TxOut,
+    Value,
+    TxBody,
+    Script,
+    AuxiliaryData,
+    PParams,
+    PParamsDelta,
+  )
+where
+
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..))
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import qualified Cardano.Ledger.Alonzo.Rules.Bbody as Alonzo (AlonzoBBODY)
+import qualified Cardano.Ledger.Alonzo.Rules.Ledger as Alonzo (AlonzoLEDGER)
+import Cardano.Ledger.Alonzo.Rules.Utxo (utxoEntrySize)
+import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
+import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS)
+import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
+import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
+import Cardano.Ledger.Alonzo.TxInfo (validScript)
+import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
+import Cardano.Ledger.Babbage.Genesis
+import Cardano.Ledger.Babbage.PParams
+  ( PParams,
+    PParams' (..),
+    PParamsUpdate,
+    updatePParams,
+  )
+import Cardano.Ledger.Babbage.Tx (ValidatedTx (..), minfee)
+import Cardano.Ledger.Babbage.TxBody (Datum (..), TxBody, TxOut (TxOut), getBabbageTxOutEitherAddr)
+import Cardano.Ledger.BaseTypes (BlocksMade (..))
+import Cardano.Ledger.Coin
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Crypto as CC
+import qualified Cardano.Ledger.Era as EraModule
+import Cardano.Ledger.Keys (GenDelegs (GenDelegs))
+import qualified Cardano.Ledger.Mary.Value as V (Value)
+import Cardano.Ledger.PoolDistr (PoolDistr (..))
+import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
+import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.Shelley (nativeMultiSigTag)
+import qualified Cardano.Ledger.Shelley.API as API
+import Cardano.Ledger.Shelley.Constraints
+  ( UsesPParams (..),
+    UsesTxOut (..),
+    UsesValue,
+  )
+import Cardano.Ledger.Shelley.EpochBoundary
+import Cardano.Ledger.Shelley.Genesis (genesisUTxO, sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams)
+import Cardano.Ledger.Shelley.LedgerState
+  ( AccountState (..),
+    DPState (..),
+    EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    smartUTxOState,
+    _genDelegs,
+  )
+import Cardano.Ledger.Shelley.Metadata (validMetadatum)
+import qualified Cardano.Ledger.Shelley.Rules.Epoch as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Mir as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Newpp as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Rupd as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Snap as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Tick as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Upec as Shelley
+import qualified Cardano.Ledger.Shelley.Tx as Shelley
+import Cardano.Ledger.Shelley.UTxO (balance)
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed)
+import Cardano.Ledger.ShelleyMA.Timelocks (validateTimelock)
+import Cardano.Ledger.Val (Val (inject), coin, (<->))
+import Control.Arrow (left)
+import Control.Monad.Except (liftEither)
+import Control.Monad.Reader (runReader)
+import Control.State.Transition.Extended (TRC (TRC))
+import Data.Default (def)
+import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict
+import qualified Data.Set as Set
+
+-- =====================================================
+
+-- | The Alonzo era
+data BabbageEra c
+
+instance
+  ( CC.Crypto c,
+    era ~ BabbageEra c
+  ) =>
+  EraModule.Era (BabbageEra c)
+  where
+  type Crypto (BabbageEra c) = c
+
+  getTxOutEitherAddr = getBabbageTxOutEitherAddr
+
+instance API.ShelleyEraCrypto c => API.ApplyTx (BabbageEra c) where
+  reapplyTx globals env state vtx =
+    let res =
+          flip runReader globals
+            . applySTSNonStatic
+              @(Core.EraRule "LEDGER" (BabbageEra c))
+            $ TRC (env, state, API.extractTx vtx)
+     in liftEither . left API.ApplyTxError $ res
+
+instance API.ShelleyEraCrypto c => API.ApplyBlock (BabbageEra c)
+
+instance (CC.Crypto c) => Shelley.ValidateScript (BabbageEra c) where
+  isNativeScript x = not (isPlutusScript x)
+  scriptPrefixTag script =
+    case script of
+      (TimelockScript _) -> nativeMultiSigTag -- "\x00"
+      (PlutusScript PlutusV1 _) -> "\x01"
+      (PlutusScript PlutusV2 _) -> "\x02"
+  validateScript (TimelockScript script) tx = validateTimelock @(BabbageEra c) script tx
+  validateScript (PlutusScript _ _) _tx = True
+
+instance
+  ( CC.Crypto c
+  ) =>
+  API.CanStartFromGenesis (BabbageEra c)
+  where
+  type AdditionalGenesisConfig (BabbageEra c) = AlonzoGenesis
+
+  initialState sg ag =
+    NewEpochState
+      initialEpochNo
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      ( EpochState
+          (AccountState (Coin 0) reserves)
+          emptySnapShots
+          ( LedgerState
+              ( smartUTxOState
+                  initialUtxo
+                  (Coin 0)
+                  (Coin 0)
+                  def
+              )
+              (DPState (def {_genDelegs = GenDelegs genDelegs}) def)
+          )
+          (extendPPWithGenesis pp ag)
+          (extendPPWithGenesis pp ag)
+          def
+      )
+      SNothing
+      (PoolDistr Map.empty)
+    where
+      initialEpochNo = 0
+      initialUtxo = genesisUTxO sg
+      reserves =
+        coin $
+          inject (word64ToCoin (sgMaxLovelaceSupply sg))
+            <-> balance initialUtxo
+      genDelegs = sgGenDelegs sg
+      pp = sgProtocolParams sg
+
+instance CC.Crypto c => UsesTxOut (BabbageEra c) where
+  makeTxOut _proxy addr val = TxOut addr val NoDatum
+
+instance CC.Crypto c => API.CLI (BabbageEra c) where
+  evaluateMinFee = minfee
+
+  evaluateConsumed = consumed
+
+  addKeyWitnesses (ValidatedTx b ws aux iv) newWits = ValidatedTx b ws' aux iv
+    where
+      ws' = ws {txwitsVKey = Set.union newWits (txwitsVKey ws)}
+
+  evaluateMinLovelaceOutput pp out =
+    Coin $ utxoEntrySize out * unCoin (_coinsPerUTxOWord pp)
+
+type instance Core.Tx (BabbageEra c) = ValidatedTx (BabbageEra c)
+
+type instance Core.TxOut (BabbageEra c) = TxOut (BabbageEra c)
+
+type instance Core.TxBody (BabbageEra c) = TxBody (BabbageEra c)
+
+type instance Core.Value (BabbageEra c) = V.Value c
+
+type instance Core.Script (BabbageEra c) = Script (BabbageEra c)
+
+type instance Core.AuxiliaryData (BabbageEra c) = AuxiliaryData (BabbageEra c)
+
+type instance Core.PParams (BabbageEra c) = PParams (BabbageEra c)
+
+type instance Core.Witnesses (BabbageEra c) = TxWitness (BabbageEra c)
+
+type instance Core.PParamsDelta (BabbageEra c) = PParamsUpdate (BabbageEra c)
+
+instance CC.Crypto c => UsesValue (BabbageEra c)
+
+instance (CC.Crypto c) => UsesPParams (BabbageEra c) where
+  mergePPUpdates _ = updatePParams
+
+instance CC.Crypto c => ValidateAuxiliaryData (BabbageEra c) c where
+  hashAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)
+  validateAuxiliaryData (AuxiliaryData metadata scrips) =
+    all validMetadatum metadata
+      && all validScript scrips
+
+instance CC.Crypto c => EraModule.SupportsSegWit (BabbageEra c) where
+  type TxSeq (BabbageEra c) = Alonzo.TxSeq (BabbageEra c)
+  fromTxSeq = Alonzo.txSeqTxns
+  toTxSeq = Alonzo.TxSeq
+  hashTxSeq = Alonzo.hashTxSeq
+  numSegComponents = 4
+
+instance API.ShelleyEraCrypto c => API.ShelleyBasedEra (BabbageEra c)
+
+-------------------------------------------------------------------------------
+-- Era Mapping
+-------------------------------------------------------------------------------
+
+-- Rules inherited from Alonzo
+
+type instance Core.EraRule "UTXOS" (BabbageEra c) = Alonzo.UTXOS (BabbageEra c)
+
+type instance Core.EraRule "UTXO" (BabbageEra c) = Alonzo.AlonzoUTXO (BabbageEra c)
+
+type instance Core.EraRule "UTXOW" (BabbageEra c) = Alonzo.AlonzoUTXOW (BabbageEra c)
+
+type instance Core.EraRule "LEDGER" (BabbageEra c) = Alonzo.AlonzoLEDGER (BabbageEra c)
+
+type instance Core.EraRule "BBODY" (BabbageEra c) = Alonzo.AlonzoBBODY (BabbageEra c)
+
+-- Rules inherited from Shelley
+
+type instance Core.EraRule "DELEG" (BabbageEra c) = API.DELEG (BabbageEra c)
+
+type instance Core.EraRule "DELEGS" (BabbageEra c) = API.DELEGS (BabbageEra c)
+
+type instance Core.EraRule "DELPL" (BabbageEra c) = API.DELPL (BabbageEra c)
+
+type instance Core.EraRule "EPOCH" (BabbageEra c) = Shelley.EPOCH (BabbageEra c)
+
+type instance Core.EraRule "LEDGERS" (BabbageEra c) = API.LEDGERS (BabbageEra c)
+
+type instance Core.EraRule "MIR" (BabbageEra c) = Shelley.MIR (BabbageEra c)
+
+type instance Core.EraRule "NEWEPOCH" (BabbageEra c) = API.NEWEPOCH (BabbageEra c)
+
+type instance Core.EraRule "NEWPP" (BabbageEra c) = Shelley.NEWPP (BabbageEra c)
+
+type instance Core.EraRule "POOL" (BabbageEra c) = API.POOL (BabbageEra c)
+
+type instance Core.EraRule "POOLREAP" (BabbageEra c) = API.POOLREAP (BabbageEra c)
+
+type instance Core.EraRule "PPUP" (BabbageEra c) = API.PPUP (BabbageEra c)
+
+type instance Core.EraRule "RUPD" (BabbageEra c) = Shelley.RUPD (BabbageEra c)
+
+type instance Core.EraRule "SNAP" (BabbageEra c) = Shelley.SNAP (BabbageEra c)
+
+type instance Core.EraRule "TICK" (BabbageEra c) = Shelley.TICK (BabbageEra c)
+
+type instance Core.EraRule "TICKF" (BabbageEra c) = Shelley.TICKF (BabbageEra c)
+
+type instance Core.EraRule "UPEC" (BabbageEra c) = Shelley.UPEC (BabbageEra c)
+
+-- Self-Describing type synomyms
+
+type Self c = BabbageEra c
+
+type Value era = V.Value (EraModule.Crypto era)
+
+type PParamsDelta era = PParamsUpdate era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Genesis.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Genesis.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Ledger.Babbage.Genesis
+  ( AlonzoGenesis (..),
+    extendPPWithGenesis,
+  )
+where
+
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
+import Cardano.Ledger.Babbage.PParams
+import qualified Cardano.Ledger.Shelley.PParams as Shelley
+import Data.Functor.Identity
+
+-- | Given the missing pieces turn a Shelley.PParams' into an Params'
+extendPPWithGenesis ::
+  Shelley.PParams' Identity era1 ->
+  AlonzoGenesis ->
+  PParams' Identity era2
+extendPPWithGenesis
+  pp
+  AlonzoGenesis
+    { coinsPerUTxOWord,
+      costmdls,
+      prices,
+      maxTxExUnits,
+      maxBlockExUnits,
+      maxValSize,
+      collateralPercentage,
+      maxCollateralInputs
+    } =
+    extendPP
+      pp
+      coinsPerUTxOWord
+      costmdls
+      prices
+      maxTxExUnits
+      maxBlockExUnits
+      maxValSize
+      collateralPercentage
+      maxCollateralInputs

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -1,0 +1,8 @@
+module Cardano.Ledger.Babbage.Tx
+  ( module X,
+    TxBody (..),
+  )
+where
+
+import Cardano.Ledger.Alonzo.Tx as X hiding (TxBody (..))
+import Cardano.Ledger.Babbage.TxBody (TxBody (..))

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -58,6 +58,7 @@ module Cardano.Ledger.Babbage.TxBody
     scriptIntegrityHash',
     adHash',
     txnetworkid',
+    getBabbageTxOutEitherAddr,
     BabbageBody,
     EraIndependentScriptIntegrity,
     ScriptIntegrityHash,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Alonzo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Alonzo.hs
@@ -15,6 +15,7 @@ import Cardano.Crypto.Util (SignableRepresentation)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Genesis as Alonzo (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import Cardano.Ledger.Alonzo.Rules.Utxo
   ( UtxoPredicateFailure (..),
   )


### PR DESCRIPTION
this adds `Cardano.Ledger.Babbage` + some small modules with mostly just reexport Alonzo stuff, and it also makes some alonzo rules era polymorphic so we can reuse them for babbage