### PR TITLE
Restructured Generic.Properties into 3 files

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -49,6 +49,8 @@ library
     Test.Cardano.Ledger.Examples.TwoPhaseValidation
     Test.Cardano.Ledger.Generic.Indexed
     Test.Cardano.Ledger.Generic.Fields
+    Test.Cardano.Ledger.Generic.Functions
+    Test.Cardano.Ledger.Generic.GenState
     Test.Cardano.Ledger.Generic.Proof
     Test.Cardano.Ledger.Generic.Scriptic
     Test.Cardano.Ledger.Generic.Updaters
@@ -116,6 +118,7 @@ library
     plutus-ledger-api,
     plutus-core,
     plutus-tx,
+    prettyprinter,
     profunctors,
     QuickCheck,
     quickcheck-instances,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Functions in this module take a (Proof era) as their first
+--   parameter and do something potentially different in each Era.
+module Test.Cardano.Ledger.Generic.Functions where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Data (DataHash, binaryDataToData, hashData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.Tx
+  ( IsValid (..),
+    ScriptIntegrityHash,
+    ValidatedTx (..),
+    hashScriptIntegrity,
+    minfee,
+  )
+import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxDats (..))
+import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams, PParams' (..))
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxOut (..))
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential (Credential, StakeReference (..))
+import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.Shelley.EpochBoundary (obligation)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (minfee)
+import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..))
+import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley (TxOut (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.UnifiedMap (ViewMap)
+import Cardano.Ledger.Val (Val (coin, inject, (<+>)))
+import Control.State.Transition.Extended (STS (State))
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Default.Class (Default (def))
+import Data.Map (Map)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Set (Set)
+import Numeric.Natural
+import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
+import Test.Cardano.Ledger.Generic.Fields (TxOutField (..))
+import Test.Cardano.Ledger.Generic.Proof
+import Test.Cardano.Ledger.Generic.Scriptic (Scriptic (..))
+
+-- ====================================================================
+-- Era agnostic actions on (Core.PParams era) (Core.TxOut era) and
+-- other Core.XX types Mostly by pattern matching against Proof objects
+
+maxCollateralInputs' :: Proof era -> Core.PParams era -> Natural
+maxCollateralInputs' (Alonzo _) x = _maxCollateralInputs x
+maxCollateralInputs' (Babbage _) x = Babbage._maxCollateralInputs x
+maxCollateralInputs' _proof _x = 0
+
+maxTxExUnits' :: Proof era -> Core.PParams era -> ExUnits
+maxTxExUnits' (Alonzo _) x = _maxTxExUnits x
+maxTxExUnits' (Babbage _) x = Babbage._maxTxExUnits x
+maxTxExUnits' _proof _x = mempty
+
+collateralPercentage' :: Proof era -> Core.PParams era -> Natural
+collateralPercentage' (Alonzo _) x = _collateralPercentage x
+collateralPercentage' (Babbage _) x = Babbage._collateralPercentage x
+collateralPercentage' _proof _x = 0
+
+obligation' ::
+  forall era c.
+  (c ~ Crypto era) =>
+  Proof era ->
+  Core.PParams era ->
+  ViewMap c (Credential 'Staking c) Coin ->
+  Map (KeyHash 'StakePool c) (PoolParams c) ->
+  Coin
+obligation' (Babbage _) = obligation @c @(Babbage.PParams era) @(ViewMap c)
+obligation' (Alonzo _) = obligation @c @(PParams era) @(ViewMap c)
+obligation' (Mary _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
+obligation' (Allegra _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
+obligation' (Shelley _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
+
+minfee' :: forall era. Proof era -> Core.PParams era -> Core.Tx era -> Coin
+minfee' (Alonzo _) = minfee
+minfee' (Babbage _) = minfee
+minfee' (Mary _) = Shelley.minfee
+minfee' (Allegra _) = Shelley.minfee
+minfee' (Shelley _) = Shelley.minfee
+
+txInBalance :: forall era. Era era => Set (TxIn (Crypto era)) -> UTxO era -> Coin
+txInBalance txinSet (UTxO m) = coin (balance (UTxO (SplitMap.toMap (txinSet SplitMap.◁ m))))
+
+hashScriptIntegrity' ::
+  Proof era ->
+  Core.PParams era ->
+  Set Language ->
+  Redeemers era ->
+  TxDats era ->
+  StrictMaybe (ScriptIntegrityHash (Crypto era))
+hashScriptIntegrity' (Babbage _) = hashScriptIntegrity
+hashScriptIntegrity' (Alonzo _) = hashScriptIntegrity
+hashScriptIntegrity' _proof = (\_pp _l _r _d -> SNothing)
+
+-- | Break a TxOut into its mandatory and optional parts
+txoutFields :: Proof era -> Core.TxOut era -> (Addr (Crypto era), Core.Value era, [TxOutField era])
+txoutFields (Alonzo _) (TxOut addr val dh) = (addr, val, [DHash dh])
+txoutFields (Babbage _) (Babbage.TxOut addr val d h) = (addr, val, [Datum d, RefScript h])
+txoutFields (Mary _) (Shelley.TxOut addr val) = (addr, val, [])
+txoutFields (Allegra _) (Shelley.TxOut addr val) = (addr, val, [])
+txoutFields (Shelley _) (Shelley.TxOut addr val) = (addr, val, [])
+
+injectFee :: Proof era -> Coin -> Core.TxOut era -> Core.TxOut era
+injectFee (Babbage _) fee (Babbage.TxOut addr val d ref) = Babbage.TxOut addr (val <+> inject fee) d ref
+injectFee (Alonzo _) fee (TxOut addr val mdh) = TxOut addr (val <+> inject fee) mdh
+injectFee (Mary _) fee (Shelley.TxOut addr val) = Shelley.TxOut addr (val <+> inject fee)
+injectFee (Allegra _) fee (Shelley.TxOut addr val) = Shelley.TxOut addr (val <+> inject fee)
+injectFee (Shelley _) fee (Shelley.TxOut addr val) = Shelley.TxOut addr (val <+> inject fee)
+
+getTxOutVal :: Proof era -> Core.TxOut era -> Core.Value era
+getTxOutVal (Babbage _) (Babbage.TxOut _ v _ _) = v
+getTxOutVal (Alonzo _) (TxOut _ v _) = v
+getTxOutVal (Mary _) (Shelley.TxOut _ v) = v
+getTxOutVal (Allegra _) (Shelley.TxOut _ v) = v
+getTxOutVal (Shelley _) (Shelley.TxOut _ v) = v
+
+getTxOutRefScript :: Proof era -> Core.TxOut era -> StrictMaybe (Core.Script era)
+getTxOutRefScript (Babbage _) (Babbage.TxOut _ _ _ ms) = ms
+getTxOutRefScript _ _ = SNothing
+
+emptyPPUPstate :: forall era. Proof era -> State (Core.EraRule "PPUP" era)
+emptyPPUPstate (Babbage _) = def
+emptyPPUPstate (Alonzo _) = def
+emptyPPUPstate (Mary _) = def
+emptyPPUPstate (Allegra _) = def
+emptyPPUPstate (Shelley _) = def
+
+maxRefInputs :: Proof era -> Int
+maxRefInputs (Babbage _) = 3
+maxRefInputs _ = 0
+
+isValid' :: Proof era -> Core.Tx era -> IsValid
+isValid' (Alonzo _) x = isValid x
+isValid' (Babbage _) x = isValid x
+isValid' _ _ = IsValid True
+
+-- | Does the TxOut have evidence of credentials and data.
+--   Evidence of data is either ScriptHash or (in Babbage) an inline Datum
+--   Evidence of credentials can come from the Addr
+txoutEvidence ::
+  forall era.
+  Proof era ->
+  Core.TxOut era ->
+  ([Credential 'Payment (Crypto era)], Maybe (DataHash (Crypto era)))
+txoutEvidence (Alonzo _) (TxOut addr _ (SJust dh)) =
+  (addrCredentials addr, Just dh)
+txoutEvidence (Alonzo _) (TxOut addr _ SNothing) =
+  (addrCredentials addr, Nothing)
+txoutEvidence (Babbage _) (Babbage.TxOut addr _ Babbage.NoDatum _) =
+  (addrCredentials addr, Nothing)
+txoutEvidence (Babbage _) (Babbage.TxOut addr _ (Babbage.DatumHash dh) _) =
+  (addrCredentials addr, Just dh)
+txoutEvidence (Babbage _) (Babbage.TxOut addr _ (Babbage.Datum _d) _) =
+  (addrCredentials addr, Just (hashData @era (binaryDataToData _d)))
+txoutEvidence (Mary _) (Shelley.TxOut addr _) =
+  (addrCredentials addr, Nothing)
+txoutEvidence (Allegra _) (Shelley.TxOut addr _) =
+  (addrCredentials addr, Nothing)
+txoutEvidence (Shelley _) (Shelley.TxOut addr _) =
+  (addrCredentials addr, Nothing)
+
+addrCredentials :: Addr crypto -> [Credential 'Payment crypto]
+addrCredentials addr = maybe [] (: []) (paymentCredAddr addr)
+
+paymentCredAddr :: Addr c -> Maybe (Credential 'Payment c)
+paymentCredAddr (Addr _ cred _) = Just cred
+paymentCredAddr _ = Nothing
+
+stakeCredAddr :: Addr c -> Maybe (Credential 'Staking c)
+stakeCredAddr (Addr _ _ (StakeRefBase cred)) = Just cred
+stakeCredAddr _ = Nothing
+
+primaryLanguage :: Proof era -> Maybe Language
+primaryLanguage (Babbage _) = Just (PlutusV2)
+primaryLanguage (Alonzo _) = Just (PlutusV1)
+primaryLanguage _ = Nothing
+
+alwaysTrue :: forall era. Proof era -> Maybe Language -> Natural -> Core.Script era
+alwaysTrue (Babbage _) (Just l) n = alwaysSucceeds @era l n
+alwaysTrue p@(Babbage _) Nothing _ = allOf [] p
+alwaysTrue (Alonzo _) (Just l) n = alwaysSucceeds @era l n
+alwaysTrue p@(Alonzo _) Nothing _ = allOf [] p
+alwaysTrue p@(Mary _) _ n = always n p
+alwaysTrue p@(Allegra _) _ n = always n p
+alwaysTrue p@(Shelley _) _ n = always n p
+
+alwaysFalse :: forall era. Proof era -> Maybe Language -> Natural -> Core.Script era
+alwaysFalse (Babbage _) (Just l) n = alwaysFails @era l n
+alwaysFalse p@(Babbage _) Nothing _ = anyOf [] p
+alwaysFalse (Alonzo _) (Just l) n = alwaysFails @era l n
+alwaysFalse p@(Alonzo _) Nothing _ = anyOf [] p
+alwaysFalse p@(Mary _) _ n = never n p
+alwaysFalse p@(Allegra _) _ n = never n p
+alwaysFalse p@(Shelley _) _ n = never n p

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -1,0 +1,471 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Strategy for Generic Tests
+--   Pre-generate a bunch of inter-related things using a state Monad over a set of Maps
+--   and Sets that remember the inter-relation ships. We then extract this state, and it
+--   becomes the environment of the regular generators. We make these Maps and Set big
+--   enough that when we need something that has one of these relationships, we randomly
+--   choose from the Maps and the Sets in the environment, knowing that we can find the
+--   related item(s) when it is needed.
+module Test.Cardano.Ledger.Generic.GenState where
+
+import Cardano.Ledger.Address (RewardAcnt (..))
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
+import Cardano.Ledger.Alonzo.Scripts hiding (Mint)
+import qualified Cardano.Ledger.Alonzo.Scripts as Tag
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.BaseTypes (Network (Testnet), ProtVer (..))
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj))
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Era (Era (..), ValidateScript (hashScript))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Keys
+  ( KeyHash (..),
+    KeyPair (..),
+    KeyRole (..),
+    coerceKeyRole,
+    hashKey,
+  )
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Pretty (PDoc, ppDPState, ppMap, ppPair, ppRecord)
+import Cardano.Ledger.Pretty.Alonzo (ppIsValid, ppTag)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.LedgerState
+  ( DPState (..),
+    DState (..),
+    PState (..),
+    RewardAccounts,
+    rewards,
+  )
+import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
+import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
+import Cardano.Ledger.Val (Val (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Monad (join, replicateM, replicateM_)
+import qualified Control.Monad.State.Strict as MS (MonadState (..), modify)
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Control.Monad.Trans.RWS.Strict (RWST (..), ask, get, modify, runRWST)
+import Data.Default.Class (Default (def))
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (SJust, SNothing))
+import qualified Data.Sequence.Strict as Seq
+import qualified Data.UMap as UM
+import Numeric.Natural
+import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+import Test.Cardano.Ledger.Generic.Fields
+import Test.Cardano.Ledger.Generic.Functions
+import Test.Cardano.Ledger.Generic.PrettyCore
+  ( dataHashSummary,
+    dataSummary,
+    keyHashSummary,
+    keyPairSummary,
+    scriptHashSummary,
+    scriptSummary,
+  )
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.Cardano.Ledger.Generic.Updaters
+import Test.Tasty.QuickCheck
+  ( Gen,
+    Positive (..),
+    arbitrary,
+    choose,
+    chooseInt,
+    elements,
+    frequency,
+    generate,
+  )
+
+-- =================================================
+
+-- | Constants that determine how big a GenState is generated.
+data GenSize = GenSize
+  { numKeys :: Int,
+    numScripts :: Int,
+    numDatums :: Int,
+    numRewards :: Int,
+    numPools :: Int
+  }
+
+data GenEnv era = GenEnv
+  { geValidityInterval :: ValidityInterval,
+    gePParams :: Core.PParams era
+  }
+
+data GenState era = GenState
+  { gsKeys :: Map (KeyHash 'Witness (Crypto era)) (KeyPair 'Witness (Crypto era)),
+    gsScripts :: Map (ScriptHash (Crypto era)) (Core.Script era),
+    gsPlutusScripts :: Map (ScriptHash (Crypto era), Tag) (IsValid, Core.Script era),
+    gsDatums :: Map (DataHash (Crypto era)) (Data era),
+    gsDPState :: DPState (Crypto era)
+  }
+
+emptyGenState :: GenState era
+emptyGenState = GenState mempty mempty mempty mempty def
+
+instance Default GenSize where
+  def = GenSize {numKeys = 2, numScripts = 2, numDatums = 5, numRewards = 5, numPools = 1}
+
+-- ========================================================================
+-- Tools to get started
+
+initState :: Reflect era => Proof era -> GenSize -> GenRS era (GenState era)
+initState proof gs = do
+  replicateM_ (numKeys gs) genKeyHash
+  replicateM_ (numScripts gs) $ sequence_ [genScript proof i | i <- [Spend, Tag.Mint, Cert, Rewrd]]
+  replicateM_ (numDatums gs) genDatumWithHash
+  replicateM_ (numRewards gs) genRewards
+  replicateM_ (numPools gs) genPool
+  get
+
+startGen :: Reflect era => Proof era -> GenSize -> Gen (GenEnv era, GenState era)
+startGen proof gsize = do
+  env <- genGenEnv proof
+  (state, _, _) <- runRWST (initState proof gsize) env emptyGenState
+  pure (env, state)
+
+startGenRS :: Reflect era => Proof era -> GenSize -> GenRS era (GenEnv era, GenState era)
+startGenRS proof gsize = lift $ startGen proof gsize
+
+-- | Helper function for debugging the state generator inside ghci
+viewGenState :: Reflect era => Proof era -> IO ()
+viewGenState proof = do
+  (_, st) <- generate (startGen proof def)
+  putStrLn (show (ppGenState proof st))
+
+-- ===========================================================
+
+-- | Generate a random, well-formed, GenEnv
+genGenEnv :: Proof era -> Gen (GenEnv era)
+genGenEnv proof = do
+  maxTxExUnits <- arbitrary :: Gen ExUnits
+  Positive maxCollateralInputs <- arbitrary :: Gen (Positive Natural)
+  collateralPercentage <- fromIntegral <$> chooseInt (1, 10000) :: Gen Natural
+  minfeeA <- fromIntegral <$> chooseInt (0, 1000)
+  minfeeB <- fromIntegral <$> chooseInt (0, 10000)
+  let pp =
+        newPParams
+          proof
+          [ MinfeeA minfeeA,
+            MinfeeB minfeeB,
+            defaultCostModels proof,
+            MaxValSize 1000,
+            MaxTxSize $ fromIntegral (maxBound :: Int),
+            MaxTxExUnits maxTxExUnits,
+            MaxCollateralInputs maxCollateralInputs,
+            CollateralPercentage collateralPercentage,
+            ProtocolVersion $ ProtVer 7 0
+          ]
+      slotNo = SlotNo 100000000
+  minSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (minBound, unSlotNo slotNo))]
+  maxSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (unSlotNo slotNo + 1, maxBound))]
+  pure $
+    GenEnv
+      { geValidityInterval = ValidityInterval (SlotNo <$> minSlotNo) (SlotNo <$> maxSlotNo),
+        gePParams = pp
+      }
+
+-- =============================================
+-- Generators of inter-related items
+
+-- Adds to the gsKeys
+genKeyHash :: Reflect era => GenRS era (KeyHash kr (Crypto era))
+genKeyHash = do
+  keyPair <- lift arbitrary
+  let keyHash = hashKey $ vKey keyPair
+  modify $ \ts@GenState {gsKeys} -> ts {gsKeys = Map.insert keyHash keyPair gsKeys}
+  pure $ coerceKeyRole keyHash
+
+-- Adds to the gsDatums
+genDatumWithHash :: Era era => GenRS era (DataHash (Crypto era), Data era)
+genDatumWithHash = do
+  datum <- lift arbitrary
+  let datumHash = hashData datum
+  modify $ \ts@GenState {gsDatums} ->
+    ts {gsDatums = Map.insert datumHash datum gsDatums}
+  pure (datumHash, datum)
+
+-- Adds to the gsDPState
+genRewards :: Reflect era => GenRS era (RewardAccounts (Crypto era))
+genRewards = do
+  n <- lift nonNeg1Digit
+  newrewards <-
+    Map.fromList <$> replicateM n ((,) <$> genCredential Rewrd <*> lift genPositiveVal)
+  modifyDState $ \ds -> ds {_unified = rewards ds UM.⨃ newrewards} -- Prefers coins in newrewards
+  pure newrewards
+
+-- Adds to PState part of DPSTate
+genPool :: Reflect era => GenRS era (KeyHash 'StakePool (Crypto era))
+genPool = frequencyT [(10, genNewPool), (90, pickExisting)]
+  where
+    pickExisting = do
+      DPState {_pstate = PState {_pParams}} <- gsDPState <$> get
+      lift (genMapElem _pParams) >>= \case
+        Nothing -> genNewPool
+        Just poolId -> pure $ fst poolId
+    genNewPool = do
+      poolId <- genKeyHash
+      pp <- genPoolParams poolId
+      modifyPState $ \ps -> ps {_pParams = Map.insert poolId pp (_pParams ps)}
+      pure poolId
+    genPoolParams _poolId = do
+      _poolVrf <- lift arbitrary
+      _poolPledge <- lift genPositiveVal
+      _poolCost <- lift genPositiveVal
+      _poolMargin <- lift arbitrary
+      _poolRAcnt <- RewardAcnt Testnet <$> genCredential Rewrd
+      let _poolOwners = mempty
+      let _poolRelays = mempty
+      let _poolMD = SNothing
+      pure PoolParams {..}
+
+-- Adds to both gsKeys and gsScripts and gsPlutusScript
+-- via genKeyHash and genScript
+
+-- | Generate a credential that can be used for supplied purpose (in case of
+-- plutus scripts), while occasionally picking out randomly from previously
+-- generated set.
+genCredential :: Reflect era => Tag -> GenRS era (Credential kr (Crypto era))
+genCredential tag =
+  frequencyT
+    [ (35, KeyHashObj <$> genKeyHash),
+      (35, ScriptHashObj <$> genScript reify tag),
+      (10, pickExistingKeyHash),
+      (20, pickExistingScript)
+    ]
+  where
+    pickExistingKeyHash =
+      KeyHashObj <$> do
+        keysMap <- gsKeys <$> get
+        lift (genMapElem keysMap) >>= \case
+          Just (k, _) -> pure $ coerceKeyRole k
+          Nothing -> genKeyHash
+    pickExistingScript =
+      ScriptHashObj
+        <$> elementsT [pickExistingPlutusScript, pickExistingTimelockScript]
+    pickExistingPlutusScript = do
+      plutusScriptsMap <-
+        Map.filterWithKey (\(_, t) _ -> t == tag) . gsPlutusScripts <$> get
+      lift (genMapElem plutusScriptsMap) >>= \case
+        Just ((h, _), _) -> pure h
+        Nothing -> genScript reify tag
+    pickExistingTimelockScript = do
+      timelockScriptsMap <- gsScripts <$> get
+      lift (genMapElem timelockScriptsMap) >>= \case
+        Just (h, _) -> pure h
+        Nothing -> genScript reify tag
+
+-- ===========================================================
+-- Generate Era agnostic Scripts
+
+-- Adds to gsScripts and gsPlutusScripts
+genScript :: forall era. Reflect era => Proof era -> Tag -> GenRS era (ScriptHash (Crypto era))
+genScript proof tag = case proof of
+  Babbage _ -> elementsT [genTimelockScript proof, genPlutusScript proof tag]
+  Alonzo _ -> elementsT [genTimelockScript proof, genPlutusScript proof tag]
+  Mary _ -> genTimelockScript proof
+  Allegra _ -> genTimelockScript proof
+  Shelley _ -> genMultiSigScript proof
+
+-- Adds to gsScripts
+genTimelockScript :: forall era. Reflect era => Proof era -> GenRS era (ScriptHash (Crypto era))
+genTimelockScript proof = do
+  GenEnv {geValidityInterval = ValidityInterval mBefore mAfter} <- ask
+  -- We need to limit how deep these timelocks can go, otherwise this generator will
+  -- diverge. It also has to stay very shallow because it grows too fast.
+  let genNestedTimelock k
+        | k > 0 =
+            elementsT $
+              nonRecTimelocks ++ [requireAllOf k, requireAnyOf k, requireMOf k]
+        | otherwise = elementsT nonRecTimelocks
+      nonRecTimelocks :: [GenRS era (Timelock (Crypto era))]
+      nonRecTimelocks =
+        [ r
+          | SJust r <-
+              [ requireTimeStart <$> mBefore,
+                requireTimeExpire <$> mAfter,
+                SJust requireSignature
+              ]
+        ]
+      requireSignature = RequireSignature <$> genKeyHash
+      requireAllOf k = do
+        n <- lift nonNeg1Digit
+        RequireAllOf . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
+      requireAnyOf k = do
+        n <- lift pos1Digit
+        RequireAnyOf . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
+      requireMOf k = do
+        n <- lift nonNeg1Digit
+        m <- lift $ choose (0, n)
+        RequireMOf m . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
+      requireTimeStart (SlotNo validFrom) = do
+        minSlotNo <- lift $ choose (minBound, validFrom)
+        pure $ RequireTimeStart (SlotNo minSlotNo)
+      requireTimeExpire (SlotNo validTill) = do
+        maxSlotNo <- lift $ choose (validTill, maxBound)
+        pure $ RequireTimeExpire (SlotNo maxSlotNo)
+  tlscript <- genNestedTimelock (2 :: Natural)
+  let corescript :: Core.Script era
+      corescript = case proof of
+        Babbage _ -> TimelockScript tlscript
+        Alonzo _ -> TimelockScript tlscript
+        Mary _ -> tlscript
+        Allegra _ -> tlscript
+        Shelley _ -> error "Shelley does not have TimeLock scripts"
+  let scriptHash = hashScript @era corescript
+  modify $ \ts@GenState {gsScripts} -> ts {gsScripts = Map.insert scriptHash corescript gsScripts}
+  pure scriptHash
+
+-- Adds to gsScripts
+genMultiSigScript :: forall era. Reflect era => Proof era -> GenRS era (ScriptHash (Crypto era))
+genMultiSigScript proof = do
+  let genNestedMultiSig k
+        | k > 0 =
+            elementsT $
+              nonRecTimelocks ++ [requireAllOf k, requireAnyOf k, requireMOf k]
+        | otherwise = elementsT nonRecTimelocks
+      nonRecTimelocks = [requireSignature]
+      requireSignature = Shelley.RequireSignature <$> genKeyHash
+      requireAllOf k = do
+        n <- lift nonNeg1Digit
+        Shelley.RequireAllOf <$> replicateM n (genNestedMultiSig (k - 1))
+      requireAnyOf k = do
+        n <- lift pos1Digit
+        Shelley.RequireAnyOf <$> replicateM n (genNestedMultiSig (k - 1))
+      requireMOf k = do
+        n <- lift nonNeg1Digit
+        m <- lift $ choose (0, n)
+        Shelley.RequireMOf m <$> replicateM n (genNestedMultiSig (k - 1))
+  msscript <- genNestedMultiSig (2 :: Natural)
+  let corescript :: Core.Script era
+      corescript = case proof of
+        Shelley _ -> msscript
+        _ -> error (show proof ++ " does not have MultiSig scripts")
+  let scriptHash = hashScript @era corescript
+  modify $ \ts@GenState {gsScripts} -> ts {gsScripts = Map.insert scriptHash corescript gsScripts}
+  pure scriptHash
+
+-- Adds to gsPlutusScripts
+genPlutusScript :: forall era. Reflect era => Proof era -> Tag -> GenRS era (ScriptHash (Crypto era))
+genPlutusScript proof tag = do
+  isValid <- lift $ frequency [(5, pure False), (95, pure True)]
+  -- Plutus scripts alwaysSucceeds needs at least numArgs, while
+  -- alwaysFails needs exactly numArgs to have the desired affect.
+  -- For reasons unknown, this number differs from Alonzo to Babbage
+  -- Perhaps because Babbage is using PlutusV2 scripts?
+  let numArgs = case (proof, tag) of
+        (Babbage _, Spend) -> 2
+        (Babbage _, _) -> 1
+        (_, Spend) -> 3
+        (_, _) -> 2
+  -- While using varying number of arguments for alwaysSucceeds we get
+  -- varying script hashes, which helps with the fuzziness
+  let mlanguage = primaryLanguage proof
+  script <-
+    if isValid
+      then alwaysTrue proof mlanguage . (+ numArgs) <$> lift (elements [0, 1, 2, 3 :: Natural])
+      else pure $ alwaysFalse proof mlanguage numArgs
+  let corescript :: Core.Script era
+      corescript = case proof of
+        Alonzo _ -> script
+        Babbage _ -> script
+        _ -> error ("Only Alonzo and Babbage have PlutusScripts. " ++ show proof ++ " does not.")
+      scriptHash = hashScript @era corescript
+  modify $ \ts@GenState {gsPlutusScripts} ->
+    ts {gsPlutusScripts = Map.insert (scriptHash, tag) (IsValid isValid, corescript) gsPlutusScripts}
+  pure scriptHash
+
+-- ===========================================================
+-- The Monad and Era agnostic generators and operators
+
+type GenRS era = RWST (GenEnv era) () (GenState era) Gen
+
+genMapElem :: Map k a -> Gen (Maybe (k, a))
+genMapElem m
+  | n == 0 = pure Nothing
+  | otherwise = do
+      i <- choose (0, n - 1)
+      pure $ Just $ Map.elemAt i m
+  where
+    n = Map.size m
+
+elementsT :: (Monad (t Gen), MonadTrans t) => [t Gen b] -> t Gen b
+elementsT = join . lift . elements
+
+frequencyT :: (Monad (t Gen), MonadTrans t) => [(Int, t Gen b)] -> t Gen b
+frequencyT = join . lift . frequency . map (pure <$>)
+
+-- | Gen a positive single digit Int, on a skewed distribution that
+--   favors 2,3,4,5 but occasionally gets others
+pos1Digit :: Gen Int
+pos1Digit = frequency (map f [(1, 1), (7, 2), (6, 3), (5, 4), (3, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
+  where
+    f (x, y) = (x, pure y)
+
+-- | Gen a non-negative single digit Int, on a skewed distribution that
+--   favors 2,3,4,5 but occasionally gets others
+nonNeg1Digit :: Gen Int
+nonNeg1Digit = frequency (map f [(1, 0), (2, 1), (7, 2), (6, 3), (5, 4), (3, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
+  where
+    f (x, y) = (x, pure y)
+
+-- | Generate a non-zero value
+genPositiveVal :: Val v => Gen v
+genPositiveVal = inject . Coin . getPositive <$> arbitrary
+
+modifyDState :: (MS.MonadState (GenState era) m) => (DState (Crypto era) -> DState (Crypto era)) -> m ()
+modifyDState f =
+  modifyDPState $ \dp@DPState {_dstate = ds} -> dp {_dstate = f ds}
+
+modifyDPState :: (MS.MonadState (GenState era) m) => (DPState (Crypto era) -> DPState (Crypto era)) -> m ()
+modifyDPState f =
+  MS.modify $ \s@GenState {gsDPState = dps} -> s {gsDPState = f dps}
+
+modifyPState :: (MS.MonadState (GenState era) m) => (PState (Crypto era) -> PState (Crypto era)) -> m ()
+modifyPState f =
+  modifyDPState $ \dp@DPState {_pstate = ps} -> dp {_pstate = f ps}
+
+-- ========================================================================
+
+deriving instance CC.Crypto c => Show (GenState (BabbageEra c))
+
+deriving instance CC.Crypto c => Show (GenState (AlonzoEra c))
+
+deriving instance CC.Crypto c => Show (GenState (MaryEra c))
+
+deriving instance CC.Crypto c => Show (GenState (AllegraEra c))
+
+deriving instance CC.Crypto c => Show (GenState (ShelleyEra c))
+
+ppGenState :: CC.Crypto (Crypto era) => Proof era -> GenState era -> PDoc
+ppGenState proof (GenState keys scripts plutus dats dp) =
+  ppRecord
+    "GenState"
+    [ ("Keymap", ppMap keyHashSummary keyPairSummary keys),
+      ("Scriptmap", ppMap scriptHashSummary (scriptSummary proof) scripts),
+      ( "PlutusScripts",
+        ppMap
+          (ppPair scriptHashSummary ppTag)
+          (ppPair ppIsValid (scriptSummary proof))
+          plutus
+      ),
+      ("Datums", ppMap dataHashSummary dataSummary dats),
+      ("DPState", ppDPState dp)
+    ]


### PR DESCRIPTION
Added two new files: Generic.Functions.hs and Generic.GenState.hs
This was done by removing code from Generic.Properties that was logically separate
from the property tests.

Generic.GenState  now includes the introduction of the GenState and GenEnv data types, and all of the function that modify the GenState. 
That makes Generic.Property.hs, only read from the GenState. This is in preparation for making the Monad in Generic.Property.hs, a simple Reader monad on top of Gen

Generic functions includes functions that take (Proof era) as first argument and can compute different thing in each Era,