### PR TITLE
babbage unit tests

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -37,9 +37,9 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (AlonzoUTXO)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo (UTXOS)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Alonzo (AlonzoUTXOW)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
-import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..), minfee)
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..), alonzoInputHashes, minfee)
 import Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut (TxOut), getAlonzoTxOutEitherAddr)
-import Cardano.Ledger.Alonzo.TxInfo (HasTxInfo (..), alonzoTxInfo, validScript)
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo, validScript)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -169,7 +169,6 @@ instance
 
 instance CC.Crypto c => UsesTxOut (AlonzoEra c) where
   makeTxOut _proxy addr val = TxOut addr val SNothing
-  getTxOutExtras (TxOut _ _ dhashM) = (dhashM, SNothing)
 
 instance CC.Crypto c => API.CLI (AlonzoEra c) where
   evaluateMinFee = minfee
@@ -221,8 +220,9 @@ instance CC.Crypto c => EraModule.SupportsSegWit (AlonzoEra c) where
 
 instance API.ShelleyEraCrypto c => API.ShelleyBasedEra (AlonzoEra c)
 
-instance CC.Crypto c => HasTxInfo (AlonzoEra c) where
+instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo
+  inputDataHashes = alonzoInputHashes
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -92,6 +92,7 @@ import Data.Default (def)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
 import qualified Data.Set as Set
+import GHC.Records (HasField (..))
 
 -- =====================================================
 
@@ -223,6 +224,7 @@ instance API.ShelleyEraCrypto c => API.ShelleyBasedEra (AlonzoEra c)
 instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo
   inputDataHashes = alonzoInputHashes
+  txscripts _ = txscripts' . getField @"wits"
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -34,8 +34,8 @@ import Cardano.Ledger.Alonzo.Tx
     txdats',
   )
 import Cardano.Ledger.Alonzo.TxInfo
-  ( FailureDescription (..),
-    HasTxInfo (..),
+  ( ExtendedUTxO (..),
+    FailureDescription (..),
     ScriptResult (..),
     TranslationError (..),
     andResult,
@@ -152,7 +152,7 @@ instance (CC.Crypto crypto) => FromCBOR (CollectError crypto) where
 collectTwoPhaseScriptInputs ::
   forall era.
   ( Era era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     Core.Script era ~ AlonzoScript.Script era,
     HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.Alonzo.TxInfo
     runPLCScript,
     valContext,
   )
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), txscripts', unTxDats)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txwitsVKey'), unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (ScriptHashObj))
@@ -168,21 +168,21 @@ collectTwoPhaseScriptInputs ::
   UTxO era ->
   Either [CollectError (Crypto era)] [(AlonzoScript.Script era, [Data era], ExUnits, CostModel)]
 collectTwoPhaseScriptInputs ei sysS pp tx utxo =
-  let scriptsUsed = Map.elems . txscripts' $ getField @"wits" tx
-      usedLanguages = [lang | (AlonzoScript.PlutusScript lang _) <- scriptsUsed]
+  let usedLanguages = [lang | (AlonzoScript.PlutusScript lang _) <- Map.elems scriptsUsed]
       costModels = getField @"_costmdls" pp
       missingCMs = [lang | lang <- usedLanguages, lang `Map.notMember` costModels]
    in case missingCMs of
         l : _ -> Left [NoCostModel l]
         _ -> merge (apply costModels) (map redeemer needed) (map getscript needed) (Right [])
   where
+    scriptsUsed = txscripts utxo tx
     txinfo lang = runIdentity $ txInfo pp lang ei sysS utxo tx
     needed = filter knownToNotBe1Phase $ scriptsNeeded utxo tx
     -- The formal spec achieves the same filtering as knownToNotBe1Phase
     -- by use of the (partial) language function, which is not defined
     -- on 1-phase scripts.
     knownToNotBe1Phase (_, sh) =
