### PR TITLE
Clean hardfork switches

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -165,7 +165,7 @@ collectTwoPhaseScriptInputs ei sysS pp tx utxo =
             (Right [])
   where
     scriptsAvailable = txscripts utxo tx
-    txinfo lang = txInfo pp lang ei sysS utxo tx
+    txinfo lang = txInfo lang ei sysS utxo tx
     AlonzoScriptsNeeded scriptsNeeded' = getScriptsNeeded utxo (tx ^. bodyTxL)
     neededAndConfirmedToBePlutus =
       mapMaybe (knownToNotBe1Phase scriptsAvailable) scriptsNeeded'

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tools.hs
@@ -161,7 +161,7 @@ evaluateTransactionExecutionUnitsWithLogs ::
   Either (TranslationError (EraCrypto era)) (RedeemerReportWithLogs (EraCrypto era))
 evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels = do
   let getInfo :: Language -> Either (TranslationError (EraCrypto era)) VersionedTxInfo
-      getInfo lang = txInfo pp lang ei sysS utxo tx
+      getInfo lang = txInfo lang ei sysS utxo tx
   ctx <- sequence $ Map.fromSet getInfo languagesUsed
   pure $
     Map.mapWithKey

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -109,7 +109,6 @@ test-suite cardano-ledger-alonzo-test
     cardano-protocol-tpraos,
     cardano-slotting,
     containers,
-    data-default-class,
     plutus-ledger-api:{plutus-ledger-api,plutus-ledger-api-testlib} ^>=1.1,
     QuickCheck,
     small-steps,

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -20,7 +20,6 @@ import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
-import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -88,7 +87,7 @@ silentlyIgnore tx =
     Right _ -> pure ()
     Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
   where
-    ctx = txInfo def PlutusV1 ei ss utxo tx
+    ctx = txInfo PlutusV1 ei ss utxo tx
 
 expectTranslationError :: Language -> Tx Alonzo -> TranslationError StandardCrypto -> Assertion
 expectTranslationError lang tx expected =
@@ -96,7 +95,7 @@ expectTranslationError lang tx expected =
     Right _ -> error "This translation was expected to fail, but it succeeded."
     Left e -> e @?= expected
   where
-    ctx = txInfo def lang ei ss utxo tx
+    ctx = txInfo lang ei ss utxo tx
 
 txInfoTests :: TestTree
 txInfoTests =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -359,7 +359,7 @@ utxoTransition = do
   ei <- liftSTS $ asks epochInfo
 
   {- epochInfoSlotToUTCTime epochInfo systemTime i_f ≠ ◇ -}
-  runTest $ validateOutsideForecast pp ei slot sysSt tx
+  runTest $ validateOutsideForecast ei slot sysSt tx
 
   {-   txins txb ≠ ∅   -}
   runTestOnSignal $ Shelley.validateInputSetEmptyUTxO txBody

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -165,15 +165,14 @@ babbageTxInfo ::
     Value era ~ MaryValue (EraCrypto era),
     TxWits era ~ AlonzoTxWits era
   ) =>
-  PParams era ->
   Language ->
   EpochInfo (Either Text) ->
   SystemStart ->
   UTxO era ->
   Tx era ->
   Either (TranslationError (EraCrypto era)) VersionedTxInfo
-babbageTxInfo pp lang ei sysS utxo tx = do
-  timeRange <- left TimeTranslationPastHorizon $ Alonzo.transVITime pp ei sysS interval
+babbageTxInfo lang ei sysS utxo tx = do
+  timeRange <- left TimeTranslationPastHorizon $ Alonzo.transVITime ei sysS interval
   case lang of
     PlutusV1 -> do
       let refInputs = txBody ^. referenceInputsTxBodyL

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -90,7 +90,6 @@ test-suite cardano-ledger-babbage-test
     cardano-protocol-tpraos,
     cardano-slotting,
     containers,
