### PR TITLE
rename UnequalCollateralReturn

### DIFF
--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -214,6 +214,6 @@ instance Mock c => Arbitrary (BabbageUtxoPred (BabbageEra c)) where
     oneof
       [ FromAlonzoUtxoFail <$> arbitrary,
         FromAlonzoUtxowFail <$> arbitrary,
-        UnequalCollateralReturn <$> arbitrary <*> arbitrary,
+        IncorrectTotalCollateralField <$> arbitrary <*> arbitrary,
         MalformedScripts <$> arbitrary
       ]

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -139,10 +139,10 @@ ppBabbageUtxoPred ::
   PDoc
 ppBabbageUtxoPred (FromAlonzoUtxoFail x) = prettyA x
 ppBabbageUtxoPred (FromAlonzoUtxowFail x) = prettyA x
-ppBabbageUtxoPred (UnequalCollateralReturn c1 c2) =
+ppBabbageUtxoPred (IncorrectTotalCollateralField c1 c2) =
   ppRecord
-    "UnequalCollateralReturn"
-    [("collateral needed", ppCoin c1), ("collateral returned", ppCoin c2)]
+    "IncorrectTotalCollateralField"
+    [("collateral provided", ppCoin c1), ("collateral declared", ppCoin c2)]
 ppBabbageUtxoPred (MalformedScripts scripts) =
   ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
 ppBabbageUtxoPred (BabbageOutputTooSmallUTxO xs) =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -934,7 +934,7 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ incorrectCollateralTotalTx pf)
-              (Left [fromUtxoB @era (UnequalCollateralReturn (Coin 5) (Coin 6))]),
+              (Left [fromUtxoB @era (IncorrectTotalCollateralField (Coin 5) (Coin 6))]),
           testCase "malformed scripts" $
             testU
               pf


### PR DESCRIPTION
The babbage era predicate failure `UnequalCollateralReturn` has a misleading name, and has been renamed to `IncorrectTotalCollateralField`.

The failure happens when the declared collateral amount listed in the transaction body does not match the actual collateral provided.
 
closes #2828