### PR TITLE
WIP  Change STS from LEDGER down to use ILC Diff

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -58,6 +58,7 @@ library
         aeson,
         bytestring,
         cardano-crypto-class,
+        cardano-data,
         cardano-ledger-binary >=1.1,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo >=1.1,
@@ -97,3 +98,22 @@ library testlib
         cardano-ledger-core,
         cardano-ledger-mary:testlib,
         small-steps
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Conway.DiffSpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-conway,
+        testlib,
+        cardano-ledger-core,
+        cardano-data:testlib

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.DiffSpec (conwayDiffSpecs)
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Conway tests" $ do
+      conwayDiffSpecs

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/DiffSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/DiffSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.DiffSpec (conwayDiffSpecs) where
+
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Test.Cardano.Data (
+  propExtend,
+  propZero,
+ )
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary ()
+
+-- ==========================================================
+
+conwayDiffSpecs :: Spec
+conwayDiffSpecs = describe "ILC Diff tests" $ do
+  describe "Diff EnactState" $ do
+    propZero (arbitrary @(EnactState (ConwayEra StandardCrypto)))
+    propExtend (arbitrary @(EnactState (ConwayEra StandardCrypto))) arbitrary
+  describe "Diff RatifyState" $ do
+    propZero (arbitrary @(RatifyState (ConwayEra StandardCrypto)))
+    propExtend (arbitrary @(RatifyState (ConwayEra StandardCrypto))) arbitrary
+  describe "Diff GovernanceState" $ do
+    propZero (arbitrary @(GovernanceState (ConwayEra StandardCrypto)))
+    propExtend (arbitrary @(GovernanceState (ConwayEra StandardCrypto))) arbitrary
+
+-- To run theses tests in ghci, uncomment and type 'main'
+-- main :: IO ()
+-- main = hspec $ conwayDiffSpecs

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -8,6 +9,7 @@
 
 module Test.Cardano.Ledger.Conway.Arbitrary () where
 
+import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (Sized)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Delegation.Certificates
@@ -17,6 +19,7 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Crypto (Crypto)
 import Control.State.Transition.Extended (STS (Event))
+import Data.Functor.Identity (Identity)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
@@ -230,3 +233,40 @@ instance
   Arbitrary (ConwayTickfEvent era)
   where
   arbitrary = undefined
+
+------------------------------------------------------------------------------------------
+-- Cardano.Ledger.Conway ILC instances ---------------------------------------------------
+------------------------------------------------------------------------------------------
+{-
+src/Cardano/Ledger/Conway/Governance.hs
+448:instance ILC (EnactState era) where
+521:instance ILC (RatifyState era) where
+584:instance ILC (ConwayGovernance era) where
+-}
+
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD Identity era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (Diff (EnactState era))
+  where
+  arbitrary = EnactState' <$> arbitrary
+
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD Identity era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (Diff (RatifyState era))
+  where
+  arbitrary = RatifyState' <$> arbitrary <*> arbitrary
+
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD Identity era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (Diff (ConwayGovernance era))
+  where
+  arbitrary = ConwayGovernance' <$> arbitrary <*> arbitrary <*> arbitrary

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -74,9 +74,10 @@ test-suite cardano-ledger-conway-test
         bytestring,
         cardano-ledger-allegra,
         cardano-ledger-alonzo,
+        cardano-data:testlib,
         cardano-ledger-babbage,
-        cardano-ledger-conway,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-conway-test,
-        cardano-ledger-core,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-shelley-test,
         tasty

--- a/eras/conway/test-suite/test/Tests.hs
+++ b/eras/conway/test-suite/test/Tests.hs
@@ -4,6 +4,7 @@
 module Main where
 
 import Cardano.Ledger.Conway (Conway)
+import Test.Cardano.Ledger.Common (hspec)
 import qualified Test.Cardano.Ledger.Conway.Serialisation.CDDL as CDDL
 import qualified Test.Cardano.Ledger.Conway.Serialisation.Roundtrip as Roundtrip
 import Test.Tasty (TestTree, defaultMain, testGroup)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -94,6 +94,9 @@ module Cardano.Ledger.Shelley.LedgerState (
   lsUTxOStateL,
   utxosFeesL,
   utxosGovernanceL,
+
+  -- * ILC instances
+  Diff (IStake', UTxOState', LedgerState'),
 ) where
 
 import Cardano.Ledger.DPState

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -478,8 +478,7 @@ shelleyCommonPParamsHKDPairs px pp =
   ]
 
 -- | Update operation for protocol parameters structure @PParams@
