### PR TITLE
document why Redeemers and TxDats use MemoBytes

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -145,7 +145,7 @@ instance Memoized Redeemers where
   type RawType Redeemers = RedeemersRaw
 
 -- | Note that 'Redeemers' are based on 'MemoBytes' since we must preserve
--- the original bytes for the 'ScriptIntegrity'.
+-- the original bytes for the 'Cardano.Ledger.Alonzo.Tx.ScriptIntegrity'.
 -- Since the 'Redeemers' exist outside of the transaction body,
 -- this is how we ensure that they are not manipulated.
 newtype Redeemers era = RedeemersConstr (MemoBytes RedeemersRaw era)
@@ -283,7 +283,7 @@ instance (Era era) => FromCBOR (Annotator (TxDatsRaw era)) where
   fromCBOR = decode $ fmap (TxDatsRaw . keyBy hashData) <$> listDecodeA From
 
 -- | Note that 'TxDats' are based on 'MemoBytes' since we must preserve
--- the original bytes for the 'ScriptIntegrity'.
+-- the original bytes for the 'Cardano.Ledger.Alonzo.Tx.ScriptIntegrity'.
 -- Since the 'TxDats' exist outside of the transaction body,
 -- this is how we ensure that they are not manipulated.
 newtype TxDats era = TxDatsConstr (MemoBytes TxDatsRaw era)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -144,6 +144,10 @@ instance Typeable era => ToCBOR (RedeemersRaw era) where
 instance Memoized Redeemers where
   type RawType Redeemers = RedeemersRaw
 
+-- | Note that 'Redeemers' are based on 'MemoBytes' since we must preserve
+-- the original bytes for the 'ScriptIntegrity'.
+-- Since the 'Redeemers' exist outside of the transaction body,
+-- this is how we ensure that they are not manipulated.
 newtype Redeemers era = RedeemersConstr (MemoBytes RedeemersRaw era)
   deriving newtype (Eq, ToCBOR, NoThunks, SafeToHash, Typeable, NFData)
 
@@ -278,6 +282,10 @@ nullDats (TxDats' d) = Map.null d
 instance (Era era) => FromCBOR (Annotator (TxDatsRaw era)) where
   fromCBOR = decode $ fmap (TxDatsRaw . keyBy hashData) <$> listDecodeA From
 
+-- | Note that 'TxDats' are based on 'MemoBytes' since we must preserve
+-- the original bytes for the 'ScriptIntegrity'.
+-- Since the 'TxDats' exist outside of the transaction body,
+-- this is how we ensure that they are not manipulated.
 newtype TxDats era = TxDatsConstr (MemoBytes TxDatsRaw era)
   deriving newtype (SafeToHash, ToCBOR, Eq, NoThunks, NFData)
 


### PR DESCRIPTION
resolves #3236

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
