### PR TITLE
Adresses issue #3001, Renames AuxiliaryData consistently across eras.

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -16,7 +16,7 @@ module Cardano.Ledger.Alonzo
     MaryValue,
     AlonzoTxBody,
     AlonzoScript,
-    AlonzoAuxiliaryData,
+    AlonzoTxAuxData,
     AlonzoPParams,
     AlonzoPParamsUpdate,
     reapplyAlonzoTx,
@@ -33,7 +33,7 @@ module Cardano.Ledger.Alonzo
   )
 where
 
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData)
+import Cardano.Ledger.Alonzo.Data (AlonzoTxAuxData)
 import qualified Cardano.Ledger.Alonzo.Data (AuxiliaryData)
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Genesis

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -168,7 +168,7 @@ instance
 instance
   ( Era era,
     ToCBOR (PredicateFailure (EraRule "UTXO" era)),
-    Typeable (AuxiliaryData era),
+    Typeable (TxAuxData era),
     Typeable (Script era),
     ToCBOR (Script era)
   ) =>
@@ -183,7 +183,7 @@ encodePredFail ::
   ( Era era,
     ToCBOR (PredicateFailure (EraRule "UTXO" era)),
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   AlonzoUtxowPredFailure era ->
   Encode 'Open (AlonzoUtxowPredFailure era)
@@ -200,7 +200,7 @@ instance
   ( Era era,
     FromCBOR (PredicateFailure (EraRule "UTXO" era)),
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   FromCBOR (AlonzoUtxowPredFailure era)
   where
@@ -210,7 +210,7 @@ decodePredFail ::
   ( Era era,
     FromCBOR (PredicateFailure (EraRule "UTXO" era)), -- TODO, we should be able to get rid of this constraint
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   Word ->
   Decode 'Open (AlonzoUtxowPredFailure era)
@@ -500,7 +500,7 @@ extSymmetricDifference as fa bs fb = (extraA, extraB)
 instance
   forall era.
   ( AlonzoEraTx era,
-    EraAuxiliaryData era,
+    EraTxAuxData era,
     ExtendedUTxO era,
     Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody),
     Script era ~ AlonzoScript era,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -164,7 +164,7 @@ data AlonzoTx era = AlonzoTx
   { body :: !(Core.TxBody era),
     wits :: !(Core.TxWits era),
     isValid :: !IsValid,
-    auxiliaryData :: !(StrictMaybe (AuxiliaryData era))
+    auxiliaryData :: !(StrictMaybe (TxAuxData era))
   }
   deriving (Generic)
 
@@ -218,9 +218,9 @@ witsAlonzoTxL :: Lens' (AlonzoTx era) (TxWits era)
 witsAlonzoTxL = lens wits (\tx txWits -> tx {wits = txWits})
 {-# INLINEABLE witsAlonzoTxL #-}
 
--- | `AuxiliaryData` setter and getter for `AlonzoTx`.
-auxDataAlonzoTxL :: Lens' (AlonzoTx era) (StrictMaybe (AuxiliaryData era))
-auxDataAlonzoTxL = lens auxiliaryData (\tx txAuxiliaryData -> tx {auxiliaryData = txAuxiliaryData})
+-- | `TxAuxData` setter and getter for `AlonzoTx`.
+auxDataAlonzoTxL :: Lens' (AlonzoTx era) (StrictMaybe (TxAuxData era))
+auxDataAlonzoTxL = lens auxiliaryData (\tx txTxAuxData -> tx {auxiliaryData = txTxAuxData})
 {-# INLINEABLE auxDataAlonzoTxL #-}
 
 -- | txsize computes the length of the serialised bytes
@@ -233,25 +233,24 @@ isValidAlonzoTxL = lens isValid (\tx valid -> tx {isValid = valid})
 {-# INLINEABLE isValidAlonzoTxL #-}
 
 deriving instance
-  (Era era, Eq (Core.TxBody era), Eq (TxWits era), Eq (AuxiliaryData era)) =>
-  Eq (AlonzoTx era)
+  (Era era, Eq (Core.TxBody era), Eq (TxWits era), Eq (TxAuxData era)) => Eq (AlonzoTx era)
 
 deriving instance
-  (Era era, Show (Core.TxBody era), Show (TxWits era), Show (AuxiliaryData era)) =>
+  (Era era, Show (Core.TxBody era), Show (TxAuxData era), Show (Script era), Show (TxWits era)) =>
   Show (AlonzoTx era)
 
 instance
   ( Era era,
-    NoThunks (AuxiliaryData era),
     NoThunks (TxWits era),
+    NoThunks (TxAuxData era),
     NoThunks (Core.TxBody era)
   ) =>
   NoThunks (AlonzoTx era)
 
 instance
   ( Era era,
-    NFData (AuxiliaryData era),
     NFData (TxWits era),
+    NFData (TxAuxData era),
     NFData (Core.TxBody era)
   ) =>
   NFData (AlonzoTx era)
@@ -320,7 +319,7 @@ isTwoPhaseScriptAddress tx =
 toCBORForSizeComputation ::
   ( ToCBOR (Core.TxBody era),
     ToCBOR (TxWits era),
-    ToCBOR (AuxiliaryData era)
+    ToCBOR (TxAuxData era)
   ) =>
   AlonzoTx era ->
   Encoding
@@ -484,7 +483,7 @@ alonzoSegwitTx ::
   Annotator (Core.TxBody era) ->
   Annotator (TxWits era) ->
   IsValid ->
-  Maybe (Annotator (AuxiliaryData era)) ->
+  Maybe (Annotator (TxAuxData era)) ->
   Annotator (Tx era)
 alonzoSegwitTx txBodyAnn txWitsAnn isValid auxDataAnn = Annotator $ \bytes ->
   let txBody = runAnnotator txBodyAnn bytes
@@ -517,7 +516,7 @@ alonzoSegwitTx txBodyAnn txWitsAnn isValid auxDataAnn = Annotator $ \bytes ->
 toCBORForMempoolSubmission ::
   ( ToCBOR (Core.TxBody era),
     ToCBOR (TxWits era),
-    ToCBOR (AuxiliaryData era)
+    ToCBOR (TxAuxData era)
   ) =>
   AlonzoTx era ->
   Encoding
@@ -533,8 +532,8 @@ toCBORForMempoolSubmission
 instance
   ( Era era,
     ToCBOR (Core.TxBody era),
-    ToCBOR (TxWits era),
-    ToCBOR (AuxiliaryData era)
+    ToCBOR (TxAuxData era),
+    ToCBOR (TxWits era)
   ) =>
   ToCBOR (AlonzoTx era)
   where
@@ -544,7 +543,7 @@ instance
   ( Typeable era,
     FromCBOR (Annotator (Core.TxBody era)),
     FromCBOR (Annotator (Core.TxWits era)),
-    FromCBOR (Annotator (AuxiliaryData era))
+    FromCBOR (Annotator (TxAuxData era))
   ) =>
   FromCBOR (Annotator (AlonzoTx era))
   where

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -14,7 +14,7 @@ module Test.Cardano.Ledger.Alonzo.AlonzoEraGen where
 import Cardano.Binary (ToCBOR (toCBOR), serializeEncoding')
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), Data (..))
+import Cardano.Ledger.Alonzo.Data (AlonzoTxAuxData (..), Data (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams
   ( AlonzoPParams,
@@ -71,7 +71,7 @@ import Cardano.Ledger.Pretty.Alonzo ()
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), coinBalance)
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData (..))
 import Cardano.Ledger.ShelleyMA.Era ()
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), translateTimelock)
 import Cardano.Ledger.TxIn (TxIn)
@@ -223,12 +223,12 @@ genSet gen =
       (1, Set.fromList <$> sequence [gen, gen])
     ]
 
-genAux :: forall c. Mock c => Constants -> Gen (StrictMaybe (AlonzoAuxiliaryData (AlonzoEra c)))
+genAux :: forall c. Mock c => Constants -> Gen (StrictMaybe (AlonzoTxAuxData (AlonzoEra c)))
 genAux constants = do
   maybeAux <- genEraAuxiliaryData @(MaryEra c) constants
   pure $
     fmap
-      (\(MAAuxiliaryData x y) -> AlonzoAuxiliaryData x (TimelockScript . translateTimelock <$> y))
+      (\(AllegraTxAuxData x y) -> AlonzoTxAuxData x (TimelockScript . translateTimelock <$> y))
       maybeAux
 
 instance CC.Crypto c => ScriptClass (AlonzoEra c) where

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -6,7 +6,7 @@ module Test.Cardano.Ledger.Alonzo.Examples.Consensus where
 
 import Cardano.Ledger.Alonzo (Alonzo)
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData (..),
+  ( AlonzoTxAuxData (..),
     AuxiliaryDataHash (..),
     Data (..),
     hashData,
@@ -156,8 +156,8 @@ exampleTx =
         ) -- redeemers
     )
     ( SJust $
-        AlonzoAuxiliaryData
-          SLE.exampleMetadataMap -- metadata
+        AlonzoTxAuxData
+          SLE.exampleAuxDataMap -- auxiliary data
           ( StrictSeq.fromList
               [alwaysFails PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
           )

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -16,7 +16,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 import Cardano.Binary (ToCBOR (..))
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData (..),
+  ( AlonzoTxAuxData (..),
     AuxiliaryDataHash,
     BinaryData,
     Data (..),
@@ -117,9 +117,9 @@ instance
     Arbitrary (Script era),
     Era era
   ) =>
-  Arbitrary (AlonzoAuxiliaryData era)
+  Arbitrary (AlonzoTxAuxData era)
   where
-  arbitrary = AlonzoAuxiliaryData <$> arbitrary <*> arbitrary
+  arbitrary = AlonzoTxAuxData <$> arbitrary <*> arbitrary
 
 instance Arbitrary Tag where
   arbitrary = elements [Spend, Mint, Cert, Rewrd]
@@ -204,7 +204,7 @@ deriving newtype instance Arbitrary IsValid
 instance
   ( Arbitrary (TxBody era),
     Arbitrary (TxWits era),
-    Arbitrary (AuxiliaryData era)
+    Arbitrary (TxAuxData era)
   ) =>
   Arbitrary (AlonzoTx era)
   where

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
@@ -25,7 +25,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
     [ cddlTest @(Value Alonzo) n "coin",
       cddlAnnotatorTest @(TxBody Alonzo) n "transaction_body",
-      cddlAnnotatorTest @(AuxiliaryData Alonzo) n "auxiliary_data",
+      cddlAnnotatorTest @(TxAuxData Alonzo) n "auxiliary_data",
       cddlAnnotatorTest @(MA.Timelock Alonzo) n "native_script",
       cddlAnnotatorTest @(Data Alonzo) n "plutus_data",
       cddlTest @(TxOut Alonzo) n "transaction_output",

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Alonzo.TxBody (txBodyRawEq)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Metadata (Metadata)
+import Cardano.Ledger.Shelley.Metadata (ShelleyTxAuxData)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Codec.CBOR.Write (toLazyByteString)
 import qualified Data.ByteString.Base16.Lazy as Base16
@@ -109,8 +109,8 @@ tests =
       skip $
         testTwiddling @(BinaryData (AlonzoEra C_Crypto))
           "alonzo/BinaryData twiddled",
-      testProperty "alonzo/Metadata" $
-        trippingAnn @(Metadata (AlonzoEra C_Crypto)),
+      testProperty "alonzo/TxAuxData" $
+        trippingAnn @(ShelleyTxAuxData (AlonzoEra C_Crypto)),
       testProperty "alonzo/AlonzoTxWits" $
         trippingAnn @(AlonzoTxWits (AlonzoEra C_Crypto)),
       testProperty "alonzo/TxBody" $
@@ -127,7 +127,7 @@ tests =
       testProperty "alonzo/PParamsUpdate" $
         tripping @(PParamsUpdate (AlonzoEra C_Crypto)),
       testProperty "alonzo/AuxiliaryData" $
-        trippingAnn @(AuxiliaryData (AlonzoEra C_Crypto)),
+        trippingAnn @(TxAuxData (AlonzoEra C_Crypto)),
       testProperty "alonzo/AlonzoUtxowPredFailure" $
         tripping @(AlonzoUtxowPredFailure (AlonzoEra C_Crypto)),
       testProperty "alonzo/AlonzoUtxoPredFailure" $

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Translation.hs
@@ -24,7 +24,7 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (TranslateEra (..))
 import Cardano.Ledger.Mary (Mary)
 import qualified Cardano.Ledger.Shelley.API as API
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData)
 import Cardano.Ledger.ShelleyMA.TxBody (MATxBody)
 import Data.Typeable (Typeable)
 import Test.Cardano.Ledger.AllegraEraGen ()
@@ -54,7 +54,7 @@ alonzoEncodeDecodeTests =
     "encoded mary types can be decoded as alonzo types"
     [ testProperty
         "decoding auxilliary"
-        (decodeTestAnn @(MAAuxiliaryData Mary) ([] :: [Core.AuxiliaryData Alonzo])),
+        (decodeTestAnn @(AllegraTxAuxData Mary) ([] :: [Core.TxAuxData Alonzo])),
       testProperty
         "decoding txbody"
         (decodeTestAnn @(MATxBody Mary) ([] :: [Core.TxBody Alonzo])),

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -14,7 +14,7 @@ module Cardano.Ledger.Babbage
     BabbageTxOut,
     BabbageTxBody,
     AlonzoScript,
-    AlonzoAuxiliaryData,
+    AlonzoTxAuxData,
 
     -- * Deprecated
     Self,
@@ -26,7 +26,7 @@ module Cardano.Ledger.Babbage
 where
 
 import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..), AuxiliaryData)
+import Cardano.Ledger.Alonzo.Data (AlonzoTxAuxData (..), AuxiliaryData)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), Script)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
 import Cardano.Ledger.Babbage.Era (BabbageEra)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -476,7 +476,7 @@ instance
     ToCBOR (PredicateFailure (EraRule "UTXOS" era)),
     ToCBOR (PredicateFailure (EraRule "UTXO" era)),
     ToCBOR (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   ToCBOR (BabbageUtxoPredFailure era)
   where
@@ -494,7 +494,7 @@ instance
     FromCBOR (PredicateFailure (EraRule "UTXOS" era)),
     FromCBOR (PredicateFailure (EraRule "UTXO" era)),
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   FromCBOR (BabbageUtxoPredFailure era)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -135,7 +135,7 @@ instance
     ToCBOR (PredicateFailure (EraRule "UTXOS" era)),
     ToCBOR (PredicateFailure (EraRule "UTXO" era)),
     ToCBOR (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   ToCBOR (BabbageUtxowPredFailure era)
   where
@@ -154,7 +154,7 @@ instance
     FromCBOR (PredicateFailure (EraRule "UTXOS" era)),
     FromCBOR (PredicateFailure (EraRule "UTXO" era)),
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   FromCBOR (BabbageUtxowPredFailure era)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -18,9 +18,9 @@ module Cardano.Ledger.Babbage.Scripts
 where
 
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData,
-    hashAlonzoAuxiliaryData,
-    validateAlonzoAuxiliaryData,
+  ( AlonzoTxAuxData,
+    hashAlonzoTxAuxData,
+    validateAlonzoTxAuxData,
   )
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
@@ -57,7 +57,7 @@ isPlutusScript x =
     Just _ -> True
     Nothing -> False
 
-instance CC.Crypto c => EraAuxiliaryData (BabbageEra c) where
-  type AuxiliaryData (BabbageEra c) = AlonzoAuxiliaryData (BabbageEra c)
-  hashAuxiliaryData = hashAlonzoAuxiliaryData
-  validateAuxiliaryData = validateAlonzoAuxiliaryData
+instance CC.Crypto c => EraTxAuxData (BabbageEra c) where
+  type TxAuxData (BabbageEra c) = AlonzoTxAuxData (BabbageEra c)
+  hashTxAuxData = hashAlonzoTxAuxData
+  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -5,7 +5,7 @@
 module Test.Cardano.Ledger.Babbage.Examples.Consensus where
 
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData (..),
+  ( AlonzoTxAuxData (..),
     AuxiliaryDataHash (..),
     Data (..),
     dataToBinaryData,
@@ -170,8 +170,8 @@ exampleTx =
         ) -- redeemers
     )
     ( SJust $
-        AlonzoAuxiliaryData
-          SLE.exampleMetadataMap -- metadata
+        AlonzoTxAuxData
+          SLE.exampleAuxDataMap -- metadata
           ( StrictSeq.fromList
               [alwaysFails PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
           )

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/CDDL.hs
@@ -26,7 +26,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
     [ cddlTest @(Value Babbage) n "coin",
       cddlAnnotatorTest @(TxBody Babbage) n "transaction_body",
-      cddlAnnotatorTest @(AuxiliaryData Babbage) n "auxiliary_data",
+      cddlAnnotatorTest @(TxAuxData Babbage) n "auxiliary_data",
       cddlAnnotatorTest @(MA.Timelock Babbage) n "native_script",
       cddlAnnotatorTest @(Data Babbage) n "plutus_data",
       cddlTest @(TxOut Babbage) n "transaction_output",

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Metadata (Metadata)
+import Cardano.Ledger.Shelley.Metadata (ShelleyTxAuxData)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Term (decodeTerm)
@@ -85,7 +85,7 @@ tests =
     [ testProperty "babbage/Script" $
         trippingAnn @(Script (BabbageEra C_Crypto)),
       testProperty "babbage/Metadata" $
-        trippingAnn @(Metadata (BabbageEra C_Crypto)),
+        trippingAnn @(ShelleyTxAuxData (BabbageEra C_Crypto)),
       testProperty "babbage/TxOut" $
         tripping @(TxOut (BabbageEra C_Crypto)),
       testProperty "babbage/TxBody" $
@@ -97,7 +97,7 @@ tests =
       testProperty "babbage/PParamsUpdate" $
         tripping @(PParamsUpdate (BabbageEra C_Crypto)),
       testProperty "babbage/AuxiliaryData" $
-        trippingAnn @(AuxiliaryData (BabbageEra C_Crypto)),
+        trippingAnn @(TxAuxData (BabbageEra C_Crypto)),
       testProperty "Script" $
         trippingAnn @(Script (BabbageEra C_Crypto)),
       testProperty "babbage/Tx" $

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -13,9 +13,9 @@ module Cardano.Ledger.Conway.Scripts
 where
 
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData,
-    hashAlonzoAuxiliaryData,
-    validateAlonzoAuxiliaryData,
+  ( AlonzoTxAuxData,
+    hashAlonzoTxAuxData,
+    validateAlonzoTxAuxData,
   )
 import Cardano.Ledger.Alonzo.Language (Language)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript)
@@ -37,7 +37,7 @@ instance CC.Crypto c => EraScript (ConwayEra c) where
   phaseScript PhaseTwoRep (PlutusScript lang bytes) = Just (Phase2Script lang bytes)
   phaseScript _ _ = Nothing
 
-instance CC.Crypto c => EraAuxiliaryData (ConwayEra c) where
-  type AuxiliaryData (ConwayEra c) = AlonzoAuxiliaryData (ConwayEra c)
-  hashAuxiliaryData = hashAlonzoAuxiliaryData
-  validateAuxiliaryData = validateAlonzoAuxiliaryData
+instance CC.Crypto c => EraTxAuxData (ConwayEra c) where
+  type TxAuxData (ConwayEra c) = AlonzoTxAuxData (ConwayEra c)
+  hashTxAuxData = hashAlonzoTxAuxData
+  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -11,7 +11,7 @@
 module Test.Cardano.Ledger.Conway.Examples.Consensus where
 
 import Cardano.Ledger.Alonzo.Data
-  ( AlonzoAuxiliaryData (..),
+  ( AlonzoTxAuxData (..),
     AuxiliaryDataHash (..),
     Data (..),
     dataToBinaryData,
@@ -185,8 +185,8 @@ exampleTx =
         ) -- redeemers
     )
     ( SJust $
-        AlonzoAuxiliaryData
-          SLE.exampleMetadataMap -- metadata
+        AlonzoTxAuxData
+          SLE.exampleAuxDataMap -- metadata
           ( StrictSeq.fromList
               [alwaysFails PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
           )

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary.hs
@@ -14,7 +14,7 @@ module Cardano.Ledger.Mary
     MATxBody,
     ShelleyPParams,
     ShelleyPParamsUpdate,
-    MAAuxiliaryData,
+    AllegraTxAuxData,
 
     -- * Deprecated
     Cardano.Ledger.Shelley.API.Tx,

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Shelley.API hiding (Metadata, TxBody)
 import Cardano.Ledger.Shelley.TxWits (decodeWits)
 import Cardano.Ledger.ShelleyMA.AuxiliaryData
-  ( MAAuxiliaryData (..),
+  ( AllegraTxAuxData (..),
   )
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock, translateTimelock)
 import qualified Cardano.Ledger.Val as Val
@@ -168,9 +168,9 @@ instance Crypto c => TranslateEra (MaryEra c) Update where
 instance Crypto c => TranslateEra (MaryEra c) Timelock where
   translateEra _ = pure . translateTimelock
 
-instance Crypto c => TranslateEra (MaryEra c) MAAuxiliaryData where
-  translateEra ctx (MAAuxiliaryData md as) =
-    pure $ MAAuxiliaryData md $ translateEra' ctx <$> as
+instance Crypto c => TranslateEra (MaryEra c) AllegraTxAuxData where
+  translateEra ctx (AllegraTxAuxData md as) =
+    pure $ AllegraTxAuxData md $ translateEra' ctx <$> as
 
 translateValue :: Crypto c => Coin -> MaryValue c
 translateValue = Val.inject

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA.hs
@@ -13,7 +13,7 @@ module Cardano.Ledger.ShelleyMA
     ShelleyTx,
     ShelleyTxOut,
     MATxBody,
-    MAAuxiliaryData,
+    AllegraTxAuxData,
     ShelleyPParams,
 
     -- * Deprecated
@@ -38,7 +38,7 @@ import Cardano.Ledger.Shelley.Tx
     Tx,
     TxOut,
   )
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (AuxiliaryData, MAAuxiliaryData)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData, AuxiliaryData)
 import Cardano.Ledger.ShelleyMA.Era (MAClass, MaryOrAllegra (..), ShelleyMAEra)
 import Cardano.Ledger.ShelleyMA.Tx ()
 import Cardano.Ledger.ShelleyMA.TxBody (MATxBody, TxBody)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -69,10 +69,10 @@ exampleTxBodyMA value =
     auxiliaryDataHash =
       AuxiliaryDataHash $ mkDummySafeHash (Proxy @(EraCrypto era)) 30
 
-exampleAuxiliaryDataMA :: (MAClass ma c) => MAAuxiliaryData (ShelleyMAEra ma c)
+exampleAuxiliaryDataMA :: (MAClass ma c) => AllegraTxAuxData (ShelleyMAEra ma c)
 exampleAuxiliaryDataMA =
-  MAAuxiliaryData
-    exampleMetadataMap
+  AllegraTxAuxData
+    exampleAuxDataMap
     (StrictSeq.fromList [exampleScriptMA])
 
 exampleScriptMA :: (MAClass ma c) => Script (ShelleyMAEra ma c)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -146,9 +146,9 @@ unQuantifyTL (MOf n xs) = RequireMOf n (fromList xs)
 unQuantifyTL (Leaf t) = t
 
 genAuxiliaryData ::
-  Arbitrary (Core.AuxiliaryData era) =>
+  Arbitrary (Core.TxAuxData era) =>
   Constants ->
-  Gen (StrictMaybe (Core.AuxiliaryData era))
+  Gen (StrictMaybe (Core.TxAuxData era))
 genAuxiliaryData Constants {frequencyTxWithMetadata} =
   frequency
     [ (frequencyTxWithMetadata, SJust <$> arbitrary),

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/EraBuffet.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/EraBuffet.hs
@@ -7,13 +7,13 @@ module Test.Cardano.Ledger.EraBuffet
     Value,
     Script,
     TxBody,
-    AuxiliaryData,
+    TxAuxData,
     Era (..),
   )
 where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Core (AuxiliaryData, Script, TxBody, Value)
+import Cardano.Ledger.Core (Script, TxAuxData, TxBody, Value)
 import Cardano.Ledger.Era (Era, EraCrypto)
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley (ShelleyEra)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -100,7 +100,7 @@ instance (CC.Crypto c, Mock c) => EraGen (MaryEra c) where
 genAuxiliaryData ::
   Mock c =>
   Constants ->
-  Gen (StrictMaybe (AuxiliaryData (MaryEra c)))
+  Gen (StrictMaybe (TxAuxData (MaryEra c)))
 genAuxiliaryData Constants {frequencyTxWithMetadata} =
   frequency
     [ (frequencyTxWithMetadata, SJust <$> arbitrary),

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -27,8 +27,8 @@ import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
 import qualified Cardano.Ledger.Mary.Value as ConcreteValue
-import Cardano.Ledger.Shelley.API (KeyHash (KeyHash), Metadata (Metadata))
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
+import Cardano.Ledger.Shelley.API (KeyHash (KeyHash), ShelleyTxAuxData (ShelleyTxAuxData))
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData (..))
 import Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
 import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA (Timelock (..))
@@ -110,7 +110,7 @@ instance
     ToCBOR (Script era),
     Arbitrary (Script era)
   ) =>
-  Arbitrary (MAAuxiliaryData era)
+  Arbitrary (AllegraTxAuxData era)
   where
   -- Why do we use the \case instead of a do statement? like this:
   --
@@ -125,7 +125,7 @@ instance
   -- in an unsatisfied `MonadFail` constraint.
   arbitrary =
     genMetadata' >>= \case
-      Metadata m -> MAAuxiliaryData m <$> (genScriptSeq @era)
+      ShelleyTxAuxData m -> AllegraTxAuxData m <$> (genScriptSeq @era)
 
 genScriptSeq ::
   forall era. Arbitrary (Script era) => Gen (StrictSeq (Script era))

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -70,7 +70,7 @@ allprops ::
   forall e.
   ( ApplyTx e,
     Arbitrary (Core.TxBody e),
-    Arbitrary (Core.AuxiliaryData e),
+    Arbitrary (Core.TxAuxData e),
     Arbitrary (Core.Value e),
     Arbitrary (Core.Script e),
     Arbitrary (ApplyTxError e),
@@ -84,7 +84,7 @@ allprops =
   testGroup
     (show $ typeRep (Proxy @e))
     [ testProperty "TxBody" $ propertyAnn @(Core.TxBody e),
-      testProperty "Metadata" $ propertyAnn @(Core.AuxiliaryData e),
+      testProperty "Metadata" $ propertyAnn @(Core.TxAuxData e),
       testProperty "Value" $ property @(Core.Value e),
       testProperty "Script" $ propertyAnn @(Core.Script e),
       testProperty "ApplyTxError" $ property @(ApplyTxError e)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/Translation.hs
@@ -34,7 +34,7 @@ allegraEncodeDecodeTests =
     "encoded shelley types can be decoded as allegra types"
     [ testProperty
         "decoding auxiliary data"
-        (decodeTestAnn @(S.Metadata Allegra) ([] :: [MAAuxiliaryData Allegra]))
+        (decodeTestAnn @(S.ShelleyTxAuxData Allegra) ([] :: [AllegraTxAuxData Allegra]))
     ]
 
 allegraTranslationTests :: TestTree

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Translation.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Era (TranslateEra (..))
 import Cardano.Ledger.Mary (Mary)
 import Cardano.Ledger.Mary.Translation ()
 import qualified Cardano.Ledger.Shelley.API as S
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData)
 import Test.Cardano.Ledger.AllegraEraGen ()
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
@@ -33,7 +33,7 @@ maryEncodeDecodeTests =
     "encoded allegra types can be decoded as mary types"
     [ testProperty
         "decoding metadata"
-        (decodeTestAnn @(S.Metadata Allegra) ([] :: [MAAuxiliaryData Mary]))
+        (decodeTestAnn @(S.ShelleyTxAuxData Allegra) ([] :: [AllegraTxAuxData Mary]))
     ]
 
 maryTranslationTests :: TestTree

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/CDDL.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/CDDL.hs
@@ -26,8 +26,8 @@ cddlTests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlAnnotatorTest @(Core.TxBody Allegra) n "transaction_body_allegra",
       cddlAnnotatorTest @(Core.Script Mary) n "native_script",
       cddlAnnotatorTest @(Core.Script Allegra) n "native_script",
-      cddlAnnotatorTest @(Core.AuxiliaryData Mary) n "auxiliary_data",
-      cddlAnnotatorTest @(Core.AuxiliaryData Allegra) n "auxiliary_data"
+      cddlAnnotatorTest @(Core.TxAuxData Mary) n "auxiliary_data",
+      cddlAnnotatorTest @(Core.TxAuxData Allegra) n "auxiliary_data"
     ]
       <*> pure cddl
 

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -13,7 +13,7 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Golden.Encoding (goldenEncodi
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (EraCrypto (..), EraScript (hashScript), PParamsUpdate, hashAuxiliaryData)
+import Cardano.Ledger.Core (EraCrypto (..), EraScript (hashScript), PParamsUpdate, hashTxAuxData)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), hashKey)
@@ -33,7 +33,7 @@ import Cardano.Ledger.Shelley.TxBody
     ShelleyTxOut (..),
     Wdrl (..),
   )
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (pattern MAAuxiliaryData)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (pattern AllegraTxAuxData)
 import Cardano.Ledger.ShelleyMA.Timelocks
   ( Timelock (..),
     ValidityInterval (..),
@@ -189,7 +189,7 @@ metadataNoScriptsGoldenTest :: forall era. (Era era, Core.Script era ~ Timelock 
 metadataNoScriptsGoldenTest =
   checkEncodingCBORAnnotated
     "metadata_no_scripts"
-    (MAAuxiliaryData @era (Map.singleton 17 (SMD.I 42)) StrictSeq.empty)
+    (AllegraTxAuxData @era (Map.singleton 17 (SMD.I 42)) StrictSeq.empty)
     ( T
         ( TkListLen 2 -- structured metadata and auxiliary scripts
             . TkMapLen 1 -- metadata wrapper
@@ -204,7 +204,7 @@ metadataWithScriptsGoldenTest :: forall era. (Era era, Core.Script era ~ Timeloc
 metadataWithScriptsGoldenTest =
   checkEncodingCBORAnnotated
     "metadata_with_scripts"
-    ( MAAuxiliaryData @era
+    ( AllegraTxAuxData @era
         (Map.singleton 17 (SMD.I 42))
         (StrictSeq.singleton policy1)
     )
@@ -262,7 +262,7 @@ goldenEncodingTestsAllegra =
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
-          mdh = hashAuxiliaryData @A $ MAAuxiliaryData Map.empty StrictSeq.empty
+          mdh = hashTxAuxData @A $ AllegraTxAuxData Map.empty StrictSeq.empty
        in checkEncodingCBORAnnotated
             "full_txn_body"
             ( MATxBody
@@ -396,7 +396,7 @@ goldenEncodingTestsMary =
           reg = DCertDeleg (RegKey testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
-          mdh = hashAuxiliaryData @A $ MAAuxiliaryData Map.empty StrictSeq.empty
+          mdh = hashTxAuxData @A $ AllegraTxAuxData Map.empty StrictSeq.empty
           mint = Map.singleton policyID1 $ Map.singleton (AssetName assetName1) 13
        in checkEncodingCBORAnnotated
             "full_txn_body"

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
@@ -6,7 +6,7 @@ module Cardano.Ledger.Shelley
     ShelleyTxBody,
     Value,
     Script,
-    AuxiliaryData,
+    TxAuxData,
     ShelleyPParams,
     TxWits,
     nativeMultiSigTag,
@@ -19,7 +19,7 @@ module Cardano.Ledger.Shelley
 where
 
 import Cardano.Ledger.Core
-  ( EraAuxiliaryData (AuxiliaryData),
+  ( EraTxAuxData (TxAuxData),
     EraTxWits (TxWits),
     Script,
     Value,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -94,8 +94,9 @@ import Cardano.Ledger.Shelley.LedgerState as X
     UTxOState (..),
   )
 import Cardano.Ledger.Shelley.Metadata as X
-  ( Metadata (..),
+  ( Metadata,
     Metadatum (..),
+    ShelleyTxAuxData (..),
   )
 import Cardano.Ledger.Shelley.PParams as X
   ( PParams,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
@@ -159,7 +159,7 @@ pattern ShelleyTxSeq xs <-
               txSeqBodyBytes = serializeFoldable $ coreBodyBytes @era <$> txns,
               -- bytes encoding Seq(TxWits era)
               txSeqWitsBytes = serializeFoldable $ coreWitnessBytes @era <$> txns,
-              -- bytes encoding a (Map Int (AuxiliaryData))
+              -- bytes encoding a (Map Int (TxAuxData))
               txSeqMetadataBytes =
                 serializeEncoding . encodeFoldableMapEncoder metaChunk $
                   coreAuxDataBytes @era <$> txns
@@ -210,8 +210,8 @@ bbHash (TxSeq' _ bodies wits md) =
 constructMetadata ::
   forall era.
   Int ->
-  Map Int (Annotator (AuxiliaryData era)) ->
-  Seq (Maybe (Annotator (AuxiliaryData era)))
+  Map Int (Annotator (TxAuxData era)) ->
+  Seq (Maybe (Annotator (TxAuxData era)))
 constructMetadata n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n - 1])
 
 -- | The parts of the Tx in Blocks that have to have FromCBOR(Annotator x) instances.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -189,7 +189,7 @@ deriving stock instance
 instance
   ( Era era,
     Typeable (Script era),
-    Typeable (AuxiliaryData era),
+    Typeable (TxAuxData era),
     ToCBOR (PredicateFailure (EraRule "UTXO" era))
   ) =>
   ToCBOR (ShelleyUtxowPredFailure era)
@@ -227,7 +227,7 @@ instance
   ( Era era,
     FromCBOR (PredicateFailure (EraRule "UTXO" era)),
     Typeable (Script era),
-    Typeable (AuxiliaryData era)
+    Typeable (TxAuxData era)
   ) =>
   FromCBOR (ShelleyUtxowPredFailure era)
   where
@@ -558,14 +558,14 @@ validateMetadata pp tx =
         (SNothing, SNothing) -> pure ()
         (SJust mdh, SNothing) -> failure $ MissingTxMetadata mdh
         (SNothing, SJust md') ->
-          failure $ MissingTxBodyMetadataHash (hashAuxiliaryData @era md')
+          failure $ MissingTxBodyMetadataHash (hashTxAuxData @era md')
         (SJust mdh, SJust md') ->
           sequenceA_
-            [ failureUnless (hashAuxiliaryData @era md' == mdh) $
-                ConflictingMetadataHash mdh (hashAuxiliaryData @era md'),
+            [ failureUnless (hashTxAuxData @era md' == mdh) $
+                ConflictingMetadataHash mdh (hashTxAuxData @era md'),
               -- check metadata value sizes
               when (SoftForks.validMetadata pp) $
-                failureUnless (validateAuxiliaryData @era pv md') InvalidMetadata
+                failureUnless (validateTxAuxData @era pv md') InvalidMetadata
             ]
 
 -- | check genesis keys signatures for instantaneous rewards certificates

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -103,14 +103,14 @@ import Numeric.Natural (Natural)
 data TxRaw era = TxRaw
   { _body :: !(Core.TxBody era),
     _wits :: !(TxWits era),
-    _auxiliaryData :: !(StrictMaybe (AuxiliaryData era))
+    _auxiliaryData :: !(StrictMaybe (TxAuxData era))
   }
   deriving (Generic, Typeable)
 
 instance
   ( NFData (Core.TxBody era),
     NFData (TxWits era),
-    NFData (AuxiliaryData era)
+    NFData (TxAuxData era)
   ) =>
   NFData (TxRaw era)
 
@@ -118,7 +118,7 @@ deriving instance
   ( Era era,
     Eq (Core.TxBody era),
     Eq (TxWits era),
-    Eq (AuxiliaryData era)
+    Eq (TxAuxData era)
   ) =>
   Eq (TxRaw era)
 
@@ -126,13 +126,13 @@ deriving instance
   ( Era era,
     Show (Core.TxBody era),
     Show (TxWits era),
-    Show (AuxiliaryData era)
+    Show (TxAuxData era)
   ) =>
   Show (TxRaw era)
 
 instance
   ( Era era,
-    NoThunks (AuxiliaryData era),
+    NoThunks (TxAuxData era),
     NoThunks (Core.TxBody era),
     NoThunks (TxWits era)
   ) =>
@@ -163,9 +163,9 @@ witsShelleyTxL =
     (\(TxConstr (Memo tx _)) txWits -> TxConstr $ memoBytes $ encodeTxRaw $ tx {_wits = txWits})
 {-# INLINEABLE witsShelleyTxL #-}
 
--- | `AuxiliaryData` setter and getter for `ShelleyTx`. The setter does update
+-- | `TxAuxData` setter and getter for `ShelleyTx`. The setter does update
 -- memoized binary representation.
-auxDataShelleyTxL :: EraTx era => Lens' (ShelleyTx era) (StrictMaybe (AuxiliaryData era))
+auxDataShelleyTxL :: EraTx era => Lens' (ShelleyTx era) (StrictMaybe (TxAuxData era))
 auxDataShelleyTxL =
   lens
     (\(TxConstr (Memo tx _)) -> _auxiliaryData tx)
@@ -217,19 +217,19 @@ instance CC.Crypto c => EraTx (ShelleyEra c) where
 deriving newtype instance
   ( NFData (Core.TxBody era),
     NFData (TxWits era),
-    NFData (AuxiliaryData era)
+    NFData (TxAuxData era)
   ) =>
   NFData (ShelleyTx era)
 
 deriving newtype instance Eq (ShelleyTx era)
 
 deriving newtype instance
-  (Era era, Show (Core.TxBody era), Show (TxWits era), Show (AuxiliaryData era)) =>
+  (Era era, Show (Core.TxBody era), Show (TxWits era), Show (TxAuxData era)) =>
   Show (ShelleyTx era)
 
 deriving newtype instance
   ( Era era,
-    NoThunks (AuxiliaryData era),
+    NoThunks (TxAuxData era),
     NoThunks (Core.TxBody era),
     NoThunks (TxWits era)
   ) =>
@@ -239,7 +239,7 @@ pattern ShelleyTx ::
   EraTx era =>
   Core.TxBody era ->
   TxWits era ->
-  StrictMaybe (AuxiliaryData era) ->
+  StrictMaybe (TxAuxData era) ->
   ShelleyTx era
 pattern ShelleyTx {body, wits, auxiliaryData} <-
   TxConstr
@@ -271,7 +271,7 @@ instance
   ( Era era,
     FromCBOR (Annotator (Core.TxBody era)),
     FromCBOR (Annotator (TxWits era)),
-    FromCBOR (Annotator (AuxiliaryData era))
+    FromCBOR (Annotator (TxAuxData era))
   ) =>
   FromCBOR (Annotator (TxRaw era))
   where
@@ -299,7 +299,7 @@ unsafeConstructTxWithBytes ::
   Era era =>
   Core.TxBody era ->
   TxWits era ->
-  StrictMaybe (AuxiliaryData era) ->
+  StrictMaybe (TxAuxData era) ->
   LBS.ByteString ->
   Tx era
 unsafeConstructTxWithBytes b w a bytes = TxConstr (mkMemoBytes (TxRaw b w a) bytes)
@@ -312,7 +312,7 @@ segwitTx ::
   EraTx era =>
   Annotator (Core.TxBody era) ->
   Annotator (TxWits era) ->
-  Maybe (Annotator (AuxiliaryData era)) ->
+  Maybe (Annotator (TxAuxData era)) ->
   Annotator (Tx era)
 segwitTx
   bodyAnn

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -110,7 +110,7 @@ defaultShelleyLedgerExamples ::
   (ShelleyTx era -> Core.Tx era) ->
   Core.Value era ->
   Core.TxBody era ->
-  Core.AuxiliaryData era ->
+  Core.TxAuxData era ->
   TranslationContext era ->
   ShelleyLedgerExamples era
 defaultShelleyLedgerExamples mkWitnesses mkAlonzoTx value txBody auxData translationContext =
@@ -209,7 +209,7 @@ exampleTx ::
   Core.EraTx era =>
   (Core.TxBody era -> KeyPairWits era -> Core.TxWits era) ->
   Core.TxBody era ->
-  Core.AuxiliaryData era ->
+  Core.TxAuxData era ->
   ShelleyTx era
 exampleTx mkWitnesses txBody auxData =
   ShelleyTx txBody (mkWitnesses txBody keyPairWits) (SJust auxData)
@@ -442,8 +442,8 @@ exampleTxBodyShelley =
     auxiliaryDataHash =
       AuxiliaryDataHash $ mkDummySafeHash (Proxy @StandardCrypto) 30
 
-exampleMetadataMap :: Map Word64 Metadatum
-exampleMetadataMap =
+exampleAuxDataMap :: Map Word64 Metadatum
+exampleAuxDataMap =
   Map.fromList
     [ (1, S "string"),
       (2, B "bytes"),
@@ -451,8 +451,8 @@ exampleMetadataMap =
       (4, Map [(I 3, B "b")])
     ]
 
-exampleAuxiliaryDataShelley :: Core.AuxiliaryData Shelley
-exampleAuxiliaryDataShelley = Metadata exampleMetadataMap
+exampleAuxiliaryDataShelley :: Core.TxAuxData Shelley
+exampleAuxiliaryDataShelley = ShelleyTxAuxData exampleAuxDataMap
 
 exampleTxIns :: CC.Crypto c => Set (TxIn c)
 exampleTxIns =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -178,7 +178,7 @@ import qualified Test.QuickCheck as QC
 -- | For use in the Serialisation and Example Tests, which assume Shelley, Allegra, or Mary Eras.
 type PreAlonzo era =
   ( TxWits era ~ ShelleyTxWits era,
-    ToCBOR (AuxiliaryData era)
+    ToCBOR (TxAuxData era)
   )
 
 -- =========================================

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -215,7 +215,7 @@ class
     Gen (TxBody era, [Script era])
 
   -- | Generate era-specific auxiliary data
-  genEraAuxiliaryData :: Constants -> Gen (StrictMaybe (AuxiliaryData era))
+  genEraAuxiliaryData :: Constants -> Gen (StrictMaybe (TxAuxData era))
 
   -- | Update an era-specific TxBody
   updateEraTxBody ::
@@ -257,7 +257,7 @@ class
   constructTx ::
     TxBody era ->
     TxWits era ->
-    StrictMaybe (AuxiliaryData era) ->
+    StrictMaybe (TxAuxData era) ->
     Tx era
   constructTx txBody txWits txAuxData =
     mkBasicTx txBody & witsTxL .~ txWits & auxDataTxL .~ txAuxData

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Metadata.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Metadata.hs
@@ -10,8 +10,8 @@ import Cardano.Ledger.BaseTypes
   ( StrictMaybe (..),
   )
 import Cardano.Ledger.Shelley.Metadata
-  ( Metadata (..),
-    Metadatum (..),
+  ( Metadatum (..),
+    ShelleyTxAuxData (..),
   )
 import Control.Exception (assert)
 import qualified Data.ByteString.Char8 as BS (length, pack)
@@ -31,8 +31,8 @@ collectionDatumMaxSize = 5
 metadataMaxSize :: Int
 metadataMaxSize = 3
 
--- | Generate Metadata (and compute hash) with frequency 'frequencyTxWithMetadata'
-genMetadata :: Constants -> Gen (StrictMaybe (Metadata era))
+-- | Generate ShelleyTxAuxData (and compute hash) with frequency 'frequencyTxWithMetadata'
+genMetadata :: Constants -> Gen (StrictMaybe (ShelleyTxAuxData era))
 genMetadata (Constants {frequencyTxWithMetadata}) =
   QC.frequency
     [ (frequencyTxWithMetadata, SJust <$> genMetadata'),
@@ -40,10 +40,10 @@ genMetadata (Constants {frequencyTxWithMetadata}) =
     ]
 
 -- | Generate Metadata (and compute hash) of size up to 'metadataMaxSize'
-genMetadata' :: Gen (Metadata era)
+genMetadata' :: Gen (ShelleyTxAuxData era)
 genMetadata' = do
   n <- QC.choose (1, metadataMaxSize)
-  Metadata . Map.fromList
+  ShelleyTxAuxData . Map.fromList
     <$> QC.vectorOf n genMetadatum
 
 -- | Generate one of the Metadatum

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -247,7 +247,7 @@ genTx
           (Wdrl (Map.fromList wdrls))
           draftFee
           (maybeToStrictMaybe update)
-          (hashAuxiliaryData @era <$> metadata)
+          (hashTxAuxData @era <$> metadata)
       let draftTx =
             constructTx @era
               draftTxBody

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -261,8 +261,8 @@ sizedMetadatum n =
 instance Arbitrary MD.Metadatum where
   arbitrary = sizedMetadatum maxMetadatumDepth
 
-instance Arbitrary (MD.Metadata era) where
-  arbitrary = MD.Metadata <$> arbitrary
+instance Arbitrary (MD.ShelleyTxAuxData era) where
+  arbitrary = MD.ShelleyTxAuxData <$> arbitrary
 
 maxTxWits :: Int
 maxTxWits = 5
@@ -812,7 +812,7 @@ instance
 genTx ::
   ( Core.EraTx era,
     Arbitrary (Core.TxBody era),
-    Arbitrary (Core.AuxiliaryData era),
+    Arbitrary (Core.TxAuxData era),
     Arbitrary (Core.TxWits era)
   ) =>
   Gen (ShelleyTx era)
@@ -876,7 +876,7 @@ instance
     ToCBOR (Core.TxWits era),
     Arbitrary (Core.TxBody era),
     Arbitrary (Core.Value era),
-    Arbitrary (Core.AuxiliaryData era),
+    Arbitrary (Core.TxAuxData era),
     Arbitrary (Core.Script era),
     Arbitrary (Core.TxWits era)
   ) =>

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -389,8 +389,8 @@ txRetirePoolBytes16 = "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e7878
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-md :: MD.Metadata era
-md = MD.Metadata $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
+md :: MD.ShelleyTxAuxData era
+md = MD.ShelleyTxAuxData $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 
 txbWithMD :: ShelleyTxBody Shelley
 txbWithMD =
@@ -402,7 +402,7 @@ txbWithMD =
       _txfee = Coin 94,
       _ttl = SlotNo 10,
       _txUpdate = SNothing,
-      _mdHash = SJust $ hashAuxiliaryData @Shelley md
+      _mdHash = SJust $ hashTxAuxData @Shelley md
     }
 
 txWithMD :: ShelleyTx Shelley

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Shelley.LedgerState
     UTxOState,
     genesisState,
   )
-import Cardano.Ledger.Shelley.Metadata (Metadata)
+import Cardano.Ledger.Shelley.Metadata (ShelleyTxAuxData)
 import Cardano.Ledger.Shelley.PParams
   ( ShelleyPParams,
     ShelleyPParamsHKD (..),
@@ -180,7 +180,7 @@ makeTx ::
   TxBody (ShelleyEra c) ->
   [KeyPair 'Witness c] ->
   Map (ScriptHash c) (MultiSig (ShelleyEra c)) ->
-  Maybe (Metadata (ShelleyEra c)) ->
+  Maybe (ShelleyTxAuxData (ShelleyEra c)) ->
   ShelleyTx (ShelleyEra c)
 makeTx txBody keyPairs msigs = ShelleyTx txBody txWits . maybeToStrictMaybe
   where

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/CDDL.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/CDDL.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.Shelley.API
     ShelleyTx,
     Update,
   )
-import Cardano.Ledger.Shelley.Metadata (Metadata)
+import Cardano.Ledger.Shelley.Metadata (ShelleyTxAuxData)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import Cardano.Ledger.Shelley.TxBody
   ( ShelleyTxBody,
@@ -59,7 +59,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
       cddlTest @StakePoolRelay n "relay",
       cddlTest @(DCert StandardCrypto) n "certificate",
       cddlTest @(TxIn StandardCrypto) n "transaction_input",
-      cddlAnnotatorTest @(Metadata Shelley) n "transaction_metadata",
+      cddlAnnotatorTest @(ShelleyTxAuxData Shelley) n "transaction_metadata",
       cddlAnnotatorTest @(MultiSig Shelley) n "multisig_script",
       cddlTest @(Update Shelley) n "update",
       cddlTest @(ProposedPPUpdates Shelley) n "proposed_protocol_parameter_updates",

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.BaseTypes
   )
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..), DeltaCoin (..))
-import Cardano.Ledger.Core (EraTx, Tx, hashAuxiliaryData, hashScript)
+import Cardano.Ledger.Core (EraTx, Tx, hashScript, hashTxAuxData)
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Era (EraCrypto (..))
@@ -900,7 +900,7 @@ tests =
                   )
               )
               (EpochNo 0)
-          mdh = hashAuxiliaryData @C $ MD.Metadata $ Map.singleton 13 (MD.I 17)
+          mdh = hashTxAuxData @C $ MD.ShelleyTxAuxData $ Map.singleton 13 (MD.I 17)
        in checkEncodingCBORAnnotated
             "txbody_full"
             ( ShelleyTxBody @C -- transaction body with all components
@@ -978,7 +978,7 @@ tests =
           s = Map.singleton (hashScript @C testScript) (testScript @C_Crypto)
           txwits :: ShelleyTxWits C
           txwits = mempty {addrWits = Set.singleton w, scriptWits = s}
-          md = (MD.Metadata @C) $ Map.singleton 17 (MD.I 42)
+          md = (MD.ShelleyTxAuxData @C) $ Map.singleton 17 (MD.I 42)
        in checkEncodingCBORAnnotated
             "tx_full"
             (ShelleyTx @(ShelleyEra C_Crypto) txb txwits (SJust md))
@@ -1134,7 +1134,7 @@ tests =
                 (hashScript @C testScript2, testScript2)
               ]
           tx4 = ShelleyTx txb4 mempty {scriptWits = ss} SNothing
-          tx5MD = MD.Metadata @C $ Map.singleton 17 (MD.I 42)
+          tx5MD = MD.ShelleyTxAuxData @C $ Map.singleton 17 (MD.I 42)
           tx5 = ShelleyTx txb5 mempty {addrWits = ws, scriptWits = ss} (SJust tx5MD)
           txns = ShelleyTxSeq $ StrictSeq.fromList [tx1, tx2, tx3, tx4, tx5]
        in checkEncodingCBORAnnotated

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
@@ -194,8 +194,8 @@ prop_roundtrip_NewEpochState = roundtrip2 toCBOR fromCBOR
 prop_roundtrip_MultiSig :: Ledger.MultiSig (ShelleyEra Mock.C_Crypto) -> Property
 prop_roundtrip_MultiSig = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
-prop_roundtrip_metadata :: Ledger.Metadata Mock.C -> Property
-prop_roundtrip_metadata = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
+prop_roundtrip_auxData :: Ledger.ShelleyTxAuxData Mock.C -> Property
+prop_roundtrip_auxData = roundtrip' toCBOR ((. Full) . runAnnotator <$> fromCBOR)
 
 prop_roundtrip_ShelleyGenesis :: ShelleyGenesis Mock.C -> Property
 prop_roundtrip_ShelleyGenesis = roundtrip toCBOR fromCBOR
@@ -273,7 +273,7 @@ tests =
       testProperty "roundtrip Epoch State" prop_roundtrip_EpochState,
       testProperty "roundtrip NewEpoch State" prop_roundtrip_NewEpochState,
       testProperty "roundtrip MultiSig" prop_roundtrip_MultiSig,
-      testProperty "roundtrip Metadata" prop_roundtrip_metadata,
+      testProperty "roundtrip TxAuxData" prop_roundtrip_auxData,
       testProperty "roundtrip Shelley Genesis" prop_roundtrip_ShelleyGenesis,
       testProperty "roundtrip coin compactcoin cbor" prop_roundtrip_Coin_1,
       testProperty "roundtrip coin cbor compactcoin" prop_roundtrip_Coin_2,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
@@ -16,13 +16,13 @@ where
 
 import Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Hashes (EraIndependentAuxiliaryData)
+import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
 import Cardano.Ledger.SafeHash (SafeHash)
 import Control.DeepSeq (NFData (..))
 import NoThunks.Class (NoThunks (..))
 
 newtype AuxiliaryDataHash c = AuxiliaryDataHash
-  { unsafeAuxiliaryDataHash :: SafeHash c EraIndependentAuxiliaryData
+  { unsafeAuxiliaryDataHash :: SafeHash c EraIndependentTxAuxData
   }
   deriving (Show, Eq, Ord, NoThunks, NFData)
 
@@ -32,4 +32,4 @@ deriving instance CC.Crypto c => FromCBOR (AuxiliaryDataHash c)
 
 type ValidateAuxiliaryData era c = ()
 
-{-# DEPRECATED ValidateAuxiliaryData "Use `Cardano.Ledger.Core.EraAuxiliaryData` instead" #-}
+{-# DEPRECATED ValidateAuxiliaryData "Use `Cardano.Ledger.Core.EraTxAuxData` instead" #-}

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -30,7 +30,7 @@ module Cardano.Ledger.Core
     compactCoinTxOutL,
     isAdaOnlyTxOutF,
     EraTxBody (..),
-    EraAuxiliaryData (..),
+    EraTxAuxData (..),
     EraTxWits (..),
     EraScript (..),
     Value,
@@ -70,6 +70,10 @@ module Cardano.Ledger.Core
 
     -- * Re-exports
     module Cardano.Ledger.Hashes,
+
+    -- * Deprecations
+    hashAuxiliaryData,
+    validateAuxiliaryData,
   )
 where
 
@@ -131,7 +135,7 @@ class (CC.Crypto (EraCrypto era), Typeable era, ProtVerLow era <= ProtVerHigh er
 class
   ( EraTxBody era,
     EraTxWits era,
-    EraAuxiliaryData era,
+    EraTxAuxData era,
     -- NFData (Tx era), TODO: Add NFData constraints to Crypto class
     NoThunks (Tx era),
     FromCBOR (Annotator (Tx era)),
@@ -347,21 +351,33 @@ toCompactPartial v =
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type
 
--- | AuxiliaryData which may be attached to a transaction
+-- | TxAuxData which may be attached to a transaction
 class
   ( Era era,
-    Eq (AuxiliaryData era),
-    Show (AuxiliaryData era),
-    NoThunks (AuxiliaryData era),
-    ToCBOR (AuxiliaryData era),
-    FromCBOR (Annotator (AuxiliaryData era)),
-    HashAnnotated (AuxiliaryData era) EraIndependentAuxiliaryData (EraCrypto era)
+    Eq (TxAuxData era),
+    Show (TxAuxData era),
+    NoThunks (TxAuxData era),
+    ToCBOR (TxAuxData era),
+    FromCBOR (Annotator (TxAuxData era)),
+    HashAnnotated (TxAuxData era) EraIndependentTxAuxData (EraCrypto era)
   ) =>
-  EraAuxiliaryData era
+  EraTxAuxData era
   where
-  type AuxiliaryData era = (r :: Type) | r -> era
-  hashAuxiliaryData :: AuxiliaryData era -> AuxiliaryDataHash (EraCrypto era)
-  validateAuxiliaryData :: ProtVer -> AuxiliaryData era -> Bool
+  type TxAuxData era = (r :: Type) | r -> era
+  hashTxAuxData :: TxAuxData era -> AuxiliaryDataHash (EraCrypto era)
+  validateTxAuxData :: ProtVer -> TxAuxData era -> Bool
+
+type AuxiliaryData era = TxAuxData era
+
+{-# DEPRECATED AuxiliaryData "Use `TxAuxData` instead" #-}
+
+hashAuxiliaryData :: EraTxAuxData era => TxAuxData era -> AuxiliaryDataHash (EraCrypto era)
+hashAuxiliaryData = hashTxAuxData
+{-# DEPRECATED hashAuxiliaryData "Use `hashTxAuxData` instead" #-}
+
+validateAuxiliaryData :: EraTxAuxData era => ProtVer -> TxAuxData era -> Bool
+validateAuxiliaryData = validateTxAuxData
+{-# DEPRECATED validateAuxiliaryData "Use `validateTxAuxData` instead" #-}
 
 class
   ( Era era,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -18,7 +18,7 @@ module Cardano.Ledger.Hashes
     EraIndependentScript,
     EraIndependentData,
     EraIndependentScriptData,
-    EraIndependentAuxiliaryData,
+    EraIndependentTxAuxData,
     EraIndependentPParamView,
     EraIndependentScriptIntegrity,
 
@@ -55,7 +55,7 @@ data EraIndependentBlockBody
 
 data EraIndependentMetadata
 
-data EraIndependentAuxiliaryData
+data EraIndependentTxAuxData
 
 data EraIndependentScript
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -49,7 +49,7 @@ import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.CompactAddress (CompactAddr (..), decompactAddr)
 import Cardano.Ledger.Compactible (Compactible (..))
-import Cardano.Ledger.Core (Era, EraAuxiliaryData (..), EraPParams (..), EraRule, EraScript (..), EraTx (..), EraTxBody (..), EraTxOut (..), EraTxWits (..), ScriptHash (..), Value)
+import Cardano.Ledger.Core (Era, EraPParams (..), EraRule, EraScript (..), EraTx (..), EraTxAuxData (..), EraTxBody (..), EraTxOut (..), EraTxWits (..), ScriptHash (..), Value)
 import Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),
     GenesisCredential (..),
@@ -92,7 +92,7 @@ import Cardano.Ledger.Shelley.LedgerState
     PState (..),
     UTxOState (..),
   )
-import Cardano.Ledger.Shelley.Metadata (Metadata (..), Metadatum (..))
+import Cardano.Ledger.Shelley.Metadata (Metadatum (..), ShelleyTxAuxData (..))
 import Cardano.Ledger.Shelley.PParams
   ( PPUpdateEnv (..),
     ProposedPPUpdates (..),
@@ -922,21 +922,21 @@ ppMetadatum (I n) = ppSexp "I" [ppInteger n]
 ppMetadatum (B bs) = ppSexp "B" [ppLong bs]
 ppMetadatum (S txt) = ppSexp "S" [text txt]
 
-ppMetadata :: Metadata era -> PDoc
-ppMetadata (Metadata m) = ppMap' (text "Metadata") ppWord64 ppMetadatum m
+ppShelleyTxAuxData :: ShelleyTxAuxData era -> PDoc
+ppShelleyTxAuxData (ShelleyTxAuxData m) = ppMap' (text "ShelleyTxAuxData") ppWord64 ppMetadatum m
 
 instance PrettyA Metadatum where
   prettyA = ppMetadatum
 
-instance PrettyA (Metadata era) where
-  prettyA = ppMetadata
+instance PrettyA (ShelleyTxAuxData era) where
+  prettyA = ppShelleyTxAuxData
 
 -- ============================
 -- Cardano.Ledger.Shelley.Tx
 
 ppTx ::
   ( PrettyA (TxBody era),
-    PrettyA (AuxiliaryData era),
+    PrettyA (TxAuxData era),
     PrettyA (TxWits era),
     EraTx era
   ) =>
@@ -972,7 +972,7 @@ ppWitnessSetHKD x =
 
 instance
   ( PrettyA (TxBody era),
-    PrettyA (AuxiliaryData era),
+    PrettyA (TxAuxData era),
     PrettyA (TxWits era),
     EraTx era,
     Tx era ~ ShelleyTx era

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -10,7 +10,7 @@
 
 module Cardano.Ledger.Pretty.Alonzo where
 
-import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (AlonzoAuxiliaryData), Data (..))
+import Cardano.Ledger.Alonzo.Data (AlonzoTxAuxData (AlonzoTxAuxData), Data (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.PParams
   ( AlonzoPParams,
@@ -172,14 +172,14 @@ instance Era era => PrettyA (Data era) where
 
 ppAuxiliaryData ::
   (PrettyA (Script era), EraTx era, Script era ~ AlonzoScript era) =>
-  AlonzoAuxiliaryData era ->
+  AlonzoTxAuxData era ->
   PDoc
-ppAuxiliaryData (AlonzoAuxiliaryData m s) =
+ppAuxiliaryData (AlonzoTxAuxData m s) =
   ppSexp "AuxiliaryData" [ppMap ppWord64 ppMetadatum m, ppStrictSeq prettyA s]
 
 instance
   (PrettyA (Script era), EraTx era, Script era ~ AlonzoScript era) =>
-  PrettyA (AlonzoAuxiliaryData era)
+  PrettyA (AlonzoTxAuxData era)
   where
   prettyA = ppAuxiliaryData
 
@@ -284,7 +284,7 @@ instance PrettyA IsValid where
 ppTx ::
   ( PrettyA (TxBody era),
     PrettyA (TxWits era),
-    PrettyA (AuxiliaryData era)
+    PrettyA (TxAuxData era)
   ) =>
   AlonzoTx era ->
   PDoc
@@ -298,9 +298,10 @@ ppTx (AlonzoTx b w iv aux) =
     ]
 
 instance
-  ( PrettyA (TxBody era),
-    PrettyA (TxWits era),
-    PrettyA (AuxiliaryData era)
+  ( PrettyA (TxWits era),
+    Era era,
+    PrettyA (TxBody era),
+    PrettyA (TxAuxData era)
   ) =>
   PrettyA (AlonzoTx era)
   where

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -73,15 +73,15 @@ ppValidityInterval (ValidityInterval b a) =
 
 instance PrettyA ValidityInterval where prettyA = ppValidityInterval
 
-ppAuxiliaryData :: Era era => PrettyA (Core.Script era) => MAAuxiliaryData era -> PDoc
-ppAuxiliaryData (AuxiliaryData' m sp) =
+ppAuxiliaryData :: Era era => PrettyA (Core.Script era) => AllegraTxAuxData era -> PDoc
+ppAuxiliaryData (AllegraTxAuxData' m sp) =
   ppRecord
-    "AuxiliaryData"
+    "AllegraTxAuxData"
     [ ("metadata", ppMap' (text "Metadata") ppWord64 ppMetadatum m),
       ("auxiliaryscripts", ppStrictSeq prettyA sp)
     ]
 
-instance (Era era, PrettyA (Core.Script era)) => PrettyA (MAAuxiliaryData era) where
+instance (Era era, PrettyA (Core.Script era)) => PrettyA (AllegraTxAuxData era) where
   prettyA = ppAuxiliaryData
 
 ppTxBody ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -97,10 +97,10 @@ data TxField era
   | BodyI [TxBodyField era] -- Inlines TxBody Fields
   | TxWits (TxWits era)
   | WitnessesI [WitnessesField era] -- Inlines Witnesess Fields
-  | AuxData (StrictMaybe (AuxiliaryData era))
+  | AuxData (StrictMaybe (TxAuxData era))
   | Valid IsValid
 
-pattern AuxData' :: [AuxiliaryData era] -> TxField era
+pattern AuxData' :: [TxAuxData era] -> TxField era
 
 pattern Valid' :: Bool -> TxField era
 
@@ -607,7 +607,7 @@ pattern Valid' x <-
   where
     Valid' x = Valid (IsValid x)
 
-auxdataview :: TxField era -> Maybe [AuxiliaryData era]
+auxdataview :: TxField era -> Maybe [TxAuxData era]
 auxdataview (AuxData x) = Just (fromStrictMaybe x)
 auxdataview _ = Nothing
 


### PR DESCRIPTION
Addresses issue https://github.com/input-output-hk/cardano-ledger/issues/3001
Renames AuxiliaryData type families consistently across eras to TxAuxData. Actual instances are called
ShelleyTxAuxData
AllegraTxAuxData
AlonzoTxAuxData