### PR TITLE
introduce flexible cost model decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,12 @@ in the naming of release branches.
   - Replaced `PredicateFailure (EraRule "UPEC" era)` with `UpecPredFailure era`
 - Changed the type of the first field of `ShelleyBbodyState` to  #3216
   `State (EraRule "LEDGERS" era)`
+- Starting in version 9, CostModels can now be deserialized from any map of Word8 values to lists of integers.
+  Only valid cost models are actually converted to evaluation contexts that can be used.
+  Errors and unrecognized language versions are stored in the CostModels type so that:
+    - they can accept cost models that they do not yet understand
+    - upon deserializing after a software update, new cost models are available from the prior serialization.
+  #3283
 
 ### Removed
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -61,6 +61,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   CostModels (..),
   ExUnits (..),
   Prices (..),
+  emptyCostModels,
   getCostModelLanguage,
   getCostModelParams,
   zipSemiExUnits,
@@ -482,7 +483,7 @@ emptyAlonzoPParams =
     , appMinPoolCost = mempty
     , -- new/updated for alonzo
       appCoinsPerUTxOWord = CoinPerWord (Coin 0)
-    , appCostModels = CostModels mempty
+    , appCostModels = emptyCostModels
     , appPrices = Prices minBound minBound
     , appMaxTxExUnits = OrdExUnits $ ExUnits 0 0
     , appMaxBlockExUnits = OrdExUnits $ ExUnits 0 0
