### PR TITLE
increase trials in "We are elected" test

### DIFF
--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -277,7 +277,7 @@ testCheckLeaderVal =
           r > 0 ==>
             let ascVal :: Double
                 ascVal = fromRational . unboundRational $ activeSlotVal f
-                numTrials = 500
+                numTrials = 2000
                 -- 4 standard deviations
                 δ = 4 * sqrt (realToFrac numTrials * p * (1 - p))
                 p = 1 - (1 - ascVal) ** fromRational r


### PR DESCRIPTION
The property test "We are elected as leader proportional to our stake" fails fairly infrequently, but often enough to be a annoying. I cannot find a problem with the test, I think that the variance with 500 trials is just too high. I've increased the number of trials to 2,000. It still runs quite fast (under a second).

```
Running in scenario: Development
Ledger with Delegation
  Unit Tests
    Test checkLeaderVal calculation
      We are elected as leader proportional to our stake: OK (0.72s)
        +++ OK, passed 100 tests.
```

I can get this test to fail consistently by setting `withMaxSuccess` to 500 when the number of trials is 500. With 2,000 trials, it succeeds often with `withMaxSuccess` set to 10,000.

If anyone else wants to check the math, that would be great too.