### PR TITLE
Polymorphise Alonzo types

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Alonzo.TxInfo
     runPLCScript,
     valContext,
   )
-import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits, unTxDats)
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..), AlonzoTxWits, unTxDats)
 import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..))
 import Cardano.Ledger.Core hiding (TranslationError)
 import Cardano.Ledger.Credential (Credential (ScriptHashObj))
@@ -148,9 +148,9 @@ collectTwoPhaseScriptInputs ::
   forall era.
   ( EraTx era,
     ShelleyEraTxBody era,
+    AlonzoEraTxWits era,
     ExtendedUTxO era,
     Script era ~ AlonzoScript era,
-    TxWits era ~ AlonzoTxWits era,
     HasField "_costmdls" (PParams era) CostModels
   ) =>
   EpochInfo (Either Text) ->

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -15,7 +15,14 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 
 import Cardano.Binary (ToCBOR (..))
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), AuxiliaryDataHash, BinaryData, Data (..), Datum (..), dataToBinaryData)
+import Cardano.Ledger.Alonzo.Data
+  ( AlonzoAuxiliaryData (..),
+    AuxiliaryDataHash,
+    BinaryData,
+    Data (..),
+    Datum (..),
+    dataToBinaryData,
+  )
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.PParams
   ( AlonzoPParams,
@@ -173,7 +180,7 @@ instance
       <*> arbitrary
 
 instance
-  (EraTxOut era, ToCBOR (PParamsUpdate era), Arbitrary (Value era), Mock (EraCrypto era)) =>
+  (EraTxOut era, ToCBOR (PParamsUpdate era), Arbitrary (TxOut era), Mock (EraCrypto era)) =>
   Arbitrary (AlonzoTxBody era)
   where
   arbitrary =
@@ -195,11 +202,8 @@ instance
 deriving newtype instance Arbitrary IsValid
 
 instance
-  ( EraTxBody era,
-    EraScript era,
-    Mock (EraCrypto era),
-    Script era ~ AlonzoScript era,
-    Arbitrary (TxBody era),
+  ( Arbitrary (TxBody era),
+    Arbitrary (TxWits era),
     Arbitrary (AuxiliaryData era)
   ) =>
   Arbitrary (AlonzoTx era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -16,7 +16,7 @@ where
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Tx (isTwoPhaseScriptAddressFromMap)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (txscripts))
-import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..), BabbageTxBody, BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..))
 import Cardano.Ledger.BaseTypes (TxIx (..), txIxFromIntegral)
 import Cardano.Ledger.Block (txid)
 import Cardano.Ledger.Coin (Coin)
@@ -32,16 +32,15 @@ import Lens.Micro
 -- ============================================================
 
 isTwoPhaseScriptAddress ::
-  forall era.
   (ExtendedUTxO era, EraScript era) =>
   Tx era ->
   UTxO era ->
   Addr (EraCrypto era) ->
   Bool
-isTwoPhaseScriptAddress tx utxo = isTwoPhaseScriptAddressFromMap @era (txscripts utxo tx)
+isTwoPhaseScriptAddress tx utxo = isTwoPhaseScriptAddressFromMap (txscripts utxo tx)
 
 collAdaBalance ::
-  (BabbageEraTxBody era, TxOut era ~ BabbageTxOut era) =>
+  BabbageEraTxBody era =>
   TxBody era ->
   Map.Map (TxIn (EraCrypto era)) (TxOut era) ->
   Coin
@@ -53,10 +52,7 @@ collAdaBalance txBody utxoCollateral =
     colbal = coinBalance $ UTxO utxoCollateral
 
 collOuts ::
