### PR TITLE
Fixed MockChain trace failures, Added strictness ann to some Data types.

### DIFF
--- a/HowToProfileLedger.md
+++ b/HowToProfileLedger.md
@@ -1,0 +1,187 @@
+                        How To Profile Ledger
+                            last edited
+                            May 7, 2022
+                            Tim Sheard
+
+Motivation
+Profiling the ledger is an intricate dance between nix, cabal, and ghc. This document
+describes how I set all this up to profile some of the property tests in the
+cardano-ledger-test module. I hope this is useful to others who want to profile
+other parts of the Ledger code.
+
+Background
+Profiling is an important tool to analyze performance (time and space) in Haskel code.
+I recommend reading through the GHC users guide. Here is a link to the appropriates section
+https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html
+This is great background, but the gude says almost nothing about how to make it all work
+in a repository that uses nix and cabal. Hence this document
+
+
+Summary
+We list here a high level description of the steps needed. In further sections we go into
+greater detail about each step
+
+1. Decide what you want to profile, and arrange the code so this is possible
+2. Choreograph the dance between nix, cabal, and ghc. This has two parts
+   a. Adding stuff to files like cabal.project, cabal.project.local, and nix/haskel.nix
+   b. Passing the right flags to nix-shell, cabal, and ghc
+3. Recompiling everything so it can be profiled. This takes a very long time (greater than
+   30 minutes when I did it)
+4. Start up the profiling. I used "cabal test" with just the right command line arguments.
+5. Inspect the produced .prof file, and decide what to do
+6. Repeat steps 3-5, until satisfied.
+7. Undo all the changes (from steps 1 and 2) made just for profiling.
+
+Deciding what to profile
+Usually one wants to profile code that appears to be using too many resoures (space or time).
+Because of the difficulty in getting nix, cabal, and ghc to work together, I have found that
+co-opting an existing Test file is the way to go. Here are the reasons why this is a good idea
+
+1) Everything is already set up to compile and run the test file by simply typing:  cabal test
+   in the root directory of the module that contains the test.
+2) Is is usually quite easy to rename the 'main' variable in the test file to something else
+   and add your own 'main', that contains the code you want to profile
+3) Using a quick check property test, allows for your code to consist of mutltiple "tests" each
+   with a different random input. This means your profiling results are less likely to be biased
+   by a bad choice of input.
+
+Here is how I did it.  I edited the file cardano-ledger/libs/cardano-ledger-test/test/Test.hs
+Here is a synopsis of what it originally looked like, and what it looked like after I edited it.
+
+BEFORE
+------------------------
+...
+
+-- main entry point
+main :: IO ()
+main = do
+  hSetEncoding stdout utf8
+  mainWithTestScenario tests
+------------------------
+
+AFTER
+-----------------------
+...
+import Test.Cardano.Ledger.Generic.Properties (adaIsPreservedBabbage)
+
+mainSave :: IO ()
+mainSave = do
+  hSetEncoding stdout utf8
+  mainWithTestScenario tests
+
+main :: IO ()
+main = defaultMain adaIsPreservedBabbage 
+-----------------------
+
+The variable 'adaIsPreservedBabbage' is a property test of type 'TestTree' that takes
+about 1 minute to run. Similar tests took about 10-20 seconds, so I was interested why
+it took so long. So now I have a 'main' that runs just this one test. I could see that I
+have set things up properly by changing directory to  cardano-ledger/libs/cardano-ledger-test
+The root directory of the module. This is the directory that contains the cardano-ledger-test.cabal file.
+So I can simply type:  cabal test, and the test runs.  Now all I need to do is get it to be profiled.
+
+Choreographing the dance.
+
+We need to tell nix, cabal, and ghc that we want to profile. We do this by changing a few of the
+files that build the system, and by passing the right flags to nix, cabal, and GHC.
+
+There is one big problem with doing this, and that is that the module 'plutus-core' uses
+template haskell, and happens to trigger a known bug in ghc. https://gitlab.haskell.org/ghc/ghc/-/issues/18320
+There are also a few slack threads about this. For example
+https://input-output-rnd.slack.com/archives/C21UF2WVC/p1624555583258300
+The workaround for this is quite convoluted, but I will try and give explicit directions here.
+
+First we must add (or change if you already have it) cabal.project.local  In the root of the 
+ledger repository. Put this in cabal.project.local
+---------------------
+ignore-project: False
+profiling: True
+profiling-detail: all-functions
+
+package plutus-core 
+   ghc-options: -fexternal-interpreter
+---------------------
+
+Supposedly this makes things work. But I could never get the nix-shell to complete with this approach.
+To get that to happen I had to add the following line to the modules section of the nix/haskell.nix  file
+-----------------------------
+       packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
+-----------------------------
+There are probaly more that a dozen lines just like this, so it is easy to figure out where to put it.
+
+The final step is to pass the right flags to nix-shell, cabal, and ghc. Here is a summary.
+
+1) to start nix, we must use
+   nix-shell --arg config "{ haskellNix.profiling = true; }"
+2) to build with cabal, we must use
+   cabal build --enable-profiling
+3) to run the test, we must pass extra flags to ghc, so we must use   
+   cabal test --test-options="+RTS  -i60 -p"
+
+How to build the system for profiling
+
+Be sure you have set up the files cabal.project.local and nix/haskell.nix as described above.
+Exit the nix-shell, if you are running it. Now change directories to the root of the Ledger repository.
+
+Now to start nix type
+
+nix-shell --arg config "{ haskellNix.profiling = true; }"
+
+When the nix-shell completes (this can take a long time, since it must make sure
+every file in the Ledger is compiled with profiling enabled). This might take a
+while. Be patient. Take the dogs for a walk.
+
+Now change directories to the root directory of the modlue that contains your
+modified Test file, and type 
+
+cabal build --enable-profiling
+
+This might also take a while. Take the dogs for second walk.  When this completes
+you are ready to start profiing!
+
+How to run a profile.
+
+In the same directory where you did (cabal build --enable-profiling) type
+
+cabal test --test-options="+RTS  -i60 -p"
+
+This should take slightly longer than running the test without profiling.
+When it is done, there will be a file in this same directory with extension .prof
+When I did it, the file was called   cardano-ledger-test.prof  . It is a big file
+Here are the first few lines.
+
+----------------------------------------------------------------------------------------------------------
+Fri May  6 14:02 2022 Time and Allocation Profiling Report  (Final)
+
+	   cardano-ledger-test +RTS -i60 -p -RTS
+
+	total time  =       51.05 secs   (51050 ticks @ 1000 us, 1 processor)
+	total alloc = 109,620,447,376 bytes  (excludes profiling overheads)
+
+COST CENTRE               MODULE                                SRC                                                            %time %alloc
+
+showsPrec                 Cardano.Ledger.Alonzo.TxInfo          src/Cardano/Ledger/Alonzo/TxInfo.hs:504:13-16                   10.3   19.9
+evalScripts               Cardano.Ledger.Alonzo.PlutusScriptApi src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs:(231,1)-(247,55)    7.5    1.6
+evalScripts.endMsg        Cardano.Ledger.Alonzo.PlutusScriptApi src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs:(240,7)-(246,11)    6.5   17.8
+show                      Cardano.Ledger.Alonzo.Scripts         src/Cardano/Ledger/Alonzo/Scripts.hs:202:3-74                    6.1   14.8
+blake2b_libsodium         Cardano.Crypto.Hash.Blake2b           src/Cardano/Crypto/Hash/Blake2b.hs:(37,1)-(43,104)               2.6    1.0
+decodeAddrStateT          Cardano.Ledger.CompactAddress         src/Cardano/Ledger/CompactAddress.hs:(287,1)-(304,40)            2.3    1.2
+splitSMGen                System.Random.SplitMix                src/System/Random/SplitMix.hs:(225,1)-(229,31)                   1.4    3.2
+explainPlutusFailure.line Cardano.Ledger.Alonzo.TxInfo          src/Cardano/Ledger/Alonzo/TxInfo.hs:(665,13)-(673,19)            1.4    2.3
+toBuilder                 Codec.CBOR.Write                      src/Codec/CBOR/Write.hs:(102,1)-(103,57)                         1.3    0.5
+genValidatedTxAndInfo     Test.Cardano.Ledger.Generic.TxGen     src/Test/Cardano/Ledger/Generic/TxGen.hs:(759,1)-(947,55)        1.3    0.1
+runE                      Data.Coders                           src/Data/Coders.hs:(566,1)-(577,20)                              1.3    0.7
+showsPrec                 Cardano.Ledger.Alonzo.TxInfo          src/Cardano/Ledger/Alonzo/TxInfo.hs:467:13-16                    1.2    3.2
+hashWith                  Cardano.Crypto.Hash.Class             src/Cardano/Crypto/Hash/Class.hs:(125,1)-(129,13)                1.2    0.5
+genKeyHash.\              Test.Cardano.Ledger.Generic.GenState  src/Test/Cardano/Ledger/Generic/GenState.hs:369:37-83            1.1    0.4
+serializeEncoding         Cardano.Binary.Serialize              src/Cardano/Binary/Serialize.hs:(61,1)-(67,49)                   0.8    2.1
+toLazyByteString          Codec.CBOR.Write                      src/Codec/CBOR/Write.hs:86:1-49                                  0.7    4.9
+---------------------------------------------------------------------------------------------------------------------
+
+The problem with my test, was that evalScripts was inadvertantly showing a large data structure
+using tellEvent. This was added when debugging and never removed. After fixing this, we had much better results.
+I hope you experience is just as rewarding.
+
+Don't forget to revert cabal.project.local, nix/haskell.nix  and your Test file to their original state.
+
+

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -32,10 +32,11 @@ import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams, PParams' (.
 import Cardano.Ledger.Babbage.Scripts (refScripts)
 import Cardano.Ledger.Babbage.TxBody as Babbage (referenceInputs', spendInputs')
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxOut (..))
+import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
-import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Era (Era (Crypto, getAllTxInputs))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Shelley.EpochBoundary (obligation)
 import Cardano.Ledger.Shelley.LedgerState
