### PR TITLE
Alonzo tools cleanup

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -6,7 +6,6 @@
 
 module Cardano.Ledger.Alonzo.Tools
   ( evaluateTransactionExecutionUnits,
-    BasicFailure (..),
     ScriptFailure (..),
   )
 where
@@ -52,14 +51,6 @@ import GHC.Records (HasField (..))
 import qualified Plutus.V1.Ledger.Api as PV1
 import qualified Plutus.V2.Ledger.Api as PV2
 
--- | Basic validtion failures that can be returned by 'evaluateTransactionExecutionUnits'.
-data BasicFailure c
-  = -- | The transaction contains inputs that are not present in the UTxO.
-    UnknownTxIns (Set (TxIn c))
-  | -- | The transaction context translation failed
-    BadTranslation TranslationError
-  deriving (Show)
-
 -- | Script failures that can be returned by 'evaluateTransactionExecutionUnits'.
 data ScriptFailure c
   = -- | A redeemer was supplied that does not point to a
@@ -89,25 +80,6 @@ data ScriptFailure c
 note :: e -> Maybe a -> Either e a
 note _ (Just x) = Right x
 note e Nothing = Left e
-
-basicValidation ::
-  ( HasField "body" (Core.Tx era) (Core.TxBody era),
-    HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era)))
-  ) =>
-  -- | The transaction.
-  Core.Tx era ->
-  -- | The current UTxO set (or the relevant portion for the transaction).
-  UTxO era ->
-  -- | Basic failures.
-  Maybe (BasicFailure (Crypto era))
-basicValidation tx utxo =
-  if Set.null badIns
-    then Nothing
-    else Just (UnknownTxIns badIns)
-  where
-    txb = getField @"body" tx
-    ins = getField @"inputs" txb
-    badIns = Set.filter (`Map.notMember` unUTxO utxo) ins
 
 type RedeemerReport c = Map RdmrPtr (Either (ScriptFailure c) ExUnits)
 
@@ -148,25 +120,19 @@ evaluateTransactionExecutionUnits ::
   SystemStart ->
   -- | The array of cost models, indexed by the supported languages.
   Array Language CostModel ->
-  -- | If the transaction meets basic validation, we return a map from
-  --  redeemer pointers to either a failure or a sufficient execution budget.
-  --  Otherwise we return a basic validation error.
-  --  The value is monadic, depending on the epoch info.
-  Either (BasicFailure (Crypto era)) (RedeemerReport (Crypto era))
-evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
-  case basicValidation tx utxo of
-    Nothing ->
-      let getInfo :: Language -> Either TranslationError (Language, VersionedTxInfo)
-          getInfo lang = (,) lang <$> txInfo pp lang ei sysS utxo tx
-          txInfos = map getInfo (Set.toList $ languagesUsed (Map.elems scripts))
-       in case sequence txInfos of
-            Left transEr -> Left $ BadTranslation transEr
-            Right ctx ->
-              Right $
-                Map.mapWithKey
-                  (findAndCount pp (array (PlutusV1, PlutusV2) ctx))
-                  (unRedeemers $ getField @"txrdmrs" ws)
-    Just e -> Left e
+  -- | We return a map from redeemer pointers to either a failure or a
+  --  sufficient execution budget.
+  --  Otherwise, we return a 'TranslationError' manifesting from failed attempts
+  --  to construct a valid execution context for the given transaction.
+  Either TranslationError (RedeemerReport (Crypto era))
+evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels =
+  let getInfo :: Language -> Either TranslationError (Language, VersionedTxInfo)
+      getInfo lang = (,) lang <$> txInfo pp lang ei sysS utxo tx
+   in do
+      ctx <- sequence $ map getInfo (Set.toList $ languagesUsed (Map.elems scripts))
+      pure $ Map.mapWithKey
+        (findAndCount pp (array (PlutusV1, PlutusV2) ctx))
+        (unRedeemers $ getField @"txrdmrs" ws)
   where
     txb = getField @"body" tx
     ws = getField @"wits" tx

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -84,8 +84,6 @@ data ScriptFailure c
     IncompatibleBudget PV1.ExBudget
   | -- | There was no cost model for a given version of Plutus
     NoCostModel Language
-  | -- | There was a corruptp cost model for a given version of Plutus
-    CorruptCostModel Language
   deriving (Show)
 
 note :: e -> Maybe a -> Either e a

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -13,7 +13,7 @@ import qualified Cardano.Crypto.Hash as Crypto
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo.PParams
 import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), Script)
-import Cardano.Ledger.Alonzo.Tools (BasicFailure (..), ScriptFailure, evaluateTransactionExecutionUnits)
+import Cardano.Ledger.Alonzo.Tools (ScriptFailure, evaluateTransactionExecutionUnits)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Babbage.PParams as Babbage.PParams
@@ -203,9 +203,7 @@ exampleInvalidExUnitCalc proof =
     exampleEpochInfo
     testSystemStart
     costmodels of
-    Left (UnknownTxIns _) -> pure ()
-    Left (BadTranslation _) ->
-      assertFailure "evaluateTransactionExecutionUnits should not fail from BadTranslation"
+    Left{} -> assertFailure "evaluateTransactionExecutionUnits should not fail from TranslationError"
     Right _ -> assertFailure "evaluateTransactionExecutionUnits should have failed"
 
 exampleTx ::


### PR DESCRIPTION
- :round_pushpin: **Remove unused 'CorruptCostModel' constructor.**
  
- :round_pushpin: **Remove 'BasicFailure', made redundant by TranslationError/TranslationLogicErrorInput**
    The 'BasicFailure' was initially introduced as an extra sanity check to make
  sure that inputs referenced in the transaction were also present in the
  provided UTxO.

  Now however, this is done regardless in the `txInfoIn` function which is used
  to construct the 'PV1.TxInInfo' for both Alonzo & Babbage transactions:

  ```hs
  case Map.lookup txin mp of
    Nothing -> Left TranslationLogicErrorInput
    Just txout -> case transTxOutAddr txout of
  ```

  Thus, the `TranslationLogicErrorInput` branch from `TranslationError` makes
  the `UnknownInputs` branch redundant, and consequently, `BasicFailure`
  redundant completely. To be 100% equivalent, `TranslationLogicErrorInput`
  should be modified to also contain the missing inputs. I didn't do to that
  extend here because `TranslationError` seems to be use as a kind of _enum_,
  with only 0-ary constructors.
