### PR TITLE
Removed erroneous prose in the shelley spec

### DIFF
--- a/eras/shelley/formal-spec/utxo.tex
+++ b/eras/shelley/formal-spec/utxo.tex
@@ -198,8 +198,7 @@ The transition contains the following predicates:
   \item
     The fee paid by the transaction has to be greater than or equal to the minimum fee,
     which is based on the size of the transaction.
-    A user or wallet might choose to create a fee larger than necessary
-    in exchange for a faster processing time.
+    We leave open the future possibility that transactions with larger fees can be prioritized.
   \item
     Each input spent in the transaction must be in the set of unspent
     outputs.


### PR DESCRIPTION
Removed erroneous prose in the Shelley spec regarding fees