### PR TITLE
Rename back the Environment types:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,80 @@ BabbageEraTxBody --> AlonzoEraTxBody --> ....
   - `TxBody` to `BabbageTxBody` (kept type synonym with a deprecation message)
   - `PParams` to `BabbagePParams` (kept type synonym with a deprecation message)
   - `PParamsUpdate` to `BabbagePParamsUpdate` (kept type synonym with a deprecation message)
+- Renamed Rules:
+  - `BBODY` -> `ShelleyBBODY`
+  - `DELEG` -> `ShelleyDELEG`
+  - `DELEGS` -> `ShelleyDELEGS`
+  - `DELPL` -> `ShelleyDELPL`
+  - `EPOCH` -> `ShelleyEPOCH`
+  - `LEDGER` -> `ShelleyLEDGER`
+  - `LEDGERS` -> `ShelleyLEDGERS`
+  - `MIR` -> `ShelleyMIR`
+  - `NEWEPOCH` -> `ShelleyNEWEPOCH`
+  - `NEWPP` -> `ShelleyNEWPP`
+  - `POOL` -> `ShelleyPOOL`
+  - `POOLREAP` -> `ShelleyPOOLREAP`
+  - `PPUP` -> `ShelleyPPUP`
+  - `RUPD` -> `ShelleyRUPD`
+  - `SNAP` -> `ShelleySNAP`
+  - `TICK` -> `ShelleyTICK, ShelleyTICKF`
+  - `UPEC` -> `ShelleyUPEC`
+  - `UTXO` -> `ShelleyUTXO`
+  - `UTXOW` -> `ShelleyUTXOW`
+- Renamed rules environments:
+  - `PPUPEnv -> PpupEnv`
+- Renamed rules events:
+  - `BbodyEvent` -> `ShelleyBbodyEvent`
+  - `DelegEvent` -> `ShelleyDelegEvent`
+  - `DelegsEvent` -> `ShelleyDelegsEvent`
+  - `DelplEvent` -> `ShelleyDelplEvent`
+  - `EpochEvent` -> `ShelleyEpochEvent`
+  - `LedgerEvent` -> `ShelleyLedgerEvent`
+  - `LedgersEvent` -> `ShelleyLedgersEvent`
+  - `MirEvent` -> `ShelleyMirEvent`
+  - `NewEpochEvent` -> `ShelleyNewEpochEvent`
+  - `PoolreapEvent` -> `ShelleyPoolreapEvent`
+  - `TickEvent` -> `ShelleyTickEvent`
+  - `TickfEvent` -> `ShelleyTickfEvent`
+  - `UtxowEvent` -> `ShelleyUtxowEvent`
+- Renamed predicate failure type names:
+  - `Cardano.Ledger.Shelley.Rules`:
+    - `BbodyPredicateFailure` -> `ShelleyBbodyPredFailure`
+    - `DelegPredicateFailure` -> `ShelleyDelegPredFailure`
+    - `DelegsPredicateFailure` -> `ShelleyDelegsPredFailure`
+    - `DelplPredicateFailure` -> `ShelleyDelplPredFailure`
+    - `EpochPredicateFailure` -> `ShelleyEpochPredFailure`
+    - `LedgerPredicateFailure` -> `ShelleyLedgerPredFailure`
+    - `LedgersPredicateFailure` -> `ShelleyLedgersPredFailure`
+    - `MirPredicateFailure` -> `ShelleyMirPredFailure`
+    - `NewEpochPredicateFailure` -> `ShelleyNewEpochPredFailure`
+    - `NewppPredicateFailure` -> `ShelleyNewppPredFailure`
+    - `LedgerPredicateFailure` -> `ShelleyLedgerPredFailure`
+    - `PoolPredicateFailure` -> `ShelleyPoolPredFailure`
+    - `PoolreapPredicateFailure` -> `ShelleyPoolreapPredFailure`
+    - `PpupPredicateFailure` -> `ShelleyPpupPredFailure`
+    - `RupdPredicateFailure` -> `ShelleyRupdPredFailure`
+    - `SnapPredicateFailure` -> `ShelleySnapPredFailure`
+    - `TickPredicateFailure` -> `ShelleyTickPredFailure`
+    - `TickfPredicateFailure` -> `ShelleyTickfPredFailure`
+    - `UpecPredicateFailure` -> `ShelleyUpecPredFailure`
+    - `UtxoPredicateFailure` -> `ShelleyUtxoPredFailure`
+    - `UtxowPredicateFailure` -> `ShelleyUtxowPredFailure`
+  - `Cardano.Ledger.ShelleyMA.Rules`:
+    - `UtxoPredicateFailure` -> `ShelleyMAUtxoPredFailure`
+  - `Cardano.Ledger.Alonzo.Rules`:
+    - `AlonzoBbodyPredFail` -> `AlonzoBbodyPredFailure` and constructor:
+      - `ShelleyInAlonzoPredFail` -> `ShelleyInAlonzoBbodyPredFailure`
+    - `UtxoPredicateFailure` -> `AlonzoUtxoPredFailure`
+    - `UtxosPredicateFailure` -> `AlonzoUtxosPredFailure`
+    - `UtxowPredicateFail` -> `AlonzoUtxowPredFailure` and constructor:
+      - `WrappedShelleyEraFailure` -> `ShelleyInAlonzoUtxowPredFailure`
+  - `Cardano.Ledger.Babbage.Rules`:
+    - `BabbageUtxoPred` -> `BabbageUtxoPredFailure` and constructor:
+      - `FromAlonzoUtxoFail` -> `AlonzoInBabbageUtxoPredFailure`
+    - `BabbageUtxowPred` -> `BabbageUtxowPredFailure` and constructor:
+      - `FromAlonzoUtxowFail` -> `AlonzoInBabbageUtxowPredFailure`
+
 ### Deprecated
 - The provenance for the reward calculation has been removed.
   The type signature to the API function `getRewardProvenance` has not change,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Keys (DSignable, Hash, coerceKeyRole)
 import Cardano.Ledger.Shelley.BlockChain (bBodySize, incrBlocks)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState)
 import Cardano.Ledger.Shelley.Rules.Bbody
