### PR TITLE
Arbitrary instances for {ConwayCertPredFailure, ConwayDelegPredFailure, ConwayVDelPredFailure}

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.4.0.0
 
 * Add a placeholder for `ConwayUTXOW` rule and replace the previous `"UTXOW"` for `ConwayEra`
+
+### `testlib`
+
 * Add `Arbitrary` instances for `ConwayCertPredFailure`, `ConwayVDelPredFailure`, and `ConwayDelegPredFailure`
 
 ## 1.3.0.0

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0.0
 
 * Add a placeholder for `ConwayUTXOW` rule and replace the previous `"UTXOW"` for `ConwayEra`
+* Add `Arbitrary` instances for `ConwayCertPredFailure`, `ConwayVDelPredFailure`, and `ConwayDelegPredFailure`
 
 ## 1.3.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -7,7 +7,7 @@ author:             IOHK
 bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
 synopsis:           Cardano ledger with an updated on-chain governance system.
 description:
-    This package builds upon the Babbage ledger with an updtaed on-chain governance system.
+    This package builds upon the Babbage ledger with an updated on-chain governance system.
 
 category:           Network
 build-type:         Simple

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -277,3 +277,48 @@ instance
       , WithdrawalsNotInRewardsCERTS <$> arbitrary
       , CertFailure <$> arbitrary
       ]
+
+-- CERT
+
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "DELEG" era))
+  , Arbitrary (PredicateFailure (EraRule "POOL" era))
+  , Arbitrary (PredicateFailure (EraRule "VDEL" era))
+  ) =>
+  Arbitrary (ConwayCertPredFailure era)
+  where
+  arbitrary =
+    oneof
+      [ DelegFailure <$> arbitrary
+      , PoolFailure <$> arbitrary
+      , VDelFailure <$> arbitrary
+      ]
+
+-- DELEG
+
+instance
+  ( Era era
+  ) =>
+  Arbitrary (ConwayDelegPredFailure era)
+  where
+  arbitrary =
+    oneof
+      [ IncorrectDepositDELEG <$> arbitrary
+      , StakeKeyAlreadyRegisteredDELEG <$> arbitrary
+      , StakeKeyNotRegisteredDELEG <$> arbitrary
+      , StakeKeyHasNonZeroAccountBalanceDELEG <$> arbitrary
+      , DRepAlreadyRegisteredForStakeKeyDELEG <$> arbitrary
+      , pure WrongCertificateTypeDELEG
+      ]
+
+-- VDEL
+
+instance (Era era, Crypto era) => Arbitrary (ConwayVDelPredFailure (ConwayEra era)) where
+  arbitrary =
+    oneof
+      [ ConwayDRepAlreadyRegisteredVDEL <$> arbitrary
+      , ConwayDRepNotRegisteredVDEL <$> arbitrary
+      , ConwayDRepIncorrectDepositVDEL <$> arbitrary
+      , ConwayCommitteeHasResignedVDEL <$> arbitrary
+      ]


### PR DESCRIPTION
add `Arbitrary` instances for `ConwayCertPredFailure`, `ConwayDelegPredFailure` and `ConwayVDelPredFailure` (required for consensus tests)

# Description

- Adds missing `Arbitrary` instances required by `ouroboros-consensus`' test suites

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
