### PR TITLE
GADT for TransactionScriptFailure and PlutusDebug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ in the naming of release branches.
 
 ### Changed
 
+- Switched `PlutusDebug` to use a `GADT` with `singletons` for better type-safety. #3167
+  - Made `Plutus` imports uniform.
 - Renamed module `Cardano.Ledger.Shelley.Metadata` -> `Cardano.Ledger.Shelley.TxAuxData` #3205
 - Updated `Conway` low protocol version to 9 and `Babbage` high protocol version to 8: #3174
 - Fixed mismathed parenthesis in the `Show` instance for `Ptr`: #3184.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Data.hs
@@ -17,7 +17,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
--- This is needed to make PlutusCore.Data.Data instances
+-- This is needed to make PlutusLedgerApi.V1.Data instances
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Ledger.Alonzo.Data
@@ -113,28 +113,21 @@ import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks)
-import qualified PlutusCore.Data as PCD
+import qualified PlutusLedgerApi.V1 as PV1 -- NOTE PV1.Data === PV2.Data
 
 -- =====================================================================
--- PCD.Data is the type that Plutus expects as data. For both V1 and V2.
+-- PV1.Data is the type that Plutus expects as data. For both V1 and V2.
 -- It is imported from the Plutus package, but it needs a few additional
 -- instances to also work in the ledger.
-
--- instance FromCBOR (Annotator PV1.Data) where -- TODO: Remove this?
---   fromCBOR = pure <$> Cborg.decode
--- instance ToCBOR PV1.Data where
---   toCBOR = Cborg.encode
-
--- TODO: Move to PlutusCore.Data module
-deriving instance NoThunks PCD.Data
+deriving instance NoThunks PV1.Data
 
 -- ============================================================================
 -- the newtype Data is a wrapper around the type that Plutus expects as data.
 -- The newtype will memoize the serialized bytes.
 
--- | This is a wrapper with a phantom era for PCD.Data, since we need
+-- | This is a wrapper with a phantom era for PV1.Data, since we need
 -- something with kind (* -> *) for MemoBytes
-newtype PlutusData era = PlutusData PCD.Data
+newtype PlutusData era = PlutusData PV1.Data
   deriving newtype (Eq, Generic, Show, NFData, NoThunks, Cborg.Serialise)
 
 instance Typeable era => ToCBOR (PlutusData era) where
@@ -161,14 +154,14 @@ instance (EraCrypto era ~ c) => HashAnnotated (Data era) EraIndependentData c wh
 
 instance Typeable era => NoThunks (Data era)
 
-pattern Data :: Era era => PCD.Data -> Data era
+pattern Data :: Era era => PV1.Data -> Data era
 pattern Data p <- (getMemoRawType -> PlutusData p)
   where
     Data p = mkMemoized $ PlutusData p
 
 {-# COMPLETE Data #-}
 
-getPlutusData :: Data era -> PCD.Data
+getPlutusData :: Data era -> PV1.Data
 getPlutusData (getMemoRawType -> PlutusData d) = d
 
 -- | Inlined data must be stored in the most compact form because it contributes

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -47,7 +47,7 @@ import Cardano.Ledger.Alonzo.TxBody
   )
 import Cardano.Ledger.Alonzo.TxInfo
   ( ExtendedUTxO (..),
-    PlutusDebug,
+    PlutusDebug (..),
     ScriptFailure (..),
     ScriptResult (..),
   )

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -102,8 +102,7 @@ import Data.Set as Set
 import GHC.Records (HasField (..))
 import Lens.Micro
 import Numeric.Natural (Natural)
-import qualified PlutusCore.Data as PCD
-import qualified PlutusLedgerApi.V1 as PV1 (ParamName)
+import qualified PlutusLedgerApi.V1 as PV1 (Data, ParamName)
 import qualified PlutusLedgerApi.V2 as PV2 (ParamName)
 import PlutusPrelude (enumerate)
 import qualified PlutusTx as P (Data (..))
@@ -222,7 +221,7 @@ freeCostModel lang =
 genPair :: Gen a -> Gen b -> Gen (a, b)
 genPair x y = (,) <$> x <*> y
 
-genPlutusData :: Gen PCD.Data
+genPlutusData :: Gen PV1.Data
 genPlutusData = resize 5 (sized gendata)
   where
     gendata n
@@ -503,7 +502,7 @@ addRedeemMap ::
   forall c.
   Crypto c =>
   TxBody (AlonzoEra c) ->
-  (PCD.Data, Natural, Natural) ->
+  (PV1.Data, Natural, Natural) ->
   ScriptPurpose c ->
   Map RdmrPtr (Data (AlonzoEra c), ExUnits) ->
   Map RdmrPtr (Data (AlonzoEra c), ExUnits)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -102,6 +102,7 @@ import Data.Set as Set
 import GHC.Records (HasField (..))
 import Lens.Micro
 import Numeric.Natural (Natural)
+import qualified PlutusCore.Data as PCD
 import qualified PlutusLedgerApi.V1 as PV1 (ParamName)
 import qualified PlutusLedgerApi.V2 as PV2 (ParamName)
 import PlutusPrelude (enumerate)
@@ -221,7 +222,7 @@ freeCostModel lang =
 genPair :: Gen a -> Gen b -> Gen (a, b)
 genPair x y = (,) <$> x <*> y
 
-genPlutusData :: Gen Plutus.Data
+genPlutusData :: Gen PCD.Data
 genPlutusData = resize 5 (sized gendata)
   where
     gendata n
@@ -502,7 +503,7 @@ addRedeemMap ::
   forall c.
   Crypto c =>
   TxBody (AlonzoEra c) ->
-  (Plutus.Data, Natural, Natural) ->
+  (PCD.Data, Natural, Natural) ->
   ScriptPurpose c ->
   Map RdmrPtr (Data (AlonzoEra c), ExUnits) ->
   Map RdmrPtr (Data (AlonzoEra c), ExUnits)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -82,7 +82,6 @@ import Data.Text (pack)
 import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Numeric.Natural (Natural)
-import qualified PlutusCore.Data as PCD
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (costModelParamsCount)
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
@@ -98,7 +97,7 @@ instance Era era => Arbitrary (Data era) where
 instance Era era => Arbitrary (BinaryData era) where
   arbitrary = dataToBinaryData <$> arbitrary
 
-instance Arbitrary PCD.Data where
+instance Arbitrary PV1.Data where
   arbitrary = resize 5 (sized gendata)
     where
       gendata n

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -82,6 +82,7 @@ import Data.Text (pack)
 import Data.Typeable (Typeable)
 import GHC.Records (HasField)
 import Numeric.Natural (Natural)
+import qualified PlutusCore.Data as PCD
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (costModelParamsCount)
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysFails, alwaysSucceeds)
@@ -97,7 +98,7 @@ instance Era era => Arbitrary (Data era) where
 instance Era era => Arbitrary (BinaryData era) where
   arbitrary = dataToBinaryData <$> arbitrary
 
-instance Arbitrary PV1.Data where
+instance Arbitrary PCD.Data where
   arbitrary = resize 5 (sized gendata)
     where
       gendata n

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -22,12 +22,13 @@ import Cardano.Ledger.Alonzo.TxInfo
 import Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
 import Data.ByteString.Short (ShortByteString)
 import Data.Proxy (Proxy (..))
+import qualified PlutusCore.Data as PCD
 import PlutusLedgerApi.Test.EvaluationContext
 import PlutusLedgerApi.Test.Examples
   ( alwaysFailingNAryFunction,
     alwaysSucceedingNAryFunction,
   )
