### PR TITLE
Reduce duplication remove input data hashes

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -51,6 +51,7 @@ library
     Cardano.Ledger.Alonzo.TxInfo
     Cardano.Ledger.Alonzo.TxSeq
     Cardano.Ledger.Alonzo.TxWits
+    Cardano.Ledger.Alonzo.UTxO
   other-modules:
     Cardano.Ledger.Alonzo.Era
     Cardano.Ledger.Alonzo.Rules.Bbody
@@ -58,7 +59,6 @@ library
     Cardano.Ledger.Alonzo.Rules.Utxo
     Cardano.Ledger.Alonzo.Rules.Utxos
     Cardano.Ledger.Alonzo.Rules.Utxow
-    Cardano.Ledger.Alonzo.UTxO
   build-depends:
     aeson >= 2,
     array,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -46,7 +46,6 @@ import qualified Cardano.Ledger.Alonzo.PParams (PParams)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (getDatumAlonzo)
 import Cardano.Ledger.Alonzo.Rules ()
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
-import Cardano.Ledger.Alonzo.Tx (alonzoInputHashes)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..), AlonzoTxBody, AlonzoTxOut)
 import qualified Cardano.Ledger.Alonzo.TxBody (TxBody, TxOut)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), alonzoTxInfo)
@@ -106,7 +105,6 @@ instance Crypto c => API.CanStartFromGenesis (AlonzoEra c) where
 
 instance Crypto c => ExtendedUTxO (AlonzoEra c) where
   txInfo = alonzoTxInfo
-  inputDataHashes = alonzoInputHashes
   txscripts _ = txscripts' . view witsTxL
   getAllowedSupplimentalDataHashes txBody _ =
     Set.fromList

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -77,12 +77,7 @@ import Cardano.Ledger.Alonzo.Scripts
     transProtocolVersion,
     validScript,
   )
-import Cardano.Ledger.Alonzo.Tx
-  ( AlonzoTx,
-    CostModel,
-    ScriptPurpose (..),
-    txdats',
-  )
+import Cardano.Ledger.Alonzo.Tx (CostModel, ScriptPurpose (..), txdats')
 import Cardano.Ledger.Alonzo.TxBody
   ( AlonzoEraTxBody (..),
     AlonzoEraTxOut (..),
@@ -456,16 +451,6 @@ class ExtendedUTxO era where
     UTxO era ->
     Tx era ->
     Either (TranslationError (EraCrypto era)) VersionedTxInfo
-
-  -- Compute two sets for all TwoPhase scripts in a Tx.
-  -- set 1) DataHashes for each Two phase Script in a TxIn that has a DataHash
-  -- set 2) TxIns that are TwoPhase scripts, and should have a DataHash but don't.
-  {- { h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isNonNativeScriptAddress tx a} -}
-  inputDataHashes ::
-    Map.Map (ScriptHash (EraCrypto era)) (Script era) ->
-    AlonzoTx era ->
-    UTxO era ->
-    (Set (DataHash (EraCrypto era)), Set (TxIn (EraCrypto era)))
 
   txscripts ::
     UTxO era ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -1,15 +1,55 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Alonzo.UTxO () where
+module Cardano.Ledger.Alonzo.UTxO (getInputDataHashesTxBody) where
 
+import Cardano.Ledger.Alonzo.Data (Datum (..))
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD (..))
-import Cardano.Ledger.Alonzo.TxBody ()
+import Cardano.Ledger.Alonzo.Tx (isTwoPhaseScriptAddressFromMap)
+import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxOut (..))
+import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
-import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), UTxO (..))
+import Cardano.Ledger.TxIn
+import Control.SetAlgebra (eval, (◁))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Lens.Micro
 
 instance Crypto c => EraUTxO (AlonzoEra c) where
   getConsumedValue = getConsumedMaryValue
