### PR TITLE
Separate Procedures

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.6.0.0
+
+* Removal of `GovernanceProcedure` in favor of `GovernanceProcedures`
+
 ## 1.5.0.0
 
 * Add `ensConstitutionL` and `rsEnactStateL` to `Governance` #3506

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.5.0.0
+version:            1.6.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -39,6 +39,7 @@ library
     other-modules:
         Cardano.Ledger.Conway.Era
         Cardano.Ledger.Conway.UTxO
+        Cardano.Ledger.Conway.Governance.Procedures
         Cardano.Ledger.Conway.Rules.Cert
         Cardano.Ledger.Conway.Rules.Deleg
         Cardano.Ledger.Conway.Rules.Pool

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -3,12 +3,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -35,28 +33,19 @@ module Cardano.Ledger.Conway.Governance (
   Vote (..),
   VotingProcedure (..),
   ProposalProcedure (..),
-  GovernanceProcedure (..),
+  GovernanceProcedures (..),
   Anchor (..),
   AnchorDataHash,
   ensConstitutionL,
   rsEnactStateL,
 ) where
 
-import Cardano.Crypto.Hash.Class (hashToTextAsHex)
-import Cardano.Ledger.BaseTypes (EpochNo (..), ProtVer (..), StrictMaybe, Url)
+import Cardano.Ledger.BaseTypes (EpochNo (..), ProtVer (..), StrictMaybe)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
-  decodeEnumBounded,
-  decodeNullStrictMaybe,
-  decodeRecordSum,
-  encodeEnum,
-  encodeListLen,
-  encodeNullStrictMaybe,
-  encodeWord8,
-  invalidKey,
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -68,294 +57,36 @@ import Cardano.Ledger.Binary.Coders (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Conway.Governance.Procedures (
+  Anchor (..),
+  AnchorDataHash,
+  GovernanceAction (..),
+  GovernanceActionId (..),
+  GovernanceActionIx (..),
+  GovernanceProcedures (..),
+  ProposalProcedure (..),
+  Vote (..),
+  Voter (..),
+  VotingProcedure (..),
+  govActionIdToText,
+ )
 import Cardano.Ledger.Conway.PParams ()
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Cardano.Ledger.SafeHash (SafeHash, extractHash)
+import Cardano.Ledger.SafeHash (SafeHash)
 import Cardano.Ledger.Shelley.Governance
-import Cardano.Ledger.TxIn (TxId (..))
-import Control.DeepSeq (NFData (rnf), rwhnf)
+import Control.DeepSeq (NFData)
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
-import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import Data.ByteString (ByteString)
 import Data.Default.Class (Default (..))
 import Data.Map.Strict (Map)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
-import qualified Data.Text as Text
-import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, (^.))
 import NoThunks.Class (NoThunks)
