### PR TITLE
Proper fix for optimized version of `isBootstrapRedeemer` function.

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
@@ -60,8 +60,7 @@ propDecompactShelleyLazyAddr = do
       keyHash1 = unsafeGetHash . CA.decompactAddr . mangle . CA.compactAddr $ addr
    in pure $ keyHash0 == keyHash1
 
--- | TODO This property test is failing to find a discrepancy that was found on mainnet.
-propIsBootstrapRedeemer :: Addr crypto -> Property
+propIsBootstrapRedeemer :: CC.Crypto crypto => Addr crypto -> Property
 propIsBootstrapRedeemer addr =
   Addr.isBootstrapRedeemer addr === CA.isBootstrapRedeemer (CA.compactAddr addr)
 


### PR DESCRIPTION
I ran into a test failure on CI, which can be reproduced with this command prior to this PR:
```shell
cabal test cardano-ledger-shelley-test --test-options='--quickcheck-replay=97935 -p "isBootstrapRedeemer is equivalent for CompactAddr and Addr"'
```

Original attempt to fix this was in #2284 which was invalid and resulted in the optimized version of the function not been used, however the test remained.

This is indeed a good optimization, since `returnRedeemAddrsToReserves` iterates over the whole UTxO and current unoptimized version of `isBootstrapRedeemer` will cause redundant address uncompacting of all Shelley addresses