### PR TITLE
Introduce RestrainedRewards event

### DIFF
--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -782,7 +782,7 @@ eventsMirrorRewards events nes = same eventRew compRew
             (completed, lastevent) = complete pulser
     total = getMostRecentTotalRewardEvent events
     aggevent = aggIncrementalRewardEvents events
-    (aggFilteredEvent, _) = filterAllRewards aggevent (nesEs nes)
+    (aggFilteredEvent, _, _, _) = filterAllRewards aggevent (nesEs nes)
     same x y = withMaxSuccess 1 $ counterexample message (x === y)
       where
         message =


### PR DESCRIPTION
This gives us a way to clean up rewards on the epoch boundary to addresses that are deregistered or rewards subject to era specific issues.