### PR TITLE
Revert failing to deserialize ptr addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ in the naming of release branches.
 ### Changed
 
 - Renamed module `Cardano.Ledger.Shelley.Metadata` -> `Cardano.Ledger.Shelley.TxAuxData` #3205
-- Changed `FromCBOR` instance in `Babbage.TxOut` to fail pointer address deserialization starting with protocol version 9: #3174
 - Updated `Conway` low protocol version to 9 and `Babbage` high protocol version to 8: #3174
 - Fixed mismathed parenthesis in the `Show` instance for `Ptr`: #3184.
 - Moved Cardano.Ledger.Shelley.LedgerState(DPState) to Cardano.Ledger(DPState) in Core

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -52,7 +52,6 @@ library
     cardano-slotting,
     containers,
     data-default-class,
-    microlens,
     plutus-tx,
     cardano-ledger-shelley-test,
     cardano-ledger-shelley,

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
@@ -1,73 +1,27 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Test.Cardano.Ledger.Conway.Serialisation.Roundtrip (allprops) where
 
-import Cardano.Ledger.Babbage (BabbageTxOut)
-import Cardano.Ledger.BaseTypes (natVersion)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import Cardano.Ledger.Core (Era (..), EraTxOut, Script, TxOut, Value, addrTxOutL, eraProtVerHigh)
+import Cardano.Ledger.Core (Era (..), eraProtVerHigh)
 import Data.Data (Proxy (..), typeRep)
-import Data.List (isInfixOf)
-import Lens.Micro ((&), (.~))
-import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Conway.Serialisation.Generators ()
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
-import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators (genNonPtrAddress, genPtrAddress)
-import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import Test.QuickCheck (Arbitrary, Property, counterexample, forAll)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 allprops ::
   forall e.
-  ( EraTxOut e,
-    TxOut e ~ BabbageTxOut e,
-    Mock (EraCrypto e),
-    Arbitrary (Value e),
-    Arbitrary (Script e)
+  ( Era e
   ) =>
   TestTree
 allprops =
   testGroup
     (show $ typeRep (Proxy @e))
     [ testProperty "ConwayGenesis" $
-        roundTripCborExpectation @(ConwayGenesis (EraCrypto e)) (eraProtVerHigh @e),
-      testProperty "conway/TxOut with pointer addresses" (ptrAddrTxOutNotDeserialized @e),
-      testProperty "conway/TxOut without pointer addresses" (nonPtrAddrTxOutDeserialized @e)
+        roundTripCborExpectation @(ConwayGenesis (EraCrypto e)) (eraProtVerHigh @e)
     ]
-
-ptrAddrTxOutNotDeserialized ::
-  forall e.
-  EraTxOut e =>
-  TxOut e ->
-  Property
-ptrAddrTxOutNotDeserialized txOut =
-  forAll (genPtrAddress @(EraCrypto e)) $ \ptrAddr ->
-    do
-      let ptrAddrTxOut = txOut & addrTxOutL .~ ptrAddr
-      let messageMatch s =
-            counterexample ("Unexpected decoder failure message: " ++ s) $
-              "Pointer addresses not supported starting with version 9" `isInfixOf` s
-      case roundTrip (natVersion @9) (cborTrip @(TxOut e)) ptrAddrTxOut of
-        Left (RoundTripFailure _ _ _ _ _ _ (Just e)) -> messageMatch (show e)
-        _ -> counterexample "Pointer address deserialization results in RoundTripFailure" False
-
-nonPtrAddrTxOutDeserialized ::
-  forall e.
-  EraTxOut e =>
-  TxOut e ->
-  Property
-nonPtrAddrTxOutDeserialized txOut =
-  forAll (genNonPtrAddress @(EraCrypto e)) $ \nonPtrAddr ->
-    do
-      let nonPtrAddrTxOut = txOut & addrTxOutL .~ nonPtrAddr
-      case roundTrip (natVersion @9) (cborTrip @(TxOut e)) nonPtrAddrTxOut of
-        Left err -> counterexample ("Unexpected decoder failure: " ++ show err) False
-        Right _ -> counterexample "Non-pointer address deserialize successfuly" True

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -16,8 +16,6 @@
 
 module Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators
   ( genCoherentBlock,
-    genNonPtrAddress,
-    genPtrAddress,
     MockGen,
     maxTxWits,
   )
@@ -186,14 +184,6 @@ instance Era era => Arbitrary (ShelleyTxAuxData era) where
 
 maxTxWits :: Int
 maxTxWits = 5
-
-genPtrAddress :: Crypto c => Gen (Addr c)
-genPtrAddress = Addr <$> arbitrary <*> arbitrary <*> (StakeRefPtr <$> arbitrary)
-
-genNonPtrAddress :: Crypto c => Gen (Addr c)
-genNonPtrAddress = oneof [AddrBootstrap <$> arbitrary, Addr <$> arbitrary <*> arbitrary <*> genNonPtrStakeRef]
-  where
-    genNonPtrStakeRef = oneof [StakeRefBase <$> arbitrary, pure StakeRefNull]
 
 instance
   (Core.EraTxOut era, Mock (EraCrypto era), Arbitrary (Core.Value era)) =>

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -21,7 +21,6 @@ module Cardano.Ledger.Address
     BootstrapAddress (..),
     bootstrapAddressAttrsSize,
     isBootstrapRedeemer,
-    isPtrAddr,
     getNetwork,
     RewardAcnt (..),
     serialiseRewardAcnt,
@@ -379,10 +378,6 @@ bootstrapAddressAttrsSize (BootstrapAddress addr) =
 isBootstrapRedeemer :: BootstrapAddress c -> Bool
 isBootstrapRedeemer (BootstrapAddress (Byron.Address _ _ Byron.ATRedeem)) = True
 isBootstrapRedeemer _ = False
-
-isPtrAddr :: Addr era -> Bool
-isPtrAddr (Addr _ _ (StakeRefPtr _)) = True
-isPtrAddr _ = False
 
 putPtr :: Ptr -> Put
 putPtr (Ptr slot (TxIx txIx) (CertIx certIx)) = do


### PR DESCRIPTION
# Description

Reverts failing to deserialize pointer addresses.  This will be implemented by failing to resolve them.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](../CHANGELOG.md)
- [ ] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [ ] Self-reviewed the diff
