### PR TITLE
do not serialize the block header to get the size

### DIFF
--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -103,7 +103,6 @@ import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
 import Cardano.Protocol.TPraos.OCert (OCert (..))
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Control.DeepSeq (NFData)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Builder.Extra as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -358,12 +357,8 @@ prevHashToNonce = \case
 issuerIDfromBHBody :: CC.Crypto crypto => BHBody crypto -> KeyHash 'BlockIssuer crypto
 issuerIDfromBHBody = hashKey . bheaderVk
 
-bHeaderSize ::
-  forall crypto.
-  (CC.Crypto crypto) =>
-  BHeader crypto ->
-  Int
-bHeaderSize = BS.length . serialize'
+bHeaderSize :: forall crypto. BHeader crypto -> Int
+bHeaderSize = fromIntegral . BSL.length . bHeaderBytes
 
 bhbody ::
   CC.Crypto crypto =>


### PR DESCRIPTION
The block header already stores its serialized bytes, it is a big waste to recompute it in order to get the size.

Many thanks to @RyanGlScott for spotting this!! :raised_hands: 