### PR TITLE
Emit new TotalAdaPotEvent after epoch transition (gh #2780)

### DIFF
--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -41,6 +41,7 @@ library
     Cardano.Ledger.Shelley.API.Wallet
     Cardano.Ledger.Shelley.API.Mempool
     Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
     Cardano.Ledger.Shelley.BlockChain
     Cardano.Ledger.Shelley.CompactAddr
     Cardano.Ledger.Shelley.Delegation.Certificates

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -32,6 +32,10 @@ module Cardano.Ledger.Shelley.API.Wallet
     -- * Transaction helpers
     CLI (..),
     addShelleyKeyWitnesses,
+    -- -- * Ada pots
+    AdaPots (..),
+    totalAdaES,
+    totalAdaPotsES,
   )
 where
 
@@ -68,6 +72,11 @@ import Cardano.Ledger.PoolDistr
     PoolDistr (..),
   )
 import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.AdaPots
+  ( AdaPots (..),
+    totalAdaES,
+    totalAdaPotsES,
+  )
 import qualified Cardano.Ledger.Shelley.EpochBoundary as EB
 import Cardano.Ledger.Shelley.LedgerState
   ( DPState (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -32,11 +32,6 @@ module Cardano.Ledger.Shelley.API.Wallet
     -- * Transaction helpers
     CLI (..),
     addShelleyKeyWitnesses,
-
-    -- * Ada Pots
-    AdaPots (..),
-    totalAdaES,
-    totalAdaPotsES,
   )
 where
 
@@ -73,11 +68,9 @@ import Cardano.Ledger.PoolDistr
     PoolDistr (..),
   )
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Constraints (UsesValue)
 import qualified Cardano.Ledger.Shelley.EpochBoundary as EB
 import Cardano.Ledger.Shelley.LedgerState
