### PR TITLE
WIP  generalize Rules for Utxow, Utxo, Utxos, then use to make rules for Babbage

### DIFF
--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -34,11 +34,16 @@ common project-config
 library
   import:             base, project-config
   exposed-modules:
+    Cardano.Ledger.Babbage.Collateral
     Cardano.Ledger.Babbage.Genesis
     Cardano.Ledger.Babbage.PParams
+    Cardano.Ledger.Babbage.Scripts
     Cardano.Ledger.Babbage.Tx
     Cardano.Ledger.Babbage.TxBody
     Cardano.Ledger.Babbage.Translation
+    Cardano.Ledger.Babbage.Rules.Utxo
+    Cardano.Ledger.Babbage.Rules.Utxos
+    Cardano.Ledger.Babbage.Rules.Utxow
     Cardano.Ledger.Babbage
   build-depends:
     array,
@@ -54,6 +59,7 @@ library
     cardano-ledger-shelley-ma,
     cardano-prelude,
     cardano-slotting,
+    compact-map,
     containers,
     data-default,
     deepseq,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Figure 2: Functions related to fees and collateral
+--   Babbage Specification
+module Cardano.Ledger.Babbage.Collateral where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
+import Cardano.Ledger.Babbage.Scripts (txscripts)
+import Cardano.Ledger.Babbage.TxBody
+  ( TxBody (..),
+    TxOut (..),
+    collateralInputs',
+    collateralReturn',
+    outputs',
+    txfee',
+  )
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (Crypto), ValidateScript (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, getScriptHash)
+import Cardano.Ledger.TxIn (TxIn (..), txid)
+import Cardano.Ledger.Val ((<->))
+import Data.Compact.SplitMap ((◁))
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Maybe.Strict (StrictMaybe (..))
+import GHC.Records (HasField (..))
+import Numeric.Natural (Natural)
+
+-- ============================================================
+
+isTwoPhaseScriptAddress ::
+  forall era.
+  ( ValidateScript era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.TxBody era ~ TxBody era,
+    Ord (Core.Script era)
+  ) =>
+  Core.Tx era ->
+  UTxO era ->
+  Addr (Crypto era) ->
+  Bool
+isTwoPhaseScriptAddress tx utxo addr =
+  case getScriptHash addr of
+    Nothing -> False
+    Just hash -> any ok (txscripts tx utxo)
+      where
+        ok script = hashScript @era script == hash && not (isNativeScript @era script)
+
+minCollateral ::
+  HasField "_collateralPercentage" (Core.PParams era) Natural =>
+  TxBody era ->
+  Core.PParams era ->
+  Coin
+minCollateral txb pp = Coin ((fee * percent) `divideCeiling` 100)
+  where
+    fee = unCoin (txfee' txb)
+    percent = fromIntegral (getField @"_collateralPercentage" pp)
+    divideCeiling x y = if _rem == 0 then n else n + 1 -- Works when both x and y are positive
+      where
+        (n, _rem) = x `divMod` y
+
+collBalance :: forall era. Era era => TxBody era -> UTxO era -> Core.Value era
+collBalance txb (UTxO m) =
+  case collateralReturn' txb of
+    SNothing -> colbal
+    SJust (TxOut _ retval _) -> colbal <-> retval
+  where
+    collateral = UTxO (collateralInputs' @era txb ◁ m)
+    colbal = balance @era collateral
+
+collOuts ::
+  ( Era era,
+    Core.TxBody era ~ TxBody era,
+    Core.TxOut era ~ TxOut era
+  ) =>
+  TxBody era ->
+  UTxO era
+collOuts txb =
+  case collateralReturn' txb of
+    SNothing -> UTxO SplitMap.empty
+    SJust txout -> UTxO (SplitMap.singleton (TxIn (txid txb) index) txout)
+      where
+        index = fromIntegral (length (outputs' txb))
+
+feesOK :: Core.PParams era -> Core.Tx era -> UTxO era -> Bool
+feesOK _pparams _tx _utxo = undefined

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -46,7 +46,6 @@ import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.BaseTypes
   ( NonNegativeInterval,
     Nonce,
-    StrictMaybe (..),
     UnitInterval,
     fromSMaybe,
     isSNothing,
@@ -80,6 +79,7 @@ import Data.Coders
 import Data.Default (Default (..))
 import Data.Functor.Identity (Identity (..))
 import Data.Map.Strict (Map)
+import Data.Maybe.Strict (StrictMaybe (..))
 import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
 import NoThunks.Class (NoThunks (..))

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Babbage.Rules.Utxo where
+
+-- ==========================================================================
+-- Utxo Depends on Utxos, which means we need to import types and operations
+-- from the Utxo and Utxos files from Babbage and earlier Eras that can be reused
+
+import Cardano.Ledger.Alonzo.Rules.Utxo
+  ( AlonzoUtxoNeeds,
+    FeeNeeds,
+    UtxoDelta (UtxoDelta),
+    UtxoEvent (..),
+    UtxoPredicateFailure (..),
+    genericAlonzoUtxo,
+    vKeyLocked,
+  )
+import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
+import Cardano.Ledger.Alonzo.Tx (minfee)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..), nullRedeemers)
+import Cardano.Ledger.Babbage.Collateral (collBalance, minCollateral)
+import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
+import Cardano.Ledger.Babbage.Tx (ValidatedTx (..), wits)
+import Cardano.Ledger.Babbage.TxBody
+  ( TxBody (..),
+    TxOut,
+    collateralInputs',
+    collateralReturn',
+    totalCollateral',
+    txfee',
+  )
+import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
+import Cardano.Ledger.Mary.Value (Value)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
+import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley (UtxoEnv (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.Val (Val (coin), adaOnly)
+import Control.Monad (unless)
+import Control.State.Transition.Extended
+  ( Embed (..),
+    Rule,
+    RuleType (Transition),
+    STS (..),
+    (?!),
+  )
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Set as Set
+import GHC.Records (HasField (..))
+
+-- ========================================================
+
+-- | Predicate failure for the Babbage Era
+data BabbageUtxoPred era
+  = FromAlonzoUtxoFail (UtxoPredicateFailure era)
+  | FromAlonzoUtxowFail (AlonzoPredFail era)
+  | UnequalCollateralReturn Coin Coin
+
+deriving instance
+  ( Era era,
+    Show (UtxoPredicateFailure era),
+    Show (PredicateFailure (Core.EraRule "UTXO" era)),
+    Show (Core.Script era)
+  ) =>
+  Show (BabbageUtxoPred era)
+
+deriving instance
+  ( Era era,
+    Eq (UtxoPredicateFailure era),
+    Eq (PredicateFailure (Core.EraRule "UTXO" era)),
+    Eq (Core.Script era)
+  ) =>
+  Eq (BabbageUtxoPred era)
+
+-- TODO FIXME  add CBOR instances
+
+-- ================================================================================
+
+-- | feesOK can differ from Era to Era, as new notions of fees arise. This is the Babbage version
+--   See: Figure 2: Functions related to fees and collateral, in the Babbage specification
+--   In the spec feesOK is a boolean function. Because wee need to handle predicate failures
+--   in the implementaion, it is coded as a TransitionRule. It will return () if it succeeds,
+--   and raise an error (rather than return) if any of the required parts are False.
+--   This version is generic in that it can be lifted to any PredicateFailure type that
+--   embeds BabbageUtxoPred era. This makes it possibly useful in future Eras.
+feesOK ::
+  forall era utxo.
+  ( Era era,
+    ValidateScript era, -- isTwoPhaseScriptAddress
+    Core.Tx era ~ ValidatedTx era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.TxBody era ~ TxBody era,
+    FeeNeeds era
+  ) =>
+  (BabbageUtxoPred era -> PredicateFailure (utxo era)) ->
+  Core.PParams era ->
+  Core.Tx era ->
+  UTxO era ->
+  Rule (utxo era) 'Transition ()
+feesOK lift pp tx (UTxO utxo) = do
+  let txb = getField @"body" tx
+      theFee = txfee' txb -- Coin supplied to pay fees
+      minimumFee = minfee @era pp tx
+      lift2 = lift . FromAlonzoUtxoFail
+  -- Part 1  (minfee pp tx ≤ txfee tx )
+  (minimumFee <= theFee) ?! lift2 (FeeTooSmallUTxO minimumFee theFee)
+
+  -- Part 2 (txrdmrs tx /= ◇ ⇒ ... )
+  unless (nullRedeemers . txrdmrs' . wits $ tx) $ do
+    -- Part 3 ((∀(a, , ) ∈ range (collInputs txb ◁ utxo), paymentHK a ∈ Addr^{vkey})
+    let collateral = collateralInputs' txb SplitMap.◁ utxo
+    -- UTxO restricted to the inputs allocated to pay the Fee
+    all vKeyLocked collateral
+      ?! lift2 (ScriptsNotPaidUTxO (UTxO (SplitMap.filter (not . vKeyLocked) collateral)))
+
+    -- Part 4 (balance ≥ minCollateral tx pp)
+    let valbalance = collBalance txb (UTxO utxo)
+        balance = coin valbalance
+    balance >= minCollateral txb pp ?! lift2 (InsufficientCollateral balance (minCollateral txb pp))
+
+    -- Part 5 (adaOnly balance)
+    adaOnly valbalance ?! lift2 (CollateralContainsNonADA valbalance)
+
+    -- Part 6 ((txcoll tx 6 = 3) ⇒ balance = txcoll tx)
+    case collateralReturn' txb of
+      SNothing -> pure ()
+      SJust _txout -> balance == total ?! lift (UnequalCollateralReturn balance total)
+        where
+          total = totalCollateral' txb
+
+    -- Part 7 (collInputs tx 6 = ∅)
+    not (Set.null (collateralInputs' txb)) ?! lift2 NoCollateralInputs
+
+    pure ()
+
+-- =============================================================
+-- The STS BabbageUTXO instance
+
+-- | The uninhabited type that marks the Babbage UTxO rule
+data BabbageUTXO era
+
+instance
+  forall era.
+  ( Era era,
+    ValidateScript era,
+    -- Concrete types assumptions for the Babbage Era
+    Core.Tx era ~ ValidatedTx era,
+    Core.TxBody era ~ TxBody era,
+    Core.TxOut era ~ TxOut era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.Value era ~ Value (Crypto era),
+    Core.EraRule "UTXO" era ~ BabbageUTXO era,
+    -- We can call the UTXOS rule
+    Embed (Core.EraRule "UTXOS" era) (BabbageUTXO era),
+    Signal (Core.EraRule "UTXOS" era) ~ ValidatedTx era,
+    Environment (Core.EraRule "UTXOS" era) ~ Shelley.UtxoEnv era,
+    State (Core.EraRule "UTXOS" era) ~ Shelley.UTxOState era,
+    -- Properties needed to Show and compare the predicate failures
+    Show (Core.Value era),
+    Show (Core.PParamsDelta era),
+    Show (Core.Script era),
+    Eq (Core.Value era),
+    Eq (Core.Script era),
+    -- Substructural properties
+    FeeNeeds era,
+    AlonzoUtxoNeeds era
+  ) =>
+  STS (BabbageUTXO era)
+  where
+  type State (BabbageUTXO era) = Shelley.UTxOState era
+  type Signal (BabbageUTXO era) = ValidatedTx era
+  type Environment (BabbageUTXO era) = Shelley.UtxoEnv era
+  type BaseM (BabbageUTXO era) = ShelleyBase
+  type PredicateFailure (BabbageUTXO era) = BabbageUtxoPred era
+  type Event (BabbageUTXO era) = UtxoEvent era
+
+  initialRules = []
+  transitionRules = [genericAlonzoUtxo babbageUtxoDelta]
+
+instance
+  ( Era era,
+    STS (BabbageUTXOS era),
+    PredicateFailure (Core.EraRule "UTXOS" era) ~ UtxosPredicateFailure era,
+    Event (Core.EraRule "UTXOS" era) ~ Event (BabbageUTXOS era),
+    BaseM (BabbageUTXOS era) ~ ShelleyBase,
+    PredicateFailure (Core.EraRule "UTXOS" era) ~ PredicateFailure (BabbageUTXOS era),
+    PredicateFailure (Core.EraRule "UTXOS" era) ~ PredicateFailure (BabbageUTXOS era)
+  ) =>
+  Embed (BabbageUTXOS era) (BabbageUTXO era)
+  where
+  wrapFailed = FromAlonzoUtxoFail . UtxosFailure
+  wrapEvent = UtxosEvent
+
+-- ====================================================
+-- Specializing Utxo to Babbage Era
+
+babbageUtxoDelta ::
+  ( Core.Witnesses era ~ TxWitness era,
+    Core.Tx era ~ ValidatedTx era,
+    Core.TxBody era ~ TxBody era,
+    ValidateScript era,
+    FeeNeeds era
+  ) =>
+  UtxoDelta BabbageUTXO era
+babbageUtxoDelta = UtxoDelta (feesOK id) (const (Set.empty)) FromAlonzoUtxoFail

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Babbage.Rules.Utxos
+  ( BabbageUTXOS,
+    UTXOS,
+  )
+where
+
+import Cardano.Ledger.Alonzo.Language (Language)
+import Cardano.Ledger.Alonzo.Rules.Utxos
+  ( UTXOS,
+    UtxosDelta (UtxosDelta),
+    UtxosEvent (..),
+    UtxosPredicateFailure (..),
+    genericUtxosTransition,
+  )
+import Cardano.Ledger.Alonzo.Scripts (Script)
+import Cardano.Ledger.Alonzo.Tx (CostModel, DataHash)
+import Cardano.Ledger.Babbage.Collateral (collBalance)
+import Cardano.Ledger.Babbage.PParams (PParams, PParamsUpdate)
+import Cardano.Ledger.Babbage.Tx (ValidatedTx (..))
+import Cardano.Ledger.Babbage.TxBody (TxBody, TxOut)
+import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase)
+import Cardano.Ledger.Coin (Coin)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (..), ValidateScript (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (Witness))
+import Cardano.Ledger.Mary.Value (Value)
+import Cardano.Ledger.Shelley.LedgerState (PPUPState (..), UTxOState (..))
+import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.Rules.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
+import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval)
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.Val as Val
+import Control.State.Transition.Extended (Embed (..), STS (..))
+import qualified Data.Compact.SplitMap as SplitMap
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import GHC.Records (HasField (getField))
+
+-- ====================================================
+-- Specialize Utxos to Babbage
+
+babbageUtxosDelta ::
+  ( Era era,
+    Core.TxBody era ~ TxBody era
+  ) =>
+  UtxosDelta BabbageUTXOS era
+babbageUtxosDelta = UtxosDelta collBalFee id
+  where
+    collBalFee txb utxo = (UTxO utxoKeep, UTxO utxoDel, coin_)
+      where
+        !(!utxoKeep, !utxoDel) =
+          SplitMap.extractKeysSet
+            (unUTxO utxo)
+            (getField @"collateral" txb)
+        !coin_ = Val.coin (collBalance txb (UTxO utxoDel))
+
+-- =======================================
+
+-- | The uninhabited type that marks the Babbage UTXOS rule
+data BabbageUTXOS era
+
+instance
+  ( ValidateScript era,
+    -- Babbage specific types
+    Core.TxBody era ~ TxBody era,
+    Core.TxOut era ~ TxOut era,
+    Core.Value era ~ Value (Crypto era),
+    Core.PParams era ~ PParams era,
+    Core.Script era ~ Script era,
+    Core.PParamsDelta era ~ PParamsUpdate era,
+    -- we need to call PPUP
+    Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
+    State (Core.EraRule "PPUP" era) ~ PPUPState era,
+    Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
+    Core.EraRule "PPUP" era ~ PPUP era,
+    HasField "_protocolVersion" (Core.PParamsDelta era) (StrictMaybe ProtVer),
+    -- Substructural properties
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
+    HasField "mint" (Core.TxBody era) (Value (Crypto era)),
+    HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "vldt" (Core.TxBody era) ValidityInterval,
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
+  ) =>
+  STS (BabbageUTXOS era)
+  where
+  type BaseM (BabbageUTXOS era) = ShelleyBase
+  type Environment (BabbageUTXOS era) = UtxoEnv era
+  type State (BabbageUTXOS era) = UTxOState era
+  type Signal (BabbageUTXOS era) = ValidatedTx era
+  type PredicateFailure (BabbageUTXOS era) = UtxosPredicateFailure era
+  type Event (BabbageUTXOS era) = UtxosEvent era
+  initialRules = []
+  transitionRules = [genericUtxosTransition babbageUtxosDelta]
+
+instance
+  ( Era era,
+    STS (PPUP era),
+    PredicateFailure (Core.EraRule "PPUP" era) ~ PpupPredicateFailure era,
+    Event (Core.EraRule "PPUP" era) ~ Event (PPUP era)
+  ) =>
+  Embed (PPUP era) (BabbageUTXOS era)
+  where
+  wrapFailed = UpdateFailure
+  wrapEvent = UpdateEvent

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Cardano.Ledger.Babbage.Rules.Utxow where
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.Rules.Utxo (FeeNeeds)
+import Cardano.Ledger.Alonzo.Rules.Utxow
+  ( AlonzoEvent (..),
+    AlonzoPredFail (..),
+    AlonzoUtxowNeeds,
+    UtxowDeltaA (UtxowDeltaA),
+    genericAlonzoUtxow,
+    witsVKeyNeeded,
+  )
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo (Script)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness, nullRedeemers, unTxDats)
+import Cardano.Ledger.Babbage.Collateral (collBalance, isTwoPhaseScriptAddress, minCollateral)
+import Cardano.Ledger.Babbage.PParams
+  ( PParams,
+    PParamsUpdate,
+    _coinsPerUTxOWord,
+    _maxCollateralInputs,
+    _maxTxExUnits,
+    _maxTxSize,
+    _maxValSize,
+    _minfeeA,
+    _minfeeB,
+    _prices,
+  )
+import Cardano.Ledger.Babbage.Rules.Utxo
+  ( BabbageUTXO,
+    BabbageUtxoPred (FromAlonzoUtxoFail, FromAlonzoUtxowFail),
+  )
+import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
+import Cardano.Ledger.Babbage.Scripts (languages, txscripts)
+import Cardano.Ledger.Babbage.Tx (DataHash, ValidatedTx (..), wits)
+import Cardano.Ledger.Babbage.TxBody
+  ( TxBody (..),
+    TxOut,
+    collateralInputs',
+    collateralReturn',
+    mint',
+    referenceInputs',
+    spendingInputs',
+    totalCollateral',
+    txfee',
+    txnetworkid',
+    vldt',
+  )
+import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Coin (Coin)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
+import Cardano.Ledger.Keys (DSignable, GenDelegPair (..), GenDelegs (..), Hash, KeyHash, KeyRole (..), asWitness, coerceKeyRole)
+import Cardano.Ledger.Mary.Value (Value)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..), UtxoPredicateFailure (..))
+import Cardano.Ledger.Shelley.Rules.Utxow
+  ( PredicateFailure,
+    ShelleyUtxowNeeds,
+    UtxowDeltaS (UtxowDeltaS),
+    UtxowEvent (UtxoEvent),
+    UtxowPredicateFailure (..),
+    genericShelleyUtxow,
+    shelleyUtxowDelta,
+  )
+import Cardano.Ledger.Shelley.TxBody (EraIndependentTxBody, unWdrl)
+import Control.State.Transition.Extended
+  ( Embed (..),
+    Rule,
+    RuleType (Transition),
+    STS (..),
+    TRC (..),
+    TransitionRule,
+    failBecause,
+    judgmentContext,
+    liftSTS,
+    trans,
+    (?!),
+    (?!:),
+  )
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Set as Set
+import GHC.Records (HasField (..))
+
+-- ==========================================================
+
+-- | The uninhabited type that marks the Babbage UTxO rule
+data BabbageUTXOW era
+
+instance
+  forall era.
+  ( Era era,
+    Core.TxBody era ~ TxBody era,
+    Core.Tx era ~ ValidatedTx era,
+    Core.PParams era ~ PParams era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.Script era ~ Alonzo.Script era,
+    Core.TxOut era ~ TxOut era,
+    Core.Value era ~ Value (Crypto era),
+    Core.PParamsDelta era ~ PParamsUpdate era,
+    --
+    Signal (Core.EraRule "UTXO" era) ~ ValidatedTx era,
+    Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXO" era) ~ UTxOState era,
+    Embed (Core.EraRule "UTXO" era) (BabbageUTXOW era),
+    --
+    Show (PredicateFailure (Core.EraRule "UTXO" era)),
+    Eq (PredicateFailure (Core.EraRule "UTXO" era)),
+    Show (PredicateFailure (Core.EraRule "UTXOS" era)),
+    Eq (PredicateFailure (Core.EraRule "UTXOS" era)),
+    --
+    AlonzoUtxowNeeds era,
+    ShelleyUtxowNeeds era
+  ) =>
+  STS (BabbageUTXOW era)
+  where
+  type State (BabbageUTXOW era) = UTxOState era
+  type Signal (BabbageUTXOW era) = ValidatedTx era
+  type Environment (BabbageUTXOW era) = UtxoEnv era
+  type BaseM (BabbageUTXOW era) = ShelleyBase
+  type PredicateFailure (BabbageUTXOW era) = BabbageUtxoPred era
+  type Event (BabbageUTXOW era) = AlonzoEvent era
+  transitionRules = [genericAlonzoUtxow babbageUtxowDeltaA]
+  initialRules = []
+
+instance
+  ( ValidateScript era,
+    Core.Tx era ~ ValidatedTx era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.TxBody era ~ TxBody era,
+    Core.TxOut era ~ TxOut era,
+    Core.PParams era ~ PParams era,
+    Core.Value era ~ Value (Crypto era),
+    --
+    Signal (Core.EraRule "UTXOS" era) ~ ValidatedTx era,
+    Environment (Core.EraRule "UTXOS" era) ~ UtxoEnv era,
+    State (Core.EraRule "UTXOS" era) ~ UTxOState era,
+    Embed (Core.EraRule "UTXOS" era) (BabbageUTXO era),
+    Core.EraRule "UTXO" era ~ BabbageUTXO era,
+    --
+    Show (Core.PParamsDelta era),
+    Show (Core.Script era),
+    Eq (Core.Script era),
+    --
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    FeeNeeds era,
+    AlonzoUtxowNeeds era
+  ) =>
+  Embed (BabbageUTXO era) (BabbageUTXOW era)
+  where
+  wrapFailed = id
+  wrapEvent = WrappedShelleyEraEvent . UtxoEvent
+
+-- =======================================================
+-- Specializing utxow to the babbage era
+
+babbageUtxowDeltaS ::
+  forall era.
+  ( Era era,
+    Core.TxBody era ~ TxBody era,
+    Core.Witnesses era ~ TxWitness era,
+    Ord (Core.Script era)
+  ) =>
+  UtxowDeltaS BabbageUTXOW era
+babbageUtxowDeltaS =
+  UtxowDeltaS
+    witsVKeyNeeded -- This is the Babbage version
+    (FromAlonzoUtxowFail . WrappedShelleyEraFailure)
+    txscripts -- This is the Babbage version
+    (referenceInputs' @era . getField @"body")
+
+babbageUtxowDeltaA ::
+  ( ValidateScript era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.TxBody era ~ TxBody era,
+    Core.Script era ~ Alonzo.Script era,
+    Ord (Core.Script era)
+  ) =>
+  UtxowDeltaA BabbageUTXOW era
+babbageUtxowDeltaA = UtxowDeltaA languages isTwoPhaseScriptAddress babbageUtxowDeltaS FromAlonzoUtxowFail

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -55,7 +55,7 @@ getDatum tx (UTxO m) sp = case hasTxIn sp of
   Just txin ->
     case SplitMap.lookup txin m of
       Nothing -> []
-      Just (TxOut _ _ datum) ->
+      Just (TxOut _ _ datum _) ->
         case datum of
           NoDatum -> []
           Datum d -> [d]

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Figure 3: Functions related to scripts
+--   Babbage Specification
+module Cardano.Ledger.Babbage.Scripts where
+
+import Cardano.Ledger.Alonzo.Data (BinaryData, dataToBinaryData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PlutusScriptApi (language)
+import Cardano.Ledger.Alonzo.Scripts (Script)
+import Cardano.Ledger.Alonzo.Tx (ScriptPurpose (..), txdats')
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness, txscripts', unTxDats)
+import Cardano.Ledger.Babbage.TxBody
+  ( Datum (..),
+    TxBody (..),
+    TxOut (..),
+    referenceInputs',
+    spendingInputs',
+  )
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Crypto, Era, ValidateScript (isNativeScript))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.TxIn (TxIn)
+import qualified Data.Compact.SplitMap as SplitMap
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Records (HasField (..))
+
+-- ====================================================================
+
+hasTxIn :: ScriptPurpose crypto -> Maybe (TxIn crypto)
+hasTxIn (Spending txin) = Just txin
+-- Only the Spending ScriptPurpose contains TxIn
+hasTxIn (Minting _policyid) = Nothing
+hasTxIn (Rewarding _rewaccnt) = Nothing
+hasTxIn (Certifying _dcert) = Nothing
+
+getDatum ::
+  ( Era era,
+    Core.TxOut era ~ TxOut era,
+    Core.Witnesses era ~ TxWitness era
+  ) =>
+  Core.Tx era ->
+  UTxO era ->
+  ScriptPurpose (Crypto era) ->
+  [BinaryData era]
+getDatum tx (UTxO m) sp = case hasTxIn sp of
+  Nothing -> []
+  Just txin ->
+    case SplitMap.lookup txin m of
+      Nothing -> []
+      Just (TxOut _ _ datum) ->
+        case datum of
+          NoDatum -> []
+          Datum d -> [d]
+          DatumHash hash ->
+            case Map.lookup hash (unTxDats $ txdats' (getField @"wits" tx)) of
+              Nothing -> []
+              Just dat -> [dataToBinaryData dat]
+
+extractScript :: Core.TxOut era -> Maybe (Core.Script era)
+extractScript _txout = undefined
+
+txscripts ::
+  ( Era era,
+    Core.TxBody era ~ TxBody era,
+    Core.Witnesses era ~ TxWitness era,
+    Ord (Core.Script era)
+  ) =>
+  Core.Tx era ->
+  UTxO era ->
+  Set (Core.Script era)
+txscripts tx (UTxO m) = witnessScripts `Set.union` referenceScripts
+  where
+    txbody = getField @"body" tx
+    allInputs = Set.union (spendingInputs' txbody) (referenceInputs' txbody)
+    witnessset = getField @"wits" tx
+    witnessScripts = Set.fromList (Map.elems (txscripts' witnessset))
+    referenceScripts = Set.foldl' accum Set.empty allInputs
+    getScript txin = do txout <- SplitMap.lookup txin m; extractScript txout
+    accum ans txin = maybe ans (`Set.insert` ans) (getScript txin)
+
+languages ::
+  forall era.
+  ( ValidateScript era,
+    Core.TxBody era ~ TxBody era,
+    Core.Witnesses era ~ TxWitness era,
+    Core.Script era ~ Script era -- THE ATERNATIVE TO THIS IS TO ADD 'language' to the ValidateScript class
+  ) =>
+  Core.Tx era ->
+  UTxO era ->
+  Set Language
+languages tx utxo =
+  Set.fromList
+    [ lang
+      | script <- Set.toList (txscripts tx utxo),
+        (not . isNativeScript @era) script,
+        Just lang <- [language @era script]
+    ]

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -45,7 +45,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Era (..), getTxOutBootstrapAddress)
+import Cardano.Ledger.Era (Crypto, Era (getTxOutAddr), getTxOutBootstrapAddress)
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
   ( decodeList,
@@ -418,6 +418,8 @@ utxoInductive = do
           (SplitMap.elems outputs)
   null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
 
+  -- Bootstrap (i.e. Byron) addresses have variable sized attributes in them.
+  -- It is important to limit their overall size.
   let outputsAttrsTooBig = filterOutputsAttrsTooBig outputs
   null outputsAttrsTooBig ?! OutputBootAddrAttrsTooBig outputsAttrsTooBig
 


### PR DESCRIPTION
We generalize rules for the Uxto* rules, We added
genericAlonzoUtxo, genericAlonzoUtxow, and genericShelleyUtxow, used them to make instances Utxow and Utxo instances for Shelley, Shelley-ma, and Alonzo. 

The goal is to use them to make Babbage instances.