### PR TITLE
Remove crypto parameterization from `AnchorData`

### DIFF
--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -309,9 +309,9 @@ stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 ; GOVCERT
 reg_committee_hot_key_cert = (14, committee_cold_credential, committee_hot_credential)
 unreg_committee_hot_key_cert = (15, committee_cold_credential)
-reg_drep_cert = (16, voting_credential, coin, anchor / null)
-unreg_drep_cert = (17, voting_credential, coin)
-update_drep_cert = (18, voting_credential, anchor / null)
+reg_drep_cert = (16, drep_credential, coin, anchor / null)
+unreg_drep_cert = (17, drep_credential, coin)
+update_drep_cert = (18, drep_credential, anchor / null)
 
 
 delta_coin = int
@@ -329,7 +329,7 @@ drep =
   ]
 
 stake_credential = credential
-voting_credential = credential
+drep_credential = credential
 committee_cold_credential = credential
 committee_hot_credential = credential
 

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -105,11 +105,11 @@ treasury_withdrawals_action = (2, { $reward_account => coin })
 
 no_confidence = (3, gov_action_id / null)
 
-new_committee = (4, gov_action_id / null, set<$committee_coldkey_credential>, committee)
+new_committee = (4, gov_action_id / null, set<$committee_cold_credential>, committee)
 
 new_constitution = (5, gov_action_id / null, constitution)
 
-committee = [{ $committee_coldkey_credential => epoch }, unit_interval]
+committee = [{ $committee_cold_credential => epoch }, unit_interval]
 
 constitution =
   [ anchor
@@ -307,8 +307,8 @@ vote_reg_deleg_cert = (12, stake_credential, drep, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 
 ; GOVCERT
-reg_committee_hot_key_cert = (14, committee_cold_keyhash, committee_hot_keyhash)
-unreg_committee_hot_key_cert = (15, committee_cold_keyhash)
+reg_committee_hot_key_cert = (14, committee_cold_credential, committee_hot_credential)
+unreg_committee_hot_key_cert = (15, committee_cold_credential)
 reg_drep_cert = (16, voting_credential, coin, anchor / null)
 unreg_drep_cert = (17, voting_credential, coin)
 update_drep_cert = (18, voting_credential, anchor / null)
@@ -330,7 +330,8 @@ drep =
 
 stake_credential = credential
 voting_credential = credential
-committee_coldkey_credential = credential
+committee_cold_credential = credential
+committee_hot_credential = credential
 
 pool_params = ( operator:       pool_keyhash
               , vrf_keyhash:    vrf_keyhash
@@ -566,8 +567,6 @@ epoch = uint
 
 addr_keyhash           = $hash28
 pool_keyhash           = $hash28
-committee_cold_keyhash = credential
-committee_hot_keyhash  = credential
 
 vrf_keyhash           = $hash32
 auxiliary_data_hash   = $hash32

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Remove redundant reimplementation of lens function `%~`: `updateWithLens`.
 * Change `getConstituitionHash` to `getConstitution`
 * Replace `constitutionHash` with `constitutionAnchor`
 * Add `upgradeShelleyTxCert`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -120,7 +120,6 @@ module Cardano.Ledger.Shelley.LedgerState (
   epochStateStakeDistrL,
   epochStateRegDrepL,
   epochStateUMapL,
-  updateWithLens,
   freshDRepPulser,
 
   -- * Lenses from CertState

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -52,8 +52,6 @@ import Data.Set (Set)
 import Lens.Micro ((&), (.~), (^.))
 import Lens.Micro.Extras (view)
 
--- import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, prevPParamsEpochStateL)
-
 -- | This function returns the coin balance of a given pot, either the
 -- reserves or the treasury, after the instantaneous rewards and pot
 -- transfers are accounted for.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -78,7 +78,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.VMap (VB, VMap, VP)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', lens, (&), (.~), (^.), _1, _2)
+import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 
@@ -730,10 +730,6 @@ epochStateRegDrepL = esLStateL . lsCertStateL . certVStateL . vsDRepsL
 
 epochStateUMapL :: Lens' (EpochState era) (UMap (EraCrypto era))
 epochStateUMapL = esLStateL . lsCertStateL . certDStateL . dsUnifiedL
-
--- | update a field of 'x' accessed by the given lens 'l' with the adjusting function 'update'
-updateWithLens :: a -> Lens' a b -> (b -> b) -> a
-updateWithLens x l update = x & l .~ update (x ^. l)
 
 -- | Construct a new (as yet unpulsed) DRepDistr from 3 pieces of the EpochState.
 --   1) The unified map (storing the map from staking credentials to DReps).

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -46,7 +46,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   UTxOState (..),
   curPParamsEpochStateL,
   newEpochStateDRepDistrL,
-  updateWithLens,
  )
 import Cardano.Ledger.Shelley.Rules.NewEpoch (
   ShelleyNEWEPOCH,
@@ -67,7 +66,7 @@ import Control.State.Transition
 import qualified Data.Map.Strict as Map
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro ((%~), (&), (.~), (^.))
 import NoThunks.Class (NoThunks (..))
 
 -- ==================================================
@@ -274,7 +273,7 @@ bheadTransition = do
       TRC (RupdEnv bprev es, nesRu nes1, slot)
 
   let nes2 = nes1 {nesRu = ru''}
-  let nes3 = updateWithLens nes2 newEpochStateDRepDistrL pulseDRepDistr
+  let nes3 = nes2 & newEpochStateDRepDistrL %~ pulseDRepDistr
   pure nes3
 
 instance

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -58,6 +58,6 @@ queryConstitution nes =
 queryConstitutionHash ::
   EraGov era =>
   NewEpochState era ->
-  Maybe (SafeHash (EraCrypto era) (AnchorData (EraCrypto era)))
+  Maybe (SafeHash (EraCrypto era) AnchorData)
 queryConstitutionHash nes =
   anchorDataHash . constitutionAnchor <$> queryConstitution nes


### PR DESCRIPTION
# Description

Besides fixing up AnchorData (#3639) this PR also:

* Fixes names in CDDL
* Removes redundant definition of a lnes function


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
