### PR TITLE
Added tests for thunks in MockChainState

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -225,13 +225,10 @@ deriving stock instance
   Eq (UtxoPredicateFailure era)
 
 instance
-  ( Era era,
-    ToCBOR (Core.Value era),
-    ToCBOR (Core.TxOut era),
-    ToCBOR (Core.TxBody era),
-    NoThunks (Core.Value era),
-    NoThunks (Core.TxOut era),
-    NoThunks (PredicateFailure (Core.EraRule "UTXOS" era))
+  ( NoThunks (Core.Value era),
+    NoThunks (UTxO era),
+    NoThunks (PredicateFailure (Core.EraRule "UTXOS" era)),
+    NoThunks (Core.TxOut era)
   ) =>
   NoThunks (UtxoPredicateFailure era)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -87,7 +87,7 @@ import Data.Text (Text)
 import Data.Typeable (Proxy (..), Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..), AllowThunksIn(..))
+import NoThunks.Class (AllowThunksIn (..), InspectHeapNamed (..), NoThunks (..))
 import Numeric.Natural (Natural)
 import Plutus.V1.Ledger.Api as PV1 hiding (Map, Script)
 import Plutus.V2.Ledger.Api as PV2 (costModelParamNames, mkEvaluationContext)
@@ -203,10 +203,10 @@ pointWiseExUnits oper (ExUnits m1 s1) (ExUnits m2 s2) = (m1 `oper` m2) && (s1 `o
 -- cost model parameters (ie the `Map` `Text` `Integer`) and that
 -- this type uses the smart constructor `mkCostModel`
 -- to hide the evaluation context.
-data CostModel = CostModel 
-  { cmLanguage :: !Language 
-  , cmMap      :: !(Map Text Integer) 
-  , cmEvalCtx  :: !PV1.EvaluationContext
+data CostModel = CostModel
+  { cmLanguage :: !Language,
+    cmMap :: !(Map Text Integer),
+    cmEvalCtx :: !PV1.EvaluationContext
   }
   deriving (Generic)
 
@@ -247,8 +247,8 @@ deriving via
   instance
     NoThunks PV1.EvaluationContext
 
---instance NoThunks CostModel
--- Temporarily ignore thunks in the evaluation context until the plutus version 
+-- instance NoThunks CostModel
+-- Temporarily ignore thunks in the evaluation context until the plutus version
 -- is bumped
 deriving via AllowThunksIn '["cmEvalCtx"] CostModel instance NoThunks CostModel
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -87,7 +87,7 @@ import Data.Text (Text)
 import Data.Typeable (Proxy (..), Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..), AllowThunksIn(..))
 import Numeric.Natural (Natural)
 import Plutus.V1.Ledger.Api as PV1 hiding (Map, Script)
 import Plutus.V2.Ledger.Api as PV2 (costModelParamNames, mkEvaluationContext)
@@ -203,7 +203,11 @@ pointWiseExUnits oper (ExUnits m1 s1) (ExUnits m2 s2) = (m1 `oper` m2) && (s1 `o
 -- cost model parameters (ie the `Map` `Text` `Integer`) and that
 -- this type uses the smart constructor `mkCostModel`
 -- to hide the evaluation context.
-data CostModel = CostModel !Language !(Map Text Integer) !PV1.EvaluationContext
+data CostModel = CostModel 
+  { cmLanguage :: !Language 
+  , cmMap      :: !(Map Text Integer) 
+  , cmEvalCtx  :: !PV1.EvaluationContext
+  }
   deriving (Generic)
 
 -- | Note that this Eq instance ignores the evaluation context, which is
@@ -243,7 +247,10 @@ deriving via
   instance
     NoThunks PV1.EvaluationContext
 
-instance NoThunks CostModel
+--instance NoThunks CostModel
+-- Temporarily ignore thunks in the evaluation context until the plutus version 
+-- is bumped
+deriving via AllowThunksIn '["cmEvalCtx"] CostModel instance NoThunks CostModel
 
 instance NFData CostModel where
   rnf (CostModel lang cm ectx) = lang `deepseq` cm `deepseq` rnf ectx

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -247,7 +247,6 @@ deriving via
   instance
     NoThunks PV1.EvaluationContext
 
--- instance NoThunks CostModel
 -- Temporarily ignore thunks in the evaluation context until the plutus version
 -- is bumped
 deriving via AllowThunksIn '["cmEvalCtx"] CostModel instance NoThunks CostModel

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -15,8 +15,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Needed for (NoThunks PV1.EvaluationContext)
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Ledger.Alonzo.Scripts
   ( Tag (..),
@@ -237,15 +235,6 @@ instance SafeToHash CostModel where
 -- rather than a HashAnotated instance.
 
 instance HashWithCrypto CostModel CostModel
-
--- | It would be preferable to have a proper NoThunks instance for
--- EvaluationContext in the Plutus repository, but we can use this
--- workaround in the meantime.
--- See https://github.com/input-output-hk/plutus/issues/4687
-deriving via
-  InspectHeapNamed "PV1.EvaluationContext" PV1.EvaluationContext
-  instance
-    NoThunks PV1.EvaluationContext
 
 -- Temporarily ignore thunks in the evaluation context until the plutus version
 -- is bumped

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -427,13 +427,13 @@ instance
         <! From
         <! From
 
-instance 
-  ( Era era
-  , NoThunks (BlocksMade (Crypto era))
-  , NoThunks (EpochState era)
-  , NoThunks (PulsingRewUpdate (Crypto era))
-  , NoThunks (StashedAVVMAddresses era)
-  ) => 
+instance
+  ( Era era,
+    NoThunks (BlocksMade (Crypto era)),
+    NoThunks (EpochState era),
+    NoThunks (PulsingRewUpdate (Crypto era)),
+    NoThunks (StashedAVVMAddresses era)
+  ) =>
   NoThunks (NewEpochState era)
 
 -- | The state associated with a 'Ledger'.
@@ -459,12 +459,13 @@ deriving stock instance
   ) =>
   Eq (LedgerState era)
 
-instance 
+instance
   ( Era era,
     NoThunks (UTxO era),
     NoThunks (State (Core.EraRule "PPUP" era)),
     NoThunks (Core.Value era)
-  ) => NoThunks (LedgerState era)
+  ) =>
+  NoThunks (LedgerState era)
 
 instance
   ( Era era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -289,13 +289,9 @@ deriving stock instance
   Eq (UTxOState era)
 
 instance
-  ( Era era,
-    NoThunks (Core.TxOut era),
+  ( NoThunks (UTxO era),
     NoThunks (State (Core.EraRule "PPUP" era)),
-    NoThunks (Core.Value era),
-    ToCBOR (Core.TxBody era),
-    ToCBOR (Core.TxOut era),
-    ToCBOR (Core.Value era)
+    NoThunks (Core.Value era)
   ) =>
   NoThunks (UTxOState era)
 
@@ -392,19 +388,6 @@ instance
 
 instance
   ( Era era,
-    NoThunks (Core.TxOut era),
-    NoThunks (Core.PParams era),
-    NoThunks (State (Core.EraRule "PPUP" era)),
-    NoThunks (Core.Value era),
-    NoThunks (StashedAVVMAddresses era),
-    ToCBOR (Core.TxBody era),
-    ToCBOR (Core.TxOut era),
-    ToCBOR (Core.Value era)
-  ) =>
-  NoThunks (NewEpochState era)
-
-instance
-  ( Era era,
     ToCBOR (Core.TxOut era),
     ToCBOR (Core.PParams era),
     ToCBOR (State (Core.EraRule "PPUP" era)),
@@ -444,6 +427,15 @@ instance
         <! From
         <! From
 
+instance 
+  ( Era era
+  , NoThunks (BlocksMade (Crypto era))
+  , NoThunks (EpochState era)
+  , NoThunks (PulsingRewUpdate (Crypto era))
+  , NoThunks (StashedAVVMAddresses era)
+  ) => 
+  NoThunks (NewEpochState era)
+
 -- | The state associated with a 'Ledger'.
 data LedgerState era = LedgerState
   { -- | The current unspent transaction outputs.
@@ -467,16 +459,12 @@ deriving stock instance
   ) =>
   Eq (LedgerState era)
 
-instance
+instance 
   ( Era era,
-    NoThunks (Core.TxOut era),
+    NoThunks (UTxO era),
     NoThunks (State (Core.EraRule "PPUP" era)),
-    NoThunks (Core.Value era),
-    ToCBOR (Core.TxBody era),
-    ToCBOR (Core.TxOut era),
-    ToCBOR (Core.Value era)
-  ) =>
-  NoThunks (LedgerState era)
+    NoThunks (Core.Value era)
+  ) => NoThunks (LedgerState era)
 
 instance
   ( Era era,

--- a/hie.yaml
+++ b/hie.yaml
@@ -66,6 +66,9 @@ cradle:
     - path: "libs/cardano-ledger-test/src"
       component: "lib:cardano-ledger-test"
 
+    - path: "libs/cardano-ledger-test/test"
+      component: "test:cardano-ledger-test"
+
     - path: "libs/cardano-ledger-test/bench"
       component: "cardano-ledger-test:bench:bench"
 

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -93,6 +93,7 @@ library
     Test.Cardano.Ledger.Model.TxOut
     Test.Cardano.Ledger.Model.UTxO
     Test.Cardano.Ledger.Model.Value
+    Test.Cardano.Ledger.NoThunks
     Test.Cardano.Ledger.Rational
     Test.Cardano.Ledger.TestableEra
     Test.Cardano.Ledger.ValueFromList

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -122,6 +122,7 @@ library
     lens,
     monad-supply,
     mtl,
+    nothunks,
     plutus-ledger-api,
     plutus-core,
     plutus-tx,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -118,11 +118,7 @@ instance Reflect era => TotalAda (MockChainState era) where
 
 deriving instance Generic (MockChainState era)
 
-instance
-  ( Era era,
-    NoThunks (NewEpochState era)
-  ) =>
-  NoThunks (MockChainState era)
+instance (Era era, NoThunks (NewEpochState era)) => NoThunks (MockChainState era)
 
 -- ======================================================================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -57,6 +58,8 @@ import Control.State.Transition
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq (..), fromStrict)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks, ThunkInfo, noThunks)
 import Test.Cardano.Ledger.Generic.Functions (TotalAda (..))
 import Test.Cardano.Ledger.Generic.PrettyCore
   ( pcNewEpochState,
@@ -112,6 +115,14 @@ instance Show (MockBlock era) where
 
 instance Reflect era => TotalAda (MockChainState era) where
   totalAda (MockChainState nes _ _) = totalAda nes
+
+deriving instance Generic (MockChainState era)
+
+instance
+  ( Era era,
+    NoThunks (NewEpochState era)
+  ) =>
+  NoThunks (MockChainState era)
 
 -- ======================================================================
 
@@ -256,3 +267,10 @@ ppMockChainFailure proof x = case proof of
         [ ("Last applied block", ppSlotNo lastslot),
           ("Candidate block", ppSlotNo cand)
         ]
+
+noThunksGen :: Proof era -> MockChainState era -> IO (Maybe ThunkInfo)
+noThunksGen (Babbage _) = noThunks []
+noThunksGen (Alonzo _) = noThunks []
+noThunksGen (Mary _) = noThunks []
+noThunksGen (Allegra _) = noThunks []
+noThunksGen (Shelley _) = noThunks []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Test.Cardano.Ledger.NoThunks
+  (
+  )
+where
+
+import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace)
+import Data.Default.Class (def)
+import NoThunks.Class (NoThunks, unsafeNoThunks)
+import Test.Cardano.Ledger.Generic.GenState (GenSize)
+import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockChainState)
+import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (Babbage), Reflect)
+import Test.Cardano.Ledger.Generic.Trace (Gen1, traceProp)
+import Test.Tasty (TestTree, defaultMain)
+import Test.Tasty.QuickCheck (testProperty)
+
+test ::
+  forall era.
+  ( Reflect era,
+    HasTrace (MOCKCHAIN era) (Gen1 era),
+    NoThunks (MockChainState era)
+  ) =>
+  Proof era ->
+  Int ->
+  GenSize ->
+  TestTree
+test proof numTx gensize =
+  testProperty (show proof ++ " era. Trace length = " ++ show numTx) $
+    traceProp
+      proof
+      numTx
+      gensize
+      ( \_ trc -> case unsafeNoThunks trc of
+          Just x -> error $ "Thunks present: " <> show x
+          Nothing -> ()
+      )
+
+main :: IO ()
+main = defaultMain $ test (Babbage Mock) 200 def

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
@@ -1,14 +1,18 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Test.Cardano.Ledger.NoThunks
-  ( test
+  ( test,
   )
 where
 
+import qualified Cardano.Ledger.Alonzo.PParams
+import qualified Cardano.Ledger.Babbage.PParams
+import qualified Cardano.Ledger.Shelley.PParams
+import Control.State.Transition.Extended (STS)
 import Data.Default.Class (def)
 import Test.Cardano.Ledger.Generic.GenState (GenSize)
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, noThunksGen)
@@ -16,21 +20,19 @@ import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (..), Reflect)
 import Test.Cardano.Ledger.Generic.Trace (traceProp)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
