### PR TITLE
hide CostModel constructor

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -42,8 +42,7 @@ import Cardano.Binary
   )
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts
-  ( CostModel (..),
-    CostModels (..),
+  ( CostModels (..),
     ExUnits (..),
     Prices (..),
   )
@@ -75,7 +74,6 @@ import Data.Coders
     Wrapped (..),
     decode,
     encode,
-    encodeFoldableAsIndefinite,
     field,
     (!>),
     (<!),
@@ -491,13 +489,10 @@ getLanguageView pp lang@PlutusV1 =
     (serialize' (serialize' lang))
     ( serialize'
         ( serializeEncoding' $
-            maybe encodeNull enc $
+            maybe encodeNull toCBOR $
               Map.lookup lang (unCostModels $ getField @"_costmdls" pp)
         )
     )
-  where
-    enc (CostModelV1 cm _) = encodeFoldableAsIndefinite $ Map.elems cm
-    enc (CostModelV2 cm _) = encodeFoldableAsIndefinite $ Map.elems cm
 getLanguageView pp lang@PlutusV2 =
   LangDepView
     (serialize' lang)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -24,7 +24,7 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Alonzo.Data (getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModel (..), CostModels (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as AlonzoScript (Script (..))
 import Cardano.Ledger.Alonzo.Tx
   ( Data,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Alonzo.Data (Data, getPlutusData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeeded)
 import Cardano.Ledger.Alonzo.Scripts
-  ( CostModel (..),
+  ( CostModel,
     ExUnits (..),
     Script (..),
     getEvaluationContext,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -24,11 +24,12 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (utxoEntrySize, vKeyLocked)
 import Cardano.Ledger.Alonzo.Rules.Utxow (langsUsed)
 import Cardano.Ledger.Alonzo.Scripts (isPlutusScript, pointWiseExUnits, txscriptfee)
 import Cardano.Ledger.Alonzo.Scripts as Alonzo
-  ( CostModel (..),
+  ( CostModel,
     CostModels (..),
     ExUnits (..),
     Prices (..),
     Script (..),
+    mkCostModel,
   )
 import Cardano.Ledger.Alonzo.Tx
   ( IsValid (..),
@@ -64,10 +65,10 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad (replicateM)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Compact.SplitMap as SplitMap
+import Data.Either (fromRight)
 import Data.Hashable (Hashable (..))
 import qualified Data.List as List
 import Data.Map as Map
-import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
 import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq ((:|>)))
@@ -75,7 +76,7 @@ import qualified Data.Sequence.Strict as Seq (fromList)
 import Data.Set as Set
 import GHC.Records (HasField (..))
 import Numeric.Natural (Natural)
-import Plutus.V1.Ledger.Api (costModelParamNames, mkEvaluationContext)
+import Plutus.V1.Ledger.Api (costModelParamNames)
 import qualified PlutusTx as P (Data (..))
 import qualified PlutusTx as Plutus
 import Test.Cardano.Ledger.AllegraEraGen (genValidityInterval)
@@ -178,10 +179,11 @@ genAlonzoMint startvalue = do
 
 -- | A cost model that sets everything as being free
 freeCostModel :: CostModel
-freeCostModel = CostModelV1 cmps ec
+freeCostModel =
+  fromRight (error "freeCostModel is not well-formed") $
+    Alonzo.mkCostModel PlutusV1 cmps
   where
     cmps = Map.fromList $ fmap (\k -> (k, 0)) (Set.toList costModelParamNames)
-    ec = fromJust $ mkEvaluationContext cmps
 
 -- ================================================================
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/PlutusScripts.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/PlutusScripts.hs
@@ -2,22 +2,20 @@
 module Test.Cardano.Ledger.Alonzo.PlutusScripts where
 
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModel (..), Script (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModel, Script (..), mkCostModel)
 import Data.ByteString.Short (pack)
-import Data.Maybe (fromJust)
-import qualified Plutus.V1.Ledger.Api as PV1
+import Data.Either (fromRight)
 import qualified Plutus.V1.Ledger.EvaluationContext as PV1
-import qualified Plutus.V2.Ledger.Api as PV2
 
 testingCostModelV1 :: CostModel
 testingCostModelV1 =
-  CostModelV1 PV1.costModelParamsForTesting (fromJust $ PV1.mkEvaluationContext PV1.costModelParamsForTesting)
+  fromRight (error "testingCostModelV1 is not well-formed") $
+    mkCostModel PlutusV1 PV1.costModelParamsForTesting
 
 testingCostModelV2 :: CostModel
 testingCostModelV2 =
-  CostModelV2 costModelParamsForTestingPV2 (fromJust $ PV2.mkEvaluationContext costModelParamsForTestingPV2)
-  where
-    costModelParamsForTestingPV2 = PV1.costModelParamsForTesting -- TODO use PV2 when it exists
+  fromRight (error "testingCostModelV2 is not well-formed") $
+    mkCostModel PlutusV2 PV1.costModelParamsForTesting -- TODO use PV2 when it exists
 
 {-# DEPRECATED defaultCostModel "use testingCostModelV1 instead" #-}
 defaultCostModel :: Maybe CostModel

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts
-  ( CostModel (..),
+  ( CostModel,
     ExUnits (..),
     Prices (..),
     Script (..),

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -72,10 +72,8 @@ ppExUnits (ExUnits mem step) =
 instance PrettyA ExUnits where prettyA = ppExUnits
 
 ppCostModel :: CostModel -> PDoc
-ppCostModel (CostModelV1 m _) =
-  ppSexp "CostModelV1" [ppMap text ppInteger m]
-ppCostModel (CostModelV2 m _) =
-  ppSexp "CostModelV2" [ppMap text ppInteger m]
+ppCostModel cm =
+  ppSexp "CostModel" [ppLanguage (getCostModelLanguage cm), ppMap text ppInteger (getCostModelParams cm)]
 
 instance PrettyA CostModel where prettyA = ppCostModel
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY, AlonzoBbodyPredFail (..))
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (..), UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModel (..), CostModels (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), mkCostModel)
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Tx
   ( IsValid (..),
@@ -132,7 +132,7 @@ import qualified Data.UMap as UM
 import GHC.Stack
 import Numeric.Natural (Natural)
 import qualified Plutus.V1.Ledger.Api as Plutus
-import Plutus.V1.Ledger.EvaluationContext (costModelParamsForTesting, mkEvaluationContext)
+import Plutus.V1.Ledger.EvaluationContext (costModelParamsForTesting)
 import Test.Cardano.Ledger.Generic.Fields
   ( PParamsField (..),
     TxBodyField (..),
@@ -167,16 +167,15 @@ testSystemStart = SystemStart $ posixSecondsToUTCTime 0
 
 -- | A cost model that sets everything as being free
 freeCostModelV1 :: CostModel
-freeCostModelV1 = CostModelV1 zeroValuedParams (fromJust $ mkEvaluationContext zeroValuedParams)
-  where
-    zeroValuedParams = 0 <$ costModelParamsForTesting
+freeCostModelV1 =
+  fromRight (error "corrupt freeCostModelV1") $
+    mkCostModel PlutusV1 (0 <$ costModelParamsForTesting)
 
 -- | A cost model that sets everything as being free
 freeCostModelV2 :: CostModel
-freeCostModelV2 = CostModelV1 zeroValuedParams (fromJust $ mkEvaluationContext zeroValuedParams)
-  where
-    costModelParamsForTestingPV2 = costModelParamsForTesting -- TODO use PV2 when it exists
-    zeroValuedParams = 0 <$ costModelParamsForTestingPV2
+freeCostModelV2 =
+  fromRight (error "corrupt freeCostModelV1") $
+    mkCostModel PlutusV1 (0 <$ costModelParamsForTesting) -- TODO use PV2 when it exists
 
 defaultPPs :: [PParamsField era]
 defaultPPs =


### PR DESCRIPTION
The `CostModel` constructor should have been hidden when the `EvaluationContext` was added to it, `costModelParamsToCostModel` is the appropriate smart constructor that everyone should use. The evaluation
context is completely dependent on the cost model parameters.