### PR TITLE
Cleanup `Cardano.Ledger.Shelley.TxBody` module.

### DIFF
--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -16,7 +16,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.ShelleyMA.Timelocks
-  ( Timelock (RequireSignature, RequireAllOf, RequireAnyOf, RequireMOf, RequireTimeExpire, RequireTimeStart),
+  ( Timelock
+      ( RequireSignature,
+        RequireAllOf,
+        RequireAnyOf,
+        RequireMOf,
+        RequireTimeExpire,
+        RequireTimeStart
+      ),
     pattern TimelockConstr,
     inInterval,
     showTimelock,
@@ -40,17 +47,11 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness))
+import Cardano.Ledger.Keys.WitVKey (WitVKey (..), witVKeyHash)
 import Cardano.Ledger.SafeHash (SafeToHash)
-import Cardano.Ledger.Serialization
-  ( decodeStrictSeq,
-    encodeFoldable,
-  )
+import Cardano.Ledger.Serialization (decodeStrictSeq, encodeFoldable)
 import Cardano.Ledger.Shelley.Constraints (UsesTxBody)
 import Cardano.Ledger.Shelley.Scripts (MultiSig, getMultiSigBytes)
-import Cardano.Ledger.Shelley.Tx (WitVKey)
-import Cardano.Ledger.Shelley.TxBody
-  ( witKeyHash,
-  )
 import Cardano.Slotting.Slot (SlotNo (..))
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Control.DeepSeq (NFData (..))
@@ -285,7 +286,7 @@ validateTimelock ::
   Bool
 validateTimelock lock tx = evalFPS @era lock vhks (getField @"body" tx)
   where
-    vhks = Set.map witKeyHash (getField @"addrWits" tx)
+    vhks = Set.map witVKeyHash (getField @"addrWits" tx)
 
 showTimelock :: CC.Crypto crypto => Timelock crypto -> String
 showTimelock (RequireTimeStart (SlotNo i)) = "(Start >= " ++ show i ++ ")"

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -53,6 +53,7 @@ library
     Cardano.Ledger.Shelley.Metadata
     Cardano.Ledger.Shelley.Orphans
     Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PoolParams
     Cardano.Ledger.Shelley.PParams
     Cardano.Ledger.Shelley.Rewards
     Cardano.Ledger.Shelley.RewardProvenance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -148,7 +148,6 @@ import Cardano.Ledger.Shelley.TxBody as X
     PoolMetadata (..),
     PoolParams (..),
     Ptr (..),
