### PR TITLE
computeStabilityWindow should not use to Double

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module Cardano.Ledger.Shelley.StabilityWindow
   ( computeStabilityWindow,
     computeRandomnessStabilisationWindow,
@@ -19,7 +17,7 @@ computeStabilityWindow ::
   ActiveSlotCoeff ->
   Word64
 computeStabilityWindow k asc =
-  ceiling $ fromIntegral @_ @Double (3 * k) / fromRational f
+  ceiling $ (3 * fromIntegral k) / f
   where
     f = unboundRational . activeSlotVal $ asc
 
@@ -33,6 +31,6 @@ computeRandomnessStabilisationWindow ::
   ActiveSlotCoeff ->
   Word64
 computeRandomnessStabilisationWindow k asc =
-  ceiling $ fromIntegral @_ @Double (4 * k) / fromRational f
+  ceiling $ (4 * fromIntegral k) / f
   where
     f = unboundRational . activeSlotVal $ asc


### PR DESCRIPTION
There is no good reason to convert to a double before taking the ceiling in this function. We now use Rational instead. Even though this is actually a different function now, we can get away with this since both mainnet and testnet have only ever had a single value which happens to agree in both versions. In particular, mainnet and testnet have always
had `k = 2160` and `f = 1/20`.

Similarly for `computeRandomnessStabilisationWindow`.

closes #2073 