### PR TITLE
Rename DELPL to CERT in Conway

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 * Added `ConwayDelegCert` and `Delegatee` #3372
 * Removed `toShelleyDCert` and `fromShelleyDCertMaybe` #3372
-* Replace `DELPL` rule with `CERT`
 * Replace `DPState c` with `CertState era`
 * Add `TranslateEra` instances for:
   * `DState`
   * `PState`
   * `VState`
 * Add `ConwayDelegsPredFailure`
+* Renamed `DELPL` to `CERT`
+* Added `ConwayDELEGS` rule
+* Added `ConwayCERT` rule synonym
+* Added `ConwayDelegsPredFailure` rule
+* Added `ConwayDelegsEvent` rule
 
 ## 1.1.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -65,7 +65,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-core ^>=1.2,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley >=1.1,
+        cardano-ledger-shelley ^>=1.2,
         cardano-strict-containers,
         containers,
         data-default-class,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -38,6 +38,7 @@ library
     other-modules:
         Cardano.Ledger.Conway.Era
         Cardano.Ledger.Conway.UTxO
+        Cardano.Ledger.Conway.Rules.Delegs
         Cardano.Ledger.Conway.Rules.Enact
         Cardano.Ledger.Conway.Rules.Epoch
         Cardano.Ledger.Conway.Rules.Ledger

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -3,6 +3,8 @@
 
 module Cardano.Ledger.Conway.Era (
   ConwayEra,
+  ConwayCERT,
+  ConwayDELEGS,
   ConwayTALLY,
   ConwayNEWEPOCH,
   ConwayEPOCH,
@@ -76,6 +78,14 @@ data ConwayRATIFY era
 
 type instance EraRule "RATIFY" (ConwayEra c) = ConwayRATIFY (ConwayEra c)
 
+data ConwayDELEGS era
+
+type instance EraRule "DELEGS" (ConwayEra c) = ConwayDELEGS (ConwayEra c)
+
+type ConwayCERT era = API.ShelleyDELPL era
+
+type instance EraRule "CERT" (ConwayEra c) = ConwayCERT (ConwayEra c)
+
 -- Rules inherited from Babbage
 
 type instance EraRule "UTXO" (ConwayEra c) = BabbageUTXO (ConwayEra c)
@@ -89,10 +99,6 @@ type instance EraRule "BBODY" (ConwayEra c) = AlonzoBBODY (ConwayEra c)
 -- Rules inherited from Shelley
 
 type instance EraRule "DELEG" (ConwayEra c) = API.ShelleyDELEG (ConwayEra c)
-
-type instance EraRule "DELEGS" (ConwayEra c) = API.ShelleyDELEGS (ConwayEra c)
-
-type instance EraRule "DELPL" (ConwayEra c) = API.ShelleyDELPL (ConwayEra c)
 
 type instance EraRule "LEDGERS" (ConwayEra c) = API.ShelleyLEDGERS (ConwayEra c)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -1,4 +1,5 @@
 module Cardano.Ledger.Conway.Rules (
+  module Cardano.Ledger.Conway.Rules.Delegs,
   module Cardano.Ledger.Conway.Rules.Enact,
   module Cardano.Ledger.Conway.Rules.Epoch,
   module Cardano.Ledger.Conway.Rules.Ledger,
@@ -10,6 +11,7 @@ module Cardano.Ledger.Conway.Rules (
 )
 where
 
+import Cardano.Ledger.Conway.Rules.Delegs
 import Cardano.Ledger.Conway.Rules.Enact
 import Cardano.Ledger.Conway.Rules.Epoch
 import Cardano.Ledger.Conway.Rules.Ledger

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Delegs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Delegs.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Rules.Delegs (
+  ConwayDELEGS,
+  ConwayDelegsPredFailure (..),
+  ConwayDelegsEvent (..),
+) where
+
+import Cardano.Ledger.Address (mkRwdAcnt)
+import Cardano.Ledger.BaseTypes (Globals (..), ShelleyBase, mkCertIxPartial)
+import Cardano.Ledger.CertState (PState, rewards)
+import Cardano.Ledger.Conway.Era (ConwayDELEGS)
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.API (
+  CertState (..),
+  Coin,
+  DCert,
+  DState (..),
+  DelegEnv,
+  DelegsEnv (..),
+  DelplEnv (..),
+  KeyHash,
+  KeyRole (..),
+  Network,
+  PoolEnv,
+  Ptr (..),
+  RewardAcnt,
+  ShelleyDELPL,
+  Withdrawals (..),
+ )
+import Cardano.Ledger.Shelley.Core (ShelleyEraTxBody)
+import Cardano.Ledger.Shelley.Rules (ShelleyDelplEvent, ShelleyDelplPredFailure, drainedRewardAccounts, isDelegationRegistered, isSubmapOfUM)
+import qualified Cardano.Ledger.UMap as UM
+import Control.Arrow (ArrowChoice (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition.Extended (Embed (..), STS (..), TRC (..), TransitionRule, judgmentContext, liftSTS, trans, (?!), (?!:))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq (..))
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+
+data ConwayDelegsPredFailure era
+  = DelegateeNotRegisteredDELEG
+      !(KeyHash 'StakePool (EraCrypto era)) -- target pool which is not registered
+  | WithdrawalsNotInRewardsDELEGS
+      !(Map (RewardAcnt (EraCrypto era)) Coin) -- withdrawals that are missing or do not withdrawal the entire amount
+  | CertFailure (PredicateFailure (EraRule "CERT" era)) -- Subtransition Failures
+  deriving (Generic)
+
+deriving instance
+  Eq (PredicateFailure (EraRule "CERT" era)) =>
+  Eq (ConwayDelegsPredFailure era)
+deriving instance
+  Show (PredicateFailure (EraRule "CERT" era)) =>
+  Show (ConwayDelegsPredFailure era)
+
+newtype ConwayDelegsEvent era = CertEvent (Event (EraRule "CERT" era))
+
+instance
+  ( EraTx era
+  , ShelleyEraTxBody era
+  , State (EraRule "CERT" era) ~ CertState era
+  , Signal (EraRule "CERT" era) ~ DCert (EraCrypto era)
+  , Environment (EraRule "CERT" era) ~ DelplEnv era
+  , EraRule "DELEGS" era ~ ConwayDELEGS era
+  , Embed (EraRule "CERT" era) (ConwayDELEGS era)
+  ) =>
+  STS (ConwayDELEGS era)
+  where
+  type State (ConwayDELEGS era) = CertState era
+  type Signal (ConwayDELEGS era) = Seq (DCert (EraCrypto era))
+  type Environment (ConwayDELEGS era) = DelegsEnv era
+  type BaseM (ConwayDELEGS era) = ShelleyBase
+  type
+    PredicateFailure (ConwayDELEGS era) =
+      ConwayDelegsPredFailure era
+  type Event (ConwayDELEGS era) = ConwayDelegsEvent era
+
+  transitionRules = [conwayDelegsTransition @era]
+
+conwayDelegsTransition ::
+  forall era.
+  ( EraTx era
+  , ShelleyEraTxBody era
+  , State (EraRule "CERT" era) ~ CertState era
+  , Embed (EraRule "CERT" era) (ConwayDELEGS era)
+  , Environment (EraRule "CERT" era) ~ DelplEnv era
+  , Signal (EraRule "CERT" era) ~ DCert (EraCrypto era)
+  , EraRule "DELEGS" era ~ ConwayDELEGS era
+  ) =>
+  TransitionRule (ConwayDELEGS era)
+conwayDelegsTransition = do
+  TRC (env@(DelegsEnv slot txIx pp tx acnt), dpstate, certificates) <- judgmentContext
+  network <- liftSTS $ asks networkId
+
+  case certificates of
+    Empty -> zeroRewards dpstate tx network
+    gamma :|> c -> do
+      dpstate' <-
+        trans @(ConwayDELEGS era) $ TRC (env, dpstate, gamma)
+      left DelegateeNotRegisteredDELEG (isDelegationRegistered @era dpstate' c)
+        ?!: id
+      -- It is impossible to have 65535 number of certificates in a
+      -- transaction, therefore partial function is justified.
+      let ptr = Ptr slot txIx (mkCertIxPartial $ toInteger $ length gamma)
+      trans @(EraRule "CERT" era) $
+        TRC (DelplEnv slot ptr pp acnt, dpstate', c)
+
+zeroRewards ::
+  forall era.
+  ( EraTx era
+  , State (EraRule "DELEGS" era) ~ CertState era
+  , PredicateFailure (EraRule "DELEGS" era) ~ ConwayDelegsPredFailure era
+  ) =>
+  CertState era ->
+  Tx era ->
+  Network ->
+  TransitionRule (EraRule "DELEGS" era)
+zeroRewards dpstate tx network = do
+  let ds = certDState dpstate
+      wdrls = unWithdrawals (tx ^. bodyTxL . withdrawalsTxBodyL)
+      rewards' = rewards ds
+  isSubmapOfUM @era wdrls rewards' -- withdrawals_ ⊆ rewards
+    ?! WithdrawalsNotInRewardsDELEGS @era
+      ( Map.differenceWith
+          (\x y -> if x /= y then Just x else Nothing)
+          wdrls
+          (Map.mapKeys (mkRwdAcnt network) (UM.rewView (dsUnified ds)))
+      )
+  let unified' = rewards' UM.⨃ drainedRewardAccounts @era wdrls
+  pure $ dpstate {certDState = ds {dsUnified = unified'}}
+
+instance
+  ( Era era
+  , Embed (EraRule "POOL" era) (ShelleyDELPL era)
+  , Embed (EraRule "DELEG" era) (ShelleyDELPL era)
+  , State (EraRule "POOL" era) ~ PState era
+  , State (EraRule "DELEG" era) ~ DState era
+  , Environment (EraRule "POOL" era) ~ PoolEnv era
+  , Environment (EraRule "DELEG" era) ~ DelegEnv era
+  , Signal (EraRule "POOL" era) ~ DCert (EraCrypto era)
+  , Signal (EraRule "DELEG" era) ~ DCert (EraCrypto era)
+  , PredicateFailure (EraRule "CERT" era) ~ ShelleyDelplPredFailure era
+  , Event (EraRule "CERT" era) ~ ShelleyDelplEvent era
+  ) =>
+  Embed (ShelleyDELPL era) (ConwayDELEGS era)
+  where
+  wrapFailed = CertFailure
+  wrapEvent = CertEvent

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -32,12 +32,13 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Block (txid)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Era (ConwayLEDGER, ConwayTALLY)
+import Cardano.Ledger.Conway.Era (ConwayDELEGS, ConwayLEDGER, ConwayTALLY)
 import Cardano.Ledger.Conway.Governance (
   ConwayGovernance (..),
   ConwayTallyState,
   GovernanceProcedure (..),
  )
+import Cardano.Ledger.Conway.Rules.Delegs (ConwayDelegsEvent, ConwayDelegsPredFailure)
 import Cardano.Ledger.Conway.Rules.Tally (ConwayTallyPredFailure, TallyEnv (..))
 import Cardano.Ledger.Conway.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Crypto (Crypto (..))
@@ -53,10 +54,6 @@ import Cardano.Ledger.Shelley.Rules (
   DelegsEnv (..),
   DelplEnv,
   LedgerEnv (..),
-  ShelleyDELEGS,
-  ShelleyDelegsEvent,
-  ShelleyDelegsPredFailure,
-  ShelleyDelplPredFailure,
   ShelleyLEDGERS,
   ShelleyLedgersEvent (..),
   ShelleyLedgersPredFailure (..),
@@ -300,15 +297,16 @@ instance
 instance
   ( EraTx era
   , ShelleyEraTxBody era
-  , Embed (EraRule "DELPL" era) (ShelleyDELEGS era)
-  , State (EraRule "DELPL" era) ~ CertState era
-  , Environment (EraRule "DELPL" era) ~ DelplEnv era
-  , PredicateFailure (EraRule "DELPL" era) ~ ShelleyDelplPredFailure era
-  , Signal (EraRule "DELPL" era) ~ DCert (EraCrypto era)
-  , PredicateFailure (EraRule "DELEGS" era) ~ ShelleyDelegsPredFailure era
-  , Event (EraRule "DELEGS" era) ~ ShelleyDelegsEvent era
+  , Embed (EraRule "CERT" era) (ConwayDELEGS era)
+  , State (EraRule "CERT" era) ~ CertState era
+  , Environment (EraRule "CERT" era) ~ DelplEnv era
+  , Signal (EraRule "CERT" era) ~ DCert (EraCrypto era)
+  , PredicateFailure (EraRule "DELEGS" era) ~ ConwayDelegsPredFailure era
+  , Event (EraRule "DELEGS" era) ~ ConwayDelegsEvent era
+  , Embed (EraRule "CERT" era) (ConwayDELEGS era)
+  , EraRule "DELEGS" era ~ ConwayDELEGS era
   ) =>
-  Embed (ShelleyDELEGS era) (ConwayLEDGER era)
+  Embed (ConwayDELEGS era) (ConwayLEDGER era)
   where
   wrapFailed = ConwayDelegsFailure
   wrapEvent = DelegsEvent

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Delegation.Certificates (ConwayDCert (..))
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import Cardano.Ledger.Conway.Rules (ConwayLEDGER)
+import Cardano.Ledger.Conway.Rules (ConwayDELEGS, ConwayDelegsPredFailure (..), ConwayLEDGER)
 import Cardano.Ledger.Conway.Translation ()
 import Cardano.Ledger.Conway.Tx (AlonzoTx (..))
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
@@ -49,10 +49,8 @@ import Cardano.Ledger.Shelley.API (
   PoolCert (..),
   ProposedPPUpdates (..),
   RewardAcnt (..),
-  ShelleyDELEGS,
   TxId (..),
  )
-import Cardano.Ledger.Shelley.Rules (ShelleyDelegsPredFailure (..))
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -83,7 +81,7 @@ ledgerExamplesConway =
     , SLE.sleApplyTxError =
         ApplyTxError $
           pure $
-            wrapFailed @(ShelleyDELEGS Conway) @(ConwayLEDGER Conway) $
+            wrapFailed @(ConwayDELEGS Conway) @(ConwayLEDGER Conway) $
               DelegateeNotRegisteredDELEG @Conway (SLE.mkKeyHash 1)
     , SLE.sleRewardsCredentials =
         Set.fromList

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Rename `obligationDPState` to `obligationCertState`
 * Rename `keyCertsRefundsDPState` to `keyCertsRefundsCertState`
 * Rename `totalCertsDepositsDPState` to `totalCertsDepositsCertState`
+* Added new functions to `DELEGS` rule
+  * `zeroRewards`
+  * `isDelegationRegistered`
+  * `drainedRewardAccounts`
+  * `isSubmapOfUM`
 
 ## 1.1.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -9,10 +9,9 @@
 * Rename `keyCertsRefundsDPState` to `keyCertsRefundsCertState`
 * Rename `totalCertsDepositsDPState` to `totalCertsDepositsCertState`
 * Added new functions to `DELEGS` rule
-  * `zeroRewards`
-  * `isDelegationRegistered`
-  * `drainedRewardAccounts`
-  * `isSubmapOfUM`
+  * `drainWithdrawals`
+  * `validateZeroRewards`
+  * `validateDelegationRegistered`
 
 ## 1.1.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -259,11 +259,7 @@ isSubmapOfUM ::
 isSubmapOfUM ws (RewardDeposits (UMap tripmap _)) = Map.isSubmapOfBy f withdrawalMap tripmap
   where
     withdrawalMap :: Map.Map (Credential 'Staking (EraCrypto era)) Coin
-    withdrawalMap =
-      Map.fromList
-        [ (cred, coin)
-        | (RewardAcnt _ cred, coin) <- Map.toList ws
-        ]
+    withdrawalMap = Map.mapKeys (\(RewardAcnt _ cred) -> cred) ws
     f :: Coin -> Trip (EraCrypto era) -> Bool
     f coin1 (Triple (SJust (UM.RDPair coin2 _)) _ _) = coin1 == fromCompact coin2
     f _ _ = False

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -39,7 +39,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway >=1.1,
+        cardano-ledger-conway >=1.2,
         cardano-ledger-core ^>=1.2,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley >=1.1,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Conway.Governance (
   VotingProcedure (..),
  )
 import Cardano.Ledger.Conway.Rules (
+  ConwayDelegsPredFailure (..),
   ConwayLedgerPredFailure (..),
   ConwayTallyPredFailure,
   EnactState (..),
@@ -286,3 +287,17 @@ instance
           , ("Ratify", prettyA cgRatify)
           , ("VoterRoles", prettyA cgVoterRoles)
           ]
+
+instance
+  PrettyA (PredicateFailure (EraRule "CERT" era)) =>
+  PrettyA (ConwayDelegsPredFailure era)
+  where
+  prettyA (DelegateeNotRegisteredDELEG x) =
+    ppRecord
+      "DelegateeNotRegisteredDELEG"
+      [("KeyHash", prettyA x)]
+  prettyA (WithdrawalsNotInRewardsDELEGS x) =
+    ppRecord
+      "WithdrawalsNotInRewardsDELEGS"
+      [("Missing Withdrawals", prettyA x)]
+  prettyA (CertFailure x) = prettyA x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Block (Block (..), txid)
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..))
+import Cardano.Ledger.Conway.Rules (ConwayDelegsPredFailure (..), ConwayLedgerPredFailure (..))
 
 import Cardano.Ledger.Credential (
   Credential (..),
@@ -672,7 +672,7 @@ makeTooBig proof@(Babbage _) =
   ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . DelegsFailure . DelplFailure . PoolFailure $
     PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys proof) (hashsize @Mock + 1)
 makeTooBig proof@(Conway _) =
-  ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . ConwayDelegsFailure . DelplFailure . PoolFailure $
+  ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . ConwayDelegsFailure . CertFailure . PoolFailure $
     PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys proof) (hashsize @Mock + 1)
 makeTooBig proof = error ("makeTooBig does not work in era " ++ show proof)
 


### PR DESCRIPTION
# Description

This PR renames the DELPL rule to CERT starting from Conway. The Shelley DELEG transition function was split into multiple functions and some of the parts that didn't depend on DELPL were reused in the Conway DELEG rule.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
