### PR TITLE
Evaluate transaction execution units

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Stop exporting an internal function `decodeBinaryData`
 * Remove redundant `Redeemers'` pattern synonym.
 * Move `Cardano.Ledger.Alonzo.Tools` module into `cardano-ledger-api:Cardano.Ledger.Api.Scripts`
+* Add helper lens `hashDataTxWitsL`
 
 ###`testlib`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -43,6 +43,7 @@ module Cardano.Ledger.Alonzo.TxWits (
   datsAlonzoTxWitsL,
   rdmrsAlonzoTxWitsL,
   AlonzoEraTxWits (..),
+  hashDataTxWitsL,
   unTxDats,
   nullDats,
 )
@@ -92,7 +93,7 @@ import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens')
+import Lens.Micro
 import NoThunks.Class (NoThunks)
 
 -- ==========================================
@@ -429,6 +430,15 @@ instance (EraScript (AlonzoEra c), Crypto c) => AlonzoEraTxWits (AlonzoEra c) wh
 
   rdmrsTxWitsL = rdmrsAlonzoTxWitsL
   {-# INLINE rdmrsTxWitsL #-}
+
+-- | This is a convenience Lens that will hash the `Data` when it is being added to the
+-- `TxWits`. See `datsTxWitsL` for a version that aloows setting `TxDats` instead.
+hashDataTxWitsL :: AlonzoEraTxWits era => Lens (TxWits era) (TxWits era) (TxDats era) [Data era]
+hashDataTxWitsL =
+  lens
+    (\wits -> wits ^. datsTxWitsL)
+    (\wits ds -> wits & datsTxWitsL .~ TxDats (Map.fromList [(hashData d, d) | d <- ds]))
+{-# INLINEABLE hashDataTxWitsL #-}
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -36,7 +36,7 @@
 * Addition of `evalTxExUnits` and `evalTxExUnitsWithLogs`. Deprecated
   `evaluateTransactionExecutionUnits` and `evaluateTransactionExecutionUnitsWithLogs` if
   favor of the newly added ones.
-* Export `hashDataTxWitsL`
+* Export `hashDataTxWitsL` and `hashScriptTxWitsL`
 
 ## 1.0.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -33,6 +33,9 @@
 * Move `Cardano.Ledger.Alonzo.Tools` module from `cardano-ledegr-alonzo` into
   `Cardano.Ledger.Api.Scripts`
 * Addition of `evalBalanceTxBody`
+* Addition of `evalTxExUnits` and `evalTxExUnitsWithLogs`. Deprecated
+  `evaluateTransactionExecutionUnits` and `evaluateTransactionExecutionUnitsWithLogs` if
+  favor of the newly added ones.
 
 ## 1.0.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Addition of `evalTxExUnits` and `evalTxExUnitsWithLogs`. Deprecated
   `evaluateTransactionExecutionUnits` and `evaluateTransactionExecutionUnitsWithLogs` if
   favor of the newly added ones.
+* Export `hashDataTxWitsL`
 
 ## 1.0.0.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -37,7 +37,7 @@ library
         Cardano.Ledger.Api.UTxO
 
     hs-source-dirs:   src
-    other-modules:    Cardano.Ledger.Api.Scripts.Tools
+    other-modules:    Cardano.Ledger.Api.Scripts.ExUnits
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -4,9 +4,6 @@ module Cardano.Ledger.Api.Scripts (
   ScriptHash,
   CostModels (..),
   ValidityInterval (..),
-
-  -- * Tools
-  module Cardano.Ledger.Api.Scripts.Tools,
 )
 where
 
@@ -14,6 +11,5 @@ import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels (..))
 import Cardano.Ledger.Api.Era ()
 import Cardano.Ledger.Api.Scripts.Data
-import Cardano.Ledger.Api.Scripts.Tools
 import Cardano.Ledger.Core (EraScript (..))
 import Cardano.Ledger.Hashes (ScriptHash)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.Ledger.Api.Scripts.Tools (
+module Cardano.Ledger.Api.Scripts.ExUnits (
   TransactionScriptFailure (..),
   ValidationFailed (..),
   evalTxExUnits,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/Tools.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/Tools.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -9,8 +10,10 @@
 module Cardano.Ledger.Api.Scripts.Tools (
   TransactionScriptFailure (..),
   ValidationFailed (..),
+  evalTxExUnits,
   evaluateTransactionExecutionUnits,
   RedeemerReport,
+  evalTxExUnitsWithLogs,
   evaluateTransactionExecutionUnitsWithLogs,
   RedeemerReportWithLogs,
 )
@@ -22,6 +25,7 @@ import Cardano.Ledger.Alonzo.PlutusScriptApi (knownToNotBe1Phase)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   CostModel,
+  CostModels (..),
   ExUnits (..),
   getEvaluationContext,
  )
@@ -113,6 +117,70 @@ type RedeemerReportWithLogs c = Map RdmrPtr (Either (TransactionScriptFailure c)
 --  a given transaction. If a redeemer is invalid, a failure is returned instead.
 --
 --  The execution budgets in the supplied transaction are completely ignored.
+--  The results of 'evalTxExUnitsWithLogs' are intended to replace them.
+evalTxExUnits ::
+  forall era.
+  ( AlonzoEraTx era
+  , ExtendedUTxO era
+  , EraUTxO era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , Script era ~ AlonzoScript era
+  ) =>
+  PParams era ->
+  -- | The transaction.
+  Tx era ->
+  -- | The current UTxO set (or the relevant portion for the transaction).
+  UTxO era ->
+  -- | The epoch info, used to translate slots to POSIX time for plutus.
+  EpochInfo (Either Text) ->
+  -- | The start time of the given block chain.
+  SystemStart ->
+  -- | We return a map from redeemer pointers to either a failure or a
+  --  sufficient execution budget.
+  --  Otherwise, we return a 'TranslationError' manifesting from failed attempts
+  --  to construct a valid execution context for the given transaction.
+  Either (TranslationError (EraCrypto era)) (RedeemerReport (EraCrypto era))
+evalTxExUnits pp tx utxo ei sysS =
+  fmap (Map.map (fmap snd)) $ evalTxExUnitsWithLogs pp tx utxo ei sysS
+
+-- | Evaluate the execution budgets needed for all the redeemers in
+--  a given transaction. If a redeemer is invalid, a failure is returned instead.
+--
+--  The execution budgets in the supplied transaction are completely ignored.
+--  The results of 'evaluateTransactionExecutionUnitsWithLogs' are intended to replace them.
+evalTxExUnitsWithLogs ::
+  forall era.
+  ( AlonzoEraTx era
+  , ExtendedUTxO era
+  , EraUTxO era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , Script era ~ AlonzoScript era
+  ) =>
+  PParams era ->
+  -- | The transaction.
+  Tx era ->
+  -- | The current UTxO set (or the relevant portion for the transaction).
+  UTxO era ->
+  -- | The epoch info, used to translate slots to POSIX time for plutus.
+  EpochInfo (Either Text) ->
+  -- | The start time of the given block chain.
+  SystemStart ->
+  -- | We return a map from redeemer pointers to either a failure or a sufficient
+  --  execution budget with logs of the script.  Otherwise, we return a 'TranslationError'
+  --  manifesting from failed attempts to construct a valid execution context for the
+  --  given transaction.
+  --
+  --  Unlike `evalTxExUnits`, this function also returns evaluation logs, useful for
+  --  debugging.
+  Either (TranslationError (EraCrypto era)) (RedeemerReportWithLogs (EraCrypto era))
+evalTxExUnitsWithLogs pp tx utxo ei sysS =
+  let lookupCostModel lang = Map.lookup lang $ costModelsValid (pp ^. ppCostModelsL)
+   in evalTxExUnitsWithLogsInternal pp tx utxo ei sysS lookupCostModel
+
+-- | Evaluate the execution budgets needed for all the redeemers in
+--  a given transaction. If a redeemer is invalid, a failure is returned instead.
+--
+--  The execution budgets in the supplied transaction are completely ignored.
 --  The results of 'evaluateTransactionExecutionUnits' are intended to replace them.
 evaluateTransactionExecutionUnits ::
   forall era.
@@ -140,6 +208,7 @@ evaluateTransactionExecutionUnits ::
   Either (TranslationError (EraCrypto era)) (RedeemerReport (EraCrypto era))
 evaluateTransactionExecutionUnits pp tx utxo ei sysS costModels =
   fmap (Map.map (fmap snd)) $ evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels
+{-# DEPRECATED evaluateTransactionExecutionUnits "In favor of `evalTxExUnits`" #-}
 
 -- | Evaluate the execution budgets needed for all the redeemers in
 --  a given transaction. If a redeemer is invalid, a failure is returned instead.
@@ -170,18 +239,56 @@ evaluateTransactionExecutionUnitsWithLogs ::
   --  Otherwise, we return a 'TranslationError' manifesting from failed attempts
   --  to construct a valid execution context for the given transaction.
   Either (TranslationError (EraCrypto era)) (RedeemerReportWithLogs (EraCrypto era))
-evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels = do
+evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels =
+  evalTxExUnitsWithLogsInternal pp tx utxo ei sysS $ \lang ->
+    if l1 <= lang && lang <= l2
+      then Just (costModels ! lang)
+      else Nothing
+  where
+    (l1, l2) = bounds costModels
+{-# DEPRECATED evaluateTransactionExecutionUnitsWithLogs "In favor of `evalTxExUnitsWithLogs`" #-}
+
+-- | Evaluate the execution budgets needed for all the redeemers in
+--  a given transaction. If a redeemer is invalid, a failure is returned instead.
+--
+--  The execution budgets in the supplied transaction are completely ignored.
+--  The results of 'evaluateTransactionExecutionUnitsWithLogs' are intended to replace them.
+evalTxExUnitsWithLogsInternal ::
+  forall era.
+  ( AlonzoEraTx era
+  , ExtendedUTxO era
+  , EraUTxO era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , Script era ~ AlonzoScript era
+  ) =>
+  PParams era ->
+  -- | The transaction.
+  Tx era ->
+  -- | The current UTxO set (or the relevant portion for the transaction).
+  UTxO era ->
+  -- | The epoch info, used to translate slots to POSIX time for plutus.
+  EpochInfo (Either Text) ->
+  -- | The start time of the given block chain.
+  SystemStart ->
+  -- | The array of cost models, indexed by the supported languages.
+  (Language -> Maybe CostModel) ->
+  -- | We return a map from redeemer pointers to either a failure or a
+  --  sufficient execution budget with logs of the script.
+  --  Otherwise, we return a 'TranslationError' manifesting from failed attempts
+  --  to construct a valid execution context for the given transaction.
+  Either (TranslationError (EraCrypto era)) (RedeemerReportWithLogs (EraCrypto era))
+evalTxExUnitsWithLogsInternal pp tx utxo ei sysS lookupCostModel = do
   let getInfo :: Language -> Either (TranslationError (EraCrypto era)) VersionedTxInfo
       getInfo lang = txInfo pp lang ei sysS utxo tx
   ctx <- sequence $ Map.fromSet getInfo languagesUsed
   pure $
     Map.mapWithKey
       (findAndCount ctx)
-      (unRedeemers $ ws ^. rdmrsTxWitsL)
+      (unRedeemers $ wits ^. rdmrsTxWitsL)
   where
     txBody = tx ^. bodyTxL
-    ws = tx ^. witsTxL
-    dats = unTxDats $ ws ^. datsTxWitsL
+    wits = tx ^. witsTxL
+    dats = unTxDats $ wits ^. datsTxWitsL
     scriptsAvailable = txscripts utxo tx
     AlonzoScriptsNeeded needed = getScriptsNeeded utxo txBody
     neededAndConfirmedToBePlutus = mapMaybe (knownToNotBe1Phase scriptsAvailable) needed
@@ -211,11 +318,7 @@ evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels = do
           Map.lookup pointer ptrToPlutusScript
       (script, lang) <- note (MissingScript pointer ptrToPlutusScript) mscript
       inf <- note (RedeemerNotNeeded pointer sh) $ Map.lookup lang info
-      let (l1, l2) = bounds costModels
-      cm <-
-        if l1 <= lang && lang <= l2
-          then Right (costModels ! lang)
-          else Left (NoCostModelInLedgerState lang)
+      cm <- note (NoCostModelInLedgerState lang) (lookupCostModel lang)
       args <- case sp of
         Spending txin -> do
           txOut <- note (UnknownTxIn txin) $ Map.lookup txin (unUTxO utxo)
@@ -235,11 +338,12 @@ evaluateTransactionExecutionUnitsWithLogs pp tx utxo ei sysS costModels = do
           PlutusV2 ->
             let debug = PlutusDebugLang SPlutusV2 cm exunits script (PlutusData pArgs) protVer
              in Left $ ValidationFailure $ ValidationFailedV2 e logs debug
-        (logs, Right exBudget) -> note (IncompatibleBudget exBudget) $ (,) logs <$> exBudgetToExUnits exBudget
+        (logs, Right exBudget) ->
+          note (IncompatibleBudget exBudget) $ (,) logs <$> exBudgetToExUnits exBudget
       where
         maxBudget = transExUnits $ pp ^. ppMaxTxExUnitsL
         protVer = pp ^. ppProtocolVersionL
         plutusProtVer = transProtocolVersion protVer
-        interpreter lang = case lang of
+        interpreter = \case
           PlutusV1 -> PV1.evaluateScriptRestricting plutusProtVer PV1.Verbose
           PlutusV2 -> PV2.evaluateScriptRestricting plutusProtVer PV2.Verbose

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -48,11 +48,31 @@ module Cardano.Ledger.Api.Tx (
   AlonzoEraTx,
   isValidTxL,
   IsValid (..),
+
+  -- ** Execution units
+  evalTxExUnits,
+  evaluateTransactionExecutionUnits,
+  RedeemerReport,
+  evalTxExUnitsWithLogs,
+  evaluateTransactionExecutionUnitsWithLogs,
+  RedeemerReportWithLogs,
+  TransactionScriptFailure (..),
+  ValidationFailed (..),
 )
 where
 
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
 import Cardano.Ledger.Api.Era ()
+import Cardano.Ledger.Api.Scripts.ExUnits (
+  RedeemerReport,
+  RedeemerReportWithLogs,
+  TransactionScriptFailure (..),
+  ValidationFailed (..),
+  evalTxExUnits,
+  evalTxExUnitsWithLogs,
+  evaluateTransactionExecutionUnits,
+  evaluateTransactionExecutionUnitsWithLogs,
+ )
 import Cardano.Ledger.Api.Tx.AuxData
 import Cardano.Ledger.Api.Tx.Body
 import Cardano.Ledger.Api.Tx.Wits

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
@@ -16,8 +16,9 @@ module Cardano.Ledger.Api.Tx.Wits (
   bootAddrTxWitsL,
   BootstrapWitness,
 
-  -- ** Script address witness
+  -- ** Script witness
   scriptTxWitsL,
+  hashScriptTxWitsL,
 
   -- * Alonzo onwards
   AlonzoEraTxWits,
@@ -46,7 +47,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   unTxDats,
  )
 import Cardano.Ledger.Api.Era ()
-import Cardano.Ledger.Core (EraTxWits (..))
+import Cardano.Ledger.Core (EraTxWits (..), hashScriptTxWitsL)
 import Cardano.Ledger.Keys (KeyRole (Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey (WitVKey), witVKeyBytes, witVKeyHash)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Api.Tx.Wits (
   -- * Alonzo onwards
   AlonzoEraTxWits,
   datsTxWitsL,
+  hashDataTxWitsL,
   TxDats (..),
   unTxDats,
   rdmrsTxWitsL,
@@ -39,6 +40,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   Redeemers (..),
   TxDats (..),
   datsTxWitsL,
+  hashDataTxWitsL,
   rdmrsTxWitsL,
   unRedeemers,
   unTxDats,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Make `getConsumedValue` accept a deposit lookup function instead of a `DPState`
 * Add `lookupDepositDState` and `lookupRewardDState`. Former can be used with
   `getConsumedValue` to regain previous behavior.
-
+* Add `hashScriptTxWitsL`
 
 ## 1.0.0.0
 

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -58,7 +58,6 @@ library
 
     build-depends:
         base >=4.14 && <4.17,
-        array,
         bytestring,
         cardano-crypto-class,
         cardano-ledger-allegra,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -5,25 +5,25 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Cardano.Ledger.Alonzo.Tools (tests, testExUnitCalculation) where
+module Test.Cardano.Ledger.Alonzo.Tools (tests) where
 
 import Cardano.Crypto.DSIGN
 import qualified Cardano.Crypto.Hash as Crypto
+import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, CostModel, ExUnits (..), Tag (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript, ExUnits (..), Tag (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
-import Cardano.Ledger.Api.Tx (TransactionScriptFailure (..), evaluateTransactionExecutionUnits)
-import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase, natVersion)
+import Cardano.Ledger.Api.Tx (TransactionScriptFailure (..), evalTxExUnits)
+import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (IncrementalStake (..), UTxOState (..))
 import Cardano.Ledger.Shelley.Rules (UtxoEnv (..))
 import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), UTxO (..))
@@ -32,15 +32,16 @@ import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Control.State.Transition.Extended (STS (BaseM, Environment, Signal, State), TRC (TRC))
-import Data.Array (Array, array)
 import Data.Default.Class (Default (..))
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
-import Test.Cardano.Ledger.Alonzo.CostModel (freeCostModel, freeV1CostModels)
+import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
@@ -50,13 +51,6 @@ import Test.Cardano.Ledger.Examples.STSTestUtils (
   mkTxDats,
   someAddr,
   someKeys,
- )
-import Test.Cardano.Ledger.Generic.Fields (
-  PParamsField (..),
-  TxBodyField (..),
-  TxField (..),
-  TxOutField (..),
-  WitnessesField (..),
  )
 import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (Alonzo, Babbage))
 import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic, always)
@@ -101,7 +95,7 @@ testSystemStart :: SystemStart
 testSystemStart = SystemStart $ posixSecondsToUTCTime 0
 
 -- checks plutus script validation against a tx which has had
--- its ex units replaced by the output of evaluateTransactionExecutionUnits
+-- its ex units replaced by the output of evalTxExUnits
 testExUnitCalculation ::
   forall era m.
   ( MonadFail m
@@ -116,17 +110,15 @@ testExUnitCalculation ::
   , EraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
-  Proof era ->
   Tx era ->
   UTxOState era ->
   UtxoEnv era ->
   EpochInfo (Either Text) ->
   SystemStart ->
-  Array Language CostModel ->
   (forall a. String -> m a) ->
   m ()
-testExUnitCalculation proof tx utxoState ue ei ss costmdls err = do
-  tx' <- updateTxExUnits proof tx utxo ei ss costmdls err
+testExUnitCalculation tx utxoState ue ei ss err = do
+  tx' <- updateTxExUnits tx utxo ei ss err
   _ <-
     failLeft err $
       runShelleyBase $
@@ -155,13 +147,11 @@ exampleExUnitCalc ::
   IO ()
 exampleExUnitCalc proof =
   testExUnitCalculation
-    proof
     (exampleTx proof (RdmrPtr Spend 0))
     (ustate proof)
-    (uenv proof)
+    uenv
     exampleEpochInfo
     testSystemStart
-    costmodels
     assertFailure
 
 exampleInvalidExUnitCalc ::
@@ -180,61 +170,59 @@ exampleInvalidExUnitCalc ::
   IO ()
 exampleInvalidExUnitCalc proof = do
   let result =
-        evaluateTransactionExecutionUnits @era
-          (pparams proof)
+        evalTxExUnits @era
+          testPParams
           (exampleTx proof (RdmrPtr Spend 1))
           (initUTxO proof)
           exampleEpochInfo
           testSystemStart
-          costmodels
   case result of
     Left err ->
       assertFailure $
-        "evaluateTransactionExecutionUnits should not have failed, but it did with: " ++ show err
+        "evalTxExUnits should not have failed, but it did with: " ++ show err
     Right report ->
       case [(rdmrPtr, failure) | (rdmrPtr, Left failure) <- Map.toList report] of
         [] ->
-          assertFailure "evaluateTransactionExecutionUnits should have produced a failing report"
+          assertFailure "evalTxExUnits should have produced a failing report"
         [(_, failure)] ->
           RedeemerPointsToUnknownScriptHash (RdmrPtr Spend 1)
             @=? failure
         failures ->
           assertFailure $
-            "evaluateTransactionExecutionUnits produce failing scripts with unexpected errors: "
+            "evalTxExUnits produce failing scripts with unexpected errors: "
               ++ show failures
 
 exampleTx ::
   ( Scriptic era
-  , EraTxBody era
+  , AlonzoEraTx era
   , Signable (DSIGN (EraCrypto era)) (Crypto.Hash (HASH (EraCrypto era)) EraIndependentTxBody)
   ) =>
   Proof era ->
   RdmrPtr ->
   Tx era
 exampleTx pf ptr =
-  newTx
-    pf
-    [ Body (validatingBody pf)
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)]
-        , ScriptWits' [always 3 pf]
-        , DataWits' [Data (PV1.I 123)]
-        , RdmrWits $
-            Redeemers $
-              Map.singleton ptr (Data (PV1.I 42), ExUnits 5000 5000)
-        ]
-    ]
+  mkBasicTx (validatingBody pf)
+    & witsTxL .~ wits
+  where
+    wits =
+      mkBasicTxWits
+        & addrTxWitsL
+          .~ Set.fromList [mkWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)]
+        & hashScriptTxWitsL .~ [always 3 pf]
+        & hashDataTxWitsL .~ [Data (PV1.I 123)]
+        & rdmrsTxWitsL
+          .~ Redeemers (Map.singleton ptr (Data (PV1.I 42), ExUnits 5000 5000))
 
-validatingBody :: (Scriptic era, EraTxBody era) => Proof era -> TxBody era
+validatingBody :: (Scriptic era, AlonzoEraTxBody era) => Proof era -> TxBody era
 validatingBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 1]