@@ -63,6 +64,7 @@ import qualified Data.Foldable as Fold
 import qualified Data.List as List
 import Data.Map (Map, keysSet, restrictKeys)
 import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.UMap as UMap
@@ -93,6 +95,13 @@ collateralPercentage' :: Proof era -> Core.PParams era -> Natural
 collateralPercentage' (Alonzo _) x = _collateralPercentage x
 collateralPercentage' (Babbage _) x = Babbage._collateralPercentage x
 collateralPercentage' _proof _x = 0
+
+protocolVersion :: Proof era -> ProtVer
+protocolVersion (Babbage _) = ProtVer 7 0
+protocolVersion (Alonzo _) = ProtVer 6 0
+protocolVersion (Mary _) = ProtVer 4 0
+protocolVersion (Allegra _) = ProtVer 3 0
+protocolVersion (Shelley _) = ProtVer 2 0
 
 obligation' ::
   forall era c.
@@ -278,6 +287,20 @@ getInputs (Alonzo _) tx = getField @"inputs" tx
 getInputs (Mary _) tx = getField @"inputs" tx
 getInputs (Allegra _) tx = getField @"inputs" tx
 getInputs (Shelley _) tx = getField @"inputs" tx
+
+getOutputs :: Proof era -> Core.TxBody era -> StrictSeq (Core.TxOut era)
+getOutputs (Babbage _) tx = getField @"outputs" tx
+getOutputs (Alonzo _) tx = getField @"outputs" tx
+getOutputs (Mary _) tx = getField @"outputs" tx
+getOutputs (Allegra _) tx = getField @"outputs" tx
+getOutputs (Shelley _) tx = getField @"outputs" tx
+
+allInputs :: Proof era -> Core.TxBody era -> Set (TxIn (Crypto era))
+allInputs (Babbage _) txb = getAllTxInputs txb
+allInputs (Alonzo _) txb = getAllTxInputs txb
+allInputs (Mary _) txb = getAllTxInputs txb
+allInputs (Allegra _) txb = getAllTxInputs txb
+allInputs (Shelley _) txb = getAllTxInputs txb
 
 primaryLanguage :: Proof era -> Maybe Language
 primaryLanguage (Babbage _) = Just (PlutusV2)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -138,6 +138,9 @@ toMUtxo (UTxO m) = SplitMap.toMap m
 fromMUtxo :: MUtxo era -> UTxO era
 fromMUtxo m = UTxO (SplitMap.fromMap m)
 
