### PR TITLE
Improve translation errors

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -21,7 +21,7 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..))
+import Cardano.Ledger.Alonzo.Data (AuxiliaryData (..), Datum (..))
 import Cardano.Ledger.Alonzo.Genesis
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams
@@ -241,6 +241,10 @@ instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
           SJust dh <- [getField @"datahash" out]
       ]
   getDatum = getDatumAlonzo
+  getTxOutDatum txOut =
+    case getField @"datahash" txOut of
+      SNothing -> NoDatum
+      SJust dh -> DatumHash dh
   allOuts txbody = toList $ getField @"outputs" txbody
   allSizedOuts = map mkSized . allOuts
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -114,7 +114,7 @@ data CollectError crypto
   = NoRedeemer !(ScriptPurpose crypto)
   | NoWitness !(ScriptHash crypto)
   | NoCostModel !Language
-  | BadTranslation !TranslationError
+  | BadTranslation !(TranslationError crypto)
   deriving (Eq, Show, Generic, NoThunks)
 
 instance (CC.Crypto crypto) => ToCBOR (CollectError crypto) where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -126,12 +126,12 @@ evaluateTransactionExecutionUnits ::
   --  sufficient execution budget.
   --  Otherwise, we return a 'TranslationError' manifesting from failed attempts
   --  to construct a valid execution context for the given transaction.
-  Either TranslationError (RedeemerReport (Crypto era))
+  Either (TranslationError (Crypto era)) (RedeemerReport (Crypto era))
 evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels =
-  let getInfo :: Language -> Either TranslationError (Language, VersionedTxInfo)
+  let getInfo :: Language -> Either (TranslationError (Crypto era)) (Language, VersionedTxInfo)
       getInfo lang = (,) lang <$> txInfo pp lang ei sysS utxo tx
    in do
-      ctx <- sequence $ map getInfo (Set.toList $ languagesUsed (Map.elems scripts))
+      ctx <- mapM getInfo (Set.toList $ languagesUsed (Map.elems scripts))
       pure $ Map.mapWithKey
         (findAndCount pp (array (PlutusV1, PlutusV2) ctx))
         (unRedeemers $ getField @"txrdmrs" ws)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -86,8 +86,6 @@ data ScriptFailure c
     IncompatibleBudget PV1.ExBudget
   | -- | There was no cost model for a given version of Plutus
     NoCostModel Language
-  | -- | There was a corruptp cost model for a given version of Plutus
-    CorruptCostModel Language
   deriving (Show)
 
 note :: e -> Maybe a -> Either e a

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -77,7 +77,7 @@ data ScriptFailure c
     IncompatibleBudget PV1.ExBudget
   | -- | There was no cost model for a given version of Plutus
     NoCostModel Language
-  deriving (Show)
+  deriving (Show, Eq)
 
 note :: e -> Maybe a -> Either e a
 note _ (Just x) = Right x

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Alonzo.Scripts
   )
 import Cardano.Ledger.Alonzo.Tx (DataHash, ScriptPurpose (..), rdptr)
 import Cardano.Ledger.Alonzo.TxInfo