-    , Collateral' [mkGenesisTxIn 11]
-    , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]]
-    , Txfee (Coin 5)
-    , WppHash (newScriptIntegrityHash pf (pparams pf) [PlutusV1] redeemers (mkTxDats (Data (PV1.I 123))))
-    ]
+  mkBasicTxBody
+    & inputsTxBodyL .~ Set.fromList [mkGenesisTxIn 1]
+    & collateralInputsTxBodyL .~ Set.fromList [mkGenesisTxIn 11]
+    & outputsTxBodyL
+      .~ SSeq.fromList [mkBasicTxOut (someAddr pf) (inject $ Coin 4995)]
+    & feeTxBodyL .~ Coin 5
+    & scriptIntegrityHashTxBodyL
+      .~ newScriptIntegrityHash pf testPParams [PlutusV1] redeemers (mkTxDats (Data (PV1.I 123)))
   where
     redeemers =
       Redeemers $
@@ -243,11 +231,8 @@ validatingBody pf =
 exampleEpochInfo :: Monad m => EpochInfo m
 exampleEpochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
 
-uenv :: EraPParams era => Proof era -> UtxoEnv era
-uenv pf = UtxoEnv (SlotNo 0) (pparams pf) def (GenDelegs mempty)
-
-costmodels :: Array Language CostModel
-costmodels = array (PlutusV1, PlutusV1) [(PlutusV1, freeCostModel PlutusV1)]
+uenv :: AlonzoEraPParams era => UtxoEnv era
+uenv = UtxoEnv (SlotNo 0) testPParams def (GenDelegs mempty)
 
 ustate ::
   ( EraTxOut era
@@ -274,34 +259,31 @@ updateTxExUnits ::
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Script era ~ AlonzoScript era
   ) =>
