### PR TITLE
Make `lvExtraEntropy` lazy.

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}


### PR DESCRIPTION
This field isn't needed in Babbage, and indeed has no sensible value.
But we're in a `StrictData` module, so it's being evaluated. Making it
lazy should solve this.

Where the extra entropy is set, we force it first in order to not
introduce unnecessary thunks.