### PR TITLE
Renamed TALLY to GOV

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.6.1.0
+## 1.7.0.0
 
 * Removal of TxOuts with zero `Coin` from UTxO on translation
+* Rename:
+    `cgTally` -> `cgGov`
+    `cgTallyL` -> `cgGovL`
+    `VDelFailure` -> `GovCertFailure`
+    `VDelEvent` -> `GovCertEvent`
+    `certVState` -> `certGState`
+    `ConwayVDelPredFailure` -> `ConwayGovCertPredFailure`
+    `ConwayTallyPredFailure` -> `ConwayGovPredFailure`
+    `TallyEnv` -> `GovEnv`
+    `ConwayTallyState` -> `ConwayGovState`
+    `TALLY` -> `GOV`
+    `VDEL` -> `GOVCERT`
 
 ## 1.6.0.0
 
@@ -20,8 +32,8 @@
 * Removal of `gasVotes` in favor of `gasCommitteeVotes`, `gasDRepVotes` and
   `gasStakePoolVotes` in `GovernanceActionState`
 * Removal of `reRoles` from `RatifyEnv` as no longer needed
-* Addtion of `reStakePoolDistr` to `RatifyEnv`
-* Remove `VoterDoesNotHaveRole` as no longer needed from `ConwayTallyPredFailure`
+* Addition of `reStakePoolDistr` to `RatifyEnv`
+* Remove `VoterDoesNotHaveRole` as no longer needed from `ConwayGovPredFailure`
 * Added `ConwayEpochPredFailure`
 * Added instance for `Embed (ConwayRATIFY era) (ConwayEPOCH era)`
 * Removed instance for `Embed (ConwayRATIFY era) (ConwayNEWEPOCH era)`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.6.1.1
+version:            1.7.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -43,14 +43,14 @@ library
         Cardano.Ledger.Conway.Rules.Cert
         Cardano.Ledger.Conway.Rules.Deleg
         Cardano.Ledger.Conway.Rules.Pool
-        Cardano.Ledger.Conway.Rules.VDel
+        Cardano.Ledger.Conway.Rules.GovCert
         Cardano.Ledger.Conway.Rules.Certs
         Cardano.Ledger.Conway.Rules.Enact
         Cardano.Ledger.Conway.Rules.Epoch
         Cardano.Ledger.Conway.Rules.Ledger
         Cardano.Ledger.Conway.Rules.NewEpoch
         Cardano.Ledger.Conway.Rules.Ratify