-  ( ShelleyBbodyEnv (..),
+  ( BbodyEnv (..),
     ShelleyBbodyEvent (..),
     ShelleyBbodyPredFailure (..),
     ShelleyBbodyState (..),
@@ -121,7 +121,7 @@ bbodyTransition ::
     PredicateFailure (someBBODY era) ~ AlonzoBbodyPredFailure era,
     BaseM (someBBODY era) ~ ShelleyBase,
     State (someBBODY era) ~ ShelleyBbodyState era,
-    Environment (someBBODY era) ~ ShelleyBbodyEnv era,
+    Environment (someBBODY era) ~ BbodyEnv era,
     -- Conditions to be an instance of STS
     Embed (EraRule "LEDGERS" era) (someBBODY era),
     Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era,
@@ -216,7 +216,7 @@ instance
     Signal (AlonzoBBODY era) =
       (Block (BHeaderView (Crypto era)) era)
 
-  type Environment (AlonzoBBODY era) = ShelleyBbodyEnv era
+  type Environment (AlonzoBBODY era) = BbodyEnv era
 
   type BaseM (AlonzoBBODY era) = ShelleyBase
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -35,13 +35,13 @@ import Cardano.Ledger.Shelley.LedgerState
     rewards,
   )
 import Cardano.Ledger.Shelley.Rules.Delegs
-  ( ShelleyDELEGS,
-    ShelleyDelegsEnv (..),
+  ( DelegsEnv (..),
+    ShelleyDELEGS,
     ShelleyDelegsEvent,
     ShelleyDelegsPredFailure,
   )
 import Cardano.Ledger.Shelley.Rules.Ledger as Shelley
-  ( ShelleyLedgerEnv (..),
+  ( LedgerEnv (..),
     ShelleyLedgerEvent (..),
     ShelleyLedgerPredFailure (..),
   )
@@ -51,7 +51,7 @@ import qualified Cardano.Ledger.Shelley.Rules.Ledgers as Shelley
     ShelleyLedgersPredFailure (..),
   )
 import Cardano.Ledger.Shelley.Rules.Utxo
-  ( ShelleyUtxoEnv (..),
+  ( UtxoEnv (..),
   )
 import Cardano.Ledger.Shelley.TxBody (DCert)
 import Control.State.Transition
@@ -78,13 +78,13 @@ ledgerTransition ::
   forall (someLEDGER :: Type -> Type) era.
   ( Signal (someLEDGER era) ~ Tx era,
     State (someLEDGER era) ~ LedgerState era,
-    Environment (someLEDGER era) ~ ShelleyLedgerEnv era,
+    Environment (someLEDGER era) ~ LedgerEnv era,
     Embed (EraRule "UTXOW" era) (someLEDGER era),
     Embed (EraRule "DELEGS" era) (someLEDGER era),
-    Environment (EraRule "DELEGS" era) ~ ShelleyDelegsEnv era,
+    Environment (EraRule "DELEGS" era) ~ DelegsEnv era,
     State (EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
-    Environment (EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOW" era) ~ UtxoEnv era,
     State (EraRule "UTXOW" era) ~ UTxOState era,
     Signal (EraRule "UTXOW" era) ~ Tx era,
     AlonzoEraTx era
@@ -99,7 +99,7 @@ ledgerTransition = do
       then
         trans @(EraRule "DELEGS" era) $
           TRC
-            ( ShelleyDelegsEnv slot txIx pp tx account,
+            ( DelegsEnv slot txIx pp tx account,
               dpstate,
               StrictSeq.fromStrict $ txBody ^. certsTxBodyL
             )
@@ -125,10 +125,10 @@ instance
     Tx era ~ AlonzoTx era,
     Embed (EraRule "DELEGS" era) (AlonzoLEDGER era),
     Embed (EraRule "UTXOW" era) (AlonzoLEDGER era),
-    Environment (EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOW" era) ~ UtxoEnv era,
     State (EraRule "UTXOW" era) ~ UTxOState era,
     Signal (EraRule "UTXOW" era) ~ AlonzoTx era,
-    Environment (EraRule "DELEGS" era) ~ ShelleyDelegsEnv era,
+    Environment (EraRule "DELEGS" era) ~ DelegsEnv era,
     State (EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
     HasField "_keyDeposit" (PParams era) Coin,
@@ -138,7 +138,7 @@ instance
   where
   type State (AlonzoLEDGER era) = LedgerState era
   type Signal (AlonzoLEDGER era) = AlonzoTx era
-  type Environment (AlonzoLEDGER era) = ShelleyLedgerEnv era
+  type Environment (AlonzoLEDGER era) = LedgerEnv era
   type BaseM (AlonzoLEDGER era) = ShelleyBase
   type PredicateFailure (AlonzoLEDGER era) = ShelleyLedgerPredFailure era
   type Event (AlonzoLEDGER era) = ShelleyLedgerEvent era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.Rules.ValidationMode
   )
 import Cardano.Ledger.Shelley.HardForks (allowOutsideForecastTTL)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv, ShelleyUtxoPredFailure)
+import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoPredFailure, UtxoEnv)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley
 import Cardano.Ledger.Shelley.Tx (TxIn)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, txouts)
@@ -496,7 +496,7 @@ utxoTransition ::
     STS (AlonzoUTXO era),
     -- instructions for calling UTXOS from AlonzoUTXO
     Embed (EraRule "UTXOS" era) (AlonzoUTXO era),
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
     HasField "_poolDeposit" (PParams era) Coin,
@@ -599,7 +599,7 @@ instance
     Show (TxOut era),
     Show (TxBody era),
     Embed (EraRule "UTXOS" era) (AlonzoUTXO era),
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ AlonzoTx era,
     HasField "_poolDeposit" (PParams era) Coin,
@@ -620,7 +620,7 @@ instance
   where
   type State (AlonzoUTXO era) = Shelley.UTxOState era
   type Signal (AlonzoUTXO era) = AlonzoTx era
-  type Environment (AlonzoUTXO era) = ShelleyUtxoEnv era
+  type Environment (AlonzoUTXO era) = UtxoEnv era
   type BaseM (AlonzoUTXO era) = ShelleyBase
   type PredicateFailure (AlonzoUTXO era) = AlonzoUtxoPredFailure era
   type Event (AlonzoUTXO era) = AlonzoUtxoEvent era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -68,8 +68,8 @@ import Cardano.Ledger.Shelley.LedgerState
   )
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
-import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyPPUP, ShelleyPPUPEnv (..), ShelleyPpupPredFailure)
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..), updateUTxOState)
+import Cardano.Ledger.Shelley.Rules.Ppup (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..), updateUTxOState)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, totalDeposits)
 import Cardano.Ledger.Val as Val (Val (coin, (<->)))
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
@@ -104,7 +104,7 @@ instance
     Script era ~ AlonzoScript era,
     Tx era ~ AlonzoTx era,
     Embed (EraRule "PPUP" era) (AlonzoUTXOS era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     HasField "_costmdls" (PParams era) CostModels,
@@ -116,7 +116,7 @@ instance
   STS (AlonzoUTXOS era)
   where
   type BaseM (AlonzoUTXOS era) = ShelleyBase
-  type Environment (AlonzoUTXOS era) = ShelleyUtxoEnv era
+  type Environment (AlonzoUTXOS era) = UtxoEnv era
   type State (AlonzoUTXOS era) = UTxOState era
   type Signal (AlonzoUTXOS era) = AlonzoTx era
   type PredicateFailure (AlonzoUTXOS era) = AlonzoUtxosPredFailure era
@@ -146,7 +146,7 @@ utxosTransition ::
     Tx era ~ AlonzoTx era,
     Script era ~ AlonzoScript era,
     Witnesses era ~ TxWitness era,
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     Embed (EraRule "PPUP" era) (AlonzoUTXOS era),
@@ -209,7 +209,7 @@ scriptsValidateTransition ::
     Tx era ~ AlonzoTx era,
     Witnesses era ~ TxWitness era,
     Script era ~ AlonzoScript era,
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     Embed (EraRule "PPUP" era) (AlonzoUTXOS era),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -74,7 +74,7 @@ import Cardano.Ledger.Shelley.LedgerState
     propWits,
     witsFromTxWitnesses,
   )
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyUtxowEvent (UtxoEvent),
     ShelleyUtxowPredFailure (..),
@@ -347,7 +347,7 @@ alonzoStyleWitness ::
     Signable (DSIGN (Crypto era)) (Hash (HASH (Crypto era)) EraIndependentTxBody),
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (AlonzoUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ AlonzoTx era
   ) =>
@@ -515,7 +515,7 @@ instance
     HasField "_protocolVersion" (PParams era) ProtVer,
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (AlonzoUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ AlonzoTx era
   ) =>
@@ -523,7 +523,7 @@ instance
   where
   type State (AlonzoUTXOW era) = UTxOState era
   type Signal (AlonzoUTXOW era) = AlonzoTx era
-  type Environment (AlonzoUTXOW era) = ShelleyUtxoEnv era
+  type Environment (AlonzoUTXOW era) = UtxoEnv era
   type BaseM (AlonzoUTXOW era) = ShelleyBase
   type PredicateFailure (AlonzoUTXOW era) = AlonzoUtxowPredFailure era
   type Event (AlonzoUTXOW era) = AlonzoUtxowEvent era

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -20,10 +20,10 @@ import Cardano.Ledger.BaseTypes (Globals)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto))
 import Cardano.Ledger.Shelley.LedgerState (DPState (..), UTxOState)
-import Cardano.Ledger.Shelley.Rules.Delegs (ShelleyDelegsEnv)
-import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplEnv, ShelleyDelplPredFailure)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv (..))
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv)
+import Cardano.Ledger.Shelley.Rules.Delegs (DelegsEnv)
+import Cardano.Ledger.Shelley.Rules.Delpl (DelplEnv, ShelleyDelplPredFailure)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.TxBody (DCert)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad.Trans.Reader (runReaderT)
@@ -48,16 +48,16 @@ instance
     Mock (Crypto era),
     MinLEDGER_STS era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     PredicateFailure (Core.EraRule "DELPL" era) ~ ShelleyDelplPredFailure era,
     Embed (Core.EraRule "DELEGS" era) (AlonzoLEDGER era),
     Embed (Core.EraRule "UTXOW" era) (AlonzoLEDGER era),
-    Environment (Core.EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
     State (Core.EraRule "UTXOW" era) ~ UTxOState era,
     Signal (Core.EraRule "UTXOW" era) ~ Core.Tx era,
-    Environment (Core.EraRule "DELEGS" era) ~ ShelleyDelegsEnv era,
+    Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
     State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
     Show (State (Core.EraRule "PPUP" era)),

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -29,13 +29,13 @@ import Cardano.Ledger.Shelley.LedgerState
     rewards,
   )
 import Cardano.Ledger.Shelley.Rules.Delegs
-  ( ShelleyDELEGS,
-    ShelleyDelegsEnv (..),
+  ( DelegsEnv (..),
+    ShelleyDELEGS,
     ShelleyDelegsEvent,
     ShelleyDelegsPredFailure,
   )
 import Cardano.Ledger.Shelley.Rules.Ledger
-  ( ShelleyLedgerEnv (..),
+  ( LedgerEnv (..),
     ShelleyLedgerEvent (..),
     ShelleyLedgerPredFailure (..),
   )
@@ -44,7 +44,7 @@ import Cardano.Ledger.Shelley.Rules.Ledgers as Shelley
   ( ShelleyLedgersEvent (LedgerEvent),
     ShelleyLedgersPredFailure (LedgerFailure),
   )
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.TxBody (DCert)
 import Control.State.Transition
   ( Assertion (..),
@@ -69,10 +69,10 @@ instance
     HasField "_poolDeposit" (PParams era) Coin,
     Embed (EraRule "DELEGS" era) (BabbageLEDGER era),
     Embed (EraRule "UTXOW" era) (BabbageLEDGER era),
-    Environment (EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOW" era) ~ UtxoEnv era,
     State (EraRule "UTXOW" era) ~ UTxOState era,
     Signal (EraRule "UTXOW" era) ~ AlonzoTx era,
-    Environment (EraRule "DELEGS" era) ~ ShelleyDelegsEnv era,
+    Environment (EraRule "DELEGS" era) ~ DelegsEnv era,
     State (EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (EraRule "DELEGS" era) ~ Seq (DCert (Crypto era))
   ) =>
@@ -80,7 +80,7 @@ instance
   where
   type State (BabbageLEDGER era) = LedgerState era
   type Signal (BabbageLEDGER era) = AlonzoTx era
-  type Environment (BabbageLEDGER era) = ShelleyLedgerEnv era
+  type Environment (BabbageLEDGER era) = LedgerEnv era
   type BaseM (BabbageLEDGER era) = ShelleyBase
   type PredicateFailure (BabbageLEDGER era) = ShelleyLedgerPredFailure era
   type Event (BabbageLEDGER era) = ShelleyLedgerEvent era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -72,7 +72,7 @@ import Cardano.Ledger.Rules.ValidationMode
   )
 import Cardano.Ledger.Serialization (Sized (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv, ShelleyUtxoPredFailure)
+import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoPredFailure, UtxoEnv)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
@@ -362,7 +362,7 @@ utxoTransition ::
     HasField "_prices" (PParams era) Prices,
     -- In this function we we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (BabbageUTXO era),
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
     Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era)),
@@ -470,7 +470,7 @@ instance
     HasField "_protocolVersion" (PParams era) ProtVer,
     -- instructions for calling UTXOS from BabbageUTXO
     Embed (EraRule "UTXOS" era) (BabbageUTXO era),
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
     Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era)),
@@ -481,7 +481,7 @@ instance
   where
   type State (BabbageUTXO era) = Shelley.UTxOState era
   type Signal (BabbageUTXO era) = AlonzoTx era
