### PR TITLE
Draft: Enable UndecidableSuperClasses where needed

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.4"]
+        ghc: ["8.10.7", "9.2.4", "9.4.2"]
         os: [ubuntu-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -98,3 +98,16 @@ source-repository-package
   --sha256: 18apsg2lqjv9cc29nbd3hzj2hqhksqjj0s4xp2rdv8cbd27racjh
   subdir:
     cborg
+
+source-repository-package
+  type: git
+  location: https://github.com/milloni/cardano-base
+  tag: a82587d621d6b64cf5001cf2845a958887aef9cc
+  --sha256: 1zx8li963wfc7kq5p2nxdj8lnw2nj59jli47bww7h2silbr60apf
+  subdir:
+    binary
+    binary/test
+    cardano-crypto-class
+    cardano-crypto-praos
+    cardano-crypto-tests
+    slotting

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -19,7 +19,7 @@ source-repository head
   subdir:   eras/alonzo/impl
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.Alonzo.Core
   ( AlonzoEraTxBody (..),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module exports implementations of many of the functions outlined in the Alonzo specification.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Alonzo.TxWits

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -26,7 +26,7 @@ source-repository head
   subdir:   eras/alonzo/test-suite
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   eras/babbage/impl
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Core.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE UndecidableSuperClasses #-}
+
 module Cardano.Ledger.Babbage.Core
   ( BabbageEraTxBody (..),
     module Cardano.Ledger.Alonzo.Core,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -23,7 +23,7 @@ source-repository head
   subdir:   eras/babbage/test-suite
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/chain/executable-spec/byron-spec-chain.cabal
+++ b/eras/byron/chain/executable-spec/byron-spec-chain.cabal
@@ -13,7 +13,7 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -29,7 +29,7 @@ data-files:          test/golden/AbstractHash
                      test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/crypto/test/cardano-crypto-test.cabal
+++ b/eras/byron/crypto/test/cardano-crypto-test.cabal
@@ -29,7 +29,7 @@ data-files:          golden/AbstractHash
                      golden/json/ProtocolMagic_Legacy_NMMustBeNothing
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
+++ b/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
@@ -14,7 +14,7 @@ build-type:          Simple
 extra-source-files:  CHANGELOG.md
 
 common base
-  build-depends:      base >= 4.12 && < 4.18
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -119,7 +119,7 @@ flag test-normal-form
     manual: True
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
+++ b/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
@@ -112,7 +112,7 @@ data-files: golden/cbor/block/BlockSignature
             golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   eras/conway/impl
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -18,7 +18,7 @@ source-repository head
   subdir:   eras/conway/test-suite
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
+++ b/eras/shelley-ma/impl/cardano-ledger-shelley-ma.cabal
@@ -19,7 +19,7 @@ source-repository head
   subdir:   eras/shelley-ma/impl
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Core.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Core.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.ShelleyMA.Core
   ( ShelleyMAEraTxBody (..),

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -24,7 +24,7 @@ source-repository head
   subdir:   eras/shelley-ma/test-suite
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -14,7 +14,7 @@ source-repository head
   subdir:   eras/shelley/impl
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 -- | Interface to the Shelley ledger for the purposes of managing a Shelley
 -- mempool.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.Shelley.Core
   ( ShelleyEraTxBody (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Shelley.UTxO

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -20,7 +20,7 @@ source-repository head
   subdir:   eras/shelley/test-suite
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -9,8 +9,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Infrastructure for generating STS Traces over any Era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Test.Cardano.Ledger.Shelley.Generator.ScriptClass
   ( ScriptClass (..),

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   libs/cardano-data
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 common base
   build-depends:
-    base >= 4.12 && < 4.17
+    base >= 4.12 && < 5
 
 common project-config
   default-language: Haskell2010

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -16,7 +16,7 @@ source-repository head
   subdir:   libs/cardano-ledger-binary
 
 common base
-  build-depends:     base >= 4.12 && < 4.17
+  build-depends:     base >= 4.12 && < 5
 
 common project-config
   default-language:  Haskell2010

--- a/libs/cardano-ledger-binary/test/cardano-binary-test.cabal
+++ b/libs/cardano-ledger-binary/test/cardano-binary-test.cabal
@@ -17,7 +17,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.14       && < 4.17     }
+common base                         { build-depends: base                             >= 4.14       && < 5     }
 
 common project-config
   default-language:     Haskell2010

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 common base
   build-depends:
-    base >= 4.12 && < 4.17
+    base >= 4.12 && < 5
 
 common project-config
   default-language: Haskell2010

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints #-}
 
 -- | This module defines core type families which we know to vary from era to

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -19,7 +19,7 @@ source-repository head
   subdir:   libs/cardano-ledger-pretty
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   libs/cardano-ledger-test
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Cardano.Ledger.Generic.Indexed where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -7,8 +7,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Generic.PrettyCore where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Test.Cardano.Ledger.Generic.Scriptic where
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/TestableEra.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/TestableEra.hs
@@ -1,4 +1,6 @@
 -- | Defines the requirements on an era to be testable
+{-# LANGUAGE UndecidableSuperClasses #-}
+
 module Test.Cardano.Ledger.TestableEra where
 
 import Cardano.Ledger.Shelley.API

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/TestableEra.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/TestableEra.hs
@@ -1,6 +1,6 @@
--- | Defines the requirements on an era to be testable
 {-# LANGUAGE UndecidableSuperClasses #-}
 
+-- | Defines the requirements on an era to be testable
 module Test.Cardano.Ledger.TestableEra where
 
 import Cardano.Ledger.Shelley.API

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -15,7 +15,7 @@ source-repository head
 
 common base
   build-depends:
-    base >= 4.12 && < 4.17
+    base >= 4.12 && < 5
 
 common project-config
   default-language: Haskell2010

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 common project-config
   default-language:   Haskell2010
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
   ghc-options:        -Wall
                       -Wcompat

--- a/libs/non-integral/non-integral.cabal
+++ b/libs/non-integral/non-integral.cabal
@@ -18,7 +18,7 @@ source-repository head
   subdir:   libs/non-integral
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/set-algebra/set-algebra.cabal
+++ b/libs/set-algebra/set-algebra.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   libs/set-algebra
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/small-steps-test/small-steps-test.cabal
+++ b/libs/small-steps-test/small-steps-test.cabal
@@ -17,7 +17,7 @@ source-repository head
   subdir:   libs/small-steps-test
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010

--- a/libs/small-steps/small-steps.cabal
+++ b/libs/small-steps/small-steps.cabal
@@ -22,7 +22,7 @@ flag sts_assert
     manual: True
 
 common base
-  build-depends:      base >= 4.12 && < 4.17
+  build-depends:      base >= 4.12 && < 5
 
 common project-config
   default-language:   Haskell2010


### PR DESCRIPTION
I am getting several errors related to UndecidableSuperClasses when building with GHC 9.4

My suspicion is that this is due to stricter class recursion checking rules in GHC 9.4 when type families are involved

I can get it to compile by enabling the UndecidableSuperClasses language extension

Would you accept this patch or alternative could you suggest a different fix?

Regards
Max