### PR TITLE
Renamed 'crypto' type arguments to 'c'

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -367,9 +367,9 @@ instance CC.Crypto c => EraAuxiliaryData (AlonzoEra c) where
   validateAuxiliaryData = validateAlonzoAuxiliaryData
 
 hashAlonzoAuxiliaryData ::
-  (HashAlgorithm (CC.HASH crypto), HashAnnotated x EraIndependentAuxiliaryData crypto) =>
+  (HashAlgorithm (CC.HASH c), HashAnnotated x EraIndependentAuxiliaryData c) =>
   x ->
-  AuxiliaryDataHash crypto
+  AuxiliaryDataHash c
 hashAlonzoAuxiliaryData x = AuxiliaryDataHash (hashAnnotated x)
 
 validateAlonzoAuxiliaryData ::

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -177,9 +177,9 @@ type AlonzoPParams era = AlonzoPParamsHKD Identity era
 
 type AlonzoPParamsUpdate era = AlonzoPParamsHKD StrictMaybe era
 
-instance CC.Crypto crypto => EraPParams (AlonzoEra crypto) where
-  type PParams (AlonzoEra crypto) = AlonzoPParams (AlonzoEra crypto)
-  type PParamsUpdate (AlonzoEra crypto) = AlonzoPParamsUpdate (AlonzoEra crypto)
+instance CC.Crypto c => EraPParams (AlonzoEra c) where
+  type PParams (AlonzoEra c) = AlonzoPParams (AlonzoEra c)
+  type PParamsUpdate (AlonzoEra c) = AlonzoPParamsUpdate (AlonzoEra c)
 
   applyPPUpdates = updatePParams
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -76,7 +76,7 @@ import NoThunks.Class (NoThunks)
 -- ===============================================================
 
 -- | Only the Spending ScriptPurpose contains TxIn
-getSpendingTxIn :: ScriptPurpose crypto -> Maybe (TxIn crypto)
+getSpendingTxIn :: ScriptPurpose c -> Maybe (TxIn c)
 getSpendingTxIn = \case
   Spending txin -> Just txin
   Minting _policyid -> Nothing
@@ -100,20 +100,20 @@ getDatumAlonzo tx (UTxO m) sp = do
 -- ========================================================================
 
 -- | When collecting inputs for twophase scripts, 3 things can go wrong.
-data CollectError crypto
-  = NoRedeemer !(ScriptPurpose crypto)
-  | NoWitness !(ScriptHash crypto)
+data CollectError c
+  = NoRedeemer !(ScriptPurpose c)
+  | NoWitness !(ScriptHash c)
   | NoCostModel !Language
-  | BadTranslation !(TranslationError crypto)
+  | BadTranslation !(TranslationError c)
   deriving (Eq, Show, Generic, NoThunks)
 
-instance (CC.Crypto crypto) => ToCBOR (CollectError crypto) where
+instance (CC.Crypto c) => ToCBOR (CollectError c) where
   toCBOR (NoRedeemer x) = encode $ Sum NoRedeemer 0 !> To x
   toCBOR (NoWitness x) = encode $ Sum NoWitness 1 !> To x
   toCBOR (NoCostModel x) = encode $ Sum NoCostModel 2 !> To x
   toCBOR (BadTranslation x) = encode $ Sum BadTranslation 3 !> To x
 
-instance (CC.Crypto crypto) => FromCBOR (CollectError crypto) where
+instance (CC.Crypto c) => FromCBOR (CollectError c) where
   fromCBOR = decode (Summands "CollectError" dec)
     where
       dec 0 = SumD NoRedeemer <! From
@@ -251,9 +251,9 @@ scriptsNeeded utxo tx = scriptsNeededFromBody utxo (tx ^. bodyTxL)
 -- We only find certificate witnesses in Delegating and Deregistration DCerts
 -- that have ScriptHashObj credentials.
 addOnlyCwitness ::
-  [(ScriptPurpose crypto, ScriptHash crypto)] ->
-  DCert crypto ->
-  [(ScriptPurpose crypto, ScriptHash crypto)]
+  [(ScriptPurpose c, ScriptHash c)] ->
+  DCert c ->
+  [(ScriptPurpose c, ScriptHash c)]
 addOnlyCwitness !ans (DCertDeleg c@(DeRegKey (ScriptHashObj hk))) =
   (Certifying $ DCertDeleg c, hk) : ans
 addOnlyCwitness !ans (DCertDeleg c@(Delegate (Delegation (ScriptHashObj hk) _dpool))) =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -233,13 +233,13 @@ newtype AlonzoUtxoEvent era
 
 -- | Returns true for VKey locked addresses, and false for any kind of
 -- script-locked address.
-isKeyHashAddr :: Addr crypto -> Bool
+isKeyHashAddr :: Addr c -> Bool
 isKeyHashAddr (AddrBootstrap _) = True
 isKeyHashAddr (Addr _ (KeyHashObj _) _) = True
 isKeyHashAddr _ = False
 
 -- | This is equivalent to `isKeyHashAddr`, but for compacted version of an address.
-isKeyHashCompactAddr :: CompactAddr crypto -> Bool
+isKeyHashCompactAddr :: CompactAddr c -> Bool
 isKeyHashCompactAddr cAddr =
   isBootstrapCompactAddr cAddr || not (isPayCredScriptCompactAddr cAddr)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -259,7 +259,7 @@ instance
 instance
   ( Era era,
     Script era ~ AlonzoScript era,
-    crypto ~ EraCrypto era,
+    c ~ EraCrypto era,
     NFData (AuxiliaryData era),
     NFData (Script era),
     NFData (Core.TxBody era),
@@ -267,8 +267,8 @@ instance
     NFData (PParamsUpdate era),
     NFData (TxDats era),
     NFData (Redeemers era),
-    NFData (VerKeyDSIGN (CC.DSIGN crypto)),
-    NFData (SigDSIGN (CC.DSIGN crypto))
+    NFData (VerKeyDSIGN (CC.DSIGN c)),
+    NFData (SigDSIGN (CC.DSIGN c))
   ) =>
   NFData (AlonzoTx era)
 
@@ -390,11 +390,11 @@ totExUnits tx =
 -- Figure 6:Indexing script and data objects
 -- ===============================================================
 
-data ScriptPurpose crypto
-  = Minting !(PolicyID crypto)
-  | Spending !(TxIn crypto)
-  | Rewarding !(RewardAcnt crypto) -- Not sure if this is the right type.
-  | Certifying !(DCert crypto)
+data ScriptPurpose c
+  = Minting !(PolicyID c)
+  | Spending !(TxIn c)
+  | Rewarding !(RewardAcnt c) -- Not sure if this is the right type.
+  | Certifying !(DCert c)
   deriving (Eq, Show, Generic, NoThunks, NFData)
 
 instance (Typeable c, CC.Crypto c) => ToCBOR (ScriptPurpose c) where
@@ -470,7 +470,7 @@ rdptrInv txBody (RdmrPtr Cert idx) =
   Certifying <$> fromIndex idx (txBody ^. certsTxBodyL)
 
 {-# DEPRECATED getMapFromValue "No longer used" #-}
-getMapFromValue :: MaryValue crypto -> Map.Map (PolicyID crypto) (Map.Map AssetName Integer)
+getMapFromValue :: MaryValue c -> Map.Map (PolicyID c) (Map.Map AssetName Integer)
 getMapFromValue (MaryValue _ (MultiAsset m)) = m
 
 -- | Find the Data and ExUnits assigned to a script.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -195,11 +195,11 @@ data TxWitnessRaw era = TxWitnessRaw
 instance
   ( Era era,
     Core.Script era ~ AlonzoScript era,
-    crypto ~ EraCrypto era,
+    c ~ EraCrypto era,
     NFData (TxDats era),
     NFData (Redeemers era),
-    NFData (SigDSIGN (CC.DSIGN crypto)),
-    NFData (VerKeyDSIGN (CC.DSIGN crypto))
+    NFData (SigDSIGN (CC.DSIGN c)),
+    NFData (VerKeyDSIGN (CC.DSIGN c))
   ) =>
   NFData (TxWitnessRaw era)
 
@@ -220,11 +220,11 @@ instance (Era era, Core.Script era ~ AlonzoScript era) => Monoid (AlonzoTxWits e
 deriving instance
   ( Era era,
     Core.Script era ~ AlonzoScript era,
-    crypto ~ EraCrypto era,
+    c ~ EraCrypto era,
     NFData (TxDats era),
     NFData (Redeemers era),
-    NFData (SigDSIGN (CC.DSIGN crypto)),
-    NFData (VerKeyDSIGN (CC.DSIGN crypto))
+    NFData (SigDSIGN (CC.DSIGN c)),
+    NFData (VerKeyDSIGN (CC.DSIGN c))
   ) =>
   NFData (AlonzoTxWits era)
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -406,24 +406,24 @@ instance (Era era, Val (Value era), DecodeNonNegative (Value era)) => Twiddle (A
 instance Twiddle SlotNo where
   twiddle = twiddle . toTerm
 
-instance C.Crypto crypto => Twiddle (DCert crypto) where
+instance C.Crypto c => Twiddle (DCert c) where
   twiddle = twiddle . toTerm
 
-instance C.Crypto crypto => Twiddle (Wdrl crypto) where
+instance C.Crypto c => Twiddle (Wdrl c) where
   twiddle = twiddle . toTerm
 
-instance C.Crypto crypto => Twiddle (AuxiliaryDataHash crypto) where
+instance C.Crypto c => Twiddle (AuxiliaryDataHash c) where
   twiddle = twiddle . toTerm
 
 emptyOrNothing ::
-  forall t a crypto.
+  forall t a c.
   ( Foldable t,
     Twiddle (t Void),
     Monoid (t Void),
     Twiddle (t a)
   ) =>
-  AlonzoTxBody (AlonzoEra crypto) ->
-  (AlonzoTxBody (AlonzoEra crypto) -> t a) ->
+  AlonzoTxBody (AlonzoEra c) ->
+  (AlonzoTxBody (AlonzoEra c) -> t a) ->
   Gen (Maybe Term)
 emptyOrNothing txBody f =
   if null $ f txBody
@@ -438,16 +438,16 @@ twiddleStrictMaybe :: Twiddle a => StrictMaybe a -> Gen (Maybe Term)
 twiddleStrictMaybe SNothing = pure Nothing
 twiddleStrictMaybe (SJust x) = Just <$> twiddle x
 
-instance C.Crypto crypto => Twiddle (Update (AlonzoEra crypto)) where
+instance C.Crypto c => Twiddle (Update (AlonzoEra c)) where
   twiddle = twiddle . toTerm
 
-instance C.Crypto crypto => Twiddle (MultiAsset crypto) where
+instance C.Crypto c => Twiddle (MultiAsset c) where
   twiddle = twiddle . encodingToTerm . encodeMint
 
-instance C.Crypto crypto => Twiddle (ScriptIntegrityHash crypto) where
+instance C.Crypto c => Twiddle (ScriptIntegrityHash c) where
   twiddle = twiddle . toTerm
 
-instance (C.Crypto crypto, Typeable t) => Twiddle (KeyHash t crypto) where
+instance (C.Crypto c, Typeable t) => Twiddle (KeyHash t c) where
   twiddle = twiddle . toTerm
 
 instance Twiddle Network where
@@ -459,7 +459,7 @@ instance C.Crypto c => Twiddle (TxIn c) where
 instance Twiddle Coin where
   twiddle = twiddle . toTerm
 
-instance C.Crypto crypto => Twiddle (AlonzoTxBody (AlonzoEra crypto)) where
+instance C.Crypto c => Twiddle (AlonzoTxBody (AlonzoEra c)) where
   twiddle txBody = do
     inputs' <- twiddle $ inputs txBody
     outputs' <- twiddle $ outputs txBody

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -176,7 +176,7 @@ import Prelude hiding (lookup)
 
 -- ======================================
 
-type ScriptIntegrityHash crypto = SafeHash crypto EraIndependentScriptIntegrity
+type ScriptIntegrityHash c = SafeHash c EraIndependentScriptIntegrity
 
 data TxBodyRaw era = TxBodyRaw
   { _spendInputs :: !(Set (TxIn (EraCrypto era))),

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -16,10 +16,10 @@ import Data.Unit.Strict (forceElemsToWHNF)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
-newtype ConwayGenesis crypto = ConwayGenesis (GenDelegs crypto)
+newtype ConwayGenesis c = ConwayGenesis (GenDelegs c)
   deriving (Eq, Generic, NoThunks)
 
-instance Crypto crypto => FromJSON (ConwayGenesis crypto) where
+instance Crypto c => FromJSON (ConwayGenesis c) where
   parseJSON = withObject "ConwayGenesis" $ \obj ->
     ConwayGenesis
       <$> forceElemsToWHNF obj .: "genDelegs"

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -204,6 +204,6 @@ exampleConwayNewEpochState =
     emptyPParams
     (emptyPParams {_coinsPerUTxOByte = Coin 1})
 
-exampleConwayGenesis :: ConwayGenesis crypto
+exampleConwayGenesis :: ConwayGenesis c
 exampleConwayGenesis =
   ConwayGenesis (GenDelegs Map.empty)

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Allegra.hs
@@ -41,14 +41,14 @@ type AllegraEra = ShelleyMAEra 'Allegra
 --------------------------------------------------------------------------------
 
 instance
-  (Crypto crypto, DSignable crypto (Hash crypto EraIndependentTxBody)) =>
-  ApplyTx (AllegraEra crypto)
+  (Crypto c, DSignable c (Hash c EraIndependentTxBody)) =>
+  ApplyTx (AllegraEra c)
 
 instance
-  (Crypto crypto, DSignable crypto (Hash crypto EraIndependentTxBody)) =>
-  ApplyBlock (AllegraEra crypto)
+  (Crypto c, DSignable c (Hash c EraIndependentTxBody)) =>
+  ApplyBlock (AllegraEra c)
 
-instance Crypto crypto => CanStartFromGenesis (AllegraEra crypto) where
+instance Crypto c => CanStartFromGenesis (AllegraEra c) where
   initialState = initialStateFromGenesis const
 
 -- Self-Describing type synomyms

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -42,12 +42,12 @@ import Cardano.Ledger.ShelleyMA.Rules ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock)
 
 instance
-  (Crypto crypto, DSignable crypto (Hash crypto EraIndependentTxBody)) =>
-  ApplyTx (MaryEra crypto)
+  (Crypto c, DSignable c (Hash c EraIndependentTxBody)) =>
+  ApplyTx (MaryEra c)
 
 instance
-  (Crypto crypto, DSignable crypto (Hash crypto EraIndependentTxBody)) =>
-  ApplyBlock (MaryEra crypto)
+  (Crypto c, DSignable c (Hash c EraIndependentTxBody)) =>
+  ApplyBlock (MaryEra c)
 
 instance Crypto c => CanStartFromGenesis (MaryEra c) where
   initialState = initialStateFromGenesis const

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -49,8 +49,8 @@ import Cardano.Ledger.ShelleyMA.TxBody (MATxBody, TxBody)
 
 -- Uses the default instance of hashScript
 
-instance MAClass ma crypto => EraSegWits (ShelleyMAEra ma crypto) where
-  type TxSeq (ShelleyMAEra ma crypto) = ShelleyTxSeq (ShelleyMAEra ma crypto)
+instance MAClass ma c => EraSegWits (ShelleyMAEra ma c) where
+  type TxSeq (ShelleyMAEra ma c) = ShelleyTxSeq (ShelleyMAEra ma c)
   fromTxSeq = Shelley.txSeqTxns
   toTxSeq = ShelleyTxSeq
   hashTxSeq = Shelley.bbHash

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
@@ -55,25 +55,25 @@ data MaryOrAllegra = Mary | Allegra
 --   between the Mary and Allegra instances
 class
   ( Typeable ma,
-    CC.Crypto crypto,
-    DecodeNonNegative (MAValue ma crypto),
-    Compactible (MAValue ma crypto),
-    Eq (CompactForm (MAValue ma crypto)),
-    NFData (MAValue ma crypto),
-    Show (MAValue ma crypto),
-    Val (MAValue ma crypto),
-    Eq (MAValue ma crypto),
-    FromCBOR (MAValue ma crypto),
-    ToCBOR (MAValue ma crypto),
-    EncodeMint (MAValue ma crypto),
-    DecodeMint (MAValue ma crypto),
-    NoThunks (MAValue ma crypto)
+    CC.Crypto c,
+    DecodeNonNegative (MAValue ma c),
+    Compactible (MAValue ma c),
+    Eq (CompactForm (MAValue ma c)),
+    NFData (MAValue ma c),
+    Show (MAValue ma c),
+    Val (MAValue ma c),
+    Eq (MAValue ma c),
+    FromCBOR (MAValue ma c),
+    ToCBOR (MAValue ma c),
+    EncodeMint (MAValue ma c),
+    DecodeMint (MAValue ma c),
+    NoThunks (MAValue ma c)
   ) =>
-  MAClass (ma :: MaryOrAllegra) crypto
+  MAClass (ma :: MaryOrAllegra) c
   where
-  type MAValue (ma :: MaryOrAllegra) crypto :: Type
-  getScriptHash :: proxy ma -> MultiAsset crypto -> Set.Set (ScriptHash crypto)
-  promoteMultiAsset :: proxy ma -> MultiAsset crypto -> Value (ShelleyMAEra ma crypto)
+  type MAValue (ma :: MaryOrAllegra) c :: Type
+  getScriptHash :: proxy ma -> MultiAsset c -> Set.Set (ScriptHash c)
+  promoteMultiAsset :: proxy ma -> MultiAsset c -> Value (ShelleyMAEra ma c)
 
 instance CC.Crypto c => MAClass 'Mary c where
   type MAValue 'Mary c = MaryValue c
@@ -87,9 +87,9 @@ instance CC.Crypto c => MAClass 'Allegra c where
 
 -- | The actual Mary and Allegra instances, rolled into one, the MAClass superclass
 --   provides the era-specific code for where they differ.
-instance MAClass ma crypto => Era (ShelleyMAEra ma crypto) where
-  type EraCrypto (ShelleyMAEra ma crypto) = crypto
-  type ProtVerLow (ShelleyMAEra ma crypto) = MAProtVer ma
+instance MAClass ma c => Era (ShelleyMAEra ma c) where
+  type EraCrypto (ShelleyMAEra ma c) = c
+  type ProtVerLow (ShelleyMAEra ma c) = MAProtVer ma
 
 type family MAProtVer (ma :: MaryOrAllegra) :: Nat where
   MAProtVer 'Allegra = 3
@@ -101,9 +101,9 @@ type family MAProtVer (ma :: MaryOrAllegra) :: Nat where
 
 type instance Value (ShelleyMAEra ma c) = MAValue ma c
 
-instance MAClass ma crypto => EraPParams (ShelleyMAEra ma crypto) where
-  type PParams (ShelleyMAEra ma crypto) = ShelleyPParams (ShelleyMAEra ma crypto)
-  type PParamsUpdate (ShelleyMAEra ma crypto) = ShelleyPParamsUpdate (ShelleyMAEra ma crypto)
+instance MAClass ma c => EraPParams (ShelleyMAEra ma c) where
+  type PParams (ShelleyMAEra ma c) = ShelleyPParams (ShelleyMAEra ma c)
+  type PParamsUpdate (ShelleyMAEra ma c) = ShelleyPParamsUpdate (ShelleyMAEra ma c)
 
   applyPPUpdates = updatePParams
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Timelocks.hs
@@ -198,8 +198,8 @@ type instance SomeScript 'PhaseOne (ShelleyMAEra ma c) = Timelock (ShelleyMAEra 
 -- | Since Timelock scripts are a strictly backwards compatible extension of
 -- Multisig scripts, we can use the same 'scriptPrefixTag' tag here as we did
 -- for the ValidateScript instance in Multisig
-instance MAClass ma crypto => EraScript (ShelleyMAEra ma crypto) where
-  type Script (ShelleyMAEra ma crypto) = Timelock (ShelleyMAEra ma crypto)
+instance MAClass ma c => EraScript (ShelleyMAEra ma c) where
+  type Script (ShelleyMAEra ma c) = Timelock (ShelleyMAEra ma c)
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
   phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
   phaseScript PhaseTwoRep _ = Nothing

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Tx.hs
@@ -36,11 +36,11 @@ import Lens.Micro ((^.))
 
 -- ========================================
 
-instance MAClass ma crypto => EraTx (ShelleyMAEra ma crypto) where
+instance MAClass ma c => EraTx (ShelleyMAEra ma c) where
   {-# SPECIALIZE instance EraTx (ShelleyMAEra 'Mary StandardCrypto) #-}
   {-# SPECIALIZE instance EraTx (ShelleyMAEra 'Allegra StandardCrypto) #-}
 
-  type Tx (ShelleyMAEra ma crypto) = ShelleyTx (ShelleyMAEra ma crypto)
+  type Tx (ShelleyMAEra ma c) = ShelleyTx (ShelleyMAEra ma c)
 
   mkBasicTx = mkBasicShelleyTx
 
@@ -56,7 +56,7 @@ instance MAClass ma crypto => EraTx (ShelleyMAEra ma crypto) where
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(ShelleyMAEra ma crypto) script tx
+  validateScript (Phase1Script script) tx = validateTimelock @(ShelleyMAEra ma c) script tx
   {-# INLINE validateScript #-}
 
   getMinFeeTx = shelleyMinFeeTx

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -316,11 +316,11 @@ lensTxBodyRaw getter setter =
     (\(TxBodyConstr (Memo txBodyRaw _)) val -> mkMATxBody $ setter txBodyRaw val)
 {-# INLINEABLE lensTxBodyRaw #-}
 
-instance MAClass ma crypto => EraTxBody (ShelleyMAEra ma crypto) where
+instance MAClass ma c => EraTxBody (ShelleyMAEra ma c) where
   {-# SPECIALIZE instance EraTxBody (ShelleyMAEra 'Mary StandardCrypto) #-}
   {-# SPECIALIZE instance EraTxBody (ShelleyMAEra 'Allegra StandardCrypto) #-}
 
-  type TxBody (ShelleyMAEra ma crypto) = MATxBody (ShelleyMAEra ma crypto)
+  type TxBody (ShelleyMAEra ma c) = MATxBody (ShelleyMAEra ma c)
 
   mkBasicTxBody = mkMATxBody initial
 
@@ -347,7 +347,7 @@ instance MAClass ma crypto => EraTxBody (ShelleyMAEra ma crypto) where
     to (\(TxBodyConstr (Memo txBodyRaw _)) -> getScriptHash (Proxy @ma) (mint txBodyRaw))
   {-# INLINEABLE mintedTxBodyF #-}
 
-instance MAClass ma crypto => ShelleyEraTxBody (ShelleyMAEra ma crypto) where
+instance MAClass ma c => ShelleyEraTxBody (ShelleyMAEra ma c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyMAEra 'Mary StandardCrypto) #-}
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyMAEra 'Allegra StandardCrypto) #-}
 
@@ -376,7 +376,7 @@ class
 
   mintValueTxBodyF :: SimpleGetter (Core.TxBody era) (Core.Value era)
 
-instance MAClass ma crypto => ShelleyMAEraTxBody (ShelleyMAEra ma crypto) where
+instance MAClass ma c => ShelleyMAEraTxBody (ShelleyMAEra ma c) where
   {-# SPECIALIZE instance ShelleyMAEraTxBody (ShelleyMAEra 'Mary StandardCrypto) #-}
   {-# SPECIALIZE instance ShelleyMAEraTxBody (ShelleyMAEra 'Allegra StandardCrypto) #-}
 

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxWits.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxWits.hs
@@ -21,11 +21,11 @@ import Cardano.Ledger.Shelley.TxWits
 import Cardano.Ledger.ShelleyMA.AuxiliaryData ()
 import Cardano.Ledger.ShelleyMA.Era (MAClass, MaryOrAllegra (..), ShelleyMAEra)
 
-instance MAClass ma crypto => EraTxWits (ShelleyMAEra ma crypto) where
+instance MAClass ma c => EraTxWits (ShelleyMAEra ma c) where
   {-# SPECIALIZE instance EraTxWits (ShelleyMAEra 'Mary StandardCrypto) #-}
   {-# SPECIALIZE instance EraTxWits (ShelleyMAEra 'Allegra StandardCrypto) #-}
 
-  type TxWits (ShelleyMAEra ma crypto) = ShelleyTxWits (ShelleyMAEra ma crypto)
+  type TxWits (ShelleyMAEra ma c) = ShelleyTxWits (ShelleyMAEra ma c)
 
   mkBasicTxWits = mempty
 

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -64,7 +64,7 @@ import Test.QuickCheck (Arbitrary, Gen, arbitrary, frequency)
 
 {------------------------------------------------------------------------------
  EraGen instance for AllegraEra - This instance makes it possible to run the
- Shelley property tests for (AllegraEra crypto)
+ Shelley property tests for (AllegraEra c)
 
  This instance is layered on top of the ShelleyMA instances
  in Cardano.Ledger.ShelleyMA.Scripts:

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -69,7 +69,7 @@ import qualified Test.QuickCheck as QC
 
 {------------------------------------------------------------------------------
  EraGen instance for MaryEra - This instance makes it possible to run the
- Shelley property tests for (MaryEra crypto)
+ Shelley property tests for (MaryEra c)
 
  This instance is layered on top of the ShelleyMA instances
  in Cardano.Ledger.ShelleyMA.Scripts:
@@ -98,9 +98,9 @@ instance (CC.Crypto c, Mock c) => EraGen (MaryEra c) where
   genEraTxWits _scriptinfo setWitVKey mapScriptWit = ShelleyTxWits setWitVKey mapScriptWit mempty
 
 genAuxiliaryData ::
-  Mock crypto =>
+  Mock c =>
   Constants ->
-  Gen (StrictMaybe (AuxiliaryData (MaryEra crypto)))
+  Gen (StrictMaybe (AuxiliaryData (MaryEra c)))
 genAuxiliaryData Constants {frequencyTxWithMetadata} =
   frequency
     [ (frequencyTxWithMetadata, SJust <$> arbitrary),
@@ -108,7 +108,7 @@ genAuxiliaryData Constants {frequencyTxWithMetadata} =
     ]
 
 -- | Carefully crafted to apply in any Era where Value is MaryValue
-maryGenesisValue :: forall era crypto. CC.Crypto crypto => GenEnv era -> Gen (MaryValue crypto)
+maryGenesisValue :: forall era c. CC.Crypto c => GenEnv era -> Gen (MaryValue c)
 maryGenesisValue (GenEnv _ _ Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
   Val.inject . Coin <$> exponential minGenesisOutputVal maxGenesisOutputVal
 

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -195,10 +195,10 @@ genMintValues = multiAssetFromListBounded @Int64 <$> arbitrary
 -- | Variant on @multiAssetFromList@ that makes sure that generated values stay
 -- bounded within the range of a given integral type.
 multiAssetFromListBounded ::
-  forall i crypto.
+  forall i c.
   (Bounded i, Integral i) =>
-  [(PolicyID crypto, AssetName, i)] ->
-  MultiAsset crypto
+  [(PolicyID c, AssetName, i)] ->
+  MultiAsset c
 multiAssetFromListBounded =
   foldr
     (\(p, n, fromIntegral -> i) ans -> ConcreteValue.insert comb p n i ans)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
@@ -52,20 +52,20 @@ pickOld o _n = o
 
 insertValue ::
   (Integer -> Integer -> Integer) ->
-  PolicyID crypto ->
+  PolicyID c ->
   AssetName ->
   Integer ->
-  MaryValue crypto ->
-  MaryValue crypto
+  MaryValue c ->
+  MaryValue c
 insertValue combine pid aid new (MaryValue c m) = MaryValue c $ insert combine pid aid new m
 
 insert3 ::
   (Integer -> Integer -> Integer) ->
-  PolicyID crypto ->
+  PolicyID c ->
   AssetName ->
   Integer ->
-  MaryValue crypto ->
-  MaryValue crypto
+  MaryValue c ->
+  MaryValue c
 insert3 combine pid aid new (MaryValue c (MultiAsset m1)) =
   case Map.lookup pid m1 of
     Nothing ->
@@ -83,19 +83,19 @@ insert3 combine pid aid new (MaryValue c (MultiAsset m1)) =
             canonicalInsert pickNew pid (canonicalInsert pickNew aid (combine old new) m2) m1
 
 -- | Make a Value with no coin, and just one token.
-unit :: PolicyID crypto -> AssetName -> Integer -> MaryValue crypto
+unit :: PolicyID c -> AssetName -> Integer -> MaryValue c
 unit pid aid n = MaryValue 0 $ MultiAsset (canonicalInsert pickNew pid (canonicalInsert pickNew aid n empty) empty)
 
 -- Use <+> and <->
 
 insert2 ::
-  CC.Crypto crypto =>
+  CC.Crypto c =>
   (Integer -> Integer -> Integer) ->
-  PolicyID crypto ->
+  PolicyID c ->
   AssetName ->
   Integer ->
-  MaryValue crypto ->
-  MaryValue crypto
+  MaryValue c ->
+  MaryValue c
 insert2 combine pid aid new m1 =
   -- The trick is to correctly not store a zero. Several ways to get a zero
   case (lookup pid aid m1, new == 0) of

--- a/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
@@ -68,7 +68,7 @@ chainChecks ::
   MonadError ChainPredicateFailure m =>
   Natural ->
   ChainChecksPParams ->
-  BHeaderView crypto ->
+  BHeaderView c ->
   m ()
 chainChecks maxpv ccd bhv = do
   unless (m <= maxpv) $ throwError (ObsoleteNodeCHAIN m maxpv)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -168,10 +168,10 @@ class
           $ res
 
 instance
-  ( CC.Crypto crypto,
-    DSignable crypto (Hash crypto EraIndependentTxBody)
+  ( CC.Crypto c,
+    DSignable c (Hash c EraIndependentTxBody)
   ) =>
-  ApplyTx (ShelleyEra crypto)
+  ApplyTx (ShelleyEra c)
 
 type MempoolEnv era = Ledger.LedgerEnv era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -163,30 +163,30 @@ applyBlock =
         asoEvents = EPDiscard
       }
 
-type ShelleyEraCrypto crypto =
-  ( CC.Crypto crypto,
-    DSignable crypto (Hash crypto EraIndependentTxBody)
+type ShelleyEraCrypto c =
+  ( CC.Crypto c,
+    DSignable c (Hash c EraIndependentTxBody)
   )
 
 {-# DEPRECATED ShelleyEraCrypto "Constraint synonyms are being removed" #-}
 
 instance
-  ( CC.Crypto crypto,
-    DSignable crypto (Hash crypto EraIndependentTxBody)
+  ( CC.Crypto c,
+    DSignable c (Hash c EraIndependentTxBody)
   ) =>
-  ApplyBlock (ShelleyEra crypto)
+  ApplyBlock (ShelleyEra c)
 
 {-------------------------------------------------------------------------------
   CHAIN Transition checks
 -------------------------------------------------------------------------------}
 
 chainChecks ::
-  forall crypto m.
+  forall c m.
   MonadError STS.ChainPredicateFailure m =>
   -- | Max major protocol version
   Natural ->
   STS.ChainChecksPParams ->
-  BHeaderView crypto ->
+  BHeaderView c ->
   m ()
 chainChecks = STS.chainChecks
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -291,7 +291,7 @@ getNonMyopicMemberRewards globals ss creds =
           let ostake = sumPoolOwnersStake pool stake
            in _poolPledge poolp <= ostake
 
-sumPoolOwnersStake :: PoolParams crypto -> EB.Stake crypto -> Coin
+sumPoolOwnersStake :: PoolParams c -> EB.Stake c -> Coin
 sumPoolOwnersStake pool stake =
   let getStakeFor o =
         maybe mempty fromCompact $ VMap.lookup (KeyHashObj o) (EB.unStake stake)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
@@ -264,9 +264,9 @@ slotToNonce (SlotNo s) = mkNonceFromNumber s
 
 incrBlocks ::
   Bool ->
-  KeyHash 'StakePool crypto ->
-  BlocksMade crypto ->
-  BlocksMade crypto
+  KeyHash 'StakePool c ->
+  BlocksMade c ->
+  BlocksMade c
 incrBlocks isOverlay hk b'@(BlocksMade b)
   | isOverlay = b'
   | otherwise = BlocksMade $ case hkVal of

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/PoolParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Delegation/PoolParams.hs
@@ -7,5 +7,5 @@ import Cardano.Ledger.BaseTypes (UnitInterval)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 
-poolSpec :: PoolParams crypto -> (Coin, UnitInterval, Coin)
+poolSpec :: PoolParams c -> (Coin, UnitInterval, Coin)
 poolSpec pool = (_poolCost pool, _poolMargin pool, _poolPledge pool)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core (Era (..), EraRule, TranslationContext, Value)
 import Cardano.Ledger.Crypto as CC (Crypto)
 
-data ShelleyEra crypto
+data ShelleyEra c
 
 instance CC.Crypto c => Era (ShelleyEra c) where
   type EraCrypto (ShelleyEra c) = c

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -141,7 +141,7 @@ filterAllRewards rs' (EpochState _as _ss ls pr _pp _nm) =
 --   aggregate (dom activeDelegs ◁ rewards) step1
 --
 --   TO IncrementalStake
-aggregateActiveStake :: Ord k => Map k (Triple crypto) -> Map k Coin -> Map k Coin
+aggregateActiveStake :: Ord k => Map k (Triple c) -> Map k Coin -> Map k Coin
 aggregateActiveStake =
   Map.mergeWithKey
     -- How to merge the ranges of the two maps where they have a common key. Below
@@ -265,11 +265,11 @@ applyRUpd'
 --   step2 =  aggregate (dom activeDelegs ◁ rewards) step1
 --   This function has a non-incremental analog, 'stakeDistr', mosty used in tests, which does use the UTxO.
 incrementalStakeDistr ::
-  forall crypto.
-  IncrementalStake crypto ->
-  DState crypto ->
-  PState crypto ->
-  SnapShot crypto
+  forall c.
+  IncrementalStake c ->
+  DState c ->
+  PState c ->
+  SnapShot c
 incrementalStakeDistr incstake ds ps =
   SnapShot
     (Stake $ VMap.fromMap (compactCoinOrError <$> step2))
@@ -288,10 +288,10 @@ incrementalStakeDistr incstake ds ps =
 --   keep ony the active credentials.
 --   This is  step1 = (dom activeDelegs ◁ credStake) ∪ (dom activeDelegs ◁ ptrStake)
 resolveActiveIncrementalPtrs ::
-  (Credential 'Staking crypto -> Bool) ->
-  Map Ptr (Credential 'Staking crypto) ->
-  IncrementalStake crypto ->
-  Map (Credential 'Staking crypto) Coin
+  (Credential 'Staking c -> Bool) ->
+  Map Ptr (Credential 'Staking c) ->
+  IncrementalStake c ->
+  Map (Credential 'Staking c) Coin
 resolveActiveIncrementalPtrs isActive ptrMap_ (IStake credStake ptrStake) =
   Map.foldlWithKey' accum step1A ptrStake -- step1A  ∪ (dom activeDelegs ◁ ptrStake)
   where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -65,7 +65,7 @@ import Lens.Micro.Extras (view)
 -- | This function returns the coin balance of a given pot, either the
 -- reserves or the treasury, after the instantaneous rewards and pot
 -- transfers are accounted for.
-availableAfterMIR :: MIRPot -> AccountState -> InstantaneousRewards crypto -> Coin
+availableAfterMIR :: MIRPot -> AccountState -> InstantaneousRewards c -> Coin
 availableAfterMIR ReservesMIR as ir =
   _reserves as `addDeltaCoin` deltaReserves ir <-> fold (iRReserves ir)
 availableAfterMIR TreasuryMIR as ir =
@@ -128,9 +128,9 @@ depositPoolChange ls pp txBody = (currentPool <+> txDeposits) <-> txRefunds
     txRefunds = keyRefunds pp txBody
 
 reapRewards ::
-  UnifiedMap crypto ->
-  RewardAccounts crypto ->
-  UnifiedMap crypto
+  UnifiedMap c ->
+  RewardAccounts c ->
+  UnifiedMap c
 reapRewards (UnifiedMap tmap ptrmap) withdrawals = UnifiedMap (Map.mapWithKey g tmap) ptrmap
   where
     g k (Triple x y z) = Triple (fmap (removeRewards k) x) y z

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
@@ -249,8 +249,8 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) max
 
 -- | Run the pulser for a bit. If is has nothing left to do, complete it.
 pulseStep ::
-  PulsingRewUpdate crypto ->
-  ShelleyBase (PulsingRewUpdate crypto, RewardEvent crypto)
+  PulsingRewUpdate c ->
+  ShelleyBase (PulsingRewUpdate c, RewardEvent c)
 pulseStep (Complete r_) = pure (Complete r_, mempty)
 pulseStep p@(Pulsing _ pulser) | done pulser = completeStep p
 pulseStep (Pulsing rewsnap pulser) = do
@@ -261,8 +261,8 @@ pulseStep (Pulsing rewsnap pulser) = do
 -- Phase 3
 
 completeStep ::
-  PulsingRewUpdate crypto ->
-  ShelleyBase (PulsingRewUpdate crypto, RewardEvent crypto)
+  PulsingRewUpdate c ->
+  ShelleyBase (PulsingRewUpdate c, RewardEvent c)
 completeStep (Complete r) = pure (Complete r, mempty)
 completeStep (Pulsing rewsnap pulser) = do
   (p2, !event) <- completeRupd (Pulsing rewsnap pulser)
@@ -274,8 +274,8 @@ completeStep (Pulsing rewsnap pulser) = do
 --   c) Construct the final RewardUpdate
 --   d) Add the leader rewards to both the events and the computed Rewards
 completeRupd ::
-  PulsingRewUpdate crypto ->
-  ShelleyBase (RewardUpdate crypto, RewardEvent crypto)
+  PulsingRewUpdate c ->
+  ShelleyBase (RewardUpdate c, RewardEvent c)
 completeRupd (Complete x) = pure (x, mempty)
 completeRupd
   ( Pulsing
@@ -342,10 +342,10 @@ decayFactor :: Float
 decayFactor = 0.9
 
 updateNonMyopic ::
-  NonMyopic crypto ->
+  NonMyopic c ->
   Coin ->
-  Map (KeyHash 'StakePool crypto) Likelihood ->
-  NonMyopic crypto
+  Map (KeyHash 'StakePool c) Likelihood ->
+  NonMyopic c
 updateNonMyopic nm rPot_ newLikelihoods =
   nm
     { likelihoodsNM = updatedLikelihoods,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -72,10 +72,10 @@ import Lens.Micro (_1, _2)
 import NoThunks.Class (NoThunks (..))
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
-type KeyPairs crypto = [(KeyPair 'Payment crypto, KeyPair 'Staking crypto)]
+type KeyPairs c = [(KeyPair 'Payment c, KeyPair 'Staking c)]
 
-type RewardAccounts crypto =
-  Map (Credential 'Staking crypto) Coin
+type RewardAccounts c =
+  Map (Credential 'Staking c) Coin
 
 data AccountState = AccountState
   { _treasury :: !Coin,
@@ -208,18 +208,18 @@ deriving stock instance
 --   that might point to something by the time the epoch boundary is reached. When
 --   the epoch boundary is reached we 'resolve' these pointers, to see if any have
 --   become non-dangling since the time they were first used in the incremental computation.
-data IncrementalStake crypto = IStake
-  { credMap :: !(Map (Credential 'Staking crypto) Coin),
+data IncrementalStake c = IStake
+  { credMap :: !(Map (Credential 'Staking c) Coin),
     ptrMap :: !(Map Ptr Coin)
   }
   deriving (Generic, Show, Eq, Ord, NoThunks, NFData)
 
-instance CC.Crypto crypto => ToCBOR (IncrementalStake crypto) where
+instance CC.Crypto c => ToCBOR (IncrementalStake c) where
   toCBOR (IStake st dangle) =
     encodeListLen 2 <> mapToCBOR st <> mapToCBOR dangle
 
-instance CC.Crypto crypto => FromSharedCBOR (IncrementalStake crypto) where
-  type Share (IncrementalStake crypto) = Interns (Credential 'Staking crypto)
+instance CC.Crypto c => FromSharedCBOR (IncrementalStake c) where
+  type Share (IncrementalStake c) = Interns (Credential 'Staking c)
   fromSharedCBOR credInterns =
     decodeRecordNamed "Stake" (const 2) $ do
       stake <- fromSharedCBOR (credInterns, mempty)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Metadata.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Metadata.hs
@@ -85,12 +85,12 @@ data Metadata era = Metadata'
   deriving (Eq, Show, Ord, Generic)
   deriving (NoThunks) via AllowThunksIn '["mdBytes"] (Metadata era)
 
-instance CC.Crypto crypto => EraAuxiliaryData (ShelleyEra crypto) where
-  type AuxiliaryData (ShelleyEra crypto) = Metadata (ShelleyEra crypto)
+instance CC.Crypto c => EraAuxiliaryData (ShelleyEra c) where
+  type AuxiliaryData (ShelleyEra c) = Metadata (ShelleyEra c)
 
   validateAuxiliaryData _ (Metadata m) = all validMetadatum m
   hashAuxiliaryData metadata =
-    AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @crypto) index metadata)
+    AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)
     where
       index = Proxy @EraIndependentAuxiliaryData
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -170,9 +170,9 @@ type ShelleyPParams era = ShelleyPParamsHKD Identity era
 
 type ShelleyPParamsUpdate era = ShelleyPParamsHKD StrictMaybe era
 
-instance CC.Crypto crypto => EraPParams (ShelleyEra crypto) where
-  type PParams (ShelleyEra crypto) = ShelleyPParams (ShelleyEra crypto)
-  type PParamsUpdate (ShelleyEra crypto) = ShelleyPParamsUpdate (ShelleyEra crypto)
+instance CC.Crypto c => EraPParams (ShelleyEra c) where
+  type PParams (ShelleyEra c) = ShelleyPParams (ShelleyEra c)
+  type PParamsUpdate (ShelleyEra c) = ShelleyPParamsUpdate (ShelleyEra c)
 
   applyPPUpdates = updatePParams
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolParams.hs
@@ -209,26 +209,26 @@ instance FromCBOR StakePoolRelay where
       k -> invalidKey k
 
 -- | A stake pool.
-data PoolParams crypto = PoolParams
-  { _poolId :: !(KeyHash 'StakePool crypto),
-    _poolVrf :: !(Hash crypto (VerKeyVRF crypto)),
+data PoolParams c = PoolParams
+  { _poolId :: !(KeyHash 'StakePool c),
+    _poolVrf :: !(Hash c (VerKeyVRF c)),
     _poolPledge :: !Coin,
     _poolCost :: !Coin,
     _poolMargin :: !UnitInterval,
-    _poolRAcnt :: !(RewardAcnt crypto),
-    _poolOwners :: !(Set (KeyHash 'Staking crypto)),
+    _poolRAcnt :: !(RewardAcnt c),
+    _poolOwners :: !(Set (KeyHash 'Staking c)),
     _poolRelays :: !(StrictSeq StakePoolRelay),
     _poolMD :: !(StrictMaybe PoolMetadata)
   }
   deriving (Show, Generic, Eq, Ord)
-  deriving (ToCBOR) via CBORGroup (PoolParams crypto)
-  deriving (FromCBOR) via CBORGroup (PoolParams crypto)
+  deriving (ToCBOR) via CBORGroup (PoolParams c)
+  deriving (FromCBOR) via CBORGroup (PoolParams c)
 
-instance NoThunks (PoolParams crypto)
+instance NoThunks (PoolParams c)
 
-deriving instance NFData (PoolParams crypto)
+deriving instance NFData (PoolParams c)
 
-instance CC.Crypto crypto => ToJSON (PoolParams crypto) where
+instance CC.Crypto c => ToJSON (PoolParams c) where
   toJSON pp =
     Aeson.object
       [ "publicKey" .= _poolId pp, -- TODO publicKey is an unfortunate name, should be poolId
@@ -242,7 +242,7 @@ instance CC.Crypto crypto => ToJSON (PoolParams crypto) where
         "metadata" .= _poolMD pp
       ]
 
-instance CC.Crypto crypto => FromJSON (PoolParams crypto) where
+instance CC.Crypto c => FromJSON (PoolParams c) where
   parseJSON =
     Aeson.withObject "PoolParams" $ \obj ->
       PoolParams
@@ -281,8 +281,8 @@ instance ToCBOR SizeOfPoolRelays where
   toCBOR = panic "The `SizeOfPoolRelays` type cannot be encoded!"
 
 instance
-  CC.Crypto crypto =>
-  ToCBORGroup (PoolParams crypto)
+  CC.Crypto c =>
+  ToCBORGroup (PoolParams c)
   where
   toCBORGroup poolParams =
     toCBOR (_poolId poolParams)
@@ -321,8 +321,8 @@ instance
   listLenBound _ = 9
 
 instance
-  CC.Crypto crypto =>
-  FromCBORGroup (PoolParams crypto)
+  CC.Crypto c =>
+  FromCBORGroup (PoolParams c)
   where
   fromCBORGroup = do
     hk <- fromCBOR

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
@@ -222,20 +222,20 @@ instance ToCBOR PerformanceEstimate where
 instance FromCBOR PerformanceEstimate where
   fromCBOR = PerformanceEstimate <$> decodeDouble
 
-data NonMyopic crypto = NonMyopic
-  { likelihoodsNM :: !(Map (KeyHash 'StakePool crypto) Likelihood),
+data NonMyopic c = NonMyopic
+  { likelihoodsNM :: !(Map (KeyHash 'StakePool c) Likelihood),
     rewardPotNM :: !Coin
   }
   deriving (Show, Eq, Generic)
 
-instance Default (NonMyopic crypto) where
+instance Default (NonMyopic c) where
   def = NonMyopic Map.empty (Coin 0)
 
-instance NoThunks (NonMyopic crypto)
+instance NoThunks (NonMyopic c)
 
-instance NFData (NonMyopic crypto)
+instance NFData (NonMyopic c)
 
-instance CC.Crypto crypto => ToCBOR (NonMyopic crypto) where
+instance CC.Crypto c => ToCBOR (NonMyopic c) where
   toCBOR
     NonMyopic
       { likelihoodsNM = aps,
@@ -245,8 +245,8 @@ instance CC.Crypto crypto => ToCBOR (NonMyopic crypto) where
         <> toCBOR aps
         <> toCBOR rp
 
-instance CC.Crypto crypto => FromSharedCBOR (NonMyopic crypto) where
-  type Share (NonMyopic crypto) = Interns (KeyHash 'StakePool crypto)
+instance CC.Crypto c => FromSharedCBOR (NonMyopic c) where
+  type Share (NonMyopic c) = Interns (KeyHash 'StakePool c)
   fromSharedPlusCBOR = do
     decodeRecordNamedT "NonMyopic" (const 2) $ do
       likelihoodsNM <- fromSharedPlusLensCBOR (toMemptyLens _1 id)
@@ -286,9 +286,9 @@ getTopRankedPools ::
   Coin ->
   Coin ->
   pp ->
-  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
-  Map (KeyHash 'StakePool crypto) PerformanceEstimate ->
-  Set (KeyHash 'StakePool crypto)
+  Map (KeyHash 'StakePool c) (PoolParams c) ->
+  Map (KeyHash 'StakePool c) PerformanceEstimate ->
+  Set (KeyHash 'StakePool c)
 getTopRankedPools rPot totalStake pp poolParams aps =
   let pdata = Map.toAscList $ Map.intersectionWith (,) poolParams aps
    in getTopRankedPoolsInternal rPot totalStake pp pdata
@@ -298,9 +298,9 @@ getTopRankedPoolsVMap ::
   Coin ->
   Coin ->
   pp ->
-  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool crypto) (PoolParams crypto) ->
-  Map (KeyHash 'StakePool crypto) PerformanceEstimate ->
-  Set (KeyHash 'StakePool crypto)
+  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool c) (PoolParams c) ->
+  Map (KeyHash 'StakePool c) PerformanceEstimate ->
+  Set (KeyHash 'StakePool c)
 getTopRankedPoolsVMap rPot totalStake pp poolParams aps =
   let pdata = [(kh, (pps, a)) | (kh, a) <- Map.toAscList aps, Just pps <- [VMap.lookup kh poolParams]]
    in getTopRankedPoolsInternal rPot totalStake pp pdata
@@ -310,8 +310,8 @@ getTopRankedPoolsInternal ::
   Coin ->
   Coin ->
   pp ->
-  [(KeyHash 'StakePool crypto, (PoolParams crypto, PerformanceEstimate))] ->
-  Set (KeyHash 'StakePool crypto)
+  [(KeyHash 'StakePool c, (PoolParams c, PerformanceEstimate))] ->
+  Set (KeyHash 'StakePool c)
 getTopRankedPoolsInternal rPot totalStake pp pdata =
   Set.fromList $
     fst

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardProvenance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardProvenance.hs
@@ -48,7 +48,7 @@ import Numeric.Natural (Natural)
 -- ==========================================================
 
 -- | Provenance for an individual stake pool's reward calculation.
-data RewardProvenancePool crypto = RewardProvenancePool
+data RewardProvenancePool c = RewardProvenancePool
   { -- | The number of blocks the pool produced.
     poolBlocksP :: !Natural,
     -- | The stake pool's stake share (portion of the total stake).
@@ -60,7 +60,7 @@ data RewardProvenancePool crypto = RewardProvenancePool
     -- the stake pool will not earn any rewards for the given epoch.
     ownerStakeP :: !Coin,
     -- | The stake pool's registered parameters.
-    poolParamsP :: !(PoolParams crypto),
+    poolParamsP :: !(PoolParams c),
     -- | The stake pool's pledge.
     pledgeRatioP :: !Rational,
     -- | The maximum number of Lovelace this stake pool can earn.
@@ -76,15 +76,15 @@ data RewardProvenancePool crypto = RewardProvenancePool
   }
   deriving (Eq, Generic)
 
-instance NoThunks (RewardProvenancePool crypto)
+instance NoThunks (RewardProvenancePool c)
 
-instance NFData (RewardProvenancePool crypto)
+instance NFData (RewardProvenancePool c)
 
-deriving instance (CC.Crypto crypto) => FromJSON (RewardProvenancePool crypto)
+deriving instance (CC.Crypto c) => FromJSON (RewardProvenancePool c)
 
-deriving instance (CC.Crypto crypto) => ToJSON (RewardProvenancePool crypto)
+deriving instance (CC.Crypto c) => ToJSON (RewardProvenancePool c)
 
-instance CC.Crypto crypto => Default (RewardProvenancePool crypto) where
+instance CC.Crypto c => Default (RewardProvenancePool c) where
   def = RewardProvenancePool 0 0 0 (Coin 0) def 0 (Coin 0) 0 (Coin 0) (Coin 0)
 
 -- | The desirability score of a stake pool, as described
@@ -113,12 +113,12 @@ instance NFData Desirability
 --  The variable names here align with those in the specification.
 --  See also Section 5 of the
 --  <https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec Design Specification>.
-data RewardProvenance crypto = RewardProvenance
+data RewardProvenance c = RewardProvenance
   { -- | The number of slots per epoch.
     spe :: !Word64,
     -- | A map from pool ID (the key hash of the stake pool operator's
     -- verification key) to the number of blocks made in the given epoch.
-    blocks :: !(BlocksMade crypto),
+    blocks :: !(BlocksMade c),
     -- | The maximum Lovelace supply. On mainnet, this value is equal to
     -- 45 * 10^15 (45 billion ADA).
     maxLL :: !Coin,
@@ -151,13 +151,13 @@ data RewardProvenance crypto = RewardProvenance
     -- | Individual stake pool provenance.
     pools ::
       !( Map
-           (KeyHash 'StakePool crypto)
-           (RewardProvenancePool crypto)
+           (KeyHash 'StakePool c)
+           (RewardProvenancePool c)
        ),
     -- | A map from pool ID to the desirability score.
     -- See the <https://hydra.iohk.io/job/Cardano/cardano-ledger/specs.pool-ranking/latest/download-by-type/doc-pdf/pool-ranking stake pool ranking document>.
     desirabilities ::
-      !(Map (KeyHash 'StakePool crypto) Desirability)
+      !(Map (KeyHash 'StakePool c) Desirability)
   }
   deriving (Eq, Generic)
 
@@ -165,15 +165,15 @@ deriving instance FromJSON Desirability
 
 deriving instance ToJSON Desirability
 
-deriving instance (CC.Crypto crypto) => FromJSON (RewardProvenance crypto)
+deriving instance (CC.Crypto c) => FromJSON (RewardProvenance c)
 
-deriving instance (CC.Crypto crypto) => ToJSON (RewardProvenance crypto)
+deriving instance (CC.Crypto c) => ToJSON (RewardProvenance c)
 
-instance NoThunks (RewardProvenance crypto)
+instance NoThunks (RewardProvenance c)
 
-instance NFData (RewardProvenance crypto)
+instance NFData (RewardProvenance c)
 
-instance Default (RewardProvenance crypto) where
+instance Default (RewardProvenance c) where
   def =
     RewardProvenance
       0
@@ -193,13 +193,13 @@ instance Default (RewardProvenance crypto) where
       def
       def
 
-instance CC.Crypto crypto => Default (PoolParams crypto) where
+instance CC.Crypto c => Default (PoolParams c) where
   def = PoolParams def def (Coin 0) (Coin 0) def def def def def
 
 instance CC.Crypto e => Default (Credential r e) where
   def = KeyHashObj def
 
-instance CC.Crypto crypto => Default (RewardAcnt crypto) where
+instance CC.Crypto c => Default (RewardAcnt c) where
   def = RewardAcnt def def
 
 instance CC.Crypto c => Default (SafeHash c i) where
@@ -211,7 +211,7 @@ instance CC.Crypto c => Default (SafeHash c i) where
 mylines :: Int -> [String] -> String
 mylines n xs = unlines (map (replicate n ' ' ++) xs)
 
-instance Show (RewardProvenancePool crypto) where
+instance Show (RewardProvenancePool c) where
   show t =
     "RewardProvenancePool\n"
       ++ mylines
@@ -228,7 +228,7 @@ instance Show (RewardProvenancePool crypto) where
           "lReward = " ++ show (lRewardP t)
         ]
 
-showPoolParams :: PoolParams crypto -> String
+showPoolParams :: PoolParams c -> String
 showPoolParams x =
   "PoolParams\n"
     ++ mylines
@@ -244,7 +244,7 @@ showPoolParams x =
         "poolMD = " ++ show (_poolMD x)
       ]
 
-instance Show (RewardProvenance crypto) where
+instance Show (RewardProvenance c) where
   show t =
     "RewardProvenance\n"
       ++ mylines
@@ -278,8 +278,8 @@ instance FromCBOR Desirability where
   fromCBOR = decode $ RecD Desirability <! D decodeDouble <! D decodeDouble
 
 instance
-  (CC.Crypto crypto) =>
-  ToCBOR (RewardProvenancePool crypto)
+  (CC.Crypto c) =>
+  ToCBOR (RewardProvenancePool c)
   where
   toCBOR (RewardProvenancePool p1 p2 p3 p4 p5 p6 p7 p8 p9 p10) =
     encode $
@@ -296,8 +296,8 @@ instance
         !> To p10
 
 instance
-  (CC.Crypto crypto) =>
-  FromCBOR (RewardProvenancePool crypto)
+  (CC.Crypto c) =>
+  FromCBOR (RewardProvenancePool c)
   where
   fromCBOR =
     decode $
@@ -314,8 +314,8 @@ instance
         <! From
 
 instance
-  (CC.Crypto crypto) =>
-  ToCBOR (RewardProvenance crypto)
+  (CC.Crypto c) =>
+  ToCBOR (RewardProvenance c)
   where
   toCBOR (RewardProvenance p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16) =
     encode $
@@ -338,8 +338,8 @@ instance
         !> To p16
 
 instance
-  (CC.Crypto crypto) =>
-  FromCBOR (RewardProvenance crypto)
+  (CC.Crypto c) =>
+  FromCBOR (RewardProvenance c)
   where
   fromCBOR =
     decode $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -252,7 +252,7 @@ delegsTransition = do
     -- than the latter into the right shape so we can call 'Map.isSubmapOf'.
     isSubmapOf ::
       Map (RewardAcnt (EraCrypto era)) Coin ->
-      ViewMap (EraCrypto era) (Credential 'Staking crypto) Coin ->
+      ViewMap (EraCrypto era) (Credential 'Staking c) Coin ->
       Bool
     isSubmapOf wdrls_ (Rewards (UnifiedMap tripmap _)) = Map.isSubmapOfBy f withdrawalMap tripmap
       where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
@@ -161,5 +161,5 @@ mirTransition = do
           pp
           nm
 
-emptyInstantaneousRewards :: InstantaneousRewards crypto
+emptyInstantaneousRewards :: InstantaneousRewards c
 emptyInstantaneousRewards = InstantaneousRewards Map.empty Map.empty mempty mempty

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -202,10 +202,10 @@ tellReward ::
 tellReward (DeltaRewardEvent (RupdEvent _ m)) | Map.null m = pure ()
 tellReward x = tellEvent x
 
-calculatePoolDistr :: SnapShot crypto -> PoolDistr crypto
+calculatePoolDistr :: SnapShot c -> PoolDistr c
 calculatePoolDistr = calculatePoolDistr' (const True)
 
-calculatePoolDistr' :: forall crypto. (KeyHash 'StakePool crypto -> Bool) -> SnapShot crypto -> PoolDistr crypto
+calculatePoolDistr' :: forall c. (KeyHash 'StakePool c -> Bool) -> SnapShot c -> PoolDistr c
 calculatePoolDistr' includeHash (SnapShot stake delegs poolParams) =
   let Coin total = sumAllStake stake
       -- total could be zero (in particular when shrinking)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -108,10 +108,10 @@ instance
   initialRules = [pure SNothing]
   transitionRules = [rupdTransition]
 
-data RupdEvent crypto
+data RupdEvent c
   = RupdEvent
       !EpochNo
-      !(Map.Map (Credential 'Staking crypto) (Set (Reward crypto)))
+      !(Map.Map (Credential 'Staking c) (Set (Reward c)))
 
 -- | tell a RupdEvent only if the map is non-empty
 tellRupd :: String -> RupdEvent (EraCrypto era) -> Rule (ShelleyRUPD era) rtype ()

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -190,10 +190,10 @@ mkBasicShelleyTx txBody =
         _auxiliaryData = SNothing
       }
 
-instance CC.Crypto crypto => EraTx (ShelleyEra crypto) where
+instance CC.Crypto c => EraTx (ShelleyEra c) where
   {-# SPECIALIZE instance EraTx (ShelleyEra CC.StandardCrypto) #-}
 
-  type Tx (ShelleyEra crypto) = ShelleyTx (ShelleyEra crypto)
+  type Tx (ShelleyEra c) = ShelleyTx (ShelleyEra c)
 
   mkBasicTx = mkBasicShelleyTx
 
@@ -383,9 +383,9 @@ txwitsScript ::
 txwitsScript tx = tx ^. witsTxL . scriptTxWitsL
 
 extractKeyHashWitnessSet ::
-  forall (r :: KeyRole) crypto.
-  [Credential r crypto] ->
-  Set (KeyHash 'Witness crypto)
+  forall (r :: KeyRole) c.
+  [Credential r c] ->
+  Set (KeyHash 'Witness c)
 extractKeyHashWitnessSet = foldr accum Set.empty
   where
     accum (KeyHashObj hk) ans = Set.insert (asWitness hk) ans

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -133,14 +133,14 @@ import NoThunks.Class (NoThunks (..))
 
 -- ========================================================================
 
-newtype Wdrl crypto = Wdrl {unWdrl :: Map (RewardAcnt crypto) Coin}
+newtype Wdrl c = Wdrl {unWdrl :: Map (RewardAcnt c) Coin}
   deriving (Show, Eq, Generic)
   deriving newtype (NoThunks, NFData)
 
-instance CC.Crypto crypto => ToCBOR (Wdrl crypto) where
+instance CC.Crypto c => ToCBOR (Wdrl c) where
   toCBOR = mapToCBOR . unWdrl
 
-instance CC.Crypto crypto => FromCBOR (Wdrl crypto) where
+instance CC.Crypto c => FromCBOR (Wdrl c) where
   fromCBOR = Wdrl <$> mapFromCBOR
 
 -- ---------------------------
@@ -279,10 +279,10 @@ type TxBody era = ShelleyTxBody era
 
 {-# DEPRECATED TxBody "Use `ShelleyTxBody` instead" #-}
 
-instance CC.Crypto crypto => EraTxBody (ShelleyEra crypto) where
+instance CC.Crypto c => EraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxBody (ShelleyEra CC.StandardCrypto) #-}
 
-  type TxBody (ShelleyEra crypto) = ShelleyTxBody (ShelleyEra crypto)
+  type TxBody (ShelleyEra c) = ShelleyTxBody (ShelleyEra c)
 
   mkBasicTxBody = mkShelleyTxBody baseTxBodyRaw
 
@@ -325,7 +325,7 @@ class EraTxBody era => ShelleyEraTxBody era where
 
   certsTxBodyL :: Lens' (Core.TxBody era) (StrictSeq (DCert (EraCrypto era)))
 
-instance CC.Crypto crypto => ShelleyEraTxBody (ShelleyEra crypto) where
+instance CC.Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyEra CC.StandardCrypto) #-}
 
   wdrlsTxBodyL =
@@ -404,8 +404,8 @@ mkShelleyTxBody = TxBodyConstr . memoBytes . txSparse
 type instance MemoHashIndex TxBodyRaw = EraIndependentTxBody
 
 instance
-  (Era era, crypto ~ EraCrypto era) =>
-  HashAnnotated (ShelleyTxBody era) EraIndependentTxBody crypto
+  (Era era, c ~ EraCrypto era) =>
+  HashAnnotated (ShelleyTxBody era) EraIndependentTxBody c
   where
   hashAnnotated (TxBodyConstr mb) = mbHash mb
 
@@ -414,10 +414,10 @@ instance Era era => ToCBOR (TxBody era) where
 
 -- ===============================================================
 
-witKeyHash :: WitVKey kr crypto -> KeyHash 'Witness crypto
+witKeyHash :: WitVKey kr c -> KeyHash 'Witness c
 witKeyHash = witVKeyHash
 {-# DEPRECATED witKeyHash "In favor of `witVKeyHash`" #-}
 
-wvkBytes :: WitVKey kr crypto -> BSL.ByteString
+wvkBytes :: WitVKey kr c -> BSL.ByteString
 wvkBytes = witVKeyBytes
 {-# DEPRECATED wvkBytes "In favor of `witVKeyBytes`" #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -174,10 +174,10 @@ scriptShelleyTxWitsL =
     (\w s -> w {scriptWits = s})
 {-# INLINEABLE scriptShelleyTxWitsL #-}
 
-instance CC.Crypto crypto => EraTxWits (ShelleyEra crypto) where
+instance CC.Crypto c => EraTxWits (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxWits (ShelleyEra CC.StandardCrypto) #-}
 
-  type TxWits (ShelleyEra crypto) = ShelleyTxWits (ShelleyEra crypto)
+  type TxWits (ShelleyEra c) = ShelleyTxWits (ShelleyEra c)
 
   mkBasicTxWits = mempty
 
@@ -251,10 +251,10 @@ instance EraScript era => FromCBOR (Annotator (ShelleyTxWits era)) where
 
 -- | This type is only used to preserve the old buggy behavior where signature
 -- was ignored in the `Ord` instance for `WitVKey`s.
-newtype IgnoreSigOrd kr crypto = IgnoreSigOrd {unIgnoreSigOrd :: WitVKey kr crypto}
+newtype IgnoreSigOrd kr c = IgnoreSigOrd {unIgnoreSigOrd :: WitVKey kr c}
   deriving (Eq)
 
-instance (Typeable kr, CC.Crypto crypto) => Ord (IgnoreSigOrd kr crypto) where
+instance (Typeable kr, CC.Crypto c) => Ord (IgnoreSigOrd kr c) where
   compare (IgnoreSigOrd w1) (IgnoreSigOrd w2) = compare (witVKeyHash w1) (witVKeyHash w2)
 
 decodeWits :: forall era s. EraScript era => Decoder s (Annotator (ShelleyTxWits era))

--- a/eras/shelley/test-suite/bench/BenchUTxOAggregate.hs
+++ b/eras/shelley/test-suite/bench/BenchUTxOAggregate.hs
@@ -85,11 +85,11 @@ genTestCase numUTxO numAddr = do
   pure (dstate, pstate, UTxO utxo)
 
 makeStatePair ::
-  Map (Credential 'Staking crypto) Coin ->
-  Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto) ->
-  Map Ptr (Credential 'Staking crypto) ->
-  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
-  (DState crypto, PState crypto)
+  Map (Credential 'Staking c) Coin ->
+  Map (Credential 'Staking c) (KeyHash 'StakePool c) ->
+  Map Ptr (Credential 'Staking c) ->
+  Map (KeyHash 'StakePool c) (PoolParams c) ->
+  (DState c, PState c)
 makeStatePair rewards' delegs ptrs' poolParams =
   ( DState
       (UM.unify rewards' delegs ptrs')

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
@@ -165,7 +165,7 @@ genChainInEpoch epoch = do
         go !acc [] = acc
         go !acc xs' = let (a, b) = splitAt n xs' in go (a : acc) b
 
-    addrToKeyHash :: Addr crypto -> Maybe (KeyHash 'Staking crypto)
+    addrToKeyHash :: Addr c -> Maybe (KeyHash 'Staking c)
     addrToKeyHash (Addr _ _ (StakeRefBase (KeyHashObj kh))) = Just kh
     addrToKeyHash _ = Nothing
 

--- a/eras/shelley/test-suite/bench/Main.hs
+++ b/eras/shelley/test-suite/bench/Main.hs
@@ -169,7 +169,7 @@ profileUTxO = do
 -- ==========================================
 -- Registering Stake Keys
 
-touchDPState :: DPState crypto -> Int
+touchDPState :: DPState c -> Int
 touchDPState (DPState _x _y) = 1
 
 touchUTxOState :: Cardano.Ledger.Shelley.LedgerState.UTxOState cryto -> Int

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -117,7 +117,7 @@ genSignature =
     . DSIGN.rawDeserialiseSigDSIGN
     <$> hedgehog (Hedgehog.Gen.bytes . Hedgehog.Range.singleton . fromIntegral $ DSIGN.sizeSigDSIGN ([] @a))
 
-genBootstrapAddress :: Gen (BootstrapAddress crypto)
+genBootstrapAddress :: Gen (BootstrapAddress c)
 genBootstrapAddress = BootstrapAddress . snd <$> genByronVKeyAddr
 
 genByronVKeyAddr :: Gen (Byron.VerificationKey, Byron.Address)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
@@ -34,29 +34,29 @@ import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.QuickCheck
 import Test.QuickCheck.Gen (chooseWord64)
 
-propValidateNewDecompact :: forall crypto. CC.Crypto crypto => Addr crypto -> Property
+propValidateNewDecompact :: forall c. CC.Crypto c => Addr c -> Property
 propValidateNewDecompact addr =
   let bs = serialiseAddr addr
       compact = SBS.toShort bs
-      decompactedOld = deserialiseAddr @crypto bs
-      decompactedNew = CA.decodeAddrShort @crypto compact
+      decompactedOld = deserialiseAddr @c bs
+      decompactedNew = CA.decodeAddrShort @c compact
    in isJust decompactedOld .&&. decompactedOld === decompactedNew
 
-propCompactAddrRoundTrip :: CC.Crypto crypto => Addr crypto -> Bool
+propCompactAddrRoundTrip :: CC.Crypto c => Addr c -> Bool
 propCompactAddrRoundTrip addr =
   let compact = CA.compactAddr addr
       decompact = CA.decompactAddr compact
    in addr == decompact
 
-propCompactSerializationAgree :: Addr crypto -> Bool
+propCompactSerializationAgree :: Addr c -> Bool
 propCompactSerializationAgree addr =
   let (CA.UnsafeCompactAddr sbs) = CA.compactAddr addr
    in sbs == SBS.toShort (serialiseAddr addr)
 
-propDecompactErrors :: forall crypto. CC.Crypto crypto => Addr crypto -> Gen Property
+propDecompactErrors :: forall c. CC.Crypto c => Addr c -> Gen Property
 propDecompactErrors addr = do
   let (CA.UnsafeCompactAddr sbs) = CA.compactAddr addr
-      hashLen = fromIntegral $ Hash.sizeHash (Proxy :: Proxy (CC.ADDRHASH crypto))
+      hashLen = fromIntegral $ Hash.sizeHash (Proxy :: Proxy (CC.ADDRHASH c))
       bs = SBS.fromShort sbs
       flipHeaderBit b =
         case BS.uncons bs of
@@ -115,9 +115,9 @@ propDecompactErrors addr = do
   pure $
     counterexample
       ("Mingled address with " ++ mingler ++ " was parsed: " ++ show badAddr)
-      $ isLeft $ CA.decodeAddrEither @crypto badAddr
+      $ isLeft $ CA.decodeAddrEither @c badAddr
 
-propDeserializeRewardAcntErrors :: forall crypto. CC.Crypto crypto => RewardAcnt crypto -> Gen Property
+propDeserializeRewardAcntErrors :: forall c. CC.Crypto c => RewardAcnt c -> Gen Property
 propDeserializeRewardAcntErrors acnt = do
   let bs = serialize' acnt
       flipHeaderBit b =
@@ -142,4 +142,4 @@ propDeserializeRewardAcntErrors acnt = do
   pure $
     counterexample
       ("Mingled address with " ++ mingler ++ " was parsed: " ++ show badAddr)
-      $ isNothing $ CA.decodeRewardAcnt @crypto badAddr
+      $ isNothing $ CA.decodeRewardAcnt @c badAddr

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ByronTranslation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ByronTranslation.hs
@@ -46,17 +46,17 @@ prop_translateTxOut_correctness compactTxOut =
 ------------------------------------------------------------------------------}
 
 translateTxOutByronToShelley ::
-  forall crypto.
-  CryptoClass.Crypto crypto =>
+  forall c.
+  CryptoClass.Crypto c =>
   Byron.TxOut ->
-  ShelleyTxOut (ShelleyEra crypto)
+  ShelleyTxOut (ShelleyEra c)
 translateTxOutByronToShelley (Byron.TxOut addr amount) =
   ShelleyTxOut (translateAddr addr) (translateAmount amount)
   where
     translateAmount :: Byron.Lovelace -> Coin
     translateAmount = Coin . Byron.lovelaceToInteger
 
-    translateAddr :: Byron.Address -> Addr crypto
+    translateAddr :: Byron.Address -> Addr c
     translateAddr = AddrBootstrap . BootstrapAddress
 
 {------------------------------------------------------------------------------

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -84,19 +84,19 @@ import Test.Cardano.Ledger.Shelley.Utils
   )
 
 -- | Alice's payment key pair
-alicePay :: CC.Crypto crypto => KeyPair 'Payment crypto
+alicePay :: CC.Crypto c => KeyPair 'Payment c
 alicePay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 0)
 
 -- | Alice's stake key pair
-aliceStake :: CC.Crypto crypto => KeyPair 'Staking crypto
+aliceStake :: CC.Crypto c => KeyPair 'Staking c
 aliceStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 1 1 1 1 1)
 
 -- | Alice's stake pool keys (cold keys, VRF keys, hot KES keys)
-alicePoolKeys :: CC.Crypto crypto => AllIssuerKeys crypto 'StakePool
+alicePoolKeys :: CC.Crypto c => AllIssuerKeys c 'StakePool
 alicePoolKeys =
   AllIssuerKeys
     (KeyPair vkCold skCold)
@@ -107,27 +107,27 @@ alicePoolKeys =
     (skCold, vkCold) = mkKeyPair (RawSeed 1 0 0 0 1)
 
 -- | Alice's base address
-aliceAddr :: CC.Crypto crypto => Addr crypto
+aliceAddr :: CC.Crypto c => Addr c
 aliceAddr = mkAddr (alicePay, aliceStake)
 
 -- | Alice's payment credential
-alicePHK :: CC.Crypto crypto => Credential 'Payment crypto
+alicePHK :: CC.Crypto c => Credential 'Payment c
 alicePHK = (KeyHashObj . hashKey . vKey) alicePay
 
 -- | Alice's stake credential
-aliceSHK :: CC.Crypto crypto => Credential 'Staking crypto
+aliceSHK :: CC.Crypto c => Credential 'Staking c
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 -- | Alice's base address
-alicePtrAddr :: CC.Crypto crypto => Addr crypto
+alicePtrAddr :: CC.Crypto c => Addr c
 alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr (SlotNo 10) minBound minBound)
 
 -- | Alice's stake pool parameters
-alicePoolParams :: forall crypto. CC.Crypto crypto => PoolParams crypto
+alicePoolParams :: forall c. CC.Crypto c => PoolParams c
 alicePoolParams =
   PoolParams
     { _poolId = (hashKey . vKey . cold) alicePoolKeys,
-      _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @crypto),
+      _poolVrf = hashVerKeyVRF . snd $ vrf (alicePoolKeys @c),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,
       _poolMargin = unsafeBoundRational 0.1,
@@ -144,33 +144,33 @@ alicePoolParams =
 
 -- | Alice's VRF key hash
 aliceVRFKeyHash ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Hash crypto (VerKeyVRF crypto)
-aliceVRFKeyHash = hashVerKeyVRF (snd $ vrf (alicePoolKeys @crypto))
+  forall c.
+  CC.Crypto c =>
+  Hash c (VerKeyVRF c)
+aliceVRFKeyHash = hashVerKeyVRF (snd $ vrf (alicePoolKeys @c))
 
 -- | Bob's payment key pair
-bobPay :: CC.Crypto crypto => KeyPair 'Payment crypto
+bobPay :: CC.Crypto c => KeyPair 'Payment c
 bobPay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 2 2 2 2 2)
 
 -- | Bob's stake key pair
-bobStake :: CC.Crypto crypto => KeyPair 'Staking crypto
+bobStake :: CC.Crypto c => KeyPair 'Staking c
 bobStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 3 3 3 3 3)
 
 -- | Bob's address
-bobAddr :: CC.Crypto crypto => Addr crypto
+bobAddr :: CC.Crypto c => Addr c
 bobAddr = mkAddr (bobPay, bobStake)
 
 -- | Bob's stake credential
-bobSHK :: CC.Crypto crypto => Credential 'Staking crypto
+bobSHK :: CC.Crypto c => Credential 'Staking c
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
 -- | Bob's stake pool keys (cold keys, VRF keys, hot KES keys)
-bobPoolKeys :: CC.Crypto crypto => AllIssuerKeys crypto 'StakePool
+bobPoolKeys :: CC.Crypto c => AllIssuerKeys c 'StakePool
 bobPoolKeys =
   AllIssuerKeys
     (KeyPair vkCold skCold)
@@ -181,11 +181,11 @@ bobPoolKeys =
     (skCold, vkCold) = mkKeyPair (RawSeed 2 0 0 0 1)
 
 -- | Bob's stake pool parameters
-bobPoolParams :: forall crypto. CC.Crypto crypto => PoolParams crypto
+bobPoolParams :: forall c. CC.Crypto c => PoolParams c
 bobPoolParams =
   PoolParams
     { _poolId = (hashKey . vKey . cold) bobPoolKeys,
-      _poolVrf = hashVerKeyVRF . snd $ vrf (bobPoolKeys @crypto),
+      _poolVrf = hashVerKeyVRF . snd $ vrf (bobPoolKeys @c),
       _poolPledge = Coin 2,
       _poolCost = Coin 1,
       _poolMargin = unsafeBoundRational 0.1,
@@ -197,47 +197,47 @@ bobPoolParams =
 
 -- | Bob's VRF key hash
 bobVRFKeyHash ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Hash crypto (VerKeyVRF crypto)
-bobVRFKeyHash = hashVerKeyVRF (snd $ vrf (bobPoolKeys @crypto))
+  forall c.
+  CC.Crypto c =>
+  Hash c (VerKeyVRF c)
+bobVRFKeyHash = hashVerKeyVRF (snd $ vrf (bobPoolKeys @c))
 
 -- Carl's payment key pair
-carlPay :: CC.Crypto crypto => KeyPair 'Payment crypto
+carlPay :: CC.Crypto c => KeyPair 'Payment c
 carlPay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 4 4 4 4 4)
 
 -- | Carl's stake key pair
-carlStake :: CC.Crypto crypto => KeyPair 'Staking crypto
+carlStake :: CC.Crypto c => KeyPair 'Staking c
 carlStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 5 5 5 5 5)
 
 -- | Carl's address
-carlAddr :: CC.Crypto crypto => Addr crypto
+carlAddr :: CC.Crypto c => Addr c
 carlAddr = mkAddr (carlPay, carlStake)
 
 -- | Carl's stake credential
-carlSHK :: CC.Crypto crypto => Credential 'Staking crypto
+carlSHK :: CC.Crypto c => Credential 'Staking c
 carlSHK = (KeyHashObj . hashKey . vKey) carlStake
 
 -- | Daria's payment key pair
-dariaPay :: CC.Crypto crypto => KeyPair 'Payment crypto
+dariaPay :: CC.Crypto c => KeyPair 'Payment c
 dariaPay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 6 6 6 6 6)
 
 -- | Daria's stake key pair
-dariaStake :: CC.Crypto crypto => KeyPair 'Staking crypto
+dariaStake :: CC.Crypto c => KeyPair 'Staking c
 dariaStake = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 7 7 7 7 7)
 
 -- | Daria's address
-dariaAddr :: CC.Crypto crypto => Addr crypto
+dariaAddr :: CC.Crypto c => Addr c
 dariaAddr = mkAddr (dariaPay, dariaStake)
 
 -- | Daria's stake credential
-dariaSHK :: CC.Crypto crypto => Credential 'Staking crypto
+dariaSHK :: CC.Crypto c => Credential 'Staking c
 dariaSHK = (KeyHashObj . hashKey . vKey) dariaStake

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Federation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Federation.hs
@@ -55,9 +55,9 @@ numCoreNodes :: Word64
 numCoreNodes = 7
 
 mkAllCoreNodeKeys ::
-  (CC.Crypto crypto) =>
+  (CC.Crypto c) =>
   Word64 ->
-  AllIssuerKeys crypto r
+  AllIssuerKeys c r
 mkAllCoreNodeKeys w =
   AllIssuerKeys
     (KeyPair vkCold skCold)
@@ -68,10 +68,10 @@ mkAllCoreNodeKeys w =
     (skCold, vkCold) = mkKeyPair (RawSeed w 0 0 0 1)
 
 coreNodes ::
-  forall crypto.
-  CC.Crypto crypto =>
-  [ ( (SignKeyDSIGN crypto, VKey 'Genesis crypto),
-      AllIssuerKeys crypto 'GenesisDelegate
+  forall c.
+  CC.Crypto c =>
+  [ ( (SignKeyDSIGN c, VKey 'Genesis c),
+      AllIssuerKeys c 'GenesisDelegate
     )
   ]
 coreNodes =
@@ -82,25 +82,25 @@ coreNodes =
 -- === Signing (Secret) Keys
 -- Retrieve the signing key for a core node by providing
 -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
-coreNodeSK :: forall crypto. CC.Crypto crypto => Int -> SignKeyDSIGN crypto
-coreNodeSK = fst . fst . (coreNodes @crypto !!)
+coreNodeSK :: forall c. CC.Crypto c => Int -> SignKeyDSIGN c
+coreNodeSK = fst . fst . (coreNodes @c !!)
 
 -- | === Verification (Public) Keys
 -- Retrieve the verification key for a core node by providing
 -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
-coreNodeVK :: forall crypto. CC.Crypto crypto => Int -> VKey 'Genesis crypto
-coreNodeVK = snd . fst . (coreNodes @crypto !!)
+coreNodeVK :: forall c. CC.Crypto c => Int -> VKey 'Genesis c
+coreNodeVK = snd . fst . (coreNodes @c !!)
 
 -- | === Block Issuer Keys
 -- Retrieve the block issuer keys (cold, VRF, and hot KES keys)
 -- for a core node by providing
 -- a number in the range @[0, ... ('numCoreNodes'-1)]@.
 coreNodeIssuerKeys ::
-  forall crypto.
-  CC.Crypto crypto =>
+  forall c.
+  CC.Crypto c =>
   Int ->
-  AllIssuerKeys crypto 'GenesisDelegate
-coreNodeIssuerKeys = snd . (coreNodes @crypto !!)
+  AllIssuerKeys c 'GenesisDelegate
+coreNodeIssuerKeys = snd . (coreNodes @c !!)
 
 -- | === Keys by Overlay Schedule
 -- Retrieve all the keys associated with a core node
@@ -137,9 +137,9 @@ coreNodeKeysBySchedule pp slot =
 -- The map from genesis/core node (verification) key hashes
 -- to their delegate's (verification) key hash.
 genDelegs ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Map (KeyHash 'Genesis crypto) (GenDelegPair crypto)
+  forall c.
+  CC.Crypto c =>
+  Map (KeyHash 'Genesis c) (GenDelegPair c)
 genDelegs =
   Map.fromList
     [ ( hashKey $ snd gkey,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Delegation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Delegation.hs
@@ -354,15 +354,15 @@ genGenesisDelegation coreNodes delegateKeys dpState =
 
 -- | Generate PoolParams and the key witness.
 genStakePool ::
-  forall crypto.
-  (CC.Crypto crypto) =>
+  forall c.
+  (CC.Crypto c) =>
   -- | Available keys for stake pool registration
-  [AllIssuerKeys crypto 'StakePool] ->
+  [AllIssuerKeys c 'StakePool] ->
   -- | KeyPairs containing staking keys to act as owners/reward account
-  KeyPairs crypto ->
+  KeyPairs c ->
   -- | Minimum pool cost Protocol Param
   Coin ->
-  Gen (PoolParams crypto, KeyPair 'StakePool crypto)
+  Gen (PoolParams c, KeyPair 'StakePool c)
 genStakePool poolKeys skeys (Coin minPoolCost) =
   mkPoolParams
     <$> QC.elements poolKeys
@@ -376,7 +376,7 @@ genStakePool poolKeys skeys (Coin minPoolCost) =
     <*> (fromInteger <$> QC.choose (0, 100) :: Gen Natural)
     <*> getAnyStakeKey skeys
   where
-    getAnyStakeKey :: KeyPairs crypto -> Gen (VKey 'Staking crypto)
+    getAnyStakeKey :: KeyPairs c -> Gen (VKey 'Staking c)
     getAnyStakeKey keys = vKey . snd <$> QC.elements keys
     mkPoolParams allPoolKeys pledge cost marginPercent acntKey =
       let interval = unsafeBoundRational $ fromIntegral marginPercent % 100

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -287,7 +287,7 @@ class
  -----------------------------------------------------------------------------}
 
 -- | Select between _lower_ and _upper_ keys from 'keyPairs'
-someKeyPairs :: CC.Crypto crypto => Constants -> Int -> Int -> Gen (KeyPairs crypto)
+someKeyPairs :: CC.Crypto c => Constants -> Int -> Int -> Gen (KeyPairs c)
 someKeyPairs c lower upper =
   take
     <$> choose (lower, upper)
@@ -312,8 +312,8 @@ genUtxo0 ge@(GenEnv _ _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = 
 
 -- | We share this dummy TxId as genesis transaction id across eras
 genesisId ::
-  Hash.HashAlgorithm (CC.HASH crypto) =>
-  TxId crypto
+  Hash.HashAlgorithm (CC.HASH c) =>
+  TxId c
 genesisId = TxId (unsafeMakeSafeHash (mkDummyHash 0))
   where
     mkDummyHash :: forall h a. Hash.HashAlgorithm h => Int -> Hash.Hash h a

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
@@ -98,9 +98,9 @@ keySpace c =
 -- NOTE: we use a seed range in the [1000...] range
 -- to create keys that don't overlap with any of the other generated keys
 coreNodeKeys ::
-  CC.Crypto crypto =>
+  CC.Crypto c =>
   Constants ->
-  [(KeyPair 'Genesis crypto, AllIssuerKeys crypto 'GenesisDelegate)]
+  [(KeyPair 'Genesis c, AllIssuerKeys c 'GenesisDelegate)]
 coreNodeKeys c@Constants {numCoreNodes} =
   [ ( (toKeyPair . mkGenKey) (RawSeed x 0 0 0 0),
       issuerKeys c 0 x
@@ -111,14 +111,14 @@ coreNodeKeys c@Constants {numCoreNodes} =
     toKeyPair (sk, vk) = KeyPair vk sk
 
 -- Pre-generate a set of keys to use for genesis delegates.
-genesisDelegates :: CC.Crypto crypto => Constants -> [AllIssuerKeys crypto 'GenesisDelegate]
+genesisDelegates :: CC.Crypto c => Constants -> [AllIssuerKeys c 'GenesisDelegate]
 genesisDelegates c =
   [ issuerKeys c 20 x
     | x <- [0 .. 50]
   ]
 
 -- Pre-generate a set of keys to use for stake pools.
-stakePoolKeys :: CC.Crypto crypto => Constants -> [AllIssuerKeys crypto 'StakePool]
+stakePoolKeys :: CC.Crypto c => Constants -> [AllIssuerKeys c 'StakePool]
 stakePoolKeys c =
   [ issuerKeys c 10 x
     | x <- [0 .. 50]
@@ -126,13 +126,13 @@ stakePoolKeys c =
 
 -- | Generate all keys for any entity which will be issuing blocks.
 issuerKeys ::
-  (CC.Crypto crypto) =>
+  (CC.Crypto c) =>
   Constants ->
   -- | Namespace parameter. Can be used to differentiate between different
   --   "types" of issuer.
   Word64 ->
   Word64 ->
-  AllIssuerKeys crypto r
+  AllIssuerKeys c r
 issuerKeys Constants {maxSlotTrace} ns x =
   let (skCold, vkCold) = mkKeyPair (RawSeed x 0 0 0 (ns + 1))
    in AllIssuerKeys
@@ -157,9 +157,9 @@ issuerKeys Constants {maxSlotTrace} ns x =
         }
 
 genesisDelegs0 ::
-  CC.Crypto crypto =>
+  CC.Crypto c =>
   Constants ->
-  Map (KeyHash 'Genesis crypto) (GenDelegPair crypto)
+  Map (KeyHash 'Genesis c) (GenDelegPair c)
 genesisDelegs0 c =
   Map.fromList
     [ ( hashVKey gkey,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
@@ -232,13 +232,13 @@ combinedScripts c@(Constants {numBaseScripts}) =
   mkScriptCombinations @era . take numBaseScripts $ baseScripts @era c
 
 -- | Constant list of KeyPairs intended to be used in the generators.
-keyPairs :: CC.Crypto crypto => Constants -> KeyPairs crypto
+keyPairs :: CC.Crypto c => Constants -> KeyPairs c
 keyPairs Constants {maxNumKeyPairs} = mkKeyPairs <$> [1 .. maxNumKeyPairs]
 
 mkKeyPairs ::
-  (DSIGNAlgorithm (DSIGN crypto)) =>
+  (DSIGNAlgorithm (DSIGN c)) =>
   Word64 ->
-  (KeyPair kr crypto, KeyPair kr' crypto)
+  (KeyPair kr c, KeyPair kr' c)
 mkKeyPairs n =
   (mkKeyPair_ (2 * n), mkKeyPair_ (2 * n + 1))
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -845,7 +845,7 @@ genRecipients len keys scripts = do
     scriptToCred' :: Script era -> Credential kr (EraCrypto era)
     scriptToCred' = ScriptHashObj . hashScript @era
 
-genPtrAddrs :: DState crypto -> [Addr crypto] -> Gen [Addr crypto]
+genPtrAddrs :: DState c -> [Addr c] -> Gen [Addr c]
 genPtrAddrs ds addrs = do
   let pointers = ptrsMap ds
   n <- QC.choose (0, min (Map.size pointers) (length addrs))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Orphans.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Orphans.hs
@@ -15,7 +15,7 @@ import Test.Cardano.Ledger.Shelley.Utils (Split (..))
 
 -- We need this here for the tests, but should not be in the actual library because
 -- a Num instance for this type does not make sense in the general case.
-deriving instance Num (DSIGN.VerKeyDSIGN (DSIGN crypto)) => Num (VKey kd crypto)
+deriving instance Num (DSIGN.VerKeyDSIGN (DSIGN c)) => Num (VKey kd c)
 
 -- ===============================================================================
 -- Generating random transactions requires splitting Values into multiple Values

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -200,7 +200,7 @@ relevantCasesAreCoveredForTrace tr = do
 
 -- | Ratio of certificates with script credentials to the number of certificates
 -- that could have script credentials.
-scriptCredentialCertsRatio :: [DCert crypto] -> Double
+scriptCredentialCertsRatio :: [DCert c] -> Double
 scriptCredentialCertsRatio certs =
   ratioInt haveScriptCerts couldhaveScriptCerts
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -1309,7 +1309,7 @@ incrementalStakeProp ::
   Property
 incrementalStakeProp Proxy = atEpoch @era (testIncrementalStake @era)
 
-tersediffincremental :: String -> Stake crypto -> Stake crypto -> String
+tersediffincremental :: String -> Stake c -> Stake c -> String
 tersediffincremental message (Stake a) (Stake c) =
   tersemapdiffs (message ++ " " ++ "hashes") (mp a) (mp c)
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestPool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestPool.hs
@@ -85,7 +85,7 @@ poolRetirement
       ]
 poolRetirement _ _ _ = property ()
 
-poolStateIsInternallyConsistent :: PState crypto -> Property
+poolStateIsInternallyConsistent :: PState c -> Property
 poolStateIsInternallyConsistent (PState pParams_ _ retiring_) = do
   let poolKeys = Map.keysSet pParams_
       pParamKeys = Map.keysSet pParams_

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestPoolreap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestPoolreap.hs
@@ -29,9 +29,9 @@ import Test.QuickCheck (Property, property)
 -- | Check that after a POOLREAP certificate transition the pool is removed from
 -- the stake pool and retiring maps.
 removedAfterPoolreap ::
-  forall crypto.
-  PState crypto ->
-  PState crypto ->
+  forall c.
+  PState c ->
+  PState c ->
   EpochNo ->
   Property
 removedAfterPoolreap p p' e =
@@ -44,5 +44,5 @@ removedAfterPoolreap p p' e =
     stp' = _pParams p'
     retiring = _retiring p
     retiring' = _retiring p'
-    retire :: Set.Set (KeyHash 'StakePool crypto) -- This declaration needed to disambiguate 'eval'
+    retire :: Set.Set (KeyHash 'StakePool c) -- This declaration needed to disambiguate 'eval'
     retire = eval (dom (retiring ▷ setSingleton e))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -172,9 +172,9 @@ type MockGen era =
     Arbitrary (VerKeyDSIGN (DSIGN (EraCrypto era)))
   )
 
-instance Mock crypto => Arbitrary (BHeader crypto) where
+instance Mock c => Arbitrary (BHeader c) where
   arbitrary = do
-    prevHash <- arbitrary :: Gen (HashHeader crypto)
+    prevHash <- arbitrary :: Gen (HashHeader c)
     allPoolKeys <- elements (map snd (coreNodeKeys defaultConstants))
     curSlotNo <- SlotNo <$> choose (0, 10)
     curBlockNo <- BlockNo <$> choose (0, 100)
@@ -197,17 +197,17 @@ instance Mock crypto => Arbitrary (BHeader crypto) where
         bodySize
         bodyHash
 
-instance DSIGNAlgorithm crypto => Arbitrary (SignedDSIGN crypto a) where
+instance DSIGNAlgorithm c => Arbitrary (SignedDSIGN c a) where
   arbitrary =
     SignedDSIGN . fromJust . rawDeserialiseSigDSIGN
-      <$> (genByteString . fromIntegral $ sizeSigDSIGN (Proxy @crypto))
+      <$> (genByteString . fromIntegral $ sizeSigDSIGN (Proxy @c))
 
-instance DSIGNAlgorithm crypto => Arbitrary (VerKeyDSIGN crypto) where
+instance DSIGNAlgorithm c => Arbitrary (VerKeyDSIGN c) where
   arbitrary =
     fromJust . rawDeserialiseVerKeyDSIGN
-      <$> (genByteString . fromIntegral $ sizeVerKeyDSIGN (Proxy @crypto))
+      <$> (genByteString . fromIntegral $ sizeVerKeyDSIGN (Proxy @c))
 
-instance CC.Crypto crypto => Arbitrary (BootstrapWitness crypto) where
+instance CC.Crypto c => Arbitrary (BootstrapWitness c) where
   arbitrary = do
     key <- arbitrary
     sig <- genSignature
@@ -215,16 +215,16 @@ instance CC.Crypto crypto => Arbitrary (BootstrapWitness crypto) where
     attributes <- arbitrary
     pure $ BootstrapWitness key sig chainCode attributes
 
-instance CC.Crypto crypto => Arbitrary (TP.HashHeader crypto) where
+instance CC.Crypto c => Arbitrary (TP.HashHeader c) where
   arbitrary = TP.HashHeader <$> genHash
 
-instance (Typeable kr, CC.Crypto crypto) => Arbitrary (WitVKey kr crypto) where
+instance (Typeable kr, CC.Crypto c) => Arbitrary (WitVKey kr c) where
   arbitrary =
     WitVKey
       <$> arbitrary
       <*> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (Wdrl crypto) where
+instance CC.Crypto c => Arbitrary (Wdrl c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -267,10 +267,10 @@ instance Arbitrary (MD.Metadata era) where
 maxTxWits :: Int
 maxTxWits = 5
 
-instance CC.Crypto crypto => Arbitrary (TxId crypto) where
+instance CC.Crypto c => Arbitrary (TxId c) where
   arbitrary = TxId <$> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (TxIn crypto) where
+instance CC.Crypto c => Arbitrary (TxIn c) where
   arbitrary =
     TxIn
       <$> (TxId <$> arbitrary)
@@ -313,13 +313,13 @@ instance Arbitrary NonNegativeInterval where
     Positive (y :: Word64) <- arbitrary
     pure $ unsafeBoundRational $ promoteRatio (x % y)
 
-instance CC.Crypto crypto => Arbitrary (KeyHash a crypto) where
+instance CC.Crypto c => Arbitrary (KeyHash a c) where
   arbitrary = KeyHash <$> genHash
 
 instance Arbitrary MIRPot where
   arbitrary = genericArbitraryU
 
-instance CC.Crypto crypto => Arbitrary (MIRTarget crypto) where
+instance CC.Crypto c => Arbitrary (MIRTarget c) where
   arbitrary =
     oneof
       [ StakeAddressesMIR <$> arbitrary,
@@ -349,20 +349,20 @@ instance Arbitrary EpochNo where
   -- Cannot be negative even though it is an 'Integer'
   arbitrary = EpochNo <$> choose (1, 100000)
 
-instance CC.Crypto crypto => Arbitrary (Addr crypto) where
+instance CC.Crypto c => Arbitrary (Addr c) where
   arbitrary = oneof [genShelleyAddress, genByronAddress]
 
-genShelleyAddress :: CC.Crypto crypto => Gen (Addr crypto)
+genShelleyAddress :: CC.Crypto c => Gen (Addr c)
 genShelleyAddress = Addr <$> arbitrary <*> arbitrary <*> arbitrary
 
-genByronAddress :: Gen (Addr crypto)
+genByronAddress :: Gen (Addr c)
 genByronAddress = AddrBootstrap <$> genBootstrapAddress
 
-instance CC.Crypto crypto => Arbitrary (StakeReference crypto) where
+instance CC.Crypto c => Arbitrary (StakeReference c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (Credential r crypto) where
+instance CC.Crypto c => Arbitrary (Credential r c) where
   arbitrary =
     oneof
       [ ScriptHashObj . ScriptHash <$> genHash,
@@ -379,24 +379,24 @@ instance Arbitrary Ptr where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (RewardAcnt crypto) where
+instance CC.Crypto c => Arbitrary (RewardAcnt c) where
   arbitrary = RewardAcnt <$> arbitrary <*> arbitrary
 
 instance Arbitrary Network where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Arbitrary (VerKeyDSIGN (DSIGN crypto))) => Arbitrary (VKey kd crypto) where
+instance (Arbitrary (VerKeyDSIGN (DSIGN c))) => Arbitrary (VKey kd c) where
   arbitrary = VKey <$> arbitrary
 
 instance Arbitrary ProtVer where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (ScriptHash crypto) where
+instance CC.Crypto c => Arbitrary (ScriptHash c) where
   arbitrary = ScriptHash <$> genHash
 
-instance CC.Crypto crypto => Arbitrary (AuxiliaryDataHash crypto) where
+instance CC.Crypto c => Arbitrary (AuxiliaryDataHash c) where
   arbitrary = AuxiliaryDataHash <$> arbitrary
 
 instance HashAlgorithm h => Arbitrary (Hash.Hash h a) where
@@ -406,7 +406,7 @@ instance Arbitrary STS.TicknState where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (STS.PrtclState crypto) where
+instance CC.Crypto c => Arbitrary (STS.PrtclState c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -417,15 +417,15 @@ deriving instance
   ) =>
   Arbitrary (UTxO era)
 
-instance CC.Crypto crypto => Arbitrary (PState crypto) where
+instance CC.Crypto c => Arbitrary (PState c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (InstantaneousRewards crypto) where
+instance CC.Crypto c => Arbitrary (InstantaneousRewards c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (FutureGenDeleg crypto) where
+instance CC.Crypto c => Arbitrary (FutureGenDeleg c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -433,23 +433,23 @@ instance (Arbitrary k, Arbitrary v) => Arbitrary (LM.ListMap k v) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (GenDelegs crypto) where
+instance CC.Crypto c => Arbitrary (GenDelegs c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (GenDelegPair crypto) where
+instance CC.Crypto c => Arbitrary (GenDelegPair c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (Triple crypto) where
+instance CC.Crypto c => Arbitrary (Triple c) where
   arbitrary = Triple <$> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (UnifiedMap crypto) where
+instance CC.Crypto c => Arbitrary (UnifiedMap c) where
   arbitrary = UnifiedMap <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (DState crypto) where
+instance CC.Crypto c => Arbitrary (DState c) where
   arbitrary =
     DState
       <$> arbitrary
@@ -457,27 +457,27 @@ instance CC.Crypto crypto => Arbitrary (DState crypto) where
       <*> arbitrary
       <*> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (DelegCert crypto) where
+instance CC.Crypto c => Arbitrary (DelegCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (Delegation crypto) where
+instance CC.Crypto c => Arbitrary (Delegation c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (PoolCert crypto) where
+instance CC.Crypto c => Arbitrary (PoolCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (GenesisDelegCert crypto) where
+instance CC.Crypto c => Arbitrary (GenesisDelegCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (MIRCert crypto) where
+instance CC.Crypto c => Arbitrary (MIRCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (DCert crypto) where
+instance CC.Crypto c => Arbitrary (DCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -485,7 +485,7 @@ instance (Era era, Mock (EraCrypto era)) => Arbitrary (PPUPState era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (DPState crypto) where
+instance CC.Crypto c => Arbitrary (DPState c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -540,10 +540,10 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance CC.Crypto crypto => Arbitrary (BlocksMade crypto) where
+instance CC.Crypto c => Arbitrary (BlocksMade c) where
   arbitrary = BlocksMade <$> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (PoolDistr crypto) where
+instance CC.Crypto c => Arbitrary (PoolDistr c) where
   arbitrary =
     PoolDistr . Map.fromList
       <$> listOf ((,) <$> arbitrary <*> genVal)
@@ -580,15 +580,15 @@ instance Arbitrary RewardType where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (Reward crypto) where
+instance CC.Crypto c => Arbitrary (Reward c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (LeaderOnlyReward crypto) where
+instance CC.Crypto c => Arbitrary (LeaderOnlyReward c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (RewardUpdate crypto) where
+instance CC.Crypto c => Arbitrary (RewardUpdate c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -596,7 +596,7 @@ instance Arbitrary a => Arbitrary (StrictMaybe a) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (STS.OBftSlot crypto) where
+instance CC.Crypto c => Arbitrary (STS.OBftSlot c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -609,15 +609,15 @@ instance Arbitrary Likelihood where
 instance Arbitrary LogWeight where
   arbitrary = LogWeight <$> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (NonMyopic crypto) where
+instance CC.Crypto c => Arbitrary (NonMyopic c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (SnapShot crypto) where
+instance CC.Crypto c => Arbitrary (SnapShot c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance CC.Crypto crypto => Arbitrary (SnapShots crypto) where
+instance CC.Crypto c => Arbitrary (SnapShots c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
@@ -626,10 +626,10 @@ instance Arbitrary PerformanceEstimate where
 
 deriving instance Arbitrary (CompactForm Coin)
 
-instance CC.Crypto crypto => Arbitrary (Stake crypto) where
+instance CC.Crypto c => Arbitrary (Stake c) where
   arbitrary = Stake <$> arbitrary
 
-instance CC.Crypto crypto => Arbitrary (PoolParams crypto) where
+instance CC.Crypto c => Arbitrary (PoolParams c) where
   arbitrary =
     PoolParams
       <$> arbitrary
@@ -905,7 +905,7 @@ instance
   arbitrary = ApplyTxError <$> arbitrary
   shrink (ApplyTxError xs) = [ApplyTxError xs' | xs' <- shrink xs]
 
-instance (Mock crypto) => Arbitrary (PulsingRewUpdate crypto) where
+instance (Mock c) => Arbitrary (PulsingRewUpdate c) where
   arbitrary =
     oneof
       [ Complete <$> arbitrary,
@@ -913,8 +913,8 @@ instance (Mock crypto) => Arbitrary (PulsingRewUpdate crypto) where
       ]
 
 instance
-  Mock crypto =>
-  Arbitrary (RewardSnapShot crypto)
+  Mock c =>
+  Arbitrary (RewardSnapShot c)
   where
   arbitrary =
     RewardSnapShot
@@ -928,8 +928,8 @@ instance
       <*> arbitrary
 
 instance
-  Mock crypto =>
-  Arbitrary (PoolRewardInfo crypto)
+  Mock c =>
+  Arbitrary (PoolRewardInfo c)
   where
   arbitrary =
     PoolRewardInfo
@@ -940,8 +940,8 @@ instance
       <*> arbitrary
 
 instance
-  Mock crypto =>
-  Arbitrary (FreeVars crypto)
+  Mock c =>
+  Arbitrary (FreeVars c)
   where
   arbitrary =
     FreeVars
@@ -952,7 +952,7 @@ instance
       <*> arbitrary {- delegations -}
 
 instance
-  Mock crypto =>
-  Arbitrary (Pulser crypto)
+  Mock c =>
+  Arbitrary (Pulser c)
   where
   arbitrary = RSLP <$> arbitrary <*> arbitrary <*> arbitrary <*> (RewardAns <$> arbitrary <*> arbitrary)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Bootstrap.hs
@@ -29,5 +29,5 @@ genSignature =
     . DSIGN.rawDeserialiseSigDSIGN
     <$> hedgehog (Hedgehog.Gen.bytes . Hedgehog.Range.singleton . fromIntegral $ DSIGN.sizeSigDSIGN ([] @a))
 
-genBootstrapAddress :: Gen (BootstrapAddress crypto)
+genBootstrapAddress :: Gen (BootstrapAddress c)
 genBootstrapAddress = BootstrapAddress <$> hedgehog Byron.genAddress

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Genesis.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Genesis.hs
@@ -69,17 +69,17 @@ genShelleyGenesis =
     <*> fmap LM.ListMap genFundsList
     <*> genStaking
 
-genStaking :: CC.Crypto crypto => Gen (ShelleyGenesisStaking crypto)
+genStaking :: CC.Crypto c => Gen (ShelleyGenesisStaking c)
 genStaking =
   ShelleyGenesisStaking
     <$> fmap LM.ListMap genPools
     <*> fmap LM.ListMap genStake
 
 genPools ::
-  CC.Crypto crypto =>
+  CC.Crypto c =>
   Gen
-    [ ( KeyHash 'StakePool crypto,
-        PoolParams crypto
+    [ ( KeyHash 'StakePool c,
+        PoolParams c
       )
     ]
 genPools =
@@ -87,21 +87,21 @@ genPools =
     (,) <$> genKeyHash <*> genPoolParams
 
 genStake ::
-  CC.Crypto crypto =>
+  CC.Crypto c =>
   Gen
-    [ ( KeyHash 'Staking crypto,
-        KeyHash 'StakePool crypto
+    [ ( KeyHash 'Staking c,
+        KeyHash 'StakePool c
       )
     ]
 genStake =
   Gen.list (Range.linear 1 10) $
     (,) <$> genKeyHash <*> genKeyHash
 
-genPoolParams :: forall crypto. CC.Crypto crypto => Gen (PoolParams crypto)
+genPoolParams :: forall c. CC.Crypto c => Gen (PoolParams c)
 genPoolParams =
   PoolParams
     <$> genKeyHash
-    <*> genVRFKeyHash @crypto
+    <*> genVRFKeyHash @c
     <*> genCoin
     <*> genCoin
     <*> genUnitInterval
@@ -144,10 +144,10 @@ genUrl = do
     Nothing -> error "wrong generator for Url"
     Just url -> return url
 
-genRewardAcnt :: CC.Crypto crypto => Gen (RewardAcnt crypto)
+genRewardAcnt :: CC.Crypto c => Gen (RewardAcnt c)
 genRewardAcnt = RewardAcnt Testnet <$> genCredential
 
-genCredential :: CC.Crypto crypto => Gen (Credential 'Staking crypto)
+genCredential :: CC.Crypto c => Gen (Credential 'Staking c)
 genCredential =
   Gen.choice
     [ ScriptHashObj . ScriptHash <$> genHash,
@@ -228,54 +228,54 @@ genDecimalBoundedRational gen = do
   pure $ unsafeBoundRational $ toInteger num % toInteger denom
 
 genGenesisDelegationList ::
-  CC.Crypto crypto =>
-  Gen [(KeyHash 'Genesis crypto, GenDelegPair crypto)]
+  CC.Crypto c =>
+  Gen [(KeyHash 'Genesis c, GenDelegPair c)]
 genGenesisDelegationList = Gen.list (Range.linear 1 10) genGenesisDelegationPair
 
 genGenesisDelegationPair ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Gen (KeyHash 'Genesis crypto, GenDelegPair crypto)
+  forall c.
+  CC.Crypto c =>
+  Gen (KeyHash 'Genesis c, GenDelegPair c)
 genGenesisDelegationPair =
-  (,) <$> genKeyHash <*> (GenDelegPair <$> genKeyHash <*> genVRFKeyHash @crypto)
+  (,) <$> genKeyHash <*> (GenDelegPair <$> genKeyHash <*> genVRFKeyHash @c)
 
 genVRFKeyHash ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Gen (Hash crypto (VerKeyVRF (VRF crypto)))
-genVRFKeyHash = hashVerKeyVRF . snd <$> (genVRFKeyPair @crypto)
+  forall c.
+  CC.Crypto c =>
+  Gen (Hash c (VerKeyVRF (VRF c)))
+genVRFKeyHash = hashVerKeyVRF . snd <$> (genVRFKeyPair @c)
 
 genVRFKeyPair ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Gen (SignKeyVRF (VRF crypto), VerKeyVRF (VRF crypto))
+  forall c.
+  CC.Crypto c =>
+  Gen (SignKeyVRF (VRF c), VerKeyVRF (VRF c))
 genVRFKeyPair = do
   seed <- genSeed seedSize
   let sk = genKeyVRF seed
       vk = deriveVerKeyVRF sk
   pure (sk, vk)
   where
-    seedSize = fromIntegral (seedSizeVRF (Proxy :: Proxy (VRF crypto)))
+    seedSize = fromIntegral (seedSizeVRF (Proxy :: Proxy (VRF c)))
 
-genFundsList :: CC.Crypto crypto => Gen [(Addr crypto, Coin)]
+genFundsList :: CC.Crypto c => Gen [(Addr c, Coin)]
 genFundsList = Gen.list (Range.linear 1 100) genGenesisFundPair
 
 genSeed :: Int -> Gen Seed
 genSeed n = mkSeedFromBytes <$> Gen.bytes (Range.singleton n)
 
 genKeyHash ::
-  ( CC.Crypto crypto
+  ( CC.Crypto c
   ) =>
-  Gen (KeyHash disc crypto)
+  Gen (KeyHash disc c)
 genKeyHash = hashKey . snd <$> genKeyPair
 
 -- | Generate a deterministic key pair given a seed.
 genKeyPair ::
-  forall crypto krole.
-  DSIGNAlgorithm (DSIGN crypto) =>
+  forall c krole.
+  DSIGNAlgorithm (DSIGN c) =>
   Gen
-    ( SignKeyDSIGN (DSIGN crypto),
-      VKey krole crypto
+    ( SignKeyDSIGN (DSIGN c),
+      VKey krole c
     )
 genKeyPair = do
   seed <- genSeed seedSize
@@ -288,15 +288,15 @@ genKeyPair = do
       fromIntegral
         ( seedSizeDSIGN
             ( Proxy ::
-                Proxy (DSIGN crypto)
+                Proxy (DSIGN c)
             )
         )
 
-genGenesisFundPair :: CC.Crypto crypto => Gen (Addr crypto, Coin)
+genGenesisFundPair :: CC.Crypto c => Gen (Addr c, Coin)
 genGenesisFundPair =
   (,) <$> genAddress <*> genCoin
 
-genAddress :: CC.Crypto crypto => Gen (Addr crypto)
+genAddress :: CC.Crypto c => Gen (Addr c)
 genAddress = do
   (secKey1, verKey1) <- genKeyPair
   (secKey2, verKey2) <- genKeyPair

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Shrinkers.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Shrinkers.hs
@@ -89,7 +89,7 @@ shrinkTxBody (ShelleyTxBody is os@((:<|) (ShelleyTxOut a vs) _) cs ws tf tl tu m
 outputBalance :: ShelleyTest era => StrictSeq (ShelleyTxOut era) -> Core.Value era
 outputBalance = foldl' (\v (ShelleyTxOut _ c) -> v <+> c) mempty
 
-shrinkTxIn :: TxIn crypto -> [TxIn crypto]
+shrinkTxIn :: TxIn c -> [TxIn c]
 shrinkTxIn = const []
 
 shrinkTxOut :: ShelleyTest era => ShelleyTxOut era -> [ShelleyTxOut era]
@@ -102,13 +102,13 @@ shrinkTxOut (ShelleyTxOut addr vl) =
 shrinkCoin :: Coin -> [Coin]
 shrinkCoin (Coin x) = Coin <$> shrinkIntegral x
 
-shrinkDCert :: DCert crypto -> [DCert crypto]
+shrinkDCert :: DCert c -> [DCert c]
 shrinkDCert = const []
 
-shrinkWdrl :: Wdrl crypto -> [Wdrl crypto]
+shrinkWdrl :: Wdrl c -> [Wdrl c]
 shrinkWdrl (Wdrl m) = Wdrl <$> shrinkMap shrinkRewardAcnt shrinkCoin m
 
-shrinkRewardAcnt :: RewardAcnt crypto -> [RewardAcnt crypto]
+shrinkRewardAcnt :: RewardAcnt c -> [RewardAcnt c]
 shrinkRewardAcnt = const []
 
 shrinkSlotNo :: SlotNo -> [SlotNo]
@@ -117,13 +117,13 @@ shrinkSlotNo (SlotNo x) = SlotNo <$> shrinkIntegral x
 shrinkUpdate :: Update era -> [Update era]
 shrinkUpdate = const []
 
-shrinkWitVKey :: WitVKey kr crypto -> [WitVKey kr crypto]
+shrinkWitVKey :: WitVKey kr c -> [WitVKey kr c]
 shrinkWitVKey = const []
 
-shrinkScriptHash :: ScriptHash crypto -> [ScriptHash crypto]
+shrinkScriptHash :: ScriptHash c -> [ScriptHash c]
 shrinkScriptHash = const []
 
-shrinkMultiSig :: MultiSig crypto -> [MultiSig crypto]
+shrinkMultiSig :: MultiSig c -> [MultiSig c]
 shrinkMultiSig = const []
 
 shrinkSet :: Ord a => (a -> [a]) -> Set a -> [Set a]

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -162,7 +162,7 @@ type ShelleyTest era =
 class Split v where
   vsplit :: v -> Integer -> ([v], Coin)
 
-type GenesisKeyPair crypto = KeyPair 'Genesis crypto
+type GenesisKeyPair c = KeyPair 'Genesis c
 
 data RawSeed = RawSeed !Word64 !Word64 !Word64 !Word64 !Word64
   deriving (Eq, Show)
@@ -188,33 +188,33 @@ mkSeedFromWords stuff =
 
 -- | For testing purposes, generate a deterministic genesis key pair given a seed.
 mkGenKey ::
-  DSIGNAlgorithm (DSIGN crypto) =>
+  DSIGNAlgorithm (DSIGN c) =>
   RawSeed ->
-  (SignKeyDSIGN (DSIGN crypto), VKey kd crypto)
+  (SignKeyDSIGN (DSIGN c), VKey kd c)
 mkGenKey seed =
   let sk = genKeyDSIGN $ mkSeedFromWords seed
    in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic key pair given a seed.
 mkKeyPair ::
-  forall crypto kd.
-  DSIGNAlgorithm (DSIGN crypto) =>
+  forall c kd.
+  DSIGNAlgorithm (DSIGN c) =>
   RawSeed ->
-  (SignKeyDSIGN (DSIGN crypto), VKey kd crypto)
+  (SignKeyDSIGN (DSIGN c), VKey kd c)
 mkKeyPair seed =
   let sk = genKeyDSIGN $ mkSeedFromWords seed
    in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic key pair given a seed.
 mkKeyPair' ::
-  DSIGNAlgorithm (DSIGN crypto) =>
+  DSIGNAlgorithm (DSIGN c) =>
   RawSeed ->
-  KeyPair kd crypto
+  KeyPair kd c
 mkKeyPair' seed = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair seed
 
-instance DSIGNAlgorithm (DSIGN crypto) => Arbitrary (KeyPair kd crypto) where
+instance DSIGNAlgorithm (DSIGN c) => Arbitrary (KeyPair kd c) where
   arbitrary = mkKeyPair' <$> arbitrary
 
 -- | For testing purposes, generate a deterministic VRF key pair given a seed.
@@ -249,9 +249,9 @@ mkKESKeyPair seed =
    in (sk, deriveVerKeyKES sk)
 
 mkAddr ::
-  CC.Crypto crypto =>
-  (KeyPair 'Payment crypto, KeyPair 'Staking crypto) ->
-  Addr crypto
+  CC.Crypto c =>
+  (KeyPair 'Payment c, KeyPair 'Staking c) ->
+  Addr c
 mkAddr (payKey, stakeKey) =
   Addr
     Testnet

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/TerseTools.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/TerseTools.hs
@@ -78,7 +78,7 @@ tersemapfilter message p mp = terselistfilter message (\(_, a) -> p a) (Map.toAs
 tersemapdiffs :: (Terse a, Terse b, Ord a, Eq b) => String -> Map.Map a b -> Map.Map a b -> [Char]
 tersemapdiffs message mp1 mp2 = terselist message (mapdiffs mp1 mp2)
 
-instance Terse (Addr crypto) where
+instance Terse (Addr c) where
   terse (Addr _net cred1 (StakeRefBase cred2)) = "Addr (" ++ terse cred1 ++ ") (" ++ terse cred2 ++ ")"
   terse (Addr _net cred (StakeRefPtr ptr)) = "Addr (" ++ terse cred ++ ") (" ++ terse ptr ++ ")"
   terse (Addr _net cred StakeRefNull) = "Addr (" ++ terse cred ++ ") Null"
@@ -100,7 +100,7 @@ instance CC.Crypto era => Terse (TxIn era) where
 instance Terse (Coin) where
   terse (Coin n) = show n
 
-tersediffincremental :: String -> IncrementalStake crypto -> IncrementalStake crypto -> String
+tersediffincremental :: String -> IncrementalStake c -> IncrementalStake c -> String
 tersediffincremental message (IStake a b) (IStake c d) =
   tersemapdiffs (message ++ " " ++ "hashes") a c
     ++ tersemapdiffs (message ++ " " ++ "ptrs") b d

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -111,8 +111,8 @@ initStGenesisDeleg = initSt initUTxO
 --
 
 newGenDelegate ::
-  CryptoClass.Crypto crypto =>
-  KeyPair 'GenesisDelegate crypto
+  CryptoClass.Crypto c =>
+  KeyPair 'GenesisDelegate c
 newGenDelegate = KeyPair vkCold skCold
   where
     (skCold, vkCold) = mkKeyPair (RawSeed 108 0 0 0 1)
@@ -191,9 +191,9 @@ blockEx1 =
     (mkOCert @c (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 10) 0 (KESPeriod 0))
 
 newGenDeleg ::
-  forall crypto.
-  CryptoClass.Crypto crypto =>
-  (FutureGenDeleg crypto, GenDelegPair crypto)
+  forall c.
+  CryptoClass.Crypto c =>
+  (FutureGenDeleg c, GenDelegPair c)
 newGenDeleg =
   ( FutureGenDeleg (SlotNo 43) (hashKey $ coreNodeVK 0),
     GenDelegPair (hashKey . vKey $ newGenDelegate) newGenesisVrfKH

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -149,11 +149,11 @@ toCompactCoinError c =
     Just compactCoin -> compactCoin
 
 mkStake ::
-  [ ( Credential 'Staking crypto,
+  [ ( Credential 'Staking c,
       Coin
     )
   ] ->
-  EB.Stake crypto
+  EB.Stake c
 mkStake = EB.Stake . GHC.Exts.fromList . map (fmap toCompactCoinError)
 
 initUTxO :: Cr.Crypto c => UTxO (ShelleyEra c)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -436,7 +436,7 @@ blockEx4 =
 deltaREx4 :: Coin
 deltaREx4 = Coin 3
 
-rewardUpdateEx4 :: forall crypto. RewardUpdate crypto
+rewardUpdateEx4 :: forall c. RewardUpdate c
 rewardUpdateEx4 =
   RewardUpdate
     { deltaT = DeltaCoin 0,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -93,35 +93,35 @@ sizeTest b16 tx = do
   Base16.encode (serialize tx) @?= b16
   (tx ^. sizeTxF) @?= toInteger (BSL.length b16 `div` 2)
 
-alicePay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
-alicePay = KeyPair @'Payment @crypto vk sk
+alicePay :: forall c. Cr.Crypto c => KeyPair 'Payment c
+alicePay = KeyPair @'Payment @c vk sk
   where
-    (sk, vk) = mkKeyPair @crypto (RawSeed 0 0 0 0 0)
+    (sk, vk) = mkKeyPair @c (RawSeed 0 0 0 0 0)
 
-aliceStake :: forall crypto. Cr.Crypto crypto => KeyPair 'Staking crypto
+aliceStake :: forall c. Cr.Crypto c => KeyPair 'Staking c
 aliceStake = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair @crypto (RawSeed 0 0 0 0 1)
+    (sk, vk) = mkKeyPair @c (RawSeed 0 0 0 0 1)
 
-aliceSHK :: forall crypto. Cr.Crypto crypto => Credential 'Staking crypto
+aliceSHK :: forall c. Cr.Crypto c => Credential 'Staking c
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
-alicePool :: forall crypto. Cr.Crypto crypto => KeyPair 'StakePool crypto
+alicePool :: forall c. Cr.Crypto c => KeyPair 'StakePool c
 alicePool = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair @crypto (RawSeed 0 0 0 0 2)
+    (sk, vk) = mkKeyPair @c (RawSeed 0 0 0 0 2)
 
-alicePoolKH :: forall crypto. Cr.Crypto crypto => KeyHash 'StakePool crypto
+alicePoolKH :: forall c. Cr.Crypto c => KeyHash 'StakePool c
 alicePoolKH = (hashKey . vKey) alicePool
 
 aliceVRF :: forall v. VRFAlgorithm v => (VRF.SignKeyVRF v, VRF.VerKeyVRF v)
 aliceVRF = mkVRFKeyPair (RawSeed 0 0 0 0 3)
 
-alicePoolParams :: forall crypto. Cr.Crypto crypto => PoolParams crypto
+alicePoolParams :: forall c. Cr.Crypto c => PoolParams c
 alicePoolParams =
   PoolParams
     { _poolId = alicePoolKH,
-      _poolVrf = hashVerKeyVRF . snd $ aliceVRF @(Cr.VRF crypto),
+      _poolVrf = hashVerKeyVRF . snd $ aliceVRF @(Cr.VRF c),
       _poolPledge = Coin 1,
       _poolCost = Coin 5,
       _poolMargin = unsafeBoundRational 0.1,
@@ -139,26 +139,26 @@ alicePoolParams =
             }
     }
 
-aliceAddr :: forall crypto. Cr.Crypto crypto => Addr crypto
+aliceAddr :: forall c. Cr.Crypto c => Addr c
 aliceAddr = mkAddr (alicePay, aliceStake)
 
-bobPay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
+bobPay :: forall c. Cr.Crypto c => KeyPair 'Payment c
 bobPay = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair @crypto (RawSeed 1 0 0 0 0)
+    (sk, vk) = mkKeyPair @c (RawSeed 1 0 0 0 0)
 
-bobStake :: forall crypto. Cr.Crypto crypto => KeyPair 'Staking crypto
+bobStake :: forall c. Cr.Crypto c => KeyPair 'Staking c
 bobStake = KeyPair vk sk
   where
-    (sk, vk) = mkKeyPair @crypto (RawSeed 1 0 0 0 1)
+    (sk, vk) = mkKeyPair @c (RawSeed 1 0 0 0 1)
 
-bobSHK :: forall crypto. Cr.Crypto crypto => Credential 'Staking crypto
+bobSHK :: forall c. Cr.Crypto c => Credential 'Staking c
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
-bobAddr :: forall crypto. Cr.Crypto crypto => Addr crypto
+bobAddr :: forall c. Cr.Crypto c => Addr c
 bobAddr = mkAddr (bobPay, bobStake)
 
-carlPay :: forall crypto. Cr.Crypto crypto => KeyPair 'Payment crypto
+carlPay :: forall c. Cr.Crypto c => KeyPair 'Payment c
 carlPay = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 2 0 0 0 0)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -105,8 +105,8 @@ import Test.Cardano.Ledger.Shelley.Utils
 -- hashing algorithm.
 --
 _assertScriptHashSizeMatchesAddrHashSize ::
-  ScriptHash crypto ->
-  KeyHash r crypto
+  ScriptHash c ->
+  KeyHash r c
 _assertScriptHashSizeMatchesAddrHashSize (ScriptHash h) =
   KeyHash (Hash.castHash h)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -232,19 +232,19 @@ getRawNonce :: Nonce -> ByteString
 getRawNonce (Nonce hsh) = Monomorphic.hashToBytes hsh
 getRawNonce NeutralNonce = error "The neutral nonce has no bytes"
 
-testGKey :: CC.Crypto crypto => GenesisKeyPair crypto
+testGKey :: CC.Crypto c => GenesisKeyPair c
 testGKey = KeyPair vk sk
   where
     (sk, vk) = mkGenKey (RawSeed 0 0 0 0 0)
 
-testGKeyHash :: CC.Crypto crypto => KeyHash 'Genesis crypto
+testGKeyHash :: CC.Crypto c => KeyHash 'Genesis c
 testGKeyHash = (hashKey . vKey) testGKey
 
-testVRF :: CC.Crypto crypto => (SignKeyVRF crypto, VerKeyVRF crypto)
+testVRF :: CC.Crypto c => (SignKeyVRF c, VerKeyVRF c)
 testVRF = mkVRFKeyPair (RawSeed 0 0 0 0 5)
 
-testVRFKH :: forall crypto. CC.Crypto crypto => Hash crypto (VerKeyVRF crypto)
-testVRFKH = hashVerKeyVRF $ snd (testVRF @crypto)
+testVRFKH :: forall c. CC.Crypto c => Hash c (VerKeyVRF c)
+testVRFKH = hashVerKeyVRF $ snd (testVRF @c)
 
 testTxb :: ShelleyTest era => ShelleyTxBody era
 testTxb =
@@ -264,29 +264,29 @@ testTxbHash ::
   SafeHash (EraCrypto era) EraIndependentTxBody
 testTxbHash = hashAnnotated $ testTxb @era
 
-testKey1 :: CC.Crypto crypto => KeyPair 'Payment crypto
+testKey1 :: CC.Crypto c => KeyPair 'Payment c
 testKey1 = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 1)
 
-testKey2 :: CC.Crypto crypto => KeyPair kr crypto
+testKey2 :: CC.Crypto c => KeyPair kr c
 testKey2 = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 2)
 
-testBlockIssuerKey :: CC.Crypto crypto => KeyPair 'BlockIssuer crypto
+testBlockIssuerKey :: CC.Crypto c => KeyPair 'BlockIssuer c
 testBlockIssuerKey = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 4)
 
-testStakePoolKey :: CC.Crypto crypto => KeyPair 'StakePool crypto
+testStakePoolKey :: CC.Crypto c => KeyPair 'StakePool c
 testStakePoolKey = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 5)
 
 testGenesisDelegateKey ::
-  CC.Crypto crypto =>
-  KeyPair 'GenesisDelegate crypto
+  CC.Crypto c =>
+  KeyPair 'GenesisDelegate c
 testGenesisDelegateKey = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 6)
@@ -312,98 +312,98 @@ testKey1SigToken = e
     Encoding e = encodeSignedDSIGN s
 
 testOpCertSigTokens ::
-  forall crypto.
-  (Mock crypto) =>
+  forall c.
+  (Mock c) =>
   Tokens ->
   Tokens
 testOpCertSigTokens = e
   where
     s =
-      signedDSIGN @crypto
-        (sKey $ testKey1 @crypto)
-        (OCertSignable @crypto (snd $ testKESKeys @crypto) 0 (KESPeriod 0))
+      signedDSIGN @c
+        (sKey $ testKey1 @c)
+        (OCertSignable @c (snd $ testKESKeys @c) 0 (KESPeriod 0))
     Encoding e = encodeSignedDSIGN s
 
-testKeyHash1 :: CC.Crypto crypto => KeyHash 'Payment crypto
+testKeyHash1 :: CC.Crypto c => KeyHash 'Payment c
 testKeyHash1 = (hashKey . vKey) testKey1
 
-testKeyHash2 :: CC.Crypto crypto => KeyHash 'Staking crypto
+testKeyHash2 :: CC.Crypto c => KeyHash 'Staking c
 testKeyHash2 = (hashKey . vKey) testKey2
 
-testKESKeys :: CC.Crypto crypto => (SignKeyKES crypto, VerKeyKES crypto)
+testKESKeys :: CC.Crypto c => (SignKeyKES c, VerKeyKES c)
 testKESKeys = mkKESKeyPair (RawSeed 0 0 0 0 3)
 
-testAddrE :: CC.Crypto crypto => Addr crypto
+testAddrE :: CC.Crypto c => Addr c
 testAddrE =
   Addr
     Testnet
     (KeyHashObj testKeyHash1)
     StakeRefNull
 
-testPayCred :: forall crypto. CC.Crypto crypto => Credential 'Payment crypto
-testPayCred = KeyHashObj (testKeyHash1 @crypto)
+testPayCred :: forall c. CC.Crypto c => Credential 'Payment c
+testPayCred = KeyHashObj (testKeyHash1 @c)
 
-testStakeCred :: forall crypto. CC.Crypto crypto => Credential 'Staking crypto
-testStakeCred = KeyHashObj $ testKeyHash2 @crypto
+testStakeCred :: forall c. CC.Crypto c => Credential 'Staking c
+testStakeCred = KeyHashObj $ testKeyHash2 @c
 
-testScript :: forall crypto. CC.Crypto crypto => MultiSig (ShelleyEra crypto)
-testScript = RequireSignature $ asWitness (testKeyHash1 @crypto)
+testScript :: forall c. CC.Crypto c => MultiSig (ShelleyEra c)
+testScript = RequireSignature $ asWitness (testKeyHash1 @c)
 
-testScriptHash :: forall crypto. CC.Crypto crypto => ScriptHash crypto
-testScriptHash = hashScript @(ShelleyEra crypto) testScript
+testScriptHash :: forall c. CC.Crypto c => ScriptHash c
+testScriptHash = hashScript @(ShelleyEra c) testScript
 
-testScript2 :: forall crypto. CC.Crypto crypto => MultiSig (ShelleyEra crypto)
-testScript2 = RequireSignature $ asWitness (testKeyHash2 @crypto)
+testScript2 :: forall c. CC.Crypto c => MultiSig (ShelleyEra c)
+testScript2 = RequireSignature $ asWitness (testKeyHash2 @c)
 
 testHeaderHash ::
-  forall crypto.
-  CC.Crypto crypto =>
-  HashHeader crypto
+  forall c.
+  CC.Crypto c =>
+  HashHeader c
 testHeaderHash =
   HashHeader $
     coerce
-      (hashWithSerialiser toCBOR 0 :: Hash crypto Int)
+      (hashWithSerialiser toCBOR 0 :: Hash c Int)
 
 testBHB ::
-  forall era crypto.
+  forall era c.
   ( EraTx era,
     PreAlonzo era,
-    ExMock crypto,
-    crypto ~ EraCrypto era,
+    ExMock c,
+    c ~ EraCrypto era,
     Tx era ~ ShelleyTx era
   ) =>
-  BHBody crypto
+  BHBody c
 testBHB =
   BHBody
     { bheaderBlockNo = BlockNo 44,
       bheaderSlotNo = SlotNo 33,
       bheaderPrev = BlockHash testHeaderHash,
       bheaderVk = vKey testBlockIssuerKey,
-      bheaderVrfVk = snd $ testVRF @crypto,
+      bheaderVrfVk = snd $ testVRF @c,
       bheaderEta =
         mkCertifiedVRF
           ( WithResult
               (mkSeed seedEta (SlotNo 33) (mkNonceFromNumber 0))
               1
           )
-          (fst $ testVRF @crypto),
+          (fst $ testVRF @c),
       bheaderL =
         mkCertifiedVRF
           ( WithResult
               (mkSeed seedL (SlotNo 33) (mkNonceFromNumber 0))
               1
           )
-          (fst $ testVRF @crypto),
+          (fst $ testVRF @c),
       bsize = 0,
       bhash = bbHash @era $ ShelleyTxSeq @era StrictSeq.empty,
       bheaderOCert =
         OCert
-          (snd $ testKESKeys @crypto)
+          (snd $ testKESKeys @c)
           0
           (KESPeriod 0)
-          ( signedDSIGN @crypto
-              (sKey $ testKey1 @crypto)
-              (OCertSignable (snd $ testKESKeys @crypto) 0 (KESPeriod 0))
+          ( signedDSIGN @c
+              (sKey $ testKey1 @c)
+              (OCertSignable (snd $ testKESKeys @c) 0 (KESPeriod 0))
           ),
       bprotver = ProtVer 0 0
     }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/JSON.hs
@@ -29,39 +29,39 @@ testProperty :: TestName -> Property -> TestTree
 testProperty s p = testPropertyNamed s (Hedgehog.Internal.Property.PropertyName s) p
 
 prop_roundtrip_Address_JSON ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Proxy crypto ->
+  forall c.
+  CC.Crypto c =>
+  Proxy c ->
   Property
 prop_roundtrip_Address_JSON _ =
   -- If this fails, FundPair and ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    addr <- Hedgehog.forAll $ genAddress @crypto
+    addr <- Hedgehog.forAll $ genAddress @c
 
     Hedgehog.tripping addr toJSON fromJSON
     Hedgehog.tripping addr encode decode
 
 prop_roundtrip_GenesisDelegationPair_JSON ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Proxy crypto ->
+  forall c.
+  CC.Crypto c =>
+  Proxy c ->
   Property
 prop_roundtrip_GenesisDelegationPair_JSON _ =
   Hedgehog.property $ do
-    dp <- Hedgehog.forAll $ genGenesisDelegationPair @crypto
+    dp <- Hedgehog.forAll $ genGenesisDelegationPair @c
 
     Hedgehog.tripping dp toJSON fromJSON
     Hedgehog.tripping dp encode decode
 
 prop_roundtrip_FundPair_JSON ::
-  forall crypto.
-  CC.Crypto crypto =>
-  Proxy crypto ->
+  forall c.
+  CC.Crypto c =>
+  Proxy c ->
   Property
 prop_roundtrip_FundPair_JSON _ =
   -- If this fails, ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    fp <- Hedgehog.forAll $ genGenesisFundPair @crypto
+    fp <- Hedgehog.forAll $ genGenesisFundPair @c
 
     Hedgehog.tripping fp toJSON fromJSON
     Hedgehog.tripping fp encode decode

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -130,38 +130,38 @@ import Test.Tasty.QuickCheck
 -- ========================================================================================
 
 -- | - This constraint says we can coerce Numbers into a signable keys
-type NumKey crypto =
-  ( Num (SignKeyDSIGN (DSIGN crypto)),
-    Num (VerKeyDSIGN (DSIGN crypto))
+type NumKey c =
+  ( Num (SignKeyDSIGN (DSIGN c)),
+    Num (VerKeyDSIGN (DSIGN c))
   )
 
-alicePay :: NumKey crypto => KeyPair 'Payment crypto
+alicePay :: NumKey c => KeyPair 'Payment c
 alicePay = KeyPair 1 1
 
-aliceStake :: NumKey crypto => KeyPair 'Staking crypto
+aliceStake :: NumKey c => KeyPair 'Staking c
 aliceStake = KeyPair 2 2
 
-aliceAddr :: (NumKey crypto, CC.Crypto crypto) => Addr crypto
+aliceAddr :: (NumKey c, CC.Crypto c) => Addr c
 aliceAddr =
   Addr
     Testnet
     (KeyHashObj . hashKey $ vKey alicePay)
     (StakeRefBase . KeyHashObj . hashKey $ vKey aliceStake)
 
-bobPay :: NumKey crypto => KeyPair 'Payment crypto
+bobPay :: NumKey c => KeyPair 'Payment c
 bobPay = KeyPair 3 3
 
-bobStake :: NumKey crypto => KeyPair 'Staking crypto
+bobStake :: NumKey c => KeyPair 'Staking c
 bobStake = KeyPair 4 4
 
-bobAddr :: (NumKey crypto, CC.Crypto crypto) => Addr crypto
+bobAddr :: (NumKey c, CC.Crypto c) => Addr c
 bobAddr =
   Addr
     Testnet
     (KeyHashObj . hashKey $ vKey bobPay)
     (StakeRefBase . KeyHashObj . hashKey $ vKey bobStake)
 
-mkGenesisTxIn :: (HashAlgorithm (HASH crypto), HasCallStack) => Integer -> TxIn crypto
+mkGenesisTxIn :: (HashAlgorithm (HASH c), HasCallStack) => Integer -> TxIn c
 mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
 
 pp :: ShelleyPParams era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
@@ -21,14 +21,14 @@ import Cardano.Ledger.SafeHash (SafeHash)
 import Control.DeepSeq (NFData (..))
 import NoThunks.Class (NoThunks (..))
 
-newtype AuxiliaryDataHash crypto = AuxiliaryDataHash
-  { unsafeAuxiliaryDataHash :: SafeHash crypto EraIndependentAuxiliaryData
+newtype AuxiliaryDataHash c = AuxiliaryDataHash
+  { unsafeAuxiliaryDataHash :: SafeHash c EraIndependentAuxiliaryData
   }
   deriving (Show, Eq, Ord, NoThunks, NFData)
 
-deriving instance CC.Crypto crypto => ToCBOR (AuxiliaryDataHash crypto)
+deriving instance CC.Crypto c => ToCBOR (AuxiliaryDataHash c)
 
-deriving instance CC.Crypto crypto => FromCBOR (AuxiliaryDataHash crypto)
+deriving instance CC.Crypto c => FromCBOR (AuxiliaryDataHash c)
 
 type ValidateAuxiliaryData era c = ()
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
@@ -18,16 +18,16 @@ import Numeric.Natural (Natural)
 -- and should work independently of the protocol. The values in
 -- 'BHeaderView' provide 'BBODY' all the data that it needs from the
 -- block headers.
-data BHeaderView crypto = BHeaderView
+data BHeaderView c = BHeaderView
   { -- | The block issuer. In the TPraos protocol, this can be a
     --  Genesis delegate, everywhere else it is the stake pool ID.
-    bhviewID :: KeyHash 'BlockIssuer crypto,
+    bhviewID :: KeyHash 'BlockIssuer c,
     -- | The purported size (in bytes) of the block body.
     bhviewBSize :: Natural,
     -- | The purported size (in bytes) of the block header.
     bhviewHSize :: Int,
     -- | The purported hash of the block body.
-    bhviewBHash :: Hash crypto EraIndependentBlockBody,
+    bhviewBHash :: Hash c EraIndependentBlockBody,
     -- | The slot for which this block was submitted to the chain.
     bhviewSlot :: SlotNo
   }

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -654,11 +654,11 @@ instance FromCBOR Network where
       Just n -> pure n
 
 -- | Blocks made
-newtype BlocksMade crypto = BlocksMade
-  { unBlocksMade :: Map (KeyHash 'StakePool crypto) Natural
+newtype BlocksMade c = BlocksMade
+  { unBlocksMade :: Map (KeyHash 'StakePool c) Natural
   }
   deriving (Eq, Generic)
-  deriving (Show) via Quiet (BlocksMade crypto)
+  deriving (Show) via Quiet (BlocksMade c)
   deriving newtype (NoThunks, NFData, ToJSON, FromJSON, ToCBOR, FromCBOR)
 
 -- TODO: It is unfeasable to have 65535 outputs in a transaction,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -61,7 +61,7 @@ data EraIndependentScript
 
 data EraIndependentData
 
-type DataHash crypto = SafeHash crypto EraIndependentData
+type DataHash c = SafeHash c EraIndependentData
 
 data EraIndependentScriptData
 
@@ -69,15 +69,15 @@ data EraIndependentPParamView
 
 data EraIndependentScriptIntegrity
 
-newtype ScriptHash crypto
-  = ScriptHash (Hash.Hash (ADDRHASH crypto) EraIndependentScript)
+newtype ScriptHash c
+  = ScriptHash (Hash.Hash (ADDRHASH c) EraIndependentScript)
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NFData, NoThunks)
 
-deriving newtype instance CC.Crypto crypto => ToCBOR (ScriptHash crypto)
+deriving newtype instance CC.Crypto c => ToCBOR (ScriptHash c)
 
-deriving newtype instance CC.Crypto crypto => FromCBOR (ScriptHash crypto)
+deriving newtype instance CC.Crypto c => FromCBOR (ScriptHash c)
 
-deriving newtype instance CC.Crypto crypto => ToJSON (ScriptHash crypto)
+deriving newtype instance CC.Crypto c => ToJSON (ScriptHash c)
 
-deriving newtype instance CC.Crypto crypto => FromJSON (ScriptHash crypto)
+deriving newtype instance CC.Crypto c => FromJSON (ScriptHash c)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -124,12 +124,12 @@ class HasKeyRole (a :: KeyRole -> Type -> Type) where
   --   The presence of this function is mostly to help the user realise where they
   --   are converting key roles.
   coerceKeyRole ::
-    a r crypto ->
-    a r' crypto
+    a r c ->
+    a r' c
   default coerceKeyRole ::
-    Coercible (a r crypto) (a r' crypto) =>
-    a r crypto ->
-    a r' crypto
+    Coercible (a r c) (a r' c) =>
+    a r c ->
+    a r' c
   coerceKeyRole = coerce
 
 -- | Use a key as a witness.
@@ -139,8 +139,8 @@ class HasKeyRole (a :: KeyRole -> Type -> Type) where
 --   explicit coercion for it.
 asWitness ::
   (HasKeyRole a) =>
-  a r crypto ->
-  a 'Witness crypto
+  a r c ->
+  a 'Witness c
 asWitness = coerceKeyRole
 
 --------------------------------------------------------------------------------
@@ -152,75 +152,75 @@ type DSignable c = DSIGN.Signable (DSIGN c)
 -- | Discriminated verification key
 --
 --   We wrap the basic `VerKeyDSIGN` in order to add the key role.
-newtype VKey (kd :: KeyRole) crypto = VKey {unVKey :: DSIGN.VerKeyDSIGN (DSIGN crypto)}
+newtype VKey (kd :: KeyRole) c = VKey {unVKey :: DSIGN.VerKeyDSIGN (DSIGN c)}
   deriving (Generic)
 
-deriving via Quiet (VKey kd crypto) instance Crypto crypto => Show (VKey kd crypto)
+deriving via Quiet (VKey kd c) instance Crypto c => Show (VKey kd c)
 
-deriving instance Crypto crypto => Eq (VKey kd crypto)
+deriving instance Crypto c => Eq (VKey kd c)
 
 deriving instance
-  (Crypto crypto, NFData (DSIGN.VerKeyDSIGN (DSIGN crypto))) =>
-  NFData (VKey kd crypto)
+  (Crypto c, NFData (DSIGN.VerKeyDSIGN (DSIGN c))) =>
+  NFData (VKey kd c)
 
-deriving instance Crypto crypto => NoThunks (VKey kd crypto)
+deriving instance Crypto c => NoThunks (VKey kd c)
 
 instance HasKeyRole VKey
 
 instance
-  (Crypto crypto, Typeable kd) =>
-  FromCBOR (VKey kd crypto)
+  (Crypto c, Typeable kd) =>
+  FromCBOR (VKey kd c)
   where
   fromCBOR = VKey <$> DSIGN.decodeVerKeyDSIGN
 
 instance
-  (Crypto crypto, Typeable kd) =>
-  ToCBOR (VKey kd crypto)
+  (Crypto c, Typeable kd) =>
+  ToCBOR (VKey kd c)
   where
   toCBOR (VKey vk) = DSIGN.encodeVerKeyDSIGN vk
   encodedSizeExpr _size proxy = DSIGN.encodedVerKeyDSIGNSizeExpr ((\(VKey k) -> k) <$> proxy)
 
 -- | Pair of signing key and verification key, with a usage role.
-data KeyPair (kd :: KeyRole) crypto = KeyPair
-  { vKey :: !(VKey kd crypto),
-    sKey :: !(DSIGN.SignKeyDSIGN (DSIGN crypto))
+data KeyPair (kd :: KeyRole) c = KeyPair
+  { vKey :: !(VKey kd c),
+    sKey :: !(DSIGN.SignKeyDSIGN (DSIGN c))
   }
   deriving (Generic, Show)
 
 instance
-  ( Crypto crypto,
-    NFData (DSIGN.VerKeyDSIGN (DSIGN crypto)),
-    NFData (DSIGN.SignKeyDSIGN (DSIGN crypto))
+  ( Crypto c,
+    NFData (DSIGN.VerKeyDSIGN (DSIGN c)),
+    NFData (DSIGN.SignKeyDSIGN (DSIGN c))
   ) =>
-  NFData (KeyPair kd crypto)
+  NFData (KeyPair kd c)
 
-instance Crypto crypto => NoThunks (KeyPair kd crypto)
+instance Crypto c => NoThunks (KeyPair kd c)
 
 instance HasKeyRole KeyPair
 
 -- | Produce a digital signature
 signedDSIGN ::
-  (Crypto crypto, DSIGN.Signable (DSIGN crypto) a) =>
-  DSIGN.SignKeyDSIGN (DSIGN crypto) ->
+  (Crypto c, DSIGN.Signable (DSIGN c) a) =>
+  DSIGN.SignKeyDSIGN (DSIGN c) ->
   a ->
-  SignedDSIGN crypto a
+  SignedDSIGN c a
 signedDSIGN key a = DSIGN.signedDSIGN () a key
 
 -- | Verify a digital signature
 verifySignedDSIGN ::
-  (Crypto crypto, DSIGN.Signable (DSIGN crypto) a) =>
-  VKey kd crypto ->
+  (Crypto c, DSIGN.Signable (DSIGN c) a) =>
+  VKey kd c ->
   a ->
-  SignedDSIGN crypto a ->
+  SignedDSIGN c a ->
   Bool
 verifySignedDSIGN (VKey vk) vd sigDSIGN =
   either (const False) (const True) $ DSIGN.verifySignedDSIGN () vk vd sigDSIGN
 
 -- | Hash a given signature
 hashSignature ::
-  (Crypto crypto) =>
-  SignedDSIGN crypto (Hash crypto h) ->
-  Hash crypto (SignedDSIGN crypto (Hash crypto h))
+  (Crypto c) =>
+  SignedDSIGN c (Hash c h) ->
+  Hash c (SignedDSIGN c (Hash c h))
 hashSignature = Hash.hashWith (DSIGN.rawSerialiseSigDSIGN . coerce)
 
 --------------------------------------------------------------------------------
@@ -228,43 +228,43 @@ hashSignature = Hash.hashWith (DSIGN.rawSerialiseSigDSIGN . coerce)
 --------------------------------------------------------------------------------
 
 -- | Discriminated hash of public Key
-newtype KeyHash (discriminator :: KeyRole) crypto
-  = KeyHash (Hash.Hash (ADDRHASH crypto) (DSIGN.VerKeyDSIGN (DSIGN crypto)))
+newtype KeyHash (discriminator :: KeyRole) c
+  = KeyHash (Hash.Hash (ADDRHASH c) (DSIGN.VerKeyDSIGN (DSIGN c)))
   deriving (Show, Eq, Ord)
   deriving newtype (NFData, NoThunks, Generic)
 
 deriving instance
-  (Crypto crypto, Typeable disc) =>
-  ToCBOR (KeyHash disc crypto)
+  (Crypto c, Typeable disc) =>
+  ToCBOR (KeyHash disc c)
 
 deriving instance
-  (Crypto crypto, Typeable disc) =>
-  FromCBOR (KeyHash disc crypto)
+  (Crypto c, Typeable disc) =>
+  FromCBOR (KeyHash disc c)
 
 deriving newtype instance
-  Crypto crypto =>
-  ToJSONKey (KeyHash disc crypto)
+  Crypto c =>
+  ToJSONKey (KeyHash disc c)
 
 deriving newtype instance
-  Crypto crypto =>
-  FromJSONKey (KeyHash disc crypto)
+  Crypto c =>
+  FromJSONKey (KeyHash disc c)
 
 deriving newtype instance
-  Crypto crypto =>
-  ToJSON (KeyHash disc crypto)
+  Crypto c =>
+  ToJSON (KeyHash disc c)
 
 deriving newtype instance
-  Crypto crypto =>
-  FromJSON (KeyHash disc crypto)
+  Crypto c =>
+  FromJSON (KeyHash disc c)
 
 instance HasKeyRole KeyHash
 
 -- | Hash a given public key
 hashKey ::
-  ( Crypto crypto
+  ( Crypto c
   ) =>
-  VKey kd crypto ->
-  KeyHash kd crypto
+  VKey kd c ->
+  KeyHash kd c
 hashKey (VKey vk) = KeyHash $ DSIGN.hashVerKeyDSIGN vk
 
 --------------------------------------------------------------------------------
@@ -285,54 +285,54 @@ type VRFSignable c = VRF.Signable (VRF c)
 -- TODO should this really live in here?
 --------------------------------------------------------------------------------
 
-data GenDelegPair crypto = GenDelegPair
-  { genDelegKeyHash :: !(KeyHash 'GenesisDelegate crypto),
-    genDelegVrfHash :: !(Hash crypto (VerKeyVRF crypto))
+data GenDelegPair c = GenDelegPair
+  { genDelegKeyHash :: !(KeyHash 'GenesisDelegate c),
+    genDelegVrfHash :: !(Hash c (VerKeyVRF c))
   }
   deriving (Show, Eq, Ord, Generic)
 
-instance NoThunks (GenDelegPair crypto)
+instance NoThunks (GenDelegPair c)
 
-instance NFData (GenDelegPair crypto)
+instance NFData (GenDelegPair c)
 
-instance Crypto crypto => ToCBOR (GenDelegPair crypto) where
+instance Crypto c => ToCBOR (GenDelegPair c) where
   toCBOR (GenDelegPair hk vrf) =
     encodeListLen 2 <> toCBOR hk <> toCBOR vrf
 
-instance Crypto crypto => FromCBOR (GenDelegPair crypto) where
+instance Crypto c => FromCBOR (GenDelegPair c) where
   fromCBOR = do
     decodeRecordNamed
       "GenDelegPair"
       (const 2)
       (GenDelegPair <$> fromCBOR <*> fromCBOR)
 
-instance Crypto crypto => ToJSON (GenDelegPair crypto) where
+instance Crypto c => ToJSON (GenDelegPair c) where
   toJSON (GenDelegPair d v) =
     Aeson.object
       [ "delegate" .= d,
         "vrf" .= v
       ]
 
-instance Crypto crypto => FromJSON (GenDelegPair crypto) where
+instance Crypto c => FromJSON (GenDelegPair c) where
   parseJSON =
     Aeson.withObject "GenDelegPair" $ \obj ->
       GenDelegPair
         <$> obj .: "delegate"
         <*> obj .: "vrf"
 
-newtype GenDelegs crypto = GenDelegs
-  { unGenDelegs :: Map (KeyHash 'Genesis crypto) (GenDelegPair crypto)
+newtype GenDelegs c = GenDelegs
+  { unGenDelegs :: Map (KeyHash 'Genesis c) (GenDelegPair c)
   }
   deriving (Eq, FromCBOR, NoThunks, NFData, Generic, FromJSON)
-  deriving (Show) via Quiet (GenDelegs crypto)
+  deriving (Show) via Quiet (GenDelegs c)
 
 deriving instance
-  (Crypto crypto) =>
-  ToCBOR (GenDelegs crypto)
+  (Crypto c) =>
+  ToCBOR (GenDelegs c)
 
-newtype GKeys crypto = GKeys {unGKeys :: Set (VKey 'Genesis crypto)}
+newtype GKeys c = GKeys {unGKeys :: Set (VKey 'Genesis c)}
   deriving (Eq, NoThunks, Generic)
-  deriving (Show) via Quiet (GKeys crypto)
+  deriving (Show) via Quiet (GKeys c)
 
 --------------------------------------------------------------------------------
 -- crypto-parametrised types

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
@@ -46,14 +46,14 @@ import NoThunks.Class (NoThunks (..))
 -- The stake is relative to the total amount of active stake
 -- in the network. Stake is active if it is both registered and
 -- delegated to a registered stake pool.
-data IndividualPoolStake crypto = IndividualPoolStake
+data IndividualPoolStake c = IndividualPoolStake
   { individualPoolStake :: !Rational,
-    individualPoolStakeVrf :: !(Hash crypto (VerKeyVRF crypto))
+    individualPoolStakeVrf :: !(Hash c (VerKeyVRF c))
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NFData, NoThunks)
 
-instance CC.Crypto crypto => ToCBOR (IndividualPoolStake crypto) where
+instance CC.Crypto c => ToCBOR (IndividualPoolStake c) where
   toCBOR (IndividualPoolStake stake vrf) =
     mconcat
       [ encodeListLen 2,
@@ -61,7 +61,7 @@ instance CC.Crypto crypto => ToCBOR (IndividualPoolStake crypto) where
         toCBOR vrf
       ]
 
-instance CC.Crypto crypto => FromCBOR (IndividualPoolStake crypto) where
+instance CC.Crypto c => FromCBOR (IndividualPoolStake c) where
   fromCBOR =
     decodeRecordNamed "IndividualPoolStake" (const 2) $
       IndividualPoolStake
@@ -70,9 +70,9 @@ instance CC.Crypto crypto => FromCBOR (IndividualPoolStake crypto) where
 
 -- | A map of stake pool IDs (the hash of the stake pool operator's
 -- verification key) to 'IndividualPoolStake'.
-newtype PoolDistr crypto = PoolDistr
+newtype PoolDistr c = PoolDistr
   { unPoolDistr ::
-      Map (KeyHash 'StakePool crypto) (IndividualPoolStake crypto)
+      Map (KeyHash 'StakePool c) (IndividualPoolStake c)
   }
   deriving stock (Show, Eq)
   deriving newtype (ToCBOR, FromCBOR, NFData, NoThunks)
@@ -81,10 +81,10 @@ newtype PoolDistr crypto = PoolDistr
 
 instance
   HasExp
-    (PoolDistr crypto)
+    (PoolDistr c)
     ( Map
-        (KeyHash 'StakePool crypto)
-        (IndividualPoolStake crypto)
+        (KeyHash 'StakePool c)
+        (IndividualPoolStake c)
     )
   where
   toExp (PoolDistr x) = Base MapR x
@@ -92,10 +92,10 @@ instance
 -- | We can Embed a Newtype around a Map (or other Iterable type) and then use it in a set expression.
 instance
   Embed
-    (PoolDistr crypto)
+    (PoolDistr c)
     ( Map
-        (KeyHash 'StakePool crypto)
-        (IndividualPoolStake crypto)
+        (KeyHash 'StakePool c)
+        (IndividualPoolStake c)
     )
   where
   toBase (PoolDistr x) = x

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -46,46 +46,46 @@ import NoThunks.Class (NoThunks (..))
 -- ====================================================================================
 
 -- | A unique ID of a transaction, which is computable from the transaction.
-newtype TxId crypto = TxId {_unTxId :: SafeHash crypto EraIndependentTxBody}
+newtype TxId c = TxId {_unTxId :: SafeHash c EraIndependentTxBody}
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NoThunks, HeapWords)
 
-deriving newtype instance CC.Crypto crypto => ToCBOR (TxId crypto)
+deriving newtype instance CC.Crypto c => ToCBOR (TxId c)
 
-deriving newtype instance CC.Crypto crypto => FromCBOR (TxId crypto)
+deriving newtype instance CC.Crypto c => FromCBOR (TxId c)
 
-deriving newtype instance CC.Crypto crypto => NFData (TxId crypto)
+deriving newtype instance CC.Crypto c => NFData (TxId c)
 
-instance CC.Crypto crypto => HeapWords (TxIn crypto) where
+instance CC.Crypto c => HeapWords (TxIn c) where
   heapWords (TxIn txId _) =
     2 + HW.heapWords txId + 1 {- txIx -}
 
 -- | The input of a UTxO.
-data TxIn crypto = TxIn !(TxId crypto) {-# UNPACK #-} !TxIx
+data TxIn c = TxIn !(TxId c) {-# UNPACK #-} !TxIx
   deriving (Generic)
 
 -- | Construct `TxIn` while throwing an error for an out of range `TxIx`. Make
 -- sure to use it only for testing.
-mkTxInPartial :: HW.HasCallStack => TxId crypto -> Integer -> TxIn crypto
+mkTxInPartial :: HW.HasCallStack => TxId c -> Integer -> TxIn c
 mkTxInPartial txId = TxIn txId . mkTxIxPartial
 
-deriving instance Eq (TxIn crypto)
+deriving instance Eq (TxIn c)
 
-deriving instance Ord (TxIn crypto)
+deriving instance Ord (TxIn c)
 
-deriving instance Show (TxIn crypto)
+deriving instance Show (TxIn c)
 
-deriving instance CC.Crypto crypto => NFData (TxIn crypto)
+deriving instance CC.Crypto c => NFData (TxIn c)
 
-instance NoThunks (TxIn crypto)
+instance NoThunks (TxIn c)
 
-instance CC.Crypto crypto => ToCBOR (TxIn crypto) where
+instance CC.Crypto c => ToCBOR (TxIn c) where
   toCBOR (TxIn txId index) =
     encodeListLen 2
       <> toCBOR txId
       <> toCBOR index
 
-instance CC.Crypto crypto => FromCBOR (TxIn crypto) where
+instance CC.Crypto c => FromCBOR (TxIn c) where
   fromCBOR =
     decodeRecordNamed
       "TxIn"

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UnifiedMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UnifiedMap.hs
@@ -25,19 +25,19 @@ import Data.UMap (Tag (..), Trip (..), UMap (..), UnifiedView (..), View (..))
 
 -- ====================================================
 
-type UnifiedMap crypto = UMap Coin (Credential 'Staking crypto) (KeyHash 'StakePool crypto) Ptr
+type UnifiedMap c = UMap Coin (Credential 'Staking c) (KeyHash 'StakePool c) Ptr
 
-type Triple crypto = Trip Coin Ptr (KeyHash 'StakePool crypto)
+type Triple c = Trip Coin Ptr (KeyHash 'StakePool c)
 
-type ViewMap crypto = View Coin (Credential 'Staking crypto) (KeyHash 'StakePool crypto) Ptr
+type ViewMap c = View Coin (Credential 'Staking c) (KeyHash 'StakePool c) Ptr
 
 instance
   UnifiedView
     Coin
-    (Credential 'Staking crypto)
-    (KeyHash 'StakePool crypto)
+    (Credential 'Staking c)
+    (KeyHash 'StakePool c)
     Ptr
-    (Credential 'Staking crypto)
+    (Credential 'Staking c)
     Coin
   where
   tag = Rew
@@ -45,21 +45,21 @@ instance
 instance
   UnifiedView
     Coin
-    (Credential 'Staking crypto)
-    (KeyHash 'StakePool crypto)
+    (Credential 'Staking c)
+    (KeyHash 'StakePool c)
     Ptr
-    (Credential 'Staking crypto)
-    (KeyHash 'StakePool crypto)
+    (Credential 'Staking c)
+    (KeyHash 'StakePool c)
   where
   tag = Del
 
 instance
   UnifiedView
     Coin
-    (Credential 'Staking crypto)
-    (KeyHash 'StakePool crypto)
+    (Credential 'Staking c)
+    (KeyHash 'StakePool c)
     Ptr
     Ptr
-    (Credential 'Staking crypto)
+    (Credential 'Staking c)
   where
   tag = Ptr

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -403,7 +403,7 @@ class PrettyA t where
 -- =====================================================
 -- Data.UMap
 
-ppTrip :: Triple crypto -> PDoc
+ppTrip :: Triple c -> PDoc
 ppTrip (Triple mcoin set mpool) =
   ppSexp
     "Triple"
@@ -412,7 +412,7 @@ ppTrip (Triple mcoin set mpool) =
       ppStrictMaybe ppKeyHash mpool
     ]
 
-ppUnifiedMap :: UnifiedMap crypto -> PDoc
+ppUnifiedMap :: UnifiedMap c -> PDoc
 ppUnifiedMap (UnifiedMap tripmap ptrmap) =
   ppRecord
     "UnifiedMap"
@@ -519,7 +519,7 @@ instance PrettyA (IndividualPoolStake c) where
 -- ================================
 -- Cardano.Ledger.Shelley.RewardUpdate
 
-ppRewardUpdate :: RewardUpdate crypto -> PDoc
+ppRewardUpdate :: RewardUpdate c -> PDoc
 ppRewardUpdate (RewardUpdate dt dr rss df nonmyop) =
   ppRecord
     "RewardUpdate"
@@ -530,7 +530,7 @@ ppRewardUpdate (RewardUpdate dt dr rss df nonmyop) =
       ("nonMyopic", ppNonMyopic nonmyop)
     ]
 
-ppRewardSnapShot :: RewardSnapShot crypto -> PDoc
+ppRewardSnapShot :: RewardSnapShot c -> PDoc
 ppRewardSnapShot (RewardSnapShot fee ver non deltaR1 rR deltaT1 ls lrews) =
   ppRecord
     "RewardSnapShot"
@@ -544,7 +544,7 @@ ppRewardSnapShot (RewardSnapShot fee ver non deltaR1 rR deltaT1 ls lrews) =
       ("leaderRewards", ppMap ppCredential (ppSet ppReward) lrews)
     ]
 
-ppPoolRewardInfo :: PoolRewardInfo crypto -> PDoc
+ppPoolRewardInfo :: PoolRewardInfo c -> PDoc
 ppPoolRewardInfo (PoolRewardInfo relStake pot params blocks lreward) =
   ppRecord
     "PoolRewardInfo"
@@ -555,7 +555,7 @@ ppPoolRewardInfo (PoolRewardInfo relStake pot params blocks lreward) =
       ("leaderReward", ppLeaderOnlyReward lreward)
     ]
 
-ppFreeVars :: FreeVars crypto -> PDoc
+ppFreeVars :: FreeVars c -> PDoc
 ppFreeVars (FreeVars ds addrs total pv pri) =
   ppRecord
     "FreeVars"
@@ -566,11 +566,11 @@ ppFreeVars (FreeVars ds addrs total pv pri) =
       ("poolRewardInfo", ppMap ppKeyHash ppPoolRewardInfo pri)
     ]
 
-ppAns :: RewardAns crypto -> PDoc
+ppAns :: RewardAns c -> PDoc
 ppAns (RewardAns x y) =
   ppRecord "RewardAns" [("allEvents", ppMap ppCredential ppReward x), ("recentEvents", ppMap ppCredential (ppSet ppReward) y)]
 
-ppRewardPulser :: Pulser crypto -> PDoc
+ppRewardPulser :: Pulser c -> PDoc
 ppRewardPulser (RSLP n free items ans) =
   ppSexp
     "RewardPulser"
@@ -580,25 +580,25 @@ ppRewardPulser (RSLP n free items ans) =
       ppAns ans
     ]
 
-ppPulsingRewUpdate :: PulsingRewUpdate crypto -> PDoc
+ppPulsingRewUpdate :: PulsingRewUpdate c -> PDoc
 ppPulsingRewUpdate (Pulsing snap pulser) =
   ppSexp "Pulsing" [ppRewardSnapShot snap, ppRewardPulser pulser]
 ppPulsingRewUpdate (Complete rewup) =
   ppSexp "Complete" [ppRewardUpdate rewup]
 
-instance PrettyA (RewardSnapShot crypto) where
+instance PrettyA (RewardSnapShot c) where
   prettyA = ppRewardSnapShot
 
-instance PrettyA (FreeVars crypto) where
+instance PrettyA (FreeVars c) where
   prettyA = ppFreeVars
 
-instance PrettyA (Pulser crypto) where
+instance PrettyA (Pulser c) where
   prettyA = ppRewardPulser
 
-instance PrettyA (PulsingRewUpdate crypto) where
+instance PrettyA (PulsingRewUpdate c) where
   prettyA = ppPulsingRewUpdate
 
-instance PrettyA (RewardUpdate crypto) where
+instance PrettyA (RewardUpdate c) where
   prettyA = ppRewardUpdate
 
 -- =================================
@@ -619,10 +619,10 @@ ppAccountState (AccountState tr re) =
       ("reserves", ppCoin re)
     ]
 
-ppDPState :: DPState crypto -> PDoc
+ppDPState :: DPState c -> PDoc
 ppDPState (DPState d p) = ppRecord "DPState" [("dstate", ppDState d), ("pstate", ppPState p)]
 
-ppDState :: DState crypto -> PDoc
+ppDState :: DState c -> PDoc
 ppDState (DState unified future gen irwd) =
   ppRecord
     "DState"
@@ -632,7 +632,7 @@ ppDState (DState unified future gen irwd) =
       ("instantaeousrewards", ppInstantaneousRewards irwd)
     ]
 
-ppFutureGenDeleg :: FutureGenDeleg crypto -> PDoc
+ppFutureGenDeleg :: FutureGenDeleg c -> PDoc
 ppFutureGenDeleg (FutureGenDeleg sl kh) =
   ppRecord
     "FutureGenDeleg"
@@ -640,7 +640,7 @@ ppFutureGenDeleg (FutureGenDeleg sl kh) =
       ("keyhash", ppKeyHash kh)
     ]
 
-ppInstantaneousRewards :: InstantaneousRewards crypto -> PDoc
+ppInstantaneousRewards :: InstantaneousRewards c -> PDoc
 ppInstantaneousRewards (InstantaneousRewards res treas dR dT) =
   ppRecord
     "InstantaneousRewards"
@@ -658,7 +658,7 @@ ppPPUPState (PPUPState p fp) =
       ("futureProposals", ppProposedPPUpdates fp)
     ]
 
-ppPState :: PState crypto -> PDoc
+ppPState :: PState c -> PDoc
 ppPState (PState par fpar ret) =
   ppRecord
     "PState"
@@ -667,14 +667,14 @@ ppPState (PState par fpar ret) =
       ("retiring", ppMap' mempty ppKeyHash ppEpochNo ret)
     ]
 
-ppRewardAccounts :: Map.Map (Credential 'Staking crypto) Coin -> PDoc
+ppRewardAccounts :: Map.Map (Credential 'Staking c) Coin -> PDoc
 ppRewardAccounts = ppMap' (text "RewardAccounts") ppCredential ppCoin
 
 ppRewardType :: RewardType -> PDoc
 ppRewardType MemberReward = text "MemberReward"
 ppRewardType LeaderReward = text "LeaderReward"
 
-ppReward :: Reward crypto -> PDoc
+ppReward :: Reward c -> PDoc
 ppReward (Reward rt pool amt) =
   ppRecord
     "Reward"
@@ -683,7 +683,7 @@ ppReward (Reward rt pool amt) =
       ("rewardAmount", ppCoin amt)
     ]
 
-ppLeaderOnlyReward :: LeaderOnlyReward crypto -> PDoc
+ppLeaderOnlyReward :: LeaderOnlyReward c -> PDoc
 ppLeaderOnlyReward (LeaderOnlyReward pool amt) =
   ppRecord
     "LeaderOnlyReward"
@@ -691,7 +691,7 @@ ppLeaderOnlyReward (LeaderOnlyReward pool amt) =
       ("rewardAmount", ppCoin amt)
     ]
 
-ppIncrementalStake :: IncrementalStake crypto -> PDoc
+ppIncrementalStake :: IncrementalStake c -> PDoc
 ppIncrementalStake (IStake st dangle) =
   ppRecord
     "IncrementalStake"
@@ -751,10 +751,10 @@ ppLedgerState (LedgerState u d) =
 instance PrettyA AccountState where
   prettyA = ppAccountState
 
-instance PrettyA (DPState crypto) where
+instance PrettyA (DPState c) where
   prettyA = ppDPState
 
-instance PrettyA (DState crypto) where
+instance PrettyA (DState c) where
   prettyA = ppDState
 
 instance
@@ -773,10 +773,10 @@ instance
   where
   prettyA x = ppNewEpochState x
 
-instance PrettyA (FutureGenDeleg crypto) where
+instance PrettyA (FutureGenDeleg c) where
   prettyA = ppFutureGenDeleg
 
-instance PrettyA (InstantaneousRewards crypto) where
+instance PrettyA (InstantaneousRewards c) where
   prettyA = ppInstantaneousRewards
 
 instance
@@ -793,7 +793,7 @@ instance
   where
   prettyA = ppPPUPState
 
-instance PrettyA (PState crypto) where
+instance PrettyA (PState c) where
   prettyA = ppPState
 
 instance
@@ -813,7 +813,7 @@ instance PrettyA (IncrementalStake c) where
 ppPerformanceEstimate :: PerformanceEstimate -> PDoc
 ppPerformanceEstimate (PerformanceEstimate n) = ppSexp "PerformanceEstimate" [ppDouble n]
 
-ppNonMyopic :: NonMyopic crypto -> PDoc
+ppNonMyopic :: NonMyopic c -> PDoc
 ppNonMyopic (NonMyopic m c) =
   ppRecord
     "NonMyopic"
@@ -851,14 +851,14 @@ instance PrettyA Likelihood where
 -- =================================
 -- Cardano.Ledger.Shelley.EpochBoundary
 
-ppStake :: Stake crypto -> PDoc
+ppStake :: Stake c -> PDoc
 ppStake (Stake m) =
   ppMap' (text "Stake") ppCredential (ppCoin . fromCompact) (VMap.toMap m)
 
-ppBlocksMade :: BlocksMade crypto -> PDoc
+ppBlocksMade :: BlocksMade c -> PDoc
 ppBlocksMade (BlocksMade m) = ppMap' (text "BlocksMade") ppKeyHash ppNatural m
 
-ppSnapShot :: SnapShot crypto -> PDoc
+ppSnapShot :: SnapShot c -> PDoc
 ppSnapShot (SnapShot st deleg params) =
   ppRecord
     "SnapShot"
@@ -867,7 +867,7 @@ ppSnapShot (SnapShot st deleg params) =
       ("poolParams", ppVMap ppKeyHash ppPoolParams params)
     ]
 
-ppSnapShots :: SnapShots crypto -> PDoc
+ppSnapShots :: SnapShots c -> PDoc
 ppSnapShots (SnapShots mark set go fees) =
   ppRecord
     "SnapShots"
@@ -877,16 +877,16 @@ ppSnapShots (SnapShots mark set go fees) =
       ("fee", ppCoin fees)
     ]
 
-instance PrettyA (Stake crypto) where
+instance PrettyA (Stake c) where
   prettyA = ppStake
 
-instance PrettyA (BlocksMade crypto) where
+instance PrettyA (BlocksMade c) where
   prettyA = ppBlocksMade
 
-instance PrettyA (SnapShot crypto) where
+instance PrettyA (SnapShot c) where
   prettyA = ppSnapShot
 
-instance PrettyA (SnapShots crypto) where
+instance PrettyA (SnapShots c) where
   prettyA = ppSnapShots
 
 -- ============================
@@ -950,7 +950,7 @@ ppTx tx =
       ("metadata", ppStrictMaybe prettyA $ tx ^. auxDataTxL)
     ]
 
-ppBootstrapWitness :: Crypto crypto => BootstrapWitness crypto -> PDoc
+ppBootstrapWitness :: Crypto c => BootstrapWitness c -> PDoc
 ppBootstrapWitness (BootstrapWitness key sig (ChainCode code) attr) =
   ppRecord
     "BootstrapWitness"
@@ -981,7 +981,7 @@ instance
   where
   prettyA = ppTx
 
-instance Crypto crypto => PrettyA (BootstrapWitness crypto) where
+instance Crypto c => PrettyA (BootstrapWitness c) where
   prettyA = ppBootstrapWitness
 
 instance (Era era, PrettyA (Script era)) => PrettyA (ShelleyTxWits era) where
@@ -990,7 +990,7 @@ instance (Era era, PrettyA (Script era)) => PrettyA (ShelleyTxWits era) where
 -- ============================
 --  Cardano.Ledger.AuxiliaryData
 
-ppSafeHash :: SafeHash crypto index -> PDoc
+ppSafeHash :: SafeHash c index -> PDoc
 ppSafeHash x = ppHash (extractHash x)
 
 ppAuxiliaryDataHash :: AuxiliaryDataHash c -> PDoc
@@ -1380,7 +1380,7 @@ ppMultiSig (RequireAllOf ps) = ppSexp "AllOf" (map ppMultiSig ps)
 ppMultiSig (RequireAnyOf ps) = ppSexp "AnyOf" (map ppMultiSig ps)
 ppMultiSig (RequireMOf m ps) = ppSexp "MOf" (pretty m : map ppMultiSig ps)
 
-ppScriptHash :: ScriptHash crypto -> PDoc
+ppScriptHash :: ScriptHash c -> PDoc
 ppScriptHash (ScriptHash h) = ppSexp "ScriptHash" [ppHash h]
 
 instance PrettyA (ScriptHash c) where
@@ -1428,7 +1428,7 @@ instance PrettyA BlockNo where
 ppKESPeriod :: KESPeriod -> PDoc
 ppKESPeriod (KESPeriod x) = text "KESPeriod" <+> pretty x
 
-ppOCertEnv :: OCertEnv crypto -> PDoc
+ppOCertEnv :: OCertEnv c -> PDoc
 ppOCertEnv (OCertEnv ps ds) =
   ppRecord
     "OCertEnv"
@@ -1436,19 +1436,19 @@ ppOCertEnv (OCertEnv ps ds) =
       ("ocertEnvGenDelegs", ppSet ppKeyHash ds)
     ]
 
-ppOCert :: forall crypto. Crypto crypto => OCert crypto -> PDoc
+ppOCert :: forall c. Crypto c => OCert c -> PDoc
 ppOCert (OCert vk n per sig) =
   ppRecord
     "OCert"
-    [ ("ocertVkKot", ppVerKeyKES (Proxy @crypto) vk),
+    [ ("ocertVkKot", ppVerKeyKES (Proxy @c) vk),
       ("ocertN", pretty n),
       ("ocertKESPeriod", ppKESPeriod per),
       ("ocertSigma", ppSignedDSIGN sig)
     ]
 
-ppOCertSignable :: forall crypto. Crypto crypto => OCertSignable crypto -> PDoc
+ppOCertSignable :: forall c. Crypto c => OCertSignable c -> PDoc
 ppOCertSignable (OCertSignable verkes w per) =
-  ppSexp "OCertSignable" [ppVerKeyKES (Proxy @crypto) verkes, pretty w, ppKESPeriod per]
+  ppSexp "OCertSignable" [ppVerKeyKES (Proxy @c) verkes, pretty w, ppKESPeriod per]
 
 instance PrettyA KESPeriod where
   prettyA = ppKESPeriod
@@ -1581,7 +1581,7 @@ ppGenDelegPair (GenDelegPair (KeyHash x) y) =
 ppGKeys :: Crypto c => GKeys c -> PDoc
 ppGKeys (GKeys x) = ppSexp "GKeys" [ppSet ppVKey x]
 
-ppVerKeyKES :: forall crypto. Crypto crypto => Proxy crypto -> VerKeyKES crypto -> PDoc
+ppVerKeyKES :: forall c. Crypto c => Proxy c -> VerKeyKES c -> PDoc
 ppVerKeyKES Proxy x = reAnnotate (Width 5 :) (viaShow x)
 
 ppGenDelegs :: GenDelegs c -> PDoc

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -228,7 +228,7 @@ ppTxBody (AlonzoTxBody i ifee o c w fee vi u rsh mnt sdh axh ni) =
       ("txnetworkid", ppStrictMaybe ppNetwork ni)
     ]
 
-ppAuxDataHash :: AuxiliaryDataHash crypto -> PDoc
+ppAuxDataHash :: AuxiliaryDataHash c -> PDoc
 ppAuxDataHash (AuxiliaryDataHash axh) = ppSafeHash axh
 
 instance

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -19,25 +19,25 @@ import Cardano.Ledger.ShelleyMA.TxBody
 import qualified Data.Map as Map
 import Prettyprinter (hsep, viaShow)
 
-ppPolicyID :: PolicyID crypto -> PDoc
+ppPolicyID :: PolicyID c -> PDoc
 ppPolicyID (PolicyID sh) = ppScriptHash sh
 
-instance PrettyA (PolicyID crypto) where prettyA x = ppSexp "PolicyID" [ppPolicyID x]
+instance PrettyA (PolicyID c) where prettyA x = ppSexp "PolicyID" [ppPolicyID x]
 
 ppAssetName :: AssetName -> PDoc
 ppAssetName = viaShow
 
 instance PrettyA AssetName where prettyA x = ppSexp "AssetName" [ppAssetName x]
 
-ppMultiAsset :: MultiAsset crypto -> PDoc
+ppMultiAsset :: MultiAsset c -> PDoc
 ppMultiAsset m = ppList pptriple (flattenMultiAsset m)
   where
     pptriple (i, asset, num) = hsep [ppPolicyID i, ppAssetName asset, ppInteger num]
 
-instance CC.Crypto crypto => PrettyA (MultiAsset crypto) where
+instance CC.Crypto c => PrettyA (MultiAsset c) where
   prettyA x = ppSexp "MultiAsset" [ppMultiAsset x]
 
-ppValue :: MaryValue crypto -> PDoc
+ppValue :: MaryValue c -> PDoc
 ppValue (MaryValue n m) = ppSexp "Value" $ [ppCoin (Coin n), ppMultiAsset m] ++ ppBad
   where
     ppBad = case getBadMultiAsset m of
@@ -45,7 +45,7 @@ ppValue (MaryValue n m) = ppSexp "Value" $ [ppCoin (Coin n), ppMultiAsset m] ++ 
       bad -> [ppString "Bad " <> ppList ppPolicyID bad]
     getBadMultiAsset (MultiAsset ma) = Map.keys (Map.filter Map.null ma)
 
-instance PrettyA (MaryValue crypto) where prettyA = ppValue
+instance PrettyA (MaryValue c) where prettyA = ppValue
 
 ppTimelock :: Era era => Timelock era -> PDoc
 ppTimelock (RequireSignature akh) =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -189,13 +189,13 @@ datumExampleSixtyFiveBytes = Data (Plutus.B sixtyFiveBytes)
 txDats :: Era era => TxDats era
 txDats = mkTxDats datumExampleSixtyFiveBytes
 
-someTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+someTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
 someTxIn = mkGenesisTxIn 1
 
-anotherTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+anotherTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
 anotherTxIn = mkGenesisTxIn 2
 
-yetAnotherTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => TxIn crypto
+yetAnotherTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
 yetAnotherTxIn = mkGenesisTxIn 3
 
 defaultPPs :: [PParamsField era]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -290,7 +290,7 @@ instance AlonzoBased (ConwayEra c) (BabbageUtxowPredFailure (ConwayEra c)) where
 -- ========================= Shared helper functions  ===================
 -- ======================================================================
 
-mkGenesisTxIn :: (CH.HashAlgorithm (CC.HASH crypto), HasCallStack) => Integer -> TxIn crypto
+mkGenesisTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => Integer -> TxIn c
 mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
 
 mkTxDats :: Era era => Data era -> TxDats era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -234,13 +234,13 @@ data PParamsField era
 initVI :: ValidityInterval
 initVI = ValidityInterval SNothing SNothing
 
-initWdrl :: Wdrl crypto
+initWdrl :: Wdrl c
 initWdrl = Wdrl Map.empty
 
-initMultiAsset :: MultiAsset crypto
+initMultiAsset :: MultiAsset c
 initMultiAsset = MultiAsset Map.empty
 
-initValue :: MaryValue crypto
+initValue :: MaryValue c
 initValue = MaryValue 0 mempty
 
 initialTxBody :: Era era => Proof era -> TxBody era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -295,7 +295,7 @@ txoutEvidence (Allegra _) (ShelleyTxOut addr _) =
 txoutEvidence (Shelley _) (ShelleyTxOut addr _) =
   (addrCredentials addr, Nothing)
 
-addrCredentials :: Addr crypto -> [Credential 'Payment crypto]
+addrCredentials :: Addr c -> [Credential 'Payment c]
 addrCredentials addr = maybe [] (: []) (paymentCredAddr addr)
 
 paymentCredAddr :: Addr c -> Maybe (Credential 'Payment c)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -152,13 +152,13 @@ theKeyHash n = hashKey (theVKey n)
 theWitVKey :: (GoodCrypto c) => Int -> SafeHash c EraIndependentTxBody -> WitVKey 'Witness c
 theWitVKey n hash = makeWitnessVKey hash (theKeyPair n)
 
-theKeyHashObj :: CC.Crypto crypto => Int -> Credential kr crypto
+theKeyHashObj :: CC.Crypto c => Int -> Credential kr c
 theKeyHashObj n = KeyHashObj . hashKey . vKey $ theKeyPair n
 
 aScriptHashObj :: forall era kr. EraScript era => Proof era -> Script era -> Credential kr (EraCrypto era)
 aScriptHashObj _wit s = ScriptHashObj . hashScript @era $ s
 
-theStakeReference :: CC.Crypto crypto => Int -> StakeReference crypto
+theStakeReference :: CC.Crypto c => Int -> StakeReference c
 theStakeReference n = (StakeRefBase . KeyHashObj . hashKey) (theVKey n)
 
 -- ====================================================
@@ -308,7 +308,7 @@ pickPolicyID n wit = PolicyID (pickScriptHash n wit)
 -- ===========================================================================
 -- An example where the 'pick' is the same type across all Crypto Evidence
 
-data PublicSecret kr kr' crypto = PublicSecret (KeyPair kr crypto) (KeyPair kr' crypto)
+data PublicSecret kr kr' c = PublicSecret (KeyPair kr c) (KeyPair kr' c)
 
 instance CC.Crypto c => Fixed (PublicSecret kr kr' c) where
   unique n = PublicSecret (KeyPair a b) (KeyPair c d)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -182,19 +182,19 @@ type Model era = ModelNewEpochState era
 -- Empty or default values, these are usefull for many things, not the
 -- least of, for making Model instances.
 
-blocksMadeZero :: BlocksMade crypto
+blocksMadeZero :: BlocksMade c
 blocksMadeZero = BlocksMade Map.empty
 
-poolDistrZero :: PoolDistr crypto
+poolDistrZero :: PoolDistr c
 poolDistrZero = PoolDistr Map.empty
 
-stakeZero :: Stake crypto
+stakeZero :: Stake c
 stakeZero = Stake VMap.empty
 
-snapShotZero :: SnapShot crypto
+snapShotZero :: SnapShot c
 snapShotZero = SnapShot stakeZero VMap.empty VMap.empty
 
-snapShotsZero :: SnapShots crypto
+snapShotsZero :: SnapShots c
 snapShotsZero = SnapShots snapShotZero snapShotZero snapShotZero (Coin 0)
 
 accountStateZero :: AccountState
@@ -203,28 +203,28 @@ accountStateZero = AccountState (Coin 0) (Coin 0)
 utxoZero :: UTxO era
 utxoZero = UTxO Map.empty
 
-genDelegsZero :: GenDelegs crypto
+genDelegsZero :: GenDelegs c
 genDelegsZero = GenDelegs Map.empty
 
-instantaneousRewardsZero :: InstantaneousRewards crypto
+instantaneousRewardsZero :: InstantaneousRewards c
 instantaneousRewardsZero = InstantaneousRewards Map.empty Map.empty mempty mempty
 
-dStateZero :: DState crypto
+dStateZero :: DState c
 dStateZero = DState UMap.empty Map.empty genDelegsZero instantaneousRewardsZero
 
-pStateZero :: PState crypto
+pStateZero :: PState c
 pStateZero = PState Map.empty Map.empty Map.empty
 
-dPStateZero :: DPState crypto
+dPStateZero :: DPState c
 dPStateZero = DPState dStateZero pStateZero
 
-incrementalStakeZero :: IncrementalStake crypto
+incrementalStakeZero :: IncrementalStake c
 incrementalStakeZero = IStake Map.empty Map.empty
 
 proposedPPUpdatesZero :: ProposedPPUpdates era
 proposedPPUpdatesZero = ProposedPPUpdates Map.empty
 
-nonMyopicZero :: NonMyopic crypto
+nonMyopicZero :: NonMyopic c
 nonMyopicZero = NonMyopic Map.empty mempty
 
 pPUPStateZeroByProof :: Proof era -> State (Core.EraRule "PPUP" era)
@@ -387,7 +387,7 @@ abstract x =
         -- SNothing -- There is no way to complete (nesRu x) to get a RewardUpdate
     }
 
-complete :: PulsingRewUpdate crypto -> RewardUpdate crypto
+complete :: PulsingRewUpdate c -> RewardUpdate c
 complete (Complete r) = r
 complete (Pulsing rewsnap pulser) = fst $ runShelleyBase (completeRupd (Pulsing rewsnap pulser))
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -119,17 +119,17 @@ getCrypto (Conway c) = c
 -- ==================================
 -- Reflection over Crypto and Era
 
-type GoodCrypto crypto =
-  ( CC.Crypto crypto,
-    DSignable crypto (CH.Hash (CC.HASH crypto) EraIndependentTxBody),
-    DSIGNAlgorithm (CC.DSIGN crypto),
-    DSIGN.Signable (CC.DSIGN crypto) (OCertSignable crypto),
-    VRF.Signable (VRF crypto) Base.Seed,
-    KES.Signable (KES crypto) (BHBody crypto),
-    ContextKES (KES crypto) ~ (),
-    ContextVRF (VRF crypto) ~ (),
-    CH.HashAlgorithm (CC.HASH crypto),
-    PraosCrypto crypto
+type GoodCrypto c =
+  ( CC.Crypto c,
+    DSignable c (CH.Hash (CC.HASH c) EraIndependentTxBody),
+    DSIGNAlgorithm (CC.DSIGN c),
+    DSIGN.Signable (CC.DSIGN c) (OCertSignable c),
+    VRF.Signable (VRF c) Base.Seed,
+    KES.Signable (KES c) (BHBody c),
+    ContextKES (KES c) ~ (),
+    ContextVRF (VRF c) ~ (),
+    CH.HashAlgorithm (CC.HASH c),
+    PraosCrypto c
   )
 
 class (GoodCrypto c) => ReflectC c where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -436,7 +436,7 @@ mapProportion epochnum lastSlot count m =
   where
     pairs = [(n, pure k) | (k, n) <- Map.toList m]
 
-chooseIssuer :: EpochNo -> Word64 -> Int -> PoolDistr crypto -> Gen (KeyHash 'StakePool crypto)
+chooseIssuer :: EpochNo -> Word64 -> Int -> PoolDistr c -> Gen (KeyHash 'StakePool c)
 chooseIssuer epochnum lastSlot count (PoolDistr m) = mapProportion epochnum lastSlot count (getInt <$> m)
   where
     getInt x = floor (individualPoolStake x * 1000)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -747,7 +747,7 @@ genRecipientsFrom txOuts = do
                 else coreTxOut reify fields : rs
   goNew extra txOuts []
 
-getDCertCredential :: DCert crypto -> Maybe (Credential 'Staking crypto)
+getDCertCredential :: DCert c -> Maybe (Credential 'Staking c)
 getDCertCredential = \case
   DCertDeleg d ->
     case d of

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators.hs
@@ -1015,9 +1015,9 @@ tellDCertScriptWits proxy mdc = do
 
 -- TODO: this is a bit overconstrained, we probably want a more constraints
 -- based approach using ValueFromList
-type family ElaborateValueType (valF :: TyValueExpected) crypto :: Type where
+type family ElaborateValueType (valF :: TyValueExpected) c :: Type where
   ElaborateValueType 'ExpectAdaOnly _ = Coin
-  ElaborateValueType 'ExpectAnyOutput crypto = MaryValue crypto
+  ElaborateValueType 'ExpectAnyOutput c = MaryValue c
 
 eraFeatureSet ::
   forall era proxy.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Alonzo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Alonzo.hs
@@ -69,13 +69,13 @@ import Test.Cardano.Ledger.Model.Rules (ModelPredicateFailure (..))
 import Test.Cardano.Ledger.Model.Value (evalModelValue)
 
 instance
-  ( PraosCrypto crypto,
-    KES.Signable (KES crypto) ~ SignableRepresentation,
-    DSIGN.Signable (DSIGN crypto) ~ SignableRepresentation
+  ( PraosCrypto c,
+    KES.Signable (KES c) ~ SignableRepresentation,
+    DSIGN.Signable (DSIGN c) ~ SignableRepresentation
   ) =>
-  ElaborateEraModel (AlonzoEra crypto)
+  ElaborateEraModel (AlonzoEra c)
   where
-  type EraFeatureSet (AlonzoEra crypto) = 'FeatureSet 'ExpectAnyOutput ('TyScriptFeature 'True 'True)
+  type EraFeatureSet (AlonzoEra c) = 'FeatureSet 'ExpectAnyOutput ('TyScriptFeature 'True 'True)
 
   toEraPredicateFailure = \case
     ModelValueNotConservedUTxO (ModelValue x) (ModelValue y) -> State.evalState $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Shelley.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Model/Elaborators/Shelley.hs
@@ -77,13 +77,13 @@ import Test.Cardano.Ledger.Model.Value
   )
 
 instance
-  ( PraosCrypto crypto,
-    KES.Signable (KES crypto) ~ SignableRepresentation,
-    DSIGN.Signable (DSIGN crypto) ~ SignableRepresentation
+  ( PraosCrypto c,
+    KES.Signable (KES c) ~ SignableRepresentation,
+    DSIGN.Signable (DSIGN c) ~ SignableRepresentation
   ) =>
-  ElaborateEraModel (ShelleyEra crypto)
+  ElaborateEraModel (ShelleyEra c)
   where
-  type EraFeatureSet (ShelleyEra crypto) = 'FeatureSet 'ExpectAdaOnly ('TyScriptFeature 'False 'False)
+  type EraFeatureSet (ShelleyEra c) = 'FeatureSet 'ExpectAdaOnly ('TyScriptFeature 'False 'False)
 
   reifyValueConstraint = ExpectedValueTypeC_Simple
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
@@ -17,14 +17,14 @@ import Cardano.Ledger.Mary.Value as Mary
 import Cardano.Ledger.Val as Val
 import Data.Map.Strict as Map
 
-class Val.Val val => ValueFromList val crypto | val -> crypto where
-  valueFromList :: Integer -> [(PolicyID crypto, AssetName, Integer)] -> val
+class Val.Val val => ValueFromList val c | val -> c where
+  valueFromList :: Integer -> [(PolicyID c, AssetName, Integer)] -> val
 
-  insert :: (Integer -> Integer -> Integer) -> PolicyID crypto -> AssetName -> Integer -> val -> val
+  insert :: (Integer -> Integer -> Integer) -> PolicyID c -> AssetName -> Integer -> val -> val
 
-  gettriples :: val -> (Integer, [(PolicyID crypto, AssetName, Integer)])
+  gettriples :: val -> (Integer, [(PolicyID c, AssetName, Integer)])
 
-instance C.Crypto crypto => ValueFromList (MaryValue crypto) crypto where
+instance C.Crypto c => ValueFromList (MaryValue c) c where
   valueFromList c triples = MaryValue c (Mary.multiAssetFromList triples)
 
   insert combine pid an new (MaryValue c ma) = MaryValue c $ Mary.insert combine pid an new ma

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
@@ -27,9 +27,9 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data OCERT crypto
+data OCERT c
 
-data OcertPredicateFailure crypto
+data OcertPredicateFailure c
   = KESBeforeStartOCERT
       !KESPeriod -- OCert Start KES Period
       !KESPeriod -- Current KES Period
@@ -49,37 +49,37 @@ data OcertPredicateFailure crypto
       !Word -- expected KES evolutions
       !String -- error message given by Consensus Layer
   | NoCounterForKeyHashOCERT
-      !(KeyHash 'BlockIssuer crypto) -- stake pool key hash
+      !(KeyHash 'BlockIssuer c) -- stake pool key hash
   deriving (Show, Eq, Generic)
 
-instance NoThunks (OcertPredicateFailure crypto)
+instance NoThunks (OcertPredicateFailure c)
 
 instance
-  ( Crypto crypto,
-    DSignable crypto (OCertSignable crypto),
-    KESignable crypto (BHBody crypto)
+  ( Crypto c,
+    DSignable c (OCertSignable c),
+    KESignable c (BHBody c)
   ) =>
-  STS (OCERT crypto)
+  STS (OCERT c)
   where
   type
-    State (OCERT crypto) =
-      Map (KeyHash 'BlockIssuer crypto) Word64
+    State (OCERT c) =
+      Map (KeyHash 'BlockIssuer c) Word64
   type
-    Signal (OCERT crypto) =
-      BHeader crypto
-  type Environment (OCERT crypto) = OCertEnv crypto
-  type BaseM (OCERT crypto) = ShelleyBase
-  type PredicateFailure (OCERT crypto) = OcertPredicateFailure crypto
+    Signal (OCERT c) =
+      BHeader c
+  type Environment (OCERT c) = OCertEnv c
+  type BaseM (OCERT c) = ShelleyBase
+  type PredicateFailure (OCERT c) = OcertPredicateFailure c
 
   initialRules = [pure Map.empty]
   transitionRules = [ocertTransition]
 
 ocertTransition ::
-  ( Crypto crypto,
-    DSignable crypto (OCertSignable crypto),
-    KESignable crypto (BHBody crypto)
+  ( Crypto c,
+    DSignable c (OCertSignable c),
+    KESignable c (BHBody c)
   ) =>
-  TransitionRule (OCERT crypto)
+  TransitionRule (OCERT c)
 ocertTransition =
   judgmentContext >>= \(TRC (env, cs, BHeader bhb sigma)) -> do
     let OCert vk_hot n c0@(KESPeriod c0_) tau = bheaderOCert bhb

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
@@ -20,7 +20,7 @@ import Control.State.Transition
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data UPDN crypto
+data UPDN c
 
 newtype UpdnEnv
   = -- | New nonce
@@ -30,23 +30,23 @@ newtype UpdnEnv
 data UpdnState = UpdnState Nonce Nonce
   deriving (Show, Eq)
 
-data UpdnPredicateFailure crypto -- No predicate failures
+data UpdnPredicateFailure c -- No predicate failures
   deriving (Generic, Show, Eq)
 
-instance NoThunks (UpdnPredicateFailure crypto)
+instance NoThunks (UpdnPredicateFailure c)
 
-newtype UpdnEvent crypto = NewEpoch EpochNo
+newtype UpdnEvent c = NewEpoch EpochNo
 
 instance
-  (Crypto crypto) =>
-  STS (UPDN crypto)
+  (Crypto c) =>
+  STS (UPDN c)
   where
-  type State (UPDN crypto) = UpdnState
-  type Signal (UPDN crypto) = SlotNo
-  type Environment (UPDN crypto) = UpdnEnv
-  type BaseM (UPDN crypto) = ShelleyBase
-  type PredicateFailure (UPDN crypto) = UpdnPredicateFailure crypto
-  type Event (UPDN crypto) = UpdnEvent crypto
+  type State (UPDN c) = UpdnState
+  type Signal (UPDN c) = SlotNo
+  type Environment (UPDN c) = UpdnEnv
+  type BaseM (UPDN c) = ShelleyBase
+  type PredicateFailure (UPDN c) = UpdnPredicateFailure c
+  type Event (UPDN c) = UpdnEvent c
   initialRules =
     [ pure
         ( UpdnState
@@ -58,7 +58,7 @@ instance
       initialNonce = mkNonceFromNumber 0
   transitionRules = [updTransition]
 
-updTransition :: Crypto crypto => TransitionRule (UPDN crypto)
+updTransition :: Crypto c => TransitionRule (UPDN c)
 updTransition = do
   TRC (UpdnEnv eta, UpdnState eta_v eta_c, s) <- judgmentContext
   ei <- liftSTS $ asks epochInfoPure

--- a/libs/ledger-state/src/Cardano/Ledger/State/Vector.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Vector.hs
@@ -21,19 +21,19 @@ import Cardano.Ledger.State.UTxO
 import Control.DeepSeq
 import Data.Map.Strict as Map
 
-data SnapShotM crypto = SnapShotM
-  { ssStake :: !(Map (Credential 'Staking crypto) (CompactForm Coin)),
-    ssDelegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)),
-    ssPoolParams :: !(Map (KeyHash 'StakePool crypto) (PoolParams crypto))
+data SnapShotM c = SnapShotM
+  { ssStake :: !(Map (Credential 'Staking c) (CompactForm Coin)),
+    ssDelegations :: !(Map (Credential 'Staking c) (KeyHash 'StakePool c)),
+    ssPoolParams :: !(Map (KeyHash 'StakePool c) (PoolParams c))
   }
 
 instance NFData (SnapShotM C) where
   rnf (SnapShotM s d p) = s `deepseq` d `deepseq` rnf p
 
-data SnapShotsM crypto = SnapShotsM
-  { ssPstakeMark :: !(SnapShotM crypto),
-    ssPstakeSet :: !(SnapShotM crypto),
-    ssPstakeGo :: !(SnapShotM crypto),
+data SnapShotsM c = SnapShotsM
+  { ssPstakeMark :: !(SnapShotM c),
+    ssPstakeSet :: !(SnapShotM c),
+    ssPstakeGo :: !(SnapShotM c),
     ssFeeSS :: !Coin
   }
 


### PR DESCRIPTION
This PR renames `crypto` type arguments to `c` for more consistency across the codebase.

closes #2929