### PR TITLE
Minor api improvements

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.0.0.1
+## 1.1.0.0
+
+* Remove redundant pattern synonym `AllegraTxAuxData'`
+* Hide internal `AllegraTxAuxDataRaw` constructor with `atadrMetadata` and `atadrTimelock`
+  record fields.
 
 ### `testlib`
 
 * Consolidate all `Arbitrary` instances from the test package to under a new `testlib`. #3285
-* Remove redundant pattern synonym `AllegraTxAuxData'`
 
 ## 1.0.0.0
 

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### `testlib`
 
 * Consolidate all `Arbitrary` instances from the test package to under a new `testlib`. #3285
+* Remove redundant pattern synonym `AllegraTxAuxData'`
 
 ## 1.0.0.0
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -38,7 +38,6 @@ import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Core (
   Era (..),
   EraTxAuxData (hashTxAuxData, validateTxAuxData),
-  Script,
  )
 import qualified Cardano.Ledger.Core as Core (TxAuxData)
 import Cardano.Ledger.Crypto (Crypto (HASH))
@@ -86,7 +85,7 @@ data AllegraTxAuxDataRaw era = AllegraTxAuxDataRaw
   }
   deriving (Generic, Eq)
 
-instance (Crypto c) => EraTxAuxData (AllegraEra c) where
+instance Crypto c => EraTxAuxData (AllegraEra c) where
   type TxAuxData (AllegraEra c) = AllegraTxAuxData (AllegraEra c)
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
   hashTxAuxData aux = AuxiliaryDataHash (hashAnnotated aux)
@@ -118,7 +117,7 @@ deriving newtype instance Era era => NoThunks (AllegraTxAuxData era)
 deriving newtype instance NFData (AllegraTxAuxData era)
 
 pattern AllegraTxAuxData ::
-  (EncCBOR (Script era), Era era) =>
+  Era era =>
   Map Word64 Metadatum ->
   StrictSeq (Timelock era) ->
   AllegraTxAuxData era
@@ -146,17 +145,14 @@ pattern AllegraTxAuxData' blob sp <-
 -- Serialisation
 --------------------------------------------------------------------------------
 
-instance (Era era, EncCBOR (Script era)) => EncCBOR (AllegraTxAuxDataRaw era) where
+instance Era era => EncCBOR (AllegraTxAuxDataRaw era) where
   encCBOR (AllegraTxAuxDataRaw blob sp) =
     encode (Rec AllegraTxAuxDataRaw !> To blob !> To sp)
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (AllegraTxAuxData era)
 
-instance
-  (Era era, DecCBOR (Annotator (Script era))) =>
-  DecCBOR (Annotator (AllegraTxAuxDataRaw era))
-  where
+instance Era era => DecCBOR (Annotator (AllegraTxAuxDataRaw era)) where
   decCBOR =
     peekTokenType >>= \case
       TypeMapLen -> decodeFromMap
@@ -183,5 +179,4 @@ instance
 deriving via
   (Mem AllegraTxAuxDataRaw era)
   instance
