### PR TITLE
CBOR Twiddler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ in the naming of release branches.
 - Added `allInputsTxBodyF`
 - Added `EraUTxO` class with `getConsumedValue`
 - Added type synonyms for eras: `Shelley`, `Allegra`, `Mary`, `Alonzo`, `Babbage` and `Conway`.
-
+- Added `Twiddle` class to test alternative serializations: #2994
 
 ### Changed
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -36,6 +36,7 @@ module Cardano.Ledger.Alonzo.Data
     AuxiliaryDataHash (..),
     hashAlonzoAuxiliaryData,
     validateAlonzoAuxiliaryData,
+    contentsEq,
 
     -- * Deprecated
     AuxiliaryData,
@@ -64,6 +65,7 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (HASH)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.MemoBytes (Mem, MemoBytes (..), MemoHashIndex, memoBytes, mkMemoBytes, shortToLazy)
+import qualified Cardano.Ledger.MemoBytes as Memo
 import Cardano.Ledger.SafeHash
   ( HashAnnotated,
     SafeToHash (..),
@@ -429,3 +431,6 @@ pattern AlonzoAuxiliaryData' txMD_ scripts_ <-
   AuxiliaryDataConstr (Memo (AuxiliaryDataRaw txMD_ scripts_) _)
 
 {-# COMPLETE AlonzoAuxiliaryData' #-}
+
+contentsEq :: Data era -> Data era -> Bool
+contentsEq (DataConstr x) (DataConstr y) = Memo.contentsEq x y

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -42,6 +42,7 @@ module Cardano.Ledger.Alonzo.Scripts
     decodeCostModel,
     CostModels (..),
     CostModelApplyError (..),
+    contentsEq,
   )
 where
 
@@ -61,6 +62,7 @@ import Cardano.Ledger.SafeHash
 import Cardano.Ledger.Serialization (mapToCBOR)
 import Cardano.Ledger.Shelley (nativeMultiSigTag)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as Timelocks
 import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Monad (when)
 import Data.ByteString.Short (ShortByteString, fromShort)
@@ -432,3 +434,7 @@ validScript pv scrip = case scrip of
 transProtocolVersion :: ProtVer -> PV1.ProtocolVersion
 transProtocolVersion (ProtVer major minor) =
   PV1.ProtocolVersion (fromIntegral major) (fromIntegral minor)
+
+contentsEq :: Script era -> Script era -> Bool
+contentsEq (TimelockScript x) (TimelockScript y) = Timelocks.contentsEq x y
+contentsEq x y = x == y

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -288,12 +288,12 @@ viewCompactTxOut txOut = case txOut of
   TxOutCompactDH' addr val dh -> (addr, val, SJust dh)
   TxOut_AddrHash28_AdaOnly stakeRef addr28Extra adaVal
     | Just addr <- decodeAddress28 stakeRef addr28Extra ->
-      (compactAddr addr, injectCompact adaVal, SNothing)
+        (compactAddr addr, injectCompact adaVal, SNothing)
     | otherwise -> error addressErrorMsg
   TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal dataHash32
     | Just addr <- decodeAddress28 stakeRef addr28Extra,
       Just dh <- decodeDataHash32 dataHash32 ->
-      (compactAddr addr, injectCompact adaVal, SJust dh)
+        (compactAddr addr, injectCompact adaVal, SJust dh)
     | otherwise -> error addressErrorMsg
 
 viewTxOut ::
@@ -310,11 +310,11 @@ viewTxOut (TxOutCompactDH' bs c dh) = (addr, val, SJust dh)
     val = fromCompact c
 viewTxOut (TxOut_AddrHash28_AdaOnly stakeRef addr28Extra adaVal)
   | Just addr <- decodeAddress28 stakeRef addr28Extra =
-    (addr, inject (fromCompact adaVal), SNothing)
+      (addr, inject (fromCompact adaVal), SNothing)
 viewTxOut (TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra adaVal dataHash32)
   | Just addr <- decodeAddress28 stakeRef addr28Extra,
     Just dh <- decodeDataHash32 dataHash32 =
-    (addr, inject (fromCompact adaVal), SJust dh)
+      (addr, inject (fromCompact adaVal), SJust dh)
 viewTxOut TxOut_AddrHash28_AdaOnly {} = error addressErrorMsg
 viewTxOut TxOut_AddrHash28_AdaOnly_DataHash32 {} = error addressErrorMsg
 
@@ -337,13 +337,13 @@ pattern AlonzoTxOut addr vl dh <-
       | StakeRefBase stakeCred <- stakeRef,
         Just adaCompact <- getAdaOnly (Proxy @era) vl,
         Just (Refl, addr28Extra) <- encodeAddress28 network paymentCred =
-        TxOut_AddrHash28_AdaOnly stakeCred addr28Extra adaCompact
+          TxOut_AddrHash28_AdaOnly stakeCred addr28Extra adaCompact
     AlonzoTxOut (Addr network paymentCred stakeRef) vl (SJust dh)
       | StakeRefBase stakeCred <- stakeRef,
         Just adaCompact <- getAdaOnly (Proxy @era) vl,
         Just (Refl, addr28Extra) <- encodeAddress28 network paymentCred,
         Just (Refl, dataHash32) <- encodeDataHash32 dh =
-        TxOut_AddrHash28_AdaOnly_DataHash32 stakeCred addr28Extra adaCompact dataHash32
+          TxOut_AddrHash28_AdaOnly_DataHash32 stakeCred addr28Extra adaCompact dataHash32
     AlonzoTxOut addr vl mdh =
       let v = fromMaybe (error "Illegal value in txout") $ toCompact vl
           a = compactAddr addr

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -53,6 +53,7 @@ library
   build-depends:
     bytestring,
     cardano-binary,
+    cardano-data,
     cardano-ledger-alonzo,
     cardano-ledger-core,
     cardano-ledger-pretty,
@@ -60,6 +61,7 @@ library
     cardano-ledger-shelley-ma,
     cardano-protocol-tpraos,
     cardano-slotting,
+    cborg,
     containers,
     data-default-class,
     hashable,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -22,6 +22,9 @@ import Cardano.Ledger.Alonzo.Data
     dataToBinaryData,
   )
 import Cardano.Ledger.Alonzo.Language (Language (..), nonNativeLanguages)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), BinaryData, Data (..), dataToBinaryData, AuxiliaryDataHash)
