### PR TITLE
Fix "UTxO entry too small" check.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -380,7 +380,7 @@ validateOutputTooSmallUTxO pp (UTxO outputs) =
         ( \out ->
             let v = getField @"value" out
              in -- pointwise is used because non-ada amounts must be >= 0 too
-                Val.pointwise (<) v (Val.inject $ Coin (utxoEntrySize out * coinsPerUTxOWord))
+                not $ Val.pointwise (>=) v (Val.inject $ Coin (utxoEntrySize out * coinsPerUTxOWord))
         )
         (SplitMap.elems outputs)
 


### PR DESCRIPTION
PR #2644 refactored these checks, but also made the change from `not $
Val.pointwise (>=)` to `Val.pointwise (<)`. However, since `pointwise`
is basically acting as `all` here, these checks are not equivalent. The
former will return `True` on e.g. `[0, 0] [0, 1]`, but the latter will
not (since 0 is not less than 0).

This commit restores the original test.