-    (Era era, DecCBOR (Annotator (Script era))) =>
-    DecCBOR (Annotator (AllegraTxAuxData era))
+    Era era => DecCBOR (Annotator (AllegraTxAuxData era))

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -16,7 +16,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra.TxAuxData (
-  AllegraTxAuxData (AllegraTxAuxData, ..),
+  AllegraTxAuxData (AllegraTxAuxData),
 
   -- * Deprecations
   AuxiliaryData,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -16,7 +16,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra.TxAuxData (
-  AllegraTxAuxData (AllegraTxAuxData, AllegraTxAuxData', ..),
+  AllegraTxAuxData (AllegraTxAuxData, ..),
 
   -- * Deprecations
   AuxiliaryData,
@@ -130,16 +130,6 @@ pattern AllegraTxAuxData blob sp <- (getMemoRawType -> AllegraTxAuxDataRaw blob 
 type AuxiliaryData = AllegraTxAuxData
 
 {-# DEPRECATED AuxiliaryData "Use `AllegraTxAuxData` instead" #-}
-
-pattern AllegraTxAuxData' ::
-  Era era =>
-  Map Word64 Metadatum ->
-  StrictSeq (Timelock era) ->
-  AllegraTxAuxData era
-pattern AllegraTxAuxData' blob sp <-
-  (getMemoRawType -> AllegraTxAuxDataRaw blob sp)
-
-{-# COMPLETE AllegraTxAuxData' #-}
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -11,7 +11,6 @@
 * Rename `smMap` to `cmValues`
 * Remove redundant pattern synonym `AlonzoTxAuxData'{atadMetadata',atadTimelock',atadPlutus'}`
 
-
 ###`testlib`
 
 * Consolidate all `Arbitrary` instances from the test package to under a new `testlib`. #3285

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Move `Cardano.Ledger.Alonzo.Tools` module into `cardano-ledger-api:Cardano.Ledger.Api.Scripts`
 * Add helper lens `hashDataTxWitsL`
 * Rename `smMap` to `cmValues`
+* Remove redundant pattern synonym `AlonzoTxAuxData'{atadMetadata',atadTimelock',atadPlutus'}`
+
 
 ###`testlib`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -23,13 +23,9 @@ module Cardano.Ledger.Alonzo.TxAuxData (
   -- * AlonzoTxAuxData
   AlonzoTxAuxData (
     AlonzoTxAuxData,
-    AlonzoTxAuxData',
     atadMetadata,
     atadTimelock,
-    atadPlutus,
-    atadMetadata',
-    atadTimelock',
-    atadPlutus'
+    atadPlutus
   ),
   mkAlonzoTxAuxData,
   AuxiliaryDataHash (..),
@@ -154,7 +150,7 @@ mkAlonzoTxAuxData atadrMetadata allScripts =
         ]
 
 getAlonzoTxAuxDataScripts :: Era era => AlonzoTxAuxData era -> StrictSeq (AlonzoScript era)
-getAlonzoTxAuxDataScripts AlonzoTxAuxData' {atadTimelock' = timelocks, atadPlutus' = plutus} =
+getAlonzoTxAuxDataScripts AlonzoTxAuxData {atadTimelock = timelocks, atadPlutus = plutus} =
   mconcat $
     (TimelockScript <$> timelocks)
       : [ PlutusScript lang . unBinaryPlutus <$> StrictSeq.fromList (NE.toList plutusScripts)
@@ -282,14 +278,3 @@ pattern AlonzoTxAuxData {atadMetadata, atadTimelock, atadPlutus} <-
       mkMemoized $ AlonzoTxAuxDataRaw {atadrMetadata, atadrTimelock, atadrPlutus}
 
 {-# COMPLETE AlonzoTxAuxData #-}
-
-pattern AlonzoTxAuxData' ::
-  Era era =>
-  Map Word64 Metadatum ->
-  StrictSeq (Timelock era) ->
-  Map Language (NE.NonEmpty BinaryPlutus) ->
-  AlonzoTxAuxData era
-pattern AlonzoTxAuxData' {atadMetadata', atadTimelock', atadPlutus'} <-
-  (getMemoRawType -> AlonzoTxAuxDataRaw atadMetadata' atadTimelock' atadPlutus')
-
-{-# COMPLETE AlonzoTxAuxData' #-}

--- a/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
+++ b/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
@@ -25,7 +25,7 @@ import Test.Tasty (TestTree, testGroup, withResource)
 tests :: Int -> TestTree
 tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
-    [ cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "coin"
+    [ cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "positive_coin"
     , cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "value"
     , cddlAnnotatorTest @(TxBody Conway) (eraProtVerHigh @Conway) n "transaction_body"
     , cddlAnnotatorTest @(TxAuxData Conway) (eraProtVerHigh @Conway) n "auxiliary_data"

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -73,5 +73,5 @@ exampleTimelock =
       , RequireSignature (mkKeyHash 100)
       ]
 
-exampleAllegraTxAuxData :: (Era era, Script era ~ Timelock era) => AllegraTxAuxData era
+exampleAllegraTxAuxData :: Era era => AllegraTxAuxData era
 exampleAllegraTxAuxData = AllegraTxAuxData exampleAuxDataMap (StrictSeq.fromList [exampleTimelock])

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -163,7 +163,7 @@ scriptGoldenTest =
               )
         )
 
-metadataNoScriptsGoldenTest :: forall era. (Era era, Script era ~ Timelock era) => TestTree
+metadataNoScriptsGoldenTest :: forall era. Era era => TestTree
 metadataNoScriptsGoldenTest =
   checkEncodingCBORAnnotated
     (eraProtVerHigh @era)
@@ -179,7 +179,7 @@ metadataNoScriptsGoldenTest =
     )
 
 -- CONTINUE also Scripts
-metadataWithScriptsGoldenTest :: forall era. (Era era, Script era ~ Timelock era) => TestTree
+metadataWithScriptsGoldenTest :: forall era. Era era => TestTree
 metadataWithScriptsGoldenTest =
   checkEncodingCBORAnnotated
     (eraProtVerHigh @era)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Export from `Cardano.Ledger.Api.Scripts.Data`: `BinaryData`, `DataHash`, `Datum`,
   `binaryDataToData`, `dataToBinaryData`, `datumDataHash`, `getPlutusData`,
   `hashBinaryData` and `makeBinaryData`.
-* Export `IsValid` from `Cardano.Ledger.Api.Tx`
+* Export `Tx` and `IsValid` from `Cardano.Ledger.Api.Tx`
 * Export from `Cardano.Ledger.Api.Tx.AuxData`: `mkAlonzoTxAuxData` and `getAlonzoTxAuxDataScripts`
 * Export from `Cardano.Ledger.Api.Tx.Wits`: `WitVKey`, `BootstrapWitness`,
   `AlonzoEraTxWits`, `TxDats`, `unTxDats`, `Redeemers`, `unRedeemers`, `RdmrPtr` and
@@ -27,7 +27,7 @@
 * Export from `Cardano.Ledger.Api.Era`:
   * `Era`
   * `ByronEra`
-  * And protocol version related functionality: `eraProtVerHigh`, `eraProtVerLow`,
+  * Protocol version related functionality: `eraProtVerHigh`, `eraProtVerLow`,
     `AtLeastEra`, `AtMostEra`, `ExactEra`, `ProtVerAtLeast`, `ProtVerAtMost`,
     `ProtVerInBounds`, `atLeastEra` and `atMostEra`
 * Move `Cardano.Ledger.Alonzo.Tools` module from `cardano-ledegr-alonzo` into

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -34,7 +34,7 @@ module Cardano.Ledger.Api.Tx (
   module Cardano.Ledger.Api.Tx.Wits,
 
   -- * Shelley onwards
-  EraTx,
+  EraTx (Tx),
   mkBasicTx,
   bodyTxL,
   witsTxL,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/In.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/In.hs
@@ -8,6 +8,7 @@ module Cardano.Ledger.Api.Tx.In (
 
   -- ** Transaction index
   TxIx,
+  mkTxIx,
   txIxToInt,
   txIxFromIntegral,
   mkTxIxPartial,
@@ -16,6 +17,7 @@ where
 
 import Cardano.Ledger.BaseTypes (
   TxIx,
+  mkTxIx,
   mkTxIxPartial,
   txIxFromIntegral,
   txIxToInt,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Remove custom `Fail` type, in favor of
   [`FailT`](https://hackage.haskell.org/package/FailT) package
 * Move `bBodySize` into `Cardano.Ledger.Core`
+* Rename `TxId` field from `_unTxId` to `unTxId`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -17,6 +17,7 @@
 
 module Cardano.Ledger.TxIn (
   TxId (..),
+  _unTxId,
   TxIn (TxIn),
   mkTxInPartial,
   TxIx,
@@ -55,6 +56,10 @@ import NoThunks.Class (NoThunks (..))
 newtype TxId c = TxId {unTxId :: SafeHash c EraIndependentTxBody}
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NoThunks, ToJSON, FromJSON)
+
+_unTxId :: TxId c -> SafeHash c EraIndependentTxBody
+_unTxId = unTxId
+{-# DEPRECATED _unTxId "In favor of `unTxId`" #-}
 
 deriving newtype instance Crypto c => HeapWords (TxId c)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -52,7 +52,7 @@ import NoThunks.Class (NoThunks (..))
 -- ====================================================================================
 
 -- | A unique ID of a transaction, which is computable from the transaction.
-newtype TxId c = TxId {_unTxId :: SafeHash c EraIndependentTxBody}
+newtype TxId c = TxId {unTxId :: SafeHash c EraIndependentTxBody}
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NoThunks, ToJSON, FromJSON)
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -76,11 +76,11 @@ ppValidityInterval (ValidityInterval b a) =
 instance PrettyA ValidityInterval where prettyA = ppValidityInterval
 
 ppAuxiliaryData :: Era era => AllegraTxAuxData era -> PDoc
-ppAuxiliaryData (AllegraTxAuxData' m sp) =
+ppAuxiliaryData (AllegraTxAuxData m sp) =
   ppRecord
     "AllegraTxAuxData"
     [ ("metadata", ppMap' (text "Metadata") ppWord64 ppMetadatum m)
-    , ("auxiliaryscripts", ppStrictSeq prettyA sp)
+    , ("auxiliaryScripts", ppStrictSeq prettyA sp)
     ]
 
 instance Era era => PrettyA (AllegraTxAuxData era) where

--- a/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
@@ -51,7 +51,7 @@ instance PersistFieldSql ShortByteString where
   sqlType _ = SqlBlob
 
 instance PersistField (TxId C) where
-  toPersistValue = PersistByteString . hashToBytes . extractHash . _unTxId
+  toPersistValue = PersistByteString . hashToBytes . extractHash . unTxId
   fromPersistValue (PersistByteString bs) =
     case hashFromBytes bs of
       Nothing -> Left "Invalid number of bytes for the hash"


### PR DESCRIPTION
# Description

* Rename TxId field from _unTxId to unTxId
* Some TxAuxData realeted cleanups:
  * Remove redundant pattern synonym `AllegraTxAuxData'` and `AlonzoTxAuxData'`
  * Hide internal `AllegraTxAuxDataRaw` constructor with `atadrMetadata` and `atadrTimelock`
    record fields.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated~
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
