### PR TITLE
post-chaps changelog version bumps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ to the issue. -->
 - [ ] New tests are added if needed and existing tests are updated
 - [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
       [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
-- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
+- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
 - [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
 - [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
 - [x] Cabal files are formatted (use `scripts/cabal-format.sh`)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -277,7 +277,7 @@ Above list is likely to change in the future.
 ## Test packages
 
 Here are test suite packages that are still subject to the versioning and release process,
-but they are exempt from changelog updates:
+but the changelog _only_ needs to indicate if breaking changes have been made:
 
 * `cardano-ledger-shelley-test`
 * `cardano-ledger-shelley-ma-test`
@@ -287,5 +287,25 @@ but they are exempt from changelog updates:
 * `cardano-crypto-test`
 * `cardano-ledger-byron-test`
 
-They are mostly used internally and are planned to be deprecated and removed in the near
+A changelog which indicates that no changes have been made will have the form:
+
+```
+# Version history for `cardano-ledger-conway-test`
+
+## 1.2.0.1
+
+*
+```
+
+A changelog which indicates that changes have been made will have the form:
+
+```
+# Version history for `cardano-ledger-conway-test`
+
+## 1.3.0.0
+
+* breaking changes
+```
+
+These packages are mostly used internally and are planned to be deprecated and removed in the near
 future in favor of `testlib`s for each corresponding package.

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.0.1
+
+*
+
 ## 1.2.0.0
 
 * Introduction of `TxCert` and `EraTxCert`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Introduction of `TxCert` and `EraTxCert`

--- a/eras/alonzo/test-suite/CHANGELOG.md
+++ b/eras/alonzo/test-suite/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Version history for `cardano-ledger-alonzo-test`
+
+## 1.1.2.1
+
+*

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Introduction of `TxCert` and `EraTxCert`

--- a/eras/babbage/test-suite/CHANGELOG.md
+++ b/eras/babbage/test-suite/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Version history for `cardano-ledger-babbage-test`
+
+## 1.1.1.2
+
+*

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Add `VDEL` rules to Conway #3467

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Version history for `cardano-ledger-conway-test`
 
-## 1.2.0.0
+## 1.2.0.1
 
-- changes have been made
-
+*

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Introduction of `TxCert` and `EraTxCert`

--- a/eras/shelley-ma/test-suite/CHANGELOG.md
+++ b/eras/shelley-ma/test-suite/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Version history for `cardano-ledger-shelley-ma-test`
+
+## 1.2.1.1
+
+*

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Deprecated `poolSpec` function

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Version history for `cardano-ledger-shelley-test`
+
+## 1.2.0.1
+
+*

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-data`
 
+## 1.1.0.1
+
+*
+
 ## 1.1.0.0
 
 - Remove `Data.UMap` #3371

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-api`
 
+## 1.2.0.1
+
+*
+
 ## 1.2.0.0
 
 * Add support for Plutus V3

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-binary`
 
+## 1.1.1.2
+
+*
+
 ## 1.1.1.1
 
 * Changed bounds on plutus-ledger-api

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-core`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Add delegated representatives to the `UMap` and make its interface more coherent #3426

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `cardano-ledger-pretty`
 
+## 1.2.0.1
+
+*
+
 ## 1.2.0.0
 
 * Rename:

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Version history for `cardano-protocol-tpraos`
 
-## 1.0.1.1
+## 1.0.3.2
 
 *
+
+## 1.0.3.1
+
+* upper bounds on cardano-ledger-core and cardano-ledger-shelley
+
+## 1.0.3.0
+
+* lower bound on cardano-crypto-class
+
+## 1.0.2.0
+
+* Add a `testlib` and move `Arbitrary` instances from
+  `Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators` over.
 
 ## 1.0.1.0
 

--- a/libs/set-algebra/CHANGELOG.md
+++ b/libs/set-algebra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `set-algebra`
 
+## 1.1.0.2
+
+*
+
 ## 1.1.0.1
 
 - Set upper bound ansi-wl-pprint < 1.0


### PR DESCRIPTION
# Description

This is a post-chaps version bump of the changelogs.

Additionally, I've created testsuite changelogs, which are only to be used to indicate if a release is needed. See the note/change I made in the `RELEASING.md`.

I will keep this PR as draft until the [CHaPs releases](https://github.com/input-output-hk/cardano-haskell-packages/pull/319) are finalized.

TODO - add cardano-ledger-binary #3470

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
