### PR TITLE
Consolidate and deprecate minfee and allOuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ in the naming of release branches.
 
 - Start on the `cardano-ledger-api` package and implement
   `setMinCoinTxOut`+`setMinCoinSizedTxOut`: #2995
-- Added `getMinCoinTxOut`/`getMinCoinSizedTxOut`: #3008
-- Added `getMinFeeTx`
+- Added `getMinCoinTxOut`/`getMinCoinSizedTxOut` to `EraTxOut`: #3008
+- Added `getMinFeeTx` to `EraTx`
+- Added `datumTxOutF` to `AlonzoEraTxOut`
 
 ### Changed
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
@@ -26,9 +27,10 @@ in the naming of release branches.
 
 - Deprecated the `validPlutusdata` function: #3006
 - Deprecated the misspelled `HasAlgorithm` type alias: #3007
-- Deprecated `evaluateMinLovelaceOutput` in favor of newly added
-  `getMinCoinTxOut`/`getMinCoinSizedTxOut` #3008
-- Deprecated `minfee` and `evaluateMinfee` in favor of new `getMinFeeTx`
+- Deprecated `CLI.evaluateMinLovelaceOutput` in favor of newly added
+  `EraTxOut.getMinCoinTxOut`/`EraTxOut.getMinCoinSizedTxOut` #3008
+- Deprecated `minfee` and `CLI.evaluateMinfee` in favor of new `EraTx.getMinFeeTx`
+- Deprecated `ExtendedUTxO.getTxOutDatum` in favor of new `AlonzoEraTxOut.datumTxOutF`
 
 ## Release branch 1.1.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ in the naming of release branches.
 - Added `getMinCoinTxOut`/`getMinCoinSizedTxOut` to `EraTxOut`: #3008
 - Added `getMinFeeTx` to `EraTx`
 - Added `datumTxOutF` to `AlonzoEraTxOut`
+- Added `allInputsTxBodyF`
 
 ### Changed
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
@@ -31,6 +32,8 @@ in the naming of release branches.
   `EraTxOut.getMinCoinTxOut`/`EraTxOut.getMinCoinSizedTxOut` #3008
 - Deprecated `minfee` and `CLI.evaluateMinfee` in favor of new `EraTx.getMinFeeTx`
 - Deprecated `ExtendedUTxO.getTxOutDatum` in favor of new `AlonzoEraTxOut.datumTxOutF`
+- Removed `ExtendedUTxO.allOuts` and `ExtendedUTxO.allSizedOuts` in favor of
+  `BabbageEraTxBody.allInputsTxBodyF`
 
 ## Release branch 1.1.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ in the naming of release branches.
 - Start on the `cardano-ledger-api` package and implement
   `setMinCoinTxOut`+`setMinCoinSizedTxOut`: #2995
 - Added `getMinCoinTxOut`/`getMinCoinSizedTxOut`: #3008
+- Added `getMinFeeTx`
 
 ### Changed
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
@@ -25,8 +26,9 @@ in the naming of release branches.
 
 - Deprecated the `validPlutusdata` function: #3006
 - Deprecated the misspelled `HasAlgorithm` type alias: #3007
-- Deprecate `evaluateMinLovelaceOutput` in favor of newly added
+- Deprecated `evaluateMinLovelaceOutput` in favor of newly added
   `getMinCoinTxOut`/`getMinCoinSizedTxOut` #3008
+- Deprecated `minfee` and `evaluateMinfee` in favor of new `getMinFeeTx`
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -32,7 +32,7 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData, Datum (..))
+import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData)
 import qualified Cardano.Ledger.Alonzo.Data (AuxiliaryData)
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Genesis
@@ -116,10 +116,6 @@ instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
           SJust dh <- [txOut ^. dataHashTxOutL]
       ]
   getDatum = getDatumAlonzo
-  getTxOutDatum txOut =
-    case txOut ^. dataHashTxOutL of
-      SNothing -> NoDatum
-      SJust dh -> DatumHash dh
   allOuts txBody = toList $ txBody ^. outputsTxBodyL
   allSizedOuts = map mkSized . allOuts
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -45,7 +45,7 @@ import qualified Cardano.Ledger.Alonzo.PParams (PParams)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (getDatumAlonzo)
 import Cardano.Ledger.Alonzo.Rules ()
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
-import Cardano.Ledger.Alonzo.Tx (alonzoInputHashes, minfee)
+import Cardano.Ledger.Alonzo.Tx (alonzoInputHashes)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..), AlonzoTxBody, AlonzoTxOut)
 import qualified Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo)
