### PR TITLE
Only evaluate Plutus scripts in static checks.

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -80,7 +80,7 @@ lblStatic = "static"
 --   The choice of '#' as a postfix here is made because often these are crypto
 --   checks.
 (?!#) :: Bool -> PredicateFailure sts -> Rule sts ctx ()
-(?!#) = labeledPred [lblStatic]
+(?!#) = labeledPred $ lblStatic NE.:| []
 
 infix 1 ?!#
 
@@ -89,7 +89,7 @@ infix 1 ?!#
 --   The choice of '#' as a postfix here is made because often these are crypto
 --   checks.
 (?!#:) :: Either e () -> (e -> PredicateFailure sts) -> Rule sts ctx ()
-(?!#:) = labeledPredE [lblStatic]
+(?!#:) = labeledPredE $ lblStatic NE.:| []
 
 infix 1 ?!#:
 
@@ -130,7 +130,7 @@ runTest :: Inject t (PredicateFailure sts) => Test t -> Rule sts ctx ()
 runTest = validateTrans inject
 
 runTestOnSignal :: Inject t (PredicateFailure sts) => Test t -> Rule sts ctx ()
-runTestOnSignal = validateTransLabeled inject [lblStatic]
+runTestOnSignal = validateTransLabeled inject $ lblStatic NE.:| []
 
 runTestMaybe :: InjectMaybe t (PredicateFailure sts) => Test t -> Rule sts ctx ()
 runTestMaybe = validate . mapMaybeValidation injectMaybe


### PR DESCRIPTION
Initially, Plutus scripts were evaluated using the following:
```
      evalScripts @era tx sLst
        ?!## ValidationTagMismatch (getField @"isValid" tx)
```

However, as of https://github.com/input-output-hk/cardano-ledger/pull/2386, additional reporting was added to Plutus script
failure, and this was changed to the following:
```
      case evalScripts @era tx sLst of
        Fails sss -> False ?!## ValidationTagMismatch (getField @"isValidating" tx) (pack (Prelude.unlines sss))
        Passes -> pure ()
```
The problem here: `evalScripts` is no longer gated by the `?!##`
operator; it must be evaulated at least to WHNF in order to match the
`Fails` constructor. This means that when reapplying transactions in the
mempool (as well as when replaying blocks), we are always running all
Plutus scripts.

The current semantics for using "labeled" predicates is insufficient to
solve this, since we cannot carry out additional actions (such as
emitting events) inside the predicate. As such, we introduce additional
functionality in the STS system to allow gating sections of rules (which
do not result in a return value) with labels. For the sake of
consistency, the existing `labeledPred` function et al are updated to
make use of this new feature.

The entire call to `evalScripts` is now gated by a `nonStatic` label,
and hence will not be evaulated in any `reapply` scenario.