+import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.PParams
   ( AlonzoPParams,
     AlonzoPParamsHKD (AlonzoPParams),
@@ -54,16 +57,29 @@ import Cardano.Ledger.Alonzo.Tx
   )
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits
+import Cardano.Ledger.Alonzo.TxWitness
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), Network)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Control.State.Transition (PredicateFailure)
+import qualified Cardano.Ledger.Crypto as C
+import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Ledger.Val (DecodeNonNegative, Val, EncodeMint (..))
+import Cardano.Slotting.Slot (SlotNo)
+import Codec.CBOR.Term (Term (..), encodeTerm)
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
 import GHC.Records (HasField)
+import Data.Twiddle
+import Data.Void (Void)
 import Numeric.Natural (Natural)
 import qualified Plutus.V1.Ledger.Api as PV1
 import qualified Plutus.V2.Ledger.Api as PV2
@@ -72,6 +88,12 @@ import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 import Test.QuickCheck
+import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Mary.Value (MultiAsset)
+import Cardano.Ledger.Keys (KeyHash)
+import Data.Typeable (Typeable)
+import Debug.Trace (traceM)
+import Codec.CBOR.Write (toLazyByteString)
 
 instance Era era => Arbitrary (Data era) where
   arbitrary = Data <$> arbitrary
@@ -84,14 +106,14 @@ instance Arbitrary PV1.Data where
     where
       gendata n
         | n > 0 =
-            oneof
-              [ PV1.I <$> arbitrary,
-                PV1.B <$> arbitrary,
-                PV1.Map <$> listOf ((,) <$> gendata (n `div` 2) <*> gendata (n `div` 2)),
-                PV1.Constr <$> fmap fromIntegral (arbitrary :: Gen Natural)
-                  <*> listOf (gendata (n `div` 2)),
-                PV1.List <$> listOf (gendata (n `div` 2))
-              ]
+          oneof
+            [ PV1.I <$> arbitrary,
+              PV1.B <$> arbitrary,
+              PV1.Map <$> listOf ((,) <$> gendata (n `div` 2) <*> gendata (n `div` 2)),
+              PV1.Constr <$> fmap fromIntegral (arbitrary :: Gen Natural)
+                <*> listOf (gendata (n `div` 2)),
+              PV1.List <$> listOf (gendata (n `div` 2))
+            ]
       gendata _ = oneof [PV1.I <$> arbitrary, PV1.B <$> arbitrary]
 
 instance
@@ -101,7 +123,11 @@ instance
   ) =>
   Arbitrary (AlonzoAuxiliaryData era)
   where
