### PR TITLE
Add a ledger event for successful Plutus scripts

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -35,14 +35,12 @@ import Cardano.Ledger.Alonzo.Tx
   )
 import Cardano.Ledger.Alonzo.TxInfo
   ( ExtendedUTxO (..),
-    ScriptFailure (..),
     ScriptResult (..),
     TranslationError (..),
     runPLCScript,
-    scriptFail,
     valContext,
   )
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), unTxDats)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness, unTxDats)
 import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (ScriptHashObj))
@@ -56,14 +54,13 @@ import Cardano.Ledger.Shelley.TxBody
     Delegation (..),
     Wdrl (..),
     getRwdCred,
-    witKeyHash,
   )
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), getScriptHash, scriptCred)
-import Cardano.Ledger.ShelleyMA.Timelocks (evalTimelock)
 import Cardano.Ledger.ShelleyMA.TxBody (ValidityInterval)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Data.ByteString.Short (ShortByteString)
 import Data.Coders
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Foldable (foldl')
@@ -75,7 +72,6 @@ import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Text (pack)
 import Debug.Trace (traceEvent)
 import GHC.Generics
 import GHC.Records (HasField (..))
@@ -166,7 +162,7 @@ collectTwoPhaseScriptInputs ::
   Core.PParams era ->
   Core.Tx era ->
   UTxO era ->
-  Either [CollectError (Crypto era)] [(AlonzoScript.Script era, [Data era], ExUnits, CostModel)]
+  Either [CollectError (Crypto era)] [(ShortByteString, Language, [Data era], ExUnits, CostModel)]
 collectTwoPhaseScriptInputs ei sysS pp tx utxo =
   let usedLanguages = [lang | (AlonzoScript.PlutusScript lang _) <- Map.elems scriptsUsed]
       costModels = unCostModels $ getField @"_costmdls" pp
@@ -183,42 +179,35 @@ collectTwoPhaseScriptInputs ei sysS pp tx utxo =
     -- on 1-phase scripts.
     knownToNotBe1Phase (sp, sh) =
       case sh `Map.lookup` scriptsUsed of
-        Just (AlonzoScript.PlutusScript lang _) -> Just (sp, lang, sh)
+        Just (AlonzoScript.PlutusScript lang script) -> Just (sp, lang, script)
         Just (AlonzoScript.TimelockScript _) -> Nothing
         Nothing -> Nothing
     redeemer (sp, lang, _) =
       case indexedRdmrs tx sp of
         Just (d, eu) -> Right (lang, sp, d, eu)
         Nothing -> Left (NoRedeemer sp)
-    getscript (_, _, hash) =
-      case hash `Map.lookup` scriptsUsed of
-        Just script -> Right script
-        Nothing -> Left (NoWitness hash)
+    getscript (_, _, script) = script
     apply costs (lang, sp, d, eu) script =
       case txinfo lang of
-        Right inf -> Right (script, getData tx utxo sp ++ (d : [valContext inf sp]), eu, costs Map.! lang)
+        Right inf -> Right (script, lang, getData tx utxo sp ++ (d : [valContext inf sp]), eu, costs Map.! lang)
         Left te -> Left $ BadTranslation te
 
--- | Merge two lists (either of which may have failures, i.e. (Left _)), collect all the failures
+-- | Merge two lists (the first of which may have failures, i.e. (Left _)), collect all the failures
 --   but if there are none, use 'f' to construct a success.
-merge :: forall t1 t2 a1 a2. (t1 -> t2 -> Either a2 a1) -> [Either a2 t1] -> [Either a2 t2] -> Either [a2] [a1] -> Either [a2] [a1]
+merge :: forall t1 t2 a1 a2. (t1 -> t2 -> Either a2 a1) -> [Either a2 t1] -> [t2] -> Either [a2] [a1] -> Either [a2] [a1]
 merge _f [] [] answer = answer
 merge _f [] (_ : _) answer = answer
 merge _f (_ : _) [] answer = answer
 merge f (x : xs) (y : ys) zs = merge f xs ys (gg x y zs)
   where
-    gg :: Either a2 t1 -> Either a2 t2 -> Either [a2] [a1] -> Either [a2] [a1]
-    gg (Right a) (Right b) (Right cs) =
+    gg :: Either a2 t1 -> t2 -> Either [a2] [a1] -> Either [a2] [a1]
+    gg (Right a) b (Right cs) =
       case f a b of
         Right c -> Right $ c : cs
         Left e -> Left [e]
-    gg (Left a) (Right _) (Right _) = Left [a]
-    gg (Right _) (Left b) (Right _) = Left [b]
-    gg (Left a) (Left b) (Right _) = Left [a, b]
-    gg (Right _) (Right _) (Left cs) = Left cs
-    gg (Right _) (Left b) (Left cs) = Left (b : cs)
-    gg (Left a) (Right _) (Left cs) = Left (a : cs)
-    gg (Left a) (Left b) (Left cs) = Left (a : b : cs)
+    gg (Left a) _ (Right _) = Left [a]
+    gg (Right _) _ (Left cs) = Left cs
+    gg (Left a) _ (Left cs) = Left (a : cs)
 
 language :: AlonzoScript.Script era -> Maybe Language
 language (AlonzoScript.PlutusScript lang _) = Just lang
@@ -237,17 +226,10 @@ evalScripts ::
   ) =>
   ProtVer ->
   tx ->
-  [(AlonzoScript.Script era, [Data era], ExUnits, CostModel)] ->
+  [(ShortByteString, Language, [Data era], ExUnits, CostModel)] ->
   ScriptResult
 evalScripts _pv _tx [] = mempty
-evalScripts pv tx ((AlonzoScript.TimelockScript timelock, _, _, _) : rest) =
-  lift (evalTimelock vhks (getField @"vldt" (getField @"body" tx)) timelock)
-    <> evalScripts pv tx rest
-  where
-    vhks = Set.map witKeyHash (txwitsVKey' (getField @"wits" tx))
-    lift True = mempty
-    lift False = scriptFail . OnePhaseSF . pack . show $ timelock
-evalScripts pv tx ((AlonzoScript.PlutusScript lang pscript, ds, units, cost) : rest) =
+evalScripts pv tx ((pscript, lang, ds, units, cost) : rest) =
   let beginMsg =
         intercalate
           ","

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -231,9 +231,9 @@ scriptsNotValidateTransition = do
       whenFailureFree $
         case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
           Passes _ps -> False ?!## ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
-          Fails ps fs ->
+          Fails ps fs -> do
             tellEvent (SuccessfulPlutusScriptsEvent ps)
-              >> tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
+            tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
     Left info -> failBecause (CollectErrors info)
 
   let !_ = traceEvent invalidEnd ()
@@ -280,7 +280,7 @@ instance FromCBOR FailureDescription where
 scriptFailureToFailureDescription :: ScriptFailure -> FailureDescription
 scriptFailureToFailureDescription (OnePhaseSF t) = OnePhaseFailure t
 scriptFailureToFailureDescription (PlutusSF t pd) =
-  PlutusFailure t (B64.encode . serialize' $ pd)
+  PlutusFailure t (B64.encode $ serialize' pd)
 
 scriptFailuresToPredicateFailure :: NonEmpty ScriptFailure -> NonEmpty FailureDescription
 scriptFailuresToPredicateFailure = fmap scriptFailureToFailureDescription

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -132,7 +132,7 @@ instance
 data UtxosEvent era
   = AlonzoPpupToUtxosEvent (Event (Core.EraRule "PPUP" era))
   | SuccessfulPlutusScriptsEvent [PlutusDebug]
-  | FailedPlutusScriptsEvent [PlutusDebug]
+  | FailedPlutusScriptsEvent (NonEmpty PlutusDebug)
 
 instance
   ( Era era,
@@ -278,15 +278,14 @@ instance FromCBOR FailureDescription where
       dec n = Invalid n
 
 scriptFailureToFailureDescription :: ScriptFailure -> FailureDescription
-scriptFailureToFailureDescription (OnePhaseSF t) = OnePhaseFailure t
 scriptFailureToFailureDescription (PlutusSF t pd) =
   PlutusFailure t (B64.encode $ serialize' pd)
 
 scriptFailuresToPredicateFailure :: NonEmpty ScriptFailure -> NonEmpty FailureDescription
 scriptFailuresToPredicateFailure = fmap scriptFailureToFailureDescription
 
-scriptFailuresToPlutusDebug :: NonEmpty ScriptFailure -> [PlutusDebug]
-scriptFailuresToPlutusDebug sfs = [pdb | PlutusSF _ pdb <- toList sfs]
+scriptFailuresToPlutusDebug :: NonEmpty ScriptFailure -> NonEmpty PlutusDebug
+scriptFailuresToPlutusDebug = fmap (\(PlutusSF _ pdb) -> pdb)
 
 data TagMismatchDescription
   = PassedUnexpectedly

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -26,10 +26,13 @@ module Cardano.Ledger.Alonzo.Rules.Utxos
     UtxosEvent (..),
     (?!##),
     ConcreteAlonzo,
+    FailureDescription (..),
+    scriptFailuresToPredicateFailure,
+    scriptFailuresToPlutusDebug,
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize')
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import Cardano.Ledger.Alonzo.PlutusScriptApi
   ( CollectError,
@@ -43,7 +46,7 @@ import Cardano.Ledger.Alonzo.Tx
     ValidatedTx (..),
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
-import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), FailureDescription (..), ScriptResult (..))
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), PlutusDebug, ScriptFailure (..), ScriptResult (..))
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import Cardano.Ledger.BaseTypes
   ( Globals,
@@ -71,13 +74,17 @@ import Cardano.Ledger.Val as Val
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
+import Data.ByteString as BS (ByteString)
+import qualified Data.ByteString.Base64 as B64
 import Data.Coders
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Foldable (toList)
 import Data.List (intercalate)
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
+import Data.Text (Text)
 import Debug.Trace (traceEvent)
 import GHC.Generics (Generic)
 import GHC.Records (HasField (..))
@@ -122,8 +129,10 @@ instance
   type Event (UTXOS era) = UtxosEvent era
   transitionRules = [utxosTransition]
 
-newtype UtxosEvent era
-  = UpdateEvent (Event (Core.EraRule "PPUP" era))
+data UtxosEvent era
+  = AlonzoPpupToUtxosEvent (Event (Core.EraRule "PPUP" era))
+  | SuccessfulPlutusScriptsEvent [PlutusDebug]
+  | FailedPlutusScriptsEvent [PlutusDebug]
 
 instance
   ( Era era,
@@ -134,7 +143,7 @@ instance
   Embed (PPUP era) (UTXOS era)
   where
   wrapFailed = UpdateFailure
-  wrapEvent = UpdateEvent
+  wrapEvent = AlonzoPpupToUtxosEvent
 
 utxosTransition ::
   forall era.
@@ -184,12 +193,12 @@ scriptsValidateTransition = do
   case collectTwoPhaseScriptInputs ei sysSt pp tx utxo of
     Right sLst ->
       case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
-        Fails sss ->
+        Fails _ps fs ->
           False
             ?!## ValidationTagMismatch
               (getField @"isValid" tx)
-              (FailedUnexpectedly sss)
-        Passes -> pure ()
+              (FailedUnexpectedly (scriptFailuresToPredicateFailure fs))
+        Passes ps -> tellEvent (SuccessfulPlutusScriptsEvent ps)
     Left info -> failBecause (CollectErrors info)
 
   () <- pure $! traceEvent validEnd ()
@@ -221,8 +230,10 @@ scriptsNotValidateTransition = do
     Right sLst ->
       whenFailureFree $
         case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
-          Passes -> False ?!## ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
-          Fails _sss -> pure ()
+          Passes _ps -> False ?!## ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
+          Fails ps fs ->
+            tellEvent (SuccessfulPlutusScriptsEvent ps)
+              >> tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
     Left info -> failBecause (CollectErrors info)
 
   let !_ = traceEvent invalidEnd ()
@@ -250,9 +261,36 @@ invalidEnd = intercalate "," ["[LEDGER][SCRIPTS_NOT_VALIDATE_TRANSITION]", "END"
 -- =============================================
 -- PredicateFailure data type for UTXOS
 
+data FailureDescription
+  = OnePhaseFailure Text
+  | PlutusFailure Text BS.ByteString
+  deriving (Show, Eq, Generic, NoThunks)
+
+instance ToCBOR FailureDescription where
+  toCBOR (OnePhaseFailure s) = encode $ Sum OnePhaseFailure 0 !> To s
+  toCBOR (PlutusFailure s b) = encode $ Sum PlutusFailure 1 !> To s !> To b
+
+instance FromCBOR FailureDescription where
+  fromCBOR = decode (Summands "FailureDescription" dec)
+    where
+      dec 0 = SumD OnePhaseFailure <! From
+      dec 1 = SumD PlutusFailure <! From <! From
+      dec n = Invalid n
+
+scriptFailureToFailureDescription :: ScriptFailure -> FailureDescription
+scriptFailureToFailureDescription (OnePhaseSF t) = OnePhaseFailure t
+scriptFailureToFailureDescription (PlutusSF t pd) =
+  PlutusFailure t (B64.encode . serialize' $ pd)
+
+scriptFailuresToPredicateFailure :: NonEmpty ScriptFailure -> NonEmpty FailureDescription
+scriptFailuresToPredicateFailure = fmap scriptFailureToFailureDescription
+
+scriptFailuresToPlutusDebug :: NonEmpty ScriptFailure -> [PlutusDebug]
+scriptFailuresToPlutusDebug sfs = [pdb | PlutusSF _ pdb <- toList sfs]
+
 data TagMismatchDescription
   = PassedUnexpectedly
-  | FailedUnexpectedly [FailureDescription]
+  | FailedUnexpectedly (NonEmpty FailureDescription)
   deriving (Show, Eq, Generic, NoThunks)
 
 instance ToCBOR TagMismatchDescription where
@@ -374,8 +412,8 @@ constructValidated globals (UtxoEnv _ pp _ _) st tx =
     utxo = _utxo st
     sysS = systemStart globals
     ei = epochInfo globals
-    lift Passes = True -- Convert a ScriptResult into a Bool
-    lift (Fails _) = False
+    lift (Passes _) = True
+    lift (Fails _ _) = False
 
 --------------------------------------------------------------------------------
 -- 2-phase checks

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -455,9 +455,7 @@ valContext ::
 valContext (TxInfoPV1 txinfo) sp = Data (PV1.toData (PV1.ScriptContext txinfo (transScriptPurpose sp)))
 valContext (TxInfoPV2 txinfo) sp = Data (PV2.toData (PV2.ScriptContext txinfo (transScriptPurpose sp)))
 
-data ScriptFailure
-  = OnePhaseSF Text
-  | PlutusSF Text PlutusDebug
+data ScriptFailure = PlutusSF Text PlutusDebug
   deriving (Show, Eq, Generic, NoThunks)
 
 data ScriptResult

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -12,7 +12,7 @@ module Cardano.Ledger.Alonzo.TxInfo where
 
 -- =============================================
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull', serialize')
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull')
 import Cardano.Crypto.Hash.Class (Hash, hashToBytes)
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
 import Cardano.Ledger.Alonzo.Data (Data (..), getPlutusData)
@@ -71,6 +71,7 @@ import Data.Coders
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Either (rights)
 import Data.Fixed (HasResolution (resolution))
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as Map
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
@@ -454,44 +455,32 @@ valContext ::
 valContext (TxInfoPV1 txinfo) sp = Data (PV1.toData (PV1.ScriptContext txinfo (transScriptPurpose sp)))
 valContext (TxInfoPV2 txinfo) sp = Data (PV2.toData (PV2.ScriptContext txinfo (transScriptPurpose sp)))
 
-data FailureDescription
-  = OnePhaseFailure Text
-  | PlutusFailure Text ByteString
-  deriving (Show, Eq, Ord, Generic, NoThunks)
+data ScriptFailure
+  = OnePhaseSF Text
+  | PlutusSF Text PlutusDebug
+  deriving (Show, Eq, Generic, NoThunks)
 
-instance ToCBOR FailureDescription where
-  toCBOR (OnePhaseFailure s) = encode $ Sum OnePhaseFailure 0 !> To s
-  toCBOR (PlutusFailure s b) = encode $ Sum PlutusFailure 1 !> To s !> To b
+data ScriptResult
+  = Passes [PlutusDebug]
+  | Fails [PlutusDebug] (NonEmpty ScriptFailure)
+  deriving (Show, Generic)
 
-instance FromCBOR FailureDescription where
-  fromCBOR = decode (Summands "FailureDescription" dec)
-    where
-      dec 0 = SumD OnePhaseFailure <! From
-      dec 1 = SumD PlutusFailure <! From <! From
-      dec n = Invalid n
+scriptPass :: PlutusDebug -> ScriptResult
+scriptPass pd = Passes [pd]
 
-data ScriptResult = Passes | Fails ![FailureDescription]
-  deriving (Show, Generic, NoThunks)
+scriptFail :: ScriptFailure -> ScriptResult
+scriptFail pd = Fails [] (pure pd)
 
-instance ToCBOR ScriptResult where
-  toCBOR Passes = encode $ Sum Passes 0
-  toCBOR (Fails fs) = encode $ Sum Fails 1 !> To fs
-
-instance FromCBOR ScriptResult where
-  fromCBOR = decode (Summands "ScriptResult" dec)
-    where
-      dec 0 = SumD Passes
-      dec 1 = SumD Fails <! From
-      dec n = Invalid n
-
-andResult :: ScriptResult -> ScriptResult -> ScriptResult
-andResult Passes Passes = Passes
-andResult Passes ans = ans
-andResult ans Passes = ans
-andResult (Fails xs) (Fails ys) = Fails (xs ++ ys)
+instance NoThunks ScriptResult
 
 instance Semigroup ScriptResult where
-  (<>) = andResult
+  (Passes ps) <> (Passes qs) = Passes (ps <> qs)
+  (Passes ps) <> (Fails qs xs) = Fails (ps <> qs) xs
+  (Fails ps xs) <> (Passes qs) = Fails (ps <> qs) xs
+  (Fails ps xs) <> (Fails qs ys) = Fails (ps <> qs) (xs <> ys)
+
+instance Monoid ScriptResult where
+  mempty = Passes mempty
 
 data PlutusDebug
   = PlutusDebugV1
@@ -506,12 +495,15 @@ data PlutusDebug
       SBS.ShortByteString
       [PV2.Data]
       ProtVer
+  deriving (Show, Eq, Generic, NoThunks)
+
+data PlutusError = PlutusErrorV1 PV1.EvaluationError | PlutusErrorV2 PV2.EvaluationError
   deriving (Show)
 
 data PlutusDebugInfo
   = DebugSuccess PV1.ExBudget
   | DebugCannotDecode String
-  | DebugInfo [Text] String
+  | DebugInfo [Text] PlutusError PlutusDebug
   | DebugBadHex String
   deriving (Show)
 
@@ -545,7 +537,7 @@ debugPlutus db =
     Right bs ->
       case decodeFull' bs of
         Left e -> DebugCannotDecode (show e)
-        Right (PlutusDebugV1 cm units script ds pv) ->
+        Right pdb@(PlutusDebugV1 cm units script ds pv) ->
           case PV1.evaluateScriptRestricting
             (transProtocolVersion pv)
             PV1.Verbose
@@ -553,9 +545,9 @@ debugPlutus db =
             (transExUnits units)
             script
             ds of
-            (logs, Left e) -> DebugInfo logs (show e)
+            (logs, Left e) -> DebugInfo logs (PlutusErrorV1 e) pdb
             (_, Right ex) -> DebugSuccess ex
-        Right (PlutusDebugV2 cm units script ds pv) ->
+        Right pdb@(PlutusDebugV2 cm units script ds pv) ->
           case PV2.evaluateScriptRestricting
             (transProtocolVersion pv)
             PV2.Verbose
@@ -563,7 +555,7 @@ debugPlutus db =
             (transExUnits units)
             script
             ds of
-            (logs, Left e) -> DebugInfo logs (show e)
+            (logs, Left e) -> DebugInfo logs (PlutusErrorV2 e) pdb
             (_, Right ex) -> DebugSuccess ex
 
 -- The runPLCScript in the Specification has a slightly different type
@@ -592,11 +584,13 @@ runPLCScript proxy pv lang cm scriptbytestring units ds =
     scriptbytestring
     ds of
     (_, Left e) -> explainPlutusFailure proxy pv lang scriptbytestring e ds cm units
-    (_, Right _) -> Passes
+    (_, Right _) -> scriptPass $ successConstructor lang cm units scriptbytestring ds pv
   where
     plutusPV = transProtocolVersion pv
     plutusInterpreter PlutusV1 = PV1.evaluateScriptRestricting plutusPV
     plutusInterpreter PlutusV2 = PV2.evaluateScriptRestricting plutusPV
+    successConstructor PlutusV1 = PlutusDebugV1
+    successConstructor PlutusV2 = PlutusDebugV2
 
 -- | Explain why a script might fail. Scripts come in two flavors:
 --
@@ -626,7 +620,7 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[dat, redeemer, info] 
       name :: String
       name = show ss
    in case PV1.fromData info of
-        Nothing -> Fails [PlutusFailure line db]
+        Nothing -> scriptFail $ PlutusSF line db
           where
             line =
               pack $
@@ -638,8 +632,8 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[dat, redeemer, info] 
                     "The redeemer is: " ++ show redeemer,
                     "The third data argument, does not decode to a context\n" ++ show info
                   ]
-            db = B64.encode . serialize' $ PlutusDebugV1 cm eu scriptbytestring ds pv
-        Just info2 -> Fails [PlutusFailure line db]
+            db = PlutusDebugV1 cm eu scriptbytestring ds pv
+        Just info2 -> scriptFail $ PlutusSF line db
           where
             info3 = show (pretty (info2 :: PV1.ScriptContext))
             line =
@@ -652,7 +646,7 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[dat, redeemer, info] 
                     "The redeemer is: " ++ show redeemer,
                     "The context is:\n" ++ info3
                   ]
-            db = B64.encode . serialize' $ PlutusDebugV1 cm eu scriptbytestring ds pv
+            db = PlutusDebugV1 cm eu scriptbytestring ds pv
 explainPlutusFailure _proxy pv lang scriptbytestring e ds@[redeemer, info] cm eu =
   -- A two data argument script.
   let ss :: Script era
@@ -660,7 +654,7 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[redeemer, info] cm eu
       name :: String
       name = show ss
    in case PV1.fromData info of
-        Nothing -> Fails [PlutusFailure line db]
+        Nothing -> scriptFail $ PlutusSF line db
           where
             line =
               pack $
@@ -671,8 +665,8 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[redeemer, info] cm eu
                     "The redeemer is: " ++ show redeemer,
                     "The second data argument, does not decode to a context\n" ++ show info
                   ]
-            db = B64.encode . serialize' $ PlutusDebugV1 cm eu scriptbytestring ds pv
-        Just info2 -> Fails [PlutusFailure line db]
+            db = PlutusDebugV1 cm eu scriptbytestring ds pv
+        Just info2 -> scriptFail $ PlutusSF line db
           where
             info3 = show (pretty (info2 :: PV1.ScriptContext))
             line =
@@ -684,10 +678,10 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds@[redeemer, info] cm eu
                     "The redeemer is: " ++ show redeemer,
                     "The context is:\n" ++ info3
                   ]
-            db = B64.encode . serialize' $ PlutusDebugV1 cm eu scriptbytestring ds pv
+            db = PlutusDebugV1 cm eu scriptbytestring ds pv
 explainPlutusFailure _proxy pv lang scriptbytestring e ds cm eu =
   -- A script with the wrong number of arguments
-  Fails [PlutusFailure line db]
+  scriptFail $ PlutusSF line db
   where
     ss :: Script era
     ss = PlutusScript lang scriptbytestring
@@ -703,7 +697,7 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds cm eu =
             ]
               ++ map show ds
           )
-    db = B64.encode . serialize' $ PlutusDebugV1 cm eu scriptbytestring ds pv
+    db = PlutusDebugV1 cm eu scriptbytestring ds pv
 
 validPlutusdata :: PV1.Data -> Bool
 validPlutusdata (PV1.Constr _n ds) = all validPlutusdata ds

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), BinaryData, Data (..), da
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
-import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos (FailureDescription (..), TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts
   ( CostModels (..),
@@ -33,13 +33,13 @@ import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
   ( TxOut (..),
   )
-import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..), ScriptResult (..))
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era, ValidateScript (..))
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Shelley.Constraints (UsesScript, UsesValue)
 import Data.Int (Int64)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
@@ -281,13 +281,9 @@ instance Arbitrary FailureDescription where
         PlutusFailure <$> (pack <$> arbitrary) <*> arbitrary
       ]
 
-instance Arbitrary ScriptResult where
-  arbitrary =
-    oneof [pure Passes, Fails <$> arbitrary]
-
 instance Arbitrary TagMismatchDescription where
   arbitrary =
-    oneof [pure PassedUnexpectedly, FailedUnexpectedly <$> arbitrary]
+    oneof [pure PassedUnexpectedly, FailedUnexpectedly <$> ((:|) <$> arbitrary <*> arbitrary)]
 
 instance Mock c => Arbitrary (UtxosPredicateFailure (AlonzoEra c)) where
   arbitrary =

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -198,10 +198,10 @@ explainTest (script@(PlutusScript _ bytes)) mode ds =
            (ExUnits 100000000 10000000)
            ds
        ) of
