### PR TITLE
Use `Data.Relation` for tests.

### DIFF
--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -57,7 +57,6 @@ library
     cardano-ledger-shelley,
     cardano-ledger-shelley-ma,
     cardano-slotting,
-    vector-map,
     containers,
     data-default,
     deepseq,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -284,7 +284,7 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
           ptrs = ptrsMap . dpsDState $ dp
           ptrs' = ptrsMap . dpsDState $ dp'
 
--- | Various preservation propertiesC
+-- | Various preservation properties
 adaPreservationChain ::
   forall era ledger.
   ( EraGen era,

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -33,7 +33,6 @@ library
   import:             base, project-config
 
   exposed-modules:     Data.AbstractSize
-                     , Data.Relation
                      , Data.CanonicalMaps
                      , Data.MemoBytes
                      , Data.Coders

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
@@ -30,7 +30,6 @@ import Cardano.Ledger.Serialization (decodeRecordNamed)
 import Control.DeepSeq (NFData)
 import Control.SetAlgebra (BaseRep (MapR), Embed (..), Exp (Base), HasExp (..))
 import Data.Map.Strict (Map)
-import Data.Relation (Relation (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
@@ -76,7 +75,7 @@ newtype PoolDistr crypto = PoolDistr
       Map (KeyHash 'StakePool crypto) (IndividualPoolStake crypto)
   }
   deriving stock (Show, Eq)
-  deriving newtype (ToCBOR, FromCBOR, NFData, NoThunks, Relation)
+  deriving newtype (ToCBOR, FromCBOR, NFData, NoThunks)
 
 -- ===============================
 

--- a/libs/set-algebra/set-algebra.cabal
+++ b/libs/set-algebra/set-algebra.cabal
@@ -50,6 +50,7 @@ test-suite tests
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Test.Control.Iterate.SetAlgebra
+                     , Test.Control.Iterate.RelationReference
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base

--- a/libs/set-algebra/src/Control/Iterate/BaseTypes.hs
+++ b/libs/set-algebra/src/Control/Iterate/BaseTypes.hs
@@ -204,7 +204,8 @@ instance (Show k, Show v) => Show (Single k v) where
 
 -- ================= Basic Set =====================
 
-data Sett k v where Sett :: (Set.Set k) -> Sett k ()
+data Sett k v where
+  Sett :: Set.Set k -> Sett k ()
 
 instance Basic Sett where
   addpair key _unit (Sett m) = Sett (Set.insert key m)

--- a/libs/set-algebra/src/Control/Iterate/Exp.hs
+++ b/libs/set-algebra/src/Control/Iterate/Exp.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/libs/set-algebra/test/Main.hs
+++ b/libs/set-algebra/test/Main.hs
@@ -1,7 +1,8 @@
 module Main where
 
+import Test.Control.Iterate.RelationReference (relationTests)
 import Test.Control.Iterate.SetAlgebra (setAlgTest)
-import Test.Tasty
+import Test.Tasty (TestTree, defaultMain, testGroup)
 
 -- ====================================================================================
 
@@ -9,7 +10,8 @@ tests :: TestTree
 tests =
   testGroup
     "set-algebra"
-    [ setAlgTest
+    [ setAlgTest,
+      relationTests
     ]
 
 main :: IO ()

--- a/libs/set-algebra/test/Test/Control/Iterate/RelationReference.hs
+++ b/libs/set-algebra/test/Test/Control/Iterate/RelationReference.hs
@@ -1,46 +1,25 @@
-{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Control.Iterate.RelationReference
-  ( Relation
-      ( (⨃),
-        (∪),
-        dom,
-        range,
-        (◁),
-        (<|),
-        (▷),
-        (|>),
-        singleton,
-        (⋪),
-        (</|),
-        (⋫),
-        (|/>),
-        Domain,
-        Range,
-        haskey,
-        addpair,
-        removekey,
-        -- below are methods not used anywhere
-        size
-      ),
-    (⊆),
-    (∪+),
-    (∈),
-    (∉),
-    (∩),
-  )
-where
+module Test.Control.Iterate.RelationReference (relationTests) where
 
+import qualified Control.Iterate.BaseTypes as SA
+import qualified Control.Iterate.Exp as SA
+import qualified Control.Iterate.SetAlgebra as SA
 import Data.Foldable (toList)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Monoid (Sum)
 import Data.Set (Set, intersection, isSubsetOf)
 import qualified Data.Set as Set
+import Test.Control.Iterate.SetAlgebra ()
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary, testProperty, (===))
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion
@@ -49,8 +28,6 @@ import qualified Data.Set as Set
 class Relation m where
   type Domain m :: Type
   type Range m :: Type
-
-  singleton :: Domain m -> Range m -> m
 
   -- | Domain
   dom :: Ord (Domain m) => m -> Set (Domain m)
@@ -61,26 +38,22 @@ class Relation m where
   -- | Domain restriction
   --
   -- Unicode: 25c1
-  (◁), (<|) :: (Ord (Domain m)) => Set (Domain m) -> m -> m
-  s <| r = s ◁ r
+  (◁) :: (Ord (Domain m)) => Set (Domain m) -> m -> m
 
   -- | Domain exclusion
   --
   -- Unicode: 22ea
-  (⋪), (</|) :: (Ord (Domain m)) => Set (Domain m) -> m -> m
-  s </| r = s ⋪ r
+  (⋪) :: (Ord (Domain m)) => Set (Domain m) -> m -> m
 
   -- | Range restriction
   --
   -- Unicode: 25b7
-  (▷), (|>) :: Ord (Range m) => m -> Set (Range m) -> m
-  s |> r = s ▷ r
+  (▷) :: Ord (Range m) => m -> Set (Range m) -> m
 
   -- | Range exclusion
   --
   -- Unicode: 22eb
-  (⋫), (|/>) :: Ord (Range m) => m -> Set (Range m) -> m
-  s |/> r = s ⋫ r
+  (⋫) :: Ord (Range m) => m -> Set (Range m) -> m
 
   -- | Union
   (∪) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
@@ -88,50 +61,34 @@ class Relation m where
   -- | Union Override Right
   (⨃) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
 
-  -- | Size of the relation
-  size :: Integral n => m -> n
-
   -- | Is this key in the Domain,  Instances should overide this default with
   -- something more efficient
   haskey :: Ord (Domain m) => Domain m -> m -> Bool
-  haskey key m = key `elem` (dom m)
-
-  -- | Insert (key,value) pair into the Relation.  Instances should overide this
-  -- default with something more efficient
-  addpair :: (Ord (Domain m), Ord (Range m)) => Domain m -> Range m -> m -> m
-  addpair key val m = m ∪ (singleton key val)
-
-  -- | Remove a key (and its associted value at that key) from the Relation.
-  -- Instances should overide this default with something more efficient
-  removekey :: Ord (Domain m) => Domain m -> m -> m
-  removekey k m = Set.singleton k ⋪ m
+  haskey key m = key `elem` dom m
 
 -- | Alias for 'elem'.
 --
 -- Unicode: 2208
 (∈) :: (Eq a, Foldable f) => a -> f a -> Bool
-a ∈ f = elem a f
+(∈) = elem
 
 -- | Alias for not 'elem'.
 --
 -- Unicode: 2209
 (∉) :: (Eq a, Foldable f) => a -> f a -> Bool
-a ∉ f = not $ elem a f
-
-infixl 4 ∉
+(∉) = notElem
 
 instance Relation (Map k v) where
   type Domain (Map k v) = k
   type Range (Map k v) = v
 
-  singleton = Map.singleton
-
   dom = Map.keysSet
+
   range = Set.fromList . Map.elems
 
   s ◁ r = Map.restrictKeys r s
 
-  s ⋪ r = Map.withoutKeys r s -- Uses library fuction which is equivalent to: Map.filterWithKey (\k _ -> k `Set.notMember` s) r
+  s ⋪ r = Map.withoutKeys r s
 
   r ▷ s = Map.filter (`Set.member` s) r
 
@@ -142,78 +99,13 @@ instance Relation (Map k v) where
   -- For union override we pass @d1@ as first argument, since 'Map.union' is left biased.
   d0 ⨃ d1 = Map.union d1 d0
 
-  size = fromIntegral . Map.size
-
-  {-# INLINE haskey #-}
-  haskey x m = case Map.lookup x m of Just _ -> True; Nothing -> False
-
-  {-# INLINE addpair #-}
-  addpair = Map.insertWith (\x _y -> x)
-
-  {-# INLINE removekey #-}
-  removekey k m = Map.delete k m
+  haskey = Map.member
 
 -- | Union override plus is (A\B)∪(B\A)∪{k|->v1+v2 | k|->v1 : A /\ k|->v2 : B}
 -- The library function Map.unionWith is more general, it allows any type for
 -- `b` as long as (+) :: b -> b -> b
 (∪+) :: (Ord a, Num b) => Map a b -> Map a b -> Map a b
-a ∪+ b = (Map.unionWith (+) a b)
-
-instance Relation (Set (a, b)) where
-  type Domain (Set (a, b)) = a
-  type Range (Set (a, b)) = b
-
-  singleton a b = Set.singleton (a, b)
-
-  dom = Set.map fst
-
-  range = Set.map snd
-
-  s ◁ r = Set.filter (\(k, _) -> k `Set.member` toSet s) r
-
-  s ⋪ r = Set.filter (\(k, _) -> k `Set.notMember` toSet s) r
-
-  r ▷ s = Set.filter (\(_, v) -> Set.member v s) r
-
-  r ⋫ s = Set.filter (\(_, v) -> Set.notMember v s) r
-
-  (∪) = Set.union
-
-  d0 ⨃ d1 = d1' ∪ ((dom d1') ⋪ d0)
-    where
-      d1' = toSet d1
-
-  size = fromIntegral . Set.size
-
-  addpair key val set = Set.insert (key, val) set
-
--- The [(a,b)] instance is used in `stakeDistr` in the file LedgerState.hs
-instance Relation [(a, b)] where
-  type Domain [(a, b)] = a
-  type Range [(a, b)] = b
-
-  singleton a b = [(a, b)]
-
-  dom = toSet . fmap fst
-
-  range = toSet . fmap snd
-
-  s ◁ r = filter ((`Set.member` toSet s) . fst) r
-
-  s ⋪ r = filter ((`Set.notMember` toSet s) . fst) r
-
-  r ▷ s = filter ((`Set.member` toSet s) . snd) r
-
-  r ⋫ s = filter ((`Set.notMember` toSet s) . snd) r
-
-  (∪) = (++)
-
-  -- In principle a list of pairs allows for duplicated keys.
-  d0 ⨃ d1 = d0 ++ toList d1
-
-  size = fromIntegral . length
-
-  addpair key val list = (key, val) : list
+(∪+) = Map.unionWith (+)
 
 ---------------------------------------------------------------------------------
 -- Aliases
@@ -230,3 +122,45 @@ toSet = Set.fromList . toList
 
 (∩) :: Ord a => Set a -> Set a -> Set a
 (∩) = intersection
+
+propUnary ::
+  forall b a e.
+  (Eq a, Show a, Arbitrary b, Show b, SA.Embed a e) =>
+  TestName ->
+  (b -> SA.Exp e) ->
+  (b -> a) ->
+  TestTree
+propUnary name expr relExpr =
+  testProperty name (\arg -> SA.eval (expr arg) === relExpr arg)
+
+propBinary ::
+  forall b c a e.
+  (Eq a, Show a, Arbitrary b, Show b, Arbitrary c, Show c, SA.Embed a e) =>
+  TestName ->
+  (b -> c -> SA.Exp e) ->
+  (b -> c -> a) ->
+  TestTree
+propBinary name expr relExpr =
+  testProperty name (\arg1 arg2 -> SA.eval (expr arg1 arg2) === relExpr arg1 arg2)
+
+type M = Map Int (Sum Float)
+
+relationTests :: TestTree
+relationTests =
+  testGroup
+    "RelationTests - check conformance with the original implementation"
+    [ propUnary @M "dom" SA.dom dom,
+      propUnary @M "range" SA.rng range,
+      propBinary @_ @M "∈" (\k m -> k SA.∈ range m) (∈),
+      propBinary @_ @M "∉" (\k m -> k SA.∉ range m) (∉),
+      propBinary @_ @M "haskey" (\k m -> k SA.∈ dom m) haskey,
+      propBinary @_ @M "◁" (SA.◁) (◁),
+      propBinary @_ @M "⋪" (SA.⋪) (⋪),
+      propBinary @M "▷" (SA.▷) (▷),
+      propBinary @M "⋫" (SA.⋫) (⋫),
+      propBinary @M "∪" (SA.∪) (∪),
+      propBinary @M "⨃" (SA.⨃) (⨃),
+      propBinary @M "∪+" (SA.∪+) (∪+),
+      propBinary @M @M "⊆" (\m1 m2 -> SA.rng m1 SA.⊆ SA.rng m2) (⊆),
+      propBinary @(Set Int) "∩" (SA.∩) (∩)
+    ]

--- a/libs/set-algebra/test/Test/Control/Iterate/RelationReference.hs
+++ b/libs/set-algebra/test/Test/Control/Iterate/RelationReference.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Data.Relation
+module Test.Control.Iterate.RelationReference
   ( Relation
       ( (⨃),
         (∪),

--- a/libs/set-algebra/test/Test/Control/Iterate/SetAlgebra.hs
+++ b/libs/set-algebra/test/Test/Control/Iterate/SetAlgebra.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- This option is on for only one reason, It allows us to make a list of
 -- functions, written as (\ w x y z -> Property) where each function uses
@@ -12,10 +11,10 @@
 -- the type of each of the parameters to the anonymous functions, without
 -- repeating them for each of the over 100 items in the list.
 
-module Test.Control.Iterate.SetAlgebra where
+module Test.Control.Iterate.SetAlgebra (setAlgTest) where
 
 import Control.Iterate.BaseTypes (List (..), Sett (..), fromPairs)
-import Control.Iterate.Collect
+import Control.Iterate.Collect (Collect (runCollect), one, when)
 import Control.Iterate.Exp (Exp (..), Query (..), domElem, lift, rngSnd)
 import Control.Iterate.SetAlgebra
   ( compute,
@@ -25,18 +24,52 @@ import Control.Iterate.SetAlgebra
     runBool,
     runSet,
     sameDomain,
-    (⨝),
   )
 import Control.SetAlgebra
+  ( BaseRep (BiMapR, ListR, MapR, SetR, SingleR),
+    BiMap,
+    Bimap,
+    Iter (element),
+    Single (Fail),
+    biMapFromList,
+    dom,
+    eval,
+    fromList,
+    keysEqual,
+    materialize,
+    rng,
+    setSingleton,
+    singleton,
+    (∈),
+    (∉),
+    (∪),
+    (≍),
+    (⋪),
+    (⋫),
+    (▷),
+    (◁),
+    (➖),
+  )
 import Data.BiMap (BiMap (..))
 import Data.Char (ord)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (intersectDomP, intersectDomPLeft)
 import qualified Data.Set as Set
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import Test.Tasty.QuickCheck
+  ( Arbitrary (arbitrary),
+    Gen,
+    Property,
+    choose,
+    conjoin,
+    counterexample,
+    frequency,
+    testProperty,
+    vectorOf,
+    (===),
+  )
 
 -- =========================================================
 -- Some examples of Exp and tests
@@ -54,22 +87,7 @@ import Test.Tasty.QuickCheck
 -- Even better, this will run in time and space proportional to: size((dom skcreds) ∩ (dom delegs))
 -- See the example with timing above.
 
-foo skcreds delegs stpools = materialize MapR $
-  do
-    (x, _z, y) <- skcreds ⨝ delegs
-    y `element` stpools
-    one (x, y)
-
 -- Even better,  stkcreds, delegs, and stpools can be any binary type construtors in the Iter class.
-
-foo ::
-  (Iter s, Iter d, Iter p, Ord a, Ord b1) =>
-  s a b2 ->
-  d a b1 ->
-  p b1 b3 ->
-  Map a b1
-example :: Exp (Map Int Char)
-example = ((dom stkcred) ◁ deleg) ▷ (dom stpool)
 
 stkcred :: Map Int [Char]
 deleg :: Map Int Char
@@ -80,37 +98,16 @@ deleg = Map.fromList [(n, chars !! n) | n <- [1 .. 10]]
 
 stpool = Map.fromList [('A', 99), ('C', 12), ('F', 42), ('R', 33), ('Z', 99)]
 
---  ((txins txb ⋪ utxo) ∪ txouts txb)
-test33 :: () -> Exp (Map Int Char)
-test33 () = ((Set.fromList [4, 7, 9] ⋪ m12) ∪ m22)
-
 -- =============== Build a few maps ===================
 
 chars :: String
 chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdeghijklmnopqrstuvwxyz0123456789"
-
-nchars :: Int
-nchars = length chars
 
 m0 :: Map.Map Int Char
 m0 = Map.fromList [(1, 'a'), (2, 'z'), (4, 'g')]
 
 m12 :: Map.Map Int Char
 m12 = Map.fromList [(n, chars !! n) | n <- [0 .. length chars - 1]]
-
-m22 :: Map.Map Int Char
-m22 = Map.fromList [(57 + n, chars !! n) | n <- [0 .. length chars - 1]]
-
-mN :: Int -> Int -> Map.Map Int Char
-mN start size = Map.fromList [(n, chars !! (n `mod` nchars)) | n <- [start .. start + size]]
-
--- | Some really big Maps, with very small overlap.
-m5, m6 :: Map.Map Int Char
-m5 = mN 1 10000000
-m6 = mN 9999995 10000000
-
-b0 :: Bimap Int Char
-b0 = biMapFromList (\l _r -> l) [(1, 'a'), (2, 'z'), (4, 'g')]
 
 -- ============ Some small Maps to And, Or, Diff, Guard, Project with =========
 
@@ -125,29 +122,34 @@ evens :: Sett Int ()
 evens = fromList SetR (\l _r -> l) [(n, ()) | n <- [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26]]
 
 l4 :: [(Int, String)]
-l4 = [(1, "m"), (2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "v"), (50, "q"), (51, "l"), (105, "Z")]
+l4 =
+  [ (1, "m"),
+    (2, "a"),
+    (5, "z"),
+    (6, "b"),
+    (7, "r"),
+    (12, "w"),
+    (34, "v"),
+    (50, "q"),
+    (51, "l"),
+    (105, "Z")
+  ]
 
 l5 :: [(String, Int)]
-l5 = [("a", 101), ("b", 102), ("c", 103), ("f", 104), ("m", 105), ("q", 107), ("s", 106), ("w", 108), ("y", 109), ("zz", 110)]
+l5 =
+  [ ("a", 101),
+    ("b", 102),
+    ("c", 103),
+    ("f", 104),
+    ("m", 105),
+    ("q", 107),
+    ("s", 106),
+    ("w", 108),
+    ("y", 109),
+    ("zz", 110)
+  ]
 
 -- =================== Some sample (Exp t) =============================
-
-ex1 :: Exp Bool
-ex1 = 5 ∈ (dom m12)
-
-ex2 :: Exp Bool
-ex2 = 70 ∈ (dom m12)
-
-ex3 :: Exp (Map Int Char)
-ex3 = m0 ∪ (singleton 3 'b')
-
-ex4, ex5, ex6 :: Exp (Map Int Char)
-ex4 = (setSingleton 2) ⋪ m0
-ex5 = dom (singleton 2 'z') ⋪ m0
-ex6 = rng (singleton 'z' 2) ⋪ m0
-
-ex7 :: Exp Bool
-ex7 = 70 ∉ (dom m12)
 
 z1 :: Map Int String
 z1 = Map.fromList [(3, "c"), (4, "d"), (5, "e"), (6, "f"), (10, "j"), (11, "k"), (21, "v")]
@@ -161,9 +163,6 @@ z3 = Map.fromList [(9, "3"), (10, "j"), (30, "a")]
 z4 :: Map Int String
 z4 = Map.fromList [(3, "c"), (5, "e"), (10, "j"), (21, "v"), (9, "3"), (30, "a")]
 
-ex8 :: Set.Set Int
-ex8 = (eval (z2 ➖ dom z1))
-
 -- ===================== test that compute works ======================
 
 -- Test that computing  x::(Exp t) computes to the given object with type t.
@@ -175,13 +174,13 @@ evalTest nm expr ans = testCase name (assertEqual name (compute expr) ans)
 
 -- Test that (eval x) and runSet(x) get the same answers
 
-eval_compile :: (Show (f k v), Ord k, Eq (f k v)) => Exp (f k v) -> TestTree
-eval_compile expr = testCase name (assertEqual name (compute expr) (runSet expr))
+evalCompile :: (Show (f k v), Ord k, Eq (f k v)) => Exp (f k v) -> TestTree
+evalCompile expr = testCase name (assertEqual name (compute expr) (runSet expr))
   where
     name = ("compute and runSet of " ++ show expr ++ " are the same")
 
-eval_tests :: TestTree
-eval_tests =
+evalTests :: TestTree
+evalTests =
   testGroup
     "eval tests"
     [ evalTest "m12" (5 ∈ (dom m12)) True,
@@ -191,28 +190,36 @@ eval_tests =
       evalTest "m0" (dom (singleton 2 'z') ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
       evalTest "m0" (rng (singleton 'z' 2) ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
       evalTest "m0" ((Map.fromList [(1, 'a'), (2, 'n'), (3, 'r')]) ∪ (singleton 2 'b')) (Map.fromList [(1 :: Int, 'a'), (2, 'n'), (3, 'r')]),
-      evalTest "m0" ([(1, 'a'), (3, 'r')] ∪ (singleton 3 'b')) (UnSafeList [(1 :: Int, 'a'), (3, 'r')]),
-      evalTest "m0" (70 ∉ (dom m12)) True,
-      evalTest "((dom stkcred) ◁ deleg) ▷ (dom stpool)" (((dom stkcred) ◁ deleg) ▷ (dom stpool)) (Map.fromList [(5, 'F')]),
+      evalTest "m0" ([(1, 'a'), (3, 'r')] ∪ singleton 3 'b') (UnSafeList [(1 :: Int, 'a'), (3, 'r')]),
+      evalTest "m0" (70 ∉ dom m12) True,
+      evalTest "((dom stkcred) ◁ deleg) ▷ (dom stpool)" ((dom stkcred ◁ deleg) ▷ dom stpool) (Map.fromList [(5, 'F')]),
       evalTest "Range exclude 1" (l4 ⋫ Set.empty) (UnSafeList l4),
       evalTest "Range exclude 2" (l4 ⋫ Fail) (UnSafeList l4),
       evalTest
         "Range exclude 3"
-        (l4 ⋫ (Set.fromList ["m", "Z"]))
+        (l4 ⋫ Set.fromList ["m", "Z"])
         (UnSafeList [(2, "a"), (5, "z"), (6, "b"), (7, "r"), (12, "w"), (34, "v"), (50, "q"), (51, "l")]),
       evalTest "DomExclude Union" ((z2 ⋪ z1) ∪ z3) z4,
       evalTest "Set difference" (z2 ➖ dom z1) (Sett (Set.fromList [2 :: Int, 13])),
-      eval_compile (((dom stkcred) ◁ deleg) ▷ (dom stpool)),
-      eval_compile (l4 ⋫ (Set.fromList ["m", "Z"])),
-      eval_compile (m0 ∪ (singleton 3 'b')),
-      eval_compile ((setSingleton 2) ⋪ m0)
+      evalCompile ((dom stkcred ◁ deleg) ▷ dom stpool),
+      evalCompile (l4 ⋫ Set.fromList ["m", "Z"]),
+      evalCompile (m0 ∪ singleton 3 'b'),
+      evalCompile (setSingleton 2 ⋪ m0),
+      evalTest "ex1" (5 ∈ dom m12) True,
+      evalTest "ex2" (70 ∈ dom m12) False,
+      evalTest "ex3" (70 ∉ dom m12) True,
+      evalTest "ex4" (m0 ∪ singleton 3 'b') (Map.insert 3 'b' m0),
+      evalTest "ex5" (setSingleton 2 ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
+      evalTest "ex6" (dom (singleton 2 'z') ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
+      evalTest "ex7" (rng (singleton 'z' 2) ⋪ m0) (Map.fromList [(1, 'a'), (4, 'g')]),
+      evalTest "ex8" (z2 ➖ dom z1) (Sett $ Set.fromList [13, 2])
     ]
 
 -- =============== test of KeysEqual and its variants =====================
 
 tree1, tree2, tree3 :: Map Int Int
 tree1 = Map.fromList [(i, i :: Int) | i <- [1 .. 20]]
-tree2 = Map.fromList [(i, i :: Int) | i <- (reverse [2 .. 20]) ++ [1]]
+tree2 = Map.fromList [(i, i :: Int) | i <- reverse [2 .. 20] ++ [1]]
 tree3 = Map.fromList [(i, i :: Int) | i <- [1 .. 19]]
 
 set1 :: Set.Set Int
@@ -334,8 +341,8 @@ testEpochEx =
     hk = "b"
     state = Map.fromList [(n, even n) | n <- [1 .. 13]]
 
-iter_tests :: TestTree
-iter_tests =
+iterTests :: TestTree
+iterTests =
   testGroup
     "Iterator tests"
     [ testAnd1 "(And l1 l2) as List, fifo" ListR,
@@ -382,26 +389,26 @@ iter_tests =
 
 intersect2ways :: Map Int Char -> Map Int String -> Char -> Bool
 intersect2ways delegs stake hk =
-  (materialize MapR (do (x, y, z) <- delegs `domEq` stake; when (y == hk); one (x, z)))
-    == (intersectDomPLeft (\_k v2 -> v2 == hk) stake delegs)
+  materialize MapR (do (x, y, z) <- delegs `domEq` stake; when (y == hk); one (x, z))
+    == intersectDomPLeft (\_k v2 -> v2 == hk) stake delegs
 
 intersectDomPLeftTest :: TestTree
 intersectDomPLeftTest = testProperty "intersect2ways" intersect2ways
 
 ledgerStateProp :: Map Int Bool -> Map Int Char -> Map Char String -> Bool
 ledgerStateProp xx yy zz =
-  (materialize MapR (do (x, _, y) <- xx `domEq` yy; y `element` zz; one (x, y)))
-    == (intersectDomP (\_k v -> Map.member v zz) xx yy)
+  materialize MapR (do (x, _, y) <- xx `domEq` yy; y `element` zz; one (x, y))
+    == intersectDomP (\_k v -> Map.member v zz) xx yy
 
 ledgerStateTest :: TestTree
 ledgerStateTest = testProperty "ledgerStateExample2ways" ledgerStateProp
 
 threeWay :: Map Int Char -> Map Int String -> Char -> Bool
 threeWay delegs stake hk =
-  ((runSet (dom (delegs ▷ Set.singleton hk) ◁ stake)))
-    == (intersectDomPLeft (\_k v2 -> v2 == hk) stake delegs)
-    && (runSet (dom (delegs ▷ Set.singleton hk) ◁ stake))
-      == materialize MapR (do (x, y, z) <- delegs `domEq` stake; when ((y == hk)); one (x, z))
+  runSet (dom (delegs ▷ Set.singleton hk) ◁ stake)
+    == intersectDomPLeft (\_k v2 -> v2 == hk) stake delegs
+    && runSet (dom (delegs ▷ Set.singleton hk) ◁ stake)
+      == materialize MapR (do (x, y, z) <- delegs `domEq` stake; when (y == hk); one (x, z))
 
 threeWayTest :: TestTree
 threeWayTest = testProperty "eval-materialize-intersectDom" threeWay
@@ -429,31 +436,36 @@ newtype Range = Range Int
 instance Show Range where
   show (Range n) = show n
 
-instance Semigroup Range where (Range x) <> (Range y) = Range (x + y)
+instance Semigroup Range where
+  Range x <> Range y = Range (x + y)
 
-instance Monoid Range where mempty = Range 0
+instance Monoid Range where
+  mempty = Range 0
 
 -- ===========================================================
 -- helper functions to construct related types and Properties.
 
-flip_rng :: (Ord b, Num b) => List a b -> List b b
-flip_rng (UnSafeList xs) = fromPairs (+) (map (\(a, b) -> (b, b)) xs)
+flipRng :: (Ord b, Num b) => List a b -> List b b
+flipRng (UnSafeList xs) = fromPairs (+) (map (\(_a, b) -> (b, b)) xs)
 
 bimap :: (Ord k, Ord v) => Map k v -> BiMap v k v
-bimap xs = biMapFromList (\earlier later -> later) (Map.toList xs)
+bimap xs = biMapFromList (\_earlier later -> later) (Map.toList xs)
 
 duplicate :: Ord a => Set.Set a -> Map.Map a a
 duplicate s = foldr (\a m -> Map.insert a a m) Map.empty s
 
 btest :: Exp Bool -> Property
-btest expr = (compute expr) === (runBool expr)
+btest expr = compute expr === runBool expr
 
 qtest :: (Ord key, Eq (f key a), Show (f key a)) => Exp (f key a) -> Property
-qtest expr = (compute expr) === (runSet expr)
+qtest expr = compute expr === runSet expr
 
 -- ======================================================
 
-type STest =
+slowFastEquiv :: TestTree
+slowFastEquiv = testProperty "slowFastEquiv" slowProperties
+
+slowProperties ::
   Key -> -- k
   Range -> -- v
   Map Key Range -> -- m1
@@ -463,131 +475,118 @@ type STest =
   Set.Set Range -> -- rs
   List Key Range -> -- ls
   Property
-
-slowFastEquiv :: TestTree
-slowFastEquiv = testGroup "slowFastEquiv" (map f many)
-  where
-    f (prop, name) = testProperty name prop
-
--- Here is where we need to turn on -fno-warn-unused-matches
--- Note how the typing (STest) fixes the type of each lambda expression,
--- even though some tests do not mention some of the variables.
-
-many :: [(STest, String)]
-many =
-  [ (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base SetR (Sett s1))), "slow1"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow2"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base SetR (Sett s1))), "slow3"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow4"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Singleton k v)), "slow5"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (SetSingleton k)), "slow6"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (Base MapR m1)), "slow7"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (RRestrict (Base MapR m1) (SetSingleton v))), "slow8"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))), "slow9"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (RExclude (Base MapR m1) (SetSingleton v))), "slow10"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (RExclude (Base MapR m1) (Base SetR (Sett rs)))), "slow11"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (DRestrict (SetSingleton k) (Base MapR m1))), "slow12"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (DRestrict (Base SetR (Sett s1)) (Base MapR m1))), "slow13"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (DExclude (SetSingleton k) (Base MapR m1))), "slow14"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Dom (DExclude (Base SetR (Sett s1)) (Base MapR m1))), "slow15"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Rng (Base SetR (Sett s1))), "slow16"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Rng (Singleton k v)), "slow17"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Rng (SetSingleton k)), "slow18"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Rng (Base MapR m1)), "slow19"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow21"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (SetSingleton k) (Base MapR m1)), "slow22"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Singleton k ()) (Base MapR m1)), "slow23"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Base MapR m2)) (Base MapR m1)), "slow24"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (RRestrict (Base MapR m1) (SetSingleton v))) (Base MapR m2)), "slow25"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))) (Base MapR m2)), "slow26"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow27"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow28"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Base SetR (Sett s1)) (Base ListR ls)), "slow29"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Base MapR m1)) (Base ListR ls)), "slow30"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (SetSingleton k) (Base ListR ls)), "slow31"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Dom (Singleton k v)) (Base ListR ls)), "slow32"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DRestrict (Rng (Singleton k v)) (Base ListR (flip_rng ls))), "slow33"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (SetSingleton k) (Base MapR m1)), "slow35"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Singleton k v)) (Base MapR m1)), "slow36"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Rng (Singleton v k)) (Base MapR m1)), "slow37"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Base SetR (Sett s1)) (Base MapR m1)), "slow38"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Base MapR m1)) (Base MapR m2)), "slow39"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (SetSingleton k) (Base BiMapR (bimap m1))), "slow40"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Dom (Singleton k v)) (Base BiMapR (bimap m1))), "slow41"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (DExclude (Rng (Singleton v k)) (Base BiMapR (bimap m1))), "slow42"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (SetSingleton v)), "slow44"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (Dom (Singleton v k))), "slow45"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base BiMapR (bimap m1)) (Rng (Singleton k v))), "slow46"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base MapR m1) (Base SetR (Sett rs))), "slow47"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base MapR m1) (SetSingleton v)), "slow48"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base ListR ls) (Base SetR (Sett rs))), "slow49"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RExclude (Base ListR ls) (Base SingleR Fail)), "slow50"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (Base MapR m1) (SetSingleton v)), "slow52"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m1)) (Dom (Base MapR (duplicate rs)))), "slow53"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m2)) (Dom (Base ListR (flip_rng ls)))), "slow54"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (Dom (Base ListR ls))), "slow56"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (Base SetR (Sett s1))), "slow57"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (Dom (Singleton k v))), "slow58"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (Rng (Singleton v k))), "slow59"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (SetSingleton k)), "slow60"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow61"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow62"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow63"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow64"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (DRestrict (Dom (Base SetR (Sett s1))) (Dom (Base MapR m1)))), "slow106"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Elem k (DExclude (Dom (Base SetR (Sett s1))) (Dom (Base MapR m1)))), "slow107"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Dom (Base ListR ls))), "slow66"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Base SetR (Sett s1))), "slow67"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Dom (Singleton k v))), "slow68"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Rng (Singleton v k))), "slow69"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (SetSingleton k)), "slow70"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow71"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow72"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow73"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (NotElem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow74"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow76"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Base MapR m1)), "slow77"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Subset (Base SetR (Sett s1)) (Dom (Base MapR m1))), "slow78"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Subset (Base MapR m1) (Base MapR m2)), "slow79"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (Subset (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow80"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow82"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Intersect (Base MapR m1) (Base MapR m2)), "slow83"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base ListR ls) (Singleton k v)), "slow85"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base MapR m1) (Base MapR m2)), "slow86"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow87"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (DExclude (SetSingleton k) (Base MapR m1)) (Base MapR m2)), "slow88"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m1)) (Base MapR m2)), "slow89"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base ListR ls) (Singleton k v)), "slow91"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base MapR m1) (Base MapR m2)), "slow92"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow93"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionPlus (Base MapR m1) (Base MapR m2)), "slow95"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow96"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (Singleton k v), "slow98"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetSingleton k), "slow99"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base MapR m1) (Base MapR m2)), "slow100"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base BiMapR (bimap m1)) (Base BiMapR (bimap m2))), "slow101"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow102"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Dom (Base BiMapR (bimap m1))) (Dom (Base BiMapR (bimap m2)))), "slow103"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow104"),
-    (\k v m1 m2 s1 s2 rs ls -> btest (KeyEqual (Base MapR m1) (Base SetR (Sett s1))), "slow105"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow108"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Base MapR m2)), "slow109"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base SetR (Sett s1)) (Dom (Base MapR m2))), "slow110"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Dom (Base MapR m2))), "slow111"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Base MapR m2)), "slow112"),
-    (\k v m1 m2 s1 s2 rs ls -> qtest (SetDiff (Base MapR m1) (Base SetR (Sett s2))), "slow113")
-  ]
+slowProperties k v m1 m2 s1 s2 rs ls =
+  conjoin $
+    map
+      (\(prop, name) -> counterexample name prop)
+      [ (qtest (Dom (Base SetR (Sett s1))), "slow1"),
+        (qtest (Dom (Base MapR m1)), "slow2"),
+        (qtest (Dom (Base SetR (Sett s1))), "slow3"),
+        (qtest (Dom (Base MapR m1)), "slow4"),
+        (qtest (Dom (Singleton k v)), "slow5"),
+        (qtest (Dom (SetSingleton k)), "slow6"),
+        (qtest (Dom (Base MapR m1)), "slow7"),
+        (qtest (Dom (RRestrict (Base MapR m1) (SetSingleton v))), "slow8"),
+        (qtest (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))), "slow9"),
+        (qtest (Dom (RExclude (Base MapR m1) (SetSingleton v))), "slow10"),
+        (qtest (Dom (RExclude (Base MapR m1) (Base SetR (Sett rs)))), "slow11"),
+        (qtest (Dom (DRestrict (SetSingleton k) (Base MapR m1))), "slow12"),
+        (qtest (Dom (DRestrict (Base SetR (Sett s1)) (Base MapR m1))), "slow13"),
+        (qtest (Dom (DExclude (SetSingleton k) (Base MapR m1))), "slow14"),
+        (qtest (Dom (DExclude (Base SetR (Sett s1)) (Base MapR m1))), "slow15"),
+        (qtest (Rng (Base SetR (Sett s1))), "slow16"),
+        (qtest (Rng (Singleton k v)), "slow17"),
+        (qtest (Rng (SetSingleton k)), "slow18"),
+        (qtest (Rng (Base MapR m1)), "slow19"),
+        (qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow21"),
+        (qtest (DRestrict (SetSingleton k) (Base MapR m1)), "slow22"),
+        (qtest (DRestrict (Singleton k ()) (Base MapR m1)), "slow23"),
+        (qtest (DRestrict (Dom (Base MapR m2)) (Base MapR m1)), "slow24"),
+        (qtest (DRestrict (Dom (RRestrict (Base MapR m1) (SetSingleton v))) (Base MapR m2)), "slow25"),
+        (qtest (DRestrict (Dom (RRestrict (Base MapR m1) (Base SetR (Sett rs)))) (Base MapR m2)), "slow26"),
+        (qtest (DRestrict (Base SetR (Sett s1)) (Base MapR m1)), "slow27"),
+        (qtest (DRestrict (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow28"),
+        (qtest (DRestrict (Base SetR (Sett s1)) (Base ListR ls)), "slow29"),
+        (qtest (DRestrict (Dom (Base MapR m1)) (Base ListR ls)), "slow30"),
+        (qtest (DRestrict (SetSingleton k) (Base ListR ls)), "slow31"),
+        (qtest (DRestrict (Dom (Singleton k v)) (Base ListR ls)), "slow32"),
+        (qtest (DRestrict (Rng (Singleton k v)) (Base ListR (flipRng ls))), "slow33"),
+        (qtest (DExclude (SetSingleton k) (Base MapR m1)), "slow35"),
+        (qtest (DExclude (Dom (Singleton k v)) (Base MapR m1)), "slow36"),
+        (qtest (DExclude (Rng (Singleton v k)) (Base MapR m1)), "slow37"),
+        (qtest (DExclude (Base SetR (Sett s1)) (Base MapR m1)), "slow38"),
+        (qtest (DExclude (Dom (Base MapR m1)) (Base MapR m2)), "slow39"),
+        (qtest (DExclude (SetSingleton k) (Base BiMapR (bimap m1))), "slow40"),
+        (qtest (DExclude (Dom (Singleton k v)) (Base BiMapR (bimap m1))), "slow41"),
+        (qtest (DExclude (Rng (Singleton v k)) (Base BiMapR (bimap m1))), "slow42"),
+        (qtest (RExclude (Base BiMapR (bimap m1)) (SetSingleton v)), "slow44"),
+        (qtest (RExclude (Base BiMapR (bimap m1)) (Dom (Singleton v k))), "slow45"),
+        (qtest (RExclude (Base BiMapR (bimap m1)) (Rng (Singleton k v))), "slow46"),
+        (qtest (RExclude (Base MapR m1) (Base SetR (Sett rs))), "slow47"),
+        (qtest (RExclude (Base MapR m1) (SetSingleton v)), "slow48"),
+        (qtest (RExclude (Base ListR ls) (Base SetR (Sett rs))), "slow49"),
+        (qtest (RExclude (Base ListR ls) (Base SingleR Fail)), "slow50"),
+        (qtest (RRestrict (Base MapR m1) (SetSingleton v)), "slow52"),
+        (qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m1)) (Dom (Base MapR (duplicate rs)))), "slow53"),
+        (qtest (RRestrict (DRestrict (Dom (Base MapR m1)) (Base MapR m2)) (Dom (Base ListR (flipRng ls)))), "slow54"),
+        (btest (Elem k (Dom (Base ListR ls))), "slow56"),
+        (btest (Elem k (Base SetR (Sett s1))), "slow57"),
+        (btest (Elem k (Dom (Singleton k v))), "slow58"),
+        (btest (Elem k (Rng (Singleton v k))), "slow59"),
+        (btest (Elem k (SetSingleton k)), "slow60"),
+        (btest (Elem k (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow61"),
+        (btest (Elem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow62"),
+        (btest (Elem k (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow63"),
+        (btest (Elem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow64"),
+        (btest (Elem k (DRestrict (Dom (Base SetR (Sett s1))) (Dom (Base MapR m1)))), "slow106"),
+        (btest (Elem k (DExclude (Dom (Base SetR (Sett s1))) (Dom (Base MapR m1)))), "slow107"),
+        (btest (NotElem k (Dom (Base ListR ls))), "slow66"),
+        (btest (NotElem k (Base SetR (Sett s1))), "slow67"),
+        (btest (NotElem k (Dom (Singleton k v))), "slow68"),
+        (btest (NotElem k (Rng (Singleton v k))), "slow69"),
+        (btest (NotElem k (SetSingleton k)), "slow70"),
+        (btest (NotElem k (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow71"),
+        (btest (NotElem k (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow72"),
+        (btest (NotElem k (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow73"),
+        (btest (NotElem k (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2)))), "slow74"),
+        (btest (Subset (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow76"),
+        (btest (Subset (Base SetR (Sett s1)) (Base MapR m1)), "slow77"),
+        (btest (Subset (Base SetR (Sett s1)) (Dom (Base MapR m1))), "slow78"),
+        (btest (Subset (Base MapR m1) (Base MapR m2)), "slow79"),
+        (btest (Subset (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow80"),
+        (qtest (Intersect (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow82"),
+        (qtest (Intersect (Base MapR m1) (Base MapR m2)), "slow83"),
+        (qtest (UnionOverrideLeft (Base ListR ls) (Singleton k v)), "slow85"),
+        (qtest (UnionOverrideLeft (Base MapR m1) (Base MapR m2)), "slow86"),
+        (qtest (UnionOverrideLeft (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow87"),
+        (qtest (UnionOverrideLeft (DExclude (SetSingleton k) (Base MapR m1)) (Base MapR m2)), "slow88"),
+        (qtest (UnionOverrideLeft (DExclude (Base SetR (Sett s1)) (Base MapR m1)) (Base MapR m2)), "slow89"),
+        (qtest (UnionOverrideRight (Base ListR ls) (Singleton k v)), "slow91"),
+        (qtest (UnionOverrideRight (Base MapR m1) (Base MapR m2)), "slow92"),
+        (qtest (UnionOverrideRight (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow93"),
+        (qtest (UnionPlus (Base MapR m1) (Base MapR m2)), "slow95"),
+        (qtest (UnionPlus (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow96"),
+        (qtest (Singleton k v), "slow98"),
+        (qtest (SetSingleton k), "slow99"),
+        (btest (KeyEqual (Base MapR m1) (Base MapR m2)), "slow100"),
+        (btest (KeyEqual (Base BiMapR (bimap m1)) (Base BiMapR (bimap m2))), "slow101"),
+        (btest (KeyEqual (Dom (Base MapR m1)) (Dom (Base MapR m2))), "slow102"),
+        (btest (KeyEqual (Dom (Base BiMapR (bimap m1))) (Dom (Base BiMapR (bimap m2)))), "slow103"),
+        (btest (KeyEqual (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow104"),
+        (btest (KeyEqual (Base MapR m1) (Base SetR (Sett s1))), "slow105"),
+        (qtest (SetDiff (Base SetR (Sett s1)) (Base SetR (Sett s2))), "slow108"),
+        (qtest (SetDiff (Base SetR (Sett s1)) (Base MapR m2)), "slow109"),
+        (qtest (SetDiff (Base SetR (Sett s1)) (Dom (Base MapR m2))), "slow110"),
+        (qtest (SetDiff (Base MapR m1) (Dom (Base MapR m2))), "slow111"),
+        (qtest (SetDiff (Base MapR m1) (Base MapR m2)), "slow112"),
+        (qtest (SetDiff (Base MapR m1) (Base SetR (Sett s2))), "slow113")
+      ]
 
 -- ==================================================
 -- Arbitrary instances for the slow tests.
 
-genKey :: Gen Key
-genKey = fmap Key (choose (1, 12)) -- Keep the set of Key and Range pretty small so Maps share keys
-
-genRange :: Gen Range
-genRange = fmap Range (choose (1, 20)) -- The Range type can have a slightly larger set
-
-genSize :: Gen Int -- Sizes should favor middle sized numbers
+-- | Sizes should favor middle sized numbers
+genSize :: Gen Int
 genSize =
   frequency
     [ (1, return 0),
@@ -600,43 +599,28 @@ genSize =
       (1, return 7)
     ]
 
-genPair :: Gen k -> Gen v -> Gen (k, v)
-genPair k v = (,) <$> k <*> v
-
-genList :: Ord k => Gen k -> Gen v -> Gen (List k v)
-genList k v = do
-  n <- genSize
-  xs <- vectorOf n (genPair k v)
-  pure $ fromPairs (\old new -> new) xs
-
-genMap :: Ord k => Gen k -> Gen v -> Gen (Map k v)
-genMap k v = do
-  n <- genSize
-  xs <- vectorOf n (genPair k v)
-  pure (Map.fromList xs)
-
-genSett :: Ord k => Gen k -> Gen (Sett k ())
-genSett k = do
-  n <- genSize
-  xs <- vectorOf n k
-  pure (Sett (Set.fromList xs))
-
-genBiMap :: (Ord k, Ord v) => Gen k -> Gen v -> Gen (Bimap k v)
-genBiMap k v = do
-  m <- genMap k v
-  pure (bimap m)
-
+-- | Keep the set of Key and Range pretty small so Maps share keys
 instance Arbitrary Key where
-  arbitrary = genKey
+  arbitrary = fmap Key (choose (1, 12))
 
+-- | The Range type can have a slightly larger set
 instance Arbitrary Range where
-  arbitrary = genRange
+  arbitrary = fmap Range (choose (1, 20))
 
-instance Arbitrary (List Key Range) where
-  arbitrary = genList genKey genRange
+instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (List k v) where
+  arbitrary = do
+    n <- genSize
+    xs <- vectorOf n arbitrary
+    pure $ fromPairs (\_old new -> new) xs
 
-instance Arbitrary (Sett Key ()) where
-  arbitrary = genSett genKey
+instance (Ord k, Arbitrary k) => Arbitrary (Sett k ()) where
+  arbitrary = do
+    n <- genSize
+    xs <- vectorOf n arbitrary
+    pure (Sett (Set.fromList xs))
+
+instance (Ord k, Ord v, Arbitrary k, Arbitrary v) => Arbitrary (Bimap k v) where
+  arbitrary = bimap <$> arbitrary
 
 -- ========================================
 -- BiMap tests. BiMaps have two parts that
@@ -645,17 +629,17 @@ instance Arbitrary (Sett Key ()) where
 -- =========================================
 
 flatten :: (Ord k) => Map.Map v (Set.Set k) -> Map.Map k v
-flatten m = Map.foldrWithKey accum Map.empty m
+flatten = Map.foldrWithKey accum Map.empty
   where
     accum val setk ans = Set.foldr accum2 ans setk
       where
         accum2 key m2 = Map.insert key val m2
 
 ok :: (Ord k, Ord v) => BiMap v k v -> Bool
-ok (MkBiMap forwrd backwrd) = forwrd == (flatten backwrd)
+ok (MkBiMap forwrd backwrd) = forwrd == flatten backwrd
 
 okfromList :: [(Int, Int)] -> Bool
-okfromList xs = ok (biMapFromList (\earlier later -> later) xs)
+okfromList xs = ok (biMapFromList (\_earlier later -> later) xs)
 
 biMapTest :: TestTree
 biMapTest = testProperty "BiMap Consistent" okfromList
@@ -668,9 +652,9 @@ setAlgTest :: TestTree
 setAlgTest =
   testGroup
     "Set Algebra Tests"
-    [ eval_tests,
+    [ evalTests,
       keysEqTests,
-      iter_tests,
+      iterTests,
       intersectDomPLeftTest,
       ledgerStateTest,
       threeWayTest,


### PR DESCRIPTION
Module `Data.Relation` is dead code, however instead of removing it completely, I thought parts of it would make a nice small addition to the `set-algebra` test suite. This PR also includes cleanups to the existing `set-algebra` test suite: tackle disabled compilation warnings and apply hlint hints