### PR TITLE
fix babbage min utxo calculation

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -243,7 +243,7 @@ validateCollateralEqBalance bal txcoll =
 -- > getValue txout ≥ inject ( ⌈ serSize txout ∗ coinsPerUTxOWord pp / 8 ⌉ )
 validateOutputTooSmallUTxO ::
   ( Era era,
-    ToCBOR (Core.Value era),
+    ToCBOR (Core.TxOut era),
     HasField "_coinsPerUTxOWord" (Core.PParams era) Coin
   ) =>
   Core.PParams era ->
@@ -252,9 +252,7 @@ validateOutputTooSmallUTxO ::
 validateOutputTooSmallUTxO pp outs = failureUnless (null outputsTooSmall) $ OutputTooSmallUTxO outputsTooSmall
   where
     Coin coinsPerUTxOWord = getField @"_coinsPerUTxOWord" pp
-    -- It's better to use the length of the bytestring that was sent over
-    -- the wire instead of reserializing the data
-    serSize = fromIntegral . BSL.length . serialize . getField @"value"
+    serSize = fromIntegral . BSL.length . serialize
     outputsTooSmall =
       filter
         ( \out ->

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -132,7 +132,8 @@ instance PrettyA (PParamsUpdate era) where
 
 ppBabbageUtxoPred ::
   ( PrettyA (UtxoPredicateFailure era),
-    PrettyA (UtxowPredicateFail era)
+    PrettyA (UtxowPredicateFail era),
+    PrettyA (Core.TxOut era)
   ) =>
   BabbageUtxoPred era ->
   PDoc
@@ -146,10 +147,13 @@ ppBabbageUtxoPred (DanglingWitnessDataHash dhset) =
   ppSexp "DanglingWitnessDataHashes" [ppSet ppDataHash dhset]
 ppBabbageUtxoPred (MalformedScripts scripts) =
   ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
+ppBabbageUtxoPred (BabbageOutputTooSmallUTxO xs) =
+  ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair prettyA ppInteger) xs]
 
 instance
   ( PrettyA (UtxoPredicateFailure era),
-    PrettyA (UtxowPredicateFail era)
+    PrettyA (UtxowPredicateFail era),
+    PrettyA (Core.TxOut era)
   ) =>
   PrettyA (BabbageUtxoPred era)
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..))
-import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..), Script (PlutusScript))
@@ -973,7 +972,7 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ largeOutputTx pf)
-              (Left [fromUtxo @era (OutputTooSmallUTxO [largeOutput pf])])
+              (Left [fromUtxoB @era $ BabbageOutputTooSmallUTxO [(largeOutput pf, 1015)]])
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Data (Data (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..), Script (PlutusScript))
@@ -258,7 +259,8 @@ defaultPPs =
     MaxTxExUnits $ ExUnits 1000000 1000000,
     MaxBlockExUnits $ ExUnits 1000000 1000000,
     ProtocolVersion $ ProtVer 7 0,
-    CollateralPercentage 100
+    CollateralPercentage 1,
+    AdaPerUTxOWord (Coin 5)
   ]
 
 pp :: Proof era -> Core.PParams era
@@ -818,6 +820,47 @@ malformedScript pf s = case pf of
     ms = PlutusScript PlutusV2 $ "nonsense " <> s
     er x = error $ "no malformedScript for " <> show x
 
+-- ========================================================================================
+--  Example 13: Invalid - TxOut too large for the included ADA, using a large inline datum
+-- ========================================================================================
+
+largeDatum :: Data era
+largeDatum = Data (Plutus.B . BS.pack $ replicate 1500 0)
+
+largeOutput :: forall era. Scriptic era => Proof era -> Core.TxOut era
+largeOutput pf =
+  newTxOut
+    pf
+    [ Address (plainAddr pf),
+      Amount (inject $ Coin 995),
+      Datum . Babbage.Datum . dataToBinaryData $ largeDatum @era
+    ]
+
+largeOutputTxBody :: Scriptic era => Proof era -> Core.TxBody era
+largeOutputTxBody pf =
+  newTxBody
+    pf
+    [ Inputs' [somePlainInput],
+      Outputs' [largeOutput pf],
+      Txfee (Coin 5)
+    ]
+
+largeOutputTx ::
+  forall era.
+  ( Scriptic era,
+    GoodCrypto (Crypto era)
+  ) =>
+  Proof era ->
+  Core.Tx era
+largeOutputTx pf =
+  newTx
+    pf
+    [ Body (largeOutputTxBody pf),
+      WitnessesI
+        [ AddrWits' [makeWitnessVKey (hashAnnotated (largeOutputTxBody pf)) (someKeys pf)]
+        ]
+    ]
+
 -- ====================================================================================
 --
 -- ====================================================================================
