### PR TITLE
Added JSON and CBOR instances to ConwayGenesis

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -8,16 +8,21 @@ module Cardano.Ledger.Conway.Genesis
   )
 where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Babbage.Genesis (extendPPWithGenesis)
 import Cardano.Ledger.Crypto (Crypto)
-import Cardano.Ledger.Keys (GenDelegs)
-import Data.Aeson (FromJSON (..), withObject, (.:))
+import Cardano.Ledger.Keys (GenDelegs (..))
+import Data.Aeson (FromJSON (..), ToJSON, object, withObject, (.:))
+import Data.Aeson.Types (KeyValue (..), ToJSON (..))
 import Data.Unit.Strict (forceElemsToWHNF)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
 newtype ConwayGenesis c = ConwayGenesis (GenDelegs c)
-  deriving (Eq, Generic, NoThunks, Show)
+  deriving (Eq, Generic, NoThunks, ToCBOR, FromCBOR, Show)
+
+instance Crypto c => ToJSON (ConwayGenesis c) where
+  toJSON (ConwayGenesis genDelegs) = object ["genDelegs" .= toJSON genDelegs]
 
 instance Crypto c => FromJSON (ConwayGenesis c) where
   parseJSON = withObject "ConwayGenesis" $ \obj ->

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -36,7 +36,8 @@ library
 
   exposed-modules:
     Test.Cardano.Ledger.Conway.Examples.Consensus,
-    Test.Cardano.Ledger.Conway.Serialisation.Generators
+    Test.Cardano.Ledger.Conway.Serialisation.Generators,
+    Test.Cardano.Ledger.Conway.Serialisation.Roundtrip
   build-depends:
     cardano-ledger-alonzo,
     cardano-ledger-alonzo-test,
@@ -53,6 +54,24 @@ library
     cardano-ledger-shelley-test,
     cardano-ledger-shelley,
     strict-containers,
+    tasty,
+    tasty-quickcheck,
+    QuickCheck,
   hs-source-dirs:
     src
+
+test-suite cardano-ledger-conway-test
+  import: base, project-config
+  type: exitcode-stdio-1.0
+  main-is: Tests.hs
+  hs-source-dirs: test
+  build-depends:
+    cardano-ledger-conway,
+    cardano-ledger-conway-test,
+    cardano-ledger-shelley-test,
+    tasty,
+  ghc-options:        -threaded
+                      -rtsopts
+                      -with-rtsopts=-N
+                      "-with-rtsopts=-K4m -M250m"
 

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Generators.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Generators.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Cardano.Ledger.Conway.Serialisation.Generators () where
 
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Crypto (Crypto)
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+import Test.QuickCheck (Arbitrary (..))
 
--- Currently Conway does not define any types that require serialization,
--- therefore we simply re-export ones from Babbage. This could change in the
--- future, thus is this placeholder module.
+deriving instance Crypto c => Arbitrary (ConwayGenesis c)

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Serialisation.Roundtrip (allprops) where
+
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Core (Era (..))
+import Data.Data (Proxy (..), typeRep)
+import Test.Cardano.Ledger.Conway.Serialisation.Generators ()
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip (property)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+allprops ::
+  forall e.
+  ( Era e
+  ) =>
+  TestTree
+allprops =
+  testGroup
+    (show $ typeRep (Proxy @e))
+    [ testProperty "ConwayGenesis" $ property @(ConwayGenesis (EraCrypto e))
+    ]

--- a/eras/conway/test-suite/test/Tests.hs
+++ b/eras/conway/test-suite/test/Tests.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Cardano.Ledger.Conway (Conway)
+import qualified Test.Cardano.Ledger.Conway.Serialisation.Roundtrip as Roundtrip
+import Test.Tasty (TestTree, askOption, testGroup)
+import Test.TestScenario (TestScenario (..), mainWithTestScenario)
+
+tests :: TestTree
+tests = askOption @TestScenario $ \case
+  _ -> mainTests
+
+mainTests :: TestTree
+mainTests =
+  testGroup
+    "Conway tests"
+    [ Roundtrip.allprops @Conway
+    ]
+
+main :: IO ()
+main = mainWithTestScenario tests

--- a/hie.yaml
+++ b/hie.yaml
@@ -60,6 +60,12 @@ cradle:
     - path: "eras/conway/impl/src"
       component: "lib:cardano-ledger-conway"
 
+    - path: "eras/conway/test-suite/src"
+      component: "lib:cardano-ledger-conway-test"
+
+    - path: "eras/conway/test-suite/test"
+      component: "cardano-ledger-conway-test:test:cardano-ledger-conway-test"
+
     - path: "eras/babbage/test-suite/src"
       component: "cardano-ledger-babbage-test"
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -330,6 +330,10 @@ deriving instance
   (Crypto c) =>
   ToCBOR (GenDelegs c)
 
+deriving instance
+  Crypto c =>
+  ToJSON (GenDelegs c)
+
 newtype GKeys c = GKeys {unGKeys :: Set (VKey 'Genesis c)}
   deriving (Eq, NoThunks, Generic)
   deriving (Show) via Quiet (GKeys c)


### PR DESCRIPTION
This PR adds `ToJSON`, `ToCBOR` and `FromCBOR` instances to `ConwayGenesis`. It also adds a test suite and round-trip tests to Conway era.

The `ToJSON` instance for `ConwayGenesis` currently outputs a JSON object containing a single field `genDelegs`, which contains the JSON data for the `GenDelegs`.

`ConwayGenesis` is encoded in CBOR just as `GenDelegs` (via the generic ToCBOR and FromCBOR instance for newtypes). 

closes #3021 