-  type Environment (BabbageUTXO era) = ShelleyUtxoEnv era
+  type Environment (BabbageUTXO era) = UtxoEnv era
   type BaseM (BabbageUTXO era) = ShelleyBase
   type PredicateFailure (BabbageUTXO era) = BabbageUtxoPredFailure era
   type Event (BabbageUTXO era) = AlonzoUtxoEvent era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -55,8 +55,8 @@ import Cardano.Ledger.Shelley.LedgerState
     updateStakeDistribution,
   )
 import Cardano.Ledger.Shelley.PParams (Update)
-import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyPPUP, ShelleyPPUPEnv (..), ShelleyPpupPredFailure)
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..), updateUTxOState)
+import Cardano.Ledger.Shelley.Rules.Ppup (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..), updateUTxOState)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), totalDeposits)
 import qualified Cardano.Ledger.Val as Val
 import Control.Monad.Trans.Reader (asks)
@@ -89,7 +89,7 @@ instance
     HasField "_costmdls" (PParams era) CostModels,
     HasField "_protocolVersion" (PParams era) ProtVer,
     Embed (EraRule "PPUP" era) (BabbageUTXOS era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     ToCBOR (PredicateFailure (EraRule "PPUP" era)) -- Serializing the PredicateFailure
@@ -97,7 +97,7 @@ instance
   STS (BabbageUTXOS era)
   where
   type BaseM (BabbageUTXOS era) = ShelleyBase
-  type Environment (BabbageUTXOS era) = ShelleyUtxoEnv era
+  type Environment (BabbageUTXOS era) = UtxoEnv era
   type State (BabbageUTXOS era) = UTxOState era
   type Signal (BabbageUTXOS era) = AlonzoTx era
   type PredicateFailure (BabbageUTXOS era) = AlonzoUtxosPredFailure era
@@ -129,7 +129,7 @@ utxosTransition ::
     HasField "_poolDeposit" (PParams era) Coin,
     HasField "_costmdls" (PParams era) CostModels,
     HasField "_protocolVersion" (PParams era) ProtVer,
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     Embed (EraRule "PPUP" era) (BabbageUTXOS era),
@@ -152,7 +152,7 @@ scriptsYes ::
     Script era ~ AlonzoScript era,
     Witnesses era ~ TxWitness era,
     STS (BabbageUTXOS era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     Embed (EraRule "PPUP" era) (BabbageUTXOS era),

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -49,7 +49,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (DSIGN, HASH)
 import Cardano.Ledger.Rules.ValidationMode (Inject (..), Test, runTest, runTestOnSignal)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), witsFromTxWitnesses)
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyUtxowEvent (UtxoEvent),
     ShelleyUtxowPredFailure,
@@ -277,7 +277,7 @@ babbageUtxowTransition ::
     Signable (DSIGN (Crypto era)) (Hash (HASH (Crypto era)) EraIndependentTxBody),
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (BabbageUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ AlonzoTx era
   ) =>
@@ -376,7 +376,7 @@ instance
     Script era ~ AlonzoScript era,
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (BabbageUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ AlonzoTx era,
     Eq (PredicateFailure (EraRule "UTXOS" era)),
@@ -386,7 +386,7 @@ instance
   where
   type State (BabbageUTXOW era) = UTxOState era
   type Signal (BabbageUTXOW era) = AlonzoTx era
-  type Environment (BabbageUTXOW era) = ShelleyUtxoEnv era
+  type Environment (BabbageUTXOW era) = UtxoEnv era
   type BaseM (BabbageUTXOW era) = ShelleyBase
   type PredicateFailure (BabbageUTXOW era) = BabbageUtxowPredFailure era
   type Event (BabbageUTXOW era) = AlonzoUtxowEvent era

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (PPUPState)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..), Update)
-import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyPPUP, ShelleyPPUPEnv (..), ShelleyPpupPredFailure)
+import Cardano.Ledger.Shelley.Rules.Ppup (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as Shelley
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), ShelleyTxOut, TxIn)
 import Cardano.Ledger.Shelley.TxBody (RewardAcnt, ShelleyEraTxBody (..))
@@ -212,7 +212,7 @@ utxoTransition ::
     STS (ShelleyMAUTXO era),
     Tx era ~ ShelleyTx era,
     Embed (EraRule "PPUP" era) (ShelleyMAUTXO era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     HasField "_minfeeA" (PParams era) Natural,
@@ -377,7 +377,7 @@ instance
     TxOut era ~ ShelleyTxOut era,
     Tx era ~ ShelleyTx era,
     Embed (EraRule "PPUP" era) (ShelleyMAUTXO era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era)
   ) =>
@@ -385,7 +385,7 @@ instance
   where
   type State (ShelleyMAUTXO era) = Shelley.UTxOState era
   type Signal (ShelleyMAUTXO era) = ShelleyTx era
-  type Environment (ShelleyMAUTXO era) = Shelley.ShelleyUtxoEnv era
+  type Environment (ShelleyMAUTXO era) = Shelley.UtxoEnv era
   type BaseM (ShelleyMAUTXO era) = ShelleyBase
   type PredicateFailure (ShelleyMAUTXO era) = ShelleyMAUtxoPredFailure era
   type Event (ShelleyMAUTXO era) = ShelleyMAUtxoEvent era

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxow.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Shelley
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyUtxowEvent (..),
     ShelleyUtxowPredFailure (..),
@@ -46,7 +46,7 @@ instance
     Witnesses era ~ ShelleyWitnesses era,
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (ShelleyMAUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ Tx era,
     HasField "_protocolVersion" (PParams era) ProtVer,
@@ -56,7 +56,7 @@ instance
   where
   type State (ShelleyMAUTXOW era) = UTxOState era
   type Signal (ShelleyMAUTXOW era) = Tx era
-  type Environment (ShelleyMAUTXOW era) = ShelleyUtxoEnv era
+  type Environment (ShelleyMAUTXOW era) = UtxoEnv era
   type BaseM (ShelleyMAUTXOW era) = ShelleyBase
   type PredicateFailure (ShelleyMAUTXOW era) = ShelleyUtxowPredFailure era
   type Event (ShelleyMAUTXOW era) = ShelleyUtxowEvent era

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -11,7 +11,7 @@ where
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra)
-import Cardano.Ledger.Shelley.API (ShelleyLEDGER, ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.API (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..), smartUTxOState)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
@@ -37,7 +37,7 @@ testMaryNoDelegLEDGER ::
   HasCallStack =>
   UTxO MaryTest ->
   ShelleyTx MaryTest ->
-  ShelleyLedgerEnv MaryTest ->
+  LedgerEnv MaryTest ->
   Either [PredicateFailure (ShelleyLEDGER MaryTest)] (UTxO MaryTest) ->
   Assertion
 testMaryNoDelegLEDGER utxo tx env (Right expectedUTxO) = do

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Mary.Value
     PolicyID (..),
   )
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.API (ShelleyLEDGER, ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.API (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.LedgerState (AccountState (..))
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..), emptyPParams)
 import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerPredFailure (..))
@@ -98,7 +98,7 @@ pp =
       _minUTxOValue = Coin 100
     }
 
-ledgerEnv :: SlotNo -> ShelleyLedgerEnv MaryTest
+ledgerEnv :: SlotNo -> LedgerEnv MaryTest
 ledgerEnv s = LedgerEnv s minBound pp (AccountState (Coin 0) (Coin 0))
 
 feeEx :: Coin

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -52,7 +52,7 @@ import Cardano.Ledger.Shelley.LedgerState (NewEpochState)
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.Rules.EraMapping ()
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv, ShelleyLedgerPredFailure)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import Cardano.Ledger.Slot (SlotNo)
 import Control.Arrow (ArrowChoice (right), left)
@@ -110,7 +110,7 @@ class
     Typeable (ApplyTxError era),
     STS (EraRule "LEDGER" era),
     BaseM (EraRule "LEDGER" era) ~ ShelleyBase,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     State (EraRule "LEDGER" era) ~ MempoolState era,
     Signal (EraRule "LEDGER" era) ~ Tx era,
     PredicateFailure (EraRule "LEDGER" era) ~ ShelleyLedgerPredFailure era
@@ -173,7 +173,7 @@ instance
   ) =>
   ApplyTx (ShelleyEra crypto)
 
-type MempoolEnv era = Ledger.ShelleyLedgerEnv era
+type MempoolEnv era = Ledger.LedgerEnv era
 
 type MempoolState era = LedgerState.LedgerState era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -108,23 +108,23 @@ import Cardano.Ledger.Shelley.PParams as X
 import Cardano.Ledger.Shelley.PoolRank as X
   ( NonMyopic,
   )
