### PR TITLE
ValidateScript can only be applied to phase 1 scripts, enforced by types. Take 2

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Language.hs
@@ -1,53 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
 
--- | This module provides data structures and operations for talking about
---     Non-native Script languages. It is expected that new languages (or new
---     versions of old languages) will be added here.
-module Cardano.Ledger.Alonzo.Language where
+-- | This module exports the module Cardano.Ledger.Language. That module exports data
+--   structures and operations for talking about Non-native Script languages. It is expected that new languages (or new
+--   versions of old languages) will be added there, and just imported here.
+module Cardano.Ledger.Alonzo.Language (module Cardano.Ledger.Language) where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeInt)
-import Control.DeepSeq (NFData (..))
-import Data.Coders (invalidKey)
-import Data.Ix (Ix)
-import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks)
-
--- | Non-Native Script language. This is an Enumerated type.
--- This is expected to be an open type. We will add new Constuctors
--- to this type as additional Non-Native scripting language as are added.
--- We use an enumerated type for two reasons.
--- 1) We can write total functions by case analysis over the constructors
--- 2) We will use DataKinds to make some datatypes  indexed by Language
--- For now, the only Non-Native Scriting language is Plutus
--- We might add new languages in the futures.
---
--- Note that the the serialization of 'Language' depends on the ordering.
-data Language
-  = PlutusV1
-  | PlutusV2
-  deriving (Eq, Generic, Show, Ord, Enum, Bounded, Ix)
-
-instance NoThunks Language
-
-instance NFData Language
-
-instance ToCBOR Language where
-  toCBOR PlutusV1 = toCBOR (0 :: Int)
-  toCBOR PlutusV2 = toCBOR (1 :: Int)
-
-instance FromCBOR Language where
-  fromCBOR = do
-    n <- decodeInt
-    lang <-
-      if n >= fromEnum (minBound :: Language) && n <= fromEnum (maxBound :: Language)
-        then pure $ toEnum n
-        else invalidKey (fromIntegral n)
-    -- We pattern match on lang so that the type checker will
-    -- notice when new language versions are added.
-    pure $ case lang of
-      PlutusV1 -> lang
-      PlutusV2 -> lang
-
-nonNativeLanguages :: [Language]
-nonNativeLanguages = [minBound .. maxBound]
+import Cardano.Ledger.Language

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -53,7 +53,6 @@ module Cardano.Ledger.Alonzo.Tx
     txrdmrs,
     TxBody,
     AlonzoTxBody (..),
-    validateAlonzoNativeScript,
     -- Figure 4
     totExUnits,
     isTwoPhaseScriptAddress,
@@ -135,7 +134,6 @@ import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..), Wdrl (..), unWdrl)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import Cardano.Ledger.ShelleyMA.Tx (validateTimelock)
-import Cardano.Ledger.ShelleyMA.TxBody (ShelleyMAEraTxBody)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val ((<+>), (<×>)))
 import Control.DeepSeq (NFData (..))
@@ -188,16 +186,7 @@ instance CC.Crypto c => EraTx (AlonzoEra c) where
   witsTxL = witsAlonzoTxL
   auxDataTxL = auxDataAlonzoTxL
   sizeTxF = sizeAlonzoTxF
-  validateScript = validateAlonzoNativeScript
-
-validateAlonzoNativeScript ::
-  forall era.
-  (EraTx era, ShelleyMAEraTxBody era, Script era ~ AlonzoScript era) =>
-  Script era ->
-  Tx era ->
-  Bool
-validateAlonzoNativeScript (TimelockScript script) tx = validateTimelock @era script tx
-validateAlonzoNativeScript (PlutusScript _ _) _tx = True
+  validateScript (Phase1Script script) tx = validateTimelock @(AlonzoEra c) script tx
 
 class (EraTx era, AlonzoEraTxBody era, AlonzoEraWitnesses era) => AlonzoEraTx era where
   isValidTxL :: Lens' (Core.Tx era) IsValid

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -208,17 +208,18 @@ validateFailedBabbageScripts ::
   Set (ScriptHash (Crypto era)) ->
   Test (Shelley.UtxowPredicateFailure era)
 validateFailedBabbageScripts tx utxo neededHashes =
-  let failedScripts =
+  let phase1Map = getPhase1 (txscripts utxo tx)
+      failedScripts =
         Map.filterWithKey
