### PR TITLE
Fix CI error dump for MultiAsset test

### DIFF
--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -76,14 +76,13 @@ spec = do
         forAll (genMaryValue (genEmptyMultiAsset @StandardCrypto)) $
           roundTripCborRangeFailureExpectation (natVersion @9) maxBound
       it "Too many assets should fail" $
-        expectFailure $
-          property $
-            forAll
-              (genMaryValue (genMultiAssetToFail @StandardCrypto True))
-              ( roundTripCborRangeExpectation @(MaryValue StandardCrypto)
-                  (eraProtVerLow @Mary)
-                  maxBound
-              )
+        property $
+          forAll
+            (genMaryValue (genMultiAssetToFail @StandardCrypto True))
+            ( roundTripCborRangeFailureExpectation @(MaryValue StandardCrypto)
+                (eraProtVerLow @Mary)
+                maxBound
+            )
   describe "MaryValue compacting" $ do
     prop "Canonical generator" $
       \(ma :: MaryValue StandardCrypto) ->


### PR DESCRIPTION
# Description

There isn't an issue open to address this because it is a small CI related issue. We fix the error dump for a failure-expectation test.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
