### PR TITLE
Added properties tests for totalAda and Incremental Stake invariant

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -638,7 +638,7 @@ instance Default (IncrementalStake c) where
 
 -- | There is a serious invariant that we must maintain in the UTxOState.
 --   Given (UTxOState utxo _ _ _ istake) it must be the case that
---   istake == (updateStakeDistribution (IStake Map.empty Map.empty) (UTxO Map.empty) utxo)
+--   istake == (updateStakeDistribution (UTxO SplitMap.empty) (UTxO SplitMap.empty) utxo)
 --   Of course computing the RHS of the above equality can be very expensive, so we only
 --   use this route in the testing function smartUTxO. But we are very carefull, wherever
 --   we update the UTxO, we carefully make INCREMENTAL changes to istake to maintain

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -57,6 +57,7 @@ import Control.State.Transition
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence (Seq (..))
+import Test.Cardano.Ledger.Generic.Functions (TotalAda (..))
 import Test.Cardano.Ledger.Generic.PrettyCore
   ( pcNewEpochState,
     ppLedgersPredicateFailure,
@@ -108,6 +109,9 @@ instance Show (MockChainState era) where
 
 instance Show (MockBlock era) where
   show (MockBlock is sl _) = show is ++ " " ++ show sl
+
+instance Reflect era => TotalAda (MockChainState era) where
+  totalAda (MockChainState nes _lastbock _count) = totalAda nes
 
 -- ======================================================================
 

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -17,7 +17,6 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
     collectOrderingAlonzo,
   )
 import Test.Cardano.Ledger.Generic.Properties (genericProperties)
-import Test.Cardano.Ledger.Generic.Trace (testTraces)
 import Test.Cardano.Ledger.Model.Properties (modelUnitTests_)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
@@ -44,8 +43,7 @@ mainTests =
           collectOrderingAlonzo,
           modelUnitTests_
         ],
-      genericProperties,
-      testTraces 200
+      genericProperties
     ]
 
 -- main entry point


### PR DESCRIPTION
This PR cleans up 3 or 4 very small things left over from the last PR (Spelling, documentation, etc)

It adds functions for generating traces, and for turning traces into properties. It then adds two property tests for totalAda and the stake distribution invariant.