-import qualified PlutusLedgerApi.V1 as P
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1)
 import qualified Test.Cardano.Ledger.Alonzo.PlutusScripts as Generated
   ( evenRedeemer2,
@@ -52,14 +53,14 @@ deriving instance Show ScriptFailure
 
 data ShouldSucceed = ShouldSucceed | ShouldFail
 
-directPlutusTest :: ShouldSucceed -> ShortByteString -> [P.Data] -> Assertion
+directPlutusTest :: ShouldSucceed -> ShortByteString -> [PCD.Data] -> Assertion
 directPlutusTest expectation script ds =
   case (expectation, evalWithTightBudget script ds) of
     (ShouldSucceed, Left e) ->
       assertBool ("This script should have succeeded, but: " <> show e) False
     (ShouldSucceed, Right _) ->
       assertBool "" True
-    (ShouldFail, Left ((P.CekError _))) ->
+    (ShouldFail, Left ((PV1.CekError _))) ->
       assertBool "" True -- TODO rule out cost model failure
     (ShouldFail, Left e) ->
       assertBool ("Not the script failure we expected: " <> show e) False
@@ -67,11 +68,11 @@ directPlutusTest expectation script ds =
       assertBool "This script should have failed" False
   where
     -- Evaluate a script with sufficient budget to run it.
-    pv = P.ProtocolVersion 6 0
-    evalWithTightBudget :: ShortByteString -> [P.Data] -> Either P.EvaluationError P.ExBudget
+    pv = PV1.ProtocolVersion 6 0
+    evalWithTightBudget :: ShortByteString -> [PCD.Data] -> Either PV1.EvaluationError PV1.ExBudget
     evalWithTightBudget scr datums = do
-      budget <- snd $ P.evaluateScriptCounting pv P.Quiet evalCtxForTesting scr datums
-      snd $ P.evaluateScriptRestricting pv P.Verbose evalCtxForTesting budget scr datums
+      budget <- snd $ PV1.evaluateScriptCounting pv PV1.Quiet evalCtxForTesting scr datums
+      snd $ PV1.evaluateScriptRestricting pv PV1.Verbose evalCtxForTesting budget scr datums
 
 getRawPlutusScript :: String -> AlonzoScript () -> ShortByteString
 getRawPlutusScript name =
@@ -123,62 +124,62 @@ plutusScriptExamples =
         directPlutusTest
           ShouldSucceed
           guessTheNumber2
-          [P.I 3, P.I 3],
+          [PV1.I 3, PV1.I 3],
       testCase "guess the number, incorrect" $
         directPlutusTest
           ShouldFail
           guessTheNumber2
-          [P.I 3, P.I 4],
+          [PV1.I 3, PV1.I 4],
       testCase "guess the number with 3 args, correct" $
         directPlutusTest
           ShouldSucceed
           guessTheNumber3
-          [P.I 3, P.I 3, P.I 9],
+          [PV1.I 3, PV1.I 3, PV1.I 9],
       testCase "evendata with 3 args, correct" $
         directPlutusTest
           ShouldSucceed
           even3
-          [P.I 4, P.I 3, P.I 9],
+          [PV1.I 4, PV1.I 3, PV1.I 9],
       testCase "evendata with 3 args, incorrect" $
         directPlutusTest
           ShouldFail
           even3
-          [P.I 3, P.I 3, P.I 9],
+          [PV1.I 3, PV1.I 3, PV1.I 9],
       testCase "odd data with 3 args, correct" $
         directPlutusTest
           ShouldSucceed
           odd3
-          [P.I 3, P.I 3, P.I 9],
+          [PV1.I 3, PV1.I 3, PV1.I 9],
       testCase "odd data with 3 args, incorrect" $
         directPlutusTest
           ShouldFail
           odd3
-          [P.I 4, P.I 3, P.I 9],
+          [PV1.I 4, PV1.I 3, PV1.I 9],
       testCase "sumsTo10 with 3 args, correct" $
         directPlutusTest
           ShouldSucceed
           sum103
-          [P.I 3, P.I 7, P.I 9],
+          [PV1.I 3, PV1.I 7, PV1.I 9],
       testCase "sumsTo10 with 3 args, incorrect" $
         directPlutusTest
           ShouldFail
           sum103
-          [P.I 4, P.I 3, P.I 9],
+          [PV1.I 4, PV1.I 3, PV1.I 9],
       testCase "even redeemer with 2 args, correct" $
         directPlutusTest
           ShouldSucceed
           evenRed2
-          [P.I 12, P.I 9],
+          [PV1.I 12, PV1.I 9],
       testCase "odd redeemer with 2 args, correct" $
         directPlutusTest
           ShouldSucceed
           oddredeemer2
-          [P.I 11, P.I 9],
+          [PV1.I 11, PV1.I 9],
       testCase "redeemer is 10 with 2 args, correct" $
         directPlutusTest
           ShouldSucceed
           redeemer102
-          [P.I 10, P.I 10],
+          [PV1.I 10, PV1.I 10],
       explainTestTree
     ]
 
@@ -187,7 +188,7 @@ plutusScriptExamples =
 alonzo :: Proxy Alonzo
 alonzo = Proxy
 
-explainTest :: AlonzoScript Alonzo -> ShouldSucceed -> [P.Data] -> Assertion
+explainTest :: AlonzoScript Alonzo -> ShouldSucceed -> [PCD.Data] -> Assertion
 explainTest script@(PlutusScript _ bytes) mode ds =
   case ( mode,
          runPLCScript
@@ -211,18 +212,18 @@ explainTestTree =
     "explain failures tests"
     [ testCase
         "even data with 3 args, fails as expected"
-        (explainTest Generated.evendata3 ShouldFail [P.I 3, P.I 3, P.I 5]),
+        (explainTest Generated.evendata3 ShouldFail [PV1.I 3, PV1.I 3, PV1.I 5]),
       testCase
         "even data with 3 args, succeeds as expected"
-        (explainTest Generated.evendata3 ShouldSucceed [P.I 4, P.I 3, P.I 5]),
+        (explainTest Generated.evendata3 ShouldSucceed [PV1.I 4, PV1.I 3, PV1.I 5]),
       testCase
         "guess the number with 3 args, succeeds as expected"
         ( explainTest
             Generated.guessTheNumber3
             ShouldSucceed
-            [P.I 4, P.I 4, P.I 5]
+            [PV1.I 4, PV1.I 4, PV1.I 5]
         ),
       testCase
         "guess the number with 3 args, fails as expected"
-        (explainTest Generated.guessTheNumber3 ShouldFail [P.I 4, P.I 5, P.I 5])
+        (explainTest Generated.guessTheNumber3 ShouldFail [PV1.I 4, PV1.I 5, PV1.I 5])
     ]

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -14,15 +14,12 @@ import Cardano.Ledger.Alonzo (Alonzo)
 import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..))
 import Cardano.Ledger.Alonzo.TxInfo
-  ( PlutusDebugInfo (..),
-    ScriptFailure (..),
-    ScriptResult (Fails, Passes),
+  ( ScriptResult (Fails, Passes),
     runPLCScript,
   )
 import Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
 import Data.ByteString.Short (ShortByteString)
 import Data.Proxy (Proxy (..))
-import qualified PlutusCore.Data as PCD
 import PlutusLedgerApi.Test.EvaluationContext
 import PlutusLedgerApi.Test.Examples
   ( alwaysFailingNAryFunction,
@@ -43,17 +40,13 @@ import qualified Test.Cardano.Ledger.Alonzo.PlutusScripts as Generated
 import Test.Tasty
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
 
-deriving instance Show PlutusDebugInfo
-
-deriving instance Show ScriptFailure
-
 -- =============================================
 
 -- Tests running Plutus scripts directely
 
 data ShouldSucceed = ShouldSucceed | ShouldFail
 
-directPlutusTest :: ShouldSucceed -> ShortByteString -> [PCD.Data] -> Assertion
+directPlutusTest :: ShouldSucceed -> ShortByteString -> [PV1.Data] -> Assertion
 directPlutusTest expectation script ds =
   case (expectation, evalWithTightBudget script ds) of
     (ShouldSucceed, Left e) ->
@@ -69,7 +62,7 @@ directPlutusTest expectation script ds =
   where
     -- Evaluate a script with sufficient budget to run it.
     pv = PV1.ProtocolVersion 6 0
-    evalWithTightBudget :: ShortByteString -> [PCD.Data] -> Either PV1.EvaluationError PV1.ExBudget
+    evalWithTightBudget :: ShortByteString -> [PV1.Data] -> Either PV1.EvaluationError PV1.ExBudget
     evalWithTightBudget scr datums = do
       budget <- snd $ PV1.evaluateScriptCounting pv PV1.Quiet evalCtxForTesting scr datums
       snd $ PV1.evaluateScriptRestricting pv PV1.Verbose evalCtxForTesting budget scr datums
@@ -188,7 +181,7 @@ plutusScriptExamples =
 alonzo :: Proxy Alonzo
 alonzo = Proxy
 
-explainTest :: AlonzoScript Alonzo -> ShouldSucceed -> [PCD.Data] -> Assertion
+explainTest :: AlonzoScript Alonzo -> ShouldSucceed -> [PV1.Data] -> Assertion
 explainTest script@(PlutusScript _ bytes) mode ds =
   case ( mode,
          runPLCScript

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -48,7 +48,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import Data.Sequence.Strict
 import GHC.Stack (HasCallStack)
-import PlutusLedgerApi.V1 (Data (..))
+import qualified PlutusCore.Data as PCD (Data (..))
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (freeCostModel)
 import Test.Cardano.Ledger.Alonzo.Examples.Consensus (ledgerExamplesAlonzo)
 import Test.Cardano.Ledger.Alonzo.Serialisation.CDDL (readDataFile)
@@ -87,7 +87,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               carlAddr
               (valueFromList 1407406 [(pid1, smallestName, 1)])
-              (SJust $ hashData @Alonzo (Data (List [])))
+              (SJust $ hashData @Alonzo (Data (PCD.List [])))
           )
           @?= Coin 1655136,
       testCase "one policy, one (smallest) name, no datum hash" $
@@ -139,7 +139,7 @@ goldenUTxOEntryMinAda =
                     (pid1, largestName 67, 1)
                   ]
               )
-              (SJust $ hashData @Alonzo (Data (Constr 0 [Constr 0 []])))
+              (SJust $ hashData @Alonzo (Data (PCD.Constr 0 [PCD.Constr 0 []])))
           )
           @?= Coin 2172366,
       testCase "two policies, one (smallest) name" $
@@ -155,7 +155,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               aliceAddr
               (valueFromList 1592591 [(pid1, smallestName, 1), (pid2, smallestName, 1)])
