### PR TITLE
Conway additions

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -42,6 +42,7 @@ library
         Cardano.Ledger.Conway.Rules.Ledger
         Cardano.Ledger.Conway.Rules.NewEpoch
         Cardano.Ledger.Conway.Rules.Tally
+        Cardano.Ledger.Conway.Rules.Tickf
         Cardano.Ledger.Conway.Rules.Utxos
 
     default-language: Haskell2010

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Delegation/Certificates.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Delegation/Certificates.hs
@@ -18,7 +18,13 @@ import Cardano.Ledger.Binary (
   listLenInt,
  )
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Shelley.Delegation.Certificates (ConstitutionalDelegCert (..), DCert (..), DelegCert (..), Delegation (..), PoolCert (..))
+import Cardano.Ledger.Shelley.Delegation.Certificates (
+  ConstitutionalDelegCert (..),
+  DCert (..),
+  DelegCert (..),
+  Delegation (..),
+  PoolCert (..),
+ )
 import Cardano.Ledger.Slot (EpochNo (..))
 import Control.DeepSeq (NFData)
 import Data.Word (Word8)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -8,6 +8,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayEPOCH,
   ConwayENACTMENT,
   ConwayUTXOS,
+  ConwayTICKF,
   ConwayLEDGER,
 ) where
 
@@ -24,7 +25,6 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyRUPD,
   ShelleySNAP,
   ShelleyTICK,
-  ShelleyTICKF,
  )
 
 -- =====================================================
@@ -67,6 +67,10 @@ data ConwayLEDGER era
 
 type instance EraRule "LEDGER" (ConwayEra c) = ConwayLEDGER (ConwayEra c)
 
+data ConwayTICKF era
+
+type instance EraRule "TICKF" (ConwayEra c) = ConwayTICKF (ConwayEra c)
+
 -- Rules inherited from Babbage
 
 type instance EraRule "UTXO" (ConwayEra c) = BabbageUTXO (ConwayEra c)
@@ -101,6 +105,6 @@ type instance EraRule "SNAP" (ConwayEra c) = ShelleySNAP (ConwayEra c)
 
 type instance EraRule "TICK" (ConwayEra c) = ShelleyTICK (ConwayEra c)
 
-type instance EraRule "TICKF" (ConwayEra c) = ShelleyTICKF (ConwayEra c)
+type instance EraRule "TICKF" (ConwayEra c) = ConwayTICKF (ConwayEra c)
 
 -- =================================================

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -3,8 +3,9 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Epoch,
   module Cardano.Ledger.Conway.Rules.Ledger,
   module Cardano.Ledger.Conway.Rules.NewEpoch,
-  module Cardano.Ledger.Conway.Rules.Utxos,
   module Cardano.Ledger.Conway.Rules.Tally,
+  module Cardano.Ledger.Conway.Rules.Tickf,
+  module Cardano.Ledger.Conway.Rules.Utxos,
 )
 where
 
@@ -13,4 +14,5 @@ import Cardano.Ledger.Conway.Rules.Epoch
 import Cardano.Ledger.Conway.Rules.Ledger
 import Cardano.Ledger.Conway.Rules.NewEpoch
 import Cardano.Ledger.Conway.Rules.Tally
