### PR TITLE
Ensure pure `EpochInfo` is not overused.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Alonzo.TxSeq (txSeqTxns)
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo (TxSeq)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import Cardano.Ledger.BHeaderView (BHeaderView (..), isOverlaySlot)
-import Cardano.Ledger.BaseTypes (ShelleyBase, UnitInterval, epochInfo)
+import Cardano.Ledger.BaseTypes (ShelleyBase, UnitInterval, epochInfoPure)
 import Cardano.Ledger.Block (Block (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto), SupportsSegWit (..))
@@ -177,7 +177,7 @@ bbodyTransition =
         let hkAsStakePool = coerceKeyRole . bhviewID $ bh
             slot = bhviewSlot bh
         firstSlotNo <- liftSTS $ do
-          ei <- asks epochInfo
+          ei <- asks epochInfoPure
           e <- epochInfoEpoch ei slot
           epochInfoFirst ei e
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.BaseTypes
     ProtVer,
     ShelleyBase,
     StrictMaybe (..),
-    epochInfoWithErr,
+    epochInfo,
     networkId,
     systemStart,
   )
@@ -512,7 +512,7 @@ utxoTransition = do
     ShelleyMA.validateOutsideValidityIntervalUTxO slot txb
 
   sysSt <- liftSTS $ asks systemStart
-  ei <- liftSTS $ asks epochInfoWithErr
+  ei <- liftSTS $ asks epochInfo
 
   {- epochInfoSlotToUTCTime epochInfo systemTime i_f ≠ ◇ -}
   runTest $ validateOutsideForecast pp ei slot sysSt tx

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -19,7 +19,6 @@ import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Data.Default.Class (def)
-import Data.Functor.Identity (Identity, runIdentity)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -37,7 +36,7 @@ byronAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
 shelleyAddr :: Addr StandardCrypto
 shelleyAddr = Addr Testnet alicePHK StakeRefNull
 
-ei :: EpochInfo Identity
+ei :: EpochInfo (Either a)
 ei = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
 
 ss :: SystemStart
@@ -95,7 +94,7 @@ silentlyIgnore tx =
     Right _ -> pure ()
     Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
   where
-    ctx = runIdentity $ txInfo def PlutusV1 ei ss utxo tx
+    ctx = txInfo def PlutusV1 ei ss utxo tx
 
 expectTranslationError :: Language -> ValidatedTx A -> TranslationError -> Assertion
 expectTranslationError lang tx expected =
@@ -103,7 +102,7 @@ expectTranslationError lang tx expected =
     Right _ -> error "This translation was expected to fail, but it succeeded."
     Left e -> e @?= expected
   where
-    ctx = runIdentity $ txInfo def lang ei ss utxo tx
+    ctx = txInfo def lang ei ss utxo tx
 
 txInfoTests :: TestTree
 txInfoTests =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Babbage.TxBody
   )
 import Cardano.Ledger.BaseTypes
   ( ShelleyBase,
-    epochInfoWithErr,
+    epochInfo,
     networkId,
     systemStart,
   )
@@ -353,7 +353,7 @@ utxoTransition = do
     ShelleyMA.validateOutsideValidityIntervalUTxO slot txb
 
   sysSt <- liftSTS $ asks systemStart
-  ei <- liftSTS $ asks epochInfoWithErr
+  ei <- liftSTS $ asks epochInfo
 
   {- epochInfoSlotToUTCTime epochInfo systemTime i_f ≠ ◇ -}
   runTest $ validateOutsideForecast pp ei slot sysSt tx

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -23,7 +23,6 @@ import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Data.Default.Class (def)
 import Data.Either (fromRight)
-import Data.Functor.Identity (Identity, runIdentity)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -44,7 +43,7 @@ byronAddr = AddrBootstrap (BootstrapAddress aliceByronAddr)
 shelleyAddr :: Addr StandardCrypto
 shelleyAddr = Addr Testnet alicePHK StakeRefNull
 
-ei :: EpochInfo Identity
+ei :: EpochInfo (Either a)
 ei = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
 
 ss :: SystemStart
@@ -145,7 +144,7 @@ successfulTranslation lang tx f =
     Right info -> assertBool "unexpected transaction info" (f info)
     Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
   where
