### PR TITLE
Fix benchmarks

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -41,7 +41,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install libsodium23 libsodium-dev
+        sudo apt-get -y install libsodium23 libsodium-dev libsecp256k1-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 

--- a/cabal.project
+++ b/cabal.project
@@ -42,8 +42,8 @@ test-show-details: streaming
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 41545ba3ac6b3095966316a99883d678b5ab8da8
-  --sha256: 0icq9y3nnl42fz536da84414av36g37894qnyw4rk3qkalksqwir
+  tag: fa42b562b514b895231b8710e4f228438a5cbd3a
+  --sha256: 0pqkrsynamaa2y69g68f07ghpqkynsi58xlrdgl5mqhc37607pb9
   subdir:
     base-deriving-via
     binary

--- a/eras/alonzo/test
+++ b/eras/alonzo/test
@@ -1,1 +1,0 @@
-test-suite

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/AuxiliaryData.hs
@@ -35,6 +35,7 @@ import Codec.CBOR.Decoding
         TypeMapLenIndef
       ),
   )
+import Control.DeepSeq
 import Data.Coders
 import Data.Map.Strict (Map)
 import Data.MemoBytes
@@ -67,6 +68,8 @@ deriving instance
   (Core.ChainData (Core.Script era)) =>
   NoThunks (AuxiliaryDataRaw era)
 
+instance NFData (Core.Script era) => NFData (AuxiliaryDataRaw era)
+
 newtype AuxiliaryData era = AuxiliaryDataWithBytes (MemoBytes (AuxiliaryDataRaw era))
   deriving (Generic, Typeable)
   deriving newtype (ToCBOR, SafeToHash)
@@ -84,6 +87,8 @@ deriving newtype instance
 deriving newtype instance
   (Era era, Core.ChainData (Core.Script era)) =>
   NoThunks (AuxiliaryData era)
+
+deriving newtype instance NFData (Core.Script era) => NFData (AuxiliaryData era)
 
 pattern AuxiliaryData ::
   ( Core.AnnotatedData (Core.Script era),

--- a/eras/shelley-ma/shelley-ma-test
+++ b/eras/shelley-ma/shelley-ma-test
@@ -1,1 +1,0 @@
-test-suite

--- a/eras/shelley/chain-and-ledger/formal-spec
+++ b/eras/shelley/chain-and-ledger/formal-spec
@@ -1,1 +1,0 @@
-../formal-spec

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Shelley.Address.Bootstrap
   ( BootstrapWitness
@@ -56,6 +57,7 @@ import Cardano.Ledger.Keys
 import qualified Cardano.Ledger.Keys as Keys
 import Cardano.Ledger.Serialization (decodeRecordNamed)
 import Cardano.Prelude (panic)
+import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
@@ -69,7 +71,7 @@ import Quiet
 newtype ChainCode = ChainCode {unChainCode :: ByteString}
   deriving (Eq, Generic)
   deriving (Show) via Quiet ChainCode
-  deriving newtype (NoThunks, ToCBOR, FromCBOR)
+  deriving newtype (NoThunks, ToCBOR, FromCBOR, NFData)
 
 data BootstrapWitness crypto = BootstrapWitness'
   { bwKey' :: !(VKey 'Witness crypto),
@@ -87,6 +89,13 @@ data BootstrapWitness crypto = BootstrapWitness'
 deriving instance CC.Crypto crypto => Show (BootstrapWitness crypto)
 
 deriving instance CC.Crypto crypto => Eq (BootstrapWitness crypto)
+
+instance
+  ( CC.Crypto era,
+    NFData (DSIGN.VerKeyDSIGN (DSIGN era)),
+    NFData (DSIGN.SigDSIGN (DSIGN era))
+  ) =>
+  NFData (BootstrapWitness era)
 
 deriving via
   (AllowThunksIn '["bwBytes"] (BootstrapWitness crypto))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Orphans.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Orphans.hs
@@ -6,7 +6,6 @@
 
 module Cardano.Ledger.Shelley.Orphans where
 
-import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Crypto.Hash (Hash (..))
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Hash.Class as HS
@@ -15,19 +14,15 @@ import qualified Cardano.Crypto.Wallet as WC
 import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..))
-import Cardano.Ledger.Slot (EpochNo)
 import Cardano.Prelude (readEither)
-import Cardano.Slotting.Slot (EpochSize (..), WithOrigin (..))
-import Control.DeepSeq (NFData (rnf))
+import Control.DeepSeq (NFData)
 import Data.Aeson
 import qualified Data.ByteString as Long (ByteString, empty)
 import qualified Data.ByteString.Lazy as Lazy (ByteString, empty)
 import qualified Data.ByteString.Short as Short (ShortByteString, empty, pack)
 import Data.Default.Class (Default (..))
-import Data.Foldable
 import Data.IP (IPv4, IPv6)
 import Data.Proxy
-import Data.Sequence.Strict (StrictSeq, fromList, fromStrict)
 import qualified Data.Sequence.Strict as SS
 import qualified Data.Text as Text
 import NoThunks.Class (NoThunks (..))
@@ -50,12 +45,6 @@ instance FromJSON IPv6 where
 instance ToJSON IPv6 where
   toJSON = toJSON . show
 
-instance FromJSON a => FromJSON (StrictSeq a) where
-  parseJSON = fmap fromList . parseJSON
-
-instance ToJSON a => ToJSON (StrictSeq a) where
-  toJSON = toJSON . toList
-
 instance NoThunks IPv4
 
 instance NoThunks IPv6
@@ -63,16 +52,6 @@ instance NoThunks IPv6
 instance NFData IPv4
 
 instance NFData IPv6
-
-{- The following NFData instances probably belong in base -}
-instance NFData EpochNo
-
-instance NFData (StrictSeq a) where
-  rnf x = case fromStrict x of _any -> ()
-
--- By defintion it is strict, so as long as the (hidden) constructor is evident, it is in normal form
-
-instance NFData a => NFData (WithOrigin a)
 
 instance NoThunks WC.XSignature where
   wNoThunks ctxt s = wNoThunks ctxt (WC.unXSignature s)
@@ -109,9 +88,3 @@ instance HS.HashAlgorithm h => Default (Hash h b) where
 
 instance Default Bool where
   def = False
-
-deriving newtype instance ToCBOR EpochSize
-
-deriving newtype instance NFData EpochSize
-
-deriving newtype instance FromCBOR EpochSize

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Hashes (ScriptHash (..))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness))
 import Cardano.Ledger.SafeHash (SafeToHash (..))
 import Cardano.Ledger.Serialization (decodeList, decodeRecordSum, encodeFoldable)
