### PR TITLE
Refactor UTxO rules for better re-use in future Eras

### DIFF
--- a/eras/alonzo/formal-spec/utxo.tex
+++ b/eras/alonzo/formal-spec/utxo.tex
@@ -18,9 +18,9 @@
     & \fun{feesOK} : \PParams \to \Tx \to \UTxO \to \Bool  \\
     & \fun{feesOK}~\var{pp}~tx~utxo~= \\
     &~~      \minfee{pp}~{tx} \leq \txfee{txb} \wedge (\fun{txrdmrs}~tx \neq \emptyset \Rightarrow \\
-    &~~~~~~((\forall (a, \wcard, \_) \in \fun{range}~(\fun{collateral}~{txb} \restrictdom \var{utxo}), a \in \AddrVKey) \\
+    &~~~~~~((\forall (a, \wcard, \wcard) \in \fun{range}~(\fun{collateral}~{txb} \restrictdom \var{utxo}), a \in \AddrVKey) \\
     &~~~~~~\wedge~ \fun{adaOnly}~\var{balance} \\
-    &~~~~~~\wedge~ \var{balance}*100 \geq \txfee{txb} * (\fun{collateralPercent}~pp))) \\
+    &~~~~~~\wedge~ \var{balance}*100 \geq \txfee{txb} * (\fun{collateralPercent}~pp) \\
     &~~~~~~\wedge~ \fun{collateral}~{tx} \neq \emptyset) \\
     &~~      \where \\
     & ~~~~~~~ \var{txb} = \txbody{tx} \\

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -90,5 +90,6 @@ library
     time,
     transformers,
     utf8-string,
