### PR TITLE
Add a couple of cardano-prelude lower-bounds

### DIFF
--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -83,7 +83,7 @@ library
         canonical-json,
         cardano-ledger-binary >=1.0,
         cardano-crypto,
-        cardano-prelude,
+        cardano-prelude >=0.1.0.1,
         heapwords,
         cryptonite,
         data-default,

--- a/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
+++ b/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
@@ -188,7 +188,7 @@ library
         cardano-crypto,
         cardano-crypto-test,
         cardano-crypto-wrapper,
-        cardano-prelude,
+        cardano-prelude >=0.1.0.1,
         cardano-prelude-test,
         containers,
         byron-spec-chain,


### PR DESCRIPTION
These just ensure that we don't pick a version before the `HeapWords`
split. The need for these came up when making CHaP revisions, and
they're really only needed in case cabal tries to pick a funny build
plan. But they're safe and cheap to add.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
