### PR TITLE
Remove Show for PlutusDebug and disable traceEvent on PlutusScriptResult

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -241,10 +241,9 @@ evalScripts pv tx ((pscript, lang, ds, units, cost) : rest) =
         intercalate
           ","
           [ "[LEDGER][PLUTUS_SCRIPT]",
-            "END",
-            "res = " <> show res
+            "END"
           ]
-   in (traceEvent endMsg res) <> evalScripts pv tx rest
+   in traceEvent endMsg res <> evalScripts pv tx rest
 
 -- Collect information (purpose and ScriptHash) about all the
 -- Credentials that refer to scripts, that might be run in a Tx.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -464,12 +464,12 @@ valContext (TxInfoPV1 txinfo) sp = Data (PV1.toData (PV1.ScriptContext txinfo (t
 valContext (TxInfoPV2 txinfo) sp = Data (PV2.toData (PV2.ScriptContext txinfo (transScriptPurpose sp)))
 
 data ScriptFailure = PlutusSF Text PlutusDebug
-  deriving (Show, Eq, Generic, NoThunks)
+  deriving (Eq, Generic, NoThunks)
 
 data ScriptResult
   = Passes [PlutusDebug]
   | Fails [PlutusDebug] (NonEmpty ScriptFailure)
-  deriving (Show, Generic)
+  deriving (Generic)
 
 scriptPass :: PlutusDebug -> ScriptResult
 scriptPass pd = Passes [pd]
@@ -501,7 +501,12 @@ data PlutusDebug
       SBS.ShortByteString
       [PV2.Data]
       ProtVer
-  deriving (Show, Eq, Generic, NoThunks)
+  deriving (Eq, Generic, NoThunks)
+
+-- There is no Show instance for PlutusDebug intentionally, because it is too
+-- expensive and it will be too tempting to use it incorrectly. If needed for
+-- testing use 'StandaloneDeriving', otherwise define an efficient way to display
+-- this info.
 
 data PlutusError = PlutusErrorV1 PV1.EvaluationError | PlutusErrorV2 PV2.EvaluationError
   deriving (Show)
@@ -511,7 +516,6 @@ data PlutusDebugInfo
   | DebugCannotDecode String
   | DebugInfo [Text] PlutusError PlutusDebug
   | DebugBadHex String
-  deriving (Show)
 
 instance ToCBOR PlutusDebug where
   toCBOR (PlutusDebugV1 a b c d e) = encode $ Sum PlutusDebugV1 0 !> To a !> To b !> To c !> To d !> To e

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -2,15 +2,21 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.Examples where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..))
-import Cardano.Ledger.Alonzo.TxInfo (ScriptResult (Fails, Passes), runPLCScript)
+import Cardano.Ledger.Alonzo.TxInfo
+  ( PlutusDebug (..),
+    PlutusDebugInfo (..),
+    ScriptFailure (..),
+    ScriptResult (Fails, Passes),
+    runPLCScript,
+  )
 import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Data.ByteString.Short (ShortByteString)
 import Data.Proxy (Proxy (..))
@@ -34,6 +40,16 @@ import qualified Test.Cardano.Ledger.Alonzo.PlutusScripts as Generated
 import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
 import Test.Tasty
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
+
+-- Do not remove these instances. They are here for two resons:
+--
+--  * Prevent usage of Show on these huge data types in production
+--  * Allow printing for testing.
+deriving instance Show PlutusDebug
+
+deriving instance Show PlutusDebugInfo
+
+deriving instance Show ScriptFailure
 
 -- =============================================
 

--- a/libs/plutus-preprocessor/src/Debug.hs
+++ b/libs/plutus-preprocessor/src/Debug.hs
@@ -1,9 +1,20 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Main where
 
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.TxInfo (debugPlutus)
+import Cardano.Ledger.Alonzo.TxInfo (PlutusDebug (..), PlutusDebugInfo (..), debugPlutus)
 import System.Environment (getArgs)
 import System.IO
 
+-- Do not remove these instances. They are here for two resons:
+--
+--  * Prevent usage of Show on these huge data types in production
+--  * Allow printing for debugging.
+deriving instance Show PlutusDebug
+
+deriving instance Show PlutusDebugInfo
+
 main :: IO ()
-main = getArgs >>= (print . debugPlutus . head)
+main = print . debugPlutus . head =<< getArgs


### PR DESCRIPTION
@TimSheard and I discovered that it is really expensive to `traceEvent` that involves `PlutusDebug`, because showing that type is way too inefficient (naturally due to the `String` type and the size of the type).

This PR simply disables showing the `ScriptResult` in the event log tracing. If this is an unacceptable solution we need discuss a better one. However, adding the huge debug trace for every script even if it is only for profiling is unacceptable, because it affects our ability to argue about performance of running a script, since showing the `PlutusDebug` will dominate the overhead. 

Also this PR intentionally removes the Show instance, to prevent future temptation of relying on it.