### PR TITLE
Fix error in Shelley Spec regarding new pool count

### DIFF
--- a/eras/shelley/formal-spec/epoch.tex
+++ b/eras/shelley/formal-spec/epoch.tex
@@ -571,13 +571,10 @@ This transition has no preconditions and results in the following state change:
                  & \{\var{hk}\mapsto \fun{poolRAcnt}~\var{pool} \mid
                    \var{hk}\mapsto\var{pool} \in \var{retired}\restrictdom\var{poolParams} \} \\
         \var{rewardAcnts'} & \left\{
-                        a \mapsto c
-                        \mathrel{\Bigg|}
-                        \begin{array}{r@{~\in~}l}
-                          \var{hk} \mapsto c & \var{pr}, \\
-                          \var{hk}\mapsto\var{a} & \var{rewardAcnts} \\
-                        \end{array}
-                      \right\} \\
+                               \sum\limits_{\wcard\mapsto c\in\var{pr}\circ\var{rewardAcnts}^{-1}(a)} c
+                               \mathrel{\Bigg|}
+			       a\in\range{rewardAcnts}
+                             \right\} \\
         \var{refunds} & \dom{rewards}\restrictdom\var{rewardAcnts'} \\
         \var{mRefunds} & \dom{rewards}\subtractdom\var{rewardAcnts'} \\
         \var{refunded} & \sum\limits_{\wcard\mapsto c\in\var{refunds}} c \\

--- a/eras/shelley/formal-spec/epoch.tex
+++ b/eras/shelley/formal-spec/epoch.tex
@@ -571,9 +571,10 @@ This transition has no preconditions and results in the following state change:
                  & \{\var{hk}\mapsto \fun{poolRAcnt}~\var{pool} \mid
                    \var{hk}\mapsto\var{pool} \in \var{retired}\restrictdom\var{poolParams} \} \\
         \var{rewardAcnts'} & \left\{
-                               \sum\limits_{\wcard\mapsto c\in\var{pr}\circ\var{rewardAcnts}^{-1}(a)} c
-                               \mathrel{\Bigg|}
-			       a\in\range{rewardAcnts}
+                               a \mapsto
+                               \sum\var{pr}(\var{rewardAcnts}^{-1}(a))
+                               \mathrel{\Big|}
+                               a\in\range{rewardAcnts}
                              \right\} \\
         \var{refunds} & \dom{rewards}\restrictdom\var{rewardAcnts'} \\
         \var{mRefunds} & \dom{rewards}\subtractdom\var{rewardAcnts'} \\

--- a/eras/shelley/formal-spec/frontmatter.tex
+++ b/eras/shelley/formal-spec/frontmatter.tex
@@ -40,6 +40,7 @@
           The TICKN rule was missing from the dependency diagram.}
         \change{2021/11/08}{Jared Corduan}{FM (IOHK)}{Fixed typo in the description of variable length encodings.}
         \change{2021/12/13}{Jared Corduan}{FM (IOHK)}{Re-wrote the MIR transitions to be more compact.}
+        \change{2022/1/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits.}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}

--- a/eras/shelley/formal-spec/frontmatter.tex
+++ b/eras/shelley/formal-spec/frontmatter.tex
@@ -40,7 +40,7 @@
           The TICKN rule was missing from the dependency diagram.}
         \change{2021/11/08}{Jared Corduan}{FM (IOHK)}{Fixed typo in the description of variable length encodings.}
         \change{2021/12/13}{Jared Corduan}{FM (IOHK)}{Re-wrote the MIR transitions to be more compact.}
-        \change{2022/1/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits.}
+        \change{2022/1/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits and an error in the POOLREAP rule.}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}

--- a/eras/shelley/formal-spec/utxo.tex
+++ b/eras/shelley/formal-spec/utxo.tex
@@ -401,9 +401,9 @@ and refund functions.
     & \text{total deposits for transaction} \\
     & \totalDeposits{pp}{poolParams}{certs} = \\
     &  ~~~ (\fun{keyDeposit}~pp)\cdot|\var{certs}\cap\DCertRegKey| \\
-    &  ~~~~~ + (\fun{poolDeposit}~pp)\cdot|\var{newPools}| \\
+    &  ~~~~~ + (\fun{poolDeposit}~pp)\cdot|\{\cwitness{c} ~\mid c\in~\var{newPools}\}| \\
     & ~~~\where \\
-    &  ~~~~~~~ \var{newPools} = \{\var{certs}\cap\DCertRegPool ~\mid~ \cwitness{c}\notin \var{poolParams}\}
+    &  ~~~~~~~ \var{newPools} = \{c ~\mid~ \var{certs}\cap\DCertRegPool,\cwitness{c}\notin \var{poolParams}\}
     \nextdef
       & \fun{keyRefunds} \in \PParams \to \TxBody \to \Coin
       & \text{key refunds for a transaction} \\

--- a/eras/shelley/formal-spec/utxo.tex
+++ b/eras/shelley/formal-spec/utxo.tex
@@ -398,15 +398,15 @@ and refund functions.
   \begin{align*}
     & \fun{totalDeposits} \in \PParams \to (\KeyHash_{pool}\mapsto\PoolParam) \\
     & ~~~~\to \seqof{\DCert} \to \Coin
-    & \text{total deposits for transaction} \\
+    & \text{total deposits for a tx} \\
     & \totalDeposits{pp}{poolParams}{certs} = \\
     &  ~~~ (\fun{keyDeposit}~pp)\cdot|\var{certs}\cap\DCertRegKey| \\
     &  ~~~~~ + (\fun{poolDeposit}~pp)\cdot|\{\cwitness{c} ~\mid c\in~\var{newPools}\}| \\
     & ~~~\where \\
-    &  ~~~~~~~ \var{newPools} = \{c ~\mid~ \var{certs}\cap\DCertRegPool,\cwitness{c}\notin \var{poolParams}\}
+    &  ~~~~~~~ \var{newPools} = \{c ~\mid~ c\in\var{certs}\cap\DCertRegPool,~\cwitness{c}\notin \var{poolParams}\}
     \nextdef
       & \fun{keyRefunds} \in \PParams \to \TxBody \to \Coin
-      & \text{key refunds for a transaction} \\
+      & \text{key refunds for a tx} \\
       & \keyRefunds{pp}{tx} = (\fun{keyDeposit}~\var{pp})\cdot|\txcerts{tx} \cap \DCertDeRegKey|\\
       \end{align*}
       \caption{Functions used in Deposits - Refunds}


### PR DESCRIPTION
Two small changes the Shelley spec (where the code was doing the correct thing).

1. In the Shelley spec, Figure 17, `newPools` is counting certificates, but should be counting unique pool ids. 
2. In the `POOLREAP` rule, we were not accounting for the fact that multiple retiring pools could have the same stake address. the old version used:
![old-rewardAcnts](https://user-images.githubusercontent.com/943479/150408545-33685d9e-9fae-4714-bbc1-222b9e43ccfb.png)
the new version uses:
![new-rewardAcnts](https://user-images.githubusercontent.com/943479/150408587-455b4ab8-d68a-40b8-a349-06003303d5f4.png)


closes #2517
closes #2587