### PR TITLE
Remove an exact same validation in Babbage in favor of the one in Shelley

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -562,7 +562,7 @@ utxoTransition = do
 
   {- ∀ ( _ ↦ (a,_)) ∈ txoutstxb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64 -}
   runTestOnSignal $
-    Shelley.validateOutputBootAddrAttrsTooBig outputs
+    Shelley.validateOutputBootAddrAttrsTooBig (Map.elems (unUTxO outputs))
 
   netId <- liftSTS $ asks networkId
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -267,7 +267,7 @@ utxoTransition = do
   runTest $ validateOutputTooBigUTxO outputs
 
   {- ∀ ( _ ↦ (a,_)) ∈ txoutstxb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64 -}
-  runTest $ Shelley.validateOutputBootAddrAttrsTooBig outputs
+  runTest $ Shelley.validateOutputBootAddrAttrsTooBig (Map.elems (unUTxO outputs))
 
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ Shelley.validateMaxTxSizeUTxO pp tx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -414,7 +414,7 @@ utxoInductive = do
   runTest $ validateOutputTooSmallUTxO pp outputs
 
   {- ∀ ( _ ↦ (a,_)) ∈ txoutstxb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64 -}
-  runTest $ validateOutputBootAddrAttrsTooBig outputs
+  runTest $ validateOutputBootAddrAttrsTooBig (Map.elems (unUTxO outputs))
 
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ validateMaxTxSizeUTxO pp tx
@@ -563,9 +563,9 @@ validateOutputTooSmallUTxO pp (UTxO outputs) =
 -- > ∀ ( _ ↦ (a,_)) ∈ txoutstxb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64
 validateOutputBootAddrAttrsTooBig ::
   EraTxOut era =>
-  UTxO era ->
+  [TxOut era] ->
   Test (ShelleyUtxoPredFailure era)
-validateOutputBootAddrAttrsTooBig (UTxO outputs) =
+validateOutputBootAddrAttrsTooBig outputs =
   failureUnless (null outputsAttrsTooBig) $ OutputBootAddrAttrsTooBig outputsAttrsTooBig
   where
     outputsAttrsTooBig =
@@ -575,7 +575,7 @@ validateOutputBootAddrAttrsTooBig (UTxO outputs) =
               Just addr -> bootstrapAddressAttrsSize addr > 64
               _ -> False
         )
-        (Map.elems outputs)
+        outputs
 
 -- | Ensure that the size of the transaction does not exceed the @maxTxSize@ protocol parameter
 --


### PR DESCRIPTION
Remove the version of `validateOutputBootAddrAttrsTooBig` that is
defined in Babbage. All eras use the version from Shelley. The only
thing special about Babbage version was that it accepted a list instead
of a `UTxO`. Converting to a list with `elems` at the call site instead
of inside the function itself is a small price to pay for removing an
extra copy of the validation function.