### PR TITLE
Backport a fix of ref inputs witnessing bug fix

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.2.0.3
 
 *

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.0.2
+version:            1.2.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -52,7 +52,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-ledger-shelley >=1.3 && <1.5,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -322,6 +322,9 @@ instance Crypto c => EraTxBody (AllegraEra c) where
       \txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash}
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINEABLE allInputsTxBodyF #-}
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.3.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.3.1.2
 
 *

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.3.1.1
+version:            1.3.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -67,7 +67,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4,
         cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -183,6 +183,9 @@ instance Crypto c => EraTxBody (AlonzoEra c) where
     lensMemoRawType atbrAuxDataHash (\txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash})
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = allInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF =
     to $ \txBody -> (txBody ^. inputsTxBodyL) `Set.union` (txBody ^. collateralInputsTxBodyL)
   {-# INLINEABLE allInputsTxBodyF #-}

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.4.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.4.0.1
 
 *

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.4.0.1
+version:            1.4.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -61,7 +61,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4,
         cardano-slotting,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -61,7 +61,8 @@ module Cardano.Ledger.Babbage.TxBody (
   outputsBabbageTxBodyL,
   feeBabbageTxBodyL,
   auxDataHashBabbageTxBodyL,
-  allInputsBabbageTxBodyF,
+  babbageSpendableInputsTxBodyF,
+  babbageAllInputsTxBodyF,
   mintedBabbageTxBodyF,
   mintValueBabbageTxBodyF,
   withdrawalsBabbbageTxBodyL,
@@ -241,14 +242,22 @@ auxDataHashBabbageTxBodyL =
     \txBodyRaw auxDataHash -> txBodyRaw {btbrAuxDataHash = auxDataHash}
 {-# INLINEABLE auxDataHashBabbageTxBodyL #-}
 
-allInputsBabbageTxBodyF ::
-  BabbageEraTxBody era => SimpleGetter (BabbageTxBody era) (Set (TxIn (EraCrypto era)))
-allInputsBabbageTxBodyF =
+babbageSpendableInputsTxBodyF ::
+  BabbageEraTxBody era => SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+babbageSpendableInputsTxBodyF =
   to $ \txBody ->
-    (txBody ^. inputsBabbageTxBodyL)
-      `Set.union` (txBody ^. collateralInputsBabbageTxBodyL)
-      `Set.union` (txBody ^. referenceInputsBabbageTxBodyL)
-{-# INLINEABLE allInputsBabbageTxBodyF #-}
+    (txBody ^. inputsTxBodyL)
+      `Set.union` (txBody ^. collateralInputsTxBodyL)
+{-# INLINEABLE babbageSpendableInputsTxBodyF #-}
+
+babbageAllInputsTxBodyF ::
+  BabbageEraTxBody era => SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+babbageAllInputsTxBodyF =
+  to $ \txBody ->
+    (txBody ^. inputsTxBodyL)
+      `Set.union` (txBody ^. collateralInputsTxBodyL)
+      `Set.union` (txBody ^. referenceInputsTxBodyL)
+{-# INLINEABLE babbageAllInputsTxBodyF #-}
 
 mintedBabbageTxBodyF :: SimpleGetter (BabbageTxBody era) (Set (ScriptHash (EraCrypto era)))
 mintedBabbageTxBodyF = to (Set.map policyID . policies . btbrMint . getMemoRawType)
@@ -387,7 +396,10 @@ instance Crypto c => EraTxBody (BabbageEra c) where
   auxDataHashTxBodyL = auxDataHashBabbageTxBodyL
   {-# INLINE auxDataHashTxBodyL #-}
 
-  allInputsTxBodyF = allInputsBabbageTxBodyF
+  spendableInputsTxBodyF = babbageSpendableInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
+  allInputsTxBodyF = babbageAllInputsTxBodyF
   {-# INLINE allInputsTxBodyF #-}
 
   withdrawalsTxBodyL = withdrawalsBabbbageTxBodyL

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.6.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.6.1.0
 
 * Removal of TxOuts with zero `Coin` from UTxO on translation

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.6.1.0
+version:            1.6.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -70,7 +70,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo >=1.3.1,
         cardano-ledger-babbage >=1.1,
-        cardano-ledger-core ^>=1.4,
+        cardano-ledger-core ^>=1.4.1,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4.1,
         cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -43,6 +43,7 @@ module Cardano.Ledger.Conway.TxBody (
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
+import Cardano.Ledger.Babbage.TxBody (babbageAllInputsTxBodyF, babbageSpendableInputsTxBodyF)
 import Cardano.Ledger.BaseTypes (Network)
 import Cardano.Ledger.Binary (
   Annotator,
@@ -281,13 +282,10 @@ instance Crypto c => EraTxBody (ConwayEra c) where
   auxDataHashTxBodyL = lensMemoRawType ctbrAuxDataHash (\txb x -> txb {ctbrAuxDataHash = x})
   {-# INLINE auxDataHashTxBodyL #-}
 
-  allInputsTxBodyF =
-    to $ \txBody ->
-      Set.unions
-        [ txBody ^. inputsTxBodyL
-        , txBody ^. collateralInputsTxBodyL
-        , txBody ^. referenceInputsTxBodyL
-        ]
+  spendableInputsTxBodyF = babbageSpendableInputsTxBodyF
+  {-# INLINE spendableInputsTxBodyF #-}
+
+  allInputsTxBodyF = babbageAllInputsTxBodyF
   {-# INLINE allInputsTxBodyF #-}
 
   withdrawalsTxBodyL = lensMemoRawType ctbrWithdrawals (\txb x -> txb {ctbrWithdrawals = x})

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.3.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.3.0.2
 
 *

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.0.2
+version:            1.3.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -59,7 +59,7 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-ledger-shelley >=1.3 && <1.5,
         containers,
         deepseq,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -236,6 +236,9 @@ instance Crypto c => EraTxBody (MaryEra c) where
       \txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash}
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINEABLE allInputsTxBodyF #-}
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.4.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+* Fix an issue with where `witsVKeyNeededNoGovernance` and `witsVKeyNeeded` required
+  witnesses for `allInputsTxL`, which affected reference inputs in Babbage.
+
 ## 1.4.1.0
 
 * Add `getConstitutionHash` to `EraGovernance` #3506

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.4.1.0
+version:            1.4.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -105,7 +105,7 @@ library
         cardano-data >=1.0,
         cardano-ledger-binary >=1.0,
         cardano-ledger-byron,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-slotting,
         vector-map >=1.0,
         containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -489,7 +489,7 @@ witsVKeyNeededNoGovernance utxo' txBody =
     `Set.union` wdrlAuthors
   where
     inputAuthors :: Set (KeyHash 'Witness (EraCrypto era))
-    inputAuthors = foldr' accum Set.empty (txBody ^. allInputsTxBodyF)
+    inputAuthors = foldr' accum Set.empty (txBody ^. spendableInputsTxBodyF)
       where
         accum txin !ans =
           case txinLookup txin utxo' of

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -274,6 +274,9 @@ instance Crypto c => EraTxBody (ShelleyEra c) where
 
   mkBasicTxBody = mkMemoized basicShelleyTxBodyRaw
 
+  spendableInputsTxBodyF = inputsTxBodyL
+  {-# INLINE spendableInputsTxBodyF #-}
+
   allInputsTxBodyF = inputsTxBodyL
   {-# INLINE allInputsTxBodyF #-}
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-api`
 
+## 1.3.1.0
+
+* Add `spendableInputsTxBodyL`
+
 ## 1.3.0.0
 
 * Add `queryConstitutionHash` to `Cardano.Ledger.Api.State.Query` #3506

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-api
-version:            1.3.0.0
+version:            1.3.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -55,7 +55,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-conway >=1.5,
-        cardano-ledger-core >=1.3 && <1.5,
+        cardano-ledger-core >=1.4.1 && <1.5,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4.1,
         cardano-slotting,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Api.Tx.Body (
   Withdrawals (..),
   auxDataHashTxBodyL,
   AuxiliaryDataHash,
+  spendableInputsTxBodyF,
   allInputsTxBodyF,
   evalBalanceTxBody,
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-core`
 
+## 1.4.1.0
+
+* Add `spendableInputsTxBodyL`
+
 ## 1.4.0.0
 
 * Added `DRep`, `DRepCredential`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.4.0.0
+version:            1.4.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -191,6 +191,14 @@ class
 
   auxDataHashTxBodyL :: Lens' (TxBody era) (StrictMaybe (AuxiliaryDataHash (EraCrypto era)))
 
+  -- | This getter will produce all inputs from the UTxO map that this transaction might
+  -- spend, which ones will depend on the validity of the transaction itself. Starting in
+  -- Alonzo this will include collateral inputs.
+  spendableInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+
+  -- | This getter will produce all inputs from the UTxO map that this transaction is
+  -- referencing, even if some of them cannot be spent by the transaction. For example
+  -- starting with Babbage era it will also include reference inputs.
   allInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
 
   certsTxBodyL :: Lens' (TxBody era) (StrictSeq (TxCert era))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -195,6 +195,7 @@ class
   -- spend, which ones will depend on the validity of the transaction itself. Starting in
   -- Alonzo this will include collateral inputs.
   spendableInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+  spendableInputsTxBodyF = allInputsTxBodyF
 
   -- | This getter will produce all inputs from the UTxO map that this transaction is
   -- referencing, even if some of them cannot be spent by the transaction. For example


### PR DESCRIPTION
# Description

This PR reflects a minor bump of packages needed for backport release of #3558 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
