### PR TITLE
conway CDDL minor fixes

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -90,6 +90,7 @@ data GovernanceAction era
   | NoConfidence
   | NewCommittee !(Set (KeyHash 'Voting (EraCrypto era))) !Rational
   | NewConstitution !(SafeHash (EraCrypto era) ByteString)
+  | InfoAction
   deriving (Generic)
 
 deriving instance EraPParams era => Eq (GovernanceAction era)
@@ -113,6 +114,7 @@ instance EraPParams era => DecCBOR (GovernanceAction era) where
       dec 3 = SumD NoConfidence
       dec 4 = SumD NewCommittee <! From <! From
       dec 5 = SumD NewConstitution <! From
+      dec 6 = SumD InfoAction
       dec k = Invalid k
 
 instance EraPParams era => EncCBOR (GovernanceAction era) where
@@ -124,6 +126,7 @@ instance EraPParams era => EncCBOR (GovernanceAction era) where
       enc NoConfidence = Sum NoConfidence 3
       enc (NewCommittee mems quorum) = Sum NewCommittee 4 !> To mems !> To quorum
       enc (NewConstitution h) = Sum NewConstitution 5 !> To h
+      enc InfoAction = Sum InfoAction 6
 
 newtype GovernanceActionIx = GovernanceActionIx Word64
   deriving (Generic, Eq, Ord, Show, Num, Enum, NFData, NoThunks, EncCBOR, DecCBOR, ToJSON)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
@@ -76,6 +76,7 @@ enactmentTransition = do
     NoConfidence -> pure $ st {ensCommittee = SNothing}
     NewCommittee mems q -> pure $ st {ensCommittee = SJust (mems, q)}
     NewConstitution c -> pure $ st {ensConstitution = c}
+    InfoAction -> pure st
 
 instance Inject (EnactPredFailure era) (EnactPredFailure era) where
   inject = id

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -71,15 +71,10 @@ transaction_body =
   , ? 20 : [* proposal_procedure]   ; New; Proposal procedures
   }
 
-vote_info =
-  [ voter_role
-  , stake_credential
-  ]
-
 voting_procedure =
   [ governance_action_id
   , voter_role
-  , stake_credential
+  , voting_credential
   , vote
   , anchor / null
   ]
@@ -98,6 +93,7 @@ governance_action =
   // no_confidence
   // new_committee
   // new_constitution
+  // info_action
   ]
 
 parameter_change_action = (0, protocol_param_update)
@@ -111,6 +107,8 @@ no_confidence = 3
 new_committee = (4, [* $addr_keyhash], rational)
 
 new_constitution = (5, $hash32)
+
+info_action = 6
 
 ; constitutional committee - 0
 ; DRep - 1
@@ -283,8 +281,8 @@ stake_vote_deleg_cert = (10, stake_credential, pool_keyhash, voting_credential)
 stake_reg_deleg_cert = (11, stake_credential, pool_keyhash, coin)
 vote_reg_deleg_cert = (12, stake_credential, voting_credential, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, voting_credential, coin)
-reg_committee_hot_key_cert = (14, addr_keyhash, addr_keyhash)
-unreg_committee_hot_key_cert = (15, addr_keyhash)
+reg_committee_hot_key_cert = (14, committee_cold_keyhash, committee_hot_keyhash)
+unreg_committee_hot_key_cert = (15, committee_cold_keyhash)
 
 
 delta_coin = int
@@ -503,10 +501,12 @@ network_id = 0 / 1
 
 epoch = uint
 
-addr_keyhash          = $hash28
-genesis_delegate_hash = $hash28
-pool_keyhash          = $hash28
-genesishash           = $hash28
+addr_keyhash           = $hash28
+genesis_delegate_hash  = $hash28
+pool_keyhash           = $hash28
+genesishash            = $hash28
+committee_cold_keyhash = $hash28
+committee_hot_keyhash  = $hash28
 
 vrf_keyhash           = $hash32
 auxiliary_data_hash   = $hash32

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -502,9 +502,7 @@ network_id = 0 / 1
 epoch = uint
 
 addr_keyhash           = $hash28
-genesis_delegate_hash  = $hash28
 pool_keyhash           = $hash28
-genesishash            = $hash28
 committee_cold_keyhash = $hash28
 committee_hot_keyhash  = $hash28
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -204,6 +204,8 @@ instance PrettyA (PParamsUpdate era) => PrettyA (GovernanceAction era) where
     ppRecord
       "NewConstitution"
       [("hash", prettyA c)]
+  prettyA InfoAction =
+    ppRecord "InfoAction" []
 
 instance forall c. PrettyA (ConwayTxCert c) where
   prettyA = ppConwayTxCert


### PR DESCRIPTION
# Description

* voting_procedure should have `voting_credential` not `stake_credential`
* info action missing (from the implementation as well)
* vote_info is vestigal and unused
* CC hot key certs had confusing parameter names (`addr_keyhash`)

Many thanks to @ryun1 for catching all these (and others as well)!


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
