### PR TITLE
Remove small memory leak during LedgerState deserialization

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -34,7 +35,6 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Compact.SplitMap as SplitMap
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
 
 -- | We use the same hashing algorithm so we can unwrap and rewrap the bytes.
@@ -52,11 +52,11 @@ hashFromShortBytesE ::
   (Crypto.HashAlgorithm h, HasCallStack) =>
   SBS.ShortByteString ->
   Crypto.Hash h a
-hashFromShortBytesE sbs = fromMaybe (error msg) $ Crypto.hashFromBytesShort sbs
-  where
-    msg =
-      "hashFromBytesShort called with ShortByteString of the wrong length: "
-        <> show sbs
+hashFromShortBytesE sbs =
+  case Crypto.hashFromBytesShort sbs of
+    Just !h -> h
+    Nothing ->
+      error $ "hashFromBytesShort called with ShortByteString of the wrong length: " <> show sbs
 
 translateCompactTxOutByronToShelley :: Byron.CompactTxOut -> TxOut (ShelleyEra c)
 translateCompactTxOutByronToShelley (Byron.CompactTxOut compactAddr amount) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -344,7 +345,7 @@ getHash = do
   bytes <- B.getByteString . fromIntegral $ Hash.sizeHash ([] @h)
   case Hash.hashFromBytes bytes of
     Nothing -> fail "getHash: implausible hash length mismatch"
-    Just h -> pure h
+    Just !h -> pure h
 
 putHash :: Hash.Hash h a -> Put
 putHash = B.putByteString . Hash.hashToBytes
@@ -492,7 +493,7 @@ bootstrapKeyHash ::
 bootstrapKeyHash (BootstrapAddress byronAddress) =
   let root = Byron.addrRoot byronAddress
       bytes = Byron.abstractHashToBytes root
-      hash =
+      !hash =
         fromMaybe (panic "bootstrapKeyHash: incorrect hash length") $
           Hash.hashFromBytes bytes
    in KeyHash hash

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -12,9 +12,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
--- We are enabling orphans since BlockNo is orphaned until the instance is added to cardano-base
--- https://github.com/input-output-hk/cardano-base/pull/233
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Protocol.TPraos.BHeader
   ( HashHeader (..),
@@ -337,7 +334,7 @@ bhHash = HashHeader . Hash.castHash . Hash.hashWithSerialiser toCBOR
 hashHeaderToNonce :: HashHeader crypto -> Nonce
 hashHeaderToNonce (HashHeader h) = case Hash.hashFromBytes bytes of
   Nothing -> Nonce (Hash.castHash (Hash.hashWith id bytes))
-  Just hash -> Nonce hash
+  Just hash -> Nonce $! hash
   where
     bytes = Hash.hashToBytes h
 

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -52,7 +52,6 @@ library
                     , text
                     , transformers
 
-                    , primitive
   exposed-modules:    Cardano.Ledger.State.UTxO
                     , Cardano.Ledger.State.Orphans
                     , Cardano.Ledger.State.Schema


### PR DESCRIPTION
This change is needed because of the recent PR into cardano-base: https://github.com/input-output-hk/cardano-base/pull/274

Supported by benchmarks:

* Old address deserialization (strict conversion of hash):
```
Case                     Max          MaxOS           Live        Allocated      GCs
NewEpochState  2,506,455,600  6,871,318,528  2,506,455,600  123,079,731,672  113,968
```

* New address deserialization (lazy conversion of hash - #2750):
```
Case                     Max          MaxOS           Live        Allocated      GCs
NewEpochState  2,603,703,288  7,100,956,672  2,506,447,208  118,780,108,856  109,760
```

* New address deserialization (strict conversion of hash - this PR)
```
Case                     Max          MaxOS           Live        Allocated      GCs
NewEpochState  2,506,456,016  6,994,001,920  2,506,456,016  118,780,107,584  109,760
```

Also includes a minor cleanup.
