### PR TITLE
Improve interface of minutxo calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ in the naming of release branches.
 
 ### Added
 
-- Start on the `cardano-ledger-api` package and implement `setBabbageMinTxOut`: #2995
+- Start on the `cardano-ledger-api` package and implement
+  `setMinCoinTxOut`+`setMinCoinSizedTxOut`: #2995
+- Added `getMinCoinTxOut`/`getMinCoinSizedTxOut`: #3008
 
 ### Changed
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
@@ -21,8 +23,10 @@ in the naming of release branches.
 
 ### Removed
 
-- Deprecated the HasAlgorithm type alias: #3007
-- Deprecated the validPlutusdata function: #3006
+- Deprecated the `validPlutusdata` function: #3006
+- Deprecated the misspelled `HasAlgorithm` type alias: #3007
+- Deprecate `evaluateMinLovelaceOutput` in favor of newly added
+  `getMinCoinTxOut`/`getMinCoinSizedTxOut` #3008
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -45,7 +45,7 @@ import qualified Cardano.Ledger.Alonzo.PParams (PParams)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (getDatumAlonzo)
 import Cardano.Ledger.Alonzo.Rules (utxoEntrySize)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), alonzoInputHashes, minfee)
+import Cardano.Ledger.Alonzo.Tx (alonzoInputHashes, minfee)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..), AlonzoTxBody, AlonzoTxOut)
 import qualified Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo)
@@ -107,10 +107,6 @@ instance CC.Crypto c => API.CLI (AlonzoEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  addKeyWitnesses (AlonzoTx b ws aux iv) newWits = AlonzoTx b ws' aux iv
-    where
-      ws' = ws {txwitsVKey = Set.union newWits (txwitsVKey ws)}
 
   evaluateMinLovelaceOutput pp out =
     Coin $ utxoEntrySize out * unCoin (_coinsPerUTxOWord pp)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Alonzo.PParams
   )
 import qualified Cardano.Ledger.Alonzo.PParams (PParams)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (getDatumAlonzo)
-import Cardano.Ledger.Alonzo.Rules (utxoEntrySize)
+import Cardano.Ledger.Alonzo.Rules ()
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
 import Cardano.Ledger.Alonzo.Tx (alonzoInputHashes, minfee)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..), AlonzoTxBody, AlonzoTxOut)
@@ -51,7 +51,6 @@ import qualified Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.BaseTypes (Globals)
-import Cardano.Ledger.Coin
 import Cardano.Ledger.Core hiding (PParamsDelta, Value)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Keys (DSignable, Hash)
@@ -107,9 +106,6 @@ instance CC.Crypto c => API.CLI (AlonzoEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  evaluateMinLovelaceOutput pp out =
-    Coin $ utxoEntrySize out * unCoin (_coinsPerUTxOWord pp)
 
 instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -16,10 +16,16 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), Data (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.PParams (AlonzoPParams, AlonzoPParamsHKD (..), extendPP, getLanguageView, retractPP)
+import Cardano.Ledger.Alonzo.PParams
+  ( AlonzoPParams,
+    AlonzoPParamsHKD (..),
+    extendPP,
+    getLanguageView,
+    retractPP,
+  )
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeededFromBody)
 import Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo (language)
-import Cardano.Ledger.Alonzo.Rules (utxoEntrySize, vKeyLocked)
+import Cardano.Ledger.Alonzo.Rules (vKeyLocked)
 import Cardano.Ledger.Alonzo.Scripts (isPlutusScript, pointWiseExUnits, txscriptfee)
 import Cardano.Ledger.Alonzo.Scripts as Alonzo
   ( AlonzoScript (..),
@@ -44,6 +50,7 @@ import Cardano.Ledger.Alonzo.TxBody
     AlonzoTxBody (..),
     AlonzoTxOut (..),
     inputs',
+    utxoEntrySize,
   )
 import Cardano.Ledger.Alonzo.TxWitness
   ( AlonzoEraWitnesses (..),

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -23,10 +23,9 @@ import Cardano.Ledger.Alonzo.PParams
     emptyPParams,
     getLanguageView,
   )
