### PR TITLE
Add VDEL rules to Conway

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0.0
 
+* Add `VDEL` rules to Conway #3467
 * Add `EncCBOR`/`DecCBOR` for `ConwayCertPredFailure`
 * Add `EncCBOR`/`DecCBOR` for `ConwayVDelPredFailure`
 * Add `POOL` rules to Conway #3464

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayCERT, ConwayDELEG, ConwayPOOL, ConwayVDEL)
 import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure (..))
-import Cardano.Ledger.Conway.Rules.VDel (ConwayVDelPredFailure, VDelEnv (VDelEnv))
+import Cardano.Ledger.Conway.Rules.VDel (ConwayVDelPredFailure)
 import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert, ConwayDelegCert, ConwayTxCert (..))
 import Cardano.Ledger.Shelley.API (CertState (..), DState, DelegEnv (DelegEnv), DelplEnv (DelplEnv), PState, PoolEnv (PoolEnv), VState)
 import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
@@ -83,7 +83,7 @@ instance
   , State (EraRule "VDEL" era) ~ VState era
   , Environment (EraRule "DELEG" era) ~ DelegEnv era
   , Environment (EraRule "POOL" era) ~ PoolEnv era
-  , Environment (EraRule "VDEL" era) ~ VDelEnv era
+  , Environment (EraRule "VDEL" era) ~ PParams era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
   , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
@@ -110,7 +110,7 @@ certTransition ::
   , State (EraRule "VDEL" era) ~ VState era
   , Environment (EraRule "DELEG" era) ~ DelegEnv era
   , Environment (EraRule "POOL" era) ~ PoolEnv era
-  , Environment (EraRule "VDEL" era) ~ VDelEnv era
+  , Environment (EraRule "VDEL" era) ~ PParams era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
   , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
@@ -129,8 +129,8 @@ certTransition = do
     ConwayTxCertPool poolCert -> do
       newPState <- trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState, poolCert)
       pure $ cState {certPState = newPState}
-    ConwayTxCertCommittee committeeCert -> do
-      newVState <- trans @(EraRule "VDEL" era) $ TRC (VDelEnv, certVState, committeeCert)
+    ConwayTxCertCommittee vDelCert -> do
+      newVState <- trans @(EraRule "VDEL" era) $ TRC (pp, certVState, vDelCert)
       pure $ cState {certVState = newVState}
 
 instance

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -13,8 +15,7 @@
 module Cardano.Ledger.Conway.Rules.VDel (
   ConwayVDEL,
   ConwayVDelEvent (..),
-  VDelEnv (..),
-  ConwayVDelPredFailure,
+  ConwayVDelPredFailure (..),
 )
 where
 
@@ -23,12 +24,14 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), encodeListLen)
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.CertState (VState)
+import Cardano.Ledger.CertState (VState (..))
 import Cardano.Ledger.Conway.Era (ConwayVDEL)
-import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert)
-import Cardano.Ledger.Core (Era (EraCrypto), EraRule)
+import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert (..))
+import Cardano.Ledger.Core (Era (EraCrypto), EraPParams, EraRule, PParams)
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (CommitteeColdKey, Voting))
 import Control.DeepSeq (NFData)
