### PR TITLE
Define 'GetLedgerView' for Babbage.

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -107,3 +107,6 @@ cradle:
 
     - path: "libs/cardano-ledger-pretty/src"
       component: "lib:cardano-ledger-pretty"
+
+    - path: "libs/cardano-protocol-tpraos"
+      component: "lib:cardano-protocol-tpraos"

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -51,6 +51,7 @@ library
     cardano-binary,
     cardano-crypto-class,
     cardano-ledger-alonzo,
+    cardano-ledger-babbage,
     cardano-ledger-core,
     cardano-ledger-shelley,
     cardano-ledger-shelley-ma,


### PR DESCRIPTION
This instance is a little (well, a lot) suspicious, since we don't
actually have extra entropy in Babbage. We rely on the fact that this
type is only used to construct the `Praos` ledger view, which is much
simler (it looks like this:

```
data LedgerView crypto = LedgerView
  { -- | Stake distribution
    lvPoolDistr     :: SL.PoolDistr crypto,
    -- | Maximum header size
    lvMaxHeaderSize :: !Natural,
    -- | Maximum block body size
    lvMaxBodySize   :: !Natural
  }
  deriving (Show)
```
). So the `error` field will be thrown away without being evaluated.

At some point we should make this situation better, but not before the
Vasil HF.