### PR TITLE
Improve nightly builds

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+            substituters = https://cache.iog.io https://cache.nixos.org/ https://cache.zw3rk.com
       - name: Build benchmarks
         run: nix-build -A haskellPackages.cardano-ledger-test.components.benchmarks
       - name: Run benchmark

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,4 +1,10 @@
 name: Haskell CI
+# If it's a scheduled (for us: nightly) build, set the name of this run to a static value, so we can identify it easier.
+# Otherwise, replicate the default run name: either the PR title if it exists, or the commit message otherwise.
+run-name: |
+       ${{github.event_name == 'schedule' && 'Haskell CI - NIGHTLY'
+         || github.event.pull_request.title == '' && github.event.head_commit.message
+         || github.event.pull_request.title}}
 
 on:
   push:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -196,3 +196,20 @@ jobs:
 
     - name: Regenerate hie.yaml and confirm that it is in sync
       run: ./scripts/gen-hie.sh
+
+  nix-build:
+    name: Build nix derivations and enter nix-shell
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v19
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.iog.io https://cache.nixos.org/
+      - name: nix-build
+        run: nix-build
+      - name: nix-shell
+        run: nix-shell shell.nix

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -207,8 +207,8 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+            substituters = https://cache.iog.io https://cache.nixos.org/ https://cache.zw3rk.com
       - name: nix-build
         run: nix-build
       - name: nix-shell


### PR DESCRIPTION
# Description

A few improvements to nightly builds:
* Rename the Github action run to make it clear it's a nightly build - hopefully this will make it easier to distinguish it in the emails if it fails
*  Add new substituters (so that we can use caching in github actions running nix )
* Run `nix-build` and `nix-shell` as part of nightly builds, so we are aware at latest the next day if they've been broken 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] `hie.yaml` has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
