### PR TITLE
Remove `DelegStakeTxCert` from the `COMPLETE` pragma for `TxCert`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Rename:
   * `ConwayCommitteeCert` -> `ConwayGovCert`
   * `ConwayTxCertCommittee` -> `ConwayTxCertGov`
+* Remove `DelegStakeTxCert` from the `COMPLETE` pragma for `TxCert`
 
 ## 1.6.3.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
@@ -78,7 +78,7 @@ instance
 
     -- note that the genesis delegates are updated not only on the epoch boundary.
     if epoch /= nesEL nes + 1
-      then pure $ nes
+      then pure nes
       else do
         -- We can skip 'SNAP'; we already have the equivalent pd'.
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -73,7 +73,6 @@ import Cardano.Ledger.Shelley.TxCert (
   encodeShelleyDelegCert,
   poolTxCertDecoder,
   shelleyTxCertDelegDecoder,
-  pattern DelegStakeTxCert,
   pattern RegPoolTxCert,
   pattern RegTxCert,
   pattern RetirePoolTxCert,
@@ -268,7 +267,6 @@ pattern UnRegDRepTxCert cred deposit <- (getUnRegDRepTxCert -> Just (cred, depos
   , RetirePoolTxCert
   , RegTxCert
   , UnRegTxCert
-  , DelegStakeTxCert
   , RegDepositTxCert
   , UnRegDepositTxCert
   , DelegTxCert

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
@@ -39,7 +39,6 @@ module Cardano.Ledger.Api.Tx.Cert (
   --   `RetirePoolTxCert`
   --   `RegTxCert`
   --   `UnRegTxCert`
-  --   `DelegStakeTxCert`
   --   `RegDepositTxCert`
   --   `UnRegDepositTxCert`
   --   `DelegTxCert`


### PR DESCRIPTION
# Description

It is not necessary for Conway, since it is already taken care of by `DelegTxCert (DelegStake poolId)`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
