### PR TITLE
clarifying the script integrity hash

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -92,11 +92,11 @@ script_data_hash = $hash32 ; New
 ; Since this data does not exist in contiguous form inside a transaction, it needs
 ; to be independently constructed by each recipient.
 ;
-; script data format:
-; [ redeemers | datums | language views ]
+; The bytestring which is hashed is the concatenation of three things:
+;   redeemers || datums || language views
 ; The redeemers are exactly the data present in the transaction witness set.
 ; Similarly for the datums, if present. If no datums are provided, the middle
-; field is an empty string.
+; field is omitted (i.e. it is the empty/null bytestring).
 ;
 ; language views CDDL:
 ; { * language => script_integrity_data }

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -103,11 +103,11 @@ script_data_hash = $hash32
 ; Since this data does not exist in contiguous form inside a transaction, it needs
 ; to be independently constructed by each recipient.
 ;
-; script data format:
-; [ redeemers | datums | language views ]
+; The bytestring which is hashed is the concatenation of three things:
+;   redeemers || datums || language views
 ; The redeemers are exactly the data present in the transaction witness set.
 ; Similarly for the datums, if present. If no datums are provided, the middle
-; field is an empty string.
+; field is omitted (i.e. it is the empty/null bytestring).
 ;
 ; language views CDDL:
 ; { * language => script_integrity_data }

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -146,11 +146,11 @@ script_data_hash = $hash32
 ; Since this data does not exist in contiguous form inside a transaction, it needs
 ; to be independently constructed by each recipient.
 ;
-; script data format:
-; [ redeemers | datums | language views ]
+; The bytestring which is hashed is the concatenation of three things:
+;   redeemers || datums || language views
 ; The redeemers are exactly the data present in the transaction witness set.
 ; Similarly for the datums, if present. If no datums are provided, the middle
-; field is an empty string.
+; field is omitted (i.e. it is the empty/null bytestring).
 ;
 ; language views CDDL:
 ; { * language => script_integrity_data }


### PR DESCRIPTION
# Description

Clarifying the script integrity hash in the CDDL description:
* remove the outer square brackets so as to not imply that the bytes are inside of a CBOR array
* explicitly describe in prose that we are concatenating
* use the notation from cryptography of double pipe for concatenation
* make it clear that if there are no datums, that "empty string" here means the empty bytestring, ie that it is omitted.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
