### PR TITLE
Fix overloaded function name `consumed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ in the naming of release branches.
 - Added `getMinFeeTx` to `EraTx`
 - Added `datumTxOutF` to `AlonzoEraTxOut`
 - Added `allInputsTxBodyF`
+- Added `EraUTxO` class with `getConsumedValue`
 
 ### Changed
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
@@ -34,6 +35,8 @@ in the naming of release branches.
 - Deprecated `ExtendedUTxO.getTxOutDatum` in favor of new `AlonzoEraTxOut.datumTxOutF`
 - Removed `ExtendedUTxO.allOuts` and `ExtendedUTxO.allSizedOuts` in favor of
   `BabbageEraTxBody.allInputsTxBodyF`
+- Deprecated `consumed` and `evaluateConsumed` in favor of new `EraUTxO.getConsumedValue`
+- Removed `CLI` class
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -58,6 +58,7 @@ library
     Cardano.Ledger.Alonzo.Rules.Utxo
     Cardano.Ledger.Alonzo.Rules.Utxos
     Cardano.Ledger.Alonzo.Rules.Utxow
+    Cardano.Ledger.Alonzo.UTxO
   build-depends:
     aeson >= 2,
     array,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -50,6 +50,7 @@ import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..), AlonzoTxBody, AlonzoTx
 import qualified Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..))
+import Cardano.Ledger.Alonzo.UTxO ()
 import Cardano.Ledger.BaseTypes (Globals)
 import Cardano.Ledger.Core hiding (PParamsDelta, Value)
 import qualified Cardano.Ledger.Crypto as CC
@@ -58,7 +59,6 @@ import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.API.Mempool
-import Cardano.Ledger.ShelleyMA.Rules (consumed)
 import Control.Arrow (left)
 import Control.Monad.Except (MonadError, liftEither)
 import Control.Monad.Reader (runReader)
@@ -100,9 +100,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (AlonzoEra c) where
   type AdditionalGenesisConfig (AlonzoEra c) = AlonzoGenesis
 
   initialState = API.initialStateFromGenesis extendPPWithGenesis
-
-instance CC.Crypto c => API.CLI (AlonzoEra c) where
-  evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Alonzo.UTxO () where
+
+import Cardano.Ledger.Alonzo.Era (AlonzoEra)
+import Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD (..))
+import Cardano.Ledger.Alonzo.TxBody ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
+
+instance Crypto c => EraUTxO (AlonzoEra c) where
+  getConsumedValue = getConsumedMaryValue

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -50,6 +50,7 @@ library
     Cardano.Ledger.Babbage.Rules.Utxo
     Cardano.Ledger.Babbage.Rules.Utxos
     Cardano.Ledger.Babbage.Rules.Ledger
+    Cardano.Ledger.Babbage.UTxO
   build-depends:
                 bytestring,
                 cardano-binary,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -46,13 +46,13 @@ import Cardano.Ledger.Babbage.TxBody
     dataHashTxOutL,
   )
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
+import Cardano.Ledger.Babbage.UTxO ()
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Serialization (sizedValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
-import Cardano.Ledger.ShelleyMA.Rules (consumed)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
@@ -70,9 +70,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (BabbageEra c) where
   type AdditionalGenesisConfig (BabbageEra c) = AlonzoGenesis
 
   initialState = API.initialStateFromGenesis extendPPWithGenesis
-
-instance CC.Crypto c => API.CLI (BabbageEra c) where
-  evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (BabbageEra c) where
   txInfo = babbageTxInfo

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Babbage.UTxO () where
+
+import Cardano.Ledger.Babbage.Era (BabbageEra)
+import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
+import Cardano.Ledger.Babbage.TxBody ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
+
+instance Crypto c => EraUTxO (BabbageEra c) where
+  getConsumedValue = getConsumedMaryValue

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -45,6 +45,7 @@ library
     Cardano.Ledger.Conway
   other-modules:
     Cardano.Ledger.Conway.Era
+    Cardano.Ledger.Conway.UTxO
   build-depends:
                 aeson,
                 bytestring,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -26,13 +26,13 @@ import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxBody (BabbageEraTxBody (..))
 import Cardano.Ledger.Conway.TxOut (AlonzoEraTxOut (..))
+import Cardano.Ledger.Conway.UTxO ()
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Serialization (sizedValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
-import Cardano.Ledger.ShelleyMA.Rules (consumed)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict
@@ -50,9 +50,6 @@ instance CC.Crypto c => API.CanStartFromGenesis (ConwayEra c) where
   type AdditionalGenesisConfig (ConwayEra c) = AlonzoGenesis
 
   initialState = API.initialStateFromGenesis extendPPWithGenesis
-
-instance CC.Crypto c => API.CLI (ConwayEra c) where
-  evaluateConsumed = consumed
 
 instance CC.Crypto c => ExtendedUTxO (ConwayEra c) where
   txInfo = babbageTxInfo

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.UTxO () where
+
+import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Conway.PParams (BabbagePParamsHKD (..))
+import Cardano.Ledger.Conway.TxBody ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
+
+instance Crypto c => EraUTxO (ConwayEra c) where
+  getConsumedValue = getConsumedMaryValue

--- a/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -40,6 +40,7 @@ library
     Cardano.Ledger.Allegra
     Cardano.Ledger.Allegra.Translation
     Cardano.Ledger.Mary
+    Cardano.Ledger.Mary.UTxO
     Cardano.Ledger.Mary.Translation
     Cardano.Ledger.Mary.Value
     Cardano.Ledger.ShelleyMA
@@ -51,6 +52,7 @@ library
     Cardano.Ledger.ShelleyMA.Tx
 
   other-modules:
+    Cardano.Ledger.Allegra.UTxO
     Cardano.Ledger.ShelleyMA.Rules.Utxo
     Cardano.Ledger.ShelleyMA.Rules.Utxow
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Allegra
   )
 where
 
+import Cardano.Ledger.Allegra.UTxO ()
 import Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
@@ -26,7 +27,7 @@ import Cardano.Ledger.Keys (DSignable)
 import Cardano.Ledger.Shelley.API hiding (PParams, Tx, TxBody, TxOut, WitnessSet)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import Cardano.Ledger.ShelleyMA
-import Cardano.Ledger.ShelleyMA.Rules (consumed)
+import Cardano.Ledger.ShelleyMA.Rules ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 import Cardano.Ledger.ShelleyMA.TxBody ()
 
@@ -46,9 +47,6 @@ instance
 
 instance CC.Crypto crypto => CanStartFromGenesis (AllegraEra crypto) where
   initialState = initialStateFromGenesis const
-
-instance CC.Crypto c => CLI (AllegraEra c) where
-  evaluateConsumed = consumed
 
 -- Self-Describing type synomyms
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Allegra.UTxO () where
+
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), getConsumedCoin)
+import Cardano.Ledger.ShelleyMA.Era (MaryOrAllegra (Allegra), ShelleyMAEra)
+import Cardano.Ledger.ShelleyMA.TxBody ()
+
+instance Crypto c => EraUTxO (ShelleyMAEra 'Allegra c) where
+  getConsumedValue = getConsumedCoin

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import qualified Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.ShelleyMA
 import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData)
-import Cardano.Ledger.ShelleyMA.Rules (consumed)
+import Cardano.Ledger.ShelleyMA.Rules ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 
 instance
@@ -50,9 +50,6 @@ instance
 
 instance CC.Crypto c => CanStartFromGenesis (MaryEra c) where
   initialState = initialStateFromGenesis const
-
-instance CC.Crypto c => CLI (MaryEra c) where
-  evaluateConsumed = consumed
 
 -- Self-Describing type synomyms
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -17,7 +17,7 @@
 module Cardano.Ledger.Shelley.UTxO
   ( -- * Primitives
     UTxO (..),
-    EraUTxO(..),
+    EraUTxO (..),
 
     -- * Functions
     txins,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Ledger.Api.Era
     Cardano.Ledger.Api.Tx
     Cardano.Ledger.Api.Tx.Out
+    Cardano.Ledger.Api.UTxO
 
   build-depends:
     cardano-ledger-alonzo,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/UTxO.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/UTxO.hs
@@ -1,0 +1,7 @@
+module Cardano.Ledger.Api.UTxO
+  ( UTxO (..),
+    EraUTxO (..),
+  )
+where
+
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), UTxO (..))


### PR DESCRIPTION
Deprecated `consumed` and `evaluateConsumed` in favor of new `EraUTxO.getConsumedValue`.

Create a `EraUTxO` class that will have more functions added to it in subsequent PRs