### PR TITLE
Implement `Sized` abstraction and use it for `OutputTooSmallUTxO` 

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -53,6 +53,7 @@ import qualified Cardano.Ledger.Mary.Value as V (Value)
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
 import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.Serialization (mkSized)
 import Cardano.Ledger.Shelley (nativeMultiSigTag)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.Constraints
@@ -239,6 +240,7 @@ instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
           SJust dh <- [getField @"datahash" out]
       ]
   allOuts txbody = toList $ getField @"outputs" txbody
+  allSizedOuts = map mkSized . allOuts
   txdata (ValidatedTx _ (TxWitness _ _ _ (TxDats' m) _) _ _) = Set.fromList $ Map.elems m
 
 -------------------------------------------------------------------------------

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Hashes (EraIndependentData)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness), hashKey)
 import qualified Cardano.Ledger.Mary.Value as Mary (AssetName (..), PolicyID (..), Value (..))
 import Cardano.Ledger.SafeHash
+import Cardano.Ledger.Serialization (Sized (sizedValue))
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.Scripts (ScriptHash (..))
 import Cardano.Ledger.Shelley.TxBody
@@ -396,6 +397,11 @@ class ExtendedUTxO era where
   allOuts ::
     Core.TxBody era ->
     [Core.TxOut era]
+  allOuts = map sizedValue . allSizedOuts
+
+  allSizedOuts ::
+    Core.TxBody era ->
+    [Sized (Core.TxOut era)]
 
   txdata ::
     Core.Tx era ->
@@ -736,7 +742,7 @@ languages ::
   ) =>
   Core.Tx era ->
   UTxO era ->
