### PR TITLE
Added a law and a test to the `Twiddler` class

### DIFF
--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -508,5 +508,5 @@ instance Typeable c => Twiddle (AlonzoScript (AlonzoEra c)) where
 instance Typeable c => Twiddle (Data (AlonzoEra c)) where
   twiddle v = twiddle v . toTerm v
 
-instance (Crypto c, Typeable c) => Twiddle (BinaryData (AlonzoEra c)) where
+instance Crypto c => Twiddle (BinaryData (AlonzoEra c)) where
   twiddle v = twiddle v . toTerm v

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -43,8 +43,8 @@ library
     Test.Cardano.Ledger.Babbage.Examples.Consensus,
     Test.Cardano.Ledger.Babbage.Serialisation.Generators
   build-depends:
-    cardano-ledger-binary,
     cardano-ledger-allegra,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-alonzo,
     cardano-ledger-alonzo-test,
     cardano-ledger-babbage,

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -11,14 +12,19 @@
 
 module Test.Cardano.Ledger.Babbage.Serialisation.Generators where
 
-import Cardano.Ledger.Babbage.PParams
+import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import Cardano.Ledger.Babbage.PParams hiding (PParamsUpdate)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody, BabbageTxOut (..))
-import Cardano.Ledger.Binary (Sized, ToCBOR, mkSized)
+import Cardano.Ledger.Binary (Sized, Term (..), ToCBOR, mkSized)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.PParams (Update (..))
+import Cardano.Ledger.Val (Val)
 import Control.State.Transition (STS (PredicateFailure))
+import Data.Maybe (catMaybes)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import Test.Cardano.Ledger.Binary.Twiddle (Twiddle (..), emptyOrNothing, toTerm, twiddleStrictMaybe)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
@@ -153,3 +159,74 @@ instance
         MalformedScriptWitnesses <$> arbitrary,
         MalformedReferenceScripts <$> arbitrary
       ]