-              (SJust $ hashData @Alonzo (Data (Constr 0 [])))
+              (SJust $ hashData @Alonzo (Data (PCD.Constr 0 [])))
           )
           @?= Coin 1827546,
       testCase "two policies, two (small) names" $

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -48,7 +48,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import Data.Sequence.Strict
 import GHC.Stack (HasCallStack)
-import qualified PlutusCore.Data as PCD (Data (..))
+import qualified PlutusLedgerApi.V1 as PV1 (Data (..))
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (freeCostModel)
 import Test.Cardano.Ledger.Alonzo.Examples.Consensus (ledgerExamplesAlonzo)
 import Test.Cardano.Ledger.Alonzo.Serialisation.CDDL (readDataFile)
@@ -87,7 +87,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               carlAddr
               (valueFromList 1407406 [(pid1, smallestName, 1)])
-              (SJust $ hashData @Alonzo (Data (PCD.List [])))
+              (SJust $ hashData @Alonzo (Data (PV1.List [])))
           )
           @?= Coin 1655136,
       testCase "one policy, one (smallest) name, no datum hash" $
@@ -139,7 +139,7 @@ goldenUTxOEntryMinAda =
                     (pid1, largestName 67, 1)
                   ]
               )
-              (SJust $ hashData @Alonzo (Data (PCD.Constr 0 [PCD.Constr 0 []])))
+              (SJust $ hashData @Alonzo (Data (PV1.Constr 0 [PV1.Constr 0 []])))
           )
           @?= Coin 2172366,
       testCase "two policies, one (smallest) name" $
@@ -155,7 +155,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               aliceAddr
               (valueFromList 1592591 [(pid1, smallestName, 1), (pid2, smallestName, 1)])
-              (SJust $ hashData @Alonzo (Data (PCD.Constr 0 [])))
+              (SJust $ hashData @Alonzo (Data (PV1.Constr 0 [])))
           )
           @?= Coin 1827546,
       testCase "two policies, two (small) names" $

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/TxInfo.hs
@@ -35,7 +35,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import GHC.Stack
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysSucceeds)
 import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
@@ -74,7 +74,7 @@ shelleyOutput :: TxOut Babbage
 shelleyOutput = BabbageTxOut shelleyAddr (Val.inject $ Coin 2) NoDatum SNothing
 
 datumEx :: Datum Babbage
-datumEx = Datum . dataToBinaryData . Data . Plutus.I $ 123
+datumEx = Datum . dataToBinaryData . Data . PV1.I $ 123
 
 inlineDatumOutput :: TxOut Babbage
 inlineDatumOutput = BabbageTxOut shelleyAddr (Val.inject $ Coin 3) datumEx SNothing

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -145,7 +145,8 @@ import Data.Ratio (denominator, numerator, (%))
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusCore.Data as PCD
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (ExMock, Mock)
 import Test.Cardano.Ledger.Shelley.Generator.Constants (Constants (..))
@@ -201,10 +202,10 @@ data TwoPhase3ArgInfo era = TwoPhase3ArgInfo
     -- | Its ScriptHash
     getHash3 :: ScriptHash (EraCrypto era),
     -- | A Data that will make it succeed
-    getData3 :: Plutus.Data,
+    getData3 :: PCD.Data,
     -- | A Redeemer that will make it succeed
     getRedeemer3 ::
