### PR TITLE
update chaps index

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,11 +15,11 @@ repository cardano-haskell-packages
 -- NOTE: repeating the index-state for Hackage is a temporary workaround
 -- for hackage.nix limited parsing ability.
 -- Bump both the following dates if you need newer packages from Hackage
-index-state: 2023-02-22T00:00:00Z
+index-state: 2023-04-28T00:00:00Z
 index-state:
-  , hackage.haskell.org 2023-02-22T00:00:00Z
+  , hackage.haskell.org 2023-04-28T00:00:00Z
 -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-04-17T14:00:00Z
+  , cardano-haskell-packages 2023-04-27T14:03:58Z
 
 packages:
   eras/allegra/impl

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-protocol-tpraos
-version:       1.0.1.0
+version:       1.0.2.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -77,7 +77,7 @@ library testlib
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-shelley:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-crypto-class,
+        cardano-crypto-class >=2.1.1,
         cardano-strict-containers,
         generic-random,
         nothunks

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-protocol-tpraos
-version:       1.0.2.0
+version:       1.0.3.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/cardano-haskell-packages/",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "63eaf65d25c6453e80e20401d34892bb03e7ae99",
-        "sha256": "1wvnvx7vjw59v7nbyr9q43fbgl1qd28rsxl094lq5pz368v4wyb1",
+        "rev": "1295457ef1efe31bcc756b65bb048d4814f0c9fd",
+        "sha256": "00lhrrv4qv2ra78skxrn65nwkv82g0fdvbmvyl0c05c5839pg57b",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/63eaf65d25c6453e80e20401d34892bb03e7ae99.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/1295457ef1efe31bcc756b65bb048d4814f0c9fd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hackage.nix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f3793d3d9fa159d0f3a652fc4a50b65ed0e86c27",
-        "sha256": "1sv9z7xh401qr6srj5c2hhcchmbi38ddxa177j4jcg2qi3qa00c8",
+        "rev": "62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56",
+        "sha256": "0vqvsqg96b4wcr0wisbllyzg1ra7pvmr3vc1c6i4bsf03vl42h45",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/f3793d3d9fa159d0f3a652fc4a50b65ed0e86c27.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "b3c99d7f13df89a9a918c835ecb7114098912962"
     },


### PR DESCRIPTION
# Description

This PR backports  #3410 (updating CHaPs) so that I can cut a release in ledger for the Plutus V3 support.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
