### PR TITLE
more babbage unit tests, two babbage bug fixes

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -89,6 +89,7 @@ import Control.Monad.Except (liftEither)
 import Control.Monad.Reader (runReader)
 import Control.State.Transition.Extended (TRC (TRC))
 import Data.Default (def)
+import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
 import qualified Data.Set as Set
@@ -225,6 +226,12 @@ instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo
   inputDataHashes = alonzoInputHashes
   txscripts _ = txscripts' . getField @"wits"
+  getAllowedSupplimentalDataHashes txbody _ =
+    Set.fromList
+      [ dh
+        | out <- toList (getField @"outputs" txbody),
+          SJust dh <- [getField @"datahash" out]
+      ]
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -385,6 +385,11 @@ class ExtendedUTxO era where
     Core.Tx era ->
     Map.Map (ScriptHash (Crypto era)) (Core.Script era)
 
+  getAllowedSupplimentalDataHashes ::
+    Core.TxBody era ->
+    UTxO era ->
+    Set (DataHash (Crypto era))
+
 alonzoTxInfo ::
   forall era m.
   ( Era era,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -212,5 +212,5 @@ scriptsNo = do
       { _utxo = UTxO (SplitMap.union utxoKeep collouts), -- NEW to Babbage
       {- fees + collateralFees -}
         _fees = fees <> collateralFees, -- NEW to Babbage
-        _stakeDistro = updateStakeDistribution (_stakeDistro us) (UTxO utxoDel) mempty
+        _stakeDistro = updateStakeDistribution (_stakeDistro us) (UTxO utxoDel) (UTxO collouts)
       }

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -15,11 +15,17 @@ module Test.Cardano.Ledger.Examples.BabbageFeatures where
 
 import qualified Cardano.Crypto.Hash as CH
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData)
+import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
-import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..))
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..))
+import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..))
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPred (..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import Cardano.Ledger.BaseTypes
   ( Network (..),
@@ -29,10 +35,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (EraRule)
 import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Credential
-  ( Credential (..),
-    StakeReference (..),
-  )
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (Era (..), ValidateScript (hashScript))
 import Cardano.Ledger.Keys
@@ -44,20 +47,25 @@ import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (ProtVer (..), UTxO (..))
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), smartUTxOState)
+import Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..))
 import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
-import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.TxIn (TxIn (..), txid)
 import Cardano.Ledger.Val (inject)
 import Control.State.Transition.Extended hiding (Assertion)
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Default.Class (Default (..))
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import GHC.Stack
 import qualified Plutus.V1.Ledger.Api as Plutus
 import Test.Cardano.Ledger.Examples.TwoPhaseValidation
-  ( Expect (..),
+  ( AlonzoBased (..),
+    Expect (..),
     expectedUTxO,
     freeCostModelV1,
     freeCostModelV2,
+    keyBy,
+    scriptStakeCredSuceed,
     testUTXOW,
     trustMeP,
   )
@@ -109,7 +117,7 @@ mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
 
 collateralOutput :: Scriptic era => Proof era -> Core.TxOut era
 collateralOutput pf =
-  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 5)]
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 50)]
 
 datumExample1 :: Data era
 datumExample1 = Data (Plutus.I 123)
@@ -123,25 +131,113 @@ inlineDatumOutput pf =
       Datum (Babbage.Datum . dataToBinaryData $ datumExample1 @era)
     ]
 
