### PR TITLE
Make snapshots of GovActionsState

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -53,7 +53,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
         cardano-ledger-core >=1.6 && <1.7,
-        cardano-ledger-shelley >=1.5.1 && <1.6,
+        cardano-ledger-shelley >=1.6 && <1.7,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
@@ -8,6 +8,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.PParams
+import Cardano.Ledger.Val (Val (..))
 import Data.Coerce
 import Lens.Micro
 
@@ -55,3 +56,5 @@ instance Crypto c => EraGov (AllegraEra c) where
   curPParamsGovStateL = curPParamsShelleyGovStateL
 
   prevPParamsGovStateL = prevPParamsShelleyGovStateL
+
+  obligationGovState = const zero

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -54,12 +54,13 @@ import Cardano.Ledger.Rules.ValidationMode (
  )
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.Governance
-import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure, keyTxRefunds, totalTxDeposits)
+import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure, keyTxRefunds)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), TxIn)
+import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..))
 import Cardano.Ledger.Shelley.UTxO (txup)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), txouts)
 import qualified Cardano.Ledger.Val as Val
@@ -205,7 +206,7 @@ utxoTransition = do
   runTest $ Shelley.validateMaxTxSizeUTxO pp tx
 
   let refunded = keyTxRefunds pp dpstate txb
