### PR TITLE
Cache secp256k1

### DIFF
--- a/.github/workflows/build-secp256k1.bash
+++ b/.github/workflows/build-secp256k1.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+# I don't understand why this just vanishes.
+export PATH=/usr/bin:$PATH
+
+echo ======== env =======
+env | grep CI_
+echo ========
+echo $PATH
+echo ========
+
+if [[ ! -d secp256k1/.git ]]; then
+  git clone https://github.com/bitcoin-core/secp256k1
+
+  cd secp256k1
+  git switch $SECP256K1_REF --detach
+  ./autogen.sh
+  ./configure $CI_SECP_FLAGS --prefix=/usr --enable-module-schnorrsig --enable-experimental
+  make
+  make check
+else
+  cd secp256k1
+fi
+
+$CI_SECP_INSTALL_CMD make install

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
+    env:
+      # current ref from: 27.02.2022
+      SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+
+      SECP_CACHE_VERSION: 2022-12-24
+
     defaults:
       run:
         shell: bash
@@ -33,7 +39,7 @@ jobs:
         gem install cddl -v 0.8.15
         gem install cbor-diag
 
-    - name: Install libsodium (Linux)
+    - name: Install libsodium
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
@@ -41,22 +47,20 @@ jobs:
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
-    - name: Install secp256k1 (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get -y install autoconf automake libtool
-        mkdir secp256k1-sources
-        cd secp256k1-sources
-        git clone https://github.com/bitcoin-core/secp256k1.git
-        cd secp256k1
-        git reset --hard $SECP256K1_REF
-        ./autogen.sh
-        ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental
-        make
-        make check
-        sudo make install
-        cd ../..
+    - uses: actions/cache@v3
+      name: "Cache secp256k1"
+      with:
+        path: secp256k1
+        key: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
+        restore-keys: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
 
+    - name: "Install secp256k1"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        CI_SECP_FLAGS: "--prefix=/usr/local"
+        CI_SECP_INSTALL_CMD: sudo
+      run: bash .github/workflows/build-secp256k1.bash
 
     - uses: haskell/actions/setup@v1
       id: setup-haskell


### PR DESCRIPTION
# Description

Reduces the installation time of `secp256k1` from this:

![Screenshot 2022-12-23 at 4 48 26 pm](https://user-images.githubusercontent.com/63014/209279070-8ad92ac0-b6d5-4605-b26e-f0ac2e213a7d.png)

to this:

![209279222-58a8b7b4-d9f3-4c04-b99f-bf567c5ada00](https://user-images.githubusercontent.com/63014/209411576-7f189152-70ae-4676-ba81-204f55702fc8.png)

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [ ] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [ ] Self-reviewed the diff
