### PR TITLE
babbage script well-formedness check

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..), ValidateScript (..))
+import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Rules.ValidationMode
   ( Inject (..),
     Test,
@@ -108,6 +109,7 @@ data BabbageUtxoPred era
   | FromAlonzoUtxowFail !(UtxowPredicateFail era)
   | UnequalCollateralReturn !Coin !Coin
   | DanglingWitnessDataHash !(Set.Set (DataHash (Crypto era)))
+  | MalformedScripts !(Set (ScriptHash (Crypto era)))
 
 deriving instance
   ( Era era,
@@ -394,6 +396,7 @@ instance
       work (FromAlonzoUtxowFail x) = Sum FromAlonzoUtxowFail 2 !> To x
       work (UnequalCollateralReturn c1 c2) = Sum UnequalCollateralReturn 3 !> To c1 !> To c2
       work (DanglingWitnessDataHash x) = Sum DanglingWitnessDataHash 4 !> To x
+      work (MalformedScripts x) = Sum MalformedScripts 5 !> To x
 
 instance
   ( Era era,
@@ -413,6 +416,7 @@ instance
       work 2 = SumD FromAlonzoUtxowFail <! From
       work 3 = SumD UnequalCollateralReturn <! From <! From
       work 4 = SumD DanglingWitnessDataHash <! From
+      work 5 = SumD MalformedScripts <! From
       work n = Invalid n
 
 deriving via InspectHeapNamed "BabbageUtxoPred" (BabbageUtxoPred era) instance NoThunks (BabbageUtxoPred era)

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -238,5 +238,6 @@ instance Mock c => Arbitrary (BabbageUtxoPred (BabbageEra c)) where
       [ FromAlonzoUtxoFail <$> arbitrary,
         FromAlonzoUtxowFail <$> arbitrary,
         UnequalCollateralReturn <$> arbitrary <*> arbitrary,
-        DanglingWitnessDataHash <$> arbitrary
+        DanglingWitnessDataHash <$> arbitrary,
+        MalformedScripts <$> arbitrary
       ]

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -144,6 +144,8 @@ ppBabbageUtxoPred (UnequalCollateralReturn c1 c2) =
     [("collateral needed", ppCoin c1), ("collateral returned", ppCoin c2)]
 ppBabbageUtxoPred (DanglingWitnessDataHash dhset) =
   ppSexp "DanglingWitnessDataHashes" [ppSet ppDataHash dhset]
+ppBabbageUtxoPred (MalformedScripts scripts) =
+  ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
 
 instance
   ( PrettyA (UtxoPredicateFailure era),


### PR DESCRIPTION
i think this small check is all that's necessary

- datums well-formedness is an invariant maintained by the wire format
- reference scripts are part of the `txscripts` set for babbage
- failedScripts are part of the `txscripts` set
- auxilliary data is checked by validateMetadata

resolves https://github.com/input-output-hk/cardano-ledger/issues/2713 