### PR TITLE
Fix index-state syntax in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,14 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
--- Bump this if you need newer packages from Hackage
+-- NOTE: repeating the index-state for Hackage is a temporary workaround
+-- for hackage.nix limited parsing ability.
+-- Bump both the following dates if you need newer packages from Hackage
 index-state: 2022-12-24T00:00:00Z
+index-state:
+  , hackage.haskell.org 2022-12-24T00:00:00Z
 -- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-11-02T15:34:17Z
+  , cardano-haskell-packages 2022-11-02T15:34:17Z
 
 packages:
   eras/allegra/impl


### PR DESCRIPTION
The index-state stanza in cabal.project is "last wins", so 
```
index-state: 2022-12-24T00:00:00Z
index-state: cardano-haskell-packages 2022-11-02T15:34:17Z
```
would set the index state of hackage to HEAD.

The correct syntax to set the index-state of both repositories is
```
index-state:
  , hackage.haskell.org 2022-12-24T00:00:00Z
  , cardano-haskell-packages 2022-11-02T15:34:17Z
```
haskell.nix has trouble parsing the index-state syntax with multiple repositories, so we repeat the index-state for Hackage. Cabal will ignore the first index-state stanza anyway.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff
