### PR TITLE
make directory change more apparent in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ for the ledger specification corresponding to the Shelley release, or
 the Byron release). Then, build the latex document by running:
 
 ```shell
+cd <myLaTexDir>
 nix-shell --pure --run make
 ```
 
 For a continuous compilation of the `LaTeX` file run:
 
 ```shell
+cd <myLaTexDir>
 nix-shell --pure --run "make watch"
 ```
 


### PR DESCRIPTION
The instructions for building the individual latex specs depend on being in the correct directory. This makes this more apparent.

resolves #3076