### PR TITLE
Simplify CostModel parameter representation 

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -212,7 +212,7 @@ instance FromJSONKey Language where
   fromJSONKey = Aeson.FromJSONKeyTextParser languageFromText
 
 validateCostModel :: MonadFail m => Language -> Map Text Integer -> m (Language, CostModel)
-validateCostModel lang cmps = case mkCostModel lang cmps of
+validateCostModel lang cmps = case mkCostModel lang (Map.elems cmps) of
   Left err -> fail $ show err
   Right cm -> pure (lang, cm)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -30,7 +30,6 @@ module Cardano.Ledger.Alonzo.Scripts
     -- * Cost Model
     CostModel,
     mkCostModel,
-    costModelParamsNames,
     getCostModelLanguage,
     getCostModelParams,
     getEvaluationContext,
@@ -88,26 +87,21 @@ import Data.Either (isRight)
 import Data.Int (Int64)
 import Data.Map (Map)
 import Data.Measure (BoundedMeasure, Measure)
-import Data.Text (Text)
-import qualified Data.Text as Text
 import Data.Typeable (Proxy (..), Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
 import Numeric.Natural (Natural)
 import PlutusCore.Evaluation.Machine.CostModelInterface (CostModelApplyWarn)
-import PlutusLedgerApi.Common (showParamName)
 import qualified PlutusLedgerApi.V1 as PV1
   ( CostModelApplyError (..),
     EvaluationContext,
-    ParamName,
     ProtocolVersion (ProtocolVersion),
     ScriptDecodeError,
     assertScriptWellFormed,
     mkEvaluationContext,
   )
-import qualified PlutusLedgerApi.V2 as PV2 (ParamName, assertScriptWellFormed, mkEvaluationContext)
-import PlutusPrelude (enumerate)
+import qualified PlutusLedgerApi.V2 as PV2 (assertScriptWellFormed, mkEvaluationContext)
 
 -- | Marker indicating the part of a transaction for which this script is acting
 -- as a validator.
@@ -309,11 +303,6 @@ decodeCostModel lang = do
   case checked of
     Left e -> fail $ show e
     Right cm -> pure cm
-
-costModelParamsNames :: Language -> [Text]
-costModelParamsNames = \case
-  PlutusV1 -> Text.pack . showParamName <$> enumerate @PV1.ParamName
-  PlutusV2 -> Text.pack . showParamName <$> enumerate @PV2.ParamName
 
 decodeParamsValues :: Decoder s [Integer]
 decodeParamsValues = decodeList fromCBOR

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/PlutusScripts.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/PlutusScripts.hs
@@ -5,17 +5,18 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (PlutusScript), CostModel, mkCostModel)
 import Data.ByteString.Short (pack)
 import Data.Either (fromRight)
+import qualified Data.Map as Map
 import PlutusLedgerApi.Test.EvaluationContext (costModelParamsForTesting)
 
 testingCostModelV1 :: CostModel
 testingCostModelV1 =
   fromRight (error "testingCostModelV1 is not well-formed") $
-    mkCostModel PlutusV1 (0 <$ costModelParamsForTesting)
+    mkCostModel PlutusV1 (0 <$ (Map.elems costModelParamsForTesting))
 
 testingCostModelV2 :: CostModel
 testingCostModelV2 =
   fromRight (error "testingCostModelV2 is not well-formed") $
-    mkCostModel PlutusV2 (0 <$ costModelParamsForTesting)
+    mkCostModel PlutusV2 (0 <$ (Map.elems costModelParamsForTesting))
 
 {- Preproceesed Plutus Script
 guessTheNumber'2_0 :: PlutusTx.Builtins.Internal.BuiltinData ->

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -24,11 +24,8 @@ import Cardano.Ledger.Alonzo.PParams
     getLanguageView,
   )
 import Cardano.Ledger.Alonzo.Scripts