+
+instance
+  ( Era era,
+    ToCBOR (PParamsUpdate era)
+  ) =>
+  Twiddle (Update era)
+  where
+  twiddle v = twiddle v . toTerm v
+
+instance Twiddle a => Twiddle (Sized a)
+
+instance
+  ( Era era,
+    Val (Value era),
+    ToCBOR (Value era),
+    ToCBOR (Script era)
+  ) =>
+  Twiddle (BabbageTxOut era)
+  where
+  twiddle v = twiddle v . toTerm v
+
+instance
+  ( Era era,
+    BabbageEraTxBody era
+  ) =>
+  Twiddle (BabbageTxBody era)
+  where
+  twiddle v txBody = do
+    inputs' <- twiddle v $ btbInputs txBody
+    outputs' <- twiddle v $ btbOutputs txBody
+    fee' <- twiddle v $ btbTxFee txBody
+    -- Empty collateral can be represented by empty set or the
+    -- value can be omitted entirely
+    ttl' <- twiddleStrictMaybe v . invalidHereafter $ btbValidityInterval txBody
+    cert' <- emptyOrNothing v $ btbCerts txBody
+    wdrls' <- twiddle v $ btbWdrls txBody
+    update' <- twiddleStrictMaybe v $ btbUpdate txBody
+    auxDataHash' <- twiddleStrictMaybe v $ btbAuxDataHash txBody
+    validityStart' <- twiddleStrictMaybe v . invalidBefore $ btbValidityInterval txBody
+    mint' <- twiddle v $ btbMint txBody
+    scriptDataHash' <- twiddleStrictMaybe v $ btbScriptIntegrityHash txBody
+    collateral' <- emptyOrNothing v $ btbCollateral txBody
+    requiredSigners' <- emptyOrNothing v $ btbReqSignerHashes txBody
+    networkId' <- twiddleStrictMaybe v $ btbTxNetworkId txBody
+    collateralReturn <- twiddleStrictMaybe v $ btbCollateralReturn txBody
+    totalCollateral <- twiddleStrictMaybe v $ btbTotalCollateral txBody
+    referenceInputs <- emptyOrNothing v $ btbReferenceInputs txBody
+    mp <- elements [TMap, TMapI]
+    let fields =
+          [ (TInt 0, inputs'),
+            (TInt 1, outputs'),
+            (TInt 2, fee')
+          ]
+            <> catMaybes
+              [ (TInt 3,) <$> ttl',
+                (TInt 4,) <$> cert',
+                (TInt 5,) <$> Just wdrls',
+                (TInt 6,) <$> update',
+                (TInt 7,) <$> auxDataHash',
+                (TInt 8,) <$> validityStart',
+                (TInt 9,) <$> Just mint',
+                (TInt 11,) <$> scriptDataHash',
+                (TInt 13,) <$> collateral',
+                (TInt 14,) <$> requiredSigners',
+                (TInt 15,) <$> networkId',
+                (TInt 16,) <$> collateralReturn,
+                (TInt 17,) <$> totalCollateral,
+                (TInt 18,) <$> referenceInputs
+              ]
+    fields' <- shuffle fields
+    pure $ mp fields'

--- a/flake.lock
+++ b/flake.lock
@@ -273,11 +273,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666164185,
-        "narHash": "sha256-5v+YB4ijeUfg5LCz9ck4gIpCPhIS+qn02OyPJO48bCE=",
+        "lastModified": 1669546925,
+        "narHash": "sha256-Gvtk9agz88tBgqmCdHl5U7gYttTkiuEd8/Rq1Im0pTg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5203abb1329f7ea084c04acda330ca75d5b9fb5",
+        "rev": "fecf05d4861f3985e8dee73f08bc82668ef75125",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665512413,
-        "narHash": "sha256-IeuXVWD+VkmdVdC3d2i7mdEWhNSEvc2GUdui09zAGpE=",
+        "lastModified": 1668450977,
+        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "08ce9a42392cf8c7fdabf7c51069381ba5455dc7",
+        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -318,6 +318,17 @@ adaIsPreservedInEachEpoch proof genSize =
         trcInit = _traceInitState trc
         trcLast = lastState trc
 
+twiddlerInvariantHolds ::
+  forall era.
+  ( Reflect era
+  ) => 
+  Proof era ->
+  GenSize ->
+  TestTree
+twiddlerInvariantHolds proof genSize =
+  testProperty (show proof) $
+    _
+
 -- ==============================================================
 -- Infrastrucure for running individual tests, with easy replay.
 -- In ghci just type

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Generic.Properties where
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..), IsValid (..))
 import qualified Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (GenDelegs (..))
@@ -39,6 +40,7 @@ import Data.Default.Class (Default (def))
 import qualified Data.Map.Strict as Map
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Binary.Arbitrary ()
+import Test.Cardano.Ledger.Binary.Twiddle (Twiddle, twiddleInvariantProp)
 import Test.Cardano.Ledger.Generic.Fields (abstractTx, abstractTxBody, abstractTxOut, abstractWitnesses)
 import Test.Cardano.Ledger.Generic.Functions (TotalAda (totalAda), isValid')
 import Test.Cardano.Ledger.Generic.GenState
@@ -66,12 +68,11 @@ import Test.Cardano.Ledger.Generic.TxGen
     genAlonzoTx,
     genUTxO,
   )
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes ()
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (StandardCrypto)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.QuickCheck
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.Cardano.Ledger.Binary.Twiddle (Twiddle, twiddleInvariantProp)
 
 -- =====================================
 -- Top level generators of TRC
@@ -325,21 +326,22 @@ adaIsPreservedInEachEpoch proof genSize =
         trcLast = lastState trc
 
 twiddleInvariantHolds ::
-  forall a era.
+  forall a.
   ( Arbitrary a,
     Show a,
     Twiddle a
   ) =>
-  Proof era ->
+  String ->
   TestTree
-twiddleInvariantHolds proof =
-  testProperty (show proof) $ twiddleInvariantProp @a
+twiddleInvariantHolds name =
+  testProperty name $ twiddleInvariantProp @a
 
 twiddleInvariantHoldsEras :: TestTree
 twiddleInvariantHoldsEras =
   testGroup
     "Twiddle invariant holds for TxBody"
-    [ twiddleInvariantHolds @(AlonzoTxBody (AlonzoEra Mock)) (Alonzo Mock)
+    [ twiddleInvariantHolds @(AlonzoTxBody (AlonzoEra StandardCrypto)) "Alonzo",
+      twiddleInvariantHolds @(BabbageTxBody (BabbageEra StandardCrypto)) "Babbage"
     ]
 
 -- ==============================================================


### PR DESCRIPTION
This PR adds a test for the `Twiddle` law. A correct `Twiddle` implementation should perserve all data when twiddle-encoded and then decoded.

I added `Twiddle` law test to Alonzo and Babbage eras.

I also moved the `twiddleStrictMaybe` and `emptyOrNothing` utility functions into the `Twiddle` module.