### PR TITLE
The total collateral field should be a Maybe Coin

### DIFF
--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -117,7 +117,7 @@ exampleTxBodyBabbage =
         ]
     )
     (SJust collateralOutput) -- collateral return
-    (Coin 8675309) -- collateral tot
+    (SJust $ Coin 8675309) -- collateral tot
     SLE.exampleCerts -- txcerts
     ( Wdrl $
         Map.singleton

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -107,7 +107,7 @@ txb i mRefInp o =
         Just ri -> Set.singleton ri,
       outputs = StrictSeq.singleton o,
       collateralReturn = SNothing,
-      totalCollateral = Coin 0,
+      totalCollateral = SNothing,
       txcerts = mempty,
       txwdrls = Wdrl mempty,
       txfee = Coin 2,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -219,7 +219,7 @@ ppTxBody x =
       ("reference inputs", ppSet ppTxIn (referenceInputs' x)),
       ("outputs", ppStrictSeq ppTxOut (outputs' x)),
       ("collateral return", ppStrictMaybe ppTxOut (collateralReturn' x)),
-      ("total collateral", ppCoin (totalCollateral' x)),
+      ("total collateral", ppStrictMaybe ppCoin (totalCollateral' x)),
       ("certificates", ppStrictSeq ppDCert (certs' x)),
       ("withdrawals", ppWdrl (wdrls' x)),
       ("txfee", ppCoin (txfee' x)),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -585,7 +585,7 @@ collateralOutputTxBody pf =
     [ Inputs' [failsEUTxOInput],
       Collateral' [collateralInput17],
       CollateralReturn' [collateralReturn pf],
-      TotalCol (Coin 5),
+      TotalCol (SJust $ Coin 5),
       Outputs' [outEx1 pf],
       Txfee (Coin 5),
       WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemersEx1 txDatsExample2)
@@ -638,7 +638,7 @@ incorrectCollateralTotalTxBody pf =
     [ Inputs' [inlineDatumInput],
       Collateral' [collateralInput11],
       CollateralReturn' [collateralReturn pf],
-      TotalCol (Coin 6),
+      TotalCol (SJust $ Coin 6),
       Outputs' [outEx1 pf],
       Txfee (Coin 5),
       WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] validatingRedeemersEx1 mempty)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -108,7 +108,7 @@ data TxBodyField era
   | RefInputs (Set (TxIn (Crypto era)))
   | Outputs (StrictSeq (Core.TxOut era))
   | CollateralReturn (StrictMaybe (Core.TxOut era))
-  | TotalCol Coin
+  | TotalCol (StrictMaybe Coin)
   | Certs (StrictSeq (DCert (Crypto era)))
   | Wdrls (Wdrl (Crypto era))
   | Txfee Coin
@@ -259,7 +259,7 @@ initialTxBody (Babbage _) =
     Set.empty
     Seq.empty
     SNothing
-    (Coin 0)
+    SNothing
     Seq.empty
     initWdrl
     (Coin 0)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -713,7 +713,7 @@ txBodyFieldSummary txb = case txb of
   (RefInputs s) -> [("RefInputs", ppInt (Set.size s))]
   (Outputs xs) -> [("Outputs", ppInt (length xs))]
   (CollateralReturn (SJust _)) -> [("Collateral Return", ppString "?")]
-  (TotalCol c) -> [("TotalCollateral", ppCoin c)]
+  (TotalCol (SJust c)) -> [("TotalCollateral", ppCoin c)]
   (Certs xs) -> [("Certs", ppInt (length xs))]
   (Wdrls x) -> [("Withdrawals", ppInt (Map.size (unWdrl x)))]
   (Vldt x) -> [("Validity interval", ppValidityInterval x)]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -707,7 +707,6 @@ genValidatedTx proof = do
           [ Inputs (Map.keysSet toSpendNoCollateral),
             Collateral bogusCollateralTxIns,
             RefInputs (Map.keysSet refInputsUtxo),
-            TotalCol (Coin 0), -- Add a bogus Coin, fill it in later
             Outputs' (rewardsWithdrawalTxOut : recipients),
             Certs' dcerts,
             Wdrls wdrls,
@@ -769,7 +768,7 @@ genValidatedTx proof = do
           txBodyNoFee
           [ Txfee fee,
             Collateral (Map.keysSet collMap),
-            TotalCol (txInBalance (Map.keysSet collMap) utxo),
+            TotalCol (SJust $ txInBalance (Map.keysSet collMap) utxo),
             WppHash mIntegrityHash
           ]
       txBodyHash = hashAnnotated txBody


### PR DESCRIPTION
The Babbage spec uses a `Maybe Coin` for the total collateral field of the transaction body, not a `Coin`, as is in the current implementation.

Using `Nothing` instead of zero to indicate that the total collateral field is not present in the transaction body is clearer and avoids edge cases.