### PR TITLE
OCert cbor and minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Changes recorded below are for all of the package versions in the list:
 
 ### Changed
 
+- Renamed `GenesisDelegCert` to `ConstitutionalDelegCert`: #3176
 - Fix `ToCBOR`/`FromCBOR` insatance for `PParams Babbage` and `PParams Alonzo`: #3297 and #3288
 - Disallow decoding a 0-value `MultiAsset` in the de-serialization. #3241
 - Move `Wdrl` to `Core`. Also rename it to `Withdrawals`, while switching `Test.Cardano.Ledger.Generic.Fields.Withdrawals` to `Withdrawals'` #3239

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `ToJSON` instance for `AlonzoTxOut`, `AlonzoScript` and `Datum`
 * Add `ToJSON` instance for `AlonzoPParams StrictMaybe`
+* Stop exporting an internal function `decodeBinaryData`
 
 ###`testlib`
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `ToJSON` instance for `AlonzoTxOut`, `AlonzoScript` and `Datum`
 * Add `ToJSON` instance for `AlonzoPParams StrictMaybe`
 * Stop exporting an internal function `decodeBinaryData`
+* Remove redundant `Redeemers'` pattern synonym.
 
 ###`testlib`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
@@ -31,7 +31,6 @@ module Cardano.Ledger.Alonzo.Scripts.Data (
   makeBinaryData,
   binaryDataToData,
   dataToBinaryData,
-  decodeBinaryData,
   Datum (..),
   datumDataHash,
 )
@@ -151,6 +150,8 @@ instance Era era => DecCBOR (BinaryData era) where
     bs <- decodeNestedCborBytes
     either fail pure $! makeBinaryData (toShort bs)
 
+-- | Construct `BinaryData` from a buffer of bytes, while ensuring that it can be later
+-- safely converted to `Data` with `binaryDataToData`
 makeBinaryData :: Era era => ShortByteString -> Either String (BinaryData era)
 makeBinaryData sbs = do
   let binaryData = BinaryData sbs
@@ -165,8 +166,8 @@ decodeBinaryData (BinaryData sbs) = do
   pure (DataConstr (mkMemoBytes plutusData $ shortToLazy sbs))
 
 -- | It is safe to convert `BinaryData` to `Data` because the only way to
