### PR TITLE
reinstate our two tickf optimizations

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -168,9 +168,9 @@ newEpochTransition = do
       es''' <- trans @(EraRule "EPOCH" era) $ TRC ((), es'', eNo)
       let adaPots = totalAdaPotsES es'''
       tellEvent $ TotalAdaPotsEvent adaPots
-      -- let pd' = ssStakeMarkPoolDistr (esSnapshots es)
+      let pd' = ssStakeMarkPoolDistr (esSnapshots es)
       -- The spec sets pd' with:
-      let pd' = calculatePoolDistr (ssStakeSet $ esSnapshots es''')
+      -- pd' = calculatePoolDistr (ssStakeSet $ esSnapshots es'''),
       --
       -- This is equivalent to:
       -- pd' = ssStakeMarkPoolDistr (esSnapshots es)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -258,7 +258,7 @@ bheadTransition = do
   -- so that it can remain a thunk when the consensus
   -- layer computes the ledger view across the epoch boundary.
   let !_ = ssStakeMark . esSnapshots . nesEs $ nes'
-  -- !_ = ssStakeMarkPoolDistr . esSnapshots . nesEs $ nes'
+      !_ = ssStakeMarkPoolDistr . esSnapshots . nesEs $ nes'
 
   ru'' <-
     trans @(EraRule "RUPD" era) $

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs
@@ -49,10 +49,10 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyEPOCH,
   ShelleyMIR,
   ShelleyNEWEPOCH,
-  -- ShelleyTICKF,
+  ShelleyTICKF,
   adoptGenesisDelegs,
   updateRewards,
-  -- validatingTickTransitionFORECAST,
+  validatingTickTransitionFORECAST,
  )
 import Cardano.Ledger.Slot (EpochNo, SlotNo (..))
 import qualified Cardano.Ledger.UMap as UM
@@ -175,12 +175,12 @@ adoptGenesisDelegsR ::
   EpochState era
 adoptGenesisDelegsR slot nes = adoptGenesisDelegs (nesEs nes) slot
 
--- tickfR2 ::
---   Globals ->
---   Cardano.Slotting.Slot.SlotNo ->
---   NewEpochState CurrentEra ->
---   NewEpochState CurrentEra
--- tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransitionFORECAST @ShelleyTICKF nes slot)
+tickfR2 ::
+  Globals ->
+  Cardano.Slotting.Slot.SlotNo ->
+  NewEpochState CurrentEra ->
+  NewEpochState CurrentEra
+tickfR2 globals slot nes = liftRule globals (TRC ((), nes, slot)) (validatingTickTransitionFORECAST @ShelleyTICKF nes slot)
 
 mirR :: Globals -> EpochState CurrentEra -> EpochState CurrentEra
 mirR globals es' = liftApplySTS globals (applySTS @(ShelleyMIR CurrentEra) (TRC ((), es', ())))
@@ -200,8 +200,8 @@ tickfRuleBench =
       let pv = esPp (nesEs nes) ^. ppProtocolVersionL
        in bgroup
             "Tickf Benchmarks"
-            [ -- bench "validatingTickTransitionfunction" $ whnf (tickfR2 globals (SlotNo 156953303)) nes
-              bgroup
+            [ bench "validatingTickTransitionfunction" $ whnf (tickfR2 globals (SlotNo 156953303)) nes
+            , bgroup
                 "Tick subparts"
                 [ bench "adoptGenesisDelegs" $ whnf (adoptGenesisDelegsR (SlotNo 156953303)) nes
                 , bench "newEpoch" $ whnf (newEpochR globals (nesEL nes + 1)) nes


### PR DESCRIPTION
# Description

While preparing for a new release, we had to remove our two `TICKF` optimizations: https://github.com/input-output-hk/cardano-ledger/pull/3375

The problem was that a local network test in cardano-node was failing, namely `cardano-testnet`.

The problem, however, was not in the optimizations, but rather in the test setup:

https://github.com/input-output-hk/ouroboros-network/blob/8685fc4b08cd5f11735768d60da921628602b630/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/TPraos.hs#L336-L344

The problem is that the inserted `mark` snapshot is now not enough to quick-start the network, the pool distribution also needs to quick-started:

```
SL.ssStakeMarkPoolDistr = SL.calculatePoolDistr initSnapShot
```
 
I verified this by running `cardano-testnet` with a modified ledger and consensus as described above.

We can now restore the optimizations in ledger, but we still need to either fix `registerGenesisStaking` as described above, or do something safer to prevent future mistakes like this.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