-    StakeCreds (..),
     StakePoolRelay (..),
     Wdrl (..),
     WitVKey (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/Certificates.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/Certificates.hs
@@ -4,19 +4,21 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Cardano.Ledger.Shelley.Delegation.Certificates
-  ( DCert (..),
+  ( Delegation (..),
+    DCert (..),
     DelegCert (..),
     PoolCert (..),
     GenesisDelegCert (..),
     MIRCert (..),
+    MIRPot (..),
+    MIRTarget (..),
     delegCWitness,
     poolCWitness,
     genesisCWitness,
@@ -33,18 +35,235 @@ module Cardano.Ledger.Shelley.Delegation.Certificates
   )
 where
 
-import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Shelley.TxBody
-  ( DCert (..),
-    DelegCert (..),
-    Delegation (..),
-    GenesisDelegCert (..),
-    MIRCert (..),
-    MIRPot (..),
-    PoolCert (..),
-    PoolParams (..),
+import Cardano.Binary
+  ( FromCBOR (fromCBOR),
+    ToCBOR (..),
+    TokenType (TypeMapLen, TypeMapLen64, TypeMapLenIndef),
+    decodeWord,
+    encodeListLen,
+    peekTokenType,
   )
+import Cardano.Ledger.BaseTypes (invalidKey)
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
+import Cardano.Ledger.Credential (Credential (..), StakeCredential)
+import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Keys
+  ( Hash,
+    KeyHash (..),
+    KeyRole (..),
+    VerKeyVRF,
+  )
+import Cardano.Ledger.Serialization
+  ( FromCBORGroup (..),
+    ToCBORGroup (..),
+    decodeRecordNamed,
+    decodeRecordSum,
+    listLenInt,
+    mapFromCBOR,
+    mapToCBOR,
+  )
+import Cardano.Ledger.Shelley.PoolParams
+import Cardano.Ledger.Slot (EpochNo (..))
+import Control.DeepSeq (NFData)
+import Data.Map.Strict (Map)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+-- | The delegation of one stake key to another.
+data Delegation crypto = Delegation
+  { _delegator :: !(StakeCredential crypto),
+    _delegatee :: !(KeyHash 'StakePool crypto)
+  }
+  deriving (Eq, Generic, Show, NFData)
+
+instance NoThunks (Delegation crypto)
+
+data DelegCert crypto
+  = -- | A stake key registration certificate.
+    RegKey !(StakeCredential crypto)
+  | -- | A stake key deregistration certificate.
+    DeRegKey !(StakeCredential crypto)
+  | -- | A stake delegation certificate.
+    Delegate !(Delegation crypto)
+  deriving (Show, Generic, Eq, NFData)
+
+data PoolCert crypto
+  = -- | A stake pool registration certificate.
+    RegPool !(PoolParams crypto)
+  | -- | A stake pool retirement certificate.
+    RetirePool !(KeyHash 'StakePool crypto) !EpochNo
+  deriving (Show, Generic, Eq, NFData)
+
+-- | Genesis key delegation certificate
+data GenesisDelegCert crypto
+  = GenesisDelegCert
+      !(KeyHash 'Genesis crypto)
+      !(KeyHash 'GenesisDelegate crypto)
+      !(Hash crypto (VerKeyVRF crypto))
+  deriving (Show, Generic, Eq, NFData)
+
+data MIRPot = ReservesMIR | TreasuryMIR
+  deriving (Show, Generic, Eq, NFData, Ord, Enum, Bounded)
+
+deriving instance NoThunks MIRPot
+
+instance ToCBOR MIRPot where
+  toCBOR ReservesMIR = toCBOR (0 :: Word8)
+  toCBOR TreasuryMIR = toCBOR (1 :: Word8)
+
+instance FromCBOR MIRPot where
+  fromCBOR =
+    decodeWord >>= \case
+      0 -> pure ReservesMIR
+      1 -> pure TreasuryMIR
+      k -> invalidKey k
+
+-- | MIRTarget specifies if funds from either the reserves
+-- or the treasury are to be handed out to a collection of
+-- reward accounts or instead transfered to the opposite pot.
+data MIRTarget crypto
+  = StakeAddressesMIR (Map (Credential 'Staking crypto) DeltaCoin)
+  | SendToOppositePotMIR Coin
+  deriving (Show, Generic, Eq, NFData)
+
+deriving instance NoThunks (MIRTarget crypto)
+
+instance
+  CC.Crypto crypto =>
+  FromCBOR (MIRTarget crypto)
+  where
+  fromCBOR = do
+    peekTokenType >>= \case
+      TypeMapLen -> StakeAddressesMIR <$> mapFromCBOR
+      TypeMapLen64 -> StakeAddressesMIR <$> mapFromCBOR
+      TypeMapLenIndef -> StakeAddressesMIR <$> mapFromCBOR
+      _ -> SendToOppositePotMIR <$> fromCBOR
+
+instance
+  CC.Crypto crypto =>
+  ToCBOR (MIRTarget crypto)
+  where
+  toCBOR (StakeAddressesMIR m) = mapToCBOR m
+  toCBOR (SendToOppositePotMIR c) = toCBOR c
+
+-- | Move instantaneous rewards certificate
+data MIRCert crypto = MIRCert
+  { mirPot :: MIRPot,
+    mirRewards :: MIRTarget crypto
+  }
+  deriving (Show, Generic, Eq, NFData)
+
+instance
+  CC.Crypto crypto =>
+  FromCBOR (MIRCert crypto)
+  where
+  fromCBOR =
+    decodeRecordNamed "MIRCert" (const 2) (MIRCert <$> fromCBOR <*> fromCBOR)
+
+instance
+  CC.Crypto crypto =>
+  ToCBOR (MIRCert crypto)
+  where
+  toCBOR (MIRCert pot targets) =
+    encodeListLen 2
+      <> toCBOR pot
+      <> toCBOR targets
+
+-- | A heavyweight certificate.
+data DCert crypto
+  = DCertDeleg !(DelegCert crypto)
+  | DCertPool !(PoolCert crypto)
+  | DCertGenesis !(GenesisDelegCert crypto)
+  | DCertMir !(MIRCert crypto)
+  deriving (Show, Generic, Eq, NFData)
+
+instance NoThunks (DelegCert crypto)
+
+instance NoThunks (PoolCert crypto)
+
+instance NoThunks (GenesisDelegCert crypto)
+
+instance NoThunks (MIRCert crypto)
+
+instance NoThunks (DCert crypto)
+
+-- CBOR
+
+instance
+  CC.Crypto crypto =>
+  ToCBOR (DCert crypto)
+  where
+  toCBOR = \case
+    -- DCertDeleg
+    DCertDeleg (RegKey cred) ->
+      encodeListLen 2
+        <> toCBOR (0 :: Word8)
+        <> toCBOR cred
+    DCertDeleg (DeRegKey cred) ->
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
+        <> toCBOR cred
+    DCertDeleg (Delegate (Delegation cred poolkh)) ->
+      encodeListLen 3
+        <> toCBOR (2 :: Word8)
+        <> toCBOR cred
+        <> toCBOR poolkh
+    -- DCertPool
+    DCertPool (RegPool poolParams) ->
+      encodeListLen (1 + listLen poolParams)
+        <> toCBOR (3 :: Word8)
+        <> toCBORGroup poolParams
+    DCertPool (RetirePool vk epoch) ->
+      encodeListLen 3
+        <> toCBOR (4 :: Word8)
+        <> toCBOR vk
+        <> toCBOR epoch
+    -- DCertGenesis
+    DCertGenesis (GenesisDelegCert gk kh vrf) ->
+      encodeListLen 4
+        <> toCBOR (5 :: Word8)
+        <> toCBOR gk
+        <> toCBOR kh
+        <> toCBOR vrf
+    -- DCertMIR
+    DCertMir mir ->
+      encodeListLen 2
+        <> toCBOR (6 :: Word8)
+        <> toCBOR mir
+
+instance
+  CC.Crypto crypto =>
+  FromCBOR (DCert crypto)
+  where
+  fromCBOR = decodeRecordSum "DCert crypto" $
+    \case
+      0 -> do
+        x <- fromCBOR
+        pure (2, DCertDeleg . RegKey $ x)
+      1 -> do
+        x <- fromCBOR
+        pure (2, DCertDeleg . DeRegKey $ x)
+      2 -> do
+        a <- fromCBOR
+        b <- fromCBOR
+        pure (3, DCertDeleg $ Delegate (Delegation a b))
+      3 -> do
+        group <- fromCBORGroup
+        pure (fromIntegral (1 + listLenInt group), DCertPool (RegPool group))
+      4 -> do
+        a <- fromCBOR
+        b <- fromCBOR
+        pure (3, DCertPool $ RetirePool a (EpochNo b))
+      5 -> do
+        a <- fromCBOR
+        b <- fromCBOR
+        c <- fromCBOR
+        pure (4, DCertGenesis $ GenesisDelegCert a b c)
+      6 -> do
+        x <- fromCBOR
+        pure (2, DCertMir x)
+      k -> invalidKey k
 
 -- | Determine the certificate author
 delegCWitness :: DelegCert crypto -> Credential 'Staking crypto

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/Certificates.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/Certificates.hs
@@ -17,7 +17,6 @@ module Cardano.Ledger.Shelley.Delegation.Certificates
     PoolCert (..),
     GenesisDelegCert (..),
     MIRCert (..),
-    StakeCreds (..),
     delegCWitness,
     poolCWitness,
     genesisCWitness,
@@ -45,7 +44,6 @@ import Cardano.Ledger.Shelley.TxBody
     MIRPot (..),
     PoolCert (..),
     PoolParams (..),
-    StakeCreds (..),
   )
 
 -- | Determine the certificate author

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -202,7 +202,7 @@ import Cardano.Ledger.Shelley.TxBody
     Wdrl (..),
     WitVKey (..),
     getRwdCred,
-    witKeyHash,
+    witVKeyHash,
   )
 import Cardano.Ledger.Shelley.UTxO
   ( UTxO (..),
@@ -1051,7 +1051,7 @@ witsFromTxWitnesses ::
   WitHashes (Crypto era)
 witsFromTxWitnesses coreTx =
   WitHashes $
-    Set.map witKeyHash addWits
+    Set.map witVKeyHash addWits
       `Set.union` Set.map bootstrapWitKeyHash bsWits
   where
     bsWits = getField @"bootWits" coreTx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -48,6 +48,7 @@ import qualified Cardano.Ledger.BaseTypes as BT
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (PParamsDelta)
 import Cardano.Ledger.Era
+import Cardano.Ledger.HKD
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
 import Cardano.Ledger.Serialization
   ( FromCBORGroup (..),
@@ -75,33 +76,15 @@ import Data.List (nub)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
-import Data.Proxy (Proxy)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 
 -- ====================================================================
 
--- | Higher Kinded Data
-type family HKD f a where
-  HKD Identity a = a
-  HKD f a = f a
-
-class HKDFunctor f where
-  hkdMap :: Proxy f -> (a -> b) -> HKD f a -> HKD f b
-
-instance HKDFunctor Identity where
-  hkdMap _ f a = f a
-
-instance HKDFunctor Maybe where
-  hkdMap _ f = fmap f
-
-instance HKDFunctor StrictMaybe where
-  hkdMap _ f = fmap f
-
 -- | Protocol parameters.
 --
--- We use the HKD type family so that the protocol parameters type and
+-- We use the `HKD` type family so that the protocol parameters type and
 -- the type for the updates to the protocol parameters can share records fields.
 -- The protocol parameters will have type 'PParams'' 'Identity', and the updates
 -- will have type 'PParams'' 'StrictMaybe', though 'Identity' will be hidden from use.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
@@ -1,0 +1,348 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Shelley.PoolParams
+  ( PoolParams (..),
+    PoolMetadata (..),
+    StakePoolRelay (..),
+    SizeOfPoolRelays (..),
+    SizeOfPoolOwners (..),
+  )
+where
+
+import Cardano.Binary
+  ( Case (..),
+    FromCBOR (fromCBOR),
+    Size,
+    ToCBOR (..),
+    encodeListLen,
+    szCases,
+  )
+import Cardano.Ledger.Address (RewardAcnt (..))
+import Cardano.Ledger.BaseTypes
+  ( DnsName,
+    Port,
+    StrictMaybe (..),
+    UnitInterval,
+    Url,
+    invalidKey,
+    maybeToStrictMaybe,
+    strictMaybeToMaybe,
+  )
+import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Keys
+  ( Hash,
+    KeyHash (..),
+    KeyRole (..),
+    VerKeyVRF,
+  )
+import Cardano.Ledger.Serialization
+  ( CBORGroup (..),
+    CborSeq (..),
+    FromCBORGroup (..),
+    ToCBORGroup (..),
+    decodeNullMaybe,
+    decodeRecordNamed,
+    decodeRecordSum,
+    decodeSet,
+    decodeStrictSeq,
+    encodeFoldable,
+    encodeNullMaybe,
+    ipv4FromCBOR,
+    ipv4ToCBOR,
+    ipv6FromCBOR,
+    ipv6ToCBOR,
+  )
+import Cardano.Ledger.Shelley.Orphans ()
+import Cardano.Prelude (panic)
+import Control.DeepSeq (NFData ())
+import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser, explicitParseField)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as Char8
+import Data.Foldable (asum)
+import Data.IP (IPv4, IPv6)
+import Data.Proxy (Proxy (..))
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import Data.Set (Set)
+import qualified Data.Text.Encoding as Text
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+-- ========================================================================
+
+data PoolMetadata = PoolMetadata
+  { _poolMDUrl :: !Url,
+    _poolMDHash :: !ByteString
+  }
+  deriving (Eq, Ord, Generic, Show)
+
+deriving instance NFData PoolMetadata
+
+instance ToJSON PoolMetadata where
+  toJSON pmd =
+    Aeson.object
+      [ "url" .= _poolMDUrl pmd,
+        "hash" .= (Text.decodeLatin1 . B16.encode) (_poolMDHash pmd)
+      ]
+
+instance FromJSON PoolMetadata where
+  parseJSON =
+    Aeson.withObject "PoolMetadata" $ \obj -> do
+      url <- obj .: "url"
+      hash <- explicitParseField parseJsonBase16 obj "hash"
+      return $ PoolMetadata url hash
+
+parseJsonBase16 :: Value -> Parser ByteString
+parseJsonBase16 v = do
+  s <- parseJSON v
+  case B16.decode (Char8.pack s) of
+    Right bs -> return bs
+    Left msg -> fail msg
+
+instance NoThunks PoolMetadata
+
+data StakePoolRelay
+  = -- | One or both of IPv4 & IPv6
+    SingleHostAddr !(StrictMaybe Port) !(StrictMaybe IPv4) !(StrictMaybe IPv6)
+  | -- | An @A@ or @AAAA@ DNS record
+    SingleHostName !(StrictMaybe Port) !DnsName
+  | -- | A @SRV@ DNS record
+    MultiHostName !DnsName
+  deriving (Eq, Ord, Generic, Show)
+
+instance FromJSON StakePoolRelay where
+  parseJSON =
+    Aeson.withObject "Credential" $ \obj ->
+      asum
+        [ explicitParseField parser1 obj "single host address",
+          explicitParseField parser2 obj "single host name",
+          explicitParseField parser3 obj "multi host name"
+        ]
+    where
+      parser1 = Aeson.withObject "SingleHostAddr" $ \obj ->
+        SingleHostAddr
+          <$> obj .:? "port" .!= SNothing
+          <*> obj .:? "IPv4" .!= SNothing
+          <*> obj .:? "IPv6" .!= SNothing
+      parser2 = Aeson.withObject "SingleHostName" $ \obj ->
+        SingleHostName
+          <$> obj .:? "port" .!= SNothing
+          <*> obj .: "dnsName"
+      parser3 = Aeson.withObject "MultiHostName" $ \obj ->
+        MultiHostName
+          <$> obj .: "dnsName"
+
+instance ToJSON StakePoolRelay where
+  toJSON (SingleHostAddr port ipv4 ipv6) =
+    Aeson.object
+      [ "single host address"
+          .= Aeson.object
+            [ "port" .= port,
+              "IPv4" .= ipv4,
+              "IPv6" .= ipv6
+            ]
+      ]
+  toJSON (SingleHostName port dnsName) =
+    Aeson.object
+      [ "single host name"
+          .= Aeson.object
+            [ "port" .= port,
+              "dnsName" .= dnsName
+            ]
+      ]
+  toJSON (MultiHostName dnsName) =
+    Aeson.object
+      [ "multi host name"
+          .= Aeson.object
+            [ "dnsName" .= dnsName
+            ]
+      ]
+
+instance NoThunks StakePoolRelay
+
+instance NFData StakePoolRelay
+
+instance ToCBOR StakePoolRelay where
+  toCBOR (SingleHostAddr p ipv4 ipv6) =
+    encodeListLen 4
+      <> toCBOR (0 :: Word8)
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
+      <> encodeNullMaybe ipv4ToCBOR (strictMaybeToMaybe ipv4)
+      <> encodeNullMaybe ipv6ToCBOR (strictMaybeToMaybe ipv6)
+  toCBOR (SingleHostName p n) =
+    encodeListLen 3
+      <> toCBOR (1 :: Word8)
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
+      <> toCBOR n
+  toCBOR (MultiHostName n) =
+    encodeListLen 2
+      <> toCBOR (2 :: Word8)
+      <> toCBOR n
+
+instance FromCBOR StakePoolRelay where
+  fromCBOR = decodeRecordSum "StakePoolRelay" $
+    \case
+      0 ->
+        (\x y z -> (4, SingleHostAddr x y z))
+          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
+          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
+          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
+      1 ->
+        (\x y -> (3, SingleHostName x y))
+          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
+          <*> fromCBOR
+      2 -> do
+        x <- fromCBOR
+        pure (2, MultiHostName x)
+      k -> invalidKey k
+
+-- | A stake pool.
+data PoolParams crypto = PoolParams
+  { _poolId :: !(KeyHash 'StakePool crypto),
+    _poolVrf :: !(Hash crypto (VerKeyVRF crypto)),
+    _poolPledge :: !Coin,
+    _poolCost :: !Coin,
+    _poolMargin :: !UnitInterval,
+    _poolRAcnt :: !(RewardAcnt crypto),
+    _poolOwners :: !(Set (KeyHash 'Staking crypto)),
+    _poolRelays :: !(StrictSeq StakePoolRelay),
+    _poolMD :: !(StrictMaybe PoolMetadata)
+  }
+  deriving (Show, Generic, Eq, Ord)
+  deriving (ToCBOR) via CBORGroup (PoolParams crypto)
+  deriving (FromCBOR) via CBORGroup (PoolParams crypto)
+
+instance NoThunks (PoolParams crypto)
+
+deriving instance NFData (PoolParams crypto)
+
+instance CC.Crypto crypto => ToJSON (PoolParams crypto) where
+  toJSON pp =
+    Aeson.object
+      [ "publicKey" .= _poolId pp, -- TODO publicKey is an unfortunate name, should be poolId
+        "vrf" .= _poolVrf pp,
+        "pledge" .= _poolPledge pp,
+        "cost" .= _poolCost pp,
+        "margin" .= _poolMargin pp,
+        "rewardAccount" .= _poolRAcnt pp,
+        "owners" .= _poolOwners pp,
+        "relays" .= _poolRelays pp,
+        "metadata" .= _poolMD pp
+      ]
+
+instance CC.Crypto crypto => FromJSON (PoolParams crypto) where
+  parseJSON =
+    Aeson.withObject "PoolParams" $ \obj ->
+      PoolParams
+        <$> obj .: "publicKey" -- TODO publicKey is an unfortunate name, should be poolId
+        <*> obj .: "vrf"
+        <*> obj .: "pledge"
+        <*> obj .: "cost"
+        <*> obj .: "margin"
+        <*> obj .: "rewardAccount"
+        <*> obj .: "owners"
+        <*> obj .: "relays"
+        <*> obj .: "metadata"
+
+instance ToCBOR PoolMetadata where
+  toCBOR (PoolMetadata u h) =
+    encodeListLen 2
+      <> toCBOR u
+      <> toCBOR h
+
+instance FromCBOR PoolMetadata where
+  fromCBOR = do
+    decodeRecordNamed "PoolMetadata" (const 2) (PoolMetadata <$> fromCBOR <*> fromCBOR)
+
+-- | The size of the '_poolOwners' 'Set'.  Only used to compute size of encoded
+-- 'PoolParams'.
+data SizeOfPoolOwners = SizeOfPoolOwners
+
+instance ToCBOR SizeOfPoolOwners where
+  toCBOR = panic "The `SizeOfPoolOwners` type cannot be encoded!"
+
+-- | The size of the '_poolRelays' 'Set'.  Only used to compute size of encoded
+-- 'PoolParams'.
+data SizeOfPoolRelays = SizeOfPoolRelays
+
+instance ToCBOR SizeOfPoolRelays where
+  toCBOR = panic "The `SizeOfPoolRelays` type cannot be encoded!"
+
+instance
+  CC.Crypto crypto =>
+  ToCBORGroup (PoolParams crypto)
+  where
+  toCBORGroup poolParams =
+    toCBOR (_poolId poolParams)
+      <> toCBOR (_poolVrf poolParams)
+      <> toCBOR (_poolPledge poolParams)
+      <> toCBOR (_poolCost poolParams)
+      <> toCBOR (_poolMargin poolParams)
+      <> toCBOR (_poolRAcnt poolParams)
+      <> encodeFoldable (_poolOwners poolParams)
+      <> toCBOR (CborSeq (StrictSeq.fromStrict (_poolRelays poolParams)))
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe (_poolMD poolParams))
+
+  encodedGroupSizeExpr size' proxy =
+    encodedSizeExpr size' (_poolId <$> proxy)
+      + encodedSizeExpr size' (_poolVrf <$> proxy)
+      + encodedSizeExpr size' (_poolPledge <$> proxy)
+      + encodedSizeExpr size' (_poolCost <$> proxy)
+      + encodedSizeExpr size' (_poolMargin <$> proxy)
+      + encodedSizeExpr size' (_poolRAcnt <$> proxy)
+      + 2
+      + poolSize * encodedSizeExpr size' (elementProxy (_poolOwners <$> proxy))
+      + 2
+      + relaySize * encodedSizeExpr size' (elementProxy (_poolRelays <$> proxy))
+      + szCases
+        [ Case "Nothing" 1,
+          Case "Just" $ encodedSizeExpr size' (elementProxy (_poolMD <$> proxy))
+        ]
+    where
+      poolSize, relaySize :: Size
+      poolSize = size' (Proxy @SizeOfPoolOwners)
+      relaySize = size' (Proxy @SizeOfPoolRelays)
+      elementProxy :: Proxy (f a) -> Proxy a
+      elementProxy _ = Proxy
+
+  listLen _ = 9
+  listLenBound _ = 9
+
+instance
+  CC.Crypto crypto =>
+  FromCBORGroup (PoolParams crypto)
+  where
+  fromCBORGroup = do
+    hk <- fromCBOR
+    vrf <- fromCBOR
+    pledge <- fromCBOR
+    cost <- fromCBOR
+    margin <- fromCBOR
+    ra <- fromCBOR
+    owners <- decodeSet fromCBOR
+    relays <- decodeStrictSeq fromCBOR
+    md <- decodeNullMaybe fromCBOR
+    pure $
+      PoolParams
+        { _poolId = hk,
+          _poolVrf = vrf,
+          _poolPledge = pledge,
+          _poolCost = cost,
+          _poolMargin = margin,
+          _poolRAcnt = ra,
+          _poolOwners = owners,
+          _poolRelays = relays,
+          _poolMD = maybeToStrictMaybe md
+        }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -285,11 +285,6 @@ unsafeConstructTxWithBytes b w a bytes = TxConstr (Memo (TxRaw b w a) bytes)
 -- Witnessing
 --------------------------------------------------------------------------------
 
--- | Higher Kinded Data
-type family HKD f a where
-  HKD Identity a = a
-  HKD f a = f a
-
 data WitnessSetHKD f era = WitnessSet'
   { addrWits' :: !(HKD f (Set (WitVKey 'Witness (Crypto era)))),
     scriptWits' :: !(HKD f (Map (ScriptHash (Crypto era)) (Core.Script era))),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -77,16 +77,13 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..))
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Era
+import Cardano.Ledger.HKD (HKD)
 import Cardano.Ledger.Keys
+import Cardano.Ledger.Keys.WitVKey (WitVKey (..), witVKeyHash)
 import Cardano.Ledger.SafeHash (SafeToHash (..))
 import Cardano.Ledger.Shelley.Address.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Shelley.Scripts
-import Cardano.Ledger.Shelley.TxBody
-  ( TxBody (..),
-    TxOut (..),
-    WitVKey (..),
-    witKeyHash,
-  )
+import Cardano.Ledger.Shelley.TxBody (TxBody (..), TxOut (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
@@ -474,11 +471,13 @@ instance
   where
   fromCBOR = decodeWits
 
+-- | This type is only used to preserve the old buggy behavior where signature
+-- was ignored in the `Ord` instance for `WitVKey`s.
 newtype IgnoreSigOrd kr crypto = IgnoreSigOrd {unIgnoreSigOrd :: WitVKey kr crypto}
   deriving (Eq)
 
 instance (Typeable kr, CC.Crypto crypto) => Ord (IgnoreSigOrd kr crypto) where
-  compare (IgnoreSigOrd w1) (IgnoreSigOrd w2) = compare (witKeyHash w1) (witKeyHash w2)
+  compare (IgnoreSigOrd w1) (IgnoreSigOrd w2) = compare (witVKeyHash w1) (witVKeyHash w2)
 
 decodeWits ::
   forall era s.
@@ -564,7 +563,7 @@ validateNativeMultiSigScript ::
 validateNativeMultiSigScript msig tx =
   evalNativeMultiSigScript msig (coerceKeyRole `Set.map` vhks)
   where
-    vhks = Set.map witKeyHash (getField @"addrWits" tx)
+    vhks = Set.map witVKeyHash (getField @"addrWits" tx)
 
 -- | Multi-signature script witness accessor function for Transactions
 txwitsScript ::

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -67,29 +67,17 @@ where
 
 import Cardano.Binary
   ( Annotator (..),
-    Case (..),
     FromCBOR (fromCBOR),
-    Size,
     ToCBOR (..),
     TokenType (TypeMapLen, TypeMapLen64, TypeMapLenIndef),
     decodeWord,
     encodeListLen,
     peekTokenType,
-    szCases,
   )
 import qualified Cardano.Crypto.Hash.Class as HS
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
-import Cardano.Ledger.BaseTypes
-  ( DnsName,
-    Port,
-    StrictMaybe (..),
-    UnitInterval,
-    Url,
-    invalidKey,
-    maybeToStrictMaybe,
-    strictMaybeToMaybe,
-  )
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), Url, invalidKey)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
 import Cardano.Ledger.CompactAddress (CompactAddr, compactAddr, decompactAddr)
 import Cardano.Ledger.Compactible
@@ -107,21 +95,13 @@ import Cardano.Ledger.Keys
 import Cardano.Ledger.Keys.WitVKey
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash)
 import Cardano.Ledger.Serialization
-  ( CBORGroup (..),
-    CborSeq (..),
-    FromCBORGroup (..),
+  ( FromCBORGroup (..),
     ToCBORGroup (..),
-    decodeNullMaybe,
     decodeRecordNamed,
     decodeRecordSum,
     decodeSet,
     decodeStrictSeq,
     encodeFoldable,
-    encodeNullMaybe,
-    ipv4FromCBOR,
-    ipv4ToCBOR,
-    ipv6FromCBOR,
-    ipv6ToCBOR,
     listLenInt,
     mapFromCBOR,
     mapToCBOR,
@@ -129,17 +109,12 @@ import Cardano.Ledger.Serialization
 import Cardano.Ledger.Shelley.Constraints (TransValue)
 import Cardano.Ledger.Shelley.Orphans ()
 import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.PoolParams
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
 import qualified Cardano.Ledger.TxIn as Core
 import Cardano.Ledger.Val (DecodeNonNegative (..))
-import Cardano.Prelude (HeapWords (..), panic)
+import Cardano.Prelude (HeapWords (..))
 import Control.DeepSeq (NFData (rnf))
-import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
-import qualified Data.Aeson as Aeson
-import Data.Aeson.Types (Parser, explicitParseField)
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as BSL
 import Data.ByteString.Short (ShortByteString, pack)
 import Data.Coders
@@ -157,8 +132,6 @@ import Data.Coders
     (!>),
   )
 import Data.Constraint (Constraint)
-import Data.Foldable (asum)
-import Data.IP (IPv4, IPv6)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -170,7 +143,6 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Sharing
-import qualified Data.Text.Encoding as Text
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
@@ -188,152 +160,6 @@ data Delegation crypto = Delegation
 
 instance NoThunks (Delegation crypto)
 
-data PoolMetadata = PoolMetadata
-  { _poolMDUrl :: !Url,
-    _poolMDHash :: !ByteString
-  }
-  deriving (Eq, Ord, Generic, Show)
-
-deriving instance NFData PoolMetadata
-
-instance ToJSON PoolMetadata where
-  toJSON pmd =
-    Aeson.object
-      [ "url" .= _poolMDUrl pmd,
-        "hash" .= (Text.decodeLatin1 . B16.encode) (_poolMDHash pmd)
-      ]
-
-instance FromJSON PoolMetadata where
-  parseJSON =
-    Aeson.withObject "PoolMetadata" $ \obj -> do
-      url <- obj .: "url"
-      hash <- explicitParseField parseJsonBase16 obj "hash"
-      return $ PoolMetadata url hash
-
-parseJsonBase16 :: Value -> Parser ByteString
-parseJsonBase16 v = do
-  s <- parseJSON v
-  case B16.decode (Char8.pack s) of
-    Right bs -> return bs
-    Left msg -> fail msg
-
-instance NoThunks PoolMetadata
-
-data StakePoolRelay
-  = -- | One or both of IPv4 & IPv6
-    SingleHostAddr !(StrictMaybe Port) !(StrictMaybe IPv4) !(StrictMaybe IPv6)
-  | -- | An @A@ or @AAAA@ DNS record
-    SingleHostName !(StrictMaybe Port) !DnsName
-  | -- | A @SRV@ DNS record
-    MultiHostName !DnsName
-  deriving (Eq, Ord, Generic, Show)
-
-instance FromJSON StakePoolRelay where
-  parseJSON =
-    Aeson.withObject "Credential" $ \obj ->
-      asum
-        [ explicitParseField parser1 obj "single host address",
-          explicitParseField parser2 obj "single host name",
-          explicitParseField parser3 obj "multi host name"
-        ]
-    where
-      parser1 = Aeson.withObject "SingleHostAddr" $ \obj ->
-        SingleHostAddr
-          <$> obj .:? "port" .!= SNothing
-          <*> obj .:? "IPv4" .!= SNothing
-          <*> obj .:? "IPv6" .!= SNothing
-      parser2 = Aeson.withObject "SingleHostName" $ \obj ->
-        SingleHostName
-          <$> obj .:? "port" .!= SNothing
-          <*> obj .: "dnsName"
-      parser3 = Aeson.withObject "MultiHostName" $ \obj ->
-        MultiHostName
-          <$> obj .: "dnsName"
-
-instance ToJSON StakePoolRelay where
-  toJSON (SingleHostAddr port ipv4 ipv6) =
-    Aeson.object
-      [ "single host address"
-          .= Aeson.object
-            [ "port" .= port,
-              "IPv4" .= ipv4,
-              "IPv6" .= ipv6
-            ]
-      ]
-  toJSON (SingleHostName port dnsName) =
-    Aeson.object
-      [ "single host name"
-          .= Aeson.object
-            [ "port" .= port,
-              "dnsName" .= dnsName
-            ]
-      ]
-  toJSON (MultiHostName dnsName) =
-    Aeson.object
-      [ "multi host name"
-          .= Aeson.object
-            [ "dnsName" .= dnsName
-            ]
-      ]
-
-instance NoThunks StakePoolRelay
-
-instance NFData StakePoolRelay
-
-instance ToCBOR StakePoolRelay where
-  toCBOR (SingleHostAddr p ipv4 ipv6) =
-    encodeListLen 4
-      <> toCBOR (0 :: Word8)
-      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
-      <> encodeNullMaybe ipv4ToCBOR (strictMaybeToMaybe ipv4)
-      <> encodeNullMaybe ipv6ToCBOR (strictMaybeToMaybe ipv6)
-  toCBOR (SingleHostName p n) =
-    encodeListLen 3
-      <> toCBOR (1 :: Word8)
-      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
-      <> toCBOR n
-  toCBOR (MultiHostName n) =
-    encodeListLen 2
-      <> toCBOR (2 :: Word8)
-      <> toCBOR n
-
-instance FromCBOR StakePoolRelay where
-  fromCBOR = decodeRecordSum "StakePoolRelay" $
-    \case
-      0 ->
-        (\x y z -> (4, SingleHostAddr x y z))
-          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
-          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
-          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
-      1 ->
-        (\x y -> (3, SingleHostName x y))
-          <$> (maybeToStrictMaybe <$> decodeNullMaybe fromCBOR)
-          <*> fromCBOR
-      2 -> do
-        x <- fromCBOR
-        pure (2, MultiHostName x)
-      k -> invalidKey k
-
--- | A stake pool.
-data PoolParams crypto = PoolParams
-  { _poolId :: !(KeyHash 'StakePool crypto),
-    _poolVrf :: !(Hash crypto (VerKeyVRF crypto)),
-    _poolPledge :: !Coin,
-    _poolCost :: !Coin,
-    _poolMargin :: !UnitInterval,
-    _poolRAcnt :: !(RewardAcnt crypto),
-    _poolOwners :: !(Set (KeyHash 'Staking crypto)),
-    _poolRelays :: !(StrictSeq StakePoolRelay),
-    _poolMD :: !(StrictMaybe PoolMetadata)
-  }
-  deriving (Show, Generic, Eq, Ord)
-  deriving (ToCBOR) via CBORGroup (PoolParams crypto)
-  deriving (FromCBOR) via CBORGroup (PoolParams crypto)
-
-instance NoThunks (PoolParams crypto)
-
-deriving instance NFData (PoolParams crypto)
-
 newtype Wdrl crypto = Wdrl {unWdrl :: Map (RewardAcnt crypto) Coin}
   deriving (Show, Eq, Generic)
   deriving newtype (NoThunks, NFData)
@@ -343,34 +169,6 @@ instance CC.Crypto crypto => ToCBOR (Wdrl crypto) where
 
 instance CC.Crypto crypto => FromCBOR (Wdrl crypto) where
   fromCBOR = Wdrl <$> mapFromCBOR
-
-instance CC.Crypto crypto => ToJSON (PoolParams crypto) where
-  toJSON pp =
-    Aeson.object
-      [ "publicKey" .= _poolId pp, -- TODO publicKey is an unfortunate name, should be poolId
-        "vrf" .= _poolVrf pp,
-        "pledge" .= _poolPledge pp,
-        "cost" .= _poolCost pp,
-        "margin" .= _poolMargin pp,
-        "rewardAccount" .= _poolRAcnt pp,
-        "owners" .= _poolOwners pp,
-        "relays" .= _poolRelays pp,
-        "metadata" .= _poolMD pp
-      ]
-
-instance CC.Crypto crypto => FromJSON (PoolParams crypto) where
-  parseJSON =
-    Aeson.withObject "PoolParams" $ \obj ->
-      PoolParams
-        <$> obj .: "publicKey" -- TODO publicKey is an unfortunate name, should be poolId
-        <*> obj .: "vrf"
-        <*> obj .: "pledge"
-        <*> obj .: "cost"
-        <*> obj .: "margin"
-        <*> obj .: "rewardAccount"
-        <*> obj .: "owners"
-        <*> obj .: "relays"
-        <*> obj .: "metadata"
 
 type TransTxId (c :: Type -> Constraint) era =
   -- Transaction Ids are the hash of a transaction body, which contains
@@ -899,97 +697,6 @@ instance
       cAddr <- fromCBOR
       coin <- decodeNonNegative
       pure $ TxOutCompact cAddr coin
-
-instance ToCBOR PoolMetadata where
-  toCBOR (PoolMetadata u h) =
-    encodeListLen 2
-      <> toCBOR u
-      <> toCBOR h
-
-instance FromCBOR PoolMetadata where
-  fromCBOR = do
-    decodeRecordNamed "PoolMetadata" (const 2) (PoolMetadata <$> fromCBOR <*> fromCBOR)
-
--- | The size of the '_poolOwners' 'Set'.  Only used to compute size of encoded
--- 'PoolParams'.
-data SizeOfPoolOwners = SizeOfPoolOwners
-
-instance ToCBOR SizeOfPoolOwners where
-  toCBOR = panic "The `SizeOfPoolOwners` type cannot be encoded!"
-
--- | The size of the '_poolRelays' 'Set'.  Only used to compute size of encoded
--- 'PoolParams'.
-data SizeOfPoolRelays = SizeOfPoolRelays
-
-instance ToCBOR SizeOfPoolRelays where
-  toCBOR = panic "The `SizeOfPoolRelays` type cannot be encoded!"
-
-instance
-  CC.Crypto crypto =>
-  ToCBORGroup (PoolParams crypto)
-  where
-  toCBORGroup poolParams =
-    toCBOR (_poolId poolParams)
-      <> toCBOR (_poolVrf poolParams)
-      <> toCBOR (_poolPledge poolParams)
-      <> toCBOR (_poolCost poolParams)
-      <> toCBOR (_poolMargin poolParams)
-      <> toCBOR (_poolRAcnt poolParams)
-      <> encodeFoldable (_poolOwners poolParams)
-      <> toCBOR (CborSeq (StrictSeq.fromStrict (_poolRelays poolParams)))
-      <> encodeNullMaybe toCBOR (strictMaybeToMaybe (_poolMD poolParams))
-
-  encodedGroupSizeExpr size' proxy =
-    encodedSizeExpr size' (_poolId <$> proxy)
-      + encodedSizeExpr size' (_poolVrf <$> proxy)
-      + encodedSizeExpr size' (_poolPledge <$> proxy)
-      + encodedSizeExpr size' (_poolCost <$> proxy)
-      + encodedSizeExpr size' (_poolMargin <$> proxy)
-      + encodedSizeExpr size' (_poolRAcnt <$> proxy)
-      + 2
-      + poolSize * encodedSizeExpr size' (elementProxy (_poolOwners <$> proxy))
-      + 2
-      + relaySize * encodedSizeExpr size' (elementProxy (_poolRelays <$> proxy))
-      + szCases
-        [ Case "Nothing" 1,
-          Case "Just" $ encodedSizeExpr size' (elementProxy (_poolMD <$> proxy))
-        ]
-    where
-      poolSize, relaySize :: Size
-      poolSize = size' (Proxy @SizeOfPoolOwners)
-      relaySize = size' (Proxy @SizeOfPoolRelays)
-      elementProxy :: Proxy (f a) -> Proxy a
-      elementProxy _ = Proxy
-
-  listLen _ = 9
-  listLenBound _ = 9
-
-instance
-  CC.Crypto crypto =>
-  FromCBORGroup (PoolParams crypto)
-  where
-  fromCBORGroup = do
-    hk <- fromCBOR
-    vrf <- fromCBOR
-    pledge <- fromCBOR
-    cost <- fromCBOR
-    margin <- fromCBOR
-    ra <- fromCBOR
-    owners <- decodeSet fromCBOR
-    relays <- decodeStrictSeq fromCBOR
-    md <- decodeNullMaybe fromCBOR
-    pure $
-      PoolParams
-        { _poolId = hk,
-          _poolVrf = vrf,
-          _poolPledge = pledge,
-          _poolCost = cost,
-          _poolMargin = margin,
-          _poolRAcnt = ra,
-          _poolOwners = owners,
-          _poolRelays = relays,
-          _poolMD = maybeToStrictMaybe md
-        }
 
 witKeyHash :: WitVKey kr crypto -> KeyHash 'Witness crypto
 witKeyHash = witVKeyHash

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -99,13 +99,13 @@ import Cardano.Ledger.Credential (Credential (..), Ptr (..), StakeCredential)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era
 import Cardano.Ledger.Hashes (EraIndependentTxBody, ScriptHash)
-import Cardano.Ledger.Keys.WitVKey
 import Cardano.Ledger.Keys
   ( Hash,
     KeyHash (..),
     KeyRole (..),
     VerKeyVRF,
   )
+import Cardano.Ledger.Keys.WitVKey
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash)
 import Cardano.Ledger.Serialization
   ( CBORGroup (..),
@@ -1018,8 +1018,6 @@ instance
           _poolRelays = relays,
           _poolMD = maybeToStrictMaybe md
         }
-
-
 
 witKeyHash :: WitVKey kr crypto -> KeyHash 'Witness crypto
 witKeyHash = witVKeyHash

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -33,7 +33,6 @@ module Cardano.Ledger.Shelley.TxBody
     PoolParams (..),
     Ptr (..),
     RewardAcnt (..),
-    StakeCreds (..),
     StakePoolRelay (..),
     TxBody
       ( TxBody,
@@ -135,7 +134,6 @@ import qualified Cardano.Ledger.TxIn as Core
 import Cardano.Ledger.Val (DecodeNonNegative (..))
 import Cardano.Prelude (HeapWords (..), panic)
 import Control.DeepSeq (NFData (rnf))
-import Control.SetAlgebra (BaseRep (MapR), Embed (..), Exp (Base), HasExp (toExp))
 import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Parser, explicitParseField)
@@ -177,20 +175,9 @@ import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import GHC.Records
-import NoThunks.Class
-  ( InspectHeapNamed (..),
-    NoThunks (..),
-  )
-import Quiet
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ========================================================================
-
-instance HasExp (StakeCreds era) (Map (Credential 'Staking era) SlotNo) where
-  toExp (StakeCreds x) = Base MapR x
-
-instance Embed (StakeCreds era) (Map (Credential 'Staking era) SlotNo) where
-  toBase (StakeCreds x) = x
-  fromBase x = StakeCreds x
 
 -- | The delegation of one stake key to another.
 data Delegation crypto = Delegation
@@ -806,21 +793,6 @@ instance
   getField (TxBodyConstr (Memo m _)) = getField @"_inputsX" m
 
 -- ===============================================================
-
-newtype StakeCreds crypto = StakeCreds
-  { unStakeCreds :: Map (Credential 'Staking crypto) SlotNo
-  }
-  deriving (Eq, Generic)
-  deriving (Show) via (Quiet (StakeCreds crypto))
-  deriving newtype (NFData, NoThunks, ToJSON, FromJSON)
-
-deriving newtype instance
-  CC.Crypto crypto =>
-  FromCBOR (StakeCreds crypto)
-
-deriving newtype instance
-  CC.Crypto crypto =>
-  ToCBOR (StakeCreds crypto)
 
 -- CBOR
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -845,7 +845,7 @@ requiredMSigSignaturesSubset SourceSignalTarget {source = chainSt, signal = bloc
       any (\kl -> Set.fromList kl `Set.isSubsetOf` keyHashes) (scriptKeyCombinations (Proxy @era) msig)
     keyHashSet :: Core.Tx era -> Set (KeyHash 'Witness (Crypto era))
     keyHashSet tx_ =
-      Set.map witKeyHash (getField @"addrWits" . getField @"wits" $ tx_)
+      Set.map witVKeyHash (getField @"addrWits" . getField @"wits" $ tx_)
 
 --- | Check for absence of double spend in a block
 noDoubleSpend ::

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -55,6 +55,7 @@ library
     Cardano.Ledger.Era
     Cardano.Ledger.Hashes
     Cardano.Ledger.Keys
+    Cardano.Ledger.Keys.WitVKey
     Cardano.Ledger.PoolDistr
     Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.SafeHash

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -54,6 +54,7 @@ library
     Cardano.Ledger.Crypto
     Cardano.Ledger.Era
     Cardano.Ledger.Hashes
+    Cardano.Ledger.HKD
     Cardano.Ledger.Keys
     Cardano.Ledger.Keys.WitVKey
     Cardano.Ledger.PoolDistr

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/HKD.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/HKD.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module contains just the type of protocol parameters.
+module Cardano.Ledger.HKD
+  ( HKD,
+    HKDFunctor (..),
+  )
+where
+
+import Data.Functor.Identity (Identity)
+import Data.Maybe.Strict (StrictMaybe (..))
+
+-- ====================================================================
+
+-- | Higher Kinded Data
+type family HKD f a where
+  HKD Identity a = a
+  HKD f a = f a
+
+class HKDFunctor f where
+  hkdMap :: proxy f -> (a -> b) -> HKD f a -> HKD f b
+
+instance HKDFunctor Identity where
+  hkdMap _ f a = f a
+
+instance HKDFunctor Maybe where
+  hkdMap _ f = fmap f
+
+instance HKDFunctor StrictMaybe where
+  hkdMap _ f = fmap f

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Keys.WitVKey
+  ( WitVKey (WitVKey),
+    witVKeyBytes,
+    witVKeyHash,
+  )
+where
+
+import Cardano.Binary
+  ( Annotator (..),
+    FromCBOR (fromCBOR),
+    ToCBOR (..),
+    annotatorSlice,
+    encodeListLen,
+    encodePreEncoded,
+    serializeEncoding,
+  )
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Hashes (EraIndependentTxBody)
+import Cardano.Ledger.Keys
+  ( Hash,
+    KeyHash (..),
+    KeyRole (..),
+    SignedDSIGN,
+    VKey,
+    asWitness,
+    decodeSignedDSIGN,
+    encodeSignedDSIGN,
+    hashKey,
+    hashSignature,
+  )
+import Cardano.Ledger.Serialization (decodeRecordNamed)
+import Control.DeepSeq
+import qualified Data.ByteString.Lazy as BSL
+import Data.Ord (comparing)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
+
+-- | Proof/Witness that a transaction is authorized by the given key holder.
+data WitVKey kr crypto = WitVKeyInternal
+  { wvkKey :: !(VKey kr crypto),
+    wvkSig :: !(SignedDSIGN crypto (Hash crypto EraIndependentTxBody)),
+    -- | Hash of the witness vkey. We store this here to avoid repeated hashing
+    --   when used in ordering.
+    wvkKeyHash :: KeyHash 'Witness crypto,
+    wvkBytes :: BSL.ByteString
+  }
+  deriving (Generic)
+
+deriving instance Crypto crypto => Show (WitVKey kr crypto)
+
+deriving instance Crypto crypto => Eq (WitVKey kr crypto)
+
+deriving via
+  AllowThunksIn '["wvkBytes", "wvkKeyHash"] (WitVKey kr crypto)
+  instance
+    (Crypto crypto, Typeable kr) => NoThunks (WitVKey kr crypto)
+
+instance NFData (WitVKey kr crypto) where
+  rnf WitVKeyInternal {wvkKeyHash, wvkBytes} = wvkKeyHash `deepseq` rnf wvkBytes
+
+instance (Typeable kr, Crypto crypto) => Ord (WitVKey kr crypto) where
+  compare x y =
+    -- It is advised against comparison on keys and signatures directly,
+    -- therefore we use hashes of verification keys and signatures for
+    -- implementing this Ord instance. Note that we do not need to memoize the
+    -- hash of a signature, like it is done with the hash of a key, because Ord
+    -- instance is only used for Sets of WitVKeys and it would be a mistake to
+    -- have two WitVKeys in a same Set for different transactions. Therefore
+    -- comparison on signatures is unlikely to happen and is only needed for
+    -- compliance with Ord laws.
+    comparing wvkKeyHash x y <> comparing (hashSignature @crypto . wvkSig) x y
+
+instance (Typeable kr, Crypto crypto) => ToCBOR (WitVKey kr crypto) where
+  toCBOR = encodePreEncoded . BSL.toStrict . wvkBytes
+
+instance (Typeable kr, Crypto crypto) => FromCBOR (Annotator (WitVKey kr crypto)) where
+  fromCBOR =
+    annotatorSlice $
+      decodeRecordNamed "WitVKey" (const 2) $
+        fmap pure $
+          mkWitVKey <$> fromCBOR <*> decodeSignedDSIGN
+    where
+      mkWitVKey k sig = WitVKeyInternal k sig (asWitness $ hashKey k)
+
+pattern WitVKey ::
+  (Typeable kr, Crypto crypto) =>
+  VKey kr crypto ->
+  SignedDSIGN crypto (Hash crypto EraIndependentTxBody) ->
+  WitVKey kr crypto
+pattern WitVKey k s <-
+  WitVKeyInternal k s _ _
+  where
+    WitVKey k s =
+      let bytes =
+            serializeEncoding $
+              encodeListLen 2
+                <> toCBOR k
+                <> encodeSignedDSIGN s
+          hash = asWitness $ hashKey k
+       in WitVKeyInternal k s hash bytes
+
+{-# COMPLETE WitVKey #-}
+
+-- | Acess computed hash. Evaluated lazily
+witVKeyHash :: WitVKey kr crypto -> KeyHash 'Witness crypto
+witVKeyHash = wvkKeyHash
+
+-- | Access CBOR encoded representation of the witness. Evaluated lazily
+witVKeyBytes :: WitVKey kr crypto -> BSL.ByteString
+witVKeyBytes = wvkBytes

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -141,7 +141,6 @@ import Cardano.Ledger.Shelley.TxBody
     PoolCert (..),
     PoolMetadata (..),
     PoolParams (..),
-    StakeCreds (..),
     StakePoolRelay (..),
     TxBody (..),
     TxBodyRaw (..),
@@ -1107,9 +1106,6 @@ ppTxBody (TxBodyConstr (Memo (TxBodyRaw ins outs cs wdrls fee ttl upd mdh) _)) =
 ppWitVKey :: (Typeable kr, Crypto c) => WitVKey kr c -> PDoc
 ppWitVKey (WitVKey key sig) = ppRecord "WitVKey" [("key", ppVKey key), ("signature", ppSignedDSIGN sig)]
 
-ppStakeCreds :: StakeCreds c -> PDoc
-ppStakeCreds (StakeCreds m) = ppSexp "" [ppMap' (text "StakeCreds") ppCredential ppSlotNo m]
-
 instance PrettyA (Delegation c) where
   prettyA = ppDelegation
 
@@ -1160,9 +1156,6 @@ instance
 
 instance (Typeable kr, Crypto c) => PrettyA (WitVKey kr c) where
   prettyA = ppWitVKey
-
-instance Crypto c => PrettyA (StakeCreds c) where
-  prettyA = ppStakeCreds
 
 -- ===========================================
 -- Data.IP


### PR DESCRIPTION
* Move `WitVKey` into its own module in `cardano-ledger-core`. Make `wvkKeyHash` lazy.
* Moved `HKD` into `cardano-ledger-core`
* Cleanup dead code: remove unused `StakeCreds`
* Move `PoolParams` into their own module
* Move all `DCert` related functionality from `TxBody` module

See individual commit messages for more info.