+pcMUtxo :: Reflect era => Proof era -> MUtxo era -> PDoc
+pcMUtxo proof m = ppMap pcTxIn (pcTxOut proof) m
+
 -- ===========================================================
 
 data ModelNewEpochState era = ModelNewEpochState

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -40,6 +40,7 @@ import Cardano.Ledger.Pretty
 import Cardano.Ledger.Pretty.Alonzo
 import qualified Cardano.Ledger.Pretty.Babbage as Babbage
 import Cardano.Ledger.Pretty.Mary
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.LedgerState
   ( AccountState (..),
     DPState (..),
@@ -1223,7 +1224,7 @@ pcTxBodyField proof x = case x of
 
 pcTxField :: Reflect era => Proof era -> TxField era -> [(Text, PDoc)]
 pcTxField proof x = case x of
-  Body b -> [("body", pcTxBody proof b)]
+  Body b -> [("txbody hash", ppSafeHash (hashAnnotated b)), ("body", pcTxBody proof b)]
   BodyI xs -> [("body", ppRecord "TxBody" (concat (map (pcTxBodyField proof) xs)))]
   Witnesses w -> [("witnesses", pcWitnesses proof w)]
   WitnessesI ws -> [("witnesses", ppRecord "Witnesses" (concat (map (pcWitnessesField proof) ws)))]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -15,35 +15,49 @@ module Test.Cardano.Ledger.Generic.Trace where
 
 -- =========================================================================
 
+import Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import qualified Cardano.Ledger.Babbage.PParams (PParams' (..))
 import Cardano.Ledger.Babbage.Rules.Ledger ()
 import Cardano.Ledger.Babbage.Rules.Utxow ()
 import Cardano.Ledger.BaseTypes (BlocksMade (..), Globals)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
-import Cardano.Ledger.Pretty (ppList, ppPair, ppWord64)
+import Cardano.Ledger.Pretty (PDoc, ppInt, ppList, ppMap, ppSafeHash, ppStrictSeq, ppString, ppWord64)
+import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.Shelley.API.Wallet (totalAdaPotsES)
+import Cardano.Ledger.Shelley.Constraints (UsesValue)
 import Cardano.Ledger.Shelley.LedgerState
   ( AccountState (..),
     EpochState (..),
     LedgerState (..),
     NewEpochState (..),
+    StashedAVVMAddresses,
+    UTxOState (..),
   )
+import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams' (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Control.Monad.Trans.Class (MonadTrans (lift))
-import Control.Monad.Trans.RWS.Strict (get, gets)
+import Control.Monad.Trans.RWS.Strict (get)
 import Control.Monad.Trans.Reader (ReaderT (..))
-import Control.State.Transition.Extended (STS (..))
+import Control.State.Transition.Extended (STS (..), TRC (..))
 import Control.State.Transition.Trace (Trace (..), lastState)
 import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace (..), traceFromInitState)
 import Data.Default.Class (Default (def))
+import qualified Data.Foldable as Fold
 import Data.Functor.Identity (Identity (runIdentity))
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (..))
-import Data.Sequence as Seq (fromList)
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as SS
+import qualified Data.Set as Set
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vector
 import GHC.Word (Word64)
