### PR TITLE
version the new cost model deserializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,7 @@ in the naming of release branches.
 
 - Fixed typo in makeHashWithExplicitProxys phantom type (indexl to index). #3072
 - Fixed the incorrect conversion of the validity interval's upper bound in `transVITime` (fixes #3043). #3200
+- Enforce that the CostModel deserializers expect a specific length prior to version 9.
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/CDDL.hs
@@ -9,6 +9,7 @@ where
 
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Alonzo (Alonzo)
+import Cardano.Ledger.Alonzo.Scripts (CostModels)
 import Cardano.Ledger.Alonzo.Scripts.Data (Data)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits, Redeemers)
 import Cardano.Ledger.Core
@@ -33,6 +34,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
     , cddlTest @(PParamsUpdate Alonzo) (eraProtVerHigh @Alonzo) n "protocol_param_update"
     , cddlAnnotatorTest @(Redeemers Alonzo) (eraProtVerHigh @Alonzo) n "[* redeemer]"
     , cddlAnnotatorTest @(Tx Alonzo) (eraProtVerHigh @Alonzo) n "transaction"
+    , cddlTest @CostModels (eraProtVerHigh @Alonzo) n "costmdls"
     ]
       <*> pure cddl
 

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -367,8 +367,8 @@ language = 0 ; Plutus v1
          / 1 ; Plutus v2
 
 costmdls =
-  { ? 0 : [ 166*166 int ] ; Plutus v1
-  , ? 1 : [ 175*175 int ] ; Plutus v2
+  { ? 0 : [ 166* int ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+  , ? 1 : [ 175* int ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
   }
 
 transaction_metadatum =


### PR DESCRIPTION
# Description

Enforce that the cost model deserializers prior to version 9 use a list of the expected length. This is required for full backwards compatibility (otherwise the current deserializers in ledger are more flexible than those currently used by the node).

Note that the `conway` CDDL file has been changed to reflect this change (and thus the CDDL tests as well).

~This is the last changed needed to resolve #2902.~ In order to resolve #2902, we still need to support deserializing cost models for future version of Plutus (we do now support adding new builtins).

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