+import Control.DeepSeq (NFData)
 import Data.ByteString.Short (ShortByteString)
 import Data.Coders (Encode (..), (!>))
 import Data.MemoBytes
@@ -72,9 +73,13 @@ data MultiSigRaw crypto
   deriving (Show, Eq, Ord, Generic)
   deriving anyclass (NoThunks)
 
+instance NFData (MultiSigRaw era)
+
 newtype MultiSig crypto = MultiSigConstr (MemoBytes (MultiSigRaw crypto))
   deriving (Eq, Ord, Show, Generic)
   deriving newtype (ToCBOR, NoThunks, SafeToHash)
+
+deriving newtype instance NFData (MultiSig era)
 
 getMultiSigBytes :: MultiSig crypto -> ShortByteString
 getMultiSigBytes (MultiSigConstr (Memo _ bytes)) = bytes

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -88,6 +88,7 @@ import Cardano.Ledger.Shelley.TxBody
     witKeyHash,
   )
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as SBS
 import Data.Coders
@@ -116,6 +117,13 @@ data TxRaw era = TxRaw
   }
   deriving (Generic, Typeable)
 
+instance
+  ( NFData (Core.TxBody era),
+    NFData (Core.Witnesses era),
+    NFData (Core.AuxiliaryData era)
+  ) =>
+  NFData (TxRaw era)
+
 deriving instance
   ( Era era,
     Eq (Core.AuxiliaryData era),
@@ -142,6 +150,13 @@ instance
 
 newtype Tx era = TxConstr (MemoBytes (TxRaw era))
   deriving newtype (SafeToHash, ToCBOR)
+
+deriving newtype instance
+  ( NFData (Core.TxBody era),
+    NFData (Core.Witnesses era),
+    NFData (Core.AuxiliaryData era)
+  ) =>
+  NFData (Tx era)
 
 deriving newtype instance Eq (Tx era)
 
@@ -296,6 +311,14 @@ deriving instance
   Eq (WitnessSetHKD Identity era)
 
 deriving instance Era era => Generic (WitnessSetHKD Identity era)
+
+instance
+  ( Era era,
+    NFData (Core.Script era),
+    NFData (WitVKey 'Witness (Crypto era)),
+    NFData (BootstrapWitness (Crypto era))
+  ) =>
+  NFData (WitnessSetHKD Identity era)
 
 deriving via
   AllowThunksIn

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -613,7 +613,7 @@ type TransTxBody (c :: Type -> Constraint) era =
   )
 
 deriving instance
-  (CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
+  (NFData (Core.TxOut era), CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
   NFData (TxBodyRaw era)
 
 deriving instance (Era era, TransTxBody Eq era) => Eq (TxBodyRaw era)
@@ -732,7 +732,7 @@ deriving newtype instance
   (TransTxBody NoThunks era, Typeable era) => NoThunks (TxBody era)
 
 deriving newtype instance
-  (CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
+  (NFData (Core.TxOut era), CC.Crypto (Crypto era), NFData (Core.PParamsDelta era)) =>
   NFData (TxBody era)
 
 deriving instance (Era era, TransTxBody Show era) => Show (TxBody era)
@@ -842,6 +842,9 @@ data WitVKey kr crypto = WitVKey'
 deriving instance CC.Crypto crypto => Show (WitVKey kr crypto)
 
 deriving instance CC.Crypto crypto => Eq (WitVKey kr crypto)
+
+instance NFData (WitVKey kr crypto) where
+  rnf (WitVKey' _ _ _ bytes) = rnf bytes
 
 deriving via
   (AllowThunksIn '["wvkBytes"] (WitVKey kr crypto))

--- a/eras/shelley/pool-ranking
+++ b/eras/shelley/pool-ranking
@@ -1,1 +1,0 @@
-../../docs/pool-ranking

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -14,8 +14,6 @@ copyright:           2020 Input Output (Hong Kong) Ltd.
 build-type:          Simple
 extra-source-files:
   CHANGELOG.md
-  bench/resources/0_ledgerstate.cbor
-  bench/resources/0_tx.cbor
 
 source-repository head
   type:     git


### PR DESCRIPTION
Fixing benchmarks requires bunch of NFData instance.

Many orphans have been moved to cardano-base, which means we need to get https://github.com/input-output-hk/cardano-base/pull/260 be merged for this PR

Also removed old symlinks.