+import Prettyprinter (vsep)
 import Test.Cardano.Ledger.Generic.ApplyTx (applyTx)
+import Test.Cardano.Ledger.Generic.Functions (allInputs, getBody, getTxOutCoin, isValid')
 import Test.Cardano.Ledger.Generic.GenState
   ( GenEnv (..),
     GenRS,
@@ -59,53 +73,53 @@ import Test.Cardano.Ledger.Generic.GenState
   )
 import Test.Cardano.Ledger.Generic.MockChain
 import Test.Cardano.Ledger.Generic.ModelState
-  ( Model,
-    mNewEpochStateZero,
-    stashedAVVMAddressesZero,
+  ( stashedAVVMAddressesZero,
+    toMUtxo,
   )
-import Test.Cardano.Ledger.Generic.PrettyCore (pcTx)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcCoin, pcTx, pcTxBody, pcTxIn)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
-import Test.Cardano.Ledger.Generic.TxGen
-  ( genValidatedTx,
-  )
-import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
+import Test.Cardano.Ledger.Generic.TxGen (genValidatedTx)
+import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, runShelleyBase, testGlobals)
 import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
 
 -- ===========================================
 
--- | Generate a Core.Tx and an internal Model of the state after the block
+-- | Generate a Core.Tx and an internal Model of the state after the tx
 --   has been applied. That model can be used to generate the next Tx