-newtype ProposedPPUpdates era
-  = ProposedPPUpdates (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdate era))
+newtype ProposedPPUpdates era = ProposedPPUpdates {unProposedPPUpdates :: Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdate era)}
   deriving (Generic)
 
 deriving instance Eq (PParamsUpdate era) => Eq (ProposedPPUpdates era)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -87,7 +87,7 @@ import Generic.Random (genericArbitraryU)
 import Numeric.Natural (Natural)
 import Test.Cardano.Chain.UTxO.Gen (genCompactTxOut)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Core.Arbitrary (genDiffCoin, genDiffMonoidMap)
 import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
 import Test.QuickCheck.Hedgehog (hedgehog)
 
@@ -752,3 +752,25 @@ instance Arbitrary RawSeed where
       <*> chooseAny
       <*> chooseAny
       <*> chooseAny
+
+------------------------------------------------------------------------------------------
+-- Cardano.Ledger.Shelley ILC instances --------------------------------------------------
+------------------------------------------------------------------------------------------
+
+instance (Era era, Arbitrary (PParamsHKD StrictMaybe era)) => Arbitrary (Diff (ShelleyPPUPState era)) where
+  arbitrary = ShelleyPPUPState' <$> arbitrary <*> arbitrary
+
+instance Crypto c => Arbitrary (Diff (IncrementalStake c)) where
+  arbitrary = IStake' <$> genDiffMonoidMap arbitrary genDiffCoin <*> genDiffMonoidMap arbitrary genDiffCoin
+
+instance
+  (Era era, Arbitrary (TxOut era), Arbitrary (Diff (GovernanceState era))) =>
+  Arbitrary (Diff (UTxOState era))
+  where
+  arbitrary = UTxOState' <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+instance
+  (Era era, Arbitrary (TxOut era), Arbitrary (Diff (GovernanceState era))) =>
+  Arbitrary (Diff (LedgerState era))
+  where
+  arbitrary = LedgerState' <$> arbitrary <*> arbitrary

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -22,6 +22,7 @@ source-repository head
 library
     exposed-modules:
         Test.Cardano.Ledger.TerseTools
+        Test.Cardano.Ledger.Shelley.ShelleyDiffTests
         Test.Cardano.Ledger.Shelley.Address.Bootstrap
         Test.Cardano.Ledger.Shelley.BenchmarkFunctions
         Test.Cardano.Ledger.Shelley.ByronTranslation
@@ -79,7 +80,7 @@ library
         cardano-crypto-class,
         cardano-crypto-test,
         cardano-crypto-wrapper,
-        cardano-data,
+        cardano-data:{cardano-data, testlib},
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-byron,
         cardano-ledger-byron-test,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -81,3 +81,14 @@ commonTests =
   , ByronTranslation.testGroupByronTranslation
   , ShelleyTranslation.testGroupShelleyTranslation
   ]
+
+-- ================================
+-- an example how one might debug one test, which can be replayed
+-- import Test.Tasty (defaultMain)
+-- import Cardano.Ledger.Crypto(StandardCrypto)
+-- import Cardano.Ledger.Shelley(ShelleyEra)
+-- main :: IO ()
+-- main = main = defaultMain (Pool.tests @(ShelleyEra StandardCrypto))
+-- Then in ghci, one can just type
+-- :main --quickcheck-replay=443873
+-- =================================

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ShelleyDiffTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ShelleyDiffTests.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.ShelleyDiffTests where
+
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.LedgerState
+import Test.Cardano.Data (
+  propExtend,
+  propZero,
+ )
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Shelley.Arbitrary ()
+
+-- ==========================================================
+
+-- We will have to tie these tests into the tests in
+-- cardano-ledger/eras/shelley/testsuite/test/Tests.hs
+-- The problem is this uses Tasty and the tests here use HSpec
+
+shelleyDiffTests :: Spec
+shelleyDiffTests = describe "ILC Diff tests" $ do
+  describe "Diff IncrementalStake" $ do
+    propZero (arbitrary @(IncrementalStake StandardCrypto))
+    propExtend (arbitrary @(IncrementalStake StandardCrypto)) arbitrary
+  describe "Diff UTxOState" $ do
+    propZero (arbitrary @(UTxOState (ShelleyEra StandardCrypto)))
+    propExtend (arbitrary @(UTxOState (ShelleyEra StandardCrypto))) arbitrary
+  describe "Diff LedgerState" $ do
+    propZero (arbitrary @(LedgerState (ShelleyEra StandardCrypto)))
+    propExtend (arbitrary @(LedgerState (ShelleyEra StandardCrypto))) arbitrary
+
+-- To run theses tests in ghci, uncomment and type 'main'
+main :: IO ()
+main = hspec $ shelleyDiffTests

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Slot (SlotNo (..))
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default.Class (def)
+import Data.Incremental (ILC (..))
 import Lens.Micro
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C_Crypto)
 import qualified Test.Cardano.Ledger.Shelley.Examples.Cast as Cast
