### PR TITLE
Add a constant to `babbageMinUTxOValue` computation

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -259,7 +259,23 @@ babbageMinUTxOValue ::
   Coin
 babbageMinUTxOValue pp sizedOut =
   Coin $
-    fromIntegral (sizedSize sizedOut) * unCoin (getField @"_coinsPerUTxOByte" pp)
+    fromIntegral (constantOverhead + sizedSize sizedOut) * unCoin (getField @"_coinsPerUTxOByte" pp)
+  where
+    -- This constant is an approximation of the memory overhead that comes
+    -- from TxIn and an entry in the Map data structure:
+    --
+    -- 160 = 20 words * 8bytes
+    --
+    -- This means that if:
+    --
+    --  * 'coinsPerUTxOByte' = 4311
+    --  * A simple TxOut with staking and payment credentials with ADA only
+    --    amount of 978597 lovelace
+    --
+    -- we get the size of TxOut to be 67 bytes and the minimum value will come
+    -- out to be 978597 lovelace. Also the absolute minimum value will be
+    -- 857889, because TxOut without staking address can't be less than 39 bytes
+    constantOverhead = 160
 
 -- > getValue txout ≥ inject ( serSize txout ∗ coinsPerUTxOByte pp )
 validateOutputTooSmallUTxO ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -111,14 +111,14 @@ plainAddr pf = Addr Testnet pCred sCred
 
 somePlainOutput :: Scriptic era => Proof era -> Core.TxOut era
 somePlainOutput pf =
-  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 1000)]
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 1140)]
 
 mkGenesisTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => Integer -> TxIn crypto
 mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
 
 collateralOutput :: Scriptic era => Proof era -> Core.TxOut era
 collateralOutput pf =
-  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 350)]
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 2115)]
 
 -- We intentionally use a ByteString with length greater than 64 to serve as
 -- as reminder that our protection against contiguous data over 64 Bytes on
@@ -236,7 +236,7 @@ referenceScriptInput3 = mkGenesisTxIn 18
 initUTxO :: PostShelley era => Proof era -> UTxO era
 initUTxO pf =
   UTxO $
-    Map.fromList $
+    Map.fromList
       [ (inlineDatumInput, inlineDatumOutput pf),
         (referenceScriptInput, referenceScriptOutput pf),
         (referenceDataHashInput, referenceDataHashOutput pf),
@@ -258,7 +258,7 @@ defaultPPs =
     MaxBlockExUnits $ ExUnits 1000000 1000000,
     ProtocolVersion $ ProtVer 7 0,
     CollateralPercentage 1,
-    AdaPerUTxOWord (Coin 5)
+    AdaPerUTxOByte (Coin 5)
   ]
 
 pp :: Proof era -> Core.PParams era
@@ -448,7 +448,7 @@ utxoStEx4 pf = smartUTxOState (utxoEx4 pf) (Coin 0) (Coin 5) def
 -- ====================================================================================
 
 outEx5 :: Scriptic era => Proof era -> Core.TxOut era
-outEx5 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 995)]
+outEx5 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 1135)]
 
 refInputWithDataHashNoWitTxBody :: Scriptic era => Proof era -> Core.TxBody era
 refInputWithDataHashNoWitTxBody pf =
@@ -534,7 +534,7 @@ utxoStEx6 pf = smartUTxOState (utxoEx6 pf) (Coin 0) (Coin 5) def
 -- ====================================================================================
 
 outEx7 :: Scriptic era => Proof era -> Core.TxOut era
-outEx7 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 995)]
+outEx7 pf = newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 1135)]
 
 redeemersEx7 :: Era era => Redeemers era
 redeemersEx7 =
@@ -589,7 +589,7 @@ utxoStEx7 pf = smartUTxOState (utxoEx7 pf) (Coin 0) (Coin 5) def
 
 collateralReturn :: Era era => Proof era -> Core.TxOut era
 collateralReturn pf =
-  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 345)]
+  newTxOut pf [Address $ plainAddr pf, Amount (inject $ Coin 2110)]
 
 collateralOutputTxBody :: Scriptic era => Proof era -> Core.TxBody era
 collateralOutputTxBody pf =
@@ -830,7 +830,7 @@ largeOutput pf =
   newTxOut
     pf
     [ Address (plainAddr pf),
-      Amount (inject $ Coin 995),
+      Amount (inject $ Coin 1135),
       Datum . Babbage.Datum . dataToBinaryData $ largeDatum @era
     ]
 
@@ -867,11 +867,12 @@ testU ::
   forall era.
   ( GoodCrypto (Crypto era),
     Default (State (EraRule "PPUP" era)),
-    PostShelley era
+    PostShelley era,
+    HasCallStack
   ) =>
   Proof era ->
   Core.Tx era ->
