### PR TITLE
Make Arbitrary instances Era agnostic

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -285,7 +285,7 @@ data ScriptIntegrity era
   = ScriptIntegrity
       !(Redeemers era) -- From the witnesses
       !(TxDats era)
-      !(Set LangDepView) -- From the Porotocl parameters
+      !(Set LangDepView) -- From the Protocol parameters
   deriving (Eq, Generic, Typeable)
 
 deriving instance HashAlgorithm (HASH (Crypto era)) => Show (ScriptIntegrity era)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -574,7 +574,7 @@ deriving via
     FromCBOR (Annotator (AlonzoTxBody era))
 
 pattern AlonzoTxBody ::
-  EraTxBody era =>
+  (EraTxOut era, ToCBOR (PParamsUpdate era)) =>
   Set (TxIn (Crypto era)) ->
   Set (TxIn (Crypto era)) ->
   StrictSeq (AlonzoTxOut era) ->

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -65,7 +65,11 @@ import Cardano.Ledger.Shelley.TxBody
     addrEitherShelleyTxOutL,
     valueEitherShelleyTxOutL,
   )
-import Cardano.Ledger.ShelleyMA.Era (MAClass (getScriptHash, promoteMultiAsset), MaryOrAllegra (..), ShelleyMAEra)
+import Cardano.Ledger.ShelleyMA.Era
+  ( MAClass (getScriptHash, promoteMultiAsset),
+    MaryOrAllegra (..),
+    ShelleyMAEra,
+  )
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val
@@ -150,7 +154,10 @@ fromSJust SNothing = error "SNothing in fromSJust"
 -- concerns as we want the Shelley era TxBody to deserialise as a Shelley-ma TxBody.
 -- txXparse and bodyFields should be Duals, visual inspection helps ensure this.
 
-txSparse :: ShelleyMAEraTxBody era => TxBodyRaw era -> Encode ('Closed 'Sparse) (TxBodyRaw era)
+txSparse ::
+  (EraTxOut era, ToCBOR (PParamsUpdate era)) =>
+  TxBodyRaw era ->
+  Encode ('Closed 'Sparse) (TxBodyRaw era)
 txSparse (TxBodyRaw inp out cert wdrl fee (ValidityInterval bot top) up hash frge) =
   Keyed (\i o f topx c w u h botx forg -> TxBodyRaw i o c w f (ValidityInterval botx topx) u h forg)
     !> Key 0 (E encodeFoldable inp) -- We don't have to send these in TxBodyX order
@@ -164,7 +171,7 @@ txSparse (TxBodyRaw inp out cert wdrl fee (ValidityInterval bot top) up hash frg
     !> encodeKeyedStrictMaybe 8 bot
     !> Omit (== mempty) (Key 9 (E encodeMint frge))
 
-bodyFields :: ShelleyMAEraTxBody era => Word -> Field (TxBodyRaw era)
+bodyFields :: (EraTxOut era, FromCBOR (PParamsUpdate era)) => Word -> Field (TxBodyRaw era)
 bodyFields 0 = field (\x tx -> tx {inputs = x}) (D (decodeSet fromCBOR))
 bodyFields 1 = field (\x tx -> tx {outputs = x}) (D (decodeStrictSeq fromCBOR))
 bodyFields 2 = field (\x tx -> tx {txfee = x}) From
@@ -234,7 +241,7 @@ instance (c ~ Crypto era, Era era) => HashAnnotated (MATxBody era) EraIndependen
 -- Make a Pattern so the newtype and the MemoBytes are hidden
 
 pattern MATxBody ::
-  ShelleyMAEraTxBody era =>
+  (EraTxOut era, ToCBOR (PParamsUpdate era)) =>
   Set (TxIn (Crypto era)) ->
   StrictSeq (ShelleyTxOut era) ->
   StrictSeq (DCert (Crypto era)) ->
@@ -259,7 +266,7 @@ pattern MATxBody inputs outputs certs wdrls txfee vldt update adHash mint <-
 {-# COMPLETE MATxBody #-}
 
 mkMATxBody ::
-  ShelleyMAEraTxBody era =>
+  (EraTxOut era, ToCBOR (PParamsUpdate era)) =>
   TxBodyRaw era ->
   MATxBody era
 mkMATxBody = TxBodyConstr . memoBytes . txSparse

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -34,7 +34,7 @@ import Cardano.Ledger.Shelley.Tx
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
 import Cardano.Ledger.ShelleyMA.Rules (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
-import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (MATxBody), ShelleyMAEraTxBody)
+import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (MATxBody))
 import Cardano.Ledger.Val ((<+>))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
@@ -283,8 +283,7 @@ genTxBody ::
   ( EraGen era,
     Value era ~ MaryValue (Crypto era),
     PParams era ~ ShelleyPParams era,
-    TxOut era ~ ShelleyTxOut era,
-    ShelleyMAEraTxBody era
+    TxOut era ~ ShelleyTxOut era
   ) =>
   ShelleyPParams era ->
   SlotNo ->

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -24,18 +24,16 @@ where
 import Cardano.Binary (Annotator, FromCBOR, ToCBOR (toCBOR))
 import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
 import qualified Cardano.Crypto.Hash as Hash
-import Cardano.Ledger.Allegra (AllegraEra)
-import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Crypto, Era)
-import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
 import qualified Cardano.Ledger.Mary.Value as ConcreteValue
