### PR TITLE
rename MalformedData predicate failure

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -108,7 +108,7 @@ data BabbageUtxoPred era
   | UnequalCollateralReturn !Coin !Coin
   | DanglingWitnessDataHash !(Set.Set (DataHash (Crypto era)))
   | MalformedScripts !(Set (ScriptHash (Crypto era)))
-  | MalformedData !(Set (DataHash (Crypto era)))
+  | DatumByteStringExceeds64Bytes !(Set (DataHash (Crypto era)))
 
 deriving instance
   ( Era era,
@@ -461,7 +461,7 @@ instance
       work (UnequalCollateralReturn c1 c2) = Sum UnequalCollateralReturn 3 !> To c1 !> To c2
       work (DanglingWitnessDataHash x) = Sum DanglingWitnessDataHash 4 !> To x
       work (MalformedScripts x) = Sum MalformedScripts 5 !> To x
-      work (MalformedData x) = Sum MalformedData 6 !> To x
+      work (DatumByteStringExceeds64Bytes x) = Sum DatumByteStringExceeds64Bytes 6 !> To x
 
 instance
   ( Era era,
@@ -482,7 +482,7 @@ instance
       work 3 = SumD UnequalCollateralReturn <! From <! From
       work 4 = SumD DanglingWitnessDataHash <! From
       work 5 = SumD MalformedScripts <! From
-      work 6 = SumD MalformedData <! From
+      work 6 = SumD DatumByteStringExceeds64Bytes <! From
       work n = Invalid n
 
 deriving via InspectHeapNamed "BabbageUtxoPred" (BabbageUtxoPred era) instance NoThunks (BabbageUtxoPred era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -172,19 +172,22 @@ validateDatumsWellFormed ::
   Core.Tx era ->
   Test (BabbageUtxoPred era)
 validateDatumsWellFormed tx =
-  let invalidDatums = Set.map hashData $ Set.filter (\(Data d) -> not $ validateData' d) (txdata tx)
+  let invalidDatums =
+        Set.map hashData $
+          Set.filter (\(Data d) -> not $ datumByteStringsAtMost64Bytes d) (txdata tx)
    in failureUnless
         (Set.null invalidDatums)
-        (MalformedData invalidDatums)
+        (DatumByteStringExceeds64Bytes invalidDatums)
 
-validateData' ::
+datumByteStringsAtMost64Bytes ::
   Plutus.Data ->
   Bool
-validateData' (Constr _ ds) = all validateData' ds
-validateData' (Map ds) = all (\(x, y) -> validateData' x && validateData' y) ds
-validateData' (List ds) = all validateData' ds
-validateData' (I _) = True
-validateData' (B bs) = BS.length bs <= 64
+datumByteStringsAtMost64Bytes (Constr _ ds) = all datumByteStringsAtMost64Bytes ds
+datumByteStringsAtMost64Bytes (Map ds) =
+  all (\(x, y) -> datumByteStringsAtMost64Bytes x && datumByteStringsAtMost64Bytes y) ds
+datumByteStringsAtMost64Bytes (List ds) = all datumByteStringsAtMost64Bytes ds
+datumByteStringsAtMost64Bytes (I _) = True
+datumByteStringsAtMost64Bytes (B bs) = BS.length bs <= 64
 
 -- ==============================================================
 -- Here we define the transtion function, using reusable tests.

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -146,8 +146,8 @@ ppBabbageUtxoPred (DanglingWitnessDataHash dhset) =
   ppSexp "DanglingWitnessDataHashes" [ppSet ppDataHash dhset]
 ppBabbageUtxoPred (MalformedScripts scripts) =
   ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
-ppBabbageUtxoPred (MalformedData dat) =
-  ppSexp "MalformedData" [ppSet ppDataHash dat]
+ppBabbageUtxoPred (DatumByteStringExceeds64Bytes dat) =
+  ppSexp "DatumByteStringExceeds64Bytes" [ppSet ppDataHash dat]
 
 instance
   ( PrettyA (UtxoPredicateFailure era),


### PR DESCRIPTION
Renamed the `MalformedData` predicate failure to `DatumByteStringExceeds64Bytes` for clarity.