### PR TITLE
Replace NominalDiffTime with a newtype wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ in the naming of release branches.
 
 ### Changed
 
+- Replace `NominalDiffTime` with a `newtype` wrapper `NominalDiffTimeMicro`. Remove use of `NominalDiffTime`, as we don't use its full precision. #3208
 - Switched `PlutusDebug` to use a `GADT` with `singletons` for better type-safety. #3167
   - Made `Plutus` imports uniform.
 - Renamed module `Cardano.Ledger.Shelley.Metadata` -> `Cardano.Ledger.Shelley.TxAuxData` #3205

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -28,7 +28,6 @@ module Cardano.Ledger.Shelley.Genesis
     validateGenesis,
     describeValidationErr,
     mkShelleyGlobals,
-    microsecondsToNominalDiffTimeMicro,
     nominalDiffTimeMicroToMicroseconds,
     nominalDiffTimeMicroToSeconds,
     toNominalDiffTimeMicro,
@@ -167,7 +166,7 @@ fromNominalDiffTimeMicro =
 
 toNominalDiffTimeMicroWithRounding :: NominalDiffTime -> NominalDiffTimeMicro
 toNominalDiffTimeMicroWithRounding =
-  microsecondsToNominalDiffTimeMicro . picoToMicro . nominalDiffTimeToSeconds
+  secondsToNominalDiffTimeMicro . picoToMicro . nominalDiffTimeToSeconds
 
 toNominalDiffTimeMicro :: NominalDiffTime -> Maybe NominalDiffTimeMicro
 toNominalDiffTimeMicro ndt
@@ -176,11 +175,8 @@ toNominalDiffTimeMicro ndt
   where
     ndtm = toNominalDiffTimeMicroWithRounding ndt
 
-microsecondsToNominalDiffTimeMicro :: Micro -> NominalDiffTimeMicro
-microsecondsToNominalDiffTimeMicro = NominalDiffTimeMicro
-
-secondsToNominalDiffTimeMicro :: Pico -> NominalDiffTimeMicro
-secondsToNominalDiffTimeMicro = NominalDiffTimeMicro . picoToMicro
+secondsToNominalDiffTimeMicro :: Micro -> NominalDiffTimeMicro
+secondsToNominalDiffTimeMicro = NominalDiffTimeMicro
 
 nominalDiffTimeMicroToMicroseconds :: NominalDiffTimeMicro -> Micro
 nominalDiffTimeMicroToMicroseconds (NominalDiffTimeMicro microseconds) = microseconds

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -289,7 +289,7 @@ testShelleyGenesis =
       sgSlotsPerKESPeriod = slotsPerKESPeriod testGlobals,
       sgMaxKESEvolutions = maxKESEvo testGlobals,
       -- Not important
