### PR TITLE
Reduce overhead of inline datums

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -98,14 +98,8 @@ import qualified Data.Set as Set
 -- | The Alonzo era
 data AlonzoEra c
 
-instance
-  ( CC.Crypto c,
-    era ~ AlonzoEra c
-  ) =>
-  EraModule.Era (AlonzoEra c)
-  where
+instance CC.Crypto c => EraModule.Era (AlonzoEra c) where
   type Crypto (AlonzoEra c) = c
-
   getTxOutEitherAddr = getAlonzoTxOutEitherAddr
 
 instance API.ShelleyEraCrypto c => API.ApplyTx (AlonzoEra c) where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -22,7 +22,6 @@ module Cardano.Ledger.Alonzo.PlutusScriptApi
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Data (getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..))
@@ -161,7 +160,6 @@ collectTwoPhaseScriptInputs ::
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "body" tx (Core.TxBody era),
     HasField "wits" tx (TxWitness era),
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "mint" (Core.TxBody era) (Mary.Value (Crypto era)),
     HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
     HasField "vldt" (Core.TxBody era) ValidityInterval

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -22,7 +22,6 @@ module Cardano.Ledger.Alonzo.Rules.Utxos
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Language (Language)
 import Cardano.Ledger.Alonzo.PlutusScriptApi
   ( CollectError,
@@ -103,7 +102,6 @@ instance
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
@@ -153,7 +151,6 @@ utxosTransition ::
     ToCBOR (Core.TxBody era),
     Core.ChainData (Core.TxOut era),
     Core.SerialisableData (Core.TxOut era),
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     HasField "mint" (Core.TxBody era) (Value (Crypto era)),
     HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
@@ -190,7 +187,6 @@ scriptsValidateTransition ::
     Core.SerialisableData (Core.TxOut era),
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "mint" (Core.TxBody era) (Value (Crypto era)),
@@ -267,7 +263,6 @@ scriptsNotValidateTransition ::
     HasField "_keyDeposit" (Core.PParams era) Coin,
     HasField "_poolDeposit" (Core.PParams era) Coin,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -269,7 +269,7 @@ alonzoStyleWitness = do
       twoPhaseOuts =
         [ output
           | (_input, output) <- SplitMap.toList smallUtxo,
-            isTwoPhaseScriptAddress @era tx (getField @"address" output)
+            isTwoPhaseScriptAddress @era tx (getTxOutAddr output)
         ]
       utxoHashes' = mapM (getField @"datahash") twoPhaseOuts
   case utxoHashes' of
@@ -280,7 +280,7 @@ alonzoStyleWitness = do
         [ input
           | (input, output) <- SplitMap.toList smallUtxo,
             SNothing <- [getField @"datahash" output],
-            isTwoPhaseScriptAddress @era tx (getField @"address" output)
+            isTwoPhaseScriptAddress @era tx (getTxOutAddr output)
         ]
     SJust utxoHashes -> do
       let txHashes = domain (unTxDats . txdats . wits $ tx)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -869,12 +869,6 @@ instance
 instance HasField "txnetworkid" (TxBody era) (StrictMaybe Network) where
   getField (TxBodyConstr (Memo m _)) = _txnetworkid m
 
-instance (Era era, CC.Crypto c, Crypto era ~ c) => HasField "address" (TxOut era) (Addr c) where
-  getField t =
-    case getAlonzoTxOutEitherAddr t of
-      Left a -> a
-      Right ca -> decompactAddr ca
-
 instance (Era era, Core.Value era ~ val, Compactible val) => HasField "value" (TxOut era) val where
   getField (TxOutCompact _ v) = fromCompact v
   getField (TxOutCompactDH _ v _) = fromCompact v

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -21,7 +21,9 @@
 
 module Cardano.Ledger.Alonzo.TxBody
   ( TxOut (.., TxOut, TxOutCompact, TxOutCompactDH),
+    -- Constructors are not exported for safety:
     Addr28Extra,
+    DataHash32,
     TxBody
       ( TxBody,
         inputs,
@@ -146,6 +148,14 @@ data Addr28Extra
       {-# UNPACK #-} !Word64 -- Payment Addr (32bits) + ... +  0/1 for Testnet/Mainnet + 0/1 Script/Pubkey
   deriving (Eq)
 
+data DataHash32
+  = DataHash32
+      {-# UNPACK #-} !Word64 -- DataHash
+      {-# UNPACK #-} !Word64 -- DataHash
+      {-# UNPACK #-} !Word64 -- DataHash
+      {-# UNPACK #-} !Word64 -- DataHash
+  deriving Eq
+
 data TxOut era
   = TxOutCompact'
       {-# UNPACK #-} !(CompactAddr (Crypto era))
@@ -162,10 +172,7 @@ data TxOut era
       !(Credential 'Staking (Crypto era))
       {-# UNPACK #-} !Addr28Extra
       {-# UNPACK #-} !(CompactForm Coin) -- Ada value
-      {-# UNPACK #-} !Word64 -- DataHash
-      {-# UNPACK #-} !Word64 -- DataHash
-      {-# UNPACK #-} !Word64 -- DataHash
-      {-# UNPACK #-} !Word64 -- DataHash
+      {-# UNPACK #-} !DataHash32
 
 deriving stock instance
   ( Eq (Core.Value era),
@@ -204,7 +211,7 @@ decodeAddress28 stakeRef (Addr28Extra a b c d) = do
       addrHash =
         hashFromPackedBytes $
           PackedBytes28 a b c (fromIntegral (d `shiftR` 32))
-  pure $ Addr network paymentCred (StakeRefBase stakeRef)
+  pure $! Addr network paymentCred (StakeRefBase stakeRef)
 
 encodeAddress28 ::
   forall crypto.
@@ -240,25 +247,20 @@ encodeAddress28 network paymentCred = do
 decodeDataHash32 ::
   forall crypto.
   (SizeHash (CC.HASH crypto) ~ 32) =>
-  Word64 ->
-  Word64 ->
-  Word64 ->
-  Word64 ->
+  DataHash32 ->
   DataHash crypto
-decodeDataHash32 a b c d =
-  unsafeMakeSafeHash $
-    hashFromPackedBytes $
-      PackedBytes32 a b c d
+decodeDataHash32 (DataHash32 a b c d) =
+  unsafeMakeSafeHash $ hashFromPackedBytes $ PackedBytes32 a b c d
 
 encodeDataHash32 ::
   forall crypto.
   (HashAlgorithm (CC.HASH crypto)) =>
   DataHash crypto ->
-  Maybe (SizeHash (CC.HASH crypto) :~: 32, Word64, Word64, Word64, Word64)
+  Maybe (SizeHash (CC.HASH crypto) :~: 32, DataHash32)
 encodeDataHash32 dataHash = do
   refl@Refl <- sameNat (Proxy @(SizeHash (CC.HASH crypto))) (Proxy @32)
   case hashToPackedBytes (extractHash dataHash) of
-    PackedBytes32 a b c d -> Just (refl, a, b, c, d)
+    PackedBytes32 a b c d -> Just (refl, DataHash32 a b c d)
     _ -> Nothing
 
 viewCompactTxOut ::
@@ -272,13 +274,13 @@ viewCompactTxOut txOut = case txOut of
   TxOut_AddrHash28_AdaOnly stakeRef addr28Extra adaVal
     | Just addr <- decodeAddress28 stakeRef addr28Extra ->
       (compactAddr addr, toCompactValue adaVal, SNothing)
-    | otherwise -> error "Impossible: Compacted and address or hash of non-standard size"
-  TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal e f g h
+    | otherwise -> error "Impossible: Compacted an address of non-standard size"
+  TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal dataHash32
     | Just addr <- decodeAddress28 stakeRef addr28Extra,
       Just Refl <- sameNat (Proxy @(SizeHash (CC.HASH (Crypto era)))) (Proxy @32) ->
-      (compactAddr addr, toCompactValue adaVal, SJust (decodeDataHash32 e f g h))
+      (compactAddr addr, toCompactValue adaVal, SJust (decodeDataHash32 dataHash32))
     | otherwise ->
-      error "Impossible: Compacted and address or hash of non-standard size"
+      error "Impossible: Compacted an address or a hash of non-standard size"
   where
     toCompactValue :: CompactForm Coin -> CompactForm (Core.Value era)
     toCompactValue ada =
@@ -303,12 +305,14 @@ viewTxOut (TxOutCompactDH' bs c dh) = (addr, val, SJust dh)
 viewTxOut (TxOut_AddrHash28_AdaOnly stakeRef addr28Extra adaVal)
   | Just addr <- decodeAddress28 stakeRef addr28Extra =
     (addr, inject (fromCompact adaVal), SNothing)
-viewTxOut (TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal e f g h)
+viewTxOut (TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal dataHash32)
   | Just addr <- decodeAddress28 stakeRef addr28Extra,
     Just Refl <- sameNat (Proxy @(SizeHash (CC.HASH (Crypto era)))) (Proxy @32) =
-    (addr, inject (fromCompact adaVal), SJust (decodeDataHash32 e f g h))
-viewTxOut (TxOut_AddrHash28_AdaOnly {}) = error "Impossible: Compacted and address or hash of non-standard size"
-viewTxOut (TxOut_AddrHash28_AdaOnly_DataHash32 {}) = error "Impossible: Compacted and address or hash of non-standard size"
+    (addr, inject (fromCompact adaVal), SJust (decodeDataHash32 dataHash32))
+viewTxOut TxOut_AddrHash28_AdaOnly {} =
+  error "Impossible: Compacted address or hash of non-standard size"
+viewTxOut TxOut_AddrHash28_AdaOnly_DataHash32 {} =
+  error "Impossible: Compacted address or hash of non-standard size"
 
 instance
   ( Era era,
@@ -344,8 +348,8 @@ pattern TxOut addr vl dh <-
       | StakeRefBase stakeCred <- stakeRef,
         Just adaCompact <- getAdaOnly (Proxy @era) vl,
         Just (Refl, addr28Extra) <- encodeAddress28 network paymentCred,
-        Just (Refl, e, f, g, h) <- encodeDataHash32 dh =
-        TxOut_AddrHash28_AdaOnly_DataHash32 stakeCred addr28Extra adaCompact e f g h
+        Just (Refl, dataHash32) <- encodeDataHash32 dh =
+        TxOut_AddrHash28_AdaOnly_DataHash32 stakeCred addr28Extra adaCompact dataHash32
     TxOut addr vl mdh =
       let v = fromMaybe (error "Illegal value in txout") $ toCompact vl
           a = compactAddr addr
@@ -648,8 +652,8 @@ instance
     let internTxOut = \case
           TxOut_AddrHash28_AdaOnly cred addr28Extra ada ->
             TxOut_AddrHash28_AdaOnly (interns credsInterns cred) addr28Extra ada
-          TxOut_AddrHash28_AdaOnly_DataHash32 cred addr28Extra ada e f g h ->
-            TxOut_AddrHash28_AdaOnly_DataHash32 (interns credsInterns cred) addr28Extra ada e f g h
+          TxOut_AddrHash28_AdaOnly_DataHash32 cred addr28Extra ada dataHash32 ->
+            TxOut_AddrHash28_AdaOnly_DataHash32 (interns credsInterns cred) addr28Extra ada dataHash32
           txOut -> txOut
     internTxOut <$> case lenOrIndef of
       Nothing -> do
@@ -891,7 +895,6 @@ getAlonzoTxOutEitherAddr = \case
   TxOutCompactDH' cAddr _ _ -> Right cAddr
   TxOut_AddrHash28_AdaOnly stakeRef addr28Extra _
     | Just addr <- decodeAddress28 stakeRef addr28Extra -> Left addr
-    | otherwise -> error "Impossible: Compacted an address of non-standard size"
-  TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra _ _ _ _ _
+  TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra _ _
     | Just addr <- decodeAddress28 stakeRef addr28Extra -> Left addr
-    | otherwise -> error "Impossible: Compacted an address or a hash of non-standard size"
+  _ -> error "Impossible: Compacted an address of non-standard size"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core as Core (PParams, TxBody, TxOut, Value)
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj), Ptr (..), StakeReference (..))
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Hashes (EraIndependentData)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness), hashKey)
 import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
@@ -185,8 +185,7 @@ txInfoIn ::
   forall era c i.
   ( Era era,
     Value era ~ Mary.Value (Crypto era),
-    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash c i)),
-    HasField "address" (TxOut era) (Addr c)
+    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash c i))
   ) =>
   UTxO era ->
   TxIn (Crypto era) ->
@@ -199,7 +198,7 @@ txInfoIn (UTxO mp) txin =
       Nothing -> Nothing
       where
         valout = transValue (getField @"value" txout)
-        addr = getField @"address" txout
+        addr = getTxOutAddr txout
         dhash = case getField @"datahash" txout of
           SNothing -> Nothing
           SJust safehash -> Just (PV1.DatumHash (transSafeHash safehash))
@@ -211,13 +210,12 @@ txInfoOut ::
   forall era c.
   ( Era era,
     Value era ~ Mary.Value (Crypto era),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash c)),
-    HasField "address" (TxOut era) (Addr c)
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash c))
   ) =>
   Core.TxOut era ->
   Maybe PV1.TxOut
 txInfoOut txo =
-  let (addr, val, datahash) = (getField @"address" txo, getField @"value" txo, getField @"datahash" txo)
+  let (addr, val, datahash) = (getTxOutAddr txo, getField @"value" txo, getField @"datahash" txo)
    in case transAddr addr of
         Just ad -> Just (PV1.TxOut ad (transValue @(Crypto era) val) (transDataHash datahash))
         Nothing -> Nothing
@@ -344,8 +342,7 @@ txInfo ::
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "mint" (Core.TxBody era) (Mary.Value (Crypto era)),
-    HasField "vldt" (Core.TxBody era) ValidityInterval,
-    HasField "address" (TxOut era) (Addr (Crypto era))
+    HasField "vldt" (Core.TxBody era) ValidityInterval
   ) =>
   Core.PParams era ->
   Language ->

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -118,8 +118,7 @@ isKeyHashAddr _ = False
 -- | We are choosing new TxOut to pay fees, We want only Key locked addresss with Ada only values.
 vKeyLocked :: Mock c => Core.TxOut (AlonzoEra c) -> Bool
 vKeyLocked txout =
-  isKeyHashAddr (getField @"address" txout)
-    && adaOnly (getField @"value" txout)
+  isKeyHashAddr (getTxOutAddr txout) && adaOnly (getField @"value" txout)
 
 phase2scripts3Arg :: forall c. Mock c => [TwoPhase3ArgInfo (AlonzoEra c)]
 phase2scripts3Arg =

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -14,7 +14,7 @@
 module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), Data (..))
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), BinaryData, Data (..), dataToBinaryData)
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
@@ -54,6 +54,9 @@ import Test.QuickCheck
 
 instance Arbitrary (Data era) where
   arbitrary = Data <$> arbitrary
+
+instance Arbitrary (BinaryData era) where
+  arbitrary = dataToBinaryData <$> arbitrary
 
 genPair :: Gen a -> Gen b -> Gen (a, b)
 genPair x y = do a <- x; b <- y; pure (a, b)

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -7,7 +7,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Tripping where
 
 import Cardano.Binary
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData, Data (..))
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData, BinaryData, Data (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams (PParams, PParamsUpdate)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
@@ -75,6 +75,8 @@ tests =
         trippingAnn @(Script (AlonzoEra C_Crypto)),
       testProperty "alonzo/Data" $
         trippingAnn @(Data (AlonzoEra C_Crypto)),
+      testProperty "alonzo/BinaryData" $
+        tripping @(BinaryData (AlonzoEra C_Crypto)),
       testProperty "alonzo/Metadata" $
         trippingAnn @(Metadata (AlonzoEra C_Crypto)),
       testProperty "alonzo/TxWitness" $

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -99,8 +99,7 @@ import qualified Data.Set as Set
 data BabbageEra c
 
 instance
-  ( CC.Crypto c,
-    era ~ BabbageEra c
+  ( CC.Crypto c
   ) =>
   EraModule.Era (BabbageEra c)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -868,12 +868,6 @@ instance
 instance HasField "txnetworkid" (TxBody era) (StrictMaybe Network) where
   getField (TxBodyConstr (Memo m _)) = _txnetworkid m
 
-instance (Era era, CC.Crypto c, Crypto era ~ c) => HasField "address" (TxOut era) (Addr c) where
-  getField t =
-    case getBabbageTxOutEitherAddr t of
-      Left a -> a
-      Right ca -> decompactAddr ca
-
 instance (Era era, Core.Value era ~ val, Compactible val) => HasField "value" (TxOut era) val where
   getField (TxOutCompact _ v) = fromCompact v
   getField (TxOutCompactDH _ v _) = fromCompact v

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -8,10 +8,9 @@
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 
-import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Era (Era)
 import Cardano.Ledger.Shelley.LedgerState
   ( UTxOState,
     witsVKeyNeeded,
@@ -26,9 +25,7 @@ import Cardano.Ledger.Shelley.Rules.Utxow
   )
 import Cardano.Ledger.Shelley.Tx (WitnessSet)
 import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO, UtxoPredicateFailure)
-import Cardano.Ledger.ShelleyMA.TxBody ()
 import Control.State.Transition.Extended
-import GHC.Records (HasField)
 
 -- ==============================================================================
 --   We want to reuse the same rules for Mary and Allegra. We accomplish this
@@ -48,7 +45,6 @@ instance
   forall era.
   ( -- Fix Core.Witnesses to the Allegra and Mary Era
     Core.Witnesses era ~ WitnessSet era,
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     -- Allow UTXOW to call UTXO
     Embed (Core.EraRule "UTXO" era) (UTXOW era),
     Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
   ( decodeList,
@@ -388,7 +388,7 @@ utxoInductive = do
   let addrsWrongNetwork =
         filter
           (\a -> getNetwork a /= ni)
-          (fmap (getField @"address") $ toList $ getField @"outputs" txb)
+          (fmap getTxOutAddr $ toList $ getField @"outputs" txb)
   null addrsWrongNetwork ?! WrongNetwork ni (Set.fromList addrsWrongNetwork)
   let wdrlsWrongNetwork =
         filter
@@ -421,7 +421,7 @@ utxoInductive = do
   -- It is important to limit their overall size.
   let outputsAttrsTooBig =
         filter
-          ( \x -> case getField @"address" x of
+          ( \x -> case getTxOutAddr x of
               AddrBootstrap addr -> bootstrapAddressAttrsSize addr > 64
               _ -> False
           )

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -30,7 +30,6 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.AuxiliaryData
   ( AuxiliaryDataHash,
     ValidateAuxiliaryData (..),
@@ -38,7 +37,7 @@ import Cardano.Ledger.AuxiliaryData
   )
 import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase, StrictMaybe (..), invalidKey, quorum, (==>))
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Keys
   ( DSignable,
     GenDelegPair (..),
@@ -255,7 +254,6 @@ type ShelleyStyleWitnessNeeds era =
     HasField "bootWits" (Core.Tx era) (Set (BootstrapWitness (Crypto era))),
     HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    HasField "address" (Core.TxOut era) (Addr (Crypto era)),
     ValidateAuxiliaryData era (Crypto era),
     ValidateScript era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody)
@@ -416,8 +414,7 @@ instance
     Signal (Core.EraRule "UTXO" era) ~ Core.Tx era,
     PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
     -- Supply the HasField and Validate instances for Shelley
-    ShelleyStyleWitnessNeeds era,
-    HasField "address" (Core.TxOut era) (Addr (Crypto era))
+    ShelleyStyleWitnessNeeds era
   ) =>
   STS (UTXOW era)
   where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -486,9 +486,6 @@ viewCompactTxOut (TxOutCompact bs c) = (addr, val)
 instance (Compactible v, v ~ Core.Value era) => HasField "value" (TxOut era) v where
   getField (TxOutCompact _ v) = fromCompact v
 
-instance (CC.Crypto c, c ~ Crypto era) => HasField "address" (TxOut era) (Addr c) where
-  getField (TxOutCompact a _) = decompactAddr a
-
 data DelegCert crypto
   = -- | A stake key registration certificate.
     RegKey !(StakeCredential crypto)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Era.hs
@@ -69,7 +69,7 @@ class
   type Crypto e :: Type
 
   -- | Extract from TxOut either an address or its compact version by doing the
-  -- least amount of work. Default implementation relies on the "address" field.
+  -- least amount of work.
   --
   -- The utility of this function comes from the fact that TxOut usually stores
   -- the address in either one of two forms: compacted or unpacked. In order to

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -462,15 +462,12 @@ sourceWithSharingUTxO stakeCredentials =
     internTxOut = \case
       Alonzo.TxOut_AddrHash28_AdaOnly cred addr28Extra e ->
         Alonzo.TxOut_AddrHash28_AdaOnly (intern (Keys.coerceKeyRole cred) stakeCredentials) addr28Extra e
-      Alonzo.TxOut_AddrHash28_AdaOnly_DataHash32 cred addr28Extra e o p q r ->
+      Alonzo.TxOut_AddrHash28_AdaOnly_DataHash32 cred addr28Extra e dataHash32 ->
         Alonzo.TxOut_AddrHash28_AdaOnly_DataHash32
           (intern (Keys.coerceKeyRole cred) stakeCredentials)
           addr28Extra
           e
-          o
-          p
-          q
-          r
+          dataHash32
       out -> out
 
 foldDbUTxO ::


### PR DESCRIPTION
Main purpose of this PR is to introduce `InlineData`, which is a `ShortByteString` of serialized plutus `Data`. It is designed with type safety in mind and by hiding type constructor it is impossible to construct `InlineData` from binary that doesn't deserialize into valid plutus data.

This whole thing is necessary  to avoid carrying around both serialized and deserialized version of Data in memory for every inline datum in the utxo.

It also cleans up the rest of usage of `HasField "address"`, which was started in #2616