### PR TITLE
conway instances added

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Change the Conway txInfo to allow Plutus V3
   NOTE - unlike V1 and V2, the ledger will no longer place the "zero ada" value
   in the script context for the transaction minting field.
+* Added instances for ConwayDelegsPredFailure:
+  `NoThunks`, `EncCBOR`, `DecCBOR`, and `Arbitrary`
 
 ## 1.1.0.0
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -252,3 +252,18 @@ instance
   Arbitrary (ConwayTickfEvent era)
   where
   arbitrary = undefined
+
+-- DELEGS
+
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "CERT" era))
+  ) =>
+  Arbitrary (ConwayDelegsPredFailure era)
+  where
+  arbitrary =
+    oneof
+      [ DelegateeNotRegisteredDELEG <$> arbitrary
+      , WithdrawalsNotInRewardsDELEGS <$> arbitrary
+      , CertFailure <$> arbitrary
+      ]


### PR DESCRIPTION
# Description

I added instances for `ConwayDelegsPredFailure` which are required to integrate the latest ledger into consensus: `Typeable`, `NoThunks`, `EncCBOR`, `DecCBOR`, and `Arbitary`. The last three, however, are undefined.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
