### PR TITLE
Add translation context to translate from Byron to Shelley

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,6 @@ in the naming of release branches.
 - `MAClass` is gone: #3175
 - `ShelleyMAEra` type in favor of `AllegraEra` and `MaryEra`: #3175
 - `MATxBody` type in favor of `AllegraTxBody` and `MaryTxBody`: #3175
-- Removed the `TranslateEra` instances for `ShelleyGenesis`: #3164
 - Deprecated `Cardano.Ledger.Serialization` in favor of `Cardano.Ledger.Binary` from
   `cardano-ledger-binary`: #3138
 - Removed `Data.Coders` from `cardano-data` in favor of `Cardano.Ledger.Binary.Coders` from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ in the naming of release branches.
   - Renamed `AlonzoTxAuxData.txMD` to `AlonzoTxAuxData.atadMetadata`:
   - Removed `AlonzoTxAuxData.scripts` in favor of two new fields `atadTimelock` and
     `atadPlutus`. This was needed due to #3166
+- Changed instance for `TranslationContext (ShelleyEra c)` to a data type that can be used to
+  translate from Byron to Shelley: #3164
 - Changed major version in `ProtVer` to use new type `Version` instead of `Natural`: #3138
 - Renamed records fields in `Cardano.Ledger` to names without `_` (underscores) #3126
   - `Alonzo.TxBody.AlonzoTxBody` pattern synonym
@@ -248,6 +250,7 @@ in the naming of release branches.
 - `MAClass` is gone: #3175
 - `ShelleyMAEra` type in favor of `AllegraEra` and `MaryEra`: #3175
 - `MATxBody` type in favor of `AllegraTxBody` and `MaryTxBody`: #3175
+- Removed the `TranslateEra` instances for `ShelleyGenesis`: #3164
 - Deprecated `Cardano.Ledger.Serialization` in favor of `Cardano.Ledger.Binary` from
   `cardano-ledger-binary`: #3138
 - Removed `Data.Coders` from `cardano-data` in favor of `Cardano.Ledger.Binary.Coders` from

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -61,6 +61,7 @@ library
     Cardano.Ledger.Shelley.SoftForks
     Cardano.Ledger.Shelley.StabilityWindow
     Cardano.Ledger.Shelley.Rules
+    Cardano.Ledger.Shelley.Translation
     Cardano.Ledger.Shelley.Tx
     Cardano.Ledger.Shelley.TxAuxData
     Cardano.Ledger.Shelley.TxBody

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API.Types
 import Cardano.Ledger.Shelley.Rules ()
+import Cardano.Ledger.Shelley.Translation (FromByronTranslationContext (..))
 import Cardano.Ledger.Slot
 import Cardano.Ledger.UTxO (coinBalance)
 import Cardano.Ledger.Val ((<->))
@@ -91,11 +92,11 @@ translateUTxOByronToShelley (Byron.UTxO utxoByron) =
 translateToShelleyLedgerState ::
   forall c.
   (Crypto c, ADDRHASH c ~ Crypto.Blake2b_224) =>
-  ShelleyGenesis c ->
+  FromByronTranslationContext (ShelleyEra c) ->
   EpochNo ->
   Byron.ChainValidationState ->
   NewEpochState (ShelleyEra c)
-translateToShelleyLedgerState genesisShelley epochNo cvs =
+translateToShelleyLedgerState transCtxt epochNo cvs =
   NewEpochState
     { nesEL = epochNo
     , nesBprev = BlocksMade Map.empty
@@ -114,7 +115,7 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
     }
   where
     pparams :: ShelleyPParams (ShelleyEra c)
-    pparams = sgProtocolParams genesisShelley
+    pparams = fbtcProtocolParams transCtxt
 
     -- NOTE: we ignore the Byron delegation map because the genesis and
     -- delegation verification keys are hashed using a different hashing
@@ -127,11 +128,11 @@ translateToShelleyLedgerState genesisShelley epochNo cvs =
     -- Shelley genesis contains the same genesis and delegation verification
     -- keys, but hashed with the right algorithm.
     genDelegs :: GenDelegs c
-    genDelegs = GenDelegs $ sgGenDelegs genesisShelley
+    genDelegs = GenDelegs $ fbtcGenDelegs transCtxt
 
     reserves :: Coin
     reserves =
