### PR TITLE
Ensure Plutus scripts are not executed when other failures already exist

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -217,15 +217,14 @@ scriptsNotValidateTransition = do
 
   case collectTwoPhaseScriptInputs (unsafeLinearExtendEpochInfo slot ei) sysSt pp tx utxo of
     Right sLst ->
-      whenFailureFree $
-        when2Phase $
-          case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
-            Passes _ps ->
-              failBecause $
-                ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
-            Fails ps fs -> do
-              tellEvent (SuccessfulPlutusScriptsEvent ps)
-              tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
+      when2Phase $
+        case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
+          Passes _ps ->
+            failBecause $
+              ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
+          Fails ps fs -> do
+            tellEvent (SuccessfulPlutusScriptsEvent ps)
+            tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
     Left info -> failBecause (CollectErrors info)
 
   let !_ = traceEvent invalidEnd ()

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -204,11 +204,12 @@ scriptsNo = do
     Right sLst ->
       {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
       {- isValid tx = evalScripts tx sLst = False -}
-      when2Phase $ case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
-        Passes _ -> failBecause $ ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
-        Fails ps fs -> do
-          tellEvent (SuccessfulPlutusScriptsEvent ps)
-          tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
+      whenFailureFree $
+        when2Phase $ case evalScripts @era (getField @"_protocolVersion" pp) tx sLst of
+          Passes _ -> failBecause $ ValidationTagMismatch (getField @"isValid" tx) PassedUnexpectedly
+          Fails ps fs -> do
+            tellEvent (SuccessfulPlutusScriptsEvent ps)
+            tellEvent (FailedPlutusScriptsEvent (scriptFailuresToPlutusDebug fs))
     Left info -> failBecause (CollectErrors info)
 
   () <- pure $! traceEvent invalidEnd ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -68,7 +68,6 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
     freeCostModelV2,
     keyBy,
     testUTXOW,
-    testUTXOWsubset,
     trustMeP,
   )
 import Test.Cardano.Ledger.Generic.Fields
@@ -1076,13 +1075,8 @@ genericBabbageFeatures pf =
               (trustMeP pf True $ malformedScriptRefTx pf)
               (Left [fromUtxowB @era (MalformedReferenceScripts (Set.fromList [hashScript @era $ malformedScript pf "rs"]))]),
           testCase "malformed script witness" $
-            -- TODO replace testUTXOWsubset with testU and figure out why a script which is failing phase 1 validation
-            -- is still being run, ie why are we getting this error as well:
-            -- FromAlonzoUtxoFail (UtxosFailure (ValidationTagMismatch (IsValid True) (FailedUnexpectedly (PlutusFailure ...
-            testUTXOWsubset
-              (UTXOW pf)
-              (initUTxO pf)
-              (pp pf)
+            testU
+              pf
               (trustMeP pf True $ malformedScriptWitTx pf)
               (Left [fromUtxowB @era (MalformedScriptWitnesses (Set.fromList [hashScript @era $ malformedScript pf "malfoy"]))]),
           testCase "inline datum and ref script and redundant script witness" $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -1073,12 +1073,23 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ malformedScriptRefTx pf)
-              (Left [fromUtxowB @era (MalformedReferenceScripts (Set.fromList [hashScript @era $ malformedScript pf "rs"]))]),
+              ( Left
+                  [ fromUtxowB @era $
+                      MalformedReferenceScripts $
+                        Set.singleton
+                          (hashScript @era $ malformedScript pf "rs")
+                  ]
+              ),
           testCase "malformed script witness" $
             testU
               pf
               (trustMeP pf True $ malformedScriptWitTx pf)
-              (Left [fromUtxowB @era (MalformedScriptWitnesses (Set.fromList [hashScript @era $ malformedScript pf "malfoy"]))]),
+              ( Left
+                  [ fromUtxowB @era $
+                      MalformedScriptWitnesses $
+                        Set.singleton (hashScript @era $ malformedScript pf "malfoy")
+                  ]
+              ),
           testCase "inline datum and ref script and redundant script witness" $
             testU
               pf


### PR DESCRIPTION
Fixes #2838 

Expectation was that #2679 has fixed this issue, however there was a tricky oversight that did not fix it for nested rules, but only for the immediate ones. In other words if UTXOS rule `whenFailureFree` it will only react to predicate failure produced by that rule alone and not the one that invoked it, i.e. the UTXO rule. This PR fixes that oversight and fixes the test that discovered this issue.

It also enables this conditional execution for Babbage UTXOS rule only and not in the Alonzo, since this fix does not affect node syncing.