### PR TITLE
Get rid of Constitutional in favor of Genesis and Committee

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
@@ -21,11 +21,6 @@ instance Crypto c => EraTxCert (AllegraEra c) where
   getTxCertPool (ShelleyTxCertPool c) = Just c
   getTxCertPool _ = Nothing
 
-  mkTxCertGenesis = ShelleyTxCertGenesis
-
-  getTxCertGenesis (ShelleyTxCertGenesis c) = Just c
-  getTxCertGenesis _ = Nothing
-
 instance Crypto c => ShelleyEraTxCert (AllegraEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (AllegraEra StandardCrypto) #-}
 
@@ -33,6 +28,11 @@ instance Crypto c => ShelleyEraTxCert (AllegraEra c) where
 
   getShelleyTxCertDeleg (ShelleyTxCertDelegCert c) = Just c
   getShelleyTxCertDeleg _ = Nothing
+
+  mkTxCertGenesisDeleg = ShelleyTxCertGenesisDeleg
+
+  getTxCertGenesisDeleg (ShelleyTxCertGenesisDeleg c) = Just c
+  getTxCertGenesisDeleg _ = Nothing
 
   mkTxCertMir = ShelleyTxCertMir
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
@@ -21,11 +21,6 @@ instance Crypto c => EraTxCert (AlonzoEra c) where
   getTxCertPool (ShelleyTxCertPool c) = Just c
   getTxCertPool _ = Nothing
 
-  mkTxCertGenesis = ShelleyTxCertGenesis
-
-  getTxCertGenesis (ShelleyTxCertGenesis c) = Just c
-  getTxCertGenesis _ = Nothing
-
 instance Crypto c => ShelleyEraTxCert (AlonzoEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (AlonzoEra StandardCrypto) #-}
 
@@ -33,6 +28,11 @@ instance Crypto c => ShelleyEraTxCert (AlonzoEra c) where
 
   getShelleyTxCertDeleg (ShelleyTxCertDelegCert c) = Just c
   getShelleyTxCertDeleg _ = Nothing
+
+  mkTxCertGenesisDeleg = ShelleyTxCertGenesisDeleg
+
+  getTxCertGenesisDeleg (ShelleyTxCertGenesisDeleg c) = Just c
+  getTxCertGenesisDeleg _ = Nothing
 
   mkTxCertMir = ShelleyTxCertMir
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -430,7 +430,7 @@ transShelleyTxCert = \case
     PV1.DCertPoolRegister (transKeyHash ppId) (PV1.PubKeyHash (PV1.toBuiltin (transHash ppVrf)))
   ShelleyTxCertPool (RetirePool keyHash (EpochNo i)) ->
     PV1.DCertPoolRetire (transKeyHash keyHash) (fromIntegral i)
-  ShelleyTxCertGenesis _ -> PV1.DCertGenesis
+  ShelleyTxCertGenesisDeleg _ -> PV1.DCertGenesis
   ShelleyTxCertMir _ -> PV1.DCertMir
 
 transWithdrawals :: Withdrawals c -> Map.Map PV1.StakingCredential Integer

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
@@ -21,11 +21,6 @@ instance Crypto c => EraTxCert (BabbageEra c) where
   getTxCertPool (ShelleyTxCertPool c) = Just c
   getTxCertPool _ = Nothing
 
-  mkTxCertGenesis = ShelleyTxCertGenesis
-
-  getTxCertGenesis (ShelleyTxCertGenesis c) = Just c
-  getTxCertGenesis _ = Nothing
-
 instance Crypto c => ShelleyEraTxCert (BabbageEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (BabbageEra StandardCrypto) #-}
 
@@ -33,6 +28,11 @@ instance Crypto c => ShelleyEraTxCert (BabbageEra c) where
 
   getShelleyTxCertDeleg (ShelleyTxCertDelegCert c) = Just c
   getShelleyTxCertDeleg _ = Nothing
+
+  mkTxCertGenesisDeleg = ShelleyTxCertGenesisDeleg
+
+  getTxCertGenesisDeleg (ShelleyTxCertGenesisDeleg c) = Just c
+  getTxCertGenesisDeleg _ = Nothing
 
   mkTxCertMir = ShelleyTxCertMir
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Added `toShelleyDelegCert` and `fromShelleyDelegCert`
 * Changed `ConwayDelegCert` structure #3408
 * Addition of `getScriptWitnessConwayTxCert` and `getVKeyWitnessConwayTxCert`
-
+* Add `ConwayCommitteeCert`
 
 ## 1.2.0.0
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -50,7 +50,14 @@ instance Era era => Arbitrary (ConwayTxCert era) where
     oneof
       [ ConwayTxCertDeleg <$> arbitrary
       , ConwayTxCertPool <$> arbitrary
-      , ConwayTxCertConstitutional <$> arbitrary
+      , ConwayTxCertCommittee <$> arbitrary
+      ]
+
+instance Crypto c => Arbitrary (ConwayCommitteeCert c) where
+  arbitrary =
+    oneof
+      [ ConwayRegCommitteeHotKey <$> arbitrary <*> arbitrary
+      , ConwayUnRegCommitteeHotKey <$> arbitrary
       ]
 
 instance Crypto c => Arbitrary (AlonzoScript (ConwayEra c)) where

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -258,7 +258,6 @@ certificate =
   // stake_delegation
   // pool_registration
   // pool_retirement
-  // constitutional_deleg_cert
   // reg_cert
   // unreg_cert
   // vote_deleg_cert
@@ -266,6 +265,8 @@ certificate =
   // stake_reg_deleg_cert
   // vote_reg_deleg_cert
   // stake_vote_reg_deleg_cert
+  // reg_committee_hot_key_cert
+  // unreg_committee_hot_key_cert
   ]
 
 stake_registration = (0, stake_credential)
@@ -273,8 +274,8 @@ stake_deregistration = (1, stake_credential)
 stake_delegation = (2, stake_credential, pool_keyhash)
 pool_registration = (3, pool_params)
 pool_retirement = (4, pool_keyhash, epoch)
-constitutional_deleg_cert = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
-; number 6 used to be the MIR certificate, which is deprecated in Conway
+; numbers 5 and 6 used to be the Genesis and MIR certificates respectively,
+; which were deprecated in Conway
 reg_cert = (7, stake_credential, coin)
 unreg_cert = (8, stake_credential, coin)
 vote_deleg_cert = (9, stake_credential, voting_credential)
@@ -282,6 +283,9 @@ stake_vote_deleg_cert = (10, stake_credential, pool_keyhash, voting_credential)
 stake_reg_deleg_cert = (11, stake_credential, pool_keyhash, coin)
 vote_reg_deleg_cert = (12, stake_credential, voting_credential, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, voting_credential, coin)
+reg_committee_hot_key_cert = (14, addr_keyhash, addr_keyhash)
+unreg_committee_hot_key_cert = (15, addr_keyhash)
+
 
 delta_coin = int
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
@@ -27,11 +27,6 @@ instance Crypto c => EraTxCert (MaryEra c) where
   getTxCertPool (ShelleyTxCertPool c) = Just c
   getTxCertPool _ = Nothing
 
-  mkTxCertGenesis = ShelleyTxCertGenesis
-
-  getTxCertGenesis (ShelleyTxCertGenesis c) = Just c
-  getTxCertGenesis _ = Nothing
-
 instance Crypto c => ShelleyEraTxCert (MaryEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (MaryEra StandardCrypto) #-}
 
@@ -39,6 +34,11 @@ instance Crypto c => ShelleyEraTxCert (MaryEra c) where
 
   getShelleyTxCertDeleg (ShelleyTxCertDelegCert c) = Just c
   getShelleyTxCertDeleg _ = Nothing
+
+  mkTxCertGenesisDeleg = ShelleyTxCertGenesisDeleg
+
+  getTxCertGenesisDeleg (ShelleyTxCertGenesisDeleg c) = Just c
+  getTxCertGenesisDeleg _ = Nothing
 
   mkTxCertMir = ShelleyTxCertMir
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -31,6 +31,7 @@
   * `delegCWitness` - no longer used.
   * `propWits` - will become an internal function in the future version
 * `validateNeededWitnesses` no longer accepts `witsVKeyNeeded` as an argument.
+* Move `ConstitutionalDelegCert` from `cardano-ledger-core` as `GenesisDelegCert`.
 
 ## 1.2.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -136,8 +136,8 @@ import Cardano.Ledger.Shelley.TxAuxData as X (
   ShelleyTxAuxData (..),
  )
 import Cardano.Ledger.Shelley.TxBody as X (
-  ConstitutionalDelegCert (..),
   Delegation (..),
+  GenesisDelegCert (..),
   MIRCert (..),
   MIRPot (..),
   MIRTarget (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -56,7 +56,12 @@ import Cardano.Ledger.Shelley.TxBody (
   MIRTarget (..),
   Ptr,
  )
-import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), pattern ShelleyTxCertDeleg)
+import Cardano.Ledger.Shelley.TxCert (
+  GenesisDelegCert (..),
+  ShelleyDelegCert (..),
+  pattern ShelleyTxCertDeleg,
+  pattern TxCertGenesisDeleg,
+ )
 import Cardano.Ledger.Slot (
   Duration (..),
   EpochNo (..),
@@ -289,7 +294,7 @@ delegationTransition = do
       UM.member hk (rewards ds) ?! StakeDelegationImpossibleDELEG hk
 
       pure (ds {dsUnified = delegations ds UM.⨃ Map.singleton hk dpool})
-    TxCertGenesis (ConstitutionalDelegCert gkh vkh vrf) -> do
+    TxCertGenesisDeleg (GenesisDelegCert gkh vkh vrf) -> do
       sp <- liftSTS $ asks stabilityWindow
       -- note that pattern match is used instead of genesisDeleg, as in the spec
       let s' = slot +* Duration sp

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.Rules.Deleg (DelegEnv (..), ShelleyDELEG, ShelleyDelegPredFailure)
 import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL, ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.TxBody (Ptr)
-import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxCert (GenesisDelegCert (..), ShelleyTxCert (..))
 import Cardano.Ledger.Slot (SlotNo)
 import Control.DeepSeq
 import Control.State.Transition
@@ -179,7 +179,7 @@ delplTransition = do
       ps <-
         trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState d, c)
       pure $ d {certPState = ps}
-    ShelleyTxCertGenesis ConstitutionalDelegCert {} -> do
+    ShelleyTxCertGenesisDeleg GenesisDelegCert {} -> do
       ds <-
         trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.Shelley.TxBody (
 import Cardano.Ledger.Shelley.TxCert (
   isInstantaneousRewards,
   pattern ShelleyTxCertDeleg,
+  pattern TxCertGenesisDeleg,
  )
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo, epochInfoEpoch)
 import Control.DeepSeq
@@ -236,7 +237,7 @@ poolDelegationTransition = do
     ShelleyTxCertDeleg _ -> do
       failBecause $ WrongCertificateTypePOOL 0
       pure ps
-    TxCertGenesis _ -> do
+    TxCertGenesisDeleg _ -> do
       failBecause $ WrongCertificateTypePOOL 2
       pure ps
     _ | isInstantaneousRewards c -> do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Reports.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Reports.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Shelley.TxCert (
   ShelleyDelegCert (..),
   isInstantaneousRewards,
   pattern ShelleyTxCertDeleg,
+  pattern TxCertGenesisDeleg,
  )
 import Cardano.Ledger.UTxO (UTxO (..))
 import Data.Foldable (fold, toList)
@@ -55,7 +56,7 @@ synopsisCert x = case x of
   ShelleyTxCertDeleg (ShelleyDelegCert cred _) -> "ShelleyDelegCert" ++ take 10 (showCred cred)
   TxCertPool (RegPool pool) -> let KeyHash hash = ppId pool in "RegPool " ++ take 10 (show hash)
   TxCertPool (RetirePool khash e) -> "RetirePool " ++ showKeyHash khash ++ " " ++ show e
-  TxCertGenesis _ -> "GenesisCert"
+  TxCertGenesisDeleg _ -> "GenesisCert"
   _ | isInstantaneousRewards x -> "MirCert"
   _ -> error "Impossible"
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -18,7 +18,7 @@
 module Cardano.Ledger.Shelley.TxBody (
   ShelleyDelegCert,
   Delegation (..),
-  ConstitutionalDelegCert (..),
+  GenesisDelegCert (..),
   MIRCert (..),
   MIRPot (..),
   MIRTarget (..),
@@ -106,6 +106,7 @@ import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxCert (
+  GenesisDelegCert (..),
   MIRCert (..),
   MIRPot (..),
   MIRTarget (..),

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -66,6 +66,7 @@ import Cardano.Ledger.Shelley.Rules (
  )
 import Cardano.Ledger.Shelley.TxAuxData
 import Cardano.Ledger.Shelley.TxCert (
+  GenesisDelegCert (..),
   MIRCert,
   MIRPot,
   MIRTarget (SendToOppositePotMIR, StakeAddressesMIR),
@@ -448,15 +449,11 @@ instance Crypto c => Arbitrary (ShelleyDelegCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Crypto c => Arbitrary (PoolCert c) where
-  arbitrary = genericArbitraryU
-  shrink = genericShrink
-
 instance Crypto c => Arbitrary (Delegation c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Crypto c => Arbitrary (ConstitutionalDelegCert c) where
+instance Crypto c => Arbitrary (GenesisDelegCert c) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
@@ -49,7 +49,11 @@ import Cardano.Ledger.Shelley.API (
 import Cardano.Ledger.Shelley.Core
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState (availableAfterMIR, rewards)
-import Cardano.Ledger.Shelley.TxCert (pattern ShelleyTxCertDeleg)
+import Cardano.Ledger.Shelley.TxCert (
+  GenesisDelegCert (..),
+  pattern ShelleyTxCertDeleg,
+  pattern TxCertGenesisDeleg,
+ )
 import Cardano.Ledger.Slot (EpochNo (EpochNo), SlotNo)
 import qualified Cardano.Ledger.UMap as UM
 import Control.Monad (replicateM)
@@ -320,7 +324,7 @@ genDelegation
       availablePools = Set.toList $ domain registeredPools
 
 genGenesisDelegation ::
-  (Era era, EraTxCert era, ProtVerAtMost era 8) =>
+  (Era era, ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   -- | Core nodes
   [(GenesisKeyPair (EraCrypto era), AllIssuerKeys (EraCrypto era) 'GenesisDelegate)] ->
   -- | All potential genesis delegate keys
@@ -341,8 +345,8 @@ genGenesisDelegation coreNodes delegateKeys dpState =
     hashVKey = hashKey . vKey
     mkCert gkey key vrf =
       Just
-        ( TxCertGenesis
-            ( ConstitutionalDelegCert
+        ( TxCertGenesisDeleg
+            ( GenesisDelegCert
                 (hashVKey gkey)
                 (hashVKey key)
                 (hashVerKeyVRF vrf)
@@ -352,11 +356,12 @@ genGenesisDelegation coreNodes delegateKeys dpState =
     GenDelegs genDelegs_ = dsGenDelegs $ certDState dpState
     genesisDelegator k = eval (k ∈ dom genDelegs_)
     genesisDelegators = filter (genesisDelegator . hashVKey) (fst <$> coreNodes)
-    notActiveDelegatee k =
-      coerceKeyRole k `List.notElem` fmap genDelegKeyHash (Map.elems genDelegs_)
-    fGenDelegs = dsFutureGenDelegs $ certDState dpState
-    notFutureDelegatee k =
-      coerceKeyRole k `List.notElem` fmap genDelegKeyHash (Map.elems fGenDelegs)
+    activeGenDelegsKeyHashSet =
+      Set.fromList $ genDelegKeyHash <$> Map.elems genDelegs_
+    futureGenDelegsKeyHashSet =
+      Set.fromList $ genDelegKeyHash <$> Map.elems (dsFutureGenDelegs $ certDState dpState)
+    notActiveDelegatee k = coerceKeyRole k `Set.notMember` activeGenDelegsKeyHashSet
+    notFutureDelegatee k = coerceKeyRole k `Set.notMember` futureGenDelegsKeyHashSet
     notDelegatee k = notActiveDelegatee k && notFutureDelegatee k
     availableDelegatees = filter (notDelegatee . hashVKey . aikCold) allDelegateKeys
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -39,6 +40,7 @@ import Cardano.Ledger.Shelley.TxBody (
   ShelleyTxBody (..),
   ShelleyTxOut (..),
  )
+import Cardano.Ledger.Shelley.TxCert (GenesisDelegCert (..), pattern TxCertGenesisDeleg)
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits)
 import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
 import Cardano.Ledger.TxIn (TxIn (..))
@@ -131,8 +133,8 @@ txbodyEx1 =
     (Set.fromList [TxIn genesisId minBound])
     (StrictSeq.singleton $ ShelleyTxOut Cast.aliceAddr aliceCoinEx1)
     ( StrictSeq.fromList
-        [ TxCertGenesis
-            ( ConstitutionalDelegCert
+        [ TxCertGenesisDeleg
+            ( GenesisDelegCert
                 (hashKey (coreNodeVK 0))
                 (hashKey (vKey newGenDelegate))
                 (newGenesisVrfKH @c)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -111,7 +111,9 @@ import Cardano.Ledger.Shelley.TxBody (
   pattern RewardAcnt,
  )
 import Cardano.Ledger.Shelley.TxCert (
+  GenesisDelegCert (..),
   pattern ShelleyTxCertDeleg,
+  pattern TxCertGenesisDeleg,
   pattern TxCertMir,
  )
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits, scriptWits)
@@ -622,8 +624,8 @@ tests =
     , checkEncodingCBOR
         shelleyProtVer
         "genesis_delegation"
-        ( TxCertGenesis @C
-            ( ConstitutionalDelegCert @C_Crypto
+        ( TxCertGenesisDeleg @C
+            ( GenesisDelegCert @C_Crypto
                 testGKeyHash
                 (hashKey . vKey $ testGenesisDelegateKey @C_Crypto)
                 (testVRFKH @C_Crypto)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Deprecate `Delegation`
 * Add `toKeyHashWitness`
 * Addition of `getVKeyWitnessTxCert` and `getScriptWitnessTxCert` to `EraTxCert` type class
+* Add new key roles: `CommitteeColdKey` and `CommitteeHotKey`
+* Remove `ConstitutionalDelegCert`. Instead it now lives in `cardano-ledger-shelley` as
+  `GenesisDelegCert`
 
 ## 1.2.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -11,14 +11,10 @@
 module Cardano.Ledger.Core.TxCert (
   EraTxCert (..),
   pattern TxCertPool,
-  pattern TxCertGenesis,
   Delegation (..),
   PoolCert (..),
   poolCWitness,
   poolCertKeyHashWitness,
-  ConstitutionalDelegCert (..),
-  genesisKeyHashWitness,
-  genesisCWitness,
 )
 where
 
@@ -26,14 +22,8 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR, FromCBOR, ToCBOR)
 import Cardano.Ledger.Core.Era (Era (EraCrypto))
 import Cardano.Ledger.Credential (Credential (..), StakeCredential)
 import Cardano.Ledger.Hashes (ScriptHash)
-import Cardano.Ledger.Keys (
-  Hash,
-  KeyHash (..),
-  KeyRole (..),
-  VerKeyVRF,
-  asWitness,
- )
-import Cardano.Ledger.PoolParams
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), asWitness)
+import Cardano.Ledger.PoolParams (PoolParams (ppId))
 import Cardano.Ledger.Slot (EpochNo (..))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Kind (Type)
@@ -65,22 +55,10 @@ class
 
   getTxCertPool :: TxCert era -> Maybe (PoolCert (EraCrypto era))
 
-  mkTxCertGenesis :: ConstitutionalDelegCert (EraCrypto era) -> TxCert era
-
-  getTxCertGenesis :: TxCert era -> Maybe (ConstitutionalDelegCert (EraCrypto era))
-
 pattern TxCertPool :: EraTxCert era => PoolCert (EraCrypto era) -> TxCert era
 pattern TxCertPool d <- (getTxCertPool -> Just d)
   where
     TxCertPool d = mkTxCertPool d
-
-pattern TxCertGenesis ::
-  EraTxCert era =>
-  ConstitutionalDelegCert (EraCrypto era) ->
-  TxCert era
-pattern TxCertGenesis d <- (getTxCertGenesis -> Just d)
-  where
-    TxCertGenesis d = mkTxCertGenesis d
 
 -- | The delegation of one stake key to another.
 data Delegation c = Delegation
@@ -107,19 +85,6 @@ instance NoThunks (PoolCert c)
 instance NFData (PoolCert c) where
   rnf = rwhnf
 
--- | Constitutional key delegation certificate
-data ConstitutionalDelegCert c
-  = ConstitutionalDelegCert
-      !(KeyHash 'Genesis c)
-      !(KeyHash 'GenesisDelegate c)
-      !(Hash c (VerKeyVRF c))
-  deriving (Show, Generic, Eq)
-
-instance NoThunks (ConstitutionalDelegCert c)
-
-instance NFData (ConstitutionalDelegCert c) where
-  rnf = rwhnf
-
 poolCertKeyHashWitness :: PoolCert c -> KeyHash 'Witness c
 poolCertKeyHashWitness = \case
   RegPool poolParams -> asWitness $ ppId poolParams
@@ -128,9 +93,3 @@ poolCertKeyHashWitness = \case
 poolCWitness :: PoolCert c -> Credential 'StakePool c
 poolCWitness (RegPool pool) = KeyHashObj $ ppId pool
 poolCWitness (RetirePool k _) = KeyHashObj k
-
-genesisKeyHashWitness :: ConstitutionalDelegCert c -> KeyHash 'Witness c
-genesisKeyHashWitness (ConstitutionalDelegCert gk _ _) = asWitness gk
-
-genesisCWitness :: ConstitutionalDelegCert c -> KeyHash 'Genesis c
-genesisCWitness (ConstitutionalDelegCert gk _ _) = gk

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -125,6 +125,8 @@ data KeyRole
   | BlockIssuer
   | Witness
   | Voting
+  | CommitteeHotKey
+  | CommitteeColdKey
   deriving (Show)
 
 class HasKeyRole (a :: KeyRole -> Type -> Type) where

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -629,3 +629,15 @@ instance Crypto c => Arbitrary (Stake c) where
         let pair = (,) <$> arbitrary <*> (CompactCoin <$> genWord64 n)
         list <- frequency [(1, pure []), (99, vectorOf n pair)]
         pure (Map.fromList list)
+
+------------------------------------------------------------------------------------------
+-- Cardano.Ledger.Core.TxCert ----------------------------------------------------------
+------------------------------------------------------------------------------------------
+
+instance Crypto c => Arbitrary (PoolCert c) where
+  arbitrary =
+    oneof
+      [ RegPool <$> arbitrary
+      , RetirePool <$> arbitrary <*> arbitrary
+      ]
+  shrink = genericShrink

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -144,7 +145,7 @@ import Cardano.Ledger.Shelley.TxBody (
   WitVKey (..),
   Withdrawals (..),
  )
-import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxCert (GenesisDelegCert (..), ShelleyDelegCert (..), ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxWits (
   ShelleyTxWits,
   prettyWitnessSetParts,
@@ -1111,8 +1112,8 @@ ppPoolCert :: PoolCert c -> PDoc
 ppPoolCert (RegPool x) = ppSexp "RegPool" [ppPoolParams x]
 ppPoolCert (RetirePool x y) = ppSexp "RetirePool" [ppKeyHash x, ppEpochNo y]
 
-ppConstitutionalDelegCert :: ConstitutionalDelegCert c -> PDoc
-ppConstitutionalDelegCert (ConstitutionalDelegCert a b1 c) = ppSexp "GenesisDelgCert" [ppKeyHash a, ppKeyHash b1, ppHash c]
+ppGenesisDelegCert :: GenesisDelegCert c -> PDoc
+ppGenesisDelegCert (GenesisDelegCert a b1 c) = ppSexp "GenesisDelgCert" [ppKeyHash a, ppKeyHash b1, ppHash c]
 
 ppMIRPot :: MIRPot -> PDoc
 ppMIRPot ReservesMIR = text "Reserves"
@@ -1126,10 +1127,11 @@ ppMIRCert :: MIRCert c -> PDoc
 ppMIRCert (MIRCert pot vs) = ppSexp "MirCert" [ppMIRPot pot, ppMIRTarget vs]
 
 ppShelleyTxCert :: ShelleyTxCert c -> PDoc
-ppShelleyTxCert (ShelleyTxCertDelegCert x) = ppSexp "ShelleyTxCertDeleg" [ppShelleyDelegCert x]
-ppShelleyTxCert (ShelleyTxCertPool x) = ppSexp "TxCertPool" [ppPoolCert x]
-ppShelleyTxCert (ShelleyTxCertGenesis x) = ppSexp "TxCertGenesis" [ppConstitutionalDelegCert x]
-ppShelleyTxCert (ShelleyTxCertMir x) = ppSexp "TxCertMir" [ppMIRCert x]
+ppShelleyTxCert = \case
+  ShelleyTxCertDelegCert x -> ppSexp "ShelleyTxCertDeleg" [ppShelleyDelegCert x]
+  ShelleyTxCertPool x -> ppSexp "TxCertPool" [ppPoolCert x]
+  ShelleyTxCertGenesisDeleg x -> ppSexp "ShelleyTxCertGenesisDeleg" [ppGenesisDelegCert x]
+  ShelleyTxCertMir x -> ppSexp "TxCertMir" [ppMIRCert x]
 
 ppTxBody ::
   ( EraTxOut era
@@ -1190,8 +1192,8 @@ instance PrettyA (ShelleyDelegCert c) where
 instance PrettyA (PoolCert c) where
   prettyA = ppPoolCert
 
-instance PrettyA (ConstitutionalDelegCert c) where
-  prettyA = ppConstitutionalDelegCert
+instance PrettyA (GenesisDelegCert c) where
+  prettyA = ppGenesisDelegCert
 
 instance PrettyA MIRPot where
   prettyA = ppMIRPot

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -42,6 +43,7 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Conway.TxCert (
+  ConwayCommitteeCert (..),
   ConwayDelegCert (..),
   ConwayTxCert (..),
   Delegatee (..),
@@ -52,7 +54,6 @@ import Cardano.Ledger.Pretty (
   PrettyA (..),
   ppAuxiliaryDataHash,
   ppCoin,
-  ppConstitutionalDelegCert,
   ppKeyHash,
   ppNetwork,
   ppPoolCert,
@@ -125,10 +126,17 @@ instance PrettyA (ConwayDelegCert c) where
       , ("Deposit", prettyA deposit)
       ]
 
-ppConwayTxCert :: ConwayTxCert c -> PDoc
-ppConwayTxCert (ConwayTxCertDeleg dc) = ppSexp "ConwayTxCertDeleg" [prettyA dc]
-ppConwayTxCert (ConwayTxCertPool pc) = ppSexp "ConwayTxCertPool" [ppPoolCert pc]
-ppConwayTxCert (ConwayTxCertConstitutional gdc) = ppSexp "ConwayTxCertConstitutional" [ppConstitutionalDelegCert gdc]
+ppConwayTxCert :: ConwayTxCert era -> PDoc
+ppConwayTxCert = \case
+  ConwayTxCertDeleg dc -> ppSexp "ConwayTxCertDeleg" [prettyA dc]
+  ConwayTxCertPool pc -> ppSexp "ConwayTxCertPool" [ppPoolCert pc]
+  ConwayTxCertCommittee gdc -> ppSexp "ConwayTxCertCommittee" [ppConwayCommitteeCert gdc]
+
+ppConwayCommitteeCert :: ConwayCommitteeCert c -> PDoc
+ppConwayCommitteeCert = \case
+  ConwayRegCommitteeHotKey coldKey hotKey ->
+    ppSexp "ConwayRegCommitteeHotKey" [prettyA coldKey, prettyA hotKey]
+  ConwayUnRegCommitteeHotKey coldKey -> ppSexp "ConwayUnRegCommitteeHotKey" [prettyA coldKey]
 
 ppConwayTxBody ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -214,7 +214,7 @@ applyShelleyCert model dcert = case dcert of
       }
     where
       pp = mPParams model
-  ShelleyTxCertGenesis _ -> model
+  ShelleyTxCertGenesisDeleg _ -> model
   ShelleyTxCertMir _ -> model
 
 -- =========================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1399,13 +1399,13 @@ instance c ~ EraCrypto era => PrettyC (PoolCert c) era where prettyC _ = pcPoolC
 pcShelleyTxCert :: ShelleyTxCert c -> PDoc
 pcShelleyTxCert (ShelleyTxCertDelegCert x) = pcDelegCert x
 pcShelleyTxCert (ShelleyTxCertPool x) = pcPoolCert x
-pcShelleyTxCert (ShelleyTxCertGenesis _) = ppString "GenesisCert"
+pcShelleyTxCert (ShelleyTxCertGenesisDeleg _) = ppString "GenesisCert"
 pcShelleyTxCert (ShelleyTxCertMir _) = ppString "MirCert"
 
 pcConwayTxCert :: ConwayTxCert c -> PDoc
 pcConwayTxCert (ConwayTxCertDeleg dc) = prettyA dc
 pcConwayTxCert (ConwayTxCertPool poolc) = pcPoolCert poolc
-pcConwayTxCert (ConwayTxCertConstitutional _) = ppString "GenesisCert"
+pcConwayTxCert (ConwayTxCertCommittee _) = ppString "ConwayTxCertCommittee"
 
 instance c ~ EraCrypto era => PrettyC (ShelleyTxCert c) era where prettyC _ = pcShelleyTxCert
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -814,7 +814,7 @@ getShelleyTxCertCredential = \case
     case pc of
       RegPool PoolParams {..} -> Just . coerceKeyRole $ KeyHashObj ppId
       RetirePool kh _ -> Just . coerceKeyRole $ KeyHashObj kh
-  ShelleyTxCertGenesis _g -> Nothing
+  ShelleyTxCertGenesisDeleg _g -> Nothing
   ShelleyTxCertMir _m -> Nothing
 
 getConwayTxCertCredential :: ConwayTxCert era -> Maybe (Credential 'Staking (EraCrypto era))
@@ -824,7 +824,7 @@ getConwayTxCertCredential (ConwayTxCertDeleg (ConwayRegCert _ _)) = Nothing
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayUnRegCert cred _)) = Just cred
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayDelegCert cred _)) = Just cred
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayRegDelegCert cred _ _)) = Just cred
-getConwayTxCertCredential (ConwayTxCertConstitutional _) = Nothing
+getConwayTxCertCredential (ConwayTxCertCommittee _) = Nothing
 
 genWithdrawals :: Reflect era => SlotNo -> GenRS era (Withdrawals (EraCrypto era), RewardAccounts (EraCrypto era))
 genWithdrawals slot =


### PR DESCRIPTION
# Description

Constitutional committee certificate turns out to be a bit different from genesis delegation certificate:

* Genesis has a VRF field, which makes no sense for committee certificate
* Hashes in committee certificates will have different roles
* ~Committee certificates have credentials?~ Spec is a bit outdated and it was decided not to allow scripts in committee certificates
* Committee certificates are split in two: register and unregister, while genesis delegation, could not be undelegated

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Any changes are noted in the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
