### PR TITLE
Draft- Opinions needed. Changed the STS State of the UTXO, UTXOW, and DELEGS rules

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxow.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxow.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.Allegra.Rules.Utxo (AllegraUTXO, AllegraUtxoPredFailure)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (DSignable, Hash)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState)
 import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxowEvent (..),
   ShelleyUtxowPredFailure (..),
@@ -42,14 +42,14 @@ instance
   , -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (AllegraUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
-  , State (EraRule "UTXO" era) ~ UTxOState era
+  , State (EraRule "UTXO" era) ~ LedgerState era
   , Signal (EraRule "UTXO" era) ~ Tx era
   , DSignable (EraCrypto era) (Hash (EraCrypto era) EraIndependentTxBody)
   , ProtVerAtMost era 8
   ) =>
   STS (AllegraUTXOW era)
   where
-  type State (AllegraUTXOW era) = UTxOState era
+  type State (AllegraUTXOW era) = LedgerState era
   type Signal (AllegraUTXOW era) = Tx era
   type Environment (AllegraUTXOW era) = UtxoEnv era
   type BaseM (AllegraUTXOW era) = ShelleyBase

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Rules (AlonzoLEDGER)
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, AlonzoTx)
 import Cardano.Ledger.BaseTypes (Globals)
-import Cardano.Ledger.Shelley.LedgerState (DPState (..), UTxOState)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState)
 import Cardano.Ledger.Shelley.Rules (
   DelegsEnv,
   DelplEnv,
@@ -50,16 +50,16 @@ instance
   , MinLEDGER_STS era
   , Embed (EraRule "DELPL" era) (CERTS era)
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , State (EraRule "DELPL" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELPL" era) ~ LedgerState era
   , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
   , PredicateFailure (EraRule "DELPL" era) ~ ShelleyDelplPredFailure era
   , Embed (EraRule "DELEGS" era) (AlonzoLEDGER era)
   , Embed (EraRule "UTXOW" era) (AlonzoLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , State (EraRule "UTXOW" era) ~ UTxOState era
+  , State (EraRule "UTXOW" era) ~ LedgerState era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
-  , State (EraRule "DELEGS" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELEGS" era) ~ LedgerState era
   , Signal (EraRule "DELEGS" era) ~ Seq (DCert (EraCrypto era))
   , Tx era ~ AlonzoTx era
   , ProtVerAtMost era 8

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -20,7 +20,6 @@ import Cardano.Ledger.Babbage.Era (BabbageLEDGER)
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUTXOW, BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Shelley.LedgerState (
-  DPState (..),
   LedgerState (..),
   UTxOState (..),
   obligationDPState,
@@ -57,10 +56,10 @@ instance
   , Embed (EraRule "DELEGS" era) (BabbageLEDGER era)
   , Embed (EraRule "UTXOW" era) (BabbageLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , State (EraRule "UTXOW" era) ~ UTxOState era
+  , State (EraRule "UTXOW" era) ~ LedgerState era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
-  , State (EraRule "DELEGS" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELEGS" era) ~ LedgerState era
   , Signal (EraRule "DELEGS" era) ~ Seq (DCert (EraCrypto era))
   ) =>
   STS (BabbageLEDGER era)

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
@@ -15,7 +15,6 @@ import Cardano.Ledger.Shelley.API (
   ApplyBlock,
   Block,
   DCert,
-  DPState,
   DelplEnv,
   ShelleyLEDGERS,
   ShelleyTx,
@@ -23,6 +22,7 @@ import Cardano.Ledger.Shelley.API (
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
+  LedgerState (..),
   NewEpochState (..),
  )
 import Cardano.Protocol.TPraos.API (GetLedgerView)
@@ -107,7 +107,7 @@ genTriple ::
   , Mock (EraCrypto era)
   , Embed (EraRule "DELPL" era) (CERTS era)
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , State (EraRule "DELPL" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELPL" era) ~ LedgerState era
   , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
   , Tx era ~ ShelleyTx era
   , EraGovernance era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -48,7 +48,7 @@ import Cardano.Ledger.Shelley.API (
   ShelleyLedgersEnv,
   StakeReference (StakeRefBase),
  )
-import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses, UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (UtxoEnv)
 import Cardano.Ledger.Shelley.TxBody (DCert, ShelleyEraTxBody, WitVKey, Withdrawals)
@@ -141,10 +141,10 @@ type MinCHAIN_STS era =
 type MinUTXO_STS era =
   ( STS (EraRule "UTXOW" era)
   , BaseM (EraRule "UTXOW" era) ~ ShelleyBase
-  , State (EraRule "UTXOW" era) ~ UTxOState era
+  , State (EraRule "UTXOW" era) ~ LedgerState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Signal (EraRule "UTXOW" era) ~ Tx era
-  , State (EraRule "UTXO" era) ~ UTxOState era
+  , State (EraRule "UTXO" era) ~ LedgerState era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , Signal (EraRule "UTXO" era) ~ Tx era
   )

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -19,9 +19,7 @@ import Cardano.Ledger.BaseTypes (Globals, TxIx, mkTxIxPartial)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   AccountState (..),
-  DPState,
   LedgerState (..),
-  UTxOState,
   genesisState,
  )
 import Cardano.Ledger.Shelley.Rules (
@@ -78,16 +76,16 @@ instance
   , MinLEDGER_STS era
   , Embed (EraRule "DELPL" era) (CERTS era)
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , State (EraRule "DELPL" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELPL" era) ~ LedgerState era
   , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
   , PredicateFailure (EraRule "DELPL" era) ~ ShelleyDelplPredFailure era
   , Embed (EraRule "DELEGS" era) (ShelleyLEDGER era)
   , Embed (EraRule "UTXOW" era) (ShelleyLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , State (EraRule "UTXOW" era) ~ UTxOState era
+  , State (EraRule "UTXOW" era) ~ LedgerState era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
-  , State (EraRule "DELEGS" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELEGS" era) ~ LedgerState era
   , Signal (EraRule "DELEGS" era) ~ Seq (DCert (EraCrypto era))
   , ProtVerAtMost era 8
   ) =>
@@ -113,7 +111,7 @@ instance
   , MinLEDGER_STS era
   , Embed (EraRule "DELPL" era) (CERTS era)
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , State (EraRule "DELPL" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELPL" era) ~ LedgerState era
   , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
   , PredicateFailure (EraRule "DELPL" era) ~ ShelleyDelplPredFailure era
   , Embed (EraRule "DELEG" era) (ShelleyDELPL era)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -130,7 +130,7 @@ genTx ::
   , Mock (EraCrypto era)
   , Embed (EraRule "DELPL" era) (CERTS era)
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , State (EraRule "DELPL" era) ~ DPState (EraCrypto era)
+  , State (EraRule "DELPL" era) ~ LedgerState era
   , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
   ) =>
   GenEnv era ->
@@ -153,7 +153,7 @@ genTx
         constants
       )
   (LedgerEnv slot txIx pparams reserves)
-  (LedgerState utxoSt@(UTxOState utxo _ _ _ _) dpState) =
+  ls@(LedgerState utxoSt@(UTxOState utxo _ _ _ _) dpState) =
     do
       -------------------------------------------------------------------------
       -- Generate the building blocks of a TxBody
@@ -180,7 +180,7 @@ genTx
           pparams
           (utxoSt, dpState)
       (certs, deposits, refunds, dpState', (certWits, certScripts)) <-
-        genDCerts ge pparams dpState slot txIx reserves
+        genDCerts ge pparams ls slot txIx reserves
       metadata <- genEraAuxiliaryData @era constants
       -------------------------------------------------------------------------
       -- Gather Key TxWits and Scripts, prepare a constructor for Tx Wits

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -71,7 +71,6 @@ import Cardano.Ledger.Shelley.Core
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState (
   AccountState (..),
-  DPState (..),
   EpochState (..),
   FilteredRewards (..),
   LedgerState (..),
@@ -80,6 +79,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   circulation,
   completeRupd,
   createRUpd,
+  dpsDState,
   filterAllRewards,
   lsDPState,
   rewards,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -207,7 +207,8 @@ poolTraceFromBlock chainSt block =
 -- | Reconstruct a DELEG trace from all the transaction certificates in a Block
 delegTraceFromBlock ::
   forall era.
-  ( ChainProperty era
+  ( EraGovernance era
+  , ChainProperty era
   , ShelleyEraTxBody era
   , EraSegWits era
   , ProtVerAtMost era 8
@@ -218,7 +219,7 @@ delegTraceFromBlock ::
 delegTraceFromBlock chainSt block =
   ( delegEnv
   , runShelleyBase $
-      Trace.closure @(ShelleyDELEG era) delegEnv delegSt0 blockCerts
+      Trace.closure @(ShelleyDELEG era) delegEnv ledgerSt0 blockCerts
   )
   where
     (_tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
@@ -229,9 +230,6 @@ delegTraceFromBlock chainSt block =
           dummyCertIx = minBound
           ptr = Ptr s txIx dummyCertIx
        in DelegEnv s ptr reserves pp
-    delegSt0 =
-      let LedgerState _ (DPState delegSt0_ _) = ledgerSt0
-       in delegSt0_
     delegCert (DCertDeleg _) = True
     delegCert (DCertMir _) = True
     delegCert _ = False

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -53,7 +53,7 @@ import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.Core hiding (TranslationError)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import Cardano.Ledger.Shelley.Rules as Shelley (ShelleyUtxowPredFailure (..))
 import Cardano.Ledger.Shelley.TxBody (
   DCert (..),
@@ -118,7 +118,7 @@ tests =
 alonzoUTXOWTests ::
   forall era.
   ( AlonzoBased era (PredicateFailure (EraRule "UTXOW" era))
-  , State (EraRule "UTXOW" era) ~ UTxOState era
+  , State (EraRule "UTXOW" era) ~ LedgerState era
   , GoodCrypto (EraCrypto era)
   , HasTokens era
   , EraTx era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -41,7 +41,7 @@ import Cardano.Ledger.Shelley.API (
  )
 import Cardano.Ledger.Shelley.Core hiding (TranslationError)
 import Cardano.Ledger.Shelley.LedgerState (
-  UTxOState (..),
+  LedgerState (..),
   smartUTxOState,
  )
 import Cardano.Ledger.Shelley.TxBody (
@@ -59,6 +59,7 @@ import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.CostModel (freeV1CostModels)
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
+import Test.Cardano.Ledger.Examples.BabbageFeatures (liftU)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   alwaysFailsHash,
   alwaysSucceedsHash,
@@ -99,7 +100,7 @@ tests =
 
 alonzoUTXOWTests ::
   forall era.
-  ( State (EraRule "UTXOW" era) ~ UTxOState era
+  ( State (EraRule "UTXOW" era) ~ LedgerState era
   , GoodCrypto (EraCrypto era)
   , HasTokens era
   , EraTx era
@@ -228,8 +229,8 @@ validatingState ::
   , EraGovernance era
   ) =>
   Proof era ->
-  UTxOState era
-validatingState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingState pf = liftU (smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def)
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingBody pf) (validatingTxOut pf)) 1
 
@@ -283,8 +284,8 @@ notValidatingState ::
   , EraGovernance era
   ) =>
   Proof era ->
-  UTxOState era
-notValidatingState pf = smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 2) (Coin 0) (Coin 5) def
+  LedgerState era
+notValidatingState pf = liftU (smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 2) (Coin 0) (Coin 5) def)
 
 -- =========================================================================
 --  Example 3: Process a CERT transaction with a succeeding Plutus script.
@@ -335,8 +336,8 @@ validatingWithCertState ::
   , EraGovernance era
   ) =>
   Proof era ->
-  UTxOState era
-validatingWithCertState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingWithCertState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingWithCertBody pf) (validatingWithCertTxOut pf)) 3
 
@@ -383,8 +384,8 @@ notValidatingWithCertState ::
   , EraGovernance era
   ) =>
   Proof era ->
-  UTxOState era
-notValidatingWithCertState pf = smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 4) (Coin 0) (Coin 5) def
+  LedgerState era
+notValidatingWithCertState pf = liftU $ smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 4) (Coin 0) (Coin 5) def
 
 -- ==============================================================================
 --  Example 5: Process a WITHDRAWAL transaction with a succeeding Plutus script.
@@ -437,8 +438,8 @@ validatingWithWithdrawalTxOut pf = newTxOut pf [Address (someAddr pf), Amount (i
 validatingWithWithdrawalState ::
   (EraTxBody era, PostShelley era, EraGovernance era) =>
   Proof era ->
-  UTxOState era
-validatingWithWithdrawalState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingWithWithdrawalState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingWithWithdrawalBody pf) (validatingWithWithdrawalTxOut pf)) 5
 
@@ -486,8 +487,8 @@ notValidatingTxWithWithdrawal pf =
 notValidatingWithWithdrawalState ::
   (EraTxBody era, PostShelley era, EraGovernance era) =>
   Proof era ->
-  UTxOState era
-notValidatingWithWithdrawalState pf = smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 6) (Coin 0) (Coin 5) def
+  LedgerState era
+notValidatingWithWithdrawalState pf = liftU $ smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 6) (Coin 0) (Coin 5) def
 
 -- =============================================================================
 --  Example 7: Process a MINT transaction with a succeeding Plutus script.
@@ -544,8 +545,8 @@ validatingWithMintState ::
   forall era.
   (PostShelley era, EraTxBody era, HasTokens era, Value era ~ MaryValue (EraCrypto era), EraGovernance era) =>
   Proof era ->
-  UTxOState era
-validatingWithMintState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingWithMintState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingWithMintBody pf) (validatingWithMintTxOut pf)) 7
 
@@ -592,8 +593,8 @@ notValidatingWithMintTx pf =
 notValidatingWithMintState ::
   (EraTxBody era, PostShelley era, EraGovernance era) =>
   Proof era ->
-  UTxOState era
-notValidatingWithMintState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+notValidatingWithMintState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf ExpectFailure 8
 
@@ -684,8 +685,8 @@ validatingManyScriptsState ::
   forall era.
   (EraTxBody era, PostShelley era, HasTokens era, Value era ~ MaryValue (EraCrypto era), EraGovernance era) =>
   Proof era ->
-  UTxOState era
-validatingManyScriptsState pf = smartUTxOState (pp pf) (UTxO utxo) (Coin 0) (Coin 5) def
+  LedgerState era
+validatingManyScriptsState pf = liftU $ smartUTxOState (pp pf) (UTxO utxo) (Coin 0) (Coin 5) def
   where
     utxo =
       Map.insert (TxIn (txid (validatingManyScriptsBody pf)) minBound) (validatingManyScriptsTxOut pf) $
@@ -741,8 +742,8 @@ validatingSupplimentaryDatumState ::
   forall era.
   (EraTxBody era, PostShelley era, EraGovernance era) =>
   Proof era ->
-  UTxOState era
-validatingSupplimentaryDatumState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingSupplimentaryDatumState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingSupplimentaryDatumBody pf) (validatingSupplimentaryDatumTxOut pf)) 3
 
@@ -797,8 +798,8 @@ validatingMultipleEqualCertsOut pf = newTxOut pf [Address (someAddr pf), Amount 
 validatingMultipleEqualCertsState ::
   (EraTxBody era, PostShelley era, EraGovernance era) =>
   Proof era ->
-  UTxOState era
-validatingMultipleEqualCertsState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingMultipleEqualCertsState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingMultipleEqualCertsBody pf) (validatingMultipleEqualCertsOut pf)) 3
 