@@ -103,8 +103,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (AlonzoEra c) where
   initialState = API.initialStateFromGenesis extendPPWithGenesis
 
 instance CC.Crypto c => API.CLI (AlonzoEra c) where
-  evaluateMinFee = minfee
-
   evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -56,7 +56,6 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
-import Cardano.Ledger.Serialization (mkSized)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.API.Mempool
 import Cardano.Ledger.ShelleyMA.Rules (consumed)
@@ -112,12 +111,10 @@ instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   getAllowedSupplimentalDataHashes txBody _ =
     Set.fromList
       [ dh
-        | txOut <- allOuts txBody,
+        | txOut <- toList $ txBody ^. outputsTxBodyL,
           SJust dh <- [txOut ^. dataHashTxOutL]
       ]
   getDatum = getDatumAlonzo
-  allOuts txBody = toList $ txBody ^. outputsTxBodyL
-  allSizedOuts = map mkSized . allOuts
 
 -- Self-Describing type synomyms
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -20,8 +20,9 @@ import Cardano.Ledger.Alonzo.Scripts
     getEvaluationContext,
   )
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, ScriptPurpose (..), rdptr)
+import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..))
 import Cardano.Ledger.Alonzo.TxInfo
-  ( ExtendedUTxO (getTxOutDatum, txscripts),
+  ( ExtendedUTxO (txscripts),
     TranslationError,
     VersionedTxInfo (..),
     exBudgetToExUnits,
@@ -169,7 +170,7 @@ evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels = do
       args <- case sp of
         Spending txin -> do
           txOut <- note (UnknownTxIn txin) $ Map.lookup txin (unUTxO utxo)
-          datum <- case getTxOutDatum txOut of
+          datum <- case txOut ^. datumTxOutF of
             Datum binaryData -> pure $ binaryDataToData binaryData
             DatumHash dh -> note (MissingDatum dh) $ Map.lookup dh dats
             NoDatum -> Left (InvalidTxIn txin)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -105,7 +105,6 @@ import Cardano.Ledger.Keys (KeyHash (..), hashKey)
 import Cardano.Ledger.Language (Language (..))
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.SafeHash (SafeHash, extractHash, hashAnnotated)
-import Cardano.Ledger.Serialization (Sized (sizedValue))
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
@@ -483,15 +482,6 @@ class ExtendedUTxO era where
     UTxO era ->
     ScriptPurpose (EraCrypto era) ->
     Maybe (Data era)
-
-  allOuts ::
-    TxBody era ->
-    [TxOut era]
-  allOuts = map sizedValue . allSizedOuts
-
-  allSizedOuts ::
-    TxBody era ->
-    [Sized (TxOut era)]
 
 getTxOutDatum :: AlonzoEraTxOut era => TxOut era -> Datum era
 getTxOutDatum txOut = txOut ^. datumTxOutF

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -59,6 +59,7 @@ module Cardano.Ledger.Alonzo.TxInfo
     languages,
     -- DEPRECATED
     validPlutusdata,
+    getTxOutDatum,
   )
 where
 
@@ -67,8 +68,7 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull')
 import Cardano.Crypto.Hash.Class (Hash, hashToBytes)
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
-import Cardano.Ledger.Alonzo.Data (Data (..), Datum (..), getPlutusData)
-import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.Data (Data (..), Datum, getPlutusData)
 import Cardano.Ledger.Alonzo.Scripts
   ( AlonzoScript (..),
     ExUnits (..),
@@ -102,6 +102,7 @@ import Cardano.Ledger.Credential
   )
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..), hashKey)
+import Cardano.Ledger.Language (Language (..))
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.SafeHash (SafeHash, extractHash, hashAnnotated)
 import Cardano.Ledger.Serialization (Sized (sizedValue))
@@ -483,9 +484,6 @@ class ExtendedUTxO era where
     ScriptPurpose (EraCrypto era) ->
     Maybe (Data era)
 
