### PR TITLE
Bump CHaP, fix issues

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,7 +15,7 @@ repository cardano-haskell-packages
 -- Bump this if you need newer packages from Hackage
 index-state: 2022-09-07T00:00:00Z
 -- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-10-14T19:00:00Z
+index-state: cardano-haskell-packages 2022-10-19T00:00:00Z
 
 packages:
   eras/alonzo/impl

--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -89,6 +89,7 @@ library
                      , cardano-binary
                      , cardano-crypto
                      , cardano-prelude
+                     , heapwords
                      , cryptonite
                      , data-default
                      , formatting

--- a/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/Hashing.hs
@@ -64,6 +64,7 @@ import Cardano.Binary
     serialize,
     withWordSize,
   )
+import Cardano.HeapWords
 import Cardano.Prelude
 import Crypto.Hash (Blake2b_256, Digest, HashAlgorithm, hashDigestSize)
 import qualified Crypto.Hash as Hash

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -250,8 +250,7 @@ library
                      , cardano-binary
                      , cardano-crypto
                      , cardano-crypto-wrapper
-                     -- HeapWords gets moved to a separate package in 0.1.0.1
-                     , cardano-prelude < 0.1.0.1
+                     , cardano-prelude 
                      , cborg
                      , containers
                      , contra-tracer
@@ -262,6 +261,7 @@ library
                      , directory
                      , filepath
                      , formatting
+                     , heapwords
                      , mtl
                      , nothunks
                      , quiet
@@ -370,6 +370,7 @@ test-suite cardano-ledger-byron-test
                      , filepath
                      , formatting
                      , generic-monoid
+                     , heapwords
                      , hedgehog >= 1.0.4
                      , microlens
                      , resourcet

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Block/Validation.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Block/Validation.hs
@@ -115,6 +115,7 @@ import Cardano.Crypto
     hashDecoded,
     hashRaw,
   )
+import Cardano.HeapWords
 import Cardano.Prelude
 import Control.Monad.Trans.Resource (ResIO)
 import qualified Data.ByteString.Lazy as BSL

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -27,6 +27,7 @@ import Cardano.Chain.Common.Attributes
     toCBORAttributes,
   )
 import Cardano.Chain.Common.NetworkMagic (NetworkMagic (..))
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.Aeson (ToJSON (..), object, (.=))
 import qualified Data.ByteString.Char8 as Char8

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrSpendingData.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrSpendingData.hs
@@ -24,6 +24,7 @@ import Cardano.Binary
     szCases,
   )
 import Cardano.Crypto.Signing (RedeemVerificationKey, VerificationKey)
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.Aeson (ToJSON)
 import Formatting (bprint, build)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/Address.hs
@@ -78,6 +78,7 @@ import Cardano.Crypto.Signing
   ( RedeemVerificationKey,
     VerificationKey,
   )
+import Cardano.HeapWords
 import Cardano.Prelude
 import qualified Data.Aeson as Aeson
 import Data.ByteString.Base58

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs
@@ -39,6 +39,7 @@ import Cardano.Binary
     dropMap,
     dropWord8,
   )
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.Aeson (ToJSON (..))
 import qualified Data.ByteString.Lazy as LBS

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/Compact.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/Compact.hs
@@ -15,6 +15,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull', serialize')
 import Cardano.Chain.Common.Address (Address (..))
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as BSS (fromShort, toShort)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/KeyHash.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/KeyHash.hs
@@ -15,6 +15,7 @@ import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Chain.Common.AddressHash
 import Cardano.Crypto (decodeAbstractHash, hashHexF)
 import Cardano.Crypto.Signing (VerificationKey)
+import Cardano.HeapWords
 import Cardano.Prelude
 import Formatting (formatToString)
 import Formatting.Buildable (Buildable)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/LovelacePortion.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/LovelacePortion.hs