+inlineDatumOutputV1 :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+inlineDatumOutputV1 pf =
+  newTxOut
+    pf
+    [ Address (scriptAddr pf (always 3 pf)),
+      Amount (inject $ Coin 5000),
+      Datum (Babbage.Datum . dataToBinaryData $ datumExample1 @era)
+    ]
+
+simpleV2EUTxO :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+simpleV2EUTxO pf =
+  newTxOut
+    pf
+    [ Address (scriptAddr pf (alwaysAlt 3 pf)),
+      Amount (inject $ Coin 5000),
+      DHash' [hashData $ datumExample1 @era]
+    ]
+
+failsEUTxO :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+failsEUTxO pf =
+  newTxOut
+    pf
+    [ Address (scriptAddr pf (never 3 pf)),
+      Amount (inject $ Coin 5000),
+      DHash' [hashData $ datumExample1 @era]
+    ]
+
 referenceScriptOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
 referenceScriptOutput pf =
   newTxOut
     pf
     [ Address (plainAddr pf),
-      Amount (inject $ Coin 10),
-      Datum (Babbage.Datum . dataToBinaryData $ datumExample1 @era),
+      Amount (inject $ Coin 5000),
       RefScript (SJust $ alwaysAlt 3 pf)
     ]
+
+referenceScriptOutput2 :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+referenceScriptOutput2 pf =
+  newTxOut
+    pf
+    [ Address (plainAddr pf),
+      Amount (inject $ Coin 5000),
+      RefScript (SJust $ always 2 pf)
+    ]
+
+referenceDataHashOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
+referenceDataHashOutput pf =
+  newTxOut
+    pf
+    [ Address (plainAddr pf),
+      Amount (inject $ Coin 10),
+      DHash' [hashData $ datumExample1 @era]
+    ]
+
+--
+-- Genesis Inputs
+--
+
+inlineDatumInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+inlineDatumInput = mkGenesisTxIn 1
+
+referenceScriptInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+referenceScriptInput = mkGenesisTxIn 2
+
+referenceDataHashInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+referenceDataHashInput = mkGenesisTxIn 3
+
+somePlainInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+somePlainInput = mkGenesisTxIn 4
+
+simpleV2EUTxOInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+simpleV2EUTxOInput = mkGenesisTxIn 5
+
+referenceScriptInput2 :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+referenceScriptInput2 = mkGenesisTxIn 6
+
+failsEUTxOInput :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+failsEUTxOInput = mkGenesisTxIn 7
+
+inlineDatumInputV1 :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+inlineDatumInputV1 = mkGenesisTxIn 8
+
+collateralInput11 :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+collateralInput11 = mkGenesisTxIn 11
+
+collateralInput17 :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+collateralInput17 = mkGenesisTxIn 17
+
+--
+-- Genesis UTxO
+--
 
 initUTxO :: PostShelley era => Proof era -> UTxO era
 initUTxO pf =
   UTxO $
     SplitMap.fromList $
