### PR TITLE
Create `TxIx` that is backed by `Word16` instead of an `Int`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -19,10 +19,14 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Script (..), decodeCostModel)
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr, TxWitness (..), unRedeemers, unTxDats)
-import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..), txIxToInt)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core as Core (PParams, TxBody, TxOut, Value)
-import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj), Ptr (..), StakeReference (..))
+import Cardano.Ledger.Credential
+  ( Credential (KeyHashObj, ScriptHashObj),
+    Ptr (..),
+    StakeReference (..),
+  )
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Era (..), getTxOutBootstrapAddress)
 import Cardano.Ledger.Hashes (EraIndependentData)
@@ -118,7 +122,7 @@ transStakeCred (KeyHashObj (KeyHash kh)) =
 transStakeReference :: StakeReference crypto -> Maybe PV1.StakingCredential
 transStakeReference (StakeRefBase cred) = Just (PV1.StakingHash (transStakeCred cred))
 transStakeReference (StakeRefPtr (Ptr (SlotNo slot) i1 i2)) =
-  Just (PV1.StakingPtr (fromIntegral slot) (fromIntegral i1) (fromIntegral i2))
+  Just (PV1.StakingPtr (fromIntegral slot) (fromIntegral (txIxToInt i1)) (fromIntegral i2))
 transStakeReference StakeRefNull = Nothing
 
 transCred :: Credential keyrole crypto -> PV1.Credential
@@ -183,7 +187,7 @@ transVITime pp ei sysS (ValidityInterval (SJust i) (SJust j)) = do
 -- translate TxIn and TxOut
 
 txInfoIn' :: TxIn c -> PV1.TxOutRef
-txInfoIn' (TxIn txid nat) = PV1.TxOutRef (txInfoId txid) (fromIntegral nat)
+txInfoIn' (TxIn txid txIx) = PV1.TxOutRef (txInfoId txid) (toInteger (txIxToInt txIx))
 
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it and return
 --   (Just translation). If does not exist in the UTxO, return Nothing.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -19,7 +20,7 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModel (..), ExUnits (..), Script (..), decodeCostModel)
 import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr, TxWitness (..), unRedeemers, unTxDats)
-import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..), txIxToInt)
+import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..), certIxToInt, txIxToInt)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core as Core (PParams, TxBody, TxOut, Value)
 import Cardano.Ledger.Credential
@@ -121,8 +122,10 @@ transStakeCred (KeyHashObj (KeyHash kh)) =
 
 transStakeReference :: StakeReference crypto -> Maybe PV1.StakingCredential
 transStakeReference (StakeRefBase cred) = Just (PV1.StakingHash (transStakeCred cred))
-transStakeReference (StakeRefPtr (Ptr (SlotNo slot) i1 i2)) =
-  Just (PV1.StakingPtr (fromIntegral slot) (fromIntegral (txIxToInt i1)) (fromIntegral i2))
+transStakeReference (StakeRefPtr (Ptr (SlotNo slot) txIx certIx)) =
+  let !txIxInteger = toInteger (txIxToInt txIx)
+      !certIxInteger = toInteger (certIxToInt certIx)
+   in Just (PV1.StakingPtr (fromIntegral slot) txIxInteger certIxInteger)
 transStakeReference StakeRefNull = Nothing
 
 transCred :: Credential keyrole crypto -> PV1.Credential

--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -17,7 +17,7 @@ transaction =
   , auxiliary_data / null
   ]
 
-transaction_index = uint
+transaction_index = uint .size 2
 
 header =
   [ header_body

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -15,7 +15,11 @@ import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx (IsValid (..), ValidatedTx (..))
 import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..))
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), TxWitness (..))
-import Cardano.Ledger.BaseTypes (NonNegativeInterval, StrictMaybe (..), boundRational)
+import Cardano.Ledger.BaseTypes
+  ( NonNegativeInterval,
+    StrictMaybe (..),
+    boundRational,
+  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (TxBody)
 import Cardano.Ledger.Crypto (StandardCrypto)
@@ -30,7 +34,6 @@ import Cardano.Ledger.Shelley.API
     ProposedPPUpdates (..),
     RewardAcnt (..),
     TxId (..),
-    TxIn (..),
     Update (..),
     Wdrl (..),
   )
@@ -39,6 +42,7 @@ import Cardano.Ledger.Shelley.Rules.Ledger (LedgerPredicateFailure (..))
 import Cardano.Ledger.Shelley.Tx (Tx (..))
 import Cardano.Ledger.Shelley.UTxO (makeWitnessesVKey)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
+import Cardano.Ledger.TxIn (mkTxInPartial)
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
@@ -96,8 +100,8 @@ ledgerExamplesAlonzo =
 exampleTxBodyAlonzo :: Cardano.Ledger.Core.TxBody StandardAlonzo
 exampleTxBodyAlonzo =
   TxBody
-    (Set.fromList [TxIn (TxId (SLE.mkDummySafeHash Proxy 1)) 0]) -- inputs
-    (Set.fromList [TxIn (TxId (SLE.mkDummySafeHash Proxy 2)) 1]) -- collateral
+    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 1)) 0]) -- inputs
+    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 2)) 1]) -- collateral
     ( StrictSeq.fromList
         [ TxOut
             (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -15,11 +15,7 @@ import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx (IsValid (..), ValidatedTx (..))
 import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (..))
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), TxWitness (..))
-import Cardano.Ledger.BaseTypes
-  ( NonNegativeInterval,
-    StrictMaybe (..),
-    boundRational,
-  )
+import Cardano.Ledger.BaseTypes (NonNegativeInterval, StrictMaybe (..), boundRational)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (TxBody)
 import Cardano.Ledger.Crypto (StandardCrypto)

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Trials.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Trials.hs
@@ -226,7 +226,7 @@ instance
   TQC.HasTrace (AlonzoLEDGER era) (GenEnv era)
   where
   envGen GenEnv {geConstants} =
-    LedgerEnv (SlotNo 0) 0
+    LedgerEnv (SlotNo 0) minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
 
@@ -239,7 +239,7 @@ instance
 
 -- An initial (mostly empty) LedgerEnv
 ledgerEnv :: forall era. Default (Core.PParams era) => LedgerEnv era
-ledgerEnv = LedgerEnv (SlotNo 0) 0 def (AccountState (Coin 0) (Coin 0))
+ledgerEnv = LedgerEnv (SlotNo 0) minBound def (AccountState (Coin 0) (Coin 0))
 
 genAlonzoTx :: Gen (Core.Tx A)
 genAlonzoTx = genstuff ap (\genv _cs _nep _ep _ls _pp utxo dp _d _p -> genTx genv ledgerEnv (utxo, dp))

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
@@ -52,7 +52,7 @@ import NoThunks.Class (NoThunks (..))
 data CompactTxIn
   = CompactTxInUtxo
       {-# UNPACK #-} !CompactTxId
-      {-# UNPACK #-} !Word32
+      {-# UNPACK #-} !Word16
   deriving (Eq, Ord, Generic, Show)
   deriving anyclass (NFData, NoThunks)
 
@@ -61,13 +61,13 @@ instance HeapWords CompactTxIn where
     -- We have
     --
     -- > data CompactTxIn = CompactTxInUtxo {-# UNPACK #-} !CompactTxId
-    -- >                                    {-# UNPACK #-} !Word32
+    -- >                                    {-# UNPACK #-} !Word16
     --
     -- so 'CompactTxInUtxo' requires:
     --
     -- - 1 word for the 'CompactTxInUtxo' object header
     -- - 4 words (on a 64-bit arch) for the unpacked 'CompactTxId'
-    -- - 1 word for the unpacked 'Word32'
+    -- - 1 word for the unpacked 'Word16'
     --
     -- +---------------------------------------------+
     -- │CompactTxInUtxo│Word#|Word#│Word#│Word#│Word#│

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
@@ -127,8 +127,8 @@ type TxAttributes = Attributes ()
 -- | Transaction arbitrary input
 data TxIn
   = -- | TxId = Which transaction's output is used
-    -- | Word32 = Index of the output in transaction's outputs
-    TxInUtxo TxId Word32
+    -- | Word16 = Index of the output in transaction's outputs
+    TxInUtxo TxId Word16
   deriving (Eq, Ord, Generic, Show)
   deriving anyclass (NFData)
 
@@ -148,7 +148,7 @@ instance ToCBOR TxIn where
   encodedSizeExpr size _ =
     2
       + knownCborDataItemSizeExpr
-        (szCases [Case "TxInUtxo" $ size $ Proxy @(TxId, Word32)])
+        (szCases [Case "TxInUtxo" $ size $ Proxy @(TxId, Word16)])
 
 instance FromCBOR TxIn where
   fromCBOR = do
@@ -159,7 +159,7 @@ instance FromCBOR TxIn where
       _ -> cborError $ DecoderErrorUnknownTag "TxIn" tag
 
 instance HeapWords TxIn where
-  heapWords (TxInUtxo txid w32) = heapWords2 txid w32
+  heapWords (TxInUtxo txid _w16) = 3 + heapWords txid + 2
 
 --------------------------------------------------------------------------------
 -- TxOut

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxO.hs
@@ -164,7 +164,7 @@ txOutputUTxO tx =
         | (ix, txOut) <- indexedOutputs
       ]
   where
-    indexedOutputs :: [(Word32, TxOut)]
+    indexedOutputs :: [(Word16, TxOut)]
     indexedOutputs = zip [0 ..] (NE.toList $ txOutputs tx)
 
     txId :: Tx -> TxId

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -127,7 +127,7 @@ genBase16Bs :: Gen ByteString
 genBase16Bs = B16.encode <$> genBytes 32
 
 genTxIn :: Gen TxIn
-genTxIn = TxInUtxo <$> genTxId <*> genWord32
+genTxIn = TxInUtxo <$> genTxId <*> genWord16
 
 genTxInList :: Gen (NonEmpty TxIn)
 genTxInList = Gen.nonEmpty (Range.linear 1 20) genTxIn

--- a/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
+++ b/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
@@ -16,7 +16,7 @@ transaction =
   , auxiliary_data / null
   ]
 
-transaction_index = uint
+transaction_index = uint .size 2
 
 header =
   [ header_body

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -70,14 +70,14 @@ testScriptPostTranslation =
           utxo =
             S.UTxO $
               SplitMap.singleton
-                (S.TxIn bootstrapTxId 0)
+                (S.TxIn bootstrapTxId minBound)
                 (S.TxOut addr (Val.inject (S.Coin 1)))
-          env = S.LedgerEnv (SlotNo 0) 0 emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0))
+          env = S.LedgerEnv (SlotNo 0) minBound emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0))
           utxoStShelley = def {S._utxo = utxo}
           utxoStAllegra = fromRight . runExcept $ translateEra @Allegra () utxoStShelley
           txb =
             S.TxBody
-              (Set.singleton $ S.TxIn bootstrapTxId 0)
+              (Set.singleton $ S.TxIn bootstrapTxId minBound)
               StrictSeq.empty
               StrictSeq.empty
               (S.Wdrl mempty)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.ShelleyMA.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody (..))
 import Cardano.Ledger.Slot (SlotNo (..))