@@ -16,6 +16,7 @@ module Cardano.Chain.Common.LovelacePortion
 where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.HeapWords
 import Cardano.Prelude
 import Control.Monad (fail)
 import qualified Data.Aeson as Aeson

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/NetworkMagic.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/NetworkMagic.hs
@@ -24,6 +24,7 @@ import Cardano.Crypto.ProtocolMagic
     RequiresNetworkMagic (..),
     getProtocolMagic,
   )
+import Cardano.HeapWords
 import Cardano.Prelude hiding ((%))
 import Data.Aeson (ToJSON)
 import Formatting (bprint, build, (%))

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Compact.hs
@@ -36,6 +36,7 @@ import Cardano.Chain.Common.Compact
 import Cardano.Chain.Common.Lovelace (Lovelace)
 import Cardano.Chain.UTxO.Tx (TxId, TxIn (..), TxOut (..))
 import Cardano.Crypto.Hashing (hashToBytes, unsafeHashFromBytes)
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.Binary.Get (Get, getWord64le, runGet)
 import Data.Binary.Put (Put, putWord64le, runPut)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs
@@ -37,6 +37,7 @@ import Cardano.Chain.Common.CBOR
     knownCborDataItemSizeExpr,
   )
 import Cardano.Crypto (Hash, serializeCborHash, shortHashF)
+import Cardano.HeapWords
 import Cardano.Prelude
 import Data.Aeson (ToJSON)
 import Formatting (Format, bprint, build, builder, int)

--- a/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxO.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/UTxO/UTxO.hs
@@ -56,6 +56,7 @@ import Cardano.Chain.UTxO.Compact
   )
 import Cardano.Chain.UTxO.Tx (Tx (..), TxId, TxIn (..), TxOut (..))
 import Cardano.Crypto (serializeCborHash)
+import Cardano.HeapWords
 import Cardano.Prelude hiding (concat, empty, toList)
 import Data.Coerce
 import qualified Data.List.NonEmpty as NE

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Compact.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Compact.hs
@@ -8,6 +8,7 @@ module Test.Cardano.Chain.Common.Compact
 where
 
 import Cardano.Chain.Common (fromCompactAddress, toCompactAddress)
+import Cardano.HeapWords
 import Cardano.Prelude
 import Hedgehog (MonadTest, assert, forAll, property, tripping)
 import Test.Cardano.Chain.Common.Gen (genAddress)

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Compact.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/UTxO/Compact.hs
@@ -14,6 +14,7 @@ import Cardano.Chain.UTxO
     toCompactTxIn,
     toCompactTxOut,
   )
+import Cardano.HeapWords
 import Cardano.Prelude
 import Hedgehog (MonadTest, assert, forAll, property, tripping)
 import Test.Cardano.Chain.UTxO.Gen (genTxId, genTxIn, genTxOut)

--- a/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
+++ b/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
@@ -220,6 +220,7 @@ library
                      , filepath
                      , formatting
                      , generic-monoid
+                     , heapwords
                      , hedgehog >= 1.0.4
                      , microlens
                      , resourcet

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/cardano-haskell-packages/",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "89f17aabd6a47c597767596d7a6030b3ee431537",
-        "sha256": "0cy9lzfkahqm74f8wvdndxlcyb7w69lk5csa3zvq8sghc13mp40p",
+        "rev": "e79a09bf6018fa0e5c3196f0ac01e58224caf73d",
+        "sha256": "0dmibhgx9q75zx83ir0miz2s3ik33840xqvz3cwicrfjn6rx0dnr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/89f17aabd6a47c597767596d7a6030b3ee431537.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/e79a09bf6018fa0e5c3196f0ac01e58224caf73d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hackage.nix": {


### PR DESCRIPTION
The main issue was with the old version of `cardano-prelude` being forced by `cardano-ledger-byron`. But in fact the other packages had already migrated for the `heapwords` change, so I just did that for `cardano-ledger-byron` also and dropped the constraint.

IMPORTANT: due to us having to mess with CHaP recently, you may find things behave a bit oddly until we get this merged, so please take a look ASAP.