### PR TITLE
Remove unused data-default-class library from shelley-ma dependencies

### DIFF
--- a/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -64,7 +64,6 @@ library
     cardano-slotting,
     cborg,
     containers,
-    data-default-class,
     deepseq,
     groups,
     mtl,


### PR DESCRIPTION
Getting intermittent `unused-packages` error.  It seems that this library is not used 