### PR TITLE
Unit tests for the Plutus txinfo translation in the Babbage era

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -100,6 +100,7 @@ data TranslationError
   | LanguageNotSupported
   | InlineDatumsNotSupported
   | ReferenceScriptsNotSupported
+  | ReferenceInputsNotSupported
   deriving (Eq, Show, Generic, NoThunks)
 
 instance ToCBOR TranslationError where
@@ -111,6 +112,7 @@ instance ToCBOR TranslationError where
   toCBOR LanguageNotSupported = encode $ Sum LanguageNotSupported 5
   toCBOR InlineDatumsNotSupported = encode $ Sum InlineDatumsNotSupported 6
   toCBOR ReferenceScriptsNotSupported = encode $ Sum ReferenceScriptsNotSupported 7
+  toCBOR ReferenceInputsNotSupported = encode $ Sum ReferenceInputsNotSupported 8
 
 instance FromCBOR TranslationError where
   fromCBOR = decode (Summands "TranslationError" dec)
@@ -123,6 +125,7 @@ instance FromCBOR TranslationError where
       dec 5 = SumD LanguageNotSupported
       dec 6 = SumD InlineDatumsNotSupported
       dec 7 = SumD ReferenceScriptsNotSupported
+      dec 8 = SumD ReferenceInputsNotSupported
       dec n = Invalid n
 
 transDataHash :: StrictMaybe (DataHash c) -> Maybe PV1.DatumHash

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -268,26 +268,3 @@ instance
   where
   wrapFailed = id
   wrapEvent = WrappedShelleyEraEvent . UtxoEvent
-
-{-
--- | In orer to reuse the AlonzoLEDGER STS instance we need to embed this UTXOW instance into it.
-instance ( ConcreteBabbage era
-         , Signal (Core.EraRule "UTXO" era) ~ ValidatedTx era
-         , State (Core.EraRule "UTXO" era) ~ UTxOState era
-         , Environment (Core.EraRule "UTXO" era) ~ UtxoEnv era
-         , Signable (DSIGN (Crypto era)) (Hash (HASH (Crypto era)) EraIndependentTxBody)
-         , Eq (PredicateFailure (Core.EraRule "UTXOS" era))
-         , Show (PredicateFailure (Core.EraRule "UTXOS" era))
-         , Embed (Core.EraRule "UTXO" era) (BabbageUTXOW era)
-         , ValidateAuxiliaryData era (Crypto era)
-         , ValidateScript era
-      --   , PredicateFailure (Core.EraRule "UTXOW" era) ~ BabbageUtxoPred era
-         , Event (Core.EraRule "UTXOW" era) ~ AlonzoEvent era
-         ) =>
-         Embed (BabbageUTXOW era) (AlonzoLEDGER era) where
-  wrapFailed =  foo -- FromAlonzoUtxowFail . UtxowFailure
-  wrapEvent = UtxowEvent
-
-foo :: BabbageUtxoPred era -> LedgerPredicateFailure era
-foo _ = undefined
--}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Control.Monad (unless)
 import qualified Data.Compact.SplitMap as SplitMap
 import qualified Data.Map as Map
 import Data.Sequence.Strict (StrictSeq)
@@ -191,6 +192,7 @@ babbageTxInfo pp lang ei sysS utxo tx = do
   pure $
     case lang of
       PlutusV1 -> do
+        unless (Set.null $ getField @"referenceInputs" tbody) (Left ReferenceInputsNotSupported)
         inputs <- mapM (txInfoInV1 utxo) (Set.toList (getField @"inputs" tbody))
         outputs <- mapM txInfoOutV1 (foldr (:) [] outs)
         pure . TxInfoPV1 $

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -78,7 +78,8 @@ test-suite cardano-ledger-babbage-test
     test
   other-modules:
     Test.Cardano.Ledger.Babbage.Serialisation.Tripping,
-    Test.Cardano.Ledger.Babbage.Serialisation.CDDL
+    Test.Cardano.Ledger.Babbage.Serialisation.CDDL,
+    Test.Cardano.Ledger.Babbage.TxInfo
   build-depends:
     QuickCheck,
     base16-bytestring,
@@ -98,6 +99,7 @@ test-suite cardano-ledger-babbage-test
     cardano-protocol-tpraos,
     cardano-slotting,
     cborg,