-genRsTxAndModel :: Reflect era => Proof era -> Model era -> Word64 -> GenRS era (Core.Tx era, Model era)
-genRsTxAndModel proof model0 n = do
-  modifyModel (const model0)
+genRsTxAndModel :: Reflect era => Proof era -> Word64 -> GenRS era (Core.Tx era)
+genRsTxAndModel proof n = do
   (_, tx) <- genValidatedTx proof
-  model1 <- gets gsModel
-  let model2 = applyTx proof (fromIntegral n) model1 tx
-  pure (tx, model2)
+  tx <$ modifyModel (\model -> applyTx proof (fromIntegral n) model tx)
 
--- | Generate a Vector of [(Word64,Core.Tx era)] representing a (Vector Block)
+-- | Generate a Vector of (StrictSeq (Core.Tx era))  representing a (Vector Block)
 genRsTxSeq ::
   forall era.
   Reflect era =>
   Proof era ->
-  Model era ->
   Word64 ->
   Word64 ->
-  [(Word64, Core.Tx era)] ->
-  GenRS era (Vector [(Word64, Core.Tx era)])
-genRsTxSeq _ _ this lastN ans | this > lastN = chop (reverse ans) []
-genRsTxSeq proof model0 this lastN ans = do
-  (tx, model1) <- genRsTxAndModel proof model0 this
-  genRsTxSeq proof model1 (this + 1) lastN ((this, tx) : ans)
+  [Core.Tx era] ->
+  GenRS era (Vector (StrictSeq (Core.Tx era)))
+genRsTxSeq _ this lastN ans | this >= lastN = chop (reverse ans) []
+genRsTxSeq proof this lastN ans = do
+  tx <- genRsTxAndModel proof this
+  genRsTxSeq proof (this + 1) lastN (tx : ans)
 
 -- | Chop a list into random size blocks
-chop :: [(Word64, Core.Tx era)] -> [[(Word64, Core.Tx era)]] -> GenRS era (Vector [(Word64, Core.Tx era)])
+chop ::
+  [Core.Tx era] ->
+  [StrictSeq (Core.Tx era)] ->
+  GenRS era (Vector (StrictSeq (Core.Tx era)))
 chop [] ans = pure $ Vector.fromList (reverse ans)
-chop xs ans | length (take 4 xs) <= 3 = pure $ Vector.fromList (reverse (xs : ans))
+chop xs ans
+  | length (Prelude.take 4 xs) <= 3 =
+      pure $ Vector.fromList (reverse (SS.fromList xs : ans))
 chop pairs ans = do
   maxBlockSize <- getBlocksizeMax <$> get
   n <- lift $ choose (2 :: Int, fromIntegral maxBlockSize)
-  let block = Prelude.take n pairs
+  let block = SS.fromList $ Prelude.take n pairs
   chop (Prelude.drop n pairs) (block : ans)
 
 -- | Generate a Vector of Blocks, and an initial LedgerState
@@ -115,14 +129,14 @@ genTxSeq ::
   Proof era ->
   GenSize ->
   Word64 ->
-  Gen (Vector [(Word64, Core.Tx era)], GenState era)
+  Gen (Vector (StrictSeq (Core.Tx era)), GenState era)
 genTxSeq proof gensize numTx = do
-  runGenRS proof gensize (genRsTxSeq proof mNewEpochStateZero 0 numTx [])
+  runGenRS proof gensize (genRsTxSeq proof 0 numTx [])
 
 run :: IO ()
 run = do
   (vs, _) <- generate $ genTxSeq (Babbage Mock) def 5
-  print (ppList (ppList (ppPair ppWord64 (pcTx (Babbage Mock)))) (Vector.toList vs))
+  print (ppList (ppStrictSeq (pcTx (Babbage Mock))) (Vector.toList vs))
 
 -- ==================================================================
 -- Constructing the "real", initial NewEpochState, from the GenState
@@ -159,6 +173,50 @@ makeEpochState gstate ledgerstate =
 
 -- ==============================================================================
 
