### PR TITLE
Added precision to the Babbage era specification concerning the use of new features with PlutusV1 scripts

### DIFF
--- a/eras/babbage/formal-spec/utxo.tex
+++ b/eras/babbage/formal-spec/utxo.tex
@@ -271,8 +271,10 @@ In the UTXO rule, we switch from a manual estimation of the size consumed by $\U
 
 To the UTXOW rule, in addition to the changes required by the new
 features, we add a check that all scripts and datums involved in the
-transaction are well-formed. Also, we forbid transactions that use the
-new features and try to execute $\PlutusVI$ scripts.
+transaction are well-formed. Also, we forbid transactions that try to
+execute $\PlutusVI$ scripts and use the new features which can't be
+translated to $\PlutusVI$'s $\TxInfo$ (reference inputs, inline datums
+and reference scripts).
 
 \begin{figure}
   \begin{equation}

--- a/eras/babbage/formal-spec/utxo.tex
+++ b/eras/babbage/formal-spec/utxo.tex
@@ -271,10 +271,11 @@ In the UTXO rule, we switch from a manual estimation of the size consumed by $\U
 
 To the UTXOW rule, in addition to the changes required by the new
 features, we add a check that all scripts and datums involved in the
-transaction are well-formed. Also, we forbid transactions that try to
+transaction are well-formed. We forbid transactions that try to
 execute $\PlutusVI$ scripts and use the new features which can't be
 translated to $\PlutusVI$'s $\TxInfo$ (reference inputs, inline datums
-and reference scripts).
+and reference scripts). We also forbid transactions that involve Byron 
+addresses.
 
 \begin{figure}
   \begin{equation}


### PR DESCRIPTION
This PR adds a precision to the Babbage era specification which specifies which features can't be used in a transaction which try to execute PlutusV1 scripts.

Don't hesitate to change the formulation if it's not clear enough.