### PR TITLE
Extend the EpochInfo window in the Alonzo era.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -41,8 +41,8 @@ test-show-details: streaming
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8fe904d629194b1fbaaf2d0a4e0ccd17052e9103
-  --sha256: sha256-5B5lJFfUm4jbCBQtqTMvtiY2AWtnsN/1TYftAglT38A=
+  tag: b1eb0e678b834ef5a6eaea84e75b41a14123331a
+  --sha256: 0944wg2nqazmhlmsynwgdwxxj6ay0hb9qig9l128isb2cjia0hlp
   subdir:
     base-deriving-via
     binary

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -347,7 +347,7 @@ utxoTransition = do
   ei <- liftSTS $ asks epochInfoWithErr
 
   {- epochInfoSlotToUTCTime epochInfo systemTime i_f ≠ ◇ -}
-  runTest $ validateOutsideForecast ei sysSt tx
+  runTest $ validateOutsideForecast pp ei slot sysSt tx
 
   {-   txins txb ≠ ∅   -}
   runTestOnSignal $ Shelley.validateInputSetEmptyUTxO txb

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -10,6 +10,7 @@ module Cardano.Ledger.Shelley.HardForks
     translateTimeForPlutusScripts,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
+    allowOutsideForecastTTL,
   )
 where
 
@@ -75,3 +76,13 @@ forgoRewardPrefilter ::
   pp ->
   Bool
 forgoRewardPrefilter pp = pvMajor (getField @"_protocolVersion" pp) > 6
+
+-- | In versions 5 and 6, we allow the ttl field to lie outside the stability
+-- window.
+allowOutsideForecastTTL ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+allowOutsideForecastTTL pp =
+  let mv = pvMajor (getField @"_protocolVersion" pp)
+   in mv == 5 || mv == 6


### PR DESCRIPTION
The `EpochInfo` provided to the ledger by consensus can throw an error
(or return the Left of an Either) when the slot it is asked to translate
lies outside of its predictable window. However, at present this
function has a bug: when consensus doesn't know about any future epochs,
it considers its predictable interval to be unbounded. This may then
change when a new era is added to the codebase, resulting in old
transactions not validating.

The intention is to remove this bug in consensus, such that the
`EpochInfo` is appropriately bounded in all eras. Unfortunately, since
some transactions with TTLs outside of the usual window have been
allowed on-chain, we have to disable this check in the Alonzo era. In
order to do this, we linearly extend the `EpochInfo` based on the
current and previous slot, which we are guaranteed to be able to
translate, since otherwise we could not be processing this slot.

closes #2788