-        Cardano.Ledger.Conway.Rules.Tally
+        Cardano.Ledger.Conway.Rules.Gov
         Cardano.Ledger.Conway.Rules.Tickf
         Cardano.Ledger.Conway.Rules.Utxos
         Cardano.Ledger.Conway.Rules.Utxow

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -6,9 +6,9 @@ module Cardano.Ledger.Conway.Era (
   ConwayCERT,
   ConwayDELEG,
   ConwayPOOL,
-  ConwayVDEL,
+  ConwayGOVCERT,
   ConwayCERTS,
-  ConwayTALLY,
+  ConwayGOV,
   ConwayNEWEPOCH,
   ConwayEPOCH,
   ConwayENACT,
@@ -48,9 +48,9 @@ type instance Value (ConwayEra c) = MaryValue c
 -- Era Mapping
 -------------------------------------------------------------------------------
 
-data ConwayTALLY era
+data ConwayGOV era
 
-type instance EraRule "TALLY" (ConwayEra c) = ConwayTALLY (ConwayEra c)
+type instance EraRule "GOV" (ConwayEra c) = ConwayGOV (ConwayEra c)
 
 data ConwayNEWEPOCH era
 
@@ -96,9 +96,9 @@ data ConwayPOOL era
 
 type instance EraRule "POOL" (ConwayEra c) = ConwayPOOL (ConwayEra c)
 
-data ConwayVDEL era
+data ConwayGOVCERT era
 
-type instance EraRule "VDEL" (ConwayEra c) = ConwayVDEL (ConwayEra c)
+type instance EraRule "GOVCERT" (ConwayEra c) = ConwayGOVCERT (ConwayEra c)
 
 data ConwayUTXOW era
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -17,12 +17,12 @@
 
 module Cardano.Ledger.Conway.Governance (
   EraGovernance (..),
-  ConwayTallyState (..),
+  ConwayGovState (..),
   EnactState (..),
   RatifyState (..),
   ConwayGovernance (..),
   -- Lenses
-  cgTallyL,
+  cgGovL,
   cgRatifyL,
   GovernanceAction (..),
   GovernanceActionState (..),
@@ -147,30 +147,30 @@ instance EraPParams era => EncCBOR (GovernanceActionState era) where
         !> To gasAction
         !> To gasProposedIn
 
-newtype ConwayTallyState era = ConwayTallyState
-  { unConwayTallyState :: Map (GovernanceActionId (EraCrypto era)) (GovernanceActionState era)
+newtype ConwayGovState era = ConwayGovState
+  { unConwayGovState :: Map (GovernanceActionId (EraCrypto era)) (GovernanceActionState era)
   }
   deriving (Generic, NFData)
 
-deriving instance EraPParams era => Eq (ConwayTallyState era)
+deriving instance EraPParams era => Eq (ConwayGovState era)
 
-deriving instance EraPParams era => Show (ConwayTallyState era)
+deriving instance EraPParams era => Show (ConwayGovState era)
 
-deriving instance EraPParams era => ToJSON (ConwayTallyState era)
+deriving instance EraPParams era => ToJSON (ConwayGovState era)
 
-instance EraPParams era => NoThunks (ConwayTallyState era)
+instance EraPParams era => NoThunks (ConwayGovState era)
 
-instance Default (ConwayTallyState era) where
-  def = ConwayTallyState mempty
+instance Default (ConwayGovState era) where
+  def = ConwayGovState mempty
 
-deriving instance EraPParams era => EncCBOR (ConwayTallyState era)
+deriving instance EraPParams era => EncCBOR (ConwayGovState era)
 
-deriving instance EraPParams era => DecCBOR (ConwayTallyState era)
+deriving instance EraPParams era => DecCBOR (ConwayGovState era)
 
-instance EraPParams era => ToCBOR (ConwayTallyState era) where
+instance EraPParams era => ToCBOR (ConwayGovState era) where
   toCBOR = toEraCBOR @era
 
-instance EraPParams era => FromCBOR (ConwayTallyState era) where
+instance EraPParams era => FromCBOR (ConwayGovState era) where
   fromCBOR = fromEraCBOR @era
 
 data EnactState era = EnactState
@@ -296,13 +296,13 @@ toRatifyStatePairs cg@(RatifyState _ _) =
       ]
 
 data ConwayGovernance era = ConwayGovernance
-  { cgTally :: !(ConwayTallyState era)
+  { cgGov :: !(ConwayGovState era)
   , cgRatify :: !(RatifyState era)
   }
   deriving (Generic, Eq, Show)
 
-cgTallyL :: Lens' (ConwayGovernance era) (ConwayTallyState era)
-cgTallyL = lens cgTally (\x y -> x {cgTally = y})
+cgGovL :: Lens' (ConwayGovernance era) (ConwayGovState era)
+cgGovL = lens cgGov (\x y -> x {cgGov = y})
 
 cgRatifyL :: Lens' (ConwayGovernance era) (RatifyState era)
 cgRatifyL = lens cgRatify (\x y -> x {cgRatify = y})
@@ -318,7 +318,7 @@ instance EraPParams era => EncCBOR (ConwayGovernance era) where
   encCBOR ConwayGovernance {..} =
     encode $
       Rec ConwayGovernance
-        !> To cgTally
+        !> To cgGov
         !> To cgRatify
 
 instance EraPParams era => ToCBOR (ConwayGovernance era) where
@@ -340,7 +340,7 @@ instance EraPParams era => ToJSON (ConwayGovernance era) where
 toConwayGovernancePairs :: (KeyValue a, EraPParams era) => ConwayGovernance era -> [a]
 toConwayGovernancePairs cg@(ConwayGovernance _ _) =
   let ConwayGovernance {..} = cg
-   in [ "tally" .= cgTally
+   in [ "gov" .= cgGov
       , "ratify" .= cgRatify
       ]
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -2,7 +2,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Cert,
   module Cardano.Ledger.Conway.Rules.Deleg,
   module Cardano.Ledger.Conway.Rules.Pool,
-  module Cardano.Ledger.Conway.Rules.VDel,
+  module Cardano.Ledger.Conway.Rules.GovCert,
   module Cardano.Ledger.Conway.Rules.Certs,
   module Cardano.Ledger.Conway.Rules.Enact,
   module Cardano.Ledger.Conway.Rules.Epoch,
@@ -10,7 +10,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.NewEpoch,
   module Cardano.Ledger.Conway.Rules.Tickf,
   module Cardano.Ledger.Conway.Rules.Ratify,
-  module Cardano.Ledger.Conway.Rules.Tally,
+  module Cardano.Ledger.Conway.Rules.Gov,
   module Cardano.Ledger.Conway.Rules.Utxos,
   module Cardano.Ledger.Conway.Rules.Utxow,
 )
@@ -21,12 +21,12 @@ import Cardano.Ledger.Conway.Rules.Certs
 import Cardano.Ledger.Conway.Rules.Deleg
 import Cardano.Ledger.Conway.Rules.Enact
 import Cardano.Ledger.Conway.Rules.Epoch
+import Cardano.Ledger.Conway.Rules.Gov
+import Cardano.Ledger.Conway.Rules.GovCert
 import Cardano.Ledger.Conway.Rules.Ledger
 import Cardano.Ledger.Conway.Rules.NewEpoch
 import Cardano.Ledger.Conway.Rules.Pool
 import Cardano.Ledger.Conway.Rules.Ratify
-import Cardano.Ledger.Conway.Rules.Tally
 import Cardano.Ledger.Conway.Rules.Tickf
 import Cardano.Ledger.Conway.Rules.Utxos
 import Cardano.Ledger.Conway.Rules.Utxow
-import Cardano.Ledger.Conway.Rules.VDel

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -110,7 +110,7 @@ instance
   ) =>
   DecCBOR (ConwayCertsPredFailure era)
   where
-  decCBOR = decode $ Summands "ConwayTallyPredFailure" $ \case
+  decCBOR = decode $ Summands "ConwayGovPredFailure" $ \case
     0 -> SumD DelegateeNotRegisteredDELEG <! From
     1 -> SumD WithdrawalsNotInRewardsCERTS <! From
     2 -> SumD CertFailure <! From

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -25,11 +25,11 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEPOCH, ConwayRATIFY)
 import Cardano.Ledger.Conway.Governance (
+  ConwayGovState (..),
   ConwayGovernance (..),
-  ConwayTallyState (..),
   RatifyState (..),
+  cgGovL,
   cgRatifyL,
-  cgTallyL,
  )
 import Cardano.Ledger.Conway.Rules.Enact (EnactPredFailure)
 import Cardano.Ledger.Conway.Rules.Ratify (RatifyEnv (..), RatifySignal (..))
@@ -204,8 +204,8 @@ epochTransition = do
         , reStakePoolDistr = stakePoolDistr
         , reCurrentEpoch = eNo
         }