-      case sh `Map.lookup` txscripts' (getField @"wits" tx) of
+      case sh `Map.lookup` scriptsUsed of
         Just (AlonzoScript.PlutusScript _ _) -> True
         Just (AlonzoScript.TimelockScript _) -> False
         Nothing -> True
@@ -191,7 +191,7 @@ collectTwoPhaseScriptInputs ei sysS pp tx utxo =
         Just (d, eu) -> Right (sp, d, eu)
         Nothing -> Left (NoRedeemer sp)
     getscript (_, hash) =
-      case hash `Map.lookup` txscripts' (getField @"wits" tx) of
+      case hash `Map.lookup` scriptsUsed of
         Just script -> Right script
         Nothing -> Left (NoWitness hash)
     apply costs (sp, d, eu) script@(AlonzoScript.PlutusScript lang _) =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -45,7 +45,7 @@ import Cardano.Ledger.Alonzo.Tx
     ValidatedTx (..),
   )
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
-import Cardano.Ledger.Alonzo.TxInfo (FailureDescription (..), HasTxInfo (..), ScriptResult (..))
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), FailureDescription (..), ScriptResult (..))
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import Cardano.Ledger.BaseTypes
   ( Globals,
@@ -105,7 +105,7 @@ instance
   forall era.
   ( Era era,
     ConcreteAlonzo era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     Embed (Core.EraRule "PPUP" era) (UTXOS era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -140,7 +140,7 @@ instance
 utxosTransition ::
   forall era.
   ( ConcreteAlonzo era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
@@ -161,7 +161,7 @@ scriptsValidateTransition ::
   forall era.
   ( ValidateScript era,
     ConcreteAlonzo era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     STS (UTXOS era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -206,7 +206,7 @@ scriptsNotValidateTransition ::
   forall era.
   ( ValidateScript era,
     ConcreteAlonzo era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     STS (UTXOS era)
   ) =>
   TransitionRule (UTXOS era)
@@ -350,7 +350,7 @@ constructValidated ::
     HasField "_costmdls" (Core.PParams era) (Map.Map Language CostModel),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     HasField "vldt" (Core.TxBody era) ValidityInterval,
-    HasTxInfo era
+    ExtendedUTxO era
   ) =>
   Globals ->
   UtxoEnv era ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Alonzo.Scripts
   )
 import Cardano.Ledger.Alonzo.Tx (DataHash, ScriptPurpose (Spending), rdptr)
 import Cardano.Ledger.Alonzo.TxInfo
-  ( HasTxInfo,
+  ( ExtendedUTxO,
     TranslationError,
     VersionedTxInfo (..),
     exBudgetToExUnits,
@@ -132,7 +132,7 @@ languagesUsed tx = Set.fromList $ mapMaybe getLanguage (getScripts tx)
 evaluateTransactionExecutionUnits ::
   forall era m.
   ( Era era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -380,6 +380,11 @@ class ExtendedUTxO era where
     UTxO era ->
     (Set (DataHash (Crypto era)), Set (TxIn (Crypto era)))
 
+  txscripts ::
+    UTxO era ->
+    Core.Tx era ->
+    Map.Map (ScriptHash (Crypto era)) (Core.Script era)
+
 alonzoTxInfo ::
   forall era m.
   ( Era era,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.Rules.Bbody as Alonzo (AlonzoBBODY)
 import Cardano.Ledger.Alonzo.Rules.Utxo (utxoEntrySize)
 import Cardano.Ledger.Alonzo.Scripts (Script (..), isPlutusScript)
-import Cardano.Ledger.Alonzo.TxInfo (HasTxInfo (..), validScript)
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), validScript)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq (..), hashTxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..), ValidateAuxiliaryData (..))
@@ -38,6 +38,7 @@ import Cardano.Ledger.Babbage.Rules.Ledger (BabbageLEDGER)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUTXO)
 import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUTXOW)
+import Cardano.Ledger.Babbage.Scripts (babbageInputDataHashes)
 import Cardano.Ledger.Babbage.Tx (ValidatedTx (..), minfee)
 import Cardano.Ledger.Babbage.TxBody (Datum (..), TxBody, TxOut (TxOut), getBabbageTxOutEitherAddr)
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
@@ -171,8 +172,6 @@ instance
 
 instance CC.Crypto c => UsesTxOut (BabbageEra c) where
   makeTxOut _proxy addr val = TxOut addr val NoDatum SNothing
-  getTxOutExtras (TxOut _ _ (DatumHash h) scriptM) = (SJust h, scriptM)
-  getTxOutExtras (TxOut _ _ _ scriptM) = (SNothing, scriptM)
 
 instance CC.Crypto c => API.CLI (BabbageEra c) where
   evaluateMinFee = minfee
@@ -222,8 +221,9 @@ instance CC.Crypto c => EraModule.SupportsSegWit (BabbageEra c) where
   hashTxSeq = Alonzo.hashTxSeq
   numSegComponents = 4
 
-instance CC.Crypto c => HasTxInfo (BabbageEra c) where
+instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
   txInfo = babbageTxInfo
+  inputDataHashes = babbageInputDataHashes
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Babbage.Rules.Ledger (BabbageLEDGER)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUTXO)
 import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUTXOW)
