### PR TITLE
WIP ValidateScript can only be applied to phase 1 scripts, enforced by types.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
@@ -1,40 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 
--- | This module provides data structures and operations for talking about
---     Non-native Script languages. It is expected that new languages (or new
---     versions of old languages) will be added here.
-module Cardano.Ledger.Alonzo.Language where
+-- | This module exports the module Cardano.Ledger.Language. That module exports data
+--   structures and operations for talking about Non-native Script languages. It is expected that new languages (or new
+--   versions of old languages) will be added there, and just imported here.
+module Cardano.Ledger.Alonzo.Language (module Cardano.Ledger.Language) where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord64)
-import Control.DeepSeq (NFData (..))
-import Data.Ix (Ix)
-import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks)
-
--- | Non-Native Script language. This is an Enumerated type.
--- This is expected to be an open type. We will add new Constuctors
--- to this type as additional Non-Native scripting language as are added.
--- We use an enumerated type for two reasons.
--- 1) We can write total functions by case analysis over the constructors
--- 2) We will use DataKinds to make some datatypes  indexed by Language
--- For now, the only Non-Native Scriting language is Plutus
--- We might add new languages in the futures.
---
--- Note that the the serialization of 'Language' depends on the ordering.
-data Language
-  = PlutusV1
-  | PlutusV2
-  deriving (Eq, Generic, Show, Ord, Enum, Bounded, Ix)
-
-instance NoThunks Language
-
-instance NFData Language
-
-instance ToCBOR Language where
-  toCBOR = toCBOR . fromEnum
-
-instance FromCBOR Language where
-  fromCBOR = toEnum . fromIntegral <$> decodeWord64
-
-nonNativeLanguages :: [Language]
-nonNativeLanguages = [minBound .. maxBound]
+import Cardano.Ledger.Language

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -49,7 +49,7 @@ import Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (KeyHashObj))
 import Cardano.Ledger.Crypto (DSIGN, HASH)
-import Cardano.Ledger.Era (Era (..), ValidateScript (..))
+import Cardano.Ledger.Era (Era (..), ValidateScript (..), getPhase2)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..), asWitness)
 import Cardano.Ledger.Rules.ValidationMode (Inject (..), Test, runTest, runTestOnSignal)
@@ -280,8 +280,7 @@ hasExactSetOfRedeemers utxo tx txbody = do
         [ (rp, (sp, sh))
           | (sp, sh) <- Alonzo.scriptsNeeded utxo tx,
             SJust rp <- [rdptr @era txbody sp],
-            Just script <- [Map.lookup sh (txscripts utxo tx)],
-            (not . isNativeScript @era) script
+            Just _phase2Script <- [Map.lookup sh (getPhase2 @era (txscripts utxo tx))]
         ]
       (extraRdmrs, missingRdmrs) =
         extSymmetricDifference

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible (Compactible)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as CryptoClass
-import Cardano.Ledger.Era (Era (..), SupportsSegWit (..), ValidateScript (..))
+import Cardano.Ledger.Era (Era (..), Phase (..), PhaseRep (..), PhasedScript (..), SomeScript, SupportsSegWit (..), ValidateScript (..))
 import Cardano.Ledger.Mary.Value (Value, policies, policyID)
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley (nativeMultiSigTag)
@@ -169,6 +169,8 @@ type instance
 -- Ledger data instances
 --------------------------------------------------------------------------------
 
+type instance SomeScript 'PhaseOne (ShelleyMAEra ma c) = Timelock c
+
 -- Since Timelock scripts are a strictly backwards compatible extension of
 -- Multisig scripts, we can use the same 'scriptPrefixTag' tag here as
 -- we did for the ValidateScript instance in Multisig which is imported
