### PR TITLE
Improve Conway certificate safety

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.0.0
+version:            1.2.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -53,7 +53,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
         cardano-ledger-core ^>=1.3,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.3.0.0
+version:            1.3.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -69,7 +69,7 @@ library
         cardano-ledger-binary >=1.0.1,
         cardano-ledger-core ^>=1.3,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-alonzo-test
-version:       1.1.2.0
+version:       1.1.2.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -54,7 +54,7 @@ library
         cardano-ledger-core:{cardano-ledger-core, testlib} ^>=1.3,
         cardano-ledger-pretty,
         cardano-ledger-allegra ^>=1.2,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.3,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.3 && <1.5,
         cardano-ledger-shelley-test ^>=1.2,
         cardano-ledger-shelley-ma-test ^>=1.2,
         cardano-ledger-mary ^>=1.3,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.3.0.0
+version:            1.4.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -63,7 +63,7 @@ library
         cardano-ledger-binary >=1.0,
         cardano-ledger-core ^>=1.3,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -61,6 +61,7 @@ instance
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
+  , ProtVerAtMost era 8
   ) =>
   STS (BabbageLEDGER era)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -265,6 +265,7 @@ babbageUtxowTransition ::
   ( AlonzoEraTx era
   , ExtendedUTxO era
   , EraUTxO era
+  , ProtVerAtMost era 8
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Script era ~ AlonzoScript era
   , STS (BabbageUTXOW era)
@@ -363,6 +364,7 @@ instance
   ( ExtendedUTxO era
   , AlonzoEraTx era
   , EraUTxO era
+  , ProtVerAtMost era 8
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , BabbageEraTxBody era
   , Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody)

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-babbage-test
-version:       1.1.1.1
+version:       1.1.1.2
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -40,12 +40,12 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} ^>=1.3,
         cardano-ledger-alonzo-test >=1.1,
-        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} ^>=1.3,
+        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.3 && <1.5,
         cardano-ledger-core:{cardano-ledger-core, testlib} ^>=1.3,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-mary ^>=1.3,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-strict-containers,
         cardano-slotting,
         containers,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.3.0.1
+## 1.4.0.0
 
-*
+* Add a placeholder for `ConwayUTXOW` rule and replace the previous `"UTXOW"` for `ConwayEra`
 
 ## 1.3.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.3.0.0
+version:            1.4.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -71,7 +71,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-core ^>=1.3,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -52,6 +52,7 @@ library
         Cardano.Ledger.Conway.Rules.Tally
         Cardano.Ledger.Conway.Rules.Tickf
         Cardano.Ledger.Conway.Rules.Utxos
+        Cardano.Ledger.Conway.Rules.Utxow
 
     default-language: Haskell2010
     ghc-options:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -16,11 +16,12 @@ module Cardano.Ledger.Conway.Era (
   ConwayTICKF,
   ConwayLEDGER,
   ConwayRATIFY,
+  ConwayUTXOW,
 ) where
 
 import Cardano.Ledger.Alonzo.Rules (AlonzoBBODY)
 import Cardano.Ledger.Babbage (BabbageEra)
-import Cardano.Ledger.Babbage.Rules (BabbageUTXO, BabbageUTXOW)
+import Cardano.Ledger.Babbage.Rules (BabbageUTXO)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Value (MaryValue)
@@ -99,11 +100,13 @@ data ConwayVDEL era
 
 type instance EraRule "VDEL" (ConwayEra c) = ConwayVDEL (ConwayEra c)
 
+data ConwayUTXOW era
+
+type instance EraRule "UTXOW" (ConwayEra c) = ConwayUTXOW (ConwayEra c)
+
 -- Rules inherited from Babbage
 
 type instance EraRule "UTXO" (ConwayEra c) = BabbageUTXO (ConwayEra c)
