### PR TITLE
optimize TICKF

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,6 @@ to the issue.
 - [ ] Commit sequence broadly makes sense
 - [ ] Commits have useful messages
 - [ ] New tests are added if needed and existing tests are updated
-- [ ] Any changes are noted in the [changelog](../CHANGELOG.md)
+- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
 - [ ] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
 - [ ] Self-reviewed the diff

--- a/docs/adr/2022-12-12_007-optimize-ledger-view.md
+++ b/docs/adr/2022-12-12_007-optimize-ledger-view.md
@@ -1,0 +1,63 @@
+---
+slug: 7
+title: |
+  7. Optimize TICKF
+authors: [Jared Corduan]
+tags: [Accepted]
+---
+
+## Status
+
+Accepted
+
+## Context
+
+Large computations on the epoch boundary are problematic.
+In the past they have led to delayed block production in new epochs.
+We have removed most of the problems surrounding large computations in the ledger on the epoch
+boundary (such as making the reward calculation and the stake distribution calculation incremental),
+but benchmarks from the consensus team still indicate performance problems in the ledger.
+In particular, the `TICKF` transition, which is used for forecasting the ledger state in order
+to check block headers and to check for leadership, still take too long.
+The node needs to check for leadership once per slot (so once per second on mainnet),
+so if `TICKF` takes a second to compute then the node is guaranteed to start skipping leadership checks.
+The performance problems with `TICKF` can exacerbate situations like
+[this](https://github.com/input-output-hk/cardano-node/issues/4421).
+
+Upon examination, the `TICKF` rule is still performing at least one large computation which can
+be optimized, namely computing the per-pool stake distribution from the per-stake-credential
+stake distribution using the delegation relation.
+The computation is currently being done on the epoch boundary when it is first needed,
+but could be performed on the previous epoch boundary.
+In particular, the leadership check appears to be computing it repeatedly on every slot
+crossing the epoch boundary until the first block in the new epoch is made.
+
+The per-pool stake distribution, however, only appears to account for about half of the
+duration of the `TICKF` rule (from our benchmarks).
+
+## Decision
+
+@nfrisby suggested two very helpful optimizations
+(but we take full responsibility for the implementation).
+
+The first suggestion was to create a thunk for the pool distribution on the first epoch
+boundary when the computation is able to be performed.
+This way the node will only have to pay the computational cost once, instead of at every
+slot in a new epoch until the first block is produced.
+In particular, we can add a lazy field to the `SnapShots` record to memoize the computation.
+
+The second suggestion was to strip down `TICKF` to only what is required to compute the 'LedgerView'.
+
+Preliminary benchmarks from the consensus team show that these two optimizations remove the
+problematic behavior on the epoch boundary.
+
+## Consequences
+
+The most dramatic consequence of these two decisions is the rapid leader checks on the epoch
+boundary.
+
+On the negative side, we have now diverged further from the formal specification
+(though it is semantically the same).
+Furthermore, the `TICKF` implementation is less obviously correct, as it has to duplicate logic.
+To combat the problem that `TICKF` could diverge from `TICK` with respect to the
+ledger view, we added a property test.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -117,7 +117,7 @@ import Cardano.Ledger.Shelley.Rules.NewEpoch as X
 import Cardano.Ledger.Shelley.Rules.Pool as X (PoolEnv (..), ShelleyPOOL)
 import Cardano.Ledger.Shelley.Rules.PoolReap as X (ShelleyPOOLREAP)
 import Cardano.Ledger.Shelley.Rules.Ppup as X (PpupEnv (..), ShelleyPPUP)
-import Cardano.Ledger.Shelley.Rules.Tick as X (ShelleyTICK)
+import Cardano.Ledger.Shelley.Rules.Tick as X (ShelleyTICK, ShelleyTICKF)
 import Cardano.Ledger.Shelley.Rules.Utxo as X
   ( ShelleyUTXO,
     UtxoEnv (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -17,10 +17,9 @@ module Cardano.Ledger.Shelley.Rules.NewEpoch
     ShelleyNewEpochPredFailure (..),
     ShelleyNewEpochEvent (..),
     PredicateFailure,
+    updateRewards,
     calculatePoolDistr,
     calculatePoolDistr',
-    updateRewards,
-    calculatePoolStake,
   )
 where
 
@@ -30,12 +29,12 @@ import Cardano.Ledger.BaseTypes
     ShelleyBase,
     StrictMaybe (SJust, SNothing),
   )
-import Cardano.Ledger.Coin (Coin (Coin), CompactForm (CompactCoin), toDeltaCoin)
+import Cardano.Ledger.Coin (toDeltaCoin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.EpochBoundary
-import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
-import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
+import Cardano.Ledger.Keys (KeyRole (Staking))
+import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import Cardano.Ledger.Shelley.AdaPots (AdaPots, totalAdaPotsES)
 import Cardano.Ledger.Shelley.Era (ShelleyNEWEPOCH)
 import Cardano.Ledger.Shelley.LedgerState
@@ -43,18 +42,14 @@ import Cardano.Ledger.Shelley.Rewards (sumRewards)
 import Cardano.Ledger.Shelley.Rules.Epoch
 import Cardano.Ledger.Shelley.Rules.Mir (ShelleyMIR, ShelleyMirEvent, ShelleyMirPredFailure)
 import Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))
