### PR TITLE
Move to get Haskell packages from CHaP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,49 @@ We use tags on the release branches to indicate patches, of the form `ledger/a.b
 We also use tags to indicate what version of the ledger was used in
 cardano-node releases, of the form `node/a.b.c` (possible with a `rc` or `rc1`, etc).
 
+### Releasing the ledger packages to CHaP
+
+When the ledger packages are released they should be released to [CHaP](https://github.com/input-output-hk/cardano-haskell-packages).
+See the CHaP README for [instructions](https://github.com/input-output-hk/cardano-haskell-packages#-from-github).
+
 ## Building
 
 See the [Readme](https://github.com/input-output-hk/cardano-ledger#building) for instructions on building.
+
+## Updating dependencies
+
+Our Haskell packages come from two package repositories:
+- Hackage
+- [CHaP](https://github.com/input-output-hk/cardano-haskell-packages) (which is essentially another Hackage)
+
+The "index state" of each repository is pinned to a particular time in `cabal.project`.
+This tells Cabal to treat the repository "as if" it was the specified time, ensuring reproducibility.
+If you want to use a package version from repository X which was added after the pinned index state time, you need to bump the index state for X.
+This is not a big deal, since all it does is change what packages `cabal` considers to be available when doing solving, but it will change what package versions cabal picks for the plan, and so will likely result in significant recompilation, and potentially some breakage.
+That typically just means that we need to fix the breakage (and add a lower-bound on the problematic package), or add an upper-bound on the problematic package.
+
+Note that `cabal` itself keeps track of what index states it knows about, so when you bump the pinned index state you may need call `cabal update` in order for `cabal` to be happy.
+
+The Nix code which builds our packages also cares about the index state.
+This is represented by inputs managed by `niv`:
+You can update these by running:
+- `niv update hackage.nix` for Hackage
+- `niv update cardano-haskell-packages` for CHaP
+
+If you fail to do this you may get an error like this from Nix:
+```
+error: Unknown index-state 2021-08-08T00:00:00Z, the latest index-state I know about is 2021-08-06T00:00:00Z. You may need to update to a newer hackage.nix.
+```
+
+### Use of `source-repository-package`s
+
+We *can* use Cabal's `source-repository-package` mechanism to pull in un-released package versions.
+However, we should try and avoid this.
+In particular, we should not release our packages to CHaP while we depend on a `source-repository-package`.
+
+If we are stuck in a situation where we need a long-running fork of a package, we should release it to CHaP instead (see the https://github.com/input-output-hk/cardano-haskell-packages[CHaP README] for more).
+
+If you do add a `source-repository-package`, you need to provide a `--sha256` comment in `cabal.project` so that Nix knows the hash of the content.
 
 ## Warnings
 

--- a/README.md
+++ b/README.md
@@ -133,18 +133,6 @@ For a continuous compilation of the `LaTeX` file run:
 nix-shell --pure --run "make watch"
 ```
 
