### PR TITLE
do not allow encoding NoDatum, instead omit it

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -270,16 +270,15 @@ data Datum era
 
 instance Era era => ToCBOR (Datum era) where
   toCBOR d = encode $ case d of
-    NoDatum -> Sum NoDatum 0
-    DatumHash dh -> Sum DatumHash 1 !> To dh
-    Datum d' -> Sum Datum 2 !> To d'
+    DatumHash dh -> Sum DatumHash 0 !> To dh
+    Datum d' -> Sum Datum 1 !> To d'
+    NoDatum -> OmitC NoDatum
 
 instance Era era => FromCBOR (Datum era) where
   fromCBOR = decode (Summands "Datum" decodeDatum)
     where
-      decodeDatum 0 = SumD NoDatum
-      decodeDatum 1 = SumD DatumHash <! From
-      decodeDatum 2 = SumD Datum <! From
+      decodeDatum 0 = SumD DatumHash <! From
+      decodeDatum 1 = SumD Datum <! From
       decodeDatum k = Invalid k
 
 datumDataHash :: Datum era -> StrictMaybe (DataHash (Crypto era))

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -404,7 +404,7 @@ pool_metadata_hash    = $hash32
 datum_hash = $hash32
 data = #6.24(bytes .cbor plutus_data)
 
-datum = [ 0 // 1, $hash32 // 2, data ]
+datum = [ 0, $hash32 // 1, data ]
 
 script_ref = #6.24(bytes .cbor script)
 


### PR DESCRIPTION
The `NoDatum` constructor of the `Datum` type is really an implementation detail and not something that we should be exposing on the wire format. If there is no datum present, the entire field (inside the transaction output) should be omitted, which is what our serializers do anyway.

~It is unfortunate that the `Datum` serializer is now partial, but I think it is still worth it.~ `OmitC` to the rescue, thanks for the suggestion @lehins !