-import Cardano.Ledger.TxIn (TxId, TxIn (..), txid)
+import Cardano.Ledger.TxIn (TxId, TxIn (..), mkTxInPartial, txid)
 import Cardano.Ledger.Val ((<+>), (<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.Exception (ErrorCall (ErrorCall), evaluate, try)
@@ -87,8 +87,8 @@ initUTxO :: UTxO MaryTest
 initUTxO =
   UTxO $
     SplitMap.fromList
-      [ (TxIn bootstrapTxId 0, TxOut Cast.aliceAddr (Val.inject aliceInitCoin)),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
+      [ (mkTxInPartial bootstrapTxId 0, TxOut Cast.aliceAddr (Val.inject aliceInitCoin)),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
 pp :: PParams MaryTest
@@ -101,7 +101,7 @@ pp =
     }
 
 ledgerEnv :: SlotNo -> LedgerEnv MaryTest
-ledgerEnv s = LedgerEnv s 0 pp (AccountState (Coin 0) (Coin 0))
+ledgerEnv s = LedgerEnv s minBound pp (AccountState (Coin 0) (Coin 0))
 
 feeEx :: Coin
 feeEx = Coin 3
@@ -176,7 +176,7 @@ tokensSimpleEx1 = mintSimpleEx1 <+> Val.inject aliceCoinSimpleEx1
 txbodySimpleEx1 :: TxBody MaryTest
 txbodySimpleEx1 =
   makeTxb
-    [TxIn bootstrapTxId 0]
+    [mkTxInPartial bootstrapTxId 0]
     [TxOut Cast.aliceAddr tokensSimpleEx1]
     unboundedInterval
     mintSimpleEx1
@@ -195,8 +195,8 @@ expectedUTxOSimpleEx1 :: UTxO MaryTest
 expectedUTxOSimpleEx1 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodySimpleEx1) 0, TxOut Cast.aliceAddr tokensSimpleEx1),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
+      [ (mkTxInPartial (txid txbodySimpleEx1) 0, TxOut Cast.aliceAddr tokensSimpleEx1),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
 ----------------------------
@@ -223,7 +223,7 @@ bobTokensSimpleEx2 =
 txbodySimpleEx2 :: TxBody MaryTest
 txbodySimpleEx2 =
   makeTxb
-    [TxIn (txid txbodySimpleEx1) 0]
+    [mkTxInPartial (txid txbodySimpleEx1) 0]
     [ TxOut Cast.aliceAddr aliceTokensSimpleEx2,
       TxOut Cast.bobAddr bobTokensSimpleEx2
     ]
@@ -241,9 +241,9 @@ expectedUTxOSimpleEx2 :: UTxO MaryTest
 expectedUTxOSimpleEx2 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodySimpleEx2) 0, TxOut Cast.aliceAddr aliceTokensSimpleEx2),
-        (TxIn (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
+      [ (mkTxInPartial (txid txbodySimpleEx2) 0, TxOut Cast.aliceAddr aliceTokensSimpleEx2),
+        (mkTxInPartial (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
 ------------------------------------------------------------
@@ -299,7 +299,7 @@ tokensTimeEx1 = mintTimeEx1 <+> Val.inject aliceCoinsTimeEx1
 txbodyTimeEx1 :: StrictMaybe SlotNo -> StrictMaybe SlotNo -> TxBody MaryTest
 txbodyTimeEx1 s e =
   makeTxb
-    [TxIn bootstrapTxId 0]
+    [mkTxInPartial bootstrapTxId 0]
     [TxOut Cast.aliceAddr tokensTimeEx1]
     (ValidityInterval s e)
     mintTimeEx1
@@ -336,8 +336,8 @@ expectedUTxOTimeEx1 :: UTxO MaryTest
 expectedUTxOTimeEx1 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodyTimeEx1Valid) 0, TxOut Cast.aliceAddr tokensTimeEx1),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
+      [ (mkTxInPartial (txid txbodyTimeEx1Valid) 0, TxOut Cast.aliceAddr tokensTimeEx1),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
 ----------------------------------------
@@ -359,7 +359,7 @@ aliceCoinsTimeEx2 = aliceCoinSimpleEx1 <-> (feeEx <+> mintTimeEx2)
 txbodyTimeEx2 :: TxBody MaryTest
 txbodyTimeEx2 =
   makeTxb
-    [TxIn (txid txbodyTimeEx1Valid) 0]
+    [mkTxInPartial (txid txbodyTimeEx1Valid) 0]
     [ TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2),
       TxOut Cast.bobAddr bobTokensTimeEx2
     ]
@@ -380,9 +380,9 @@ expectedUTxOTimeEx2 :: UTxO MaryTest
 expectedUTxOTimeEx2 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodyTimeEx2) 0, TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2)),
-        (TxIn (txid txbodyTimeEx2) 1, TxOut Cast.bobAddr bobTokensTimeEx2),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
+      [ (mkTxInPartial (txid txbodyTimeEx2) 0, TxOut Cast.aliceAddr (Val.inject aliceCoinsTimeEx2)),
+        (mkTxInPartial (txid txbodyTimeEx2) 1, TxOut Cast.bobAddr bobTokensTimeEx2),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin))
       ]
 
 --------------------------------------------------------------
@@ -420,7 +420,7 @@ tokensSingWitEx1 = mintSingWitEx1 <+> Val.inject bobCoinsSingWitEx1
 txbodySingWitEx1 :: TxBody MaryTest
 txbodySingWitEx1 =
   makeTxb
-    [TxIn bootstrapTxId 1]
+    [mkTxInPartial bootstrapTxId 1]
     [TxOut Cast.bobAddr tokensSingWitEx1]
     unboundedInterval
     mintSingWitEx1
@@ -440,8 +440,8 @@ expectedUTxOSingWitEx1 :: UTxO MaryTest
 expectedUTxOSingWitEx1 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodySingWitEx1) 0, TxOut Cast.bobAddr tokensSingWitEx1),
-        (TxIn bootstrapTxId 0, TxOut Cast.aliceAddr (Val.inject aliceInitCoin))
+      [ (mkTxInPartial (txid txbodySingWitEx1) 0, TxOut Cast.bobAddr tokensSingWitEx1),
+        (mkTxInPartial bootstrapTxId 0, TxOut Cast.aliceAddr (Val.inject aliceInitCoin))
       ]
 
 txSingWitEx1Invalid :: Tx MaryTest
@@ -478,7 +478,7 @@ aliceTokensNegEx1 =
 txbodyNegEx1 :: TxBody MaryTest
 txbodyNegEx1 =
   makeTxb
-    [TxIn (txid txbodySimpleEx2) 0]
+    [mkTxInPartial (txid txbodySimpleEx2) 0]
     [TxOut Cast.aliceAddr aliceTokensNegEx1]
     unboundedInterval
     mintNegEx1
@@ -500,9 +500,9 @@ expectedUTxONegEx1 :: UTxO MaryTest
 expectedUTxONegEx1 =
   UTxO $
     SplitMap.fromList
-      [ (TxIn (txid txbodyNegEx1) 0, TxOut Cast.aliceAddr aliceTokensNegEx1),
-        (TxIn bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin)),
-        (TxIn (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2)
+      [ (mkTxInPartial (txid txbodyNegEx1) 0, TxOut Cast.aliceAddr aliceTokensNegEx1),
+        (mkTxInPartial bootstrapTxId 1, TxOut Cast.bobAddr (Val.inject bobInitCoin)),
+        (mkTxInPartial (txid txbodySimpleEx2) 1, TxOut Cast.bobAddr bobTokensSimpleEx2)
       ]
 
 --
@@ -523,7 +523,7 @@ aliceTokensNegEx2 =
 txbodyNegEx2 :: TxBody MaryTest
 txbodyNegEx2 =
   makeTxb
-    [TxIn (txid txbodySimpleEx2) 0]
+    [mkTxInPartial (txid txbodySimpleEx2) 0]
     [TxOut Cast.aliceAddr aliceTokensNegEx2]
     unboundedInterval
     mintNegEx2
@@ -567,7 +567,7 @@ bigOut = TxOut Cast.aliceAddr $ bigValue <+> Val.inject minUtxoBigEx
 txbodyWithBigValue :: TxBody MaryTest
 txbodyWithBigValue =
   makeTxb
-    [TxIn bootstrapTxId 0]
+    [mkTxInPartial bootstrapTxId 0]
     [smallOut, bigOut]
     unboundedInterval
     (bigValue <+> smallValue)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.ShelleyMA.Timelocks
   )
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody (..))
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
-import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.TxIn (mkTxInPartial)
 import qualified Cardano.Ledger.Val as Val
 import Codec.CBOR.Encoding (Tokens (..))
 import qualified Data.ByteString.Char8 as BS
