### PR TITLE
Add `spendableInputsTxBodyF` and fix requiring witnesses for refInputs

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -322,6 +322,9 @@ instance Crypto c => EraTxBody (AllegraEra c) where
       \txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash}
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINEABLE allInputsTxBodyF #-}
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -183,6 +183,9 @@ instance Crypto c => EraTxBody (AlonzoEra c) where
     lensMemoRawType atbrAuxDataHash (\txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash})
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = allInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF =
     to $ \txBody -> (txBody ^. inputsTxBodyL) `Set.union` (txBody ^. collateralInputsTxBodyL)
   {-# INLINEABLE allInputsTxBodyF #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -61,7 +61,8 @@ module Cardano.Ledger.Babbage.TxBody (
   outputsBabbageTxBodyL,
   feeBabbageTxBodyL,
   auxDataHashBabbageTxBodyL,
-  allInputsBabbageTxBodyF,
+  babbageSpendableInputsTxBodyF,
+  babbageAllInputsTxBodyF,
   mintedBabbageTxBodyF,
   mintValueBabbageTxBodyF,
   withdrawalsBabbbageTxBodyL,
@@ -241,14 +242,22 @@ auxDataHashBabbageTxBodyL =
     \txBodyRaw auxDataHash -> txBodyRaw {btbrAuxDataHash = auxDataHash}
 {-# INLINEABLE auxDataHashBabbageTxBodyL #-}
 
-allInputsBabbageTxBodyF ::
-  BabbageEraTxBody era => SimpleGetter (BabbageTxBody era) (Set (TxIn (EraCrypto era)))
-allInputsBabbageTxBodyF =
+babbageSpendableInputsTxBodyF ::
+  BabbageEraTxBody era => SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+babbageSpendableInputsTxBodyF =
   to $ \txBody ->
-    (txBody ^. inputsBabbageTxBodyL)
-      `Set.union` (txBody ^. collateralInputsBabbageTxBodyL)
-      `Set.union` (txBody ^. referenceInputsBabbageTxBodyL)
-{-# INLINEABLE allInputsBabbageTxBodyF #-}
+    (txBody ^. inputsTxBodyL)
+      `Set.union` (txBody ^. collateralInputsTxBodyL)
+{-# INLINEABLE babbageSpendableInputsTxBodyF #-}
+
+babbageAllInputsTxBodyF ::
+  BabbageEraTxBody era => SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+babbageAllInputsTxBodyF =
+  to $ \txBody ->
+    (txBody ^. inputsTxBodyL)
+      `Set.union` (txBody ^. collateralInputsTxBodyL)
+      `Set.union` (txBody ^. referenceInputsTxBodyL)
+{-# INLINEABLE babbageAllInputsTxBodyF #-}
 
 mintedBabbageTxBodyF :: SimpleGetter (BabbageTxBody era) (Set (ScriptHash (EraCrypto era)))
 mintedBabbageTxBodyF = to (Set.map policyID . policies . btbrMint . getMemoRawType)
@@ -387,7 +396,10 @@ instance Crypto c => EraTxBody (BabbageEra c) where
   auxDataHashTxBodyL = auxDataHashBabbageTxBodyL
   {-# INLINE auxDataHashTxBodyL #-}
 
-  allInputsTxBodyF = allInputsBabbageTxBodyF
+  spendableInputsTxBodyF = babbageSpendableInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
+  allInputsTxBodyF = babbageAllInputsTxBodyF
   {-# INLINE allInputsTxBodyF #-}
 
   withdrawalsTxBodyL = withdrawalsBabbbageTxBodyL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -43,6 +43,7 @@ module Cardano.Ledger.Conway.TxBody (
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
+import Cardano.Ledger.Babbage.TxBody (babbageAllInputsTxBodyF, babbageSpendableInputsTxBodyF)
 import Cardano.Ledger.BaseTypes (Network)
 import Cardano.Ledger.Binary (
   Annotator,
@@ -281,13 +282,10 @@ instance Crypto c => EraTxBody (ConwayEra c) where
   auxDataHashTxBodyL = lensMemoRawType ctbrAuxDataHash (\txb x -> txb {ctbrAuxDataHash = x})
   {-# INLINE auxDataHashTxBodyL #-}
 
-  allInputsTxBodyF =
-    to $ \txBody ->
-      Set.unions
-        [ txBody ^. inputsTxBodyL
-        , txBody ^. collateralInputsTxBodyL
-        , txBody ^. referenceInputsTxBodyL
-        ]
+  spendableInputsTxBodyF = babbageSpendableInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
+  allInputsTxBodyF = babbageAllInputsTxBodyF
   {-# INLINE allInputsTxBodyF #-}
 
   withdrawalsTxBodyL = lensMemoRawType ctbrWithdrawals (\txb x -> txb {ctbrWithdrawals = x})

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -236,6 +236,9 @@ instance Crypto c => EraTxBody (MaryEra c) where
       \txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash}
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINEABLE allInputsTxBodyF #-}
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -489,7 +489,7 @@ witsVKeyNeededNoGovernance utxo' txBody =
     `Set.union` wdrlAuthors
   where
     inputAuthors :: Set (KeyHash 'Witness (EraCrypto era))
-    inputAuthors = foldr' accum Set.empty (txBody ^. allInputsTxBodyF)
+    inputAuthors = foldr' accum Set.empty (txBody ^. spendableInputsTxBodyF)
       where
         accum txin !ans =
           case txinLookup txin utxo' of

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -274,6 +274,9 @@ instance Crypto c => EraTxBody (ShelleyEra c) where
 
   mkBasicTxBody = mkMemoized basicShelleyTxBodyRaw
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINE allInputsTxBodyF #-}
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename `cgTallyL` to `cgGovL`
 * Rename `ConwayTallyState` to `ConwayGovState`
+* Add `spendableInputsTxBodyL`
 
 ## 1.3.0.0
 

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Api.Tx.Body (
   Withdrawals (..),
   auxDataHashTxBodyL,
   AuxiliaryDataHash,
+  spendableInputsTxBodyF,
   allInputsTxBodyF,
   evalBalanceTxBody,
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `Plutus`
 * Changed `Phase2Script` constructor of the `PhaseScript` type. It now accepts new
   `Plutus` type instead of `Language` and `ShortByteString`
+* Add `spendableInputsTxBodyL`
 
 ## 1.4.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -190,6 +190,14 @@ class
 
   auxDataHashTxBodyL :: Lens' (TxBody era) (StrictMaybe (AuxiliaryDataHash (EraCrypto era)))
 
+  -- | This getter will produce all inputs from the UTxO map that this transaction might
+  -- spend, which ones will depend on the validity of the transaction itself. Starting in
+  -- Alonzo this will include collateral inputs.
+  spendableInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+
+  -- | This getter will produce all inputs from the UTxO map that this transaction is
+  -- referencing, even if some of them cannot be spent by the transaction. For example
+  -- starting with Babbage era it will also include reference inputs.
   allInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
 
   certsTxBodyL :: Lens' (TxBody era) (StrictSeq (TxCert era))


### PR DESCRIPTION
# Description

Restructure of collecting required witnesses by accident also enforced to require witnesses for reference inputs in #3425

This PR fixes the problem by adding `spendableInputsTxBodyF`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
