### PR TITLE
clarify script integrity hash data further in CDDL

### DIFF
--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -124,21 +124,35 @@ script_data_hash = $hash32
 ;        in (byte-wise) lexical order sorts earlier.
 ;
 ; For PlutusV1 (language id 0), the language view is the following:
-;   - the value of costmdls map at key 0 is encoded as an indefinite length
-;     list and the result is encoded as a bytestring. (our apologies)
+;   - the value of costmdls map at key 0 (in other words, the script_integrity_data)
+;     is encoded as an indefinite length list and the result is encoded as a bytestring.
+;     (our apologies)
+;     For example, the script_integrity_data corresponding to the all zero costmodel for V1
+;     would be encoded as (in hex):
+;     58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff
 ;   - the language ID tag is also encoded twice. first as a uint then as
 ;     a bytestring. (our apologies)
+;     Concretely, this means that the language version for V1 is encoded as
+;     4100 in hex.
 ; For PlutusV2 (language id 1), the language view is the following:
 ;   - the value of costmdls map at key 1 is encoded as an definite length list.
+;     For example, the script_integrity_data corresponding to the all zero costmodel for V2
+;     would be encoded as (in hex):
+;     98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+;   - the language ID tag is encoded as expected.
+;     Concretely, this means that the language version for V2 is encoded as
+;     01 in hex.
 ;
 ; Note that each Plutus language represented inside a transaction must have
 ; a cost model in the costmdls protocol parameter in order to execute,
 ; regardless of what the script integrity data is.
 ;
 ; Finally, note that in the case that a transaction includes datums but does not
-; include any redeemers, the script data format becomes (in hex):
+; include the redeemers field, the script data format becomes (in hex):
 ; [ 80 | datums | A0 ]
 ; corresponding to a CBOR empty list and an empty map.
+; Note that a transaction might include the redeemers field and set it to the
+; empty map, in which case the user supplied encoding of the empty map is used.
 
 ; address = bytes
 ; reward_account = bytes

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -201,21 +201,35 @@ script_data_hash = $hash32
 ;        in (byte-wise) lexical order sorts earlier.
 ;
 ; For PlutusV1 (language id 0), the language view is the following:
-;   - the value of costmdls map at key 0 is encoded as an indefinite length
-;     list and the result is encoded as a bytestring. (our apologies)
+;   - the value of costmdls map at key 0 (in other words, the script_integrity_data)
+;     is encoded as an indefinite length list and the result is encoded as a bytestring.
+;     (our apologies)
+;     For example, the script_integrity_data corresponding to the all zero costmodel for V1
+;     would be encoded as (in hex):
+;     58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff
 ;   - the language ID tag is also encoded twice. first as a uint then as
 ;     a bytestring. (our apologies)
+;     Concretely, this means that the language version for V1 is encoded as
+;     4100 in hex.
 ; For PlutusV2 (language id 1), the language view is the following:
 ;   - the value of costmdls map at key 1 is encoded as an definite length list.
+;     For example, the script_integrity_data corresponding to the all zero costmodel for V2
+;     would be encoded as (in hex):
+;     98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+;   - the language ID tag is encoded as expected.
+;     Concretely, this means that the language version for V2 is encoded as
+;     01 in hex.
 ;
 ; Note that each Plutus language represented inside a transaction must have
 ; a cost model in the costmdls protocol parameter in order to execute,
 ; regardless of what the script integrity data is.
 ;
 ; Finally, note that in the case that a transaction includes datums but does not
-; include any redeemers, the script data format becomes (in hex):
+; include the redeemers field, the script data format becomes (in hex):
 ; [ 80 | datums | A0 ]
 ; corresponding to a CBOR empty list and an empty map.
+; Note that a transaction might include the redeemers field and set it to the
+; empty map, in which case the user supplied encoding of the empty map is used.
 
 ; address = bytes
 ; reward_account = bytes


### PR DESCRIPTION
# Description

I have added some clarifying prose to the comments in the CDDL surrounding the script integrity hash data.

resolves #3313

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
