### PR TITLE
Upgradeable families

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -52,7 +52,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.4.1 && <1.6,
+        cardano-ledger-core >=1.5 && <1.6,
         cardano-ledger-shelley >=1.5 && <1.6,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -84,3 +84,20 @@ library testlib
         cardano-strict-containers,
         generic-random,
         QuickCheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Allegra.BinarySpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-allegra,
+        testlib

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Allegra.Era (
@@ -25,6 +24,8 @@ instance Crypto c => Era (AllegraEra c) where
   type PreviousEra (AllegraEra c) = ShelleyEra c
   type EraCrypto (AllegraEra c) = c
   type ProtVerLow (AllegraEra c) = 3
+
+  eraName = "Allegra"
 
 --------------------------------------------------------------------------------
 -- Core instances

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -40,7 +40,6 @@ module Cardano.Ledger.Allegra.Scripts (
 )
 where
 
-import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Crypto.Hash.Class (HashAlgorithm)
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
@@ -75,6 +74,7 @@ import Cardano.Ledger.MemoBytes (
 import Cardano.Ledger.SafeHash (SafeToHash)
 import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.DeepSeq (NFData (..))
 import Data.ByteString.Lazy (fromStrict)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -40,6 +40,7 @@ module Cardano.Ledger.Allegra.Scripts (
 )
 where
 
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Crypto.Hash.Class (HashAlgorithm)
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
@@ -91,6 +92,8 @@ data ValidityInterval = ValidityInterval
   }
   deriving (Ord, Eq, Generic, Show, NoThunks, NFData)
 
+instance ToExpr ValidityInterval
+
 encodeVI :: ValidityInterval -> Encode ('Closed 'Dense) ValidityInterval
 encodeVI (ValidityInterval f t) = Rec ValidityInterval !> To f !> To t
 
@@ -118,6 +121,8 @@ data TimelockRaw era
 deriving instance Era era => NoThunks (TimelockRaw era)
 
 deriving instance HashAlgorithm (HASH (EraCrypto era)) => Show (TimelockRaw era)
+
+instance ToExpr (TimelockRaw era)
 
 -- | This function deconstructs and then reconstructs the timelock script
 -- to prove the compiler that we can arbirarily switch out the eras as long
@@ -179,6 +184,8 @@ newtype Timelock era = TimelockConstr (MemoBytes TimelockRaw era)
   deriving newtype (ToCBOR, NoThunks, NFData, SafeToHash)
 
 instance Era era => EncCBOR (Timelock era)
+
+instance ToExpr (Timelock era)
 
 instance Memoized Timelock where
   type RawType Timelock = TimelockRaw

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -107,8 +107,7 @@ instance Crypto c => TranslateEra (AllegraEra c) ShelleyGovState where
         }
 
 instance Crypto c => TranslateEra (AllegraEra c) ShelleyTxOut where
