### PR TITLE
Send email if nightly build failed

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -220,3 +220,27 @@ jobs:
         run: nix-build
       - name: nix-shell
         run: nix-shell shell.nix
+
+  notify-nightly-failure:
+    name: Send an email to the team if the nightly build failed
+    if:  |
+          ${{ failure() }} && ${{ github.event_name == 'schedule'}}
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - nix-build
+    steps:
+      - uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          # The gmail address used for this needs to have 2-Step Verification enabled
+          # and a Mail App password generated, which then needs to be stored in Github Actions secrets
+          # under the key NOTIFICATIONS_EMAIL_PASSWORD
+          username: ghnotifications.cardano.ledger@gmail.com
+          password: ${{ secrets.NOTIFICATIONS_EMAIL_PASSWORD }}
+          subject: ${{ github.repository }} - Nightly build failed
+          body: |
+            Nightly Github Actions build failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          to: ledger@iohk.io
+          from: ghnotifications.cardano.ledger@gmail.com


### PR DESCRIPTION
# Description

By default, email notifications about build failures are sent to the user who set up the workflow. 
However, if a nightly build fails, the entire team should be notified. 

This PR uses a send-mail action to send an email notification if the nightly build failed. 
I couldn't find any internal smtp server or anything like that (probably AWS is an option, but it needs credentials and more setup), so I set up a new gmail address for this: ghnotifications.cardano.ledger@gmail.com
I guess ideally the recovery email for this email should be the team email. 

The github action then is using the gmail smtp server with this email to send the notification when necessary. 
There is an additional complication with regards to authentication. 
The [password referenced in the github action](https://github.com/input-output-hk/cardano-ledger/compare/td/notify-if-nightly-failed?expand=1#diff-c09cc8dc973415b1221308559b96942a1c4b872e690bf360fc22d9b42822d519R241)  is not the password of the email account, but it is a so called App password that is generated from within the email account.
In order to generate this password, the first step is to turn on 2-Step Verification from Security Settings.
After that, from Security settings -> 2-Step Verification -> App passwords , generate a new password as show below: 


![2023-04-05_15-14](https://user-images.githubusercontent.com/2070003/230108348-906891cf-6c3d-4142-885f-36ba2f82f3a8.png)

This is necessary only if we need to regenerate this password, but it should work as it is right now. 
However, we do need to add  it to the github actions secrets under the key `NOTIFICATIONS_EMAIL_PASSWORD`: 

![2023-04-05_15-16](https://user-images.githubusercontent.com/2070003/230108940-91512273-77f5-4761-a69e-e7a81fc583d6.png)



So we should merge this PR only after we update the Settings in this repo

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