-import Cardano.Ledger.Shelley.Rules.Deleg as X (ShelleyDELEG, ShelleyDelegEnv (..))
-import Cardano.Ledger.Shelley.Rules.Delegs as X (ShelleyDELEGS, ShelleyDelegsEnv (..))
-import Cardano.Ledger.Shelley.Rules.Delpl as X (ShelleyDELPL, ShelleyDelplEnv (..))
-import Cardano.Ledger.Shelley.Rules.Ledger as X (ShelleyLEDGER, ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Deleg as X (DelegEnv (..), ShelleyDELEG)
+import Cardano.Ledger.Shelley.Rules.Delegs as X (DelegsEnv (..), ShelleyDELEGS)
+import Cardano.Ledger.Shelley.Rules.Delpl as X (DelplEnv (..), ShelleyDELPL)
+import Cardano.Ledger.Shelley.Rules.Ledger as X (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.Rules.Ledgers as X (ShelleyLEDGERS, ShelleyLedgersEnv (..))
 import Cardano.Ledger.Shelley.Rules.NewEpoch as X
   ( ShelleyNEWEPOCH,
     calculatePoolDistr,
     calculatePoolDistr',
   )
-import Cardano.Ledger.Shelley.Rules.Pool as X (ShelleyPOOL, ShelleyPoolEnv (..))
+import Cardano.Ledger.Shelley.Rules.Pool as X (PoolEnv (..), ShelleyPOOL)
 import Cardano.Ledger.Shelley.Rules.PoolReap as X (ShelleyPOOLREAP)
-import Cardano.Ledger.Shelley.Rules.Ppup as X (ShelleyPPUP, ShelleyPPUPEnv (..))
+import Cardano.Ledger.Shelley.Rules.Ppup as X (PpupEnv (..), ShelleyPPUP)
 import Cardano.Ledger.Shelley.Rules.Tick as X (ShelleyTICK)
 import Cardano.Ledger.Shelley.Rules.Utxo as X
   ( ShelleyUTXO,
-    ShelleyUtxoEnv (..),
+    UtxoEnv (..),
   )
 import Cardano.Ledger.Shelley.Rules.Utxow as X (ShelleyUTXOW)
 import Cardano.Ledger.Shelley.Scripts as X

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -58,7 +58,7 @@ class
     Signal (EraRule "TICK" era) ~ SlotNo,
     STS (EraRule "BBODY" era),
     BaseM (EraRule "BBODY" era) ~ ShelleyBase,
-    Environment (EraRule "BBODY" era) ~ STS.ShelleyBbodyEnv era,
+    Environment (EraRule "BBODY" era) ~ STS.BbodyEnv era,
     State (EraRule "BBODY" era) ~ STS.ShelleyBbodyState era,
     Signal (EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     ToCBORGroup (TxSeq era)
@@ -196,7 +196,7 @@ chainChecks = STS.chainChecks
 
 mkBbodyEnv ::
   NewEpochState era ->
-  STS.ShelleyBbodyEnv era
+  STS.BbodyEnv era
 mkBbodyEnv
   LedgerState.NewEpochState
     { LedgerState.nesEs

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -13,7 +13,7 @@
 module Cardano.Ledger.Shelley.Rules.Bbody
   ( ShelleyBBODY,
     ShelleyBbodyState (..),
-    ShelleyBbodyEnv (..),
+    BbodyEnv (..),
     ShelleyBbodyPredFailure (..),
     ShelleyBbodyEvent (..),
     PredicateFailure,
@@ -59,7 +59,7 @@ deriving stock instance Show (LedgerState era) => Show (ShelleyBbodyState era)
 
 deriving stock instance Eq (LedgerState era) => Eq (ShelleyBbodyState era)
 
-data ShelleyBbodyEnv era = BbodyEnv
+data BbodyEnv era = BbodyEnv
   { bbodyPp :: PParams era,
     bbodyAccount :: AccountState
   }
@@ -114,7 +114,7 @@ instance
     Signal (ShelleyBBODY era) =
       Block (BHeaderView (Crypto era)) era
 
-  type Environment (ShelleyBBODY era) = ShelleyBbodyEnv era
+  type Environment (ShelleyBBODY era) = BbodyEnv era
 
   type BaseM (ShelleyBBODY era) = ShelleyBase
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -10,7 +10,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Deleg
   ( ShelleyDELEG,
-    ShelleyDelegEnv (..),
+    DelegEnv (..),
     PredicateFailure,
     ShelleyDelegPredFailure (..),
   )
@@ -84,16 +84,16 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyDELEG era
 
-data ShelleyDelegEnv era = DelegEnv
+data DelegEnv era = DelegEnv
   { slotNo :: SlotNo,
     ptr_ :: Ptr,
     acnt_ :: AccountState,
     ppDE :: PParams era -- The protocol parameters are only used for the HardFork mechanism
   }
 
-deriving instance (Show (PParams era)) => Show (ShelleyDelegEnv era)
+deriving instance (Show (PParams era)) => Show (DelegEnv era)
 
-deriving instance (Eq (PParams era)) => Eq (ShelleyDelegEnv era)
+deriving instance (Eq (PParams era)) => Eq (DelegEnv era)
 
 data ShelleyDelegPredFailure era
   = StakeKeyAlreadyRegisteredDELEG
@@ -145,7 +145,7 @@ instance
   where
   type State (ShelleyDELEG era) = DState (Crypto era)
   type Signal (ShelleyDELEG era) = DCert (Crypto era)
-  type Environment (ShelleyDELEG era) = ShelleyDelegEnv era
+  type Environment (ShelleyDELEG era) = DelegEnv era
   type BaseM (ShelleyDELEG era) = ShelleyBase
   type PredicateFailure (ShelleyDELEG era) = ShelleyDelegPredFailure era
   type Event (ShelleyDELEG era) = ShelleyDelegEvent era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -14,7 +14,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Delegs
   ( ShelleyDELEGS,
-    ShelleyDelegsEnv (..),
+    DelegsEnv (..),
     ShelleyDelegsPredFailure (..),
     ShelleyDelegsEvent (..),
     PredicateFailure,
@@ -52,7 +52,7 @@ import Cardano.Ledger.Shelley.LedgerState
     _pParams,
     _unified,
   )
-import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDELPL, ShelleyDelplEnv (..), ShelleyDelplEvent, ShelleyDelplPredFailure)
+import Cardano.Ledger.Shelley.Rules.Delpl (DelplEnv (..), ShelleyDELPL, ShelleyDelplEvent, ShelleyDelplPredFailure)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     DelegCert (..),
@@ -90,7 +90,7 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyDELEGS era
 
-data ShelleyDelegsEnv era = ShelleyDelegsEnv
+data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: !SlotNo,
     delegsIx :: !TxIx,
     delegspp :: !(PParams era),
@@ -102,7 +102,7 @@ deriving stock instance
   ( Show (Tx era),
     Show (PParams era)
   ) =>
-  Show (ShelleyDelegsEnv era)
+  Show (DelegsEnv era)
 
 data ShelleyDelegsPredFailure era
   = DelegateeNotRegisteredDELEG
@@ -128,7 +128,7 @@ instance
   ( EraTx era,
     ShelleyEraTxBody era,
     Embed (EraRule "DELPL" era) (ShelleyDELEGS era),
-    Environment (EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (EraRule "DELPL" era) ~ DelplEnv era,
     State (EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
@@ -136,7 +136,7 @@ instance
   where
   type State (ShelleyDELEGS era) = DPState (Crypto era)
   type Signal (ShelleyDELEGS era) = Seq (DCert (Crypto era))
-  type Environment (ShelleyDELEGS era) = ShelleyDelegsEnv era
+  type Environment (ShelleyDELEGS era) = DelegsEnv era
   type BaseM (ShelleyDELEGS era) = ShelleyBase
   type
     PredicateFailure (ShelleyDELEGS era) =
@@ -196,13 +196,13 @@ delegsTransition ::
   ( EraTx era,
     ShelleyEraTxBody era,
     Embed (EraRule "DELPL" era) (ShelleyDELEGS era),
-    Environment (EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (EraRule "DELPL" era) ~ DelplEnv era,
     State (EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
   TransitionRule (ShelleyDELEGS era)
 delegsTransition = do
-  TRC (env@(ShelleyDelegsEnv slot txIx pp tx acnt), dpstate, certificates) <- judgmentContext
+  TRC (env@(DelegsEnv slot txIx pp tx acnt), dpstate, certificates) <- judgmentContext
   network <- liftSTS $ asks networkId
 
   case certificates of

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -14,7 +14,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Delpl
   ( ShelleyDELPL,
-    ShelleyDelplEnv (..),
+    DelplEnv (..),
     ShelleyDelplPredFailure (..),
     ShelleyDelplEvent,
     PredicateFailure,
@@ -37,8 +37,8 @@ import Cardano.Ledger.Shelley.LedgerState
     dpsDState,
     dpsPState,
   )
-import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDELEG, ShelleyDelegEnv (..), ShelleyDelegPredFailure)
-import Cardano.Ledger.Shelley.Rules.Pool (ShelleyPOOL, ShelleyPoolEnv (..), ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules.Deleg (DelegEnv (..), ShelleyDELEG, ShelleyDelegPredFailure)
+import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL, ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     DelegCert (..),
@@ -56,7 +56,7 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyDELPL era
 
-data ShelleyDelplEnv era = DelplEnv
+data DelplEnv era = DelplEnv
   { delplSlotNo :: SlotNo,
     delPlPtr :: Ptr,
     delPlPp :: PParams era,
@@ -93,11 +93,11 @@ instance
 instance
   ( Era era,
     Embed (EraRule "DELEG" era) (ShelleyDELPL era),
-    Environment (EraRule "DELEG" era) ~ ShelleyDelegEnv era,
+    Environment (EraRule "DELEG" era) ~ DelegEnv era,
     State (EraRule "DELEG" era) ~ DState (Crypto era),
     Signal (EraRule "DELEG" era) ~ DCert (Crypto era),
     Embed (EraRule "POOL" era) (ShelleyDELPL era),
-    Environment (EraRule "POOL" era) ~ ShelleyPoolEnv era,
+    Environment (EraRule "POOL" era) ~ PoolEnv era,
     State (EraRule "POOL" era) ~ PState (Crypto era),
     Signal (EraRule "POOL" era) ~ DCert (Crypto era)
   ) =>
@@ -105,7 +105,7 @@ instance
   where
   type State (ShelleyDELPL era) = DPState (Crypto era)
   type Signal (ShelleyDELPL era) = DCert (Crypto era)
-  type Environment (ShelleyDELPL era) = ShelleyDelplEnv era
+  type Environment (ShelleyDELPL era) = DelplEnv era
   type BaseM (ShelleyDELPL era) = ShelleyBase
   type PredicateFailure (ShelleyDELPL era) = ShelleyDelplPredFailure era
   type Event (ShelleyDELPL era) = ShelleyDelplEvent era
@@ -152,11 +152,11 @@ instance
 delplTransition ::
   forall era.
   ( Embed (EraRule "DELEG" era) (ShelleyDELPL era),
-    Environment (EraRule "DELEG" era) ~ ShelleyDelegEnv era,
+    Environment (EraRule "DELEG" era) ~ DelegEnv era,
     State (EraRule "DELEG" era) ~ DState (Crypto era),
     Signal (EraRule "DELEG" era) ~ DCert (Crypto era),
     Embed (EraRule "POOL" era) (ShelleyDELPL era),
-    Environment (EraRule "POOL" era) ~ ShelleyPoolEnv era,
+    Environment (EraRule "POOL" era) ~ PoolEnv era,
     State (EraRule "POOL" era) ~ PState (Crypto era),
     Signal (EraRule "POOL" era) ~ DCert (Crypto era)
   ) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -26,8 +26,8 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Shelley.LedgerState (AccountState, LedgerState)
 import Cardano.Ledger.Shelley.Rules.Ledger
-  ( ShelleyLEDGER,
-    ShelleyLedgerEnv (..),
+  ( LedgerEnv (..),
+    ShelleyLEDGER,
     ShelleyLedgerEvent,
     ShelleyLedgerPredFailure,
   )
@@ -99,7 +99,7 @@ instance
 instance
   ( Era era,
     Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era),
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     State (EraRule "LEDGER" era) ~ LedgerState era,
     Signal (EraRule "LEDGER" era) ~ Tx era,
     DSignable (Crypto era) (Hash (Crypto era) EraIndependentTxBody),
@@ -119,7 +119,7 @@ instance
 ledgersTransition ::
   forall era.
   ( Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era),
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     State (EraRule "LEDGER" era) ~ LedgerState era,
     Signal (EraRule "LEDGER" era) ~ Tx era
   ) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -10,7 +10,7 @@
 module Cardano.Ledger.Shelley.Rules.Newpp
   ( ShelleyNEWPP,
     ShelleyNewppState (..),
-    ShelleyNewppEnv (..),
+    NewppEnv (..),
     ShelleyNewppPredFailure (..),
     PredicateFailure,
   )
@@ -56,7 +56,7 @@ data ShelleyNEWPP era
 data ShelleyNewppState era
   = NewppState (PParams era) (PPUPState era)
 
-data ShelleyNewppEnv era
+data NewppEnv era
   = NewppEnv
       (DState (Crypto era))
       (PState (Crypto era))
@@ -86,7 +86,7 @@ instance
   where
   type State (ShelleyNEWPP era) = ShelleyNewppState era
   type Signal (ShelleyNEWPP era) = Maybe (PParams era)
-  type Environment (ShelleyNEWPP era) = ShelleyNewppEnv era
+  type Environment (ShelleyNEWPP era) = NewppEnv era
   type BaseM (ShelleyNEWPP era) = ShelleyBase
   type PredicateFailure (ShelleyNEWPP era) = ShelleyNewppPredFailure era
   transitionRules = [newPpTransition]

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -14,7 +14,7 @@
 module Cardano.Ledger.Shelley.Rules.Pool
   ( ShelleyPOOL,
     PoolEvent (..),
-    ShelleyPoolEnv (..),
+    PoolEnv (..),
     PredicateFailure,
     ShelleyPoolPredFailure (..),
   )
@@ -74,12 +74,12 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyPOOL (era :: Type)
 
-data ShelleyPoolEnv era
+data PoolEnv era
   = PoolEnv SlotNo (PParams era)
 
-deriving instance (Show (PParams era)) => Show (ShelleyPoolEnv era)
+deriving instance (Show (PParams era)) => Show (PoolEnv era)
 
-deriving instance (Eq (PParams era)) => Eq (ShelleyPoolEnv era)
+deriving instance (Eq (PParams era)) => Eq (PoolEnv era)
 
 data ShelleyPoolPredFailure era
   = StakePoolNotRegisteredOnKeyPOOL
@@ -116,7 +116,7 @@ instance
 
   type Signal (ShelleyPOOL era) = DCert (Crypto era)
 
-  type Environment (ShelleyPOOL era) = ShelleyPoolEnv era
+  type Environment (ShelleyPOOL era) = PoolEnv era
 
   type BaseM (ShelleyPOOL era) = ShelleyBase
   type PredicateFailure (ShelleyPOOL era) = ShelleyPoolPredFailure era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -11,7 +11,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Ppup
   ( ShelleyPPUP,
-    ShelleyPPUPEnv (..),
+    PpupEnv (..),
     ShelleyPpupPredFailure (..),
     PpupEvent (..),
     PredicateFailure,
@@ -63,7 +63,7 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyPPUP era
 
-data ShelleyPPUPEnv era
+data PpupEnv era
   = PPUPEnv SlotNo (PParams era) (GenDelegs (Crypto era))
 
 data VotingPeriod = VoteForThisEpoch | VoteForNextEpoch
@@ -120,7 +120,7 @@ instance
   where
   type State (ShelleyPPUP era) = PPUPState era
   type Signal (ShelleyPPUP era) = Maybe (Update era)
-  type Environment (ShelleyPPUP era) = ShelleyPPUPEnv era
+  type Environment (ShelleyPPUP era) = PpupEnv era
   type BaseM (ShelleyPPUP era) = ShelleyBase
   type PredicateFailure (ShelleyPPUP era) = ShelleyPpupPredFailure era
   type Event (ShelleyPPUP era) = PpupEvent era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -8,7 +8,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Rupd
   ( ShelleyRUPD,
-    ShelleyRupdEnv (..),
+    RupdEnv (..),
     PredicateFailure,
     ShelleyRupdPredFailure,
     epochInfoRange,
@@ -79,7 +79,7 @@ import Numeric.Natural (Natural)
 
 data ShelleyRUPD era
 
-data ShelleyRupdEnv era
+data RupdEnv era
   = RupdEnv (BlocksMade (Crypto era)) (EpochState era)
 
 data ShelleyRupdPredFailure era -- No predicate failures
@@ -100,7 +100,7 @@ instance
   where
   type State (ShelleyRUPD era) = StrictMaybe (PulsingRewUpdate (Crypto era))
   type Signal (ShelleyRUPD era) = SlotNo
-  type Environment (ShelleyRUPD era) = ShelleyRupdEnv era
+  type Environment (ShelleyRUPD era) = RupdEnv era
   type BaseM (ShelleyRUPD era) = ShelleyBase
   type PredicateFailure (ShelleyRUPD era) = ShelleyRupdPredFailure era
   type Event (ShelleyRUPD era) = RupdEvent (Crypto era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Shelley.LedgerState
     PulsingRewUpdate,
   )
 import Cardano.Ledger.Shelley.Rules.NewEpoch (ShelleyNEWEPOCH, ShelleyNewEpochEvent, ShelleyNewEpochPredFailure)
-import Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent, ShelleyRUPD, ShelleyRupdEnv (..), ShelleyRupdPredFailure)
+import Cardano.Ledger.Shelley.Rules.Rupd (RupdEnv (..), RupdEvent, ShelleyRUPD, ShelleyRupdPredFailure)
 import Cardano.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
@@ -84,7 +84,7 @@ instance
     Embed (EraRule "RUPD" era) (ShelleyTICK era),
     State (ShelleyTICK era) ~ NewEpochState era,
     BaseM (ShelleyTICK era) ~ ShelleyBase,
-    Environment (EraRule "RUPD" era) ~ ShelleyRupdEnv era,
+    Environment (EraRule "RUPD" era) ~ RupdEnv era,
     State (EraRule "RUPD" era) ~ StrictMaybe (PulsingRewUpdate (Crypto era)),
     Signal (EraRule "RUPD" era) ~ SlotNo,
     Environment (EraRule "NEWEPOCH" era) ~ (),
@@ -93,12 +93,8 @@ instance
   ) =>
   STS (ShelleyTICK era)
   where
-  type
-    State (ShelleyTICK era) =
-      NewEpochState era
-  type
-    Signal (ShelleyTICK era) =
-      SlotNo
+  type State (ShelleyTICK era) = NewEpochState era
+  type Signal (ShelleyTICK era) = SlotNo
   type Environment (ShelleyTICK era) = ()
   type BaseM (ShelleyTICK era) = ShelleyBase
   type PredicateFailure (ShelleyTICK era) = ShelleyTickPredFailure era
@@ -168,7 +164,7 @@ bheadTransition ::
     STS (ShelleyTICK era),
     State (ShelleyTICK era) ~ NewEpochState era,
     BaseM (ShelleyTICK era) ~ ShelleyBase,
-    Environment (EraRule "RUPD" era) ~ ShelleyRupdEnv era,
+    Environment (EraRule "RUPD" era) ~ RupdEnv era,
     State (EraRule "RUPD" era) ~ StrictMaybe (PulsingRewUpdate (Crypto era)),
     Signal (EraRule "RUPD" era) ~ SlotNo,
     Environment (EraRule "NEWEPOCH" era) ~ (),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Shelley.LedgerState
     pattern EpochState,
   )
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
-import Cardano.Ledger.Shelley.Rules.Newpp (ShelleyNEWPP, ShelleyNewppEnv (..), ShelleyNewppState (..))
+import Cardano.Ledger.Shelley.Rules.Newpp (NewppEnv (..), ShelleyNEWPP, ShelleyNewppState (..))
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
   ( Embed (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -16,7 +16,7 @@
 
 module Cardano.Ledger.Shelley.Rules.Utxo
   ( ShelleyUTXO,
-    ShelleyUtxoEnv (..),
+    UtxoEnv (..),
     ShelleyUtxoPredFailure (..),
     UtxoEvent (..),
     PredicateFailure,
@@ -67,9 +67,9 @@ import Cardano.Ledger.Shelley.PParams
     Update,
   )
 import Cardano.Ledger.Shelley.Rules.Ppup
-  ( PpupEvent,
+  ( PpupEnv (..),
+    PpupEvent,
     ShelleyPPUP,
-    ShelleyPPUPEnv (..),
     ShelleyPpupPredFailure,
   )
 import Cardano.Ledger.Shelley.Tx
@@ -137,14 +137,14 @@ import Validation (failureUnless)
 
 data ShelleyUTXO era
 
-data ShelleyUtxoEnv era
+data UtxoEnv era
   = UtxoEnv
       SlotNo
       (PParams era)
       (Map (KeyHash 'StakePool (Crypto era)) (PoolParams (Crypto era)))
       (GenDelegs (Crypto era))
 
-deriving instance Show (PParams era) => Show (ShelleyUtxoEnv era)
+deriving instance Show (PParams era) => Show (UtxoEnv era)
 
 data UtxoEvent era
   = TotalDeposits Coin
@@ -311,7 +311,7 @@ instance
     Show (ShelleyTx era),
     Eq (PredicateFailure (EraRule "PPUP" era)),
     Embed (EraRule "PPUP" era) (ShelleyUTXO era),
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era)
   ) =>
@@ -319,7 +319,7 @@ instance
   where
   type State (ShelleyUTXO era) = UTxOState era
   type Signal (ShelleyUTXO era) = ShelleyTx era
-  type Environment (ShelleyUTXO era) = ShelleyUtxoEnv era
+  type Environment (ShelleyUTXO era) = UtxoEnv era
   type BaseM (ShelleyUTXO era) = ShelleyBase
   type PredicateFailure (ShelleyUTXO era) = ShelleyUtxoPredFailure era
   type Event (ShelleyUTXO era) = UtxoEvent era
@@ -362,12 +362,12 @@ utxoInductive ::
     STS (utxo era),
     Embed (EraRule "PPUP" era) (utxo era),
     BaseM (utxo era) ~ ShelleyBase,
-    Environment (utxo era) ~ ShelleyUtxoEnv era,
+    Environment (utxo era) ~ UtxoEnv era,
     State (utxo era) ~ UTxOState era,
     Signal (utxo era) ~ Tx era,
     PredicateFailure (utxo era) ~ ShelleyUtxoPredFailure era,
     Event (utxo era) ~ UtxoEvent era,
-    Environment (EraRule "PPUP" era) ~ ShelleyPPUPEnv era,
+    Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
     HasField "_minfeeA" (PParams era) Natural,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -84,7 +84,7 @@ import Cardano.Ledger.Shelley.Delegation.Certificates
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState.Types (UTxOState (..))
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (Update))
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUTXO, ShelleyUtxoEnv (..), ShelleyUtxoPredFailure, UtxoEvent)
+import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUTXO, ShelleyUtxoPredFailure, UtxoEnv (..), UtxoEvent)
 import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
 import Cardano.Ledger.Shelley.Tx
   ( ShelleyTx,
@@ -268,7 +268,7 @@ instance
 initialLedgerStateUTXOW ::
   forall era.
   ( Embed (EraRule "UTXO" era) (ShelleyUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era
   ) =>
   InitialRule (ShelleyUTXOW era)
@@ -285,10 +285,10 @@ transitionRulesUTXOW ::
     ShelleyEraTxBody era,
     BaseM (utxow era) ~ ShelleyBase,
     Embed (EraRule "UTXO" era) (utxow era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ Tx era,
-    Environment (utxow era) ~ ShelleyUtxoEnv era,
+    Environment (utxow era) ~ UtxoEnv era,
     State (utxow era) ~ UTxOState era,
     Signal (utxow era) ~ Tx era,
     PredicateFailure (utxow era) ~ ShelleyUtxowPredFailure era,
@@ -353,7 +353,7 @@ instance
     HasField "_protocolVersion" (PParams era) ProtVer,
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (ShelleyUTXOW era),
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
     Signal (EraRule "UTXO" era) ~ Tx era,
     HasField "_protocolVersion" (PParams era) ProtVer,
@@ -363,7 +363,7 @@ instance
   where
   type State (ShelleyUTXOW era) = UTxOState era
   type Signal (ShelleyUTXOW era) = ShelleyTx era
-  type Environment (ShelleyUTXOW era) = ShelleyUtxoEnv era
+  type Environment (ShelleyUTXOW era) = UtxoEnv era
   type BaseM (ShelleyUTXOW era) = ShelleyBase
   type PredicateFailure (ShelleyUTXOW era) = ShelleyUtxowPredFailure era
   type Event _ = ShelleyUtxowEvent era

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Shelley.API
     Block,
     DCert,
     DPState,
-    ShelleyDelplEnv,
+    DelplEnv,
     ShelleyLEDGERS,
     ShelleyTx,
   )
@@ -111,7 +111,7 @@ genTriple ::
     Core.PParams era ~ ShelleyPParams era,
     Mock (Crypto era),
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     ShelleyTest era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Shelley.PParams
     ShelleyPParamsHKD (..),
     emptyPParams,
   )
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow
   ( ShelleyUTXOW,
     ShelleyUtxowPredFailure (..),
@@ -165,7 +165,7 @@ utxoState1 =
     bobResult = (mkTxInPartial txid 0, ShelleyTxOut bobAddr coinsToBob)
     aliceResult = (mkTxInPartial txid 1, ShelleyTxOut aliceAddr (Coin 998990))
 
-utxoEnv :: ShelleyUtxoEnv C
+utxoEnv :: UtxoEnv C
 utxoEnv =
   UtxoEnv
     0

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -53,7 +53,7 @@ import Cardano.Ledger.Shelley.LedgerState
     UTxOState (..),
   )
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..), emptyPParams)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLEDGER, ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), WitnessSetHKD (..))
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
@@ -171,13 +171,13 @@ ppsBench =
       _tau = unsafeBoundRational 0.2
     }
 
-ledgerEnv :: (Core.PParams era ~ ShelleyPParams era) => ShelleyLedgerEnv era
+ledgerEnv :: (Core.PParams era ~ ShelleyPParams era) => LedgerEnv era
 ledgerEnv = LedgerEnv (SlotNo 0) minBound ppsBench (AccountState (Coin 0) (Coin 0))
 
 testLEDGER ::
   LedgerState B ->
   ShelleyTx B ->
-  ShelleyLedgerEnv B ->
+  LedgerEnv B ->
   ()
 testLEDGER initSt tx env = do
   let st = runShelleyBase $ applySTS @(ShelleyLEDGER B) (TRC (env, initSt, tx))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -45,14 +45,14 @@ import Cardano.Ledger.Shelley.API
     Block (..),
     Credential (ScriptHashObj),
     KeyPairs,
+    LedgerEnv,
     LedgerState,
-    ShelleyLedgerEnv,
     ShelleyLedgersEnv,
     StakeReference (StakeRefBase),
   )
 import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses, UTxOState (..))
 import Cardano.Ledger.Shelley.PParams (Update)
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.TxBody (DCert, ShelleyEraTxBody, Wdrl, WitVKey)
 import Cardano.Ledger.Shelley.UTxO (UTxO)
 import Cardano.Ledger.Slot (EpochNo)
@@ -119,7 +119,7 @@ type MinLEDGER_STS era =
     BaseM (EraRule "LEDGER" era) ~ ShelleyBase,
     Signal (EraRule "LEDGER" era) ~ Tx era,
     State (EraRule "LEDGER" era) ~ LedgerState era,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     BaseM (EraRule "LEDGERS" era) ~ ShelleyBase,
     State (EraRule "LEDGERS" era) ~ LedgerState era,
     Signal (EraRule "LEDGERS" era) ~ Seq (Tx era),
@@ -140,10 +140,10 @@ type MinUTXO_STS era =
   ( STS (EraRule "UTXOW" era),
     BaseM (EraRule "UTXOW" era) ~ ShelleyBase,
     State (EraRule "UTXOW" era) ~ UTxOState era,
-    Environment (EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOW" era) ~ UtxoEnv era,
     Signal (EraRule "UTXOW" era) ~ Tx era,
     State (EraRule "UTXO" era) ~ UTxOState era,
-    Environment (EraRule "UTXO" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     Signal (EraRule "UTXO" era) ~ Tx era
   )
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Era
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.LedgerState (incrementalStakeDistr)
 import Cardano.Ledger.Shelley.Rules.Bbody
-  ( ShelleyBbodyEnv,
+  ( BbodyEnv,
     ShelleyBbodyState,
   )
 import Cardano.Ledger.Slot
@@ -102,7 +102,7 @@ instance
     MinLEDGER_STS era,
     MinCHAIN_STS era,
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
-    Environment (Core.EraRule "BBODY" era) ~ ShelleyBbodyEnv era,
+    Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ ShelleyBbodyState era,
     Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/DCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/DCert.hs
@@ -26,12 +26,12 @@ import Cardano.Ledger.Shelley.API
   ( AccountState,
     DCert,
     DPState (..),
+    DelplEnv (..),
     KeyPair (..),
     KeyRole (..),
     PState (..),
     Ptr (..),
     ShelleyDELPL,
-    ShelleyDelplEnv (..),
   )
 import Cardano.Ledger.Shelley.Delegation.Certificates (isDeRegKey)
 import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplEvent, ShelleyDelplPredFailure)
@@ -101,7 +101,7 @@ deriving stock instance
 instance
   ( Era era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
@@ -121,7 +121,7 @@ instance
 certsTransition ::
   forall era.
   ( Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
@@ -159,7 +159,7 @@ instance
 instance
   ( EraGen era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
@@ -194,7 +194,7 @@ genDCerts ::
   forall era.
   ( EraGen era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -25,11 +25,11 @@ import Cardano.Ledger.Shelley.LedgerState
     UTxOState,
     genesisState,
   )
-import Cardano.Ledger.Shelley.Rules.Delegs (ShelleyDelegsEnv)
-import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDELPL, ShelleyDelplEnv, ShelleyDelplPredFailure)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLEDGER, ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Delegs (DelegsEnv)
+import Cardano.Ledger.Shelley.Rules.Delpl (DelplEnv, ShelleyDELPL, ShelleyDelplPredFailure)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.Rules.Ledgers (ShelleyLEDGERS, ShelleyLedgersEnv (..))
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv)
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv)
 import Cardano.Ledger.Shelley.TxBody (DCert)
 import Cardano.Ledger.Slot (SlotNo (..))
 import Control.Monad (foldM)
@@ -73,16 +73,16 @@ instance
     Mock (Crypto era),
     MinLEDGER_STS era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     PredicateFailure (Core.EraRule "DELPL" era) ~ ShelleyDelplPredFailure era,
     Embed (Core.EraRule "DELEGS" era) (ShelleyLEDGER era),
     Embed (Core.EraRule "UTXOW" era) (ShelleyLEDGER era),
-    Environment (Core.EraRule "UTXOW" era) ~ ShelleyUtxoEnv era,
+    Environment (Core.EraRule "UTXOW" era) ~ UtxoEnv era,
     State (Core.EraRule "UTXOW" era) ~ UTxOState era,
     Signal (Core.EraRule "UTXOW" era) ~ Core.Tx era,
-    Environment (Core.EraRule "DELEGS" era) ~ ShelleyDelegsEnv era,
+    Environment (Core.EraRule "DELEGS" era) ~ DelegsEnv era,
     State (Core.EraRule "DELEGS" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELEGS" era) ~ Seq (DCert (Crypto era)),
     Show (State (Core.EraRule "PPUP" era))
@@ -107,7 +107,7 @@ instance
     Mock (Crypto era),
     MinLEDGER_STS era,
     Embed (Core.EraRule "DELPL" era) (CERTS era),
-    Environment (Core.EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (Core.EraRule "DELPL" era) ~ DelplEnv era,
     State (Core.EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (Core.EraRule "DELPL" era) ~ DCert (Crypto era),
     PredicateFailure (Core.EraRule "DELPL" era) ~ ShelleyDelplPredFailure era,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -54,8 +54,8 @@ import Cardano.Ledger.Shelley.LedgerState
     ptrsMap,
     rewards,
   )
-import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplEnv)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Delpl (DelplEnv)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
 import Cardano.Ledger.Shelley.Tx (TxIn (..))
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody, Wdrl (..))
 import Cardano.Ledger.Shelley.UTxO
@@ -119,7 +119,7 @@ showBalance ::
     HasField "_keyDeposit" (PParams era) Coin,
     HasField "_poolDeposit" (PParams era) Coin
   ) =>
-  ShelleyLedgerEnv era ->
+  LedgerEnv era ->
   UTxOState era ->
   DPState (Crypto era) ->
   Tx era ->
@@ -159,12 +159,12 @@ genTx ::
   ( EraGen era,
     Mock (Crypto era),
     Embed (EraRule "DELPL" era) (CERTS era),
-    Environment (EraRule "DELPL" era) ~ ShelleyDelplEnv era,
+    Environment (EraRule "DELPL" era) ~ DelplEnv era,
     State (EraRule "DELPL" era) ~ DPState (Crypto era),
     Signal (EraRule "DELPL" era) ~ DCert (Crypto era)
   ) =>
   GenEnv era ->
-  ShelleyLedgerEnv era ->
+  LedgerEnv era ->
   LedgerState era ->
   Gen (Tx era)
 genTx

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.SafeHash (SafeHash)
 import Cardano.Ledger.Shelley.API (LedgerState, PPUPState)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx)
 import Cardano.Ledger.Shelley.UTxO (makeWitnessVKey)
 import Control.Monad.Trans.Reader (ReaderT)
@@ -135,7 +135,7 @@ propertyTests ::
     Embed (EraRule "DELEGS" era) ledger,
     Embed (EraRule "UTXOW" era) ledger,
     State (EraRule "PPUP" era) ~ PPUPState era,
-    Environment ledger ~ ShelleyLedgerEnv era,
+    Environment ledger ~ LedgerEnv era,
     QC.BaseEnv ledger ~ Globals,
     BaseM ledger ~ ReaderT Globals Identity,
     State ledger ~ LedgerState era,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -75,8 +75,8 @@ import Cardano.Ledger.Shelley.LedgerState
     _genDelegs,
   )
 import Cardano.Ledger.Shelley.Rules.Bbody
-  ( ShelleyBBODY,
-    ShelleyBbodyEnv (..),
+  ( BbodyEnv (..),
+    ShelleyBBODY,
     ShelleyBbodyPredFailure,
     ShelleyBbodyState (..),
   )
@@ -242,7 +242,7 @@ initialShelleyState lab e utxo reserves genDelegs pp initNonce =
 instance
   ( Era era,
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
-    Environment (Core.EraRule "BBODY" era) ~ ShelleyBbodyEnv era,
+    Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ ShelleyBbodyState era,
     Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),
@@ -285,7 +285,7 @@ chainTransition ::
   ( Era era,
     STS (CHAIN era),
     Embed (Core.EraRule "BBODY" era) (CHAIN era),
-    Environment (Core.EraRule "BBODY" era) ~ ShelleyBbodyEnv era,
+    Environment (Core.EraRule "BBODY" era) ~ BbodyEnv era,
     State (Core.EraRule "BBODY" era) ~ ShelleyBbodyState era,
     Signal (Core.EraRule "BBODY" era) ~ Block (BHeaderView (Crypto era)) era,
     Embed (Core.EraRule "TICKN" era) (CHAIN era),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -73,9 +73,9 @@ import Cardano.Ledger.Shelley.LedgerState
     rs,
   )
 import Cardano.Ledger.Shelley.Rewards (sumRewards)
-import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegEnv (..))
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv (..))
-import Cardano.Ledger.Shelley.Rules.Pool (ShelleyPOOL, ShelleyPoolEnv (..))
+import Cardano.Ledger.Shelley.Rules.Deleg (DelegEnv (..))
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL)
 import Cardano.Ledger.Shelley.Rules.Upec (votedValue)
 import Cardano.Ledger.Shelley.TxBody hiding (TxBody, TxOut)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance, totalDeposits, txins, txouts, pattern UTxO)