@@ -845,8 +846,8 @@ validatingNonScriptOutWithDatumState ::
   , EraGovernance era
   ) =>
   Proof era ->
-  UTxOState era
-validatingNonScriptOutWithDatumState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
+  LedgerState era
+validatingNonScriptOutWithDatumState pf = liftU $ smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def
   where
     utxo = expectedUTxO' pf (ExpectSuccess (validatingNonScriptOutWithDatumTxBody pf) (validatingNonScriptOutWithDatumTxOut pf)) 103
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -80,7 +80,7 @@ import Cardano.Ledger.Shelley.API (
   UTxO (..),
  )
 import Cardano.Ledger.Shelley.Core hiding (TranslationError)
-import Cardano.Ledger.Shelley.LedgerState (smartUTxOState)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), smartUTxOState)
 import Cardano.Ledger.Shelley.Rules (
   BbodyEnv (..),
   ShelleyBbodyState,
@@ -109,6 +109,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore ()
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic (..), after, matchkey)
 import Test.Cardano.Ledger.Generic.Updaters
+import Test.Cardano.Ledger.Shelley.Address.Bootstrap (dPStateZero)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (genesisId)
 import Test.Cardano.Ledger.Shelley.Utils (
   RawSeed (..),
@@ -365,7 +366,7 @@ testUTXOWsubset (UTXOW other) _ = error ("Cannot use testUTXOW in era " ++ show 
 -- | Use a test where any two (ValidationTagMismatch x y) failures match regardless of 'x' and 'y'
 testUTXOspecialCase wit@(UTXOW proof) utxo pparam tx expected =
   let env = UtxoEnv (SlotNo 0) pparam def (GenDelegs mempty)
-      state = smartUTxOState pparam utxo (Coin 0) (Coin 0) def
+      state = LedgerState (smartUTxOState pparam utxo (Coin 0) (Coin 0) def) dPStateZero
    in case proof of
         Alonzo _ -> runSTS wit (TRC (env, state, tx)) (specialCont proof expected)
         Babbage _ -> runSTS wit (TRC (env, state, tx)) (specialCont proof expected)
@@ -396,7 +397,7 @@ testUTXOWwith ::
   Assertion
 testUTXOWwith wit@(UTXOW proof) cont utxo pparams tx expected =
   let env = UtxoEnv (SlotNo 0) pparams def (GenDelegs mempty)
-      state = smartUTxOState pparams utxo (Coin 0) (Coin 0) def
+      state = LedgerState (smartUTxOState pparams utxo (Coin 0) (Coin 0) def) dPStateZero
    in case proof of
         Conway _ -> runSTS wit (TRC (env, state, tx)) (cont expected)
         Babbage _ -> runSTS wit (TRC (env, state, tx)) (cont expected)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -79,22 +79,22 @@ import Test.Tasty.QuickCheck (testProperty)
 genTxAndUTXOState :: Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
 genTxAndUTXOState proof@(Conway _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Babbage _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Alonzo _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Mary _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Allegra _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Shelley _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), ledgerState, vtx), genState)
 
 genTxAndLEDGERState ::
   forall era.


### PR DESCRIPTION
Changed the STS State of the UTXO, UTXOW, and DELEGS rules. From UTxOState  to LedgerState, for UTXO and UTXOW and from DPState to LedgerState. for DELEGS.
This is an experiment. When we move to incremental computation of the distribution maps, any place that alters
one of the roots of the incremental computations, will need access to all the roots. Since we currently alter the roots
in several different STS rules, all these rules need the same STS state. That is the motivation to make LedgerState
a common STS state for all of them.

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
