### PR TITLE
Rename CommitteeCert into a GovCert

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -40,6 +40,9 @@
 * Change `GovernanceActionDoesNotExist` to `GovernanceActionsDoNotExist`, which now
   reports all actions as a set, rather than one action per each individual failure.
 * Type of `gpVotingProcedures` in `GovernanceProcedures` was aslo changed to `GovernanceProcedures`
+* Rename:
+  * `ConwayCommitteeCert` -> `ConwayGovCert`
+  * `ConwayTxCertCommittee` -> `ConwayTxCertGov`
 
 ## 1.6.3.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayCERT, ConwayDELEG, ConwayGOVCERT, ConwayPOOL)
 import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure (..))
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
-import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert, ConwayDelegCert, ConwayTxCert (..))
+import Cardano.Ledger.Conway.TxCert (ConwayDelegCert, ConwayGovCert, ConwayTxCert (..))
 import Cardano.Ledger.Shelley.API (
   CertState (..),
   DState,
@@ -103,7 +103,7 @@ instance
   , Environment (EraRule "GOVCERT" era) ~ PParams era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
   , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
-  , Signal (EraRule "GOVCERT" era) ~ ConwayCommitteeCert (EraCrypto era)
+  , Signal (EraRule "GOVCERT" era) ~ ConwayGovCert (EraCrypto era)
   , Embed (EraRule "DELEG" era) (ConwayCERT era)
   , Embed (EraRule "POOL" era) (ConwayCERT era)
   , Embed (EraRule "GOVCERT" era) (ConwayCERT era)
@@ -130,7 +130,7 @@ certTransition ::
   , Environment (EraRule "GOVCERT" era) ~ PParams era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert (EraCrypto era)
   , Signal (EraRule "POOL" era) ~ PoolCert (EraCrypto era)
-  , Signal (EraRule "GOVCERT" era) ~ ConwayCommitteeCert (EraCrypto era)
+  , Signal (EraRule "GOVCERT" era) ~ ConwayGovCert (EraCrypto era)
   , Embed (EraRule "DELEG" era) (ConwayCERT era)
   , Embed (EraRule "POOL" era) (ConwayCERT era)
   , Embed (EraRule "GOVCERT" era) (ConwayCERT era)
@@ -147,7 +147,7 @@ certTransition = do
     ConwayTxCertPool poolCert -> do
       newPState <- trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState, poolCert)
       pure $ cState {certPState = newPState}
-    ConwayTxCertCommittee govCert -> do
+    ConwayTxCertGov govCert -> do
       newVState <- trans @(EraRule "GOVCERT" era) $ TRC (pp, certVState, govCert)
       pure $ cState {certVState = newVState}
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.CertState (VState (..))
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Era (ConwayGOVCERT)
-import Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert (..))
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..))
 import Cardano.Ledger.Core (Era (EraCrypto), EraPParams, EraRule, PParams)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto)
