### PR TITLE
Adjust `CostModel`'s `FromJSON` instance

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -10,6 +10,10 @@
 * Add helper lens `hashDataTxWitsL`
 * Rename `smMap` to `cmValues`
 * Remove redundant pattern synonym `AlonzoTxAuxData'{atadMetadata',atadTimelock',atadPlutus'}`
+* Addition of `costModelToMap`, `costModelFromMap` and `costModelParamNames`
+* Made it possible for `FromJSON` to decode `CostModels` both as the new approach:
+  1. as a list of cost models values,
+  2. and the old approach of mapping from the parameter name to the cost model value
 
 ###`testlib`
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -92,8 +92,7 @@ library
         transformers,
         tree-diff,
         utf8-string,
-        validation-selective,
-        vector
+        validation-selective
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-name-shadowing

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -69,7 +69,14 @@ import Cardano.Ledger.Alonzo.Scripts (
   getCostModelParams,
   zipSemiExUnits,
  )
-import Cardano.Ledger.BaseTypes (EpochNo (..), NonNegativeInterval, Nonce (NeutralNonce), StrictMaybe (..), UnitInterval, isSNothing)
+import Cardano.Ledger.BaseTypes (
+  EpochNo (..),
+  NonNegativeInterval,
+  Nonce (NeutralNonce),
+  StrictMaybe (..),
+  UnitInterval,
+  isSNothing,
+ )
 import qualified Cardano.Ledger.BaseTypes as BT (ProtVer (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),


### PR DESCRIPTION
# Description

It turns out cardano-node relies on JSON for CostModel for PlutusV2 to also contain the parameter names, not just a list of values. This PR implements this backwards compatibility in a forward compatible way.

* Addition of `costModelToMap`, `costModelFromMap` and `costModelParamNames`
* Made it possible for `FromJSON` to decode `CostModels` both as the new approach:
  1. as a list of cost models values,
  2. and the old approach of mapping from the parameter name to the cost model value

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