@@ -49,8 +50,8 @@ testPoolNetworkID pv poolParams e = do
         runShelleyBase $
           applySTSTest @(ShelleyPOOL ShelleyTest)
             ( TRC
-                ( PoolEnv (SlotNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
-                , def
+                ( PoolEnv (SlotNo 0) (emptyPParams & ppProtocolVersionL .~ pv) def
+                , totalDiff def
                 , DCertPool (RegPool poolParams)
                 )
             )

--- a/hie.yaml
+++ b/hie.yaml
@@ -69,6 +69,9 @@ cradle:
     - path: "eras/conway/impl/testlib"
       component: "cardano-ledger-conway:lib:testlib"
 
+    - path: "eras/conway/impl/test"
+      component: "cardano-ledger-conway:test:tests"
+
     - path: "eras/conway/test-suite/src"
       component: "lib:cardano-ledger-conway-test"
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -23,6 +23,7 @@ library
         Data.UMap
         Data.ListMap
         Data.Universe
+        Data.Incremental
 
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -54,6 +55,7 @@ library testlib
 
     build-depends:
         base,
+        cardano-data,
         containers,
         hspec,
         QuickCheck
@@ -62,7 +64,10 @@ test-suite cardano-data-tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
-    other-modules:    Test.Cardano.Data.MapExtrasSpec
+    other-modules:
+        Test.Cardano.Data.MapExtrasSpec
+        Test.Cardano.Data.IlcTest
+
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates

--- a/libs/cardano-data/src/Data/Incremental.hs
+++ b/libs/cardano-data/src/Data/Incremental.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Introduce the Incremental Lambda Calculus embodied in the ILC class.
+--   Instances for two patterns of use involving Maps.
+module Data.Incremental where
+
+import Control.DeepSeq (NFData (..))
+import Data.Kind
+import Data.Map.Internal (Map (..))
+import Data.Map.Strict
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import GHC.Generics (Generic (..))
+
+-- ===================================================
+-- Incremental lambda calculus
+
+class ILC t where
+  data Diff t :: Type
+  applyDiff :: t -> Diff t -> t
+  extend :: Diff t -> Diff t -> Diff t
+  zero :: Diff t
+  totalDiff :: t -> Diff t
+
+infixr 0 $$
+($$) :: ILC t => t -> Diff t -> t
+x $$ y = applyDiff x y
+
+-- | Every (Diff t) is a Semigroup
+instance ILC t => Semigroup (Diff t) where
+  x <> y = extend x y
+
+-- | Every (Diff t) is a Monoid
+instance ILC t => Monoid (Diff t) where
+  mempty = zero
+
+-- ==============================================================
+-- Delta types.
+-- We are going to give the type (Map dom rng) an ILC instance.
+-- It turns out there are two reasonable choices for Map. The two
+-- reasonable choices differ on what properties the range of the Map
+-- has. If the range of the Map is a monoid, there are 3 ways the map
+-- might change.
+-- 1) entry is deleted,
+-- 2) an entry is changed or created, so there is a new range value
+-- 3) the range of an entry is combined (using monoid (actually semigroup) <>) with another value.
+--
+-- If the range is not a Monoid there are only two ways the map might change
+-- 1) entry is deleted,
+-- 2) an entry is changed or created, so there is a new range value
+--
+-- To do this we introduce two datatypes MonoidRngD and BinaryRngD. They
+-- will become part of the definition for the Diff(Map dom rng). It also
+-- turns out thet Both of them are Semigroups (but not Monoids as neither
+-- has a notion of No-Change. This is deliberate, but might be reconsidered
+-- at some point)
+
+-- | The range is deleted, overwritten, or combined using a Monoid
+data MonoidRngD v = DeleteM | WriteM !v | CombM !v
+  deriving (Show, Eq, Generic, NFData)
+
+instance (Semigroup t) => Semigroup (MonoidRngD t) where
+  CombM x <> DeleteM = WriteM x
+  CombM x <> WriteM y = WriteM (x <> y)
+  CombM x <> CombM y = CombM (x <> y)
+  x <> _ = x
+
+-- | The range is deleted or changed
+data BinaryRngD v = DeleteD | WriteD !v
+  deriving (Eq, Generic, NFData)
+
+-- The show instance is manual because it supports cutting and pasting
+-- error messages, to get values for exploring failures. With out the
+-- parantheses they often won't read properly.
+instance Show v => Show (BinaryRngD v) where
+  show DeleteD = "DeleteD"
+  show (WriteD d) = "WriteD(" ++ show d ++ ")"
+
+instance Semigroup (BinaryRngD t) where
+  DeleteD <> _ = DeleteD
+  WriteD x <> _ = WriteD x
+
+-- ============================================================
+-- Since there are two reasonable ILC instances for the Map
+-- type we wrap the map in a newtype for the first instance.
+-- This is the special case of a Map where the range is a
+-- Monoid. We provide tools to enforce the invariant, that in a
+-- MonoidMap, we never store 'mempty' of the Monoid.
+
+newtype MonoidMap k v = MM {unMM :: Map k v}
+  deriving newtype (Show, Eq, NFData)
+
+monoidInsertWith :: (Monoid v, Eq v, Ord k) => k -> v -> MonoidMap k v -> MonoidMap k v
+monoidInsertWith k !v1 (MM m) = MM (alter ok k m)
+  where
+    ok Nothing = if v1 == mempty then Nothing else Just v1
+    ok (Just v2) = if total == mempty then Nothing else Just total
+      where
+        total = v1 <> v2
+{-# INLINEABLE monoidInsertWith #-}
+
+monoidInsert :: (Monoid v, Eq v, Ord k) => k -> v -> MonoidMap k v -> MonoidMap k v
+monoidInsert k !v1 (MM m) = if v1 == mempty then MM (delete k m) else MM (insert k v1 m)
+{-# INLINEABLE monoidInsert #-}
+
+-- =========================================
+-- ILC instances
+
+-- | Monoidal maps have special properties, so they get their
+--   own instance (wrapped in the newtype).
+instance (Ord k, Eq v, ILC v, Monoid v) => ILC (MonoidMap k v) where
+  newtype Diff (MonoidMap k v) = Dm (Map k (MonoidRngD (Diff v)))
+  applyDiff mm (Dm md) = Map.foldlWithKey' accum mm md
+    where
+      accum :: MonoidMap k v -> k -> MonoidRngD (Diff v) -> MonoidMap k v
+      accum (MM ans) cred DeleteM = MM (Map.delete cred ans)
+      accum ans cred (CombM dv) =
+        monoidInsertWith cred (applyDiff mempty dv) ans
+      accum ans cred (WriteM dv) = monoidInsert cred (applyDiff mempty dv) ans
+  {-# INLINEABLE applyDiff #-}
+  zero = Dm Map.empty
+  extend (Dm x) (Dm y) = Dm (Map.unionWith (<>) x y)
+  totalDiff _ = zero
+
+instance (Show (Diff v), Show k) => Show (Diff (MonoidMap k v)) where
+  show (Dm x) = show (Map.toList x)
+
+deriving newtype instance (NFData k, NFData (Diff v)) => NFData (Diff (MonoidMap k v))
+deriving newtype instance (Eq k, Eq (Diff v)) => Eq (Diff (MonoidMap k v))
+
+-- | Normal map can only be deleted or updated so they use BinaryRngD
+instance Ord k => ILC (Map k v) where
+  newtype Diff (Map k v) = Dn (Map k (BinaryRngD v))
+    deriving (Eq)
+  applyDiff m (Dn md) = Map.foldlWithKey' accum m md
+    where
+      accum ans k DeleteD = Map.delete k ans
+      accum ans k (WriteD drep) = Map.insert k drep ans
+  {-# INLINEABLE applyDiff #-}
+  zero = Dn Map.empty
+  extend (Dn x) (Dn y) = Dn (Map.unionWith (<>) x y)
+  totalDiff _ = zero
+
+instance (Show k, Show v) => Show (Diff (Map k v)) where
+  show (Dn x) = show (Map.toList x)
+
+deriving newtype instance (NFData k, NFData v) => NFData (Diff (Map k v))
+
+-- ===========================================================
+-- A type which is it's own diff (modulo no changes at all)
+
+newtype Total x = Total x
+  deriving (Eq, Show)
+
+instance ILC (Total x) where
+  data Diff (Total x) = Total' x | Zero
+    deriving (Eq, Show)
+  applyDiff (Total x) d = Total (applyTotal x d)
+  extend Zero x = x
+  extend x _ = x
+  zero = Zero
+  totalDiff (Total x) = Total' x
+
+applyTotal :: x -> Diff (Total x) -> x
+applyTotal x Zero = x
+applyTotal _ (Total' y) = y
+
+-- ================================================================
+-- Operations on Diff(MonoidMap k v) and Diff(Map k v)
+
+insertM :: k -> Diff v -> Diff (MonoidMap k v)
+insertM k v = Dm (Map.singleton k (WriteM v))
+
+deleteM :: k -> Diff (MonoidMap k v)
+deleteM k = Dm (Map.singleton k DeleteM)
+
+combineM :: k -> Diff v -> Diff (MonoidMap k v)
+combineM k v = Dm (Map.singleton k (CombM v))
+
+lookupM :: (Monoid v, ILC v, Ord k) => k -> MonoidMap k v -> Diff (MonoidMap k v) -> Maybe v
+lookupM k (MM m) (Dm dm) = case Map.lookup k dm of
+  Nothing -> Map.lookup k m
+  Just (WriteM x) -> Just (applyDiff mempty x)
+  Just DeleteM -> Nothing
+  Just (CombM x) -> case Map.lookup k m of
+    Nothing -> Just (applyDiff mempty x)
+    Just y -> Just (applyDiff y x)
+
+insertD :: k -> v -> Diff (Map k v)
+insertD k v = Dn (Map.singleton k (WriteD v))
+
+deleteD :: k -> Diff (Map k v)
+deleteD k = Dn (Map.singleton k DeleteD)
+
+restrictDomainD :: Set k -> Diff (Map k v)
+restrictDomainD = Dn . Map.fromSet (const DeleteD)
+
+lookupD :: Ord k => k -> Map k v -> Diff (Map k v) -> Maybe v
+lookupD k m (Dn dm) = case Map.lookup k dm of
+  Nothing -> Map.lookup k m
+  Just (WriteD x) -> Just x
+  Just DeleteD -> Nothing
+
+-- =================================================================
+-- helper functions for making binary derivatives
+
+-- | insert a change (MonoidRngD c) into a Map.
+--   Note that if we wrap the (result :: Map k (MonoidRngD c)) with the constructor 'Dn'
+--   Dn :: Map k (BinaryRngD v) -> Diff (Map k v)
+--   then we get Diff(Map k v)
+insertC ::
+  (Ord k, Monoid c) =>
+  k ->
+  MonoidRngD c ->
+  Map k (MonoidRngD c) ->
+  Map k (MonoidRngD c)
+insertC = insertWith (<>)
+
+-- | Split two maps, x and y, into three parts
+--   1) the key appears only in x
+--   2) the key appears in both x and y
+--   3) the key appears only in y
+--   Given three 'C'ontinuation style functions, reduce
+--   the three parts to a single value.
+inter3C ::
+  Ord k =>
+  a ->
+  Map k u ->
+  Map k v ->
+  (a -> k -> u -> a) ->
+  (a -> k -> (u, v) -> a) ->
+  (a -> k -> v -> a) ->
+  a
+inter3C ans0 m0 n0 c1 c2 c3 = go ans0 m0 n0
+  where
+    go ans Tip Tip = ans
+    go !ans m Tip = Map.foldlWithKey' c1 ans m
+    go !ans Tip n = Map.foldlWithKey' c3 ans n
+    go !ans (Bin _ kx x l r) n = case Map.splitLookup kx n of
+      (ln, Nothing, rn) -> go (go (c1 ans kx x) l ln) r rn
+      (ln, Just y, rn) -> go (go (c2 ans kx (x, y)) l ln) r rn

--- a/libs/cardano-data/test/Main.hs
+++ b/libs/cardano-data/test/Main.hs
@@ -7,6 +7,7 @@ import System.IO (
   stdout,
   utf8,
  )
+import Test.Cardano.Data.IlcTest (ilcTests)
 import Test.Cardano.Data.MapExtrasSpec (mapExtrasSpec)
 import Test.Hspec
 import Test.Hspec.Runner
@@ -22,6 +23,7 @@ spec :: Spec
 spec =
   describe "cardano-data" $ do
     describe "MapExtras" mapExtrasSpec
+    ilcTests
 
 main :: IO ()
 main = do

--- a/libs/cardano-data/test/Test/Cardano/Data/IlcTest.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/IlcTest.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Data.IlcTest (ilcTests) where
+
+import Data.Incremental
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Test.Cardano.Data (plusBinary, plusUnary, propExtend, propZero)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+-- ==================================================================================
+-- These are standins for Coin and DRep which we can't import here
+
+newtype MockCoin = MockCoin Integer
+  deriving (Eq, Show, Ord)
+
+instance Semigroup MockCoin where
+  (MockCoin n) <> (MockCoin m) = MockCoin (n + m)
+
+instance Monoid MockCoin where
+  mempty = MockCoin 0
+
+instance ILC MockCoin where
+  newtype Diff MockCoin = DeltaMockCoin Integer
+    deriving (Eq, Show)
+  applyDiff (MockCoin n) (DeltaMockCoin m) = MockCoin (n + m)
+  zero = DeltaMockCoin 0
+  extend (DeltaMockCoin n) (DeltaMockCoin m) = DeltaMockCoin (n + m)
+  totalDiff _ = zero
+
+newtype Rep = Rep String
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Rep where
+  arbitrary =
+    Rep <$> do
+      a <- choose ('A', 'Z')
+      b <- choose ('a', 'z')
+      c <- choose ('0', '9')
+      pure [a, b, c]
+
+instance Arbitrary (Diff MockCoin) where
+  arbitrary = DeltaMockCoin <$> arbitrary
+
+instance Arbitrary MockCoin where
+  arbitrary = MockCoin <$> arbitrary
+
+-- ==================================================================================
+-- derivative of a unary function
+
+sumCoins :: Map Int MockCoin -> MockCoin
+sumCoins xs = Map.foldl' accum (MockCoin 0) xs
+  where
+    accum (MockCoin i) (MockCoin j) = MockCoin (i + j)
+
+sumCoins' :: Map Int MockCoin -> Diff (Map Int MockCoin) -> Diff MockCoin
+sumCoins' m (Dn mb) = DeltaMockCoin $ Map.foldlWithKey' accum 0 mb
+  where
+    accum ans k DeleteD = case Map.lookup k m of
+      Nothing -> ans
+      Just (MockCoin i) -> ans - i
+    accum ans k (WriteD (MockCoin i)) = case Map.lookup k m of
+      Nothing -> ans + i
+      Just (MockCoin j) -> ans + i - j
+
+-- ==================================================================================
+-- derivative of a binary function
+
+changeMockCoin :: MockCoin -> MockCoin -> MockCoin
+changeMockCoin (MockCoin n) (MockCoin m) = MockCoin (m * n)
+
+changeCoin' :: MockCoin -> Diff MockCoin -> MockCoin -> Diff MockCoin -> Diff MockCoin
+changeCoin' (MockCoin n) (DeltaMockCoin i) (MockCoin m) (DeltaMockCoin j) =
+  DeltaMockCoin (n * j + m * i + i * j)
+
+-- ================================================
+
+insertDTest :: Int -> MockCoin -> Map Int MockCoin -> Expectation
+insertDTest k v m = applyDiff m (insertD k v) `shouldBe` Map.insert k v m
+
+deleteDTest :: Int -> Map Int MockCoin -> Expectation
+deleteDTest k m = applyDiff m (deleteD k) `shouldBe` Map.delete k m
+
+lookupDTest :: Int -> Map Int MockCoin -> Diff (Map Int MockCoin) -> Expectation
+lookupDTest k m md = lookupD k m md `shouldBe` Map.lookup k (applyDiff m md)
+
+insertMTest :: Int -> Diff MockCoin -> Map Int MockCoin -> Expectation
+insertMTest k v m = applyDiff (MM m) (insertM k v) `shouldBe` monoidInsert k (applyDiff mempty v) (MM m)
+
+deleteMTest :: Int -> Map Int MockCoin -> Expectation
+deleteMTest k m = applyDiff (MM m) (deleteM k) `shouldBe` MM (Map.delete k m)
+
+combMTest :: Int -> Diff MockCoin -> Map Int MockCoin -> Expectation
+combMTest k v m = applyDiff (MM m) (combineM k v) `shouldBe` monoidInsertWith k (applyDiff mempty v) (MM m)
+
+-- ================================================
+-- Property tests
+
+ilcTests :: Spec
+ilcTests = describe "ILC tests" $ do
+  describe "Coin" $ do
+    propZero (arbitrary @MockCoin)
+    propExtend (arbitrary @MockCoin) (arbitrary @(Diff MockCoin))
+
+  describe "Map cred Coin" $ do
+    propZero (arbitrary @(Map Int MockCoin))
+    propExtend (arbitrary @(Map Int MockCoin)) (arbitrary @(Diff (Map Int MockCoin)))
+
+  describe "MonoidMap cred Coin" $ do
+    propZero (arbitrary @(MonoidMap Int MockCoin))
+    propExtend (arbitrary @(MonoidMap Int MockCoin)) (arbitrary @(Diff (MonoidMap Int MockCoin)))
+
+  describe "Map cred Rep" $ do
+    propZero (arbitrary @(Map Int Rep))
+    propExtend (arbitrary @(Map Int Rep)) (arbitrary @(Diff (Map Int Rep)))
+
+  describe "Total (Int,Bool)" $ do
+    propZero (arbitrary @(Total (Int, Bool)))
+    propExtend (arbitrary @(Total (Int, Bool))) (arbitrary @(Diff (Total (Int, Bool))))
+
+  describe "Unary functions" $
+    prop "sumCoins' is derivative of unary function sumCoins" $
+      plusUnary sumCoins sumCoins'
+
+  describe "Binary functions" $ do
+    prop "changeCoin' is derivative of changeCoin" $
+      plusBinary changeMockCoin changeCoin' arbitrary arbitrary arbitrary arbitrary
+
+  describe "Functions on Diff(Map k v)" $ do
+    prop "insertD test" insertDTest
+    prop "deleteD test" deleteDTest
+    prop "lookupD test" lookupDTest
+
+  describe "Functions on Diff(MonoidMap k v)" $ do
+    prop "insertM test" insertMTest
+    prop "deleteM test" deleteMTest
+    prop "combineM test" combMTest
+
+-- To run theses tests in ghci, uncomment and type 'main'
+-- main = hspec $ ilcTests

--- a/libs/cardano-data/testlib/Test/Cardano/Data.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data.hs
@@ -1,12 +1,27 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Cardano.Data (
   expectValidMap,
   genNonEmptyMap,
+  propZero,
+  propExtend,
+  plusUnary,
+  plusBinary,
+  genMonoidRngD,
+  genBinaryRngD,
 ) where
 
 import Control.Monad
+import Data.Incremental
 import qualified Data.Map.Internal.Debug as Map
 import qualified Data.Map.Strict as Map hiding (showTree)
 import Test.Hspec
+import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
 expectValidMap :: HasCallStack => (Ord k, Show k, Show a) => Map.Map k a -> Expectation
@@ -23,3 +38,132 @@ expectValidMap m =
 
 genNonEmptyMap :: Ord k => Gen k -> Gen v -> Gen (Map.Map k v)
 genNonEmptyMap genKey genVal = Map.fromList <$> listOf1 ((,) <$> genKey <*> genVal)
+
+-- ======================================================================
+-- Reusable components for the Incremental Lambda Calculus (ILC)
+-- ======================================================================
+
+-- =================================
+-- Generic, reusable, Property tests
+
+propZero :: forall t. (Eq t, Show t, ILC t) => Gen t -> Spec
+propZero gent = prop "propZero" $ do
+  x <- gent
+  pure $ applyDiff @t x (zero @t) `shouldBe` x
+
+type ILCProp t = (ILC t, Show t, Eq t, Show (Diff t))
+
+propExtend :: forall t. (ILCProp t) => Gen t -> Gen (Diff t) -> Spec
+propExtend gent genDiff = prop "propExtend" $ do
+  x <- gent
+  dx1 <- genDiff
+  dx2 <- genDiff
+  let ext = extend @t dx2 dx1
+      appdif = applyDiff @t x dx1
+  pure
+    ( counterexample
+        ( unlines
+            [ "x= " ++ show x
+            , "dx1= " ++ show dx1
+            , "dx2= " ++ show dx2
+            , "extend dx2 dx1= " ++ show ext
+            , "applyDiff x dx1= " ++ show appdif
+            , "lhs (applyDiff x (extend dx2 dx1))= " ++ show (applyDiff x ext)
+            , "rhs (applyDiff (applyDiff x dx1) dx2)= " ++ show (applyDiff appdif dx2)
+            ]
+        )
+        (applyDiff x (extend @t dx2 dx1) `shouldBe` applyDiff (applyDiff @t x dx1) dx2)
+    )
+
+-- | Test that f' is really the derivative of the unary function f.
+plusUnary ::
+  forall a b.
+  (ILCProp a, ILCProp b) =>
+  (a -> b) ->
+  (a -> Diff a -> Diff b) ->
+  a ->
+  Diff a ->
+  Property
+plusUnary f f' a da =
+  counterexample
+    ( unlines
+        [ "a = " ++ show a
+        , "da = " ++ show da
+        , "f a = " ++ show (f a)
+        , "f' a da = " ++ show (f' a da)
+        , "applyDiff (f a) (f' a da)) = " ++ show (applyDiff (f a) (f' a da))
+        , "applyDiff a da = " ++ show (applyDiff a da)
+        , "f (applyDiff a da) = " ++ show (f (applyDiff a da))
+        ]
+    )
+    (f (applyDiff a da) `shouldBe` applyDiff (f a) (f' a da))
+
+-- | Test that f' is really the derivative of the binary function f.
+plusBinary ::
+  forall a b c.
+  (ILCProp a, ILCProp b, ILCProp c) =>
+  (a -> b -> c) ->
+  (a -> Diff a -> b -> Diff b -> Diff c) ->
+  Gen a ->
+  Gen (Diff a) ->
+  Gen b ->
+  Gen (Diff b) ->
+  Gen Property
+plusBinary f f' ga gda gb gdb = do
+  m <- ga
+  dm <- gda
+  n <- gb
+  dn <- gdb
+  pure $
+    counterexample
+      ( unlines
+          [ "m = " ++ show m
+          , "dm = " ++ show dm
+          , "n = " ++ show n
+          , "dn = " ++ show dn
+          , "f m n = " ++ show (f m n)
+          , "f' m dm n dn = " ++ show (f' m dm n dn)
+          , "applyDiff m dm = " ++ show (applyDiff m dm)
+          , "applyDiff n dn = " ++ show (applyDiff n dn)
+          , ""
+          , "f (applyDiff m dm) (applyDiff n dn) = " ++ show (f (applyDiff m dm) (applyDiff n dn))
+          , "applyDiff (f m n) (f' m dm n dn) = " ++ show (applyDiff (f m n) (f' m dm n dn))
+          ]
+      )
+      (f (applyDiff m dm) (applyDiff n dn) `shouldBe` applyDiff (f m n) (f' m dm n dn))
+
+-- ====================
+-- reusable ILC Generators
+
+instance Arbitrary t => Arbitrary (MonoidRngD t) where
+  arbitrary = genMonoidRngD arbitrary
+
+instance Arbitrary t => Arbitrary (BinaryRngD t) where
+  arbitrary = genBinaryRngD arbitrary
+
+instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Diff (Map.Map k v)) where
+  arbitrary = Dn <$> arbitrary
+
+instance (Ord k, Eq v, Monoid v, Arbitrary k, Arbitrary v) => Arbitrary (MonoidMap k v) where
+  arbitrary = MM . Map.filter (/= mempty) <$> arbitrary
+
+instance (Ord k, Arbitrary (Diff v), Arbitrary k, Arbitrary v) => (Arbitrary (Diff (MonoidMap k v))) where
+  arbitrary = Dm <$> arbitrary
+
+genMonoidRngD :: Gen t -> Gen (MonoidRngD t)
+genMonoidRngD g = oneof [pure DeleteM, WriteM <$> g, CombM <$> g]
+
+genBinaryRngD :: Gen t -> Gen (BinaryRngD t)
+genBinaryRngD g = oneof [pure DeleteD, WriteD <$> g]
+
+genTotal :: Gen t -> Gen (Total t)
+genTotal gent = Total <$> gent
+
+genDiffTotal :: Gen t -> Gen (Diff (Total t))
+genDiffTotal gent = frequency [(1, pure Zero), (6, Total' <$> gent)]
+
+instance Arbitrary t => Arbitrary (Total t) where
+  arbitrary = genTotal arbitrary
+
+instance Arbitrary t => Arbitrary (Diff (Total t)) where
+  arbitrary = genDiffTotal arbitrary

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -137,6 +137,7 @@ library testlib
         binary,
         bytestring,
         cardano-crypto-class,
+        cardano-data:{cardano-data, testlib},
         cardano-ledger-core,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-byron-test,
@@ -163,6 +164,7 @@ test-suite tests
     other-modules:
         Test.Cardano.Ledger.AddressSpec
         Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.CoreDiffTests
 
     default-language: Haskell2010
     ghc-options:
@@ -175,6 +177,7 @@ test-suite tests
         aeson,
         binary,
         bytestring,
+        cardano-data:testlib,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-core,
         cardano-crypto-class,

--- a/libs/cardano-ledger-core/test/Main.hs
+++ b/libs/cardano-ledger-core/test/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import qualified Test.Cardano.Ledger.AddressSpec as AddressSpec
 import qualified Test.Cardano.Ledger.BaseTypesSpec as BaseTypesSpec
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.CoreDiffTests (diffTests)
 
 main :: IO ()
 main =
@@ -10,3 +11,4 @@ main =
     describe "Core" $ do
       BaseTypesSpec.spec
       AddressSpec.spec
+      diffTests

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/CoreDiffTests.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/CoreDiffTests.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.CoreDiffTests (diffTests) where
+
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.DPState (
+  DPState (..),
+  DState (..),
+  InstantaneousRewards (..),
+  PState (..),
+ )
+import Cardano.Ledger.UMapCompact (
+  RDPair,
+  UMap,
+ )
+import Test.Cardano.Data (
+  propExtend,
+  propZero,
+ )
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Arbitrary (
+  genCoin,
+  genDiffCoin,
+  genDiffDPState,
+  genDiffDState,
+  genDiffInstantaneousRewards,
+  genDiffPState,
+  genDiffRDPair,
+  genDiffUMap,
+ )
+
+-- ====================================================
+
+diffTests :: Spec
+diffTests = describe "ILC Diff tests" $ do
+  describe "Diff Coin" $ do
+    propZero genCoin
+    propExtend genCoin genDiffCoin
+  describe "Diff RDPair" $ do
+    propZero (arbitrary @RDPair)
+    propExtend arbitrary genDiffRDPair
+  describe "Diff UMap" $ do
+    propZero (arbitrary @(UMap StandardCrypto))
+    propExtend (arbitrary @(UMap StandardCrypto)) genDiffUMap
+  describe "Diff InstantaneousRewards" $ do
+    propZero (arbitrary @(InstantaneousRewards StandardCrypto))
+    propExtend (arbitrary @(InstantaneousRewards StandardCrypto)) genDiffInstantaneousRewards
+  describe "Diff PState" $ do
+    propZero (arbitrary @(PState StandardCrypto))
+    propExtend (arbitrary @(PState StandardCrypto)) genDiffPState
+  describe "Diff DState" $ do
+    propZero (arbitrary @(DState StandardCrypto))
+    propExtend (arbitrary @(DState StandardCrypto)) genDiffDState
+  describe "Diff DPState" $ do
+    propZero (arbitrary @(DPState StandardCrypto))
+    propExtend (arbitrary @(DPState StandardCrypto)) genDiffDPState
+
+-- To run theses tests in ghci, uncomment and type 'main'
+-- main :: IO ()
+-- main = hspec $ diffTests


### PR DESCRIPTION
Change the STS instanced from LEDGER down to use ILC Diffs for the STS State type family.
So far we have added 
  1) The ILC class
   2) ILC instances for Coin, UMap, DPState, DState, PState, InstantaneousRewards
   3) Added a bunch of property tests

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