-  let depositChange = totalTxDeposits pp dpstate txb Val.<-> refunded
+  let depositChange = getTotalDepositsTxBody pp dpstate txb Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txb) depositChange
   pure $! Shelley.updateUTxOState pp u txb depositChange ppup'
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -76,6 +76,7 @@ import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxBody (
   ShelleyEraTxBody (..),
   Withdrawals (..),
+  totalTxDepositsShelley,
  )
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
@@ -347,6 +348,8 @@ instance Crypto c => ShelleyEraTxBody (AllegraEra c) where
   updateTxBodyL =
     lensMemoRawType atbrUpdate $ \txBodyRaw update -> txBodyRaw {atbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
+
+  getTotalDepositsTxBody = totalTxDepositsShelley
 
 instance Crypto c => AllegraEraTxBody (AllegraEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AllegraEra StandardCrypto) #-}

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -69,7 +69,7 @@ library
         cardano-ledger-binary >=1.0.1,
         cardano-ledger-core >=1.6 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5.1,
+        cardano-ledger-shelley ^>=1.6,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -119,6 +119,7 @@ import Cardano.Ledger.Shelley.PParams (
   shelleyCommonPParamsHKDPairsV6,
  )
 import Cardano.Ledger.TreeDiff (ToExpr (..))
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson as Aeson (
   FromJSON (parseJSON),
@@ -289,6 +290,8 @@ instance Crypto c => EraGov (AlonzoEra c) where
   curPParamsGovStateL = curPParamsShelleyGovStateL
 
   prevPParamsGovStateL = prevPParamsShelleyGovStateL
+
+  obligationGovState = const zero
 
 instance Era era => EncCBOR (AlonzoPParams Identity era) where
   encCBOR AlonzoPParams {..} =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -27,7 +27,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   DState (..),
   LedgerState (..),
   UTxOState (..),
-  obligationCertState,
  )
 import Cardano.Ledger.Shelley.Rules (
   DelegsEnv (..),
@@ -36,6 +35,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegsPredFailure,
   ShelleyLEDGERS,
   UtxoEnv (..),
+  shelleyLedgerAssertions,
  )
 import Cardano.Ledger.Shelley.Rules as Shelley (
   LedgerEnv (..),
@@ -46,7 +46,6 @@ import Cardano.Ledger.Shelley.Rules as Shelley (
   depositEqualsObligation,
  )
 import Control.State.Transition (
-  Assertion (..),
   Embed (..),
   STS (..),
   TRC (..),
@@ -109,6 +108,7 @@ ledgerTransition = do
 instance
   ( DSignable (EraCrypto era) (Hash (EraCrypto era) EraIndependentTxBody)
   , AlonzoEraTx era
+  , EraGov era
   , Tx era ~ AlonzoTx era
   , Embed (EraRule "DELEGS" era) (AlonzoLEDGER era)
   , Embed (EraRule "UTXOW" era) (AlonzoLEDGER era)
@@ -134,13 +134,7 @@ instance
 
   renderAssertionViolation = Shelley.depositEqualsObligation
 
-  assertions =
-    [ PostCondition
-        "Deposit pot must equal obligation (AlonzoLEDGER)"
-        ( \(TRC (_, _, _))
-           (LedgerState utxoSt dpstate) -> obligationCertState dpstate == utxosDeposited utxoSt
-        )
-    ]
+  assertions = shelleyLedgerAssertions
 
 instance
   ( Era era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -76,7 +76,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
   UTxOState (..),
   keyTxRefunds,
-  totalTxDeposits,
   updateStakeDistribution,
  )
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
@@ -250,7 +249,7 @@ alonzoEvalScriptsTxValid = do
   let txBody = tx ^. bodyTxL
       protVer = pp ^. ppProtocolVersionL
       refunded = keyTxRefunds pp dpstate txBody
-      depositChange = totalTxDeposits pp dpstate txBody <-> refunded
+      depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   () <- pure $! traceEvent validBegin ()
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -108,6 +108,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -207,6 +208,8 @@ instance Crypto c => ShelleyEraTxBody (AlonzoEra c) where
   updateTxBodyL =
     lensMemoRawType atbrUpdate (\txBodyRaw update_ -> txBodyRaw {atbrUpdate = update_})
   {-# INLINEABLE updateTxBodyL #-}
+
+  getTotalDepositsTxBody = totalTxDepositsShelley
 
 instance Crypto c => AllegraEraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AlonzoEra StandardCrypto) #-}

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -54,7 +54,7 @@ library
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.5 && <1.7,
         cardano-ledger-pretty,
         cardano-ledger-allegra ^>=1.2,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.5 && <1.6,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.7,
         cardano-ledger-shelley-test ^>=1.2,
         cardano-ledger-shelley-ma-test ^>=1.2,
         cardano-ledger-mary ^>=1.3,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -45,6 +45,7 @@ import Test.Cardano.Ledger.Shelley.Generator.Utxo (genTx)
 -- with meaningful delegation certificates.
 instance
   ( EraGen era
+  , EraGov era
   , AlonzoEraTx era
   , Mock (EraCrypto era)
   , MinLEDGER_STS era

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -64,7 +64,7 @@ library
         cardano-ledger-binary >=1.0,
         cardano-ledger-core >=1.6 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5,
+        cardano-ledger-shelley ^>=1.6,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -86,6 +86,7 @@ import Cardano.Ledger.Orphans ()
 import Cardano.Ledger.Shelley.PParams (emptyPPPUpdates)
 import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Ledger.TreeDiff (ToExpr (..))
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson as Aeson (
   Key,
@@ -245,6 +246,8 @@ instance Crypto c => EraGov (BabbageEra c) where
   curPParamsGovStateL = curPParamsShelleyGovStateL
 
   prevPParamsGovStateL = prevPParamsShelleyGovStateL
+
+  obligationGovState = const zero
 
 instance Era era => EncCBOR (BabbagePParams Identity era) where
   encCBOR BabbagePParams {..} =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -52,7 +52,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
   UTxOState (..),
   keyTxRefunds,
-  totalTxDeposits,
   updateStakeDistribution,
  )
 import Cardano.Ledger.Shelley.PParams (Update)
@@ -161,7 +160,7 @@ tellDepositChangeEvent pp dpstate txBody = do
   {- refunded := keyRefunds pp txb -}
   let refunded = keyTxRefunds pp dpstate txBody
   {- depositChange := (totalDeposits pp poolParams txcerts txb) − refunded -}
-  let depositChange = totalTxDeposits pp dpstate txBody <-> refunded
+  let depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   pure depositChange
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -152,6 +152,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData)
 import Data.Sequence.Strict (StrictSeq, (|>))
@@ -417,6 +418,8 @@ instance Crypto c => ShelleyEraTxBody (BabbageEra c) where
 
   updateTxBodyL = updateBabbageTxBodyL
   {-# INLINE updateTxBodyL #-}
+
+  getTotalDepositsTxBody = totalTxDepositsShelley
 
 instance Crypto c => AllegraEraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -45,7 +45,7 @@ library
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-mary ^>=1.3,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley >=1.4 && <1.6,
+        cardano-ledger-shelley >=1.6 && <1.7,
         cardano-strict-containers,
         cardano-slotting,
         containers,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## 1.8.0.0
 
+* Remove `rsFuture` from `RatifyState`
+* Add to `GovActionsState`:
+  * `curGovActionsState`
+  * `prevGovActionsState`
+  * `prevDRepState`
+  * `prevCommitteeState`
+* Add `ToExpr` instances to:
+  * `PoolVotingThresholds`
+  * `DRepVotingThresholds`
+  * `GovActionState`
+  * `GovActionsState`
+  * `EnactState`
+  * `RatifyState`
+  * `ConwayGovState`
+  * `GovActionIx`
+  * `GovActionId`
+  * `Vote`
+  * `Committee`
+  * `PrevGovActionId`
+  * `GovAction`
+  * `ConwayPParams` with `Identity` and `StrictMaybe`
+* Add lenses:
+  * `cgEnactStateL`
+  * `curGovActionsStateL`
+  * `prevGovActionsStateL`
+  * `prevDRepStateL`
+  * `prevCommitteeStateL`
+* Replace `cgRatifyState` with `cgEnactState`
+* Deprecate `cgRatifyStateL`
 * Add `ProposalDepositIncorrect` predicate failure, that is produced when `ProposalProcedure` deposit does not match `"govActionDeposit"` from `PParams` #3669
 * Add "minCommitteeSize" `PParam` validation for `NewCommittee` `GovAction` #3668
   * Add `committeeMembersL` and `committeeQuorumL` lenses for `Committee`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -73,7 +73,7 @@ library
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.6,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5.1,
+        cardano-ledger-shelley ^>=1.6,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Core.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Core.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Binary.Encoding (EncCBOR (encCBOR))
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Governance.Procedures (ProposalProcedure, VotingProcedures)
 import Cardano.Ledger.HKD (HKD, HKDFunctor)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON)
 import Data.Default.Class (Default)
@@ -136,6 +137,8 @@ data PoolVotingThresholds = PoolVotingThresholds
   }
   deriving (Eq, Ord, Show, Generic, Default, ToJSON, NFData, NoThunks)
 
+instance ToExpr PoolVotingThresholds
+
 instance EncCBOR PoolVotingThresholds where
   encCBOR PoolVotingThresholds {..} =
     encodeListLen 4
@@ -166,6 +169,8 @@ data DRepVotingThresholds = DRepVotingThresholds
   , dvtTreasuryWithdrawal :: !UnitInterval
   }
   deriving (Eq, Ord, Show, Generic, Default, ToJSON, NFData, NoThunks)
+
+instance ToExpr DRepVotingThresholds
 
 instance EncCBOR DRepVotingThresholds where
   encCBOR DRepVotingThresholds {..} =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -42,6 +42,7 @@ module Cardano.Ledger.Conway.Governance (
   ConwayEraGov (..),
   -- Lenses
   cgGovActionsStateL,
+  cgEnactStateL,
   cgRatifyStateL,
   ensConstitutionL,
   rsEnactStateL,
@@ -49,6 +50,10 @@ module Cardano.Ledger.Conway.Governance (
   prevPParamsConwayGovStateL,
   constitutionScriptL,
   constitutionAnchorL,
+  curGovActionsStateL,
+  prevGovActionsStateL,
+  prevDRepsStateL,
+  prevCommitteeStateL,
 ) where
 
 import Cardano.Ledger.Address (RewardAcnt)
@@ -67,6 +72,7 @@ import Cardano.Ledger.Binary.Coders (
   (!>),
   (<!),
  )
+import Cardano.Ledger.CertState (CommitteeState, DRepState)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (
@@ -93,9 +99,12 @@ import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Shelley.Governance
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Default.Class (Default (..))
+import Data.Foldable (Foldable (..))
+import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
@@ -115,6 +124,8 @@ data GovActionState era = GovActionState
   , gasExpiresAfter :: !EpochNo
   }
   deriving (Generic)
+
+instance EraPParams era => ToExpr (GovActionState era)
 
 instance EraPParams era => ToJSON (GovActionState era) where
   toJSON = object . toGovActionStatePairs
@@ -170,32 +181,88 @@ instance EraPParams era => EncCBOR (GovActionState era) where
         !> To gasProposedIn
         !> To gasExpiresAfter
 
-newtype GovActionsState era = GovActionsState
-  { unGovActionsState :: Map (GovActionId (EraCrypto era)) (GovActionState era)
+data GovActionsState era = GovActionsState
+  { curGovActionsState :: !(Map (GovActionId (EraCrypto era)) (GovActionState era))
+  , prevGovActionsState :: !(Map (GovActionId (EraCrypto era)) (GovActionState era))
+  , prevDRepsState :: !(Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era)))
+  , prevCommitteeState :: !(CommitteeState era)
   }
-  deriving (Generic, NFData, Semigroup, Monoid)
+  deriving (Generic)
+
+instance EraPParams era => ToExpr (GovActionsState era)
 
 insertGovActionsState ::
   GovActionState era ->
   GovActionsState era ->
   GovActionsState era
-insertGovActionsState v@GovActionState {gasId} (GovActionsState m) =
-  GovActionsState $ Map.insert gasId v m
+insertGovActionsState v@GovActionState {gasId} =
+  curGovActionsStateL %~ Map.insert gasId v
+
+curGovActionsStateL ::
+  Lens'
+    (GovActionsState era)
+    (Map (GovActionId (EraCrypto era)) (GovActionState era))
+curGovActionsStateL = lens curGovActionsState (\x y -> x {curGovActionsState = y})
+
+prevGovActionsStateL ::
+  Lens'
+    (GovActionsState era)
+    (Map (GovActionId (EraCrypto era)) (GovActionState era))
+prevGovActionsStateL = lens prevGovActionsState (\x y -> x {prevGovActionsState = y})
+
+prevDRepsStateL ::
+  Lens'
+    (GovActionsState era)
+    (Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era)))
+prevDRepsStateL = lens prevDRepsState (\x y -> x {prevDRepsState = y})
+
+prevCommitteeStateL ::
+  Lens'
+    (GovActionsState era)
+    (CommitteeState era)
+prevCommitteeStateL = lens prevCommitteeState (\x y -> x {prevCommitteeState = y})
 
 deriving instance EraPParams era => Eq (GovActionsState era)
 
 deriving instance EraPParams era => Show (GovActionsState era)
 
