### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -92,12 +92,16 @@ jobs:
     - name: Build
       run: cabal build all
 
-    - name: Git clone
-      run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror
+    - name: Download Mainnet Mirror
+      run: |
+        REF=a31ac75
+        curl -L https://github.com/input-output-hk/cardano-mainnet-mirror/tarball/$REF -o mainnet-mirror.tgz
+        tar -xzf mainnet-mirror.tgz
+        mv input-output-hk-cardano-mainnet-mirror-$REF/epochs .
 
     - name: Run tests
       run: |
-        export CARDANO_MAINNET_MIRROR="$(pwd)/cardano-mainnet-mirror/epochs"
+        export CARDANO_MAINNET_MIRROR="$(pwd)/epochs"
         cabal test all
 
   fourmolu:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
@@ -74,7 +74,7 @@ jobs:
     - name: Cabal Configure
       run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       if: matrix.os != 'macos-latest'
       name: Cache cabal store
       with:
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Install fourmolu
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -80,9 +80,15 @@ jobs:
       with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist
-        key: cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
-        restore-keys: cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
+          dist-newstyle
+        # cache is invalidated upon a change to cabal.project (and/or cabal.project.local), a bump to
+        # CABAL_CACHE_VERSION or after a week of inactivity
+        key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}-${{ github.head_ref }}
+        # Restoring attempts are from current branch, master or any other branch
+        restore-keys: |
+          cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}-${{ github.head_ref }}
+          cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}-master
+          cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
 
     - name: Install dependencies
       run: cabal build all --only-dependencies

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,10 +1,8 @@
 name: Haskell CI
 
 on:
-  push:
-    branches: [ '*' ]
   pull_request:
-    branches: [ "master", "release/*" ]
+    branches: [ "**" ]
 
 jobs:
   build:


### PR DESCRIPTION
# Description

* Improved runtime of "Download Mainnet Mirror" from 5~8 Min to 1.5 Min. Renamed it from a less descriptive "Git Clone" name
* Fixed caching. Shaves off 30-50 minutes upon a cache hit.
* Stop triggering CI on pushes, which caused duplicate runs. We want to run upon any PR, regardless of the target branch. Fixed.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