-    tallyStateToSeq = Seq.fromList . Map.toList
-    ratSig = RatifySignal . tallyStateToSeq . unConwayTallyState $ cgTally govSt
+    govStateToSeq = Seq.fromList . Map.toList
+    ratSig = RatifySignal . govStateToSeq . unConwayGovState $ cgGov govSt
   rs@RatifyState {rsFuture} <-
     trans @(EraRule "RATIFY" era) $ TRC (ratEnv, cgRatify govSt, ratSig)
   let es'' =
@@ -215,9 +215,9 @@ epochTransition = do
           , esPrevPp = pp
           , esPp = pp
           }
-      newTally = ConwayTallyState . Map.fromList . toList $ rsFuture
+      newGov = ConwayGovState . Map.fromList . toList $ rsFuture
   pure $
-    (es'' & esLStateL . lsUTxOStateL . utxosGovernanceL . cgTallyL .~ newTally)
+    (es'' & esLStateL . lsUTxOStateL . utxosGovernanceL . cgGovL .~ newGov)
       & (esLStateL . lsUTxOStateL . utxosGovernanceL . cgRatifyL .~ rs)
 
 instance

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -15,19 +15,19 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Conway.Rules.Tally (
-  ConwayTALLY,
-  TallyEnv (..),
-  ConwayTallyPredFailure (..),
+module Cardano.Ledger.Conway.Rules.Gov (
+  ConwayGOV,
+  GovEnv (..),
+  ConwayGovPredFailure (..),
 ) where
 
 import Cardano.Ledger.BaseTypes (EpochNo (..), ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Era (ConwayTALLY)
+import Cardano.Ledger.Conway.Era (ConwayGOV)
 import Cardano.Ledger.Conway.Governance (
-  ConwayTallyState (..),
+  ConwayGovState (..),
   GovernanceAction,
   GovernanceActionId (..),
   GovernanceActionState (..),
@@ -53,53 +53,53 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
-data TallyEnv era = TallyEnv
+data GovEnv era = GovEnv
   { teTxId :: !(TxId (EraCrypto era))
   , teEpoch :: !EpochNo
   }
 
-newtype ConwayTallyPredFailure era
+newtype ConwayGovPredFailure era
   = GovernanceActionDoesNotExist (GovernanceActionId (EraCrypto era))
   deriving (Eq, Show, Generic)
 
-instance Era era => NFData (ConwayTallyPredFailure era)
+instance Era era => NFData (ConwayGovPredFailure era)
 
-instance Era era => NoThunks (ConwayTallyPredFailure era)
+instance Era era => NoThunks (ConwayGovPredFailure era)
 
-instance EraPParams era => DecCBOR (ConwayTallyPredFailure era) where
-  decCBOR = decode $ Summands "ConwayTallyPredFailure" $ \case
+instance EraPParams era => DecCBOR (ConwayGovPredFailure era) where
+  decCBOR = decode $ Summands "ConwayGovPredFailure" $ \case
     0 -> SumD GovernanceActionDoesNotExist <! From
     k -> Invalid k
 
-instance EraPParams era => EncCBOR (ConwayTallyPredFailure era) where
+instance EraPParams era => EncCBOR (ConwayGovPredFailure era) where
   encCBOR =
     encode . \case
       GovernanceActionDoesNotExist gid -> Sum (GovernanceActionDoesNotExist @era) 0 !> To gid
 
-instance EraPParams era => ToCBOR (ConwayTallyPredFailure era) where
+instance EraPParams era => ToCBOR (ConwayGovPredFailure era) where
   toCBOR = toEraCBOR @era
 
-instance EraPParams era => FromCBOR (ConwayTallyPredFailure era) where
+instance EraPParams era => FromCBOR (ConwayGovPredFailure era) where
   fromCBOR = fromEraCBOR @era
 
-instance Era era => STS (ConwayTALLY era) where
-  type State (ConwayTALLY era) = ConwayTallyState era
-  type Signal (ConwayTALLY era) = GovernanceProcedures era
-  type Environment (ConwayTALLY era) = TallyEnv era
-  type BaseM (ConwayTALLY era) = ShelleyBase
-  type PredicateFailure (ConwayTALLY era) = ConwayTallyPredFailure era
-  type Event (ConwayTALLY era) = ()
+instance Era era => STS (ConwayGOV era) where
+  type State (ConwayGOV era) = ConwayGovState era
+  type Signal (ConwayGOV era) = GovernanceProcedures era
+  type Environment (ConwayGOV era) = GovEnv era
+  type BaseM (ConwayGOV era) = ShelleyBase
+  type PredicateFailure (ConwayGOV era) = ConwayGovPredFailure era
+  type Event (ConwayGOV era) = ()
 
   initialRules = []
 
-  transitionRules = [tallyTransition]
+  transitionRules = [govTransition]
 
 addVote ::
   VotingProcedure era ->
-  ConwayTallyState era ->
-  ConwayTallyState era
-addVote VotingProcedure {vProcGovActionId, vProcVoter, vProcVote} (ConwayTallyState st) =
-  ConwayTallyState $
+  ConwayGovState era ->
+  ConwayGovState era
+addVote VotingProcedure {vProcGovActionId, vProcVoter, vProcVote} (ConwayGovState st) =
+  ConwayGovState $
     Map.update (Just . updateVote) vProcGovActionId st
   where
     updateVote GovernanceActionState {..} =
@@ -126,10 +126,10 @@ addAction ::
   Coin ->
   KeyHash 'Staking (EraCrypto era) ->
   GovernanceAction era ->
-  ConwayTallyState era ->
-  ConwayTallyState era
-addAction epoch gaid c addr act (ConwayTallyState st) =
-  ConwayTallyState $
+  ConwayGovState era ->
+  ConwayGovState era
+addAction epoch gaid c addr act (ConwayGovState st) =
+  ConwayGovState $
     Map.insert gaid gai' st
   where
     gai' =
@@ -144,17 +144,17 @@ addAction epoch gaid c addr act (ConwayTallyState st) =
         }
 
 noSuchGovernanceAction ::
-  ConwayTallyState era ->
+  ConwayGovState era ->
   GovernanceActionId (EraCrypto era) ->
-  Test (ConwayTallyPredFailure era)
-noSuchGovernanceAction (ConwayTallyState st) gaid =
+  Test (ConwayGovPredFailure era)
+noSuchGovernanceAction (ConwayGovState st) gaid =
   failureUnless (Map.member gaid st) $
     GovernanceActionDoesNotExist gaid
 
-tallyTransition :: forall era. TransitionRule (ConwayTALLY era)
-tallyTransition = do
+govTransition :: forall era. TransitionRule (ConwayGOV era)
+govTransition = do
   -- TODO Check the signatures
-  TRC (TallyEnv txid epoch, st, GovernanceProcedures {..}) <- judgmentContext
+  TRC (GovEnv txid epoch, st, GovernanceProcedures {..}) <- judgmentContext
 
   let applyProps _ st' Empty = pure st'
       applyProps idx st' (ProposalProcedure {..} :<| ps) = do
@@ -176,5 +176,5 @@ tallyTransition = do
         applyVotes st'' vs
   applyVotes stProps gpVotingProcedures
 
-instance Inject (ConwayTallyPredFailure era) (ConwayTallyPredFailure era) where
+instance Inject (ConwayGovPredFailure era) (ConwayGovPredFailure era) where
   inject = id

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -11,10 +11,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Conway.Rules.VDel (
-  ConwayVDEL,
-  ConwayVDelEvent (..),
-  ConwayVDelPredFailure (..),
+module Cardano.Ledger.Conway.Rules.GovCert (
+  ConwayGOVCERT,
+  ConwayGovCertEvent (..),
+  ConwayGovCertPredFailure (..),
 )
 where
 
@@ -25,7 +25,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), encodeListLen)
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.CertState (VState (..))
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Conway.Era (ConwayVDEL)
+import Cardano.Ledger.Conway.Era (ConwayGOVCERT)
 import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert (..))
 import Cardano.Ledger.Core (Era (EraCrypto), EraPParams, EraRule, PParams)
 import Cardano.Ledger.Credential (Credential)
