### PR TITLE
fix conway CDDL, Value allows larger values

### DIFF
--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Version history for `cardano-ledger-conway-test`
+
+## 1.2.0.0
+
+- changes have been made
+

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -487,11 +487,10 @@ asset_name = bytes .size (0..32)
 negInt64 = -9223372036854775808 .. -1
 posInt64 = 1 .. 9223372036854775807
 nonZeroInt64 = negInt64 / posInt64 ; this is the same as the current int64 definition but without zero
-natNum = 1 .. 4294967295 ; non-zero 32bit uint
 
 positive_coin = 1 .. 18446744073709551615
 
-value = positive_coin / [positive_coin,multiasset<natNum>]
+value = positive_coin / [positive_coin,multiasset<positive_coin>]
 
 mint = multiasset<nonZeroInt64>
 


### PR DESCRIPTION
# Description

In conway, the number of any individual multi-asset in a transaction output can be any positive Word64. The CDDL, however, was specifying that the max was `4,294,967,295`.

See:
- https://github.com/input-output-hk/cardano-ledger/blob/c1603995da7c57d95371844191d235b05bb476b7/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs#L296-L303
- https://github.com/input-output-hk/cardano-ledger/blob/c1603995da7c57d95371844191d235b05bb476b7/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs#L147-L152

The CDDL property tests that currently exist will ensure that expanding the values from the CDDL do not lead to deserialization errors.

Many thanks to @vsubhuman for catching this!

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