-  ( ExtendedUTxO (txscripts, getTxOutDatum),
+  ( ExtendedUTxO (getTxOutDatum, txscripts),
     TranslationError,
     VersionedTxInfo (..),
     exBudgetToExUnits,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -77,7 +77,7 @@ import Cardano.Binary
   )
 import Cardano.Crypto.Hash
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Alonzo.Data (AuxiliaryDataHash (..), Data, DataHash)
+import Cardano.Ledger.Alonzo.Data (AuxiliaryDataHash (..), DataHash)
 import Cardano.Ledger.Alonzo.Scripts (Script)
 import Cardano.Ledger.BaseTypes
   ( Network (..),
@@ -919,16 +919,5 @@ addressErrorMsg :: String
 addressErrorMsg = "Impossible: Compacted an address of non-standard size"
 {-# NOINLINE addressErrorMsg #-}
 
-instance HasField "datum" (TxOut era) (StrictMaybe (Data era)) where
-  getField _ = SNothing
-
 instance HasField "referenceScript" (TxOut era) (StrictMaybe (Script era)) where
   getField _ = SNothing
-
-
-
--- instance
---   (Era era, c ~ Crypto era) =>
---   HasField "datum" (TxOut era) (StrictMaybe (Either (Data era) (DataHash c)))
---   where
---   getField _ = fmap Right . getField @"datahash"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -924,3 +924,11 @@ instance HasField "datum" (TxOut era) (StrictMaybe (Data era)) where
 
 instance HasField "referenceScript" (TxOut era) (StrictMaybe (Script era)) where
   getField _ = SNothing
+
+
+
+-- instance
+--   (Era era, c ~ Crypto era) =>
+--   HasField "datum" (TxOut era) (StrictMaybe (Either (Data era) (DataHash c)))
+--   where
+--   getField _ = fmap Right . getField @"datahash"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -472,7 +472,7 @@ alonzoTxInfo pp lang ei sysS utxo tx = do
         case Map.lookup txIn (unUTxO utxo) of
           Nothing -> Left $ TranslationLogicMissingInput txIn
           Just txOut -> Right (txIn, txOut)
-  txOuts <- mapM lookupTxOut (Set.toList(getField @"inputs" tbody))
+  txOuts <- mapM lookupTxOut (Set.toList (getField @"inputs" tbody))
   case lang of
     PlutusV1 ->
       Right . TxInfoPV1 $

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -96,7 +96,7 @@ silentlyIgnore tx =
   where
     ctx = txInfo def PlutusV1 ei ss utxo tx
 
-expectTranslationError :: Language -> ValidatedTx A -> TranslationError -> Assertion
+expectTranslationError :: Language -> ValidatedTx A -> TranslationError StandardCrypto -> Assertion
 expectTranslationError lang tx expected =
   case ctx of
     Right _ -> error "This translation was expected to fail, but it succeeded."
@@ -123,6 +123,6 @@ txInfoTests =
             expectTranslationError
               PlutusV2
               (txEx shelleyInput shelleyOutput)
-              LanguageNotSupported
+              (LanguageNotSupported PlutusV2)
         ]
     ]

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -54,11 +54,6 @@ byronInput = mkTxInPartial genesisId 0
 shelleyInput :: TxIn StandardCrypto
 shelleyInput = mkTxInPartial genesisId 1
 
--- This input is only unknown in the sense
--- that it is not present in the UTxO created below.
-unknownInput :: TxIn StandardCrypto
-unknownInput = mkTxInPartial genesisId 2
-
 byronOutput :: TxOut A
 byronOutput = TxOut byronAddr (Val.inject $ Coin 1) SNothing
 
@@ -113,9 +108,7 @@ txInfoTests =
         [ testCase "silently ignore byron txout" $
             silentlyIgnore (txEx shelleyInput byronOutput),
           testCase "silently ignore byron txin" $
-            silentlyIgnore (txEx byronInput shelleyOutput),
-          testCase "silently ignore unknown txin (logic error)" $
-            silentlyIgnore (txEx unknownInput shelleyOutput)
+            silentlyIgnore (txEx byronInput shelleyOutput)
         ],
       testGroup
         "Plutus V2"

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -240,6 +240,7 @@ instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
       referencedOuts = Map.elems $ Map.restrictKeys utxo (getField @"referenceInputs" txbody)
       outs = newOuts <> referencedOuts
   getDatum = getDatumBabbage
+  getTxOutDatum (TxOut _ _ datum _) = datum
   allSizedOuts txbody = toList (getField @"sizedOutputs" txbody) <> collOuts
     where
       collOuts = case getField @"sizedCollateralReturn" txbody of

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -82,13 +82,6 @@ data TxIn crypto = TxIn !(TxId crypto) {-# UNPACK #-} !TxIx
 mkTxInPartial :: HW.HasCallStack => TxId crypto -> Integer -> TxIn crypto
 mkTxInPartial txId = TxIn txId . mkTxIxPartial
 
--- This instance might be useful again if we can get Map to perform well.
--- instance CC.Crypto crypto => Split (TxIn crypto) where
---   splitKey (TxIn txId txIx) = (txIxToInt txIx, toKey txId)
---   joinKey txIx key =
---     -- `fromIntegral` is safe here, since we have only valid values in the Map:
---     TxIn (fromKey key) (TxIx (fromIntegral txIx))
-
 deriving instance Eq (TxIn crypto)
 
 deriving instance Ord (TxIn crypto)

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -117,7 +117,6 @@ library
     genvalidity-scientific,
     groups,
     hkd,
-    iproute,
     lens,
     monad-supply,
     mtl,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
@@ -17,11 +16,7 @@ import Cardano.Ledger.Alonzo.Tools (ScriptFailure, evaluateTransactionExecutionU
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Babbage.PParams as Babbage.PParams
-import Cardano.Ledger.Babbage.Tx
-  ( Data,
-    DataHash,
-  )
-import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase, StrictMaybe)
+import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase)
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Ledger.Crypto
@@ -49,7 +44,14 @@ import GHC.Records (HasField (getField))
 import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
-import Test.Cardano.Ledger.Examples.TwoPhaseValidation (datumExample1, initUTxO, someKeys, testSystemStart, validatingBody, validatingRedeemersEx1)
+import Test.Cardano.Ledger.Examples.TwoPhaseValidation
+  ( datumExample1,
+    initUTxO,
+    someKeys,
+    testSystemStart,
+    validatingBody,
+    validatingRedeemersEx1,
+  )
 import Test.Cardano.Ledger.Generic.Fields (PParamsField (..), TxField (..), WitnessesField (..))
 import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (Alonzo, Babbage))
 import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic, always)