@@ -234,7 +234,7 @@ goldenEncodingTestsAllegra =
       metadataNoScritpsGoldenTest @A,
       metadataWithScritpsGoldenTest @A,
       -- "minimal_txn_body"
-      let tin = TxIn genesisId 1
+      let tin = mkTxInPartial genesisId 1
           tout = TxOut @A testAddrE (Coin 2)
        in checkEncodingCBORAnnotated
             "minimal_txbody"
@@ -260,7 +260,7 @@ goldenEncodingTestsAllegra =
                 <> T (TkWord64 9)
             ),
       -- "full_txn_body"
-      let tin = TxIn genesisId 1
+      let tin = mkTxInPartial genesisId 1
           tout = TxOut @A testAddrE (Coin 2)
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
@@ -367,7 +367,7 @@ goldenEncodingTestsMary =
       metadataNoScritpsGoldenTest @M,
       metadataWithScritpsGoldenTest @M,
       -- "minimal_txn_body"
-      let tin = TxIn genesisId 1
+      let tin = mkTxInPartial genesisId 1
           tout = TxOut @M testAddrE (Val.inject $ Coin 2)
        in checkEncodingCBORAnnotated
             "minimal_txbody"
@@ -393,7 +393,7 @@ goldenEncodingTestsMary =
                 <> T (TkWord64 9)
             ),
       -- "full_txn_body"
-      let tin = TxIn genesisId 1
+      let tin = mkTxInPartial genesisId 1
           tout = TxOut @M testAddrE (Val.inject $ Coin 2)
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Hashing
-import Cardano.Ledger.BaseTypes (BlocksMade (..))
+import Cardano.Ledger.BaseTypes (BlocksMade (..), TxIx (..))
 import Cardano.Ledger.Coin (CompactForm (CompactCoin))
 import Cardano.Ledger.CompactAddress (CompactAddr (UnsafeCompactAddr))
 import qualified Cardano.Ledger.Crypto as CC

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -69,7 +69,7 @@ translateCompactTxInByronToShelley ::
 translateCompactTxInByronToShelley (Byron.CompactTxInUtxo compactTxId idx) =
   TxIn
     (translateTxIdByronToShelley (Byron.fromCompactTxId compactTxId))
-    (fromIntegral idx)
+    (TxIx idx)
 
 translateUTxOByronToShelley ::
   forall c.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -216,7 +216,7 @@ mkMempoolEnv
   slot =
     Ledger.LedgerEnv
       { Ledger.ledgerSlotNo = slot,
-        Ledger.ledgerIx = 0,
+        Ledger.ledgerIx = minBound,
         Ledger.ledgerPp = LedgerState.esPp nesEs,
         Ledger.ledgerAccount = LedgerState.esAccountState nesEs
       }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.BaseTypes as X
     Port (..),
     ProtVer (..),
     StrictMaybe (..),
+    TxIx (..),
     epochInfo,
   )
 -- TODO deprecate these?

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
-
 module Cardano.Ledger.Shelley.API.Types
   ( module X,
   )
@@ -11,14 +9,19 @@ import Cardano.Ledger.Address as X
   )
 import Cardano.Ledger.BHeaderView as X (isOverlaySlot)
 import Cardano.Ledger.BaseTypes as X
