### PR TITLE
Bump allegra and alonzo versions for release 8.2 

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.0.3
+
+*
+
 ## 1.2.0.2
 
 *

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.0.1
+version:            1.2.0.2
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.3.1.2
+
+*
+
 ## 1.3.1.1
 
 *

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.3.1.0
+version:            1.3.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/test-suite/CHANGELOG.md
+++ b/eras/alonzo/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo-test`
 
+## 1.1.2.3
+
+*
+
 ## 1.1.2.2
 
 *

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-alonzo-test
-version:       1.1.2.1
+version:       1.1.2.2
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/eras/babbage/test-suite/CHANGELOG.md
+++ b/eras/babbage/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage-test`
 
+## 1.1.1.4
+
+*
+
 ## 1.1.1.3
 
 *

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-babbage-test
-version:       1.1.1.2
+version:       1.1.1.3
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway-test`
 
+## 1.2.0.3
+
+* 
+
 ## 1.2.0.2
 
 *

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-conway-test
-version:       1.2.0.1
+version:       1.2.0.2
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
# Description

- bump `cardano-ledger-allegra` to 1.2.0.2 (only change is bounds on `cardano-ledger-core`)
- bump `cardano-ledger-alonzo` to 1.3.1.1 (only change is bounds on `cardano-ledger-core`)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
