### PR TITLE
CAD-4157: Stash AVVM to allow on-disk UTxO.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -164,6 +164,7 @@ instance
       )
       SNothing
       (PoolDistr Map.empty)
+      ()
     where
       initialEpochNo = 0
       initialUtxo = genesisUTxO sg

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -70,7 +70,8 @@ instance
           nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ nesEs nes,
           nesRu = nesRu nes,
-          nesPd = nesPd nes
+          nesPd = nesPd nes,
+          stashedAVVMAddresses = ()
         }
 
 instance Crypto c => TranslateEra (AlonzoEra c) ShelleyGenesis where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -169,6 +169,7 @@ instance
       )
       SNothing
       (PoolDistr Map.empty)
+      ()
     where
       initialEpochNo = 0
       initialUtxo = genesisUTxO sg

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -71,7 +71,8 @@ instance
           nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ nesEs nes,
           nesRu = nesRu nes,
-          nesPd = nesPd nes
+          nesPd = nesPd nes,
+          stashedAVVMAddresses = ()
         }
 
 instance Crypto c => TranslateEra (BabbageEra c) ShelleyGenesis where

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -72,6 +72,7 @@ instance
       )
       SNothing
       (PoolDistr Map.empty)
+      ()
     where
       initialEpochNo = 0
       initialUtxo = genesisUTxO sg

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -44,6 +44,14 @@ import qualified Data.Map.Strict as Map
 -- being total. Do not change it!
 --------------------------------------------------------------------------------
 
+-- | Return the subset of UTxO corresponding to Byron-era AVVM addresses, which
+-- are to be removed on the Shelley/Allegra boundary. This set will be passed
+-- _back_ to the translation functions as the UTxO, allowing these addresses to
+-- be removed. This is needed because we cannot do a full scan on the UTxO at
+-- this point, since it has been persisted to disk.
+shelleyToAllegraAVVMsToDelete :: NewEpochState era -> StrictMaybe (UTxO era)
+shelleyToAllegraAVVMsToDelete = stashedAVVMAddresses
+
 type instance PreviousEra (AllegraEra c) = ShelleyEra c
 
 -- | Currently no context is needed to translate from Shelley to Allegra.
@@ -62,6 +70,11 @@ instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
           nesEs = translateEra' ctxt $ LS.returnRedeemAddrsToReserves . nesEs $ nes,
           nesRu = nesRu nes,
           nesPd = nesPd nes
+        }
+        { -- At this point, the consensus layer has passed in our stashed AVVM
+          -- addresses as our UTxO, and we have deleted them above (with
+          -- 'returnRedeemAddrsToReserves'), so we may safely discard this map.
+          stashedAVVMAddresses = SNothing
         }
 
 instance forall c. Crypto c => TranslateEra (AllegraEra c) Tx where

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -49,7 +49,7 @@ import qualified Data.Map.Strict as Map
 -- _back_ to the translation functions as the UTxO, allowing these addresses to
 -- be removed. This is needed because we cannot do a full scan on the UTxO at
 -- this point, since it has been persisted to disk.
-shelleyToAllegraAVVMsToDelete :: NewEpochState era -> StrictMaybe (UTxO era)
+shelleyToAllegraAVVMsToDelete :: NewEpochState (ShelleyEra c) -> UTxO (ShelleyEra c)
 shelleyToAllegraAVVMsToDelete = stashedAVVMAddresses
 
 type instance PreviousEra (AllegraEra c) = ShelleyEra c
@@ -69,12 +69,11 @@ instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
           nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ LS.returnRedeemAddrsToReserves . nesEs $ nes,
           nesRu = nesRu nes,