-  getTxOutDatum ::
-    TxOut era -> Datum era
-
   allOuts ::
     TxBody era ->
     [TxOut era]
@@ -494,6 +492,10 @@ class ExtendedUTxO era where
   allSizedOuts ::
     TxBody era ->
     [Sized (TxOut era)]
+
+getTxOutDatum :: AlonzoEraTxOut era => TxOut era -> Datum era
+getTxOutDatum txOut = txOut ^. datumTxOutF
+{-# DEPRECATED getTxOutDatum "In favor of `datumTxOutF`" #-}
 
 alonzoTxInfo ::
   forall era.

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -41,7 +41,6 @@ import Cardano.Ledger.Alonzo.Tx
     IsValid (..),
     ScriptPurpose (..),
     hashScriptIntegrity,
-    minfee,
     rdptr,
     totExUnits,
   )
@@ -436,7 +435,7 @@ instance Mock c => EraGen (AlonzoEra c) where
 
   genEraDone pp tx =
     let theFee = tx ^. bodyTxL . feeTxBodyL -- Coin supplied to pay fees
-        minimumFee = minfee @(AlonzoEra c) pp tx
+        minimumFee = getMinFeeTx @(AlonzoEra c) pp tx
      in if minimumFee <= theFee
           then pure tx
           else myDiscard "MinFeee violation: genEraDne: AlonzoEraGen.hs"

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -24,12 +24,11 @@ import Cardano.Ledger.Alonzo.PParams
     getLanguageView,
   )
 import Cardano.Ledger.Alonzo.Scripts (CostModel, CostModels (..), Prices (..), mkCostModel)
-import Cardano.Ledger.Alonzo.Tx (minfee)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), utxoEntrySize)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), boundRational)
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Era (EraSegWits (..))
+import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Value (MaryValue (..), valueFromList)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Codec.CBOR.Read (deserialiseFromBytes)
@@ -220,7 +219,7 @@ goldenMinFee =
             prices = Prices priceMem priceSteps
             pp = emptyPParams {_minfeeA = 44, _minfeeB = 155381, _prices = prices}
 
-        Coin 1006053 @?= minfee pp firstTx
+        Coin 1006053 @?= getMinFeeTx pp firstTx
     ]
 
 fromRightError :: (HasCallStack, Show a) => String -> Either a b -> b

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Babbage.Tx
     getDatumBabbage,
   )
 import Cardano.Ledger.Babbage.TxBody