@@ -61,7 +63,8 @@ import Test.Tasty.QuickCheck (Gen, Property, arbitrary, counterexample, testProp
 
 tests :: TestTree
 tests =
-  testGroup "ExUnit tools" $
+  testGroup
+    "ExUnit tools"
     [ testProperty "Plutus ExUnit translation round-trip" exUnitsTranslationRoundTrip,
       testGroup
         "Alonzo"
@@ -102,8 +105,6 @@ testExUnitCalculation ::
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "txdats" (Core.Witnesses era) (TxDats era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
@@ -147,8 +148,6 @@ exampleExUnitCalc ::
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "txdats" (Core.Witnesses era) (TxDats era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
@@ -182,8 +181,6 @@ exampleInvalidExUnitCalc ::
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
     Core.Script era ~ Script era,
     Signable
       (Ledger.Crypto.DSIGN (Crypto era))
@@ -203,7 +200,7 @@ exampleInvalidExUnitCalc proof =
     exampleEpochInfo
     testSystemStart
     costmodels of
-    Left{} -> assertFailure "evaluateTransactionExecutionUnits should not fail from TranslationError"
+    Left {} -> assertFailure "evaluateTransactionExecutionUnits should not fail from TranslationError"
     Right _ -> assertFailure "evaluateTransactionExecutionUnits should have failed"
 
 exampleTx ::
@@ -251,8 +248,6 @@ updateTxExUnits ::
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
     HasField "certs" (Core.TxBody era) (StrictSeq (DCert (Crypto era))),
-    HasField "datahash" (Core.TxOut era) (StrictMaybe (DataHash (Crypto era))),
-    HasField "datum" (Core.TxOut era) (StrictMaybe (Data era)),
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "txdats" (Core.Witnesses era) (TxDats era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -13,7 +13,7 @@ import qualified Cardano.Crypto.Hash as Crypto
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo.PParams
 import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), Script)
-import Cardano.Ledger.Alonzo.Tools (BasicFailure (..), ScriptFailure, evaluateTransactionExecutionUnits)
+import Cardano.Ledger.Alonzo.Tools (ScriptFailure, evaluateTransactionExecutionUnits)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWitness
 import qualified Cardano.Ledger.Babbage.PParams as Babbage.PParams
@@ -203,9 +203,7 @@ exampleInvalidExUnitCalc proof =
     exampleEpochInfo
     testSystemStart
     costmodels of
-    Left (UnknownTxIns _) -> pure ()
-    Left (BadTranslation _) ->
-      assertFailure "evaluateTransactionExecutionUnits should not fail from BadTranslation"
+    Left{} -> assertFailure "evaluateTransactionExecutionUnits should not fail from TranslationError"
     Right _ -> assertFailure "evaluateTransactionExecutionUnits should have failed"
 
 exampleTx ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (..))
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..), Script (PlutusScript))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
-import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..))
+import Cardano.Ledger.Alonzo.TxInfo (TranslationError (..), TxOutSource (..))
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPred (..))
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUtxowPred (..))
@@ -1117,7 +1117,15 @@ genericBabbageFeatures pf =
             testU
               pf
               (trustMeP pf True $ inlineDatumV1Tx pf)
