### PR TITLE
Fix cabal warnings

### DIFF
--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -66,13 +66,14 @@ library
         text
 
 library testlib
-    exposed-modules: Test.Cardano.Ledger.Mary.Arbitrary
-    visibility:      public
-    hs-source-dirs:  testlib
+    exposed-modules:  Test.Cardano.Ledger.Mary.Arbitrary
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates
         -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
-        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+        -Wunused-packages
 
     build-depends:
         base,


### PR DESCRIPTION
This gets rid of the following warnings by cabal:
1. `missing default language`
2. `-threaded -*rts* does not apply to library component`