-  translateEra () (TxOutCompact addr cfval) =
-    pure $ TxOutCompact (coerce addr) cfval
+  translateEra () = pure . upgradeTxOut
 
 instance Crypto c => TranslateEra (AllegraEra c) UTxO where
   translateEra ctxt utxo =

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash, hashAnnotated)
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum, ShelleyTxAuxData (..), validMetadatum)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Codec.CBOR.Decoding (
   TokenType (
     TypeListLen,
@@ -84,6 +85,8 @@ data AllegraTxAuxDataRaw era = AllegraTxAuxDataRaw
   -- - Pool reward account registrations
   }
   deriving (Generic, Eq)
+
+instance ToExpr (AllegraTxAuxDataRaw era)
 
 instance Crypto c => EraTxAuxData (AllegraEra c) where
   type TxAuxData (AllegraEra c) = AllegraTxAuxData (AllegraEra c)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -38,9 +38,8 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Core (
   Era (..),
-  EraTxAuxData (hashTxAuxData, validateTxAuxData),
+  EraTxAuxData (..),
  )
-import qualified Cardano.Ledger.Core as Core (TxAuxData)
 import Cardano.Ledger.Crypto (Crypto (HASH))
 import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
 import Cardano.Ledger.MemoBytes (
@@ -53,7 +52,7 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
  )
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash, hashAnnotated)
-import Cardano.Ledger.Shelley.TxAuxData (Metadatum, validMetadatum)
+import Cardano.Ledger.Shelley.TxAuxData (Metadatum, ShelleyTxAuxData (..), validMetadatum)
 import Codec.CBOR.Decoding (
   TokenType (
     TypeListLen,
@@ -88,7 +87,11 @@ data AllegraTxAuxDataRaw era = AllegraTxAuxDataRaw
 
 instance Crypto c => EraTxAuxData (AllegraEra c) where
   type TxAuxData (AllegraEra c) = AllegraTxAuxData (AllegraEra c)
+
+  upgradeTxAuxData (ShelleyTxAuxData md) = AllegraTxAuxData md mempty
+
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
+
   hashTxAuxData aux = AuxiliaryDataHash (hashAnnotated aux)
 
 deriving instance HashAlgorithm (HASH (EraCrypto era)) => Show (AllegraTxAuxDataRaw era)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
@@ -12,6 +12,8 @@ instance Crypto c => EraTxCert (AllegraEra c) where
 
   type TxCert (AllegraEra c) = ShelleyTxCert (AllegraEra c)
 
+  upgradeTxCert = Right . upgradeShelleyTxCert
+
   getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
 
   getScriptWitnessTxCert = getScriptWitnessShelleyTxCert

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxOut.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxOut.hs
@@ -13,7 +13,8 @@ import Cardano.Ledger.Shelley.TxBody (
   addrEitherShelleyTxOutL,
   valueEitherShelleyTxOutL,
  )
-import Lens.Micro
+import Data.Coerce (coerce)
+import Lens.Micro ((^.))
 
 instance Crypto c => EraTxOut (AllegraEra c) where
   {-# SPECIALIZE instance EraTxOut (AllegraEra StandardCrypto) #-}
@@ -21,6 +22,8 @@ instance Crypto c => EraTxOut (AllegraEra c) where
   type TxOut (AllegraEra c) = ShelleyTxOut (AllegraEra c)
 
   mkBasicTxOut = ShelleyTxOut
+
+  upgradeTxOut (TxOutCompact addr cfval) = TxOutCompact (coerce addr) cfval
 
   addrEitherTxOutL = addrEitherShelleyTxOutL
   {-# INLINE addrEitherTxOutL #-}

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Allegra" $ do
+      BinarySpec.spec

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Common
 
 main :: IO ()
 main =

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -3,8 +3,8 @@
 module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra
-import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Cardano.Ledger.Allegra.TxAuxData
+import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
 

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
+
+import Cardano.Ledger.Allegra
+import Test.Cardano.Ledger.Allegra.Arbitrary ()
+import Cardano.Ledger.Allegra.TxAuxData
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+
+spec :: Spec
+spec = specUpgrade @Allegra @AllegraTxAuxData True

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.0.0
 
-* Add `translateAlonzoScript` and `translateDatum`
+* Add `translateAlonzoTxAuxData`, `translateAlonzoScript` and `translateDatum`
 * Deprecated `translateTxOut` in favor of `upgradeTxOut`
 * Deprecated `transStakeCred` in favor of `transCred`
 * Rename `transShelleyTxCert` to `alonzoTransTxCert`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0.0
 
+* Add `translateAlonzoScript` and `translateDatum`
+* Deprecated `translateTxOut` in favor of `upgradeTxOut`
 * Deprecated `transStakeCred` in favor of `transCred`
 * Rename `transShelleyTxCert` to `alonzoTransTxCert`
 * Change type of `Plutus` to use `BinaryPlutus` instead of `ShortByteString`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -119,3 +119,21 @@ library testlib
         plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
         plutus-core,
         text
+
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Alonzo.BinarySpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-alonzo,
+        testlib

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -67,7 +67,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.4.1 && <1.6,
+        cardano-ledger-core >=1.5 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.5,
         cardano-slotting,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -120,7 +120,6 @@ library testlib
         plutus-core,
         text
 
-
 test-suite tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -27,6 +27,8 @@ instance Crypto c => Era (AlonzoEra c) where
   type ProtVerLow (AlonzoEra c) = 5
   type ProtVerHigh (AlonzoEra c) = 6
 
+  eraName = "Alonzo"
+
 type instance Value (AlonzoEra c) = MaryValue c
 
 -------------------------------------------------------------------------------

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -166,6 +166,8 @@ instance NoThunks Tag
 instance NFData Tag where
   rnf = rwhnf
 
+instance ToExpr Tag
+
 -- =======================================================
 
 -- | Scripts in the Alonzo Era, Either a Timelock script or a Plutus script.
@@ -173,6 +175,8 @@ data AlonzoScript era
   = TimelockScript !(Timelock era)
   | PlutusScript !Plutus
   deriving (Eq, Generic, NoThunks)
+
+instance ToExpr (AlonzoScript era)
 
 translateAlonzoScript ::
   (Era era1, Era era2, EraCrypto era1 ~ EraCrypto era2) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
@@ -233,7 +233,7 @@ datumDataHash = \case
   Datum bd -> SJust (hashBinaryData bd)
 
 translateDatum ::
-  (EraCrypto era1 ~ EraCrypto era2) =>
+  EraCrypto era1 ~ EraCrypto era2 =>
   Datum era1 ->
   Datum era2
 translateDatum = \case

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
@@ -33,6 +33,7 @@ module Cardano.Ledger.Alonzo.Scripts.Data (
   dataToBinaryData,
   Datum (..),
   datumDataHash,
+  translateDatum,
 )
 where
 
@@ -75,6 +76,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON (..), Value (Null))
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
+import Data.Coerce
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
@@ -229,3 +231,12 @@ datumDataHash = \case
   NoDatum -> SNothing
   DatumHash dh -> SJust dh
   Datum bd -> SJust (hashBinaryData bd)
+
+translateDatum ::
+  (EraCrypto era1 ~ EraCrypto era2) =>
+  Datum era1 ->
+  Datum era2
+translateDatum = \case
+  NoDatum -> NoDatum
+  DatumHash dh -> DatumHash dh
+  Datum bd -> Datum (coerce bd)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -14,10 +14,9 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.PParams ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.CertState (PState (..), VState (..))
-import Cardano.Ledger.Core (upgradePParams, upgradePParamsUpdate)
+import Cardano.Ledger.Core (upgradePParams, upgradePParamsUpdate, upgradeTxOut)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Era (
@@ -36,7 +35,6 @@ import Cardano.Ledger.Shelley.API (
  )
 import qualified Cardano.Ledger.Shelley.API as API
 import qualified Cardano.Ledger.Shelley.Tx as LTX
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 
@@ -163,4 +161,5 @@ translateTxOut ::
   Crypto c =>
   Core.TxOut (MaryEra c) ->
   Core.TxOut (AlonzoEra c)
-translateTxOut (Shelley.TxOutCompact addr value) = TxOutCompact addr value
+translateTxOut = upgradeTxOut
+{-# DEPRECATED translateTxOut "Use `upgradeTxOut` instead" #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.SafeHash (
   hashAnnotated,
  )
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum, validMetadatum)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData, deepseq)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -103,6 +104,8 @@ deriving via
   InspectHeapNamed "AlonzoTxAuxDataRaw" (AlonzoTxAuxDataRaw era)
   instance
     NoThunks (AlonzoTxAuxDataRaw era)
+
+instance ToExpr (AlonzoTxAuxDataRaw era)
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (AlonzoTxAuxData era)
@@ -226,10 +229,13 @@ emptyAuxData = AlonzoTxAuxDataRaw mempty mempty mempty
 -- Version with serialized bytes.
 
 newtype AlonzoTxAuxData era = AuxiliaryDataConstr (MemoBytes AlonzoTxAuxDataRaw era)
+  deriving (Generic)
   deriving newtype (ToCBOR, SafeToHash)
 
 instance Memoized AlonzoTxAuxData where
   type RawType AlonzoTxAuxData = AlonzoTxAuxDataRaw
+
+instance ToExpr (AlonzoTxAuxData era)
 
 type AuxiliaryData era = AlonzoTxAuxData era
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
@@ -12,6 +12,8 @@ instance Crypto c => EraTxCert (AlonzoEra c) where
 
   type TxCert (AlonzoEra c) = ShelleyTxCert (AlonzoEra c)
 
+  upgradeTxCert = Right . upgradeShelleyTxCert
+
   getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
 
   getScriptWitnessTxCert = getScriptWitnessShelleyTxCert

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -78,6 +78,7 @@ import Cardano.Ledger.SafeHash (
   extractHash,
   unsafeMakeSafeHash,
  )
+import qualified Cardano.Ledger.Shelley.TxOut as Shelley
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Control.Monad (guard, (<$!>))
@@ -299,6 +300,8 @@ instance Crypto c => EraTxOut (AlonzoEra c) where
   type TxOut (AlonzoEra c) = AlonzoTxOut (AlonzoEra c)
 
   mkBasicTxOut addr vl = AlonzoTxOut addr vl SNothing
+
+  upgradeTxOut (Shelley.TxOutCompact addr value) = TxOutCompact addr value
 
   addrEitherTxOutL =
     lens

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Alonzo" $ do
+      BinarySpec.spec

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Common
 
 main :: IO ()
 main =

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.BinarySpec (spec) where
+
+import Cardano.Ledger.Alonzo
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+
+spec :: Spec
+spec =
+  -- Scripts are not upgradeable from Mary through their CBOR instances, since Mary had no
+  -- concept of a prefix.
+  specUpgrade @Alonzo @AlonzoTxAuxData False

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.3.0
 
+* Deprecate `translateTxOut`
 * Added `babbagePParamsHKDPairs`
 
 ## 1.4.2.0

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -61,7 +61,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.4,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.4.1 && <1.6,
+        cardano-ledger-core >=1.5 && <1.6,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.5,
         cardano-slotting,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -39,6 +39,7 @@ library
     hs-source-dirs:   src
     other-modules:
         Cardano.Ledger.Babbage.Era
+        Cardano.Ledger.Babbage.TxAuxData
         Cardano.Ledger.Babbage.TxCert
         Cardano.Ledger.Babbage.Rules.Utxow
         Cardano.Ledger.Babbage.Rules.Utxo

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -96,3 +96,20 @@ library testlib
         cardano-ledger-core,
         small-steps,
         QuickCheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Babbage.BinarySpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-babbage,
+        testlib

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Babbage.Tx (
   babbageTxScripts,
   getDatumBabbage,
  )
+import Cardano.Ledger.Babbage.TxAuxData ()
 import Cardano.Ledger.Babbage.TxBody (
   BabbageTxBody,
   BabbageTxOut,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
@@ -38,6 +38,8 @@ instance Crypto c => Era (BabbageEra c) where
   type ProtVerLow (BabbageEra c) = 7
   type ProtVerHigh (BabbageEra c) = 8
 
+  eraName = "Babbage"
+
 type instance Value (BabbageEra c) = MaryValue c
 
 -------------------------------------------------------------------------------

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -21,11 +21,6 @@ where
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), translateAlonzoScript)
-import Cardano.Ledger.Alonzo.TxAuxData (
-  AlonzoTxAuxData,
-  hashAlonzoTxAuxData,
-  validateAlonzoTxAuxData,
- )
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
@@ -62,8 +57,3 @@ isPlutusScript x =
   case phaseScript @era PhaseTwoRep x of
     Just _ -> True
     Nothing -> False
-
-instance Crypto c => EraTxAuxData (BabbageEra c) where
-  type TxAuxData (BabbageEra c) = AlonzoTxAuxData (BabbageEra c)
-  hashTxAuxData = hashAlonzoTxAuxData
-  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -20,7 +20,7 @@ where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), translateAlonzoScript)
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData,
   hashAlonzoTxAuxData,