-## Updating dependencies
-
-When updating the [pinned hackage index-state](https://github.com/input-output-hk/cardano-ledger/blob/master/cabal.project) (for example, in order to get a new version of a package), it's necessary to make sure that [`hackage.nix` pin](https://github.com/input-output-hk/cardano-ledger/blob/master/nix/sources.json) points to a later date than the index-state, in order to avoid an error like this:
-```
-error: Unknown index-state 2021-08-08T00:00:00Z, the latest index-state I know about is 2021-08-06T00:00:00Z. You may need to update to a newer hackage.nix.
-```
-
-You can update the `sources.json` file using niv:
-```
-niv update hackage
-```
-
 # Testing
 
 Before running tests with `cabal test`, the `CARDANO_MAINNET_MIRROR` environment variable should be set to the path to [mainnet epochs](https://github.com/input-output-hk/cardano-mainnet-mirror/tree/master/epochs) on your local storage.

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,21 @@
+-- Custom repository for cardano haskell packages, see CONTRIBUTING for more
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+-- See CONTRIBUTING for some Nix commands you will need to run if you
+-- update either of these.
+-- Bump this if you need newer packages from Hackage
 index-state: 2022-09-07T00:00:00Z
+-- Bump this if you need newer packages from CHaP
+index-state: cardano-haskell-packages 2022-10-10T00:00:00Z
 
 packages:
   eras/alonzo/impl
@@ -45,79 +62,6 @@ benchmarks: true
 -- The only sensible test display option
 test-show-details: streaming
 
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: 46cd4c97cff9f1f0a0da976aa9e32bd2899c85ee
-  --sha256: 0qn56ahqmy79riwyaq5m0d4vpamdjkkk04b0x8zwlyd5y3pg58xd
-  subdir:
-    base-deriving-via
-    binary
-    binary/test
-    cardano-crypto-class
-    cardano-crypto-praos
-    heapwords
-    measures
-    slotting
-    cardano-strict-containers
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-crypto
-  tag: f73079303f663e028288f9f4a9e08bcca39a923e
-  --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
-  --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
-  subdir:
-    cardano-prelude
-    cardano-prelude-test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/plutus
-  tag: ecbfc46d3302f438a31c4f2f8f30cd1a87dab271
-  --sha256: 1r16a9xk49bw3r9wihmf49p2f8pfqqymrpgf85lzccyjrxdvxd7r
-  subdir:
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    plutus-core
-    prettyprinter-configurable
-    word-array
-
--- https://github.com/Quid2/flat/pull/22 fixes a potential exception
--- when decoding invalid (e.g. malicious) text literals.
-source-repository-package
-  type: git
-  location: https://github.com/Quid2/flat.git
-  tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
-  --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm
-
-source-repository-package
-  type: git
-  location: https://github.com/fpco/weigh.git
-  tag: bfcf4415144d7d2817dfcb91b6f9a6dfd7236de7
-  --sha256: 01fy4nbq6kaqi73ydn6w7rd1izkg5p217q5znyp2icybf41sl1b6
-
--- https://github.com/well-typed/cborg/pull/301
-source-repository-package
-  type: git
-  location: https://github.com/lehins/cborg
-  tag: c2e86cdd1ac9c51dedb5ef199f513cf48668bcd7
-  --sha256: 18apsg2lqjv9cc29nbd3hzj2hqhksqjj0s4xp2rdv8cbd27racjh
-  subdir:
-    cborg
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/moo
-  tag: 8c487714fbfdea66188fcb85053e7e292e0cc348
-  --sha256: sha256-HWxnkf6xEAFfY14QxQFU/RsQ09skzLSMKvrAB1EQstU=
-
 allow-newer:
   monoidal-containers:aeson,
   size-based:template-haskell,
@@ -135,3 +79,35 @@ constraints:
   , protolude >= 0.3.2
 
   , persistent < 2.14
+
+-- This is a pre-release version of plutus so we can do some early integration
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus
+  tag: ecbfc46d3302f438a31c4f2f8f30cd1a87dab271
+  --sha256: 1r16a9xk49bw3r9wihmf49p2f8pfqqymrpgf85lzccyjrxdvxd7r
+  subdir:
+    plutus-ledger-api
+    plutus-tx
+    plutus-tx-plugin
+    plutus-core
+    prettyprinter-configurable
+    word-array
+
+-- This is an unreleased version of `weigh` that includes `WallTime`.
+-- It's okay for us to have this since it's only our benchmarks
+-- that depend on `weigh`, not our released packages.
+source-repository-package
+  type: git
+  location: https://github.com/fpco/weigh.git
+  tag: bfcf4415144d7d2817dfcb91b6f9a6dfd7236de7
+  --sha256: 01fy4nbq6kaqi73ydn6w7rd1izkg5p217q5znyp2icybf41sl1b6
+
+-- https://github.com/well-typed/cborg/pull/301
+source-repository-package
+  type: git
+  location: https://github.com/lehins/cborg
+  tag: c2e86cdd1ac9c51dedb5ef199f513cf48668bcd7
+  --sha256: 18apsg2lqjv9cc29nbd3hzj2hqhksqjj0s4xp2rdv8cbd27racjh
+  subdir:
+    cborg

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -250,7 +250,8 @@ library
                      , cardano-binary
                      , cardano-crypto
                      , cardano-crypto-wrapper
-                     , cardano-prelude
+                     -- HeapWords gets moved to a separate package in 0.1.0.1
+                     , cardano-prelude < 0.1.0.1
                      , cborg
                      , containers
                      , contra-tracer

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,7 +44,7 @@ let
         latex = import ./latex.nix { inherit (pkgs) stdenv lib texlive; };
       })
       # And, of course, our haskell-nix-ified cabal project:
-      (import ./pkgs.nix)
+      (import ./pkgs.nix { inherit sources; } )
     ];
 
   pkgs = import nixpkgs {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -5,6 +5,7 @@
 , stdenv
 , pkgs
 , haskell-nix
+, CHaP
 , buildPackages
 , config ? {}
 # GHC attribute name
@@ -26,6 +27,7 @@ let
   # https://input-output-hk.github.io/haskell.nix/user-guide/projects/
   pkgSet = haskell-nix.cabalProject {
     inherit src;
+    inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
     compiler-nix-name = compiler;
     modules = [
       {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,8 +1,10 @@
+{ sources }:
 # our packages overlay
 pkgs: _:
 with pkgs; {
   cardanoLedgerSpecsHaskellPackages = import ./haskell.nix {
     inherit config lib stdenv pkgs haskell-nix buildPackages;
+    CHaP = sources.cardano-haskell-packages;
   };
 
   cbor-diag = pkgs.callPackage ./pkgs/cbor-diag { };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+  "cardano-haskell-packages": {
+    "branch": "repo",
+    "description": "Metadata for Cardano's Haskell package repository",
+    "homepage": "https://input-output-hk.github.io/cardano-haskell-packages/",
+    "owner": "input-output-hk",
+    "repo": "cardano-haskell-packages",
+    "rev": "d4af732a53321a1d1760023a2fa5b3f656cc3bfd",
+    "sha256": "0zp19d79szvkvg8h5iv8w6qfd6m2cxy6p7pndf2r6zh923zyxqmf",
+    "type": "tarball",
+    "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/d4af732a53321a1d1760023a2fa5b3f656cc3bfd.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
   "hackage.nix": {
     "branch": "master",
     "description": "Automatically generated Nix expressions for Hackage",


### PR DESCRIPTION
This moves the `cardano-ledger` repository to use CHaP, murdering most of the `source-repository-package`s in the process.

I tried to explain all the process differences, please let me know if it's clear enough!