### PR TITLE
align babbage spec to impl regarding overflow

### DIFF
--- a/eras/babbage/formal-spec/utxo.tex
+++ b/eras/babbage/formal-spec/utxo.tex
@@ -7,7 +7,7 @@ self-explanatory. Note that the new $\fun{collOuts}$ function
 generates a single output with an index $| \txouts{txb} |$. This is to
 avoid potential confusion for transactions spending that output. Note
 that $\TxId$ can only hold integers up to $2^{16} - 1$. In case of an
-overflow, we let this number be $0$.
+overflow, we let this number be $2^{16} - 1$.
 
 \begin{figure*}[htb]
   \emph{Functions}


### PR DESCRIPTION
In the impossible event that there are more transaction outputs in the in the transaction than will fit into a Word16 (which backs the TxIn), we give the collateral return output the index 2^16 - 1.

This behavior is already present in the implementation, see
c601deaccb3d283573dd754c52c6cc0e4e22bad7

This change makes the corresponding change to the formal spec.