### PR TITLE
Add POOL rules to Conway

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.3.0.0
 
+* Add `POOL` rules to Conway #3464
+  * Make `ShelleyPOOL` rules reusable in Conway
 * Add `CERT` and `DELEG` rules to Conway #3412
   * Add `domDeleteAll` to `UMap`.
 * Introduction of `TxCert` and `EraTxCert`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -81,7 +81,7 @@ instance
   , Environment (EraRule "POOL" era) ~ PoolEnv era
   , Environment (EraRule "VDEL" era) ~ VDelEnv era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
-  , Signal (EraRule "POOL" era) ~ TxCert era
+  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
   , Embed (EraRule "DELEG" era) (ConwayCERT era)
   , Embed (EraRule "POOL" era) (ConwayCERT era)
@@ -108,7 +108,7 @@ certTransition ::
   , Environment (EraRule "POOL" era) ~ PoolEnv era
   , Environment (EraRule "VDEL" era) ~ VDelEnv era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
-  , Signal (EraRule "POOL" era) ~ TxCert era
+  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
   , Embed (EraRule "DELEG" era) (ConwayCERT era)
   , Embed (EraRule "POOL" era) (ConwayCERT era)
@@ -122,8 +122,8 @@ certTransition = do
     ConwayTxCertDeleg delegCert -> do
       newDState <- trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState, delegCert)
       pure $ cState {certDState = newDState}