-  ( BabbageEraTxBody (referenceInputsTxBodyL, sizedCollateralReturnTxBodyL, sizedOutputsTxBodyL),
+  ( BabbageEraTxBody (..),
     BabbageTxBody,
     BabbageTxOut,
     TxBody,
@@ -49,6 +49,7 @@ import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
+import Cardano.Ledger.Serialization (sizedValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Rules (consumed)
@@ -80,15 +81,10 @@ instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
   getAllowedSupplimentalDataHashes txBody (UTxO utxo) =
     Set.fromList [dh | txOut <- outs, SJust dh <- [txOut ^. dataHashTxOutL]]
     where
-      newOuts = allOuts txBody
+      newOuts = map sizedValue $ toList $ txBody ^. allSizedOutputsTxBodyF
       referencedOuts = Map.elems $ Map.restrictKeys utxo (txBody ^. referenceInputsTxBodyL)
       outs = newOuts <> referencedOuts
   getDatum = getDatumBabbage
-  allSizedOuts txBody = toList (txBody ^. sizedOutputsTxBodyL) <> collOuts
-    where
-      collOuts = case txBody ^. sizedCollateralReturnTxBodyL of
-        SNothing -> []
-        SJust x -> [x]
 
 -- Self-Describing type synomyms
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Babbage.Tx
   ( babbageInputDataHashes,
     babbageTxScripts,
     getDatumBabbage,
-    minfee,
   )
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (referenceInputsTxBodyL, sizedCollateralReturnTxBodyL, sizedOutputsTxBodyL),
@@ -72,8 +71,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (BabbageEra c) where
   initialState = API.initialStateFromGenesis extendPPWithGenesis
 
 instance CC.Crypto c => API.CLI (BabbageEra c) where
-  evaluateMinFee = minfee
-
   evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -40,7 +40,7 @@ import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (referenceInputsTxBodyL, sizedCollateralReturnTxBodyL, sizedOutputsTxBodyL),
     BabbageTxBody,
-    BabbageTxOut (BabbageTxOut),
+    BabbageTxOut,
     TxBody,
     TxOut,
     dataHashTxOutL,
@@ -84,7 +84,6 @@ instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
       referencedOuts = Map.elems $ Map.restrictKeys utxo (txBody ^. referenceInputsTxBodyL)
       outs = newOuts <> referencedOuts
   getDatum = getDatumBabbage
-  getTxOutDatum (BabbageTxOut _ _ datum _) = datum
   allSizedOuts txBody = toList (txBody ^. sizedOutputsTxBodyL) <> collOuts
     where
       collOuts = case txBody ^. sizedCollateralReturnTxBodyL of

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -40,7 +40,6 @@ import Cardano.Ledger.Alonzo.Rules
 import Cardano.Ledger.Alonzo.Scripts (ExUnits)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (collateralInputsTxBodyL))
-import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (allOuts, allSizedOuts))
 import Cardano.Ledger.Alonzo.TxWitness (AlonzoEraWitnesses, TxWitness (..), nullRedeemers)
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Era (BabbageUTXO)
@@ -95,7 +94,7 @@ import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Coders
 import Data.Coerce (coerce)
-import Data.Foldable (Foldable (foldl'), sequenceA_)
+import Data.Foldable (Foldable (foldl'), sequenceA_, toList)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
@@ -343,8 +342,7 @@ utxoTransition ::
     Environment (EraRule "UTXOS" era) ~ UtxoEnv era,
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
-    Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era)),
-    ExtendedUTxO era
+    Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   TransitionRule (BabbageUTXO era)
 utxoTransition = do
@@ -383,19 +381,20 @@ utxoTransition = do
   {-   adaID ∉ supp mint tx  - check not needed because mint field of type MultiAsset cannot contain ada  -}
 
   {-   ∀ txout ∈ allOuts txb, getValue txout ≥ inject (serSize txout ∗ coinsPerUTxOByte pp) -}
-  runTest $ validateOutputTooSmallUTxO pp $ allSizedOuts txBody
+  let allSizedOutputs = toList (txBody ^. allSizedOutputsTxBodyF)
+  runTest $ validateOutputTooSmallUTxO pp allSizedOutputs
 
-  let outs = allOuts txBody
+  let allOutputs = fmap sizedValue allSizedOutputs
   {-   ∀ txout ∈ allOuts txb, serSize (getValue txout) ≤ maxValSize pp   -}
-  runTest $ validateOutputTooBigUTxO pp outs
+  runTest $ validateOutputTooBigUTxO pp allOutputs
 
   {- ∀ ( _ ↦ (a,_)) ∈ allOuts txb,  a ∈ Addrbootstrap → bootstrapAttrsSize a ≤ 64 -}
-  runTestOnSignal $ Shelley.validateOutputBootAddrAttrsTooBig outs
+  runTestOnSignal $ Shelley.validateOutputBootAddrAttrsTooBig allOutputs
 
   netId <- liftSTS $ asks networkId
 
   {- ∀(_ → (a, _)) ∈ allOuts txb, netId a = NetworkId -}
-  runTestOnSignal $ Shelley.validateWrongNetwork netId outs
+  runTestOnSignal $ Shelley.validateWrongNetwork netId allOutputs
 
   {- ∀(a → ) ∈ txwdrls txb, netId a = NetworkId -}
   runTestOnSignal $ Shelley.validateWrongNetworkWithdrawal netId txBody
@@ -442,8 +441,7 @@ instance
     State (EraRule "UTXOS" era) ~ Shelley.UTxOState era,
     Signal (EraRule "UTXOS" era) ~ Tx era,
     Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era)),
-    PredicateFailure (EraRule "UTXO" era) ~ BabbageUtxoPredFailure era,
-    ExtendedUTxO era
+    PredicateFailure (EraRule "UTXO" era) ~ BabbageUtxoPredFailure era
   ) =>
   STS (BabbageUTXO era)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Alonzo.TxWitness
     unTxDats,
   )
 import Cardano.Ledger.Babbage.Era (BabbageEra)
+import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (..),
     BabbageEraTxOut (..),