-import Cardano.Ledger.Alonzo.Rules (utxoEntrySize)
 import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), Prices (..), mkCostModel)
 import Cardano.Ledger.Alonzo.Tx (minfee)
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), utxoEntrySize)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), boundRational)
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..))

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Genesis (AlonzoGenesis, extendPPWithGenesis)
 import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
-import Cardano.Ledger.Babbage.Rules (babbageMinUTxOValue)
+import Cardano.Ledger.Babbage.Rules ()
 import Cardano.Ledger.Babbage.Tx
   ( babbageInputDataHashes,
     babbageTxScripts,
@@ -50,7 +50,6 @@ import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
-import Cardano.Ledger.Serialization (mkSized)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Rules (consumed)
@@ -76,8 +75,6 @@ instance CC.Crypto c => API.CLI (BabbageEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  evaluateMinLovelaceOutput pp out = babbageMinUTxOValue pp (mkSized out)
 
 instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
   txInfo = babbageTxInfo

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -28,14 +28,12 @@ import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), AuxiliaryData)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Genesis (AlonzoGenesis, extendPPWithGenesis)
 import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Babbage.Rules (babbageMinUTxOValue)
 import Cardano.Ledger.Babbage.Tx
-  ( AlonzoTx (..),
-    babbageInputDataHashes,
+  ( babbageInputDataHashes,
     babbageTxScripts,
     getDatumBabbage,
     minfee,
@@ -78,10 +76,6 @@ instance CC.Crypto c => API.CLI (BabbageEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  addKeyWitnesses (AlonzoTx b ws aux iv) newWits = AlonzoTx b ws' aux iv
-    where
-      ws' = ws {txwitsVKey = Set.union newWits (txwitsVKey ws)}
 
   evaluateMinLovelaceOutput pp out = babbageMinUTxOValue pp (mkSized out)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -13,11 +13,9 @@ module Cardano.Ledger.Conway (ConwayEra) where
 import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
 import Cardano.Ledger.Babbage.Rules (babbageMinUTxOValue)
 import Cardano.Ledger.Babbage.Tx
-  ( AlonzoTx (..),
-    babbageInputDataHashes,
+  ( babbageInputDataHashes,
     babbageTxScripts,
     getDatumBabbage,
     minfee,
@@ -58,10 +56,6 @@ instance CC.Crypto c => API.CLI (ConwayEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  addKeyWitnesses (AlonzoTx b ws aux iv) newWits = AlonzoTx b ws' aux iv
-    where
-      ws' = ws {txwitsVKey = Set.union newWits (txwitsVKey ws)}
 
   evaluateMinLovelaceOutput pp out = babbageMinUTxOValue pp (mkSized out)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -13,7 +13,7 @@ module Cardano.Ledger.Conway (ConwayEra) where
 import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
-import Cardano.Ledger.Babbage.Rules (babbageMinUTxOValue)
+import Cardano.Ledger.Babbage.Rules ()
 import Cardano.Ledger.Babbage.Tx
   ( babbageInputDataHashes,
     babbageTxScripts,
@@ -30,7 +30,6 @@ import Cardano.Ledger.Conway.TxOut (AlonzoEraTxOut (..), BabbageTxOut (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
-import Cardano.Ledger.Serialization (mkSized)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Rules (consumed)
@@ -56,8 +55,6 @@ instance CC.Crypto c => API.CLI (ConwayEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  evaluateMinLovelaceOutput pp out = babbageMinUTxOValue pp (mkSized out)
 
 instance CC.Crypto c => ExtendedUTxO (ConwayEra c) where
   txInfo = babbageTxInfo

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
@@ -27,8 +27,10 @@ import Cardano.Ledger.Babbage.TxBody as BabbageTxOutReExports
   ( AlonzoEraTxOut (..),
     BabbageEraTxOut (..),
     BabbageTxOut (..),
+    babbageMinUTxOValue,
   )
 import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC
@@ -46,6 +48,8 @@ instance CC.Crypto c => EraTxOut (ConwayEra c) where
 
   valueEitherTxOutL = valueEitherBabbageTxOutL
   {-# INLINE valueEitherTxOutL #-}
+
+  getMinCoinSizedTxOut = babbageMinUTxOValue
 
 instance CC.Crypto c => AlonzoEraTxOut (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTxOut (ConwayEra CC.StandardCrypto) #-}

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -54,8 +54,6 @@ instance CC.Crypto c => CLI (AllegraEra c) where
 
   evaluateConsumed = consumed
 
-  evaluateMinLovelaceOutput pp _out = _minUTxOValue pp
-
 -- Self-Describing type synomyms
 
 type Self c = ShelleyMAEra 'Allegra c

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -54,8 +54,6 @@ instance CC.Crypto c => CLI (AllegraEra c) where
 
   evaluateConsumed = consumed
 
-  addKeyWitnesses = addShelleyKeyWitnesses
-
   evaluateMinLovelaceOutput pp _out = _minUTxOValue pp
 
 -- Self-Describing type synomyms

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import qualified Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData)
-import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed, scaledMinDeposit)
+import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed)
 import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 
@@ -57,8 +57,6 @@ instance CC.Crypto c => CLI (MaryEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = consumed
-
-  evaluateMinLovelaceOutput pp (ShelleyTxOut _ v) = scaledMinDeposit v (_minUTxOValue pp)
 
 -- Self-Describing type synomyms
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -58,8 +58,6 @@ instance CC.Crypto c => CLI (MaryEra c) where
 
   evaluateConsumed = consumed
 
-  addKeyWitnesses = addShelleyKeyWitnesses
-
   evaluateMinLovelaceOutput pp (ShelleyTxOut _ v) = scaledMinDeposit v (_minUTxOValue pp)
 
 -- Self-Describing type synomyms

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -60,7 +60,7 @@ instance CC.Crypto c => CLI (MaryEra c) where
 
 -- Self-Describing type synomyms
 
-type MaryEra c = ShelleyMAEra 'Mary c
+type MaryEra = ShelleyMAEra 'Mary
 
 type Self c = ShelleyMAEra 'Mary c
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
@@ -92,8 +92,8 @@ instance MAClass ma crypto => Era (ShelleyMAEra ma crypto) where
   type ProtVerLow (ShelleyMAEra ma crypto) = MAProtVer ma
 
 type family MAProtVer (ma :: MaryOrAllegra) :: Nat where
-  MAProtVer 'Mary = 3
-  MAProtVer 'Allegra = 4
+  MAProtVer 'Allegra = 3
+  MAProtVer 'Mary = 4
 
 --------------------------------------------------------------------------------
 -- Core instances

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -41,6 +41,7 @@ module Cardano.Ledger.ShelleyMA.TxBody
     fromSJust,
     ValidityInterval (..),
     initial,
+    scaledMinDeposit,
   )
 where
 
@@ -56,7 +57,7 @@ import Cardano.Ledger.Mary.Value (MultiAsset)
 import Cardano.Ledger.MemoBytes (Mem, MemoBytes (..), MemoHashIndex, memoBytes)
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Serialization (encodeFoldable)
-import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.PParams (Update, _minUTxOValue)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     ShelleyEraTxBody (..),
@@ -75,6 +76,7 @@ import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val
   ( DecodeMint (..),
     EncodeMint (..),
+    Val (isAdaOnly, size),
   )
 import Control.DeepSeq (NFData (..))
 import Data.Coders
@@ -405,3 +407,48 @@ instance MAClass ma crypto => EraTxOut (ShelleyMAEra ma crypto) where
 
   valueEitherTxOutL = valueEitherShelleyTxOutL
   {-# INLINE valueEitherTxOutL #-}
+
+  getMinCoinTxOut pp txOut = scaledMinDeposit (txOut ^. valueTxOutL) (_minUTxOValue pp)
+
+-- | The `scaledMinDeposit` calculation uses the minUTxOValue protocol parameter
+-- (passed to it as Coin mv) as a specification of "the cost of making a
+-- Shelley-sized UTxO entry", calculated here by "utxoEntrySizeWithoutVal +
+-- uint", using the constants in the "where" clause.  In the case when a UTxO
+-- entry contains coins only (and the Shelley UTxO entry format is used - we
+-- will extend this to be correct for other UTxO formats shortly), the deposit
+-- should be exactly the minUTxOValue.  This is the "inject (coin v) == v" case.
+-- Otherwise, we calculate the per-byte deposit by multiplying the minimum
+-- deposit (which is for the number of Shelley UTxO-entry bytes) by the size of
+-- a Shelley UTxO entry.  This is the "(mv * (utxoEntrySizeWithoutVal + uint))"
+-- calculation.  We then calculate the total deposit required for making a UTxO
+-- entry with a Val-class member v by dividing "(mv * (utxoEntrySizeWithoutVal +
+-- uint))" by the estimated total size of the UTxO entry containing v, ie by
+-- "(utxoEntrySizeWithoutVal + size v)".  See the formal specification for
+-- details.
+--
+-- This scaling function is right for UTxO, not EUTxO
+scaledMinDeposit :: Val v => v -> Coin -> Coin
+scaledMinDeposit v (Coin mv)
+  | isAdaOnly v = Coin mv -- without non-Coin assets, scaled deposit should be exactly minUTxOValue
+  -- The calculation should represent this equation
+  -- minValueParameter / coinUTxOSize = actualMinValue / valueUTxOSize
+  -- actualMinValue = (minValueParameter / coinUTxOSize) * valueUTxOSize
+  | otherwise = Coin $ max mv (coinsPerUTxOWord * (utxoEntrySizeWithoutVal + size v))
+  where
+    -- lengths obtained from tracing on HeapWords of inputs and outputs
+    -- obtained experimentally, and number used here
+    -- units are Word64s
+    txoutLenNoVal = 14
+    txinLen = 7
+
+    -- unpacked CompactCoin Word64 size in Word64s
+    coinSize :: Integer
+    coinSize = 0
+
+    utxoEntrySizeWithoutVal :: Integer
+    utxoEntrySizeWithoutVal = 6 + txoutLenNoVal + txinLen
+
+    -- how much ada does a Word64 of UTxO space cost, calculated from minAdaValue PP
+    -- round down
+    coinsPerUTxOWord :: Integer
+    coinsPerUTxOWord = quot mv (utxoEntrySizeWithoutVal + coinSize)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
@@ -21,8 +21,8 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (hashScript)
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
-import Cardano.Ledger.ShelleyMA.Rules (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
+import Cardano.Ledger.ShelleyMA.TxBody (scaledMinDeposit)
 import Cardano.Ledger.Slot (SlotNo (..))
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -32,9 +32,8 @@ import Cardano.Ledger.Shelley.Tx
     WitnessSetHKD (..),
   )
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
-import Cardano.Ledger.ShelleyMA.Rules (scaledMinDeposit)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..))
-import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (MATxBody))
+import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (MATxBody), scaledMinDeposit)
 import Cardano.Ledger.Val ((<+>))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -33,6 +33,7 @@ module Cardano.Ledger.Shelley.API.Wallet
     -- * Transaction helpers
     CLI (..),
     addKeyWitnesses,
+    evaluateTransactionFee,
     evaluateTransactionBalance,
     addShelleyKeyWitnesses,
     -- -- * Ada pots
@@ -471,43 +472,40 @@ class
   -- Used for the default implentation of 'evaluateTransactionBalance'.
   evaluateConsumed :: PParams era -> UTxO era -> TxBody era -> Value era
 
-  -- | Evaluate the fee for a given transaction.
-  evaluateTransactionFee ::
-    -- | The current protocol parameters.
-    PParams era ->
-    -- | The transaction.
-    Tx era ->
-    -- | The number of key witnesses still to be added to the transaction.
-    Word ->
-    -- | The required fee.
-    Coin
-  evaluateTransactionFee pp tx numKeyWits =
-    evaluateMinFee @era pp tx'
-    where
-      sigSize = fromIntegral $ sizeSigDSIGN (Proxy @(DSIGN (EraCrypto era)))
-      dummySig =
-        fromRight
-          (error "corrupt dummy signature")
-          (decodeFullDecoder "dummy signature" decodeSignedDSIGN (serialize $ LBS.replicate sigSize 0))
-      vkeySize = fromIntegral $ sizeVerKeyDSIGN (Proxy @(DSIGN (EraCrypto era)))
-      dummyVKey w =
-        let padding = LBS.replicate paddingSize 0
-            paddingSize = vkeySize - LBS.length sw
-            sw = serialize w
-            keyBytes = serialize $ padding <> sw
-         in fromRight (error "corrupt dummy vkey") (decodeFull keyBytes)
-      dummyKeyWits = Set.fromList $
-        flip map [1 .. numKeyWits] $
-          \x -> WitVKey (dummyVKey x) dummySig
-
-      tx' = addKeyWitnesses @era tx dummyKeyWits
-
   -- | Evaluate the minimum lovelace that a given transaction output must contain.
   evaluateMinLovelaceOutput :: PParams era -> TxOut era -> Coin
 
 addKeyWitnesses :: EraTx era => Tx era -> Set (WitVKey 'Witness (EraCrypto era)) -> Tx era
 addKeyWitnesses tx newWits = tx & witsTxL . addrWitsL %~ Set.union newWits
 
+-- | Evaluate the fee for a given transaction.
+evaluateTransactionFee ::
+  forall era.
+  CLI era =>
+  -- | The current protocol parameters.
+  PParams era ->
+  -- | The transaction.
+  Tx era ->
+  -- | The number of key witnesses still to be added to the transaction.
+  Word ->
+  -- | The required fee.
+  Coin
+evaluateTransactionFee pp tx numKeyWits = evaluateMinFee pp tx'
+  where
+    sigSize = fromIntegral $ sizeSigDSIGN (Proxy @(DSIGN (EraCrypto era)))
+    dummySig =
+      fromRight
+        (error "corrupt dummy signature")
+        (decodeFullDecoder "dummy signature" decodeSignedDSIGN (serialize $ LBS.replicate sigSize 0))
+    vkeySize = fromIntegral $ sizeVerKeyDSIGN (Proxy @(DSIGN (EraCrypto era)))
+    dummyVKey w =
+      let padding = LBS.replicate paddingSize 0
+          paddingSize = vkeySize - LBS.length sw
+          sw = serialize w
+          keyBytes = serialize $ padding <> sw
+       in fromRight (error "corrupt dummy vkey") (decodeFull keyBytes)
+    dummyKeyWits = Set.fromList [WitVKey (dummyVKey x) dummySig | x <- [1 .. numKeyWits]]
+    tx' = addKeyWitnesses tx dummyKeyWits
 
 -- | Evaluate the difference between the value currently being consumed by
 -- a transaction and the number of lovelace being produced.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -35,6 +35,7 @@ module Cardano.Ledger.Shelley.API.Wallet
     addKeyWitnesses,
     evaluateTransactionFee,
     evaluateTransactionBalance,
+    evaluateMinLovelaceOutput,
     addShelleyKeyWitnesses,
     -- -- * Ada pots
     AdaPots (..),
@@ -472,8 +473,10 @@ class
   -- Used for the default implentation of 'evaluateTransactionBalance'.
   evaluateConsumed :: PParams era -> UTxO era -> TxBody era -> Value era
 
-  -- | Evaluate the minimum lovelace that a given transaction output must contain.
-  evaluateMinLovelaceOutput :: PParams era -> TxOut era -> Coin
+-- | Evaluate the minimum lovelace that a given transaction output must contain.
+evaluateMinLovelaceOutput :: EraTxOut era => PParams era -> TxOut era -> Coin
+evaluateMinLovelaceOutput = getMinCoinTxOut
+{-# DEPRECATED evaluateMinLovelaceOutput "In favor of `getMinCoinTxOut`" #-}
 
 addKeyWitnesses :: EraTx era => Tx era -> Set (WitVKey 'Witness (EraCrypto era)) -> Tx era
 addKeyWitnesses tx newWits = tx & witsTxL . addrWitsL %~ Set.union newWits
@@ -546,8 +549,6 @@ instance CC.Crypto c => CLI (ShelleyEra c) where
   evaluateMinFee = minfee
 
   evaluateConsumed = coinConsumed
-
-  evaluateMinLovelaceOutput pp _out = _minUTxOValue pp
 
 --------------------------------------------------------------------------------
 -- CBOR instances

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -105,7 +105,7 @@ import Cardano.Ledger.Shelley.Delegation.Certificates
     PoolCert (..),
   )
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.PParams (Update, _minUTxOValue)
 import Cardano.Ledger.Shelley.PoolParams
 import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Ledger.TxIn (TxIn)
@@ -177,6 +177,8 @@ instance CC.Crypto crypto => EraTxOut (ShelleyEra crypto) where
 
   valueEitherTxOutL = valueEitherShelleyTxOutL
   {-# INLINE valueEitherTxOutL #-}
+
+  getMinCoinTxOut pp _ = _minUTxOValue pp
 
 addrEitherShelleyTxOutL ::
   Lens' (ShelleyTxOut era) (Either (Addr (EraCrypto era)) (CompactAddr (EraCrypto era)))

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -41,14 +41,17 @@ library
   hs-source-dirs: src
 
   exposed-modules:
+    Cardano.Ledger.Api.Era
     Cardano.Ledger.Api.Tx
     Cardano.Ledger.Api.Tx.Out
 
   build-depends:
-    cardano-ledger-core,
     cardano-ledger-alonzo,
     cardano-ledger-babbage,
+    cardano-ledger-conway,
+    cardano-ledger-core,
     cardano-ledger-shelley,
+    cardano-ledger-shelley-ma,
     microlens,
 
 test-suite cardano-ledger-api-test
@@ -66,9 +69,11 @@ test-suite cardano-ledger-api-test
     cardano-binary,
     cardano-ledger-api,
     cardano-ledger-core,
+    cardano-ledger-alonzo,
     cardano-ledger-babbage,
     cardano-ledger-babbage-test,
     cardano-ledger-conway,
+    cardano-ledger-shelley,
     microlens,
     tasty,
     tasty-quickcheck,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -1,0 +1,29 @@
+module Cardano.Ledger.Api.Era
+  ( -- * Eras
+
+    -- ** Shelley
+    ShelleyEra,
+
+    -- ** Shelley MA
+    ShelleyMAEra,
+    MaryEra,
+    AllegraEra,
+
+    -- ** Alonzo
+    AlonzoEra,
+
+    -- ** Babbage
+    BabbageEra,
+
+    -- ** Conway
+    ConwayEra,
+  )
+where
+
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.ShelleyMA (ShelleyMAEra)

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
@@ -11,14 +11,16 @@ module Test.Cardano.Ledger.Api.Tx.Out
 where
 
 import Cardano.Binary (serialize)
+import Cardano.Ledger.Alonzo.PParams hiding (PParams)
+import Cardano.Ledger.Api.Era
 import Cardano.Ledger.Api.Tx.Out
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.PParams hiding (PParams)
+import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Coin
-import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
-import Cardano.Ledger.Serialization (mkSized, sizedValue)
+import Cardano.Ledger.Shelley.PParams hiding (PParams)
+import qualified Cardano.Ledger.Val as Val
 import qualified Data.ByteString.Lazy as BSL
 import GHC.Records
 import Lens.Micro
@@ -27,60 +29,70 @@ import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
+propSetShelleyMinTxOut ::
+  forall era.
+  ( EraTxOut era,
+    Arbitrary (PParams era),
+    Arbitrary (TxOut era),
+    Show (PParams era),
+    AtMostEra MaryEra era,
+    HasField "_minUTxOValue" (PParams era) Coin
+  ) =>
+  TestTree
+propSetShelleyMinTxOut = testProperty "setShelleyMinTxOut" prop
+  where
+    _atMostMary = atMostEra @MaryEra @era
+    prop :: PParams era -> TxOut era -> Property
+    prop pp txOut =
+      within 1000000 $ -- just in case if there is a problem with termination
+        let txOut' = setMinCoinTxOut pp txOut
+            val = txOut' ^. valueTxOutL
+            minUTxOValue = unCoin $ getField @"_minUTxOValue" pp
+            minVal
+              | Val.isAdaOnly val = 0
+              | otherwise = (27 + Val.size val) * (minUTxOValue `quot` 27)
+         in Val.coin val === Coin (max minVal minUTxOValue)
+
+propSetAlonzoMinTxOut :: TestTree
+propSetAlonzoMinTxOut = testProperty "setAlonzoMinTxOut" prop
+  where
+    prop :: PParams (AlonzoEra StandardCrypto) -> TxOut (AlonzoEra StandardCrypto) -> Property
+    prop pp txOut =
+      within 1000000 $ -- just in case if there is a problem with termination
+        let txOut' = setMinCoinTxOut pp txOut
+            valSize = Val.size (txOut' ^. valueTxOutL)
+            dataHashSize = maybe 0 (const 10) $ strictMaybeToMaybe (txOut' ^. dataHashTxOutL)
+            sz = 27 + valSize + dataHashSize
+         in (txOut' ^. coinTxOutL) === Coin (sz * unCoin (getField @"_coinsPerUTxOWord" pp))
+
 propSetBabbageMinTxOut ::
   forall era.
   ( EraTxOut era,
+    Arbitrary (PParams era),
+    Arbitrary (TxOut era),
+    Show (PParams era),
     AtLeastEra BabbageEra era,
     HasField "_coinsPerUTxOByte" (PParams era) Coin
   ) =>
-  PParams era ->
-  TxOut era ->
-  Property
-propSetBabbageMinTxOut pp txOut =
-  within 1000000 $ -- just in case if there is a problem with termination
-    let txOut' = sizedValue (setMinCoinSizedTxOut pp (mkSized txOut))
-        size = toInteger (BSL.length (serialize txOut'))
-     in (txOut' ^. coinTxOutL)
-          === Coin ((160 + size) * unCoin (getField @"_coinsPerUTxOByte" pp))
+  TestTree
+propSetBabbageMinTxOut = testProperty "setBabbageMinTxOut" prop
   where
     _atLeastBabbage = atLeastEra @BabbageEra @era
-
-babbageTxOutTests ::
-  forall era.
-  ( Arbitrary (PParams era),
-    Arbitrary (TxOut era),
-    Show (PParams era),
-    EraTxOut era,
-    AtLeastEra BabbageEra era,
-    HasField "_coinsPerUTxOByte" (PParams era) Coin
-  ) =>
-  [TestTree]
-babbageTxOutTests =
-  [ testProperty "setBabbageMinTxOut" $ propSetBabbageMinTxOut @era
-  ]
-
-conwayTxOutTests ::
-  forall era.
-  ( Arbitrary (PParams era),
-    Arbitrary (TxOut era),
-    Show (PParams era),
-    EraTxOut era,
-    AtLeastEra BabbageEra era,
-    AtLeastEra ConwayEra era,
-    HasField "_coinsPerUTxOByte" (PParams era) Coin
-  ) =>
-  [TestTree]
-conwayTxOutTests =
-  concat
-    [ babbageTxOutTests @era
-    ]
-  where
-    _atLeastConway = atLeastEra @ConwayEra @era
+    prop :: PParams era -> TxOut era -> Property
+    prop pp txOut =
+      within 1000000 $ -- just in case if there is a problem with termination
+        let txOut' = setMinCoinTxOut pp txOut
+            sz = toInteger (BSL.length (serialize txOut'))
+         in (txOut' ^. coinTxOutL)
+              === Coin ((160 + sz) * unCoin (getField @"_coinsPerUTxOByte" pp))
 
 txOutTests :: TestTree
 txOutTests =
   testGroup "TxOut" $
-    concat
-      [ babbageTxOutTests @(BabbageEra StandardCrypto),
-        conwayTxOutTests @(ConwayEra StandardCrypto)
-      ]
+    [ testGroup "ShelleyEra" [propSetShelleyMinTxOut @(ShelleyEra StandardCrypto)],
+      testGroup "AllegraEra" [propSetShelleyMinTxOut @(AllegraEra StandardCrypto)],
+      testGroup "MaryEra" [propSetShelleyMinTxOut @(MaryEra StandardCrypto)],
+      testGroup "AlonzoEra" [propSetAlonzoMinTxOut],
+      testGroup "BabbageEra" [propSetBabbageMinTxOut @(BabbageEra StandardCrypto)],
+      testGroup "ConwayEra" [propSetBabbageMinTxOut @(ConwayEra StandardCrypto)]
+    ]

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Out.hs
@@ -38,7 +38,7 @@ propSetBabbageMinTxOut ::
   Property
 propSetBabbageMinTxOut pp txOut =
   within 1000000 $ -- just in case if there is a problem with termination
-    let txOut' = sizedValue (setBabbageMinTxOut pp (mkSized txOut))
+    let txOut' = sizedValue (setMinCoinSizedTxOut pp (mkSized txOut))
         size = toInteger (BSL.length (serialize txOut'))
      in (txOut' ^. coinTxOutL)
           === Coin ((160 + size) * unCoin (getField @"_coinsPerUTxOByte" pp))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Serialization.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Serialization.hs
@@ -357,7 +357,7 @@ mkSized a =
 sizedDecoder :: Decoder s a -> Decoder s (Sized a)
 sizedDecoder decoder = do
   Annotated v (ByteSpan start end) <- annotatedDecoder decoder
-  pure $ Sized v $! end - start
+  pure $! Sized v $! end - start
 
 instance FromCBOR a => FromCBOR (Sized a) where
   fromCBOR = sizedDecoder fromCBOR

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -81,13 +81,13 @@ import Cardano.Ledger.Pretty
 import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API
-  ( CLI (..),
-    DPState (..),
+  ( DPState (..),
     DState (..),
     LedgerState (..),
     PoolParams (..),
     ProtVer (..),
     UTxO (..),
+    evaluateTransactionFee,
   )
 import Cardano.Ledger.Shelley.BlockChain (bBodySize)
 import Cardano.Ledger.Shelley.LedgerState


### PR DESCRIPTION
This PR essentially moves the implementation of `evaluateMinLovelaceOutput` into `EraTxOurt` as a newly named function(s) `getMinCoinTxOut`/`getMinCoinSizedTxOut` and makes use of it both in UTXO rules and in the external API.