### PR TITLE
Revert `TotalRewardEvent` changes

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -156,10 +156,10 @@ newEpochTransition = do
       let updateRewards ru'@(RewardUpdate dt dr rs_ df _) = do
             let totRs = sumRewards (esPrevPp es) rs_
             Val.isZero (dt <> (dr <> toDeltaCoin totRs <> df)) ?! CorruptRewardUpdate ru'
-            let (es', _regRU) = applyRUpd' ru' es
+            let (es', regRU) = applyRUpd' ru' es
             -- This event (which is only generated once per epoch) must be generated even if the
             -- map is empty (db-sync depends on it).
-            tellEvent (TotalRewardEvent e rs_)
+            tellEvent $ TotalRewardEvent e regRU
             pure es'
       es' <- case ru of
         SNothing -> pure es

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -104,7 +104,7 @@ import Cardano.Ledger.Shelley.Rewards
     mkApparentPerformance,
     mkPoolRewardInfo,
   )
-import Cardano.Ledger.Shelley.Rules.NewEpoch (NewEpochEvent (TotalRewardEvent))
+import Cardano.Ledger.Shelley.Rules.NewEpoch (NewEpochEvent (DeltaRewardEvent, TotalRewardEvent))
 import Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))
 import qualified Cardano.Ledger.Shelley.Rules.Tick as Tick
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..), RewardAcnt (..))
@@ -754,6 +754,7 @@ aggDeltaRewardEvents :: [ChainEvent C] -> Map (Credential 'Staking (Crypto C)) (
 aggDeltaRewardEvents events = foldl' accum Map.empty events
   where
     accum ans (TickEvent (Tick.RupdEvent (RupdEvent _ m))) = Map.unionWith Set.union m ans
+    accum ans (TickEvent (Tick.NewEpochEvent (DeltaRewardEvent (RupdEvent _ m)))) = Map.unionWith Set.union m ans
     accum ans _ = ans
 
 getMostRecentTotalRewardEvent :: [ChainEvent C] -> Map (Credential 'Staking (Crypto C)) (Set (Reward (Crypto C)))


### PR DESCRIPTION
This reverts changes to the `TotalRewardEvent` done in https://github.com/input-output-hk/cardano-ledger/pull/2615/files#diff-e38c0cafe1544253b0aa549f1fdaeb9b824089696fa5320f0c1dd5b3fa7d7f58R159-R161 and fixes the related test.