### PR TITLE
Simplify To/FromCBOR instances for DSIGN types

### DIFF
--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/FromCBOR.hs
@@ -18,11 +18,6 @@ module Cardano.Ledger.Binary.Decoding.FromCBOR (
 where
 
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm, SeedSizeDSIGN, SigDSIGN, SignKeyDSIGN, VerKeyDSIGN)
-import Cardano.Crypto.DSIGN.EcdsaSecp256k1 (EcdsaSecp256k1DSIGN)
-import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
-import Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
-import Cardano.Crypto.DSIGN.Mock (MockDSIGN)
-import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashFromBytes, sizeHash)
 import Cardano.Crypto.KES.Class (KESAlgorithm, OptimizedKESAlgorithm, SigKES, SignKeyKES, VerKeyKES)
 import Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
@@ -397,49 +392,13 @@ instance FromCBOR UTCTime where
 -- DSIGN
 --------------------------------------------------------------------------------
 
-instance FromCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => FromCBOR (VerKeyDSIGN v) where
   fromCBOR = decodeVerKeyDSIGN
 
-instance FromCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => FromCBOR (SignKeyDSIGN v) where
   fromCBOR = decodeSignKeyDSIGN
 
-instance FromCBOR (SigDSIGN EcdsaSecp256k1DSIGN) where
-  fromCBOR = decodeSigDSIGN
-
-instance FromCBOR (VerKeyDSIGN MockDSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
-
-instance FromCBOR (SignKeyDSIGN MockDSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
-
-instance FromCBOR (SigDSIGN MockDSIGN) where
-  fromCBOR = decodeSigDSIGN
-
-instance FromCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
-
-instance FromCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
-
-instance FromCBOR (SigDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeSigDSIGN
-
-instance FromCBOR (VerKeyDSIGN Ed448DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
-
-instance FromCBOR (SignKeyDSIGN Ed448DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
-
-instance FromCBOR (SigDSIGN Ed448DSIGN) where
-  fromCBOR = decodeSigDSIGN
-
-instance FromCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
-
-instance FromCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
-
-instance FromCBOR (SigDSIGN SchnorrSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => FromCBOR (SigDSIGN v) where
   fromCBOR = decodeSigDSIGN
 
 --------------------------------------------------------------------------------

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/ToCBOR.hs
@@ -62,11 +62,6 @@ import Cardano.Crypto.DSIGN.Class (
   sizeSignKeyDSIGN,
   sizeVerKeyDSIGN,
  )
-import Cardano.Crypto.DSIGN.EcdsaSecp256k1 (EcdsaSecp256k1DSIGN)
-import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
-import Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
-import Cardano.Crypto.DSIGN.Mock (MockDSIGN)
-import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 import Cardano.Crypto.Hash.Class (
   Hash (..),
   HashAlgorithm,
@@ -855,63 +850,15 @@ encodedSigDSIGNSizeExpr _proxy =
 -- DSIGN
 --------------------------------------------------------------------------------
 
-instance ToCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => ToCBOR (VerKeyDSIGN v) where
   toCBOR = encodeVerKeyDSIGN
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
-instance ToCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => ToCBOR (SignKeyDSIGN v) where
   toCBOR = encodeSignKeyDSIGN
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
-instance ToCBOR (SigDSIGN EcdsaSecp256k1DSIGN) where
-  toCBOR = encodeSigDSIGN
-  encodedSizeExpr _ = encodedSigDSIGNSizeExpr
-
-instance ToCBOR (VerKeyDSIGN MockDSIGN) where
-  toCBOR = encodeVerKeyDSIGN
-  encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
-
-instance ToCBOR (SignKeyDSIGN MockDSIGN) where
-  toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
-
-instance ToCBOR (SigDSIGN MockDSIGN) where
-  toCBOR = encodeSigDSIGN
-  encodedSizeExpr _ = encodedSigDSIGNSizeExpr
-
-instance ToCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
-  encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
-
-instance ToCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
-
-instance ToCBOR (SigDSIGN Ed25519DSIGN) where
-  toCBOR = encodeSigDSIGN
-  encodedSizeExpr _ = encodedSigDSIGNSizeExpr
-
-instance ToCBOR (VerKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
-  encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
-
-instance ToCBOR (SignKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
-
-instance ToCBOR (SigDSIGN Ed448DSIGN) where
-  toCBOR = encodeSigDSIGN
-  encodedSizeExpr _ = encodedSigDSIGNSizeExpr
-
-instance ToCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
-  encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
-
-instance ToCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
-
-instance ToCBOR (SigDSIGN SchnorrSecp256k1DSIGN) where
+instance DSIGNAlgorithm v => ToCBOR (SigDSIGN v) where
   toCBOR = encodeSigDSIGN
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 


### PR DESCRIPTION
# Description

I assume To/FromCBOR instance for DSIGN were not defined in the same "catch all" way as it is done for all other crypto types (i.e. the way it is defined in this PR) in order to prevent memory locked DSIGN implementation to have To/FromCBOR instances, because that would violate the safety guarantees of locked memory by leaking secrets onto the Haskell heap. However, now that we have a pretty solid memory locked DSIGN implementation we can safely provide those instances for  all `SigKeyDSIGN v`, `VerKeyDSIGN v` and `SigDSIGN v`, because memory locked version will be a totally separate interface with type families named `SigKeyDSIGNM v`, `VerKeyDSIGNM v` and `SigDSIGNM v`. See https://github.com/input-output-hk/cardano-base/pull/255

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)
- [x] Self-reviewed the diff