-              (Left [fromUtxos @era (CollectErrors [BadTranslation InlineDatumsNotSupported])]),
+              ( Left
+                  [ fromUtxos @era
+                      ( CollectErrors
+                          [ BadTranslation $
+                              InlineDatumsNotSupported (TxOutFromInput inlineDatumInputV1)
+                          ]
+                      )
+                  ]
+              ),
           testCase "min-utxo value with output too large" $
             testU
               pf

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -371,7 +371,7 @@ redeemerExample1 :: Data era
 redeemerExample1 = Data (Plutus.I 42)
 
 txDatsExample1 :: Era era => TxDats era
-txDatsExample1 = TxDats $ keyBy hashData $ [datumExample1]
+txDatsExample1 = TxDats $ keyBy hashData [datumExample1]
 
 alwaysSucceedsOutput :: forall era. (Scriptic era) => Proof era -> Core.TxOut era
 alwaysSucceedsOutput pf =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -22,9 +22,19 @@ import Cardano.Ledger.Alonzo.PParams (PParams' (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..), collectTwoPhaseScriptInputs)
 import Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBBODY, AlonzoBbodyPredFail (..))
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (..))
-import Cardano.Ledger.Alonzo.Rules.Utxos (FailureDescription (..), TagMismatchDescription (..), UtxosPredicateFailure (..))
+import Cardano.Ledger.Alonzo.Rules.Utxos
+  ( FailureDescription (..),
+    TagMismatchDescription (..),
+    UtxosPredicateFailure (..),
+  )
 import Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), Script (..), mkCostModel)
+import Cardano.Ledger.Alonzo.Scripts
+  ( CostModel,
+    CostModels (..),
+    ExUnits (..),
+    Script (..),
+    mkCostModel,
+  )
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Tx
   ( IsValid (..),
@@ -1654,7 +1664,7 @@ getTxInfo ::
   SystemStart ->
   UTxO era ->
   Core.Tx era ->
-  Either TranslationError VersionedTxInfo
+  Either (TranslationError (Crypto era)) VersionedTxInfo
 getTxInfo (Alonzo _) = txInfo
 getTxInfo (Babbage _) = txInfo
 getTxInfo era = error ("getTxInfo Not defined in era " ++ show era)


### PR DESCRIPTION
While looking at #2825 and #2836 I realized that TranslationError was a new type in Babbage and thus we can in fact improve it before the release, so the node can use it to produce better errors to the users. I started at the point of the #2825 PR, since it seemed like a sensible cleanup.

While working on improving the type I found a few problems:

* All error constructors could use with some extra information about the piece of transaction that is at fault for the error. The most common information was about problems with TxOuts, but in order to indicate which TxOut is the offender I moved as well as renamed and improved the `TxOutSource`  (previously `OutputSource`). This will be enough to point at the offender.
* `TranslationLogicErrorDoubleDatum` was an error that could never happen in practice, but it was impossible to avoid without some changes to the way inline datums are being extracted from TxOut in a general way. Thus is the addition of `getTxOutDatum` and removal of less powerful `HasField "datum"` instances.


Two more problems found, that ~haven't~ have been resolved ~yet~:

1. [x] In the PR #2825 we remove `basicValidation`, which is redundant for Babbage, however for Alonzo txInfo check does not verify presence of inputs in the utxo, it simply filters them out. Will now produce `TranslationLogicMissingInput`
2. [x] Test `"attempt calculate ExUnits with invalid tx"` is totally wrong.