### PR TITLE
Inactive DReps 

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `reDRepState` to `RatifyEnv`
 * Add field `gasId` to `GovActionState`
 * Add `insertGovActionsState`
 * Change type of `rsRemoved` in `RatifyState` to use  `GovActionState` instead of a tuple
@@ -9,6 +10,7 @@
 
 ## 1.7.0.0
 
+* Add `Network` validation for `ProposalProcedure` and `TreasuryWithdrawals` in GOV #3659
 * Make `DELEG`, `POOL` and `GOVCERT` conform to spec-v0.8 #3628
   * Add `CertEnv` and `CertsEnv` to pass `EpochNo` down from `LEDGER` to sub-rules
   * Add `drepDeposit` to `DRepState` to track deposits paid by `DRep`s

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -24,7 +24,7 @@ where
 
 import Cardano.Ledger.Address (RewardAcnt (getRwdCred))
 import Cardano.Ledger.BaseTypes (ShelleyBase)
-import Cardano.Ledger.CertState (certDStateL, dsUnifiedL)
+import Cardano.Ledger.CertState (certDStateL, dsUnifiedL, vsDRepsL)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway.Core
@@ -254,6 +254,7 @@ epochTransition = do
         , reStakePoolDistr = stakePoolDistr
         , reDRepDistr = drepDistr
         , reCurrentEpoch = eNo
