### PR TITLE
Add DRep to UMap, Rename Trip to UElem

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Shelley.LedgerState.Types (
   UTxOState (..),
  )
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..), unWithdrawals)
-import Cardano.Ledger.UMap (View (RewardDeposits), sumDepositView, sumRewardsView)
+import Cardano.Ledger.UMap (UView (RewDepUView), sumDepositUView, sumRewardsUView)
 import Cardano.Ledger.UTxO (UTxO (..), coinBalance, txouts)
 import Data.Foldable (fold)
 import qualified Data.Map.Strict as Map
@@ -74,10 +74,10 @@ totalAdaPotsES (EpochState (AccountState treasury_ reserves_) _ ls _ _ _) =
   where
     UTxOState u deposits fees_ _ _ = lsUTxOState ls
     CertState _ _ dstate = lsCertState ls
-    rewards_ = fromCompact $ sumRewardsView (rewards dstate)
+    rewards_ = fromCompact $ sumRewardsUView (rewards dstate)
     coins = coinBalance u
     keyDeposits_ =
-      fromCompact . sumDepositView . RewardDeposits . dsUnified . certDState $ lsCertState ls
+      fromCompact . sumDepositUView . RewDepUView . dsUnified . certDState $ lsCertState ls
     poolDeposits_ = fold (psDeposits . certPState $ lsCertState ls)
 
 -- | Calculate the total ada in the epoch state

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (keyTxRefunds, totalTxDeposits)
 import Cardano.Ledger.Shelley.LedgerState.Types
 import Cardano.Ledger.Shelley.TxBody (MIRPot (..))
-import Cardano.Ledger.UMap (RDPair (..), Trip (..), UMap (..))
+import Cardano.Ledger.UMap (RDPair (..), UMElem (..), UMap (..))
 import Cardano.Ledger.UTxO (UTxO (..), coinBalance)
 import Cardano.Ledger.Val ((<+>), (<->))
 import Data.Default.Class (def)
@@ -115,7 +115,7 @@ reapRewards ::
   UMap c
 reapRewards (UMap tmap ptrmap) withdrawals = UMap (Map.mapWithKey g tmap) ptrmap
   where
-    g k (Triple x y z) = Triple (fmap (removeRewards k) x) y z
+    g k (UMElem w x y z) = UMElem (fmap (removeRewards k) w) x y z
     removeRewards k v@(RDPair _ d) =
       if k `Map.member` withdrawals then RDPair (CompactCoin 0) d else v
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -71,7 +71,7 @@ import Cardano.Ledger.Slot (
   (*-),
   (+*),
  )
-import Cardano.Ledger.UMap (RDPair (..), View (..), compactCoinOrError, fromCompact)
+import Cardano.Ledger.UMap (RDPair (..), UView (..), compactCoinOrError, fromCompact)
 import qualified Cardano.Ledger.UMap as UM
 import Control.DeepSeq
 import Control.Monad.Trans.Reader (asks)
@@ -272,8 +272,8 @@ delegationTransition = do
       UM.notMember hk (rewards ds) ?! StakeKeyAlreadyRegisteredDELEG hk
       let u1 = dsUnified ds
           deposit = compactCoinOrError (pp ^. ppKeyDepositL)
-          u2 = RewardDeposits u1 UM.∪ (hk, RDPair (UM.CompactCoin 0) deposit)
-          u3 = Ptrs u2 UM.∪ (ptr, hk)
+          u2 = RewDepUView u1 UM.∪ (hk, RDPair (UM.CompactCoin 0) deposit)
+          u3 = PtrUView u2 UM.∪ (ptr, hk)
       pure (ds {dsUnified = u3})
     ShelleyTxCertDeleg (ShelleyUnRegCert hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
@@ -283,9 +283,9 @@ delegationTransition = do
       rewardCoin == Just mempty ?! StakeKeyNonZeroAccountBalanceDELEG (fromCompact <$> rewardCoin)
 
       let u0 = dsUnified ds
-          u1 = Set.singleton hk UM.⋪ RewardDeposits u0
-          u2 = Set.singleton hk UM.⋪ Delegations u1
-          u3 = Ptrs u2 UM.⋫ Set.singleton hk
+          u1 = Set.singleton hk UM.⋪ RewDepUView u0
+          u2 = Set.singleton hk UM.⋪ SPoolUView u1
+          u3 = PtrUView u2 UM.⋫ Set.singleton hk
           u4 = ds {dsUnified = u3}
       pure u4
     ShelleyTxCertDeleg (ShelleyDelegCert hk dpool) -> do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -70,7 +70,7 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyEraTxCert, pattern ShelleyTxCertDeleg)
 import Cardano.Ledger.Slot (SlotNo)
