### PR TITLE
Governance queries

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.Allegra.Translation (shelleyToAllegraAVVMsToDelete) where
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.Binary (DecoderError)
+import Cardano.Ledger.CertState (CommitteeState (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -128,8 +129,13 @@ instance Crypto c => TranslateEra (AllegraEra c) UTxOState where
 instance Crypto c => TranslateEra (AllegraEra c) DState where
   translateEra _ DState {..} = pure DState {..}
 
+instance Crypto c => TranslateEra (AllegraEra c) CommitteeState where
+  translateEra _ CommitteeState {..} = pure CommitteeState {..}
+
 instance Crypto c => TranslateEra (AllegraEra c) VState where
-  translateEra _ VState {..} = pure VState {..}
+  translateEra ctx VState {..} = do
+    committeeState <- translateEra ctx vsCommitteeState
+    pure VState {vsCommitteeState = committeeState, ..}
 
 instance Crypto c => TranslateEra (AllegraEra c) PState where
   translateEra _ PState {..} = pure PState {..}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.PParams ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Binary (DecoderError)
-import Cardano.Ledger.CertState (PState (..), VState (..))
+import Cardano.Ledger.CertState (CommitteeState (..), PState (..), VState (..))
 import Cardano.Ledger.Core (upgradePParams, upgradePParamsUpdate, upgradeTxOut)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -105,8 +105,13 @@ instance Crypto c => TranslateEra (AlonzoEra c) EpochState where
 instance Crypto c => TranslateEra (AlonzoEra c) DState where
   translateEra _ DState {..} = pure DState {..}
 
+instance Crypto c => TranslateEra (AlonzoEra c) CommitteeState where
+  translateEra _ CommitteeState {..} = pure CommitteeState {..}
+
 instance Crypto c => TranslateEra (AlonzoEra c) VState where
-  translateEra _ VState {..} = pure VState {..}
+  translateEra ctx VState {..} = do
+    committeeState <- translateEra ctx vsCommitteeState
+    pure VState {vsCommitteeState = committeeState, ..}
 
 instance Crypto c => TranslateEra (AlonzoEra c) PState where
   translateEra _ PState {..} = pure PState {..}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams ()
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
 import Cardano.Ledger.Binary (DecoderError)
+import Cardano.Ledger.CertState (CommitteeState (..))
 import qualified Cardano.Ledger.Core as Core (Tx)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley.API (
@@ -103,8 +104,13 @@ instance Crypto c => TranslateEra (BabbageEra c) EpochState where
 instance Crypto c => TranslateEra (BabbageEra c) DState where
   translateEra _ DState {..} = pure DState {..}
 
+instance Crypto c => TranslateEra (BabbageEra c) CommitteeState where
+  translateEra _ CommitteeState {..} = pure CommitteeState {..}
+
 instance Crypto c => TranslateEra (BabbageEra c) VState where
-  translateEra _ VState {..} = pure VState {..}
+  translateEra ctx VState {..} = do
+    committeeState <- translateEra ctx vsCommitteeState
+    pure VState {vsCommitteeState = committeeState, ..}
 
 instance Crypto c => TranslateEra (BabbageEra c) PState where
   translateEra _ PState {..} = pure PState {..}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -20,12 +19,12 @@ module Cardano.Ledger.Conway.Translation (
 ) where
 
 import Cardano.Ledger.Address (addrPtrNormalize)
-import Cardano.Ledger.Alonzo.Scripts.Data (translateDatum)
-
 import Cardano.Ledger.Alonzo.Scripts (translateAlonzoScript)
+import Cardano.Ledger.Alonzo.Scripts.Data (translateDatum)
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Binary (DecoderError)
+import Cardano.Ledger.CertState (CommitteeState (..))
 import Cardano.Ledger.Conway.Core hiding (Tx)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
@@ -122,8 +121,13 @@ instance Crypto c => TranslateEra (ConwayEra c) EpochState where
 instance Crypto c => TranslateEra (ConwayEra c) DState where
   translateEra _ DState {..} = pure DState {..}
 
+instance Crypto c => TranslateEra (ConwayEra c) CommitteeState where
+  translateEra _ CommitteeState {..} = pure CommitteeState {..}
+
 instance Crypto c => TranslateEra (ConwayEra c) VState where
-  translateEra _ VState {..} = pure VState {..}
+  translateEra ctx VState {..} = do
+    committeeState <- translateEra ctx vsCommitteeState
+    pure VState {vsCommitteeState = committeeState, ..}
 
 instance Crypto c => TranslateEra (ConwayEra c) PState where
   translateEra _ PState {..} = pure PState {..}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -13,6 +13,7 @@
 module Cardano.Ledger.Mary.Translation where
 
 import Cardano.Ledger.Binary (DecoderError)
+import Cardano.Ledger.CertState (CommitteeState (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -79,8 +80,13 @@ instance Crypto c => TranslateEra (MaryEra c) EpochState where
 instance Crypto c => TranslateEra (MaryEra c) DState where
   translateEra _ DState {..} = pure DState {..}
 
+instance Crypto c => TranslateEra (MaryEra c) CommitteeState where
+  translateEra _ CommitteeState {..} = pure CommitteeState {..}
+
 instance Crypto c => TranslateEra (MaryEra c) VState where
-  translateEra _ VState {..} = pure VState {..}
+  translateEra ctx VState {..} = do
+    committeeState <- translateEra ctx vsCommitteeState
+    pure VState {vsCommitteeState = committeeState, ..}
 
 instance Crypto c => TranslateEra (MaryEra c) PState where
   translateEra _ PState {..} = pure PState {..}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -136,7 +136,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   psDepositsL,
   vsDRepsL,
   vsDRepDistrL,
-  vsCommitteeHotKeysL,
+  vsCommitteeStateL,
 
   -- * Lenses from SnapShot(s)
   ssStakeMarkL,

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Add `queryGovState`, `queryDRepState`, `queryDRepStakeDistr` and `queryCommitteeState`
 * Add `queryConstitution`.
 * Replace `constitutionHash` with `constitutionAnchor`
 * Add `eraName`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -6,17 +6,35 @@ module Cardano.Ledger.Api.State.Query (
   filterStakePoolDelegsAndRewards,
   queryStakePoolDelegsAndRewards,
 
+  -- * @GetGovState@
+  queryGovState,
+
+  -- * @GetConstitution@
+  queryConstitution,
+
   -- * @GetConstitutionHash@
   queryConstitutionHash,
+
+  -- * @GetDRepState@
+  queryDRepState,
+
+  -- * @GetDRepStakeDistr@
+  queryDRepStakeDistr,
+
+  -- * @GetCommitteeState@
+  queryCommitteeState,
 ) where
 
 import Cardano.Ledger.Allegra.Core (Constitution (constitutionAnchor))
+import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Conway.Governance (Anchor (..), AnchorData, EraGov (..))
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
+import Cardano.Ledger.DRepDistr (extractDRepDistr)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.Shelley.Governance (EraGov (GovState, getConstitution))
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.UMap (
   StakeCredentials (scRewards, scSPools),
@@ -24,6 +42,7 @@ import Cardano.Ledger.UMap (
   domRestrictedStakeCredentials,
  )
 import Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Lens.Micro
 
@@ -52,8 +71,7 @@ getDState :: NewEpochState era -> DState era
 getDState = certDState . lsCertState . esLState . nesEs
 
 queryConstitution :: EraGov era => NewEpochState era -> Maybe (Constitution era)
-queryConstitution nes =
-  getConstitution (nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL)
+queryConstitution = getConstitution . queryGovState
 
 queryConstitutionHash ::
   EraGov era =>
@@ -61,3 +79,40 @@ queryConstitutionHash ::
   Maybe (SafeHash (EraCrypto era) AnchorData)
 queryConstitutionHash nes =
   anchorDataHash . constitutionAnchor <$> queryConstitution nes
+
+-- | This query returns all of the state related to governance
+queryGovState :: NewEpochState era -> GovState era
+queryGovState nes = nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL
+
+-- | Query DRep state.
+queryDRepState ::
+  NewEpochState era ->
+  -- | Specify a set of DRep credentials whose state should be returned. When this set is
+  -- empty, states for all of the DReps will be returned.
+  Set (Credential 'DRepRole (EraCrypto era)) ->
+  Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era))
+queryDRepState nes creds
+  | null creds = drepsState
+  | otherwise = drepsState `Map.restrictKeys` creds
+  where
+    drepsState = vsDReps $ certVState $ lsCertState $ esLState $ nesEs nes
+
+-- | Query DRep stake distribution. Note that this can be an expensive query because there
+-- is a chance that current distribution has not been fully computed yet.
+queryDRepStakeDistr ::
+  NewEpochState era ->
+  -- | Specify DRep Ids whose stake distribution should be returned. When this set is
+  -- empty, distributions for all of the DReps will be returned.
+  Set (DRep (EraCrypto era)) ->
+  Map (DRep (EraCrypto era)) Coin
+queryDRepStakeDistr nes creds
+  | null creds = Map.map fromCompact distr
+  | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` creds
+  where
+    distr = extractDRepDistr distrPulser
+    distrPulser = vsDRepDistr $ certVState $ lsCertState $ esLState $ nesEs nes
+
+-- | Query committee members
+queryCommitteeState :: NewEpochState era -> CommitteeState era
+queryCommitteeState nes =
+  vsCommitteeState $ certVState $ lsCertState $ esLState $ nesEs nes

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.0.0
 
+* Introduce `CommitteeState` and `csCommitteeCredsL`.
+* Change then name and the type of `vsCommitteeHotKeys` to `vsCommitteeState` and
+  `vsCommitteeHotKeysL` to `vsCommitteeStateL`
 * Add `drepExpiryL` and `drepAnchorL`
 * Add `eraName`
 * Add `addrPtrNormalize`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -796,7 +796,7 @@ data Anchor c = Anchor
   { anchorUrl :: !Url
   , anchorDataHash :: !(SafeHash c AnchorData)
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance NoThunks (Anchor c)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
@@ -51,7 +51,7 @@ data DRepState c = DRepState
   { drepExpiry :: !EpochNo
   , drepAnchor :: !(StrictMaybe (Anchor c))
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NoThunks (DRepState era)
 
@@ -105,7 +105,7 @@ accumDRepDistr ::
   Map (Credential 'DRepRole c) (DRepState c) ->
   Map (DRep c) (CompactForm Coin) ->
   Credential 'Staking c ->
-  (CompactForm Coin) ->
+  CompactForm Coin ->
   Map (DRep c) (CompactForm Coin)
 accumDRepDistr um regDreps ans stakecred c =
   case UMap.lookup stakecred (DRepUView um) of
@@ -160,7 +160,7 @@ instance Crypto c => NFData (DRepPulser c Identity (Map (DRep c) (CompactForm Co
 instance Pulsable (DRepPulser c) where
   done (DRepPulser _ _ _ m _) = VMap.null m
   current (DRepPulser _ _ _ _ ans) = ans
-  pulseM (ll@(DRepPulser _ _ _ balance _)) | VMap.null balance = pure ll
+  pulseM ll@(DRepPulser _ _ _ balance _) | VMap.null balance = pure ll
   pulseM (DRepPulser n um regDreps balance ans) =
     let !(!steps, !balance') = VMap.splitAt n balance -- Athough it is initialized as a thunk. We want to force it with each pulse.
         ans' = foldlWithKey (accumDRepDistr um regDreps) ans steps

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.Binary (EncCBOR, Sized, mkSized)
 import Cardano.Ledger.CertState (
   Anchor (..),
   CertState (..),
+  CommitteeState (..),
   DRepState (..),
   DState (..),
   FutureGenDeleg (..),
@@ -684,6 +685,8 @@ instance Crypto c => Arbitrary (Anchor c) where
 
 instance Crypto c => Arbitrary (DRepState c) where
   arbitrary = DRepState <$> arbitrary <*> arbitrary
+
+deriving instance Era era => Arbitrary (CommitteeState era)
 
 instance Era era => Arbitrary (VState era) where
   arbitrary = VState <$> arbitrary <*> (DRComplete <$> arbitrary) <*> arbitrary

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -3,11 +3,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -57,7 +59,7 @@ import Cardano.Ledger.BaseTypes (
   txIxToInt,
  )
 import Cardano.Ledger.Block (Block (..))
-import Cardano.Ledger.CertState (DRepState, VState (..))
+import Cardano.Ledger.CertState (CommitteeState (..), DRepState, VState (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
@@ -1688,6 +1690,8 @@ instance PrettyA (GenDelegs c) where
 
 instance PrettyA (DRepState c) where
   prettyA = viaShow
+
+deriving instance PrettyA (CommitteeState era)
 
 instance PrettyA (VState era) where
   prettyA (VState vsDReps vsDRepDistr vsCommitteeHotKeys) =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -72,14 +72,14 @@ instance Eq a => FromList (Maybe a) a where
   tsRep (MaybeR z) = z
 
 instance (Ord k, Eq a) => FromList (Map k a) (k, a) where
-  makeFromList xs = Map.fromList xs
-  getList xs = Map.toList xs
+  makeFromList = Map.fromList
+  getList = Map.toList
   tsRep (MapR k v) = PairR k v
 
 -- | CAREFULL HERE, this instance may NOT be size preserving.
 instance Ord a => FromList (Set a) a where
-  makeFromList xs = Set.fromList xs
-  getList xs = Set.toList xs
+  makeFromList = Set.fromList
+  getList = Set.toList
   tsRep (SetR x) = x
 
 -- ================================================
@@ -219,10 +219,10 @@ infixl 0 ^$
 (^$) f x = f :$ Simple x
 
 constTarget :: t -> Target era t
-constTarget t = Constr "constTarget" (const t) ^$ (Lit UnitR ())
+constTarget t = Constr "constTarget" (const t) ^$ Lit UnitR ()
 
 emptyTarget :: Target era ()
-emptyTarget = (Simple (Lit UnitR ()))
+emptyTarget = Simple (Lit UnitR ())
 
 justTarget :: Term era t -> Target era (Maybe t)
 justTarget x = Constr "Just" Just ^$ x
@@ -247,22 +247,22 @@ setToListTarget x = Constr "toList" Set.toList ^$ x
 -- variables but puts no global constraints on them and does not use them to
 -- compute anything. The 'bindN' Target constructors each bind N such variables.
 bind2 :: Term era a1 -> Term era a2 -> Target era ()
-bind2 a b = (Constr "bind2" (\_ _ -> ()) ^$ a ^$ b)
+bind2 a b = Constr "bind2" (\_ _ -> ()) ^$ a ^$ b
 
 bind3 :: Term era a1 -> Term era a2 -> Term era a3 -> Target era ()
-bind3 a b c = (Constr "bind3" (\_ _ _ -> ()) ^$ a ^$ b ^$ c)
+bind3 a b c = Constr "bind3" (\_ _ _ -> ()) ^$ a ^$ b ^$ c
 
 bind4 :: Term era a1 -> Term era a2 -> Term era a3 -> Term era a4 -> Target era ()
-bind4 a b c d = (Constr "bind4" (\_ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d)
+bind4 a b c d = Constr "bind4" (\_ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d
 
 bind5 :: Term era a1 -> Term era a2 -> Term era a3 -> Term era a4 -> Term era a5 -> Target era ()
-bind5 a b c d e = (Constr "bind5" (\_ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e)
+bind5 a b c d e = Constr "bind5" (\_ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e
 
 bind6 :: Term era a1 -> Term era a2 -> Term era a3 -> Term era a4 -> Term era a5 -> Term era a6 -> Target era ()
-bind6 a b c d e f = (Constr "bind5" (\_ _ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e ^$ f)
+bind6 a b c d e f = Constr "bind5" (\_ _ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e ^$ f
 
 bind7 :: Term era a1 -> Term era a2 -> Term era a3 -> Term era a4 -> Term era a5 -> Term era a6 -> Term era a7 -> Target era ()
-bind7 a b c d e f g = (Constr "bind5" (\_ _ _ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e ^$ f ^$ g)
+bind7 a b c d e f g = Constr "bind5" (\_ _ _ _ _ _ _ -> ()) ^$ a ^$ b ^$ c ^$ d ^$ e ^$ f ^$ g
 
 -- ===================================
 
@@ -539,9 +539,7 @@ findV (Subst m) v@(V n1 rep1 _) = case Map.lookup n1 m of
 --  | Not really a composition, just adding 'sub1' to 'sub2', but if any thing
 --    is in both 'sub1' and 'sub2', the 'sub1' binding overrides the 'sub2' binding
 composeSubst :: Subst era -> Subst era -> Subst era
-composeSubst (Subst sub1) (Subst sub2) = Subst (Map.foldrWithKey' accum sub2 sub1)
-  where
-    accum nm x ans = Map.insert nm x ans
+composeSubst (Subst sub1) (Subst sub2) = Subst (Map.foldrWithKey' Map.insert sub2 sub1)
 
 singleSubst :: V era t -> Term era t -> Subst era
 singleSubst (V n r access) expr = Subst (Map.insert n (SubstElem r expr access) Map.empty)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -43,14 +43,6 @@ manyCoin size = do
 
 -- ======================================
 
-{- For reference. THis keeps changing
-data VState era
-  = VState {vsDReps :: !(Set (Credential 'Voting (EraCrypto era))),
-            vsCommitteeHotKeys :: !(Map
-                                      (Credential 'CommitteeColdKey (EraCrypto era))
-                                      (Maybe (Credential 'CommitteeHotKey (EraCrypto era))))}
--}
-
 vstatePreds :: Proof era -> [Pred era]
 vstatePreds _p =
   [ Sized (Range 3 8) dreps

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -50,12 +50,12 @@ import Cardano.Ledger.BaseTypes (
   TxIx (..),
   txIxToInt,
  )
+import Cardano.Ledger.CertState (CommitteeState (..))
 import qualified Cardano.Ledger.CertState as DP
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Conway.Governance (GovActionsState (..))
 import Cardano.Ledger.Conway.Rules (
   ConwayEpochPredFailure (..),
-  -- FIXME TODO ConwayNewEpochPredFailure,
   EnactPredFailure (..),
  )
 import qualified Cardano.Ledger.Conway.Rules as Conway
@@ -1688,12 +1688,12 @@ pcCertState (CertState vst pst dst) =
     ]
 
 pcVState :: VState era -> PDoc
-pcVState (VState dreps drepDistr committeeHotKeys) =
+pcVState (VState dreps drepDistr (CommitteeState committeeHotCreds)) =
   ppRecord
     "VState"
     [ ("DReps", ppMap pcCredential pcDRepState dreps)
     , ("DResDistr", ppMap pcDRep (pcCoin . fromCompact) (extractDRepDistr drepDistr))
-    , ("CC Hot Keys", ppMap pcCredential (ppMaybe pcCredential) committeeHotKeys)
+    , ("CC Hot Keys", ppMap pcCredential (ppMaybe pcCredential) committeeHotCreds)
     ]
 
 pcDRepState :: DRepState c -> PDoc


### PR DESCRIPTION
# Description

This PR implements 5 queries for consensus:

* `GetGovState`
* `GetDRepState`
* `GetDRepStakeDistr`
* `GetCommitteeState`
* `GetConstitution`

Also it adds a newtype `CommitteeState`

And fixes #3624 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff


(Edit: After the PR was merged, I updated this description to also mention the fifth added query, `GetConstitution`.)