### PR TITLE
updatet hackage index

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,9 +12,9 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
-index-state: 2023-04-28T00:00:00Z
+index-state: 2023-05-25T00:00:00Z
 index-state:
-  , hackage.haskell.org 2023-04-28T00:00:00Z
+  , hackage.haskell.org 2023-05-25T00:00:00Z
 -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2023-05-09T09:56:38Z
 
@@ -94,12 +94,3 @@ source-repository-package
   location: https://github.com/fpco/weigh.git
   tag: bfcf4415144d7d2817dfcb91b6f9a6dfd7236de7
   --sha256: 01fy4nbq6kaqi73ydn6w7rd1izkg5p217q5znyp2icybf41sl1b6
-
--- https://github.com/well-typed/cborg/pull/301
-source-repository-package
-  type: git
-  location: https://github.com/lehins/cborg
-  tag: c2e86cdd1ac9c51dedb5ef199f513cf48668bcd7
-  --sha256: 18apsg2lqjv9cc29nbd3hzj2hqhksqjj0s4xp2rdv8cbd27racjh
-  subdir:
-    cborg

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.1.0
 
 * Add `unlessDecoderVersionAtLeast` and `guardUntilAtLeast`
+* Set bound on cborg >=0.2.9
 
 ## 1.1.0.0
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -56,7 +56,7 @@ library
         cardano-crypto-praos >=2.1,
         cardano-slotting,
         cardano-strict-containers >=0.1.2,
-        cborg,
+        cborg >=0.2.9,
         containers,
         data-fix,
         deepseq,

--- a/libs/set-algebra/CHANGELOG.md
+++ b/libs/set-algebra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `set-algebra`
 
+## 1.1.0.1
+
+- Set upper bound ansi-wl-pprint < 1.0
+
 ## 1.1.0.0
 
 - Remove unused instances for `Data.UMap` #3371

--- a/libs/set-algebra/set-algebra.cabal
+++ b/libs/set-algebra/set-algebra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               set-algebra
-version:            1.1.0.0
+version:            1.1.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -31,7 +31,7 @@ library
 
     build-depends:
         base >=4.14 && <4.17,
-        ansi-wl-pprint,
+        ansi-wl-pprint <1.0,
         cardano-data >=1.1,
         containers
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/cardano-haskell-packages/",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "ef8e5093f0ea0f1e59f944fa502c685b1bf085c2",
-        "sha256": "03bj4hwsrknvkqazix16hmk9ylc5xc7qb0ajxxmjngn7xmkw20c6",
+        "rev": "656cf97bed04220d9c1f354ad706e61be71d72df",
+        "sha256": "00058ayy6zrfg5jvc79spgdbakshdwnyvn1cqcw8j0f8k958pws9",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/ef8e5093f0ea0f1e59f944fa502c685b1bf085c2.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-haskell-packages/archive/656cf97bed04220d9c1f354ad706e61be71d72df.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hackage.nix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56",
-        "sha256": "0vqvsqg96b4wcr0wisbllyzg1ra7pvmr3vc1c6i4bsf03vl42h45",
+        "rev": "a46bcacd98b9a38a4bec8a9b0d60dbd187ca5262",
+        "sha256": "0myqfnazjfh368gyvip9gblvqs01kd0cddsp9f9canfq4xvg9g7j",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/a46bcacd98b9a38a4bec8a9b0d60dbd187ca5262.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "b3c99d7f13df89a9a918c835ecb7114098912962"
     },


### PR DESCRIPTION
# Description

Updatet hackage index and set `cborg >=0.2.9 in` `cardano-ledger-binary`. Also remove the cborg SRP.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