@@ -174,7 +174,7 @@ longTraceLen = 150
 
 type TestingLedger era ledger =
   ( BaseM ledger ~ ReaderT Globals Identity,
-    Environment ledger ~ ShelleyLedgerEnv era,
+    Environment ledger ~ LedgerEnv era,
     State ledger ~ LedgerState era,
     Signal ledger ~ Tx era,
     Embed (EraRule "DELEGS" era) ledger,
@@ -1000,7 +1000,7 @@ delegProperties =
     conjoin $
       map chainProp (sourceSignalTargets tr)
   where
-    delegProp :: ShelleyDelegEnv era -> SourceSignalTarget (ShelleyDELEG era) -> Property
+    delegProp :: DelegEnv era -> SourceSignalTarget (ShelleyDELEG era) -> Property
     delegProp denv delegSst =
       conjoin $
         [ TestDeleg.keyRegistration delegSst,
@@ -1103,7 +1103,7 @@ delegTraceFromBlock ::
   ) =>
   ChainState era ->
   Block (BHeader (Crypto era)) era ->
-  (ShelleyDelegEnv era, Trace (ShelleyDELEG era))
+  (DelegEnv era, Trace (ShelleyDELEG era))
 delegTraceFromBlock chainSt block =
   ( delegEnv,
     runShelleyBase $
@@ -1138,7 +1138,7 @@ ledgerTraceBase ::
   ) =>
   ChainState era ->
   Block (BHeader (Crypto era)) era ->
-  (ChainState era, ShelleyLedgerEnv era, LedgerState era, [Tx era])
+  (ChainState era, LedgerEnv era, LedgerState era, [Tx era])
 ledgerTraceBase chainSt block =
   ( tickedChainSt,
     LedgerEnv slot minBound pp_ (esAccountState nes),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestDeleg.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestDeleg.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Shelley.LedgerState
     delegations,
     rewards,
   )
-import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegEnv (..))
+import Cardano.Ledger.Shelley.Rules.Deleg (DelegEnv (..))
 import Cardano.Ledger.Shelley.TxBody
   ( MIRPot (..),
     MIRTarget (..),
@@ -133,7 +133,7 @@ rewardsSumInvariant
 
 checkInstantaneousRewards ::
   (HasField "_protocolVersion" (Core.PParams era) ProtVer) =>
-  ShelleyDelegEnv era ->
+  DelegEnv era ->
   SourceSignalTarget (ShelleyDELEG era) ->
   Property
 checkInstantaneousRewards

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
@@ -18,13 +18,13 @@ import Cardano.Ledger.Shelley.API
     Credential (..),
     DCert (..),
     DState (..),
+    DelegEnv (..),
     InstantaneousRewards (..),
     MIRCert (..),
     MIRPot (..),
     MIRTarget (..),
     Ptr (..),
     ShelleyDELEG,
-    ShelleyDelegEnv (..),
   )
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..), emptyPParams)
 import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegPredFailure (..))