-      word64ToCoin (sgMaxLovelaceSupply genesisShelley) <-> coinBalance utxoShelley
+      word64ToCoin (fbtcMaxLovelaceSupply transCtxt) <-> coinBalance utxoShelley
 
     epochState :: EpochState (ShelleyEra c)
     epochState =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -92,7 +92,7 @@ translateUTxOByronToShelley (Byron.UTxO utxoByron) =
 translateToShelleyLedgerState ::
   forall c.
   (Crypto c, ADDRHASH c ~ Crypto.Blake2b_224) =>
-  FromByronTranslationContext (ShelleyEra c) ->
+  FromByronTranslationContext c ->
   EpochNo ->
   Byron.ChainValidationState ->
   NewEpochState (ShelleyEra c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Shelley.Era (
 where
 
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Core (Era (..), EraRule, TranslationContext, Value)
+import Cardano.Ledger.Core (Era (..), EraRule, Value)
 import Cardano.Ledger.Crypto as CC (Crypto)
 
 data ShelleyEra c
@@ -37,8 +37,6 @@ instance CC.Crypto c => Era (ShelleyEra c) where
   type ProtVerLow (ShelleyEra c) = 2
 
 type instance Value (ShelleyEra _c) = Coin
-
-type instance TranslationContext (ShelleyEra c) = ()
 
 data ShelleyBBODY era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -16,25 +16,26 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Shelley.Genesis (
-  ShelleyGenesisStaking (..),
-  ShelleyGenesis (..),
-  ValidationErr (..),
-  NominalDiffTimeMicro (..),
-  emptyGenesisStaking,
-  sgActiveSlotCoeff,
-  genesisUTxO,
-  initialFundsPseudoTxIn,
-  validateGenesis,
-  describeValidationErr,
-  mkShelleyGlobals,
-  nominalDiffTimeMicroToMicroseconds,
-  nominalDiffTimeMicroToSeconds,
-  toNominalDiffTimeMicro,
-  toNominalDiffTimeMicroWithRounding,
-  fromNominalDiffTimeMicro,
-  secondsToNominalDiffTimeMicro,
-)
+module Cardano.Ledger.Shelley.Genesis
+  ( ShelleyGenesisStaking (..),
+    ShelleyGenesis (..),
+    ValidationErr (..),
+    NominalDiffTimeMicro (..),
+    emptyGenesisStaking,
+    sgActiveSlotCoeff,
+    genesisUTxO,
+    initialFundsPseudoTxIn,
+    validateGenesis,
+    describeValidationErr,
+    mkShelleyGlobals,
+    nominalDiffTimeMicroToMicroseconds,
+    nominalDiffTimeMicroToSeconds,
+    toNominalDiffTimeMicro,
+    toNominalDiffTimeMicroWithRounding,
+    fromNominalDiffTimeMicro,
+    secondsToNominalDiffTimeMicro,
+    translateShelleyGenesis,
+  )
 where
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -210,7 +211,54 @@ data ShelleyGenesis c = ShelleyGenesis
 
 deriving instance Crypto c => NoThunks (ShelleyGenesis c)
 
-sgActiveSlotCoeff :: ShelleyGenesis c -> ActiveSlotCoeff
+-- | Although there could be (and was) a `TranslateEra` instance for ShelleyGenesis, it is morally
+-- more correct to have a separate function fulfill that task. The reason is that conceptually there
+-- is no need to translate ShelleyGenesis values when moving to the next era. A `TranslateEra`
+-- instance would be a convenience that is ultimately more confusing.
+translateShelleyGenesis ::
+  CC.Crypto era1 ~ CC.Crypto era2 => ShelleyGenesis era1 -> ShelleyGenesis era2
+translateShelleyGenesis genesis =
+  ShelleyGenesis
+    { sgSystemStart = sgSystemStart genesis,
+      sgNetworkMagic = sgNetworkMagic genesis,
+      sgNetworkId = sgNetworkId genesis,
+      sgActiveSlotsCoeff = sgActiveSlotsCoeff genesis,
+      sgSecurityParam = sgSecurityParam genesis,
+      sgEpochLength = sgEpochLength genesis,
+      sgSlotsPerKESPeriod = sgSlotsPerKESPeriod genesis,
+      sgMaxKESEvolutions = sgMaxKESEvolutions genesis,
+      sgSlotLength = sgSlotLength genesis,
+      sgUpdateQuorum = sgUpdateQuorum genesis,
+      sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis,
+      sgProtocolParams = translatePParams $ sgProtocolParams genesis,
+      sgGenDelegs = sgGenDelegs genesis,
+      sgInitialFunds = sgInitialFunds genesis,
+      sgStaking = sgStaking genesis
+    }
+  where
+    translatePParams :: ShelleyPParams era1 -> ShelleyPParams era2
+    translatePParams pp =
+      ShelleyPParams
+        { _minfeeA = _minfeeA pp,
+          _minfeeB = _minfeeB pp,
+          _maxBBSize = _maxBBSize pp,
+          _maxTxSize = _maxTxSize pp,
+          _maxBHSize = _maxBHSize pp,
+          _keyDeposit = _keyDeposit pp,
+          _poolDeposit = _poolDeposit pp,
+          _eMax = _eMax pp,
+          _nOpt = _nOpt pp,
+          _a0 = _a0 pp,
+          _rho = _rho pp,
+          _tau = _tau pp,
+          _d = _d pp,
+          _extraEntropy = _extraEntropy pp,
+          _protocolVersion = _protocolVersion pp,
+          _minUTxOValue = _minUTxOValue pp,
+          _minPoolCost = _minPoolCost pp
+        }
+
+sgActiveSlotCoeff :: ShelleyGenesis era -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff
 
 instance Crypto c => ToJSON (ShelleyGenesis c) where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -210,7 +210,6 @@ data ShelleyGenesis c = ShelleyGenesis
 
 deriving instance Crypto c => NoThunks (ShelleyGenesis c)
 
-
 sgActiveSlotCoeff :: ShelleyGenesis c -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -34,7 +34,6 @@ module Cardano.Ledger.Shelley.Genesis (
   toNominalDiffTimeMicroWithRounding,
   fromNominalDiffTimeMicro,
   secondsToNominalDiffTimeMicro,
-  translateShelleyGenesis,
 )
 where
 
@@ -71,7 +70,6 @@ import Cardano.Ledger.Crypto (Crypto, HASH, KES)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.StabilityWindow
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
@@ -212,53 +210,8 @@ data ShelleyGenesis c = ShelleyGenesis
 
 deriving instance Crypto c => NoThunks (ShelleyGenesis c)
 
--- | Although there could be (and was) a `TranslateEra` instance for ShelleyGenesis, it is morally
--- more correct to have a separate function fulfill that task. The reason is that conceptually there
--- is no need to translate ShelleyGenesis values when moving to the next era. A `TranslateEraaskell
--- instance would be a convenience that is ultimately more confusing.
-translateShelleyGenesis ::
-  Crypto era1 ~ Crypto era2 => ShelleyGenesis era1 -> ShelleyGenesis era2
-translateShelleyGenesis genesis =
-  ShelleyGenesis
-    { sgSystemStart = sgSystemStart genesis
-    , sgNetworkMagic = sgNetworkMagic genesis
-    , sgNetworkId = sgNetworkId genesis
-    , sgActiveSlotsCoeff = sgActiveSlotsCoeff genesis
-    , sgSecurityParam = sgSecurityParam genesis
-    , sgEpochLength = sgEpochLength genesis
-    , sgSlotsPerKESPeriod = sgSlotsPerKESPeriod genesis
-    , sgMaxKESEvolutions = sgMaxKESEvolutions genesis
-    , sgSlotLength = sgSlotLength genesis
-    , sgUpdateQuorum = sgUpdateQuorum genesis
-    , sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis
-    , sgProtocolParams = translatePParams $ sgProtocolParams genesis
-    , sgGenDelegs = sgGenDelegs genesis
-    , sgInitialFunds = sgInitialFunds genesis
-    , sgStaking = sgStaking genesis
-    }
-  where
-    translatePParams pp =
-      ShelleyPParams
-        { _minfeeA = _minfeeA pp
-        , _minfeeB = _minfeeB pp
-        , _maxBBSize = _maxBBSize pp
-        , _maxTxSize = _maxTxSize pp
-        , _maxBHSize = _maxBHSize pp
-        , _keyDeposit = _keyDeposit pp
-        , _poolDeposit = _poolDeposit pp
-        , _eMax = _eMax pp
-        , _nOpt = _nOpt pp
-        , _a0 = _a0 pp
-        , _rho = _rho pp
-        , _tau = _tau pp
-        , _d = _d pp
-        , _extraEntropy = _extraEntropy pp
-        , _protocolVersion = _protocolVersion pp
-        , _minUTxOValue = _minUTxOValue pp
-        , _minPoolCost = _minPoolCost pp
-        }
 
-sgActiveSlotCoeff :: ShelleyGenesis era -> ActiveSlotCoeff
+sgActiveSlotCoeff :: ShelleyGenesis c -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff
 
 instance Crypto c => ToJSON (ShelleyGenesis c) where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -71,6 +71,7 @@ import Cardano.Ledger.Crypto (Crypto, HASH, KES)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.StabilityWindow
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
@@ -213,10 +214,10 @@ deriving instance Crypto c => NoThunks (ShelleyGenesis c)
 
 -- | Although there could be (and was) a `TranslateEra` instance for ShelleyGenesis, it is morally
 -- more correct to have a separate function fulfill that task. The reason is that conceptually there
--- is no need to translate ShelleyGenesis values when moving to the next era. A `TranslateEra`
+-- is no need to translate ShelleyGenesis values when moving to the next era. A `TranslateEraaskell
 -- instance would be a convenience that is ultimately more confusing.
 translateShelleyGenesis ::
-  CC.Crypto era1 ~ CC.Crypto era2 => ShelleyGenesis era1 -> ShelleyGenesis era2
+  Crypto era1 ~ Crypto era2 => ShelleyGenesis era1 -> ShelleyGenesis era2
 translateShelleyGenesis genesis =
   ShelleyGenesis
     { sgSystemStart = sgSystemStart genesis,
@@ -236,7 +237,6 @@ translateShelleyGenesis genesis =
       sgStaking = sgStaking genesis
     }
   where
-    translatePParams :: ShelleyPParams era1 -> ShelleyPParams era2
     translatePParams pp =
       ShelleyPParams
         { _minfeeA = _minfeeA pp,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -16,26 +16,26 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Shelley.Genesis
-  ( ShelleyGenesisStaking (..),
-    ShelleyGenesis (..),
-    ValidationErr (..),
-    NominalDiffTimeMicro (..),
-    emptyGenesisStaking,
-    sgActiveSlotCoeff,
-    genesisUTxO,
-    initialFundsPseudoTxIn,
-    validateGenesis,
-    describeValidationErr,
-    mkShelleyGlobals,
-    nominalDiffTimeMicroToMicroseconds,
-    nominalDiffTimeMicroToSeconds,
-    toNominalDiffTimeMicro,
-    toNominalDiffTimeMicroWithRounding,
-    fromNominalDiffTimeMicro,
-    secondsToNominalDiffTimeMicro,
-    translateShelleyGenesis,
-  )
+module Cardano.Ledger.Shelley.Genesis (
+  ShelleyGenesisStaking (..),
+  ShelleyGenesis (..),
+  ValidationErr (..),
+  NominalDiffTimeMicro (..),
+  emptyGenesisStaking,
+  sgActiveSlotCoeff,
+  genesisUTxO,
+  initialFundsPseudoTxIn,
+  validateGenesis,
+  describeValidationErr,
+  mkShelleyGlobals,
+  nominalDiffTimeMicroToMicroseconds,
+  nominalDiffTimeMicroToSeconds,
+  toNominalDiffTimeMicro,
+  toNominalDiffTimeMicroWithRounding,
+  fromNominalDiffTimeMicro,
+  secondsToNominalDiffTimeMicro,
+  translateShelleyGenesis,
+)
 where
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -220,42 +220,42 @@ translateShelleyGenesis ::
   Crypto era1 ~ Crypto era2 => ShelleyGenesis era1 -> ShelleyGenesis era2
 translateShelleyGenesis genesis =
   ShelleyGenesis
-    { sgSystemStart = sgSystemStart genesis,
-      sgNetworkMagic = sgNetworkMagic genesis,
-      sgNetworkId = sgNetworkId genesis,
-      sgActiveSlotsCoeff = sgActiveSlotsCoeff genesis,
-      sgSecurityParam = sgSecurityParam genesis,
-      sgEpochLength = sgEpochLength genesis,
-      sgSlotsPerKESPeriod = sgSlotsPerKESPeriod genesis,
-      sgMaxKESEvolutions = sgMaxKESEvolutions genesis,
-      sgSlotLength = sgSlotLength genesis,
-      sgUpdateQuorum = sgUpdateQuorum genesis,
-      sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis,
-      sgProtocolParams = translatePParams $ sgProtocolParams genesis,
-      sgGenDelegs = sgGenDelegs genesis,
-      sgInitialFunds = sgInitialFunds genesis,
-      sgStaking = sgStaking genesis
+    { sgSystemStart = sgSystemStart genesis
+    , sgNetworkMagic = sgNetworkMagic genesis
+    , sgNetworkId = sgNetworkId genesis
+    , sgActiveSlotsCoeff = sgActiveSlotsCoeff genesis
+    , sgSecurityParam = sgSecurityParam genesis
+    , sgEpochLength = sgEpochLength genesis
+    , sgSlotsPerKESPeriod = sgSlotsPerKESPeriod genesis
+    , sgMaxKESEvolutions = sgMaxKESEvolutions genesis
+    , sgSlotLength = sgSlotLength genesis
+    , sgUpdateQuorum = sgUpdateQuorum genesis
+    , sgMaxLovelaceSupply = sgMaxLovelaceSupply genesis
+    , sgProtocolParams = translatePParams $ sgProtocolParams genesis
+    , sgGenDelegs = sgGenDelegs genesis
+    , sgInitialFunds = sgInitialFunds genesis
+    , sgStaking = sgStaking genesis
     }
   where
     translatePParams pp =
       ShelleyPParams
-        { _minfeeA = _minfeeA pp,
-          _minfeeB = _minfeeB pp,
-          _maxBBSize = _maxBBSize pp,
-          _maxTxSize = _maxTxSize pp,
-          _maxBHSize = _maxBHSize pp,
-          _keyDeposit = _keyDeposit pp,
-          _poolDeposit = _poolDeposit pp,
-          _eMax = _eMax pp,
-          _nOpt = _nOpt pp,
-          _a0 = _a0 pp,
-          _rho = _rho pp,
-          _tau = _tau pp,
-          _d = _d pp,
-          _extraEntropy = _extraEntropy pp,
-          _protocolVersion = _protocolVersion pp,
-          _minUTxOValue = _minUTxOValue pp,
-          _minPoolCost = _minPoolCost pp
+        { _minfeeA = _minfeeA pp
+        , _minfeeB = _minfeeB pp
+        , _maxBBSize = _maxBBSize pp
+        , _maxTxSize = _maxTxSize pp
+        , _maxBHSize = _maxBHSize pp
+        , _keyDeposit = _keyDeposit pp
+        , _poolDeposit = _poolDeposit pp
+        , _eMax = _eMax pp
+        , _nOpt = _nOpt pp
+        , _a0 = _a0 pp
+        , _rho = _rho pp
+        , _tau = _tau pp
+        , _d = _d pp
+        , _extraEntropy = _extraEntropy pp
+        , _protocolVersion = _protocolVersion pp
+        , _minUTxOValue = _minUTxOValue pp
+        , _minPoolCost = _minPoolCost pp
         }
 
 sgActiveSlotCoeff :: ShelleyGenesis era -> ActiveSlotCoeff

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Shelley.Translation where
+
+import Cardano.Ledger.Core (Era, EraCrypto, TranslationContext)
+import Cardano.Ledger.Keys
+import Cardano.Ledger.Shelley.Era (ShelleyEra)
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
+import Cardano.Ledger.Shelley.PParams (ShelleyPParams, emptyPParams)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import GHC.Generics (Generic)
+import GHC.Word (Word64)
+import NoThunks.Class (NoThunks (..))
+
+-- | Required data to translate a Byron ledger into a Shelley ledger.
+data FromByronTranslationContext era = FromByronTranslationContext
+  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis (EraCrypto era)) (GenDelegPair (EraCrypto era))),
+    fbtcProtocolParams :: !(ShelleyPParams era),
+    fbtcMaxLovelaceSupply :: !Word64
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Trivial FromByronTranslationContext value, for use in cases where we do not need
+-- to translate from Byron to Shelley.
+emptyFromByronTranslationContext :: FromByronTranslationContext era
+emptyFromByronTranslationContext =
+  FromByronTranslationContext
+    { fbtcGenDelegs = Map.empty,
+      fbtcMaxLovelaceSupply = 0,
+      fbtcProtocolParams = emptyPParams
+    }
+
+toFromByronTranslationContext :: ShelleyGenesis era -> FromByronTranslationContext era
+toFromByronTranslationContext ShelleyGenesis {sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams} =
+  FromByronTranslationContext
+    { fbtcGenDelegs = sgGenDelegs,
+      fbtcProtocolParams = sgProtocolParams,
+      fbtcMaxLovelaceSupply = sgMaxLovelaceSupply
+    }
+
+deriving instance Era era => NoThunks (FromByronTranslationContext era)
+
+type instance TranslationContext (ShelleyEra c) = FromByronTranslationContext (ShelleyEra c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -12,11 +12,12 @@ module Cardano.Ledger.Shelley.Translation (
 )
 where
 
-import Cardano.Ledger.Core (Era, EraCrypto, TranslationContext)
+import Cardano.Ledger.Core (PParams, TranslationContext)
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
-import Cardano.Ledger.Shelley.PParams (ShelleyPParams, emptyPParams)
+import Cardano.Ledger.Shelley.PParams (emptyPParams)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import GHC.Generics (Generic)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.Ledger.Shelley.Translation
-  ( FromByronTranslationContext (..),
-    emptyFromByronTranslationContext,
-    toFromByronTranslationContext,
-  )
+module Cardano.Ledger.Shelley.Translation (
+  FromByronTranslationContext (..),
+  emptyFromByronTranslationContext,
+  toFromByronTranslationContext,
+)
 where
 
 import Cardano.Ledger.Core (Era, EraCrypto, TranslationContext)
@@ -25,9 +25,9 @@ import NoThunks.Class (NoThunks (..))
 
 -- | Required data to translate a Byron ledger into a Shelley ledger.
 data FromByronTranslationContext era = FromByronTranslationContext
-  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis (EraCrypto era)) (GenDelegPair (EraCrypto era))),
-    fbtcProtocolParams :: !(ShelleyPParams era),
-    fbtcMaxLovelaceSupply :: !Word64
+  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis (EraCrypto era)) (GenDelegPair (EraCrypto era)))
+  , fbtcProtocolParams :: !(ShelleyPParams era)
+  , fbtcMaxLovelaceSupply :: !Word64
   }
   deriving (Eq, Show, Generic)
 
