### PR TITLE
set LC_ALL="C.UTF-8" inside nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -59,6 +59,7 @@ let
         fi
       }
       PROMPT_COMMAND=prompt
+      export LC_ALL="C.UTF-8"
     '';
   };
 


### PR DESCRIPTION
Micro PR :microscope:  to set `LC_ALL="C.UTF-8"` in the nix shell. This is needed if you want to build our haddocks, since we use unicode characters. Thanks goes to @teodanciu who showed me how to do this :)