### PR TITLE
update tullia/cicero CI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -268,16 +268,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669546925,
-        "narHash": "sha256-Gvtk9agz88tBgqmCdHl5U7gYttTkiuEd8/Rq1Im0pTg=",
+        "lastModified": 1676817468,
+        "narHash": "sha256-ovuJ1jQOC2/EEibufBkXmSN/O9mLx80Wh7aDmHmHAhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fecf05d4861f3985e8dee73f08bc82668ef75125",
+        "rev": "0cf4274b5d06325bd16dbf879a30981bc283e58a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -115,21 +115,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gomod2nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2",
@@ -149,25 +134,35 @@
         "type": "github"
       }
     },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
+    "incl": {
+      "inputs": {
+        "nixlib": [
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
         "type": "github"
       },
       "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
+        "owner": "divnix",
+        "repo": "incl",
         "type": "github"
       }
     },
     "n2c": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": [
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "tullia",
           "std",
@@ -334,6 +329,21 @@
         "type": "github"
       }
     },
+    "nosys": {
+      "locked": {
+        "lastModified": 1667881534,
+        "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "2d0d5207f6a230e9d0f660903f8db9807b54814f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
     "parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -363,16 +373,21 @@
     },
     "std": {
       "inputs": {
+        "arion": [
+          "tullia",
+          "std",
+          "blank"
+        ],
         "blank": "blank",
         "devshell": "devshell",
         "dmerge": "dmerge",
         "flake-utils": "flake-utils_2",
+        "incl": "incl",
         "makes": [
           "tullia",
           "std",
           "blank"
         ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "microvm": [
           "tullia",
           "std",
@@ -381,14 +396,15 @@
         "n2c": "n2c",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs_4",
+        "nosys": "nosys",
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1665513321,
-        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
+        "lastModified": 1674526466,
+        "narHash": "sha256-tMTaS0bqLx6VJ+K+ZT6xqsXNpzvSXJTmogkraBGzymg=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
+        "rev": "516387e3d8d059b50e742a2ff1909ed3c8f82826",
         "type": "github"
       },
       "original": {
@@ -407,11 +423,11 @@
         "std": "std"
       },
       "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
+        "lastModified": 1675695930,
+        "narHash": "sha256-B7rEZ/DBUMlK1AcJ9ajnAPPxqXY6zW2SBX+51bZV0Ac=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
+        "rev": "621365f2c725608f381b3ad5b57afef389fd4c31",
         "type": "github"
       },
       "original": {
@@ -444,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
     tullia = {
       url = github:input-output-hk/tullia;
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -45,7 +45,12 @@
         };
 
         memory = 1024 * 8;
-        nomad.resources.cpu = 10000;
+
+        nomad = {
+          resources.cpu = 10000;
+
+          driver = "exec";
+        };
       };
 
       actions."cardano-ledger/ci" = {

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -7,7 +7,8 @@
 
   perSystem = {lib, ...}: {
     tullia = let
-      ciInputName = "GitHub event";
+      ciInputName = "GitHub Push or PR";
+      repository = "input-output-hk/cardano-ledger";
     in rec {
       tasks.ci = {
         config,
@@ -26,14 +27,16 @@
             # bind-mounted into the container, so we don't need to fetch the
             # source from GitHub and we don't want to report a GitHub status.
             enable = config.actionRun.facts != {};
-            repository = "input-output-hk/cardano-ledger";
+            inherit repository;
+            remote = config.preset.github.lib.readRepository ciInputName null;
             revision = config.preset.github.lib.readRevision ciInputName null;
           };
         };
 
         command.text = config.preset.github.status.lib.reportBulk {
           bulk.text = ''
-            nix eval .#hydraJobs --apply __attrNames --json | nix-systems -i
+            nix eval .#hydraJobs --apply __attrNames --json |
+            nix-systems -i
           '';
           each.text = ''nix build -L .#hydraJobs."$1".required'';
           skippedDescription =
@@ -55,13 +58,13 @@
 
           let github = {
             #input: "${ciInputName}"
-            #repo: "input-output-hk/cardano-ledger"
+            #repo: "${repository}"
           }
 
           #lib.merge
           #ios: [
-            #lib.io.github_push & github,
-            { #lib.io.github_pr, github, #target_default: false },
+            {#lib.io.github_push, github, #default_branch: true},
+            {#lib.io.github_pr,   github, #target_default: false},
           ]
         '';
       };


### PR DESCRIPTION
# Description

- support PRs from forks
- run with exec driver instead of podman
  - more reliable
  - much better caching
  - faster
- update tullia
  - update nix version (needed for tullia's std flake input) by updating nixpkgs so we can keep eval memory usage down

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- ~~New tests are added if needed and existing tests are updated~~
- ~~Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)~~
- ~~Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`)~~
- ~~Cabal files are formatted (which can be done with `scripts/cabal-format.sh`)~~
- [x] Self-reviewed the diff
