### PR TITLE
Fix add-from-github.sh invocation example in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -174,10 +174,10 @@ CHaP. (TODO: implement a script that lists all of the package that fit the above
 1. Follow the [CHaP release
    instructions](https://github.com/input-output-hk/cardano-haskell-packages#-from-github)
 
-   For example:
+   For example, to release commit with SHA `deadbeef`:
 
    ```shell
-   $ ./scripts/add-from-github.sh https://github.com/input-output-hk/cardano-ledger libs/cardano-ledger-core deadbeef...
+   $ ./scripts/add-from-github.sh https://github.com/input-output-hk/cardano-ledger deadbeef libs/cardano-ledger-core ...
    ```
    It is important to supply a commit SHA instead of a branch name.
 


### PR DESCRIPTION
# Description

Just a small fix in the order of arguments when invoking ./scripts/add-from-github.sh when doing a release

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