-  ( BabbageEraTxBody era,
-    TxBody era ~ BabbageTxBody era,
-    TxOut era ~ BabbageTxOut era
-  ) =>
+  BabbageEraTxBody era =>
   TxBody era ->
   UTxO era
 collOuts txBody =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -14,9 +14,9 @@
 module Cardano.Ledger.Babbage.Rules.Ledger (BabbageLEDGER) where
 
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowEvent, ledgerTransition)
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, AlonzoTx (..))
-import Cardano.Ledger.Babbage.Era
-import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUtxowPredFailure)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
+import Cardano.Ledger.Babbage.Era (BabbageLEDGER)
+import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUTXOW, BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
@@ -58,7 +58,6 @@ import GHC.Records (HasField)
 
 instance
   ( AlonzoEraTx era,
-    Tx era ~ AlonzoTx era,
     Show (PParams era),
     Show (TxOut era),
     Show (Tx era),
@@ -69,7 +68,7 @@ instance
     Embed (EraRule "UTXOW" era) (BabbageLEDGER era),
     Environment (EraRule "UTXOW" era) ~ UtxoEnv era,
     State (EraRule "UTXOW" era) ~ UTxOState era,
-    Signal (EraRule "UTXOW" era) ~ AlonzoTx era,
+    Signal (EraRule "UTXOW" era) ~ Tx era,
     Environment (EraRule "DELEGS" era) ~ DelegsEnv era,
     State (EraRule "DELEGS" era) ~ DPState (EraCrypto era),
     Signal (EraRule "DELEGS" era) ~ Seq (DCert (EraCrypto era))
@@ -77,7 +76,7 @@ instance
   STS (BabbageLEDGER era)
   where
   type State (BabbageLEDGER era) = LedgerState era
-  type Signal (BabbageLEDGER era) = AlonzoTx era
+  type Signal (BabbageLEDGER era) = Tx era
   type Environment (BabbageLEDGER era) = LedgerEnv era
   type BaseM (BabbageLEDGER era) = ShelleyBase
   type PredicateFailure (BabbageLEDGER era) = ShelleyLedgerPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -155,7 +155,6 @@ scriptsYes ::
     AlonzoEraTx era,
     Tx era ~ AlonzoTx era,
     Script era ~ AlonzoScript era,
-    TxWits era ~ AlonzoTxWits era,
     STS (BabbageUTXOS era),
     Environment (EraRule "PPUP" era) ~ PpupEnv era,
     State (EraRule "PPUP" era) ~ PPUPState era,
@@ -219,7 +218,6 @@ scriptsNo ::
     Tx era ~ AlonzoTx era,
     TxOut era ~ BabbageTxOut era,
     TxBody era ~ BabbageTxBody era,
-    TxWits era ~ AlonzoTxWits era,
     Script era ~ AlonzoScript era,
     HasField "_protocolVersion" (PParams era) ProtVer,
     HasField "_costmdls" (PParams era) CostModels

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -34,7 +34,7 @@ import Cardano.Ledger.Alonzo.Rules
   )
 import Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoUtxoEvent)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModels)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..), validScript)
 import Cardano.Ledger.Babbage.Era (BabbageUTXOW)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUTXO, BabbageUtxoPredFailure (..))
@@ -265,9 +265,8 @@ validateScriptsWellFormed pp tx =
 -- | A very specialized transitionRule function for the Babbage Era.
 babbageUtxowTransition ::
   forall era.