-      ( Plutus.Data, -- The redeeming data
+      ( PCD.Data, -- The redeeming data
         Natural, -- The ExUnits memory count
         Natural -- The ExUnits steps count
       ),
@@ -218,7 +219,7 @@ data TwoPhase2ArgInfo era = TwoPhase2ArgInfo
     getHash2 :: ScriptHash (EraCrypto era),
     -- | A Redeemer that will make it succeed
     getRedeemer2 ::
-      ( Plutus.Data, -- The redeeming data
+      ( PCD.Data, -- The redeeming data
         Natural, -- The ExUnits memory count
         Natural -- The ExUnits steps count
       ),
@@ -691,7 +692,7 @@ genesisCoins genesisTxId outs =
 -- ==================================================================
 -- Operations on GenEnv that deal with ScriptSpace
 
-hashData :: forall era. Era era => Plutus.Data -> DataHash (EraCrypto era)
+hashData :: forall era. Era era => PCD.Data -> DataHash (EraCrypto era)
 hashData x = unsafeMakeSafeHash (Hash.castHash (Hash.hashWith (toStrict . serialise) x))
 
 {-

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -145,7 +145,6 @@ import Data.Ratio (denominator, numerator, (%))
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
-import qualified PlutusCore.Data as PCD
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (ExMock, Mock)
@@ -202,10 +201,10 @@ data TwoPhase3ArgInfo era = TwoPhase3ArgInfo
     -- | Its ScriptHash
     getHash3 :: ScriptHash (EraCrypto era),
     -- | A Data that will make it succeed
-    getData3 :: PCD.Data,
+    getData3 :: PV1.Data,
     -- | A Redeemer that will make it succeed
     getRedeemer3 ::
-      ( PCD.Data, -- The redeeming data
+      ( PV1.Data, -- The redeeming data
         Natural, -- The ExUnits memory count
         Natural -- The ExUnits steps count
       ),
@@ -219,7 +218,7 @@ data TwoPhase2ArgInfo era = TwoPhase2ArgInfo
     getHash2 :: ScriptHash (EraCrypto era),
     -- | A Redeemer that will make it succeed
     getRedeemer2 ::
-      ( PCD.Data, -- The redeeming data
+      ( PV1.Data, -- The redeeming data
         Natural, -- The ExUnits memory count
         Natural -- The ExUnits steps count
       ),
@@ -692,7 +691,7 @@ genesisCoins genesisTxId outs =
 -- ==================================================================
 -- Operations on GenEnv that deal with ScriptSpace
 
-hashData :: forall era. Era era => PCD.Data -> DataHash (EraCrypto era)
+hashData :: forall era. Era era => PV1.Data -> DataHash (EraCrypto era)
 hashData x = unsafeMakeSafeHash (Hash.castHash (Hash.hashWith (toStrict . serialise) x))
 
 {-

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -72,7 +72,7 @@ library
                    , network
                    , nothunks
                    , primitive
-                   , plutus-ledger-api ^>= 1.1
+                   , plutus-core
                    , recursion-schemes
                    , serialise
                    , tagged

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -72,7 +72,7 @@ library
                    , network
                    , nothunks
                    , primitive
-                   , plutus-core
+                   , plutus-ledger-api ^>= 1.1
                    , recursion-schemes
                    , serialise
                    , tagged

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -36,7 +36,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Functor ((<&>))
 import qualified Data.Set as Set
-import qualified PlutusCore.Data as PCD
+import qualified PlutusLedgerApi.V1 as PV1
 
 -- | A decoder for a value paired with an annotation specifying the start and end
 -- of the consumed bytes.
@@ -84,5 +84,5 @@ decodeAnnSet dec = do
 -- Plutus
 --------------------------------------------------------------------------------
 
-instance FromCBOR (C.Annotator PCD.Data) where
+instance FromCBOR (C.Annotator PV1.Data) where
   fromCBOR = pure <$> fromPlainDecoder Serialise.decode

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -36,7 +36,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Functor ((<&>))
 import qualified Data.Set as Set
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusCore.Data as PCD
 
 -- | A decoder for a value paired with an annotation specifying the start and end
 -- of the consumed bytes.
@@ -84,5 +84,5 @@ decodeAnnSet dec = do
 -- Plutus
 --------------------------------------------------------------------------------
 
-instance FromCBOR (C.Annotator Plutus.Data) where
+instance FromCBOR (C.Annotator PCD.Data) where
   fromCBOR = pure <$> fromPlainDecoder Serialise.decode

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
@@ -81,6 +81,7 @@ import Data.Void (Void)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.TypeNats (KnownNat, type (*))
 import Numeric.Natural (Natural)
+import qualified PlutusLedgerApi.V1 as PV1
 import Prelude hiding (decodeFloat)
 
 class Typeable a => FromCBOR a where
@@ -605,4 +606,11 @@ deriving instance FromCBOR EpochSize
 deriving instance FromCBOR SystemStart
 
 instance FromCBOR BlockNo where
+  fromCBOR = fromPlainDecoder decode
+
+--------------------------------------------------------------------------------
+-- Plutus
+--------------------------------------------------------------------------------
+
+instance FromCBOR PV1.Data where
   fromCBOR = fromPlainDecoder decode

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -117,11 +117,10 @@ import qualified Codec.Serialise as Serialise (Serialise (encode))
 import Control.Category (Category ((.)))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BS.Lazy
-import qualified Data.ByteString.Short as SBS (length)
-#if MIN_VERSION_bytestring(0,11,1)
-import Data.ByteString.Short (ShortByteString(SBS))
-#else
-import Data.ByteString.Short.Internal (ShortByteString(SBS))
+import qualified Data.ByteString.Short as SBS
+import qualified PlutusCore.Data as PCD
+#if __GLASGOW_HASKELL__ < 900
+import qualified Data.ByteString.Short.Internal as SBS
 #endif
 import Data.Fixed (Fixed (..), Nano, Pico)
 import Data.Foldable (toList)
@@ -154,7 +153,6 @@ import Formatting (bprint, build, shown, stext)
 import qualified Formatting.Buildable as B (Buildable (..))
 import GHC.TypeNats (KnownNat, type (*))
 import Numeric.Natural (Natural)
-import qualified PlutusLedgerApi.V1 as Plutus
 import Prelude hiding (encodeFloat, (.))
 
 #if MIN_VERSION_recursion_schemes(5,2,0)
@@ -738,12 +736,12 @@ instance ToCBOR SlicedByteArray where
   toCBOR = encodeByteArray
   {-# INLINE toCBOR #-}
 
-instance ToCBOR ShortByteString where
-  toCBOR sbs@(SBS ba) =
+instance ToCBOR SBS.ShortByteString where
+  toCBOR sbs@(SBS.SBS ba) =
     encodeByteArray $ SBA (Prim.ByteArray ba) 0 (SBS.length sbs)
 
   encodedSizeExpr size _ =
-    let len = size (Proxy @(LengthOf ShortByteString))
+    let len = size (Proxy @(LengthOf SBS.ShortByteString))
      in apMono "withWordSize@Int" (withWordSize @Int . fromIntegral) len + len
 
 instance ToCBOR BS.Lazy.ByteString where
@@ -1189,5 +1187,5 @@ instance ToCBOR BlockNo where
 -- Plutus
 --------------------------------------------------------------------------------
 
-instance ToCBOR Plutus.Data where
+instance ToCBOR PCD.Data where
   toCBOR = fromPlainEncoding . Serialise.encode

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -117,10 +117,11 @@ import qualified Codec.Serialise as Serialise (Serialise (encode))
 import Control.Category (Category ((.)))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BS.Lazy
-import qualified Data.ByteString.Short as SBS
-import qualified PlutusCore.Data as PCD
-#if __GLASGOW_HASKELL__ < 900
-import qualified Data.ByteString.Short.Internal as SBS
+import qualified Data.ByteString.Short as SBS (length)
+#if MIN_VERSION_bytestring(0,11,1)
+import Data.ByteString.Short (ShortByteString(SBS))
+#else
+import Data.ByteString.Short.Internal (ShortByteString(SBS))
 #endif
 import Data.Fixed (Fixed (..), Nano, Pico)
 import Data.Foldable (toList)
@@ -153,6 +154,7 @@ import Formatting (bprint, build, shown, stext)
 import qualified Formatting.Buildable as B (Buildable (..))
 import GHC.TypeNats (KnownNat, type (*))
 import Numeric.Natural (Natural)
+import qualified PlutusLedgerApi.V1 as PV1
 import Prelude hiding (encodeFloat, (.))
 
 #if MIN_VERSION_recursion_schemes(5,2,0)
@@ -736,12 +738,12 @@ instance ToCBOR SlicedByteArray where
   toCBOR = encodeByteArray
   {-# INLINE toCBOR #-}
 
-instance ToCBOR SBS.ShortByteString where
-  toCBOR sbs@(SBS.SBS ba) =
+instance ToCBOR ShortByteString where
+  toCBOR sbs@(SBS ba) =
     encodeByteArray $ SBA (Prim.ByteArray ba) 0 (SBS.length sbs)
 
   encodedSizeExpr size _ =
-    let len = size (Proxy @(LengthOf SBS.ShortByteString))
+    let len = size (Proxy @(LengthOf ShortByteString))
      in apMono "withWordSize@Int" (withWordSize @Int . fromIntegral) len + len
 
 instance ToCBOR BS.Lazy.ByteString where
@@ -1187,5 +1189,5 @@ instance ToCBOR BlockNo where
 -- Plutus
 --------------------------------------------------------------------------------
 
-instance ToCBOR PCD.Data where
+instance ToCBOR PV1.Data where
   toCBOR = fromPlainEncoding . Serialise.encode

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -46,7 +46,8 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Pretty hiding (ppPParams, ppPParamsUpdate, ppTx, ppTxBody, ppTxOut)
 import Cardano.Ledger.Pretty.Mary (ppMultiAsset, ppTimelock, ppValidityInterval)
 import Cardano.Ledger.SafeHash (SafeToHash)
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusCore.Data as PCD
+import qualified PlutusLedgerApi.V1 as PV1
 import qualified Prettyprinter as PP
 
 ppTxSeq ::
@@ -158,14 +159,14 @@ ppPParamsUpdate (AlonzoPParams feeA feeB mbb mtx mbh kd pd em no a0 rho tau d ex
 instance PrettyA (AlonzoPParamsUpdate era) where
   prettyA = ppPParamsUpdate
 
-ppPlutusData :: Plutus.Data -> PDoc
-ppPlutusData (Plutus.Constr tag args) = ppSexp "Constr" [ppInteger tag, ppList ppPlutusData args]
-ppPlutusData (Plutus.Map pairs) = ppSexp "Map" [ppList (ppPair ppPlutusData ppPlutusData) pairs]
-ppPlutusData (Plutus.List xs) = ppSexp "List" [ppList ppPlutusData xs]
-ppPlutusData (Plutus.I i) = ppSexp "I" [ppInteger i]
-ppPlutusData (Plutus.B bytes) = ppSexp "B" [ppLong bytes]
+ppPlutusData :: PCD.Data -> PDoc
+ppPlutusData (PV1.Constr tag args) = ppSexp "Constr" [ppInteger tag, ppList ppPlutusData args]
+ppPlutusData (PV1.Map pairs) = ppSexp "Map" [ppList (ppPair ppPlutusData ppPlutusData) pairs]
+ppPlutusData (PV1.List xs) = ppSexp "List" [ppList ppPlutusData xs]
+ppPlutusData (PV1.I i) = ppSexp "I" [ppInteger i]
+ppPlutusData (PV1.B bytes) = ppSexp "B" [ppLong bytes]
 
-instance PrettyA Plutus.Data where
+instance PrettyA PCD.Data where
   prettyA = ppPlutusData
 
 ppData :: Era era => Data era -> PDoc

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -46,7 +46,6 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Pretty hiding (ppPParams, ppPParamsUpdate, ppTx, ppTxBody, ppTxOut)
 import Cardano.Ledger.Pretty.Mary (ppMultiAsset, ppTimelock, ppValidityInterval)
 import Cardano.Ledger.SafeHash (SafeToHash)
-import qualified PlutusCore.Data as PCD
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified Prettyprinter as PP
 
@@ -159,14 +158,14 @@ ppPParamsUpdate (AlonzoPParams feeA feeB mbb mtx mbh kd pd em no a0 rho tau d ex
 instance PrettyA (AlonzoPParamsUpdate era) where
   prettyA = ppPParamsUpdate
 
-ppPlutusData :: PCD.Data -> PDoc
+ppPlutusData :: PV1.Data -> PDoc
 ppPlutusData (PV1.Constr tag args) = ppSexp "Constr" [ppInteger tag, ppList ppPlutusData args]
 ppPlutusData (PV1.Map pairs) = ppSexp "Map" [ppList (ppPair ppPlutusData ppPlutusData) pairs]
 ppPlutusData (PV1.List xs) = ppSexp "List" [ppList ppPlutusData xs]
 ppPlutusData (PV1.I i) = ppSexp "I" [ppInteger i]
 ppPlutusData (PV1.B bytes) = ppSexp "B" [ppLong bytes]
 
-instance PrettyA PCD.Data where
+instance PrettyA PV1.Data where
   prettyA = ppPlutusData
 
 ppData :: Era era => Data era -> PDoc

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -100,8 +100,6 @@ library
     microlens,
     mtl,
     nothunks,
-    -- plutus-ledger-api:{plutus-ledger-api-testlib} ^>=1.1,
-    plutus-ledger-api,
     plutus-core,
     plutus-ledger-api ^>=1.1,
     prettyprinter,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -42,7 +42,7 @@ import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import GHC.Records (HasField)
 import Lens.Micro
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
@@ -223,10 +223,10 @@ exampleTx pf ptr =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits $
             Redeemers $
-              Map.singleton ptr (Data (Plutus.I 42), ExUnits 5000 5000)
+              Map.singleton ptr (Data (PV1.I 42), ExUnits 5000 5000)
         ]
     ]
 
@@ -238,12 +238,12 @@ validatingBody pf =
       Collateral' [mkGenesisTxIn 11],
       Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pparams pf) [PlutusV1] redeemers (mkTxDats (Data (Plutus.I 123))))
+      WppHash (newScriptIntegrityHash pf (pparams pf) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 123))))
     ]
   where
     redeemers =
       Redeemers $
-        Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+        Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 exampleEpochInfo :: Monad m => EpochInfo m
 exampleEpochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Shelley.API (evaluateTransactionFee)
 import Cardano.Ledger.UTxO (makeWitnessVKey)
 import Cardano.Ledger.Val (Val (inject))
 import qualified Data.Map.Strict as Map
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( freeCostModelV1,
     mkGenesisTxIn,
@@ -74,7 +74,7 @@ testEvaluateTransactionFee =
         [ Body validatingBody,
           WitnessesI
             [ ScriptWits' [always 3 pf],
-              DataWits' [Data (Plutus.I 123)],
+              DataWits' [Data (PV1.I 123)],
               RdmrWits redeemers
             ]
         ]
@@ -85,7 +85,7 @@ testEvaluateTransactionFee =
           WitnessesI
             [ AddrWits' [makeWitnessVKey (hashAnnotated validatingBody) (someKeys pf)],
               ScriptWits' [always 3 pf],
-              DataWits' [Data (Plutus.I 123)],
+              DataWits' [Data (PV1.I 123)],
               RdmrWits redeemers
             ]
         ]
@@ -96,11 +96,11 @@ testEvaluateTransactionFee =
           Collateral' [mkGenesisTxIn 11],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (newPParams pf defaultPPs) [PlutusV1] redeemers (mkTxDats (Data (Plutus.I 123))))
+          WppHash (newScriptIntegrityHash pf (newPParams pf defaultPPs) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 123))))
         ]
     redeemers =
       Redeemers $
