### PR TITLE
Set TranslationContext for Babbage to AlonzoGenesis. 

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -15,6 +15,7 @@ import Cardano.Binary
   ( DecoderError,
   )
 import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo (TxOut (..))
@@ -56,7 +57,7 @@ import qualified Cardano.Ledger.Shelley.API as API
 
 type instance PreviousEra (BabbageEra c) = AlonzoEra c
 
-type instance TranslationContext (BabbageEra c) = ()
+type instance TranslationContext (BabbageEra c) = AlonzoGenesis
 
 instance
   (Crypto c) =>

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -47,6 +47,7 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import qualified PlutusTx as Plutus
+import qualified Test.Cardano.Ledger.Alonzo.Examples.Consensus as AlonzoLE
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
 import qualified Test.Cardano.Ledger.Mary.Examples.Consensus as MarySLE
 import qualified Test.Cardano.Ledger.Shelley.Examples.Consensus as SLE
@@ -76,7 +77,7 @@ ledgerExamplesBabbage =
       SLE.sleResultExamples = resultExamples,
       SLE.sleNewEpochState = exampleBabbageNewEpochState,
       SLE.sleChainDepState = SLE.exampleLedgerChainDepState 1,
-      SLE.sleTranslationContext = ()
+      SLE.sleTranslationContext = AlonzoLE.exampleAlonzoGenesis
     }
   where
     resultExamples =

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -205,8 +205,8 @@ instance CC.Crypto c => GetLedgerView (BabbageEra c) where
           lvExtraEntropy = error "Extra entropy is not set in the Babbage era",
           lvPoolDistr = nesPd,
           lvGenDelegs =
-            _genDelegs . _dstate
-              . _delegationState
+            _genDelegs . dpsDState
+              . lsDPState
               $ esLState nesEs,
           lvChainChecks = pparamsToChainChecksPParams . esPp $ nesEs
         }


### PR DESCRIPTION
This is a bit wrong, but makes downstream integration much easier. The
translation context is a diff from the previous era, whereas the genesis
is really the delta from Shelley. However, consensus currently assumes
that these are the same thing, since they have been for all prior eras.

At some point, we should alter consensus to drop this assumption and
deal correctly with the link between these. For now, we just set Babbage
to use the Alonzo genesis for its translation context.

This PR also fixes the broken build caused by the previous merge.