@@ -28,7 +28,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (
  )
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
@@ -46,9 +46,13 @@ type instance SomeScript 'PhaseOne (BabbageEra c) = Timelock (BabbageEra c)
 
 type instance SomeScript 'PhaseTwo (BabbageEra c) = (Language, ShortByteString)
 
-instance CC.Crypto c => EraScript (BabbageEra c) where
+instance Crypto c => EraScript (BabbageEra c) where
   type Script (BabbageEra c) = AlonzoScript (BabbageEra c)
+
+  upgradeScript = translateAlonzoScript
+
   scriptPrefixTag = babbageScriptPrefixTag
+
   phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
   phaseScript PhaseTwoRep (PlutusScript plutus) = Just (Phase2Script plutus)
   phaseScript _ _ = Nothing
@@ -59,7 +63,7 @@ isPlutusScript x =
     Just _ -> True
     Nothing -> False
 
-instance CC.Crypto c => EraTxAuxData (BabbageEra c) where
+instance Crypto c => EraTxAuxData (BabbageEra c) where
   type TxAuxData (BabbageEra c) = AlonzoTxAuxData (BabbageEra c)
   hashTxAuxData = hashAlonzoTxAuxData
   validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -14,12 +14,10 @@ module Cardano.Ledger.Babbage.Translation where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Babbage.Core hiding (Tx)
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams ()
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), Datum (..))
 import Cardano.Ledger.Binary (DecoderError)
 import qualified Cardano.Ledger.Core as Core (Tx)
 import Cardano.Ledger.Crypto (Crypto)
@@ -161,8 +159,5 @@ translateTxOut ::
   Crypto c =>
   TxOut (AlonzoEra c) ->
   TxOut (BabbageEra c)
-translateTxOut (AlonzoTxOut addr value dh) = BabbageTxOut addr value d SNothing
-  where
-    d = case dh of
-      SNothing -> NoDatum
-      SJust d' -> DatumHash d'
+translateTxOut = upgradeTxOut
+{-# DEPRECATED translateTxOut "Use `upgradeTxOut` instead" #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   unTxDats,
  )
 import Cardano.Ledger.Babbage.Era (BabbageEra)
