### PR TITLE
deprecate HasAlgorithm type aliase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ in the naming of release branches.
   #2954
 - All Shelley rules are now available through `Cadano.Ledger.Shelley.Rules` module: #2996
 
+### Removed
+
+- Deprecated the HasAlgorithm type alias: #3007
+
 ## Release branch 1.1.x
 
 ### Added

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -61,10 +61,10 @@ import Cardano.Ledger.Coin (CompactForm (..), DeltaCoin (..))
 import Cardano.Ledger.Core (Crypto, Era, EraScript (..), EraSegWits (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
 import Cardano.Ledger.Keys.Bootstrap (ChainCode (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
-import Cardano.Ledger.SafeHash (HasAlgorithm, SafeHash, unsafeMakeSafeHash)
+import Cardano.Ledger.SafeHash (SafeHash, unsafeMakeSafeHash)
 import Cardano.Ledger.Serialization (ToCBORGroup)
 import Cardano.Ledger.Shelley.API hiding (SignedDSIGN, TxBody)
 import Cardano.Ledger.Shelley.LedgerState (FutureGenDeleg, StashedAVVMAddresses)
@@ -157,7 +157,7 @@ genHash = mkDummyHash <$> arbitrary
 mkDummyHash :: forall h a. HashAlgorithm h => Int -> Hash.Hash h a
 mkDummyHash = coerce . hashWithSerialiser @h toCBOR
 
-instance HasAlgorithm c => Arbitrary (SafeHash c i) where
+instance Hash.HashAlgorithm (CC.HASH c) => Arbitrary (SafeHash c i) where
   arbitrary = unsafeMakeSafeHash <$> arbitrary
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
This alias is spelled incorrectly, is not used much, and can lead to confusing compiler errors.

resolves  #2934