### PR TITLE
Update release tag pattern 

### DIFF
--- a/.github/workflows/push-specs.yml
+++ b/.github/workflows/push-specs.yml
@@ -3,7 +3,7 @@ name: Push Specs
 on:
   push:
     tags:
-      - 'cardano-ledger-specs-[0-9]+.[0-9]+.[0-9]+'
+      - 'cardano-ledger-spec-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
 
 jobs:
   push-docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,22 @@ cabal configure <package-name> --ghc-options="-Wwarn"
 cabal build <package-name>
 ```
 
+## Publishing specifications
+PDF specs are stored as attachments to [github releases](https://github.com/input-output-hk/cardano-ledger/releases)
+We can create a release that builds and attaches the latest specs, by triggering the [push-docs github action](https://github.com/input-output-hk/cardano-ledger/blob/master/.github/workflows/push-specs.yml).
+This github action can be triggered by pushing a tag of the pattern: `cardano-ledger-spec-YYYY-MM-DD`, for example: `cardano-ledger-spec-2023-01-17`
+
+For example, if we decide it's time to publish new versions of docs,
+we can do the following to publish the PDFs under release `cardano-ledger-spec-2023-03-21`:
+```
+git tag cardano-ledger-spec-2023-03-21
+git push origin cardano-ledger-spec-2023-03-21
+```
+
+This will create a new release that will be available as [latest](https://github.com/input-output-hk/cardano-ledger/releases/latest).
+Make sure that the `YYYY-MM-DD` part in the tag name is alphabetically greater than the rest, otherwise the release won't be tagged as `latest`.
+Using the current date should ensure that this is the case.
+
 ## Testing the Haskell programs
 
 The tests can be run with cabal.


### PR DESCRIPTION
so that releases get sorted in a deterministic way.
# Description

Without this change, if we realease:
`cardano-ledger-spec-1.0.0`
`cardano-ledger-spec-2.0.0`
....
`cardano-ledger-spec-10.0.0` 

then the latter won't be considered the latest,  because the sorting is done alphabetically. 

If we use `cardano-ledger-spec-YYYY-MM-DD` tag as proposed in this PR and tag based on the current date, then the provided alphabetical sorting should give us the desired sorting by latest. 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