-    (ShouldSucceed, Passes) -> assertBool "" True
-    (ShouldSucceed, Fails xs) -> assertBool (show xs) False
-    (ShouldFail, Passes) -> assertBool ("Test that should fail, passes: " ++ show script) False
-    (ShouldFail, Fails _) -> assertBool "" True
+    (ShouldSucceed, Passes _) -> assertBool "" True
+    (ShouldSucceed, Fails _ xs) -> assertBool (show xs) False
+    (ShouldFail, Passes _) -> assertBool ("Test that should fail, passes: " ++ show script) False
+    (ShouldFail, Fails _ _) -> assertBool "" True
 explainTest _other _mode _ds = assertBool "BAD Script" False
 
 explainTestTree :: TestTree

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
@@ -96,7 +96,7 @@ alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
                 (UTxO u) of
                 Left e -> error $ "Plutus script collection error: " <> show e
                 Right c -> c
-            collectedScripts = Set.fromList $ map (\(s, _, _, _) -> s) collected
+            collectedScripts = Set.fromList $ map (\(s, v, _, _, _) -> PlutusScript v s) collected
             suppliedPScrpts = Set.fromList [PlutusScript v s | PlutusScript v s <- Map.elems allScripts]
             expectedPScripts = collectedScripts == suppliedPScrpts
             allPlutusTrue = case evalScripts (_protocolVersion pp) tx collected of

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PropertyTests.hs
@@ -100,8 +100,8 @@ alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
             suppliedPScrpts = Set.fromList [PlutusScript v s | PlutusScript v s <- Map.elems allScripts]
             expectedPScripts = collectedScripts == suppliedPScrpts
             allPlutusTrue = case evalScripts (_protocolVersion pp) tx collected of
