### PR TITLE
check that created ref scripts are well-formed

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -111,8 +111,11 @@ data BabbageUtxoPred era
       -- ^ collateral provided
       !Coin
       -- ^ collateral amount declared in transaction body
-  | -- | the set of malformed scripts
-    MalformedScripts
+  | -- | the set of malformed script witnesses
+    MalformedScriptWitnesses
+      !(Set (ScriptHash (Crypto era)))
+  | -- | the set of malformed script witnesses
+    MalformedReferenceScripts
       !(Set (ScriptHash (Crypto era)))
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
@@ -490,8 +493,9 @@ instance
       work (FromAlonzoUtxoFail x) = Sum FromAlonzoUtxoFail 1 !> To x
       work (FromAlonzoUtxowFail x) = Sum FromAlonzoUtxowFail 2 !> To x
       work (IncorrectTotalCollateralField c1 c2) = Sum IncorrectTotalCollateralField 3 !> To c1 !> To c2
-      work (MalformedScripts x) = Sum MalformedScripts 4 !> To x
-      work (BabbageOutputTooSmallUTxO x) = Sum BabbageOutputTooSmallUTxO 5 !> To x
+      work (MalformedScriptWitnesses x) = Sum MalformedScriptWitnesses 4 !> To x
+      work (MalformedReferenceScripts x) = Sum MalformedReferenceScripts 5 !> To x
+      work (BabbageOutputTooSmallUTxO x) = Sum BabbageOutputTooSmallUTxO 6 !> To x
 
 instance
   ( Era era,
@@ -510,8 +514,9 @@ instance
       work 1 = SumD FromAlonzoUtxoFail <! From
       work 2 = SumD FromAlonzoUtxowFail <! From
       work 3 = SumD IncorrectTotalCollateralField <! From <! From
-      work 4 = SumD MalformedScripts <! From
-      work 5 = SumD BabbageOutputTooSmallUTxO <! From
+      work 4 = SumD MalformedScriptWitnesses <! From
+      work 5 = SumD MalformedReferenceScripts <! From
+      work 6 = SumD BabbageOutputTooSmallUTxO <! From
       work n = Invalid n
 
 deriving via InspectHeapNamed "BabbageUtxoPred" (BabbageUtxoPred era) instance NoThunks (BabbageUtxoPred era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -64,6 +64,7 @@ module Cardano.Ledger.Babbage.TxBody
     ScriptIntegrityHash,
     txOutData,
     txOutDataHash,
+    txOutScript,
   )
 where
 

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -215,5 +215,6 @@ instance Mock c => Arbitrary (BabbageUtxoPred (BabbageEra c)) where
       [ FromAlonzoUtxoFail <$> arbitrary,
         FromAlonzoUtxowFail <$> arbitrary,
         IncorrectTotalCollateralField <$> arbitrary <*> arbitrary,
-        MalformedScripts <$> arbitrary
+        MalformedScriptWitnesses <$> arbitrary,
+        MalformedReferenceScripts <$> arbitrary
       ]

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -143,8 +143,10 @@ ppBabbageUtxoPred (IncorrectTotalCollateralField c1 c2) =
   ppRecord
     "IncorrectTotalCollateralField"
     [("collateral provided", ppCoin c1), ("collateral declared", ppCoin c2)]
-ppBabbageUtxoPred (MalformedScripts scripts) =
-  ppSexp "MalformedScripts" [ppSet ppScriptHash scripts]
+ppBabbageUtxoPred (MalformedScriptWitnesses scripts) =
+  ppSexp "MalformedScriptWitnesses" [ppSet ppScriptHash scripts]
+ppBabbageUtxoPred (MalformedReferenceScripts scripts) =
+  ppSexp "MalformedReferenceScripts" [ppSet ppScriptHash scripts]
 ppBabbageUtxoPred (BabbageOutputTooSmallUTxO xs) =
   ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair prettyA ppCoin) xs]
 


### PR DESCRIPTION
We now check that reference scripts are well-formed upon creation, and no longer check that a reference script is well-formed upon use.

I've split the predicate failure `MalformedScripts` into two failures: `MalformedScriptWitnesses` and `MalformedReferenceScripts`, depending on if a malformed script is a script witness or a newly created reference script.

I updated the old malformed script unit test into two tests, one for each of the cases above. I ran into one surprise, namely that the malformed script witness fails phase 1 validation (as expected) but is still run in phase 2. I left a `TODO` in the test to address this (and I made this issue: #2838).

closes #2834