-  ( Globals (..),
+  ( CertIx,
+    Globals (..),
     Network (..),
     Nonce (..),
     Port (..),
     ProtVer (..),
     StrictMaybe (..),
-    TxIx (..),
+    TxIx,
+    certIxFromIntegral,
+    certIxToInt,
     epochInfo,
+    txIxFromIntegral,
+    txIxToInt,
   )
 -- TODO deprecate these?
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -308,7 +308,7 @@ genesisUTxO genesis =
 -- we need this same 'TxIn' to use as an input to the spending transaction.
 initialFundsPseudoTxIn :: forall crypto. CC.Crypto crypto => Addr crypto -> TxIn crypto
 initialFundsPseudoTxIn addr =
-  TxIn (pseudoTxId addr) 0
+  TxIn (pseudoTxId addr) minBound
   where
     pseudoTxId =
       TxId

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -39,7 +39,6 @@ module Cardano.Ledger.Shelley.LedgerState
     PulsingRewUpdate (..),
     FutureGenDeleg (..),
     InstantaneousRewards (..),
-    Ix,
     KeyPairs,
     LedgerState (..),
     PPUPState (..),
@@ -208,7 +207,6 @@ import Cardano.Ledger.Shelley.Rewards
 import Cardano.Ledger.Shelley.Tx (extractKeyHashWitnessSet)
 import Cardano.Ledger.Shelley.TxBody
   ( EraIndependentTxBody,
-    Ix,
     MIRPot (..),
     PoolCert (..),
     PoolParams (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -29,6 +29,7 @@ import Cardano.Binary
 import Cardano.Ledger.Address (mkRwdAcnt)
 import Cardano.Ledger.BaseTypes
   ( ShelleyBase,
+    TxIx,
     invalidKey,
     networkId,
   )
@@ -56,7 +57,6 @@ import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     DelegCert (..),
     Delegation (..),
-    Ix,
     Ptr (..),
     RewardAcnt (..),
     Wdrl (..),
@@ -90,11 +90,11 @@ import NoThunks.Class (NoThunks (..))
 data DELEGS era
 
 data DelegsEnv era = DelegsEnv
-  { delegsSlotNo :: SlotNo,
-    delegsIx :: Ix,
-    delegspp :: Core.PParams era,
-    delegsTx :: Core.Tx era,
-    delegsAccount :: AccountState
+  { delegsSlotNo :: !SlotNo,
+    delegsIx :: !TxIx,
+    delegspp :: !(Core.PParams era),
+    delegsTx :: !(Core.Tx era),
+    delegsAccount :: !AccountState
   }
 
 deriving stock instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -243,7 +243,7 @@ delegsTransition = do
       isDelegationRegistered ?!: id
 
       -- It is impossible to have 4294967295 number of certificates in a
-      -- trabsaction, thus partial function is justified.
+      -- transaction, therefore partial function is justified.
       let ptr = Ptr slot txIx (mkCertIxPartial $ toInteger $ length gamma)
       trans @(Core.EraRule "DELPL" era) $
         TRC (DelplEnv slot ptr pp acnt, dpstate', c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.BaseTypes
   ( ShelleyBase,
     TxIx,
     invalidKey,
+    mkCertIxPartial,
     networkId,
   )
 import Cardano.Ledger.Coin (Coin)
@@ -225,7 +226,7 @@ delegsTransition = do
               )
               Map.empty
               wdrls_
-          unified' = (rewards' UM.⨃ wdrls_')
+          unified' = rewards' UM.⨃ wdrls_'
       pure $ dpstate {_dstate = ds {_unified = unified'}}
     gamma :|> c -> do
       dpstate' <-
@@ -241,7 +242,9 @@ delegsTransition = do
             _ -> Right ()
       isDelegationRegistered ?!: id
 
-      let ptr = Ptr slot txIx (fromIntegral $ length gamma)
+      -- It is impossible to have 4294967295 number of certificates in a
+      -- trabsaction, thus partial function is justified.
+      let ptr = Ptr slot txIx (mkCertIxPartial $ toInteger $ length gamma)
       trans @(Core.EraRule "DELPL" era) $
         TRC (DelplEnv slot ptr pp acnt, dpstate', c)
   where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -28,7 +28,7 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.BaseTypes (ShelleyBase, invalidKey)
+import Cardano.Ledger.BaseTypes (ShelleyBase, TxIx, invalidKey)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
@@ -39,7 +39,6 @@ import Cardano.Ledger.Shelley.LedgerState
   ( AccountState,
     DPState (..),
     DState (..),
-    Ix,
     PState (..),
     UTxOState (..),
     rewards,
@@ -79,10 +78,10 @@ import NoThunks.Class (NoThunks (..))
 data LEDGER era
 
 data LedgerEnv era = LedgerEnv
-  { ledgerSlotNo :: SlotNo,
-    ledgerIx :: Ix,
-    ledgerPp :: Core.PParams era,
-    ledgerAccount :: AccountState
+  { ledgerSlotNo :: !SlotNo,
+    ledgerIx :: !TxIx,
+    ledgerPp :: !(Core.PParams era),
+    ledgerAccount :: !AccountState
   }
 
 deriving instance Show (Core.PParams era) => Show (LedgerEnv era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -142,7 +142,7 @@ ledgersTransition = do
             TRC (LedgerEnv slot ix pp account, (u', dp'), tx)
       )
       (u, dp)
-      $ zip [0 ..] $
+      $ zip [minBound ..] $
         toList txwits
 
   pure $ LedgerState u'' dp''

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -25,7 +25,6 @@ module Cardano.Ledger.Shelley.TxBody
     DelegCert (..),
     Delegation (..),
     GenesisDelegCert (..),
-    Ix,
     MIRCert (..),
     MIRPot (..),
     MIRTarget (..),
@@ -100,12 +99,7 @@ import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
 import Cardano.Ledger.CompactAddress (CompactAddr, compactAddr, decompactAddr)
 import Cardano.Ledger.Compactible
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Credential
-  ( Credential (..),
-    Ix,
-    Ptr (..),
-    StakeCredential,
-  )
+import Cardano.Ledger.Credential (Credential (..), Ptr (..), StakeCredential)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
 import Cardano.Ledger.Hashes (EraIndependentTxBody, ScriptHash)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -175,7 +175,7 @@ txouts tx =
   UTxO $
     SplitMap.fromList
       [ (TxIn transId idx, out)
-        | (out, idx) <- zip (toList $ getField @"outputs" tx) [0 ..]
+        | (out, idx) <- zip (toList $ getField @"outputs" tx) [minBound ..]
       ]
   where
     transId = Core.txid tx

--- a/eras/shelley/test-suite/bench/BenchUTxOAggregate.hs
+++ b/eras/shelley/test-suite/bench/BenchUTxOAggregate.hs
@@ -8,6 +8,7 @@ module BenchUTxOAggregate where
 import Cardano.Ledger.Address
   ( Addr (..),
   )
+import Cardano.Ledger.BaseTypes (mkTxIxPartial)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.CompactAddress (compactAddr)
 import Cardano.Ledger.Compactible (toCompact)
@@ -63,7 +64,7 @@ genTestCase numUTxO numAddr = do
         (compactAddr addr)
         (fromJust $ toCompact $ Val.inject (Coin $ fromIntegral i))
   let mktxid i = TxId (unsafeMakeSafeHash (mkDummyHash i))
-  let mktxin i = TxIn (mktxid i) (fromIntegral i)
+  let mktxin i = TxIn (mktxid i) (mkTxIxPartial (toInteger i))
   let utxo = SplitMap.fromList $ zip (mktxin <$> [1 ..]) txOuts
       liveptrs :: [Ptr]
       liveptrs = [p | (TxOut (Addr _ _ (StakeRefPtr p)) _) <- txOuts]

--- a/eras/shelley/test-suite/cddl-files/shelley.cddl
+++ b/eras/shelley/test-suite/cddl-files/shelley.cddl
@@ -18,7 +18,7 @@ transaction =
   , transaction_metadata / null
   ]
 
-transaction_index = uint
+transaction_index = uint .size 2
 
 header =
   [ header_body

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -78,7 +78,7 @@ import Cardano.Ledger.Shelley.UTxO
 import Cardano.Ledger.Slot
   ( SlotNo (..),
   )
-import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
 import Cardano.Ledger.Val ((<->))
 import Cardano.Prelude
   ( ByteString,
@@ -149,7 +149,7 @@ utxo0 :: UTxO C
 utxo0 =
   UTxO $
     SplitMap.singleton
-      (TxIn genesisId 0)
+      (TxIn genesisId minBound)
       (TxOut aliceAddr aliceInitCoin)
 
 utxoState0 :: UTxOState C
@@ -179,8 +179,8 @@ utxoState1 =
     }
   where
     txid = TxId $ hashAnnotated txBody
-    bobResult = (TxIn txid 0, TxOut bobAddr coinsToBob)
-    aliceResult = (TxIn txid 1, TxOut aliceAddr (Coin 998990))
+    bobResult = (mkTxInPartial txid 0, TxOut bobAddr coinsToBob)
+    aliceResult = (mkTxInPartial txid 1, TxOut aliceAddr (Coin 998990))
 
 utxoEnv :: UtxoEnv C
 utxoEnv =
@@ -240,7 +240,7 @@ coinsToBob = Coin 1000
 txBody :: TxBody C
 txBody =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut bobAddr coinsToBob, TxOut aliceAddr change],
       _certs = StrictSeq.fromList mempty,
       _wdrls = Wdrl Map.empty,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -118,7 +118,7 @@ aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 -- | Alice's base address
 alicePtrAddr :: CC.Crypto crypto => Addr crypto
-alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) 0 0)
+alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) minBound minBound)
 
 -- | Alice's stake pool parameters
 alicePoolParams :: forall crypto. CC.Crypto crypto => PoolParams crypto

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -330,7 +330,7 @@ exampleNewEpochState value ppp pp =
                     { _utxo =
                         UTxO $
                           SplitMap.fromList
-                            [ ( TxIn (TxId (mkDummySafeHash Proxy 1)) 0,
+                            [ ( TxIn (TxId (mkDummySafeHash Proxy 1)) minBound,
                                 makeTxOut (Proxy @era) addr value
                               )
                             ],
@@ -461,7 +461,7 @@ exampleAuxiliaryDataShelley = Metadata exampleMetadataMap
 exampleTxIns :: Cardano.Ledger.Crypto.Crypto c => Set (TxIn c)
 exampleTxIns =
   Set.fromList
-    [ TxIn (TxId (mkDummySafeHash Proxy 1)) 0
+    [ TxIn (TxId (mkDummySafeHash Proxy 1)) minBound
     ]
 
 exampleCerts :: Cardano.Ledger.Crypto.Crypto c => StrictSeq (DCert c)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -706,7 +706,7 @@ genesisCoins ::
   UTxO era
 genesisCoins genesisTxId outs =
   UTxO $
-    SplitMap.fromList [(TxIn genesisTxId idx, out) | (idx, out) <- zip [0 ..] outs]
+    SplitMap.fromList [(TxIn genesisTxId idx, out) | (idx, out) <- zip [minBound ..] outs]
 
 -- ==================================================================
 -- Operations on GenEnv that deal with ScriptSpace

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/DCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/DCert.hs
@@ -5,12 +5,10 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.Cardano.Ledger.Shelley.Generator.Trace.DCert
@@ -19,7 +17,7 @@ module Test.Cardano.Ledger.Shelley.Generator.Trace.DCert
   )
 where
 
-import Cardano.Ledger.BaseTypes (Globals, ShelleyBase)
+import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, TxIx)
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
@@ -110,7 +108,7 @@ instance
   ) =>
   STS (CERTS era)
   where
-  type Environment (CERTS era) = (SlotNo, Ix, Core.PParams era, AccountState)
+  type Environment (CERTS era) = (SlotNo, TxIx, Core.PParams era, AccountState)
   type State (CERTS era) = (DPState (Crypto era), Ix)
   type Signal (CERTS era) = Maybe (DCert (Crypto era), CertCred era)
   type PredicateFailure (CERTS era) = CertsPredicateFailure era
@@ -205,7 +203,7 @@ genDCerts ::
   Core.PParams era ->
   DPState (Crypto era) ->
   SlotNo ->
-  Ix ->
+  TxIx ->
   AccountState ->
   Gen
     ( StrictSeq (DCert (Crypto era)),
@@ -241,7 +239,7 @@ genDCerts
     pure
       ( StrictSeq.fromList certs,
         totalDeposits pparams (`Map.notMember` pools) certs,
-        (length deRegStakeCreds) <×> (getField @"_keyDeposit" pparams),
+        length deRegStakeCreds <×> getField @"_keyDeposit" pparams,
         lastState_,
         ( concat (keyCredAsWitness <$> keyCreds'),
           extractScriptCred <$> scriptCreds

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -1166,7 +1166,7 @@ ledgerTraceBase ::
   )
 ledgerTraceBase chainSt block =
   ( tickedChainSt,
-    LedgerEnv slot 0 pp_ (esAccountState nes),
+    LedgerEnv slot minBound pp_ (esAccountState nes),
     (utxoSt0, delegSt0),
     txs
   )

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -1136,7 +1136,7 @@ delegTraceFromBlock chainSt block =
     blockCerts = filter delegCert (certs txs)
     delegEnv =
       let (LedgerEnv s txIx pp reserves) = ledgerEnv
-          dummyCertIx = 0
+          dummyCertIx = minBound
           ptr = Ptr s txIx dummyCertIx
        in DelegEnv s ptr reserves pp
     delegSt0 =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -394,6 +393,8 @@ instance CC.Crypto crypto => Arbitrary (Credential r crypto) where
       [ ScriptHashObj . ScriptHash <$> genHash,
         KeyHashObj <$> arbitrary
       ]
+
+deriving instance Arbitrary TxIx
 
 instance Arbitrary Ptr where
   arbitrary = genericArbitraryU

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -45,6 +44,7 @@ import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     BlocksMade (..),
+    CertIx (..),
     DnsName,
     NonNegativeInterval,
     PositiveInterval,
@@ -395,6 +395,8 @@ instance CC.Crypto crypto => Arbitrary (Credential r crypto) where
       ]
 
 deriving instance Arbitrary TxIx
+
+deriving instance Arbitrary CertIx
 
 instance Arbitrary Ptr where
   arbitrary = genericArbitraryU

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -49,6 +49,7 @@ import Cardano.Ledger.BaseTypes
     NonNegativeInterval,
     PositiveInterval,
     PositiveUnitInterval,
+    TxIx (..),
     UnitInterval,
     Url,
     mkActiveSlotCoeff,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -127,7 +127,7 @@ feeTx1 = Coin 1
 txbodyEx1 :: (Cr.Crypto c) => TxBody (ShelleyEra c)
 txbodyEx1 =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr aliceCoinEx1)
     ( StrictSeq.fromList
         [ DCertGenesis

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -132,7 +132,7 @@ feeTx1 = Coin 1
 txbodyEx1 :: (ShelleyTest era) => MIRPot -> TxBody era
 txbodyEx1 pot =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr aliceCoinEx1)
     ( StrictSeq.fromList
         [ DCertMir (MIRCert pot ir),
@@ -212,7 +212,7 @@ expectedStEx1' txwits pot =
     . C.newLab (blockEx1' txwits pot)
     . C.feesAndDeposits feeTx1 (_keyDeposit ppEx)
     . C.newUTxO (txbodyEx1 pot)
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) 0 1)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 1)
     . C.mir Cast.aliceSHK pot aliceMIRCoin
     $ initStMIR (Coin 1000)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Shelley.Examples.Mir
   )
 where
 
-import Cardano.Ledger.BaseTypes (Nonce, StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Nonce, StrictMaybe (..), mkCertIxPartial)
 import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
 import Cardano.Ledger.Credential (Ptr (..))
@@ -212,7 +212,7 @@ expectedStEx1' txwits pot =
     . C.newLab (blockEx1' txwits pot)
     . C.feesAndDeposits feeTx1 (_keyDeposit ppEx)
     . C.newUTxO (txbodyEx1 pot)
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 1)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 1))
     . C.mir Cast.aliceSHK pot aliceMIRCoin
     $ initStMIR (Coin 1000)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
@@ -50,7 +50,7 @@ env :: ProtVer -> AccountState -> DelegEnv ShelleyTest
 env pv acnt =
   DelegEnv
     { slotNo = SlotNo 50,
-      ptr_ = Ptr (SlotNo 50) 0 0,
+      ptr_ = Ptr (SlotNo 50) minBound minBound,
       acnt_ = acnt,
       ppDE = emptyPParams {_protocolVersion = pv}
     }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.BaseTypes
     Nonce,
     StrictMaybe (..),
     epochInfo,
+    mkCertIxPartial,
     (⭒),
   )
 import Cardano.Ledger.Block (Block, bheader)
@@ -264,9 +265,9 @@ expectedStEx1 =
     . C.newLab blockEx1
     . C.feesAndDeposits feeTx1 (((3 :: Integer) <×> _keyDeposit ppEx) <+> _poolDeposit ppEx)
     . C.newUTxO txbodyEx1
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 0)
-    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound 1)
-    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound 2)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 0))
+    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 1))
+    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 2))
     . C.newPool Cast.alicePoolParams
     . C.mir Cast.carlSHK ReservesMIR carlMIR
     . C.mir Cast.dariaSHK ReservesMIR dariaMIR

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -92,7 +92,7 @@ import Cardano.Ledger.Slot
     SlotNo (..),
     epochInfoSize,
   )
