### PR TITLE
Remove dependency on cardano-prelude (except byron) 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -43,14 +43,15 @@ test-show-details: streaming
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 631cb6cf1fa01ab346233b610a38b3b4cba6e6ab
-  --sha256: 0944wg2nqazmhlmsynwgdwxxj6ay0hb9qig9l128isb2cjia0hlp
+  tag: 278e71d44ad2a347992449a08e5de72a6672c0d7
+  --sha256: 0d71pxh4i35r5l6nncdd8vcyad619p2ys3qwa8yc7pfhl0pqslh3
   subdir:
     base-deriving-via
     binary
     binary/test
     cardano-crypto-class
     cardano-crypto-praos
+    heapwords
     measures
     slotting
     strict-containers
@@ -79,8 +80,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 8ab4c3355c5fdf67dcf6acc1f5a14668d5e6f0a9
-  --sha256: coD/Kpl7tutwXb6ukQCH5XojBjquYkW7ob0BWZtdpok=
+  tag: 0264c65ae275e51cc73f049254bed5c2b5c79ed0
+  --sha256: 0ay4ljcmrkh2zsnvpz8kbxj19g30gq1wcasmscflqxa437dz21xv
   subdir:
     plutus-ledger-api
     plutus-tx

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -69,7 +69,6 @@ library
     cardano-crypto-class,
     cardano-ledger-core,
     cardano-ledger-shelley-ma,
-    cardano-prelude,
     cardano-slotting,
     containers,
     data-default,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -54,6 +54,7 @@ import Cardano.Binary
     withSlice,
   )
 import Cardano.Crypto.Hash.Class (HashAlgorithm)
+import Cardano.HeapWords (HeapWords (..), heapWords0, heapWords1)
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), validScript)

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -102,7 +102,6 @@ library
     cardano-data,
     cardano-ledger-byron,
     cardano-ledger-core,
-    cardano-prelude,
     cardano-slotting,
     cborg,
     vector-map,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
@@ -61,7 +61,6 @@ import Cardano.Ledger.Serialization
     ipv6ToCBOR,
   )
 import Cardano.Ledger.Shelley.Orphans ()
-import Cardano.Prelude (panic)
 import Control.DeepSeq (NFData ())
 import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
@@ -271,14 +270,14 @@ instance FromCBOR PoolMetadata where
 data SizeOfPoolOwners = SizeOfPoolOwners
 
 instance ToCBOR SizeOfPoolOwners where
-  toCBOR = panic "The `SizeOfPoolOwners` type cannot be encoded!"
+  toCBOR = error "The `SizeOfPoolOwners` type cannot be encoded!"
 
 -- | The size of the '_poolRelays' 'Set'.  Only used to compute size of encoded
 -- 'PoolParams'.
 data SizeOfPoolRelays = SizeOfPoolRelays
 
 instance ToCBOR SizeOfPoolRelays where
-  toCBOR = panic "The `SizeOfPoolRelays` type cannot be encoded!"
+  toCBOR = error "The `SizeOfPoolRelays` type cannot be encoded!"
 
 instance
   CC.Crypto crypto =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -72,6 +72,7 @@ import Cardano.Binary
     encodeListLen,
   )
 import qualified Cardano.Crypto.Hash.Class as HS
+import Cardano.HeapWords (HeapWords (..))
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), Url)
@@ -109,7 +110,6 @@ import Cardano.Ledger.Shelley.PoolParams
 import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val (DecodeNonNegative (..))
-import Cardano.Prelude (HeapWords (..))
 import Control.DeepSeq (NFData (rnf))
 import qualified Data.ByteString.Lazy as BSL
 import Data.ByteString.Short (ShortByteString, pack)

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -80,7 +80,6 @@ library
     cardano-crypto-wrapper,
     cardano-data,
     cardano-ledger-byron,
-    cardano-prelude,
     cardano-slotting,
     containers,
     data-default-class,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -87,7 +87,6 @@ import Cardano.Ledger.Keys
     hashKey,
   )
 import Cardano.Ledger.Slot (SlotNo (..))
-import Cardano.Prelude (panic)
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
@@ -495,6 +494,6 @@ bootstrapKeyHash (BootstrapAddress byronAddress) =
   let root = Byron.addrRoot byronAddress
       bytes = Byron.abstractHashToBytes root
       !hash =