-deriving instance EraPParams era => ToJSON (GovActionsState era)
+toGovActionsStatePairs :: (KeyValue a, EraPParams era) => GovActionsState era -> [a]
+toGovActionsStatePairs gas@(GovActionsState _ _ _ _) =
+  let GovActionsState {..} = gas
+   in [ "curGovActionsState" .= curGovActionsState
+      , "prevGovActionsState" .= prevGovActionsState
+      , "prevDRepsState" .= prevDRepsState
+      , "prevCommitteeState" .= prevCommitteeState
+      ]
+
+instance EraPParams era => ToJSON (GovActionsState era) where
+  toJSON = object . toGovActionsStatePairs
+  toEncoding = pairs . mconcat . toGovActionsStatePairs
+
+instance EraPParams era => NFData (GovActionsState era)
 
 instance EraPParams era => NoThunks (GovActionsState era)
 
 instance Default (GovActionsState era) where
-  def = GovActionsState mempty
+  def = GovActionsState mempty mempty mempty def
 
-deriving instance EraPParams era => EncCBOR (GovActionsState era)
+instance EraPParams era => EncCBOR (GovActionsState era) where
+  encCBOR GovActionsState {..} =
+    encode $
+      Rec GovActionsState
+        !> To curGovActionsState
+        !> To prevGovActionsState
+        !> To prevDRepsState
+        !> To prevCommitteeState
 
-deriving instance EraPParams era => DecCBOR (GovActionsState era)
+instance EraPParams era => DecCBOR (GovActionsState era) where
+  decCBOR =
+    decode $
+      RecD GovActionsState
+        <! From
+        <! From
+        <! From
+        <! From
 
 instance EraPParams era => ToCBOR (GovActionsState era) where
   toCBOR = toEraCBOR @era
@@ -224,6 +291,8 @@ ensCurPParamsL = lens ensPParams (\es x -> es {ensPParams = x})
 
 ensPrevPParamsL :: Lens' (EnactState era) (PParams era)
 ensPrevPParamsL = lens ensPrevPParams (\es x -> es {ensPrevPParams = x})
+
+instance ToExpr (PParamsHKD Identity era) => ToExpr (EnactState era)
 
 instance EraPParams era => ToJSON (EnactState era) where
   toJSON = object . toEnactStatePairs
@@ -292,7 +361,6 @@ instance EraPParams era => NoThunks (EnactState era)
 
 data RatifyState era = RatifyState
   { rsEnactState :: !(EnactState era)
-  , rsFuture :: !(StrictSeq (GovActionState era))
   , rsRemoved :: !(StrictSeq (GovActionState era))
   }
   deriving (Generic)
@@ -304,6 +372,8 @@ deriving instance EraPParams era => Show (RatifyState era)
 rsEnactStateL :: Lens' (RatifyState era) (EnactState era)
 rsEnactStateL = lens rsEnactState (\x y -> x {rsEnactState = y})
 
+instance EraPParams era => ToExpr (RatifyState era)
+
 instance EraPParams era => Default (RatifyState era)
 
 instance EraPParams era => DecCBOR (RatifyState era) where
@@ -312,14 +382,12 @@ instance EraPParams era => DecCBOR (RatifyState era) where
       RecD RatifyState
         <! From
         <! From
-        <! From
 
 instance EraPParams era => EncCBOR (RatifyState era) where
   encCBOR RatifyState {..} =
     encode $
       Rec RatifyState
         !> To rsEnactState
