### PR TITLE
Append non-zero exit code to nix-shell prompt

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -48,6 +48,18 @@ let
     exactDeps = false;
 
     inherit withHoogle;
+    shellHook = ''
+      DEFAULT_PS1="\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] "
+      prompt() {
+        local EXIT="$?"
+        if [ $EXIT != 0 ]; then
+          PS1="$DEFAULT_PS1\[\033[1;31m\]($EXIT)\[\033[00m\] "
+        else
+          PS1="$DEFAULT_PS1"
+        fi
+      }
+      PROMPT_COMMAND=prompt
+    '';
   };
 
   devops = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
to make command failures easier to see

Not sure if anyone else finds this useful - sometimes I ignored by mistake a failed command because the failure was not very obvious in the output. 
This adds the error code to the prompt in case the last command failed, for example: 
![2022-05-12_17-50](https://user-images.githubusercontent.com/2070003/168127715-56c710ec-f42c-4da4-a32e-a605ec2effd8.png)

If this is not an annoyance for anyone else, we can ignore the PR 