-    data-default-class,
     plutus-ledger-api,
     cardano-strict-containers,
     tasty,

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -29,7 +29,6 @@ import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
-import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -149,7 +148,7 @@ successfulTranslation lang tx f =
     Right info -> assertBool "unexpected transaction info" (f info)
     Left e -> assertFailure $ "no translation error was expected, but got: " <> show e
   where
-    ctx = txInfo def lang ei ss utxo tx
+    ctx = txInfo lang ei ss utxo tx
 
 successfulV2Translation :: AlonzoTx Babbage -> (VersionedTxInfo -> Bool) -> Assertion
 successfulV2Translation = successfulTranslation PlutusV2
@@ -160,7 +159,7 @@ expectTranslationError lang tx expected =
     Right _ -> assertFailure "This translation was expected to fail, but it succeeded."
     Left e -> e @?= expected
   where
-    ctx = txInfo def lang ei ss utxo tx
+    ctx = txInfo lang ei ss utxo tx
 
 expectV1TranslationError :: AlonzoTx Babbage -> TranslationError StandardCrypto -> Assertion
 expectV1TranslationError = expectTranslationError PlutusV1

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -7,7 +7,6 @@ module Cardano.Ledger.Shelley.HardForks
     allowMIRTransfer,
     validatePoolRewardAccountNetID,
     allowScriptStakeCredsToEarnRewards,
-    translateTimeForPlutusScripts,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
     allowOutsideForecastTTL,
@@ -51,14 +50,6 @@ allowScriptStakeCredsToEarnRewards ::
   pp ->
   Bool
 allowScriptStakeCredsToEarnRewards pp = pvMajor (getField @"_protocolVersion" pp) > natVersion @4
-
--- | Starting with protocol version 6, we translate slots to time correctly for
--- Plutus scripts.
-translateTimeForPlutusScripts ::
-  (HasField "_protocolVersion" pp ProtVer) =>
-  pp ->
-  Bool
-translateTimeForPlutusScripts pp = pvMajor (getField @"_protocolVersion" pp) > natVersion @5
 
 -- | Starting with protocol version 7, the UTXO rule predicate failure
 -- MissingScriptWitnessesUTXOW will not be used for extraneous scripts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Shelley.HardForks
   ( aggregatedRewards,
     allowMIRTransfer,
     validatePoolRewardAccountNetID,
-    allowScriptStakeCredsToEarnRewards,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
     allowOutsideForecastTTL,
@@ -42,14 +41,6 @@ validatePoolRewardAccountNetID ::
   pp ->
   Bool
 validatePoolRewardAccountNetID pp = pvMajor (getField @"_protocolVersion" pp) > natVersion @4
-
--- | Starting with protocol version 5, Stake Credentials bound by scripts
--- will be eligibile for staking rewards.
-allowScriptStakeCredsToEarnRewards ::
-  (HasField "_protocolVersion" pp ProtVer) =>
-  pp ->
-  Bool
-allowScriptStakeCredsToEarnRewards pp = pvMajor (getField @"_protocolVersion" pp) > natVersion @4
 
 -- | Starting with protocol version 7, the UTXO rule predicate failure
 -- MissingScriptWitnessesUTXOW will not be used for extraneous scripts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -8,7 +8,6 @@ module Cardano.Ledger.Shelley.HardForks
     validatePoolRewardAccountNetID,
     missingScriptsSymmetricDifference,
     forgoRewardPrefilter,
-    allowOutsideForecastTTL,
   )
 where
 
@@ -58,13 +57,3 @@ forgoRewardPrefilter ::
   pp ->
   Bool
 forgoRewardPrefilter pp = pvMajor (getField @"_protocolVersion" pp) > natVersion @6
