### PR TITLE
Ts fix cannonical

### DIFF
--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -32,7 +32,9 @@ import Test.Cardano.Ledger.Mary.Arbitrary (genEmptyMultiAsset, genMaryValue, gen
 spec :: Spec
 spec = do
   describe "MultiAsset" $ do
-    prop "Canonical construction agrees" $ propCanonicalConstructionAgrees @StandardCrypto
+    prop "Canonical construction agrees" $
+      withMaxSuccess 100000 $
+        propCanonicalConstructionAgrees @StandardCrypto
   describe "CBOR roundtrip" $ do
     context "Coin" $ do
       prop "Non-negative Coin succeeds for all eras" $

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -93,6 +93,7 @@ test-suite cardano-ledger-shelley-ma-test
     build-depends:
         base,
         bytestring,
+        cardano-crypto-class,
         cardano-data,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
@@ -104,6 +105,8 @@ test-suite cardano-ledger-shelley-ma-test
         cborg,
         containers,
         data-default-class,
+        deepseq,
+        groups,
         mtl,
         microlens,
         QuickCheck,

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Version history for `cardano-data`
 
+## 1.0.1.0
+
+* Fix - A bug was fixed in the `canonicalInsert` function.
+  The bug manifested by creating an unbalanced tree in the `Data.Map` internals of the
+  'CanonicalMap', which can result in a crash.
+  This was the root cause of https://github.com/input-output-hk/cardano-node/issues/4826.
+
 ## 1.0.0.0
 
 * First properly versioned released.

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-data
-version:            1.0.0.0
+version:            1.0.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-data/src/Data/CanonicalMaps.hs
+++ b/libs/cardano-data/src/Data/CanonicalMaps.hs
@@ -12,8 +12,6 @@ where
 
 import Data.Map.Internal (
   Map (..),
-  balanceL,
-  balanceR,
   link,
   link2,
  )
@@ -80,8 +78,8 @@ canonicalInsert f !kx x = go
     go Tip = if x == zeroC then Tip else Map.singleton kx x
     go (Bin sy ky y l r) =
       case compare kx ky of
-        LT -> balanceL ky y (go l) r
-        GT -> balanceR ky y l (go r)
+        LT -> link ky y (go l) r
+        GT -> link ky y l (go r)
         EQ -> if new == zeroC then link2 l r else Bin sy kx new l r
           where
             new = f y x -- Apply to value in the tree, then the new value


### PR DESCRIPTION
# Description

This fixes the bug discovered in https://github.com/input-output-hk/cardano-node/issues/4826. This issue merits a full retrospective, which we will provide. For now, however, we are applying the patch to the main ledger branch, adding property tests, and providing a terse explanation in these PR notes.

The `Data.Map.Internal` functions `balanceR` and `balanceL` expect the size difference between their two arguments to be 0 or 1, which allows them to re-balance the underlying tree in constant time. The canonical map can, however, _shrink_ by one when it places the multi-assets in canonical form, resulting in the tree becoming unbalanced. Unlike `balanceR` and `balanceL`, `link` makes no assumptions about the relative balance, at the cost of spending log time re-balancing. The performance cost will not be noticeable.

The credit goes to @TimSheard for finding the problem so fast. Also many thanks to @lehins for his help in quickly narrowing things down.

replaces #3271

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