+    validation-selective,
   hs-source-dirs:
     src

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -38,13 +38,14 @@ import Cardano.Ledger.Alonzo.TxWitness
 import Cardano.Ledger.BaseTypes
   ( ShelleyBase,
     StrictMaybe (..),
+    quorum,
     strictMaybeToMaybe,
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (KeyHashObj))
 import Cardano.Ledger.Era (Era (..), ValidateScript (..))
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..), asWitness)
-import Cardano.Ledger.Rules.ValidationMode ((?!#))
+import Cardano.Ledger.Rules.ValidationMode (runValidationStaticWith, runValidationWith, (?!#))
 import Cardano.Ledger.Shelley.Delegation.Certificates
   ( delegCWitness,
     genesisCWitness,
@@ -54,6 +55,8 @@ import Cardano.Ledger.Shelley.Delegation.Certificates
 import Cardano.Ledger.Shelley.LedgerState
   ( UTxOState (..),
     WitHashes (..),
+    diffWitHashes,
+    nullWitHashes,
     propWits,
     unWitHashes,
     witsFromTxWitnesses,
@@ -64,8 +67,8 @@ import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyStyleWitnessNeeds,
     UtxowEvent (UtxoEvent),
     UtxowPredicateFailure (..),
-    shelleyStyleWitness,
   )
+import qualified Cardano.Ledger.Shelley.Rules.Utxow as Shelley
 import Cardano.Ledger.Shelley.Scripts (ScriptHash (..))
 import Cardano.Ledger.Shelley.Tx (TxIn (..), extractKeyHashWitnessSet)
 import Cardano.Ledger.Shelley.TxBody
@@ -76,11 +79,13 @@ import Cardano.Ledger.Shelley.TxBody
     unWdrl,
   )
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), txinLookup)
+import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (domain, eval, (⊆), (➖))
 import Control.State.Transition.Extended
 import Data.Coders
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Foldable (toList)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -89,6 +94,7 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import GHC.Records
 import NoThunks.Class
+import Validation
 
 -- =================================================
 
@@ -253,15 +259,15 @@ alonzoStyleWitness ::
   ) =>
   TransitionRule (utxow era)
 alonzoStyleWitness = do
-  (TRC (UtxoEnv _slot pp _stakepools _genDelegs, u', tx)) <- judgmentContext
+  (TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
   {-  txw := txwits tx  -}
   {-  witsKeyHashes := { hashKey vk | vk ∈ dom(txwitsVKey txw) }  -}
-  let utxo = _utxo u'
+  let utxo = _utxo u
       txbody = getField @"body" (tx :: Core.Tx era)
-      witsKeyHashes = unWitHashes $ witsFromTxWitnesses @era tx
+      witsKeyHashes = witsFromTxWitnesses @era tx
 
   {-  { h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isNonNativeScriptAddress tx a} = dom(txdats txw)   -}
   let inputs = getField @"inputs" txbody :: (Set (TxIn (Crypto era)))
@@ -322,8 +328,8 @@ alonzoStyleWitness = do
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but
       witsVKeyNeeded includes the reqSignerHashes in the union   -}
   let reqSignerHashes' = getField @"reqSignerHashes" txbody
-  eval (reqSignerHashes' ⊆ witsKeyHashes)
-    ?!# MissingRequiredSigners (eval $ reqSignerHashes' ➖ witsKeyHashes)
+  eval (reqSignerHashes' ⊆ unWitHashes witsKeyHashes)
+    ?!# MissingRequiredSigners (eval $ reqSignerHashes' ➖ unWitHashes witsKeyHashes)
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   let languages =
@@ -345,7 +351,60 @@ alonzoStyleWitness = do
   {-  { c ∈ txcerts txb ∩ DCert_mir} ≠ ∅  ⇒ (|genSig| ≥ Quorum) ∧ (d pp > 0)  -}
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  shelleyStyleWitness witsVKeyNeeded WrappedShelleyEraFailure
+
+  -- check scripts
+  {-  ∀ s ∈ range(txscripts txw) ∩ Scriptnative), runNativeScript s tx   -}
+
+  runValidationStaticWith WrappedShelleyEraFailure $
+    Shelley.validateFailedScripts tx
+
+  {-  { s | (_,s) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)          -}
+  runValidationWith WrappedShelleyEraFailure $
+    Shelley.validateMissingScripts pp utxo tx
+
+  -- check VKey witnesses
+
+  {-  ∀ (vk ↦ σ) ∈ (txwitsVKey txw), V_vk⟦ txbodyHash ⟧_σ                -}
+  runValidationStaticWith WrappedShelleyEraFailure $
+    Shelley.validateVerifiedWits tx
+
+  {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
+  runValidationWith WrappedShelleyEraFailure $
+    validateNeededWitnesses genDelegs utxo tx witsKeyHashes
+
+  -- check metadata hash
+  {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
+  runValidationStaticWith WrappedShelleyEraFailure $
+    Shelley.validateMetadata pp tx
+
+  -- check genesis keys signatures for instantaneous rewards certificates
+  {-  genSig := { hashKey gkey | gkey ∈ dom(genDelegs)} ∩ witsKeyHashes  -}
+  {-  { c ∈ txcerts txb ∩ DCert_mir} ≠ ∅  ⇒ (|genSig| ≥ Quorum) ∧ (d pp > 0)  -}
+  coreNodeQuorum <- liftSTS $ asks quorum
+  runValidationWith WrappedShelleyEraFailure $
+    Shelley.validateMIRInsufficientGenesisSigs genDelegs coreNodeQuorum witsKeyHashes tx
+
+  trans @(Core.EraRule "UTXO" era) $
+    TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
+
+validateNeededWitnesses ::
+  ( Era era,
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "update" (Core.TxBody era) (StrictMaybe (Update era)),
+    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era)))
+  ) =>
+  GenDelegs (Crypto era) ->
+  UTxO era ->
+  Core.Tx era ->
+  WitHashes (Crypto era) ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateNeededWitnesses genDelegs utxo tx witsKeyHashes =
+  let needed = witsVKeyNeeded utxo tx genDelegs
+      missingWitnesses = diffWitHashes needed witsKeyHashes
+   in failureUnless (nullWitHashes missingWitnesses) $
+        MissingVKeyWitnessesUTXOW missingWitnesses
 
 -- | Collect the set of hashes of keys that needs to sign a given transaction.
 --  This set consists of the txin owners, certificate authors, and withdrawal

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -311,12 +311,12 @@ minfee ::
   ( HasField "_minfeeA" (Core.PParams era) Natural,
     HasField "_minfeeB" (Core.PParams era) Natural,
     HasField "_prices" (Core.PParams era) Prices,
-    HasField "wits" (tx era) (Core.Witnesses era),
+    HasField "wits" (Core.Tx era) (Core.Witnesses era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
-    HasField "txsize" (tx era) Integer
+    HasField "txsize" (Core.Tx era) Integer
   ) =>
   Core.PParams era ->
-  tx era ->
+  Core.Tx era ->
   Coin
 minfee pp tx =
   (getField @"txsize" tx <×> a pp)
@@ -328,10 +328,10 @@ minfee pp tx =
     allExunits = totExUnits tx
 
 totExUnits ::
-  ( HasField "wits" (tx era) (Core.Witnesses era),
+  ( HasField "wits" (Core.Tx era) (Core.Witnesses era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era)
   ) =>
-  tx era ->
+  Core.Tx era ->
   ExUnits
 totExUnits = foldMap snd . Map.elems . unRedeemers . getField @"txrdmrs" . getField @"wits"
 

--- a/eras/babbage/formal-spec/utxo.tex
+++ b/eras/babbage/formal-spec/utxo.tex
@@ -32,7 +32,7 @@
     & \fun{feesOK} : \PParams \to \Tx \to \UTxO \to \Bool  \\
     & \fun{feesOK}~\var{pp}~tx~utxo = \\
     &~~      \minfee{pp}{tx} \leq \txfee{tx} \wedge (\fun{txrdmrs}~tx \neq \Nothing \Rightarrow \\
-    &~~~~~~((\forall (a, \wcard, \_) \in \fun{range}~(\fun{collInputs}~tx \restrictdom \var{utxo}), \fun{paymentHK}~a \in \AddrVKey) \\
+    &~~~~~~((\forall (a, \wcard, \wcard) \in \fun{range}~(\fun{collInputs}~tx \restrictdom \var{utxo}), a \in \AddrVKey) \\
     &~~~~~~\wedge \fun{adaOnly}~\var{balance} \\
     &~~~~~~\wedge \var{balance} \geq \hldiff{\fun{minCollateral}~tx~pp} \\
     &~~~~~~\wedge \hldiff{(\fun{txcoll}~tx \neq \Nothing) \Rightarrow \var{balance} = \fun{txcoll}~tx} \\

--- a/eras/shelley-ma/formal-spec/utxo.tex
+++ b/eras/shelley-ma/formal-spec/utxo.tex
@@ -165,7 +165,7 @@ $\Coin$.
   \begin{equation}\label{eq:utxo-inductive-shelley}
     \inference[UTxO-inductive]
     { \var{txb}\leteq\txbody{tx}
-      & \hldiff{\fun{ininterval}~\var{slot}~(\fun{txvld}{tx})}
+      & \hldiff{\fun{ininterval}~\var{slot}~(\fun{txvldt}~{tx})}
       \\ \txins{txb} \neq \emptyset
       & \minfee{pp}{tx} \leq \txfee{txb}
       & \txins{txb} \subseteq \dom \var{utxo}

--- a/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -73,5 +73,6 @@ library
     small-steps,
     strict-containers,
     text,
-    transformers
+    transformers,
+    validation-selective,
   hs-source-dirs: src

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -10,13 +10,11 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
--- The STS instance for UTXO is technically an orphan.
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.ShelleyMA.Rules.Utxo where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, serialize)
-import Cardano.Ledger.Address (Addr, getNetwork)
+import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.BaseTypes
   ( Network,
     ShelleyBase,
@@ -26,6 +24,8 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.Rules.ValidationMode (runValidation, runValidationTransMaybe)
 import Cardano.Ledger.Shelley.Constraints
   ( TransValue,
     UsesAuxiliary,
@@ -41,20 +41,8 @@ import Cardano.Ledger.Shelley.PParams (PParams, PParams' (..), Update)
 import Cardano.Ledger.Shelley.Rules.Ppup (PPUP, PPUPEnv (..), PpupPredicateFailure)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley
 import Cardano.Ledger.Shelley.Tx (Tx (..), TxIn, TxOut)
-import Cardano.Ledger.Shelley.TxBody
-  ( DCert,
-    RewardAcnt (getRwdNetwork),
-    Wdrl,
-    unWdrl,
-  )
-import Cardano.Ledger.Shelley.UTxO
-  ( UTxO (..),
-    totalDeposits,
-    txins,
-    txouts,
-    txup,
-    unUTxO,
-  )
+import Cardano.Ledger.Shelley.TxBody (DCert, RewardAcnt, Wdrl)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), totalDeposits, txouts, txup)
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Ledger.ShelleyMA.TxBody (TxBody)
@@ -72,15 +60,16 @@ import Data.Coders
   )
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Foldable (toList)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
-import qualified Data.Set as Set
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import GHC.Records
 import NoThunks.Class (NoThunks)
 import Numeric.Natural (Natural)
+import Validation
 
 {- The scaledMinDeposit calculation uses the minUTxOValue protocol parameter
 (passed to it as Coin mv) as a specification of "the cost of
@@ -128,6 +117,10 @@ scaledMinDeposit v (Coin mv)
     coinsPerUTxOWord :: Integer
     coinsPerUTxOWord = quot mv (utxoEntrySizeWithoutVal + coinSize)
 
+-- | This is a constant value hardcoded for ShelleyMA that was later moved to PParams
+newtype MaxValSize = MaxValSize {_maxValSize :: Natural}
+  deriving (Eq, Show)
+
 -- ==========================================================
 
 data UtxoPredicateFailure era
@@ -161,6 +154,20 @@ data UtxoPredicateFailure era
   | OutputTooBigUTxO
       ![Core.TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
+
+fromShelleyFailure :: Shelley.UtxoPredicateFailure era -> Maybe (UtxoPredicateFailure era)
+fromShelleyFailure = \case
+  Shelley.BadInputsUTxO ins -> Just $ BadInputsUTxO ins
+  Shelley.ExpiredUTxO {} -> Nothing -- Rule was replaced with `OutsideValidityIntervalUTxO`
+  Shelley.MaxTxSizeUTxO a m -> Just $ MaxTxSizeUTxO a m
+  Shelley.InputSetEmptyUTxO -> Just InputSetEmptyUTxO
+  Shelley.FeeTooSmallUTxO mf af -> Just $ FeeTooSmallUTxO mf af
+  Shelley.ValueNotConservedUTxO {} -> Nothing -- Rule was updated
+  Shelley.WrongNetwork n as -> Just $ WrongNetwork n as
+  Shelley.WrongNetworkWithdrawal n as -> Just $ WrongNetworkWithdrawal n as
+  Shelley.OutputTooSmallUTxO {} -> Nothing -- Rule was updated
+  Shelley.UpdateFailure ppf -> Just $ UpdateFailure ppf
+  Shelley.OutputBootAddrAttrsTooBig outs -> Just $ OutputBootAddrAttrsTooBig outs
 
 deriving stock instance
   ( Shelley.TransUTxOState Show era,
@@ -215,6 +222,7 @@ utxoTransition ::
   ( UsesTxBody era,
     UsesValue era,
     STS (UTXO era),
+    Core.Tx era ~ Tx era,
     Embed (Core.EraRule "PPUP" era) (UTXO era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -238,84 +246,149 @@ utxoTransition = do
   let Shelley.UTxOState utxo _ _ ppup _ = u
   let txb = getField @"body" tx
 
-  inInterval slot (getField @"vldt" txb)
-    ?! OutsideValidityIntervalUTxO (getField @"vldt" txb) slot
+  {- ininterval slot (txvld tx) -}
+  runValidation $ validateOutsideValidityIntervalUTxO slot txb
 
-  txins @era txb /= Set.empty ?! InputSetEmptyUTxO
+  {- txins txb ≠ ∅ -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateInputSetEmptyUTxO txb
 
-  let minFee = Shelley.minfee pp tx
-      txFee = getField @"txfee" txb
-  minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
+  {- minfee pp tx ≤ txfee txb -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateFeeTooSmallUTxO pp tx
 
-  let badInputs = Set.filter (`SplitMap.notMember` unUTxO utxo) (txins @era txb)
-  Set.null badInputs ?! BadInputsUTxO badInputs
+  {- txins txb ⊆ dom utxo -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateBadInputsUTxO utxo txb
 
-  ni <- liftSTS $ asks networkId
-  let addrsWrongNetwork =
-        filter
-          (\a -> getNetwork a /= ni)
-          (fmap getTxOutAddr $ toList $ getField @"outputs" txb)
-  null addrsWrongNetwork ?! WrongNetwork ni (Set.fromList addrsWrongNetwork)
-  let wdrlsWrongNetwork =
-        filter
-          (\a -> getRwdNetwork a /= ni)
-          (Map.keys . unWdrl . getField @"wdrls" $ txb)
-  null wdrlsWrongNetwork
-    ?! WrongNetworkWithdrawal
-      ni
-      (Set.fromList wdrlsWrongNetwork)
+  netId <- liftSTS $ asks networkId
 
-  let consumed_ = consumed pp utxo txb
-      produced_ = Shelley.produced @era pp (`Map.notMember` stakepools) txb
-  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
+  {- ∀(_ → (a, _)) ∈ txouts txb, netId a = NetworkId -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateWrongNetwork netId txb
+
+  {- ∀(a → ) ∈ txwdrls txb, netId a = NetworkId -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateWrongNetworkWithdrawal netId txb
+
+  {- consumed pp utxo txb = produced pp poolParams txb -}
+  runValidation $ validateValueNotConservedUTxO pp utxo stakepools txb
 
   -- process Protocol Parameter Update Proposals
   ppup' <-
-    trans @(Core.EraRule "PPUP" era) $
-      TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
+    trans @(Core.EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
 
-  -- Check that the mint field does not try to mint ADA. This is equivalent to
-  -- the check `adaPolicy ∉ supp mint tx` in the spec.
-  Val.coin (getField @"mint" txb) == Val.zero ?! TriesToForgeADA
+  runValidation $ validateTriesToForgeADA txb
 
-  let outputs = unUTxO (txouts txb)
-      minUTxOValue = getField @"_minUTxOValue" pp
-      outputsTooSmall =
-        filter
-          ( \out ->
-              let v = getField @"value" out
-               in not $
-                    Val.pointwise
-                      (>=)
-                      v
-                      (Val.inject $ scaledMinDeposit v minUTxOValue)
-          )
-          (SplitMap.elems outputs)
-  null outputsTooSmall ?! OutputTooSmallUTxO outputsTooSmall
+  let outputs = txouts txb
+  {- ∀ txout ∈ txouts txb, getValue txout ≥ inject (scaledMinDeposit v (minUTxOValue pp)) -}
+  runValidation $ validateOutputTooSmallUTxO pp outputs
 
-  let outputsTooBig =
-        filter
-          ( \out ->
-              let v = getField @"value" out
-               in (BSL.length . serialize) v > 4000
-              -- TODO this is arbitrary, but sufficiently below the current
-              -- max transaction size. We will make it a protocol parameter
-              -- in the Alonzo era.
-          )
-          (SplitMap.elems outputs)
-  null outputsTooBig ?! OutputTooBigUTxO outputsTooBig
+  -- In ShelleyMA MaxValSize is a constant of 4000 bytes, i.e. 500 words.
+  {- ∀ txout ∈ txouts txb, serSize (getValue txout) ≤ MaxValSize -}
+  runValidation $ validateOutputTooBigUTxO (MaxValSize 4000) outputs
 
-  let outputsAttrsTooBig = Shelley.filterOutputsAttrsTooBig outputs
-  null outputsAttrsTooBig ?! OutputBootAddrAttrsTooBig outputsAttrsTooBig
+  {- ∀ ( _ ↦ (a,_)) ∈ txoutstxb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64 -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateOutputBootAddrsTooBig outputs
 
-  let maxTxSize_ = fromIntegral (getField @"_maxTxSize" pp)
-      txSize_ = getField @"txsize" tx
-  txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
+  {- txsize tx ≤ maxTxSize pp -}
+  runValidationTransMaybe fromShelleyFailure $ Shelley.validateMaxTxSizeUTxO pp tx
 
   let refunded = Shelley.keyRefunds pp txb
   let txCerts = toList $ getField @"certs" txb
   let depositChange = totalDeposits pp (`Map.notMember` stakepools) txCerts Val.<-> refunded
   pure $! Shelley.updateUTxOState u txb depositChange ppup'
+
+-- | Ensure the transaction is within the validity window.
+--
+-- > ininterval slot (txvld tx)
+validateOutsideValidityIntervalUTxO ::
+  HasField "vldt" (Core.TxBody era) ValidityInterval =>
+  SlotNo ->
+  Core.TxBody era ->
+  Validation (NonEmpty (UtxoPredicateFailure era)) ()
+validateOutsideValidityIntervalUTxO slot txb =
+  failureUnless (inInterval slot (txvld txb)) $
+    OutsideValidityIntervalUTxO (txvld txb) slot
+  where
+    txvld = getField @"vldt"
+
+-- | Check that the mint field does not try to mint ADA. This is equivalent to
+-- the check:
+--
+-- > adaPolicy ∉ supp mint tx
+validateTriesToForgeADA ::
+  (Val.Val (Core.Value era), HasField "mint" (Core.TxBody era) (Core.Value era)) =>
+  Core.TxBody era ->
+  Validation (NonEmpty (UtxoPredicateFailure era)) ()
+validateTriesToForgeADA txb =
+  failureUnless (Val.coin (getField @"mint" txb) == Val.zero) TriesToForgeADA
+
+-- | Ensure that there are no `Core.TxOut`s that have `Value` of size larger than @MaxValSize@
+--
+-- > ∀ txout ∈ txouts txb, serSize (getValue txout) ≤ MaxValSize
+validateOutputTooBigUTxO ::
+  ( HasField "_maxValSize" params Natural,
+    HasField "value" (Core.TxOut era) (Core.Value era),
+    ToCBOR (Core.Value era)
+  ) =>
+  params ->
+  UTxO era ->
+  Validation (NonEmpty (UtxoPredicateFailure era)) ()
+validateOutputTooBigUTxO params (UTxO outputs) =
+  failureUnless (null outputsTooBig) $ OutputTooBigUTxO outputsTooBig
+  where
+    maxValSize = getField @"_maxValSize" params
+    outputsTooBig =
+      filter
+        ( \out ->
+            let v = getField @"value" out
+             in fromIntegral (BSL.length (serialize v)) > maxValSize
+        )
+        (SplitMap.elems outputs)
+
+-- | Ensure that there are no `Core.TxOut`s that have value less than the scaled @minUTxOValue@
+--
+-- > ∀ txout ∈ txouts txb, getValue txout ≥ inject (scaledMinDeposit v (minUTxOValue pp))
+validateOutputTooSmallUTxO ::
+  ( HasField "_minUTxOValue" (Core.PParams era) Coin,
+    HasField "value" (Core.TxOut era) (Core.Value era),
+    Val.Val (Core.Value era)
+  ) =>
+  Core.PParams era ->
+  UTxO era ->
+  Validation (NonEmpty (UtxoPredicateFailure era)) ()
+validateOutputTooSmallUTxO pp (UTxO outputs) =
+  failureUnless (null outputsTooSmall) $ OutputTooSmallUTxO outputsTooSmall
+  where
+    minUTxOValue = getField @"_minUTxOValue" pp
+    outputsTooSmall =
+      filter
+        ( \out ->
+            let v = getField @"value" out
+             in Val.pointwise (<) v (Val.inject $ scaledMinDeposit v minUTxOValue)
+        )
+        (SplitMap.elems outputs)
+
+-- | Ensure that value consumed and produced matches up exactly. Note that this
+-- is different from Shelley, since implementation of `consumed` has changed.
+--
+-- > consumed pp utxo txb = produced pp poolParams txb
+validateValueNotConservedUTxO ::
+  ( Era era,
+    HasField "_keyDeposit" (Core.PParams era) Coin,
+    HasField "_poolDeposit" (Core.PParams era) Coin,
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "mint" (Core.TxBody era) (Core.Value era)
+  ) =>
+  Core.PParams era ->
+  UTxO era ->
+  Map.Map (KeyHash 'StakePool (Crypto era)) a ->
+  Core.TxBody era ->
+  Validation (NonEmpty (UtxoPredicateFailure era)) ()
+validateValueNotConservedUTxO pp utxo stakepools txb =
+  failureUnless (consumedValue == producedValue) $
+    ValueNotConservedUTxO consumedValue producedValue
+  where
+    consumedValue = consumed pp utxo txb
+    producedValue = Shelley.produced pp (`Map.notMember` stakepools) txb
 
 --------------------------------------------------------------------------------
 -- UTXO STS

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -301,10 +301,10 @@ validateOutsideValidityIntervalUTxO ::
   Core.TxBody era ->
   Validation (NonEmpty (UtxoPredicateFailure era)) ()
 validateOutsideValidityIntervalUTxO slot txb =
-  failureUnless (inInterval slot (txvld txb)) $
-    OutsideValidityIntervalUTxO (txvld txb) slot
+  failureUnless (inInterval slot (txvldt txb)) $
+    OutsideValidityIntervalUTxO (txvldt txb) slot
   where
-    txvld = getField @"vldt"
+    txvldt = getField @"vldt"
 
 -- | Check that the mint field does not try to mint ADA. This is equivalent to
 -- the check:

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -11,17 +11,14 @@ module Cardano.Ledger.ShelleyMA.Rules.Utxow where
 import Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era)
-import Cardano.Ledger.Shelley.LedgerState
-  ( UTxOState,
-    witsVKeyNeeded,
-  )
+import Cardano.Ledger.Shelley.LedgerState (UTxOState)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Shelley
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyStyleWitnessNeeds,
     UtxowEvent (..),
     UtxowPredicateFailure (..),
-    shelleyStyleWitness,
+    transitionRulesUTXOW,
   )
 import Cardano.Ledger.Shelley.Tx (WitnessSet)
 import Cardano.Ledger.ShelleyMA.Rules.Utxo (UTXO, UtxoPredicateFailure)
@@ -62,7 +59,7 @@ instance
   type PredicateFailure (UTXOW era) = UtxowPredicateFailure era
   type Event (UTXOW era) = UtxowEvent era
 
-  transitionRules = [shelleyStyleWitness witsVKeyNeeded id]
+  transitionRules = [transitionRulesUTXOW]
 
   -- The ShelleyMA Era uses the same PredicateFailure type
   -- as Shelley, so the 'embed' function is identity

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -115,3 +115,4 @@ library
     text,
     time,
     transformers,
+    validation-selective,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -66,7 +66,6 @@ module Cardano.Ledger.Shelley.LedgerState
     txsizeBound,
     produced,
     consumed,
-    witsVKeyNeeded,
     witsFromTxWitnesses,
     propWits,
 
@@ -104,7 +103,7 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.Address (Addr (..), bootstrapKeyHash, isBootstrapRedeemer)
+import Cardano.Ledger.Address (Addr (..), isBootstrapRedeemer)
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     BlocksMade (..),
@@ -115,7 +114,6 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     UnitInterval,
     activeSlotVal,
-    strictMaybeToMaybe,
   )
 import Cardano.Ledger.Coin
   ( Coin (..),
@@ -146,14 +144,7 @@ import Cardano.Ledger.Shelley.Address.Bootstrap
     bootstrapWitKeyHash,
   )
 import Cardano.Ledger.Shelley.Constraints (TransValue)
-import Cardano.Ledger.Shelley.Delegation.Certificates
-  ( DCert (..),
-    delegCWitness,
-    genesisCWitness,
-    isDeRegKey,
-    poolCWitness,
-    requiresVKeyWitness,
-  )
+import Cardano.Ledger.Shelley.Delegation.Certificates (DCert (..), isDeRegKey)
 import Cardano.Ledger.Shelley.EpochBoundary
   ( SnapShot (..),
     SnapShots (..),
@@ -199,11 +190,9 @@ import Cardano.Ledger.Shelley.Rewards
     mkPoolRewardInfo,
     sumRewards,
   )
-import Cardano.Ledger.Shelley.Tx (extractKeyHashWitnessSet)
 import Cardano.Ledger.Shelley.TxBody
   ( EraIndependentTxBody,
     MIRPot (..),
-    PoolCert (..),
     PoolParams (..),
     Ptr (..),
     RewardAcnt (..),
@@ -217,7 +206,6 @@ import Cardano.Ledger.Shelley.UTxO
   ( UTxO (..),
     balance,
     totalDeposits,
-    txinLookup,
     txins,
     txouts,
   )
@@ -956,77 +944,6 @@ witsFromTxWitnesses coreTx =
   where
     bsWits = getField @"bootWits" coreTx
     addWits = getField @"addrWits" coreTx
-
--- | Collect the set of hashes of keys that needs to sign a
---  given transaction. This set consists of the txin owners,
---  certificate authors, and withdrawal reward accounts.
-witsVKeyNeeded ::
-  forall era tx.
-  ( Era era,
-    HasField "body" tx (Core.TxBody era),
-    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
-    HasField "update" (Core.TxBody era) (StrictMaybe (Update era))
-  ) =>
-  UTxO era ->
-  tx ->
-  GenDelegs (Crypto era) ->
-  WitHashes (Crypto era)
-witsVKeyNeeded utxo' tx genDelegs =
-  WitHashes $
-    certAuthors
-      `Set.union` inputAuthors
-      `Set.union` owners
-      `Set.union` wdrlAuthors
-      `Set.union` updateKeys
-  where
-    txbody = getField @"body" tx
-    inputAuthors :: Set (KeyHash 'Witness (Crypto era))
-    inputAuthors = foldr accum Set.empty (getField @"inputs" txbody)
-      where
-        accum txin ans =
-          case txinLookup txin utxo' of
-            Just out ->
-              case getTxOutAddr out of
-                Addr _ (KeyHashObj pay) _ -> Set.insert (asWitness pay) ans
-                AddrBootstrap bootAddr ->
-                  Set.insert (asWitness (bootstrapKeyHash bootAddr)) ans
-                _ -> ans
-            Nothing -> ans
-
-    wdrlAuthors :: Set (KeyHash 'Witness (Crypto era))
-    wdrlAuthors = Map.foldrWithKey accum Set.empty (unWdrl (getField @"wdrls" txbody))
-      where
-        accum key _ ans = Set.union (extractKeyHashWitnessSet [getRwdCred key]) ans
-    owners :: Set (KeyHash 'Witness (Crypto era))
-    owners = foldr accum Set.empty (getField @"certs" txbody)
-      where
-        accum (DCertPool (RegPool pool)) ans =
-          Set.union
-            (Set.map asWitness (_poolOwners pool))
-            ans
-        accum _cert ans = ans
-    cwitness (DCertDeleg dc) = extractKeyHashWitnessSet [delegCWitness dc]
-    cwitness (DCertPool pc) = extractKeyHashWitnessSet [poolCWitness pc]
-    cwitness (DCertGenesis gc) = Set.singleton (asWitness $ genesisCWitness gc)
-    cwitness c = error $ show c ++ " does not have a witness"
-    -- key reg requires no witness but this is already filtered outby requiresVKeyWitness
-    -- before the call to `cwitness`, so this error should never be reached.
-
-    certAuthors :: Set (KeyHash 'Witness (Crypto era))
-    certAuthors = foldr accum Set.empty (getField @"certs" txbody)
-      where
-        accum cert ans | requiresVKeyWitness cert = Set.union (cwitness cert) ans
-        accum _cert ans = ans
-    updateKeys :: Set (KeyHash 'Witness (Crypto era))
-    updateKeys =
-      asWitness
-        `Set.map` propWits
-          ( strictMaybeToMaybe $
-              getField @"update" txbody
-          )
-          genDelegs
 
 -- | Calculate the set of hash keys of the required witnesses for update
 -- proposals.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Shelley.Rules.Utxo
     UtxoEvent (..),
     PredicateFailure,
     updateUTxOState,
+
     -- * Validations
     validateInputSetEmptyUTxO,
     validateFeeTooSmallUTxO,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -21,7 +21,14 @@ module Cardano.Ledger.Shelley.Rules.Utxow
     PredicateFailure,
     shelleyStyleWitness,
     ShelleyStyleWitnessNeeds,
-    initialLedgerStateUTXOW,
+
+    -- * Individual validation steps
+    validateFailedScripts,
+    validateMissingScripts,
+    validateVerifiedWits,
+    validateNeededWitnesses,
+    validateMetadata,
+    validateMIRInsufficientGenesisSigs,
   )
 where
 
@@ -48,14 +55,15 @@ import Cardano.Ledger.Keys
     VKey,
     asWitness,
   )
-import Cardano.Ledger.Rules.ValidationMode (failBecauseS, (?!#), (?!#:))
+import Cardano.Ledger.Rules.ValidationMode (runValidationStaticWith, runValidationWith)
+import Cardano.Ledger.SafeHash (extractHash, hashAnnotated)
 import Cardano.Ledger.Serialization
   ( decodeList,
     decodeRecordSum,
     decodeSet,
     encodeFoldable,
   )
-import Cardano.Ledger.Shelley.Address.Bootstrap (BootstrapWitness)
+import Cardano.Ledger.Shelley.Address.Bootstrap (BootstrapWitness, bwKey, verifyBootstrapWit)
 import Cardano.Ledger.Shelley.Delegation.Certificates (isInstantaneousRewards)
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState
@@ -63,7 +71,6 @@ import Cardano.Ledger.Shelley.LedgerState
     WitHashes (..),
     diffWitHashes,
     nullWitHashes,
-    verifiedWits,
     witsFromTxWitnesses,
     witsVKeyNeeded,
   )
@@ -75,12 +82,11 @@ import Cardano.Ledger.Shelley.Tx
   ( Tx,
     ValidateScript,
     WitVKey,
-    WitnessSet,
     hashScript,
     validateScript,
   )
-import Cardano.Ledger.Shelley.TxBody (DCert, EraIndependentTxBody, Wdrl)
-import Cardano.Ledger.Shelley.UTxO (UTxO, scriptsNeeded)
+import Cardano.Ledger.Shelley.TxBody (DCert, EraIndependentTxBody, Wdrl, WitVKey (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO, scriptsNeeded, verifyWitVKey)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Monad (when)
 import Control.Monad.Trans.Reader (asks)
@@ -97,9 +103,9 @@ import Control.State.Transition
     trans,
     wrapEvent,
     wrapFailed,
-    (?!),
-    (?!:),
   )
+import Data.Foldable (sequenceA_)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq (filter)
 import Data.Sequence.Strict (StrictSeq)
@@ -107,10 +113,11 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
-import Data.Word (Word8)
+import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import GHC.Records (HasField, getField)
 import NoThunks.Class (NoThunks (..))
+import Validation
 
 -- =========================================
 
@@ -291,7 +298,6 @@ shelleyStyleWitness ::
     Environment (utxow era) ~ UtxoEnv era,
     State (utxow era) ~ UTxOState era,
     Signal (utxow era) ~ Core.Tx era,
-    -- PredicateFailure (utxow era) ~ UtxowPredicateFailure era,
     STS (utxow era),
     ShelleyStyleWitnessNeeds era
   ) =>
@@ -306,88 +312,36 @@ shelleyStyleWitness collectVKeyWitnesses embed = do
   {-  txw := txwits tx  -}
   {-  auxdata := auxiliaryData tx   -}
   {-  witsKeyHashes := { hashKey vk | vk ∈ dom(txwitsVKey txw) }  -}
-  let txbody = getField @"body" tx
-      utxo = _utxo u
+  let utxo = _utxo u
       witsKeyHashes = witsFromTxWitnesses @era tx
-      auxdata = getField @"auxiliaryData" tx
 
   -- check scripts
   {-  ∀ s ∈ range(txscripts txw) ∩ Scriptnative), runNativeScript s tx   -}
-  let failedScripts =
-        filter
-          ( \(hs, validator) ->
-              hashScript @era validator /= hs
-                || not (validateScript @era validator tx)
-          )
-          (Map.toList (getField @"scriptWits" tx))
-  case failedScripts of
-    [] -> pure ()
-    fs -> failBecauseS $ embed $ ScriptWitnessNotValidatingUTXOW $ Set.fromList $ fmap fst fs
+
+  runValidationStaticWith embed $ validateFailedScripts tx
 
   {-  { s | (_,s) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)          -}
-  let sNeeded = scriptsNeeded utxo tx
-      sReceived = Map.keysSet (getField @"scriptWits" tx)
-  if HardForks.missingScriptsSymmetricDifference pp
-    then do
-      sNeeded `Set.isSubsetOf` sReceived
-        ?! embed (MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived))
-      sReceived `Set.isSubsetOf` sNeeded
-        ?! embed (ExtraneousScriptWitnessesUTXOW (sReceived `Set.difference` sNeeded))
-    else
-      sNeeded == sReceived
-        ?! embed (MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived))
+  runValidationWith embed $ validateMissingScripts pp utxo tx
 
   -- check VKey witnesses
 
   {-  ∀ (vk ↦ σ) ∈ (txwitsVKey txw), V_vk⟦ txbodyHash ⟧_σ                -}
-  verifiedWits @era tx ?!#: (embed . InvalidWitnessesUTXOW)
+  runValidationStaticWith embed $ validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
   let needed = collectVKeyWitnesses utxo tx genDelegs
-      missingWitnesses = diffWitHashes needed witsKeyHashes
-      haveNeededWitnesses =
-        if nullWitHashes missingWitnesses
-          then Right ()
-          else Left missingWitnesses
-  haveNeededWitnesses ?!: (embed . MissingVKeyWitnessesUTXOW)
+  runValidationWith embed $ validateNeededWitnesses needed witsKeyHashes
 
   -- check metadata hash
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  case (getField @"adHash" txbody, auxdata) of
-    (SNothing, SNothing) -> pure ()
-    (SJust mdh, SNothing) -> failBecauseS $ embed (MissingTxMetadata mdh)
-    (SNothing, SJust md') ->
-      failBecauseS $
-        embed (MissingTxBodyMetadataHash (hashAuxiliaryData @era md'))
-    (SJust mdh, SJust md') -> do
-      hashAuxiliaryData @era md' == mdh
-        ?!# embed (ConflictingMetadataHash mdh (hashAuxiliaryData @era md'))
-
-      -- check metadata value sizes
-      when (SoftForks.validMetadata pp) $
-        validateAuxiliaryData @era md' ?!# embed InvalidMetadata
+  runValidationStaticWith embed $ validateMetadata pp tx
 
   -- check genesis keys signatures for instantaneous rewards certificates
   {-  genSig := { hashKey gkey | gkey ∈ dom(genDelegs)} ∩ witsKeyHashes  -}
-  let genDelegates =
-        Set.fromList $
-          asWitness . genDelegKeyHash
-            <$> Map.elems genMapping
-      (WitHashes khAsSet) = witsKeyHashes
-      genSig = eval (genDelegates ∩ khAsSet)
-      mirCerts =
-        StrictSeq.forceToStrict
-          . Seq.filter isInstantaneousRewards
-          . StrictSeq.fromStrict
-          $ getField @"certs" txbody
-      GenDelegs genMapping = genDelegs
-
   {-  { c ∈ txcerts txb ∩ DCert_mir} ≠ ∅  ⇒ (|genSig| ≥ Quorum) ∧ (d pp > 0)  -}
   coreNodeQuorum <- liftSTS $ asks quorum
-  ( not (null mirCerts)
-      ==> Set.size genSig >= fromIntegral coreNodeQuorum
-    )
-    ?! embed (MIRInsufficientGenesisSigsUTXOW genSig)
+  runValidationWith embed $
+    validateMIRInsufficientGenesisSigs genDelegs coreNodeQuorum witsKeyHashes tx
 
   trans @(Core.EraRule "UTXO" era) $
     TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
@@ -404,16 +358,15 @@ instance
   wrapEvent = UtxoEvent
 
 instance
-  ( -- Fix Core.Witnesses to the Shelley Era
-    Core.Witnesses era ~ WitnessSet era,
+  ( Era era,
     Core.Tx era ~ Tx era,
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
     -- Allow UTXOW to call UTXO
     Embed (Core.EraRule "UTXO" era) (UTXOW era),
     Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era,
     State (Core.EraRule "UTXO" era) ~ UTxOState era,
     Signal (Core.EraRule "UTXO" era) ~ Core.Tx era,
-    PredicateFailure (UTXOW era) ~ UtxowPredicateFailure era,
-    -- Supply the HasField and Validate instances for Shelley
     ShelleyStyleWitnessNeeds era
   ) =>
   STS (UTXOW era)
@@ -426,3 +379,140 @@ instance
   type Event _ = UtxowEvent era
   transitionRules = [shelleyStyleWitness witsVKeyNeeded id]
   initialRules = [initialLedgerStateUTXOW]
+
+{-  ∀ s ∈ range(txscripts txw) ∩ Scriptnative), runNativeScript s tx   -}
+validateFailedScripts ::
+  forall era.
+  ValidateScript era =>
+  Core.Tx era ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateFailedScripts tx = do
+  let failedScripts =
+        Map.filterWithKey
+          ( \hs validator ->
+              hashScript @era validator /= hs || not (validateScript @era validator tx)
+          )
+          (getField @"scriptWits" tx)
+  failureUnless (Map.null failedScripts) $
+    ScriptWitnessNotValidatingUTXOW (Map.keysSet failedScripts)
+
+{-  { s | (_,s) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)          -}
+validateMissingScripts ::
+  forall era.
+  ( ValidateScript era,
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "_protocolVersion" (Core.PParams era) ProtVer
+  ) =>
+  Core.PParams era ->
+  UTxO era ->
+  Core.Tx era ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateMissingScripts pp utxo tx =
+  let sNeeded = scriptsNeeded utxo tx
+      sReceived = Map.keysSet (getField @"scriptWits" tx)
+   in if HardForks.missingScriptsSymmetricDifference pp
+        then
+          sequenceA_
+            [ failureUnless (sNeeded `Set.isSubsetOf` sReceived) $
+                MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived),
+              failureUnless (sReceived `Set.isSubsetOf` sNeeded) $
+                ExtraneousScriptWitnessesUTXOW (sReceived `Set.difference` sNeeded)
+            ]
+        else
+          failureUnless (sNeeded == sReceived) $
+            MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived)
+
+-- | Given a ledger state, determine if the UTxO witnesses in a given
+--  transaction are correct.
+validateVerifiedWits ::
+  forall era.
+  ( Era era,
+    HasField "addrWits" (Core.Tx era) (Set (WitVKey 'Witness (Crypto era))),
+    HasField "bootWits" (Core.Tx era) (Set (BootstrapWitness (Crypto era))),
+    DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody)
+  ) =>
+  Core.Tx era ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateVerifiedWits tx =
+  case failed <> failedBootstrap of
+    [] -> pure ()
+    nonEmpty -> failure $ InvalidWitnessesUTXOW nonEmpty
+  where
+    txbody = getField @"body" tx
+    wvkKey (WitVKey k _) = k
+    failed =
+      wvkKey
+        <$> filter
+          (not . verifyWitVKey (extractHash (hashAnnotated @(Crypto era) txbody)))
+          (Set.toList $ getField @"addrWits" tx)
+    failedBootstrap =
+      bwKey
+        <$> filter
+          (not . verifyBootstrapWit (extractHash (hashAnnotated @(Crypto era) txbody)))
+          (Set.toList $ getField @"bootWits" tx)
+
+validateNeededWitnesses ::
+  WitHashes (Crypto era) ->
+  WitHashes (Crypto era) ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateNeededWitnesses needed witsKeyHashes =
+  let missingWitnesses = diffWitHashes needed witsKeyHashes
+   in failureUnless (nullWitHashes missingWitnesses) $
+        MissingVKeyWitnessesUTXOW missingWitnesses
+
+-- | check metadata hash
+--   ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)
+validateMetadata ::
+  forall era.
+  ( Era era,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    ValidateAuxiliaryData era (Crypto era)
+  ) =>
+  Core.PParams era ->
+  Core.Tx era ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateMetadata pp tx =
+  let txbody = getField @"body" tx
+   in case (getField @"adHash" txbody, getField @"auxiliaryData" tx) of
+        (SNothing, SNothing) -> pure ()
+        (SJust mdh, SNothing) -> failure $ MissingTxMetadata mdh
+        (SNothing, SJust md') ->
+          failure $ MissingTxBodyMetadataHash (hashAuxiliaryData @era md')
+        (SJust mdh, SJust md') ->
+          sequenceA_
+            [ failureUnless (hashAuxiliaryData @era md' == mdh) $
+                ConflictingMetadataHash mdh (hashAuxiliaryData @era md'),
+              -- check metadata value sizes
+              when (SoftForks.validMetadata pp) $
+                failureUnless (validateAuxiliaryData @era md') InvalidMetadata
+            ]
+
+-- | check genesis keys signatures for instantaneous rewards certificates
+--
+-- genSig := { hashKey gkey | gkey ∈ dom(genDelegs)} ∩ witsKeyHashes
+-- { c ∈ txcerts txb ∩ DCert_mir} ≠ ∅  ⇒ (|genSig| ≥ Quorum) ∧ (d pp > 0)
+validateMIRInsufficientGenesisSigs ::
+  ( HasField "body" (Core.Tx era) (Core.TxBody era),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert crypto))
+  ) =>
+  GenDelegs (Crypto era) ->
+  Word64 ->
+  WitHashes (Crypto era) ->
+  Core.Tx era ->
+  Validation (NonEmpty (UtxowPredicateFailure era)) ()
+validateMIRInsufficientGenesisSigs (GenDelegs genMapping) coreNodeQuorum witsKeyHashes tx =
+  let genDelegates =
+        Set.fromList $ asWitness . genDelegKeyHash <$> Map.elems genMapping
+      WitHashes khAsSet = witsKeyHashes
+      genSig = eval (genDelegates ∩ khAsSet)
+      txBody = getField @"body" tx
+      mirCerts =
+        StrictSeq.forceToStrict
+          . Seq.filter isInstantaneousRewards
+          . StrictSeq.fromStrict
+          $ getField @"certs" txBody
+   in failureUnless
+        (not (null mirCerts) ==> Set.size genSig >= fromIntegral coreNodeQuorum)
+        $ MIRInsufficientGenesisSigsUTXOW genSig

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -263,12 +263,12 @@ totalDeposits ::
   (KeyHash 'StakePool crypto -> Bool) ->
   [DCert crypto] ->
   Coin
-totalDeposits pp isNewPool cs =
+totalDeposits pp isNewPool certs =
   (numKeys <×> getField @"_keyDeposit" pp)
     <+> (numNewPools <×> getField @"_poolDeposit" pp)
   where
-    numKeys = length $ filter isRegKey cs
-    pools = Set.fromList $ Maybe.mapMaybe getKeyHashFromRegPool cs
+    numKeys = length $ filter isRegKey certs
+    pools = Set.fromList $ Maybe.mapMaybe getKeyHashFromRegPool certs
     numNewPools = length $ Set.filter isNewPool pools
 
 getKeyHashFromRegPool :: DCert crypto -> Maybe (KeyHash 'StakePool crypto)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -159,26 +159,20 @@ txins ::
   Set (TxIn (Crypto era))
 txins = getField @"inputs"
 
--- Because its only input (Core.TxBody) is a type family this
--- function tends to give errors like
--- "Could not deduce: Core.TxOut era0 ~ Core.TxOut era"
--- The way to fix this is to use TypeApplications like this:  txouts @era body
--- where the type variable: era, is in scope (use ScopedTypeVariables)
-
 -- | Compute the transaction outputs of a transaction.
 txouts ::
   forall era.
   Era era =>
   Core.TxBody era ->
   UTxO era
-txouts tx =
+txouts txBody =
   UTxO $
     SplitMap.fromList
       [ (TxIn transId idx, out)
-        | (out, idx) <- zip (toList $ getField @"outputs" tx) [minBound ..]
+        | (out, idx) <- zip (toList $ getField @"outputs" txBody) [minBound ..]
       ]
   where
-    transId = Core.txid tx
+    transId = Core.txid txBody
 
 -- | Lookup a txin for a given UTxO collection
 txinLookup ::

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -96,4 +96,5 @@ library
     strict-containers,
     text,
     time,
-    transformers
+    transformers,
+    validation-selective,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Rules.ValidationMode
     runValidationStatic,
     runValidationStaticTrans,
     runValidationStaticTransMaybe,
+    mapMaybeValidation,
   )
 where
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -18,15 +18,19 @@ module Cardano.Ledger.Rules.ValidationMode
 
     -- * Interface with validation-selective libarary
     runValidation,
-    runValidationWith,
+    runValidationTrans,
+    runValidationTransMaybe,
     runValidationStatic,
-    runValidationStaticWith,
+    runValidationStaticTrans,
   )
 where
 
 import Control.State.Transition.Extended
+import Data.Bifunctor (first)
 import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (mapMaybe)
 import Validation
 
 applySTSValidateSuchThat ::
@@ -96,24 +100,42 @@ applySTSNonStatic ::
   m (Either [PredicateFailure s] (State s))
 applySTSNonStatic = applySTSValidateSuchThat (notElem lblStatic)
 
+-- | Fail with all `PredicateFailure`'s in STS if `Validation` was unsuccessful.
 runValidation ::
   Validation (NonEmpty (PredicateFailure sts)) () -> Rule sts ctx ()
 runValidation v = whenFailure_ v (traverse_ (\pf -> pf `seq` failBecause pf))
 
-runValidationWith ::
+-- | Same as `runValidation`, except with ability to translate opaque failures
+-- into `PredicateFailure`s with a help of supplied function.
+runValidationTrans ::
   (e -> PredicateFailure sts) ->
   Validation (NonEmpty e) () ->
   Rule sts ctx ()
-runValidationWith toPredicateFailure v =
+runValidationTrans toPredicateFailure v =
   whenFailure_ v (traverse_ (\e -> failBecause $! toPredicateFailure e))
 
+-- | Same as `runValidationTrans`, but makes it possible to filter out failures
+-- with the translating function when it returns `Nothing`.
+runValidationTransMaybe ::
+  (e -> Maybe (PredicateFailure sts)) ->
+  Validation (NonEmpty e) () ->
+  Rule sts ctx ()
+runValidationTransMaybe toPredicateFailureMaybe =
+  runValidation
+    . maybe (Success ()) Failure
+    . NE.nonEmpty
+    . fromFailure []
+    . first (mapMaybe toPredicateFailureMaybe . NE.toList)
+
+-- | Same as `runValidation`, but will label preficate failures as @"static"@
 runValidationStatic ::
   Validation (NonEmpty (PredicateFailure sts)) () -> Rule sts ctx ()
 runValidationStatic v = whenFailure_ v (traverse_ (\pf -> pf `seq` failBecauseS pf))
 
-runValidationStaticWith ::
+-- | Same as `runValidationTrans`, but will label preficate failures as @"static"@
+runValidationStaticTrans ::
   (e -> PredicateFailure sts) ->
   Validation (NonEmpty e) () ->
   Rule sts ctx ()
-runValidationStaticWith toPredicateFailure v =
+runValidationStaticTrans toPredicateFailure v =
   whenFailure_ v (traverse_ (\e -> failBecauseS $! toPredicateFailure e))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -98,20 +98,22 @@ applySTSNonStatic = applySTSValidateSuchThat (notElem lblStatic)
 
 runValidation ::
   Validation (NonEmpty (PredicateFailure sts)) () -> Rule sts ctx ()
-runValidation v = whenFailure_ v (traverse_ failBecause)
+runValidation v = whenFailure_ v (traverse_ (\pf -> pf `seq` failBecause pf))
 
 runValidationWith ::
   (e -> PredicateFailure sts) ->
   Validation (NonEmpty e) () ->
   Rule sts ctx ()
-runValidationWith f v = whenFailure_ v (traverse_ (failBecause . f))
+runValidationWith toPredicateFailure v =
+  whenFailure_ v (traverse_ (\e -> failBecause $! toPredicateFailure e))
 
 runValidationStatic ::
   Validation (NonEmpty (PredicateFailure sts)) () -> Rule sts ctx ()
-runValidationStatic v = whenFailure_ v (traverse_ failBecauseS)
+runValidationStatic v = whenFailure_ v (traverse_ (\pf -> pf `seq` failBecauseS pf))
 
 runValidationStaticWith ::
   (e -> PredicateFailure sts) ->
   Validation (NonEmpty e) () ->
   Rule sts ctx ()
-runValidationStaticWith f v = whenFailure_ v (traverse_ (failBecauseS . f))
+runValidationStaticWith toPredicateFailure v =
+  whenFailure_ v (traverse_ (\e -> failBecauseS $! toPredicateFailure e))


### PR DESCRIPTION
This approach relies on splitting large rules into smaller validation steps, which can then be reused individually in any era.

In this PR only UTXOW rule has been changed to show how this approach would work.

Any feedback is welcomed. 


(FYI this PR has a bit higher diff than strictly necessary because it moves `witsVKeyNeeded` and `verifiedWits` into `UTXOW`, since those functions do not need to be exported.)