### PR TITLE
base Babbage min UTxO value on serialized bytes

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -9,6 +9,7 @@
 --   Babbage Specification
 module Cardano.Ledger.Babbage.Collateral where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Tx (isTwoPhaseScriptAddressFromMap)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (txscripts))
@@ -64,7 +65,8 @@ collBalance ::
   forall era.
   ( Era era,
     HasField "collateralReturn" (Core.TxBody era) (StrictMaybe (TxOut era)),
-    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era)))
+    HasField "collateral" (Core.TxBody era) (Set (TxIn (Crypto era))),
+    ToCBOR (Core.Script era)
   ) =>
   Core.TxBody era ->
   UTxO era ->

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -8,6 +8,7 @@
 
 module Cardano.Ledger.Babbage.Rules.Utxow where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Crypto.DSIGN.Class (Signable)
 import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Alonzo.Data (DataHash)
@@ -97,7 +98,9 @@ babbageMissingScripts pp sNeeded sReceived =
 
 {- dom(txdats txw) ⊆ inputHashes ∪ {h | ( , , h) ∈ txouts tx ∪ utxo (refInputs tx)  -}
 danglingWitnessDataHashes ::
-  Era era =>
+  ( Era era,
+    ToCBOR (Core.Script era)
+  ) =>
   Set.Set (DataHash (Crypto era)) ->
   (Alonzo.TxDats era) ->
   [TxOut era] ->

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -10,6 +10,7 @@
 --   Babbage Specification
 module Cardano.Ledger.Babbage.Scripts where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Alonzo.Data (BinaryData, dataToBinaryData)
 import Cardano.Ledger.Alonzo.Tx
   ( ScriptPurpose (..),
@@ -47,7 +48,8 @@ getTxIn (Certifying _dcert) = Nothing
 getDatum ::
   ( Era era,
     Core.TxOut era ~ TxOut era,
-    Core.Witnesses era ~ TxWitness era
+    Core.Witnesses era ~ TxWitness era,
+    ToCBOR (Core.Script era)
   ) =>
   Core.Tx era ->
   UTxO era ->
@@ -141,7 +143,8 @@ babbageInputDataHashes ::
   forall era.
   ( HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     ValidateScript era,
-    Core.TxOut era ~ TxOut era
+    Core.TxOut era ~ TxOut era,
+    ToCBOR (Core.Script era)
   ) =>
   Map.Map (ScriptHash (Crypto era)) (Core.Script era) ->
   ValidatedTx era ->

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -14,6 +14,8 @@
 module Test.Cardano.Ledger.Babbage.Serialisation.Generators where
 
 -- instances
+
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), BinaryData, Data (..), dataToBinaryData)
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
@@ -64,6 +66,7 @@ instance
   ( Era era,
     UsesValue era,
     Mock (Crypto era),
+    ToCBOR (Core.Script era),
     Arbitrary (Core.Value era),
     Arbitrary (Core.Script era)
   ) =>

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -41,6 +41,7 @@ library
   build-depends:
     bech32,
     bytestring,
+    cardano-binary,
     cardano-crypto-class,
     cardano-data,
     cardano-ledger-alonzo,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -10,6 +10,7 @@
 
 module Cardano.Ledger.Pretty.Babbage where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Alonzo.Data (BinaryData, DataHash, binaryDataToData)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail)
@@ -159,6 +160,7 @@ ppTxOut ::
   forall era.
   ( Era era,
     ValidateScript era,
+    ToCBOR (Core.Script era),
     PrettyA (Core.Script era),
     PrettyA (Core.Value era)
   ) =>
@@ -180,6 +182,7 @@ ppTxOut (TxOut addr val datum mscript) =
 instance
   ( Era era,
     ValidateScript era,
+    ToCBOR (Core.Script era),
     PrettyA (Core.Script era),
     PrettyA (Core.Value era)
   ) =>
@@ -206,6 +209,7 @@ instance PrettyA (DataHash era) where prettyA = ppDataHash
 
 ppTxBody ::
   ( ValidateScript era,
+    ToCBOR (Core.Script era),
     PrettyA (Core.Value era),
     PrettyA (Core.PParamsDelta era),
     PrettyA (Core.Script era)
@@ -237,6 +241,7 @@ ppTxBody x =
 instance
   ( Era era,
     ValidateScript era,
+    ToCBOR (Core.Script era),
     PrettyA (Core.Value era),
     PrettyA (Core.PParamsDelta era),
     PrettyA (Core.Script era)


### PR DESCRIPTION
In the Babbage era, the minimum lovelace required for an output is based on the serialized bytes.

To accomplish this, I've added a `Word64` to each of the `TxOut` constructors. The `TxOut` pattern automatically fills in this value. Note also that this value is not a part of the wire specification, but is added on deserialization.

closes #2682 