### PR TITLE
Add `ConwayUpdateDRep` constructor to ConwayTxCertGov type

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -48,6 +48,7 @@
   * `ConwayTxCertCommittee` -> `ConwayTxCertGov`
 * Remove `DelegStakeTxCert` from the `COMPLETE` pragma for `TxCert`
 * Add `Committee` and adjust `NewCommittee` governance action
+* Add `ConwayUpdateDRep` constructor to `ConwayGovCert` type and corresponding pattern `UnRegDRepTxCert`
 
 ## 1.6.3.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -152,6 +152,9 @@ conwayGovCertTransition = do
     ConwayResignCommitteeColdKey coldK -> do
       checkColdKeyHasNotResigned coldK vsCommitteeHotKeys
       pure $ vState {vsCommitteeHotKeys = Map.insert coldK Nothing vsCommitteeHotKeys}
+    ConwayUpdateDRep cred _mAnchor -> do
+      Set.notMember cred vsDReps ?! ConwayDRepNotRegistered cred
+      pure vState -- TODO: update anchor
   where
     checkColdKeyHasNotResigned coldK vsCommitteeHotKeys =
       ((isNothing <$> Map.lookup coldK vsCommitteeHotKeys) /= Just True)

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -282,6 +282,7 @@ certificate =
   // unreg_committee_hot_key_cert
   // reg_drep_cert
   // unreg_drep_cert
+  // update_drep_cert
   ]
 
 stake_registration = (0, stake_credential)
@@ -309,6 +310,7 @@ reg_committee_hot_key_cert = (14, committee_cold_keyhash, committee_hot_keyhash)
 unreg_committee_hot_key_cert = (15, committee_cold_keyhash)
 reg_drep_cert = (16, voting_credential, coin, anchor / null)
 unreg_drep_cert = (17, voting_credential, coin)
+update_drep_cert = (18, voting_credential, anchor / null)
 
 
 delta_coin = int

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -144,6 +144,8 @@ ppConwayGovCert = \case
     ppSexp "ConwayRegDRep" [prettyA cred, prettyA deposit, prettyA mAnchor]
   ConwayUnRegDRep cred deposit ->
     ppSexp "ConwayUnRegDRep" [prettyA cred, prettyA deposit]
+  ConwayUpdateDRep cred mAnchor ->
+    ppSexp "ConwayUpdateDRep" [prettyA cred, prettyA mAnchor]
   ConwayAuthCommitteeHotKey coldKey hotKey ->
     ppSexp "ConwayAuthCommitteeHotKey" [prettyA coldKey, prettyA hotKey]
   ConwayResignCommitteeColdKey coldKey ->


### PR DESCRIPTION
and corresponding pattern `UpdateDRepTxCert`

Closes https://github.com/input-output-hk/cardano-ledger/issues/3589

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
