### PR TITLE
Allow zero coin in TxOuts in Conway

### DIFF
--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-conway-test`
 
+## 1.2.0.4
+
+* Change CDDL spec for `Coin`
+
 ## 1.2.0.3
 
-* 
+*
 
 ## 1.2.0.2
 

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-conway-test
-version:       1.2.0.3
+version:       1.2.0.4
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -45,7 +45,7 @@ library
         cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.6,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3 && <1.5,
         cardano-ledger-allegra ^>=1.2,
-        cardano-ledger-mary ^>=1.3,
+        cardano-ledger-mary ^>=1.3.1,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-shelley-test >=1.1,
         cardano-ledger-shelley >=1.3 && <1.5,

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -513,9 +513,9 @@ negInt64 = -9223372036854775808 .. -1
 posInt64 = 1 .. 9223372036854775807
 nonZeroInt64 = negInt64 / posInt64 ; this is the same as the current int64 definition but without zero
 
-positive_coin = 1 .. 18446744073709551615
+positive_amount = 1 .. 18446744073709551615
 
-value = positive_coin / [positive_coin,multiasset<positive_coin>]
+value = coin / [coin,multiasset<positive_amount>]
 
 mint = multiasset<nonZeroInt64>
 

--- a/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
+++ b/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/Serialisation/CDDL.hs
@@ -26,7 +26,7 @@ import Test.Tasty (TestTree, testGroup, withResource)
 tests :: Int -> TestTree
 tests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
-    [ cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "positive_coin"
+    [ cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "coin"
     , cddlTest @(Value Conway) (eraProtVerHigh @Conway) n "value"
     , cddlAnnotatorTest @(TxBody Conway) (eraProtVerHigh @Conway) n "transaction_body"
     , cddlAnnotatorTest @(TxAuxData Conway) (eraProtVerHigh @Conway) n "auxiliary_data"

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.3.1.0
+
+* Allow decoding zero `Coin` for `Value`
+
 ## 1.3.0.2
 
 *

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.0.2
+version:            1.3.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
# Description

As it turns out there are some TxOuts from Byron era that contain zero Coin.

For that reason we will allow zero coin, but not zero multi asset

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