-              Fails _ -> False
-              Passes -> True
+              Fails _ _ -> False
+              Passes _ -> True
          in counterexample
               ( mconcat
                   [ "\nHas plutus scripts: ",

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -202,9 +202,9 @@ scriptsNo = do
       {- isValid tx = evalScripts tx sLst = False -}
       case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
         Passes _ -> False ?!## ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
-        Fails ps fs ->
+        Fails ps fs -> do
           tellEvent (SuccessfulPlutusScriptsEvent ps)
-            >> tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
+          tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
     Left info -> failBecause (CollectErrors info)
 
   () <- pure $! traceEvent invalidEnd ()

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Alonzo.Scripts
     Script (..),
     Tag (..),
   )
-import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..), ScriptResult (..))
+import Cardano.Ledger.Alonzo.TxInfo (ScriptResult (..))
 import Cardano.Ledger.Alonzo.TxWitness
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.PParams

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..), collectTwoPhaseScriptInputs)
 import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY, AlonzoBbodyPredFail (..))
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
-import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos (FailureDescription (..), TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), mkCostModel)
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
@@ -35,7 +35,7 @@ import Cardano.Ledger.Alonzo.Tx
     minfee,
   )
 import Cardano.Ledger.Alonzo.TxBody (ScriptIntegrityHash)
