### PR TITLE
Start a test suite for cardano ledger api

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -298,7 +298,7 @@ instance
 instance
   ( EraTx era,
     ShelleyEraTxBody era,
-    ProtVerInEra era (ShelleyEra c),
+    ExactEra ShelleyEra era,
     TxOut era ~ ShelleyTxOut era,
     Show (Value era),
     Show (Witnesses era),
@@ -353,10 +353,10 @@ instance
     ]
 
 utxoInductive ::
-  forall era utxo c.
+  forall era utxo.
   ( EraTx era,
     ShelleyEraTxBody era,
-    ProtVerInEra era (ShelleyEra c),
+    ExactEra ShelleyEra era,
     TxOut era ~ ShelleyTxOut era,
     STS (utxo era),
     Embed (EraRule "PPUP" era) (utxo era),
@@ -430,7 +430,7 @@ utxoInductive = do
 --
 -- > txttl txb ≥ slot
 validateTimeToLive ::
-  (ShelleyEraTxBody era, ProtVerInEra era (ShelleyEra c)) =>
+  (ShelleyEraTxBody era, ExactEra ShelleyEra era) =>
   TxBody era ->
   SlotNo ->
   Test (ShelleyUtxoPredFailure era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -422,7 +422,7 @@ instance CC.Crypto crypto => EraTxBody (ShelleyEra crypto) where
 class EraTxBody era => ShelleyEraTxBody era where
   wdrlsTxBodyL :: Lens' (Core.TxBody era) (Wdrl (Crypto era))
 
-  ttlTxBodyL :: ProtVerInEra era (ShelleyEra c) => Lens' (Core.TxBody era) SlotNo
+  ttlTxBodyL :: ExactEra ShelleyEra era => Lens' (Core.TxBody era) SlotNo
 
   updateTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe (Update era))
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -50,3 +50,26 @@ library
     cardano-ledger-babbage,
     cardano-ledger-shelley,
     microlens,
+
+test-suite cardano-ledger-api-test
+  import:             base, project-config
+
+  type:                exitcode-stdio-1.0
+  main-is:             Tests.hs
+  ghc-options: -rtsopts -threaded
+
+  hs-source-dirs:      test
+  other-modules:
+    Test.Cardano.Ledger.Api.Tx.Out
+  build-depends:
+    bytestring,
+    cardano-binary,
+    cardano-ledger-api,
+    cardano-ledger-core,
+    cardano-ledger-babbage,
+    cardano-ledger-babbage-test,
+    cardano-ledger-conway,
+    microlens,
+    tasty,
+    tasty-quickcheck,
+    QuickCheck,

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Api.Tx.Out
+  ( txOutTests,
+  )
+where
+
+import Cardano.Binary (serialize)
+import Cardano.Ledger.Api.Tx.Out
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.PParams hiding (PParams)
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Serialization (mkSized, sizedValue)
+import qualified Data.ByteString.Lazy as BSL
+import GHC.Records
+import Lens.Micro
+import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+propSetBabbageMinTxOut ::
+  forall era.
+  ( EraTxOut era,
+    AtLeastEra BabbageEra era,
+    HasField "_coinsPerUTxOByte" (PParams era) Coin
+  ) =>
+  PParams era ->
+  TxOut era ->
+  Property
+propSetBabbageMinTxOut pp txOut =
+  within 1000000 $ -- just in case if there is a problem with termination
+    let txOut' = sizedValue (setBabbageMinTxOut pp (mkSized txOut))
+        size = toInteger (BSL.length (serialize txOut'))
+     in (txOut' ^. coinTxOutL)
+          === Coin ((160 + size) * unCoin (getField @"_coinsPerUTxOByte" pp))
+  where
+    _atLeastBabbage = atLeastEra @BabbageEra @era
+
+babbageTxOutTests ::
+  forall era.
+  ( Arbitrary (PParams era),
+    Arbitrary (TxOut era),
+    Show (PParams era),
+    EraTxOut era,
+    AtLeastEra BabbageEra era,
+    HasField "_coinsPerUTxOByte" (PParams era) Coin
+  ) =>
+  [TestTree]
+babbageTxOutTests =
+  [ testProperty "setBabbageMinTxOut" $ propSetBabbageMinTxOut @era
+  ]
+
+conwayTxOutTests ::
+  forall era.
+  ( Arbitrary (PParams era),
+    Arbitrary (TxOut era),
+    Show (PParams era),
+    EraTxOut era,
+    AtLeastEra BabbageEra era,
+    AtLeastEra ConwayEra era,
+    HasField "_coinsPerUTxOByte" (PParams era) Coin
+  ) =>
+  [TestTree]
+conwayTxOutTests =
+  concat
+    [ babbageTxOutTests @era
+    ]
+  where
+    _atLeastConway = atLeastEra @ConwayEra @era
+
+txOutTests :: TestTree
+txOutTests =
+  testGroup "TxOut" $
+    concat
+      [ babbageTxOutTests @(BabbageEra StandardCrypto),
+        conwayTxOutTests @(ConwayEra StandardCrypto)
+      ]

--- a/libs/cardano-ledger-api/test/Tests.hs
+++ b/libs/cardano-ledger-api/test/Tests.hs
@@ -1,0 +1,20 @@
+module Main where
+
+import System.IO (hSetEncoding, stdout, utf8)
+import Test.Cardano.Ledger.Api.Tx.Out (txOutTests)
+import Test.Tasty
+
+-- ====================================================================================
+
+apiTests :: TestTree
+apiTests =
+  testGroup
+    "cardano-ledger-api"
+    [ txOutTests
+    ]
+
+-- main entry point
+main :: IO ()
+main = do
+  hSetEncoding stdout utf8
+  defaultMain apiTests

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -554,7 +554,7 @@ chainTest proof n gsize = testProperty message action
           (Gen1 vs genstate)
           (Just (\_ -> pure $ Right initState))
       -- Here is where we can add some properties for traces:
-      pure $ (_traceInitState trace1 === initState)
+      pure (_traceInitState trace1 === initState)
 
 testTraces :: Int -> TestTree
 testTraces n =


### PR DESCRIPTION
Add test suite to the cardano-ledger-api. Improve era checks.
* Implement a way to specify minimum era with `AtLeastEra`
* Fixed the naming:
  * `ProtVerAtLeast` -> `ProtVerNoLess`
  * `ProtVerAtMost` -> `ProtVerNoMore`
  * `ProtVerInEra` -> `ExactEra`