-
-type instance EraRule "UTXOW" (ConwayEra c) = BabbageUTXOW (ConwayEra c)
 
 -- Rules inherited from Alonzo
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Ratify,
   module Cardano.Ledger.Conway.Rules.Tally,
   module Cardano.Ledger.Conway.Rules.Utxos,
+  module Cardano.Ledger.Conway.Rules.Utxow,
 )
 where
 
@@ -27,4 +28,5 @@ import Cardano.Ledger.Conway.Rules.Ratify
 import Cardano.Ledger.Conway.Rules.Tally
 import Cardano.Ledger.Conway.Rules.Tickf
 import Cardano.Ledger.Conway.Rules.Utxos
+import Cardano.Ledger.Conway.Rules.Utxow
 import Cardano.Ledger.Conway.Rules.VDel

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -28,10 +28,27 @@ import Cardano.Ledger.Conway.Era (ConwayCERT, ConwayDELEG, ConwayPOOL, ConwayVDE
 import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure (..))
 import Cardano.Ledger.Conway.Rules.VDel (ConwayVDelPredFailure)
 import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert, ConwayDelegCert, ConwayTxCert (..))
-import Cardano.Ledger.Shelley.API (CertState (..), DState, DelegEnv (DelegEnv), DelplEnv (DelplEnv), PState, PoolEnv (PoolEnv), VState)
+import Cardano.Ledger.Shelley.API (
+  CertState (..),
+  DState,
+  DelegEnv (DelegEnv),
+  DelplEnv (DelplEnv),
+  PState,
+  PoolEnv (PoolEnv),
+  VState,
+ )
 import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
 import Control.DeepSeq (NFData)
-import Control.State.Transition.Extended (Embed, STS (..), TRC (TRC), TransitionRule, judgmentContext, trans, wrapEvent, wrapFailed)
+import Control.State.Transition.Extended (
+  Embed,
+  STS (..),
+  TRC (TRC),
+  TransitionRule,
+  judgmentContext,
+  trans,
+  wrapEvent,
+  wrapFailed,
+ )
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
@@ -121,7 +138,8 @@ certTransition ::
   ) =>
   TransitionRule (ConwayCERT era)
 certTransition = do
