### PR TITLE
Ts generic state to env

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -47,15 +47,20 @@ library
     Test.Cardano.Ledger.BaseTypes
     Test.Cardano.Ledger.Examples.BabbageFeatures
     Test.Cardano.Ledger.Examples.TwoPhaseValidation
+    Test.Cardano.Ledger.Generic.ApplyTx
     Test.Cardano.Ledger.Generic.Indexed
     Test.Cardano.Ledger.Generic.Fields
     Test.Cardano.Ledger.Generic.Functions
     Test.Cardano.Ledger.Generic.GenState
+    Test.Cardano.Ledger.Generic.TxGen
     Test.Cardano.Ledger.Generic.Proof
-    Test.Cardano.Ledger.Generic.Scriptic
-    Test.Cardano.Ledger.Generic.Updaters
+    Test.Cardano.Ledger.Generic.MockChain
+    Test.Cardano.Ledger.Generic.ModelState
     Test.Cardano.Ledger.Generic.PrettyCore
     Test.Cardano.Ledger.Generic.Properties
+    Test.Cardano.Ledger.Generic.Scriptic
+    Test.Cardano.Ledger.Generic.Trace
+    Test.Cardano.Ledger.Generic.Updaters
     Test.Cardano.Ledger.Model.API
     Test.Cardano.Ledger.Model.Acnt
     Test.Cardano.Ledger.Model.BaseTypes
@@ -132,6 +137,7 @@ library
     semigroupoids,
     small-steps,
     small-steps-test,
+    set-algebra,
     some,
     strict-containers,
     tagged,
@@ -141,6 +147,7 @@ library
     text,
     time,
     transformers,
+    vector,
     writer-cps-mtl,
 
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -24,7 +24,6 @@ import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..), Script (Plu
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..))
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPred (..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import Cardano.Ledger.BaseTypes

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -16,7 +16,6 @@ module Test.Cardano.Ledger.Examples.TwoPhaseValidation where
 import qualified Cardano.Crypto.Hash as CH
 import Cardano.Crypto.Hash.Class (sizeHash)
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (Data (..), hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams (PParams' (..))
@@ -38,7 +37,6 @@ import Cardano.Ledger.Alonzo.TxBody (ScriptIntegrityHash)
 import Cardano.Ledger.Alonzo.TxInfo (TranslationError, VersionedTxInfo, txInfo, valContext)
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), unRedeemers)
 import Cardano.Ledger.BHeaderView (BHeaderView (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams' (..))
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPred (..))
 import Cardano.Ledger.BaseTypes
@@ -147,7 +145,6 @@ import Test.Cardano.Ledger.Generic.PrettyCore ()
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Scriptic (HasTokens (..), PostShelley, Scriptic (..), after, matchkey)
 import Test.Cardano.Ledger.Generic.Updaters
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C_Crypto)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
 import Test.Cardano.Ledger.Shelley.Utils
   ( RawSeed (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Generic.ApplyTx where
+
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..), Delegation (..), EraIndependentTxBody, PoolCert (..), PoolParams (..), RewardAcnt (..), Wdrl (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Val ((<+>), (<->))
+import Data.Foldable (toList)
+import qualified Data.List as List
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Stack (HasCallStack)
+import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..), TxField (..), abstractTx, abstractTxBody)
+import Test.Cardano.Ledger.Generic.Functions (getTxOutCoin, keyPoolDeposits, txInBalance)
+import Test.Cardano.Ledger.Generic.ModelState (Model, ModelNewEpochState (..))
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+
+-- ========================================================================
+
+hasValid :: [TxField era] -> Maybe Bool
+hasValid [] = Nothing
+hasValid (Valid (IsValid b) : _) = Just b
+hasValid (_ : fs) = hasValid fs
+
+applyTx :: Reflect era => Proof era -> Int -> Model era -> Core.Tx era -> Model era
+applyTx proof count model tx = ans
+  where
+    fields = abstractTx proof tx
+    ans = case hasValid fields of
+      Nothing -> List.foldl' (applyTxSimple proof count) model fields
+      Just True -> List.foldl' (applyTxSimple proof count) model fields
+      Just False -> List.foldl' (applyTxFail proof count) model fields
+
+applyTxSimple :: Proof era -> Int -> Model era -> TxField era -> Model era
+applyTxSimple proof count model field = case field of
+  Body body -> applyTxBody proof count model body
+  BodyI fs -> List.foldl' (applyField proof count) model fs
+  Witnesses _ -> model
+  WitnessesI _ -> model
+  AuxData _ -> model
+  Valid _ -> model
+
+applyTxBody :: Proof era -> Int -> Model era -> Core.TxBody era -> Model era
+applyTxBody proof count model tx = List.foldl' (applyField proof count) model (abstractTxBody proof tx)
+
+applyField :: Proof era -> Int -> Model era -> TxBodyField era -> Model era
+applyField proof count model field = case field of
+  (Inputs txins) -> model {mUTxO = Map.withoutKeys (mUTxO model) txins}
+  (Outputs seqo) -> case Map.lookup count (mIndex model) of
+    Nothing -> error "Output not found"
+    Just (TxId hash) -> model {mUTxO = Map.union newstuff (mUTxO model)}
+      where
+        newstuff = additions hash (toList seqo)
+  (Txfee coin) -> model {mFees = coin <+> (mFees model)}
+  (Certs seqc) -> List.foldl' (applyCert proof) model (toList seqc)
+  (Wdrls (Wdrl m)) -> Map.foldlWithKey' (applyWdrl proof) model m
+  _other -> model
+
+applyWdrl :: Proof era -> Model era -> RewardAcnt (Crypto era) -> Coin -> Model era
+applyWdrl _proof model (RewardAcnt _network cred) coin =
+  model {mRewards = Map.adjust (\c -> c <-> coin) cred (mRewards model)}
+
+applyCert :: Proof era -> Model era -> DCert (Crypto era) -> Model era
+applyCert proof model dcert = case dcert of
+  (DCertDeleg (RegKey x)) ->
+    model
+      { mRewards = Map.insert x (Coin 0) (mRewards model),
+        mDeposited = mDeposited model <+> keydeposit
+      }
+    where
+      pp = mPParams model
+      (keydeposit, _) = keyPoolDeposits proof pp
+  (DCertDeleg (DeRegKey x)) -> case Map.lookup x (mRewards model) of
+    Nothing -> error "DeRegKey not in rewards"
+    Just (Coin 0) ->
+      model
+        { mRewards = Map.delete x (mRewards model),
+          mDeposited = mDeposited model <-> keydeposit
+        }
+      where
+        pp = mPParams model
+        (keydeposit, _) = keyPoolDeposits proof pp
+    Just (Coin _n) -> error "DeRegKey with non-zero balance"
+  (DCertDeleg (Delegate (Delegation cred hash))) ->
+    model {mDelegations = Map.insert cred hash (mDelegations model)}
+  (DCertPool (RegPool poolparams)) ->
+    model
+      { mPoolParams = Map.insert hk poolparams (mPoolParams model),
+        mDeposited = mDeposited model <+> pooldeposit
+      }
+    where
+      hk = _poolId poolparams
+      pp = mPParams model
+      (_, pooldeposit) = keyPoolDeposits proof pp
+  (DCertPool (RetirePool keyhash epoch)) ->
+    model
+      { mRetiring = Map.insert keyhash epoch (mRetiring model),
+        mDeposited = mDeposited model <-> pooldeposit
+      }
+    where
+      pp = mPParams model
+      (_, pooldeposit) = keyPoolDeposits proof pp
+  (DCertGenesis _) -> model
+  (DCertMir _) -> model
+
+-- =========================================================
+-- What to do if the second phase does not validatate.
+-- Process and use Collateral to pay fees
+
+data CollInfo era = CollInfo
+  { ciBal :: Coin, -- Balance of all the collateral inputs
+    ciRet :: Coin, -- Coin amount of the collateral return output
+    ciDelset :: Set (TxIn (Crypto era)), -- The set of inputs to delete from the UTxO
+    ciAddmap :: Map (TxIn (Crypto era)) (Core.TxOut era) -- Things to Add to the UTxO
+  }
+
+emptyCollInfo :: CollInfo era
+emptyCollInfo = CollInfo (Coin 0) (Coin 0) Set.empty Map.empty
+
+-- | Collect information about how to process Collateral, in a second phase failure.
+collInfo ::
+  (Reflect era, HasCallStack) =>
+  Proof era ->
+  Int ->
+  Model era ->
+  CollInfo era ->
+  TxBodyField era ->
+  CollInfo era
+collInfo proof count model info field = case field of
+  CollateralReturn SNothing -> info
+  CollateralReturn (SJust txout) ->
+    case Map.lookup count (mIndex model) of
+      Nothing -> error "Output not found"
+      Just (TxId hash) -> info {ciRet = getTxOutCoin proof txout, ciAddmap = newstuff}
+        where
+          newstuff = additions hash [txout]
+  Collateral inputs ->
+    info
+      { ciDelset = inputs,
+        ciBal = txInBalance inputs (mUTxO model)
+      }
+  _ -> info
+
+updateInfo :: CollInfo era -> Model era -> Model era
+updateInfo info m =
+  m
+    { mUTxO = Map.union (ciAddmap info) (Map.withoutKeys (mUTxO m) (ciDelset info)),
+      mFees = mFees m <+> ciBal info <-> ciRet info
+    }
+
+applyTxFail :: Reflect era => Proof era -> Int -> Model era -> TxField era -> Model era
+applyTxFail proof count model field = case field of
+  Body body -> updateInfo info model
+    where
+      info = List.foldl' (collInfo proof count model) emptyCollInfo (abstractTxBody proof body)
+  BodyI fs -> updateInfo info model
+    where
+      info = List.foldl' (collInfo proof count model) emptyCollInfo fs
+  Witnesses _ -> model
+  WitnessesI _ -> model
+  AuxData _ -> model
+  Valid _ -> model
+
+-- =======================================
+
+additions ::
+  SafeHash (Crypto era) EraIndependentTxBody ->
+  [Core.TxOut era] ->
+  Map (TxIn (Crypto era)) (Core.TxOut era)
+additions bodyhash outputs =
+  Map.fromList
+    [ (TxIn (TxId bodyhash) idx, out)
+      | (out, idx) <- zip outputs [minBound ..]
+    ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -16,7 +16,8 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Data (DataHash, binaryDataToData, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams (PParams, PParams' (..))
-import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeededFromBody)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Tag (..))
 import Cardano.Ledger.Alonzo.Tx
   ( IsValid (..),
     ScriptIntegrityHash,
@@ -25,8 +26,11 @@ import Cardano.Ledger.Alonzo.Tx
     minfee,
   )
 import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
+import Cardano.Ledger.Alonzo.TxInfo (languages)
 import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxDats (..))
 import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams, PParams' (..))
+import Cardano.Ledger.Babbage.Scripts (refScripts)
+import Cardano.Ledger.Babbage.TxBody as Babbage (referenceInputs', spendInputs')
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxOut (..))
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
@@ -36,23 +40,28 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Shelley.EpochBoundary (obligation)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (minfee)
 import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..))
-import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+import Cardano.Ledger.Shelley.Scripts (ScriptHash (..))
+import Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..), PoolCert (..), PoolParams (..))
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley (TxOut (..))
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, scriptsNeeded, totalDeposits)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.UnifiedMap (ViewMap)
-import Cardano.Ledger.Val (Val (coin, inject, (<+>)))
+import Cardano.Ledger.Val (Val (coin, inject, (<+>), (<->)))
 import Control.State.Transition.Extended (STS (State))
-import qualified Data.Compact.SplitMap as SplitMap
 import Data.Default.Class (Default (def))
-import Data.Map (Map)
+import Data.Foldable (toList)
+import qualified Data.List as List
+import Data.Map (Map, keysSet, restrictKeys)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Records (HasField (getField))
 import Numeric.Natural
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
-import Test.Cardano.Ledger.Generic.Fields (TxOutField (..))
+import Test.Cardano.Ledger.Generic.Fields (TxField (..), TxOutField (..), initialTx)
+import Test.Cardano.Ledger.Generic.ModelState (MUtxo, fromMUtxo)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Scriptic (Scriptic (..))
+import Test.Cardano.Ledger.Generic.Updaters (updateTx)
 
 -- ====================================================================
 -- Era agnostic actions on (Core.PParams era) (Core.TxOut era) and
@@ -78,14 +87,60 @@ obligation' ::
   (c ~ Crypto era) =>
   Proof era ->
   Core.PParams era ->
-  ViewMap c (Credential 'Staking c) Coin ->
+  Map (Credential 'Staking c) Coin ->
   Map (KeyHash 'StakePool c) (PoolParams c) ->
   Coin
-obligation' (Babbage _) = obligation @c @(Babbage.PParams era) @(ViewMap c)
-obligation' (Alonzo _) = obligation @c @(PParams era) @(ViewMap c)
-obligation' (Mary _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
-obligation' (Allegra _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
-obligation' (Shelley _) = obligation @c @(Shelley.PParams era) @(ViewMap c)
+obligation' (Babbage _) = obligation @c @(Babbage.PParams era) @Map
+obligation' (Alonzo _) = obligation @c @(PParams era) @Map
+obligation' (Mary _) = obligation @c @(Shelley.PParams era) @Map
+obligation' (Allegra _) = obligation @c @(Shelley.PParams era) @Map
+obligation' (Shelley _) = obligation @c @(Shelley.PParams era) @Map
+
+totalDeposits' ::
+  forall era.
+  Proof era ->
+  Core.PParams era ->
+  (KeyHash 'StakePool (Crypto era) -> Bool) ->
+  [DCert (Crypto era)] ->
+  Coin
+totalDeposits' (Babbage _) pp = totalDeposits pp
+totalDeposits' (Alonzo _) pp = totalDeposits pp
+totalDeposits' (Mary _) pp = totalDeposits pp
+totalDeposits' (Allegra _) pp = totalDeposits pp
+totalDeposits' (Shelley _) pp = totalDeposits pp
+
+-- | Positive numbers are "deposits owed", negative amounts are "refunds gained"
+depositsAndRefunds :: Proof era -> Core.PParams era -> [DCert (Crypto era)] -> Coin
+depositsAndRefunds proof pp certificates = List.foldl' accum (Coin 0) certificates
+  where
+    accum ans (DCertDeleg (RegKey _)) = keydep <+> ans
+    accum ans (DCertDeleg (DeRegKey _)) = ans <-> keydep
+    accum ans (DCertPool (RegPool _)) = pooldep <+> ans
+    accum ans (DCertPool (RetirePool _ _)) = ans <-> pooldep
+    accum ans _ = ans
+    (keydep, pooldep :: Coin) = keyPoolDeposits proof pp
+
+keyPoolDeposits :: Proof era -> Core.PParams era -> (Coin, Coin)
+keyPoolDeposits proof pp = case proof of
+  Babbage _ -> (getField @"_keyDeposit" pp, getField @"_poolDeposit" pp)
+  Alonzo _ -> (getField @"_keyDeposit" pp, getField @"_poolDeposit" pp)
+  Mary _ -> (getField @"_keyDeposit" pp, getField @"_poolDeposit" pp)
+  Allegra _ -> (getField @"_keyDeposit" pp, getField @"_poolDeposit" pp)
+  Shelley _ -> (getField @"_keyDeposit" pp, getField @"_poolDeposit" pp)
+
+-- | Compute the set of ScriptHashes for which there should be ScriptWitnesses. In Babbage
+--  Era and later, where inline Scripts are allowed, they should not appear in this set.
+scriptsNeeded' :: Proof era -> MUtxo era -> Core.TxBody era -> Set (ScriptHash (Crypto era))
+scriptsNeeded' (Babbage _) utxo txbody = regularScripts `Set.difference` inlineScripts
+  where
+    theUtxo = fromMUtxo utxo
+    inputs = spendInputs' txbody `Set.union` referenceInputs' txbody
+    inlineScripts = keysSet $ refScripts inputs theUtxo
+    regularScripts = Set.fromList (map snd (scriptsNeededFromBody theUtxo txbody))
+scriptsNeeded' (Alonzo _) utxo txbody = Set.fromList (map snd (scriptsNeededFromBody (fromMUtxo utxo) txbody))
+scriptsNeeded' p@(Mary _) utxo txbody = scriptsNeeded (fromMUtxo utxo) (updateTx p (initialTx p) (Body txbody))
+scriptsNeeded' p@(Allegra _) utxo txbody = scriptsNeeded (fromMUtxo utxo) (updateTx p (initialTx p) (Body txbody))
+scriptsNeeded' p@(Shelley _) utxo txbody = scriptsNeeded (fromMUtxo utxo) (updateTx p (initialTx p) (Body txbody))
 
 minfee' :: forall era. Proof era -> Core.PParams era -> Core.Tx era -> Coin
 minfee' (Alonzo _) = minfee
@@ -94,8 +149,13 @@ minfee' (Mary _) = Shelley.minfee
 minfee' (Allegra _) = Shelley.minfee
 minfee' (Shelley _) = Shelley.minfee
 
-txInBalance :: forall era. Era era => Set (TxIn (Crypto era)) -> UTxO era -> Coin
-txInBalance txinSet (UTxO m) = coin (balance (UTxO (SplitMap.toMap (txinSet SplitMap.◁ m))))
+txInBalance ::
+  forall era.
+  Era era =>
+  Set (TxIn (Crypto era)) ->
+  MUtxo era ->
+  Coin
+txInBalance txinSet m = coin (balance (fromMUtxo (restrictKeys m txinSet)))
 
 hashScriptIntegrity' ::
   Proof era ->
@@ -129,6 +189,13 @@ getTxOutVal (Alonzo _) (TxOut _ v _) = v
 getTxOutVal (Mary _) (Shelley.TxOut _ v) = v
 getTxOutVal (Allegra _) (Shelley.TxOut _ v) = v
 getTxOutVal (Shelley _) (Shelley.TxOut _ v) = v
+
+getTxOutCoin :: Proof era -> Core.TxOut era -> Coin
+getTxOutCoin (Babbage _) (Babbage.TxOut _ v _ _) = coin v
+getTxOutCoin (Alonzo _) (TxOut _ v _) = coin v
+getTxOutCoin (Mary _) (Shelley.TxOut _ v) = coin v
+getTxOutCoin (Allegra _) (Shelley.TxOut _ v) = coin v
+getTxOutCoin (Shelley _) (Shelley.TxOut _ v) = coin v
 
 getTxOutRefScript :: Proof era -> Core.TxOut era -> StrictMaybe (Core.Script era)
 getTxOutRefScript (Babbage _) (Babbage.TxOut _ _ _ ms) = ms
@@ -186,6 +253,20 @@ stakeCredAddr :: Addr c -> Maybe (Credential 'Staking c)
 stakeCredAddr (Addr _ _ (StakeRefBase cred)) = Just cred
 stakeCredAddr _ = Nothing
 
+getBody :: Proof era -> Core.Tx era -> Core.TxBody era
+getBody (Babbage _) tx = getField @"body" tx
+getBody (Alonzo _) tx = getField @"body" tx
+getBody (Mary _) tx = getField @"body" tx
+getBody (Allegra _) tx = getField @"body" tx
+getBody (Shelley _) tx = getField @"body" tx
+
+getInputs :: Proof era -> Core.TxBody era -> Set (TxIn (Crypto era))
+getInputs (Babbage _) tx = getField @"inputs" tx
+getInputs (Alonzo _) tx = getField @"inputs" tx
+getInputs (Mary _) tx = getField @"inputs" tx
+getInputs (Allegra _) tx = getField @"inputs" tx
+getInputs (Shelley _) tx = getField @"inputs" tx
+
 primaryLanguage :: Proof era -> Maybe Language
 primaryLanguage (Babbage _) = Just (PlutusV2)
 primaryLanguage (Alonzo _) = Just (PlutusV1)
@@ -208,3 +289,25 @@ alwaysFalse p@(Alonzo _) Nothing _ = anyOf [] p
 alwaysFalse p@(Mary _) _ n = never n p
 alwaysFalse p@(Allegra _) _ n = never n p
 alwaysFalse p@(Shelley _) _ n = never n p
+
+certs :: Proof era -> Core.Tx era -> [DCert (Crypto era)]
+certs (Babbage _) tx = toList $ getField @"certs" (getField @"body" tx)
+certs (Alonzo _) tx = toList $ getField @"certs" (getField @"body" tx)
+certs (Mary _) tx = toList $ getField @"certs" (getField @"body" tx)
+certs (Allegra _) tx = toList $ getField @"certs" (getField @"body" tx)
+certs (Shelley _) tx = toList $ getField @"certs" (getField @"body" tx)
+
+languagesUsed ::
+  forall era.
+  Era era =>
+  Proof era ->
+  Core.Tx era ->
+  UTxO era ->
+  Map (ScriptHash (Crypto era), Tag) (IsValid, Core.Script era) ->
+  Set Language
+languagesUsed proof tx utxo _plutusScripts = case proof of
+  (Shelley _) -> Set.empty
+  (Allegra _) -> Set.empty
+  (Mary _) -> Set.empty
+  (Alonzo _) -> Cardano.Ledger.Alonzo.TxInfo.languages tx utxo
+  (Babbage _) -> Cardano.Ledger.Alonzo.TxInfo.languages tx utxo

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -35,7 +34,14 @@ import Cardano.Ledger.Keys
   )
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Cardano.Ledger.Pretty (PDoc, ppInt, ppMap, ppRecord, ppSet, ppString)
-import Cardano.Ledger.Shelley.LedgerState (DPState (..), DState (..), LedgerState (..), PState (..), RewardAccounts, smartUTxOState)
+import Cardano.Ledger.Shelley.LedgerState
+  ( DPState (..),
+    DState (..),
+    LedgerState (..),
+    PState (..),
+    RewardAccounts,
+    smartUTxOState,
+  )
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
@@ -138,7 +144,20 @@ data GenState era = GenState
   }
 
 emptyGenState :: Reflect era => Proof era -> GenEnv era -> GenState era
-emptyGenState proof genv = GenState mempty mempty mempty mempty mNewEpochStateZero Map.empty Map.empty Map.empty Map.empty Set.empty proof genv
+emptyGenState proof genv =
+  GenState
+    mempty
+    mempty
+    mempty
+    mempty
+    mNewEpochStateZero
+    Map.empty
+    Map.empty
+    Map.empty
+    Map.empty
+    Set.empty
+    proof
+    genv
 
 instance Default GenSize where
   def =
@@ -385,7 +404,7 @@ genFreshCredentials ::
   Set (Credential kr (Crypto era)) ->
   [Credential kr (Crypto era)] ->
   GenRS era [Credential kr (Crypto era)]
-genFreshCredentials _n 0 _tag _old _ans = error ("Ran out of tries in genFreshCredentials.")
+genFreshCredentials _n 0 _tag _old _ans = error "Ran out of tries in genFreshCredentials."
 genFreshCredentials n0 tries tag old0 ans0 = go n0 old0 ans0
   where
     go 0 _ ans = pure ans
@@ -400,7 +419,7 @@ genFreshCredential ::
   Tag ->
   Set (Credential kr (Crypto era)) ->
   GenRS era (Credential kr (Crypto era))
-genFreshCredential 0 _tag _old = error ("Ran out of tries in genFreshCredential.")
+genFreshCredential 0 _tag _old = error "Ran out of tries in genFreshCredential."
 genFreshCredential tries0 tag old = go tries0
   where
     go tries = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -11,27 +12,18 @@
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Strategy for Generic Tests
---   Pre-generate a bunch of inter-related things using a state Monad over a set of Maps
---   and Sets that remember the inter-relation ships. We then extract this state, and it
---   becomes the environment of the regular generators. We make these Maps and Set big
---   enough that when we need something that has one of these relationships, we randomly
---   choose from the Maps and the Sets in the environment, knowing that we can find the
---   related item(s) when it is needed.
+--   Make the GenState include a Mode of the NewEpochState, modify
+--   the ModelNewEpochState to reflect what we generated.
 module Test.Cardano.Ledger.Generic.GenState where
 
 import Cardano.Ledger.Address (RewardAcnt (..))
-import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (Data, DataHash, hashData)
+import Cardano.Ledger.Alonzo.Data (Data (..), DataHash, hashData)
 import Cardano.Ledger.Alonzo.Scripts hiding (Mint)
-import qualified Cardano.Ledger.Alonzo.Scripts as Tag
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.BaseTypes (Network (Testnet), ProtVer (..))
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj))
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Era (..), ValidateScript (hashScript))
 import Cardano.Ledger.Hashes (ScriptHash (..))
 import Cardano.Ledger.Keys