-        Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+        Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 defaultPPs :: [PParamsField era]
 defaultPPs =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -94,7 +94,7 @@ import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.UMap (View (Rewards))
 import qualified Data.UMap as UM
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( alwaysFailsHash,
     alwaysSucceedsHash,
@@ -214,10 +214,10 @@ testAlonzoBadPMDHBlock other = error ("testAlonzoBadPMDHBlock does not work in e
 -- ============================== DATA ===============================
 
 someDatum :: Era era => Data era
-someDatum = Data (Plutus.I 123)
+someDatum = Data (PV1.I 123)
 
 anotherDatum :: Era era => Data era
-anotherDatum = Data (Plutus.I 0)
+anotherDatum = Data (PV1.I 0)
 
 validatingTx ::
   forall era.
@@ -253,7 +253,7 @@ validatingBody pf =
 validatingRedeemers :: Era era => Redeemers era
 validatingRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingTxOut :: EraTxOut era => Proof era -> TxOut era
 validatingTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]
@@ -290,7 +290,7 @@ notValidatingTx pf =
       Redeemers
         ( Map.fromList
             [ ( RdmrPtr Tag.Spend 0,
-                (Data (Plutus.I 1), ExUnits 5000 5000)
+                (Data (PV1.I 1), ExUnits 5000 5000)
               )
             ]
         )
@@ -334,7 +334,7 @@ validatingBodyWithWithdrawal pf =
 validatingWithWithdrawalRedeemers :: Era era => Redeemers era
 validatingWithWithdrawalRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingTxWithWithdrawalOut :: EraTxOut era => Proof era -> TxOut era
 validatingTxWithWithdrawalOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 1995)]
@@ -373,7 +373,7 @@ notValidatingTxWithWithdrawal pf =
             ),
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] notValidatingRedeemers mempty)
         ]
-    notValidatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+    notValidatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (PV1.I 0), ExUnits 5000 5000)
 
 validatingTxWithCert ::
   forall era.
@@ -409,7 +409,7 @@ validatingBodyWithCert pf =
 validatingRedeemrsWithCert :: Era era => Redeemers era
 validatingRedeemrsWithCert =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Cert 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Cert 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingTxWithCertOut :: EraTxOut era => Proof era -> TxOut era
 validatingTxWithCertOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]
@@ -443,7 +443,7 @@ notValidatingTxWithCert pf =
           Txfee (Coin 5),
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] notValidatingRedeemersWithCert mempty)
         ]
-    notValidatingRedeemersWithCert = Redeemers $ Map.singleton (RdmrPtr Tag.Cert 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+    notValidatingRedeemersWithCert = Redeemers $ Map.singleton (RdmrPtr Tag.Cert 0) (Data (PV1.I 0), ExUnits 5000 5000)
 
 validatingTxWithMint ::
   forall era.
@@ -484,7 +484,7 @@ validatingBodyWithMint pf =
 validatingRedeemersWithMint :: Era era => Redeemers era
 validatingRedeemersWithMint =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Mint 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Mint 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 multiAsset :: forall era. (Scriptic era, HasTokens era) => Proof era -> MultiAsset (EraCrypto era)
 multiAsset pf = forge @era 1 (always 2 pf)
@@ -523,7 +523,7 @@ notValidatingTxWithMint pf =
           Mint ma,
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] notValidatingRedeemersWithMint mempty)
         ]
-    notValidatingRedeemersWithMint = Redeemers $ Map.singleton (RdmrPtr Tag.Mint 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+    notValidatingRedeemersWithMint = Redeemers $ Map.singleton (RdmrPtr Tag.Mint 0) (Data (PV1.I 0), ExUnits 5000 5000)
     ma = forge @era 1 (never 1 pf)
 
 poolMDHTooBigTx ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -49,7 +49,7 @@ import Data.Either (fromRight)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( freeCostModelV1,
     initUTxO,
@@ -115,10 +115,10 @@ collectTwoPhaseScriptInputsOutputOrdering =
 -- ============================== DATA ===============================
 
 datum :: Era era => Data era
-datum = Data (Plutus.I 123)
+datum = Data (PV1.I 123)
 
 redeemer :: Era era => Data era
-redeemer = Data (Plutus.I 42)
+redeemer = Data (PV1.I 42)
 
 validatingTx ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -78,7 +78,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import GHC.Stack
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( AlonzoBased (..),
     alwaysSucceedsHash,
@@ -181,14 +181,14 @@ alonzoUTXOWTests pf =
                             (pp pf)
                             [PlutusV1]
                             (Redeemers mempty)
-                            (mkTxDats (Data (Plutus.I 123)))
+                            (mkTxDats (Data (PV1.I 123)))
                         )
                         ( newScriptIntegrityHash
                             pf
                             (pp pf)
                             [PlutusV1]
                             wrongWpphashRedeemers
-                            (mkTxDats (Data (Plutus.I 123)))
+                            (mkTxDats (Data (PV1.I 123)))
                         )
                   ]
               ),
@@ -238,7 +238,7 @@ alonzoUTXOWTests pf =
               ( Left
                   [ fromPredFail @era $
                       MissingRequiredDatums
-                        (Set.singleton $ hashData @era (Data (Plutus.I 123)))
+                        (Set.singleton $ hashData @era (Data (PV1.I 123)))
                         mempty
                   ]
               ),
@@ -410,7 +410,7 @@ missingRedeemerTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (missingRedeemerTxBody pf)) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)]
+          DataWits' [Data (PV1.I 123)]
         ]
     ]
 
@@ -422,7 +422,7 @@ missingRedeemerTxBody pf =
       Collateral' [mkGenesisTxIn 11],
       Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] (Redeemers mempty) (mkTxDats (Data (Plutus.I 123))))
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] (Redeemers mempty) (mkTxDats (Data (PV1.I 123))))
     ]
 
 wrongWppHashTx ::
@@ -436,14 +436,14 @@ wrongWppHashTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (missingRedeemerTxBody pf)) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits wrongWpphashRedeemers
         ]
     ]
 
 wrongWpphashRedeemers :: Era era => Redeemers era
 wrongWpphashRedeemers =
-  Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+  Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 missing1phaseScriptWitnessTx ::
   forall era.
@@ -471,7 +471,7 @@ missing1phaseScriptWitnessTx pf =
               timelockScript 1 pf,
               timelockScript 2 pf
             ],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingManyScriptsRedeemers
         ]
     ]
@@ -502,7 +502,7 @@ missing2phaseScriptWitnessTx pf =
               timelockScript 1 pf,
               timelockScript 2 pf
             ],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingManyScriptsRedeemers
         ]
     ]
@@ -531,7 +531,7 @@ validatingManyScriptsBody pf =
               ]
         ),
       Mint mint,
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingManyScriptsRedeemers (mkTxDats (Data (Plutus.I 123)))),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingManyScriptsRedeemers (mkTxDats (Data (PV1.I 123)))),
       Vldt (ValidityInterval SNothing (SJust $ SlotNo 1))
     ]
   where
@@ -546,10 +546,10 @@ validatingManyScriptsBody pf =
 validatingManyScriptsRedeemers :: Era era => Redeemers era
 validatingManyScriptsRedeemers =
   Redeemers . Map.fromList $
-    [ (RdmrPtr Tag.Spend 0, (Data (Plutus.I 101), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Cert 1, (Data (Plutus.I 102), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Rewrd 0, (Data (Plutus.I 103), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Mint 1, (Data (Plutus.I 104), ExUnits 5000 5000))
+    [ (RdmrPtr Tag.Spend 0, (Data (PV1.I 101), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Cert 1, (Data (PV1.I 102), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Rewrd 0, (Data (PV1.I 103), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Mint 1, (Data (PV1.I 104), ExUnits 5000 5000))
     ]
 
 wrongRedeemerLabelTx ::
@@ -567,7 +567,7 @@ wrongRedeemerLabelTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated wrongRedeemerLabelTxBody) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits misPurposedRedeemer
         ]
     ]
@@ -579,11 +579,11 @@ wrongRedeemerLabelTx pf =
           Collateral' [mkGenesisTxIn 11],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] misPurposedRedeemer (mkTxDats (Data (Plutus.I 123))))
+          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] misPurposedRedeemer (mkTxDats (Data (PV1.I 123))))
         ]
     misPurposedRedeemer =
       Redeemers $ -- The label *should* be Spend, not Mint
-        Map.singleton (RdmrPtr Tag.Mint 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+        Map.singleton (RdmrPtr Tag.Mint 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 missingDatumTx ::
   forall era.
@@ -613,7 +613,7 @@ missingDatumTx pf =
           Txfee (Coin 5),
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
         ]
-    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 phase1FailureTx ::
   forall era.
@@ -642,7 +642,7 @@ phase1FailureTx pf =
               timelockScript 1 pf,
               timelockScript 2 pf
             ],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingManyScriptsRedeemers
         ]
     ]