+    compact-map,
     containers,
     data-default-class,
     plutus-core,

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -1,0 +1,252 @@
+module Test.Cardano.Ledger.Babbage.TxInfo where
+
+import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
+import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData)
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.PParams ()
+import Cardano.Ledger.Alonzo.Tx (IsValid (..), ValidatedTx (..))
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..), VersionedTxInfo (..), txInfo)
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.TxBody (Datum (..), TxBody (..), TxOut (..))
+import Cardano.Ledger.Babbage.TxInfo (OutputSource (..), txInfoInV2, txInfoOutV2)
+import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (StakeReference (..))
+import Cardano.Ledger.Shelley.TxBody (Wdrl (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxIn (..), mkTxInPartial)
+import qualified Cardano.Ledger.Val as Val
+import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
+import Cardano.Slotting.Slot (EpochSize (..))
+import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
+import qualified Data.Compact.SplitMap as SplitMap
+import Data.Default.Class (def)
+import Data.Either (fromRight)
+import Data.Functor.Identity (Identity, runIdentity)
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import qualified Plutus.V1.Ledger.Api as Plutus
+import qualified Plutus.V2.Ledger.Api as PV2
+import Test.Cardano.Ledger.Alonzo.Scripts (alwaysSucceeds)
+import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
+import Test.Cardano.Ledger.Shelley.Address.Bootstrap (aliceByronAddr)
+import Test.Cardano.Ledger.Shelley.Examples.Cast (alicePHK)
+import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase, (@?=))
+
+byronAddr :: Addr StandardCrypto
+byronAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
+
+shelleyAddr :: Addr StandardCrypto
+shelleyAddr = Addr Testnet alicePHK StakeRefNull
+
+ei :: EpochInfo Identity
+ei = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
+
+ss :: SystemStart
+ss = SystemStart $ posixSecondsToUTCTime 0
+
+type B = BabbageEra StandardCrypto
+
+-- This input is only a "Byron input" in the sense
+-- that we attach it to a Byron output in the UTxO created below.
+byronInput :: TxIn StandardCrypto
+byronInput = mkTxInPartial genesisId 0
+
+-- This input is only unknown in the sense
+-- that it is not present in the UTxO created below.
+unknownInput :: TxIn StandardCrypto
+unknownInput = mkTxInPartial genesisId 1
+
+byronOutput :: TxOut B
+byronOutput = TxOut byronAddr (Val.inject $ Coin 1) NoDatum SNothing
+
+shelleyOutput :: TxOut B
+shelleyOutput = TxOut shelleyAddr (Val.inject $ Coin 2) NoDatum SNothing
+
+datumEx :: Datum B
+datumEx = Datum . dataToBinaryData . Data . Plutus.I $ 123
+
+inlineDatumOutput :: TxOut B
+inlineDatumOutput = TxOut shelleyAddr (Val.inject $ Coin 3) datumEx SNothing
+
+refScriptOutput :: TxOut B
+refScriptOutput = TxOut shelleyAddr (Val.inject $ Coin 3) NoDatum (SJust $ alwaysSucceeds PlutusV2 3)
+
+-- This input is only a "Shelley input" in the sense
+-- that we attach it to a Shelley output in the UTxO created below.
+shelleyInput :: TxIn StandardCrypto
+shelleyInput = mkTxInPartial genesisId 2
+
+inputWithInlineDatum :: TxIn StandardCrypto
+inputWithInlineDatum = mkTxInPartial genesisId 3
+
+inputWithRefScript :: TxIn StandardCrypto
+inputWithRefScript = mkTxInPartial genesisId 4
+
+utxo :: UTxO B
+utxo =
+  UTxO $
+    SplitMap.fromList
+      [ (byronInput, byronOutput),
+        (shelleyInput, shelleyOutput),
+        (inputWithInlineDatum, inlineDatumOutput),
+        (inputWithRefScript, refScriptOutput)
+      ]
+
+txb :: TxIn StandardCrypto -> Maybe (TxIn StandardCrypto) -> TxOut B -> TxBody B
+txb i mRefInp o =
+  TxBody
+    (Set.singleton i) -- spend inputs
+    mempty -- collateral inputs
+    ( case mRefInp of
+        Nothing -> mempty
+        Just ri -> (Set.singleton ri) -- referenceInputs inputs
+    )
+    (StrictSeq.singleton o) -- outputs
+    SNothing -- collateral output
+    (Coin 0) -- total collateral
+    mempty -- certs
+    (Wdrl mempty) -- withdrawals
+    (Coin 2) -- txfee
+    (ValidityInterval SNothing SNothing) -- validity interval
+    SNothing -- updates
+    mempty -- required signers
+    mempty -- mint
+    SNothing -- script integrity hash
+    SNothing -- auxiliary data hash
+    SNothing -- network ID
+
+txBare :: TxIn StandardCrypto -> TxOut B -> ValidatedTx B
+txBare i o = ValidatedTx (txb i Nothing o) mempty (IsValid True) SNothing
+
+txRefInput :: ValidatedTx B
+txRefInput = ValidatedTx (txb shelleyInput (Just shelleyInput) shelleyOutput) mempty (IsValid True) SNothing
+
+hasReferenceInput :: VersionedTxInfo -> Bool
+hasReferenceInput (TxInfoPV1 _) = False
+hasReferenceInput (TxInfoPV2 info) = (PV2.txInfoReferenceInputs info) /= mempty
+
+expectOneInput :: PV2.TxInInfo -> VersionedTxInfo -> Bool
+expectOneInput _ (TxInfoPV1 _) = False
+expectOneInput i (TxInfoPV2 info) = (PV2.txInfoInputs info) == [i]
+
+expectOneOutput :: PV2.TxOut -> VersionedTxInfo -> Bool
+expectOneOutput _ (TxInfoPV1 _) = False
+expectOneOutput o (TxInfoPV2 info) = (PV2.txInfoOutputs info) == [o]
+
+successfulTranslation :: Language -> ValidatedTx B -> (VersionedTxInfo -> Bool) -> Assertion
+successfulTranslation lang tx f =
+  case ctx of
+    Right info -> assertBool "unexpected transaction info" (f info)
+    Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
+  where
+    ctx = runIdentity $ txInfo def lang ei ss utxo tx
+
+successfulV2Translation :: ValidatedTx B -> (VersionedTxInfo -> Bool) -> Assertion
+successfulV2Translation = successfulTranslation PlutusV2
+
+expectTranslationError :: Language -> ValidatedTx B -> TranslationError -> Assertion
+expectTranslationError lang tx expected =
+  case ctx of
+    Right _ -> error "This translation was expected to fail, but it succeeded."
+    Left e -> e @?= expected
+  where
+    ctx = runIdentity $ txInfo def lang ei ss utxo tx
+
+expectV1TranslationError :: ValidatedTx B -> TranslationError -> Assertion
+expectV1TranslationError = expectTranslationError PlutusV1
+
+expectV2TranslationError :: ValidatedTx B -> TranslationError -> Assertion
+expectV2TranslationError = expectTranslationError PlutusV2
+
+translatedInputEx1 :: PV2.TxInInfo
+translatedInputEx1 = fromRight (error "translatedInputEx1 failed") (txInfoInV2 utxo inputWithInlineDatum)
+
+translatedInputEx2 :: PV2.TxInInfo
+translatedInputEx2 = fromRight (error "translatedInputEx2 failed") (txInfoInV2 utxo inputWithRefScript)
+
+translatedOutputEx1 :: PV2.TxOut
+translatedOutputEx1 = fromRight (error "translatedOutputEx1 failed") (txInfoOutV2 OutputFromOutput inlineDatumOutput)
+
+translatedOutputEx2 :: PV2.TxOut
+translatedOutputEx2 = fromRight (error "translatedOutputEx2 failed") (txInfoOutV2 OutputFromOutput refScriptOutput)
+
+txInfoTests :: TestTree
+txInfoTests =
+  testGroup
+    "txInfo translation"
+    [ testGroup
+        "Plutus V1"
+        [ testCase "translation error on byron txout" $
+            expectV1TranslationError
+              (txBare shelleyInput byronOutput)
+              ByronOutputInContext,
+          testCase "translation error on byron txin" $
+            expectV1TranslationError
+              (txBare byronInput shelleyOutput)
+              ByronInputInContext,
+          testCase "translation error on unknown txin (logic error)" $
+            expectV1TranslationError
+              (txBare unknownInput shelleyOutput)
+              TranslationLogicErrorInput,
+          testCase "translation error on reference input" $
+            expectV1TranslationError
+              txRefInput
+              ReferenceInputsNotSupported,
+          testCase "translation error on inline datum in input" $
+            expectV1TranslationError
+              (txBare inputWithInlineDatum shelleyOutput)
+              InlineDatumsNotSupported,
+          testCase "translation error on inline datum in output" $
+            expectV1TranslationError
+              (txBare shelleyInput inlineDatumOutput)
+              InlineDatumsNotSupported,
+          testCase "translation error on reference script in input" $
+            expectV1TranslationError
+              (txBare inputWithRefScript shelleyOutput)
+              ReferenceScriptsNotSupported,
+          testCase "translation error on reference script in output" $
+            expectV1TranslationError
+              (txBare shelleyInput refScriptOutput)
+              ReferenceScriptsNotSupported
+        ],
+      testGroup
+        "Plutus V2"
+        [ testCase "translation error on byron txout" $
+            expectV2TranslationError
+              (txBare shelleyInput byronOutput)
+              ByronOutputInContext,
+          testCase "translation error on byron txin" $
+            expectV2TranslationError
+              (txBare byronInput shelleyOutput)
+              ByronInputInContext,
+          testCase "translation error on unknown txin (logic error)" $
+            expectV2TranslationError
+              (txBare unknownInput shelleyOutput)
+              TranslationLogicErrorInput,
+          testCase "use reference input in Babbage" $
+            successfulV2Translation
+              txRefInput
+              hasReferenceInput,
+          testCase "use inline datum in input" $
+            successfulV2Translation
+              (txBare inputWithInlineDatum shelleyOutput)
+              (expectOneInput translatedInputEx1),
+          testCase "use inline datum in output" $
+            successfulV2Translation
+              (txBare shelleyInput inlineDatumOutput)
+              (expectOneOutput translatedOutputEx1),
+          testCase "use reference script in input" $
+            successfulV2Translation
+              (txBare inputWithRefScript shelleyOutput)
+              (expectOneInput translatedInputEx2),
+          testCase "use reference script in output" $
+            successfulV2Translation
+              (txBare shelleyInput refScriptOutput)
+              (expectOneOutput translatedOutputEx2)
+        ]
+    ]

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -100,25 +100,25 @@ utxo =
 txb :: TxIn StandardCrypto -> Maybe (TxIn StandardCrypto) -> TxOut B -> TxBody B
 txb i mRefInp o =
   TxBody