-import Cardano.Ledger.UMap (Trip (..), UMap (..), View (..), fromCompact)
+import Cardano.Ledger.UMap (UMElem (..), UMap (..), UView (..), fromCompact)
 import qualified Cardano.Ledger.UMap as UM
 import Control.DeepSeq
 import Control.Monad.Trans.Reader (asks)
@@ -253,14 +253,14 @@ validateDelegationRegistered certState = \case
 isSubmapOfUM ::
   forall era.
   Map (RewardAcnt (EraCrypto era)) Coin ->
-  View (EraCrypto era) (Credential 'Staking (EraCrypto era)) UM.RDPair ->
+  UView (EraCrypto era) (Credential 'Staking (EraCrypto era)) UM.RDPair ->
   Bool
-isSubmapOfUM ws (RewardDeposits (UMap tripmap _)) = Map.isSubmapOfBy f withdrawalMap tripmap
+isSubmapOfUM ws (RewDepUView (UMap tripmap _)) = Map.isSubmapOfBy f withdrawalMap tripmap
   where
     withdrawalMap :: Map.Map (Credential 'Staking (EraCrypto era)) Coin
     withdrawalMap = Map.mapKeys (\(RewardAcnt _ cred) -> cred) ws
-    f :: Coin -> Trip (EraCrypto era) -> Bool
-    f coin1 (Triple (SJust (UM.RDPair coin2 _)) _ _) = coin1 == fromCompact coin2
+    f :: Coin -> UMElem (EraCrypto era) -> Bool
+    f coin1 (UMElem (SJust (UM.RDPair coin2 _)) _ _ _) = coin1 == fromCompact coin2
     f _ _ = False
 
 drainWithdrawals :: DState era -> Withdrawals (EraCrypto era) -> DState era
@@ -287,7 +287,7 @@ validateZeroRewards dState (Withdrawals wdrls) network = do
     Map.differenceWith
       (\x y -> if x /= y then Just x else Nothing)
       wdrls
-      (Map.mapKeys (mkRwdAcnt network) (UM.rewView (dsUnified dState)))
+      (Map.mapKeys (mkRwdAcnt network) (UM.rewardMap (dsUnified dState)))
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -56,7 +56,7 @@ import Cardano.Ledger.Shelley.Rules.Reports (showTxCerts, synopsisCoinMap)
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow (ShelleyUTXOW, ShelleyUtxowPredFailure)
 import Cardano.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
-import Cardano.Ledger.UMap (depositView)
+import Cardano.Ledger.UMap (depositMap)
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Reader (Reader)
 import Control.Monad.Trans.Reader (asks)
@@ -280,7 +280,7 @@ depositEqualsObligation
           <> "\nutxosDeposited = "
           <> show (utxosDeposited . lsUTxOState <$> avState)
           <> "\nKey Deposits summary = "
-          <> synopsisCoinMap (depositView . dsUnified . certDState . lsCertState <$> avState)
+          <> synopsisCoinMap (depositMap . dsUnified . certDState . lsCertState <$> avState)
           <> "\nPool Deposits summary = "
           <> synopsisCoinMap (psDeposits . certPState . lsCertState <$> avState)
           <> "\nConsumed = "

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.TxBody (RewardAcnt, getRwdCred, ppRewardAcnt)
 import Cardano.Ledger.Slot (EpochNo (..))
-import Cardano.Ledger.UMap (View (Delegations, RewardDeposits), compactCoinOrError)
+import Cardano.Ledger.UMap (UView (RewDepUView, SPoolUView), compactCoinOrError)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<+>), (<->))
 import Control.SetAlgebra (dom, eval, setSingleton, (⋪), (▷), (◁))
@@ -153,8 +153,8 @@ poolReapTransition = do
       us {utxosDeposited = utxosDeposited us <-> (unclaimed <+> refunded)}
       a {asTreasury = asTreasury a <+> unclaimed}
       ( let u0 = dsUnified ds
-            u1 = RewardDeposits u0 UM.∪+ Map.map compactCoinOrError refunds
-            u2 = (Delegations u1 UM.⋫ retired)
+            u1 = RewDepUView u0 UM.∪+ Map.map compactCoinOrError refunds
+            u2 = SPoolUView u1 UM.⋫ retired
          in ds {dsUnified = u2}
       )
       ps

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -239,8 +239,9 @@ registerGenesisStaking
           { dsUnified =
               UM.unify
                 (Map.map pairWithDepositsButNoRewards . Map.mapKeys KeyHashObj . LM.toMap $ sgsStake)
+                (UM.ptrMap (dsUnified (certDState oldCertState)))
                 (Map.mapKeys KeyHashObj $ LM.toMap sgsStake)
-                (UM.ptrView (dsUnified (certDState oldCertState)))
+                Map.empty
           }
 
       -- We consider pools as having been registered in slot 0

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Shelley.Rules.Reports (
   synopsisCert,
  )
 import Cardano.Ledger.TreeDiff (ediffEq)
-import Cardano.Ledger.UMap (sumRewardsView)
+import Cardano.Ledger.UMap (sumRewardsUView)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.UTxO (UTxO (..), coinBalance, txouts)
 import Cardano.Ledger.Val ((<+>), (<->))
@@ -302,8 +302,8 @@ checkWithdrawalBound SourceSignalTarget {source, signal, target} =
   where
     rewardDelta :: Coin
     rewardDelta =
-      fromCompact (sumRewardsView (rewards . certDState . lsCertState . esLState . nesEs . chainNes $ source))
-        <-> fromCompact (sumRewardsView (rewards . certDState . lsCertState . esLState . nesEs . chainNes $ target))
+      fromCompact (sumRewardsUView (rewards . certDState . lsCertState . esLState . nesEs . chainNes $ source))
+        <-> fromCompact (sumRewardsUView (rewards . certDState . lsCertState . esLState . nesEs . chainNes $ target))
 
 -- | If we are not at an Epoch Boundary, then (Utxo + Deposits)
 -- increases by Withdrawals minus Fees (for all transactions in a block)
@@ -402,8 +402,8 @@ potsSumIncreaseByRewardsPerTx SourceSignalTarget {source = chainSt, signal = blo
         } =
         (coinBalance u' <+> d' <+> f')
           <-> (coinBalance u <+> d <+> f)
-          === (UM.fromCompact (sumRewardsView (UM.RewardDeposits umap1)))
-          <-> (UM.fromCompact (sumRewardsView (UM.RewardDeposits umap2)))
+          === (UM.fromCompact (sumRewardsUView (UM.RewDepUView umap1)))
+          <-> (UM.fromCompact (sumRewardsUView (UM.RewDepUView umap2)))
 
 -- | The Rewards pot decreases by the sum of withdrawals in a transaction
 potsRewardsDecreaseByWithdrawalsPerTx ::
@@ -420,7 +420,7 @@ potsRewardsDecreaseByWithdrawalsPerTx SourceSignalTarget {source = chainSt, sign
       map rewardsDecreaseByWithdrawals $
         sourceSignalTargets ledgerTr
   where
-    rewardsSum = UM.fromCompact . sumRewardsView . rewards . certDState
+    rewardsSum = UM.fromCompact . sumRewardsUView . rewards . certDState
     (_, ledgerTr) = ledgerTraceFromBlock @era @ledger chainSt block
     rewardsDecreaseByWithdrawals
       SourceSignalTarget

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -135,7 +135,7 @@ keyDelegation
     { signal = ShelleyTxCertDeleg (ShelleyDelegCert from to)
     , target = targetSt
     } =
-    let fromImage = eval (rng (Set.singleton from `UM.domRestrictedView` delegations targetSt))
+    let fromImage = eval (rng (Set.singleton from `UM.domRestrictedMap` delegations targetSt))
      in conjoin
           [ counterexample
               "a delegated key should have a reward account"
@@ -154,8 +154,8 @@ keyDelegation _ = property ()
 rewardsSumInvariant :: SourceSignalTarget (ShelleyDELEG era) -> Property
 rewardsSumInvariant
   SourceSignalTarget {source, target} =
-    let sourceRewards = UM.compactRewView (dsUnified source)
-        targetRewards = UM.compactRewView (dsUnified target)
+    let sourceRewards = UM.compactRewardMap (dsUnified source)
+        targetRewards = UM.compactRewardMap (dsUnified target)
         rewardsSum = foldl' (<>) mempty
      in conjoin
           [ counterexample

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Shelley.Rules.Reports (
   synopsisCoinMap,
  )
 import Cardano.Ledger.TreeDiff (diffExpr)
-import Cardano.Ledger.UMap (depositView)
+import Cardano.Ledger.UMap (depositMap)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<+>))
 import Control.State.Transition.Trace (
@@ -85,13 +85,13 @@ depositInvariant SourceSignalTarget {source = chainSt} =
   let LedgerState {lsUTxOState = utxost, lsCertState = CertState _vstate pstate dstate} = (esLState . nesEs . chainNes) chainSt
       allDeposits = utxosDeposited utxost
       sumCoin = Map.foldl' (<+>) (Coin 0)
-      keyDeposits = (UM.fromCompact . UM.sumDepositView . UM.RewardDeposits . dsUnified) dstate
+      keyDeposits = (UM.fromCompact . UM.sumDepositUView . UM.RewDepUView . dsUnified) dstate
       poolDeposits = sumCoin (psDeposits pstate)
    in counterexample
         ( unlines
             [ "Deposit invariant fails"
             , "All deposits = " ++ show allDeposits
-            , "Key deposits = " ++ synopsisCoinMap (Just (depositView (dsUnified dstate)))
+            , "Key deposits = " ++ synopsisCoinMap (Just (depositMap (dsUnified dstate)))
             , "Pool deposits = " ++ synopsisCoinMap (Just (psDeposits pstate))
             ]
         )
@@ -102,8 +102,8 @@ rewardDepositDomainInvariant ::
   Property
 rewardDepositDomainInvariant SourceSignalTarget {source = chainSt} =
   let LedgerState {lsCertState = CertState {certDState = dstate}} = (esLState . nesEs . chainNes) chainSt
-      rewardDomain = UM.domain (UM.RewardDeposits (dsUnified dstate))
-      depositDomain = Map.keysSet (depositView (dsUnified dstate))
+      rewardDomain = UM.domain (UM.RewDepUView (dsUnified dstate))
+      depositDomain = Map.keysSet (depositMap (dsUnified dstate))
    in counterexample
         ( unlines
             [ "Reward-Deposit domain invariant fails"

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -200,9 +200,9 @@ stakeDistr u ds ps =
     (VMap.fromMap poolParams)
   where
     rewards' :: Map.Map (Credential 'Staking (EraCrypto era)) Coin
-    rewards' = UM.rewView (dsUnified ds)
+    rewards' = UM.rewardMap (dsUnified ds)
     delegs :: Map.Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))
-    delegs = UM.delView (dsUnified ds)
+    delegs = UM.sPoolMap (dsUnified ds)
     ptrs' = ptrsMap ds
     PState {psStakePoolParams = poolParams} = ps
     stakeRelation :: Map (Credential 'Staking (EraCrypto era)) Coin

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -60,11 +60,11 @@ keyTxRefunds ::
 keyTxRefunds pp dpstate tx = snd (foldl' accum (initialKeys, Coin 0) certs)
   where
     certs = tx ^. certsTxBodyL
-    initialKeys = UM.RewardDeposits $ dsUnified $ certDState dpstate
+    initialKeys = UM.RewDepUView $ dsUnified $ certDState dpstate
     keyDeposit = UM.compactCoinOrError (pp ^. ppKeyDepositL)
     accum (!keys, !ans) (ShelleyTxCertDeleg (ShelleyRegCert k)) =
       -- Deposit is added locally to the growing 'keys'
-      (UM.RewardDeposits $ UM.insert k (UM.RDPair mempty keyDeposit) keys, ans)
+      (UM.RewDepUView $ UM.insert k (UM.RDPair mempty keyDeposit) keys, ans)
     accum (!keys, !ans) (ShelleyTxCertDeleg (ShelleyUnRegCert k)) =
       -- If the key is registered, lookup the deposit in the locally growing 'keys'
       -- if it is not registered, then just return ans
@@ -104,7 +104,7 @@ genTxBodyFrom ::
 genTxBodyFrom CertState {certDState, certPState} (UTxO u) = do
   txBody <- arbitrary
   inputs <- sublistOf (Map.keys u)
-  unDelegCreds <- sublistOf (toList (UM.domain (UM.RewardDeposits $ dsUnified certDState)))
+  unDelegCreds <- sublistOf (toList (UM.domain (UM.RewDepUView $ dsUnified certDState)))
   deRegKeys <- sublistOf (Map.elems (psStakePoolParams certPState))
   certs <-
     shuffle $

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -40,7 +40,7 @@
   * Reimplementations
     * `unionRewAgg` NOTE: It does not require `assert (Map.valid result) result` any more
       and has been tested for equivalence with the older version with 
-      `--qc-max-success=10000 --qc-max-size=1000` in one of the commits.
+      `--qc-max-success=10000 --qc-max-size=1000`. The test is added to `UMapSpec`.
 * Add `certsTxBodyL` to `EraTxBody`
 * Introduce `TxCert` type family and `EraTxCert` type class.
 * Deprecate `Delegation`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,12 +1,46 @@
 # Version history for `cardano-ledger-core`
 
-## 1.4.0.0
-
-* Add delegated representatives to the `UMap` and make its interface more coherent #3426
-  * There are a number of 
-
 ## 1.3.0.0
 
+* Add delegated representatives to the `UMap` and make its interface more coherent #3426
+  * Additions
+    * Add `Credential 'Voting (EraCrypto era)` as the fourth element to the `UMap` n-tuple.
+    * `umElemPtrs :: UMElem c -> Maybe (Set Ptr)`
+    * `umElemDRep :: UMElem c -> Maybe (Credential 'Voting (EraCrypto era))`
+    * `UView (DRepUView)` constructor and `dRepUView`
+    * `revPtrMap :: UMap c -> Map (Credential 'Staking c) (Set Ptr)`
+    * `dRepMap :: UMap c -> Map (Credential 'Staking c) (Credential 'Voting c)`
+    * synonym `unionL = (∪)`
+    * synonym `unionR = (⨃)`
+    * synonym `domDelete = (⋪)`
+    * synonym `rngDelete = (⋫)`
+  * Renames
+    * `Trip` to `UMElem`, pattern `Triple` to `UMElem`
+    * `viewTrip` to `umElemAsTuple`
+    * `tripRewardActiveDelegation` to `umElemRDActive`
+    * `tripReward` to `umElemRDPair`
+    * `tripDelegation` to `umElemSPool`
+    * `View (RewardDeposits, Delegations, Ptrs)` to `UView (RewDepUView, SPoolUView, PtrUView)`
+      * `rdPairs` to `rewDepUView`
+      * `delegations` to `sPoolUView`
+      * `ptrs` to `ptrUView`
+      * `unView` to `unUView`
+      * `viewtoVMap` to `unUnifyToVMap`
+      * `rewView` to `rewardMap`
+      * `compactRewView` to `compactRewardMap`
+      * `depositView` to `depositMap`
+      * `rdPairView` to `rdPairMap`
+      * `delView` to `sPoolMap`
+      * `ptrView` to `ptrMap`
+      * `domRestrictedView` to `domRestrictedMap`
+    * `zero` to `nullUMElem`
+    * `zeroMaybe` to `nullUMElemMaybe`
+    * `sumRewardsView` to `sumRewardsUView`
+    * `sumDepositView` to `sumDepositUView`
+  * Reimplementations
+    * `unionRewAgg` NOTE: It does not require `assert (Map.valid result) result` any more
+      and has been tested for equivalence with the older version with 
+      `--qc-max-success=10000 --qc-max-size=1000` in one of the commits.
 * Add `certsTxBodyL` to `EraTxBody`
 * Introduce `TxCert` type family and `EraTxCert` type class.
 * Deprecate `Delegation`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-core`
 
+## 1.4.0.0
+
+* Add delegated representatives to the `UMap` and make its interface more coherent #3426
+  * There are a number of 
+
 ## 1.3.0.0
 
 * Add `certsTxBodyL` to `EraTxBody`

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -158,7 +159,7 @@ import Cardano.Ledger.Slot (
   SlotNo (..),
  )
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
-import Cardano.Ledger.UMap (RDPair (..), Trip (Triple), UMap (..))
+import Cardano.Ledger.UMap (RDPair (..), UMElem (UMElem), UMap (..))
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Protocol.TPraos.BHeader (
   BHBody (..),
@@ -418,21 +419,22 @@ ppRDPair (RDPair rew dep) =
     , ("deposit", ppCoin (fromCompact dep))
     ]
 
-ppTrip :: Trip c -> PDoc
-ppTrip (Triple mpair set mpool) =
+ppUMElem :: UMElem c -> PDoc
+ppUMElem (UMElem rd ptr spool drep) =
   ppSexp
-    "Triple"
-    [ ppStrictMaybe ppRDPair mpair
-    , ppSet ppPtr set
-    , ppStrictMaybe ppKeyHash mpool
+    "UMElem"
+    [ ppStrictMaybe ppRDPair rd
+    , ppSet ppPtr ptr
+    , ppStrictMaybe ppKeyHash spool
+    , ppStrictMaybe ppCredential drep
     ]
 
 ppUnifiedMap :: UMap c -> PDoc
-ppUnifiedMap (UMap tripmap ptrmap) =
+ppUnifiedMap UMap {..} =
   ppRecord
     "UMap"
-    [ ("combined", ppMap ppCredential ppTrip tripmap)
-    , ("ptrs", ppMap ppPtr ppCredential ptrmap)
+    [ ("combined", ppMap ppCredential ppUMElem umElems)
+    , ("ptrs", ppMap ppPtr ppCredential umPtrs)
     ]
 
 -- ======================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -680,7 +680,7 @@ dstate ::
   DPS.InstantaneousRewards (EraCrypto era) ->
   DState era
 dstate rew dep deleg ptr fgen gen instR =
-  DState (unSplitUMap (Split rew dep deleg undefined ptr)) fgen (GenDelegs gen) instR
+  DState (unSplitUMap (Split rew dep deleg Map.empty undefined ptr)) fgen (GenDelegs gen) instR
 
 instantaneousRewardsT :: Target era (DPS.InstantaneousRewards (EraCrypto era))
 instantaneousRewardsT =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -75,7 +75,7 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.TxCert (pattern ShelleyTxCertDeleg)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.UMap (View (RewardDeposits))
+import Cardano.Ledger.UMap (UView (RewDepUView))
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val (inject, (<+>), (<->))
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -188,7 +188,7 @@ initialBBodyState pf utxo =
                   UM.insert
                     (scriptStakeCredSuceed pf)
                     (UM.RDPair (UM.CompactCoin 1000) successDeposit)
-                    (RewardDeposits UM.empty)
+                    (RewDepUView UM.empty)
               }
         }
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.Rules.Reports (synopsisCoinMap)
 import Cardano.Ledger.TreeDiff (diffExpr)
-import Cardano.Ledger.UMap (View (RewardDeposits), depositView, domain, fromCompact, sumDepositView)
+import Cardano.Ledger.UMap (UView (RewDepUView), depositMap, domain, fromCompact, sumDepositUView)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val ((<+>))
 import Control.State.Transition (STS (..))
@@ -131,13 +131,13 @@ depositInvariant SourceSignalTarget {source = mockChainSt} =
       -- TODO handle VState
       allDeposits = utxosDeposited utxost
       sumCoin m = Map.foldl' (<+>) (Coin 0) m
-      keyDeposits = fromCompact $ sumDepositView (RewardDeposits (dsUnified dstate))
+      keyDeposits = fromCompact $ sumDepositUView (RewDepUView (dsUnified dstate))
       poolDeposits = sumCoin (psDeposits pstate)
    in counterexample
         ( unlines
             [ "Deposit invariant fails"
             , "All deposits = " ++ show allDeposits
-            , "Key deposits = " ++ synopsisCoinMap (Just (depositView (dsUnified dstate)))
+            , "Key deposits = " ++ synopsisCoinMap (Just (depositMap (dsUnified dstate)))
             , "Pool deposits = " ++ synopsisCoinMap (Just (psDeposits pstate))
             ]
         )
@@ -149,8 +149,8 @@ rewardDepositDomainInvariant ::
 rewardDepositDomainInvariant SourceSignalTarget {source = mockChainSt} =
   let LedgerState {lsCertState = CertState _ _ dstate} = (esLState . nesEs . mcsNes) mockChainSt
       -- TODO VState
-      rewardDomain = domain (RewardDeposits (dsUnified dstate))
-      depositDomain = Map.keysSet (depositView (dsUnified dstate))
+      rewardDomain = domain (RewDepUView (dsUnified dstate))
+      depositDomain = Map.keysSet (depositMap (dsUnified dstate))
    in counterexample
         ( unlines
             [ "Reward-Deposit domain invariant fails"

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -407,8 +407,8 @@ instance Reflect era => TotalAda (UTxO era) where
 
 instance TotalAda (DState era) where
   totalAda dstate =
-    (UM.fromCompact $ UM.sumRewardsView (UM.RewardDeposits (dsUnified dstate)))
-      <> (UM.fromCompact $ UM.sumDepositView (UM.RewardDeposits (dsUnified dstate)))
+    (UM.fromCompact $ UM.sumRewardsUView (UM.RewDepUView (dsUnified dstate)))
+      <> (UM.fromCompact $ UM.sumDepositUView (UM.RewDepUView (dsUnified dstate)))
 
 instance TotalAda (PState era) where
   totalAda pstate = Fold.fold (psDeposits pstate)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -662,7 +662,7 @@ pcGenState proof gs =
     , ("Model", pcModelNewEpochState @era proof (gsModel gs))
     , ("Initial Utxo", ppMap pcTxIn (pcTxOut @era proof) (gsInitialUtxo gs))
     , ("Initial Rewards", ppMap pcCredential pcCoin (gsInitialRewards gs))
-    , ("Initial Delegations", ppMap pcCredential pcKeyHash (gsInitialDelegations gs))
+    , ("Initial SPoolUView", ppMap pcCredential pcKeyHash (gsInitialDelegations gs))
     , ("Initial PoolParams", ppMap pcKeyHash pcPoolParams (gsInitialPoolParams gs))
     , ("Initial PoolDistr", ppMap pcKeyHash pcIndividualPoolStake (gsInitialPoolDistr gs))
     , ("Stable PoolParams", ppSet pcKeyHash (gsStablePools gs))
@@ -691,7 +691,7 @@ instance era ~ BabbageEra Mock => Show (GenState era) where
 initialLedgerState :: forall era. Reflect era => GenState era -> LedgerState era
 initialLedgerState gstate = LedgerState utxostate dpstate
   where
-    umap = UM.unify (Map.map rdpair (gsInitialRewards gstate)) (gsInitialDelegations gstate) Map.empty
+    umap = UM.unify (Map.map rdpair (gsInitialRewards gstate)) Map.empty (gsInitialDelegations gstate) Map.empty
     utxostate = smartUTxOState pp (UTxO (gsInitialUtxo gstate)) deposited (Coin 0) emptyGovernanceState
     dpstate = CertState def pstate dstate
     dstate =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -300,7 +300,7 @@ class Extract t era where
 instance Extract (DState era) era where
   extract x =
     DState
-      (UM.unify (makeRewards x) (mDelegations x) Map.empty)
+      (UM.unify (makeRewards x) Map.empty (mDelegations x) Map.empty)
       Map.empty
       genDelegsZero
       instantaneousRewardsZero
@@ -361,9 +361,9 @@ abstract x =
   ModelNewEpochState
     { mPoolParams = (psStakePoolParams . certPState . lsCertState . esLState . nesEs) x
     , mPoolDeposits = (psDeposits . certPState . lsCertState . esLState . nesEs) x
-    , mRewards = (UM.rewView . dsUnified . certDState . lsCertState . esLState . nesEs) x
-    , mDelegations = (UM.delView . dsUnified . certDState . lsCertState . esLState . nesEs) x
-    , mKeyDeposits = (UM.depositView . dsUnified . certDState . lsCertState . esLState . nesEs) x
+    , mRewards = (UM.rewardMap . dsUnified . certDState . lsCertState . esLState . nesEs) x
+    , mDelegations = (UM.sPoolMap . dsUnified . certDState . lsCertState . esLState . nesEs) x
+    , mKeyDeposits = (UM.depositMap . dsUnified . certDState . lsCertState . esLState . nesEs) x
     , mUTxO = (unUTxO . utxosUtxo . lsUTxOState . esLState . nesEs) x
     , mMutFee = Map.empty
     , mAccountState = (esAccountState . nesEs) x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -104,13 +104,13 @@ import Cardano.Ledger.Shelley.TxBody (
 import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap (
-  delView,
-  depositView,
+  depositMap,
   fromCompact,
-  ptrView,
-  rewView,
+  ptrMap,
+  rewardMap,
+  sPoolMap,
  )
-import qualified Cardano.Ledger.UMap as UM (UMap, View (..), size)
+import qualified Cardano.Ledger.UMap as UM (UMap, UView (..), size)
 import Cardano.Ledger.UTxO (UTxO (..))
 import qualified Cardano.Ledger.Val as Val
 import Control.State.Transition.Extended (STS (..))
@@ -1194,9 +1194,10 @@ uMapSummary :: UM.UMap c -> PDoc
 uMapSummary umap =
   ppRecord
     "UMap"
-    [ ("Reward Map", ppInt (UM.size (UM.RewardDeposits umap)))
-    , ("Delegations Map", ppInt (UM.size (UM.Delegations umap)))
-    , ("Ptrs Map", ppInt (UM.size (UM.Ptrs umap)))
+    [ ("Reward-Deposit Map", ppInt (UM.size (UM.RewDepUView umap)))
+    , ("Ptrs Map", ppInt (UM.size (UM.PtrUView umap)))
+    , ("SPoolUView Map", ppInt (UM.size (UM.SPoolUView umap)))
+    , ("DRepUView Map", ppInt (UM.size (UM.DRepUView umap)))
     ]
 
 pStateSummary :: PState c -> PDoc
@@ -1687,10 +1688,10 @@ pcDState :: DState c -> PDoc
 pcDState ds =
   ppRecord
     "DState"
-    [ ("rewards", ppMap pcCredential pcCoin (rewView (dsUnified ds)))
-    , ("deposits", ppMap pcCredential pcCoin (depositView (dsUnified ds)))
-    , ("delegate", ppMap pcCredential pcKeyHash (delView (dsUnified ds)))
-    , ("ptrs", ppMap ppPtr ppCredential (ptrView (dsUnified ds)))
+    [ ("rewards", ppMap pcCredential pcCoin (rewardMap (dsUnified ds)))
+    , ("deposits", ppMap pcCredential pcCoin (depositMap (dsUnified ds)))
+    , ("delegate", ppMap pcCredential pcKeyHash (sPoolMap (dsUnified ds)))
+    , ("ptrs", ppMap ppPtr ppCredential (ptrMap (dsUnified ds)))
     , ("fGenDel", ppMap pcFutureGenDeleg pcGenDelegPair (dsFutureGenDelegs ds))
     , ("GenDel", ppMap pcKeyHash pcGenDelegPair (unGenDelegs (dsGenDelegs ds)))
     , ("iRewards", pcIRewards (dsIRewards ds))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -248,7 +248,7 @@ raiseMockError slot (SlotNo next) epochstate pdfs txs GenState {..} =
   let utxo = unUTxO $ (utxosUtxo . lsUTxOState . esLState) epochstate
       _ssPoolParams = (psStakePoolParams . certPState . lsCertState . esLState) epochstate
       _pooldeposits = (psDeposits . certPState . lsCertState . esLState) epochstate
-      _keydeposits = (UM.depositView . dsUnified . certDState . lsCertState . esLState) epochstate
+      _keydeposits = (UM.depositMap . dsUnified . certDState . lsCertState . esLState) epochstate
    in show $
         vsep
           [ ppString "==================================="

--- a/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
@@ -115,6 +115,11 @@ Delegation
   credentialId CredentialId
   stakePoolId KeyHashId
   UniqueDelegation dstateId credentialId
+DRep
+  dstateId DStateId
+  credentialId CredentialId
+  dRepCredentialId CredentialId
+  UniqueDRep dstateId credentialId
 Ptr
   dstateId DStateId
   credentialId CredentialId

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -27,7 +27,8 @@ import Cardano.Ledger.PoolDistr (individualPoolStakeVrf)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PoolRank
-import Cardano.Ledger.UMap (delView, ptrView, rewView)
+import Cardano.Ledger.UMap (rewardMap, sPoolMap)
+import qualified Cardano.Ledger.UMap as UM (ptrMap)
 import Conduit
 import Control.Exception (throwIO)
 import Control.Foldl (Fold (..))
@@ -417,7 +418,7 @@ instance Pretty DStateStats where
     prettyRecord
       "DStateStats"
       [ "CredentialStaking" <:> dssCredentialStaking
-      , "Delegations" <:> dssDelegations
+      , "SPoolUView" <:> dssDelegations
       , "KeyHashGenesis" <:> dssKeyHashGenesis
       , "KeyHashGenesisDelegate" <:> dssKeyHashGenesisDelegate
       , "HashVerKeyVRF" <:> dssHashVerKeyVRF
@@ -437,10 +438,10 @@ countDStateStats :: DState CurrentEra -> DStateStats
 countDStateStats DState {..} =
   DStateStats
     { dssCredentialStaking =
-        statMapKeys (rewView dsUnified)
-          <> statMapKeys (delView dsUnified)
-          <> statSet (range (ptrView dsUnified))
-    , dssDelegations = statFoldable (delView dsUnified)
+        statMapKeys (rewardMap dsUnified)
+          <> statMapKeys (sPoolMap dsUnified)
+          <> statSet (range (UM.ptrMap dsUnified))
+    , dssDelegations = statFoldable (sPoolMap dsUnified)
     , dssKeyHashGenesis =
         statFoldable (fGenDelegGenKeyHash <$> Map.keys dsFutureGenDelegs)
           <> statMapKeys (unGenDelegs dsGenDelegs)


### PR DESCRIPTION
# Description

- [x] Add DReps to UMap
- [x] Rename Trip to UElem, and the pattern Triple to UElem
- [x] Validate the equivalence of `unionRewAgg` and `unionKeyRewards` with the help of property tests, and remove one implementation between them.

> This property test has been retained in the history of the branch

```shellsession
[nix-shell:~/Code/_iog/cardano-ledger/vdelegs-in-umap]$ cabal test cardano-ledger-core --test-options '-m unionKeyRewards -a 10000 --qc-max-size 1000'
Build profile: -w ghc-9.2.7 -O1
In order, the following will be built (use -v for more details):
 - cardano-ledger-core-1.3.0.0 (test:tests) (ephemeral targets)
Preprocessing test suite 'tests' for cardano-ledger-core-1.3.0.0..
Building test suite 'tests' for cardano-ledger-core-1.3.0.0..
Running 1 test suites...
Test suite tests: RUNNING...

Core
  UMap
    unionRewAgg === unionKeyRewards
      unionRewAgg === unionKeyRewards [✔] (55383ms)
        +++ OK, passed 10000 tests.

Finished in 55.3837 seconds
1 example, 0 failures
Test suite tests: PASS
Test suite logged to:
/home/aniketd/Code/_iog/cardano-ledger/vdelegs-in-umap/dist-newstyle/build/x86_64-linux/ghc-9.2.7/cardano-ledger-core-1.3.0.0/t/tests/test/cardano-ledger-core-1.3.0.0-tests.log
1 of 1 test suites (1 of 1 test cases) passed.
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