-      [ (mkGenesisTxIn 1, inlineDatumOutput pf),
-        (mkGenesisTxIn 2, referenceScriptOutput pf)
+      [ (inlineDatumInput, inlineDatumOutput pf),
+        (referenceScriptInput, referenceScriptOutput pf),
+        (referenceDataHashInput, referenceDataHashOutput pf),
+        (somePlainInput, somePlainOutput pf),
+        (simpleV2EUTxOInput, simpleV2EUTxO pf),
+        (referenceScriptInput2, referenceScriptOutput2 pf),
+        (failsEUTxOInput, failsEUTxO pf),
+        (inlineDatumInputV1, inlineDatumOutputV1 pf),
+        (collateralInput11, collateralOutput pf),
+        (collateralInput17, collateralOutput pf)
       ]
-        ++ map (\i -> (mkGenesisTxIn i, somePlainOutput pf)) [3 .. 8]
-        ++ map (\i -> (mkGenesisTxIn i, collateralOutput pf)) [11 .. 18]
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
@@ -157,7 +253,7 @@ pp :: Proof era -> Core.PParams era
 pp pf = newPParams pf defaultPPs
 
 -- =========================================================================
---  Example 1: Spend a EUTxO with an inline datum
+--  Example 1: Spend a EUTxO with an inline datum.
 -- =========================================================================
 
 redeemerExample1 :: Data era
@@ -175,9 +271,8 @@ inlineDatumTxBody :: Scriptic era => Proof era -> Core.TxBody era
 inlineDatumTxBody pf =
   newTxBody
     pf
-    [ Inputs' [mkGenesisTxIn 1],
-      RefInputs' [mkGenesisTxIn 2],
-      Collateral' [mkGenesisTxIn 11],
+    [ Inputs' [inlineDatumInput],
+      Collateral' [collateralInput11],
       Outputs' [outEx1 pf],
       Txfee (Coin 5),
       WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
@@ -212,22 +307,22 @@ utxoStEx1 ::
 utxoStEx1 pf = smartUTxOState (utxoEx1 pf) (Coin 0) (Coin 5) def
 
 -- =========================================================================
---  Example 2: Use a reference script
+--  Example 2: Use a reference script.
 -- =========================================================================
 
-outEx2 :: Scriptic era => Proof era -> Core.TxOut era
-outEx2 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 4995)]
+txDatsExample2 :: Era era => TxDats era
+txDatsExample2 = TxDats $ keyBy hashData [datumExample1]
 
 referenceScriptTxBody :: Scriptic era => Proof era -> Core.TxBody era
 referenceScriptTxBody pf =
   newTxBody
     pf
-    [ Inputs' [mkGenesisTxIn 1],
-      RefInputs' [mkGenesisTxIn 2],
-      Collateral' [mkGenesisTxIn 11],
+    [ Inputs' [simpleV2EUTxOInput],
+      RefInputs' [referenceScriptInput],
+      Collateral' [collateralInput11],
       Outputs' [outEx1 pf],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 txDatsExample2)
     ]
 
 referenceScriptTx ::
@@ -243,12 +338,13 @@ referenceScriptTx pf =
     [ Body (referenceScriptTxBody pf),
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (referenceScriptTxBody pf)) (someKeys pf)],
+          DataWits' [datumExample1],
           RdmrWits validatingRedeemersEx1
         ]
     ]
 
 utxoEx2 :: forall era. PostShelley era => Proof era -> UTxO era
-utxoEx2 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (referenceScriptTxBody pf) (outEx2 pf)) 1
+utxoEx2 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (referenceScriptTxBody pf) (outEx1 pf)) 5
 
 utxoStEx2 ::
   forall era.
@@ -256,6 +352,387 @@ utxoStEx2 ::
   Proof era ->
   UTxOState era
 utxoStEx2 pf = smartUTxOState (utxoEx2 pf) (Coin 0) (Coin 5) def