-        !> To rsFuture
         !> To rsRemoved
 
 instance EraPParams era => ToCBOR (RatifyState era) where
@@ -337,30 +405,36 @@ instance EraPParams era => ToJSON (RatifyState era) where
   toEncoding = pairs . mconcat . toRatifyStatePairs
 
 toRatifyStatePairs :: (KeyValue a, EraPParams era) => RatifyState era -> [a]
-toRatifyStatePairs cg@(RatifyState _ _ _) =
+toRatifyStatePairs cg@(RatifyState _ _) =
   let RatifyState {..} = cg
    in [ "enactState" .= rsEnactState
-      , "future" .= rsFuture
       , "removed" .= rsRemoved
       ]
 
 data ConwayGovState era = ConwayGovState
   { cgGovActionsState :: !(GovActionsState era)
-  , cgRatifyState :: !(RatifyState era)
+  , cgEnactState :: !(EnactState era)
   }
   deriving (Generic, Eq, Show)
 
 cgGovActionsStateL :: Lens' (ConwayGovState era) (GovActionsState era)
 cgGovActionsStateL = lens cgGovActionsState (\x y -> x {cgGovActionsState = y})
 
+cgEnactStateL :: Lens' (ConwayGovState era) (EnactState era)
+cgEnactStateL = lens cgEnactState (\x y -> x {cgEnactState = y})
+
+{-# DEPRECATED cgRatifyStateL "Use cgEnactStateL instead" #-}
 cgRatifyStateL :: Lens' (ConwayGovState era) (RatifyState era)
-cgRatifyStateL = lens cgRatifyState (\x y -> x {cgRatifyState = y})
+cgRatifyStateL =
+  lens
+    (\ConwayGovState {..} -> RatifyState cgEnactState mempty)
+    (\x RatifyState {..} -> x & cgEnactStateL .~ rsEnactState)
 
 curPParamsConwayGovStateL :: Lens' (ConwayGovState era) (PParams era)
-curPParamsConwayGovStateL = cgRatifyStateL . rsEnactStateL . ensCurPParamsL
+curPParamsConwayGovStateL = cgEnactStateL . ensCurPParamsL
 
 prevPParamsConwayGovStateL :: Lens' (ConwayGovState era) (PParams era)
-prevPParamsConwayGovStateL = cgRatifyStateL . rsEnactStateL . ensPrevPParamsL
+prevPParamsConwayGovStateL = cgEnactStateL . ensPrevPParamsL
 
 instance EraPParams era => DecCBOR (ConwayGovState era) where
   decCBOR =
@@ -374,7 +448,7 @@ instance EraPParams era => EncCBOR (ConwayGovState era) where
     encode $
       Rec ConwayGovState
         !> To cgGovActionsState
-        !> To cgRatifyState
+        !> To cgEnactState
 
 instance EraPParams era => ToCBOR (ConwayGovState era) where
   toCBOR = toEraCBOR @era
@@ -392,24 +466,29 @@ instance EraPParams era => ToJSON (ConwayGovState era) where
   toJSON = object . toConwayGovPairs
   toEncoding = pairs . mconcat . toConwayGovPairs
 
+instance EraPParams era => ToExpr (ConwayGovState era)
+
 toConwayGovPairs :: (KeyValue a, EraPParams era) => ConwayGovState era -> [a]
 toConwayGovPairs cg@(ConwayGovState _ _) =
   let ConwayGovState {..} = cg
    in [ "gov" .= cgGovActionsState
-      , "ratify" .= cgRatifyState
+      , "ratify" .= cgEnactState
       ]
 
 instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
   type GovState (ConwayEra c) = ConwayGovState (ConwayEra c)
 
-  getConstitution g = Just $ g ^. cgRatifyStateL . rsEnactStateL . ensConstitutionL
+  getConstitution g = Just $ g ^. cgEnactStateL . ensConstitutionL
 
   curPParamsGovStateL = curPParamsConwayGovStateL
 
   prevPParamsGovStateL = prevPParamsConwayGovStateL
 
+  obligationGovState st =
+    foldMap' gasDeposit (st ^. cgGovActionsStateL . curGovActionsStateL)
+
 class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)
 
 instance Crypto c => ConwayEraGov (ConwayEra c) where
-  constitutionGovStateL = cgRatifyStateL . rsEnactStateL . ensConstitutionL
+  constitutionGovStateL = cgEnactStateL . ensConstitutionL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -69,13 +69,14 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Core (Era (..), EraPParams, PParamsUpdate)
+import Cardano.Ledger.Core (Era (..), EraPParams (..), PParamsUpdate)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.SafeHash (extractHash)
 import Cardano.Ledger.Shelley.Governance (Constitution)
 import Cardano.Ledger.Shelley.RewardProvenance ()
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxId (..))
 import Cardano.Slotting.Slot (EpochNo)
 import Control.DeepSeq (NFData (..))
@@ -105,11 +106,15 @@ newtype GovActionIx = GovActionIx Word32
     , ToJSON
     )
 
+instance ToExpr GovActionIx
+
 data GovActionId c = GovActionId
   { gaidTxId :: !(TxId c)
   , gaidGovActionIx :: !GovActionIx
   }
   deriving (Generic, Eq, Ord, Show)
+
+instance ToExpr (GovActionId c)
 
 instance Crypto c => DecCBOR (GovActionId c) where
   decCBOR =
@@ -193,6 +198,8 @@ data Vote
   | VoteYes
   | Abstain
   deriving (Generic, Eq, Show, Enum, Bounded)
+
+instance ToExpr Vote
 
 instance ToJSON Vote
 
@@ -325,6 +332,8 @@ data Committee era = Committee
   }
   deriving (Eq, Show, Generic)
 
+instance ToExpr (Committee era)
+
 instance Era era => NoThunks (Committee era)
 
 instance Era era => NFData (Committee era)
@@ -369,7 +378,7 @@ data GovActionPurpose
   deriving (Eq, Show)
 
 newtype PrevGovActionId (r :: GovActionPurpose) c = PrevGovActionId (GovActionId c)
