### PR TITLE
Revert Tickf optimization

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.1.1.0
+
+* Disable `TICKF` rule optimization: [#3375](https://github.com/input-output-hk/cardano-ledger/pull/3375)
+
 ## 1.1.0.0
 
 * Added a default implementation for `emptyGovernanceState`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.1.0.0
+version:            1.1.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -169,9 +169,9 @@ newEpochTransition = do
       es''' <- trans @(EraRule "EPOCH" era) $ TRC ((), es'', e)
       let adaPots = totalAdaPotsES es'''
       tellEvent $ TotalAdaPotsEvent adaPots
-      let pd' = ssStakeMarkPoolDistr (esSnapshots es)
+      -- let pd' = ssStakeMarkPoolDistr (esSnapshots es)
       -- The spec sets pd' with:
-      -- pd' = calculatePoolDistr (ssStakeSet $ esSnapshots es'''),
+      let pd' = calculatePoolDistr (ssStakeSet $ esSnapshots es''')
       --
       -- This is equivalent to:
       -- pd' = ssStakeMarkPoolDistr (esSnapshots es)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -258,7 +258,7 @@ bheadTransition = do
   -- so that it can remain a thunk when the consensus
   -- layer computes the ledger view across the epoch boundary.
   let !_ = ssStakeMark . esSnapshots . nesEs $ nes'
-      !_ = ssStakeMarkPoolDistr . esSnapshots . nesEs $ nes'
+  -- !_ = ssStakeMarkPoolDistr . esSnapshots . nesEs $ nes'
 
   ru'' <-
     trans @(EraRule "RUPD" era) $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -55,13 +55,12 @@ import Cardano.Ledger.Shelley.Rules.Rupd (
   ShelleyRUPD,
   ShelleyRupdPredFailure,
  )
-import Cardano.Ledger.Shelley.Rules.Upec (ShelleyUPEC, ShelleyUpecPredFailure, UpecState (..))
+import Cardano.Ledger.Shelley.Rules.Upec (UpecState (..))
 import Cardano.Ledger.Slot (EpochNo (unEpochNo), SlotNo, epochInfoEpoch)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
@@ -297,38 +296,35 @@ to tick the ledger state to a future slot.
 ------------------------------------------------------------------------------}
 
 newtype ShelleyTickfPredFailure era
-  = TickfUpecFailure (PredicateFailure (EraRule "UPEC" era)) -- Subtransition Failures
+  = TickfNewEpochFailure (PredicateFailure (EraRule "NEWEPOCH" era)) -- Subtransition Failures
   deriving (Generic)
 
 deriving stock instance
   ( Era era
-  , Show (PredicateFailure (EraRule "UPEC" era))
+  , Show (PredicateFailure (EraRule "NEWEPOCH" era))
   ) =>
   Show (ShelleyTickfPredFailure era)
 
 deriving stock instance
   ( Era era
-  , Eq (PredicateFailure (EraRule "UPEC" era))
+  , Eq (PredicateFailure (EraRule "NEWEPOCH" era))
   ) =>
   Eq (ShelleyTickfPredFailure era)
 
 instance