-  arbitrary = AlonzoAuxiliaryData <$> arbitrary <*> arbitrary
+  arbitrary =
+    frequency
+      [ (9, AlonzoAuxiliaryData <$> arbitrary <*> arbitrary),
+        (1, pure $ AlonzoAuxiliaryData mempty mempty)
+      ]
 
 instance Arbitrary Tag where
   arbitrary = elements [Spend, Mint, Cert, Rewrd]
@@ -387,4 +413,103 @@ instance
       [ pure NoDatum,
         DatumHash <$> arbitrary,
         Datum . dataToBinaryData <$> arbitrary
+
+instance (Era era, Val (Value era), DecodeNonNegative (Value era)) => Twiddle (AlonzoTxOut era) where
+  twiddle = twiddle . toTerm
+
+instance Twiddle SlotNo where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto crypto => Twiddle (DCert crypto) where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto crypto => Twiddle (Wdrl crypto) where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto crypto => Twiddle (AuxiliaryDataHash crypto) where
+  twiddle = twiddle . toTerm
+
+emptyOrNothing ::
+  forall t a crypto.
+  ( Foldable t,
+    Twiddle (t Void),
+    Monoid (t Void),
+    Twiddle (t a)
+  ) =>
+  AlonzoTxBody (AlonzoEra crypto) ->
+  ( AlonzoTxBody (AlonzoEra crypto) ->
+    t a
+  ) ->
+  Gen (Maybe Term)
+emptyOrNothing txBody f =
+  if null $ f txBody
+    then
+      oneof
+        [ Just <$> twiddle @(t Void) mempty,
+          pure Nothing
+        ]
+    else Just <$> twiddle (f txBody)
+
+twiddleStrictMaybe :: Twiddle a => StrictMaybe a -> Gen (Maybe Term)
+twiddleStrictMaybe SNothing = pure Nothing
+twiddleStrictMaybe (SJust x) = Just <$> twiddle x
+
+instance C.Crypto crypto => Twiddle (Update (AlonzoEra crypto)) where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto crypto => Twiddle (MultiAsset crypto) where
+  twiddle = twiddle . encodingToTerm . encodeMint
+
+instance C.Crypto crypto => Twiddle (ScriptIntegrityHash crypto) where
+  twiddle = twiddle . toTerm
+
+instance (C.Crypto crypto, Typeable t) => Twiddle (KeyHash t crypto) where
+  twiddle = twiddle . toTerm
+
+instance Twiddle Network where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto c => Twiddle (TxIn c) where
+  twiddle = twiddle . toTerm
+
+instance Twiddle Coin where
+  twiddle = twiddle . toTerm
+
+instance C.Crypto crypto => Twiddle (AlonzoTxBody (AlonzoEra crypto)) where
+  twiddle txBody = do
+    inputs' <- twiddle $ inputs txBody
+    traceM $ "inputs': " <> (show  . toLazyByteString $ encodeTerm inputs')
+    outputs' <- twiddle $ outputs txBody
+    fee' <- twiddle $ txfee txBody
+    -- Empty collateral can be represented by empty set or the
+    -- value can be omitted entirely
+    ttl' <- twiddleStrictMaybe . invalidHereafter $ txvldt txBody
+    cert' <- emptyOrNothing txBody txcerts
+    wdrls' <- twiddle $ txwdrls txBody
+    update' <- twiddleStrictMaybe $ txUpdates txBody
+    auxDataHash' <- twiddleStrictMaybe $ adHash txBody
+    validityStart' <- twiddleStrictMaybe . invalidBefore $ txvldt txBody
+    mint' <- twiddle $ mint txBody
+    scriptDataHash' <- twiddleStrictMaybe $ scriptIntegrityHash txBody 
+    collateral' <- emptyOrNothing txBody collateral
+    requiredSigners' <- emptyOrNothing txBody reqSignerHashes
+    networkId' <- twiddleStrictMaybe $ txnetworkid txBody
+    mp <- elements [TMap, TMapI]
+    pure . mp $
+      [ (TInt 0, inputs'),
+        (TInt 1, outputs'),
+        (TInt 2, fee')
       ]
+        <> catMaybes
+          [ (TInt 3,) <$> ttl',
+            (TInt 4,) <$> cert',
+            (TInt 5,) <$> Just wdrls',
+            (TInt 6,) <$> update',
+            (TInt 7,) <$> auxDataHash',
+            (TInt 8,) <$> validityStart',
+            (TInt 9,) <$> Just mint',
+            (TInt 11,) <$> scriptDataHash',
+            (TInt 13,) <$> collateral',
+            (TInt 14,) <$> requiredSigners',
+            (TInt 15,) <$> networkId'
+          ]

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -495,21 +495,32 @@ instance C.Crypto crypto => Twiddle (AlonzoTxBody (AlonzoEra crypto)) where
     requiredSigners' <- emptyOrNothing txBody reqSignerHashes
     networkId' <- twiddleStrictMaybe $ txnetworkid txBody
     mp <- elements [TMap, TMapI]
-    pure . mp $
-      [ (TInt 0, inputs'),
-        (TInt 1, outputs'),
-        (TInt 2, fee')
-      ]
-        <> catMaybes
-          [ (TInt 3,) <$> ttl',
-            (TInt 4,) <$> cert',
-            (TInt 5,) <$> Just wdrls',
-            (TInt 6,) <$> update',
-            (TInt 7,) <$> auxDataHash',
-            (TInt 8,) <$> validityStart',
-            (TInt 9,) <$> Just mint',
-            (TInt 11,) <$> scriptDataHash',
-            (TInt 13,) <$> collateral',
-            (TInt 14,) <$> requiredSigners',
-            (TInt 15,) <$> networkId'
+    let fields = 
+          [ (TInt 0, inputs'),
+            (TInt 1, outputs'),
+            (TInt 2, fee')
           ]
+            <> catMaybes
+              [ (TInt 3,) <$> ttl',
+                (TInt 4,) <$> cert',
+                (TInt 5,) <$> Just wdrls',
+                (TInt 6,) <$> update',
+                (TInt 7,) <$> auxDataHash',
+                (TInt 8,) <$> validityStart',
+                (TInt 9,) <$> Just mint',
+                (TInt 11,) <$> scriptDataHash',
+                (TInt 13,) <$> collateral',
+                (TInt 14,) <$> requiredSigners',
+                (TInt 15,) <$> networkId'
+              ]
+    fields' <- shuffle fields
+    pure $ mp fields'
+
+instance Typeable c => Twiddle (AlonzoScript (AlonzoEra c)) where
+  twiddle = twiddle . toTerm
+
+instance Typeable c => Twiddle (Data (AlonzoEra c)) where
+  twiddle = twiddle . toTerm
+
+instance Typeable c => Twiddle (BinaryData (AlonzoEra c)) where
+  twiddle = twiddle . toTerm

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -11,40 +11,60 @@ import Cardano.Ledger.Alonzo.Data (BinaryData, Data (..))
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure, AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.Scripts (CostModels)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits)
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody, txBodyRawEq)
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
+import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash (makeHashWithExplicitProxys))
 import Cardano.Ledger.Shelley.Metadata (Metadata)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
+import Codec.CBOR.Read (deserialiseFromBytes)
+import Codec.CBOR.Term
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import Data.Roundtrip (roundTrip, roundTripAnn)
+import Data.Data (Proxy (..))
+import Data.Functor.Identity (Identity (..))
+import Data.Roundtrip (roundTrip, roundTripAnn, roundTripAnnWithTwiddling)
+import Data.Twiddle (Twiddle (..))
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.Tasty
 import Test.Tasty.QuickCheck
+import Codec.CBOR.Write (toLazyByteString)
 
 trippingF ::
   (Eq src, Show src, Show target, ToCBOR src) =>
   (src -> Either target (BSL.ByteString, src)) ->
   src ->
   Property
-trippingF f x =
-  case f x of
-    Right (remaining, y)
+trippingF f x = runIdentity $ trippingM g (===) x
+  where
+    g a = pure (f a, toLazyByteString $ toCBOR a)
+
+trippingM ::
+  (Monad m, Show target) =>
+  (src -> m (Either target (BSL.ByteString, src), BSL.ByteString)) ->
+  (src -> src -> Property) ->
+  src ->
+  m Property
+trippingM f g x = do
+  res <- f x
+  pure $ case res of
+    (Right (remaining, y), _)
       | BSL.null remaining ->
-          x === y
-    Right (remaining, _) ->
+        g x y
+    (Right (remaining, _), _) ->
       counterexample
         ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
         False
-    Left stuff ->
+    (Left stuff, bs) ->
       counterexample
         ( concat
             [ "Failed to decode: ",
               show stuff,
               "\nbytes: ",
-              show (Base16.encode (serialize x))
+              show (Base16.encode bs)
             ]
         )
         False
@@ -59,8 +79,17 @@ trippingAnn ::
   Property
 trippingAnn = trippingF roundTripAnn
 
+trippingAnnWithTwiddling :: (Twiddle t, FromCBOR (Annotator t)) => (t -> t -> Property) -> t -> Property
+trippingAnnWithTwiddling comp x = property $ trippingM roundTripAnnWithTwiddling comp x
+
 tripping :: (Eq src, Show src, ToCBOR src, FromCBOR src) => src -> Property
 tripping = trippingF roundTrip
+
+compareTxBody ::
+  TxBody (AlonzoEra C_Crypto) ->
+  TxBody (AlonzoEra C_Crypto) ->
+  Property
+compareTxBody x y = counterexample "TxBody contents are different" (txBodyRawEq x y)
 
 tests :: TestTree
 tests =
@@ -78,6 +107,8 @@ tests =
         trippingAnn @(AlonzoTxWits (AlonzoEra C_Crypto)),
       testProperty "alonzo/TxBody" $
         trippingAnn @(TxBody (AlonzoEra C_Crypto)),
+      testProperty "alonzo/TxBody twiddled" $
+        trippingAnnWithTwiddling @(TxBody (AlonzoEra C_Crypto)) compareTxBody,
       testProperty "alonzo/CostModels" $
         tripping @CostModels,
       testProperty "alonzo/PParams" $
@@ -99,3 +130,20 @@ tests =
       testProperty "alonzo/Block" $
         trippingAnn @(Block (BHeader C_Crypto) (AlonzoEra C_Crypto))
     ]
+
+test :: IO ()
+test = do
+  x <- generate . resize 1 $ arbitrary @(AlonzoTxBody (AlonzoEra C_Crypto))
+  let hash = makeHashWithExplicitProxys (Proxy @C_Crypto) (Proxy @BSL.ByteString)
+  let xb = toStrictByteString $ toCBOR x
+  putStrLn $ "Untwiddled hash: " <> show (hash xb)
+  y <- generate $ twiddle x
+  let yb = toStrictByteString $ encodeTerm y
+  putStrLn $ "Twiddled hash: " <> show (hash yb)
+  let yr = deserialiseFromBytes (fromCBOR @(Annotator (AlonzoTxBody (AlonzoEra C_Crypto)))) $ BSL.fromStrict yb
+  let y' = case yr of
+        Left err -> error $ show err
+        Right (leftover, Annotator f)
+          | BSL.null leftover -> f . Full $ BSL.fromStrict yb
+          | otherwise -> error $ "Leftover bytes: " <> show leftover
+  putStrLn $ "Twiddled roundtrip hash: " <> show (hashAnnotated y')

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.ShelleyMA.Timelocks
     decodeVI,
     translate,
     translateTimelock,
+    contentsEq,
   )
 where
 
@@ -54,6 +55,7 @@ import Cardano.Ledger.MemoBytes
     memoBytes,
     mkMemoBytes,
   )
+import qualified Cardano.Ledger.MemoBytes as Memo
 import Cardano.Ledger.SafeHash (SafeToHash)
 import Cardano.Ledger.Serialization (decodeStrictSeq, encodeFoldable)
 import Cardano.Ledger.Shelley.Scripts (MultiSig, getMultiSigBytes, nativeMultiSigTag)
@@ -307,6 +309,9 @@ showTimelock (RequireMOf m xs) = "(MOf " ++ show m ++ " " ++ foldl accum ")" xs
   where
     accum ans x = showTimelock x ++ " " ++ ans
 showTimelock (RequireSignature hash) = "(Signature " ++ show hash ++ ")"
+
+contentsEq :: Timelock era -> Timelock era -> Bool
+contentsEq (TimelockConstr x) (TimelockConstr y) = Memo.contentsEq x y
 
 -- ===============================================================
 -- Pretty Printer

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -47,9 +47,9 @@ handleResult ::
 handleResult x (Right (remaining, y))
   | BSL.null remaining = x === y
   | otherwise =
-    counterexample
-      ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
-      False
+      counterexample
+        ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
+        False
 handleResult _ (Left stuff) =
   counterexample
     ("Failed to decode: " <> show stuff)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -37,16 +37,23 @@ propertyAnn ::
   ) =>
   t ->
   Property
-propertyAnn x = case roundTripAnn x of
-  Right (remaining, y) | BSL.null remaining -> x === y
-  Right (remaining, _) ->
+propertyAnn x = handleResult x $ roundTripAnn x
+
+handleResult ::
+  (Eq a1, Show a1, Show a2) =>
+  a1 ->
+  Either a2 (BSL.ByteString, a1) ->
+  Property
+handleResult x (Right (remaining, y))
+  | BSL.null remaining = x === y
+  | otherwise =
     counterexample
       ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
       False
-  Left stuff ->
-    counterexample
-      ("Failed to decode: " <> show stuff)
-      False
+handleResult _ (Left stuff) =
+  counterexample
+    ("Failed to decode: " <> show stuff)
+    False
 
 property ::
   forall t.
@@ -57,17 +64,7 @@ property ::
   ) =>
   t ->
   Property
-property x =
-  case roundTrip x of
-    Right (remaining, y) | BSL.null remaining -> x === y
-    Right (remaining, _) ->
-      counterexample
-        ("Unconsumed trailing bytes:\n" <> BSL.unpack remaining)
-        False
-    Left stuff ->
-      counterexample
-        ("Failed to decode: " <> show stuff)
-        False
+property x = handleResult x $ roundTrip x
 
 allprops ::
   forall e.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -147,7 +147,7 @@ import Test.QuickCheck
     shrink,
     vectorOf,
   )
-import Test.QuickCheck.Gen (chooseAny, frequency)
+import Test.QuickCheck.Gen (chooseAny)
 
 -- =======================================================
 
@@ -649,7 +649,7 @@ instance Arbitrary Url where
   arbitrary = return . fromJust $ textToUrl "text"
 
 instance Arbitrary a => Arbitrary (StrictSeq a) where
-  arbitrary = StrictSeq.forceToStrict <$> frequency [(9, arbitrary), (1, pure mempty)]
+  arbitrary = StrictSeq.forceToStrict <$> arbitrary
   shrink = map StrictSeq.forceToStrict . shrink . StrictSeq.fromStrict
 
 instance Arbitrary StakePoolRelay where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -147,7 +147,7 @@ import Test.QuickCheck
     shrink,
     vectorOf,
   )
-import Test.QuickCheck.Gen (chooseAny)
+import Test.QuickCheck.Gen (chooseAny, frequency)
 
 -- =======================================================
 
@@ -649,7 +649,7 @@ instance Arbitrary Url where
   arbitrary = return . fromJust $ textToUrl "text"
 
 instance Arbitrary a => Arbitrary (StrictSeq a) where
-  arbitrary = StrictSeq.forceToStrict <$> arbitrary
+  arbitrary = StrictSeq.forceToStrict <$> frequency [(9, arbitrary), (1, pure mempty)]
   shrink = map StrictSeq.forceToStrict . shrink . StrictSeq.fromStrict
 
 instance Arbitrary StakePoolRelay where

--- a/hie.yaml
+++ b/hie.yaml
@@ -81,6 +81,9 @@ cradle:
     - path: "libs/cardano-data/src"
       component: "lib:cardano-data"
 
+    - path: "libs/cardano-data/test"
+      component: "test:cardano-data-tests"
+
     - path: "libs/small-steps/src"
       component: "lib:small-steps-test"
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -42,6 +42,7 @@ library
                      , Data.Roundtrip
                      , Data.UMap
                      , Data.ListMap
+                     , Data.Twiddle
 
   build-depends:       aeson
                      , base >=4.11 && <5
@@ -60,6 +61,7 @@ library
                      , text
                      , transformers >= 0.5
                      , vector
+                     , QuickCheck
                      -- IOHK deps
                      , cardano-crypto-class
                      , cardano-binary

--- a/libs/cardano-data/src/Data/Roundtrip.hs
+++ b/libs/cardano-data/src/Data/Roundtrip.hs
@@ -11,6 +11,7 @@ module Data.Roundtrip
     embedTrip',
     roundTripAnn,
     roundTripAnnWithTwiddling,
+    roundTripWithTwiddling,
     embedTripAnn,
     RoundTripResult,
   )
@@ -57,6 +58,10 @@ roundTripAnnWithTwiddling x = do
   tw <- encodeTerm <$> twiddle x
   let bs = toLazyByteString tw
   pure (roundTripAnn' bs, bs)
+
+roundTripWithTwiddling :: t -> Gen (RoundTripResult t, LBS.ByteString)
+roundTripWithTwiddling = do
+  undefined
 
 roundTripAnn' :: FromCBOR (Annotator t) => Lazy.ByteString -> RoundTripResult t
 roundTripAnn' bytes = case deserialiseFromBytes fromCBOR bytes of

--- a/libs/cardano-data/src/Data/Twiddle.hs
+++ b/libs/cardano-data/src/Data/Twiddle.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE EmptyCase #-}
+
+module Data.Twiddle
+  ( Twiddler (unTwiddler),
+    Twiddle (..),
+    toTwiddler,
+    encodingToTerm,
+    toTerm,
+  )
+where
+
+import Cardano.Binary (ToCBOR (..), FromCBOR (..), Encoding)
+import Codec.CBOR.Read (deserialiseFromBytes)
+import Codec.CBOR.Term (Term (..), decodeTerm, encodeTerm)
+import Codec.CBOR.Write (toLazyByteString)
+import Data.Bitraversable (bimapM)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (fromStrict, toStrict)
+import Data.Foldable (toList)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text.Lazy as T
+import Data.Typeable (Typeable)
+import GHC.Generics
+import Test.QuickCheck (Arbitrary (..), Gen, elements, shuffle)
+import Data.Void (Void, absurd)
+
+data Twiddler a = Twiddler
+  { unTwiddler :: !a,
+    _unEnc :: Term
+  }
+
+gTwiddleTList :: forall a p. (Generic a, TwiddleL' (Rep a p)) => a -> Gen Term
+gTwiddleTList a = TList <$> twiddleL' (from @a @p a)
+
+class Twiddle a where
+  twiddle :: a -> Gen Term
+  default twiddle :: forall p. (Generic a, TwiddleL' (Rep a p)) => a -> Gen Term
+  twiddle = gTwiddleTList @a @p
+
+instance Twiddle a => Twiddle [a] where
+  twiddle l = do
+    f <- elements [TList, TListI]
+    l' <- traverse twiddle l
+    pure $ f l'
+
+instance (Twiddle k, Twiddle v) => Twiddle (Map k v) where
+  twiddle m = do
+    -- Elements of a map do not have to be in a specific order so we shuffle them
+    m' <- shuffle $ Map.toList m
+    m'' <- traverse (bimapM twiddle twiddle) m'
+    f <- elements [TMap, TMapI]
+    pure $ f m''
+
+instance Twiddle ByteString where
+  twiddle bs = do
+    f <- elements [TBytes, TBytesI . fromStrict]
+    pure $ f bs
+
+instance Twiddle Text where
+  twiddle t = do
+    f <- elements [TString, TStringI . T.fromStrict]
+    pure $ f t
+
+instance Twiddle Int where
+  -- TODO: Put small ints into bigger words (e.g. a Word16 value into Word32)
+  --
+  -- This is not possible with the CBOR AST provided by cborg
+  twiddle = pure . TInt
+
+instance (Twiddle a, Arbitrary a, ToCBOR a) => Arbitrary (Twiddler a) where
+  arbitrary = do
+    x <- arbitrary
+    enc' <- twiddle x
+    pure $ Twiddler x enc'
+
+instance Twiddle a => Twiddle (Set a) where
+  twiddle = twiddle . toList
+
+instance Twiddle a => Twiddle (Seq a) where
+  twiddle = twiddle . toList
+
+instance Twiddle a => Twiddle (StrictSeq a) where
+  twiddle = twiddle . toList
+
+instance Typeable a => ToCBOR (Twiddler a) where
+  toCBOR (Twiddler _ x) = encodeTerm x
+
+instance (Typeable a, ToCBOR a, FromCBOR a) => FromCBOR (Twiddler a) where
+  fromCBOR = f <$> fromCBOR
+    where
+      f x = Twiddler x $ toTerm x
+
+instance Show a => Show (Twiddler a) where
+  show (Twiddler x _) = "Twiddler " <> show x
+
+instance Eq a => Eq (Twiddler a) where
+  (Twiddler x _) == (Twiddler y _) = x == y
+
+class TwiddleL' a where
+  twiddleL' :: a -> Gen [Term]
+
+instance TwiddleL' (V1 p) where
+  twiddleL' v1 = case v1 of
+
+instance TwiddleL' (U1 p) where
+  twiddleL' U1 = pure []
+
+instance (TwiddleL' (l x), TwiddleL' (r x)) => TwiddleL' ((l :*: r) x) where
+  twiddleL' (lx :*: rx) = do
+    lx' <- twiddleL' lx
+    rx' <- twiddleL' rx
+    pure $ lx' <> rx'
+
+instance (TwiddleL' (l x), TwiddleL' (r x)) => TwiddleL' ((l :+: r) x) where
+  twiddleL' (L1 lx) = twiddleL' lx
+  twiddleL' (R1 rx) = twiddleL' rx
+
+instance Twiddle c => TwiddleL' (K1 i c p) where
+  twiddleL' (K1 c) = pure <$> twiddle c
+
+instance (TwiddleL' (f p)) => TwiddleL' (M1 i c f p) where
+  twiddleL' (M1 fp) = twiddleL' fp
+
+instance Twiddle Integer where
+  twiddle = pure . TInteger
+
+instance Twiddle Void where
+  twiddle = absurd
+
+instance Twiddle Bool where
+  twiddle = pure . TBool
+
+instance Twiddle Float where
+  twiddle = pure . TFloat
+
+instance Twiddle Double where
+  twiddle = pure . TDouble
+
+instance Twiddle Term where
+  twiddle (TInt n) = twiddle n
+  twiddle (TInteger n) = twiddle n
+  twiddle (TBytes bs) = twiddle bs
+  twiddle (TBytesI bs) = twiddle $ toStrict bs
+  twiddle (TString txt) = twiddle txt
+  twiddle (TStringI txt) = twiddle $ T.toStrict txt
+  twiddle (TList tes) = twiddle tes
+  twiddle (TListI tes) = twiddle tes
+  twiddle (TMap x0) = twiddle $ Map.fromList x0
+  twiddle (TMapI x0) = twiddle $ Map.fromList x0
+  twiddle (TTagged wo te') = TTagged wo <$> twiddle te'
+  twiddle (TBool b) = twiddle b
+  twiddle TNull = pure TNull
+  twiddle (TSimple wo) = pure $ TSimple wo
+  twiddle (THalf x) = pure $ THalf x
+  twiddle (TFloat x) = twiddle x
+  twiddle (TDouble x) = twiddle x
+
+encodingToTerm :: Encoding -> Term
+encodingToTerm enc = case res of
+  Right (_, t) -> t
+  Left err -> error $ show err
+  where
+    res = deserialiseFromBytes decodeTerm $ toLazyByteString enc
+
+toTerm :: ToCBOR a => a -> Term
+toTerm = encodingToTerm . toCBOR
+
+toTwiddler :: Twiddle a => a -> Gen (Twiddler a)
+toTwiddler x = Twiddler x <$> twiddle x

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -670,7 +670,7 @@ newtype BlocksMade crypto = BlocksMade
 
 -- | Transaction index.
 newtype TxIx = TxIx Word64
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (NFData, Enum, Bounded, NoThunks, ToCBOR, FromCBOR)
 
 txIxToInt :: TxIx -> Int

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -33,6 +33,7 @@ module Cardano.Ledger.MemoBytes
     printMemo,
     roundTripMemo,
     shortToLazy,
+    contentsEq,
   )
 where
 
@@ -151,3 +152,7 @@ roundTripMemo (Memo' _t bytes _hash) =
 -- | Helper function. Converts a short bytestring to a lazy bytestring.
 shortToLazy :: ShortByteString -> BSL.ByteString
 shortToLazy = fromStrict . fromShort
+
+-- | Returns true if the contents of the MemoBytes are equal
+contentsEq :: Eq (t era) => MemoBytes t era -> MemoBytes t era -> Bool
+contentsEq x y = mbType x == mbType y

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -106,7 +106,6 @@ library
     Test.Cardano.Ledger.Generic.GenState.Types
     Test.Cardano.Ledger.Generic.GenState.Generators
     Test.Cardano.Ledger.Generic.GenState.GenScript
-    Test.Cardano.Ledger.Twiddle
   build-depends:
     aeson >= 2,
     array,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -106,6 +106,7 @@ library
     Test.Cardano.Ledger.Generic.GenState.Types
     Test.Cardano.Ledger.Generic.GenState.Generators
     Test.Cardano.Ledger.Generic.GenState.GenScript
+    Test.Cardano.Ledger.Twiddle
   build-depends:
     aeson >= 2,
     array,
@@ -122,6 +123,7 @@ library
     cardano-ledger-shelley-ma,
     cardano-protocol-tpraos,
     cardano-slotting,
+    cborg,
     containers,
     vector-map,
     data-default-class,


### PR DESCRIPTION
This PR adds the `Twiddle` class that can be used to serialize the data structure with some random variations (e.g. finite lists/byte strings might be serialized as indefinite lists and vice-versa, map entries are shuffled around). 

Some data types might also have a custom `Twiddle` instance, for example `AlonzoTxBody` has one that might represent empty auxiliary data as either an empty list or just omit the field completely.

I also added some round-trip tests to Alonzo era that use twiddling to ensure that the deserializer respects the CDDL. These tests already caught some bugs in the deserializers (see #3003) and are disabled until the issues are fixed. I should create an issue to re-enable the test once this PR gets merged.

closes #2944 