-  deriving (Eq, Show, Generic, EncCBOR, DecCBOR, NoThunks, NFData, ToJSON)
+  deriving (Eq, Show, Generic, EncCBOR, DecCBOR, NoThunks, NFData, ToJSON, ToExpr)
 
 type role PrevGovActionId nominal nominal
 
@@ -410,6 +419,8 @@ data GovAction era
       !(Constitution era)
   | InfoAction
   deriving (Generic)
+
+instance ToExpr (PParamsHKD StrictMaybe era) => ToExpr (GovAction era)
 
 deriving instance EraPParams era => Eq (GovAction era)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -46,6 +46,7 @@ import Cardano.Ledger.Conway.Core hiding (Value)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.HKD (HKD, HKDFunctor (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson hiding (Encoding, decode, encode)
@@ -137,6 +138,8 @@ data ConwayPParams f era = ConwayPParams
   }
   deriving (Generic)
 
+instance ToExpr (ConwayPParams Identity era)
+
 deriving instance Eq (ConwayPParams Identity era)
 
 deriving instance Ord (ConwayPParams Identity era)
@@ -178,6 +181,8 @@ deriving instance Show (UpgradeConwayPParams Identity)
 instance NoThunks (UpgradeConwayPParams Identity)
 
 instance NFData (UpgradeConwayPParams Identity)
+
+instance ToExpr (ConwayPParams StrictMaybe era)
 
 deriving instance Eq (UpgradeConwayPParams StrictMaybe)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -196,7 +196,7 @@ ratifyTransition ::
 ratifyTransition = do
   TRC
     ( env@RatifyEnv {reCurrentEpoch}
-      , st@RatifyState {rsEnactState, rsFuture, rsRemoved}
+      , st@RatifyState {rsEnactState, rsRemoved}
       , RatifySignal rsig
       ) <-
     judgmentContext
@@ -220,7 +220,7 @@ ratifyTransition = do
           -- Finally, filter out actions that are not processed.
           if gasExpiresAfter < reCurrentEpoch
             then pure st' {rsRemoved = ast :<| rsRemoved} -- Action expires after current Epoch. Remove it.
-            else pure st' {rsFuture = ast :<| rsFuture}
+            else pure st'
     Empty -> pure st
 
 instance EraGov era => Embed (ConwayENACT era) (ConwayRATIFY era) where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -105,7 +105,6 @@ instance
     RatifyState
       <$> arbitrary
       <*> arbitrary
-      <*> arbitrary
 
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>
@@ -136,7 +135,13 @@ instance
       <*> arbitrary
       <*> arbitrary
 
-deriving instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovActionsState era)
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovActionsState era) where
+  arbitrary =
+    GovActionsState
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovActionState era) where
   arbitrary =

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -48,7 +48,7 @@ library
         cardano-ledger-mary ^>=1.3,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley >=1.3 && <1.6,
+        cardano-ledger-shelley >=1.6 && <1.7,
         cardano-slotting,
         containers,
         data-default-class,

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -60,7 +60,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-core >=1.6 && <1.7,
-        cardano-ledger-shelley >=1.5.1 && <1.6,
+        cardano-ledger-shelley >=1.6 && <1.7,
         containers,
         deepseq,
         groups,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
@@ -8,6 +8,7 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Shelley.Governance (EraGov (..), ShelleyGovState (..), curPParamsShelleyGovStateL, prevPParamsShelleyGovStateL)
 import Cardano.Ledger.Shelley.PParams
+import Cardano.Ledger.Val (Val (..))
 import Data.Coerce
 import Lens.Micro
 
@@ -55,3 +56,5 @@ instance Crypto c => EraGov (MaryEra c) where
   curPParamsGovStateL = curPParamsShelleyGovStateL
 
   prevPParamsGovStateL = prevPParamsShelleyGovStateL
