### PR TITLE
Replace deprecated testProperty with our own version.

### DIFF
--- a/eras/byron/chain/executable-spec/test/Main.hs
+++ b/eras/byron/chain/executable-spec/test/Main.hs
@@ -1,13 +1,8 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
-
 module Main (main) where
 
-import Test.Byron.AbstractSize.Properties (testAbstractSize)
+import Test.Byron.AbstractSize.Properties (testAbstractSize, testProperty)
 import Test.Byron.Spec.Chain.STS.Properties as CHAIN
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
 
 main :: IO ()
 main = defaultMain tests

--- a/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
+++ b/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
--- TODO Remove use of deprecated function testProperty
-
-module Test.Byron.AbstractSize.Properties (testAbstractSize) where
+module Test.Byron.AbstractSize.Properties (testAbstractSize, testProperty) where
 
 import Byron.Spec.Chain.STS.Block (Block (..), BlockBody (..), BlockHeader (..))
 import Byron.Spec.Chain.STS.Rule.Chain (CHAIN)
@@ -25,10 +22,15 @@ import qualified Data.Set as Set
 import Data.Typeable (TypeRep, Typeable, typeOf)
 import Data.Word (Word64)
 import Hedgehog (MonadTest, Property, diff, forAll, property, withTests, (===))
+import Hedgehog.Internal.Property (PropertyName (..))
 import Numeric.Natural (Natural)
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestName, TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
-import Test.Tasty.Hedgehog
+import Test.Tasty.Hedgehog hiding (testProperty)
+
+-- | testProperty has been deprecated. We make our own version here.
+testProperty :: TestName -> Property -> TestTree
+testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 --------------------------------------------------------------------------------
 -- Example typeReps for Block/Header/Body

--- a/eras/byron/ledger/executable-spec/test/Main.hs
+++ b/eras/byron/ledger/executable-spec/test/Main.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Main
   ( main,
   )
 where
 
-import Test.Byron.Spec.Ledger.AbstractSize.Properties (testTxHasTypeReps)
+import Test.Byron.Spec.Ledger.AbstractSize.Properties (testProperty, testTxHasTypeReps)
 import qualified Test.Byron.Spec.Ledger.Core.Generators.Properties as CoreGen
 import Test.Byron.Spec.Ledger.Delegation.Examples (deleg)
 import qualified Test.Byron.Spec.Ledger.Delegation.Properties as DELEG
@@ -18,7 +15,6 @@ import qualified Test.Byron.Spec.Ledger.UTxO.Properties as UTxO
 import Test.Byron.Spec.Ledger.Update.Examples (upiendExamples)
 import qualified Test.Byron.Spec.Ledger.Update.Properties as UPDATE
 import Test.Tasty (TestTree, defaultMain, localOption, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
 import Test.Tasty.Ingredients.ConsoleReporter (UseColor (Auto))
 
 main :: IO ()

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
--- TODO Remove use of deprecated function testProperty
-
-module Test.Byron.Spec.Ledger.AbstractSize.Properties (testTxHasTypeReps) where
+module Test.Byron.Spec.Ledger.AbstractSize.Properties (testTxHasTypeReps, testProperty) where
 
 import Byron.Spec.Ledger.Core hiding ((<|))
 import Byron.Spec.Ledger.STS.UTXOW (UTXOW)
@@ -19,10 +16,15 @@ import Data.Sequence (empty, (<|), (><))
 import qualified Data.Sequence as Seq
 import Data.Typeable (TypeRep, Typeable, typeOf)
 import Hedgehog (MonadTest, Property, forAll, property, withTests, (===))
+import Hedgehog.Internal.Property (PropertyName (..))
 import Numeric.Natural (Natural)
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestName, TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
-import Test.Tasty.Hedgehog
+import Test.Tasty.Hedgehog hiding (testProperty)
+
+-- | testProperty has been deprecated. We make our own version here.
+testProperty :: TestName -> Property -> TestTree
+testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 --------------------------------------------------------------------------------
 -- Example HasTypeReps.typeReps for TxIn, Tx

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.Spec.Ledger.Relation.Properties (testRelation) where
 
@@ -15,9 +12,14 @@ import Data.Map.Strict (Map)
 import Data.Set (Set, union, (\\))
 import Hedgehog (Gen, MonadTest, Property, PropertyT, forAll, property, withTests, (===))
 import qualified Hedgehog.Gen as Gen
+import Hedgehog.Internal.Property (PropertyName (..))
 import qualified Hedgehog.Range as Range
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Hedgehog
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.Hedgehog hiding (testProperty)
+
+-- | testProperty has been deprecated. We make our own version here.
+testProperty :: TestName -> Property -> TestTree
+testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 --------------------------------------------------------------------------------
 -- Properties on Relations

--- a/eras/byron/ledger/impl/test/Test/Options.hs
+++ b/eras/byron/ledger/impl/test/Test/Options.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Options
   ( TestScenario (..),
@@ -26,13 +23,14 @@ import Hedgehog (Gen, Group (..), Property, PropertyT, TestLimit, withTests)
 import Hedgehog.Internal.Property (GroupName (..), PropertyName (..))
 import Test.Cardano.Prelude
 import Test.Tasty
-  ( TestTree,
+  ( TestName,
+    TestTree,
     askOption,
     defaultMainWithIngredients,
     includingOptions,
     testGroup,
   )
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.Hedgehog hiding (testProperty)
 import Test.Tasty.Ingredients (Ingredient (..), composeReporters)
 import Test.Tasty.Ingredients.Basic (consoleTestReporter, listingTests)
 import Test.Tasty.Options
@@ -41,6 +39,10 @@ import Test.Tasty.Options
     lookupOption,
     safeRead,
   )
+
+-- | testProperty has been deprecated. We make our own version here.
+testProperty :: TestName -> Property -> TestTree
+testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 --------------------------------------------------------------------------------
 -- TestScenario

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Cardano.Ledger.Shelley.Serialisation.Tripping.JSON
   ( tests,
@@ -21,10 +18,15 @@ import Data.Aeson (decode, encode, fromJSON, toJSON)
 import Data.Proxy
 import Hedgehog (Property)
 import qualified Hedgehog
+import Hedgehog.Internal.Property (PropertyName (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators.Genesis
 import Test.Tasty
-import Test.Tasty.Hedgehog
+import Test.Tasty.Hedgehog hiding (testProperty)
+
+-- | testProperty has been deprecated. We make our own version here.
+testProperty :: TestName -> Property -> TestTree
+testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 prop_roundtrip_Address_JSON ::
   forall crypto.

--- a/libs/small-steps-test/test/examples/Main.hs
+++ b/libs/small-steps-test/test/examples/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- TODO Remove use of deprecated function testProperty
 


### PR DESCRIPTION
Re[aces al calls to Hedghog testProperty with our own testProperty written in terms of testPropertyNamed.

Since most of these were in 3 different modules in the byron era, and none of them have a common module they all import from. I had to write our version of testProperty several times.
