### PR TITLE
Improve performance of access to coin in TxOut

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -70,8 +70,8 @@ import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules.Ppup (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..), updateUTxOState)
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, totalDeposits)
-import Cardano.Ledger.Val as Val (Val (coin, (<->)))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance, totalDeposits)
+import Cardano.Ledger.Val as Val (Val ((<->)))
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Cardano.Slotting.Slot (SlotNo)
 import Control.Monad.Trans.Reader (ReaderT, asks)
@@ -281,7 +281,7 @@ scriptsNotValidateTransition = do
   pure
     $! us
       { _utxo = UTxO utxoKeep,
-        _fees = fees <> Val.coin (balance (UTxO utxoDel)),
+        _fees = fees <> coinBalance (UTxO utxoDel),
         _stakeDistro = updateStakeDistribution (_stakeDistro us) (UTxO utxoDel) mempty
       }
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -64,12 +64,12 @@ import Cardano.Ledger.Mary.Value (AssetName (..), MultiAsset (..), PolicyID (..)
 import Cardano.Ledger.Pretty.Alonzo ()
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
 import Cardano.Ledger.ShelleyMA.Era ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), translateTimelock)
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.Ledger.Val (Val (coin, isAdaOnly, (<+>), (<×>)))
+import Cardano.Ledger.Val (Val (isAdaOnly, (<+>), (<×>)))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad (replicateM)
 import Data.Either (fromRight)
@@ -451,7 +451,7 @@ instance Mock c => EraGen (AlonzoEra c) where
 
 sumCollateral :: (EraTx era, AlonzoEraTxBody era) => Tx era -> UTxO era -> Coin
 sumCollateral tx (UTxO utxo) =
-  coin . balance . UTxO $ Map.restrictKeys utxo collateral_
+  coinBalance . UTxO $ Map.restrictKeys utxo collateral_
   where
     collateral_ = tx ^. bodyTxL . collateralInputsTxBodyL
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -6,20 +6,24 @@
 
 -- | Figure 2: Functions related to fees and collateral
 --   Babbage Specification
-module Cardano.Ledger.Babbage.Collateral where
+module Cardano.Ledger.Babbage.Collateral
+  ( isTwoPhaseScriptAddress,
+    collAdaBalance,
+    collOuts,
+  )
+where
 
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Tx (isTwoPhaseScriptAddressFromMap)
-import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..))
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (txscripts))
 import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..), BabbageTxBody, BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (TxIx (..), txIxFromIntegral)
 import Cardano.Ledger.Block (txid)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val ((<->))
-import Control.SetAlgebra (eval, (◁))
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Word (Word16, Word64)
@@ -36,19 +40,17 @@ isTwoPhaseScriptAddress ::
   Bool
 isTwoPhaseScriptAddress tx utxo = isTwoPhaseScriptAddressFromMap @era (txscripts utxo tx)
 
-collBalance ::
-  forall era.
+collAdaBalance ::
   (BabbageEraTxBody era, TxOut era ~ BabbageTxOut era) =>
   TxBody era ->
-  UTxO era ->
-  Value era
-collBalance txBody (UTxO m) =
+  Map.Map (TxIn (Crypto era)) (TxOut era) ->
+  Coin
+collAdaBalance txBody utxoCollateral =
   case txBody ^. collateralReturnTxBodyL of
     SNothing -> colbal
-    SJust txOut -> colbal <-> (txOut ^. valueTxOutL @era)
+    SJust txOut -> colbal <-> (txOut ^. coinTxOutL)
   where