-      sgSlotLength = secondsToNominalDiffTime 2,
+      sgSlotLength = secondsToNominalDiffTimeMicro 2,
       sgUpdateQuorum = quorum testGlobals,
       sgMaxLovelaceSupply = maxLovelaceSupply testGlobals,
       sgProtocolParams = emptyPParams,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -153,9 +154,7 @@ instance (Era era, Mock (EraCrypto era)) => Arbitrary (Update era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Arbitrary NominalDiffTimeMicro where
-  arbitrary = secondsToNominalDiffTimeMicro <$> arbitrary
-  shrink = fmap secondsToNominalDiffTimeMicro . shrink . nominalDiffTimeMicroToSeconds
+deriving newtype instance Arbitrary NominalDiffTimeMicro
 
 maxMetadatumDepth :: Int
 maxMetadatumDepth = 2

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -153,6 +153,10 @@ instance (Era era, Mock (EraCrypto era)) => Arbitrary (Update era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
+instance Arbitrary NominalDiffTimeMicro where
+  arbitrary = secondsToNominalDiffTimeMicro <$> arbitrary
+  shrink = fmap secondsToNominalDiffTimeMicro . shrink . nominalDiffTimeMicroToSeconds
+
 maxMetadatumDepth :: Int
 maxMetadatumDepth = 2
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.Binary
   ( FromCBOR (..),
     ToCBOR (..),
     Version,
+    allVersions,
     fromNotSharedCBOR,
     shelleyProtVer,
   )
@@ -113,5 +114,12 @@ tests =
           roundTripExpectation @(ShelleyGenesis Mock.C) v cborTrip
       ]
       ++ map testsVersion [shelleyProtVer .. maxBound]
+      ++ map nominalDiffTimeMicroTest allVersions
   where
     v = shelleyProtVer
+
+nominalDiffTimeMicroTest :: Version -> TestTree
+nominalDiffTimeMicroTest version =
+  testGroup
+    ("Version: " ++ show version)
+    $ [testProperty "NominalDiffTimeMicro" $ roundTripExpectation @NominalDiffTimeMicro version cborTrip]

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -151,7 +151,6 @@ test-suite tests
                    , hspec
                    , iproute
                    , primitive
-                   , QuickCheck
                    , tagged
                    , text
                    , testlib

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -64,7 +64,6 @@ module Cardano.Ledger.Binary.Decoding.Decoder
 
     -- *** Time
     decodeUTCTime,
-    decodeNominalDiffTime,
 
     -- *** Network
     decodeIPv4,
@@ -242,7 +241,7 @@ import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
-import Data.Time.Clock (NominalDiffTime, UTCTime (..), picosecondsToDiffTime)
+import Data.Time.Clock (UTCTime (..), picosecondsToDiffTime)
 import qualified Data.VMap as VMap
 import qualified Data.Vector.Generic as VG
 import Data.Word (Word16, Word32, Word64, Word8)
@@ -869,10 +868,6 @@ decodeUTCTime =
         UTCTime
           (fromOrdinalDate year dayOfYear)
           (picosecondsToDiffTime timeOfDayPico)
-
--- | For backwards compatibility we round pico precision to micro
-decodeNominalDiffTime :: Decoder s NominalDiffTime
-decodeNominalDiffTime = fromRational . (% 1_000_000) <$> decodeInteger
 
 --------------------------------------------------------------------------------
 -- Network

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -58,7 +59,7 @@ import Data.ByteString.Short (ShortByteString(SBS))
 #else
 import Data.ByteString.Short.Internal (ShortByteString(SBS))
 #endif
-import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.Fixed (Fixed (..))
 import Data.IP (IPv4, IPv6)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
@@ -159,11 +160,7 @@ instance FromCBOR Double where
 instance FromCBOR Rational where
   fromCBOR = decodeRational
 
-instance FromCBOR Nano where
-  fromCBOR = MkFixed <$> fromCBOR
-
-instance FromCBOR Pico where
-  fromCBOR = MkFixed <$> fromCBOR
+deriving newtype instance Typeable p => FromCBOR (Fixed p)
 
 instance FromCBOR Void where
   fromCBOR = cborError DecoderErrorVoid

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
@@ -70,7 +70,7 @@ import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Tagged (Tagged (Tagged))
 import qualified Data.Text as T
-import Data.Time.Clock (NominalDiffTime, UTCTime (..))
+import Data.Time.Clock (UTCTime (..))
 import Data.Typeable (Proxy (..), Typeable, typeRep)
 import qualified Data.VMap as VMap
 import qualified Data.Vector as V
@@ -164,9 +164,6 @@ instance FromCBOR Nano where
 
 instance FromCBOR Pico where
   fromCBOR = MkFixed <$> fromCBOR
-
-instance FromCBOR NominalDiffTime where
-  fromCBOR = decodeNominalDiffTime
 
 instance FromCBOR Void where
   fromCBOR = cborError DecoderErrorVoid

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
@@ -41,7 +41,6 @@ module Cardano.Ledger.Binary.Encoding.Encoder
 
     -- *** Time
     encodeUTCTime,
-    encodeNominalDiffTime,
 
     -- *** Network
     encodeIPv4,
@@ -97,19 +96,17 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Lazy as BSL
-import Data.Fixed (E12, resolution)
 import Data.Foldable as F (foldMap', foldl')
 import Data.IP (IPv4, IPv6, toHostAddress, toHostAddress6)
 import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Map.Strict as Map
 import Data.Monoid (Sum (..))
-import Data.Proxy (Proxy (Proxy))
 import Data.Ratio (Ratio, denominator, numerator)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Time.Calendar.OrdinalDate (toOrdinalDate)
-import Data.Time.Clock (NominalDiffTime, UTCTime (..), diffTimeToPicoseconds)
+import Data.Time.Clock (UTCTime (..), diffTimeToPicoseconds)
 import qualified Data.VMap as VMap
 import qualified Data.Vector.Generic as VG
 import Data.Word (Word16, Word32, Word64, Word8)
@@ -517,12 +514,6 @@ encodeUTCTime (UTCTime day timeOfDay) =
   where
     (year, dayOfYear) = toOrdinalDate day
     timeOfDayPico = diffTimeToPicoseconds timeOfDay
-
-encodeNominalDiffTime :: NominalDiffTime -> Encoding
-encodeNominalDiffTime = encodeInteger . (`div` 1_000_000) . toPicoseconds
-  where
-    toPicoseconds t =
-      numerator (toRational t * toRational (resolution $ Proxy @E12))
 
 --------------------------------------------------------------------------------
 -- Network

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -140,7 +140,7 @@ import Data.Tagged (Tagged (..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Lazy.Builder (Builder)
-import Data.Time.Clock (NominalDiffTime, UTCTime (..))
+import Data.Time.Clock (UTCTime (..))
 import Data.Typeable (Proxy (..), TypeRep, Typeable, typeRep)
 import qualified Data.VMap as VMap
 import qualified Data.Vector as V
@@ -582,10 +582,6 @@ instance ToCBOR Nano where
 
 instance ToCBOR Pico where
   toCBOR (MkFixed picoseconds) = toCBOR picoseconds
-
--- | For backwards compatibility we round pico precision to micro
-instance ToCBOR NominalDiffTime where
-  toCBOR = encodeNominalDiffTime
 
 instance ToCBOR Natural where
   toCBOR = toCBOR . toInteger

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -123,7 +124,7 @@ import Data.ByteString.Short (ShortByteString(SBS))
 #else
 import Data.ByteString.Short.Internal (ShortByteString(SBS))
 #endif
-import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.Fixed (Fixed (..))
 import Data.Foldable (toList)
 import Data.Functor.Foldable (cata, project)
 import Data.IP (IPv4, IPv6)
@@ -577,11 +578,7 @@ instance ToCBOR a => ToCBOR (Ratio a) where
   toCBOR = encodeRatio toCBOR
   encodedSizeExpr size _ = 1 + size (Proxy @a) + size (Proxy @a)
 
-instance ToCBOR Nano where
-  toCBOR (MkFixed nanoseconds) = toCBOR nanoseconds
-
-instance ToCBOR Pico where
-  toCBOR (MkFixed picoseconds) = toCBOR picoseconds
+deriving newtype instance Typeable p => ToCBOR (Fixed p)
 
 instance ToCBOR Natural where
   toCBOR = toCBOR . toInteger

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
@@ -42,7 +42,7 @@ import Cardano.Slotting.Slot (EpochNo, EpochSize, SlotNo, WithOrigin)
 import Cardano.Slotting.Time (SystemStart)
 import Codec.CBOR.ByteArray (ByteArray (..))
 import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (..))
-import Data.Fixed (Fixed (..), Nano, Pico)
+import Data.Fixed (Nano, Pico)
 import Data.Foldable as F
 import Data.IP (IPv4, IPv6)
 import Data.Int
@@ -55,12 +55,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Tagged (Tagged (Tagged))
-import Data.Time.Clock
-  ( NominalDiffTime,
-    UTCTime (..),
-    nominalDiffTimeToSeconds,
-    secondsToNominalDiffTime,
-  )
+import Data.Time.Clock (UTCTime)
 import qualified Data.VMap as VMap
 import qualified Data.Vector as V
 import qualified Data.Vector.Primitive as VP
@@ -71,24 +66,6 @@ import Numeric.Natural
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Hspec
-import Test.QuickCheck
-
--- | We do not handle the full precision of NominalDiffTime.
-newtype NominalDiffTimeRounded = NominalDiffTimeRounded NominalDiffTime
-  deriving (Show, Eq, ToCBOR, FromCBOR)
-
-instance Arbitrary NominalDiffTimeRounded where
-  arbitrary = secondsToNominalDiffTimeRounded <$> arbitrary
-  shrink = fmap secondsToNominalDiffTimeRounded . shrink . nominalDiffTimeRoundedToSeconds
-
-secondsToNominalDiffTimeRounded :: Pico -> NominalDiffTimeRounded
-secondsToNominalDiffTimeRounded (MkFixed s) =
-  NominalDiffTimeRounded $
-    secondsToNominalDiffTime $
-      MkFixed (1_000_000 * (s `div` 1_000_000))
-
-nominalDiffTimeRoundedToSeconds :: NominalDiffTimeRounded -> Pico
-nominalDiffTimeRoundedToSeconds (NominalDiffTimeRounded ndt) = nominalDiffTimeToSeconds ndt
 
 spec :: Spec
 spec = do
@@ -114,7 +91,6 @@ spec = do
         roundTripSpec @Rational version cborTrip
         roundTripSpec @Nano version cborTrip
         roundTripSpec @Pico version cborTrip
-        roundTripSpec @NominalDiffTimeRounded version cborTrip
         roundTripSpec @UTCTime version cborTrip
         roundTripSpec @IPv4 version cborTrip
         roundTripSpec @IPv6 version cborTrip

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Orphans.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Orphans.hs
@@ -1,11 +1,8 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Orphans where
@@ -24,12 +21,11 @@ import qualified Data.ByteString as Long (ByteString, empty)
 import qualified Data.ByteString.Lazy as Lazy (ByteString, empty)
 import qualified Data.ByteString.Short as Short (ShortByteString, empty, pack)
 import Data.Default.Class (Default (..))
-import Data.Fixed (Fixed (..), Micro)
+import Data.Fixed (Fixed (..))
 import Data.IP (IPv4, IPv6)
 import Data.Proxy
 import qualified Data.Sequence.Strict as SS
 import qualified Data.Text as Text
-import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Text.Read (readEither)
 
@@ -68,9 +64,7 @@ instance SignableRepresentation (Hash.Hash a b) where
 
 -- | TODO: We should upstream instance
 -- HasResolution p => NoThunks (Fixed p) into the nothunks package.
-deriving anyclass instance NoThunks Micro
-
-deriving instance Generic Micro
+deriving newtype instance NoThunks (Fixed p)
 
 -- ===============================================
 -- Blank instance needed to compute Provenance

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Orphans.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Orphans.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Orphans where
@@ -20,10 +24,12 @@ import qualified Data.ByteString as Long (ByteString, empty)
 import qualified Data.ByteString.Lazy as Lazy (ByteString, empty)
 import qualified Data.ByteString.Short as Short (ShortByteString, empty, pack)
 import Data.Default.Class (Default (..))
+import Data.Fixed (Fixed (..), Micro)
 import Data.IP (IPv4, IPv6)
 import Data.Proxy
 import qualified Data.Sequence.Strict as SS
 import qualified Data.Text as Text
+import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Text.Read (readEither)
 
@@ -59,6 +65,12 @@ instance NoThunks WC.XSignature where
 
 instance SignableRepresentation (Hash.Hash a b) where
   getSignableRepresentation = Hash.hashToBytes
+
+-- | TODO: We should upstream instance
+-- HasResolution p => NoThunks (Fixed p) into the nothunks package.
+deriving anyclass instance NoThunks Micro
+
+deriving instance Generic Micro
 
 -- ===============================================
 -- Blank instance needed to compute Provenance

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..))
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
-import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), mkShelleyGlobals)
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), fromNominalDiffTimeMicro, mkShelleyGlobals)
 import Cardano.Ledger.Shelley.LedgerState
   ( EpochState (..),
     FilteredRewards (..),
@@ -131,7 +131,7 @@ mkGlobals genesis pp =
     epochInfoE =
       fixedEpochInfo
         (sgEpochLength genesis)
-        (mkSlotLength $ sgSlotLength genesis)
+        (mkSlotLength . fromNominalDiffTimeMicro . sgSlotLength $ genesis)
 
 -- =========================================================
 -- We would like to benchmark things that are used in the STS system.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
@@ -858,7 +858,7 @@ testShelleyGenesis =
       sgSlotsPerKESPeriod = slotsPerKESPeriod testGlobals,
       sgMaxKESEvolutions = maxKESEvo testGlobals,
       -- Not important
-      sgSlotLength = secondsToNominalDiffTime 2,
+      sgSlotLength = secondsToNominalDiffTimeMicro 2,
       sgUpdateQuorum = quorum testGlobals,
       sgMaxLovelaceSupply = maxLovelaceSupply testGlobals,
       sgProtocolParams = emptyPParams,

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.CompactAddress
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool
 import Cardano.Ledger.Shelley.API.Wallet (getFilteredUTxO, getUTxO)
-import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), mkShelleyGlobals)
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), fromNominalDiffTimeMicro, mkShelleyGlobals)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.State.UTxO
 import Cardano.Ledger.UTxO
@@ -221,7 +221,7 @@ mkGlobals genesis pp =
     epochInfoE =
       fixedEpochInfo
         (sgEpochLength genesis)
-        (mkSlotLength $ sgSlotLength genesis)
+        (mkSlotLength . fromNominalDiffTimeMicro . sgSlotLength $ genesis)
 
 getFilteredOldUTxO ::
   EraTxOut era =>


### PR DESCRIPTION


# Description

Remove CBOR instances of NominalDiffTime and only keep those for the newtype wrapper. This is because we don't use full precision during serialisation.

Closes #3185 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](../CHANGELOG.md)
- [x] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [x] Self-reviewed the diff