@@ -662,7 +662,7 @@ validatingTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingRedeemers
         ]
     ]
@@ -675,11 +675,11 @@ validatingBody pf =
       Collateral' [mkGenesisTxIn 11],
       Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemers (mkTxDats (Data (Plutus.I 123))))
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemers (mkTxDats (Data (PV1.I 123))))
     ]
 
 validatingRedeemers :: Era era => Redeemers era
-validatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+validatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 notValidatingTx ::
   ( Scriptic era,
@@ -695,7 +695,7 @@ notValidatingTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated body) (someKeys pf)],
           ScriptWits' [never 0 pf],
-          DataWits' [Data (Plutus.I 0)],
+          DataWits' [Data (PV1.I 0)],
           RdmrWits redeemers
         ]
     ]
@@ -707,13 +707,13 @@ notValidatingTx pf =
           Collateral' [mkGenesisTxIn 12],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 2995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers (mkTxDats (Data (Plutus.I 0))))
+          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 0))))
         ]
     redeemers =
       Redeemers
         ( Map.fromList
             [ ( RdmrPtr Tag.Spend 0,
-                (Data (Plutus.I 1), ExUnits 5000 5000)
+                (Data (PV1.I 1), ExUnits 5000 5000)
               )
             ]
         )
@@ -733,7 +733,7 @@ tooManyExUnitsTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated tooManyExUnitsTxBody) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits redeemers
         ]
     ]
@@ -745,11 +745,11 @@ tooManyExUnitsTx pf =
           Collateral' [mkGenesisTxIn 11],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers (mkTxDats (Data (Plutus.I 123))))
+          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 123))))
         ]
     redeemers =
       Redeemers $
-        Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 1000001 5000)
+        Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 1000001 5000)
 
 missingCollateralSigTx ::
   forall era.
@@ -762,8 +762,8 @@ missingCollateralSigTx pf =
     [ Body (validatingBody pf),
       WitnessesI
         [ ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
-          RdmrWits $ Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+          DataWits' [Data (PV1.I 123)],
+          RdmrWits $ Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
         ]
     ]
 
@@ -795,7 +795,7 @@ plutusOutputWithNoDataTx pf =
           Txfee (Coin 5),
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
         ]
-    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 notOkSupplimentaryDatumTx ::
   forall era.
@@ -827,7 +827,7 @@ notOkSupplimentaryDatumTx pf =
     outputWithNoDatum = newTxOut pf [Address $ someAddr pf, Amount (inject $ Coin 995)]
 
 totallyIrrelevantDatum :: Era era => Data era
-totallyIrrelevantDatum = Data (Plutus.I 1729)
+totallyIrrelevantDatum = Data (PV1.I 1729)
 
 extraRedeemersTx ::
   forall era.
@@ -844,7 +844,7 @@ extraRedeemersTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated extraRedeemersBody) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits extraRedeemersEx
         ]
     ]
@@ -856,10 +856,10 @@ extraRedeemersTx pf =
           Collateral' [mkGenesisTxIn 11],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] extraRedeemersEx (mkTxDats (Data (Plutus.I 123))))
+          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] extraRedeemersEx (mkTxDats (Data (PV1.I 123))))
         ]
-    extraRedeemersEx = Redeemers $ Map.insert (RdmrPtr Tag.Spend 7) (Data (Plutus.I 42), ExUnits 432 444) (unRedeemers redeemers)
-    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    extraRedeemersEx = Redeemers $ Map.insert (RdmrPtr Tag.Spend 7) (Data (PV1.I 42), ExUnits 432 444) (unRedeemers redeemers)
+    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 multipleEqualCertsInvalidTx ::
   forall era.
@@ -896,8 +896,8 @@ multipleEqualCertsInvalidTx pf =
     redeemers =
       Redeemers $
         Map.fromList
-          [ (RdmrPtr Tag.Cert 0, (Data (Plutus.I 42), ExUnits 5000 5000)),
-            (RdmrPtr Tag.Cert 1, (Data (Plutus.I 42), ExUnits 5000 5000))
+          [ (RdmrPtr Tag.Cert 0, (Data (PV1.I 42), ExUnits 5000 5000)),
+            (RdmrPtr Tag.Cert 1, (Data (PV1.I 42), ExUnits 5000 5000))
           ]
 
 noCostModelTx ::
@@ -915,7 +915,7 @@ noCostModelTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated noCostModelBody) (someKeys pf)],
           ScriptWits' [alwaysAlt 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits redeemers
         ]
     ]
@@ -927,9 +927,9 @@ noCostModelTx pf =
           Collateral' [mkGenesisTxIn 11],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] redeemers (mkTxDats (Data (Plutus.I 123))))
+          WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] redeemers (mkTxDats (Data (PV1.I 123))))
         ]
-    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    redeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 -- ============================== HELPER FUNCTIONS ===============================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -61,7 +61,7 @@ import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default.Class (Default (..))
 import qualified Data.Map.Strict as Map
 import GHC.Stack
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( alwaysFailsHash,
     alwaysSucceedsHash,
@@ -203,7 +203,7 @@ validatingTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)],
           ScriptWits' [always 3 pf],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingRedeemers
         ]
     ]
@@ -216,11 +216,11 @@ validatingBody pf =
       Collateral' [mkGenesisTxIn 11],
       Outputs' [validatingTxOut pf],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemers (mkTxDats (Data (Plutus.I 123))))
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemers (mkTxDats (Data (PV1.I 123))))
     ]
 
 validatingRedeemers :: Era era => Redeemers era
-validatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+validatingRedeemers = Redeemers $ Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingTxOut :: EraTxOut era => Proof era -> TxOut era
 validatingTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]
@@ -238,7 +238,7 @@ validatingState pf = smartUTxOState utxo (Coin 0) (Coin 5) def
 --  Example 2: Process a SPEND transaction with a failing Plutus script.
 -- ======================================================================
 datumExample2 :: Era era => Data era
-datumExample2 = Data (Plutus.I 0)
+datumExample2 = Data (PV1.I 0)
 
 notValidatingTx ::
   ( Scriptic era,
@@ -272,7 +272,7 @@ notValidatingTx pf =
       Redeemers
         ( Map.fromList
             [ ( RdmrPtr Tag.Spend 0,
-                (Data (Plutus.I 1), ExUnits 5000 5000)
+                (Data (PV1.I 1), ExUnits 5000 5000)
               )
             ]
         )
@@ -324,7 +324,7 @@ validatingWithCertTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject 
 validatingWithCertRedeemers :: Era era => Redeemers era
 validatingWithCertRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Cert 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Cert 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingWithCertState ::
   (Default (State (EraRule "PPUP" era)), EraTxBody era, PostShelley era) =>
@@ -369,7 +369,7 @@ notValidatingWithCertTx pf =
         ]
     redeemers =
       Redeemers $
-        Map.singleton (RdmrPtr Tag.Cert 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+        Map.singleton (RdmrPtr Tag.Cert 0) (Data (PV1.I 0), ExUnits 5000 5000)
 
 notValidatingWithCertState ::
   (Default (State (EraRule "PPUP" era)), EraTxBody era, PostShelley era) =>
@@ -420,7 +420,7 @@ validatingWithWithdrawalBody pf =
 validatingWithWithdrawalRedeemers :: Era era => Redeemers era
 validatingWithWithdrawalRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 validatingWithWithdrawalTxOut :: EraTxOut era => Proof era -> TxOut era
 validatingWithWithdrawalTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 1995)]
@@ -472,7 +472,7 @@ notValidatingTxWithWithdrawal pf =
           WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
         ]
     redeemers =
-      Redeemers $ Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+      Redeemers $ Map.singleton (RdmrPtr Tag.Rewrd 0) (Data (PV1.I 0), ExUnits 5000 5000)
 
 notValidatingWithWithdrawalState ::
   (Default (State (EraRule "PPUP" era)), EraTxBody era, PostShelley era) =>
@@ -523,7 +523,7 @@ validatingWithMintBody pf =
 validatingWithMintRedeemers :: Era era => Redeemers era
 validatingWithMintRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Mint 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Mint 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 multiAsset :: forall era. (Scriptic era, HasTokens era) => Proof era -> MultiAsset (EraCrypto era)
 multiAsset pf = forge @era 1 (always 2 pf)
@@ -577,7 +577,7 @@ notValidatingWithMintTx pf =
         ]
     redeemers =
       Redeemers $
-        Map.singleton (RdmrPtr Tag.Mint 0) (Data (Plutus.I 0), ExUnits 5000 5000)
+        Map.singleton (RdmrPtr Tag.Mint 0) (Data (PV1.I 0), ExUnits 5000 5000)
     mint = forge @era 1 (never 1 pf)
 
 notValidatingWithMintState ::