@@ -36,20 +36,20 @@ data FromByronTranslationContext era = FromByronTranslationContext
 emptyFromByronTranslationContext :: FromByronTranslationContext era
 emptyFromByronTranslationContext =
   FromByronTranslationContext
-    { fbtcGenDelegs = Map.empty,
-      fbtcMaxLovelaceSupply = 0,
-      fbtcProtocolParams = emptyPParams
+    { fbtcGenDelegs = Map.empty
+    , fbtcMaxLovelaceSupply = 0
+    , fbtcProtocolParams = emptyPParams
     }
 
-toFromByronTranslationContext
-  :: ShelleyEra c ~ era
-  => ShelleyGenesis c
-  -> FromByronTranslationContext era
+toFromByronTranslationContext ::
+  ShelleyEra c ~ era =>
+  ShelleyGenesis c ->
+  FromByronTranslationContext era
 toFromByronTranslationContext ShelleyGenesis {sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams} =
   FromByronTranslationContext
-    { fbtcGenDelegs = sgGenDelegs,
-      fbtcProtocolParams = sgProtocolParams,
-      fbtcMaxLovelaceSupply = sgMaxLovelaceSupply
+    { fbtcGenDelegs = sgGenDelegs
+    , fbtcProtocolParams = sgProtocolParams
+    , fbtcMaxLovelaceSupply = sgMaxLovelaceSupply
     }
 
 deriving instance Era era => NoThunks (FromByronTranslationContext era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -41,7 +41,10 @@ emptyFromByronTranslationContext =
       fbtcProtocolParams = emptyPParams
     }
 
-toFromByronTranslationContext :: ShelleyGenesis era -> FromByronTranslationContext era
+toFromByronTranslationContext
+  :: ShelleyEra c ~ era
+  => ShelleyGenesis c
+  -> FromByronTranslationContext era
 toFromByronTranslationContext ShelleyGenesis {sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams} =
   FromByronTranslationContext
     { fbtcGenDelegs = sgGenDelegs,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -42,9 +42,8 @@ emptyFromByronTranslationContext =
     }
 
 toFromByronTranslationContext ::
-  ShelleyEra c ~ era =>
   ShelleyGenesis c ->
-  FromByronTranslationContext era
+  FromByronTranslationContext c
 toFromByronTranslationContext ShelleyGenesis {sgGenDelegs, sgMaxLovelaceSupply, sgProtocolParams} =
   FromByronTranslationContext
     { fbtcGenDelegs = sgGenDelegs

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -33,7 +33,7 @@ data FromByronTranslationContext c = FromByronTranslationContext
 
 -- | Trivial FromByronTranslationContext value, for use in cases where we do not need
 -- to translate from Byron to Shelley.
-emptyFromByronTranslationContext :: FromByronTranslationContext era
+emptyFromByronTranslationContext :: FromByronTranslationContext c
 emptyFromByronTranslationContext =
   FromByronTranslationContext
     { fbtcGenDelegs = Map.empty

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -8,7 +8,7 @@
 module Cardano.Ledger.Shelley.Translation
   ( FromByronTranslationContext (..),
     emptyFromByronTranslationContext,
-    toFromByronTranslationContext
+    toFromByronTranslationContext,
   )
 where
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -51,6 +51,6 @@ toFromByronTranslationContext ShelleyGenesis {sgGenDelegs, sgMaxLovelaceSupply, 
     , fbtcMaxLovelaceSupply = sgMaxLovelaceSupply
     }
 
-deriving instance Era era => NoThunks (FromByronTranslationContext era)
+deriving instance Crypto c => NoThunks (FromByronTranslationContext c)
 
-type instance TranslationContext (ShelleyEra c) = FromByronTranslationContext (ShelleyEra c)
+type instance TranslationContext (ShelleyEra c) = FromByronTranslationContext c

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -24,9 +24,9 @@ import GHC.Word (Word64)
 import NoThunks.Class (NoThunks (..))
 
 -- | Required data to translate a Byron ledger into a Shelley ledger.
-data FromByronTranslationContext era = FromByronTranslationContext
-  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis (EraCrypto era)) (GenDelegPair (EraCrypto era)))
-  , fbtcProtocolParams :: !(ShelleyPParams era)
+data FromByronTranslationContext c = FromByronTranslationContext
+  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis c) (GenDelegPairc))
+  , fbtcProtocolParams :: !(PParams (ShelleyEra c))
   , fbtcMaxLovelaceSupply :: !Word64
   }
   deriving (Eq, Show, Generic)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -25,7 +25,7 @@ import NoThunks.Class (NoThunks (..))
 
 -- | Required data to translate a Byron ledger into a Shelley ledger.
 data FromByronTranslationContext c = FromByronTranslationContext
