### PR TITLE
Fix Byron address format

### DIFF
--- a/eras/byron/cddl-spec/byron.cddl
+++ b/eras/byron/cddl-spec/byron.cddl
@@ -45,11 +45,14 @@ attributes = {* any => any}
 
 ; Addresses
 
+protocolMagic = u32
+
 addrdistr = [1] / [0, stakeholderid]
 
 addrtype = &("PubKey" : 0, "Script" : 1, "Redeem" : 2) / (u64 .gt 2)
-addrattr = { ? 0 : addrdistr
-           , ? 1 : bytes}
+addrattr = {   0 : addrdistr
+           , ? 1 : bytes
+           , ? 2 : protocolMagic }
 address = [ #6.24(bytes .cbor ([addressid, addrattr, addrtype])), u64 ]
 
 ; Transactions

--- a/eras/byron/cddl-spec/byron.cddl
+++ b/eras/byron/cddl-spec/byron.cddl
@@ -45,7 +45,7 @@ attributes = {* any => any}
 
 ; Addresses
 
-protocolMagic = u32
+protocolMagic = bytes ; integer encoded as CBOR encoded as Bytes in CBOR
 
 addrdistr = [1] / [0, stakeholderid]
 


### PR DESCRIPTION
The CDDL definition for Byron era has some mistakes in it:

1. It marked `addrdistr` as option. However, you can see that in the written spec, the field is not optional
![image](https://user-images.githubusercontent.com/2608559/179967688-35082dc6-547b-47b8-a4e1-6952fa3d3796.png)

I'm a little confused by the Rust implementation which marks the field as required but at the same time allows it to be missing during deserialization (setting `BootstrapEraDistr` as the default value) so maybe there is some history I am missing here (if this is intended, then maybe the `.default` type should be used in the CDDL definition)

EDIT: it turns out Dd addresses always contain the map, but Ae2 addresses just contain an empty map instead (which thus need a default stake_distribution)

2. Both the written spec and the binary spec are missing the `protocolMagic` attribute in addresses. Potentially the cause of this is because the protocolMagic was only added partway through the Byron era (notably, added when the public testnet was released) and it was only used on testnets.

You could argue that maybe this field is included in the `Unparsed :: Word8 ⇀ Bytes }` mapping used for attributes in the written spec, but this unparsed mapping is also missing from the binary spec so it's better to have protocolMagic than nothing I guess

3. The checksum for `address` is marked as u64, but it should be u32 since crc32 is a 32-bit type