### PR TITLE
add Babbage CDDL tests

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -41,7 +41,7 @@ import Cardano.Binary
     ToCBOR (..),
     TokenType (..),
     decodeAnnotator,
-    decodeTag,
+    decodeNestedCborBytes,
     encodeTag,
     peekTokenType,
     withSlice,
@@ -129,13 +129,12 @@ newtype BinaryData era = BinaryData ShortByteString
 instance (Crypto era ~ c) => HashAnnotated (BinaryData era) EraIndependentData c
 
 instance Typeable era => ToCBOR (BinaryData era) where
-  toCBOR (BinaryData sbs) = encodeTag 42 <> toCBOR sbs
+  toCBOR (BinaryData sbs) = encodeTag 24 <> toCBOR sbs
 
 instance Typeable era => FromCBOR (BinaryData era) where
   fromCBOR = do
-    42 <- decodeTag
-    sbs <- fromCBOR
-    either fail pure $! makeBinaryData sbs
+    bs <- decodeNestedCborBytes
+    either fail pure $! makeBinaryData (toShort bs)
 
 makeBinaryData :: ShortByteString -> Either String (BinaryData era)
 makeBinaryData sbs = do

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -13,7 +13,10 @@ copyright:           2020 Input Output (Hong Kong) Ltd.
 category:            Network
 build-type:          Simple
 
--- extra-source-files:
+extra-source-files:
+  cddl-files/babbage.cddl
+  cddl-files/real/crypto.cddl
+  cddl-files/mock/extras.cddl
 
 source-repository head
   type:     git
@@ -73,7 +76,8 @@ test-suite cardano-ledger-babbage-test
   hs-source-dirs:
     test
   other-modules:
-    Test.Cardano.Ledger.Babbage.Serialisation.Tripping
+    Test.Cardano.Ledger.Babbage.Serialisation.Tripping,
+    Test.Cardano.Ledger.Babbage.Serialisation.CDDL
   build-depends:
     QuickCheck,
     base16-bytestring,

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -47,24 +47,24 @@ operational_cert =
 protocol_version = (uint, uint)
 
 transaction_body =
- { 0 : set<transaction_input>    ; inputs
- , 1 : [* transaction_output]
- , 2 : coin                      ; fee
- , ? 3 : uint                    ; time to live
- , ? 4 : [* certificate]
- , ? 5 : withdrawals
- , ? 6 : update
- , ? 7 : auxiliary_data_hash
- , ? 8 : uint                    ; validity interval start
- , ? 9 : mint
- , ? 11 : script_data_hash
- , ? 13 : set<transaction_input> ; collateral inputs
- , ? 14 : required_signers
- , ? 15 : network_id
- , ? 16 : transaction_output     ; collateral return; New
- , ? 17 : coin                   ; total collateral; New
- , ? 18 : set<transaction_input> ; reference inputs; New
- }
+  { 0 : set<transaction_input>    ; inputs
+  , 1 : [* transaction_output]
+  , 2 : coin                      ; fee
+  , ? 3 : uint                    ; time to live
+  , ? 4 : [* certificate]
+  , ? 5 : withdrawals
+  , ? 6 : update
+  , ? 7 : auxiliary_data_hash
+  , ? 8 : uint                    ; validity interval start
+  , ? 9 : mint
+  , ? 11 : script_data_hash
+  , ? 13 : set<transaction_input> ; collateral inputs
+  , ? 14 : required_signers
+  , ? 15 : network_id
+  , ? 16 : transaction_output     ; collateral return; New
+  , ? 17 : coin                   ; total collateral; New
+  , ? 18 : set<transaction_input> ; reference inputs; New
+  }
 
 required_signers = set<$addr_keyhash>
 
@@ -72,7 +72,7 @@ transaction_input = [ transaction_id : $hash32
                     , index : uint
                     ]
 
