### PR TITLE
Fix typos in addrEitherTxOutL docstring

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -272,7 +272,7 @@ class
   -- The utility of this function comes from the fact that TxOut usually stores
   -- the address in either one of two forms: compacted or unpacked. In order to
   -- avoid extroneous conversions in `getTxOutAddr` and `getTxOutCompactAddr` we
-  -- can define just this functionality. Also sometimes it crutial to know at
+  -- can define just this functionality. Also sometimes it is crucial to know at
   -- the callsite which form of address we have readily available without any
   -- conversions (eg. searching millions of TxOuts for a particular address)
   addrEitherTxOutL :: Lens' (TxOut era) (Either (Addr (EraCrypto era)) (CompactAddr (EraCrypto era)))


### PR DESCRIPTION
# Description

Fix typos in `addrEitherTxOutL` docstring.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [ ] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [ ] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
