### PR TITLE
Improve witness needed logic

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
@@ -12,6 +12,10 @@ instance Crypto c => EraTxCert (AllegraEra c) where
 
   type TxCert (AllegraEra c) = ShelleyTxCert (AllegraEra c)
 
+  getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessShelleyTxCert
+
   mkTxCertPool = ShelleyTxCertPool
 
   getTxCertPool (ShelleyTxCertPool c) = Just c

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `EraPlutusContext`
 * Add `EraPlutusContext 'PlutusV1` instance to `AlonzoEra`
 * Rename `transTxCert` to `transShelleyTxCert`
+* Remove `witsVKeyNeeded`, in favor of the one from `cardano-ledger-shelley`
 
 ## 1.2.0.0
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
@@ -5,12 +5,16 @@ module Cardano.Ledger.Alonzo.TxCert () where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
-import Cardano.Ledger.Shelley.TxCert (EraTxCert (..), ShelleyEraTxCert (..), ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxCert
 
 instance Crypto c => EraTxCert (AlonzoEra c) where
   {-# SPECIALIZE instance EraTxCert (AlonzoEra StandardCrypto) #-}
 
   type TxCert (AlonzoEra c) = ShelleyTxCert (AlonzoEra c)
+
+  getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessShelleyTxCert
 
   mkTxCertPool = ShelleyTxCertPool
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Alonzo.Rules (
   missingRequiredDatums,
   ppViewHashesMatch,
   requiredSignersAreWitnessed,
-  witsVKeyNeeded,
  )
 import Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoUtxoEvent)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
@@ -317,7 +316,7 @@ babbageUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
-  runTest $ validateNeededWitnesses witsVKeyNeeded genDelegs utxo tx witsKeyHashes
+  runTest $ validateNeededWitnesses genDelegs utxo tx witsKeyHashes
   -- TODO can we add the required signers to witsVKeyNeeded so we dont need the check below?
 
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
@@ -12,6 +12,10 @@ instance Crypto c => EraTxCert (BabbageEra c) where
 
   type TxCert (BabbageEra c) = ShelleyTxCert (BabbageEra c)
 
+  getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessShelleyTxCert
+
   mkTxCertPool = ShelleyTxCertPool
 
   getTxCertPool (ShelleyTxCertPool c) = Just c

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Add `EraPlutusContext 'PlutusV3` instance to `ConwayEra`
 * Added `toShelleyDelegCert` and `fromShelleyDelegCert`
 * Changed `ConwayDelegCert` structure #3408
+* Addition of `getScriptWitnessConwayTxCert` and `getVKeyWitnessConwayTxCert`
+
 
 ## 1.2.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -15,6 +15,8 @@ module Cardano.Ledger.Conway.TxCert (
   ConwayEraTxCert (..),
   fromShelleyDelegCert,
   toShelleyDelegCert,
+  getScriptWitnessConwayTxCert,
+  getVKeyWitnessConwayTxCert,
 )
 where
 
