### PR TITLE
Versioned CBOR

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Install ormolu
       run: |
         mkdir -p "$HOME/.local/bin"
-        curl -sL https://github.com/tweag/ormolu/releases/download/0.4.0.0/ormolu-Linux.zip -o /tmp/ormolu.zip
+        curl -sL https://github.com/tweag/ormolu/releases/download/0.5.0.1/ormolu-Linux.zip -o /tmp/ormolu.zip
         unzip /tmp/ormolu.zip -d "$HOME/.local/bin/"
         chmod a+x "$HOME/.local/bin/ormolu"
         echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ in the naming of release branches.
 
 ### Added
 
+- Start on the `cardano-ledger-binary` package as a replacement for `cardano-binary` package: #3036
 - Start on the `cardano-ledger-api` package and implement
   `setMinCoinTxOut`+`setMinCoinSizedTxOut`: #2995
 - Added `getMinCoinTxOut`/`getMinCoinSizedTxOut` to `EraTxOut`: #3008

--- a/cabal.project
+++ b/cabal.project
@@ -19,6 +19,7 @@ packages:
   eras/shelley-ma/test-suite
   libs/cardano-ledger-api
   libs/cardano-ledger-core
+  libs/cardano-ledger-binary
   libs/cardano-ledger-pretty
   libs/cardano-ledger-test
   libs/cardano-protocol-tpraos
@@ -107,6 +108,21 @@ source-repository-package
   location: https://github.com/fpco/weigh.git
   tag: bfcf4415144d7d2817dfcb91b6f9a6dfd7236de7
   --sha256: 01fy4nbq6kaqi73ydn6w7rd1izkg5p217q5znyp2icybf41sl1b6
+
+-- https://github.com/well-typed/cborg/pull/301
+source-repository-package
+  type: git
+  location: https://github.com/lehins/cborg
+  tag: c2e86cdd1ac9c51dedb5ef199f513cf48668bcd7
+  --sha256: 18apsg2lqjv9cc29nbd3hzj2hqhksqjj0s4xp2rdv8cbd27racjh
+  subdir:
+    cborg
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/moo
+  tag: 8c487714fbfdea66188fcb85053e7e292e0cc348
+  --sha256: sha256-HWxnkf6xEAFfY14QxQFU/RsQ09skzLSMKvrAB1EQstU=
 
 allow-newer:
   monoidal-containers:aeson,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -148,12 +148,14 @@ bbodyTransition =
             actualBodySize = bBodySize txsSeq
             actualBodyHash = hashTxSeq @era txsSeq
 
-        actualBodySize == fromIntegral (bhviewBSize bh)
+        actualBodySize
+          == fromIntegral (bhviewBSize bh)
           ?! ShelleyInAlonzoBbodyPredFailure
             ( WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ bhviewBSize bh)
             )
 
-        actualBodyHash == bhviewBHash bh
+        actualBodyHash
+          == bhviewBHash bh
           ?! ShelleyInAlonzoBbodyPredFailure
             ( InvalidBodyHashBBODY @era actualBodyHash (bhviewBHash bh)
             )

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -143,7 +143,10 @@ instance
   transitionRules = [ledgerTransition @AlonzoLEDGER]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
-    "AssertionViolation (" <> avSTS <> "): " <> avMsg
+    "AssertionViolation ("
+      <> avSTS
+      <> "): "
+      <> avMsg
       <> "\n"
       <> show avCtx
       <> "\n"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -321,7 +321,8 @@ validateInsufficientCollateral ::
 validateInsufficientCollateral pp txBody bal =
   failureUnless (Val.scale (100 :: Int) bal >= Val.scale collPerc txfee) $
     InsufficientCollateral bal $
-      rationalToCoinViaCeiling $ (fromIntegral collPerc * unCoin txfee) % 100
+      rationalToCoinViaCeiling $
+        (fromIntegral collPerc * unCoin txfee) % 100
   where
     txfee = txBody ^. feeTxBodyL -- Coin supplied to pay fees
     collPerc = getField @"_collateralPercentage" pp
@@ -333,7 +334,8 @@ validateCollateralContainsNonADA ::
   Test (AlonzoUtxoPredFailure era)
 validateCollateralContainsNonADA collateralTxOuts =
   failureUnless (areAllAdaOnly collateralTxOuts) $
-    CollateralContainsNonADA $ sumAllValue collateralTxOuts
+    CollateralContainsNonADA $
+      sumAllValue collateralTxOuts
 
 -- | If tx has non-native scripts, end of validity interval must translate to time
 --

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -290,8 +290,8 @@ scriptsNotValidateTransition = do
       {- utxoKeep = getField @"collateral" txb ⋪ utxo -}
       {- utxoDel  = getField @"collateral" txb ◁ utxo -}
       !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
-  pure
-    $! us
+  pure $!
+    us
       { _utxo = UTxO utxoKeep,
         _fees = fees <> coinBalance (UTxO utxoDel),
         _stakeDistro = updateStakeDistribution (_stakeDistro us) (UTxO utxoDel) mempty

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -330,7 +330,8 @@ decodeArrayAsMap keys decodeValue = do
       numKeys = Set.size keys
   when (numValues /= numKeys) $
     fail $
-      "Expected array with " <> show numKeys
+      "Expected array with "
+        <> show numKeys
         <> " entries, but encoded array has "
         <> show numValues
         <> " entries."

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -410,7 +410,8 @@ transExUnits (ExUnits mem steps) =
 
 exBudgetToExUnits :: PV1.ExBudget -> Maybe ExUnits
 exBudgetToExUnits (PV1.ExBudget (PV1.ExCPU steps) (PV1.ExMemory memory)) =
-  ExUnits <$> safeFromInteger memory
+  ExUnits
+    <$> safeFromInteger memory
     <*> safeFromInteger steps
   where
     safeFromInteger :: Integral a => a -> Maybe Natural

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -489,7 +489,8 @@ instance
     where
       dec :: forall s. Decoder s (Annotator (Map RdmrPtr (Data era, ExUnits)))
       dec = do
-        entries <- fmap sequence . decodeList
+        entries <- fmap sequence
+          . decodeList
           . decodeRecordNamed "redeemer" (const 4)
           $ do
             rdmrPtr <- fromCBORGroup

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -209,7 +209,9 @@ freeCostModel :: CostModel
 freeCostModel =
   let lang = PlutusV1
    in fromRight (error "freeCostModel is not well-formed") $
-        Alonzo.mkCostModel lang $ Map.fromSet (const 0) $ costModelParamsNamesSet lang
+        Alonzo.mkCostModel lang $
+          Map.fromSet (const 0) $
+            costModelParamsNamesSet lang
 
 -- ================================================================
 
@@ -353,7 +355,8 @@ genAlonzoPParams constants = do
   let mxTx = ExUnits (5 * bigMem + 1) (5 * bigStep + 1)
   -- mxTx <- ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000))
   mxBl <-
-    ExUnits <$> genNatural (20 * bigMem + 1) (30 * bigMem + 1)
+    ExUnits
+      <$> genNatural (20 * bigMem + 1) (30 * bigMem + 1)
       <*> genNatural (20 * bigStep + 1) (30 * bigStep + 1)
   mxV <- genNatural 4000 10000 -- This can't be too small. Shelley uses Hard coded 4000
   let cost = CostModels $ Map.singleton PlutusV1 freeCostModel

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -106,7 +106,8 @@ instance Arbitrary PV1.Data where
               [ PV1.I <$> arbitrary,
                 PV1.B <$> arbitrary,
                 PV1.Map <$> listOf ((,) <$> gendata (n `div` 2) <*> gendata (n `div` 2)),
-                PV1.Constr <$> fmap fromIntegral (arbitrary :: Gen Natural)
+                PV1.Constr
+                  <$> fmap fromIntegral (arbitrary :: Gen Natural)
                   <*> listOf (gendata (n `div` 2)),
                 PV1.List <$> listOf (gendata (n `div` 2))
               ]

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -86,7 +86,10 @@ instance
   transitionRules = [ledgerTransition @BabbageLEDGER]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
-    "AssertionViolation (" <> avSTS <> "): " <> avMsg
+    "AssertionViolation ("
+      <> avSTS
+      <> "): "
+      <> avMsg
       <> "\n"
       <> show avCtx
       <> "\n"

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -260,8 +260,8 @@ scriptsNo = do
   let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
       UTxO collouts = collOuts txBody
       collateralFees = collAdaBalance txBody utxoDel -- NEW to Babbage
-  pure
-    $! us {- (collInputs txb ⋪ utxo) ∪ collouts tx -}
+  pure $!
+    us {- (collInputs txb ⋪ utxo) ∪ collouts tx -}
       { _utxo = UTxO (Map.union utxoKeep collouts), -- NEW to Babbage
       {- fees + collateralFees -}
         _fees = fees <> collateralFees, -- NEW to Babbage

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -101,7 +101,8 @@ txInfoOutV2 os txOut = do
           NoDatum -> PV2.NoOutputDatum
           DatumHash dh -> PV2.OutputDatumHash $ Alonzo.transDataHash' dh
           Datum binaryData ->
-            PV2.OutputDatum . PV2.Datum
+            PV2.OutputDatum
+              . PV2.Datum
               . PV2.dataToBuiltinData
               . getPlutusData
               . binaryDataToData

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
@@ -37,7 +37,8 @@ trippingF f x =
           x === y
     Right (remaining, y) ->
       counterexample
-        ( "Unconsumed trailing bytes:\n" <> BSL.unpack remaining
+        ( "Unconsumed trailing bytes:\n"
+            <> BSL.unpack remaining
             <> "\nbad res: "
             <> show y
             <> "\nfull term: "

--- a/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Block.hs
+++ b/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Block.hs
@@ -62,8 +62,8 @@ instance HasTypeReps BlockHeader where
       <| typeOf (x ^. bhDlgHash :: Hash)
       <| typeOf (x ^. bhUpdHash :: Hash)
       <| typeReps (x ^. bhSlot :: Slot)
-      <> typeReps (x ^. bhIssuer :: VKey)
-      <> typeReps (x ^. bhSig :: Sig Hash)
+        <> typeReps (x ^. bhIssuer :: VKey)
+        <> typeReps (x ^. bhSig :: Sig Hash)
 
 data BlockBody = BlockBody
   { -- | Delegation certificates

--- a/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/Chain.hs
+++ b/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/Chain.hs
@@ -115,14 +115,14 @@ instance STS CHAIN where
                   _dSEnvK = k
                 }
         ds <- trans @DELEG $ IRC dsEnv
-        pure
-          $! ( s0,
-               [],
-               genesisHash,
-               utxoSt0,
-               ds,
-               upiState0
-             )
+        pure $!
+          ( s0,
+            [],
+            genesisHash,
+            utxoSt0,
+            ds,
+            upiState0
+          )
     ]
 
   transitionRules =
@@ -186,7 +186,8 @@ isHeaderSizeTooBigFailure _ = False
 headerIsValid :: UPIState -> BlockHeader -> Rule CHAIN 'Transition ()
 headerIsValid us bh = do
   let sMax = snd (us ^. _1) ^. maxHdrSz
-  bHeaderSize bh <= sMax
+  bHeaderSize bh
+    <= sMax
     ?! HeaderSizeTooBig bh (bHeaderSize bh) (Threshold sMax)
 
 -- | Lens for the delegation interface state contained in the chain state.
@@ -327,8 +328,8 @@ sigGenChain
           NoGenUpdate ->
             pure (Nothing, [])
 
-      pure
-        $! mkBlock
+      pure $!
+        mkBlock
           h
           nextSlot
           vkI

--- a/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/eras/byron/chain/executable-spec/src/Byron/Spec/Chain/STS/Rule/SigCnt.hs
@@ -76,7 +76,8 @@ issuer (pps, dms, k) sgs =
   if null validIssuers
     then
       error $
-        "No valid issuers!" ++ "\n"
+        "No valid issuers!"
+          ++ "\n"
           ++ "k = "
           ++ show k
           ++ "\n"

--- a/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
+++ b/eras/byron/chain/executable-spec/test/Test/Byron/AbstractSize/Properties.hs
@@ -113,24 +113,25 @@ exampleTypeRepsBlockBody =
         typeOf (undefined :: [DCert]),
         typeOf (undefined :: [Tx])
       ]
-    >< typeReps aTxWits
-    >< typeReps aTxWits
-    >< Seq.fromList
-      [ typeOf (undefined :: Maybe UProp),
-        typeOf (undefined :: [Vote]),
-        typeOf (undefined :: ProtVer),
-        typeOf (undefined :: Natural),
-        typeOf (undefined :: Natural),
-        typeOf (undefined :: Natural)
-      ]
+      >< typeReps aTxWits
+      >< typeReps aTxWits
+      >< Seq.fromList
+        [ typeOf (undefined :: Maybe UProp),
+          typeOf (undefined :: [Vote]),
+          typeOf (undefined :: ProtVer),
+          typeOf (undefined :: Natural),
+          typeOf (undefined :: Natural),
+          typeOf (undefined :: Natural)
+        ]
 
 -- | The typeReps for a 'Block' is a combination of typeReps for
 -- the header and body in the block.
 exampleTypeRepsBlock :: Assertion
 exampleTypeRepsBlock =
-  typeReps aBlock @?= typeOf (undefined :: Block)
-    <| typeReps aHeader
-    >< typeReps aBody
+  typeReps aBlock
+    @?= typeOf (undefined :: Block)
+      <| typeReps aHeader
+      >< typeReps aBody
 
 --------------------------------------------------------------------------------
 -- Properties of abstractSize for Block/Header/Body

--- a/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
@@ -148,7 +148,8 @@ instance
     -- many bytes, fail otherwise. Then convert to a digest.
     bs <- fromCBOR @SBS.ShortByteString
     when (SBS.length bs /= expectedSize) $
-      cborError $ DecoderErrorCustom "AbstractHash" "Bytes not expected length"
+      cborError $
+        DecoderErrorCustom "AbstractHash" "Bytes not expected length"
     return (AbstractHash bs)
     where
       expectedSize = hashDigestSize (Prelude.undefined :: algo)

--- a/eras/byron/crypto/src/Cardano/Crypto/ProtocolMagic.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/ProtocolMagic.hs
@@ -127,7 +127,8 @@ instance A.FromJSON RequiresNetworkMagic where
         "NMMustBeJust" -> Right RequiresMagic
         other ->
           Left
-            ( "invalid value " <> other
+            ( "invalid value "
+                <> other
                 <> ", acceptable values are RequiresNoMagic | RequiresMagic"
             )
 

--- a/eras/byron/crypto/test/Test/Cardano/Crypto/Signing/Redeem.hs
+++ b/eras/byron/crypto/test/Test/Cardano/Crypto/Signing/Redeem.hs
@@ -60,8 +60,8 @@ prop_redeemSignDifferentKey = property $ do
 
   assert
     . not
-    $ verifyRedeemSig Dummy.protocolMagicId SignForTestingOnly vk a $
-      redeemSign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifyRedeemSig Dummy.protocolMagicId SignForTestingOnly vk a
+    $ redeemSign Dummy.protocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when then wrong signature data is used
 prop_redeemSignDifferentData :: Property
@@ -72,8 +72,8 @@ prop_redeemSignDifferentData = property $ do
 
   assert
     . not
-    $ verifyRedeemSig Dummy.protocolMagicId SignForTestingOnly vk b $
-      redeemSign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifyRedeemSig Dummy.protocolMagicId SignForTestingOnly vk b
+    $ redeemSign Dummy.protocolMagicId SignForTestingOnly sk a
 
 genData :: Gen [Int32]
 genData = Gen.list (Range.constant 0 50) (Gen.int32 Range.constantBounded)

--- a/eras/byron/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
+++ b/eras/byron/crypto/test/Test/Cardano/Crypto/Signing/Signing.hs
@@ -53,8 +53,8 @@ prop_signDifferentKey = property $ do
 
   assert
     . not
-    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk a $
-      sign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk a
+    $ sign Dummy.protocolMagicId SignForTestingOnly sk a
 
 -- | Signing fails when then wrong signature data is used
 prop_signDifferentData :: Property
@@ -65,8 +65,8 @@ prop_signDifferentData = property $ do
 
   assert
     . not
-    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk b $
-      sign Dummy.protocolMagicId SignForTestingOnly sk a
+    $ verifySignature toCBOR Dummy.protocolMagicId SignForTestingOnly vk b
+    $ sign Dummy.protocolMagicId SignForTestingOnly sk a
 
 genData :: Gen [Int32]
 genData = Gen.list (Range.constant 0 50) (Gen.int32 Range.constantBounded)

--- a/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation.hs
+++ b/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation.hs
@@ -308,11 +308,11 @@ dIStateDSState =
     ( \dis dss ->
         dis
           & scheduledDelegations
-          .~ dss
-          ^. scheduledDelegations
+            .~ dss
+              ^. scheduledDelegations
           & keyEpochDelegations
-          .~ dss
-          ^. keyEpochDelegations
+            .~ dss
+              ^. keyEpochDelegations
     )
 
 dIStateDState :: Lens' DIState DState
@@ -322,11 +322,11 @@ dIStateDState =
     ( \dis dss ->
         dis
           & delegationMap
-          .~ dss
-          ^. delegationMap
+            .~ dss
+              ^. delegationMap
           & lastDelegation
-          .~ dss
-          ^. lastDelegation
+            .~ dss
+              ^. lastDelegation
     )
 
 --------------------------------------------------------------------------------
@@ -376,13 +376,20 @@ instance STS SDELEG where
         let d = liveAfter (env ^. k)
         notAlreadyScheduled d env st cert ?! IsAlreadyScheduled
         Set.member (cert ^. to dwho . _1) (env ^. allowedDelegators) ?! IsNotGenesisKey
-        env ^. epoch <= cert ^. to depoch
+        env
+          ^. epoch
+          <= cert
+          ^. to depoch
           ?! EpochInThePast
             EpochDiff
               { currentEpoch = env ^. epoch,
                 certEpoch = cert ^. to depoch
               }
-        cert ^. to depoch <= env ^. epoch + 1
+        cert
+          ^. to depoch
+          <= env
+          ^. epoch
+          + 1
           ?! EpochPastNextEpoch
             EpochDiff
               { currentEpoch = env ^. epoch,
@@ -466,8 +473,8 @@ instance STS ADELEG where
           Nothing -> pure () -- If vks hasn't delegated, then we proceed and
           -- update the @ADELEG@ state.
           Just sp -> sp < s ?! S_BeforeExistingDelegation
-        return
-          $! DState
+        return $!
+          DState
             { _dStateDelegationMap = dms ⨃ [(vks, vkd)],
               _dStateLastDelegation = dws ⨃ [(vks, s)]
             },
@@ -580,8 +587,8 @@ instance STS DELEG where
         IRC env <- judgmentContext
         initADelegsState <- trans @ADELEGS $ IRC (env ^. allowedDelegators)
         initSDelegsState <- trans @SDELEGS $ IRC env
-        pure
-          $! DIState
+        pure $!
+          DIState
             { _dIStateDelegationMap = initADelegsState ^. delegationMap,
               _dIStateLastDelegation = initADelegsState ^. lastDelegation,
               _dIStateScheduledDelegations = initSDelegsState ^. scheduledDelegations,

--- a/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/UTxO/Generators.hs
+++ b/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/UTxO/Generators.hs
@@ -168,7 +168,8 @@ genInputOutput ins inValue genOut outValue modifyOutValue =
       case treeValue (runDiscardEffectT insTree) of
         Nothing -> empty
         Just is ->
-          (,) <$> pure insTree
+          (,)
+            <$> pure insTree
             <*> toTreeMaybeT
               ( genSplitValue
                   (sum $ inValue <$> is)
@@ -364,5 +365,5 @@ viewTwo = \case
   [] -> []
   [_] -> []
   x : x' : xs ->
-    ([], x, x', xs) :
-    fmap (\(as, b, c, ds) -> (x : as, b, c, ds)) (viewTwo (x' : xs))
+    ([], x, x', xs)
+      : fmap (\(as, b, c, ds) -> (x : as, b, c, ds)) (viewTwo (x' : xs))

--- a/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Update.hs
+++ b/eras/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Update.hs
@@ -697,10 +697,10 @@ instance STS UPVOTE where
         vts' <- trans @ADDVOTE $ TRC ((rups, dms), vts, vote)
         let pid = vote ^. vPropId
         size ([pid] ◁ vts') < t || pid ∈ dom cps ?! S_HigherThanThdAndNotAlreadyConfirmed
-        pure
-          $! ( cps,
-               vts'
-             ),
+        pure $!
+          ( cps,
+            vts'
+          ),
       do
         TRC
           ( (sn, t, rups, dms),
@@ -712,10 +712,10 @@ instance STS UPVOTE where
         let pid = vote ^. vPropId
         t <= size ([pid] ◁ vts') ?! S_CfmThdNotReached
         pid ∉ dom cps ?! S_AlreadyConfirmed
-        pure
-          $! ( cps ⨃ [(pid, sn)],
-               vts'
-             )
+        pure $!
+          ( cps ⨃ [(pid, sn)],
+            vts'
+          )
     ]
 
 instance Embed ADDVOTE UPVOTE where
@@ -1028,17 +1028,17 @@ instance STS UPIREG where
           judgmentContext
         (rpus', raus') <- trans @UPREG $ TRC ((pv, pps, avs, dms), (rpus, raus), up)
         let pws' = pws ⨃ [(up ^. upId, sn)]
-        pure
-          $! ( (pv, pps),
-               fads,
-               avs,
-               rpus',
-               raus',
-               cps,
-               vts,
-               bvs,
-               pws'
-             )
+        pure $!
+          ( (pv, pps),
+            fads,
+            avs,
+            rpus',
+            raus',
+            cps,
+            vts,
+            bvs,
+            pws'
+          )
     ]
 
 instance Embed UPREG UPIREG where
@@ -1050,7 +1050,8 @@ instance HasTrace UPIREG where
   sigGen (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, pws) =
     do
       (vk, pv', pps', sv') <-
-        (,,,) <$> issuerGen
+        (,,,)
+          <$> issuerGen
           <*> pvGen
           <*> pparamsGen
           <*> swVerGen
@@ -1435,17 +1436,17 @@ instance STS UPIVOTE where
                 ),
                 v
               )
-        pure
-          $! ( (pv, pps),
-               fads,
-               avs,
-               rpus,
-               raus,
-               cps',
-               vts',
-               bvs,
-               pws
-             )
+        pure $!
+          ( (pv, pps),
+            fads,
+            avs,
+            rpus,
+            raus,
+            cps',
+            vts',
+            bvs,
+            pws
+          )
     ]
 
 instance Embed UPVOTE UPIVOTE where
@@ -1523,17 +1524,17 @@ instance STS UPIVOTES where
               [ (an, (av, sn, m))
                 | (an, av, m) <- toList cfmRaus
               ]
-        pure
-          $! ( (pv, pps),
-               fads,
-               avs ⨃ avsNew,
-               rpus,
-               (dom cps) ⋪ raus,
-               cps,
-               vts,
-               bvs,
-               pws
-             )
+        pure $!
+          ( (pv, pps),
+            fads,
+            avs ⨃ avsNew,
+            rpus,
+            (dom cps) ⋪ raus,
+            cps,
+            vts,
+            bvs,
+            pws
+          )
     ]
 
 instance Embed APPLYVOTES UPIVOTES where
@@ -1765,8 +1766,8 @@ instance STS UPIEC where
         (pv', pps') <-
           trans @PVBUMP $
             TRC ((GP.epochFirstSlot k e_n, fads, k), (pv, pps), ())
-        return
-          $! if pv == pv'
+        return $!
+          if pv == pv'
             then us
             else
               ( (pv', pps') :: (ProtVer, PParams),

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/AbstractSize/Properties.hs
@@ -41,13 +41,14 @@ aTxId = TxId (hash aTx)
 exampleTypeRepsTxIn :: Assertion
 exampleTypeRepsTxIn =
   let txIn = TxIn aTxId 0
-   in typeReps txIn @?= typeOf (undefined :: TxIn)
-        <| typeOf (undefined :: TxId)
-        <| typeOf (undefined :: Hash)
-        <| typeOf (undefined :: Maybe Int)
-        <| typeOf (undefined :: Int)
-        <| typeOf (undefined :: Natural)
-        <| empty
+   in typeReps txIn
+        @?= typeOf (undefined :: TxIn)
+          <| typeOf (undefined :: TxId)
+          <| typeOf (undefined :: Hash)
+          <| typeOf (undefined :: Maybe Int)
+          <| typeOf (undefined :: Int)
+          <| typeOf (undefined :: Natural)
+          <| empty
 
 -- | A 'TxWits' term may contain multiple inputs/outputs/witnesses.
 --   In this example, we have 2 inputs and show how the 'typeReps' for
@@ -58,16 +59,17 @@ exampleTypeRepsTx =
       outs = []
       wits = []
       tx = Tx (TxBody [in0, in1] outs) wits
-   in typeReps tx @?= typeOf (undefined :: Tx)
-        <| typeOf (undefined :: TxBody)
-        <| typeOf (undefined :: [TxIn])
-        <| typeReps in0
-        >< typeReps in1
-        >< ( Seq.fromList
-               [ typeOf (undefined :: [TxOut]),
-                 typeOf (undefined :: [Wit])
-               ]
-           )
+   in typeReps tx
+        @?= typeOf (undefined :: Tx)
+          <| typeOf (undefined :: TxBody)
+          <| typeOf (undefined :: [TxIn])
+          <| typeReps in0
+          >< typeReps in1
+          >< ( Seq.fromList
+                 [ typeOf (undefined :: [TxOut]),
+                   typeOf (undefined :: [Wit])
+                 ]
+             )
 
 --------------------------------------------------------------------------------
 -- Properties of abstractSize of TxWits / TxIn /TxOut / Wit

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Examples.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Examples.hs
@@ -53,55 +53,55 @@ deleg =
           checkTrace @ADELEG runIdentity genKeys $
             pure (DState [] [])
               .- (s 0, (gk 0, k 10))
-                .-> DState
-                  [(gk 0, k 10)]
-                  [(gk 0, s 0)]
+              .-> DState
+                [(gk 0, k 10)]
+                [(gk 0, s 0)]
               .- (s 1, (gk 1, k 11))
-                .-> DState
-                  [(gk 0, k 10), (gk 1, k 11)]
-                  [(gk 0, s 0), (gk 1, s 1)]
+              .-> DState
+                [(gk 0, k 10), (gk 1, k 11)]
+                [(gk 0, s 0), (gk 1, s 1)]
               -- Here we try to delegate to a key @k 11@ that is already delegated (by
               -- @gk 0@), so the state remains unaltered.
               .- (s 2, (gk 0, k 11))
-                .-> DState
-                  [(gk 0, k 10), (gk 1, k 11)]
-                  [(gk 0, s 0), (gk 1, s 1)]
+              .-> DState
+                [(gk 0, k 10), (gk 1, k 11)]
+                [(gk 0, s 0), (gk 1, s 1)]
               .- (s 3, (gk 2, k 12))
-                .-> DState
-                  [(gk 0, k 10), (gk 1, k 11), (gk 2, k 12)]
-                  [(gk 0, s 0), (gk 1, s 1), (gk 2, s 3)],
+              .-> DState
+                [(gk 0, k 10), (gk 1, k 11), (gk 2, k 12)]
+                [(gk 0, s 0), (gk 1, s 1), (gk 2, s 3)],
         testCase "Example 1" $
           checkTrace @ADELEG runIdentity genKeys $
             pure (DState [] [])
               .- (s 0, (gk 0, k 2))
-                .-> DState
-                  [(gk 0, k 2)]
-                  [(gk 0, s 0)]
+              .-> DState
+                [(gk 0, k 2)]
+                [(gk 0, s 0)]
               -- Trying to delegate to a key that was delegated already has no effect
               -- should be a no-op on the delegation state.
               .- (s 1, (gk 1, k 2))
-                .-> DState
-                  [(gk 0, k 2)]
-                  [(gk 0, s 0)],
+              .-> DState
+                [(gk 0, k 2)]
+                [(gk 0, s 0)],
         testCase "Example 2" $
           checkTrace @ADELEG runIdentity genKeys $
             pure (DState [] [])
               .- (s 6, (gk 1, k 2))
-                .-> DState
-                  [(gk 1, k 2)]
-                  [(gk 1, s 6)]
+              .-> DState
+                [(gk 1, k 2)]
+                [(gk 1, s 6)]
               .- (s 7, (gk 2, k 2))
-                .-> DState
-                  [(gk 1, k 2)]
-                  [(gk 1, s 6)]
+              .-> DState
+                [(gk 1, k 2)]
+                [(gk 1, s 6)]
               .- (s 16, (gk 1, k 0))
-                .-> DState
-                  [(gk 1, k 0)]
-                  [(gk 1, s 16)]
+              .-> DState
+                [(gk 1, k 0)]
+                [(gk 1, s 16)]
               .- (s 19, (gk 2, k 0))
-                .-> DState
-                  [(gk 1, k 0)]
-                  [(gk 1, s 16)]
+              .-> DState
+                [(gk 1, k 0)]
+                [(gk 1, s 16)]
       ],
     testGroup
       "Multiple Activations"
@@ -112,9 +112,9 @@ deleg =
                    (s 5, (gk 2, k 0)),
                    (s 5, (gk 1, k 1))
                  ]
-                .-> DState
-                  [(gk 1, k 1)]
-                  [(gk 1, s 5)]
+              .-> DState
+                [(gk 1, k 1)]
+                [(gk 1, s 5)]
       ],
     testGroup
       "Scheduling"
@@ -122,17 +122,17 @@ deleg =
           checkTrace @SDELEG runIdentity (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (bk 2160)) $
             pure (DSState [] [])
               .- dc (gk 0) (k 10) (e 8)
-                .-> DSState
-                  [(s 4322, (gk 0, k 10))]
-                  [(e 8, gk 0)]
+              .-> DSState
+                [(s 4322, (gk 0, k 10))]
+                [(e 8, gk 0)]
               .- dc (gk 1) (k 11) (e 8)
-                .-> DSState
-                  [(s 4322, (gk 0, k 10)), (s 4322, (gk 1, k 11))]
-                  [(e 8, gk 0), (e 8, gk 1)]
+              .-> DSState
+                [(s 4322, (gk 0, k 10)), (s 4322, (gk 1, k 11))]
+                [(e 8, gk 0), (e 8, gk 1)]
               .- dc (gk 2) (k 10) (e 8)
-                .-> DSState
-                  [(s 4322, (gk 0, k 10)), (s 4322, (gk 1, k 11)), (s 4322, (gk 2, k 10))]
-                  [(e 8, gk 0), (e 8, gk 1), (e 8, gk 2)]
+              .-> DSState
+                [(s 4322, (gk 0, k 10)), (s 4322, (gk 1, k 11)), (s 4322, (gk 2, k 10))]
+                [(e 8, gk 0), (e 8, gk 1), (e 8, gk 2)]
       ],
     testGroup
       "Interface"

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Delegation/Properties.hs
@@ -182,7 +182,8 @@ instance STS DBLOCK where
                 then 0
                 else Epoch $ unSlot nextSlot `div` slotsPerEpoch (_dSEnvK env)
         return
-          ( env & slot .~ nextSlot
+          ( env
+              & slot .~ nextSlot
               & epoch .~ nextEpoch,
             stNext
           )

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Relation/Properties.hs
@@ -103,8 +103,10 @@ propDomainExclusionAndUnion ::
   r ->
   m ()
 propDomainExclusionAndUnion s r1 r2 =
-  (dom r1 `union` s) ⋪ (r1 ∪ r2)
-    === (dom r1 `union` s) ⋪ r2
+  (dom r1 `union` s)
+    ⋪ (r1 ∪ r2)
+    === (dom r1 `union` s)
+    ⋪ r2
 
 --------------------------------------------------------------------------------
 -- Property helpers

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Update/Examples.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Update/Examples.hs
@@ -140,48 +140,48 @@ upiendExamples =
                     fromList [(UpId 1, Slot {unSlot = 2})]
                   )
                   .- (ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0}, VKey Owner {unOwner = 0})
-                    .-> ( ( ProtVer {_pvMaj = 0, _pvMin = 0, _pvAlt = 0},
-                            oldPParams
-                          ),
-                          [ ( Slot {unSlot = 15},
+                  .-> ( ( ProtVer {_pvMaj = 0, _pvMin = 0, _pvAlt = 0},
+                          oldPParams
+                        ),
+                        [ ( Slot {unSlot = 15},
+                            ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
+                              newPParams
+                            )
+                          )
+                        ],
+                        fromList [],
+                        fromList
+                          [ ( UpId 1,
                               ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
                                 newPParams
                               )
                             )
                           ],
-                          fromList [],
-                          fromList
-                            [ ( UpId 1,
-                                ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
-                                  newPParams
-                                )
-                              )
-                            ],
-                          fromList [(UpId 1, (ApName "", ApVer 0, Metadata))],
-                          fromList [(UpId 1, Slot {unSlot = 5})],
-                          fromList
-                            [ ( UpId 1,
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 1}}
-                              ),
-                              ( UpId 1,
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 2}}
-                              ),
-                              ( UpId 1,
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 3}}
-                              )
-                            ],
-                          fromList
-                            [ ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 0}}
-                              ),
-                              ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 1}}
-                              ),
-                              ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
-                                VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 3}}
-                              )
-                            ],
-                          fromList [(UpId 1, Slot {unSlot = 2})]
-                        )
+                        fromList [(UpId 1, (ApName "", ApVer 0, Metadata))],
+                        fromList [(UpId 1, Slot {unSlot = 5})],
+                        fromList
+                          [ ( UpId 1,
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 1}}
+                            ),
+                            ( UpId 1,
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 2}}
+                            ),
+                            ( UpId 1,
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 3}}
+                            )
+                          ],
+                        fromList
+                          [ ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 0}}
+                            ),
+                            ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 1}}
+                            ),
+                            ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0},
+                              VKeyGenesis {unVKeyGenesis = VKey Owner {unOwner = 3}}
+                            )
+                          ],
+                        fromList [(UpId 1, Slot {unSlot = 2})]
+                      )
       ]
   ]

--- a/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Update/Properties.hs
+++ b/eras/byron/ledger/executable-spec/test/Test/Byron/Spec/Ledger/Update/Properties.hs
@@ -440,7 +440,8 @@ instance HasTrace UBLOCK where
     aBlockIssuer <-
       Gen.prune $
         -- Pick a delegate from the delegation map
-        Gen.element $ Bimap.elems (Update.delegationMap upienv)
+        Gen.element $
+          Bimap.elems (Update.delegationMap upienv)
 
     aBlockVersion <-
       Update.protocolVersionEndorsementGen upienv upistate

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Block/Validation.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Block/Validation.hs
@@ -302,15 +302,18 @@ validateHeaderMatchesBody hdr body = do
   let hdrProof = headerProof hdr
 
   -- Validate the delegation payload signature
-  proofDelegation hdrProof == hashDecoded (bodyDlgPayload body)
+  proofDelegation hdrProof
+    == hashDecoded (bodyDlgPayload body)
     `orThrowError` DelegationProofValidationError
 
   -- Validate the transaction payload proof
-  proofUTxO hdrProof == recoverTxProof (bodyTxPayload body)
+  proofUTxO hdrProof
+    == recoverTxProof (bodyTxPayload body)
     `orThrowError` UTxOProofValidationError
 
   -- Validate the update payload proof
-  proofUpdate hdrProof == hashDecoded (bodyUpdatePayload body)
+  proofUpdate hdrProof
+    == hashDecoded (bodyUpdatePayload body)
     `orThrowError` UpdateProofValidationError
 
 validateBlockProofs ::
@@ -353,7 +356,8 @@ updateBody ::
   m BodyState
 updateBody env bs b = do
   -- Validate the block size
-  blockLength b <= maxBlockSize
+  blockLength b
+    <= maxBlockSize
     `orThrowErrorInBlockValidationMode` ChainValidationBlockTooLarge maxBlockSize (blockLength b)
 
   -- Validate the delegation, transaction, and update payload proofs.
@@ -446,7 +450,8 @@ headerIsValid ::
   m ()
 headerIsValid updateState h =
   -- Validate the header size
-  headerLength h <= maxHeaderSize
+  headerLength h
+    <= maxHeaderSize
     `orThrowErrorInBlockValidationMode` ChainValidationHeaderTooLarge maxHeaderSize (headerLength h)
   where
     maxHeaderSize = Update.ppMaxHeaderSize $ UPI.adoptedProtocolParameters updateState
@@ -502,7 +507,8 @@ updateBlock ::
   m ChainValidationState
 updateBlock config cvs b = do
   -- Compare the block's 'ProtocolMagic' to the configured value
-  blockProtocolMagicId b == configProtocolMagicId config
+  blockProtocolMagicId b
+    == configProtocolMagicId config
     `orThrowErrorInBlockValidationMode` ChainValidationProtocolMagicMismatch
       (blockProtocolMagicId b)
       (configProtocolMagicId config)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -46,7 +46,8 @@ data AddrAttributes = AddrAttributes
 
 instance HeapWords AddrAttributes where
   heapWords aa =
-    3 + heapWords (aaVKDerivationPath aa)
+    3
+      + heapWords (aaVKDerivationPath aa)
       + heapWords (aaNetworkMagic aa)
 
 instance B.Buildable AddrAttributes where

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
@@ -296,7 +296,7 @@ checkAddrSpendingData asd addr =
   addrRoot addr
     == addressHash address'
     && addrType addr
-    == addrSpendingDataToType asd
+      == addrSpendingDataToType asd
   where
     address' = Address' (addrType addr, asd, addrAttributes addr)
 
@@ -337,7 +337,8 @@ isRedeemAddress addr = case addrType addr of
 -- indirectly once again, in an infinite loop.
 toCBORAddr :: Address -> Encoding
 toCBORAddr addr =
-  toCBOR (addrRoot addr) <> toCBOR (addrAttributes addr)
+  toCBOR (addrRoot addr)
+    <> toCBOR (addrAttributes addr)
     <> toCBOR
       (addrType addr)
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/TxSizeLinear.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/TxSizeLinear.hs
@@ -73,7 +73,7 @@ calculateTxSizeLinear ::
 calculateTxSizeLinear (TxSizeLinear a b) sz =
   addLovelace a
     =<< flip scaleLovelaceRationalUp b
-    <$> integerToLovelace (fromIntegral sz)
+      <$> integerToLovelace (fromIntegral sz)
 
 txSizeLinearMinValue :: TxSizeLinear -> Lovelace
 txSizeLinearMinValue (TxSizeLinear a _) = a

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Delegation/Certificate.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Delegation/Certificate.hs
@@ -217,7 +217,8 @@ instance Decoded (ACertificate ByteString) where
 instance B.Buildable (ACertificate a) where
   build (UnsafeACertificate e iVK dVK _ _) =
     bprint
-      ( "Delegation.Certificate { w = " . build
+      ( "Delegation.Certificate { w = "
+          . build
           . ", iVK = "
           . build
           . ", dVK = "

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Delegation/Validation/Scheduling.hs
@@ -159,15 +159,21 @@ scheduleCertificate ::
   m State
 scheduleCertificate env st cert = do
   -- Check that the delegator is a genesis key
-  delegatorHash `Set.member` allowedDelegators
+  delegatorHash
+    `Set.member` allowedDelegators
     `orThrowError` NonGenesisDelegator delegatorHash
 
   -- Check that the delegation epoch refers to the current or to the next epoch
-  currentEpoch <= delegationEpoch && delegationEpoch <= currentEpoch + 1
+  currentEpoch
+    <= delegationEpoch
+    && delegationEpoch
+    <= currentEpoch
+    + 1
     `orThrowError` WrongEpoch currentEpoch delegationEpoch
 
   -- Check that the delegator hasn't already delegated in 'delegationEpoch'
-  (delegationEpoch, delegatorHash) `Set.notMember` keyEpochDelegations
+  (delegationEpoch, delegatorHash)
+    `Set.notMember` keyEpochDelegations
     `orThrowError` MultipleDelegationsForEpoch delegationEpoch delegatorHash
 
   -- Check that the delegator hasn't issued a certificate in this slot

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
@@ -156,14 +156,16 @@ instance ToCBOR CompactTxId where
 
 getCompactTxId :: Get CompactTxId
 getCompactTxId =
-  CompactTxId <$> getWord64le
+  CompactTxId
+    <$> getWord64le
     <*> getWord64le
     <*> getWord64le
     <*> getWord64le
 
 putCompactTxId :: CompactTxId -> Put
 putCompactTxId (CompactTxId a b c d) =
-  putWord64le a >> putWord64le b
+  putWord64le a
+    >> putWord64le b
     >> putWord64le c
     >> putWord64le d
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
@@ -86,12 +86,16 @@ instance ToJSON Tx
 
 instance ToCBOR Tx where
   toCBOR tx =
-    encodeListLen 3 <> toCBOR (txInputs tx) <> toCBOR (txOutputs tx)
+    encodeListLen 3
+      <> toCBOR (txInputs tx)
+      <> toCBOR (txOutputs tx)
       <> toCBOR
         (txAttributes tx)
 
   encodedSizeExpr size pxy =
-    1 + size (txInputs <$> pxy) + size (txOutputs <$> pxy)
+    1
+      + size (txInputs <$> pxy)
+      + size (txOutputs <$> pxy)
       + size
         (txAttributes <$> pxy)
 
@@ -141,7 +145,8 @@ instance ToJSON TxIn
 
 instance ToCBOR TxIn where
   toCBOR (TxInUtxo txInHash txInIndex) =
-    encodeListLen 2 <> toCBOR (0 :: Word8)
+    encodeListLen 2
+      <> toCBOR (0 :: Word8)
       <> encodeKnownCborDataItem
         (txInHash, txInIndex)
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Validation.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Validation.hs
@@ -178,7 +178,8 @@ validateTxAux ::
   m ()
 validateTxAux env utxo (ATxAux (Annotated tx _) _ txBytes) = do
   -- Check that the size of the transaction is less than the maximum
-  txSize <= maxTxSize
+  txSize
+    <= maxTxSize
     `orThrowError` TxValidationTxTooLarge txSize maxTxSize
 
   -- Calculate the minimum fee from the 'TxFeePolicy'
@@ -235,7 +236,8 @@ validateTx ::
   m ()
 validateTx env utxo (Annotated tx _) = do
   -- Check that the transaction attributes are less than the max size
-  unknownAttributesLength (txAttributes tx) < 128
+  unknownAttributesLength (txAttributes tx)
+    < 128
     `orThrowError` TxValidationUnknownAttributes
 
   -- Check that outputs have valid NetworkMagic
@@ -273,7 +275,8 @@ validateTxOutNM ::
   m ()
 validateTxOutNM nm txOut = do
   -- Make sure that the unknown attributes are less than the max size
-  unknownAttributesLength (addrAttributes (txOutAddress txOut)) < 128
+  unknownAttributesLength (addrAttributes (txOutAddress txOut))
+    < 128
     `orThrowError` TxValidationUnknownAddressAttributes
 
   -- Check that the network magic in the address matches the expected one

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolParameters.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolParameters.hs
@@ -65,7 +65,8 @@ data ProtocolParameters = ProtocolParameters
 instance B.Buildable ProtocolParameters where
   build pp =
     bprint
-      ( "{ script version: " . build
+      ( "{ script version: "
+          . build
           . ", slot duration: "
           . bytes'
           . ", block size limit: "

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolParametersUpdate.hs
@@ -46,7 +46,8 @@ data ProtocolParametersUpdate = ProtocolParametersUpdate
 instance B.Buildable ProtocolParametersUpdate where
   build ppu =
     bprint
-      ( "{ script version: " . bmodifier build
+      ( "{ script version: "
+          . bmodifier build
           . ", slot duration: "
           . bmodifier bytes'
           . ", block size limit: "

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolVersion.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/ProtocolVersion.hs
@@ -38,7 +38,9 @@ instance ToJSON ProtocolVersion
 
 instance ToCBOR ProtocolVersion where
   toCBOR pv =
-    encodeListLen 3 <> toCBOR (pvMajor pv) <> toCBOR (pvMinor pv)
+    encodeListLen 3
+      <> toCBOR (pvMajor pv)
+      <> toCBOR (pvMinor pv)
       <> toCBOR
         (pvAlt pv)
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/SoftforkRule.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/SoftforkRule.hs
@@ -55,7 +55,9 @@ instance Aeson.ToJSON SoftforkRule
 
 instance ToCBOR SoftforkRule where
   toCBOR sr =
-    encodeListLen 3 <> toCBOR (srInitThd sr) <> toCBOR (srMinThd sr)
+    encodeListLen 3
+      <> toCBOR (srInitThd sr)
+      <> toCBOR (srMinThd sr)
       <> toCBOR
         (srThdDecrement sr)
 

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -252,8 +252,8 @@ registerProposal env st proposal = do
   Registration.State registeredProtocolUpdateProposals' registeredSoftwareUpdateProposals' <-
     Registration.registerProposal subEnv subSt proposal
       `wrapError` Registration
-  pure
-    $! st
+  pure $!
+    st
       { registeredProtocolUpdateProposals = registeredProtocolUpdateProposals',
         registeredSoftwareUpdateProposals = registeredSoftwareUpdateProposals',
         proposalRegistrationSlot =
@@ -352,8 +352,8 @@ registerVote env st vote = do
   Voting.State proposalVotes' confirmedProposals' <-
     Voting.registerVoteWithConfirmation protocolMagic subEnv subSt vote
       `wrapError` Voting
-  pure
-    $! st
+  pure $!
+    st
       { confirmedProposals = confirmedProposals',
         proposalVotes = proposalVotes'
       }
@@ -415,8 +415,8 @@ registerEndorsement env st endorsement = do
           Registration.pupProtocolVersion
             <$> M.elems registeredProtocolUpdateProposals'
 
-  pure
-    $! st
+  pure $!
+    st
       { candidateProtocolUpdates = forceElemsToWHNF candidateProtocolUpdates',
         registeredProtocolUpdateProposals = registeredProtocolUpdateProposals',
         registeredSoftwareUpdateProposals =

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Block/Model.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Block/Model.hs
@@ -289,7 +289,8 @@ ts_prop_invalidDelegationCertificatesAreRejected =
       where
         invalidDelegationGen :: SignalGenerator CHAIN
         invalidDelegationGen env@(sn, _, allowedDelegators, _, k) st =
-          addDelegation <$> sigGenChain NoGenDelegation NoGenUTxO NoGenUpdate env st
+          addDelegation
+            <$> sigGenChain NoGenDelegation NoGenUTxO NoGenUpdate env st
             <*> invalidDelegationCerts
           where
             addDelegation block delegationCerts =
@@ -389,8 +390,8 @@ ts_prop_invalidUpdateRegistrationsAreRejected =
               upiSt = mkUpiSt st
           uprop <- sigGen @UPIREG upiEnv upiSt
           tamperedUprop <- tamperWithUpdateProposal upiEnv upiSt uprop
-          pure
-            $! Abstract.updateBody
+          pure $!
+            Abstract.updateBody
               block
               (\body -> body {Abstract._bUpdProp = Just tamperedUprop})
 
@@ -443,8 +444,8 @@ ts_prop_invalidTxWitsAreRejected =
       let (_slot, _sgs, _h, utxoSt, _delegSt, _upiSt) = st
           utxoEnv = UTxOEnv {utxo0 = utxo, pps = pparams}
       txWitsList <- tamperedTxList utxoEnv utxoSt
-      pure
-        $! Abstract.updateBody
+      pure $!
+        Abstract.updateBody
           block
           (\body -> body {Abstract._bUtxo = txWitsList})
 
@@ -465,8 +466,8 @@ ts_prop_invalidVotesAreRejected =
           block <- sigGenChain NoGenDelegation NoGenUTxO GenUpdate env st
           let blockVotes = Abstract._bUpdVotes (Abstract._bBody block)
           tamperedVotes <- tamperWithVotes (mkUpiEnv block env st) (mkUpiSt st) blockVotes
-          pure
-            $! Abstract.updateBody
+          pure $!
+            Abstract.updateBody
               block
               (\body -> body {Abstract._bUpdVotes = tamperedVotes})
 
@@ -484,11 +485,14 @@ ts_prop_invalidBlockPayloadProofsAreRejected =
       coverInvalidBlockProofs 15 abstractPfs
       -- Check that the concrete failures correspond with the abstract ones.
       when (any (== InvalidDelegationHash) $ extractValues abstractPfs) $
-        assert $ concretePf == ChainValidationProofValidationError DelegationProofValidationError
+        assert $
+          concretePf == ChainValidationProofValidationError DelegationProofValidationError
       when (any (== InvalidUpdateProposalHash) $ extractValues abstractPfs) $
-        assert $ concretePf == ChainValidationProofValidationError UpdateProofValidationError
+        assert $
+          concretePf == ChainValidationProofValidationError UpdateProofValidationError
       when (any (== InvalidUtxoHash) $ extractValues abstractPfs) $
-        assert $ concretePf == ChainValidationProofValidationError UTxOProofValidationError
+        assert $
+          concretePf == ChainValidationProofValidationError UTxOProofValidationError
 
 -- | Output resulting from elaborating and validating an abstract trace with
 -- the concrete validators.
@@ -658,17 +662,17 @@ invalidSizesAreRejected
         where
           genAlteredUpdateState ((pv, pps), fads, avs, rpus, raus, cps, vts, bvs, pws) = do
             newMaxSize <- Gen.integral (Range.constant 0 maxSize)
-            pure
-              $! ( (pv, pps `setAbstractParamTo` newMaxSize),
-                   fads,
-                   avs,
-                   rpus,
-                   raus,
-                   cps,
-                   vts,
-                   bvs,
-                   pws
-                 )
+            pure $!
+              ( (pv, pps `setAbstractParamTo` newMaxSize),
+                fads,
+                avs,
+                rpus,
+                raus,
+                cps,
+                vts,
+                bvs,
+                pws
+              )
 
       genConcreteAlteredState ::
         ChainValidationState -> Natural -> Gen ChainValidationState
@@ -699,7 +703,8 @@ ts_prop_invalidBlockSizesAreRejected =
       PropertyT IO ()
     checkMaxSizeFailure abstractPfs ChainValidationBlockTooLarge {} = do
       assert $
-        any (== InvalidBlockSize) $ extractValues abstractPfs
+        any (== InvalidBlockSize) $
+          extractValues abstractPfs
       footnote $
         "InvalidBlockSize not found in the abstract predicate failures: "
           ++ show abstractPfs

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Block/Size.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Block/Size.hs
@@ -175,7 +175,8 @@ ts_prop_sizeABoundaryHeader =
   encodedSizeTest
     (uncurry toCBORABoundaryHeader)
     (uncurryP toCBORABoundaryHeaderSize)
-    ( (,) <$> Crypto.genProtocolMagicId
+    ( (,)
+        <$> Crypto.genProtocolMagicId
         <*> genBoundaryHeader
     )
 

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Byron/API.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Byron/API.hs
@@ -192,7 +192,7 @@ ts_mempoolValidation = withTestsTS 100 . property $ do
               vote' = elaborateVote pm upIdMap' <$> vote
            in addAnnotation
                 <$> [MempoolUpdateProposal up']
-                <> (MempoolUpdateVote <$> vote')
+                  <> (MempoolUpdateVote <$> vote')
 
   let mempoolPayloads =
         [mempoolTx]

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Gen.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Gen.hs
@@ -83,7 +83,8 @@ genAddress = makeAddress <$> genAddrSpendingData <*> genAddrAttributes
 
 genAddressWithNM :: NetworkMagic -> Gen Address
 genAddressWithNM nm =
-  makeAddress <$> genAddrSpendingData
+  makeAddress
+    <$> genAddrSpendingData
     <*> genAddrAttributesWithNM nm
 
 genAddrType :: Gen AddrType

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -149,7 +149,9 @@ elaborate abstractToConcreteIdMaps config dCert st abstractBlock =
 
     dcerts =
       abstractBlock
-        ^.. ( Abstract.bBody . Abstract.bDCerts . traverse
+        ^.. ( Abstract.bBody
+                . Abstract.bDCerts
+                . traverse
                 . to
                   (elaborateDCert pm)
             )

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/UTxO.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/UTxO.hs
@@ -116,7 +116,8 @@ elaborateTxIns ::
   [Abstract.TxIn] ->
   NonEmpty Concrete.TxIn
 elaborateTxIns elaborateTxId =
-  fromMaybe (panic "elaborateTxIns: Empty list of TxIns") . NE.nonEmpty
+  fromMaybe (panic "elaborateTxIns: Empty list of TxIns")
+    . NE.nonEmpty
     . fmap
       (elaborateTxIn elaborateTxId)
 

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Gen.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Gen.hs
@@ -148,7 +148,9 @@ genTxPayload pm = mkTxPayload <$> Gen.list (Range.linear 0 10) (genTxAux pm)
 
 genTxProof :: ProtocolMagicId -> Gen TxProof
 genTxProof pm =
-  TxProof <$> genWord32 <*> genMerkleRoot genTx
+  TxProof
+    <$> genWord32
+    <*> genMerkleRoot genTx
     <*> genAbstractHash
       (Gen.list (Range.linear 1 5) (genTxWitness pm))
 

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Update/Gen.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Update/Gen.hs
@@ -159,7 +159,8 @@ genInstallerHash = InstallerHash <$> genHashRaw
 
 genPayload :: ProtocolMagicId -> Gen Payload
 genPayload pm =
-  payload <$> Gen.maybe (genProposal pm)
+  payload
+    <$> Gen.maybe (genProposal pm)
     <*> Gen.list
       (Range.linear 0 10)
       (genVote pm)
@@ -222,7 +223,7 @@ genRegistrationError =
                     (,) <$> genSystemTag <*> genInstallerHash
                 pure (name, (Registration.ApplicationVersion version slotNo meta))
             )
-          <*> genSoftwareVersion,
+        <*> genSoftwareVersion,
       Registration.MaxBlockSizeTooLarge <$> (Registration.TooLarge <$> genNatural <*> genNatural),
       Registration.MaxTxSizeTooLarge <$> (Registration.TooLarge <$> genNatural <*> genNatural),
       pure Registration.ProposalAttributesUnknown,

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -123,7 +123,9 @@ instance FromCBOR AssetName where
       then
         cborError $
           DecoderErrorCustom "asset name exceeds 32 bytes:" $
-            decodeLatin1 $ BS16.encode $ SBS.fromShort an
+            decodeLatin1 $
+              BS16.encode $
+                SBS.fromShort an
       else pure $ AssetName an
 
 -- | Policy ID

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Rules/Utxo.hs
@@ -331,42 +331,52 @@ instance
     BadInputsUTxO ins ->
       encodeListLen 2 <> toCBOR (0 :: Word8) <> encodeFoldable ins
     (OutsideValidityIntervalUTxO a b) ->
-      encodeListLen 3 <> toCBOR (1 :: Word8)
+      encodeListLen 3
+        <> toCBOR (1 :: Word8)
         <> toCBOR a
         <> toCBOR b
     (MaxTxSizeUTxO a b) ->
-      encodeListLen 3 <> toCBOR (2 :: Word8)
+      encodeListLen 3
+        <> toCBOR (2 :: Word8)
         <> toCBOR a
         <> toCBOR b
     InputSetEmptyUTxO -> encodeListLen 1 <> toCBOR (3 :: Word8)
     (FeeTooSmallUTxO a b) ->
-      encodeListLen 3 <> toCBOR (4 :: Word8)
+      encodeListLen 3
+        <> toCBOR (4 :: Word8)
         <> toCBOR a
         <> toCBOR b
     (ValueNotConservedUTxO a b) ->
-      encodeListLen 3 <> toCBOR (5 :: Word8)
+      encodeListLen 3
+        <> toCBOR (5 :: Word8)
         <> toCBOR a
         <> toCBOR b
     OutputTooSmallUTxO outs ->
-      encodeListLen 2 <> toCBOR (6 :: Word8)
+      encodeListLen 2
+        <> toCBOR (6 :: Word8)
         <> encodeFoldable outs
     (UpdateFailure a) ->
-      encodeListLen 2 <> toCBOR (7 :: Word8)
+      encodeListLen 2
+        <> toCBOR (7 :: Word8)
         <> toCBOR a
     (WrongNetwork right wrongs) ->
-      encodeListLen 3 <> toCBOR (8 :: Word8)
+      encodeListLen 3
+        <> toCBOR (8 :: Word8)
         <> toCBOR right
         <> encodeFoldable wrongs
     (WrongNetworkWithdrawal right wrongs) ->
-      encodeListLen 3 <> toCBOR (9 :: Word8)
+      encodeListLen 3
+        <> toCBOR (9 :: Word8)
         <> toCBOR right
         <> encodeFoldable wrongs
     OutputBootAddrAttrsTooBig outs ->
-      encodeListLen 2 <> toCBOR (10 :: Word8)
+      encodeListLen 2
+        <> toCBOR (10 :: Word8)
         <> encodeFoldable outs
     TriesToForgeADA -> encodeListLen 1 <> toCBOR (11 :: Word8)
     OutputTooBigUTxO outs ->
-      encodeListLen 2 <> toCBOR (12 :: Word8)
+      encodeListLen 2
+        <> toCBOR (12 :: Word8)
         <> encodeFoldable outs
 
 instance

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -302,7 +302,8 @@ genTxBody pparams slot ins outs cert wdrl fee upd meta = do
         Just os -> (mint, os)
       ps =
         map (\k -> Map.findWithDefault (error $ "Cannot find policy: " ++ show k) k policyIndex) $
-          Set.toList $ policies mint
+          Set.toList $
+            policies mint
   pure
     ( MATxBody
         ins

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/TranslationTools.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/TranslationTools.hs
@@ -91,7 +91,8 @@ decodeTestAnn _ x =
    in case decoded of
         Left e ->
           assertFailure $
-            "\nerror: " <> show e
+            "\nerror: "
+              <> show e
               <> "\nbytes: "
               <> show (B16.encode bytes)
               <> "\n"

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
@@ -260,24 +260,32 @@ valuePropList =
     -- the following 4 laws only holds for non zero n and m, and when not(n==m).
     -- Zeros cause the inserts to be no-ops in that case.
     ( \n m _ p a ->
-        n == 0 || m == 0 || n == m
+        n == 0
+          || m == 0
+          || n == m
           || (insertValue pickOld p a m (insertValue pickNew p a n zero))
-          == (insertValue pickNew p a n zero),
+            == (insertValue pickNew p a n zero),
       "retains-old"
     ),
     ( \n m _ p a ->
-        n == 0 || m == 0 || n == m
+        n == 0
+          || m == 0
+          || n == m
           || (insertValue pickNew p a m (insertValue pickNew p a n zero))
-          == (insertValue pickNew p a m zero),
+            == (insertValue pickNew p a m zero),
       "new-overrides"
     ),
     ( \n m _ p a ->
-        n == 0 || m == 0 || n == m
+        n == 0
+          || m == 0
+          || n == m
           || lookupMultiAsset p a (insertValue pickOld p a m (insertValue pickNew p a n zero)) == n,
       "oldVsNew"
     ),
     ( \n m _ p a ->
-        n == 0 || m == 0 || n == m
+        n == 0
+          || m == 0
+          || n == m
           || lookupMultiAsset p a (insertValue pickNew p a m (insertValue pickNew p a n zero)) == m,
       "newVsOld"
     ),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Orphans.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Orphans.hs
@@ -84,7 +84,8 @@ instance Default Lazy.ByteString where
 instance HS.HashAlgorithm h => Default (Hash h b) where
   def =
     UnsafeHash $
-      Short.pack $ replicate (fromIntegral (Hash.sizeHash (Proxy :: Proxy h))) 0
+      Short.pack $
+        replicate (fromIntegral (Hash.sizeHash (Proxy :: Proxy h))) 0
 
 instance Default Bool where
   def = False

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
@@ -175,7 +175,8 @@ applyDecay decay (Likelihood logWeights) = Likelihood $ mul decay <$> logWeights
 posteriorDistribution :: Histogram -> Likelihood -> Histogram
 posteriorDistribution (Histogram points) (Likelihood likelihoods) =
   normalize $
-    Histogram $ StrictSeq.zipWith (+) points likelihoods
+    Histogram $
+      StrictSeq.zipWith (+) points likelihoods
 
 -- | Normalize the histogram so that the total area is 1
 normalize :: Histogram -> Histogram

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -148,10 +148,12 @@ bbodyTransition =
             actualBodySize = bBodySize txsSeq
             actualBodyHash = hashTxSeq @era txsSeq
 
-        actualBodySize == fromIntegral (bhviewBSize bhview)
+        actualBodySize
+          == fromIntegral (bhviewBSize bhview)
           ?! WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ bhviewBSize bhview)
 
-        actualBodyHash == bhviewBHash bhview
+        actualBodyHash
+          == bhviewBHash bhview
           ?! InvalidBodyHashBBODY actualBodyHash (bhviewBHash bhview)
 
         ls' <-

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -174,7 +174,8 @@ instance
     DuplicateGenesisDelegateDELEG kh ->
       encodeListLen 2 <> toCBOR (6 :: Word8) <> toCBOR kh
     InsufficientForInstantaneousRewardsDELEG pot needed potAmount ->
-      encodeListLen 4 <> toCBOR (7 :: Word8)
+      encodeListLen 4
+        <> toCBOR (7 :: Word8)
         <> toCBOR pot
         <> toCBOR needed
         <> toCBOR potAmount
@@ -189,14 +190,16 @@ instance
     MIRNegativesNotCurrentlyAllowed ->
       encodeListLen 1 <> toCBOR (12 :: Word8)
     InsufficientForTransferDELEG pot needed available ->
-      encodeListLen 4 <> toCBOR (13 :: Word8)
+      encodeListLen 4
+        <> toCBOR (13 :: Word8)
         <> toCBOR pot
         <> toCBOR needed
         <> toCBOR available
     MIRProducesNegativeUpdate ->
       encodeListLen 1 <> toCBOR (14 :: Word8)
     MIRNegativeTransfer pot amt ->
-      encodeListLen 3 <> toCBOR (15 :: Word8)
+      encodeListLen 3
+        <> toCBOR (15 :: Word8)
         <> toCBOR pot
         <> toCBOR amt
 
@@ -328,7 +331,8 @@ delegationTransition = do
           tellEvent (NewEpoch newEpoch)
           firstSlot <- liftSTS $ epochInfoFirst ei newEpoch
           let tooLate = firstSlot *- Duration sp
-          slot < tooLate
+          slot
+            < tooLate
             ?! MIRCertificateTooLateinEpochDELEG slot tooLate
 
           let (potAmount, delta, instantaneousRewards) =
@@ -342,7 +346,8 @@ delegationTransition = do
 
           all (>= mempty) combinedMap ?! MIRProducesNegativeUpdate
 
-          requiredForRewards <= available
+          requiredForRewards
+            <= available
             ?! InsufficientForInstantaneousRewardsDELEG targetPot requiredForRewards available
 
           pure $
@@ -357,7 +362,8 @@ delegationTransition = do
           tellEvent (NewEpoch newEpoch)
           firstSlot <- liftSTS $ epochInfoFirst ei newEpoch
           let tooLate = firstSlot *- Duration sp
-          slot < tooLate
+          slot
+            < tooLate
             ?! MIRCertificateTooLateinEpochDELEG slot tooLate
 
           all (>= mempty) credCoinMap ?! MIRNegativesNotCurrentlyAllowed
@@ -369,7 +375,8 @@ delegationTransition = do
           let credCoinMap' = Map.map (\(DeltaCoin x) -> Coin x) credCoinMap
               combinedMap = Map.union credCoinMap' instantaneousRewards
               requiredForRewards = fold combinedMap
-          requiredForRewards <= potAmount
+          requiredForRewards
+            <= potAmount
             ?! InsufficientForInstantaneousRewardsDELEG targetPot requiredForRewards potAmount
 
           case targetPot of
@@ -385,13 +392,16 @@ delegationTransition = do
           tellEvent (NewEpoch newEpoch)
           firstSlot <- liftSTS $ epochInfoFirst ei newEpoch
           let tooLate = firstSlot *- Duration sp
-          slot < tooLate
+          slot
+            < tooLate
             ?! MIRCertificateTooLateinEpochDELEG slot tooLate
 
           let available = availableAfterMIR targetPot acnt (_irwd ds)
-          coin >= mempty
+          coin
+            >= mempty
             ?! MIRNegativeTransfer targetPot coin
-          coin <= available
+          coin
+            <= available
             ?! InsufficientForTransferDELEG targetPot coin available
 
           let ir = _irwd ds

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -167,7 +167,8 @@ instance
         <> toCBOR (1 :: Word8)
         <> mapToCBOR ws
     (DelplFailure a) ->
-      encodeListLen 2 <> toCBOR (2 :: Word8)
+      encodeListLen 2
+        <> toCBOR (2 :: Word8)
         <> toCBOR a
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -122,10 +122,12 @@ instance
   where
   toCBOR = \case
     (PoolFailure a) ->
-      encodeListLen 2 <> toCBOR (0 :: Word8)
+      encodeListLen 2
+        <> toCBOR (0 :: Word8)
         <> toCBOR a
     (DelegFailure a) ->
-      encodeListLen 2 <> toCBOR (1 :: Word8)
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
         <> toCBOR a
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -179,7 +179,10 @@ instance
   transitionRules = [ledgerTransition]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
-    "AssertionViolation (" <> avSTS <> "): " <> avMsg
+    "AssertionViolation ("
+      <> avSTS
+      <> "): "
+      <> avMsg
       <> "\n"
       <> show avCtx
       <> "\n"

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -132,7 +132,8 @@ ledgersTransition = do
           TRC (LedgerEnv slot ix pp account, ls', tx)
     )
     ls
-    $ zip [minBound ..] $ toList txwits
+    $ zip [minBound ..]
+    $ toList txwits
 
 instance
   ( Era era,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -120,7 +120,8 @@ newPpTransition = do
           diff = oblgCurr - oblgNew
           Coin availableReserves = availableAfterMIR ReservesMIR acnt (_irwd dstate)
 
-      Coin oblgCurr == _deposited utxoSt
+      Coin oblgCurr
+        == _deposited utxoSt
         ?! UnexpectedDepositPot (Coin oblgCurr) (_deposited utxoSt)
 
       if availableReserves + diff >= 0

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -195,13 +195,15 @@ poolDelegationTransition = do
       when (HardForks.validatePoolRewardAccountNetID pp) $ do
         actualNetID <- liftSTS $ asks networkId
         let suppliedNetID = getRwdNetwork (_poolRAcnt poolParam)
-        actualNetID == suppliedNetID
+        actualNetID
+          == suppliedNetID
           ?! WrongNetworkPOOL actualNetID suppliedNetID (_poolId poolParam)
 
       when (SoftForks.restrictPoolMetadataHash pp) $
         forM_ (_poolMD poolParam) $ \pmd ->
           let s = BS.length (_poolMDHash pmd)
-           in s <= fromIntegral (sizeHash ([] @(CC.HASH (EraCrypto era))))
+           in s
+                <= fromIntegral (sizeHash ([] @(CC.HASH (EraCrypto era))))
                 ?! PoolMedataHashTooBig (_poolId poolParam) s
 
       let poolCost = _poolCost poolParam
@@ -231,7 +233,11 @@ poolDelegationTransition = do
         ei <- asks epochInfoPure
         epochInfoEpoch ei slot
       let EpochNo maxEpoch = getField @"_eMax" pp
-      cepoch < e && e <= cepoch + maxEpoch
+      cepoch
+        < e
+        && e
+        <= cepoch
+        + maxEpoch
         ?! StakePoolRetirementWrongEpochPOOL cepoch e (cepoch + maxEpoch)
       pure $ ps {_retiring = eval (_retiring ps ⨃ singleton hk (EpochNo e))}
     DCertDeleg _ -> do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -212,38 +212,47 @@ instance
     BadInputsUTxO ins ->
       encodeListLen 2 <> toCBOR (0 :: Word8) <> encodeFoldable ins
     (ExpiredUTxO a b) ->
-      encodeListLen 3 <> toCBOR (1 :: Word8)
+      encodeListLen 3
+        <> toCBOR (1 :: Word8)
         <> toCBOR a
         <> toCBOR b
     (MaxTxSizeUTxO a b) ->
-      encodeListLen 3 <> toCBOR (2 :: Word8)
+      encodeListLen 3
+        <> toCBOR (2 :: Word8)
         <> toCBOR a
         <> toCBOR b
     InputSetEmptyUTxO -> encodeListLen 1 <> toCBOR (3 :: Word8)
     (FeeTooSmallUTxO a b) ->
-      encodeListLen 3 <> toCBOR (4 :: Word8)
+      encodeListLen 3
+        <> toCBOR (4 :: Word8)
         <> toCBOR a
         <> toCBOR b
     (ValueNotConservedUTxO a b) ->
-      encodeListLen 3 <> toCBOR (5 :: Word8)
+      encodeListLen 3
+        <> toCBOR (5 :: Word8)
         <> toCBOR a
         <> toCBOR b
     OutputTooSmallUTxO outs ->
-      encodeListLen 2 <> toCBOR (6 :: Word8)
+      encodeListLen 2
+        <> toCBOR (6 :: Word8)
         <> encodeFoldable outs
     (UpdateFailure a) ->
-      encodeListLen 2 <> toCBOR (7 :: Word8)
+      encodeListLen 2
+        <> toCBOR (7 :: Word8)
         <> toCBOR a
     (WrongNetwork right wrongs) ->
-      encodeListLen 3 <> toCBOR (8 :: Word8)
+      encodeListLen 3
+        <> toCBOR (8 :: Word8)
         <> toCBOR right
         <> encodeFoldable wrongs
     (WrongNetworkWithdrawal right wrongs) ->
-      encodeListLen 3 <> toCBOR (9 :: Word8)
+      encodeListLen 3
+        <> toCBOR (9 :: Word8)
         <> toCBOR right
         <> encodeFoldable wrongs
     OutputBootAddrAttrsTooBig outs ->
-      encodeListLen 2 <> toCBOR (10 :: Word8)
+      encodeListLen 2
+        <> toCBOR (10 :: Word8)
         <> encodeFoldable outs
 
 instance
@@ -327,7 +336,10 @@ instance
   transitionRules = [utxoInductive]
 
   renderAssertionViolation AssertionViolation {avSTS, avMsg, avCtx, avState} =
-    "AssertionViolation (" <> avSTS <> "): " <> avMsg
+    "AssertionViolation ("
+      <> avSTS
+      <> "): "
+      <> avMsg
       <> "\n"
       <> show avCtx
       <> "\n"

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -206,16 +206,20 @@ instance
     MissingVKeyWitnessesUTXOW missing ->
       encodeListLen 2 <> toCBOR (1 :: Word8) <> encodeFoldable missing
     MissingScriptWitnessesUTXOW ss ->
-      encodeListLen 2 <> toCBOR (2 :: Word8)
+      encodeListLen 2
+        <> toCBOR (2 :: Word8)
         <> encodeFoldable ss
     ScriptWitnessNotValidatingUTXOW ss ->
-      encodeListLen 2 <> toCBOR (3 :: Word8)
+      encodeListLen 2
+        <> toCBOR (3 :: Word8)
         <> encodeFoldable ss
     UtxoFailure a ->
-      encodeListLen 2 <> toCBOR (4 :: Word8)
+      encodeListLen 2
+        <> toCBOR (4 :: Word8)
         <> toCBOR a
     MIRInsufficientGenesisSigsUTXOW sigs ->
-      encodeListLen 2 <> toCBOR (5 :: Word8)
+      encodeListLen 2
+        <> toCBOR (5 :: Word8)
         <> encodeFoldable sigs
     MissingTxBodyMetadataHash h ->
       encodeListLen 2 <> toCBOR (6 :: Word8) <> toCBOR h
@@ -226,7 +230,8 @@ instance
     InvalidMetadata ->
       encodeListLen 1 <> toCBOR (9 :: Word8)
     ExtraneousScriptWitnessesUTXOW ss ->
-      encodeListLen 2 <> toCBOR (10 :: Word8)
+      encodeListLen 2
+        <> toCBOR (10 :: Word8)
         <> encodeFoldable ss
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -403,7 +403,8 @@ shelleyMinFeeTx ::
 shelleyMinFeeTx pp tx =
   Coin $
     fromIntegral (getField @"_minfeeA" pp)
-      * tx ^. sizeTxF + fromIntegral (getField @"_minfeeB" pp)
+      * tx ^. sizeTxF
+      + fromIntegral (getField @"_minfeeB" pp)
 
 minfee ::
   ( EraTx era,

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
@@ -116,7 +116,8 @@ genChainInEpoch epoch = do
       Nothing -> pure x
       Just x' -> x' >>= flip applyUntil f
     applyBlk cs' blk =
-      (either err id) . flip runReader testGlobals
+      (either err id)
+        . flip runReader testGlobals
         . applySTS @(CHAIN B)
         $ TRC ((), cs', blk)
       where

--- a/eras/shelley/test-suite/src/Test/Cardano/Crypto/VRF/Fake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Crypto/VRF/Fake.hs
@@ -136,7 +136,9 @@ evalVRF' a sk@(SignKeyFakeVRF n) =
   let y = sneakilyExtractResult a sk
       p = unsneakilyExtractPayload a
       realValue =
-        fromIntegral . bytesToNatural . hashToBytes
+        fromIntegral
+          . bytesToNatural
+          . hashToBytes
           . hashWithSerialiser @Blake2b_224 id
           $ toCBOR p <> toCBOR sk
    in (y, CertFakeVRF n realValue)
@@ -165,5 +167,6 @@ readBinaryWord16 =
 
 writeBinaryWord16 :: Word16 -> ByteString
 writeBinaryWord16 =
-  BS.reverse . fst
+  BS.reverse
+    . fst
     . BS.unfoldrN 2 (\w -> Just (fromIntegral w, unsafeShiftR w 8))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/CompactAddr.hs
@@ -112,10 +112,11 @@ propDecompactErrors addr = do
         mingleDropLength,
         mingleStaking
       ]
-  pure $
-    counterexample
+  pure
+    $ counterexample
       ("Mingled address with " ++ mingler ++ " was parsed: " ++ show badAddr)
-      $ isLeft $ CA.decodeAddrEither @c badAddr
+    $ isLeft
+    $ CA.decodeAddrEither @c badAddr
 
 propDeserializeRewardAcntErrors :: forall c. CC.Crypto c => RewardAcnt c -> Gen Property
 propDeserializeRewardAcntErrors acnt = do
@@ -139,7 +140,8 @@ propDeserializeRewardAcntErrors acnt = do
         mingleAddLength,
         mingleDropLength
       ]
-  pure $
-    counterexample
+  pure
+    $ counterexample
       ("Mingled address with " ++ mingler ++ " was parsed: " ++ show badAddr)
-      $ isNothing $ CA.decodeRewardAcnt @c badAddr
+    $ isNothing
+    $ CA.decodeRewardAcnt @c badAddr

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Delegation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Delegation.hs
@@ -285,14 +285,16 @@ genDelegation
               if null availableDelegates
                 then pure Nothing
                 else
-                  mkCert <$> QC.elements availableDelegates
+                  mkCert
+                    <$> QC.elements availableDelegates
                     <*> QC.elements availablePools
             ),
             ( frequencyScriptCredDelegation,
               if null availableDelegatesScripts
                 then pure Nothing
                 else
-                  mkCertFromScript <$> QC.elements availableDelegatesScripts
+                  mkCertFromScript
+                    <$> QC.elements availableDelegatesScripts
                     <*> QC.elements availablePools
             )
           ]
@@ -462,13 +464,15 @@ genInstantaneousRewardsAccounts s genesisDelegatesByHash pparams accountState de
           (Map.lookup gk genesisDelegatesByHash)
       credentials = rewards delegSt
   winnerCreds <-
-    take <$> QC.elements [0 .. (max 0 $ UM.size credentials - 1)]
+    take
+      <$> QC.elements [0 .. (max 0 $ UM.size credentials - 1)]
       <*> QC.shuffle (Set.toList (UM.domain credentials))
   coins <- replicateM (length winnerCreds) $ genInteger 1 1000
   let credCoinMap = Map.fromList $ zip winnerCreds (fmap DeltaCoin coins)
 
   coreSigners <-
-    take <$> QC.elements [5 .. (max 0 $ length genDelegs_ - 1)]
+    take
+      <$> QC.elements [5 .. (max 0 $ length genDelegs_ - 1)]
       <*> QC.shuffle (lookupGenDelegate' . genDelegKeyHash <$> Map.elems genDelegs_)
 
   pot <- QC.elements [ReservesMIR, TreasuryMIR]
@@ -510,7 +514,8 @@ genInstantaneousRewardsTransfer s genesisDelegatesByHash pparams accountState de
           (Map.lookup gk genesisDelegatesByHash)
 
   coreSigners <-
-    take <$> QC.elements [5 .. (max 0 $ length genDelegs_ - 1)]
+    take
+      <$> QC.elements [5 .. (max 0 $ length genDelegs_ - 1)]
       <*> QC.shuffle (lookupGenDelegate' . genDelegKeyHash <$> Map.elems genDelegs_)
 
   pot <- QC.elements [ReservesMIR, TreasuryMIR]

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Metadata.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Metadata.hs
@@ -49,7 +49,8 @@ genMetadata' = do
 -- | Generate one of the Metadatum
 genMetadatum :: Gen (Word64, Metadatum)
 genMetadatum = do
-  (,) <$> QC.arbitrary
+  (,)
+    <$> QC.arbitrary
     <*> ( QC.oneof
             [ genDatumInt,
               genDatumString,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -98,7 +98,8 @@ genIntervalInThousands lower upper =
 
 genPParams :: Constants -> Gen (ShelleyPParams era)
 genPParams c@Constants {maxMinFeeA, maxMinFeeB, minMajorPV} =
-  mkPParams <$> genNatural 0 maxMinFeeA -- _minfeeA
+  mkPParams
+    <$> genNatural 0 maxMinFeeA -- _minfeeA
     <*> genNatural 0 maxMinFeeB -- _minfeeB
     <*> szGen -- (maxBBSize, maxBHSize, maxTxSize)
     <*> genKeyDeposit

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -424,7 +424,8 @@ checkPreservation SourceSignalTarget {source, target, signal} =
     txs = map dispTx (zip txs' [0 :: Int ..])
 
     dispTx (tx, ix) =
-      "\nTransaction " ++ show ix
+      "\nTransaction "
+        ++ show ix
         ++ "\nfee :"
         ++ show (tx ^. bodyTxL . feeTxBodyL)
         ++ "\nwithdrawals: "
@@ -455,7 +456,8 @@ checkWithdrawlBound SourceSignalTarget {source, signal, target} =
     rewardDelta :: Coin
     rewardDelta =
       fold
-        ( rewards . dpsDState
+        ( rewards
+            . dpsDState
             . lsDPState
             . esLState
             . nesEs
@@ -463,7 +465,8 @@ checkWithdrawlBound SourceSignalTarget {source, signal, target} =
             $ source
         )
         <-> fold
-          ( rewards . dpsDState
+          ( rewards
+              . dpsDState
               . lsDPState
               . esLState
               . nesEs
@@ -483,8 +486,10 @@ utxoDepositsIncreaseByFeesWithdrawals ::
   Property
 utxoDepositsIncreaseByFeesWithdrawals SourceSignalTarget {source, signal, target} =
   counterexample "utxoDepositsIncreaseByFeesWithdrawals" $
-    circulation target <-> circulation source
-      === withdrawals signal <-> txFees ledgerTr
+    circulation target
+      <-> circulation source
+      === withdrawals signal
+      <-> txFees ledgerTr
   where
     us = lsUTxOState . esLState . nesEs . chainNes
     circulation chainSt =
@@ -533,8 +538,9 @@ potsSumIncreaseWdrlsPerTx SourceSignalTarget {source = chainSt, signal = block} 
           target = LedgerState UTxOState {_utxo = u', _deposited = d', _fees = f'} _
         } =
         property (hasFailedScripts tx)
-          .||. (coinBalance u' <+> d' <+> f') <-> (coinBalance u <+> d <+> f)
-          === fold (unWdrl (tx ^. bodyTxL . wdrlsTxBodyL))
+          .||. (coinBalance u' <+> d' <+> f')
+            <-> (coinBalance u <+> d <+> f)
+            === fold (unWdrl (tx ^. bodyTxL . wdrlsTxBodyL))
 
 -- | (Utxo + Deposits + Fees) increases by the reward delta
 potsSumIncreaseByRewardsPerTx ::
@@ -563,8 +569,10 @@ potsSumIncreaseByRewardsPerTx SourceSignalTarget {source = chainSt, signal = blo
               UTxOState {_utxo = u', _deposited = d', _fees = f'}
               DPState {dpsDState = DState {_unified = umap2}}
         } =
-        (coinBalance u' <+> d' <+> f') <-> (coinBalance u <+> d <+> f)
-          === fold (UM.unUnify (UM.Rewards umap1)) <-> fold (UM.unUnify (UM.Rewards umap2))
+        (coinBalance u' <+> d' <+> f')
+          <-> (coinBalance u <+> d <+> f)
+          === fold (UM.unUnify (UM.Rewards umap1))
+          <-> fold (UM.unUnify (UM.Rewards umap2))
 
 -- | The Rewards pot decreases by the sum of withdrawals in a transaction
 potsRewardsDecreaseByWdrlsPerTx ::

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -170,7 +170,11 @@ data RawSeed = RawSeed !Word64 !Word64 !Word64 !Word64 !Word64
 instance Arbitrary RawSeed where
   arbitrary =
     RawSeed
-      <$> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny
+      <$> chooseAny
+      <*> chooseAny
+      <*> chooseAny
+      <*> chooseAny
+      <*> chooseAny
 
 instance ToCBOR RawSeed where
   toCBOR (RawSeed w1 w2 w3 w4 w5) = toCBOR (w1, w2, w3, w4, w5)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -173,7 +173,8 @@ initStPoolLifetime = initSt initUTxO
 
 aliceCoinEx1 :: Coin
 aliceCoinEx1 =
-  aliceInitCoin <-> _poolDeposit ppEx
+  aliceInitCoin
+    <-> _poolDeposit ppEx
     <-> ((3 :: Integer) <×> _keyDeposit ppEx)
     <-> Coin 3
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -130,7 +130,8 @@ alicePoolParams =
       _poolRelays =
         StrictSeq.singleton $
           SingleHostName SNothing $
-            fromJust $ textToDns "relay.io",
+            fromJust $
+              textToDns "relay.io",
       _poolMD =
         SJust $
           PoolMetadata

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Address.hs
@@ -118,14 +118,16 @@ goldenTests_MockCrypto =
     keyHashHex = "01020304a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9c0c1c2c3c4"
     keyHash :: Credential kh StandardCrypto
     keyHash =
-      KeyHashObj . KeyHash
+      KeyHashObj
+        . KeyHash
         . fromMaybe (error "Unable to decode")
         $ hashFromTextAsHex keyHashHex
     scriptHashHex :: IsString s => s
     scriptHashHex = "05060708b5b6b7b8d5d6d7d8d9e0e1e2e3e4e5e6e7e8e9f0f1f2f3f4"
     scriptHash :: Credential kh StandardCrypto
     scriptHash =
-      ScriptHashObj . ScriptHash
+      ScriptHashObj
+        . ScriptHash
         . fromMaybe (error "Unable to decode")
         $ hashFromTextAsHex scriptHashHex
     ptrHex :: IsString s => s
@@ -208,7 +210,8 @@ goldenTests_ShelleyCrypto =
     -- and should be 28-byte in the aftermath
     keyBlake2b224 :: BS.ByteString -> Credential kh StandardCrypto
     keyBlake2b224 vk =
-      KeyHashObj . KeyHash
+      KeyHashObj
+        . KeyHash
         . fromMaybe (error "Supplied bytes are of unexpected length")
         $ hashFromBytes hk
       where

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -247,16 +247,16 @@ testCheckLeaderVal =
             == False,
       testProperty "checkLeaderVal succeeds iff l < 1 - (1-f)^r" $
         \(VRFNatVal n) (ASC f) (StakeProportion r) ->
-          r > 0
-            ==> let ascVal :: Double
-                    ascVal = fromRational . unboundRational $ activeSlotVal f
-                 in checkLeaderValue @v
-                      (VRF.mkTestOutputVRF n)
-                      r
-                      f
-                      === ( (realToFrac n / realToFrac (maxVRFVal + 1))
-                              < (1 - (1 - ascVal) ** fromRational r)
-                          ),
+          r > 0 ==>
+            let ascVal :: Double
+                ascVal = fromRational . unboundRational $ activeSlotVal f
+             in checkLeaderValue @v
+                  (VRF.mkTestOutputVRF n)
+                  r
+                  f
+                  === ( (realToFrac n / realToFrac (maxVRFVal + 1))
+                          < (1 - (1 - ascVal) ** fromRational r)
+                      ),
       -- Suppose that our VRF value V is drawn uniformly from [0, maxVRFVal).
       -- The leader check verifies that fromNat V < 1 - (1-f)^r, where fromNat
       -- is an appropriate mapping into the unit interval giving fromNat V ~
@@ -274,41 +274,41 @@ testCheckLeaderVal =
       --
       testProperty "We are elected as leader proportional to our stake" $
         \(ASC f) (StakeProportion r) ->
-          r > 0
-            ==> let ascVal :: Double
-                    ascVal = fromRational . unboundRational $ activeSlotVal f
-                    numTrials = 500
-                    -- 4 standard deviations
-                    δ = 4 * sqrt (realToFrac numTrials * p * (1 - p))
-                    p = 1 - (1 - ascVal) ** fromRational r
-                    mean = realToFrac numTrials * p
-                    maxVRFValInt :: Integer
-                    maxVRFValInt = fromIntegral maxVRFVal
-                    lb = floor (mean - δ)
-                    ub = ceiling (mean + δ)
-                 in do
-                      vrfVals <- Gen.vectorOf numTrials (Gen.choose (0, maxVRFValInt))
-                      let s =
-                            length . filter id $
-                              ( \v ->
-                                  checkLeaderValue @v
-                                    (VRF.mkTestOutputVRF $ fromIntegral v)
-                                    r
-                                    f
-                              )
-                                <$> vrfVals
-                      pure
-                        . counterexample
-                          ( show lb
-                              ++ " /< "
-                              ++ show s
-                              ++ " /< "
-                              ++ show ub
-                              ++ " (p="
-                              ++ show p
-                              ++ ")"
+          r > 0 ==>
+            let ascVal :: Double
+                ascVal = fromRational . unboundRational $ activeSlotVal f
+                numTrials = 500
+                -- 4 standard deviations
+                δ = 4 * sqrt (realToFrac numTrials * p * (1 - p))
+                p = 1 - (1 - ascVal) ** fromRational r
+                mean = realToFrac numTrials * p
+                maxVRFValInt :: Integer
+                maxVRFValInt = fromIntegral maxVRFVal
+                lb = floor (mean - δ)
+                ub = ceiling (mean + δ)
+             in do
+                  vrfVals <- Gen.vectorOf numTrials (Gen.choose (0, maxVRFValInt))
+                  let s =
+                        length . filter id $
+                          ( \v ->
+                              checkLeaderValue @v
+                                (VRF.mkTestOutputVRF $ fromIntegral v)
+                                r
+                                f
                           )
-                        $ s > lb && s < ub
+                            <$> vrfVals
+                  pure
+                    . counterexample
+                      ( show lb
+                          ++ " /< "
+                          ++ show s
+                          ++ " /< "
+                          ++ show ub
+                          ++ " (p="
+                          ++ show p
+                          ++ ")"
+                      )
+                    $ s > lb && s < ub
     ]
   where
     maxVRFVal :: Natural
@@ -413,17 +413,17 @@ testSpendNonexistentInput =
     [ UtxowFailure (UtxoFailure (ValueNotConservedUTxO (Coin 0) (Coin 10000))),
       UtxowFailure (UtxoFailure $ BadInputsUTxO (Set.singleton $ mkGenesisTxIn 42))
     ]
-    $ aliceGivesBobLovelace $
-      AliceToBob
-        { input = mkGenesisTxIn 42, -- Non Existent
-          toBob = Coin 3000,
-          fee = Coin 1500,
-          deposits = Coin 0,
-          refunds = Coin 0,
-          certs = [],
-          ttl = SlotNo 100,
-          signers = [asWitness alicePay]
-        }
+    $ aliceGivesBobLovelace
+    $ AliceToBob
+      { input = mkGenesisTxIn 42, -- Non Existent
+        toBob = Coin 3000,
+        fee = Coin 1500,
+        deposits = Coin 0,
+        refunds = Coin 0,
+        certs = [],
+        ttl = SlotNo 100,
+        signers = [asWitness alicePay]
+      }
 
 testWitnessNotIncluded :: Assertion
 testWitnessNotIncluded =
@@ -646,17 +646,17 @@ testOutputTooSmall :: Assertion
 testOutputTooSmall =
   testInvalidTx
     [UtxowFailure (UtxoFailure $ OutputTooSmallUTxO [ShelleyTxOut bobAddr (Coin 1)])]
-    $ aliceGivesBobLovelace $
-      AliceToBob
-        { input = TxIn genesisId minBound,
-          toBob = Coin 1, -- Too Small
-          fee = Coin 997,
-          deposits = Coin 0,
-          refunds = Coin 0,
-          certs = [],
-          ttl = SlotNo 0,
-          signers = [asWitness alicePay]
-        }
+    $ aliceGivesBobLovelace
+    $ AliceToBob
+      { input = TxIn genesisId minBound,
+        toBob = Coin 1, -- Too Small
+        fee = Coin 997,
+        deposits = Coin 0,
+        refunds = Coin 0,
+        certs = [],
+        ttl = SlotNo 0,
+        signers = [asWitness alicePay]
+      }
 
 alicePoolColdKeys :: KeyPair 'StakePool C_Crypto
 alicePoolColdKeys = KeyPair vk sk
@@ -695,22 +695,22 @@ testPoolCostTooSmall =
             )
         )
     ]
-    $ aliceGivesBobLovelace $
-      AliceToBob
-        { input = TxIn genesisId minBound,
-          toBob = Coin 100,
-          fee = Coin 997,
-          deposits = Coin 250,
-          refunds = Coin 0,
-          certs = [DCertPool $ RegPool alicePoolParamsSmallCost],
-          ttl = SlotNo 0,
-          signers =
-            ( [ asWitness alicePay,
-                asWitness aliceStake,
-                asWitness alicePoolColdKeys
-              ]
-            )
-        }
+    $ aliceGivesBobLovelace
+    $ AliceToBob
+      { input = TxIn genesisId minBound,
+        toBob = Coin 100,
+        fee = Coin 997,
+        deposits = Coin 250,
+        refunds = Coin 0,
+        certs = [DCertPool $ RegPool alicePoolParamsSmallCost],
+        ttl = SlotNo 0,
+        signers =
+          ( [ asWitness alicePay,
+              asWitness aliceStake,
+              asWitness alicePoolColdKeys
+            ]
+          )
+      }
 
 testProducedOverMaxWord64 :: Assertion
 testProducedOverMaxWord64 =

--- a/hie.yaml
+++ b/hie.yaml
@@ -90,6 +90,15 @@ cradle:
     - path: "libs/cardano-data/test"
       component: "test:cardano-data-tests"
 
+    - path: "libs/cardano-ledger-binary/src"
+      component: "cardano-ledger-binary:lib:cardano-ledger-binary"
+
+    - path: "libs/cardano-ledger-binary/test-lib"
+      component: "cardano-ledger-binary:lib:testlib"
+
+    - path: "libs/cardano-ledger-binary/test"
+      component: "cardano-ledger-binary:test:tests"
+
     - path: "libs/small-steps/src"
       component: "lib:small-steps-test"
 

--- a/libs/cardano-data/src/Data/BiMap.hs
+++ b/libs/cardano-data/src/Data/BiMap.hs
@@ -83,7 +83,8 @@ decodeMapAsBimap ::
 decodeMapAsBimap = do
   bimap@(MkBiMap mf mb) <- decodeMapSkel biMapFromAscDistinctList
   unless (Map.valid mf && Map.valid mb) $
-    cborError $ DecoderErrorCustom "BiMap" "Expected distinct keys in ascending order"
+    cborError $
+      DecoderErrorCustom "BiMap" "Expected distinct keys in ascending order"
   pure bimap
 
 instance (NoThunks a, NoThunks b) => NoThunks (BiMap v a b) where

--- a/libs/cardano-data/src/Data/Coders.hs
+++ b/libs/cardano-data/src/Data/Coders.hs
@@ -972,7 +972,9 @@ decodeRecordSum name decoder = do
   case lenOrIndef of
     Just n ->
       let errMsg =
-            "\nSum " ++ name ++ "\nreturned="
+            "\nSum "
+              ++ name
+              ++ "\nreturned="
               ++ show size
               ++ " actually read= "
               ++ show n

--- a/libs/cardano-data/test/Test/Data/Coders.hs
+++ b/libs/cardano-data/test/Test/Data/Coders.hs
@@ -211,13 +211,15 @@ biggerItems = toFlatTerm (encode (encBigger bigger))
 
 decBigger :: Decode ('Closed 'Dense) Bigger
 decBigger =
-  RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
+  RecD Bigger
+    <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
     <! (RecD Two <! From <! From)
     <! (RecD Big <! From <! From <! From)
 
 encBigger :: Bigger -> Encode ('Closed 'Dense) Bigger
 encBigger (Bigger (Test a (Two b c) d) (Two e f) (Big g h i)) =
-  Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
+  Rec Bigger
+    !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
     !> (Rec Two !> To e !> To f)
     !> (Rec Big !> To g !> To h !> To i)
 

--- a/libs/cardano-ledger-binary/.ghcid
+++ b/libs/cardano-ledger-binary/.ghcid
@@ -1,0 +1,1 @@
+-c "nix-shell ../../shell.nix --run \"cabal repl cardano-ledger-binary\"" -o ghcid.txt

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for cardano-ledger-binary
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/libs/cardano-ledger-binary/Setup.hs
+++ b/libs/cardano-ledger-binary/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,0 +1,143 @@
+cabal-version: 3.0
+
+name:                cardano-ledger-binary
+version:             0.1.0.0
+synopsis:            Binary serialization library used throughout ledger
+homepage:            https://github.com/input-output-hk/cardano-ledger
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+category:            Network
+build-type:          Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/cardano-ledger-binary
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:
+                     Cardano.Ledger.Binary
+                     Cardano.Ledger.Binary.Coders
+                     Cardano.Ledger.Binary.Decoding
+                     Cardano.Ledger.Binary.Encoding
+                     Cardano.Ledger.Binary.FlatTerm
+                     Cardano.Ledger.Binary.Version
+  other-modules:
+                     Cardano.Ledger.Binary.Encoding.Coders
+                     Cardano.Ledger.Binary.Encoding.Encoder
+                     Cardano.Ledger.Binary.Encoding.ToCBOR
+                     Cardano.Ledger.Binary.Decoding.Annotated
+                     Cardano.Ledger.Binary.Decoding.Coders
+                     Cardano.Ledger.Binary.Decoding.Decoder
+                     Cardano.Ledger.Binary.Decoding.Drop
+                     Cardano.Ledger.Binary.Decoding.FromCBOR
+                     Cardano.Ledger.Binary.Decoding.Sharing
+                     Cardano.Ledger.Binary.Decoding.Sized
+
+  build-depends:       base >=4.11 && <5
+                     , binary
+                     , bytestring
+                     , cardano-binary
+                     , cardano-strict-containers
+                     , cborg
+                     , containers
+                     , data-fix
+                     , deepseq
+                     , formatting
+                     , iproute
+                     , microlens
+                     , mtl
+                     , network
+                     , nothunks
+                     , primitive
+                     , recursion-schemes
+                     , tagged
+                     , text
+                     , time
+                     , transformers >= 0.5
+                     , vector
+                     , vector-map
+  hs-source-dirs:      src
+
+library testlib
+  import:               base, project-config
+  visibility: public
+  hs-source-dirs: test-lib
+  exposed-modules:
+                        Test.Cardano.Ledger.Binary.Arbitrary
+                      , Test.Cardano.Ledger.Binary.RoundTrip
+                      , Test.Cardano.Ledger.Binary.TreeDiff
+                      , Test.Cardano.Ledger.Binary.Twiddle
+  build-depends:        base
+                      , bytestring
+                      , base16-bytestring
+                      , cardano-ledger-binary
+                      , cborg
+                      , containers
+                      , cardano-strict-containers
+                      , tree-diff
+                      , iproute
+                      , hspec
+                      , primitive
+                      , QuickCheck
+                      , quickcheck-instances
+                      , text
+                      , vector
+                      , vector-map
+
+
+test-suite tests
+  import:               base, project-config
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  type:                 exitcode-stdio-1.0
+
+  other-modules:        Test.Cardano.Ledger.Binary.RoundTripSpec
+                      , Test.Cardano.Ledger.Binary.Vintage.Coders
+                      , Test.Cardano.Ledger.Binary.Vintage.Drop
+                      , Test.Cardano.Ledger.Binary.Vintage.Failure
+                      , Test.Cardano.Ledger.Binary.Vintage.Helpers
+                      , Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+                      , Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+                      , Test.Cardano.Ledger.Binary.Vintage.Serialization
+                      , Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-ledger-binary
+                      , cardano-prelude-test
+                      , cardano-strict-containers
+                      , cborg
+                      , containers
+                      , formatting
+                      , hedgehog
+                      , hspec
+                      , iproute
+                      , pretty-show
+                      , primitive
+                      , QuickCheck
+                      , tagged
+                      , text
+                      , testlib
+                      , time
+                      , vector
+                      , vector-map
+
+  ghc-options:          -threaded
+                        -rtsopts

--- a/libs/cardano-ledger-binary/default.nix
+++ b/libs/cardano-ledger-binary/default.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import ../../../default.nix {};
+in
+  pkgs.libs.cardano-ledger-binary

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Cardano.Ledger.Binary
+  ( module Cardano.Ledger.Binary.Decoding,
+    module Cardano.Ledger.Binary.Encoding,
+    module Cardano.Ledger.Binary.Version,
+    Term (..),
+    C.DeserialiseFailure (..),
+    translateViaCBORAnnotator,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding
+import Cardano.Ledger.Binary.Encoding
+import Cardano.Ledger.Binary.Version
+import qualified Codec.CBOR.Read as C (DeserialiseFailure (..))
+import Codec.CBOR.Term (Term (..))
+import Control.Monad.Except (Except, MonadError (throwError))
+import Data.Text (Text)
+
+-- | Translate one type into another through their common binary format. This is
+-- useful for types that build upon one another and are "upgradeable". It is
+-- important to note that the deserialization will happen with `Annotator`,
+-- since that is usually the way to deserialize upgradeable types that live on
+-- chain.
+translateViaCBORAnnotator ::
+  (ToCBOR a, FromCBOR (Annotator b)) =>
+  Version ->
+  Text ->
+  a ->
+  Except DecoderError b
+translateViaCBORAnnotator version name x =
+  case decodeFullAnnotator version name fromCBOR (serialize version x) of
+    Right newx -> pure newx
+    Left decoderError -> throwError decoderError

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Coders.hs
@@ -1,0 +1,30 @@
+-- | "Cardano.Ledger.Binary.Coders" provides tools for writing 'ToCBOR' and 'FromCBOR'
+--   instances (see module 'Cardano.Ledger.Binary') in an intuitive way that mirrors the way one
+--   constructs values of a particular type. Advantages include:
+--
+-- 1. Book-keeping details neccesary to write correct instances are hidden from the user.
+-- 2. Inverse 'ToCBOR' and 'FromCBOR' instances have visually similar definitions.
+-- 3. Advanced instances involving sparse-encoding, compact-representation, and
+-- 'Annotator' instances are also supported.
+--
+-- A Guide to Visual inspection of Duality in Encode and Decode
+--
+-- 1. @(Sum c)@     and @(SumD c)@    are duals
+-- 2. @(Rec c)@     and @(RecD c)@    are duals
+-- 3. @(Keyed c)@   and @(KeyedD c)@  are duals
+-- 4. @(OmitC x)@   and @(Emit x)@    are duals
+-- 5. @(Omit p ..)@ and @(Emit x)@    are duals if (p x) is True
+-- 6. @(To x)@      and @(From)@      are duals if (x::T) and (forall (y::T). isRight (roundTrip y))
+-- 7. @(E enc x)@   and @(D dec)@     are duals if (forall x . isRight (roundTrip' enc dec x))
+-- 8. @(f !> x)@    and @(g <! y)@    are duals if (f and g are duals) and (x and y are duals)
+--
+-- Duality properties of @(Summands name decodeT)@ and @(SparseKeyed name (init::T) pick
+-- required)@ also exist but are harder to describe succinctly.
+module Cardano.Ledger.Binary.Coders
+  ( module Cardano.Ledger.Binary.Encoding.Coders,
+    module Cardano.Ledger.Binary.Decoding.Coders,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Coders
+import Cardano.Ledger.Binary.Encoding.Coders

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Binary.Decoding
+  ( -- * Running decoders
+    decodeFull,
+    decodeFull',
+    decodeFullDecoder,
+    decodeFullDecoder',
+    decodeFullAnnotator,
+    decodeFullAnnotatedBytes,
+    module Cardano.Ledger.Binary.Version,
+    module Cardano.Ledger.Binary.Decoding.FromCBOR,
+    module Cardano.Ledger.Binary.Decoding.Sharing,
+    module Cardano.Ledger.Binary.Decoding.Decoder,
+    module Cardano.Ledger.Binary.Decoding.Annotated,
+    module Cardano.Ledger.Binary.Decoding.Sized,
+    module Cardano.Ledger.Binary.Decoding.Drop,
+
+    -- * Nested CBOR in CBOR
+    decodeNestedCbor,
+    decodeNestedCborBytes,
+
+    -- * Unsafe deserialization
+    unsafeDeserialize,
+    unsafeDeserialize',
+
+    -- * Helpers
+    toStrictByteString,
+
+    -- * Deprecated
+    decodeAnnotator,
+    fromCBORMaybe,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Annotated
+import Cardano.Ledger.Binary.Decoding.Decoder
+import Cardano.Ledger.Binary.Decoding.Drop
+import Cardano.Ledger.Binary.Decoding.FromCBOR
+import Cardano.Ledger.Binary.Decoding.Sharing
+import Cardano.Ledger.Binary.Decoding.Sized
+import Cardano.Ledger.Binary.Version
+import Codec.CBOR.Read as Read (DeserialiseFailure, IDecode (..), deserialiseIncremental)
+import Codec.CBOR.Write (toStrictByteString)
+import Control.Exception (displayException)
+import Control.Monad (when)
+import Control.Monad.ST (ST, runST)
+import Data.Bifunctor (bimap)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Internal as BSL
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+
+-- | Deserialize a Haskell value from the external binary representation, which
+-- have been made using 'serialize' or a matching serialization functionilty in
+-- another language that uses CBOR format. Accepts lazy `BSL.ByteString` as
+-- input, for strict variant use `unsafeDeserialize'` instead.
+--
+-- This deserializaer is not safe for these reasons:
+--
+-- *  /Throws/: @'Read.DeserialiseFailure'@ if the given external
+--   representation is invalid or does not correspond to a value of the
+--   expected type.
+--
+-- * Decoding will not fail when the binary input is not consumed in full.
+unsafeDeserialize ::
+  FromCBOR a =>
+  Version ->
+  BSL.ByteString ->
+  a
+unsafeDeserialize version =
+  either (error . displayException) id . bimap fst fst . deserialiseDecoder version fromCBOR
+
+-- | Variant of 'unsafeDeserialize' that accepts a strict `BS.ByteString` as
+-- input.
+unsafeDeserialize' :: FromCBOR a => Version -> BS.ByteString -> a
+unsafeDeserialize' version = unsafeDeserialize version . BSL.fromStrict
+
+-- | Deserialize a Haskell value from a binary CBOR representation, failing if
+--   there are leftovers. In other words, the __Full__ here implies the contract
+--   on this function that the input must be consumed in its entirety by the
+--   decoder specified in `FromCBOR`.
+decodeFull :: forall a. FromCBOR a => Version -> BSL.ByteString -> Either DecoderError a
+decodeFull version = decodeFullDecoder version (label $ Proxy @a) fromCBOR
+
+-- | Same as `decodeFull`, except accepts a strict `BS.ByteString` as input
+-- instead of the lazy one.
+decodeFull' :: forall a. FromCBOR a => Version -> BS.ByteString -> Either DecoderError a
+decodeFull' version = decodeFull version . BSL.fromStrict
+
+-- | Same as `decodeFull`, except instead of relying on the `FromCBOR` instance
+-- the `Decoder` must be suplied manually.
+decodeFullDecoder ::
+  -- | Protocol version to be used during decoding.
+  Version ->
+  -- | Label for error reporting
+  Text ->
+  -- | The parser for the @ByteString@ to decode. It should decode the given
+  -- @ByteString@ into a value of type @a@
+  (forall s. Decoder s a) ->
+  -- | The @ByteString@ to decode
+  BSL.ByteString ->
+  Either DecoderError a
+decodeFullDecoder version lbl decoder bs =
+  case deserialiseDecoder version decoder bs of
+    Right (x, leftover) ->
+      if BS.null leftover
+        then pure x
+        else Left $ DecoderErrorLeftover lbl leftover
+    Left (e, _) -> Left $ DecoderErrorDeserialiseFailure lbl e
+
+-- | Same as `decodeFullDecoder`, except works on strict `BS.ByteString`
+decodeFullDecoder' ::
+  Version ->
+  Text ->
+  (forall s. Decoder s a) ->
+  BS.ByteString ->
+  Either DecoderError a
+decodeFullDecoder' version lbl decoder = decodeFullDecoder version lbl decoder . BSL.fromStrict
+
+-- | Deserialise a Haskell type from a 'BSL.ByteString' input, which be consumed
+-- incrementally using the provided 'Decoder'. Unlike `decodeFullDecoder` there
+-- is no requiremenet to consume all input, therefore left over binary input is
+-- returned upon sucessfull or failed deserialization.
+deserialiseDecoder ::
+  Version ->
+  (forall s. Decoder s a) ->
+  BSL.ByteString ->
+  Either (Read.DeserialiseFailure, BS.ByteString) (a, BS.ByteString)
+deserialiseDecoder version decoder bs0 =
+  runST (supplyAllInput bs0 =<< Read.deserialiseIncremental (toPlainDecoder version decoder))
+
+supplyAllInput ::
+  BSL.ByteString ->
+  Read.IDecode s a ->
+  ST s (Either (Read.DeserialiseFailure, BS.ByteString) (a, BS.ByteString))
+supplyAllInput bs' (Read.Done bs _ x) =
+  return (Right (x, bs <> BSL.toStrict bs'))
+supplyAllInput bs (Read.Partial k) = case bs of
+  BSL.Chunk chunk bs' -> k (Just chunk) >>= supplyAllInput bs'
+  BSL.Empty -> k Nothing >>= supplyAllInput BSL.Empty
+supplyAllInput _ (Read.Fail bs _ exn) = return (Left (exn, bs))
+
+--------------------------------------------------------------------------------
+-- Annotator
+--------------------------------------------------------------------------------
+
+-- | Same as `decodeFullDecoder`, except it provdes the means of passing portion or all
+-- of the `BSL.ByteString` input argument to the decoding `Annotator`.
+decodeFullAnnotator ::
+  Version ->
+  Text ->
+  (forall s. Decoder s (Annotator a)) ->
+  BSL.ByteString ->
+  Either DecoderError a
+decodeFullAnnotator v lbl decoder bytes =
+  (\x -> runAnnotator x (Full bytes)) <$> decodeFullDecoder v lbl decoder bytes
+
+-- | Same as `decodeFullDecoder`, decodes a Haskell value from a lazy
+-- `BSL.ByteString`, requiring that the full ByteString is consumed, and
+-- replaces `ByteSpan` annotations with the corresponding slice of the input as
+-- a strict `BS.ByteString`.
+decodeFullAnnotatedBytes ::
+  Functor f =>
+  Version ->
+  Text ->
+  (forall s. Decoder s (f ByteSpan)) ->
+  BSL.ByteString ->
+  Either DecoderError (f BS.ByteString)
+decodeFullAnnotatedBytes v lbl decoder bytes =
+  annotationBytes bytes <$> decodeFullDecoder v lbl decoder bytes
+
+--------------------------------------------------------------------------------
+-- Nested CBOR-in-CBOR
+-- https://tools.ietf.org/html/rfc7049#section-2.4.4.1
+--------------------------------------------------------------------------------
+
+-- | Remove the the semantic tag 24 from the enclosed CBOR data item,
+-- failing if the tag cannot be found.
+decodeNestedCborTag :: Decoder s ()
+decodeNestedCborTag = do
+  t <- decodeTag
+  when (t /= 24) $
+    cborError $
+      DecoderErrorUnknownTag
+        "decodeNestedCborTag"
+        (fromIntegral t)
+
+-- | Remove the the semantic tag 24 from the enclosed CBOR data item,
+-- decoding back the inner `ByteString` as a proper Haskell type.
+-- Consume its input in full.
+decodeNestedCbor :: FromCBOR a => Decoder s a
+decodeNestedCbor = do
+  bs <- decodeNestedCborBytes
+  version <- getDecoderVersion
+  either cborError pure $ decodeFull' version bs
+
+-- | Like `decodeKnownCborDataItem`, but assumes nothing about the Haskell
+-- type we want to deserialise back, therefore it yields the `ByteString`
+-- Tag 24 surrounded (stripping such tag away).
+--
+-- In CBOR notation, if the data was serialised as:
+--
+-- >>> 24(h'DEADBEEF')
+--
+-- then `decodeNestedCborBytes` yields the inner 'DEADBEEF', unchanged.
+decodeNestedCborBytes :: Decoder s BS.ByteString
+decodeNestedCborBytes = do
+  decodeNestedCborTag
+  decodeBytes
+
+decodeAnnotator ::
+  Version ->
+  Text ->
+  (forall s. Decoder s (Annotator a)) ->
+  BSL.ByteString ->
+  Either DecoderError a
+decodeAnnotator = decodeFullAnnotator
+{-# DEPRECATED decodeAnnotator "In favor of `decodeFullAnnotator`" #-}
+
+fromCBORMaybe :: Decoder s a -> Decoder s (Maybe a)
+fromCBORMaybe = decodeMaybe
+{-# DEPRECATED fromCBORMaybe "In favor of `decodeMaybe`" #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Binary.Decoding.Annotated
+  ( C.Annotated (..),
+    C.ByteSpan (..),
+    C.Decoded (..),
+    C.annotationBytes,
+    annotatedDecoder,
+    C.slice,
+    fromCBORAnnotated,
+    reAnnotate,
+    C.Annotator (..),
+    annotatorSlice,
+    withSlice,
+    C.FullByteString (..),
+    decodeAnnSet,
+  )
+where
+
+import qualified Cardano.Binary as C
+import Cardano.Ledger.Binary.Decoding.Decoder (Decoder, decodeList, decodeWithByteSpan)
+import Cardano.Ledger.Binary.Decoding.FromCBOR (FromCBOR (..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Functor ((<&>))
+import qualified Data.Set as Set
+
+-- | A decoder for a value paired with an annotation specifying the start and end
+-- of the consumed bytes.
+annotatedDecoder :: Decoder s a -> Decoder s (C.Annotated a C.ByteSpan)
+annotatedDecoder vd =
+  decodeWithByteSpan vd <&> \(x, start, end) -> C.Annotated x (C.ByteSpan start end)
+
+-- | A decoder for a value paired with an annotation specifying the start and end
+-- of the consumed bytes.
+fromCBORAnnotated :: FromCBOR a => Decoder s (C.Annotated a C.ByteSpan)
+fromCBORAnnotated = annotatedDecoder fromCBOR
+
+-- | Reconstruct an annotation by re-serialising the payload to a ByteString.
+reAnnotate :: C.ToCBOR a => C.Annotated a b -> C.Annotated a BS.ByteString
+reAnnotate (C.Annotated x _) = C.Annotated x (C.serialize' x)
+
+-------------------------------------------------------------------------
+-- Annotator
+-------------------------------------------------------------------------
+
+-- | The argument is a decoder for a annotator that needs access to the bytes that
+-- | were decoded. This function constructs and supplies the relevant piece.
+annotatorSlice ::
+  Decoder s (C.Annotator (BSL.ByteString -> a)) ->
+  Decoder s (C.Annotator a)
+annotatorSlice dec = do
+  (k, bytes) <- withSlice dec
+  pure $ k <*> bytes
+
+-- | Pairs the decoder result with an annotator that can be used to construct the exact
+-- bytes used to decode the result.
+withSlice :: Decoder s a -> Decoder s (a, C.Annotator BSL.ByteString)
+withSlice dec = do
+  C.Annotated r byteSpan <- annotatedDecoder dec
+  return (r, C.Annotator (\(C.Full bsl) -> C.slice bsl byteSpan))
+
+-- TODO: Implement version that matches the length of a list with the size of the Set in
+-- order to enforce no duplicates.
+decodeAnnSet :: Ord t => Decoder s (C.Annotator t) -> Decoder s (C.Annotator (Set.Set t))
+decodeAnnSet dec = do
+  xs <- decodeList dec
+  pure (Set.fromList <$> sequence xs)

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
@@ -1,0 +1,581 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Binary.Decoding.Coders
+  ( -- * Creating decoders.
+
+    --
+    -- $Decoders
+    Decode (..),
+    (<!),
+    (<*!),
+    (<?),
+    decode,
+    decodeSparse,
+
+    -- * Index types for well-formed Coders.
+
+    --
+    -- $Indexes
+    Density (..),
+    Wrapped (..),
+    Field (..),
+    ofield,
+    invalidField,
+    field,
+    fieldA,
+    fieldAA,
+
+    -- * Using Duals .
+    decodeDual,
+
+    -- * Containers, Combinators
+
+    --
+    -- $Combinators
+    listDecodeA,
+    mapDecodeA,
+    setDecodeA,
+
+    -- * Low level (Encoding/Decoder) utility functions
+    decodeRecordNamed,
+    decodeRecordNamedT,
+    decodeRecordSum,
+    invalidKey,
+    unusedRequiredKeys,
+    duplicateKey,
+  )
+where
+
+import qualified Cardano.Binary as C
+import Cardano.Ledger.Binary.Decoding.Annotated (Annotator (..), decodeAnnSet)
+import Cardano.Ledger.Binary.Decoding.Decoder
+import Cardano.Ledger.Binary.Decoding.FromCBOR (FromCBOR (fromCBOR))
+import Control.Applicative (liftA2)
+import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Set (Set, insert, member)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Data.Typeable (Typeable, typeOf)
+import Data.Void (Void)
+
+-- ====================================================================
+
+-- ===============================================================================
+-- Encode and Decode are typed data structures which specify encoders and decoders
+-- for Algebraic data structures written in Haskell. They exploit types and count
+-- the correct number fields in an encoding and decoding, which are automatically computed.
+-- They are somewhat dual, and are designed so that visual inspection of a Encode and
+-- its dual Decode can help the user conclude that the two are self-consistent.
+-- They are also reusable abstractions that can be defined once, and then used many places.
+--
+-- (Encode t) is a data structure from which 3 things can be recovered
+-- Given:    x :: Encode t
+-- 1. get a value of type t
+-- 2. get an Encoding for that value, which correctly encodes the number of "fields"
+--    written to the ByteString. Care must still be taken that the Keys are correct.
+-- 3. get a (MemoBytes t)
+--
+-- The advantage of using Encode with a MemoBytes, is we don't have to make a ToCBOR
+-- instance. Instead the "instance" is spread amongst the pattern constuctors by using
+-- (memoBytes encoding) in the where clause of the pattern contructor.
+-- See some examples of this see the file Timelocks.hs
+--
+
+-- ========================================================
+-- Subsidary classes and datatype used in the Coders scheme
+-- =========================================================
+
+-- $Indexes
+--  Some CBOR instances wrap encoding sequences with prefixes and suffixes. I.e.
+--  prefix , encode, encode, encode , ... , suffix.
+--  There are two kinds of wrapping coders: Nary sums, and Sparsely encoded products.
+--  Coders in these classes can only be decoded when they are wrapped by their
+--  closing forms 'Summands' and 'SparseKeyed'. Another dimension, where we use indexes
+--  to maintain type safety, are records which can be
+--  encoded densely (all their fields serialised) or sparsely (only some of their
+--  fields). We use indexes to types to try and mark (and enforce) these distinctions.
+
+-- | Index for record density. Distinguishing (all the fields) from (some of the fields).
+data Density = Dense | Sparse
+
+-- | Index for a wrapped Coder. Wrapping is necessary for 'Summands' and 'SparseKeyed'.
+data Wrapped where
+  Open :: Wrapped -- Needs some type-wide wrapping
+  Closed :: Density -> Wrapped -- Does not need type-wide wrapping,
+  -- But may need field-wide wrapping, when Density is 'Sparse
+
+-- | A Field pairs an update function and a decoder for one field of a Sparse record.
+data Field t where
+  Field :: (x -> t -> t) -> (forall s. Decoder s x) -> Field t
+
+{-# INLINE field #-}
+field :: (x -> t -> t) -> Decode ('Closed d) x -> Field t
+field update dec = Field update (decode dec)
+
+{-# INLINE ofield #-}
+ofield :: (StrictMaybe x -> t -> t) -> Decode ('Closed d) x -> Field t
+ofield update dec = Field update (SJust <$> decode dec)
+
+{-# INLINE invalidField #-}
+invalidField :: forall t. Word -> Field t
+invalidField n = field (flip $ const @t @Void) (Invalid n)
+
+-- | Sparse decode something with a (FromCBOR (Annotator t)) instance
+-- A special case of 'field'
+fieldA :: (Applicative ann) => (x -> t -> t) -> Decode ('Closed d) x -> Field (ann t)
+fieldA update dec = Field (liftA2 update) (pure <$> decode dec)
+
+-- | Sparse decode something with a (FromCBOR (Annotator t)) instance
+fieldAA ::
+  (Applicative ann) =>
+  (x -> t -> t) ->
+  Decode ('Closed d) (ann x) ->
+  Field (ann t)
+fieldAA update dec = Field (liftA2 update) (decode dec)
+
+-- ==================================================================
+-- Decode
+-- ===================================================================
+
+-- | The type @('Decode' t)@ is designed to be dual to @('Encode' t)@. It was designed so that
+-- in many cases a decoder can be extracted from an encoder by visual inspection. We now give some
+-- example of @(Decode t)@  and  @(Encode t)@ pairs.
+--
+--
+-- An example with 1 constructor (a record) uses 'Rec' and 'RecD'
+--
+-- In this example, let @Int@ and @C@ have 'ToCBOR' instances.
+--
+-- @
+-- data C = C { unC :: Text.Text }
+-- instance ToCBOR C where
+--   toCBOR (C t) = toCBOR t
+-- instance FromCBOR C where
+--   fromCBOR = C <$> fromCBOR
+--
+-- data B = B { unB :: Text.Text }
+--
+-- data A = ACon Int B C
+--
+-- encodeA :: A -> Encode ('Closed 'Dense) A
+-- encodeA (ACon i b c) = Rec ACon !> To i !> E (toCBOR . unB) b !> To c
+--
+-- decodeA :: Decode ('Closed 'Dense) A
+-- decodeA = RecD ACon <! From <! D (B <$> fromCBOR) <! From
+--
+-- instance ToCBOR A where
+--   toCBOR = encode . encodeA
+-- instance FromCBOR A where
+--   fromCBOR = decode decodeA
+-- @
+--
+-- An example with multiple constructors uses 'Sum', 'SumD', and 'Summands'.
+--
+-- @
+-- data N = N1 Int | N2 B Bool | N3 A
+--
+-- encodeN :: N -> Encode 'Open N
+-- encodeN (N1 i)    = Sum N1 0 !> To i
+-- encodeN (N2 b tf) = Sum N2 1 !> E (toCBOR . unB) b !> To tf
+-- encodeN (N3 a)    = Sum N3 2 !> To a
+--
+-- decodeN :: Decode ('Closed 'Dense) N    -- Note each clause has an 'Open decoder,
+-- decodeN = Summands "N" decodeNx           -- But Summands returns a ('Closed 'Dense) decoder
+--   where decodeNx 0 = SumD N1 <! From
+--         decodeNx 1 = SumD N2 <! D (B <$> fromCBOR) <! From
+--         decodeNx 3 = SumD N3 <! From
+--         decodeNx k = Invalid k
+--
+-- instance ToCBOR N   where toCBOR x = encode(encodeN x)
+-- instance FromCBOR N where fromCBOR = decode decodeN
+-- @
+--
+-- Two examples using variants of sparse encoding for records, i.e. those datatypes with only one constructor.
+-- The Virtual constructor approach using 'Summands', 'OmitC', 'Emit'.
+-- The Sparse field approach using 'Keyed', 'Key' and 'Omit'. The approaches work
+-- because encoders and decoders don't put
+-- fields with default values in the Encoding, and reconstruct the default values on the decoding side.
+-- We will illustrate the two approaches using the datatype M
+--
+-- @
+-- data M = M Int [Bool] Text.Text
+--   deriving (Show, Typeable)
+--
+-- a0, a1, a2, a3 :: M  -- Some illustrative examples, using things that might be given default values.
+-- a0 = M 0 [] "ABC"
+-- a1 = M 0 [True] "ABC"
+-- a2 = M 9 [] "ABC"
+-- a3 = M 9 [False] "ABC"
+-- @
+--
+-- The virtual constructor strategy pretends there are mutiple constructors
+-- Even though there is only one. We use invariants about the data to avoid
+-- encoding some of the values. Note the use of 'Sum' with virtual constructor tags 0,1,2,3
+--
+-- @
+-- encM :: M -> Encode 'Open M
+-- encM (M 0 [] t) = Sum M 0 !> OmitC 0 !> OmitC [] !> To t
+-- encM (M 0 bs t) = Sum M 1 !> OmitC 0 !> To bs !> To t
+-- encM (M n [] t) = Sum M 2 !> To n !> OmitC [] !> To t
+-- encM (M n bs t) = Sum M 3 !> To n !> To bs !> To t
+--
+-- decM :: Word -> Decode 'Open M
+-- decM 0 = SumD M <! Emit 0 <! Emit [] <! From  -- The virtual constructors tell which fields have been Omited
+-- decM 1 = SumD M <! Emit 0 <! From <! From     -- So those fields are reconstructed using 'Emit'.
+-- decM 2 = SumD M <! From <! Emit [] <! From
+-- decM 3 = SumD M <! From <! From <! From
+-- decM n = Invalid n
+--
+-- instance ToCBOR M where
+--   toCBOR m = encode (encM m)
+--
+-- instance FromCBOR M where
+--   fromCBOR = decode (Summands "M" decM)
+-- @
+--
+-- The Sparse field approach uses N keys, one for each field that is not defaulted. For example
+-- @(M 9 [True] (pack "hi")))@. Here zero fields are defaulted, so there should be 3 keys.
+-- Encoding this example would look something like this.
+--
+-- @
+-- [TkMapLen 3,TkInt 0,TkInt 9,TkInt 1,TkListBegin,TkBool True,TkBreak,TkInt 2,TkString "hi"]
+--                   ^key            ^key                                    ^key
+-- @
+--
+-- So the user supplies a function, that encodes every field, each field must use a unique
+-- key, and fields with default values have Omit wrapped around the Key encoding.
+-- The user must ensure that there is NOT an Omit on a required field. 'encM2' is an example.
+--
+-- @
+-- encM2:: M -> Encode ('Closed 'Sparse) M
+-- encM2 (M n xs t) =
+--     Keyed M
+--        !> Omit (== 0) (Key 0 (To n))    -- Omit if n is zero
+--        !> Omit null (Key 1 (To xs))     -- Omit if xs is null
+--        !> Key 2 (To t)                  -- Always encode t
+-- @
+--
+-- To write an Decoder we must pair a decoder for each field, with a function that updates only
+-- that field. We use the 'Field' GADT to construct these pairs, and we must write a function, that
+-- for each field tag, picks out the correct pair. If the Encode and Decode don't agree on how the
+-- tags correspond to a particular field, things will fail.
+--
+-- @
+-- boxM :: Word -> Field M
+-- boxM 0 = field update0 From
+--   where
+--     update0 n (M _ xs t) = M n xs t
+-- boxM 1 = field update1 From
+--   where
+--     update1 xs (M n _ t) = M n xs t
+-- boxM 2 = field update2 From
+--   where
+--     update2 t (M n xs _) = M n xs t
+-- boxM n = invalidField n
+-- @
+--
+-- Finally there is a new constructor for 'Decode', called 'SparseKeyed', that decodes field
+-- keyed sparse objects. The user supplies an initial value and field function, and a list
+-- of tags of the required fields. The initial value should have default values and
+-- any well type value in required fields. If the encode function (baz above) is
+-- encoded properly the required fields in the initial value should always be over
+-- overwritten. If it is not written properly, or a bad encoding comes from somewhere
+-- else, the intial values in the required fields might survive decoding. The list
+-- of required fields is checked.
+--
+-- @
+-- instance FromCBOR M where
+--   fromCBOR = decode (SparseKeyed
+--                       "TT"                        -- ^ Name of the type being decoded
+--                       (M 0 [] (Text.pack "a"))  -- ^ The default value
+--                       boxM                      -- ^ The Field function
+--                       [(2, "Stringpart")]         -- ^ The required Fields
+--                     )
+--
+-- instance ToCBOR M where
+--   toCBOR m = encode(encM2 m)
+-- @
+data Decode (w :: Wrapped) t where
+  -- | Label the constructor of a Record-like datatype (one with exactly 1 constructor) as a Decode.
+  RecD :: t -> Decode ('Closed 'Dense) t
+  -- | Label the constructor of a Record-like datatype (one with multiple constructors) as an Decode.
+  SumD :: t -> Decode 'Open t
+  -- | Lift a Word to Decode function into a DeCode for a type with multiple constructors.
+  Summands :: String -> (Word -> Decode 'Open t) -> Decode ('Closed 'Dense) t
+  -- | Lift a Word to Field function into a DeCode for a type with 1 constructor stored sparsely
+  SparseKeyed ::
+    Typeable t =>
+    -- | Name of the Type (for error messages)
+    String ->
+    -- | The type with default values in all fields
+    t ->
+    -- | What to do with key in the @Word@
+    (Word -> Field t) ->
+    -- | Pairs of keys and Strings which must be there (default values not allowed)
+    [(Word, String)] ->
+    Decode ('Closed 'Dense) t
+  -- | Label a (component, field, argument) as sparsely stored, which will be populated
+  -- with the default value.
+  KeyedD :: t -> Decode ('Closed 'Sparse) t
+  -- | Label a (component, field, argument). It will be decoded using the existing
+  -- FromCBOR instance at @t@
+  From :: FromCBOR t => Decode w t
+  -- | Label a (component, field, argument). It will be decoded using the given decoder.
+  D :: (forall s. Decoder s t) -> Decode ('Closed 'Dense) t
+  -- | Apply a functional decoding (arising from 'RecD' or 'SumD') to get (type wise)
+  -- smaller decoding.
+  ApplyD :: Decode w1 (a -> t) -> Decode ('Closed d) a -> Decode w1 t
+  -- | Mark a Word as a Decoding which is not a valid Decoding. Used when decoding sums
+  -- that are tagged out of range.
+  Invalid :: Word -> Decode w t
+  -- | Used to make (Decode w) an instance of Functor.
+  Map :: (a -> b) -> Decode w a -> Decode w b
+  -- | Assert that the next thing decoded must be tagged with the given word.
+  TagD :: Word -> Decode ('Closed x) t -> Decode ('Closed x) t
+  -- | Decode the next thing, not by inspecting the bytes, but pulled out of thin air,
+  -- returning @t@. Used in sparse decoding.
+  Emit :: t -> Decode w t
+  -- The next two could be generalized to any (Applicative f) rather than Annotator
+
+  -- | Lift a @(Decode w t)@ to a @(Decode w (Annotator t))@. Used on a (component, field,
+  -- argument) that was not Annotator encoded, but contained in Record or Sum which is
+  -- Annotator encoded.
+  Ann :: Decode w t -> Decode w (Annotator t)
+  -- | Apply a functional decoding (arising from 'RecD' or 'SumD' that needs to be
+  -- Annotator decoded) to get (type wise) smaller decoding.
+  ApplyAnn ::
+    -- | A functional Decode
+    Decode w1 (Annotator (a -> t)) ->
+    -- | An Decoder for an Annotator
+    Decode ('Closed d) (Annotator a) ->
+    Decode w1 (Annotator t)
+  -- | the function to Either can raise an error when applied by returning (Left errorMessage)
+  ApplyErr :: Decode w1 (a -> Either String t) -> Decode ('Closed d) a -> Decode w1 t
+
+infixl 4 <!
+
+infixl 4 <*!
+
+infixl 4 <?
+
+-- | Infix form of @ApplyD@ with the same infixity and precedence as @($)@.
+(<!) :: Decode w1 (a -> t) -> Decode ('Closed w) a -> Decode w1 t
+x <! y = ApplyD x y
+
+-- | Infix form of @ApplyAnn@ with the same infixity and precedence as @($)@.
+(<*!) :: Decode w1 (Annotator (a -> t)) -> Decode ('Closed d) (Annotator a) -> Decode w1 (Annotator t)
+x <*! y = ApplyAnn x y
+
+-- | Infix form of @ApplyErr@ with the same infixity and precedence as @($)@.
+(<?) :: Decode w1 (a -> Either String t) -> Decode ('Closed d) a -> Decode w1 t
+f <? y = ApplyErr f y
+
+hsize :: Decode w t -> Int
+hsize (Summands _ _) = 1
+hsize (SumD _) = 0
+hsize (RecD _) = 0
+hsize (KeyedD _) = 0
+hsize From = 1
+hsize (D _) = 1
+hsize (ApplyD f x) = hsize f + hsize x
+hsize (Invalid _) = 0
+hsize (Map _ x) = hsize x
+hsize (Emit _) = 0
+hsize SparseKeyed {} = 1
+hsize (TagD _ _) = 1
+hsize (Ann x) = hsize x
+hsize (ApplyAnn f x) = hsize f + hsize x
+hsize (ApplyErr f x) = hsize f + hsize x
+
+decode :: Decode w t -> Decoder s t
+decode x = fmap snd (decodE x)
+
+decodE :: Decode w t -> Decoder s (Int, t)
+decodE x = decodeCount x 0
+
+decodeCount :: forall (w :: Wrapped) s t. Decode w t -> Int -> Decoder s (Int, t)
+decodeCount (Summands nm f) n = (n + 1,) <$> decodeRecordSum nm (decodE . f)
+decodeCount (SumD cn) n = pure (n + 1, cn)
+decodeCount (KeyedD cn) n = pure (n + 1, cn)
+decodeCount (RecD cn) n = decodeRecordNamed "RecD" (const n) (pure (n, cn))
+decodeCount From n = (n,) <$> fromCBOR
+decodeCount (D dec) n = (n,) <$> dec
+decodeCount (Invalid k) _ = invalidKey k
+decodeCount (Map f x) n = do (m, y) <- decodeCount x n; pure (m, f y)
+decodeCount (Emit x) n = pure (n, x)
+decodeCount (TagD expectedTag decoder) n = do
+  assertTag expectedTag
+  decodeCount decoder n
+decodeCount (SparseKeyed name initial pick required) n =
+  (n + 1,) <$> decodeSparse name initial pick required
+decodeCount (Ann x) n = do (m, y) <- decodeCount x n; pure (m, pure y)
+decodeCount (ApplyAnn g x) n = do
+  (i, f) <- decodeCount g (n + hsize x)
+  y <- decodeClosed x
+  pure (i, f <*> y)
+decodeCount (ApplyD cn g) n = do
+  (i, f) <- decodeCount cn (n + hsize g)
+  y <- decodeClosed g
+  pure (i, f y)
+decodeCount (ApplyErr cn g) n = do
+  (i, f) <- decodeCount cn (n + hsize g)
+  y <- decodeClosed g
+  case f y of
+    Right z -> pure (i, z)
+    Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
+
+-- The type of DecodeClosed precludes pattern match against (SumD c) as the types are different.
+
+decodeClosed :: Decode ('Closed d) t -> Decoder s t
+decodeClosed (Summands nm f) = decodeRecordSum nm (decodE . f)
+decodeClosed (KeyedD cn) = pure cn
+decodeClosed (RecD cn) = pure cn
+decodeClosed From = fromCBOR
+decodeClosed (D dec) = dec
+decodeClosed (ApplyD cn g) = do
+  f <- decodeClosed cn
+  y <- decodeClosed g
+  pure (f y)
+decodeClosed (Invalid k) = invalidKey k
+decodeClosed (Map f x) = f <$> decodeClosed x
+decodeClosed (Emit n) = pure n
+decodeClosed (TagD expectedTag decoder) = do
+  assertTag expectedTag
+  decodeClosed decoder
+decodeClosed (SparseKeyed name initial pick required) =
+  decodeSparse name initial pick required
+decodeClosed (Ann x) = fmap pure (decodeClosed x)
+decodeClosed (ApplyAnn g x) = do
+  f <- decodeClosed g
+  y <- decodeClosed x
+  pure (f <*> y)
+decodeClosed (ApplyErr cn g) = do
+  f <- decodeClosed cn
+  y <- decodeClosed g
+  case f y of
+    Right z -> pure z
+    Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
+
+decodeSparse ::
+  Typeable a =>
+  String ->
+  a ->
+  (Word -> Field a) ->
+  [(Word, String)] ->
+  Decoder s a
+decodeSparse name initial pick required = do
+  lenOrIndef <- decodeMapLenOrIndef
+  (!v, used) <- case lenOrIndef of
+    Just len -> getSparseBlock len initial pick Set.empty name
+    Nothing -> getSparseBlockIndef initial pick Set.empty name
+  if all (\(key, _name) -> member key used) required
+    then pure v
+    else unusedRequiredKeys used required (show (typeOf initial))
+
+-- | Given a function that picks a Field from a key, decodes that field
+--   and returns a (t -> t) transformer, which when applied, will
+--   update the record with the value decoded.
+applyField :: (Word -> Field t) -> Set Word -> String -> Decoder s (t -> t, Set Word)
+applyField f seen name = do
+  tag <- decodeWord
+  if Set.member tag seen
+    then duplicateKey name tag
+    else case f tag of
+      Field update d -> d >>= \v -> pure (update v, insert tag seen)
+
+-- | Decode a Map Block of key encoded data for type t
+--   given a function that picks the right box for a given key, and an
+--   initial value for the record (usually starts filled with default values).
+--   The Block can be either len-encoded or block-encoded.
+getSparseBlock :: Int -> t -> (Word -> Field t) -> Set Word -> String -> Decoder s (t, Set Word)
+getSparseBlock 0 initial _pick seen _name = pure (initial, seen)
+getSparseBlock n initial pick seen name = do
+  (transform, seen2) <- applyField pick seen name
+  getSparseBlock (n - 1) (transform initial) pick seen2 name
+
+getSparseBlockIndef :: t -> (Word -> Field t) -> Set Word -> String -> Decoder s (t, Set Word)
+getSparseBlockIndef initial pick seen name =
+  decodeBreakOr >>= \case
+    True -> pure (initial, seen)
+    False -> do
+      (transform, seen2) <- applyField pick seen name
+      getSparseBlockIndef (transform initial) pick seen2 name
+
+-- ======================================================
+-- (Decode ('Closed 'Dense)) and (Decode ('Closed 'Sparse)) are applicative
+-- (Decode 'Open) is not applicative since there is no
+-- (Applys 'Open 'Open) instance. And there should never be one.
+
+instance Functor (Decode w) where
+  fmap f (Map g x) = Map (f . g) x
+  fmap f x = Map f x
+
+instance Applicative (Decode ('Closed d)) where
+  pure x = Emit x
+  f <*> x = ApplyD f x
+
+-- | Use `Cardano.Ledger.Binary.Coders.encodeDual` and `decodeDual`, when you want to
+-- guarantee that a type has both `ToCBOR` and `FromCBR` instances.
+decodeDual :: forall t. (C.ToCBOR t, FromCBOR t) => Decode ('Closed 'Dense) t
+decodeDual = D fromCBOR
+  where
+    -- Enforce ToCBOR constraint on t
+    _toCBOR = C.toCBOR (undefined :: t)
+
+-- =============================================================================
+
+listDecodeA :: Decode ('Closed 'Dense) (Annotator x) -> Decode ('Closed 'Dense) (Annotator [x])
+listDecodeA dx = D (sequence <$> decodeList (decode dx))
+
+setDecodeA ::
+  Ord x =>
+  Decode ('Closed 'Dense) (Annotator x) ->
+  Decode ('Closed 'Dense) (Annotator (Set x))
+setDecodeA dx = D (decodeAnnSet (decode dx))
+
+mapDecodeA ::
+  Ord k =>
+  Decode ('Closed 'Dense) (Annotator k) ->
+  Decode ('Closed 'Dense) (Annotator v) ->
+  Decode ('Closed 'Dense) (Annotator (Map.Map k v))
+mapDecodeA k v = D (decodeMapTraverse (decode k) (decode v))
+
+--------------------------------------------------------------------------------
+-- Utility functions for working with CBOR
+--------------------------------------------------------------------------------
+
+invalidKey :: Word -> Decoder s a
+invalidKey k = cborError $ DecoderErrorCustom "not a valid key:" (Text.pack $ show k)
+
+duplicateKey :: String -> Word -> Decoder s a
+duplicateKey name k =
+  cborError $
+    DecoderErrorCustom
+      "Duplicate key:"
+      (Text.pack $ show k ++ " while decoding type " ++ name)
+
+unusedRequiredKeys :: Set Word -> [(Word, String)] -> String -> Decoder s a
+unusedRequiredKeys used required name =
+  cborError $
+    DecoderErrorCustom
+      (Text.pack ("value of type " ++ name))
+      (Text.pack (message (filter bad required)))
+  where
+    bad (k, _) = not (member k used)
+    message [] = ", not decoded."
+    message [pair] = report pair ++ message []
+    message (pair : more) = report pair ++ ", and " ++ message more
+    report (k, f) = "field " ++ f ++ " with key " ++ show k

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -1,0 +1,1127 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Ledger.Binary.Decoding.Decoder
+  ( -- * Decoders
+    Decoder,
+    toPlainDecoder,
+    fromPlainDecoder,
+    withPlainDecoder,
+    enforceVersionDecoder,
+    DecoderError (..),
+    C.ByteOffset,
+    C.DecodeAction (..),
+    C.TokenType (..),
+
+    -- ** Versioning
+    getDecoderVersion,
+    ifDecoderVersionAtLeast,
+
+    -- ** Error reporting
+    cborError,
+    showDecoderError,
+    assertTag,
+    enforceSize,
+    matchSize,
+
+    -- ** Compatibility tools
+    binaryGetDecoder,
+
+    -- ** Custom decoders
+    decodeRational,
+    decodeRecordNamed,
+    decodeRecordNamedT,
+    decodeRecordSum,
+
+    -- *** Containers
+    decodeMaybe,
+    decodeList,
+    decodeNullMaybe,
+    decodeVector,
+    decodeSet,
+    setTag,
+    decodeMap,
+    decodeVMap,
+    decodeSeq,
+    decodeStrictSeq,
+
+    -- *** Time
+    decodeUTCTime,
+    decodeNominalDiffTime,
+
+    -- *** Network
+    decodeIPv4,
+    decodeIPv6,
+    decodeMapContents,
+    decodeMapNoDuplicates,
+    decodeMapTraverse,
+    decodeMapContentsTraverse,
+
+    -- ** Lifted @cborg@ decoders
+    decodeBool,
+    decodeBreakOr,
+    decodeByteArray,
+    decodeByteArrayCanonical,
+    decodeBytes,
+    decodeBytesCanonical,
+    decodeBytesIndef,
+    decodeDouble,
+    decodeDoubleCanonical,
+    decodeFloat,
+    decodeFloat16Canonical,
+    decodeFloatCanonical,
+    decodeInt,
+    decodeInt16,
+    decodeInt16Canonical,
+    decodeInt32,
+    decodeInt32Canonical,
+    decodeInt64,
+    decodeInt64Canonical,
+    decodeInt8,
+    decodeInt8Canonical,
+    decodeIntCanonical,
+    decodeInteger,
+    decodeIntegerCanonical,
+    decodeNatural,
+    decodeListLen,
+    decodeListLenCanonical,
+    decodeListLenCanonicalOf,
+    decodeListLenIndef,
+    decodeListLenOf,
+    decodeListLenOrIndef,
+    decodeMapLen,
+    decodeMapLenCanonical,
+    decodeMapLenIndef,
+    decodeMapLenOrIndef,
+    decodeNegWord,
+    decodeNegWord64,
+    decodeNegWord64Canonical,
+    decodeNegWordCanonical,
+    decodeNull,
+    decodeSequenceLenIndef,
+    decodeSequenceLenN,
+    decodeSimple,
+    decodeSimpleCanonical,
+    decodeString,
+    decodeStringCanonical,
+    decodeStringIndef,
+    decodeTag,
+    decodeTag64,
+    decodeTag64Canonical,
+    decodeTagCanonical,
+    decodeUtf8ByteArray,
+    decodeUtf8ByteArrayCanonical,
+    decodeWithByteSpan,
+    decodeWord,
+    decodeWord16,
+    decodeWord16Canonical,
+    decodeWord32,
+    decodeWord32Canonical,
+    decodeWord64,
+    decodeWord64Canonical,
+    decodeWord8,
+    decodeWord8Canonical,
+    decodeWordCanonical,
+    decodeWordCanonicalOf,
+    decodeWordOf,
+    decodeTerm,
+    peekAvailable,
+    peekByteOffset,
+    peekTokenType,
+  )
+where
+
+import Cardano.Binary (DecoderError (..))
+import Cardano.Ledger.Binary.Version
+import Codec.CBOR.ByteArray (ByteArray)
+import qualified Codec.CBOR.Decoding as C
+  ( ByteOffset,
+    DecodeAction (..),
+    Decoder,
+    TokenType (..),
+    decodeBool,
+    decodeBreakOr,
+    decodeByteArray,
+    decodeByteArrayCanonical,
+    decodeBytes,
+    decodeBytesCanonical,
+    decodeBytesIndef,
+    decodeDouble,
+    decodeDoubleCanonical,
+    decodeFloat,
+    decodeFloat16Canonical,
+    decodeFloatCanonical,
+    decodeInt,
+    decodeInt16,
+    decodeInt16Canonical,
+    decodeInt32,
+    decodeInt32Canonical,
+    decodeInt64,
+    decodeInt64Canonical,
+    decodeInt8,
+    decodeInt8Canonical,
+    decodeIntCanonical,
+    decodeInteger,
+    decodeIntegerCanonical,
+    decodeListLen,
+    decodeListLenCanonical,
+    decodeListLenCanonicalOf,
+    decodeListLenIndef,
+    decodeListLenOf,
+    decodeListLenOrIndef,
+    decodeMapLen,
+    decodeMapLenCanonical,
+    decodeMapLenIndef,
+    decodeMapLenOrIndef,
+    decodeNegWord,
+    decodeNegWord64,
+    decodeNegWord64Canonical,
+    decodeNegWordCanonical,
+    decodeNull,
+    decodeSequenceLenIndef,
+    decodeSequenceLenN,
+    decodeSimple,
+    decodeSimpleCanonical,
+    decodeString,
+    decodeStringCanonical,
+    decodeStringIndef,
+    decodeTag,
+    decodeTag64,
+    decodeTag64Canonical,
+    decodeTagCanonical,
+    decodeUtf8ByteArray,
+    decodeUtf8ByteArrayCanonical,
+    decodeWithByteSpan,
+    decodeWord,
+    decodeWord16,
+    decodeWord16Canonical,
+    decodeWord32,
+    decodeWord32Canonical,
+    decodeWord64,
+    decodeWord64Canonical,
+    decodeWord8,
+    decodeWord8Canonical,
+    decodeWordCanonical,
+    decodeWordCanonicalOf,
+    decodeWordOf,
+    peekAvailable,
+    peekByteOffset,
+    peekTokenType,
+  )
+import qualified Codec.CBOR.Term as C (Term (..), decodeTerm)
+import Control.Monad
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans.Identity (IdentityT (runIdentityT))
+import Data.Binary.Get (Get, getWord32le, runGetOrFail)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Functor.Compose (Compose (..))
+import Data.IP (IPv4, IPv6, fromHostAddress, fromHostAddress6)
+import Data.Int (Int16, Int32, Int64, Int8)
+import qualified Data.Map.Strict as Map
+import Data.Ratio (Ratio, (%))
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
+import Data.Time.Clock (NominalDiffTime, UTCTime (..), picosecondsToDiffTime)
+import qualified Data.VMap as VMap
+import qualified Data.Vector.Generic as VG
+import Data.Word (Word16, Word32, Word64, Word8)
+import Formatting (build, formatToString)
+import GHC.Exts as Exts (IsList (..))
+import Network.Socket (HostAddress6)
+import Numeric.Natural (Natural)
+import Prelude hiding (decodeFloat)
+
+--------------------------------------------------------------------------------
+-- Versioned Decoder
+--------------------------------------------------------------------------------
+
+newtype Decoder s a = Decoder
+  { runDecoder :: Version -> C.Decoder s a
+  }
+
+instance Functor (Decoder s) where
+  fmap f (Decoder d) = Decoder (fmap f . d)
+  {-# INLINE fmap #-}
+
+instance Applicative (Decoder s) where
+  pure x = Decoder (const (pure x))
+  {-# INLINE pure #-}
+  Decoder f <*> Decoder g = Decoder $ \v -> f v <*> g v
+  {-# INLINE (<*>) #-}
+  Decoder f *> Decoder g = Decoder $ \v -> f v *> g v
+  {-# INLINE (*>) #-}
+
+instance Monad (Decoder s) where
+  Decoder f >>= g = Decoder $ \v -> do
+    x <- f v
+    runDecoder (g x) v
+  {-# INLINE (>>=) #-}
+
+instance MonadFail (Decoder s) where
+  fail msg = fromPlainDecoder $ fail msg
+  {-# INLINE fail #-}
+
+-- | Promote a regular `C.Decoder` to a versioned one. Which means it will work for all
+-- versions.
+fromPlainDecoder :: C.Decoder s a -> Decoder s a
+fromPlainDecoder d = Decoder (const d)
+
+-- | Extract the underlying `C.Decoder` by specifying the concrete version to be used.
+toPlainDecoder :: Version -> Decoder s a -> C.Decoder s a
+toPlainDecoder v (Decoder d) = d v
+
+-- | Use the supplied decoder as a plain decoder with current version.
+withPlainDecoder :: Decoder s a -> (C.Decoder s a -> C.Decoder s b) -> Decoder s b
+withPlainDecoder vd f = Decoder $ \curVersion -> f (toPlainDecoder curVersion vd)
+
+-- | Ignore the current version of the decoder and enforce the supplied one instead.
+enforceVersionDecoder :: Version -> Decoder s a -> Decoder s a
+enforceVersionDecoder version = fromPlainDecoder . toPlainDecoder version
+
+--------------------------------------------------------------------------------
+-- Working with current decoder version
+--------------------------------------------------------------------------------
+
+-- | Extract current version of the decoder
+--
+-- >>> import Cardano.Ledger.Decoding
+-- >>> decodeFullDecoder 3 "Version" getDecoderVersion ""
+-- Right 3
+getDecoderVersion :: Decoder s Version
+getDecoderVersion = Decoder pure
+
+-- | Conditionally choose the newer or older decoder, depending on the current
+-- version. Version in the context of encoders/decoders is the major protocol
+-- version. Supplied version acts as a pivot.
+--
+-- =====__Example__
+--
+-- Let's say prior to the version 2 some type `Foo` was backed by `Word16`, but at the 2nd
+-- version onwards it was switched to `Word32` instead. In order to support both versions,
+-- we change the type, but we also use this condition to keep backwards compatibility of
+-- the decoder:
+--
+-- >>> newtype Foo = Foo Word32
+-- >>> decFoo = Foo <$> ifDecoderVersionAtLeast 2 decodeWord32 (fromIntegral <$> decodeWord16)
+ifDecoderVersionAtLeast ::
+  Version ->
+  -- | Use this decoder if current decoder version is larger or equal to the supplied
+  -- `Version`
+  Decoder s a ->
+  -- | Use this decoder if current decoder version is lower than the supplied `Version`
+  Decoder s a ->
+  Decoder s a
+ifDecoderVersionAtLeast atLeast newerDecoder olderDecoder = do
+  cur <- getDecoderVersion
+  if cur >= atLeast
+    then newerDecoder
+    else olderDecoder
+
+--------------------------------------------------------------------------------
+-- Error reporting
+--------------------------------------------------------------------------------
+
+cborError :: DecoderError -> Decoder s a
+cborError = fail . showDecoderError
+
+showDecoderError :: DecoderError -> String
+showDecoderError = formatToString build
+
+-- | `Decoder` for `Rational`. Versions variance:
+--
+-- * [>= 8] - Allows variable as well as exact list length encoding. Enforces
+--   tag 30 and ensures that the denominator cannot be negative
+--
+-- * [>= 2] - Allows variable as well as exact list length encoding. Also
+--   enforces special set tag 30
+--
+-- * [< 2] - Expects exact list length encoding.
+decodeRational :: Decoder s Rational
+decodeRational =
+  ifDecoderVersionAtLeast
+    (natVersion @8)
+    decodeRationalV8
+    ( ifDecoderVersionAtLeast
+        (natVersion @2)
+        (decodeFraction decodeInteger)
+        ( do
+            enforceSize "Ratio" 2
+            n <- decodeInteger
+            d <- decodeInteger
+            if d <= 0
+              then cborError $ DecoderErrorCustom "Ratio" "invalid denominator"
+              else return $! n % d
+        )
+    )
+
+decodeFraction :: Integral a => Decoder s a -> Decoder s (Ratio a)
+decodeFraction decoder = do
+  t <- decodeTag
+  unless (t == 30) $ cborError $ DecoderErrorCustom "rational" "expected tag 30"
+  (numValues, values) <- decodeCollectionWithLen decodeListLenOrIndef decoder
+  case values of
+    [n, d] -> do
+      when (d == 0) (fail "denominator cannot be 0")
+      pure $ n % d
+    _ -> cborError $ DecoderErrorSizeMismatch "rational" 2 numValues
+{-# DEPRECATED decodeFraction "In favor of `decodeRational`" #-}
+
+decodeRationalV8 :: Decoder s Rational
+decodeRationalV8 = do
+  assertTag 30
+  (numValues, values) <- decodeCollectionWithLen decodeListLenOrIndef decodeInteger
+  case values of
+    [n, d] -> do
+      when (d <= 0) (fail "Denominator must be positive")
+      pure $ n % d
+    _ -> cborError $ DecoderErrorSizeMismatch "rational" 2 numValues
+
+--------------------------------------------------------------------------------
+-- Containers
+--------------------------------------------------------------------------------
+
+-- | @'Decoder'@ for list.
+--
+-- * [>= 2] - Allows variable as well as exact list length encoding.
+--
+-- * [< 2] - Expects variable list length encoding
+decodeList :: Decoder s a -> Decoder s [a]
+decodeList decodeValue =
+  ifDecoderVersionAtLeast
+    (natVersion @2)
+    (decodeCollection decodeListLenOrIndef decodeValue)
+    (decodeListWith decodeValue)
+
+-- | @'Decoder'@ for list.
+decodeListWith :: Decoder s a -> Decoder s [a]
+decodeListWith decodeValue = do
+  decodeListLenIndef
+  decodeSequenceLenIndef (flip (:)) [] reverse decodeValue
+
+-- | `Decoder` for `Maybe`. Versions variance:
+--
+-- * [>= 2] - Allows variable as well as exact list length encoding.
+--
+-- * [< 2] - Expects exact list length encoding
+decodeMaybe :: Decoder s a -> Decoder s (Maybe a)
+decodeMaybe decodeValue = do
+  ifDecoderVersionAtLeast
+    (natVersion @2)
+    (decodeMaybeVarLen decodeValue)
+    (decodeMaybeExactLen decodeValue)
+
+decodeMaybeExactLen :: Decoder s a -> Decoder s (Maybe a)
+decodeMaybeExactLen decodeValue = do
+  n <- decodeListLen
+  case n of
+    0 -> return Nothing
+    1 -> do
+      !x <- decodeValue
+      return (Just x)
+    _ -> fail "too many elements while decoding Maybe."
+
+decodeMaybeVarLen :: Decoder s a -> Decoder s (Maybe a)
+decodeMaybeVarLen decodeValue = do
+  maybeLength <- decodeListLenOrIndef
+  case maybeLength of
+    Just 0 -> pure Nothing
+    Just 1 -> Just <$!> decodeValue
+    Just _ -> fail "too many elements in length-style decoding of Maybe."
+    Nothing -> do
+      isBreak <- decodeBreakOr
+      if isBreak
+        then pure Nothing
+        else do
+          !x <- decodeValue
+          isBreak2 <- decodeBreakOr
+          unless isBreak2 $
+            fail "too many elements in break-style decoding of Maybe."
+          pure (Just x)
+
+-- | Alternative way to decode a Maybe type.
+--
+-- /Note/ - this is not the default method for decoding `Maybe`, use `decodeMaybe` instead.
+decodeNullMaybe :: Decoder s a -> Decoder s (Maybe a)
+decodeNullMaybe decoder = do
+  peekTokenType >>= \case
+    C.TypeNull -> do
+      decodeNull
+      pure Nothing
+    _ -> Just <$> decoder
+
+decodeRecordNamed :: Text.Text -> (a -> Int) -> Decoder s a -> Decoder s a
+decodeRecordNamed name getRecordSize decoder = do
+  runIdentityT $ decodeRecordNamedT name getRecordSize (lift decoder)
+
+decodeRecordNamedT ::
+  (MonadTrans m, Monad (m (Decoder s))) =>
+  Text.Text ->
+  (a -> Int) ->
+  m (Decoder s) a ->
+  m (Decoder s) a
+decodeRecordNamedT name getRecordSize decoder = do
+  lenOrIndef <- lift decodeListLenOrIndef
+  x <- decoder
+  lift $ case lenOrIndef of
+    Just n -> matchSize (Text.pack "Record " <> name) n (getRecordSize x)
+    Nothing -> do
+      isBreak <- decodeBreakOr
+      unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
+  pure x
+
+decodeRecordSum :: String -> (Word -> Decoder s (Int, a)) -> Decoder s a
+decodeRecordSum name decoder = do
+  lenOrIndef <- decodeListLenOrIndef
+  tag <- decodeWord
+  (size, x) <- decoder tag -- we decode all the stuff we want
+  case lenOrIndef of
+    Just n -> matchSize (Text.pack "Sum " <> Text.pack name) size n
+    Nothing -> do
+      isBreak <- decodeBreakOr -- if there is stuff left, it is unnecessary extra stuff
+      unless isBreak $ cborError $ DecoderErrorCustom (Text.pack name) "Excess terms in array"
+  pure x
+
+--------------------------------------------------------------------------------
+-- Decoder for Map
+--------------------------------------------------------------------------------
+
+-- | Checks canonicity by comparing the new key being decoded with
+--   the previous one, to enfore these are sorted the correct way.
+--   See: https://tools.ietf.org/html/rfc7049#section-3.9
+--   "[..]The keys in every map must be sorted lowest value to highest.[...]"
+decodeMapSkel ::
+  forall k m v s.
+  Ord k =>
+  -- | Decoded list is guaranteed to be sorted on keys in descending order without any
+  -- duplicate keys.
+  ([(k, v)] -> m) ->
+  -- | Decoder for keys
+  Decoder s k ->
+  -- | Decoder for values
+  Decoder s v ->
+  Decoder s m
+decodeMapSkel fromDistinctDescList decodeKey decodeValue = do
+  n <- decodeMapLen
+  fromDistinctDescList <$> case n of
+    0 -> return []
+    _ -> do
+      (firstKey, firstValue) <- decodeEntry
+      decodeEntries (n - 1) firstKey [(firstKey, firstValue)]
+  where
+    -- Decode a single (k,v).
+    decodeEntry :: Decoder s (k, v)
+    decodeEntry = do
+      !k <- decodeKey
+      !v <- decodeValue
+      return (k, v)
+
+    -- Decode all the entries, enforcing canonicity by ensuring that the
+    -- previous key is smaller than the next one.
+    decodeEntries :: Int -> k -> [(k, v)] -> Decoder s [(k, v)]
+    decodeEntries 0 _ acc = pure acc
+    decodeEntries !remainingPairs previousKey !acc = do
+      p@(newKey, _) <- decodeEntry
+      -- Order of keys needs to be strictly increasing, because otherwise it's
+      -- possible to supply lists with various amount of duplicate keys which
+      -- will result in the same map as long as the last value of the given
+      -- key on the list is the same in all of them.
+      if newKey > previousKey
+        then decodeEntries (remainingPairs - 1) newKey (p : acc)
+        else cborError $ DecoderErrorCanonicityViolation "Map"
+{-# INLINE decodeMapSkel #-}
+
+decodeMapV1 ::
+  forall k v s.
+  Ord k =>
+  -- | Decoder for keys
+  Decoder s k ->
+  -- | Decoder for values
+  Decoder s v ->
+  Decoder s (Map.Map k v)
+decodeMapV1 = decodeMapSkel Map.fromDistinctDescList
+
+decodeCollection :: Decoder s (Maybe Int) -> Decoder s a -> Decoder s [a]
+decodeCollection lenOrIndef el = snd <$> decodeCollectionWithLen lenOrIndef el
+
+decodeCollectionWithLen ::
+  Decoder s (Maybe Int) ->
+  Decoder s v ->
+  Decoder s (Int, [v])
+decodeCollectionWithLen lenOrIndef el = do
+  lenOrIndef >>= \case
+    Just len -> (,) len <$> replicateM len el
+    Nothing -> loop (0, []) (not <$> decodeBreakOr) el
+  where
+    loop (!n, !acc) condition action =
+      condition >>= \case
+        False -> pure (n, reverse acc)
+        True -> action >>= \v -> loop (n + 1, v : acc) condition action
+
+decodeMapByKey ::
+  forall k t v s.
+  (Exts.IsList t, Exts.Item t ~ (k, v)) =>
+  -- | Decoder for keys
+  Decoder s k ->
+  -- | Decoder for values
+  (k -> Decoder s v) ->
+  Decoder s t
+decodeMapByKey decodeKey decodeValueFor =
+  uncurry Exts.fromListN
+    <$> decodeCollectionWithLen decodeMapLenOrIndef decodeInlinedPair
+  where
+    decodeInlinedPair = do
+      !key <- decodeKey
+      !value <- decodeValueFor key
+      pure (key, value)
+
+-- | We want to make a uniform way of encoding and decoding `Map.Map`. The original `ToCBOR`
+-- and `FromCBOR` instances date to Byron Era didn't support versioning were not always
+-- cannonical. We want to make these cannonical improvements staring with protocol version
+-- 2.
+decodeMapV2 ::
+  forall k v s.
+  Ord k =>
+  -- | Decoder for keys
+  Decoder s k ->
+  -- | Decoder for values
+  Decoder s v ->
+  Decoder s (Map.Map k v)
+decodeMapV2 decodeKey decodeValue = decodeMapByKey decodeKey (const decodeValue)
+
+-- | `Decoder` for `Map.Map`. Versions variance:
+--
+-- * [>= 2] - Allows variable as well as exact list length encoding. Duplicates are
+--   silently ignored
+--
+-- * [< 2] - Expects exact list length encoding and enforces strict order
+--   without any duplicates.
+--
+-- An example of how to use versioning
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import Codec.CBOR.FlatTerm
+-- >>> fromFlatTerm (toPlainDecoder 1 (decodeMap decodeInt decodeBytes)) [TkMapLen 2,TkInt 1,TkBytes "Foo",TkInt 2,TkBytes "Bar"]
+-- Right (fromList [(1,"Foo"),(2,"Bar")])
+-- >>> fromFlatTerm (toPlainDecoder 2 (decodeMap decodeInt decodeBytes)) [TkMapBegin,TkInt 1,TkBytes "Foo",TkInt 2,TkBytes "Bar"]
+-- Left "decodeMapLen: unexpected token TkMapBegin"
+-- >>> fromFlatTerm (toPlainDecoder 2 (decodeMap decodeInt decodeBytes)) [TkMapBegin,TkInt 1,TkBytes "Foo",TkInt 2,TkBytes "Bar",TkBreak]
+-- Right (fromList [(1,"Foo"),(2,"Bar")])
+decodeMap ::
+  Ord k =>
+  Decoder s k ->
+  Decoder s v ->
+  Decoder s (Map.Map k v)
+decodeMap decodeKey decodeValue =
+  ifDecoderVersionAtLeast
+    (natVersion @2)
+    (decodeMapV2 decodeKey decodeValue)
+    (decodeMapV1 decodeKey decodeValue)
+
+-- | Decode `VMap`. Unlike `decodeMap` it does not behavee differently for
+-- version prior to 2.
+decodeVMap ::
+  (VMap.Vector kv k, VMap.Vector vv v, Ord k) =>
+  Decoder s k ->
+  Decoder s v ->
+  Decoder s (VMap.VMap kv vv k v)
+decodeVMap decodeKey decodeValue = decodeMapByKey decodeKey (const decodeValue)
+
+-- | We stitch a `258` in from of a (Hash)Set, so that tools which
+-- programmatically check for canonicity can recognise it from a normal
+-- array. Why 258? This will be formalised pretty soon, but IANA allocated
+-- 256...18446744073709551615 to "First come, first served":
+-- https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml Currently `258` is
+-- the first unassigned tag and as it requires 2 bytes to be encoded, it sounds
+-- like the best fit.
+setTag :: Word
+setTag = 258
+
+decodeSetTag :: Decoder s ()
+decodeSetTag = do
+  t <- decodeTag
+  when (t /= setTag) $ cborError $ DecoderErrorUnknownTag "Set" (fromIntegral t)
+
+decodeSetSkel ::
+  forall a s c.
+  Ord a =>
+  -- | Decoded list is guaranteed to be sorted on keys in descending order without any
+  -- duplicate keys.
+  ([a] -> c) ->
+  Decoder s a ->
+  Decoder s c
+decodeSetSkel fromDistinctDescList decodeValue = do
+  decodeSetTag
+  n <- decodeListLen
+  fromDistinctDescList <$> case n of
+    0 -> return []
+    _ -> do
+      firstValue <- decodeValue
+      decodeEntries (n - 1) firstValue [firstValue]
+  where
+    decodeEntries :: Int -> a -> [a] -> Decoder s [a]
+    decodeEntries 0 _ acc = pure acc
+    decodeEntries !remainingEntries previousValue !acc = do
+      newValue <- decodeValue
+      -- Order of values needs to be strictly increasing, because otherwise
+      -- it's possible to supply lists with various amount of duplicates which
+      -- will result in the same set.
+      if newValue > previousValue
+        then decodeEntries (remainingEntries - 1) newValue (newValue : acc)
+        else cborError $ DecoderErrorCanonicityViolation "Set"
+{-# INLINE decodeSetSkel #-}
+
+-- | `Decoder` for `Set.Set`. Versions variance:
+--
+-- * [>= 2] - Allows variable as well as exact list length encoding. Duplicates are
+--   silently ignored
+--
+-- * [< 2] - Expects exact list length encoding and enforces strict order
+--   without any duplicates. Also enforces special set tag 258, which was
+--   abandoned starting with version 2
+decodeSet :: Ord a => Decoder s a -> Decoder s (Set.Set a)
+decodeSet valueDecoder =
+  ifDecoderVersionAtLeast
+    (natVersion @2)
+    (Set.fromList <$> decodeCollection decodeListLenOrIndef valueDecoder)
+    (decodeSetSkel Set.fromDistinctDescList valueDecoder)
+
+decodeContainerSkelWithReplicate ::
+  -- | How to get the size of the container
+  Decoder s Int ->
+  -- | replicateM for the container
+  (Int -> Decoder s c) ->
+  -- | concat for the container
+  ([c] -> c) ->
+  Decoder s c
+decodeContainerSkelWithReplicate decodeLen replicateFun concatList = do
+  -- Look at how much data we have at the moment and use it as the limit for
+  -- the size of a single call to replicateFun. We don't want to use
+  -- replicateFun directly on the result of decodeLen since this might lead to
+  -- DOS attack (attacker providing a huge value for length). So if it's above
+  -- our limit, we'll do manual chunking and then combine the containers into
+  -- one.
+  sz <- decodeLen
+  limit <- peekAvailable
+  if sz <= limit
+    then replicateFun sz
+    else do
+      -- Take the max of limit and a fixed chunk size (note: limit can be
+      -- 0). This basically means that the attacker can make us allocate a
+      -- container of size 128 even though there's no actual input.
+      let chunkSize = max limit 128
+          (d, m) = sz `divMod` chunkSize
+      containers <- sequence $ replicateFun m : replicate d (replicateFun chunkSize)
+      return $! concatList containers
+{-# INLINE decodeContainerSkelWithReplicate #-}
+
+-- | Generic decoder for vectors. Its intended use is to allow easy
+-- definition of 'Serialise' instances for custom vector
+decodeVector :: VG.Vector vec a => Decoder s a -> Decoder s (vec a)
+decodeVector decodeValue =
+  decodeContainerSkelWithReplicate
+    decodeListLen
+    (`VG.replicateM` decodeValue)
+    VG.concat
+{-# INLINE decodeVector #-}
+
+-- | Decoder for `Seq.Seq`. Same behavior for all versions, allows variable as
+-- well as exact list length encoding
+decodeSeq :: Decoder s a -> Decoder s (Seq.Seq a)
+decodeSeq decoder = Seq.fromList <$> decodeCollection decodeListLenOrIndef decoder
+
+-- | Decoder for `SSeq.StrictSeq`. Same behavior for all versions, allows variable as
+-- well as exact list length encoding.
+decodeStrictSeq :: Decoder s a -> Decoder s (SSeq.StrictSeq a)
+decodeStrictSeq decoder = SSeq.fromList <$> decodeCollection decodeListLenOrIndef decoder
+
+decodeAccWithLen ::
+  Decoder s (Maybe Int) ->
+  (a -> b -> b) ->
+  b ->
+  Decoder s a ->
+  Decoder s (Int, b)
+decodeAccWithLen lenOrIndef combine acc0 action = do
+  mLen <- lenOrIndef
+  let condition = case mLen of
+        Nothing -> const <$> decodeBreakOr
+        Just len -> pure (>= len)
+      loop !i !acc = do
+        shouldStop <- condition
+        if shouldStop i
+          then pure (i, acc)
+          else do
+            v <- action
+            loop (i + 1) (v `combine` acc)
+  loop 0 acc0
+
+-- | Just like `decodeMap`, but assumes that there are no duplicate keys, which is not enforced.
+decodeMapNoDuplicates :: Ord a => Decoder s a -> Decoder s b -> Decoder s (Map.Map a b)
+decodeMapNoDuplicates decodeKey decodeValue =
+  snd
+    <$> decodeAccWithLen
+      decodeMapLenOrIndef
+      (uncurry Map.insert)
+      Map.empty
+      decodeInlinedPair
+  where
+    decodeInlinedPair = do
+      !key <- decodeKey
+      !value <- decodeValue
+      pure (key, value)
+
+decodeMapContents :: Decoder s a -> Decoder s [a]
+decodeMapContents = decodeCollection decodeMapLenOrIndef
+
+decodeMapTraverse ::
+  (Ord a, Applicative t) =>
+  Decoder s (t a) ->
+  Decoder s (t b) ->
+  Decoder s (t (Map.Map a b))
+decodeMapTraverse decodeKey decodeValue =
+  fmap Map.fromList <$> decodeMapContentsTraverse decodeKey decodeValue
+
+decodeMapContentsTraverse ::
+  Applicative t =>
+  Decoder s (t a) ->
+  Decoder s (t b) ->
+  Decoder s (t [(a, b)])
+decodeMapContentsTraverse decodeKey decodeValue =
+  sequenceA <$> decodeMapContents decodeInlinedPair
+  where
+    decodeInlinedPair = getCompose $ (,) <$> Compose decodeKey <*> Compose decodeValue
+
+--------------------------------------------------------------------------------
+-- Time
+--------------------------------------------------------------------------------
+
+-- | `Decoder` for `UTCTime`. Versions variance:
+--
+-- * [>= 2] - Allows variable list length encoding, but still expects number of
+--   elements to be 3.
+--
+-- * [< 2] - Expects exact list length encoding to be 3
+decodeUTCTime :: Decoder s UTCTime
+decodeUTCTime =
+  ifDecoderVersionAtLeast
+    (natVersion @2)
+    (enforceSize "UTCTime" 3 >> timeDecoder)
+    (decodeRecordNamed "UTCTime" (const 3) timeDecoder)
+  where
+    timeDecoder = do
+      !year <- decodeInteger
+      !dayOfYear <- decodeInt
+      !timeOfDayPico <- decodeInteger
+      return $!
+        UTCTime
+          (fromOrdinalDate year dayOfYear)
+          (picosecondsToDiffTime timeOfDayPico)
+
+-- | For backwards compatibility we round pico precision to micro
+decodeNominalDiffTime :: Decoder s NominalDiffTime
+decodeNominalDiffTime = fromRational . (% 1_000_000) <$> decodeInteger
+
+--------------------------------------------------------------------------------
+-- Network
+--------------------------------------------------------------------------------
+
+-- | Convert a `Get` monad from @binary@ package into a `Decoder`
+binaryGetDecoder ::
+  -- | Flag to allow left over at the end or not
+  Bool ->
+  -- | Name of the function or type for error reporting
+  Text.Text ->
+  -- | Deserializer for the @binary@ package
+  Get a ->
+  Decoder s a
+binaryGetDecoder allowLeftOver name getter = do
+  bs <- decodeBytes
+  case runGetOrFail getter (BSL.fromStrict bs) of
+    Left (_, _, err) -> cborError $ DecoderErrorCustom name (Text.pack err)
+    Right (leftOver, _, ha)
+      | allowLeftOver || BSL.null leftOver -> pure ha
+      | otherwise ->
+          cborError $ DecoderErrorLeftover name (BSL.toStrict leftOver)
+
+decodeIPv4 :: Decoder s IPv4
+decodeIPv4 =
+  fromHostAddress
+    <$> ifDecoderVersionAtLeast
+      (natVersion @8)
+      (binaryGetDecoder False "decodeIPv4" getWord32le)
+      (binaryGetDecoder True "decodeIPv4" getWord32le)
+
+getHostAddress6 :: Get HostAddress6
+getHostAddress6 = do
+  !w1 <- getWord32le
+  !w2 <- getWord32le
+  !w3 <- getWord32le
+  !w4 <- getWord32le
+  return (w1, w2, w3, w4)
+
+decodeIPv6 :: Decoder s IPv6
+decodeIPv6 =
+  fromHostAddress6
+    <$> ifDecoderVersionAtLeast
+      (natVersion @8)
+      (binaryGetDecoder False "decodeIPv6" getHostAddress6)
+      (binaryGetDecoder True "decodeIPv6" getHostAddress6)
+
+--------------------------------------------------------------------------------
+-- Wrapped CBORG decoders
+--------------------------------------------------------------------------------
+
+assertTag :: Word -> Decoder s ()
+assertTag tagExpected = do
+  tagReceived <-
+    peekTokenType >>= \case
+      C.TypeTag -> fromIntegral <$> decodeTag
+      C.TypeTag64 -> decodeTag64
+      _ -> fail "expected tag"
+  unless (tagReceived == (fromIntegral tagExpected :: Word64)) $
+    fail $
+      "expecteg tag " <> show tagExpected <> " but got tag " <> show tagReceived
+
+-- | Enforces that the input size is the same as the decoded one, failing in
+--   case it's not
+enforceSize :: Text.Text -> Int -> Decoder s ()
+enforceSize lbl requestedSize = decodeListLen >>= matchSize lbl requestedSize
+
+-- | Compare two sizes, failing if they are not equal
+matchSize :: Text.Text -> Int -> Int -> Decoder s ()
+matchSize lbl requestedSize actualSize =
+  when (actualSize /= requestedSize) $
+    cborError $
+      DecoderErrorSizeMismatch
+        lbl
+        requestedSize
+        actualSize
+
+decodeBool :: Decoder s Bool
+decodeBool = fromPlainDecoder C.decodeBool
+
+decodeBreakOr :: Decoder s Bool
+decodeBreakOr = fromPlainDecoder C.decodeBreakOr
+
+decodeByteArray :: Decoder s ByteArray
+decodeByteArray = fromPlainDecoder C.decodeByteArray
+
+decodeByteArrayCanonical :: Decoder s ByteArray
+decodeByteArrayCanonical = fromPlainDecoder C.decodeByteArrayCanonical
+
+decodeBytes :: Decoder s BS.ByteString
+decodeBytes = fromPlainDecoder C.decodeBytes
+
+decodeBytesCanonical :: Decoder s BS.ByteString
+decodeBytesCanonical = fromPlainDecoder C.decodeBytesCanonical
+
+decodeBytesIndef :: Decoder s ()
+decodeBytesIndef = fromPlainDecoder C.decodeBytesIndef
+
+decodeDouble :: Decoder s Double
+decodeDouble = fromPlainDecoder C.decodeDouble
+
+decodeDoubleCanonical :: Decoder s Double
+decodeDoubleCanonical = fromPlainDecoder C.decodeDoubleCanonical
+
+decodeFloat :: Decoder s Float
+decodeFloat = fromPlainDecoder C.decodeFloat
+
+decodeFloat16Canonical :: Decoder s Float
+decodeFloat16Canonical = fromPlainDecoder C.decodeFloat16Canonical
+
+decodeFloatCanonical :: Decoder s Float
+decodeFloatCanonical = fromPlainDecoder C.decodeFloatCanonical
+
+decodeInt :: Decoder s Int
+decodeInt = fromPlainDecoder C.decodeInt
+
+decodeInt16 :: Decoder s Int16
+decodeInt16 = fromPlainDecoder C.decodeInt16
+
+decodeInt16Canonical :: Decoder s Int16
+decodeInt16Canonical = fromPlainDecoder C.decodeInt16Canonical
+
+decodeInt32 :: Decoder s Int32
+decodeInt32 = fromPlainDecoder C.decodeInt32
+
+decodeInt32Canonical :: Decoder s Int32
+decodeInt32Canonical = fromPlainDecoder C.decodeInt32Canonical
+
+decodeInt64 :: Decoder s Int64
+decodeInt64 = fromPlainDecoder C.decodeInt64
+
+decodeInt64Canonical :: Decoder s Int64
+decodeInt64Canonical = fromPlainDecoder C.decodeInt64Canonical
+
+decodeInt8 :: Decoder s Int8
+decodeInt8 = fromPlainDecoder C.decodeInt8
+
+decodeInt8Canonical :: Decoder s Int8
+decodeInt8Canonical = fromPlainDecoder C.decodeInt8Canonical
+
+decodeIntCanonical :: Decoder s Int
+decodeIntCanonical = fromPlainDecoder C.decodeIntCanonical
+
+decodeInteger :: Decoder s Integer
+decodeInteger = fromPlainDecoder C.decodeInteger
+
+decodeNatural :: Decoder s Natural
+decodeNatural = do
+  !n <- decodeInteger
+  if n >= 0
+    then return $! fromInteger n
+    else cborError $ DecoderErrorCustom "Natural" "got a negative number"
+
+decodeIntegerCanonical :: Decoder s Integer
+decodeIntegerCanonical = fromPlainDecoder C.decodeIntegerCanonical
+
+decodeListLen :: Decoder s Int
+decodeListLen = fromPlainDecoder C.decodeListLen
+
+decodeListLenCanonical :: Decoder s Int
+decodeListLenCanonical = fromPlainDecoder C.decodeListLenCanonical
+
+decodeListLenCanonicalOf :: Int -> Decoder s ()
+decodeListLenCanonicalOf = fromPlainDecoder . C.decodeListLenCanonicalOf
+
+decodeListLenIndef :: Decoder s ()
+decodeListLenIndef = fromPlainDecoder C.decodeListLenIndef
+
+decodeListLenOf :: Int -> Decoder s ()
+decodeListLenOf = fromPlainDecoder . C.decodeListLenOf
+
+decodeListLenOrIndef :: Decoder s (Maybe Int)
+decodeListLenOrIndef = fromPlainDecoder C.decodeListLenOrIndef
+
+decodeMapLen :: Decoder s Int
+decodeMapLen = fromPlainDecoder C.decodeMapLen
+
+decodeMapLenCanonical :: Decoder s Int
+decodeMapLenCanonical = fromPlainDecoder C.decodeMapLenCanonical
+
+decodeMapLenIndef :: Decoder s ()
+decodeMapLenIndef = fromPlainDecoder C.decodeMapLenIndef
+
+decodeMapLenOrIndef :: Decoder s (Maybe Int)
+decodeMapLenOrIndef = fromPlainDecoder C.decodeMapLenOrIndef
+
+decodeNegWord :: Decoder s Word
+decodeNegWord = fromPlainDecoder C.decodeNegWord
+
+decodeNegWord64 :: Decoder s Word64
+decodeNegWord64 = fromPlainDecoder C.decodeNegWord64
+
+decodeNegWord64Canonical :: Decoder s Word64
+decodeNegWord64Canonical = fromPlainDecoder C.decodeNegWord64Canonical
+
+decodeNegWordCanonical :: Decoder s Word
+decodeNegWordCanonical = fromPlainDecoder C.decodeNegWordCanonical
+
+decodeNull :: Decoder s ()
+decodeNull = fromPlainDecoder C.decodeNull
+
+decodeSequenceLenIndef :: (r -> a -> r) -> r -> (r -> b) -> Decoder s a -> Decoder s b
+decodeSequenceLenIndef a b c dec =
+  withPlainDecoder dec $ C.decodeSequenceLenIndef a b c
+
+decodeSequenceLenN :: (r -> a -> r) -> r -> (r -> b) -> Int -> Decoder s a -> Decoder s b
+decodeSequenceLenN a b c n dec =
+  withPlainDecoder dec $ C.decodeSequenceLenN a b c n
+
+decodeSimple :: Decoder s Word8
+decodeSimple = fromPlainDecoder C.decodeSimple
+
+decodeSimpleCanonical :: Decoder s Word8
+decodeSimpleCanonical = fromPlainDecoder C.decodeSimpleCanonical
+
+decodeString :: Decoder s Text.Text
+decodeString = fromPlainDecoder C.decodeString
+
+decodeStringCanonical :: Decoder s Text.Text
+decodeStringCanonical = fromPlainDecoder C.decodeStringCanonical
+
+decodeStringIndef :: Decoder s ()
+decodeStringIndef = fromPlainDecoder C.decodeStringIndef
+
+decodeTag :: Decoder s Word
+decodeTag = fromPlainDecoder C.decodeTag
+
+decodeTag64 :: Decoder s Word64
+decodeTag64 = fromPlainDecoder C.decodeTag64
+
+decodeTag64Canonical :: Decoder s Word64
+decodeTag64Canonical = fromPlainDecoder C.decodeTag64Canonical
+
+decodeTagCanonical :: Decoder s Word
+decodeTagCanonical = fromPlainDecoder C.decodeTagCanonical
+
+decodeUtf8ByteArray :: Decoder s ByteArray
+decodeUtf8ByteArray = fromPlainDecoder C.decodeUtf8ByteArray
+
+decodeUtf8ByteArrayCanonical :: Decoder s ByteArray
+decodeUtf8ByteArrayCanonical = fromPlainDecoder C.decodeUtf8ByteArrayCanonical
+
+decodeWithByteSpan :: Decoder s a -> Decoder s (a, C.ByteOffset, C.ByteOffset)
+decodeWithByteSpan d = withPlainDecoder d C.decodeWithByteSpan
+
+decodeWord :: Decoder s Word
+decodeWord = fromPlainDecoder C.decodeWord
+
+decodeWord16 :: Decoder s Word16
+decodeWord16 = fromPlainDecoder C.decodeWord16
+
+decodeWord16Canonical :: Decoder s Word16
+decodeWord16Canonical = fromPlainDecoder C.decodeWord16Canonical
+
+decodeWord32 :: Decoder s Word32
+decodeWord32 = fromPlainDecoder C.decodeWord32
+
+decodeWord32Canonical :: Decoder s Word32
+decodeWord32Canonical = fromPlainDecoder C.decodeWord32Canonical
+
+decodeWord64 :: Decoder s Word64
+decodeWord64 = fromPlainDecoder C.decodeWord64
+
+decodeWord64Canonical :: Decoder s Word64
+decodeWord64Canonical = fromPlainDecoder C.decodeWord64Canonical
+
+decodeWord8 :: Decoder s Word8
+decodeWord8 = fromPlainDecoder C.decodeWord8
+
+decodeWord8Canonical :: Decoder s Word8
+decodeWord8Canonical = fromPlainDecoder C.decodeWord8Canonical
+
+decodeWordCanonical :: Decoder s Word
+decodeWordCanonical = fromPlainDecoder C.decodeWordCanonical
+
+decodeWordCanonicalOf :: Word -> Decoder s ()
+decodeWordCanonicalOf = fromPlainDecoder . C.decodeWordCanonicalOf
+
+decodeWordOf :: Word -> Decoder s ()
+decodeWordOf = fromPlainDecoder . C.decodeWordOf
+
+decodeTerm :: Decoder s C.Term
+decodeTerm = fromPlainDecoder C.decodeTerm
+
+peekAvailable :: Decoder s Int
+peekAvailable = fromPlainDecoder C.peekAvailable
+
+peekByteOffset :: Decoder s C.ByteOffset
+peekByteOffset = fromPlainDecoder C.peekByteOffset
+
+peekTokenType :: Decoder s C.TokenType
+peekTokenType = fromPlainDecoder C.peekTokenType

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Drop.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Drop.hs
@@ -1,0 +1,66 @@
+-- | A 'Dropper s' is a 'Decoder s ()', that is a decoder that returns nothing
+--
+--   We use 'Dropper's when we don't care about the result of decoding, for
+--   example when we have deprecated some part of the serialised blockchain, but
+--   still need to decode old blocks.
+module Cardano.Ledger.Binary.Decoding.Drop
+  ( Dropper,
+    dropBytes,
+    dropInt32,
+    dropList,
+    dropMap,
+    dropSet,
+    dropTuple,
+    dropTriple,
+    dropWord8,
+    dropWord64,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Decoder
+import Control.Monad (replicateM_)
+import Data.Functor (void)
+
+type Dropper s = Decoder s ()
+
+dropBytes :: Dropper s
+dropBytes = void decodeBytes
+
+dropInt32 :: Dropper s
+dropInt32 = void decodeInt32
+
+-- | Drop a list of values using the supplied `Dropper` for each element
+dropList :: Dropper s -> Dropper s
+dropList dropElems = do
+  decodeListLenIndef
+  decodeSequenceLenIndef const () id dropElems
+
+dropMap :: Dropper s -> Dropper s -> Dropper s
+dropMap dropKey dropValue = do
+  n <- decodeMapLen
+  replicateM_ n $ dropKey >> dropValue
+
+dropSet :: Dropper s -> Dropper s
+dropSet dropElem = do
+  void decodeTag
+  n <- decodeListLen
+  replicateM_ n dropElem
+
+dropTuple :: Dropper s -> Dropper s -> Dropper s
+dropTuple dropA dropB = do
+  decodeListLenOf 2
+  dropA
+  dropB
+
+dropTriple :: Dropper s -> Dropper s -> Dropper s -> Dropper s
+dropTriple dropA dropB dropC = do
+  decodeListLenOf 3
+  dropA
+  dropB
+  dropC
+
+dropWord8 :: Dropper s
+dropWord8 = void decodeWord8
+
+dropWord64 :: Dropper s
+dropWord64 = void decodeWord64

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
@@ -1,0 +1,297 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Ledger.Binary.Decoding.FromCBOR
+  ( FromCBOR (..),
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Decoder
+import Codec.CBOR.ByteArray (ByteArray (..))
+import Codec.CBOR.ByteArray.Sliced (SlicedByteArray, fromByteArray)
+import Codec.CBOR.Term (Term (..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Short.Internal as SBS
+import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.IP (IPv4, IPv6)
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe.Strict as SMaybe
+import qualified Data.Primitive.ByteArray as Prim
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Data.Tagged (Tagged (Tagged))
+import qualified Data.Text as T
+import Data.Time.Clock (NominalDiffTime, UTCTime (..))
+import Data.Typeable
+import qualified Data.VMap as VMap
+import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Unboxed as VU
+import Data.Void (Void)
+import Data.Word (Word16, Word32, Word64, Word8)
+import Numeric.Natural (Natural)
+import Prelude hiding (decodeFloat)
+
+class Typeable a => FromCBOR a where
+  fromCBOR :: Decoder s a
+
+  label :: Proxy a -> T.Text
+  label = T.pack . show . typeRep
+
+--------------------------------------------------------------------------------
+-- Primitive types
+--------------------------------------------------------------------------------
+
+instance FromCBOR () where
+  fromCBOR = decodeNull
+
+instance FromCBOR Bool where
+  fromCBOR = decodeBool
+
+--------------------------------------------------------------------------------
+-- Numeric data
+--------------------------------------------------------------------------------
+
+instance FromCBOR Integer where
+  fromCBOR = decodeInteger
+
+instance FromCBOR Natural where
+  fromCBOR = decodeNatural
+
+instance FromCBOR Word where
+  fromCBOR = decodeWord
+
+instance FromCBOR Word8 where
+  fromCBOR = decodeWord8
+
+instance FromCBOR Word16 where
+  fromCBOR = decodeWord16
+
+instance FromCBOR Word32 where
+  fromCBOR = decodeWord32
+
+instance FromCBOR Word64 where
+  fromCBOR = decodeWord64
+
+instance FromCBOR Int where
+  fromCBOR = decodeInt
+
+instance FromCBOR Int8 where
+  fromCBOR = decodeInt8
+
+instance FromCBOR Int16 where
+  fromCBOR = decodeInt16
+
+instance FromCBOR Int32 where
+  fromCBOR = decodeInt32
+
+instance FromCBOR Int64 where
+  fromCBOR = decodeInt64
+
+instance FromCBOR Float where
+  fromCBOR = decodeFloat
+
+instance FromCBOR Double where
+  fromCBOR = decodeDouble
+
+instance FromCBOR Rational where
+  fromCBOR = decodeRational
+
+instance FromCBOR Nano where
+  fromCBOR = MkFixed <$> fromCBOR
+
+instance FromCBOR Pico where
+  fromCBOR = MkFixed <$> fromCBOR
+
+instance FromCBOR NominalDiffTime where
+  fromCBOR = decodeNominalDiffTime
+
+instance FromCBOR Void where
+  fromCBOR = cborError DecoderErrorVoid
+
+instance FromCBOR Term where
+  fromCBOR = decodeTerm
+
+instance FromCBOR IPv4 where
+  fromCBOR = decodeIPv4
+
+instance FromCBOR IPv6 where
+  fromCBOR = decodeIPv6
+
+--------------------------------------------------------------------------------
+-- Tagged
+--------------------------------------------------------------------------------
+
+instance (Typeable s, FromCBOR a) => FromCBOR (Tagged s a) where
+  fromCBOR = Tagged <$> fromCBOR
+
+--------------------------------------------------------------------------------
+-- Containers
+--------------------------------------------------------------------------------
+
+instance (FromCBOR a, FromCBOR b) => FromCBOR (a, b) where
+  fromCBOR = do
+    decodeListLenOf 2
+    !x <- fromCBOR
+    !y <- fromCBOR
+    return (x, y)
+
+instance (FromCBOR a, FromCBOR b, FromCBOR c) => FromCBOR (a, b, c) where
+  fromCBOR = do
+    decodeListLenOf 3
+    !x <- fromCBOR
+    !y <- fromCBOR
+    !z <- fromCBOR
+    return (x, y, z)
+
+instance (FromCBOR a, FromCBOR b, FromCBOR c, FromCBOR d) => FromCBOR (a, b, c, d) where
+  fromCBOR = do
+    decodeListLenOf 4
+    !a <- fromCBOR
+    !b <- fromCBOR
+    !c <- fromCBOR
+    !d <- fromCBOR
+    return (a, b, c, d)
+
+instance
+  (FromCBOR a, FromCBOR b, FromCBOR c, FromCBOR d, FromCBOR e) =>
+  FromCBOR (a, b, c, d, e)
+  where
+  fromCBOR = do
+    decodeListLenOf 5
+    !a <- fromCBOR
+    !b <- fromCBOR
+    !c <- fromCBOR
+    !d <- fromCBOR
+    !e <- fromCBOR
+    return (a, b, c, d, e)
+
+instance
+  ( FromCBOR a,
+    FromCBOR b,
+    FromCBOR c,
+    FromCBOR d,
+    FromCBOR e,
+    FromCBOR f,
+    FromCBOR g
+  ) =>
+  FromCBOR (a, b, c, d, e, f, g)
+  where
+  fromCBOR = do
+    decodeListLenOf 7
+    !a <- fromCBOR
+    !b <- fromCBOR
+    !c <- fromCBOR
+    !d <- fromCBOR
+    !e <- fromCBOR
+    !f <- fromCBOR
+    !g <- fromCBOR
+    return (a, b, c, d, e, f, g)
+
+instance FromCBOR BS.ByteString where
+  fromCBOR = decodeBytes
+
+instance FromCBOR T.Text where
+  fromCBOR = decodeString
+
+instance FromCBOR BSL.ByteString where
+  fromCBOR = BSL.fromStrict <$> fromCBOR
+
+instance FromCBOR SBS.ShortByteString where
+  fromCBOR = do
+    BA (Prim.ByteArray ba) <- decodeByteArray
+    return $ SBS.SBS ba
+
+instance FromCBOR ByteArray where
+  fromCBOR = decodeByteArray
+
+instance FromCBOR Prim.ByteArray where
+  fromCBOR = unBA <$> decodeByteArray
+
+instance FromCBOR SlicedByteArray where
+  fromCBOR = fromByteArray . unBA <$> decodeByteArray
+
+instance FromCBOR a => FromCBOR [a] where
+  fromCBOR = decodeList fromCBOR
+
+instance (FromCBOR a, FromCBOR b) => FromCBOR (Either a b) where
+  fromCBOR = do
+    decodeListLenOf 2
+    t <- decodeWord
+    case t of
+      0 -> do
+        !x <- fromCBOR
+        return (Left x)
+      1 -> do
+        !x <- fromCBOR
+        return (Right x)
+      _ -> cborError $ DecoderErrorUnknownTag "Either" (fromIntegral t)
+
+instance FromCBOR a => FromCBOR (NonEmpty a) where
+  fromCBOR = do
+    ls <- fromCBOR
+    case nonEmpty ls of
+      Nothing -> cborError $ DecoderErrorEmptyList "NonEmpty"
+      Just ne -> pure ne
+
+instance FromCBOR a => FromCBOR (Maybe a) where
+  fromCBOR = decodeMaybe fromCBOR
+
+instance FromCBOR a => FromCBOR (SMaybe.StrictMaybe a) where
+  fromCBOR = SMaybe.maybeToStrictMaybe <$> decodeMaybe fromCBOR
+
+instance (Ord a, FromCBOR a) => FromCBOR (SSeq.StrictSeq a) where
+  fromCBOR = decodeStrictSeq fromCBOR
+
+instance (Ord a, FromCBOR a) => FromCBOR (Seq.Seq a) where
+  fromCBOR = decodeSeq fromCBOR
+
+instance (Ord a, FromCBOR a) => FromCBOR (Set.Set a) where
+  fromCBOR = decodeSet fromCBOR
+
+instance (Ord k, FromCBOR k, FromCBOR v) => FromCBOR (Map.Map k v) where
+  fromCBOR = decodeMap fromCBOR fromCBOR
+
+instance
+  ( Ord k,
+    FromCBOR k,
+    FromCBOR a,
+    Typeable kv,
+    Typeable av,
+    VMap.Vector kv k,
+    VMap.Vector av a
+  ) =>
+  FromCBOR (VMap.VMap kv av k a)
+  where
+  fromCBOR = decodeVMap fromCBOR fromCBOR
+
+instance FromCBOR a => FromCBOR (V.Vector a) where
+  fromCBOR = decodeVector fromCBOR
+  {-# INLINE fromCBOR #-}
+
+instance (FromCBOR a, VP.Prim a) => FromCBOR (VP.Vector a) where
+  fromCBOR = decodeVector fromCBOR
+  {-# INLINE fromCBOR #-}
+
+instance (FromCBOR a, VS.Storable a) => FromCBOR (VS.Vector a) where
+  fromCBOR = decodeVector fromCBOR
+  {-# INLINE fromCBOR #-}
+
+instance (FromCBOR a, VU.Unbox a) => FromCBOR (VU.Vector a) where
+  fromCBOR = decodeVector fromCBOR
+  {-# INLINE fromCBOR #-}
+
+--------------------------------------------------------------------------------
+-- Time
+--------------------------------------------------------------------------------
+
+instance FromCBOR UTCTime where
+  fromCBOR = decodeUTCTime

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Binary.Decoding.Sharing
+  ( FromSharedCBOR (..),
+    Interns (..),
+    Intern (..),
+    fromSharedLensCBOR,
+    fromSharedPlusLensCBOR,
+    fromNotSharedCBOR,
+    interns,
+    internsFromMap,
+    internsFromVMap,
+    toMemptyLens,
+    fromShareCBORfunctor,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Decoder
+import Cardano.Ledger.Binary.Decoding.FromCBOR
+import Control.Monad ((<$!>))
+import Control.Monad.Trans
+import Control.Monad.Trans.State.Strict
+import qualified Data.Foldable as F
+import Data.Kind
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict.Internal
+import Data.Primitive.Types (Prim)
+import Data.VMap (VB, VMap, VP)
+import qualified Data.VMap as VMap
+import Lens.Micro
+
+-- =======================================
+
+-- | This is an abstract interface that does the interning. In other words it
+-- does the actual sharing by looking up the supplied value in some existing
+-- data structure and uses that value instead. Relying on this interface gives us
+-- the benefit of ignoring the type of underlying data structure and allows us
+-- to compose many `Intern`s with the monoidal interface provided by `Interns`
+-- wrapper. In order to create an `Intern` see the `internsFromMap` or
+-- `internsFromVMap` functions.
+data Intern a = Intern
+  { -- | Function that will do the interning. If value is not available then
+    -- `Nothing` is returned.
+    internMaybe :: a -> Maybe a,
+    -- | Used for sorting. Normally set to the size of the underlying data
+    -- structure. Keeping interns sorted with respect to how many elements
+    -- is in the underlying data structure in theory gives a better chance of
+    -- successful intern hit sooner rather than later.
+    internWeight :: !Int
+  }
+
+newtype Interns a = Interns [Intern a]
+  deriving (Monoid)
+
+interns :: Interns k -> k -> k
+interns (Interns []) !k = k -- optimize for common case when there are no interns
+interns (Interns is) !k = go is
+  where
+    go [] = k
+    go (x : xs) =
+      case internMaybe x k of
+        Just kx -> kx
+        Nothing -> go xs
+{-# INLINE interns #-}
+
+internsFromMap :: Ord k => Map k a -> Interns k
+internsFromMap m =
+  Interns
+    [ Intern
+        { internMaybe = \k ->
+            let go Tip = Nothing
+                go (Bin _ kx _ l r) =
+                  case compare k kx of
+                    LT -> go l
+                    GT -> go r
+                    EQ -> Just kx
+             in go m,
+          internWeight = Map.size m
+        }
+    ]
+
+internsFromVMap :: Ord k => VMap VB kv k a -> Interns k
+internsFromVMap m =
+  Interns
+    [ Intern
+        { internMaybe = \k -> VMap.internMaybe k m,
+          internWeight = VMap.size m
+        }
+    ]
+
+instance Semigroup (Interns a) where
+  (<>) is1 (Interns []) = is1
+  (<>) (Interns []) is2 = is2
+  (<>) (Interns is1) (Interns is2) =
+    Interns (F.foldr insertIntoSortedInterns is2 is1)
+    where
+      insertIntoSortedInterns i [] = [i]
+      insertIntoSortedInterns i (a : as)
+        | internWeight a > internWeight i = a : insertIntoSortedInterns i as
+        | otherwise = i : a : as
+
+class Monoid (Share a) => FromSharedCBOR a where
+  {-# MINIMAL (fromSharedCBOR | fromSharedPlusCBOR) #-}
+  type Share a :: Type
+  type Share a = ()
+
+  -- | Whenever `fromShareCBOR` is being used for defining the instance this
+  -- function should return the state that can be added whenever user invokes
+  -- `fromSharedPlusCBOR`. `mempty` is returned by default.
+  getShare :: a -> Share a
+  getShare _ = mempty
+
+  -- | Utilize sharing when decoding, but do not add anything to the state for
+  -- future sharing.
+  fromSharedCBOR :: Share a -> Decoder s a
+  fromSharedCBOR s = fst <$> runStateT fromSharedPlusCBOR s
+
+  -- | Deserialize with sharing and add to the state that is used for sharing. Default
+  -- implementation will add value returned by `getShare` for adding to the
+  -- state.
+  fromSharedPlusCBOR :: StateT (Share a) (Decoder s) a
+  fromSharedPlusCBOR = do
+    s <- get
+    x <- lift $ fromSharedCBOR s
+    x <$ put (getShare x <> s)
+
+fromSharedLensCBOR ::
+  FromSharedCBOR b =>
+  SimpleGetter bs (Share b) ->
+  StateT bs (Decoder s) b
+fromSharedLensCBOR l = do
+  s <- get
+  lift $ fromSharedCBOR (s ^. l)
+
+-- | Using this function it is possible to compose two lenses. One will extract
+-- a value and another will used it for placing it into a empty monoid. Here is
+-- an example of how a second element of a tuple can be projected on the third
+-- element of a 3-tuple.
+--
+-- > toMemptyLens _3 _2 == lens (\(_, b) -> (mempty, mempty, b)) (\(a, _) (_, _, b) -> (a, b))
+--
+-- Here is an example where we extract a second element of a tuple and insert it at
+-- third position of a three tuple while all other elements are set to `mempty`:
+--
+-- >>> import Lens.Micro
+-- >>> ("foo","bar") ^. toMemptyLens _3 _2 :: (Maybe String, (), String)
+-- (Nothing,(),"bar")
+--
+-- In the opposite direction of extracting the third element of a 3-tuple and
+-- replacing the second element of the tuple the setter is being applied to
+--
+-- >>> ("foo","bar") & toMemptyLens _3 _2 .~ (Just "baz", (), "booyah") :: (String, String)
+-- ("foo","booyah")
+toMemptyLens :: Monoid a => Lens' a b -> Lens' c b -> Lens' c a
+toMemptyLens lto lfrom =
+  lens (\s -> mempty & lto .~ (s ^. lfrom)) (\s a -> s & lfrom .~ (a ^. lto))
+
+-- | Just like `fromSharedPlusCBOR`, except allows to transform the shared state
+-- with a lens.
+fromSharedPlusLensCBOR ::
+  FromSharedCBOR b =>
+  Lens' bs (Share b) ->
+  StateT bs (Decoder s) b
+fromSharedPlusLensCBOR l = do
+  s <- get
+  (x, k) <- lift $ runStateT fromSharedPlusCBOR (s ^. l)
+  x <$ put (s & l .~ k)
+
+-- | Use `FromSharedCBOR` class while ignoring sharing
+fromNotSharedCBOR :: FromSharedCBOR a => Decoder s a
+fromNotSharedCBOR = fromSharedCBOR mempty
+
+instance (Ord k, FromCBOR k, FromCBOR v) => FromSharedCBOR (Map k v) where
+  type Share (Map k v) = (Interns k, Interns v)
+  fromSharedCBOR (kis, vis) = do
+    decodeMap (interns kis <$> fromCBOR) (interns vis <$> fromCBOR)
+  getShare !m = (internsFromMap m, mempty)
+
+instance (Ord k, FromCBOR k, FromCBOR v) => FromSharedCBOR (VMap VB VB k v) where
+  type Share (VMap VB VB k v) = (Interns k, Interns v)
+  fromSharedCBOR (kis, vis) = do
+    decodeVMap (interns kis <$> fromCBOR) (interns vis <$> fromCBOR)
+  getShare !m = (internsFromVMap m, mempty)
+
+instance (Ord k, FromCBOR k, FromCBOR v, Prim v) => FromSharedCBOR (VMap VB VP k v) where
+  type Share (VMap VB VP k v) = Interns k
+  fromSharedCBOR kis = do
+    decodeVMap (interns kis <$> fromCBOR) fromCBOR
+  getShare !m = internsFromVMap m
+
+-- | Share every item in a functor, have deserializing it
+fromShareCBORfunctor :: (FromCBOR (f b), Monad f) => Interns b -> Decoder s (f b)
+fromShareCBORfunctor kis = do
+  sm <- fromCBOR
+  pure (interns kis <$!> sm)

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Ledger.Binary.Decoding.Sized
+  ( Sized (..),
+    mkSized,
+    decodeSized,
+    sizedDecoder,
+    toSizedL,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Annotated (Annotated (..), ByteSpan (..), annotatedDecoder)
+import Cardano.Ledger.Binary.Decoding.Decoder (Decoder)
+import Cardano.Ledger.Binary.Decoding.FromCBOR (FromCBOR (fromCBOR))
+import Cardano.Ledger.Binary.Encoding (serialize)
+import Cardano.Ledger.Binary.Encoding.ToCBOR (ToCBOR (toCBOR))
+import Cardano.Ledger.Binary.Version (Version)
+import Control.DeepSeq (NFData (..), deepseq)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Int (Int64)
+import GHC.Generics (Generic)
+import Lens.Micro (Lens', lens, (&), (.~), (^.))
+import NoThunks.Class (NoThunks)
+
+-- | A CBOR deserialized value together with its size. When deserializing use
+-- either `decodeSized` or its `FromCBOR` instance.
+--
+-- Use `mkSized` to construct such value.
+data Sized a = Sized
+  { sizedValue :: !a,
+    -- | Overhead in bytes. The field is lazy on purpose, because it might not
+    -- be needed, but it can be expensive to compute.
+    sizedSize :: Int64
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks a => NoThunks (Sized a)
+
+instance NFData a => NFData (Sized a) where
+  rnf (Sized val sz) = val `deepseq` sz `seq` ()
+
+-- | Construct a `Sized` value by serializing it first and recording the amount
+-- of bytes it requires. Note, however, CBOR serialization is not canonical,
+-- therefore it is *NOT* a requirement that this property holds:
+--
+-- > sizedSize (mkSized a) === sizedSize (unsafeDeserialize (serialize a) :: a)
+mkSized :: ToCBOR a => Version -> a -> Sized a
+mkSized version a =
+  Sized
+    { sizedValue = a,
+      sizedSize = BSL.length (serialize version a)
+    }
+
+decodeSized :: Decoder s a -> Decoder s (Sized a)
+decodeSized decoder = do
+  Annotated v (ByteSpan start end) <- annotatedDecoder decoder
+  pure $! Sized v $! end - start
+
+sizedDecoder :: Decoder s a -> Decoder s (Sized a)
+sizedDecoder = decodeSized
+{-# DEPRECATED sizedDecoder "In favor of more consistently named `decodeSized`" #-}
+
+instance FromCBOR a => FromCBOR (Sized a) where
+  fromCBOR = decodeSized fromCBOR
+
+-- | Discards the size.
+instance ToCBOR a => ToCBOR (Sized a) where
+  -- Size is an auxiliary value and should not be transmitted over the wire,
+  -- therefore it is ignored.
+  toCBOR (Sized v _) = toCBOR v
+
+-- | Take a lens that operates on a particular type and convert it into a lens
+-- that operates on the `Sized` version of the type.
+toSizedL :: ToCBOR s => Version -> Lens' s a -> Lens' (Sized s) a
+toSizedL version l =
+  lens (\sv -> sizedValue sv ^. l) (\sv a -> mkSized version (sizedValue sv & l .~ a))
+{-# INLINEABLE toSizedL #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Ledger.Binary.Encoding
+  ( -- * Running decoders
+    serialize,
+    serialize',
+    serializeBuilder,
+    serializeEncoding,
+    serializeEncoding',
+    module Cardano.Ledger.Binary.Version,
+    module Cardano.Ledger.Binary.Encoding.Encoder,
+    module Cardano.Ledger.Binary.Encoding.ToCBOR,
+
+    -- * Nested CBOR-in-CBOR
+    encodeNestedCbor,
+    encodeNestedCborBytes,
+    nestedCborSizeExpr,
+    nestedCborBytesSizeExpr,
+
+    -- * Tools
+    runByteBuilder,
+
+    -- * Deprecated
+    toCBORMaybe,
+  )
+where
+
+import Cardano.Ledger.Binary.Encoding.Encoder
+import Cardano.Ledger.Binary.Encoding.ToCBOR
+import Cardano.Ledger.Binary.Version
+import qualified Data.ByteString as BS
+import Data.ByteString.Builder (Builder)
+import Data.ByteString.Builder.Extra (safeStrategy, toLazyByteStringWith)
+import qualified Data.ByteString.Lazy as BSL
+
+-- | Serialize a Haskell value with a 'ToCBOR' instance to an external binary
+--   representation.
+--
+--   The output is represented as a lazy 'LByteString' and is constructed
+--   incrementally.
+serialize :: ToCBOR a => Version -> a -> BSL.ByteString
+serialize version = serializeEncoding version . toCBOR
+
+-- | Serialize a Haskell value to an external binary representation.
+--
+--   The output is represented as a strict 'ByteString'.
+serialize' :: ToCBOR a => Version -> a -> BS.ByteString
+serialize' version = BSL.toStrict . serialize version
+
+-- | Serialize into a Builder. Useful if you want to throw other ByteStrings
+--   around it.
+serializeBuilder :: ToCBOR a => Version -> a -> Builder
+serializeBuilder version = toBuilder version . toCBOR
+
+-- | Serialize a Haskell value to an external binary representation using the
+--   provided CBOR 'Encoding'
+--
+--   The output is represented as an 'LByteString' and is constructed
+--   incrementally.
+serializeEncoding :: Version -> Encoding -> BSL.ByteString
+serializeEncoding version =
+  toLazyByteStringWith strategy mempty . toBuilder version
+  where
+    -- 1024 is the size of the first buffer, 4096 is the size of subsequent
+    -- buffers. Chosen because they seem to give good performance. They are not
+    -- sacred.
+    strategy = safeStrategy 1024 4096
+
+-- | A strict version of 'serializeEncoding'
+serializeEncoding' :: Version -> Encoding -> BS.ByteString
+serializeEncoding' version = BSL.toStrict . serializeEncoding version
+
+--------------------------------------------------------------------------------
+-- Nested CBOR-in-CBOR
+-- https://tools.ietf.org/html/rfc7049#section-2.4.4.1
+--------------------------------------------------------------------------------
+
+-- | Encode and serialise the given `a` and sorround it with the semantic tag 24
+--   In CBOR diagnostic notation:
+--   >>> 24(h'DEADBEEF')
+encodeNestedCbor :: ToCBOR a => a -> Encoding
+encodeNestedCbor value =
+  encodeTag 24
+    <> withCurrentEncodingVersion (\version -> toCBOR (serialize version value))
+
+-- | Like `encodeNestedCbor`, but assumes nothing about the shape of
+--   input object, so that it must be passed as a binary `ByteString` blob. It's
+--   the caller responsibility to ensure the input `ByteString` correspond
+--   indeed to valid, previously-serialised CBOR data.
+encodeNestedCborBytes :: BSL.ByteString -> Encoding
+encodeNestedCborBytes x = encodeTag 24 <> toCBOR x
+
+nestedCborSizeExpr :: Size -> Size
+nestedCborSizeExpr x = 2 + apMono "withWordSize" withWordSize x + x
+
+nestedCborBytesSizeExpr :: Size -> Size
+nestedCborBytesSizeExpr x = 2 + apMono "withWordSize" withWordSize x + x
+
+--------------------------------------------------------------------------------
+-- Tools
+--------------------------------------------------------------------------------
+
+-- | Run a ByteString 'Builder' using a strategy aimed at making smaller
+-- things efficiently.
+--
+-- It takes a size hint and produces a strict 'ByteString'. This will be fast
+-- when the size hint is the same or slightly bigger than the true size.
+runByteBuilder :: Int -> Builder -> BS.ByteString
+runByteBuilder !sizeHint =
+  BSL.toStrict . toLazyByteStringWith (safeStrategy sizeHint (2 * sizeHint)) mempty
+{-# NOINLINE runByteBuilder #-}
+
+--------------------------------------------------------------------------------
+-- Deprecations
+--------------------------------------------------------------------------------
+
+toCBORMaybe :: (a -> Encoding) -> (Maybe a -> Encoding)
+toCBORMaybe = encodeMaybe
+{-# DEPRECATED toCBORMaybe "In favor of `encodeMaybe`" #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Coders.hs
@@ -1,0 +1,239 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Data.Coders provides tools for writing 'ToCBOR' and 'FromCBOR' instances (see module
+--   'Cardano.Binary') in an intuitive way that mirrors the way one constructs values of a
+--   particular type. Advantages include:
+--
+-- 1. Book-keeping details neccesary to write correct instances are hidden from the user.
+-- 2. Inverse 'ToCBOR' and 'FromCBOR' instances have visually similar definitions.
+-- 3. Advanced instances involving sparse-encoding, compact-representation, and 'Annotator' instances are also supported.
+--
+-- A Guide to Visual inspection of Duality in Encode and Decode
+--
+-- 1. @(Sum c)@     and @(SumD c)@    are duals
+-- 2. @(Rec c)@     and @(RecD c)@    are duals
+-- 3. @(Keyed c)@   and @(KeyedD c)@  are duals
+-- 4. @(OmitC x)@   and @(Emit x)@    are duals
+-- 5. @(Omit p ..)@ and @(Emit x)@    are duals if (p x) is True
+-- 6. @(To x)@      and @(From)@      are duals if (x::T) and (forall (y::T). isRight (roundTrip y))
+-- 7. @(E enc x)@   and @(D dec)@     are duals if (forall x . isRight (roundTrip' enc dec x))
+-- 6. @(ED d x)@    and @(DD f)@      are duals as long as d=(Dual enc dec) and (forall x . isRight (roundTrip' enc dec x))
+-- 7. @(f !> x)@    and @(g <! y)@    are duals if (f and g are duals) and (x and y are duals)
+--
+-- Duality properties of @(Summands name decodeT)@ and @(SparseKeyed name (init::T) pick required)@ also exist
+-- but are harder to describe succinctly.
+module Cardano.Ledger.Binary.Encoding.Coders
+  ( -- * Creating encoders.
+
+    --
+    -- $Encoders
+    Encode (..),
+    (!>),
+    encode,
+
+    -- * Index types for well-formed Coders.
+
+    --
+    -- $Indexes
+    runE, -- Used in testing
+    encodeDual,
+
+    -- * Containers, Combinators, Annotators
+
+    --
+    -- $Combinators
+    encodeKeyedStrictMaybeWith,
+    encodeKeyedStrictMaybe,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding.Coders (Density (Dense, Sparse), Wrapped (..))
+import Cardano.Ledger.Binary.Decoding.Decoder (Decoder)
+import Cardano.Ledger.Binary.Decoding.FromCBOR (FromCBOR (..))
+import Cardano.Ledger.Binary.Encoding.Encoder
+  ( Encoding,
+    encodeListLen,
+    encodeMapLen,
+    encodeTag,
+    encodeWord,
+  )
+import Cardano.Ledger.Binary.Encoding.ToCBOR (ToCBOR (toCBOR))
+import Data.Maybe.Strict (StrictMaybe (SJust, SNothing))
+
+-- ====================================================================
+
+-- ===============================================================================
+-- Encode and Decode are typed data structures which specify encoders and decoders
+-- for Algebraic data structures written in Haskell. They exploit types and count
+-- the correct number fields in an encoding and decoding, which are automatically computed.
+-- They are somewhat dual, and are designed so that visual inspection of a Encode and
+-- its dual Decode can help the user conclude that the two are self-consistent.
+-- They are also reusable abstractions that can be defined once, and then used many places.
+--
+-- (Encode t) is a data structure from which 3 things can be recovered
+-- Given:    x :: Encode t
+-- 1. get a value of type t
+-- 2. get an Encoding for that value, which correctly encodes the number of "fields"
+--    written to the ByteString. Care must still be taken that the Keys are correct.
+-- 3. get a (MemoBytes t)
+--
+-- The advantage of using Encode with a MemoBytes, is we don't have to make a ToCBOR
+-- instance. Instead the "instance" is spread amongst the pattern constuctors by using
+-- (memoBytes encoding) in the where clause of the pattern contructor.
+-- See some examples of this see the file Timelocks.hs
+--
+
+-- ===========================================================
+-- The coders and the decoders as GADT datatypes
+-- ===========================================================
+
+-- Encoders
+
+-- | A first-order domain specific langage for describing ToCBOR instances. Applying
+--   the interpreter 'encode' to a well-typed @(Encode w T)@ always produces a valid encoding for @T@.
+--   Constructing an Encode of type T is just like building a value of type T, applying a constructor
+--   of @T@ to the correctly typed arguments. For example
+--
+-- @
+-- data T = T Bool Word
+--
+-- instance ToCBOR T where
+--   toCBOR (T b w) = encode (Rec T !> To b !> To w)
+-- @
+--
+-- Note the similarity of
+--
+-- @(/T/ /b/ /w/)@ and @(/T/ $ /b/ $ /w/)@ and @(Rec /T/ !> To /b/ !> To /w/)@
+--
+-- Where ('!>') is the infx version of 'ApplyE' with the same infixity and precedence as ('$'). Note
+-- how the constructor and each (component, field, argument) is labeled with one of the constructors
+-- of 'Encode', and are combined with the application operator ('!>'). Using different constructors supports
+-- different styles of encoding.
+data Encode (w :: Wrapped) t where
+  -- | Label the constructor of a Record-like datatype (one with exactly 1 constructor) as an Encode.
+  Rec :: t -> Encode ('Closed 'Dense) t
+  -- | Label one of the constructors of a sum datatype (one with multiple constructors) as an Encode
+  Sum :: t -> Word -> Encode 'Open t
+  -- | Label the constructor of a Record-like datatype as being encoded sparsely (storing only non-default values).
+  Keyed :: t -> Encode ('Closed 'Sparse) t
+  -- | Label an (component, field, argument) to be encoded using an existing ToCBOR instance.
+  To :: ToCBOR a => a -> Encode ('Closed 'Dense) a
+  -- | Label a  (component, field, argument) to be encoded using the given encoding function.
+  E :: (t -> Encoding) -> t -> Encode ('Closed 'Dense) t
+  -- | Lift one Encode to another with a different type. Used to make a Functor instance of (Encode w).
+  MapE :: (a -> b) -> Encode w a -> Encode w b
+  -- | Skip over the  (component,field, argument), don't encode it at all (used in sparse encoding).
+  OmitC :: t -> Encode w t
+  -- | Precede the given encoding (in the produced bytes) with the given tag Word.
+  Tag :: Word -> Encode ('Closed x) t -> Encode ('Closed x) t
+  -- | Omit the  (component,field, argument) if the function is True, otherwise encode with the given encoding.
+  Omit ::
+    (t -> Bool) ->
+    Encode ('Closed 'Sparse) t ->
+    Encode ('Closed 'Sparse) t
+  -- | Precede the encoding (in the produced bytes) with the key Word. Analagous to 'Tag', but lifts a 'Dense' encoding to a 'Sparse' encoding.
+  Key :: Word -> Encode ('Closed 'Dense) t -> Encode ('Closed 'Sparse) t
+  -- | Apply a functional encoding (arising from 'Rec' or 'Sum') to get (type wise) smaller encoding. A fully saturated chain of 'ApplyE' will be a complete encoding. See also '!>' which is infix 'ApplyE'.
+  ApplyE :: Encode w (a -> t) -> Encode ('Closed r) a -> Encode w t
+
+-- The Wrapped index of ApplyE is determined by the index
+-- at the bottom of its left spine. The choices are 'Open (Sum c tag),
+-- ('Closed 'Dense) (Rec c), and ('Closed 'Sparse) (Keyed c).
+
+infixl 4 !>
+
+-- | Infix operator version of @ApplyE@. Has the same infxity and operator precedence as '$'
+(!>) :: Encode w (a -> t) -> Encode ('Closed r) a -> Encode w t
+x !> y = ApplyE x y
+
+runE :: Encode w t -> t
+runE (Sum cn _) = cn
+runE (Rec cn) = cn
+runE (ApplyE f x) = runE f (runE x)
+runE (To x) = x
+runE (E _ x) = x
+runE (MapE f x) = f $ runE x
+runE (OmitC x) = x
+runE (Omit _ x) = runE x
+runE (Tag _ x) = runE x
+runE (Key _ x) = runE x
+runE (Keyed cn) = cn
+
+gsize :: Encode w t -> Word
+gsize (Sum _ _) = 0
+gsize (Rec _) = 0
+gsize (To _) = 1
+gsize (E _ _) = 1
+gsize (MapE _ x) = gsize x
+gsize (ApplyE f x) = gsize f + gsize x
+gsize (OmitC _) = 0
+gsize (Omit p x) = if p (runE x) then 0 else gsize x
+gsize (Tag _ _) = 1
+gsize (Key _ x) = gsize x
+gsize (Keyed _) = 0
+
+-- | Translate a first-order @(Encode w d) domain specific langage program, into an 'Encoding' .
+encode :: Encode w t -> Encoding
+encode = encodeCountPrefix 0
+  where
+    encodeCountPrefix :: Word -> Encode w t -> Encoding
+    -- n is the number of fields we must write in the prefix.
+    encodeCountPrefix n (Sum _ tag) = encodeListLen (n + 1) <> encodeWord tag
+    encodeCountPrefix n (Keyed _) = encodeMapLen n
+    encodeCountPrefix n (Rec _) = encodeListLen n
+    encodeCountPrefix _ (To x) = toCBOR x
+    encodeCountPrefix _ (E enc x) = enc x
+    encodeCountPrefix n (MapE _ x) = encodeCountPrefix n x
+    encodeCountPrefix _ (OmitC _) = mempty
+    encodeCountPrefix n (Tag tag x) = encodeTag tag <> encodeCountPrefix n x
+    encodeCountPrefix n (Key tag x) = encodeWord tag <> encodeCountPrefix n x
+    encodeCountPrefix n (Omit p x) =
+      if p (runE x) then mempty else encodeCountPrefix n x
+    encodeCountPrefix n (ApplyE ff xx) = encodeCountPrefix (n + gsize xx) ff <> encodeClosed xx
+      where
+        encodeClosed :: Encode ('Closed d) t -> Encoding
+        encodeClosed (Rec _) = mempty
+        encodeClosed (To x) = toCBOR x
+        encodeClosed (E enc x) = enc x
+        encodeClosed (MapE _ x) = encodeClosed x
+        encodeClosed (ApplyE f x) = encodeClosed f <> encodeClosed x
+        encodeClosed (OmitC _) = mempty
+        encodeClosed (Omit p x) =
+          if p (runE x) then mempty else encodeClosed x
+        encodeClosed (Tag tag x) = encodeTag tag <> encodeClosed x
+        encodeClosed (Key tag x) = encodeWord tag <> encodeClosed x
+        encodeClosed (Keyed _) = mempty
+
+encodeKeyedStrictMaybeWith ::
+  Word ->
+  (a -> Encoding) ->
+  StrictMaybe a ->
+  Encode ('Closed 'Sparse) (StrictMaybe a)
+encodeKeyedStrictMaybeWith _ _ SNothing = OmitC SNothing
+encodeKeyedStrictMaybeWith key enc (SJust x) = Key key (MapE SJust $ E enc x)
+
+encodeKeyedStrictMaybe ::
+  ToCBOR a =>
+  Word ->
+  StrictMaybe a ->
+  Encode ('Closed 'Sparse) (StrictMaybe a)
+encodeKeyedStrictMaybe key = encodeKeyedStrictMaybeWith key toCBOR
+
+-- | Use `encodeDual` and `Cardano.Ledger.Binary.Coders.decodeDual`, when you want to
+-- guarantee that a type has both `ToCBOR` and `FromCBR` instances.
+encodeDual :: forall t. (ToCBOR t, FromCBOR t) => t -> Encode ('Closed 'Dense) t
+encodeDual = E toCBOR
+  where
+    -- Enforce FromCBOR constraint on t
+    _fromCBOR = fromCBOR :: Decoder s t

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
@@ -1,0 +1,478 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Binary.Encoding.Encoder
+  ( -- * Decoders
+    Encoding,
+    toBuilder,
+    C.Tokens (..),
+    toPlainEncoding,
+    fromPlainEncoding,
+    fromPlainEncodingWithVersion,
+    withCurrentEncodingVersion,
+    enforceVersionEncoding,
+
+    -- ** Custom
+    encodeMaybe,
+    encodeNullMaybe,
+    encodePair,
+    encodeTuple,
+    encodeRatio,
+
+    -- *** Containers
+    encodeList,
+    encodeSeq,
+    encodeSet,
+    encodeMap,
+    encodeVMap,
+    encodeVector,
+
+    -- *** Time
+    encodeUTCTime,
+    encodeNominalDiffTime,
+
+    -- *** Network
+    encodeIPv4,
+    ipv4ToBytes,
+    encodeIPv6,
+    ipv6ToBytes,
+
+    -- ** Original
+    encodeWord,
+    encodeWord8,
+    encodeWord16,
+    encodeWord32,
+    encodeWord64,
+    encodeInt,
+    encodeInt8,
+    encodeInt16,
+    encodeInt32,
+    encodeInt64,
+    encodeInteger,
+    encodeBytes,
+    encodeBytesIndef,
+    encodeByteArray,
+    encodeString,
+    encodeStringIndef,
+    encodeUtf8ByteArray,
+    encodeListLen,
+    encodeListLenIndef,
+    encodeMapLen,
+    encodeMapLenIndef,
+    encodeBreak,
+    encodeTag,
+    encodeTag64,
+    encodeBool,
+    encodeUndef,
+    encodeNull,
+    encodeSimple,
+    encodeFloat16,
+    encodeFloat,
+    encodeDouble,
+    encodePreEncoded,
+    encodeTerm,
+  )
+where
+
+import qualified Cardano.Binary as C
+import Cardano.Ledger.Binary.Decoding.Decoder (setTag)
+import Cardano.Ledger.Binary.Version
+import Codec.CBOR.ByteArray.Sliced (SlicedByteArray)
+import qualified Codec.CBOR.Term as C (Term (..), encodeTerm)
+import qualified Codec.CBOR.Write as CBOR (toBuilder)
+import Data.Binary.Put (putWord32le, runPut)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Fixed (E12, resolution)
+import Data.Foldable (foldMap')
+import Data.IP (IPv4, IPv6, toHostAddress, toHostAddress6)
+import Data.Int (Int16, Int32, Int64, Int8)
+import qualified Data.Map.Strict as Map
+import Data.Monoid (Sum (..))
+import Data.Proxy (Proxy (Proxy))
+import Data.Ratio (Ratio, denominator, numerator)
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+import Data.Text (Text)
+import Data.Time.Calendar.OrdinalDate (toOrdinalDate)
+import Data.Time.Clock (NominalDiffTime, UTCTime (..), diffTimeToPicoseconds)
+import qualified Data.VMap as VMap
+import qualified Data.Vector.Generic as VG
+import Data.Word (Word16, Word32, Word64, Word8)
+import Prelude hiding (encodeFloat)
+
+--------------------------------------------------------------------------------
+-- Versioned Encoder
+--------------------------------------------------------------------------------
+
+newtype Encoding = Encoding (Version -> C.Encoding)
+  deriving (Semigroup, Monoid)
+
+fromPlainEncoding :: C.Encoding -> Encoding
+fromPlainEncoding enc = Encoding (const enc)
+
+fromPlainEncodingWithVersion :: (Version -> C.Encoding) -> Encoding
+fromPlainEncodingWithVersion = Encoding
+
+toPlainEncoding :: Version -> Encoding -> C.Encoding
+toPlainEncoding v (Encoding enc) = enc v
+
+toBuilder :: Version -> Encoding -> Builder
+toBuilder version (Encoding enc) = CBOR.toBuilder $ enc version
+
+-- | Get access to the current version being used in the encoder
+withCurrentEncodingVersion :: (Version -> Encoding) -> Encoding
+withCurrentEncodingVersion f =
+  Encoding $ \version -> toPlainEncoding version $ f version
+
+-- | Ignore the current version of the encoder and enforce the supplied one instead.
+enforceVersionEncoding :: Version -> Encoding -> Encoding
+enforceVersionEncoding version encoding = fromPlainEncoding (toPlainEncoding version encoding)
+
+-- | Conditionoly choose the encoder newer or older deceder, depending on the current
+-- version. Supplied version acts as a pivot.
+--
+-- =====__Example__
+ifEncodingVersionAtLeast ::
+  Version ->
+  -- | Use this encoder if current encoder version is larger or equal to the supplied
+  -- `Version`
+  Encoding ->
+  -- | Use this encoder if current encoder version is lower than the supplied `Version`
+  Encoding ->
+  Encoding
+ifEncodingVersionAtLeast atLeast (Encoding newerEncoding) (Encoding olderEncoding) =
+  Encoding $ \cur ->
+    if cur >= atLeast
+      then newerEncoding cur
+      else olderEncoding cur
+
+--------------------------------------------------------------------------------
+-- Wrapped CBORG encoders
+--------------------------------------------------------------------------------
+
+encodeWord :: Word -> Encoding
+encodeWord e = fromPlainEncoding (C.encodeWord e)
+
+encodeWord8 :: Word8 -> Encoding
+encodeWord8 e = fromPlainEncoding (C.encodeWord8 e)
+
+encodeWord16 :: Word16 -> Encoding
+encodeWord16 e = fromPlainEncoding (C.encodeWord16 e)
+
+encodeWord32 :: Word32 -> Encoding
+encodeWord32 e = fromPlainEncoding (C.encodeWord32 e)
+
+encodeWord64 :: Word64 -> Encoding
+encodeWord64 e = fromPlainEncoding (C.encodeWord64 e)
+
+encodeInt :: Int -> Encoding
+encodeInt e = fromPlainEncoding (C.encodeInt e)
+
+encodeInt8 :: Int8 -> Encoding
+encodeInt8 e = fromPlainEncoding (C.encodeInt8 e)
+
+encodeInt16 :: Int16 -> Encoding
+encodeInt16 e = fromPlainEncoding (C.encodeInt16 e)
+
+encodeInt32 :: Int32 -> Encoding
+encodeInt32 e = fromPlainEncoding (C.encodeInt32 e)
+
+encodeInt64 :: Int64 -> Encoding
+encodeInt64 e = fromPlainEncoding (C.encodeInt64 e)
+
+encodeInteger :: Integer -> Encoding
+encodeInteger e = fromPlainEncoding (C.encodeInteger e)
+
+encodeBytes :: ByteString -> Encoding
+encodeBytes e = fromPlainEncoding (C.encodeBytes e)
+
+encodeBytesIndef :: Encoding
+encodeBytesIndef = fromPlainEncoding C.encodeBytesIndef
+
+encodeByteArray :: SlicedByteArray -> Encoding
+encodeByteArray e = fromPlainEncoding (C.encodeByteArray e)
+
+encodeString :: Text -> Encoding
+encodeString e = fromPlainEncoding (C.encodeString e)
+
+encodeStringIndef :: Encoding
+encodeStringIndef = fromPlainEncoding C.encodeStringIndef
+
+encodeUtf8ByteArray :: SlicedByteArray -> Encoding
+encodeUtf8ByteArray e = fromPlainEncoding (C.encodeUtf8ByteArray e)
+
+encodeListLen :: Word -> Encoding
+encodeListLen e = fromPlainEncoding (C.encodeListLen e)
+
+encodeListLenIndef :: Encoding
+encodeListLenIndef = fromPlainEncoding C.encodeListLenIndef
+
+encodeMapLen :: Word -> Encoding
+encodeMapLen e = fromPlainEncoding (C.encodeMapLen e)
+
+encodeMapLenIndef :: Encoding
+encodeMapLenIndef = fromPlainEncoding C.encodeMapLenIndef
+
+encodeBreak :: Encoding
+encodeBreak = fromPlainEncoding C.encodeBreak
+
+encodeTag :: Word -> Encoding
+encodeTag e = fromPlainEncoding (C.encodeTag e)
+
+encodeTag64 :: Word64 -> Encoding
+encodeTag64 e = fromPlainEncoding (C.encodeTag64 e)
+
+encodeBool :: Bool -> Encoding
+encodeBool e = fromPlainEncoding (C.encodeBool e)
+
+encodeUndef :: Encoding
+encodeUndef = fromPlainEncoding C.encodeUndef
+
+encodeNull :: Encoding
+encodeNull = fromPlainEncoding C.encodeNull
+
+encodeSimple :: Word8 -> Encoding
+encodeSimple e = fromPlainEncoding (C.encodeSimple e)
+
+encodeFloat16 :: Float -> Encoding
+encodeFloat16 e = fromPlainEncoding (C.encodeFloat16 e)
+
+encodeFloat :: Float -> Encoding
+encodeFloat e = fromPlainEncoding (C.encodeFloat e)
+
+encodeDouble :: Double -> Encoding
+encodeDouble e = fromPlainEncoding (C.encodeDouble e)
+
+encodePreEncoded :: ByteString -> Encoding
+encodePreEncoded e = fromPlainEncoding (C.encodePreEncoded e)
+
+encodeTerm :: C.Term -> Encoding
+encodeTerm = fromPlainEncoding . C.encodeTerm
+
+--------------------------------------------------------------------------------
+-- Custom
+--------------------------------------------------------------------------------
+
+encodeRatio :: (t -> Encoding) -> Ratio t -> Encoding
+encodeRatio encodeNumeric r =
+  ifEncodingVersionAtLeast (natVersion @2) (encodeTag 30) mempty
+    <> encodeListLen 2
+    <> encodeNumeric (numerator r)
+    <> encodeNumeric (denominator r)
+
+--------------------------------------------------------------------------------
+-- Containers
+--------------------------------------------------------------------------------
+
+encodeMaybe :: (a -> Encoding) -> Maybe a -> Encoding
+encodeMaybe encodeValue = \case
+  Nothing -> encodeListLen 0
+  Just x -> encodeListLen 1 <> encodeValue x
+
+-- | Alternative way to encode a Maybe type.
+--
+-- /Note/ - this is not the default method for encoding `Maybe`, use `encodeMaybe` instead
+encodeNullMaybe :: (a -> Encoding) -> Maybe a -> Encoding
+encodeNullMaybe encodeValue = \case
+  Nothing -> encodeNull
+  Just x -> encodeValue x
+
+encodeTuple :: (a -> Encoding) -> (b -> Encoding) -> (a, b) -> Encoding
+encodeTuple encodeFirst encodeSecond (x, y) =
+  encodeListLen 2
+    <> encodeFirst x
+    <> encodeSecond y
+
+encodePair :: (a -> Encoding) -> (b -> Encoding) -> (a, b) -> Encoding
+encodePair = encodeTuple
+{-# DEPRECATED encodePair "In favor of `encodeTuple`" #-}
+
+--------------------------------------------------------------------------------
+-- Map
+--------------------------------------------------------------------------------
+
+-- | Encode a Map. Versions variance:
+--
+-- * [>= 2] - Variable length encoding for Maps larger than 23 key value pairs, otherwise exact
+--   length encoding
+--
+-- * [< 2] - Variable length encoding.
+encodeMap ::
+  (k -> Encoding) ->
+  (v -> Encoding) ->
+  Map.Map k v ->
+  Encoding
+encodeMap encodeKey encodeValue m =
+  let mapEncoding = Map.foldMapWithKey (\k v -> encodeKey k <> encodeValue v) m
+   in ifEncodingVersionAtLeast
+        (natVersion @2)
+        (variableMapLenEncoding (Map.size m) mapEncoding)
+        (exactMapLenEncoding (Map.size m) mapEncoding)
+{-# INLINE encodeMap #-}
+
+-- | Mimics `Map` encoder `encodeMap` identically.
+encodeVMap ::
+  (VMap.Vector kv k, VMap.Vector vv v) =>
+  (k -> Encoding) ->
+  (v -> Encoding) ->
+  VMap.VMap kv vv k v ->
+  Encoding
+encodeVMap encodeKey encodeValue m =
+  let mapEncoding = VMap.foldMapWithKey (\k v -> encodeKey k <> encodeValue v) m
+   in ifEncodingVersionAtLeast
+        (natVersion @2)
+        (variableMapLenEncoding (VMap.size m) mapEncoding)
+        (exactMapLenEncoding (VMap.size m) mapEncoding)
+{-# INLINE encodeVMap #-}
+
+-- Usage of fromIntegral in `exactMapLenEncoding` is safe, since it is an internal function
+-- and is applied to Map's size.
+exactMapLenEncoding :: Int -> Encoding -> Encoding
+exactMapLenEncoding len contents =
+  encodeMapLen (fromIntegral len :: Word) <> contents
+{-# INLINE exactMapLenEncoding #-}
+
+-- | Conditionally use variable length encoding, but only for Maps larger than 23
+variableMapLenEncoding :: Int -> Encoding -> Encoding
+variableMapLenEncoding len contents =
+  if len <= lengthThreshold
+    then exactMapLenEncoding len contents
+    else encodeMapLenIndef <> contents <> encodeBreak
+{-# INLINE variableMapLenEncoding #-}
+
+-- | This is the optimal maximum number for encoding exact length. Above that threashold
+-- using variable length encoding will result in less bytes on the wire.
+lengthThreshold :: Int
+lengthThreshold = 23
+
+--------------------------------------------------------------------------------
+-- Set
+--------------------------------------------------------------------------------
+
+-- Usage of fromIntegral in `exactListLenEncoding` is safe, since it is an internal function
+-- and is applied to List's size.
+exactListLenEncoding :: Int -> Encoding -> Encoding
+exactListLenEncoding len contents =
+  encodeListLen (fromIntegral len :: Word) <> contents
+{-# INLINE exactListLenEncoding #-}
+
+-- | Conditionally use variable length encoding, but only for lists and sets larger than
+-- 23
+variableListLenEncoding :: Int -> Encoding -> Encoding
+variableListLenEncoding len contents =
+  if len <= lengthThreshold
+    then exactListLenEncoding len contents
+    else encodeListLenIndef <> contents <> encodeBreak
+{-# INLINE variableListLenEncoding #-}
+
+-- | Encode a Set. Versions variance:
+--
+-- * [>= 2] - Variable length encoding for Sets larger than 23 elements, otherwise exact
+--   length encoding
+--
+-- * [< 2] - Variable length encoding. Also prefixes with a special 258 tag.
+encodeSet :: (a -> Encoding) -> Set.Set a -> Encoding
+encodeSet encodeValue f =
+  let foldableEncoding = foldMap' encodeValue f
+   in ifEncodingVersionAtLeast
+        (natVersion @2)
+        (variableListLenEncoding (Set.size f) foldableEncoding)
+        (encodeTag setTag <> exactListLenEncoding (Set.size f) foldableEncoding)
+{-# INLINE encodeSet #-}
+
+-- | Encode a list. Versions variance:
+--
+-- * [>= 2] - Variable length encoding for lists longer than 23 elements, otherwise exact
+--   length encoding
+--
+-- * [< 2] - Variable length encoding
+encodeList :: (a -> Encoding) -> [a] -> Encoding
+encodeList encodeValue xs =
+  let varLenEncList =
+        encodeListLenIndef <> foldr (\x r -> encodeValue x <> r) encodeBreak xs
+      (Sum len, exactLenEncList) = foldMap' (\v -> (1, encodeValue v)) xs
+      -- we don't want to compute the length of the list, unless it is smaller than the
+      -- threshold
+      encListVer2 =
+        case drop lengthThreshold xs of
+          [] -> exactListLenEncoding len exactLenEncList
+          _ -> varLenEncList
+   in ifEncodingVersionAtLeast (natVersion @2) encListVer2 varLenEncList
+
+-- | Encode a Seq. Variable length encoding for Sequences larger than 23 elements,
+--   otherwise exact length encoding
+encodeSeq :: (a -> Encoding) -> Seq.Seq a -> Encoding
+encodeSeq encodeValue f = variableListLenEncoding (Seq.length f) (foldMap' encodeValue f)
+{-# INLINE encodeSeq #-}
+
+--------------------------------------------------------------------------------
+-- Vector
+--------------------------------------------------------------------------------
+encodeContainerSkel ::
+  (Word -> Encoding) ->
+  (container -> Int) ->
+  (accumFunc -> Encoding -> container -> Encoding) ->
+  accumFunc ->
+  container ->
+  Encoding
+encodeContainerSkel encodeLen size foldFunction f c =
+  encodeLen (fromIntegral (size c)) <> foldFunction f mempty c
+{-# INLINE encodeContainerSkel #-}
+
+-- | Generic encoder for vectors. Its intended use is to allow easy
+-- definition of 'ToCBOR' instances for custom vector
+encodeVector :: VG.Vector v a => (a -> Encoding) -> v a -> Encoding
+encodeVector encodeValue =
+  encodeContainerSkel
+    encodeListLen
+    VG.length
+    VG.foldr
+    (\a b -> encodeValue a <> b)
+{-# INLINE encodeVector #-}
+
+--------------------------------------------------------------------------------
+-- Time
+--------------------------------------------------------------------------------
+
+encodeUTCTime :: UTCTime -> Encoding
+encodeUTCTime (UTCTime day timeOfDay) =
+  encodeListLen 3
+    <> encodeInteger year
+    <> encodeInt dayOfYear
+    <> encodeInteger timeOfDayPico
+  where
+    (year, dayOfYear) = toOrdinalDate day
+    timeOfDayPico = diffTimeToPicoseconds timeOfDay
+
+encodeNominalDiffTime :: NominalDiffTime -> Encoding
+encodeNominalDiffTime = encodeInteger . (`div` 1_000_000) . toPicoseconds
+  where
+    toPicoseconds t =
+      numerator (toRational t * toRational (resolution $ Proxy @E12))
+
+--------------------------------------------------------------------------------
+-- Network
+--------------------------------------------------------------------------------
+
+ipv4ToBytes :: IPv4 -> BS.ByteString
+ipv4ToBytes = BSL.toStrict . runPut . putWord32le . toHostAddress
+
+encodeIPv4 :: IPv4 -> Encoding
+encodeIPv4 = encodeBytes . ipv4ToBytes
+
+ipv6ToBytes :: IPv6 -> BS.ByteString
+ipv6ToBytes ipv6 = BSL.toStrict . runPut $ do
+  let (w1, w2, w3, w4) = toHostAddress6 ipv6
+  putWord32le w1
+  putWord32le w2
+  putWord32le w3
+  putWord32le w4
+
+encodeIPv6 :: IPv6 -> Encoding
+encodeIPv6 = encodeBytes . ipv6ToBytes

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -1,0 +1,709 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Binary.Encoding.ToCBOR
+  ( ToCBOR (..),
+    withWordSize,
+    PreEncoded (..),
+
+    -- * Size of expressions
+    Range (..),
+    szEval,
+    Size,
+    Case (..),
+    caseValue,
+    LengthOf (..),
+    SizeOverride (..),
+    isTodo,
+    szCases,
+    szLazy,
+    szGreedy,
+    szForce,
+    szWithCtx,
+    szSimplify,
+    apMono,
+    szBounds,
+  )
+where
+
+import Cardano.Ledger.Binary.Encoding.Encoder
+import Codec.CBOR.ByteArray (ByteArray (..))
+import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (SBA), fromByteArray)
+import Codec.CBOR.Term (Term (..))
+import Control.Category (Category ((.)))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BS.Lazy
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Short.Internal as SBS
+import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.Foldable (toList)
+import Data.Functor.Foldable (cata, project)
+import Data.IP (IPv4, IPv6)
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map as Map
+import qualified Data.Maybe.Strict as SMaybe
+import qualified Data.Primitive.ByteArray as Prim (ByteArray (..))
+import Data.Ratio (Ratio)
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Data.Tagged (Tagged (..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Text.Lazy.Builder (Builder)
+import Data.Time.Clock (NominalDiffTime, UTCTime (..))
+import Data.Typeable (Proxy (..), TypeRep, Typeable, typeRep)
+import qualified Data.VMap as VMap
+import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Unboxed as VU
+import Data.Void (Void, absurd)
+import Data.Word (Word16, Word32, Word64, Word8)
+import Foreign.Storable (sizeOf)
+import Formatting (bprint, build, shown, stext)
+import qualified Formatting.Buildable as B (Buildable (..))
+import Numeric.Natural (Natural)
+import Prelude hiding (encodeFloat, (.))
+#if MIN_VERSION_recursion_schemes(5,2,0)
+import Data.Fix (Fix(..))
+#else
+import Data.Functor.Foldable (Fix(..))
+#endif
+
+class Typeable a => ToCBOR a where
+  toCBOR :: a -> Encoding
+
+  encodedSizeExpr :: (forall t. ToCBOR t => Proxy t -> Size) -> Proxy a -> Size
+  encodedSizeExpr = todo
+
+  encodedListSizeExpr :: (forall t. ToCBOR t => Proxy t -> Size) -> Proxy [a] -> Size
+  encodedListSizeExpr = defaultEncodedListSizeExpr
+
+-- | A type used to represent the length of a value in 'Size' computations.
+newtype LengthOf xs = LengthOf xs
+
+instance Typeable xs => ToCBOR (LengthOf xs) where
+  toCBOR = error "The `LengthOf` type cannot be encoded!"
+
+-- | Default size expression for a list type.
+defaultEncodedListSizeExpr ::
+  forall a.
+  ToCBOR a =>
+  (forall t. ToCBOR t => Proxy t -> Size) ->
+  Proxy [a] ->
+  Size
+defaultEncodedListSizeExpr size _ =
+  2 + size (Proxy @(LengthOf [a])) * size (Proxy @a)
+
+newtype PreEncoded = PreEncoded {unPreEncoded :: BS.ByteString}
+
+instance ToCBOR PreEncoded where
+  toCBOR = encodePreEncoded . unPreEncoded
+
+--------------------------------------------------------------------------------
+-- Size expressions
+--------------------------------------------------------------------------------
+
+(.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)
+f .: g = \x y -> f (g x y)
+
+-- | Expressions describing the statically-computed size bounds on
+--   a type's possible values.
+type Size = Fix SizeF
+
+-- | The base functor for @Size@ expressions.
+data SizeF t
+  = -- | Sum of two sizes.
+    AddF t t
+  | -- | Product of two sizes.
+    MulF t t
+  | -- | Difference of two sizes.
+    SubF t t
+  | -- | Absolute value of a size.
+    AbsF t
+  | -- | Negation of a size.
+    NegF t
+  | -- | Signum of a size.
+    SgnF t
+  | -- | Case-selection for sizes. Used for sum types.
+    CasesF [Case t]
+  | -- | A constant value.
+    ValueF Natural
+  | -- | Application of a monotonic function to a size.
+    ApF Text (Natural -> Natural) t
+  | -- | A suspended size calculation ("thunk"). This is used to delay the
+    --   computation of a size until some later point, which is useful for
+    --   progressively building more detailed size estimates for a type
+    --   from the outside in. For example, `szLazy` can be followed by
+    --   applications of `szForce` to reveal more detailed expressions
+    --   describing the size bounds on a type.
+    forall a. ToCBOR a => TodoF (forall x. ToCBOR x => Proxy x -> Size) (Proxy a)
+
+instance Functor SizeF where
+  fmap f = \case
+    AddF x y -> AddF (f x) (f y)
+    MulF x y -> MulF (f x) (f y)
+    SubF x y -> SubF (f x) (f y)
+    AbsF x -> AbsF (f x)
+    NegF x -> NegF (f x)
+    SgnF x -> SgnF (f x)
+    CasesF xs -> CasesF (map (fmap f) xs)
+    ValueF x -> ValueF x
+    ApF n g x -> ApF n g (f x)
+    TodoF g x -> TodoF g x
+
+instance Num (Fix SizeF) where
+  (+) = Fix .: AddF
+  (*) = Fix .: MulF
+  (-) = Fix .: SubF
+  negate = Fix . NegF
+  abs = Fix . AbsF
+  signum = Fix . SgnF
+  fromInteger = Fix . ValueF . fromInteger
+
+instance B.Buildable t => B.Buildable (SizeF t) where
+  build x_ =
+    let showp2 :: (B.Buildable a, B.Buildable b) => a -> Text -> b -> Builder
+        showp2 = bprint ("(" . build . " " . stext . " " . build . ")")
+     in case x_ of
+          AddF x y -> showp2 x "+" y
+          MulF x y -> showp2 x "*" y
+          SubF x y -> showp2 x "-" y
+          NegF x -> bprint ("-" . build) x
+          AbsF x -> bprint ("|" . build . "|") x
+          SgnF x -> bprint ("sgn(" . build . ")") x
+          CasesF xs ->
+            bprint ("{ " . build . "}") $ foldMap (bprint (build . " ")) xs
+          ValueF x -> bprint shown (toInteger x)
+          ApF n _ x -> bprint (stext . "(" . build . ")") n x
+          TodoF _ x -> bprint ("(_ :: " . shown . ")") (typeRep x)
+
+instance B.Buildable (Fix SizeF) where
+  build x = bprint build (project @(Fix _) x)
+
+-- | Create a case expression from individual cases.
+szCases :: [Case Size] -> Size
+szCases = Fix . CasesF
+
+-- | An individual labeled case.
+data Case t
+  = Case Text t
+  deriving (Functor)
+
+-- | Discard the label on a case.
+caseValue :: Case t -> t
+caseValue (Case _ x) = x
+
+instance B.Buildable t => B.Buildable (Case t) where
+  build (Case n x) = bprint (stext . "=" . build) n x
+
+-- | A range of values. Should satisfy the invariant @forall x. lo x <= hi x@.
+data Range b = Range
+  { lo :: b,
+    hi :: b
+  }
+
+-- | The @Num@ instance for @Range@ uses interval arithmetic. Note that the
+--   @signum@ method is not lawful: if the interval @x@ includes 0 in its
+--   interior but is not symmetric about 0, then @abs x * signum x /= x@.
+instance (Ord b, Num b) => Num (Range b) where
+  x + y = Range {lo = lo x + lo y, hi = hi x + hi y}
+  x * y =
+    let products = [u * v | u <- [lo x, hi x], v <- [lo y, hi y]]
+     in Range {lo = minimum products, hi = maximum products}
+  x - y = Range {lo = lo x - hi y, hi = hi x - lo y}
+  negate x = Range {lo = negate (hi x), hi = negate (lo x)}
+  abs x =
+    if
+        | lo x <= 0 && hi x >= 0 -> Range {lo = 0, hi = max (hi x) (negate $ lo x)}
+        | lo x <= 0 && hi x <= 0 -> Range {lo = negate (hi x), hi = negate (lo x)}
+        | otherwise -> x
+  signum x = Range {lo = signum (lo x), hi = signum (hi x)}
+  fromInteger n = Range {lo = fromInteger n, hi = fromInteger n}
+
+instance B.Buildable (Range Natural) where
+  build r = bprint (shown . ".." . shown) (toInteger $ lo r) (toInteger $ hi r)
+
+-- | Fully evaluate a size expression by applying the given function to any
+--   suspended computations. @szEval g@ effectively turns each "thunk"
+--   of the form @TodoF f x@ into @g x@, then evaluates the result.
+szEval ::
+  (forall t. ToCBOR t => (Proxy t -> Size) -> Proxy t -> Range Natural) ->
+  Size ->
+  Range Natural
+szEval doit = cata $ \case
+  AddF x y -> x + y
+  MulF x y -> x * y
+  SubF x y -> x - y
+  NegF x -> negate x
+  AbsF x -> abs x
+  SgnF x -> signum x
+  CasesF xs ->
+    Range
+      { lo = minimum (map (lo . caseValue) xs),
+        hi = maximum (map (hi . caseValue) xs)
+      }
+  ValueF x -> Range {lo = x, hi = x}
+  ApF _ f x -> Range {lo = f (lo x), hi = f (hi x)}
+  TodoF f x -> doit f x
+
+-- | Evaluate the expression lazily, by immediately creating a thunk
+--    that will evaluate its contents lazily.
+--
+-- > ghci> putStrLn $ pretty $ szLazy (Proxy @TxAux)
+-- > (_ :: TxAux)
+szLazy :: ToCBOR a => (Proxy a -> Size)
+szLazy = todo (encodedSizeExpr szLazy)
+
+-- | Evaluate an expression greedily. There may still be thunks in the
+--    result, for types that did not provide a custom 'encodedSizeExpr' method
+--    in their 'ToCBOR' instance.
+--
+-- > ghci> putStrLn $ pretty $ szGreedy (Proxy @TxAux)
+-- > (0 + { TxAux=(2 + ((0 + (((1 + (2 + ((_ :: LengthOf [TxIn]) * (2 + { TxInUtxo=(2 + ((1 + 34) + { minBound=1 maxBound=5 })) })))) + (2 + ((_ :: LengthOf [TxOut]) * (0 + { TxOut=(2 + ((0 + ((2 + ((2 + withWordSize((((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + (((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + { minBound=1 maxBound=5 })) + { minBound=1 maxBound=9 })) })))) + (_ :: Attributes ()))) + (_ :: Vector TxInWitness))) })
+szGreedy :: ToCBOR a => (Proxy a -> Size)
+szGreedy = encodedSizeExpr szGreedy
+
+-- | Is this expression a thunk?
+isTodo :: Size -> Bool
+isTodo (Fix (TodoF _ _)) = True
+isTodo _ = False
+
+-- | Create a "thunk" that will apply @f@ to @pxy@ when forced.
+todo ::
+  forall a.
+  ToCBOR a =>
+  (forall t. ToCBOR t => Proxy t -> Size) ->
+  Proxy a ->
+  Size
+todo f pxy = Fix (TodoF f pxy)
+
+-- | Apply a monotonically increasing function to the expression.
+--   There are three cases when applying @f@ to a @Size@ expression:
+--      * When applied to a value @x@, compute @f x@.
+--      * When applied to cases, apply to each case individually.
+--      * In all other cases, create a deferred application of @f@.
+apMono :: Text -> (Natural -> Natural) -> Size -> Size
+apMono n f = \case
+  Fix (ValueF x) -> Fix (ValueF (f x))
+  Fix (CasesF cs) -> Fix (CasesF (map (fmap (apMono n f)) cs))
+  x -> Fix (ApF n f x)
+
+-- | Greedily compute the size bounds for a type, using the given context to
+--   override sizes for specific types.
+szWithCtx :: (ToCBOR a) => Map.Map TypeRep SizeOverride -> Proxy a -> Size
+szWithCtx ctx pxy = case Map.lookup (typeRep pxy) ctx of
+  Nothing -> normal
+  Just override -> case override of
+    SizeConstant sz -> sz
+    SizeExpression f -> f (szWithCtx ctx)
+    SelectCases names -> cata (selectCase names) normal
+  where
+    -- The non-override case
+    normal = encodedSizeExpr (szWithCtx ctx) pxy
+
+    selectCase :: [Text] -> SizeF Size -> Size
+    selectCase names orig = case orig of
+      CasesF cs -> matchCase names cs (Fix orig)
+      _ -> Fix orig
+
+    matchCase :: [Text] -> [Case Size] -> Size -> Size
+    matchCase names cs orig =
+      case filter (\(Case name _) -> name `elem` names) cs of
+        [] -> orig
+        [Case _ x] -> x
+        cs' -> Fix (CasesF cs')
+
+-- | Override mechanisms to be used with 'szWithCtx'.
+data SizeOverride
+  = -- | Replace with a fixed @Size@.
+    SizeConstant Size
+  | -- | Recursively compute the size.
+    SizeExpression ((forall a. ToCBOR a => Proxy a -> Size) -> Size)
+  | -- | Select only a specific case from a @CasesF@.
+    SelectCases [Text]
+
+-- | Simplify the given @Size@, resulting in either the simplified @Size@ or,
+--   if it was fully simplified, an explicit upper and lower bound.
+szSimplify :: Size -> Either Size (Range Natural)
+szSimplify = cata $ \case
+  TodoF f pxy -> Left (todo f pxy)
+  ValueF x -> Right (Range {lo = x, hi = x})
+  CasesF xs -> case mapM caseValue xs of
+    Right xs' ->
+      Right (Range {lo = minimum (map lo xs'), hi = maximum (map hi xs')})
+    Left _ -> Left (szCases $ map (fmap toSize) xs)
+  AddF x y -> binOp (+) x y
+  MulF x y -> binOp (*) x y
+  SubF x y -> binOp (-) x y
+  NegF x -> unOp negate x
+  AbsF x -> unOp abs x
+  SgnF x -> unOp signum x
+  ApF _ f (Right x) -> Right (Range {lo = f (lo x), hi = f (hi x)})
+  ApF n f (Left x) -> Left (apMono n f x)
+  where
+    binOp ::
+      (forall a. Num a => a -> a -> a) ->
+      Either Size (Range Natural) ->
+      Either Size (Range Natural) ->
+      Either Size (Range Natural)
+    binOp op (Right x) (Right y) = Right (op x y)
+    binOp op x y = Left (op (toSize x) (toSize y))
+
+    unOp ::
+      (forall a. Num a => a -> a) ->
+      Either Size (Range Natural) ->
+      Either Size (Range Natural)
+    unOp f = \case
+      Right x -> Right (f x)
+      Left x -> Left (f x)
+
+    toSize :: Either Size (Range Natural) -> Size
+    toSize = \case
+      Left x -> x
+      Right r ->
+        if lo r == hi r
+          then fromIntegral (lo r)
+          else
+            szCases
+              [Case "lo" (fromIntegral $ lo r), Case "hi" (fromIntegral $ hi r)]
+
+-- | Force any thunks in the given @Size@ expression.
+--
+-- > ghci> putStrLn $ pretty $ szForce $ szLazy (Proxy @TxAux)
+-- > (0 + { TxAux=(2 + ((0 + (_ :: Tx)) + (_ :: Vector TxInWitness))) })
+szForce :: Size -> Size
+szForce = cata $ \case
+  AddF x y -> x + y
+  MulF x y -> x * y
+  SubF x y -> x - y
+  NegF x -> negate x
+  AbsF x -> abs x
+  SgnF x -> signum x
+  CasesF xs -> Fix $ CasesF xs
+  ValueF x -> Fix (ValueF x)
+  ApF n f x -> apMono n f x
+  TodoF f x -> f x
+
+szBounds :: ToCBOR a => a -> Either Size (Range Natural)
+szBounds = szSimplify . szGreedy . pure
+
+-- | Compute encoded size of an integer
+withWordSize :: (Integral s, Integral a) => s -> a
+withWordSize x =
+  let s = fromIntegral x :: Integer
+   in if
+          | s <= 0x17 && s >= (-0x18) -> 1
+          | s <= 0xff && s >= (-0x100) -> 2
+          | s <= 0xffff && s >= (-0x10000) -> 3
+          | s <= 0xffffffff && s >= (-0x100000000) -> 5
+          | otherwise -> 9
+
+--------------------------------------------------------------------------------
+-- Primitive types
+--------------------------------------------------------------------------------
+
+instance ToCBOR () where
+  toCBOR = const encodeNull
+  encodedSizeExpr _ _ = 1
+
+instance ToCBOR Bool where
+  toCBOR = encodeBool
+  encodedSizeExpr _ _ = 1
+
+--------------------------------------------------------------------------------
+-- Numeric data
+--------------------------------------------------------------------------------
+
+instance ToCBOR Integer where
+  toCBOR = encodeInteger
+
+encodedSizeRange :: forall a. (Integral a, Bounded a) => Proxy a -> Size
+encodedSizeRange _ =
+  szCases
+    [ mkCase "minBound" 0, -- min, in absolute value
+      mkCase "maxBound" maxBound
+    ]
+  where
+    mkCase :: Text -> a -> Case Size
+    mkCase n = Case n . fromInteger . withWordSize
+
+instance ToCBOR Word where
+  toCBOR = encodeWord
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Word8 where
+  toCBOR = encodeWord8
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Word16 where
+  toCBOR = encodeWord16
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Word32 where
+  toCBOR = encodeWord32
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Word64 where
+  toCBOR = encodeWord64
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Int where
+  toCBOR = encodeInt
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Int8 where
+  toCBOR = encodeInt8
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Int16 where
+  toCBOR = encodeInt16
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Int32 where
+  toCBOR = encodeInt32
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Int64 where
+  toCBOR = encodeInt64
+  encodedSizeExpr _ = encodedSizeRange
+
+instance ToCBOR Float where
+  toCBOR = encodeFloat
+  encodedSizeExpr _ _ = 1 + fromIntegral (sizeOf (0 :: Float))
+
+instance ToCBOR Double where
+  toCBOR = encodeDouble
+  encodedSizeExpr _ _ = 1 + fromIntegral (sizeOf (0 :: Float))
+
+instance ToCBOR a => ToCBOR (Ratio a) where
+  toCBOR = encodeRatio toCBOR
+  encodedSizeExpr size _ = 1 + size (Proxy @a) + size (Proxy @a)
+
+instance ToCBOR Nano where
+  toCBOR (MkFixed nanoseconds) = toCBOR nanoseconds
+
+instance ToCBOR Pico where
+  toCBOR (MkFixed picoseconds) = toCBOR picoseconds
+
+-- | For backwards compatibility we round pico precision to micro
+instance ToCBOR NominalDiffTime where
+  toCBOR = encodeNominalDiffTime
+
+instance ToCBOR Natural where
+  toCBOR = toCBOR . toInteger
+
+instance ToCBOR Void where
+  toCBOR = absurd
+
+instance ToCBOR Term where
+  toCBOR = encodeTerm
+
+instance ToCBOR Encoding where
+  toCBOR = id
+
+instance ToCBOR IPv4 where
+  toCBOR = encodeIPv4
+
+instance ToCBOR IPv6 where
+  toCBOR = encodeIPv6
+
+--------------------------------------------------------------------------------
+-- Tagged
+--------------------------------------------------------------------------------
+
+instance (Typeable s, ToCBOR a) => ToCBOR (Tagged s a) where
+  toCBOR (Tagged a) = toCBOR a
+
+  encodedSizeExpr size _ = encodedSizeExpr size (Proxy @a)
+
+--------------------------------------------------------------------------------
+-- Containers
+--------------------------------------------------------------------------------
+
+instance (ToCBOR a, ToCBOR b) => ToCBOR (a, b) where
+  toCBOR (a, b) = encodeListLen 2 <> toCBOR a <> toCBOR b
+
+  encodedSizeExpr size _ = 1 + size (Proxy @a) + size (Proxy @b)
+
+instance (ToCBOR a, ToCBOR b, ToCBOR c) => ToCBOR (a, b, c) where
+  toCBOR (a, b, c) = encodeListLen 3 <> toCBOR a <> toCBOR b <> toCBOR c
+
+  encodedSizeExpr size _ =
+    1 + size (Proxy @a) + size (Proxy @b) + size (Proxy @c)
+
+instance (ToCBOR a, ToCBOR b, ToCBOR c, ToCBOR d) => ToCBOR (a, b, c, d) where
+  toCBOR (a, b, c, d) =
+    encodeListLen 4 <> toCBOR a <> toCBOR b <> toCBOR c <> toCBOR d
+
+  encodedSizeExpr size _ =
+    1 + size (Proxy @a) + size (Proxy @b) + size (Proxy @c) + size (Proxy @d)
+
+instance
+  (ToCBOR a, ToCBOR b, ToCBOR c, ToCBOR d, ToCBOR e) =>
+  ToCBOR (a, b, c, d, e)
+  where
+  toCBOR (a, b, c, d, e) =
+    encodeListLen 5
+      <> toCBOR a
+      <> toCBOR b
+      <> toCBOR c
+      <> toCBOR d
+      <> toCBOR e
+
+  encodedSizeExpr size _ =
+    1
+      + size (Proxy @a)
+      + size (Proxy @b)
+      + size (Proxy @c)
+      + size (Proxy @d)
+      + size (Proxy @e)
+
+instance
+  (ToCBOR a, ToCBOR b, ToCBOR c, ToCBOR d, ToCBOR e, ToCBOR f, ToCBOR g) =>
+  ToCBOR (a, b, c, d, e, f, g)
+  where
+  toCBOR (a, b, c, d, e, f, g) =
+    encodeListLen 7
+      <> toCBOR a
+      <> toCBOR b
+      <> toCBOR c
+      <> toCBOR d
+      <> toCBOR e
+      <> toCBOR f
+      <> toCBOR g
+
+  encodedSizeExpr size _ =
+    1
+      + size (Proxy @a)
+      + size (Proxy @b)
+      + size (Proxy @c)
+      + size (Proxy @d)
+      + size (Proxy @e)
+      + size (Proxy @f)
+      + size (Proxy @g)
+
+instance ToCBOR BS.ByteString where
+  toCBOR = encodeBytes
+  encodedSizeExpr size _ =
+    let len = size (Proxy @(LengthOf BS.ByteString))
+     in apMono "withWordSize@Int" (withWordSize @Int . fromIntegral) len + len
+
+instance ToCBOR Text.Text where
+  toCBOR = encodeString
+  encodedSizeExpr size _ =
+    let bsLength =
+          size (Proxy @(LengthOf Text))
+            * szCases [Case "minChar" 1, Case "maxChar" 4]
+     in bsLength + apMono "withWordSize" withWordSize bsLength
+
+instance ToCBOR ByteArray where
+  toCBOR = toCBOR . unBA
+  {-# INLINE toCBOR #-}
+
+instance ToCBOR Prim.ByteArray where
+  toCBOR = encodeByteArray . fromByteArray
+  {-# INLINE toCBOR #-}
+
+instance ToCBOR SlicedByteArray where
+  toCBOR = encodeByteArray
+  {-# INLINE toCBOR #-}
+
+instance ToCBOR SBS.ShortByteString where
+  toCBOR sbs@(SBS.SBS ba) =
+    encodeByteArray $ SBA (Prim.ByteArray ba) 0 (SBS.length sbs)
+
+  encodedSizeExpr size _ =
+    let len = size (Proxy @(LengthOf SBS.ShortByteString))
+     in apMono "withWordSize@Int" (withWordSize @Int . fromIntegral) len + len
+
+instance ToCBOR BS.Lazy.ByteString where
+  toCBOR = toCBOR . BS.Lazy.toStrict
+  encodedSizeExpr size _ =
+    let len = size (Proxy @(LengthOf BS.Lazy.ByteString))
+     in apMono "withWordSize@Int" (withWordSize @Int . fromIntegral) len + len
+
+instance ToCBOR a => ToCBOR [a] where
+  toCBOR = encodeList toCBOR
+  encodedSizeExpr size _ = encodedListSizeExpr size (Proxy @[a])
+
+instance (ToCBOR a, ToCBOR b) => ToCBOR (Either a b) where
+  toCBOR (Left x) = encodeListLen 2 <> encodeWord 0 <> toCBOR x
+  toCBOR (Right x) = encodeListLen 2 <> encodeWord 1 <> toCBOR x
+
+  encodedSizeExpr size _ =
+    szCases
+      [Case "Left" (2 + size (Proxy @a)), Case "Right" (2 + size (Proxy @b))]
+
+instance ToCBOR a => ToCBOR (NonEmpty a) where
+  toCBOR = toCBOR . toList
+  encodedSizeExpr size _ = size (Proxy @[a]) -- MN TODO make 0 count impossible
+
+instance ToCBOR a => ToCBOR (Maybe a) where
+  toCBOR = encodeMaybe toCBOR
+
+  encodedSizeExpr size _ =
+    szCases [Case "Nothing" 1, Case "Just" (1 + size (Proxy @a))]
+
+instance ToCBOR a => ToCBOR (SMaybe.StrictMaybe a) where
+  toCBOR SMaybe.SNothing = encodeListLen 0
+  toCBOR (SMaybe.SJust x) = encodeListLen 1 <> toCBOR x
+
+instance (Ord k, ToCBOR k, ToCBOR v) => ToCBOR (Map.Map k v) where
+  toCBOR = encodeMap toCBOR toCBOR
+
+instance (Ord a, ToCBOR a) => ToCBOR (Set.Set a) where
+  toCBOR = encodeSet toCBOR
+
+instance (Ord a, ToCBOR a) => ToCBOR (Seq.Seq a) where
+  toCBOR = encodeSeq toCBOR
+
+instance (Ord a, ToCBOR a) => ToCBOR (SSeq.StrictSeq a) where
+  toCBOR = toCBOR . SSeq.fromStrict
+
+instance
+  (Ord k, ToCBOR k, ToCBOR v, VMap.Vector kv k, VMap.Vector vv v, Typeable kv, Typeable vv) =>
+  ToCBOR (VMap.VMap kv vv k v)
+  where
+  toCBOR = encodeVMap toCBOR toCBOR
+
+instance ToCBOR a => ToCBOR (V.Vector a) where
+  toCBOR = encodeVector toCBOR
+  {-# INLINE toCBOR #-}
+  encodedSizeExpr size _ =
+    2 + size (Proxy @(LengthOf (V.Vector a))) * size (Proxy @a)
+
+instance (ToCBOR a, VP.Prim a) => ToCBOR (VP.Vector a) where
+  toCBOR = encodeVector toCBOR
+  {-# INLINE toCBOR #-}
+  encodedSizeExpr size _ =
+    2 + size (Proxy @(LengthOf (VP.Vector a))) * size (Proxy @a)
+
+instance (ToCBOR a, VS.Storable a) => ToCBOR (VS.Vector a) where
+  toCBOR = encodeVector toCBOR
+  {-# INLINE toCBOR #-}
+  encodedSizeExpr size _ =
+    2 + size (Proxy @(LengthOf (VS.Vector a))) * size (Proxy @a)
+
+instance (ToCBOR a, VU.Unbox a) => ToCBOR (VU.Vector a) where
+  toCBOR = encodeVector toCBOR
+  {-# INLINE toCBOR #-}
+  encodedSizeExpr size _ =
+    2 + size (Proxy @(LengthOf (VU.Vector a))) * size (Proxy @a)
+
+--------------------------------------------------------------------------------
+-- Time
+--------------------------------------------------------------------------------
+
+instance ToCBOR UTCTime where
+  toCBOR = encodeUTCTime

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/FlatTerm.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/FlatTerm.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Ledger.Binary.FlatTerm
+  ( C.FlatTerm,
+    C.TermToken (..),
+    toFlatTerm,
+    fromFlatTerm,
+    C.validFlatTerm,
+  )
+where
+
+import Cardano.Ledger.Binary.Decoding
+import Cardano.Ledger.Binary.Encoding
+import qualified Codec.CBOR.FlatTerm as C
+
+toFlatTerm :: Version -> Encoding -> C.FlatTerm
+toFlatTerm version = C.toFlatTerm . toPlainEncoding version
+
+fromFlatTerm :: Version -> (forall s. Decoder s a) -> C.FlatTerm -> Either String a
+fromFlatTerm version decoder = C.fromFlatTerm (toPlainDecoder version decoder)

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Cardano.Ledger.Binary.Version
+  ( -- * Versioning
+    Version,
+    MinVersion,
+    MaxVersion,
+    natVersion,
+    natVersionProxy,
+    mkVersion,
+    allVersions,
+  )
+where
+
+import Data.Proxy
+import GHC.TypeLits
+import Numeric.Natural
+
+--------------------------------------------------------------------------------
+-- Versioned Decoder
+--------------------------------------------------------------------------------
+
+-- | Protocol version number that is used during encoding and decoding. All supported
+-- versions are in the range from `MinVersion` to `MaxVersion`.
+newtype Version = Version Word
+  deriving (Eq, Ord, Show, Enum)
+
+-- | Minimum supported version
+type MinVersion = 1
+
+-- | Maximum supported version
+type MaxVersion = 8
+
+instance Bounded Version where
+  minBound = Version (fromInteger (natVal (Proxy @MinVersion)))
+  maxBound = Version (fromInteger (natVal (Proxy @MaxVersion)))
+
+-- | Same as `natVersionProxy`, construct a version from a type level `Nat`, except it can be
+-- supplied through @TypeApplications@.
+natVersion :: forall v. (KnownNat v, MinVersion <= v, v <= MaxVersion) => Version
+natVersion = natVersionProxy (Proxy @v)
+
+-- | Safely construct a `Version` from a type level `Nat`, which is supplied as a `Proxy`
+natVersionProxy :: (KnownNat v, MinVersion <= v, v <= MaxVersion) => Proxy v -> Version
+natVersionProxy = Version . fromInteger . natVal
+
+-- | Construct a `Version` and fail if the supplied value is not supported version number.
+mkVersion :: MonadFail m => Natural -> m Version
+mkVersion v
+  | fromIntegral minVersion <= v && v <= fromIntegral maxVersion =
+      pure (Version (fromIntegral v))
+  | otherwise =
+      fail $
+        "Unsupported decoder version: "
+          ++ show v
+          ++ ". Expected value in bounds: ["
+          ++ show minVersion
+          ++ ", "
+          ++ show maxVersion
+          ++ "]"
+  where
+    Version minVersion = minBound
+    Version maxVersion = maxBound
+
+allVersions :: [Version]
+allVersions = [minBound .. maxBound]

--- a/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/Arbitrary.hs
+++ b/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/Arbitrary.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Binary.Arbitrary () where
+
+import Codec.CBOR.ByteArray (ByteArray (..))
+import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (..))
+import qualified Data.Foldable as F
+import Data.IP (IPv4, IPv6, toIPv4w, toIPv6w)
+import Data.Maybe.Strict
+import qualified Data.Primitive.ByteArray as Prim (byteArrayFromListN)
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.VMap as VMap
+import qualified Data.Vector.Primitive as VP
+import Data.Word
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+deriving instance Arbitrary ByteArray
+
+instance Arbitrary SlicedByteArray where
+  arbitrary = do
+    NonNegative off <- arbitrary
+    Positive count <- arbitrary
+    NonNegative slack <- arbitrary
+    let len = off + count + slack
+    ba <- Prim.byteArrayFromListN len <$> (vector len :: Gen [Word8])
+    pure $ SBA ba off count
+
+instance Arbitrary IPv4 where
+  arbitrary = toIPv4w <$> arbitrary
+
+instance Arbitrary IPv6 where
+  arbitrary = do
+    t <- (,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    pure $ toIPv6w t
+
+instance (VP.Prim e, Arbitrary e) => Arbitrary (VP.Vector e) where
+  arbitrary = VP.fromList <$> arbitrary
+  shrink = fmap VP.fromList . shrink . VP.toList
+
+instance Arbitrary e => Arbitrary (SSeq.StrictSeq e) where
+  arbitrary = SSeq.fromList <$> arbitrary
+  shrink = fmap SSeq.fromList . shrink . F.toList
+
+instance Arbitrary e => Arbitrary (StrictMaybe e) where
+  arbitrary = maybeToStrictMaybe <$> arbitrary
+  shrink = fmap maybeToStrictMaybe . shrink . strictMaybeToMaybe
+
+instance
+  (Ord k, VMap.Vector kv k, VMap.Vector vv v, Arbitrary k, Arbitrary v) =>
+  Arbitrary (VMap.VMap kv vv k v)
+  where
+  arbitrary = VMap.fromMap <$> arbitrary
+  shrink = fmap VMap.fromList . shrink . VMap.toList

--- a/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/RoundTrip.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Defines reusable abstractions for testing RoundTrip properties of CBOR instances
+module Test.Cardano.Ledger.Binary.RoundTrip
+  ( roundTripSpec,
+    roundTripExpectation,
+    RoundTripFailure (..),
+    Trip (..),
+    cborTrip,
+    roundTrip,
+    roundTripTwiddled,
+    roundTripAnn,
+    roundTripAnnTwiddled,
+    embedTrip,
+    embedTripAnn,
+    embedTripLabel,
+  )
+where
+
+import Cardano.Ledger.Binary
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Proxy
+import qualified Data.Text as Text
+import Data.Typeable
+import Test.Cardano.Ledger.Binary.TreeDiff (showExpr, showHexBytesGrouped)
+import Test.Cardano.Ledger.Binary.Twiddle (Twiddle (..))
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck hiding (label)
+
+-- =====================================================================
+
+-- | Tests the roundtrip property using QuickCheck generators
+roundTripSpec ::
+  forall t.
+  (Show t, Eq t, Typeable t, Arbitrary t) =>
+  Version ->
+  Trip t t ->
+  Spec
+roundTripSpec version trip =
+  prop (show (typeRep $ Proxy @t)) $ roundTripExpectation version trip
+
+roundTripExpectation ::
+  (Show t, Eq t, Typeable t) =>
+  Version ->
+  Trip t t ->
+  t ->
+  Expectation
+roundTripExpectation version trip t =
+  case roundTrip version trip t of
+    Left err -> expectationFailure $ "Failed to deserialize encoded: " ++ show err
+    Right tDecoded -> tDecoded `shouldBe` t
+
+-- =====================================================================
+
+data RoundTripFailure = RoundTripFailure
+  { -- | Version that was used during encoding
+    rtfVersion :: Version,
+    -- | Produced encoding
+    rtfEncoding :: Encoding,
+    -- | Serialized encoding using the version in this failure
+    rtfEncodedBytes :: BSL.ByteString,
+    -- | Error received while decoding the produced bytes
+    rtfDecoderError :: DecoderError
+  }
+
+instance Show RoundTripFailure where
+  show RoundTripFailure {..} =
+    unlines $
+      [ show rtfVersion,
+        showDecoderError rtfDecoderError,
+        prettyTerm
+      ]
+        ++ showHexBytesGrouped bytes
+    where
+      bytes = BSL.toStrict rtfEncodedBytes
+      prettyTerm =
+        case decodeFullDecoder' rtfVersion "Term" decodeTerm bytes of
+          Left err -> "Could not decode as Term: " ++ show err
+          Right term -> showExpr term
+
+-- | A definition of a CBOR trip through binary representation of one type to
+-- another. In this module this is called an embed. When a source and target type is the
+-- exact same one then it would be a dual and is expected to round trip.
+data Trip a b = Trip
+  { tripEncoder :: a -> Encoding,
+    tripDecoder :: forall s. Decoder s b
+  }
+
+cborTrip :: (ToCBOR a, FromCBOR b) => Trip a b
+cborTrip = Trip toCBOR fromCBOR
+
+roundTrip :: Typeable t => Version -> Trip t t -> t -> Either RoundTripFailure t
+roundTrip = embedTrip
+
+roundTripTwiddled ::
+  (Twiddle t, FromCBOR t) => Version -> t -> Gen (Either RoundTripFailure t)
+roundTripTwiddled version x = do
+  tw <- twiddle x
+  pure (roundTrip version (Trip (const (encodeTerm tw)) fromCBOR) x)
+
+roundTripAnn :: (ToCBOR t, FromCBOR (Annotator t)) => Version -> t -> Either RoundTripFailure t
+roundTripAnn = embedTripAnn
+
+roundTripAnnTwiddled ::
+  (Twiddle t, FromCBOR (Annotator t)) => Version -> t -> Gen (Either RoundTripFailure t)
+roundTripAnnTwiddled version x = do
+  tw <- twiddle x
+  pure (decodeAnn version (encodeTerm tw))
+
+decodeAnn ::
+  forall t.
+  FromCBOR (Annotator t) =>
+  Version ->
+  Encoding ->
+  Either RoundTripFailure t
+decodeAnn version encoding =
+  first (RoundTripFailure version encoding encodedBytes) $
+    decodeFullAnnotator version (label (Proxy @(Annotator t))) fromCBOR encodedBytes
+  where
+    encodedBytes = serializeEncoding version encoding
+
+embedTripLabel ::
+  forall a b.
+  Text.Text ->
+  Version ->
+  Trip a b ->
+  a ->
+  Either RoundTripFailure b
+embedTripLabel lbl version (Trip encoder decoder) s =
+  first (RoundTripFailure version encoding encodedBytes) $
+    decodeFullDecoder version lbl decoder encodedBytes
+  where
+    encoding = encoder s
+    encodedBytes = serializeEncoding version encoding
+
+-- | Can we serialise a type, and then deserialise it as something else?
+embedTrip :: forall a b. Typeable b => Version -> Trip a b -> a -> Either RoundTripFailure b
+embedTrip = embedTripLabel (Text.pack (show (typeRep $ Proxy @b)))
+
+embedTripAnn ::
+  forall a b. (ToCBOR a, FromCBOR (Annotator b)) => Version -> a -> Either RoundTripFailure b
+embedTripAnn version = decodeAnn version . toCBOR

--- a/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Cardano.Ledger.Binary.TreeDiff
+  ( CBORBytes (..),
+    showExpr,
+    diffExpr,
+    hexByteStringExpr,
+    showHexBytesGrouped,
+  )
+where
+
+import Cardano.Ledger.Binary
+import Data.Bifunctor (bimap)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BSL
+import Data.TreeDiff
+
+{-------------------------------------------------------------------------------
+  Diffing Cbor
+-------------------------------------------------------------------------------}
+
+diffExpr :: ToExpr a => a -> a -> String
+diffExpr x y = show (ansiWlEditExpr (ediff x y))
+
+showExpr :: ToExpr a => a -> String
+showExpr = show . ansiWlExpr . toExpr
+
+newtype CBORBytes = CBORBytes BS.ByteString
+
+instance ToExpr CBORBytes where
+  toExpr (CBORBytes bytes) =
+    -- `decodeTerm` does not care about the version, so we can use any version
+    case decodeFullDecoder' minBound "Term" decodeTerm bytes of
+      Left err -> error $ "Error decoding CBOR: " ++ showDecoderError err
+      Right term -> toExpr term
+
+instance ToExpr Term where
+  toExpr =
+    \case
+      TInt i -> App "TInt" [toExpr i]
+      TInteger i -> App "TInteger" [toExpr i]
+      TBytes bs -> App "TBytes" $ hexByteStringExpr bs
+      TBytesI bs -> App "TBytesI" $ hexByteStringExpr $ BSL.toStrict bs
+      TString s -> App "TString" [toExpr s]
+      TStringI s -> App "TStringI" [toExpr s]
+      TList xs -> App "TList" [Lst (map toExpr xs)]
+      TListI xs -> App "TListI" [Lst (map toExpr xs)]
+      TMap xs -> App "TMap" [Lst (map (toExpr . bimap toExpr toExpr) xs)]
+      TMapI xs -> App "TMapI" [Lst (map (toExpr . bimap toExpr toExpr) xs)]
+      TTagged 24 (TBytes x) -> App "CBOR-in-CBOR" [toExpr (CBORBytes x)]
+      TTagged t x -> App "TTagged" [toExpr t, toExpr x]
+      TBool x -> App "TBool" [toExpr x]
+      TNull -> App "TNull" []
+      TSimple x -> App "TSimple" [toExpr x]
+      THalf x -> App "THalf" [toExpr x]
+      TFloat x -> App "TFloat" [toExpr x]
+      TDouble x -> App "TDouble" [toExpr x]
+
+hexByteStringExpr :: BS.ByteString -> [Expr]
+hexByteStringExpr bs =
+  [ toExpr (BS.length bs),
+    Lst (map toExpr $ showHexBytesGrouped bs)
+  ]
+
+-- | Show a ByteString as hex groups of 8bytes each. This is a slightly more
+-- useful form for debugging, rather than bunch of escaped characters.
+showHexBytesGrouped :: BS.ByteString -> [String]
+showHexBytesGrouped bs =
+  [ "0x" <> BS8.unpack (BS.take 16 $ BS.drop i bs16)
+    | i <- [0, 16 .. BS.length bs16 - 1]
+  ]
+  where
+    bs16 = Base16.encode bs

--- a/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/Twiddle.hs
+++ b/libs/cardano-ledger-binary/test-lib/Test/Cardano/Ledger/Binary/Twiddle.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Binary.Twiddle
+  ( Twiddler (unTwiddler),
+    Twiddle (..),
+    encodingToTerm,
+    toTwiddler,
+    toTerm,
+  )
+where
+
+import Cardano.Ledger.Binary
+  ( Encoding,
+    FromCBOR (..),
+    Term (..),
+    ToCBOR (..),
+    Version,
+    decodeFull,
+    encodeTerm,
+    getDecoderVersion,
+    serialize,
+  )
+import Data.Bitraversable (bimapM)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (fromStrict, toStrict)
+import Data.Foldable (toList)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import Data.Sequence.Strict (StrictSeq)
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text.Lazy as T
+import Data.Typeable (Typeable)
+import Data.Void (Void, absurd)
+import GHC.Generics
+import Test.QuickCheck (Arbitrary (..), Gen, elements, shuffle)
+
+data Twiddler a = Twiddler
+  { unTwiddler :: !a,
+    _unEnc :: Term
+  }
+
+gTwiddleTList :: forall a p. (Generic a, TwiddleL (Rep a p)) => a -> Gen Term
+gTwiddleTList a = TList <$> twiddleL (from @a @p a)
+
+class Twiddle a where
+  twiddle :: a -> Gen Term
+  default twiddle :: forall p. (Generic a, TwiddleL (Rep a p)) => a -> Gen Term
+  twiddle = gTwiddleTList @a @p
+
+instance Twiddle a => Twiddle [a] where
+  twiddle l = do
+    f <- elements [TList, TListI]
+    l' <- traverse twiddle l
+    pure $ f l'
+
+instance (Twiddle k, Twiddle v) => Twiddle (Map k v) where
+  twiddle m = do
+    -- Elements of a map do not have to be in a specific order so we shuffle them
+    m' <- shuffle $ Map.toList m
+    m'' <- traverse (bimapM twiddle twiddle) m'
+    f <- elements [TMap, TMapI]
+    pure $ f m''
+
+instance Twiddle ByteString where
+  twiddle bs = do
+    f <- elements [TBytes, TBytesI . fromStrict]
+    pure $ f bs
+
+instance Twiddle Text where
+  twiddle t = do
+    f <- elements [TString, TStringI . T.fromStrict]
+    pure $ f t
+
+instance Twiddle Int where
+  -- TODO: Put small ints into bigger words (e.g. a Word16 value into Word32)
+  --
+  -- This is not possible with the CBOR AST provided by cborg
+  twiddle = pure . TInt
+
+instance (Twiddle a, Arbitrary a, ToCBOR a) => Arbitrary (Twiddler a) where
+  arbitrary = do
+    x <- arbitrary
+    enc' <- twiddle x
+    pure $ Twiddler x enc'
+
+instance Twiddle a => Twiddle (Set a) where
+  twiddle = twiddle . toList
+
+instance Twiddle a => Twiddle (Seq a) where
+  twiddle = twiddle . toList
+
+instance Twiddle a => Twiddle (StrictSeq a) where
+  twiddle = twiddle . toList
+
+instance Typeable a => ToCBOR (Twiddler a) where
+  toCBOR (Twiddler _ x) = encodeTerm x
+
+instance (Typeable a, ToCBOR a, FromCBOR a) => FromCBOR (Twiddler a) where
+  fromCBOR = do
+    version <- getDecoderVersion
+    (\x -> Twiddler x $ toTerm version x) <$> fromCBOR
+
+instance Show a => Show (Twiddler a) where
+  show (Twiddler x _) = "Twiddler " <> show x
+
+instance Eq a => Eq (Twiddler a) where
+  (Twiddler x _) == (Twiddler y _) = x == y
+
+class TwiddleL a where
+  twiddleL :: a -> Gen [Term]
+
+instance TwiddleL (V1 p) where
+  twiddleL v1 = case v1 of {}
+
+instance TwiddleL (U1 p) where
+  twiddleL U1 = pure []
+
+instance (TwiddleL (l x), TwiddleL (r x)) => TwiddleL ((l :*: r) x) where
+  twiddleL (lx :*: rx) = do
+    lx' <- twiddleL lx
+    rx' <- twiddleL rx
+    pure $ lx' <> rx'
+
+instance (TwiddleL (l x), TwiddleL (r x)) => TwiddleL ((l :+: r) x) where
+  twiddleL (L1 lx) = twiddleL lx
+  twiddleL (R1 rx) = twiddleL rx
+
+instance Twiddle c => TwiddleL (K1 i c p) where
+  twiddleL (K1 c) = pure <$> twiddle c
+
+instance (TwiddleL (f p)) => TwiddleL (M1 i c f p) where
+  twiddleL (M1 fp) = twiddleL fp
+
+instance Twiddle Integer where
+  twiddle = pure . TInteger
+
+instance Twiddle Void where
+  twiddle = absurd
+
+instance Twiddle Bool where
+  twiddle = pure . TBool
+
+instance Twiddle Float where
+  twiddle = pure . TFloat
+
+instance Twiddle Double where
+  twiddle = pure . TDouble
+
+instance Twiddle Term where
+  twiddle (TInt n) = twiddle n
+  twiddle (TInteger n) = twiddle n
+  twiddle (TBytes bs) = twiddle bs
+  twiddle (TBytesI bs) = twiddle $ toStrict bs
+  twiddle (TString txt) = twiddle txt
+  twiddle (TStringI txt) = twiddle $ T.toStrict txt
+  twiddle (TList tes) = twiddle tes
+  twiddle (TListI tes) = twiddle tes
+  twiddle (TMap x0) = twiddle $ Map.fromList x0
+  twiddle (TMapI x0) = twiddle $ Map.fromList x0
+  twiddle (TTagged wo te') = TTagged wo <$> twiddle te'
+  twiddle (TBool b) = twiddle b
+  twiddle TNull = pure TNull
+  twiddle (TSimple wo) = pure $ TSimple wo
+  twiddle (THalf x) = pure $ THalf x
+  twiddle (TFloat x) = twiddle x
+  twiddle (TDouble x) = twiddle x
+
+encodingToTerm :: Version -> Encoding -> Term
+encodingToTerm version enc =
+  case decodeFull version (serialize version enc) of
+    Right t -> t
+    Left err -> error $ show err
+
+toTerm :: ToCBOR a => Version -> a -> Term
+toTerm version = encodingToTerm version . toCBOR
+
+toTwiddler :: Twiddle a => a -> Gen (Twiddler a)
+toTwiddler x = Twiddler x <$> twiddle x

--- a/libs/cardano-ledger-binary/test/LICENSE
+++ b/libs/cardano-ledger-binary/test/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-2021 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to
+do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/libs/cardano-ledger-binary/test/Main.hs
+++ b/libs/cardano-ledger-binary/test/Main.hs
@@ -1,0 +1,29 @@
+module Main where
+
+import System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+import qualified Test.Cardano.Ledger.Binary.RoundTripSpec as RoundTripSpec
+import qualified Test.Cardano.Ledger.Binary.Vintage.Coders as Vintage.Coders
+import qualified Test.Cardano.Ledger.Binary.Vintage.Drop as Vintage.Drop
+import qualified Test.Cardano.Ledger.Binary.Vintage.Failure as Vintage.Failure
+import qualified Test.Cardano.Ledger.Binary.Vintage.RoundTrip as Vintage.RoundTrip
+import qualified Test.Cardano.Ledger.Binary.Vintage.Serialization as Vintage.Serialization
+import qualified Test.Cardano.Ledger.Binary.Vintage.SizeBounds as Vintage.SizeBounds
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Vintage Test Suite" $ do
+    it "RoundTrip" $ Vintage.RoundTrip.tests `shouldReturn` True
+    it "SizeBounds" $ Vintage.SizeBounds.tests `shouldReturn` True
+    it "Serialization" $ Vintage.Serialization.tests `shouldReturn` True
+    it "Drop" $ Vintage.Drop.tests `shouldReturn` True
+    it "Failure" $ Vintage.Failure.tests `shouldReturn` True
+    Vintage.Coders.spec
+  describe "Versioned" $ do
+    RoundTripSpec.spec
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetEncoding stdout utf8
+  hspec spec

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.RoundTripSpec (spec) where
+
+import Cardano.Ledger.Binary
+import Codec.CBOR.ByteArray (ByteArray (..))
+import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (..))
+import Control.Monad (forM_)
+import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.IP (IPv4, IPv6)
+import Data.Int
+import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict
+import qualified Data.Primitive.ByteArray as Prim (ByteArray)
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Data.Time.Clock
+  ( NominalDiffTime,
+    UTCTime (..),
+    nominalDiffTimeToSeconds,
+    secondsToNominalDiffTime,
+  )
+import qualified Data.VMap as VMap
+import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Unboxed as VU
+import Data.Word
+import Numeric.Natural
+import Test.Cardano.Ledger.Binary.Arbitrary ()
+import Test.Cardano.Ledger.Binary.RoundTrip
+import Test.Hspec
+import Test.QuickCheck
+
+-- | We do not handle the full precision of NominalDiffTime.
+newtype NominalDiffTimeRounded = NominalDiffTimeRounded NominalDiffTime
+  deriving (Show, Eq, ToCBOR, FromCBOR)
+
+instance Arbitrary NominalDiffTimeRounded where
+  arbitrary = secondsToNominalDiffTimeRounded <$> arbitrary
+  shrink = fmap secondsToNominalDiffTimeRounded . shrink . nominalDiffTimeRoundedToSeconds
+
+secondsToNominalDiffTimeRounded :: Pico -> NominalDiffTimeRounded
+secondsToNominalDiffTimeRounded (MkFixed s) =
+  NominalDiffTimeRounded $
+    secondsToNominalDiffTime $
+      MkFixed (1_000_000 * (s `div` 1_000_000))
+
+nominalDiffTimeRoundedToSeconds :: NominalDiffTimeRounded -> Pico
+nominalDiffTimeRoundedToSeconds (NominalDiffTimeRounded ndt) = nominalDiffTimeToSeconds ndt
+
+spec :: Spec
+spec =
+  describe "RoundTrip" $ do
+    forM_ allVersions $ \version ->
+      describe (show version) $ do
+        roundTripSpec @() version cborTrip
+        roundTripSpec @Bool version cborTrip
+        roundTripSpec @Integer version cborTrip
+        roundTripSpec @Natural version cborTrip
+        roundTripSpec @Word version cborTrip
+        roundTripSpec @Word8 version cborTrip
+        roundTripSpec @Word16 version cborTrip
+        roundTripSpec @Word32 version cborTrip
+        roundTripSpec @Word64 version cborTrip
+        roundTripSpec @Int version cborTrip
+        roundTripSpec @Int8 version cborTrip
+        roundTripSpec @Int16 version cborTrip
+        roundTripSpec @Int32 version cborTrip
+        roundTripSpec @Int64 version cborTrip
+        roundTripSpec @Float version cborTrip
+        roundTripSpec @Double version cborTrip
+        roundTripSpec @Rational version cborTrip
+        roundTripSpec @Nano version cborTrip
+        roundTripSpec @Pico version cborTrip
+        roundTripSpec @NominalDiffTimeRounded version cborTrip
+        roundTripSpec @UTCTime version cborTrip
+        roundTripSpec @IPv4 version cborTrip
+        roundTripSpec @IPv6 version cborTrip
+        roundTripSpec @(Maybe Integer) version cborTrip
+        roundTripSpec @(StrictMaybe Integer) version cborTrip
+        roundTripSpec @[Integer] version cborTrip
+        roundTripSpec @(V.Vector Integer) version cborTrip
+        roundTripSpec @(VS.Vector Int16) version cborTrip
+        roundTripSpec @(VP.Vector Int) version cborTrip
+        roundTripSpec @(VU.Vector (Bool, Word)) version cborTrip
+        roundTripSpec @(Set.Set Int) version cborTrip
+        roundTripSpec @(Map.Map Integer Int) version cborTrip
+        roundTripSpec @(Seq.Seq Int) version cborTrip
+        roundTripSpec @(SSeq.StrictSeq Int) version cborTrip
+        roundTripSpec @(VMap.VMap VMap.VB VMap.VS Integer Int) version cborTrip
+        roundTripSpec @Prim.ByteArray version cborTrip
+        roundTripSpec @ByteArray version cborTrip
+        roundTripSpec @SlicedByteArray version cborTrip
+        let maybeNullTrip = Trip (encodeNullMaybe toCBOR) (decodeNullMaybe fromCBOR)
+        roundTripSpec @(Maybe Integer) version maybeNullTrip

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Coders.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Coders.hs
@@ -1,0 +1,403 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.Coders (spec) where
+
+import Cardano.Ledger.Binary
+import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.Binary.FlatTerm (FlatTerm, toFlatTerm)
+import Data.Sequence.Strict (StrictSeq, fromList)
+import Data.Text (Text, pack)
+import Data.Typeable
+import Test.Cardano.Ledger.Binary.RoundTrip (Trip (..), cborTrip, roundTripExpectation)
+import Test.Hspec
+
+-- | "coders" functionality and this test module was introduced during Shelley, thus
+-- version 2
+shelleyProtVer :: Version
+shelleyProtVer = natVersion @2
+
+-- ==========================================================================
+
+data TT
+  = A Int
+  | B Int Bool
+  | G [Int]
+  | H (StrictSeq Bool)
+  deriving (Show, Eq)
+
+instance FromCBOR TT where
+  fromCBOR = decodeRecordSum "TT" $
+    \case
+      0 -> (\i -> (2, A i)) <$> fromCBOR -- Tag for A is 0
+      1 -> do
+        -- (,) 3 . B <$> fromCBOR <*> fromCBOR
+        i <- fromCBOR
+        b <- fromCBOR
+        pure (3, B i b) -- Tag for B is 1
+      2 -> do
+        l <- decodeList fromCBOR
+        pure (2, G l) -- Tag for G is 2
+      3 -> do
+        i <- decodeStrictSeq fromCBOR
+        pure (2, H i) -- Tag for H is 3
+      k -> invalidKey k
+
+-- =============================================================================================
+-- JUST A NOTE about the (instance ToCBOR a => ToCBOR [a]). This uses the Begin .. End encoding,
+-- while encodeList uses the list-length encoding.
+--     toCBOR [5::Int,2]     --> [TkListBegin,TkInt 5,TkInt 2,TkBreak].
+--     encodeList [5::Int,2] --> [TkListLen 2,TkInt 5,TkInt 2]
+-- the (instance FromCBOR a => FromCBOR [a]) will ONLY RECOGNIZE THE BEGIN END ENCODING.
+-- but the decoder (decodeList fromCBOR) will recognize both styles of encoding. So in a decoder
+-- or FromCBOR instance it is always preferable to use (decodeList fromCBOR) over (fromCBOR)
+-- For example in the instance above, we could write either of these 2 lines
+--       2 -> do { l <- decodeList fromCBOR; pure(2,G l) }
+--       2 -> do { l <- fromCBOR; pure(2,G l) }
+-- BUT THE FIRST IS MORE GENERAL. The following instance should be replaced
+-- instance FromCBOR a => FromCBOR [a]  -- Defined in ‘cardano-binary-1.5.0:Cardano.Binary.FromCBOR’
+
+instance ToCBOR TT where
+  toCBOR (A i) = encodeListLen 2 <> encodeWord 0 <> toCBOR i
+  toCBOR (B i b) = encodeListLen 3 <> encodeWord 1 <> toCBOR i <> toCBOR b
+  toCBOR (G is) = encodeListLen 2 <> encodeWord 2 <> toCBOR is
+  toCBOR (H bs) = encodeListLen 2 <> encodeWord 3 <> toCBOR bs
+
+-- The Key is that in (G constr tag <@> ...)
+-- The 'tag' for 'constr' aligns with the Tag in the case match
+-- in the FromCBOR instance for TT above.
+
+-- ===============================================================
+
+-- ===================================
+-- Examples
+
+data Two = Two Int Bool
+  deriving (Show, Eq)
+
+decTwo :: Decode ('Closed 'Dense) Two
+encTwo :: Two -> Encode ('Closed 'Dense) Two
+decTwo = RecD Two <! From <! From
+
+encTwo (Two a b) = Rec Two !> To a !> To b
+
+instance ToCBOR Two where
+  toCBOR two = encode $ encTwo two
+
+instance FromCBOR Two where
+  fromCBOR = decode decTwo
+
+-- ============
+
+data Test = Test Int Two Integer
+  deriving (Show, Eq)
+
+test1 :: Test
+test1 = Test 3 (Two 9 True) 33
+
+decTestWithGroupForTwo :: Decode ('Closed 'Dense) Test
+encTestWithGroupForTwo :: Test -> Encode ('Closed 'Dense) Test
+decTestWithGroupForTwo = RecD Test <! From <! decTwo <! From
+
+encTestWithGroupForTwo (Test a b c) = Rec Test !> To a !> encTwo b !> To c
+
+instance ToCBOR Test where
+  toCBOR = encode . encTestWithGroupForTwo
+
+instance FromCBOR Test where
+  fromCBOR = decode decTestWithGroupForTwo
+
+-- ===========
+
+data Three = In Int | N Bool Integer | F Two
+  deriving (Show, Eq)
+
+three1, three2, three3 :: Three
+three1 = In 7
+three2 = N True 22
+three3 = F (Two 1 False)
+
+-- The following values 'decThree' and 'encThree' are meant to simulate the following instances
+{-
+instance ToCBOR Three where
+  toCBOR (In x) = encodeListLen 2 <> encodeWord 0 <> toCBOR x
+  toCBOR (N b i) = encodeListLen 3 <> encodeWord 1 <> toCBOR b <> toCBOR i
+  toCBOR (F (Two i b)) = encodeListLen 3 <> encodeWord 2 <> toCBOR i <>  toCBOR b
+     -- even though F has only 1 argument, we inline the two parts of Two,
+     -- so it appears to have 2 arguments. This mimics CBORGROUP instances
+
+instance FromCBOR Three where
+  fromCBOR = decodeRecordSum "Three" $
+    \case
+      0 -> do
+        x <- fromCBOR
+        pure (2, In x)
+      1 -> do
+        b <- fromCBOR
+        i <- fromCBOR
+        pure (3, N b i)
+      2 -> do
+        i <- fromCBOR
+        b <- fromCBOR
+        pure (3,F (Two i b))
+      k -> invalidKey k
+-}
+
+decThree :: Word -> Decode 'Open Three
+decThree 0 = SumD In <! From
+decThree 1 = SumD N <! From <! From
+decThree 2 = SumD F <! decTwo
+decThree k = Invalid k
+
+encThree :: Three -> Encode 'Open Three
+encThree (In x) = Sum In 0 !> To x
+encThree (N b i) = Sum N 1 !> To b !> To i
+encThree (F t) = Sum F 2 !> encTwo t
+
+instance FromCBOR Three where
+  fromCBOR = decode (Summands "Three" decThree)
+
+instance ToCBOR Three where
+  toCBOR x = encode (encThree x)
+
+-- ================================================================
+-- In this test we nest many Records, and flatten out everything
+
+data Big = Big Int Bool Integer
+  deriving (Show, Eq)
+
+data Bigger = Bigger Test Two Big
+  deriving (Show, Eq)
+
+bigger :: Bigger
+bigger = Bigger (Test 2 (Two 4 True) 99) (Two 7 False) (Big 5 False 102)
+
+-- Note there are 9 individual items, each which fits in one CBOR Token
+-- So we expect the encoding to have 10 items, 1 prefix and 9 others
+
+biggerItems :: FlatTerm
+biggerItems = toFlatTerm shelleyProtVer (encode (encBigger bigger))
+
+decBigger :: Decode ('Closed 'Dense) Bigger
+decBigger =
+  RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
+    <! (RecD Two <! From <! From)
+    <! (RecD Big <! From <! From <! From)
+
+encBigger :: Bigger -> Encode ('Closed 'Dense) Bigger
+encBigger (Bigger (Test a (Two b c) d) (Two e f) (Big g h i)) =
+  Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
+    !> (Rec Two !> To e !> To f)
+    !> (Rec Big !> To g !> To h !> To i)
+
+instance ToCBOR Bigger where
+  toCBOR = encode . encBigger
+
+instance FromCBOR Bigger where
+  fromCBOR = decode decBigger
+
+-- ======================================================================
+-- There are two ways to write smart encoders and decoders that don't put
+-- fields with default values in the Encoding, and that reconstruct them
+-- on the decoding side. These techniques work on record datatypes, i.e.
+-- those with only one constructor. We will illustrate the two approaches
+-- in the datatype A
+
+data M = M Int [Bool] Text
+  deriving (Show, Eq)
+
+a0, a1, a2, a3 :: M
+a0 = M 0 [] "ABC"
+a1 = M 0 [True] "ABC"
+a2 = M 9 [] "ABC"
+a3 = M 9 [False] "ABC"
+
+-- ==========================================================================
+-- The virtual constructor stategy pretends there are mutiple constructors
+-- Even though there is only one. We use invariants about the data to avoid
+-- encoding some of the values.
+
+encM :: M -> Encode 'Open M
+encM (M 0 [] t) = Sum M 0 !> OmitC 0 !> OmitC [] !> To t
+encM (M 0 bs t) = Sum M 1 !> OmitC 0 !> To bs !> To t
+encM (M n [] t) = Sum M 2 !> To n !> OmitC [] !> To t
+encM (M n bs t) = Sum M 3 !> To n !> To bs !> To t
+
+decM :: Word -> Decode 'Open M
+decM 0 = SumD M <! Emit 0 <! Emit [] <! From
+decM 1 = SumD M <! Emit 0 <! From <! From
+decM 2 = SumD M <! From <! Emit [] <! From
+decM 3 = SumD M <! From <! From <! From
+decM n = Invalid n
+
+dualMvirtual :: Trip M M
+dualMvirtual = Trip (encode . encM) (decode (Summands "M" decM))
+
+-- ================================================================================
+-- The Sparse encoding strategy uses N keys, one for each field that is not defaulted
+-- encode (baz (M 9 [True] (pack "hi"))) --Here No fields are defaulted, should be 3 keys
+-- [TkMapLen 3,TkInt 0,TkInt 9,TkInt 1,TkListBegin,TkBool True,TkBreak,TkInt 2,TkString "hi"]
+--                   ^key            ^key                                    ^key
+-- So the user supplies a function, that encodes every field, each field must use a unique
+-- key, and fields with default values have Omit wrapped around the Key encoding.
+-- The user must ensure that there is NOT an Omit on a required field. 'baz' is an example.
+
+baz :: M -> Encode ('Closed 'Sparse) M
+baz (M n xs t) = Keyed M !> Omit (== 0) (Key 0 (To n)) !> Omit null (Key 1 (To xs)) !> Key 2 (To t)
+
+-- To write an Decoder we must pair a decoder for each field, with a function that updates only
+-- that field. We use the Field GADT to construct these pairs, and we must write a function, that
+-- for each field tag, picks out the correct pair. If the Encode and Decode don't agree on how the
+-- tags correspond to a particular field, things will fail.
+
+boxM :: Word -> Field M
+boxM 0 = field update0 From
+  where
+    update0 n (M _ xs t) = M n xs t
+boxM 1 = field update1 From
+  where
+    update1 xs (M n _ t) = M n xs t
+boxM 2 = field update2 From
+  where
+    update2 t (M n xs _) = M n xs t
+boxM n = invalidField n
+
+-- Finally there is a new constructor for Decode, called SparseKeyed, that decodes field
+-- keyed sparse objects. The user supplies an initial value and pick function, and a list
+-- of tags of the required fields. The initial value should have default values and
+-- any well type value in required fields. If the encode function (baz above) is
+-- encoded properly the required fields in the initial value should always be over
+-- overwritten. If it is not written properly, or a bad encoding comes from somewhere
+-- else, the intial values in the required fields might survive decoding. The list
+-- of required fields is checked.
+
+decodeM :: Decode ('Closed 'Dense) M -- Only the field with Key 2 is required
+decodeM = SparseKeyed "M" (M 0 [] (pack "a")) boxM [(2, "Stringpart")]
+
+dualM :: Trip M M
+dualM = Trip (encode . baz) (decode decodeM)
+
+roundTripSpec :: (HasCallStack, Show t, Eq t, Typeable t) => String -> Trip t t -> t -> Spec
+roundTripSpec name trip val =
+  it name $ roundTripExpectation shelleyProtVer trip val
+
+-- | Check that a value can be encoded using Coders and decoded using FromCBOR
+encodeSpec :: (HasCallStack, Show t, Eq t, FromCBOR t) => String -> Encode w t -> t -> Spec
+encodeSpec name enc = roundTripSpec name (Trip (const (encode enc)) fromCBOR)
+
+newtype C = C Text
+  deriving (Show, Eq)
+
+instance ToCBOR C where
+  toCBOR (C t) = toCBOR t
+
+instance FromCBOR C where
+  fromCBOR = C <$> fromCBOR
+
+newtype BB = BB Text
+  deriving (Show, Eq)
+
+dualBB :: Trip BB BB
+dualBB = Trip (\(BB t) -> toCBOR t) (BB <$> fromCBOR)
+
+-- Record Type
+
+data A = ACon Int BB C
+  deriving (Show, Eq)
+
+encodeA :: A -> Encode ('Closed 'Dense) A
+encodeA (ACon i b c) = Rec ACon !> To i !> E (tripEncoder dualBB) b !> To c
+
+decodeA :: Decode ('Closed 'Dense) A
+decodeA = RecD ACon <! From <! D (tripDecoder dualBB) <! From
+
+instance ToCBOR A where
+  toCBOR x = encode (encodeA x)
+
+instance FromCBOR A where
+  fromCBOR = decode decodeA
+
+dualA :: Trip A A
+dualA = cborTrip
+
+recordTests :: Spec
+recordTests =
+  describe "Record tests" $ do
+    roundTripSpec "A1" dualA (ACon 34 (BB "HI") (C "There"))
+    roundTripSpec "A2" dualA (ACon 9 (BB "One") (C "Two"))
+
+-- An example with multiple constructors uses Sum, SumD, and Summands
+
+data N
+  = N1 Int
+  | N2 BB Bool
+  | N3 A
+  deriving (Show, Eq)
+
+encodeN :: N -> Encode 'Open N
+encodeN (N1 i) = Sum N1 0 !> To i
+encodeN (N2 b tf) = Sum N2 1 !> E (tripEncoder dualBB) b !> To tf
+encodeN (N3 a) = Sum N3 2 !> To a
+
+decodeN :: Decode ('Closed 'Dense) N
+decodeN = Summands "N" decodeNx
+  where
+    decodeNx 0 = SumD N1 <! From
+    decodeNx 1 = SumD N2 <! D (tripDecoder dualBB) <! From
+    decodeNx 2 = SumD N3 <! From
+    decodeNx k = Invalid k
+
+dualN :: Trip N N
+dualN = Trip (encode . encodeN) (decode decodeN)
+
+-- ============================================================
+
+ttSpec :: Spec
+ttSpec =
+  describe "Encode TT" $ do
+    -- Tag for A is 0
+    encodeSpec "sA" (Sum A 0 !> To 7) (A 7)
+    -- Tag for B is 1
+    encodeSpec "sB" (Sum B 1 !> To 13 !> To True) (B 13 True)
+    -- Tag for G is 2
+    encodeSpec "sG" (Sum G 2 !> To [3, 4, 5]) (G [3, 4, 5])
+    encodeSpec "sGa" (Sum G 2 !> E toCBOR [2, 5]) (G [2, 5])
+    -- Tag for H is 3
+    let sseq = fromList [False, True]
+    encodeSpec "sH" (Sum H 3 !> E toCBOR sseq) (H sseq)
+
+spec :: Spec
+spec =
+  describe "Coders" $ do
+    describe "Simple Coders" $ do
+      it "encode Bigger is compact" (length biggerItems `shouldBe` 10)
+      ttSpec
+      describe "Encode TT" $ do
+        encodeSpec "Three1" (encThree three1) three1
+        encodeSpec "Three2" (encThree three2) three2
+        encodeSpec "Three3" (encThree three3) three3
+      encodeSpec "test1" (encTestWithGroupForTwo test1) test1
+      encodeSpec "Bigger inlines" (encBigger bigger) bigger
+    recordTests
+    describe "Sparse tests" $ do
+      roundTripSpec "a0" dualM a0
+      roundTripSpec "a1" dualM a1
+      roundTripSpec "a2" dualM a2
+      roundTripSpec "a3" dualM a3
+    describe "Virtual Cosntructor tests" $ do
+      roundTripSpec "a0v" dualMvirtual a0
+      roundTripSpec "a1v" dualMvirtual a1
+      roundTripSpec "a2v" dualMvirtual a2
+      roundTripSpec "a3v" dualMvirtual a3
+    describe "Sum tests" $ do
+      roundTripSpec "N1" dualN (N1 4)
+      roundTripSpec "N2" dualN (N2 (BB "N2") True)
+      roundTripSpec "N3" dualN (N3 (ACon 6 (BB "N3") (C "Test")))

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Coders.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Coders.hs
@@ -188,13 +188,15 @@ biggerItems = toFlatTerm shelleyProtVer (encode (encBigger bigger))
 
 decBigger :: Decode ('Closed 'Dense) Bigger
 decBigger =
-  RecD Bigger <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
+  RecD Bigger
+    <! (RecD Test <! From <! (RecD Two <! From <! From) <! From)
     <! (RecD Two <! From <! From)
     <! (RecD Big <! From <! From <! From)
 
 encBigger :: Bigger -> Encode ('Closed 'Dense) Bigger
 encBigger (Bigger (Test a (Two b c) d) (Two e f) (Big g h i)) =
-  Rec Bigger !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
+  Rec Bigger
+    !> (Rec Test !> To a !> (Rec Two !> To b !> To c) !> To d)
     !> (Rec Two !> To e !> To f)
     !> (Rec Big !> To g !> To h !> To i)
 

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Drop.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Drop.hs
@@ -37,7 +37,8 @@ prop_dropMap = property $ do
     forAll $
       Gen.map
         (Range.constant 0 10)
-        ( (,) <$> genInt32
+        ( (,)
+            <$> genInt32
             <*> Gen.list (Range.constant 0 10) genWord8
         )
   let encodedBs = serialize byronProtVer mp
@@ -53,7 +54,8 @@ prop_dropTuple :: Property
 prop_dropTuple = property $ do
   (set, bs) <-
     forAll $
-      (,) <$> Gen.set (Range.constant 0 10) genInt32
+      (,)
+        <$> Gen.set (Range.constant 0 10) genInt32
         <*> genBytes
   let encodedBs = serialize byronProtVer (set, bs)
   decodeFull byronProtVer encodedBs === Right (set, bs)

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Drop.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Drop.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.Drop (tests) where
+
+import Cardano.Ledger.Binary
+import Data.ByteString (ByteString)
+import Data.Int (Int32)
+import Data.Word (Word64, Word8)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Cardano.Ledger.Binary.Vintage.Helpers (byronProtVer)
+
+tests :: IO Bool
+tests = checkParallel $$(discover)
+
+------------------------------------------------------------------------------
+-- Properties testing whether dropping elements actully removes it or not
+
+genInt32 :: Gen Int32
+genInt32 = Gen.int32 Range.exponentialBounded
+
+genBytes :: Gen ByteString
+genBytes = Gen.bytes (Range.linear 0 1000)
+
+genWord8 :: Gen Word8
+genWord8 = Gen.word8 Range.exponentialBounded
+
+genWord64 :: Gen Word64
+genWord64 = Gen.word64 Range.exponentialBounded
+
+prop_dropMap :: Property
+prop_dropMap = property $ do
+  mp <-
+    forAll $
+      Gen.map
+        (Range.constant 0 10)
+        ( (,) <$> genInt32
+            <*> Gen.list (Range.constant 0 10) genWord8
+        )
+  let encodedBs = serialize byronProtVer mp
+  decodeFull byronProtVer encodedBs === Right mp
+  decodeFullDecoder
+    byronProtVer
+    "Drop Test Failed"
+    (dropMap dropInt32 (dropList dropWord8))
+    encodedBs
+    === Right ()
+
+prop_dropTuple :: Property
+prop_dropTuple = property $ do
+  (set, bs) <-
+    forAll $
+      (,) <$> Gen.set (Range.constant 0 10) genInt32
+        <*> genBytes
+  let encodedBs = serialize byronProtVer (set, bs)
+  decodeFull byronProtVer encodedBs === Right (set, bs)
+  decodeFullDecoder
+    byronProtVer
+    "Drop Test Failed"
+    (dropTuple (dropSet dropInt32) dropBytes)
+    encodedBs
+    === Right ()
+
+prop_dropTriple :: Property
+prop_dropTriple = property $ do
+  tri <- forAll $ (,,) <$> genInt32 <*> genWord8 <*> genWord64
+  let encodedBs = serialize byronProtVer tri
+  decodeFull byronProtVer encodedBs === Right tri
+  decodeFullDecoder
+    byronProtVer
+    "Drop Test Failed"
+    (dropTriple dropInt32 dropWord8 dropWord64)
+    encodedBs
+    === Right ()

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Failure.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Failure.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.Failure (tests) where
+
+import Cardano.Ledger.Binary hiding (Range)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Set (Set)
+import GHC.Stack (HasCallStack, withFrozenCallStack)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import Hedgehog.Internal.Property (failWith)
+import qualified Hedgehog.Range as Range
+import Numeric.Natural (Natural)
+import Test.Cardano.Ledger.Binary.Vintage.Helpers (byronProtVer)
+
+{- HLINT ignore "Use record patterns" -}
+
+tests :: IO Bool
+tests = checkParallel $$(discover)
+
+----------------------------------------------------------------------
+-------------------------   Generators   -----------------------------
+
+data VEncoding = VEncoding Version Encoding
+
+mkByronEncoding :: Encoding -> VEncoding
+mkByronEncoding = VEncoding byronProtVer
+
+instance Show VEncoding where
+  show (VEncoding v enc) = show (toPlainEncoding v enc)
+
+genInvalidNonEmptyCBOR :: Gen VEncoding -- NonEmpty Bool
+genInvalidNonEmptyCBOR = pure (mkByronEncoding (toCBOR ([] :: [Bool])))
+
+genInvalidEitherCBOR :: Gen VEncoding -- Either Bool Bool
+genInvalidEitherCBOR = do
+  b <- Gen.bool
+  pure (mkByronEncoding (encodeListLen 2 <> encodeWord 3 <> toCBOR b))
+
+genNegativeInteger :: Gen Integer
+genNegativeInteger =
+  negate . toInteger <$> Gen.word64 (Range.exponential 1 maxBound)
+
+----------------------------------------------------------------------
+-------------------------   Properties   -----------------------------
+
+prop_shouldFailNonEmpty :: Property
+prop_shouldFailNonEmpty = property $ do
+  VEncoding v ne <- forAll genInvalidNonEmptyCBOR
+  assertIsLeft (decode v ne :: Either DecoderError (NonEmpty Bool))
+
+prop_shouldFailEither :: Property
+prop_shouldFailEither = property $ do
+  VEncoding v e <- forAll genInvalidEitherCBOR
+  assertIsLeft (decode v e :: Either DecoderError (Either Bool Bool))
+
+prop_shouldFailMaybe :: Property
+prop_shouldFailMaybe = property $ do
+  VEncoding v e <- forAll genInvalidEitherCBOR
+  assertIsLeft (decode v e :: Either DecoderError (Maybe Bool))
+
+prop_shouldFailSetTag :: Property
+prop_shouldFailSetTag = property $ do
+  VEncoding v set <- forAll genInvalidEitherCBOR
+  let wrongTag = encodeTag 266
+  assertIsLeft (decode v (wrongTag <> set) :: Either DecoderError (Set Int))
+
+prop_shouldFailSet :: Property
+prop_shouldFailSet = property $ do
+  ls <- forAll $ Gen.list (Range.constant 0 20) (Gen.int Range.constantBounded)
+  let set =
+        encodeTag 258
+          <> encodeListLen (fromIntegral (length ls + 2))
+          <> mconcat (toCBOR <$> (4 : 3 : ls))
+  assertIsLeft (decode byronProtVer set :: Either DecoderError (Set Int))
+
+prop_shouldFailNegativeNatural :: Property
+prop_shouldFailNegativeNatural = property $ do
+  n <- forAll genNegativeInteger
+  assertIsLeft (decode byronProtVer (toCBOR n) :: Either DecoderError Natural)
+
+---------------------------------------------------------------------
+------------------------------- helpers -----------------------------
+
+assertIsLeft :: (HasCallStack, MonadTest m) => Either DecoderError b -> m ()
+assertIsLeft (Right _) = withFrozenCallStack $ failWith Nothing "This should have Left : failed"
+assertIsLeft (Left !x) = case x of
+  DecoderErrorDeserialiseFailure _ (DeserialiseFailure _ str) | not (null str) -> success
+  DecoderErrorCanonicityViolation _ -> success
+  DecoderErrorCustom _ _ -> success
+  DecoderErrorEmptyList _ -> success
+  DecoderErrorLeftover _ _ -> success
+  DecoderErrorSizeMismatch _ _ _ -> success
+  DecoderErrorUnknownTag _ i | i > 0 -> success
+  _ -> success
+
+decode :: FromCBOR a => Version -> Encoding -> Either DecoderError a
+decode version enc =
+  let encoded = serializeEncoding version enc
+   in decodeFull version encoded

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Helpers.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Helpers.hs
@@ -1,0 +1,263 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.Helpers
+  ( byronProtVer,
+
+    -- * Binary test helpers
+    U,
+    U24,
+    extensionProperty,
+    cborFlatTermValid,
+
+    -- * Static size estimates
+    SizeTestConfig (..),
+    cfg,
+    scfg,
+    sizeTest,
+  )
+where
+
+import Cardano.Ledger.Binary
+  ( FromCBOR (..),
+    Range (..),
+    Size,
+    SizeOverride (..),
+    ToCBOR (..),
+    decodeListLenOf,
+    decodeNestedCborBytes,
+    encodeListLen,
+    encodeNestedCborBytes,
+    serialize,
+    szSimplify,
+    szWithCtx,
+    unsafeDeserialize,
+  )
+import Cardano.Ledger.Binary.FlatTerm (toFlatTerm, validFlatTerm)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map as M
+import Data.Text.Lazy (unpack)
+import Data.Text.Lazy.Builder (toLazyText)
+import Data.Typeable (TypeRep)
+import Data.Word (Word8)
+import Formatting (Buildable, bprint, build)
+import Hedgehog (annotate, failure, forAllWith, success)
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as HH.Gen
+import Numeric.Natural (Natural)
+import Test.Cardano.Ledger.Binary.Arbitrary ()
+import Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip (byronProtVer)
+import Test.Hspec ()
+import Test.Hspec.QuickCheck ()
+import Test.QuickCheck
+  ( Arbitrary (arbitrary),
+    Gen,
+    Property,
+    choose,
+    forAll,
+    property,
+    (===),
+  )
+
+--------------------------------------------------------------------------------
+-- From/to tests
+--------------------------------------------------------------------------------
+
+-- | Machinery to test we perform "flat" encoding.
+cborFlatTermValid :: ToCBOR a => a -> Property
+cborFlatTermValid = property . validFlatTerm . toFlatTerm byronProtVer . toCBOR
+
+--------------------------------------------------------------------------------
+
+-- Type to be used to simulate a breaking change in the serialisation
+-- schema, so we can test instances which uses the `UnknownXX` pattern
+-- for extensibility.
+-- Check the `extensionProperty` for more details.
+data U = U Word8 BS.ByteString deriving (Show, Eq)
+
+instance ToCBOR U where
+  toCBOR (U word8 bs) =
+    encodeListLen 2
+      <> toCBOR (word8 :: Word8)
+      <> encodeNestedCborBytes
+        (LBS.fromStrict bs)
+
+instance FromCBOR U where
+  fromCBOR = do
+    decodeListLenOf 2
+    U <$> fromCBOR <*> decodeNestedCborBytes
+
+instance Arbitrary U where
+  arbitrary = U <$> choose (0, 255) <*> arbitrary
+
+-- | Like `U`, but we expect to read back the Cbor Data Item when decoding.
+data U24 = U24 Word8 BS.ByteString deriving (Show, Eq)
+
+instance FromCBOR U24 where
+  fromCBOR = do
+    decodeListLenOf 2
+    U24 <$> fromCBOR <*> decodeNestedCborBytes
+
+instance ToCBOR U24 where
+  toCBOR (U24 word8 bs) =
+    encodeListLen 2
+      <> toCBOR (word8 :: Word8)
+      <> encodeNestedCborBytes
+        (LBS.fromStrict bs)
+
+-- | Given a data type which can be extended, verify we can indeed do so
+-- without breaking anything. This should work with every time which adopted
+-- the schema of having at least one constructor of the form:
+-- .... | Unknown Word8 ByteString
+extensionProperty ::
+  forall a. (Arbitrary a, Eq a, Show a, FromCBOR a, ToCBOR a) => Property
+extensionProperty = forAll @a (arbitrary :: Gen a) $ \input ->
+  {- This function works as follows:
+
+     1. When we call `serialized`, we are implicitly assuming (as contract of this
+        function) that the input type would be of a shape such as:
+
+        data MyType = Constructor1 Int Bool
+                    | Constructor2 String
+                    | UnknownConstructor Word8 ByteString
+
+        Such type will be encoded, roughly, like this:
+
+        encode (Constructor1 a b) = encodeWord 0 <> encodeNestedCbor (a,b)
+        encode (Constructor2 a b) = encodeWord 1 <> encodeNestedCbor a
+        encode (UnknownConstructor tag bs) = encodeWord tag <> encodeNestedCborBytes bs
+
+        In CBOR terms, we would produce something like this:
+
+        <tag :: Word32><Tag24><CborDataItem :: ByteString>
+
+     2. Now, when we call `unsafeDeserialize serialized`, we are effectively asking to produce as
+        output a value of type `U`. `U` is defined by only 1 constructor, it
+        being `U Word8 ByteString`, but this is still compatible with our `tag + cborDataItem`
+        format. So now we will have something like:
+
+        U <tag :: Word32> <CborDataItem :: ByteString>
+
+        (The <Tag24> has been removed as part of the decoding process).
+
+     3. We now call `unsafeDeserialize (serialize u)`, which means: Can you produce a CBOR binary
+        from `U`, and finally try to decode it into a value of type `a`? This will work because
+        our intermediate encoding into `U` didn't touch the inital `<tag :: Word32>`, so we will
+        be able to reconstruct the original object back.
+        More specifically, `serialize u` would produce once again:
+
+        <tag :: Word32><Tag24><CborDataItem :: ByteString>
+
+        (The <Tag24> has been added as part of the encoding process).
+
+        `unsafeDeserialize` would then consume the tag (to understand which type constructor this corresponds to),
+        remove the <Tag24> token and finally proceed to deserialise the rest.
+
+  -}
+  let serialized = serialize byronProtVer input -- Step 1
+      (u :: U) = unsafeDeserialize byronProtVer serialized -- Step 2
+      (encoded :: a) = unsafeDeserialize byronProtVer (serialize byronProtVer u) -- Step 3
+   in encoded === input
+
+--------------------------------------------------------------------------------
+-- Static size estimates
+--------------------------------------------------------------------------------
+
+bshow :: Buildable a => a -> String
+bshow = unpack . toLazyText . bprint build
+
+-- | Configuration for a single test case.
+data SizeTestConfig a = SizeTestConfig
+  { -- | Pretty-print values
+    debug :: a -> String,
+    -- | Generator
+    gen :: HH.Gen a,
+    -- | Must estimates be exact?
+    precise :: Bool,
+    -- | Additional size overrides
+    addlCtx :: M.Map TypeRep SizeOverride,
+    -- | Size overrides computed from a concrete instance.
+    computedCtx :: a -> M.Map TypeRep SizeOverride
+  }
+
+-- | Default configuration, for @Buildable@ types.
+cfg :: Buildable a => SizeTestConfig a
+cfg =
+  SizeTestConfig
+    { debug = bshow,
+      gen = HH.Gen.discard,
+      precise = False,
+      addlCtx = M.empty,
+      computedCtx = const M.empty
+    }
+
+-- | Default configuration, for @Show@able types.
+scfg :: Show a => SizeTestConfig a
+scfg =
+  SizeTestConfig
+    { debug = show,
+      gen = HH.Gen.discard,
+      precise = False,
+      addlCtx = M.empty,
+      computedCtx = const M.empty
+    }
+
+-- | Create a test case from the given test configuration.
+sizeTest :: forall a. ToCBOR a => SizeTestConfig a -> HH.Property
+sizeTest SizeTestConfig {..} = HH.property $ do
+  x <- forAllWith debug gen
+
+  let ctx = M.union (computedCtx x) addlCtx
+
+      badBounds :: Natural -> Range Natural -> HH.PropertyT IO ()
+      badBounds sz bounds = do
+        annotate ("Computed bounds: " <> bshow bounds)
+        annotate ("Actual size:     " <> show sz)
+        annotate ("Value: " <> debug x)
+
+  case szVerify ctx x of
+    Exact -> success
+    WithinBounds _ _ | not precise -> success
+    WithinBounds sz bounds -> do
+      badBounds sz bounds
+      annotate "Bounds were not exact."
+      failure
+    BoundsAreSymbolic bounds -> do
+      annotate ("Bounds are symbolic: " <> bshow bounds)
+      failure
+    OutOfBounds sz bounds -> do
+      badBounds sz bounds
+      annotate "Size fell outside of bounds."
+      failure
+
+-- | The possible results from @szVerify@, describing various ways
+--   a size can or cannot be found within a certain range.
+data ComparisonResult
+  = -- | Size matched the bounds, and the bounds were exact.
+    Exact
+  | -- | Size matched the bounds, but the bounds are not exact.
+    WithinBounds Natural (Range Natural)
+  | -- | The bounds could not be reduced to a numerical range.
+    BoundsAreSymbolic Size
+  | -- | The size fell outside of the bounds.
+    OutOfBounds Natural (Range Natural)
+
+-- | For a given value @x :: a@ with @ToCBOR a@, check that the encoded size
+--   of @x@ falls within the statically-computed size range for @a@.
+szVerify :: ToCBOR a => M.Map TypeRep SizeOverride -> a -> ComparisonResult
+szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
+  Left bounds -> BoundsAreSymbolic bounds
+  Right range
+    | lo range <= sz && sz <= hi range ->
+        if lo range == hi range then Exact else WithinBounds sz range
+  Right range -> OutOfBounds sz range
+  where
+    sz :: Natural
+    sz = fromIntegral $ LBS.length $ serialize byronProtVer x

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Helpers/GoldenRoundTrip.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Helpers/GoldenRoundTrip.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Golden and round-trip testing of 'FromCBOR' and 'ToCBOR' instances
+module Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+  ( goldenTestCBOR,
+    goldenTestCBORExplicit,
+    goldenTestExplicit,
+    roundTripsCBORShow,
+    roundTripsCBORBuildable,
+    compareHexDump,
+    byronProtVer,
+  )
+where
+
+import Cardano.Ledger.Binary
+  ( Decoder,
+    DecoderError,
+    Encoding,
+    FromCBOR (..),
+    ToCBOR (..),
+    Version,
+    decodeFull,
+    decodeFullDecoder,
+    natVersion,
+    serialize,
+    serializeEncoding,
+  )
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Char8 as BS
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import Formatting.Buildable (Buildable (..))
+import GHC.Stack (HasCallStack, withFrozenCallStack)
+import Hedgehog
+  ( MonadTest,
+    Property,
+    eval,
+    property,
+    success,
+    tripping,
+    withTests,
+    (===),
+  )
+import Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Show
+  ( LineDiff,
+    lineDiff,
+    mkValue,
+    renderLineDiff,
+    showPretty,
+  )
+import Test.Cardano.Prelude
+  ( decodeBase16,
+    encodeWithIndex,
+    trippingBuildable,
+  )
+import Text.Show.Pretty (Value (..))
+
+byronProtVer :: Version
+byronProtVer = natVersion @1
+
+type HexDump = BSL.ByteString
+
+type HexDumpDiff = [LineDiff]
+
+renderHexDumpDiff :: HexDumpDiff -> [Char]
+renderHexDumpDiff = Prelude.unlines . fmap renderLineDiff
+
+-- | Diff two 'HexDump's by comparing lines pairwise
+hexDumpDiff :: HexDump -> HexDump -> Maybe HexDumpDiff
+hexDumpDiff x y = do
+  xs <- sequence (mkValue <$> BS.lines x)
+  ys <- sequence (mkValue <$> BS.lines y)
+  pure $
+    concatMap (uncurry lineDiff) $
+      zipWithPadding
+        (String "")
+        (String "")
+        xs
+        ys
+
+zipWithPadding :: a -> b -> [a] -> [b] -> [(a, b)]
+zipWithPadding a b (x : xs) (y : ys) = (x, y) : zipWithPadding a b xs ys
+zipWithPadding a _ [] ys = zip (repeat a) ys
+zipWithPadding _ b xs [] = zip xs (repeat b)
+
+-- | A custom version of '(===)' for 'HexDump's to get prettier diffs
+compareHexDump :: (MonadTest m, HasCallStack) => HexDump -> HexDump -> m ()
+compareHexDump x y = do
+  ok <- withFrozenCallStack $ eval (x == y)
+  if ok then success else withFrozenCallStack $ failHexDumpDiff x y
+
+-- | Fail with a nice line diff of the two HexDumps
+failHexDumpDiff :: (MonadTest m, HasCallStack) => HexDump -> HexDump -> m ()
+failHexDumpDiff x y = case hexDumpDiff x y of
+  Nothing ->
+    withFrozenCallStack $
+      failWith Nothing $
+        Prelude.unlines
+          ["━━━ Not Equal ━━━", showPretty x, showPretty y]
+  Just dif -> withFrozenCallStack $ failWith Nothing $ renderHexDumpDiff dif
+
+-- | Check that the 'encode' and 'decode' function of the 'Bi' instances work as
+-- expected w.r.t. the give reference data, this is, given a value @x::a@, and
+-- a file path @fp@:
+--
+-- - The encoded data should coincide with the contents of the @fp@.
+-- - Decoding @fp@ should give as a result @x@
+goldenTestCBOR ::
+  forall a.
+  (FromCBOR a, ToCBOR a, Eq a, Show a, HasCallStack) =>
+  a ->
+  FilePath ->
+  Property
+goldenTestCBOR =
+  withFrozenCallStack $
+    goldenTestCBORExplicit (label $ Proxy @a) toCBOR fromCBOR
+
+-- | Variant of 'goldenTestBi' using custom encode and decode functions.
+--
+-- This is required for the encode/decode golden-tests for types that do no
+-- have a 'Bi' instance.
+goldenTestCBORExplicit ::
+  forall a.
+  (Eq a, Show a, HasCallStack) =>
+  -- | Label for error reporting when decoding.
+  Text ->
+  (a -> Encoding) ->
+  (forall s. Decoder s a) ->
+  a ->
+  FilePath ->
+  Property
+goldenTestCBORExplicit eLabel enc dec =
+  goldenTestExplicit (serializeEncoding byronProtVer . enc) fullDecoder
+  where
+    fullDecoder :: BSL.ByteString -> Either DecoderError a
+    fullDecoder = decodeFullDecoder byronProtVer eLabel dec
+
+goldenTestExplicit ::
+  forall a.
+  (Eq a, Show a, HasCallStack) =>
+  (a -> BS.ByteString) ->
+  (BS.ByteString -> Either DecoderError a) ->
+  a ->
+  FilePath ->
+  Property
+goldenTestExplicit encode decode x path = withFrozenCallStack $ do
+  let bs' = encodeWithIndex . encode $ x
+  withTests 1 . property $ do
+    bs <- liftIO $ BS.readFile path
+    let target = decodeBase16 bs
+    compareHexDump bs bs'
+    fmap decode target === Just (Right x)
+
+-- | Round trip test a value (any instance of 'FromCBOR', 'ToCBOR', and 'Show'
+--   classes) by serializing it to a ByteString and back again and that also has
+--   a 'Show' instance. If the 'a' type has both 'Show' and 'Buildable'
+--   instances, it's best to use this version.
+roundTripsCBORShow ::
+  (FromCBOR a, ToCBOR a, Eq a, MonadTest m, Show a, HasCallStack) =>
+  a ->
+  m ()
+roundTripsCBORShow x =
+  withFrozenCallStack $ tripping x (serialize byronProtVer) (decodeFull byronProtVer)
+
+-- | Round trip (via ByteString) any instance of the 'FromCBOR' and 'ToCBOR'
+--   class that also has a 'Buildable' instance.
+roundTripsCBORBuildable ::
+  (FromCBOR a, ToCBOR a, Eq a, MonadTest m, Buildable a, HasCallStack) =>
+  a ->
+  m ()
+roundTripsCBORBuildable a =
+  withFrozenCallStack $ trippingBuildable a (serialize byronProtVer) (decodeFull byronProtVer)

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/RoundTrip.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.RoundTrip (tests) where
+
+import Data.Fixed (E9, Fixed (..))
+import Data.Ratio ((%))
+import Hedgehog (Property, Range, checkParallel)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+  ( roundTripsCBORBuildable,
+    roundTripsCBORShow,
+  )
+import Test.Cardano.Prelude (discoverRoundTrip, eachOf)
+
+tests :: IO Bool
+tests = checkParallel $$discoverRoundTrip
+
+roundTripUnitBi :: Property
+roundTripUnitBi = eachOf 1 (pure ()) roundTripsCBORBuildable
+
+roundTripBoolBi :: Property
+roundTripBoolBi = eachOf 10 Gen.bool roundTripsCBORBuildable
+
+-- | Tests up to 'Integer's with multiple machine words using large upper bound
+roundTripIntegerBi :: Property
+roundTripIntegerBi =
+  eachOf
+    1000
+    (Gen.integral (Range.linearFrom 0 (-1e40) 1e40 :: Range Integer))
+    roundTripsCBORBuildable
+
+roundTripWordBi :: Property
+roundTripWordBi =
+  eachOf 1000 (Gen.word Range.constantBounded) roundTripsCBORBuildable
+
+roundTripWord8Bi :: Property
+roundTripWord8Bi =
+  eachOf 1000 (Gen.word8 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripWord16Bi :: Property
+roundTripWord16Bi =
+  eachOf 1000 (Gen.word16 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripWord32Bi :: Property
+roundTripWord32Bi =
+  eachOf 1000 (Gen.word32 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripWord64Bi :: Property
+roundTripWord64Bi =
+  eachOf 1000 (Gen.word64 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripIntBi :: Property
+roundTripIntBi =
+  eachOf 1000 (Gen.int Range.constantBounded) roundTripsCBORBuildable
+
+roundTripFloatBi :: Property
+roundTripFloatBi =
+  eachOf 1000 (Gen.float (Range.constant (-1e12) 1e12)) roundTripsCBORBuildable
+
+roundTripInt32Bi :: Property
+roundTripInt32Bi =
+  eachOf 1000 (Gen.int32 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripInt64Bi :: Property
+roundTripInt64Bi =
+  eachOf 1000 (Gen.int64 Range.constantBounded) roundTripsCBORBuildable
+
+roundTripRatioBi :: Property
+roundTripRatioBi =
+  let r :: Range.Range Integer
+      r = Range.constant (-1_000_000_000_000_0000_000) 1_000_000_000_000_0000_000
+   in eachOf
+        1000
+        ((%) <$> Gen.integral r <*> Gen.integral r)
+        roundTripsCBORBuildable
+
+roundTripNanoBi :: Property
+roundTripNanoBi =
+  eachOf
+    1000
+    ((MkFixed :: Integer -> Fixed E9) <$> Gen.integral (Range.constantFrom 0 (-1e12) 1e12))
+    roundTripsCBORShow
+
+roundTripMapBi :: Property
+roundTripMapBi =
+  eachOf
+    100
+    ( Gen.map
+        (Range.constant 0 50)
+        ((,) <$> Gen.int Range.constantBounded <*> Gen.int Range.constantBounded)
+    )
+    roundTripsCBORShow
+
+roundTripSetBi :: Property
+roundTripSetBi =
+  eachOf
+    100
+    (Gen.set (Range.constant 0 50) (Gen.int Range.constantBounded))
+    roundTripsCBORShow
+
+roundTripByteStringBi :: Property
+roundTripByteStringBi =
+  eachOf 100 (Gen.bytes $ Range.constant 0 100) roundTripsCBORShow
+
+roundTripTextBi :: Property
+roundTripTextBi =
+  eachOf
+    100
+    (Gen.text (Range.constant 0 100) Gen.unicode)
+    roundTripsCBORBuildable

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Serialization.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/Serialization.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.Serialization (tests) where
+
+import Cardano.Ledger.Binary hiding (Range)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BS.Lazy
+import qualified Data.ByteString.Short as BS.Short
+import Data.Int (Int32, Int64)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Time as Time
+import qualified Data.Time.Calendar.OrdinalDate as Time
+import qualified Data.Vector as V
+import Data.Word (Word16, Word32, Word64, Word8)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Cardano.Ledger.Binary.Vintage.Helpers (byronProtVer)
+
+{- HLINT ignore "Redundant <$>" -}
+
+tests :: IO Bool
+tests = checkParallel $$(discover)
+
+data TestStruct = TestStruct
+  { tsUnit :: (),
+    tsBool :: !Bool,
+    tsInteger :: !Integer,
+    tsWord :: !Word,
+    tsWord8 :: !Word8,
+    tsWord16 :: !Word16,
+    tsWord32 :: !Word32,
+    tsWord64 :: !Word64,
+    tsInt :: !Int,
+    tsFloat :: !Float,
+    tsInt32 :: !Int32,
+    tsInt64 :: !Int64,
+    tsTupleBoolBool :: !(Bool, Bool),
+    tsTupleBoolBoolBool :: !(Bool, Bool, Bool),
+    tsTupleBoolBoolBoolBool :: !(Bool, Bool, Bool, Bool),
+    tsByteString :: !BS.ByteString,
+    tsText :: !Text,
+    tsListBool :: ![Bool],
+    tsEitherBoolBool :: !(Either Bool Bool),
+    tsNonEmptyBool :: !(NonEmpty Bool),
+    tsMaybeBool :: !(Maybe Bool),
+    tsMapBoolBool :: !(Map Bool Bool),
+    tsSetBool :: !(Set Bool),
+    tsVectorBool :: !(V.Vector Bool),
+    tsLByteString :: BS.Lazy.ByteString,
+    tsSByteString :: BS.Short.ShortByteString,
+    tsUTCTime :: Time.UTCTime
+  }
+  deriving (Show, Eq)
+
+genTestStruct :: Gen TestStruct
+genTestStruct =
+  TestStruct
+    <$> pure ()
+    <*> Gen.bool
+    <*> Gen.integral (Range.linearFrom 0 (-1e40) 1e40 :: Range Integer)
+    <*> Gen.word Range.constantBounded
+    <*> Gen.word8 Range.constantBounded
+    <*> Gen.word16 Range.constantBounded
+    <*> Gen.word32 Range.constantBounded
+    <*> Gen.word64 Range.constantBounded
+    <*> Gen.int Range.constantBounded
+    <*> Gen.float (Range.constant (-1e12) 1e12)
+    <*> Gen.int32 Range.constantBounded
+    <*> Gen.int64 Range.constantBounded
+    <*> ((,) <$> Gen.bool <*> Gen.bool)
+    <*> ((,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool)
+    <*> ((,,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool <*> Gen.bool)
+    <*> Gen.bytes (Range.linear 0 20)
+    <*> Gen.text (Range.linear 0 20) Gen.unicode
+    <*> Gen.list (Range.constant 0 10) Gen.bool
+    <*> Gen.choice [Right <$> Gen.bool, Left <$> Gen.bool]
+    <*> Gen.nonEmpty (Range.linear 1 20) Gen.bool
+    <*> Gen.maybe Gen.bool
+    <*> Gen.map (Range.constant 0 2) ((,) <$> Gen.bool <*> Gen.bool)
+    <*> Gen.set (Range.constant 0 2) Gen.bool
+    <*> (V.fromList <$> Gen.list (Range.constant 0 10) Gen.bool)
+    <*> (BS.Lazy.fromStrict <$> Gen.bytes (Range.linear 0 20))
+    <*> (BS.Short.toShort <$> Gen.bytes (Range.linear 0 20))
+    <*> genUTCTime
+
+instance ToCBOR TestStruct where
+  toCBOR ts =
+    encodeListLen 1
+      <> toCBOR (tsUnit ts)
+      <> toCBOR (tsBool ts)
+      <> toCBOR (tsInteger ts)
+      <> toCBOR (tsWord ts)
+      <> toCBOR (tsWord8 ts)
+      <> toCBOR (tsWord16 ts)
+      <> toCBOR (tsWord32 ts)
+      <> toCBOR (tsWord64 ts)
+      <> toCBOR (tsInt ts)
+      <> toCBOR (tsFloat ts)
+      <> toCBOR (tsInt32 ts)
+      <> toCBOR (tsInt64 ts)
+      <> toCBOR (tsTupleBoolBool ts)
+      <> toCBOR (tsTupleBoolBoolBool ts)
+      <> toCBOR (tsTupleBoolBoolBoolBool ts)
+      <> toCBOR (tsByteString ts)
+      <> toCBOR (tsText ts)
+      <> toCBOR (tsListBool ts)
+      <> toCBOR (tsEitherBoolBool ts)
+      <> toCBOR (tsNonEmptyBool ts)
+      <> toCBOR (tsMaybeBool ts)
+      <> toCBOR (tsMapBoolBool ts)
+      <> toCBOR (tsSetBool ts)
+      <> toCBOR (tsVectorBool ts)
+      <> toCBOR (tsLByteString ts)
+      <> toCBOR (tsSByteString ts)
+      <> toCBOR (tsUTCTime ts)
+
+instance FromCBOR TestStruct where
+  fromCBOR = do
+    decodeListLenOf 1
+    TestStruct
+      <$> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+
+genUTCTime :: Gen Time.UTCTime
+genUTCTime =
+  Time.UTCTime
+    <$> genDay
+    <*> genDiffTimeOfDay
+  where
+    -- UTC time takes a DiffTime s.t. 0 <= t < 86401s
+    genDiffTimeOfDay :: Gen Time.DiffTime
+    genDiffTimeOfDay =
+      Time.picosecondsToDiffTime
+        <$> Gen.integral (Range.constantFrom 0 0 ((86401e12) - 1))
+
+genDay :: Gen Time.Day
+genDay = Time.fromOrdinalDate <$> genYear <*> genDayOfYear
+
+genYear :: Gen Integer
+genYear = Gen.integral (Range.linear (-10000) 10000)
+
+genDayOfYear :: Gen Int
+genDayOfYear = Gen.int (Range.constantFrom 1 1 366)
+
+prop_roundTripSerialize' :: Property
+prop_roundTripSerialize' = property $ do
+  ts <- forAll genTestStruct
+  (unsafeDeserialize' byronProtVer . serialize' byronProtVer $ ts) === ts
+
+prop_roundTripEncodeNestedCbor :: Property
+prop_roundTripEncodeNestedCbor = property $ do
+  ts <- forAll genTestStruct
+  let encoded = serializeEncoding byronProtVer . encodeNestedCbor $ ts
+  decodeFullDecoder byronProtVer "" decodeNestedCbor encoded === Right ts
+
+prop_decodeContainerSkelWithReplicate :: Property
+prop_decodeContainerSkelWithReplicate = property $
+  assert $ case decode vec of
+    Right _ -> True
+    _ -> False
+  where
+    decode :: Encoding -> Either DecoderError (V.Vector ())
+    decode enc = decodeFull byronProtVer (serializeEncoding byronProtVer enc)
+
+    vec = encodeListLen 4097 <> mconcat (replicate 4097 encodeNull)

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/SizeBounds.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Vintage/SizeBounds.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.Vintage.SizeBounds (tests) where
+
+import Cardano.Ledger.Binary
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map as M
+import Data.Proxy (Proxy (Proxy))
+import Data.Tagged (Tagged (..))
+import qualified Data.Text as T
+import Data.Typeable (typeRep)
+import Data.Word (Word32, Word8)
+import Hedgehog (Gen, Group (..), checkParallel)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Cardano.Ledger.Binary.Vintage.Helpers
+
+tests :: IO Bool
+tests =
+  let listOf :: Gen a -> Gen [a]
+      listOf = Gen.list (Range.linear 0 300)
+   in checkParallel $
+        Group
+          "Encoded size bounds for core types."
+          [ ("()", sizeTest $ scfg {gen = pure (), precise = True}),
+            ("Bool", sizeTest $ cfg {gen = Gen.bool, precise = True}),
+            ("Word", sizeTest $ cfg {gen = Gen.word Range.exponentialBounded}),
+            ("Word8", sizeTest $ cfg {gen = Gen.word8 Range.exponentialBounded}),
+            ("Word16", sizeTest $ cfg {gen = Gen.word16 Range.exponentialBounded}),
+            ("Word32", sizeTest $ cfg {gen = Gen.word32 Range.exponentialBounded}),
+            ("Word64", sizeTest $ cfg {gen = Gen.word64 Range.exponentialBounded}),
+            ("Int", sizeTest $ cfg {gen = Gen.int Range.exponentialBounded}),
+            ( "Int (precision)",
+              sizeTest $
+                cfg
+                  { gen = Gen.int Range.exponentialBounded,
+                    computedCtx = \x ->
+                      M.fromList
+                        [ ( typeRep (Proxy @Int),
+                            SizeConstant $ fromIntegral (withWordSize x :: Integer)
+                          )
+                        ],
+                    precise = True
+                  }
+            ),
+            ( "Float",
+              sizeTest $
+                cfg {gen = Gen.float (Range.exponentialFloat (-1000000) 1000000)}
+            ),
+            ("Int32", sizeTest $ cfg {gen = Gen.int32 Range.exponentialBounded}),
+            ("Int64", sizeTest $ cfg {gen = Gen.int64 Range.exponentialBounded}),
+            ( "Tagged () Word32",
+              sizeTest $
+                (scfg @(Tagged () Word32))
+                  { gen = Tagged <$> Gen.word32 Range.exponentialBounded
+                  }
+            ),
+            ( "(Bool, Bool)",
+              sizeTest $
+                scfg {gen = (,) <$> Gen.bool <*> Gen.bool, precise = True}
+            ),
+            ( "(Bool, Bool, Bool)",
+              sizeTest $
+                scfg
+                  { gen = (,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool,
+                    precise = True
+                  }
+            ),
+            ( "(Bool, Bool, Bool, Bool)",
+              sizeTest $
+                scfg
+                  { gen = (,,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool <*> Gen.bool,
+                    precise = True
+                  }
+            ),
+            ( "ByteString",
+              sizeTest $
+                (scfg @BS.ByteString)
+                  { debug = show . (BS.unpack :: BS.ByteString -> [Word8]),
+                    gen = Gen.bytes (Range.linear 0 1000),
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf BS.ByteString)),
+                            SizeConstant $ fromIntegral $ BS.length bs
+                          )
+                        ],
+                    precise = True
+                  }
+            ),
+            ( "Lazy.ByteString",
+              sizeTest $
+                (scfg @LBS.ByteString)
+                  { debug = show . (LBS.unpack :: LBS.ByteString -> [Word8]),
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf LBS.ByteString)),
+                            SizeConstant $ fromIntegral $ LBS.length bs
+                          )
+                        ],
+                    gen = LBS.fromStrict <$> Gen.bytes (Range.linear 0 1000),
+                    precise = True
+                  }
+            ),
+            ( "Text",
+              sizeTest $
+                cfg
+                  { gen = Gen.text (Range.linear 0 1000) Gen.latin1,
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf T.Text)),
+                            SizeConstant $ fromIntegral $ T.length bs
+                          )
+                        ]
+                  }
+            ),
+            ( "Text 2",
+              sizeTest $
+                cfg
+                  { gen = Gen.text (Range.linear 0 1000) Gen.unicode,
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf T.Text)),
+                            SizeConstant $ fromIntegral $ T.length bs
+                          )
+                        ]
+                  }
+            ),
+            ( "[Bool]",
+              sizeTest $
+                scfg
+                  { gen = listOf Gen.bool,
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf [Bool])),
+                            SizeConstant $ fromIntegral $ length bs
+                          )
+                        ],
+                    precise = True
+                  }
+            ),
+            ( "NonEmpty Bool",
+              sizeTest $
+                scfg
+                  { gen = listOf Gen.bool,
+                    computedCtx = \bs ->
+                      M.fromList
+                        [ ( typeRep (Proxy @(LengthOf [Bool])),
+                            SizeConstant $ fromIntegral $ length bs
+                          )
+                        ],
+                    precise = True
+                  }
+            ),
+            ( "Either Bool Bool",
+              sizeTest $
+                (scfg @(Either Bool Bool))
+                  { gen = Left <$> Gen.bool,
+                    precise = True
+                  }
+            ),
+            ( "Either Bool Bool",
+              sizeTest $
+                (scfg @(Either Bool Bool))
+                  { gen = Right <$> Gen.bool,
+                    precise = True
+                  }
+            ),
+            ("Maybe Bool", sizeTest $ cfg {gen = Gen.bool, precise = True})
+          ]

--- a/libs/cardano-ledger-binary/test/cardano-binary-test.cabal
+++ b/libs/cardano-ledger-binary/test/cardano-binary-test.cabal
@@ -1,0 +1,58 @@
+cabal-version: 2.2
+
+name:                cardano-binary-test
+version:             1.3.0
+synopsis:            Test helpers from cardano-binary exposed to other packages
+description:         Test helpers from cardano-binary exposed to other packages
+license:             MIT
+license-file:        LICENSE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:         -Werror
+
+library
+  import:               base, project-config
+  exposed-modules:      Test.Cardano.Binary.Helpers
+                        Test.Cardano.Binary.Helpers.GoldenRoundTrip
+                        Test.Cardano.Binary.Serialization
+                        Test.Cardano.Binary.Drop
+                        Test.Cardano.Binary.Failure
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-prelude-test
+                      , cborg
+                      , containers
+                      , formatting
+                      , hedgehog
+                      , hspec
+                      , pretty-show
+                      , QuickCheck
+                      , quickcheck-instances
+                      , text
+                      , time
+                      , vector

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -409,7 +409,8 @@ putPtr (Ptr slot (TxIx txIx) (CertIx certIx)) = do
 
 getPtr :: Get Ptr
 getPtr =
-  Ptr <$> (SlotNo <$> getVariableLengthWord64)
+  Ptr
+    <$> (SlotNo <$> getVariableLengthWord64)
     <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
     <*> (CertIx . fromIntegral <$> getVariableLengthWord64)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CompactAddress.hs
@@ -321,10 +321,10 @@ decodeAddrStateT buf = do
       then AddrBootstrap <$> decodeBootstrapAddress buf
       else do
         -- Ensure there are no unexpected bytes in the header
-        unless (header .&. headerNonShelleyBits == 0) $
-          failDecoding
+        unless (header .&. headerNonShelleyBits == 0)
+          $ failDecoding
             "Shelley Address"
-            $ "Invalid header. Unused bits are not suppose to be set: " <> show header
+          $ "Invalid header. Unused bits are not suppose to be set: " <> show header
         -- Advance one byte for the consumed header
         modify' (+ 1)
         payment <- decodePaymentCredential header buf
@@ -346,7 +346,8 @@ ensureBufIsConsumed name buf = do
   lastOffset <- get
   let len = bufLength buf
   unless (lastOffset == len) $
-    failDecoding name $ "Left over bytes: " ++ show (len - lastOffset)
+    failDecoding name $
+      "Left over bytes: " ++ show (len - lastOffset)
 {-# INLINE ensureBufIsConsumed #-}
 
 -- | This decoder assumes the whole `ShortByteString` is occupied by the `BootstrapAddress`
@@ -566,7 +567,8 @@ decodeRewardAccountT buf = do
   modify' (+ 1)
   let header = Header $ bufUnsafeIndex buf 0
   unless (headerIsRewardAccount header) $
-    fail $ "Invalid header for the reward account: " <> show header
+    fail $
+      "Invalid header for the reward account: " <> show header
   account <-
     if headerRewardAccountIsScript header
       then ScriptHashObj <$> decodeScriptHash buf
@@ -597,12 +599,13 @@ decompactAddrLazy (UnsafeCompactAddr bytes) =
     header = run "address header" 0 bytes getWord
     addrNetId =
       unwrap "address network id" $
-        word8ToNetwork $ header .&. 0x0F -- 0b00001111 is the mask for the network id
-        -- The address format is
-        -- header | pay cred | stake cred
-        -- where the header is 1 byte
-        -- the pay cred is (sizeHash (ADDRHASH crypto)) bytes
-        -- and the stake cred can vary
+        word8ToNetwork $
+          header .&. 0x0F -- 0b00001111 is the mask for the network id
+          -- The address format is
+          -- header | pay cred | stake cred
+          -- where the header is 1 byte
+          -- the pay cred is (sizeHash (ADDRHASH crypto)) bytes
+          -- and the stake cred can vary
     paycred = run "payment credential" 1 bytes (getPayCred header)
     stakecred = run "staking credential" 1 bytes $ do
       skipHash ([] @(ADDRHASH c))
@@ -716,7 +719,8 @@ getVariableLengthWord64 = word7sToWord64 <$> getWord7s
 
 getPtr :: GetShort Ptr
 getPtr =
-  Ptr <$> (SlotNo <$> getVariableLengthWord64)
+  Ptr
+    <$> (SlotNo <$> getVariableLengthWord64)
     <*> (TxIx . fromIntegral <$> getVariableLengthWord64)
     <*> (CertIx . fromIntegral <$> getVariableLengthWord64)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -466,7 +466,8 @@ class
   -- ONE SHOULD NOT OVERIDE THE hashScript DEFAULT METHOD
   -- UNLESS YOU UNDERSTAND THE SafeToHash class, AND THE ROLE OF THE scriptPrefixTag
   hashScript =
-    ScriptHash . Hash.castHash
+    ScriptHash
+      . Hash.castHash
       . Hash.hashWith
         (\x -> scriptPrefixTag @era x <> originalBytes x)
   phaseScript :: PhaseRep phase -> Script era -> Maybe (PhasedScript phase era)

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
@@ -82,8 +82,8 @@ constructTxOutAlonzoBench ::
   StrictMaybe (DataHash StandardCrypto) ->
   Benchmark
 constructTxOutAlonzoBench count name mkAddr value !mdh =
-  cvalue
-    `seq` bgroup
+  cvalue `seq`
+    bgroup
       name
       [ env (pure (mkAddr <$> [1 .. count])) $
           bench "TxOut" . nf (map (\addr -> AlonzoTxOut addr value mdh :: TxOut Alonzo)),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -90,13 +90,14 @@ exUnitsTranslationRoundTrip :: Gen Property
 exUnitsTranslationRoundTrip = do
   e <- arbitrary
   let result = exBudgetToExUnits (transExUnits e)
-  pure $
-    counterexample
-      ( "Before: " <> show e
+  pure
+    $ counterexample
+      ( "Before: "
+          <> show e
           <> "\n After: "
           <> show result
       )
-      $ result == Just e
+    $ result == Just e
 
 testSystemStart :: SystemStart
 testSystemStart = SystemStart $ posixSecondsToUTCTime 0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -1032,10 +1032,10 @@ txFromTestCaseData
         tx =
           newTx
             pf
-            ( Body (txBody testCaseData) :
-              [ WitnessesI
-                  (AddrWits' addrWits : otherWitsFields testCaseData)
-              ]
+            ( Body (txBody testCaseData)
+                : [ WitnessesI
+                      (AddrWits' addrWits : otherWitsFields testCaseData)
+                  ]
             )
      in tx
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -137,7 +137,8 @@ testTxValidForLEDGER proof (Box _ trc@(TRC (_, ledgerState, vtx)) _genstate) =
         totalAda ledgerState' === totalAda ledgerState
     Left errs ->
       counterexample
-        ( show (pcLedgerState proof ledgerState) ++ "\n\n"
+        ( show (pcLedgerState proof ledgerState)
+            ++ "\n\n"
             ++ show (pcTx proof vtx)
             ++ "\n\n"
             ++ show (ppList prettyA errs)

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -199,7 +199,8 @@ instance CC.Crypto c => GetLedgerView (BabbageEra c) where
           lvExtraEntropy = error "Extra entropy is not set in the Babbage era",
           lvPoolDistr = pd,
           lvGenDelegs =
-            _genDelegs . dpsDState
+            _genDelegs
+              . dpsDState
               . lsDPState
               $ esLState es,
           lvChainChecks = pparamsToChainChecksPParams . esPp $ es
@@ -226,7 +227,8 @@ instance CC.Crypto c => GetLedgerView (ConwayEra c) where
           lvExtraEntropy = error "Extra entropy is not set in the Conway era",
           lvPoolDistr = pd,
           lvGenDelegs =
-            _genDelegs . dpsDState
+            _genDelegs
+              . dpsDState
               . lsDPState
               $ esLState es,
           lvChainChecks = pparamsToChainChecksPParams . esPp $ es
@@ -299,7 +301,8 @@ view
             lvExtraEntropy = ee,
             lvPoolDistr = pd,
             lvGenDelegs =
-              _genDelegs . dpsDState
+              _genDelegs
+                . dpsDState
                 . lsDPState
                 $ esLState es,
             lvChainChecks = pparamsToChainChecksPParams . esPp $ es
@@ -475,7 +478,8 @@ tickChainDepState
       STS.Prtcl.PrtclState _ _ candidateNonce = csProtocol
       err = error "Panic! tickChainDepState failed."
       newTickState =
-        fromRight err . flip runReader globals
+        fromRight err
+          . flip runReader globals
           . applySTS @STS.Tickn.TICKN
           $ TRC
             ( STS.Tickn.TicknEnv

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
@@ -91,7 +91,9 @@ ocertTransition =
     maxKESiterations <- liftSTS $ asks maxKESEvo
 
     c0 <= kp ?! KESBeforeStartOCERT c0 kp
-    kp_ < c0_ + fromIntegral maxKESiterations
+    kp_
+      < c0_
+      + fromIntegral maxKESiterations
       ?! KESAfterEndOCERT kp c0 maxKESiterations
 
     let t = if kp_ >= c0_ then kp_ - c0_ else 0 -- this is required to prevent an

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -307,7 +307,8 @@ selectMap ::
   ReaderT SqlBackend m (Map.Map k a)
 selectMap fs f = do
   runConduit $
-    selectSource fs [] .| mapMC (\(Entity _ a) -> f a)
+    selectSource fs []
+      .| mapMC (\(Entity _ a) -> f a)
       .| foldlC (\m (k, v) -> Map.insert k v m) mempty
 {-# INLINEABLE selectMap #-}
 

--- a/libs/non-integral/app/Main.hs
+++ b/libs/non-integral/app/Main.hs
@@ -33,7 +33,8 @@ doTestsFromStdin = do
       let c = ln' (1 - f)
       let res = taylorExpCmp 3 (1 / (1 - a)) (-(b * c))
       putStrLn $
-        show (exp' x) ++ " "
+        show (exp' x)
+          ++ " "
           ++ show (-(ln' a))
           ++ " "
           ++ show (1 - ((1 - f) *** b))

--- a/libs/non-integral/test/Tests/Cardano/Ledger/NonIntegral.hs
+++ b/libs/non-integral/test/Tests/Cardano/Ledger/NonIntegral.hs
@@ -122,9 +122,9 @@ praosLeaderCheck f a p sigma = case taylorExpCmp 3 (1 / q) (-sigma * c) of
 
 prop_FPMonotonic :: Monotonic FixedPoint
 prop_FPMonotonic constrain f x y =
-  both constrain (x, y)
-    ==> classify zeroes "both zero case"
-    $ (zeroes || monotonic f x y) === True
+  both constrain (x, y) ==>
+    classify zeroes "both zero case" $
+      (zeroes || monotonic f x y) === True
   where
     zeroes = both zero (x, y)
     zero a = (f a, 0) ~= epsFP
@@ -160,16 +160,16 @@ prop_FPlnPow (Unit x) (Unit y) = (x > 0) ==> (log_pow x y ~= epsFP) === True
 
 prop_neg_taylorExpCmp :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
 prop_neg_taylorExpCmp (Unit p) (Unit s) =
-  both (\x -> 0 < x && x < 1) (p, s)
-    ==> taylorExpCmpCheck (exp' sm) p sm
+  both (\x -> 0 < x && x < 1) (p, s) ==>
+    taylorExpCmpCheck (exp' sm) p sm
   where
     sm = -s
 
 prop_LeaderCmp :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
 prop_LeaderCmp (Unit p) (Unit s) =
-  both (\x -> 0 < x && x < 1) (p, s)
-    ==> classify (p < a) "is leader"
-    $ praosLeaderCheck f a p s
+  both (\x -> 0 < x && x < 1) (p, s) ==>
+    classify (p < a) "is leader" $
+      praosLeaderCheck f a p s
   where
     a = leader f s
     f = 1 / 10

--- a/libs/small-steps-test/src/Control/State/Transition/Generator.hs
+++ b/libs/small-steps-test/src/Control/State/Transition/Generator.hs
@@ -428,8 +428,8 @@ invalidTrace baseEnv maxTraceLength failureProfile = do
       st = lastState tr
   iSig <- generateSignalWithFailureProportions @s failureProfile env st
   let est' = interpretSTS @s baseEnv $ applySTSTest @s $ TRC (env, st, iSig)
-  pure
-    $! Invalid.Trace
+  pure $!
+    Invalid.Trace
       { Invalid.validPrefix = tr,
         Invalid.signal = iSig,
         Invalid.errorOrLastState = est'

--- a/libs/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/libs/small-steps-test/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -140,7 +140,8 @@ traceFromInitState baseEnv maxTraceLength traceGenEnv genSt0 = do
   env <- envGen @sts @traceGenEnv traceGenEnv
   res <-
     fromMaybe
-      ( pure . interpretSTS @sts @traceGenEnv baseEnv
+      ( pure
+          . interpretSTS @sts @traceGenEnv baseEnv
           . Trace.applySTSTest
       )
       genSt0

--- a/libs/small-steps-test/test/Control/State/Transition/Examples/CommitReveal.hs
+++ b/libs/small-steps-test/test/Control/State/Transition/Examples/CommitReveal.hs
@@ -137,8 +137,8 @@ instance
       CRPredicateFailure hashAlgo hashToDataMap commitData
 
   initialRules =
-    [ pure
-        $! CRSt
+    [ pure $!
+        CRSt
           { hashToData = mempty,
             committedHashes = Set.empty
           }
@@ -150,16 +150,17 @@ instance
         case crSignal of
           Commit dataHash commitData -> do
             dataHash `Set.notMember` committedHashes ?! AlreadyComitted dataHash
-            pure
-              $! CRSt
+            pure $!
+              CRSt
                 { hashToData = insert dataHash commitData hashToData,
                   committedHashes = Set.insert dataHash committedHashes
                 }
           Reveal someData -> do
-            hashWithSerialiser toCBOR someData `Set.member` committedHashes
+            hashWithSerialiser toCBOR someData
+              `Set.member` committedHashes
               ?! InvalidReveal someData
-            pure
-              $! CRSt
+            pure $!
+              CRSt
                 { hashToData =
                     delete
                       (hashWithSerialiser toCBOR someData)

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -57,10 +57,10 @@
     "homepage": null,
     "owner": "tweag",
     "repo": "ormolu",
-    "rev": "0.4.0.0",
-    "sha256": "1nw33h01r0zs9bym8rpmrk0yrvxn09mwzr4an0irqfs6ai15rs76",
+    "rev": "0.5.0.1",
+    "sha256": "12g807igwcv0jlhw39ya35bpx0yy4xzv02xy8b3dqhn732y8z1wb",
     "type": "tarball",
-    "url": "https://github.com/tweag/ormolu/archive/refs/tags/0.4.0.0.tar.gz",
+    "url": "https://github.com/tweag/ormolu/archive/refs/tags/0.5.0.1.tar.gz",
     "url_template": "https://github.com/<owner>/<repo>/archive/refs/tags/<rev>.tar.gz"
   }
 }


### PR DESCRIPTION
Started new package `cardano-ledger-binary`:
    
This package introduces new `Encoding` and `Decoder` wrappers that can change their behavior depending on a version, which corresponds to major protocol version. This package introduces new conceptws and consolidates all the old ones that were spread around different packages:
    
* Introduced `Version` in its own module and make it safe to construct
* Switch from `ReaderT` to manual Version passing to recover      representational role
* All decoders and encoders as well as `FromCBOR`/`ToCBOR` classes      from `cardano-binary` package
* Re-exports `Annotator` functionality from `cardano-binary` package,      with plans to migrate it completely in the future
* Moved dropper from `cardano-binary`
* Test suites from `cardano-binary` and `cardano-data` as vintage test      suites
* `FromSharedCBOR` from `cardano-data` package
* `Data.Coders` module from `cardano-data` package
* `Data.Twiddler` module from `cardano-data` package into a `test-lib`
* Improved Roundtripping tests and sophisticated way to display CBOR      encoded blobs that was transferred from `ouroboros-consensus` repo.
* Custom decoders/encoders from `Cardano.Ledger.Serialization` module      from `cardano-ledger-core` package
* Implement round trip test for all To/FromCBOR instances. Discovered      major bug with `SlicedByteArray` and fix it in `cborg` package:      https://github.com/well-typed/cborg/pull/301
