### PR TITLE
Datum validation happens only on deserialization

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -108,7 +108,6 @@ data BabbageUtxoPred era
   | UnequalCollateralReturn !Coin !Coin
   | DanglingWitnessDataHash !(Set.Set (DataHash (Crypto era)))
   | MalformedScripts !(Set (ScriptHash (Crypto era)))
-  | DatumByteStringExceeds64Bytes !(Set (DataHash (Crypto era)))
 
 deriving instance
   ( Era era,
@@ -461,7 +460,6 @@ instance
       work (UnequalCollateralReturn c1 c2) = Sum UnequalCollateralReturn 3 !> To c1 !> To c2
       work (DanglingWitnessDataHash x) = Sum DanglingWitnessDataHash 4 !> To x
       work (MalformedScripts x) = Sum MalformedScripts 5 !> To x
-      work (DatumByteStringExceeds64Bytes x) = Sum DatumByteStringExceeds64Bytes 6 !> To x
 
 instance
   ( Era era,
@@ -482,7 +480,6 @@ instance
       work 3 = SumD UnequalCollateralReturn <! From <! From
       work 4 = SumD DanglingWitnessDataHash <! From
       work 5 = SumD MalformedScripts <! From
-      work 6 = SumD DatumByteStringExceeds64Bytes <! From
       work n = Invalid n
 
 deriving via InspectHeapNamed "BabbageUtxoPred" (BabbageUtxoPred era) instance NoThunks (BabbageUtxoPred era)

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -146,8 +146,6 @@ ppBabbageUtxoPred (DanglingWitnessDataHash dhset) =
   ppSexp "DanglingWitnessDataHashes" [ppSet ppDataHash dhset]
 ppBabbageUtxoPred (MalformedScripts scripts) =
   ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
-ppBabbageUtxoPred (DatumByteStringExceeds64Bytes dat) =
-  ppSexp "DatumByteStringExceeds64Bytes" [ppSet ppDataHash dat]
 
 instance
   ( PrettyA (UtxoPredicateFailure era),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
 import Cardano.Ledger.TxIn (TxIn (..), txid)
 import Cardano.Ledger.Val (inject)
 import Control.State.Transition.Extended hiding (Assertion)
+import qualified Data.ByteString as BS
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Default.Class (Default (..))
@@ -121,8 +122,14 @@ collateralOutput :: Scriptic era => Proof era -> Core.TxOut era
 collateralOutput pf =
   newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 50)]
 
+-- We intentionally use a ByteString with length greater than 64 to serve as
+-- as reminder that our protection against contiguous data over 64 Bytes on
+-- the wire is done during deserialization using the Plutus library.
+sixtyFiveBytes :: BS.ByteString
+sixtyFiveBytes = BS.pack [1 .. 65]
+
 datumExample1 :: Data era
-datumExample1 = Data (Plutus.I 123)
+datumExample1 = Data (Plutus.B sixtyFiveBytes)
 
 inlineDatumOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
 inlineDatumOutput pf =


### PR DESCRIPTION
This PR removes the ledger validation check done on `Datum`s. The correct check is done in the Plutus library, during deserialization.