### PR TITLE
Conway GenDelegs update

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -11,6 +11,7 @@
 module Cardano.Ledger.Conway (ConwayEra) where
 
 import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.Babbage.Rules (babbageMinUTxOValue)
@@ -40,7 +41,6 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
 import qualified Data.Set as Set
 import Lens.Micro
-import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 
 -- =====================================================
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Babbage.Tx
   )
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Conway.Genesis (AlonzoGenesis, extendPPWithGenesis)
+import Cardano.Ledger.Conway.Genesis (extendPPWithGenesis)
 import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxBody (BabbageEraTxBody (..))
@@ -40,6 +40,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
 import qualified Data.Set as Set
 import Lens.Micro
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 
 -- =====================================================
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -1,8 +1,10 @@
 module Cardano.Ledger.Conway.Genesis
-  ( AlonzoGenesis (..),
+  ( ConwayGenesis (..),
     extendPPWithGenesis,
   )
 where
 
-import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Babbage.Genesis (extendPPWithGenesis)
+import Cardano.Ledger.Keys (GenDelegs)
+
+newtype ConwayGenesis crypto = ConwayGenesis (GenDelegs crypto)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -13,7 +13,6 @@
 module Cardano.Ledger.Conway.Translation where
 
 import Cardano.Binary (DecoderError)
-import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Babbage (BabbageEra)
@@ -41,6 +40,7 @@ import Cardano.Ledger.Shelley.API
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD)
 import Data.Coerce
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 
 --------------------------------------------------------------------------------
 -- Translation from Alonzo to Babbage
@@ -59,7 +59,7 @@ import Data.Coerce
 
 type instance PreviousEra (ConwayEra c) = BabbageEra c
 
-type instance TranslationContext (ConwayEra c) = AlonzoGenesis
+type instance TranslationContext (ConwayEra c) = ConwayGenesis c
 
 instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
   translateEra ctxt nes =
@@ -75,7 +75,7 @@ instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
         }
 
 instance Crypto c => TranslateEra (ConwayEra c) ShelleyGenesis where
-  translateEra ctxt genesis =
+  translateEra ctxt@(ConwayGenesis (API.GenDelegs genDelegs)) genesis =
     pure
       API.ShelleyGenesis
         { API.sgSystemStart = API.sgSystemStart genesis,
@@ -90,7 +90,7 @@ instance Crypto c => TranslateEra (ConwayEra c) ShelleyGenesis where
           API.sgUpdateQuorum = API.sgUpdateQuorum genesis,
           API.sgMaxLovelaceSupply = API.sgMaxLovelaceSupply genesis,
           API.sgProtocolParams = translateEra' ctxt (API.sgProtocolParams genesis),
-          API.sgGenDelegs = API.sgGenDelegs genesis,
+          API.sgGenDelegs = genDelegs,
           API.sgInitialFunds = API.sgInitialFunds genesis,
           API.sgStaking = API.sgStaking genesis
         }

--- a/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -64,7 +64,6 @@ library
     cardano-slotting,
     cborg,
     containers,
-    data-default-class,
     deepseq,
     groups,
     mtl,


### PR DESCRIPTION
This PR makes it possible to swap out the governance map when translating from Babbage era to Conway era by passing the new governance map into the translation context.

closes #2948 