### PR TITLE
Avoid using sequence of tuples, by adding GovActionId to GovActionState

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.7.0.1
+## 1.8.0.0
 
-*
+* Add field `gasId` to `GovActionState`
+* Add `insertGovActionsState`
+* Change type of `rsRemoved` in `RatifyState` to use  `GovActionState` instead of a tuple
+* Change `RatifySignal` to use `GovActionsState` instead of a tuple
 
 ## 1.7.0.0
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ## 1.7.0.0
 
-* Add `Network` validation for `ProposalProcedure` and `TreasuryWithdrawals` in GOV #3659
 * Make `DELEG`, `POOL` and `GOVCERT` conform to spec-v0.8 #3628
   * Add `CertEnv` and `CertsEnv` to pass `EpochNo` down from `LEDGER` to sub-rules
   * Add `drepDeposit` to `DRepState` to track deposits paid by `DRep`s

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.7.0.0
+version:            1.8.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -17,7 +17,7 @@
 module Cardano.Ledger.Conway.Governance (
   EraGov (..),
   GovActionsState (..),
-  insertGovActionEntry,
+  insertGovActionsState,
   EnactState (..),
   RatifyState (..),
   ConwayGovState (..),

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,6 +17,7 @@
 module Cardano.Ledger.Conway.Governance (
   EraGov (..),
   GovActionsState (..),
+  insertGovActionEntry,
   EnactState (..),
   RatifyState (..),
   ConwayGovState (..),
@@ -95,13 +97,15 @@ import Control.DeepSeq (NFData (..))
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Default.Class (Default (..))
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
 
 data GovActionState era = GovActionState
-  { gasCommitteeVotes :: !(Map (Credential 'HotCommitteeRole (EraCrypto era)) Vote)
+  { gasId :: !(GovActionId (EraCrypto era))
+  , gasCommitteeVotes :: !(Map (Credential 'HotCommitteeRole (EraCrypto era)) Vote)
   , gasDRepVotes :: !(Map (Credential 'DRepRole (EraCrypto era)) Vote)
   , gasStakePoolVotes :: !(Map (KeyHash 'StakePool (EraCrypto era)) Vote)
   , gasDeposit :: !Coin
@@ -116,9 +120,10 @@ instance EraPParams era => ToJSON (GovActionState era) where
   toEncoding = pairs . mconcat . toGovActionStatePairs
 
 toGovActionStatePairs :: (KeyValue a, EraPParams era) => GovActionState era -> [a]
-toGovActionStatePairs gas@(GovActionState _ _ _ _ _ _ _) =
+toGovActionStatePairs gas@(GovActionState _ _ _ _ _ _ _ _) =
   let GovActionState {..} = gas
-   in [ "committeeVotes" .= gasCommitteeVotes
+   in [ "actionId" .= gasId
+      , "committeeVotes" .= gasCommitteeVotes
       , "dRepVotes" .= gasDRepVotes
       , "stakePoolVotes" .= gasStakePoolVotes
       , "deposit" .= gasDeposit
@@ -146,11 +151,13 @@ instance EraPParams era => DecCBOR (GovActionState era) where
         <! From
         <! From
         <! From
+        <! From
 
 instance EraPParams era => EncCBOR (GovActionState era) where
   encCBOR GovActionState {..} =
     encode $
       Rec GovActionState
+        !> To gasId
         !> To gasCommitteeVotes
         !> To gasDRepVotes
         !> To gasStakePoolVotes
@@ -162,7 +169,14 @@ instance EraPParams era => EncCBOR (GovActionState era) where
 newtype GovActionsState era = GovActionsState
   { unGovActionsState :: Map (GovActionId (EraCrypto era)) (GovActionState era)
   }
-  deriving (Generic, NFData)
+  deriving (Generic, NFData, Semigroup, Monoid)
+
+insertGovActionsState ::
+  GovActionState era ->
+  GovActionsState era ->
+  GovActionsState era
+insertGovActionsState v@GovActionState {gasId} (GovActionsState m) =
+  GovActionsState $ Map.insert gasId v m
 
 deriving instance EraPParams era => Eq (GovActionsState era)
 
@@ -274,16 +288,14 @@ instance EraPParams era => NoThunks (EnactState era)
 
 data RatifyState era = RatifyState
   { rsEnactState :: !(EnactState era)
-  , rsFuture ::
-      !( StrictSeq
-          (GovActionId (EraCrypto era), GovActionState era)
-       )
-  , rsRemoved ::
-      !( StrictSeq
-          (GovActionId (EraCrypto era), GovActionState era)
-       )
+  , rsFuture :: !(StrictSeq (GovActionState era))
+  , rsRemoved :: !(StrictSeq (GovActionState era))
   }
-  deriving (Generic, Eq, Show)
+  deriving (Generic)
+
+deriving instance EraPParams era => Eq (RatifyState era)
+
+deriving instance EraPParams era => Show (RatifyState era)
 
 rsEnactStateL :: Lens' (RatifyState era) (EnactState era)
 rsEnactStateL = lens rsEnactState (\x y -> x {rsEnactState = y})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Conway.Governance (
   RatifyState (..),
   cgGovActionsStateL,
   cgRatifyStateL,
-  insertGovActionEntry,
+  insertGovActionsState,
  )
 import Cardano.Ledger.Conway.Rules.Enact (EnactPredFailure)
 import Cardano.Ledger.Conway.Rules.Ratify (RatifyEnv (..), RatifySignal (..))
@@ -268,7 +268,7 @@ epochTransition = do
           & prevPParamsEpochStateL .~ pp
           & curPParamsEpochStateL .~ pp
       -- TODO can we be more efficient?
-      newGov = foldr' insertGovActionEntry mempty rsFuture
+      newGov = foldr' insertGovActionsState mempty rsFuture
       esGovernanceL = esLStateL . lsUTxOStateL . utxosGovStateL
       esDonationL :: Lens' (EpochState era) Coin
       esDonationL = esLStateL . lsUTxOStateL . utxosDonationL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -151,7 +151,8 @@ addAction epoch gaid c addr act (GovActionsState st) =
   where
     gai' =
       GovActionState
-        { gasCommitteeVotes = mempty
+        { gasId = gaid
+        , gasCommitteeVotes = mempty
         , gasDRepVotes = mempty
         , gasStakePoolVotes = mempty
         , gasDeposit = c

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -147,6 +147,7 @@ instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovActionState e
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovAction era) where
   arbitrary =

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-pretty
-version:            1.3.0.1
+version:            1.3.0.2
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -39,7 +39,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway ^>=1.7,
+        cardano-ledger-conway ^>=1.8,
         cardano-ledger-core ^>=1.6,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley ^>=1.5,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -287,11 +287,12 @@ instance PrettyA (Anchor era) where
   prettyA = viaShow
 
 instance PrettyA (PParamsUpdate era) => PrettyA (GovActionState era) where
-  prettyA gas@(GovActionState _ _ _ _ _ _ _) =
+  prettyA gas@(GovActionState _ _ _ _ _ _ _ _) =
     let GovActionState {..} = gas
      in ppRecord
           "GovActionState"
-          [ ("CommitteVotes", prettyA gasCommitteeVotes)
+          [ ("Id", prettyA gasId)
+          , ("CommitteVotes", prettyA gasCommitteeVotes)
           , ("DRepVotes", prettyA gasDRepVotes)
           , ("StakePoolVotes", prettyA gasStakePoolVotes)
           , ("Return Address", prettyA gasReturnAddr)


### PR DESCRIPTION
# Description

closes #3578

This PR fixes the above ticket in a different way. Namely, by adding `govActionId` to the `GovActionState`. This approach is very similar to how `PoolParams` are implemented.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
