### PR TITLE
Rename ShelleyDelegCerts constructors

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -166,8 +166,8 @@ addOnlyCwitness ::
   [(ScriptPurpose era, ScriptHash (EraCrypto era))] ->
   TxCert era ->
   [(ScriptPurpose era, ScriptHash (EraCrypto era))]
-addOnlyCwitness !ans (ShelleyTxCertDeleg c@(DeRegKey (ScriptHashObj hk))) =
+addOnlyCwitness !ans (ShelleyTxCertDeleg c@(ShelleyUnRegCert (ScriptHashObj hk))) =
   (Certifying $ ShelleyTxCertDeleg c, hk) : ans
-addOnlyCwitness !ans (ShelleyTxCertDeleg c@(Delegate (Delegation (ScriptHashObj hk) _dpool))) =
+addOnlyCwitness !ans (ShelleyTxCertDeleg c@(ShelleyDelegCert (ScriptHashObj hk) _dpool)) =
   (Certifying $ ShelleyTxCertDeleg c, hk) : ans
 addOnlyCwitness !ans _ = ans

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -196,10 +196,9 @@ instance (Era era, Val (Value era)) => EncCBOR (ConwayTxCert era) where
 encodeConwayDelegCert :: Crypto c => ConwayDelegCert c -> Encoding
 encodeConwayDelegCert = \case
   -- Shelley backwards compatibility
-  ConwayRegCert cred SNothing -> encodeShelleyDelegCert $ RegKey cred
-  ConwayUnRegCert cred SNothing -> encodeShelleyDelegCert $ DeRegKey cred
-  ConwayDelegCert cred (DelegStake poolId) ->
-    encodeShelleyDelegCert $ Delegate (Delegation cred poolId)
+  ConwayRegCert cred SNothing -> encodeShelleyDelegCert $ ShelleyRegCert cred
+  ConwayUnRegCert cred SNothing -> encodeShelleyDelegCert $ ShelleyUnRegCert cred
+  ConwayDelegCert cred (DelegStake poolId) -> encodeShelleyDelegCert $ ShelleyDelegCert cred poolId
   -- New in Conway
   ConwayRegCert cred (SJust deposit) ->
     encodeListLen 3
@@ -244,13 +243,13 @@ encodeConwayDelegCert = \case
 
 fromShelleyDelegCert :: ShelleyDelegCert c -> ConwayDelegCert c
 fromShelleyDelegCert = \case
-  RegKey c -> ConwayRegCert c SNothing
-  DeRegKey c -> ConwayUnRegCert c SNothing
-  Delegate (Delegation c kh) -> ConwayDelegCert c (DelegStake kh)
+  ShelleyRegCert cred -> ConwayRegCert cred SNothing
+  ShelleyUnRegCert cred -> ConwayUnRegCert cred SNothing
+  ShelleyDelegCert cred poolId -> ConwayDelegCert cred (DelegStake poolId)
 
 toShelleyDelegCert :: ConwayDelegCert c -> Maybe (ShelleyDelegCert c)
 toShelleyDelegCert = \case
-  ConwayRegCert c SNothing -> Just $ RegKey c
-  ConwayUnRegCert c SNothing -> Just $ DeRegKey c
-  ConwayDelegCert c (DelegStake kh) -> Just $ Delegate (Delegation c kh)
+  ConwayRegCert cred SNothing -> Just $ ShelleyRegCert cred
+  ConwayUnRegCert cred SNothing -> Just $ ShelleyUnRegCert cred
+  ConwayDelegCert cred (DelegStake poolId) -> Just $ ShelleyDelegCert cred poolId
   _ -> Nothing

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -242,7 +242,7 @@ goldenEncodingTestsAllegra =
     , -- "full_txn_body"
       let tin = mkTxInPartial genesisId 1
           tout = ShelleyTxOut @Allegra testAddrE (Coin 2)