@@ -182,7 +184,9 @@ instance
   ValidateScript (ShelleyMAEra ma c)
   where
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
-  validateScript script tx = validateTimelock @(ShelleyMAEra ma c) script tx
+  validateScript (Phase1Script script) tx = validateTimelock @(ShelleyMAEra ma c) script tx
+  phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
+  phaseScript PhaseTwoRep _ = Nothing
 
 -- Uses the default instance of hashScript
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -55,7 +55,7 @@ import Cardano.Ledger.BaseTypes
   )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Era (Era (..), getPhase1)
 import Cardano.Ledger.Keys
   ( DSignable,
     GenDelegPair (..),
@@ -399,12 +399,13 @@ validateFailedScripts ::
   Core.Tx era ->
   Test (UtxowPredicateFailure era)
 validateFailedScripts tx = do
-  let failedScripts =
+  let phase1Map = getPhase1 (getField @"scriptWits" tx)
+      failedScripts =
         Map.filterWithKey
-          ( \hs validator ->
-              hashScript @era validator /= hs || not (validateScript @era validator tx)
+          ( \hs (core, phase) ->
+              hashScript @era core /= hs || not (validateScript @era phase tx)
           )
-          (getField @"scriptWits" tx)
+          phase1Map
   failureUnless (Map.null failedScripts) $
     ScriptWitnessNotValidatingUTXOW (Map.keysSet failedScripts)
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -57,6 +57,7 @@ library
     Cardano.Ledger.HKD
     Cardano.Ledger.Keys
     Cardano.Ledger.Keys.WitVKey
+    Cardano.Ledger.Language
     Cardano.Ledger.PoolDistr
     Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.SafeHash

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | This module provides data structures and operations for talking about
+--     Non-native Script languages. It is expected that new languages (or new
+--     versions of old languages) will be added here.
+module Cardano.Ledger.Language where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord64)
+import Control.DeepSeq (NFData (..))
+import Data.Ix (Ix)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+-- | Non-Native Script language. This is an Enumerated type.
+-- This is expected to be an open type. We will add new Constuctors
+-- to this type as additional Non-Native scripting language as are added.
+-- We use an enumerated type for two reasons.
+-- 1) We can write total functions by case analysis over the constructors
+-- 2) We will use DataKinds to make some datatypes  indexed by Language
+-- For now, the only Non-Native Scriting language is Plutus
+-- We might add new languages in the futures.
+--
+-- Note that the the serialization of 'Language' depends on the ordering.
+data Language
+  = PlutusV1
+  | PlutusV2
+  deriving (Eq, Generic, Show, Ord, Enum, Bounded, Ix)
+
+instance NoThunks Language
+
+instance NFData Language
+
+instance ToCBOR Language where
+  toCBOR = toCBOR . fromEnum
+
+instance FromCBOR Language where
+  fromCBOR = toEnum . fromIntegral <$> decodeWord64
+
+nonNativeLanguages :: [Language]
+nonNativeLanguages = [minBound .. maxBound]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -11,7 +11,7 @@ import Cardano.Crypto.DSIGN
 import qualified Cardano.Crypto.Hash as Crypto
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo.PParams
-import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), Script, Tag (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), ExUnits (..), Tag (..))
 import Cardano.Ledger.Alonzo.Tools (TransactionScriptFailure (..), evaluateTransactionExecutionUnits)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWitness
@@ -21,7 +21,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN, HASH)
 import qualified Cardano.Ledger.Crypto as Ledger.Crypto
-import Cardano.Ledger.Era (Era (Crypto))
+import Cardano.Ledger.Era (Era (Crypto), ValidateScript)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
@@ -101,7 +101,7 @@ testExUnitCalculation ::
     State (Core.EraRule "UTXOS" era) ~ UTxOState era,
     Environment (Core.EraRule "UTXOS" era) ~ UtxoEnv era,
     Signal (Core.EraRule "UTXOS" era) ~ Core.Tx era,
-    Era era,
+    ValidateScript era,
     ExtendedUTxO era,
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
@@ -111,8 +111,7 @@ testExUnitCalculation ::
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
     HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
     Show (PredicateFailure (Core.EraRule "UTXOS" era)),
-    STS (Core.EraRule "UTXOS" era),
-    Core.Script era ~ Script era
+    STS (Core.EraRule "UTXOS" era)
   ) =>
   Proof era ->
   Core.Tx era ->
@@ -156,8 +155,7 @@ exampleExUnitCalc ::
     STS (Core.EraRule "UTXOS" era),
     Scriptic era,
     PostShelley era,