-    (Set.singleton i) -- spend inputs
-    mempty -- collateral inputs
-    ( case mRefInp of
+    { inputs = Set.singleton i,
+      collateral = mempty,
+      referenceInputs = case mRefInp of
         Nothing -> mempty
-        Just ri -> (Set.singleton ri) -- referenceInputs inputs
-    )
-    (StrictSeq.singleton o) -- outputs
-    SNothing -- collateral output
-    (Coin 0) -- total collateral
-    mempty -- certs
-    (Wdrl mempty) -- withdrawals
-    (Coin 2) -- txfee
-    (ValidityInterval SNothing SNothing) -- validity interval
-    SNothing -- updates
-    mempty -- required signers
-    mempty -- mint
-    SNothing -- script integrity hash
-    SNothing -- auxiliary data hash
-    SNothing -- network ID
+        Just ri -> Set.singleton ri,
+      outputs = StrictSeq.singleton o,
+      collateralReturn = SNothing,
+      totalCollateral = Coin 0,
+      txcerts = mempty,
+      txwdrls = Wdrl mempty,
+      txfee = Coin 2,
+      txvldt = ValidityInterval SNothing SNothing,
+      txUpdates = SNothing,
+      reqSignerHashes = mempty,
+      mint = mempty,
+      scriptIntegrityHash = SNothing,
+      adHash = SNothing,
+      txnetworkid = SNothing
+    }
 
 txBare :: TxIn StandardCrypto -> TxOut B -> ValidatedTx B
 txBare i o = ValidatedTx (txb i Nothing o) mempty (IsValid True) SNothing