@@ -54,83 +54,83 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data ConwayVDelPredFailure era
-  = ConwayDRepAlreadyRegisteredVDEL !(Credential 'Voting (EraCrypto era))
-  | ConwayDRepNotRegisteredVDEL !(Credential 'Voting (EraCrypto era))
-  | ConwayDRepIncorrectDepositVDEL !Coin
-  | ConwayCommitteeHasResignedVDEL !(KeyHash 'CommitteeColdKey (EraCrypto era))
+data ConwayGovCertPredFailure era
+  = ConwayDRepAlreadyRegistered !(Credential 'Voting (EraCrypto era))
+  | ConwayDRepNotRegistered !(Credential 'Voting (EraCrypto era))
+  | ConwayDRepIncorrectDeposit !Coin
+  | ConwayCommitteeHasResigned !(KeyHash 'CommitteeColdKey (EraCrypto era))
   deriving (Show, Eq, Generic)
 
-instance NoThunks (ConwayVDelPredFailure era)
+instance NoThunks (ConwayGovCertPredFailure era)
 
-instance NFData (ConwayVDelPredFailure era)
+instance NFData (ConwayGovCertPredFailure era)
 
 instance
   (Typeable era, Crypto (EraCrypto era)) =>
-  EncCBOR (ConwayVDelPredFailure era)
+  EncCBOR (ConwayGovCertPredFailure era)
   where
   encCBOR = \case
-    ConwayDRepAlreadyRegisteredVDEL cred ->
+    ConwayDRepAlreadyRegistered cred ->
       encodeListLen 2
         <> encCBOR (0 :: Word8)
         <> encCBOR cred
-    ConwayDRepNotRegisteredVDEL cred ->
+    ConwayDRepNotRegistered cred ->
       encodeListLen 2
         <> encCBOR (1 :: Word8)
         <> encCBOR cred
-    ConwayDRepIncorrectDepositVDEL deposit ->
+    ConwayDRepIncorrectDeposit deposit ->
       encodeListLen 2
         <> encCBOR (2 :: Word8)
         <> encCBOR deposit
-    ConwayCommitteeHasResignedVDEL keyH ->
+    ConwayCommitteeHasResigned keyH ->
       encodeListLen 2
         <> encCBOR (3 :: Word8)
         <> encCBOR keyH
 
 instance
   (Typeable era, Crypto (EraCrypto era)) =>
-  DecCBOR (ConwayVDelPredFailure era)
+  DecCBOR (ConwayGovCertPredFailure era)
   where
-  decCBOR = decodeRecordSum "ConwayVDelPredFailure" $
+  decCBOR = decodeRecordSum "ConwayGovCertPredFailure" $
     \case
       0 -> do
         cred <- decCBOR
-        pure (2, ConwayDRepAlreadyRegisteredVDEL cred)
+        pure (2, ConwayDRepAlreadyRegistered cred)
       1 -> do
         cred <- decCBOR
-        pure (2, ConwayDRepNotRegisteredVDEL cred)
+        pure (2, ConwayDRepNotRegistered cred)
       2 -> do
         deposit <- decCBOR
-        pure (2, ConwayDRepIncorrectDepositVDEL deposit)
+        pure (2, ConwayDRepIncorrectDeposit deposit)
       3 -> do
         keyH <- decCBOR
-        pure (2, ConwayCommitteeHasResignedVDEL keyH)
+        pure (2, ConwayCommitteeHasResigned keyH)
       k -> invalidKey k
 
-newtype ConwayVDelEvent era = VDelEvent (Event (EraRule "VDEL" era))
+newtype ConwayGovCertEvent era = GovCertEvent (Event (EraRule "GOVCERT" era))
 
 instance
   ( EraPParams era
-  , State (EraRule "VDEL" era) ~ VState era
-  , Signal (EraRule "VDEL" era) ~ ConwayCommitteeCert (EraCrypto era)
-  , Environment (EraRule "VDEL" era) ~ PParams era
-  , EraRule "VDEL" era ~ ConwayVDEL era
-  , Eq (PredicateFailure (EraRule "VDEL" era))
-  , Show (PredicateFailure (EraRule "VDEL" era))
+  , State (EraRule "GOVCERT" era) ~ VState era
+  , Signal (EraRule "GOVCERT" era) ~ ConwayCommitteeCert (EraCrypto era)
+  , Environment (EraRule "GOVCERT" era) ~ PParams era
+  , EraRule "GOVCERT" era ~ ConwayGOVCERT era
+  , Eq (PredicateFailure (EraRule "GOVCERT" era))
+  , Show (PredicateFailure (EraRule "GOVCERT" era))
   ) =>
-  STS (ConwayVDEL era)
+  STS (ConwayGOVCERT era)
   where
-  type State (ConwayVDEL era) = VState era
-  type Signal (ConwayVDEL era) = ConwayCommitteeCert (EraCrypto era)
-  type Environment (ConwayVDEL era) = PParams era
-  type BaseM (ConwayVDEL era) = ShelleyBase
-  type PredicateFailure (ConwayVDEL era) = ConwayVDelPredFailure era
-  type Event (ConwayVDEL era) = ConwayVDelEvent era
+  type State (ConwayGOVCERT era) = VState era
+  type Signal (ConwayGOVCERT era) = ConwayCommitteeCert (EraCrypto era)
+  type Environment (ConwayGOVCERT era) = PParams era
+  type BaseM (ConwayGOVCERT era) = ShelleyBase
+  type PredicateFailure (ConwayGOVCERT era) = ConwayGovCertPredFailure era
+  type Event (ConwayGOVCERT era) = ConwayGovCertEvent era
 
-  transitionRules = [conwayVDelTransition @era]
+  transitionRules = [conwayGovCertTransition @era]
 
-conwayVDelTransition :: TransitionRule (ConwayVDEL era)
-conwayVDelTransition = do
+conwayGovCertTransition :: TransitionRule (ConwayGOVCERT era)
+conwayGovCertTransition = do
   TRC
     ( _pp
       , vState@VState {vsDReps, vsCommitteeHotKeys}
@@ -139,12 +139,12 @@ conwayVDelTransition = do
     judgmentContext
   case c of
     ConwayRegDRep cred _deposit -> do
-      Set.notMember cred vsDReps ?! ConwayDRepAlreadyRegisteredVDEL cred
+      Set.notMember cred vsDReps ?! ConwayDRepAlreadyRegistered cred
       -- TODO: check against a new PParam `drepDeposit`, once PParams are updated. -- someCheck ?! ConwayDRepIncorrectDeposit deposit
       pure $ vState {vsDReps = Set.insert cred vsDReps}
     ConwayUnRegDRep cred _deposit -> do
       -- TODO: check against a new PParam `drepDeposit`, once PParams are updated. -- someCheck ?! ConwayDRepIncorrectDeposit deposit
-      Set.member cred vsDReps ?! ConwayDRepNotRegisteredVDEL cred
+      Set.member cred vsDReps ?! ConwayDRepNotRegistered cred
       pure $ vState {vsDReps = Set.delete cred vsDReps}
     ConwayAuthCommitteeHotKey coldK hotK -> do
       checkColdKeyHasNotResigned coldK vsCommitteeHotKeys
@@ -156,4 +156,4 @@ conwayVDelTransition = do
     checkColdKeyHasNotResigned coldK vsCommitteeHotKeys =
       (isNothing <$> Map.lookup coldK vsCommitteeHotKeys)
         /= Just True
-        ?! ConwayCommitteeHasResignedVDEL coldK
+        ?! ConwayCommitteeHasResigned coldK

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -100,7 +100,7 @@ instance
       <*> arbitrary
       <*> arbitrary
 
-deriving instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ConwayTallyState era)
+deriving instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ConwayGovState era)
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceActionState era) where
   arbitrary =
@@ -175,11 +175,11 @@ instance
 -- Cardano.Ledger.Conway.Rules -----------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
--- TALLY
+-- GOV
 
-instance Era era => Arbitrary (TallyEnv era) where
+instance Era era => Arbitrary (GovEnv era) where
   arbitrary =
-    TallyEnv
+    GovEnv
       <$> arbitrary
       <*> arbitrary
 
@@ -199,13 +199,13 @@ instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceProced
   arbitrary =
     GovernanceProcedures <$> arbitrary <*> arbitrary
 
-instance Era era => Arbitrary (ConwayTallyPredFailure era) where
+instance Era era => Arbitrary (ConwayGovPredFailure era) where
   arbitrary = GovernanceActionDoesNotExist <$> arbitrary
 
 instance
   ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))
   , Arbitrary (PredicateFailure (EraRule "CERTS" era))
-  , Arbitrary (PredicateFailure (EraRule "TALLY" era))
+  , Arbitrary (PredicateFailure (EraRule "GOV" era))
   ) =>
   Arbitrary (ConwayLedgerPredFailure era)
   where
@@ -213,7 +213,7 @@ instance
     oneof
       [ ConwayUtxowFailure <$> arbitrary
       , ConwayCertsFailure <$> arbitrary
-      , ConwayTallyFailure <$> arbitrary
+      , ConwayGovFailure <$> arbitrary
       ]
 
 -- EPOCH
@@ -282,7 +282,7 @@ instance
   ( Era era
   , Arbitrary (PredicateFailure (EraRule "DELEG" era))
   , Arbitrary (PredicateFailure (EraRule "POOL" era))
-  , Arbitrary (PredicateFailure (EraRule "VDEL" era))
+  , Arbitrary (PredicateFailure (EraRule "GOVCERT" era))
   ) =>
   Arbitrary (ConwayCertPredFailure era)
   where
@@ -290,7 +290,7 @@ instance
     oneof
       [ DelegFailure <$> arbitrary
       , PoolFailure <$> arbitrary
-      , VDelFailure <$> arbitrary
+      , GovCertFailure <$> arbitrary
       ]
 
 -- DELEG
@@ -310,13 +310,13 @@ instance
       , pure WrongCertificateTypeDELEG
       ]
 