-    ctx = runIdentity $ txInfo def lang ei ss utxo tx
+    ctx = txInfo def lang ei ss utxo tx
 
 successfulV2Translation :: ValidatedTx B -> (VersionedTxInfo -> Bool) -> Assertion
 successfulV2Translation = successfulTranslation PlutusV2
@@ -156,7 +155,7 @@ expectTranslationError lang tx expected =
     Right _ -> assertFailure "This translation was expected to fail, but it succeeded."
     Left e -> e @?= expected
   where
-    ctx = runIdentity $ txInfo def lang ei ss utxo tx
+    ctx = txInfo def lang ei ss utxo tx
 
 expectV1TranslationError :: ValidatedTx B -> TranslationError -> Assertion
 expectV1TranslationError = expectTranslationError PlutusV1

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -56,7 +56,7 @@ import Cardano.Ledger.BaseTypes
     NonNegativeInterval,
     ProtVer,
     UnitInterval,
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.CompactAddress (compactAddr)
@@ -445,7 +445,7 @@ getRewardProvenance globals newepochstate =
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     asc = activeSlotCoeff globals
     secparam = securityParameter globals
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -429,7 +429,7 @@ mkShelleyGlobals ::
 mkShelleyGlobals genesis epochInfoAc maxMajorPV =
   Globals
     { activeSlotCoeff = sgActiveSlotCoeff genesis,
-      epochInfoWithErr = epochInfoAc,
+      epochInfo = epochInfoAc,
       maxKESEvo = sgMaxKESEvolutions genesis,
       maxLovelaceSupply = sgMaxLovelaceSupply genesis,
       maxMajorPV = maxMajorPV,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -22,12 +22,12 @@ module Cardano.Ledger.Shelley.Rules.Bbody
 where
 
 import Cardano.Ledger.BHeaderView (BHeaderView (..), isOverlaySlot)
-import Cardano.Ledger.BaseTypes (BlocksMade, ShelleyBase, UnitInterval, epochInfo)
+import Cardano.Ledger.BaseTypes (BlocksMade, ShelleyBase, UnitInterval, epochInfoPure)
 import Cardano.Ledger.Block (Block (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto), SupportsSegWit (fromTxSeq, hashTxSeq))
 import qualified Cardano.Ledger.Era as Era
-import Cardano.Ledger.Hashes (EraIndependentBlockBody)
+import Cardano.Ledger.Hashes (EraIndependentBlockBody, EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash, coerceKeyRole)
 import Cardano.Ledger.Serialization (ToCBORGroup)
 import Cardano.Ledger.Shelley.BlockChain (bBodySize, incrBlocks)
@@ -37,7 +37,6 @@ import Cardano.Ledger.Shelley.LedgerState
     LedgerState,
   )
 import Cardano.Ledger.Shelley.Rules.Ledgers (LedgersEnv (..))
-import Cardano.Ledger.Shelley.TxBody (EraIndependentTxBody)
 import Cardano.Ledger.Slot (epochInfoEpoch, epochInfoFirst)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
@@ -172,7 +171,7 @@ bbodyTransition =
         let hkAsStakePool = coerceKeyRole . bhviewID $ bhview
             slot = bhviewSlot bhview
         firstSlotNo <- liftSTS $ do
-          ei <- asks epochInfo
+          ei <- asks epochInfoPure
           e <- epochInfoEpoch ei slot
           epochInfoFirst ei e
         pure $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -21,7 +21,7 @@ import Cardano.Binary
     ToCBOR (..),
     encodeListLen,
   )
-import Cardano.Ledger.BaseTypes (Globals (..), ProtVer, ShelleyBase, epochInfo, invalidKey)
+import Cardano.Ledger.BaseTypes (Globals (..), ProtVer, ShelleyBase, epochInfoPure, invalidKey)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), addDeltaCoin, toDeltaCoin)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential)
@@ -324,7 +324,7 @@ delegationTransition = do
       if HardForks.allowMIRTransfer pp
         then do
           sp <- liftSTS $ asks stabilityWindow
-          ei <- liftSTS $ asks epochInfo
+          ei <- liftSTS $ asks epochInfoPure
           EpochNo currEpoch <- liftSTS $ epochInfoEpoch ei slot
           let newEpoch = EpochNo (currEpoch + 1)
           tellEvent (NewEpoch newEpoch)
@@ -352,7 +352,7 @@ delegationTransition = do
             TreasuryMIR -> pure $ ds {_irwd = (_irwd ds) {iRTreasury = combinedMap}}
         else do
           sp <- liftSTS $ asks stabilityWindow