-        fromMaybe (panic "bootstrapKeyHash: incorrect hash length") $
+        fromMaybe (error "bootstrapKeyHash: incorrect hash length") $
           Hash.hashFromBytes bytes
    in KeyHash hash

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -22,8 +22,8 @@ module Cardano.Ledger.Coin
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.HeapWords (HeapWords)
 import Cardano.Ledger.Compactible
-import Cardano.Prelude (HeapWords)
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Group (Abelian, Group (..))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -66,7 +66,6 @@ import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Hashes (ScriptHash (..))
 import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Slot (SlotNo (..))
-import Cardano.Prelude (panic)
 import Control.DeepSeq (NFData)
 import Control.Monad (ap, guard, unless, when)
 import qualified Control.Monad.Fail
@@ -112,7 +111,7 @@ decompactAddrOld short = snd . unwrap "CompactAddr" $ runGetShort getShortAddr 0
     -- is using a CompactAddr, which can only be constructed using compactAddr.
     -- compactAddr serializes an Addr, so this is guaranteed to work.
     unwrap :: forall a. Text -> Maybe a -> a
-    unwrap name = fromMaybe (panic $ "Impossible failure when decoding " <> name)
+    unwrap name = fromMaybe (error $ "Impossible failure when decoding " <> name)
 {-# NOINLINE decompactAddrOld #-}
 
 ------------------------------------------------------------------------------------------
@@ -594,7 +593,7 @@ decompactAddrLazy (UnsafeCompactAddr bytes) =
     -- is using a CompactAddr, which can only be constructed using compactAddr.
     -- compactAddr serializes an Addr, so this is guaranteed to work.
     unwrap :: forall a. Text -> Maybe a -> a
-    unwrap name = fromMaybe (panic $ "Impossible failure when decoding " <> name)
+    unwrap name = fromMaybe (error $ "Impossible failure when decoding " <> name)
     header = run "address header" 0 bytes getWord
     addrNetId =
       unwrap "address network id" $

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -56,7 +56,6 @@ import Cardano.Ledger.Keys
   )
 import qualified Cardano.Ledger.Keys as Keys
 import Cardano.Ledger.Serialization (decodeRecordNamed)
-import Cardano.Prelude (panic)
 import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
@@ -185,7 +184,7 @@ unpackByronVKey
     -- This maybe is produced by a check that the length of the public key
     -- is the correct one. (32 bytes). If the XPub was constructed correctly,
     -- we already know that it has this length.
-    Nothing -> panic "unpackByronVKey: impossible!"
+    Nothing -> error "unpackByronVKey: impossible!"
     Just vk -> (VKey vk, ChainCode chainCodeBytes)
 
 verifyBootstrapWit ::
@@ -204,7 +203,7 @@ verifyBootstrapWit txbodyHash witness =
 
 coerceSignature :: WC.XSignature -> DSIGN.SigDSIGN DSIGN.Ed25519DSIGN
 coerceSignature sig =
-  fromMaybe (panic "coerceSignature: impossible! signature size mismatch") $
+  fromMaybe (error "coerceSignature: impossible! signature size mismatch") $
     DSIGN.rawDeserialiseSigDSIGN (WC.unXSignature sig)
 
 makeBootstrapWitness ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
@@ -58,8 +58,8 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Crypto.Hash as Hash
+import Cardano.HeapWords (HeapWords (..))
 import qualified Cardano.Ledger.Crypto as CC
-import Cardano.Prelude (HeapWords (..))
 import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString, fromShort)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -27,6 +27,8 @@ import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (..), encodeListLen)
 import Cardano.Ledger.BaseTypes (TxIx (..), mkTxIxPartial)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
+import Cardano.HeapWords (HeapWords (..))
+import qualified Cardano.HeapWords as HW
 import Cardano.Ledger.SafeHash (SafeHash)
 import Cardano.Ledger.Serialization (decodeRecordNamed)
 import Cardano.Prelude (HeapWords (..))


### PR DESCRIPTION
This removes the last remaining references to cardano-prelude (excluding byron), namely: 
  * HeapWords (usage from cardano-prelude replaced with that from cardano-base)
  * panic  

Because of the depedency on cardano-base, this PR depends on the merging of this one: https://github.com/input-output-hk/cardano-base/pull/280.  After the latter is merged, we have to update [cabal.project ](https://github.com/input-output-hk/cardano-ledger/blob/td/remove-cardano-prelude/cabal.project#L44)  with the corresponding tag and sha256  on this branch, before merging this PR. 

closes #1676