### PR TITLE
remove subSlotCount function

### DIFF
--- a/eras/byron/ledger/impl/src/Cardano/Chain/Slotting/SlotNumber.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Slotting/SlotNumber.hs
@@ -10,6 +10,7 @@
 module Cardano.Chain.Slotting.SlotNumber
   ( SlotNumber (..),
     addSlotCount,
+    -- deprecated
     subSlotCount,
   )
 where
@@ -57,9 +58,12 @@ instance B.Buildable SlotNumber where
 
 -- | Increase a 'SlotNumber' by 'SlotCount'
 addSlotCount :: SlotCount -> SlotNumber -> SlotNumber
-addSlotCount (SlotCount a) (SlotNumber b) = SlotNumber $ a + b
+addSlotCount (SlotCount a) (SlotNumber b)
+  | a <= maxBound - b = SlotNumber $ a + b
+  | otherwise = SlotNumber maxBound
 
 -- | Decrease a 'SlotNumber' by 'SlotCount', going no lower than 0
+{-# DEPRECATED subSlotCount "this function is dangerous and can usually be replaced by addSlotCount" #-}
 subSlotCount :: SlotCount -> SlotNumber -> SlotNumber
 subSlotCount (SlotCount a) (SlotNumber b) =
   if a > b then SlotNumber 0 else SlotNumber (b - a)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Endorsement.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Endorsement.hs
@@ -26,7 +26,7 @@ import Cardano.Binary
 import Cardano.Chain.Common (BlockCount, KeyHash)
 import qualified Cardano.Chain.Delegation as Delegation
 import Cardano.Chain.ProtocolConstants (kSlotSecurityParam)
-import Cardano.Chain.Slotting (SlotNumber, subSlotCount)
+import Cardano.Chain.Slotting (SlotNumber, addSlotCount)
 import Cardano.Chain.Update.Proposal (UpId)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Chain.Update.ProtocolVersion (ProtocolVersion)
@@ -172,8 +172,7 @@ register env st endorsement =
     isConfirmedAndStable upId = upId `M.member` scps
       where
         -- Stable and confirmed proposals.
-        scps = M.filter (<= stableAt) confirmedProposals
-        stableAt = subSlotCount (kSlotSecurityParam k) currentSlot
+        scps = M.filter (\x -> addSlotCount (kSlotSecurityParam k) x <= currentSlot) confirmedProposals
 
     numberOfEndorsements :: Int
     numberOfEndorsements =

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -51,8 +51,8 @@ import Cardano.Chain.Slotting
   ( EpochNumber,
     SlotCount (SlotCount),
     SlotNumber,
+    addSlotCount,
     epochFirstSlot,
-    subSlotCount,
     unSlotNumber,
   )
 import Cardano.Chain.Update.Proposal (AProposal, UpId, recoverUpId)
@@ -403,7 +403,7 @@ registerEndorsement env st endorsement = do
   let pidsKeep = nonExpiredPids `union` confirmedPids
 
       nonExpiredPids =
-        M.keysSet $ M.filter (subSlotCount u currentSlot <=) proposalRegistrationSlot
+        M.keysSet $ M.filter (\s -> currentSlot <= addSlotCount u s) proposalRegistrationSlot
 
       confirmedPids = M.keysSet confirmedProposals
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface/ProtocolVersionBump.hs
@@ -9,7 +9,7 @@ where
 
 import Cardano.Chain.Common.BlockCount (BlockCount)
 import Cardano.Chain.ProtocolConstants (kUpdateStabilityParam)
-import Cardano.Chain.Slotting (SlotNumber, subSlotCount)
+import Cardano.Chain.Slotting (SlotNumber, addSlotCount)
 import Cardano.Chain.Update.ProtocolParameters (ProtocolParameters)
 import Cardano.Chain.Update.ProtocolVersion (ProtocolVersion)
 import Cardano.Chain.Update.Validation.Endorsement
@@ -59,4 +59,4 @@ tryBumpVersion env st =
     Environment {k, epochFirstSlot, candidateProtocolVersions} = env
 
     stableCandidates =
-      filter ((<= subSlotCount (kUpdateStabilityParam k) epochFirstSlot) . cpuSlot) candidateProtocolVersions
+      filter ((\x -> addSlotCount (kUpdateStabilityParam k) x <= epochFirstSlot) . cpuSlot) candidateProtocolVersions

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Slotting/Properties.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Slotting/Properties.hs
@@ -10,7 +10,6 @@ import Cardano.Chain.Slotting
     SlotNumber (..),
     addSlotCount,
     fromSlotNumber,
-    subSlotCount,
     toSlotNumber,
   )
 import Cardano.Prelude
@@ -66,16 +65,10 @@ ts_prop_addSlotCount = withTestsTS 100 . property $ do
   sc <- forAll genSlotCount
   fs <- forAll genSlotNumber
   let added = fs + (SlotNumber $ unSlotCount sc)
-  addSlotCount sc fs === added
-
--- Check that `subSlotCount` actually subtracts.
-ts_prop_subSlotCount :: TSProperty
-ts_prop_subSlotCount = withTestsTS 100 . property $ do
-  sc <- forAll genSlotCount
-  fs <- forAll genSlotNumber
-  let sc' = SlotNumber $ unSlotCount sc
-      subtracted = fs - sc'
-  subSlotCount sc fs === if fs > sc' then subtracted else SlotNumber 0
+  addSlotCount sc fs
+    === if unSlotNumber fs <= maxBound - (unSlotCount sc)
+      then added
+      else SlotNumber maxBound
 
 tests :: TSGroup
 tests = $$discoverPropArg


### PR DESCRIPTION
The `subSlotCount` function is dangerous and can be replaced by `addSlotCount` everywhere in the consensus and ledger repositories.

closes #1698 