-import Control.State.Transition.Extended (STS)
-import qualified Cardano.Ledger.Babbage.PParams
-import qualified Cardano.Ledger.Alonzo.PParams
-import qualified Cardano.Ledger.Shelley.PParams
 
 test :: TestTree
-test = testGroup "There are no unexpected thunks in MockChainState"
-  [ f $ Babbage Mock,
-    f $ Alonzo Mock,
-    f $ Allegra Mock,
-    f $ Mary Mock,
-    f $ Shelley Mock
-  ]
-    where 
-      f proof = testThunks proof 100 def
+test =
+  testGroup
+    "There are no unexpected thunks in MockChainState"
+    [ f $ Babbage Mock,
+      f $ Alonzo Mock,
+      f $ Allegra Mock,
+      f $ Mary Mock,
+      f $ Shelley Mock
+    ]
+  where
+    f proof = testThunks proof 100 def
 
 testThunks ::
   forall era.
@@ -54,5 +56,5 @@ testThunks proof numTx gensize =
             Nothing -> return ()
       )
 
---main :: IO ()
---main = defaultMain test
+-- main :: IO ()
+-- main = defaultMain test

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -20,9 +20,9 @@ import Test.Cardano.Ledger.Examples.TwoPhaseValidation
 import Test.Cardano.Ledger.Generic.AggPropTests (aggTests)
 import Test.Cardano.Ledger.Generic.Properties (genericProperties)
 import Test.Cardano.Ledger.Model.Properties (modelUnitTests_)