-    col = UTxO (eval ((txBody ^. collateralInputsTxBodyL) ◁ m))
-    colbal = balance @era col
+    colbal = coinBalance $ UTxO utxoCollateral
 
 collOuts ::
   ( BabbageEraTxBody era,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -71,8 +71,8 @@ import Cardano.Ledger.Serialization (Sized (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoPredFailure, UtxoEnv)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley
-import Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), areAllAdaOnly, balance)
+import Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
 import qualified Cardano.Ledger.ShelleyMA.Rules as ShelleyMA
   ( validateOutsideValidityIntervalUTxO,
     validateValueNotConservedUTxO,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Alonzo.Rules
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModels)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, ScriptResult (Fails, Passes))
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
-import Cardano.Ledger.Babbage.Collateral (collBalance, collOuts)
+import Cardano.Ledger.Babbage.Collateral (collAdaBalance, collOuts)
 import Cardano.Ledger.Babbage.Era (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody
@@ -247,7 +247,7 @@ scriptsNo = do
   {- utxoDel  = getField @"collateral" txb ◁ utxo -}
   let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
       UTxO collouts = collOuts txBody
-      collateralFees = Val.coin (collBalance txBody utxo) -- NEW to Babbage
+      collateralFees = collAdaBalance txBody utxoDel -- NEW to Babbage
   pure
     $! us {- (collInputs txb ⋪ utxo) ∪ collouts tx -}
       { _utxo = UTxO (Map.union utxoKeep collouts), -- NEW to Babbage

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API.Types
 import Cardano.Ledger.Shelley.EpochBoundary
 import Cardano.Ledger.Shelley.Rules.EraMapping ()
+import Cardano.Ledger.Shelley.UTxO (coinBalance)
 import Cardano.Ledger.Slot
 import Cardano.Ledger.Val ((<->))
 import qualified Data.ByteString.Short as SBS
@@ -131,7 +132,7 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
 
     reserves :: Coin
     reserves =
-      word64ToCoin (sgMaxLovelaceSupply genesisShelley) <-> balance utxoShelley
+      word64ToCoin (sgMaxLovelaceSupply genesisShelley) <-> coinBalance utxoShelley
 
     epochState :: EpochState (ShelleyEra c)
     epochState =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
@@ -21,14 +21,14 @@ import Cardano.Ledger.Shelley.API.Types
     PoolDistr (PoolDistr),
     ShelleyGenesis (sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams),
     StrictMaybe (SNothing),
-    balance,
     genesisUTxO,
     word64ToCoin,
   )
 import Cardano.Ledger.Shelley.EpochBoundary (emptySnapShots)
 import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses, smartUTxOState)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams)
-import Cardano.Ledger.Val (Val (coin, (<->)))
+import Cardano.Ledger.Shelley.UTxO (coinBalance)
+import Cardano.Ledger.Val (Val ((<->)))
 import Control.State.Transition (STS (State))
 import Data.Default.Class (Default, def)
 import Data.Kind (Type)
@@ -90,6 +90,6 @@ initialStateFromGenesis extendPPWithGenesis' sg ag =
   where
     initialEpochNo = 0
     initialUtxo = genesisUTxO sg
-    reserves = word64ToCoin (sgMaxLovelaceSupply sg) <-> coin (balance initialUtxo)
+    reserves = word64ToCoin (sgMaxLovelaceSupply sg) <-> coinBalance initialUtxo
     genDelegs = sgGenDelegs sg
     pp = sgProtocolParams sg

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -88,7 +88,6 @@ import Cardano.Ledger.Shelley.LedgerState
     RewardUpdate,
     UTxOState (..),
     circulation,
-    consumed,
     createRUpd,
     incrementalStakeDistr,
     minfee,
@@ -107,7 +106,7 @@ import Cardano.Ledger.Shelley.Rewards (StakeShare (..))
 import Cardano.Ledger.Shelley.Rules.NewEpoch (calculatePoolDistr)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), ShelleyWitnesses, WitnessSetHKD (..))
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..), ShelleyEraTxBody, WitVKey (..))
-import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinConsumed)
 import Cardano.Ledger.Slot (epochInfoSize)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val ((<->))
@@ -546,7 +545,7 @@ addShelleyKeyWitnesses (ShelleyTx b ws aux) newWits = ShelleyTx b ws' aux
 instance CC.Crypto c => CLI (ShelleyEra c) where
   evaluateMinFee = minfee
 
-  evaluateConsumed = consumed
+  evaluateConsumed = coinConsumed
 
   addKeyWitnesses = addShelleyKeyWitnesses
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -24,8 +24,7 @@ import Cardano.Ledger.Shelley.LedgerState
     UTxOState (..),
     rewards,
   )
