### PR TITLE
Create TotalDeposits events during all eras

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Introduction of `TxCert` and `EraTxCert`
 * Add `EraTxCert` and `ShelleyEraTxCert` instances to `AllegraEra`
+* Fix an issue where `TotalDeposits` didn't appear on Allegra and Mary era
 
 ## 1.1.1.0
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `EraPlutusContext 'PlutusV1` instance to `AlonzoEra`
 * Rename `transTxCert` to `transShelleyTxCert`
 * Remove `witsVKeyNeeded`, in favor of the one from `cardano-ledger-shelley`
+* Fix an issue where `TotalDeposits` didn't appear on Alonzo era
 
 ## 1.2.0.0
 

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `EraTxCert` and `ShelleyEraTxCert` instances to `BabbageEra`
 * Add `EraPlutusContext 'PlutusV1` instance to `BabbageEra`
 * Add `EraPlutusContext 'PlutusV2` instance to `BabbageEra`
+* Fix an issue where `TotalDeposits` didn't appear on Babbage era
 
 ## 1.2.0.0
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -41,6 +41,7 @@ import Cardano.Ledger.Babbage.Era (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, strictMaybeToMaybe, systemStart)
 import Cardano.Ledger.Binary (EncCBOR (..))
+import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
   UTxOState (..),
@@ -168,6 +169,7 @@ scriptsYes = do
       {- depositChange := (totalDeposits pp poolParams txcerts txb) − refunded -}
       protVer = pp ^. ppProtocolVersionL
       depositChange = totalTxDeposits pp dpstate txBody <-> refunded
+  tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
 


### PR DESCRIPTION
# Description

`TotalDeposits` appeared as event only during the Shelley era, since next eras have a different `Event (EraRule "UTXO")` instance. This pr makes sure the event appears during all eras.

Would it be possible to have new releases with this? I've updated the Changelogs assuming that.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