+import Cardano.Ledger.Babbage.TxAuxData ()
 import Cardano.Ledger.Babbage.TxBody (
   BabbageEraTxBody (..),
   BabbageEraTxOut (..),
@@ -33,7 +34,7 @@ import Cardano.Ledger.Babbage.TxBody (
  )
 import Cardano.Ledger.Babbage.TxWits ()
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Control.Applicative ((<|>))
@@ -44,8 +45,8 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro
 
-instance CC.Crypto c => EraTx (BabbageEra c) where
-  {-# SPECIALIZE instance EraTx (BabbageEra CC.StandardCrypto) #-}
+instance Crypto c => EraTx (BabbageEra c) where
+  {-# SPECIALIZE instance EraTx (BabbageEra StandardCrypto) #-}
 
   type Tx (BabbageEra c) = AlonzoTx (BabbageEra c)
 
@@ -68,13 +69,13 @@ instance CC.Crypto c => EraTx (BabbageEra c) where
 
   getMinFeeTx = alonzoMinFeeTx
 
-instance CC.Crypto c => AlonzoEraTx (BabbageEra c) where
-  {-# SPECIALIZE instance AlonzoEraTx (BabbageEra CC.StandardCrypto) #-}
+instance Crypto c => AlonzoEraTx (BabbageEra c) where
+  {-# SPECIALIZE instance AlonzoEraTx (BabbageEra StandardCrypto) #-}
 
   isValidTxL = isValidAlonzoTxL
   {-# INLINE isValidTxL #-}
 
-instance CC.Crypto c => EraSegWits (BabbageEra c) where
+instance Crypto c => EraSegWits (BabbageEra c) where
   type TxSeq (BabbageEra c) = AlonzoTxSeq (BabbageEra c)
   fromTxSeq = txSeqTxns
   toTxSeq = AlonzoTxSeq

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Ledger.Babbage.TxAuxData () where
+
+import Cardano.Ledger.Alonzo.TxAuxData (
+  AlonzoTxAuxData,
+  hashAlonzoTxAuxData,
+  validateAlonzoTxAuxData,
+  translateAlonzoTxAuxData
+ )
+import Cardano.Ledger.Babbage.Era
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto
+
+instance Crypto c => EraTxAuxData (BabbageEra c) where
+  type TxAuxData (BabbageEra c) = AlonzoTxAuxData (BabbageEra c)
+
+  upgradeTxAuxData = translateAlonzoTxAuxData
+
+  hashTxAuxData = hashAlonzoTxAuxData
+
+  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+
 module Cardano.Ledger.Babbage.TxAuxData () where
 
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData,
   hashAlonzoTxAuxData,
+  translateAlonzoTxAuxData,
   validateAlonzoTxAuxData,
-  translateAlonzoTxAuxData
  )
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Core

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
@@ -12,6 +12,8 @@ instance Crypto c => EraTxCert (BabbageEra c) where
 
   type TxCert (BabbageEra c) = ShelleyTxCert (BabbageEra c)
 
+  upgradeTxCert = Right . upgradeShelleyTxCert
+
   getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
 
   getScriptWitnessTxCert = getScriptWitnessShelleyTxCert

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Alonzo.Scripts.Data (
  )
 import Cardano.Ledger.Alonzo.TxBody (
   Addr28Extra,
+  AlonzoTxOut (AlonzoTxOut),
   DataHash32,
   decodeAddress28,
   decodeDataHash32,
@@ -152,6 +153,12 @@ instance Crypto c => EraTxOut (BabbageEra c) where
   type TxOut (BabbageEra c) = BabbageTxOut (BabbageEra c)
 
   mkBasicTxOut addr vl = BabbageTxOut addr vl NoDatum SNothing
+
+  upgradeTxOut (AlonzoTxOut addr value mDatumHash) = BabbageTxOut addr value datum SNothing
+    where
+      datum = case mDatumHash of
+        SNothing -> NoDatum
+        SJust datumHash -> DatumHash datumHash
 
   addrEitherTxOutL = addrEitherBabbageTxOutL
   {-# INLINE addrEitherTxOutL #-}

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Common
 
 main :: IO ()
 main =

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Babbage" $ do
+      BinarySpec.spec

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Babbage.BinarySpec (spec) where
+
+import Cardano.Ledger.Babbage
+import Test.Cardano.Ledger.Babbage.Arbitrary ()
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+
+spec :: Spec
+spec = specUpgrade @Babbage @AlonzoTxAuxData True

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Add `MalformedProposal` to `ConwayGovPredFailure`
 * Add `ppuWellFormed` to `ConwayEraPParams`
 * Filter out zero valued `TxOut`'s on Byron/Shelley boundary instead of on Babbage/Conway.
+* Deprecate `translateTxOut` in favor of `upgradeTxOut`
+* Deprecate `translateScript` in favor of `upgradeScript`
 * Switch GovernanceActionIx to `Word32` fro `Word64` and remove `Num` and `Enum`
   instances, which are dangerous due to potential overflows.
 * Add `currentTreasuryValue :: !(StrictMaybe Coin)` as a new field to Conway TxBody #3586

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -108,7 +108,6 @@ library testlib
         cardano-ledger-conway,
         small-steps
 
-
 test-suite tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -107,3 +107,22 @@ library testlib
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-conway,
         small-steps
+
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Conway.BinarySpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-alonzo,
+        cardano-ledger-conway,
+        testlib

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -54,6 +54,7 @@ library
         Cardano.Ledger.Conway.Rules.Tickf
         Cardano.Ledger.Conway.Rules.Utxos
         Cardano.Ledger.Conway.Rules.Utxow
+        Cardano.Ledger.Conway.TxAuxData
 
     default-language: Haskell2010
     ghc-options:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -42,6 +42,8 @@ instance Crypto c => Era (ConwayEra c) where
   type EraCrypto (ConwayEra c) = c
   type ProtVerLow (ConwayEra c) = 9
 
+  eraName = "Conway"
+
 type instance Value (ConwayEra c) = MaryValue c
 
 -------------------------------------------------------------------------------

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -15,11 +15,6 @@ where
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language (Language)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript, translateAlonzoScript)
-import Cardano.Ledger.Alonzo.TxAuxData (
-  AlonzoTxAuxData,
-  hashAlonzoTxAuxData,
-  validateAlonzoTxAuxData,
- )
 import Cardano.Ledger.Babbage.Scripts (babbageScriptPrefixTag)
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core
@@ -40,8 +35,3 @@ instance Crypto c => EraScript (ConwayEra c) where
   phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
   phaseScript PhaseTwoRep (PlutusScript plutus) = Just (Phase2Script plutus)
   phaseScript _ _ = Nothing
-
-instance Crypto c => EraTxAuxData (ConwayEra c) where
-  type TxAuxData (ConwayEra c) = AlonzoTxAuxData (ConwayEra c)
-  hashTxAuxData = hashAlonzoTxAuxData
-  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -14,7 +14,7 @@ where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language (Language)
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript, translateAlonzoScript)
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData,
   hashAlonzoTxAuxData,
@@ -23,21 +23,25 @@ import Cardano.Ledger.Alonzo.TxAuxData (
 import Cardano.Ledger.Babbage.Scripts (babbageScriptPrefixTag)
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 import Data.ByteString.Short (ShortByteString)
 
 type instance SomeScript 'PhaseOne (ConwayEra c) = Timelock (ConwayEra c)
 
 type instance SomeScript 'PhaseTwo (ConwayEra c) = (Language, ShortByteString)
 
-instance CC.Crypto c => EraScript (ConwayEra c) where
+instance Crypto c => EraScript (ConwayEra c) where
   type Script (ConwayEra c) = AlonzoScript (ConwayEra c)
+
+  upgradeScript = translateAlonzoScript
+
   scriptPrefixTag = babbageScriptPrefixTag
+
   phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
   phaseScript PhaseTwoRep (PlutusScript plutus) = Just (Phase2Script plutus)
   phaseScript _ _ = Nothing
 
-instance CC.Crypto c => EraTxAuxData (ConwayEra c) where
+instance Crypto c => EraTxAuxData (ConwayEra c) where
   type TxAuxData (ConwayEra c) = AlonzoTxAuxData (ConwayEra c)
   hashTxAuxData = hashAlonzoTxAuxData
   validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -27,13 +27,14 @@ import Cardano.Ledger.Babbage.Tx as BabbageTxReExport (
   AlonzoTx (..),
  )
 import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Conway.TxAuxData ()
 import Cardano.Ledger.Conway.TxBody ()
 import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 
-instance CC.Crypto c => EraTx (ConwayEra c) where
-  {-# SPECIALIZE instance EraTx (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => EraTx (ConwayEra c) where
+  {-# SPECIALIZE instance EraTx (ConwayEra StandardCrypto) #-}
 
   type Tx (ConwayEra c) = AlonzoTx (ConwayEra c)
 
@@ -51,18 +52,18 @@ instance CC.Crypto c => EraTx (ConwayEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(ConwayEra c) script tx
+  validateScript (Phase1Script script) = validateTimelock @(ConwayEra c) script
   {-# INLINE validateScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
 
-instance CC.Crypto c => AlonzoEraTx (ConwayEra c) where
-  {-# SPECIALIZE instance AlonzoEraTx (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => AlonzoEraTx (ConwayEra c) where
+  {-# SPECIALIZE instance AlonzoEraTx (ConwayEra StandardCrypto) #-}
 
   isValidTxL = isValidAlonzoTxL
   {-# INLINE isValidTxL #-}
 
-instance CC.Crypto c => EraSegWits (ConwayEra c) where
+instance Crypto c => EraSegWits (ConwayEra c) where
   type TxSeq (ConwayEra c) = AlonzoTxSeq (ConwayEra c)
   fromTxSeq = txSeqTxns
   toTxSeq = AlonzoTxSeq

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Ledger.Conway.TxAuxData () where
+
+import Cardano.Ledger.Alonzo.TxAuxData (
+  AlonzoTxAuxData,
+  hashAlonzoTxAuxData,
+  validateAlonzoTxAuxData,
+  translateAlonzoTxAuxData
+ )
+import Cardano.Ledger.Conway.Era
+import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto
+
+instance Crypto c => EraTxAuxData (ConwayEra c) where
+  type TxAuxData (ConwayEra c) = AlonzoTxAuxData (ConwayEra c)
+
+  upgradeTxAuxData = translateAlonzoTxAuxData
+
+  hashTxAuxData = hashAlonzoTxAuxData
+
+  validateTxAuxData = validateAlonzoTxAuxData

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+
 module Cardano.Ledger.Conway.TxAuxData () where
 
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData,
   hashAlonzoTxAuxData,
+  translateAlonzoTxAuxData,
   validateAlonzoTxAuxData,
-  translateAlonzoTxAuxData
  )
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxOut.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Conway.BinarySpec as BinarySpec
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Conway" $ do
+      BinarySpec.spec

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.BinarySpec (spec) where
+
+import Cardano.Ledger.Alonzo.TxAuxData
+import Cardano.Ledger.Conway
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary ()
+import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+
+spec :: Spec
+spec = specUpgrade @Conway @AlonzoTxAuxData True

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.3.1.1
+## 1.3.2.0
 
-*
+* Deprecate `translateValue` and `translateCompactValue`
 
 ## 1.3.1.0
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.1.1
+version:            1.3.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -99,7 +99,10 @@ test-suite tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
-    other-modules:    Test.Cardano.Ledger.Mary.ValueSpec
+    other-modules:
+        Test.Cardano.Ledger.Mary.BinarySpec
+        Test.Cardano.Ledger.Mary.ValueSpec
+
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates
@@ -113,5 +116,6 @@ test-suite tests
         cardano-data:{cardano-data, testlib},
         cardano-ledger-binary:testlib >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-allegra,
         cardano-ledger-mary,
         testlib

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Mary.Era (MaryEra) where
@@ -21,6 +20,8 @@ instance Crypto c => Era (MaryEra c) where
   type PreviousEra (MaryEra c) = AllegraEra c
   type EraCrypto (MaryEra c) = c
   type ProtVerLow (MaryEra c) = 4
+
+  eraName = "Mary"
 
 --------------------------------------------------------------------------------
 -- Core instances

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
@@ -1,20 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Scripts (
@@ -22,7 +12,7 @@ module Cardano.Ledger.Mary.Scripts (
 )
 where
 
-import Cardano.Ledger.Allegra.Scripts
+import Cardano.Ledger.Allegra.Scripts (Timelock, translateTimelock)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
@@ -35,6 +25,10 @@ type instance SomeScript 'PhaseOne (MaryEra c) = Timelock (MaryEra c)
 -- for the ValidateScript instance in MultiSig
 instance Crypto c => EraScript (MaryEra c) where
   type Script (MaryEra c) = Timelock (MaryEra c)
+
+  upgradeScript = translateTimelock
+
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
+
   phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
   phaseScript PhaseTwoRep _ = Nothing

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Shelley.API hiding (Metadata)
 import qualified Cardano.Ledger.Val as Val
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
 
 --------------------------------------------------------------------------------
 -- Translation from Allegra to Mary
@@ -129,8 +128,7 @@ instance Crypto c => TranslateEra (MaryEra c) UTxOState where
         }
 
 instance Crypto c => TranslateEra (MaryEra c) ShelleyTxOut where
-  translateEra () (TxOutCompact addr cfval) =
-    pure $ TxOutCompact (coerce addr) (translateCompactValue cfval)
+  translateEra () = pure . upgradeTxOut
 
 instance Crypto c => TranslateEra (MaryEra c) UTxO where
   translateEra ctxt utxo =
@@ -152,9 +150,8 @@ instance Crypto c => TranslateEra (MaryEra c) AllegraTxAuxData where
 
 translateValue :: Crypto c => Coin -> MaryValue c
 translateValue = Val.inject
+{-# DEPRECATED translateValue "Use `Val.inject` instead" #-}
 
 translateCompactValue :: Crypto c => CompactForm Coin -> CompactForm (MaryValue c)
-translateCompactValue =
-  fromMaybe (error msg) . toCompact . translateValue . fromCompact
-  where
-    msg = "impossible error: compact coin is out of range"
+translateCompactValue = Val.injectCompact
+{-# DEPRECATED translateCompactValue "Use `Val.injectCompact` instead" #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
@@ -1,18 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.TxAuxData (
@@ -22,7 +14,7 @@ where
 
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
-import Cardano.Ledger.Core (EraTxAuxData (..))
+import Cardano.Ledger.Core (EraTxAuxData (..), upgradeScript)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Scripts ()
@@ -34,5 +26,9 @@ import Control.DeepSeq (deepseq)
 
 instance Crypto c => EraTxAuxData (MaryEra c) where
   type TxAuxData (MaryEra c) = AllegraTxAuxData (MaryEra c)
+
+  upgradeTxAuxData (AllegraTxAuxData md scripts) = AllegraTxAuxData md $ upgradeScript <$> scripts
+
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
+
   hashTxAuxData aux = AuxiliaryDataHash (hashAnnotated aux)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
@@ -13,12 +13,15 @@ import Cardano.Ledger.Shelley.TxCert (
   ShelleyTxCert (..),
   getScriptWitnessShelleyTxCert,
   getVKeyWitnessShelleyTxCert,
+  upgradeShelleyTxCert,
  )
 
 instance Crypto c => EraTxCert (MaryEra c) where
   {-# SPECIALIZE instance EraTxCert (MaryEra StandardCrypto) #-}
 
   type TxCert (MaryEra c) = ShelleyTxCert (MaryEra c)
+
+  upgradeTxCert = Right . upgradeShelleyTxCert
 
   getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxOut.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxOut.hs
@@ -14,7 +14,8 @@ import Cardano.Ledger.Shelley.TxBody (
   addrEitherShelleyTxOutL,
   valueEitherShelleyTxOutL,
  )
-import Cardano.Ledger.Val (Val (isAdaOnly, size))
+import Cardano.Ledger.Val (Val (isAdaOnly, size), injectCompact)
+import Data.Coerce (coerce)
 import Lens.Micro ((^.))
 
 instance Crypto c => EraTxOut (MaryEra c) where
@@ -23,6 +24,8 @@ instance Crypto c => EraTxOut (MaryEra c) where
   type TxOut (MaryEra c) = ShelleyTxOut (MaryEra c)
 
   mkBasicTxOut = ShelleyTxOut
+
+  upgradeTxOut (TxOutCompact addr cfval) = TxOutCompact (coerce addr) (injectCompact cfval)
 
   addrEitherTxOutL = addrEitherShelleyTxOutL
   {-# INLINE addrEitherTxOutL #-}

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -2,9 +2,11 @@ module Main where
 
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
+import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Mary" $ do
       ValueSpec.spec
+      BinarySpec.spec

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -1,8 +1,8 @@
 module Main where
 
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
 
 main :: IO ()
 main =

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
+
+import Cardano.Ledger.Mary
+import Test.Cardano.Ledger.Mary.Arbitrary ()
+import Cardano.Ledger.Allegra.TxAuxData
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+
+spec :: Spec
+spec = specUpgrade @Mary @AllegraTxAuxData True

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -2,11 +2,11 @@
 
 module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
 
-import Cardano.Ledger.Mary
-import Test.Cardano.Ledger.Mary.Arbitrary ()
 import Cardano.Ledger.Allegra.TxAuxData
+import Cardano.Ledger.Mary
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Mary.Arbitrary ()
 
 spec :: Spec
 spec = specUpgrade @Mary @AllegraTxAuxData True

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -41,7 +41,7 @@ spec :: Spec
 spec = do
   describe "MultiAsset" $ do
     prop "Canonical construction agrees" $
-      withMaxSuccess 100000 $
+      withMaxSuccess 10000 $
         propCanonicalConstructionAgrees @StandardCrypto
   describe "CBOR roundtrip" $ do
     context "Coin" $ do

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Add `upgradeShelleyTxCert`
 * Rename `*governance*` to `*gov*` #3607
   * `EraGovernance` to `EraGov`
   * `GovernanceState` to `GovState`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
@@ -37,6 +37,8 @@ instance Crypto c => Era (ShelleyEra c) where
   type EraCrypto (ShelleyEra c) = c
   type ProtVerLow (ShelleyEra c) = 2
 
+  eraName = "Shelley"
+
 type instance Value (ShelleyEra _c) = Coin
 
 data ShelleyBBODY era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
@@ -100,6 +100,10 @@ type instance SomeScript 'PhaseOne (ShelleyEra c) = MultiSig (ShelleyEra c)
 instance Crypto c => EraScript (ShelleyEra c) where
   type Script (ShelleyEra c) = MultiSig (ShelleyEra c)
 
+  -- Calling this partial function will result in compilation error, since ByronEra has
+  -- no instance for EraScript type class.
+  upgradeScript = error "It is not possible to translate a script with 'upgradeScript' from Byron era"
+
   -- In the ShelleyEra there is only one kind of Script and its tag is "\x00"
   scriptPrefixTag _script = nativeMultiSigTag
   phaseScript PhaseOneRep multisig = Just (Phase1Script multisig)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -112,7 +112,12 @@ type Metadata era = ShelleyTxAuxData era
 instance Crypto c => EraTxAuxData (ShelleyEra c) where
   type TxAuxData (ShelleyEra c) = ShelleyTxAuxData (ShelleyEra c)
 
+  -- Calling this partial function will result in compilation error, since ByronEra has
+  -- no instance for EraTxOut type class.
+  upgradeTxAuxData = error "It is not possible to translate Byron TxOut with 'upgradeTxOut'"
+
   validateTxAuxData _ (ShelleyTxAuxData m) = all validMetadatum m
+
   hashTxAuxData metadata =
     AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)
     where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.Binary (
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain (ToCBOR (toCBOR), encodePreEncoded)
 import Cardano.Ledger.Core (Era (..), EraTxAuxData (..), eraProtVerLow)
-import Cardano.Ledger.Crypto
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
 import Cardano.Ledger.SafeHash (
   HashAnnotated,
@@ -66,7 +66,8 @@ import Cardano.Ledger.SafeHash (
   SafeToHash (..),
   hashAnnotated,
  )
-import Cardano.Ledger.Shelley.Era
+import Cardano.Ledger.Shelley.Era (ShelleyEra)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (rnf), deepseq)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -88,6 +89,8 @@ data Metadatum
   | S !T.Text
   deriving stock (Show, Eq, Ord, Generic)
 
+instance ToExpr Metadatum
+
 instance NoThunks Metadatum
 
 instance NFData Metadatum where
@@ -104,6 +107,8 @@ data ShelleyTxAuxData era = ShelleyTxAuxData'
   }
   deriving (Eq, Show, Ord, Generic)
   deriving (NoThunks) via AllowThunksIn '["mdBytes"] (ShelleyTxAuxData era)
+
+instance ToExpr (ShelleyTxAuxData era)
 
 type Metadata era = ShelleyTxAuxData era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -36,6 +36,7 @@ module Cardano.Ledger.Shelley.TxCert (
   getScriptWitnessShelleyTxCert,
   delegCWitness,
   ShelleyTxCert (..),
+  upgradeShelleyTxCert,
 
   -- ** GenesisDelegCert
   GenesisDelegCert (..),
@@ -109,6 +110,10 @@ instance Crypto c => EraTxCert (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxCert (ShelleyEra StandardCrypto) #-}
 
   type TxCert (ShelleyEra c) = ShelleyTxCert (ShelleyEra c)
+
+  -- Calling this partial function will result in compilation error, since ByronEra has
+  -- no instance for EraTxOut type class.
+  upgradeTxCert = error "Byron does not have any TxCerts to upgrade with 'upgradeTxCert'"
 
   getVKeyWitnessTxCert = getVKeyWitnessShelleyTxCert
 
@@ -303,6 +308,16 @@ data ShelleyTxCert era
   deriving (Show, Generic, Eq, NFData)
 
 instance NoThunks (ShelleyTxCert era)
+
+upgradeShelleyTxCert ::
+  EraCrypto era1 ~ EraCrypto era2 =>
+  ShelleyTxCert era1 ->
+  ShelleyTxCert era2
+upgradeShelleyTxCert = \case
+  ShelleyTxCertDelegCert cert -> ShelleyTxCertDelegCert cert
+  ShelleyTxCertPool cert -> ShelleyTxCertPool cert
+  ShelleyTxCertGenesisDeleg cert -> ShelleyTxCertGenesisDeleg cert
+  ShelleyTxCertMir cert -> ShelleyTxCertMir cert
 
 -- CBOR
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
@@ -69,6 +69,10 @@ instance Crypto crypto => EraTxOut (ShelleyEra crypto) where
 
   mkBasicTxOut = ShelleyTxOut
 
+  -- Calling this partial function will result in compilation error, since ByronEra has
+  -- no instance for EraTxOut type class.
+  upgradeTxOut = error "It is not possible to translate Byron TxOut with 'upgradeTxOut'"
+
   addrEitherTxOutL = addrEitherShelleyTxOutL
   {-# INLINE addrEitherTxOutL #-}
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -6,11 +6,17 @@ cradle:
     - path: "eras/allegra/impl/testlib"
       component: "cardano-ledger-allegra:lib:testlib"
 
+    - path: "eras/allegra/impl/test"
+      component: "cardano-ledger-allegra:test:tests"
+
     - path: "eras/alonzo/impl/src"
       component: "lib:cardano-ledger-alonzo"
 
     - path: "eras/alonzo/impl/testlib"
       component: "cardano-ledger-alonzo:lib:testlib"
+
+    - path: "eras/alonzo/impl/test"
+      component: "cardano-ledger-alonzo:test:tests"
 
     - path: "eras/alonzo/test-suite/src"
       component: "lib:cardano-ledger-alonzo-test"
@@ -29,6 +35,9 @@ cradle:
 
     - path: "eras/babbage/impl/testlib"
       component: "cardano-ledger-babbage:lib:testlib"
+
+    - path: "eras/babbage/impl/test"
+      component: "cardano-ledger-babbage:test:tests"
 
     - path: "eras/babbage/test-suite/src"
       component: "lib:cardano-ledger-babbage-test"
@@ -80,6 +89,9 @@ cradle:
 
     - path: "eras/conway/impl/testlib"
       component: "cardano-ledger-conway:lib:testlib"
+
+    - path: "eras/conway/impl/test"
+      component: "cardano-ledger-conway:test:tests"
 
     - path: "eras/conway/test-suite/src"
       component: "lib:cardano-ledger-conway-test"

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `upgradeTxAucData` function to `EraTxAuxData`
 * Add `upgradeTxOut` function to `EraTxOut`
 * Add `upgradeScript` function to `EraScript`
+* Add `upgradeTxAuxData` function to `EraTxAuxData`
+* Add `upgradeTxCert` function and `TxCertUpgradeError` family to `EraTxCert`
 * Export:
   * Procedures: `VotingProcedure`, `VotingProcedures` and `ProposalProcedure`
   * Constitution: `Constitution`, `constitutionHashL` and `constitutionScriptL`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Add `upgradeTxAucData` function to `EraTxAuxData`
 * Add `upgradeTxOut` function to `EraTxOut`
 * Add `upgradeScript` function to `EraScript`
 * Export:

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0.0
 
+* Add `upgradeTxOut` function to `EraTxOut`
+* Add `upgradeScript` function to `EraScript`
 * Export:
   * Procedures: `VotingProcedure`, `VotingProcedures` and `ProposalProcedure`
   * Constitution: `Constitution`, `constitutionHashL` and `constitutionScriptL`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Add `eraName`
 * Add `upgradeTxAucData` function to `EraTxAuxData`
 * Add `upgradeTxOut` function to `EraTxOut`
 * Add `upgradeScript` function to `EraScript`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -1,6 +1,11 @@
 module Cardano.Ledger.Api.Era (
   -- * Eras
-  Era (..),
+  Era (
+    PreviousEra,
+    ProtVerLow,
+    ProtVerHigh
+  ),
+  eraName,
 
   -- ** Byron
   ByronEra,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -1,6 +1,11 @@
 module Cardano.Ledger.Api.Scripts (
   module Cardano.Ledger.Api.Scripts.Data,
-  EraScript (..),
+  EraScript (Script),
+  scriptPrefixTag,
+  upgradeScript,
+  hashScript,
+  phaseScript,
+  isNativeScript,
   ScriptHash,
   CostModels (..),
   ValidityInterval (..),

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
@@ -1,5 +1,8 @@
 module Cardano.Ledger.Api.Tx.AuxData (
-  EraTxAuxData (..),
+  EraTxAuxData (TxAuxData),
+  upgradeTxAuxData,
+  hashTxAuxData,
+  validateTxAuxData,
 
   -- * Shelley
   ShelleyTxAuxData (..),

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Cardano.Ledger.Api.Tx.Cert (
-  EraTxCert,
-  TxCert,
+  EraTxCert (TxCert, TxCertUpgradeError),
+  upgradeTxCert,
   getVKeyWitnessTxCert,
   getScriptWitnessTxCert,
   pattern RegPoolTxCert,
@@ -74,10 +74,13 @@ import Cardano.Ledger.Conway.TxCert (
   pattern UnRegDepositTxCert,
  )
 import Cardano.Ledger.Core (
-  EraTxCert,
-  TxCert,
-  getScriptWitnessTxCert,
-  getVKeyWitnessTxCert,
+  EraTxCert (
+    TxCert,
+    TxCertUpgradeError,
+    getScriptWitnessTxCert,
+    getVKeyWitnessTxCert,
+    upgradeTxCert
+  ),
   pattern RegPoolTxCert,
   pattern RetirePoolTxCert,
  )

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Api.Tx.Out (
   module Cardano.Ledger.Api.Tx.Address,
   EraTxOut (TxOut),
   mkBasicTxOut,
+  upgradeTxOut,
 
   -- ** Value
   valueTxOutL,

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-binary`
 
+## 1.1.2.0
+
+* Re-export `ToExpr` from `Test.Cardano.Ledger.Binary.TreeDiff`
+
 ## 1.1.1.2
 
 *

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.1.1.2
+version:       1.1.2.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Plain/Golden.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Plain/Golden.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Binary.Plain
 import qualified Data.ByteString as BS
 import Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Lazy as BSL
-import Data.TreeDiff (ToExpr)
 import Test.Cardano.Ledger.Binary.TreeDiff
 import Test.Hspec
 

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Binary.TreeDiff (
+  ToExpr,
   CBORBytes (..),
   HexBytes (..),
   showExpr,
@@ -127,7 +128,7 @@ showHexBytesGrouped bs =
 -- | Check that two values are equal and if they are not raise an exception with the
 -- `ToExpr` diff
 expectExprEqual :: (Eq a, ToExpr a) => a -> a -> Expectation
-expectExprEqual x y = expectExprEqualWithMessage "Expected two values to be equal:" x y
+expectExprEqual = expectExprEqualWithMessage "Expected two values to be equal:"
 
 -- | Use this with HSpec, but with Tasty use 'assertExprEqualWithMessage' below
 expectExprEqualWithMessage :: (ToExpr a, Eq a, HasCallStack) => [Char] -> a -> a -> Expectation

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.0.0
 
+* Add `addrPtrNormalize`
+* Add `upgradeTxOut` function to `EraTxOut`
+* Add `upgradeScript` function to `EraScript`
 * Add `Anchor` and `AnchorDataHash`
 * Add `DRepState`
 * Change `vsDReps` to a map

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Add `eraName`
 * Add `addrPtrNormalize`
 * Add `upgradeTxOut` function to `EraTxOut`
 * Add `upgradeScript` function to `EraScript`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `addrPtrNormalize`
 * Add `upgradeTxOut` function to `EraTxOut`
 * Add `upgradeScript` function to `EraScript`
+* Add `upgradeTxAuxData` function to `EraTxAuxData`
+* Add `upgradeTxCert` function and `TxCertUpgradeError` family to `EraTxCert`
 * Add `Anchor` and `AnchorDataHash`
 * Add `DRepState`
 * Change `vsDReps` to a map

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -124,6 +124,7 @@ library testlib
         Test.Cardano.Ledger.Common
         Test.Cardano.Ledger.Core.Address
         Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
         Test.Cardano.Ledger.Core.KeyPair
         Test.Cardano.Ledger.Core.Utils
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -382,7 +382,16 @@ class
   EraTxAuxData era
   where
   type TxAuxData era = (r :: Type) | r -> era
+
+  -- | Every era, except Shelley, must be able to upgrade a `TxAuxData` from a previous
+  -- era.
+  --
+  -- /Warning/ - Important to note that any memoized binary representation will not be
+  -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
+  upgradeTxAuxData :: EraTxAuxData (PreviousEra era) => TxAuxData (PreviousEra era) -> TxAuxData era
+
   hashTxAuxData :: TxAuxData era -> AuxiliaryDataHash (EraCrypto era)
+
   validateTxAuxData :: ProtVer -> TxAuxData era -> Bool
 
 type AuxiliaryData era = TxAuxData era
@@ -460,6 +469,9 @@ class
   type Script era = (r :: Type) | r -> era
 
   -- | Every era, except Shelley, must be able to upgrade a `Script` from a previous era.
+  --
+  -- /Warning/ - Important to note that any memoized binary representation will not be
+  -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeScript :: EraScript (PreviousEra era) => Script (PreviousEra era) -> Script era
 
   scriptPrefixTag :: Script era -> BS.ByteString

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -229,12 +229,16 @@ class
 
   {-# MINIMAL
     mkBasicTxOut
+    , upgradeTxOut
     , valueEitherTxOutL
     , addrEitherTxOutL
     , (getMinCoinSizedTxOut | getMinCoinTxOut)
     #-}
 
   mkBasicTxOut :: Addr (EraCrypto era) -> Value era -> TxOut era
+
+  -- | Every era, except Shelley, must be able to upgrade a `TxOut` from a previous era.
+  upgradeTxOut :: EraTxOut (PreviousEra era) => TxOut (PreviousEra era) -> TxOut era
 
   valueTxOutL :: Lens' (TxOut era) (Value era)
   valueTxOutL =
@@ -454,6 +458,9 @@ class
   where
   -- | Scripts which may lock transaction outputs in this era
   type Script era = (r :: Type) | r -> era
+
+  -- | Every era, except Shelley, must be able to upgrade a `Script` from a previous era.
+  upgradeScript :: EraScript (PreviousEra era) => Script (PreviousEra era) -> Script era
 
   scriptPrefixTag :: Script era -> BS.ByteString
   hashScript :: Script era -> ScriptHash (EraCrypto era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -387,7 +387,7 @@ class
   -- era.
   --
   -- /Warning/ - Important to note that any memoized binary representation will not be
-  -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
+  -- preserved. If you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeTxAuxData :: EraTxAuxData (PreviousEra era) => TxAuxData (PreviousEra era) -> TxAuxData era
 
   hashTxAuxData :: TxAuxData era -> AuxiliaryDataHash (EraCrypto era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -82,6 +82,14 @@ class
 
   type ProtVerHigh era = ProtVerLow era
 
+  -- | Textual name of the current era.
+  --
+  -- Designed to be used with @TypeApplications@:
+  --
+  -- >>> eraName @(ByronEra StandardCrypto)
+  -- Byron
+  eraName :: String
+
 -- | This is the era that preceded Shelley era. It cannot have any other class instances,
 -- except for `Era` type class.
 data ByronEra c
@@ -94,6 +102,8 @@ instance Crypto c => Era (ByronEra c) where
   type PreviousEra (ByronEra c) = VoidEra c
   type ProtVerLow (ByronEra c) = 0
   type ProtVerHigh (ByronEra c) = 1
+
+  eraName = "Byron"
 
 -----------------------------
 -- Protocol version bounds --

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Language.hs
@@ -76,6 +76,8 @@ data Plutus = Plutus
   }
   deriving stock (Eq, Ord, Show, Generic)
 
+instance ToExpr Plutus
+
 -- | Already in Normal Form
 instance NFData Plutus where
   rnf = rwhnf
@@ -86,6 +88,8 @@ instance NoThunks Plutus
 newtype BinaryPlutus = BinaryPlutus {unBinaryPlutus :: ShortByteString}
   deriving stock (Eq, Ord, Generic)
   deriving newtype (ToCBOR, FromCBOR, EncCBOR, DecCBOR, NFData, NoThunks)
+
+instance ToExpr BinaryPlutus
 
 instance Show BinaryPlutus where
   show = show . B64.encode . fromShort . unBinaryPlutus

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -62,6 +62,7 @@ import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Core (Era (EraCrypto), eraProtVerLow)
 import Cardano.Ledger.Crypto (HASH)
 import Cardano.Ledger.SafeHash (SafeHash, SafeToHash (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (..))
 import Data.ByteString.Lazy (fromStrict, toStrict)
 import qualified Data.ByteString.Lazy as BSL
@@ -87,6 +88,7 @@ data MemoBytes t era = Memo'
   , mbBytes :: ShortByteString
   , mbHash :: SafeHash (EraCrypto era) (MemoHashIndex t)
   }
+  deriving (Generic)
   deriving (NoThunks) via AllowThunksIn '["mbBytes", "mbHash"] (MemoBytes t era)
 
 pattern Memo :: Era era => t era -> ShortByteString -> MemoBytes t era
@@ -101,7 +103,7 @@ type family MemoHashIndex (t :: Type -> Type) :: Type
 
 deriving instance NFData (t era) => NFData (MemoBytes t era)
 
-deriving instance Generic (MemoBytes t era)
+instance ToExpr (t era) => ToExpr (MemoBytes t era)
 
 instance (Typeable t, Typeable era) => Plain.ToCBOR (MemoBytes t era) where
   toCBOR (Memo' _ bytes _hash) = Plain.encodePreEncoded (fromShort bytes)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Core.Binary where
+
+import Cardano.Ledger.Core
+import Cardano.Ledger.MemoBytes (Memoized (RawType), zipMemoRawType)
+import Test.Cardano.Ledger.Binary.RoundTrip
+import Test.Cardano.Ledger.Binary.TreeDiff (ToExpr, expectExprEqual)
+import Test.Cardano.Ledger.Common
+
+specTxOutUpgrade ::
+  forall era.
+  ( EraTxOut (PreviousEra era)
+  , EraTxOut era
+  , Arbitrary (TxOut (PreviousEra era))
+  , HasCallStack
+  ) =>
+  Spec
+specTxOutUpgrade =
+  prop "upgradeTxOut is preserved through serialization" $ \prevTxOut -> do
+    case embedTrip (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) cborTrip prevTxOut of
+      Left err -> expectationFailure $ "Expected to deserialize: " ++ show err
+      Right (curTxOut :: TxOut era) ->
+        curTxOut `shouldBe` upgradeTxOut prevTxOut
+
+specTxAuxDataUpgrade ::
+  forall era t.
+  ( EraTxAuxData (PreviousEra era)
+  , EraTxAuxData era
+  , t era ~ TxAuxData era
+  , Memoized t
+  , Eq (RawType t era)
+  , ToExpr (RawType t era)
+  , Arbitrary (TxAuxData (PreviousEra era))
+  , HasCallStack
+  ) =>
+  Spec
+specTxAuxDataUpgrade =
+  prop "upgradeTxAuxData is preserved through serialization" $ \prevTxAuxData -> do
+    case embedTripAnn (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) prevTxAuxData of
+      Left err ->
+        expectationFailure $
+          "Expected to deserialize: =======================================================\n"
+            ++ show err
+      Right (curTxAuxData :: t era) ->
+        -- We need to do all this MemoBytes trickery because underlying bytes and thus the
+        -- equality of the same type will no longer be the same, despite that the value will
+        zipMemoRawType @t @t expectExprEqual curTxAuxData (upgradeTxAuxData prevTxAuxData)
+
+specScriptUpgrade ::
+  forall era.
+  ( EraScript (PreviousEra era)
+  , EraScript era
+  , Arbitrary (Script (PreviousEra era))
+  , HasCallStack
+  ) =>
+  Spec
+specScriptUpgrade =
+  prop "upgradeScript is preserved through serialization" $ \prevScript -> do
+    case embedTripAnn (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) prevScript of
+      Left err ->
+        expectationFailure $
+          "Expected to deserialize: =======================================================\n"
+            ++ show err
+      Right (curScript :: Script era) ->
+        curScript `shouldBe` upgradeScript prevScript
+
+specUpgrade ::
+  forall era t.
+  ( EraTxOut (PreviousEra era)
+  , EraTxOut era
+  , Arbitrary (TxOut (PreviousEra era))
+  , EraTxAuxData (PreviousEra era)
+  , EraTxAuxData era
+  , t era ~ TxAuxData era
+  , Memoized t
+  , Eq (RawType t era)
+  , ToExpr (RawType t era)
+  , Arbitrary (TxAuxData (PreviousEra era))
+  , EraScript (PreviousEra era)
+  , EraScript era
+  , Arbitrary (Script (PreviousEra era))
+  , HasCallStack
+  ) =>
+  Bool ->
+  Spec
+specUpgrade isScriptUpgradeable =
+  describe ("Upgrade from " ++ eraName @(PreviousEra era) ++ " to " ++ eraName @era) $ do
+    specTxOutUpgrade @era
+    specTxAuxDataUpgrade @era @t
+    when isScriptUpgradeable $
+      specScriptUpgrade @era

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
@@ -25,10 +25,40 @@ specTxOutUpgrade ::
 specTxOutUpgrade =
   prop "upgradeTxOut is preserved through serialization" $ \prevTxOut -> do
     case embedTrip (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) cborTrip prevTxOut of
-      Left err -> expectationFailure $ "Expected to deserialize: " ++ show err
+      Left err ->
+        expectationFailure $
+          "Expected to deserialize: =======================================================\n"
+            ++ show err
       Right (curTxOut :: TxOut era) ->
         curTxOut `shouldBe` upgradeTxOut prevTxOut
 
+specTxCertUpgrade ::
+  forall era.
+  ( EraTxCert (PreviousEra era)
+  , EraTxCert era
+  , Arbitrary (TxCert (PreviousEra era))
+  , HasCallStack
+  ) =>
+  Spec
+specTxCertUpgrade =
+  prop "upgradeTxCert is preserved through serialization" $ \prevTxCert -> do
+    case embedTrip (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) cborTrip prevTxCert of
+      Left err
+        | Right _ <- upgradeTxCert prevTxCert ->
+            -- We expect deserialization to succeed, when upgrade is possible
+            expectationFailure $
+              "Expected to deserialize: =======================================================\n"
+                ++ show err
+        | otherwise -> pure () -- Both upgrade and deserializer fail successfully
+      Right (curTxCert :: TxCert era)
+        | Right upgradedTxCert <- upgradeTxCert prevTxCert ->
+            curTxCert `shouldBe` upgradedTxCert
+        | otherwise -> expectationFailure "Expected upgradeTxCert to succeed"
+
+-- The reason why we need to pass `t` as a type argument here is because `TxAuxData` is a
+-- type family, so we don't know if the final type will be of the kind `Type -> Type` and
+-- can be used with MemoBytes, which requires `t` to be of such kind, because it is later
+-- applied to `era`.
 specTxAuxDataUpgrade ::
   forall era t.
   ( EraTxAuxData (PreviousEra era)
@@ -72,16 +102,19 @@ specScriptUpgrade =
         curScript `shouldBe` upgradeScript prevScript
 
 specUpgrade ::
-  forall era t.
+  forall era txAuxData.
   ( EraTxOut (PreviousEra era)
   , EraTxOut era
   , Arbitrary (TxOut (PreviousEra era))
+  , EraTxCert (PreviousEra era)
+  , EraTxCert era
+  , Arbitrary (TxCert (PreviousEra era))
   , EraTxAuxData (PreviousEra era)
   , EraTxAuxData era
-  , t era ~ TxAuxData era
-  , Memoized t
-  , Eq (RawType t era)
-  , ToExpr (RawType t era)
+  , txAuxData era ~ TxAuxData era -- See specTxAuxDataUpgrade for `txAuxData` explanation.
+  , Memoized txAuxData
+  , Eq (RawType txAuxData era)
+  , ToExpr (RawType txAuxData era)
   , Arbitrary (TxAuxData (PreviousEra era))
   , EraScript (PreviousEra era)
   , EraScript era
@@ -93,6 +126,7 @@ specUpgrade ::
 specUpgrade isScriptUpgradeable =
   describe ("Upgrade from " ++ eraName @(PreviousEra era) ++ " to " ++ eraName @era) $ do
     specTxOutUpgrade @era
-    specTxAuxDataUpgrade @era @t
+    specTxCertUpgrade @era
+    specTxAuxDataUpgrade @era @txAuxData
     when isScriptUpgradeable $
       specScriptUpgrade @era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -662,7 +662,7 @@ testBBodyState pf =
       poolID = hashKey . vKey . coerceKeyRole $ coldKeys
       example1UtxoSt = smartUTxOState (pp pf) utxo totalDeposits (Coin 40) def
       -- the default CertState 'def' means that the 'totalDeposits' must be 0
-      totalDeposits = (Coin 0)
+      totalDeposits = Coin 0
    in BbodyState
         (LedgerState example1UtxoSt def)
         (BlocksMade $ Map.singleton poolID 1)


### PR DESCRIPTION
# Description

Take care of part of #3618

Adds `upgradeTxOut`, `upgradeTxAuxData`, `upgradeScript` and `upgradeTxCert` as well as:

* Creates a test suite to each `cardano-ledger-[era]` package that didn't have one. See #3623 for more info on a long goal with respect to test suites.
* Add a test for each of the four type families that checks upgrading matches translation through CBOR.
* Add `eraName` that can be used in any place where textual representation of an era is needed (this can subsume similar functionality from consensus)
* Add `ToExpr` instances for more types. Needed for testing.
* For consistency moves `EraTxAuxData` instances into their own modules for Babbage and Conway 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
