### PR TITLE
Generate each Tx with its own ValidityInterval.

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -295,12 +295,26 @@ getOutputs (Mary _) tx = getField @"outputs" tx
 getOutputs (Allegra _) tx = getField @"outputs" tx
 getOutputs (Shelley _) tx = getField @"outputs" tx
 
+getScriptWits :: Proof era -> Core.Witnesses era -> Map (ScriptHash (Crypto era)) (Core.Script era)
+getScriptWits (Babbage _) tx = getField @"scriptWits" tx
+getScriptWits (Alonzo _) tx = getField @"scriptWits" tx
+getScriptWits (Mary _) tx = getField @"scriptWits" tx
+getScriptWits (Allegra _) tx = getField @"scriptWits" tx
+getScriptWits (Shelley _) tx = getField @"scriptWits" tx
+
 allInputs :: Proof era -> Core.TxBody era -> Set (TxIn (Crypto era))
 allInputs (Babbage _) txb = getAllTxInputs txb
 allInputs (Alonzo _) txb = getAllTxInputs txb
 allInputs (Mary _) txb = getAllTxInputs txb
 allInputs (Allegra _) txb = getAllTxInputs txb
 allInputs (Shelley _) txb = getAllTxInputs txb
+
+getWitnesses :: Proof era -> Core.Tx era -> Core.Witnesses era
+getWitnesses (Babbage _) tx = getField @"wits" tx
+getWitnesses (Alonzo _) tx = getField @"wits" tx
+getWitnesses (Mary _) tx = getField @"wits" tx
+getWitnesses (Allegra _) tx = getField @"wits" tx
+getWitnesses (Shelley _) tx = getField @"wits" tx
 
 primaryLanguage :: Proof era -> Maybe Language
 primaryLanguage (Babbage _) = Just (PlutusV2)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1092,9 +1092,9 @@ pcData d@(Data (B bytes)) =
 
 instance Era era => PrettyC (Alonzo.Data era) era where prettyC _ = pcData
 
-pcTimelock :: Reflect era => PDoc -> Timelock (Crypto era) -> PDoc
+pcTimelock :: forall era. Reflect era => PDoc -> Timelock (Crypto era) -> PDoc
 pcTimelock hash (RequireSignature akh) = ppSexp "Signature" [keyHashSummary akh, hash]
-pcTimelock hash (RequireAllOf _) = ppSexp "AllOf" [hash]
+pcTimelock hash (RequireAllOf _ts) = ppSexp "AllOf" [hash]
 pcTimelock hash (RequireAnyOf _) = ppSexp "AnyOf" [hash]
 pcTimelock hash (RequireMOf m _) = ppSexp "MOfN" [ppInteger (fromIntegral m), hash]
 pcTimelock hash (RequireTimeExpire mslot) = ppSexp "Expires" [ppSlotNo mslot, hash]
@@ -1326,3 +1326,5 @@ instance Reflect era => PrettyC (EpochState era) era where prettyC = pcEpochStat
 
 pc :: PrettyC t era => Proof era -> t -> IO ()
 pc proof x = putStrLn (show (prettyC proof x))
+
+-- ===================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -110,7 +110,7 @@ genTxAndLEDGERState proof sizes = do
   let genT = do
         (initial, _) <- genUTxO -- Generate a random UTxO, so mUTxO is not empty
         modifyModel (\m -> m {mUTxO = initial})
-        (_utxo, tx) <- genValidatedTx proof
+        (_utxo, tx) <- genValidatedTx proof slotNo
         model <- gets gsModel
         pp <- gets (gePParams . gsGenEnv)
         let ledgerState = extract @(LedgerState era) model
@@ -235,13 +235,13 @@ adaIsPreserved ::
   Proof era ->
   TestTree
 adaIsPreserved proof =
-  testProperty (show proof ++ " era. Trace length = 100") $
-    traceProp proof 100 def (\firstSt lastSt -> totalAda firstSt === totalAda lastSt)
+  testProperty (show proof ++ " era. Trace length = 45") $
+    traceProp proof 45 def (\firstSt lastSt -> totalAda firstSt === totalAda lastSt)
 
 tracePreserveAda :: TestTree
 tracePreserveAda =
   testGroup
-    "Total Ada is preserved over traces of length 100"
+    "Total Ada is preserved over traces of length 45"
     [ adaIsPreservedBabbage,
       adaIsPreserved (Alonzo Mock),
       adaIsPreserved (Mary Mock),
@@ -252,7 +252,7 @@ tracePreserveAda =
 adaIsPreservedBabbage :: TestTree
 adaIsPreservedBabbage = adaIsPreserved (Babbage Mock)
 
--- | The incremental Stake invaraint is preserved over a trace of length 100
+-- | The incremental Stake invaraint is preserved over a trace of length 45
 stakeInvariant :: Era era => MockChainState era -> MockChainState era -> Property
 stakeInvariant (MockChainState _ _ _) (MockChainState nes _ _) =
   case (lsUTxOState . esLState . nesEs) nes of
@@ -260,8 +260,8 @@ stakeInvariant (MockChainState _ _ _) (MockChainState nes _ _) =
 
 incrementStakeInvariant :: (Reflect era, HasTrace (MOCKCHAIN era) (Gen1 era)) => Proof era -> TestTree
 incrementStakeInvariant proof =
-  testProperty (show proof ++ " era. Trace length = 100") $
-    traceProp proof 100 def stakeInvariant
+  testProperty (show proof ++ " era. Trace length = 45") $
+    traceProp proof 45 def stakeInvariant
 
 incrementalStake :: TestTree
 incrementalStake =
@@ -282,7 +282,7 @@ genericProperties =
       txPreserveAda,
       tracePreserveAda,
       incrementalStake,
-      testTraces 100
+      testTraces 45 -- When we get the Epoch Boundary correct we can increass this to 100-200
     ]
 
 -- ==============================================================
@@ -323,7 +323,7 @@ runTest computeWith action proof = do
   action ans
 
 main2 :: IO ()
-main2 = runTest (\x -> fst <$> genValidatedTx x) (const (pure ())) (Babbage Mock)
+main2 = runTest (\x -> fst <$> genValidatedTx x (SlotNo 0)) (const (pure ())) (Babbage Mock)
 
 main3 :: IO ()
 main3 = runTest (\_x -> UTxO . fst <$> genUTxO) action (Alonzo Mock)


### PR DESCRIPTION
Updates the Generic generator of transaction used in Property.hs to give each Tx its own ValidityInterval tied to the actual SlotNo the Tx is validated in.