### PR TITLE
Disable staking Ptr optimization

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -27,7 +27,7 @@ import Control.SetAlgebra (eval, (◁))
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
-import Data.Word (Word16)
+import Data.Word (Word16, Word64)
 import GHC.Records (HasField (..))
 
 -- ============================================================
@@ -77,4 +77,4 @@ collOuts txb =
           -- In the impossible event that there are more transaction outputs
           -- in the transaction than will fit into a Word16 (which backs the TxIx),
           -- we give the collateral return output an index of maxBound.
-          Nothing -> TxIx (maxBound :: Word16)
+          Nothing -> TxIx ((fromIntegral :: Word16 -> Word64) (maxBound :: Word16))

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
@@ -46,7 +46,7 @@ trippingF f x =
             <> case deserialiseFromBytes decodeTerm (serialize x) of
               Left e -> ppShow e
               Right (_, terms) -> ppShow terms
-            <> "\nreamining term: "
+            <> "\nremaining term: "
             <> case deserialiseFromBytes decodeTerm (serialize y) of
               Left e -> ppShow e
               Right (_, terms) -> ppShow terms

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Val ((<->))
 import qualified Data.ByteString.Short as SBS
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
+import Data.Word
 import GHC.Stack (HasCallStack)
 
 -- | We use the same hashing algorithm so we can unwrap and rewrap the bytes.
@@ -70,7 +71,7 @@ translateCompactTxInByronToShelley ::
 translateCompactTxInByronToShelley (Byron.CompactTxInUtxo compactTxId idx) =
   TxIn
     (translateTxIdByronToShelley (Byron.fromCompactTxId compactTxId))
-    (TxIx idx)
+    (TxIx ((fromIntegral :: Word16 -> Word64) idx))
 
 translateUTxOByronToShelley ::
   forall c.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
@@ -44,16 +43,16 @@ import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes
   ( ActiveSlotCoeff,
     BlocksMade (..),
-    CertIx (..),
     DnsName,
     NonNegativeInterval,
     PositiveInterval,
     PositiveUnitInterval,
-    TxIx (..),
     UnitInterval,
     Url,
     mkActiveSlotCoeff,
+    mkCertIxPartial,
     mkNonceFromNumber,
+    mkTxIxPartial,
     promoteRatio,
     textToDns,
     textToUrl,
@@ -134,7 +133,7 @@ import qualified Data.Time as Time
 import qualified Data.Time.Calendar.OrdinalDate as Time
 import Data.Typeable (Typeable)
 import qualified Data.VMap as VMap
-import Data.Word (Word64, Word8)
+import Data.Word (Word16, Word64, Word8)
 import Generic.Random (genericArbitraryU)
 import Numeric.Natural (Natural)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
@@ -390,9 +389,11 @@ instance CC.Crypto crypto => Arbitrary (Credential r crypto) where
         KeyHashObj <$> arbitrary
       ]
 
-deriving instance Arbitrary TxIx
+instance Arbitrary TxIx where
+  arbitrary = mkTxIxPartial . toInteger <$> (arbitrary :: Gen Word16)
 
-deriving instance Arbitrary CertIx
+instance Arbitrary CertIx where
+  arbitrary = mkCertIxPartial . toInteger <$> (arbitrary :: Gen Word16)
 
 instance Arbitrary Ptr where
   arbitrary = genericArbitraryU

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -109,7 +109,7 @@ import Data.Maybe (fromMaybe)
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
-import Data.Word (Word16, Word64)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
@@ -403,8 +403,8 @@ isBootstrapRedeemer _ = False
 putPtr :: Ptr -> Put
 putPtr (Ptr slot (TxIx txIx) (CertIx certIx)) = do
   putSlot slot
-  putVariableLengthWord64 ((fromIntegral :: Word16 -> Word64) txIx)
-  putVariableLengthWord64 ((fromIntegral :: Word16 -> Word64) certIx)
+  putVariableLengthWord64 ((fromIntegral @_ @Word64) txIx)
+  putVariableLengthWord64 ((fromIntegral @_ @Word64) certIx)
   where
     putSlot (SlotNo n) = putVariableLengthWord64 n
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -431,8 +431,8 @@ decodePtr ::
 decodePtr buf =
   Ptr
     <$> (SlotNo . (fromIntegral :: Word32 -> Word64) <$> decodeVariableLengthWord32 "SlotNo" buf)
-    <*> (TxIx <$> decodeVariableLengthWord16 "TxIx" buf)
-    <*> (CertIx <$> decodeVariableLengthWord16 "CertIx" buf)
+    <*> (TxIx . (fromIntegral :: Word16 -> Word64) <$> decodeVariableLengthWord16 "TxIx" buf)
+    <*> (CertIx . (fromIntegral :: Word16 -> Word64) <$> decodeVariableLengthWord16 "CertIx" buf)
 {-# INLINE decodePtr #-}
 
 guardLength ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -132,7 +132,7 @@ instance NoThunks (StakeReference crypto)
 -- ┗━━┷━━┷━━┷━━┷━━┷━━┷━━┷━━┛
 --
 -- @@@
--- newtype Ptr = PtrCompact
+-- newtype Ptr = PtrCompact Word64
 
 -- | Pointer to a slot number, transaction index and an index in certificate
 -- list.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1013,7 +1013,7 @@ pcTxId (TxId safehash) = trim (ppSafeHash safehash)
 instance c ~ Crypto era => PrettyC (TxId c) era where prettyC _ = pcTxId
 
 pcTxIn :: TxIn crypto -> PDoc
-pcTxIn (TxIn (TxId h) (TxIx i)) = parens (hsep [ppString "TxIn", trim (ppSafeHash h), ppWord16 i])
+pcTxIn (TxIn (TxId h) (TxIx i)) = parens (hsep [ppString "TxIn", trim (ppSafeHash h), ppWord64 i])
 
 instance c ~ Crypto era => PrettyC (TxIn c) era where prettyC _ = pcTxIn
 


### PR DESCRIPTION
Unfortunately we can't make Ptr unpacking optimization until Babbage has been properly released, so this PR reverts the functionality to the 1.33/1.34 version. This indirectly relies on Address deserialization, which has been fixed in #2750, but it needs to be on mainnet, before we can unpack the Ptr.