@@ -152,7 +152,7 @@ successfulV2Translation = successfulTranslation PlutusV2
 expectTranslationError :: Language -> ValidatedTx B -> TranslationError -> Assertion
 expectTranslationError lang tx expected =
   case ctx of
-    Right _ -> error "This translation was expected to fail, but it succeeded."
+    Right _ -> assertFailure "This translation was expected to fail, but it succeeded."
     Left e -> e @?= expected
   where
     ctx = runIdentity $ txInfo def lang ei ss utxo tx

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -128,15 +128,15 @@ txRefInput = ValidatedTx (txb shelleyInput (Just shelleyInput) shelleyOutput) me
 
 hasReferenceInput :: VersionedTxInfo -> Bool
 hasReferenceInput (TxInfoPV1 _) = False
-hasReferenceInput (TxInfoPV2 info) = (PV2.txInfoReferenceInputs info) /= mempty
+hasReferenceInput (TxInfoPV2 info) = PV2.txInfoReferenceInputs info /= mempty
 
 expectOneInput :: PV2.TxInInfo -> VersionedTxInfo -> Bool
 expectOneInput _ (TxInfoPV1 _) = False
-expectOneInput i (TxInfoPV2 info) = (PV2.txInfoInputs info) == [i]
+expectOneInput i (TxInfoPV2 info) = PV2.txInfoInputs info == [i]
 
 expectOneOutput :: PV2.TxOut -> VersionedTxInfo -> Bool
 expectOneOutput _ (TxInfoPV1 _) = False