-import Cardano.Ledger.TxIn (TxIn (..), txid)
+import Cardano.Ledger.TxIn (TxIn (..), mkTxInPartial, txid)
 import Cardano.Ledger.Val ((<+>), (<->), (<×>))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Protocol.TPraos.BHeader (BHeader, bhHash, hashHeaderToNonce)
@@ -193,7 +193,7 @@ feeTx1 = Coin 3
 txbodyEx1 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx1 =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx1)])
     ( StrictSeq.fromList
         ( [ DCertDeleg (RegKey Cast.aliceSHK),
@@ -264,9 +264,9 @@ expectedStEx1 =
     . C.newLab blockEx1
     . C.feesAndDeposits feeTx1 (((3 :: Integer) <×> _keyDeposit ppEx) <+> _poolDeposit ppEx)
     . C.newUTxO txbodyEx1
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) 0 0)
-    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) 0 1)
-    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) 0 2)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 0)
+    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound 1)
+    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound 2)
     . C.newPool Cast.alicePoolParams
     . C.mir Cast.carlSHK ReservesMIR carlMIR
     . C.mir Cast.dariaSHK ReservesMIR dariaMIR
@@ -299,7 +299,7 @@ aliceCoinEx2Ptr = aliceCoinEx1 <-> (aliceCoinEx2Base <+> feeTx2)
 txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    { _inputs = Set.fromList [TxIn (txid (txbodyEx1 @c)) 0],
+    { _inputs = Set.fromList [TxIn (txid (txbodyEx1 @c)) minBound],
       _outputs =
         StrictSeq.fromList
           [ TxOut Cast.aliceAddr (Val.inject aliceCoinEx2Base),
@@ -470,7 +470,7 @@ aliceCoinEx4Base = aliceCoinEx2Base <-> feeTx4
 txbodyEx4 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx4 =
   TxBody
-    { _inputs = Set.fromList [TxIn (txid txbodyEx2) 0],
+    { _inputs = Set.fromList [TxIn (txid txbodyEx2) minBound],
       _outputs = StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx4Base)],
       _certs =
         StrictSeq.fromList
@@ -893,7 +893,7 @@ bobAda10 =
 txbodyEx10 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx10 =
   TxBody
-    (Set.fromList [TxIn genesisId 1])
+    (Set.fromList [mkTxInPartial genesisId 1])
     (StrictSeq.singleton $ TxOut Cast.bobAddr (Val.inject bobAda10))
     (StrictSeq.fromList [DCertDeleg (DeRegKey Cast.bobSHK)])
     (Wdrl $ Map.singleton (RewardAcnt Testnet Cast.bobSHK) bobRAcnt8)
@@ -958,7 +958,7 @@ aliceRetireEpoch = EpochNo 5
 txbodyEx11 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx11 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx4) 0])
+    (Set.fromList [TxIn (txid txbodyEx4) minBound])
     (StrictSeq.singleton $ TxOut Cast.alicePtrAddr (Val.inject aliceCoinEx11Ptr))
     (StrictSeq.fromList [DCertPool (RetirePool (hk Cast.alicePoolKeys) aliceRetireEpoch)])
     (Wdrl Map.empty)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -104,7 +104,7 @@ aliceCoinEx1 = aliceInitCoin <-> _poolDeposit ppEx <-> feeTx1
 txbodyEx1 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx1 =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx1)])
     (StrictSeq.fromList ([DCertPool (RegPool Cast.alicePoolParams)]))
     (Wdrl Map.empty)
@@ -180,7 +180,7 @@ newPoolParams = Cast.alicePoolParams {_poolCost = Coin 500}
 txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx1) 0])
+    (Set.fromList [TxIn (txid txbodyEx1) minBound])
     (StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx2)])
     ( StrictSeq.fromList
         ( [ DCertPool (RegPool newPoolParams)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.BaseTypes
     ProtVer (..),
     StrictMaybe (..),
     activeSlotVal,
+    mkCertIxPartial,
     (⭒),
   )
 import Cardano.Ledger.Block (Block, bheader)
@@ -268,9 +269,9 @@ expectedStEx1 =
     . C.newLab blockEx1
     . C.feesAndDeposits feeTx1 (((3 :: Integer) <×> _keyDeposit ppEx) <+> ((2 :: Integer) <×> _poolDeposit ppEx))
     . C.newUTxO txbodyEx1
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 0)
-    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound 1)
-    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound 2)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 0))
+    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 1))
+    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound (mkCertIxPartial 2))
     . C.newPool alicePoolParams'
     . C.newPool bobPoolParams'
     . C.delegation Cast.aliceSHK (_poolId alicePoolParams')

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -200,7 +200,7 @@ bobPoolParams' = Cast.bobPoolParams {_poolRAcnt = RewardAcnt Testnet Cast.carlSH
 txbodyEx1 :: forall era. TwoPoolsConstraints era => TxBody era
 txbodyEx1 =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.fromList [TxOut Cast.aliceAddr (Val.inject aliceCoinEx1)])
     ( StrictSeq.fromList
         [ DCertDeleg (RegKey Cast.aliceSHK),
@@ -268,9 +268,9 @@ expectedStEx1 =
     . C.newLab blockEx1
     . C.feesAndDeposits feeTx1 (((3 :: Integer) <×> _keyDeposit ppEx) <+> ((2 :: Integer) <×> _poolDeposit ppEx))
     . C.newUTxO txbodyEx1
-    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) 0 0)
-    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) 0 1)
-    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) 0 2)
+    . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo 10) minBound 0)
+    . C.newStakeCred Cast.bobSHK (Ptr (SlotNo 10) minBound 1)
+    . C.newStakeCred Cast.carlSHK (Ptr (SlotNo 10) minBound 2)
     . C.newPool alicePoolParams'
     . C.newPool bobPoolParams'
     . C.delegation Cast.aliceSHK (_poolId alicePoolParams')

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -149,7 +149,7 @@ aliceCoinEx1 = aliceInitCoin <-> feeTx1
 txbodyEx1 :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx1 =
   TxBody
-    (Set.fromList [TxIn genesisId 0])
+    (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr (Val.inject aliceCoinEx1))
     StrictSeq.empty
     (Wdrl Map.empty)
@@ -224,7 +224,7 @@ aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 txbodyEx2 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx2 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx1) 0])
+    (Set.fromList [TxIn (txid txbodyEx1) minBound])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr (Val.inject aliceCoinEx2))
     StrictSeq.empty
     (Wdrl Map.empty)
@@ -317,7 +317,7 @@ aliceCoinEx3 = aliceCoinEx2 <-> feeTx3
 txbodyEx3 :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbodyEx3 =
   TxBody
-    (Set.fromList [TxIn (txid txbodyEx2) 0])
+    (Set.fromList [TxIn (txid txbodyEx2) minBound])
     (StrictSeq.singleton $ TxOut Cast.aliceAddr (Val.inject aliceCoinEx3))
     StrictSeq.empty
     (Wdrl Map.empty)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -69,6 +69,7 @@ import Cardano.Ledger.Shelley.TxBody
   )
 import Cardano.Ledger.Shelley.UTxO (makeWitnessesVKey)
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
+import Cardano.Ledger.TxIn (mkTxInPartial)
 import qualified Cardano.Ledger.Val as Val
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
@@ -178,7 +179,7 @@ carlPay = KeyPair vk sk
 txbSimpleUTxO :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbSimpleUTxO =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.empty,
       _wdrls = Wdrl Map.empty,
