### PR TITLE
Switch from `Shelley`/`BabbageTxOut` to a more general `TxOut`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -75,7 +75,6 @@ import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody
   ( DCert (..),
     ShelleyEraTxBody (..),
-    ShelleyTxOut (..),
     Wdrl (..),
   )
 import Cardano.Ledger.TxIn (TxIn (..))
@@ -91,7 +90,7 @@ import NoThunks.Class (NoThunks (..))
 
 data AllegraTxBodyRaw ma era = AllegraTxBodyRaw
   { atbrInputs :: !(Set (TxIn (EraCrypto era))),
-    atbrOutputs :: !(StrictSeq (ShelleyTxOut era)),
+    atbrOutputs :: !(StrictSeq (TxOut era)),
     atbrCerts :: !(StrictSeq (DCert (EraCrypto era))),
     atbrWdrls :: !(Wdrl (EraCrypto era)),
     atbrTxFee :: !Coin,
@@ -102,21 +101,21 @@ data AllegraTxBodyRaw ma era = AllegraTxBodyRaw
   }
 
 deriving instance
-  (Era era, NFData (Value era), NFData (PParamsUpdate era), NFData ma) =>
+  (Era era, NFData (TxOut era), NFData (PParamsUpdate era), NFData ma) =>
   NFData (AllegraTxBodyRaw ma era)
 
 deriving instance
-  (Era era, Eq (PParamsUpdate era), Eq (Value era), Eq (CompactForm (Value era)), Eq ma) =>
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq ma) =>
   Eq (AllegraTxBodyRaw ma era)
 
 deriving instance
-  (Era era, Compactible (Value era), Show (Value era), Show (PParamsUpdate era), Show ma) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era), Show ma) =>
   Show (AllegraTxBodyRaw ma era)
 
 deriving instance Generic (AllegraTxBodyRaw ma era)
 
 deriving instance
-  (Era era, NoThunks (PParamsUpdate era), NoThunks (Value era), NoThunks ma) =>
+  (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era), NoThunks ma) =>
   NoThunks (AllegraTxBodyRaw ma era)
 
 instance (FromCBOR ma, Monoid ma, AllegraEraTxBody era) => FromCBOR (AllegraTxBodyRaw ma era) where
@@ -205,21 +204,21 @@ instance Memoized AllegraTxBody where
   type RawType AllegraTxBody = AllegraTxBodyRaw ()
 
 deriving instance
-  (Era era, Eq (PParamsUpdate era), Eq (Value era), Eq (CompactForm (Value era))) =>
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era)) =>
   Eq (AllegraTxBody era)
 
 deriving instance
-  (Era era, Show (Value era), Compactible (Value era), Show (PParamsUpdate era)) =>
+  (Era era, Show (TxOut era), Compactible (Value era), Show (PParamsUpdate era)) =>
   Show (AllegraTxBody era)
 
 deriving instance Generic (AllegraTxBody era)
 
 deriving newtype instance
-  (Era era, NoThunks (Value era), NoThunks (PParamsUpdate era)) =>
+  (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) =>
   NoThunks (AllegraTxBody era)
 
 deriving newtype instance
-  ( NFData (Value era),
+  ( NFData (TxOut era),
     NFData (PParamsUpdate era),
     Era era
   ) =>
@@ -241,7 +240,7 @@ instance (c ~ EraCrypto era, Era era) => HashAnnotated (AllegraTxBody era) EraIn
 pattern AllegraTxBody ::
   EraTxOut era =>
   Set (TxIn (EraCrypto era)) ->
-  StrictSeq (ShelleyTxOut era) ->
+  StrictSeq (TxOut era) ->
   StrictSeq (DCert (EraCrypto era)) ->
   Wdrl (EraCrypto era) ->
   Coin ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -94,7 +94,6 @@ import Cardano.Ledger.Binary
   )
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
@@ -114,7 +113,6 @@ import Cardano.Ledger.Shelley.Delegation.Certificates (DCert)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..), Wdrl (Wdrl), unWdrl)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -147,7 +145,7 @@ data AlonzoTxBodyRaw era = AlonzoTxBodyRaw
   deriving (Generic, Typeable)
 
 deriving instance
-  (Era era, Eq (TxOut era), Eq (PParamsUpdate era), Eq (Value era), Compactible (Value era)) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (AlonzoTxBodyRaw era)
 
 instance (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) => NoThunks (AlonzoTxBodyRaw era)
@@ -155,7 +153,7 @@ instance (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) => NoThun
 instance (Era era, NFData (TxOut era), NFData (PParamsUpdate era)) => NFData (AlonzoTxBodyRaw era)
 
 deriving instance
-  (Era era, Show (TxOut era), Show (PParamsUpdate era), Show (Value era), Val (Value era)) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (AlonzoTxBodyRaw era)
 
 newtype AlonzoTxBody era = TxBodyConstr (MemoBytes AlonzoTxBodyRaw era)
@@ -253,7 +251,7 @@ instance Crypto c => AlonzoEraTxBody (AlonzoEra c) where
   {-# INLINEABLE networkIdTxBodyL #-}
 
 deriving newtype instance
-  (Era era, Eq (TxOut era), Eq (PParamsUpdate era), Eq (Value era), Compactible (Value era)) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (AlonzoTxBody era)
 
 deriving instance
@@ -265,17 +263,13 @@ deriving instance
   NFData (AlonzoTxBody era)
 
 deriving instance
-  (Era era, Show (TxOut era), Show (PParamsUpdate era), Show (Value era), Val (Value era)) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (AlonzoTxBody era)
 
 deriving via
   (Mem AlonzoTxBodyRaw era)
   instance
-    ( Era era,
-      FromCBOR (TxOut era),
-      FromCBOR (PParamsUpdate era),
-      Show (Value era)
-    ) =>
+    (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
     FromCBOR (Annotator (AlonzoTxBody era))
 
 pattern AlonzoTxBody ::
@@ -455,11 +449,7 @@ instance
           !> encodeKeyedStrictMaybe 15 atbrTxNetworkId
 
 instance
-  ( Era era,
-    FromCBOR (TxOut era),
-    FromCBOR (PParamsUpdate era),
-    Show (Value era)
-  ) =>
+  (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
   FromCBOR (AlonzoTxBodyRaw era)
   where
   fromCBOR =
@@ -516,11 +506,7 @@ emptyAlonzoTxBodyRaw =
     SNothing
 
 instance
-  ( Era era,
-    FromCBOR (TxOut era),
-    FromCBOR (PParamsUpdate era),
-    Show (Value era)
-  ) =>
+  (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
   FromCBOR (Annotator (AlonzoTxBodyRaw era))
   where
   fromCBOR = pure <$> fromCBOR

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -45,7 +45,6 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (collateralInputsTxBodyL))
 import Cardano.Ledger.Alonzo.TxWits
   ( AlonzoEraTxWits (..),
-    AlonzoTxWits (..),
     nullRedeemers,
   )
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
@@ -53,8 +52,6 @@ import Cardano.Ledger.Babbage.Era (BabbageUTXO)
 import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (..),
-    BabbageTxBody (..),
-    BabbageTxOut,
   )
 import Cardano.Ledger.BaseTypes
   ( ProtVer (..),
@@ -274,9 +271,7 @@ validateCollateralEqBalance bal txcoll =
 
 -- > getValue txout ≥ inject ( serSize txout ∗ coinsPerUTxOByte pp )
 validateOutputTooSmallUTxO ::
-  ( EraTxOut era,
-    TxOut era ~ BabbageTxOut era
-  ) =>
+  EraTxOut era =>
   PParams era ->
   [Sized (TxOut era)] ->
   Test (BabbageUtxoPredFailure era)
@@ -326,8 +321,6 @@ utxoTransition ::
     BabbageEraTxBody era,
     AlonzoEraTxWits era,
     Tx era ~ AlonzoTx era,
-    TxBody era ~ BabbageTxBody era,
-    TxOut era ~ BabbageTxOut era,
     STS (BabbageUTXO era),
     HasField "_maxTxSize" (PParams era) Natural,
     HasField "_maxValSize" (PParams era) Natural,
@@ -421,9 +414,6 @@ instance
     BabbageEraTxBody era,
     AlonzoEraTxWits era,
     Tx era ~ AlonzoTx era,
-    TxOut era ~ BabbageTxOut era,
-    TxBody era ~ BabbageTxBody era,
-    TxWits era ~ AlonzoTxWits era,
     HasField "_maxCollateralInputs" (PParams era) Natural,
     HasField "_coinsPerUTxOByte" (PParams era) Coin,
     HasField "_collateralPercentage" (PParams era) Natural,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -34,7 +34,6 @@ import Cardano.Ledger.Alonzo.Rules
   )
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModels)
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, ScriptResult (Fails, Passes))
-import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance, collOuts)
 import Cardano.Ledger.Babbage.Era (BabbageUTXOS)