-    Default (State (Core.EraRule "PPUP" era)),
-    Core.Script era ~ Script era
+    Default (State (Core.EraRule "PPUP" era))
   ) =>
   Proof era ->
   IO ()
@@ -183,7 +181,6 @@ exampleInvalidExUnitCalc ::
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
-    Core.Script era ~ Script era,
     Signable
       (Ledger.Crypto.DSIGN (Crypto era))
       ( Crypto.Hash
@@ -261,7 +258,7 @@ ustate pf =
 updateTxExUnits ::
   forall era m.
   ( MonadFail m,
-    Era era,
+    ValidateScript era,
     ExtendedUTxO era,
     HasField "_maxTxExUnits" (Core.PParams era) ExUnits,
     HasField "_protocolVersion" (Core.PParams era) ProtVer,
@@ -269,8 +266,7 @@ updateTxExUnits ::
     HasField "inputs" (Core.TxBody era) (Set (TxIn (Crypto era))),
     HasField "txdats" (Core.Witnesses era) (TxDats era),
     HasField "txrdmrs" (Core.Witnesses era) (Redeemers era),
-    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era)),
-    Core.Script era ~ Script era
+    HasField "wdrls" (Core.TxBody era) (Wdrl (Crypto era))
   ) =>
   Proof era ->
   Core.Tx era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -929,8 +929,7 @@ txFromTestCaseData
 testExpectSuccessValid ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era,
-    Scriptic era,
-    GoodCrypto (Crypto era),
+    Reflect era,
     Default (State (EraRule "PPUP" era)),
     PostShelley era,
     HasField "referenceInputs" (Core.TxBody era) (Set.Set (TxIn (Crypto era))),
@@ -976,8 +975,7 @@ testExpectSuccessInvalid ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era,
     Core.TxBody era ~ Babbage.TxBody era,
-    Scriptic era,
-    GoodCrypto (Crypto era),
+    Reflect era,
     Default (State (EraRule "PPUP" era)),
     PostShelley era,
     HasField "referenceInputs" (Core.TxBody era) (Set.Set (TxIn (Crypto era))),
@@ -1005,7 +1003,7 @@ testExpectFailure ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era,
     Core.TxBody era ~ Babbage.TxBody era,
-    GoodCrypto (Crypto era),
+    Reflect era,
     Default (State (EraRule "PPUP" era)),
     PostShelley era
   ) =>
@@ -1028,7 +1026,7 @@ genericBabbageFeatures ::
     BabbageBased era (PredicateFailure (EraRule "UTXOW" era)),
     State (EraRule "UTXOW" era) ~ UTxOState era,
     Core.TxBody era ~ Babbage.TxBody era,
-    GoodCrypto (Crypto era),
+    Reflect era,
     Default (State (EraRule "PPUP" era)),
     PostShelley era,
     HasField "referenceInputs" (Core.TxBody era) (Set.Set (TxIn (Crypto era))),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1322,6 +1322,21 @@ pcEpochState proof (EpochState (AccountState tre res) _ ls _ _ _) =
 
 instance Reflect era => PrettyC (EpochState era) era where prettyC = pcEpochState
 
+pcBbodyState ::
+  ( Reflect era
+  ) =>
+  Proof era ->
+  BbodyState era ->
+  PDoc
+pcBbodyState proof (BbodyState ls (BlocksMade mp)) =
+  ppRecord
+    "BbodyState"
+    [ ("ledger state", pcLedgerState proof ls),
+      ("blocks made", ppMap pcKeyHash ppNatural mp)
+    ]
+
+instance Reflect era => PrettyC (BbodyState era) era where prettyC = pcBbodyState
+
 pc :: PrettyC t era => Proof era -> t -> IO ()
 pc proof x = putStrLn (show (prettyC proof x))
 


### PR DESCRIPTION
Changed ValidateScript, so that validateScript has type
PhasedScript 'One era -> Core.Tx era -> Bool
Type ensure only scriptes from Phase1 can be validated.
Introduces types Phase, PhasedScript, and type family SomeScript