-  ( CostModel,
-    CostModels (..),
+  ( CostModels (..),
     Prices (..),
-    costModelParamsNamesSet,
-    mkCostModel,
   )
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), utxoEntrySize)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), boundRational)
@@ -46,6 +43,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import GHC.Stack (HasCallStack)
 import PlutusLedgerApi.V1 (Data (..))
+import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (freeCostModel)
 import Test.Cardano.Ledger.Alonzo.Examples.Consensus (ledgerExamplesAlonzo)
 import Test.Cardano.Ledger.Alonzo.Serialisation.CDDL (readDataFile)
 import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
@@ -229,13 +227,6 @@ goldenMinFee =
 fromRightError :: (HasCallStack, Show a) => String -> Either a b -> b
 fromRightError errorMsg =
   either (\e -> error $ errorMsg ++ ": " ++ show e) id
-
--- | A cost model that sets everything as being free
-freeCostModel :: HasCallStack => Language -> CostModel
-freeCostModel lang =
-  fromRightError "freeCostModel is not well-formed" $ mkCostModel lang cmps
-  where
-    cmps = Map.fromSet (const 0) $ costModelParamsNamesSet lang
 
 exPP :: AlonzoPParams Alonzo
 exPP =

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -97,7 +97,7 @@ instance PrettyA ExUnits where
 
 ppCostModel :: CostModel -> PDoc
 ppCostModel cm =
-  ppSexp "CostModel" [ppLanguage (getCostModelLanguage cm), ppMap text ppInteger (getCostModelParams cm)]
+  ppSexp "CostModel" [ppLanguage (getCostModelLanguage cm), ppList ppInteger (getCostModelParams cm)]
 
 instance PrettyA CostModel where
   prettyA = ppCostModel

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -104,8 +104,9 @@ import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import GHC.Natural (Natural)
 import GHC.Stack
-import PlutusLedgerApi.Test.EvaluationContext (costModelParamsForTesting)
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
+import qualified PlutusLedgerApi.V2 as PV2
+import PlutusPrelude (enumerate)
 import Test.Cardano.Ledger.Generic.Fields
   ( TxOutField (..),
   )
@@ -140,13 +141,15 @@ alwaysSucceedsHash n pf = hashScript @era $ always n pf
 freeCostModelV1 :: CostModel
 freeCostModelV1 =
   fromRight (error "corrupt freeCostModelV1") $
-    mkCostModel PlutusV1 (0 <$ costModelParamsForTesting)
+    mkCostModel PlutusV1 $
+      const 0 <$> (enumerate @PV1.ParamName)
 
 -- | A cost model that sets everything as being free
 freeCostModelV2 :: CostModel
 freeCostModelV2 =
-  fromRight (error "corrupt freeCostModelV1") $
-    mkCostModel PlutusV1 (0 <$ costModelParamsForTesting) -- TODO use PV2 when it exist
+  fromRight (error "corrupt freeCostModelV2") $
+    mkCostModel PlutusV1 $
+      const 0 <$> (enumerate @PV2.ParamName)
 
 someKeys :: forall era. Era era => Proof era -> KeyPair 'Payment (EraCrypto era)
 someKeys _pf = KeyPair vk sk
@@ -248,10 +251,10 @@ initUTxO pf =
         ]
 
 datumExample1 :: Era era => Data era
-datumExample1 = Data (Plutus.I 123)
+datumExample1 = Data (PV1.I 123)
 
 datumExample2 :: Era era => Data era
-datumExample2 = Data (Plutus.I 0)
+datumExample2 = Data (PV1.I 0)
 
 -- ======================================================================
 -- ====================== Shared classes and Instances ==================


### PR DESCRIPTION
In the new version of Plutus API, we are passing costmodel parameter values as a list, instead of a map indexed by parameter names. So there is no need to keep the parameter names in the model .

Closes https://github.com/input-output-hk/cardano-ledger/issues/3042