@@ -619,7 +619,7 @@ validatingManyScriptsTx pf =
               timelockScript 1 pf,
               timelockScript 2 pf
             ],
-          DataWits' [Data (Plutus.I 123)],
+          DataWits' [Data (PV1.I 123)],
           RdmrWits validatingManyScriptsRedeemers
         ]
     ]
@@ -647,17 +647,17 @@ validatingManyScriptsBody pf =
               ]
         ),
       Mint (validatingManyScriptsMint pf),
-      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingManyScriptsRedeemers (mkTxDats (Data (Plutus.I 123)))),
+      WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingManyScriptsRedeemers (mkTxDats (Data (PV1.I 123)))),
       Vldt (ValidityInterval SNothing (SJust $ SlotNo 1))
     ]
 
 validatingManyScriptsRedeemers :: Era era => Redeemers era
 validatingManyScriptsRedeemers =
   Redeemers . Map.fromList $
-    [ (RdmrPtr Tag.Spend 0, (Data (Plutus.I 101), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Cert 1, (Data (Plutus.I 102), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Rewrd 0, (Data (Plutus.I 103), ExUnits 5000 5000)),
-      (RdmrPtr Tag.Mint 1, (Data (Plutus.I 104), ExUnits 5000 5000))
+    [ (RdmrPtr Tag.Spend 0, (Data (PV1.I 101), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Cert 1, (Data (PV1.I 102), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Rewrd 0, (Data (PV1.I 103), ExUnits 5000 5000)),
+      (RdmrPtr Tag.Mint 1, (Data (PV1.I 104), ExUnits 5000 5000))
     ]
 
 validatingManyScriptsMint :: forall era. (PostShelley era, HasTokens era) => Proof era -> MultiAsset (EraCrypto era)
@@ -702,7 +702,7 @@ validatingSupplimentaryDatumTx pf =
     [ Body (validatingSupplimentaryDatumBody pf),
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated (validatingSupplimentaryDatumBody pf)) (someKeys pf)],
-          DataWits' [Data (Plutus.I 123)]
+          DataWits' [Data (PV1.I 123)]
         ]
     ]
 
@@ -713,11 +713,11 @@ validatingSupplimentaryDatumBody pf =
     [ Inputs' [mkGenesisTxIn 3],
       Outputs' [validatingSupplimentaryDatumTxOut pf],
       Txfee (Coin 5),
-      WppHash (newScriptIntegrityHash pf (pp pf) [] (Redeemers mempty) (mkTxDats (Data (Plutus.I 123))))
+      WppHash (newScriptIntegrityHash pf (pp pf) [] (Redeemers mempty) (mkTxDats (Data (PV1.I 123))))
     ]
 
 validatingSupplimentaryDatum :: Era era => Data era
-validatingSupplimentaryDatum = Data (Plutus.I 123)
+validatingSupplimentaryDatum = Data (PV1.I 123)
 
 validatingSupplimentaryDatumTxOut :: forall era. (EraTxBody era, Scriptic era) => Proof era -> TxOut era
 validatingSupplimentaryDatumTxOut pf =
@@ -779,7 +779,7 @@ validatingMultipleEqualCertsRedeemers :: Era era => Redeemers era
 validatingMultipleEqualCertsRedeemers =
   Redeemers $
     Map.fromList
-      [ (RdmrPtr Tag.Cert 0, (Data (Plutus.I 42), ExUnits 5000 5000))
+      [ (RdmrPtr Tag.Cert 0, (Data (PV1.I 42), ExUnits 5000 5000))
       ]
 
 validatingMultipleEqualCertsOut :: EraTxOut era => Proof era -> TxOut era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -74,7 +74,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import GHC.Stack
 import Lens.Micro
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( AlonzoBased (..),
     freeCostModelV1,
@@ -168,15 +168,15 @@ simpleScriptAddr :: forall era. (Scriptic era) => Proof era -> Addr (EraCrypto e
 simpleScriptAddr pf = scriptAddr pf (simpleScript pf)
 
 datumExampleEven :: Era era => Data era
-datumExampleEven = Data (Plutus.I 2)
+datumExampleEven = Data (PV1.I 2)
 
 datumExampleOdd :: Era era => Data era
-datumExampleOdd = Data (Plutus.I 3)
+datumExampleOdd = Data (PV1.I 3)
 
 validatingRedeemers :: Era era => Redeemers era
 validatingRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Spend 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Spend 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 -- We intentionally use a ByteString with length greater than 64 to serve as
 -- as reminder that our protection against contiguous data over 64 Bytes on
@@ -185,7 +185,7 @@ sixtyFiveBytes :: BS.ByteString
 sixtyFiveBytes = BS.pack [1 .. 65]
 
 datumExampleSixtyFiveBytes :: Era era => Data era
-datumExampleSixtyFiveBytes = Data (Plutus.B sixtyFiveBytes)
+datumExampleSixtyFiveBytes = Data (PV1.B sixtyFiveBytes)
 
 txDats :: Era era => TxDats era
 txDats = mkTxDats datumExampleSixtyFiveBytes
@@ -504,7 +504,7 @@ refInputWithDataHashWithWit pf =
 certRedeemers :: Era era => Redeemers era
 certRedeemers =
   Redeemers $
-    Map.singleton (RdmrPtr Tag.Cert 0) (Data (Plutus.I 42), ExUnits 5000 5000)
+    Map.singleton (RdmrPtr Tag.Cert 0) (Data (PV1.I 42), ExUnits 5000 5000)
 
 refscriptForDelegCert :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
 refscriptForDelegCert pf =
@@ -889,7 +889,7 @@ simpleScriptOutWithRefScriptUTxOState pf =
 -- ========================================================================================
 
 largeDatum :: Era era => Data era
-largeDatum = Data (Plutus.B . BS.pack $ replicate 1500 0)
+largeDatum = Data (PV1.B . BS.pack $ replicate 1500 0)
 
 largeOutput' :: forall era. (EraTxOut era) => Proof era -> TxOut era
 largeOutput' pf =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -45,7 +45,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import Lens.Micro
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Examples.STSTestUtils
   ( freeCostModelV1,
     initUTxO,
@@ -375,7 +375,7 @@ notValidatingTx pf =
       WitnessesI
         [ AddrWits' [makeWitnessVKey (hashAnnotated notValidatingBody) (someKeys pf)],
           ScriptWits' [never 0 pf],
-          DataWits' [Data (Plutus.I 0)],
+          DataWits' [Data (PV1.I 0)],
           RdmrWits redeemers
         ]
     ]
@@ -387,13 +387,13 @@ notValidatingTx pf =
           Collateral' [mkGenesisTxIn 12],
           Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 2995)]],
           Txfee (Coin 5),
-          WppHash (newScriptIntegrityHash pf (pparams pf) [PlutusV1] redeemers (mkTxDats (Data (Plutus.I 0))))
+          WppHash (newScriptIntegrityHash pf (pparams pf) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 0))))
         ]
     redeemers =
       Redeemers
         ( Map.fromList
             [ ( RdmrPtr Tag.Spend 0,
-                (Data (Plutus.I 1), ExUnits 5000 5000)
+                (Data (PV1.I 1), ExUnits 5000 5000)
               )
             ]
         )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
@@ -85,7 +85,7 @@ import Data.Word (Word64, Word8)
 import GHC.Records (HasField)
 import GHC.Stack (HasCallStack)
 import Numeric.Natural (Natural)
-import qualified PlutusLedgerApi.V1 as Plutus
+import qualified PlutusLedgerApi.V1 as PV1
 import qualified Test.Cardano.Ledger.Allegra.Examples.Consensus as Old (ledgerExamplesAllegra)
 import Test.Cardano.Ledger.Alonzo.EraMapping ()
 import qualified Test.Cardano.Ledger.Alonzo.Examples.Consensus as Old (ledgerExamplesAlonzo)
@@ -1022,10 +1022,10 @@ ledgerExamplesAlonzo =
     exampleAlonzoGenesis
 
 datumExample :: Era era => Data era
-datumExample = Data (Plutus.I 191)
+datumExample = Data (PV1.I 191)
 
 redeemerExample :: Era era => Data era
-redeemerExample = Data (Plutus.I 919)
+redeemerExample = Data (PV1.I 919)
 
 exampleAlonzoGenesis :: AlonzoGenesis
 exampleAlonzoGenesis =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -103,7 +103,7 @@ import qualified Data.Set as Set
 import Data.Text (Text, pack)
 import Data.Typeable (Typeable)
 import qualified Data.UMap as UMap (View (..), delView, rewView, size)