@@ -925,7 +968,12 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ inlineDatumV1Tx pf)
-              (Left [fromUtxos @era (CollectErrors [BadTranslation InlineDatumsNotSupported])])
+              (Left [fromUtxos @era (CollectErrors [BadTranslation InlineDatumsNotSupported])]),
+          testCase "min-utxo value with output too large" $
+            testU
+              pf
+              (trustMeP pf True $ largeOutputTx pf)
+              (Left [fromUtxo @era (OutputTooSmallUTxO [largeOutput pf])])
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -204,6 +204,8 @@ data PParamsField era
     ProtocolVersion (ProtVer)
   | -- | Minimum Stake Pool Cost
     MinPoolCost (Coin)
+  | -- | Minimum Lovelace in a UTxO (deprecated by AdaPerUTxOWord)
+    MinUTxOValue (Coin)
   | -- | Cost in ada per byte of UTxO storage (instead of _minUTxOValue)
     AdaPerUTxOWord (Coin)
   | -- | Cost models for non-native script languages

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -320,7 +320,16 @@ updateShelleyPP pp dpp = case dpp of
   (ExtraEntropy nonce) -> pp {Shelley._extraEntropy = nonce}
   (ProtocolVersion pv) -> pp {Shelley._protocolVersion = pv}
   (MinPoolCost coin) -> pp {Shelley._minPoolCost = coin}
-  _ -> pp
+  (MinUTxOValue mu) -> pp {Shelley._minUTxOValue = mu}
+  -- Not present in Shelley
+  (AdaPerUTxOWord _) -> pp
+  (Costmdls _) -> pp
+  (Prices _) -> pp
+  (MaxTxExUnits _) -> pp
+  (MaxBlockExUnits _) -> pp
+  (MaxValSize _) -> pp
+  (MaxCollateralInputs _) -> pp
+  (CollateralPercentage _) -> pp
 
 -- | updatePParams uses the Override policy exclusively
 updatePParams :: Proof era -> Core.PParams era -> PParamsField era -> Core.PParams era
@@ -350,7 +359,10 @@ updatePParams (Alonzo _) pp dpp = case dpp of
   MaxTxExUnits n -> pp {Alonzo._maxTxExUnits = n}
   MaxBlockExUnits n -> pp {Alonzo._maxBlockExUnits = n}
   CollateralPercentage perc -> pp {Alonzo._collateralPercentage = perc}
-  _ -> pp
+  MaxCollateralInputs n -> pp {Alonzo._maxCollateralInputs = n}
+  AdaPerUTxOWord n -> pp {Alonzo._coinsPerUTxOWord = n}
+  -- Not used in Alonzo
+  MinUTxOValue _ -> pp
 updatePParams (Babbage _) pp dpp = case dpp of
   (MinfeeA nat) -> pp {Babbage._minfeeA = nat}
   (MinfeeB nat) -> pp {Babbage._minfeeB = nat}
@@ -373,9 +385,11 @@ updatePParams (Babbage _) pp dpp = case dpp of
   MaxBlockExUnits n -> pp {Babbage._maxBlockExUnits = n}
   CollateralPercentage perc -> pp {Babbage._collateralPercentage = perc}
   MaxCollateralInputs n -> pp {Babbage._maxCollateralInputs = n}
-  D _ -> pp -- All these are no longer in Babbage
+  AdaPerUTxOWord n -> pp {Babbage._coinsPerUTxOWord = n}
+  -- Not used in Babbage
+  D _ -> pp
   ExtraEntropy _ -> pp
-  AdaPerUTxOWord _ -> pp
+  MinUTxOValue _ -> pp
 
 newPParams :: Proof era -> [PParamsField era] -> Core.PParams era
 newPParams era = List.foldl' (updatePParams era) (initialPParams era)


### PR DESCRIPTION
Fix the bug in the Babbage minimum utxo calculation. closes #2765

This commit can be review commit by commit:
* The first commit removes the wildcard pattern matching in updaters. We were silently ignoring updates to the `AdaPerUTxOWord` field.
* The next commit creates a unit test which exhibits the bug described in #2765.
* The next commit fixes the bug. We now correctly count the size of all the bytes in the serialized outputs.
* The last commit swaps out the Alonzo predicate failure for violations of the min-utxo check for a more descriptive failure. In particular, the failure now tells you what the minimum value was for the given offending outputs.

In addition to the unit test added in this PR, we will soon change the value of `AdaPerUTxOWord` in the property tests to something non-zero.