-          ( \hs script ->
-              let zero = hs `Set.member` neededHashes
-                  one = isNativeScript @era script
-                  two = hashScript @era script /= hs -- TODO this is probably not needed. Only the script is transmitted on the wire, we compute the hash
-                  three = not (validateScript @era script tx)
-                  answer = zero && one && (two || three)
+          ( \hs (script, phased) ->
+              let needed = hs `Set.member` neededHashes
+                  hashDisagrees = hashScript @era script /= hs
+                  -- TODO this is probably not needed. Only the script is transmitted on the wire, we compute the hash
+                  scriptDoesNotValidate = not (validateScript @era phased tx)
+                  answer = needed && (hashDisagrees || scriptDoesNotValidate)
                in answer
           )
-          (txscripts utxo tx)
+          phase1Map
    in failureUnless
         (Map.null failedScripts)
         (Shelley.ScriptWitnessNotValidatingUTXOW $ Map.keysSet failedScripts)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.ShelleyMA.Tx (validateTimelock)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Applicative ((<|>))
 import Control.SetAlgebra (eval, (◁))
@@ -59,7 +60,7 @@ instance CC.Crypto c => EraTx (BabbageEra c) where
   witsTxL = witsAlonzoTxL
   auxDataTxL = auxDataAlonzoTxL
   sizeTxF = sizeAlonzoTxF
-  validateScript = validateAlonzoNativeScript
+  validateScript (Phase1Script script) tx = validateTimelock @(BabbageEra c) script tx
 
 instance CC.Crypto c => AlonzoEraTx (BabbageEra c) where
   isValidTxL = isValidAlonzoTxL

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -46,6 +46,7 @@ library
   other-modules:
     Cardano.Ledger.Conway.Era
   build-depends:
+                bytestring,
                 cardano-binary,
                 cardano-crypto-class,
                 cardano-ledger-alonzo,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -17,16 +17,25 @@ import Cardano.Ledger.Alonzo.Data
     hashAlonzoAuxiliaryData,
     validateAlonzoAuxiliaryData,
   )
+import Cardano.Ledger.Alonzo.Language (Language)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript)
 import Cardano.Ledger.Babbage.Scripts (babbageScriptPrefixTag)
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
+import Data.ByteString.Short (ShortByteString)
+
+type instance SomeScript 'PhaseOne (ConwayEra c) = Timelock c
+
+type instance SomeScript 'PhaseTwo (ConwayEra c) = (Language, ShortByteString)
 
 instance CC.Crypto c => EraScript (ConwayEra c) where
   type Script (ConwayEra c) = AlonzoScript (ConwayEra c)
-  isNativeScript x = not (isPlutusScript x)
   scriptPrefixTag = babbageScriptPrefixTag
+  phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
+  phaseScript PhaseTwoRep (PlutusScript lang bytes) = Just (Phase2Script lang bytes)
+  phaseScript _ _ = Nothing
 
 instance CC.Crypto c => EraAuxiliaryData (ConwayEra c) where
   type AuxiliaryData (ConwayEra c) = AlonzoAuxiliaryData (ConwayEra c)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -13,7 +14,6 @@ import Cardano.Ledger.Alonzo.Tx
     isValidAlonzoTxL,
     mkBasicAlonzoTx,
     sizeAlonzoTxF,
-    validateAlonzoNativeScript,
     witsAlonzoTxL,
   )
 import Cardano.Ledger.Alonzo.TxSeq
@@ -29,6 +29,7 @@ import Cardano.Ledger.Conway.TxBody ()
 import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.ShelleyMA.Tx (validateTimelock)
 
 instance CC.Crypto c => EraTx (ConwayEra c) where
   type Tx (ConwayEra c) = AlonzoTx (ConwayEra c)
@@ -37,7 +38,7 @@ instance CC.Crypto c => EraTx (ConwayEra c) where
   witsTxL = witsAlonzoTxL
   auxDataTxL = auxDataAlonzoTxL
   sizeTxF = sizeAlonzoTxF
-  validateScript = validateAlonzoNativeScript
+  validateScript (Phase1Script script) tx = validateTimelock @(ConwayEra c) script tx
 
 instance CC.Crypto c => AlonzoEraTx (ConwayEra c) where
   isValidTxL = isValidAlonzoTxL

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -162,12 +162,16 @@ newtype Timelock crypto = TimelockConstr (MemoBytes (TimelockRaw crypto))
   deriving (Eq, Show, Generic)
   deriving newtype (ToCBOR, NoThunks, NFData, SafeToHash)
 
+type instance SomeScript 'PhaseOne (ShelleyMAEra ma c) = Timelock c
+
 -- | Since Timelock scripts are a strictly backwards compatible extension of
 -- Multisig scripts, we can use the same 'scriptPrefixTag' tag here as we did
 -- for the ValidateScript instance in Multisig
 instance MAClass ma crypto => EraScript (ShelleyMAEra ma crypto) where
   type Script (ShelleyMAEra ma crypto) = Timelock crypto
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
+  phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
+  phaseScript PhaseTwoRep _ = Nothing
 
 deriving via
   Mem (TimelockRaw crypto)

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -12,7 +13,7 @@ module Cardano.Ledger.ShelleyMA.Tx
   )
 where
 
