### PR TITLE
Fix a faulty address deserialization tests.

### DIFF
--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
@@ -24,7 +24,7 @@ import Data.Maybe (isNothing)
 import Data.Proxy
 import Data.Word
 import Test.Cardano.Ledger.Binary.RoundTrip (cborTrip, mkTrip, roundTripExpectation)
-import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Common hiding ((.&.))
 import Test.Cardano.Ledger.Core.Address
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.Core.Utils (runFailError)
@@ -144,7 +144,11 @@ propDecompactErrors addr = do
                   serializeSuffix [genGood32, genBad16, genGood16],
                   serializeSuffix [genGood32, genGood16, genBad16],
                   serializeSuffix [genGood32, genGood16, genGood16, genGood16],
-                  (\x -> BS.singleton (x .|. 0b10000000) <> suffix) <$> arbitrary
+                  -- We need to reset the first bit, to indicate that no more bytes do
+                  -- follow. This is similar to (except the original suffix is retained):
+                  --
+                  -- serializeSuffix [genGood8, genGood32, genGood16, genGood16]
+                  (\x -> BS.singleton (x .&. 0b01111111) <> suffix) <$> arbitrary
                 ]
             pure ("Mingle Ptr", prefix <> newSuffix)
           Addr _ _ StakeRefNull {} -> do


### PR DESCRIPTION
There was a test failure to one of the quickcheck property tests on CI. After a thorough investigation it turned out to be that the test was bad. Setting MSB with `x .|. 0b10000000` actually indicated that there was a chance that the generated byte can be the beginning of the subsequent value, so for sufficiently small values that followed it would simply combine the two.  In the test failure below, the value generated (i.e. `x`) was: `58`, thus: 
```haskell
>>> (58 `shiftL` 7) .|. 42 == 7466
True
```
And sure enough `SlotNo` in the `Ptr` was `7466`.

What we actually want is to indicate that we prefixed with a totally new value by forcing the MSB to be 0 with `x .&. 0b01111111`

Test failure prior to this commit could be reproduced with:

```
$ cabal test cardano-ledger-core \
  --test-options='--match "/Core/CompactAddr/Ensure Addr failures on incorrect binary data/" \
  --seed 870162015'

Core
  CompactAddr
    Ensure Addr failures on incorrect binary data [✘] (1ms)

Failures:

  test/Test/Cardano/Ledger/AddressSpec.hs:40:5: 
  1) Core.CompactAddr Ensure Addr failures on incorrect binary data
       Falsified (after 16 tests):
         Addr Mainnet (KeyHashObj (KeyHash "a7bb79b3fcbf6f9417e9cec1ac7c0c61fabed8197f2327b980475531")) (StakeRefPtr (Ptr (SlotNo 42) (TxIx 2) (CertIx 117)))
         Mingled address with Mingle Ptr was parsed: "A\167\187y\179\252\191o\148\ETB\233\206\193\172|\fa\250\190\216\EM\DEL#'\185\128GU1\186*\STXu"

  To rerun use: --match "/Core/CompactAddr/Ensure Addr failures on incorrect binary data/"

Randomized with seed 870162015
```

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with ormolu (which can be run with `scripts/ormolise.sh`
- [x] Self-reviewed the diff