-import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..), TranslationError, VersionedTxInfo, txInfo, valContext)
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError, VersionedTxInfo, txInfo, valContext)
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), unRedeemers)
 import Cardano.Ledger.BHeaderView (BHeaderView (..))
 import Cardano.Ledger.Babbage (BabbageEra)
@@ -121,6 +121,7 @@ import Data.Default.Class (Default (..))
 import Data.Either (fromRight)
 import Data.Functor.Identity (Identity, runIdentity)
 import qualified Data.List as List
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
@@ -2251,7 +2252,7 @@ alonzoUTXOWexamplesB pf =
                   [ fromUtxos @era
                       ( ValidationTagMismatch
                           (IsValid True)
-                          (FailedUnexpectedly [quietPlutusFailure])
+                          (FailedUnexpectedly (quietPlutusFailure :| []))
                       )
                   ]
               ),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -30,12 +30,11 @@ import Cardano.Ledger.Alonzo.Data (Data (..), binaryDataToData)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..))
 import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail (..))
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (UtxoPredicateFailure (..))
-import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos (FailureDescription (..), TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (Script (..))
 import Cardano.Ledger.Alonzo.Tx (IsValid (..), ScriptPurpose (..))
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxOut (..))
-import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..))
 import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), unTxDats)
 import Cardano.Ledger.Babbage (BabbageEra)
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
@@ -70,6 +69,7 @@ import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition.Extended (STS (..))
 import qualified Data.Compact.SplitMap as Split
