### PR TITLE
Improve roundtrip CBOR serialization failure testing functions:

### DIFF
--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -102,7 +102,7 @@ test-suite tests
         base16-bytestring,
         bytestring,
         cardano-data:{cardano-data, testlib},
-        cardano-ledger-binary:testlib,
+        cardano-ledger-binary:testlib >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary,
         testlib

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -94,7 +94,7 @@ test-suite cardano-ledger-shelley-ma-test
         base,
         bytestring,
         cardano-data,
-        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-allegra >=1.1,

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -49,7 +49,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Lens.Micro
-import Test.Cardano.Ledger.Binary.RoundTrip (roundTripFailureCborRangeExpectation)
+import Test.Cardano.Ledger.Binary.RoundTrip (roundTripCborRangeFailureExpectation)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
 import Test.Cardano.Ledger.Shelley.Serialisation.GoldenUtils (
   ToTokens (..),
@@ -442,7 +442,7 @@ goldenEncodingTestsMary =
 
 assetName32Bytes :: Assertion
 assetName32Bytes =
-  roundTripFailureCborRangeExpectation (eraProtVerHigh @Mary) maxBound $
+  roundTripCborRangeFailureExpectation (eraProtVerHigh @Mary) maxBound $
     AssetName "123456789-123456789-123456789-123"
 
 -- | Golden Tests for Allegra and Mary

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version history for `cardano-ledger-binary`
 
-## 1.0.1.0
+## 1.1.0.0
 
 * Add `ToJSON`/`FromJSON` instances for `Version`
 * Add `decodeFullFromHexText` and `serializeAsHexText`
@@ -14,6 +14,14 @@
 ### `testlib`
 
 * Add `Arbitrary` instance for `Term`
+* Renamed:
+  * `roundTripAnnFailureRangeExpectation` -> `roundTripAnnRangeFailureExpectation`
+  * `roundTripFailureCborRangeExpectation` -> `roundTripCborRangeFailureExpectation`
+  * `roundTripAnnFailureRangeExpectation` -> `roundTripAnnRangeFailureExpectation`
+* Added:
+  * `embedTripFailureExpectation`
+  * `embedTripRangeFailureExpectation`
+  * `roundTripRangeFailureExpectation`
 
 ## 1.0.0.0
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.0.1.0
+version:       1.1.0.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
# Description

* Renamed:
  * `roundTripAnnFailureRangeExpectation` -> `roundTripAnnRangeFailureExpectation`
  * `roundTripFailureCborRangeExpectation` -> `roundTripCborRangeFailureExpectation`
  * `roundTripAnnFailureRangeExpectation` -> `roundTripAnnRangeFailureExpectation`
* Added:
  * `embedTripFailureExpectation`
  * `embedTripRangeFailureExpectation`
  * `roundTripRangeFailureExpectation`


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