-
-data GovernanceAction era
-  = ParameterChange !(PParamsUpdate era)
-  | HardForkInitiation !ProtVer
-  | TreasuryWithdrawals !(Map (Credential 'Staking (EraCrypto era)) Coin)
-  | NoConfidence
-  | NewCommittee !(Set (KeyHash 'Voting (EraCrypto era))) !Rational
-  | NewConstitution !(SafeHash (EraCrypto era) ByteString)
-  | InfoAction
-  deriving (Generic)
-
-deriving instance EraPParams era => Eq (GovernanceAction era)
-
-deriving instance EraPParams era => Show (GovernanceAction era)
-
-instance EraPParams era => NoThunks (GovernanceAction era)
-
-instance EraPParams era => NFData (GovernanceAction era)
-
-instance EraPParams era => ToJSON (GovernanceAction era)
-
-instance EraPParams era => DecCBOR (GovernanceAction era) where
-  decCBOR =
-    decode $
-      Summands "GovernanceAction" dec
-    where
-      dec 0 = SumD ParameterChange <! From
-      dec 1 = SumD HardForkInitiation <! From
-      dec 2 = SumD TreasuryWithdrawals <! From
-      dec 3 = SumD NoConfidence
-      dec 4 = SumD NewCommittee <! From <! From
-      dec 5 = SumD NewConstitution <! From
-      dec 6 = SumD InfoAction
-      dec k = Invalid k
-
-instance EraPParams era => EncCBOR (GovernanceAction era) where
-  encCBOR x = encode (enc x)
-    where
-      enc (ParameterChange ppup) = Sum ParameterChange 0 !> To ppup
-      enc (HardForkInitiation pv) = Sum HardForkInitiation 1 !> To pv
-      enc (TreasuryWithdrawals ws) = Sum TreasuryWithdrawals 2 !> To ws
-      enc NoConfidence = Sum NoConfidence 3
-      enc (NewCommittee mems quorum) = Sum NewCommittee 4 !> To mems !> To quorum
-      enc (NewConstitution h) = Sum NewConstitution 5 !> To h
-      enc InfoAction = Sum InfoAction 6
-
-newtype GovernanceActionIx = GovernanceActionIx Word64
-  deriving (Generic, Eq, Ord, Show, Num, Enum, NFData, NoThunks, EncCBOR, DecCBOR, ToJSON)
-
-data GovernanceActionId c = GovernanceActionId
-  { gaidTxId :: !(TxId c)
-  , gaidGovActionIx :: !GovernanceActionIx
-  }
-  deriving (Generic, Eq, Ord, Show)
-
-instance Crypto c => DecCBOR (GovernanceActionId c) where
-  decCBOR =
-    decode $
-      RecD GovernanceActionId
-        <! From
-        <! From
-
-instance Crypto c => EncCBOR (GovernanceActionId c) where
-  encCBOR GovernanceActionId {..} =
-    encode $
-      Rec GovernanceActionId
-        !> To gaidTxId
-        !> To gaidGovActionIx
-
-instance NoThunks (GovernanceActionId c)
-
-instance Crypto c => NFData (GovernanceActionId c)
-
-instance Crypto c => ToJSON (GovernanceActionId c) where
-  toJSON = object . toGovernanceActionIdPairs
-  toEncoding = pairs . mconcat . toGovernanceActionIdPairs
-
-toGovernanceActionIdPairs :: (KeyValue a, Crypto c) => GovernanceActionId c -> [a]
-toGovernanceActionIdPairs gaid@(GovernanceActionId _ _) =
-  let GovernanceActionId {..} = gaid
-   in [ "txId" .= gaidTxId
-      , "govActionIx" .= gaidGovActionIx
-      ]
-
-instance Crypto c => ToJSONKey (GovernanceActionId c) where
-  toJSONKey = toJSONKeyText govActionIdToText
-
-govActionIdToText :: GovernanceActionId c -> Text.Text
-govActionIdToText (GovernanceActionId (TxId txidHash) (GovernanceActionIx ix)) =
-  hashToTextAsHex (extractHash txidHash)
-    <> Text.pack "#"
-    <> Text.pack (show ix)
-
-data AnchorDataHash
-
-data Anchor c = Anchor
-  { anchorUrl :: !Url
-  , anchorDataHash :: !(SafeHash c AnchorDataHash)
-  }
-  deriving (Eq, Show, Generic)
-
-instance NoThunks (Anchor c)
-
-instance Crypto c => NFData (Anchor c) where
-  rnf = rwhnf
-
-instance Crypto c => DecCBOR (Anchor c) where
-  decCBOR =
-    decode $
-      RecD Anchor
-        <! From
-        <! From
-
-instance Crypto c => EncCBOR (Anchor c) where
-  encCBOR Anchor {..} =
-    encode $
-      Rec Anchor
-        !> To anchorUrl
-        !> To anchorDataHash
-
-instance Crypto c => ToJSON (Anchor c) where
-  toJSON = object . toAnchorPairs
-  toEncoding = pairs . mconcat . toAnchorPairs
-
-toAnchorPairs :: (KeyValue a, Crypto c) => Anchor c -> [a]
-toAnchorPairs vote@(Anchor _ _) =
-  let Anchor {..} = vote
-   in [ "url" .= anchorUrl
-      , "dataHash" .= anchorDataHash
-      ]
-
-data VotingProcedure era = VotingProcedure
-  { vProcGovActionId :: !(GovernanceActionId (EraCrypto era))
-  , vProcVoter :: !(Voter (EraCrypto era))
-  , vProcVote :: !Vote
-  , vProcAnchor :: !(StrictMaybe (Anchor (EraCrypto era)))
-  }
-  deriving (Generic, Eq, Show)
-
-instance NoThunks (VotingProcedure era)
-
-instance Crypto (EraCrypto era) => NFData (VotingProcedure era)
-
-instance Era era => DecCBOR (VotingProcedure era) where
-  decCBOR =
-    decode $
-      RecD VotingProcedure
-        <! From
-        <! From
-        <! From
-        <! D (decodeNullStrictMaybe decCBOR)
-
-instance Era era => EncCBOR (VotingProcedure era) where
-  encCBOR VotingProcedure {..} =
-    encode $
-      Rec (VotingProcedure @era)
-        !> To vProcGovActionId
-        !> To vProcVoter
-        !> To vProcVote
-        !> E (encodeNullStrictMaybe encCBOR) vProcAnchor
-
-instance EraPParams era => ToJSON (VotingProcedure era) where
-  toJSON = object . toVotingProcedurePairs
-  toEncoding = pairs . mconcat . toVotingProcedurePairs
-
-toVotingProcedurePairs :: (KeyValue a, EraPParams era) => VotingProcedure era -> [a]
-toVotingProcedurePairs vProc@(VotingProcedure _ _ _ _) =
-  let VotingProcedure {..} = vProc
-   in [ "govActionId" .= vProcGovActionId
-      , "voter" .= vProcVoter
-      , "anchor" .= vProcAnchor
-      , "decision" .= vProcVote
-      ]
-
-data ProposalProcedure era = ProposalProcedure
-  { pProcDeposit :: !Coin
-  , pProcReturnAddr :: !(KeyHash 'Staking (EraCrypto era))
-  , pProcGovernanceAction :: !(GovernanceAction era)
-  , pProcAnchor :: !(StrictMaybe (Anchor (EraCrypto era)))
-  }
-  deriving (Generic, Eq, Show)
-
-instance EraPParams era => NoThunks (ProposalProcedure era)
-
-instance EraPParams era => NFData (ProposalProcedure era)
-
-instance EraPParams era => DecCBOR (ProposalProcedure era) where
-  decCBOR =
-    decode $
-      RecD ProposalProcedure
-        <! From
-        <! From
-        <! From
-        <! D (decodeNullStrictMaybe decCBOR)
-
-instance EraPParams era => EncCBOR (ProposalProcedure era) where
-  encCBOR ProposalProcedure {..} =
-    encode $
-      Rec (ProposalProcedure @era)
-        !> To pProcDeposit
-        !> To pProcReturnAddr
-        !> To pProcGovernanceAction
-        !> E (encodeNullStrictMaybe encCBOR) pProcAnchor
-
-data GovernanceProcedure era
-  = GovernanceVotingProcedure !(VotingProcedure era)
-  | GovernanceProposalProcedure !(ProposalProcedure era)
-  deriving (Eq, Generic)
-
-instance EraPParams era => NoThunks (GovernanceProcedure era)
-
-instance EraPParams era => NFData (GovernanceProcedure era)
-
-deriving instance EraPParams era => Show (GovernanceProcedure era)
-
-data Voter c
-  = CommitteeVoter !(Credential 'CommitteeHotKey c)
-  | DRepVoter !(Credential 'Voting c)
-  | StakePoolVoter !(KeyHash 'StakePool c)
-  deriving (Generic, Eq, Ord, Show)
-
-instance Crypto c => ToJSON (Voter c)
-
-instance Crypto c => DecCBOR (Voter c) where
-  decCBOR = decodeRecordSum "Voter" $ \case
-    0 -> (2,) . CommitteeVoter . KeyHashObj <$> decCBOR
-    1 -> (2,) . CommitteeVoter . ScriptHashObj <$> decCBOR
-    2 -> (2,) . DRepVoter . KeyHashObj <$> decCBOR
-    3 -> (2,) . DRepVoter . ScriptHashObj <$> decCBOR
-    4 -> (2,) . StakePoolVoter <$> decCBOR
-    5 -> fail "Script objects are not allowed for StakePool votes"
-    t -> invalidKey t
-
-instance Crypto c => EncCBOR (Voter c) where
-  encCBOR = \case
-    CommitteeVoter (KeyHashObj keyHash) ->
-      encodeListLen 2 <> encodeWord8 0 <> encCBOR keyHash
-    CommitteeVoter (ScriptHashObj scriptHash) ->
-      encodeListLen 2 <> encodeWord8 1 <> encCBOR scriptHash
-    DRepVoter (KeyHashObj keyHash) ->
-      encodeListLen 2 <> encodeWord8 2 <> encCBOR keyHash
-    DRepVoter (ScriptHashObj scriptHash) ->
-      encodeListLen 2 <> encodeWord8 3 <> encCBOR scriptHash
-    StakePoolVoter keyHash ->
-      encodeListLen 2 <> encodeWord8 4 <> encCBOR keyHash
-
-instance NoThunks (Voter c)
-
-instance NFData (Voter c)
-
-data Vote
-  = VoteNo
-  | VoteYes
-  | Abstain
-  deriving (Generic, Eq, Show, Enum, Bounded)
-
-instance ToJSON Vote
-
-instance NoThunks Vote
-
-instance NFData Vote
-
-instance DecCBOR Vote where
-  decCBOR = decodeEnumBounded
-
-instance EncCBOR Vote where
-  encCBOR = encodeEnum
 
 data GovernanceActionState era = GovernanceActionState
   { gasCommitteeVotes :: !(Map (Credential 'CommitteeHotKey (EraCrypto era)) Vote)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -1,0 +1,342 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use record patterns" #-}
+
+module Cardano.Ledger.Conway.Governance.Procedures (
+  GovernanceProcedures (..),
+  VotingProcedure (..),
+  ProposalProcedure (..),
+  Anchor (..),
+  AnchorDataHash,
+  Vote (..),
+  Voter (..),
+  GovernanceAction (..),
+  GovernanceActionId (..),
+  GovernanceActionIx (..),
+  govActionIdToText,
+) where
+
+import Cardano.Crypto.Hash (ByteString, hashToTextAsHex)
+import Cardano.Ledger.BaseTypes (ProtVer, Url)
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+  decodeEnumBounded,
+  decodeNullStrictMaybe,
+  encodeEnum,
+  encodeListLen,
+  encodeNullStrictMaybe,
+  encodeWord8,
+  invalidKey,
+ )
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, decodeRecordSum, encode, (!>), (<!))
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Core (Era (..), EraPParams, PParamsUpdate)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.SafeHash (SafeHash, extractHash)
+import Cardano.Ledger.TxIn (TxId (..))
+import Control.DeepSeq (NFData (..), rwhnf)
+import Data.Aeson (KeyValue (..), ToJSON (..), ToJSONKey (..), object, pairs)
+import Data.Aeson.Types (toJSONKeyText)
+import Data.Map.Strict (Map)
+import Data.Maybe.Strict (StrictMaybe)
+import Data.Sequence (Seq)
+import Data.Set (Set)
+import qualified Data.Text as Text
+import Data.Word (Word64)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+newtype GovernanceActionIx = GovernanceActionIx Word64
+  deriving
+    ( Generic
+    , Eq
+    , Ord
+    , Show
+    , Num
+    , Enum
+    , NFData
+    , NoThunks
+    , EncCBOR
+    , DecCBOR
+    , ToJSON
+    )
+
+data GovernanceActionId c = GovernanceActionId
+  { gaidTxId :: !(TxId c)
+  , gaidGovActionIx :: !GovernanceActionIx
+  }
+  deriving (Generic, Eq, Ord, Show)
+
+instance Crypto c => DecCBOR (GovernanceActionId c) where
+  decCBOR =
+    decode $
+      RecD GovernanceActionId
+        <! From
+        <! From
+
+instance Crypto c => EncCBOR (GovernanceActionId c) where
+  encCBOR GovernanceActionId {..} =
+    encode $
+      Rec GovernanceActionId
+        !> To gaidTxId
+        !> To gaidGovActionIx
+
+instance NoThunks (GovernanceActionId c)
+
+instance Crypto c => NFData (GovernanceActionId c)
+
+instance Crypto c => ToJSON (GovernanceActionId c) where
+  toJSON = object . toGovernanceActionIdPairs
+  toEncoding = pairs . mconcat . toGovernanceActionIdPairs
+
+toGovernanceActionIdPairs :: (KeyValue a, Crypto c) => GovernanceActionId c -> [a]
+toGovernanceActionIdPairs gaid@(GovernanceActionId _ _) =
+  let GovernanceActionId {..} = gaid
+   in [ "txId" .= gaidTxId
+      , "govActionIx" .= gaidGovActionIx
+      ]
+
+instance Crypto c => ToJSONKey (GovernanceActionId c) where
+  toJSONKey = toJSONKeyText govActionIdToText
+
+govActionIdToText :: GovernanceActionId c -> Text.Text
+govActionIdToText (GovernanceActionId (TxId txidHash) (GovernanceActionIx ix)) =
+  hashToTextAsHex (extractHash txidHash)
+    <> Text.pack "#"
+    <> Text.pack (show ix)
+
+data Voter c
+  = CommitteeVoter !(Credential 'CommitteeHotKey c)
+  | DRepVoter !(Credential 'Voting c)
+  | StakePoolVoter !(KeyHash 'StakePool c)
+  deriving (Generic, Eq, Ord, Show)
+
+instance Crypto c => ToJSON (Voter c)
+
+instance Crypto c => DecCBOR (Voter c) where
+  decCBOR = decodeRecordSum "Voter" $ \case
+    0 -> (2,) . CommitteeVoter . KeyHashObj <$> decCBOR
+    1 -> (2,) . CommitteeVoter . ScriptHashObj <$> decCBOR
+    2 -> (2,) . DRepVoter . KeyHashObj <$> decCBOR
+    3 -> (2,) . DRepVoter . ScriptHashObj <$> decCBOR
+    4 -> (2,) . StakePoolVoter <$> decCBOR
+    5 -> fail "Script objects are not allowed for StakePool votes"
+    t -> invalidKey t
+
+instance Crypto c => EncCBOR (Voter c) where
+  encCBOR = \case
+    CommitteeVoter (KeyHashObj keyHash) ->
+      encodeListLen 2 <> encodeWord8 0 <> encCBOR keyHash
+    CommitteeVoter (ScriptHashObj scriptHash) ->
+      encodeListLen 2 <> encodeWord8 1 <> encCBOR scriptHash
+    DRepVoter (KeyHashObj keyHash) ->
+      encodeListLen 2 <> encodeWord8 2 <> encCBOR keyHash
+    DRepVoter (ScriptHashObj scriptHash) ->
+      encodeListLen 2 <> encodeWord8 3 <> encCBOR scriptHash
+    StakePoolVoter keyHash ->
+      encodeListLen 2 <> encodeWord8 4 <> encCBOR keyHash
+
+instance NoThunks (Voter c)
+
+instance NFData (Voter c)
+
+data Vote
+  = VoteNo
+  | VoteYes
+  | Abstain
+  deriving (Generic, Eq, Show, Enum, Bounded)
+
+instance ToJSON Vote
+
+instance NoThunks Vote
+
+instance NFData Vote
+
+instance DecCBOR Vote where
+  decCBOR = decodeEnumBounded
+
+instance EncCBOR Vote where
+  encCBOR = encodeEnum
+
+data AnchorDataHash
+
+data Anchor c = Anchor
+  { anchorUrl :: !Url
+  , anchorDataHash :: !(SafeHash c AnchorDataHash)
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks (Anchor c)
+
+instance Crypto c => NFData (Anchor c) where
+  rnf = rwhnf
+
+instance Crypto c => DecCBOR (Anchor c) where
+  decCBOR =
+    decode $
+      RecD Anchor
+        <! From
+        <! From
+
+instance Crypto c => EncCBOR (Anchor c) where
+  encCBOR Anchor {..} =
+    encode $
+      Rec Anchor
+        !> To anchorUrl
+        !> To anchorDataHash
+
+instance Crypto c => ToJSON (Anchor c) where
+  toJSON = object . toAnchorPairs
+  toEncoding = pairs . mconcat . toAnchorPairs
+
+toAnchorPairs :: (KeyValue a, Crypto c) => Anchor c -> [a]
+toAnchorPairs vote@(Anchor _ _) =
+  let Anchor {..} = vote
+   in [ "url" .= anchorUrl
+      , "dataHash" .= anchorDataHash
+      ]
+
+data VotingProcedure era = VotingProcedure
+  { vProcGovActionId :: !(GovernanceActionId (EraCrypto era))
+  , vProcVoter :: !(Voter (EraCrypto era))
+  , vProcVote :: !Vote
+  , vProcAnchor :: !(StrictMaybe (Anchor (EraCrypto era)))
+  }
+  deriving (Generic, Eq, Show)
+
+instance NoThunks (VotingProcedure era)
+
+instance Crypto (EraCrypto era) => NFData (VotingProcedure era)
+
+instance Era era => DecCBOR (VotingProcedure era) where
+  decCBOR =
+    decode $
+      RecD VotingProcedure
+        <! From
+        <! From
+        <! From
+        <! D (decodeNullStrictMaybe decCBOR)
+
+instance Era era => EncCBOR (VotingProcedure era) where
+  encCBOR VotingProcedure {..} =
+    encode $
+      Rec (VotingProcedure @era)
+        !> To vProcGovActionId
+        !> To vProcVoter
+        !> To vProcVote
+        !> E (encodeNullStrictMaybe encCBOR) vProcAnchor
+
+instance EraPParams era => ToJSON (VotingProcedure era) where
+  toJSON = object . toVotingProcedurePairs
+  toEncoding = pairs . mconcat . toVotingProcedurePairs
+
+toVotingProcedurePairs :: (KeyValue a, EraPParams era) => VotingProcedure era -> [a]
+toVotingProcedurePairs vProc@(VotingProcedure _ _ _ _) =
+  let VotingProcedure {..} = vProc
+   in [ "govActionId" .= vProcGovActionId
+      , "voter" .= vProcVoter
+      , "anchor" .= vProcAnchor
+      , "decision" .= vProcVote
+      ]
+
+data GovernanceProcedures era = GovernanceProcedures
+  { gpVotingProcedures :: !(Seq (VotingProcedure era))
+  , gpProposalProcedures :: !(Seq (ProposalProcedure era))
+  }
+  deriving (Eq, Generic)
+
+instance EraPParams era => NoThunks (GovernanceProcedures era)
+
+instance EraPParams era => NFData (GovernanceProcedures era)
+
+deriving instance EraPParams era => Show (GovernanceProcedures era)
+
+data ProposalProcedure era = ProposalProcedure
+  { pProcDeposit :: !Coin
+  , pProcReturnAddr :: !(KeyHash 'Staking (EraCrypto era))
+  , pProcGovernanceAction :: !(GovernanceAction era)
+  , pProcAnchor :: !(StrictMaybe (Anchor (EraCrypto era)))
+  }
+  deriving (Generic, Eq, Show)
+
+instance EraPParams era => NoThunks (ProposalProcedure era)
+
+instance EraPParams era => NFData (ProposalProcedure era)
+
+instance EraPParams era => DecCBOR (ProposalProcedure era) where
+  decCBOR =
+    decode $
+      RecD ProposalProcedure
+        <! From
+        <! From
+        <! From
+        <! D (decodeNullStrictMaybe decCBOR)
+
+instance EraPParams era => EncCBOR (ProposalProcedure era) where
+  encCBOR ProposalProcedure {..} =
+    encode $
+      Rec (ProposalProcedure @era)
+        !> To pProcDeposit
+        !> To pProcReturnAddr
+        !> To pProcGovernanceAction
+        !> E (encodeNullStrictMaybe encCBOR) pProcAnchor
+
+data GovernanceAction era
+  = ParameterChange !(PParamsUpdate era)
+  | HardForkInitiation !ProtVer
+  | TreasuryWithdrawals !(Map (Credential 'Staking (EraCrypto era)) Coin)
+  | NoConfidence
+  | NewCommittee !(Set (KeyHash 'Voting (EraCrypto era))) !Rational
+  | NewConstitution !(SafeHash (EraCrypto era) ByteString)
+  | InfoAction
+  deriving (Generic)
+
+deriving instance EraPParams era => Eq (GovernanceAction era)
+
+deriving instance EraPParams era => Show (GovernanceAction era)
+
+instance EraPParams era => NoThunks (GovernanceAction era)
+
+instance EraPParams era => NFData (GovernanceAction era)
+
+instance EraPParams era => ToJSON (GovernanceAction era)
+
+instance EraPParams era => DecCBOR (GovernanceAction era) where
+  decCBOR =
+    decode $
+      Summands "GovernanceAction" dec
+    where
+      dec 0 = SumD ParameterChange <! From
+      dec 1 = SumD HardForkInitiation <! From
+      dec 2 = SumD TreasuryWithdrawals <! From
+      dec 3 = SumD NoConfidence
+      dec 4 = SumD NewCommittee <! From <! From
+      dec 5 = SumD NewConstitution <! From
+      dec 6 = SumD InfoAction
+      dec k = Invalid k
+
+instance EraPParams era => EncCBOR (GovernanceAction era) where
+  encCBOR x = encode (enc x)
+    where
+      enc (ParameterChange ppup) = Sum ParameterChange 0 !> To ppup
+      enc (HardForkInitiation pv) = Sum HardForkInitiation 1 !> To pv
+      enc (TreasuryWithdrawals ws) = Sum TreasuryWithdrawals 2 !> To ws
+      enc NoConfidence = Sum NoConfidence 3
+      enc (NewCommittee mems quorum) = Sum NewCommittee 4 !> To mems !> To quorum
+      enc (NewConstitution h) = Sum NewConstitution 5 !> To h
+      enc InfoAction = Sum InfoAction 6

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -195,12 +195,9 @@ instance Era era => Arbitrary (VotingProcedure era) where
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ProposalProcedure era) where
   arbitrary = ProposalProcedure <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
-instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceProcedure era) where
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovernanceProcedures era) where
   arbitrary =
-    oneof
-      [ GovernanceVotingProcedure <$> arbitrary
-      , GovernanceProposalProcedure <$> arbitrary
-      ]
+    GovernanceProcedures <$> arbitrary <*> arbitrary
 
 instance Era era => Arbitrary (ConwayTallyPredFailure era) where
   arbitrary = GovernanceActionDoesNotExist <$> arbitrary

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -42,7 +42,7 @@ library
         cardano-ledger-babbage-test,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-strict-containers,
-        cardano-ledger-conway:{cardano-ledger-conway, testlib} >=1.3 && <1.6,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.6,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3 && <1.5,
         cardano-ledger-allegra ^>=1.2,
         cardano-ledger-mary ^>=1.3,

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-pretty
-version:            1.2.1.1
+version:            1.2.1.2
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -39,7 +39,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway ^>=1.5,
+        cardano-ledger-conway ^>=1.6,
         cardano-ledger-core >=1.3 && <1.5,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley ^>=1.4,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Conway.Governance (
   GovernanceActionId (..),
   GovernanceActionIx (..),
   GovernanceActionState (..),
-  GovernanceProcedure,
+  GovernanceProcedures,
   ProposalProcedure (..),
   Vote (..),
   Voter (..),
@@ -185,7 +185,7 @@ instance EraPParams era => PrettyA (VotingProcedure era) where
 instance EraPParams era => PrettyA (ProposalProcedure era) where
   prettyA = viaShow
 
-instance EraPParams era => PrettyA (GovernanceProcedure era) where
+instance EraPParams era => PrettyA (GovernanceProcedures era) where
   prettyA = viaShow
 
 instance PrettyA (PParamsUpdate era) => PrettyA (GovernanceAction era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -60,7 +60,7 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance (GovernanceProcedure (..))
+import Cardano.Ledger.Conway.Governance (GovernanceProcedures (..))
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..), hashKey)
@@ -75,7 +75,7 @@ import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Sequence.Strict (StrictSeq)
+import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SSeq (fromList)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -124,7 +124,7 @@ data TxBodyField era
   | WppHash (StrictMaybe (ScriptIntegrityHash (EraCrypto era)))
   | AdHash (StrictMaybe (AuxiliaryDataHash (EraCrypto era)))
   | Txnetworkid (StrictMaybe Network)
-  | GovernanceProcs (StrictSeq (GovernanceProcedure era))
+  | GovernanceProcs (GovernanceProcedures era)
 
 pattern Inputs' :: [TxIn (EraCrypto era)] -> TxBodyField era -- Set
 
@@ -327,7 +327,7 @@ abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol cert wdrl 
   , WppHash sih
   , AdHash adh
   , Txnetworkid net
-  , GovernanceProcs $ (GovernanceVotingProcedure <$> vp) <> (GovernanceProposalProcedure <$> pp)
+  , GovernanceProcs $ GovernanceProcedures (fromStrict vp) (fromStrict pp)
   ]
 abstractTxBody (Babbage _) (BabbageTxBody inp col ref out colret totcol cert wdrl fee vldt up req mnt sih adh net) =
   [ Inputs inp

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1507,7 +1507,7 @@ pcTxBodyField proof x = case x of
   AdHash (SJust (AuxiliaryDataHash h)) -> [("aux data hash", trim (ppSafeHash h))]
   Txnetworkid SNothing -> []
   Txnetworkid (SJust nid) -> [("network id", pcNetwork nid)]
-  GovernanceProcs ga -> [("governance procedures", ppStrictSeq prettyA ga)]
+  GovernanceProcs ga -> [("governance procedures", prettyA ga)]
 
 pcTxField ::
   forall era.


### PR DESCRIPTION
# Description

This PR replaces the signal of the TALLY rule for a new `GovernanceProcedures` datatype, which stores votes and proposals separately. This new type resides in the new `Cardano.Ledger.Conway.Governance.Procedures` file, which is re-exported by `Cardano.Ledger.Conway.Governance`.

resolve #3513 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