+import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
-import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 
 -- ====================================================================================
 
@@ -33,20 +33,20 @@ tests = askOption $ \case
   _ -> mainTests
 
 mainTestTrees :: [TestTree]
-mainTestTrees = 
-    [ baseTypesTests,
-      Tools.tests,
-      testGroup
-        "STS Tests"
-        [ allTrees,
-          babbageFeatures,
-          alonzoAPITests,
-          collectOrderingAlonzo,
-          modelUnitTests_
-        ],
-      genericProperties def,
-      aggTests
-    ]
+mainTestTrees =
+  [ baseTypesTests,
+    Tools.tests,
+    testGroup
+      "STS Tests"
+      [ allTrees,
+        babbageFeatures,
+        alonzoAPITests,
+        collectOrderingAlonzo,
+        modelUnitTests_
+      ],
+    genericProperties def,
+    aggTests
+  ]
 
 nightlyTestTrees :: [TestTree]
 nightlyTestTrees =

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main where
 
@@ -23,19 +22,18 @@ import Test.Cardano.Ledger.Generic.Properties (genericProperties)
 import Test.Cardano.Ledger.Model.Properties (modelUnitTests_)
 import Test.Tasty
 import Test.TestScenario (TestScenario (..), mainWithTestScenario)
+import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 
 -- ====================================================================================
 
 tests :: TestTree
 tests = askOption $ \case
