### PR TITLE
move RewardType and Reward to cardano-ledger-core package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ in the naming of release branches.
 #2976
 - Moved `TxOut` to a separate module in each era #3024
 - Moved `mintedTxBodyF` into `ShelleyMAEraTxBody` class #3019
+- Moved thet `RewardType` and `Reward` types from the `Cardano.Ledger.Shelley.Reward` module in the
+  `cardano-ledger-shelley` package into a new module `Cardano.Ledger.Reward`
+  inside the `cardano-ledger-core` package. #3059
 
 ### Removed
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -42,11 +42,7 @@ import Cardano.Ledger.Shelley.LedgerState.DPState
   )
 import Cardano.Ledger.Shelley.LedgerState.Types
 import Cardano.Ledger.Shelley.RewardUpdate (RewardUpdate (..))
-import Cardano.Ledger.Shelley.Rewards
-  ( Reward (..),
-    aggregateRewards,
-    filterRewards,
-  )
+import Cardano.Ledger.Shelley.Rewards (aggregateRewards, filterRewards)
 import Cardano.Ledger.Shelley.TxBody
   ( Ptr (..),
   )

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
@@ -25,6 +25,7 @@ import Cardano.Binary
 import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase)
 import Cardano.Ledger.Coin (Coin (..), CompactForm, DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (fromCompact))
+import Cardano.Ledger.Core (Reward (..), RewardType (MemberReward))
 import Cardano.Ledger.Credential (Credential (..))
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
@@ -32,8 +33,6 @@ import Cardano.Ledger.Serialization (decodeRecordNamed)
 import Cardano.Ledger.Shelley.PoolRank (Likelihood, NonMyopic)
 import Cardano.Ledger.Shelley.Rewards
   ( PoolRewardInfo (..),
-    Reward (..),
-    RewardType (..),
     rewardOnePoolMember,
   )
 import Control.DeepSeq (NFData (..))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Shelley.AdaPots (AdaPots, totalAdaPotsES)
 import Cardano.Ledger.Shelley.EpochBoundary
 import Cardano.Ledger.Shelley.Era (ShelleyNEWEPOCH)
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rewards (Reward, sumRewards)
+import Cardano.Ledger.Shelley.Rewards (sumRewards)
 import Cardano.Ledger.Shelley.Rules.Epoch
 import Cardano.Ledger.Shelley.Rules.Mir (ShelleyMIR, ShelleyMirEvent, ShelleyMirPredFailure)
 import Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Shelley.LedgerState
     pulseStep,
     startStep,
   )
-import Cardano.Ledger.Shelley.Rewards (Reward)
 import Cardano.Ledger.Slot
   ( Duration (..),
     EpochNo,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -103,8 +103,7 @@ import Cardano.Ledger.Shelley.RewardUpdate
     RewardPulser (RSLP),
   )
 import Cardano.Ledger.Shelley.Rewards
-  ( Reward (rewardAmount),
-    StakeShare (..),
+  ( StakeShare (..),
     aggregateRewards,
     leaderRew,
     memberRew,
@@ -376,7 +375,7 @@ rewardsBoundedByPot _ = property $ do
             show slotsPerEpoch
           ]
       )
-      (fold (fmap rewardAmount rs) < rewardPot)
+      (fold (fmap Core.rewardAmount rs) < rewardPot)
 
 -- ====================================================================================
 -- To demonstrate that the code we wrote that uses pulsing does not
@@ -715,7 +714,9 @@ newEpochEventsProp tracelen propf = withMaxSuccess 10 $
         propf (concat (runShelleyBase $ getEvents tr)) (chainNes target)
       _ -> property True
 
