### PR TITLE
Recompute stake distribution in Conway translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,7 @@ BabbageEraTxBody --> AlonzoEraTxBody --> ....
                 `--> BabbageEraTxOut -> AlonzoEraTxOut -->
 ```
 ### Changed
+- Updated `Translation.hs` in Conway to recompute the stake distribution
 - Introduced a new switch in `HardForks` that turns off pointer address resolution in `IncrementalStake` starting with version 9
 - Some types have been moved:
   - The `WitVKey` type has been moved into its own module in core.


### PR DESCRIPTION
# Description

Since we [stop resolving pointer addresses](https://github.com/input-output-hk/cardano-ledger/pull/3253) starting with Conway, we also have to adjust the stake within the UTxOState. 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