+
+-- | Compute two sets for all TwoPhase scripts in a Tx.
+--
+--   1) DataHashes for each Two phase Script in a TxIn that has a DataHash
+--   2) TxIns that are TwoPhase scripts, and should have a DataHash but don't.
+--
+-- @{ h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isNonNativeScriptAddress tx a}@
+getInputDataHashesTxBody ::
+  (EraTxBody era, AlonzoEraTxOut era, EraScript era) =>
+  UTxO era ->
+  TxBody era ->
+  Map.Map (ScriptHash (EraCrypto era)) (Script era) ->
+  (Set.Set (DataHash (EraCrypto era)), Set.Set (TxIn (EraCrypto era)))
+getInputDataHashesTxBody (UTxO mp) txBody hashScriptMap =
+  Map.foldlWithKey' accum (Set.empty, Set.empty) smallUtxo
+  where
+    spendInputs = txBody ^. inputsTxBodyL
+    smallUtxo = eval (spendInputs ◁ mp)
+    accum ans@(!hashSet, !inputSet) txIn txOut =
+      let addr = txOut ^. addrTxOutL
+       in case txOut ^. datumTxOutF of
+            NoDatum
+              | isTwoPhaseScriptAddressFromMap hashScriptMap addr ->
+                  (hashSet, Set.insert txIn inputSet)
+            DatumHash dataHash
+              | isTwoPhaseScriptAddressFromMap hashScriptMap addr ->
+                  (Set.insert dataHash hashSet, inputSet)
+            -- Though it is somewhat odd to allow non-two-phase-scripts to include a datum,
+            -- the Alonzo era already set the precedent with datum hashes, and several dapp
+            -- developers see this as a helpful feature.
+            _ -> ans

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -33,11 +33,7 @@ import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Genesis (AlonzoGenesis, extendPPWithGenesis)
 import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
 import Cardano.Ledger.Babbage.Rules ()
-import Cardano.Ledger.Babbage.Tx
-  ( babbageInputDataHashes,
-    babbageTxScripts,
-    getDatumBabbage,
-  )
+import Cardano.Ledger.Babbage.Tx (babbageTxScripts, getDatumBabbage)
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (..),
     BabbageTxBody,
@@ -76,7 +72,6 @@ instance Crypto c => API.CanStartFromGenesis (BabbageEra c) where
 
 instance Crypto c => ExtendedUTxO (BabbageEra c) where
   txInfo = babbageTxInfo
-  inputDataHashes = babbageInputDataHashes
   txscripts = babbageTxScripts
   getAllowedSupplimentalDataHashes txBody (UTxO utxo) =
     Set.fromList [dh | txOut <- outs, SJust dh <- [txOut ^. dataHashTxOutL]]

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -307,7 +307,7 @@ babbageUtxowTransition = do
   runTest $ babbageMissingScripts pp sNeeded sRefs sReceived
 
   {-  inputHashes ⊆  dom(txdats txw) ⊆  allowed -}
-  runTest $ missingRequiredDatums hashScriptMap utxo tx txBody
+  runTest $ missingRequiredDatums hashScriptMap utxo tx
 
   {-  dom (txrdmrs tx) = { rdptr txb sp | (sp, h) ∈ scriptsNeeded utxo tx,
                            h ↦ s ∈ txscripts txw, s ∈ Scriptph2}     -}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -18,11 +18,7 @@ import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
 import Cardano.Ledger.Babbage.Rules ()
-import Cardano.Ledger.Babbage.Tx
-  ( babbageInputDataHashes,
-    babbageTxScripts,
-    getDatumBabbage,
-  )
+import Cardano.Ledger.Babbage.Tx (babbageTxScripts, getDatumBabbage)
 import Cardano.Ledger.Babbage.TxInfo (babbageTxInfo)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Genesis (extendPPWithGenesis)
@@ -59,7 +55,6 @@ instance Crypto c => API.CanStartFromGenesis (ConwayEra c) where
 
 instance Crypto c => ExtendedUTxO (ConwayEra c) where
   txInfo = babbageTxInfo
-  inputDataHashes = babbageInputDataHashes
   txscripts = babbageTxScripts
   getAllowedSupplimentalDataHashes txBody (UTxO utxo) =
     Set.fromList [dh | txOut <- outs, SJust dh <- [txOut ^. dataHashTxOutL]]


### PR DESCRIPTION
The recently added to Alonzo era lens `datumTxOutF` allows us to remove duplicate implementations for `inputDataHashes`. That is exactly what this PR does.