-  Proof era ->
   Tx era ->
   UTxO era ->
   EpochInfo (Either Text) ->
   SystemStart ->
-  Array Language CostModel ->
   (forall a. String -> m a) ->
   m (Tx era)
-updateTxExUnits proof tx utxo ei ss costmdls err =
-  let res = evaluateTransactionExecutionUnits (pparams proof) tx utxo ei ss costmdls
+updateTxExUnits tx utxo ei ss err =
+  let res = evalTxExUnits testPParams tx utxo ei ss
    in case res of
         Left e -> err (show e)
         Right (rdmrs :: Map RdmrPtr (Either (TransactionScriptFailure (EraCrypto era)) ExUnits)) ->
-          replaceRdmrs proof tx <$> traverse (failLeft err) rdmrs
+          replaceRdmrs tx <$> traverse (failLeft err) rdmrs
 
 replaceRdmrs ::
   forall era.
   (AlonzoEraTxWits era, EraTx era) =>
-  Proof era ->
   Tx era ->
   Map RdmrPtr ExUnits ->
   Tx era
-replaceRdmrs pf tx rdmrs = updateTx pf tx (WitnessesI [RdmrWits newrdmrs])
+replaceRdmrs tx rdmrs = tx & witsTxL . rdmrsTxWitsL .~ newRdmrs
   where