@@ -637,7 +638,7 @@ getLanguageView pp lang =
         (serialize' version lang)
         costModelEncoding
   where
-    costModel = Map.lookup lang (unCostModels $ pp ^. ppCostModelsL)
+    costModel = Map.lookup lang (costModelsValid $ pp ^. ppCostModelsL)
     costModelEncoding = serializeEncoding' version $ maybe encodeNull encodeCostModel costModel
     version = BT.pvMajor $ pp ^. ppProtocolVersionL
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PlutusScriptApi.hs
@@ -153,7 +153,7 @@ collectTwoPhaseScriptInputs ::
   Either [CollectError (EraCrypto era)] [(ShortByteString, Language, [Data era], ExUnits, CostModel)]
 collectTwoPhaseScriptInputs ei sysS pp tx utxo =
   let usedLanguages = Set.fromList [lang | (_, lang, _) <- neededAndConfirmedToBePlutus]
-      costModels = unCostModels $ pp ^. ppCostModelsL
+      costModels = costModelsValid $ pp ^. ppCostModelsL
       missingCMs = Set.filter (`Map.notMember` costModels) usedLanguages
    in case Set.lookupMin missingCMs of
         Just l -> Left [NoCostModel l]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -75,7 +75,7 @@ import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   ExUnits (..),
-  decodeCostModel,
+  decodeCostModelFailHard,
   encodeCostModel,
   getEvaluationContext,
   transProtocolVersion,
@@ -615,7 +615,7 @@ instance
     let lang = fromSLanguage $ isLanguage @l
     when (fromEnum lang /= fromIntegral tag) $ fail $ "Unexpected language: " <> show tag
     slang <- fromCBOR
-    costModel <- decodeCostModel lang
+    costModel <- decodeCostModelFailHard lang
     exUnits <- fromCBOR
     sbs <- fromCBOR
     pData <- fromCBOR

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -27,6 +27,7 @@ source-repository head
 library
     exposed-modules:
         Test.Cardano.Ledger.Alonzo.AlonzoEraGen
+        Test.Cardano.Ledger.Alonzo.CostModel
         Test.Cardano.Ledger.Alonzo.EraMapping
         Test.Cardano.Ledger.Alonzo.Examples.Consensus
         Test.Cardano.Ledger.Alonzo.PlutusScripts

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/CostModel.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/CostModel.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.CostModel (
+  costModelParamsCount,
+  freeCostModel,
+  freeV1CostModels,
+  freeV1V2CostModels,
+)
+where
+
+import Cardano.Ledger.Alonzo.Language (Language (..))
+import Cardano.Ledger.Alonzo.Scripts as Alonzo (
+  CostModel,
+  CostModels (..),
+  mkCostModel,
+ )
+import Data.Either (fromRight)
+import qualified Data.Map.Strict as Map
+import qualified PlutusLedgerApi.V1 as PV1 (ParamName)
+import qualified PlutusLedgerApi.V2 as PV2 (ParamName)
+import PlutusPrelude (enumerate)
+
+costModelParamsCount :: Language -> Int
+costModelParamsCount lang = case lang of
+  PlutusV1 -> length (enumerate @PV1.ParamName)
+  PlutusV2 -> length (enumerate @PV2.ParamName)
+
+-- | A cost model that sets everything as being free
+freeCostModel :: Language -> CostModel
+freeCostModel lang =
+  fromRight (error "freeCostModel is not well-formed") $
+    Alonzo.mkCostModel lang (replicate (costModelParamsCount lang) 0)
+
+freeV1CostModels :: CostModels
+freeV1CostModels = CostModels (Map.singleton PlutusV1 (freeCostModel PlutusV1)) mempty mempty
+
+freeV1V2CostModels :: CostModels
+freeV1V2CostModels =
+  CostModels (Map.fromList [(l, freeCostModel l) | l <- [PlutusV1, PlutusV2]]) mempty mempty

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -170,7 +170,7 @@ exampleAlonzoGenesis :: AlonzoGenesis
 exampleAlonzoGenesis =
   AlonzoGenesis
     { agCoinsPerUTxOWord = CoinPerWord $ Coin 1
-    , agCostModels = CostModels $ Map.fromList [(PlutusV1, testingCostModelV1)]
+    , agCostModels = CostModels (Map.fromList [(PlutusV1, testingCostModelV1)]) mempty mempty
     , agPrices = Prices (boundRational' 90) (boundRational' 91)
     , agMaxTxExUnits = ExUnits 123 123
     , agMaxBlockExUnits = ExUnits 223 223

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -47,7 +47,7 @@ import Data.Sequence.Strict
 import GHC.Stack (HasCallStack)
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1 (Data (..))
-import Test.Cardano.Ledger.Alonzo.AlonzoEraGen (freeCostModel)
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1V2CostModels)
 import Test.Cardano.Ledger.Alonzo.Examples.Consensus (ledgerExamplesAlonzo)
 import Test.Cardano.Ledger.Alonzo.Serialisation.CDDL (readDataFile)
 import Test.Cardano.Ledger.EraBuffet (StandardCrypto)
@@ -253,7 +253,7 @@ fromRightError errorMsg =
 exPP :: PParams Alonzo
 exPP =
   emptyPParams
-    & ppCostModelsL .~ CostModels (Map.fromList [(l, freeCostModel l) | l <- [PlutusV1, PlutusV2]])
+    & ppCostModelsL .~ freeV1V2CostModels
 
 exampleLangDepViewPV1 :: LangDepView
 exampleLangDepViewPV1 = LangDepView b1 b2
@@ -308,13 +308,20 @@ expectedGenesis =
   AlonzoGenesis
     { agCoinsPerUTxOWord = CoinPerWord $ Coin 34482
     , agPrices = Prices (fromJust $ boundRational 0.0577) (fromJust $ boundRational 0.0000721)
-    , agCostModels = CostModels $ Map.fromList [(PlutusV1, expectedCostModel), (PlutusV2, expectedCostModelV2)]
+    , agCostModels = expectedCostModels
     , agMaxTxExUnits = ExUnits 10000000 10000000000
     , agMaxBlockExUnits = ExUnits 50000000 40000000000
     , agMaxValSize = 5000
     , agCollateralPercentage = 150
     , agMaxCollateralInputs = 3
     }
+
+expectedCostModels :: CostModels
+expectedCostModels =
+  CostModels
+    (Map.fromList [(PlutusV1, expectedCostModel), (PlutusV2, expectedCostModelV2)])
+    mempty
+    mempty
 
 expectedCostModel :: CostModel
 expectedCostModel =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -40,9 +40,10 @@ import Cardano.Ledger.Alonzo.PParams (
   getLanguageView,
  )
 import Cardano.Ledger.Alonzo.Scripts (
-  CostModels (..),
+  CostModels,
   ExUnits (..),
   Prices (..),
+  emptyCostModels,
  )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
@@ -295,7 +296,7 @@ emptyBabbagePParams =
     , bppProtocolVersion = ProtVer (eraProtVerLow @era) 0
     , bppMinPoolCost = mempty
     , bppCoinsPerUTxOByte = CoinPerByte $ Coin 0
-    , bppCostModels = CostModels mempty
+    , bppCostModels = emptyCostModels
     , bppPrices = Prices minBound minBound
     , bppMaxTxExUnits = OrdExUnits $ ExUnits 0 0
     , bppMaxBlockExUnits = OrdExUnits $ ExUnits 0 0

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -366,10 +366,17 @@ ex_unit_prices =
 language = 0 ; Plutus v1
          / 1 ; Plutus v2
 
-costmdls =
-  { ? 0 : [ 166* int ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
-  , ? 1 : [ 175* int ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
-  }
+potential_languages = 0 .. 255
+
+; The format for costmdls is flexible enough to allow adding Plutus built-ins and language
+; versions in the future.
+;
+; To construct valid cost models, however, you must restrict to:
+;
+; { ? 0 : [ 166* int ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+; , ? 1 : [ 175* int ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
+; }
+costmdls = { * potential_languages => [int] }
 
 transaction_metadatum =
     { * transaction_metadatum => transaction_metadatum }

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Roundtrip.hs
@@ -11,6 +11,7 @@ import Cardano.Ledger.Binary.Version (natVersion)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Core (Era (..))
 import Data.Data (Proxy (..), typeRep)
+import Test.Cardano.Ledger.Alonzo.Serialisation.Generators (FlexibleCostModels)
 import Test.Cardano.Ledger.Binary.RoundTrip (roundTripCborRangeExpectation)
 import Test.Cardano.Ledger.Conway.Serialisation.Generators ()
 import Test.Tasty (TestTree, testGroup)
@@ -22,4 +23,6 @@ allprops =
     (show $ typeRep (Proxy @e))
     [ testProperty "ConwayGenesis" $
         roundTripCborRangeExpectation @(ConwayGenesis (EraCrypto e)) (natVersion @2) maxBound
+    , testProperty "v9 CostModels" $
+        roundTripCborRangeExpectation @FlexibleCostModels (natVersion @9) (natVersion @9)
     ]

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
@@ -54,6 +54,15 @@ instance NoThunks Language
 
 instance NFData Language
 
+-- | Make a language form its `Enum` index.
+mkLanguageEnum :: Int -> Maybe Language
+mkLanguageEnum iLang
+  | minLang <= iLang && iLang <= maxLang = Just $ toEnum iLang
+  | otherwise = Nothing
+  where
+    minLang = fromEnum (minBound :: Language)
+    maxLang = fromEnum (maxBound :: Language)
+
 instance FromJSON Language where
   parseJSON = withText "Language" languageFromText
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   CostModel,
-  CostModels (CostModels),
+  CostModels (..),
   ExUnits (ExUnits),
   Prices (..),
   Tag,
@@ -105,7 +105,7 @@ instance PrettyA CostModel where
   prettyA = ppCostModel
 
 ppCostModels :: CostModels -> PDoc
-ppCostModels (CostModels cms) = ppMap ppLanguage ppCostModel cms
+ppCostModels cms = ppMap ppLanguage ppCostModel (costModelsValid cms)
 
 ppPrices :: Prices -> PDoc
 ppPrices Prices {prMem, prSteps} =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -10,7 +10,7 @@ module Test.Cardano.Ledger.Alonzo.Tools (tests, testExUnitCalculation) where
 import Cardano.Crypto.DSIGN
 import qualified Cardano.Crypto.Hash as Crypto
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModel, CostModels (..), ExUnits (..), Tag (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModel, ExUnits (..), Tag (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
 import Cardano.Ledger.Alonzo.Tools (TransactionScriptFailure (..), evaluateTransactionExecutionUnits)
@@ -40,7 +40,7 @@ import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
-import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1)
+import Test.Cardano.Ledger.Alonzo.CostModel (freeCostModel, freeV1CostModels)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
@@ -247,7 +247,7 @@ uenv :: EraPParams era => Proof era -> UtxoEnv era
 uenv pf = UtxoEnv (SlotNo 0) (pparams pf) def (GenDelegs mempty)
 
 costmodels :: Array Language CostModel
-costmodels = array (PlutusV1, PlutusV1) [(PlutusV1, testingCostModelV1)]
+costmodels = array (PlutusV1, PlutusV1) [(PlutusV1, freeCostModel PlutusV1)]
 
 ustate ::
   ( EraTxOut era
@@ -314,7 +314,7 @@ pparams :: EraPParams era => Proof era -> PParams era
 pparams proof =
   newPParams
     proof
-    [ Costmdls . CostModels $ Map.singleton PlutusV1 testingCostModelV1
+    [ Costmdls freeV1CostModels
     , MaxValSize 1000000000
     , MaxTxExUnits $ ExUnits 100000000 100000000
     , MaxBlockExUnits $ ExUnits 100000000 100000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
@@ -13,7 +13,7 @@
 
 module Test.Cardano.Ledger.Examples.AlonzoAPI (tests) where
 
-import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
 import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..))
@@ -27,9 +27,9 @@ import Cardano.Ledger.Shelley.API (evaluateTransactionFee)
 import Cardano.Ledger.Val (Val (inject))
 import qualified Data.Map.Strict as Map
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
-  freeCostModelV1,
   mkGenesisTxIn,
   mkTxDats,
   someAddr,
@@ -101,7 +101,7 @@ testEvaluateTransactionFee =
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -19,10 +19,7 @@ import Cardano.Ledger.Alonzo.Language (Language (..))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoBbodyPredFailure (..),
  )
-import Cardano.Ledger.Alonzo.Scripts (
-  CostModels (..),
-  ExUnits (..),
- )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), hashData)
 import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..))
@@ -92,11 +89,11 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   alwaysFailsHash,
   alwaysSucceedsHash,
-  freeCostModelV1,
   initUTxO,
   mkGenesisTxIn,
   mkTxDats,
@@ -710,7 +707,7 @@ hashsize = fromIntegral $ sizeHash ([] @(CC.HASH c))
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Alonzo.PlutusScriptApi (CollectError (..), collectTwoPhase
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   CostModel,
-  CostModels (..),
   ExUnits (..),
  )
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
@@ -47,6 +46,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   freeCostModelV1,
@@ -199,7 +199,7 @@ testSystemStart = SystemStart $ posixSecondsToUTCTime 0
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -23,10 +23,7 @@ import Cardano.Ledger.Alonzo.Rules (
   FailureDescription (..),
   TagMismatchDescription (..),
  )
-import Cardano.Ledger.Alonzo.Scripts (
-  CostModels (..),
-  ExUnits (..),
- )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), hashData)
 import Cardano.Ledger.Alonzo.Tx (
@@ -71,11 +68,11 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   AlonzoBased (..),
   alwaysSucceedsHash,
-  freeCostModelV1,
   initUTxO,
   keyBy,
   mkGenesisTxIn,
@@ -954,7 +951,7 @@ extraneousKeyHash = hashKey . snd . mkKeyPair $ RawSeed 0 0 0 0 99
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -15,10 +15,7 @@ module Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW (tests) where
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (
-  CostModels (..),
-  ExUnits (..),
- )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), hashData)
 import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..))
