### PR TITLE
applyRuleInternal: descend into subrule in the Label case upon ValidateNone

### DIFF
--- a/libs/small-steps/src/Control/State/Transition/Extended.hs
+++ b/libs/small-steps/src/Control/State/Transition/Extended.hs
@@ -629,7 +629,7 @@ applyRuleInternal isAlreadyFailing ep vp goSTS jc r = do
       EPDiscard -> pure a
     validateIf lbls = case vp of
       ValidateAll -> True
-      ValidateNone -> False
+      ValidateNone -> True
       ValidateSuchThat f -> f lbls
 
 applySTSInternal ::


### PR DESCRIPTION
This is probably not the proper fix, but it does fix the problem I'm having.

As far as I can tell, `ValidateAll / ValidateNone / ValidateSuchThat` were originally used to decide whether to evaluate a `Predicate`. But the current behavior is: in the `Label` case, upon `ValidateNone`, it would stop descending into the subrule even if the subrule is not a `Predicate`.

This causes a problem for me: `SuccessfulPlutusScriptsEvent` and `FailedPlutusScriptsEvent` are never emitted, because the action that emits them [is hidden behind a Label added by when2Phase](https://github.com/input-output-hk/cardano-ledger/blob/b60ecae5a68230c60921fcc57e4929a1d235dfbe/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs#L204)!

The proper fix, if we do want to stop descending whenever we see a `Label`, is probably to create a separate type similar to `ValidationPolicy`, and leave the original `ValidationPolicy` for the `Predicate` case.

@JaredCorduan @lehins 