-import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.API (KeyHash (KeyHash), Metadata (Metadata))
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
 import Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA (Timelock (..))
 import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (..))
+import Control.State.Transition (PredicateFailure)
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce (coerce)
 import Data.Int (Int64)
@@ -108,9 +106,9 @@ instance
   ( Era era,
     c ~ Crypto era,
     Mock c,
-    FromCBOR (Annotator (Core.Script era)),
-    ToCBOR (Core.Script era),
-    Arbitrary (Core.Script era)
+    FromCBOR (Annotator (Script era)),
+    ToCBOR (Script era),
+    Arbitrary (Script era)
   ) =>
   Arbitrary (MAAuxiliaryData era)
   where
@@ -130,17 +128,27 @@ instance
       Metadata m -> MAAuxiliaryData m <$> (genScriptSeq @era)
 
 genScriptSeq ::
-  forall era. Arbitrary (Core.Script era) => Gen (StrictSeq (Core.Script era))
+  forall era. Arbitrary (Script era) => Gen (StrictSeq (Script era))
 genScriptSeq = do
   n <- choose (0, 3)
   l <- vectorOf n arbitrary
   pure (fromList l)
 
-{-------------------------------------------------------------------------------
-  MaryEra Generators
--------------------------------------------------------------------------------}
+instance
+  ( Era era,
+    Mock (Crypto era),
+    Arbitrary (Value era),
+    Arbitrary (TxOut era),
+    Arbitrary (PredicateFailure (EraRule "PPUP" era))
+  ) =>
+  Arbitrary (ShelleyMAUtxoPredFailure era)
+  where
+  arbitrary = genericArbitraryU
 
-instance Mock c => Arbitrary (MATxBody (MaryEra c)) where
+instance
+  (EraTxOut era, Mock (Crypto era), Arbitrary (Value era), ToCBOR (PParamsUpdate era)) =>
+  Arbitrary (MATxBody era)
+  where
   arbitrary =
     MATxBody
       <$> arbitrary
@@ -152,6 +160,10 @@ instance Mock c => Arbitrary (MATxBody (MaryEra c)) where
       <*> arbitrary
       <*> arbitrary
       <*> genMintValues
+
+{-------------------------------------------------------------------------------
+  MaryEra Generators
+-------------------------------------------------------------------------------}
 
 instance Mock c => Arbitrary (PolicyID c) where
   arbitrary = PolicyID <$> arbitrary
@@ -170,9 +182,7 @@ instance Mock c => Arbitrary (MaryValue c) where
       [ -- Shrink the ADA value
         flip MaryValue assets <$> shrink ada,
         -- Shrink the non-ADA assets by reducing the list length
-        MaryValue
-          ada
-          <$> shrink assets
+        MaryValue ada <$> shrink assets
       ]
 
 -- | When generating values for the mint field, we do two things:
