### PR TITLE
Fixing the Mint field translation.

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `VState`
 * Added support for Plutus V3 in the types and functions that use `Language`.
   (Note that the Alonzo ledger era rules do not allow V3 scripts, however.).
+* Fix a bug of converting a mint field to the plutus context: [#3398](https://github.com/input-output-hk/cardano-ledger/pull/3398)
 
 ## 1.1.0.0
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -363,7 +363,10 @@ transAssetName :: AssetName -> PV1.TokenName
 transAssetName (AssetName bs) = PV1.TokenName (PV1.toBuiltin (SBS.fromShort bs))
 
 transMultiAsset :: MultiAsset c -> PV1.Value
-transMultiAsset (MultiAsset m) = Map.foldlWithKey' accum1 mempty m
+transMultiAsset ma = transMultiAssetInternal ma mempty
+
+transMultiAssetInternal :: MultiAsset c -> PV1.Value -> PV1.Value
+transMultiAssetInternal (MultiAsset m) initAcc = Map.foldlWithKey' accum1 initAcc m
   where
     accum1 ans sym mp2 = Map.foldlWithKey' accum2 ans mp2
       where
@@ -380,7 +383,7 @@ transMultiAsset (MultiAsset m) = Map.foldlWithKey' accum1 mempty m
 -- makes no sense). However, if we don't preserve previous translation, scripts that
 -- previously succeeded will fail.
 transMintValue :: MultiAsset c -> PV1.Value
-transMintValue m = transMultiAsset m <> justZeroAda
+transMintValue m = transMultiAssetInternal m justZeroAda
   where
     justZeroAda = PV1.singleton PV1.adaSymbol PV1.adaToken 0
 


### PR DESCRIPTION
It was incorrectly fixed in 21825f12729ab6ab97097fa9aa95ba4a5a15672d

This is due to the fact that the Map in Plutus is not like a Map in Haskell's containers library. Plutus Map is an assoc Map that is based on lists and the order of elements actually matters. So, the original fix placed the ADA value at the end, while the original and correct implementation, as in this PR, places it at the beginning.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
