### PR TITLE
Removed testProperty calls introduced by #2908

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ in the naming of release branches.
   - The `PoolParams` type has been moved into its own module
   - The `DCert` type and related functionality from `TxBody` to `Cardano.Ledger.Shelley.Delegation.Certificates`.
   #2880
-- The initial funds and staking in the Shelley genesis type (used only for testing) now use `ListMap` instead of `Map`.
+  - The initial funds and staking in the Shelley genesis type (used only for testing) now use `ListMap` instead of `Map`.
   #2871, #2890, #2892, #2895
+  - Switched to using `testPropertyNamed` in tests. Tests now have short names (lower case and hyphenated) in addition to longer descriptive names.
+  #2926
 ### Deprecated
 - The provenance for the reward calculation has been removed.
   The type signature to the API function `getRewardProvenance` has not change,

--- a/eras/byron/chain/executable-spec/test/Main.hs
+++ b/eras/byron/chain/executable-spec/test/Main.hs
@@ -1,13 +1,11 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
 import Test.Byron.AbstractSize.Properties (testAbstractSize)
 import Test.Byron.Spec.Chain.STS.Properties as CHAIN
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.Hedgehog (testPropertyNamed)
 
 main :: IO ()
 main = defaultMain tests
@@ -18,12 +16,30 @@ main = defaultMain tests
         "Chain"
         [ testGroup
             "Properties"
-            [ testProperty "Increasing slots" CHAIN.slotsIncrease,
-              testProperty "Block issuers are delegates" CHAIN.blockIssuersAreDelegates,
+            [ testPropertyNamed
+                "Increasing slots"
+                "increasing-slots"
+                CHAIN.slotsIncrease,
+              testPropertyNamed
+                "Block issuers are delegates"
+                "issuers-delegates"
+                CHAIN.blockIssuersAreDelegates,
               testAbstractSize,
-              testProperty "Only valid signals are generated" CHAIN.onlyValidSignalsAreGenerated,
-              testProperty "Signers list is bounded by k " CHAIN.signersListIsBoundedByK,
-              testProperty "We are generating reasonable Chain Traces" CHAIN.relevantCasesAreCovered,
-              testProperty "Invalid signals are generated when requested" CHAIN.invalidSignalsAreGenerated
+              testPropertyNamed
+                "Only valid signals are generated"
+                "valid-signals"
+                CHAIN.onlyValidSignalsAreGenerated,
+              testPropertyNamed
+                "Signers list is bounded by k "
+                "signers-bounded"
+                CHAIN.signersListIsBoundedByK,
+              testPropertyNamed
+                "We are generating reasonable Chain Traces"
+                "reasonable-traces"
+                CHAIN.relevantCasesAreCovered,
+              testPropertyNamed
+                "Invalid signals are generated when requested"
+                "generate-invalid-signals"
+                CHAIN.invalidSignalsAreGenerated
             ]
         ]

--- a/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
+++ b/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.AbstractSize.Properties (testAbstractSize) where
 
@@ -178,5 +176,8 @@ testAbstractSize =
     [ testCase "AbstractSize - example - BlockHeader" exampleTypeRepsBlockHeader,
       testCase "AbstractSize - example - BlockBody" exampleTypeRepsBlockBody,
       testCase "AbstractSize - example - Block" exampleTypeRepsBlock,
-      testProperty "AbstractSize - Block/Header/Body" propBlockAbstractSize
+      testPropertyNamed
+        "AbstractSize - Block/Header/Body"
+        "abstract-size-bhb"
+        propBlockAbstractSize
     ]

--- a/eras/byron/ledger/executable-spec/test/Main.hs
+++ b/eras/byron/ledger/executable-spec/test/Main.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Main
   ( main,
@@ -18,7 +15,7 @@ import qualified Test.Byron.Spec.Ledger.UTxO.Properties as UTxO
 import Test.Byron.Spec.Ledger.Update.Examples (upiendExamples)
 import qualified Test.Byron.Spec.Ledger.Update.Properties as UPDATE
 import Test.Tasty (TestTree, defaultMain, localOption, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.Ingredients.ConsoleReporter (UseColor (Auto))
 
 main :: IO ()
@@ -31,39 +28,106 @@ main = defaultMain tests
           "Test.Byron.Spec.Ledger"
           [ testGroup
               "Core generators properties"
-              [testProperty "Relevant k values are generated" CoreGen.relevantKValuesAreGenerated],
+              [ testPropertyNamed
+                  "Relevant k values are generated"
+                  "relevant-vals-generated"
+                  CoreGen.relevantKValuesAreGenerated
+              ],
             testGroup "Delegation Examples" deleg,
             testGroup
               "Delegation properties"
-              [ testProperty "Certificates are triggered" DELEG.dcertsAreTriggered,
-                testProperty "No certificates are replayed" DELEG.dcertsAreNotReplayed,
-                testProperty "DBLOCK Traces are classified" DELEG.dblockTracesAreClassified,
-                testProperty "Relevant DBLOCK traces covered" DELEG.relevantCasesAreCovered,
-                testProperty "Duplicated certificates are rejected" DELEG.rejectDupSchedDelegs,
-                testProperty "Traces are classified" DELEG.tracesAreClassified,
-                testProperty "Only valid DBLOCK signals are generated" DELEG.onlyValidSignalsAreGenerated,
-                testProperty "Invalid signals are generated when requested" DELEG.invalidSignalsAreGenerated
+              [ testPropertyNamed
+                  "Certificates are triggered"
+                  "certificates-triggered"
+                  DELEG.dcertsAreTriggered,
+                testPropertyNamed
+                  "No certificates are replayed"
+                  "no-cert-replay"
+                  DELEG.dcertsAreNotReplayed,
+                testPropertyNamed
+                  "DBLOCK Traces are classified"
+                  "dblock-traces-classified"
+                  DELEG.dblockTracesAreClassified,
+                testPropertyNamed
+                  "Relevant DBLOCK traces covered"
+                  "dblock-traces-covered"
+                  DELEG.relevantCasesAreCovered,
+                testPropertyNamed
+                  "Duplicated certificates are rejected"
+                  "duplicate-certs-rejected"
+                  DELEG.rejectDupSchedDelegs,
+                testPropertyNamed
+                  "Traces are classified"
+                  "traces-classified"
+                  DELEG.tracesAreClassified,
+                testPropertyNamed
+                  "Only valid DBLOCK signals are generated"
+                  "only-valid-dblock-signals"
+                  DELEG.onlyValidSignalsAreGenerated,
+                testPropertyNamed
+                  "Invalid signals are generated when requested"
+                  "invalid-signals-on-request"
+                  DELEG.invalidSignalsAreGenerated
               ],
             testGroup
               "UTxO properties"
-              [ testProperty "Money is constant" moneyIsConstant,
-                testProperty "Relevant UTxO traces are generated" UTxO.relevantCasesAreCovered,
-                testProperty "No double spending" UTxO.noDoubleSpending,
-                testProperty "UTxO is outputs minus inputs" UTxO.utxoDiff,
-                testProperty "UTxO and txouts are disjoint" UTxO.utxoAndTxoutsMustBeDisjoint
+              [ testPropertyNamed
+                  "Money is constant"
+                  "constant-money"
+                  moneyIsConstant,
+                testPropertyNamed
+                  "Relevant UTxO traces are generated"
+                  "relevant-utxo-traces-generated"
+                  UTxO.relevantCasesAreCovered,
+                testPropertyNamed
+                  "No double spending"
+                  "no-double-spending"
+                  UTxO.noDoubleSpending,
+                testPropertyNamed
+                  "UTxO is outputs minus inputs"
+                  "utxo-outputs-inputs"
+                  UTxO.utxoDiff,
+                testPropertyNamed
+                  "UTxO and txouts are disjoint"
+                  "uxot-txouts-disjoint"
+                  UTxO.utxoAndTxoutsMustBeDisjoint
               ],
             testTxHasTypeReps,
             testGroup "Update examples" upiendExamples,
             testGroup
               "Update properties"
-              [ testProperty "UPIREG traces are classified" UPDATE.upiregTracesAreClassified,
-                testProperty "UBLOCK traces are classified" UPDATE.ublockTraceLengthsAreClassified,
-                testProperty "Relevant UPIREG traces are covered" UPDATE.upiregRelevantTracesAreCovered,
-                testProperty "Only valid UPIREG signals are generated" UPDATE.onlyValidSignalsAreGenerated,
-                testProperty "Only valid UBLOCK signals are generated" UPDATE.ublockOnlyValidSignalsAreGenerated,
-                testProperty "Relevant UBLOCK traces are covered" UPDATE.ublockRelevantTracesAreCovered,
-                testProperty "Invalid registrations are generated when requested" UPDATE.invalidRegistrationsAreGenerated,
-                testProperty "Invalid signals are generated when requested" UPDATE.invalidSignalsAreGenerated
+              [ testPropertyNamed
+                  "UPIREG traces are classified"
+                  "upireg-traces-classified"
+                  UPDATE.upiregTracesAreClassified,
+                testPropertyNamed
+                  "UBLOCK traces are classified"
+                  "ublock-traces-classified"
+                  UPDATE.ublockTraceLengthsAreClassified,
+                testPropertyNamed
+                  "Relevant UPIREG traces are covered"
+                  "upireg-traces-covered"
+                  UPDATE.upiregRelevantTracesAreCovered,
+                testPropertyNamed
+                  "Only valid UPIREG signals are generated"
+                  "only-valid-upireg-signals"
+                  UPDATE.onlyValidSignalsAreGenerated,
+                testPropertyNamed
+                  "Only valid UBLOCK signals are generated"
+                  "only-valid-ublock-signals"
+                  UPDATE.ublockOnlyValidSignalsAreGenerated,
+                testPropertyNamed
+                  "Relevant UBLOCK traces are covered"
+                  "ublock-traces-covered"
+                  UPDATE.ublockRelevantTracesAreCovered,
+                testPropertyNamed
+                  "Invalid registrations are generated when requested"
+                  "invalid-registrations-on-request"
+                  UPDATE.invalidRegistrationsAreGenerated,
+                testPropertyNamed
+                  "Invalid signals are generated when requested"
+                  "invalid-signals-on-request"
+                  UPDATE.invalidSignalsAreGenerated
               ],
             -- TODO move this out of here (these are not properties of the transition
             -- systems) and also move the Relation class and instances out of Byron.Spec.Ledger.Core

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.Spec.Ledger.AbstractSize.Properties (testTxHasTypeReps) where
 
@@ -156,5 +154,8 @@ testTxHasTypeReps =
     "Test HasTypeReps instances"
     [ testCase "AbstractSize - example - TxIn" exampleTypeRepsTxIn,
       testCase "AbstractSize - example - Tx" exampleTypeRepsTx,
-      testProperty "AbstractSize and HasTypeReps - Tx*" propTxAbstractSize
+      testPropertyNamed
+        "AbstractSize and HasTypeReps - Tx*"
+        "abstract-size-hastypereps-tx-star"
+        propTxAbstractSize
     ]

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Byron.Spec.Ledger.Relation.Properties (testRelation) where
 
@@ -166,86 +163,109 @@ testRelation =
     "Test Relation instances"
     [ testGroup
         "Relation - Set"
-        [ testProperty
+        [ testPropertyNamed
             "DomainRestrictionAndIntersection"
+            "domain-restriction-and-intersection"
             (propRelation genIntS genSet propDomainRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "DomainRestrictionAndIntersectionB"
+            "domain-restriction-and-intersection-b"
             (propRelation genIntS genSet propDomainRestrictionAndIntersectionB),
-          testProperty
+          testPropertyNamed
             "DomainExclusionAndSetDifference"
+            "domain-exclusion-and-set-difference"
             (propRelation genIntS genSet propDomainExclusionAndSetDifference),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersection"
+            "range-restriction-and-intersection"
             (propRelation genIntS genSet propRangeRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersectionB"
+            "range-restriction-and-intersection-b"
             (propRelation genIntS genSet propRangeRestrictionAndIntersectionB)
         ],
       testGroup
         "Relation - Map"
-        [ testProperty
+        [ testPropertyNamed
             "DomainRestrictionAndIntersection"
+            "domain-restriction-and-intersection"
             (propRelation genIntS genMap propDomainRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "DomainRestrictionAndIntersectionB"
+            "domain-restriction-and-intersection-b"
             (propRelation genIntS genMap propDomainRestrictionAndIntersectionB),
-          testProperty
+          testPropertyNamed
             "DomainExclusionAndSetDifference"
+            "domain-exclusion-and-set-difference"
             (propRelation genIntS genMap propDomainExclusionAndSetDifference),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersection"
+            "range-restriction-and-intersection"
             (propRelation genIntS genMap propRangeRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersectionB"
+            "range-restriction-and-intersection-b"
             (propRelation genIntS genMap propRangeRestrictionAndIntersectionB)
         ],
       testGroup
         "Relation - Bimap"
-        [ testProperty
+        [ testPropertyNamed
             "DomainRestrictionAndIntersection"
+            "domain-restriction-and-intersection"
             (propRelation genIntS genBimap propDomainRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "DomainRestrictionAndIntersectionB"
+            "domain-restriction-and-intersection-b"
             (propRelation genIntS genBimap propDomainRestrictionAndIntersectionB),
-          testProperty
+          testPropertyNamed
             "DomainExclusionAndSetDifference"
+            "domain-exclusion-and-set-difference"
             (propRelation genIntS genBimap propDomainExclusionAndSetDifference),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersection"
+            "range-restriction-and-intersection"
             (propRelation genIntS genBimap propRangeRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersectionB"
+            "range-restriction-and-intersection-b"
             (propRelation genIntS genBimap propRangeRestrictionAndIntersectionB)
         ],
       testGroup
         "Relation - Pairs list"
-        [ testProperty
+        [ testPropertyNamed
             "DomainRestrictionAndIntersection"
+            "domain-restriction-and-intersection"
             (propRelation genIntS genPairsList propDomainRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "DomainRestrictionAndIntersectionB"
+            "domain-restriction-and-intersection-b"
             (propRelation genIntS genPairsList propDomainRestrictionAndIntersectionB),
-          testProperty
+          testPropertyNamed
             "DomainExclusionAndSetDifference"
+            "domain-exclusion-and-set-difference"
             (propRelation genIntS genPairsList propDomainExclusionAndSetDifference),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersection"
+            "range-restriction-and-intersection"
             (propRelation genIntS genPairsList propRangeRestrictionAndIntersection),
-          testProperty
+          testPropertyNamed
             "RangeRestrictionAndIntersectionB"
+            "range-restriction-and-intersection-b"
             (propRelation genIntS genPairsList propRangeRestrictionAndIntersectionB)
         ],
       testGroup
         "Relations"
-        [ testProperty
+        [ testPropertyNamed
             "Set instance"
+            "set-instance"
             (propRelations genIntS genSet propDomainExclusionAndUnion),
-          testProperty
+          testPropertyNamed
             "Map instance"
+            "map-instance"
             (propRelations genIntS genMap propDomainExclusionAndUnion),
-          testProperty
+          testPropertyNamed
             "Bimap instance"
+            "bimap-instance"
             (propRelations genIntS genBimap propDomainExclusionAndUnion)
         ]
     ]

--- a/eras/byron/ledger/impl/test/Test/Options.hs
+++ b/eras/byron/ledger/impl/test/Test/Options.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Options
   ( TestScenario (..),
@@ -32,7 +29,7 @@ import Test.Tasty
     includingOptions,
     testGroup,
   )
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.Ingredients (Ingredient (..), composeReporters)
 import Test.Tasty.Ingredients.Basic (consoleTestReporter, listingTests)
 import Test.Tasty.Options
@@ -96,7 +93,10 @@ tsGroupToTree tsGroup = askOption $ \scenario -> case tsGroup scenario of
   Group {groupName, groupProperties} ->
     testGroup
       (unGroupName groupName)
-      (uncurry testProperty . first unPropertyName <$> groupProperties)
+      (uncurry testPropertyNoName <$> groupProperties)
+
+testPropertyNoName :: PropertyName -> Property -> TestTree
+testPropertyNoName propName@(PropertyName name) = testPropertyNamed name propName
 
 -- | Convenient alias for TestScenario-dependent @Property@s
 type TSProperty = TestScenario -> Property

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
@@ -1,8 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 module Test.Cardano.Ledger.Shelley.Serialisation.Tripping.JSON
   ( tests,
@@ -80,12 +78,20 @@ tests :: TestTree
 tests =
   testGroup
     "Shelley Genesis"
-    [ testProperty "Address round trip" $
-        prop_roundtrip_Address_JSON @C_Crypto Proxy,
-      testProperty "Genesis round trip" $
-        prop_roundtrip_ShelleyGenesis_JSON @C Proxy,
-      testProperty "fund pair round trip" $
-        prop_roundtrip_FundPair_JSON @C_Crypto Proxy,
-      testProperty "delegation pair round trip" $
-        prop_roundtrip_GenesisDelegationPair_JSON @C_Crypto Proxy
+    [ testPropertyNamed
+        "Address round trip"
+        "address-round-trip"
+        $ prop_roundtrip_Address_JSON @C_Crypto Proxy,
+      testPropertyNamed
+        "Genesis round trip"
+        "genesis-round-trip"
+        $ prop_roundtrip_ShelleyGenesis_JSON @C Proxy,
+      testPropertyNamed
+        "Fund pair round trip"
+        "fund-pair-round-trip"
+        $ prop_roundtrip_FundPair_JSON @C_Crypto Proxy,
+      testPropertyNamed
+        "Delegation pair round trip"
+        "delegation-pair-round-trip"
+        $ prop_roundtrip_GenesisDelegationPair_JSON @C_Crypto Proxy
     ]

--- a/libs/small-steps-test/test/examples/Main.hs
+++ b/libs/small-steps-test/test/examples/Main.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
--- TODO Remove use of deprecated function testProperty
 
 import qualified Control.State.Transition.Examples.CommitReveal as CommitReveal
 import qualified Control.State.Transition.Examples.GlobalSum as GSum
@@ -28,11 +25,11 @@ main = do
                   Sum.prop_Bounded,
               testPropertyNamed
                 "Only valid traces are generated"
-                "prop_onlyValidTracesAreGenerated"
+                "prop-only-valid-traces-generated"
                 Sum.prop_onlyValidTracesAreGenerated,
               testPropertyNamed
                 "Classified"
-                "prop_Classified"
+                "prop-classified"
                 Sum.prop_Classified,
               Tasty.QuickCheck.testProperty
                 "Classified (QuickCheck)"


### PR DESCRIPTION
This PR removes all Hedgehog deprecation warnings. I used lowercase with hyphens for short test names.

closes #2910