### PR TITLE
Adjust deposits event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ in the naming of release branches.
 - Moved thet `RewardType` and `Reward` types from the `Cardano.Ledger.Shelley.Reward` module in the
   `cardano-ledger-shelley` package into a new module `Cardano.Ledger.Reward`
   inside the `cardano-ledger-core` package. #3059
+- Added the tx hash to the `TotalDeposits` event and replaced the deposits by the deposits change #3212
 
 ### Removed
 

--- a/docs/LedgerEvents.md
+++ b/docs/LedgerEvents.md
@@ -94,11 +94,12 @@ It is related to the other rewards events by the property:
 RupdEvent - RestrainedRewards = Total
 ```
 
-### `TotalDeposits totalDeposits`
+### `TotalDeposits txHash depositChange`
 
 This event happens for every transaction, it contains the sum of all the deposits
 paid by the given transaction (both stake credential registration deposits and
-stake pool registration deposits).
+stake pool registration deposits) minus the sum of all refunds. It also contains
+the transaction hash.
 
 ### `RegisterPool poolID`
 This event happens for every new stake pool registration certificate.


### PR DESCRIPTION
# Description

The tx hash is used to associate the event with the tx since the events within a block can appear out of order. The adjustment from deposits to deposits change is useful for db-sync.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](../CHANGELOG.md)
- [x] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [x] Self-reviewed the diff
