### PR TITLE
specify the seed operation and slotToSeed function

### DIFF
--- a/eras/shelley/formal-spec/crypto-details.tex
+++ b/eras/shelley/formal-spec/crypto-details.tex
@@ -52,6 +52,14 @@ More generally, we expect the following properties from a Verifyable Random Func
 \item[Pseudorandomness] Assuming the public-private key pair has been generated honestly, the VRF hash output on any adversarially-chosen VRF input looks indistinguishable from random for a computationally bounded adversary who does not know the private key. 
 \end{description}
 
+\subsection{Abstract functions $\seedOp$ and \fun{seedToSlot}}
+\label{sec:mkseed-slottoseed}
+The seed operation $x \seedOp y$ from Figure~\ref{fig:defs-vrf} is implemented
+as the BLAKE2b-256 hash of the concatenation of $x$ and $y$.
+
+The function \fun{slotToSeed} from Figure~\ref{fig:defs:blocks} is implemented
+as the big-endian encoding of the slot number in 8 bytes.
+
 \subsection{Multi-Signatures}
 As presented in Figure~\ref{fig:types-msig}, Shelley realizes multi-signatures 
 in a native way, via a script-like DSL. One defines the conditions required to 

--- a/eras/shelley/formal-spec/frontmatter.tex
+++ b/eras/shelley/formal-spec/frontmatter.tex
@@ -40,8 +40,9 @@
           The TICKN rule was missing from the dependency diagram.}
         \change{2021/11/08}{Jared Corduan}{FM (IOHK)}{Fixed typo in the description of variable length encodings.}
         \change{2021/12/13}{Jared Corduan}{FM (IOHK)}{Re-wrote the MIR transitions to be more compact.}
-        \change{2022/1/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits and an error in the POOLREAP rule.}
-        \change{2022/1/31}{Jordan Millar, Jared Corduan}{FM (IOHK)}{Fixed prose regarding the hash used in the epoch nonce. Added an item to the errata regarding this same hash.}
+        \change{2022/01/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits and an error in the POOLREAP rule.}
+        \change{2022/01/26}{Jared Corduan}{FM (IOHK)}{Specify seed operation and seedToSlot.}
+        \change{2022/01/31}{Jordan Millar, Jared Corduan}{FM (IOHK)}{Fixed prose regarding the hash used in the epoch nonce. Added an item to the errata regarding this same hash.}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}


### PR DESCRIPTION
specify the seed operation and `slotToSeed` function in the appendix of the Shelley Ledger specification.

closes #1323