-  Either [(PredicateFailure (Core.EraRule "UTXOW" era))] (State (Core.EraRule "UTXOW" era)) ->
+  Either [PredicateFailure (Core.EraRule "UTXOW" era)] (State (Core.EraRule "UTXOW" era)) ->
   Assertion
 testU pf tx expect = testUTXOW (UTXOW pf) (initUTxO pf) (pp pf) tx expect
 
@@ -971,7 +972,7 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ largeOutputTx pf)
-              (Left [fromUtxoB @era $ BabbageOutputTooSmallUTxO [(largeOutput pf, Coin 8115)]])
+              (Left [fromUtxoB @era $ BabbageOutputTooSmallUTxO [(largeOutput pf, Coin 8915)]])
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -1903,7 +1903,8 @@ genericCont ::
     PrettyA x,
     Eq y,
     Show y,
-    PrettyA y
+    PrettyA y,
+    HasCallStack
   ) =>
   Either [x] y ->
   Either [x] y ->
@@ -1967,13 +1968,14 @@ testUTXOWsubset,
     forall era.
     ( GoodCrypto (Crypto era),
       Default (State (EraRule "PPUP" era)),
-      PostShelley era
+      PostShelley era,
+      HasCallStack
     ) =>
     WitRule "UTXOW" era ->
     UTxO era ->
     Core.PParams era ->
     Core.Tx era ->
-    Either [(PredicateFailure (Core.EraRule "UTXOW" era))] (State (Core.EraRule "UTXOW" era)) ->
+    Either [PredicateFailure (Core.EraRule "UTXOW" era)] (State (Core.EraRule "UTXOW" era)) ->
     Assertion
 
 -- | Use an equality test on the expected and computed [PredicateFailure]
@@ -1990,11 +1992,12 @@ testU ::
   forall era.
   ( GoodCrypto (Crypto era),
     Default (State (EraRule "PPUP" era)),
-    PostShelley era
+    PostShelley era,
+    HasCallStack
   ) =>
   Proof era ->
   Core.Tx era ->
-  Either [(PredicateFailure (Core.EraRule "UTXOW" era))] (State (Core.EraRule "UTXOW" era)) ->
+  Either [PredicateFailure (Core.EraRule "UTXOW" era)] (State (Core.EraRule "UTXOW" era)) ->
   Assertion
 testU pf tx expect = testUTXOW (UTXOW pf) (initUTxO pf) (pp pf) tx expect
 
@@ -2022,7 +2025,8 @@ specialCont ::
   ( Eq (PredicateFailure (EraRule "UTXOW" era)),
     Eq a,
     Show (PredicateFailure (EraRule "UTXOW" era)),
-    Show a
+    Show a,
+    HasCallStack
   ) =>
   Proof era ->
   Either [PredicateFailure (EraRule "UTXOW" era)] a ->
@@ -2366,8 +2370,7 @@ instance AlonzoBased (BabbageEra c) (BabbageUtxoPred (BabbageEra c)) where
 -- ===================================================================
 
 testBBODY ::
-  ( GoodCrypto (Crypto era)
-  ) =>
+  (GoodCrypto (Crypto era), HasCallStack) =>
   WitRule "BBODY" era ->
   BbodyState era ->
   Block (BHeaderView (Crypto era)) era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -174,53 +174,55 @@ pattern RefScript' :: [Core.Script era] -> TxOutField era -- 0 or 1 element
 
 -- ==================
 data PParamsField era
-  = MinfeeA (Natural)
+  = MinfeeA Natural
   | -- | The constant factor for the minimum fee calculation
-    MinfeeB (Natural)
+    MinfeeB Natural
   | -- | Maximal block body size
-    MaxBBSize (Natural)
+    MaxBBSize Natural
   | -- | Maximal transaction size
-    MaxTxSize (Natural)
+    MaxTxSize Natural
   | -- | Maximal block header size
-    MaxBHSize (Natural)
+    MaxBHSize Natural
   | -- | The amount of a key registration deposit
-    KeyDeposit (Coin)
+    KeyDeposit Coin
   | -- | The amount of a pool registration deposit
-    PoolDeposit (Coin)
+    PoolDeposit Coin
   | -- | epoch bound on pool retirement
-    EMax (EpochNo)
+    EMax EpochNo
   | -- | Desired number of pools
-    NOpt (Natural)
+    NOpt Natural
   | -- | Pool influence
-    A0 (NonNegativeInterval)
+    A0 NonNegativeInterval
   | -- | Monetary expansion
-    Rho (UnitInterval)
+    Rho UnitInterval
   | -- | Treasury expansion
-    Tau (UnitInterval)
+    Tau UnitInterval
   | -- | Decentralization parameter
-    D (UnitInterval) -- Dropped in Babbage
+    D UnitInterval -- Dropped in Babbage
   | -- | Extra entropy