-    newrdmrs = foldr replaceRdmr (tx ^. witsTxL . rdmrsTxWitsL) (Map.assocs rdmrs)
+    newRdmrs = Map.foldrWithKey replaceRdmr (tx ^. witsTxL . rdmrsTxWitsL) rdmrs
 
-    replaceRdmr :: (RdmrPtr, ExUnits) -> Redeemers era -> Redeemers era
-    replaceRdmr (ptr, ex) x@(Redeemers r) =
+    replaceRdmr :: RdmrPtr -> ExUnits -> Redeemers era -> Redeemers era
+    replaceRdmr ptr ex x@(Redeemers r) =
       case Map.lookup ptr r of
         Just (dat, _ex) -> Redeemers $ Map.insert ptr (dat, ex) r
         Nothing -> x
@@ -310,13 +292,11 @@ failLeft :: (Monad m, Show e) => (String -> m a) -> Either e a -> m a
 failLeft _ (Right a) = pure a
 failLeft err (Left e) = err (show e)
 
-pparams :: EraPParams era => Proof era -> PParams era
-pparams proof =
-  newPParams
-    proof
-    [ Costmdls freeV1CostModels
-    , MaxValSize 1000000000
-    , MaxTxExUnits $ ExUnits 100000000 100000000
-    , MaxBlockExUnits $ ExUnits 100000000 100000000
-    , ProtocolVersion $ ProtVer (natVersion @5) 0
-    ]
+testPParams :: forall era. AlonzoEraPParams era => PParams era
+testPParams =
+  emptyPParams
+    & ppCostModelsL .~ freeV1CostModels
+    & ppMaxValSizeL .~ 1000000000
+    & ppMaxTxExUnitsL .~ ExUnits 100000000 100000000
+    & ppMaxBlockExUnitsL .~ ExUnits 100000000 100000000
+    & ppProtocolVersionL .~ ProtVer (eraProtVerHigh @era) 0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO, exBudgetToExUnits, transExUnits)
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
-import Cardano.Ledger.Api.Scripts (TransactionScriptFailure (..), evaluateTransactionExecutionUnits)
+import Cardano.Ledger.Api.Tx (TransactionScriptFailure (..), evaluateTransactionExecutionUnits)
 import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase, natVersion)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -112,7 +112,13 @@ import Test.Cardano.Ledger.Generic.Fields (
  )
 import Test.Cardano.Ledger.Generic.PrettyCore ()
 import Test.Cardano.Ledger.Generic.Proof
