### PR TITLE
Plutus V2 in the Babbage Era

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -77,8 +77,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 44358f6e534a9dd4be32a081f22ff0a649061f90
-  --sha256: 0sn3bcrm8qzmgvp8qs5bxfr7aizb02r3dwq0dyxw3kxhx3qs40fh
+  tag: 4417dfea15746596f51f313ef231fb9ecb1d02fc
+  --sha256: 0nx7jbql3mmd64f0kjxrv9azzyc61b6sm2xh5dil910lw891szwh
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -39,7 +39,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
 import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..), minfee)
 import Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut (TxOut), getAlonzoTxOutEitherAddr)
-import Cardano.Ledger.Alonzo.TxInfo (validScript)
+import Cardano.Ledger.Alonzo.TxInfo (HasTxInfo (..), alonzoTxInfo, validScript)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -219,6 +219,9 @@ instance CC.Crypto c => EraModule.SupportsSegWit (AlonzoEra c) where
   numSegComponents = 4
 
 instance API.ShelleyEraCrypto c => API.ShelleyBasedEra (AlonzoEra c)
+
+instance CC.Crypto c => HasTxInfo (AlonzoEra c) where
+  txInfo = alonzoTxInfo
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -93,8 +93,6 @@ instance FromCBOR (Annotator Plutus.Data) where
 instance ToCBOR Plutus.Data where
   toCBOR = Cborg.encode
 
-deriving anyclass instance NoThunks Plutus.BuiltinByteString
-
 deriving instance NoThunks Plutus.Data
 
 -- ============================================================================

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -186,7 +186,7 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
         Nothing -> pure Nothing
         Just (TimelockScript _) -> []
         Just (PlutusScript v bytes) -> pure $ Just (bytes, v)
-      pointer <- case rdptr @era txb sp of
+      pointer <- case rdptr txb sp of
         SNothing -> []
         -- Since scriptsNeeded used the transaction to create script purposes,
         -- it would be a logic error if rdptr was not able to find sp.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -11,31 +11,31 @@ module Cardano.Ledger.Alonzo.Tools
   )
 where
 
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data, getPlutusData)
-import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
-import Cardano.Ledger.Alonzo.PParams (_maxTxExUnits, _protocolVersion)
+import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeeded)
 import Cardano.Ledger.Alonzo.Scripts
   ( CostModel (..),
     ExUnits (..),
     Script (..),
   )
-import Cardano.Ledger.Alonzo.Tx (DataHash, ScriptPurpose (Spending), ValidatedTx (..), rdptr)
-import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
+import Cardano.Ledger.Alonzo.Tx (DataHash, ScriptPurpose (Spending), rdptr)
 import Cardano.Ledger.Alonzo.TxInfo
-  ( TranslationError,
+  ( HasTxInfo,
+    TranslationError,
     VersionedTxInfo (..),
     exBudgetToExUnits,
     transExUnits,
     txInfo,
     valContext,
   )
-import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), unRedeemers, unTxDats)
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers, TxDats, unRedeemers, unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
 import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Shelley.Scripts (ScriptHash)
 import Cardano.Ledger.Shelley.Tx (TxIn)
