### PR TITLE
enforce unique map keys in CBOR decoding, ver. 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,7 @@ in the naming of release branches.
 - Fixed typo in makeHashWithExplicitProxys phantom type (indexl to index). #3072
 - Fixed the incorrect conversion of the validity interval's upper bound in `transVITime` (fixes #3043). #3200
 - Enforce that the CostModel deserializers expect a specific length prior to version 9.
+- Starting in version 9, duplicate keys in CBOR maps are not longer allowed
 
 ## Release branch 1.1.x
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -130,7 +130,8 @@ test-suite tests
   main-is:           Main.hs
   type:              exitcode-stdio-1.0
 
-  other-modules:     Test.Cardano.Ledger.Binary.RoundTripSpec
+  other-modules:     Test.Cardano.Ledger.Binary.Failure
+                   , Test.Cardano.Ledger.Binary.RoundTripSpec
                    , Test.Cardano.Ledger.Binary.Vintage.Coders
                    , Test.Cardano.Ledger.Binary.Vintage.Drop
                    , Test.Cardano.Ledger.Binary.Vintage.Failure
@@ -153,6 +154,7 @@ test-suite tests
                    , hspec
                    , iproute
                    , primitive
+                   , QuickCheck
                    , tagged
                    , text
                    , testlib

--- a/libs/cardano-ledger-binary/test/Main.hs
+++ b/libs/cardano-ledger-binary/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+import qualified Test.Cardano.Ledger.Binary.Failure as Failure
 import qualified Test.Cardano.Ledger.Binary.RoundTripSpec as RoundTripSpec
 import qualified Test.Cardano.Ledger.Binary.Vintage.Coders as Vintage.Coders
 import qualified Test.Cardano.Ledger.Binary.Vintage.Drop as Vintage.Drop
@@ -21,6 +22,7 @@ spec = do
     Vintage.Coders.spec
   describe "Versioned" $ do
     RoundTripSpec.spec
+    Failure.spec
 
 main :: IO ()
 main = do

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.Failure (spec) where
+
+import Cardano.Ledger.Binary
+import Data.Either (isLeft)
+import Data.Map (Map)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+-- | Generate an association list with at least one duplicate key
+genDuplicateAssocList :: Gen [(Int, Int)]
+genDuplicateAssocList = do
+  xs <- getNonEmpty <$> arbitrary
+  (a, _) <- elements xs -- pick a key to duplicate
+  c <- arbitrary -- pick a value for duplicate key
+  shuffle ((a, c) : xs)
+
+-- | Generate a CBOR encoded association list with at least one duplicate key
+genDuplicateAssocListEncoding :: Gen Encoding
+genDuplicateAssocListEncoding = do
+  xs <- genDuplicateAssocList
+  let flatXs = concat [[a, b] | (a, b) <- xs]
+  oneof
+    [ pure $ encodeMapLen (fromIntegral $ Prelude.length xs) <> foldMap toCBOR flatXs
+    , pure $ encodeMapLenIndef <> foldMap toCBOR flatXs <> encodeBreak
+    ]
+
+-- | Starting in version 9, do not accept duplicates in CBOR maps
+prop_shouldFailMapWithDupKeys :: Property
+prop_shouldFailMapWithDupKeys =
+  forAllBlind genDuplicateAssocListEncoding $
+    ( \encodedMap ->
+        (property . isLeft) (decode (natVersion @9) encodedMap :: Either DecoderError (Map Int Int))
+    )
+
+decode :: FromCBOR a => Version -> Encoding -> Either DecoderError a
+decode version enc =
+  let encoded = serializeEncoding version enc
+   in decodeFull version encoded
+
+spec :: Spec
+spec = do
+  describe "Failures" $ do
+    prop "map duplicates are not allowed starting v9" prop_shouldFailMapWithDupKeys

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
@@ -307,7 +307,7 @@ spec = do
           \xs sxs -> xs `shouldBe` Set.toList sxs
         embedTripSpec v v (cborTrip @(VMap.VMap VMap.VP VMap.VP Word Int) @(Map.Map Word Int)) $
           \xs sxs -> xs `shouldBe` VMap.toMap sxs
-    forM_ [minBound .. natVersion @8] $ \v ->
+    forM_ [minBound .. natVersion @9] $ \v ->
       describe (show v) $ do
         embedTripSpec v v (cborTrip @Rational @(Integer, Integer)) $
           \(x, y) r -> (x, y) `shouldBe` (numerator r, denominator r)


### PR DESCRIPTION
# Description

Starting in major version 9, we raise a CBOR decoding error if a map contains duplicate keys.

resolves #2965

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