-  ( AccountState (..),
-    DPState (..),
+  ( DPState (..),
     EpochState (..),
     LedgerState (..),
     NewEpochState (..),
@@ -90,7 +83,6 @@ import Cardano.Ledger.Shelley.LedgerState
     incrementalStakeDistr,
     minfee,
     produced,
-    rewards,
   )
 import Cardano.Ledger.Shelley.PParams (PParams' (..))
 import Cardano.Ledger.Shelley.PoolRank
@@ -105,11 +97,10 @@ import Cardano.Ledger.Shelley.Rewards (StakeShare (..))
 import Cardano.Ledger.Shelley.Rules.NewEpoch (calculatePoolDistr)
 import Cardano.Ledger.Shelley.Tx (Tx (..), WitnessSet, WitnessSetHKD (..))
 import Cardano.Ledger.Shelley.TxBody (DCert, PoolParams (..), WitVKey (..))
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.Slot (epochInfoSize)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val ((<->))
-import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (EpochSize)
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (runReader)
@@ -126,7 +117,7 @@ import Data.Coders
   )
 import Data.Default.Class (Default (..))
 import Data.Either (fromRight)
-import Data.Foldable (fold, foldMap')
+import Data.Foldable (foldMap')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
@@ -556,55 +547,6 @@ instance CC.Crypto c => CLI (ShelleyEra c) where
   addKeyWitnesses = addShelleyKeyWitnesses
 
   evaluateMinLovelaceOutput pp _out = _minUTxOValue pp
-
-data AdaPots = AdaPots
-  { treasuryAdaPot :: Coin,
-    reservesAdaPot :: Coin,
-    rewardsAdaPot :: Coin,
-    utxoAdaPot :: Coin,
-    depositsAdaPot :: Coin,
-    feesAdaPot :: Coin
-  }
-  deriving (Show, Eq)
-
--- | Calculate the total ada pots in the epoch state
-totalAdaPotsES ::
-  UsesValue era =>
-  EpochState era ->
-  AdaPots
-totalAdaPotsES (EpochState (AccountState treasury_ reserves_) _ ls _ _ _) =
-  AdaPots
-    { treasuryAdaPot = treasury_,
-      reservesAdaPot = reserves_,
-      rewardsAdaPot = rewards_,
-      utxoAdaPot = coins,
-      depositsAdaPot = deposits,
-      feesAdaPot = fees_
-    }
-  where
-    (UTxOState u deposits fees_ _ _) = lsUTxOState ls
-    (DPState dstate _) = lsDPState ls
-    rewards_ = fold (rewards dstate)
-    coins = Val.coin $ balance u
-
--- | Calculate the total ada in the epoch state
-totalAdaES :: UsesValue era => EpochState era -> Coin
-totalAdaES cs =
-  treasuryAdaPot
-    <> reservesAdaPot
-    <> rewardsAdaPot
-    <> utxoAdaPot
-    <> depositsAdaPot
-    <> feesAdaPot
-  where
-    AdaPots
-      { treasuryAdaPot,
-        reservesAdaPot,
-        rewardsAdaPot,
-        utxoAdaPot,
-        depositsAdaPot,
-        feesAdaPot
-      } = totalAdaPotsES cs
 
 --------------------------------------------------------------------------------
 -- CBOR instances

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Ledger.Shelley.AdaPots
+  ( AdaPots (..),
+    totalAdaES,
+    totalAdaPotsES,
+  )
+where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Shelley.Constraints (UsesValue)
+import Cardano.Ledger.Shelley.LedgerState
+  ( AccountState (..),
+    DPState (..),
+    EpochState (..),
+    LedgerState (..),
+    UTxOState (..),
+    rewards,
+  )
+import Cardano.Ledger.Shelley.UTxO (balance)
+import qualified Cardano.Ledger.Val as Val
+import Data.Foldable (fold)
+
+data AdaPots = AdaPots
+  { treasuryAdaPot :: Coin,
+    reservesAdaPot :: Coin,
+    rewardsAdaPot :: Coin,
+    utxoAdaPot :: Coin,
+    depositsAdaPot :: Coin,
+    feesAdaPot :: Coin
+  }
+  deriving (Show, Eq)
+
+-- | Calculate the total ada pots in the epoch state
+totalAdaPotsES ::
+  UsesValue era =>
+  EpochState era ->
+  AdaPots
+totalAdaPotsES (EpochState (AccountState treasury_ reserves_) _ ls _ _ _) =
+  AdaPots
+    { treasuryAdaPot = treasury_,
+      reservesAdaPot = reserves_,
+      rewardsAdaPot = rewards_,
+      utxoAdaPot = coins,
+      depositsAdaPot = deposits,
+      feesAdaPot = fees_
+    }
+  where
+    (UTxOState u deposits fees_ _ _) = lsUTxOState ls
+    (DPState dstate _) = lsDPState ls
+    rewards_ = fold (rewards dstate)
+    coins = Val.coin $ balance u
+
+-- | Calculate the total ada in the epoch state
+totalAdaES :: UsesValue era => EpochState era -> Coin
+totalAdaES cs =
+  treasuryAdaPot
+    <> reservesAdaPot
+    <> rewardsAdaPot
+    <> utxoAdaPot
+    <> depositsAdaPot
+    <> feesAdaPot
+  where
+    AdaPots
+      { treasuryAdaPot,
+        reservesAdaPot,
+        rewardsAdaPot,
+        utxoAdaPot,
+        depositsAdaPot,
+        feesAdaPot
+      } = totalAdaPotsES cs

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -55,7 +55,7 @@ import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import qualified Cardano.Ledger.Pretty as PP
 import Cardano.Ledger.Serialization (ToCBORGroup)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.API.Wallet
+import Cardano.Ledger.Shelley.AdaPots
   ( AdaPots (..),
     totalAdaES,
     totalAdaPotsES,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ShelleyTranslation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ShelleyTranslation.hs
@@ -1,7 +1,7 @@
 module Test.Cardano.Ledger.Shelley.ShelleyTranslation (testGroupShelleyTranslation) where
 
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.API.Wallet (totalAdaES)
+import Cardano.Ledger.Shelley.AdaPots (totalAdaES)
 import Cardano.Ledger.Shelley.LedgerState (EpochState, returnRedeemAddrsToReserves)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C_Crypto)
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -39,7 +39,7 @@ import Cardano.Ledger.Pretty
     ppWord64,
   )
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.API.Wallet (totalAdaPotsES)
+import Cardano.Ledger.Shelley.AdaPots (totalAdaPotsES)
 import Cardano.Ledger.Shelley.Constraints (UsesValue)
 import Cardano.Ledger.Shelley.LedgerState
   ( AccountState (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
@@ -100,7 +100,7 @@ import Cardano.Ledger.Shelley.API.Mempool
     mkMempoolState,
   )
 import Cardano.Ledger.Shelley.API.Validation (ApplyBlock, applyTick)
-import Cardano.Ledger.Shelley.API.Wallet (totalAdaES)
+import Cardano.Ledger.Shelley.AdaPots (totalAdaES)
 import Cardano.Ledger.Shelley.Constraints (UsesTxOut, UsesValue, makeTxOut)
 import Cardano.Ledger.Shelley.Genesis (initialFundsPseudoTxIn)
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState)


### PR DESCRIPTION
This is an alternative to https://github.com/input-output-hk/cardano-ledger/pull/2791

It is a solution for: https://github.com/input-output-hk/cardano-ledger/issues/2780

The difference is in how the code is refactored. This PR extracts `AdaPots` in a separate module (outside the API) and uses it from `NewEpoch`, rather than move `calculatePoolDistr` inside `Wallet.API`.

But the question is: do these functions have to be in the API? From what I can tell, there is nothing using them at the moment, but I know little!  

Are there better alternatives to this refactoring? 