### PR TITLE
Filter out zero TxOuts on Byron/Shelley boundary instead of Babbage/Conway

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Filter out zero valued `TxOut`'s on Byron/Shelley boundary instead of on Babbage/Conway.
 * Switch GovernanceActionIx to `Word32` fro `Word64` and remove `Num` and `Enum`
   instances, which are dangerous due to potential overflows.
 * Add `currentTreasuryValue :: !(StrictMaybe Coin)` as a new field to Conway TxBody #3586

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -40,7 +40,6 @@ import Cardano.Ledger.Shelley.API (
   VState (..),
  )
 import qualified Cardano.Ledger.Shelley.API as API
-import Cardano.Ledger.Val (Val (coin, zero))
 import Data.Coerce
 import qualified Data.Map.Strict as Map
 import Lens.Micro
@@ -154,18 +153,16 @@ instance Crypto c => TranslateEra (ConwayEra c) UTxOState where
 
 instance Crypto c => TranslateEra (ConwayEra c) API.UTxO where
   translateEra _ctxt utxo =
-    pure $ API.UTxO $ translateTxOut `Map.mapMaybe` API.unUTxO utxo
+    pure $ API.UTxO $ translateTxOut `Map.map` API.unUTxO utxo
 
 -- | Filter out `TxOut`s with zero Coins and normalize Pointers,
 -- while converting `TxOut`s to Conway era.
 translateTxOut ::
   Crypto c =>
   TxOut (BabbageEra c) ->
-  Maybe (TxOut (ConwayEra c))
-translateTxOut (BabbageTxOut addr value d s)
-  | coin value == zero = Nothing
-  | otherwise =
-      Just $ BabbageTxOut (addrPtrNormalize addr) value (translateDatum d) (translateScript <$> s)
+  TxOut (ConwayEra c)
+translateTxOut (BabbageTxOut addr value d s) =
+  BabbageTxOut (addrPtrNormalize addr) value (translateDatum d) (translateScript <$> s)
 
 -- | This function is implemented solely for the purpose of translating garbage pointers
 -- into knowingly invalid ones. Any pointer that contains a SlotNo, TxIx or CertIx that

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Filter out zero valued `TxOut`'s on Byron/Shelley boundary.
 * Rename `getProducedValue` to `shelleyProducedValue`
 * Change the constraints on `produced` and `evaluateTransactionBalance`
 * Add `lsCertStateL`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -32,12 +32,13 @@ import Cardano.Ledger.Shelley.Rules ()
 import Cardano.Ledger.Shelley.Translation (FromByronTranslationContext (..))
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.UTxO (coinBalance)
-import Cardano.Ledger.Val ((<->))
+import Cardano.Ledger.Val (zero, (<->))
 import qualified Data.ByteString.Short as SBS
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import Data.Word
 import GHC.Stack (HasCallStack)
+import Lens.Micro ((^.))
 import Lens.Micro.Extras (view)
 
 -- | We use the same hashing algorithm so we can unwrap and rewrap the bytes.
@@ -88,6 +89,10 @@ translateUTxOByronToShelley (Byron.UTxO utxoByron) =
       | (txInByron, txOutByron) <- Map.toList utxoByron
       , let txInShelley = translateCompactTxInByronToShelley txInByron
             txOutShelley = translateCompactTxOutByronToShelley txOutByron
+      , -- In some testnets there are a few TxOuts with zero values injected at
+      -- initialization of Byron. We do not allow zero values in TxOuts in Shelley
+      -- onwards.
+      txOutShelley ^. coinTxOutL /= zero
       ]
 
 translateToShelleyLedgerState ::


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
