### PR TITLE
Fix `ValidateNone` policy.

### DIFF
--- a/libs/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
+++ b/libs/small-steps-test/test/Control/State/Transition/Examples/GlobalSum.hs
@@ -11,6 +11,7 @@ import Control.Arrow (right)
 import Control.Monad.Reader
 import Control.State.Transition.Extended
 import Data.Foldable (foldl')
+import qualified Data.List.NonEmpty as NE
 import Data.Void (Void)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -46,6 +47,8 @@ instance STS GSUM where
         TRC ((), st, xs) <- judgmentContext
         sum <- liftSTS $ reader opSum
         tellEvent $ ErrorEvent (error "Event has been evaluated!")
+        labeled ("testLabel" NE.:| []) $ (sum xs /= 56) ?! NoFailure
+        sum xs /= 56 ?! NoFailure
         return $! st + sum xs
     ]
 
@@ -55,12 +58,32 @@ tests =
     "STS.Extended"
     [ testCase "Sum" $ withSum @=? Right 55,
       testCase "Product" $ withProduct @=? Right 3628800,
-      testCase "Sum/Lazy Events" $ withLazyEventsSum @=? Right 55
+      testCase "Sum/Lazy Events" $ withLazyEventsSum @=? Right 55,
+      testGroup
+        "Sum/Validate"
+        [ testCase "Filtered" $
+            withLblSum (ValidateSuchThat ("testLabel" `notElem`)) @=? Left [NoFailure],
+          testCase "Unfiltered" $
+            withLblSum (ValidateSuchThat (const True)) @=? Left [NoFailure, NoFailure],
+          testCase "None" $
+            withLblSum ValidateNone @=? Right 56
+        ]
     ]
   where
     inputs = [1 .. 10]
     ctx = TRC ((), 0, inputs)
     withSum = runReader (applySTS @GSUM ctx) (Ops (foldl' (+) 0))
+    withLblSum vp =
+      right fst $
+        runReader (applySTSOptsEither @GSUM lblOpts ctx) (Ops (foldl' (+) 1))
+      where
+        lblOpts =
+          ApplySTSOpts
+            { asoAssertions = AssertionsOff,
+              asoValidation = vp,
+              asoEvents = EPReturn
+            }
+
     withProduct = runReader (applySTS @GSUM ctx) (Ops (foldl' (*) 1))
     withLazyEventsSum =
       right fst $


### PR DESCRIPTION
PR #2767 moved to using `labeled` sections to gate validation for more
than just predicates. However, it totally failed to take account of the
fact that `ValidateNone` should turn off all predicates, and hence
accidentally turned them all back on. *facepalm*.

This PR fixes that, and adds a set of tests to ensure that it remains
fixed.