### PR TITLE
Set `ConwayGenesis` as `TranslationContext` for Conway

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Add `EncCBOR`/`DecCBOR` and `ToCBOR`/`FromCBOR` for `ConwayTallyPredFailure`
 * Add `ToCBOR`/`FromCBOR` for `ConwayGovernance`
 * Remove `cgAlonzoGenesis` from `ConwayGenesis`.
+* Set `ConwayGenesis` as `TranslationContext`
 
 ### `testlib`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -23,6 +23,7 @@ import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), Datum (..))
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Conway.Core hiding (Tx)
 import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Conway.Tx ()
 import qualified Cardano.Ledger.Core as Core (Tx)
@@ -56,7 +57,7 @@ import Lens.Micro
 -- being total. Do not change it!
 --------------------------------------------------------------------------------
 
-type instance TranslationContext (ConwayEra c) = API.GenDelegs c
+type instance TranslationContext (ConwayEra c) = ConwayGenesis c
 
 instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
   translateEra ctxt nes =
@@ -112,16 +113,16 @@ instance Crypto c => TranslateEra (ConwayEra c) EpochState where
         }
 
 instance Crypto c => TranslateEra (ConwayEra c) API.LedgerState where
-  translateEra newGenDelegs ls =
+  translateEra conwayGenesis ls =
     pure
       API.LedgerState
-        { API.lsUTxOState = translateEra' newGenDelegs $ API.lsUTxOState ls
+        { API.lsUTxOState = translateEra' conwayGenesis $ API.lsUTxOState ls
         , API.lsDPState = updateGenesisKeys $ API.lsDPState ls
         }
     where
       updateGenesisKeys (DPState dstate pstate) = DPState dstate' pstate
         where
-          dstate' = dstate {dsGenDelegs = newGenDelegs}
+          dstate' = dstate {dsGenDelegs = cgGenDelegs conwayGenesis}
 
 instance Crypto c => TranslateEra (ConwayEra c) UTxOState where
   translateEra ctxt us =

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert (..))
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Rules (ConwayLEDGER)
 import Cardano.Ledger.Conway.Translation ()
 import Cardano.Ledger.Conway.Tx (AlonzoTx (..))
@@ -205,5 +206,8 @@ exampleConwayNewEpochState =
     emptyPParams
     (emptyPParams & ppCoinsPerUTxOByteL .~ CoinPerByte (Coin 1))
 
-exampleConwayGenesis :: GenDelegs c
-exampleConwayGenesis = GenDelegs Map.empty
+exampleConwayGenesis :: ConwayGenesis c
+exampleConwayGenesis =
+  ConwayGenesis
+    { cgGenDelegs = GenDelegs Map.empty
+    }


### PR DESCRIPTION
# Description

This was an oversight. Translation context is always equal to genesis type for each era, except Shelley

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