--- VDEL
+-- GOVCERT
 
-instance Era era => Arbitrary (ConwayVDelPredFailure era) where
+instance Era era => Arbitrary (ConwayGovCertPredFailure era) where
   arbitrary =
     oneof
-      [ ConwayDRepAlreadyRegisteredVDEL <$> arbitrary
-      , ConwayDRepNotRegisteredVDEL <$> arbitrary
-      , ConwayDRepIncorrectDepositVDEL <$> arbitrary
-      , ConwayCommitteeHasResignedVDEL <$> arbitrary
+      [ ConwayDRepAlreadyRegistered <$> arbitrary
+      , ConwayDRepNotRegistered <$> arbitrary
+      , ConwayDRepIncorrectDeposit <$> arbitrary
+      , ConwayCommitteeHasResigned <$> arbitrary
       ]

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -42,7 +42,7 @@ library
         cardano-ledger-babbage-test,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-strict-containers,
-        cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.6,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.7,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3 && <1.6,
         cardano-ledger-allegra ^>=1.2,
         cardano-ledger-mary ^>=1.3,

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -296,7 +296,7 @@ stake_reg_deleg_cert = (11, stake_credential, pool_keyhash, coin)
 vote_reg_deleg_cert = (12, stake_credential, drep, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 
-; VDEL
+; GOVCERT
 reg_committee_hot_key_cert = (14, committee_cold_keyhash, committee_hot_keyhash)
 unreg_committee_hot_key_cert = (15, committee_cold_keyhash)
 reg_drep_cert = (16, voting_credential, coin)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -124,10 +124,10 @@ votedValue ::
   Int ->
   Maybe (PParams era)
 votedValue (ProposedPPUpdates pup) pps quorumN =
-  let incrTally vote tally = 1 + Map.findWithDefault 0 vote tally
+  let incrGov vote gov = 1 + Map.findWithDefault 0 vote gov
       votes =
         Map.foldr
-          (\vote tally -> Map.insert vote (incrTally vote tally) tally)
+          (\vote gov -> Map.insert vote (incrGov vote gov) gov)
           (Map.empty :: Map (PParamsUpdate era) Int)
           pup
       consensus = Map.filter (>= quorumN) votes

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-api`
 
+## 1.4.0.0
+
+* Rename `cgTallyL` to `cgGovL`
+* Rename `ConwayTallyState` to `ConwayGovState`
+
 ## 1.3.0.0
 
 * Add `queryConstitutionHash` to `Cardano.Ledger.Api.State.Query` #3506

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-api
-version:            1.3.0.1
+version:            1.4.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -18,8 +18,8 @@ module Cardano.Ledger.Api.Governance (
   -- ** Conway Governance
   ConwayGovernance (..),
   cgRatifyL,
-  cgTallyL,
-  ConwayTallyState (..),
+  cgGovL,
+  ConwayGovState (..),
   RatifyState (..),
   EnactState (..),
   Voter (..),
@@ -42,8 +42,8 @@ import Cardano.Ledger.Api.Era ()
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
   AnchorDataHash,
+  ConwayGovState (..),
   ConwayGovernance (..),
-  ConwayTallyState (..),
   EnactState (..),
   GovernanceAction (..),
   GovernanceActionId (..),
@@ -54,8 +54,8 @@ import Cardano.Ledger.Conway.Governance (
   Voter (..),
   -- Lenses
 
+  cgGovL,
   cgRatifyL,
-  cgTallyL,
  )
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeHash, SafeToHash, hashAnnotated)

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for `cardano-ledger-pretty`
 
+## 1.3.0.0
+
+* Replace `ConwayTallyPredFailure era` with `ConwayGovPredFailure era`
+* Replace `ConwayTallyState era` with `ConwayGovState era`
+* Replace `ConwayVDelPredFailure era` with `ConwayGovCertPredFailure era`
+
 ## 1.2.1.0
 
 * Added `PrettyA` instance for `DRep`

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-pretty
-version:            1.2.1.3
+version:            1.3.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -39,8 +39,8 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway ^>=1.6,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-conway ^>=1.7,
+        cardano-ledger-core >=1.4 && <1.6,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley ^>=1.4,
         cardano-protocol-tpraos >=1.0,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -22,8 +22,8 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
   Anchor,
+  ConwayGovState (..),
   ConwayGovernance (..),
-  ConwayTallyState (..),
   GovernanceAction (..),
   GovernanceActionId (..),
   GovernanceActionIx (..),
@@ -38,9 +38,9 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertPredFailure (..),
   ConwayCertsPredFailure (..),
   ConwayDelegPredFailure (..),
+  ConwayGovCertPredFailure,
+  ConwayGovPredFailure,
   ConwayLedgerPredFailure (..),
-  ConwayTallyPredFailure,
-  ConwayVDelPredFailure,
   EnactState (..),
   PredicateFailure,
   RatifyState (..),
@@ -228,21 +228,21 @@ instance Crypto c => PrettyA (PParamsUpdate (ConwayEra c)) where
 instance
   ( PrettyA (PredicateFailure (EraRule "UTXOW" era))
   , PrettyA (PredicateFailure (EraRule "CERTS" era))
-  , PrettyA (PredicateFailure (EraRule "TALLY" era))
+  , PrettyA (PredicateFailure (EraRule "GOV" era))
   ) =>
   PrettyA (ConwayLedgerPredFailure era)
   where
   prettyA (ConwayUtxowFailure x) = prettyA x
   prettyA (ConwayCertsFailure x) = prettyA x
-  prettyA (ConwayTallyFailure x) = prettyA x
+  prettyA (ConwayGovFailure x) = prettyA x
   prettyA (ConwayWdrlNotDelegatedToDRep x) =
     ppSexp "ConwayWdrlNotDelegatedToDRep" [prettyA x]
 
-instance PrettyA (ConwayTallyPredFailure era) where
+instance PrettyA (ConwayGovPredFailure era) where
   prettyA = viaShow
 
-instance PrettyA (PParamsUpdate era) => PrettyA (ConwayTallyState era) where
-  prettyA (ConwayTallyState x) = prettyA x
+instance PrettyA (PParamsUpdate era) => PrettyA (ConwayGovState era) where
+  prettyA (ConwayGovState x) = prettyA x
 
 instance PrettyA (GovernanceActionId era) where
   prettyA gaid@(GovernanceActionId _ _) =
@@ -313,7 +313,7 @@ instance
     let ConwayGovernance {..} = cg
      in ppRecord
           "ConwayGovernance"
-          [ ("Tally", prettyA cgTally)
+          [ ("Gov", prettyA cgGov)
           , ("Ratify", prettyA cgRatify)
           ]
 
@@ -334,7 +334,7 @@ instance
 instance
   ( PrettyA (PredicateFailure (EraRule "DELEG" era))
   , PrettyA (PredicateFailure (EraRule "POOL" era))
-  , PrettyA (PredicateFailure (EraRule "VDEL" era))
+  , PrettyA (PredicateFailure (EraRule "GOVCERT" era))
   ) =>
   PrettyA (ConwayCertPredFailure era)
   where
@@ -347,10 +347,10 @@ instance
       ppRecord
         "ConwayPoolFailure"
         [("POOL", prettyA x)]
-    VDelFailure x ->
+    GovCertFailure x ->
       ppRecord
-        "ConwayVDelFailure"
-        [("VDEL", prettyA x)]
+        "ConwayGovCertFailure"
+        [("GOVCERT", prettyA x)]
 
 instance PrettyA (ConwayDelegPredFailure era) where
   prettyA = \case
@@ -379,5 +379,5 @@ instance PrettyA (ConwayDelegPredFailure era) where
         "WrongCertificateTypeDELEG"
         []
 
-instance PrettyA (ConwayVDelPredFailure era) where
-  prettyA = const $ ppRecord "ConwayVDelPredFailure" []
+instance PrettyA (ConwayGovCertPredFailure era) where
+  prettyA = const $ ppRecord "ConwayGovCertPredFailure" []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -69,7 +69,7 @@ import Test.Cardano.Ledger.Constrained.Lenses
 import Test.Cardano.Ledger.Constrained.TypeRep (Rep (..), testEql, (:~:) (Refl))
 import Test.Cardano.Ledger.Generic.Proof (Evidence (..), Proof (..))
 
-import Cardano.Ledger.Conway.Governance (ConwayTallyState (..))
+import Cardano.Ledger.Conway.Governance (ConwayGovState (..))
 import Cardano.Ledger.Shelley.Governance (ShelleyPPUPState (..))
 import qualified Cardano.Ledger.Shelley.Governance as Core (GovernanceState (..))
 import qualified Cardano.Ledger.Shelley.PParams as Core (ProposedPPUpdates (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -36,8 +36,8 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
+  ConwayGovState (..),
   ConwayGovernance (..),
-  ConwayTallyState (..),
   GovernanceActionState (..),
   RatifyState (..),
  )
@@ -422,9 +422,9 @@ instance TotalAda (CertState era) where
 instance TotalAda (ShelleyPPUPState era) where
   totalAda _ = mempty
 
-instance TotalAda (ConwayTallyState era) where
+instance TotalAda (ConwayGovState era) where
   -- TODO Might need a review once the specification is done
-  totalAda (ConwayTallyState x) = mconcat $ gasDeposit <$> Map.elems x
+  totalAda (ConwayGovState x) = mconcat $ gasDeposit <$> Map.elems x
 
 governanceStateTotalAda :: forall era. Reflect era => GovernanceState era -> Coin
 governanceStateTotalAda = case reify @era of

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import qualified Cardano.Ledger.CertState as DP
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
-import Cardano.Ledger.Conway.Governance (ConwayTallyState (..))
+import Cardano.Ledger.Conway.Governance (ConwayGovState (..))
 import Cardano.Ledger.Conway.Rules (
   ConwayEpochPredFailure (..),
   ConwayNewEpochPredFailure,
@@ -1565,8 +1565,8 @@ pcTxBody proof txbody = ppRecord "TxBody" pairs
     fields = abstractTxBody proof txbody
     pairs = concatMap (pcTxBodyField proof) fields
 
-instance PrettyC (ConwayTallyState era) era where
-  prettyC proof (ConwayTallyState x) = case proof of
+instance PrettyC (ConwayGovState era) era where
+  prettyC proof (ConwayGovState x) = case proof of
     Shelley _ -> ppMap prettyA prettyA x
     Mary _ -> ppMap prettyA prettyA x
     Allegra _ -> ppMap prettyA prettyA x


### PR DESCRIPTION
# Description

This PR applies the following substitutions:
```
s/Tally/Gov/g
s/VDel/GovCert/g
```

I also renamed
```
eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tally.hs -> Gov.hs
eras/conway/impl/src/Cardano/Ledger/Conway/Rules/VDel.hs -> GovCert.hs
```
.. and updated the Conway cabal file with the new paths.

resolves #3515 
resolves #3505 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