-import Cardano.Ledger.Babbage.Scripts (babbageInputDataHashes)
+import Cardano.Ledger.Babbage.Scripts (babbageInputDataHashes, babbageTxScripts)
 import Cardano.Ledger.Babbage.Tx (ValidatedTx (..), minfee)
 import Cardano.Ledger.Babbage.TxBody (Datum (..), TxBody, TxOut (TxOut), getBabbageTxOutEitherAddr)
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
@@ -224,6 +224,7 @@ instance CC.Crypto c => EraModule.SupportsSegWit (BabbageEra c) where
 instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
   txInfo = babbageTxInfo
   inputDataHashes = babbageInputDataHashes
+  txscripts = babbageTxScripts
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -11,7 +11,7 @@ module Cardano.Ledger.Babbage.Collateral where
 
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Tx (isTwoPhaseScriptAddressFromMap)
-import Cardano.Ledger.Babbage.Scripts (txscripts)
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (txscripts))
 import Cardano.Ledger.Babbage.TxBody
   ( TxBody (..),
     TxOut (..),
@@ -37,9 +37,8 @@ import Numeric.Natural (Natural)
 
 isTwoPhaseScriptAddress ::
   forall era.
-  ( Core.TxOut era ~ TxOut era,
-    ValidateScript era,
-    Core.TxBody era ~ TxBody era
+  ( ValidateScript era,
+    ExtendedUTxO era
   ) =>
   Core.Tx era ->
   UTxO era ->

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -24,7 +24,6 @@ import Cardano.Ledger.BaseTypes (txIxFromIntegral)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto), ValidateScript (..))
-import Cardano.Ledger.Shelley.Constraints (UsesTxOut (..))
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
 import Cardano.Ledger.TxIn (TxIn (..), txid)
 import Cardano.Ledger.Val ((<->))
@@ -38,7 +37,7 @@ import Numeric.Natural (Natural)
 
 isTwoPhaseScriptAddress ::
   forall era.
-  ( UsesTxOut era,
+  ( Core.TxOut era ~ TxOut era,
     ValidateScript era,
     Core.TxBody era ~ TxBody era
   ) =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 -- ,FailureDescription (..))
 