@@ -46,7 +46,7 @@ ignoreAllButIRWD ::
   Either [PredicateFailure (ShelleyDELEG ShelleyTest)] (InstantaneousRewards C_Crypto)
 ignoreAllButIRWD = fmap _irwd
 
-env :: ProtVer -> AccountState -> ShelleyDelegEnv ShelleyTest
+env :: ProtVer -> AccountState -> DelegEnv ShelleyTest
 env pv acnt =
   DelegEnv
     { slotNo = SlotNo 50,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -12,11 +12,11 @@ import Cardano.Ledger.Shelley.API
   ( DCert (..),
     Network (..),
     PoolCert (..),
+    PoolEnv (..),
     PoolParams (..),
     RewardAcnt (..),
     ShelleyPOOL,
     ShelleyPParamsHKD (..),
-    ShelleyPoolEnv (..),
   )
 import Cardano.Ledger.Slot (SlotNo (..))
 import Control.State.Transition.Extended hiding (Assertion)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -59,7 +59,7 @@ import Cardano.Ledger.Shelley.PParams
     emptyPParams,
     _maxTxSize,
   )
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Scripts
   ( MultiSig,
     pattern RequireAllOf,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -39,8 +39,8 @@ import Cardano.Ledger.Keys
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API
   ( DCert (..),
+    LedgerEnv (..),
     ShelleyLEDGER,
-    ShelleyLedgerEnv (..),
   )
 import Cardano.Ledger.Shelley.Delegation.Certificates (pattern RegPool)
 import Cardano.Ledger.Shelley.LedgerState
@@ -317,7 +317,7 @@ testLEDGER ::
   HasCallStack =>
   LedgerState C ->
   ShelleyTx C ->
-  ShelleyLedgerEnv C ->
+  LedgerEnv C ->
   Either [PredicateFailure (ShelleyLEDGER C)] (LedgerState C) ->
   Assertion
 testLEDGER initSt tx env (Right expectedSt) = do
@@ -396,7 +396,7 @@ addReward dp ra c = dp {dpsDState = ds {_unified = rewards'}}
     ds = dpsDState dp
     rewards' = UM.insert ra c (rewards ds)
 
-ledgerEnv :: ShelleyLedgerEnv C
+ledgerEnv :: LedgerEnv C
 ledgerEnv = LedgerEnv (SlotNo 0) minBound pp (AccountState (Coin 0) (Coin 0))
 
 testInvalidTx ::

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -26,8 +26,8 @@ import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API
   ( ApplyTx,
     Globals,
+    LedgerEnv,
     LedgerState,
-    ShelleyLedgerEnv,
     applyTxsTransition,
   )
 import Cardano.Ledger.Shelley.LedgerState (DPState, UTxOState)
@@ -77,7 +77,7 @@ benchWithGenState ::
     Default (State (EraRule "PPUP" era)),
     BaseEnv (EraRule "LEDGER" era) ~ Globals,
     Signal (EraRule "LEDGER" era) ~ Tx era,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     State (EraRule "LEDGER" era) ~ LedgerState era
   ) =>
   Proxy era ->
@@ -120,7 +120,7 @@ deserialiseTxEra ::
     BaseEnv (EraRule "LEDGER" era) ~ Globals,
     HasTrace (EraRule "LEDGER" era) (GenEnv era),
     State (EraRule "LEDGER" era) ~ LedgerState era,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     Signal (EraRule "LEDGER" era) ~ Tx era,
     NFData (Tx era)
   ) =>

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -14,8 +14,8 @@ import Cardano.Ledger.Shelley.API
   ( AccountState (..),
     Coin (..),
     Globals,
+    LedgerEnv (..),
     MempoolEnv,
-    ShelleyLedgerEnv (..),
   )
 import Cardano.Ledger.Shelley.LedgerState (LedgerState)
 import Cardano.Ledger.Slot (SlotNo (SlotNo))
@@ -70,7 +70,7 @@ generateApplyTxEnvForEra ::
     HasTrace (EraRule "LEDGER" era) (GenEnv era),
     BaseEnv (EraRule "LEDGER" era) ~ Globals,
     Signal (EraRule "LEDGER" era) ~ Core.Tx era,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era,
     State (EraRule "LEDGER" era) ~ LedgerState era
   ) =>
   Proxy era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -24,7 +24,7 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.LedgerState (IncrementalStake (..), UTxOState (..))
