### PR TITLE
Do not serialize empty txbody fields

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -721,7 +721,7 @@ encodeTxBodyRaw
           TxBodyRaw i ifee o c w f (ValidityInterval b t) u rsh mi sh ah ni
       )
       !> Key 0 (E encodeFoldable _inputs)
-      !> Key 13 (E encodeFoldable _collateral)
+      !> Omit null (Key 13 (E encodeFoldable _collateral))
       !> Key 1 (E encodeFoldable _outputs)
       !> Key 2 (To _txfee)
       !> encodeKeyedStrictMaybe 3 top
@@ -729,7 +729,7 @@ encodeTxBodyRaw
       !> Omit (null . unWdrl) (Key 5 (To _wdrls))
       !> encodeKeyedStrictMaybe 6 _update
       !> encodeKeyedStrictMaybe 8 bot
-      !> Key 14 (E encodeFoldable _reqSignerHashes)
+      !> Omit null (Key 14 (E encodeFoldable _reqSignerHashes))
       !> Omit isZero (Key 9 (E encodeMint _mint))
       !> encodeKeyedStrictMaybe 11 _scriptIntegrityHash
       !> encodeKeyedStrictMaybe 7 _adHash

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -823,8 +823,8 @@ encodeTxBodyRaw
           TxBodyRaw i ifee ri o cr tc c w f (ValidityInterval b t) u rsh mi sh ah ni
       )
       !> Key 0 (E encodeFoldable _spendInputs)
-      !> Key 13 (E encodeFoldable _collateralInputs)
-      !> Key 18 (E encodeFoldable _referenceInputs)
+      !> Omit null (Key 13 (E encodeFoldable _collateralInputs))
+      !> Omit null (Key 18 (E encodeFoldable _referenceInputs))
       !> Key 1 (E encodeFoldable _outputs)
       !> encodeKeyedStrictMaybe 16 _collateralReturn
       !> encodeKeyedStrictMaybe 17 _totalCollateral
@@ -834,7 +834,7 @@ encodeTxBodyRaw
       !> Omit (null . unWdrl) (Key 5 (To _wdrls))
       !> encodeKeyedStrictMaybe 6 _update
       !> encodeKeyedStrictMaybe 8 bot
-      !> Key 14 (E encodeFoldable _reqSignerHashes)
+      !> Omit null (Key 14 (E encodeFoldable _reqSignerHashes))
       !> Omit isZero (Key 9 (E encodeMint _mint))
       !> encodeKeyedStrictMaybe 11 _scriptIntegrityHash
       !> encodeKeyedStrictMaybe 7 _adHash


### PR DESCRIPTION
Two optional transaction body fields from Alonzo and Babbage, and one Babbage-only optional field, are being serialized as empty containers when not used. They should be omitted when not used, which is what this PR changes.

The Alonzo/Babbage fields are:
* collateral inputs (key 13 our CBOR encoding of the txbody)
* required signers (key 14 our CBOR encoding of the txbody)

The Babbage-only field is:
* reference inputs (key 18 our CBOR encoding of the txbody)

Note that this is not a breaking change, our deserializers are flexible enough to handle empty containers.

resolves #2862