### PR TITLE
fix ShelleyGenesis' NoThunks instance to allow thunks inside the sgInitialFunds and sgStaking fields

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -32,6 +32,7 @@
   * `propWits` - will become an internal function in the future version
 * `validateNeededWitnesses` no longer accepts `witsVKeyNeeded` as an argument.
 * Move `ConstitutionalDelegCert` from `cardano-ledger-core` as `GenesisDelegCert`.
+* Fixed `NoThunks (ShelleyGenesis c)` instance, as it was incorrectly disallowing thunks in its `sgInitialFunds` and `sgStaking` fields
 
 ## 1.2.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -101,7 +101,7 @@ import Data.Time.Clock (
 import Data.Unit.Strict (forceElemsToWHNF)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..), AllowThunksIn(..))
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 
 -- | Genesis Shelley staking configuration.
 --
@@ -221,8 +221,10 @@ deriving instance Crypto c => Show (ShelleyGenesis c)
 
 deriving instance Crypto c => Eq (ShelleyGenesis c)
 
-deriving via AllowThunksIn '["sgInitialFunds", "sgStaking"] (ShelleyGenesis c)
-  instance Crypto c => NoThunks (ShelleyGenesis c)
+deriving via
+  AllowThunksIn '["sgInitialFunds", "sgStaking"] (ShelleyGenesis c)
+  instance
+    Crypto c => NoThunks (ShelleyGenesis c)
 
 sgActiveSlotCoeff :: ShelleyGenesis c -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -100,7 +101,7 @@ import Data.Time.Clock (
 import Data.Unit.Strict (forceElemsToWHNF)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
+import NoThunks.Class (NoThunks (..), AllowThunksIn(..))
 
 -- | Genesis Shelley staking configuration.
 --
@@ -208,7 +209,11 @@ data ShelleyGenesis c = ShelleyGenesis
   , sgProtocolParams :: !(PParams (ShelleyEra c))
   , sgGenDelegs :: !(Map (KeyHash 'Genesis c) (GenDelegPair c))
   , sgInitialFunds :: LM.ListMap (Addr c) Coin
+  -- ^ 'sgInitialFunds' is intentionally kept lazy, as it can otherwise cause
+  --   out-of-memory problems in testing and benchmarking.
   , sgStaking :: ShelleyGenesisStaking c
+  -- ^ 'sgStaking' is intentionally kept lazy, as it can otherwise cause
+  --   out-of-memory problems in testing and benchmarking.
   }
   deriving stock (Generic)
 
@@ -216,7 +221,8 @@ deriving instance Crypto c => Show (ShelleyGenesis c)
 
 deriving instance Crypto c => Eq (ShelleyGenesis c)
 
-deriving instance Crypto c => NoThunks (ShelleyGenesis c)
+deriving via AllowThunksIn '["sgInitialFunds", "sgStaking"] (ShelleyGenesis c)
+  instance Crypto c => NoThunks (ShelleyGenesis c)
 
 sgActiveSlotCoeff :: ShelleyGenesis c -> ActiveSlotCoeff
 sgActiveSlotCoeff = mkActiveSlotCoeff . sgActiveSlotsCoeff


### PR DESCRIPTION
this was causing consensus' test suite to fail when built with strict-stm's checktvarinvariant flag enabled, as consensus has an invariant that all mutable cells must contain no unforced thunks (via NoThunks)

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
