### PR TITLE
Make VMap.VU an Unboxed Vector

### DIFF
--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -59,7 +59,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable as VS
-import qualified Data.Vector.Storable as VU
+import qualified Data.Vector.Unboxed as VU
 import qualified GHC.Exts as Exts
 import GHC.Generics (Generic)
 import NoThunks.Class


### PR DESCRIPTION
VMap.VU was erroneously a Storable Vector.