-          nesPd = nesPd nes
-        }
-        { -- At this point, the consensus layer has passed in our stashed AVVM
+          nesPd = nesPd nes,
+          -- At this point, the consensus layer has passed in our stashed AVVM
           -- addresses as our UTxO, and we have deleted them above (with
           -- 'returnRedeemAddrsToReserves'), so we may safely discard this map.
-          stashedAVVMAddresses = SNothing
+          stashedAVVMAddresses = ()
         }
 
 instance forall c. Crypto c => TranslateEra (AllegraEra c) Tx where

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -65,6 +65,7 @@ instance Crypto c => CanStartFromGenesis (MaryEra c) where
       )
       SNothing
       (PoolDistr Map.empty)
+      ()
     where
       initialEpochNo = 0
       initialUtxo = genesisUTxO sg

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -67,7 +67,8 @@ instance Crypto c => TranslateEra (MaryEra c) NewEpochState where
           nesBcur = nesBcur nes,
           nesEs = translateEra' ctxt $ nesEs nes,
           nesRu = nesRu nes,
-          nesPd = nesPd nes
+          nesPd = nesPd nes,
+          stashedAVVMAddresses = ()
         }
 
 instance Crypto c => TranslateEra (MaryEra c) Tx where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -101,16 +101,15 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
       nesBcur = BlocksMade Map.empty,
       nesEs = epochState,
       nesRu = SNothing,
-      nesPd = PoolDistr Map.empty
-    }
-    { -- At this point, we compute the stashed AVVM addresses, while we are able
+      nesPd = PoolDistr Map.empty,
+      -- At this point, we compute the stashed AVVM addresses, while we are able
       -- to do a linear scan of the UTxO, and stash them away for use at the
       -- Shelley/Allegra boundary.
       stashedAVVMAddresses =
         let UTxO utxo = _utxo . lsUTxOState . esLState $ epochState
             redeemers =
               SplitMap.filter (maybe False isBootstrapRedeemer . getTxOutBootstrapAddress) utxo
-         in SJust $ UTxO redeemers
+         in UTxO redeemers
     }
   where
     pparams :: PParams (ShelleyEra c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
@@ -79,6 +79,7 @@ instance
       )
       SNothing
       (PoolDistr Map.empty)
+      (UTxO mempty)
     where
       initialEpochNo = 0
       initialUtxo = genesisUTxO sg

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -98,7 +98,8 @@ instance
     Default (EpochState era),
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     Default (State (Core.EraRule "PPUP" era)),
-    Default (Core.PParams era)
+    Default (Core.PParams era),
+    Default (StashedAVVMAddresses era)
   ) =>
   STS (NEWEPOCH era)
   where
@@ -121,6 +122,7 @@ instance
           def
           SNothing
           (PoolDistr Map.empty)
+          def
     ]
 
   transitionRules = [newEpochTransition]
@@ -141,13 +143,14 @@ newEpochTransition ::
     UsesValue era,
     Default (State (Core.EraRule "PPUP" era)),
     Default (Core.PParams era),
+    Default (StashedAVVMAddresses era),
     Event (Core.EraRule "RUPD" era) ~ RupdEvent (Crypto era)
   ) =>
   TransitionRule (NEWEPOCH era)
 newEpochTransition = do
   TRC
     ( _,
-      ~src@(NewEpochState (EpochNo eL) _ bcur es ru _pd),
+      src@(NewEpochState (EpochNo eL) _ bcur es ru _pd _),
       e@(EpochNo e_)
       ) <-
     judgmentContext

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -147,7 +147,7 @@ newEpochTransition ::
 newEpochTransition = do
   TRC
     ( _,
-      src@(NewEpochState (EpochNo eL) _ bcur es ru _pd),
+      ~src@(NewEpochState (EpochNo eL) _ bcur es ru _pd),
       e@(EpochNo e_)
       ) <-
     judgmentContext