-import Test.Cardano.Ledger.Generic.Scriptic (HasTokens (..), PostShelley, Scriptic (..), after, matchkey)
+import Test.Cardano.Ledger.Generic.Scriptic (
+  HasTokens (..),
+  PostShelley,
+  Scriptic (..),
+  after,
+  matchkey,
+ )
 import Test.Cardano.Ledger.Generic.Updaters
 import Test.Cardano.Ledger.Shelley.Utils (
   RawSeed (..),
@@ -615,7 +621,7 @@ testBBodyState pf =
       alwaysFailsOutput =
         newTxOut
           pf
-          [ Address (someScriptAddr (never 0 pf) pf)
+          [ Address (someScriptAddr (never 0 pf))
           , Amount (inject $ Coin 3000)
           , DHash' [hashData $ anotherDatum @era]
           ]
@@ -631,13 +637,13 @@ testBBodyState pf =
       unspendableOut =
         newTxOut
           pf
-          [ Address (someScriptAddr (always 3 pf) pf)
+          [ Address (someScriptAddr (always 3 pf))
           , Amount (inject $ Coin 5000)
           ]
       alwaysSucceedsOutputV2 =
         newTxOut
           pf
-          [ Address (someScriptAddr (alwaysAlt 3 pf) pf)
+          [ Address (someScriptAddr (alwaysAlt 3 pf))
           , Amount (inject $ Coin 5000)
           , DHash' [hashData $ someDatum @era]
           ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -732,7 +732,7 @@ validatingSupplimentaryDatumTxOut :: forall era. (EraTxBody era, Scriptic era) =
 validatingSupplimentaryDatumTxOut pf =
   newTxOut
     pf
-    [ Address (someScriptAddr (always 3 pf) pf)
+    [ Address (someScriptAddr (always 3 pf))
     , Amount (inject $ Coin 995)
     , DHash' [hashData $ validatingSupplimentaryDatum @era]
     ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -137,14 +137,14 @@ freeCostModelV1 :: CostModel
 freeCostModelV1 =
   fromRight (error "corrupt freeCostModelV1") $
     mkCostModel PlutusV1 $
-      const 0 <$> (enumerate @PV1.ParamName)
+      0 <$ (enumerate @PV1.ParamName)
 
 -- | A cost model that sets everything as being free
 freeCostModelV2 :: CostModel
 freeCostModelV2 =
   fromRight (error "corrupt freeCostModelV2") $
     mkCostModel PlutusV1 $
-      const 0 <$> (enumerate @PV2.ParamName)
+      0 <$ (enumerate @PV2.ParamName)
 
 someKeys :: forall era. Era era => Proof era -> KeyPair 'Payment (EraCrypto era)
 someKeys _pf = KeyPair vk sk
@@ -158,9 +158,9 @@ someAddr pf = Addr Testnet pCred sCred
     pCred = KeyHashObj . hashKey . vKey $ someKeys pf
     sCred = StakeRefBase . KeyHashObj . hashKey $ svk
 
--- Create an address with a given payment script.The proof here is used only as a Proxy.
-someScriptAddr :: forall era. (Scriptic era) => Script era -> Proof era -> Addr (EraCrypto era)
-someScriptAddr s _pf = Addr Testnet pCred sCred
+-- Create an address with a given payment script.
+someScriptAddr :: forall era. Scriptic era => Script era -> Addr (EraCrypto era)
+someScriptAddr s = Addr Testnet pCred sCred
   where
     pCred = ScriptHashObj . hashScript @era $ s
     (_ssk, svk) = mkKeyPair @(EraCrypto era) (RawSeed 0 0 0 0 0)
@@ -202,14 +202,14 @@ initUTxO pf =
     alwaysSucceedsOutput =
       newTxOut
         pf
-        [ Address (someScriptAddr (always 3 pf) pf)
+        [ Address (someScriptAddr (always 3 pf))
         , Amount (inject $ Coin 5000)
         , DHash' [hashData $ datumExample1 @era]
         ]
     alwaysFailsOutput =
       newTxOut
         pf
-        [ Address (someScriptAddr (never 0 pf) pf)
+        [ Address (someScriptAddr (never 0 pf))
         , Amount (inject $ Coin 3000)
         , DHash' [hashData $ datumExample2 @era]
         ]
@@ -227,13 +227,13 @@ initUTxO pf =
     unspendableOut =
       newTxOut
         pf
-        [ Address (someScriptAddr (always 3 pf) pf)
+        [ Address (someScriptAddr (always 3 pf))
         , Amount (inject $ Coin 5000)
         ]
     alwaysSucceedsOutputV2 =
       newTxOut
         pf
-        [ Address (someScriptAddr (alwaysAlt 3 pf) pf)
+        [ Address (someScriptAddr (alwaysAlt 3 pf))
         , Amount (inject $ Coin 5000)
         , DHash' [hashData $ datumExample1 @era]
         ]


### PR DESCRIPTION
# Description

Implemented new functions `evalTxExUnits` and `evalTxExUnitsWithlogs`that do not require `CostModels` as an array and instead draws the`CostModels` from the supplied `PParams`. This approach simplifies usage downstream, beacause all uses that I found converted `ppCostModelsL` to an array before calling `evaluateTransactionExecutionUnits`

Both `evaluateTransactionExecutionUnits` and `evaluateTransactionExecutionUnitsWithLogs` are now deprecated.

Fixes #3334 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