--- construct `BinaryData` is thorugh smart constructor `makeBinaryData` that
--- takes care of verification.
+-- construct `BinaryData` is through the smart constructor `makeBinaryData` that
+-- takes care of validation.
 binaryDataToData :: Era era => BinaryData era -> Data era
 binaryDataToData binaryData =
   case decodeBinaryData binaryData of

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -19,10 +19,7 @@
 
 module Cardano.Ledger.Alonzo.TxWits (
   RdmrPtr (..),
-  Redeemers (
-    Redeemers,
-    Redeemers'
-  ),
+  Redeemers (Redeemers),
   unRedeemers,
   nullRedeemers,
   TxDats (TxDats, TxDats'),
@@ -158,14 +155,6 @@ deriving instance HashAlgorithm (HASH (EraCrypto era)) => Show (Redeemers era)
 -- =====================================================
 -- Pattern for Redeemers
 
-pattern Redeemers' ::
-  Era era =>
-  Map RdmrPtr (Data era, ExUnits) ->
-  Redeemers era
-pattern Redeemers' rs <- (getMemoRawType -> RedeemersRaw rs)
-
-{-# COMPLETE Redeemers' #-}
-
 pattern Redeemers ::
   forall era.
   Era era =>
@@ -179,7 +168,7 @@ pattern Redeemers rs <-
 {-# COMPLETE Redeemers #-}
 
 unRedeemers :: Era era => Redeemers era -> Map RdmrPtr (Data era, ExUnits)
-unRedeemers (Redeemers' rs) = rs
+unRedeemers (Redeemers rs) = rs
 
 nullRedeemers :: Era era => Redeemers era -> Bool
 nullRedeemers = Map.null . unRedeemers
@@ -231,8 +220,8 @@ instance (Era era, Script era ~ AlonzoScript era) => Semigroup (AlonzoTxWits era
   (<>) x y | isEmptyTxWitness x = y
   (<>) x y | isEmptyTxWitness y = x
   (<>)
-    (getMemoRawType -> AlonzoTxWitsRaw a b c d (Redeemers' e))
-    (getMemoRawType -> AlonzoTxWitsRaw u v w x (Redeemers' y)) =
+    (getMemoRawType -> AlonzoTxWitsRaw a b c d (Redeemers e))
+    (getMemoRawType -> AlonzoTxWitsRaw u v w x (Redeemers y)) =
       AlonzoTxWits (a <> u) (b <> v) (c <> w) (d <> x) (Redeemers (e <> y))
 
 instance (Era era, Script era ~ AlonzoScript era) => Monoid (AlonzoTxWits era) where
@@ -250,7 +239,7 @@ deriving instance
   NFData (AlonzoTxWits era)
 
 isEmptyTxWitness :: Era era => AlonzoTxWits era -> Bool
-isEmptyTxWitness (getMemoRawType -> AlonzoTxWitsRaw a b c d (Redeemers' e)) =
+isEmptyTxWitness (getMemoRawType -> AlonzoTxWitsRaw a b c d (Redeemers e)) =
   Set.null a && Set.null b && Map.null c && nullDats d && Map.null e
 
 -- =====================================================

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -268,7 +268,7 @@ pattern TxDats' m <- (getMemoRawType -> TxDatsRaw m)
 
 {-# COMPLETE TxDats' #-}
 
-pattern TxDats :: Era era => Typeable era => Map (DataHash (EraCrypto era)) (Data era) -> TxDats era
+pattern TxDats :: Era era => Map (DataHash (EraCrypto era)) (Data era) -> TxDats era
 pattern TxDats m <- (getMemoRawType -> TxDatsRaw m)
   where
     TxDats m = mkMemoized (TxDatsRaw m)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -23,6 +23,8 @@
 * Add `ToJSONKey` instance for `GovernanceActionId` #3323
 * Fix `EncCBOR`/`DecCBOR` and `ToCBOR`/`FromCBOR` for `ConwayTallyState` #3323
 * Add `Anchor` and `AnchorDataHash` types. #3323
+* Rename `transDCert` to `toShelleyDCert`
+* Add `fromShelleyDCertMaybe`
 
 ### `testlib`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Delegation/Certificates.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Delegation/Certificates.hs
@@ -3,7 +3,8 @@
 
 module Cardano.Ledger.Conway.Delegation.Certificates (
   ConwayDCert (..),
-  transDCert,
+  toShelleyDCert,
+  fromShelleyDCertMaybe,
 )
 where
 
@@ -102,7 +103,13 @@ instance Crypto c => EncCBOR (ConwayDCert c) where
         <> encCBOR kh
         <> encCBOR vrf
 
-transDCert :: ConwayDCert c -> DCert c
-transDCert (ConwayDCertDeleg dc) = DCertDeleg dc
-transDCert (ConwayDCertPool pc) = DCertPool pc
-transDCert (ConwayDCertConstitutional gdc) = DCertGenesis gdc
+toShelleyDCert :: ConwayDCert c -> DCert c
+toShelleyDCert (ConwayDCertDeleg dc) = DCertDeleg dc
+toShelleyDCert (ConwayDCertPool pc) = DCertPool pc
+toShelleyDCert (ConwayDCertConstitutional gdc) = DCertGenesis gdc
+
+fromShelleyDCertMaybe :: DCert c -> Maybe (ConwayDCert c)
+fromShelleyDCertMaybe (DCertDeleg dc) = Just $ ConwayDCertDeleg dc
+fromShelleyDCertMaybe (DCertPool pc) = Just $ ConwayDCertPool pc
+fromShelleyDCertMaybe (DCertGenesis gdc) = Just $ ConwayDCertConstitutional gdc
+fromShelleyDCertMaybe DCertMir {} = Nothing

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
   ConwayEraTxBody (..),
  )
-import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, transDCert)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, toShelleyDCert)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.PParams ()
 import Cardano.Ledger.Conway.Rules.Tally (GovernanceProcedure)
@@ -304,7 +304,7 @@ instance Crypto c => ShelleyEraTxBody (ConwayEra c) where
   certsTxBodyL = notSupportedInThisEraL
   {-# INLINE certsTxBodyL #-}
 
-  certsTxBodyG = getterMemoRawType (fmap transDCert . ctbrCerts)
+  certsTxBodyG = getterMemoRawType (fmap toShelleyDCert . ctbrCerts)
 
 instance Crypto c => AllegraEraTxBody (ConwayEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (ConwayEra StandardCrypto) #-}

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Add `encodeStrictMaybe`/`decodeStrictMaybe` and `encodeNullStrictMaybe`/`decodeNullStrictMaybe`
 * Fix CBOR instance for `StrictMaybe`. It was never used in Byron, so special
   serialization is not needed for pre-protocol version `2`.
+* Re-export crypto related encoding and decoding functions for `VRF`, `KES` and `DSIGN`
+  from `Cardano.Ledger.Binary.Plain`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
@@ -14,10 +14,41 @@ module Cardano.Ledger.Binary.Plain (
   decodeListLikeT,
   serializeAsHexText,
   decodeFullFromHexText,
+
+  -- * DSIGN
+  C.encodeVerKeyDSIGN,
+  C.decodeVerKeyDSIGN,
+  C.encodeSignKeyDSIGN,
+  C.decodeSignKeyDSIGN,
+  C.encodeSigDSIGN,
+  C.decodeSigDSIGN,
+  C.encodeSignedDSIGN,
+  C.decodeSignedDSIGN,
+
+  -- * KES
+  C.encodeVerKeyKES,
+  C.decodeVerKeyKES,
+  C.encodeSignKeyKES,
+  C.decodeSignKeyKES,
+  C.encodeSigKES,
+  C.decodeSigKES,
+  C.encodeSignedKES,
+  C.decodeSignedKES,
+
+  -- * VRF
+  C.encodeVerKeyVRF,
+  C.decodeVerKeyVRF,
+  C.encodeSignKeyVRF,
+  C.decodeSignKeyVRF,
+  C.encodeCertVRF,
+  C.decodeCertVRF,
 )
 where
 
 import Cardano.Binary hiding (encodedSizeExpr)
+import qualified Cardano.Crypto.DSIGN.Class as C
+import qualified Cardano.Crypto.KES.Class as C
+import qualified Cardano.Crypto.VRF.Class as C
 import Codec.CBOR.Term
 import Control.Monad (unless)
 import Control.Monad.Trans (MonadTrans (..))

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -18,7 +18,7 @@ module Cardano.Ledger.Pretty.Conway (
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert (..), transDCert)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert (..), toShelleyDCert)
 import Cardano.Ledger.Conway.Governance (
   ConwayGovernance (..),
   ConwayTallyState (..),
@@ -141,7 +141,7 @@ instance PrettyA (PParamsUpdate era) => PrettyA (GovernanceAction era) where
       [("hash", prettyA c)]
 
 instance forall c. PrettyA (ConwayDCert c) where
-  prettyA = prettyA . transDCert
+  prettyA = prettyA . toShelleyDCert
 
 instance Crypto c => PrettyA (PParams (ConwayEra c)) where
   prettyA = ppBabbagePParams

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -60,7 +60,7 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, transDCert)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, toShelleyDCert)
 import Cardano.Ledger.Conway.Rules (GovernanceProcedure)
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -320,7 +320,7 @@ abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol cert wdrl 
   , Outputs (sizedValue <$> out)
   , CollateralReturn (sizedValue <$> colret)
   , TotalCol totcol
-  , Certs $ transDCert <$> cert
+  , Certs $ toShelleyDCert <$> cert
   , Withdrawals' wdrl
   , Txfee fee
   , Vldt vldt

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -985,7 +985,7 @@ witnessFieldSummary wit = case wit of
   (BootWits s) -> ("BootStrap Witnesses", ppInt (Set.size s))
   (ScriptWits s) -> ("Script Witnesses", ppInt (Map.size s))
   (DataWits m) -> ("Data Witnesses", ppInt (Map.size (unTxDats m)))
-  (RdmrWits (Redeemers' m)) -> ("Redeemer Witnesses", ppInt (Map.size m))
+  (RdmrWits (Redeemers m)) -> ("Redeemer Witnesses", ppInt (Map.size m))
 
 witnessSummary :: Era era => Proof era -> TxWits era -> PDoc
 witnessSummary proof wits =

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-protocol-tpraos`
 
+## 1.0.1.0
+
+* Add `ToCBOR`/`FromCBOR` instaces for `OCert` and `KESPeriod`
+* Make fields for `OCertEnv` strict.
+
 ## 1.0.0.0
 
 * First properly versioned release.

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -30,11 +30,15 @@ import Cardano.Ledger.Binary (
   DecCBORGroup (..),
   EncCBOR (..),
   EncCBORGroup (..),
+  FromCBOR (..),
+  ToCBOR (..),
   encodedSigDSIGNSizeExpr,
   encodedVerKeyKESSizeExpr,
+  fromPlainDecoder,
+  fromPlainEncoding,
   runByteBuilder,
  )
-import Cardano.Ledger.Binary.Crypto
+import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Crypto (Crypto, KES)
 import Cardano.Ledger.Keys (
   KeyHash,
@@ -76,7 +80,7 @@ currentIssueNo (OCertEnv stPools genDelegs) cs hk
   | otherwise = Nothing
 
 newtype KESPeriod = KESPeriod {unKESPeriod :: Word}
-  deriving (Eq, Generic, Ord, NoThunks, DecCBOR, EncCBOR)
+  deriving (Eq, Generic, Ord, NoThunks, DecCBOR, EncCBOR, ToCBOR, FromCBOR)
   deriving (Show) via Quiet KESPeriod
 
 data OCert c = OCert
@@ -98,15 +102,12 @@ deriving instance Crypto c => Show (OCert c)
 
 instance Crypto c => NoThunks (OCert c)
 
-instance
-  (Crypto c) =>
-  EncCBORGroup (OCert c)
-  where
-  encCBORGroup ocert =
-    encodeVerKeyKES (ocertVkHot ocert)
-      <> encCBOR (ocertN ocert)
-      <> encCBOR (ocertKESPeriod ocert)
-      <> encodeSignedDSIGN (ocertSigma ocert)
+-- Serialization of OCerts cannot be versioned, unless it gets parameterized by era.
+-- Therefore we use plain encoding for defining the versioned one, instead of the oppoit
+-- approach how it is done for types with versioned serialization
+
+instance Crypto c => EncCBORGroup (OCert c) where
+  encCBORGroup = fromPlainEncoding . encodeOCertFields
   encodedGroupSizeExpr size proxy =
     encodedVerKeyKESSizeExpr (ocertVkHot <$> proxy)
       + encodedSizeExpr size (toWord . ocertN <$> proxy)
@@ -119,16 +120,30 @@ instance
   listLen _ = 4
   listLenBound _ = 4
 
-instance
-  (Crypto c) =>
-  DecCBORGroup (OCert c)
-  where
-  decCBORGroup =
-    OCert
-      <$> decodeVerKeyKES
-      <*> decCBOR
-      <*> decCBOR
-      <*> decodeSignedDSIGN
+instance Crypto c => DecCBORGroup (OCert c) where
+  decCBORGroup = fromPlainDecoder decodeOCertFields
+
+instance Crypto c => ToCBOR (OCert c) where
+  toCBOR ocert = Plain.encodeListLen (listLen ocert) <> encodeOCertFields ocert
+
+instance Crypto c => FromCBOR (OCert c) where
+  fromCBOR =
+    Plain.decodeRecordNamed "OCert" (fromIntegral . listLen) decodeOCertFields
+
+encodeOCertFields :: Crypto c => OCert c -> Plain.Encoding
+encodeOCertFields ocert =
+  KES.encodeVerKeyKES (ocertVkHot ocert)
+    <> Plain.toCBOR (ocertN ocert)
+    <> Plain.toCBOR (ocertKESPeriod ocert)
+    <> DSIGN.encodeSignedDSIGN (ocertSigma ocert)
+
+decodeOCertFields :: Crypto c => Plain.Decoder s (OCert c)
+decodeOCertFields =
+  OCert
+    <$> KES.decodeVerKeyKES
+    <*> Plain.fromCBOR
+    <*> Plain.fromCBOR
+    <*> DSIGN.decodeSignedDSIGN
 
 kesPeriod :: SlotNo -> ShelleyBase KESPeriod
 kesPeriod (SlotNo s) =

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -62,8 +62,8 @@ import NoThunks.Class (NoThunks (..))
 import Quiet
 
 data OCertEnv c = OCertEnv
-  { ocertEnvStPools :: Set (KeyHash 'StakePool c)
-  , ocertEnvGenDelegs :: Set (KeyHash 'GenesisDelegate c)
+  { ocertEnvStPools :: !(Set (KeyHash 'StakePool c))
+  , ocertEnvGenDelegs :: !(Set (KeyHash 'GenesisDelegate c))
   }
   deriving (Show, Eq)
 


### PR DESCRIPTION
# Description

Looks like OCert can't be easily CBOR versioned in the cardano-api, which is OK, since it is a pretty simple type and is unlikely to change. So this PR adds ToCBOR/FromCBOR instances and bases EncCBOR/DecCBOR on the unversioned implementation

Also other minor improvements

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