-          ei <- liftSTS $ asks epochInfo
+          ei <- liftSTS $ asks epochInfoPure
           EpochNo currEpoch <- liftSTS $ epochInfoEpoch ei slot
           let newEpoch = EpochNo (currEpoch + 1)
           tellEvent (NewEpoch newEpoch)
@@ -380,7 +380,7 @@ delegationTransition = do
       if HardForks.allowMIRTransfer pp
         then do
           sp <- liftSTS $ asks stabilityWindow
-          ei <- liftSTS $ asks epochInfo
+          ei <- liftSTS $ asks epochInfoPure
           EpochNo currEpoch <- liftSTS $ epochInfoEpoch ei slot
           let newEpoch = EpochNo (currEpoch + 1)
           tellEvent (NewEpoch newEpoch)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -26,7 +26,16 @@ import Cardano.Binary
     encodeListLen,
   )
 import Cardano.Crypto.Hash.Class (sizeHash)
-import Cardano.Ledger.BaseTypes (Globals (..), Network, ProtVer, ShelleyBase, StrictMaybe (..), epochInfo, invalidKey, networkId)
+import Cardano.Ledger.BaseTypes
+  ( Globals (..),
+    Network,
+    ProtVer,
+    ShelleyBase,
+    StrictMaybe (..),
+    epochInfoPure,
+    invalidKey,
+    networkId,
+  )
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto (HASH))
@@ -224,7 +233,7 @@ poolDelegationTransition = do
       -- note that pattern match is used instead of cwitness, as in the spec
       eval (hk ∈ dom stpools) ?! StakePoolNotRegisteredOnKeyPOOL hk
       EpochNo cepoch <- liftSTS $ do
-        ei <- asks epochInfo
+        ei <- asks epochInfoPure
         epochInfoEpoch ei slot
       let EpochNo maxEpoch = getField @"_eMax" pp
       cepoch < e && e <= cepoch + maxEpoch

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -163,7 +163,7 @@ ppupTransitionNonEmpty = do
 
       sp <- liftSTS $ asks stabilityWindow
       firstSlotNextEpoch <- do
-        ei <- liftSTS $ asks epochInfo
+        ei <- liftSTS $ asks epochInfoPure
         EpochNo e <- liftSTS $ epochInfoEpoch ei slot
         let newEpochNo = EpochNo $ e + 1
         tellEvent $ NewEpoch newEpochNo
@@ -171,7 +171,7 @@ ppupTransitionNonEmpty = do
       let tooLate = firstSlotNextEpoch *- Duration (2 * sp)
 
       currentEpoch <- liftSTS $ do
-        ei <- asks epochInfo
+        ei <- asks epochInfoPure
         epochInfoEpoch ei slot
 
       if slot < tooLate

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     UnitInterval,
     activeSlotCoeff,
-    epochInfo,
+    epochInfoPure,
     maxLovelaceSupply,
     randomnessStabilisationWindow,
     securityParameter,
@@ -141,7 +141,7 @@ rupdTransition ::
 rupdTransition = do
   TRC (RupdEnv b es, ru, s) <- judgmentContext
   (slotsPerEpoch, slot, slotForce, maxLL, asc, k, e) <- liftSTS $ do
-    ei <- asks epochInfo
+    ei <- asks epochInfoPure
     sr <- asks randomnessStabilisationWindow
     e <- epochInfoEpoch ei s
     slotsPerEpoch <- epochInfoSize ei e

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Shelley.Rules.Tick
   )
 where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfo)
+import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfoPure)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto, Era)
 import Cardano.Ledger.Keys (GenDelegs (..))
@@ -155,7 +155,7 @@ validatingTickTransition ::
   TransitionRule (tick era)
 validatingTickTransition nes slot = do
   epoch <- liftSTS $ do