@@ -203,25 +213,9 @@ multiAssetFromListBounded =
 instance Arbitrary AssetName where
   arbitrary = AssetName . SBS.pack . take 32 . SBS.unpack <$> arbitrary
 
-instance Mock c => Arbitrary (ShelleyMAUtxoPredFailure (MaryEra c)) where
-  arbitrary = genericArbitraryU
-
 {-------------------------------------------------------------------------------
   AllegraEra Generators
 -------------------------------------------------------------------------------}
-
-instance Mock c => Arbitrary (MATxBody (AllegraEra c)) where
-  arbitrary =
-    MATxBody
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> pure mempty
 
 instance Era era => Arbitrary (Timelock era) where
   arbitrary = sizedTimelock maxTimelockDepth
@@ -229,6 +223,3 @@ instance Era era => Arbitrary (Timelock era) where
 instance Arbitrary ValidityInterval where
   arbitrary = genericArbitraryU
   shrink = genericShrink
-
-instance Mock c => Arbitrary (ShelleyMAUtxoPredFailure (AllegraEra c)) where
-  arbitrary = genericArbitraryU

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -468,7 +468,7 @@ deriving via Mem TxBodyRaw era instance EraTxBody era => FromCBOR (Annotator (Tx
 
 -- | Pattern for use by external users
 pattern ShelleyTxBody ::
-  EraTxBody era =>
+  (EraTxOut era, ToCBOR (PParamsUpdate era)) =>
   Set (TxIn (Crypto era)) ->
   StrictSeq (TxOut era) ->
   StrictSeq (DCert (Crypto era)) ->
@@ -499,7 +499,7 @@ pattern ShelleyTxBody {_inputs, _outputs, _certs, _wdrls, _txfee, _ttl, _txUpdat
 
 {-# COMPLETE ShelleyTxBody #-}
 
-mkShelleyTxBody :: EraTxBody era => TxBodyRaw era -> ShelleyTxBody era
+mkShelleyTxBody :: (EraTxOut era, ToCBOR (PParamsUpdate era)) => TxBodyRaw era -> ShelleyTxBody era
 mkShelleyTxBody = TxBodyConstr . memoBytes . txSparse
 
 -- =========================================

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
@@ -10,7 +10,8 @@
 
 module Test.Cardano.Ledger.Shelley.Serialisation.Generators () where
 
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Binary (ToCBOR)
+import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ShelleyTxBody (ShelleyTxBody))
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams)
 import qualified Cardano.Ledger.Shelley.Rules.Utxo as STS
@@ -30,7 +31,10 @@ import Test.QuickCheck
   necessarily valid
 -------------------------------------------------------------------------------}
 
-instance Mock c => Arbitrary (ShelleyTxBody (ShelleyEra c)) where
+instance
+  (EraTxOut era, Mock (Crypto era), Arbitrary (Value era), ToCBOR (PParamsUpdate era)) =>
+  Arbitrary (ShelleyTxBody era)
+  where
   arbitrary =
     ShelleyTxBody
       <$> arbitrary
@@ -42,7 +46,15 @@ instance Mock c => Arbitrary (ShelleyTxBody (ShelleyEra c)) where
       <*> arbitrary
       <*> arbitrary
 
-instance Mock c => Arbitrary (STS.ShelleyUtxoPredFailure (ShelleyEra c)) where
+instance
+  ( Era era,
+    Mock (Crypto era),
+    Arbitrary (Value era),
+    Arbitrary (TxOut era),
+    Arbitrary (STS.PredicateFailure (EraRule "PPUP" era))
+  ) =>
+  Arbitrary (STS.ShelleyUtxoPredFailure era)
+  where
   arbitrary = genericArbitraryU
   shrink _ = []
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Bootstrap.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -152,20 +152,20 @@ testTxValidForLEDGER proof (Box _ trc@(TRC (_, ledgerState, vtx)) _genstate) =
 -- The generic types make a roundtrip without adding or losing information
 
 txOutRoundTrip ::
-  EraTxOut era => Proof era -> TxOut era -> Bool
-txOutRoundTrip proof x = coreTxOut proof (abstractTxOut proof x) == x
+  EraTxOut era => Proof era -> TxOut era -> Property
+txOutRoundTrip proof x = coreTxOut proof (abstractTxOut proof x) === x
 
 txRoundTrip ::
-  EraTx era => Proof era -> Tx era -> Bool
-txRoundTrip proof x = coreTx proof (abstractTx proof x) == x
+  EraTx era => Proof era -> Tx era -> Property
+txRoundTrip proof x = coreTx proof (abstractTx proof x) === x
 
 txBodyRoundTrip ::
-  EraTxBody era => Proof era -> TxBody era -> Bool
-txBodyRoundTrip proof x = coreTxBody proof (abstractTxBody proof x) == x
+  EraTxBody era => Proof era -> TxBody era -> Property
+txBodyRoundTrip proof x = coreTxBody proof (abstractTxBody proof x) === x
 
 txWitRoundTrip ::
-  EraWitnesses era => Proof era -> Witnesses era -> Bool
-txWitRoundTrip proof x = assembleWits proof (abstractWitnesses proof x) == x
+  EraWitnesses era => Proof era -> Witnesses era -> Property
+txWitRoundTrip proof x = assembleWits proof (abstractWitnesses proof x) === x
 
 coreTypesRoundTrip :: TestTree
 coreTypesRoundTrip =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -142,16 +142,16 @@ assembleWits :: Era era => Proof era -> [WitnessesField era] -> Witnesses era
 assembleWits era = List.foldl' (updateWitnesses merge era) (initialWitnesses era)
 
 coreTxOut :: Era era => Proof era -> [TxOutField era] -> TxOut era
-coreTxOut era dts = List.foldl' (updateTxOut era) (initialTxOut era) dts
+coreTxOut era = List.foldl' (updateTxOut era) (initialTxOut era)
 
 coreTxBody :: EraTxBody era => Proof era -> [TxBodyField era] -> TxBody era
-coreTxBody era dts = List.foldl' (updateTxBody era) (initialTxBody era) dts
+coreTxBody era = List.foldl' (updateTxBody era) (initialTxBody era)
 
 overrideTxBody :: EraTxBody era => Proof era -> TxBody era -> [TxBodyField era] -> TxBody era
-overrideTxBody era old dts = List.foldl' (updateTxBody era) old dts
+overrideTxBody era = List.foldl' (updateTxBody era)
 
 coreTx :: Proof era -> [TxField era] -> Tx era
-coreTx era dts = List.foldl' (updateTx era) (initialTx era) dts
+coreTx era = List.foldl' (updateTx era) (initialTx era)
 
 -- ====================================================================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -101,7 +101,7 @@ instance Merge (Map (ScriptHash c) v) where
 -- Updaters for Tx
 
 updateTx :: Proof era -> Tx era -> TxField era -> Tx era
-updateTx (wit@(Shelley _)) (tx@(ShelleyTx b w d)) dt =
+updateTx wit@(Shelley _) tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
@@ -109,7 +109,7 @@ updateTx (wit@(Shelley _)) (tx@(ShelleyTx b w d)) dt =
     WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
     AuxData faux -> ShelleyTx b w faux
     Valid _ -> tx
-updateTx (wit@(Allegra _)) (tx@(ShelleyTx b w d)) dt =
+updateTx wit@(Allegra _) tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
@@ -117,7 +117,7 @@ updateTx (wit@(Allegra _)) (tx@(ShelleyTx b w d)) dt =
     WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
     AuxData faux -> ShelleyTx b w faux
     Valid _ -> tx
-updateTx (wit@(Mary _)) (tx@(ShelleyTx b w d)) dt =
+updateTx wit@(Mary _) tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -174,6 +174,8 @@ updateTxBody pf txBody dt =
       Wdrls wdrls -> txBody & wdrlsTxBodyL .~ wdrls
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
       Update update -> txBody & updateTxBodyL .~ update
+      AdHash auxDataHash -> txBody & auxDataHashTxBodyL .~ auxDataHash
+      Mint mint -> txBody & mintTxBodyL .~ mint
       _ -> txBody
     Mary _ -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs


### PR DESCRIPTION
There is no need to redefine duplicate Arbitrary instances for the same type in different era. This PR solves this problem