-import Cardano.Ledger.Shelley.Rules.Utxo (PredicateFailure, ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (PredicateFailure, UtxoEnv (..))
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), makeWitnessVKey)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
@@ -94,7 +94,7 @@ testExUnitCalculation ::
   ( MonadFail m,
     BaseM (EraRule "UTXOS" era) ~ ShelleyBase,
     State (EraRule "UTXOS" era) ~ UTxOState era,
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
     AlonzoEraTx era,
     ExtendedUTxO era,
@@ -107,7 +107,7 @@ testExUnitCalculation ::
   Proof era ->
   Tx era ->
   UTxOState era ->
-  ShelleyUtxoEnv era ->
+  UtxoEnv era ->
   EpochInfo (Either Text) ->
   SystemStart ->
   Array Language CostModel ->
@@ -127,7 +127,7 @@ exampleExUnitCalc ::
   forall era.
   ( BaseM (EraRule "UTXOS" era) ~ ShelleyBase,
     State (EraRule "UTXOS" era) ~ UTxOState era,
-    Environment (EraRule "UTXOS" era) ~ ShelleyUtxoEnv era,
+    Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     Signable
       (CC.DSIGN (Crypto era))
       (Crypto.Hash (CC.HASH (Crypto era)) EraIndependentTxBody),
@@ -218,7 +218,7 @@ exampleTx pf ptr =
 exampleEpochInfo :: Monad m => EpochInfo m
 exampleEpochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
 
-uenv :: Proof era -> ShelleyUtxoEnv era
+uenv :: Proof era -> UtxoEnv era
 uenv pf = UtxoEnv (SlotNo 0) (pparams pf) mempty (GenDelegs mempty)
 
 costmodels :: Array Language CostModel

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -94,13 +94,13 @@ import Cardano.Ledger.Shelley.LedgerState
     smartUTxOState,
   )
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
-import Cardano.Ledger.Shelley.Rules.Bbody (ShelleyBbodyEnv (..), ShelleyBbodyPredFailure (..), ShelleyBbodyState (..))
+import Cardano.Ledger.Shelley.Rules.Bbody (BbodyEnv (..), ShelleyBbodyPredFailure (..), ShelleyBbodyState (..))
 import Cardano.Ledger.Shelley.Rules.Delegs (ShelleyDelegsPredFailure (..))
 import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplPredFailure (..))
 import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerPredFailure (..))
 import Cardano.Ledger.Shelley.Rules.Ledgers (ShelleyLedgersPredFailure (..))
 import Cardano.Ledger.Shelley.Rules.Pool (ShelleyPoolPredFailure (..))
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow as Shelley (ShelleyUtxowPredFailure (..))
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
@@ -190,7 +190,7 @@ defaultPPs =
     CollateralPercentage 100
   ]
 