+
+-- =========================================================================
+--  Example 3: Spend a EUTxO with an inline datum, using a reference script.
+--             Notice that the reference input is not consumed.
+-- =========================================================================
+
+inlineDatumAndRefScriptTxBody :: Scriptic era => Proof era -> Core.TxBody era
+inlineDatumAndRefScriptTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [mkGenesisTxIn 1],
+      RefInputs' [referenceScriptInput],
+      Collateral' [collateralInput11],
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
+    ]
+
+inlineDatumAndRefScriptTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+inlineDatumAndRefScriptTx pf =
+  newTx
+    pf
+    [ Body (inlineDatumAndRefScriptTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (inlineDatumAndRefScriptTxBody pf)) (someKeys pf)],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+utxoEx3 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx3 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (inlineDatumAndRefScriptTxBody pf) (outEx1 pf)) 1
+
+utxoStEx3 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx3 pf = smartUTxOState (utxoEx3 pf) (Coin 0) (Coin 5) def
+
+-- =========================================================================
+--  Example 4: Spend a EUTxO with an inline datum, using a reference script,
+--             and also redundantly supply the script witness.
+-- =========================================================================
+
+inlineDatumAndRefScriptAndWitScriptTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+inlineDatumAndRefScriptAndWitScriptTx pf =
+  newTx
+    pf
+    [ Body (inlineDatumAndRefScriptTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (inlineDatumAndRefScriptTxBody pf)) (someKeys pf)],
+          ScriptWits' [alwaysAlt 3 pf], -- This is redundant with the reference script
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+utxoEx4 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx4 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (inlineDatumAndRefScriptTxBody pf) (outEx1 pf)) 1
+
+utxoStEx4 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx4 pf = smartUTxOState (utxoEx4 pf) (Coin 0) (Coin 5) def
+
+-- ====================================================================================
+--  Example 5: Use a reference input with a data hash in the correspending output and
+--             without supplying the correspending data witness.
+-- ====================================================================================
+
+outEx5 :: Scriptic era => Proof era -> Core.TxOut era
+outEx5 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 995)]
+
+refInputWithDataHashNoWitTxBody :: Scriptic era => Proof era -> Core.TxBody era
+refInputWithDataHashNoWitTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [somePlainInput],
+      RefInputs' [referenceDataHashInput],
+      Outputs' [outEx5 pf],
+      Txfee (Coin 5)
+    ]
+
+refInputWithDataHashNoWitTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+refInputWithDataHashNoWitTx pf =
+  newTx
+    pf
+    [ Body (refInputWithDataHashNoWitTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (refInputWithDataHashNoWitTxBody pf)) (someKeys pf)]
+        ]
+    ]
+
+utxoEx5 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx5 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (refInputWithDataHashNoWitTxBody pf) (outEx5 pf)) 4
+
+utxoStEx5 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx5 pf = smartUTxOState (utxoEx5 pf) (Coin 0) (Coin 5) def
+
+-- =======================================================================================
+--  Example 6: Use a reference input with a data hash in the correspending output and
+--             supplying the correspending data witness.
+-- =======================================================================================
+
+refInputWithDataHashWithWitTxBody :: Scriptic era => Proof era -> Core.TxBody era
+refInputWithDataHashWithWitTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [somePlainInput],
+      RefInputs' [referenceDataHashInput],
+      WppHash (newScriptIntegrityHash pf (pp pf) [] (Redeemers mempty) txDatsExample2),
+      Outputs' [outEx5 pf],
+      Txfee (Coin 5)
+    ]
+
+refInputWithDataHashWithWitTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+refInputWithDataHashWithWitTx pf =
+  newTx
+    pf
+    [ Body (refInputWithDataHashWithWitTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (refInputWithDataHashWithWitTxBody pf)) (someKeys pf)],
+          DataWits' [datumExample1]
+        ]
+    ]
+
+utxoEx6 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx6 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (refInputWithDataHashWithWitTxBody pf) (outEx5 pf)) 4
+
+utxoStEx6 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx6 pf = smartUTxOState (utxoEx6 pf) (Coin 0) (Coin 5) def
+
+-- ====================================================================================
+--  Example 7: Use a reference script for authorizing a delegation certificate
+-- ====================================================================================
+
+outEx7 :: Scriptic era => Proof era -> Core.TxOut era
+outEx7 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 995)]
+
+redeemersEx7 :: Era era => Redeemers era
+redeemersEx7 =
+  Redeemers $
+    Map.singleton (RdmrPtr Tag.Cert 0) (redeemerExample1, ExUnits 5000 5000)
+
+refScriptForDelegCertTxBody :: Scriptic era => Proof era -> Core.TxBody era
+refScriptForDelegCertTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [somePlainInput],
+      RefInputs' [referenceScriptInput2],
+      Collateral' [collateralInput11],
+      Outputs' [outEx7 pf],
+      Certs' [DCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemersEx7 mempty)
+    ]
+
+refScriptForDelegCertTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+refScriptForDelegCertTx pf =
+  newTx
+    pf
+    [ Body (refScriptForDelegCertTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (refScriptForDelegCertTxBody pf)) (someKeys pf)],
+          RdmrWits redeemersEx7
+        ]
+    ]
+
+utxoEx7 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx7 pf = expectedUTxO (initUTxO pf) (ExpectSuccess (refScriptForDelegCertTxBody pf) (outEx5 pf)) 4
+
+utxoStEx7 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx7 pf = smartUTxOState (utxoEx7 pf) (Coin 0) (Coin 5) def
+
+-- ====================================================================================
+--  Example 8: Use a collateral output
+-- ====================================================================================
+
+collateralReturn :: Era era => Proof era -> Core.TxOut era
+collateralReturn pf =
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 45)]
+
+collateralOutputTxBody :: Scriptic era => Proof era -> Core.TxBody era
+collateralOutputTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [failsEUTxOInput],
+      Collateral' [collateralInput17],
+      CollateralReturn' [collateralReturn pf],
+      TotalCol (Coin 5),
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemersEx1 txDatsExample2)
+    ]
+
+collateralOutputTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+collateralOutputTx pf =
+  newTx
+    pf
+    [ Body (collateralOutputTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (collateralOutputTxBody pf)) (someKeys pf)],
+          ScriptWits' [never 3 pf],
+          DataWits' [datumExample1],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+utxoEx8 :: forall era. PostShelley era => Proof era -> UTxO era
+utxoEx8 pf =
+  UTxO $
+    SplitMap.insert
+      (TxIn (txid (collateralOutputTxBody pf)) (mkTxIxPartial 1))
+      (collateralReturn pf)
+      utxoWithoutCollateral
+  where
+    UTxO utxoWithoutCollateral = expectedUTxO (initUTxO pf) ExpectFailure 7
+
+utxoStEx8 ::
+  forall era.
+  (Default (State (EraRule "PPUP" era)), PostShelley era) =>
+  Proof era ->
+  UTxOState era
+utxoStEx8 pf = smartUTxOState (utxoEx8 pf) (Coin 0) (Coin 5) def
+
+-- ====================================================================================
+--  Example 9: Invalid - collateral total
+-- ====================================================================================
+
+incorrectCollateralTotalTxBody :: Scriptic era => Proof era -> Core.TxBody era
+incorrectCollateralTotalTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [inlineDatumInput],
+      Collateral' [collateralInput11],
+      CollateralReturn' [collateralReturn pf],
+      TotalCol (Coin 6),
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)
+    ]
+
+incorrectCollateralTotalTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+incorrectCollateralTotalTx pf =
+  newTx
+    pf
+    [ Body (incorrectCollateralTotalTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (incorrectCollateralTotalTxBody pf)) (someKeys pf)],
+          ScriptWits' [alwaysAlt 3 pf],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+-- ====================================================================================
+--  Example 10: Invalid - Inline datum used with redundant datum in witness set
+-- ====================================================================================
+
+inlineDatumRedundantDatumTxBody :: Scriptic era => Proof era -> Core.TxBody era
+inlineDatumRedundantDatumTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [inlineDatumInput],
+      Collateral' [collateralInput11],
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 txDatsExample2)
+    ]
+
+inlineDatumRedundantDatumTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+inlineDatumRedundantDatumTx pf =
+  newTx
+    pf
+    [ Body (inlineDatumRedundantDatumTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (inlineDatumRedundantDatumTxBody pf)) (someKeys pf)],
+          ScriptWits' [alwaysAlt 3 pf],
+          DataWits' [datumExample1],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+-- ====================================================================================
+--  Example 11: Invalid - Using inline datums with Plutus V1 script
+-- ====================================================================================
+
+inlineDatumV1TxBody :: Scriptic era => Proof era -> Core.TxBody era
+inlineDatumV1TxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [inlineDatumInputV1],
+      Collateral' [collateralInput11],
+      Outputs' [outEx1 pf],
+      Txfee (Coin 5),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemersEx1 mempty)
+    ]
+
+inlineDatumV1Tx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+inlineDatumV1Tx pf =
+  newTx
+    pf
+    [ Body (inlineDatumV1TxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (inlineDatumV1TxBody pf)) (someKeys pf)],
+          ScriptWits' [always 3 pf],
+          RdmrWits validatingRedeemersEx1
+        ]
+    ]
+
+class BabbageBased era failure where
+  fromUtxoB :: BabbageUtxoPred era -> failure
+
+instance BabbageBased (BabbageEra c) (BabbageUtxoPred (BabbageEra c)) where
+  fromUtxoB = id
 
 testU ::
   forall era.