@@ -212,8 +213,8 @@ txbMutiUTxO =
   TxBody
     { _inputs =
         Set.fromList
-          [ TxIn genesisId 0,
-            TxIn genesisId 1
+          [ mkTxInPartial genesisId 0,
+            mkTxInPartial genesisId 1
           ],
       _outputs =
         StrictSeq.fromList
@@ -254,7 +255,7 @@ txMutiUTxOBytes16 = "83a4008282582003170a2e7597b7b7e3d84c05391d139a62b157e78786d
 txbRegisterStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbRegisterStake =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.fromList [DCertDeleg (RegKey aliceSHK)],
       _wdrls = Wdrl Map.empty,
@@ -282,7 +283,7 @@ txRegisterStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e7
 txbDelegateStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbDelegateStake =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs =
         StrictSeq.fromList
@@ -317,7 +318,7 @@ txDelegateStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e7
 txbDeregisterStake :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbDeregisterStake =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.fromList [DCertDeleg (DeRegKey aliceSHK)],
       _wdrls = Wdrl Map.empty,
@@ -348,7 +349,7 @@ txDeregisterStakeBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157
 txbRegisterPool :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbRegisterPool =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.fromList [DCertPool (RegPool alicePoolParams)],
       _wdrls = Wdrl Map.empty,
@@ -376,7 +377,7 @@ txRegisterPoolBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78
 txbRetirePool :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbRetirePool =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.fromList [DCertPool (RetirePool alicePoolKH (EpochNo 5))],
       _wdrls = Wdrl Map.empty,
@@ -408,7 +409,7 @@ md = MD.Metadata $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 txbWithMD :: forall c. Cr.Crypto c => TxBody (ShelleyEra c)
 txbWithMD =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.empty,
       _wdrls = Wdrl Map.empty,
@@ -445,7 +446,7 @@ msig =
 txbWithMultiSig :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbWithMultiSig =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0], -- acting as if this is multi-sig
+    { _inputs = Set.fromList [TxIn genesisId minBound], -- acting as if this is multi-sig
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.empty,
       _wdrls = Wdrl Map.empty,
@@ -477,7 +478,7 @@ txWithMultiSigBytes16 = "83a4008182582003170a2e7597b7b7e3d84c05391d139a62b157e78
 txbWithWithdrawal :: Cr.Crypto c => TxBody (ShelleyEra c)
 txbWithWithdrawal =
   TxBody
-    { _inputs = Set.fromList [TxIn genesisId 0],
+    { _inputs = Set.fromList [TxIn genesisId minBound],
       _outputs = StrictSeq.fromList [TxOut aliceAddr (Val.inject $ Coin 10)],
       _certs = StrictSeq.empty,
       _wdrls = Wdrl $ Map.singleton (RewardAcnt Testnet aliceSHK) (Val.inject $ Coin 100),

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.Hash (HashAlgorithm (..), hashFromBytes, hashFromTextAsHex, sizeHash)
 import Cardano.Crypto.Hash.Blake2b (Blake2b_224)
 import Cardano.Ledger.Address
-import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.BaseTypes (Network (..), mkTxIxPartial)
 import Cardano.Ledger.Credential
   ( Credential (..),
     Ptr (..),
@@ -140,7 +140,7 @@ goldenTests_MockCrypto =
     ptrHex :: IsString s => s
     ptrHex = "81000203"
     ptr :: Ptr
-    ptr = Ptr (SlotNo 128) 2 3
+    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) 3
 
 goldenTests_ShelleyCrypto :: TestTree
 goldenTests_ShelleyCrypto =
@@ -211,7 +211,7 @@ goldenTests_ShelleyCrypto =
     stakeKey :: Credential 'Staking ShelleyCrypto
     stakeKey = keyBlake2b224 $ B16.encode "1c2c3c4c5c6c7c8c"
     ptr :: Ptr
-    ptr = Ptr (SlotNo 128) 2 3
+    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) 3
     -- 32-byte verification key is expected, vk, ie., public key without chain code.
     -- The verification key undergoes Blake2b_224 hashing
     -- and should be 28-byte in the aftermath

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.Hash (HashAlgorithm (..), hashFromBytes, hashFromTextAsHex, sizeHash)
 import Cardano.Crypto.Hash.Blake2b (Blake2b_224)
 import Cardano.Ledger.Address
-import Cardano.Ledger.BaseTypes (Network (..), mkTxIxPartial)
+import Cardano.Ledger.BaseTypes (Network (..), mkCertIxPartial, mkTxIxPartial)
 import Cardano.Ledger.Credential
   ( Credential (..),
     Ptr (..),
@@ -140,7 +140,7 @@ goldenTests_MockCrypto =
     ptrHex :: IsString s => s
     ptrHex = "81000203"
     ptr :: Ptr
-    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) 3
+    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) (mkCertIxPartial 3)
 
 goldenTests_ShelleyCrypto :: TestTree
 goldenTests_ShelleyCrypto =
@@ -211,7 +211,7 @@ goldenTests_ShelleyCrypto =
     stakeKey :: Credential 'Staking ShelleyCrypto
     stakeKey = keyBlake2b224 $ B16.encode "1c2c3c4c5c6c7c8c"
     ptr :: Ptr
-    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) 3
+    ptr = Ptr (SlotNo 128) (mkTxIxPartial 2) (mkCertIxPartial 3)
     -- 32-byte verification key is expected, vk, ie., public key without chain code.
     -- The verification key undergoes Blake2b_224 hashing
     -- and should be 28-byte in the aftermath

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -63,7 +63,7 @@ import Cardano.Binary
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Crypto.Hash.Class as Hash
 import qualified Cardano.Crypto.Hashing as Byron
-import Cardano.Ledger.BaseTypes (Network (..), networkToWord8, word8ToNetwork)
+import Cardano.Ledger.BaseTypes (Network (..), TxIx (..), networkToWord8, word8ToNetwork)
 import Cardano.Ledger.Credential
   ( Credential (..),
     PaymentCredential,
@@ -100,7 +100,7 @@ import Data.Maybe (fromMaybe)
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
-import Data.Word (Word64)
+import Data.Word (Word16, Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
@@ -389,9 +389,9 @@ isBootstrapRedeemer (BootstrapAddress (Byron.Address _ _ Byron.ATRedeem)) = True
 isBootstrapRedeemer _ = False
 
 putPtr :: Ptr -> Put
-putPtr (Ptr slot txIx certIx) = do
+putPtr (Ptr slot (TxIx txIx) certIx) = do
   putSlot slot
-  putVariableLengthWord64 txIx
+  putVariableLengthWord64 ((fromIntegral :: Word16 -> Word64) txIx)
   putVariableLengthWord64 certIx
   where
     putSlot (SlotNo n) = putVariableLengthWord64 n
@@ -399,7 +399,7 @@ putPtr (Ptr slot txIx certIx) = do
 getPtr :: Get Ptr
 getPtr =
   Ptr <$> (SlotNo <$> getVariableLengthWord64)
-    <*> getVariableLengthWord64
+    <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
     <*> getVariableLengthWord64
 
 newtype Word7 = Word7 Word8

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -63,7 +63,13 @@ import Cardano.Binary
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Crypto.Hash.Class as Hash
 import qualified Cardano.Crypto.Hashing as Byron
-import Cardano.Ledger.BaseTypes (Network (..), TxIx (..), networkToWord8, word8ToNetwork)
+import Cardano.Ledger.BaseTypes
+  ( CertIx (..),
+    Network (..),
+    TxIx (..),
+    networkToWord8,
+    word8ToNetwork,
+  )
 import Cardano.Ledger.Credential
   ( Credential (..),
     PaymentCredential,
@@ -389,10 +395,10 @@ isBootstrapRedeemer (BootstrapAddress (Byron.Address _ _ Byron.ATRedeem)) = True
 isBootstrapRedeemer _ = False
 
 putPtr :: Ptr -> Put
-putPtr (Ptr slot (TxIx txIx) certIx) = do
+putPtr (Ptr slot (TxIx txIx) (CertIx certIx)) = do
   putSlot slot
   putVariableLengthWord64 ((fromIntegral :: Word16 -> Word64) txIx)
-  putVariableLengthWord64 certIx
+  putVariableLengthWord64 ((fromIntegral :: Word16 -> Word64) certIx)
   where
     putSlot (SlotNo n) = putVariableLengthWord64 n
 
@@ -400,7 +406,7 @@ getPtr :: Get Ptr
 getPtr =
   Ptr <$> (SlotNo <$> getVariableLengthWord64)
     <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
-    <*> getVariableLengthWord64
+    <*> (CertIx . fromIntegral <$> getVariableLengthWord64)
 
 newtype Word7 = Word7 Word8
   deriving (Eq, Show)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -51,12 +51,10 @@ module Cardano.Ledger.BaseTypes
     -- * Indices
     TxIx (..),
     txIxToInt,
-    txIxFromInteger,
     txIxFromIntegral,
     mkTxIxPartial,
     CertIx (..),
     certIxToInt,
-    certIxFromInteger,
     certIxFromIntegral,
     mkCertIxPartial,
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
@@ -136,7 +136,7 @@ instance
     ValidateScript era,
     Era.SupportsSegWit era,
     FromCBOR (Annotator (Era.TxSeq era)),
-    FromCBOR (Annotator (h)),
+    FromCBOR (Annotator h),
     Typeable h
   ) =>
   FromCBOR (Annotator (Block h era))
@@ -166,7 +166,7 @@ bbody (Block' _ txs _) = txs
 --
 -- This function will be used by the consensus layer to enable storing
 -- the UTxO on disk. In particular, given a block, the consensus layer
--- will use 'neededTxInsForBlock' to retrived the needed UTxO from disk
+-- will use 'neededTxInsForBlock' to retrieve the needed UTxO from disk
 -- and present only those to the ledger.
 neededTxInsForBlock ::
   ( Era era,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Address
     toWord7,
     word7sToWord64,
   )
-import qualified Cardano.Ledger.Address as Address (isBootstrapRedeemer)
 import Cardano.Ledger.BaseTypes (CertIx (..), TxIx (..), word8ToNetwork)
 import Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -34,7 +34,7 @@ import Cardano.Ledger.Address
     word7sToWord64,
   )
 import qualified Cardano.Ledger.Address as Address (isBootstrapRedeemer)
-import Cardano.Ledger.BaseTypes (TxIx (..), word8ToNetwork)
+import Cardano.Ledger.BaseTypes (CertIx (..), TxIx (..), word8ToNetwork)
 import Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),
     PaymentCredential,
@@ -209,7 +209,7 @@ getPtr :: GetShort Ptr
 getPtr =
   Ptr <$> (SlotNo <$> getVariableLengthWord64)
     <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
-    <*> getVariableLengthWord64
+    <*> (CertIx . fromIntegral <$> getVariableLengthWord64)
 
 getKeyHash :: CC.Crypto crypto => GetShort (Credential kr crypto)
 getKeyHash = KeyHashObj . KeyHash <$> getHash

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -33,7 +33,8 @@ import Cardano.Ledger.Address
     toWord7,
     word7sToWord64,
   )
-import Cardano.Ledger.BaseTypes (word8ToNetwork)
+import qualified Cardano.Ledger.Address as Address (isBootstrapRedeemer)
+import Cardano.Ledger.BaseTypes (TxIx (..), word8ToNetwork)
 import Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),
     PaymentCredential,