@@ -41,44 +33,57 @@ import Cardano.Ledger.Keys
     coerceKeyRole,
     hashKey,
   )
-import Cardano.Ledger.Mary (MaryEra)
-import Cardano.Ledger.Pretty (PDoc, ppDPState, ppMap, ppPair, ppRecord)
-import Cardano.Ledger.Pretty.Alonzo (ppIsValid, ppTag)
-import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState
-  ( DPState (..),
-    DState (..),
-    PState (..),
-    RewardAccounts,
-    rewards,
-  )
+import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
+import Cardano.Ledger.Pretty (PDoc, ppInt, ppMap, ppRecord, ppSet, ppString)
+import Cardano.Ledger.Shelley.LedgerState (DPState (..), DState (..), LedgerState (..), PState (..), RewardAccounts, smartUTxOState)
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Monad (join, replicateM, replicateM_)
-import qualified Control.Monad.State.Strict as MS (MonadState (..), modify)
+import Control.Monad (join, replicateM, when)
 import Control.Monad.Trans.Class (MonadTrans (lift))
-import Control.Monad.Trans.RWS.Strict (RWST (..), ask, get, modify, runRWST)
+import Control.Monad.Trans.RWS.Strict (RWST (..), ask, get, gets, modify)
+import qualified Control.Monad.Trans.Reader as Reader
+import Control.SetAlgebra (eval, (⨃))
 import Data.Default.Class (Default (def))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (SJust, SNothing))
 import qualified Data.Sequence.Strict as Seq
-import qualified Data.UMap as UM
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.UMap as UMap
+import GHC.Word (Word64)
 import Numeric.Natural
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
 import Test.Cardano.Ledger.Generic.Fields
 import Test.Cardano.Ledger.Generic.Functions
+  ( alwaysFalse,
+    alwaysTrue,
+    obligation',
+    primaryLanguage,
+  )
+import Test.Cardano.Ledger.Generic.ModelState
+  ( ModelNewEpochState (..),
+    fromMUtxo,
+    genDelegsZero,
+    instantaneousRewardsZero,
+    mNewEpochStateZero,
+    pPUPStateZero,
+    pcModelNewEpochState,
+  )
 import Test.Cardano.Ledger.Generic.PrettyCore
