### PR TITLE
Add `FromSharedCBOR` constraint to the `EraTxOut`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -458,7 +458,7 @@ instance EraTxBody era => ToCBOR (TxBody era) where
 
 -- ===============================================================
 
-instance EraTxOut era => ToCBOR (TxOut era) where
+instance (Era era, ToCBOR (CompactForm (Value era))) => ToCBOR (TxOut era) where
   toCBOR (TxOutCompact addr coin) =
     encodeListLen 2
       <> toCBOR addr
@@ -469,7 +469,10 @@ instance EraTxOut era => FromCBOR (TxOut era) where
 
 -- This instance does not do any sharing and is isomorphic to FromCBOR
 -- use the weakest constraint necessary
-instance (EraTxOut era, DecodeNonNegative (Value era)) => FromSharedCBOR (TxOut era) where
+instance
+  (Era era, Show (Value era), DecodeNonNegative (Value era), Compactible (Value era)) =>
+  FromSharedCBOR (TxOut era)
+  where
   type Share (TxOut era) = Interns (Credential 'Staking (Crypto era))
   fromSharedCBOR _ =
     decodeRecordNamed "TxOut" (const 2) $ do

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -66,9 +66,10 @@ import Cardano.Ledger.BaseTypes (ProtVer)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.CompactAddress (CompactAddr, compactAddr, decompactAddr, isBootstrapCompactAddr)
 import Cardano.Ledger.Compactible (Compactible (..))
+import Cardano.Ledger.Credential
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes
-import Cardano.Ledger.Keys (KeyRole (Witness))
+import Cardano.Ledger.Keys (KeyRole (Staking, Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey)
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash (..))
@@ -85,6 +86,7 @@ import Data.Maybe (fromMaybe)
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
+import Data.Sharing (FromSharedCBOR (Share), Interns)
 import Data.Typeable (Typeable)
 import Data.Void (Void, absurd)
 import Data.Word (Word64)
@@ -177,6 +179,8 @@ class
     FromCBOR (Value era),
     ToCBOR (Value era),
     FromCBOR (TxOut era),
+    FromSharedCBOR (TxOut era),
+    Share (TxOut era) ~ Interns (Credential 'Staking (Crypto era)),
     ToCBOR (TxOut era),
     NoThunks (TxOut era),
     NFData (TxOut era),


### PR DESCRIPTION
In order to not propagate this `FromSharedCBOR` constraint all the way to consensus it should be as a superclass of `EraTxOut` (before it was superclass of `ShelleyBasedEra` synonym, which was removed in #2901)