@@ -207,7 +208,7 @@ getVariableLengthWord64 = word7sToWord64 <$> getWord7s
 getPtr :: GetShort Ptr
 getPtr =
   Ptr <$> (SlotNo <$> getVariableLengthWord64)
-    <*> getVariableLengthWord64
+    <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
     <*> getVariableLengthWord64
 
 getKeyHash :: CC.Crypto crypto => GetShort (Credential kr crypto)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -19,7 +19,7 @@ module Cardano.Ledger.Credential
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
-import Cardano.Ledger.BaseTypes (invalidKey)
+import Cardano.Ledger.BaseTypes (TxIx, invalidKey)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys
@@ -99,7 +99,7 @@ type Ix = Word64
 
 -- | Pointer to a slot, transaction index and index in certificate list.
 data Ptr
-  = Ptr !SlotNo !Ix !Ix
+  = Ptr !SlotNo !TxIx !Ix
   deriving (Show, Eq, Ord, Generic, NFData, NoThunks)
   deriving (ToCBOR, FromCBOR) via CBORGroup Ptr
 
@@ -137,8 +137,9 @@ instance ToCBORGroup Ptr where
     where
       getSlotNo :: Ptr -> SlotNo
       getSlotNo (Ptr a _ _) = a
-      getIx1, getIx2 :: Ptr -> Ix
+      getIx1 :: Ptr -> TxIx
       getIx1 (Ptr _ x _) = x
+      getIx2 :: Ptr -> Ix
       getIx2 (Ptr _ _ x) = x
 
   listLen _ = 3

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -6,19 +6,24 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),
     GenesisCredential (..),
     PaymentCredential,