@@ -35,7 +37,7 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Credential (Credential, StakeCredential)
+import Cardano.Ledger.Credential (Credential, StakeCredential, credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.TxCert (
@@ -54,6 +56,10 @@ import NoThunks.Class (NoThunks)
 
 instance Crypto c => EraTxCert (ConwayEra c) where
   type TxCert (ConwayEra c) = ConwayTxCert (ConwayEra c)
+
+  getVKeyWitnessTxCert = getVKeyWitnessConwayTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessConwayTxCert
 
   mkTxCertPool = ConwayTxCertPool
   getTxCertPool (ConwayTxCertPool x) = Just x
@@ -253,3 +259,27 @@ toShelleyDelegCert = \case
   ConwayUnRegCert cred SNothing -> Just $ ShelleyUnRegCert cred
   ConwayDelegCert cred (DelegStake poolId) -> Just $ ShelleyDelegCert cred poolId
   _ -> Nothing
+
+getScriptWitnessConwayTxCert ::
+  ConwayTxCert era ->
+  Maybe (ScriptHash (EraCrypto era))
+getScriptWitnessConwayTxCert = \case
+  ConwayTxCertDeleg delegCert ->
+    case delegCert of
+      ConwayRegCert _ _ -> Nothing
+      ConwayUnRegCert cred _ -> credScriptHash cred
+      ConwayDelegCert cred _ -> credScriptHash cred
+      ConwayRegDelegCert cred _ _ -> credScriptHash cred
+  _ -> Nothing
+
+getVKeyWitnessConwayTxCert :: ConwayTxCert era -> Maybe (KeyHash 'Witness (EraCrypto era))
+getVKeyWitnessConwayTxCert = \case
+  ConwayTxCertDeleg delegCert ->
+    case delegCert of
+      -- Registration certificates do not require a witness
+      ConwayRegCert _ _ -> Nothing
+      ConwayUnRegCert cred _ -> credKeyHashWitness cred
+      ConwayDelegCert cred _ -> credKeyHashWitness cred
+      ConwayRegDelegCert cred _ _ -> credKeyHashWitness cred
+  ConwayTxCertPool poolCert -> Just $ poolCertKeyHashWitness poolCert
+  ConwayTxCertConstitutional genesisCert -> Just $ genesisKeyHashWitness genesisCert

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
@@ -5,12 +5,22 @@ module Cardano.Ledger.Mary.TxCert () where
 
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
-import Cardano.Ledger.Shelley.TxCert (EraTxCert (..), ShelleyEraTxCert (..), ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxCert (
+  EraTxCert (..),
+  ShelleyEraTxCert (..),
+  ShelleyTxCert (..),
+  getScriptWitnessShelleyTxCert,
+  getVKeyWitnessShelleyTxCert,
+ )
 
 instance Crypto c => EraTxCert (MaryEra c) where
   {-# SPECIALIZE instance EraTxCert (MaryEra StandardCrypto) #-}
 
   type TxCert (MaryEra c) = ShelleyTxCert (MaryEra c)
+
+  getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessShelleyTxCert
 
   mkTxCertPool = ShelleyTxCertPool
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
   * `scriptStakeCred` in favor of `getScriptWitnessTxCert`
   * `requiresVKeyWitness` in favor of `getVKeyWitnessTxCert`
   * `delegCWitness`
+* `validateNeededWitnesses` no longer accepts `witsVKeyNeeded` as an argument.
 
 ## 1.2.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -22,6 +22,13 @@
   * `RegKey` in favor of `ShelleyRegCert`
   * `DeRegKey` in favor of `ShelleyUnRegCert`
   * `Delegate` in favor of `ShelleyDelegCert`
+* Addition of `getVKeyWitnessShelleyTxCert` and `getScriptWitnessShelleyTxCert`
+* Deprecate:
+  * `extractKeyHashWitnessSet` in favor of `credKeyHashWitness`
+  * `scriptCred` in favor of `credScriptHash`
+  * `scriptStakeCred` in favor of `getScriptWitnessTxCert`
+  * `requiresVKeyWitness` in favor of `getVKeyWitnessTxCert`
+  * `delegCWitness`
 
 ## 1.2.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -28,7 +28,8 @@
   * `scriptCred` in favor of `credScriptHash`
   * `scriptStakeCred` in favor of `getScriptWitnessTxCert`
   * `requiresVKeyWitness` in favor of `getVKeyWitnessTxCert`
-  * `delegCWitness`
+  * `delegCWitness` - no longer used.
+  * `propWits` - will become an internal function in the future version
 * `validateNeededWitnesses` no longer accepts `witsVKeyNeeded` as an argument.
 
 ## 1.2.0.0

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -62,9 +61,9 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Credential (Credential (..), credKeyHashWitness)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
-import Cardano.Ledger.Keys (HasKeyRole (coerceKeyRole), KeyHash, KeyRole (Witness), asWitness)
+import Cardano.Ledger.Keys (HasKeyRole (coerceKeyRole), KeyHash, KeyRole (Witness))
 import Cardano.Ledger.Keys.Bootstrap (bootstrapWitKeyHash)
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
 import Cardano.Ledger.MemoBytes (Mem, MemoBytes, memoBytes, mkMemoBytes, pattern Memo)
@@ -81,6 +80,7 @@ import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
 import Data.Map.Strict (Map)
+import Data.Maybe (mapMaybe)
 import Data.Maybe.Strict (
   StrictMaybe (..),
   maybeToStrictMaybe,
@@ -399,10 +399,8 @@ extractKeyHashWitnessSet ::
   forall (r :: KeyRole) c.
   [Credential r c] ->
   Set (KeyHash 'Witness c)
-extractKeyHashWitnessSet = foldr accum Set.empty
-  where
-    accum (KeyHashObj hk) ans = Set.insert (asWitness hk) ans
-    accum _other ans = ans
+extractKeyHashWitnessSet = Set.fromList . mapMaybe credKeyHashWitness
+{-# DEPRECATED extractKeyHashWitnessSet "In favor of `credKeyHashWitness`" #-}
 
 -- | Minimum fee calculation
 shelleyMinFeeTx :: EraTx era => PParams era -> Tx era -> Coin

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -14,14 +14,21 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
--- Due to Delegation usage
-{-# OPTIONS_GHC -Wno-orphans -Wno-deprecations #-}
+-- Due to Delegation usage.
+-- TODO: remove when Delegation is gone
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- Due to deprecated requiresVKeyWitness.
+-- TODO: remove when requiresVKeyWitness is gone:
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Cardano.Ledger.Shelley.TxCert (
   ShelleyEraTxCert (..),
   pattern TxCertMir,
   pattern ShelleyTxCertDeleg,
   ShelleyDelegCert (.., RegKey, DeRegKey, Delegate),
+  getVKeyWitnessShelleyTxCert,
+  getScriptWitnessShelleyTxCert,
   delegCWitness,
   ShelleyTxCert (..),
   MIRCert (..),
@@ -78,7 +85,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Credential (Credential (..), StakeCredential)
+import Cardano.Ledger.Credential (Credential (..), StakeCredential, credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
@@ -92,6 +99,10 @@ instance Crypto c => EraTxCert (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxCert (ShelleyEra StandardCrypto) #-}
 
   type TxCert (ShelleyEra c) = ShelleyTxCert (ShelleyEra c)
+
+  getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
+
+  getScriptWitnessTxCert = getScriptWitnessShelleyTxCert
 
   mkTxCertPool = ShelleyTxCertPool
 
@@ -340,6 +351,7 @@ delegCWitness :: ShelleyDelegCert c -> Credential 'Staking c
 delegCWitness (ShelleyRegCert _) = error "no witness in key registration certificate"
 delegCWitness (ShelleyUnRegCert cred) = cred
 delegCWitness (ShelleyDelegCert cred _) = cred
+{-# DEPRECATED delegCWitness "This was a partial function, logic rewritten in a safer way" #-}
 
 -- | Check for 'ShelleyRegCert' constructor
 isRegKey :: (ShelleyEraTxCert era) => TxCert era -> Bool
@@ -386,6 +398,34 @@ isTreasuryMIRCert x = case getTxCertMir x of
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure
 -- that calling a variant of 'cwitness' is safe.
-requiresVKeyWitness :: ShelleyEraTxCert era => TxCert era -> Bool
+--
+-- Note: This will not compile for Conway, because it is incorrect for Conway, use
+-- `getVKeyWitnessTxCert` instead.
+requiresVKeyWitness :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCert era -> Bool
 requiresVKeyWitness (ShelleyTxCertDeleg (ShelleyRegCert _)) = False
 requiresVKeyWitness x = isNothing $ getTxCertMir x
+{-# DEPRECATED requiresVKeyWitness "In favor of `getVKeyWitnessTxCert`" #-}
+
+
+getScriptWitnessShelleyTxCert ::
+  ShelleyTxCert era ->
+  Maybe (ScriptHash (EraCrypto era))
+getScriptWitnessShelleyTxCert = \case
+  ShelleyTxCertDelegCert delegCert ->
+    case delegCert of
+      ShelleyRegCert _ -> Nothing
+      ShelleyUnRegCert cred -> credScriptHash cred
+      ShelleyDelegCert cred _ -> credScriptHash cred
+  _ -> Nothing
+
+getVKeyWitnessShelleyTxCert :: ShelleyTxCert era -> Maybe (KeyHash 'Witness (EraCrypto era))
+getVKeyWitnessShelleyTxCert = \case
+  ShelleyTxCertDelegCert delegCert ->
+    case delegCert of
+      -- Registration certificates do not require a witness
+      ShelleyRegCert _ -> Nothing
+      ShelleyUnRegCert cred -> credKeyHashWitness cred
+      ShelleyDelegCert cred _ -> credKeyHashWitness cred
+  ShelleyTxCertPool poolCert -> Just $ poolCertKeyHashWitness poolCert
+  ShelleyTxCertGenesis genesisCert -> Just $ genesisKeyHashWitness genesisCert
+  ShelleyTxCertMir {} -> Nothing

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -406,7 +406,6 @@ requiresVKeyWitness (ShelleyTxCertDeleg (ShelleyRegCert _)) = False
 requiresVKeyWitness x = isNothing $ getTxCertMir x
 {-# DEPRECATED requiresVKeyWitness "In favor of `getVKeyWitnessTxCert`" #-}
 
-
 getScriptWitnessShelleyTxCert ::
   ShelleyTxCert era ->
   Maybe (ScriptHash (EraCrypto era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -80,7 +80,6 @@ scriptCred :: Credential kr c -> Maybe (ScriptHash c)
 scriptCred = credScriptHash
 {-# DEPRECATED scriptCred "In favor of `credScriptHash`" #-}
 
-
 -- | Computes the set of script hashes required to unlock the transaction inputs
 -- and the withdrawals.
 scriptsNeeded ::

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add `certsTxBodyL` to `EraTxBody`
 * Introduce `TxCert` type family and `EraTxCert` type class.
 * Deprecate `Delegation`
+* Add `toKeyHashWitness`
+* Addition of `getVKeyWitnessTxCert` and `getScriptWitnessTxCert` to `EraTxCert` type class
 
 ## 1.2.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -7,14 +7,14 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Credential (
   Credential (KeyHashObj, ScriptHashObj),
   GenesisCredential (..),
   PaymentCredential,
+  credKeyHashWitness,
+  credScriptHash,
   Ptr (Ptr),
   ptrSlotNo,
   ptrTxIx,
@@ -42,6 +42,7 @@ import Cardano.Ledger.Keys (
   HasKeyRole (..),
   KeyHash,
   KeyRole (..),
+  asWitness,
  )
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
@@ -106,6 +107,18 @@ instance Crypto c => FromJSONKey (Credential kr c)
 type PaymentCredential c = Credential 'Payment c
 
 type StakeCredential c = Credential 'Staking c
+
+-- | Convert a KeyHash into a Witness KeyHash. Does nothing for Script credentials.
+credKeyHashWitness :: Credential r c -> Maybe (KeyHash 'Witness c)
+credKeyHashWitness = \case
+  KeyHashObj hk -> Just $ asWitness hk
+  ScriptHashObj _ -> Nothing
+
+-- | Extract ScriptHash from a Credential. Returns Nothing for KeyHashes
+credScriptHash :: Credential kr c -> Maybe (ScriptHash c)
+credScriptHash = \case
+  ScriptHashObj hs -> Just hs
+  KeyHashObj _ -> Nothing
 
 data StakeReference c
   = StakeRefBase !(StakeCredential c)


### PR DESCRIPTION
# Description

## Abstract deciding which certificates require witnesses.

Certificates structure has changed in Conway, because of that old logic,
even with backwards compatibility translation, will not work correctly.
In particular, some new certificates did not require a witness, where
they should have required one. Abstracting the logic by adding
`getVKeyWitnessTxCert` and `getScriptWitnessTxCert` to `EraTxCert` we
can solve this problem with different implemnetation on per era basis.
This also opens up an opportunitiy for deduplication implemented in
a subsequent commit.

## Make registration certificates with deposits require witnesses

It was discusses during a meeting that it was an unfortunate requirement
in Shelley to not enforce a witness for staking credential registration.
It was implemented to allow ITIN rewards, which is not a feature anymore.
Therefore this is no longer a necessary requirement and it was decided
to change this by enforcing a wtiness for registration certificates, but
only for the ones that contain a deposit. This would mean that we can
keep backwards compatibility throughout Conway, but in the next era it
will become a proper requirement.

## Reduce duplication by consolidatiing two versions of witsVKeyNeeded

Implementations in Shelley and Alonzo were almost identical.

## Avoid usage of partial functions

In three different places `error` call was removed by improving the logic.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
