### PR TITLE
Bump `bimap` upper bound to `<0.6`

### DIFF
--- a/eras/byron/chain/executable-spec/byron-spec-chain.cabal
+++ b/eras/byron/chain/executable-spec/byron-spec-chain.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               byron-spec-chain
-version:            1.0.0.0
+version:            1.0.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -28,7 +28,7 @@ library
 
     build-depends:
         base >=4.14 && <4.19,
-        bimap >=0.4 && <0.5,
+        bimap >=0.4 && <0.6,
         bytestring,
         containers,
         byron-spec-ledger >=1.0,

--- a/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
+++ b/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               byron-spec-ledger
-version:            1.0.0.0
+version:            1.0.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -37,7 +37,7 @@ library
 
     build-depends:
         base >=4.14 && <4.19,
-        bimap >=0.4 && <0.5,
+        bimap >=0.4 && <0.6,
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-byron
-version:            1.0.0.1
+version:            1.0.0.2
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -230,7 +230,7 @@ library
         base >=4.14 && <4.19,
         aeson,
         base58-bytestring,
-        bimap >=0.4 && <0.5,
+        bimap >=0.4 && <0.6,
         binary,
         bytestring,
         canonical-json,


### PR DESCRIPTION
# Description
This is a prerequisite for GHC 9.6 work in integrating latest ledger in: https://github.com/input-output-hk/cardano-api/pull/80 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
