### PR TITLE
Rename Cardano.Ledger.Mary.Value.{insert,lookup}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ in the naming of release branches.
 
 ### Changed
 
+- Renamed in `Cardano.Ledger.Mary.Value`: #3047
+  - `insert` to `insertMultiAsset`
+  - `lookup` to `lookupMultiAsset`
 - Changed `mint` field type to `MultiAsset (Crypto era)` in `MATxBody`, `AlonzoTxBody`, `BabbageTxBody`
   #2954
 - All Shelley rules are now available through `Cadano.Ledger.Shelley.Rules` module: #2996

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -201,7 +201,7 @@ multiAssetFromListBounded ::
   MultiAsset c
 multiAssetFromListBounded =
   foldr
-    (\(p, n, fromIntegral -> i) ans -> ConcreteValue.insert comb p n i ans)
+    (\(p, n, fromIntegral -> i) ans -> ConcreteValue.insertMultiAsset comb p n i ans)
     mempty
   where
     comb :: Integer -> Integer -> Integer

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Mary.Value as Mary
     MaryValue (..),
     MultiAsset (..),
     PolicyID (..),
-    insert,
+    insertMultiAsset,
     multiAssetFromList,
   )
 import Cardano.Ledger.Val as Val
@@ -27,7 +27,7 @@ class Val.Val val => ValueFromList val c | val -> c where
 instance C.Crypto c => ValueFromList (MaryValue c) c where
   valueFromList c triples = MaryValue c (Mary.multiAssetFromList triples)
 
-  insert combine pid an new (MaryValue c ma) = MaryValue c $ Mary.insert combine pid an new ma
+  insert combine pid an new (MaryValue c ma) = MaryValue c $ Mary.insertMultiAsset combine pid an new ma
 
   gettriples (MaryValue c (MultiAsset m1)) = (c, triples)
     where


### PR DESCRIPTION
`insert` and `lookup` are very common functions from `containers` and even `base`. They need to be
rename in order to be more descriptive.

- Rename `insert` to `inserMultiAsset`, and `lookup` to `lookupMultiAsset`.
- Deprecate `insert` and `lookup` in favor of the new alternatives.

Closes #3047 