@@ -74,6 +75,8 @@ instance CC.Crypto c => EraTx (BabbageEra c) where
 
   validateScript (Phase1Script script) tx = validateTimelock @(BabbageEra c) script tx
   {-# INLINE validateScript #-}
+
+  getMinFeeTx = alonzoMinFeeTx
 
 instance CC.Crypto c => AlonzoEraTx (BabbageEra c) where
   {-# SPECIALIZE instance AlonzoEraTx (BabbageEra CC.StandardCrypto) #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Conway.Genesis (extendPPWithGenesis)
 import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxBody (BabbageEraTxBody (..))
-import Cardano.Ledger.Conway.TxOut (AlonzoEraTxOut (..), BabbageTxOut (..))
+import Cardano.Ledger.Conway.TxOut (AlonzoEraTxOut (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
@@ -64,7 +64,6 @@ instance CC.Crypto c => ExtendedUTxO (ConwayEra c) where
       referencedOuts = Map.elems $ Map.restrictKeys utxo (txBody ^. referenceInputsTxBodyL)
       outs = newOuts <> referencedOuts
   getDatum = getDatumBabbage
-  getTxOutDatum (BabbageTxOut _ _ datum _) = datum
   allSizedOuts txBody = toList (txBody ^. sizedOutputsTxBodyL) <> collOuts
     where
       collOuts = case txBody ^. sizedCollateralReturnTxBodyL of

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.Conway.TxOut (AlonzoEraTxOut (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
+import Cardano.Ledger.Serialization (sizedValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.ShelleyMA.Rules (consumed)
@@ -60,12 +61,7 @@ instance CC.Crypto c => ExtendedUTxO (ConwayEra c) where
   getAllowedSupplimentalDataHashes txBody (UTxO utxo) =
     Set.fromList [dh | txOut <- outs, SJust dh <- [txOut ^. dataHashTxOutL]]
     where
-      newOuts = allOuts txBody
+      newOuts = map sizedValue $ toList $ txBody ^. allSizedOutputsTxBodyF
       referencedOuts = Map.elems $ Map.restrictKeys utxo (txBody ^. referenceInputsTxBodyL)
       outs = newOuts <> referencedOuts
   getDatum = getDatumBabbage
-  allSizedOuts txBody = toList (txBody ^. sizedOutputsTxBodyL) <> collOuts
-    where
-      collOuts = case txBody ^. sizedCollateralReturnTxBodyL of
-        SNothing -> []
-        SJust x -> [x]

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Babbage.Tx
   ( babbageInputDataHashes,
     babbageTxScripts,
     getDatumBabbage,
-    minfee,
   )
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import Cardano.Ledger.Conway.Era (ConwayEra)
@@ -52,8 +51,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (ConwayEra c) where
   initialState = API.initialStateFromGenesis extendPPWithGenesis
 
 instance CC.Crypto c => API.CLI (ConwayEra c) where
-  evaluateMinFee = minfee
-
   evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -9,7 +9,8 @@ module Cardano.Ledger.Conway.Tx
 where
 
 import Cardano.Ledger.Alonzo.Tx
-  ( auxDataAlonzoTxL,
+  ( alonzoMinFeeTx,
+    auxDataAlonzoTxL,
     bodyAlonzoTxL,
     isValidAlonzoTxL,
     mkBasicAlonzoTx,
@@ -25,6 +26,7 @@ import Cardano.Ledger.Babbage.Tx as BabbageTxReExport
     AlonzoTx (..),
   )
 import Cardano.Ledger.Conway.Era (ConwayEra)
+import qualified Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.TxBody ()
 import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.Core
@@ -52,6 +54,8 @@ instance CC.Crypto c => EraTx (ConwayEra c) where
 
   validateScript (Phase1Script script) tx = validateTimelock @(ConwayEra c) script tx
   {-# INLINE validateScript #-}
+
+  getMinFeeTx = alonzoMinFeeTx
 
 instance CC.Crypto c => AlonzoEraTx (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTx (ConwayEra CC.StandardCrypto) #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -17,6 +17,7 @@ where
 
 import Cardano.Ledger.Babbage.TxBody
   ( allInputsBabbageTxBodyF,
+    allSizedOutputsBabbageTxBodyF,
     auxDataHashBabbageTxBodyL,
     certsBabbageTxBodyL,
     collateralInputsBabbageTxBodyL,
@@ -135,3 +136,6 @@ instance CC.Crypto c => BabbageEraTxBody (ConwayEra c) where
 
   sizedCollateralReturnTxBodyL = sizedCollateralReturnBabbageTxBodyL
   {-# INLINE sizedCollateralReturnTxBodyL #-}
+
+  allSizedOutputsTxBodyF = allSizedOutputsBabbageTxBodyF
+  {-# INLINE allSizedOutputsTxBodyF #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
@@ -17,9 +17,11 @@ where
 import Cardano.Ledger.Alonzo.Data (Datum (NoDatum))
 import Cardano.Ledger.Babbage.TxBody
   ( addrEitherBabbageTxOutL,
+    babbageMinUTxOValue,
     dataBabbageTxOutL,
     dataHashBabbageTxOutL,
     datumBabbageTxOutL,
+    getDatumBabbageTxOut,
     referenceScriptBabbageTxOutL,
     valueEitherBabbageTxOutL,
   )
@@ -27,7 +29,6 @@ import Cardano.Ledger.Babbage.TxBody as BabbageTxOutReExports
   ( AlonzoEraTxOut (..),
     BabbageEraTxOut (..),
     BabbageTxOut (..),
-    babbageMinUTxOValue,
   )
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
@@ -35,6 +36,7 @@ import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC
 import Data.Maybe.Strict (StrictMaybe (..))
+import Lens.Micro
 
 instance CC.Crypto c => EraTxOut (ConwayEra c) where
   {-# SPECIALIZE instance EraTxOut (ConwayEra CC.StandardCrypto) #-}
@@ -56,6 +58,9 @@ instance CC.Crypto c => AlonzoEraTxOut (ConwayEra c) where
 
   dataHashTxOutL = dataHashBabbageTxOutL
   {-# INLINE dataHashTxOutL #-}
+
+  datumTxOutF = to getDatumBabbageTxOut
+  {-# INLINE datumTxOutF #-}
 
 instance CC.Crypto c => BabbageEraTxOut (ConwayEra c) where
   {-# SPECIALIZE instance BabbageEraTxOut (ConwayEra CC.StandardCrypto) #-}

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -24,11 +24,9 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable)
 import Cardano.Ledger.Shelley.API hiding (PParams, Tx, TxBody, TxOut, WitnessSet)
-import Cardano.Ledger.Shelley.LedgerState (minfee)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import Cardano.Ledger.ShelleyMA
-import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed)
-import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
+import Cardano.Ledger.ShelleyMA.Rules (consumed)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody ()
 
@@ -50,8 +48,6 @@ instance CC.Crypto crypto => CanStartFromGenesis (AllegraEra crypto) where
   initialState = initialStateFromGenesis const
 
 instance CC.Crypto c => CLI (AllegraEra c) where
-  evaluateMinFee = minfee
-
   evaluateConsumed = consumed
 
 -- Self-Describing type synomyms

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -33,13 +33,11 @@ import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley.API hiding (TxBody)
-import Cardano.Ledger.Shelley.LedgerState (minfee)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import qualified Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData)
-import Cardano.Ledger.ShelleyMA.Rules.Utxo (consumed)
-import Cardano.Ledger.ShelleyMA.Rules.Utxow ()
+import Cardano.Ledger.ShelleyMA.Rules (consumed)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 
 instance
@@ -54,8 +52,6 @@ instance CC.Crypto c => CanStartFromGenesis (MaryEra c) where
   initialState = initialStateFromGenesis const
 
 instance CC.Crypto c => CLI (MaryEra c) where
-  evaluateMinFee = minfee
-
   evaluateConsumed = consumed
 
 -- Self-Describing type synomyms

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -175,8 +175,6 @@ utxoTransition ::
     Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
-    HasField "_minfeeA" (PParams era) Natural,
-    HasField "_minfeeB" (PParams era) Natural,
     HasField "_keyDeposit" (PParams era) Coin,
     HasField "_poolDeposit" (PParams era) Coin,
     HasField "_maxTxSize" (PParams era) Natural

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
@@ -16,6 +16,7 @@ where
 import Cardano.Ledger.Core (EraTx (..), EraWitnesses (..), PhasedScript (..))
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.Tx
   ( ShelleyTx,
     ShelleyWitnesses,
@@ -25,6 +26,7 @@ import Cardano.Ledger.Shelley.Tx
     bootAddrShelleyWitsL,
     mkBasicShelleyTx,
     scriptShelleyWitsL,
+    shelleyMinFeeTx,
     sizeShelleyTxF,
     witsShelleyTxL,
   )
@@ -59,6 +61,8 @@ instance MAClass ma crypto => EraTx (ShelleyMAEra ma crypto) where
 
   validateScript (Phase1Script script) tx = validateTimelock @(ShelleyMAEra ma crypto) script tx
   {-# INLINE validateScript #-}
+
+  getMinFeeTx = shelleyMinFeeTx
 
 -- =======================================================
 -- Validating timelock scripts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -465,7 +465,6 @@ class
   ) =>
   CLI era
   where
-
   -- | The consumed calculation.
   -- Used for the default implentation of 'evaluateTransactionBalance'.
   evaluateConsumed :: PParams era -> UTxO era -> TxBody era -> Value era
@@ -549,9 +548,7 @@ addShelleyKeyWitnesses = addKeyWitnesses
 {-# DEPRECATED addShelleyKeyWitnesses "In favor of 'addKeyWitnesses'" #-}
 
 instance CC.Crypto c => CLI (ShelleyEra c) where
-
   evaluateConsumed = coinConsumed
-
 
 --------------------------------------------------------------------------------
 -- CBOR instances

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -77,7 +77,6 @@ import Cardano.Ledger.Shelley.Tx
   ( ShelleyTx (..),
     ShelleyTxOut (..),
     TxIn,
-    minfee,
   )
 import Cardano.Ledger.Shelley.TxBody
   ( PoolParams,
@@ -369,8 +368,6 @@ utxoInductive ::
     Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     Signal (EraRule "PPUP" era) ~ Maybe (Update era),
-    HasField "_minfeeA" (PParams era) Natural,
-    HasField "_minfeeB" (PParams era) Natural,
     HasField "_keyDeposit" (PParams era) Coin,
     HasField "_poolDeposit" (PParams era) Coin,
     HasField "_maxTxSize" (PParams era) Natural
@@ -453,17 +450,14 @@ validateInputSetEmptyUTxO txb =
 --
 -- > minfee pp tx ≤ txfee txb
 validateFeeTooSmallUTxO ::
-  ( EraTx era,
-    HasField "_minfeeA" (PParams era) Natural,
-    HasField "_minfeeB" (PParams era) Natural
-  ) =>
+  EraTx era =>
   PParams era ->
   Tx era ->
   Test (ShelleyUtxoPredFailure era)
 validateFeeTooSmallUTxO pp tx =
   failureUnless (minFee <= txFee) $ FeeTooSmallUTxO minFee txFee
   where
-    minFee = minfee pp tx
+    minFee = getMinFeeTx pp tx
     txFee = txb ^. feeTxBodyL
     txb = tx ^. bodyTxL
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -46,7 +46,6 @@ import Cardano.Ledger.Shelley.LedgerState
     LedgerState (..),
     UTxOState (..),
     dpsDState,
-    minfee,
     ptrsMap,
     rewards,
   )
@@ -346,7 +345,7 @@ genNextDelta
   tx
   _count -- the counter of the fix loop
   delta@(Delta dfees extraInputs extraWitnesses change _ extraScripts) =
-    let !baseTxFee = minfee pparams tx
+    let !baseTxFee = getMinFeeTx pparams tx
         -- based on the current contents of delta, how much will the fee
         -- increase when we add the delta to the tx?
         draftSize =

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -21,10 +21,8 @@ import Cardano.Ledger.BaseTypes
     textToUrl,
   )
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (hashAuxiliaryData, hashScript, sizeTxF)
+import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as Cr
-import Cardano.Ledger.Era (Era (..))
-import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys
   ( DSignable,
     Hash,
@@ -53,7 +51,6 @@ import Cardano.Ledger.Shelley.API
     hashVerKeyVRF,
   )
 import qualified Cardano.Ledger.Shelley.API as API
-import Cardano.Ledger.Shelley.LedgerState (minfee)
 import qualified Cardano.Ledger.Shelley.Metadata as MD
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..), emptyPParams)
 import Cardano.Ledger.Shelley.Tx
@@ -511,7 +508,7 @@ testEvaluateTransactionFee =
     pp
     txSimpleUTxONoWit
     1
-    @?= minfee pp (txSimpleUTxO @StandardCrypto)
+    @?= getMinFeeTx pp (txSimpleUTxO @StandardCrypto)
   where
     pp = emptyPParams {_minfeeA = 1, _minfeeB = 1}
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -155,6 +155,8 @@ class
 
   validateScript :: PhasedScript 'PhaseOne era -> Tx era -> Bool
 
+  getMinFeeTx :: PParams era -> Tx era -> Coin
+
 class
   ( EraTxOut era,
     EraPParams era,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/TwoPhaseValidation.hs
@@ -41,7 +41,6 @@ import Cardano.Ledger.Alonzo.Tx
   ( AlonzoTx (..),
     IsValid (..),
     ScriptPurpose (..),
-    minfee,
   )
 import Cardano.Ledger.Alonzo.TxInfo (TranslationError, VersionedTxInfo, txInfo, valContext)
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr (..), Redeemers (..), TxDats (..), unRedeemers)
@@ -1888,7 +1887,7 @@ testEvaluateTransactionFee =
     pparams
     validatingTxNoWits
     1
-    @?= minfee pparams (validatingTx pf)
+    @?= getMinFeeTx pparams (validatingTx pf)
   where
     pf = Alonzo Mock
     pparams = newPParams pf $ defaultPPs ++ [MinfeeA 1]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams, AlonzoPParamsHKD (..))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (scriptsNeededFromBody)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..), minfee)
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), collateral')
 import Cardano.Ledger.Alonzo.TxInfo (languages)
 import Cardano.Ledger.Babbage.PParams (BabbagePParams)
@@ -46,7 +46,6 @@ import Cardano.Ledger.Shelley.LedgerState
     NewEpochState (..),
     UTxOState (..),
   )
-import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (minfee)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.Rewards (Reward, aggregateRewards)
 import Cardano.Ledger.Shelley.TxBody
@@ -221,14 +220,6 @@ scriptsNeeded' (Alonzo _) utxo txbody = Set.fromList (map snd (scriptsNeededFrom
 scriptsNeeded' p@(Mary _) utxo txbody = scriptsNeeded (UTxO utxo) (updateTx p (initialTx p) (Body txbody))
 scriptsNeeded' p@(Allegra _) utxo txbody = scriptsNeeded (UTxO utxo) (updateTx p (initialTx p) (Body txbody))
 scriptsNeeded' p@(Shelley _) utxo txbody = scriptsNeeded (UTxO utxo) (updateTx p (initialTx p) (Body txbody))
-
-minfee' :: forall era. Proof era -> PParams era -> Tx era -> Coin
-minfee' (Alonzo _) = minfee
-minfee' (Conway _) = minfee
-minfee' (Babbage _) = minfee
-minfee' (Mary _) = Shelley.minfee
-minfee' (Allegra _) = Shelley.minfee
-minfee' (Shelley _) = Shelley.minfee
 
 txInBalance ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -935,7 +935,7 @@ genAlonzoTxAndInfo proof slot = do
             Valid isValid,
             AuxData' []
           ]
-      fee = minfee' proof gePParams bogusTxForFeeCalc
+      fee = getMinFeeTx gePParams bogusTxForFeeCalc
       deposits = depositsAndRefunds proof gePParams dcerts
 
   -- 8. Crank up the amount in one of outputs to account for the fee and deposits. Note


### PR DESCRIPTION
We have these classes `CLI` and `ExtendedUTxO` that bunch together somewhat related functions. However now we have type classes that could consume functionality from those classes in a more related fashion.

Also we have multiple functions with the same name like `minfee` which are used in different eras, which has caused bugs on multiple occasions. Here we adopt a type class approach to avoid such bugs in the future

- Deprecated `minfee` and `CLI.evaluateMinfee` in favor of new `EraTx.getMinFeeTx`
- Deprecated `ExtendedUTxO.getTxOutDatum` in favor of new `AlonzoEraTxOut.datumTxOutF`
- Removed `ExtendedUTxO.allOuts` and `ExtendedUTxO.allSizedOuts` in favor of
  `BabbageEraTxBody.allInputsTxBodyF`