-import Cardano.Ledger.Shelley.TxBody (PoolParams (ppVrf))
 import Cardano.Ledger.Slot (EpochNo (EpochNo))
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition
 import Data.Default.Class (Default, def)
 import qualified Data.Map.Strict as Map
-import Data.Ratio ((%))
 import Data.Set (Set)
-import Data.VMap as VMap
 import GHC.Generics (Generic)
 import GHC.Records (HasField)
-import GHC.Word (Word64)
 import NoThunks.Class (NoThunks (..))
 
 data ShelleyNewEpochPredFailure era
@@ -175,8 +170,24 @@ newEpochTransition = do
       es''' <- trans @(EraRule "EPOCH" era) $ TRC ((), es'', e)
       let adaPots = totalAdaPotsES es'''
       tellEvent $ TotalAdaPotsEvent adaPots
-      let ss = esSnapshots es'''
-          pd' = calculatePoolDistr (ssStakeSet ss)
+      let pd' = ssStakeMarkPoolDistr (esSnapshots es)
+      -- The spec sets pd' with:
+      -- pd' = calculatePoolDistr (ssStakeSet $ esSnapshots es'''),
+      --
+      -- This is equivalent to:
+      -- pd' = ssStakeMarkPoolDistr (esSnapshots es)
+      --
+      -- since:
+      --
+      -- \* SNAP rotates `ssStakeMark` to `ssStakeSet`, so
+      -- \* the `ssStakeSet` snapshot in es''' is `ssStakeMark` in es
+      -- \* `ssStakeMarkPoolDistr` is computed by calling `calculatePoolDistr`
+      --    on the `ssStakeMark` snapshot at the previous epoch boundary.
+      -- \* RUPD does not alter `esSnaphots`
+      -- \* MIR does not alter `esSnaphots`
+      --
+      -- This was done to memoize the per-pool stake distribution.
+      -- See ADR-7.
       pure $
         src
           { nesEL = e,
@@ -194,38 +205,6 @@ tellReward ::
   Rule (ShelleyNEWEPOCH era) rtype ()
 tellReward (DeltaRewardEvent (RupdEvent _ m)) | Map.null m = pure ()
 tellReward x = tellEvent x
-
-calculatePoolDistr :: SnapShot c -> PoolDistr c
-calculatePoolDistr = calculatePoolDistr' (const True)
-
-calculatePoolDistr' :: forall c. (KeyHash 'StakePool c -> Bool) -> SnapShot c -> PoolDistr c
-calculatePoolDistr' includeHash (SnapShot stake delegs poolParams) =
-  let Coin total = sumAllStake stake
-      -- total could be zero (in particular when shrinking)
-      nonZeroTotal :: Integer
-      nonZeroTotal = if total == 0 then 1 else total
-      poolStakeMap :: Map.Map (KeyHash 'StakePool c) Word64
-      poolStakeMap = calculatePoolStake includeHash delegs stake
-   in PoolDistr $
-        Map.intersectionWith
-          (\word64 poolparam -> IndividualPoolStake (toInteger word64 % nonZeroTotal) (ppVrf poolparam))
-          poolStakeMap
-          (VMap.toMap poolParams)
-
--- | Sum up the Coin (as CompactForm Coin = Word64) for each StakePool
-calculatePoolStake ::
-  (KeyHash 'StakePool c -> Bool) ->
-  VMap VB VB (Credential 'Staking c) (KeyHash 'StakePool c) ->
-  Stake c ->
-  Map.Map (KeyHash 'StakePool c) Word64
-calculatePoolStake includeHash delegs stake = VMap.foldlWithKey accum Map.empty delegs
-  where
-    accum ans cred keyHash =
-      if includeHash keyHash
-        then case VMap.lookup cred (unStake stake) of
-          Nothing -> ans
-          Just (CompactCoin c) -> Map.insertWith (+) keyHash c ans
-        else ans
 
 instance
   ( STS (ShelleyEPOCH era),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -24,8 +24,9 @@ import Cardano.Ledger.Core (EraTxOut)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.EpochBoundary
   ( SnapShot (ssDelegations, ssStake),
-    SnapShots (ssFee, ssStakeGo, ssStakeMark, ssStakeSet),
+    SnapShots (..),
     Stake (unStake),
+    calculatePoolDistr,
     emptySnapShots,
   )
 import Cardano.Ledger.Era (EraCrypto)
@@ -103,8 +104,10 @@ snapTransition = do
      in StakeDistEvent stakeMap
 
   pure $
-    s
+    SnapShots
       { ssStakeMark = istakeSnap,
+        ssStakeMarkPoolDistr = calculatePoolDistr istakeSnap,
+        -- ssStakeMarkPoolDistr exists for performance reasons, see ADR-7
         ssStakeSet = ssStakeMark s,
         ssStakeGo = ssStakeSet s,
         ssFee = fees

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -20,14 +20,14 @@ module Cardano.Ledger.Shelley.Rules.Tick
     PredicateFailure,
     adoptGenesisDelegs,
     ShelleyTICKF,
-    ShelleyTickfPredFailure (..),
+    ShelleyTickfPredFailure,
     validatingTickTransition,
   )
 where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfoPure)
 import Cardano.Ledger.Core
-import Cardano.Ledger.EpochBoundary (SnapShots (ssStakeMark))
+import Cardano.Ledger.EpochBoundary (SnapShots (ssStakeMark, ssStakeMarkPoolDistr))
 import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.Shelley.Era (ShelleyTICK, ShelleyTICKF)
 import Cardano.Ledger.Shelley.LedgerState
@@ -188,11 +188,13 @@ bheadTransition = do
 
   nes' <- validatingTickTransition @ShelleyTICK nes slot
 
-  -- Here we force the evaluation of the mark snapshot.
+  -- Here we force the evaluation of the mark snapshot
+  -- and the per-pool stake distribution.
   -- We do NOT force it in the TICKF and TICKN rule
   -- so that it can remain a thunk when the consensus
   -- layer computes the ledger view across the epoch boundary.
   let !_ = ssStakeMark . esSnapshots . nesEs $ nes'
+      !_ = ssStakeMarkPoolDistr . esSnapshots . nesEs $ nes'
 
   ru'' <-
     trans @(EraRule "RUPD" era) $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -22,6 +24,7 @@ module Cardano.Ledger.Shelley.Rules.Tick
     ShelleyTICKF,
     ShelleyTickfPredFailure,
     validatingTickTransition,
+    validatingTickTransitionFORECAST,
   )
 where
 
@@ -37,7 +40,10 @@ import Cardano.Ledger.Shelley.LedgerState
     FutureGenDeleg (..),
     LedgerState (..),
     NewEpochState (..),
+    PPUPState (..),
     PulsingRewUpdate,
+    UTxOState (..),
+    UpecState (..),
   )
 import Cardano.Ledger.Shelley.Rules.NewEpoch
   ( ShelleyNEWEPOCH,
@@ -50,11 +56,13 @@ import Cardano.Ledger.Shelley.Rules.Rupd
     ShelleyRUPD,
     ShelleyRupdPredFailure,
   )
-import Cardano.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
+import Cardano.Ledger.Shelley.Rules.Upec (ShelleyUPEC, ShelleyUpecPredFailure)
+import Cardano.Ledger.Slot (EpochNo (unEpochNo), SlotNo, epochInfoEpoch)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
 import qualified Data.Map.Strict as Map
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
@@ -167,6 +175,63 @@ validatingTickTransition nes slot = do
 
   pure $ nes' {nesEs = es''}
 
+-- | This is a limited version of 'validatingTickTransition' which is only suitable
+-- for the future ledger view.
+validatingTickTransitionFORECAST ::
+  forall tick era.
+  ( State (tick era) ~ NewEpochState era,
+    BaseM (tick era) ~ ShelleyBase,
+    State (EraRule "UPEC" era) ~ UpecState era,
+    Signal (EraRule "UPEC" era) ~ (),
+    Environment (EraRule "UPEC" era) ~ EpochState era,
+    Embed (EraRule "UPEC" era) (tick era),
+    STS (tick era)
+  ) =>
+  NewEpochState era ->
+  SlotNo ->
+  TransitionRule (tick era)
+validatingTickTransitionFORECAST nes slot = do
+  -- This whole function is a specialization of an inlined 'NEWEPOCH'.
+  --
+  -- The ledger view, 'LedgerView', is built entirely from the 'nesPd' and 'esPp' and
+  -- 'dsGenDelegs', so the correctness of 'validatingTickTransitionFORECAST' only
+  -- depends on getting these three fields correct.
+
+  epoch <- liftSTS $ do
+    ei <- asks epochInfoPure
+    epochInfoEpoch ei slot
+
+  let es = nesEs nes
+      ss = esSnapshots es
+
+  -- the relevant 'NEWEPOCH' logic
+  let pd' = ssStakeMarkPoolDistr ss
+
+  -- note that the genesis delegates are updated not only on the epoch boundary.
+  if unEpochNo epoch /= unEpochNo (nesEL nes) + 1
+    then pure $ nes {nesEs = adoptGenesisDelegs es slot}
+    else do
+      -- We can skip 'SNAP'; we already have the equivalent pd'.
+
+      -- We can skip 'MIR' and 'POOLREAP';
+      -- we don't need to do the checks:
+      -- if the checks would fail, then the node will fail in the 'TICK' rule
+      -- if it ever then node tries to validate blocks for which the
+      -- return value here was used to validate their headers.
+
+      let pp = esPp es
+          updates = utxosPpups . lsUTxOState . esLState $ es
+      UpecState pp' _ <-
+        trans @(EraRule "UPEC" era) $
+          TRC (es, UpecState pp updates, ())
+      let es' = (adoptGenesisDelegs es slot) {esPp = pp'}
+
+      pure $!
+        nes
+          { nesPd = pd',
+            nesEs = es'
+          }
+
 bheadTransition ::
   forall era.
   ( Embed (EraRule "NEWEPOCH" era) (ShelleyTICK era),
@@ -232,35 +297,37 @@ to tick the ledger state to a future slot.
 ------------------------------------------------------------------------------}
 
 newtype ShelleyTickfPredFailure era
-  = TickfNewEpochFailure (PredicateFailure (EraRule "NEWEPOCH" era)) -- Subtransition Failures
+  = TickfUpecFailure (PredicateFailure (EraRule "UPEC" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
   ( Era era,
-    Show (PredicateFailure (EraRule "NEWEPOCH" era))
+    Show (PredicateFailure (EraRule "UPEC" era))
   ) =>
   Show (ShelleyTickfPredFailure era)
 
 deriving stock instance
   ( Era era,
-    Eq (PredicateFailure (EraRule "NEWEPOCH" era))
+    Eq (PredicateFailure (EraRule "UPEC" era))
   ) =>
   Eq (ShelleyTickfPredFailure era)
 
 instance
-  ( NoThunks (PredicateFailure (EraRule "NEWEPOCH" era))
+  ( NoThunks (PredicateFailure (EraRule "UPEC" era))
   ) =>
   NoThunks (ShelleyTickfPredFailure era)
 
 newtype ShelleyTickfEvent era
-  = TickfNewEpochEvent (Event (EraRule "NEWEPOCH" era)) -- Subtransition Events
+  = TickfUpecEvent (Event (EraRule "UPEC" era)) -- Subtransition Events
 
 instance
   ( Era era,
-    Embed (EraRule "NEWEPOCH" era) (ShelleyTICKF era),
-    Environment (EraRule "NEWEPOCH" era) ~ (),
-    State (EraRule "NEWEPOCH" era) ~ NewEpochState era,
-    Signal (EraRule "NEWEPOCH" era) ~ EpochNo
+    EraPParams era,
+    State (EraRule "PPUP" era) ~ PPUPState era,
+    Signal (EraRule "UPEC" era) ~ (),
+    State (EraRule "UPEC" era) ~ UpecState era,
+    Environment (EraRule "UPEC" era) ~ EpochState era,
+    Embed (EraRule "UPEC" era) (ShelleyTICKF era)
   ) =>
   STS (ShelleyTICKF era)
   where
@@ -279,15 +346,16 @@ instance
   transitionRules =
     [ do
         TRC ((), nes, slot) <- judgmentContext
-        validatingTickTransition nes slot
+        validatingTickTransitionFORECAST nes slot
     ]
 
 instance
-  ( STS (ShelleyNEWEPOCH era),
-    PredicateFailure (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochPredFailure era,
-    Event (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochEvent era
+  ( Era era,
+    STS (ShelleyUPEC era),
+    PredicateFailure (EraRule "UPEC" era) ~ ShelleyUpecPredFailure era,
+    Event (EraRule "UPEC" era) ~ Void
   ) =>
-  Embed (ShelleyNEWEPOCH era) (ShelleyTICKF era)
+  Embed (ShelleyUPEC era) (ShelleyTICKF era)
   where
-  wrapFailed = TickfNewEpochFailure
-  wrapEvent = TickfNewEpochEvent
+  wrapFailed = TickfUpecFailure
+  wrapEvent = TickfUpecEvent

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -222,7 +222,8 @@ registerGenesisStaking
           { esLState = newLedgerState,
             esSnapshots =
               (esSnapshots oldEpochState)
-                { ssStakeMark = initSnapShot
+                { ssStakeMark = initSnapShot,
+                  ssStakeMarkPoolDistr = newPoolDistr
                 }
           }
       newLedgerState =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -378,7 +378,12 @@ instance Crypto c => Arbitrary (SnapShot c) where
   shrink = genericShrink
 
 instance Crypto c => Arbitrary (SnapShots c) where
-  arbitrary = genericArbitraryU
+  arbitrary = do
+    mark <- arbitrary
+    set <- arbitrary
+    go <- arbitrary
+    fee <- arbitrary
+    pure $ SnapShots mark (calculatePoolDistr mark) set go fee
   shrink = genericShrink
 
 instance Arbitrary PerformanceEstimate where

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -66,7 +66,7 @@ import Cardano.Ledger.Credential
   ( Credential (..),
     Ptr,
   )
-import Cardano.Ledger.EpochBoundary (SnapShot, SnapShots (..))
+import Cardano.Ledger.EpochBoundary (SnapShot, SnapShots (..), calculatePoolDistr)
 import Cardano.Ledger.Era (Era, EraCrypto)
 import Cardano.Ledger.Keys
   ( GenDelegPair,
@@ -610,6 +610,7 @@ newSnapshot snap fee cs = cs {chainNes = nes'}
     snaps =
       SnapShots
         { ssStakeMark = snap,
+          ssStakeMarkPoolDistr = calculatePoolDistr snap,
           ssStakeSet = ssMark,
           ssStakeGo = ssSet,
           ssFee = fee

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
@@ -6,18 +6,34 @@
 module Test.Cardano.Ledger.Shelley.RulesTests
   ( chainExamples,
     multisigExamples,
+    testTickF,
   )
 where
 
-import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (hashScript)
 import Cardano.Ledger.Credential (pattern ScriptHashObj)
 import Cardano.Ledger.Keys (asWitness, hashKey, vKey)
+import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Shelley.API (ShelleyTICK, ShelleyTICKF)
+import Cardano.Ledger.Shelley.LedgerState
+  ( EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    UTxOState (..),
+    obligationDPState,
+  )
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..)) -- _maxTxSize getField
+import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..), RewardUpdate (..))
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
 import Cardano.Ledger.Shelley.TxBody (RewardAcnt (..), Wdrl (..))
+import Cardano.Ledger.Slot (EpochNo (..))
+import Cardano.Protocol.TPraos.API (GetLedgerView (..))
+import Control.State.Transition.Extended (TRC (..))
 import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Cardano.Ledger.Shelley.Examples (testCHAINExample)
@@ -41,8 +57,15 @@ import Test.Cardano.Ledger.Shelley.MultiSigExamples
     applyTxWithScript,
     bobOnly,
   )
+import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
+-- EraIndepGenerators is neded for Arbitrary NewEpochState
+import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
+-- Generators is neded for Arbitrary ShelleyPParams
+import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, runShelleyBase, slotFromEpoch)
+import Test.QuickCheck (Property, discard, (===))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
+import Test.Tasty.QuickCheck (testProperty)
 
 chainExamples :: TestTree
 chainExamples =
@@ -520,3 +543,49 @@ testRwdAliceSignsAlone''' =
         )
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
+
+-- | The reward aggregation bug described in the Shelley ledger spec in
+-- section 17.4 (in the Errata) resulted in needing to use 'aggregatedRewards' to change
+-- the behavior of how rewards are collected starting at protocol version 3.
+-- Instead of collecting a `Coin` for each stake credential, we collect 'Set Reward'.
+-- In major protocol version 2, it is impossible for this set to be empty, but sadly this
+-- property is not enforced in the types. For this reason, the property test
+-- 'propTickfPerservesLedgerView' removes these empty sets from an otherwise arbitrary
+-- 'NewEpochState'.
+filterEmptyRewards :: NewEpochState Shelley -> NewEpochState Shelley
+filterEmptyRewards (NewEpochState el bprev bcur es ru pd stash) =
+  NewEpochState el bprev bcur es ru' pd stash
+  where
+    removeEmptyRewards = Map.filter $ not . Set.null
+    ru' = case ru of
+      SNothing -> SNothing
+      SJust (Pulsing _ _) -> SNothing
+      SJust (Complete rewardUpdate) ->
+        SJust . Complete $ rewardUpdate {rs = removeEmptyRewards (rs rewardUpdate)}
+
+setDepositsToObligation :: NewEpochState Shelley -> NewEpochState Shelley
+setDepositsToObligation (NewEpochState el bprev bcur (EpochState as ss ls ppp pp nm) ru pd stash) =
+  NewEpochState el bprev bcur (EpochState as ss ls' ppp pp nm) ru pd stash
+  where
+    LedgerState (UTxOState utxo _deposited fees ppups stakeDistr) dpstate = ls
+    deposited = obligationDPState dpstate
+    ls' = LedgerState (UTxOState utxo deposited fees ppups stakeDistr) dpstate
+
+-- | This property test checks the correctness of the TICKF transation.
+-- TICKF is used by the consensus layer to get a ledger view in a computationally
+-- cheaper way than using the TICK rule.
+-- Therefore TICKF and TICK need to compute the same ledger view.
+propTickfPerservesLedgerView :: NewEpochState Shelley -> Property
+propTickfPerservesLedgerView nes =
+  let (EpochNo e) = nesEL nes
+      slot = slotFromEpoch (EpochNo $ e + 1)
+      nes' = (setDepositsToObligation . filterEmptyRewards) nes
+      tickNes = runShelleyBase $ applySTSTest @(ShelleyTICK Shelley) (TRC ((), nes', slot))
+      tickFNes = runShelleyBase $ applySTSTest @(ShelleyTICKF Shelley) (TRC ((), nes', slot))
+   in fromMaybe discard $ do
+        Right tickNes' <- pure tickNes
+        Right tickFNes' <- pure tickFNes
+        pure $ currentLedgerView tickNes' === currentLedgerView tickFNes'
+
+testTickF :: TestTree
+testTickF = testProperty "TICKF properties" propTickfPerservesLedgerView

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -64,6 +64,7 @@ import Cardano.Ledger.EpochBoundary
   ( SnapShot (..),
     SnapShots (..),
     Stake (..),
+    calculatePoolDistr,
   )
 import Cardano.Ledger.Era (EraCrypto (..))
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
@@ -1309,7 +1310,7 @@ tests =
        in checkEncodingCBOR
             shelleyProtVer
             "snapshots"
-            (SnapShots mark set go fs)
+            (SnapShots mark (calculatePoolDistr mark) set go fs)
             ( T (TkListLen 4)
                 <> S mark
                 <> S set
@@ -1352,7 +1353,7 @@ tests =
               }
           ps = [(hashKey $ vKey testStakePoolKey, params)]
           fs = Coin 123
-          ss = SnapShots mark set go fs
+          ss = SnapShots mark (calculatePoolDistr mark) set go fs
           ls = def
           pps = emptyPParams
           bs = Map.singleton (hashKey $ vKey testStakePoolKey) 1

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -10,7 +10,7 @@ import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
 import Test.Cardano.Ledger.Shelley.Pretty (prettyTest)
 import Test.Cardano.Ledger.Shelley.PropertyTests (depositTests, minimalPropertyTests, propertyTests)
 import Test.Cardano.Ledger.Shelley.Rewards (rewardTests)
-import Test.Cardano.Ledger.Shelley.RulesTests (chainExamples, multisigExamples)
+import Test.Cardano.Ledger.Shelley.RulesTests (chainExamples, multisigExamples, testTickF)
 import Test.Cardano.Ledger.Shelley.SafeHash (safeHashTest)
 import qualified Test.Cardano.Ledger.Shelley.Serialisation as Serialisation
 import Test.Cardano.Ledger.Shelley.UnitTests (unitTests)
@@ -33,6 +33,7 @@ mainTests =
       Serialisation.tests 5,
       chainExamples,
       multisigExamples,
+      testTickF,
       unitTests,
       prettyTest,
       safeHashTest

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -884,7 +884,7 @@ ppSnapShot (SnapShot st deleg params) =
     ]
 
 ppSnapShots :: SnapShots c -> PDoc
-ppSnapShots (SnapShots mark set go fees) =
+ppSnapShots (SnapShots mark _markPD set go fees) =
   ppRecord
     "SnapShots"
     [ ("pstakeMark", ppSnapShot mark),

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
@@ -25,7 +25,12 @@ import Cardano.Ledger.Binary (FromCBOR (..), decodeFullDecoder)
 import Cardano.Ledger.Coin (DeltaCoin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
-import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..))
+import Cardano.Ledger.EpochBoundary
+  ( SnapShot (..),
+    SnapShots (..),
+    calculatePoolDistr,
+    calculatePoolStake,
+  )
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), fromNominalDiffTimeMicro, mkShelleyGlobals)
 import Cardano.Ledger.Shelley.LedgerState
@@ -47,10 +52,8 @@ import Cardano.Ledger.Shelley.Rules
     ShelleyNEWEPOCH,
     ShelleyTICKF,
     adoptGenesisDelegs,
-    calculatePoolDistr,
-    calculatePoolStake,
     updateRewards,
-    validatingTickTransition,
+    validatingTickTransitionFORECAST,
   )
 import Cardano.Ledger.Slot (EpochNo, SlotNo (..))
 import Cardano.Slotting.EpochInfo (fixedEpochInfo)
@@ -177,7 +180,7 @@ tickfR2 ::
   Cardano.Slotting.Slot.SlotNo ->
   NewEpochState CurrentEra ->
   NewEpochState CurrentEra
-tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransition @ShelleyTICKF nes slot)
+tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransitionFORECAST @ShelleyTICKF nes slot)
 
 mirR :: Globals -> EpochState CurrentEra -> EpochState CurrentEra
 mirR globals es' = liftApplySTS globals (applySTS @(ShelleyMIR CurrentEra) (TRC ((), es', ())))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -43,11 +43,7 @@ import Cardano.Ledger.BaseTypes (BlocksMade (..))
 import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.EpochBoundary