-
--- | In versions 5 and 6, we allow the ttl field to lie outside the stability
--- window.
-allowOutsideForecastTTL ::
-  (HasField "_protocolVersion" pp ProtVer) =>
-  pp ->
-  Bool
-allowOutsideForecastTTL pp =
-  let mv = pvMajor (getField @"_protocolVersion" pp)
-   in mv == natVersion @5 || mv == natVersion @6

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
@@ -220,14 +220,12 @@ instance CC.Crypto c => FromCBOR (PoolRewardInfo c) where
       )
 
 notPoolOwner ::
-  HasField "_protocolVersion" pp ProtVer =>
-  pp ->
   PoolParams c ->
   Credential 'Staking c ->
   Bool
-notPoolOwner pp pps = \case
+notPoolOwner pps = \case
   KeyHashObj hk -> hk `Set.notMember` ppOwners pps
-  ScriptHashObj _ -> HardForks.allowScriptStakeCredsToEarnRewards pp
+  ScriptHashObj _ -> True
 
 -- | The stake pool member reward calculation
 rewardOnePoolMember ::
@@ -257,7 +255,7 @@ rewardOnePoolMember
   rewardInfo
   hk
   (Coin c) =
-    if prefilter && notPoolOwner pp (poolPs rewardInfo) hk && r /= Coin 0
+    if prefilter && notPoolOwner (poolPs rewardInfo) hk && r /= Coin 0
       then Just r
       else Nothing
     where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -438,7 +438,7 @@ rewardOnePool
               notPoolOwner hk
           ]
       notPoolOwner (KeyHashObj hk) = hk `Set.notMember` ppOwners pool