+-- | Turn a UTxO into a smaller UTxO, with only entries mentioned in
+--   the inputs of 'txs' ,  then pretty print it.
+pcSmallUTxO :: Proof era -> UTxO era -> [Core.Tx era] -> PDoc
+pcSmallUTxO proof u txs = ppMap pcTxIn (pcCoin . getTxOutCoin proof) m
+  where
+    keys = Set.unions (map f txs)
+    f tx = allInputs proof (getBody proof tx)
+    m = Map.restrictKeys (toMUtxo u) keys
+
+raiseMockError ::
+  (UsesValue era, Reflect era) =>
+  Word64 ->
+  EpochState era ->
+  [MockChainFailure era] ->
+  [Core.Tx era] ->
+  String
+raiseMockError slot epochstate pdfs txs =
+  show $
+    vsep
+      [ pcSmallUTxO reify ((_utxo . lsUTxOState . esLState) epochstate) txs,
+        ppString "===================================",
+        ppString "Slot " <> ppWord64 slot,
+        ppString "===================================",
+        showBlock txs,
+        ppString "===================================",
+        ppString (show (totalAdaPotsES epochstate)),
+        ppString "===================================",
+        ppList (ppMockChainFailure reify) pdfs
+      ]
+
+showBlock :: Reflect era => [Core.Tx era] -> PDoc
+showBlock txs = ppList pppair (zip txs [0 ..])
+  where
+    pppair (tx, n) =
+      let body = getBody reify tx
+       in vsep
+            [ ppString "\n###########",
+              ppInt n,
+              ppSafeHash (hashAnnotated body),
+              pcTxBody reify body,
+              ppString (show (isValid' reify tx)),
+              ppString "\n"
+            ]
+
 -- =====================================================================
 -- HasTrace instance of MOCKCHAIN depends on STS(MOCKCHAIN era) instance
 -- We show the type family instances here for reference.
@@ -171,10 +229,11 @@ instance STS (MOCKCHAIN era)
 -}
 -- ==============================================================
 
-newtype Gen1 era = Gen1 (Vector [Core.Tx era])
+newtype Gen1 era = Gen1 (Vector (StrictSeq (Core.Tx era)))
 
 instance
   ( STS (MOCKCHAIN era),
+    UsesValue era,
     Reflect era
   ) =>
   HasTrace (MOCKCHAIN era) (Gen1 era)
@@ -186,22 +245,18 @@ instance
   envGen _gstate = pure ()
 
   sigGen (Gen1 txss) () mcs@(MockChainState newepoch (SlotNo lastSlot) count) = do
-    let NewEpochState _epoch _ _ _ _ pooldistr _ = newepoch
+    let NewEpochState _epochnum _ _ epochstate _ pooldistr _ = newepoch
     issuerkey <- chooseIssuer pooldistr
     nextSlotNo <- SlotNo . (+ lastSlot) <$> choose (15, 25)
-    let txs = Seq.fromList (txss ! count)
-    -- Assemble it into a MockBlock
+    let txs = txss ! count
+    -- Assmble it into a MockBlock
     let mockblock = MockBlock issuerkey nextSlotNo txs
     -- Run the STS Rules for MOCKCHAIN with generated signal
-    goSTS
-      (MOCKCHAIN reify)
-      ()
-      mcs
-      mockblock
-      ( \case
-          Left pdfs -> error ("MOCKCHAIN sigGen:\n" <> show (ppList (ppMockChainFailure reify) pdfs))
-          Right _mcs -> pure mockblock
-      )
+
+    case runShelleyBase (applySTSTest (TRC @(MOCKCHAIN era) ((), mcs, mockblock))) of
+      Left pdfs -> error (raiseMockError lastSlot epochstate pdfs (Fold.toList (txss ! count)))
+      -- Left pdfs -> trace ("Discard\n"++show(ppList (ppMockChainFailure reify) pdfs)) discard -- TODO should we enable this?
+      Right mcs2 -> seq mcs2 (pure mockblock)
 
   shrinkSignal _x = []
 
@@ -214,6 +269,7 @@ chooseIssuer (PoolDistr m) = mapProportion getInt m
     getInt x = floor (individualPoolStake x * 1000)
 
 -- ===================================================================================
+
 -- Generating Traces, and making properties out of a Trace
 -- =========================================================================
 
@@ -232,7 +288,7 @@ genTrace proof numTxInTrace gsize = do
   traceFromInitState @(MOCKCHAIN era)
     testGlobals
     (fromIntegral (length vs))
-    (Gen1 (Vector.map (map snd) vs))
+    (Gen1 vs)
     (Just (\_ -> pure $ Right initState))
 
 traceProp ::
@@ -246,7 +302,47 @@ traceProp ::
   (MockChainState era -> MockChainState era -> prop) ->
   Gen prop
 traceProp proof numTxInTrace gsize f = do
-  trace <- genTrace proof numTxInTrace gsize
-  pure (f (_traceInitState trace) (lastState trace))
+  trace1 <- genTrace proof numTxInTrace gsize
+  pure (f (_traceInitState trace1) (lastState trace1))
 
--- =====================================================
+-- =========================================================================
+-- Test for just making a trace
+
+chainTest ::
+  forall era.
+  ( Reflect era,
+    HasTrace (MOCKCHAIN era) (Gen1 era),
+    Eq (Core.TxOut era),
+    Eq (Core.PParams era),
+    Eq (State (Core.EraRule "PPUP" era)),
+    Eq (StashedAVVMAddresses era)
+  ) =>
+  Proof era ->
+  Word64 ->
+  GenSize ->
+  TestTree
+chainTest proof n gsize = testProperty message action
+  where
+    message = "MockChainTrace: " ++ show proof ++ " era."
+    action = do
+      (vs, genstate) <- genTxSeq proof gsize n
+      initState <- genMockChainState proof genstate
+      trace1 <-
+        traceFromInitState @(MOCKCHAIN era)
+          testGlobals
+          (fromIntegral (length vs))
+          (Gen1 vs)
+          (Just (\_ -> pure $ Right initState))
+      -- Here is where we can add some properties for traces:
+      pure (_traceInitState trace1 === initState)
+
+testTraces :: Word64 -> TestTree
+testTraces n =
+  testGroup
+    "MockChainTrace"
+    [ chainTest (Babbage Mock) n def,
+      chainTest (Alonzo Mock) n def,
+      chainTest (Mary Mock) n def,
+      chainTest (Allegra Mock) n def,
+      chainTest (Shelley Mock) n def
+    ]

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -8,6 +8,7 @@
 
 module Main where
 
+import System.IO (hSetEncoding, stdout, utf8)
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
 import Test.Cardano.Ledger.BaseTypes (baseTypesTests)
 import Test.Cardano.Ledger.Examples.BabbageFeatures (babbageFeatures)
@@ -48,4 +49,6 @@ mainTests =
 
 -- main entry point
 main :: IO ()
-main = mainWithTestScenario tests
+main = do
+  hSetEncoding stdout utf8
+  mainWithTestScenario tests

--- a/libs/small-steps-test/small-steps-test.cabal
+++ b/libs/small-steps-test/small-steps-test.cabal
@@ -38,6 +38,7 @@ library
                      , Control.State.Transition.Trace.Generator.QuickCheck
                      , Hedgehog.Extra.Manual
   build-depends:       goblins
+                     , cardano-prelude
                      , hedgehog >= 1.0.4
                      , tasty-hunit
                      , microlens

--- a/libs/small-steps-test/src/Control/State/Transition/Trace.hs
+++ b/libs/small-steps-test/src/Control/State/Transition/Trace.hs
@@ -50,6 +50,7 @@ module Control.State.Transition.Trace
   )
 where
 