-    ei <- asks epochInfo
+    ei <- asks epochInfoPure
     epochInfoEpoch ei slot
 
   nes' <- trans @(Core.EraRule "NEWEPOCH" era) $ TRC ((), nes, epoch)

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.BaseTypes
   ( Globals (activeSlotCoeff, securityParameter),
     Network (Testnet),
     StrictMaybe (..),
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -188,7 +188,7 @@ createRUpd globals cs =
     total = totalAda cs
     epochSize =
       runIdentity $
-        epochInfoSize (epochInfo globals) (LS.nesEL nes)
+        epochInfoSize (epochInfoPure globals) (LS.nesEL nes)
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
 
@@ -209,6 +209,6 @@ createRUpdWithProv globals cs =
     total = totalAda cs
     epochSize =
       runIdentity $
-        epochInfoSize (epochInfo globals) (LS.nesEL nes)
+        epochInfoSize (epochInfoPure globals) (LS.nesEL nes)
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -386,7 +386,7 @@ exampleLedgerChainDepState seed =
     }
 
 testEpochInfo :: EpochInfo Identity
-testEpochInfo = epochInfo testGlobals
+testEpochInfo = epochInfoPure testGlobals
 
 mkDummyHash :: forall h a. HashAlgorithm h => Proxy h -> Int -> Hash.Hash h a
 mkDummyHash _ = coerce . hashWithSerialiser @h toCBOR

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -67,7 +67,7 @@ import Cardano.Ledger.BaseTypes
     ProtVer (..),
     StrictMaybe (..),
     UnitInterval,
-    epochInfo,
+    epochInfoPure,
     stabilityWindow,
   )
 import Cardano.Ledger.Block (Block (..))
@@ -682,7 +682,7 @@ getKESPeriodRenewalNo keys (KESPeriod kp) =
 -- slots of the current epoch.
 tooLateInEpoch :: SlotNo -> Bool
 tooLateInEpoch s = runShelleyBase $ do
-  ei <- asks epochInfo
+  ei <- asks epochInfoPure
   firstSlotNo <- epochInfoFirst ei (epochFromSlotNo s + 1)
   stabilityWindow <- asks stabilityWindow
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -20,7 +20,7 @@ module Test.Cardano.Ledger.Shelley.Rules.ClassifyTraces
 where
 
 import Cardano.Binary (ToCBOR, serialize')
-import Cardano.Ledger.BaseTypes (Globals, StrictMaybe (..), epochInfo)
+import Cardano.Ledger.BaseTypes (Globals, StrictMaybe (..), epochInfoPure)
 import Cardano.Ledger.Block (Block (..), bheader)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..), SupportsSegWit (fromTxSeq), TxSeq)
@@ -420,6 +420,6 @@ epochsInTrace bs =
   where
     fromEpoch = atEpoch . blockSlot $ head bs
     toEpoch = atEpoch . blockSlot $ last bs
-    EpochSize slotsPerEpoch = runShelleyBase $ (epochInfoSize . epochInfo) testGlobals undefined
+    EpochSize slotsPerEpoch = runShelleyBase $ (epochInfoSize . epochInfoPure) testGlobals undefined
     blockSlot = bheaderSlotNo . bhbody . bheader
     atEpoch (SlotNo s) = s `div` slotsPerEpoch

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -79,7 +79,7 @@ import Cardano.Ledger.BaseTypes
     Network (..),
     Nonce,
     ShelleyBase,
-    epochInfo,
+    epochInfoPure,
     mkActiveSlotCoeff,
     mkNonceFromOutputVRF,
   )
@@ -285,7 +285,7 @@ unsafeBoundRational r =
 testGlobals :: Globals
 testGlobals =
   Globals
-    { epochInfoWithErr = fixedEpochInfo (EpochSize 100) (mkSlotLength 1),
+    { epochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1),
       slotsPerKESPeriod = 20,
       stabilityWindow = 33,
       randomnessStabilisationWindow = 33,
@@ -303,13 +303,13 @@ runShelleyBase :: ShelleyBase a -> a
 runShelleyBase act = runIdentity $ runReaderT act testGlobals
 
 epochFromSlotNo :: SlotNo -> EpochNo
-epochFromSlotNo = runIdentity . epochInfoEpoch (epochInfo testGlobals)
+epochFromSlotNo = runIdentity . epochInfoEpoch (epochInfoPure testGlobals)
 
 slotFromEpoch :: EpochNo -> SlotNo
-slotFromEpoch = runIdentity . epochInfoFirst (epochInfo testGlobals)
+slotFromEpoch = runIdentity . epochInfoFirst (epochInfoPure testGlobals)
 
 epochSize :: EpochNo -> EpochSize
-epochSize = runIdentity . epochInfoSize (epochInfo testGlobals)
+epochSize = runIdentity . epochInfoSize (epochInfoPure testGlobals)
 
 -- | Try to evolve KES key until specific KES period is reached, given the
 -- current KES period.

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.BaseTypes
     Network (..),
     Nonce,
     StrictMaybe (..),
-    epochInfo,
+    epochInfoPure,
     mkCertIxPartial,
     (⭒),
   )