-import Cardano.Ledger.Shelley.UTxO (balance)
-import qualified Cardano.Ledger.Val as Val
+import Cardano.Ledger.Shelley.UTxO (coinBalance)
 import Data.Foldable (fold)
 
 data AdaPots = AdaPots
@@ -56,7 +55,7 @@ totalAdaPotsES (EpochState (AccountState treasury_ reserves_) _ ls _ _ _) =
     UTxOState u deposits fees_ _ _ = lsUTxOState ls
     DPState dstate _ = lsDPState ls
     rewards_ = fold (rewards dstate)
-    coins = Val.coin $ balance u
+    coins = coinBalance u
 
 -- | Calculate the total ada in the epoch state
 totalAdaES :: EraTxOut era => EpochState era -> Coin

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -48,7 +48,6 @@ module Cardano.Ledger.Shelley.LedgerState
     diffWitHashes,
     minfee,
     produced,
-    consumed,
     witsFromTxWitnesses,
     propWits,
 
@@ -96,7 +95,7 @@ import Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rules.Utxow (propWits)
 import Cardano.Ledger.Shelley.Tx (minfee, witsFromTxWitnesses)
-import Cardano.Ledger.Shelley.UTxO (consumed, keyRefunds, produced)
+import Cardano.Ledger.Shelley.UTxO (keyRefunds, produced)
 import Data.Default.Class (def)
 import Data.Set (Set)
 import qualified Data.Set as Set

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -57,7 +57,6 @@ import Cardano.Ledger.UnifiedMap
   ( Triple,
     UMap (..),
   )
-import qualified Cardano.Ledger.Val as Val
 import Control.SetAlgebra (dom, eval, (∈))
 import Control.State.Transition (STS (State))
 import Data.Foldable (fold)
@@ -107,7 +106,7 @@ incrementalAggregateUtxoCoinByCredential mode (UTxO u) initial =
         Coin 0 -> Nothing
         final -> Just final
     accum ans@(IStake stake ptrs) out =
-      let c = Val.coin (out ^. valueTxOutL)
+      let c = out ^. coinTxOutL
        in case out ^. addrTxOutL of
             Addr _ _ (StakeRefPtr p) -> IStake stake (Map.alter (keepOrDelete c) p ptrs)
             Addr _ _ (StakeRefBase hk) -> IStake (Map.alter (keepOrDelete c) hk stake) ptrs

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.Shelley.TxBody
   )
 import Cardano.Ledger.Shelley.UTxO
   ( UTxO (..),
-    balance,
+    coinBalance,
     keyRefunds,
     totalDeposits,
   )
@@ -183,7 +183,7 @@ returnRedeemAddrsToReserves es = es {esAccountState = acnt', esLState = ls'}
     utxoR = UTxO redeemers :: UTxO era
     acnt' =
       acnt
-        { _reserves = _reserves acnt <+> Val.coin (balance utxoR)
+        { _reserves = _reserves acnt <+> coinBalance utxoR
         }
     us' = us {_utxo = UTxO nonredeemers :: UTxO era}
     ls' = ls {lsUTxOState = us'}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -52,7 +52,6 @@ import Cardano.Ledger.UnifiedMap
     UnifiedMap,
   )
 import Cardano.Ledger.Val ((<+>), (<->))