+import Cardano.Ledger.Conway.Rules.Tickf
 import Cardano.Ledger.Conway.Rules.Utxos

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tally.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tally.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -18,6 +19,7 @@ module Cardano.Ledger.Conway.Rules.Tally (
 ) where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Conway.Era (ConwayTALLY)
 import Cardano.Ledger.Conway.Governance (
   ConwayTallyState (..),
@@ -30,6 +32,7 @@ import Cardano.Ledger.Conway.Governance (
 import Cardano.Ledger.Core (Era (..))
 import Cardano.Ledger.Rules.ValidationMode (Inject (..), Test, runTest)
 import Cardano.Ledger.Shelley.Tx (TxId (..))
+import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   STS (..),
   TRC (..),
@@ -39,6 +42,7 @@ import Control.State.Transition.Extended (
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
+import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
 newtype TallyEnv era = TallyEnv (TxId (EraCrypto era))
@@ -49,7 +53,9 @@ data GovernanceProcedure era
 
 newtype ConwayTallyPredFailure era
   = NoSuchGovernanceAction (Vote era)
-  deriving (Eq, Show)
+  deriving (Eq, Show, ToCBOR, FromCBOR, NoThunks)
+
+deriving instance Era era => NFData (ConwayTallyPredFailure era)
 
 instance Era era => STS (ConwayTALLY era) where
   type State (ConwayTALLY era) = ConwayTallyState era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Rules.Tickf (
+  ConwayTICKF,
+  ConwayTickfPredFailure,
+)
+where
+
+import Cardano.Ledger.BaseTypes (ShelleyBase, SlotNo)
+import Cardano.Ledger.Conway.Era
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.LedgerState
+import Control.State.Transition
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+-- ==================================================
+
+{------------------------------------------------------------------------------
+-- TICKF transition
+
+-- This is a variant on the TICK transition called only by the consensus layer
+to tick the ledger state to a future slot.
+------------------------------------------------------------------------------}
+
+data ConwayTickfPredFailure era
+  deriving (Generic)
+
+deriving instance
+  ( Era era
+  ) =>
+  Show (ConwayTickfPredFailure era)
+
+deriving instance
+  ( Era era
+  ) =>
+  Eq (ConwayTickfPredFailure era)
+
+instance NoThunks (ConwayTickfPredFailure era)
+
+data ConwayTickfEvent era
+
+instance
+  ( Era era
+  ) =>
+  STS (ConwayTICKF era)
+  where
+  type State (ConwayTICKF era) = NewEpochState era
+  type Signal (ConwayTICKF era) = SlotNo
+  type Environment (ConwayTICKF era) = ()
+  type BaseM (ConwayTICKF era) = ShelleyBase
+  type PredicateFailure (ConwayTICKF era) = ConwayTickfPredFailure era
+  type Event (ConwayTICKF era) = ConwayTickfEvent era
+
+  initialRules = []
+  transitionRules = pure $ do
+    TRC ((), nes, _) <- judgmentContext
+    pure nes

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
@@ -6,6 +6,7 @@
 module Cardano.Ledger.Conway.Rules.Tickf (
   ConwayTICKF,
   ConwayTickfPredFailure,
+  ConwayTickfEvent,
 )
 where
 

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -54,8 +54,7 @@ library
         cardano-strict-containers,
         microlens,
         tasty,
-        tasty-quickcheck,
-        QuickCheck
+        tasty-quickcheck
 
 test-suite cardano-ledger-conway-test
     type:             exitcode-stdio-1.0

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Generators.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Serialisation/Generators.hs
@@ -1,14 +1,196 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conway.Serialisation.Generators () where
 
+import Cardano.Ledger.Binary (Sized)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Delegation.Certificates
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Crypto (Crypto)
+import Control.State.Transition.Extended (STS (Event))
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
-import Test.QuickCheck (Arbitrary (..))
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
+import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators (genMintValues)
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
   arbitrary = ConwayGenesis <$> arbitrary <*> arbitrary
+
+instance Crypto c => Arbitrary (ConwayDCert c) where
+  arbitrary =
+    oneof
+      [ ConwayDCertDeleg <$> arbitrary
+      , ConwayDCertPool <$> arbitrary
+      , ConwayDCertConstitutional <$> arbitrary
+      ]
+
+------------------------------------------------------------------------------------------
+-- Cardano.Ledger.Conway.Governance ------------------------------------------------------
+------------------------------------------------------------------------------------------
+
+deriving instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ConwayTallyState era)
+
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceActionInfo era) where
+  arbitrary =
+    GovernanceActionInfo
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceActionState era) where
+  arbitrary =
+    GovernanceActionState
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceAction era) where
+  arbitrary =
+    oneof
+      [ ParameterChange <$> arbitrary
+      , HardForkInitiation <$> arbitrary
+      , TreasuryWithdrawals <$> arbitrary
+      ]
+
+instance Era era => Arbitrary (Vote era) where
+  arbitrary =
+    Vote
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance Crypto c => Arbitrary (GovernanceActionId c) where
+  arbitrary =
+    GovernanceActionId
+      <$> arbitrary
+      <*> arbitrary
+
+deriving instance Arbitrary GovernanceActionIx
+
+instance Arbitrary VoterRole where
+  arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary VoteDecision where
+  arbitrary = arbitraryBoundedEnum
+
+instance
+  ( Mock (EraCrypto era)
+  , ConwayEraTxBody era
+  , Arbitrary (Sized (TxOut era))
+  , Arbitrary (TxOut era)
+  , Arbitrary (Value era)
+  , Arbitrary (Script era)
+  , Arbitrary (PParamsUpdate era)
+  ) =>
+  Arbitrary (ConwayTxBody era)
+  where
+  arbitrary =
+    ConwayTxBody
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> genMintValues
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+------------------------------------------------------------------------------------------
+-- Cardano.Ledger.Conway.Rules -----------------------------------------------------------
+------------------------------------------------------------------------------------------
+
+-- TALLY
+
+deriving instance Era era => Arbitrary (ConwayTallyPredFailure era)
+deriving instance Era era => Arbitrary (TallyEnv era)
+
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceProcedure era) where
+  arbitrary =
+    oneof
+      [ VotingProcedure <$> arbitrary
+      , ProposalProcedure <$> arbitrary
+      ]
+
+instance
+  ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))
+  , Arbitrary (PredicateFailure (EraRule "DELEGS" era))
+  , Arbitrary (PredicateFailure (EraRule "TALLY" era))
+  ) =>
+  Arbitrary (ConwayLedgerPredFailure era)
+  where
+  arbitrary =
+    oneof
+      [ ConwayUtxowFailure <$> arbitrary
+      , ConwayDelegsFailure <$> arbitrary
+      , ConwayTallyFailure <$> arbitrary
+      ]
+
+-- EPOCH
+
+instance
+  ( Era era
+  , Arbitrary (Event (EraRule "POOLREAP" era))
+  , Arbitrary (Event (EraRule "SNAP" era))
+  ) =>
+  Arbitrary (ConwayEpochEvent era)
+  where
+  arbitrary =
+    oneof
+      [ PoolReapEvent <$> arbitrary
+      , SnapEvent <$> arbitrary
+      ]
+
+-- NEWEPOCH
+
+instance
+  ( Era era
+  , Arbitrary (Event (EraRule "RUPD" era))
+  ) =>
+  Arbitrary (ConwayNewEpochEvent era)
+  where
+  arbitrary =
+    oneof
+      [ DeltaRewardEvent <$> arbitrary
+      , RestrainedRewards <$> arbitrary <*> arbitrary <*> arbitrary
+      ]
+
+-- TICKF
+
+instance
+  ( Era era
+  ) =>
+  Arbitrary (ConwayTickfPredFailure era)
+  where
+  arbitrary = undefined
+
+instance
+  ( Era era
+  ) =>
+  Arbitrary (ConwayTickfEvent era)
+  where
+  arbitrary = undefined

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -125,6 +126,9 @@ deriving instance Arbitrary SlotNo
 
 instance Arbitrary t => Arbitrary (WithOrigin t) where
   arbitrary = frequency [(20, pure Origin), (80, At <$> arbitrary)]
+  shrink = \case
+    Origin -> []
+    At x -> Origin : map At (shrink x)
 
 deriving instance Arbitrary EpochNo
 

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -38,6 +38,7 @@ library
         cardano-ledger-alonzo,
         cardano-ledger-babbage,
         cardano-ledger-binary,
+        cardano-ledger-conway,
         cardano-ledger-core,
         cardano-ledger-mary,
         cardano-ledger-shelley,


### PR DESCRIPTION
# Description

Few things for the Conway era:

* Bring back `getLedgerView` - it is needed for consensus
* Add TICKF rule placeholder for conway
* Add some common instances for Conway predicate failures
* Add Arbitrary instances for newly introduced types in Conway

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