+import Cardano.Prelude (NFData)
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
@@ -104,6 +105,13 @@ data Trace s = Trace
   deriving (Generic)
 
 makeLenses ''Trace
+
+deriving instance
+  ( NFData (Environment s),
+    NFData (State s),
+    NFData (SigState s)
+  ) =>
+  (NFData (Trace s))
 
 deriving instance
   (Eq (State s), Eq (Signal s), Eq (Environment s)) => (Eq (Trace s))

--- a/libs/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/libs/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -96,8 +96,8 @@ traceFrom traceEnv maxTraceLength traceGenEnv env st0 = do
       State sts ->
       [(State sts, Signal sts)] ->
       QuickCheck.Gen [(State sts, Signal sts)]
-    loop 0 _ acc = pure $! acc
-    loop !d sti stSigs = do
+    loop 0 _ !acc = pure acc
+    loop d !sti !stSigs = do
       sig <- sigGen @sts @traceGenEnv traceGenEnv env sti
       case interpretSTS @sts @traceGenEnv traceEnv (Trace.applySTSTest @sts (TRC (env, sti, sig))) of
         Left _predicateFailures ->


### PR DESCRIPTION
Fixed the annoying MockChain trace failures. Paradoxically this was done be adding a 'seq' call to
genRecipientsFrom.  Also added strictness annotations (!) to GenSize, GenState, and MockChainState as well as the predicate faiulres for MOCKCHAIN. Reabased on master and ormolised.