-transaction_output = legacy_Transaction_output / post_alonzo_transaction_output ; New
+transaction_output = legacy_transaction_output / post_alonzo_transaction_output ; New
 
 legacy_transaction_output =
   [ address
@@ -84,12 +84,11 @@ legacy_transaction_output =
 ; a transaction output to include both a datum hash and a datum.
 ; In other words, keys 2 and 3 are mutually exclusive.
 post_alonzo_transaction_output =
-     { 0 => address
-     , 1 => value
-     , ? 2 => datum_hash
-     , ? 3 => datum      ; New; inline datum
-     , ? 4 => script     ; New; script reference
-     }
+  { 0 : address
+  , 1 : value
+  , ? 2 : datum      ; New; inline datum
+  , ? 3 : script_ref ; New; script reference
+  }
 
 script_data_hash = $hash32
 ; This is a hash of data which may affect evaluation of a script.
@@ -401,3 +400,12 @@ genesishash           = $hash28
 vrf_keyhash           = $hash32
 auxiliary_data_hash   = $hash32
 pool_metadata_hash    = $hash32
+
+datum_hash = $hash32
+data = #6.24(bytes .cbor plutus_data)
+
+datum = [ 0 // 1, $hash32 // 2, data ]
+
+script_ref = #6.24(bytes .cbor script)
+
+script = [ 0, native_script // 1, plutus_script // 2, plutus_script ]

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Babbage.Serialisation.CDDL
+  ( tests,
+  )
+where
+
+import Cardano.Ledger.Alonzo.Data (Data)
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers, TxWitness)
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.PParams (PParamsUpdate)
+import Cardano.Ledger.Babbage.Tx (ValidatedTx)
+import Cardano.Ledger.Babbage.TxBody (Datum, TxOut)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
+import qualified Data.ByteString.Lazy as BSL
+import Test.Cardano.Ledger.Shelley.Serialisation.CDDLUtils
+  ( cddlAnnotatorTest,
+    cddlTest,
+  )
+import Test.Tasty (TestTree, testGroup, withResource)
+
+type B = BabbageEra StandardCrypto
+
+tests :: Int -> TestTree
+tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
+  testGroup "CDDL roundtrip tests" $
+    [ cddlTest @(Core.Value B) n "coin",
+      cddlAnnotatorTest @(Core.TxBody B) n "transaction_body",
+      cddlAnnotatorTest @(Core.AuxiliaryData B) n "auxiliary_data",
+      cddlAnnotatorTest @(MA.Timelock StandardCrypto) n "native_script",
+      cddlAnnotatorTest @(Data B) n "plutus_data",
+      cddlTest @(TxOut B) n "transaction_output",
+      cddlAnnotatorTest @(Core.Script B) n "script",
+      cddlTest @(Datum B) n "datum",
+      cddlAnnotatorTest @(TxWitness B) n "transaction_witness_set",
+      cddlTest @(PParamsUpdate B) n "protocol_param_update",
+      cddlAnnotatorTest @(Redeemers B) n "[* redeemer]",
+      cddlAnnotatorTest @(ValidatedTx B) n "transaction"
+    ]
+      <*> pure cddl
+
+combinedCDDL :: IO BSL.ByteString
+combinedCDDL = do
+  base <- BSL.readFile "cddl-files/babbage.cddl"
+  crypto <- BSL.readFile "cddl-files/real/crypto.cddl"
+  extras <- BSL.readFile "cddl-files/mock/extras.cddl"
+  pure $ base <> crypto <> extras

--- a/eras/babbage/test-suite/test/Tests.hs
+++ b/eras/babbage/test-suite/test/Tests.hs
@@ -8,6 +8,7 @@
 
 module Main where
 
+import qualified Test.Cardano.Ledger.Babbage.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Babbage.Serialisation.Tripping as Tripping
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
@@ -24,21 +25,24 @@ mainTests :: TestTree
 mainTests =
   testGroup
     "Babbage tests"
-    [ Tripping.tests
+    [ Tripping.tests,
+      CDDL.tests 5
     ]
 
 fastTests :: TestTree
 fastTests =
   testGroup
     "Babbage tests"
-    [ Tripping.tests
+    [ Tripping.tests,
+      CDDL.tests 1
     ]
 
 nightlyTests :: TestTree
 nightlyTests =
   testGroup
     "Babbage tests"
-    []
+    [ CDDL.tests 50
+    ]
 
 -- main entry point
 main :: IO ()

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/CDDLUtils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/CDDLUtils.hs
@@ -36,6 +36,8 @@ import Cardano.Prelude
     forM_,
     throwIO,
   )
+import Codec.CBOR.Read (deserialiseFromBytes)
+import Codec.CBOR.Term (decodeTerm)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy as BSL
 import Data.ByteString.Lazy.Char8 as Char8 (lines, unpack)
@@ -122,7 +124,10 @@ cddlTestCommon serializer decoder n cddlData = do
               [ "Failed to deserialize",
                 "Error: " <> show e,
                 "Generated diag: " <> Char8.unpack exampleDiag,
-                "Generated base16: " <> Char8.unpack (Base16.encode exampleBytes)
+                "Generated base16: " <> Char8.unpack (Base16.encode exampleBytes),
+                "terms: " <> case deserialiseFromBytes decodeTerm exampleBytes of
+                  Left e' -> show e'
+                  Right (_, terms) -> show terms
               ]
       let reencoded = serializer decoded
       verifyConforming reencoded cddl >>= \case


### PR DESCRIPTION
this PR contains 

- bug fixes for some `From/ToCBOR` instances
- uses nested cbor functions from https://input-output-hk.github.io/ouroboros-network/cardano-binary/Cardano-Binary-Serialize.html#g:1 which use the proper `encoded-cbor` tag https://datatracker.ietf.org/doc/html/rfc8610#appendix-D for cbor-in-cbor
- changes to the babbage cddl that let us use coders and help make cbor-in-cbor types more well defined
- more details in the serialization tests' error messages that were helpful to me while debugging failing tests