### PR TITLE
Remove duplication. Reuse the same function in Babbage from Alonzo.

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add `ToJSON` instance for `BabbageTxOut`.
 * Add `ToJSON` instance for `BabbagePParams Identity` and `BabbagePParams StrictMaybe`
+* Removed validation function `validateOutputTooBigUTxO`, in favor of the same function
+  from `cardano-ledger-alonzo`.
 
 ###`testlib`
 


### PR DESCRIPTION
# Description

Also improve consistency a little by relying on Foldable.

Avoid allocation of intermediate lists by writing in a more fusion friendly manner

Avoid redundant usage of `txouts` function

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated~
- [ ] ~Any changes are noted in the `CHANGELOG.md` for affected package~
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