@@ -802,7 +802,7 @@ rewardInfoTest = rewardInfoEx8 @?= expected
   where
     expected =
       RP.RewardProvenance
-        { RP.spe = unEpochSize . runShelleyBase $ epochInfoSize (epochInfo testGlobals) (EpochNo 0),
+        { RP.spe = unEpochSize . runShelleyBase $ epochInfoSize (epochInfoPure testGlobals) (EpochNo 0),
           RP.blocks =
             BlocksMade $
               Map.singleton (_poolId $ Cast.alicePoolParams) 1,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.BaseTypes
     StrictMaybe (..),
     UnitInterval,
     activeSlotVal,
-    epochInfo,
+    epochInfoPure,
     mkActiveSlotCoeff,
   )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), rationalToCoinViaFloor, toDeltaCoin)
@@ -392,7 +392,7 @@ justRewardInfo globals newepochstate =
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
 
@@ -426,7 +426,7 @@ nothingInNothingOut newepochstate =
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
 
@@ -449,7 +449,7 @@ justInJustOut newepochstate =
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     asc = activeSlotCoeff globals
     k = securityParameter testGlobals
 
@@ -691,7 +691,7 @@ oldEqualsNew pv newepochstate =
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     unAggregated =
       runReader (runProvM $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc k) globals
     old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
@@ -718,7 +718,7 @@ oldEqualsNewOn pv newepochstate = old === new
     blocksmade = nesBprev newepochstate
     epochnumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfo globals) epochnumber) globals
+    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
     (unAggregated, _) =
       runReader (runWithProvM def $ createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc k) globals
     old :: Map (Credential 'Staking (Crypto era)) Coin

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -60,7 +60,7 @@ module Cardano.Ledger.BaseTypes
 
     -- * STS Base
     Globals (..),
-    epochInfo,
+    epochInfoPure,
     ShelleyBase,
   )
 where
@@ -583,7 +583,7 @@ activeSlotLog f = fromIntegral (unActiveSlotLog f) / fpPrecision
 --------------------------------------------------------------------------------
 
 data Globals = Globals
