### PR TITLE
Fixup release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,17 @@
 # Description
 
-Add your description here, if it fixes a particular issue please provide a
+<!-- Add your description here, if it fixes a particular issue please provide a
 [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
-to the issue.
+to the issue. -->
 
 # Checklist
 
 - [ ] Commit sequence broadly makes sense and commits have useful messages
 - [ ] New tests are added if needed and existing tests are updated
-- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
-- [ ] The version bounds in `.cabal` files are updated
+- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
+      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
+- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
+- [ ] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
 - [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
 - [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
 - [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+**THIS CHANGELOG HAS BEEN DEPRECATED**
+
 We have adopted per-Haskell-package changelogs. Please see the `CHANGELOG.md` for each
 individual package for any notable changes.
+
+See the [REALEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd) for an up-to-date information about Releasing and Versioning Process.
 
 Below was the last `cardano-ledger` repository branch based release and we now have fully
 switched to [CHaPs](https://github.com/input-output-hk/cardano-haskell-packages).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -208,14 +208,19 @@ diverged from a version on `master` significantly enough to make it impossible f
 version to be released from `master`. In other words a patch backporting. In such a
 scenario a few steps should be followed:
 
-1. A branch with a prefix `release/` need to be created from a tag of a package version
-   that is being updated. For example if a current version on `master` is
-   `cardano-ledger-core-1.22.10.0` then the latest `cardano-ledger-core-1.21.x` should be
-   used as base:
+1. Two ephemeral branches with a prefix `release/` need to be created. Both should branch
+   of from a tag of a package version that is being updated. For example if a current
+   version on `master` is `cardano-ledger-core-1.22.10.0` then the latest
+   `cardano-ledger-core-1.21.x` should be used as base:
 
    ```shell
+   $ git checkout -b release/cardano-ledger-core-1.21.2.1 cardano-ledger-core-1.21.2.1
+   $ git push -u origin release/cardano-ledger-core-1.21.2.1
    $ git checkout -b release/cardano-ledger-core-1.21.3.0 cardano-ledger-core-1.21.2.1
    ```
+
+   We'll need the first branch in order to use it as base when creating a PR for code
+   review.
 
 2. Changes that need to be released should be `cherry-pick`ed from master. If a fix on
    `master` was implemented in some incompatible fashion to the current release, then it
@@ -225,8 +230,8 @@ scenario a few steps should be followed:
 
 3. Regular release process should follow from here.
 
-4. Once the package has been released and a git tag for that release was created, the
-   `release/` branch can be removed.
+4. Once the package has been released and a git tag for that release was created, both of
+   the `release/` branches can be removed.
 
 This process does not accommodate backporting fixes to versions that are at least two major
 versions behind the one on `master`.


### PR DESCRIPTION
# Description

Minor improvements to the versioning and releasing documentation.

* Creating a patch release was not properly documented, in particular how to create a PR and which base branch to use was not mentioned.
* Per Sam's request, top level `CHANGELOG.md` now gets a deprecation notice
* PR template now has more information, to avoid common mistakes for outside contributors.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated~
- [ ] ~Any changes are noted in the `CHANGELOG.md` for affected package~
- [ ] ~The version bounds in `.cabal` files are updated~
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
