### PR TITLE
flake: don't build aarch64

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,7 @@
 # code owners are automatically assigned to review PRs
 
-# Devops
-.buildkite @input-output-hk/devops
-.github    @input-output-hk/devops
-nix        @input-output-hk/devops
-*.nix      @input-output-hk/devops
-bors.toml  @input-output-hk/devops
+# DevX
+*.nix       @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+nix         @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+flake.lock  @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+.github     @input-output-hk/core-tech-devx @input-output-hk/core-tech-release

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
     supportedSystems = [
       "x86_64-linux"
       "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
+      # "aarch64-linux" - disable these temporarily because the build is broken
+      # "aarch64-darwin" - disable these temporarily because the build is broken
     ];
   in
     inputs.flake-utils.lib.eachSystem supportedSystems (
@@ -68,6 +68,12 @@
           inputMap = {
             "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
           };
+          cabalProjectLocal = ''
+            repository cardano-haskell-packages-local
+              url: file:${inputs.CHaP}
+              secure: True
+            active-repositories: hackage.haskell.org, cardano-haskell-packages-local
+          '';
 
           # force LANG to be UTF-8, otherwise GHC might choke on UTF encoded data.
           shell.shellHook = ''
@@ -159,6 +165,7 @@
           );
       in
         lib.recursiveUpdate flake rec {
+          project = cabalProject;
           # add a required job, that's basically all hydraJobs.
           hydraJobs =
             nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates


### PR DESCRIPTION
* exposes project at top-level
* adds work-around for referencing local CHaP

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