-  ( dataHashSummary,
-    dataSummary,
-    keyHashSummary,
-    keyPairSummary,
-    scriptHashSummary,
-    scriptSummary,
+  ( PrettyC (..),
+    pcCoin,
+    pcCredential,
+    pcIndividualPoolStake,
+    pcKeyHash,
+    pcPoolParams,
+    pcTxIn,
+    pcTxOut,
   )
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 import Test.Cardano.Ledger.Generic.Updaters
@@ -97,70 +102,209 @@ import Test.Tasty.QuickCheck
 
 -- | Constants that determine how big a GenState is generated.
 data GenSize = GenSize
-  { numKeys :: Int,
-    numScripts :: Int,
-    numDatums :: Int,
-    numRewards :: Int,
-    numPools :: Int
+  { treasury :: Integer, -- DO WE EVER USE THIS?
+    reserves :: Integer, -- DO WE EVER USE THIS?
+    startSlot :: Word64,
+    blocksizeMax :: Integer,
+    collInputsMax :: Natural,
+    spendInputsMax :: Int,
+    refInputsMax :: Int,
+    utxoChoicesMax :: Int,
+    certificateMax :: Int,
+    withdrawalMax :: Int,
+    oldUtxoPercent :: Int -- between 0-100, 10 means pick an old UTxO 10% of the time
   }
+  deriving (Show)
 
 data GenEnv era = GenEnv
   { geValidityInterval :: ValidityInterval,
-    gePParams :: Core.PParams era
+    gePParams :: Core.PParams era,
+    geSize :: GenSize
   }
 
 data GenState era = GenState
-  { gsKeys :: Map (KeyHash 'Witness (Crypto era)) (KeyPair 'Witness (Crypto era)),
-    gsScripts :: Map (ScriptHash (Crypto era)) (Core.Script era),
-    gsPlutusScripts :: Map (ScriptHash (Crypto era), Tag) (IsValid, Core.Script era),
-    gsDatums :: Map (DataHash (Crypto era)) (Data era),
-    gsDPState :: DPState (Crypto era)
+  { gsKeys :: !(Map (KeyHash 'Witness (Crypto era)) (KeyPair 'Witness (Crypto era))),
+    gsScripts :: !(Map (ScriptHash (Crypto era)) (Core.Script era)),
+    gsPlutusScripts :: !(Map (ScriptHash (Crypto era), Tag) (IsValid, Core.Script era)),
+    gsDatums :: !(Map (DataHash (Crypto era)) (Data era)),
+    gsModel :: !(ModelNewEpochState era),
+    gsInitialUtxo :: !(Map (TxIn (Crypto era)) (Core.TxOut era)),
+    gsInitialRewards :: !(Map (Credential 'Staking (Crypto era)) Coin),
+    gsInitialPoolParams :: !(Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era))),
+    gsInitialPoolDistr :: !(Map (KeyHash 'StakePool (Crypto era)) (IndividualPoolStake (Crypto era))),
+    gsRegKey :: !(Set (Credential 'Staking (Crypto era))),
+    gsProof :: !(Proof era),
+    gsGenEnv :: !(GenEnv era)
   }
 
-emptyGenState :: GenState era
-emptyGenState = GenState mempty mempty mempty mempty def
+emptyGenState :: Reflect era => Proof era -> GenEnv era -> GenState era
+emptyGenState proof genv = GenState mempty mempty mempty mempty mNewEpochStateZero Map.empty Map.empty Map.empty Map.empty Set.empty proof genv
 
 instance Default GenSize where
-  def = GenSize {numKeys = 2, numScripts = 2, numDatums = 5, numRewards = 5, numPools = 1}
+  def =
+    GenSize
+      { treasury = 1000000,
+        reserves = 1000000,
+        startSlot = 10000000,
+        blocksizeMax = 10,
+        collInputsMax = 5,
+        oldUtxoPercent = 15,
+        spendInputsMax = 10,
+        refInputsMax = 6,
+        utxoChoicesMax = 30,
+        certificateMax = 10,
+        withdrawalMax = 10
+      }
+
+small :: GenSize
+small =
+  GenSize
+    { treasury = 1000000,
+      reserves = 1000000,
+      startSlot = 100,
+      blocksizeMax = 3,
+      collInputsMax = 2,
+      oldUtxoPercent = 5,
+      spendInputsMax = 3,
+      refInputsMax = 1,
+      utxoChoicesMax = 12,
+      certificateMax = 2,
+      withdrawalMax = 2
+    }
+
+-- ==============================================================
+-- The Monad
+
+type GenRS era = RWST (GenEnv era) () (GenState era) Gen
+
+type GenR era = Reader.ReaderT (GenState era) Gen
+
+genMapElem :: Map k a -> Gen (Maybe (k, a))
+genMapElem m
+  | n == 0 = pure Nothing
+  | otherwise = do
+      i <- choose (0, n - 1)
+      pure $ Just $ Map.elemAt i m
+  where
+    n = Map.size m
+
+genSetElem :: Set a -> Gen (Maybe a)
+genSetElem m
+  | n == 0 = pure Nothing
+  | otherwise = do
+      i <- choose (0, n - 1)
+      pure $ Just $ Set.elemAt i m
+  where
+    n = Set.size m
+
+elementsT :: (Monad (t Gen), MonadTrans t) => [t Gen b] -> t Gen b
+elementsT = join . lift . elements
+
+frequencyT :: (Monad (t Gen), MonadTrans t) => [(Int, t Gen b)] -> t Gen b
+frequencyT = join . lift . frequency . map (pure <$>)
+
+-- | Gen a positive single digit Int, on a skewed distribution that
+--   favors 2,3,4,5 but occasionally gets others
+positiveSingleDigitInt :: Gen Int
+positiveSingleDigitInt =
+  frequency (map f [(1, 1), (5, 2), (4, 3), (4, 4), (3, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
+  where
+    f (x, y) = (x, pure y)
+
+-- | Gen a non-negative single digit Int, on a skewed distribution that
+--   favors 2,3,4,5 but occasionally gets others
+nonNegativeSingleDigitInt :: Gen Int
+nonNegativeSingleDigitInt =
+  frequency (map f [(1, 0), (2, 1), (5, 2), (4, 3), (3, 4), (2, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
+  where
+    f (x, y) = (x, pure y)
+
+-- | Generate a non-zero value
+genPositiveVal :: Val v => Gen v
+genPositiveVal = inject . Coin . getPositive <$> arbitrary
+
+-- | Generate a value to used in the Rewards, where an occasional 0 is necessary to
+--   make DeReg certificates, which demand their reward balance to be zero
+genRewardVal :: Val v => Gen v
+genRewardVal = frequency [(2, pure mempty), (98, genPositiveVal)]
+
+modifyModel :: (ModelNewEpochState era -> ModelNewEpochState era) -> GenRS era ()
+modifyModel f = modify (\gstate -> gstate {gsModel = f (gsModel gstate)})
+
+-- =====================================================================
+-- Accessing information
+
+getSlot :: GenState era -> SlotNo
+getSlot = SlotNo . startSlot . geSize . gsGenEnv
+
+getBlocksizeMax :: GenState era -> Integer
+getBlocksizeMax = blocksizeMax . geSize . gsGenEnv
+
+getSpendInputsMax :: GenState era -> Int
+getSpendInputsMax = spendInputsMax . geSize . gsGenEnv
+
+getRefInputsMax :: GenState era -> Int
+getRefInputsMax = refInputsMax . geSize . gsGenEnv
+
+getCertificateMax :: GenState era -> Int
+getCertificateMax = certificateMax . geSize . gsGenEnv
+
+getUtxoChoicesMax :: GenState era -> Int
+getUtxoChoicesMax = utxoChoicesMax . geSize . gsGenEnv
+
+getCollInputsMax :: GenState era -> Natural
+getCollInputsMax = collInputsMax . geSize . gsGenEnv
+
+getOldUtxoPercent :: GenState era -> Int
+getOldUtxoPercent x = max 0 (min 100 (oldUtxoPercent (geSize (gsGenEnv x))))
+
+getTreasury :: GenState era -> Coin
+getTreasury = Coin . treasury . geSize . gsGenEnv
+
+getReserves :: GenState era -> Coin
+getReserves = Coin . reserves . geSize . gsGenEnv
+
+getUtxoElem :: GenRS era (Maybe (TxIn (Crypto era), Core.TxOut era))
+getUtxoElem = do
+  x <- gets (mUTxO . gsModel)
+  lift $ genMapElem x
+
+getUtxoTest :: GenRS era (TxIn (Crypto era) -> Bool)
+getUtxoTest = do
+  x <- gets (mUTxO . gsModel)
+  pure (\k -> maybe False (const True) (Map.lookup k x))
+
+-- | To compute deposits we need a function that tells if the KeyHash is a new Pool
+--   Compute this function before we do any generation, since such generation
+--   may actually add to the mPoolParams, and then the added thing won't appear new.
+getNewPoolTest :: GenRS era (KeyHash 'StakePool (Crypto era) -> Bool)
+getNewPoolTest = do
+  poolparams <- gets (mPoolParams . gsModel)
+  pure (`Map.member` poolparams)
 
 -- ========================================================================
 -- Tools to get started
 
-initState :: Reflect era => Proof era -> GenSize -> GenRS era (GenState era)
-initState proof gs = do
-  replicateM_ (numKeys gs) genKeyHash
-  replicateM_ (numScripts gs) $ sequence_ [genScript proof i | i <- [Spend, Tag.Mint, Cert, Rewrd]]
-  replicateM_ (numDatums gs) genDatumWithHash
-  replicateM_ (numRewards gs) genRewards
-  replicateM_ (numPools gs) genPool
-  get
+runGenRS :: Reflect era => Proof era -> GenSize -> GenRS era ans -> Gen (ans, GenState era)
+runGenRS proof gsize action = do
+  genenv <- genGenEnv proof gsize
+  (ans, state, ()) <- runRWST action genenv (emptyGenState proof genenv)
+  pure (ans, state)
 
-startGen :: Reflect era => Proof era -> GenSize -> Gen (GenEnv era, GenState era)
-startGen proof gsize = do
-  env <- genGenEnv proof
-  (state, _, _) <- runRWST (initState proof gsize) env emptyGenState
-  pure (env, state)
-
-startGenRS :: Reflect era => Proof era -> GenSize -> GenRS era (GenEnv era, GenState era)
-startGenRS proof gsize = lift $ startGen proof gsize
-
--- | Helper function for debugging the state generator inside ghci
-viewGenState :: Reflect era => Proof era -> IO ()
-viewGenState proof = do
-  (_, st) <- generate (startGen proof def)
-  putStrLn (show (ppGenState proof st))
-
--- ===========================================================
+-- | Should not be used in tests, this is a helper function to be used in ghci only!
+ioGenRS :: Reflect era => Proof era -> GenSize -> GenRS era ans -> IO (ans, GenState era)
+ioGenRS proof gsize action = generate $ runGenRS proof gsize action
 
 -- | Generate a random, well-formed, GenEnv
-genGenEnv :: Proof era -> Gen (GenEnv era)
-genGenEnv proof = do
+genGenEnv :: Proof era -> GenSize -> Gen (GenEnv era)
+genGenEnv proof gsize = do
   maxTxExUnits <- arbitrary :: Gen ExUnits
-  Positive maxCollateralInputs <- arbitrary :: Gen (Positive Natural)
-  collateralPercentage <- fromIntegral <$> chooseInt (1, 10000) :: Gen Natural
+  maxCollateralInputs <- elements [1 .. collInputsMax gsize]
+  collateralPercentage <- fromIntegral <$> chooseInt (1, 10000)
   minfeeA <- fromIntegral <$> chooseInt (0, 1000)
   minfeeB <- fromIntegral <$> chooseInt (0, 10000)
-  let pp =
+  let slotNo = startSlot gsize
+      pp =
         newPParams
           proof
           [ MinfeeA minfeeA,
@@ -171,16 +315,29 @@ genGenEnv proof = do
             MaxTxExUnits maxTxExUnits,
             MaxCollateralInputs maxCollateralInputs,
             CollateralPercentage collateralPercentage,
-            ProtocolVersion $ ProtVer 7 0
+            ProtocolVersion $ ProtVer 7 0,
+            PoolDeposit $ Coin 5,
+            KeyDeposit $ Coin 2
           ]
-      slotNo = SlotNo 100000000
-  minSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (minBound, unSlotNo slotNo))]
-  maxSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (unSlotNo slotNo + 1, maxBound))]
+  minSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (minBound, slotNo))]
+  maxSlotNo <- frequency [(1, pure SNothing), (4, SJust <$> choose (slotNo + 1, maxBound))]
   pure $
     GenEnv
       { geValidityInterval = ValidityInterval (SlotNo <$> minSlotNo) (SlotNo <$> maxSlotNo),
-        gePParams = pp
+        gePParams = pp,
+        geSize = gsize
       }
+
+genGenState :: Reflect era => Proof era -> GenSize -> Gen (GenState era)
+genGenState proof gsize = do
+  env <- genGenEnv proof gsize
+  pure (emptyGenState proof env)
+
+-- | Helper function for development and debugging in ghci
+viewGenState :: Reflect era => Proof era -> GenSize -> Bool -> IO ()
+viewGenState proof gsize verbose = do
+  st <- generate (genGenState proof gsize)
+  when verbose $ putStrLn (show (pcGenState proof st))
 
 -- =============================================
 -- Generators of inter-related items
@@ -202,28 +359,84 @@ genDatumWithHash = do
     ts {gsDatums = Map.insert datumHash datum gsDatums}
   pure (datumHash, datum)
 
--- Adds to the gsDPState
+-- Adds to the rewards of the ModelNewEpochState
 genRewards :: Reflect era => GenRS era (RewardAccounts (Crypto era))
 genRewards = do
-  n <- lift nonNeg1Digit
-  newrewards <-
-    Map.fromList <$> replicateM n ((,) <$> genCredential Rewrd <*> lift genPositiveVal)
-  modifyDState $ \ds -> ds {_unified = rewards ds UM.⨃ newrewards} -- Prefers coins in newrewards
-  pure newrewards
+  wmax <- gets (withdrawalMax . geSize . gsGenEnv)
+  n <- lift $ choose (1, wmax)
+  -- we need a fresh credential, one that was not previously
+  -- generated here, or one that arose from RegKey (i.e. prev)
+  old <- gets (Map.keysSet . gsInitialRewards)
+  prev <- gets gsRegKey
+  credentials <- genFreshCredentials n 100 Rewrd (Set.union old prev) []
+  newRewards <- Map.fromList <$> mapM (\x -> (,) x <$> lift genRewardVal) credentials
+  modifyModel (\m -> m {mRewards = eval (mRewards m ⨃ newRewards)}) -- Prefers coins in newrewards
+  pure newRewards
 
--- Adds to PState part of DPSTate
-genPool :: Reflect era => GenRS era (KeyHash 'StakePool (Crypto era))
+-- | Generate a 'n' fresh credentials (ones not in the set 'old'). We get 'tries' chances,
+--   if it doesn't work in 'tries' attempts then quit with an error. Better to raise an error
+--   than go into an infinite loop.
+genFreshCredentials ::
+  forall era kr.
+  Reflect era =>
+  Int ->
+  Int ->
+  Tag ->
+  Set (Credential kr (Crypto era)) ->
+  [Credential kr (Crypto era)] ->
+  GenRS era [Credential kr (Crypto era)]
+genFreshCredentials _n 0 _tag _old _ans = error ("Ran out of tries in genFreshCredentials.")
+genFreshCredentials n0 tries tag old0 ans0 = go n0 old0 ans0
+  where
+    go 0 _ ans = pure ans
+    go n old ans = do
+      c <- genFreshCredential tries tag old
+      go (n - 1) (Set.insert c old) (c : ans)
+
+genFreshCredential ::
+  forall era kr.
+  Reflect era =>
+  Int ->
+  Tag ->
+  Set (Credential kr (Crypto era)) ->
+  GenRS era (Credential kr (Crypto era))
+genFreshCredential 0 _tag _old = error ("Ran out of tries in genFreshCredential.")
+genFreshCredential tries0 tag old = go tries0
+  where
+    go tries = do
+      c <- genCredential tag
+      if Set.member c old
+        then go (tries - 1)
+        else pure c
+
+-- Adds to the mPoolParams and the  mPoolDistr of the Model, and the initial set of objects for Traces
+genPool :: forall era. Reflect era => GenRS era (KeyHash 'StakePool (Crypto era))
 genPool = frequencyT [(10, genNewPool), (90, pickExisting)]
   where
     pickExisting = do
-      DPState {dpsPState = PState {_pParams}} <- gsDPState <$> get
+      _pParams <- gets (mPoolParams . gsModel)
       lift (genMapElem _pParams) >>= \case
         Nothing -> genNewPool
         Just poolId -> pure $ fst poolId
     genNewPool = do
       poolId <- genKeyHash
-      pp <- genPoolParams poolId
-      modifyPState $ \ps -> ps {_pParams = Map.insert poolId pp (_pParams ps)}
+      poolparam <- genPoolParams poolId
+      percent <- lift $ choose (0, 1 :: Float)
+      let stake = IndividualPoolStake @(Crypto era) (toRational percent) (_poolVrf poolparam)
+      modify
+        ( \st ->
+            st
+              { gsInitialPoolParams = Map.insert poolId poolparam (gsInitialPoolParams st),
+                gsInitialPoolDistr = Map.insert poolId stake (gsInitialPoolDistr st)
+              }
+        )
+      modifyModel
+        ( \m ->
+            m
+              { mPoolParams = Map.insert poolId poolparam (mPoolParams m),
+                mPoolDistr = Map.insert poolId stake (mPoolDistr m)
+              }
+        )
       pure poolId
     genPoolParams _poolId = do
       _poolVrf <- lift arbitrary
@@ -306,13 +519,13 @@ genTimelockScript proof = do
         ]
       requireSignature = RequireSignature <$> genKeyHash
       requireAllOf k = do
-        n <- lift nonNeg1Digit
+        n <- lift nonNegativeSingleDigitInt
         RequireAllOf . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
       requireAnyOf k = do
-        n <- lift pos1Digit
+        n <- lift positiveSingleDigitInt
         RequireAnyOf . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
       requireMOf k = do
-        n <- lift nonNeg1Digit
+        n <- lift nonNegativeSingleDigitInt
         m <- lift $ choose (0, n)
         RequireMOf m . Seq.fromList <$> replicateM n (genNestedTimelock (k - 1))
       requireTimeStart (SlotNo validFrom) = do
@@ -344,13 +557,13 @@ genMultiSigScript proof = do
       nonRecTimelocks = [requireSignature]
       requireSignature = Shelley.RequireSignature <$> genKeyHash
       requireAllOf k = do
-        n <- lift nonNeg1Digit
+        n <- lift nonNegativeSingleDigitInt
         Shelley.RequireAllOf <$> replicateM n (genNestedMultiSig (k - 1))
       requireAnyOf k = do
-        n <- lift pos1Digit
+        n <- lift positiveSingleDigitInt
         Shelley.RequireAnyOf <$> replicateM n (genNestedMultiSig (k - 1))
       requireMOf k = do
-        n <- lift nonNeg1Digit
+        n <- lift nonNegativeSingleDigitInt
         m <- lift $ choose (0, n)
         Shelley.RequireMOf m <$> replicateM n (genNestedMultiSig (k - 1))
   msscript <- genNestedMultiSig (2 :: Natural)
@@ -382,6 +595,7 @@ genPlutusScript proof tag = do
     if isValid
       then alwaysTrue proof mlanguage . (+ numArgs) <$> lift (elements [0, 1, 2, 3 :: Natural])
       else pure $ alwaysFalse proof mlanguage numArgs
+
   let corescript :: Core.Script era
       corescript = case proof of
         Alonzo _ -> script
@@ -392,80 +606,52 @@ genPlutusScript proof tag = do
     ts {gsPlutusScripts = Map.insert (scriptHash, tag) (IsValid isValid, corescript) gsPlutusScripts}
   pure scriptHash
 
--- ===========================================================
--- The Monad and Era agnostic generators and operators
+-- =================================================================
 
-type GenRS era = RWST (GenEnv era) () (GenState era) Gen
-
-genMapElem :: Map k a -> Gen (Maybe (k, a))
-genMapElem m
-  | n == 0 = pure Nothing
-  | otherwise = do
-      i <- choose (0, n - 1)
-      pure $ Just $ Map.elemAt i m
-  where
-    n = Map.size m
-
-elementsT :: (Monad (t Gen), MonadTrans t) => [t Gen b] -> t Gen b
-elementsT = join . lift . elements
-
-frequencyT :: (Monad (t Gen), MonadTrans t) => [(Int, t Gen b)] -> t Gen b
-frequencyT = join . lift . frequency . map (pure <$>)
-
--- | Gen a positive single digit Int, on a skewed distribution that
---   favors 2,3,4,5 but occasionally gets others
-pos1Digit :: Gen Int
-pos1Digit = frequency (map f [(1, 1), (7, 2), (6, 3), (5, 4), (3, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
-  where
-    f (x, y) = (x, pure y)
-
--- | Gen a non-negative single digit Int, on a skewed distribution that
---   favors 2,3,4,5 but occasionally gets others
-nonNeg1Digit :: Gen Int
-nonNeg1Digit = frequency (map f [(1, 0), (2, 1), (7, 2), (6, 3), (5, 4), (3, 5), (2, 6), (1, 7), (1, 8), (1, 9)])
-  where
-    f (x, y) = (x, pure y)
-
--- | Generate a non-zero value
-genPositiveVal :: Val v => Gen v
-genPositiveVal = inject . Coin . getPositive <$> arbitrary
-
-modifyDState :: (MS.MonadState (GenState era) m) => (DState (Crypto era) -> DState (Crypto era)) -> m ()
-modifyDState f =
-  modifyDPState $ \dp@DPState {dpsDState = ds} -> dp {dpsDState = f ds}
-
-modifyDPState :: (MS.MonadState (GenState era) m) => (DPState (Crypto era) -> DPState (Crypto era)) -> m ()
-modifyDPState f =
-  MS.modify $ \s@GenState {gsDPState = dps} -> s {gsDPState = f dps}
-
-modifyPState :: (MS.MonadState (GenState era) m) => (PState (Crypto era) -> PState (Crypto era)) -> m ()
-modifyPState f =
-  modifyDPState $ \dp@DPState {dpsPState = ps} -> dp {dpsPState = f ps}
-
--- ========================================================================
-
-deriving instance CC.Crypto c => Show (GenState (BabbageEra c))
-
-deriving instance CC.Crypto c => Show (GenState (AlonzoEra c))
-
-deriving instance CC.Crypto c => Show (GenState (MaryEra c))
-
-deriving instance CC.Crypto c => Show (GenState (AllegraEra c))
-
-deriving instance CC.Crypto c => Show (GenState (ShelleyEra c))
-
-ppGenState :: CC.Crypto (Crypto era) => Proof era -> GenState era -> PDoc
-ppGenState proof (GenState keys scripts plutus dats dp) =
+pcGenState :: Reflect era => Proof era -> GenState era -> PDoc
+pcGenState proof (GenState keys scripts plutus dats model iutxo irew ipoolp ipoold irkey prf _genenv) =
   ppRecord
-    "GenState"
-    [ ("Keymap", ppMap keyHashSummary keyPairSummary keys),
-      ("Scriptmap", ppMap scriptHashSummary (scriptSummary proof) scripts),
-      ( "PlutusScripts",
-        ppMap
-          (ppPair scriptHashSummary ppTag)
-          (ppPair ppIsValid (scriptSummary proof))
-          plutus
-      ),
-      ("Datums", ppMap dataHashSummary dataSummary dats),
-      ("DPState", ppDPState dp)
+    "GenState Summary"
+    [ ("Keymap", ppInt (Map.size keys)),
+      ("Scriptmap", ppInt (Map.size scripts)),
+      ("PlutusScripts", ppInt (Map.size plutus)),
+      ("Datums", ppInt (Map.size dats)),
+      ("Model", pcModelNewEpochState proof model),
+      ("Initial Utxo", ppMap pcTxIn (pcTxOut proof) iutxo),
+      ("Initial Rewards", ppMap pcCredential pcCoin irew),
+      ("Initial PoolParams", ppMap pcKeyHash pcPoolParams ipoolp),
+      ("Initial PoolDistr", ppMap pcKeyHash pcIndividualPoolStake ipoold),
+      ("Previous RegKey", ppSet pcCredential irkey),
+      ("GenEnv", ppString "GenEnv ..."),
+      ("Proof", ppString (show prf))
     ]
+
+instance Reflect era => PrettyC (GenState era) era where prettyC = pcGenState
+
+instance era ~ BabbageEra Mock => Show (GenState era) where
+  show x = show (pcGenState (Babbage Mock) x)
+
+-- =====================================================================
+-- Build an Initial LedgerState for a Trace from a GenState, after
+-- generating a coherent Trace (a sequence of Transactions that can
+-- logically be applied one after another)
+
+initialLedgerState :: forall era. Reflect era => GenState era -> LedgerState era
+initialLedgerState gstate = LedgerState utxostate dpstate
+  where
+    utxostate = smartUTxOState (fromMUtxo (gsInitialUtxo gstate)) deposited (Coin 0) (pPUPStateZero @era)
+    dpstate = DPState dstate pstate
+    dstate =
+      DState
+        (UMap.unify (gsInitialRewards gstate) Map.empty Map.empty)
+        Map.empty
+        genDelegsZero
+        instantaneousRewardsZero
+    pstate = PState (gsInitialPoolParams gstate) Map.empty Map.empty
+    -- In a wellformed LedgerState the deposited equals the obligation
+    deposited =
+      obligation'
+        reify
+        (gePParams (gsGenEnv gstate))
+        (gsInitialRewards gstate)
+        (gsInitialPoolParams gstate)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -15,10 +15,8 @@
 module Test.Cardano.Ledger.Generic.Indexed where
 
 import Cardano.Crypto.DSIGN.Class ()
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (Script (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (Value)
 import qualified Cardano.Ledger.Core as Core
@@ -44,6 +42,15 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as Seq (fromList)
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Generic.Proof
+  ( AlonzoEra,
+    BabbageEra,
+    Evidence (..),
+    GoodCrypto,
+    Mock,
+    Proof (..),
+    Reflect (..),
+    ReflectC (..),
+  )
 import Test.Cardano.Ledger.Shelley.Utils (RawSeed (..), mkKeyPair)
 
 -- ===========================================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Generic.MockChain where
+
+import Cardano.Ledger.BaseTypes (BlocksMade (..), ShelleyBase)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.Pretty
+  ( PDoc,
+    PrettyA (..),
+    ppInt,
+    ppKeyHash,
+    ppRecord,
+    ppSlotNo,
+  )
+import Cardano.Ledger.Shelley.LedgerState
+  ( DPState (..),
+    DState (..),
+    EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    PState (..),
+  )
+import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv)
+import Cardano.Ledger.Shelley.Rules.Ledgers (LEDGERS, LedgersEnv (..), LedgersEvent, LedgersPredicateFailure)
+import Cardano.Ledger.Shelley.Rules.Rupd (RupdEnv)
+import Cardano.Ledger.Shelley.Rules.Tick (TICK, TickEvent, TickPredicateFailure)
+import Cardano.Slotting.Slot (EpochNo, SlotNo)
+import Control.State.Transition
+  ( Embed (..),
+    STS (..),
+    TRC (..),
+    TransitionRule,
+    judgmentContext,
+    trans,
+    (?!),
+  )
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe)
+import Data.Sequence (Seq (..))
+import Test.Cardano.Ledger.Generic.PrettyCore
+  ( pcNewEpochState,
+    ppLedgersPredicateFailure,
+    ppTickPredicateFailure,
+  )
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (reify))
+
+-- ================================================
+
+data MOCKCHAIN era -- This is a Testing only STS instance
+
+type instance Core.EraRule "MOCKCHAIN" era = MOCKCHAIN era
+
+data MockChainFailure era
+  = MockChainFromTickFailure (TickPredicateFailure era)
+  | MockChainFromLedgersFailure (LedgersPredicateFailure era)
+  | BlocksOutOfOrder
+      SlotNo -- The last applied block SlotNo
+      SlotNo -- The candidate block SlotNo
+
+data MockChainEvent era
+  = MockChainFromTickEvent (TickEvent era)
+  | MockChainFromLedgersEvent (LedgersEvent era)
+
+data MockBlock era = MockBlock
+  { mbIssuer :: KeyHash 'StakePool (Crypto era),
+    mbSlot :: SlotNo,
+    mbTrans :: Seq (Core.Tx era)
+  }
+
+data MockChainState era = MockChainState
+  { mcsNes :: NewEpochState era,
+    mcsLastBlock :: SlotNo,
+    mcsCount :: Int -- Counts the blocks made
+  }
+
+instance Show (MockChainState era) where
+  show (MockChainState nes slot count) = show count ++ " " ++ show slot ++ "\n  " ++ show (nesBcur nes)
+
+instance Show (MockBlock era) where
+  show (MockBlock is sl _) = show is ++ " " ++ show sl
+
+-- ======================================================================
+
+instance
+  ( Reflect era,
+    STS (LEDGERS era),
+    STS (TICK era),
+    State (Core.EraRule "TICK" era) ~ NewEpochState era,
+    Signal (Core.EraRule "TICK" era) ~ SlotNo,
+    Environment (Core.EraRule "TICK" era) ~ (),
+    Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    State (Core.EraRule "LEDGER" era) ~ (LedgerState era),
+    Embed (Core.EraRule "TICK" era) (MOCKCHAIN era)
+  ) =>
+  STS (MOCKCHAIN era)
+  where
+  type State (MOCKCHAIN era) = MockChainState era
+  type Signal (MOCKCHAIN era) = (MockBlock era)
+  type Environment (MOCKCHAIN era) = ()
+  type BaseM (MOCKCHAIN era) = ShelleyBase
+  type PredicateFailure (MOCKCHAIN era) = MockChainFailure era
+  type Event (MOCKCHAIN era) = MockChainEvent era
+  initialRules = [error "INITIAL RULE CALLED IN MOCKCHAIN"]
+  transitionRules = [chainTransition]
+
+chainTransition ::
+  forall era.
+  ( STS (LEDGERS era),
+    State (Core.EraRule "TICK" era) ~ NewEpochState era,
+    Signal (Core.EraRule "TICK" era) ~ SlotNo,
+    Environment (Core.EraRule "TICK" era) ~ (),
+    Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    State (Core.EraRule "LEDGER" era) ~ (LedgerState era),
+    Embed (Core.EraRule "TICK" era) (MOCKCHAIN era)
+  ) =>
+  TransitionRule (MOCKCHAIN era)
+chainTransition = do
+  TRC (_, MockChainState nes lastSlot count, (MockBlock issuer slot txs)) <- judgmentContext
+
+  lastSlot < slot ?! BlocksOutOfOrder lastSlot slot
+
+  nes' <- trans @(Core.EraRule "TICK" era) $ TRC ((), nes, slot)
+
+  let NewEpochState _ _ (BlocksMade current) epochState _ _ _ = nes'
+      EpochState account _ ledgerState _ pparams _ = epochState
+      LedgerState _ (DPState (DState _ _ _genDelegs _) (PState _ _ _)) = ledgerState
+
+  let newblocksmade = BlocksMade (Map.unionWith (+) current (Map.singleton issuer 1))
+
+  newledgerState <-
+    trans @(LEDGERS era) $ TRC (LedgersEnv slot pparams account, ledgerState, txs)
+
+  let newEpochstate = epochState {esLState = newledgerState}
+      newNewEpochState = nes' {nesEs = newEpochstate, nesBcur = newblocksmade}
+
+  pure (MockChainState newNewEpochState slot (count + 1))
+
+-- ===========================
+-- Embed instances
+
+instance
+  ( STS (TICK era),
+    Signal (Core.EraRule "RUPD" era) ~ SlotNo,
+    State (Core.EraRule "RUPD" era) ~ StrictMaybe (PulsingRewUpdate (Crypto era)),
+    Environment (Core.EraRule "RUPD" era) ~ RupdEnv era,
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo,
+    State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
+    Environment (Core.EraRule "NEWEPOCH" era) ~ ()
+  ) =>
+  Embed (TICK era) (MOCKCHAIN era)
+  where
+  wrapFailed = MockChainFromTickFailure
+  wrapEvent = MockChainFromTickEvent
+
+instance
+  ( STS (LEDGERS era),
+    State (Core.EraRule "LEDGER" era) ~ LedgerState era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
+    Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era
+  ) =>
+  Embed (LEDGERS era) (MOCKCHAIN era)
+  where
+  wrapFailed = MockChainFromLedgersFailure
+  wrapEvent = MockChainFromLedgersEvent
+
+-- ================================================================
+
+deriving instance
+  (Show (TickEvent era), Show (LedgersEvent era)) => Show (MockChainEvent era)
+
+deriving instance
+  (Eq (TickEvent era), Eq (LedgersEvent era)) => Eq (MockChainEvent era)
+
+deriving instance
+  (Show (TickPredicateFailure era), Show (LedgersPredicateFailure era)) => Show (MockChainFailure era)
+
+deriving instance
+  (Eq (TickPredicateFailure era), Eq (LedgersPredicateFailure era)) => Eq (MockChainFailure era)
+
+ppMockChainState ::
+  Reflect era =>
+  MockChainState era ->
+  PDoc
+ppMockChainState (MockChainState nes sl count) =
+  ppRecord
+    "MockChainState"
+    [ ("NewEpochState", pcNewEpochState reify nes),
+      ("LastBlock", ppSlotNo sl),
+      ("Count", ppInt count)
+    ]
+
+instance Reflect era => PrettyA (MockChainState era) where
+  prettyA = ppMockChainState
+
+ppMockBlock :: MockBlock era -> PDoc
+ppMockBlock (MockBlock iss sl txs) =
+  ppRecord
+    "MockBock"
+    [ ("Issuer", ppKeyHash iss),
+      ("Slot", ppSlotNo sl),
+      ("Transactions", ppInt (length txs))
+    ]
+
+instance PrettyA (MockBlock era) where prettyA = ppMockBlock
+
+ppMockChainFailure :: Proof era -> MockChainFailure era -> PDoc
+ppMockChainFailure proof x = case proof of
+  (Babbage _) -> help x
+  (Alonzo _) -> help x
+  (Mary _) -> help x
+  (Allegra _) -> help x
+  (Shelley _) -> help x
+  where
+    help (MockChainFromTickFailure y) = ppTickPredicateFailure y
+    help (MockChainFromLedgersFailure y) = ppLedgersPredicateFailure y
+    help (BlocksOutOfOrder lastslot cand) =
+      ppRecord
+        "BlocksOutOfOrder"
+        [ ("Last applied block", ppSlotNo lastslot),
+          ("Candidate block", ppSlotNo cand)
+        ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -1,0 +1,437 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | The data types in this file constitute a Model of the NewEpochState
+--   sufficient for generating transactions that can run in the
+--   MockChain STS instance. This is a model so we drop some details of the
+--   real NewEpochState, and add some additional details specific to Tx generation.
+--   Dropped details include
+--   1) Efficiency concerns
+--      a) Pulsing Reward updates
+--      b) Inverse of the Rewards Map
+--      c) esNonMyopic field
+--      d) _stakeDistro, Incremental Stake distribution
+--   2) Transaction features that make changes to the Protocol Parameters
+--   3) Using Hashes of the TxBody as the Ix, instead we maintain an index of
+--      an arbitrary Hash to the sequence (Count) in which the TxBody was generated.
+--   Additional details
+--   1) Utxo entries to pay fees. It is incredibly hard to generate Txs with the
+--      correct fees. So we keep a small set of UtxoEntrys, where it is allowed to
+--      mutate the value field of the TxOut. We have to be sure these entries are carefully
+--      managed, as they do not follow the rules of the real world.
+--   Additional comments
+--   1) We include data in the Model for Epoch boundary computations, but we do not
+--      do anything with them at this time.
+module Test.Cardano.Ledger.Generic.ModelState where
+
+import Cardano.Ledger.BaseTypes (BlocksMade (..))
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Keys
+  ( GenDelegs (..),
+    KeyHash (..),
+    KeyRole (..),
+  )
+import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
+import Cardano.Ledger.Pretty
+  ( PDoc,
+    ppAccountState,
+    ppCoin,
+    ppEpochNo,
+    ppInt,
+    ppKeyHash,
+    ppMap,
+    ppNatural,
+    ppRecord,
+    ppString,
+  )
+import Cardano.Ledger.Pretty.Alonzo ()
+import Cardano.Ledger.Pretty.Babbage ()
+import Cardano.Ledger.Shelley.EpochBoundary
+  ( SnapShot (..),
+    SnapShots (..),
+    Stake (..),
+  )
+import Cardano.Ledger.Shelley.LedgerState
+  ( AccountState (..),
+    DPState (..),
+    DState (..),
+    EpochState (..),
+    IncrementalStake (..),
+    InstantaneousRewards (..),
+    LedgerState (..),
+    NewEpochState (..),
+    PPUPState (..),
+    PState (..),
+    StashedAVVMAddresses,
+    UTxOState (..),
+    completeRupd,
+    smartUTxOState,
+  )
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
+import Cardano.Ledger.Shelley.PoolRank (NonMyopic (..))
+import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..), RewardUpdate (..))
+import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.Slot (EpochNo (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Control.Monad.Trans ()
+import Control.Provenance (runProvM)
+import Control.State.Transition (STS (State))
+import qualified Data.Compact.SplitMap as SplitMap
+import qualified Data.Compact.VMap as VMap
+import Data.Default.Class (Default (def))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Text (Text)
+import qualified Data.UMap as UMap
+import GHC.Natural (Natural)
+import Test.Cardano.Ledger.Generic.PrettyCore
+  ( PrettyC (..),
+    credSummary,
+    keyHashSummary,
+    pcCredential,
+    pcIndividualPoolStake,
+    pcKeyHash,
+    pcPoolParams,
+    pcTxId,
+    pcTxIn,
+    pcTxOut,
+  )
+import Test.Cardano.Ledger.Generic.Proof
+  ( BabbageEra,
+    Evidence (..),
+    Mock,
+    Proof (..),
+    Reflect (..),
+  )
+import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
+
+-- =============================================
+
+-- | MUtxo = Model UTxO. In the Model we represent the
+--   UTxO as a Map (not a newtype around a SplitMap)
+type MUtxo era = Map (TxIn (Crypto era)) (Core.TxOut era)
+
+toMUtxo :: UTxO era -> MUtxo era
+toMUtxo (UTxO m) = SplitMap.toMap m
+
+fromMUtxo :: MUtxo era -> UTxO era
+fromMUtxo m = UTxO (SplitMap.fromMap m)
+
+-- ===========================================================
+
+data ModelNewEpochState era = ModelNewEpochState
+  { -- PState fields
+    mPoolParams :: !(Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era))),
+    -- DState state fields
+    mRewards :: !(Map (Credential 'Staking (Crypto era)) Coin),
+    mDelegations :: !(Map (Credential 'Staking (Crypto era)) (KeyHash 'StakePool (Crypto era))),
+    --  _fGenDelegs,  _genDelegs, and _irwd, are for
+    --  changing the PParams and are abstracted away
+
+    -- UTxO state fields (and extra stuff)
+    mUTxO :: !(Map (TxIn (Crypto era)) (Core.TxOut era)),
+    -- | The current UTxO
+    mMutFee :: !(Map (TxIn (Crypto era)) (Core.TxOut era)),
+    -- _ppups is for changing PParams, and _stakeDistro is for efficiency
+    -- and are abstracted away.
+
+    -- EpochState fields
+    mAccountState :: !AccountState,
+    -- esPrevPp and esPp are for changing PParams
+    -- esNonMyopic is for efficiency, and all are abstracted away
+
+    -- Model NewEpochState fields
+    mPoolDistr :: !(Map (KeyHash 'StakePool (Crypto era)) (IndividualPoolStake (Crypto era))),
+    mPParams :: !(Core.PParams era),
+    mDeposited :: !Coin,
+    mFees :: !Coin,
+    mCount :: !Int,
+    mIndex :: !(Map Int (TxId (Crypto era))),
+    -- below here NO EFFECT until we model EpochBoundary
+    mFPoolParams :: !(Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era))),
+    mRetiring :: !(Map (KeyHash 'StakePool (Crypto era)) EpochNo),
+    mSnapshots :: !(SnapShots (Crypto era)),
+    mEL :: !EpochNo, -- Last epoch,
+    mBprev :: !(Map (KeyHash 'StakePool (Crypto era)) Natural), --  Blocks made before current epoch, NO EFFECT until we model EpochBoundar
+    mBcur :: !(Map (KeyHash 'StakePool (Crypto era)) Natural),
+    -- | Blocks made in current epoch
+    mRu :: !(StrictMaybe (RewardUpdate (Crypto era))) -- Possible reward update
+  }
+
+type UtxoEntry era = (TxIn (Crypto era), Core.TxOut era)
+
+type Model era = ModelNewEpochState era
+
+-- ======================================================================
+-- Empty or default values, these are usefull for many things, not the
+-- least of, for making Model instances.
+
+blocksMadeZero :: BlocksMade crypto
+blocksMadeZero = BlocksMade Map.empty
+
+poolDistrZero :: PoolDistr crypto
+poolDistrZero = PoolDistr Map.empty
+
+stakeZero :: Stake crypto
+stakeZero = Stake VMap.empty
+
+snapShotZero :: SnapShot crypto
+snapShotZero = SnapShot stakeZero VMap.empty VMap.empty
+
+snapShotsZero :: SnapShots crypto
+snapShotsZero = SnapShots snapShotZero snapShotZero snapShotZero (Coin 0)
+
+accountStateZero :: AccountState
+accountStateZero = AccountState (Coin 0) (Coin 0)
+
+utxoZero :: UTxO era
+utxoZero = UTxO SplitMap.empty
+
+genDelegsZero :: GenDelegs crypto
+genDelegsZero = GenDelegs Map.empty
+
+instantaneousRewardsZero :: InstantaneousRewards crypto
+instantaneousRewardsZero = InstantaneousRewards Map.empty Map.empty mempty mempty
+
+dStateZero :: DState crypto
+dStateZero = DState UMap.empty Map.empty genDelegsZero instantaneousRewardsZero
+
+pStateZero :: PState crypto
+pStateZero = PState Map.empty Map.empty Map.empty
+
+dPStateZero :: DPState crypto
+dPStateZero = DPState dStateZero pStateZero
+
+incrementalStakeZero :: IncrementalStake crypto
+incrementalStakeZero = IStake Map.empty Map.empty
+
+proposedPPUpdatesZero :: ProposedPPUpdates era
+proposedPPUpdatesZero = ProposedPPUpdates Map.empty
+
+nonMyopicZero :: NonMyopic crypto
+nonMyopicZero = NonMyopic Map.empty mempty
+
+pPUPStateZeroByProof :: Proof era -> State (Core.EraRule "PPUP" era)
+pPUPStateZeroByProof (Babbage _) = PPUPState proposedPPUpdatesZero proposedPPUpdatesZero
+pPUPStateZeroByProof (Alonzo _) = PPUPState proposedPPUpdatesZero proposedPPUpdatesZero
+pPUPStateZeroByProof (Mary _) = PPUPState proposedPPUpdatesZero proposedPPUpdatesZero
+pPUPStateZeroByProof (Allegra _) = PPUPState proposedPPUpdatesZero proposedPPUpdatesZero
+pPUPStateZeroByProof (Shelley _) = PPUPState proposedPPUpdatesZero proposedPPUpdatesZero
+
+pParamsZeroByProof :: Proof era -> Core.PParams era
+pParamsZeroByProof (Babbage _) = def
+pParamsZeroByProof (Alonzo _) = def
+pParamsZeroByProof (Mary _) = def
+pParamsZeroByProof (Allegra _) = def
+pParamsZeroByProof (Shelley _) = def
+
+pPUPStateZero :: forall era. Reflect era => State (Core.EraRule "PPUP" era)
+pPUPStateZero = pPUPStateZeroByProof @era (reify :: Proof era)
+
+uTxOStateZero :: forall era. Reflect era => UTxOState era
+uTxOStateZero = smartUTxOState utxoZero mempty mempty (pPUPStateZero @era)
+
+pParamsZero :: Reflect era => Core.PParams era
+pParamsZero = lift pParamsZeroByProof
+
+ledgerStateZero :: Reflect era => LedgerState era
+ledgerStateZero = LedgerState uTxOStateZero dPStateZero
+
+epochStateZero :: Reflect era => EpochState era
+epochStateZero = EpochState accountStateZero snapShotsZero ledgerStateZero pParamsZero pParamsZero nonMyopicZero
+
+newEpochStateZero :: forall era. Reflect era => NewEpochState era
+newEpochStateZero =
+  NewEpochState
+    (EpochNo 0)
+    blocksMadeZero
+    blocksMadeZero
+    epochStateZero
+    SNothing
+    poolDistrZero
+    (stashedAVVMAddressesZero (reify :: Proof era))
+
+stashedAVVMAddressesZero :: Proof era -> StashedAVVMAddresses era
+stashedAVVMAddressesZero (Shelley _) = utxoZero
+stashedAVVMAddressesZero (Babbage _) = ()
+stashedAVVMAddressesZero (Alonzo _) = ()
+stashedAVVMAddressesZero (Mary _) = ()
+stashedAVVMAddressesZero (Allegra _) = ()
+
+mNewEpochStateZero :: Reflect era => ModelNewEpochState era
+mNewEpochStateZero =
+  ModelNewEpochState
+    { mPoolParams = Map.empty,
+      mRewards = Map.empty,
+      mDelegations = Map.empty,
+      mUTxO = Map.empty,
+      mMutFee = Map.empty,
+      mAccountState = accountStateZero,
+      mPoolDistr = Map.empty,
+      mPParams = pParamsZero,
+      mDeposited = Coin 0,
+      mFees = Coin 0,
+      mCount = 0,
+      mIndex = Map.empty,
+      -- below here NO EFFECT until we model EpochBoundary
+      mFPoolParams = Map.empty,
+      mRetiring = Map.empty,
+      mSnapshots = snapShotsZero,
+      mEL = EpochNo 0,
+      mBprev = Map.empty,
+      mBcur = Map.empty,
+      mRu = SNothing
+    }
+
+testNES :: NewEpochState (BabbageEra Mock)
+testNES = newEpochStateZero
+
+testMNES :: ModelNewEpochState (BabbageEra Mock)
+testMNES = mNewEpochStateZero
+
+-- ======================================================================
+
+class Extract t era where
+  extract :: ModelNewEpochState era -> t
+
+instance Crypto era ~ c => Extract (DState c) era where
+  extract x =
+    DState
+      (UMap.unify (mRewards x) (mDelegations x) Map.empty)
+      Map.empty
+      genDelegsZero
+      instantaneousRewardsZero
+
+instance Crypto era ~ c => Extract (PState c) era where
+  extract x = PState (mPoolParams x) (mFPoolParams x) (mRetiring x)
+
+instance Crypto era ~ c => Extract (DPState c) era where
+  extract x = DPState (extract x) (extract x)
+
+instance Reflect era => Extract (UTxOState era) era where
+  extract x =
+    smartUTxOState
+      (UTxO (SplitMap.fromMap (mUTxO x)))
+      (mDeposited x)
+      (mFees x)
+      (pPUPStateZero @era)
+
+instance Reflect era => Extract (LedgerState era) era where
+  extract x = LedgerState (extract x) (extract x)
+
+instance Reflect era => Extract (EpochState era) era where
+  extract x =
+    EpochState
+      (mAccountState x)
+      (mSnapshots x)
+      (extract x)
+      (pParamsZero @era)
+      (pParamsZero @era)
+      nonMyopicZero
+
+instance forall era. Reflect era => Extract (NewEpochState era) era where
+  extract x =
+    NewEpochState
+      (mEL x)
+      (BlocksMade (mBprev x))
+      (BlocksMade (mBcur x))
+      (extract x)
+      (Complete <$> (mRu x))
+      (PoolDistr (mPoolDistr x))
+      (stashedAVVMAddressesZero (reify :: Proof era))
+
+abstract :: NewEpochState era -> ModelNewEpochState era
+abstract x =
+  ModelNewEpochState
+    { mPoolParams = (_pParams . dpsPState . lsDPState . esLState . nesEs) x,
+      mRewards = (UMap.rewView . _unified . dpsDState . lsDPState . esLState . nesEs) x,
+      mDelegations = (UMap.delView . _unified . dpsDState . lsDPState . esLState . nesEs) x,
+      mUTxO = (SplitMap.toMap . unUTxO . _utxo . lsUTxOState . esLState . nesEs) x,
+      mMutFee = Map.empty,
+      mAccountState = (esAccountState . nesEs) x,
+      mPoolDistr = (unPoolDistr . nesPd) x,
+      mPParams = (esPp . nesEs) x,
+      mDeposited = (_deposited . lsUTxOState . esLState . nesEs) x,
+      mFees = (_fees . lsUTxOState . esLState . nesEs) x,
+      mCount = 0,
+      mIndex = Map.empty,
+      -- below here NO EFFECT until we model EpochBoundary
+      mFPoolParams = (_fPParams . dpsPState . lsDPState . esLState . nesEs) x,
+      mRetiring = (_retiring . dpsPState . lsDPState . esLState . nesEs) x,
+      mSnapshots = (esSnapshots . nesEs) x,
+      mEL = nesEL x,
+      mBprev = unBlocksMade (nesBprev x),
+      mBcur = unBlocksMade (nesBcur x),
+      mRu = case nesRu x of
+        SNothing -> SNothing
+        SJust pru -> SJust (complete pru)
+        -- SNothing -- There is no way to complete (nesRu x) to get a RewardUpdate
+    }
+
+complete :: PulsingRewUpdate crypto -> RewardUpdate crypto
+complete (Complete r) = r
+complete (Pulsing rewsnap pulser) = fst $ runShelleyBase $ runProvM (completeRupd (Pulsing rewsnap pulser))
+
+-- =====================================================================
+
+pcModelNewEpochState :: Reflect era => Proof era -> ModelNewEpochState era -> PDoc
+pcModelNewEpochState proof x =
+  ppRecord "ModelNewEpochState" $
+    [ ("poolparams", ppMap keyHashSummary pcPoolParams (mPoolParams x)),
+      ("rewards", ppMap credSummary ppCoin (mRewards x)),
+      ("delegations", ppMap pcCredential pcKeyHash (mDelegations x)),
+      ("utxo", ppMap pcTxIn (pcTxOut proof) (mUTxO x)),
+      ("mutFees", ppMap pcTxIn (pcTxOut proof) (mMutFee x)),
+      ("account", ppAccountState (mAccountState x)),
+      ("pool distr", ppMap pcKeyHash pcIndividualPoolStake (mPoolDistr x)),
+      ("protocol params", ppString "PParams ..."),
+      ("deposited", ppCoin (mDeposited x)),
+      ("fees", ppCoin (mFees x)),
+      ("count", ppInt (mCount x)),
+      ("index", ppMap ppInt pcTxId (mIndex x))
+      -- Add additional EpochBoundary fields here
+    ]
+      ++ Maybe.catMaybes (epochBoundaryPDoc proof x)
+
+epochBoundaryPDoc :: Proof era -> ModelNewEpochState era -> [Maybe (Text, PDoc)]
+epochBoundaryPDoc _proof x =
+  [ if Map.null futurepp then Nothing else Just ("future pparams", ppMap ppKeyHash pcPoolParams futurepp),
+    if Map.null retiring then Nothing else Just ("retiring", ppMap ppKeyHash ppEpochNo retiring),
+    if lastepoch == EpochNo 0 then Nothing else Just ("last epoch", ppEpochNo lastepoch),
+    if Map.null prevBlocks then Nothing else Just ("prev blocks", ppMap ppKeyHash ppNatural prevBlocks),
+    if Map.null curBlocks then Nothing else Just ("current blocks", ppMap ppKeyHash ppNatural curBlocks)
+  ]
+  where
+    futurepp = mFPoolParams x
+    retiring = mRetiring x
+    lastepoch = mEL x
+    prevBlocks = (mBprev x)
+    curBlocks = (mBcur x)
+
+-- SnapShots and PulsingRewUdate delberately ommitted from pretty printer
+
+instance Reflect era => PrettyC (ModelNewEpochState era) era where prettyC = pcModelNewEpochState
+
+instance era ~ BabbageEra Mock => Show (ModelNewEpochState era) where
+  show x = show (prettyC (Babbage Mock) x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -16,899 +16,103 @@
 
 module Test.Cardano.Ledger.Generic.Properties where
 
-import Cardano.Ledger.Alonzo.Data (Data, dataToBinaryData, hashData)
-import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.PParams (PParams' (..))
-import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
-import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
-import Cardano.Ledger.Alonzo.TxInfo (languages)
-import Cardano.Ledger.Alonzo.TxWitness
-  ( RdmrPtr (..),
-    Redeemers (..),
-    TxDats (..),
-  )
-import Cardano.Ledger.Babbage (BabbageEra)
-import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams' (..))
-import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxOut (..))
-import Cardano.Ledger.BaseTypes
-  ( Network (..),
-    ProtVer (..),
-    mkTxIxPartial,
-  )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..))
-import Cardano.Ledger.Hashes (EraIndependentTxBody, ScriptHash (..))
-import Cardano.Ledger.Keys
-  ( GenDelegs (..),
-    KeyRole (..),
-    coerceKeyRole,
-  )
-import Cardano.Ledger.Pretty (PrettyA (..), ppList, ppRecord)
-import Cardano.Ledger.Pretty.Babbage ()
-import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
-import Cardano.Ledger.Shelley.API
-  ( Addr (..),
-    Credential (..),
-    LedgerEnv (LedgerEnv),
-    RewardAcnt (..),
-    StakeReference (..),
-    UTxO (..),
-    Wdrl (..),
-  )
+import Cardano.Ledger.Keys (GenDelegs (..))
+import Cardano.Ledger.Pretty (PrettyA (..), ppList)
 import Cardano.Ledger.Shelley.LedgerState
   ( AccountState (..),
     DPState (..),
-    DState (..),
     LedgerState (..),
-    PState (..),
     UTxOState (..),
     rewards,
   )
-import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams' (..))
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
-import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
-import Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..), Delegation (..))
-import Cardano.Ledger.Shelley.UTxO (balance, makeWitnessVKey)
-import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
-import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
 import Cardano.Ledger.Val
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Monad (forM, replicateM)
-import Control.Monad.State.Strict (MonadState (..))
-import Control.Monad.Trans.Class (MonadTrans (lift))
-import Control.Monad.Trans.RWS.Strict (RWST (..), ask)
+import Control.Monad.Trans.RWS.Strict (gets)
 import Control.State.Transition.Extended hiding (Assertion)
-import Data.Bifunctor (first)
-import Data.Coerce
-import qualified Data.Compact.SplitMap as SplitMap
+import Data.Coerce (coerce)
 import Data.Default.Class (Default (def))
 import qualified Data.Foldable as F
-import Data.Functor
-import qualified Data.List as List
-import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes)
-import Data.Maybe.Strict (StrictMaybe (..))
-import Data.Monoid (All (..))
-import Data.Ratio ((%))
-import Data.Set (Set)
-import qualified Data.Set as Set
-import Data.UMap (View (Rewards))
-import qualified Data.UMap as UM
-import Debug.Trace (trace)
-import GHC.Stack
-import Numeric.Natural
-import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
-import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
-import Test.Cardano.Ledger.Generic.Fields hiding (Mint)
-import qualified Test.Cardano.Ledger.Generic.Fields as Generic (TxBodyField (Mint))
-import Test.Cardano.Ledger.Generic.Functions
+import Debug.Trace
+import Test.Cardano.Ledger.Generic.Fields (abstractTx, abstractTxBody, abstractTxOut, abstractWitnesses)
+import Test.Cardano.Ledger.Generic.Functions (isValid')
 import Test.Cardano.Ledger.Generic.GenState
   ( GenEnv (..),
     GenRS,
+    GenSize (startSlot),
     GenState (..),
-    elementsT,
-    emptyGenState,
-    frequencyT,
-    genCredential,
-    genDatumWithHash,
-    genGenEnv,
-    genKeyHash,
-    genPool,
-    genPositiveVal,
-    genRewards,
-    genScript,
+    modifyModel,
+    runGenRS,
   )
-import Test.Cardano.Ledger.Generic.PrettyCore (txSummary, utxoString)
+import Test.Cardano.Ledger.Generic.ModelState
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyC (..), pcLedgerState, pcTx, txSummary)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
-import Test.Cardano.Ledger.Generic.Updaters hiding (first)
-import Test.Cardano.Ledger.Shelley.Generator.Core (genNatural)
+import Test.Cardano.Ledger.Generic.TxGen
+  ( Box (..),
+    applySTSByProof,
+    assembleWits,
+    coreTx,
+    coreTxBody,
+    coreTxOut,
+    genUTxO,
+    genValidatedTx,
+  )
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
-import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
 import Test.QuickCheck
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
--- ===================================================
--- Assembing lists of Fields in to (Core.XX era)
-
--- | This uses merging semantics, it expects duplicate fields, and merges them together
-assembleWits :: Era era => Proof era -> [WitnessesField era] -> Core.Witnesses era
-assembleWits era = List.foldl' (updateWitnesses merge era) (initialWitnesses era)
-
-coreTxOut :: Era era => Proof era -> [TxOutField era] -> Core.TxOut era
-coreTxOut era dts = List.foldl' (updateTxOut era) (initialTxOut era) dts
-
-coreTxBody :: Era era => Proof era -> [TxBodyField era] -> Core.TxBody era
-coreTxBody era dts = List.foldl' (updateTxBody era) (initialTxBody era) dts
-
-overrideTxBody :: Proof era -> Core.TxBody era -> [TxBodyField era] -> Core.TxBody era
-overrideTxBody era old dts = List.foldl' (updateTxBody era) old dts
-
-coreTx :: Proof era -> [TxField era] -> Core.Tx era
-coreTx era dts = List.foldl' (updateTx era) (initialTx era) dts
-
--- ==================================================
--- Era agnostic generators.
-
-lookupByKeyM ::
-  (MonadState s m, Ord k, Show k) => String -> k -> (s -> Map.Map k v) -> m v
-lookupByKeyM name k getMap = do
-  m <- getMap <$> get
-  case Map.lookup k m of
-    Nothing ->
-      error $
-        "Can't find " ++ name ++ " in the test enviroment: " ++ show k
-    Just val -> pure val
-
--- | Generate a list of specified length with randomish `ExUnit`s where the sum
---   of all values produced will not exceed the maxTxExUnits.
-genExUnits :: Proof era -> Int -> GenRS era [ExUnits]
-genExUnits era n = do
-  GenEnv {gePParams} <- ask
-  let ExUnits maxMemUnits maxStepUnits = maxTxExUnits' era gePParams
-  memUnits <- lift $ genSequenceSum maxMemUnits
-  stepUnits <- lift $ genSequenceSum maxStepUnits
-  pure $ zipWith ExUnits memUnits stepUnits
-  where
-    un = fromIntegral n
-    genUpTo maxVal (!totalLeft, !acc) _
-      | totalLeft == 0 = pure (0, 0 : acc)
-      | otherwise = do
-          x <- min totalLeft . round . (% un) <$> genNatural 0 maxVal
-          pure (totalLeft - x, x : acc)
-    genSequenceSum maxVal
-      | maxVal == 0 = pure $ replicate n 0
-      | otherwise = snd <$> F.foldlM (genUpTo maxVal) (maxVal, []) [1 .. n]
-
-lookupScript ::
-  forall era m.
-  MonadState (GenState era) m =>
-  ScriptHash (Crypto era) ->
-  Maybe Tag ->
-  m (Maybe (Core.Script era))
-lookupScript scriptHash mTag = do
-  m <- gsScripts <$> get
-  case Map.lookup scriptHash m of
-    Just script -> pure $ Just script
-    Nothing
-      | Just tag <- mTag ->
-          Just . snd <$> lookupByKeyM "plutusScript" (scriptHash, tag) gsPlutusScripts
-    _ -> pure Nothing
-
--- | Same as `genCredKeyWit`, but for `TxOuts`
-genTxOutKeyWitness ::
-  forall era.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Core.TxOut era ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-genTxOutKeyWitness era mTag txout =
-  case (getTxOutAddr txout) of
-    AddrBootstrap baddr ->
-      error $ "Can't authorize bootstrap address: " ++ show baddr
-    Addr _ payCred _ ->
-      case getTxOutRefScript reify txout of
-        SNothing -> (mkWitVKey era mTag payCred)
-        SJust script -> do
-          f1 <- mkWitVKey era mTag payCred
-          f2 <- genGenericScriptWitness reify (Just Spend) script
-          pure (\safehash -> f1 safehash ++ f2 safehash)
-
-genCredKeyWit ::
-  forall era k.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Credential k (Crypto era) ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-genCredKeyWit era mTag cred = mkWitVKey era mTag cred
-
--- | Same as `genCredTimelockKeyWit`, but for `TxOuts`
-genTxOutTimelockKeyWitness ::
-  forall era.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Core.TxOut era ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> Core.Witnesses era)
-genTxOutTimelockKeyWitness era mTag txout = do
-  case (getTxOutAddr txout) of
-    AddrBootstrap baddr ->
-      error $ "Can't authorize bootstrap address: " ++ show baddr
-    Addr _ payCred _ -> (assembleWits era .) <$> (mkWitVKey era mTag payCred)
-
--- | Generator for witnesses necessary for Scripts and Key
--- credentials. Because of the Key credentials generating function requires a body
--- hash for an acutal witness to be constructed. In order to be able to estimate
--- fees and collateral needed we will use produced witness generators twice: one
--- time with bogus body hash for estimation, and the second time with an actual
--- body hash.
-genCredTimelockKeyWit ::
-  forall era k.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Credential k (Crypto era) ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> Core.Witnesses era)
-genCredTimelockKeyWit era mTag cred =
-  do
-    f <- mkWitVKey era mTag cred
-    pure (assembleWits era . f)
-
--- | Generate a Witnesses producing function. We handle Witnesses come from Keys and Scripts
---   Because scripts vary be Era, we need some Era specific code here: genGenericScriptWitness
-mkWitVKey ::
-  forall era kr.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Credential kr (Crypto era) ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-mkWitVKey _ _mTag (KeyHashObj keyHash) = do
-  keyPair <- lookupByKeyM "credential" (coerceKeyRole keyHash) gsKeys
-  pure $ \bodyHash -> [AddrWits' [makeWitnessVKey bodyHash keyPair]]
-mkWitVKey era mTag (ScriptHashObj scriptHash) =
-  lookupScript @era scriptHash mTag >>= \case
-    Nothing ->
-      error $ "Impossible: Cannot find script with hash " ++ show scriptHash
-    Just script -> do
-      let scriptWit = [ScriptWits' [script]]
-      otherWit <- genGenericScriptWitness era mTag script
-      pure (\hash -> (scriptWit ++ otherWit hash))
-
-genGenericScriptWitness ::
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Core.Script era ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-genGenericScriptWitness (Shelley c) mTag timelock = mkMultiSigWit (Shelley c) mTag timelock
-genGenericScriptWitness (Allegra c) mTag timelock = mkTimelockWit (Allegra c) mTag timelock
-genGenericScriptWitness (Mary c) mTag timelock = mkTimelockWit (Mary c) mTag timelock
-genGenericScriptWitness (Alonzo c) mTag (TimelockScript timelock) = mkTimelockWit (Alonzo c) mTag timelock
-genGenericScriptWitness (Alonzo _) _ (PlutusScript _ _) = pure (const [])
-genGenericScriptWitness (Babbage c) mTag (TimelockScript timelock) = mkTimelockWit (Babbage c) mTag timelock
-genGenericScriptWitness (Babbage _) _ (PlutusScript _ _) = pure (const [])
-
--- | Used in Aonzo and Babbage and Mary Eras
-mkTimelockWit ::
-  forall era.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Timelock (Crypto era) ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-mkTimelockWit era mTag =
-  \case
-    RequireSignature keyHash -> mkWitVKey era mTag (KeyHashObj keyHash)
-    RequireAllOf timelocks -> F.fold <$> mapM (mkTimelockWit era mTag) timelocks
-    RequireAnyOf timelocks
-      | F.null timelocks -> pure (const [])
-      | otherwise -> mkTimelockWit era mTag =<< lift (elements (F.toList timelocks))
-    RequireMOf m timelocks -> do
-      ts <- take m <$> lift (shuffle (F.toList timelocks))
-      F.fold <$> mapM (mkTimelockWit era mTag) ts
-    RequireTimeStart _ -> pure (const [])
-    RequireTimeExpire _ -> pure (const [])
-
--- | Used in Shelley Eras
-mkMultiSigWit ::
-  forall era.
-  (Reflect era) =>
-  Proof era ->
-  Maybe Tag ->
-  Shelley.MultiSig (Crypto era) ->
-  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
-mkMultiSigWit era mTag (Shelley.RequireSignature keyHash) = mkWitVKey era mTag (KeyHashObj keyHash)
-mkMultiSigWit era mTag (Shelley.RequireAllOf timelocks) = F.fold <$> mapM (mkMultiSigWit era mTag) timelocks
-mkMultiSigWit era mTag (Shelley.RequireAnyOf timelocks)
-  | F.null timelocks = pure (const [])
-  | otherwise = mkMultiSigWit era mTag =<< lift (elements (F.toList timelocks))
-mkMultiSigWit era mTag (Shelley.RequireMOf m timelocks) = do
-  ts <- take m <$> lift (shuffle (F.toList timelocks))
-  F.fold <$> mapM (mkMultiSigWit era mTag) ts
-
-makeDatumWitness :: Proof era -> Core.TxOut era -> GenRS era [WitnessesField era]
-makeDatumWitness proof txout = case (proof, txout) of -- (TxOut _ _ mDatum) = mkDatumWit mDatum
-  (Babbage _, Babbage.TxOut _ _ (Babbage.DatumHash h) _) -> mkDatumWit (SJust h)
-  (Babbage _, Babbage.TxOut _ _ (Babbage.Datum _) _) -> pure []
-  (Babbage _, Babbage.TxOut _ _ Babbage.NoDatum _) -> pure []
-  (Alonzo _, TxOut _ _ mDatum) -> mkDatumWit mDatum
-  _ -> pure [] -- No other era has data witnesses
-  where
-    mkDatumWit SNothing = pure []
-    mkDatumWit (SJust datumHash) = do
-      datum <- lookupByKeyM "datum" datumHash gsDatums
-      pure [DataWits' [datum]]
-
-lookupPlutusScript ::
-  (MonadState (GenState era) m) =>
-  Credential k (Crypto era) ->
-  Tag ->
-  m (Maybe (IsValid, ScriptHash (Crypto era)))
-lookupPlutusScript (KeyHashObj _) _ = pure Nothing
-lookupPlutusScript (ScriptHashObj scriptHash) tag =
-  fmap (Map.lookup (scriptHash, tag) . gsPlutusScripts) get <&> \case
-    Nothing -> Nothing
-    Just (isValid, _) -> Just (isValid, scriptHash)
-
--- | Make RdmrWits WitnessesField only if the Credential is for a Plutus Script
---  And it is in the spending inputs, not the reference inputs
-redeemerWitnessMaker ::
-  Era era =>
-  Tag ->
-  [Maybe (GenRS era (Data era), Credential k (Crypto era))] ->
-  GenRS era (IsValid, [ExUnits -> [WitnessesField era]])
-redeemerWitnessMaker tag listWithCred =
-  let creds =
-        [ (ix, genDat, cred)
-          | (ix, mCred) <- zip [0 ..] listWithCred,
-            Just (genDat, cred) <- [mCred]
-        ]
-      allValid = IsValid . getAll . foldMap (\(IsValid v) -> All v)
-   in fmap (first allValid . unzip . catMaybes) $
-        forM creds $ \(ix, genDat, cred) ->
-          lookupPlutusScript cred tag >>= \case
-            Nothing -> pure Nothing
-            Just (isValid, _) -> do
-              datum <- genDat
-              let rPtr = RdmrPtr tag ix
-                  mkWit3 exUnits = [RdmrWits (Redeemers $ Map.singleton rPtr (datum, exUnits))]
-              -- we should not add this if the tx turns out to be in the reference inputs.
-              -- we accomplish this by not calling this function on referenceInputs
-              pure $ Just (isValid, mkWit3)
-
--- | Collaterals can't have scripts, this is where this generator is needed.
-genNoScriptRecipient :: Reflect era => GenRS era (Addr (Crypto era))
-genNoScriptRecipient = do
-  paymentCred <- KeyHashObj <$> genKeyHash
-  stakeCred <- StakeRefBase . KeyHashObj <$> genKeyHash
-  pure (Addr Testnet paymentCred stakeCred)
-
-genRecipient :: Reflect era => GenRS era (Addr (Crypto era))
-genRecipient = do
-  paymentCred <- genCredential Spend
-  stakeCred <- genCredential Cert
-  pure (Addr Testnet paymentCred (StakeRefBase stakeCred))
-
-genDatum :: Era era => GenRS era (Data era)
-genDatum = snd <$> genDatumWithHash
-
--- | Generate a Babbage Datum witness to use as a redeemer for a Plutus Script.
---   Witnesses can be a ScriptHash, or an inline Datum
-genBabbageDatum :: forall era. Era era => GenRS era (Babbage.Datum era)
-genBabbageDatum =
-  frequencyT
-    [ (1, (Babbage.DatumHash . fst) <$> genDatumWithHash),
-      (4, (Babbage.Datum . dataToBinaryData . snd) <$> genDatumWithHash)
-    ]
-
-genRefScript :: Reflect era => Proof era -> GenRS era (StrictMaybe (Core.Script era))
-genRefScript proof = do
-  scripthash <- genScript proof Spend
-  mscript <- lookupScript scripthash (Just Spend)
-  case mscript of
-    Nothing -> pure SNothing
-    Just script -> pure (SJust script)
-
-genTxOut :: Reflect era => Proof era -> Core.Value era -> GenRS era [TxOutField era]
-genTxOut proof val = do
-  addr <- genRecipient
-  cred <- maybe (error "BootstrapAddress encountered") pure $ paymentCredAddr addr
-  dataHashFields <-
-    case cred of
-      KeyHashObj _ -> pure []
-      ScriptHashObj scriptHash -> do
-        maybecorescript <- lookupScript scriptHash (Just Spend)
-        case (proof, maybecorescript) of
-          (Babbage _, Just (PlutusScript _ _)) -> do
-            datum <- genBabbageDatum
-            script <- genRefScript proof
-            pure $ [Datum datum] ++ [RefScript script]
-          (Alonzo _, Just (PlutusScript _ _)) -> do
-            (datahash, _data) <- genDatumWithHash
-            pure [DHash (SJust datahash)]
-          (_, _) -> pure []
-  pure $ [Address addr, Amount val] ++ dataHashFields
-
-genUTxO :: Reflect era => GenRS era (UTxO era)
-genUTxO = do
-  NonEmpty ins <- lift $ resize 20 arbitrary
-  UTxO <$> sequence (SplitMap.fromSet (const genOut) (Set.fromList ins))
-  where
-    genOut = do
-      val <- lift genPositiveVal
-      fields <- genTxOut reify val
-      pure (coreTxOut reify fields)
-
-genDCert :: Reflect era => GenRS era (DCert (Crypto era))
-genDCert =
-  elementsT
-    [ DCertDeleg
-        <$> elementsT
-          [ RegKey <$> genCredential Cert,
-            DeRegKey <$> genCredential Cert,
-            Delegate <$> genDelegation
-          ]
-    ]
-  where
-    genDelegation = do
-      rewardAccount <- genCredential Cert
-      poolId <- genPool
-      pure $ Delegation {_delegator = rewardAccount, _delegatee = poolId}
-
-genDCerts :: Reflect era => GenRS era [DCert (Crypto era)]
-genDCerts = do
-  let genUniqueScript (!dcs, !ss, !regCreds) _ = do
-        dc <- genDCert
-        -- Workaround a misfeature where duplicate plutus scripts in DCert are ignored
-        let insertIfNotPresent dcs' regCreds' mKey mScriptHash
-              | Just (_, scriptHash) <- mScriptHash =
-                  if (scriptHash, mKey) `Set.member` ss
-                    then (dcs, ss, regCreds)
-                    else (dc : dcs', Set.insert (scriptHash, mKey) ss, regCreds')
-              | otherwise = (dc : dcs', ss, regCreds')
-        -- Generate registration and de-registration delegation certificates,
-        -- while ensuring the proper registered/unregestered state in DState
-        case dc of
-          DCertDeleg d
-            | RegKey regCred <- d ->
-                if regCred `Set.member` regCreds
-                  then pure (dcs, ss, regCreds)
-                  else pure (dc : dcs, ss, Set.insert regCred regCreds)
-            | DeRegKey deregCred <- d ->
-                if deregCred `Set.member` regCreds
-                  then
-                    insertIfNotPresent dcs (Set.delete deregCred regCreds) Nothing
-                      <$> lookupPlutusScript deregCred Cert
-                  else pure (dcs, ss, regCreds)
-            | Delegate (Delegation delegCred delegKey) <- d ->
-                let (dcs', regCreds')
-                      | delegCred `Set.member` regCreds = (dcs, regCreds)
-                      | otherwise =
-                          (DCertDeleg (RegKey delegCred) : dcs, Set.insert delegCred regCreds)
-                 in insertIfNotPresent dcs' regCreds' (Just delegKey)
-                      <$> lookupPlutusScript delegCred Cert
-          _ -> pure (dc : dcs, ss, regCreds)
-  NonNegative n <- lift arbitrary
-  DPState {dpsDState = DState {_unified}} <- gsDPState <$> get
-  let initSets = ([], Set.empty, UM.domain (Rewards _unified))
-  (dcs, _, _) <- F.foldlM genUniqueScript initSets [1 :: Int .. n]
-  pure $ reverse dcs
-
-genCollateralUTxO ::
-  forall era.
-  (HasCallStack, Reflect era) =>
-  [Addr (Crypto era)] ->
-  Coin ->
-  UTxO era ->
-  GenRS era (UTxO era, Map.Map (TxIn (Crypto era)) (Core.TxOut era))
-genCollateralUTxO collateralAddresses (Coin fee) (UTxO utxo) = do
-  GenEnv {gePParams} <- ask
-  let collPerc = collateralPercentage' reify gePParams
-      minCollTotal = Coin (ceiling ((fee * toInteger collPerc) % 100))
-      -- Generate a collateral that is neither in UTxO map nor has already been generated
-      genNewCollateral addr coll um c = do
-        -- The size of the Gen computation is driven down when we generate scripts, so it can be 0 here
-        -- that is really bad, because if the happens we get the same TxIn every time, and 'coll' never grows,
-        -- so this function doesn't terminate. We want many choices of TxIn, so resize just this arbitrary by 10.
-        txIn <- lift (resize 20 (arbitrary :: Gen (TxIn (Crypto era))))
-        if SplitMap.member txIn utxo || Map.member txIn coll
-          then genNewCollateral addr coll um c
-          else pure (um, Map.insert txIn (coreTxOut reify [Address addr, Amount (inject c)]) coll, c)
-      -- Either pick a collateral from a map or generate a completely new one
-      genCollateral addr coll um
-        | Map.null um = genNewCollateral addr coll um =<< lift genPositiveVal
-        | otherwise = do
-            i <- lift $ chooseInt (0, Map.size um - 1)
-            let (txIn, txOut) = Map.elemAt i um
-                val = getTxOutVal reify txOut
-            pure (Map.deleteAt i um, Map.insert txIn txOut coll, coin val)
-      -- Recursively either pick existing key spend only outputs or generate new ones that
-      -- will be later added to the UTxO map
-      go ::
-        [Addr (Crypto era)] ->
-        Map (TxIn (Crypto era)) (Core.TxOut era) ->
-        Coin ->
-        Map (TxIn (Crypto era)) (Core.TxOut era) ->
-        GenRS era (Map (TxIn (Crypto era)) (Core.TxOut era))
-      go ecs !coll !curCollTotal !um
-        | curCollTotal >= minCollTotal = pure coll
-        | [] <- ecs = error "Impossible: supplied less addresses then `maxCollateralInputs`"
-        | ec : ecs' <- ecs = do
-            (um', coll', c) <-
-              if null ecs'
-                then genNewCollateral ec coll um (minCollTotal <-> curCollTotal)
-                else elementsT [genCollateral ec coll Map.empty, genCollateral ec coll um]
-            go ecs' coll' (curCollTotal <+> c) um'
-  collaterals <-
-    go collateralAddresses Map.empty (Coin 0) $
-      SplitMap.toMap $ SplitMap.filter spendOnly utxo
-  pure (UTxO (Map.foldrWithKey' SplitMap.insert utxo collaterals), collaterals)
-
-spendOnly :: Era era => Core.TxOut era -> Bool
-spendOnly txout = case getTxOutAddr txout of
-  (Addr _ (ScriptHashObj _) _) -> False
-  (Addr _ _ (StakeRefBase (ScriptHashObj _))) -> False
-  _ -> True
-
-genUTxOState :: forall era. Reflect era => UTxO era -> GenRS era (UTxOState era)
-genUTxOState utxo = do
-  GenEnv {gePParams} <- ask
-  DPState {dpsDState, dpsPState} <- gsDPState <$> get
-  let deposited = obligation' reify gePParams (rewards dpsDState) (_pParams dpsPState)
-  lift (UTxOState utxo deposited <$> arbitrary <*> pure (emptyPPUPstate @era reify) <*> pure def)
-
-genRecipientsFrom :: Reflect era => [Core.TxOut era] -> GenRS era [Core.TxOut era]
-genRecipientsFrom txOuts = do
-  let outCount = length txOuts
-  approxCount <- lift $ choose (1, outCount)
-  let extra = outCount - approxCount
-      avgExtra = ceiling (toInteger extra % toInteger approxCount)
-      genExtra e
-        | e <= 0 || avgExtra == 0 = pure 0
-        | otherwise = lift $ chooseInt (0, avgExtra)
-  let goNew _ [] !rs = pure rs
-      goNew e (tx : txs) !rs = do
-        leftToAdd <- genExtra e
-        goExtra (e - leftToAdd) leftToAdd (inject (Coin 0)) tx txs rs
-      goExtra _ _ s tx [] !rs = genWithChange s tx rs
-      goExtra e 0 s tx txs !rs = goNew e txs =<< genWithChange s tx rs
-      goExtra e n s txout (tx : txs) !rs = goExtra e (n - 1) (s <+> v) tx txs rs
-        where
-          v = getTxOutVal reify txout
-      genWithChange s txout rs = do
-        let (!addr, !v, !ds) = txoutFields reify txout
-        c <- Coin <$> lift (choose (1, unCoin $ coin v))
-        fields <- genTxOut reify (s <+> inject c)
-        if c < coin v
-          then
-            let !change = coreTxOut reify ([Address addr, Amount (v <-> inject c)] ++ ds)
-             in pure (coreTxOut reify fields : change : rs)
-          else pure (coreTxOut reify fields : rs)
-  goNew extra txOuts []
-
-getDCertCredential :: DCert crypto -> Maybe (Credential 'Staking crypto)
-getDCertCredential = \case
-  DCertDeleg d ->
-    case d of
-      RegKey _rk -> Nothing -- we don't require witnesses for RegKey
-      DeRegKey drk -> Just drk
-      Delegate (Delegation dk _) -> Just dk
-  DCertPool _p -> Nothing
-  DCertGenesis _g -> Nothing
-  DCertMir _m -> Nothing
-
-genWithdrawals :: Reflect era => GenRS era (Wdrl (Crypto era))
-genWithdrawals = do
-  let networkId = Testnet
-  newrewards <- genRewards
-  pure $ Wdrl $ Map.fromList $ map (first (RewardAcnt networkId)) $ Map.toList newrewards
-
-languagesUsed ::
-  forall era.
-  Era era =>
-  Proof era ->
-  Core.Tx era ->
-  UTxO era ->
-  Map (ScriptHash (Crypto era), Tag) (IsValid, Core.Script era) ->
-  Set Language
-languagesUsed proof tx utxo _plutusScripts = case proof of
-  (Shelley _) -> Set.empty
-  (Allegra _) -> Set.empty
-  (Mary _) -> Set.empty
-  (Alonzo _) -> Cardano.Ledger.Alonzo.TxInfo.languages tx utxo
-  (Babbage _) -> Cardano.Ledger.Alonzo.TxInfo.languages tx utxo
-
-timeToLive :: ValidityInterval -> SlotNo
-timeToLive (ValidityInterval _ (SJust n)) = n
-timeToLive (ValidityInterval _ SNothing) = SlotNo maxBound
-
-genValidatedTx :: forall era. Reflect era => Proof era -> GenRS era (UTxO era, Core.Tx era)
-genValidatedTx proof = do
-  GenEnv {geValidityInterval, gePParams} <- ask
-  UTxO utxoNoCollateral <- genUTxO
-  -- 1. Produce utxos that will be spent
-  numInputs <- lift $ choose (1, length utxoNoCollateral)
-  toSpendNoCollateral <-
-    Map.fromList . take numInputs <$> lift (shuffle $ SplitMap.toList utxoNoCollateral)
-
-  -- 2. Produce some that will not be spent but only referred to (Note this may overlap with the spending)
-  numRefInputs <- lift $ choose (0, maxRefInputs proof)
-  refInputsUtxo <-
-    Map.fromList . take numRefInputs <$> lift (shuffle $ SplitMap.toList utxoNoCollateral)
-
-  -- 3. Check if all Plutus scripts are valid
-  let toSpendNoCollateralTxOuts :: [Core.TxOut era]
-      toSpendNoCollateralTxOuts = Map.elems toSpendNoCollateral
-      -- We use maxBound to ensure the serialized size overestimation
-      maxCoin = Coin (toInteger (maxBound :: Int))
-  -- 4. Generate all recipients and witnesses needed for spending Plutus scripts
-  recipients <- genRecipientsFrom toSpendNoCollateralTxOuts
-
-  --  mkPaymentWits :: ExUnits -> [WitnessesField era]
-  (IsValid v1, mkPaymentWits) <-
-    redeemerWitnessMaker
-      Spend
-      [ (\dh cred -> (lookupByKeyM "datum" dh gsDatums, cred))
-          <$> mDatumHash
-          <*> (Just credential)
-        | (_, coretxout) <- Map.toAscList toSpendNoCollateral,
-          let (credentials, mDatumHash) = txoutEvidence proof coretxout,
-          credential <- credentials
-      ]
-
-  wdrls@(Wdrl wdrlMap) <- genWithdrawals
-  rewardsWithdrawalTxOut <- coreTxOut proof <$> (genTxOut proof $ inject $ F.fold wdrlMap)
-  let wdrlCreds = map (getRwdCred . fst) $ Map.toAscList wdrlMap
-  (IsValid v2, mkWdrlWits) <-
-    redeemerWitnessMaker Rewrd $ map (Just . (,) genDatum) wdrlCreds
-  dcerts <- genDCerts
-  let dcertCreds = map getDCertCredential dcerts
-  (IsValid v3, mkCertsWits) <-
-    redeemerWitnessMaker Cert $ map ((,) genDatum <$>) dcertCreds
-
-  let isValid = IsValid (v1 && v2 && v3)
-      mkWits :: [ExUnits -> [WitnessesField era]]
-      mkWits = mkPaymentWits ++ mkCertsWits ++ mkWdrlWits
-  exUnits <- genExUnits proof (length mkWits)
-
-  let redeemerWitsList :: [WitnessesField era]
-      redeemerWitsList = concat (zipWith ($) mkWits exUnits)
-  datumWitsList <- concat <$> mapM (makeDatumWitness proof) (Map.elems toSpendNoCollateral)
-  keyWitsMakers <- mapM (genTxOutKeyWitness proof (Just Spend)) (toSpendNoCollateralTxOuts ++ Map.elems refInputsUtxo)
-  dcertWitsMakers <- mapM (genCredKeyWit proof (Just Cert)) $ catMaybes dcertCreds
-  rwdrsWitsMakers <- mapM (genCredKeyWit proof (Just Rewrd)) wdrlCreds
-
-  -- 5. Estimate inputs that will be used as collateral
-  maxCollateralCount <-
-    lift $ chooseInt (1, fromIntegral (maxCollateralInputs' proof gePParams))
-  bogusCollateralTxId <- lift (arbitrary :: Gen (TxId (Crypto era)))
-  let bogusCollateralTxIns =
-        Set.fromList
-          [ TxIn bogusCollateralTxId (mkTxIxPartial (fromIntegral i))
-            | i <- [1 .. 10 :: Int] -- [maxBound, maxBound - 1 .. maxBound - maxCollateralCount - 1]
-          ]
-  collateralAddresses <- replicateM maxCollateralCount genNoScriptRecipient
-  bogusCollateralKeyWitsMakers <-
-    mapM (\a -> genTxOutKeyWitness proof Nothing (coreTxOut proof [Address a, Amount (inject maxCoin)])) collateralAddresses
-  networkId <- lift $ elements [SNothing, SJust Testnet]
-
-  -- 6. Estimate the fee
-  let redeemerDatumWits = (redeemerWitsList ++ datumWitsList)
-      bogusIntegrityHash = hashScriptIntegrity' proof gePParams mempty (Redeemers mempty) mempty
-      txBodyNoFee =
-        coreTxBody
-          proof
-          [ Inputs (Map.keysSet toSpendNoCollateral),
-            Collateral bogusCollateralTxIns,
-            RefInputs (Map.keysSet refInputsUtxo),
-            Outputs' (rewardsWithdrawalTxOut : recipients),
-            Certs' dcerts,
-            Wdrls wdrls,
-            Txfee maxCoin,
-            if (Some proof) >= (Some (Allegra Mock))
-              then (Vldt geValidityInterval)
-              else (TTL (timeToLive geValidityInterval)),
-            Update' [],
-            ReqSignerHashes' [],
-            Generic.Mint mempty,
-            WppHash bogusIntegrityHash,
-            AdHash' [],
-            Txnetworkid networkId
-          ]
-      txBodyNoFeeHash = hashAnnotated txBodyNoFee
-      witsMakers :: [SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era]]
-      witsMakers = keyWitsMakers ++ dcertWitsMakers ++ rwdrsWitsMakers
-      noFeeWits :: [WitnessesField era]
-      noFeeWits =
-        redeemerDatumWits
-          <> foldMap ($ txBodyNoFeeHash) (witsMakers ++ bogusCollateralKeyWitsMakers)
-      bogusTxForFeeCalc =
-        coreTx
-          proof
-          [ Body txBodyNoFee,
-            Witnesses (assembleWits proof noFeeWits),
-            Valid isValid,
-            AuxData' []
-          ]
-      -- refAdjustment = txInBalance (Map.keysSet refInputsUtxo) (UTxO (SplitMap.fromMap refInputsUtxo))
-      fee = minfee' proof gePParams bogusTxForFeeCalc
-
-  -- 7. Crank up the amount in one of outputs to account for the fee. Note this is
-  -- a hack that is not possible in a real life, but in the end it does produce
-  -- real life like setup
-  feeKey <- lift $ elements $ Map.keys toSpendNoCollateral
-  let utxoFeeAdjusted =
-        UTxO $ case SplitMap.lookup feeKey utxoNoCollateral of
-          Nothing -> utxoNoCollateral -- It is aways there because spend is a subset, s just need the txOut
-          Just txOut -> SplitMap.insert feeKey (injectFee proof fee txOut) utxoNoCollateral
-
-  -- 8. Generate utxos that will be used as collateral
-  (utxo, collMap) <- genCollateralUTxO collateralAddresses fee utxoFeeAdjusted
-  collateralKeyWitsMakers <-
-    mapM (genTxOutKeyWitness proof Nothing) $ Map.elems collMap
-
-  -- 9. Construct the correct Tx with valid fee and collaterals
-  allPlutusScripts <- gsPlutusScripts <$> get
-  let mIntegrityHash =
-        hashScriptIntegrity'
-          proof
-          gePParams
-          (languagesUsed proof bogusTxForFeeCalc (UTxO utxoNoCollateral) allPlutusScripts)
-          (mkTxrdmrs redeemerDatumWits)
-          (mkTxdats redeemerDatumWits)
-      txBody =
-        overrideTxBody
-          proof
-          txBodyNoFee
-          [ Txfee fee,
-            Collateral (Map.keysSet collMap),
-            TotalCol (SJust $ txInBalance (Map.keysSet collMap) utxo),
-            WppHash mIntegrityHash
-          ]
-      txBodyHash = hashAnnotated txBody
-      wits =
-        redeemerDatumWits
-          <> foldMap ($ txBodyHash) (witsMakers ++ collateralKeyWitsMakers)
-      validTx =
-        coreTx
-          proof
-          [ Body txBody,
-            Witnesses (assembleWits proof wits),
-            Valid isValid,
-            AuxData' []
-          ]
-  pure (utxo, validTx)
-
--- | Scan though the fields unioning all the RdrmWits fields into one Redeemer map
-mkTxrdmrs :: forall era. Era era => [WitnessesField era] -> Redeemers era
-mkTxrdmrs fields = Redeemers (List.foldl' accum Map.empty fields)
-  where
-    accum m1 (RdmrWits (Redeemers m2)) = Map.union m1 m2
-    accum m1 _ = m1
-
--- | Scan though the fields unioning all the DataWits fields into one TxDat
-mkTxdats :: forall era. Era era => [WitnessesField era] -> TxDats era
-mkTxdats fields = TxDats (List.foldl' accum Map.empty fields)
-  where
-    accum m (DataWits' ds) = (List.foldl' accum2 m ds)
-      where
-        accum2 m2 d = Map.insert (hashData @era d) d m2
-    accum m _ = m
-
--- =======================================================
--- An encapsulation of the Top level types we generate,
--- but that has its own Show instance that we can control.
-
-data Box era = Box (Proof era) (TRC (Core.EraRule "LEDGER" era)) (GenState era)
-
-instance
-  ( Era era,
-    PrettyA (State (Core.EraRule "LEDGER" era)),
-    PrettyA (Core.Script era),
-    PrettyA (Signal (Core.EraRule "LEDGER" era)),
-    Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era
-  ) =>
-  Show (Box era)
-  where
-  show (Box _proof (TRC (_env, _state, _sig)) _gs) =
-    show $
-      ppRecord
-        "Box"
-        []
-
--- Sample things we might use in the Box
--- ("Tx", txSummary proof _sig)
--- ("Tx", prettyA _sig)
--- ("TRC state",prettyA _state)
--- ("GenEnv",ppGenState proof _gs)
-
 -- =====================================
--- Now the Top level generators
+-- Top level generators of TRC
 
-genTxAndUTXOState :: Reflect era => Proof era -> Gen (TRC (Core.EraRule "UTXOW" era), GenState era)
-genTxAndUTXOState proof@(Babbage _) = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof
+genTxAndUTXOState :: Reflect era => Proof era -> GenSize -> Gen (TRC (Core.EraRule "UTXOW" era), GenState era)
+genTxAndUTXOState proof@(Babbage _) gsize = do
+  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp mempty (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Alonzo _) = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof
+genTxAndUTXOState proof@(Alonzo _) gsize = do
+  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp mempty (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Mary _) = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof
+genTxAndUTXOState proof@(Mary _) gsize = do
+  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp mempty (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Allegra _) = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof
+genTxAndUTXOState proof@(Allegra _) gsize = do
+  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp mempty (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Shelley _) = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof
+genTxAndUTXOState proof@(Shelley _) gsize = do
+  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp mempty (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
 
 genTxAndLEDGERState ::
+  forall era.
   ( Reflect era,
     Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
     State (Core.EraRule "LEDGER" era) ~ LedgerState era,
     Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era
   ) =>
   Proof era ->
+  GenSize ->
   Gen (Box era)
-genTxAndLEDGERState proof = do
+genTxAndLEDGERState proof sizes = do
+  let slotNo = SlotNo (startSlot sizes)
   txIx <- arbitrary
-  maxTxExUnits <- (arbitrary :: Gen ExUnits)
-  maxCollateralInputs <- elements [1 .. 7 :: Natural]
-  collateralPercentage <- (fromIntegral <$> chooseInt (1, 10000)) :: Gen Natural
-  minfeeA <- fromIntegral <$> chooseInt (0, 1000)
-  minfeeB <- fromIntegral <$> chooseInt (0, 10000)
-  -- (env,pp) <- setup proof -- Generate a PParams and a GenEnv
   let genT = do
-        (utxo, tx) <- genValidatedTx proof
-        utxoState <- genUTxOState utxo
-        dpState <- gsDPState <$> get
-        pure $ TRC (ledgerEnv, LedgerState utxoState dpState, tx)
-      pp =
-        newPParams
-          proof
-          [ MinfeeA minfeeA,
-            MinfeeB minfeeB,
-            defaultCostModels proof,
-            MaxValSize 1000,
-            MaxTxSize $ fromIntegral (maxBound :: Int),
-            MaxTxExUnits maxTxExUnits,
-            MaxCollateralInputs maxCollateralInputs,
-            CollateralPercentage collateralPercentage,
-            ProtocolVersion $ ProtVer 7 0
-          ]
-      slotNo = SlotNo 100000000
-      ledgerEnv = LedgerEnv slotNo txIx pp (AccountState (Coin 0) (Coin 0))
-  minSlotNo <- oneof [pure SNothing, SJust <$> choose (minBound, unSlotNo slotNo)]
-  maxSlotNo <- oneof [pure SNothing, SJust <$> choose (unSlotNo slotNo + 1, maxBound)]
-  let env =
-        GenEnv
-          { geValidityInterval = ValidityInterval (SlotNo <$> minSlotNo) (SlotNo <$> maxSlotNo),
-            gePParams = pp
-          }
-  (trc, s, _) <- runRWST genT env emptyGenState
-  pure (Box proof trc s)
-
--- ==============================================================================
--- How we take the generated stuff and put it through the STS rule mechanism
--- in a way that is Era Agnostic
-
-applySTSByProof ::
-  forall era.
-  (GoodCrypto (Crypto era)) =>
-  Proof era ->
-  RuleContext 'Transition (Core.EraRule "LEDGER" era) ->
-  (Either [PredicateFailure (Core.EraRule "LEDGER" era)] (State (Core.EraRule "LEDGER" era)))
-applySTSByProof (Babbage _) _trc = runShelleyBase $ applySTS @(Core.EraRule "LEDGER" (BabbageEra (Crypto era))) _trc
-applySTSByProof (Alonzo _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Mary _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Allegra _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Shelley _) trc = runShelleyBase $ applySTS trc
+        (initial, _) <- genUTxO -- Generate a random UTxO, so mUTxO is not empty
+        modifyModel (\m -> m {mUTxO = initial})
+        (_utxo, tx) <- genValidatedTx proof
+        model <- gets gsModel
+        pp <- gets (gePParams . gsGenEnv)
+        let ledgerState = extract @(LedgerState era) model
+            ledgerEnv = LedgerEnv slotNo txIx pp (AccountState (Coin 0) (Coin 0))
+        pure $ TRC (ledgerEnv, ledgerState, tx)
+  (trc, genstate) <- runGenRS proof def genT
+  pure (Box proof trc genstate)
 
 -- =============================================
 -- Now a test
@@ -924,13 +128,12 @@ testTxValidForLEDGER ::
   ( Reflect era,
     Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
     State (Core.EraRule "LEDGER" era) ~ LedgerState era,
-    PrettyA (PredicateFailure (Core.EraRule "LEDGER" era)),
-    PrettyA (Signal (Core.EraRule "LEDGER" era))
+    PrettyA (PredicateFailure (Core.EraRule "LEDGER" era))
   ) =>
   Proof era ->
   Box era ->
   Property
-testTxValidForLEDGER proof (Box _ (trc@(TRC (_, ledgerState, vtx))) _) =
+testTxValidForLEDGER proof (Box _ (trc@(TRC (_, ledgerState, vtx))) _genstate) =
   ( if False
       then trace (show (txSummary proof vtx))
       else id
@@ -942,33 +145,12 @@ testTxValidForLEDGER proof (Box _ (trc@(TRC (_, ledgerState, vtx))) _) =
           totalAda ledgerState' === totalAda ledgerState
       Left errs ->
         counterexample
-          ( utxoString proof (_utxo (lsUTxOState ledgerState)) ++ "\n\n"
-              ++ show (prettyA vtx)
+          ( show (pcLedgerState proof ledgerState) ++ "\n\n"
+              ++ show (pcTx proof vtx)
               ++ "\n\n"
               ++ show (ppList prettyA errs)
-              ++ "\n\n"
-              ++ show (txSummary proof vtx)
           )
           (property False)
-
--- ===============================================================
--- Tools for generating other things from a GenEnv. This way one can
--- test individual functions in this file.
-
--- | Construct a random (Gen b)
-makeGen :: Proof era -> (Proof era -> GenRS era b) -> Gen b
-makeGen proof computeWith = do
-  env <- genGenEnv proof
-  (ans, _state, _written) <- runRWST (computeWith proof) env emptyGenState
-  pure ans
-
-runTest :: PrettyA a => (Proof era -> GenRS era a) -> Proof era -> IO ()
-runTest computeWith proof = do
-  ans <- generate (makeGen proof computeWith)
-  putStrLn (show (prettyA ans))
-
-main2 :: IO ()
-main2 = runTest (\x -> fst <$> genValidatedTx x) (Alonzo Mock)
 
 -- =============================================
 -- Make some property tests
@@ -998,7 +180,7 @@ coreTypesRoundTrip =
     "Core types make generic roundtrips"
     [ testGroup
         "Witnesses roundtrip"
-        [ testProperty "Babbage era" $ txWitRoundTrip (Babbage Mock), -- No Arbitrary instance yet
+        [ testProperty "Babbage era" $ txWitRoundTrip (Babbage Mock),
           testProperty "Alonzo era" $ txWitRoundTrip (Alonzo Mock),
           testProperty "Mary era" $ txWitRoundTrip (Mary Mock),
           testProperty "Allegra era" $ txWitRoundTrip (Allegra Mock),
@@ -1006,7 +188,7 @@ coreTypesRoundTrip =
         ],
       testGroup
         "TxBody roundtrips"
-        [ testProperty "Babbage era" $ txBodyRoundTrip (Babbage Mock), -- No Arbitrary instance yet
+        [ testProperty "Babbage era" $ txBodyRoundTrip (Babbage Mock),
           testProperty "Alonzo era" $ txBodyRoundTrip (Alonzo Mock),
           testProperty "Mary era" $ txBodyRoundTrip (Mary Mock),
           testProperty "Allegra era" $ txBodyRoundTrip (Allegra Mock),
@@ -1014,7 +196,7 @@ coreTypesRoundTrip =
         ],
       testGroup
         "TxOut roundtrips"
-        [ testProperty "Babbage era" $ txOutRoundTrip (Babbage Mock), -- No Arbitrary instance yet
+        [ testProperty "Babbage era" $ txOutRoundTrip (Babbage Mock),
           testProperty "Alonzo era" $ txOutRoundTrip (Alonzo Mock),
           testProperty "Mary era" $ txOutRoundTrip (Mary Mock),
           testProperty "Allegra era" $ txOutRoundTrip (Allegra Mock),
@@ -1022,7 +204,7 @@ coreTypesRoundTrip =
         ],
       testGroup
         "Tx roundtrips"
-        [ testProperty "Babbage era" $ txRoundTrip (Babbage Mock), -- No Arbitrary instance yet
+        [ testProperty "Babbage era" $ txRoundTrip (Babbage Mock),
           testProperty "Alonzo era" $ txRoundTrip (Alonzo Mock),
           testProperty "Mary era" $ txRoundTrip (Mary Mock),
           testProperty "Allegra era" $ txRoundTrip (Allegra Mock),
@@ -1038,15 +220,22 @@ genericProperties =
       testGroup
         "Alonzo UTXOW property tests"
         [ testProperty "Shelley Tx preserves ADA" $
-            forAll (genTxAndLEDGERState (Shelley Mock)) (testTxValidForLEDGER (Shelley Mock)),
+            forAll (genTxAndLEDGERState (Shelley Mock) def) (testTxValidForLEDGER (Shelley Mock)),
+          testProperty "Allegra Tx preserves ADA" $
+            forAll (genTxAndLEDGERState (Allegra Mock) def) (testTxValidForLEDGER (Allegra Mock)),
           testProperty "Mary Tx preserves ADA" $
-            forAll (genTxAndLEDGERState (Mary Mock)) (testTxValidForLEDGER (Mary Mock)),
+            forAll (genTxAndLEDGERState (Mary Mock) def) (testTxValidForLEDGER (Mary Mock)),
           testProperty "Alonzo ValidTx preserves ADA" $
-            forAll (genTxAndLEDGERState (Alonzo Mock)) (testTxValidForLEDGER (Alonzo Mock))
-            -- Commented out this test for now, since the generator seems to
-            -- generate extraneous script witnesses, which are not allowed any longer
-            -- testProperty "Babbage ValidTx preserves ADA" $
-            --  forAll (genTxAndLEDGERState (Babbage Mock)) (testTxValidForLEDGER (Babbage Mock))
+            {-
+                        forAll (genTxAndLEDGERState (Alonzo Mock)) (testTxValidForLEDGER (Alonzo Mock))
+                        -- Commented out this test for now, since the generator seems to
+                        -- generate extraneous script witnesses, which are not allowed any longer
+                        -- testProperty "Babbage ValidTx preserves ADA" $
+                        --  forAll (genTxAndLEDGERState (Babbage Mock)) (testTxValidForLEDGER (Babbage Mock))
+            -}
+            forAll (genTxAndLEDGERState (Alonzo Mock) def) (testTxValidForLEDGER (Alonzo Mock)),
+          testProperty "Babbage ValidTx preserves ADA" $
+            forAll (genTxAndLEDGERState (Babbage Mock) def) (testTxValidForLEDGER (Babbage Mock))
         ]
     ]
 
@@ -1056,15 +245,41 @@ genericProperties =
 -- :main --quickcheck-replay=205148
 
 main :: IO ()
-main = test 1 (Babbage Mock)
+main = test 100 (Babbage Mock)
 
 test :: ReflectC (Crypto era) => Int -> Proof era -> IO ()
 test n proof = defaultMain $
   case proof of
     Babbage _ ->
-      testProperty "Babbage ValidTx preserves ADA" $ (withMaxSuccess n (forAll (genTxAndLEDGERState proof) (testTxValidForLEDGER proof)))
+      testProperty "Babbage ValidTx preserves ADA" $
+        (withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof)))
     Alonzo _ ->
-      testProperty "Babbage ValidTx preserves ADA" $ (withMaxSuccess n (forAll (genTxAndLEDGERState proof) (testTxValidForLEDGER proof)))
+      testProperty "Babbage ValidTx preserves ADA" $
+        (withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof)))
     Shelley _ ->
-      testProperty "Babbage ValidTx preserves ADA" $ (withMaxSuccess n (forAll (genTxAndLEDGERState proof) (testTxValidForLEDGER proof)))
+      testProperty "Babbage ValidTx preserves ADA" $
+        (withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof)))
     other -> error ("NO Test in era " ++ show other)
+
+-- ===============================================================
+-- Tools for generating other things from a GenEnv. This way one can
+-- test individual functions in this file. These are intended for use
+-- when developng and debugging.
+
+-- | Construct a random (Gen b)
+makeGen :: Reflect era => Proof era -> (Proof era -> GenRS era b) -> Gen b
+makeGen proof computeWith = fst <$> runGenRS proof def (computeWith proof)
+
+runTest :: (Reflect era, PrettyC a era) => (Proof era -> GenRS era a) -> (a -> IO ()) -> Proof era -> IO ()
+runTest computeWith action proof = do
+  ans <- generate (makeGen proof computeWith)
+  putStrLn (show (prettyC proof ans))
+  action ans
+
+main2 :: IO ()
+main2 = runTest (\x -> fst <$> genValidatedTx x) (const (pure ())) (Alonzo Mock)
+
+main3 :: IO ()
+main3 = runTest (\_x -> (fromMUtxo . fst) <$> genUTxO) action (Alonzo Mock)
+  where
+    action (UTxO x) = putStrLn ("Size = " ++ show (Map.size x))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
@@ -9,18 +9,13 @@
 
 module Test.Cardano.Ledger.Generic.Scriptic where
 
-import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (Script (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Era (..), ValidateScript (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Mary (MaryEra)
 import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Cardano.Ledger.Shelley.Scripts as Multi
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Slotting.Slot (SlotNo (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -1,0 +1,282 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Generic.Trace where
+
+-- =========================================================================
+
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import qualified Cardano.Ledger.Babbage.PParams (PParams' (..))
+import Cardano.Ledger.Babbage.Rules.Ledger ()
+import Cardano.Ledger.Babbage.Rules.Utxow ()
+import Cardano.Ledger.BaseTypes (BlocksMade (..), Globals)
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
+import Cardano.Ledger.Pretty (ppList, ppPair, ppWord64)
+import Cardano.Ledger.Shelley.LedgerState
+  ( AccountState (..),
+    EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+  )
+import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams' (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Control.Monad.Trans.RWS.Strict (get, gets)
+import Control.Monad.Trans.Reader (ReaderT (..))
+import Control.State.Transition.Extended (STS (..))
+import Control.State.Transition.Trace (Trace (..))
+import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace (..), traceFromInitState)
+import Data.Default.Class (Default (def))
+import Data.Functor.Identity (Identity (runIdentity))
+import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Sequence as Seq (fromList)
+import Data.Vector (Vector, (!))
+import qualified Data.Vector as Vector
+import GHC.Word (Word64)
+import Test.Cardano.Ledger.Generic.ApplyTx (applyTx)
+import Test.Cardano.Ledger.Generic.GenState
+  ( GenEnv (..),
+    GenRS,
+    GenSize,
+    GenState (..),
+    getBlocksizeMax,
+    getReserves,
+    getSlot,
+    getTreasury,
+    initialLedgerState,
+    modifyModel,
+    runGenRS,
+  )
+import Test.Cardano.Ledger.Generic.MockChain
+import Test.Cardano.Ledger.Generic.ModelState
+  ( Model,
+    mNewEpochStateZero,
+    stashedAVVMAddressesZero,
+  )
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTx)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.Cardano.Ledger.Generic.TxGen
+  ( genValidatedTx,
+  )
+import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCaseSteps)
+
+-- ===========================================
+
+-- | Generate a Core.Tx and an internal Model of the state after the block
+--   has been applied. That model can be used to generate the next Tx
+genRsTxAndModel :: Reflect era => Proof era -> Model era -> Word64 -> GenRS era (Core.Tx era, Model era)
+genRsTxAndModel proof model0 n = do
+  modifyModel (const model0)
+  (_, tx) <- genValidatedTx proof
+  model1 <- gets gsModel
+  let model2 = applyTx proof (fromIntegral n) model1 tx
+  pure (tx, model2)
+
+-- | Generate a Vector of [(Word64,Core.Tx era)] representing a (Vector Block)
+genRsTxSeq ::
+  forall era.
+  Reflect era =>
+  Proof era ->
+  Model era ->
+  Word64 ->
+  Word64 ->
+  [(Word64, Core.Tx era)] ->
+  GenRS era (Vector [(Word64, Core.Tx era)])
+genRsTxSeq _ _ this lastN ans | this > lastN = chop (reverse ans) []
+genRsTxSeq proof model0 this lastN ans = do
+  (tx, model1) <- genRsTxAndModel proof model0 this
+  genRsTxSeq proof model1 (this + 1) lastN ((this, tx) : ans)
+
+-- | Chop a list into random size blocks
+chop :: [(Word64, Core.Tx era)] -> [[(Word64, Core.Tx era)]] -> GenRS era (Vector [(Word64, Core.Tx era)])
+chop [] ans = pure $ Vector.fromList (reverse ans)
+chop xs ans | length (take 4 xs) <= 3 = pure $ Vector.fromList (reverse (xs : ans))
+chop pairs ans = do
+  maxBlockSize <- getBlocksizeMax <$> get
+  n <- lift $ choose (2 :: Int, fromIntegral maxBlockSize)
+  let block = Prelude.take n pairs
+  chop (Prelude.drop n pairs) (block : ans)
+
+-- | Generate a Vector of Blocks, and an initial LedgerState
+genTxSeq ::
+  forall era.
+  Reflect era =>
+  Proof era ->
+  GenSize ->
+  Word64 ->
+  Gen (Vector [(Word64, Core.Tx era)], GenState era)
+genTxSeq proof gensize numTx = do
+  runGenRS proof gensize (genRsTxSeq proof mNewEpochStateZero 0 numTx [])
+
+run :: IO ()
+run = do
+  (vs, _) <- generate $ genTxSeq (Babbage Mock) def 5
+  putStrLn (show (ppList (ppList (ppPair ppWord64 (pcTx (Babbage Mock)))) (Vector.toList vs)))
+
+-- ==================================================================
+-- Constructing the "real", initial NewEpochState, from the GenState
+
+genMockChainState ::
+  Reflect era =>
+  Proof era ->
+  GenState era ->
+  Gen (MockChainState era)
+genMockChainState proof gstate = pure $ MockChainState newepochstate (getSlot gstate) 0
+  where
+    ledgerstate = initialLedgerState gstate
+    newepochstate =
+      NewEpochState
+        { nesEL = EpochNo 0,
+          nesBprev = BlocksMade Map.empty,
+          nesBcur = BlocksMade Map.empty,
+          nesEs = makeEpochState gstate ledgerstate,
+          nesRu = SNothing,
+          nesPd = PoolDistr (gsInitialPoolDistr gstate),
+          stashedAVVMAddresses = stashedAVVMAddressesZero proof
+        }
+
+makeEpochState :: GenState era -> LedgerState era -> EpochState era
+makeEpochState gstate ledgerstate =
+  EpochState
+    { esAccountState = AccountState (getTreasury gstate) (getReserves gstate),
+      esSnapshots = def,
+      esLState = ledgerstate,
+      esPrevPp = gePParams (gsGenEnv gstate),
+      esPp = gePParams (gsGenEnv gstate),
+      esNonMyopic = def
+    }
+
+-- ==============================================================================
+
+-- =====================================================================
+-- HasTrace instance of MOCKCHAIN depends on STS(MOCKCHAIN era) instance
+-- We show the type family instances here for reference.
+{-
+instance STS (MOCKCHAIN era)
+  where
+  type State (MOCKCHAIN era) = MockChainState era
+  type Signal (MOCKCHAIN era) = (MockBlock era,UTxO era)
+  type Environment (MOCKCHAIN era) = ()
+-}
+-- ==============================================================
+
+newtype Gen1 era = Gen1 (Vector [Core.Tx era])
+
+instance
+  ( STS (MOCKCHAIN era),
+    Reflect era
+  ) =>
+  HasTrace (MOCKCHAIN era) (Gen1 era)
+  where
+  type BaseEnv (MOCKCHAIN era) = Globals
+
+  interpretSTS globals act = runIdentity $ runReaderT act globals
+
+  envGen _gstate = pure ()
+
+  sigGen (Gen1 txss) () mcs@(MockChainState newepoch (SlotNo lastSlot) count) = do
+    let NewEpochState _epoch _ _ _ _ pooldistr _ = newepoch
+    issuerkey <- chooseIssuer pooldistr
+    nextSlotNo <- SlotNo . (+ lastSlot) <$> choose (15, 25)
+    let txs = Seq.fromList (txss ! count)
+    -- Assmble it into a MockBlock
+    let mockblock = MockBlock issuerkey nextSlotNo txs
+    -- Run the STS Rules for MOCKCHAIN with generated signal
+    goSTS
+      (MOCKCHAIN reify)
+      ()
+      mcs
+      mockblock
+      ( \case
+          Left pdfs -> error ("MOCKCHAIN sigGen:\n" <> show (ppList (ppMockChainFailure reify) pdfs))
+          Right _mcs -> pure (mockblock)
+      )
+
+  shrinkSignal _x = []
+
+mapProportion :: (v -> Int) -> Map.Map k v -> Gen k
+mapProportion toInt m = frequency [(toInt v, pure k) | (k, v) <- Map.toList m]
+
+chooseIssuer :: PoolDistr crypto -> Gen (KeyHash 'StakePool crypto)
+chooseIssuer (PoolDistr m) = mapProportion getInt m
+  where
+    getInt x = floor (individualPoolStake x * 1000)
+
+-- ===================================================================================
+
+-- =========================================================================
+-- Making and running tracesx
+
+makeMOCKCHAINtrace ::
+  forall era.
+  (Reflect era, HasTrace (MOCKCHAIN era) (Gen1 era)) =>
+  Proof era ->
+  GenSize ->
+  Word64 ->
+  Gen (Trace (MOCKCHAIN era))
+makeMOCKCHAINtrace proof gensize tracelen = do
+  (vs, genstate) <- genTxSeq proof gensize tracelen
+  traceFromInitState @(MOCKCHAIN era)
+    testGlobals
+    (fromIntegral (length vs))
+    (Gen1 (Vector.map (map snd) vs))
+    (Just (\_ -> Right <$> genMockChainState proof genstate))
+
+chainTest ::
+  forall era.
+  ( Reflect era,
+    HasTrace (MOCKCHAIN era) (Gen1 era)
+  ) =>
+  Proof era ->
+  Word64 ->
+  GenSize ->
+  TestTree
+chainTest proof n gsize = testCaseSteps message action
+  where
+    message = "MockChainTrace in the (" ++ show proof ++ ") era."
+    action step = do
+      step ("Generating a sequence of Tx of length " ++ show n)
+      (vs, genstate) <- generate $ genTxSeq proof gsize n
+      step ("Applying the STS rules to the trace with " ++ show (length vs) ++ " blocks.")
+      !_trace <-
+        generate $
+          traceFromInitState @(MOCKCHAIN era)
+            testGlobals
+            (fromIntegral (length vs))
+            (Gen1 (Vector.map (map snd) vs))
+            (Just (\_ -> Right <$> genMockChainState proof genstate))
+      pure ()
+
+-- | test that we can generate a sequence of Tx that all STS validate given a (Proof era)
+testTraces :: Word64 -> TestTree
+testTraces n =
+  testGroup
+    "MockChainTrace"
+    [ chainTest (Babbage Mock) n def,
+      chainTest (Alonzo Mock) n def,
+      chainTest (Mary Mock) n def,
+      chainTest (Allegra Mock) n def,
+      chainTest (Shelley Mock) n def
+    ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -1,0 +1,994 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Generic.TxGen where
+
+import Cardano.Ledger.Alonzo.Data (Data, dataToBinaryData, hashData)
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
+import Cardano.Ledger.Alonzo.TxBody (TxOut (..))
+import Cardano.Ledger.Alonzo.TxWitness
+  ( RdmrPtr (..),
+    Redeemers (..),
+    TxDats (..),
+  )
+import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams' (..))
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxOut (..))
+import Cardano.Ledger.BaseTypes (Network (..), mkTxIxPartial)
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Hashes (EraIndependentTxBody, ScriptHash (..))
+import Cardano.Ledger.Keys
+  ( KeyHash,
+    KeyRole (..),
+    coerceKeyRole,
+  )
+import Cardano.Ledger.Pretty (PrettyA (..), ppRecord)
+import Cardano.Ledger.Pretty.Babbage ()
+import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
+import Cardano.Ledger.Shelley.API
+  ( Addr (..),
+    Credential (..),
+    RewardAcnt (..),
+    StakeReference (..),
+    Wdrl (..),
+  )
+import Cardano.Ledger.Shelley.LedgerState (RewardAccounts)
+import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams' (..))
+import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
+import Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..), Delegation (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), makeWitnessVKey)
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Val
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Monad (forM, replicateM)
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Control.Monad.Trans.RWS.Strict (get, gets, modify)
+import Control.State.Transition.Extended hiding (Assertion)
+import Data.Bifunctor (first)
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Default.Class (Default (def))
+import qualified Data.Foldable as F
+import Data.Functor
+import qualified Data.List as List
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (catMaybes)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Monoid (All (..))
+import Data.Ratio ((%))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Word (Word16)
+import GHC.Stack
+import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+import Test.Cardano.Ledger.Generic.ApplyTx (applyTx)
+import Test.Cardano.Ledger.Generic.Fields hiding (Mint)
+import qualified Test.Cardano.Ledger.Generic.Fields as Generic (TxBodyField (Mint))
+import Test.Cardano.Ledger.Generic.Functions
+import Test.Cardano.Ledger.Generic.GenState
+  ( GenEnv (..),
+    GenRS,
+    GenState (..),
+    elementsT,
+    frequencyT,
+    genCredential,
+    genDatumWithHash,
+    genFreshCredential,
+    genKeyHash,
+    genPool,
+    genPositiveVal,
+    genRewards,
+    genScript,
+    getCertificateMax,
+    getOldUtxoPercent,
+    getRefInputsMax,
+    getSpendInputsMax,
+    getUtxoChoicesMax,
+    getUtxoElem,
+    getUtxoTest,
+    modifyModel,
+    runGenRS,
+  )
+import Test.Cardano.Ledger.Generic.ModelState
+  ( MUtxo,
+    ModelNewEpochState (..),
+    UtxoEntry,
+    fromMUtxo,
+    pcModelNewEpochState,
+  )
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTx)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.Cardano.Ledger.Generic.Updaters hiding (first)
+import Test.Cardano.Ledger.Shelley.Generator.Core (genNatural)
+import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
+import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
+import Test.QuickCheck
+
+-- ===================================================
+-- Assembing lists of Fields in to (Core.XX era)
+
+-- | This uses merging semantics, it expects duplicate fields, and merges them together
+assembleWits :: Era era => Proof era -> [WitnessesField era] -> Core.Witnesses era
+assembleWits era = List.foldl' (updateWitnesses merge era) (initialWitnesses era)
+
+coreTxOut :: Era era => Proof era -> [TxOutField era] -> Core.TxOut era
+coreTxOut era dts = List.foldl' (updateTxOut era) (initialTxOut era) dts
+
+coreTxBody :: Era era => Proof era -> [TxBodyField era] -> Core.TxBody era
+coreTxBody era dts = List.foldl' (updateTxBody era) (initialTxBody era) dts
+
+overrideTxBody :: Proof era -> Core.TxBody era -> [TxBodyField era] -> Core.TxBody era
+overrideTxBody era old dts = List.foldl' (updateTxBody era) old dts
+
+coreTx :: Proof era -> [TxField era] -> Core.Tx era
+coreTx era dts = List.foldl' (updateTx era) (initialTx era) dts
+
+-- ====================================================================
+
+lookupByKeyM ::
+  (Ord k, Show k, HasCallStack) => String -> k -> (GenState era -> Map.Map k v) -> GenRS era v
+lookupByKeyM name k getMap = do
+  m <- gets getMap
+  case Map.lookup k m of
+    Nothing ->
+      error $
+        "Can't find " ++ name ++ " in the test enviroment: " ++ show k
+    Just val -> pure val
+
+-- | Generate a list of specified length with randomish `ExUnit`s where the sum
+--   of all values produced will not exceed the maxTxExUnits.
+genExUnits :: Proof era -> Int -> GenRS era [ExUnits]
+genExUnits era n = do
+  GenEnv {gePParams} <- gets gsGenEnv
+  let ExUnits maxMemUnits maxStepUnits = maxTxExUnits' era gePParams
+  memUnits <- lift $ genSequenceSum maxMemUnits
+  stepUnits <- lift $ genSequenceSum maxStepUnits
+  pure $ zipWith ExUnits memUnits stepUnits
+  where
+    un = fromIntegral n
+    genUpTo maxVal (!totalLeft, !acc) _
+      | totalLeft == 0 = pure (0, 0 : acc)
+      | otherwise = do
+          x <- min totalLeft . round . (% un) <$> genNatural 0 maxVal
+          pure (totalLeft - x, x : acc)
+    genSequenceSum maxVal
+      | maxVal == 0 = pure $ replicate n 0
+      | otherwise = snd <$> F.foldlM (genUpTo maxVal) (maxVal, []) [1 .. n]
+
+lookupScript ::
+  forall era.
+  ScriptHash (Crypto era) ->
+  Maybe Tag ->
+  GenRS era (Maybe (Core.Script era))
+lookupScript scriptHash mTag = do
+  m <- gsScripts <$> get
+  case Map.lookup scriptHash m of
+    Just script -> pure $ Just script
+    Nothing
+      | Just tag <- mTag ->
+          Just . snd <$> lookupByKeyM "plutusScript" (scriptHash, tag) gsPlutusScripts
+    _ -> pure Nothing
+
+-- ========================================================================
+-- Generating Witnesses, here we are not adding anything to the GenState
+-- only looking up things already added, and assembling the right pieces to
+-- make Witnesses.
+
+-- | Used in Shelley Eras
+mkMultiSigWit ::
+  forall era.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Shelley.MultiSig (Crypto era) ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+mkMultiSigWit era mTag (Shelley.RequireSignature keyHash) = mkWitVKey era mTag (KeyHashObj keyHash)
+mkMultiSigWit era mTag (Shelley.RequireAllOf timelocks) = F.fold <$> mapM (mkMultiSigWit era mTag) timelocks
+mkMultiSigWit era mTag (Shelley.RequireAnyOf timelocks)
+  | F.null timelocks = pure (const [])
+  | otherwise = mkMultiSigWit era mTag =<< lift (elements (F.toList timelocks))
+mkMultiSigWit era mTag (Shelley.RequireMOf m timelocks) = do
+  ts <- take m <$> lift (shuffle (F.toList timelocks))
+  F.fold <$> mapM (mkMultiSigWit era mTag) ts
+
+-- | Used in Aonzo and Babbage and Mary Eras
+mkTimelockWit ::
+  forall era.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Timelock (Crypto era) ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+mkTimelockWit era mTag =
+  \case
+    RequireSignature keyHash -> mkWitVKey era mTag (KeyHashObj keyHash)
+    RequireAllOf timelocks -> F.fold <$> mapM (mkTimelockWit era mTag) timelocks
+    RequireAnyOf timelocks
+      | F.null timelocks -> pure (const [])
+      | otherwise -> mkTimelockWit era mTag =<< lift (elements (F.toList timelocks))
+    RequireMOf m timelocks -> do
+      ts <- take m <$> lift (shuffle (F.toList timelocks))
+      F.fold <$> mapM (mkTimelockWit era mTag) ts
+    RequireTimeStart _ -> pure (const [])
+    RequireTimeExpire _ -> pure (const [])
+
+genGenericScriptWitness ::
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Core.Script era ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+genGenericScriptWitness (Shelley c) mTag timelock = mkMultiSigWit (Shelley c) mTag timelock
+genGenericScriptWitness (Allegra c) mTag timelock = mkTimelockWit (Allegra c) mTag timelock
+genGenericScriptWitness (Mary c) mTag timelock = mkTimelockWit (Mary c) mTag timelock
+genGenericScriptWitness (Alonzo c) mTag (TimelockScript timelock) = mkTimelockWit (Alonzo c) mTag timelock
+genGenericScriptWitness (Alonzo _) _ (PlutusScript _ _) = pure (const [])
+genGenericScriptWitness (Babbage c) mTag (TimelockScript timelock) = mkTimelockWit (Babbage c) mTag timelock
+genGenericScriptWitness (Babbage _) _ (PlutusScript _ _) = pure (const [])
+
+-- | Generate a Witnesses producing function. We handle Witnesses come from Keys and Scripts
+--   Because scripts vary be Era, we need some Era specific code here: genGenericScriptWitness
+mkWitVKey ::
+  forall era kr.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Credential kr (Crypto era) ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+mkWitVKey _ _mTag (KeyHashObj keyHash) = do
+  keyPair <- lookupByKeyM "credential" (coerceKeyRole keyHash) gsKeys
+  pure $ \bodyHash -> [AddrWits' [makeWitnessVKey bodyHash keyPair]]
+mkWitVKey era mTag (ScriptHashObj scriptHash) =
+  lookupScript @era scriptHash mTag >>= \case
+    Nothing ->
+      error $ "Impossible: Cannot find script with hash " ++ show scriptHash
+    Just script -> do
+      let scriptWit = [ScriptWits' [script]]
+      otherWit <- genGenericScriptWitness era mTag script
+      pure (\hash -> (scriptWit ++ otherWit hash))
+
+-- | Generator for witnesses necessary for Scripts and Key
+-- credentials. Because of the Key credentials generating function requires a body
+-- hash for an acutal witness to be constructed. In order to be able to estimate
+-- fees and collateral needed we will use these produced witness generators twice: one
+-- time with bogus body hash for estimation, and the second time with an actual
+-- body hash.
+genCredTimelockKeyWit ::
+  forall era k.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Credential k (Crypto era) ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> Core.Witnesses era)
+genCredTimelockKeyWit era mTag cred = (assembleWits era .) <$> mkWitVKey era mTag cred
+
+-- | Same as `genCredKeyWit`, but for `TxOuts`
+genTxOutKeyWitness ::
+  forall era.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Core.TxOut era ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+genTxOutKeyWitness era mTag txout =
+  case (getTxOutAddr txout) of
+    AddrBootstrap baddr ->
+      error $ "Can't authorize bootstrap address: " ++ show baddr
+    Addr _ payCred _ ->
+      case getTxOutRefScript reify txout of
+        SNothing -> mkWitVKey era mTag payCred
+        SJust script -> do
+          f1 <- mkWitVKey era mTag payCred
+          f2 <- genGenericScriptWitness reify (Just Spend) script
+          pure (\safehash -> f1 safehash ++ f2 safehash)
+
+genCredKeyWit ::
+  forall era k.
+  (Reflect era) =>
+  Proof era ->
+  Maybe Tag ->
+  Credential k (Crypto era) ->
+  GenRS era (SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era])
+genCredKeyWit era mTag cred = mkWitVKey era mTag cred
+
+makeDatumWitness :: Proof era -> Core.TxOut era -> GenRS era [WitnessesField era]
+makeDatumWitness proof txout = case (proof, txout) of
+  (Babbage _, Babbage.TxOut _ _ (Babbage.DatumHash h) _) -> mkDatumWit (SJust h)
+  (Babbage _, Babbage.TxOut _ _ (Babbage.Datum _) _) -> pure []
+  (Babbage _, Babbage.TxOut _ _ Babbage.NoDatum _) -> pure []
+  (Alonzo _, TxOut _ _ mDatum) -> mkDatumWit mDatum
+  _ -> pure [] -- No other era has data witnesses
+  where
+    mkDatumWit SNothing = pure []
+    mkDatumWit (SJust datumHash) = do
+      datum <- lookupByKeyM "datum" datumHash gsDatums
+      pure [DataWits' [datum]]
+
+-- | Does the current Credential point to a PlutusScript? If so return its IsValid and Hash
+lookupPlutusScript ::
+  Credential k (Crypto era) ->
+  Tag ->
+  GenRS era (Maybe (IsValid, ScriptHash (Crypto era)))
+lookupPlutusScript (KeyHashObj _) _ = pure Nothing
+lookupPlutusScript (ScriptHashObj scriptHash) tag =
+  fmap (Map.lookup (scriptHash, tag) . gsPlutusScripts) get <&> \case
+    Nothing -> Nothing
+    Just (isValid, _) -> Just (isValid, scriptHash)
+
+-- | Make RdmrWits WitnessesField only if the Credential is for a Plutus Script
+--  And it is in the spending inputs, not the reference inputs
+redeemerWitnessMaker ::
+  Era era =>
+  Tag ->
+  [Maybe (GenRS era (Data era), Credential k (Crypto era))] ->
+  GenRS era (IsValid, [ExUnits -> [WitnessesField era]])
+redeemerWitnessMaker tag listWithCred =
+  let creds =
+        [ (ix, genDat, cred)
+          | (ix, mCred) <- zip [0 ..] listWithCred,
+            Just (genDat, cred) <- [mCred]
+        ]
+      allValid = IsValid . getAll . foldMap (\(IsValid v) -> All v)
+   in fmap (first allValid . unzip . catMaybes) $
+        forM creds $ \(ix, genDat, cred) ->
+          lookupPlutusScript cred tag >>= \case
+            Nothing -> pure Nothing
+            Just (isValid, _) -> do
+              datum <- genDat
+              let rPtr = RdmrPtr tag ix
+                  mkWit3 exUnits = [RdmrWits (Redeemers $ Map.singleton rPtr (datum, exUnits))]
+              -- we should not add this if the tx turns out to be in the reference inputs.
+              -- we accomplish this by not calling this function on referenceInputs
+              pure $ Just (isValid, mkWit3)
+
+-- ===================================================================================
+-- Now we start actual generators that create things and enter them into
+-- the GenState, and sometimes into the Model.
+
+-- | Collaterals can't have scripts, this is where this generator is needed.
+--   As we generate this we add to the gsKeys field of the GenState.
+genNoScriptRecipient :: Reflect era => GenRS era (Addr (Crypto era))
+genNoScriptRecipient = do
+  paymentCred <- KeyHashObj <$> genKeyHash
+  stakeCred <- StakeRefBase . KeyHashObj <$> genKeyHash
+  pure (Addr Testnet paymentCred stakeCred)
+
+-- | Sometimes generates new Credentials, and some times reuses old ones
+genRecipient :: Reflect era => GenRS era (Addr (Crypto era))
+genRecipient = do
+  paymentCred <- genCredential Spend
+  stakeCred <- genCredential Cert
+  pure (Addr Testnet paymentCred (StakeRefBase stakeCred))
+
+genDatum :: Era era => GenRS era (Data era)
+genDatum = snd <$> genDatumWithHash
+
+-- | Generate a Babbage Datum witness to use as a redeemer for a Plutus Script.
+--   Witnesses can be a ScriptHash, or an inline Datum
+genBabbageDatum :: forall era. Era era => GenRS era (Babbage.Datum era)
+genBabbageDatum =
+  frequencyT
+    [ (1, (Babbage.DatumHash . fst) <$> genDatumWithHash),
+      (4, (Babbage.Datum . dataToBinaryData . snd) <$> genDatumWithHash)
+    ]
+
+genRefScript :: Reflect era => Proof era -> GenRS era (StrictMaybe (Core.Script era))
+genRefScript proof = do
+  scripthash <- genScript proof Spend
+  mscript <- lookupScript scripthash (Just Spend)
+  case mscript of
+    Nothing -> pure SNothing
+    Just script -> pure (SJust script)
+
+genTxOut :: Reflect era => Proof era -> Core.Value era -> GenRS era [TxOutField era]
+genTxOut proof val = do
+  addr <- genRecipient
+  cred <- maybe (error "BootstrapAddress encountered") pure $ paymentCredAddr addr
+  dataHashFields <-
+    case cred of
+      KeyHashObj _ -> pure []
+      ScriptHashObj scriptHash -> do
+        maybeCoreScript <- lookupScript scriptHash (Just Spend)
+        case (proof, maybeCoreScript) of
+          (Babbage _, Just (PlutusScript _ _)) -> do
+            datum <- genBabbageDatum
+            script <- genRefScript proof
+            pure $ [Datum datum, RefScript script]
+          (Alonzo _, Just (PlutusScript _ _)) -> do
+            (datahash, _data) <- genDatumWithHash
+            pure [DHash (SJust datahash)]
+          (_, _) -> pure []
+  pure $ [Address addr, Amount val] ++ dataHashFields
+
+-- ================================================================================
+
+-- | Generate a TxIn whose TxIx will never clash with an Input created from a TxOut
+genTxIn :: forall era. Reflect era => Proof era -> Int -> Gen (TxIn (Crypto era))
+genTxIn _proof numChoices = do
+  txId <- resize 40 arbitrary
+  -- The TxIx for Inputs created from outputs of a TxBody, will only range from (1..numChoices)
+  -- TxIx for these arbitrary Inputs range from (n+1..n+100). This makes the TxIx ranges
+  -- incommensurate.
+  txIx <- (mkTxIxPartial . fromIntegral) <$> choose (numChoices + 1, numChoices + 100)
+  pure (TxIn txId txIx)
+
+-- | Generate a non-empty List of fresh TxIn. By fresh we mean TxIn's that
+--   we have not generated previously. We use the current InitialUtxo to test this.
+genFreshTxIn :: forall era. Reflect era => Int -> GenRS era [TxIn (Crypto era)]
+genFreshTxIn tries | tries <= 0 = error "Could not generate a fresh TxIn after many tries."
+genFreshTxIn tries = do
+  entrysInUse <- gets gsInitialUtxo
+  -- Max number of choices. So the UTxO will never be larger than this
+  numChoicesMax <- gets getUtxoChoicesMax
+  n <- lift $ choose (1, numChoicesMax + 3)
+  ins <- lift $ vectorOf n (genTxIn @era reify numChoicesMax)
+  case filter (`Map.notMember` entrysInUse) ins of
+    [] -> genFreshTxIn (tries - 1)
+    freshTxIns -> pure (take numChoicesMax freshTxIns)
+
+-- ====================================================================
+-- Generating UTxO and associated Inputs (Set (TxIn era))
+
+-- | Generate a somewhat arbitrary MUtxo.  Occasionally add a bit of
+--   the MUtxo in the Model to the one generated.  This way the Tx we generate may
+--   spend some of the old UTxo. The result has at most 1 entry from the
+--   old MUtxo, and If it has only one entry, that entry is not from the old MUtxo
+genUTxO :: Reflect era => GenRS era (MUtxo era, Maybe (UtxoEntry era))
+genUTxO = do
+  ins <- genFreshTxIn 100
+  pairs <- sequence (map (\x -> (x,) <$> genOut) ins)
+  percent <- gets getOldUtxoPercent
+  -- Choose a pair from the oldUTxO
+  maybepair <- frequencyT [(percent, getUtxoElem), (100 - percent, pure Nothing)]
+  pure (Map.fromList (maybeCons maybepair pairs), maybepair)
+  where
+    -- Note: Never add an old pair unless there are more than 1 new pairs
+    maybeCons (Just pair) xs | length xs > 1 = pair : xs
+    maybeCons _ xs = xs
+    genOut = do
+      val <- lift genPositiveVal
+      fields <- genTxOut reify val
+      pure (coreTxOut reify fields)
+
+-- | Generate both the spending and reference inputs and a key from the spending
+--   inputs we can use to pay the fee. That key is never from the oldUTxO
+genSpendReferenceInputs ::
+  Map (TxIn (Crypto era)) (Core.TxOut era) ->
+  GenRS
+    era
+    ( UtxoEntry era, -- The fee key, used to pay the fee.
+      Map (TxIn (Crypto era)) (Core.TxOut era),
+      Map (TxIn (Crypto era)) (Core.TxOut era),
+      Map (TxIn (Crypto era)) (Core.TxOut era)
+    )
+genSpendReferenceInputs newUTxO = do
+  let pairs = SplitMap.toList newUTxO
+  maxInputs <- gets getSpendInputsMax
+  maxRef <- gets getRefInputsMax
+  numInputs <- lift $ choose (1, min (SplitMap.size newUTxO) maxInputs)
+  numRefInputs <- lift $ choose (0, maxRef)
+  badTest <- getUtxoTest
+  (feepair@(txin, txout), inputPairs) <- lift $ chooseGood (badTest . fst) numInputs pairs
+  refInputPairs <- take numRefInputs <$> lift (shuffle pairs)
+  let inputs = Map.fromList inputPairs
+      refInputs = Map.fromList refInputPairs
+  -- The feepair is added to the mMutFee field
+  modifyModel (\m -> m {mMutFee = Map.insert txin txout (mMutFee m)})
+  let filtered = Map.restrictKeys newUTxO (Set.union (Map.keysSet inputs) (Map.keysSet refInputs))
+  pure (feepair, inputs, refInputs, filtered)
+
+-- | The invariant is:
+--
+-- * 'xs' is a non empty list.
+-- * 'xs' has at most one 'bad' element
+-- * if 'xs' has length 1, then the element is guaranteed to be good.
+-- * 'n' is a positive `Int`, ranging between (1 .. length xs).
+-- Return a pair (good,ys) where
+-- > (bad good)==False,
+-- > (good `elem` ys),
+-- > (length ys) == n, and
+-- > all (`elem` xs) ys.
+--
+-- This is used to generate the spending inputs, which always contain on
+-- Input we can use to pay the fee, that does not come from the oldUTxO.
+chooseGood :: (a -> Bool) -> Int -> [a] -> Gen (a, [a])
+chooseGood bad n xs = do
+  let (good, others) =
+        case xs of
+          [] -> error ("empty list in chooseGood, should never happen. n = " ++ show n ++ ", length xs = " ++ show (length xs))
+          [x] -> (x, [])
+          (x : y : more) -> if bad x then (y, (x : more)) else (x, y : more)
+  tailx <- take (n - 1) <$> shuffle others
+  result <- shuffle (good : tailx)
+  pure (good, result)
+
+-- ==================================================
+-- Generating Certificates, May add to the Model
+
+genFreshRegCred :: forall era. Reflect era => GenRS era (Credential 'Staking (Crypto era))
+genFreshRegCred = do
+  old <- gets (Map.keysSet . gsInitialRewards)
+  cred <- genFreshCredential 100 Cert old
+  modify (\st -> st {gsRegKey = Set.insert cred (gsRegKey st)})
+  pure cred
+
+genDCert :: forall era. Reflect era => GenRS era (DCert (Crypto era))
+genDCert = do
+  elementsT
+    [ DCertDeleg
+        <$> elementsT
+          [ RegKey <$> genFreshRegCred @era,
+            DeRegKey <$> genCredential Cert,
+            Delegate <$> genDelegation
+          ]
+    ]
+  where
+    genDelegation = do
+      rewardAccount <- genFreshRegCred @era
+      poolId <- genPool
+      pure $ Delegation {_delegator = rewardAccount, _delegatee = poolId}
+
+genDCerts :: forall era. Reflect era => GenRS era ([DCert (Crypto era)])
+genDCerts = do
+  let genUniqueScript (!dcs, !ss, !regCreds) _ = do
+        dc <- genDCert
+        -- Workaround a misfeature where duplicate plutus scripts in DCert are ignored
+        -- so if a duplicate might be generated, we don't do that generation
+        let insertIfNotPresent dcs' regCreds' mKey mScriptHash
+              | Just (_, scriptHash) <- mScriptHash =
+                  if (scriptHash, mKey) `Set.member` ss
+                    then (dcs, ss, regCreds)
+                    else (dc : dcs', Set.insert (scriptHash, mKey) ss, regCreds')
+              | otherwise = (dc : dcs', ss, regCreds')
+        -- Generate registration and de-registration delegation certificates,
+        -- while ensuring the proper registered/unregistered state in DState
+        case dc of
+          DCertDeleg d
+            | RegKey regCred <- d ->
+                if regCred `Map.member` regCreds -- Can't register if it is already registered
+                  then pure (dcs, ss, regCreds)
+                  else pure (dc : dcs, ss, Map.insert regCred (Coin 99) regCreds) -- 99 is a NonZero Value
+            | DeRegKey deregCred <- d ->
+                -- We can't make DeRegKey certificate if deregCred is not already registered
+                -- or if the Rewards balance for deregCred is not 0
+                case Map.lookup deregCred regCreds of
+                  Nothing -> pure (dcs, ss, regCreds)
+                  -- No credential, skip making certificate
+                  Just (Coin 0) ->
+                    -- Ok to make certificate, rewards balance is 0
+                    insertIfNotPresent dcs (Map.delete deregCred regCreds) Nothing
+                      <$> lookupPlutusScript deregCred Cert
+                  Just (Coin _) -> pure (dcs, ss, regCreds)
+            -- Either Reward balance is not zero, or no Credential, so skip making certificate
+            | Delegate (Delegation delegCred delegKey) <- d ->
+                let (dcs', regCreds')
+                      | delegCred `Map.member` regCreds = (dcs, regCreds)
+                      | otherwise -- In order to Delegate, the delegCred must exist in rewards.
+                      -- so if it is not there, we put it there, otherwise we may
+                      -- never generate a valid delegation.
+                        =
+                          (DCertDeleg (RegKey delegCred) : dcs, Map.insert delegCred (Coin 99) regCreds)
+                 in insertIfNotPresent dcs' regCreds' (Just delegKey)
+                      <$> lookupPlutusScript delegCred Cert
+          _ -> pure (dc : dcs, ss, regCreds)
+  maxcert <- gets getCertificateMax
+  n <- lift $ choose (0, maxcert)
+  reward <- gets (mRewards . gsModel)
+  let initSets ::
+        ( [DCert (Crypto era)],
+          Set (ScriptHash (Crypto era), Maybe (KeyHash 'StakePool (Crypto era))),
+          Map (Credential 'Staking (Crypto era)) Coin
+        )
+      initSets = ([], Set.empty, reward)
+  (dcs, _, _) <- F.foldlM genUniqueScript initSets [1 :: Int .. n]
+  pure $ reverse dcs
+
+genCollateralUTxO ::
+  forall era.
+  (HasCallStack, Reflect era) =>
+  [Addr (Crypto era)] ->
+  Coin ->
+  MUtxo era ->
+  GenRS era (MUtxo era, Map.Map (TxIn (Crypto era)) (Core.TxOut era))
+genCollateralUTxO collateralAddresses (Coin fee) utxo = do
+  GenEnv {gePParams} <- gets gsGenEnv
+  let collPerc = collateralPercentage' reify gePParams
+      minCollTotal = Coin (ceiling ((fee * toInteger collPerc) % 100))
+      -- Generate a collateral that is neither in UTxO map nor has already been generated
+      genNewCollateral addr coll um c = do
+        -- The size of the Gen computation is driven down when we generate scripts, so it can be 0 here
+        -- that is really bad, because if the happens we get the same TxIn every time, and 'coll' never grows,
+        -- so this function doesn't terminate. We want many choices of TxIn, so resize just this arbitrary by 30.
+        entrysInUse <- gets gsInitialUtxo
+        txIn <- lift (resize 30 (arbitrary :: Gen (TxIn (Crypto era))))
+        if Map.member txIn utxo || Map.member txIn coll || txIn `Map.member` entrysInUse
+          then genNewCollateral addr coll um c
+          else pure (um, Map.insert txIn (coreTxOut reify [Address addr, Amount (inject c)]) coll, c)
+      -- Either pick a collateral from a map or generate a completely new one
+      genCollateral addr coll um
+        | Map.null um = genNewCollateral addr coll um =<< lift genPositiveVal
+        | otherwise = do
+            i <- lift $ chooseInt (0, Map.size um - 1)
+            let (txIn, txOut) = Map.elemAt i um
+                val = getTxOutVal reify txOut
+            pure (Map.deleteAt i um, Map.insert txIn txOut coll, coin val)
+      -- Recursively either pick existing key spend only outputs or generate new ones that
+      -- will be later added to the UTxO map
+      go ::
+        [Addr (Crypto era)] ->
+        Map (TxIn (Crypto era)) (Core.TxOut era) ->
+        Coin ->
+        Map (TxIn (Crypto era)) (Core.TxOut era) ->
+        GenRS era (Map (TxIn (Crypto era)) (Core.TxOut era))
+      go ecs !coll !curCollTotal !um
+        | curCollTotal >= minCollTotal = pure coll
+        | [] <- ecs = error "Impossible: supplied less addresses then `maxCollateralInputs`"
+        | ec : ecs' <- ecs = do
+            (um', coll', c) <-
+              if null ecs'
+                then genNewCollateral ec coll um (minCollTotal <-> curCollTotal)
+                else elementsT [genCollateral ec coll Map.empty, genCollateral ec coll um]
+            go ecs' coll' (curCollTotal <+> c) um'
+  collaterals <-
+    go collateralAddresses Map.empty (Coin 0) $
+      SplitMap.toMap $ SplitMap.filter spendOnly utxo
+  pure -- ((Map.foldrWithKey' Map.insert utxo collaterals), collaterals)
+    (Map.union collaterals utxo, collaterals)
+
+spendOnly :: Era era => Core.TxOut era -> Bool
+spendOnly txout = case getTxOutAddr txout of
+  (Addr _ (ScriptHashObj _) _) -> False
+  _ -> True
+
+genRecipientsFrom :: Reflect era => [Core.TxOut era] -> GenRS era [Core.TxOut era]
+genRecipientsFrom txOuts = do
+  let outCount = length txOuts
+  approxCount <- lift $ choose (1, outCount)
+  let extra = outCount - approxCount
+      avgExtra = ceiling (toInteger extra % toInteger approxCount)
+      genExtra e
+        | e <= 0 || outCount == 0 || avgExtra == 0 = pure 0
+        | otherwise = lift $ chooseInt (0, avgExtra)
+  let goNew _ [] !rs = pure rs
+      goNew e (tx : txs) !rs = do
+        leftToAdd <- genExtra e
+        goExtra (e - leftToAdd) leftToAdd (inject (Coin 0)) tx txs rs
+      goExtra _ _ s tx [] !rs = genWithChange s tx rs
+      goExtra e 0 s tx txs !rs = goNew e txs =<< genWithChange s tx rs
+      goExtra e n !s txout (tx : txs) !rs = goExtra e (n - 1) (s <+> v) tx txs rs
+        where
+          v = getTxOutVal reify txout
+      genWithChange s txout rs = do
+        let !(!addr, !v, !ds) = txoutFields reify txout
+        c <- Coin <$> lift (choose (1, unCoin $ coin v))
+        fields <- genTxOut reify (s <+> inject c)
+        if c < coin v
+          then
+            let !change = coreTxOut reify (Address addr : Amount (v <-> inject c) : ds)
+             in pure (coreTxOut reify fields : change : rs)
+          else pure (coreTxOut reify fields : rs)
+  goNew extra txOuts []
+
+getDCertCredential :: DCert crypto -> Maybe (Credential 'Staking crypto)
+getDCertCredential = \case
+  DCertDeleg d ->
+    case d of
+      RegKey _rk -> Nothing -- we don't require witnesses for RegKey
+      DeRegKey drk -> Just drk
+      Delegate (Delegation dk _) -> Just dk
+  DCertPool _p -> Nothing
+  DCertGenesis _g -> Nothing
+  DCertMir _m -> Nothing
+
+genWithdrawals :: Reflect era => GenRS era (Wdrl (Crypto era), RewardAccounts (Crypto era))
+genWithdrawals = do
+  let networkId = Testnet
+  newRewards <- genRewards
+  pure (Wdrl $ Map.mapKeys (RewardAcnt networkId) newRewards, newRewards)
+
+timeToLive :: ValidityInterval -> SlotNo
+timeToLive (ValidityInterval _ (SJust n)) = n
+timeToLive (ValidityInterval _ SNothing) = SlotNo maxBound
+
+-- ============================================================================
+
+genValidatedTx :: forall era. Reflect era => Proof era -> GenRS era (UTxO era, Core.Tx era)
+genValidatedTx proof = do
+  (utxo, tx, _fee, _old) <- genValidatedTxAndInfo proof
+  pure (utxo, tx)
+
+genValidatedTxAndInfo ::
+  forall era.
+  Reflect era =>
+  Proof era ->
+  GenRS
+    era
+    ( UTxO era,
+      Core.Tx era,
+      UtxoEntry era, -- The fee key
+      Maybe (UtxoEntry era) -- from oldUtxO
+    )
+genValidatedTxAndInfo proof = do
+  GenEnv {geValidityInterval, gePParams} <- gets gsGenEnv
+
+  -- 1. Produce utxos that will be spent
+  (utxoChoices, maybeoldpair) <- genUTxO
+
+  -- 2. Generate UTxO for spending and reference inputs
+  --    Note the spending inputs and the reference inputs may overlap.
+  --    feeKey is one of the inputs from the spending inputs, safe to pay the fee with.
+  ( feepair@(feeKey, _), -- One of the spending inputs, to be used to pay the fee
+    toSpendNoCollateral, -- All of the spending inputs
+    refInputsUtxo, -- All the reference inputs
+    utxoNoCollateral -- Union of all the above
+    ) <-
+    genSpendReferenceInputs utxoChoices
+
+  -- 3. Check if all Plutus scripts are valid
+  let toSpendNoCollateralTxOuts :: [Core.TxOut era]
+      toSpendNoCollateralTxOuts = Map.elems toSpendNoCollateral
+      -- We use maxBound to ensure the serialized size overestimation
+      maxCoin = Coin (toInteger (maxBound :: Int))
+  -- 4. Generate all recipients and witnesses needed for spending Plutus scripts
+  recipients <- genRecipientsFrom toSpendNoCollateralTxOuts
+
+  --  mkPaymentWits :: ExUnits -> [WitnessesField era]
+  (IsValid v1, mkPaymentWits) <-
+    redeemerWitnessMaker
+      Spend
+      [ (\dh cred -> (lookupByKeyM "datum" dh gsDatums, cred))
+          <$> mDatumHash
+          <*> (Just credential)
+        | (_, coretxout) <- Map.toAscList toSpendNoCollateral,
+          let (credentials, mDatumHash) = txoutEvidence proof coretxout,
+          credential <- credentials
+      ]
+
+  -- generate Withdrawals before DCerts, as Rewards are populated in the Model here,
+  -- and we need to avoid certain DCerts if they conflict with existing Rewards
+  (wdrls@(Wdrl wdrlMap), newRewards) <- genWithdrawals
+  rewardsWithdrawalTxOut <- coreTxOut proof <$> (genTxOut proof $ inject $ F.fold wdrlMap)
+  let wdrlCreds = map (getRwdCred . fst) $ Map.toAscList wdrlMap
+  (IsValid v2, mkWdrlWits) <-
+    redeemerWitnessMaker Rewrd $ map (Just . (,) genDatum) wdrlCreds
+
+  dcerts <- genDCerts
+  let dcertCreds = map getDCertCredential dcerts
+  (IsValid v3, mkCertsWits) <-
+    redeemerWitnessMaker Cert $ map ((,) genDatum <$>) dcertCreds
+
+  let isValid = IsValid (v1 && v2 && v3)
+      mkWits :: [ExUnits -> [WitnessesField era]]
+      mkWits = mkPaymentWits ++ mkCertsWits ++ mkWdrlWits
+  exUnits <- genExUnits proof (length mkWits)
+
+  let redeemerWitsList :: [WitnessesField era]
+      redeemerWitsList = concat (zipWith ($) mkWits exUnits)
+  datumWitsList <- concat <$> mapM (makeDatumWitness proof) (Map.elems toSpendNoCollateral)
+  keyWitsMakers <-
+    mapM
+      (genTxOutKeyWitness proof (Just Spend))
+      (toSpendNoCollateralTxOuts ++ Map.elems refInputsUtxo)
+  dcertWitsMakers <- mapM (genCredKeyWit proof (Just Cert)) $ catMaybes dcertCreds
+  rwdrsWitsMakers <- mapM (genCredKeyWit proof (Just Rewrd)) wdrlCreds
+
+  -- 5. Estimate inputs that will be used as collateral
+  maxCollateralCount <-
+    lift $ chooseInt (1, fromIntegral (maxCollateralInputs' proof gePParams))
+  bogusCollateralTxId <- lift (arbitrary :: Gen (TxId (Crypto era)))
+  let bogusCollateralTxIns =
+        Set.fromList
+          [ TxIn bogusCollateralTxId (mkTxIxPartial (fromIntegral i))
+            | i <- [maxBound, maxBound - 1 .. maxBound - (fromIntegral maxCollateralCount) - 1] :: [Word16]
+          ]
+  collateralAddresses <- replicateM maxCollateralCount genNoScriptRecipient
+  bogusCollateralKeyWitsMakers <- forM collateralAddresses $ \a ->
+    genTxOutKeyWitness proof Nothing (coreTxOut proof [Address a, Amount (inject maxCoin)])
+  networkId <- lift $ elements [SNothing, SJust Testnet]
+
+  -- 6. Estimate the fee
+  let redeemerDatumWits = (redeemerWitsList ++ datumWitsList)
+      bogusIntegrityHash = hashScriptIntegrity' proof gePParams mempty (Redeemers mempty) mempty
+      inputSet = Map.keysSet toSpendNoCollateral
+      outputList = (rewardsWithdrawalTxOut : recipients)
+      txBodyNoFee =
+        coreTxBody
+          proof
+          [ Inputs inputSet,
+            Collateral bogusCollateralTxIns,
+            RefInputs (Map.keysSet refInputsUtxo),
+            TotalCol (SJust (Coin 0)), -- Add a bogus Coin, fill it in later
+            Outputs' outputList,
+            Certs' dcerts,
+            Wdrls wdrls,
+            Txfee maxCoin,
+            if Some proof >= Some (Allegra Mock)
+              then Vldt geValidityInterval
+              else TTL (timeToLive geValidityInterval),
+            Update' [],
+            ReqSignerHashes' [],
+            Generic.Mint mempty,
+            WppHash bogusIntegrityHash,
+            AdHash' [],
+            Txnetworkid networkId
+          ]
+      txBodyNoFeeHash = hashAnnotated txBodyNoFee
+      witsMakers :: [SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era]]
+      witsMakers = keyWitsMakers ++ dcertWitsMakers ++ rwdrsWitsMakers
+      bogusNeededScripts = scriptsNeeded' proof utxoNoCollateral txBodyNoFee
+      noFeeWits :: [WitnessesField era]
+      noFeeWits =
+        onlyNecessaryScripts proof bogusNeededScripts $
+          redeemerDatumWits
+            <> foldMap ($ txBodyNoFeeHash) (witsMakers ++ bogusCollateralKeyWitsMakers)
+      bogusTxForFeeCalc =
+        coreTx
+          proof
+          [ Body txBodyNoFee,
+            Witnesses (assembleWits proof noFeeWits),
+            Valid isValid,
+            AuxData' []
+          ]
+      fee = minfee' proof gePParams bogusTxForFeeCalc
+      deposits = depositsAndRefunds proof gePParams dcerts
+
+  -- 7. Crank up the amount in one of outputs to account for the fee and deposits. Note
+  -- this is a hack that is not possible in a real life, but in the end it does produce
+  -- real life like setup. We use the entry with TxIn feeKey, which we can safely overwrite.
+  let utxoFeeAdjusted = Map.adjust (injectFee proof (fee <+> deposits)) feeKey utxoNoCollateral
+
+  -- 8. Generate utxos that will be used as collateral
+  (utxo, collMap) <- genCollateralUTxO collateralAddresses fee utxoFeeAdjusted
+  collateralKeyWitsMakers <-
+    mapM (genTxOutKeyWitness proof Nothing) $ Map.elems collMap
+
+  -- 9. Construct the correct Tx with valid fee and collaterals
+  allPlutusScripts <- gsPlutusScripts <$> get
+  let mIntegrityHash =
+        hashScriptIntegrity'
+          proof
+          gePParams
+          (languagesUsed proof bogusTxForFeeCalc (UTxO utxoNoCollateral) allPlutusScripts)
+          (mkTxrdmrs redeemerDatumWits)
+          (mkTxdats redeemerDatumWits)
+      txBody =
+        overrideTxBody
+          proof
+          txBodyNoFee
+          [ Txfee fee,
+            Collateral (Map.keysSet collMap),
+            TotalCol (SJust (txInBalance (Map.keysSet collMap) utxo)),
+            WppHash mIntegrityHash
+          ]
+      txBodyHash = hashAnnotated txBody
+      neededScripts = scriptsNeeded' proof utxo txBody
+      wits =
+        onlyNecessaryScripts proof neededScripts $
+          redeemerDatumWits
+            <> foldMap ($ txBodyHash) (witsMakers ++ collateralKeyWitsMakers)
+      validTx =
+        coreTx
+          proof
+          [ Body txBody,
+            Witnesses (assembleWits proof wits),
+            Valid isValid,
+            AuxData' []
+          ]
+  count <- gets (mCount . gsModel)
+  -- Add the new objects freshly generated for this Tx to the set of Initial objects for a Trace
+  modify
+    ( \st ->
+        st
+          { gsInitialUtxo = Map.union (gsInitialUtxo st) (minus utxo maybeoldpair),
+            gsInitialRewards = Map.unions [gsInitialRewards st, newRewards]
+          }
+    )
+  -- Modify the model to track what this transaction does.
+  modifyModel
+    ( \m ->
+        m
+          { mCount = count + 1,
+            mIndex = Map.insert count (TxId txBodyHash) (mIndex m),
+            mUTxO = utxo -- This is the UTxO that will run this Tx,
+          }
+    )
+  pure (fromMUtxo utxo, validTx, feepair, maybeoldpair)
+
+minus :: MUtxo era -> Maybe (UtxoEntry era) -> MUtxo era
+minus m Nothing = m
+minus m (Just (txin, _)) = Map.delete txin m
+
+-- | Keep only Script witnesses that are neccessary in 'era',
+onlyNecessaryScripts :: Proof era -> Set (ScriptHash (Crypto era)) -> [WitnessesField era] -> [WitnessesField era]
+onlyNecessaryScripts _ _ [] = []
+onlyNecessaryScripts proof hashes (ScriptWits m : xs) =
+  ScriptWits (Map.restrictKeys m hashes) : onlyNecessaryScripts proof hashes xs
+onlyNecessaryScripts proof hashes (x : xs) = x : onlyNecessaryScripts proof hashes xs
+
+-- | Scan though the fields unioning all the RdrmWits fields into one Redeemer map
+mkTxrdmrs :: forall era. Era era => [WitnessesField era] -> Redeemers era
+mkTxrdmrs fields = Redeemers (List.foldl' accum Map.empty fields)
+  where
+    accum m1 (RdmrWits (Redeemers m2)) = Map.union m1 m2
+    accum m1 _ = m1
+
+-- | Scan though the fields unioning all the DataWits fields into one TxDat
+mkTxdats :: forall era. Era era => [WitnessesField era] -> TxDats era
+mkTxdats fields = TxDats (List.foldl' accum Map.empty fields)
+  where
+    accum m (DataWits' ds) = List.foldl' accum2 m ds
+      where
+        accum2 m2 d = Map.insert (hashData @era d) d m2
+    accum m _ = m
+
+-- =======================================================
+-- An encapsulation of the Top level types we generate,
+-- but that has its own Show instance that we can control.
+
+data Box era = Box (Proof era) (TRC (Core.EraRule "LEDGER" era)) (GenState era)
+
+instance
+  ( Era era,
+    PrettyA (State (Core.EraRule "LEDGER" era)),
+    PrettyA (Core.Script era),
+    PrettyA (Signal (Core.EraRule "LEDGER" era)),
+    Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era
+  ) =>
+  Show (Box era)
+  where
+  show (Box _proof (TRC (_env, _state, _sig)) _gs) =
+    show $
+      ppRecord
+        "Box"
+        []
+
+-- Sample things we might use in the Box
+-- ("Tx", tcTx proof _sig)
+-- ("Tx", prettyA _sig)
+-- ("TRC state",prettyA _state)
+-- ("GenEnv",pcGenState proof _gs)
+
+testTx :: IO ()
+testTx = do
+  let proof = Babbage Mock
+  ((_utxo, tx, _feepair, _), genstate) <- generate $ runGenRS proof def (genValidatedTxAndInfo proof)
+  let m = gsModel genstate
+      count = mCount m
+  putStrLn (show (pcTx proof tx))
+  putStrLn (show (pcModelNewEpochState proof m))
+  let m2 = applyTx proof count m tx
+  putStrLn (show (pcModelNewEpochState proof m2))
+
+-- ==============================================================================
+-- How we take the generated stuff and put it through the STS rule mechanism
+-- in a way that is Era Agnostic
+
+applySTSByProof ::
+  forall era.
+  (GoodCrypto (Crypto era)) =>
+  Proof era ->
+  RuleContext 'Transition (Core.EraRule "LEDGER" era) ->
+  (Either [PredicateFailure (Core.EraRule "LEDGER" era)] (State (Core.EraRule "LEDGER" era)))
+applySTSByProof (Babbage _) _trc = runShelleyBase $ applySTS @(Core.EraRule "LEDGER" (BabbageEra (Crypto era))) _trc
+applySTSByProof (Alonzo _) trc = runShelleyBase $ applySTS trc
+applySTSByProof (Mary _) trc = runShelleyBase $ applySTS trc
+applySTSByProof (Allegra _) trc = runShelleyBase $ applySTS trc
+applySTSByProof (Shelley _) trc = runShelleyBase $ applySTS trc

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -17,6 +17,7 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
     collectOrderingAlonzo,
   )
 import Test.Cardano.Ledger.Generic.Properties (genericProperties)
+import Test.Cardano.Ledger.Generic.Trace (testTraces)
 import Test.Cardano.Ledger.Model.Properties (modelUnitTests_)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
@@ -43,7 +44,8 @@ mainTests =
           collectOrderingAlonzo,
           modelUnitTests_
         ],
-      genericProperties
+      genericProperties,
+      testTraces 200
     ]
 
 -- main entry point


### PR DESCRIPTION
This PR is built on top of PR #2696 
It replaces the RWST monad with ReaderT in Properties.hs
This means we can generate Tx in any era, without mutating any state.
Perfect for trace generation.