-  ( NoThunks (PredicateFailure (EraRule "UPEC" era))
+  ( NoThunks (PredicateFailure (EraRule "NEWEPOCH" era))
   ) =>
   NoThunks (ShelleyTickfPredFailure era)
 
 newtype ShelleyTickfEvent era
-  = TickfUpecEvent (Event (EraRule "UPEC" era)) -- Subtransition Events
+  = TickfNewEpochEvent (Event (EraRule "NEWEPOCH" era)) -- Subtransition Events
 
 instance
   ( Era era
-  , EraPParams era
-  , State (EraRule "PPUP" era) ~ ShelleyPPUPState era
-  , Signal (EraRule "UPEC" era) ~ ()
-  , State (EraRule "UPEC" era) ~ UpecState era
-  , Environment (EraRule "UPEC" era) ~ EpochState era
-  , Embed (EraRule "UPEC" era) (ShelleyTICKF era)
-  , GovernanceState era ~ ShelleyPPUPState era
+  , Embed (EraRule "NEWEPOCH" era) (ShelleyTICKF era)
+  , Environment (EraRule "NEWEPOCH" era) ~ ()
+  , State (EraRule "NEWEPOCH" era) ~ NewEpochState era
+  , Signal (EraRule "NEWEPOCH" era) ~ EpochNo
   ) =>
   STS (ShelleyTICKF era)
   where
@@ -347,16 +343,15 @@ instance
   transitionRules =
     [ do
         TRC ((), nes, slot) <- judgmentContext
-        validatingTickTransitionFORECAST nes slot
+        validatingTickTransition nes slot
     ]
 
 instance
-  ( Era era
-  , STS (ShelleyUPEC era)
-  , PredicateFailure (EraRule "UPEC" era) ~ ShelleyUpecPredFailure era
-  , Event (EraRule "UPEC" era) ~ Void
+  ( STS (ShelleyNEWEPOCH era)
+  , PredicateFailure (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochPredFailure era
+  , Event (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochEvent era
   ) =>
-  Embed (ShelleyUPEC era) (ShelleyTICKF era)
+  Embed (ShelleyNEWEPOCH era) (ShelleyTICKF era)
   where
-  wrapFailed = TickfUpecFailure
-  wrapEvent = TickfUpecEvent
+  wrapFailed = TickfNewEpochFailure
+  wrapEvent = TickfNewEpochEvent

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
@@ -49,10 +49,10 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyEPOCH,
   ShelleyMIR,
   ShelleyNEWEPOCH,
-  ShelleyTICKF,
+  -- ShelleyTICKF,
   adoptGenesisDelegs,
   updateRewards,
-  validatingTickTransitionFORECAST,
+  -- validatingTickTransitionFORECAST,
  )
 import Cardano.Ledger.Slot (EpochNo, SlotNo (..))
 import qualified Cardano.Ledger.UMapCompact as UM
@@ -175,12 +175,12 @@ adoptGenesisDelegsR ::
   EpochState era
 adoptGenesisDelegsR slot nes = adoptGenesisDelegs (nesEs nes) slot
 
-tickfR2 ::
-  Globals ->
-  Cardano.Slotting.Slot.SlotNo ->
-  NewEpochState CurrentEra ->
-  NewEpochState CurrentEra
-tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransitionFORECAST @ShelleyTICKF nes slot)
+-- tickfR2 ::
+--   Globals ->
+--   Cardano.Slotting.Slot.SlotNo ->
+--   NewEpochState CurrentEra ->
+--   NewEpochState CurrentEra
+-- tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransitionFORECAST @ShelleyTICKF nes slot)
 
 mirR :: Globals -> EpochState CurrentEra -> EpochState CurrentEra
 mirR globals es' = liftApplySTS globals (applySTS @(ShelleyMIR CurrentEra) (TRC ((), es', ())))
@@ -200,8 +200,8 @@ tickfRuleBench =
       let pv = esPp (nesEs nes) ^. ppProtocolVersionL
        in bgroup
             "Tickf Benchmarks"
-            [ bench "validatingTickTransitionfunction" $ whnf (tickfR2 globals (SlotNo 156953303)) nes
-            , bgroup
+            [ -- bench "validatingTickTransitionfunction" $ whnf (tickfR2 globals (SlotNo 156953303)) nes
+              bgroup
                 "Tick subparts"
                 [ bench "adoptGenesisDelegs" $ whnf (adoptGenesisDelegsR (SlotNo 156953303)) nes
                 , bench "newEpoch" $ whnf (newEpochR globals (nesEL nes + 1)) nes


### PR DESCRIPTION
# Description

This PR disables both of the optimizations implemented in #3209 Current implementation is causing problems. Reasons are not yet known and require investigation. That is why this PR only disables the optimizations instead of reverting them completely.

Important to note that both of the optimizations are causing problems, even when applied separately: 
* lazy computation of pool stake distribution
* and minimizing logic in TICKF rule 

That is why they are both being disabled.

Naturally, as all of my PRs go, this one also has a little bit of a cleanup included in it as a separate commit.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