-  TRC (DelplEnv slot ptr pp acnt, cState@CertState {certDState, certPState, certVState}, c) <- judgmentContext
+  TRC (DelplEnv slot ptr pp acnt, cState, c) <- judgmentContext
+  let CertState {certDState, certPState, certVState} = cState
   case c of
     ConwayTxCertDeleg delegCert -> do
       newDState <- trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState, delegCert)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -25,7 +25,7 @@ import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowEvent)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.Babbage.Rules (BabbageUTXOW, BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.Tx (IsValid (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfoPure)
@@ -41,6 +41,7 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.Rules.Certs (ConwayCertsEvent, ConwayCertsPredFailure)
 import Cardano.Ledger.Conway.Rules.Tally (ConwayTallyPredFailure, TallyEnv (..))
+import Cardano.Ledger.Conway.Rules.Utxow (ConwayUTXOW)
 import Cardano.Ledger.Conway.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Shelley.LedgerState (
@@ -272,11 +273,11 @@ ledgerTransition = do
 
 instance
   ( Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
-  , BaseM (BabbageUTXOW era) ~ ShelleyBase
+  , BaseM (ConwayUTXOW era) ~ ShelleyBase
   , AlonzoEraTx era
   , EraUTxO era
   , BabbageEraTxBody era
-  , Embed (EraRule "UTXO" era) (BabbageUTXOW era)
+  , Embed (EraRule "UTXO" era) (ConwayUTXOW era)
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , Script era ~ AlonzoScript era
@@ -285,11 +286,11 @@ instance
   , Signal (EraRule "UTXO" era) ~ Tx era
   , PredicateFailure (EraRule "UTXOW" era) ~ BabbageUtxowPredFailure era
   , Event (EraRule "UTXOW" era) ~ AlonzoUtxowEvent era
-  , STS (BabbageUTXOW era)
-  , PredicateFailure (BabbageUTXOW era) ~ BabbageUtxowPredFailure era
-  , Event (BabbageUTXOW era) ~ AlonzoUtxowEvent era
+  , STS (ConwayUTXOW era)
+  , PredicateFailure (ConwayUTXOW era) ~ BabbageUtxowPredFailure era
+  , Event (ConwayUTXOW era) ~ AlonzoUtxowEvent era
   ) =>
-  Embed (BabbageUTXOW era) (ConwayLEDGER era)
+  Embed (ConwayUTXOW era) (ConwayLEDGER era)
   where
   wrapFailed = ConwayUtxowFailure
   wrapEvent = UtxowEvent

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Rules.Utxow (
+  ConwayUTXOW,
+)
+where
+
+import Cardano.Crypto.DSIGN.Class (Signable)
+import Cardano.Crypto.Hash.Class (Hash)
+import Cardano.Ledger.Alonzo.Rules (
+  AlonzoUtxowEvent (WrappedShelleyEraEvent),
+ )
+import Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoUtxoEvent)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
+import Cardano.Ledger.Alonzo.TxInfo (ExtendedUTxO (..))
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (
+  BabbageUTXO,
+  BabbageUtxoPredFailure,
+  BabbageUtxowPredFailure (..),
+ )
+import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Era (ConwayUTXOW)
+import Cardano.Ledger.Crypto (DSIGN, HASH)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.Rules (
+  ShelleyUtxowEvent (UtxoEvent),
+  UtxoEnv (..),
+ )
+import Cardano.Ledger.UTxO (EraUTxO (..))
+import Control.State.Transition.Extended (
+  Embed (..),
+  STS (..),
+ )
+
+instance
+  forall era.
+  ( ExtendedUTxO era
+  , AlonzoEraTx era
+  , EraUTxO era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ConwayEraTxBody era
+  , Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
+  , Script era ~ AlonzoScript era
+  , -- Allow UTXOW to call UTXO
+    Embed (EraRule "UTXO" era) (ConwayUTXOW era)
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
+  , State (EraRule "UTXO" era) ~ UTxOState era
+  , Signal (EraRule "UTXO" era) ~ Tx era
+  , Eq (PredicateFailure (EraRule "UTXOS" era))
+  , Show (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  STS (ConwayUTXOW era)
+  where
+  type State (ConwayUTXOW era) = UTxOState era
+  type Signal (ConwayUTXOW era) = Tx era
+  type Environment (ConwayUTXOW era) = UtxoEnv era
+  type BaseM (ConwayUTXOW era) = ShelleyBase
+  type PredicateFailure (ConwayUTXOW era) = BabbageUtxowPredFailure era
+  type Event (ConwayUTXOW era) = AlonzoUtxowEvent era
+  transitionRules = []
+  initialRules = []
+
+instance
+  ( Era era
+  , STS (BabbageUTXO era)
+  , PredicateFailure (EraRule "UTXO" era) ~ BabbageUtxoPredFailure era
+  , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
+  , BaseM (ConwayUTXOW era) ~ ShelleyBase
+  , PredicateFailure (ConwayUTXOW era) ~ BabbageUtxowPredFailure era
+  , Event (ConwayUTXOW era) ~ AlonzoUtxowEvent era
+  ) =>
+  Embed (BabbageUTXO era) (ConwayUTXOW era)
+  where
+  wrapFailed = UtxoFailure
+  wrapEvent = WrappedShelleyEraEvent . UtxoEvent

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-conway-test
-version:       1.2.0.0
+version:       1.2.0.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -38,17 +38,17 @@ library
         base >=4.14 && <4.19,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} ^>=1.3,
         cardano-ledger-alonzo-test,
-        cardano-ledger-babbage ^>=1.3,
+        cardano-ledger-babbage >=1.3 && <1.5,
         cardano-ledger-babbage-test,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-strict-containers,
-        cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.3,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib} >=1.3 && <1.5,
         cardano-ledger-core:{cardano-ledger-core, testlib} ^>=1.3,
         cardano-ledger-allegra ^>=1.2,
         cardano-ledger-mary ^>=1.3,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-slotting,
         containers,
         data-default-class,

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.0.0
+version:            1.3.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -60,7 +60,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-core ^>=1.3,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         containers,
         deepseq,
         groups,

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-shelley-ma-test
-version:       1.2.1.0
+version:       1.2.1.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -54,7 +54,7 @@ library
         containers,
         hashable,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.3,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.3 && <1.5,
         cardano-strict-containers,
         microlens,
         mtl,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -7,9 +7,7 @@
 * Prevent using `mkGenesisDelegTxCert`, `getGenesisDelegTxCert` and `GenesisDelegTxCert`
   from being used in eras after Babbage. This also affects all functions that use those
   functions and patern synonym
-* Change `WrongCertificateTypePOOL`. Instead of accepting a number tag of a type, it now
-  contains the actual violating certificate. This was an impossible case, so it should not
-  really affect downstream users
+* Remove `WrongCertificateTypePOOL` as an impossible case.
 
 ## 1.3.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.3.0.1
+## 1.4.0.0
 
-*
+* Prevent using `getMirTxCert` from being used in eras after Babbage. This also affects
+  all functions that use it
+* Prevent using `mkGenesisDelegTxCert`, `getGenesisDelegTxCert` and `GenesisDelegTxCert`
+  from being used in eras after Babbage. This also affects all functions that use those
+  functions and patern synonym
+* Change `WrongCertificateTypePOOL`. Instead of accepting a number tag of a type, it now
+  contains the actual violating certificate. This was an impossible case, so it should not
+  really affect downstream users
 
 ## 1.3.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.3.0.0
+version:            1.4.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -141,7 +141,7 @@ data ShelleyDelegPredFailure era
 
 newtype ShelleyDelegEvent era = NewEpoch EpochNo
 
-instance (EraPParams era, ShelleyEraTxCert era) => STS (ShelleyDELEG era) where
+instance (EraPParams era, ShelleyEraTxCert era, ProtVerAtMost era 8) => STS (ShelleyDELEG era) where
   type State (ShelleyDELEG era) = DState era
   type Signal (ShelleyDELEG era) = TxCert era
   type Environment (ShelleyDELEG era) = DelegEnv era
@@ -262,7 +262,9 @@ instance
         pure (3, MIRNegativeTransfer pot amt)
       k -> invalidKey k
 
-delegationTransition :: (ShelleyEraTxCert era, EraPParams era) => TransitionRule (ShelleyDELEG era)
+delegationTransition ::
+  (ShelleyEraTxCert era, EraPParams era, ProtVerAtMost era 8) =>
+  TransitionRule (ShelleyDELEG era)
 delegationTransition = do
   TRC (DelegEnv slot ptr acnt pp, ds, c) <- judgmentContext
   let pv = pp ^. ppProtocolVersionL
@@ -384,7 +386,7 @@ delegationTransition = do
       pure ds
 
 checkSlotNotTooLate ::
-  (ShelleyEraTxCert era, EraPParams era) =>
+  (ShelleyEraTxCert era, EraPParams era, ProtVerAtMost era 8) =>
   SlotNo ->
   Rule (ShelleyDELEG era) 'Transition ()
 checkSlotNotTooLate slot = do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -103,7 +103,7 @@ instance
   , Signal (EraRule "DELEG" era) ~ TxCert era
   , Embed (EraRule "POOL" era) (ShelleyDELPL era)
   , Environment (EraRule "POOL" era) ~ PoolEnv era
-  , Signal (EraRule "POOL" era) ~ TxCert era
+  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , TxCert era ~ ShelleyTxCert era
   ) =>
   STS (ShelleyDELPL era)
@@ -165,20 +165,16 @@ delplTransition ::
   , Signal (EraRule "DELEG" era) ~ TxCert era
   , Embed (EraRule "POOL" era) (ShelleyDELPL era)
   , Environment (EraRule "POOL" era) ~ PoolEnv era
-  , Signal (EraRule "POOL" era) ~ TxCert era
+  , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
   , TxCert era ~ ShelleyTxCert era
   ) =>
   TransitionRule (ShelleyDELPL era)
 delplTransition = do
   TRC (DelplEnv slot ptr pp acnt, d, c) <- judgmentContext
   case c of