@@ -269,9 +746,18 @@ testU ::
   Assertion
 testU pf tx expect = testUTXOW (UTXOW pf) (initUTxO pf) (pp pf) tx expect
 
+{- TODO
+
+INVALID examples:
+  * a tx with a script/datum which is not well-formed
+  * a tx with a plutus script and and byron outputs
+-}
+
 genericBabbageFeatures ::
   forall era.
-  ( State (EraRule "UTXOW" era) ~ UTxOState era,
+  ( AlonzoBased era (PredicateFailure (EraRule "UTXOW" era)),
+    BabbageBased era (PredicateFailure (EraRule "UTXOW" era)),
+    State (EraRule "UTXOW" era) ~ UTxOState era,
     GoodCrypto (Crypto era),
     Default (State (EraRule "PPUP" era)),
     PostShelley era
@@ -287,12 +773,67 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ inlineDatumTx pf)
-              (Right . utxoStEx1 $ pf),
+              (Right $ utxoStEx1 pf),
           testCase "reference script" $
             testU
               pf
               (trustMeP pf True $ referenceScriptTx pf)
-              (Right . utxoStEx2 $ pf)
+              (Right $ utxoStEx2 pf),
+          testCase "inline datum and ref script" $
+            testU
+              pf
+              (trustMeP pf True $ inlineDatumAndRefScriptTx pf)
+              (Right $ utxoStEx3 pf),
+          testCase "inline datum and ref script and redundant script witness" $
+            testU
+              pf
+              (trustMeP pf True $ inlineDatumAndRefScriptAndWitScriptTx pf)
+              (Right $ utxoStEx4 pf),
+          testCase "reference input with data hash, no data witness" $
+            testU
+              pf
+              (trustMeP pf True $ refInputWithDataHashNoWitTx pf)
+              (Right $ utxoStEx5 pf),
+          testCase "reference input with data hash, with data witness" $
+            testU
+              pf
+              (trustMeP pf True $ refInputWithDataHashWithWitTx pf)
+              (Right $ utxoStEx6 pf),
+          testCase "reference script to authorize delegation certificate" $
+            testU
+              pf
+              (trustMeP pf True $ refScriptForDelegCertTx pf)
+              (Right $ utxoStEx7 pf),
+          testCase "use a collateral output" $
+            testU
+              pf
+              (trustMeP pf False $ collateralOutputTx pf)
+              (Right $ utxoStEx8 pf)
+        ],
+      testGroup
+        "invalid transactions"
+        [ testCase "incorrect collateral total" $
+            testU
+              pf
+              (trustMeP pf True $ incorrectCollateralTotalTx pf)
+              (Left [fromUtxoB @era (UnequalCollateralReturn (Coin 5) (Coin 6))]),
+          testCase "inline datum with redundant datum witness" $
+            testU
+              pf
+              (trustMeP pf True $ inlineDatumRedundantDatumTx pf)
+              ( Left
+                  [ fromPredFail @era
+                      ( NonOutputSupplimentaryDatums
+                          (Set.singleton $ hashData @era datumExample1)
+                          mempty
+                      )
+                  ]
+              ),
+          testCase "inline datum with Plutus V1" $
+            testU
+              pf
+              (trustMeP pf True $ inlineDatumV1Tx pf)
+              (Left [fromUtxos @era (CollectErrors [BadTranslation InlineDatumsNotSupported])])
         ]
     ]
 


### PR DESCRIPTION
This PR fixes two bugs in the Babbage rules (each fix is in its own commit):

* In the case of expected failing Plutus scripts, collateral outputs must be a part of the incremental stake distribution computation.
* The collection of tests named `missingRequiredDatums` now uses a new class method in `ExtendedUTxO` to determine which data witnesses are allowed which are not strictly needed. In the Babbage era, data witnesses are allowed for reference inputs. Additionally, `danglingWitnessDataHashes` was removed since it is redundant with `missingRequiredDatums`.

This PR adds unit tests for most of the remaining ones in  #2471.