+import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), unUTxO)
 import Cardano.Slotting.EpochInfo.API (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -43,6 +43,8 @@ import Data.Array (Array, array, bounds, (!))
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -89,12 +91,15 @@ note _ (Just x) = Right x
 note e Nothing = Left e
 
 basicValidation ::
+  ( HasField "body" (Core.Tx era) (Core.TxBody era),
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
+  ) =>
   -- | The transaction.
-  Core.Tx (AlonzoEra c) ->
+  Core.Tx era ->
   -- | The current UTxO set (or the relevant portion for the transaction).
-  UTxO (AlonzoEra c) ->
+  UTxO era ->
   -- | Basic failures.
-  Maybe (BasicFailure c)
+  Maybe (BasicFailure (Crypto era))
 basicValidation tx utxo =
   if Set.null badIns
     then Nothing
@@ -106,21 +111,43 @@ basicValidation tx utxo =
 
 type RedeemerReport c = Map RdmrPtr (Either (ScriptFailure c) ExUnits)
 
+languagesUsed ::
+  ( HasField "wits" (Core.Tx era) (Core.Witnesses era),
+    HasField "txscripts" (Core.Witnesses era) (Map (ScriptHash (Crypto era)) (Script era))
+  ) =>
+  Core.Tx era ->
+  Set Language
+languagesUsed tx = Set.fromList $ mapMaybe getLanguage (getScripts tx)
+  where
+    getScripts = Map.elems . getField @"txscripts" . getField @"wits"
+    -- TODO account for reference scripts (and reference inputs) in babbage
+    getLanguage (TimelockScript _) = Nothing
+    getLanguage (PlutusScript lang _) = Just lang
+
 -- | Evaluate the execution budgets needed for all the redeemers in
 --  a given transaction. If a redeemer is invalid, a failure is returned instead.
 --
 --  The execution budgets in the supplied transaction are completely ignored.
 --  The results of 'evaluateTransactionExecutionUnits' are intended to replace them.
 evaluateTransactionExecutionUnits ::
-  forall c m.
-  ( CC.Crypto c,
+  forall era m.
+  ( Era era,
+    HasTxInfo era,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "txscripts" (Core.Witnesses era) (Map (ScriptHash (Crypto era)) (Script era)),
+    HasField "txdats" (Core.Witnesses era) (TxDats era),
+    HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
+    HasField "_maxTxExUnits" (Core.PParams era) (ExUnits),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     Monad m
   ) =>
-  Core.PParams (AlonzoEra c) ->
+  Core.PParams era ->
   -- | The transaction.
-  Core.Tx (AlonzoEra c) ->
+  Core.Tx era ->
   -- | The current UTxO set (or the relevant portion for the transaction).
-  UTxO (AlonzoEra c) ->
+  UTxO era ->
   -- | The epoch info, used to translate slots to POSIX time for plutus.
   EpochInfo m ->
   -- | The start time of the given block chain.
@@ -131,13 +158,13 @@ evaluateTransactionExecutionUnits ::
   --  redeemer pointers to either a failure or a sufficient execution budget.
   --  Otherwise we return a basic validation error.
   --  The value is monadic, depending on the epoch info.
-  m (Either (BasicFailure c) (RedeemerReport c))
+  m (Either (BasicFailure (Crypto era)) (RedeemerReport (Crypto era)))
 evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
   case basicValidation tx utxo of
     Nothing -> do
       let getInfo :: Language -> m (Either TranslationError (Language, VersionedTxInfo))
           getInfo lang = ((,) lang <$>) <$> txInfo pp lang ei sysS utxo tx
-      txInfos <- mapM getInfo (Set.toList nonNativeLanguages)
+      txInfos <- mapM getInfo (Set.toList $ languagesUsed tx)
       case sequence txInfos of
         Left transEr -> pure . Left $ BadTranslation transEr
         Right ctx ->
@@ -155,10 +182,11 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
     ptrToPlutusScript = Map.fromList $ do
       (sp, sh) <- scriptsNeeded utxo tx
       msb <- case Map.lookup sh scripts of
+        -- TODO account for reference scripts (and reference inputs) in Babbage
         Nothing -> pure Nothing
         Just (TimelockScript _) -> []
         Just (PlutusScript v bytes) -> pure $ Just (bytes, v)
-      pointer <- case rdptr @(AlonzoEra c) txb sp of
+      pointer <- case rdptr @era txb sp of
         SNothing -> []
         -- Since scriptsNeeded used the transaction to create script purposes,
         -- it would be a logic error if rdptr was not able to find sp.
@@ -166,11 +194,11 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
       pure (pointer, (sp, msb))
 
     findAndCount ::
-      Core.PParams (AlonzoEra c) ->
+      Core.PParams era ->
       Array Language VersionedTxInfo ->
       RdmrPtr ->
-      (Data (AlonzoEra c), ExUnits) ->
-      Either (ScriptFailure c) ExUnits
+      (Data era, ExUnits) ->
+      Either (ScriptFailure (Crypto era)) ExUnits
     findAndCount pparams info pointer (rdmr, _) = do
       (sp, mscript) <- note (RedeemerNotNeeded pointer) $ Map.lookup pointer ptrToPlutusScript
       (script, lang) <- note (MissingScript pointer) mscript
@@ -181,9 +209,10 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
       args <- case sp of
         (Spending txin) -> do
           txOut <- note (UnknownTxIn txin) $ SplitMap.lookup txin (unUTxO utxo)
-          let TxOut _ _ mdh = txOut
+          let mdh = getField @"datahash" txOut
           dh <- note (InvalidTxIn txin) $ strictMaybeToMaybe mdh
           dat <- note (MissingDatum dh) $ Map.lookup dh dats
+          -- TODO account for inline datums (and reference inputs) in babbage
           pure [dat, rdmr, valContext inf sp]
         _ -> pure [rdmr, valContext inf sp]
       let pArgs = map getPlutusData args
@@ -194,7 +223,7 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
           PlutusV2 -> Left $ ValidationFailedV2 e logs
         (_, Right exBudget) -> note (IncompatibleBudget exBudget) $ exBudgetToExUnits exBudget
       where
-        maxBudget = transExUnits . _maxTxExUnits $ pparams
+        maxBudget = transExUnits . getField @"_maxTxExUnits" $ pparams
         interpreter lang = case lang of
           PlutusV1 -> PV1.evaluateScriptRestricting PV1.Verbose
           PlutusV2 -> PV2.evaluateScriptRestricting PV2.Verbose

--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -113,8 +113,6 @@ script_data_hash = $hash32 ; New
 ;     list and the result is encoded as a bytestring. (our apologies)
 ;   - the language ID tag is also encoded twice. first as a uint then as
 ;     a bytestring. (our apologies)
-; For PlutusV2 (language id 1), the language view is the following:
-;   - the value of costmdls map at key 1 is encoded as an definite length list.
 ;
 ; If there is no value for key 0, then the corresponding scripts cannot execute.
 ; Regardless of what the script integrity data is.

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -38,6 +38,7 @@ library
     Cardano.Ledger.Babbage.PParams
     Cardano.Ledger.Babbage.Tx
     Cardano.Ledger.Babbage.TxBody
+    Cardano.Ledger.Babbage.TxInfo
     Cardano.Ledger.Babbage.Translation
     Cardano.Ledger.Babbage
   build-depends:
@@ -54,6 +55,7 @@ library
     cardano-ledger-shelley-ma,
     cardano-prelude,
     cardano-slotting,
+    compact-map,
     containers,
     data-default,
     deepseq,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
-import Cardano.Ledger.Alonzo.TxInfo (validScript)
+import Cardano.Ledger.Alonzo.TxInfo (HasTxInfo (..), validScript)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -43,6 +43,7 @@ import Cardano.Ledger.Babbage.PParams
   )
 import Cardano.Ledger.Babbage.Tx (ValidatedTx (..), minfee)
 import Cardano.Ledger.Babbage.TxBody (Datum (..), TxBody, TxOut (TxOut), getBabbageTxOutEitherAddr)
+import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import Cardano.Ledger.BaseTypes (BlocksMade (..))
 import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
@@ -220,6 +221,9 @@ instance CC.Crypto c => EraModule.SupportsSegWit (BabbageEra c) where
   numSegComponents = 4
 
 instance API.ShelleyEraCrypto c => API.ShelleyBasedEra (BabbageEra c)
+
+instance CC.Crypto c => HasTxInfo (BabbageEra c) where
+  txInfo = babbageTxInfo
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -987,5 +987,5 @@ txOutDataHash = \case
 
 txOutScript :: TxOut era -> Maybe (Core.Script era)
 txOutScript = \case
-  TxOutCompactRefScript' _ _ _ s -> Just $! s
+  TxOutCompactRefScript' _ _ _ s -> Just s
   _ -> Nothing

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -1,0 +1,239 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Babbage.TxInfo where
+
+import Cardano.Crypto.Hash.Class (hashToBytes)
+import Cardano.Ledger.Alonzo.Data (getPlutusData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.Tx (Data, DataHash, rdptrInv)
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..), VersionedTxInfo (..))
+import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr, TxWitness (..), unRedeemers, unTxDats)
+import Cardano.Ledger.BaseTypes (ProtVer (..), StrictMaybe (..))
+import Cardano.Ledger.Core as Core (PParams, Script, Tx, TxBody, TxOut, Value)
+import Cardano.Ledger.Era (Era (..), ValidateScript (..))
+import Cardano.Ledger.Hashes (EraIndependentData)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness))
+import qualified Cardano.Ledger.Mary.Value as Mary (Value (..))
+import Cardano.Ledger.SafeHash
+import Cardano.Ledger.Shelley.Scripts (ScriptHash (..))
+import Cardano.Ledger.Shelley.TxBody
+  ( DCert (..),
+    Wdrl (..),
+  )
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.Val (Val (..))
+import Cardano.Slotting.EpochInfo (EpochInfo)
+import Cardano.Slotting.Time (SystemStart)
+import qualified Data.Compact.SplitMap as SplitMap
+import qualified Data.Map as Map
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Records (HasField (..))
+import qualified Plutus.V1.Ledger.Api as PV1
+import Plutus.V1.Ledger.Contexts ()
+import qualified Plutus.V2.Ledger.Api as PV2
+
+transScriptHash :: ScriptHash c -> PV2.ScriptHash
+transScriptHash (ScriptHash h) = PV2.ScriptHash (PV2.toBuiltin (hashToBytes h))
+
+transReferenceScript :: forall era. ValidateScript era => StrictMaybe (Core.Script era) -> Maybe PV2.ScriptHash
+transReferenceScript SNothing = Nothing
+transReferenceScript (SJust s) = Just . transScriptHash . hashScript @era $ s
+
+-- | Given a TxOut, translate it for V2 and return (Right transalation).
+-- If the transaction contains any Byron addresses or Babbage features, return Left.
+txInfoOutV1 ::
+  forall era.
+  ( Era era,
+    ValidateScript era,
+    Value era ~ Mary.Value (Crypto era),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
+    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
+    HasField "referenceScript" (Core.TxOut era) (StrictMaybe (Core.Script era))
+  ) =>
+  Core.TxOut era ->
+  Either TranslationError PV1.TxOut
+txInfoOutV1 txout =
+  let val = getField @"value" txout
+      datahash = getField @"datahash" txout
+      inlineDatum = getField @"datum" txout
+      referenceScript = transReferenceScript @era $ getField @"referenceScript" txout
+   in case (Alonzo.transTxOutAddr txout, inlineDatum, referenceScript) of
+        (Nothing, _, _) -> Left ByronOutputInContext
+        (_, SJust _, _) -> Left InlineDatumsNotSupported
+        (_, _, Just _) -> Left ReferenceScriptsNotSupported
+        (Just ad, SNothing, Nothing) ->
+          Right (PV1.TxOut ad (Alonzo.transValue @(Crypto era) val) (Alonzo.transDataHash datahash))
+
+-- | Given a TxOut, translate it for V2 and return (Right transalation). It is
+--   possible the address part is a Bootstrap Address, in that case return Left.
+txInfoOutV2 ::
+  forall era.
+  ( Era era,
+    ValidateScript era,
+    Value era ~ Mary.Value (Crypto era),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
+    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
+    HasField "referenceScript" (Core.TxOut era) (StrictMaybe (Core.Script era))
+  ) =>
+  Core.TxOut era ->
+  Either TranslationError PV2.TxOut
+txInfoOutV2 txout =
+  let val = getField @"value" txout
+      d = case (getField @"datahash" txout, getField @"datum" txout) of
+        (SNothing, SNothing) -> Right PV2.NoOutputDatum
+        (SJust dh, SNothing) -> Right . PV2.OutputDatumHash $ Alonzo.transDataHash' dh
+        (SNothing, SJust d') ->
+          Right . PV2.OutputDatum . PV2.Datum . PV2.dataToBuiltinData . getPlutusData $ d'
+        (SJust _, SJust _) -> Left TranslationLogicErrorDoubleDatum
+      referenceScript = transReferenceScript @era $ getField @"referenceScript" txout
+   in case (Alonzo.transTxOutAddr txout, d) of
+        (_, Left e) -> Left e
+        (Nothing, _) -> Left ByronOutputInContext
+        (Just ad, Right d') ->
+          Right (PV2.TxOut ad (Alonzo.transValue @(Crypto era) val) d' referenceScript)
+
+-- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V1 context
+--   and return (Just translation). If does not exist in the UTxO, return Nothing.
+txInfoInV1 ::
+  forall era.
+  ( ValidateScript era,
+    Value era ~ Mary.Value (Crypto era),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
+    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
+    HasField "referenceScript" (Core.TxOut era) (StrictMaybe (Core.Script era))
+  ) =>
+  UTxO era ->
+  TxIn (Crypto era) ->
+  Either TranslationError PV1.TxInInfo
+txInfoInV1 (UTxO mp) txin =
+  case SplitMap.lookup txin mp of
+    Nothing -> Left TranslationLogicErrorInput
+    Just txout -> do
+      out <- txInfoOutV1 txout
+      Right (PV1.TxInInfo (Alonzo.txInfoIn' txin) out)
+
+-- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V2 context
+--   and return (Just translation). If does not exist in the UTxO, return Nothing.
+txInfoInV2 ::
+  forall era.
+  ( ValidateScript era,
+    Value era ~ Mary.Value (Crypto era),
+    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
+    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
+    HasField "referenceScript" (Core.TxOut era) (StrictMaybe (Core.Script era))
+  ) =>
+  UTxO era ->
+  TxIn (Crypto era) ->
+  Either TranslationError PV2.TxInInfo
+txInfoInV2 (UTxO mp) txin =
+  case SplitMap.lookup txin mp of
+    Nothing -> Left TranslationLogicErrorInput
+    Just txout -> do
+      out <- txInfoOutV2 txout
+      Right (PV2.TxInInfo (Alonzo.txInfoIn' txin) out)
+
+transRedeemer :: Data era -> PV2.Redeemer
+transRedeemer = PV2.Redeemer . PV2.dataToBuiltinData . getPlutusData
+
+transRedeemerPtr ::
+  ( Era era,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era)))
+  ) =>
+  (Core.TxBody era) ->
+  (RdmrPtr, (Data era, ExUnits)) ->
+  Either TranslationError (PV2.ScriptPurpose, PV2.Redeemer)
+transRedeemerPtr txb (ptr, (d, _)) =
+  case rdptrInv txb ptr of
+    SNothing -> Left TranslationLogicErrorRedeemer
+    SJust sp -> Right (Alonzo.transScriptPurpose sp, transRedeemer d)
+
+babbageTxInfo ::
+  forall era m.
+  ( Era era,
+    ValidateScript era,
+    Monad m,
+    Value era ~ Mary.Value (Crypto era),
+    HasField "wits" (Core.Tx era) (TxWitness era),
+    HasField "datahash" (TxOut era) (StrictMaybe (SafeHash (Crypto era) EraIndependentData)),
+    HasField "datum" (TxOut era) (StrictMaybe (Data era)),
+    HasField "referenceScript" (TxOut era) (StrictMaybe (Core.Script era)),
+    HasField "_protocolVersion" (PParams era) ProtVer,
+    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "referenceInputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    HasField "reqSignerHashes" (Core.TxBody era) (Set (KeyHash 'Witness (Crypto era))),
+    HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
+    HasField "mint" (Core.TxBody era) (Mary.Value (Crypto era)),
+    HasField "vldt" (Core.TxBody era) ValidityInterval
+  ) =>
+  Core.PParams era ->
+  Language ->
+  EpochInfo m ->
+  SystemStart ->
+  UTxO era ->
+  Core.Tx era ->
+  m (Either TranslationError VersionedTxInfo)
+babbageTxInfo pp lang ei sysS utxo tx = do
+  timeRange <- Alonzo.transVITime pp ei sysS interval
+  pure $
+    case lang of
+      PlutusV1 -> do
+        inputs <- mapM (txInfoInV1 utxo) (Set.toList (getField @"inputs" tbody))
+        outputs <- mapM txInfoOutV1 (foldr (:) [] outs)
+        pure . TxInfoPV1 $
+          PV1.TxInfo
+            { PV1.txInfoInputs = inputs,
+              PV1.txInfoOutputs = outputs,
+              PV1.txInfoFee = Alonzo.transValue (inject @(Mary.Value (Crypto era)) fee),
+              PV1.txInfoMint = Alonzo.transValue forge,
+              PV1.txInfoDCert = foldr (\c ans -> Alonzo.transDCert c : ans) [] (getField @"certs" tbody),
+              PV1.txInfoWdrl = Map.toList (Alonzo.transWdrl (getField @"wdrls" tbody)),
+              PV1.txInfoValidRange = timeRange,
+              PV1.txInfoSignatories = map Alonzo.transKeyHash (Set.toList (getField @"reqSignerHashes" tbody)),
+              PV1.txInfoData = map Alonzo.transDataPair datpairs,
+              PV1.txInfoId = PV1.TxId (Alonzo.transSafeHash (hashAnnotated @(Crypto era) tbody))
+            }
+      PlutusV2 -> do
+        inputs <- mapM (txInfoInV2 utxo) (Set.toList (getField @"inputs" tbody))
+        refInputs <- mapM (txInfoInV2 utxo) (Set.toList (getField @"referenceInputs" tbody))
+        outputs <- mapM txInfoOutV2 (foldr (:) [] outs)
+        rdmrs' <- mapM (transRedeemerPtr tbody) rdmrs
+        pure . TxInfoPV2 $
+          PV2.TxInfo
+            { PV2.txInfoInputs = inputs,
+              PV2.txInfoOutputs = outputs,
+              PV2.txInfoReferenceInputs = refInputs,
+              PV2.txInfoFee = Alonzo.transValue (inject @(Mary.Value (Crypto era)) fee),
+              PV2.txInfoMint = Alonzo.transValue forge,
+              PV2.txInfoDCert = foldr (\c ans -> Alonzo.transDCert c : ans) [] (getField @"certs" tbody),
+              PV2.txInfoWdrl = PV2.fromList $ Map.toList (Alonzo.transWdrl (getField @"wdrls" tbody)),
+              PV2.txInfoValidRange = timeRange,
+              PV2.txInfoSignatories = map Alonzo.transKeyHash (Set.toList (getField @"reqSignerHashes" tbody)),
+              PV2.txInfoRedeemers = PV2.fromList rdmrs',
+              PV2.txInfoData = PV2.fromList $ map Alonzo.transDataPair datpairs,
+              PV2.txInfoId = PV2.TxId (Alonzo.transSafeHash (hashAnnotated @(Crypto era) tbody))
+            }
+  where
+    tbody :: Core.TxBody era
+    tbody = getField @"body" tx
+    witnesses = getField @"wits" tx
+    outs = getField @"outputs" tbody
+    fee = getField @"txfee" tbody
+    forge = getField @"mint" tbody
+    interval = getField @"vldt" tbody
+
+    datpairs = Map.toList (unTxDats $ txdats' witnesses)
+    rdmrs = Map.toList (unRedeemers $ txrdmrs' witnesses)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -10,7 +10,6 @@ module Cardano.Ledger.Shelley.HardForks
     translateTimeForPlutusScripts,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
-    failInPresenceOfByronAddress,
   )
 where
 
@@ -76,11 +75,3 @@ forgoRewardPrefilter ::
   pp ->
   Bool
 forgoRewardPrefilter pp = pvMajor (getField @"_protocolVersion" pp) > 6
-
--- | Starting with protocol version 7, Plutus V1 scripts will fail if the transaction
--- it is included in contains a Byron address.
-failInPresenceOfByronAddress ::
-  (HasField "_protocolVersion" pp ProtVer) =>
-  pp ->
-  Bool
-failInPresenceOfByronAddress pp = pvMajor (getField @"_protocolVersion" pp) > 6

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -22,7 +22,7 @@ module Test.Cardano.Ledger.Generic.Properties where
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data, DataHash, binaryDataToData, hashData)
-import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
+import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeeded)
 import Cardano.Ledger.Alonzo.Scripts
@@ -111,7 +111,7 @@ import Data.Functor
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes, fromJust, mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Monoid (All (..))
 import Data.Ratio ((%))
@@ -122,7 +122,6 @@ import Data.UMap (View (Rewards))
 import qualified Data.UMap as UM
 import GHC.Stack
 import Numeric.Natural
-import Plutus.V1.Ledger.Api (defaultCostModelParams)
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Generic.Fields hiding (Mint)
@@ -602,7 +601,7 @@ genPlutusScript proof tag = do
         | otherwise = 2
   -- While using varying number of arguments for alwaysSucceeds we get
   -- varying script hashes, which helps with the fuzziness
-  language <- lift $ elements (Set.toList nonNativeLanguages)
+  language <- lift $ elements (languages proof)
   script <-
     if isValid
       then alwaysSucceeds @era language . (+ numArgs) . getNonNegative <$> lift arbitrary
@@ -1211,11 +1210,7 @@ genTxAndLEDGERState proof = do
           proof
           [ MinfeeA minfeeA,
             MinfeeB minfeeB,
-            Costmdls $
-              Map.fromList
-                [ (PlutusV1, CostModel $ 0 <$ fromJust defaultCostModelParams),
-                  (PlutusV2, CostModel $ 0 <$ fromJust defaultCostModelParams)
-                ],
+            defaultCostModels proof,
             MaxValSize 1000,
             MaxTxSize $ fromIntegral (maxBound :: Int),
             MaxTxExUnits maxTxExUnits,
@@ -1293,11 +1288,7 @@ setup proof = do
           proof
           [ MinfeeA minfeeA,
             MinfeeB minfeeB,
-            Costmdls $
-              Map.fromList
-                [ (PlutusV1, CostModel $ 0 <$ fromJust defaultCostModelParams),
-                  (PlutusV2, CostModel $ 0 <$ fromJust defaultCostModelParams)
-                ],
+            defaultCostModels proof,
             MaxValSize 1000,
             MaxTxSize $ fromIntegral (maxBound :: Int),
             MaxTxExUnits maxTxExUnits,


### PR DESCRIPTION
The use of Plutus V2 is no longer tied to the protocol major version 7, but instead the Babbage era. Moreover, the transaction context for Plutus V2 now includes Babbage specific data, and V2 is now forbidden in the Alonzo era.

The `txInfo` function from the Alonzo era is now a class method, enabling different eras to have different behavior.

closes #2663 