### PR TITLE
Fix voting procedure

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Added `ConwayWdrlNotDelegatedToDRep` to `ConwayLedgerPredFailure`
 * Changed the type of voting delegatee from `Credential` to `DRep`
+* Removal of `VoterRole` in favor of `Voter`
+* Removal of `vProcRole` and `vProcRoleKeyHash` in favor of `vProcVoter` in `VotingProcedure`
+* Removal of `cgVoterRolesL` and `cgVoterRoles` for `ConwayGovernance` as no longer needed.
+* Removal of `gasVotes` in favor of `gasCommitteeVotes`, `gasDRepVotes` and
+  `gasStakePoolVotes` in `GovernanceActionState`
+* Removal of `reRoles` from `RatifyEnv` as no longer needed
+* Addtion of `reStakePoolDistr` to `RatifyEnv`
+* Remove `VoterDoesNotHaveRole` as no longer needed from `ConwayTallyPredFailure`
 
 ## 1.4.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -280,7 +280,7 @@ ledgerTransition = do
   tallySt' <-
     trans @(EraRule "TALLY" era) $
       TRC
-        ( TallyEnv (txid txBody) epoch $ cgVoterRoles govSt
+        ( TallyEnv (txid txBody) epoch
         , cgTally govSt
         , StrictSeq.fromStrict govProcedures
         )

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -156,12 +156,12 @@ newEpochTransition ::
 newEpochTransition = do
   TRC
     ( _
-      , src@(NewEpochState eL _ bcur eps ru _pd _)
+      , nes@(NewEpochState eL _ bcur eps ru _pd _)
       , eNo
       ) <-
     judgmentContext
   if eNo /= eL + 1
-    then pure src
+    then pure nes
     else do
       es' <- case ru of
         SNothing -> pure eps
@@ -177,8 +177,8 @@ newEpochTransition = do
           ratEnv =
             RatifyEnv
               { reStakeDistr = stakeDistr
+              , reStakePoolDistr = nesPd nes
               , reCurrentEpoch = eL + 1
-              , reRoles = cgVoterRoles govSt
               }
           tallyStateToSeq = Seq.fromList . Map.toList
           ratSig = RatifySignal . tallyStateToSeq . unConwayTallyState $ cgTally govSt
@@ -192,7 +192,7 @@ newEpochTransition = do
       let ss = esSnapshots es'''
           pd' = calculatePoolDistr (ssStakeSet ss)
       pure $
-        src
+        nes
           { nesEL = eNo
           , nesBprev = bcur
           , nesBcur = BlocksMade mempty

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -77,7 +77,6 @@ instance
     ConwayGovernance
       <$> arbitrary
       <*> arbitrary
-      <*> arbitrary
 
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>
@@ -111,6 +110,8 @@ instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceAction
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceAction era) where
   arbitrary =
@@ -128,8 +129,13 @@ instance Crypto c => Arbitrary (GovernanceActionId c) where
 
 deriving instance Arbitrary GovernanceActionIx
 
-instance Arbitrary VoterRole where
-  arbitrary = arbitraryBoundedEnum
+instance Crypto c => Arbitrary (Voter c) where
+  arbitrary =
+    oneof
+      [ CommitteeVoter <$> arbitrary
+      , DRepVoter <$> arbitrary
+      , StakePoolVoter <$> arbitrary
+      ]
 
 instance Arbitrary Vote where
   arbitrary = arbitraryBoundedEnum
@@ -176,7 +182,6 @@ instance Era era => Arbitrary (TallyEnv era) where
     TallyEnv
       <$> arbitrary
       <*> arbitrary
-      <*> arbitrary
 
 instance Crypto c => Arbitrary (Anchor c) where
   arbitrary =
@@ -185,7 +190,7 @@ instance Crypto c => Arbitrary (Anchor c) where
       <*> arbitrary
 
 instance Era era => Arbitrary (VotingProcedure era) where
-  arbitrary = VotingProcedure <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = VotingProcedure <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ProposalProcedure era) where
   arbitrary = ProposalProcedure <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
@@ -198,11 +203,7 @@ instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceProced
       ]
 
 instance Era era => Arbitrary (ConwayTallyPredFailure era) where
-  arbitrary =
-    oneof
-      [ VoterDoesNotHaveRole <$> arbitrary <*> arbitrary
-      , GovernanceActionDoesNotExist <$> arbitrary
-      ]
+  arbitrary = GovernanceActionDoesNotExist <$> arbitrary
 
 instance
   ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -73,8 +73,7 @@ transaction_body =
 
 voting_procedure =
   [ governance_action_id
-  , voter_role
-  , voting_credential
+  , voter
   , vote
   , anchor / null
   ]
@@ -110,10 +109,18 @@ new_constitution = (5, $hash32)
 
 info_action = 6
 
-; constitutional committee - 0
-; DRep - 1
-; SPO - 2
-voter_role = 0 .. 2
+; Constitutional Committee Hot KeyHash: 0
+; Constitutional Committee Hot ScriptHash: 1
+; DRep KeyHash: 2
+; DRep ScriptHash: 3
+; StakingPool KeyHash: 4
+voter =
+  [ 0, addr_keyhash
+  // 1, scripthash
+  // 2, addr_keyhash
+  // 3, scripthash
+  // 4, addr_keyhash
+  ]
 
 anchor =
   [ anchor_url       : url

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Version history for `cardano-ledger-api`
 
-## 1.2.2.0
+## 1.3.0.0
 
 * Addition of `Cardano.Ledger.Api.Tx.Cert`
+* Removal of `VoterRole` in favor of `Voter`
+* Removal of `cgVoterRolesL` and `cgVoterRoles` as no longer needed.
 
 ## 1.2.1.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -54,7 +54,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-conway >=1.1,
+        cardano-ledger-conway >=1.5,
         cardano-ledger-core >=1.3 && <1.5,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -19,20 +19,17 @@ module Cardano.Ledger.Api.Governance (
   ConwayGovernance (..),
   cgRatifyL,
   cgTallyL,
-  cgVoterRolesL,
   ConwayTallyState (..),
   RatifyState (..),
   EnactState (..),
-  VoterRole (..),
+  Voter (..),
+  Vote (..),
 
   -- ** Governance Action
   GovernanceAction (..),
   GovernanceActionId (..),
   GovernanceActionIx (..),
   GovernanceActionState (..),
-
-  -- ** Vote
-  Vote (..),
 
   -- *** Anchor
   Anchor (..),
@@ -54,12 +51,11 @@ import Cardano.Ledger.Conway.Governance (
   GovernanceActionState (..),
   RatifyState (..),
   Vote (..),
-  VoterRole (..),
+  Voter (..),
   -- Lenses
 
   cgRatifyL,
   cgTallyL,
-  cgVoterRolesL,
  )
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeHash, SafeToHash, hashAnnotated)

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-pretty
-version:            1.2.1.0
+version:            1.2.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -39,7 +39,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway >=1.3,
+        cardano-ledger-conway ^>=1.5,
         cardano-ledger-core >=1.3 && <1.5,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley ^>=1.4,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Conway.Governance (
   GovernanceProcedure,
   ProposalProcedure (..),
   Vote (..),
-  VoterRole (..),
+  Voter (..),
   VotingProcedure (..),
  )
 import Cardano.Ledger.Conway.Rules (
@@ -256,18 +256,20 @@ instance PrettyA (GovernanceActionId era) where
 instance PrettyA GovernanceActionIx where
   prettyA (GovernanceActionIx x) = prettyA x
 
-instance PrettyA VoterRole where
+instance PrettyA (Voter c) where
   prettyA = ppString . show
 
 instance PrettyA (Anchor era) where
   prettyA = viaShow
 
 instance PrettyA (PParamsUpdate era) => PrettyA (GovernanceActionState era) where
-  prettyA gas@(GovernanceActionState _ _ _ _ _) =
+  prettyA gas@(GovernanceActionState _ _ _ _ _ _ _) =
     let GovernanceActionState {..} = gas
      in ppRecord
           "GovernanceActionState"
-          [ ("Votes", prettyA gasVotes)
+          [ ("CommitteVotes", prettyA gasCommitteeVotes)
+          , ("DRepVotes", prettyA gasDRepVotes)
+          , ("StakePoolVotes", prettyA gasStakePoolVotes)
           , ("Deposit", prettyA gasDeposit)
           , ("Return Address", prettyA gasReturnAddr)
           , ("Action", prettyA gasAction)
@@ -307,13 +309,12 @@ instance
   ) =>
   PrettyA (ConwayGovernance era)
   where
-  prettyA cg@(ConwayGovernance _ _ _) =
+  prettyA cg@(ConwayGovernance _ _) =
     let ConwayGovernance {..} = cg
      in ppRecord
           "ConwayGovernance"
           [ ("Tally", prettyA cgTally)
           , ("Ratify", prettyA cgRatify)
-          , ("VoterRoles", prettyA cgVoterRoles)
           ]
 
 instance

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -439,7 +439,7 @@ instance TotalAda (RatifyState era) where
   totalAda (RatifyState _ as) = foldMap (gasDeposit . snd) as
 
 instance TotalAda (ConwayGovernance era) where
-  totalAda (ConwayGovernance ts rs _) = totalAda ts <+> totalAda rs
+  totalAda (ConwayGovernance ts rs) = totalAda ts <+> totalAda rs
 
 instance Reflect era => TotalAda (LedgerState era) where
   totalAda (LedgerState utxos dps) = totalAda utxos <+> totalAda dps


### PR DESCRIPTION
# Description

Switch from using Voting role at the value level to the type level.
This PR fixes a number of issues related to the `VotingProcedure`.

First and foremost the `Voting` key role is dedicated for DReps only,
but it was being used for Stake Pools and Consitutional Committee
members as well. Using the appropriate key roles makes tarcking of
VoterRole at the value level, not only redundant, but also wrong.

Votes where tracked in a single Map with `(VoterRole, Credential 'Voting c)`
as a key, which was inefficient and wrong at the same time. It was wrong
because it required key role casting, which actually led to a bug of
checking StakePool ids against Stake Credential Map.

Counting up the StakePool votes now uses the Stake Pool Distribution Map
instead of Stake Credential, which fixes the bug that was mentioned above.

ScriptHashes are no longer allowed for StakePool votes. This might be
reverted in the future, but hopefully not. See https://github.com/input-output-hk/cardano-ledger/issues/3512 for more discussion
on this issue.

Fix CDDL for changes to the new VotingProcedure field in the TxBody.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
