### PR TITLE
Improve performance txout with benchmarks

### DIFF
--- a/eras/alonzo/formal-spec/utxo.tex
+++ b/eras/alonzo/formal-spec/utxo.tex
@@ -19,7 +19,7 @@
     & \fun{feesOK}~\var{pp}~tx~utxo~= \\
     &~~      \minfee{pp}~{tx} \leq \txfee{txb} \wedge (\fun{txrdmrs}~tx \neq \emptyset \Rightarrow \\
     &~~~~~~((\forall (a, \wcard, \wcard) \in \fun{range}~(\fun{collateral}~{txb} \restrictdom \var{utxo}), a \in \AddrVKey) \\
-    &~~~~~~\wedge~ \fun{adaOnly}~\var{balance} \\
+    &~~~~~~\wedge~ \fun{isAdaOnly}~\var{balance} \\
     &~~~~~~\wedge~ \var{balance}*100 \geq \txfee{txb} * (\fun{collateralPercent}~pp) \\
     &~~~~~~\wedge~ \fun{collateral}~{tx} \neq \emptyset) \\
     &~~      \where \\

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -324,7 +324,7 @@ validateCollateral pp txb utxoCollateral bal =
       validateScriptsNotPaidUTxO utxoCollateral,
       -- Part 4: balance ∗ 100 ≥ txfee txb ∗ (collateralPercent pp)
       validateInsufficientCollateral pp txb bal,
-      -- Part 5: adaOnly balance
+      -- Part 5: isAdaOnly balance
       validateCollateralContainsNonADA bal,
       -- Part 6: (∀(a,_,_) ∈ range (collateral txb ◁ utxo), a ∈ Addrvkey)
       failureIf (null utxoCollateral) NoCollateralInputs
@@ -358,13 +358,13 @@ validateInsufficientCollateral pp txb bal =
     txfee = getField @"txfee" txb -- Coin supplied to pay fees
     collPerc = getField @"_collateralPercentage" pp
 
--- > adaOnly balance
+-- > isAdaOnly balance
 validateCollateralContainsNonADA ::
   Val.Val (Core.Value era) =>
   Core.Value era ->
   Validation (NonEmpty (UtxoPredicateFailure era)) ()
 validateCollateralContainsNonADA bal =
-  failureUnless (Val.inject (Val.coin bal) == bal) $ CollateralContainsNonADA bal
+  failureUnless (Val.isAdaOnly bal) $ CollateralContainsNonADA bal
 
 -- | If tx has non-native scripts, end of validity interval must translate to time
 --

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -905,7 +905,7 @@ getAlonzoTxOutEitherAddr = \case
     | otherwise -> error addressErrorMsg
   TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra _ _
     | Just addr <- decodeAddress28 stakeRef addr28Extra -> Left addr
-  _ -> error addressErrorMsg
+    | otherwise -> error addressErrorMsg
 
 addressErrorMsg :: String
 addressErrorMsg = "Impossible: Compacted an address of non-standard size"

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary (pattern AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.Ledger.Val (Val (coin), adaOnly, (<+>), (<×>))
+import Cardano.Ledger.Val (Val (coin, isAdaOnly, (<+>), (<×>)))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad (replicateM)
 import qualified Data.ByteString.Char8 as BS
@@ -112,7 +112,7 @@ import Test.QuickCheck hiding ((><))
 
 -- | We are choosing new TxOut to pay fees, We want only Key locked addresss with Ada only values.
 vKeyLockedAdaOnly :: Mock c => Core.TxOut (AlonzoEra c) -> Bool
-vKeyLockedAdaOnly txout = vKeyLocked txout && adaOnly (getField @"value" txout)
+vKeyLockedAdaOnly txout = vKeyLocked txout && isAdaOnly (getField @"value" txout)
 
 phase2scripts3Arg :: forall c. Mock c => [TwoPhase3ArgInfo (AlonzoEra c)]
 phase2scripts3Arg =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -130,7 +130,6 @@ import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val
   ( DecodeNonNegative,
     Val (..),
-    adaOnly,
     decodeMint,
     decodeNonNegative,
     encodeMint,
@@ -336,10 +335,8 @@ pattern TxOutCompact addr vl <-
   (viewCompactTxOut -> (addr, vl, NoDatum, SNothing))
   where
     TxOutCompact cAddr cVal
-      | adaOnly value = TxOut (decompactAddr cAddr) value NoDatum SNothing
+      | isAdaOnlyCompact cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) NoDatum SNothing
       | otherwise = TxOutCompact' cAddr cVal
-      where
-        value = fromCompact cVal
 
 pattern TxOutCompactDH ::
   ( Era era,
@@ -353,10 +350,8 @@ pattern TxOutCompactDH addr vl dh <-
   (viewCompactTxOut -> (addr, vl, DatumHash dh, SNothing))
   where
     TxOutCompactDH cAddr cVal dh
-      | adaOnly value = TxOut (decompactAddr cAddr) value (DatumHash dh) SNothing
+      | isAdaOnlyCompact cVal = TxOut (decompactAddr cAddr) (fromCompact cVal) (DatumHash dh) SNothing
       | otherwise = TxOutCompactDH' cAddr cVal dh
-      where
-        value = fromCompact cVal
 
 {-# COMPLETE TxOutCompact, TxOutCompactDH #-}
 

--- a/eras/shelley-ma/formal-spec/utxo.tex
+++ b/eras/shelley-ma/formal-spec/utxo.tex
@@ -33,13 +33,13 @@
     & \fun{ubalance} \in \UTxO \to \hldiff{\ValMonoid} \\
     & \fun{ubalance} ~ utxo = \hldiff{\sum_{\wcard\mapsto\var{u}\in~\var{utxo}} \fun{getValue}~\var{u}}
     \nextdef
-    & \fun{adaOnly} ~\in~ \mathsf{ValType} \to \Bool \\
-    & \fun{adaOnly}~v = v \in \range \fun{inject}
+    & \fun{isAdaOnly} ~\in~ \mathsf{ValType} \to \Bool \\
+    & \fun{isAdaOnly}~v = v \in \range \fun{inject}
     \nextdef
     & \fun{scaledMinDeposit} \in \ValMonoid \to \Coin \to \Coin \\
     & \fun{scaledMinDeposit}~\var{v}~\var{mv} ~=~
     \begin{cases}
-      \var{mv} & \fun{adaOnly}~v \\
+      \var{mv} & \fun{isAdaOnly}~v \\
       \fun{max}~(\var{mv},~\fun{utxoEntrySize}~{v} * \fun{coinsPerUTxOWord}~mv)) & \text{otherwise}
     \end{cases}
   \end{align*}

--- a/eras/shelley-ma/formal-spec/value-size.tex
+++ b/eras/shelley-ma/formal-spec/value-size.tex
@@ -107,7 +107,7 @@ of the size of a UTxO entry, and the associated min-Ada-value.
     & \fun{size} \in \Value_C \to \MemoryEstimate \\
     & \fun{size}~\var{vl} ~=~
     \begin{cases}
-      k_0 & \fun{adaOnly}~vl\\
+      k_0 & \fun{isAdaOnly}~vl\\
       k_1 + \lfloor~ (((\fun{numAssets}~vl) * k_2) + (\fun{sumALs}~vl) & \\
       ~~~~~~ + ((\fun{numPids}~vl) * k_3) + (k_4 - 1)))~ /~ k_4~\rfloor & \text{otherwise} \\
     \end{cases} \\

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -39,7 +40,7 @@ import Cardano.Binary
     toCBOR,
   )
 import qualified Cardano.Crypto.Hash.Class as Hash
-import Cardano.Ledger.Coin (Coin (..), integerToWord64)
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..), integerToWord64)
 import Cardano.Ledger.Compactible (Compactible (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Serialization (decodeMap, encodeMap)
@@ -181,6 +182,14 @@ instance CC.Crypto crypto => Val (Value crypto) where
         ( roundupBytesToWords (representationSize (snd $ gettriples vv))
             + repOverhead
         )
+
+  isAdaOnly (Value _ v) = Map.null v
+
+  isAdaOnlyCompact = \case
+    CompactValue (CompactValueAdaOnly _) -> True
+    CompactValue (CompactValueMultiAsset {}) -> False
+
+  injectCompact = CompactValue . CompactValueAdaOnly
 
 -- space (in Word64s) taken up by the ada amount
 adaWords :: Int
@@ -351,9 +360,9 @@ instance CC.Crypto crypto => FromCBOR (CompactValue crypto) where
       Just x -> pure x
 
 data CompactValue crypto
-  = CompactValueAdaOnly {-# UNPACK #-} !Word64
+  = CompactValueAdaOnly {-# UNPACK #-} !(CompactForm Coin)
   | CompactValueMultiAsset
-      {-# UNPACK #-} !Word64 -- ada
+      {-# UNPACK #-} !(CompactForm Coin) -- ada
       {-# UNPACK #-} !Word32 -- number of ma's
       {-# UNPACK #-} !ShortByteString -- rep
   deriving (Show, Typeable)
@@ -483,7 +492,7 @@ to ::
   Maybe (CompactValue crypto)
 to (Value ada ma)
   | Map.null ma =
-    CompactValueAdaOnly <$> integerToWord64 ada
+    CompactValueAdaOnly . CompactCoin <$> integerToWord64 ada
 to v = do
   c <- integerToWord64 ada
   -- Here we convert the (pid, assetName, quantity) triples into
@@ -494,7 +503,7 @@ to v = do
   preparedTriples <-
     zip [0 ..] . sortOn (\(_, x, _) -> x) <$> traverse prepare triples
   pure $
-    CompactValueMultiAsset c (fromIntegral numTriples) $
+    CompactValueMultiAsset (CompactCoin c) (fromIntegral numTriples) $
       runST $ do
         byteArray <- BA.newByteArray repSize
         forM_ preparedTriples $ \(i, (pidoff, anoff, q)) ->
@@ -618,8 +627,8 @@ representationSize xs = abcRegionSize + pidBlockSize + anameBlockSize
       Semigroup.getSum $ foldMap' (Semigroup.Sum . BS.length . assetName) assetNames
 
 from :: forall crypto. (CC.Crypto crypto) => CompactValue crypto -> Value crypto
-from (CompactValueAdaOnly c) = Value (fromIntegral c) mempty
-from (CompactValueMultiAsset c numAssets rep) =
+from (CompactValueAdaOnly (CompactCoin c)) = Value (fromIntegral c) mempty
+from (CompactValueMultiAsset (CompactCoin c) numAssets rep) =
   valueFromList (fromIntegral c) triples
   where
     n = fromIntegral numAssets

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -83,6 +83,13 @@ instance Compactible Coin where
   toCompact (Coin c) = CompactCoin <$> integerToWord64 c
   fromCompact (CompactCoin c) = word64ToCoin c
 
+instance Compactible DeltaCoin where
+  newtype CompactForm DeltaCoin = CompactDeltaCoin Word64
+    deriving (Eq, Show, NoThunks, NFData, Typeable, HeapWords, Prim)
+
+  toCompact (DeltaCoin dc) = CompactDeltaCoin <$> integerToWord64 dc
+  fromCompact (CompactDeltaCoin cdc) = DeltaCoin (unCoin (word64ToCoin cdc))
+
 -- It's odd for this to live here. Where should it go?
 integerToWord64 :: Integer -> Maybe Word64
 integerToWord64 c
@@ -96,3 +103,9 @@ instance ToCBOR (CompactForm Coin) where
 
 instance FromCBOR (CompactForm Coin) where
   fromCBOR = CompactCoin <$> fromCBOR
+
+instance ToCBOR (CompactForm DeltaCoin) where
+  toCBOR (CompactDeltaCoin c) = toCBOR c
+
+instance FromCBOR (CompactForm DeltaCoin) where
+  fromCBOR = CompactDeltaCoin <$> fromCBOR

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -46,6 +47,7 @@ import Cardano.Ledger.Hashes (ScriptHash (..))
 import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Prelude (Text, cborError, panic)
+import Control.DeepSeq (NFData)
 import Control.Monad (ap)
 import qualified Control.Monad.Fail
 import Data.Bits (testBit, (.&.))
@@ -57,7 +59,7 @@ import qualified Data.Primitive.ByteArray as BA
 import Data.Word (Word64, Word8)
 
 newtype CompactAddr crypto = UnsafeCompactAddr ShortByteString
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, NFData)
 
 instance CC.Crypto c => Show (CompactAddr c) where
   show c = show (decompactAddr c)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
@@ -21,8 +21,9 @@ module Cardano.Ledger.Val
 where
 
 import Cardano.Binary (Decoder, Encoding, decodeWord64, toCBOR)
-import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (..))
+import Data.Coerce
 import Data.Foldable (foldl')
 import Data.Group (Abelian)
 
@@ -66,6 +67,12 @@ class
   -- | If a quantity is stored in only one of 'v1' or 'v2', we use 0 for the missing quantity.
   pointwise :: (Integer -> Integer -> Bool) -> t -> t -> Bool
 
+  isAdaOnly :: t -> Bool
+
+  isAdaOnlyCompact :: CompactForm t -> Bool
+
+  injectCompact :: CompactForm Coin -> CompactForm t
+
 -- =============================================================
 -- Synonyms with types fixed at (Val t). Makes calls easier
 -- to read, and gives better error messages, when a mistake is made
@@ -88,6 +95,7 @@ invert x = (-1 :: Integer) <×> x
 -- returns a Value containing only the coin (ada) tokens from the input Value
 adaOnly :: Val v => v -> Bool
 adaOnly v = (inject . coin) v == v
+{-# DEPRECATED adaOnly "In favor of `isAdaOnly`" #-}
 
 instance Val Coin where
   n <×> (Coin x) = Coin $ fromIntegral n * x
@@ -96,8 +104,20 @@ instance Val Coin where
   size _ = 1
   modifyCoin f v = f v
   pointwise p (Coin x) (Coin y) = p x y
+  isAdaOnly _ = True
+  isAdaOnlyCompact _ = True
+  injectCompact = id
 
-deriving via Coin instance Val DeltaCoin
+instance Val DeltaCoin where
+  n <×> (DeltaCoin x) = DeltaCoin $ fromIntegral n * x
+  coin = coerce
+  inject = coerce
+  size _ = 1
+  modifyCoin f v = coerce f v
+  pointwise p (DeltaCoin x) (DeltaCoin y) = p x y
+  isAdaOnly _ = True
+  isAdaOnlyCompact _ = True
+  injectCompact (CompactCoin cc) = CompactDeltaCoin cc
 
 -- =============================================================
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
@@ -67,6 +67,9 @@ class
   -- | If a quantity is stored in only one of 'v1' or 'v2', we use 0 for the missing quantity.
   pointwise :: (Integer -> Integer -> Bool) -> t -> t -> Bool
 
+  -- | Check if value contains only ADA. Must hold property:
+  --
+  -- > inject (coin v) == v
   isAdaOnly :: t -> Bool
 
   isAdaOnlyCompact :: CompactForm t -> Bool

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
@@ -52,7 +52,7 @@ benchTxOut =
       txOutAddrAdaOnlyDataHash :: Int -> TxOut A
       txOutAddrAdaOnlyDataHash n = TxOut (addr n) ada (SJust dataHash32)
       count :: Int
-      count = 10000
+      count = 1000
    in bgroup
         "TxOut"
         [ bgroup
@@ -132,7 +132,7 @@ serializeTxOutAlonzoBench count name mkTxOuts =
     name
     [ env (pure (mkTxOuts <$> [1 .. count])) $ bench "ToCBOR" . nf (map serialize),
       env (pure (serialize . mkTxOuts <$> [1 .. count])) $
-      bench "FromCBOR" . nf (map (either (error . show) (id @(TxOut A)) . decodeFull))
+        bench "FromCBOR" . nf (map (either (error . show) (id @(TxOut A)) . decodeFull))
     ]
 
 payAddr28 :: Int -> KeyHash 'Payment StandardCrypto

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Bench.Cardano.Ledger.TxOut (benchTxOut) where
+
+import Cardano.Binary (decodeFull, serialize)
+import Cardano.Crypto.Hash.Class
+import Cardano.Ledger.Address
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data
+import Cardano.Ledger.Alonzo.TxBody
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin
+import Cardano.Ledger.CompactAddress
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Era (getTxOutAddr)
+import Cardano.Ledger.Hashes
+import Cardano.Ledger.Keys
+import Cardano.Ledger.Mary.Value
+import Cardano.Ledger.SafeHash
+import Cardano.Ledger.Val
+import Control.DeepSeq
+import Criterion.Main
+import Data.Map.Strict (singleton)
+import Data.Maybe
+import qualified Data.Text as T
+import GHC.Records
+
+type A = AlonzoEra StandardCrypto
+
+benchTxOut :: Benchmark
+benchTxOut =
+  let ada :: Value StandardCrypto
+      ada = inject (Coin 100)
+      key :: Int -> Credential 'Payment StandardCrypto
+      key = KeyHashObj . payAddr28
+      stake :: StakeReference StandardCrypto
+      stake = StakeRefBase (KeyHashObj stakeAddr28)
+      addr :: Int -> Addr StandardCrypto
+      addr n = Addr Mainnet (key n) stake
+      value :: Value StandardCrypto
+      value = Value 200 (singleton (PolicyID policyId28) (singleton assName 217))
+      txOutAddr :: Int -> TxOut A
+      txOutAddr n = TxOut (addr n) value (SJust dataHash32)
+      txOutAddrAdaOnly :: Int -> TxOut A
+      txOutAddrAdaOnly n = TxOut (addr n) ada SNothing
+      txOutAddrAdaOnlyDataHash :: Int -> TxOut A
+      txOutAddrAdaOnlyDataHash n = TxOut (addr n) ada (SJust dataHash32)
+      count :: Int
+      count = 10000
+   in bgroup
+        "TxOut"
+        [ bgroup
+            "construct"
+            [ constructTxOutAlonzoBench count "ValueDataHash" addr value (SJust dataHash32),
+              constructTxOutAlonzoBench count "AdaOnlyDataHash" addr ada (SJust dataHash32),
+              constructTxOutAlonzoBench count "AdaOnly" addr ada SNothing
+            ],
+          bgroup
+            "access"
+            [ accessTxOutAlonzoBench count "ValueDataHash" txOutAddr,
+              accessTxOutAlonzoBench count "AdaOnlyDataHash" txOutAddrAdaOnlyDataHash,
+              accessTxOutAlonzoBench count "AdaOnly" txOutAddrAdaOnly
+            ],
+          bgroup
+            "serialize"
+            [ serializeTxOutAlonzoBench count "ValueDataHash" txOutAddr,
+              serializeTxOutAlonzoBench count "AdaOnlyDataHash" txOutAddrAdaOnlyDataHash,
+              serializeTxOutAlonzoBench count "AdaOnly" txOutAddrAdaOnly
+            ]
+        ]
+
+constructTxOutAlonzoBench ::
+  Int ->
+  String ->
+  (Int -> Addr StandardCrypto) ->
+  Value StandardCrypto ->
+  StrictMaybe (DataHash StandardCrypto) ->
+  Benchmark
+constructTxOutAlonzoBench count name mkAddr value !mdh =
+  cvalue
+    `seq` bgroup
+      name
+      [ env (pure (mkAddr <$> [1 .. count])) $
+          bench "TxOut" . nf (map (\addr -> TxOut addr value mdh :: TxOut A)),
+        env (pure (compactAddr . mkAddr <$> [1 .. count])) $
+          bench "TxOutCompact" . nf (map (\caddr -> mkTxOutCompact caddr cvalue :: TxOut A))
+      ]
+  where
+    cvalue = maybe (error "Uncompactible") id $ toCompact value
+    mkTxOutCompact ::
+      CompactAddr StandardCrypto -> CompactForm (Value StandardCrypto) -> TxOut A
+    mkTxOutCompact =
+      case mdh of
+        SNothing -> TxOutCompact
+        SJust dh -> \a v -> TxOutCompactDH a v dh
+
+accessTxOutAlonzoBench :: Int -> String -> (Int -> TxOut A) -> Benchmark
+accessTxOutAlonzoBench count name mkTxOuts =
+  bgroup
+    name
+    [ env (pure (mkTxOuts <$> [1 .. count])) $ \txOuts ->
+        bench "TxOut" $
+          nf (map (\(TxOut addr vl dh) -> addr `deepseq` vl `deepseq` dh)) txOuts,
+      env (pure (mkTxOuts <$> [1 .. count])) $ \txOuts ->
+        bench "TxOutCompact" $
+          nf
+            ( map
+                ( \case
+                    TxOutCompact addr vl -> addr `deepseq` vl
+                    TxOutCompactDH addr vl dh -> addr `deepseq` dh `deepseq` vl
+                )
+            )
+            txOuts,
+      env (pure (mkTxOuts <$> [1 .. count])) $ \txOuts ->
+        bench "getTxOutAddr" $
+          nf
+            (map getTxOutAddr)
+            txOuts,
+      env (pure (mkTxOuts <$> [1 .. count])) $ \txOuts ->
+        bench "getField value" $ nf (map (getField @"value")) txOuts
+    ]
+
+serializeTxOutAlonzoBench :: Int -> String -> (Int -> TxOut A) -> Benchmark
+serializeTxOutAlonzoBench count name mkTxOuts =
+  bgroup
+    name
+    [ env (pure (mkTxOuts <$> [1 .. count])) $ bench "ToCBOR" . nf (map serialize),
+      env (pure (serialize . mkTxOuts <$> [1 .. count])) $
+      bench "FromCBOR" . nf (map (either (error . show) (id @(TxOut A)) . decodeFull))
+    ]
+
+payAddr28 :: Int -> KeyHash 'Payment StandardCrypto
+payAddr28 n =
+  let i = n `mod` 10
+      prefix = T.pack (take 6 (cycle (show i)))
+   in KeyHash $
+        fromJust $
+          hashFromTextAsHex
+            (prefix <> "0405060708090a0b0c0d0e0f12131415161718191a1b1c1d1e")
+
+stakeAddr28 :: KeyHash 'Staking StandardCrypto
+stakeAddr28 =
+  KeyHash $
+    fromJust $
+      hashFromTextAsHex "2122232425262728292a2b2c2d2e2f32333435363738393a3b3c3d3e"
+
+dataHash32 :: DataHash StandardCrypto
+dataHash32 =
+  unsafeMakeSafeHash $
+    fromJust $
+      hashFromTextAsHex "404144434445464748494a4b4c4d4e4f505152555455565758595a5b5c5d5e5f"
+
+policyId28 :: ScriptHash StandardCrypto
+policyId28 =
+  ScriptHash $
+    fromJust $
+      hashFromTextAsHex "6166636465666768696a6b6c6d6e6f72777475767778797a7b7c7d7e"
+
+assName :: AssetName
+assName = AssetName "Booyah"

--- a/libs/cardano-ledger-test/bench/Main.hs
+++ b/libs/cardano-ledger-test/bench/Main.hs
@@ -5,12 +5,14 @@ import qualified Bench.Cardano.Ledger.Balance as Balance
 import qualified Bench.Cardano.Ledger.EpochBoundary as Epoch
 import qualified Bench.Cardano.Ledger.Serialisation.Generators as SerGen
 import qualified Bench.Cardano.Ledger.SumStake as SumStake
+import qualified Bench.Cardano.Ledger.TxOut as TxOut
 import Criterion.Main (defaultMain)
 
 main :: IO ()
 main =
   defaultMain
-    [ SerGen.benchTxGeneration,
+    [ TxOut.benchTxOut,
+      SerGen.benchTxGeneration,
       ApplyTx.applyTxBenchmarks,
       Epoch.aggregateUtxoBench,
       SumStake.sumStakeBenchmarks,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -170,6 +170,7 @@ benchmark bench
     Bench.Cardano.Ledger.EpochBoundary
     Bench.Cardano.Ledger.Serialisation.Generators
     Bench.Cardano.Ledger.SumStake
+    Bench.Cardano.Ledger.TxOut
   build-depends:
     bytestring,
     cardano-binary,
@@ -190,7 +191,8 @@ benchmark bench
     cardano-ledger-shelley-test,
     random,
     small-steps,
-    small-steps-test
+    small-steps-test,
+    text
   ghc-options:
       -threaded
       -rtsopts

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/TxOut.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/TxOut.hs
@@ -112,5 +112,5 @@ modelUTxOEntrySize (ModelTxOut _a v d) =
 canBeUsedAsCollateral :: ModelTxOut era -> Bool
 canBeUsedAsCollateral txo
   | not $ has (modelTxOut_address . modelAddress_pmt . _ModelKeyHashObj) txo = False
-  | not $ Val.adaOnly $ _mtxo_value txo = False
+  | not $ Val.isAdaOnly $ _mtxo_value txo = False
   | otherwise = True


### PR DESCRIPTION
This PR improves performance of TxOut and adds benchmarks. In particular serialization and TxOutCompact+TxOutCompactDH patterns

There is also a fix for couple of Babbage's TxOut accessor functions