-  Nightly -> mainTests
+  Nightly -> nightlyTests
   Fast -> mainTests
   _ -> mainTests
 
-mainTests :: TestTree
-mainTests =
-  testGroup
-    "cardano-core"
+mainTestTrees :: [TestTree]
+mainTestTrees = 
     [ baseTypesTests,
       Tools.tests,
       testGroup
@@ -49,6 +47,16 @@ mainTests =
       genericProperties def,
       aggTests
     ]
+
+nightlyTestTrees :: [TestTree]
+nightlyTestTrees =
+  mainTestTrees <> [NoThunks.test]
+
+mainTests :: TestTree
+mainTests = testGroup "cardano-core" mainTestTrees
+
+nightlyTests :: TestTree
+nightlyTests = testGroup "cardano-core-nightly" nightlyTestTrees
 
 -- main entry point
 main :: IO ()


### PR DESCRIPTION
This PR adds tests that make sure that there are no unexpected thunks in the MockChainState after running a long trace. To run the nightly tests, use `cabal v2-test cardano-ledger-test --test-options="--scenario Nightly"`.

Currently we ignore thunks in the Plutus `EvaluationContext`, since we haven't yet bumped `plutus-core` to a version that adds a `NoThunks` instance to it (see #2853, [ plutus/#4687](https://github.com/input-output-hk/plutus/issues/4687)).

resolves #2856