-import Cardano.Ledger.Alonzo.TxInfo (HasTxInfo, ScriptResult (Fails, Passes))
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, ScriptResult (Fails, Passes))
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import qualified Cardano.Ledger.Babbage.Collateral as Babbage
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
@@ -75,7 +75,7 @@ instance
   forall era.
   ( Era era,
     ConcreteBabbage era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     Embed (Core.EraRule "PPUP" era) (BabbageUTXOS era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -107,7 +107,7 @@ instance
 utxosTransition ::
   forall era.
   ( ConcreteBabbage era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
     Signal (Core.EraRule "PPUP" era) ~ Maybe (Update era),
@@ -128,7 +128,7 @@ scriptsYes ::
   forall era.
   ( ValidateScript era,
     ConcreteBabbage era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     STS (BabbageUTXOS era),
     Environment (Core.EraRule "PPUP" era) ~ PPUPEnv era,
     State (Core.EraRule "PPUP" era) ~ PPUPState era,
@@ -178,7 +178,7 @@ scriptsNo ::
   forall era.
   ( ValidateScript era,
     ConcreteBabbage era,
-    HasTxInfo era,
+    ExtendedUTxO era,
     STS (BabbageUTXOS era)
   ) =>
   TransitionRule (BabbageUTXOS era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -26,7 +26,8 @@ import Cardano.Ledger.Alonzo.Rules.Ledger (AlonzoLEDGER)
 import Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (UtxoEvent)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoEvent (WrappedShelleyEraEvent), UtxowPredicateFail, hasExactSetOfRedeemers, missingRequiredDatums, ppViewHashesMatch, requiredSignersAreWitnessed, witsVKeyNeeded)
 import Cardano.Ledger.Alonzo.Scripts (Script)
-import Cardano.Ledger.Alonzo.Tx (ScriptPurpose, ValidatedTx (..), txInputHashes, wits)
+import Cardano.Ledger.Alonzo.Tx (ScriptPurpose, ValidatedTx (..), wits)
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (inputDataHashes))
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo (TxDats (..), TxWitness (..), txdats')
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Babbage.Collateral as Babbage (isTwoPhaseScriptAddress)
@@ -105,7 +106,7 @@ danglingWitnessDataHashes inputHashes (Alonzo.TxDats m) outs =
 validateFailedBabbageScripts ::
   forall era.
   ( ValidateScript era,
-    UsesTxOut era,
+    Core.TxOut era ~ TxOut era,
     Core.Script era ~ Script era,
     Core.TxBody era ~ TxBody era
   ) =>
@@ -137,7 +138,7 @@ babbageUtxowTransition ::
   forall era.
   ( ValidateScript era,
     ValidateAuxiliaryData era (Crypto era),
-    UsesTxOut era,
+    ExtendedUTxO era,
     STS (BabbageUTXOW era),
     -- Fix some Core types to the Babbage Era
     ConcreteBabbage era,
@@ -164,7 +165,7 @@ babbageUtxowTransition = do
       {- txwitscripts tx ∪ {hash s ↦ s | ( , , , s) ∈ utxo (spendInputs tx ∪ refInputs tx)} -}
       hashScriptMap = txscripts utxo tx
       {- { h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isNonNativeScriptAddress tx a} -}
-      (inputHashes, _) = txInputHashes (txscripts utxo tx) tx utxo
+      (inputHashes, _) = inputDataHashes (txscripts utxo tx) tx utxo
 
   -- check scripts
   {- ∀s ∈ range(txscripts txw utxo ∩ Script^{ph1}), validateScript s tx -}
@@ -232,7 +233,7 @@ instance
   forall era.
   ( ValidateScript era,
     ValidateAuxiliaryData era (Crypto era),
-    UsesTxOut era,
+    ExtendedUTxO era,
     Signable (DSIGN (Crypto era)) (Hash (HASH (Crypto era)) EraIndependentTxBody),
     -- Fix some Core types to the Babbage Era
     Core.Tx era ~ ValidatedTx era,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -11,15 +11,6 @@ module Cardano.Ledger.Babbage.Rules.Utxow where
 
 import Cardano.Crypto.DSIGN.Class (Signable)
 import Cardano.Crypto.Hash.Class (Hash, hash)
--- Rule,
--- RuleType (Transition),
-
--- (?!),
-
--- StrictMaybe (..),
-
--- strictMaybeToMaybe,
-
 import Cardano.Ledger.Alonzo.Data (DataHash)
 import Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo (language, scriptsNeeded)
 import Cardano.Ledger.Alonzo.Rules.Ledger (AlonzoLEDGER)
@@ -27,7 +18,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo (UtxoEvent)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoEvent (WrappedShelleyEraEvent), UtxowPredicateFail, hasExactSetOfRedeemers, missingRequiredDatums, ppViewHashesMatch, requiredSignersAreWitnessed, witsVKeyNeeded)
 import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.Alonzo.Tx (ScriptPurpose, ValidatedTx (..), wits)
-import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (inputDataHashes))
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo (TxDats (..), TxWitness (..), txdats')
 import Cardano.Ledger.AuxiliaryData (ValidateAuxiliaryData)
 import qualified Cardano.Ledger.Babbage.Collateral as Babbage (isTwoPhaseScriptAddress)
@@ -37,7 +28,6 @@ import Cardano.Ledger.Babbage.Rules.Utxo
     BabbageUtxoPred (..),
   )
 import Cardano.Ledger.Babbage.Rules.Utxos (ConcreteBabbage)
-import Cardano.Ledger.Babbage.Scripts (txscripts)
 import Cardano.Ledger.Babbage.TxBody
   ( Datum (..),
     TxBody (..),
@@ -106,9 +96,8 @@ danglingWitnessDataHashes inputHashes (Alonzo.TxDats m) outs =
 validateFailedBabbageScripts ::
   forall era.
   ( ValidateScript era,
-    Core.TxOut era ~ TxOut era,
-    Core.Script era ~ Script era,
-    Core.TxBody era ~ TxBody era
+    ExtendedUTxO era,
+    Core.Script era ~ Script era
   ) =>
   Core.Tx era ->
   UTxO era ->
@@ -222,7 +211,7 @@ babbageUtxowTransition = do
   -- which appears in the spec, seems broken since costmdls is a projection of PPrams, not Tx
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
-  runTest $ ppViewHashesMatch tx txbody pp
+  runTest $ ppViewHashesMatch tx txbody pp utxo
 
   trans @(Core.EraRule "UTXO" era) $
     TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -977,16 +977,19 @@ txOutData = \case
   TxOut_AddrHash28_AdaOnly {} -> Nothing
   TxOut_AddrHash28_AdaOnly_DataHash32 {} -> Nothing
 
+-- | Return the data hash of a given transaction output, if one is present.
+--  Note that this function does *not* return the hash of any inline datums
+--  that are present.
 txOutDataHash :: Era era => TxOut era -> Maybe (DataHash (Crypto era))
 txOutDataHash = \case
   TxOutCompact' {} -> Nothing
   TxOutCompactDH' _ _ dh -> Just dh
-  TxOutCompactDatum _ _ binaryData -> Just $! hashBinaryData binaryData
+  TxOutCompactDatum _ _ _ -> Nothing
   TxOutCompactRefScript _ _ datum _ ->
     case datum of
       NoDatum -> Nothing
       DatumHash dh -> Just dh
-      Datum binaryData -> Just $! hashBinaryData binaryData
+      Datum _ -> Nothing
   TxOut_AddrHash28_AdaOnly {} -> Nothing
   TxOut_AddrHash28_AdaOnly_DataHash32 _ _ _ dataHash32 -> decodeDataHash32 dataHash32
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Constraints.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Constraints.hs
@@ -25,13 +25,11 @@ import Cardano.Ledger.Core
     Value,
   )
 import Cardano.Ledger.Era (Crypto, Era (..))
-import Cardano.Ledger.Hashes (DataHash, EraIndependentTxBody)
+import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.SafeHash (HashAnnotated)
 import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val)
 import Data.Kind (Constraint, Type)
-import Data.Maybe.Strict (StrictMaybe (SNothing))
 import Data.Proxy (Proxy)
-import GHC.Records (HasField (..))
 
 --------------------------------------------------------------------------------
 -- Shelley Era
@@ -65,17 +63,6 @@ class
   UsesTxOut era
   where
   makeTxOut :: Proxy era -> Addr (Crypto era) -> Value era -> TxOut era
-  getTxOutExtras :: TxOut era -> (StrictMaybe (DataHash (Crypto era)), StrictMaybe (Script era))
-  getTxOutExtras _txout = (SNothing, SNothing)
-
-txOutView ::
-  forall era.
-  UsesTxOut era =>
-  TxOut era ->
-  (Addr (Crypto era), Value era, StrictMaybe (DataHash (Crypto era)), StrictMaybe (Script era))
-txOutView txout =
-  case getTxOutExtras txout of
-    (mdh, mds) -> (getTxOutAddr txout, getField @"value" txout, mdh, mds)
 
 type UsesScript era =
   ( Era era,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -45,6 +45,7 @@ library
   exposed-modules:
     Test.Cardano.Ledger.Alonzo.Tools
     Test.Cardano.Ledger.BaseTypes
+    Test.Cardano.Ledger.Examples.BabbageFeatures
     Test.Cardano.Ledger.Examples.TwoPhaseValidation
     Test.Cardano.Ledger.Generic.Indexed
     Test.Cardano.Ledger.Generic.Fields

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -1,0 +1,303 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Examples.BabbageFeatures where
+
+import qualified Cardano.Crypto.Hash as CH
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..))
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage
+import Cardano.Ledger.BaseTypes
+  ( Network (..),
+    StrictMaybe (..),
+    mkTxIxPartial,
+  )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (EraRule)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential
+  ( Credential (..),
+    StakeReference (..),
+  )
+import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Era (Era (..), ValidateScript (hashScript))
+import Cardano.Ledger.Keys
+  ( KeyPair (..),
+    KeyRole (..),
+    hashKey,
+  )
+import Cardano.Ledger.Pretty.Babbage ()
+import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.Shelley.API (ProtVer (..), UTxO (..))
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), smartUTxOState)
+import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.Val (inject)
+import Control.State.Transition.Extended hiding (Assertion)
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Default.Class (Default (..))
+import qualified Data.Map as Map
+import GHC.Stack
+import qualified Plutus.V1.Ledger.Api as Plutus
+import Test.Cardano.Ledger.Examples.TwoPhaseValidation
+  ( Expect (..),
+    expectedUTxO,
+    freeCostModel,
+    testUTXOW,
+    trustMeP,
+  )
+import Test.Cardano.Ledger.Generic.Fields
+  ( PParamsField (..),
+    TxBodyField (..),
+    TxField (..),
+    TxOutField (..),
+    WitnessesField (..),
+  )
+import Test.Cardano.Ledger.Generic.PrettyCore ()
+import Test.Cardano.Ledger.Generic.Proof
+import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic (..))
+import Test.Cardano.Ledger.Generic.Updaters
+import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
+import Test.Cardano.Ledger.Shelley.Utils (RawSeed (..), mkKeyPair)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase)
+
+-- =======================
+-- Setup the initial state
+-- =======================
+
+scriptAddr :: forall era. (Scriptic era) => Proof era -> Core.Script era -> Addr (Crypto era)
+scriptAddr _pf s = Addr Testnet pCred sCred
+  where
+    pCred = ScriptHashObj . hashScript @era $ s
+    (_ssk, svk) = mkKeyPair @(Crypto era) (RawSeed 0 0 0 0 0)
+    sCred = StakeRefBase . KeyHashObj . hashKey $ svk
+
+someKeys :: forall era. Era era => Proof era -> KeyPair 'Payment (Crypto era)
+someKeys _pf = KeyPair vk sk
+  where
+    (sk, vk) = mkKeyPair @(Crypto era) (RawSeed 1 1 1 1 1)
+
+plainAddr :: forall era. Era era => Proof era -> Addr (Crypto era)
+plainAddr pf = Addr Testnet pCred sCred
+  where
+    (_ssk, svk) = mkKeyPair @(Crypto era) (RawSeed 0 0 0 0 2)
+    pCred = KeyHashObj . hashKey . vKey $ someKeys pf
+    sCred = StakeRefBase . KeyHashObj . hashKey $ svk
+
+somePlainOutput :: Scriptic era => Proof era -> Core.TxOut era
+somePlainOutput pf =
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 1000)]
+
+mkGenesisTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => Integer -> TxIn crypto
+mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
+
+collateralOutput :: Scriptic era => Proof era -> Core.TxOut era
+collateralOutput pf =
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 5)]
+
+datumExample1 :: Data era
+datumExample1 = Data (Plutus.I 123)
+
+inlineDatumOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+inlineDatumOutput pf =
+  newTxOut
+    pf
+    [ Address (scriptAddr pf (alwaysAlt 3 pf)),
+      Amount (inject $ Coin 5000),
+      Datum (Babbage.Datum . dataToBinaryData $ datumExample1 @era)
+    ]
+
+referenceScriptOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+referenceScriptOutput pf =
+  newTxOut
+    pf
+    [ Address (plainAddr pf),
+      Amount (inject $ Coin 10),
+      Datum (Babbage.Datum . dataToBinaryData $ datumExample1 @era),
+      RefScript (SJust $ alwaysAlt 3 pf)
+    ]
+
+initUTxO :: PostShelley era => Proof era -> UTxO era
+initUTxO pf =
+  UTxO $
+    SplitMap.fromList $
+      [ (mkGenesisTxIn 1, inlineDatumOutput pf),
+        (mkGenesisTxIn 2, referenceScriptOutput pf)
+      ]
+        ++ map (\i -> (mkGenesisTxIn i, somePlainOutput pf)) [3 .. 8]
+        ++ map (\i -> (mkGenesisTxIn i, collateralOutput pf)) [11 .. 18]
+
+defaultPPs :: [PParamsField era]
+defaultPPs =
+  [ Costmdls $ Map.fromList [(PlutusV1, freeCostModel), (PlutusV2, freeCostModel)],
+    MaxValSize 1000000000,
+    MaxTxExUnits $ ExUnits 1000000 1000000,
+    MaxBlockExUnits $ ExUnits 1000000 1000000,
+    ProtocolVersion $ ProtVer 7 0,
+    CollateralPercentage 100
+  ]
+
+pp :: Proof era -> Core.PParams era
+pp pf = newPParams pf defaultPPs
+
+-- =========================================================================
+--  Example 1: Spend a EUTxO with an inline datum
+-- =========================================================================
+
+redeemerExample1 :: Data era
+redeemerExample1 = Data (Plutus.I 42)
+
+validatingRedeemersEx1 :: Era era => Redeemers era
+validatingRedeemersEx1 =
+  Redeemers $
+    Map.singleton (RdmrPtr Tag.Spend 0) (redeemerExample1, ExUnits 5000 5000)
+
+outEx1 :: Scriptic era => Proof era -> Core.TxOut era
+outEx1 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 4995)]
+
+inlineDatumTxBody :: Scriptic era => Proof era -> Core.TxBody era
+inlineDatumTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [mkGenesisTxIn 1],
+      RefInputs' [mkGenesisTxIn 2],
+      Collateral' [mkGenesisTxIn 11],
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
+    ]
+
+inlineDatumTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+inlineDatumTx pf =
+  newTx
+    pf
+    [ Body (inlineDatumTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (inlineDatumTxBody pf)) (someKeys pf)],
+          ScriptWits' [alwaysAlt 3 pf],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+utxoEx1 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx1 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (inlineDatumTxBody pf) (outEx1 pf)) 1
+
+utxoStEx1 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx1 pf = smartUTxOState (utxoEx1 pf) (Coin 0) (Coin 5) def
+
+-- =========================================================================
+--  Example 2: Use a reference script
+-- =========================================================================
+
+outEx2 :: Scriptic era => Proof era -> Core.TxOut era
+outEx2 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 4995)]
+
+referenceScriptTxBody :: Scriptic era => Proof era -> Core.TxBody era
+referenceScriptTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [mkGenesisTxIn 1],
+      RefInputs' [mkGenesisTxIn 2],
+      Collateral' [mkGenesisTxIn 11],
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
+    ]
+
+referenceScriptTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+referenceScriptTx pf =
+  newTx
+    pf
+    [ Body (referenceScriptTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (referenceScriptTxBody pf)) (someKeys pf)],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+utxoEx2 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx2 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (referenceScriptTxBody pf) (outEx2 pf)) 1
+
+utxoStEx2 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx2 pf = smartUTxOState (utxoEx2 pf) (Coin 0) (Coin 5) def
+
+testU ::
+  forall era.
+  ( GoodCrypto (Crypto era),
+    Default (State (EraRule "PPUP" era)),
+    PostShelley era
+  ) =>
+  Proof era ->
+  Core.Tx era ->
+  Either [(PredicateFailure (Core.EraRule "UTXOW" era))] (State (Core.EraRule "UTXOW" era)) ->
+  Assertion
+testU pf tx expect = testUTXOW (UTXOW pf) (initUTxO pf) (pp pf) tx expect
+
+genericBabbageFeatures ::
+  forall era.
+  ( State (EraRule "UTXOW" era) ~ UTxOState era,
+    GoodCrypto (Crypto era),
+    Default (State (EraRule "PPUP" era)),
+    PostShelley era
+  ) =>
+  Proof era ->
+  TestTree
+genericBabbageFeatures pf =
+  testGroup
+    (show pf ++ " UTXOW examples")
+    [ testGroup
+        "valid transactions"
+        [ testCase "inline datum" $
+            testU
+              pf
+              (trustMeP pf True $ inlineDatumTx pf)
+              (Right . utxoStEx1 $ pf),
+          testCase "reference script" $
+            testU
+              pf
+              (trustMeP pf True $ referenceScriptTx pf)
+              (Right . utxoStEx2 $ pf)
+        ]
+    ]
+
+babbageFeatures :: TestTree
+babbageFeatures =
+  testGroup
+    "Babbage Features"
+    [ genericBabbageFeatures (Babbage Mock)
+    ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -167,7 +167,7 @@ ppUtxowPredicateFail (NonOutputSupplimentaryDatums s1 s2) =
     ]
 ppUtxowPredicateFail (PPViewHashesDontMatch h1 h2) =
   ppRecord