@@ -42,14 +41,19 @@ import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody
   ( AlonzoEraTxBody (collateralInputsTxBodyL),
     BabbageEraTxBody,
-    BabbageTxOut,
     ShelleyEraTxBody (..),
   )
 import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase, epochInfo, strictMaybeToMaybe, systemStart)
 import Cardano.Ledger.Binary (ToCBOR (..))
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.LedgerState (PPUPState (..), UTxOState (..), keyTxRefunds, totalTxDeposits, updateStakeDistribution)
+import Cardano.Ledger.Shelley.LedgerState
+  ( PPUPState (..),
+    UTxOState (..),
+    keyTxRefunds,
+    totalTxDeposits,
+    updateStakeDistribution,
+  )
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules
   ( PpupEnv (..),
@@ -79,9 +83,6 @@ instance
     EraUTxO era,
     ScriptsNeeded era ~ AlonzoScriptsNeeded era,
     Tx era ~ AlonzoTx era,
-    TxOut era ~ BabbageTxOut era,
-    TxBody era ~ BabbageTxBody era,
-    TxWits era ~ AlonzoTxWits era,
     Script era ~ AlonzoScript era,
     HasField "_keyDeposit" (PParams era) Coin,
     HasField "_poolDeposit" (PParams era) Coin,
@@ -123,9 +124,6 @@ utxosTransition ::
     EraUTxO era,
     ScriptsNeeded era ~ AlonzoScriptsNeeded era,
     Tx era ~ AlonzoTx era,
-    TxOut era ~ BabbageTxOut era,
-    TxBody era ~ BabbageTxBody era,
-    TxWits era ~ AlonzoTxWits era,
     Script era ~ AlonzoScript era,
     HasField "_keyDeposit" (PParams era) Coin,
     HasField "_poolDeposit" (PParams era) Coin,
@@ -215,8 +213,6 @@ scriptsNo ::
     STS (BabbageUTXOS era),
     BabbageEraTxBody era,
     Tx era ~ AlonzoTx era,
-    TxOut era ~ BabbageTxOut era,
-    TxBody era ~ BabbageTxBody era,
     Script era ~ AlonzoScript era,
     HasField "_costmdls" (PParams era) CostModels
   ) =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -41,7 +41,6 @@ import Cardano.Ledger.Babbage.Tx (refScripts)
 import Cardano.Ledger.Babbage.TxBody
   ( BabbageEraTxBody (..),
     BabbageEraTxOut (..),
-    BabbageTxOut (..),
   )
 import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase, quorum, strictMaybeToMaybe)
 import Cardano.Ledger.Binary (FromCBOR (..), ToCBOR (..))
@@ -229,8 +228,7 @@ validateScriptsWellFormed ::
   forall era.
   ( EraTx era,
     BabbageEraTxBody era,
-    Script era ~ AlonzoScript era,
-    TxOut era ~ BabbageTxOut era
+    Script era ~ AlonzoScript era
   ) =>
   PParams era ->
   Tx era ->
@@ -267,7 +265,6 @@ babbageUtxowTransition ::
     EraUTxO era,
     ScriptsNeeded era ~ AlonzoScriptsNeeded era,
     Script era ~ AlonzoScript era,
-    TxOut era ~ BabbageTxOut era,
     STS (BabbageUTXOW era),
     BabbageEraTxBody era,
     HasField "_costmdls" (PParams era) CostModels,
@@ -368,7 +365,6 @@ instance
     EraUTxO era,
     ScriptsNeeded era ~ AlonzoScriptsNeeded era,
     BabbageEraTxBody era,
-    TxOut era ~ BabbageTxOut era,
     HasField "_costmdls" (PParams era) CostModels,
     HasField "_protocolVersion" (PParams era) ProtVer,
     Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody),

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -51,6 +51,8 @@ instance
 instance
   ( Mock (EraCrypto era),
     BabbageEraTxBody era,
+    Arbitrary (Sized (TxOut era)),
+    Arbitrary (TxOut era),
     Arbitrary (Value era),
     Arbitrary (Script era)
   ) =>
@@ -182,6 +184,7 @@ instance
 
 instance
   ( Era era,
+    Twiddle (TxOut era),
     BabbageEraTxBody era
   ) =>
   Twiddle (BabbageTxBody era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -7,12 +7,21 @@
 
 module Cardano.Ledger.Conway.Rules.Utxo (ConwayUTXO) where
 
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoEvent (..), AlonzoUtxoPredFailure (..), AlonzoUtxosEvent, AlonzoUtxosPredFailure, AlonzoUtxowEvent (..))
+import Cardano.Ledger.Alonzo.Rules
+  ( AlonzoUtxoEvent (..),
+    AlonzoUtxoPredFailure (..),
+    AlonzoUtxosEvent,
+    AlonzoUtxosPredFailure,
+    AlonzoUtxowEvent (..),
+  )
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
-import Cardano.Ledger.Babbage (BabbageTxOut)
 import Cardano.Ledger.Babbage.PParams (BabbagePParamsUpdate)
