### PR TITLE
Added support for doctest in cardano-ledger-api

### DIFF
--- a/libs/cardano-ledger-api/Setup.hs
+++ b/libs/cardano-ledger-api/Setup.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -8,9 +8,21 @@ description:
   packages.
 bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
 
+-- Necessary for enabling doctest
+-- See https://hackage.haskell.org/package/cabal-doctest
+build-type:         Custom
+
 license:            Apache-2.0
 author:             IOHK
 maintainer:         operations@iohk.io
+
+-- Custom setup for enabling doctest.
+-- See https://hackage.haskell.org/package/cabal-doctest
+custom-setup
+  setup-depends:
+    , base           >=4 && <5
+    , Cabal
+    , cabal-doctest  ^>=1
 
 source-repository head
   type:     git
@@ -86,3 +98,20 @@ test-suite cardano-ledger-api-test
     tasty,
     tasty-quickcheck,
     QuickCheck,
+
+-- Inspired from https://github.com/input-output-hk/haskell.nix/blob/master/test/cabal-doctests/cabal-doctests-test.cabal
+test-suite doctests
+  hs-source-dirs:    doctests
+  x-doctest-options: --no-magic
+  type:              exitcode-stdio-1.0
+  main-is:           Doctests.hs
+  ghc-options:       -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base     >=4.7 && <5
+    , cardano-ledger-babbage-test
+    , cardano-strict-containers
+    , doctest
+    , template-haskell
+    , QuickCheck
+
+  default-language:  Haskell2010

--- a/libs/cardano-ledger-api/doctests/Doctests.hs
+++ b/libs/cardano-ledger-api/doctests/Doctests.hs
@@ -1,0 +1,18 @@
+-- Inspired from https://hackage.haskell.org/package/cabal-doctest and
+-- https://github.com/input-output-hk/haskell.nix/blob/master/test/cabal-doctests/doctests/Doctests.hs
+module Main where
+
+import Build_doctests (flags, module_sources, pkgs)
+import Data.Foldable (traverse_)
+import System.Environment (unsetEnv)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = do
+  putStrLn ""
+  traverse_ putStrLn args -- optionally print arguments
+  unsetEnv "GHC_ENVIRONMENT" -- see 'Notes'; you may not need this
+  doctest args
+  where
+    args :: [String]
+    args = flags ++ pkgs ++ module_sources -- ++ ["-v"]

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -1,28 +1,32 @@
--- \* Building and inspecting transactions
---
-
 -- | Transaction building and inspecting relies heavily on lenses (`microlens`). Therefore, some
 -- familiarity with those is necessary. However, you can probably go a long way by simply
 -- looking at the examples and try to go from there.
 --
--- Here's an example on how to build a very simple Babbage era unbalanced transaction using the
--- provided interface.
+-- Let's start by defining the GHC extensions and imports.
 --
--- >>> :set -XTypeApplications
+-- >>> :set -XScopedTypeVariables
 -- >>> import Test.QuickCheck
 -- >>> import qualified Data.Sequence.Strict as StrictSeq
--- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+-- >>> import Cardano.Ledger.Api.Era (Babbage)
 -- >>> import Lens.Micro
--- prop> \txOut ->
+-- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
+--
+-- Here's an example on how to build a Babbage era unbalanced transaction containing a single
+-- transaction output using the provided interface.
+--
+-- >>> :{
+-- quickCheck $ \(txOut :: TxOut Babbage) ->
 --     let
 --         -- Defining a Babbage era transaction body with a single random transaction output
 --         txBody = mkBasicTxBody
---                & outputsTxBodyL <>~ StrictSeq.singleton (txOut @Babbage)
+--                & outputsTxBodyL <>~ StrictSeq.singleton txOut
 --         -- Defining a basic transaction with our transaction body
 --         tx = mkBasicTx txBody
 --      in
 --         -- We verify that the transaction's outputs contains our single random output
 --         tx ^. bodyTxL . outputsTxBodyL == StrictSeq.singleton txOut
+-- :}
+-- +++ OK, passed 100 tests.
 module Cardano.Ledger.Api.Tx
   ( -- | Building and inspecting transaction bodies
     module Cardano.Ledger.Api.Tx.Body,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -4,22 +4,31 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
--- \* Building and inspecting transaction outputs
+-- | This module is used for building and inspecting transaction outputs.
+--
+-- You'll find some examples below.
+--
+-- Let's start by defining the GHC extensions and imports.
+--
+-- >>> :set -XTypeApplications
+-- >>> import Cardano.Ledger.Api.Era (Babbage)
+-- >>> import Lens.Micro
+-- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators () -- Neded for doctests only
+-- >>> import Test.QuickCheck -- Needed for doctests only
 --
 -- Here's an example on how to build a very basic Babbage era transaction output with a random
 -- address and value, and without any datum or reference script.
 --
--- >>> :set -XTypeApplications
--- >>> import Test.QuickCheck
--- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
--- >>> import Lens.Micro
--- prop> \addr val ->
+-- >>> :{
+-- quickCheck $ \addr val ->
 --     let
 --         -- Defining a Babbage era transaction output with some random address and value.
 --         txOut = mkBasicTxOut @Babbage addr val
 --      in
 --         -- We verify that the transaction output contains our random address and value.
 --         txOut ^. addrTxOutL == addr && txOut ^. valueTxOutL == val
+-- :}
+-- +++ OK, passed 100 tests.
 module Cardano.Ledger.Api.Tx.Out
   ( module Cardano.Ledger.Api.Scripts.Data,
     EraTxOut (..),


### PR DESCRIPTION
* Added a test-suite for running all doctests in Haddock comments

* Fixed existing "doctest" in cardano-ledger-api's doc which wasn't conforming to the doctest syntax.

Linked to https://github.com/input-output-hk/cardano-ledger/issues/3015, but this PR only enables doctests in `cardano-ledger-api`