-    ExtraEntropy (Nonce) -- Dropped in Babbage
+    ExtraEntropy Nonce -- Dropped in Babbage
   | -- | Protocol version
-    ProtocolVersion (ProtVer)
+    ProtocolVersion ProtVer
   | -- | Minimum Stake Pool Cost
-    MinPoolCost (Coin)
-  | -- | Minimum Lovelace in a UTxO (deprecated by AdaPerUTxOWord)
-    MinUTxOValue (Coin)
-  | -- | Cost in ada per byte of UTxO storage (instead of _minUTxOValue)
-    AdaPerUTxOWord (Coin)
+    MinPoolCost Coin
+  | -- | Minimum Lovelace in a UTxO deprecated by AdaPerUTxOWord
+    MinUTxOValue Coin
+  | -- | Cost in ada per 8 bytes of UTxO storage instead of _minUTxOValue
+    AdaPerUTxOWord Coin -- Dropped in Babbage
+  | -- | Cost in ada per 1 byte of UTxO storage instead of _coinsPerUTxOWord
+    AdaPerUTxOByte Coin -- New in Babbage
   | -- | Cost models for non-native script languages
-    Costmdls (CostModels)
-  | -- | Prices of execution units (for non-native script languages)
-    Prices (Prices)
+    Costmdls CostModels
+  | -- | Prices of execution units for non-native script languages
+    Prices Prices
   | -- | Max total script execution resources units allowed per tx
-    MaxTxExUnits (ExUnits)
+    MaxTxExUnits ExUnits
   | -- | Max total script execution resources units allowed per block
-    MaxBlockExUnits (ExUnits)
+    MaxBlockExUnits ExUnits
   | -- | Max size of a Value in an output
-    MaxValSize (Natural)
+    MaxValSize Natural
   | -- | The scaling percentage of the collateral relative to the fee
-    CollateralPercentage (Natural)
+    CollateralPercentage Natural
   | -- | Maximum number of collateral inputs allowed in a transaction
     MaxCollateralInputs Natural
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxDats (..), TxWitness (
 import qualified Cardano.Ledger.Babbage.PParams as Babbage (PParams' (..))
 import qualified Cardano.Ledger.Babbage.Tx as Babbage (ValidatedTx (..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage (Datum (..), TxBody (..), TxOut (..))
+import Cardano.Ledger.Coin (Coin (Coin, unCoin))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Hashes (ScriptHash)
@@ -34,6 +35,7 @@ import qualified Cardano.Ledger.Shelley.Tx as Shelley (Tx (..))
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley (TxBody (..), TxOut (..))
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA (TxBody (..))
+import Cardano.Ledger.Val ((<×>))
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -314,6 +316,7 @@ updateShelleyPP pp dpp = case dpp of
   (MinUTxOValue mu) -> pp {Shelley._minUTxOValue = mu}
   -- Not present in Shelley
   (AdaPerUTxOWord _) -> pp
+  (AdaPerUTxOByte _) -> pp
   (Costmdls _) -> pp
   (Prices _) -> pp
   (MaxTxExUnits _) -> pp
@@ -352,6 +355,7 @@ updatePParams (Alonzo _) pp dpp = case dpp of
   CollateralPercentage perc -> pp {Alonzo._collateralPercentage = perc}
   MaxCollateralInputs n -> pp {Alonzo._maxCollateralInputs = n}
   AdaPerUTxOWord n -> pp {Alonzo._coinsPerUTxOWord = n}
+  AdaPerUTxOByte n -> pp {Alonzo._coinsPerUTxOWord = (8 :: Int) <×> n}
   -- Not used in Alonzo
   MinUTxOValue _ -> pp
 updatePParams (Babbage _) pp dpp = case dpp of
@@ -376,7 +380,8 @@ updatePParams (Babbage _) pp dpp = case dpp of
   MaxBlockExUnits n -> pp {Babbage._maxBlockExUnits = n}
   CollateralPercentage perc -> pp {Babbage._collateralPercentage = perc}
   MaxCollateralInputs n -> pp {Babbage._maxCollateralInputs = n}
-  AdaPerUTxOWord n -> pp {Babbage._coinsPerUTxOByte = n} -- TODO rename AdaPerUTxOWord
+  AdaPerUTxOWord n -> pp {Babbage._coinsPerUTxOByte = Coin $ (unCoin n + 7) `div` 8}
+  AdaPerUTxOByte n -> pp {Babbage._coinsPerUTxOByte = n}
   -- Not used in Babbage
   D _ -> pp
   ExtraEntropy _ -> pp


### PR DESCRIPTION
When using TxOut serialization size for minUTxO value, we did not account for the overhead that comes from TxIn and Map data structure that is used for keeping TxOut in memeory.

This PR fixes this problem by adding a constant of 160 bytes. See comment in the PR for more info.