### PR TITLE
Modified ConwayDCert

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.2.0.0
+
+* Added `ConwayDelegCert` and `Delegatee` #3372
+* Removed `toShelleyDCert` and `fromShelleyDCertMaybe` #3372
+
 ## 1.1.0.0
 
 * Added `RATIFY` rule

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -77,7 +77,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
   ConwayEraTxBody (..),
  )
-import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, toShelleyDCert)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance (ProposalProcedure, VotingProcedure)
 import Cardano.Ledger.Conway.PParams ()
@@ -99,7 +99,6 @@ import Cardano.Ledger.MemoBytes (
   Memoized (..),
   getMemoRawType,
   getMemoSafeHash,
-  getterMemoRawType,
   lensMemoRawType,
   mkMemoized,
  )
@@ -308,7 +307,8 @@ instance Crypto c => ShelleyEraTxBody (ConwayEra c) where
   certsTxBodyL = notSupportedInThisEraL
   {-# INLINE certsTxBodyL #-}
 
-  certsTxBodyG = getterMemoRawType (fmap toShelleyDCert . ctbrCerts)
+  -- TODO Fix this once DCert is a type family
+  certsTxBodyG = undefined
 
 instance Crypto c => AllegraEraTxBody (ConwayEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (ConwayEra StandardCrypto) #-}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -25,6 +25,22 @@ import Test.Cardano.Ledger.Mary.Arbitrary (genMintValues)
 instance Crypto c => Arbitrary (ConwayGenesis c) where
   arbitrary = ConwayGenesis <$> arbitrary
 
+instance Crypto c => Arbitrary (Delegatee c) where
+  arbitrary =
+    oneof
+      [ DelegStake <$> arbitrary
+      , DelegVote <$> arbitrary
+      , DelegStakeVote <$> arbitrary <*> arbitrary
+      ]
+
+instance Crypto c => Arbitrary (ConwayDelegCert c) where
+  arbitrary =
+    oneof
+      [ ConwayDeleg <$> arbitrary <*> arbitrary <*> arbitrary
+      , ConwayReDeleg <$> arbitrary <*> arbitrary
+      , ConwayUnDeleg <$> arbitrary <*> arbitrary
+      ]
+
 instance Crypto c => Arbitrary (ConwayDCert c) where
   arbitrary =
     oneof

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -266,20 +266,26 @@ script_data_hash = $hash32
 ; 1001 - 1101: future formats
 
 certificate =
-  [ stake_registration
-  // stake_deregistration
-  // stake_delegation
-  // pool_registration
+  [ pool_registration
   // pool_retirement
-  // genesis_key_delegation
+  // constitutional_deleg_cert
+  // deleg_cert
+  // redeleg_cert
+  // undeleg_cert
   ]
 
-stake_registration = (0, stake_credential)
-stake_deregistration = (1, stake_credential)
-stake_delegation = (2, stake_credential, pool_keyhash)
+delegatee =
+  [ 0, pool_keyhash
+  // 1, voting_credential
+  // 2, pool_keyhash, voting_credential
+  ]
+
 pool_registration = (3, pool_params)
 pool_retirement = (4, pool_keyhash, epoch)
-genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+constitutional_deleg_cert = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+deleg_cert = (6, stake_credential, delegatee, coin)
+redeleg_cert = (7, stake_credential, delegatee)
+undeleg_cert = (8, stake_credential, coin)
 
 move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin ]
 ; The first field determines where the funds are drawn from.
@@ -289,10 +295,13 @@ move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin
 
 delta_coin = int
 
-stake_credential =
+credential =
   [  0, addr_keyhash
   // 1, scripthash
   ]
+
+stake_credential = credential
+voting_credential = credential
 
 pool_params = ( operator:       pool_keyhash
               , vrf_keyhash:    vrf_keyhash

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -46,7 +46,6 @@ import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (
   ApplyTxError (..),
-  DelegCert (..),
   Network (..),
   NewEpochState (..),
   PoolCert (..),
@@ -73,7 +72,7 @@ import qualified PlutusTx as Plutus
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr, mkWitnessesVKey)
 import qualified Test.Cardano.Ledger.Mary.Examples.Consensus as MarySLE
-import Test.Cardano.Ledger.Shelley.Examples.Consensus (examplePoolParams, exampleStakeKey, keyToCredential)
+import Test.Cardano.Ledger.Shelley.Examples.Consensus (examplePoolParams)
 import qualified Test.Cardano.Ledger.Shelley.Examples.Consensus as SLE
 
 -- ==============================================================
@@ -126,9 +125,8 @@ collateralOutput =
 
 exampleConwayCerts :: CC.Crypto c => StrictSeq (ConwayDCert c)
 exampleConwayCerts =
-  StrictSeq.fromList
-    [ ConwayDCertDeleg (RegKey (keyToCredential exampleStakeKey))
-    , ConwayDCertPool (RegPool examplePoolParams)
+  StrictSeq.fromList -- TODO should I add the new certs here?
+    [ ConwayDCertPool (RegPool examplePoolParams)
     ]
 
 exampleTxBodyConway :: TxBody Conway

--- a/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
+++ b/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
@@ -12,8 +12,10 @@ import Cardano.Ledger.Alonzo.Tx (Data)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers)
 import Cardano.Ledger.Babbage.TxBody (Datum)
 import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert)
 import Cardano.Ledger.Conway.Governance (ProposalProcedure, VotingProcedure)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Data.ByteString.Lazy as BSL
 import Paths_cardano_ledger_conway_test (getDataFileName)
 import Test.Cardano.Ledger.Shelley.Serialisation.CDDLUtils (
@@ -41,6 +43,7 @@ tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
     , cddlAnnotatorTest @(Tx Conway) (eraProtVerHigh @Conway) n "transaction"
     , cddlTest @(VotingProcedure Conway) (eraProtVerHigh @Conway) n "voting_procedure"
     , cddlTest @(ProposalProcedure Conway) (eraProtVerHigh @Conway) n "proposal_procedure"
+    , cddlTest @(ConwayDCert StandardCrypto) (eraProtVerHigh @Conway) n "certificate"
     ]
       <*> pure cddl
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -40,6 +40,7 @@ class EraTxBody era => ShelleyEraTxBody era where
 
   certsTxBodyL :: ProtVerAtMost era 8 => Lens' (TxBody era) (StrictSeq (DCert (EraCrypto era)))
 
+  -- TODO remove this once DCert becomes a type family
   certsTxBodyG :: SimpleGetter (TxBody era) (StrictSeq (DCert (EraCrypto era)))
   default certsTxBodyG :: ProtVerAtMost era 8 => SimpleGetter (TxBody era) (StrictSeq (DCert (EraCrypto era)))
   certsTxBodyG = certsTxBodyL

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for `cardano-ledger-pretty`
 
+## 1.1.1.0
+
+ * Added `PrettyA` instances for:
+   * `Delegatee era` #3372
+   * `ConwayDelegCert c` #3372
+
 ## 1.1.0.0
 
 * Added:

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -60,7 +60,7 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert, toShelleyDCert)
+import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert)
 import Cardano.Ledger.Conway.Governance (GovernanceProcedure (..))
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -313,14 +313,14 @@ abstractTxBody (Alonzo _) (AlonzoTxBody inp col out cert wdrl fee vldt up req mn
   , AdHash adh
   , Txnetworkid net
   ]
-abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol cert wdrl fee vldt req mnt sih adh net vp pp) =
+abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol _cert wdrl fee vldt req mnt sih adh net vp pp) =
   [ Inputs inp
   , Collateral col
   , RefInputs ref
   , Outputs (sizedValue <$> out)
   , CollateralReturn (sizedValue <$> colret)
   , TotalCol totcol
-  , Certs $ toShelleyDCert <$> cert
+  , Certs undefined -- TODO fix once DCert is a type family
   , Withdrawals' wdrl
   , Txfee fee
   , Vldt vldt

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1398,7 +1398,7 @@ pcDCert (DCertGenesis _) = ppString "GenesisCert"
 pcDCert (DCertMir _) = ppString "MirCert"
 
 pcConwayDCert :: ConwayDCert c -> PDoc
-pcConwayDCert (ConwayDCertDeleg dc) = pcDelegCert dc
+pcConwayDCert (ConwayDCertDeleg dc) = prettyA dc
 pcConwayDCert (ConwayDCertPool poolc) = pcPoolCert poolc
 pcConwayDCert (ConwayDCertConstitutional _) = ppString "GenesisCert"
 


### PR DESCRIPTION
# Description

This PR modifies the `ConwayDCert`. Pool registration and deregistration certificates have been removed and delegation certificates were reworked to also allow delegating stake to DReps. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
