### PR TITLE
Reduce gh pages size

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,10 +25,9 @@ jobs:
         run: |
               git config --local user.name ${{ github.actor }}
               git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-              cp -r ./haddocks/* ./
+              git add -A --force ./haddocks
+              git mv ./haddocks/* .
               rm -rf haddocks
-              git add -A --force
-              git commit -m "Updated"
 
       - name: Push to gh-pages
         uses: ad-m/github-push-action@v0.6.0


### PR DESCRIPTION
# Description

Only add the haddocks to the commit on gh-pages branch, rather than force-adding everything. The latter creates huge git objects, which can causes failures and delays when fetching etc. 


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
