### PR TITLE
Haddocks on Github Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,40 @@
+name: Github Pages
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  gh-pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+            substituters = https://cache.iog.io https://cache.nixos.org/ https://cache.zw3rk.com
+      - name: Build projects and haddocks
+        run: nix-shell --command "cabal update && cabal build --enable-documentation all && ./scripts/haddocks.sh"
+      - name: Add files
+        run: |
+              git config --local user.name ${{ github.actor }}
+              git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+              cp -r ./haddocks/* ./
+              rm -rf haddocks
+              git add -A --force
+              git commit -m "Updated"
+
+      - name: Push to gh-pages
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: gh-pages
+            force: true
+            directory: .
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ In addition, there is a formalization of the Ledger Specification in Isabelle/HO
 
 Some user documentation is published on [Read the Docs](https://cardano-ledger.readthedocs.io/en/latest)
 
+Haddock code documentation of the latest master branch is available [here](https://input-output-hk.github.io/cardano-ledger).
+
 # Repository structure
 
 The directory structure of this repository is as follows:

--- a/cabal.project
+++ b/cabal.project
@@ -68,6 +68,9 @@ packages:
 program-options
   ghc-options: -Werror
 
+package plutus-preprocessor
+  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+
 package cardano-ledger-core
   flags: +asserts
 

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -87,6 +87,8 @@ interface_options () {
   done
 }
 
+./scripts/mkprolog.sh ./haddocks ./scripts/prolog
+
 # Generate top level index using interface files
 haddock \
   -o ${OUTPUT_DIR} \
@@ -95,6 +97,7 @@ haddock \
   --gen-index \
   --gen-contents \
   --quickjump \
+  --prolog ./scripts/prolog \
   $(interface_options)
 
 # Assemble a toplevel `doc-index.json` from package level ones.

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Build haddock documentation and an index for all projects in
+# `cardano-ledger` repository.
+#
+# usage:
+# ./haddocks.sh directory [true|false]
+#
+# $1 - where to put the generated pages, this directory contents will be wiped
+#      out (so don't pass `/` or `./` - the latter will delete your 'dist-newstyle')
+#      (the default is './haddocks')
+# $2 - whether to re-build haddocks with `cabal haddock` command or a component name
+#      (the default is true)
+#
+
+set -euo pipefail
+
+OUTPUT_DIR=${1:-"./haddocks"}
+REGENERATE=${2:-"true"}
+
+BUILD_DIR="dist-newstyle"
+GHC_VERSION=$(ghc --numeric-version)
+OS_ARCH="$(cat dist-newstyle/cache/plan.json | jq -r '.arch + "-" + .os' | head -n 1 | xargs)"
+
+
+# Generate  `doc-index.json` and `doc-index.html` per package, to assemble them later at the top level.
+HADDOCK_OPTS=(
+    --builddir "${BUILD_DIR}"
+    --haddock-all
+    --haddock-internal
+    --haddock-html
+    --haddock-quickjump
+    --haddock-hyperlink-source
+    --haddock-option "--show-all"
+    --haddock-option "--use-unicode"
+    --haddock-option="--base-url=.."
+  )
+
+# build documentation of all modules
+if [ ${REGENERATE} == "true" ]; then
+  cabal haddock "${HADDOCK_OPTS[@]}" all
+elif [ ${REGENERATE} != "false" ]; then
+  cabal haddock "${HADDOCK_OPTS[@]}" ${REGENERATE}
+fi
+
+if [[ !( -d ${OUTPUT_DIR} ) ]]; then
+  mkdir -p ${OUTPUT_DIR}
+fi
+
+# make all files user writable
+chmod -R u+w "${OUTPUT_DIR}"
+
+# copy the new docs
+for dir in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}"); do
+  package=$(echo "${dir}" | sed 's/-[0-9]\+\(\.[0-9]\+\)*//')
+  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}" ]; then
+    cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}" ${OUTPUT_DIR}
+  else continue;
+  fi
+  # copy test packages documentation when it exists
+  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t" ]; then
+      for test_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t"); do
+          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/doc/html/${package}/${test_package}" ]; then
+              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/doc/html/${package}/${test_package}" "${OUTPUT_DIR}/${package}:${test_package}"
+              cp -n "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${test_package}"
+          fi
+      done
+  fi
+  # copy lib packages documentation when it exists
+  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l" ]; then
+      for lib_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l"); do
+          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${lib_package}/doc/html/${package}" ]; then
+              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${lib_package}/doc/html/${package}" "${OUTPUT_DIR}/${package}:${lib_package}"
+              cp -n "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${lib_package}"
+          fi
+      done
+  fi
+done
+
+# build read-interface arguments for haddock
+interface_options () {
+    for package in $(ls "${OUTPUT_DIR}"); do
+        if [[ -d "${OUTPUT_DIR}/${package}" ]]; then
+            haddock_file=$(ls -1 ${OUTPUT_DIR}/${package}/*.haddock | head -1)
+            echo "--read-interface=${package},${haddock_file}"
+        fi
+  done
+}
+
+# Generate top level index using interface files
+haddock \
+  -o ${OUTPUT_DIR} \
+  --title "cardano-ledger" \
+  --package-name "Cardano Ledger" \
+  --gen-index \
+  --gen-contents \
+  --quickjump \
+  $(interface_options)
+
+# Assemble a toplevel `doc-index.json` from package level ones.
+echo "[]" > "${OUTPUT_DIR}/doc-index.json"
+for file in $(ls $OUTPUT_DIR/*/doc-index.json); do
+  project=$(basename $(dirname $file));
+  jq -s \
+    ".[0] + [.[1][] | (. + {link: (\"${project}/\" + .link)}) ]" \
+    "${OUTPUT_DIR}/doc-index.json" \
+    ${file} \
+    > /tmp/doc-index.json
+  mv /tmp/doc-index.json "${OUTPUT_DIR}/doc-index.json"
+done

--- a/scripts/mkprolog.sh
+++ b/scripts/mkprolog.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+HADDOCKS_DIR=${1:-"./haddocks"}
+PROLOG_FILE=${2:-"./scripts/prolog"}
+
+> ${PROLOG_FILE}
+
+cat > ${PROLOG_FILE} << EOF
+= Cardano Ledger Repository Hackage Documentation
+
+[skip to module list](#module-list)
+
+This site contains Haskell documentation of:
+
+EOF
+
+for dir in $(ls ${HADDOCKS_DIR}); do
+  if [[ -d ${HADDOCKS_DIR}/${dir} ]]; then
+    link=$(echo "${dir}" | sed "s/:/%3A/g")
+    echo "* __[${dir}](${link}/index.html)__" >> ${PROLOG_FILE}
+  fi
+done


### PR DESCRIPTION
# Description

This PR introduces a new github workflow, triggered on master, which: 
- builds haddock for every package, aggregating them as a site (listed on the landing page)
- deploys this site to github pages, so the haddocks will be accessible here, after the PR is merged: https://input-output-hk.github.io/cardano-ledger  (replacing the current content, which seems obsolete anyway).  

The links between the packages are working well (for example: when inspecting rules, clicking on anything from small-steps or cardano-core will take you there). 
I'm unsatisfied for not being able to link to hackage the packages for which hackage documentation exists (like base).  I was able to do this only at the cost of the links between packages not working, but I thought it's more important to have the latter working. 

This is a copy of the site with this PR on my own fork, to demonstrate how the pages will look like: https://bienpulenta.github.io/cardano-ledger/

 
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