-  ( SnapShot (..),
-    SnapShots (..),
-    Stake (..),
-  )
+import Cardano.Ledger.EpochBoundary (SnapShots, emptySnapShots)
 import Cardano.Ledger.Era (Era (..))
 import Cardano.Ledger.Keys
   ( GenDelegs (..),
@@ -101,7 +97,6 @@ import qualified Data.Maybe as Maybe
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Text (Text)
 import qualified Data.UMap as UMap
-import qualified Data.VMap as VMap
 import GHC.Natural (Natural)
 import Test.Cardano.Ledger.Generic.PrettyCore
   ( PrettyC (..),
@@ -190,15 +185,6 @@ blocksMadeZero = BlocksMade Map.empty
 poolDistrZero :: PoolDistr c
 poolDistrZero = PoolDistr Map.empty
 
-stakeZero :: Stake c
-stakeZero = Stake VMap.empty
-
-snapShotZero :: SnapShot c
-snapShotZero = SnapShot stakeZero VMap.empty VMap.empty
-
-snapShotsZero :: SnapShots c
-snapShotsZero = SnapShots snapShotZero snapShotZero snapShotZero (Coin 0)
-
 accountStateZero :: AccountState
 accountStateZero = AccountState (Coin 0) (Coin 0)
 
@@ -258,7 +244,7 @@ ledgerStateZero :: Reflect era => LedgerState era
 ledgerStateZero = LedgerState uTxOStateZero dPStateZero
 
 epochStateZero :: Reflect era => EpochState era
-epochStateZero = EpochState accountStateZero snapShotsZero ledgerStateZero pParamsZero pParamsZero nonMyopicZero
+epochStateZero = EpochState accountStateZero emptySnapShots ledgerStateZero pParamsZero pParamsZero nonMyopicZero
 
 newEpochStateZero :: forall era. Reflect era => NewEpochState era
 newEpochStateZero =
@@ -299,7 +285,7 @@ mNewEpochStateZero =
       -- below here NO EFFECT until we model EpochBoundary
       mFPoolParams = Map.empty,
       mRetiring = Map.empty,
-      mSnapshots = snapShotsZero,
+      mSnapshots = emptySnapShots,
       mEL = EpochNo 0,
       mBprev = Map.empty,
       mBcur = Map.empty,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxBody (certs')
 import Cardano.Ledger.BaseTypes (BlocksMade (..), Globals)
 import Cardano.Ledger.Core
-import Cardano.Ledger.EpochBoundary (SnapShots (..))
+import Cardano.Ledger.EpochBoundary (SnapShots (..), calculatePoolDistr)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
 import Cardano.Ledger.Pretty
@@ -221,7 +221,7 @@ makeEpochState gstate ledgerstate =
 
 snaps :: EraTxOut era => LedgerState era -> SnapShots (EraCrypto era)
 snaps (LedgerState UTxOState {utxosUtxo = u, utxosFees = f} (DPState dstate pstate)) =
-  SnapShots snap snap snap f
+  SnapShots snap (calculatePoolDistr snap) snap snap f
   where
     snap = stakeDistr u dstate pstate
 

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -358,6 +358,7 @@ getSnapShotsNoSharing (Entity epochStateId EpochState {epochStateSnapShotsFee}) 
   pure $
     EpochBoundary.SnapShots
       { ssStakeMark = mark,
+        ssStakeMarkPoolDistr = EpochBoundary.calculatePoolDistr mark,
         ssStakeSet = set,
         ssStakeGo = go,
         ssFee = epochStateSnapShotsFee
@@ -438,6 +439,7 @@ getSnapShotsWithSharing (Entity epochStateId EpochState {epochStateSnapShotsFee}
   pure $
     EpochBoundary.SnapShots
       { ssStakeMark = mark,
+        ssStakeMarkPoolDistr = EpochBoundary.calculatePoolDistr mark,
         ssStakeSet = set,
         ssStakeGo = go,
         ssFee = epochStateSnapShotsFee


### PR DESCRIPTION
# Description

This PR optimizes the `TICKF` transition, particularly for the problematically slow computations on the epoch boundary. See the ADR in this PR for more context. See also #3034.

This PR consists of four commits: one for each of the two optimizations mentioned in the ADR, one for the ADR, and one to fix a broken link in the PR template.

I did not update the changelog since all the changes are invisible outside of this code base.

replaces #3140 and #3141

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](../CHANGELOG.md)
- [x] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [x] Self-reviewed the diff
