### PR TITLE
fix two cbor list len mistakes

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -379,7 +379,7 @@ instance NFData (DState crypto)
 
 instance CC.Crypto crypto => ToCBOR (DState crypto) where
   toCBOR (DState unified fgs gs ir) =
-    encodeListLen 6
+    encodeListLen 4
       <> toCBOR unified
       <> toCBOR fgs
       <> toCBOR gs
@@ -390,7 +390,7 @@ instance CC.Crypto crypto => FromSharedCBOR (DState crypto) where
     Share (DState crypto) =
       (Interns (Credential 'Staking crypto), Interns (KeyHash 'StakePool crypto))
   fromSharedPlusCBOR = do
-    decodeRecordNamedT "DState" (const 6) $ do
+    decodeRecordNamedT "DState" (const 4) $ do
       unified <- fromSharedPlusCBOR
       fgs <- lift fromCBOR
       gs <- lift fromCBOR

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
@@ -242,14 +242,14 @@ instance CC.Crypto crypto => ToCBOR (NonMyopic crypto) where
       { likelihoodsNM = aps,
         rewardPotNM = rp
       } =
-      encodeListLen 3
+      encodeListLen 2
         <> toCBOR aps
         <> toCBOR rp
 
 instance CC.Crypto crypto => FromSharedCBOR (NonMyopic crypto) where
   type Share (NonMyopic crypto) = Interns (KeyHash 'StakePool crypto)
   fromSharedPlusCBOR = do
-    decodeRecordNamedT "NonMyopic" (const 3) $ do
+    decodeRecordNamedT "NonMyopic" (const 2) $ do
       likelihoodsNM <- fromSharedPlusLensCBOR (toMemptyLens _1 id)
       rewardPotNM <- lift fromCBOR
       pure $ NonMyopic {likelihoodsNM, rewardPotNM}

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -21,6 +21,7 @@ import Cardano.Binary
     ToCBOR (..),
     decodeAnnotator,
     decodeFullDecoder,
+    serialize',
     toCBOR,
   )
 import Cardano.Crypto.DSIGN (encodeSignedDSIGN, encodeVerKeyDSIGN)
@@ -178,6 +179,7 @@ import Cardano.Protocol.TPraos.OCert
   )
 import Codec.CBOR.Encoding (Encoding (..), Tokens (..))
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Coerce (coerce)
 import Data.Default.Class (def)
@@ -192,6 +194,7 @@ import Data.String (fromString)
 import Numeric.Natural (Natural)
 import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, C_Crypto, ExMock, Mock)
+import Test.Cardano.Ledger.Shelley.Examples.Consensus as Ex (ledgerExamplesShelley, sleNewEpochState)
 import Test.Cardano.Ledger.Shelley.Generator.Core (PreAlonzo)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
 import Test.Cardano.Ledger.Shelley.Serialisation.GoldenUtils
@@ -202,6 +205,7 @@ import Test.Cardano.Ledger.Shelley.Serialisation.GoldenUtils
   )
 import Test.Cardano.Ledger.Shelley.Utils
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
 
 -- ============================================
 
@@ -1327,7 +1331,22 @@ tests =
                 <> S es
                 <> S (SJust ru)
                 <> S pd
-            )
+            ),
+      let actual = B16.encode . serialize' $ Ex.sleNewEpochState Ex.ledgerExamplesShelley
+          expected =
+            "8600a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541"
+              <> "0aa1581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a03"
+              <> "86821927101903e8828283a0a0a08482a0a0a0a084a0a0000085a1825820ee155a"
+              <> "ce9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e2500825839"
+              <> "00cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc410d6a577e"
+              <> "9441ad8ed9663931906e4d43ece8f82c712b1d0235affb060a1903e80182a0a082"
+              <> "a0a08483a0a0a083a0a0a083a0a0a00092000000190800000000001864d81e8200"
+              <> "01d81e820001d81e820001d81e8200018100000000009200000019080000000000"
+              <> "1864d81e820001d81e820001d81e820001d81e82000181000000010082a0008183"
+              <> "00880082000082a000000000a0a0840185a0803903ba820000a0a082a0a0a1581c"
+              <> "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418282010158"
+              <> "20c5e21ab1c9f6022d81c3b25e3436cb7f1df77f9652ae3e1310c28e621dd87b4c"
+       in testCase "ledger state golden test" (actual @?= expected)
     ]
   where
     genesisTxIn1 = TxIn @C_Crypto genesisId (mkTxIxPartial 1)


### PR DESCRIPTION
In our ledger state serialization, two of the list lengths were incorrect. It passed the round trip tests since the broken encoding was consistent with the broken deserializer. This PR fixes the two mistakes. It also adds a golden test (the same one used by consensus) so that we can catch such changes and be aware of them before upgrading ledger in consensus.

I am hoping this makes its way into https://github.com/input-output-hk/ouroboros-network/pull/3599