### PR TITLE
Bump plutus again

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -77,8 +77,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 5cc518f1202930ad52b8ba838af32af084c0e754
-  --sha256: 0w9v0n7rv2bmp0m4nrvxxncic7b23v3m4f89k31x0cawqzvhysbf
+  tag: fec94223a985e34d3b270460c8f150002f41b85b
+  --sha256: 1mwknikvbpv9lj43c3ya24v7wpcbpcsrk0fnh6knpi7ds4rmj9j0
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -323,7 +323,7 @@ language = 0 ; Plutus v1
 
 costmdls =
   { ? 0 : [ 166*166 int ] ; Plutus v1
-  , ? 1 : [ 170*170 int ] ; Plutus v2
+  , ? 1 : [ 175*175 int ] ; Plutus v2
   }
 
 transaction_metadatum =


### PR DESCRIPTION
This bumps `plutus` to the tip of `release/1.0.0`, including:
- Fixing the checks for builtins
- Fixing the protocol version corresponding to Vasil
- Cost models for the SECP256k1 functions