### PR TITLE
Switch larger functions from `INLINE` to `INLINEABLE` 

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -217,26 +217,26 @@ mkBasicAlonzoTx txBody = AlonzoTx txBody mempty (IsValid True) SNothing
 -- | `Core.TxBody` setter and getter for `AlonzoTx`.
 bodyAlonzoTxL :: Lens' (AlonzoTx era) (Core.TxBody era)
 bodyAlonzoTxL = lens body (\tx txBody -> tx {body = txBody})
-{-# INLINE bodyAlonzoTxL #-}
+{-# INLINEABLE bodyAlonzoTxL #-}
 
 -- | `Witnesses` setter and getter for `AlonzoTx`.
 witsAlonzoTxL :: Lens' (AlonzoTx era) (TxWitness era)
 witsAlonzoTxL = lens wits (\tx txWits -> tx {wits = txWits})
-{-# INLINE witsAlonzoTxL #-}
+{-# INLINEABLE witsAlonzoTxL #-}
 
 -- | `AuxiliaryData` setter and getter for `AlonzoTx`.
 auxDataAlonzoTxL :: Lens' (AlonzoTx era) (StrictMaybe (AuxiliaryData era))
 auxDataAlonzoTxL = lens auxiliaryData (\tx txAuxiliaryData -> tx {auxiliaryData = txAuxiliaryData})
-{-# INLINE auxDataAlonzoTxL #-}
+{-# INLINEABLE auxDataAlonzoTxL #-}
 
 -- | txsize computes the length of the serialised bytes
 sizeAlonzoTxF :: EraTx era => SimpleGetter (AlonzoTx era) Integer
 sizeAlonzoTxF = to (fromIntegral . LBS.length . serializeEncoding . toCBORForSizeComputation)
-{-# INLINE sizeAlonzoTxF #-}
+{-# INLINEABLE sizeAlonzoTxF #-}
 
 isValidAlonzoTxL :: Lens' (AlonzoTx era) IsValid
 isValidAlonzoTxL = lens isValid (\tx valid -> tx {isValid = valid})
-{-# INLINE isValidAlonzoTxL #-}
+{-# INLINEABLE isValidAlonzoTxL #-}
 
 deriving instance
   (Era era, Eq (Core.TxBody era), Eq (AuxiliaryData era)) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -392,7 +392,7 @@ instance CC.Crypto c => AlonzoEraTxOut (AlonzoEra c) where
 
   dataHashTxOutL =
     lens getAlonzoTxOutDataHash (\(AlonzoTxOut addr cv _) dh -> AlonzoTxOut addr cv dh)
-  {-# INLINE dataHashTxOutL #-}
+  {-# INLINEABLE dataHashTxOutL #-}
 
 getTxOutCompactValue :: EraTxOut era => AlonzoTxOut era -> CompactForm (Value era)
 getTxOutCompactValue =
@@ -456,7 +456,7 @@ lensTxBodyRaw getter setter =
   lens
     (\(TxBodyConstr (Memo txBodyRaw _)) -> getter txBodyRaw)
     (\(TxBodyConstr (Memo txBodyRaw _)) val -> mkAlonzoTxBody $ setter txBodyRaw val)
-{-# INLINE lensTxBodyRaw #-}
+{-# INLINEABLE lensTxBodyRaw #-}
 
 instance CC.Crypto c => EraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance EraTxBody (AlonzoEra CC.StandardCrypto) #-}
@@ -467,57 +467,58 @@ instance CC.Crypto c => EraTxBody (AlonzoEra c) where
 
   inputsTxBodyL =
     lensTxBodyRaw _inputs (\txBodyRaw inputs_ -> txBodyRaw {_inputs = inputs_})
-  {-# INLINE inputsTxBodyL #-}
+  {-# INLINEABLE inputsTxBodyL #-}
 
   outputsTxBodyL =
     lensTxBodyRaw _outputs (\txBodyRaw outputs_ -> txBodyRaw {_outputs = outputs_})
-  {-# INLINE outputsTxBodyL #-}
+  {-# INLINEABLE outputsTxBodyL #-}
 
   feeTxBodyL =
     lensTxBodyRaw _txfee (\txBodyRaw fee_ -> txBodyRaw {_txfee = fee_})
-  {-# INLINE feeTxBodyL #-}
+  {-# INLINEABLE feeTxBodyL #-}
 
   auxDataHashTxBodyL =
     lensTxBodyRaw _adHash (\txBodyRaw auxDataHash -> txBodyRaw {_adHash = auxDataHash})
-  {-# INLINE auxDataHashTxBodyL #-}
+  {-# INLINEABLE auxDataHashTxBodyL #-}
 
   allInputsTxBodyF =
     to $ \txBody -> (txBody ^. inputsTxBodyL) `Set.union` (txBody ^. collateralInputsTxBodyL)
-  {-# INLINE allInputsTxBodyF #-}
+  {-# INLINEABLE allInputsTxBodyF #-}
 
   mintedTxBodyF =
     to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (_mint txBodyRaw)))
-  {-# INLINE mintedTxBodyF #-}
+  {-# INLINEABLE mintedTxBodyF #-}
 
 instance CC.Crypto c => ShelleyEraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (AlonzoEra CC.StandardCrypto) #-}
 
   wdrlsTxBodyL =
     lensTxBodyRaw _wdrls (\txBodyRaw wdrls_ -> txBodyRaw {_wdrls = wdrls_})
-  {-# INLINE wdrlsTxBodyL #-}
+  {-# INLINEABLE wdrlsTxBodyL #-}
 
   ttlTxBodyL = notSupportedInThisEraL
 
   updateTxBodyL =
     lensTxBodyRaw _update (\txBodyRaw update_ -> txBodyRaw {_update = update_})
-  {-# INLINE updateTxBodyL #-}
+  {-# INLINEABLE updateTxBodyL #-}
 
   certsTxBodyL =
     lensTxBodyRaw _certs (\txBodyRaw certs_ -> txBodyRaw {_certs = certs_})
-  {-# INLINE certsTxBodyL #-}
+  {-# INLINEABLE certsTxBodyL #-}
 
 instance CC.Crypto c => ShelleyMAEraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance ShelleyMAEraTxBody (AlonzoEra CC.StandardCrypto) #-}
 
   vldtTxBodyL =
     lensTxBodyRaw _vldt (\txBodyRaw vldt_ -> txBodyRaw {_vldt = vldt_})
-  {-# INLINE vldtTxBodyL #-}
+  {-# INLINEABLE vldtTxBodyL #-}
 
   mintTxBodyL =
     lensTxBodyRaw _mint (\txBodyRaw mint_ -> txBodyRaw {_mint = mint_})
-  {-# INLINE mintTxBodyL #-}
+  {-# INLINEABLE mintTxBodyL #-}
 
   mintValueTxBodyF = mintTxBodyL . to (MaryValue 0)
+  {-# INLINEABLE mintValueTxBodyF #-}
 
 class (ShelleyMAEraTxBody era, AlonzoEraTxOut era) => AlonzoEraTxBody era where
   collateralInputsTxBodyL :: Lens' (Core.TxBody era) (Set (TxIn (Crypto era)))
@@ -534,23 +535,23 @@ instance CC.Crypto c => AlonzoEraTxBody (AlonzoEra c) where
 
   collateralInputsTxBodyL =
     lensTxBodyRaw _collateral (\txBodyRaw collateral_ -> txBodyRaw {_collateral = collateral_})
-  {-# INLINE collateralInputsTxBodyL #-}
+  {-# INLINEABLE collateralInputsTxBodyL #-}
 
   reqSignerHashesTxBodyL =
     lensTxBodyRaw
       _reqSignerHashes
       (\txBodyRaw reqSignerHashes_ -> txBodyRaw {_reqSignerHashes = reqSignerHashes_})
-  {-# INLINE reqSignerHashesTxBodyL #-}
+  {-# INLINEABLE reqSignerHashesTxBodyL #-}
 
   scriptIntegrityHashTxBodyL =
     lensTxBodyRaw
       _scriptIntegrityHash
       (\txBodyRaw scriptIntegrityHash_ -> txBodyRaw {_scriptIntegrityHash = scriptIntegrityHash_})
-  {-# INLINE scriptIntegrityHashTxBodyL #-}
+  {-# INLINEABLE scriptIntegrityHashTxBodyL #-}
 
   networkIdTxBodyL =
     lensTxBodyRaw _txnetworkid (\txBodyRaw networkId -> txBodyRaw {_txnetworkid = networkId})
-  {-# INLINE networkIdTxBodyL #-}
+  {-# INLINEABLE networkIdTxBodyL #-}
 
 deriving newtype instance CC.Crypto (Crypto era) => Eq (AlonzoTxBody era)
 
@@ -770,7 +771,7 @@ instance
         cv <- decodeNonNegative
         mkTxOutCompact a ca cv . SJust <$> fromCBOR
       Just _ -> cborError $ DecoderErrorCustom "txout" "wrong number of terms in txout"
-  {-# INLINE fromSharedCBOR #-}
+  {-# INLINEABLE fromSharedCBOR #-}
 
 pattern TxOutCompact ::
   (Era era, Val (Value era), HasCallStack) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -349,7 +349,7 @@ mkAlonzoTxWitness ::
   TxWitnessRaw era ->
   TxWitness era
 mkAlonzoTxWitness = TxWitnessConstr . memoBytes . encodeWitnessRaw
-{-# INLINE mkAlonzoTxWitness #-}
+{-# INLINEABLE mkAlonzoTxWitness #-}
 
 -- =======================================================
 -- Accessors
@@ -364,42 +364,42 @@ lensWitsRaw getter setter =
   lens
     (\(TxWitnessConstr (Memo witsRaw _)) -> getter witsRaw)
     (\(TxWitnessConstr (Memo witsRaw _)) val -> mkAlonzoTxWitness $ setter witsRaw val)
-{-# INLINE lensWitsRaw #-}
+{-# INLINEABLE lensWitsRaw #-}
 
 addrAlonzoWitsL ::
   (Era era, Core.Script era ~ AlonzoScript era) =>
   Lens' (TxWitness era) (Set (WitVKey 'Witness (Crypto era)))
 addrAlonzoWitsL =
   lensWitsRaw _txwitsVKey (\witsRaw addrWits -> witsRaw {_txwitsVKey = addrWits})
-{-# INLINE addrAlonzoWitsL #-}
+{-# INLINEABLE addrAlonzoWitsL #-}
 
 bootAddrAlonzoWitsL ::
   (Era era, Core.Script era ~ AlonzoScript era) =>
   Lens' (TxWitness era) (Set (BootstrapWitness (Crypto era)))
 bootAddrAlonzoWitsL =
   lensWitsRaw _txwitsBoot (\witsRaw bootAddrWits -> witsRaw {_txwitsBoot = bootAddrWits})
-{-# INLINE bootAddrAlonzoWitsL #-}
+{-# INLINEABLE bootAddrAlonzoWitsL #-}
 
 scriptAlonzoWitsL ::
   (Era era, Core.Script era ~ AlonzoScript era) =>
   Lens' (TxWitness era) (Map (ScriptHash (Crypto era)) (Script era))
 scriptAlonzoWitsL =
   lensWitsRaw _txscripts (\witsRaw scriptWits -> witsRaw {_txscripts = scriptWits})
-{-# INLINE scriptAlonzoWitsL #-}
+{-# INLINEABLE scriptAlonzoWitsL #-}
 
 datsAlonzoWitsL ::
   (Era era, Core.Script era ~ AlonzoScript era) =>
   Lens' (TxWitness era) (TxDats era)
 datsAlonzoWitsL =
   lensWitsRaw _txdats (\witsRaw datsWits -> witsRaw {_txdats = datsWits})
-{-# INLINE datsAlonzoWitsL #-}
+{-# INLINEABLE datsAlonzoWitsL #-}
 
 rdmrsAlonzoWitsL ::
   (Era era, Core.Script era ~ AlonzoScript era) =>
   Lens' (TxWitness era) (Redeemers era)
 rdmrsAlonzoWitsL =
   lensWitsRaw _txrdmrs (\witsRaw rdmrsWits -> witsRaw {_txrdmrs = rdmrsWits})
-{-# INLINE rdmrsAlonzoWitsL #-}
+{-# INLINEABLE rdmrsAlonzoWitsL #-}
 
 instance (EraScript (AlonzoEra c), CC.Crypto c) => EraWitnesses (AlonzoEra c) where
   {-# SPECIALIZE instance EraWitnesses (AlonzoEra CC.StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -262,13 +262,13 @@ dataHashBabbageTxOutL =
         SNothing -> BabbageTxOut addr cv NoDatum s
         SJust dh -> BabbageTxOut addr cv (DatumHash dh) s
     )
-{-# INLINE dataHashBabbageTxOutL #-}
+{-# INLINEABLE dataHashBabbageTxOutL #-}
 
 instance CC.Crypto c => AlonzoEraTxOut (BabbageEra c) where
   {-# SPECIALIZE instance AlonzoEraTxOut (BabbageEra CC.StandardCrypto) #-}
 
   dataHashTxOutL = dataHashBabbageTxOutL
-  {-# INLINE dataHashTxOutL #-}
+  {-# INLINEABLE dataHashTxOutL #-}
 
 class (AlonzoEraTxOut era, EraScript era) => BabbageEraTxOut era where
   referenceScriptTxOutL :: Lens' (Core.TxOut era) (StrictMaybe (Script era))
@@ -286,28 +286,28 @@ dataBabbageTxOutL =
           SNothing -> BabbageTxOut addr cv NoDatum s
           SJust d -> BabbageTxOut addr cv (Datum (dataToBinaryData d)) s
     )
-{-# INLINE dataBabbageTxOutL #-}
+{-# INLINEABLE dataBabbageTxOutL #-}
 
 datumBabbageTxOutL :: EraTxOut era => Lens' (BabbageTxOut era) (Datum era)
 datumBabbageTxOutL =
   lens getBabbageTxOutDatum (\(BabbageTxOut addr cv _ s) d -> BabbageTxOut addr cv d s)
-{-# INLINE datumBabbageTxOutL #-}
+{-# INLINEABLE datumBabbageTxOutL #-}
 
 referenceScriptBabbageTxOutL :: EraTxOut era => Lens' (BabbageTxOut era) (StrictMaybe (Script era))
 referenceScriptBabbageTxOutL =
   lens getBabbageTxOutScript (\(BabbageTxOut addr cv d _) s -> BabbageTxOut addr cv d s)
-{-# INLINE referenceScriptBabbageTxOutL #-}
+{-# INLINEABLE referenceScriptBabbageTxOutL #-}
 
 instance CC.Crypto c => BabbageEraTxOut (BabbageEra c) where
   {-# SPECIALIZE instance BabbageEraTxOut (BabbageEra CC.StandardCrypto) #-}
   dataTxOutL = dataBabbageTxOutL
-  {-# INLINE dataTxOutL #-}
+  {-# INLINEABLE dataTxOutL #-}
 
   datumTxOutL = datumBabbageTxOutL
-  {-# INLINE datumTxOutL #-}
+  {-# INLINEABLE datumTxOutL #-}
 
   referenceScriptTxOutL = referenceScriptBabbageTxOutL
-  {-# INLINE referenceScriptTxOutL #-}
+  {-# INLINEABLE referenceScriptTxOutL #-}
 
 addrEitherBabbageTxOutL ::
   EraTxOut era =>
@@ -322,7 +322,7 @@ addrEitherBabbageTxOutL =
               Left addr -> mkTxOutCompact addr (compactAddr addr) cVal datum mScript
               Right cAddr -> mkTxOutCompact (decompactAddr cAddr) cAddr cVal datum mScript
     )
-{-# INLINE addrEitherBabbageTxOutL #-}
+{-# INLINEABLE addrEitherBabbageTxOutL #-}
 
 valueEitherBabbageTxOutL ::
   forall era.
@@ -337,7 +337,7 @@ valueEitherBabbageTxOutL =
               Left val -> mkTxOut (decompactAddr cAddr) cAddr val datum mScript
               Right cVal -> mkTxOutCompact (decompactAddr cAddr) cAddr cVal datum mScript
     )
-{-# INLINE valueEitherBabbageTxOutL #-}
+{-# INLINEABLE valueEitherBabbageTxOutL #-}
 
 deriving stock instance
   (Era era, Eq (Script era), Eq (CompactForm (Value era))) =>
@@ -560,13 +560,13 @@ lensTxBodyRaw getter setter =
   lens
     (\(TxBodyConstr (Memo txBodyRaw _)) -> getter txBodyRaw)
     (\(TxBodyConstr (Memo txBodyRaw _)) val -> mkBabbageTxBodyFromRaw $ setter txBodyRaw val)
-{-# INLINE lensTxBodyRaw #-}
+{-# INLINEABLE lensTxBodyRaw #-}
 
 inputsBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (Set (TxIn (Crypto era)))
 inputsBabbageTxBodyL =
   lensTxBodyRaw _spendInputs (\txBodyRaw inputs_ -> txBodyRaw {_spendInputs = inputs_})
-{-# INLINE inputsBabbageTxBodyL #-}
+{-# INLINEABLE inputsBabbageTxBodyL #-}
 
 outputsBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictSeq (TxOut era))
@@ -574,18 +574,18 @@ outputsBabbageTxBodyL =
   lensTxBodyRaw
     (fmap sizedValue . _outputs)
     (\txBodyRaw outputs_ -> txBodyRaw {_outputs = mkSized <$> outputs_})
-{-# INLINE outputsBabbageTxBodyL #-}
+{-# INLINEABLE outputsBabbageTxBodyL #-}
 
 feeBabbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) Coin
 feeBabbageTxBodyL =
   lensTxBodyRaw _txfee (\txBodyRaw fee_ -> txBodyRaw {_txfee = fee_})
-{-# INLINE feeBabbageTxBodyL #-}
+{-# INLINEABLE feeBabbageTxBodyL #-}
 
 auxDataHashBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe (AuxiliaryDataHash (Crypto era)))
 auxDataHashBabbageTxBodyL =
   lensTxBodyRaw _adHash (\txBodyRaw auxDataHash -> txBodyRaw {_adHash = auxDataHash})
-{-# INLINE auxDataHashBabbageTxBodyL #-}
+{-# INLINEABLE auxDataHashBabbageTxBodyL #-}
 
 allInputsBabbageTxBodyF ::
   BabbageEraTxBody era => SimpleGetter (BabbageTxBody era) (Set (TxIn (Crypto era)))
@@ -594,45 +594,46 @@ allInputsBabbageTxBodyF =
     (txBody ^. inputsBabbageTxBodyL)
       `Set.union` (txBody ^. collateralInputsBabbageTxBodyL)
       `Set.union` (txBody ^. referenceInputsBabbageTxBodyL)
-{-# INLINE allInputsBabbageTxBodyF #-}
+{-# INLINEABLE allInputsBabbageTxBodyF #-}
 
 mintedBabbageTxBodyF :: Era era => SimpleGetter (BabbageTxBody era) (Set (ScriptHash (Crypto era)))
 mintedBabbageTxBodyF =
   to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (_mint txBodyRaw)))
-{-# INLINE mintedBabbageTxBodyF #-}
+{-# INLINEABLE mintedBabbageTxBodyF #-}
 
 wdrlsBabbbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) (Wdrl (Crypto era))
 wdrlsBabbbageTxBodyL =
   lensTxBodyRaw _wdrls (\txBodyRaw wdrls_ -> txBodyRaw {_wdrls = wdrls_})
-{-# INLINE wdrlsBabbbageTxBodyL #-}
+{-# INLINEABLE wdrlsBabbbageTxBodyL #-}
 
 updateBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe (Update era))
 updateBabbageTxBodyL =
   lensTxBodyRaw _update (\txBodyRaw update_ -> txBodyRaw {_update = update_})
-{-# INLINE updateBabbageTxBodyL #-}
+{-# INLINEABLE updateBabbageTxBodyL #-}
 
 certsBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictSeq (DCert (Crypto era)))
 certsBabbageTxBodyL =
   lensTxBodyRaw _certs (\txBodyRaw certs_ -> txBodyRaw {_certs = certs_})
-{-# INLINE certsBabbageTxBodyL #-}
+{-# INLINEABLE certsBabbageTxBodyL #-}
 
 vldtBabbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) ValidityInterval
 vldtBabbageTxBodyL =
   lensTxBodyRaw _vldt (\txBodyRaw vldt_ -> txBodyRaw {_vldt = vldt_})
-{-# INLINE vldtBabbageTxBodyL #-}
+{-# INLINEABLE vldtBabbageTxBodyL #-}
 
 mintBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (MultiAsset (Crypto era))
 mintBabbageTxBodyL =
   lensTxBodyRaw _mint (\txBodyRaw mint_ -> txBodyRaw {_mint = mint_})
-{-# INLINE mintBabbageTxBodyL #-}
+{-# INLINEABLE mintBabbageTxBodyL #-}
 
 mintValueBabbageTxBodyF ::
   (BabbageEraTxBody era, Value era ~ MaryValue (Crypto era)) =>
   SimpleGetter (BabbageTxBody era) (Value era)
 mintValueBabbageTxBodyF = mintBabbageTxBodyL . to (MaryValue 0)
+{-# INLINEABLE mintValueBabbageTxBodyF #-}
 
 collateralInputsBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (Set (TxIn (Crypto era)))
@@ -640,7 +641,7 @@ collateralInputsBabbageTxBodyL =
   lensTxBodyRaw
     _collateralInputs
     (\txBodyRaw collateral_ -> txBodyRaw {_collateralInputs = collateral_})
-{-# INLINE collateralInputsBabbageTxBodyL #-}
+{-# INLINEABLE collateralInputsBabbageTxBodyL #-}
 
 reqSignerHashesBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (Set (KeyHash 'Witness (Crypto era)))
@@ -648,7 +649,7 @@ reqSignerHashesBabbageTxBodyL =
   lensTxBodyRaw
     _reqSignerHashes
     (\txBodyRaw reqSignerHashes_ -> txBodyRaw {_reqSignerHashes = reqSignerHashes_})
-{-# INLINE reqSignerHashesBabbageTxBodyL #-}
+{-# INLINEABLE reqSignerHashesBabbageTxBodyL #-}
 
 scriptIntegrityHashBabbageTxBodyL ::
   BabbageEraTxBody era =>
@@ -657,19 +658,19 @@ scriptIntegrityHashBabbageTxBodyL =
   lensTxBodyRaw
     _scriptIntegrityHash
     (\txBodyRaw scriptIntegrityHash_ -> txBodyRaw {_scriptIntegrityHash = scriptIntegrityHash_})
-{-# INLINE scriptIntegrityHashBabbageTxBodyL #-}
+{-# INLINEABLE scriptIntegrityHashBabbageTxBodyL #-}
 
 networkIdBabbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe Network)
 networkIdBabbageTxBodyL =
   lensTxBodyRaw _txnetworkid (\txBodyRaw networkId -> txBodyRaw {_txnetworkid = networkId})
-{-# INLINE networkIdBabbageTxBodyL #-}
+{-# INLINEABLE networkIdBabbageTxBodyL #-}
 
 sizedOutputsBabbageTxBodyL ::
   BabbageEraTxBody era =>
   Lens' (BabbageTxBody era) (StrictSeq (Sized (BabbageTxOut era)))
 sizedOutputsBabbageTxBodyL =
   lensTxBodyRaw _outputs (\txBodyRaw outputs_ -> txBodyRaw {_outputs = outputs_})
-{-# INLINE sizedOutputsBabbageTxBodyL #-}
+{-# INLINEABLE sizedOutputsBabbageTxBodyL #-}
 
 referenceInputsBabbageTxBodyL ::
   BabbageEraTxBody era =>
@@ -678,14 +679,14 @@ referenceInputsBabbageTxBodyL =
   lensTxBodyRaw
     _referenceInputs
     (\txBodyRaw reference_ -> txBodyRaw {_referenceInputs = reference_})
-{-# INLINE referenceInputsBabbageTxBodyL #-}
+{-# INLINEABLE referenceInputsBabbageTxBodyL #-}
 
 totalCollateralBabbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe Coin)
 totalCollateralBabbageTxBodyL =
   lensTxBodyRaw
     _totalCollateral
     (\txBodyRaw totalCollateral_ -> txBodyRaw {_totalCollateral = totalCollateral_})
-{-# INLINE totalCollateralBabbageTxBodyL #-}
+{-# INLINEABLE totalCollateralBabbageTxBodyL #-}
 
 collateralReturnBabbageTxBodyL ::
   BabbageEraTxBody era =>
@@ -694,7 +695,7 @@ collateralReturnBabbageTxBodyL =
   lensTxBodyRaw
     (fmap sizedValue . _collateralReturn)
     (\txBodyRaw collateralReturn_ -> txBodyRaw {_collateralReturn = mkSized <$> collateralReturn_})
-{-# INLINE collateralReturnBabbageTxBodyL #-}
+{-# INLINEABLE collateralReturnBabbageTxBodyL #-}
 
 sizedCollateralReturnBabbageTxBodyL ::
   BabbageEraTxBody era =>
@@ -703,7 +704,7 @@ sizedCollateralReturnBabbageTxBodyL =
   lensTxBodyRaw
     _collateralReturn
     (\txBodyRaw collateralReturn_ -> txBodyRaw {_collateralReturn = collateralReturn_})
-{-# INLINE sizedCollateralReturnBabbageTxBodyL #-}
+{-# INLINEABLE sizedCollateralReturnBabbageTxBodyL #-}
 
 instance CC.Crypto c => EraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance EraTxBody (BabbageEra CC.StandardCrypto) #-}
@@ -755,6 +756,7 @@ instance CC.Crypto c => ShelleyMAEraTxBody (BabbageEra c) where
   {-# INLINE mintTxBodyL #-}
 
   mintValueTxBodyF = mintValueBabbageTxBodyF
+  {-# INLINE mintValueTxBodyF #-}
 
 instance CC.Crypto c => AlonzoEraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance AlonzoEraTxBody (BabbageEra CC.StandardCrypto) #-}

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
@@ -70,7 +70,7 @@ validateTimelock ::
 validateTimelock timelock tx = evalTimelock vhks (tx ^. bodyTxL . vldtTxBodyL) timelock
   where
     vhks = Set.map witVKeyHash (tx ^. witsTxL . addrWitsL)
-{-# INLINE validateTimelock #-}
+{-# INLINEABLE validateTimelock #-}
 
 instance MAClass ma crypto => EraWitnesses (ShelleyMAEra ma crypto) where
   {-# SPECIALIZE instance EraWitnesses (ShelleyMAEra 'Mary StandardCrypto) #-}

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -263,7 +263,7 @@ mkMATxBody ::
   TxBodyRaw era ->
   MATxBody era
 mkMATxBody = TxBodyConstr . memoBytes . txSparse
-{-# INLINE mkMATxBody #-}
+{-# INLINEABLE mkMATxBody #-}
 
 -- | This pattern is for deconstruction only but accompanied with fields and
 -- projection functions.
@@ -307,7 +307,7 @@ lensTxBodyRaw getter setter =
   lens
     (\(TxBodyConstr (Memo txBodyRaw _)) -> getter txBodyRaw)
     (\(TxBodyConstr (Memo txBodyRaw _)) val -> mkMATxBody $ setter txBodyRaw val)
-{-# INLINE lensTxBodyRaw #-}
+{-# INLINEABLE lensTxBodyRaw #-}
 
 instance MAClass ma crypto => EraTxBody (ShelleyMAEra ma crypto) where
   {-# SPECIALIZE instance EraTxBody (ShelleyMAEra 'Mary StandardCrypto) #-}
@@ -319,26 +319,26 @@ instance MAClass ma crypto => EraTxBody (ShelleyMAEra ma crypto) where
 
   inputsTxBodyL =
     lensTxBodyRaw inputs (\txBodyRaw inputs_ -> txBodyRaw {inputs = inputs_})
-  {-# INLINE inputsTxBodyL #-}
+  {-# INLINEABLE inputsTxBodyL #-}
 
   outputsTxBodyL =
     lensTxBodyRaw outputs (\txBodyRaw outputs_ -> txBodyRaw {outputs = outputs_})
-  {-# INLINE outputsTxBodyL #-}
+  {-# INLINEABLE outputsTxBodyL #-}
 
   feeTxBodyL =
     lensTxBodyRaw txfee (\txBodyRaw fee_ -> txBodyRaw {txfee = fee_})
-  {-# INLINE feeTxBodyL #-}
+  {-# INLINEABLE feeTxBodyL #-}
 
   auxDataHashTxBodyL =
     lensTxBodyRaw adHash (\txBodyRaw auxDataHash -> txBodyRaw {adHash = auxDataHash})
-  {-# INLINE auxDataHashTxBodyL #-}
+  {-# INLINEABLE auxDataHashTxBodyL #-}
 
   allInputsTxBodyF = inputsTxBodyL
-  {-# INLINE allInputsTxBodyF #-}
+  {-# INLINEABLE allInputsTxBodyF #-}
 
   mintedTxBodyF =
     to (\(TxBodyConstr (Memo txBodyRaw _)) -> getScriptHash (Proxy @ma) (mint txBodyRaw))
-  {-# INLINE mintedTxBodyF #-}
+  {-# INLINEABLE mintedTxBodyF #-}
 
 instance MAClass ma crypto => ShelleyEraTxBody (ShelleyMAEra ma crypto) where
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyMAEra 'Mary StandardCrypto) #-}
@@ -346,18 +346,18 @@ instance MAClass ma crypto => ShelleyEraTxBody (ShelleyMAEra ma crypto) where
 
   wdrlsTxBodyL =
     lensTxBodyRaw wdrls (\txBodyRaw wdrls_ -> txBodyRaw {wdrls = wdrls_})
-  {-# INLINE wdrlsTxBodyL #-}
+  {-# INLINEABLE wdrlsTxBodyL #-}
 
   ttlTxBodyL = notSupportedInThisEraL
-  {-# INLINE ttlTxBodyL #-}
+  {-# INLINEABLE ttlTxBodyL #-}
 
   updateTxBodyL =
     lensTxBodyRaw update (\txBodyRaw update_ -> txBodyRaw {update = update_})
-  {-# INLINE updateTxBodyL #-}
+  {-# INLINEABLE updateTxBodyL #-}
 
   certsTxBodyL =
     lensTxBodyRaw certs (\txBodyRaw certs_ -> txBodyRaw {certs = certs_})
-  {-# INLINE certsTxBodyL #-}
+  {-# INLINEABLE certsTxBodyL #-}
 
 class
   (ShelleyEraTxBody era, EncodeMint (Value era), DecodeMint (Value era)) =>
@@ -375,14 +375,15 @@ instance MAClass ma crypto => ShelleyMAEraTxBody (ShelleyMAEra ma crypto) where
 
   vldtTxBodyL =
     lensTxBodyRaw vldt (\txBodyRaw vldt_ -> txBodyRaw {vldt = vldt_})
-  {-# INLINE vldtTxBodyL #-}
+  {-# INLINEABLE vldtTxBodyL #-}
 
   mintTxBodyL =
     lensTxBodyRaw mint (\txBodyRaw mint_ -> txBodyRaw {mint = mint_})
-  {-# INLINE mintTxBodyL #-}
+  {-# INLINEABLE mintTxBodyL #-}
 
   mintValueTxBodyF =
     to (\(TxBodyConstr (Memo txBodyRaw _)) -> promoteMultiAsset (Proxy @ma) (mint txBodyRaw))
+  {-# INLINEABLE mintValueTxBodyF #-}
 
 instance MAClass ma crypto => EraTxOut (ShelleyMAEra ma crypto) where
   {-# SPECIALIZE instance EraTxOut (ShelleyMAEra 'Mary StandardCrypto) #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -179,7 +179,7 @@ bodyShelleyTxL =
   lens
     (\(TxConstr (Memo tx _)) -> _body tx)
     (\(TxConstr (Memo tx _)) txBody -> TxConstr $ memoBytes $ encodeTxRaw $ tx {_body = txBody})
-{-# INLINE bodyShelleyTxL #-}
+{-# INLINEABLE bodyShelleyTxL #-}
 
 -- | `Witnesses` setter and getter for `ShelleyTx`. The setter does update
 -- memoized binary representation.
@@ -188,7 +188,7 @@ witsShelleyTxL =
   lens
     (\(TxConstr (Memo tx _)) -> _wits tx)
     (\(TxConstr (Memo tx _)) txWits -> TxConstr $ memoBytes $ encodeTxRaw $ tx {_wits = txWits})
-{-# INLINE witsShelleyTxL #-}
+{-# INLINEABLE witsShelleyTxL #-}
 
 -- | `AuxiliaryData` setter and getter for `ShelleyTx`. The setter does update
 -- memoized binary representation.
@@ -197,16 +197,16 @@ auxDataShelleyTxL =
   lens
     (\(TxConstr (Memo tx _)) -> _auxiliaryData tx)
     (\(TxConstr (Memo tx _)) auxData -> mkShelleyTx $ tx {_auxiliaryData = auxData})
-{-# INLINE auxDataShelleyTxL #-}
+{-# INLINEABLE auxDataShelleyTxL #-}
 
 -- | Size getter for `ShelleyTx`.
 sizeShelleyTxF :: Era era => SimpleGetter (Tx era) Integer
 sizeShelleyTxF = to (\(TxConstr (Memo _ bytes)) -> fromIntegral $ SBS.length bytes)
-{-# INLINE sizeShelleyTxF #-}
+{-# INLINEABLE sizeShelleyTxF #-}
 
 mkShelleyTx :: EraTx era => TxRaw era -> ShelleyTx era
 mkShelleyTx = TxConstr . memoBytes . encodeTxRaw
-{-# INLINE mkShelleyTx #-}
+{-# INLINEABLE mkShelleyTx #-}
 
 mkBasicShelleyTx :: EraTx era => Core.TxBody era -> ShelleyTx era
 mkBasicShelleyTx txBody =
@@ -372,21 +372,21 @@ type ShelleyWitnesses = WitnessSetHKD Identity
 addrShelleyWitsL ::
   EraWitnesses era => Lens' (ShelleyWitnesses era) (Set (WitVKey 'Witness (Crypto era)))
 addrShelleyWitsL = lens addrWits' (\w s -> w {addrWits = s})
-{-# INLINE addrShelleyWitsL #-}
+{-# INLINEABLE addrShelleyWitsL #-}
 
 -- | Bootstrap Addresses witness setter and getter for `ShelleyWitnesses`. The
 -- setter does update memoized binary representation.
 bootAddrShelleyWitsL ::
   EraWitnesses era => Lens' (ShelleyWitnesses era) (Set (BootstrapWitness (Crypto era)))
 bootAddrShelleyWitsL = lens bootWits' (\w s -> w {bootWits = s})
-{-# INLINE bootAddrShelleyWitsL #-}
+{-# INLINEABLE bootAddrShelleyWitsL #-}
 
 -- | Script witness setter and getter for `ShelleyWitnesses`. The
 -- setter does update memoized binary representation.
 scriptShelleyWitsL ::
   EraWitnesses era => Lens' (ShelleyWitnesses era) (Map (ScriptHash (Crypto era)) (Script era))
 scriptShelleyWitsL = lens scriptWits' (\w s -> w {scriptWits = s})
-{-# INLINE scriptShelleyWitsL #-}
+{-# INLINEABLE scriptShelleyWitsL #-}
 
 instance CC.Crypto crypto => EraWitnesses (ShelleyEra crypto) where
   {-# SPECIALIZE instance EraWitnesses (ShelleyEra CC.StandardCrypto) #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -396,19 +396,19 @@ instance CC.Crypto crypto => EraTxBody (ShelleyEra crypto) where
     lens
       (\(TxBodyConstr (Memo m _)) -> _inputsX m)
       (\txBody inputs -> txBody {_inputs = inputs})
-  {-# INLINE inputsTxBodyL #-}
+  {-# INLINEABLE inputsTxBodyL #-}
 
   outputsTxBodyL =
     lens
       (\(TxBodyConstr (Memo m _)) -> _outputsX m)
       (\txBody outputs -> txBody {_outputs = outputs})
-  {-# INLINE outputsTxBodyL #-}
+  {-# INLINEABLE outputsTxBodyL #-}
 
   feeTxBodyL =
     lens
       (\(TxBodyConstr (Memo m _)) -> _txfeeX m)
       (\txBody fee -> txBody {_txfee = fee})
-  {-# INLINE feeTxBodyL #-}
+  {-# INLINEABLE feeTxBodyL #-}
 
   -- TODO: fix this wart. Shelley does not know what minting is and this lens should move to Mary
   mintedTxBodyF = to (const Set.empty)
@@ -417,7 +417,7 @@ instance CC.Crypto crypto => EraTxBody (ShelleyEra crypto) where
     lens
       (\(TxBodyConstr (Memo m _)) -> _mdHashX m)
       (\txBody auxDataHash -> txBody {_mdHash = auxDataHash})
-  {-# INLINE auxDataHashTxBodyL #-}
+  {-# INLINEABLE auxDataHashTxBodyL #-}
 
 class EraTxBody era => ShelleyEraTxBody era where
   wdrlsTxBodyL :: Lens' (Core.TxBody era) (Wdrl (Crypto era))
@@ -435,25 +435,25 @@ instance CC.Crypto crypto => ShelleyEraTxBody (ShelleyEra crypto) where
     lens
       (\(TxBodyConstr (Memo m _)) -> _wdrlsX m)
       (\txBody wdrls -> txBody {_wdrls = wdrls})
-  {-# INLINE wdrlsTxBodyL #-}
+  {-# INLINEABLE wdrlsTxBodyL #-}
 
   ttlTxBodyL =
     lens
       (\(TxBodyConstr (Memo m _)) -> _ttlX m)
       (\txBody ttl -> txBody {_ttl = ttl})
-  {-# INLINE ttlTxBodyL #-}
+  {-# INLINEABLE ttlTxBodyL #-}
 
   updateTxBodyL =
     lens
       (\(TxBodyConstr (Memo m _)) -> _txUpdateX m)
       (\txBody update -> txBody {_txUpdate = update})
-  {-# INLINE updateTxBodyL #-}
+  {-# INLINEABLE updateTxBodyL #-}
 
   certsTxBodyL =
     lens
       (\(TxBodyConstr (Memo m _)) -> _certsX m)
       (\txBody certs -> txBody {_certs = certs})
-  {-# INLINE certsTxBodyL #-}
+  {-# INLINEABLE certsTxBodyL #-}
 
 deriving newtype instance
   (Era era, NoThunks (PParamsUpdate era)) => NoThunks (TxBody era)


### PR DESCRIPTION
Memory usage during compilation  has gone through the roof due to recent INLINE pragma additions: #2979 

This PR switches usage of INLINE in favor of INLINEABLE for obviously large functions