### PR TITLE
Generalized the generic unit tests in TwoPhaseValidation.hs 

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -169,6 +169,7 @@ instance
 
 instance CC.Crypto c => UsesTxOut (AlonzoEra c) where
   makeTxOut _proxy addr val = TxOut addr val SNothing
+  getTxOutExtras (TxOut _ _ dhashM) = (dhashM, SNothing)
 
 instance CC.Crypto c => API.CLI (AlonzoEra c) where
   evaluateMinFee = minfee

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -53,13 +53,9 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Hashes
-  ( EraIndependentAuxiliaryData,
-    EraIndependentData,
-  )
+import Cardano.Ledger.Hashes (DataHash, EraIndependentAuxiliaryData, EraIndependentData)
 import Cardano.Ledger.SafeHash
   ( HashAnnotated,
-    SafeHash,
     SafeToHash (..),
     hashAnnotated,
   )
@@ -171,8 +167,6 @@ hashBinaryData :: Era era => BinaryData era -> DataHash (Crypto era)
 hashBinaryData = hashAnnotated
 
 -- =============================================================================
-
-type DataHash crypto = SafeHash crypto EraIndependentData
 
 hashData :: Era era => Data era -> DataHash (Crypto era)
 hashData = hashAnnotated

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -171,6 +171,8 @@ instance
 
 instance CC.Crypto c => UsesTxOut (BabbageEra c) where
   makeTxOut _proxy addr val = TxOut addr val NoDatum SNothing
+  getTxOutExtras (TxOut _ _ (DatumHash h) scriptM) = (SJust h, scriptM)
+  getTxOutExtras (TxOut _ _ _ scriptM) = (SNothing, scriptM)
 
 instance CC.Crypto c => API.CLI (BabbageEra c) where
   evaluateMinFee = minfee

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -102,7 +102,6 @@ data BabbageUtxoPred era
   = FromAlonzoUtxoFail !(UtxoPredicateFailure era) -- Inherited from Alonzo
   | FromAlonzoUtxowFail !(UtxowPredicateFail era)
   | UnequalCollateralReturn !Coin !Coin
-  | UnknownDataHash !(Set.Set (DataHash (Crypto era)))
   | DanglingWitnessDataHash !(Set.Set (DataHash (Crypto era)))
 
 deriving instance
@@ -363,7 +362,6 @@ instance
       work (FromAlonzoUtxoFail x) = Sum FromAlonzoUtxoFail 1 !> To x
       work (FromAlonzoUtxowFail x) = Sum FromAlonzoUtxowFail 2 !> To x
       work (UnequalCollateralReturn c1 c2) = Sum UnequalCollateralReturn 3 !> To c1 !> To c2
-      work (UnknownDataHash x) = Sum UnknownDataHash 4 !> To x
       work (DanglingWitnessDataHash x) = Sum DanglingWitnessDataHash 5 !> To x
 
 instance
@@ -383,7 +381,6 @@ instance
       work 1 = SumD FromAlonzoUtxoFail <! From
       work 2 = SumD FromAlonzoUtxowFail <! From
       work 3 = SumD UnequalCollateralReturn <! From <! From
-      work 4 = SumD UnknownDataHash <! From
       work 5 = SumD DanglingWitnessDataHash <! From
       work n = Invalid n
 

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -239,6 +239,5 @@ instance Mock c => Arbitrary (BabbageUtxoPred (BabbageEra c)) where
       [ FromAlonzoUtxoFail <$> arbitrary,
         FromAlonzoUtxowFail <$> arbitrary,
         UnequalCollateralReturn <$> arbitrary <*> arbitrary,
-        UnknownDataHash <$> arbitrary,
         DanglingWitnessDataHash <$> arbitrary
       ]

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Hashes
 
     -- * Script hashes
     ScriptHash (..),
+    DataHash,
   )
 where
 
@@ -31,6 +32,7 @@ import Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Crypto (ADDRHASH)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.SafeHash (SafeHash)
 import Control.DeepSeq (NFData)
 import Data.Aeson
 import Data.Compact.HashMap (Keyed)
@@ -59,6 +61,8 @@ data EraIndependentAuxiliaryData
 data EraIndependentScript
 
 data EraIndependentData
+
+type DataHash crypto = SafeHash crypto EraIndependentData
 
 data EraIndependentScriptData
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -140,8 +140,6 @@ ppBabbageUtxoPred (UnequalCollateralReturn c1 c2) =
   ppRecord
     "UnequalCollateralReturn"
     [("collateral needed", ppCoin c1), ("collateral returned", ppCoin c2)]
-ppBabbageUtxoPred (UnknownDataHash dhset) =
-  ppSexp "UnknownDataHashes" [ppSet ppDataHash dhset]
 ppBabbageUtxoPred (DanglingWitnessDataHash dhset) =
   ppSexp "DanglingWitnessDataHashes" [ppSet ppDataHash dhset]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
@@ -105,6 +105,12 @@ instance forall c. CC.Crypto c => HasTokens (AlonzoEra c) where
       pid = Mary.PolicyID (hashScript @(AlonzoEra c) s)
       an = Mary.AssetName $ BS.pack "an"
 
+instance forall c. CC.Crypto c => HasTokens (BabbageEra c) where
+  forge n s = Mary.Value 0 $ Map.singleton pid (Map.singleton an n)
+    where
+      pid = Mary.PolicyID (hashScript @(BabbageEra c) s)
+      an = Mary.AssetName $ BS.pack "an"
+
 -- =================================
 -- Make Scripts in Alonzo era
 

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -11,9 +11,8 @@ module Main where
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
 import Test.Cardano.Ledger.BaseTypes (baseTypesTests)
 import Test.Cardano.Ledger.Examples.TwoPhaseValidation
-  ( alonzoAPITests,
-    alonzoBBODYexamples,
-    alonzoUTXOWexamples,
+  ( allTrees,
+    alonzoAPITests,
     collectOrderingAlonzo,
   )
 import Test.Cardano.Ledger.Generic.Properties (genericProperties)
@@ -38,8 +37,7 @@ mainTests =
       Tools.tests,
       testGroup
         "STS Tests"
-        [ alonzoUTXOWexamples,
-          alonzoBBODYexamples,
+        [ allTrees,
           alonzoAPITests,
           collectOrderingAlonzo,
           alonzoProperties,


### PR DESCRIPTION
The tests now work in both Alonzo and Babbage eras. Fixed some errors in Updaters.hs
This constitutes a good base of unit tests for the Babbage Rules. They do not do Babbage specific things.