### PR TITLE
Add lower bounds to aeson

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -57,7 +57,7 @@ library
     Cardano.Ledger.Alonzo.TxWitness
     Cardano.Ledger.DescribeEras
   build-depends:
-    aeson,
+    aeson >= 2,
     array,
     base-deriving-via,
     base64-bytestring,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -85,7 +85,7 @@ library
     Cardano.Ledger.Shelley.UTxO
   hs-source-dirs: src
   build-depends:
-    aeson,
+    aeson >= 2,
     base16-bytestring >= 1,
     bytestring,
     cardano-binary,

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -171,7 +171,7 @@ test-suite cardano-ledger-shelley-test
       -- determined ad-hoc.
       "-with-rtsopts=-K4m -M250m"
   build-depends:
-      aeson,
+      aeson >= 2,
       base16-bytestring >= 1,
       binary,
       bytestring,

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -65,7 +65,7 @@ library
     Cardano.Ledger.Val
 
   build-depends:
-    aeson,
+    aeson >= 2,
     base16-bytestring,
     binary,
     bytestring,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -90,7 +90,7 @@ library
     Test.Cardano.Ledger.TestableEra
     Test.Cardano.Ledger.ValueFromList
   build-depends:
-    aeson,
+    aeson >= 2,
     array,
     bytestring,
     cardano-binary,

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -98,7 +98,7 @@ benchmark performance
   main-is:          Performance.hs
   build-depends:
     base,
-    aeson,
+    aeson >= 2,
     bytestring,
     base16-bytestring,
     cardano-binary,


### PR DESCRIPTION
The `cardano-ledger` has code which depends on `aeson >= 2`.

For example, if the solver solves with `aeson < 2` the following error occurs:

```
src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs:35:53: error:
    Module ‘Data.Aeson.Encoding.Internal’ does not export ‘key’
   |
35 | import qualified Data.Aeson.Encoding.Internal as A (key)
   |                                                     ^^^

src/Cardano/Crypto/Signing/Redeem/VerificationKey.hs:36:1: error:
    Could not load module ‘Data.Aeson.Key’
    It is a member of the hidden package ‘aeson-2.0.3.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.3.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.3.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.3.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.3.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.2.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.2.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
```