### PR TITLE
add an epoch number to the TotalRewardEvent event

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -238,7 +238,6 @@ deriving instance Typeable era => NoThunks (ScriptIntegrity era)
 -- Instead, we must use a reproducable serialization
 instance Era era => SafeToHash (ScriptIntegrity era) where
   originalBytes (ScriptIntegrity m d l) =
-    -- TODO: double check that canonical encodings are used for the langDepView (l)
     let dBytes = if nullDats d then mempty else originalBytes d
         lBytes = serializeEncoding' (encodeLangViews l)
      in originalBytes m <> dBytes <> lBytes

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -78,7 +78,7 @@ instance
 
 data NewEpochEvent era
   = DeltaRewardEvent (Event (Core.EraRule "RUPD" era))
-  | TotalRewardEvent (Map.Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))))
+  | TotalRewardEvent EpochNo (Map.Map (Credential 'Staking (Crypto era)) (Set (Reward (Crypto era))))
   | EpochEvent (Event (Core.EraRule "EPOCH" era))
   | MirEvent (Event (Core.EraRule "MIR" era))
 
@@ -158,7 +158,7 @@ newEpochTransition = do
             Val.isZero (dt <> (dr <> toDeltaCoin totRs <> df)) ?! CorruptRewardUpdate ru'
             let (es', _regRU) = applyRUpd' ru' es
             if not (Map.null rs_) -- Tell the TotalRewardEvent, this should equal aggregating the DeltaRewardEvents
-              then tellEvent (TotalRewardEvent rs_)
+              then tellEvent (TotalRewardEvent e rs_)
               else pure ()
             pure es'
       es' <- case ru of

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -759,7 +759,7 @@ aggDeltaRewardEvents events = foldl' accum Map.empty events
 getMostRecentTotalRewardEvent :: [ChainEvent C] -> Map (Credential 'Staking (Crypto C)) (Set (Reward (Crypto C)))
 getMostRecentTotalRewardEvent events = foldl' accum Map.empty events
   where
-    accum ans (TickEvent (Tick.NewEpochEvent (TotalRewardEvent m))) = Map.unionWith Set.union m ans
+    accum ans (TickEvent (Tick.NewEpochEvent (TotalRewardEvent _ m))) = Map.unionWith Set.union m ans
     accum ans _ = ans
 
 complete :: PulsingRewUpdate crypto -> (RewardUpdate crypto, RewardEvent crypto)


### PR DESCRIPTION
Prior to #2615, the reward event included an epoch number. In #2615, we renamed the old reward event to `TotalRewardEvent` and created a new incremental reward event named `DeltaRewardEvent`. The event `TotalRewardEvent` does not currently, however, include an epoch number, though `DeltaRewardEvent` does. The PR add an epoch number to `TotalRewardEvent`.