-          reg = ShelleyTxCertDeleg (RegKey testStakeCred)
+          reg = ShelleyTxCertDeleg (ShelleyRegCert testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
           mdh = hashTxAuxData @Allegra $ AllegraTxAuxData Map.empty StrictSeq.empty
@@ -396,7 +396,7 @@ goldenEncodingTestsMary =
     , -- "full_txn_body"
       let tin = mkTxInPartial genesisId 1
           tout = ShelleyTxOut @Mary testAddrE (Val.inject $ Coin 2)
-          reg = ShelleyTxCertDeleg (RegKey testStakeCred)
+          reg = ShelleyTxCertDeleg (ShelleyRegCert testStakeCred)
           ras = Map.singleton (RewardAcnt Testnet (KeyHashObj testKeyHash)) (Coin 123)
           up = testUpdate
           mdh = hashTxAuxData @Allegra $ AllegraTxAuxData Map.empty StrictSeq.empty

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -7,7 +7,7 @@
   `Cardano.Ledger.Shelley.Delegation.PoolParams` modules
 * Added `Cardano.Ledger.Shelley.TxCert` module
 * Make `DCert` parameterized on `era` instead of `c`rypto and rename it as `ShelleyTxCert`:
-  * `DCertDelegCert` -> `ShelleyTxCertDelegCert`
+  * `DCertDelegCert` -> `ShelleyTxCertDeleg`
   * `DCertPool` -> `ShelleyTxCertPool`
   * `DCertGenesis` -> `ShelleyTxCertGenesis`
   * `DCertMir` -> `ShelleyTxCertMir`
@@ -18,6 +18,10 @@
 * Remove `certsTxBodyL` and `certsTxBodyG` from `ShelleyEraTxBody`. Former migrated to `EraTxBody`.
 * Add helper functions `shelleyTxCertDelegDecoder`, `commonTxCertDecoder`, `encodeShelleyDelegCert`,
   `encodePoolCert` and `encodeConstitutionalCert`
+* Deprecate:
+  * `RegKey` in favor of `ShelleyRegCert`
+  * `DeRegKey` in favor of `ShelleyUnRegCert`
+  * `Delegate` in favor of `ShelleyDelegCert`
 
 ## 1.2.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
@@ -107,11 +107,11 @@ keyCertsRefunds pp lookupDeposit certs = snd (foldl' accum (mempty, Coin 0) cert
   where
     keyDeposit = pp ^. ppKeyDepositL
     accum (!regKeys, !totalRefunds) = \case
-      ShelleyTxCertDeleg (RegKey k) ->
+      ShelleyTxCertDeleg (ShelleyRegCert k) ->
         -- Need to track new delegations in case that the same key is later deregistered in
         -- the same transaction.
         (Set.insert k regKeys, totalRefunds)
-      ShelleyTxCertDeleg (DeRegKey k)
+      ShelleyTxCertDeleg (ShelleyUnRegCert k)
         -- We first check if there was already a registration certificate in this
         -- transaction.
         | Set.member k regKeys -> (Set.delete k regKeys, totalRefunds <+> keyDeposit)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -262,7 +262,7 @@ delegationTransition = do
   TRC (DelegEnv slot ptr acnt pp, ds, c) <- judgmentContext
   let pv = pp ^. ppProtocolVersionL
   case c of
-    ShelleyTxCertDeleg (RegKey hk) -> do
+    ShelleyTxCertDeleg (ShelleyRegCert hk) -> do
       -- (hk ∉ dom (rewards ds))
       UM.notMember hk (rewards ds) ?! StakeKeyAlreadyRegisteredDELEG hk
       let u1 = dsUnified ds
@@ -270,7 +270,7 @@ delegationTransition = do
           u2 = RewardDeposits u1 UM.∪ (hk, RDPair (UM.CompactCoin 0) deposit)
           u3 = Ptrs u2 UM.∪ (ptr, hk)
       pure (ds {dsUnified = u3})
-    ShelleyTxCertDeleg (DeRegKey hk) -> do
+    ShelleyTxCertDeleg (ShelleyUnRegCert hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
       -- (hk ∈ dom (rewards ds))
       UM.member hk (rewards ds) ?! StakeKeyNotRegisteredDELEG hk
@@ -283,7 +283,7 @@ delegationTransition = do
           u3 = Ptrs u2 UM.⋫ Set.singleton hk
           u4 = ds {dsUnified = u3}
       pure u4
-    ShelleyTxCertDeleg (Delegate (Delegation hk dpool)) -> do
+    ShelleyTxCertDeleg (ShelleyDelegCert hk dpool) -> do
       -- note that pattern match is used instead of cwitness and dpool, as in the spec
       -- (hk ∈ dom (rewards ds))
       UM.member hk (rewards ds) ?! StakeDelegationImpossibleDELEG hk

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -243,9 +243,8 @@ validateDelegationRegistered ::
   TxCert era ->
   Test (KeyHash 'StakePool (EraCrypto era))
 validateDelegationRegistered certState = \case
-  ShelleyTxCertDeleg (Delegate deleg) ->
+  ShelleyTxCertDeleg (ShelleyDelegCert _ targetPool) ->
     let stPools = psStakePoolParams $ certPState certState
-        targetPool = dDelegatee deleg
      in failureUnless (eval (targetPool ∈ dom stPools)) targetPool
   _ -> pure ()
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.Rules.Deleg (DelegEnv (..), ShelleyDELEG, ShelleyDelegPredFailure)
 import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL, ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.TxBody (Ptr)
-import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Slot (SlotNo)
 import Control.DeepSeq
 import Control.State.Transition
@@ -183,15 +183,7 @@ delplTransition = do
       ds <-
         trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}
-    ShelleyTxCertDelegCert (RegKey _) -> do
-      ds <-
-        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
-      pure $ d {certDState = ds}
-    ShelleyTxCertDelegCert (DeRegKey _) -> do
-      ds <-
-        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
-      pure $ d {certDState = ds}
-    ShelleyTxCertDelegCert (Delegate _) -> do
+    ShelleyTxCertDelegCert _ -> do
       ds <-
         trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Reports.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Reports.hs
@@ -50,9 +50,9 @@ showCred (KeyHashObj (KeyHash x)) = show x
 
 synopsisCert :: ShelleyEraTxCert era => TxCert era -> String
 synopsisCert x = case x of
-  ShelleyTxCertDeleg (RegKey cred) -> "RegKey " ++ take 10 (showCred cred)
-  ShelleyTxCertDeleg (DeRegKey cred) -> "DeRegKey " ++ take 10 (showCred cred)
-  ShelleyTxCertDeleg (Delegate _) -> "Delegation"
+  ShelleyTxCertDeleg (ShelleyRegCert cred) -> "ShelleyRegCert " ++ take 10 (showCred cred)
+  ShelleyTxCertDeleg (ShelleyUnRegCert cred) -> "ShelleyUnRegCert " ++ take 10 (showCred cred)
+  ShelleyTxCertDeleg (ShelleyDelegCert cred _) -> "ShelleyDelegCert" ++ take 10 (showCred cred)
   TxCertPool (RegPool pool) -> let KeyHash hash = ppId pool in "RegPool " ++ take 10 (show hash)
   TxCertPool (RetirePool khash e) -> "RetirePool " ++ showKeyHash khash ++ " " ++ show e
   TxCertGenesis _ -> "GenesisCert"

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -67,11 +68,13 @@ scriptStakeCred ::
   ShelleyEraTxCert era =>
   TxCert era ->
   Maybe (ScriptHash (EraCrypto era))
-scriptStakeCred (ShelleyTxCertDeleg (DeRegKey (KeyHashObj _))) = Nothing
-scriptStakeCred (ShelleyTxCertDeleg (DeRegKey (ScriptHashObj hs))) = Just hs
-scriptStakeCred (ShelleyTxCertDeleg (Delegate (Delegation (KeyHashObj _) _))) = Nothing
-scriptStakeCred (ShelleyTxCertDeleg (Delegate (Delegation (ScriptHashObj hs) _))) = Just hs
-scriptStakeCred _ = Nothing
+scriptStakeCred = \case
+  ShelleyTxCertDeleg delegCert ->
+    case delegCert of
+      ShelleyRegCert _ -> Nothing
+      ShelleyUnRegCert cred -> scriptCred cred
+      ShelleyDelegCert cred _ -> scriptCred cred
+  _ -> Nothing
 
 scriptCred :: Credential kr c -> Maybe (ScriptHash c)
 scriptCred (KeyHashObj _) = Nothing

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -10,7 +10,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+-- Due to Delegation usage
+{-# OPTIONS_GHC -Wno-orphans -Wno-deprecations #-}
 
 module Test.Cardano.Ledger.Shelley.Arbitrary (
   collectionDatumMaxSize,

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
@@ -16,11 +16,11 @@ data Constants = Constants
   -- ^ minimal number of transaction inputs to select
   , maxNumGenInputs :: Int
   -- ^ maximal number of transaction inputs to select
-  , frequencyRegKeyCert :: Int
+  , frequencyRegCert :: Int
   -- ^ Relative frequency of generated credential registration certificates
   , frequencyRegPoolCert :: Int
   -- ^ Relative frequency of generated pool registration certificates
-  , frequencyDelegationCert :: Int
+  , frequencyDelegCert :: Int
   -- ^ Relative frequency of generated delegation certificates
   , frequencyGenesisDelegationCert :: Int
   -- ^ Relative frequency of generated genesis delegation certificates
@@ -108,9 +108,9 @@ defaultConstants =
   Constants
     { minNumGenInputs = 1
     , maxNumGenInputs = 5
-    , frequencyRegKeyCert = 2
+    , frequencyRegCert = 2
     , frequencyRegPoolCert = 2
-    , frequencyDelegationCert = 3
+    , frequencyDelegCert = 3
     , frequencyGenesisDelegationCert = 1
     , frequencyDeRegKeyCert = 1
     , frequencyRetirePoolCert = 1

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -234,7 +234,7 @@ firstStakeKeyCred = stakeKeyToCred stakeKeyOne
 stakeKeyRegistrations :: [KeyPair 'Staking B_Crypto] -> StrictSeq (TxCert B)
 stakeKeyRegistrations keys =
   StrictSeq.fromList $
-    fmap (ShelleyTxCertDeleg . RegKey . (KeyHashObj . hashKey . vKey)) keys
+    fmap (ShelleyTxCertDeleg . ShelleyRegCert . KeyHashObj . hashKey . vKey) keys
 
 -- Create a transaction body given a sequence of certificates.
 -- It spends the genesis coin given by the index ix.
@@ -311,7 +311,7 @@ txbDeRegStakeKey x y =
     (Set.fromList [mkTxInPartial genesisId 1])
     (StrictSeq.fromList [ShelleyTxOut aliceAddr (inject $ Coin 100)])
     ( StrictSeq.fromList $
-        fmap (ShelleyTxCertDeleg . DeRegKey . stakeKeyToCred) (stakeKeys x y)
+        fmap (ShelleyTxCertDeleg . ShelleyUnRegCert . stakeKeyToCred) (stakeKeys x y)
     )
     (Withdrawals Map.empty)
     (Coin 0)
@@ -515,7 +515,7 @@ txbDelegate n m =
     (StrictSeq.fromList [ShelleyTxOut aliceAddr (inject $ Coin 100)])
     ( StrictSeq.fromList $
         fmap
-          (\ks -> ShelleyTxCertDeleg $ Delegate (Delegation (stakeKeyToCred ks) firstStakePoolKeyHash))
+          (\ks -> ShelleyTxCertDeleg $ ShelleyDelegCert (stakeKeyToCred ks) firstStakePoolKeyHash)
           (stakeKeys n m)
     )
     (Withdrawals Map.empty)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -470,7 +470,7 @@ exampleTxIns =
 exampleCerts :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => StrictSeq (TxCert era)
 exampleCerts =
   StrictSeq.fromList
-    [ ShelleyTxCertDeleg (RegKey (keyToCredential exampleStakeKey))
+    [ ShelleyTxCertDeleg (ShelleyRegCert (keyToCredential exampleStakeKey))
     , TxCertPool (RegPool examplePoolParams)
     , TxCertMir $
         MIRCert ReservesMIR $

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Constants.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Constants.hs
@@ -1,4 +1,5 @@
-module Test.Cardano.Ledger.Shelley.Generator.Constants (
+module Test.Cardano.Ledger.Shelley.Generator.Constants
+  {-# DEPRECATED "Use `Test.Cardano.Ledger.Shelley.Constants` instead" #-} (
   Constants (..),
   defaultConstants,
 ) where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -230,9 +230,9 @@ scriptCredentialCertsRatio certs =
       length $
         filter
           ( \case
-              ShelleyTxCertDeleg (RegKey (ScriptHashObj _)) -> True
-              ShelleyTxCertDeleg (DeRegKey (ScriptHashObj _)) -> True
-              ShelleyTxCertDeleg (Delegate (Delegation (ScriptHashObj _) _)) -> True
+              ShelleyTxCertDeleg (ShelleyRegCert (ScriptHashObj _)) -> True
+              ShelleyTxCertDeleg (ShelleyUnRegCert (ScriptHashObj _)) -> True
+              ShelleyTxCertDeleg (ShelleyDelegCert (ScriptHashObj _) _) -> True
               _ -> False
           )
           certs

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -143,7 +143,7 @@ txbodyEx1 pot =
     (StrictSeq.singleton $ ShelleyTxOut Cast.aliceAddr aliceCoinEx1)
     ( StrictSeq.fromList
         [ ShelleyTxCertMir (MIRCert pot ir)
-        , ShelleyTxCertDeleg (RegKey Cast.aliceSHK)
+        , ShelleyTxCertDeleg (ShelleyRegCert Cast.aliceSHK)
         ]
     )
     (Withdrawals Map.empty)
@@ -153,7 +153,7 @@ txbodyEx1 pot =
     SNothing
   where
     aliceInitCoin = Val.inject $ Coin $ 10 * 1000 * 1000 * 1000 * 1000 * 1000
-    aliceCoinEx1 = aliceInitCoin <-> (Val.inject $ feeTx1 <+> Coin 7)
+    aliceCoinEx1 = aliceInitCoin <-> Val.inject (feeTx1 <+> Coin 7)
 
 mirWits :: Crypto c => [Int] -> [KeyPair 'Witness c]
 mirWits = map (asWitness . aikCold . coreNodeIssuerKeys)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -176,7 +176,7 @@ initStPoolLifetime = initSt initUTxO
 aliceCoinEx1 :: Coin
 aliceCoinEx1 =
   aliceInitCoin
-    <-> (Coin 250)
+    <-> Coin 250
     <-> ((3 :: Integer) <×> Coin 7)
     <-> Coin 3
 
@@ -195,9 +195,9 @@ txbodyEx1 =
     (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.fromList [ShelleyTxOut Cast.aliceAddr (Val.inject aliceCoinEx1)])
     ( StrictSeq.fromList
-        ( [ ShelleyTxCertDeleg (RegKey Cast.aliceSHK)
-          , ShelleyTxCertDeleg (RegKey Cast.bobSHK)
-          , ShelleyTxCertDeleg (RegKey Cast.carlSHK)
+        ( [ ShelleyTxCertDeleg (ShelleyRegCert Cast.aliceSHK)
+          , ShelleyTxCertDeleg (ShelleyRegCert Cast.bobSHK)
+          , ShelleyTxCertDeleg (ShelleyRegCert Cast.carlSHK)
           , TxCertPool (RegPool Cast.alicePoolParams)
           ]
             ++ [ ShelleyTxCertMir
@@ -306,8 +306,8 @@ txbodyEx2 =
           ]
     , stbCerts =
         StrictSeq.fromList
-          [ ShelleyTxCertDeleg (Delegate $ Delegation Cast.aliceSHK (aikColdKeyHash Cast.alicePoolKeys))
-          , ShelleyTxCertDeleg (Delegate $ Delegation Cast.bobSHK (aikColdKeyHash Cast.alicePoolKeys))
+          [ ShelleyTxCertDeleg (ShelleyDelegCert Cast.aliceSHK (aikColdKeyHash Cast.alicePoolKeys))
+          , ShelleyTxCertDeleg (ShelleyDelegCert Cast.bobSHK (aikColdKeyHash Cast.alicePoolKeys))
           ]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = feeTx2
@@ -473,7 +473,7 @@ txbodyEx4 =
     , stbOutputs = StrictSeq.fromList [ShelleyTxOut Cast.aliceAddr (Val.inject aliceCoinEx4Base)]
     , stbCerts =
         StrictSeq.fromList
-          [ShelleyTxCertDeleg (Delegate $ Delegation Cast.carlSHK (aikColdKeyHash Cast.alicePoolKeys))]
+          [ShelleyTxCertDeleg (ShelleyDelegCert Cast.carlSHK (aikColdKeyHash Cast.alicePoolKeys))]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = feeTx4
     , stbTTL = SlotNo 500
@@ -865,7 +865,7 @@ txbodyEx10 =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 1])
     (StrictSeq.singleton $ ShelleyTxOut Cast.bobAddr (Val.inject bobAda10))
-    (StrictSeq.fromList [ShelleyTxCertDeleg (DeRegKey Cast.bobSHK)])
+    (StrictSeq.fromList [ShelleyTxCertDeleg (ShelleyUnRegCert Cast.bobSHK)])
     (Withdrawals $ Map.singleton (RewardAcnt Testnet Cast.bobSHK) bobRAcnt8)
     feeTx10
     (SlotNo 500)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -238,7 +238,7 @@ txbRegisterStake =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
     , stbOutputs = StrictSeq.fromList [ShelleyTxOut aliceAddr (Val.inject $ Coin 10)]
-    , stbCerts = StrictSeq.fromList [ShelleyTxCertDeleg (RegKey aliceSHK)]
+    , stbCerts = StrictSeq.fromList [ShelleyTxCertDeleg (ShelleyRegCert aliceSHK)]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = Coin 94
     , stbTTL = SlotNo 10
@@ -269,7 +269,7 @@ txbDelegateStake =
     , stbCerts =
         StrictSeq.fromList
           [ ShelleyTxCertDeleg
-              (Delegate $ Delegation bobSHK alicePoolKH)
+              (ShelleyDelegCert bobSHK alicePoolKH)
           ]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = Coin 94
@@ -301,7 +301,7 @@ txbDeregisterStake =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
     , stbOutputs = StrictSeq.fromList [ShelleyTxOut aliceAddr (Val.inject $ Coin 10)]
-    , stbCerts = StrictSeq.fromList [ShelleyTxCertDeleg (DeRegKey aliceSHK)]
+    , stbCerts = StrictSeq.fromList [ShelleyTxCertDeleg (ShelleyUnRegCert aliceSHK)]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = Coin 94
     , stbTTL = SlotNo 10

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -521,7 +521,7 @@ tests =
     , checkEncodingCBOR
         shelleyProtVer
         "register_stake_reference"
-        (ShelleyTxCertDeleg @C (RegKey (testStakeCred @C_Crypto)))
+        (ShelleyTxCertDeleg @C (ShelleyRegCert (testStakeCred @C_Crypto)))
         ( T (TkListLen 2)
             <> T (TkWord 0) -- Reg cert
             <> S (testStakeCred @C_Crypto) -- keyhash
@@ -529,7 +529,7 @@ tests =
     , checkEncodingCBOR
         shelleyProtVer
         "deregister_stake_reference"
-        (ShelleyTxCertDeleg @C (DeRegKey (testStakeCred @C_Crypto)))
+        (ShelleyTxCertDeleg @C (ShelleyUnRegCert (testStakeCred @C_Crypto)))
         ( T (TkListLen 2)
             <> T (TkWord 1) -- DeReg cert
             <> S (testStakeCred @C_Crypto) -- keyhash
@@ -537,7 +537,7 @@ tests =
     , checkEncodingCBOR
         shelleyProtVer
         "stake_delegation"
-        (ShelleyTxCertDeleg @C (Delegate (Delegation (testStakeCred @C_Crypto) (hashKey . vKey $ testStakePoolKey))))
+        (ShelleyTxCertDeleg @C (ShelleyDelegCert (testStakeCred @C_Crypto) (hashKey $ vKey testStakePoolKey)))
         ( T
             ( TkListLen 3
                 . TkWord 2 -- delegation cert with key
@@ -817,7 +817,7 @@ tests =
             )
     , -- checkEncodingCBOR "full_txn_body"
       let tout = ShelleyTxOut @C testAddrE (Coin 2)
-          reg = ShelleyTxCertDeleg (RegKey (testStakeCred @C_Crypto))
+          reg = ShelleyTxCertDeleg (ShelleyRegCert (testStakeCred @C_Crypto))
           ra = RewardAcnt Testnet (KeyHashObj testKeyHash2)
           ras = Map.singleton ra (Coin 123)
           up =

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -62,10 +62,10 @@ keyTxRefunds pp dpstate tx = snd (foldl' accum (initialKeys, Coin 0) certs)
     certs = tx ^. certsTxBodyL
     initialKeys = UM.RewardDeposits $ dsUnified $ certDState dpstate
     keyDeposit = UM.compactCoinOrError (pp ^. ppKeyDepositL)
-    accum (!keys, !ans) (ShelleyTxCertDeleg (RegKey k)) =
+    accum (!keys, !ans) (ShelleyTxCertDeleg (ShelleyRegCert k)) =
       -- Deposit is added locally to the growing 'keys'
       (UM.RewardDeposits $ UM.insert k (UM.RDPair mempty keyDeposit) keys, ans)
-    accum (!keys, !ans) (ShelleyTxCertDeleg (DeRegKey k)) =
+    accum (!keys, !ans) (ShelleyTxCertDeleg (ShelleyUnRegCert k)) =
       -- If the key is registered, lookup the deposit in the locally growing 'keys'
       -- if it is not registered, then just return ans
       case UM.lookup k keys of
@@ -109,7 +109,7 @@ genTxBodyFrom CertState {certDState, certPState} (UTxO u) = do
   certs <-
     shuffle $
       toList (txBody ^. certsTxBodyL)
-        <> (ShelleyTxCertDeleg . DeRegKey <$> unDelegCreds)
+        <> (ShelleyTxCertDeleg . ShelleyUnRegCert <$> unDelegCreds)
         <> (TxCertPool . RegPool <$> deRegKeys)
   pure
     ( txBody

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `certsTxBodyL` to `EraTxBody`
 * Introduce `TxCert` type family and `EraTxCert` type class.
+* Deprecate `Delegation`
 
 ## 1.2.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -77,6 +77,7 @@ data Delegation c = Delegation
   , dDelegatee :: !(KeyHash 'StakePool c)
   }
   deriving (Eq, Generic, Show)
+{-# DEPRECATED Delegation "No longer used" #-}
 
 instance NFData (Delegation c) where
   rnf = rwhnf

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- Due to usage of Delegation
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Pretty where
 
@@ -1099,10 +1101,11 @@ ppTxOut (ShelleyTxOut addr val) =
     , prettyA val
     ]
 
-ppDelegCert :: ShelleyDelegCert c -> PDoc
-ppDelegCert (RegKey x) = ppSexp "RegKey" [ppCredential x]
-ppDelegCert (DeRegKey x) = ppSexp "DeRegKey" [ppCredential x]
-ppDelegCert (Delegate x) = ppSexp "Delegate" [ppDelegation x]
+ppShelleyDelegCert :: ShelleyDelegCert c -> PDoc
+ppShelleyDelegCert (ShelleyRegCert cred) = ppSexp "ShelleyRegCert" [ppCredential cred]
+ppShelleyDelegCert (ShelleyUnRegCert cred) = ppSexp "ShelleyUnRegCert" [ppCredential cred]
+ppShelleyDelegCert (ShelleyDelegCert cred poolId) =
+  ppSexp "ShelleyDelegCert" [ppCredential cred, ppKeyHash poolId]
 
 ppPoolCert :: PoolCert c -> PDoc
 ppPoolCert (RegPool x) = ppSexp "RegPool" [ppPoolParams x]
@@ -1123,7 +1126,7 @@ ppMIRCert :: MIRCert c -> PDoc
 ppMIRCert (MIRCert pot vs) = ppSexp "MirCert" [ppMIRPot pot, ppMIRTarget vs]
 
 ppShelleyTxCert :: ShelleyTxCert c -> PDoc
-ppShelleyTxCert (ShelleyTxCertDelegCert x) = ppSexp "ShelleyTxCertDeleg" [ppDelegCert x]
+ppShelleyTxCert (ShelleyTxCertDelegCert x) = ppSexp "ShelleyTxCertDeleg" [ppShelleyDelegCert x]
 ppShelleyTxCert (ShelleyTxCertPool x) = ppSexp "TxCertPool" [ppPoolCert x]
 ppShelleyTxCert (ShelleyTxCertGenesis x) = ppSexp "TxCertGenesis" [ppConstitutionalDelegCert x]
 ppShelleyTxCert (ShelleyTxCertMir x) = ppSexp "TxCertMir" [ppMIRCert x]
@@ -1182,7 +1185,7 @@ instance
   prettyA = ppTxOut
 
 instance PrettyA (ShelleyDelegCert c) where
-  prettyA = ppDelegCert
+  prettyA = ppShelleyDelegCert
 
 instance PrettyA (PoolCert c) where
   prettyA = ppPoolCert

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -50,7 +50,7 @@ import Test.Cardano.Ledger.Generic.Proof (
   ShelleyEra,
   unReflect,
  )
-import Test.Cardano.Ledger.Shelley.Generator.Constants (defaultConstants)
+import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Update (genShelleyPParamsUpdate)
 import Test.QuickCheck (
   Arbitrary (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -17,9 +17,7 @@ module Test.Cardano.Ledger.Examples.AlonzoBBODY (tests) where
 import Cardano.Crypto.Hash.Class (sizeHash)
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Language (Language (..))
-import Cardano.Ledger.Alonzo.Rules (
-  AlonzoBbodyPredFailure (..),
- )
+import Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), hashData)
@@ -414,7 +412,7 @@ validatingBodyWithCert pf =
     [ Inputs' [mkGenesisTxIn 3]
     , Collateral' [mkGenesisTxIn 13]
     , Outputs' [validatingTxWithCertOut pf]
-    , Certs' [ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)]
+    , Certs' [ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)]
     , Txfee (Coin 5)
     , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingRedeemrsWithCert mempty)
     ]
@@ -458,7 +456,7 @@ notValidatingTxWithCert pf =
         [ Inputs' [mkGenesisTxIn 4]
         , Collateral' [mkGenesisTxIn 14]
         , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]]
-        , Certs' [ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredFail pf)]
+        , Certs' [ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredFail pf)]
         , Txfee (Coin 5)
         , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] notValidatingRedeemersWithCert mempty)
         ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -514,8 +514,8 @@ validatingManyScriptsBody pf =
     , Outputs' [txOut]
     , Txfee (Coin 5)
     , Certs'
-        [ ShelleyTxCertDeleg (DeRegKey $ timelockStakeCred pf)
-        , ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)
+        [ ShelleyTxCertDeleg (ShelleyUnRegCert $ timelockStakeCred pf)
+        , ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)
         ]
     , Withdrawals'
         ( Withdrawals $
@@ -884,8 +884,8 @@ multipleEqualCertsInvalidTx pf =
         , Collateral' [mkGenesisTxIn 13]
         , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]]
         , Certs'
-            [ ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)
-            , ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf) -- not allowed by DELEG, but here is fine
+            [ ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)
+            , ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf) -- not allowed by DELEG, but here is fine
             ]
         , Txfee (Coin 5)
         , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -319,7 +319,7 @@ validatingWithCertBody pf =
     [ Inputs' [mkGenesisTxIn 3]
     , Collateral' [mkGenesisTxIn 13]
     , Outputs' [validatingWithCertTxOut pf]
-    , Certs' [ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)]
+    , Certs' [ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)]
     , Txfee (Coin 5)
     , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingWithCertRedeemers mempty)
     ]
@@ -374,7 +374,7 @@ notValidatingWithCertTx pf =
         [ Inputs' [mkGenesisTxIn 4]
         , Collateral' [mkGenesisTxIn 14]
         , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]]
-        , Certs' [ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredFail pf)]
+        , Certs' [ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredFail pf)]
         , Txfee (Coin 5)
         , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
         ]
@@ -651,8 +651,8 @@ validatingManyScriptsBody pf =
     , Outputs' [validatingManyScriptsTxOut pf]
     , Txfee (Coin 5)
     , Certs'
-        [ ShelleyTxCertDeleg (DeRegKey $ timelockStakeCred pf)
-        , ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)
+        [ ShelleyTxCertDeleg (ShelleyUnRegCert $ timelockStakeCred pf)
+        , ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)
         ]
     , Withdrawals'
         ( Withdrawals $
@@ -784,8 +784,8 @@ validatingMultipleEqualCertsBody pf =
     , Collateral' [mkGenesisTxIn 13]
     , Outputs' [validatingMultipleEqualCertsOut pf]
     , Certs'
-        [ ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf)
-        , ShelleyTxCertDeleg (DeRegKey $ scriptStakeCredSuceed pf) -- not allowed by DELEG, but here is fine
+        [ ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf)
+        , ShelleyTxCertDeleg (ShelleyUnRegCert $ scriptStakeCredSuceed pf) -- not allowed by DELEG, but here is fine
         ]
     , Txfee (Coin 5)
     , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] validatingMultipleEqualCertsRedeemers mempty)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -520,7 +520,10 @@ refscriptForDelegCert pf =
           , RefInputs' [anotherTxIn]
           , Collateral' [yetAnotherTxIn]
           , Outputs' [newTxOut pf [Address (plainAddr pf), Amount (inject $ Coin 1135)]]
-          , Certs' [ShelleyTxCertDeleg (DeRegKey (ScriptHashObj (hashScript @era $ alwaysAlt 2 pf)))]
+          , Certs'
+              [ ShelleyTxCertDeleg $
+                  ShelleyUnRegCert (ScriptHashObj (hashScript @era $ alwaysAlt 2 pf))
+              ]
           , Txfee (Coin 5)
           , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV2] certRedeemers mempty)
           ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -130,8 +130,8 @@ depositsAndRefunds ::
   Coin
 depositsAndRefunds pp certificates keydeposits = List.foldl' accum (Coin 0) certificates
   where
-    accum ans (ShelleyTxCertDeleg (RegKey _)) = pp ^. ppKeyDepositL <+> ans
-    accum ans (ShelleyTxCertDeleg (DeRegKey hk)) =
+    accum ans (ShelleyTxCertDeleg (ShelleyRegCert _)) = pp ^. ppKeyDepositL <+> ans
+    accum ans (ShelleyTxCertDeleg (ShelleyUnRegCert hk)) =
       case Map.lookup hk keydeposits of
         Nothing -> ans
         Just c -> ans <-> c

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1384,9 +1384,9 @@ pcPoolParams x =
 instance PrettyC (PoolParams era) era where prettyC _ = pcPoolParams
 
 pcDelegCert :: ShelleyDelegCert c -> PDoc
-pcDelegCert (RegKey cred) = ppSexp "RegKey" [pcCredential cred]
-pcDelegCert (DeRegKey cred) = ppSexp "DeRegKey" [pcCredential cred]
-pcDelegCert (Delegate (Delegation x y)) = ppSexp "Delegate" [pcCredential x, pcKeyHash y]
+pcDelegCert (ShelleyRegCert cred) = ppSexp "ShelleyRegCert" [pcCredential cred]
+pcDelegCert (ShelleyUnRegCert cred) = ppSexp "ShelleyUnRegCert" [pcCredential cred]
+pcDelegCert (ShelleyDelegCert x y) = ppSexp "ShelleyDelegCert" [pcCredential x, pcKeyHash y]
 
 instance c ~ EraCrypto era => PrettyC (ShelleyDelegCert c) era where prettyC _ = pcDelegCert
 


### PR DESCRIPTION
# Description

Rename `ShelleyDelegCert` constructors so they:
* Match `ConwayDelegCerts` better
* Avoid misleading `Key` suffix, where it actually contains credential
* Deprecate `Delegation` type that brings nothing but mental overhead.

In summary. Deprecate:
  * `RegKey` in favor of `ShelleyRegCert`
  * `DeRegKey` in favor of `ShelleyUnRegCert`
  * `Delegate` in favor of `ShelleyDelegCert`
  * `Delegation`
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
