### PR TITLE
Rationalise 'chainChecks'.

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
@@ -23,7 +23,6 @@ where
 
 import Cardano.Ledger.BHeaderView (BHeaderView (..))
 import Cardano.Ledger.BaseTypes (ProtVer (..))
-import Cardano.Ledger.Era (Crypto)
 import Control.Monad (unless)
 import Control.Monad.Except (MonadError, throwError)
 import GHC.Generics (Generic)
@@ -52,7 +51,7 @@ pparamsToChainChecksPParams pp =
       ccProtocolVersion = getField @"_protocolVersion" pp
     }
 
-data ChainPredicateFailure era
+data ChainPredicateFailure
   = HeaderSizeTooLargeCHAIN
       !Natural -- Header Size
       !Natural -- Max Header Size
@@ -64,13 +63,13 @@ data ChainPredicateFailure era
       !Natural -- max protocol version
   deriving (Generic, Show, Eq, Ord)
 
-instance NoThunks (ChainPredicateFailure era)
+instance NoThunks ChainPredicateFailure
 
 chainChecks ::
-  MonadError (ChainPredicateFailure era) m =>
+  MonadError ChainPredicateFailure m =>
   Natural ->
   ChainChecksPParams ->
-  BHeaderView (Crypto era) ->
+  BHeaderView crypto ->
   m ()
 chainChecks maxpv ccd bhv = do
   unless (m <= maxpv) $ throwError (ObsoleteNodeCHAIN m maxpv)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -48,6 +48,7 @@ import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
+import Numeric.Natural (Natural)
 
 {-------------------------------------------------------------------------------
   Block validation API
@@ -57,7 +58,7 @@ class
   ( ChainData (NewEpochState era),
     SerialisableData (NewEpochState era),
     ChainData (BlockTransitionError era),
-    ChainData (STS.ChainPredicateFailure era),
+    ChainData STS.ChainPredicateFailure,
     STS (Core.EraRule "TICK" era),
     BaseM (Core.EraRule "TICK" era) ~ ShelleyBase,
     Environment (Core.EraRule "TICK" era) ~ (),
@@ -201,13 +202,14 @@ instance ShelleyEraCrypto crypto => ApplyBlock (ShelleyEra crypto)
 -------------------------------------------------------------------------------}
 
 chainChecks ::
-  forall era m.
-  MonadError (STS.ChainPredicateFailure era) m =>
-  Globals ->
+  forall crypto m.
+  MonadError STS.ChainPredicateFailure m =>
+  -- | Max major protocol version
+  Natural ->
   STS.ChainChecksPParams ->
-  BHeaderView (Crypto era) ->
+  BHeaderView crypto ->
   m ()
-chainChecks globals = STS.chainChecks (maxMajorPV globals)
+chainChecks = STS.chainChecks
 
 {-------------------------------------------------------------------------------
   Applying blocks

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -139,7 +139,7 @@ deriving stock instance
 instance (Era era, TransUTxOState NFData era) => NFData (ChainState era)
 
 data TestChainPredicateFailure era
-  = RealChainPredicateFailure !(ChainPredicateFailure era)
+  = RealChainPredicateFailure !ChainPredicateFailure
   | BbodyFailure !(PredicateFailure (Core.EraRule "BBODY" era)) -- Subtransition Failures
   | TickFailure !(PredicateFailure (Core.EraRule "TICK" era)) -- Subtransition Failures
   | TicknFailure !(PredicateFailure (Core.EraRule "TICKN" era)) -- Subtransition Failures


### PR DESCRIPTION
'chainChecks' is a bit of a weird function; it implements "envelope"
checks, but sits somewhat within the ledger code. The current
implementation requires full access to 'Globals', which contains a bunch
of ledger specific contents. It's also era-parametrised, despite having
nothing to do with the ledger era.

This PR therefore does two things:
- Change the API function to only require the max major PV, not the full
  globals.
- Remove the redundnant era parameter from 'ChainPredicateFailure'.