### PR TITLE
Change constitution to use `Anchor`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `ConwayEraGov` with `constitutionGovStateL`
 * Add `PrevGovActionId` and `GovActionPurpose`
 * Add optional `PrevGovActionId` to `ParameterChange`, `HardForkInitiation`,
   `NoConfidence`, `NewCommittee` and `NewConstitution` governance actions.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -22,7 +22,7 @@ module Cardano.Ledger.Conway.Governance.Procedures (
   VotingProcedure (..),
   ProposalProcedure (..),
   Anchor (..),
-  AnchorDataHash,
+  AnchorData (..),
   Vote (..),
   Voter (..),
   Committee (..),
@@ -41,7 +41,7 @@ import Cardano.Crypto.Hash (hashToTextAsHex)
 import Cardano.Ledger.Address (RewardAcnt)
 import Cardano.Ledger.BaseTypes (
   Anchor (..),
-  AnchorDataHash,
+  AnchorData (..),
   ProtVer,
   UnitInterval,
  )

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -111,7 +111,7 @@ new_constitution = (5, gov_action_id / null, constitution)
 committee = [{ $committee_coldkey_credential => epoch }, unit_interval]
 
 constitution =
-  [ $hash32
+  [ anchor
   , scripthash / null
   ]
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.5.0.0
 
+* Change `getConstituitionHash` to `getConstitution`
+* Replace `constitutionHash` with `constitutionAnchor`
 * Add `upgradeShelleyTxCert`
 * Rename `*governance*` to `*gov*` #3607
   * `EraGovernance` to `EraGov`
@@ -13,7 +15,7 @@
 * Rename `getProducedValue` to `shelleyProducedValue`
 * Change the constraints on `produced` and `evaluateTransactionBalance`
 * Add `lsCertStateL`
-* Make new `Constitution` datatype and `ConstitutionData` newtype #3556
+* Make new `Constitution` datatype #3556
   * Adopt some Default instances for example SafeHash
 * Add new methods to `EraGovernance`:
   * `curPParamsGovStateL`

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -50,6 +50,7 @@ import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Text (pack)
 import Data.Time
 import Data.Word (Word64, Word8)
 import Lens.Micro ((&), (.~))
@@ -395,6 +396,13 @@ mkDummySafeHash :: forall c a. Crypto c => Proxy c -> Int -> SafeHash c a
 mkDummySafeHash _ =
   unsafeMakeSafeHash
     . mkDummyHash @(HASH c)
+
+mkDummyAnchor :: Crypto c => Int -> Anchor c
+mkDummyAnchor n =
+  Anchor
+    { anchorUrl = fromJust . textToUrl $ "dummy@" <> pack (show n)
+    , anchorDataHash = mkDummySafeHash Proxy n
+    }
 
 {-------------------------------------------------------------------------------
   Shelley era specific functions

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0.0
 
+* Add `queryConstitution`.
+* Replace `constitutionHash` with `constitutionAnchor`
 * Add `eraName`
 * Add `upgradeTxAucData` function to `EraTxAuxData`
 * Add `upgradeTxOut` function to `EraTxOut`

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -49,7 +49,6 @@ library
     build-depends:
         base >=4.14 && <4.19,
         array,
-        bytestring,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo >=1.4,
         cardano-ledger-babbage >=1.1,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 module Cardano.Ledger.Api.Governance (
   EraGov (GovState),
   emptyGovState,
@@ -22,7 +17,7 @@ module Cardano.Ledger.Api.Governance (
 
   -- ** Constitution
   Constitution (..),
-  constitutionHashL,
+  constitutionAnchorL,
   constitutionScriptL,
 
   -- ** Governance State
@@ -47,7 +42,6 @@ module Cardano.Ledger.Api.Governance (
   -- *** Anchor
   Anchor (..),
   AnchorData (..),
-  AnchorDataHash,
   hashAnchorData,
 ) where
 
@@ -55,9 +49,10 @@ module Cardano.Ledger.Api.Governance (
 
 import Cardano.Ledger.Allegra.Core (Constitution (..))
 import Cardano.Ledger.Api.Era ()
+import Cardano.Ledger.BaseTypes (hashAnchorData)
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
-  AnchorDataHash,
+  AnchorData (..),
   ConwayGovState (..),
   EnactState (..),
   GovAction (..),
@@ -75,12 +70,10 @@ import Cardano.Ledger.Conway.Governance (
   VotingProcedures (..),
   cgGovL,
   cgRatifyL,
-  constitutionHashL,
+  constitutionAnchorL,
   constitutionScriptL,
   govActionIdToText,
  )
-import Cardano.Ledger.Crypto (Crypto)
-import Cardano.Ledger.SafeHash (HashAnnotated, SafeHash, SafeToHash, hashAnnotated)
 import Cardano.Ledger.Shelley.Governance (
   EraGov (GovState),
   ShelleyGovState (..),
@@ -88,13 +81,3 @@ import Cardano.Ledger.Shelley.Governance (
   getProposedPPUpdates,
  )
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), emptyPPPUpdates)
-import Data.ByteString (ByteString)
-
-newtype AnchorData c = AnchorData ByteString
-  deriving (Eq, SafeToHash)
-
-instance HashAnnotated (AnchorData c) AnchorDataHash c
-
--- | Hash `AnchorData`
-hashAnchorData :: Crypto c => AnchorData c -> SafeHash c AnchorDataHash
-hashAnchorData = hashAnnotated

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -10,8 +10,9 @@ module Cardano.Ledger.Api.State.Query (
   queryConstitutionHash,
 ) where
 
+import Cardano.Ledger.Allegra.Core (Constitution (constitutionAnchor))
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Conway.Governance (ConstitutionData, EraGov (getConstitutionHash))
+import Cardano.Ledger.Conway.Governance (Anchor (..), AnchorData, EraGov (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
@@ -50,7 +51,13 @@ queryStakePoolDelegsAndRewards nes = filterStakePoolDelegsAndRewards (dsUnified 
 getDState :: NewEpochState era -> DState era
 getDState = certDState . lsCertState . esLState . nesEs
 
+queryConstitution :: EraGov era => NewEpochState era -> Maybe (Constitution era)
+queryConstitution nes =
+  getConstitution (nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL)
+
 queryConstitutionHash ::
-  EraGov era => NewEpochState era -> Maybe (SafeHash (EraCrypto era) ConstitutionData)
+  EraGov era =>
+  NewEpochState era ->
+  Maybe (SafeHash (EraCrypto era) (AnchorData (EraCrypto era)))
 queryConstitutionHash nes =
-  getConstitutionHash $ nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL
+  anchorDataHash . constitutionAnchor <$> queryConstitution nes

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `upgradeScript` function to `EraScript`
 * Add `upgradeTxAuxData` function to `EraTxAuxData`
 * Add `upgradeTxCert` function and `TxCertUpgradeError` family to `EraTxCert`
+* Add `Default` instance for `Anchor`
 * Add `Anchor` and `AnchorDataHash`
 * Add `DRepState`
 * Change `vsDReps` to a map

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -19,7 +19,7 @@ module Cardano.Ledger.CertState (
   FutureGenDeleg (..),
   Anchor (..),
   DRepState (..),
-  AnchorDataHash,
+  AnchorData,
   lookupDepositDState,
   lookupRewardDState,
   rewards,
@@ -39,7 +39,7 @@ module Cardano.Ledger.CertState (
 )
 where
 
-import Cardano.Ledger.BaseTypes (Anchor (..), AnchorDataHash, StrictMaybe)
+import Cardano.Ledger.BaseTypes (Anchor (..), AnchorData, StrictMaybe)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   DecShareCBOR (..),

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -226,7 +226,7 @@ instance PrettyA (PParamsUpdate era) => PrettyA (GovAction era) where
     ppRecord
       "NewConstitution"
       [ ("previous governance action id", prettyA pgaid)
-      , ("hash", prettyA constitutionHash)
+      , ("anchor", prettyA constitutionAnchor)
       , ("script", prettyA constitutionScript)
       ]
   prettyA InfoAction =
@@ -303,7 +303,7 @@ instance PrettyA (Constitution era) where
   prettyA Constitution {..} =
     ppRecord
       "Constitution"
-      [ ("hash", prettyA constitutionHash)
+      [ ("anchor", prettyA constitutionAnchor)
       , ("script", prettyA constitutionScript)
       ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -131,7 +131,7 @@ someTxIn :: (CH.HashAlgorithm (HASH c), HasCallStack) => TxIn c
 someTxIn = mkGenesisTxIn 1
 
 proposedConstitution :: forall era. Scriptic era => Constitution era
-proposedConstitution = Constitution (SLE.mkDummySafeHash Proxy 1) SNothing
+proposedConstitution = Constitution (SLE.mkDummyAnchor 1) SNothing
 
 newConstitutionProposal :: forall era. Scriptic era => Proof era -> ProposalProcedure era
 newConstitutionProposal pf =
@@ -153,7 +153,7 @@ anotherConstitutionProposal pf prevGovActionId =
     (RewardAcnt Mainnet (KeyHashObj (stakeKeyHash pf)))
     ( NewConstitution
         (SJust (PrevGovActionId prevGovActionId))
-        (Constitution (SLE.mkDummySafeHash Proxy 2) SNothing)
+        (Constitution (SLE.mkDummyAnchor 2) SNothing)
     )
     (Anchor (fromJust $ textToUrl "another.constitution.com") (SLE.mkDummySafeHash Proxy 2))
 


### PR DESCRIPTION
# Description

This PR replaces the constitution has with `Anchor`. Replaced `getConstitutionHash` with `getConstitution` in `EraGov`. Added `ConwayEraGov`, which adds a lens for accessing the constitution.

closes #3613

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
