### PR TITLE
specify txid in shelley spec appendix

### DIFF
--- a/eras/shelley/formal-spec/cddl.tex
+++ b/eras/shelley/formal-spec/cddl.tex
@@ -10,3 +10,8 @@ The CDDL specification is located at
 
 % TODO - Include the CDDL spec inline?
 % \lstinputlisting[backgroundcolor = \color{lightgray}]{../impl/cddl-files/shelley.cddl}
+
+Note that the ledger does
+\textbf{not support a canonical representation}.
+This is an intentional decision to discourage people from
+checking signatures and hashes on re-serialized data.

--- a/eras/shelley/formal-spec/crypto-details.tex
+++ b/eras/shelley/formal-spec/crypto-details.tex
@@ -1,6 +1,10 @@
 \section{Cryptographic Details}
 \label{sec:crypto-details}
 
+\subsection{Warning About Re-serialization}
+It is a bad security practice to check signatures or hashes on re-serialized data,
+the original bytes must be preserved.
+
 \subsection{Hashing}
 We present the (informal) properties of cryptographically safe hash functions:
 \begin{description}
@@ -52,13 +56,22 @@ More generally, we expect the following properties from a Verifyable Random Func
 \item[Pseudorandomness] Assuming the public-private key pair has been generated honestly, the VRF hash output on any adversarially-chosen VRF input looks indistinguishable from random for a computationally bounded adversary who does not know the private key. 
 \end{description}
 
-\subsection{Abstract functions $\seedOp$ and \fun{seedToSlot}}
-\label{sec:mkseed-slottoseed}
-The seed operation $x \seedOp y$ from Figure~\ref{fig:defs-vrf} is implemented
-as the BLAKE2b-256 hash of the concatenation of $x$ and $y$.
+\subsection{Abstract functions}
+\label{sec:abstract-funcs-implementation}
 
-The function \fun{slotToSeed} from Figure~\ref{fig:defs:blocks} is implemented
-as the big-endian encoding of the slot number in 8 bytes.
+\begin{itemize}
+  \item The transaction ID function $\fun{txid}$ from Figure~\ref{fig:defs:utxo-shelley} is implemented
+        as the BLAKE2b-256 hash of the CBOR serialization of the transaction body.
+        \textbf{Note} that we do \textbf{not} enforce canonical CBOR and that there are
+        multiple valid serializations for any given transaction body.
+        The transaction ID must be computed using the original bytes that were
+        submitted to the network.
+  \item The seed operation $x \seedOp y$ from Figure~\ref{fig:defs-vrf} is implemented
+        as the BLAKE2b-256 hash of the concatenation of $x$ and $y$.
+  \item The function \fun{slotToSeed} from Figure~\ref{fig:defs:blocks} is implemented
+        as the big-endian encoding of the slot number in 8 bytes.
+\end{itemize}
+
 
 \subsection{Multi-Signatures}
 As presented in Figure~\ref{fig:types-msig}, Shelley realizes multi-signatures 

--- a/eras/shelley/formal-spec/frontmatter.tex
+++ b/eras/shelley/formal-spec/frontmatter.tex
@@ -43,6 +43,7 @@
         \change{2022/01/20}{Jared Corduan}{FM (IOHK)}{Fixed error in counting new pools for deposits and an error in the POOLREAP rule.}
         \change{2022/01/26}{Jared Corduan}{FM (IOHK)}{Specify seed operation and seedToSlot.}
         \change{2022/01/31}{Jordan Millar, Jared Corduan}{FM (IOHK)}{Fixed prose regarding the hash used in the epoch nonce. Added an item to the errata regarding this same hash.}
+        \change{2022/08/25}{Jared Corduan}{FM (IOHK)}{Specify the txid function in the Appendix. Warn about re-serializing.}
       \end{changelog}
       \clearpage%
 \renewcommand{\thepage}{\arabic{page}}


### PR DESCRIPTION
The Shelley ledger spec was missing a description of the `txid` function in the appendix (it's fine for it to be abstract in the spec iteself).

I also used the opportunity to warn people about re-serializing data.