-utxoEnv :: PParams era -> ShelleyUtxoEnv era
+utxoEnv :: PParams era -> UtxoEnv era
 utxoEnv pparams =
   UtxoEnv
     (SlotNo 0)
@@ -1739,7 +1739,7 @@ collectOrderingAlonzo =
 -- Alonzo BBODY Tests
 -- =======================
 
-bbodyEnv :: Proof era -> ShelleyBbodyEnv era
+bbodyEnv :: Proof era -> BbodyEnv era
 bbodyEnv pf = BbodyEnv (pp pf) def
 
 dpstate :: Scriptic era => Proof era -> DPState (Crypto era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -36,14 +36,14 @@ import Cardano.Ledger.Shelley.LedgerState
     StashedAVVMAddresses,
   )
 import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate)
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv)
 import Cardano.Ledger.Shelley.Rules.Ledgers
   ( ShelleyLEDGERS,
     ShelleyLedgersEnv (..),
     ShelleyLedgersEvent,
     ShelleyLedgersPredFailure,
   )
-import Cardano.Ledger.Shelley.Rules.Rupd (ShelleyRupdEnv)
+import Cardano.Ledger.Shelley.Rules.Rupd (RupdEnv)
 import Cardano.Ledger.Shelley.Rules.Tick (ShelleyTICK, ShelleyTickEvent, ShelleyTickPredFailure)
 import Cardano.Slotting.Slot (EpochNo, SlotNo)
 import Control.State.Transition
@@ -130,7 +130,7 @@ instance
     Signal (Core.EraRule "TICK" era) ~ SlotNo,
     Environment (Core.EraRule "TICK" era) ~ (),
     Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
-    Environment (Core.EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
     State (Core.EraRule "LEDGER" era) ~ LedgerState era,
     Embed (Core.EraRule "TICK" era) (MOCKCHAIN era)
   ) =>
@@ -152,7 +152,7 @@ chainTransition ::
     Signal (Core.EraRule "TICK" era) ~ SlotNo,
     Environment (Core.EraRule "TICK" era) ~ (),
     Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era,
-    Environment (Core.EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
     State (Core.EraRule "LEDGER" era) ~ LedgerState era,
     Embed (Core.EraRule "TICK" era) (MOCKCHAIN era)
   ) =>
@@ -185,7 +185,7 @@ instance
   ( STS (ShelleyTICK era),
     Signal (Core.EraRule "RUPD" era) ~ SlotNo,
     State (Core.EraRule "RUPD" era) ~ StrictMaybe (PulsingRewUpdate (Crypto era)),
-    Environment (Core.EraRule "RUPD" era) ~ ShelleyRupdEnv era,
+    Environment (Core.EraRule "RUPD" era) ~ RupdEnv era,
     State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
     Signal (Core.EraRule "NEWEPOCH" era) ~ EpochNo,
     State (Core.EraRule "NEWEPOCH" era) ~ NewEpochState era,
@@ -199,7 +199,7 @@ instance
 instance
   ( STS (ShelleyLEDGERS era),
     State (Core.EraRule "LEDGER" era) ~ LedgerState era,
-    Environment (Core.EraRule "LEDGER" era) ~ ShelleyLedgerEnv era,
+    Environment (Core.EraRule "LEDGER" era) ~ LedgerEnv era,
     Signal (Core.EraRule "LEDGER" era) ~ Core.Tx era
   ) =>
   Embed (ShelleyLEDGERS era) (MOCKCHAIN era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -26,8 +26,8 @@ import Cardano.Ledger.Shelley.LedgerState
     updateStakeDistribution,
   )
 import qualified Cardano.Ledger.Shelley.PParams as Shelley (ShelleyPParamsHKD (..))
-import Cardano.Ledger.Shelley.Rules.Ledger (ShelleyLedgerEnv (..))
-import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv (..))
+import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad.Trans.RWS.Strict (gets)
@@ -97,7 +97,7 @@ genTxAndLEDGERState ::
   ( Reflect era,
     Signal (EraRule "LEDGER" era) ~ Tx era,
     State (EraRule "LEDGER" era) ~ LedgerState era,
-    Environment (EraRule "LEDGER" era) ~ ShelleyLedgerEnv era
+    Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   ) =>
   Proof era ->
   GenSize ->


### PR DESCRIPTION
* `ShelleyLedgerEnv` -> `LedgerEnv`
* `ShelleyBbodyEnv` -> `BbodyEnv`
* `ShelleyDelegsEnv` -> `DelegsEnv`
* `ShelleyDelegEnv` -> `DelegEnv`
* `ShelleyDelplEnv` -> `DelplEnv`
* `ShelleyNewppEnv` -> `NewppEnv`
* `ShelleyPoolEnv` -> `PoolEnv`
* `ShelleyRupdEnv` -> `RupdEnv`
* `ShelleyUtxoEnv` -> `UtxoEnv`

Also rename `PPUP` -> `Ppup` suffix for consistency:

* `ShelleyPPUPEnv` -> `PpupEnv`