### PR TITLE
update changelog for 1.1.x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ in the naming of release branches.
 
 ## [Unreleased]
 
+## Release branch 1.1.x
+
 ### Added
 - New `calculatePoolDistr'` function which is similar to `calculatePoolDistr` but has a new
   filter argument to only include the stake pool ids (stake pool key hashes) that are needed.
@@ -208,7 +210,7 @@ BabbageEraTxBody --> AlonzoEraTxBody --> ....
   It now uses the Alonze minfee function.
   #2936
 
-## Release branch 1.0.0
+## Release branch 1.0.x
 
 The first release branch in the cardano-ledger repository,
 namely `release/1.0.0`, branches from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,13 @@
 
 We use [trunk based developement](https://trunkbaseddevelopment.com/).
 In particular, releases will be handled by release branches,
-starting with `release/1.0.0`.
+starting with `release/1.0.x`.
 Normal development will branch off of master and be merged back to master.
 Only bug-fixes can be cherry-picked onto the release branches.
+
+We use tags on the release branches to indicate patches, of the form `ledger/a.b.c`.
+We also use tags to indicate what version of the ledger was used in
+cardano-node releases, of the form `node/a.b.c` (possible with a `rc` or `rc1`, etc).
 
 ## Building
 


### PR DESCRIPTION
Update the changelog for the `1.1.x` release.

Also update the contributing document with our use of tags for patches.