### PR TITLE
Bump cardano-ledger-shelley-test version

### DIFF
--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 1.2.0.1
 
-*
+* Changed bounds on cardano-ledger-shelley-test

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-shelley-test
-version:       1.2.0.0
+version:       1.2.0.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.3.2
 
-*
+* Changed upper bound on cardano-ledger-shelley  and base
 
 ## 1.0.3.1
 

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-protocol-tpraos
-version:       1.0.3.1
+version:       1.0.3.2
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
since its bounds on cardano-ledger-shelley have changed from 1.3 to 1.4

# Description

I'm having[ issues releasing to CHaP,](https://github.com/input-output-hk/cardano-haskell-packages/actions/runs/5315773558/jobs/9625101920?pr=353) and I think it might be because we haven't bumped this version when changing the cardano-ledger-shelley bounds (or at least one of the issues!) 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
