### PR TITLE
Don't run unnecessary gh actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     # "Nightly" builds: Every day at 06:00 UTC
     - cron: '0 6 * * *'
+# Cancel running actions when a new action on the same PR is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     # "Nightly" builds: Every day at 06:00 UTC
     - cron: '0 6 * * *'
+  # for running the workflow manually - useful for branches without PRs, for which jobs don't get ran automatically
+  workflow_dispatch:
+
 # Cancel running actions when a new action on the same PR is started
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Description
Reduces the number of github actions run by cancelling workflows when a new one for the same PR is starting
 
# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] `hie.yaml` has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