-aggIncrementalRewardEvents :: [ChainEvent C] -> Map (Credential 'Staking (EraCrypto C)) (Set (Reward (EraCrypto C)))
+aggIncrementalRewardEvents ::
+  [ChainEvent C] ->
+  Map (Credential 'Staking (EraCrypto C)) (Set (Core.Reward (EraCrypto C)))
 aggIncrementalRewardEvents = foldl' accum Map.empty
   where
     accum ans (TickEvent (TickRupdEvent (RupdEvent _ m))) = Map.unionWith Set.union m ans
@@ -723,7 +724,9 @@ aggIncrementalRewardEvents = foldl' accum Map.empty
       Map.unionWith Set.union m ans
     accum ans _ = ans
 
-getMostRecentTotalRewardEvent :: [ChainEvent C] -> Map (Credential 'Staking (EraCrypto C)) (Set (Reward (EraCrypto C)))
+getMostRecentTotalRewardEvent ::
+  [ChainEvent C] ->
+  Map (Credential 'Staking (EraCrypto C)) (Set (Core.Reward (EraCrypto C)))
 getMostRecentTotalRewardEvent = foldl' accum Map.empty
   where
     accum ans (TickEvent (TickNewEpochEvent (TotalRewardEvent _ m))) = Map.unionWith Set.union m ans
@@ -757,16 +760,16 @@ eventsMirrorRewards events nes = same eventRew compRew
               x
               y
 
-ppAgg :: Map (Credential 'Staking (EraCrypto C)) (Set (Reward (EraCrypto C))) -> PDoc
+ppAgg :: Map (Credential 'Staking (EraCrypto C)) (Set (Core.Reward (EraCrypto C))) -> PDoc
 ppAgg = ppMap prettyA (ppSet ppReward)
 
-instance Terse (Reward c) where
+instance Terse (Core.Reward c) where
   terse x = show (ppReward x)
 
 instance PrettyA x => Terse (Set x) where
   terse x = show (ppSet prettyA x)
 
-instance PrettyA (Reward c) where
+instance PrettyA (Core.Reward c) where
   prettyA = ppReward
 
 -- ================================================================

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -58,7 +58,14 @@ import Cardano.Ledger.BaseTypes
     textToUrl,
   )
 import Cardano.Ledger.Coin (CompactForm (..), DeltaCoin (..))
-import Cardano.Ledger.Core (Era, EraCrypto, EraScript (..), EraSegWits (..))
+import Cardano.Ledger.Core
+  ( Era,
+    EraCrypto,
+    EraScript (..),
+    EraSegWits (..),
+    Reward (..),
+    RewardType (..),
+  )
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (DSIGN)
 import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
@@ -85,8 +92,6 @@ import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rewards
   ( LeaderOnlyReward (..),
     PoolRewardInfo (..),
-    Reward (..),
-    RewardType (..),
     StakeShare (..),
   )
 import qualified Cardano.Ledger.Shelley.Rules as STS

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Block (Block, bheader, txid)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), addDeltaCoin, toDeltaCoin)
 import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core (Reward (..), RewardType (..))
 import Cardano.Ledger.Credential (Credential, Ptr (..))
 import qualified Cardano.Ledger.Crypto as Cr
 import Cardano.Ledger.Era (EraCrypto (..))
@@ -62,7 +63,6 @@ import Cardano.Ledger.Shelley.PoolRank
     leaderProbability,
     likelihood,
   )
-import Cardano.Ledger.Shelley.Rewards (Reward (..), RewardType (..))
 import Cardano.Ledger.Shelley.Tx
   ( ShelleyTx (..),
   )

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -68,9 +68,7 @@ import Cardano.Ledger.Shelley.PoolRank
     likelihood,
   )
 import Cardano.Ledger.Shelley.Rewards
-  ( Reward (..),
-    RewardType (..),
-    StakeShare (..),
+  ( StakeShare (..),
     aggregateRewards,
     leaderRew,
     memberRew,
@@ -760,7 +758,7 @@ rewardUpdateEx9 ::
   forall era.
   ExMock (EraCrypto era) =>
   ShelleyPParams era ->
-  Map (Credential 'Staking (EraCrypto era)) (Set (Reward (EraCrypto era))) ->
+  Map (Credential 'Staking (EraCrypto era)) (Set (Core.Reward (EraCrypto era))) ->
   RewardUpdate (EraCrypto era)
 rewardUpdateEx9 pp rewards =
   RewardUpdate
@@ -812,15 +810,15 @@ twoPools9 = CHAINExample expectedStEx8 blockEx9 (Right $ expectedStEx9 ppEx)
 --
 -- Now test with Aggregation
 --
-carlsRewards :: forall c. ExMock c => Set (Reward c)
+carlsRewards :: forall c. ExMock c => Set (Core.Reward c)
 carlsRewards =
   Set.fromList
-    [ Reward MemberReward (hk Cast.alicePoolKeys) (carlMemberRewardsFromAlice @c),
-      Reward LeaderReward (hk Cast.alicePoolKeys) (carlLeaderRewardsFromAlice @c),
-      Reward LeaderReward (hk Cast.bobPoolKeys) (carlLeaderRewardsFromBob @c)
+    [ Core.Reward Core.MemberReward (hk Cast.alicePoolKeys) (carlMemberRewardsFromAlice @c),
+      Core.Reward Core.LeaderReward (hk Cast.alicePoolKeys) (carlLeaderRewardsFromAlice @c),
+      Core.Reward Core.LeaderReward (hk Cast.bobPoolKeys) (carlLeaderRewardsFromBob @c)
     ]
 
-rsEx9Agg :: forall c. ExMock c => Map (Credential 'Staking c) (Set (Reward c))
+rsEx9Agg :: forall c. ExMock c => Map (Credential 'Staking c) (Set (Core.Reward c))
 rsEx9Agg = Map.singleton Cast.carlSHK carlsRewards
 
 ppProtVer3 :: ShelleyPParams era
@@ -840,13 +838,13 @@ twoPools9Agg = CHAINExample expectedStEx8Agg blockEx9 (Right expectedStEx9Agg)
 testAggregateRewardsLegacy :: HasCallStack => Assertion
 testAggregateRewardsLegacy = do
   let expectedReward = carlLeaderRewardsFromBob @(EraCrypto C)
-  expectedReward @?= rewardAmount (minimum (carlsRewards @(EraCrypto C)))
+  expectedReward @?= Core.rewardAmount (minimum (carlsRewards @(EraCrypto C)))
   aggregateRewards @C_Crypto ppEx rsEx9Agg @?= Map.singleton Cast.carlSHK expectedReward
 
 testAggregateRewardsNew :: Assertion
 testAggregateRewardsNew =
   aggregateRewards @C_Crypto ppProtVer3 rsEx9Agg
-    @?= Map.singleton Cast.carlSHK (foldMap rewardAmount (carlsRewards @(EraCrypto C)))
+    @?= Map.singleton Cast.carlSHK (foldMap Core.rewardAmount (carlsRewards @(EraCrypto C)))
 
 --
 -- Two Pools Test Group

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -60,6 +60,7 @@ library
     Cardano.Ledger.Language
     Cardano.Ledger.MemoBytes
     Cardano.Ledger.PoolDistr
+    Cardano.Ledger.Rewards
     Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.SafeHash
     Cardano.Ledger.Serialization

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -68,6 +68,10 @@ module Cardano.Ledger.Core
     getPhase1,
     getPhase2,
 
+    -- * Rewards
+    RewardType (..),
+    Reward (..),
+
     -- * Re-exports
     module Cardano.Ledger.Hashes,
 
@@ -92,6 +96,7 @@ import Cardano.Ledger.Keys (KeyRole (Staking, Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey)
 import Cardano.Ledger.Language (Language)
+import Cardano.Ledger.Rewards (Reward (..), RewardType (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash (..))
 import Cardano.Ledger.Serialization (Sized (sizedValue), ToCBORGroup (..), mkSized)
 import Cardano.Ledger.TxIn (TxIn (..))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rewards.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rewards.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Rewards
+  ( RewardType (..),
+    Reward (..),
+  )
+where
+
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeWord,
+    encodeWord,
+  )
+import Cardano.Ledger.BaseTypes (invalidKey)
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Control.DeepSeq (NFData)
+import Data.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+-- | The staking rewards in Cardano are all either:
+--
+-- * member rewards - rewards given to a registered stake credential which has delegated
+-- to a stake pool, or
+--
+-- * leader rewards - rewards given to a registered stake pool (in particular, given to to the
+-- stake credential in the stake pool registration certificate).
+--
+-- See Figure 47, "Functions used in the Reward Splitting", of the
+-- <https://hydra.iohk.io/job/Cardano/cardano-ledger/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec formal specification>
+-- for more details.
+data RewardType = MemberReward | LeaderReward
+  deriving (Eq, Show, Ord, Generic)
+
+instance NoThunks RewardType
+
+instance NFData RewardType
+
+instance ToCBOR RewardType where
+  toCBOR MemberReward = encodeWord 0
+  toCBOR LeaderReward = encodeWord 1
+
+instance FromCBOR RewardType where
+  fromCBOR =
+    decodeWord >>= \case
+      0 -> pure MemberReward
+      1 -> pure LeaderReward
+      n -> invalidKey n
+
+-- | The 'Reward' type captures:
+--
+-- * if the reward is a member or leader reward
+--
+-- * the stake pool ID associated with the reward
+--
+-- * the number of Lovelace in the reward
+data Reward c = Reward
+  { rewardType :: RewardType,
+    rewardPool :: KeyHash 'StakePool c,
+    rewardAmount :: Coin
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Note that this Ord instance is chosen to align precisely
+--  with the Allegra reward aggregation, as given by the
+--  function 'aggregateRewards' so that 'Set.findMax' returns
+--  the expected value.
+instance Ord (Reward c) where
+  compare (Reward MemberReward _ _) (Reward LeaderReward _ _) = GT
+  compare (Reward LeaderReward _ _) (Reward MemberReward _ _) = LT
+  compare (Reward _ pool1 _) (Reward _ pool2 _) = compare pool1 pool2
+
+instance NoThunks (Reward c)
+
+instance NFData (Reward c)
+
+instance Crypto c => ToCBOR (Reward c) where
+  toCBOR (Reward rt pool c) =
+    encode $ Rec Reward !> To rt !> To pool !> To c
+
+instance Crypto c => FromCBOR (Reward c) where
+  fromCBOR =
+    decode $ RecD Reward <! From <! From <! From

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rewards.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rewards.hs
@@ -33,7 +33,7 @@ import NoThunks.Class (NoThunks (..))
 -- * member rewards - rewards given to a registered stake credential which has delegated
 -- to a stake pool, or
 --
--- * leader rewards - rewards given to a registered stake pool (in particular, given to to the
+-- * leader rewards - rewards given to a registered stake pool (in particular, given to the
 -- stake credential in the stake pool registration certificate).
 --
 -- See Figure 47, "Functions used in the Reward Splitting", of the

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -49,7 +49,21 @@ import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.CompactAddress (CompactAddr (..), decompactAddr)
 import Cardano.Ledger.Compactible (Compactible (..))
-import Cardano.Ledger.Core (Era, EraPParams (..), EraRule, EraScript (..), EraTx (..), EraTxAuxData (..), EraTxBody (..), EraTxOut (..), EraTxWits (..), ScriptHash (..), Value)
+import Cardano.Ledger.Core
+  ( Era,
+    EraPParams (..),
+    EraRule,
+    EraScript (..),
+    EraTx (..),
+    EraTxAuxData (..),
+    EraTxBody (..),
+    EraTxOut (..),
+    EraTxWits (..),
+    Reward (..),
+    RewardType (..),
+    ScriptHash (..),
+    Value,
+  )
 import Cardano.Ledger.Credential
   ( Credential (KeyHashObj, ScriptHashObj),
     GenesisCredential (..),
@@ -120,8 +134,6 @@ import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rewards
   ( LeaderOnlyReward (..),
     PoolRewardInfo (..),
-    Reward (..),
-    RewardType (..),
     StakeShare (..),
   )
 import Cardano.Ledger.Shelley.Scripts (MultiSig (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -21,7 +21,6 @@ import Cardano.Ledger.Coin (Coin (..), addDeltaCoin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.API (Credential, KeyRole (Staking))
-import Cardano.Ledger.Shelley.Rewards (Reward)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     DelegCert (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -46,7 +46,7 @@ import Cardano.Ledger.Shelley.LedgerState
     UTxOState (..),
   )
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..))
-import Cardano.Ledger.Shelley.Rewards (Reward, aggregateRewards)
+import Cardano.Ledger.Shelley.Rewards (aggregateRewards)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     DelegCert (..),


### PR DESCRIPTION
I moved the `RewardType` and `Reward` types from the `Cardano.Ledger.Shelley.Reward` module in the `cardano-ledger-shelley` package into a new module `Cardano.Ledger.Reward` in the `cardano-ledger-core` package. And added a wee bit of documentation while I was at it.

resolves #3048