### PR TITLE
Drop alonzo genesis from conway genesis

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add `RatifyFailure` to `ConwayNewEpochPredFailure` #3339
 * Add `EncCBOR`/`DecCBOR` and `ToCBOR`/`FromCBOR` for `ConwayTallyPredFailure`
 * Add `ToCBOR`/`FromCBOR` for `ConwayGovernance`
+* Remove `cgAlonzoGenesis` from `ConwayGenesis`.
 
 ### `testlib`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -49,8 +49,8 @@ instance (Crypto c, DSignable c (Hash c EraIndependentTxBody)) => API.ApplyBlock
 
 instance Crypto c => API.CanStartFromGenesis (ConwayEra c) where
   type AdditionalGenesisConfig (ConwayEra c) = ConwayGenesis c
-  fromShelleyPParams cg =
-    translateEra' (cgGenDelegs cg) . API.fromShelleyPParams (cgAlonzoGenesis cg)
+  fromShelleyPParams =
+    error "Unimplemented: Current interface is too limited and needs replacement for Conway to work"
 
 instance Crypto c => ExtendedUTxO (ConwayEra c) where
   txInfo = babbageTxInfo

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -23,7 +23,7 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Mary.Arbitrary (genMintValues)
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
-  arbitrary = ConwayGenesis <$> arbitrary <*> arbitrary
+  arbitrary = ConwayGenesis <$> arbitrary
 
 instance Crypto c => Arbitrary (ConwayDCert c) where
   arbitrary =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -9,12 +9,11 @@ module Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators (genCoherent
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.KES as KES
 import Cardano.Crypto.Util (SignableRepresentation)
-import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes (
   BlockNo (..),
   SlotNo (..),
  )
-import Cardano.Ledger.Crypto (DSIGN, KES, VRF)
+import Cardano.Ledger.Crypto (DSIGN, KES)
 import Cardano.Ledger.Shelley.API hiding (SignedDSIGN)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Protocol.TPraos.API (PraosCrypto)
@@ -43,7 +42,6 @@ genCoherentBlock ::
   forall era.
   ( EraSegWits era
   , Arbitrary (Tx era)
-  , VRF.Signable (VRF (EraCrypto era)) ~ SignableRepresentation
   , KES.Signable (KES (EraCrypto era)) ~ SignableRepresentation
   , DSIGN.Signable (DSIGN (EraCrypto era)) ~ SignableRepresentation
   , PraosCrypto (EraCrypto era)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -32,7 +32,7 @@
 -- +++ OK, passed 100 tests.
 module Cardano.Ledger.Api.Tx.Out (
   module Cardano.Ledger.Api.Tx.Address,
-  EraTxOut,
+  EraTxOut (TxOut),
   mkBasicTxOut,
 
   -- ** Value


### PR DESCRIPTION
# Description

This is the first step to taking care of #3337 

`AlonzoGenesis` has no business being in `ConwayGenesis`, so it is being removed. This breaks `CanStartFromGenesis`, but that will be fixed in a subsequent PR

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
