### PR TITLE
Relax generator and speedup tests

### DIFF
--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -192,7 +192,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
       <*> arbitrary
       <*> genMintValues @(EraCrypto era)
       <*> arbitrary

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -86,6 +86,8 @@ tests =
         roundTripCborExpectation @(AlonzoUtxosPredFailure Alonzo)
     , testProperty "Script" $
         roundTripAnnRangeExpectation @(Script Alonzo)
+          (eraProtVerLow @Alonzo)
+          (eraProtVerHigh @Alonzo)
     , testProperty "alonzo/Tx" $
         roundTripAnnRangeExpectation @(Tx Alonzo)
           (eraProtVerLow @Alonzo)

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -75,7 +75,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
       <*> arbitrary
       <*> genMintValues
       <*> arbitrary

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
@@ -23,13 +23,19 @@ tests =
   testGroup
     "Babbage CBOR round-trip"
     [ testProperty "babbage/Script" $
-        roundTripAnnExpectation @(Script Babbage)
+        roundTripAnnRangeExpectation @(Script Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "babbage/Metadata" $
-        roundTripAnnExpectation @(TxAuxData Babbage)
+        roundTripAnnRangeExpectation @(TxAuxData Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "babbage/TxOut" $
         roundTripCborExpectation @(TxOut Babbage)
     , testProperty "babbage/TxBody" $
-        roundTripAnnExpectation @(TxBody Babbage)
+        roundTripAnnRangeExpectation @(TxBody Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "babbage/CostModel" $
         roundTripCborExpectation @CostModels
     , testProperty "babbage/PParams" $
@@ -37,13 +43,21 @@ tests =
     , testProperty "babbage/PParamsUpdate" $
         roundTripCborExpectation @(PParamsUpdate Babbage)
     , testProperty "babbage/AuxiliaryData" $
-        roundTripAnnExpectation @(TxAuxData Babbage)
+        roundTripAnnRangeExpectation @(TxAuxData Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "Script" $
-        roundTripAnnExpectation @(Script Babbage)
+        roundTripAnnRangeExpectation @(Script Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "babbage/Tx" $
-        roundTripAnnExpectation @(Tx Babbage)
+        roundTripAnnRangeExpectation @(Tx Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     , testProperty "babbage/BabbageUtxoPredFailure" $
         roundTripCborExpectation @(BabbageUtxoPredFailure Babbage)
     , testProperty "babbage/Block" $
-        roundTripAnnExpectation @(Block (BHeader StandardCrypto) Babbage)
+        roundTripAnnRangeExpectation @(Block (BHeader StandardCrypto) Babbage)
+          (eraProtVerLow @Babbage)
+          (eraProtVerHigh @Babbage)
     ]

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Generators.hs
@@ -50,6 +50,7 @@ import Test.QuickCheck (
   listOf,
   oneof,
   resize,
+  scale,
   shrink,
   vectorOf,
  )
@@ -151,7 +152,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
       <*> arbitrary
 
 {-------------------------------------------------------------------------------
@@ -170,7 +171,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
       <*> arbitrary
       <*> genMintValues
 

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 
 import Cardano.Ledger.Allegra (Allegra)
 import Cardano.Ledger.Binary (FromCBOR, ToCBOR)
-import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (Mary)
 import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.API (ApplyTx, ApplyTxError)
@@ -18,7 +18,7 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Typeable (typeRep)
 import Test.Cardano.Ledger.Binary.RoundTrip (
   cborTrip,
-  roundTripAnnExpectation,
+  roundTripAnnRangeExpectation,
   roundTripCborExpectation,
   roundTripExpectation,
  )
@@ -32,22 +32,31 @@ import Test.Tasty.QuickCheck (testProperty)
 eraRoundTripProps ::
   forall e.
   ( ApplyTx e
-  , Arbitrary (Core.TxBody e)
-  , Arbitrary (Core.TxAuxData e)
-  , Arbitrary (Core.Value e)
-  , Arbitrary (Core.Script e)
+  , Arbitrary (TxBody e)
+  , Arbitrary (TxAuxData e)
+  , Arbitrary (Value e)
+  , Arbitrary (Script e)
   , Arbitrary (ApplyTxError e)
-  , ToCBOR (PredicateFailure (Core.EraRule "LEDGER" e))
-  , FromCBOR (PredicateFailure (Core.EraRule "LEDGER" e))
+  , ToCBOR (PredicateFailure (EraRule "LEDGER" e))
+  , FromCBOR (PredicateFailure (EraRule "LEDGER" e))
   ) =>
   TestTree
 eraRoundTripProps =
   testGroup
     (show $ typeRep (Proxy @e))
-    [ testProperty "TxBody" $ roundTripAnnExpectation @(Core.TxBody e)
-    , testProperty "Metadata" $ roundTripAnnExpectation @(Core.TxAuxData e)
-    , testProperty "Value" $ roundTripExpectation @(Core.Value e) cborTrip
-    , testProperty "Script" $ roundTripAnnExpectation @(Core.Script e)
+    [ testProperty "TxBody" $
+        roundTripAnnRangeExpectation @(TxBody e)
+          (eraProtVerLow @e)
+          (eraProtVerHigh @e)
+    , testProperty "Metadata" $
+        roundTripAnnRangeExpectation @(TxAuxData e)
+          (eraProtVerLow @e)
+          (eraProtVerHigh @e)
+    , testProperty "Value" $ roundTripExpectation @(Value e) cborTrip
+    , testProperty "Script" $
+        roundTripAnnRangeExpectation @(Script e)
+          (eraProtVerLow @e)
+          (eraProtVerHigh @e)
     , testProperty "ApplyTxError" $ roundTripCborExpectation @(ApplyTxError e)
     ]
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators.hs
@@ -19,7 +19,7 @@ import qualified Cardano.Ledger.Shelley.Rules as STS
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
-import Test.QuickCheck (Arbitrary (..))
+import Test.QuickCheck (Arbitrary (..), scale)
 
 {-------------------------------------------------------------------------------
   ShelleyEra Generators
@@ -40,7 +40,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
       <*> arbitrary
 
 instance

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Binary (
   fromNotSharedCBOR,
  )
 import Cardano.Ledger.Compactible (Compactible (..))
+import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.API as Ledger
@@ -79,11 +80,17 @@ tests =
   testGroup
     "Serialisation roundtrip Property Tests"
     $ [ testProperty "Block" $
-          roundTripAnnExpectation @(Block (TP.BHeader StandardCrypto) Shelley)
+          roundTripAnnRangeExpectation @(Block (TP.BHeader StandardCrypto) Shelley)
+            (eraProtVerLow @Shelley)
+            (eraProtVerHigh @Shelley)
       , testProperty "TxBody" $
-          roundTripAnnExpectation @(ShelleyTxBody Shelley)
+          roundTripAnnRangeExpectation @(ShelleyTxBody Shelley)
+            (eraProtVerLow @Shelley)
+            (eraProtVerHigh @Shelley)
       , testProperty "Tx" $
-          roundTripAnnExpectation @(ShelleyTx Shelley)
+          roundTripAnnRangeExpectation @(ShelleyTx Shelley)
+            (eraProtVerLow @Shelley)
+            (eraProtVerHigh @Shelley)
       , testProperty "TxOut" $
           roundTripExpectation @(ShelleyTxOut Shelley) cborTrip
       , testProperty "LEDGER Predicate Failures" $
@@ -95,9 +102,13 @@ tests =
       , testProperty "NewEpoch State" $
           roundTripExpectation @(NewEpochState Shelley) cborTrip
       , testProperty "MultiSig" $
-          roundTripAnnExpectation @(MultiSig Shelley)
+          roundTripAnnRangeExpectation @(MultiSig Shelley)
+            (eraProtVerLow @Shelley)
+            (eraProtVerHigh @Shelley)
       , testProperty "TxAuxData" $
-          roundTripAnnExpectation @(ShelleyTxAuxData Shelley)
+          roundTripAnnRangeExpectation @(ShelleyTxAuxData Shelley)
+            (eraProtVerLow @Shelley)
+            (eraProtVerHigh @Shelley)
       , testProperty "Shelley Genesis" $
           roundTripExpectation @(ShelleyGenesis StandardCrypto) cborTrip
       , testProperty "NominalDiffTimeMicro" $


### PR DESCRIPTION
# Description

This PR fixes the slowdown in tests  introduced in #3288 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [ ] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