-expectOneOutput o (TxInfoPV2 info) = (PV2.txInfoOutputs info) == [o]
+expectOneOutput o (TxInfoPV2 info) = PV2.txInfoOutputs info == [o]
 
 successfulTranslation :: Language -> ValidatedTx B -> (VersionedTxInfo -> Bool) -> Assertion
 successfulTranslation lang tx f =

--- a/eras/babbage/test-suite/test/Tests.hs
+++ b/eras/babbage/test-suite/test/Tests.hs
@@ -10,6 +10,7 @@ module Main where
 
 import qualified Test.Cardano.Ledger.Babbage.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Babbage.Serialisation.Tripping as Tripping
+import Test.Cardano.Ledger.Babbage.TxInfo (txInfoTests)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
 
@@ -26,6 +27,7 @@ mainTests =
   testGroup
     "Babbage tests"
     [ Tripping.tests,
+      txInfoTests,
       CDDL.tests 5
     ]
 
@@ -34,6 +36,7 @@ fastTests =
   testGroup
     "Babbage tests"
     [ Tripping.tests,
+      txInfoTests,
       CDDL.tests 1
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -65,7 +65,6 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
     freeCostModelV1,
     freeCostModelV2,
     keyBy,
-    scriptStakeCredSuceed,
     testUTXOW,
     trustMeP,
   )
@@ -173,7 +172,7 @@ referenceScriptOutput2 pf =
     pf
     [ Address (plainAddr pf),
       Amount (inject $ Coin 5000),
-      RefScript (SJust $ always 2 pf)
+      RefScript (SJust $ alwaysAlt 2 pf)
     ]
 
 referenceDataHashOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
@@ -529,7 +528,7 @@ redeemersEx7 =
   Redeemers $
     Map.singleton (RdmrPtr Tag.Cert 0) (redeemerExample1, ExUnits 5000 5000)
 
-refScriptForDelegCertTxBody :: Scriptic era => Proof era -> Core.TxBody era
+refScriptForDelegCertTxBody :: forall era. Scriptic era => Proof era -> Core.TxBody era
 refScriptForDelegCertTxBody pf =
   newTxBody
     pf
@@ -537,10 +536,12 @@ refScriptForDelegCertTxBody pf =
       RefInputs' [referenceScriptInput2],
       Collateral' [collateralInput11],
       Outputs' [outEx7 pf],
-      Certs' [DCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)],
+      Certs' [DCertDeleg (DeRegKey cred)],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemersEx7 mempty)
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] redeemersEx7 mempty)
     ]
+  where
+    cred = ScriptHashObj (hashScript @era $ alwaysAlt 2 pf)
 
 refScriptForDelegCertTx ::
   forall era.


### PR DESCRIPTION
Analogously to the Alonzo tests [here](https://github.com/input-output-hk/cardano-ledger/blob/cd802efa11f22ad5b774b1addf4cffe4479f8d38/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs), this PR adds unit tests for the txinfo translation in the Babbage era.

This PR also fixes two bugs:
* we were not yielding a translation error for Plutus V1 scripts inside of transactions that used reference inputs.
* we were returning a very misleading error when translating an input whose corresponding output was from Byron. (It was previously returning `ByronOutputInContext` for both cases).

These tests cover (at a better level, I would argue) the last two tests in  #2471.