### PR TITLE
Adjust thresholds for sanchonet

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -34,7 +34,6 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.PoolDistr (PoolDistr (..), individualPoolStake)
 import Cardano.Ledger.Slot (EpochNo (..))
-import Control.Monad (guard)
 import Control.State.Transition.Extended (
   Embed (..),
   STS (..),
@@ -90,7 +89,7 @@ instance
 
 -- Temporary threshold of 1 lovelace
 spoThreshold :: Rational
-spoThreshold = 1 % 45000000000000000
+spoThreshold = 51 % 100
 
 epochsToExpire :: EpochNo
 epochsToExpire = 10
@@ -100,12 +99,35 @@ accepted RatifyEnv {reStakePoolDistr = PoolDistr poolDistr} gas =
   totalAcceptedStakePoolsRatio > spoThreshold
   where
     GovernanceActionState {gasStakePoolVotes} = gas
-    totalAcceptedStakePoolsRatio =
-      getSum $ Map.foldMapWithKey lookupStakeDistrForYesVotes gasStakePoolVotes
+    -- Final ratio for `totalAcceptedStakePoolsRatio` we want is: t = y / (s - a)
+    -- Where:
+    --  * `y` - total delegated stake that voted Yes
+    --  * `a` - total delegated stake that voted Abstain
+    --  * `s` - total delegated stake
+    --
+    -- However, computing the total stake again would be wasteful, since we already have
+    -- distributions per pool computed. So, values that we have available are not exactly
+    -- what we need, because we have:
+    --  * `y/s` - stake that votes yes over the total stake
+    --  * `a/s` - stake that voted abstain over the total stake
+    --
+    -- We divide both numerator and denominator by `s` and we'll get a formula that we can
+    -- use:
+    --
+    -- t = y / (s - a) = (y / s) / (1 - a / s)
+    totalAcceptedStakePoolsRatio
+      | abstainVotesRatio == 1 = 0 -- guard against the degenerate case when all abstain.
+      | otherwise = yesVotesRatio / (1 - abstainVotesRatio)
+      where
+        (Sum yesVotesRatio, Sum abstainVotesRatio) =
+          Map.foldMapWithKey lookupStakePoolDistrForVotes gasStakePoolVotes
 
-    lookupStakeDistrForYesVotes poolId vote = fromMaybe mempty $ do
-      guard (vote == VoteYes)
-      Sum . individualPoolStake <$> Map.lookup poolId poolDistr
+        lookupStakePoolDistrForVotes poolId vote = fromMaybe (mempty, mempty) $ do
+          distr <- Sum . individualPoolStake <$> Map.lookup poolId poolDistr
+          case vote of
+            VoteNo -> Nothing
+            VoteYes -> Just (distr, mempty)
+            Abstain -> Just (mempty, distr)
 
 ratifyTransition ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -182,7 +182,7 @@ govActionStateWithVote ProposalProcedure {..} kh v =
     pProcGovernanceAction
     (EpochNo 0)
 
--- | Value for the actual threshold, plus a small epsilon for GT (>) reation
+-- | Value for the actual threshold, plus a small epsilon for GT (>) relation
 spoThreshold :: Rational
 spoThreshold = 51 % 100 + 1 % 100000000000
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -182,8 +182,9 @@ govActionStateWithVote ProposalProcedure {..} kh v =
     pProcGovernanceAction
     (EpochNo 0)
 
+-- | Value for the actual threshold, plus a small epsilon for GT (>) reation
 spoThreshold :: Rational
-spoThreshold = 1 % 45000000000000000
+spoThreshold = 51 % 100 + 1 % 100000000000
 
 defaultPPs :: [PParamsField era]
 defaultPPs =
@@ -343,7 +344,7 @@ testGovernance pf = do
             [
               ( stakePoolKeyHash pf
               , IndividualPoolStake
-                  (spoThreshold * 2)
+                  spoThreshold
                   (vrfKeyHash @(EraCrypto era))
               )
             ]


### PR DESCRIPTION
# Description

Fixes #3605 

* [x] - Thresholds (make actions pass with SPO majority alone):
  * DRep - 0% - these were already 0
  * CC - 0% - same here, also 0
  * SPO - >50% (51% if that's easier) - set to 51%
* [x] - Equation should be (yes / total stake delegated - abstain votes) - done.
* [x] - expiration of actions: 30 epochs - set to 30
* [x] - HF Action >100% (impossible) - set to 101%

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
