### PR TITLE
Improve SplitMap deserialization. Make interning stricter

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -121,7 +121,7 @@ import Cardano.Ledger.Val
     isZero,
   )
 import Control.DeepSeq (NFData (..), rwhnf)
-import Control.Monad (guard)
+import Control.Monad (guard, (<$!>))
 import Data.Bits
 import Data.Coders
 import Data.Maybe (fromMaybe)
@@ -616,7 +616,7 @@ instance
           TxOut_AddrHash28_AdaOnly_DataHash32 cred addr28Extra ada dataHash32 ->
             TxOut_AddrHash28_AdaOnly_DataHash32 (interns credsInterns cred) addr28Extra ada dataHash32
           txOut -> txOut
-    internTxOut <$> case lenOrIndef of
+    internTxOut <$!> case lenOrIndef of
       Nothing -> do
         a <- fromCBOR
         cv <- decodeNonNegative

--- a/libs/cardano-data/src/Data/Sharing.hs
+++ b/libs/cardano-data/src/Data/Sharing.hs
@@ -28,7 +28,7 @@ module Data.Sharing
 where
 
 import Cardano.Binary (Decoder, FromCBOR (..), decodeListLen, dropMap)
-import Control.Monad (void)
+import Control.Monad (void, (<$!>))
 import Control.Monad.Trans
 import Control.Monad.Trans.State.Strict
 import Data.BiMap (BiMap (..), biMapFromMap)
@@ -221,7 +221,7 @@ instance (Ord a, Ord b, FromCBOR a, FromCBOR b) => FromSharedCBOR (BiMap b a b) 
   getShare (MkBiMap m1 m2) = (internsFromMap m1, internsFromMap m2)
 
 -- | Share every item in a functor, have deserializing it
-fromShareCBORfunctor :: (FromCBOR (f b), Functor f) => Interns b -> Decoder s (f b)
+fromShareCBORfunctor :: (FromCBOR (f b), Monad f) => Interns b -> Decoder s (f b)
 fromShareCBORfunctor kis = do
   sm <- fromCBOR
-  pure (interns kis <$> sm)
+  pure (interns kis <$!> sm)


### PR DESCRIPTION
Current deserialization for Map is a bit dumb: first it deserializes into a list, which is then reversed and only after that it is converted to a `Map`. It makes sense only for preservation of semantics of deserialization in presence of duplicate keys. For UTxO we know for sure there will never be any duplicate TxIns, which means that we can construct a Map as it is being deserialized thus avoiding intermediate list allocations, which saves memory and about 20% in deserialization time.

This PR also reduces memory overhead during deserialization by making internin a little stricter