### PR TITLE
Property tests for constraints language

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -45,6 +45,7 @@ library
     Test.Cardano.Ledger.Constrained.Lenses
     Test.Cardano.Ledger.Constrained.Monad
     Test.Cardano.Ledger.Constrained.Spec
+    Test.Cardano.Ledger.Constrained.Tests
     Test.Cardano.Ledger.Constrained.TypeRep
     Test.Cardano.Ledger.Constrained.Vars
     Test.Cardano.Ledger.Examples.BabbageFeatures

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
@@ -71,7 +71,7 @@ subsetFromSetWithSize set n = help set Set.empty n
       | count <= 0 = pure target
       | otherwise = do
           item <- itemFromSet source
-          help (Set.delete item set) (Set.insert item target) (count - 1)
+          help (Set.delete item source) (Set.insert item target) (count - 1)
 
 mapFromSubset :: Ord a => Map a b -> Int -> Gen a -> Gen b -> Gen (Map a b)
 mapFromSubset subset n genA genB = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
@@ -44,8 +44,10 @@ fixSet numtrys size genA s = help numtrys s
             else error ("Ran out of trys in fixSet: " ++ show trys)
     help trys set = case compare (Set.size set) size of
       EQ -> pure set
-      GT -> help (trys - 1) (Set.deleteMin set)
-      LT -> do a <- genA; help (trys - 1) (Set.insert a set)
+      GT -> help (trys - 1) (iterate Set.deleteMin set !! (Set.size set - size))
+      LT -> do
+        new <- Set.fromList <$> vectorOf (size - Set.size set) genA
+        help (trys - 1) (Set.union new set)
 
 mapSized :: Ord a => Int -> Gen a -> Gen b -> Gen (Map a b)
 mapSized size genA genB = setSized size genA >>= addRange

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
@@ -41,7 +41,7 @@ fixSet numtrys size genA s = help numtrys s
       | trys <= 0 =
           if Set.size set == size
             then pure set
-            else error ("Ran out of trys in fixSet: " ++ show trys)
+            else error ("Ran out of trys in fixSet: need " ++ show size ++ " elements, have " ++ show (Set.size set))
     help trys set = case compare (Set.size set) size of
       EQ -> pure set
       GT -> help (trys - 1) (iterate Set.deleteMin set !! (Set.size set - size))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
