### PR TITLE
Update CHANGELOG of released packages with next version

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.0.2
+
+*
+
 ## 1.2.0.1
 
 *

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.3.1.1
+
+*
+
 ## 1.3.1.0
 
 * Added `Semigroup` and `Monoid` instances to `AlonzoScriptsNeeded`

--- a/eras/alonzo/test-suite/CHANGELOG.md
+++ b/eras/alonzo/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo-test`
 
+## 1.1.2.2
+
+*
+
 ## 1.1.2.1
 
 *

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.4.0.1
+
+*
+
 ## 1.4.0.0
 
 * Added a protocol version constraint to:

--- a/eras/babbage/test-suite/CHANGELOG.md
+++ b/eras/babbage/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage-test`
 
+## 1.1.1.3
+
+*
+
 ## 1.1.1.2
 
 *

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.4.0.1
+
+*
+
 ## 1.4.0.0
 
 * Added `ConwayUTXOW` rule

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway-test`
 
+## 1.2.0.2
+
+*
+
 ## 1.2.0.1
 
 *

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.3.0.2
+
+*
+
 ## 1.3.0.1
 
 *

--- a/eras/shelley-ma/test-suite/CHANGELOG.md
+++ b/eras/shelley-ma/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley-ma-test`
 
+## 1.2.1.2
+
+*
+
 ## 1.2.1.1
 
 *

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.4.0.1
+
+*
+
 ## 1.4.0.0
 
 * Deprecated `updateTxBodyG`

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley-test`
 
+## 1.2.0.2
+
+*
+
 ## 1.2.0.1
 
 * Changed bounds on cardano-ledger-shelley-test

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-api`
 
+## 1.2.1.1
+
+*
+
 ## 1.2.1.0
 
 * Deprecated `updateTxBodyG`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-core`
 
+## 1.3.1.1
+
+*
+
 ## 1.3.1.0
 
 * Addition of `getPoolCertTxCert`

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `cardano-ledger-pretty`
 
+## 1.2.0.2
+
+*
+
 ## 1.2.0.1
 
 *

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-protocol-tpraos`
 
+## 1.0.3.3
+
+*
+
 ## 1.0.3.2
 
 * Changed upper bound on cardano-ledger-shelley  and base


### PR DESCRIPTION
following the CHaP release

# Description

Released 

cardano-ledger-core 1.3.1.0
cardano-ledger-pretty 1.2.0.1
cardano-ledger-mary 1.3.0.1
cardano-ledger-conway 1.4.0.0
cardano-ledger-shelley 1.4.0.0
cardano-ledger-alonzo 1.3.1.0
cardano-ledger-alonzo-test 1.1.2.1
cardano-ledger-allegra 1.2.0.1
cardano-ledger-babbage 1.4.0.0
cardano-ledger-babbage-test 1.1.1.2
cardano-ledger-shelley-ma-test 1.2.1.1
cardano-ledger-shelley-test-1.2.0.1 
cardano-protocol-tpraos-1.0.3.2  

as per: 
https://github.com/input-output-hk/cardano-haskell-packages/pull/353

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