@@ -60,11 +57,11 @@ import Data.Default.Class (Default (..))
 import qualified Data.Map.Strict as Map
 import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   alwaysFailsHash,
   alwaysSucceedsHash,
-  freeCostModelV1,
   initUTxO,
   mkGenesisTxIn,
   mkTxDats,
@@ -922,7 +919,7 @@ scriptStakeCredSuceed pf = ScriptHashObj (alwaysSucceedsHash 2 pf)
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxosPredFailure (CollectErrors),
   AlonzoUtxowPredFailure (NonOutputSupplimentaryDatums),
  )
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (PlutusScript), CostModels (..), ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (PlutusScript), ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Alonzo.TxInfo (
@@ -70,11 +70,10 @@ import qualified Data.Set as Set
 import GHC.Stack
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1V2CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   AlonzoBased (..),
-  freeCostModelV1,
-  freeCostModelV2,
   mkGenesisTxIn,
   mkTxDats,
   testUTXOW,
@@ -197,7 +196,7 @@ yetAnotherTxIn = mkGenesisTxIn 3
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.fromList [(PlutusV1, freeCostModelV1), (PlutusV2, freeCostModelV2)]
+  [ Costmdls freeV1V2CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -11,7 +11,7 @@
 module Test.Cardano.Ledger.Generic.ApplyTx where
 
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
-import Cardano.Ledger.Alonzo.Scripts (CostModels (..), ExUnits (ExUnits))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (ExUnits))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
@@ -47,9 +47,9 @@ import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
-  freeCostModelV1,
   initUTxO,
   mkGenesisTxIn,
   mkTxDats,
@@ -88,7 +88,7 @@ import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo)
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
-  [ Costmdls . CostModels $ Map.singleton PlutusV1 freeCostModelV1
+  [ Costmdls $ freeV1CostModels
   , MaxValSize 1000000000
   , MaxTxExUnits $ ExUnits 1000000 1000000
   , MaxBlockExUnits $ ExUnits 1000000 1000000

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Consensus.hs
@@ -981,7 +981,7 @@ exampleAlonzoGenesis :: AlonzoGenesis
 exampleAlonzoGenesis =
   AlonzoGenesis
     { agCoinsPerUTxOWord = CoinPerWord (Coin 1)
-    , agCostModels = CostModels $ Map.fromList [(PlutusV1, testingCostModelV1)]
+    , agCostModels = CostModels (Map.fromList [(PlutusV1, testingCostModelV1)]) mempty mempty
     , agPrices = Prices (boundRational' 90) (boundRational' 91)
     , agMaxTxExUnits = ExUnits 123 123
     , agMaxBlockExUnits = ExUnits 223 223

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Generic.Updaters where
 
 import Cardano.Crypto.DSIGN.Class ()
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModels (..))
+import Cardano.Ledger.Alonzo.Scripts (emptyCostModels)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), hashScriptIntegrity)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
@@ -42,7 +42,7 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro
-import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1, testingCostModelV2)
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels, freeV1V2CostModels)
 import Test.Cardano.Ledger.Generic.Fields
 import Test.Cardano.Ledger.Generic.Proof
 
