### PR TITLE
Revert "Update index state to 2022-07-01T00:00:00Z"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2022-07-01T00:00:00Z
+index-state: 2022-02-18T00:00:00Z
 
 packages:
   eras/alonzo/impl
@@ -62,8 +62,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
-  --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
+  tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
+  --sha256: 00h10l5mmiza9819p9v5q5749nb9pzgi20vpzpy1d34zmh6gf1cj
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -110,13 +110,6 @@ constraints:
   -- ones they reuse the one from 'some', but there isn't e.g. a proper version
   -- constraint from dependent-sum-template (which is the library we actually use).
   , dependent-sum > 0.6.2.0
-
-  -- Plutus dependency
-  , algebraic-graphs < 0.7
-
-  , protolude >= 0.3.2
-
-  , persistent < 2.14
 
 -- Have to specify  '-Werror' for each package until this is taken care of:
 -- https://github.com/haskell/cabal/issues/3579

--- a/eras/byron/chain/executable-spec/test/Main.hs
+++ b/eras/byron/chain/executable-spec/test/Main.hs
@@ -1,7 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
-
 module Main (main) where
 
 import Test.Byron.AbstractSize.Properties (testAbstractSize)

--- a/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
+++ b/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.AbstractSize.Properties (testAbstractSize) where
 

--- a/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
@@ -82,7 +82,6 @@ import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
-import Data.String (String)
 import qualified Data.Text.Encoding as T
 import Formatting (Format, bprint, build, fitLeft, later, sformat, (%.))
 import qualified Formatting.Buildable as B (Buildable (..))
@@ -120,7 +119,7 @@ instance ToJSON (AbstractHash algo a) where
   toJSON = toJSON . sformat hashHexF
 
 instance HashAlgorithm algo => FromJSON (AbstractHash algo a) where
-  parseJSON = toAesonError . readEither @_ @String <=< parseJSON
+  parseJSON = toAesonError . readEither <=< parseJSON
 
 instance
   (HashAlgorithm algo, FromJSON (AbstractHash algo a)) =>

--- a/eras/byron/ledger/executable-spec/test/Main.hs
+++ b/eras/byron/ledger/executable-spec/test/Main.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Main
   ( main,

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.Spec.Ledger.AbstractSize.Properties (testTxHasTypeReps) where
 

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.Spec.Ledger.Relation.Properties (testRelation) where
 

--- a/eras/byron/ledger/impl/test/Test/Options.hs
+++ b/eras/byron/ledger/impl/test/Test/Options.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Options
   ( TestScenario (..),

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Cardano.Ledger.Shelley.Serialisation.Tripping.JSON
   ( tests,

--- a/libs/small-steps-test/test/examples/Main.hs
+++ b/libs/small-steps-test/test/examples/Main.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 import qualified Control.State.Transition.Examples.CommitReveal as CommitReveal
 import qualified Control.State.Transition.Examples.GlobalSum as GSum
 import qualified Control.State.Transition.Examples.Sum as Sum
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.ExpectedFailure (expectFailBecause)
-import Test.Tasty.Hedgehog (testPropertyNamed)
+import Test.Tasty.Hedgehog (testProperty)
 import qualified Test.Tasty.QuickCheck as Tasty.QuickCheck
 
 main :: IO ()
@@ -22,18 +19,11 @@ main = do
             "Sum"
             [ expectFailBecause
                 "it allows to inspect generated trace counterexamples"
-                $ testPropertyNamed
-                  "False (Hedgehog)"
-                  "prop_Bounded"
-                  Sum.prop_Bounded,
-              testPropertyNamed
+                $ testProperty "False (Hedgehog)" Sum.prop_Bounded,
+              testProperty
                 "Only valid traces are generated"
-                "prop_onlyValidTracesAreGenerated"
                 Sum.prop_onlyValidTracesAreGenerated,
-              testPropertyNamed
-                "Classified"
-                "prop_Classified"
-                Sum.prop_Classified,
+              testProperty "Classified" Sum.prop_Classified,
               Tasty.QuickCheck.testProperty
                 "Classified (QuickCheck)"
                 Sum.prop_qc_Classified,


### PR DESCRIPTION
This reverts commit b425b51a80f57cadccff5eaf9443bf492b2c51d6.

The update to the index state broke our ability to get a nix shell on master. We are in the middle of trying to fix this (see #2914), but in order to unblock master I am reverting the update. cc @newhoggy 