### PR TITLE
Add EraIndependentBlockHeader

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Hashes
   ( -- * Era-independent hash type identifiers.
     -- $eraIndep
     EraIndependentTxBody,
+    EraIndependentBlockHeader,
     EraIndependentBlockBody,
     EraIndependentMetadata,
     EraIndependentScript,
@@ -46,6 +47,8 @@ import NoThunks.Class (NoThunks (..))
 --   define some era-independent indices here.
 
 data EraIndependentTxBody
+
+data EraIndependentBlockHeader
 
 data EraIndependentBlockBody
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -73,7 +73,10 @@ import Cardano.Ledger.BaseTypes
     mkNonceFromOutputVRF,
   )
 import qualified Cardano.Ledger.Crypto as CC
-import Cardano.Ledger.Hashes (EraIndependentBlockBody)
+import Cardano.Ledger.Hashes
+  ( EraIndependentBlockBody,
+    EraIndependentBlockHeader,
+  )
 import Cardano.Ledger.Keys
   ( CertifiedVRF,
     Hash,
@@ -112,7 +115,7 @@ import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import Numeric.Natural (Natural)
 
 -- | The hash of a Block Header
-newtype HashHeader crypto = HashHeader {unHashHeader :: Hash crypto (BHeader crypto)}
+newtype HashHeader crypto = HashHeader {unHashHeader :: Hash crypto EraIndependentBlockHeader}
   deriving stock (Show, Eq, Generic, Ord)
   deriving newtype (NFData, NoThunks)
 
@@ -323,7 +326,7 @@ bhHash ::
   CC.Crypto crypto =>
   BHeader crypto ->
   HashHeader crypto
-bhHash = HashHeader . Hash.hashWithSerialiser toCBOR
+bhHash = HashHeader . Hash.castHash . Hash.hashWithSerialiser toCBOR
 
 -- | HashHeader to Nonce
 -- What is going on here?


### PR DESCRIPTION
Now we have new protocols, the header may change, so introduce an era
(protocol) independent marker for this.