### PR TITLE
deprecate the alonze txout serialization format

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Added `toShelleyDelegCert` and `fromShelleyDelegCert`
 * Changed `ConwayDelegCert` structure #3408
 * Addition of `getScriptWitnessConwayTxCert` and `getVKeyWitnessConwayTxCert`
-
+* Changed deprecated the legacy serialization format for transaction outputs
 
 ## 1.2.0.0
 

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -60,6 +60,7 @@ test-suite cardano-ledger-conway-test
     hs-source-dirs:   test
     other-modules:
         Test.Cardano.Ledger.Conway.Serialisation.CDDL
+        Test.Cardano.Ledger.Conway.Serialisation.Failure
         Test.Cardano.Ledger.Conway.TxInfo
         Paths_cardano_ledger_conway_test
 
@@ -74,11 +75,14 @@ test-suite cardano-ledger-conway-test
         base,
         bytestring,
         cardano-ledger-allegra,
-        cardano-ledger-alonzo,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-babbage,
         cardano-ledger-babbage-test >=1.1.1 && <1.2,
+        cardano-ledger-binary,
         cardano-ledger-conway,
         cardano-ledger-conway-test,
         cardano-ledger-core,
         cardano-ledger-shelley-test,
-        tasty
+        QuickCheck,
+        tasty,
+        tasty-quickcheck

--- a/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/Failure.hs
+++ b/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/Failure.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Serialisation.Failure (
+  tests,
+)
+where
+
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut)
+import Cardano.Ledger.Babbage (BabbageTxOut)
+import Cardano.Ledger.Binary (
+  DecoderError (..),
+  DeserialiseFailure (..),
+  decodeFull,
+  natVersion,
+  serialize,
+ )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.QuickCheck (Property, counterexample, (.&&.), (===))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+-- Test that the legacy serialization format for txouts has been deprecated starting
+-- at protocol version 9.
+-- The legacy serialization format can be produced by generation an AlonzoTxOut.
+propConwayTxOutDeprecation :: AlonzoTxOut (ConwayEra StandardCrypto) -> Property
+propConwayTxOutDeprecation a =
+  let encoded = serialize (natVersion @9) a
+      decoded :: Either DecoderError (BabbageTxOut (ConwayEra StandardCrypto))
+      decoded = decodeFull (natVersion @9) encoded
+   in case decoded of
+        Left
+          ( DecoderErrorDeserialiseFailure
+              x
+              (DeserialiseFailure 0 y)
+            ) ->
+            x === "BabbageTxOut (ConwayEra StandardCrypto)"
+              .&&. y === "legacy TxOut serialization was deprecated in version 9"
+        Left _ -> counterexample "wrong error" False
+        Right _ -> counterexample "should not have serialized" False
+
+tests :: TestTree
+tests =
+  testGroup
+    "Expected serialization failures"
+    [ testProperty "TxOut deprecation" propConwayTxOutDeprecation
+    ]

--- a/eras/conway/test-suite/test/Tests.hs
+++ b/eras/conway/test-suite/test/Tests.hs
@@ -7,6 +7,7 @@ import Cardano.Ledger.Conway (Conway)
 import Data.Proxy (Proxy (..))
 import qualified Test.Cardano.Ledger.Babbage.TxInfo as Babbage (txInfoTests)
 import qualified Test.Cardano.Ledger.Conway.Serialisation.CDDL as CDDL
+import qualified Test.Cardano.Ledger.Conway.Serialisation.Failure as Failure
 import qualified Test.Cardano.Ledger.Conway.Serialisation.Roundtrip as Roundtrip
 import qualified Test.Cardano.Ledger.Conway.TxInfo as Conway (txInfoTests)
 import Test.Tasty (TestTree, defaultMain, testGroup)
@@ -22,4 +23,5 @@ defaultTests =
     , CDDL.tests 5
     , Babbage.txInfoTests (Proxy @Conway)
     , Conway.txInfoTests (Proxy @Conway)
+    , Failure.tests
     ]


### PR DESCRIPTION
# Description

Deprecate the alonze txout serialization format starting in version 9.

closes #3362

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