-import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition (STS (State))
 import Data.Default.Class (Default, def)
 import Data.Foldable (fold, toList)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -88,7 +88,7 @@ import Cardano.Ledger.Shelley.TxBody
 import Cardano.Ledger.Shelley.UTxO
   ( UTxO (..),
     balance,
-    consumed,
+    coinConsumed,
     keyRefunds,
     produced,
     totalDeposits,
@@ -532,7 +532,7 @@ validateValueNotConservedUTxO pp utxo stakepools txb =
   failureUnless (consumedValue == producedValue) $
     ValueNotConservedUTxO consumedValue producedValue
   where
-    consumedValue = consumed pp utxo txb
+    consumedValue = Val.inject $ coinConsumed pp utxo txb
     producedValue = produced pp (`Map.notMember` stakepools) txb
 
 -- | Ensure there are no `TxOut`s that have less than @minUTxOValue@

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -12,7 +12,6 @@
 module Test.Cardano.Ledger.Shelley.Generator.Utxo
   ( genTx,
     Delta (..),
-    showBalance,
     encodedLen,
     myDiscard,
     pickRandomFromMap,
@@ -45,19 +44,16 @@ import Cardano.Ledger.Shelley.LedgerState
     DState (..),
     KeyPairs,
     LedgerState (..),
-    PState (..),
     UTxOState (..),
-    consumed,
     dpsDState,
     minfee,
-    produced,
     ptrsMap,
     rewards,
   )
 import Cardano.Ledger.Shelley.Rules.Delpl (DelplEnv)
 import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
 import Cardano.Ledger.Shelley.Tx (TxIn (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody, Wdrl (..))
+import Cardano.Ledger.Shelley.TxBody (Wdrl (..))
 import Cardano.Ledger.Shelley.UTxO
   ( UTxO (..),
     makeWitnessesFromScriptKeys,
@@ -111,31 +107,6 @@ myDiscard :: [Char] -> a
 myDiscard message = trace ("\nDiscarded trace: " ++ message) discard
 
 -- ====================================================
-
-showBalance ::
-  forall era.
-  ( EraTx era,
-    ShelleyEraTxBody era,
-    HasField "_keyDeposit" (PParams era) Coin,
-    HasField "_poolDeposit" (PParams era) Coin
-  ) =>
-  LedgerEnv era ->
-  UTxOState era ->
-  DPState (Crypto era) ->
-  Tx era ->
-  String
-showBalance
-  (LedgerEnv _ _ pparams _)
-  (UTxOState utxo _ _ _ _)
-  (DPState _ (PState stakepools _ _))
-  tx =
-    "\n\nConsumed: " ++ show (consumed pparams utxo txBody)
-      ++ "  Produced: "
-      ++ show (produced @era pparams (`Map.notMember` stakepools) txBody)
-    where
-      txBody = tx ^. bodyTxL
-
---  ========================================================================
 
 -- | Generates a transaction in the context of the LEDGER STS environment
 -- and state.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -82,7 +82,6 @@ import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance, totalDeposits, txins
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UnifiedMap (ViewMap)
 import Cardano.Ledger.Val ((<+>), (<->))
-import qualified Cardano.Ledger.Val as Val (coin)
 import Cardano.Protocol.TPraos.API (GetLedgerView)
 import Cardano.Protocol.TPraos.BHeader
   ( BHeader (..),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -78,7 +78,7 @@ import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
 import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL)
 import Cardano.Ledger.Shelley.Rules.Upec (votedValue)
 import Cardano.Ledger.Shelley.TxBody hiding (TxBody, TxOut)
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, totalDeposits, txins, txouts, pattern UTxO)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance, totalDeposits, txins, txouts)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UnifiedMap (ViewMap)
 import Cardano.Ledger.Val ((<+>), (<->))
@@ -270,7 +270,7 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
           )
           $ utxoBal === incrStakeBal
         where
-          utxoBal = Val.coin $ balance u'
+          utxoBal = coinBalance u'
           incrStakeBal = fold (credMap sd') <> fold (ptrMap sd')
           ptrs = ptrsMap . dpsDState $ dp
           ptrs' = ptrsMap . dpsDState $ dp'