+import Data.List.NonEmpty (toList)
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Set as Set
@@ -401,7 +401,7 @@ instance PrettyA (CollectError crypto) where
 ppTagMismatchDescription :: TagMismatchDescription -> PDoc
 ppTagMismatchDescription (PassedUnexpectedly) = ppSexp "PassedUnexpectedly" []
 ppTagMismatchDescription (FailedUnexpectedly xs) =
-  ppSexp "FailedUnexpectedly" [ppList ppFailureDescription xs]
+  ppSexp "FailedUnexpectedly" [ppList ppFailureDescription (toList xs)]
 
 instance PrettyA TagMismatchDescription where
   prettyA = ppTagMismatchDescription


### PR DESCRIPTION
This PR adds a ledger event for successful Plutus scripts, providing all the information needed to re-run the scripts.

# Redux Notes for reviewers

There are two new events:
* `SuccessfulPlutusScriptsEvent [PlutusDebug]`
* `FailedPlutusScriptsEvent [PlutusDebug]`

In the case of no failures, with the transaction marked as `IsValid == True`, all the information needed to re-run all the scripts in a given transaction are a part of a `SuccessfulPlutusScriptsEvent` event. In the case of failures, with the transaction marked as `IsValid == False`, there are two events, one for the successes and one for the failures. No event is transmitted otherwise, since this triggers a predicate failure.

## Other notable changes

The type returned by `runPLCScript` (the ledger function which wraps the Plutus evaluator) is named `ScriptResult` and has been changed from

```
data ScriptResult = Passes | Fails ![FailureDescription]
```
to
```
data ScriptResult  = Passes [PlutusDebug]  | Fails [PlutusDebug] (NonEmpty ScriptFailure)
```

In other words, `ScriptResult` now collects the successful script information as well.  There is only a small difference between `FailureDescription` and `ScriptFailure`. The former contains an encoded bytestring with the needed information to re-run scripts, the later contains the un-encoded data. We cannot change the serialization of the predicates failures without breaking the node-to-client protocol, and since `FailureDescription` is used for a predicate failure we keep this type around (though it is moved to `Cardano.Ledger.Alonzo.Rules.Utxos`). The `ScriptFailure` type allows use to transmit the ledger event without encoding the data.

Lastly, the type `PlutusDebugInfo` has one small change in the `DebugInfo` constructor. Instead of the less helpful `String`, it now contains the actual Plutus error. It also now contains the `PlutusDebug`.

closes #2659 