@@ -175,13 +175,14 @@ newEpochTransition = do
       let EpochState _acnt ss _ls _pr _ _ = es'''
           pd' = calculatePoolDistr (_pstakeSet ss)
       pure $
-        NewEpochState
-          e
-          bcur
-          (BlocksMade Map.empty)
-          es'''
-          SNothing
-          pd'
+        src
+          { nesEL = e,
+            nesBprev = bcur,
+            nesBcur = BlocksMade mempty,
+            nesEs = es''',
+            nesRu = SNothing,
+            nesPd = pd'
+          }
 
 -- | tell a RupdEvent as a DeltaRewardEvent only if the map is non-empty
 tellReward :: (Event (Core.EraRule "RUPD" era) ~ RupdEvent (Crypto era)) => NewEpochEvent era -> Rule (NEWEPOCH era) rtype ()

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -179,7 +179,7 @@ bheadTransition ::
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do
-  TRC ((), ~nes@(NewEpochState _ bprev _ es _ _), slot) <-
+  TRC ((), nes@(NewEpochState _ bprev _ es _ _ _), slot) <-
     judgmentContext
 
   nes' <- validatingTickTransition @TICK nes slot

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -179,7 +179,7 @@ bheadTransition ::
   ) =>
   TransitionRule (TICK era)
 bheadTransition = do
-  TRC ((), nes@(NewEpochState _ bprev _ es _ _), slot) <-
+  TRC ((), ~nes@(NewEpochState _ bprev _ es _ _), slot) <-
     judgmentContext
 
   nes' <- validatingTickTransition @TICK nes slot

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -89,6 +89,7 @@ import Data.Coders (decodeSplitMap, encodeSplitMap)
 import Data.Coerce (coerce)
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Constraint (Constraint)
+import Data.Default.Class (Default)
 import Data.Foldable (foldMap', toList)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
@@ -108,7 +109,7 @@ import Quiet
 
 -- | The unspent transaction outputs.
 newtype UTxO era = UTxO {unUTxO :: SplitMap.SplitMap (TxIn (Crypto era)) (Core.TxOut era)}
-  deriving (Generic, Semigroup)
+  deriving (Default, Generic, Semigroup)
 
 type TransUTxO (c :: Type -> Constraint) era = (c (Core.TxOut era), TransTxId c era)
 

--- a/eras/shelley/test-suite/bench/BenchValidation.hs
+++ b/eras/shelley/test-suite/bench/BenchValidation.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Shelley.Bench.Gen (genBlock, genChainState)
 import Cardano.Ledger.Shelley.BlockChain (slotToNonce)
 import Cardano.Ledger.Shelley.LedgerState
   ( NewEpochState,
+    StashedAVVMAddresses,
     nesBcur,
   )
 import Cardano.Ledger.Shelley.TxBody (TransTxBody, TransTxId)
@@ -124,7 +125,8 @@ applyBlock ::
     TransTxBody NFData era,
     API.ApplyBlock era,
     NFData (Core.PParams era),
-    NFData (State (Core.EraRule "PPUP" era))
+    NFData (State (Core.EraRule "PPUP" era)),
+    NFData (StashedAVVMAddresses era)
   ) =>
   ValidateInput era ->
   Int ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -111,7 +111,8 @@ defaultShelleyLedgerExamples ::
     PredicateFailure (Core.EraRule "DELEGS" era)
       ~ DelegsPredicateFailure era,
     Core.PParams era ~ Cardano.Ledger.Shelley.PParams.PParams era,
-    Core.PParamsDelta era ~ PParams' StrictMaybe era
+    Core.PParamsDelta era ~ PParams' StrictMaybe era,
+    Default (StashedAVVMAddresses era)
   ) =>
   (Core.TxBody era -> KeyPairWits era -> Core.Witnesses era) ->
   (Tx era -> Core.Tx era) ->
@@ -298,7 +299,8 @@ exampleNewEpochState ::
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "_nOpt" (Core.PParams era) Natural,
     HasField "_rho" (Core.PParams era) UnitInterval,
-    HasField "_tau" (Core.PParams era) UnitInterval
+    HasField "_tau" (Core.PParams era) UnitInterval,
+    Default (StashedAVVMAddresses era)
   ) =>
   Core.Value era ->
   Core.PParams era ->
@@ -311,7 +313,8 @@ exampleNewEpochState value ppp pp =
       nesBcur = BlocksMade (Map.singleton (mkKeyHash 2) 3),
       nesEs = epochState,
       nesRu = SJust rewardUpdate,
-      nesPd = examplePoolDistr
+      nesPd = examplePoolDistr,
+      stashedAVVMAddresses = def
     }
   where
     epochState :: EpochState era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -126,7 +126,7 @@ genBlockWithTxGen
             $ selectNextSlotWithLeader ge origChainState firstConsideredSlot
 
     -- Now we need to compute the KES period and get the set of hot keys.
-    let NewEpochState _ _ _ es _ _ = chainNes chainSt
+    let NewEpochState _ _ _ es _ _ _ = chainNes chainSt
         EpochState acnt _ ls _ pp _ = es
         kp@(KESPeriod kesPeriod_) = runShelleyBase $ kesPeriod nextSlot
         cs = chainOCertIssue chainSt

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -55,7 +55,7 @@ import Cardano.Ledger.Shelley.API
     StakeReference (StakeRefBase),
   )
 import Cardano.Ledger.Shelley.Constraints (UsesPParams (..))
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses, UTxOState (..))
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl, WitVKey)
@@ -212,7 +212,8 @@ class
     PrettyA (Core.Tx era),
     PrettyA (Core.TxBody era),
     PrettyA (Core.Witnesses era),
-    PrettyA (Core.Value era)
+    PrettyA (Core.Value era),
+    Default (StashedAVVMAddresses era)
   ) =>
   EraGen era
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -74,7 +74,7 @@ import Cardano.Ledger.Shelley.Constraints
     UsesTxOut,
     UsesValue,
   )
-import Cardano.Ledger.Shelley.LedgerState (FutureGenDeleg)
+import Cardano.Ledger.Shelley.LedgerState (FutureGenDeleg, StashedAVVMAddresses)
 import qualified Cardano.Ledger.Shelley.Metadata as MD
 import Cardano.Ledger.Shelley.PoolRank
   ( Likelihood (..),
@@ -561,12 +561,12 @@ instance
     Arbitrary (Core.Value era),
     Arbitrary (Core.PParams era),
     Arbitrary (State (Core.EraRule "PPUP" era)),
+    Arbitrary (StashedAVVMAddresses era),
     EraGen era
   ) =>
   Arbitrary (NewEpochState era)
   where
   arbitrary = genericArbitraryU
-  shrink = genericShrink
 
 instance CC.Crypto crypto => Arbitrary (BlocksMade crypto) where
   arbitrary = BlocksMade <$> arbitrary

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -106,6 +106,7 @@ import Cardano.Ledger.Shelley.API
   )
 import Cardano.Ledger.Shelley.BlockChain (TxSeq)
 import Cardano.Ledger.Shelley.Constraints
+import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses)
 import Cardano.Ledger.Shelley.PParams (PParamsUpdate)
 import Cardano.Ledger.Shelley.Tx (Tx, TxOut, WitnessSet)
 import Cardano.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
@@ -173,6 +174,7 @@ type ShelleyTest era =
     Core.Witnesses era ~ WitnessSet era,
     Split (Core.Value era),
     Default (State (Core.EraRule "PPUP" era)),
+    Default (StashedAVVMAddresses era),
     Core.AnnotatedData (Core.Witnesses era)
   )
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Init.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Init.hs
@@ -107,7 +107,11 @@ nonce0 = hashHeaderToNonce (lastByronHeaderHash @c)
 -- The initial state for the examples uses the function
 -- 'initialShelleyState' with the genesis delegation
 -- 'genDelegs' and any given starting 'UTxO' set.
-initSt :: forall era. ShelleyTest era => UTxO era -> ChainState era
+initSt ::
+  forall era.
+  (ShelleyTest era) =>
+  UTxO era ->
+  ChainState era
 initSt utxo =
   initialShelleyState
     (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -147,7 +147,7 @@ import Cardano.Ledger.Shelley.TxBody
     pattern PoolParams,
     pattern RewardAcnt,
   )
-import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
+import Cardano.Ledger.Shelley.UTxO (UTxO (UTxO), makeWitnessVKey)
 import Cardano.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Cardano.Ledger.TxIn (TxId, TxIn (..))
 import Cardano.Prelude (LByteString)
@@ -1321,20 +1321,22 @@ tests =
               es
               (SJust ru)
               pd
+              (UTxO mempty)
        in checkEncodingCBOR
             "new_epoch_state"
             nes
-            ( T (TkListLen 6)
+            ( T (TkListLen 7)
                 <> S e
                 <> S (BlocksMade @C_Crypto bs)
                 <> S (BlocksMade @C_Crypto bs)
                 <> S es
                 <> S (SJust ru)
                 <> S pd
+                <> S (UTxO @(ShelleyEra C_Crypto) mempty)
             ),
       let actual = B16.encode . serialize' $ Ex.sleNewEpochState Ex.ledgerExamplesShelley
           expected =
-            "8600a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541"
+            "8700a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541"
               <> "0aa1581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a03"
               <> "86821927101903e8828283a0a0a08482a0a0a0a084a0a0000085a1825820ee155a"
               <> "ce9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e2500825839"
@@ -1345,7 +1347,7 @@ tests =
               <> "1864d81e820001d81e820001d81e820001d81e82000181000000010082a0008183"
               <> "00880082000082a000000000a0a0840185a0803903ba820000a0a082a0a0a1581c"
               <> "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418282010158"
-              <> "20c5e21ab1c9f6022d81c3b25e3436cb7f1df77f9652ae3e1310c28e621dd87b4c"
+              <> "20c5e21ab1c9f6022d81c3b25e3436cb7f1df77f9652ae3e1310c28e621dd87b4ca0"
        in testCase "ledger state golden test" (actual @?= expected)
     ]
   where

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -731,7 +731,7 @@ ppEpochState (EpochState acnt snap ls prev pp non) =
     ]
 
 ppNewEpochState :: CanPrettyPrintLedgerState era => NewEpochState era -> PDoc
-ppNewEpochState (NewEpochState enum prevB curB es rewup pool) =
+ppNewEpochState (NewEpochState enum prevB curB es rewup pool _) =
   ppRecord
     "NewEpochState"
     [ ("epochnum", ppEpochNo enum),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Properties.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses)
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
 import Cardano.Ledger.Shelley.TxBody (MIRPot (..))
 import Cardano.Ledger.Val (Val (..))
@@ -136,7 +137,8 @@ modelTestDelegations ::
     Show (Core.Script era),
     Show (Core.PParams era),
     Show (State (Core.EraRule "PPUP" era)),
-    Show (LedgerState.LedgerState era)
+    Show (LedgerState.LedgerState era),
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   Coin ->
@@ -523,7 +525,8 @@ modelGenTest ::
     Show (Core.TxOut era),
     Show (Core.Script era),
     Show (Core.PParams era),
-    Show (State (Core.EraRule "PPUP" era))
+    Show (State (Core.EraRule "PPUP" era)),
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   Property
@@ -548,7 +551,8 @@ testModelShrinking ::
     Show (Core.Script era),
     Show (Core.PParams era),
     Show (State (Core.EraRule "PPUP" era)),
-    Show (LedgerState.LedgerState era)
+    Show (LedgerState.LedgerState era),
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   Property
@@ -611,7 +615,8 @@ propertyShrinking ::
     Show (Core.PParams era),
     Show (State (Core.EraRule "PPUP" era)),
     Show (LedgerState.LedgerState era),
-    ElaborateEraModel era
+    ElaborateEraModel era,
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   (ModelGenesis (EraFeatureSet era), [ModelEpoch (EraFeatureSet era)]) ->
@@ -657,7 +662,8 @@ testDelegCombinations ::
     Show (Core.TxOut era),
     Show (Core.Script era),
     Show (Core.PParams era),
-    Show (State (Core.EraRule "PPUP" era))
+    Show (State (Core.EraRule "PPUP" era)),
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   TestTree
@@ -686,7 +692,8 @@ modelUnitTests ::
     Show (Core.TxOut era),
     Show (Core.Script era),
     Show (Core.PParams era),
-    Show (State (Core.EraRule "PPUP" era))
+    Show (State (Core.EraRule "PPUP" era)),
+    Show (StashedAVVMAddresses era)
   ) =>
   proxy era ->
   TestTree

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -196,19 +196,16 @@ instance CC.Crypto c => GetLedgerView (AlonzoEra c)
 -- because it makes it simpler to get the ledger view for Praos.
 instance CC.Crypto c => GetLedgerView (BabbageEra c) where
   currentLedgerView
-    NewEpochState
-      { nesPd,
-        nesEs
-      } =
+    NewEpochState {nesPd = pd, nesEs = es} =
       LedgerView
-        { lvD = getField @"_d" . esPp $ nesEs,
+        { lvD = getField @"_d" . esPp $ es,
           lvExtraEntropy = error "Extra entropy is not set in the Babbage era",
-          lvPoolDistr = nesPd,
+          lvPoolDistr = pd,
           lvGenDelegs =
             _genDelegs . dpsDState
               . lsDPState
-              $ esLState nesEs,
-          lvChainChecks = pparamsToChainChecksPParams . esPp $ nesEs
+              $ esLState es,
+          lvChainChecks = pparamsToChainChecksPParams . esPp $ es
         }
 
   futureLedgerView globals ss slot =
@@ -264,18 +261,18 @@ view ::
   LedgerView (Crypto era)
 view
   NewEpochState
-    { nesPd,
-      nesEs
+    { nesPd = pd,
+      nesEs = es
     } =
     LedgerView
-      { lvD = getField @"_d" . esPp $ nesEs,
-        lvExtraEntropy = getField @"_extraEntropy" . esPp $ nesEs,
-        lvPoolDistr = nesPd,
+      { lvD = getField @"_d" . esPp $ es,
+        lvExtraEntropy = getField @"_extraEntropy" . esPp $ es,
+        lvPoolDistr = pd,
         lvGenDelegs =
           _genDelegs . dpsDState
             . lsDPState
-            $ esLState nesEs,
-        lvChainChecks = pparamsToChainChecksPParams . esPp $ nesEs
+            $ esLState es,
+        lvChainChecks = pparamsToChainChecksPParams . esPp $ es
       }
 
 -- $timetravel


### PR DESCRIPTION
This commit provides ledger support for the transition of UTxO to
on-disk storage. In particular, the translation between Shelley and
Allegra is currently problematic, owing to the need to remove AVVM
addresses (dormant since Byron) from the UTxO. This requires a linear
scan of the UTxO, which is now stored on disk and hence cannot/should
not be accessed in such a way.

The solution to this is a bit of a hack; since the Byron UTxO are not
stored on disk, and since AVVM addresses remain untouched during the
Shelley era, we instead perform the scan at the Byron/Shelley boundary,
store the set of UTxO in the ledger state, only to yield them to the
consensus layer at the Shelley/Allegra boundary. Thus provided with the
set of addresses, consensus passes them back as the UTxO, allowing the
translation function to delete them.

This change is written such that, with no on-disk UTxO, the ledger
functionality remains identical, other than a slight bump in memory
usage during the Shelley era.

As far as possible, this commit minimises ledger changes. Thus, a
pattern is introduced replicating the existing `NewEpochState`
constructor. Unfortunately, there are two knock-on effects related to
weaknesses in pattern synonyms:

- A couple of patterns matching on `NewEpochState` now seem to be
  failable. Since they cannot fail, we instead make them irrefutable.
- Record fields associated with pattern synonyms do not play nicely with
  `NamedFieldPuns`. As such, we replace a couple of puns with explicit
  bindings.

A single additional function `shelleyToAllegraAVVMsToDelete` is exported
for the use of the consensus layer. Otherwise no API changes are made.

This does entail a change in the ledger state serialisation format.