### PR TITLE
Backport performance regression fix

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.1.0.0
+version:            1.1.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -186,10 +186,11 @@ instance Crypto c => EraTx (AlonzoEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(AlonzoEra c) script tx
+  validateScript (Phase1Script script) = validateTimelock @(AlonzoEra c) script
   {-# INLINE validateScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
+  {-# INLINE getMinFeeTx #-}
 
 class (EraTx era, AlonzoEraTxBody era, AlonzoEraTxWits era) => AlonzoEraTx era where
   isValidTxL :: Lens' (Tx era) IsValid
@@ -388,6 +389,7 @@ instance (Crypto c) => DecCBOR (ScriptPurpose c) where
       dec 2 = SumD Rewarding <! From
       dec 3 = SumD Certifying <! From
       dec n = Invalid n
+  {-# INLINE decCBOR #-}
 
 -- =======================================
 
@@ -557,6 +559,7 @@ instance
           ( sequence . maybeToStrictMaybe
               <$> decodeNullMaybe decCBOR
           )
+  {-# INLINE decCBOR #-}
 
 -- =======================================================================
 -- Some generic functions that compute over Tx. We try to be abstract over

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -273,6 +273,7 @@ nullDats (TxDats' d) = Map.null d
 
 instance (Era era) => DecCBOR (Annotator (TxDatsRaw era)) where
   decCBOR = decode $ fmap (TxDatsRaw . keyBy hashData) <$> listDecodeA From
+  {-# INLINE decCBOR #-}
 
 -- | Note that 'TxDats' are based on 'MemoBytes' since we must preserve
 -- the original bytes for the 'Cardano.Ledger.Alonzo.Tx.ScriptIntegrity'.
@@ -501,12 +502,15 @@ instance Era era => DecCBOR (Annotator (RedeemersRaw era)) where
         (rdmrPtr, dat, ex) <- decodeElement
         let f x y z = (x, (y, z))
         pure $ f rdmrPtr <$> dat <*> pure ex
+      {-# INLINE decodeAnnElement #-}
       decodeElement :: forall s. Decoder s (RdmrPtr, Annotator (Data era), ExUnits)
       decodeElement = do
         decodeRecordNamed
           "Redeemer"
           (\(rdmrPtr, _, _) -> fromIntegral (listLen rdmrPtr) + 2)
           $ (,,) <$> decCBORGroup <*> decCBOR <*> decCBOR
+      {-# INLINE decodeElement #-}
+  {-# INLINE decCBOR #-}
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (Redeemers era)
@@ -562,9 +566,11 @@ instance
           addScripts
           (fmap (PlutusScript PlutusV2) <$> From)
       txWitnessField n = field (\_ t -> t) (Invalid n)
+      {-# INLINE txWitnessField #-}
 
       addScripts :: [AlonzoScript era] -> AlonzoTxWitsRaw era -> AlonzoTxWitsRaw era
       addScripts x wits = wits {atwrScriptTxWits = getKeys ([] :: [era]) x <> atwrScriptTxWits wits}
+      {-# INLINE addScripts #-}
       getKeys ::
         forall proxy e.
         EraScript e =>
@@ -572,6 +578,8 @@ instance
         [Script e] ->
         Map (ScriptHash (EraCrypto e)) (Script e)
       getKeys _ = keyBy (hashScript @e)
+      {-# INLINE getKeys #-}
+  {-# INLINE decCBOR #-}
 
 deriving via
   (Mem AlonzoTxWitsRaw era)

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.1.0.0
+version:            1.1.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -237,7 +237,8 @@ feeBabbageTxBodyL =
 auxDataHashBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe (AuxiliaryDataHash (EraCrypto era)))
 auxDataHashBabbageTxBodyL =
-  lensMemoRawType btbrAuxDataHash $ \txBodyRaw auxDataHash -> txBodyRaw {btbrAuxDataHash = auxDataHash}
+  lensMemoRawType btbrAuxDataHash $
+    \txBodyRaw auxDataHash -> txBodyRaw {btbrAuxDataHash = auxDataHash}
 {-# INLINEABLE auxDataHashBabbageTxBodyL #-}
 
 allInputsBabbageTxBodyF ::
@@ -253,9 +254,12 @@ mintedBabbageTxBodyF :: SimpleGetter (BabbageTxBody era) (Set (ScriptHash (EraCr
 mintedBabbageTxBodyF = to (Set.map policyID . policies . btbrMint . getMemoRawType)
 {-# INLINEABLE mintedBabbageTxBodyF #-}
 
-withdrawalsBabbbageTxBodyL :: BabbageEraTxBody era => Lens' (BabbageTxBody era) (Withdrawals (EraCrypto era))
+withdrawalsBabbbageTxBodyL ::
+  BabbageEraTxBody era =>
+  Lens' (BabbageTxBody era) (Withdrawals (EraCrypto era))
 withdrawalsBabbbageTxBodyL =
-  lensMemoRawType btbrWithdrawals $ \txBodyRaw withdrawals -> txBodyRaw {btbrWithdrawals = withdrawals}
+  lensMemoRawType btbrWithdrawals $
+    \txBodyRaw withdrawals -> txBodyRaw {btbrWithdrawals = withdrawals}
 {-# INLINEABLE withdrawalsBabbbageTxBodyL #-}
 
 updateBabbageTxBodyL ::
@@ -727,12 +731,14 @@ instance
       bodyFields 14 = field (\x tx -> tx {btbrReqSignerHashes = x}) From
       bodyFields 15 = ofield (\x tx -> tx {btbrTxNetworkId = x}) From
       bodyFields n = field (\_ t -> t) (Invalid n)
+      {-# INLINE bodyFields #-}
       requiredFields :: [(Word, String)]
       requiredFields =
         [ (0, "inputs")
         , (1, "outputs")
         , (2, "fee")
         ]
+  {-# INLINE decCBOR #-}
 
 basicBabbageTxBodyRaw :: BabbageTxBodyRaw era
 basicBabbageTxBodyRaw =

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.1.1.0
+version:            1.1.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -236,7 +236,7 @@ updateRewards ::
 updateRewards es e ru'@(RewardUpdate dt dr rs_ df _) = do
   let totRs = sumRewards (esPrevPp es ^. ppProtocolVersionL) rs_
   Val.isZero (dt <> (dr <> toDeltaCoin totRs <> df)) ?! CorruptRewardUpdate ru'
-  let !(!es', filtered) = applyRUpdFiltered ru' es
+  let (!es', filtered) = applyRUpdFiltered ru' es
   tellEvent $ RestrainedRewards e (frShelleyIgnored filtered) (frUnregistered filtered)
   -- This event (which is only generated once per epoch) must be generated even if the
   -- map is empty (db-sync depends on it).

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -27,10 +27,11 @@ import Cardano.Ledger.EpochBoundary (
   SnapShot (ssDelegations, ssStake),
   SnapShots (..),
   Stake (unStake),
-  calculatePoolDistr,
+  -- calculatePoolDistr,
   emptySnapShots,
  )
 import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
+import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import Cardano.Ledger.Shelley.Era (ShelleySNAP)
 import Cardano.Ledger.Shelley.LedgerState (
   DPState (..),
@@ -109,7 +110,7 @@ snapTransition = do
   pure $
     SnapShots
       { ssStakeMark = istakeSnap
-      , ssStakeMarkPoolDistr = calculatePoolDistr istakeSnap
+      , ssStakeMarkPoolDistr = PoolDistr mempty -- calculatePoolDistr istakeSnap
       , -- ssStakeMarkPoolDistr exists for performance reasons, see ADR-7
         ssStakeSet = ssStakeMark s
       , ssStakeGo = ssStakeSet s

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -216,7 +216,7 @@ registerGenesisStaking
           , esSnapshots =
               (esSnapshots oldEpochState)
                 { ssStakeMark = initSnapShot
-                , ssStakeMarkPoolDistr = newPoolDistr
+                -- , ssStakeMarkPoolDistr = newPoolDistr
                 }
           }
       newLedgerState =

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -61,7 +61,7 @@ import Cardano.Ledger.Credential (
   Credential (..),
   Ptr,
  )
-import Cardano.Ledger.EpochBoundary (SnapShot, SnapShots (..), calculatePoolDistr)
+import Cardano.Ledger.EpochBoundary (SnapShot, SnapShots (..))
 import Cardano.Ledger.Keys (
   GenDelegPair,
   GenDelegs (..),
@@ -612,7 +612,7 @@ newSnapshot snap fee cs = cs {chainNes = nes'}
     snaps =
       SnapShots
         { ssStakeMark = snap
-        , ssStakeMarkPoolDistr = calculatePoolDistr snap
+        , ssStakeMarkPoolDistr = PoolDistr mempty
         , ssStakeSet = ssMark
         , ssStakeGo = ssSet
         , ssFee = fee

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.1.0.0
+version:       1.1.0.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Crypto.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Crypto.hs
@@ -43,27 +43,35 @@ import Cardano.Ledger.Binary.Encoding.Encoder (Encoding, fromPlainEncoding)
 
 encodeVerKeyDSIGN :: C.DSIGNAlgorithm v => C.VerKeyDSIGN v -> Encoding
 encodeVerKeyDSIGN = fromPlainEncoding . C.encodeVerKeyDSIGN
+{-# INLINE encodeVerKeyDSIGN #-}
 
 decodeVerKeyDSIGN :: C.DSIGNAlgorithm v => Decoder s (C.VerKeyDSIGN v)
 decodeVerKeyDSIGN = fromPlainDecoder C.decodeVerKeyDSIGN
+{-# INLINE decodeVerKeyDSIGN #-}
 
 encodeSignKeyDSIGN :: C.DSIGNAlgorithm v => C.SignKeyDSIGN v -> Encoding
 encodeSignKeyDSIGN = fromPlainEncoding . C.encodeSignKeyDSIGN
+{-# INLINE encodeSignKeyDSIGN #-}
 
 decodeSignKeyDSIGN :: C.DSIGNAlgorithm v => Decoder s (C.SignKeyDSIGN v)
 decodeSignKeyDSIGN = fromPlainDecoder C.decodeSignKeyDSIGN
+{-# INLINE decodeSignKeyDSIGN #-}
 
 encodeSigDSIGN :: C.DSIGNAlgorithm v => C.SigDSIGN v -> Encoding
 encodeSigDSIGN = fromPlainEncoding . C.encodeSigDSIGN
+{-# INLINE encodeSigDSIGN #-}
 
 decodeSigDSIGN :: C.DSIGNAlgorithm v => Decoder s (C.SigDSIGN v)
 decodeSigDSIGN = fromPlainDecoder C.decodeSigDSIGN
+{-# INLINE decodeSigDSIGN #-}
 
 encodeSignedDSIGN :: C.DSIGNAlgorithm v => C.SignedDSIGN v a -> Encoding
 encodeSignedDSIGN = fromPlainEncoding . C.encodeSignedDSIGN
+{-# INLINE encodeSignedDSIGN #-}
 
 decodeSignedDSIGN :: C.DSIGNAlgorithm v => Decoder s (C.SignedDSIGN v a)
 decodeSignedDSIGN = fromPlainDecoder C.decodeSignedDSIGN
+{-# INLINE decodeSignedDSIGN #-}
 
 --------------------------------------------------------------------------------
 -- KES
@@ -71,27 +79,35 @@ decodeSignedDSIGN = fromPlainDecoder C.decodeSignedDSIGN
 
 encodeVerKeyKES :: C.KESAlgorithm v => C.VerKeyKES v -> Encoding
 encodeVerKeyKES = fromPlainEncoding . C.encodeVerKeyKES
+{-# INLINE encodeVerKeyKES #-}
 
 decodeVerKeyKES :: C.KESAlgorithm v => Decoder s (C.VerKeyKES v)
 decodeVerKeyKES = fromPlainDecoder C.decodeVerKeyKES
+{-# INLINE decodeVerKeyKES #-}
 
 encodeSignKeyKES :: C.KESAlgorithm v => C.SignKeyKES v -> Encoding
 encodeSignKeyKES = fromPlainEncoding . C.encodeSignKeyKES
+{-# INLINE encodeSignKeyKES #-}
 
 decodeSignKeyKES :: C.KESAlgorithm v => Decoder s (C.SignKeyKES v)
 decodeSignKeyKES = fromPlainDecoder C.decodeSignKeyKES
+{-# INLINE decodeSignKeyKES #-}
 
 encodeSigKES :: C.KESAlgorithm v => C.SigKES v -> Encoding
 encodeSigKES = fromPlainEncoding . C.encodeSigKES
+{-# INLINE encodeSigKES #-}
 
 decodeSigKES :: C.KESAlgorithm v => Decoder s (C.SigKES v)
 decodeSigKES = fromPlainDecoder C.decodeSigKES
+{-# INLINE decodeSigKES #-}
 
 encodeSignedKES :: C.KESAlgorithm v => C.SignedKES v a -> Encoding
 encodeSignedKES = fromPlainEncoding . C.encodeSignedKES
+{-# INLINE encodeSignedKES #-}
 
 decodeSignedKES :: C.KESAlgorithm v => Decoder s (C.SignedKES v a)
 decodeSignedKES = fromPlainDecoder C.decodeSignedKES
+{-# INLINE decodeSignedKES #-}
 
 --------------------------------------------------------------------------------
 -- VRF
@@ -99,18 +115,24 @@ decodeSignedKES = fromPlainDecoder C.decodeSignedKES
 
 encodeVerKeyVRF :: C.VRFAlgorithm v => C.VerKeyVRF v -> Encoding
 encodeVerKeyVRF = fromPlainEncoding . C.encodeVerKeyVRF
+{-# INLINE encodeVerKeyVRF #-}
 
 decodeVerKeyVRF :: C.VRFAlgorithm v => Decoder s (C.VerKeyVRF v)
 decodeVerKeyVRF = fromPlainDecoder C.decodeVerKeyVRF
+{-# INLINE decodeVerKeyVRF #-}
 
 encodeSignKeyVRF :: C.VRFAlgorithm v => C.SignKeyVRF v -> Encoding
 encodeSignKeyVRF = fromPlainEncoding . C.encodeSignKeyVRF
+{-# INLINE encodeSignKeyVRF #-}
 
 decodeSignKeyVRF :: C.VRFAlgorithm v => Decoder s (C.SignKeyVRF v)
 decodeSignKeyVRF = fromPlainDecoder C.decodeSignKeyVRF
+{-# INLINE decodeSignKeyVRF #-}
 
 encodeCertVRF :: C.VRFAlgorithm v => C.CertVRF v -> Encoding
 encodeCertVRF = fromPlainEncoding . C.encodeCertVRF
+{-# INLINE encodeCertVRF #-}
 
 decodeCertVRF :: C.VRFAlgorithm v => Decoder s (C.CertVRF v)
 decodeCertVRF = fromPlainDecoder C.decodeCertVRF
+{-# INLINE decodeCertVRF #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
@@ -137,6 +137,7 @@ invalidField n = field (flip $ const @t @Void) (Invalid n)
 -- A special case of 'field'
 fieldA :: (Applicative ann) => (x -> t -> t) -> Decode ('Closed d) x -> Field (ann t)
 fieldA update dec = Field (liftA2 update) (pure <$> decode dec)
+{-# INLINE fieldA #-}
 
 -- | Sparse decode something with a (DecCBOR (Annotator t)) instance
 fieldAA ::
@@ -145,6 +146,7 @@ fieldAA ::
   Decode ('Closed d) (ann x) ->
   Field (ann t)
 fieldAA update dec = Field (liftA2 update) (decode dec)
+{-# INLINE fieldAA #-}
 
 -- ==================================================================
 -- Decode
@@ -374,14 +376,17 @@ infixl 4 <?
 -- | Infix form of @ApplyD@ with the same infixity and precedence as @($)@.
 (<!) :: Decode w1 (a -> t) -> Decode ('Closed w) a -> Decode w1 t
 x <! y = ApplyD x y
+{-# INLINE (<!) #-}
 
 -- | Infix form of @ApplyAnn@ with the same infixity and precedence as @($)@.
 (<*!) :: Decode w1 (Annotator (a -> t)) -> Decode ('Closed d) (Annotator a) -> Decode w1 (Annotator t)
 x <*! y = ApplyAnn x y
+{-# INLINE (<*!) #-}
 
 -- | Infix form of @ApplyErr@ with the same infixity and precedence as @($)@.
 (<?) :: Decode w1 (a -> Either String t) -> Decode ('Closed d) a -> Decode w1 t
 f <? y = ApplyErr f y
+{-# INLINE (<?) #-}
 
 hsize :: Decode w t -> Int
 hsize (Summands _ _) = 1
@@ -399,12 +404,15 @@ hsize (TagD _ _) = 1
 hsize (Ann x) = hsize x
 hsize (ApplyAnn f x) = hsize f + hsize x
 hsize (ApplyErr f x) = hsize f + hsize x
+{-# INLINE hsize #-}
 
 decode :: Decode w t -> Decoder s t
 decode x = fmap snd (decodE x)
+{-# INLINE decode #-}
 
 decodE :: Decode w t -> Decoder s (Int, t)
 decodE x = decodeCount x 0
+{-# INLINE decodE #-}
 
 decodeCount :: forall (w :: Wrapped) s t. Decode w t -> Int -> Decoder s (Int, t)
 decodeCount (Summands nm f) n = (n + 1,) <$> decodeRecordSum nm (decodE . f)
@@ -436,6 +444,7 @@ decodeCount (ApplyErr cn g) n = do
   case f y of
     Right z -> pure (i, z)
     Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
+{-# INLINEABLE decodeCount #-}
 
 -- The type of DecodeClosed precludes pattern match against (SumD c) as the types are different.
 
@@ -468,6 +477,7 @@ decodeClosed (ApplyErr cn g) = do
   case f y of
     Right z -> pure z
     Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
+{-# INLINEABLE decodeClosed #-}
 
 decodeSparse ::
   Typeable a =>
@@ -484,6 +494,7 @@ decodeSparse name initial pick required = do
   if all (\(key, _name) -> member key used) required
     then pure v
     else unusedRequiredKeys used required (show (typeOf initial))
+{-# INLINEABLE decodeSparse #-}
 
 -- | Given a function that picks a Field from a key, decodes that field
 --   and returns a (t -> t) transformer, which when applied, will
@@ -495,6 +506,7 @@ applyField f seen name = do
     then duplicateKey name tag
     else case f tag of
       Field update d -> d >>= \v -> pure (update v, insert tag seen)
+{-# INLINEABLE applyField #-}
 
 -- | Decode a Map Block of key encoded data for type t
 --   given a function that picks the right box for a given key, and an
@@ -505,6 +517,7 @@ getSparseBlock 0 initial _pick seen _name = pure (initial, seen)
 getSparseBlock n initial pick seen name = do
   (transform, seen2) <- applyField pick seen name
   getSparseBlock (n - 1) (transform initial) pick seen2 name
+{-# INLINEABLE getSparseBlock #-}
 
 getSparseBlockIndef :: t -> (Word -> Field t) -> Set Word -> String -> Decoder s (t, Set Word)
 getSparseBlockIndef initial pick seen name =
@@ -513,6 +526,7 @@ getSparseBlockIndef initial pick seen name =
     False -> do
       (transform, seen2) <- applyField pick seen name
       getSparseBlockIndef (transform initial) pick seen2 name
+{-# INLINEABLE getSparseBlockIndef #-}
 
 -- ======================================================
 -- (Decode ('Closed 'Dense)) and (Decode ('Closed 'Sparse)) are applicative
@@ -522,10 +536,13 @@ getSparseBlockIndef initial pick seen name =
 instance Functor (Decode w) where
   fmap f (Map g x) = Map (f . g) x
   fmap f x = Map f x
+  {-# INLINE fmap #-}
 
 instance Applicative (Decode ('Closed d)) where
-  pure x = Emit x
+  pure = Emit
+  {-# INLINE pure #-}
   f <*> x = ApplyD f x
+  {-# INLINE (<*>) #-}
 
 -- | Use `Cardano.Ledger.Binary.Coders.encodeDual` and `decodeDual`, when you want to
 -- guarantee that a type has both `EncCBOR` and `FromCBR` instances.
@@ -534,17 +551,20 @@ decodeDual = D decCBOR
   where
     -- Enforce EncCBOR constraint on t
     _encCBOR = encCBOR (undefined :: t)
+{-# INLINE decodeDual #-}
 
 -- =============================================================================
 
 listDecodeA :: Decode ('Closed 'Dense) (Annotator x) -> Decode ('Closed 'Dense) (Annotator [x])
 listDecodeA dx = D (sequence <$> decodeList (decode dx))
+{-# INLINE listDecodeA #-}
 
 setDecodeA ::
   Ord x =>
   Decode ('Closed 'Dense) (Annotator x) ->
   Decode ('Closed 'Dense) (Annotator (Set x))
 setDecodeA dx = D (decodeAnnSet (decode dx))
+{-# INLINE setDecodeA #-}
 
 mapDecodeA ::
   Ord k =>
@@ -552,6 +572,7 @@ mapDecodeA ::
   Decode ('Closed 'Dense) (Annotator v) ->
   Decode ('Closed 'Dense) (Annotator (Map.Map k v))
 mapDecodeA k v = D (decodeMapTraverse (decode k) (decode v))
+{-# INLINE mapDecodeA #-}
 
 --------------------------------------------------------------------------------
 -- Utility functions for working with CBOR
@@ -563,6 +584,7 @@ duplicateKey name k =
     DecoderErrorCustom
       "Duplicate key:"
       (Text.pack $ show k ++ " while decoding type " ++ name)
+{-# NOINLINE duplicateKey #-}
 
 unusedRequiredKeys :: Set Word -> [(Word, String)] -> String -> Decoder s a
 unusedRequiredKeys used required name =
@@ -576,3 +598,4 @@ unusedRequiredKeys used required name =
     message [pair] = report pair ++ message []
     message (pair : more) = report pair ++ ", and " ++ message more
     report (k, f) = "field " ++ f ++ " with key " ++ show k
+{-# NOINLINE unusedRequiredKeys #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
@@ -444,7 +444,7 @@ decodeCount (ApplyErr cn g) n = do
   case f y of
     Right z -> pure (i, z)
     Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
-{-# INLINEABLE decodeCount #-}
+{-# INLINE decodeCount #-}
 
 -- The type of DecodeClosed precludes pattern match against (SumD c) as the types are different.
 
@@ -477,7 +477,7 @@ decodeClosed (ApplyErr cn g) = do
   case f y of
     Right z -> pure z
     Left message -> cborError $ DecoderErrorCustom "decoding error:" (Text.pack message)
-{-# INLINEABLE decodeClosed #-}
+{-# INLINE decodeClosed #-}
 
 decodeSparse ::
   Typeable a =>
@@ -494,7 +494,7 @@ decodeSparse name initial pick required = do
   if all (\(key, _name) -> member key used) required
     then pure v
     else unusedRequiredKeys used required (show (typeOf initial))
-{-# INLINEABLE decodeSparse #-}
+{-# INLINE decodeSparse #-}
 
 -- | Given a function that picks a Field from a key, decodes that field
 --   and returns a (t -> t) transformer, which when applied, will
@@ -506,7 +506,7 @@ applyField f seen name = do
     then duplicateKey name tag
     else case f tag of
       Field update d -> d >>= \v -> pure (update v, insert tag seen)
-{-# INLINEABLE applyField #-}
+{-# INLINE applyField #-}
 
 -- | Decode a Map Block of key encoded data for type t
 --   given a function that picks the right box for a given key, and an
@@ -517,7 +517,7 @@ getSparseBlock 0 initial _pick seen _name = pure (initial, seen)
 getSparseBlock n initial pick seen name = do
   (transform, seen2) <- applyField pick seen name
   getSparseBlock (n - 1) (transform initial) pick seen2 name
-{-# INLINEABLE getSparseBlock #-}
+{-# INLINE getSparseBlock #-}
 
 getSparseBlockIndef :: t -> (Word -> Field t) -> Set Word -> String -> Decoder s (t, Set Word)
 getSparseBlockIndef initial pick seen name =
@@ -526,7 +526,7 @@ getSparseBlockIndef initial pick seen name =
     False -> do
       (transform, seen2) <- applyField pick seen name
       getSparseBlockIndef (transform initial) pick seen2 name
-{-# INLINEABLE getSparseBlockIndef #-}
+{-# INLINE getSparseBlockIndef #-}
 
 -- ======================================================
 -- (Decode ('Closed 'Dense)) and (Decode ('Closed 'Sparse)) are applicative

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -87,6 +87,7 @@ class Typeable a => DecCBOR a where
   decCBOR :: Decoder s a
   default decCBOR :: Plain.FromCBOR a => Decoder s a
   decCBOR = fromPlainDecoder Plain.fromCBOR
+  {-# INLINE decCBOR #-}
 
   -- | Validate decoding of a Haskell value, without the need to actually construct
   -- it. Coule be slightly faster than `decCBOR`, however it should respect this law:
@@ -100,11 +101,13 @@ class Typeable a => DecCBOR a where
 
 instance DecCBOR Version where
   decCBOR = decodeVersion
+  {-# INLINE decCBOR #-}
 
 -- | Convert a versioned `DecCBOR` instance to a plain `Plain.Decoder` using Byron protocol
 -- version.
 fromByronCBOR :: DecCBOR a => Plain.Decoder s a
 fromByronCBOR = toPlainDecoder byronProtVer decCBOR
+{-# INLINE fromByronCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Primitive types
@@ -112,9 +115,11 @@ fromByronCBOR = toPlainDecoder byronProtVer decCBOR
 
 instance DecCBOR () where
   decCBOR = decodeNull
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Bool where
   decCBOR = decodeBool
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Numeric data
@@ -122,48 +127,63 @@ instance DecCBOR Bool where
 
 instance DecCBOR Integer where
   decCBOR = decodeInteger
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Natural where
   decCBOR = decodeNatural
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Word where
   decCBOR = decodeWord
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Word8 where
   decCBOR = decodeWord8
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Word16 where
   decCBOR = decodeWord16
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Word32 where
   decCBOR = decodeWord32
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Word64 where
   decCBOR = decodeWord64
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Int where
   decCBOR = decodeInt
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Int8 where
   decCBOR = decodeInt8
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Int16 where
   decCBOR = decodeInt16
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Int32 where
   decCBOR = decodeInt32
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Int64 where
   decCBOR = decodeInt64
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Float where
   decCBOR = decodeFloat
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Double where
   decCBOR = decodeDouble
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Rational where
   decCBOR = decodeRational
+  {-# INLINE decCBOR #-}
 
 deriving newtype instance Typeable p => DecCBOR (Fixed p)
 
@@ -172,12 +192,15 @@ instance DecCBOR Void where
 
 instance DecCBOR Term where
   decCBOR = decodeTerm
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR IPv4 where
   decCBOR = decodeIPv4
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR IPv6 where
   decCBOR = decodeIPv6
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Tagged
@@ -185,7 +208,7 @@ instance DecCBOR IPv6 where
 
 instance (Typeable s, DecCBOR a) => DecCBOR (Tagged s a) where
   decCBOR = Tagged <$> decCBOR
-
+  {-# INLINE decCBOR #-}
   dropCBOR _ = dropCBOR (Proxy @a)
 
 --------------------------------------------------------------------------------
@@ -199,6 +222,7 @@ instance (DecCBOR a, DecCBOR b) => DecCBOR (a, b) where
     !y <- decCBOR
     return (x, y)
   dropCBOR _ = decodeListLenOf 2 <* dropCBOR (Proxy @a) <* dropCBOR (Proxy @b)
+  {-# INLINE decCBOR #-}
 
 instance (DecCBOR a, DecCBOR b, DecCBOR c) => DecCBOR (a, b, c) where
   decCBOR = do
@@ -212,6 +236,7 @@ instance (DecCBOR a, DecCBOR b, DecCBOR c) => DecCBOR (a, b, c) where
       <* dropCBOR (Proxy @a)
       <* dropCBOR (Proxy @b)
       <* dropCBOR (Proxy @c)
+  {-# INLINE decCBOR #-}
 
 instance (DecCBOR a, DecCBOR b, DecCBOR c, DecCBOR d) => DecCBOR (a, b, c, d) where
   decCBOR = do
@@ -227,6 +252,7 @@ instance (DecCBOR a, DecCBOR b, DecCBOR c, DecCBOR d) => DecCBOR (a, b, c, d) wh
       <* dropCBOR (Proxy @b)
       <* dropCBOR (Proxy @c)
       <* dropCBOR (Proxy @d)
+  {-# INLINE decCBOR #-}
 
 instance
   (DecCBOR a, DecCBOR b, DecCBOR c, DecCBOR d, DecCBOR e) =>
@@ -247,6 +273,7 @@ instance
       <* dropCBOR (Proxy @c)
       <* dropCBOR (Proxy @d)
       <* dropCBOR (Proxy @e)
+  {-# INLINE decCBOR #-}
 
 instance
   (DecCBOR a, DecCBOR b, DecCBOR c, DecCBOR d, DecCBOR e, DecCBOR f) =>
@@ -269,6 +296,7 @@ instance
       <* dropCBOR (Proxy @d)
       <* dropCBOR (Proxy @e)
       <* dropCBOR (Proxy @f)
+  {-# INLINE decCBOR #-}
 
 instance
   ( DecCBOR a
@@ -300,35 +328,45 @@ instance
       <* dropCBOR (Proxy @e)
       <* dropCBOR (Proxy @f)
       <* dropCBOR (Proxy @g)
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR BS.ByteString where
   decCBOR = decodeBytes
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR T.Text where
   decCBOR = decodeString
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR BSL.ByteString where
   decCBOR = BSL.fromStrict <$> decCBOR
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR ShortByteString where
   decCBOR = do
     BA (Prim.ByteArray ba) <- decodeByteArray
     return $ SBS ba
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR ByteArray where
   decCBOR = decodeByteArray
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Prim.ByteArray where
   decCBOR = unBA <$> decodeByteArray
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR SlicedByteArray where
   decCBOR = fromByteArray . unBA <$> decodeByteArray
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR a => DecCBOR [a] where
   decCBOR = decodeList decCBOR
+  {-# INLINE decCBOR #-}
 
 instance (DecCBOR a, DecCBOR b) => DecCBOR (Either a b) where
   decCBOR = decodeEither (decCBOR >>= \a -> a `seq` pure a) (decCBOR >>= \a -> a `seq` pure a)
+  {-# INLINE decCBOR #-}
   dropCBOR _ = () <$ decodeEither (dropCBOR (Proxy :: Proxy a)) (dropCBOR (Proxy :: Proxy b))
 
 instance DecCBOR a => DecCBOR (NonEmpty a) where
@@ -337,26 +375,33 @@ instance DecCBOR a => DecCBOR (NonEmpty a) where
     case nonEmpty ls of
       Nothing -> cborError $ DecoderErrorEmptyList "NonEmpty"
       Just ne -> pure ne
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR a => DecCBOR (Maybe a) where
   decCBOR = decodeMaybe decCBOR
+  {-# INLINE decCBOR #-}
   dropCBOR _ = () <$ decodeMaybe (dropCBOR (Proxy @a))
 
 instance DecCBOR a => DecCBOR (SMaybe.StrictMaybe a) where
   decCBOR = decodeStrictMaybe decCBOR
+  {-# INLINE decCBOR #-}
   dropCBOR _ = () <$ decodeStrictMaybe (dropCBOR (Proxy @a))
 
 instance DecCBOR a => DecCBOR (SSeq.StrictSeq a) where
   decCBOR = decodeStrictSeq decCBOR
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR a => DecCBOR (Seq.Seq a) where
   decCBOR = decodeSeq decCBOR
+  {-# INLINE decCBOR #-}
 
 instance (Ord a, DecCBOR a) => DecCBOR (Set.Set a) where
   decCBOR = decodeSet decCBOR
+  {-# INLINE decCBOR #-}
 
 instance (Ord k, DecCBOR k, DecCBOR v) => DecCBOR (Map.Map k v) where
   decCBOR = decodeMap decCBOR decCBOR
+  {-# INLINE decCBOR #-}
 
 instance
   ( Ord k
@@ -370,6 +415,7 @@ instance
   DecCBOR (VMap.VMap kv av k a)
   where
   decCBOR = decodeVMap decCBOR decCBOR
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR a => DecCBOR (V.Vector a) where
   decCBOR = decodeVector decCBOR
@@ -393,6 +439,7 @@ instance (DecCBOR a, VU.Unbox a) => DecCBOR (VU.Vector a) where
 
 instance DecCBOR UTCTime where
   decCBOR = decodeUTCTime
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Crypto
@@ -404,12 +451,15 @@ instance DecCBOR UTCTime where
 
 instance DSIGNAlgorithm v => DecCBOR (VerKeyDSIGN v) where
   decCBOR = decodeVerKeyDSIGN
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm v => DecCBOR (SignKeyDSIGN v) where
   decCBOR = decodeSignKeyDSIGN
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm v => DecCBOR (SigDSIGN v) where
   decCBOR = decodeSigDSIGN
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Hash
@@ -429,6 +479,7 @@ instance (HashAlgorithm h, Typeable a) => DecCBOR (Hash h a) where
         where
           expected = sizeHash (Proxy :: Proxy h)
           actual = BS.length bs
+  {-# INLINEABLE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- KES
@@ -439,72 +490,90 @@ instance
   DecCBOR (VerKeyKES (SimpleKES d t))
   where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance
   (DSIGNAlgorithm d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)) =>
   DecCBOR (SignKeyKES (SimpleKES d t))
   where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance
   (DSIGNAlgorithm d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)) =>
   DecCBOR (SigKES (SimpleKES d t))
   where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 instance (KESAlgorithm d, HashAlgorithm h) => DecCBOR (VerKeyKES (SumKES h d)) where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance (KESAlgorithm d, HashAlgorithm h) => DecCBOR (SignKeyKES (SumKES h d)) where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance (KESAlgorithm d, HashAlgorithm h) => DecCBOR (SigKES (SumKES h d)) where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (VerKeyKES (CompactSingleKES d)) where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (SignKeyKES (CompactSingleKES d)) where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (SigKES (CompactSingleKES d)) where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 instance
   (OptimizedKESAlgorithm d, HashAlgorithm h) =>
   DecCBOR (VerKeyKES (CompactSumKES h d))
   where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance
   (OptimizedKESAlgorithm d, HashAlgorithm h) =>
   DecCBOR (SignKeyKES (CompactSumKES h d))
   where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance
   (OptimizedKESAlgorithm d, HashAlgorithm h) =>
   DecCBOR (SigKES (CompactSumKES h d))
   where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (VerKeyKES (SingleKES d)) where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (SignKeyKES (SingleKES d)) where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance DSIGNAlgorithm d => DecCBOR (SigKES (SingleKES d)) where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 instance KnownNat t => DecCBOR (VerKeyKES (MockKES t)) where
   decCBOR = decodeVerKeyKES
+  {-# INLINE decCBOR #-}
 
 instance KnownNat t => DecCBOR (SignKeyKES (MockKES t)) where
   decCBOR = decodeSignKeyKES
+  {-# INLINE decCBOR #-}
 
 instance KnownNat t => DecCBOR (SigKES (MockKES t)) where
   decCBOR = decodeSigKES
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- VRF
@@ -512,30 +581,39 @@ instance KnownNat t => DecCBOR (SigKES (MockKES t)) where
 
 instance DecCBOR (VerKeyVRF SimpleVRF) where
   decCBOR = decodeVerKeyVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (SignKeyVRF SimpleVRF) where
   decCBOR = decodeSignKeyVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (CertVRF SimpleVRF) where
   decCBOR = decodeCertVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (VerKeyVRF MockVRF) where
   decCBOR = decodeVerKeyVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (SignKeyVRF MockVRF) where
   decCBOR = decodeSignKeyVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (CertVRF MockVRF) where
   decCBOR = decodeCertVRF
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Praos.Proof where
   decCBOR = decCBOR >>= Praos.proofFromBytes
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Praos.SignKey where
   decCBOR = decCBOR >>= Praos.skFromBytes
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR Praos.VerKey where
   decCBOR = decCBOR >>= Praos.vkFromBytes
+  {-# INLINE decCBOR #-}
 
 deriving instance DecCBOR (VerKeyVRF Praos.PraosVRF)
 
@@ -551,6 +629,7 @@ instance (VRFAlgorithm v, Typeable a) => DecCBOR (CertifiedVRF v a) where
       <$ enforceSize "CertifiedVRF" 2
       <*> decCBOR
       <*> decodeCertVRF
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Slotting
@@ -558,9 +637,11 @@ instance (VRFAlgorithm v, Typeable a) => DecCBOR (CertifiedVRF v a) where
 
 instance DecCBOR SlotNo where
   decCBOR = fromPlainDecoder Serialise.decode
+  {-# INLINE decCBOR #-}
 
 instance (Serialise.Serialise t, Typeable t) => DecCBOR (WithOrigin t) where
   decCBOR = fromPlainDecoder Serialise.decode
+  {-# INLINE decCBOR #-}
 
 deriving instance DecCBOR EpochNo
 
@@ -570,6 +651,7 @@ deriving instance DecCBOR SystemStart
 
 instance DecCBOR BlockNo where
   decCBOR = fromPlainDecoder decode
+  {-# INLINE decCBOR #-}
 
 --------------------------------------------------------------------------------
 -- Plutus
@@ -577,3 +659,4 @@ instance DecCBOR BlockNo where
 
 instance DecCBOR PV1.Data where
   decCBOR = fromPlainDecoder decode
+  {-# INLINE decCBOR #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -21,7 +21,7 @@ where
 
 import qualified Cardano.Binary as Plain (Decoder, FromCBOR (..))
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm, SeedSizeDSIGN, SigDSIGN, SignKeyDSIGN, VerKeyDSIGN)
-import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashFromBytes, sizeHash)
+import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm)
 import Cardano.Crypto.KES.Class (KESAlgorithm, OptimizedKESAlgorithm, SigKES, SignKeyKES, VerKeyKES)
 import Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
 import Cardano.Crypto.KES.CompactSum (CompactSumKES)
@@ -465,21 +465,7 @@ instance DSIGNAlgorithm v => DecCBOR (SigDSIGN v) where
 -- Hash
 --------------------------------------------------------------------------------
 
-instance (HashAlgorithm h, Typeable a) => DecCBOR (Hash h a) where
-  decCBOR = do
-    bs <- decodeBytes
-    case hashFromBytes bs of
-      Just x -> return x
-      Nothing ->
-        fail $
-          "hash bytes wrong size, expected "
-            ++ show expected
-            ++ " but got "
-            ++ show actual
-        where
-          expected = sizeHash (Proxy :: Proxy h)
-          actual = BS.length bs
-  {-# INLINEABLE decCBOR #-}
+instance (HashAlgorithm h, Typeable a) => DecCBOR (Hash h a)
 
 --------------------------------------------------------------------------------
 -- KES

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -400,7 +400,8 @@ decodeRational =
       if d <= 0
         then cborError $ DecoderErrorCustom "Rational" "invalid denominator"
         else return $! n % d
-{-# INLINEABLE decodeRational #-}
+    {-# INLINE decodeRationalFixedSizeTuple #-}
+{-# INLINE decodeRational #-}
 
 -- | Future `Decoder` for `Rational` type. This decoder will be applied in future and is
 -- prepared here as use case on how to do upgrades to serialization. Versions variance:
@@ -443,7 +444,7 @@ decodeRationalWithoutTag = do
       when (d == 0) (fail "Denominator cannot be zero")
       pure $! n % d
     _ -> cborError $ DecoderErrorSizeMismatch "Rational" 2 numValues
-{-# INLINEABLE decodeRationalWithoutTag #-}
+{-# INLINE decodeRationalWithoutTag #-}
 
 --------------------------------------------------------------------------------
 -- Containers
@@ -460,7 +461,7 @@ decodeList decodeValue =
     (natVersion @2)
     (decodeCollection decodeListLenOrIndef decodeValue)
     (decodeListWith decodeValue)
-{-# INLINEABLE decodeList #-}
+{-# INLINE decodeList #-}
 
 -- | @'Decoder'@ for list.
 decodeListWith :: Decoder s a -> Decoder s [a]
@@ -480,7 +481,7 @@ decodeMaybe decodeValue = do
     (natVersion @2)
     (decodeMaybeVarLen decodeValue)
     (decodeMaybeExactLen decodeValue)
-{-# INLINEABLE decodeMaybe #-}
+{-# INLINE decodeMaybe #-}
 
 decodeMaybeExactLen :: Decoder s a -> Decoder s (Maybe a)
 decodeMaybeExactLen decodeValue = do
@@ -491,7 +492,7 @@ decodeMaybeExactLen decodeValue = do
       !x <- decodeValue
       return (Just x)
     _ -> fail "too many elements while decoding Maybe."
-{-# INLINEABLE decodeMaybeExactLen #-}
+{-# INLINE decodeMaybeExactLen #-}
 
 decodeMaybeVarLen :: Decoder s a -> Decoder s (Maybe a)
 decodeMaybeVarLen decodeValue = do
@@ -510,7 +511,7 @@ decodeMaybeVarLen decodeValue = do
           unless isBreak2 $
             fail "too many elements in break-style decoding of Maybe."
           pure (Just x)
-{-# INLINEABLE decodeMaybeVarLen #-}
+{-# INLINE decodeMaybeVarLen #-}
 
 -- | Alternative way to decode a Maybe type.
 --
@@ -551,7 +552,7 @@ decodeEither decodeLeft decodeRight = do
     0 -> Left <$> decodeLeft
     1 -> Right <$> decodeRight
     _ -> cborError $ DecoderErrorUnknownTag "Either" (fromIntegral t)
-{-# INLINEABLE decodeEither #-}
+{-# INLINE decodeEither #-}
 
 decodeRecordNamed :: Text.Text -> (a -> Int) -> Decoder s a -> Decoder s a
 decodeRecordNamed name getRecordSize decoder = do
@@ -573,7 +574,7 @@ decodeRecordNamedT name getRecordSize decoder = do
       isBreak <- decodeBreakOr
       unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
   pure x
-{-# INLINEABLE decodeRecordNamedT #-}
+{-# INLINE decodeRecordNamedT #-}
 
 decodeRecordSum :: String -> (Word -> Decoder s (Int, a)) -> Decoder s a
 decodeRecordSum name decoder = do
@@ -586,7 +587,7 @@ decodeRecordSum name decoder = do
       isBreak <- decodeBreakOr -- if there is stuff left, it is unnecessary extra stuff
       unless isBreak $ cborError $ DecoderErrorCustom (Text.pack name) "Excess terms in array"
   pure x
-{-# INLINEABLE decodeRecordSum #-}
+{-# INLINE decodeRecordSum #-}
 
 decodeEnumBounded :: forall a s. (Enum a, Bounded a, Typeable a) => Decoder s a
 decodeEnumBounded = do
@@ -594,7 +595,7 @@ decodeEnumBounded = do
   if fromEnum (minBound :: a) <= n && n <= fromEnum (maxBound :: a)
     then pure $ toEnum n
     else fail $ "Failed to decode an Enum: " <> show n <> " for TypeRep: " <> show (typeRep (Proxy @a))
-{-# INLINEABLE decodeEnumBounded #-}
+{-# INLINE decodeEnumBounded #-}
 
 decodeWithOrigin :: Decoder s a -> Decoder s (WithOrigin a)
 decodeWithOrigin f = withOriginFromMaybe <$> decodeMaybe f
@@ -651,7 +652,7 @@ decodeMapSkel fromDistinctDescList decodeKey decodeValue = do
       if newKey > previousKey
         then decodeEntries (remainingPairs - 1) newKey (p : acc)
         else cborError $ DecoderErrorCanonicityViolation "Map"
-{-# INLINEABLE decodeMapSkel #-}
+{-# INLINE decodeMapSkel #-}
 
 decodeCollection :: Decoder s (Maybe Int) -> Decoder s a -> Decoder s [a]
 decodeCollection lenOrIndef el = snd <$> decodeCollectionWithLen lenOrIndef el
@@ -670,7 +671,7 @@ decodeCollectionWithLen lenOrIndef el = do
       condition >>= \case
         False -> pure (n, reverse acc)
         True -> action >>= \v -> loop (n + 1, v : acc) condition action
-{-# INLINEABLE decodeCollectionWithLen #-}
+{-# INLINE decodeCollectionWithLen #-}
 
 decodeIsListByKey ::
   forall k t v s.
@@ -688,7 +689,8 @@ decodeIsListByKey decodeKey decodeValueFor =
       !key <- decodeKey
       !value <- decodeValueFor key
       pure (key, value)
-{-# INLINEABLE decodeIsListByKey #-}
+    {-# INLINE decodeInlinedPair #-}
+{-# INLINE decodeIsListByKey #-}
 
 -- | `Decoder` for `Map.Map`. Versions variance:
 --
@@ -731,7 +733,7 @@ decodeMapByKey decodeKey decodeValue =
         (decodeIsListByKey decodeKey decodeValue)
     )
     (decodeMapSkel Map.fromDistinctDescList decodeKey decodeValue)
-{-# INLINEABLE decodeMapByKey #-}
+{-# INLINE decodeMapByKey #-}
 
 -- | Decode `VMap`. Unlike `decodeMap` it does not behavee differently for
 -- version prior to 2.
@@ -788,7 +790,7 @@ decodeSetSkel fromDistinctDescList decodeValue = do
       if newValue > previousValue
         then decodeEntries (remainingEntries - 1) newValue (newValue : acc)
         else cborError $ DecoderErrorCanonicityViolation "Set"
-{-# INLINEABLE decodeSetSkel #-}
+{-# INLINE decodeSetSkel #-}
 
 -- | `Decoder` for `Set.Set`. Versions variance:
 --
@@ -811,7 +813,7 @@ decodeSet valueDecoder =
         (Set.fromList <$> decodeCollection decodeListLenOrIndef valueDecoder)
     )
     (decodeSetSkel Set.fromDistinctDescList valueDecoder)
-{-# INLINEABLE decodeSet #-}
+{-# INLINE decodeSet #-}
 
 -- Decode a Set as a either a definite or indefinite list. Duplicates are
 --   not allowed. Set tag 258 is permitted, but not enforced.
@@ -835,7 +837,7 @@ decodeSetEnforceNoDuplicates decodeElement = do
           a <- decodeElement
           when (a `Set.member` acc) $ fail "Duplicate key detected in the Set"
           loop condition nextStep (Set.insert a acc)
-{-# INLINEABLE decodeSetEnforceNoDuplicates #-}
+{-# INLINE decodeSetEnforceNoDuplicates #-}
 
 decodeContainerSkelWithReplicate ::
   -- | How to get the size of the container
@@ -907,7 +909,7 @@ decodeAccWithLen lenOrIndef combine acc0 action = do
             v <- action
             loop (i + 1) (v `combine` acc)
   loop 0 acc0
-{-# INLINEABLE decodeAccWithLen #-}
+{-# INLINE decodeAccWithLen #-}
 
 -- | Just like `decodeMap`, but assumes that there are no duplicate keys, which is not enforced.
 decodeMapNoDuplicates :: Ord a => Decoder s a -> Decoder s b -> Decoder s (Map.Map a b)
@@ -924,7 +926,7 @@ decodeMapNoDuplicates decodeKey decodeValue =
       !value <- decodeValue
       pure (key, value)
     {-# INLINE decodeInlinedPair #-}
-{-# INLINEABLE decodeMapNoDuplicates #-}
+{-# INLINE decodeMapNoDuplicates #-}
 
 -- | Just like `decodeMap`, but fails on duplicate keys
 decodeMapEnforceNoDuplicates ::
@@ -948,7 +950,7 @@ decodeMapEnforceNoDuplicates decodeKey decodeValueFor = do
           !value <- decodeValueFor key
           when (key `Map.member` acc) $ fail "Duplicate key detected in the Map"
           loop condition nextStep (Map.insert key value acc)
-{-# INLINEABLE decodeMapEnforceNoDuplicates #-}
+{-# INLINE decodeMapEnforceNoDuplicates #-}
 
 decodeMapContents :: Decoder s a -> Decoder s [a]
 decodeMapContents = decodeCollection decodeMapLenOrIndef
@@ -1001,7 +1003,7 @@ decodeUTCTime =
           (fromOrdinalDate year dayOfYear)
           (picosecondsToDiffTime timeOfDayPico)
     {-# INLINE timeDecoder #-}
-{-# INLINEABLE decodeUTCTime #-}
+{-# INLINE decodeUTCTime #-}
 
 --------------------------------------------------------------------------------
 -- Network
@@ -1024,7 +1026,7 @@ binaryGetDecoder allowLeftOver name getter = do
       | allowLeftOver || BSL.null leftOver -> pure ha
       | otherwise ->
           cborError $ DecoderErrorLeftover name (BSL.toStrict leftOver)
-{-# INLINEABLE binaryGetDecoder #-}
+{-# INLINE binaryGetDecoder #-}
 
 decodeIPv4 :: Decoder s IPv4
 decodeIPv4 =
@@ -1033,7 +1035,7 @@ decodeIPv4 =
       (natVersion @9)
       (binaryGetDecoder False "decodeIPv4" getWord32le)
       (binaryGetDecoder True "decodeIPv4" getWord32le)
-{-# INLINEABLE decodeIPv4 #-}
+{-# INLINE decodeIPv4 #-}
 
 getHostAddress6 :: Get HostAddress6
 getHostAddress6 = do
@@ -1042,7 +1044,7 @@ getHostAddress6 = do
   !w3 <- getWord32le
   !w4 <- getWord32le
   return (w1, w2, w3, w4)
-{-# INLINEABLE getHostAddress6 #-}
+{-# INLINE getHostAddress6 #-}
 
 decodeIPv6 :: Decoder s IPv6
 decodeIPv6 =
@@ -1051,7 +1053,7 @@ decodeIPv6 =
       (natVersion @9)
       (binaryGetDecoder False "decodeIPv6" getHostAddress6)
       (binaryGetDecoder True "decodeIPv6" getHostAddress6)
-{-# INLINEABLE decodeIPv6 #-}
+{-# INLINE decodeIPv6 #-}
 
 --------------------------------------------------------------------------------
 -- Wrapped CBORG decoders
@@ -1063,7 +1065,7 @@ decodeTagMaybe =
     C.TypeTag -> Just . fromIntegral <$> decodeTag
     C.TypeTag64 -> Just <$> decodeTag64
     _ -> pure Nothing
-{-# INLINEABLE decodeTagMaybe #-}
+{-# INLINE decodeTagMaybe #-}
 
 allowTag :: Word -> Decoder s ()
 allowTag tagExpected = do
@@ -1072,7 +1074,7 @@ allowTag tagExpected = do
     unless (tagReceived == (fromIntegral tagExpected :: Word64)) $
       fail $
         "Expecteg tag " <> show tagExpected <> " but got tag " <> show tagReceived
-{-# INLINEABLE allowTag #-}
+{-# INLINE allowTag #-}
 
 assertTag :: Word -> Decoder s ()
 assertTag tagExpected = do
@@ -1083,13 +1085,13 @@ assertTag tagExpected = do
   unless (tagReceived == (fromIntegral tagExpected :: Word64)) $
     fail $
       "Expecteg tag " <> show tagExpected <> " but got tag " <> show tagReceived
-{-# INLINEABLE assertTag #-}
+{-# INLINE assertTag #-}
 
 -- | Enforces that the input size is the same as the decoded one, failing in
 --   case it's not
 enforceSize :: Text.Text -> Int -> Decoder s ()
 enforceSize lbl requestedSize = decodeListLen >>= matchSize lbl requestedSize
-{-# INLINEABLE enforceSize #-}
+{-# INLINE enforceSize #-}
 
 -- | Compare two sizes, failing if they are not equal
 matchSize :: Text.Text -> Int -> Int -> Decoder s ()
@@ -1200,7 +1202,7 @@ decodeNatural = do
   if n >= 0
     then return $! fromInteger n
     else cborError $ DecoderErrorCustom "Natural" "got a negative number"
-{-# INLINEABLE decodeNatural #-}
+{-# INLINE decodeNatural #-}
 
 decodeIntegerCanonical :: Decoder s Integer
 decodeIntegerCanonical = fromPlainDecoder C.decodeIntegerCanonical

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
@@ -56,6 +56,7 @@ decodeSized :: Decoder s a -> Decoder s (Sized a)
 decodeSized decoder = do
   Annotated v (ByteSpan start end) <- annotatedDecoder decoder
   pure $! Sized v $! end - start
+{-# INLINE decodeSized #-}
 
 sizedDecoder :: Decoder s a -> Decoder s (Sized a)
 sizedDecoder = decodeSized
@@ -63,6 +64,7 @@ sizedDecoder = decodeSized
 
 instance DecCBOR a => DecCBOR (Sized a) where
   decCBOR = decodeSized decCBOR
+  {-# INLINE decCBOR #-}
 
 -- | Discards the size.
 instance EncCBOR a => EncCBOR (Sized a) where

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
@@ -86,7 +86,7 @@ decodeRecordNamedT ::
 decodeRecordNamedT name getRecordSize decoder =
   decodeListLikeT name decoder $ \result n ->
     lift $ matchSize ("Record " <> name) n (getRecordSize result)
-{-# INLINEABLE decodeRecordNamedT #-}
+{-# INLINE decodeRecordNamedT #-}
 
 decodeRecordSum :: Text.Text -> (Word -> Decoder s (Int, a)) -> Decoder s a
 decodeRecordSum name decoder =
@@ -94,7 +94,7 @@ decodeRecordSum name decoder =
     snd <$> do
       decodeListLikeT name (lift (decodeWord >>= decoder)) $ \(size, _) n ->
         lift $ matchSize (Text.pack "Sum " <> name) size n
-{-# INLINEABLE decodeRecordSum #-}
+{-# INLINE decodeRecordSum #-}
 
 decodeListLikeT ::
   (MonadTrans m, Monad (m (Decoder s))) =>
@@ -114,4 +114,4 @@ decodeListLikeT name decoder actOnLength = do
       isBreak <- decodeBreakOr
       unless isBreak $ cborError $ DecoderErrorCustom name "Excess terms in array"
   pure result
-{-# INLINEABLE decodeListLikeT #-}
+{-# INLINE decodeListLikeT #-}

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -58,6 +58,7 @@ instance Bounded Version where
 
 instance FromCBOR Version where
   fromCBOR = fromCBOR >>= mkVersion64
+  {-# INLINE fromCBOR #-}
 
 instance FromJSON Version where
   parseJSON v = parseJSON v >>= mkVersion64
@@ -66,10 +67,12 @@ instance FromJSON Version where
 -- supplied through @TypeApplications@.
 natVersion :: forall v. (KnownNat v, MinVersion <= v, v <= MaxVersion) => Version
 natVersion = natVersionProxy (Proxy @v)
+{-# INLINE natVersion #-}
 
 -- | Safely construct a `Version` from a type level `Nat`, which is supplied as a `Proxy`
 natVersionProxy :: (KnownNat v, MinVersion <= v, v <= MaxVersion) => Proxy v -> Version
 natVersionProxy = Version . fromInteger . natVal
+{-# INLINE natVersionProxy #-}
 
 -- | Construct a `Version` and fail if the supplied value is not a supported version number.
 mkVersion :: (Integral i, MonadFail m) => i -> m Version
@@ -79,6 +82,7 @@ mkVersion v
   | otherwise = mkVersion64 (fromIntegral v)
   where
     vi = toInteger v
+{-# INLINEABLE mkVersion #-}
 
 -- | Construct a `Version` and fail if the supplied value is not supported version number.
 mkVersion64 :: MonadFail m => Word64 -> m Version
@@ -97,6 +101,7 @@ mkVersion64 v
   where
     Version minVersion = minBound
     Version maxVersion = maxBound
+{-# INLINEABLE mkVersion64 #-}
 
 -- | Convert a `Version` to an `Integral` value.
 --
@@ -104,23 +109,28 @@ mkVersion64 v
 -- safe even for smallest integral types.
 getVersion :: Integral i => Version -> i
 getVersion (Version w64) = fromIntegral w64
+{-# INLINE getVersion #-}
 
 -- | Extract `Word64` representation of the `Version`
 getVersion64 :: Version -> Word64
 getVersion64 (Version w64) = w64
+{-# INLINE getVersion64 #-}
 
 -- | Increment version by 1.
 succVersion :: MonadFail m => Version -> m Version
 succVersion (Version v64) = mkVersion64 (v64 + 1)
+{-# INLINE succVersion #-}
 
 allVersions :: [Version]
 allVersions = [minBound .. maxBound]
 
 byronProtVer :: Version
 byronProtVer = natVersion @1
+{-# INLINE byronProtVer #-}
 
 shelleyProtVer :: Version
 shelleyProtVer = natVersion @2
+{-# INLINE shelleyProtVer #-}
 
 -- ==================================
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -82,7 +82,7 @@ mkVersion v
   | otherwise = mkVersion64 (fromIntegral v)
   where
     vi = toInteger v
-{-# INLINEABLE mkVersion #-}
+{-# INLINE mkVersion #-}
 
 -- | Construct a `Version` and fail if the supplied value is not supported version number.
 mkVersion64 :: MonadFail m => Word64 -> m Version
@@ -101,7 +101,7 @@ mkVersion64 v
   where
     Version minVersion = minBound
     Version maxVersion = maxBound
-{-# INLINEABLE mkVersion64 #-}
+{-# INLINE mkVersion64 #-}
 
 -- | Convert a `Version` to an `Integral` value.
 --

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.1.0.0
+version:            1.1.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -2,16 +2,13 @@
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Ledger.Address (
@@ -64,6 +61,7 @@ import qualified Cardano.Crypto.Hashing as Byron
 import Cardano.Ledger.BaseTypes (
   CertIx (..),
   Network (..),
+  SlotNo (..),
   TxIx (..),
   byronProtVer,
   natVersion,
@@ -87,12 +85,11 @@ import Cardano.Ledger.Credential (
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Hashes (ScriptHash (..))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Ledger.TreeDiff (ToExpr (toExpr), defaultExprViaShow)
 import Cardano.Prelude (unsafeShortByteStringIndex)
 import Control.DeepSeq (NFData)
 import Control.Monad (guard, unless, when)
-import Control.Monad.Trans.Fail
+import Control.Monad.Trans.Fail (runFail)
 import Control.Monad.Trans.State (StateT, evalStateT, get, modify', state)
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
@@ -102,7 +99,7 @@ import qualified Data.Aeson.Types as Aeson
 import Data.Binary (Put)
 import qualified Data.Binary as B
 import qualified Data.Binary.Put as B
-import Data.Bits
+import Data.Bits (Bits (clearBit, setBit, shiftL, shiftR, testBit, (.&.), (.|.)))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
@@ -121,7 +118,7 @@ import GHC.Show (intToDigit)
 import GHC.Stack (HasCallStack)
 import NoThunks.Class (NoThunks (..))
 import Numeric (showIntAtBase)
-import Quiet
+import Quiet (Quiet (Quiet))
 
 mkRwdAcnt ::
   Network ->
@@ -130,23 +127,29 @@ mkRwdAcnt ::
 mkRwdAcnt network script@(ScriptHashObj _) = RewardAcnt network script
 mkRwdAcnt network key@(KeyHashObj _) = RewardAcnt network key
 
+-- TODO: Deprecate in favor of RewardAcnt. This is just a synonym.
+
 -- | Serialise an address to the external format.
 serialiseAddr :: Addr c -> ByteString
 serialiseAddr = BSL.toStrict . B.runPut . putAddr
+{-# INLINE serialiseAddr #-}
 
 -- | Deserialise an address from the external format. This will fail if the
 -- input data is not in the right format (or if there is trailing data).
 deserialiseAddr :: Crypto c => ByteString -> Maybe (Addr c)
 deserialiseAddr = decodeAddr
+{-# INLINE deserialiseAddr #-}
 
 -- | Serialise a reward account to the external format.
 serialiseRewardAcnt :: RewardAcnt c -> ByteString
 serialiseRewardAcnt = BSL.toStrict . B.runPut . putRewardAcnt
+{-# INLINE serialiseRewardAcnt #-}
 
 -- | Deserialise a reward account from the external format. This will fail if the
 -- input data is not in the right format (or if there is trailing data).
 deserialiseRewardAcnt :: Crypto c => ByteString -> Maybe (RewardAcnt c)
 deserialiseRewardAcnt = decodeRewardAcnt
+{-# INLINE deserialiseRewardAcnt #-}
 
 -- | An address for UTxO.
 --
@@ -255,6 +258,7 @@ putAddr (Addr network pc sr) =
           let header = setPayCredBit $ netId `setBit` isEnterpriseAddr `setBit` notBaseAddr
           B.putWord8 header
           putCredential pc
+{-# INLINE putAddr #-}
 
 putRewardAcnt :: RewardAcnt c -> Put
 putRewardAcnt (RewardAcnt network cred) = do
@@ -266,13 +270,16 @@ putRewardAcnt (RewardAcnt network cred) = do
       header = setPayCredBit (netId .|. rewardAcntPrefix)
   B.putWord8 header
   putCredential cred
+{-# INLINE putRewardAcnt #-}
 
 putHash :: Hash.Hash h a -> Put
 putHash = B.putByteString . Hash.hashToBytes
+{-# INLINE putHash #-}
 
 putCredential :: Credential kr c -> Put
 putCredential (ScriptHashObj (ScriptHash h)) = putHash h
 putCredential (KeyHashObj (KeyHash h)) = putHash h
+{-# INLINE putCredential #-}
 
 -- | The size of the extra attributes in a bootstrp (ie Byron) address. Used
 -- to help enforce that people do not post huge ones on the chain.
@@ -319,15 +326,19 @@ putVariableLengthWord64 = putWord7s . word64ToWord7s
 
 instance Crypto c => EncCBOR (Addr c) where
   encCBOR = encCBOR . B.runPut . putAddr
+  {-# INLINE encCBOR #-}
 
 instance Crypto c => DecCBOR (Addr c) where
   decCBOR = fromCborAddr
+  {-# INLINE decCBOR #-}
 
 instance Crypto c => EncCBOR (RewardAcnt c) where
   encCBOR = encCBOR . B.runPut . putRewardAcnt
+  {-# INLINE encCBOR #-}
 
 instance Crypto c => DecCBOR (RewardAcnt c) where
   decCBOR = fromCborRewardAcnt
+  {-# INLINE decCBOR #-}
 
 newtype BootstrapAddress c = BootstrapAddress
   { unBootstrapAddress :: Byron.Address
@@ -376,6 +387,7 @@ instance Crypto c => Show (CompactAddr c) where
 -- | Unwrap the compact address and get to the address' binary representation.
 unCompactAddr :: CompactAddr c -> ShortByteString
 unCompactAddr (UnsafeCompactAddr sbs) = sbs
+{-# INLINE unCompactAddr #-}
 
 compactAddr :: Addr c -> CompactAddr c
 compactAddr = UnsafeCompactAddr . SBS.toShort . serialiseAddr
@@ -889,7 +901,7 @@ instance Crypto c => DecCBOR (CompactAddr c) where
   decCBOR = fromCborCompactAddr
   {-# INLINE decCBOR #-}
 
--- | Efficiently check whether compated adddress is an address with a credential
+-- | Efficiently check whether compacted adddress is an address with a credential
 -- that is a payment script.
 isPayCredScriptCompactAddr :: CompactAddr c -> Bool
 isPayCredScriptCompactAddr (UnsafeCompactAddr bytes) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -651,6 +651,7 @@ instance DecCBOR Network where
     word8ToNetwork <$> decCBOR >>= \case
       Nothing -> cborError $ DecoderErrorCustom "Network" "Unknown network id"
       Just n -> pure n
+  {-# INLINE decCBOR #-}
 
 -- | Blocks made
 newtype BlocksMade c = BlocksMade

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -178,6 +178,7 @@ instance HasKeyRole VKey
 
 instance (Crypto c, Typeable kd) => FromCBOR (VKey kd c) where
   fromCBOR = VKey <$> DSIGN.decodeVerKeyDSIGN
+  {-# INLINE fromCBOR #-}
 
 instance (Crypto c, Typeable kd) => ToCBOR (VKey kd c) where
   toCBOR = DSIGN.encodeVerKeyDSIGN . unVKey
@@ -307,6 +308,7 @@ instance Crypto c => DecCBOR (GenDelegPair c) where
       "GenDelegPair"
       (const 2)
       (GenDelegPair <$> decCBOR <*> decCBOR)
+  {-# INLINE decCBOR #-}
 
 instance Crypto c => ToJSON (GenDelegPair c) where
   toJSON (GenDelegPair d v) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -210,6 +210,7 @@ verifySignedDSIGN ::
   Bool
 verifySignedDSIGN (VKey vk) vd sigDSIGN =
   either (const False) (const True) $ DSIGN.verifySignedDSIGN () vk vd sigDSIGN
+{-# INLINE verifySignedDSIGN #-}
 
 -- | Hash a given signature
 hashSignature ::
@@ -217,6 +218,7 @@ hashSignature ::
   SignedDSIGN c (Hash c h) ->
   Hash c (SignedDSIGN c (Hash c h))
 hashSignature = Hash.hashWith (DSIGN.rawSerialiseSigDSIGN . coerce)
+{-# INLINE hashSignature #-}
 
 --------------------------------------------------------------------------------
 -- Key Hashes

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -98,6 +98,8 @@ instance (Typeable kr, Crypto c) => DecCBOR (Annotator (WitVKey kr c)) where
             mkWitVKey <$> Plain.fromCBOR <*> decodeSignedDSIGN
     where
       mkWitVKey k sig = WitVKeyInternal k sig (asWitness $ hashKey k)
+      {-# INLINE mkWitVKey #-}
+  {-# INLINE decCBOR #-}
 
 pattern WitVKey ::
   (Typeable kr, Crypto c) =>

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
@@ -194,6 +194,7 @@ class SafeToHash x => HashAnnotated x index c | x -> index c where
   -- and  @(HashAnnotated x i crypto)@ instances.
   hashAnnotated :: Hash.HashAlgorithm (HASH c) => x -> SafeHash c index
   hashAnnotated = makeHashWithExplicitProxys (Proxy @c) (Proxy @index)
+  {-# INLINE hashAnnotated #-}
 
 -- ========================================================================
 
@@ -207,7 +208,8 @@ class SafeToHash x => HashWithCrypto x index | x -> index where
     Proxy c ->
     x ->
     SafeHash c index
-  hashWithCrypto proxy y = makeHashWithExplicitProxys proxy (Proxy @index) y
+  hashWithCrypto proxy = makeHashWithExplicitProxys proxy (Proxy @index)
+  {-# INLINE hashWithCrypto #-}
 
 -- ======================================================================
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
@@ -158,6 +158,7 @@ verifyWitVKey ::
   WitVKey kr c ->
   Bool
 verifyWitVKey txbodyHash (WitVKey vkey sig) = verifySignedDSIGN vkey txbodyHash (coerce sig)
+{-# INLINE verifyWitVKey #-}
 
 -- | Determine the total balance contained in the UTxO.
 balance :: EraTxOut era => UTxO era -> Value era


### PR DESCRIPTION
# Description

This is a backport of performance improvements implemented in #3393 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