-    ConwayTxCertPool _poolCert -> do
-      newPState <- trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState, c)
+    ConwayTxCertPool poolCert -> do
+      newPState <- trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState, poolCert)
       pure $ cState {certPState = newPState}
     ConwayTxCertCommittee committeeCert -> do
       newVState <- trans @(EraRule "VDEL" era) $ TRC (VDelEnv, certVState, committeeCert)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -16,9 +16,10 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.CertState (PState (..))
 import Cardano.Ledger.Conway.Era (ConwayPOOL)
 import Cardano.Ledger.Core (
+  EraCrypto,
   EraPParams,
   EraRule,
-  EraTxCert (TxCert),
+  PoolCert,
  )
 import Cardano.Ledger.Shelley.API (
   PoolEnv,
@@ -26,7 +27,7 @@ import Cardano.Ledger.Shelley.API (
 import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyPoolPredFailure,
-  poolDelegationTransition,
+  poolCertTransition,
  )
 import Cardano.Ledger.Shelley.TxCert (ShelleyEraTxCert)
 import Control.State.Transition (
@@ -39,11 +40,13 @@ import Control.State.Transition (
   State,
   transitionRules,
  )
+import Control.State.Transition.Extended (TRC (TRC), TransitionRule, judgmentContext)
 
 instance
+  forall era.
   ( EraPParams era
   , State (EraRule "POOL" era) ~ PState era
-  , Signal (EraRule "POOL" era) ~ TxCert era
+  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Environment (EraRule "POOL" era) ~ PoolEnv era
   , EraRule "POOL" era ~ ConwayPOOL era
   , ShelleyEraTxCert era
@@ -51,10 +54,20 @@ instance
   STS (ConwayPOOL era)
   where
   type State (ConwayPOOL era) = PState era
-  type Signal (ConwayPOOL era) = TxCert era
+  type Signal (ConwayPOOL era) = PoolCert (EraCrypto era)
   type Environment (ConwayPOOL era) = PoolEnv era
   type BaseM (ConwayPOOL era) = ShelleyBase
   type PredicateFailure (ConwayPOOL era) = ShelleyPoolPredFailure era
   type Event (ConwayPOOL era) = PoolEvent era
 
-  transitionRules = [poolDelegationTransition]
+  transitionRules = [conwayPoolTransition]
+
+conwayPoolTransition ::
+  ( EraPParams era
+  , ShelleyEraTxCert era
+  , EraRule "POOL" era ~ ConwayPOOL era
+  ) =>
+  TransitionRule (ConwayPOOL era)
+conwayPoolTransition = do
+  TRC (penv, pState, c) <- judgmentContext
+  poolCertTransition penv pState c

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -11,17 +13,46 @@
 
 module Cardano.Ledger.Conway.Rules.Pool (
   ConwayPOOL,
-  ConwayPoolEvent (..),
   ConwayPoolPredFailure (..),
 )
 where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase)
-import Cardano.Ledger.CertState (PState)
+import Cardano.Crypto.Hash (sizeHash)
+import Cardano.Ledger.BaseTypes (EpochNo, Network, ShelleyBase, epochInfoPure)
+import Cardano.Ledger.CertState (PState (..), payPoolDeposit)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Era (ConwayPOOL)
-import Cardano.Ledger.Core (Era (EraCrypto), EraRule)
-import Cardano.Ledger.Shelley.API (PoolCert, PoolEnv)
+import Cardano.Ledger.Core (
+  Era (EraCrypto),
+  EraPParams,
+  EraRule,
+  PoolCert (..),
+  ppEMaxL,
+  ppMinPoolCostL,
+  ppProtocolVersionL,
+ )
+import Cardano.Ledger.Crypto (Crypto (HASH))
+import Cardano.Ledger.Shelley.API (
+  KeyHash,
+  KeyRole (StakePool),
+  PoolEnv (PoolEnv),
+  PoolParams (PoolParams),
+  getRwdNetwork,
+  networkId,
+  pmHash,
+  ppCost,
+  ppId,
+  ppMetadata,
+  ppRewardAcnt,
+ )
+import qualified Cardano.Ledger.Shelley.HardForks as HardForks
+import Cardano.Ledger.Shelley.Rules (PoolEvent (RegisterPool, ReregisterPool))
+import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
+import Cardano.Ledger.Slot (epochInfoEpoch)
 import Control.DeepSeq (NFData)
+import Control.Monad (forM_, when)
+import Control.Monad.Trans.Reader (asks)
+import Control.SetAlgebra (dom, eval, (∈), (∉), (∪), (⋪), (⨃))
 import Control.State.Transition (
   BaseM,
   Environment,
@@ -32,17 +63,25 @@ import Control.State.Transition (
   State,
   transitionRules,
  )
+import Control.State.Transition.Extended (TRC (TRC), TransitionRule, judgmentContext, liftSTS, tellEvent, (?!))
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks (..))
 
 data ConwayPoolPredFailure era
   = ConwayPoolPredFailure
+  | WrongNetworkPOOL !Network !Network !(KeyHash 'StakePool (EraCrypto era))
+  | PoolMedataHashTooBigPOOL !(KeyHash 'StakePool (EraCrypto era)) !Int
+  | StakePoolCostTooLowPOOL !Coin !Coin
+  | StakePoolNotRegisteredOnKeyPOOL !(KeyHash 'StakePool (EraCrypto era))
+  | StakePoolRetirementWrongEpochPOOL EpochNo EpochNo EpochNo
   deriving (Show, Eq, Generic, NoThunks, NFData)
 
-newtype ConwayPoolEvent era = PoolEvent (Event (EraRule "POOL" era))
-
 instance
-  ( Era era
+  ( EraPParams era
   , State (EraRule "POOL" era) ~ PState era
   , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Environment (EraRule "POOL" era) ~ PoolEnv era
@@ -55,6 +94,69 @@ instance
   type Environment (ConwayPOOL era) = PoolEnv era
   type BaseM (ConwayPOOL era) = ShelleyBase
   type PredicateFailure (ConwayPOOL era) = ConwayPoolPredFailure era
-  type Event (ConwayPOOL era) = ConwayPoolEvent era
+  type Event (ConwayPOOL era) = PoolEvent era
 
-  transitionRules = undefined -- TODO
+  transitionRules = [conwayPoolTransition @era]
+
+conwayPoolTransition ::
+  forall era.
+  ( EraPParams era
+  , EraRule "POOL" era ~ ConwayPOOL era
+  ) =>
+  TransitionRule (ConwayPOOL era)
+conwayPoolTransition = do
+  TRC
+    ( PoolEnv slot pp
+      , pState@PState {psStakePoolParams, psFutureStakePoolParams, psRetiring}
+      , c
+      ) <-
+    judgmentContext
+  let pv = pp ^. ppProtocolVersionL
+  case c of
+    RegPool poolParams@PoolParams {ppId, ppCost, ppRewardAcnt, ppMetadata} -> do
+      when (HardForks.validatePoolRewardAccountNetID pv) $ do
+        actualNetID <- liftSTS $ asks networkId
+        let suppliedNetID = getRwdNetwork ppRewardAcnt
+        actualNetID == suppliedNetID ?! WrongNetworkPOOL actualNetID suppliedNetID ppId
+      when (SoftForks.restrictPoolMetadataHash pv) $ do
+        forM_ ppMetadata $ \pMetadata ->
+          let s = BS.length (pmHash pMetadata)
+           in s <= fromIntegral (sizeHash ([] @(HASH (EraCrypto era)))) ?! PoolMedataHashTooBigPOOL ppId s
+      let minPoolCost = pp ^. ppMinPoolCostL
+      ppCost >= minPoolCost ?! StakePoolCostTooLowPOOL ppCost minPoolCost
+      if eval (ppId ∉ dom psStakePoolParams)
+        then do
+          -- NOTE: @Soupstraw only this is part is in the spec right now.
+          -- register new, Pool-Reg
+          tellEvent $ RegisterPool ppId
+          pure $
+            payPoolDeposit ppId pp $
+              pState
+                { psStakePoolParams = eval $ psStakePoolParams ∪ Map.singleton ppId poolParams
+                }
+        else do
+          tellEvent $ ReregisterPool ppId
+          -- hk is already registered, so we want to reregister it. That means adding it to the
+          -- Future pool params (if it is not there already), and overriding the range with the new 'pp',
+          -- if it is (using ⨃ ). We must also unretire it, if it has been scheduled for retirement.
+          -- The deposit does not change. One pays the deposit just once. Only if it is fully retired
+          -- (i.e. it's deposit has been refunded, and it has been removed from the registered pools).
+          -- does it need to pay a new deposit (at the current deposit amount). But of course,
+          -- if that has happened, we cannot be in this branch of the if statement.
+          pure $
+            pState
+              { psFutureStakePoolParams = eval $ psFutureStakePoolParams ⨃ Map.singleton ppId poolParams
+              , psRetiring = eval $ Set.singleton ppId ⋪ psRetiring
+              }
+    RetirePool sPool epochN -> do
+      eval (sPool ∈ dom psStakePoolParams) ?! StakePoolNotRegisteredOnKeyPOOL sPool
+      cepoch <- liftSTS $ do
+        ei <- asks epochInfoPure
+        epochInfoEpoch ei slot
+      let maxEpoch = pp ^. ppEMaxL
+      (cepoch < epochN && epochN <= cepoch + maxEpoch) ?! StakePoolRetirementWrongEpochPOOL cepoch epochN (cepoch + maxEpoch)
+      -- We just schedule it for retirement. When it is retired we refund the deposit (see POOLREAP)
+      -- pure $ pState {psRetiring = eval $ psRetiring ⨃ Map.singleton sPool epochN}
+
+      -- NOTE: @Soupstraw: only this line is in the spec now.
+      pure $ pState {psRetiring = Map.singleton sPool epochN `Map.union` psRetiring}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -1,11 +1,7 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -13,46 +9,26 @@
 
 module Cardano.Ledger.Conway.Rules.Pool (
   ConwayPOOL,
-  ConwayPoolPredFailure (..),
 )
 where
 
-import Cardano.Crypto.Hash (sizeHash)
-import Cardano.Ledger.BaseTypes (EpochNo, Network, ShelleyBase, epochInfoPure)
-import Cardano.Ledger.CertState (PState (..), payPoolDeposit)
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.CertState (PState (..))
 import Cardano.Ledger.Conway.Era (ConwayPOOL)
 import Cardano.Ledger.Core (
-  Era (EraCrypto),
   EraPParams,
   EraRule,
-  PoolCert (..),
-  ppEMaxL,
-  ppMinPoolCostL,
-  ppProtocolVersionL,
+  EraTxCert (TxCert),
  )
-import Cardano.Ledger.Crypto (Crypto (HASH))
 import Cardano.Ledger.Shelley.API (
-  KeyHash,
-  KeyRole (StakePool),
-  PoolEnv (PoolEnv),
-  PoolParams (PoolParams),
-  getRwdNetwork,
-  networkId,
-  pmHash,
-  ppCost,
-  ppId,
-  ppMetadata,
-  ppRewardAcnt,
+  PoolEnv,
  )
-import qualified Cardano.Ledger.Shelley.HardForks as HardForks
-import Cardano.Ledger.Shelley.Rules (PoolEvent (RegisterPool, ReregisterPool))
-import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
-import Cardano.Ledger.Slot (epochInfoEpoch)
-import Control.DeepSeq (NFData)
-import Control.Monad (forM_, when)
-import Control.Monad.Trans.Reader (asks)
-import Control.SetAlgebra (dom, eval, (∈), (∉), (∪), (⋪), (⨃))
+import Cardano.Ledger.Shelley.Rules (
+  PoolEvent,
+  ShelleyPoolPredFailure,
+  poolDelegationTransition,
+ )
+import Cardano.Ledger.Shelley.TxCert (ShelleyEraTxCert)
 import Control.State.Transition (
   BaseM,
   Environment,
@@ -63,100 +39,22 @@ import Control.State.Transition (
   State,
   transitionRules,
  )
-import Control.State.Transition.Extended (TRC (TRC), TransitionRule, judgmentContext, liftSTS, tellEvent, (?!))
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import GHC.Generics (Generic)
-import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks (..))
-
-data ConwayPoolPredFailure era
-  = ConwayPoolPredFailure
-  | WrongNetworkPOOL !Network !Network !(KeyHash 'StakePool (EraCrypto era))
-  | PoolMedataHashTooBigPOOL !(KeyHash 'StakePool (EraCrypto era)) !Int
-  | StakePoolCostTooLowPOOL !Coin !Coin
-  | StakePoolNotRegisteredOnKeyPOOL !(KeyHash 'StakePool (EraCrypto era))
-  | StakePoolRetirementWrongEpochPOOL EpochNo EpochNo EpochNo
-  deriving (Show, Eq, Generic, NoThunks, NFData)
 
 instance
   ( EraPParams era
   , State (EraRule "POOL" era) ~ PState era
-  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
+  , Signal (EraRule "POOL" era) ~ TxCert era
   , Environment (EraRule "POOL" era) ~ PoolEnv era
   , EraRule "POOL" era ~ ConwayPOOL era
+  , ShelleyEraTxCert era
   ) =>
   STS (ConwayPOOL era)
   where
   type State (ConwayPOOL era) = PState era
-  type Signal (ConwayPOOL era) = PoolCert (EraCrypto era)
+  type Signal (ConwayPOOL era) = TxCert era
   type Environment (ConwayPOOL era) = PoolEnv era
   type BaseM (ConwayPOOL era) = ShelleyBase
-  type PredicateFailure (ConwayPOOL era) = ConwayPoolPredFailure era
+  type PredicateFailure (ConwayPOOL era) = ShelleyPoolPredFailure era
   type Event (ConwayPOOL era) = PoolEvent era
 
-  transitionRules = [conwayPoolTransition @era]
-
-conwayPoolTransition ::
-  forall era.
-  ( EraPParams era
-  , EraRule "POOL" era ~ ConwayPOOL era
-  ) =>
-  TransitionRule (ConwayPOOL era)
-conwayPoolTransition = do
-  TRC
-    ( PoolEnv slot pp
-      , pState@PState {psStakePoolParams, psFutureStakePoolParams, psRetiring}
-      , c
-      ) <-
-    judgmentContext
-  let pv = pp ^. ppProtocolVersionL
-  case c of
-    RegPool poolParams@PoolParams {ppId, ppCost, ppRewardAcnt, ppMetadata} -> do
-      when (HardForks.validatePoolRewardAccountNetID pv) $ do
-        actualNetID <- liftSTS $ asks networkId
-        let suppliedNetID = getRwdNetwork ppRewardAcnt
-        actualNetID == suppliedNetID ?! WrongNetworkPOOL actualNetID suppliedNetID ppId
-      when (SoftForks.restrictPoolMetadataHash pv) $ do
-        forM_ ppMetadata $ \pMetadata ->
-          let s = BS.length (pmHash pMetadata)
-           in s <= fromIntegral (sizeHash ([] @(HASH (EraCrypto era)))) ?! PoolMedataHashTooBigPOOL ppId s
-      let minPoolCost = pp ^. ppMinPoolCostL
-      ppCost >= minPoolCost ?! StakePoolCostTooLowPOOL ppCost minPoolCost
-      if eval (ppId ∉ dom psStakePoolParams)
-        then do
-          -- NOTE: @Soupstraw only this is part is in the spec right now.
-          -- register new, Pool-Reg
-          tellEvent $ RegisterPool ppId
-          pure $
-            payPoolDeposit ppId pp $
-              pState
-                { psStakePoolParams = eval $ psStakePoolParams ∪ Map.singleton ppId poolParams
-                }
-        else do
-          tellEvent $ ReregisterPool ppId
-          -- hk is already registered, so we want to reregister it. That means adding it to the
-          -- Future pool params (if it is not there already), and overriding the range with the new 'pp',
-          -- if it is (using ⨃ ). We must also unretire it, if it has been scheduled for retirement.
-          -- The deposit does not change. One pays the deposit just once. Only if it is fully retired
-          -- (i.e. it's deposit has been refunded, and it has been removed from the registered pools).
-          -- does it need to pay a new deposit (at the current deposit amount). But of course,
-          -- if that has happened, we cannot be in this branch of the if statement.
-          pure $
-            pState
-              { psFutureStakePoolParams = eval $ psFutureStakePoolParams ⨃ Map.singleton ppId poolParams
-              , psRetiring = eval $ Set.singleton ppId ⋪ psRetiring
-              }
-    RetirePool sPool epochN -> do
-      eval (sPool ∈ dom psStakePoolParams) ?! StakePoolNotRegisteredOnKeyPOOL sPool
-      cepoch <- liftSTS $ do
-        ei <- asks epochInfoPure
-        epochInfoEpoch ei slot
-      let maxEpoch = pp ^. ppEMaxL
-      (cepoch < epochN && epochN <= cepoch + maxEpoch) ?! StakePoolRetirementWrongEpochPOOL cepoch epochN (cepoch + maxEpoch)
-      -- We just schedule it for retirement. When it is retired we refund the deposit (see POOLREAP)
-      -- pure $ pState {psRetiring = eval $ psRetiring ⨃ Map.singleton sPool epochN}
-
-      -- NOTE: @Soupstraw: only this line is in the spec now.
-      pure $ pState {psRetiring = Map.singleton sPool epochN `Map.union` psRetiring}
+  transitionRules = [poolDelegationTransition]

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -39,7 +39,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertsPredFailure (..),
   ConwayDelegPredFailure (..),
   ConwayLedgerPredFailure (..),
-  ConwayPoolPredFailure,
   ConwayTallyPredFailure,
   ConwayVDelPredFailure,
   EnactState (..),
@@ -371,9 +370,6 @@ instance PrettyA (ConwayDelegPredFailure era) where
       ppRecord
         "WrongCertificateTypeDELEG"
         []
-
-instance PrettyA (ConwayPoolPredFailure era) where
-  prettyA = const $ ppRecord "ConwayPoolPredFailure" []
 
 instance PrettyA (ConwayVDelPredFailure era) where
   prettyA = const $ ppRecord "ConwayVDelPredFailure" []


### PR DESCRIPTION
# Description

- [x] Replace the `TransitionRule` function entirely with just calling the Shelley version instead, as there are currently no significant differences between the two. @aniketd 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
