### PR TITLE
Conway txinfo

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Deprecated `transStakeCred` in favor of `transCred`
 * Rename `transShelleyTxCert` to `alonzoTransTxCert`
 * Change type of `Plutus` to use `BinaryPlutus` instead of `ShortByteString`
 * Deprecate `runPLCScript` in favor of `runPlutusScript`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Rename `transShelleyTxCert` to `alonzoTransTxCert`
 * Change type of `Plutus` to use `BinaryPlutus` instead of `ShortByteString`
 * Deprecate `runPLCScript` in favor of `runPlutusScript`
 * Addition of `PlutusWithContext`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -85,7 +85,7 @@ where
 -- =============================================
 
 import Cardano.Crypto.Hash.Class (Hash, hashToBytes)
-import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
+import Cardano.Ledger.Address (Addr (..), RewardAcnt (..), Withdrawals (..))
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts (
@@ -131,6 +131,7 @@ import Cardano.Ledger.Credential (
  )
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..), hashKey)
+import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
 import Cardano.Ledger.Language (
   BinaryPlutus (..),
   IsLanguage (..),
@@ -141,9 +142,9 @@ import Cardano.Ledger.Language (
   withSLanguage,
  )
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
+import Cardano.Ledger.PoolParams (PoolParams (..))
 import Cardano.Ledger.SafeHash (SafeHash, extractHash, hashAnnotated)
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
-import Cardano.Ledger.Shelley.TxBody (PoolParams (..), WitVKey (..), Withdrawals (..))
 import Cardano.Ledger.Shelley.TxCert
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UTxO (UTxO (..))
@@ -420,7 +421,7 @@ transValue (MaryValue n m) = justAda <> transMultiAsset m
     justAda = PV1.singleton PV1.adaSymbol PV1.adaToken n
 
 -- =============================================
--- translate fileds like TxCert, Withdrawals, and similar
+-- translate fields like TxCert, Withdrawals, and similar
 
 data PlutusTxCert (l :: Language) where
   TxCertPlutusV1 :: PV1.DCert -> PlutusTxCert 'PlutusV1
@@ -436,7 +437,7 @@ unTxCertV2 (TxCertPlutusV2 x) = x
 unTxCertV3 :: PlutusTxCert 'PlutusV3 -> PV3.DCert
 unTxCertV3 (TxCertPlutusV3 x) = x
 
-class EraTxCert era => EraPlutusContext (l :: Language) era where
+class Era era => EraPlutusContext (l :: Language) era where
   transTxCert :: TxCert era -> PlutusTxCert l
 
 instance Crypto c => EraPlutusContext 'PlutusV1 (AlonzoEra c) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Alonzo.TxInfo (
   TranslationError (..),
   TxOutSource (..),
   VersionedTxInfo (..),
-  transShelleyTxCert,
+  alonzoTransTxCert,
   unTxCertV1,
   unTxCertV2,
  )
@@ -177,10 +177,10 @@ transRedeemerPtr txb (ptr, (d, _)) =
     SJust sp -> Right (Alonzo.transScriptPurpose sp, transRedeemer d)
 
 instance Crypto c => EraPlutusContext 'PlutusV1 (BabbageEra c) where
-  transTxCert = TxCertPlutusV1 . transShelleyTxCert
+  transTxCert = TxCertPlutusV1 . alonzoTransTxCert
 
 instance Crypto c => EraPlutusContext 'PlutusV2 (BabbageEra c) where
-  transTxCert = TxCertPlutusV2 . transShelleyTxCert
+  transTxCert = TxCertPlutusV2 . alonzoTransTxCert
 
 babbageTxInfo ::
   forall era.
@@ -205,7 +205,7 @@ babbageTxInfo pp lang ei sysS utxo tx = do
     PlutusV2 -> babbageTxInfoV2 timeRange tx utxo
     _ -> Left $ LanguageNotSupported lang
   where
-    interval = tx ^. bodyTxL ^. vldtTxBodyL
+    interval = tx ^. bodyTxL . vldtTxBodyL
 
 babbageTxInfoV1 ::
   forall era.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7.0.0
 