-    ShelleyTxCertPool (RegPool _) -> do
+    ShelleyTxCertPool poolCert -> do
       ps <-
-        trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState d, c)
-      pure $ d {certPState = ps}
-    ShelleyTxCertPool (RetirePool _ _) -> do
-      ps <-
-        trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState d, c)
+        trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState d, poolCert)
       pure $ d {certPState = ps}
     ShelleyTxCertGenesisDeleg GenesisDelegCert {} -> do
       ds <-

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -205,6 +205,7 @@ instance
 instance
   ( ShelleyEraTxCert era
   , EraPParams era
+  , ProtVerAtMost era 8
   , PredicateFailure (EraRule "DELEG" era) ~ ShelleyDelegPredFailure era
   ) =>
   Embed (ShelleyDELEG era) (ShelleyDELPL era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -262,11 +262,12 @@ depositEqualsObligation ::
   , Environment t ~ LedgerEnv era
   , Signal t ~ Tx era
   , State t ~ LedgerState era
+  , ProtVerAtMost era 8
   ) =>
   AssertionViolation t ->
   String
 depositEqualsObligation
-  AssertionViolation {avSTS, avMsg, avCtx = (TRC (LedgerEnv slot _ pp _, _, tx)), avState} =
+  AssertionViolation {avSTS, avMsg, avCtx = TRC (LedgerEnv slot _ pp _, _, tx), avState} =
     let dpstate = lsCertState <$> avState
         utxo = utxosUtxo . lsUTxOState <$> avState
         txb = tx ^. bodyTxL

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -293,6 +293,7 @@ transitionRulesUTXOW ::
   ( EraTx era
   , EraUTxO era
   , ShelleyEraTxBody era
+  , ProtVerAtMost era 8
   , ScriptsNeeded era ~ ShelleyScriptsNeeded era
   , BaseM (utxow era) ~ ShelleyBase
   , Embed (EraRule "UTXO" era) (utxow era)
@@ -361,6 +362,7 @@ instance
   ( EraTx era
   , EraUTxO era
   , ShelleyEraTxBody era
+  , ProtVerAtMost era 8
   , Tx era ~ ShelleyTx era
   , ScriptsNeeded era ~ ShelleyScriptsNeeded era
   , DSignable (EraCrypto era) (Hash (EraCrypto era) EraIndependentTxBody)
@@ -545,6 +547,7 @@ validateMetadata pp tx =
 validateMIRInsufficientGenesisSigs ::
   ( EraTx era
   , ShelleyEraTxBody era
+  , ProtVerAtMost era 8
   ) =>
   GenDelegs (EraCrypto era) ->
   Word64 ->

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -137,10 +137,12 @@ class EraTxCert era => ShelleyEraTxCert era where
     TxCert era -> Maybe (StakeCredential (EraCrypto era), KeyHash 'StakePool (EraCrypto era))
 
   mkGenesisDelegTxCert :: ProtVerAtMost era 8 => GenesisDelegCert (EraCrypto era) -> TxCert era
-  getGenesisDelegTxCert :: TxCert era -> Maybe (GenesisDelegCert (EraCrypto era))
+  getGenesisDelegTxCert ::
+    ProtVerAtMost era 8 => TxCert era -> Maybe (GenesisDelegCert (EraCrypto era))
 
   mkMirTxCert :: ProtVerAtMost era 8 => MIRCert (EraCrypto era) -> TxCert era
-  getMirTxCert :: TxCert era -> Maybe (MIRCert (EraCrypto era))
+  getMirTxCert ::
+    ProtVerAtMost era 8 => TxCert era -> Maybe (MIRCert (EraCrypto era))
 
 instance Crypto c => ShelleyEraTxCert (ShelleyEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (ShelleyEra StandardCrypto) #-}
@@ -460,7 +462,7 @@ isDelegation (DelegStakeTxCert _ _) = True
 isDelegation _ = False
 
 -- | Check for 'GenesisDelegate' constructor
-isGenesisDelegation :: ShelleyEraTxCert era => TxCert era -> Bool
+isGenesisDelegation :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCert era -> Bool
 isGenesisDelegation = isJust . getGenesisDelegTxCert
 
 -- | Check for 'RegPool' constructor
@@ -473,15 +475,15 @@ isRetirePool :: EraTxCert era => TxCert era -> Bool
 isRetirePool (RetirePoolTxCert _ _) = True
 isRetirePool _ = False
 
-isInstantaneousRewards :: ShelleyEraTxCert era => TxCert era -> Bool
+isInstantaneousRewards :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCert era -> Bool
 isInstantaneousRewards = isJust . getMirTxCert
 
-isReservesMIRCert :: ShelleyEraTxCert era => TxCert era -> Bool
+isReservesMIRCert :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCert era -> Bool
 isReservesMIRCert x = case getMirTxCert x of
   Just (MIRCert ReservesMIR _) -> True
   _ -> False
 
-isTreasuryMIRCert :: ShelleyEraTxCert era => TxCert era -> Bool
+isTreasuryMIRCert :: (ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCert era -> Bool
 isTreasuryMIRCert x = case getMirTxCert x of
   Just (MIRCert TreasuryMIR _) -> True
   _ -> False

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -136,7 +136,7 @@ class EraTxCert era => ShelleyEraTxCert era where
   getDelegStakeTxCert ::
     TxCert era -> Maybe (StakeCredential (EraCrypto era), KeyHash 'StakePool (EraCrypto era))
 
-  mkGenesisDelegTxCert :: GenesisDelegCert (EraCrypto era) -> TxCert era
+  mkGenesisDelegTxCert :: ProtVerAtMost era 8 => GenesisDelegCert (EraCrypto era) -> TxCert era
   getGenesisDelegTxCert :: TxCert era -> Maybe (GenesisDelegCert (EraCrypto era))
 
   mkMirTxCert :: ProtVerAtMost era 8 => MIRCert (EraCrypto era) -> TxCert era
@@ -195,7 +195,7 @@ pattern MirTxCert d <- (getMirTxCert -> Just d)
     MirTxCert d = mkMirTxCert d
 
 pattern GenesisDelegTxCert ::
-  ShelleyEraTxCert era =>
+  (ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   KeyHash 'Genesis (EraCrypto era) ->
   KeyHash 'GenesisDelegate (EraCrypto era) ->
   Hash (EraCrypto era) (VerKeyVRF (EraCrypto era)) ->
@@ -366,7 +366,7 @@ instance
       gen <- decCBOR
       genDeleg <- decCBOR
       vrf <- decCBOR
-      pure (4, GenesisDelegTxCert gen genDeleg vrf)
+      pure (4, ShelleyTxCertGenesisDeleg $ GenesisDelegCert gen genDeleg vrf)
     6 -> do
       x <- decCBOR
       pure (2, ShelleyTxCertMir x)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -652,9 +652,8 @@ instance Era era => Arbitrary (ShelleyPpupPredFailure era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Era era => Arbitrary (ShelleyPoolPredFailure era) where
+instance (Arbitrary (TxCert era), Era era) => Arbitrary (ShelleyPoolPredFailure era) where
   arbitrary = genericArbitraryU
-  shrink = genericShrink
 
 instance
   ( Era era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -652,8 +652,9 @@ instance Era era => Arbitrary (ShelleyPpupPredFailure era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance (Arbitrary (TxCert era), Era era) => Arbitrary (ShelleyPoolPredFailure era) where
+instance Era era => Arbitrary (ShelleyPoolPredFailure era) where
   arbitrary = genericArbitraryU
+  shrink = genericShrink
 
 instance
   ( Era era

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -85,7 +85,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-byron,
         cardano-ledger-byron-test,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3.1,
         cardano-ledger-pretty,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.4,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -87,7 +87,7 @@ library
         cardano-ledger-byron-test,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3,
         cardano-ledger-pretty,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.3,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.4,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting,
         cborg,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -132,10 +132,10 @@ poolStateIsInternallyConsistent (SourceSignalTarget {source = chainSt, signal = 
   where
     (_, poolTr) = poolTraceFromBlock chainSt block
 
-poolRegistrationProp :: EraTxCert era => SourceSignalTarget (ShelleyPOOL era) -> Property
+poolRegistrationProp :: SourceSignalTarget (ShelleyPOOL era) -> Property
 poolRegistrationProp
   SourceSignalTarget
-    { signal = (RegPoolTxCert poolParams)
+    { signal = RegPool poolParams
     , source = sourceSt
     , target = targetSt
     } =
@@ -169,11 +169,15 @@ poolRegistrationProp
               ]
 poolRegistrationProp _ = property ()
 
-poolRetirementProp :: EraTxCert era => EpochNo -> EpochNo -> SourceSignalTarget (ShelleyPOOL era) -> Property
+poolRetirementProp ::
+  EpochNo ->
+  EpochNo ->
+  SourceSignalTarget (ShelleyPOOL era) ->
+  Property
 poolRetirementProp
   currentEpoch@(EpochNo ce)
   (EpochNo maxEpoch)
-  SourceSignalTarget {source = sourceSt, target = targetSt, signal = (RetirePoolTxCert hk e)} =
+  SourceSignalTarget {source = sourceSt, target = targetSt, signal = RetirePool hk e} =
     conjoin
       [ counterexample
           ("epoch must be well formed " <> show ce <> " " <> show e <> " " <> show maxEpoch)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -66,6 +66,7 @@ import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Data.Foldable (toList)
 import Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import Data.Proxy
 import qualified Data.Set as Set
 import Data.Word (Word64)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -195,15 +195,12 @@ poolTraceFromBlock chainSt block =
   where
     (tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
     certs = concatMap (toList . view certsTxBodyL . view bodyTxL)
-    poolCerts = filter poolCert (certs txs)
+    poolCerts = mapMaybe getPoolCertTxCert (certs txs)
     poolEnv =
       let (LedgerEnv s _ pp _) = ledgerEnv
        in PoolEnv s pp
     poolSt0 =
       certPState (lsCertState ledgerSt0)
-    poolCert (RegPoolTxCert _) = True
-    poolCert (RetirePoolTxCert _ _) = True
-    poolCert _ = False
 
 -- | Reconstruct a DELEG trace from all the transaction certificates in a Block
 delegTraceFromBlock ::

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -49,7 +49,7 @@ testPoolNetworkID pv poolParams e = do
             ( TRC
                 ( PoolEnv (SlotNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
                 , def
-                , RegPoolTxCert poolParams
+                , RegPool poolParams
                 )
             )
   case (st, e) of

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -56,7 +56,7 @@ library
         cardano-ledger-conway >=1.1,
         cardano-ledger-core ^>=1.3,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley >=1.3 && <1.5,
         cardano-slotting,
         containers,
         microlens,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-core`
 
-## 1.3.0.1
+## 1.3.1.0
 
-*
+* Addition of `getPoolCertTxCert`
 
 ## 1.3.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.3.0.0
+version:            1.3.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -15,6 +15,7 @@ module Cardano.Ledger.Core.TxCert (
   pattern RetirePoolTxCert,
   Delegation (..),
   PoolCert (..),
+  getPoolCertTxCert,
   poolCWitness,
   poolCertKeyHashWitness,
 )
@@ -72,6 +73,12 @@ pattern RetirePoolTxCert ::
 pattern RetirePoolTxCert poolId epochNo <- (getRetirePoolTxCert -> Just (poolId, epochNo))
   where
     RetirePoolTxCert poolId epochNo = mkRetirePoolTxCert poolId epochNo
+
+getPoolCertTxCert :: EraTxCert era => TxCert era -> Maybe (PoolCert (EraCrypto era))
+getPoolCertTxCert = \case
+  RegPoolTxCert poolParams -> Just $ RegPool poolParams
+  RetirePoolTxCert poolId epochNo -> Just $ RetirePool poolId epochNo
+  _ -> Nothing
 
 -- | The delegation of one stake key to another.
 data Delegation c = Delegation

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -42,7 +42,7 @@ library
         cardano-ledger-conway >=1.3,
         cardano-ledger-core ^>=1.3,
         cardano-ledger-mary >=1.0,
-        cardano-ledger-shelley ^>=1.3,
+        cardano-ledger-shelley ^>=1.4,
         cardano-protocol-tpraos >=1.0,
         cardano-slotting,
         containers,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-test
-version:            1.1.0.0
+version:            9.9.9.9
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -470,7 +470,7 @@ instance
   prettyA (PoolFailure x) = prettyA x
   prettyA (DelegFailure x) = prettyA x
 
-instance PrettyA (TxCert era) => PrettyA (ShelleyPoolPredFailure era) where
+instance PrettyA (ShelleyPoolPredFailure era) where
   prettyA (StakePoolNotRegisteredOnKeyPOOL kh) =
     ppRecord
       "StakePoolNotRegisteredOnKeyPOOL"
@@ -488,10 +488,6 @@ instance PrettyA (TxCert era) => PrettyA (ShelleyPoolPredFailure era) where
         , ("Pool Retirement Epoch", prettyA poolRetEpoch)
         , ("First Epoch Too Far", prettyA firstTooFarEpoch)
         ]
-  prettyA (WrongCertificateTypePOOL disallowedCertificate) =
-    ppRecord
-      "WrongCertificateTypePOOL"
-      [("Disallowed Certificate", prettyA disallowedCertificate)]
   prettyA
     ( StakePoolCostTooLowPOOL
         prcStakePoolCost

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -470,7 +470,7 @@ instance
   prettyA (PoolFailure x) = prettyA x
   prettyA (DelegFailure x) = prettyA x
 
-instance PrettyA (ShelleyPoolPredFailure era) where
+instance PrettyA (TxCert era) => PrettyA (ShelleyPoolPredFailure era) where
   prettyA (StakePoolNotRegisteredOnKeyPOOL kh) =
     ppRecord
       "StakePoolNotRegisteredOnKeyPOOL"

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -41,7 +41,7 @@ library
         cardano-ledger-conway >=1.1,
         cardano-ledger-core >=1.2 && <1.4,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley >=1.2 && <1.4,
+        cardano-ledger-shelley >=1.2 && <1.5,
         cardano-slotting,
         containers,
         deepseq,

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               ledger-state
-version:            1.1.0.0
+version:            9.9.9.9
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
# Description

Deprecated certificates (MIR and GenesisDeleg) were still usable in Conway, as far as the type system is concerned. This PR fixes it with proper deprecation of those certificates

* Prevent using `getMirTxCert` from being used in eras after Babbage. This also affects
  all functions that use it
* Prevent using `mkGenesisDelegTxCert`, `getGenesisDelegTxCert` and `GenesisDelegTxCert`
  from being used in eras after Babbage. This also affects all functions that use those
  functions and patern synonym
* Change `WrongCertificateTypePOOL`. Instead of accepting a number tag of a type, it now
  contains the actual violating certificate. This was an impossible case, so it should not
  really affect downstream users
* Add a placeholder for `ConwayUTXOW` rule and replace the previous `"UTXOW"` for `ConwayEra`. The rule itself will be implemented in #3466 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
