### PR TITLE
Switch `AssetName` to be backed by `ShortByteString` and `Show` it in Hex

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -57,7 +57,7 @@ import qualified Codec.Serialise as Cborg (Serialise (..))
 import Control.DeepSeq (deepseq)
 import Data.ByteString as BS (ByteString, length)
 import qualified Data.ByteString.Base64 as B64
-import Data.ByteString.Short as SBS (ShortByteString)
+import Data.ByteString.Short as SBS (ShortByteString, fromShort)
 import qualified Data.ByteString.UTF8 as BSU
 import Data.Coders
   ( Decode (..),
@@ -278,7 +278,7 @@ transPolicyID :: Mary.PolicyID crypto -> PV1.CurrencySymbol
 transPolicyID (Mary.PolicyID (ScriptHash x)) = PV1.CurrencySymbol (PV1.toBuiltin (hashToBytes x))
 
 transAssetName :: Mary.AssetName -> PV1.TokenName
-transAssetName (Mary.AssetName bs) = PV1.TokenName (PV1.toBuiltin bs)
+transAssetName (Mary.AssetName bs) = PV1.TokenName (PV1.toBuiltin (SBS.fromShort bs))
 
 transValue :: Mary.Value c -> PV1.Value
 transValue (Mary.Value n mp) = Map.foldlWithKey' accum1 justada mp

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -63,7 +63,6 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val (Val (coin, isAdaOnly, (<+>), (<×>)))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad (replicateM)
-import qualified Data.ByteString.Char8 as BS
 import Data.Either (fromRight)
 import Data.Hashable (Hashable (..))
 import qualified Data.List as List
@@ -172,7 +171,7 @@ genAlonzoMint startvalue = do
     Nothing -> pure (startvalue, [])
     Just (TwoPhase2ArgInfo script shash _ _) -> do
       count <- chooseEnum (1, 10)
-      let assetname = AssetName . BS.pack $ "purple"
+      let assetname = AssetName "purple"
       pure (((valueFromList 0 [(PolicyID shash, assetname, count)]) <> startvalue), [script])
 
 -- ================================================================

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -31,7 +31,6 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Value (Value (..), valueFromList)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Lazy as BSL
-import Data.Char (chr)
 import Data.Either (fromRight)
 import qualified Data.Map.Strict as Map
 import Data.Set as Set
@@ -89,7 +88,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( TxOut
               aliceAddr
-              (valueFromList 1444443 [(pid1, smallName '1', 1)])
+              (valueFromList 1444443 [(pid1, smallName 1, 1)])
               SNothing
           )
           @?= Coin 1344798,
@@ -97,7 +96,13 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( TxOut
               aliceAddr
-              (valueFromList 1555554 [(pid1, smallName '1', 1), (pid1, smallName '2', 1), (pid1, smallName '3', 1)])
+              ( valueFromList
+                  1555554
+                  [ (pid1, smallName 1, 1),
+                    (pid1, smallName 2, 1),
+                    (pid1, smallName 3, 1)
+                  ]
+              )
               SNothing
           )
           @?= Coin 1448244,
@@ -105,7 +110,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( TxOut
               carlAddr
-              (valueFromList 1555554 [(pid1, largestName 'a', 1)])
+              (valueFromList 1555554 [(pid1, largestName 65, 1)])
               SNothing
           )
           @?= Coin 1448244,
@@ -115,12 +120,12 @@ goldenUTxOEntryMinAda =
               carlAddr
               ( valueFromList
                   1962961
-                  [ (pid1, largestName 'a', 1),
-                    (pid1, largestName 'b', 1),
-                    (pid1, largestName 'c', 1)
+                  [ (pid1, largestName 65, 1),
+                    (pid1, largestName 66, 1),
+                    (pid1, largestName 67, 1)
                   ]
               )
-              (SJust $ hashData @(AlonzoEra StandardCrypto) (Data (Constr 0 [(Constr 0 [])])))
+              (SJust $ hashData @(AlonzoEra StandardCrypto) (Data (Constr 0 [Constr 0 []])))
           )
           @?= Coin 2172366,
       testCase "two policies, one (smallest) name" $
@@ -143,7 +148,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( TxOut
               bobAddr
-              (valueFromList 1629628 [(pid1, smallName '1', 1), (pid2, smallName '2', 1)])
+              (valueFromList 1629628 [(pid1, smallName 1, 1), (pid2, smallName 2, 1)])
               SNothing
           )
           @?= Coin 1517208,
@@ -151,7 +156,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( TxOut
               aliceAddr
-              ( let f i c = (i, smallName (chr c), 1)
+              ( let f i c = (i, smallName c, 1)
                  in valueFromList 7407400 [f i c | (i, cs) <- [(pid1, [32 .. 63]), (pid2, [64 .. 95]), (pid3, [96 .. 127])], c <- cs]
               )
               {-
@@ -185,10 +190,10 @@ goldenSerialization =
   testGroup
     "golden tests - serialization"
     [ testCase "Alonzo Block" $ do
-        expected <- (BSL.readFile "golden/block.cbor")
+        expected <- BSL.readFile "golden/block.cbor"
         serialize (SLE.sleBlock ledgerExamplesAlonzo) @?= expected,
       testCase "Alonzo Tx" $ do
-        expected <- (BSL.readFile "golden/tx.cbor")
+        expected <- BSL.readFile "golden/tx.cbor"
         serialize (SLE.sleTx ledgerExamplesAlonzo) @?= expected
     ]
 

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
@@ -24,12 +24,12 @@ import Cardano.Ledger.Shelley.Tx (hashScript)
 import Cardano.Ledger.ShelleyMA.Rules.Utxo (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Ledger.Slot (SlotNo (..))
-import qualified Data.ByteString.Char8 as BS
-import Data.Char (chr)
+import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import Data.Word (Word8)
 import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
@@ -58,19 +58,19 @@ pid3 =
 
 -- | The smallest asset name has length zero
 smallestName :: AssetName
-smallestName = AssetName $ BS.pack ""
+smallestName = AssetName $ SBS.pack []
 
 -- | The small asset names have length one
-smallName :: Char -> AssetName
-smallName c = AssetName . BS.pack $ [c]
+smallName :: Word8 -> AssetName
+smallName c = AssetName $ SBS.pack [c]
 
 -- | The largest asset names have length thirty-two
-largestName :: Char -> AssetName
-largestName c = AssetName . BS.pack $ c : "0123456789ABCDEFGHIJ0123456789A"
+largestName :: Word8 -> AssetName
+largestName c = AssetName . SBS.pack $ c : [1 .. 31]
 
 -- | try using a real asset name the way the CLI handles input
 realName :: AssetName
-realName = AssetName $ (Text.encodeUtf8 . Text.pack) "ATADAcoin"
+realName = AssetName . SBS.toShort . Text.encodeUtf8 . Text.pack $ "ATADAcoin"
 
 -- | This is the current value of the protocol parameter
 --  at the time this comment was written, namely one Ada.
@@ -93,7 +93,7 @@ goldenScaledMinDeposit =
           ( Value 1444443 $
               Map.singleton
                 pid1
-                (Map.fromList [(smallName '1', 1)])
+                (Map.fromList [(smallName 1, 1)])
           )
           minUTxO
           @?= Coin 1444443,
@@ -112,9 +112,9 @@ goldenScaledMinDeposit =
               Map.singleton
                 pid1
                 ( Map.fromList
-                    [ (smallName '1', 1),
-                      (smallName '2', 1),
-                      (smallName '3', 1)
+                    [ (smallName 1, 1),
+                      (smallName 2, 1),
+                      (smallName 3, 1)
                     ]
                 )
           )
@@ -125,7 +125,7 @@ goldenScaledMinDeposit =
           ( Value 1555554 $
               Map.singleton
                 pid1
-                (Map.fromList [(largestName 'a', 1)])
+                (Map.fromList [(largestName 65, 1)])
           )
           minUTxO
           @?= Coin 1555554,
@@ -135,9 +135,9 @@ goldenScaledMinDeposit =
               Map.singleton
                 pid1
                 ( Map.fromList
-                    [ (largestName 'a', 1),
-                      (largestName 'b', 1),
-                      (largestName 'c', 1)
+                    [ (largestName 65, 1),
+                      (largestName 66, 1),
+                      (largestName 67, 1)
                     ]
                 )
           )
@@ -162,10 +162,10 @@ goldenScaledMinDeposit =
           ( Value 1629628 $
               Map.fromList
                 [ ( pid1,
-                    Map.fromList [(smallName '1', 1)]
+                    Map.fromList [(smallName 1, 1)]
                   ),
                   ( pid2,
-                    Map.fromList [(smallName '2', 1)]
+                    Map.fromList [(smallName 2, 1)]
                   )
                 ]
           )
@@ -176,13 +176,13 @@ goldenScaledMinDeposit =
           ( Value 7407400 $
               Map.fromList
                 [ ( pid1,
-                    Map.fromList $ map ((,1) . smallName . chr) [32 .. 63]
+                    Map.fromList $ map ((,1) . smallName) [32 .. 63]
                   ),
                   ( pid2,
-                    Map.fromList $ map ((,1) . smallName . chr) [64 .. 95]
+                    Map.fromList $ map ((,1) . smallName) [64 .. 95]
                   ),
                   ( pid3,
-                    Map.fromList $ map ((,1) . smallName . chr) [96 .. 127]
+                    Map.fromList $ map ((,1) . smallName) [96 .. 127]
                   )
                 ]
           )

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -36,13 +36,13 @@ import Cardano.Ledger.Val ((<+>))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
 import Control.Monad (replicateM)
-import qualified Data.ByteString.Char8 as BS
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict (StrictSeq (..), (<|), (><))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import GHC.Exts (fromString)
 import GHC.Records (HasField (getField))
 import Test.Cardano.Ledger.AllegraEraGen
   ( genValidityInterval,
@@ -144,7 +144,7 @@ redCoinId :: forall c. CryptoClass.Crypto c => PolicyID c
 redCoinId = PolicyID $ hashScript @(MaryEra c) redCoins
 
 red :: AssetName
-red = AssetName $ BS.pack "redCoin"
+red = AssetName "red"
 
 genRed :: CryptoClass.Crypto c => Gen (Value c)
 genRed = do
@@ -206,7 +206,7 @@ genYellow = do
   where
     genSingleYellow x = do
       y <- genInteger coloredCoinMinMint coloredCoinMaxMint
-      let an = AssetName . BS.pack $ "yellow" <> show x
+      let an = AssetName . fromString $ "yellow" <> show x
       pure (an, y)
 
 -- | Carefully crafted to apply in any Era where Core.Value is Value

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -41,7 +41,7 @@ import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA.STS
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA (Timelock (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA (TxBody (..))
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Coerce (coerce)
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
@@ -203,7 +203,7 @@ valueFromListBounded (fromIntegral -> ada) =
         (min (fromIntegral $ maxBound @i) (a + b))
 
 instance Arbitrary Mary.AssetName where
-  arbitrary = Mary.AssetName . BS.pack . take 32 . BS.unpack <$> arbitrary
+  arbitrary = Mary.AssetName . SBS.pack . take 32 . SBS.unpack <$> arbitrary
 
 instance Mock c => Arbitrary (MA.STS.UtxoPredicateFailure (MaryEra c)) where
   arbitrary = genericArbitraryU

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -41,10 +42,10 @@ import Cardano.Ledger.Val ((<+>), (<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.Exception (ErrorCall (ErrorCall), evaluate, try)
 import Control.State.Transition.Extended (PredicateFailure)
-import qualified Data.ByteString.Char8 as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import GHC.Exts (fromString)
 import Test.Cardano.Ledger.EraBuffet (TestCrypto)
 import Test.Cardano.Ledger.Mary.Examples (testMaryNoDelegLEDGER)
 import qualified Test.Cardano.Ledger.Mary.Examples.Cast as Cast
@@ -150,10 +151,10 @@ purplePolicyId :: PolicyID TestCrypto
 purplePolicyId = PolicyID $ hashScript @MaryTest purplePolicy
 
 plum :: AssetName
-plum = AssetName $ BS.pack "plum"
+plum = AssetName "plum"
 
 amethyst :: AssetName
-amethyst = AssetName $ BS.pack "amethyst"
+amethyst = AssetName "amethyst"
 
 ------------------------
 -- Mint Purple Tokens --
@@ -277,7 +278,7 @@ boundedTimePolicyId :: PolicyID TestCrypto
 boundedTimePolicyId = PolicyID $ hashScript @MaryTest boundedTimePolicy
 
 tokenTimeEx :: AssetName
-tokenTimeEx = AssetName $ BS.pack "tokenTimeEx"
+tokenTimeEx = AssetName "tokenTimeEx"
 
 ------------------------------------
 -- Mint Bounded Time Range Tokens --
@@ -398,7 +399,7 @@ alicePolicyId :: PolicyID TestCrypto
 alicePolicyId = PolicyID $ hashScript @MaryTest alicePolicy
 
 tokenSingWitEx1 :: AssetName
-tokenSingWitEx1 = AssetName $ BS.pack "tokenSingWitEx1"
+tokenSingWitEx1 = AssetName "tokenSingWitEx1"
 
 -----------------------
 -- Mint Alice Tokens --
@@ -558,7 +559,7 @@ bigValue =
   Value 0 $
     Map.singleton
       purplePolicyId
-      (Map.fromList $ map (\x -> (AssetName . BS.pack $ show x, 1)) [1 .. numAssets])
+      (Map.fromList $ map (\x -> (AssetName . fromString $ show x, 1)) [1 .. numAssets])
 
 bigOut :: TxOut MaryTest
 bigOut = TxOut Cast.aliceAddr $ bigValue <+> Val.inject minUtxoBigEx

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Mary.Value
   )
 import Cardano.Ledger.Val (Val (..), invert)
 import Control.Monad (replicateM)
-import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)
 import Data.CanonicalMaps
   ( CanonicalZero (..),
     canonicalInsert,
@@ -126,11 +126,11 @@ insertTests =
 -- ============================================================================================
 -- Arbitray instances
 
-genB :: Gen ByteString
+genB :: Gen ShortByteString
 genB = resize 4 arbitrary
 
 genAssetName :: Gen AssetName
-genAssetName = fmap AssetName genB
+genAssetName = AssetName <$> genB
 
 genPolicyID :: Gen (PolicyID C_Crypto)
 genPolicyID = PolicyID <$> arbitrary

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -46,7 +46,7 @@ import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import qualified Cardano.Ledger.Val as Val
 import Codec.CBOR.Encoding (Tokens (..))
-import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -79,14 +79,14 @@ policyID1 = PolicyID . (hashScript @A) $ policy1
 policyID2 :: PolicyID TestCrypto
 policyID2 = PolicyID . (hashScript @A) . RequireAllOf . StrictSeq.fromList $ []
 
-assetName1 :: BS.ByteString
-assetName1 = BS.pack "a1"
+assetName1 :: SBS.ShortByteString
+assetName1 = "a1"
 
-assetName2 :: BS.ByteString
-assetName2 = BS.pack "a2"
+assetName2 :: SBS.ShortByteString
+assetName2 = "a2"
 
-assetName3 :: BS.ByteString
-assetName3 = BS.pack "a3"
+assetName3 :: SBS.ShortByteString
+assetName3 = "a3"
 
 -- ===========================================
 -- == Test Values for Building Transactions ==
@@ -336,15 +336,15 @@ goldenEncodingTestsMary =
             <> S policyID1
             <> T
               ( TkMapLen 2
-                  . TkBytes assetName1
+                  . TkBytes (SBS.fromShort assetName1)
                   . TkInteger 13
-                  . TkBytes assetName2
+                  . TkBytes (SBS.fromShort assetName2)
                   . TkInteger 17
               )
             <> S policyID2
             <> T
               ( TkMapLen 1
-                  . TkBytes assetName3
+                  . TkBytes (SBS.fromShort assetName3)
                   . TkInteger 19
               )
         ),
@@ -359,7 +359,7 @@ goldenEncodingTestsMary =
             <> S policyID1
             <> T
               ( TkMapLen 1
-                  . TkBytes assetName1
+                  . TkBytes (SBS.fromShort assetName1)
                   . TkInteger (-19)
               )
         ),
@@ -441,7 +441,7 @@ goldenEncodingTestsMary =
     ]
 
 assetName32Bytes :: Assertion
-assetName32Bytes = expectDecodeFailure . AssetName . BS.pack $ "123456789-123456789-123456789-123"
+assetName32Bytes = expectDecodeFailure $ AssetName "123456789-123456789-123456789-123"
 
 -- | Golden Tests for Allegra and Mary
 goldenEncodingTests :: TestTree

--- a/libs/cardano-data/src/Data/CanonicalMaps.hs
+++ b/libs/cardano-data/src/Data/CanonicalMaps.hs
@@ -119,3 +119,4 @@ pointWise p m (Bin _ k v2 ls rs) =
   case Map.splitLookup k m of
     (lm, Just v1, rm) -> p v1 v2 && pointWise p ls lm && pointWise p rs rm
     _ -> False
+{-# INLINEABLE pointWise #-}

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.Pretty hiding (ppTxBody)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData
 import Cardano.Ledger.ShelleyMA.Timelocks
 import Cardano.Ledger.ShelleyMA.TxBody
-import Prettyprinter (hsep)
+import Prettyprinter (hsep, viaShow)
 
 ppValue :: Value crypto -> PDoc
 ppValue v = case gettriples' v of
@@ -27,7 +27,7 @@ ppPolicyID :: PolicyID crypto -> PDoc
 ppPolicyID (PolicyID sh) = ppScriptHash sh
 
 ppAssetName :: AssetName -> PDoc
-ppAssetName (AssetName bs) = ppLong bs
+ppAssetName = viaShow
 
 instance PrettyA (Value crypto) where prettyA = ppValue
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Shelley.TxBody (WitVKey (..))
 import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
 import Cardano.Slotting.Slot (SlotNo (..))
-import Data.ByteString (ByteString, pack, unpack)
+import Data.ByteString.Short (ShortByteString, pack, unpack)
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as Seq (fromList)
@@ -62,26 +62,26 @@ class PrettyA t => Fixed t where
   size _ = Nothing
 
 class Era e => IndexedE t e where
-  pickE :: Int -> Proof e -> (t e)
+  pickE :: Int -> Proof e -> t e
 
-pickCbyCrypto :: (Fixed (t c)) => Int -> Evidence c -> (t c)
+pickCbyCrypto :: Fixed (t c) => Int -> Evidence c -> t c
 pickCbyCrypto n Standard = unique n
 pickCbyCrypto n Mock = unique n
 
-pickCbyEra :: (Fixed (t (Crypto era))) => Int -> Proof era -> (t (Crypto era))
+pickCbyEra :: Fixed (t (Crypto era)) => Int -> Proof era -> t (Crypto era)
 pickCbyEra n _ = unique n
 
 -- =======================================================
 -- Examples where the type is independent of Era
 
-names :: ByteString
+names :: ShortByteString
 names = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-allnames :: [ByteString]
-allnames = (map (\x -> pack [x]) (unpack names))
+allnames :: [ShortByteString]
+allnames = map (\x -> pack [x]) (unpack names)
 
 instance Fixed Mary.AssetName where
-  unique n = (map Mary.AssetName allnames) !! n
+  unique n = map Mary.AssetName allnames !! n
   size _ = Just (length allnames)
 
 instance Fixed Coin where
@@ -315,7 +315,7 @@ instance (CC.Crypto c) => PrettyA (PublicSecret kr kr' c) where
   prettyA (PublicSecret x y) = ppPair prettyA prettyA (x, y)
 
 instance PrettyA (SKey kr c) where
-  prettyA (SKey _x) = ppString ("SKey")
+  prettyA (SKey _x) = ppString "SKey"
 
 instance PrettyA (MultiAsset era) where
   prettyA (MultiAsset v) = prettyA v

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Generators/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Generators/Tx.hs
@@ -32,7 +32,7 @@ import qualified Control.Monad.State.Strict as State
 import Control.Monad.Supply
   ( MonadSupply (..),
   )
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Map (Map)
@@ -194,7 +194,7 @@ genAssetName :: Gen AssetName
 genAssetName =
   AssetName
     <$> oneof
-      [ pure BS.empty,
+      [ pure SBS.empty,
         resize 32 arbitrary
       ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Properties.hs
@@ -42,7 +42,6 @@ import qualified Control.Monad.State.Strict as State
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import Control.Monad.Writer.Class
 import Control.State.Transition.Extended
-import qualified Data.ByteString.Char8 as BS
 import Data.Foldable
 import Data.Functor.Contravariant (Predicate (..))
 import Data.HKD
@@ -126,7 +125,7 @@ modelPlutusScript :: Natural -> ModelScript ('TyScriptFeature x 'True)
 modelPlutusScript = ModelScript_PlutusV1 . ModelPlutusScript_AlwaysSucceeds
 
 instance IsString AssetName where
-  fromString = AssetName . BS.pack
+  fromString = AssetName . fromString
 
 modelTestDelegations ::
   forall era proxy.


### PR DESCRIPTION
AssetName is limited to 32 bytes, there is no reason to use `ByteString` for it's representation. Also the value is not ascii or not even utf8, so hex is now used for the Show instance