-import Control.State.Transition (
+import Control.State.Transition.Extended (
   BaseM,
   Environment,
   Event,
@@ -36,15 +39,25 @@ import Control.State.Transition (
   STS,
   Signal,
   State,
+  TRC (TRC),
+  TransitionRule,
+  judgmentContext,
   transitionRules,
+  (?!),
  )
-import Data.Typeable (Typeable)
-import Data.Word (Word8)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data ConwayVDelPredFailure era = ConwayVDelPredFailure
-  deriving (Show, Eq, Generic, NoThunks, NFData)
+data ConwayVDelPredFailure era
+  = ConwayDRepAlreadyRegisteredVDEL !(Credential 'Voting (EraCrypto era))
+  | ConwayDRepNotRegisteredVDEL !(Credential 'Voting (EraCrypto era))
+  | ConwayCommitteeAlreadyRegisteredVDEL !(KeyHash 'CommitteeColdKey (EraCrypto era))
+  | ConwayCommitteeNotRegisteredVDEL !(KeyHash 'CommitteeColdKey (EraCrypto era))
+  deriving (Show, Eq, Generic)
+
+instance NoThunks (ConwayVDelPredFailure era)
+
+instance NFData (ConwayVDelPredFailure era)
 
 instance Typeable era => EncCBOR (ConwayVDelPredFailure era) where
   encCBOR = \case
@@ -56,15 +69,13 @@ instance Typeable era => DecCBOR (ConwayVDelPredFailure era) where
       0 -> pure (1, ConwayVDelPredFailure)
       k -> invalidKey k
 
-data VDelEnv era = VDelEnv
-
 newtype ConwayVDelEvent era = VDelEvent (Event (EraRule "VDEL" era))
 
 instance
-  ( Era era
+  ( EraPParams era
   , State (EraRule "VDEL" era) ~ VState era
   , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
-  , Environment (EraRule "VDEL" era) ~ VDelEnv era
+  , Environment (EraRule "VDEL" era) ~ PParams era
   , EraRule "VDEL" era ~ ConwayVDEL era
   , Eq (PredicateFailure (EraRule "VDEL" era))
   , Show (PredicateFailure (EraRule "VDEL" era))
@@ -73,9 +84,45 @@ instance
   where
   type State (ConwayVDEL era) = VState era
   type Signal (ConwayVDEL era) = ConwayCommitteeCert (EraCrypto era)
-  type Environment (ConwayVDEL era) = VDelEnv era
+  type Environment (ConwayVDEL era) = PParams era
   type BaseM (ConwayVDEL era) = ShelleyBase
   type PredicateFailure (ConwayVDEL era) = ConwayVDelPredFailure era
   type Event (ConwayVDEL era) = ConwayVDelEvent era
 
-  transitionRules = undefined -- TODO
+  transitionRules = [conwayVDelTransition @era]
+
+conwayVDelTransition :: TransitionRule (ConwayVDEL era)
+conwayVDelTransition = do
+  TRC
+    ( _pp
+      , vState@VState {vsDReps, vsCCHotKeys}
+      , c
+      ) <-
+    judgmentContext
+  case c of
+    ConwayDRepReg cred -> do
+      Set.notMember cred vsDReps ?! ConwayDRepAlreadyRegisteredVDEL cred
+      -- TODO: check against a new PParam `drepDeposit`, once PParams are updated.
+      pure $
+        vState
+          { vsDReps = Set.insert cred vsDReps
+          }
+    ConwayDRepUnReg cred -> do
+      Set.member cred vsDReps ?! ConwayDRepNotRegisteredVDEL cred
+      pure $
+        vState
+          { vsDReps = Set.delete cred vsDReps
+          }
+    ConwayAuthCommitteeHotKey coldK hotK -> do
+      -- TODO: implement after the spec is to be updated w.r.t. checking if the coldK belongs to CC.
+      Map.notMember coldK vsCCHotKeys ?! ConwayCommitteeAlreadyRegisteredVDEL coldK
+      pure $
+        vState
+          { vsCCHotKeys = Map.insert coldK hotK vsCCHotKeys
+          }
+    ConwayResignCommitteeColdKey coldK -> do
+      Map.member coldK vsCCHotKeys ?! ConwayCommitteeNotRegisteredVDEL coldK
+      pure $
+        vState
+          { vsCCHotKeys = Map.delete coldK vsCCHotKeys
+          }

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -115,7 +114,6 @@ conwayVDelTransition = do
           }
     ConwayAuthCommitteeHotKey coldK hotK -> do
       -- TODO: implement after the spec is to be updated w.r.t. checking if the coldK belongs to CC.
-      Map.notMember coldK vsCCHotKeys ?! ConwayCommitteeAlreadyRegisteredVDEL coldK
       pure $
         vState
           { vsCCHotKeys = Map.insert coldK hotK vsCCHotKeys

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
@@ -99,7 +99,7 @@ conwayVDelTransition :: TransitionRule (ConwayVDEL era)
 conwayVDelTransition = do
   TRC
     ( _pp
-      , vState@VState {vsDReps, vsCCHotKeys}
+      , vState@VState {vsDReps, vsCommitteeHotKeys}
       , c
       ) <-
     judgmentContext
@@ -113,9 +113,9 @@ conwayVDelTransition = do
       Set.member cred vsDReps ?! ConwayDRepNotRegisteredVDEL cred
       pure $ vState {vsDReps = Set.delete cred vsDReps}
     ConwayAuthCommitteeHotKey coldK hotK -> do
-      (isNothing <$> Map.lookup coldK vsCCHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
-      pure $ vState {vsCCHotKeys = Map.insert coldK (Just hotK) vsCCHotKeys}
+      (isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
+      pure $ vState {vsCommitteeHotKeys = Map.insert coldK (Just hotK) vsCommitteeHotKeys}
     ConwayResignCommitteeColdKey coldK -> do
-      Map.member coldK vsCCHotKeys ?! ConwayCommitteeNotRegisteredVDEL coldK
-      (isNothing <$> Map.lookup coldK vsCCHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
-      pure $ vState {vsCCHotKeys = Map.insert coldK Nothing vsCCHotKeys}
+      Map.member coldK vsCommitteeHotKeys ?! ConwayCommitteeNotRegisteredVDEL coldK
+      (isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
+      pure $ vState {vsCommitteeHotKeys = Map.insert coldK Nothing vsCommitteeHotKeys}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
@@ -104,11 +104,11 @@ conwayVDelTransition = do
       ) <-
     judgmentContext
   case c of
-    ConwayDRepReg cred _deposit -> do
+    ConwayRegDRep cred _deposit -> do
       Set.notMember cred vsDReps ?! ConwayDRepAlreadyRegisteredVDEL cred
       -- TODO: check against a new PParam `drepDeposit`, once PParams are updated. -- someCheck ?! ConwayDRepIncorrectDeposit deposit
       pure $ vState {vsDReps = Set.insert cred vsDReps}
-    ConwayDRepUnReg cred _deposit -> do
+    ConwayUnRegDRep cred _deposit -> do
       -- TODO: check against a new PParam `drepDeposit`, once PParams are updated. -- someCheck ?! ConwayDRepIncorrectDeposit deposit
       Set.member cred vsDReps ?! ConwayDRepNotRegisteredVDEL cred
       pure $ vState {vsDReps = Set.delete cred vsDReps}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs
@@ -113,9 +113,11 @@ conwayVDelTransition = do
       Set.member cred vsDReps ?! ConwayDRepNotRegisteredVDEL cred
       pure $ vState {vsDReps = Set.delete cred vsDReps}
     ConwayAuthCommitteeHotKey coldK hotK -> do
-      (isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
+      checkColdKeyHasNotResigned coldK vsCommitteeHotKeys
       pure $ vState {vsCommitteeHotKeys = Map.insert coldK (Just hotK) vsCommitteeHotKeys}
     ConwayResignCommitteeColdKey coldK -> do
-      Map.member coldK vsCommitteeHotKeys ?! ConwayCommitteeNotRegisteredVDEL coldK
-      (isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK
+      checkColdKeyHasNotResigned coldK vsCommitteeHotKeys
       pure $ vState {vsCommitteeHotKeys = Map.insert coldK Nothing vsCommitteeHotKeys}
+  where
+    checkColdKeyHasNotResigned coldK vsCommitteeHotKeys =
+      (isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True ?! ConwayCommitteeHasResignedVDEL coldK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -279,7 +279,9 @@ instance NFData (ConwayDelegCert c)
 instance NoThunks (ConwayDelegCert c)
 
 data ConwayCommitteeCert c
-  = ConwayAuthCommitteeHotKey !(KeyHash 'CommitteeColdKey c) !(KeyHash 'CommitteeHotKey c)
+  = ConwayDRepReg !(Credential 'Voting c)
+  | ConwayDRepUnReg !(Credential 'Voting c)
+  | ConwayAuthCommitteeHotKey !(KeyHash 'CommitteeColdKey c) !(KeyHash 'CommitteeHotKey c)
   | ConwayResignCommitteeColdKey !(KeyHash 'CommitteeColdKey c)
   deriving (Show, Generic, Eq)
 
@@ -291,6 +293,7 @@ committeeKeyHashWitness :: ConwayCommitteeCert c -> KeyHash 'Witness c
 committeeKeyHashWitness = \case
   ConwayAuthCommitteeHotKey coldKeyHash _ -> asWitness coldKeyHash
   ConwayResignCommitteeColdKey coldKeyHash -> asWitness coldKeyHash
+  _ -> undefined
 
 data ConwayTxCert era
   = ConwayTxCertDeleg !(ConwayDelegCert (EraCrypto era))
@@ -429,6 +432,14 @@ encodeCommitteeHotKey = \case
   ConwayResignCommitteeColdKey cred ->
     encodeListLen 2
       <> encodeWord8 15
+      <> encCBOR cred
+  ConwayDRepReg cred ->
+    encodeListLen 2
+      <> encodeWord8 16
+      <> encCBOR cred
+  ConwayDRepUnReg cred ->
+    encodeListLen 2
+      <> encodeWord8 17
       <> encCBOR cred
 
 fromShelleyDelegCert :: ShelleyDelegCert c -> ConwayDelegCert c

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -52,7 +52,7 @@ import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Core (
   Era (EraCrypto),
   EraTxCert (..),
-  PoolCert,
+  PoolCert (..),
   ScriptHash,
   Value,
   eraProtVerLow,
@@ -63,7 +63,6 @@ import Cardano.Ledger.Credential (Credential, StakeCredential, credKeyHashWitnes
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..), asWitness)
 import Cardano.Ledger.Shelley.TxCert (
-  PoolCert (..),
   ShelleyDelegCert (..),
   ShelleyEraTxCert (..),
   encodePoolCert,
@@ -145,11 +144,11 @@ class ShelleyEraTxCert era => ConwayEraTxCert era where
   mkResignCommitteeColdTxCert :: KeyHash 'CommitteeColdKey (EraCrypto era) -> TxCert era
   getResignCommitteeColdTxCert :: TxCert era -> Maybe (KeyHash 'CommitteeColdKey (EraCrypto era))
 
-  mkRegDRepTxCert :: Credential 'Voting (EraCrypto era) -> TxCert era
-  getRegDRepTxCert :: TxCert era -> Maybe (Credential 'Voting (EraCrypto era))
+  mkRegDRepTxCert :: Credential 'Voting (EraCrypto era) -> Coin -> TxCert era
+  getRegDRepTxCert :: TxCert era -> Maybe (Credential 'Voting (EraCrypto era), Coin)
 
-  mkUnRegDRepTxCert :: Credential 'Voting (EraCrypto era) -> TxCert era
-  getUnRegDRepTxCert :: TxCert era -> Maybe (Credential 'Voting (EraCrypto era))
+  mkUnRegDRepTxCert :: Credential 'Voting (EraCrypto era) -> Coin -> TxCert era
+  getUnRegDRepTxCert :: TxCert era -> Maybe (Credential 'Voting (EraCrypto era), Coin)
 
 instance Crypto c => ConwayEraTxCert (ConwayEra c) where
   mkRegDepositTxCert cred c = ConwayTxCertDeleg $ ConwayRegCert cred $ SJust c
@@ -177,14 +176,14 @@ instance Crypto c => ConwayEraTxCert (ConwayEra c) where
   getResignCommitteeColdTxCert (ConwayTxCertCommittee (ConwayResignCommitteeColdKey ck)) = Just ck
   getResignCommitteeColdTxCert _ = Nothing
 
-  mkRegDRepTxCert = ConwayTxCertCommittee . ConwayDRepReg
+  mkRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayDRepReg cred deposit
   getRegDRepTxCert = \case
-    ConwayTxCertCommittee (ConwayDRepReg cred) -> Just cred
+    ConwayTxCertCommittee (ConwayDRepReg cred deposit) -> Just (cred, deposit)
     _ -> Nothing
 
-  mkUnRegDRepTxCert = ConwayTxCertCommittee . ConwayDRepUnReg
+  mkUnRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayDRepUnReg cred deposit
   getUnRegDRepTxCert = \case
-    ConwayTxCertCommittee (ConwayDRepUnReg cred) -> Just cred
+    ConwayTxCertCommittee (ConwayDRepUnReg cred deposit) -> Just (cred, deposit)
     _ -> Nothing
 
 pattern RegDepositTxCert ::
@@ -244,18 +243,20 @@ pattern ResignCommitteeColdTxCert ck <- (getResignCommitteeColdTxCert -> Just ck
 pattern RegDRepTxCert ::
   ConwayEraTxCert era =>
   Credential 'Voting (EraCrypto era) ->
+  Coin ->
   TxCert era
-pattern RegDRepTxCert cred <- (getRegDRepTxCert -> Just cred)
+pattern RegDRepTxCert cred deposit <- (getRegDRepTxCert -> Just (cred, deposit))
   where
-    RegDRepTxCert cred = mkRegDRepTxCert cred
+    RegDRepTxCert cred deposit = mkRegDRepTxCert cred deposit
 
 pattern UnRegDRepTxCert ::
   ConwayEraTxCert era =>
   Credential 'Voting (EraCrypto era) ->
+  Coin ->
   TxCert era
-pattern UnRegDRepTxCert cred <- (getUnRegDRepTxCert -> Just cred)
+pattern UnRegDRepTxCert cred deposit <- (getUnRegDRepTxCert -> Just (cred, deposit))
   where
-    UnRegDRepTxCert cred = mkUnRegDRepTxCert cred
+    UnRegDRepTxCert cred deposit = mkUnRegDRepTxCert cred deposit
 
 {-# COMPLETE
   RegPoolTxCert
@@ -315,8 +316,8 @@ instance NFData (ConwayDelegCert c)
 instance NoThunks (ConwayDelegCert c)
 
 data ConwayCommitteeCert c
-  = ConwayDRepReg !(Credential 'Voting c)
-  | ConwayDRepUnReg !(Credential 'Voting c)
+  = ConwayDRepReg !(Credential 'Voting c) !Coin
+  | ConwayDRepUnReg !(Credential 'Voting c) !Coin
   | ConwayAuthCommitteeHotKey !(KeyHash 'CommitteeColdKey c) !(KeyHash 'CommitteeHotKey c)
   | ConwayResignCommitteeColdKey !(KeyHash 'CommitteeColdKey c)
   deriving (Show, Generic, Eq)
@@ -325,11 +326,11 @@ instance NFData (ConwayCommitteeCert c)
 
 instance NoThunks (ConwayCommitteeCert c)
 
-committeeKeyHashWitness :: ConwayCommitteeCert c -> KeyHash 'Witness c
+committeeKeyHashWitness :: ConwayCommitteeCert c -> Maybe (KeyHash 'Witness c)
 committeeKeyHashWitness = \case
-  ConwayAuthCommitteeHotKey coldKeyHash _ -> asWitness coldKeyHash
-  ConwayResignCommitteeColdKey coldKeyHash -> asWitness coldKeyHash
-  _ -> undefined
+  ConwayAuthCommitteeHotKey coldKeyHash _ -> Just $ asWitness coldKeyHash
+  ConwayResignCommitteeColdKey coldKeyHash -> Just $ asWitness coldKeyHash
+  _ -> Nothing
 
 data ConwayTxCert era
   = ConwayTxCertDeleg !(ConwayDelegCert (EraCrypto era))
@@ -388,10 +389,12 @@ conwayTxCertDelegDecoder = \case
     pure (2, ResignCommitteeColdTxCert cred)
   16 -> do
     cred <- decCBOR
-    pure (2, RegDRepTxCert cred)
+    deposit <- decCBOR
+    pure (3, RegDRepTxCert cred deposit)
   17 -> do
     cred <- decCBOR
-    pure (2, UnRegDRepTxCert cred)
+    deposit <- decCBOR
+    pure (3, UnRegDRepTxCert cred deposit)
   k -> invalidKey k
   where
     delegCertDecoder n decodeDelegatee = do
@@ -475,14 +478,16 @@ encodeCommitteeHotKey = \case
     encodeListLen 2
       <> encodeWord8 15
       <> encCBOR cred
-  ConwayDRepReg cred ->
-    encodeListLen 2
+  ConwayDRepReg cred deposit ->
+    encodeListLen 3
       <> encodeWord8 16
       <> encCBOR cred
-  ConwayDRepUnReg cred ->
-    encodeListLen 2
+      <> encCBOR deposit
+  ConwayDRepUnReg cred deposit ->
+    encodeListLen 3
       <> encodeWord8 17
       <> encCBOR cred
+      <> encCBOR deposit
 
 fromShelleyDelegCert :: ShelleyDelegCert c -> ConwayDelegCert c
 fromShelleyDelegCert = \case
@@ -526,4 +531,4 @@ getVKeyWitnessConwayTxCert = \case
       ConwayDelegCert cred _ -> credKeyHashWitness cred
       ConwayRegDelegCert cred _ _ -> credKeyHashWitness cred
   ConwayTxCertPool poolCert -> Just $ poolCertKeyHashWitness poolCert
-  ConwayTxCertCommittee committeeCert -> Just $ committeeKeyHashWitness committeeCert
+  ConwayTxCertCommittee committeeCert -> committeeKeyHashWitness committeeCert

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -176,14 +176,14 @@ instance Crypto c => ConwayEraTxCert (ConwayEra c) where
   getResignCommitteeColdTxCert (ConwayTxCertCommittee (ConwayResignCommitteeColdKey ck)) = Just ck
   getResignCommitteeColdTxCert _ = Nothing
 
-  mkRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayDRepReg cred deposit
+  mkRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayRegDRep cred deposit
   getRegDRepTxCert = \case
-    ConwayTxCertCommittee (ConwayDRepReg cred deposit) -> Just (cred, deposit)
+    ConwayTxCertCommittee (ConwayRegDRep cred deposit) -> Just (cred, deposit)
     _ -> Nothing
 
-  mkUnRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayDRepUnReg cred deposit
+  mkUnRegDRepTxCert cred deposit = ConwayTxCertCommittee $ ConwayUnRegDRep cred deposit
   getUnRegDRepTxCert = \case
-    ConwayTxCertCommittee (ConwayDRepUnReg cred deposit) -> Just (cred, deposit)
+    ConwayTxCertCommittee (ConwayUnRegDRep cred deposit) -> Just (cred, deposit)
     _ -> Nothing
 
 pattern RegDepositTxCert ::
@@ -316,8 +316,8 @@ instance NFData (ConwayDelegCert c)
 instance NoThunks (ConwayDelegCert c)
 
 data ConwayCommitteeCert c
-  = ConwayDRepReg !(Credential 'Voting c) !Coin
-  | ConwayDRepUnReg !(Credential 'Voting c) !Coin
+  = ConwayRegDRep !(Credential 'Voting c) !Coin
+  | ConwayUnRegDRep !(Credential 'Voting c) !Coin
   | ConwayAuthCommitteeHotKey !(KeyHash 'CommitteeColdKey c) !(KeyHash 'CommitteeHotKey c)
   | ConwayResignCommitteeColdKey !(KeyHash 'CommitteeColdKey c)
   deriving (Show, Generic, Eq)
@@ -478,12 +478,12 @@ encodeCommitteeHotKey = \case
     encodeListLen 2
       <> encodeWord8 15
       <> encCBOR cred
-  ConwayDRepReg cred deposit ->
+  ConwayRegDRep cred deposit ->
     encodeListLen 3
       <> encodeWord8 16
       <> encCBOR cred
       <> encCBOR deposit
-  ConwayDRepUnReg cred deposit ->
+  ConwayUnRegDRep cred deposit ->
     encodeListLen 3
       <> encodeWord8 17
       <> encCBOR cred

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -56,8 +56,8 @@ instance Era era => Arbitrary (ConwayTxCert era) where
 instance Crypto c => Arbitrary (ConwayCommitteeCert c) where
   arbitrary =
     oneof
-      [ ConwayDRepReg <$> arbitrary
-      , ConwayDRepUnReg <$> arbitrary
+      [ ConwayDRepReg <$> arbitrary <*> arbitrary
+      , ConwayDRepUnReg <$> arbitrary <*> arbitrary
       , ConwayAuthCommitteeHotKey <$> arbitrary <*> arbitrary
       , ConwayResignCommitteeColdKey <$> arbitrary
       ]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -56,7 +56,9 @@ instance Era era => Arbitrary (ConwayTxCert era) where
 instance Crypto c => Arbitrary (ConwayCommitteeCert c) where
   arbitrary =
     oneof
-      [ ConwayAuthCommitteeHotKey <$> arbitrary <*> arbitrary
+      [ ConwayDRepReg <$> arbitrary
+      , ConwayDRepUnReg <$> arbitrary
+      , ConwayAuthCommitteeHotKey <$> arbitrary <*> arbitrary
       , ConwayResignCommitteeColdKey <$> arbitrary
       ]
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -56,8 +56,8 @@ instance Era era => Arbitrary (ConwayTxCert era) where
 instance Crypto c => Arbitrary (ConwayCommitteeCert c) where
   arbitrary =
     oneof
-      [ ConwayDRepReg <$> arbitrary <*> arbitrary
-      , ConwayDRepUnReg <$> arbitrary <*> arbitrary
+      [ ConwayRegDRep <$> arbitrary <*> arbitrary
+      , ConwayUnRegDRep <$> arbitrary <*> arbitrary
       , ConwayAuthCommitteeHotKey <$> arbitrary <*> arbitrary
       , ConwayResignCommitteeColdKey <$> arbitrary
       ]

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -265,15 +265,22 @@ certificate =
   // stake_vote_reg_deleg_cert
   // reg_committee_hot_key_cert
   // unreg_committee_hot_key_cert
+  // reg_drep_cert
+  // unreg_drep_cert
   ]
 
 stake_registration = (0, stake_credential)
 stake_deregistration = (1, stake_credential)
 stake_delegation = (2, stake_credential, pool_keyhash)
+
+; POOL
 pool_registration = (3, pool_params)
 pool_retirement = (4, pool_keyhash, epoch)
+
 ; numbers 5 and 6 used to be the Genesis and MIR certificates respectively,
 ; which were deprecated in Conway
+
+; DELEG
 reg_cert = (7, stake_credential, coin)
 unreg_cert = (8, stake_credential, coin)
 vote_deleg_cert = (9, stake_credential, voting_credential)
@@ -281,8 +288,12 @@ stake_vote_deleg_cert = (10, stake_credential, pool_keyhash, voting_credential)
 stake_reg_deleg_cert = (11, stake_credential, pool_keyhash, coin)
 vote_reg_deleg_cert = (12, stake_credential, voting_credential, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, voting_credential, coin)
+
+; VDEL
 reg_committee_hot_key_cert = (14, committee_cold_keyhash, committee_hot_keyhash)
 unreg_committee_hot_key_cert = (15, committee_cold_keyhash)
+reg_drep_cert = (16, voting_credential, coin)
+unreg_drep_cert = (17, voting_credential, coin)
 
 
 delta_coin = int
@@ -341,7 +352,7 @@ protocol_param_update =
   , ? 3:  uint               ; max transaction size
   , ? 4:  uint               ; max block header size
   , ? 5:  coin               ; key deposit
-  , ? 6:  coin               ; pool deposit
+  , ? 6:  coin               ; pool deposit (TODO: drep deposit needs to be added)
   , ? 7: epoch               ; maximum epoch
   , ? 8: uint                ; n_opt: desired number of stake pools
   , ? 9: rational            ; pool pledge influence

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -258,7 +258,7 @@ data VState era = VState
   , vsCCHotKeys ::
       !( Map
           (KeyHash 'CommitteeColdKey (EraCrypto era))
-          (KeyHash 'CommitteeHotKey (EraCrypto era))
+          (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))) -- `Nothing` to indicate "resigned".
        )
   }
   deriving (Show, Eq, Generic)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -257,8 +257,8 @@ data VState era = VState
   { vsDReps :: !(Set (Credential 'Voting (EraCrypto era)))
   , vsCCHotKeys ::
       !( Map
-          (KeyHash 'Voting (EraCrypto era))
-          (KeyHash 'Voting (EraCrypto era))
+          (KeyHash 'CommitteeColdKey (EraCrypto era))
+          (KeyHash 'CommitteeHotKey (EraCrypto era))
        )
   }
   deriving (Show, Eq, Generic)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -255,7 +255,7 @@ toPStatePair PState {..} =
 
 data VState era = VState
   { vsDReps :: !(Set (Credential 'Voting (EraCrypto era)))
-  , vsCCHotKeys ::
+  , vsCommitteeHotKeys ::
       !( Map
           (KeyHash 'CommitteeColdKey (EraCrypto era))
           (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))) -- `Nothing` to indicate "resigned".
@@ -282,7 +282,7 @@ instance Era era => EncCBOR (VState era) where
     encode $
       Rec (VState @era)
         !> To vsDReps
-        !> To vsCCHotKeys
+        !> To vsCommitteeHotKeys
 
 -- | The state associated with the DELPL rule, which combines the DELEG rule
 -- and the POOL rule.

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -1669,11 +1669,11 @@ instance PrettyA (GenDelegs c) where
   prettyA = ppGenDelegs
 
 instance PrettyA (VState era) where
-  prettyA (VState vsDReps vsCCHotKeys) =
+  prettyA (VState vsDReps vsCommitteeHotKeys) =
     ppRecord
       "VState"
       [ ("DReps", prettyA vsDReps)
-      , ("CC Hot Keys", prettyA vsCCHotKeys)
+      , ("CC Hot Keys", prettyA vsCommitteeHotKeys)
       ]
 
 -- ======================================================

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -1669,11 +1669,11 @@ instance PrettyA (GenDelegs c) where
   prettyA = ppGenDelegs
 
 instance PrettyA (VState era) where
-  prettyA st@(VState _ _) =
+  prettyA (VState vsDReps vsCCHotKeys) =
     ppRecord
       "VState"
-      [ ("DReps", prettyA $ vsDReps st)
-      , ("CC Hot Keys", prettyA $ vsCCHotKeys st)
+      [ ("DReps", prettyA vsDReps)
+      , ("CC Hot Keys", prettyA vsCCHotKeys)
       ]
 
 -- ======================================================
@@ -1752,6 +1752,9 @@ instance PrettyA a => PrettyA (StrictSeq a) where
 
 instance PrettyA a => PrettyA (StrictMaybe a) where
   prettyA = ppStrictMaybe prettyA
+
+instance PrettyA a => PrettyA (Maybe a) where
+  prettyA = ppMaybe prettyA
 
 ptrace :: PrettyA t => String -> t -> a -> a
 ptrace x y z = trace ("\n" ++ show (prettyA y) ++ "\n" ++ show x) z

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -138,10 +138,10 @@ ppConwayTxCert = \case
 
 ppConwayCommitteeCert :: ConwayCommitteeCert c -> PDoc
 ppConwayCommitteeCert = \case
-  ConwayDRepReg cred ->
-    ppSexp "ConwayDRepReg" [prettyA cred]
-  ConwayDRepUnReg cred ->
-    ppSexp "ConwayDRepUnReg" [prettyA cred]
+  ConwayDRepReg cred deposit ->
+    ppSexp "ConwayDRepReg" [prettyA cred, prettyA deposit]
+  ConwayDRepUnReg cred deposit ->
+    ppSexp "ConwayDRepUnReg" [prettyA cred, prettyA deposit]
   ConwayAuthCommitteeHotKey coldKey hotKey ->
     ppSexp "ConwayAuthCommitteeHotKey" [prettyA coldKey, prettyA hotKey]
   ConwayResignCommitteeColdKey coldKey ->

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -138,10 +138,10 @@ ppConwayTxCert = \case
 
 ppConwayCommitteeCert :: ConwayCommitteeCert c -> PDoc
 ppConwayCommitteeCert = \case
-  ConwayDRepReg cred deposit ->
-    ppSexp "ConwayDRepReg" [prettyA cred, prettyA deposit]
-  ConwayDRepUnReg cred deposit ->
-    ppSexp "ConwayDRepUnReg" [prettyA cred, prettyA deposit]
+  ConwayRegDRep cred deposit ->
+    ppSexp "ConwayRegDRep" [prettyA cred, prettyA deposit]
+  ConwayUnRegDRep cred deposit ->
+    ppSexp "ConwayUnRegDRep" [prettyA cred, prettyA deposit]
   ConwayAuthCommitteeHotKey coldKey hotKey ->
     ppSexp "ConwayAuthCommitteeHotKey" [prettyA coldKey, prettyA hotKey]
   ConwayResignCommitteeColdKey coldKey ->

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -138,9 +138,14 @@ ppConwayTxCert = \case
 
 ppConwayCommitteeCert :: ConwayCommitteeCert c -> PDoc
 ppConwayCommitteeCert = \case
+  ConwayDRepReg cred ->
+    ppSexp "ConwayDRepReg" [prettyA cred]
+  ConwayDRepUnReg cred ->
+    ppSexp "ConwayDRepUnReg" [prettyA cred]
   ConwayAuthCommitteeHotKey coldKey hotKey ->
     ppSexp "ConwayAuthCommitteeHotKey" [prettyA coldKey, prettyA hotKey]
-  ConwayResignCommitteeColdKey coldKey -> ppSexp "ConwayResignCommitteeColdKey" [prettyA coldKey]
+  ConwayResignCommitteeColdKey coldKey ->
+    ppSexp "ConwayResignCommitteeColdKey" [prettyA coldKey]
 
 ppConwayTxBody ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -113,7 +113,7 @@ vsDRepsL = lens vsDReps (\vs u -> vs {vsDReps = u})
 vsCCHotKeysL ::
   Lens'
     (VState era)
-    (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
+    (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))))
 vsCCHotKeysL = lens vsCCHotKeys (\vs u -> vs {vsCCHotKeys = u})
 
 -- ========================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -110,11 +110,11 @@ psDepositsL = lens psDeposits (\ds u -> ds {psDeposits = u})
 vsDRepsL :: Lens' (VState era) (Set (Credential 'Voting (EraCrypto era)))
 vsDRepsL = lens vsDReps (\vs u -> vs {vsDReps = u})
 
-vsCCHotKeysL ::
+vsCommitteeHotKeysL ::
   Lens'
     (VState era)
     (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))))
-vsCCHotKeysL = lens vsCCHotKeys (\vs u -> vs {vsCCHotKeys = u})
+vsCommitteeHotKeysL = lens vsCommitteeHotKeys (\vs u -> vs {vsCommitteeHotKeys = u})
 
 -- ========================================
 -- CertState

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -113,7 +113,7 @@ vsDRepsL = lens vsDReps (\vs u -> vs {vsDReps = u})
 vsCCHotKeysL ::
   Lens'
     (VState era)
-    (Map (KeyHash 'Voting (EraCrypto era)) (KeyHash 'Voting (EraCrypto era)))
+    (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
 vsCCHotKeysL = lens vsCCHotKeys (\vs u -> vs {vsCCHotKeys = u})
 
 -- ========================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -141,6 +141,8 @@ hasOrd rep xx = explain ("'hasOrd " ++ show rep ++ "' fails") (help rep xx)
     help SizeR v = pure $ With v
     help VCredR v = pure $ With v
     help VHashR v = pure $ With v
+    help CommColdHashR v = pure $ With v
+    help CommHotHashR v = pure $ With v
 
 -- ===============================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -116,6 +116,8 @@ data Rep era t where
   GenHashR :: Rep era (KeyHash 'Genesis (EraCrypto era))
   GenDelegHashR :: Rep era (KeyHash 'GenesisDelegate (EraCrypto era))
   VHashR :: Rep era (KeyHash 'Voting (EraCrypto era))
+  CommColdHashR :: Rep era (KeyHash 'CommitteeColdKey (EraCrypto era))
+  CommHotHashR :: Rep era (KeyHash 'CommitteeHotKey (EraCrypto era))
   PoolParamsR :: Rep era (PoolParams (EraCrypto era))
   NewEpochStateR :: Rep era (NewEpochState era)
   IntR :: Rep era Int
@@ -258,6 +260,8 @@ instance Show (Rep era t) where
   show SizeR = "Size"
   show VCredR = "VCredR"
   show VHashR = "VHashR"
+  show CommColdHashR = "CommColdHashR"
+  show CommHotHashR = "CommHotHashR"
 
 synopsis :: forall e t. Rep e t -> t -> String
 synopsis RationalR r = show r
@@ -312,6 +316,8 @@ synopsis SlotNoR x = show x
 synopsis SizeR x = show x
 synopsis VCredR x = show x
 synopsis VHashR x = show x
+synopsis CommColdHashR x = show x
+synopsis CommHotHashR x = show x
 
 synSum :: Rep era a -> a -> String
 synSum (MapR _ CoinR) m = ", sum = " ++ show (pcCoin (Map.foldl' (<>) mempty m))
@@ -382,6 +388,8 @@ instance Shaped (Rep era) any where
   shape (PairR a b) = Nary 38 [shape a, shape b]
   shape VCredR = Nullary 39
   shape VHashR = Nullary 40
+  shape CommColdHashR = Nullary 41
+  shape CommHotHashR = Nullary 42
 
 compareRep :: forall era t s. Rep era t -> Rep era s -> Ordering
 compareRep x y = cmpIndex @(Rep era) x y
@@ -436,6 +444,8 @@ genSizedRep _ SlotNoR = arbitrary
 genSizedRep _ SizeR = do lo <- choose (1, 6); hi <- choose (6, 10); pure (SzRng lo hi)
 genSizedRep _ VCredR = arbitrary
 genSizedRep _ VHashR = arbitrary
+genSizedRep _ CommColdHashR = arbitrary
+genSizedRep _ CommHotHashR = arbitrary
 
 genRep ::
   Era era =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -230,7 +230,7 @@ ccHotKeys :: Term era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (K
 ccHotKeys = Var $ V "dreps" (MapR CommColdHashR (MaybeR CommHotHashR)) (Yes NewEpochStateR ccHotKeysL)
 
 ccHotKeysL :: NELens era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))))
-ccHotKeysL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsCCHotKeysL
+ccHotKeysL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeHotKeysL
 
 -- UTxOState
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -226,10 +226,10 @@ dreps = Var $ V "dreps" (SetR VCredR) (Yes NewEpochStateR drepsL)
 drepsL :: NELens era (Set (Credential 'Voting (EraCrypto era)))
 drepsL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
 
-ccHotKeys :: Term era (Map (KeyHash 'Voting (EraCrypto era)) (KeyHash 'Voting (EraCrypto era)))
-ccHotKeys = Var $ V "dreps" (MapR VHashR VHashR) (Yes NewEpochStateR ccHotKeysL)
+ccHotKeys :: Term era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
+ccHotKeys = Var $ V "dreps" (MapR CommColdHashR CommHotHashR) (Yes NewEpochStateR ccHotKeysL)
 
-ccHotKeysL :: NELens era (Map (KeyHash 'Voting (EraCrypto era)) (KeyHash 'Voting (EraCrypto era)))
+ccHotKeysL :: NELens era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
 ccHotKeysL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsCCHotKeysL
 
 -- UTxOState

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -226,10 +226,10 @@ dreps = Var $ V "dreps" (SetR VCredR) (Yes NewEpochStateR drepsL)
 drepsL :: NELens era (Set (Credential 'Voting (EraCrypto era)))
 drepsL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
 
-ccHotKeys :: Term era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
-ccHotKeys = Var $ V "dreps" (MapR CommColdHashR CommHotHashR) (Yes NewEpochStateR ccHotKeysL)
+ccHotKeys :: Term era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))))
+ccHotKeys = Var $ V "dreps" (MapR CommColdHashR (MaybeR CommHotHashR)) (Yes NewEpochStateR ccHotKeysL)
 
-ccHotKeysL :: NELens era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (KeyHash 'CommitteeHotKey (EraCrypto era)))
+ccHotKeysL :: NELens era (Map (KeyHash 'CommitteeColdKey (EraCrypto era)) (Maybe (KeyHash 'CommitteeHotKey (EraCrypto era))))
 ccHotKeysL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsCCHotKeysL
 
 -- UTxOState

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1408,7 +1408,7 @@ pcShelleyTxCert (ShelleyTxCertMir _) = ppString "MirCert"
 pcConwayTxCert :: ConwayTxCert c -> PDoc
 pcConwayTxCert (ConwayTxCertDeleg dc) = prettyA dc
 pcConwayTxCert (ConwayTxCertPool poolc) = pcPoolCert poolc
-pcConwayTxCert (ConwayTxCertCommittee _) = ppString "ConwayTxCertCommittee"
+pcConwayTxCert (ConwayTxCertCommittee _) = ppString "ConwayTxCertCommittee" -- TODO: @aniketd add pretty instance for the certs
 
 instance c ~ EraCrypto era => PrettyC (ShelleyTxCert c) era where prettyC _ = pcShelleyTxCert
 


### PR DESCRIPTION
# Description

- [ ] ~~Rename all `CommitteeCert`s to `GovCert`s~~
- [ ] ~~Rename `TALLY` rule to `GOV` cc. @lehins @Soupstraw @WhatisRT (perhaps in a separate issue and PR)~~
- [x] The renames may be done in another follow-up PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