-  { epochInfoWithErr :: !(EpochInfo (Either Text)),
+  { epochInfo :: !(EpochInfo (Either Text)),
     slotsPerKESPeriod :: !Word64,
     -- | The window size in which our chosen chain growth property
     --   guarantees at least k blocks. From the paper
@@ -618,8 +618,11 @@ instance NoThunks Globals
 
 type ShelleyBase = ReaderT Globals Identity
 
-epochInfo :: Globals -> EpochInfo Identity
-epochInfo = hoistEpochInfo (either (throw . EpochErr) pure) . epochInfoWithErr
+-- | Pure epoch info via throw. Note that this should only be used when we can
+-- guarantee the validity of the translation; in particular, the `EpochInfo`
+-- used here should never be applied to user-supplied input.
+epochInfoPure :: Globals -> EpochInfo Identity
+epochInfoPure = hoistEpochInfo (either (throw . EpochErr) pure) . epochInfo
 
 newtype EpochErr = EpochErr Text
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/API.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/API.hs
@@ -135,7 +135,7 @@ where
 
 import Cardano.Ledger.BaseTypes
   ( Globals (..),
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Coin
   ( Coin,
@@ -335,7 +335,7 @@ instance NFData (ModelLedger era)
 applyModelTick :: HasModelM era st r m => SlotNo -> m ()
 applyModelTick mslot = do
   globals <- asks getGlobals
-  let ei = epochInfo globals
+  let ei = epochInfoPure globals
   Identity firstSlot <- epochInfoFirst ei <$> use (modelLedger . to getModelLedger_epoch)
   let slot = firstSlot + mslot
 
@@ -384,7 +384,7 @@ applyModelBlocksMade blocksMade = do
   currentSlotOffset <- modelLedger . modelLedger_slotOffset <<.= 0
 
   globals <- asks getGlobals
-  let ei = epochInfo globals
+  let ei = epochInfoPure globals
       prevEpoch = epochNo
       epoch = succ epochNo
       firstOfOld = runIdentity $ epochInfoFirst ei prevEpoch

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
@@ -67,7 +67,7 @@ import Cardano.Ledger.BaseTypes
     Globals (..),
     Network (Testnet),
     StrictMaybe (..),
-    epochInfo,
+    epochInfoPure,
     mkTxIxPartial,
   )
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
@@ -1088,7 +1088,7 @@ class
       mblock@(ModelBlock mslot mtxSeq) -> do
         currentEpoch <- use $ _2 . eesCurrentEpoch
         let slot = runIdentity (epochInfoFirst ei currentEpoch) + mslot
-            ei = epochInfo globals
+            ei = epochInfoPure globals
             ttl = succ slot
 
         unless (currentEpoch == runIdentity (epochInfoEpoch ei slot)) $ error $ "model slot out of range: " <> show mslot
@@ -1403,7 +1403,7 @@ class
 
     prevEpoch <- use $ _2 . eesCurrentEpoch
     epoch <- _2 . eesCurrentEpoch <%= succ
-    let ei = epochInfo globals
+    let ei = epochInfoPure globals
     bs <- for (Map.toList $ unModelBlocksMade mblocksMade) $ \(maddr, n) -> do
       poolKey <- zoom _2 $ getTestPoolId (Proxy :: Proxy era) maddr
       pure (poolKey, n)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Shelley.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Shelley.hs
@@ -12,7 +12,7 @@ import qualified Cardano.Crypto.DSIGN.Class as DSIGN
 import qualified Cardano.Crypto.KES.Class as KES
 import Cardano.Crypto.Util (SignableRepresentation)
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.BaseTypes (Globals (..), activeSlotVal, epochInfo)
+import Cardano.Ledger.BaseTypes (Globals (..), activeSlotVal, epochInfoPure)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto (DSIGN, KES)
 import Cardano.Ledger.Era (Crypto)
@@ -132,7 +132,7 @@ fromShelleyGlobals globals pp genDelegs initialFunds =
       sgNetworkId = networkId globals,
       sgActiveSlotsCoeff = activeSlotVal $ activeSlotCoeff globals,
       sgSecurityParam = securityParameter globals,
-      sgEpochLength = runIdentity $ flip epochInfoSize (EpochNo 1) $ epochInfo globals,
+      sgEpochLength = runIdentity $ flip epochInfoSize (EpochNo 1) $ epochInfoPure globals,
       sgSlotsPerKESPeriod = slotsPerKESPeriod globals,
       sgMaxKESEvolutions = maxKESEvo globals,
       sgSlotLength = (secondsToNominalDiffTime 1),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Generators/Chain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Generators/Chain.hs
@@ -20,7 +20,7 @@ where
 
 import Cardano.Ledger.BaseTypes
   ( Globals (..),
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Val as Val
@@ -113,7 +113,7 @@ genBlocksMade = do
     use
       (modelLedger . modelLedger_nes . modelNewEpochState_es . modelEpochState_ss . modelSnapshots_pstake . snapshotQueue_go . modelSnapshot_pools)
   currentEpoch <- use $ modelLedger . to getModelLedger_epoch
-  EpochSize numSlots <- asks $ runIdentity . flip epochInfoSize currentEpoch . epochInfo . _modelGeneratorContext_globals
+  EpochSize numSlots <- asks $ runIdentity . flip epochInfoSize currentEpoch . epochInfoPure . _modelGeneratorContext_globals
   pools' <- Map.fromList . take (fromEnum numSlots) <$> shuffle (Map.toList pools)
 
   -- TODO: Model scenarios where pools make varying amounts of blocks (e.g. 0 or many)
@@ -125,8 +125,8 @@ genBlocksMade = do
 genModelEpoch :: HasGenModelM st era m => m (ModelEpoch era)
 genModelEpoch = do
   currentEpoch <- use $ modelLedger . to getModelLedger_epoch
-  EpochSize numSlots <- asks $ runIdentity . flip epochInfoSize currentEpoch . epochInfo . _modelGeneratorContext_globals
-  firstSlot <- asks $ runIdentity . flip epochInfoFirst currentEpoch . epochInfo . _modelGeneratorContext_globals
+  EpochSize numSlots <- asks $ runIdentity . flip epochInfoSize currentEpoch . epochInfoPure . _modelGeneratorContext_globals
+  firstSlot <- asks $ runIdentity . flip epochInfoFirst currentEpoch . epochInfoPure . _modelGeneratorContext_globals
 
   -- we don't have to put a block in every slot.
   numSlotsUsed <- liftGen =<< asks (_modelGeneratorParams_numSlotsUsed . _modelGeneratorContext_modelGeneratorParams)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Rules.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Rules.hs
@@ -50,7 +50,7 @@ where
 
 import Cardano.Ledger.BaseTypes
   ( Globals (..),
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Keys (KeyRole (..))
@@ -697,7 +697,7 @@ instance ModelSTS 'ModelRule_TICK where
   applyRuleImpl _ slot = RWS.execRWST $ do
     Identity epoch <-
       epochInfoEpoch
-        <$> asks (epochInfo . getGlobals)
+        <$> asks (epochInfoPure . getGlobals)
         <*> pure (getConst slot)
 
     lift $ setSlot epoch (getConst slot)
@@ -716,7 +716,7 @@ instance ModelSTS 'ModelRule_RUPD where
       State.get >>= \case
         Compose (Just _) -> pure ()
         Compose (Nothing) -> do
-          ei <- asks (epochInfo . getGlobals)
+          ei <- asks (epochInfoPure . getGlobals)
           rsw <- asks (randomnessStabilisationWindow . getGlobals)
           let e = runIdentity $ epochInfoEpoch ei s
           when (s > runIdentity (epochInfoFirst ei e) + (fromIntegral rsw)) $ do

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -55,7 +55,7 @@ import Cardano.Ledger.BaseTypes
     Seed,
     ShelleyBase,
     UnitInterval,
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Chain (ChainChecksPParams, pparamsToChainChecksPParams)
 import Cardano.Ledger.Core (ChainData, SerialisableData)
@@ -563,7 +563,7 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
     poolDistr = unPoolDistr $ nesPd ss
     STS.Tickn.TicknState epochNonce _ = csTickn cds
     currentEpoch = nesEL ss
-    ei = epochInfo globals
+    ei = epochInfoPure globals
     f = activeSlotCoeff globals
     epochSlots = Set.fromList [a .. b]
     (a, b) = runIdentity $ epochInfoRange ei currentEpoch

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -41,7 +41,7 @@ import Cardano.Ledger.BaseTypes
     UnitInterval,
     activeSlotCoeff,
     activeSlotVal,
-    epochInfo,
+    epochInfoPure,
   )
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys
@@ -268,7 +268,7 @@ overlayTransition =
 
         asc <- liftSTS $ asks activeSlotCoeff
         firstSlotNo <- liftSTS $ do
-          ei <- asks epochInfo
+          ei <- asks epochInfoPure
           e <- epochInfoEpoch ei slot
           epochInfoFirst ei e
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
@@ -61,7 +61,7 @@ instance
 updTransition :: Crypto crypto => TransitionRule (UPDN crypto)
 updTransition = do
   TRC (UpdnEnv eta, UpdnState eta_v eta_c, s) <- judgmentContext
-  ei <- liftSTS $ asks epochInfo
+  ei <- liftSTS $ asks epochInfoPure
   sp <- liftSTS $ asks stabilityWindow
   EpochNo e <- liftSTS $ epochInfoEpoch ei s
   let newEpochNo = EpochNo (e + 1)


### PR DESCRIPTION
The `EpochInfo` in `Globals` sits in `Either Text`, but we allow it to
be exposed in a pure `Identity` monad for cases where the information
solicited is guaranteed to be available. However, since this is the
"default" option, at some points it has been misused. As such, we make
three changes:

1. The names have been reversed: `epochInfo` will now give the `Either
   Text` version, whereas `epochInfoPure` will give the `Identity`
   version. The latter has some additional notes describing when it's
   valid to use these.
2. Not all places that previously used `epochInfo` are switched to
   `epochInfoPure`. In particular, we ensure that places that use time
   translation must use the full `EpochInfo (Either Text)`.
3. We rationalise the logic around `txInfo`. We now take the `EpochInfo
   (Either Text)` explicitly and fail inside the same `Left` case as all
   other failures.

Note that this is necessary to avoid `collectTwoPhaseScriptInputs` throwing a pure error, even when the earlier check has failed, since a failing check does not terminate processing and a pure error will be thrown anyway.