@@ -7,6 +7,7 @@
 module Test.Cardano.Ledger.Constrained.Env (
   V (..),
   Env (..),
+  Payload (..),
   emptyEnv,
   findVar,
   storeVar,
@@ -40,6 +41,9 @@ data Access era t where
 type Field era x = Lens' (NewEpochState era) x
 
 data V era t where V :: String -> Rep era t -> (Access era t) -> V era t
+
+instance Show (V era t) where
+  show (V nm rep _) = nm ++ " :: " ++ show rep
 
 data Payload era where
   Payload :: Rep era t -> t -> (Access era t) -> Payload era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
@@ -50,7 +50,7 @@ import Prelude hiding (subtract)
 -- of what it is doing, and why.
 
 traceOn :: Bool
-traceOn = True
+traceOn = False
 
 ifTrace :: String -> a -> a
 ifTrace message a = case traceOn of
@@ -730,7 +730,9 @@ genSet rep@(SetR r) cond = explain ("Producing Set generator for " ++ showSetSpe
     xs <- partition i n
     pure (Set.fromList xs)
   SetSpec (Just n) None -> pure $ genSizedRep n rep
-  SetSpec (Just n) (SubsetRng set) -> pure $ subsetFromSetWithSize set n
+  SetSpec (Just n) (SubsetRng set)
+    | Set.size set < n -> failT ["Cannot make subset of size " ++ show n ++ " from set of size " ++ show (Set.size set)]
+    | otherwise -> pure $ subsetFromSetWithSize set n
   SetSpec (Just n) (DisjointRng set) -> pure $ setSized n (suchThat (genRep r) (`Set.notMember` set))
   SetSpec (Just _) (ProjRng _ _) -> failT ["FIX ME:  SetSpec (Just _) (ProjRng _ _)"]
   SetSpec (Just n) (Equal xs) ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
@@ -258,7 +258,7 @@ data OrderInfo = OrderInfo
   , setBeforeSubset :: Bool
   , mapBeforeDom :: Bool
   }
-  deriving (Show)
+  deriving (Show, Eq)
 
 standardOrderInfo :: OrderInfo
 standardOrderInfo =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
@@ -722,7 +722,10 @@ genSet rep@(SetR r) cond = explain ("Producing Set generator for " ++ showSetSpe
   SetSpec _ (NeverRng xs) -> failT xs
   SetSpec Nothing None -> pure $ genRep rep
   SetSpec Nothing (SubsetRng x) -> pure $ subsetFromSet x
-  SetSpec Nothing (DisjointRng x) -> pure $ suchThat (genRep rep) (Set.disjoint x)
+  SetSpec Nothing (DisjointRng x) ->
+    -- TODO: might want to push the suchThat into the element generator here to improve
+    --       distribution.
+    pure $ suchThat (genRep rep) (Set.disjoint x)
   SetSpec Nothing (Equal xs) -> pure $ pure (Set.fromList xs)
   SetSpec Nothing (ProjRng _ _) -> failT ["FIX ME: SetSpec Nothing (ProjRng _ _)"]
   SetSpec Nothing (SumRng n) -> pure $ do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
@@ -52,10 +52,14 @@ Current limitations
   - Only generates Sized and :<=: constraints
   - Only tests standardOrderInfo variable order
 
-Current issues
-  - Generates cyclic constraints of the form [Random A, B ⊆ A, A ⊆ B]
-  - Property fails on constraints like [Sized 3 A, B ⊆ A, C ⊆ B, Sized 1 C]
-    where the solver solves B with the empty set and then fails on the size constraint for C.
+The soundness property discards cases where we fail to find a solution to the constraints, but it's
+still interesting to know when this happens, since we try our best to generate solvable constraints.
+There is a strict version of the property (`prop_soundness' True`) that fails instead. Currently it
+fails in these cases:
+  - We can generate cyclic constraints of the form [Random A, B ⊆ A, A ⊆ B]
+  - When the existence of a solution to a later variable depends on the value picked for an earlier
+    variable. For instance, [Sized 3 A, B ⊆ A, C ⊆ B, Sized 1 C]. Here B needs to be solved with a
+    non-empty set for C to have a solution.
 -}
 
 -- Generators ---

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Test.Cardano.Ledger.Constrained.Tests where
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+import Cardano.Ledger.DPState (PState (..))
+import Cardano.Ledger.Pretty
+import Test.Cardano.Ledger.Constrained.Ast
+
+import Cardano.Ledger.Coin (Coin (..))
+import Test.Cardano.Ledger.Constrained.Env
+import Cardano.Ledger.Era (Era (EraCrypto))
+import Cardano.Ledger.Shelley
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes
+import Test.Cardano.Ledger.Constrained.Classes
+import Test.Cardano.Ledger.Constrained.Monad
+import Test.Cardano.Ledger.Constrained.Spec
+import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.Proof (
+  Evidence (..),
+  Proof (..),
+  Reflect (..),
+ )
+import Test.QuickCheck hiding (Fixed, total)
+
+-- Generators ---
+
+genLiteral :: Era era => Rep era t -> Gen (Literal era t)
+genLiteral rep = Lit rep <$> genRep rep
+
+genSizedLiteral :: Era era => Int -> Rep era t -> Gen (Literal era t)
+genSizedLiteral n rep = Lit rep <$> genSizedRep n rep
+
+genFreshVarName :: Env era -> Gen String
+genFreshVarName (Env env) = elements varNames
+  where
+    varNames = take 10 [ name | s <- "" : varNames
+                              , c <- ['A'..'Z']
+                              , let name = s ++ [c]
+                              , Map.notMember name env
+                       ]
+
+envVarsOfType :: Env era -> Rep era t -> [(V era t, Literal era t)]
+envVarsOfType (Env env) rep = concatMap (wellTyped rep) $ Map.toList env
+  where
+    wellTyped :: Rep era t -> (String, Payload era) -> [(V era t, Literal era t)]
+    wellTyped rep (name, Payload rep' val access) =
+      case testEql rep rep' of
+        Just Refl -> [(V name rep access, Lit rep val)]
+        Nothing   -> []
+
+genTerm :: Era era => Env era -> Rep era t -> Bool -> Gen (Term era t, Env era)
+genTerm env rep allowFixed = sized $ genSizedTerm env rep allowFixed
+
+genSizedTerm :: Era era => Env era -> Rep era t -> Bool -> Int -> Gen (Term era t, Env era)
+genSizedTerm env rep allowFixed size = frequency $
+  [ (5, genFixed)       | allowFixed ] ++
+  [ (5, genExistingVar) | not $ null existingVars ] ++
+  [ (1, genFreshVar)    | size > 0 || not allowFixed ]
+  where
+    existingVars = envVarsOfType env rep
+
+    genFixed       = (, env) . Fixed <$> genSizedLiteral size rep
+    genExistingVar = (, env) . Var <$> elements (map fst existingVars)
+
+    genFreshVar = do
+      name      <- genFreshVarName env
+      Lit _ val <- genSizedLiteral size rep
+      let var = V name rep No
+      pure (Var var, storeVar var val env)
+
+data TypeInEra era where
+  TypeInEra :: (Show t, Ord t) => Rep era t -> TypeInEra era
+
+genType :: Gen (TypeInEra era)
+genType = elements [TypeInEra IntR, TypeInEra (SetR IntR)]
+
+genBaseType :: Gen (TypeInEra era)
+genBaseType = elements [TypeInEra IntR]
+
+errPred :: [String] -> Pred era
+errPred errs = Fixed (Lit (ListR StringR) ["Errors:"]) :=: Fixed (Lit (ListR StringR) errs)
+
+genPred :: Era era => Env era -> Gen (Pred era, Env era)
+genPred env = sized $ genSizedPred env
+
+genSizedPred :: Era era => Env era -> Int -> Gen (Pred era, Env era)
+genSizedPred env size = frequency
+  [ (1, sized) ]
+  where
+    -- Fixed size
+    sized = do
+      TypeInEra rep <- genBaseType
+      (set, env')   <- genSizedTerm env (SetR rep) False size -- Must contain a variable!
+      case runTyped $ runTerm env' set of
+        Left errs -> pure (errPred errs, env')
+        Right val -> pure (Sized n set, env')
+          where n = Fixed $ Lit Word64R (getsize val)
+
+genPreds :: Era era => Env era -> Gen ([Pred era], Env era)
+genPreds env = do
+  n <- choose (1, 10)
+  loop (n :: Int) env
+  where
+    loop n env
+      | n == 0    = pure ([], env)
+      | otherwise = do
+        (pr, env')   <- genPred env
+        (prs, env'') <- loop (n - 1) env'
+        pure (pr : prs, env'')
+
+-- Tests ---
+
+type TestEra = ShelleyEra C_Crypto
+
+testProof :: Proof TestEra
+testProof = Shelley Mock
+
+testEnv :: Env TestEra
+testEnv = Env $ Map.fromList [ ("A", Payload IntR 5 No) ]
+
+ensureRight :: Testable prop => Either [String] a -> (a -> prop) -> Property
+ensureRight (Left errs) _ = counterexample (unlines errs) False
+ensureRight (Right x) prop = property $ prop x
+
+ensureTyped :: Testable prop => Typed a -> (a -> prop) -> Property
+ensureTyped = ensureRight . runTyped
+
+ifTyped :: Testable prop => Typed a -> (a -> prop) -> Property
+ifTyped t prop =
+  case runTyped t of
+    Left{}  -> False ==> False
+    Right x -> property $ prop x
+
+-- | Generate a set of satisfiable constraints and check that we can generate a solution and that it
+--   actually satisfies the constraints.
+prop_soundness :: Property
+prop_soundness =
+  forAll (genPreds @TestEra emptyEnv)                        $ \ (preds, _) ->
+  ensureTyped (compile standardOrderInfo preds)              $ \ graph ->
+  forAll (genDependGraph testProof graph) . flip ensureRight $ \ subst ->
+  let env = substToEnv subst emptyEnv
+      checkPred pr = counterexample ("Failed: " ++ show pr) $ ensureTyped (runPred env pr) id
+  in conjoin $ map checkPred preds
+

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -377,7 +377,7 @@ genRep ::
   Era era =>
   Rep era b ->
   Gen b
-genRep x = do (NonZero n) <- arbitrary; genSizedRep n x
+genRep x = do (NonNegative n) <- arbitrary; genSizedRep n x
 
 -- ===========================
 


### PR DESCRIPTION
Work-in-progress soundness property for constraint language. Checks that given a set of constraints, any solution we find is a valid solution.

From the documentation:

Current limitations of the tests
  - Only `IntR` and `SetR IntR` types (and `Word64R` for size constraints)
  - Only generates `Sized`, `:<=:`, `Disjoint`, and `SumsTo(SumSet)` constraints

Known limitations of the code that the tests avoid
  - Constraints of the form `Sized X t` cannot be solved (with X unknown), even with `sizeBeforeArg = False`. On the other hand `Sized n X` is no problem regardless of the value of `sizeBeforeArg`.
  - Superset constraints cannot be solved, meaning `setBeforeSubset` is always set to `True`.
  - The generator for `SumSet` is wrong. It does `Set.fromList` on a partitioned list which doesn't account for duplicate elements.
