### PR TITLE
Make a note about script tags in the CDDL specs

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -386,7 +386,6 @@ network_id = 0 / 1 ; New
 epoch = uint
 
 addr_keyhash          = $hash28
-scripthash            = $hash28
 genesis_delegate_hash = $hash28
 pool_keyhash          = $hash28
 genesishash           = $hash28
@@ -394,3 +393,11 @@ genesishash           = $hash28
 vrf_keyhash           = $hash32
 auxiliary_data_hash   = $hash32
 pool_metadata_hash    = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; The tags in the Alonzo era are:
+;   "\x00" for multisig scripts
+;   "\x01" for Plutus V1 scripts
+scripthash            = $hash28

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -394,7 +394,6 @@ network_id = 0 / 1
 epoch = uint
 
 addr_keyhash          = $hash28
-scripthash            = $hash28
 genesis_delegate_hash = $hash28
 pool_keyhash          = $hash28
 genesishash           = $hash28
@@ -402,6 +401,15 @@ genesishash           = $hash28
 vrf_keyhash           = $hash32
 auxiliary_data_hash   = $hash32
 pool_metadata_hash    = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; The tags in the Babbage era are:
+;   "\x00" for multisig scripts
+;   "\x01" for Plutus V1 scripts
+;   "\x02" for Plutus V2 scripts
+scripthash            = $hash28
 
 datum_hash = $hash32
 data = #6.24(bytes .cbor plutus_data)

--- a/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
+++ b/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
@@ -259,13 +259,19 @@ int64 = -9223372036854775808 .. 9223372036854775807
 epoch = uint
 
 addr_keyhash          = $hash28
-scripthash            = $hash28
 genesis_delegate_hash = $hash28
 pool_keyhash          = $hash28
 genesishash           = $hash28
 
 vrf_keyhash           = $hash32
 metadata_hash         = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; In the Allegra and Mary eras there is only one such tag,
+; namely "\x00" for multisig scripts.
+scripthash            = $hash28
 
 ; allegra differences
 transaction_body_allegra =

--- a/eras/shelley/test-suite/cddl-files/shelley.cddl
+++ b/eras/shelley/test-suite/cddl-files/shelley.cddl
@@ -237,12 +237,18 @@ coin = uint
 epoch = uint
 
 addr_keyhash          = $hash28
-scripthash            = $hash28
 genesis_delegate_hash = $hash28
 pool_keyhash          = $hash28
 genesishash           = $hash28
 
 vrf_keyhash           = $hash32
 metadata_hash         = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; In the Shelley era there is only one such tag,
+; namely "\x00" for multisig scripts.
+scripthash            = $hash28
 
 $nonce /= [ 0 // 1, bytes .size 32 ]


### PR DESCRIPTION
I've added a comment to all the CDDL files to explain how the script hashes are computed.

In particular, each script language is associated with a script tag which much be prepended to the script bytes before hashing.

resolves #2756