### PR TITLE
Account for backport release

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.1.1
+
+*
+
+## 1.2.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.2.0.3
 
 *

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.0.3
+version:            1.2.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -52,7 +52,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-shelley >=1.3 && <1.5,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -14,6 +14,10 @@
   `Plutus` type instead of a `Language` and `ShortByteString`
 * Rename `pdSBS` field to `pdPlutusScript` in the `PlutusDebugLang` data type
 
+## 1.3.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.3.1.1
 
 *

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -67,7 +67,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.4 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4,
         cardano-slotting,

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.4.1.0
+## 1.4.2.0
 
 * Added `babbagePParamsHKDPairs`
+
+## 1.4.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
 
 ## 1.4.0.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.4.1.0
+version:            1.4.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -61,7 +61,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.4,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4,
         cardano-slotting,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,29 +2,36 @@
 
 ## 1.7.0.0
 
-* Make `Anchor` required in `ProposalProcedure`.
-* Removal of TxOuts with zero `Coin` from UTxO on translation
+* Add `ConwayPParams` #3498
+* Add `UpgradeConwayPParams` #3498
+* Add `ConwayEraPParams` #3498
+* Add `PoolVotingThresholds` #3498
+* Add `DRepVotingThresholds` #3498
 * Rename:
-    `cgTally` -> `cgGov`
-    `cgTallyL` -> `cgGovL`
-    `VDelFailure` -> `GovCertFailure`
-    `VDelEvent` -> `GovCertEvent`
-    `certVState` -> `certGState`
-    `ConwayVDelPredFailure` -> `ConwayGovCertPredFailure`
-    `ConwayTallyPredFailure` -> `ConwayGovPredFailure`
-    `TallyEnv` -> `GovEnv`
-    `ConwayTallyState` -> `ConwayGovState`
-    `TALLY` -> `GOV`
-    `VDEL` -> `GOVCERT`
+   * `cgTally` -> `cgGov`
+   * `cgTallyL` -> `cgGovL`
+   * `VDelFailure` -> `GovCertFailure`
+   * `VDelEvent` -> `GovCertEvent`
+   * `certVState` -> `certGState`
+   * `ConwayVDelPredFailure` -> `ConwayGovCertPredFailure`
+   * `ConwayTallyPredFailure` -> `ConwayGovPredFailure`
+   * `TallyEnv` -> `GovEnv`
+   * `ConwayTallyState` -> `ConwayGovState`
+   * `TALLY` -> `GOV`
+   * `VDEL` -> `GOVCERT`
+* Make `Anchor` required in `ProposalProcedure`.
+
+## 1.6.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
+## 1.6.1.0
+
+* Removal of TxOuts with zero `Coin` from UTxO on translation
 
 ## 1.6.0.0
 
 * Removal of `GovernanceProcedure` in favor of `GovernanceProcedures`
-* Add `ConwayPParams` #3498
-  * Add `UpgradeConwayPParams`
-  * Add `ConwayEraPParams`
-  * Add `PoolVotingThresholds`
-  * Add `DRepVotingThresholds`
 
 ## 1.5.0.0
 
@@ -39,7 +46,7 @@
   `gasStakePoolVotes` in `GovernanceActionState`
 * Removal of `reRoles` from `RatifyEnv` as no longer needed
 * Addition of `reStakePoolDistr` to `RatifyEnv`
-* Remove `VoterDoesNotHaveRole` as no longer needed from `ConwayGovPredFailure`
+* Remove `VoterDoesNotHaveRole` as no longer needed from `ConwayTallyPredFailure`
 * Added `ConwayEpochPredFailure`
 * Added instance for `Embed (ConwayRATIFY era) (ConwayEPOCH era)`
 * Removed instance for `Embed (ConwayRATIFY era) (ConwayNEWEPOCH era)`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -70,7 +70,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.4,
         cardano-ledger-babbage >=1.4.1,
-        cardano-ledger-core >=1.4 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4.1,
         cardano-slotting,

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.3.1.1
+
+*
+
+## 1.3.1.0
+
+* Add implementation for `spendableInputsTxBodyL`
+
 ## 1.3.0.2
 
 *

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.0.3
+version:            1.3.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -59,7 +59,7 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-shelley >=1.3 && <1.5,
         containers,
         deepseq,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.4.2.1
+
+*
+
+## 1.4.2.0
+
+* Add implementation for `spendableInputsTxBodyL`
+* Fix an issue with where `witsVKeyNeededNoGovernance` and `witsVKeyNeeded` required
+  witnesses for `allInputsTxL`, which affected reference inputs in Babbage.
+
 ## 1.4.1.0
 
 * Add `getConstitutionHash` to `EraGovernance` #3506

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.4.1.1
+version:            1.4.2.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -105,7 +105,7 @@ library
         cardano-data >=1.0,
         cardano-ledger-binary >=1.0,
         cardano-ledger-byron,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-slotting,
         vector-map >=1.0,
         containers,

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Rename `cgTallyL` to `cgGovL`
 * Rename `ConwayTallyState` to `ConwayGovState`
+
+## 1.3.1.0
+
 * Add `spendableInputsTxBodyL`
 
 ## 1.3.0.0

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -55,7 +55,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-conway >=1.5,
-        cardano-ledger-core >=1.3 && <1.6,
+        cardano-ledger-core >=1.4.1 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.4.1,
         cardano-slotting,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `Plutus`
 * Changed `Phase2Script` constructor of the `PhaseScript` type. It now accepts new
   `Plutus` type instead of `Language` and `ShortByteString`
+* Remove default implementation for `spendableInputsTxBodyL`
 
 ## 1.4.1.0
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added `Plutus`
 * Changed `Phase2Script` constructor of the `PhaseScript` type. It now accepts new
   `Plutus` type instead of `Language` and `ShortByteString`
+
+## 1.4.1.0
+
 * Add `spendableInputsTxBodyL`
 
 ## 1.4.0.0

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -194,7 +194,6 @@ class
   -- spend, which ones will depend on the validity of the transaction itself. Starting in
   -- Alonzo this will include collateral inputs.
   spendableInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
-  spendableInputsTxBodyF = allInputsTxBodyF
 
   -- | This getter will produce all inputs from the UTxO map that this transaction is
   -- referencing, even if some of them cannot be spent by the transaction. For example

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -194,6 +194,7 @@ class
   -- spend, which ones will depend on the validity of the transaction itself. Starting in
   -- Alonzo this will include collateral inputs.
   spendableInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
+  spendableInputsTxBodyF = allInputsTxBodyF
 
   -- | This getter will produce all inputs from the UTxO map that this transaction is
   -- referencing, even if some of them cannot be spent by the transaction. For example


### PR DESCRIPTION
# Description

Update changelogs, versions and bounds. This PR accounts for the backport fix implemented and released in #3560 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
