### PR TITLE
integrity hash not needed for all ref scripts

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -325,9 +325,10 @@ ppViewHashesMatch ::
   Core.TxBody era ->
   Core.PParams era ->
   UTxO era ->
+  Set (ScriptHash (Crypto era)) ->
   Test (UtxowPredicateFail era)
-ppViewHashesMatch tx txbody pp utxo = do
-  let langs = languages @era tx utxo
+ppViewHashesMatch tx txbody pp utxo sNeeded = do
+  let langs = languages @era tx utxo sNeeded
       langViews = Set.map (getLanguageView pp) langs
       computedPPhash = hashScriptIntegrity langViews (txrdmrs . wits $ tx) (txdats . wits $ tx)
       bodyPPhash = getField @"scriptIntegrityHash" txbody
@@ -421,7 +422,7 @@ alonzoStyleWitness = do
   -- which appears in the spec, seems broken since costmdls is a projection of PPrams, not Tx
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
-  runTest $ ppViewHashesMatch tx txbody pp utxo
+  runTest $ ppViewHashesMatch tx txbody pp utxo sNeeded
 
   trans @(Core.EraRule "UTXO" era) $
     TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -783,9 +783,11 @@ languages ::
   ) =>
   Core.Tx era ->
   UTxO era ->
+  Set (ScriptHash (Crypto era)) ->
   Set Language
-languages tx utxo = Map.foldl' accum Set.empty allscripts
+languages tx utxo sNeeded = Map.foldl' accum Set.empty allscripts
   where
-    allscripts = txscripts @era utxo tx
+    isNeeded scriptHash _script = scriptHash `Set.member` sNeeded
+    allscripts = Map.filterWithKey isNeeded $ txscripts @era utxo tx
     accum ans (TimelockScript _) = ans
     accum ans (PlutusScript l _) = Set.insert l ans

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -787,7 +787,6 @@ languages ::
   Set Language
 languages tx utxo sNeeded = Map.foldl' accum Set.empty allscripts
   where
-    isNeeded scriptHash _script = scriptHash `Set.member` sNeeded
-    allscripts = Map.filterWithKey isNeeded $ txscripts @era utxo tx
+    allscripts = Map.restrictKeys (txscripts @era utxo tx) sNeeded
     accum ans (TimelockScript _) = ans
     accum ans (PlutusScript l _) = Set.insert l ans

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -353,7 +353,7 @@ babbageUtxowTransition = do
   -- which appears in the spec, seems broken since costmdls is a projection of PPrams, not Tx
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
-  runTest $ ppViewHashesMatch tx txbody pp utxo
+  runTest $ ppViewHashesMatch tx txbody pp utxo sNeeded
 
   trans @(Core.EraRule "UTXO" era) $
     TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -907,7 +907,7 @@ genValidatedTxAndInfo proof slot = do
       txBodyNoFeeHash = hashAnnotated txBodyNoFee
       witsMakers :: [SafeHash (Crypto era) EraIndependentTxBody -> [WitnessesField era]]
       witsMakers = keyWitsMakers ++ dcertWitsMakers ++ rwdrsWitsMakers
-      bogusNeededScripts = scriptsNeeded' proof utxoNoCollateral txBodyNoFee
+      bogusNeededScripts = scriptWitsNeeded' proof utxoNoCollateral txBodyNoFee
       noFeeWits :: [WitnessesField era]
       noFeeWits =
         onlyNecessaryScripts proof bogusNeededScripts $
@@ -935,8 +935,8 @@ genValidatedTxAndInfo proof slot = do
     mapM (genTxOutKeyWitness proof Nothing) $ Map.elems collMap
 
   -- 10. Construct the correct Tx with valid fee and collaterals
-  allPlutusScripts <- gsPlutusScripts <$> get
-  let langs = Set.toList $ languagesUsed proof bogusTxForFeeCalc (UTxO utxoNoCollateral) allPlutusScripts
+  let sNeeded = scriptsNeeded' proof utxo txBodyNoFee
+      langs = Set.toList $ languagesUsed proof bogusTxForFeeCalc (UTxO utxoNoCollateral) sNeeded
       mIntegrityHash =
         newScriptIntegrityHash
           proof
@@ -959,7 +959,7 @@ genValidatedTxAndInfo proof slot = do
             WppHash mIntegrityHash
           ]
       txBodyHash = hashAnnotated txBody
-      neededScripts = scriptsNeeded' proof utxo txBody
+      neededScripts = scriptWitsNeeded' proof utxo txBody
       wits =
         onlyNecessaryScripts proof neededScripts $
           redeemerDatumWits


### PR DESCRIPTION
This fixes a bug found by @james-iohk. See https://github.com/input-output-hk/cardano-node/issues/4057#issuecomment-1158011896

If a reference script is not actually going to be run, we do not need to demand the corresponding language be a part of the script integrity hash. The problem stems from the `txscripts` function, which is almost never the function one wants (it gives you all the scripts associated with a tx, not the ones that are going to be evaluated).

This commit fixes the implementation, we must also fix the spec (cc @WhatisRT , when we fix this, we should definitely add @james-iohk to the list of contributors!).

Note that I renamed an era-generic helper function used in the property tests. I renamed `scriptsNeeded'` to `scriptWitsNeeded'`, since that function is used for supplying the script witnesses that are needed. I also added a new function called `scriptsNeeded'` which returns the scripts that are needed for evaluation (this name matches the spec and the implementation now).