### PR TITLE
Minimize constraints to avoid ghc bug

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -216,9 +216,13 @@ sizeAlonzoTxF = to (fromIntegral . LBS.length . serializeEncoding . toCBORForSiz
 isValidAlonzoTxL :: Lens' (AlonzoTx era) IsValid
 isValidAlonzoTxL = lens isValid (\tx valid -> tx {isValid = valid})
 
-deriving instance EraTx era => Eq (AlonzoTx era)
+deriving instance
+  (Era era, Eq (Core.TxBody era), Eq (AuxiliaryData era)) =>
+  Eq (AlonzoTx era)
 
-deriving instance EraTx era => Show (AlonzoTx era)
+deriving instance
+  (Era era, Show (Core.TxBody era), Show (AuxiliaryData era), Show (Script era)) =>
+  Show (AlonzoTx era)
 
 instance
   ( Era era,
@@ -507,10 +511,20 @@ toCBORForMempoolSubmission
         !> To isValid
         !> E (encodeNullMaybe toCBOR . strictMaybeToMaybe) auxiliaryData
 
-instance EraTx era => ToCBOR (AlonzoTx era) where
+instance
+  (Era era, ToCBOR (Core.TxBody era), ToCBOR (AuxiliaryData era)) =>
+  ToCBOR (AlonzoTx era)
+  where
   toCBOR = toCBORForMempoolSubmission
 
-instance (EraTx era, Script era ~ AlonzoScript era) => FromCBOR (Annotator (AlonzoTx era)) where
+instance
+  ( EraScript era,
+    Script era ~ AlonzoScript era,
+    FromCBOR (Annotator (Core.TxBody era)),
+    FromCBOR (Annotator (AuxiliaryData era))
+  ) =>
+  FromCBOR (Annotator (AlonzoTx era))
+  where
   fromCBOR =
     decode $
       Ann (RecD AlonzoTx)

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -48,6 +48,7 @@ import Cardano.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core hiding (TxBody)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash)
@@ -110,16 +111,22 @@ data TxBodyRaw era = TxBodyRaw
   }
 
 deriving instance
-  (NFData (Value era), EraTxOut era, NFData (PParamsUpdate era)) =>
+  (Era era, NFData (Value era), NFData (PParamsUpdate era)) =>
   NFData (TxBodyRaw era)
 
-deriving instance EraTxBody era => Eq (TxBodyRaw era)
+deriving instance
+  (Era era, Eq (PParamsUpdate era), Eq (Value era), Eq (CompactForm (Value era))) =>
+  Eq (TxBodyRaw era)
 
-deriving instance EraTxBody era => Show (TxBodyRaw era)
+deriving instance
+  (Era era, Compactible (Value era), Show (Value era), Show (PParamsUpdate era)) =>
+  Show (TxBodyRaw era)
 
 deriving instance Generic (TxBodyRaw era)
 
-deriving instance (EraTxBody era, NoThunks (Value era)) => NoThunks (TxBodyRaw era)
+deriving instance
+  (Era era, NoThunks (PParamsUpdate era), NoThunks (Value era)) =>
+  NoThunks (TxBodyRaw era)
 
 instance ShelleyMAEraTxBody era => FromCBOR (TxBodyRaw era) where
   fromCBOR =
@@ -194,16 +201,20 @@ type TxBody era = MATxBody era
 
 deriving instance Eq (MATxBody era)
 
-deriving instance EraTxBody era => Show (MATxBody era)
+deriving instance
+  (Era era, Show (Value era), Compactible (Value era), Show (PParamsUpdate era)) =>
+  Show (MATxBody era)
 
 deriving instance Generic (MATxBody era)
 
-deriving newtype instance (EraTxBody era, NoThunks (Value era)) => NoThunks (MATxBody era)
+deriving newtype instance
+  (Era era, NoThunks (Value era), NoThunks (PParamsUpdate era)) =>
+  NoThunks (MATxBody era)
 
 deriving newtype instance
   ( NFData (Value era),
     NFData (PParamsUpdate era),
-    EraTxBody era
+    Era era
   ) =>
   NFData (MATxBody era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -140,9 +140,21 @@ instance
   ) =>
   NFData (TxRaw era)
 
-deriving instance EraTx era => Eq (TxRaw era)
+deriving instance
+  ( Era era,
+    Eq (Core.TxBody era),
+    Eq (Witnesses era),
+    Eq (AuxiliaryData era)
+  ) =>
+  Eq (TxRaw era)
 
-deriving instance EraTx era => Show (TxRaw era)
+deriving instance
+  ( Era era,
+    Show (Core.TxBody era),
+    Show (Witnesses era),
+    Show (AuxiliaryData era)
+  ) =>
+  Show (TxRaw era)
 
 instance
   ( Era era,
@@ -221,9 +233,11 @@ deriving newtype instance
   ) =>
   NFData (ShelleyTx era)
 
-deriving newtype instance Eq (Tx era)
+deriving newtype instance Eq (ShelleyTx era)
 
-deriving newtype instance EraTx era => Show (ShelleyTx era)
+deriving newtype instance
+  (Era era, Show (Core.TxBody era), Show (Witnesses era), Show (AuxiliaryData era)) =>
+  Show (ShelleyTx era)
 
 deriving newtype instance
   ( Era era,
@@ -265,7 +279,14 @@ encodeTxRaw TxRaw {_body, _wits, _auxiliaryData} =
     !> To _wits
     !> E (encodeNullMaybe toCBOR . strictMaybeToMaybe) _auxiliaryData
 
-instance EraTx era => FromCBOR (Annotator (TxRaw era)) where
+instance
+  ( Era era,
+    FromCBOR (Annotator (Core.TxBody era)),
+    FromCBOR (Annotator (Witnesses era)),
+    FromCBOR (Annotator (AuxiliaryData era))
+  ) =>
+  FromCBOR (Annotator (TxRaw era))
+  where
   fromCBOR =
     decode $
       Ann (RecD TxRaw)


### PR DESCRIPTION
Consensus tools tests [stumbled upon the same GHC bug](https://hydra.iohk.io/build/17830322) that was mentioned in this https://github.com/input-output-hk/cardano-ledger/pull/2950#issuecomment-1207298011

I went through all of the sites where bug could potentially be triggered and removed this possibility by removing redundant constraints. 

There are no semantic changes in this PR, just expansion of class instances' constraints to the minimal possible set, but only for those instances that can trigger the bug.