@@ -112,7 +112,7 @@ newtype ConwayGovCertEvent era = GovCertEvent (Event (EraRule "GOVCERT" era))
 instance
   ( EraPParams era
   , State (EraRule "GOVCERT" era) ~ VState era
-  , Signal (EraRule "GOVCERT" era) ~ ConwayCommitteeCert (EraCrypto era)
+  , Signal (EraRule "GOVCERT" era) ~ ConwayGovCert (EraCrypto era)
   , Environment (EraRule "GOVCERT" era) ~ PParams era
   , EraRule "GOVCERT" era ~ ConwayGOVCERT era
   , Eq (PredicateFailure (EraRule "GOVCERT" era))
@@ -121,7 +121,7 @@ instance
   STS (ConwayGOVCERT era)
   where
   type State (ConwayGOVCERT era) = VState era
-  type Signal (ConwayGOVCERT era) = ConwayCommitteeCert (EraCrypto era)
+  type Signal (ConwayGOVCERT era) = ConwayGovCert (EraCrypto era)
   type Environment (ConwayGOVCERT era) = PParams era
   type BaseM (ConwayGOVCERT era) = ShelleyBase
   type PredicateFailure (ConwayGOVCERT era) = ConwayGovCertPredFailure era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -69,10 +69,10 @@ instance Era era => Arbitrary (ConwayTxCert era) where
     oneof
       [ ConwayTxCertDeleg <$> arbitrary
       , ConwayTxCertPool <$> arbitrary
-      , ConwayTxCertCommittee <$> arbitrary
+      , ConwayTxCertGov <$> arbitrary
       ]
 
-instance Crypto c => Arbitrary (ConwayCommitteeCert c) where
+instance Crypto c => Arbitrary (ConwayGovCert c) where
   arbitrary =
     oneof
       [ ConwayRegDRep <$> arbitrary <*> arbitrary <*> arbitrary

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -48,8 +48,8 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Conway.TxCert (
-  ConwayCommitteeCert (..),
   ConwayDelegCert (..),
+  ConwayGovCert (..),
   ConwayTxCert (..),
   Delegatee (..),
  )
@@ -135,10 +135,10 @@ ppConwayTxCert :: ConwayTxCert era -> PDoc
 ppConwayTxCert = \case
   ConwayTxCertDeleg dc -> ppSexp "ConwayTxCertDeleg" [prettyA dc]
   ConwayTxCertPool pc -> ppSexp "ConwayTxCertPool" [ppPoolCert pc]
-  ConwayTxCertCommittee gdc -> ppSexp "ConwayTxCertCommittee" [ppConwayCommitteeCert gdc]
+  ConwayTxCertGov gdc -> ppSexp "ConwayTxCertGov" [ppConwayGovCert gdc]
 
-ppConwayCommitteeCert :: ConwayCommitteeCert c -> PDoc
-ppConwayCommitteeCert = \case
+ppConwayGovCert :: ConwayGovCert c -> PDoc
+ppConwayGovCert = \case
   ConwayRegDRep cred deposit mAnchor ->
     ppSexp "ConwayRegDRep" [prettyA cred, prettyA deposit, prettyA mAnchor]
   ConwayUnRegDRep cred deposit ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1463,7 +1463,7 @@ pcShelleyTxCert (ShelleyTxCertMir _) = ppString "MirCert"
 pcConwayTxCert :: ConwayTxCert c -> PDoc
 pcConwayTxCert (ConwayTxCertDeleg dc) = prettyA dc
 pcConwayTxCert (ConwayTxCertPool poolc) = pcPoolCert poolc
-pcConwayTxCert (ConwayTxCertCommittee _) = ppString "ConwayTxCertCommittee" -- TODO: @aniketd add pretty instance for the certs
+pcConwayTxCert (ConwayTxCertGov _) = ppString "ConwayTxCertGov" -- TODO: @aniketd add pretty instance for the certs
 
 instance c ~ EraCrypto era => PrettyC (ShelleyTxCert c) era where prettyC _ = pcShelleyTxCert
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -828,7 +828,7 @@ getConwayTxCertCredential (ConwayTxCertDeleg (ConwayRegCert _ _)) = Nothing
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayUnRegCert cred _)) = Just cred
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayDelegCert cred _)) = Just cred
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayRegDelegCert cred _ _)) = Just cred
-getConwayTxCertCredential (ConwayTxCertCommittee _) = Nothing
+getConwayTxCertCredential (ConwayTxCertGov _) = Nothing
 
 genWithdrawals :: Reflect era => SlotNo -> GenRS era (Withdrawals (EraCrypto era), RewardAccounts (EraCrypto era))
 genWithdrawals slot =


### PR DESCRIPTION
# Description

Fixes #3583 

This PR does the rename:
  * `ConwayCommitteeCert` -> `ConwayGovCert`
  * `ConwayTxCertCommittee` -> `ConwayTxCertGov`

As well as enforces witnesses for DRep unregistration certificates: both scripts and keys

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
