### PR TITLE
Translate bad `Ptr`s to valid `Ptr`s during translation to Conway.

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -54,10 +54,12 @@ module Cardano.Ledger.BaseTypes (
   TxIx (..),
   txIxToInt,
   txIxFromIntegral,
+  mkTxIx,
   mkTxIxPartial,
   CertIx (..),
   certIxToInt,
   certIxFromIntegral,
+  mkCertIx,
   mkCertIxPartial,
 
   -- * STS Base
@@ -670,6 +672,10 @@ newtype TxIx = TxIx Word64
   deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (NFData, Enum, Bounded, NoThunks, EncCBOR, DecCBOR, ToCBOR, FromCBOR, ToJSON)
 
+-- | Construct a `TxIx` from a 16 bit unsigned integer
+mkTxIx :: Word16 -> TxIx
+mkTxIx = TxIx . fromIntegral
+
 txIxToInt :: TxIx -> Int
 txIxToInt (TxIx w16) = fromIntegral w16
 
@@ -689,6 +695,10 @@ mkTxIxPartial i =
 newtype CertIx = CertIx Word64
   deriving stock (Eq, Ord, Show)
   deriving newtype (NFData, Enum, Bounded, NoThunks, EncCBOR, DecCBOR, ToCBOR, FromCBOR, ToJSON)
+
+-- | Construct a `CertIx` from a 16 bit unsigned integer
+mkCertIx :: Word16 -> CertIx
+mkCertIx = CertIx . fromIntegral
 
 certIxToInt :: CertIx -> Int
 certIxToInt (CertIx w16) = fromIntegral w16


### PR DESCRIPTION
Bad pointers and ugly addresses are not allowed in transactions starting with Babbage era. However, Ptr's that did land on chain in prior eras are still present in the LedgerState. Thanks to deprecation of `Ptr`s we can simplify the Ptr decoding logic, but only after the bad ones have been translated.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