-import Cardano.Ledger.Core (Era (Crypto), EraTx (..), EraWitnesses (..))
+import Cardano.Ledger.Core (Era (Crypto), EraTx (..), EraWitnesses (..), PhasedScript (..))
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
 import Cardano.Ledger.Shelley.Tx
   ( ShelleyTx,
@@ -48,7 +49,7 @@ instance MAClass ma crypto => EraTx (ShelleyMAEra ma crypto) where
 
   sizeTxF = sizeShelleyTxF
 
-  validateScript = validateTimelock
+  validateScript (Phase1Script script) tx = validateTimelock @(ShelleyMAEra ma crypto) script tx
 
 -- =======================================================
 -- Validating timelock scripts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -374,12 +374,13 @@ instance
 validateFailedScripts ::
   forall era. EraTx era => Tx era -> Test (UtxowPredicateFailure era)
 validateFailedScripts tx = do
-  let failedScripts =
+  let phase1Map = getPhase1 (tx ^. witsTxL . scriptWitsL)
+      failedScripts =
         Map.filterWithKey
-          ( \hs validator ->
-              hashScript @era validator /= hs || not (validateScript @era validator tx)
+          ( \hs (core, phase) ->
+              hashScript @era core /= hs || not (validateScript @era phase tx)
           )
-          (tx ^. witsTxL . scriptWitsL)
+          phase1Map
   failureUnless (Map.null failedScripts) $
     ScriptWitnessNotValidatingUTXOW (Map.keysSet failedScripts)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
@@ -89,11 +89,15 @@ newtype MultiSig crypto = MultiSigConstr (MemoBytes (MultiSigRaw crypto))
 nativeMultiSigTag :: BS.ByteString
 nativeMultiSigTag = "\00"
 
+type instance SomeScript 'PhaseOne (ShelleyEra c) = MultiSig c
+
 instance CC.Crypto c => EraScript (ShelleyEra c) where
   type Script (ShelleyEra c) = MultiSig c
 
   -- In the ShelleyEra there is only one kind of Script and its tag is "\x00"
   scriptPrefixTag _script = nativeMultiSigTag
+  phaseScript PhaseOneRep multisig = Just (Phase1Script multisig)
+  phaseScript PhaseTwoRep _ = Nothing
 
 deriving newtype instance NFData (MultiSig era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -212,7 +212,7 @@ instance CC.Crypto crypto => EraTx (ShelleyEra crypto) where
 
   sizeTxF = sizeShelleyTxF
 
-  validateScript = validateNativeMultiSigScript
+  validateScript (Phase1Script multisig) tx = validateNativeMultiSigScript multisig tx
 
 deriving newtype instance
   ( NFData (Core.TxBody era),

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -58,6 +58,7 @@ library
     Cardano.Ledger.Keys
     Cardano.Ledger.Keys.Bootstrap
     Cardano.Ledger.Keys.WitVKey
+    Cardano.Ledger.Language
     Cardano.Ledger.PoolDistr
     Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.SafeHash

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | This module provides data structures and operations for talking about
+--     Non-native Script languages. It is expected that new languages (or new
+--     versions of old languages) will be added here.
+module Cardano.Ledger.Language where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeInt)
+import Control.DeepSeq (NFData (..))
+import Data.Coders (invalidKey)
+import Data.Ix (Ix)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+-- | Non-Native Script language. This is an Enumerated type.
+-- This is expected to be an open type. We will add new Constuctors
+-- to this type as additional Non-Native scripting language as are added.
+-- We use an enumerated type for two reasons.
+-- 1) We can write total functions by case analysis over the constructors
+-- 2) We will use DataKinds to make some datatypes  indexed by Language
+-- For now, the only Non-Native Scriting language is Plutus
+-- We might add new languages in the futures.
+--
+-- Note that the the serialization of 'Language' depends on the ordering.
+data Language
+  = PlutusV1
+  | PlutusV2
+  deriving (Eq, Generic, Show, Ord, Enum, Bounded, Ix)
+
+instance NoThunks Language
+
+instance NFData Language
+
+instance ToCBOR Language where
+  toCBOR PlutusV1 = toCBOR (0 :: Int)
+  toCBOR PlutusV2 = toCBOR (1 :: Int)
+
+instance FromCBOR Language where
+  fromCBOR = do
+    n <- decodeInt
+    lang <-
+      if n >= fromEnum (minBound :: Language) && n <= fromEnum (maxBound :: Language)
+        then pure $ toEnum n
+        else invalidKey (fromIntegral n)
+    -- We pattern match on lang so that the type checker will
+    -- notice when new language versions are added.
+    pure $ case lang of
+      PlutusV1 -> lang
+      PlutusV2 -> lang
+
+nonNativeLanguages :: [Language]
+nonNativeLanguages = [minBound .. maxBound]


### PR DESCRIPTION
This is a replacement for https://github.com/input-output-hk/cardano-ledger/pull/2921


Changed ValidateScript, so that validateScript has type
PhasedScript 'One era -> Core.Tx era -> Bool
Type ensure only scriptes from Phase1 can be validated.
Introduces types Phase, PhasedScript, and type family SomeScript

All this built on top of Alexey's major rewrite
