### PR TITLE
Get ormolu from haskell.nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -61,18 +61,5 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "ormolu": {
-        "branch": "master",
-        "builtin": false,
-        "description": "A formatter for Haskell source code",
-        "homepage": null,
-        "owner": "tweag",
-        "repo": "ormolu",
-        "rev": "0.5.0.1",
-        "sha256": "12g807igwcv0jlhw39ya35bpx0yy4xzv02xy8b3dqhn732y8z1wb",
-        "type": "tarball",
-        "url": "https://github.com/tweag/ormolu/archive/refs/tags/0.5.0.1.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/refs/tags/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -22,18 +22,18 @@ let
     name = "cabal-dev-shell";
 
     # These programs will be available inside the nix-shell.
-    buildInputs = with haskellPackages; [
+    nativeBuildInputs = with haskellPackages; [
       nix-prefetch-git
       niv
       pkg-config
       hlint
-      ormolu # XXX switch to ormolu_0_5_0_1 once our pkgs has it
       pyEnv
     ];
 
     tools = {
       cabal = "3.8.1.0";
       ghcid = "0.8.7";
+      ormolu = "0.5.0.1";
       haskell-language-server="latest";
     };
 


### PR DESCRIPTION
`haskell.nix` has nice support for this kind of thing, we can just use it. I ran `./scripts/ormolise.sh` from a `nix-shell` and it was a no-op, so I think it worked.