-    Ptr (..),
+    Ptr (Ptr),
+    ptrSlotNo,
+    ptrTxIx,
+    ptrCertIx,
     StakeCredential,
     StakeReference (..),
   )
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
-import Cardano.Ledger.BaseTypes (CertIx, TxIx, invalidKey)
+import Cardano.Ledger.BaseTypes (CertIx (..), TxIx (..), invalidKey)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys
@@ -36,9 +41,10 @@ import Cardano.Ledger.Slot (SlotNo (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey, (.:), (.=))
 import qualified Data.Aeson as Aeson
+import Data.Bits
 import Data.Foldable (asum)
 import Data.Typeable (Typeable)
-import Data.Word (Word8)
+import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
@@ -94,10 +100,40 @@ data StakeReference crypto
 
 instance NoThunks (StakeReference crypto)
 
--- | Pointer to a slot, transaction index and index in certificate list.
-data Ptr = Ptr !SlotNo !TxIx !CertIx
+-- | Pointer to a slot number, transaction index and an index in certificate
+-- list. We expect that `SlotNo` will fit into `Word32` for a very long time,
+-- because we can assume that the rate at which it is incremented isn't going to
+-- icrease in the near future. Therefore with current rate we should be fine for
+-- about a 150 years. I suggest to remove this optimization in about a
+-- hundred years or thereabouts, so around a year 2122 would be good.
+--
+-- Compaction works in a following manner. Total 8 bytes: first 4 bytes are for
+-- SlotNo (s0-s3), followed by 2 bytes for CertIx (c0-c1) and 2 more bytes for TxIx (t0-t1).
+--
+-- @@@
+--
+-- ┏━━┯━━┯━━┯━━┯━━┯━━┯━━┯━━┓
+-- ┃s3 s2 s1 s0┊c1 c0┊t1 t0┃
+-- ┗━━┷━━┷━━┷━━┷━━┷━━┷━━┷━━┛
+--
+-- @@@
+newtype Ptr = PtrCompact Word64
   deriving (Show, Eq, Ord, Generic, NFData, NoThunks)
   deriving (ToCBOR, FromCBOR) via CBORGroup Ptr
+
+-- | With this pattern synonym we can recover actual values from compacted version of `Ptr`.
+pattern Ptr :: SlotNo -> TxIx -> CertIx -> Ptr
+pattern Ptr slotNo txIx certIx <-
+  (viewPtr -> (slotNo, txIx, certIx))
+  where
+    Ptr (SlotNo slotNo) (TxIx txIx) (CertIx certIx) =
+      PtrCompact ((slotNo `shiftL` 32) .|. (fromIntegral txIx `shiftL` 16) .|. fromIntegral certIx)
+
+{-# COMPLETE Ptr #-}
+
+viewPtr :: Ptr -> (SlotNo, TxIx, CertIx)
+viewPtr (PtrCompact ptr) =
+  (SlotNo (ptr `shiftR` 32), TxIx (fromIntegral (ptr `shiftR` 16)), CertIx (fromIntegral ptr))
 
 ptrSlotNo :: Ptr -> SlotNo
 ptrSlotNo (Ptr sn _ _) = sn
@@ -107,7 +143,6 @@ ptrTxIx (Ptr _ txIx _) = txIx
 
 ptrCertIx :: Ptr -> CertIx
 ptrCertIx (Ptr _ _ cIx) = cIx
-
 
 instance
   (Typeable kr, CC.Crypto crypto) =>

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -7,47 +7,37 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.TxIn
   ( TxId (..),
-    TxIn (TxIn, ..),
+    TxIn (TxIn),
+    mkTxInPartial,
+    TxIx,
     txid,
   )
 where
 
-import Cardano.Binary
-  ( DecoderError (DecoderErrorCustom),
-    FromCBOR (fromCBOR),
-    ToCBOR (..),
-    encodeListLen,
-  )
+import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (..), encodeListLen)
+import Cardano.Ledger.BaseTypes (TxIx (..), mkTxIxPartial, txIxToInt)
 import Cardano.Ledger.Core (TxBody)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Serialization (decodeRecordNamed)
-import Cardano.Prelude (HeapWords (..), NFData, cborError)
+import Cardano.Prelude (HeapWords (..), NFData)
 import qualified Cardano.Prelude as HW
-import Control.Monad (when)
 import Data.Compact.HashMap (Keyed (..))
 import Data.Compact.SplitMap as SMap
-import Data.Text as T (pack)
-import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
-import Numeric.Natural (Natural)
 
 -- | Compute the id of a transaction.
 txid ::
@@ -81,28 +71,23 @@ deriving newtype instance CC.Crypto crypto => FromCBOR (TxId crypto)
 deriving newtype instance CC.Crypto crypto => NFData (TxId crypto)
 
 instance CC.Crypto crypto => HeapWords (TxIn crypto) where
-  heapWords (TxIn txId txIx) =
-    2 + HW.heapWords txId + HW.heapWordsUnpacked txIx
+  heapWords (TxIn txId _) =
+    2 + HW.heapWords txId + 1 {- txIx -}
 
 -- | The input of a UTxO.
-data TxIn crypto = TxInCompact !(TxId crypto) {-# UNPACK #-} !Int
+data TxIn crypto = TxIn !(TxId crypto) {-# UNPACK #-} !TxIx
   deriving (Generic)
 
+-- | Construct `TxIn` while throwing an error for an out of range `TxIx`. Make
+-- sure to use it only for testing.
+mkTxInPartial :: HW.HasCallStack => TxId crypto -> Integer -> TxIn crypto
+mkTxInPartial txId = TxIn txId . mkTxIxPartial
+
 instance CC.Crypto crypto => Split (TxIn crypto) where
-  splitKey (TxInCompact txId txIx) = (txIx, toKey txId)
-  joinKey txIx key = TxInCompact (fromKey key) txIx
-
-pattern TxIn ::
-  TxId crypto ->
-  Natural -> -- TODO We might want to change this to Int generally
-  TxIn crypto
-pattern TxIn addr index <-
-  TxInCompact addr (fromIntegral -> index)
-  where
-    TxIn addr index =
-      TxInCompact addr (fromIntegral index)
-
-{-# COMPLETE TxIn #-}
+  splitKey (TxIn txId txIx) = (txIxToInt txIx, toKey txId)
+  joinKey txIx key =
+    -- `fromIntegral` is safe here, since we have only valid values in the SplitMap:
+    TxIn (fromKey key) (TxIx (fromIntegral txIx))
 
 deriving instance Eq (TxIn crypto)
 
@@ -115,7 +100,7 @@ deriving instance CC.Crypto crypto => NFData (TxIn crypto)
 instance NoThunks (TxIn crypto)
 
 instance CC.Crypto crypto => ToCBOR (TxIn crypto) where
-  toCBOR (TxInCompact txId index) =
+  toCBOR (TxIn txId index) =
     encodeListLen 2
       <> toCBOR txId
       <> toCBOR index
@@ -125,10 +110,4 @@ instance CC.Crypto crypto => FromCBOR (TxIn crypto) where
     decodeRecordNamed
       "TxIn"
       (const 2)
-      (TxInCompact <$> fromCBOR <*> txIxFromCBOR)
-    where
-      txIxFromCBOR = do
-        w64 :: Word64 <- fromCBOR
-        when (w64 > fromIntegral (maxBound :: Int)) $
-          cborError $ DecoderErrorCustom "TxIn" ("Tx index is too big: " <> T.pack (show w64))
-        pure $ fromIntegral w64
+      (TxIn <$> fromCBOR <*> fromCBOR)

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.BaseTypes
     activeSlotLog,
     activeSlotVal,
     dnsToText,
+    txIxToInt,
   )
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
@@ -1055,7 +1056,7 @@ ppTxId :: TxId c -> PDoc
 ppTxId (TxId x) = ppSexp "TxId" [ppSafeHash x]
 
 ppTxIn :: TxIn c -> PDoc
-ppTxIn (TxIn txid index) = ppSexp "TxIn" [ppTxId txid, ppNatural index]
+ppTxIn (TxIn txid index) = ppSexp "TxIn" [ppTxId txid, pretty (txIxToInt index)]
 
 ppTxOut :: (Era era, PrettyA (Core.Value era)) => TxOut era -> PDoc
 ppTxOut (TxOutCompact caddr cval) = ppSexp "TxOut" [ppCompactAddr caddr, ppCompactForm prettyA cval]
@@ -1345,7 +1346,7 @@ ppCredential (ScriptHashObj (ScriptHash x)) = ppSexp "ScriptCred" [ppHash x]
 ppCredential (KeyHashObj (KeyHash x)) = ppSexp "KeyCred" [ppHash x]
 
 ppPtr :: Ptr -> PDoc
-ppPtr (Ptr slot n m) = ppSexp "Ptr" [ppSlotNo slot, pretty n, pretty m]
+ppPtr (Ptr slot n m) = ppSexp "Ptr" [ppSlotNo slot, pretty (txIxToInt n), pretty m]
 
 ppStakeReference :: StakeReference c -> PDoc
 ppStakeReference (StakeRefBase x) = ppSexp "BaseRef" [ppCredential x]

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.BaseTypes
     Url (..),
     activeSlotLog,
     activeSlotVal,
+    certIxToInt,
     dnsToText,
     txIxToInt,
   )
@@ -86,7 +87,6 @@ import Cardano.Ledger.Shelley.LedgerState
     FutureGenDeleg (..),
     IncrementalStake (..),
     InstantaneousRewards (..),
-    Ix,
     LedgerState (..),
     NewEpochState (..),
     PPUPState (..),
@@ -651,9 +651,6 @@ ppInstantaneousRewards (InstantaneousRewards res treas dR dT) =
       ("deltaReserves", ppDeltaCoin dR),
       ("deltaTreasury", ppDeltaCoin dT)
     ]
-
-ppIx :: Ix -> PDoc
-ppIx = viaShow
 
 ppPPUPState :: PrettyA (PParamsDelta era) => PPUPState era -> PDoc
 ppPPUPState (PPUPState p fp) =
@@ -1346,7 +1343,8 @@ ppCredential (ScriptHashObj (ScriptHash x)) = ppSexp "ScriptCred" [ppHash x]
 ppCredential (KeyHashObj (KeyHash x)) = ppSexp "KeyCred" [ppHash x]
 
 ppPtr :: Ptr -> PDoc
-ppPtr (Ptr slot n m) = ppSexp "Ptr" [ppSlotNo slot, pretty (txIxToInt n), pretty m]
+ppPtr (Ptr slot txIx certIx) =
+  ppSexp "Ptr" [ppSlotNo slot, pretty (txIxToInt txIx), pretty (certIxToInt certIx)]
 
 ppStakeReference :: StakeReference c -> PDoc
 ppStakeReference (StakeRefBase x) = ppSexp "BaseRef" [ppCredential x]

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -80,7 +80,7 @@ applyTxMempoolEnv :: Default (Core.PParams era) => MempoolEnv era
 applyTxMempoolEnv =
   LedgerEnv
     { ledgerSlotNo = SlotNo 0,
-      ledgerIx = 0,
+      ledgerIx = minBound,
       ledgerPp = def,
       ledgerAccount = AccountState (Coin 45000000000) (Coin 45000000000)
     }

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
@@ -52,7 +52,7 @@ payCred = KeyHashObj (hashKey . VKey $ VerKeyMockDSIGN 0)
 
 -- | Infinite list of transaction inputs
 txIns :: [TxIn TestCrypto]
-txIns = [0 ..] <&> TxIn txId
+txIns = [minBound ..] <&> TxIn txId
   where
     txId =
       TxId . castSafeHash $
@@ -99,7 +99,7 @@ stakeCreds n =
 stakePtrs :: [StakeCredential c] -> Map Ptr (StakeCredential c)
 stakePtrs creds =
   Map.fromList
-    [ (Ptr (SlotNo i) 0 0, cred)
+    [ (Ptr (SlotNo i) minBound minBound, cred)
       | (i, cred) <- zip [0 ..] creds
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
@@ -68,6 +68,7 @@ import Cardano.Ledger.BaseTypes
     Network (Testnet),
     StrictMaybe (..),
     epochInfo,
+    mkTxIxPartial,
   )
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
 import qualified Cardano.Ledger.Core as Core
@@ -1366,7 +1367,8 @@ class
 
       let txid = TxIn.txid @era realTxBody
       ifor_ mtxOutputs $ \n (mutxoid, _) ->
-        _2 . eesUTxOs . at mutxoid . _Just . tuoi_txid .= Just (Shelley.TxIn txid (fromIntegral n))
+        _2 . eesUTxOs . at mutxoid . _Just . tuoi_txid
+          .= Just (Shelley.TxIn txid (mkTxIxPartial (toInteger n)))
       pure $ makeTx proxy realTxBody txWitnessArguments
 
   -- | build a full tx from TxBody and set of witnesses.

--- a/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
@@ -12,6 +12,7 @@ import Cardano.Binary
 import Cardano.Crypto.Hash.Class
 import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.TxBody
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Keys
@@ -64,6 +65,10 @@ instance PersistFieldSql (TxId C) where
 deriving instance PersistField (CompactForm Coin)
 
 deriving instance PersistFieldSql (CompactForm Coin)
+
+deriving instance PersistField TxIx
+
+deriving instance PersistFieldSql TxIx
 
 instance PersistField Coin where
   toPersistValue = PersistInt64 . fromIntegral . unCoin

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -73,11 +73,11 @@ insertUTxO utxo stateKey = do
   where
     insertTxOut (TxIn.TxIn txId txIx, out) = do
       txKey <-
-        insert $ Tx {txInIx = fromIntegral txIx, txInId = txId, txOut = out}
+        insert $ Tx {txInIx = txIx, txInId = txId, txOut = out}
       txsKey <-
         insert $
           Txs
-            { txsInIx = fromIntegral txIx,
+            { txsInIx = txIx,
               txsInId = txId,
               txsOut = out,
               txsStakeCredential = Nothing
@@ -450,7 +450,7 @@ sourceUTxO ::
   ConduitM () (TxIn.TxIn C, Alonzo.TxOut CurrentEra) (ReaderT SqlBackend m) ()
 sourceUTxO =
   selectSource [] []
-    .| mapC (\(Entity _ Tx {..}) -> (TxIn.TxIn txInId (fromIntegral txInIx), txOut))
+    .| mapC (\(Entity _ Tx {..}) -> (TxIn.TxIn txInId txInIx, txOut))
 
 sourceWithSharingUTxO ::
   MonadResource m =>

--- a/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.State.Schema where
 
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Credential as Credential
 import qualified Cardano.Ledger.Keys as Keys
@@ -24,7 +25,6 @@ import Cardano.Ledger.State.Orphans (Enc, SnapShotType (..))
 import Cardano.Ledger.State.UTxO
 import qualified Cardano.Ledger.TxIn as TxIn
 import qualified Data.Map.Strict as Map
-import Data.Word
 import Database.Persist.Sqlite
 import Database.Persist.TH
 
@@ -90,12 +90,12 @@ KeyHash
   witness KeyHashWitness
   UniqueKeyHash witness
 Tx
-  inIx Word64
+  inIx TxIx
   inId (TxIn.TxId C)
   out (Alonzo.TxOut CurrentEra)
   UniqueTx inIx inId
 Txs
-  inIx Word64
+  inIx TxIx
   inId (TxIn.TxId C)
   out (Alonzo.TxOut CurrentEra)
   stakeCredential CredentialId Maybe


### PR DESCRIPTION
Majority of the changes in this PR are to test suites, but the juice of it is in the `Cardano.Ledger.Credentials` module:

* Introduction of `TxIx` for type safety and memory optimization
* Introduction of `CertIx` for type safety and memory optimization
* Collapsing `Ptr` into a `Word64`, since we can assume that `SlotNo` isn't going to reach `2^32 - 1` value any time soon and other members of `Ptr` were switched to `Word16` in the steps above. 

Left notes for future generations about the limits, hopefully they won't miss them.