### PR TITLE
Remove `EncodeMint`/`DecodeMint` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,7 @@ in the naming of release branches.
 - Removed unused `Data.BiMap` module from `cardano-data` #3089
 - Removed `getMultiSigBytes` as unused #3138
 - Removed `hashCostModel` as unused and invalid #3138
+- Removed `EncodeMint`/`DecodeMint` classes in favor of regular `ToCBOR`/`FromCBOR` #3172
 
 ### Fixed
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -108,7 +108,7 @@ import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..), Wdrl (Wdrl), unWdrl
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.ShelleyMA.TxBody (ShelleyMAEraTxBody (..))
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val (Val (..), decodeMint, encodeMint)
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -465,7 +465,7 @@ encodeTxBodyRaw
       !> encodeKeyedStrictMaybe 6 atbrUpdate
       !> encodeKeyedStrictMaybe 8 bot
       !> Omit null (Key 14 (To atbrReqSignerHashes))
-      !> Omit (== mempty) (Key 9 (E encodeMint atbrMint))
+      !> Omit (== mempty) (Key 9 (To atbrMint))
       !> encodeKeyedStrictMaybe 11 atbrScriptIntegrityHash
       !> encodeKeyedStrictMaybe 7 atbrAuxDataHash
       !> encodeKeyedStrictMaybe 15 atbrTxNetworkId
@@ -503,7 +503,7 @@ instance
         ofield
           (\x tx -> tx {atbrValidityInterval = (atbrValidityInterval tx) {invalidBefore = x}})
           From
-      bodyFields 9 = field (\x tx -> tx {atbrMint = x}) (D decodeMint)
+      bodyFields 9 = field (\x tx -> tx {atbrMint = x}) From
       bodyFields 11 = ofield (\x tx -> tx {atbrScriptIntegrityHash = x}) From
       bodyFields 14 = field (\x tx -> tx {atbrReqSignerHashes = x}) From
       bodyFields 15 = ofield (\x tx -> tx {atbrTxNetworkId = x}) From

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -56,6 +56,7 @@ import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), ScriptIntegrityHash)
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.BaseTypes (Network, StrictMaybe (..), Version)
+import Cardano.Ledger.Binary (toCBOR)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
@@ -65,7 +66,7 @@ import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.Ledger.Val (DecodeNonNegative, EncodeMint (..), Val)
+import Cardano.Ledger.Val (DecodeNonNegative, Val)
 import Cardano.Slotting.Slot (SlotNo)
 import Codec.CBOR.Term (Term (..))
 import Control.State.Transition (PredicateFailure)
@@ -443,7 +444,7 @@ instance Crypto c => Twiddle (Update (AlonzoEra c)) where
   twiddle v = twiddle v . toTerm v
 
 instance Crypto c => Twiddle (MultiAsset c) where
-  twiddle v = twiddle v . encodingToTerm v . encodeMint
+  twiddle v = twiddle v . encodingToTerm v . toCBOR
 
 instance Crypto c => Twiddle (ScriptIntegrityHash c) where
   twiddle v = twiddle v . toTerm v

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -163,12 +163,7 @@ import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (Wdrl (Wdrl), unWdrl)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val
-  ( DecodeNonNegative,
-    Val (..),
-    decodeMint,
-    encodeMint,
-  )
+import Cardano.Ledger.Val (DecodeNonNegative, Val (..))
 import Control.DeepSeq (NFData)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import qualified Data.Sequence.Strict as StrictSeq
@@ -727,7 +722,7 @@ encodeTxBodyRaw
       !> encodeKeyedStrictMaybe 6 btbrUpdate
       !> encodeKeyedStrictMaybe 8 bot
       !> Omit null (Key 14 (To btbrReqSignerHashes))
-      !> Omit (== mempty) (Key 9 (E encodeMint btbrMint))
+      !> Omit (== mempty) (Key 9 (To btbrMint))
       !> encodeKeyedStrictMaybe 11 btbrScriptIntegrityHash
       !> encodeKeyedStrictMaybe 7 btbrAuxDataHash
       !> encodeKeyedStrictMaybe 15 btbrTxNetworkId
@@ -784,7 +779,7 @@ instance
         ofield
           (\x tx -> tx {btbrValidityInterval = (btbrValidityInterval tx) {invalidBefore = x}})
           From