-    "NonOutputSupplimentaryDatums"
+    "PPViewHashesDontMatch"
     [ ("PPHash in the TxBody", ppStrictMaybe ppSafeHash h1),
       ("PPHash Computed from the current Protocol Parameters", ppStrictMaybe ppSafeHash h2)
     ]

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -10,6 +10,7 @@ module Main where
 
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
 import Test.Cardano.Ledger.BaseTypes (baseTypesTests)
+import Test.Cardano.Ledger.Examples.BabbageFeatures (babbageFeatures)
 import Test.Cardano.Ledger.Examples.TwoPhaseValidation
   ( allTrees,
     alonzoAPITests,
@@ -38,6 +39,7 @@ mainTests =
       testGroup
         "STS Tests"
         [ allTrees,
+          babbageFeatures,
           alonzoAPITests,
           collectOrderingAlonzo,
           alonzoProperties,


### PR DESCRIPTION
This PR adds two new units tests for some Babbage era features, namely:

* using an inline datum
* using a reference script

I also fixed some problems along the way. It might be easier to read this PR commit by commit. The fixes are:

* ~I reverted the bump to the index-state, we can add it back when we resolve the problems with https://github.com/input-output-hk/cardano-ledger/pull/2677~
* I :cherries:-picked the commit from @TimSheard 's PR https://github.com/input-output-hk/cardano-ledger/pull/2680 that added the `ExtendedUTxO` class.
* I added another method to the `ExtendedUTxO` class, `txscripts`, so that we could reuse Alonzo functions and predicates.
* I made it so that `txOutDataHash` no longer returns hashed inline datums. This function is fed into the `HasField "datahash"` instance, and I found it confusing for this "accessor" to retrieve the inline datums.