### PR TITLE
Fix `Show` instance for the `Ptr` and improve for `TxIx` and `CertIx`

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -665,8 +665,8 @@ newtype BlocksMade crypto = BlocksMade
 -- other than `Word16`. There is also `mkTxIxPartial` that can be used for
 -- testing.
 newtype TxIx = TxIx Word16
-  deriving stock (Eq, Ord)
-  deriving newtype (NFData, Enum, Bounded, Show, NoThunks, ToCBOR, FromCBOR)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData, Enum, Bounded, NoThunks, ToCBOR, FromCBOR)
 
 txIxToInt :: TxIx -> Int
 txIxToInt (TxIx w16) = fromIntegral w16
@@ -685,8 +685,8 @@ mkTxIxPartial i =
 -- index safely from anything other than `Word16`. There is also
 -- `mkCertIxPartial` that can be used for testing.
 newtype CertIx = CertIx Word16
-  deriving stock (Eq, Ord)
-  deriving newtype (NFData, Enum, Bounded, Show, NoThunks, ToCBOR, FromCBOR)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData, Enum, Bounded, NoThunks, ToCBOR, FromCBOR)
 
 certIxToInt :: CertIx -> Int
 certIxToInt (CertIx w16) = fromIntegral w16

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -22,8 +22,16 @@ module Cardano.Ledger.Credential
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen)
-import Cardano.Ledger.BaseTypes (CertIx (..), TxIx (..), invalidKey)
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    encodeListLen,
+  )
+import Cardano.Ledger.BaseTypes
+  ( CertIx (..),
+    TxIx (..),
+    invalidKey,
+  )
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys
@@ -39,7 +47,14 @@ import Cardano.Ledger.Serialization
   )
 import Cardano.Ledger.Slot (SlotNo (..))
 import Control.DeepSeq (NFData)
-import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey, (.:), (.=))
+import Data.Aeson
+  ( FromJSON (..),
+    FromJSONKey,
+    ToJSON (..),
+    ToJSONKey,
+    (.:),
+    (.=),
+  )
 import qualified Data.Aeson as Aeson
 import Data.Bits
 import Data.Foldable (asum)
@@ -103,7 +118,7 @@ instance NoThunks (StakeReference crypto)
 -- | Pointer to a slot number, transaction index and an index in certificate
 -- list. We expect that `SlotNo` will fit into `Word32` for a very long time,
 -- because we can assume that the rate at which it is incremented isn't going to
--- icrease in the near future. Therefore with current rate we should be fine for
+-- increase in the near future. Therefore with current rate we should be fine for
 -- about a 150 years. I suggest to remove this optimization in about a
 -- hundred years or thereabouts, so around a year 2122 would be good.
 --
@@ -118,8 +133,22 @@ instance NoThunks (StakeReference crypto)
 --
 -- @@@
 newtype Ptr = PtrCompact Word64
-  deriving (Show, Eq, Ord, Generic, NFData, NoThunks)
+  deriving (Eq, Ord, Generic, NFData, NoThunks)
   deriving (ToCBOR, FromCBOR) via CBORGroup Ptr
+
+instance Show Ptr where
+  showsPrec n (Ptr slotNo txIx certIx)
+    | n < 1 = inner
+    | otherwise = ('(' :) . inner . (")" ++)
+    where
+      inner =
+        ("Ptr (" ++)
+          . shows slotNo
+          . (") (" ++)
+          . shows txIx
+          . (") " ++)
+          . shows certIx
+          . (')' :)
 
 -- | With this pattern synonym we can recover actual values from compacted version of `Ptr`.
 pattern Ptr :: SlotNo -> TxIx -> CertIx -> Ptr


### PR DESCRIPTION
Current show instance shows the packed version:
```haskell
λ> Ptr 4 (mkTxIxPartial 5) (mkCertIxPartial 6)
PtrCompact 17180196870
λ> Just (Ptr 4 (mkTxIxPartial 5) (mkCertIxPartial 6))
Just (PtrCompact 17180196870)
```

What we want instead is this, which this PR implements:
```haskell
λ> Ptr 4 (mkTxIxPartial 5) (mkCertIxPartial 6)
Ptr (SlotNo 4) TxIx 5 CertIx 6
λ> Just (Ptr 4 (mkTxIxPartial 5) (mkCertIxPartial 6))
Just (Ptr (SlotNo 4) TxIx 5 CertIx 6)
```