-  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis c) (GenDelegPairc))
+  { fbtcGenDelegs :: !(Map (KeyHash 'Genesis c) (GenDelegPair c))
   , fbtcProtocolParams :: !(PParams (ShelleyEra c))
   , fbtcMaxLovelaceSupply :: !Word64
   }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -5,7 +5,12 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.Ledger.Shelley.Translation where
+module Cardano.Ledger.Shelley.Translation
+  ( FromByronTranslationContext (..),
+    emptyFromByronTranslationContext,
+    toFromByronTranslationContext
+  )
+where
 
 import Cardano.Ledger.Core (Era, EraCrypto, TranslationContext)
 import Cardano.Ledger.Keys

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -31,7 +31,6 @@ import Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.Shelley.Rules
 import Cardano.Ledger.Shelley.Translation (emptyFromByronTranslationContext)
 import Cardano.Ledger.Shelley.TxWits
-import Cardano.Ledger.Shelley.UTxO
 import Cardano.Protocol.TPraos.API
 import Cardano.Protocol.TPraos.BHeader
 import Cardano.Protocol.TPraos.OCert

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -29,7 +29,9 @@ import Cardano.Ledger.Shelley.API hiding (KeyPair, vKey)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.Shelley.Translation (emptyFromByronTranslationContext)
 import Cardano.Ledger.Shelley.TxWits
+import Cardano.Ledger.Shelley.UTxO
 import Cardano.Protocol.TPraos.API
 import Cardano.Protocol.TPraos.BHeader
 import Cardano.Protocol.TPraos.OCert
@@ -418,7 +420,7 @@ ledgerExamplesShelley =
     exampleCoin
     exampleTxBodyShelley
     exampleAuxiliaryDataShelley
-    ()
+    emptyFromByronTranslationContext
 
 mkWitnessesPreAlonzo ::
   ( Core.EraTx era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
@@ -54,10 +54,6 @@ import qualified Cardano.Ledger.Shelley.PParams as PParams (Update (..))
 import qualified Cardano.Ledger.Shelley.PParams as ShelleyPP
 import Cardano.Ledger.Shelley.Rules
 import Cardano.Ledger.Shelley.Translation (emptyFromByronTranslationContext)
-import Cardano.Ledger.ShelleyMA (ShelleyMAEra)
-import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData (..))
-import Cardano.Ledger.ShelleyMA.Era (MAClass)
-import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Cardano.Ledger.Val (inject)
 import Cardano.Protocol.TPraos.API

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
@@ -53,6 +53,11 @@ import Cardano.Ledger.Shelley.PParams
 import qualified Cardano.Ledger.Shelley.PParams as PParams (Update (..))
 import qualified Cardano.Ledger.Shelley.PParams as ShelleyPP
 import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.Shelley.Translation (emptyFromByronTranslationContext)
+import Cardano.Ledger.ShelleyMA (ShelleyMAEra)
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (AllegraTxAuxData (..))
+import Cardano.Ledger.ShelleyMA.Era (MAClass)
+import Cardano.Ledger.ShelleyMA.Timelocks (Timelock (..), ValidityInterval (..))
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Cardano.Ledger.Val (inject)
 import Cardano.Protocol.TPraos.API
@@ -916,7 +921,7 @@ ledgerExamplesShelley =
     exampleCoin
     (exampleTxBody (Shelley Standard) (inject (Coin 100000)))
     exampleShelleyTxAuxData
-    ()
+    emptyFromByronTranslationContext
 
 exampleCoin :: Coin
 exampleCoin = Coin 10

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -75,7 +75,6 @@ import Cardano.Ledger.Keys (
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.PoolDistr (PoolDistr (..), individualPoolStake)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
   NewEpochState (..),

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -85,6 +85,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
 import Cardano.Ledger.Shelley.Rules (ShelleyTickfPredFailure)
+import Cardano.Ledger.Shelley.Translation (FromByronTranslationContext (..))
 import Cardano.Ledger.Slot (SlotNo)
 import Cardano.Protocol.TPraos.BHeader (
   BHBody,
@@ -598,14 +599,14 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
 -- way as 'translateToShelleyLedgerState'.
 mkInitialShelleyLedgerView ::
   forall c.
-  ShelleyGenesis c ->
+  FromByronTranslationContext (ShelleyEra c) ->
   LedgerView c
-mkInitialShelleyLedgerView genesisShelley =
-  let !ee = _extraEntropy . sgProtocolParams $ genesisShelley
+mkInitialShelleyLedgerView transCtxt =
+  let !ee = _extraEntropy . fbtcProtocolParams $ transCtxt
    in LedgerView
-        { lvD = _d . sgProtocolParams $ genesisShelley
-        , lvExtraEntropy = ee
-        , lvPoolDistr = PoolDistr Map.empty
-        , lvGenDelegs = GenDelegs $ sgGenDelegs genesisShelley
-        , lvChainChecks = pparamsToChainChecksPParams . sgProtocolParams $ genesisShelley
+        { lvD = _d . fbtcProtocolParams $ transCtxt,
+          lvExtraEntropy = ee,
+          lvPoolDistr = PoolDistr Map.empty,
+          lvGenDelegs = GenDelegs $ fbtcGenDelegs transCtxt,
+          lvChainChecks = pparamsToChainChecksPParams . fbtcProtocolParams $ transCtxt
         }

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -598,7 +598,7 @@ getLeaderSchedule globals ss cds poolHash key pp = Set.filter isLeader epochSlot
 -- way as 'translateToShelleyLedgerState'.
 mkInitialShelleyLedgerView ::
   forall c.
-  FromByronTranslationContext (ShelleyEra c) ->
+  FromByronTranslationContext c ->
   LedgerView c
 mkInitialShelleyLedgerView transCtxt =
   let !ee = _extraEntropy . fbtcProtocolParams $ transCtxt

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -603,9 +603,9 @@ mkInitialShelleyLedgerView ::
 mkInitialShelleyLedgerView transCtxt =
   let !ee = _extraEntropy . fbtcProtocolParams $ transCtxt
    in LedgerView
-        { lvD = _d . fbtcProtocolParams $ transCtxt,
-          lvExtraEntropy = ee,
-          lvPoolDistr = PoolDistr Map.empty,
-          lvGenDelegs = GenDelegs $ fbtcGenDelegs transCtxt,
-          lvChainChecks = pparamsToChainChecksPParams . fbtcProtocolParams $ transCtxt
+        { lvD = _d . fbtcProtocolParams $ transCtxt
+        , lvExtraEntropy = ee
+        , lvPoolDistr = PoolDistr Map.empty
+        , lvGenDelegs = GenDelegs $ fbtcGenDelegs transCtxt
+        , lvChainChecks = pparamsToChainChecksPParams . fbtcProtocolParams $ transCtxt
         }


### PR DESCRIPTION
This PR does two things:

1. It changes the `TranslationContext` for the `ShelleyEra` to allow for translating from Byron into the first Shelley era.
2. ~It removes the `TranslateEra` instances for `ShelleyGenesis`.~ Done in input-output-hk/ouroboros-network#3224 

Closes https://github.com/input-output-hk/ouroboros-consensus/issues/409. In short, it is required for removing the entire `ShelleyGenesis` value from the `ShelleyLedgerConfig` in `ouroboros-consensus`. Closes input-output-hk/ouroboros-consensus#409.

There is a PR in ouroboros-consensus: https://github.com/input-output-hk/ouroboros-network/pull/4091 which require the (backported) changes from this PR.