-import Cardano.Ledger.Babbage.Rules (BabbageUTXOW, BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (UtxoFailure))
+import Cardano.Ledger.Babbage.Rules
+  ( BabbageUTXOW,
+    BabbageUtxoPredFailure (..),
+    BabbageUtxowPredFailure (UtxoFailure),
+  )
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Era (ConwayUTXO, ConwayUTXOS)
 import Cardano.Ledger.Conway.Rules.Utxos ()
@@ -21,20 +30,20 @@ import Cardano.Ledger.Core
     EraRule,
     EraScript (..),
     EraTx,
-    EraTxOut (..),
-    Value,
   )
 import Cardano.Ledger.Era (Era (..))
-import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Rules.ValidationMode (Inject)
 import Cardano.Ledger.Shelley.API (PPUPState (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
-import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure, ShelleyUtxowEvent (UtxoEvent), UtxoEnv (..))
+import Cardano.Ledger.Shelley.Rules
+  ( ShelleyPpupPredFailure,
+    ShelleyUtxowEvent (UtxoEvent),
+    UtxoEnv (..),
+  )
 import Control.State.Transition.Extended (Embed (..), STS (..))
 
 instance
   ( EraTx era,
-    Value era ~ MaryValue (EraCrypto era),
     State (EraRule "PPUP" era) ~ PPUPState era,
     PredicateFailure (EraRule "UTXOS" era) ~ AlonzoUtxosPredFailure era,
     PredicateFailure (EraRule "UTXO" era) ~ BabbageUtxoPredFailure era,
@@ -53,15 +62,12 @@ instance
   transitionRules = []
 
 instance
-  ( EraScript era,
-    Era era,
+  ( EraTx era,
     PredicateFailure (EraRule "PPUP" era) ~ ShelleyPpupPredFailure era,
     PredicateFailure (EraRule "UTXOS" era) ~ AlonzoUtxosPredFailure era,
     Event (EraRule "UTXOS" era) ~ AlonzoUtxosEvent era,
     Script era ~ AlonzoScript era,
     State (EraRule "PPUP" era) ~ PPUPState era,
-    Value era ~ MaryValue (EraCrypto era),
-    TxOut era ~ BabbageTxOut era,
     PParamsUpdate era ~ BabbagePParamsUpdate era,
     Inject (PredicateFailure (EraRule "PPUP" era)) (PredicateFailure (EraRule "UTXOS" era))
   ) =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -12,19 +12,15 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Era (ConwayUTXOS)
 import Cardano.Ledger.Conway.PParams (BabbagePParamsUpdate)
-import Cardano.Ledger.Conway.TxOut (BabbageTxOut (..))
-import Cardano.Ledger.Core (Era (..), EraPParams (..), EraRule, EraScript (..), EraTxOut (..), Value)
-import Cardano.Ledger.Mary.Value (MaryValue (..))
+import Cardano.Ledger.Core (EraPParams (..), EraRule, EraTx (..), Script)
 import Cardano.Ledger.Rules.ValidationMode (Inject)
 import Cardano.Ledger.Shelley.LedgerState (PPUPState (..), UTxOState (..))
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure, UtxoEnv (..))
 import Control.State.Transition.Extended (STS (..))
 
 instance
-  ( EraScript era,
+  ( EraTx era,
     PredicateFailure (EraRule "PPUP" era) ~ ShelleyPpupPredFailure era,
-    TxOut era ~ BabbageTxOut era,
-    Value era ~ MaryValue (EraCrypto era),
     Script era ~ AlonzoScript era,
     State (EraRule "PPUP" era) ~ PPUPState era,
     PParamsUpdate era ~ BabbagePParamsUpdate era,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -73,7 +73,7 @@ import Cardano.Ledger.Binary.Coders
     ofield,
     (!>),
   )
-import Cardano.Ledger.Coin (Coin (..), CompactForm)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
   ( ConwayEraTxBody (..),
   )
@@ -84,7 +84,7 @@ import Cardano.Ledger.Conway.PParams ()
 import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value
   ( MaryValue (..),
@@ -106,7 +106,6 @@ import Cardano.Ledger.MemoBytes
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.TxBody (Wdrl (..))
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val (DecodeNonNegative, Val)
 import Control.DeepSeq
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Sequence.Strict (StrictSeq, (|>))
@@ -143,45 +142,23 @@ data ConwayTxBodyRaw era = ConwayTxBodyRaw
   deriving (Generic, Typeable)
 
 deriving instance
-  ( Era era,
-    Eq (Script era),
-    Eq (CompactForm (Value era)),
-    Eq (PParamsUpdate era),
-    Eq (TxOut era)
-  ) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (ConwayTxBodyRaw era)
 
 instance
-  ( NoThunks (PParamsUpdate era),
-    NoThunks (TxOut era)
-  ) =>
+  (NoThunks (TxOut era), NoThunks (PParamsUpdate era)) =>
   NoThunks (ConwayTxBodyRaw era)
 
 instance
-  ( Era era,
-    NFData (PParamsUpdate era),
-    NFData (TxOut era)
-  ) =>
+  (Era era, NFData (TxOut era), NFData (PParamsUpdate era)) =>
   NFData (ConwayTxBodyRaw era)
 
 deriving instance
-  ( Era era,
-    Val (Value era),
-    Show (Value era),
-    Show (Script era),
-    Show (PParamsUpdate era),
-    Show (TxOut era)
-  ) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (ConwayTxBodyRaw era)
 
 instance
-  ( Era era,
-    Val (Value era),
-    DecodeNonNegative (Value era),
-    FromCBOR (Annotator (Script era)),
-    FromCBOR (PParamsUpdate era),
-    FromCBOR (TxOut era)
-  ) =>
+  (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
   FromCBOR (ConwayTxBodyRaw era)
   where
   fromCBOR =
@@ -228,36 +205,19 @@ newtype ConwayTxBody era = TxBodyConstr (MemoBytes ConwayTxBodyRaw era)
   deriving (Generic, SafeToHash, ToCBOR)
 
 instance
-  ( Era era,
-    NoThunks (PParamsUpdate era),
-    NoThunks (TxOut era)
-  ) =>
+  (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) =>
   NoThunks (ConwayTxBody era)
 
 deriving instance
-  ( Era era,
-    Eq (Script era),
-    Eq (CompactForm (Value era)),
-    Eq (PParamsUpdate era),
-    Eq (TxOut era)
-  ) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (ConwayTxBody era)
 
 deriving newtype instance
-  ( Era era,
-    NFData (PParamsUpdate era),
-    NFData (TxOut era)
-  ) =>
+  (Era era, NFData (TxOut era), NFData (PParamsUpdate era)) =>
   NFData (ConwayTxBody era)
 
 deriving instance
-  ( Era era,
-    Val (Value era),
-    Show (Value era),
-    Show (Script era),
-    Show (PParamsUpdate era),
-    Show (TxOut era)
-  ) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (ConwayTxBody era)
 
 type instance MemoHashIndex ConwayTxBodyRaw = EraIndependentTxBody
@@ -266,13 +226,7 @@ instance (c ~ EraCrypto era) => HashAnnotated (ConwayTxBody era) EraIndependentT
   hashAnnotated = getMemoSafeHash
 
 instance
-  ( Era era,
-    Val (Value era),
-    DecodeNonNegative (Value era),
-    FromCBOR (PParamsUpdate era),
-    FromCBOR (Annotator (Script era)),
-    FromCBOR (TxOut era)
-  ) =>
+  (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
   FromCBOR (Annotator (ConwayTxBodyRaw era))
   where
   fromCBOR = pure <$> fromCBOR
@@ -280,13 +234,7 @@ instance
 deriving via
   (Mem ConwayTxBodyRaw era)
   instance
-    ( Era era,
-      Val (Value era),
-      DecodeNonNegative (Value era),
-      FromCBOR (PParamsUpdate era),
-      FromCBOR (Annotator (Script era)),
-      FromCBOR (TxOut era)
-    ) =>
+    (Era era, FromCBOR (TxOut era), FromCBOR (PParamsUpdate era)) =>
     FromCBOR (Annotator (ConwayTxBody era))
 
 mkConwayTxBody :: ConwayEraTxBody era => ConwayTxBody era
@@ -313,8 +261,8 @@ basicConwayTxBodyRaw =
     mempty
     mempty
 
-instance CC.Crypto c => EraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance EraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => EraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance EraTxBody (ConwayEra StandardCrypto) #-}
 
   type TxBody (ConwayEra c) = ConwayTxBody (ConwayEra c)
 
@@ -344,8 +292,8 @@ instance CC.Crypto c => EraTxBody (ConwayEra c) where
         ]
   {-# INLINE allInputsTxBodyF #-}
 
-instance CC.Crypto c => ShelleyEraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance ShelleyEraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => ShelleyEraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance ShelleyEraTxBody (ConwayEra StandardCrypto) #-}
 
   wdrlsTxBodyL = lensMemoRawType ctbrWdrls (\txb x -> txb {ctbrWdrls = x})
   {-# INLINE wdrlsTxBodyL #-}
@@ -361,14 +309,14 @@ instance CC.Crypto c => ShelleyEraTxBody (ConwayEra c) where
 
   certsTxBodyG = getterMemoRawType (fmap transDCert . ctbrCerts)
 
-instance CC.Crypto c => AllegraEraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance AllegraEraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => AllegraEraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance AllegraEraTxBody (ConwayEra StandardCrypto) #-}
 
   vldtTxBodyL = lensMemoRawType ctbrVldt (\txb x -> txb {ctbrVldt = x})
   {-# INLINE vldtTxBodyL #-}
 
-instance CC.Crypto c => MaryEraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance MaryEraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => MaryEraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance MaryEraTxBody (ConwayEra StandardCrypto) #-}
 
   mintTxBodyL = lensMemoRawType ctbrMint (\txb x -> txb {ctbrMint = x})
   {-# INLINE mintTxBodyL #-}
@@ -378,8 +326,8 @@ instance CC.Crypto c => MaryEraTxBody (ConwayEra c) where
   mintedTxBodyF = to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (ctbrMint txBodyRaw)))
   {-# INLINE mintedTxBodyF #-}
 
-instance CC.Crypto c => AlonzoEraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance AlonzoEraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => AlonzoEraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance AlonzoEraTxBody (ConwayEra StandardCrypto) #-}
 
   collateralInputsTxBodyL = lensMemoRawType ctbrCollateralInputs (\txb x -> txb {ctbrCollateralInputs = x})
   {-# INLINE collateralInputsTxBodyL #-}
@@ -393,8 +341,8 @@ instance CC.Crypto c => AlonzoEraTxBody (ConwayEra c) where
   networkIdTxBodyL = lensMemoRawType ctbrTxNetworkId (\txb x -> txb {ctbrTxNetworkId = x})
   {-# INLINE networkIdTxBodyL #-}
 
-instance CC.Crypto c => BabbageEraTxBody (ConwayEra c) where
-  {-# SPECIALIZE instance BabbageEraTxBody (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => BabbageEraTxBody (ConwayEra c) where
+  {-# SPECIALIZE instance BabbageEraTxBody (ConwayEra StandardCrypto) #-}
 
   sizedOutputsTxBodyL = lensMemoRawType ctbrOutputs (\txb x -> txb {ctbrOutputs = x})
   {-# INLINE sizedOutputsTxBodyL #-}
@@ -421,7 +369,7 @@ instance CC.Crypto c => BabbageEraTxBody (ConwayEra c) where
           SJust collTxOut -> txOuts |> collTxOut
   {-# INLINE allSizedOutputsTxBodyF #-}
 
-instance CC.Crypto c => ConwayEraTxBody (ConwayEra c) where
+instance Crypto c => ConwayEraTxBody (ConwayEra c) where
   govActionsTxBodyL = lensMemoRawType ctbrGovActions (\txb x -> txb {ctbrGovActions = x})
   votesTxBodyL = lensMemoRawType ctbrVotes (\txb x -> txb {ctbrVotes = x})
   conwayCertsTxBodyL = lensMemoRawType ctbrCerts (\txb x -> txb {ctbrCerts = x})

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -40,7 +40,6 @@ import Cardano.Ledger.Allegra.TxBody
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Binary (Annotator, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
@@ -57,8 +56,8 @@ import Cardano.Ledger.MemoBytes
     mkMemoized,
   )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
+import Cardano.Ledger.Shelley.Delegation.Certificates (DCert)
 import Cardano.Ledger.Shelley.PParams (Update)
-import Cardano.Ledger.Shelley.TxBody (DCert (..), ShelleyTxOut (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -77,21 +76,21 @@ newtype MaryTxBody era = TxBodyConstr (MemoBytes MaryTxBodyRaw era)
 newtype MaryTxBodyRaw era = MaryTxBodyRaw (AllegraTxBodyRaw (MultiAsset (EraCrypto era)) era)
 
 deriving newtype instance
-  (Era era, NFData (Value era), NFData (PParamsUpdate era)) =>
+  (Era era, NFData (TxOut era), NFData (PParamsUpdate era)) =>
   NFData (MaryTxBodyRaw era)
 
 deriving newtype instance
-  (Era era, Eq (PParamsUpdate era), Eq (Value era), Eq (CompactForm (Value era))) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (MaryTxBodyRaw era)
 
 deriving newtype instance
-  (Era era, Compactible (Value era), Show (Value era), Show (PParamsUpdate era)) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (MaryTxBodyRaw era)
 
 deriving instance Generic (MaryTxBodyRaw era)
 
 deriving newtype instance
-  (Era era, NoThunks (PParamsUpdate era), NoThunks (Value era)) =>
+  (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) =>
   NoThunks (MaryTxBodyRaw era)
 
 deriving newtype instance AllegraEraTxBody era => FromCBOR (MaryTxBodyRaw era)
@@ -105,21 +104,21 @@ instance Memoized MaryTxBody where
   type RawType MaryTxBody = MaryTxBodyRaw
 
 deriving newtype instance
-  (Era era, Eq (PParamsUpdate era), Eq (Value era), Eq (CompactForm (Value era))) =>
+  (Era era, Eq (TxOut era), Eq (PParamsUpdate era)) =>
   Eq (MaryTxBody era)
 
 deriving newtype instance
-  (Era era, Show (Value era), Compactible (Value era), Show (PParamsUpdate era)) =>
+  (Era era, Show (TxOut era), Show (PParamsUpdate era)) =>
   Show (MaryTxBody era)
 
 deriving instance Generic (MaryTxBody era)
 
 deriving newtype instance
-  (Era era, NoThunks (Value era), NoThunks (PParamsUpdate era)) =>
+  (Era era, NoThunks (TxOut era), NoThunks (PParamsUpdate era)) =>
   NoThunks (MaryTxBody era)
 
 deriving newtype instance
-  ( NFData (Value era),
+  ( NFData (TxOut era),
     NFData (PParamsUpdate era),
     Era era
   ) =>
@@ -141,7 +140,7 @@ instance (c ~ EraCrypto era, Era era) => HashAnnotated (MaryTxBody era) EraIndep
 pattern MaryTxBody ::
   EraTxOut era =>
   Set.Set (TxIn (EraCrypto era)) ->
-  StrictSeq (ShelleyTxOut era) ->
+  StrictSeq (TxOut era) ->
   StrictSeq (DCert (EraCrypto era)) ->
   Wdrl (EraCrypto era) ->
   Coin ->

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -98,7 +98,7 @@ genTxBody ::
   AllegraEraTxBody era =>
   SlotNo ->
   Set.Set (TxIn (EraCrypto era)) ->
-  StrictSeq (ShelleyTxOut era) ->
+  StrictSeq (TxOut era) ->
   StrictSeq (DCert (EraCrypto era)) ->
   Wdrl (EraCrypto era) ->
   Coin ->

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -140,7 +140,7 @@ instance
   arbitrary = genericArbitraryU
 
 instance
-  (EraTxOut era, Mock (EraCrypto era), Arbitrary (Value era)) =>
+  (EraTxOut era, Mock (EraCrypto era), Arbitrary (TxOut era)) =>
   Arbitrary (AllegraTxBody era)
   where
   arbitrary =
@@ -159,7 +159,7 @@ instance
 -------------------------------------------------------------------------------}
 
 instance
-  (EraTxOut era, Mock (EraCrypto era), Arbitrary (Value era)) =>
+  (EraTxOut era, Mock (EraCrypto era), Arbitrary (TxOut era)) =>
   Arbitrary (MaryTxBody era)
   where
   arbitrary =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
@@ -31,7 +31,7 @@ import Test.QuickCheck
 -------------------------------------------------------------------------------}
 
 instance
-  (EraTxOut era, Mock (EraCrypto era), Arbitrary (Value era)) =>
+  (EraTxOut era, Mock (EraCrypto era), Arbitrary (TxOut era)) =>
   Arbitrary (ShelleyTxBody era)
   where
   arbitrary =

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -1072,12 +1072,12 @@ ppTxId (TxId x) = ppSexp "TxId" [ppSafeHash x]
 ppTxIn :: TxIn c -> PDoc
 ppTxIn (TxIn txid index) = ppSexp "TxIn" [ppTxId txid, pretty (txIxToInt index)]
 
-ppTxOut :: (EraTxOut era, PrettyA (Value era)) => TxOut era -> PDoc
-ppTxOut txOut =
+ppTxOut :: (EraTxOut era, PrettyA (Value era)) => ShelleyTxOut era -> PDoc
+ppTxOut (ShelleyTxOut addr val) =
   ppSexp
     "TxOut"
-    [ ppCompactAddr (txOut ^. compactAddrTxOutL),
-      ppCompactForm prettyA (txOut ^. compactValueTxOutL)
+    [ ppAddr addr,
+      prettyA val
     ]
 
 ppDelegCert :: DelegCert c -> PDoc
@@ -1110,7 +1110,7 @@ ppDCert (DCertGenesis x) = ppSexp "DCertGenesis" [ppConstitutionalDelegCert x]
 ppDCert (DCertMir x) = ppSexp "DCertMir" [ppMIRCert x]
 
 ppTxBody ::
-  (Era era, PrettyA (TxOut era), TxOut era ~ ShelleyTxOut era) =>
+  (Era era, PrettyA (TxOut era)) =>
   PrettyA (PParamsUpdate era) =>
   ShelleyTxBody era ->
   PDoc
@@ -1153,7 +1153,6 @@ instance PrettyA (TxIn c) where
 
 instance
   ( EraTxOut era,
-    TxOut era ~ ShelleyTxOut era,
     PrettyA (Value era)
   ) =>
   PrettyA (ShelleyTxOut era)
@@ -1179,7 +1178,7 @@ instance PrettyA (DCert c) where
   prettyA = ppDCert
 
 instance
-  (PrettyA (TxOut era), PrettyA (PParamsUpdate era), TxOut era ~ ShelleyTxOut era, Era era) =>
+  (PrettyA (TxOut era), PrettyA (PParamsUpdate era), Era era) =>
   PrettyA (ShelleyTxBody era)
   where
   prettyA = ppTxBody

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -222,23 +222,19 @@ ppDataHash x = ppSafeHash x
 instance PrettyA (DataHash era) where prettyA = ppDataHash
 
 ppTxBody ::
-  ( EraScript era,
-    PrettyA (Value era),
-    PrettyA (PParamsUpdate era),
-    PrettyA (Script era),
-    EraTxOut era
+  ( PrettyA (TxOut era),
+    PrettyA (PParamsUpdate era)
   ) =>
   BabbageTxBody era ->
   PDoc
 ppTxBody x =
-  -- (TxBody si ci ri o cr tc c w fee vi u rsh mnt sdh axh ni) =
   ppRecord
     "TxBody(Babbage)"
     [ ("spending inputs", ppSet ppTxIn (spendInputs' x)),
       ("collateral inputs", ppSet ppTxIn (collateralInputs' x)),
       ("reference inputs", ppSet ppTxIn (referenceInputs' x)),
-      ("outputs", ppStrictSeq ppTxOut (outputs' x)),
-      ("collateral return", ppStrictMaybe ppTxOut (collateralReturn' x)),
+      ("outputs", ppStrictSeq prettyA (outputs' x)),
+      ("collateral return", ppStrictMaybe prettyA (collateralReturn' x)),
       ("total collateral", ppStrictMaybe ppCoin (totalCollateral' x)),
       ("certificates", ppStrictSeq ppDCert (certs' x)),
       ("withdrawals", ppWdrl (wdrls' x)),
@@ -254,10 +250,8 @@ ppTxBody x =
 
 instance
   ( EraTxOut era,
-    EraScript era,
-    PrettyA (Value era),
-    PrettyA (PParamsUpdate era),
-    PrettyA (Script era)
+    PrettyA (TxOut era),
+    PrettyA (PParamsUpdate era)
   ) =>
   PrettyA (BabbageTxBody era)
   where

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -13,8 +13,13 @@ module Cardano.Ledger.Pretty.Conway
   )
 where
 
-import Cardano.Ledger.Babbage.TxBody (AllegraEraTxBody (..), AlonzoEraTxBody (..), BabbageEraTxBody (..), MaryEraTxBody (..), ShelleyEraTxBody (..))
-import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody
+  ( AllegraEraTxBody (..),
+    AlonzoEraTxBody (..),
+    BabbageEraTxBody (..),
+    MaryEraTxBody (..),
+    ShelleyEraTxBody (..),
+  )
 import Cardano.Ledger.Conway.Core (ConwayEraTxBody (..))
 import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert (..), transDCert)
 import Cardano.Ledger.Conway.Governance
@@ -27,7 +32,7 @@ import Cardano.Ledger.Conway.Governance
     VoterRole (..),
   )
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
-import Cardano.Ledger.Core (EraPParams (..), EraTxBody (..), EraTxOut (..), Value)
+import Cardano.Ledger.Core (EraPParams (..), EraTxBody (..), Value)
 import Cardano.Ledger.Pretty
   ( PDoc,
     PrettyA (..),
@@ -55,8 +60,7 @@ import Cardano.Ledger.Pretty.Mary (ppMultiAsset, ppValidityInterval)
 import Lens.Micro ((^.))
 
 instance
-  ( TxOut era ~ BabbageTxOut era,
-    ConwayEraTxBody era,
+  ( ConwayEraTxBody era,
     PrettyA (Value era),
     TxBody era ~ ConwayTxBody era,
     PrettyA (PParamsUpdate era)
@@ -74,7 +78,6 @@ ppConwayTxBody ::
   forall era.
   ( ConwayEraTxBody era,
     PrettyA (Value era),
-    TxOut era ~ BabbageTxOut era,
     TxBody era ~ ConwayTxBody era,
     PrettyA (GovernanceActionInfo era)
   ) =>

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.Conway.Governance
     VoterRole (..),
   )
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
-import Cardano.Ledger.Core (EraPParams (..), EraTxBody (..), Value)
+import Cardano.Ledger.Core (EraPParams (..), EraTxBody (..), EraTxOut (..))
 import Cardano.Ledger.Pretty
   ( PDoc,
     PrettyA (..),
@@ -51,7 +51,6 @@ import Cardano.Ledger.Pretty
     ppStrictSeq,
     ppTxId,
     ppTxIn,
-    ppTxOut,
     ppUrl,
     ppWdrl,
     ppWord64,
@@ -61,7 +60,7 @@ import Lens.Micro ((^.))
 
 instance
   ( ConwayEraTxBody era,
-    PrettyA (Value era),
+    PrettyA (TxOut era),
     TxBody era ~ ConwayTxBody era,
     PrettyA (PParamsUpdate era)
   ) =>
@@ -77,7 +76,7 @@ ppConwayDCert (ConwayDCertConstitutional gdc) = ppSexp "ConwayDCertConstitutiona
 ppConwayTxBody ::
   forall era.
   ( ConwayEraTxBody era,
-    PrettyA (Value era),
+    PrettyA (TxOut era),
     TxBody era ~ ConwayTxBody era,
     PrettyA (GovernanceActionInfo era)
   ) =>
@@ -89,8 +88,8 @@ ppConwayTxBody txb =
     [ ("spending inputs", ppSet ppTxIn $ txb ^. inputsTxBodyL),
       ("collateral inputs", ppSet ppTxIn $ txb ^. collateralInputsTxBodyL),
       ("reference inputs", ppSet ppTxIn $ txb ^. referenceInputsTxBodyL),
-      ("outputs", ppStrictSeq (ppTxOut @era) (txb ^. outputsTxBodyL)),
-      ("collateral return", ppStrictMaybe (ppTxOut @era) (txb ^. collateralReturnTxBodyL)),
+      ("outputs", ppStrictSeq prettyA (txb ^. outputsTxBodyL)),
+      ("collateral return", ppStrictMaybe prettyA (txb ^. collateralReturnTxBodyL)),
       ("total collateral", ppStrictMaybe ppCoin $ txb ^. totalCollateralTxBodyL),
       ("certificates", ppStrictSeq ppConwayDCert $ txb ^. conwayCertsTxBodyL),
       ("withdrawals", ppWdrl $ txb ^. wdrlsTxBodyL),

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -16,7 +16,6 @@ import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Mary.TxBody
 import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.Pretty
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxOut)
 import qualified Data.Map as Map
 import Data.Text (Text)
 import Lens.Micro
@@ -89,7 +88,7 @@ instance Era era => PrettyA (AllegraTxAuxData era) where
 
 allegraFields ::
   ( AllegraEraTxBody era,
-    PrettyA (Value era),
+    PrettyA (TxOut era),
     PrettyA (PParamsUpdate era),
     ProtVerAtMost era 8
   ) =>
@@ -97,7 +96,7 @@ allegraFields ::
   [(Text, PDoc)]
 allegraFields txBody =
   [ ("inputs", ppSet ppTxIn (txBody ^. inputsTxBodyL)),
-    ("outputs", ppStrictSeq ppTxOut (txBody ^. outputsTxBodyL)),
+    ("outputs", ppStrictSeq prettyA (txBody ^. outputsTxBodyL)),
     ("certificates", ppStrictSeq ppDCert (txBody ^. certsTxBodyG)),
     ("withdrawals", ppWdrl (txBody ^. wdrlsTxBodyL)),
     ("txfee", ppCoin (txBody ^. feeTxBodyL)),
@@ -108,9 +107,8 @@ allegraFields txBody =
 
 instance
   ( AllegraEraTxBody era,
-    PrettyA (Value era),
+    PrettyA (TxOut era),
     PrettyA (PParamsUpdate era),
-    TxOut era ~ ShelleyTxOut era,
     TxBody era ~ AllegraTxBody era,
     ProtVerAtMost era 8
   ) =>
@@ -120,9 +118,8 @@ instance
 
 instance
   ( MaryEraTxBody era,
-    PrettyA (Value era),
+    PrettyA (TxOut era),
     PrettyA (PParamsUpdate era),
-    TxOut era ~ ShelleyTxOut era,
     TxBody era ~ MaryTxBody era,
     ProtVerAtMost era 8
   ) =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Babbage.TxBody
   ( AlonzoEraTxBody (..),
     BabbageEraTxBody (..),
     BabbageTxBody (..),
-    BabbageTxOut (..),
     Datum (..),
   )
 import Cardano.Ledger.BaseTypes
@@ -49,7 +48,7 @@ import Cardano.Ledger.Block (txid)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys
   ( KeyHash,
     KeyRole (..),
@@ -189,13 +188,13 @@ datumExampleSixtyFiveBytes = Data (PV1.B sixtyFiveBytes)
 txDats :: Era era => TxDats era
 txDats = mkTxDats datumExampleSixtyFiveBytes
 
-someTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
+someTxIn :: (CH.HashAlgorithm (HASH c), HasCallStack) => TxIn c
 someTxIn = mkGenesisTxIn 1
 
-anotherTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
+anotherTxIn :: (CH.HashAlgorithm (HASH c), HasCallStack) => TxIn c
 anotherTxIn = mkGenesisTxIn 2
 
-yetAnotherTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => TxIn c
+yetAnotherTxIn :: (CH.HashAlgorithm (HASH c), HasCallStack) => TxIn c
 yetAnotherTxIn = mkGenesisTxIn 3
 
 defaultPPs :: [PParamsField era]
@@ -1071,7 +1070,6 @@ testExpectSuccessValid
 newColReturn ::
   forall era.
   ( TxBody era ~ BabbageTxBody era,
-    TxOut era ~ BabbageTxOut era,
     BabbageEraTxBody era
   ) =>
   TxBody era ->
@@ -1088,7 +1086,6 @@ testExpectSuccessInvalid ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era,
     TxBody era ~ BabbageTxBody era,
-    TxOut era ~ BabbageTxOut era,
     GoodCrypto (EraCrypto era),
     Default (State (EraRule "PPUP" era)),
     PostShelley era,
@@ -1139,7 +1136,6 @@ genericBabbageFeatures ::
     BabbageBased era (PredicateFailure (EraRule "UTXOW" era)),
     State (EraRule "UTXOW" era) ~ UTxOState era,
     TxBody era ~ BabbageTxBody era,
-    TxOut era ~ BabbageTxOut era,
     GoodCrypto (EraCrypto era),
     BabbageEraTxBody era,
     Default (State (EraRule "PPUP" era)),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Shelley.LedgerState
   )
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), ShelleyPParamsHKD)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), ShelleyTxOut, Wdrl (..))
+import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), Wdrl (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.UTxO (UTxO (..))
 import Control.State.Transition.Extended (STS (..), State)
@@ -361,9 +361,7 @@ sameTxWits proof@(Conway _) x y = sameAlonzoTxWits proof x y
 -- Comparing TxBody for Sameness
 
 sameShelleyTxBody ::
-  ( Reflect era,
-    TxOut era ~ ShelleyTxOut era
-  ) =>
+  Reflect era =>
   Proof era ->
   ShelleyTxBody era ->
   ShelleyTxBody era ->
@@ -380,9 +378,7 @@ sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Wdrl w1) f1 s1 pu1 d1) (Shelley
   ]
 
 sameAllegraTxBody ::
-  ( Reflect era,
-    TxOut era ~ ShelleyTxOut era
-  ) =>
+  Reflect era =>
   Proof era ->
   AllegraTxBody era ->
   AllegraTxBody era ->
@@ -399,9 +395,7 @@ sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Wdrl w1) f1 v1 pu1 d1) (Allegra
   ]
 
 sameMaryTxBody ::
-  ( Reflect era,
-    TxOut era ~ ShelleyTxOut era
-  ) =>
+  Reflect era =>
   Proof era ->
   MaryTxBody era ->
   MaryTxBody era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -25,14 +25,12 @@ import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD)
-import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody, BabbageTxBody (..), BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody, BabbageTxBody (..))
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Conway.Core (ConwayEraTxBody)
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
-import Cardano.Ledger.Core (EraTxOut (..))
-import qualified Cardano.Ledger.Core as Core
-import Cardano.Ledger.Era (Era, EraCrypto)
+import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Genesis))
 import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
 import Cardano.Ledger.Pretty
@@ -142,7 +140,7 @@ sameUTxO (Babbage _) x y = eqByShow x y
 sameUTxO (Conway _) x y = eqByShow x y
 {-# NOINLINE sameUTxO #-}
 
-samePPUP :: Proof era -> State (Core.EraRule "PPUP" era) -> State (Core.EraRule "PPUP" era) -> Maybe PDoc
+samePPUP :: Proof era -> State (EraRule "PPUP" era) -> State (EraRule "PPUP" era) -> Maybe PDoc
 samePPUP (Shelley _) x y = eqByShow x y
 samePPUP (Allegra _) x y = eqByShow x y
 samePPUP (Mary _) x y = eqByShow x y
@@ -268,7 +266,7 @@ instance Same era (ShelleyResultExamples era) where
 -- We cannot make them Same instances because they are type families.
 -- We also can avoid all extra constraints by pattern matching against all current Proofs.
 
-samePParams :: Proof era -> Core.PParams era -> Core.PParams era -> Maybe PDoc
+samePParams :: Proof era -> PParams era -> PParams era -> Maybe PDoc
 samePParams (Shelley _) x y = eqByShow x y
 samePParams (Allegra _) x y = eqByShow x y
 samePParams (Mary _) x y = eqByShow x y
@@ -277,7 +275,7 @@ samePParams (Babbage _) x y = eqByShow x y
 samePParams (Conway _) x y = eqByShow x y
 {-# NOINLINE samePParams #-}
 
-samePParamsUpdate :: Proof era -> Core.PParamsUpdate era -> Core.PParamsUpdate era -> Maybe PDoc
+samePParamsUpdate :: Proof era -> PParamsUpdate era -> PParamsUpdate era -> Maybe PDoc
 samePParamsUpdate (Shelley _) x y = eqByShow x y
 samePParamsUpdate (Allegra _) x y = eqByShow x y
 samePParamsUpdate (Mary _) x y = eqByShow x y
@@ -286,7 +284,7 @@ samePParamsUpdate (Babbage _) x y = eqByShow x y
 samePParamsUpdate (Conway _) x y = eqByShow x y
 {-# NOINLINE samePParamsUpdate #-}
 
-sameTxOut :: Proof era -> Core.TxOut era -> Core.TxOut era -> Maybe PDoc
+sameTxOut :: Proof era -> TxOut era -> TxOut era -> Maybe PDoc
 sameTxOut (Shelley _) x y = eqByShow x y
 sameTxOut (Allegra _) x y = eqByShow x y
 sameTxOut (Mary _) x y = eqByShow x y
@@ -308,7 +306,7 @@ sameLedgerFail (Babbage _) x y = eqByShow x y
 sameLedgerFail (Conway _) x y = eqByShow x y
 {-# NOINLINE sameLedgerFail #-}
 
-sameTransCtx :: Proof era -> Core.TranslationContext era -> Core.TranslationContext era -> Maybe PDoc
+sameTransCtx :: Proof era -> TranslationContext era -> TranslationContext era -> Maybe PDoc
 sameTransCtx (Shelley _) x y = eqByShow x y
 sameTransCtx (Allegra _) x y = eqByShow x y
 sameTransCtx (Mary _) x y = eqByShow x y
@@ -335,7 +333,7 @@ sameShelleyTxWits proof (ShelleyTxWits vk1 sh1 boot1) (ShelleyTxWits vk2 sh2 boo
 
 sameAlonzoTxWits ::
   forall era.
-  (Reflect era, Core.Script era ~ AlonzoScript era) =>
+  (Reflect era, Script era ~ AlonzoScript era) =>
   Proof era ->
   AlonzoTxWits era ->
   AlonzoTxWits era ->
@@ -351,7 +349,7 @@ sameAlonzoTxWits
       ("RedeemerWits", eqVia (ppMap ppRdmrPtr (pcPair pcData pcExUnits)) r1 r2)
     ]
 
-sameTxWits :: Reflect era => Proof era -> Core.TxWits era -> Core.TxWits era -> [(String, Maybe PDoc)]
+sameTxWits :: Reflect era => Proof era -> TxWits era -> TxWits era -> [(String, Maybe PDoc)]
 sameTxWits proof@(Shelley _) x y = sameShelleyTxWits proof x y
 sameTxWits proof@(Allegra _) x y = sameShelleyTxWits proof x y
 sameTxWits proof@(Mary _) x y = sameShelleyTxWits proof x y
@@ -364,7 +362,7 @@ sameTxWits proof@(Conway _) x y = sameAlonzoTxWits proof x y
 
 sameShelleyTxBody ::
   ( Reflect era,
-    Core.TxOut era ~ ShelleyTxOut era
+    TxOut era ~ ShelleyTxOut era
   ) =>
   Proof era ->
   ShelleyTxBody era ->
@@ -383,7 +381,7 @@ sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Wdrl w1) f1 s1 pu1 d1) (Shelley
 
 sameAllegraTxBody ::
   ( Reflect era,
-    Core.TxOut era ~ ShelleyTxOut era
+    TxOut era ~ ShelleyTxOut era
   ) =>
   Proof era ->
   AllegraTxBody era ->
@@ -402,7 +400,7 @@ sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Wdrl w1) f1 v1 pu1 d1) (Allegra
 
 sameMaryTxBody ::
   ( Reflect era,
-    Core.TxOut era ~ ShelleyTxOut era
+    TxOut era ~ ShelleyTxOut era
   ) =>
   Proof era ->
   MaryTxBody era ->
@@ -447,8 +445,7 @@ sameAlonzoTxBody
 
 sameBabbageTxBody ::
   ( Reflect era,
-    BabbageEraTxBody era,
-    Core.TxOut era ~ BabbageTxOut era
+    BabbageEraTxBody era
   ) =>
   Proof era ->
   BabbageTxBody era ->
@@ -477,9 +474,8 @@ sameBabbageTxBody
     ]
 
 sameConwayTxBody ::
-  ( TxOut era ~ BabbageTxOut era,
-    ConwayEraTxBody era,
-    PrettyA (Core.PParamsUpdate era),
+  ( ConwayEraTxBody era,
+    PrettyA (PParamsUpdate era),
     Reflect era
   ) =>
   Proof era ->
@@ -509,7 +505,7 @@ sameConwayTxBody
       ("Votes", eqVia (ppStrictSeq prettyA) vs1 vs2)
     ]
 
-sameTxBody :: Reflect era => Proof era -> Core.TxBody era -> Core.TxBody era -> [(String, Maybe PDoc)]
+sameTxBody :: Reflect era => Proof era -> TxBody era -> TxBody era -> [(String, Maybe PDoc)]
 sameTxBody proof@(Shelley _) x y = sameShelleyTxBody proof x y
 sameTxBody proof@(Allegra _) x y = sameAllegraTxBody proof x y
 sameTxBody proof@(Mary _) x y = sameMaryTxBody proof x y
@@ -521,7 +517,7 @@ sameTxBody proof@(Conway _) x y = sameConwayTxBody proof x y
 -- Comparing Tx for Sameness
 
 sameShelleyTx ::
-  (Reflect era, Core.TxWits era ~ ShelleyTxWits era) =>
+  (Reflect era, TxWits era ~ ShelleyTxWits era) =>
   Proof era ->
   ShelleyTx era ->
   ShelleyTx era ->
@@ -534,8 +530,8 @@ sameShelleyTx proof (ShelleyTx b1 w1 aux1) (ShelleyTx b2 w2 aux2) =
 
 sameAlonzoTx ::
   ( Reflect era,
-    Core.Script era ~ AlonzoScript era,
-    Core.TxWits era ~ AlonzoTxWits era
+    Script era ~ AlonzoScript era,
+    TxWits era ~ AlonzoTxWits era
   ) =>
   Proof era ->
   AlonzoTx era ->
@@ -549,7 +545,7 @@ sameAlonzoTx proof (AlonzoTx b1 w1 v1 aux1) (AlonzoTx b2 w2 v2 aux2) =
        ]
 {-# NOINLINE sameAlonzoTx #-}
 
-sameTx :: Reflect era => Proof era -> Core.Tx era -> Core.Tx era -> [(String, Maybe PDoc)]
+sameTx :: Reflect era => Proof era -> Tx era -> Tx era -> [(String, Maybe PDoc)]
 sameTx proof@(Shelley _) x y = sameShelleyTx proof x y
 sameTx proof@(Allegra _) x y = sameShelleyTx proof x y
 sameTx proof@(Mary _) x y = sameShelleyTx proof x y
@@ -566,8 +562,8 @@ ints = [0 ..]
 
 sameShelleyTxSeq ::
   ( Reflect era,
-    Core.Tx era ~ ShelleyTx era,
-    SafeToHash (Core.TxWits era)
+    Tx era ~ ShelleyTx era,
+    SafeToHash (TxWits era)
   ) =>
   Proof era ->
   ShelleyTxSeq era ->
@@ -581,7 +577,7 @@ sameShelleyTxSeq proof (ShelleyTxSeq ss1) (ShelleyTxSeq ss2) =
 sameAlonzoTxSeq ::
   ( Reflect era,
     AlonzoEraTx era,
-    SafeToHash (Core.TxWits era)
+    SafeToHash (TxWits era)
   ) =>
   Proof era ->
   AlonzoTxSeq era ->
@@ -592,7 +588,7 @@ sameAlonzoTxSeq proof (AlonzoTxSeq ss1) (AlonzoTxSeq ss2) =
   where
     f n t1 t2 = SomeM (show n) (sameTx proof) t1 t2
 
-sameTxSeq :: Reflect era => Proof era -> Core.TxSeq era -> Core.TxSeq era -> [(String, Maybe PDoc)]
+sameTxSeq :: Reflect era => Proof era -> TxSeq era -> TxSeq era -> [(String, Maybe PDoc)]
 sameTxSeq proof@(Shelley _) x y = sameShelleyTxSeq proof x y
 sameTxSeq proof@(Allegra _) x y = sameShelleyTxSeq proof x y
 sameTxSeq proof@(Mary _) x y = sameShelleyTxSeq proof x y


### PR DESCRIPTION
# Description

By switching to more general type family `TxOut` from a concrete one, we can reduce number of constraints needed in many places, thus simplifying the code a bit. There are no semantic changes in this PR, just cleanup.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [x] Self-reviewed the diff
