### PR TITLE
cosmetic changes to babbage CDDL

### DIFF
--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -80,14 +80,11 @@ legacy_transaction_output =
   , ? datum_hash : $hash32
   ]
 
-; Note that in the post_alonzo_transaction_output, we do not allow
-; a transaction output to include both a datum hash and a datum.
-; In other words, keys 2 and 3 are mutually exclusive.
 post_alonzo_transaction_output =
   { 0 : address
   , 1 : value
-  , ? 2 : datum      ; New; inline datum
-  , ? 3 : script_ref ; New; script reference
+  , ? 2 : datum_option ; New; datum option
+  , ? 3 : script_ref   ; New; script reference
   }
 
 script_data_hash = $hash32
@@ -408,7 +405,7 @@ pool_metadata_hash    = $hash32
 datum_hash = $hash32
 data = #6.24(bytes .cbor plutus_data)
 
-datum = [ 0, $hash32 // 1, data ]
+datum_option = [ 0, $hash32 // 1, data ]
 
 script_ref = #6.24(bytes .cbor script)
 

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
@@ -35,7 +35,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlAnnotatorTest @(Data B) n "plutus_data",
       cddlTest @(TxOut B) n "transaction_output",
       cddlAnnotatorTest @(Core.Script B) n "script",
-      cddlTest @(Datum B) n "datum",
+      cddlTest @(Datum B) n "datum_option",
       cddlAnnotatorTest @(TxWitness B) n "transaction_witness_set",
       cddlTest @(PParamsUpdate B) n "protocol_param_update",
       cddlTest @CostModels n "costmdls",


### PR DESCRIPTION
I made two small, cosmetic changes to the Babbage CDDL:

* I removed an outdated comment
* I renamed `datum` to `datum_option` (since it can be a hash or a datum)