-import qualified PlutusCore.Data as Plutus (Data (..))
+import qualified PlutusCore.Data as PCD (Data (..))
 import Prettyprinter (hsep, parens, viaShow, vsep)
 import Test.Cardano.Ledger.Generic.Fields
   ( TxBodyField (..),
@@ -912,12 +912,12 @@ datumSummary (Datum b) = dataSummary (binaryDataToData b)
 dataSummary :: Era era => Cardano.Ledger.Alonzo.Data.Data era -> PDoc
 dataSummary (Data x) = plutusDataSummary x
 
-plutusDataSummary :: Plutus.Data -> PDoc
-plutusDataSummary (Plutus.Constr n ds) = (ppString (show n)) <> ppList plutusDataSummary ds
-plutusDataSummary (Plutus.Map ds) = ppString "Map" <> ppList (ppPair plutusDataSummary plutusDataSummary) ds
-plutusDataSummary (Plutus.List xs) = ppList plutusDataSummary xs
-plutusDataSummary (Plutus.I n) = ppInteger n
-plutusDataSummary (Plutus.B bs) = trim (ppLong bs)
+plutusDataSummary :: PCD.Data -> PDoc
+plutusDataSummary (PCD.Constr n ds) = (ppString (show n)) <> ppList plutusDataSummary ds
+plutusDataSummary (PCD.Map ds) = ppString "Map" <> ppList (ppPair plutusDataSummary plutusDataSummary) ds
+plutusDataSummary (PCD.List xs) = ppList plutusDataSummary xs
+plutusDataSummary (PCD.I n) = ppInteger n
+plutusDataSummary (PCD.B bs) = trim (ppLong bs)
 
 multiAssetSummary :: MultiAsset c -> PDoc
 multiAssetSummary (MultiAsset m) = ppString ("num tokens = " ++ show (Map.size m))
@@ -1128,15 +1128,15 @@ pcDatum (Datum b) = pcData (binaryDataToData b)
 instance Era era => PrettyC (Datum era) era where prettyC _ = pcDatum
 
 pcData :: forall era. Era era => Data era -> PDoc
-pcData d@(Data (Plutus.Constr n _)) =
+pcData d@(Data (PCD.Constr n _)) =
   ppSexp (pack ("Constr" ++ show n)) [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (Plutus.Map _)) =
+pcData d@(Data (PCD.Map _)) =
   ppSexp "Map" [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (Plutus.List _)) =
+pcData d@(Data (PCD.List _)) =
   ppSexp "List" [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (Plutus.I n)) =
+pcData d@(Data (PCD.I n)) =
   ppSexp "I" [ppInteger n, ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (Plutus.B bytes)) =
+pcData d@(Data (PCD.B bytes)) =
   ppSexp "B" [trim (viaShow bytes), ppString "Hash", trim $ ppSafeHash (hashData d)]
 
 instance Era era => PrettyC (Data era) era where prettyC _ = pcData

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -103,7 +103,7 @@ import qualified Data.Set as Set
 import Data.Text (Text, pack)
 import Data.Typeable (Typeable)
 import qualified Data.UMap as UMap (View (..), delView, rewView, size)
-import qualified PlutusCore.Data as PCD (Data (..))
+import qualified PlutusLedgerApi.V1 as PV1 (Data (..))
 import Prettyprinter (hsep, parens, viaShow, vsep)
 import Test.Cardano.Ledger.Generic.Fields
   ( TxBodyField (..),
@@ -912,12 +912,12 @@ datumSummary (Datum b) = dataSummary (binaryDataToData b)
 dataSummary :: Era era => Cardano.Ledger.Alonzo.Data.Data era -> PDoc
 dataSummary (Data x) = plutusDataSummary x
 
-plutusDataSummary :: PCD.Data -> PDoc
-plutusDataSummary (PCD.Constr n ds) = (ppString (show n)) <> ppList plutusDataSummary ds
-plutusDataSummary (PCD.Map ds) = ppString "Map" <> ppList (ppPair plutusDataSummary plutusDataSummary) ds
-plutusDataSummary (PCD.List xs) = ppList plutusDataSummary xs
-plutusDataSummary (PCD.I n) = ppInteger n
-plutusDataSummary (PCD.B bs) = trim (ppLong bs)
+plutusDataSummary :: PV1.Data -> PDoc
+plutusDataSummary (PV1.Constr n ds) = (ppString (show n)) <> ppList plutusDataSummary ds
+plutusDataSummary (PV1.Map ds) = ppString "Map" <> ppList (ppPair plutusDataSummary plutusDataSummary) ds
+plutusDataSummary (PV1.List xs) = ppList plutusDataSummary xs
+plutusDataSummary (PV1.I n) = ppInteger n
+plutusDataSummary (PV1.B bs) = trim (ppLong bs)
 
 multiAssetSummary :: MultiAsset c -> PDoc
 multiAssetSummary (MultiAsset m) = ppString ("num tokens = " ++ show (Map.size m))
@@ -1128,15 +1128,15 @@ pcDatum (Datum b) = pcData (binaryDataToData b)
 instance Era era => PrettyC (Datum era) era where prettyC _ = pcDatum
 
 pcData :: forall era. Era era => Data era -> PDoc
-pcData d@(Data (PCD.Constr n _)) =
+pcData d@(Data (PV1.Constr n _)) =
   ppSexp (pack ("Constr" ++ show n)) [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (PCD.Map _)) =
+pcData d@(Data (PV1.Map _)) =
   ppSexp "Map" [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (PCD.List _)) =
+pcData d@(Data (PV1.List _)) =
   ppSexp "List" [ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (PCD.I n)) =
+pcData d@(Data (PV1.I n)) =
   ppSexp "I" [ppInteger n, ppString "Hash", trim $ ppSafeHash (hashData d)]
-pcData d@(Data (PCD.B bytes)) =
+pcData d@(Data (PV1.B bytes)) =
   ppSexp "B" [trim (viaShow bytes), ppString "Hash", trim $ ppSafeHash (hashData d)]
 
 instance Era era => PrettyC (Data era) era where prettyC _ = pcData

--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -38,7 +38,6 @@ executable plutus-preprocessor
       cardano-ledger-alonzo,
       flat,
       hashable >= 1.4.1.0,
-      plutus-core ^>= 1.1,
       plutus-tx ^>= 1.1,
       -- This package needs at least 1.1.1 for 9.2
       -- compatibility in the plugin

--- a/libs/plutus-preprocessor/src/Debug.hs
+++ b/libs/plutus-preprocessor/src/Debug.hs
@@ -1,17 +1,14 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main where
 
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.TxInfo (PlutusDebug (..), PlutusDebugInfo (..), debugPlutus)
+import Cardano.Ledger.Alonzo.TxInfo (debugPlutus)
 import Cardano.Ledger.BaseTypes (natVersion)
 import System.Environment (getArgs)
 import System.IO
-
-deriving instance Show PlutusDebugInfo
 
 main :: IO ()
 main = print . debugPlutus (natVersion @7) . head =<< getArgs

--- a/libs/plutus-preprocessor/src/Main.hs
+++ b/libs/plutus-preprocessor/src/Main.hs
@@ -19,7 +19,7 @@ import Data.ByteString.Short (ShortByteString, pack, toShort, unpack)
 import Flat (flat)
 import Language.Haskell.TH
 import Language.Haskell.TH.Ppr
-import qualified PlutusLedgerApi.V1 as P
+import qualified PlutusLedgerApi.V1 as PV1
 import PlutusScripts
   ( evenRedeemerDecl,
     evenRedeemerDecl2Args,
@@ -89,52 +89,52 @@ $redeemerIs10Decl2Args
 
 guessTheNumberBytes :: ShortByteString
 guessTheNumberBytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||guessTheNumber'3||])
 
 guess2args :: ShortByteString
 guess2args =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||guessTheNumber'2||])
 
 evendataBytes :: ShortByteString
 evendataBytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||evendata'||])
 
 evenRedeemerBytes :: ShortByteString
 evenRedeemerBytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||evenRedeemer'||])
 
 odddataBytes :: ShortByteString
 odddataBytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||odddata'||])
 
 oddRedeemerBytes :: ShortByteString
 oddRedeemerBytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||oddRedeemer'||])
 
 sumsTo10Bytes :: ShortByteString
 sumsTo10Bytes =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||sumsTo10'||])
 
 oddRedeemerBytes2Arg :: ShortByteString
 oddRedeemerBytes2Arg =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||oddRedeemer2'||])
 
 evenRedeemerBytes2Args :: ShortByteString
 evenRedeemerBytes2Args =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||evenRedeemer2'||])
 
 redeemerIs10Bytes2Args :: ShortByteString
 redeemerIs10Bytes2Args =
-  P.serialiseCompiledCode
+  PV1.serialiseCompiledCode
     $$(P.compile [||redeemerIs102'||])
 
 -- ========================================================================

--- a/libs/plutus-preprocessor/src/PlutusScripts.hs
+++ b/libs/plutus-preprocessor/src/PlutusScripts.hs
@@ -19,7 +19,7 @@ where
 
 import Data.String (fromString)
 import Language.Haskell.TH
-import qualified PlutusLedgerApi.V1 as P
+import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusTx as P (Data (..), compile)
 import qualified PlutusTx.Builtins as P
 import qualified PlutusTx.Prelude as P


### PR DESCRIPTION
**NOTE**:
- The first commit only renames all `Plutus.*` imports in a standard form of either `PV1` (`PlutusLedgerApi.V1`), `PV2` (`PlutusLedgerApi.V2`) or `PCD` (`PlutusCore.Data`)
- Only the second commit implements all the changes related to making `PlutusDebug` a GADT.

TODO:
- [x] Get confirmation about CBOR codecs being correct
- [x] Add CHANGELOG entry