+
+  obligationGovState = const zero

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (Update)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -264,6 +265,8 @@ instance Crypto c => ShelleyEraTxBody (MaryEra c) where
   updateTxBodyL =
     lensMaryTxBodyRaw atbrUpdate $ \txBodyRaw update -> txBodyRaw {atbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
+
+  getTotalDepositsTxBody = totalTxDepositsShelley
 
 instance Crypto c => AllegraEraTxBody (MaryEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (MaryEra StandardCrypto) #-}

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -54,7 +54,7 @@ library
         containers,
         hashable,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.5 && <1.6,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.7,
         cardano-strict-containers,
         microlens,
         mtl,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.5.1.0
+## 1.6.0.0
 
+* Add `getTotalTxDepositsBody` to `ShelleyEraTxBody`
+* Add `obligationGovState` to `EraGov`
+* Add `ToExpr` instance to `Constitution`
+* Replace `obligationCertState` with `totalObligation`
+* Deprecated `totalTxDeposits`
+* Add `potEqualsObligation`
+* Add `shelleyLedgerAssertions`
+* Add `totalTxDepositsShelley`
 * Add `eqMultiSigRaw`, `shelleyEqTxRaw` and `shelleyEqTxWitsRaw`
 * Add `EqRaw` instance for `MultiSig`, `ShelleyTxWits`, `ShelleyTxAuxData`, `TxBody` and `Tx`
 * Add `ToExpr` instance for `GenesisDelegCert`, `MIRPot`, `MirTarget`, `MIRCert`,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.5.1.0
+version:            1.6.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
   keyTxRefunds,
-  totalTxDeposits,
  )
 import Cardano.Ledger.Shelley.LedgerState.Types (
   AccountState (..),
@@ -166,5 +165,5 @@ producedTxBody txBody pp dpstate =
   Produced
     { proOutputs = coinBalance (txouts txBody)
     , proFees = txBody ^. feeTxBodyL
-    , proDeposits = totalTxDeposits pp dpstate txBody
+    , proDeposits = getTotalDepositsTxBody pp dpstate txBody
     }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Shelley.Core (
 where
 
 import Cardano.Ledger.Address
+import Cardano.Ledger.CertState (CertState)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
@@ -40,6 +41,8 @@ class (ShelleyEraTxCert era, EraTxBody era) => ShelleyEraTxBody era where
   updateTxBodyG :: SimpleGetter (TxBody era) (StrictMaybe (Update era))
   default updateTxBodyG :: ProtVerAtMost era 8 => SimpleGetter (TxBody era) (StrictMaybe (Update era))
   updateTxBodyG = updateTxBodyL
+
+  getTotalDepositsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
 
 type Wdrl c = Withdrawals c
 {-# DEPRECATED Wdrl "In favor of `Cardano.Ledger.Address.Withdrawals`" #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -32,11 +32,13 @@ import Cardano.Ledger.Binary (
   encodeNullStrictMaybe,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
 import Cardano.Ledger.TreeDiff (ToExpr)
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Default.Class (Default (..))
@@ -82,6 +84,8 @@ class
   -- | Lens for accessing the previous protocol parameters
   prevPParamsGovStateL :: Lens' (GovState era) (PParams era)
 
+  obligationGovState :: GovState era -> Coin
+
 instance
   ( ToExpr (PParamsUpdate era)
   , ToExpr (PParams era)
@@ -96,6 +100,8 @@ instance Crypto c => EraGov (ShelleyEra c) where
   curPParamsGovStateL = curPParamsShelleyGovStateL
 
   prevPParamsGovStateL = prevPParamsShelleyGovStateL
+
+  obligationGovState = const zero
 
 data ShelleyGovState era = ShelleyGovState
   { proposals :: !(ProposedPPUpdates era)
@@ -214,6 +220,8 @@ data Constitution era = Constitution
   , constitutionScript :: !(StrictMaybe (ScriptHash (EraCrypto era)))
   }
   deriving (Generic)
+
+instance ToExpr (Constitution era)
 
 constitutionAnchorL :: Lens' (Constitution era) (Anchor (EraCrypto era))
 constitutionAnchorL = lens constitutionAnchor (\x y -> x {constitutionAnchor = y})

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -51,7 +51,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   payPoolDeposit,
   refundPoolDeposit,
   totalTxDeposits,
-  obligationCertState,
+  totalObligation,
   keyCertsRefunds,
   keyCertsRefundsCertState,
   totalCertsDeposits,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Keys (
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
   keyTxRefunds,
-  totalTxDeposits,
  )
 import Cardano.Ledger.Shelley.LedgerState.Types
 import Cardano.Ledger.Shelley.TxBody (MIRPot (..))
@@ -118,7 +117,7 @@ depositPoolChange ls pp txBody = (currentPool <+> txDeposits) <-> txRefunds
     -- to emphasize this point.
 
     currentPool = (utxosDeposited . lsUTxOState) ls
-    txDeposits = totalTxDeposits pp (lsCertState ls) txBody
+    txDeposits = getTotalDepositsTxBody pp (lsCertState ls) txBody
     txRefunds = keyTxRefunds pp (lsCertState ls) txBody
 
 -- Remove the rewards from the UMap, but leave the deposits alone

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
@@ -8,12 +8,13 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
-  totalTxDeposits,
   totalCertsDeposits,
   totalCertsDepositsCertState,
   keyTxRefunds,
   keyCertsRefunds,
   keyCertsRefundsCertState,
+  totalTxDeposits,
+  totalTxDepositsShelley,
 )
 where
 
@@ -79,14 +80,23 @@ totalCertsDepositsCertState pp dpstate =
 
 -- | Calculates the total amount of deposits needed for all pool registration and
 -- stake delegation certificates to be valid.
+totalTxDepositsShelley ::
+  ShelleyEraTxBody era =>
+  PParams era ->
+  CertState era ->
+  TxBody era ->
+  Coin
+totalTxDepositsShelley pp dpstate txb =
+  totalCertsDepositsCertState pp dpstate (txb ^. certsTxBodyL)
+
+{-# DEPRECATED totalTxDeposits "Use totalTxDepositsShelley or getTotalDepositsTxBody instead" #-}
 totalTxDeposits ::
   ShelleyEraTxBody era =>
   PParams era ->
   CertState era ->
   TxBody era ->
   Coin
-totalTxDeposits pp dpstate txb =
-  totalCertsDepositsCertState pp dpstate (txb ^. certsTxBodyL)
+totalTxDeposits = totalTxDepositsShelley
 
 -- | Compute the key deregistration refunds in a transaction
 keyCertsRefundsCertState ::

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
@@ -39,7 +39,8 @@ import Cardano.Ledger.Shelley.LedgerState (
   lsCertState,
   lsUTxOState,
   lsUTxOStateL,
-  obligationCertState,
+  totalObligation,
+  utxosGovStateL,
   pattern CertState,
   pattern EpochState,
  )
@@ -214,7 +215,7 @@ epochTransition = do
     -- kept (dsUnified of DState and psDeposits of PState) are adjusted by
     -- the rules, So we can recompute the utxosDeposited field using adjustedCertState
     -- since we have the invariant that: obligationCertState dpstate == utxosDeposited utxostate
-    oblgNew = obligationCertState adjustedCertState
+    oblgNew = totalObligation adjustedCertState (utxoSt'' ^. utxosGovStateL)
     reserves = asReserves acnt'
     utxoSt''' = utxoSt'' {utxosDeposited = oblgNew}
     acnt'' = acnt' {asReserves = reserves}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -75,7 +75,7 @@ newtype ShelleyUpecPredFailure era
 instance NoThunks (ShelleyUpecPredFailure era)
 
 instance
-  ( EraPParams era
+  ( EraGov era
   , Default (PParams era)
   , GovState era ~ ShelleyGovState era
   ) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -67,7 +67,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
   UTxOState (..),
   keyTxRefunds,
-  totalTxDeposits,
  )
 import Cardano.Ledger.Shelley.LedgerState.IncrementalStake
 import Cardano.Ledger.Shelley.PParams (Update)
@@ -427,7 +426,7 @@ utxoInductive = do
   runTest $ validateMaxTxSizeUTxO pp tx
 
   let refunded = keyTxRefunds pp dpstate txBody
-  let totalDeposits' = totalTxDeposits pp dpstate txBody
+  let totalDeposits' = getTotalDepositsTxBody pp dpstate txBody
   let depositChange = totalDeposits' Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   pure $! updateUTxOState pp u txBody depositChange ppup'

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -61,6 +61,7 @@ module Cardano.Ledger.Shelley.TxBody (
   -- * Helpers
   addrEitherShelleyTxOutL,
   valueEitherShelleyTxOutL,
+  totalTxDepositsShelley,
 ) where
 
 import Cardano.Ledger.Address (RewardAcnt (..))
@@ -106,6 +107,7 @@ import Cardano.Ledger.PoolParams
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
+import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (totalTxDepositsShelley)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
@@ -319,6 +321,8 @@ instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   updateTxBodyL =
     lensMemoRawType stbrUpdate $ \txBodyRaw update -> txBodyRaw {stbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
+
+  getTotalDepositsTxBody = totalTxDepositsShelley
 
 deriving newtype instance
   (Era era, NoThunks (TxOut era), NoThunks (TxCert era), NoThunks (PParamsUpdate era)) =>

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -89,7 +89,7 @@ library
         cardano-ledger-byron-test,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3.1,
         cardano-ledger-pretty,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.5 && <1.6,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.7,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting,
         cborg,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -74,6 +74,7 @@ genAccountState Constants {minTreasury, maxTreasury, minReserves, maxReserves} =
 -- with meaningful delegation certificates.
 instance
   ( EraGen era
+  , EraGov era
   , Mock (EraCrypto era)
   , MinLEDGER_STS era
   , Embed (EraRule "DELPL" era) (CERTS era)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -52,7 +52,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   prevPParamsEpochStateL,
   rewards,
   rs,
-  totalTxDeposits,
  )
 import Cardano.Ledger.Shelley.Rewards (sumRewards)
 import Cardano.Ledger.Shelley.Rules (
@@ -295,7 +294,7 @@ checkPreservation SourceSignalTarget {source, target, signal} count =
         ++ "\ncerts:"
         ++ showListy (("   " ++) . synopsisCert) (toList $ tx ^. bodyTxL . certsTxBodyL)
         ++ "total deposits "
-        ++ show (totalTxDeposits currPP oldCertState (tx ^. bodyTxL))
+        ++ show (getTotalDepositsTxBody currPP oldCertState (tx ^. bodyTxL))
         ++ "\ntotal refunds "
         ++ show (keyTxRefunds currPP oldCertState (tx ^. bodyTxL))
 
@@ -481,7 +480,7 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
         created =
           coinBalance u'
             <+> (txb ^. feeTxBodyL)
-            <+> totalTxDeposits pp_ dpstate txb
+            <+> getTotalDepositsTxBody pp_ dpstate txb
         consumed_ =
           coinBalance u
             <+> keyTxRefunds pp_ dpstate txb
@@ -522,7 +521,7 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
             coinBalance (txouts @era txb)
               <> txb
                 ^. feeTxBodyL
-              <> totalTxDeposits pp_ dpstate txb
+              <> getTotalDepositsTxBody pp_ dpstate txb
 
 preserveOutputsTx ::
   forall era ledger.

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
@@ -25,7 +25,8 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   NewEpochState (..),
   UTxOState (..),
-  obligationCertState,
+  totalObligation,
+  utxosGovStateL,
  )
 import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..), RewardUpdate (..))
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
@@ -37,6 +38,7 @@ import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
+import Lens.Micro ((^.))
 import Test.Cardano.Ledger.Core.KeyPair (vKey)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, C_Crypto)
 import Test.Cardano.Ledger.Shelley.Examples (testCHAINExample)
@@ -568,7 +570,13 @@ setDepositsToObligation nes = nes {nesEs = es {esLState = ls {lsUTxOState = utxo
   where
     es = nesEs nes
     ls = esLState es
-    utxoState = (lsUTxOState ls) {utxosDeposited = obligationCertState $ lsCertState ls}
+    utxoState =
+      (lsUTxOState ls)
+        { utxosDeposited =
+            totalObligation
+              (lsCertState ls)
+              (utxoState ^. utxosGovStateL)
+        }
 
 -- | This property test checks the correctness of the TICKF transation.
 -- TICKF is used by the consensus layer to get a ledger view in a computationally

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-api`
 
-## 1.4.0.1
+## 1.4.1.0
 
-*
+* Add `cgEnactStateL`
 
 ## 1.4.0.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-api
-version:            1.4.0.1
+version:            1.4.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -56,7 +56,7 @@ library
         cardano-ledger-conway >=1.7,
         cardano-ledger-core >=1.5 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5,
+        cardano-ledger-shelley ^>=1.6,
         cardano-slotting,
         containers,
         microlens,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Api.Governance (
   -- ** Governance State
   ConwayGovState (..),
   cgRatifyStateL,
+  cgEnactStateL,
   cgGovActionsStateL,
   GovActionsState (..),
   RatifyState (..),
@@ -68,6 +69,7 @@ import Cardano.Ledger.Conway.Governance (
   Voter (..),
   VotingProcedure (..),
   VotingProcedures (..),
+  cgEnactStateL,
   cgGovActionsStateL,
   cgRatifyStateL,
   constitutionAnchorL,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -291,6 +291,8 @@ deriving instance Era era => EncCBOR (CommitteeState era)
 
 deriving instance Era era => DecCBOR (CommitteeState era)
 
+deriving instance Era era => ToJSON (CommitteeState era)
+
 instance Era era => ToCBOR (CommitteeState era) where
   toCBOR = toEraCBOR @era
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
@@ -220,6 +220,7 @@ class
   , FromCBOR (PParamsHKD Identity era)
   , NoThunks (PParamsHKD Identity era)
   , ToJSON (PParamsHKD Identity era)
+  , ToExpr (PParamsHKD Identity era)
   , Eq (PParamsHKD StrictMaybe era)
   , Ord (PParamsHKD StrictMaybe era)
   , Show (PParamsHKD StrictMaybe era)
@@ -230,6 +231,7 @@ class
   , FromCBOR (PParamsHKD StrictMaybe era)
   , NoThunks (PParamsHKD StrictMaybe era)
   , ToJSON (PParamsHKD StrictMaybe era)
+  , ToExpr (PParamsHKD StrictMaybe era)
   ) =>
   EraPParams era
   where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.UMap
 import qualified Cardano.Ledger.UMap as UMap
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad.Identity (Identity (..))
+import Data.Aeson (ToJSON)
 import Data.Kind
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -74,7 +75,9 @@ instance Crypto c => EncCBOR (DRepState c) where
         !> To drepAnchor
         !> To drepDeposit
 
-instance ToExpr (DRepState era)
+instance ToExpr (DRepState c)
+
+instance Crypto c => ToJSON (DRepState c)
 
 drepExpiryL :: Lens' (DRepState c) EpochNo
 drepExpiryL = lens drepExpiry (\x y -> x {drepExpiry = y})

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -42,7 +42,7 @@ library
         cardano-ledger-conway ^>=1.8,
         cardano-ledger-core ^>=1.6,
         cardano-ledger-mary >=1.0,
-        cardano-ledger-shelley ^>=1.5,
+        cardano-ledger-shelley ^>=1.6,
         cardano-protocol-tpraos >=1.0,
         cardano-slotting,
         containers,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -266,7 +266,15 @@ instance EraPParams era => PrettyA (ConwayGovPredFailure era) where
   prettyA = viaShow
 
 instance PrettyA (PParamsUpdate era) => PrettyA (GovActionsState era) where
-  prettyA (GovActionsState x) = prettyA x
+  prettyA x@(GovActionsState _ _ _ _) =
+    let GovActionsState {..} = x
+     in ppRecord
+          "GovActionsState"
+          [ ("curGovActionsState", prettyA curGovActionsState)
+          , ("prevGovActionsState", prettyA prevGovActionsState)
+          , ("prevDRepsState", prettyA prevDRepsState)
+          , ("prevCommitteeState", prettyA prevCommitteeState)
+          ]
 
 instance PrettyA (GovActionId era) where
   prettyA gaid@(GovActionId _ _) =
@@ -330,12 +338,11 @@ instance
   ) =>
   PrettyA (RatifyState era)
   where
-  prettyA rs@(RatifyState _ _ _) =
+  prettyA rs@(RatifyState _ _) =
     let RatifyState {..} = rs
      in ppRecord
           "RatifyState"
           [ ("EnactState", prettyA rsEnactState)
-          , ("Future", prettyA rsFuture)
           , ("Removed", prettyA rsRemoved)
           ]
 
@@ -350,7 +357,7 @@ instance
      in ppRecord
           "ConwayGovState"
           [ ("GovActionsState", prettyA cgGovActionsState)
-          , ("RatifyState", prettyA cgRatifyState)
+          , ("EnactState", prettyA cgEnactState)
           ]
 
 instance

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -231,6 +231,8 @@ data PParamsField era
     CollateralPercentage Natural
   | -- | Maximum number of collateral inputs allowed in a transaction
     MaxCollateralInputs Natural
+  | -- | Proposal deposit
+    GovActionDeposit Coin
 
 -- =========================================================================
 -- Era parametric "empty" or initial values.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -96,8 +96,9 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   PState (..),
   RewardAccounts,
-  obligationCertState,
   smartUTxOState,
+  totalObligation,
+  utxosGovStateL,
  )
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley (MultiSig (..))
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
@@ -704,7 +705,7 @@ initialLedgerState gstate = LedgerState utxostate dpstate
         instantaneousRewardsZero
     pstate = PState pools Map.empty Map.empty (fmap (const poolDeposit) pools)
     -- In a wellformed LedgerState the deposited equals the obligation
-    deposited = obligationCertState dpstate
+    deposited = totalObligation dpstate (utxostate ^. utxosGovStateL)
     pools = gsInitialPoolParams gstate
     pp = mPParams (gsModel gstate)
     keyDeposit = pp ^. ppKeyDepositL

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1627,13 +1627,13 @@ pcTxBody proof txbody = ppRecord ("TxBody " <> pack (show proof)) pairs
     pairs = concatMap (pcTxBodyField proof) fields
 
 instance PrettyC (GovActionsState era) era where
-  prettyC proof (GovActionsState x) = case proof of
-    Shelley _ -> ppMap prettyA prettyA x
-    Mary _ -> ppMap prettyA prettyA x
-    Allegra _ -> ppMap prettyA prettyA x
-    Alonzo _ -> ppMap prettyA prettyA x
-    Babbage _ -> ppMap prettyA prettyA x
-    Conway _ -> ppMap prettyA prettyA x
+  prettyC proof x = case proof of
+    Shelley _ -> prettyA x
+    Mary _ -> prettyA x
+    Allegra _ -> prettyA x
+    Alonzo _ -> prettyA x
+    Babbage _ -> prettyA x
+    Conway _ -> prettyA x
 
 pc :: PrettyC t era => Proof era -> t -> IO ()
 pc proof x = putStrLn (show (prettyC proof x))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -390,6 +390,7 @@ updatePParams proof pp' ppf =
             MaxValSize maxValSize -> pp & ppMaxValSizeL .~ maxValSize
             CollateralPercentage colPerc -> pp & ppCollateralPercentageL .~ colPerc
             MaxCollateralInputs maxColInputs -> pp & ppMaxCollateralInputsL .~ maxColInputs
+            GovActionDeposit c -> pp & ppGovActionDepositL .~ c
             _ -> pp
 
 newPParams :: EraPParams era => Proof era -> [PParamsField era] -> PParams era

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -41,7 +41,7 @@ library
         cardano-ledger-conway >=1.1,
         cardano-ledger-core >=1.2 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley >=1.5 && <1.6,
+        cardano-ledger-shelley >=1.6 && <1.7,
         cardano-slotting,
         containers,
         deepseq,


### PR DESCRIPTION
# Description

This PR adds governance action state snapshotting and fixes some issues with governance action deposits. `RatifyState` is no longer stored inside `ConwayGovState` and is replaced with `EnactState`.

closes #3590

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