+        , reDRepState = vstate ^. vsDRepsL
         }
     ratSig =
       RatifySignal . Seq.fromList . Map.elems . unGovActionsState $

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Conway.Rules.Ratify (
 ) where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.CertState (DRepState (..))
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Conway.Era (ConwayENACT, ConwayRATIFY)
 import Cardano.Ledger.Conway.Governance (
@@ -58,6 +59,7 @@ data RatifyEnv era = RatifyEnv
   { reStakeDistr :: !(Map (Credential 'Staking (EraCrypto era)) Coin)
   , reStakePoolDistr :: !(PoolDistr (EraCrypto era))
   , reDRepDistr :: !(Map (DRep (EraCrypto era)) (CompactForm Coin))
+  , reDRepState :: !(Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era)))
   , reCurrentEpoch :: !EpochNo
   }
   deriving (Show)

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/RatifySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/RatifySpec.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -10,6 +12,7 @@ module Test.Cardano.Ledger.Conway.RatifySpec (spec) where
 
 import Cardano.Ledger.BaseTypes (EpochNo (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Governance (
   GovAction (..),
@@ -18,15 +21,17 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.Rules (RatifyEnv (..), dRepAccepted, dRepAcceptedRatio)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRepDistr (DRepState (..))
+import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
+import Cardano.Ledger.Val ((<+>), (<->))
 import Data.Foldable (fold)
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
-import qualified Data.Set as Set
+import Data.Word (Word64)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Core.Arbitrary ()
@@ -36,77 +41,70 @@ spec = do
   describe "Ratification" $ do
     drepsProp @Conway
     drepsPropNoStake @Conway
+    drepsPropAllAbstain @Conway
+    drepsPropNoVotes @Conway
+    drepsPropAllYes @Conway
+    drepsPropAllNoConfidence @Conway
 
 drepsProp :: forall era. Era era => Spec
 drepsProp =
-  prop "DRep vote counts" $
-    forAll (arbitrary @(Map (DRep (EraCrypto era)) (CompactForm Coin))) $
-      \dRepDistr -> do
-        forAll (shuffle (Map.keys dRepDistr)) $ \dreps -> do
-          let size = fromIntegral $ length dreps
-              yes = ratio (30 :: Integer) size
-              drepsYes = onlyDrepsCred $ take yes dreps
-              votesYes = Map.fromList $ [(cred, VoteYes) | DRepCredential cred <- drepsYes]
-              CompactCoin stakeYes = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsYes)
-
-              no = ratio 40 size
-              drepsNo = onlyDrepsCred $ take no . drop yes $ dreps
-              votesNo = Map.fromList $ [(cred, VoteNo) | DRepCredential cred <- drepsNo]
-              CompactCoin stakeNo = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsNo)
-
-              abstain = ratio 10 size
-              drepsAbstain = onlyDrepsCred $ take abstain . drop (yes + no) $ dreps
-              votesAbstain = Map.fromList [(cred, Abstain) | DRepCredential cred <- drepsAbstain]
-              CompactCoin stakeAbstain = fold $ Map.restrictKeys dRepDistr (Set.fromList drepsAbstain)
-
-              CompactCoin stakeAlwaysAbstain = fromMaybe (CompactCoin 0) $ Map.lookup DRepAlwaysAbstain dRepDistr
-              CompactCoin stakeAlwaysNoConfidence = fromMaybe (CompactCoin 0) $ Map.lookup DRepAlwaysNoConfidence dRepDistr
-              CompactCoin notVotedStake =
-                fold $
-                  Map.withoutKeys
-                    dRepDistr
-                    (Set.fromList (drepsYes ++ drepsNo ++ drepsAbstain ++ [DRepAlwaysAbstain, DRepAlwaysNoConfidence]))
-
-              votes = Map.union votesYes $ Map.union votesNo votesAbstain
-
-              CompactCoin totalStake = fold dRepDistr
-              ratifyEnv =
-                RatifyEnv
-                  { reStakeDistr = Map.empty
-                  , reStakePoolDistr = PoolDistr Map.empty
-                  , reDRepDistr = dRepDistr
-                  , reDRepState =
-                      Map.fromList
-                        [(cred, DRepState (EpochNo 100) SNothing mempty) | DRepCredential cred <- Map.keys dRepDistr]
-                  , reCurrentEpoch = EpochNo 0
-                  }
-
+  prop "DRep vote count for arbitrary vote ratios" $
+    forAll genRatios $ \ratios -> do
+      forAll (drepsTestData @era ratios) $
+        \(DRepTestData {..}) -> do
+          let drepState =
+                Map.fromList
+                  [(cred, DRepState (EpochNo 100) SNothing mempty) | DRepCredential cred <- Map.keys distr]
+              ratifyEnv = emptyRatifyEnv {reDRepDistr = distr, reDRepState = drepState}
               actual = dRepAcceptedRatio @era ratifyEnv votes InfoAction
+              -- Check the accepted min ratio is : yes/(total - abstain), or zero if everyone abstained
               expected
-                | totalStake == stakeAbstain + stakeAlwaysAbstain = 0
-                | otherwise = toInteger stakeYes % toInteger (totalStake - stakeAbstain - stakeAlwaysAbstain)
-
+                | totalStake == stakeAbstain <+> stakeAlwaysAbstain = 0
+                | otherwise = unCoin stakeYes % unCoin (totalStake <-> stakeAbstain <-> stakeAlwaysAbstain)
           actual `shouldBe` expected
 
+          -- This can be also expressed as: yes/(yes + no + not voted + noconfidence)
           let expectedRephrased
-                | stakeYes + stakeNo + notVotedStake + stakeAlwaysNoConfidence == 0 = 0
-                | otherwise = toInteger stakeYes % toInteger (stakeYes + stakeNo + notVotedStake + stakeAlwaysNoConfidence)
+                | stakeYes <+> stakeNo <+> stakeNotVoted <+> stakeNoConfidence == Coin 0 = 0
+                | otherwise = unCoin stakeYes % unCoin (stakeYes <+> stakeNo <+> stakeNotVoted <+> stakeNoConfidence)
           actual `shouldBe` expectedRephrased
 
           let actualNoConfidence = dRepAcceptedRatio @era ratifyEnv votes (NoConfidence SNothing)
+              -- For NoConfidence action, we count the `NoConfidence` votes as Yes
               expectedNoConfidence
-                | totalStake == stakeAbstain + stakeAlwaysAbstain = 0
-                | otherwise = toInteger (stakeYes + stakeAlwaysNoConfidence) % toInteger (totalStake - stakeAbstain - stakeAlwaysAbstain)
+                | totalStake == stakeAbstain <+> stakeAlwaysAbstain = 0
+                | otherwise = unCoin (stakeYes <+> stakeNoConfidence) % unCoin (totalStake <-> stakeAbstain <-> stakeAlwaysAbstain)
           actualNoConfidence `shouldBe` expectedNoConfidence
-  where
-    ratio pct tot = ceiling $ (pct * tot) % 100
-    onlyDrepsCred l =
-      filter
-        ( \case
-            DRepCredential _ -> True
-            _ -> False
-        )
-        l
+
+drepsPropAllAbstain :: forall era. Era era => Spec
+drepsPropAllAbstain =
+  prop "If all votes are abstain, accepted ratio is zero" $
+    forAll (drepsTestData @era (Ratios {yes = 0, no = 0, abstain = 50 % 100, alwaysAbstain = 50 % 100, noConfidence = 0})) $
+      \drepTestData ->
+        acceptedRatio drepTestData `shouldBe` 0
+
+drepsPropAllNoConfidence :: forall era. Era era => Spec
+drepsPropAllNoConfidence =
+  prop "If all votes are no confidence, accepted ratio is zero" $
+    forAll (drepsTestData @era (Ratios {yes = 0, no = 0, abstain = 0, alwaysAbstain = 0, noConfidence = 100 % 100})) $
+      \drepTestData ->
+        acceptedRatio drepTestData `shouldBe` 0
+
+drepsPropNoVotes :: forall era. Era era => Spec
+drepsPropNoVotes =
+  prop "If there are no votes, accepted ratio is zero" $
+    forAll (drepsTestData @era (Ratios {yes = 0, no = 0, abstain = 0, alwaysAbstain = 0, noConfidence = 0})) $
+      \drepTestData ->
+        acceptedRatio drepTestData `shouldBe` 0
+
+drepsPropAllYes :: forall era. Era era => Spec
+drepsPropAllYes =
+  prop "If all vote yes, accepted ratio is 1 (unless there is no stake) " $
+    forAll (drepsTestData @era (Ratios {yes = 100 % 100, no = 0, abstain = 0, alwaysAbstain = 0, noConfidence = 0})) $
+      \drepTestData ->
+        if totalStake drepTestData == Coin 0
+          then acceptedRatio drepTestData `shouldBe` 0
+          else acceptedRatio drepTestData `shouldBe` 1
 
 drepsPropNoStake ::
   forall era.
@@ -125,3 +123,106 @@ drepsPropNoStake =
           dRepAccepted @era env {reDRepDistr = Map.empty} gas (1 % 2)
             `shouldBe` False
       )
+
+acceptedRatio :: forall era. DRepTestData era -> Rational
+acceptedRatio (DRepTestData {..}) =
+  let drepState =
+        Map.fromList
+          [(cred, DRepState (EpochNo 100) SNothing mempty) | DRepCredential cred <- Map.keys distr]
+      ratifyEnv = emptyRatifyEnv {reDRepDistr = distr, reDRepState = drepState}
+   in dRepAcceptedRatio @era ratifyEnv votes InfoAction
+
+data DRepTestData era = DRepTestData
+  { distr :: Map (DRep (EraCrypto era)) (CompactForm Coin)
+  , votes :: Map (Credential 'DRepRole (EraCrypto era)) Vote
+  , totalStake :: Coin
+  , stakeYes :: Coin
+  , stakeNo :: Coin
+  , stakeAbstain :: Coin
+  , stakeAlwaysAbstain :: Coin
+  , stakeNoConfidence :: Coin
+  , stakeNotVoted :: Coin
+  }
+  deriving (Show)
+
+data Ratios = Ratios
+  { yes :: Rational
+  , no :: Rational
+  , abstain :: Rational
+  , alwaysAbstain :: Rational
+  , noConfidence :: Rational
+  }
+  deriving (Show)
+
+-- Prepare the stake distribution and votes according to the given ratios.
+drepsTestData ::
+  forall era.
+  Era era =>
+  Ratios ->
+  Gen (DRepTestData era)
+drepsTestData Ratios {yes, no, abstain, alwaysAbstain, noConfidence} = do
+  let inDreps = listOf (DRepCredential <$> (arbitrary @(Credential 'DRepRole (EraCrypto era))))
+  dreps <- inDreps
+
+  let drepSize = length dreps
+      alwaysAbstainPct :: Word64 = pct alwaysAbstain
+      noConfidencePct :: Word64 = pct noConfidence
+      distr =
+        Map.alter
+          (\case _ -> Just (CompactCoin noConfidencePct))
+          DRepAlwaysNoConfidence
+          . Map.alter
+            (\case _ -> Just (CompactCoin alwaysAbstainPct))
+            DRepAlwaysAbstain
+          $ Map.fromList [(drep, CompactCoin 1) | drep <- dreps]
+      (drepsYes, drepsNo, drepsAbstain, rest) = splitByPct yes no abstain dreps
+      notVotedStake = length rest
+      votes =
+        Map.union
+          (Map.fromList [(cred, VoteYes) | DRepCredential cred <- drepsYes])
+          $ Map.union
+            (Map.fromList [(cred, VoteNo) | DRepCredential cred <- drepsNo])
+            (Map.fromList [(cred, Abstain) | DRepCredential cred <- drepsAbstain])
+      pct :: Integral a => Rational -> a
+      pct r = ceiling (r * fromIntegral drepSize)
+  pure
+    DRepTestData
+      { distr = distr
+      , votes = votes
+      , totalStake = fromCompact (fold distr)
+      , stakeYes = Coin (fromIntegral (length drepsYes))
+      , stakeNo = Coin (fromIntegral (length drepsNo))
+      , stakeAbstain = Coin (fromIntegral (length drepsAbstain))
+      , stakeAlwaysAbstain = Coin (fromIntegral alwaysAbstainPct)
+      , stakeNoConfidence = Coin (fromIntegral noConfidencePct)
+      , stakeNotVoted = Coin (fromIntegral notVotedStake)
+      }
+  where
+    splitByPct :: Rational -> Rational -> Rational -> [a] -> ([a], [a], [a], [a])
+    splitByPct x y z l =
+      let
+        size = fromIntegral $ length l
+        (xs, rest) = splitAt (ceiling (x * size)) l
+        (ys, rest') = splitAt (ceiling (y * size)) rest
+        (zs, rest'') = splitAt (ceiling (z * size)) rest'
+       in
+        (xs, ys, zs, rest'')
+
+genRatios :: Gen Ratios
+genRatios = do
+  (a, b, c, d, e, _) <- genPctsOf100
+  pure $ Ratios {yes = a, no = b, abstain = c, alwaysAbstain = d, noConfidence = e}
+
+genPctsOf100 :: Gen (Rational, Rational, Rational, Rational, Rational, Rational)
+genPctsOf100 = do
+  a <- choose (0, 100)
+  b <- choose (0, 100)
+  c <- choose (0, 100)
+  d <- choose (0, 100)
+  e <- choose (0, 100)
+  f <- choose (0, 100)
+  let s = a + b + c + d + e + f
+  pure (a % s, b % s, c % s, d % s, e % s, f % s)
+
+emptyRatifyEnv :: RatifyEnv era
+emptyRatifyEnv = RatifyEnv Map.empty (PoolDistr Map.empty) Map.empty Map.empty (EpochNo 0)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -117,6 +117,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Crypto (EraCrypto era) => Arbitrary (Constitution era) where
   arbitrary = Constitution <$> arbitrary <*> arbitrary


### PR DESCRIPTION
Don't count inactive (expired) DReps  in Ratification
 
Closes https://github.com/input-output-hk/cardano-ledger/issues/3448 
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
