### PR TITLE
Whitenoise generators without EraGen

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -861,7 +861,6 @@ genBlock ::
   Gen (Block h era)
 genBlock = Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary)
 
-
 -- | For some purposes, a totally random block generator may not be suitable.
 -- There are tests in the ouroboros-network repository, for instance, that
 -- perform some integrity checks on the generated blocks.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -141,15 +141,11 @@ import Numeric.Natural (Natural)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Ledger.Shelley.Generator.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core
-  ( KeySpace (KeySpace_),
-    geKeySpace,
-    ksCoreNodes,
-    mkBlock,
+  ( mkBlock,
     mkBlockHeader,
     mkOCert,
   )
-import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen)
-import Test.Cardano.Ledger.Shelley.Generator.Presets (coreNodeKeys, genEnv)
+import Test.Cardano.Ledger.Shelley.Generator.Presets (coreNodeKeys)
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators.Bootstrap
   ( genBootstrapAddress,
     genSignature,
@@ -561,8 +557,7 @@ instance
     Arbitrary (Core.Value era),
     Arbitrary (Core.PParams era),
     Arbitrary (State (Core.EraRule "PPUP" era)),
-    Arbitrary (StashedAVVMAddresses era),
-    EraGen era
+    Arbitrary (StashedAVVMAddresses era)
   ) =>
   Arbitrary (NewEpochState era)
   where
@@ -585,8 +580,7 @@ instance
     Arbitrary (Core.TxOut era),
     Arbitrary (Core.Value era),
     Arbitrary (Core.PParams era),
-    Arbitrary (State (Core.EraRule "PPUP" era)),
-    EraGen era
+    Arbitrary (State (Core.EraRule "PPUP" era))
   ) =>
   Arbitrary (EpochState era)
   where
@@ -739,7 +733,7 @@ genUTCTime = do
       (Time.picosecondsToDiffTime diff)
 
 instance
-  (Mock (Crypto era), EraGen era, Arbitrary (PParams era)) =>
+  (Mock (Crypto era), Arbitrary (PParams era)) =>
   Arbitrary (ShelleyGenesis era)
   where
   arbitrary =
@@ -867,6 +861,7 @@ genBlock ::
   Gen (Block h era)
 genBlock = Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary)
 
+
 -- | For some purposes, a totally random block generator may not be suitable.
 -- There are tests in the ouroboros-network repository, for instance, that
 -- perform some integrity checks on the generated blocks.
@@ -877,8 +872,7 @@ genBlock = Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary)
 -- This generator uses 'mkBlock' provide more coherent blocks.
 genCoherentBlock ::
   forall era h.
-  ( EraGen era,
-    ToCBORGroup (TxSeq era),
+  ( ToCBORGroup (TxSeq era),
     Mock (Crypto era),
     UsesTxBody era,
     Arbitrary (Core.Tx era),
@@ -886,7 +880,7 @@ genCoherentBlock ::
   ) =>
   Gen (Block h era)
 genCoherentBlock = do
-  let KeySpace_ {ksCoreNodes} = geKeySpace (genEnv p)
+  let ksCoreNodes = coreNodeKeys defaultConstants
   prevHash <- arbitrary :: Gen (HashHeader (Crypto era))
   allPoolKeys <- elements (map snd ksCoreNodes)
   txs <- arbitrary
@@ -907,9 +901,6 @@ genCoherentBlock = do
       kesPeriod
       keyRegKesPeriod
       ocert
-  where
-    p :: Proxy era
-    p = Proxy
 
 instance
   ( Era era,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
@@ -77,7 +77,7 @@ tests :: TestTree
 tests =
   testGroup
     "Shelley Genesis"
-    [ testProperty "Adress round trip" $
+    [ testProperty "Address round trip" $
         prop_roundtrip_Address_JSON @C_Crypto Proxy,
       testProperty "Genesis round trip" $
         prop_roundtrip_ShelleyGenesis_JSON @C Proxy,

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -5,6 +5,7 @@
 import Cardano.Crypto.Libsodium (sodiumInit)
 import Cardano.Ledger.Shelley.PParams (PParams' (..))
 import Cardano.Ledger.Shelley.Rules.Ledger (LEDGER)
+import System.IO (hSetEncoding, stdout, utf8)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
 import Test.Cardano.Ledger.Shelley.Pretty (prettyTest)
 import Test.Cardano.Ledger.Shelley.PropertyTests (minimalPropertyTests, propertyTests)
@@ -56,6 +57,8 @@ fastTests =
       safeHashTest
     ]
 
--- main entry point
 main :: IO ()
-main = sodiumInit >> mainWithTestScenario tests
+main = do
+  hSetEncoding stdout utf8
+  sodiumInit
+  mainWithTestScenario tests


### PR DESCRIPTION
The module Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators had several white noise Arbitrary instances that had EraGen as preconditions (super classes). It was possible to remove all of these.  So now the tests in the consensus layer should not need EraGen instances. 

I also point out that a few Babbage specific Arbitrary instances can be found here
src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