@@ -488,7 +488,7 @@ utxoDepositsIncreaseByFeesWithdrawals SourceSignalTarget {source, signal, target
     us = lsUTxOState . esLState . nesEs . chainNes
     circulation chainSt =
       let UTxOState {_utxo = u, _deposited = d} = us chainSt
-       in Val.coin (balance u) <+> d
+       in coinBalance u <+> d
     (_, ledgerTr) = ledgerTraceFromBlock @era @ledger source signal
 
 -- | If we are not at an Epoch Boundary, then (Utxo + Deposits + Fees)
@@ -505,7 +505,7 @@ potsSumIncreaseWdrlsPerBlock SourceSignalTarget {source, signal, target} =
     potsSum chainSt =
       let UTxOState {_utxo = u, _deposited = d, _fees = f} =
             lsUTxOState . esLState . nesEs . chainNes $ chainSt
-       in Val.coin (balance u) <+> d <+> f
+       in coinBalance u <+> d <+> f
 
 -- | If we are not at an Epoch Boundary, then (Utxo + Deposits + Fees)
 -- increases by sum of withdrawals in a transaction
@@ -532,7 +532,7 @@ potsSumIncreaseWdrlsPerTx SourceSignalTarget {source = chainSt, signal = block} 
           target = LedgerState UTxOState {_utxo = u', _deposited = d', _fees = f'} _
         } =
         property (hasFailedScripts tx)
-          .||. (Val.coin (balance u') <+> d' <+> f') <-> (Val.coin (balance u) <+> d <+> f)
+          .||. (coinBalance u' <+> d' <+> f') <-> (coinBalance u <+> d <+> f)
           === fold (unWdrl (tx ^. bodyTxL . wdrlsTxBodyL))
 
 -- | (Utxo + Deposits + Fees) increases by the reward delta
@@ -562,7 +562,7 @@ potsSumIncreaseByRewardsPerTx SourceSignalTarget {source = chainSt, signal = blo
               UTxOState {_utxo = u', _deposited = d', _fees = f'}
               DPState {dpsDState = DState {_unified = umap2}}
         } =
-        (Val.coin (balance u') <+> d' <+> f') <-> (Val.coin (balance u) <+> d <+> f)
+        (coinBalance u' <+> d' <+> f') <-> (coinBalance u <+> d <+> f)
           === fold (UM.unUnify (UM.Rewards umap1)) <-> fold (UM.unUnify (UM.Rewards umap2))
 
 -- | The Rewards pot decreases by the sum of withdrawals in a transaction
@@ -634,11 +634,11 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
         certs = toList (txb ^. certsTxBodyL)
         pools = _pParams . dpsPState $ dstate
         created =
-          Val.coin (balance u')
+          coinBalance u'
             <+> txb ^. feeTxBodyL
             <+> totalDeposits pp_ (`Map.notMember` pools) certs
         consumed_ =
-          Val.coin (balance u)
+          coinBalance u
             <+> keyRefunds pp_ txb
             <+> fold (unWdrl (txb ^. wdrlsTxBodyL))
 
@@ -673,12 +673,12 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
           txb = tx ^. bodyTxL
           pools = _pParams . dpsPState $ dstate
           inps =
-            Val.coin (balance @era (UTxO (Map.restrictKeys u (txb ^. inputsTxBodyL))))
+            coinBalance @era (UTxO (Map.restrictKeys u (txb ^. inputsTxBodyL)))
               <> keyRefunds pp_ txb
               <> fold (unWdrl (txb ^. wdrlsTxBodyL))
           outs =
             let certs = toList (txb ^. certsTxBodyL)
-             in Val.coin (balance (txouts @era txb))
+             in coinBalance (txouts @era txb)
                   <> txb ^. feeTxBodyL
                   <> totalDeposits pp_ (`Map.notMember` pools) certs
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Core
     EraTxOut (..),
     bootAddrTxOutF,
     coinTxOutL,
+    compactCoinTxOutL,
     isAdaOnlyTxOutF,
     EraTxBody (..),
     EraAuxiliaryData (..),
@@ -288,6 +289,22 @@ coinTxOutL =
             txOut & compactValueTxOutL .~ modifyCompactCoin (const (toCompactPartial c)) cVal
     )
 {-# INLINE coinTxOutL #-}
+
+compactCoinTxOutL :: EraTxOut era => Lens' (TxOut era) (CompactForm Coin)
+compactCoinTxOutL =
+  lens
+    ( \txOut ->
+        case txOut ^. valueEitherTxOutL of
+          Left val -> toCompactPartial (coin val)
+          Right cVal -> coinCompact cVal
+    )
+    ( \txOut cCoin ->
+        case txOut ^. valueEitherTxOutL of
+          Left val -> txOut & valueTxOutL .~ modifyCoin (const (fromCompact cCoin)) val
+          Right cVal ->
+            txOut & compactValueTxOutL .~ modifyCompactCoin (const cCoin) cVal
+    )
+{-# INLINE compactCoinTxOutL #-}
 
 -- | This is a getter that implements an efficient way to check whether 'TxOut'
 -- contains ADA only.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Core
     EraTxOut (..),
     bootAddrTxOutF,
     coinTxOutL,
+    isAdaOnlyTxOutF,
     EraTxBody (..),
     EraAuxiliaryData (..),
     EraWitnesses (..),
@@ -287,6 +288,14 @@ coinTxOutL =
             txOut & compactValueTxOutL .~ modifyCompactCoin (const (toCompactPartial c)) cVal
     )
 {-# INLINE coinTxOutL #-}
+
+-- | This is a getter that implements an efficient way to check whether 'TxOut'
+-- contains ADA only.
+isAdaOnlyTxOutF :: EraTxOut era => SimpleGetter (TxOut era) Bool
+isAdaOnlyTxOutF = to $ \txOut ->
+  case txOut ^. valueEitherTxOutL of
+    Left val -> isAdaOnly val
+    Right cVal -> isAdaOnlyCompact cVal
 
 toCompactPartial :: (Val a, Show a) => a -> CompactForm a
 toCompactPartial v =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -1104,13 +1104,12 @@ testExpectSuccessInvalid
     let txBody' = txBody tc
         tx' = txFromTestCaseData pf tc
         (InitUtxo inputs' refInputs' collateral') = initUtxoFromTestCaseData pf tc
-
-        initUtxo = Map.fromList $ inputs' ++ refInputs' ++ collateral'
-        colBallance = Collateral.collAdaBalance txBody' initUtxo
+        initUtxo = UTxO . Map.fromList $ inputs' ++ refInputs' ++ collateral'
+        colBallance = Collateral.collAdaBalance txBody' (Map.fromList collateral')
         expectedUtxo = UTxO $ Map.fromList (inputs' ++ refInputs' ++ newColReturn txBody')
         expectedState = smartUTxOState expectedUtxo (Coin 0) colBallance def
         assumedInvalidTx = trustMeP pf False tx'
-     in testUTXOW (UTXOW pf) (UTxO initUtxo) (pp pf) assumedInvalidTx (Right expectedState)
+     in testUTXOW (UTXOW pf) initUtxo (pp pf) assumedInvalidTx (Right expectedState)
 
 testExpectFailure ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Alonzo.TxInfo
     TxOutSource (TxOutFromInput, TxOutFromOutput),
   )
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..))
-import qualified Cardano.Ledger.Babbage.Collateral as Collateral (collBalance)
+import qualified Cardano.Ledger.Babbage.Collateral as Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxBody
   ( AlonzoEraTxBody (..),
@@ -63,7 +63,6 @@ import qualified Cardano.Ledger.Shelley.Rules.Utxow as Shelley
 import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (inject)
-import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition.Extended hiding (Assertion)
 import qualified Data.ByteString as BS
 import Data.ByteString.Short as SBS (ShortByteString, pack)
@@ -1106,12 +1105,12 @@ testExpectSuccessInvalid
         tx' = txFromTestCaseData pf tc
         (InitUtxo inputs' refInputs' collateral') = initUtxoFromTestCaseData pf tc
 
-        initUtxo = (UTxO . Map.fromList) $ inputs' ++ refInputs' ++ collateral'
-        colBallance = Val.coin $ Collateral.collBalance txBody' initUtxo
+        initUtxo = Map.fromList $ inputs' ++ refInputs' ++ collateral'
+        colBallance = Collateral.collAdaBalance txBody' initUtxo
         expectedUtxo = UTxO $ Map.fromList (inputs' ++ refInputs' ++ newColReturn txBody')
         expectedState = smartUTxOState expectedUtxo (Coin 0) colBallance def
         assumedInvalidTx = trustMeP pf False tx'
-     in testUTXOW (UTXOW pf) initUtxo (pp pf) assumedInvalidTx (Right expectedState)
+     in testUTXOW (UTXOW pf) (UTxO initUtxo) (pp pf) assumedInvalidTx (Right expectedState)
 
 testExpectFailure ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -57,7 +57,7 @@ import Cardano.Ledger.Shelley.TxBody
     ShelleyEraTxBody (..),
     ShelleyTxOut (..),
   )
-import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, scriptsNeeded, totalDeposits)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance, scriptsNeeded, totalDeposits)
 import Cardano.Ledger.Slot (EpochNo)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (coin, inject, (<+>), (<->)))
@@ -236,7 +236,7 @@ txInBalance ::
   Set (TxIn (Crypto era)) ->
   MUtxo era ->
   Coin
-txInBalance txinSet m = coin (balance (UTxO (restrictKeys m txinSet)))
+txInBalance txinSet m = coinBalance (UTxO (restrictKeys m txinSet))
 
 -- | Break a TxOut into its mandatory and optional parts
 txoutFields :: Proof era -> TxOut era -> (Addr (Crypto era), Value era, [TxOutField era])

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -60,7 +60,7 @@ import Cardano.Ledger.Shelley.TxBody
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance, scriptsNeeded, totalDeposits)
 import Cardano.Ledger.Slot (EpochNo)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val (Val (coin, inject, (<+>), (<->)))
+import Cardano.Ledger.Val (Val (inject, (<+>), (<->)))
 import Cardano.Slotting.EpochInfo.API (epochInfoSize)
 import Control.Monad.Reader (runReader)
 import Control.State.Transition.Extended (STS (State))

--- a/libs/ledger-state/README.md
+++ b/libs/ledger-state/README.md
@@ -59,6 +59,14 @@ $ cabal run -- ledger-state:ledger-state --epoch-state-cbor="${CARDANO_DATA}/led
 
 ## Running benchmarks
 
+### Memory
+
 ```shell
-$ cabal bench ledger-state --benchmark-options="--new-epoch-state-cbor=\"${CARDANO_DATA}/ledger-state.bin\" --new-epoch-state-sqlite=\"${CARDANO_DATA}/ledger-state.sqlite\""
+$ cabal bench ledger-state:memory --benchmark-options="--new-epoch-state-cbor=\"${CARDANO_DATA}/ledger-state.bin\" --new-epoch-state-sqlite=\"${CARDANO_DATA}/ledger-state.sqlite\""
 ```
+### Performance
+
+Performance benchmarks need an actual mainnet ledger state and genesis config
+file to run properly. It is not possible to add extra arguments to criterion cli
+menu, therefore paths to those files must be supplied as environment variables.
+


### PR DESCRIPTION
Performance of `areAllAdaOnly` and `coinBalance` are over 100x faster than the one of `balance` (see benchmark below). This is because whenever we only need `Coin` we don't have to deserialize the `MaryValue` and we can operate on the compact form of the coin directly.

Therefore this PR attempts to switch all places where this pattern happens

* `coin $ balance utxo` -> `coinBalance utxo`
* `isAdaOnly $ balance utxo` -> `areAllAdaOnly utxo`
* `coin (txOut ^. valueTxOutL)` -> `txOut ^. coinTxOutL`

Another big part of this PR is the explicit implementation of the fact that it is possible to have MultiAsset in the collateral input set, but only if it is fully being send back in the returnCollateral. Most importantly it changes the predicate failure `CollateralContainsNonADA` to not return negative MultiAsset values, when returnCollateral contains mismatched type and/or amount of concrete MultiAsset.

---
These are the benchmarks of the newly added functions on the full UTxO, except `areAllAdaOnly`, which is applied to the part of the UTxO that is actually all ada only.
```
benchmarking UTxO/balance
time                 15.16 s    (13.32 s .. 16.53 s)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 14.82 s    (14.31 s .. 15.14 s)
std dev              507.2 ms   (195.3 ms .. 675.9 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking UTxO/coinBalance
time                 147.4 ms   (146.8 ms .. 147.7 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 147.2 ms   (146.9 ms .. 147.4 ms)
std dev              317.9 μs   (177.1 μs .. 449.6 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarking UTxO/areAllAdaOnly
time                 114.6 ms   (111.9 ms .. 115.9 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 115.6 ms   (114.7 ms .. 116.2 ms)
std dev              1.003 ms   (529.9 μs .. 1.439 ms)
variance introduced by outliers: 11% (moderately inflated)
```