-      notPoolOwner (ScriptHashObj _) = HardForks.allowScriptStakeCredsToEarnRewards pp
+      notPoolOwner (ScriptHashObj _) = True
       lReward =
         leaderRew
           poolR

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -103,7 +103,6 @@ collectTwoPhaseScriptInputsOutputOrdering =
         ( fromRight (error "translation error") $
             getTxInfo
               apf
-              (pp apf)
               PlutusV1
               testEpochInfo
               testSystemStart
@@ -178,7 +177,6 @@ collectInputs x = error ("collectInputs Not defined in era " ++ show x)
 
 getTxInfo ::
   Proof era ->
-  PParams era ->
   Language ->
   EpochInfo (Either Text) ->
   SystemStart ->


### PR DESCRIPTION
Closes: https://github.com/input-output-hk/cardano-ledger/issues/3104

Answers the question: which HardFork switches can we remove from the code without affecting the state

How I checked:

1. Checked out cardano-node (tag 1.35.3) and synced up with mainnet until slot 76138419 (the tip at the time)
2. Checked out db-analyser (part of ouroboros-network), at branch release/cardano-node-1.35.x 
2. Took snapshots of the ledger state, using db-analyser, corresponding to the first slots of each era
3. For each tested switch:
	- set the switch to True in cardano-ledger in a branch off tag node/1.35.3
	- run db-analyzer pointing to the aforementioned cardano-ledger branch:
		- analyzing from a slot that is not affected by the switch (earlier than the protocol version from the condition)
		- taking a snapshot of the ledger state for slots corresponding to the snapshots taken at step 2
	- this db-analyzer had two possible outcomes: an error or a snapshot. The error is an indication that the switch cannot be removed. In case there was no error, the sha256 sum of the produced snapshot was compared with that of the corresponding snapshot produced at step 2 (using the code with the HardFork switch intact)


### 1. allowMIRTransfer pp = pvMajor (getField @"_protocolVersion" pp) > 4  :negative_squared_cross_mark: 

Ran: 
```
cabal run ouroboros-consensus-cardano-tools:db-analyser2 -- --db /home/teodora/cardano-mainnet/db/db-mainnet --only-immutable-db --analyse-from 23068800 --store-ledger 39916975  cardano --config /home/teodora/cardano-mainnet/config.json
```
because 23068800 is the first slot in Mary (version 4) and 39916975 is the first slot in the next era

This resulted in an error:  `ExtValidationErrorLedger (HardForkLedgerErrorFromEra S (S (S (Z (WrapLedgerErr {unwrapLedgerErr = BBodyError (BlockTransitionError [LedgersFailure (LedgerFailure (DelegsFailure (WithdrawalsNotInRewardsDELEGS (fromList [(RewardAcnt {getRwdNetwork = Mainnet, getRwdCred = KeyHashObj (KeyHash "7f5287ac749c44f8b517165a35ea60a0a165904b25da29749d2366e4")},Coin 220383)]))))])})))))`

So I concluded it can't be removed. 

--------------------------------------------------------

### 2. aggregatedRewards pp = pvMajor (getField @"_protocolVersion" pp) > 2 :negative_squared_cross_mark: 

set to True, trying to take a snapshot from 4492800 (first Shelley slot(v2)) to 16588800 (first Allegra slot (v3)) resulted in: 
` ExtValidationErrorLedger (HardForkLedgerErrorFromEra S (Z (WrapLedgerErr {unwrapLedgerErr = BBodyError (BlockTransitionError [LedgersFailure (LedgerFailure (DelegsFailure (WithdrawalsNotInRewardsDELEGS (fromList [(RewardAcnt {getRwdNetwork = Mainnet, getRwdCred = KeyHashObj (KeyHash "24f1b3791037e55363815fc4b788b886cd1d82a2f2d39e17196cd1a4")},Coin 431236474)]))))])})))`

--------------------------------------------------------

### 3. validatePoolRewardAccountNetID pp = pvMajor (getField @"_protocolVersion" pp) > 4  :negative_squared_cross_mark: 
set to True, trying to take a snapshot from 23068800 (first Mary slot(v2)) to 39916975 (first Alonzo slot (v3)) resulted in: `ExtValidationErrorLedger (HardForkLedgerErrorFromEra S (S (S (Z (WrapLedgerErr {unwrapLedgerErr = BBodyError (BlockTransitionError [LedgersFailure (LedgerFailure (DelegsFailure (DelplFailure (PoolFailure (WrongNetworkPOOL Mainnet Testnet (KeyHash "ae8ee8f5676a3c3aadefd0ee7adb57ebbd39dd7126c8517e718dc4c1"))))))])})))))`

--------------------------------------------------------

### 4. forgoRewardPrefilter pp = pvMajor (getField @"_protocolVersion" pp) > 6 :negative_squared_cross_mark: 
  
set to True, trying to take a snapshot from 43372972 (v6) to 76138419 resulted in:  `ExtValidationErrorLedger (HardForkLedgerErrorFromEra S (S (S (S (Z (WrapLedgerErr {unwrapLedgerErr = BBodyError (BlockTransitionError [ShelleyInAlonzoPredFail (LedgersFailure (LedgerFailure (DelegsFailure (DelplFailure (DelegFailure (StakeKeyNonZeroAccountBalanceDELEG (Just (Coin 658031))))))))])}))))))`

--------------------------------------------------------
### 5. translateTimeForPlutusScripts pp = pvMajor (getField @"_protocolVersion" pp) > 5  :heavy_check_mark: 
set to True, a snapshot of 76138419 (latest slot that I had synced with mainnet) was generated with the same sha256 of the snapshot taken with the switch enabled (9aafb9e44500f84d2a59dfd8019934dd42a947edf976c35d90fa6bb4136604dd  ) 

--------------------------------------------------------
### 6. allowScriptStakeCredsToEarnRewards pp = pvMajor (getField @"_protocolVersion" pp) > 4 :heavy_check_mark: 
set to True, a snapshot of 76138419 with the original sha256 is generated

--------------------------------------------------------
### 7. allowOutsideForecastTTL pp =let mv = pvMajor (getField @"_protocolVersion" pp) in mv == 5 || mv == 6 :heavy_check_mark: 
set to True, a snapshot  of 76138419 with the original sha256 is generated

--------------------------------------------------------
### 8. missingScriptsSymmetricDifference  :grey_question: 
I forgot why we can't switch this off even if the state is the same

	