-  Set (Language)
+  Set Language
 languages tx utxo = Map.foldl' accum Set.empty allscripts
   where
     allscripts = Cardano.Ledger.Alonzo.TxInfo.txscripts @era utxo tx

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -4,7 +4,13 @@
 
 module Test.Cardano.Ledger.Babbage.Examples.Consensus where
 
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), AuxiliaryDataHash (..), Data (..), dataToBinaryData, hashData)
+import Cardano.Ledger.Alonzo.Data
+  ( AuxiliaryData (..),
+    AuxiliaryDataHash (..),
+    Data (..),
+    dataToBinaryData,
+    hashData,
+  )
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
@@ -23,6 +29,7 @@ import Cardano.Ledger.Era (ValidateScript (hashScript))
 import Cardano.Ledger.Keys (asWitness)
 import qualified Cardano.Ledger.Mary.Value as Mary
 import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.Serialization (mkSized)
 import Cardano.Ledger.Shelley.API
   ( ApplyTxError (..),
     Credential (..),
@@ -109,14 +116,15 @@ exampleTxBodyBabbage =
     (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 2)) 1]) -- collateral inputs
     (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 1)) 3]) -- reference inputs
     ( StrictSeq.fromList
-        [ TxOut
-            (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
-            (MarySLE.exampleMultiAssetValue 2)
-            (Datum $ dataToBinaryData datumExample) -- inline datum
-            (SJust $ alwaysSucceeds PlutusV2 3) -- reference script
+        [ mkSized $
+            TxOut
+              (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+              (MarySLE.exampleMultiAssetValue 2)
+              (Datum $ dataToBinaryData datumExample) -- inline datum
+              (SJust $ alwaysSucceeds PlutusV2 3) -- reference script
         ]
     )
-    (SJust collateralOutput) -- collateral return
+    (SJust $ mkSized collateralOutput) -- collateral return
     (SJust $ Coin 8675309) -- collateral tot
     SLE.exampleCerts -- txcerts
     ( Wdrl $

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -11,6 +11,7 @@
 
 module Test.Cardano.Ledger.Babbage.Serialisation.Generators where
 
+import Cardano.Binary (ToCBOR)
 import Cardano.Ledger.Alonzo.Data (dataToBinaryData)
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
@@ -23,6 +24,7 @@ import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageBody, Datum (..), TxOut (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
+import Cardano.Ledger.Serialization (Sized, mkSized)
 import Cardano.Ledger.Shelley.Constraints (UsesValue)
 import qualified Data.Set as Set
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
@@ -31,6 +33,9 @@ import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 import Test.QuickCheck
+
+instance (ToCBOR a, Arbitrary a) => Arbitrary (Sized a) where
+  arbitrary = mkSized <$> arbitrary
 
 instance
   ( Era era,

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -12,6 +12,7 @@ import Cardano.Ledger.Babbage.TxInfo (OutputSource (..), txInfoInV2, txInfoOutV2
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (StakeReference (..))
+import Cardano.Ledger.Serialization (mkSized)
 import Cardano.Ledger.Shelley.TxBody (Wdrl (..))
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
@@ -105,7 +106,7 @@ txb i mRefInp o =
       referenceInputs = case mRefInp of
         Nothing -> mempty
         Just ri -> Set.singleton ri,
-      outputs = StrictSeq.singleton o,
+      outputs = StrictSeq.singleton (mkSized o),
       collateralReturn = SNothing,
       totalCollateral = SNothing,
       txcerts = mempty,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -146,7 +146,7 @@ ppBabbageUtxoPred (UnequalCollateralReturn c1 c2) =
 ppBabbageUtxoPred (MalformedScripts scripts) =
   ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
 ppBabbageUtxoPred (BabbageOutputTooSmallUTxO xs) =
-  ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair prettyA ppInteger) xs]
+  ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair prettyA ppCoin) xs]
 
 instance
   ( PrettyA (UtxoPredicateFailure era),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -971,7 +971,7 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ largeOutputTx pf)
-              (Left [fromUtxoB @era $ BabbageOutputTooSmallUTxO [(largeOutput pf, 8115)]])
+              (Left [fromUtxoB @era $ BabbageOutputTooSmallUTxO [(largeOutput pf, Coin 8115)]])
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Era (Era (..), ValidateScript, hashScript)
 import Cardano.Ledger.Keys (KeyHash, KeyPair (..), KeyRole (..), hashKey)
 import qualified Cardano.Ledger.Mary.Value as Mary (Value (..))
+import Cardano.Ledger.Serialization (sizedValue)
 import Cardano.Ledger.Shelley.Address.Bootstrap (BootstrapWitness (..))
 import qualified Cardano.Ledger.Shelley.PParams as PP (Update)
 import Cardano.Ledger.Shelley.Scripts (ScriptHash)
@@ -353,8 +354,8 @@ abstractTxBody (Babbage _) (Babbage.TxBody inp col ref out colret totcol cert wd
   [ Inputs inp,
     Collateral col,
     RefInputs ref,
-    Outputs out,
-    CollateralReturn colret,
+    Outputs (sizedValue <$> out),
+    CollateralReturn (sizedValue <$> colret),
     TotalCol totcol,
     Certs cert,
     Wdrls wdrl,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -3,23 +3,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
---
--- Eq (Some Proof)
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Test.Cardano.Ledger.Generic.Updaters where
 
@@ -37,6 +27,7 @@ import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxBody (.
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Serialization (mkSized)
 import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..))
 import Cardano.Ledger.Shelley.Tx as Shelley (WitnessSetHKD (addrWits, bootWits, scriptWits))
 import qualified Cardano.Ledger.Shelley.Tx as Shelley (Tx (..))
@@ -207,8 +198,8 @@ updateTxBody (Babbage _) tx dt = case dt of
   (Inputs is) -> tx {Babbage.inputs = is}
   (Collateral is) -> tx {Babbage.collateral = is}
   (RefInputs is) -> tx {Babbage.referenceInputs = is}
-  (Outputs outs1) -> tx {Babbage.outputs = outs1}
-  (CollateralReturn outs1) -> tx {Babbage.collateralReturn = outs1}
+  (Outputs outs1) -> tx {Babbage.outputs = mkSized <$> outs1}
+  (CollateralReturn outs1) -> tx {Babbage.collateralReturn = mkSized <$> outs1}
   (Certs cs) -> tx {Babbage.txcerts = cs}
   (Wdrls ws) -> tx {Babbage.txwdrls = ws}
   (Txfee c) -> tx {Babbage.txfee = c}


### PR DESCRIPTION
Current `OutputTooSmallUTxO` is suboptimal for two reasons:

* each TxOu has to be unnecessarily serialized upon validation
* TxOut size computed might be different from size of the TxOut submitted over the wire due to non-canonical serialization, which can prove to be problem.

This PR fixes those deficiencies by recording the size each TxOut occupies in the TxOut and using that value for validation.