### PR TITLE
Implement DRep ratification with an 'always passing' threshold

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -113,7 +113,10 @@ test-suite tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
-    other-modules:    Test.Cardano.Ledger.Conway.BinarySpec
+    other-modules:
+        Test.Cardano.Ledger.Conway.BinarySpec
+        Test.Cardano.Ledger.Conway.RatifySpec
+
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates
@@ -125,4 +128,6 @@ test-suite tests
         cardano-ledger-core:testlib,
         cardano-ledger-alonzo,
         cardano-ledger-conway,
+        cardano-ledger-core,
+        containers,
         testlib

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -2,9 +2,11 @@ module Main where
 
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Conway.RatifySpec as RatifySpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Conway" $ do
       BinarySpec.spec
+      RatifySpec.spec

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/RatifySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/RatifySpec.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.RatifySpec (spec) where
+
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Governance (
+  GovAction (..),
+  GovActionState (..),
+  Vote (..),
+ )
+import Cardano.Ledger.Conway.Rules (RatifyEnv (..), dRepAccepted, dRepAcceptedRatio)
+import Cardano.Ledger.Core
+import Data.Foldable (fold)
+import Data.Functor.Identity (Identity)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
+import qualified Data.Set as Set
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary ()
+import Test.Cardano.Ledger.Core.Arbitrary ()
+
+spec :: Spec
+spec = do
+  describe "Ratification" $ do
+    drepsProp @Conway
+    drepsPropNoStake @Conway
+
+drepsProp :: forall era. Era era => Spec
+drepsProp =
+  prop "DRep vote counts" $
+    forAll (arbitrary @(Map (DRep (EraCrypto era)) (CompactForm Coin))) $
+      \dRepDistr -> do
+        forAll (shuffle (Map.keys dRepDistr)) $ \dreps -> do
+          let size = fromIntegral $ length dreps
+              yes = ratio (30 :: Integer) size
+              drepsYes = onlyDrepsCred $ take yes dreps
+              votesYes = Map.fromList $ [(cred, VoteYes) | DRepCredential cred <- drepsYes]
+              CompactCoin stakeYes = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsYes)
+
+              no = ratio 40 size
+              drepsNo = onlyDrepsCred $ take no . drop yes $ dreps
+              votesNo = Map.fromList $ [(cred, VoteNo) | DRepCredential cred <- drepsNo]
+              CompactCoin stakeNo = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsNo)
+
+              abstain = ratio 10 size
+              drepsAbstain = onlyDrepsCred $ take abstain . drop (yes + no) $ dreps
+              votesAbstain = Map.fromList [(cred, Abstain) | DRepCredential cred <- drepsAbstain]
+              CompactCoin stakeAbstain = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsAbstain)
+
+              CompactCoin stakeAlwaysAbstain = fromMaybe (CompactCoin 0) $ Map.lookup DRepAlwaysAbstain dRepDistr
+              CompactCoin stakeAlwaysNoConfidence = fromMaybe (CompactCoin 0) $ Map.lookup DRepAlwaysNoConfidence dRepDistr
+              CompactCoin notVotedStake =
+                fold $
+                  Map.withoutKeys
+                    dRepDistr
+                    (Set.fromList (drepsYes ++ drepsNo ++ drepsAbstain ++ [DRepAlwaysAbstain, DRepAlwaysNoConfidence]))
+
+              votes = Map.union votesYes $ Map.union votesNo votesAbstain
+
+              CompactCoin totalStake = fold dRepDistr
+
+              actual = dRepAcceptedRatio @era dRepDistr votes InfoAction
+              expected
+                | totalStake == stakeAbstain + stakeAlwaysAbstain = 0
+                | otherwise = toInteger stakeYes % toInteger (totalStake - stakeAbstain - stakeAlwaysAbstain)
+
+          actual `shouldBe` expected
+
+          let expectedRephrased
+                | stakeYes + stakeNo + notVotedStake + stakeAlwaysNoConfidence == 0 = 0
+                | otherwise = toInteger stakeYes % toInteger (stakeYes + stakeNo + notVotedStake + stakeAlwaysNoConfidence)
+          actual `shouldBe` expectedRephrased
+
+          let actualNoConfidence = dRepAcceptedRatio @era dRepDistr votes (NoConfidence SNothing)
+              expectedNoConfidence
+                | totalStake == stakeAbstain + stakeAlwaysAbstain = 0
+                | otherwise = toInteger (stakeYes + stakeAlwaysNoConfidence) % toInteger (totalStake - stakeAbstain - stakeAlwaysAbstain)
+          actualNoConfidence `shouldBe` expectedNoConfidence
+  where
+    ratio pct tot = ceiling $ (pct * tot) % 100
+    onlyDrepsCred l =
+      filter
+        ( \case
+            DRepCredential _ -> True
+            _ -> False
+        )
+        l
+
+drepsPropNoStake ::
+  forall era.
+  ( EraPParams era
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  , Arbitrary (PParamsHKD Identity era)
+  ) =>
+  Spec
+drepsPropNoStake =
+  prop "If there is no stake, accept only if the threshold is zero" $
+    forAll
+      ((,) <$> arbitrary @(RatifyEnv era) <*> arbitrary @(GovActionState era))
+      ( \(env, gas) -> do
+          dRepAccepted @era env {reDRepDistr = Map.empty} gas 0
+            `shouldBe` True
+          dRepAccepted @era env {reDRepDistr = Map.empty} gas (1 % 2)
+            `shouldBe` False
+      )

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -85,7 +85,7 @@ instance Crypto c => Arbitrary (AlonzoScript (ConwayEra c)) where
   arbitrary = genAlonzoScript [PlutusV1, PlutusV2, PlutusV3]
 
 ------------------------------------------------------------------------------------------
--- Cardano.Ledger.Conway.Gov ------------------------------------------------------
+-- Cardano.Ledger.Conway.Goverance  ------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
 instance
@@ -104,6 +104,17 @@ instance
   arbitrary =
     RatifyState
       <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance
+  (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>
+  Arbitrary (RatifyEnv era)
+  where
+  arbitrary =
+    RatifyEnv
+      <$> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
 


### PR DESCRIPTION
# Description

Closes https://github.com/input-output-hk/cardano-ledger/issues/3612

An example of the computation:

For these Dreps:
```
D1 -> s1
D2 -> s2
D3 -> s3
D4 -> s4
Abstain -> sA
NoConfidence -> sN
```

and these votes:
```
D1 -> Yes
D2 -> No
D3 -> Abstain
D9 -> No  -- This is not in the drep distribution map
```

We need to compute this ratio in case of an action different from NoConfidence:
` s1/(s1 + s2 + s3 + s4 + sA + sN - s3 -sA)` 
and this one for NoConfidence:
` (s1 + sN)/(s1 + s2 + s3 + s4 + sA + sN - s3 -sA)` 

Because we don't have the ratios precomputed (as is the case  for spo stake distribution), instead of folding to get the total and then subtracting the abstains, we fold the distribution and only add what's necessary, depending on the vote and on the action. 



<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
