### PR TITLE
Workaround ghcup issue on CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -50,6 +50,13 @@ jobs:
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
+    # Workaround the issue on GA Ubuntu images:
+    # https://github.com/actions/runner-images/issues/7061
+    - name: Fixup ghcup
+      run: |
+        rm -f /usr/local/.ghcup/cache/ghcup-0.0.7.yaml*
+        sudo chown -R $USER /usr/local/.ghcup
+
     - name: Install Haskell
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell


### PR DESCRIPTION
# Description

Yesterday we started getting CI failures due to ghcup hitting an issue on GA ubuntu image. This PR works around it

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [ ] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