-  ( EraTx era,
+  ( AlonzoEraTx era,
     ExtendedUTxO era,
-    Tx era ~ AlonzoTx era,
     Script era ~ AlonzoScript era,
     TxOut era ~ BabbageTxOut era,
     STS (BabbageUTXOW era),
@@ -279,7 +278,7 @@ babbageUtxowTransition ::
     Embed (EraRule "UTXO" era) (BabbageUTXOW era),
     Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
-    Signal (EraRule "UTXO" era) ~ AlonzoTx era
+    Signal (EraRule "UTXO" era) ~ Tx era
   ) =>
   TransitionRule (BabbageUTXOW era)
 babbageUtxowTransition = do
@@ -363,7 +362,7 @@ babbageUtxowTransition = do
 instance
   forall era.
   ( ExtendedUTxO era,
-    EraTx era,
+    AlonzoEraTx era,
     BabbageEraTxBody era,
     TxOut era ~ BabbageTxOut era,
     HasField "_costmdls" (PParams era) CostModels,
@@ -371,21 +370,19 @@ instance
     Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody),
     Show (TxBody era),
     Show (TxOut era),
-    -- Fix some Core types to the Babbage Era
-    Tx era ~ AlonzoTx era,
     Script era ~ AlonzoScript era,
     -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (BabbageUTXOW era),
     Environment (EraRule "UTXO" era) ~ UtxoEnv era,
     State (EraRule "UTXO" era) ~ UTxOState era,
-    Signal (EraRule "UTXO" era) ~ AlonzoTx era,
+    Signal (EraRule "UTXO" era) ~ Tx era,
     Eq (PredicateFailure (EraRule "UTXOS" era)),
     Show (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   STS (BabbageUTXOW era)
   where
   type State (BabbageUTXOW era) = UTxOState era
-  type Signal (BabbageUTXOW era) = AlonzoTx era
+  type Signal (BabbageUTXOW era) = Tx era
   type Environment (BabbageUTXOW era) = UtxoEnv era
   type BaseM (BabbageUTXOW era) = ShelleyBase
   type PredicateFailure (BabbageUTXOW era) = BabbageUtxowPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -139,7 +139,7 @@ import Cardano.Ledger.CompactAddress
   )
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core hiding (TxBody, TxOut)
-import qualified Cardano.Ledger.Core as Core (TxBody)
+import qualified Cardano.Ledger.Core as Core (TxBody, TxOut)
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset, policies, policyID)
@@ -380,7 +380,7 @@ sizedCollateralReturnBabbageTxBodyL =
 {-# INLINEABLE sizedCollateralReturnBabbageTxBodyL #-}
 
 allSizedOutputsBabbageTxBodyF ::
-  BabbageEraTxBody era =>
+  (BabbageEraTxBody era, Core.TxOut era ~ BabbageTxOut era) =>
   SimpleGetter (Core.TxBody era) (StrictSeq (Sized (BabbageTxOut era)))
 allSizedOutputsBabbageTxBodyF =
   to $ \txBody ->
@@ -458,17 +458,17 @@ instance CC.Crypto c => AlonzoEraTxBody (BabbageEra c) where
   {-# INLINE networkIdTxBodyL #-}
 
 class (AlonzoEraTxBody era, BabbageEraTxOut era) => BabbageEraTxBody era where
-  sizedOutputsTxBodyL :: Lens' (Core.TxBody era) (StrictSeq (Sized (BabbageTxOut era)))
+  sizedOutputsTxBodyL :: Lens' (Core.TxBody era) (StrictSeq (Sized (Core.TxOut era)))
 
   referenceInputsTxBodyL :: Lens' (Core.TxBody era) (Set (TxIn (EraCrypto era)))
 
   totalCollateralTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe Coin)
 
-  collateralReturnTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe (BabbageTxOut era))
+  collateralReturnTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe (Core.TxOut era))
 
-  sizedCollateralReturnTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe (Sized (BabbageTxOut era)))
+  sizedCollateralReturnTxBodyL :: Lens' (Core.TxBody era) (StrictMaybe (Sized (Core.TxOut era)))
 
-  allSizedOutputsTxBodyF :: SimpleGetter (TxBody era) (StrictSeq (Sized (BabbageTxOut era)))
+  allSizedOutputsTxBodyF :: SimpleGetter (TxBody era) (StrictSeq (Sized (Core.TxOut era)))
 
 instance CC.Crypto c => BabbageEraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance BabbageEraTxBody (BabbageEra CC.StandardCrypto) #-}


### PR DESCRIPTION
This PR makes Alonzo types to use type families from core rather than concrete types. This simplifies the constraints and improves future compatibility.