### PR TITLE
Fix inlining for CompactAddr in the FromCBOR instance

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -611,6 +611,7 @@ instance
   FromCBOR (TxOut era)
   where
   fromCBOR = fromNotSharedCBOR
+  {-# INLINE fromCBOR #-}
 
 instance
   ( Era era,
@@ -649,7 +650,7 @@ instance
         cv <- decodeNonNegative
         mkTxOutCompact a ca cv . SJust <$> fromCBOR
       Just _ -> cborError $ DecoderErrorCustom "txout" "wrong number of terms in txout"
-  {-# INLINEABLE fromSharedCBOR #-}
+  {-# INLINE fromSharedCBOR #-}
 
 pattern TxOutCompact ::
   ( Era era,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
@@ -10,7 +10,13 @@ module Test.Cardano.Ledger.Shelley.Address.CompactAddr where
 
 import Cardano.Binary (serialize')
 import qualified Cardano.Crypto.Hash.Class as Hash
-import Cardano.Ledger.Address (Addr (..), RewardAcnt (..), putVariableLengthWord64, serialiseAddr)
+import Cardano.Ledger.Address
+  ( Addr (..),
+    RewardAcnt (..),
+    deserialiseAddr,
+    putVariableLengthWord64,
+    serialiseAddr,
+  )
 import qualified Cardano.Ledger.CompactAddress as CA
 import Cardano.Ledger.Credential
 import qualified Cardano.Ledger.Crypto as CC (Crypto (ADDRHASH))
@@ -30,8 +36,9 @@ import Test.QuickCheck.Gen (chooseWord64)
 
 propValidateNewDecompact :: forall crypto. CC.Crypto crypto => Addr crypto -> Property
 propValidateNewDecompact addr =
-  let compact = SBS.toShort $ serialiseAddr addr
-      decompactedOld = CA.deserializeShortAddr @crypto compact
+  let bs = serialiseAddr addr
+      compact = SBS.toShort bs
+      decompactedOld = deserialiseAddr @crypto bs
       decompactedNew = CA.decodeAddrShort @crypto compact
    in isJust decompactedOld .&&. decompactedOld === decompactedNew
 

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -133,8 +133,7 @@ benchmark address
     criterion,
     deepseq,
     strict-containers,
-    text,
-    ledger-state
+    text
   ghc-options:
       -threaded
       -rtsopts


### PR DESCRIPTION
There was not enough inlining prior to this PR which resulted in a slight but noticeable regression, when comparing to the implementation prior to the fix to address deserialization. TLDR, nothing crazy, just some inlining.