### PR TITLE
Fixed typo in byron ledger spec

### DIFF
--- a/eras/byron/ledger/formal-spec/crypto-primitives.tex
+++ b/eras/byron/ledger/formal-spec/crypto-primitives.tex
@@ -12,7 +12,7 @@ type suffix, and use simply $\serialised{\wcard}$.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \var{vk} & \SKey & \text{signing key}\\
+      \var{sk} & \SKey & \text{signing key}\\
       \var{vk} & \VKey & \text{verifying key}\\
       \var{hk} & \KeyHash & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\


### PR DESCRIPTION
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
