### PR TITLE
Fixed that the preservation of Ada proof was missing

### DIFF
--- a/eras/shelley/formal-spec/hand_proofs.tex
+++ b/eras/shelley/formal-spec/hand_proofs.tex
@@ -1,3 +1,5 @@
+\newcommand{\StakeCreds}{\type{StakeCreds}}
+\newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
 
 \subsection{Preservation of Value}
 \label{sec:preservation-of-value}

--- a/eras/shelley/formal-spec/shelley-ledger.tex
+++ b/eras/shelley/formal-spec/shelley-ledger.tex
@@ -361,6 +361,7 @@
 \include{software-updates}
 \include{sts-overview}
 \include{properties}
+\include{hand_proofs}
 \include{leader-value}
 \include{errata}
 


### PR DESCRIPTION
# Description

The latex file was there, it was just not included. I thought I'd fixed that years ago, but it seems that I've never committed the fix.