-      bodyFields 9 = field (\x tx -> tx {btbrMint = x}) (D decodeMint)
+      bodyFields 9 = field (\x tx -> tx {btbrMint = x}) From
       bodyFields 11 = ofield (\x tx -> tx {btbrScriptIntegrityHash = x}) From
       bodyFields 14 = field (\x tx -> tx {btbrReqSignerHashes = x}) From
       bodyFields 15 = ofield (\x tx -> tx {btbrTxNetworkId = x}) From

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Core.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Core.hs
@@ -9,14 +9,10 @@ where
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
-import Cardano.Ledger.Val (DecodeMint, EncodeMint)
 import Data.Set (Set)
 import Lens.Micro (Lens', SimpleGetter)
 
-class
-  (ShelleyEraTxBody era, EncodeMint (Value era), DecodeMint (Value era)) =>
-  ShelleyMAEraTxBody era
-  where
+class ShelleyEraTxBody era => ShelleyMAEraTxBody era where
   vldtTxBodyL :: Lens' (TxBody era) ValidityInterval
 
   mintTxBodyL :: Lens' (TxBody era) (MultiAsset (EraCrypto era))

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/Era.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Shelley.Rules
     ShelleyTICKF,
     ShelleyUPEC,
   )
-import Cardano.Ledger.Val (DecodeMint, DecodeNonNegative, EncodeMint, Val, zero)
+import Cardano.Ledger.Val (DecodeNonNegative, Val, zero)
 import Control.DeepSeq (NFData (..))
 import Data.Kind (Type)
 import Data.Set as Set (Set, empty, map)
@@ -72,8 +72,6 @@ class
     Eq (MAValue ma c),
     FromCBOR (MAValue ma c),
     ToCBOR (MAValue ma c),
-    EncodeMint (MAValue ma c),
-    DecodeMint (MAValue ma c),
     NoThunks (MAValue ma c),
     KnownNat (MAProtVer ma),
     MinVersion <= MAProtVer ma,

--- a/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
+++ b/eras/shelley-ma/impl/src/Cardano/Ledger/ShelleyMA/TxBody.hs
@@ -84,10 +84,6 @@ import Cardano.Ledger.ShelleyMA.Era
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
 import Cardano.Ledger.ShelleyMA.TxOut
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val
-  ( DecodeMint (..),
-    EncodeMint (..),
-  )
 import Control.DeepSeq (NFData (..))
 import qualified Data.Map.Strict as Map
 import Data.Proxy
@@ -166,7 +162,7 @@ txSparse (MATxBodyRaw inp out cert wdrl fee (ValidityInterval bot top) up hash f
     !> encodeKeyedStrictMaybe 6 up
     !> encodeKeyedStrictMaybe 7 hash
     !> encodeKeyedStrictMaybe 8 bot
-    !> Omit (== mempty) (Key 9 (E encodeMint frge))
+    !> Omit (== mempty) (Key 9 (To frge))
 
 bodyFields :: EraTxOut era => Word -> Field (MATxBodyRaw era)
 bodyFields 0 = field (\x tx -> tx {matbrInputs = x}) From
@@ -194,7 +190,7 @@ bodyFields 8 =
           }
     )
     From
-bodyFields 9 = field (\x tx -> tx {matbrMint = x}) (D decodeMint)
+bodyFields 9 = field (\x tx -> tx {matbrMint = x}) From
 bodyFields n = invalidField n
 
 initial :: MATxBodyRaw era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
@@ -14,12 +14,10 @@ module Cardano.Ledger.Val
     sumVal,
     adaOnly,
     DecodeNonNegative (..),
-    DecodeMint (..),
-    EncodeMint (..),
   )
 where
 
-import Cardano.Ledger.Binary (Decoder, Encoding, decodeWord64, toCBOR)
+import Cardano.Ledger.Binary (Decoder, decodeWord64)
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Data.Coerce
@@ -144,21 +142,3 @@ instance (DecodeNonNegative a, Compactible a, Show a) => DecodeNonNegative (Comp
   decodeNonNegative = do
     v <- decodeNonNegative
     maybe (fail $ "illegal value: " <> show v) pure (toCompact v)
-
--- =============================================================
-
-class DecodeMint v where
-  decodeMint :: Decoder s v
-
-instance DecodeMint Coin where
-  decodeMint = fail "cannot have coin in mint field"
-
--- =============================================================
-
-class EncodeMint v where
-  encodeMint :: v -> Encoding
-
-instance EncodeMint Coin where
-  -- we expect nothing to be able to successfully decode this
-  -- this is an alternative to throwing an error at encoding
-  encodeMint = toCBOR


### PR DESCRIPTION
These two type classes are remnants of the time when mint field was a `Value` instead of `MultiAsset`. No longer needed. With classes gone also are gone the bogus instances for `Coin`