### PR TITLE
deprecate the unused validPlutusdata function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ in the naming of release branches.
 ### Removed
 
 - Deprecated the HasAlgorithm type alias: #3007
+- Deprecated the validPlutusdata function: #3006
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/formal-spec/txinfo.tex
+++ b/eras/alonzo/formal-spec/txinfo.tex
@@ -252,14 +252,6 @@ Plutus script.
 
 \begin{figure*}[htb]
   \begin{align*}
-    & \fun{validPlutusdata} \in \type{P.Data} \to \Bool \\
-    & \fun{validPlutusdata}~ (\type{P.Constr} ~\wcard ~ds) = \bigwedge_{d\in ds} \type{validPlutusdata}~d \\
-    & \fun{validPlutusdata}~ (\type{P.Map}~ ds) = \bigwedge_{(x,y)\in ds} \type{validPlutusdata}~x \wedge \type{validPlutusdata}~y \\
-    & \fun{validPlutusdata} ~(\type{P.List}~ ds) =  \bigwedge_{d\in ds} \type{validPlutusdata}~d \\
-    & \fun{validPlutusdata}~ (\type{P.I}~ \wcard) = \True \\
-    & \fun{validPlutusdata}~ (\type{P.B}~ bs) = \fun{length} ~bs \leq 64 \\
-    & \text{Checks if a Data element is constructed correctly}
-    \nextdef
     & \fun{validScript} \in \Script \to \Bool \\
     & \fun{validScript} ~sc = \begin{cases}
       \True & \text{if $sc \in \ScriptPhOne$} \\

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -56,8 +56,9 @@ module Cardano.Ledger.Alonzo.TxInfo
     debugPlutus,
     runPLCScript,
     explainPlutusFailure,
-    validPlutusdata,
     languages,
+    -- DEPRECATED
+    validPlutusdata,
   )
 where
 
@@ -783,6 +784,7 @@ explainPlutusFailure _proxy pv lang scriptbytestring e ds cm eu =
         PlutusV2 -> PlutusDebugV2 cm eu scriptbytestring ds pv
    in scriptFail $ PlutusSF line db
 
+{-# DEPRECATED validPlutusdata "Plutus data bytestrings are not restricted to sixty-four bytes." #-}
 validPlutusdata :: PV1.Data -> Bool
 validPlutusdata (PV1.Constr _n ds) = all validPlutusdata ds
 validPlutusdata (PV1.Map ds) =


### PR DESCRIPTION
At one point in the design of the Alonzo specification, we imposed a sixty-four byte limit on Plutus Data bytestrings, which the
`validPlutusdata` function enforced.

This was later relaxed, see:
https://github.com/input-output-hk/plutus/blob/fd927b1b9cb3292ed3409b0d40f0dcf627e13323/plutus-core/plutus-core/src/PlutusCore/Data.hs#L84

We now deprecate the `validPlutusdata` function and remove it from the Alonzo ledger specification (it was also unused in the spec).

resolves #2940