### PR TITLE
enforce unique elements in CBOR sets, ver. 9

### DIFF
--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fix deserializer for `Rational` and allow optionally tag `30` starting with protocol version `2`
 * Fix serializer for `Ratio` and encode tag `30` starting with protocol version `2`
 * Add new encoder `encodeRatioNoTag` for `Ratio`
+* Changed: Starting in version 9, duplicate keys in CBOR sets are not longer allowed.
+  Additionally, the CBOR set tag 258 is permitted but not enforced.
 
 ### `testlib`
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -133,6 +133,7 @@ test-suite tests
     other-modules:
         Test.Cardano.Ledger.Binary.Failure
         Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
         Test.Cardano.Ledger.Binary.RoundTripSpec
         Test.Cardano.Ledger.Binary.Vintage.Coders
         Test.Cardano.Ledger.Binary.Vintage.Drop

--- a/libs/cardano-ledger-binary/test/Main.hs
+++ b/libs/cardano-ledger-binary/test/Main.hs
@@ -4,6 +4,7 @@ import System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdou
 import qualified Test.Cardano.Ledger.Binary.Failure as Failure
 import qualified Test.Cardano.Ledger.Binary.PlainSpec as PlainSpec
 import qualified Test.Cardano.Ledger.Binary.RoundTripSpec as RoundTripSpec
+import qualified Test.Cardano.Ledger.Binary.Success as Success
 import qualified Test.Cardano.Ledger.Binary.Vintage.Coders as Vintage.Coders
 import qualified Test.Cardano.Ledger.Binary.Vintage.Drop as Vintage.Drop
 import qualified Test.Cardano.Ledger.Binary.Vintage.Failure as Vintage.Failure
@@ -25,6 +26,7 @@ spec = do
   describe "Versioned" $ do
     RoundTripSpec.spec
     Failure.spec
+    Success.spec
 
 main :: IO ()
 main = do

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Binary.Failure (spec) where
 
 import Cardano.Ledger.Binary
-import Data.Either (isLeft)
 import Data.Map (Map)
+import Data.Proxy (Proxy (Proxy))
+import Data.Set (Set)
+import Test.Cardano.Ledger.Binary.RoundTrip (Trip (..), embedTripRangeFailureExpectation)
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -28,20 +31,44 @@ genDuplicateAssocListEncoding = do
     , pure $ encodeMapLenIndef <> foldMap encCBOR flatXs <> encodeBreak
     ]
 
+-- | Generate a list with at least one duplicate
+genDuplicateList :: Gen [Int]
+genDuplicateList = do
+  xs <- getNonEmpty <$> arbitrary
+  a <- elements xs -- pick an element to duplicate
+  shuffle (a : xs)
+
+-- | Generate a CBOR encoded list with at least one duplicate, with and with the set tag
+genDuplicateListEncoding :: Gen Encoding
+genDuplicateListEncoding = do
+  xs <- genDuplicateList
+  let definite = encodeListLen (fromIntegral $ Prelude.length xs) <> foldMap encCBOR xs
+      indefinite = encodeListLenIndef <> foldMap encCBOR xs <> encodeBreak
+  elements
+    [ definite
+    , encodeTag 258 <> definite
+    , indefinite
+    , encodeTag 258 <> indefinite
+    ]
+
 -- | Starting in version 9, do not accept duplicates in CBOR maps
 prop_shouldFailMapWithDupKeys :: Property
 prop_shouldFailMapWithDupKeys =
   forAllBlind genDuplicateAssocListEncoding $
-    ( \encodedMap ->
-        (property . isLeft) (decode (natVersion @9) encodedMap :: Either DecoderError (Map Int Int))
-    )
+    \mapEncoding ->
+      let trip = Trip id (decCBOR @(Map Int Int)) (dropCBOR (Proxy @(Map Int Int)))
+       in property $ embedTripRangeFailureExpectation trip (natVersion @9) maxBound mapEncoding
 
-decode :: DecCBOR a => Version -> Encoding -> Either DecoderError a
-decode version enc =
-  let encoded = serialize version enc
-   in decodeFull version encoded
+-- | Starting in version 9, do not accept duplicates in CBOR sets
+prop_shouldFailSetWithDupKeys :: Property
+prop_shouldFailSetWithDupKeys =
+  forAllBlind genDuplicateListEncoding $
+    \setEncoding ->
+      let trip = Trip id (decCBOR @(Set Int)) (dropCBOR (Proxy @(Set Int)))
+       in property $ embedTripRangeFailureExpectation trip (natVersion @9) maxBound setEncoding
 
 spec :: Spec
 spec = do
   describe "Failures" $ do
     prop "map duplicates are not allowed starting v9" prop_shouldFailMapWithDupKeys
+    prop "set duplicates are not allowed starting v9" prop_shouldFailSetWithDupKeys

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Success.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Success.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Binary.Success (spec) where
+
+import Cardano.Ledger.Binary
+import Control.Monad (forM_)
+import Data.Proxy (Proxy (Proxy))
+import qualified Data.Set as Set
+import Test.Cardano.Ledger.Binary.RoundTrip (Trip (..), embedTripExpectation)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+-- | Generate a list with unique elements
+genIntSet :: Gen (Set.Set Int)
+genIntSet = Set.fromList <$> listOf chooseAny
+
+-- | Generate a CBOR encoded list with no duplicates, with and with the set tag
+genUniqueListEncoding :: Gen (Set.Set Int, Encoding)
+genUniqueListEncoding = do
+  xsSet <- genIntSet
+  let xs = Set.toList xsSet
+      definite = encodeListLen (fromIntegral $ Prelude.length xs) <> foldMap encCBOR xs
+      indefinite = encodeListLenIndef <> foldMap encCBOR xs <> encodeBreak
+  (,) xsSet
+    <$> elements
+      [ definite
+      , encodeTag 258 <> definite
+      , indefinite
+      , encodeTag 258 <> indefinite
+      ]
+
+-- | Starting in version 9, check set decoding with and without tag 258
+prop_setWithNoDuplicatesAndTag :: Property
+prop_setWithNoDuplicatesAndTag =
+  forAllBlind genUniqueListEncoding $
+    \(s, setEncoder) ->
+      let trip = Trip id (decCBOR @(Set.Set Int)) (dropCBOR (Proxy @(Set.Set Int)))
+       in property $
+            forM_ [(natVersion @9) .. maxBound] $
+              \v -> embedTripExpectation v v trip (\s' _ -> (s' `shouldBe` s)) setEncoder
+
+spec :: Spec
+spec = do
+  describe "Successes" $ do
+    prop "encode Set, v9" prop_setWithNoDuplicatesAndTag


### PR DESCRIPTION
# Description

Starting in major version 9, we now raise a decoding error if a CBOR set contains duplicate keys. Additionally, we allow (but do not require) the set tag.

resolves #3340

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
