### PR TITLE
no-op: fix era name in comment

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -111,7 +111,7 @@ instance ShelleyEraCrypto c => API.ApplyBlock (BabbageEra c)
 
 instance ShelleyEraCrypto c => API.ShelleyBasedEra (BabbageEra c)
 
--- | The Alonzo era
+-- | The Babbage era
 data BabbageEra c
 
 instance


### PR DESCRIPTION
A minor thing I found while studying Babbage :).