+* Switch GovernanceActionIx to `Word32` fro `Word64` and remove `Num` and `Enum`
+  instances, which are dangerous due to potential overflows.
 * Add `currentTreasuryValue :: !(StrictMaybe Coin)` as a new field to Conway TxBody #3586
 * Add an optional Anchor to the Conway DRep registration certificate #3576
 * Change `ConwayCommitteeCert` to allow:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -75,19 +75,17 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Sequence (Seq (..))
 import Data.Set (Set)
 import qualified Data.Text as Text
-import Data.Word (Word64)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens)
 import NoThunks.Class (NoThunks)
 
-newtype GovernanceActionIx = GovernanceActionIx Word64
+newtype GovernanceActionIx = GovernanceActionIx Word32
   deriving
     ( Generic
     , Eq
     , Ord
     , Show
-    , Num
-    , Enum
     , NFData
     , NoThunks
     , EncCBOR
@@ -302,7 +300,7 @@ indexedGovProps ::
 indexedGovProps = enumerateProps 0
   where
     enumerateProps _ Empty = Empty
-    enumerateProps !n (x :<| xs) = (n, x) :<| enumerateProps (succ n) xs
+    enumerateProps !n (x :<| xs) = (GovernanceActionIx n, x) :<| enumerateProps (succ n) xs
 
 instance EraPParams era => NoThunks (GovernanceProcedures era)
 

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-shelley-test`
 
-## 1.2.0.2
+## 1.2.0.3
 
 *
+
+## 1.2.0.2
+
+* GHC-9.6 compatibility
 
 ## 1.2.0.1
 

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,18 +1,20 @@
-cabal-version: 3.0
-name:          cardano-ledger-shelley-test
-version:       1.2.0.2
-license:       Apache-2.0
-maintainer:    operations@iohk.io
-author:        IOHK
+cabal-version:      3.0
+name:               cardano-ledger-shelley-test
+version:            1.2.0.2
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
 synopsis:
     Test helpers from cardano-ledger-shelley exposed to other packages
 
-build-type:    Simple
+build-type:         Simple
 data-files:
     cddl-files/shelley.cddl
     cddl-files/real/crypto.cddl
     cddl-files/mock/extras.cddl
     test/Golden/ShelleyGenesis
+
+extra-source-files: CHANGELOG.md
 
 source-repository head
     type:     git

--- a/libs/small-steps-test/CHANGELOG.md
+++ b/libs/small-steps-test/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Version history for `small-steps-test-test`
+
+## 1.2.0.3
+
+*
+
+## 1.2.0.2
+
+* GHC-9.6 ompatibility
+
+## 1.0.0.0
+
+*
+
+## 0.1.1.2
+
+*
+
+## 0.1.1.1
+
+*
+
+## 0.1.0.0
+
+* Initial release

--- a/libs/small-steps-test/small-steps-test.cabal
+++ b/libs/small-steps-test/small-steps-test.cabal
@@ -1,13 +1,14 @@
-cabal-version: 3.0
-name:          small-steps-test
-version:       1.0.0.1
-license:       Apache-2.0
-maintainer:    operations@iohk.io
-author:        IOHK
-homepage:      https://github.com/input-output-hk/cardano-ledger
-synopsis:      Small step semantics testing library
-category:      Control
-build-type:    Simple
+cabal-version:      3.0
+name:               small-steps-test
+version:            1.0.0.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:           Small step semantics testing library
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
 
 source-repository head
     type:     git


### PR DESCRIPTION
# Description

This PR provides a collection of minor, but valuable improvements:

* Translate all pre-conway features, thus making some parts of PlutusV3 usable
* Switch GovernanceActionIx to `Word32` fro `Word64` and remove `Num` and `Enum` instances, which are dangerous due to potential overflows.
* Deprecate `transStakeCred`, which is identical to `transCred`
* Account for patch release of two packages: https://github.com/input-output-hk/cardano-haskell-packages/pull/418 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