@@ -411,20 +411,12 @@ newScriptIntegrityHash (Alonzo _) pp ls rds dats =
 newScriptIntegrityHash _wit _pp _ls _rds _dats = SNothing
 
 defaultCostModels :: Proof era -> PParamsField era
-defaultCostModels (Shelley _) = Costmdls (CostModels mempty)
-defaultCostModels (Allegra _) = Costmdls (CostModels mempty)
-defaultCostModels (Mary _) = Costmdls (CostModels mempty)
-defaultCostModels (Alonzo _) = Costmdls . CostModels $ Map.singleton PlutusV1 testingCostModelV1
-defaultCostModels (Babbage _) =
-  Costmdls . CostModels . Map.fromList $
-    [ (PlutusV1, testingCostModelV1)
-    , (PlutusV2, testingCostModelV2)
-    ]
-defaultCostModels (Conway _) =
-  Costmdls . CostModels . Map.fromList $
-    [ (PlutusV1, testingCostModelV1)
-    , (PlutusV2, testingCostModelV2)
-    ]
+defaultCostModels (Shelley _) = Costmdls emptyCostModels
+defaultCostModels (Allegra _) = Costmdls emptyCostModels
+defaultCostModels (Mary _) = Costmdls emptyCostModels
+defaultCostModels (Alonzo _) = Costmdls freeV1CostModels
+defaultCostModels (Babbage _) = Costmdls freeV1V2CostModels
+defaultCostModels (Conway _) = Costmdls freeV1V2CostModels
 
 languages :: Proof era -> [Language]
 languages (Shelley _) = []


### PR DESCRIPTION
# Description

Starting in version 9, `CostModels` can now be deserialized from any map of `Word8` values to lists of integers. Only valid cost models are actually converted to evaluation contexts that can be used. Errors and unrecognized language versions are stored in the `CostModels` type so that:

* they can accept cost models that they do not yet understand
* upon deserializing after a software update, new cost models are available from the prior serialization.

resolves #2902

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff
