### PR TITLE
Equality on raw types

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.2.1.2
+## 1.2.2.0
 
-*
+* Add `EqRaw` instance for `Timelock`, `AllegraTxAuxData` and `AllegraTxBody`
+* Add `ToExpr` instance for `AllegraTxAuxData`
 
 ## 1.2.1.1
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.1.2
+version:            1.2.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -52,8 +52,8 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.5 && <1.7,
-        cardano-ledger-shelley >=1.5 && <1.6,
+        cardano-ledger-core >=1.6 && <1.7,
+        cardano-ledger-shelley >=1.5.1 && <1.6,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -64,6 +64,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto, HASH)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (Witness))
 import Cardano.Ledger.MemoBytes (
+  EqRaw (..),
   Mem,
   MemoBytes (Memo),
   Memoized (..),
@@ -210,6 +211,9 @@ instance Crypto c => EraScript (AllegraEra c) where
 
   phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
   phaseScript PhaseTwoRep _ = Nothing
+
+instance EqRaw (Timelock era) where
+  eqRaw = eqTimelockRaw
 
 deriving via
   Mem TimelockRaw era

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Core (
 import Cardano.Ledger.Crypto (Crypto (HASH))
 import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes,
   MemoHashIndex,
@@ -107,6 +108,8 @@ newtype AllegraTxAuxData era = AuxiliaryDataWithBytes (MemoBytes AllegraTxAuxDat
   deriving (Generic)
   deriving newtype (Eq, ToCBOR, SafeToHash)
 
+instance ToExpr (AllegraTxAuxData era)
+
 instance Memoized AllegraTxAuxData where
   type RawType AllegraTxAuxData = AllegraTxAuxDataRaw
 
@@ -122,6 +125,8 @@ deriving newtype instance
 deriving newtype instance Era era => NoThunks (AllegraTxAuxData era)
 
 deriving newtype instance NFData (AllegraTxAuxData era)
+
+instance EqRaw (AllegraTxAuxData era)
 
 pattern AllegraTxAuxData ::
   Era era =>

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -61,6 +61,7 @@ import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes,
   MemoHashIndex,
@@ -354,3 +355,7 @@ instance Crypto c => AllegraEraTxBody (AllegraEra c) where
     lensMemoRawType atbrValidityInterval $
       \txBodyRaw vldt -> txBodyRaw {atbrValidityInterval = vldt}
   {-# INLINEABLE vldtTxBodyL #-}
+
+instance
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq (TxCert era)) =>
+  EqRaw (AllegraTxBody era)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -3,10 +3,9 @@
 module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra
-import Cardano.Ledger.Allegra.TxAuxData
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
 
 spec :: Spec
-spec = specUpgrade @Allegra @AllegraTxAuxData True
+spec = specUpgrade @Allegra True

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.4.0.1
+## 1.4.1.0
 
-*
+* Made `isPlutusScript` more general.
+* Add `alonzoEqTxRaw` and `alonzoEqTxWitsRaw`
+* Add `EqRaw` instance for `AlonzoScript`, `AlonzoTxWits`, `AlonzoTxAuxData`,
+  `AlonzoTxBody` and `AlonzoTx`
 
 ## 1.4.0.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.4.0.1
+version:            1.4.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -67,9 +67,9 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.5 && <1.7,
+        cardano-ledger-core >=1.6 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5,
+        cardano-ledger-shelley ^>=1.5.1,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (HASH))
 import Cardano.Ledger.Language (Language (..), Plutus (..), guardPlutus)
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes (..),
   MemoHashIndex,
@@ -236,6 +237,8 @@ instance Memoized AlonzoTxAuxData where
   type RawType AlonzoTxAuxData = AlonzoTxAuxDataRaw
 
 instance ToExpr (AlonzoTxAuxData era)
+
+instance EqRaw (AlonzoTxAuxData era)
 
 type AuxiliaryData era = AlonzoTxAuxData era
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -96,6 +96,7 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset (..), policies, policyID)
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes,
   MemoHashIndex,
@@ -403,6 +404,10 @@ mint' = atbrMint . getMemoRawType
 scriptIntegrityHash' = atbrScriptIntegrityHash . getMemoRawType
 
 txnetworkid' = atbrTxNetworkId . getMemoRawType
+
+instance
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq (TxCert era)) =>
+  EqRaw (AlonzoTxBody era)
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
@@ -11,4 +11,4 @@ spec :: Spec
 spec =
   -- Scripts are not upgradeable from Mary through their CBOR instances, since Mary had no
   -- concept of a prefix.
-  specUpgrade @Alonzo @AlonzoTxAuxData False
+  specUpgrade @Alonzo False

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.4.3.1
+## 1.4.4.0
 
-*
+* Add `EqRaw` instance for `BabbageTxBody`
 
 ## 1.4.3.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.4.3.1
+version:            1.4.4.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -60,9 +60,9 @@ library
         cardano-crypto-class,
         cardano-data >=1.0,
         cardano-ledger-allegra >=1.1,
-        cardano-ledger-alonzo ^>=1.4,
+        cardano-ledger-alonzo ^>=1.4.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.5 && <1.7,
+        cardano-ledger-core >=1.6 && <1.7,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.5,
         cardano-slotting,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -20,7 +20,11 @@ where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), translateAlonzoScript)
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoScript (..),
+  isPlutusScript,
+  translateAlonzoScript,
+ )
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
@@ -51,9 +55,3 @@ instance Crypto c => EraScript (BabbageEra c) where
   phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
   phaseScript PhaseTwoRep (PlutusScript plutus) = Just (Phase2Script plutus)
   phaseScript _ _ = Nothing
-
-isPlutusScript :: forall era. EraScript era => Script era -> Bool
-isPlutusScript x =
-  case phaseScript @era PhaseTwoRep x of
-    Just _ -> True
-    Nothing -> False

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -64,7 +64,7 @@ instance Crypto c => EraTx (BabbageEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(BabbageEra c) script tx
+  validateScript (Phase1Script script) = validateTimelock @(BabbageEra c) script
   {-# INLINE validateScript #-}
 
   getMinFeeTx = alonzoMinFeeTx

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -140,6 +140,7 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset, policies, policyID)
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes,
   MemoHashIndex,
@@ -470,6 +471,10 @@ instance Crypto c => BabbageEraTxBody (BabbageEra c) where
 
   allSizedOutputsTxBodyF = allSizedOutputsBabbageTxBodyF
   {-# INLINE allSizedOutputsTxBodyF #-}
+
+instance
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq (TxCert era)) =>
+  EqRaw (BabbageTxBody era)
 
 deriving newtype instance
   (Era era, Eq (TxOut era), Eq (TxCert era), Eq (PParamsUpdate era)) =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
@@ -25,10 +25,10 @@ import Cardano.Ledger.Alonzo.TxWits as BabbageTxWitsReExport (
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.TxBody ()
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 
-instance CC.Crypto c => EraTxWits (BabbageEra c) where
-  {-# SPECIALIZE instance EraTxWits (BabbageEra CC.StandardCrypto) #-}
+instance Crypto c => EraTxWits (BabbageEra c) where
+  {-# SPECIALIZE instance EraTxWits (BabbageEra StandardCrypto) #-}
 
   type TxWits (BabbageEra c) = AlonzoTxWits (BabbageEra c)
 
@@ -43,8 +43,8 @@ instance CC.Crypto c => EraTxWits (BabbageEra c) where
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-instance CC.Crypto c => AlonzoEraTxWits (BabbageEra c) where
-  {-# SPECIALIZE instance AlonzoEraTxWits (BabbageEra CC.StandardCrypto) #-}
+instance Crypto c => AlonzoEraTxWits (BabbageEra c) where
+  {-# SPECIALIZE instance AlonzoEraTxWits (BabbageEra StandardCrypto) #-}
 
   datsTxWitsL = datsAlonzoTxWitsL
   {-# INLINE datsTxWitsL #-}

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
@@ -8,4 +8,4 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
 
 spec :: Spec
-spec = specUpgrade @Babbage @AlonzoTxAuxData True
+spec = specUpgrade @Babbage True

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Add "minCommitteeSize" `PParam` validation for `NewCommittee` `GovAction` #3668
   * Add `committeeMembersL` and `committeeQuorumL` lenses for `Committee`
   * Add `NewCommitteeSizeTooSmall` `PredicateFailure` in `GOV`
+* Add `EqRaw` instance for `ConwayTxBody`
+* Add `ToExpr` instance for `Delegatee`, `ConwayDelegCert`, `ConwayGovCert` and
+  `ConwayTxCert`
 * Implement expiry for governance proposals #3664
   * Update `ppGovActionExpiration` to be an `EpochNo`
   * Add `gasExpiresAfter :: !EpochNo` to `GovActionState`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -69,7 +69,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.1,
         cardano-ledger-allegra >=1.1,
-        cardano-ledger-alonzo ^>=1.4,
+        cardano-ledger-alonzo ^>=1.4.1,
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.6,
         cardano-ledger-mary >=1.1,
@@ -126,7 +126,6 @@ test-suite tests
     build-depends:
         base,
         cardano-ledger-core:testlib,
-        cardano-ledger-alonzo,
         cardano-ledger-conway,
         cardano-ledger-core,
         containers,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -166,7 +166,7 @@ newEpochTransition = do
       -- the number of stake credentials by 8*k (8, rather than 10, to be sure we finish a bit early)
       k <- liftSTS $ asks securityParameter -- Maximum number of blocks we are allowed to roll back
       let stakeSize = VMap.size (es2 ^. epochStateStakeDistrL)
-      let pulseSize = max 1 (ceiling (((fromIntegral stakeSize) :: Ratio Word64) / (8 * ((fromIntegral k) :: Ratio Word64))))
+      let pulseSize = max 1 (ceiling ((fromIntegral stakeSize :: Ratio Word64) / (8 * (fromIntegral k :: Ratio Word64))))
       let es3 = es2 & epochStateDRepDistrL .~ freshDRepPulser pulseSize es2 -- Install a new (as yet unpulsed) DRepDistr pulser
       let adaPots = totalAdaPotsES es2
       tellEvent $ TotalAdaPotsEvent adaPots

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -14,7 +14,11 @@ where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo.Language (Language)
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), isPlutusScript, translateAlonzoScript)
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoScript (..),
+  isPlutusScript,
+  translateAlonzoScript,
+ )
 import Cardano.Ledger.Babbage.Scripts (babbageScriptPrefixTag)
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -88,6 +88,7 @@ import Cardano.Ledger.Mary.Value (
   policies,
  )
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes (..),
   MemoHashIndex,
@@ -398,6 +399,10 @@ instance Crypto c => ConwayEraTxBody (ConwayEra c) where
   treasuryDonationTxBodyL =
     lensMemoRawType ctbrTreasuryDonation (\txb x -> txb {ctbrTreasuryDonation = x})
   {-# INLINE treasuryDonationTxBodyL #-}
+
+instance
+  (EraPParams era, Eq (TxOut era), Eq (TxCert era)) =>
+  EqRaw (ConwayTxBody era)
 
 pattern ConwayTxBody ::
   ConwayEraTxBody era =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -81,6 +81,7 @@ import Cardano.Ledger.Shelley.TxCert (
   pattern RetirePoolTxCert,
   pattern UnRegTxCert,
  )
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import GHC.Generics (Generic)
@@ -327,6 +328,8 @@ instance NFData (Delegatee c)
 
 instance NoThunks (Delegatee c)
 
+instance ToExpr (Delegatee c)
+
 -- | Certificates for registration and delegation of stake to Pools and DReps. Comparing
 -- to previous eras, there is now ability to:
 --
@@ -357,6 +360,8 @@ instance NFData (ConwayDelegCert c)
 
 instance NoThunks (ConwayDelegCert c)
 
+instance ToExpr (ConwayDelegCert c)
+
 data ConwayGovCert c
   = ConwayRegDRep !(Credential 'DRepRole c) !Coin !(StrictMaybe (Anchor c))
   | ConwayUnRegDRep !(Credential 'DRepRole c) !Coin
@@ -369,6 +374,8 @@ instance Crypto c => NFData (ConwayGovCert c)
 
 instance NoThunks (ConwayGovCert c)
 
+instance ToExpr (ConwayGovCert c)
+
 data ConwayTxCert era
   = ConwayTxCertDeleg !(ConwayDelegCert (EraCrypto era))
   | ConwayTxCertPool !(PoolCert (EraCrypto era))
@@ -378,6 +385,8 @@ data ConwayTxCert era
 instance Crypto (EraCrypto era) => NFData (ConwayTxCert era)
 
 instance NoThunks (ConwayTxCert era)
+
+instance ToExpr (ConwayTxCert c)
 
 instance
   ( ShelleyEraTxCert era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
@@ -21,10 +21,10 @@ import Cardano.Ledger.Alonzo.TxWits as BabbageTxWitsReExport (
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC
+import Cardano.Ledger.Crypto
 
-instance CC.Crypto c => EraTxWits (ConwayEra c) where
-  {-# SPECIALIZE instance EraTxWits (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => EraTxWits (ConwayEra c) where
+  {-# SPECIALIZE instance EraTxWits (ConwayEra StandardCrypto) #-}
 
   type TxWits (ConwayEra c) = AlonzoTxWits (ConwayEra c)
 
@@ -39,8 +39,8 @@ instance CC.Crypto c => EraTxWits (ConwayEra c) where
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-instance CC.Crypto c => AlonzoEraTxWits (ConwayEra c) where
-  {-# SPECIALIZE instance AlonzoEraTxWits (ConwayEra CC.StandardCrypto) #-}
+instance Crypto c => AlonzoEraTxWits (ConwayEra c) where
+  {-# SPECIALIZE instance AlonzoEraTxWits (ConwayEra StandardCrypto) #-}
 
   datsTxWitsL = datsAlonzoTxWitsL
   {-# INLINE datsTxWitsL #-}

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
@@ -2,11 +2,10 @@
 
 module Test.Cardano.Ledger.Conway.BinarySpec (spec) where
 
-import Cardano.Ledger.Alonzo.TxAuxData
 import Cardano.Ledger.Conway
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
 
 spec :: Spec
-spec = specUpgrade @Conway @AlonzoTxAuxData True
+spec = specUpgrade @Conway True

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.3.2.1
+## 1.3.3.0
 
-*
+* Add `EqRaw` instance for `MaryTxBody`
 
 ## 1.3.2.0
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.2.1
+version:            1.3.3.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -59,8 +59,8 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.5 && <1.7,
-        cardano-ledger-shelley >=1.5 && <1.6,
+        cardano-ledger-core >=1.6 && <1.7,
+        cardano-ledger-shelley >=1.5.1 && <1.6,
         containers,
         deepseq,
         groups,
@@ -116,6 +116,5 @@ test-suite tests
         cardano-data:{cardano-data, testlib},
         cardano-ledger-binary:testlib >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-allegra,
         cardano-ledger-mary,
         testlib

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -52,7 +52,7 @@ instance Crypto c => EraTx (MaryEra c) where
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(MaryEra c) script tx
+  validateScript (Phase1Script script) = validateTimelock @(MaryEra c) script
   {-# INLINE validateScript #-}
 
   getMinFeeTx = shelleyMinFeeTx

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Mary.TxCert ()
 import Cardano.Ledger.Mary.TxOut ()
 import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.MemoBytes (
+  EqRaw,
   Mem,
   MemoBytes (Memo),
   MemoHashIndex,
@@ -94,6 +95,10 @@ newtype MaryTxBody era = TxBodyConstr (MemoBytes MaryTxBodyRaw era)
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (MaryTxBody era)
+
+instance
+  (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq (TxCert era)) =>
+  EqRaw (MaryTxBody era)
 
 instance AllegraEraTxBody era => DecCBOR (Annotator (MaryTxBodyRaw era)) where
   decCBOR = pure <$> decCBOR

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -2,11 +2,10 @@
 
 module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
 
-import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Mary
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
 import Test.Cardano.Ledger.Mary.Arbitrary ()
 
 spec :: Spec
-spec = specUpgrade @Mary @AllegraTxAuxData True
+spec = specUpgrade @Mary True

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.5.0.1
+## 1.5.1.0
 
-*
+* Add `eqMultiSigRaw`, `shelleyEqTxRaw` and `shelleyEqTxWitsRaw`
+* Add `EqRaw` instance for `MultiSig`, `ShelleyTxWits`, `ShelleyTxAuxData`, `TxBody` and `Tx`
+* Add `ToExpr` instance for `GenesisDelegCert`, `MIRPot`, `MirTarget`, `MIRCert`,
+  `ShelleyTxCert`, `ShelleyDelegCert`, `MultiSig` and `MultiSigRaw`
 
 ## 1.5.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.5.0.1
+version:            1.5.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -105,7 +105,7 @@ library
         cardano-data >=1.0,
         cardano-ledger-binary >=1.0,
         cardano-ledger-byron,
-        cardano-ledger-core >=1.5 && <1.7,
+        cardano-ledger-core >=1.6 && <1.7,
         cardano-slotting,
         vector-map >=1.0,
         containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -60,6 +60,7 @@ import qualified Cardano.Ledger.Binary.Plain as Plain (ToCBOR (toCBOR), encodePr
 import Cardano.Ledger.Core (Era (..), EraTxAuxData (..), eraProtVerLow)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
+import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.SafeHash (
   HashAnnotated,
   SafeHash,
@@ -127,6 +128,9 @@ instance Crypto c => EraTxAuxData (ShelleyEra c) where
     AuxiliaryDataHash (makeHashWithExplicitProxys (Proxy @c) index metadata)
     where
       index = Proxy @EraIndependentTxAuxData
+
+instance EqRaw (ShelleyTxAuxData era) where
+  eqRaw txAuxData1 txAuxData2 = mdMap txAuxData1 == mdMap txAuxData2
 
 instance NFData (ShelleyTxAuxData era) where
   rnf m = mdMap m `deepseq` rnf (mdBytes m)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -92,6 +92,7 @@ import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Keys.WitVKey
 import Cardano.Ledger.MemoBytes (
+  EqRaw (..),
   Mem,
   MemoBytes,
   MemoHashIndex,
@@ -266,6 +267,10 @@ newtype ShelleyTxBody era = TxBodyConstr (MemoBytes ShelleyTxBodyRaw era)
 
 instance Memoized ShelleyTxBody where
   type RawType ShelleyTxBody = ShelleyTxBodyRaw
+
+instance
+  (Era era, Eq (TxOut era), Eq (TxCert era), Eq (PParamsUpdate era)) =>
+  EqRaw (ShelleyTxBody era)
 
 instance Crypto c => EraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxBody (ShelleyEra StandardCrypto) #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -100,6 +100,7 @@ import Cardano.Ledger.Credential (Credential (..), StakeCredential, credKeyHashW
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (Hash, KeyHash (..), KeyRole (..), VerKeyVRF, asWitness)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Map.Strict (Map)
 import Data.Maybe (isJust, isNothing)
@@ -236,6 +237,8 @@ instance NoThunks (GenesisDelegCert c)
 instance NFData (GenesisDelegCert c) where
   rnf = rwhnf
 
+instance ToExpr (GenesisDelegCert c)
+
 genesisKeyHashWitness :: GenesisDelegCert c -> KeyHash 'Witness c
 genesisKeyHashWitness (GenesisDelegCert gk _ _) = asWitness gk
 
@@ -257,6 +260,8 @@ instance DecCBOR MIRPot where
       0 -> pure ReservesMIR
       1 -> pure TreasuryMIR
       k -> invalidKey k
+
+instance ToExpr MIRPot
 
 -- | MIRTarget specifies if funds from either the reserves
 -- or the treasury are to be handed out to a collection of
@@ -280,6 +285,8 @@ instance Crypto c => EncCBOR (MIRTarget c) where
   encCBOR (StakeAddressesMIR m) = encCBOR m
   encCBOR (SendToOppositePotMIR c) = encCBOR c
 
+instance ToExpr (MIRTarget c)
+
 -- | Move instantaneous rewards certificate
 data MIRCert c = MIRCert
   { mirPot :: !MIRPot
@@ -299,6 +306,8 @@ instance Crypto c => EncCBOR (MIRCert c) where
       <> encCBOR pot
       <> encCBOR targets
 
+instance ToExpr (MIRCert c)
+
 -- | A heavyweight certificate.
 data ShelleyTxCert era
   = ShelleyTxCertDelegCert !(ShelleyDelegCert (EraCrypto era))
@@ -308,6 +317,8 @@ data ShelleyTxCert era
   deriving (Show, Generic, Eq, NFData)
 
 instance NoThunks (ShelleyTxCert era)
+
+instance ToExpr (ShelleyTxCert era)
 
 upgradeShelleyTxCert ::
   EraCrypto era1 ~ EraCrypto era2 =>
@@ -428,6 +439,8 @@ data ShelleyDelegCert c
   | -- | A stake delegation certificate.
     ShelleyDelegCert !(StakeCredential c) !(KeyHash 'StakePool c)
   deriving (Show, Generic, Eq)
+
+instance ToExpr (ShelleyDelegCert c)
 
 pattern RegKey :: StakeCredential c -> ShelleyDelegCert c
 pattern RegKey cred = ShelleyRegCert cred

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 1.6.0.0
 
-*
+* Add `eqBootstrapWitnessRaw` and `eqWitVKeyRaw`
+* Add `eqRawType`
+* Add `EqRaw` type class with `eqRaw`.
+* Add `EqRaw` instance for `WitVKey` and `BootstrapWitness`
+* Require `EqRaw` instance for `Script`, `TxWits`, `TxAuxData`, `TxBody` and `Tx`
+* Add `ToExpr` instance for `PoolCert`
+* Require `ToExpr` instance for `Script`, `TxAuxData` and `TxCert`
 
 ## 1.5.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -109,8 +109,10 @@ import Cardano.Ledger.Keys (KeyRole (Staking, Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey)
 import Cardano.Ledger.Language (Plutus)
+import Cardano.Ledger.MemoBytes
 import Cardano.Ledger.Rewards (Reward (..), RewardType (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
@@ -142,6 +144,7 @@ class
   , ToCBOR (Tx era)
   , Show (Tx era)
   , Eq (Tx era)
+  , EqRaw (Tx era)
   ) =>
   EraTx era
   where
@@ -173,6 +176,7 @@ class
   , NFData (TxBody era)
   , Show (TxBody era)
   , Eq (TxBody era)
+  , EqRaw (TxBody era)
   ) =>
   EraTxBody era
   where
@@ -372,11 +376,13 @@ type family Value era :: Type
 class
   ( Era era
   , Eq (TxAuxData era)
+  , EqRaw (TxAuxData era)
   , Show (TxAuxData era)
   , NoThunks (TxAuxData era)
   , ToCBOR (TxAuxData era)
   , EncCBOR (TxAuxData era)
   , DecCBOR (Annotator (TxAuxData era))
+  , ToExpr (TxAuxData era)
   , HashAnnotated (TxAuxData era) EraIndependentTxAuxData (EraCrypto era)
   ) =>
   EraTxAuxData era
@@ -410,6 +416,7 @@ validateAuxiliaryData = validateTxAuxData
 class
   ( EraScript era
   , Eq (TxWits era)
+  , EqRaw (TxWits era)
   , Show (TxWits era)
   , Monoid (TxWits era)
   , NoThunks (TxWits era)
@@ -457,11 +464,13 @@ class
   ( Era era
   , Show (Script era)
   , Eq (Script era)
+  , EqRaw (Script era)
   , ToCBOR (Script era)
   , EncCBOR (Script era)
   , DecCBOR (Annotator (Script era))
   , NoThunks (Script era)
   , SafeToHash (Script era)
+  , ToExpr (Script era)
   ) =>
   EraScript era
   where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -62,6 +62,7 @@ class
   , NFData (TxCert era)
   , Show (TxCert era)
   , Eq (TxCert era)
+  , ToExpr (TxCert era)
   ) =>
   EraTxCert era
   where
@@ -135,6 +136,8 @@ instance NoThunks (PoolCert c)
 
 instance NFData (PoolCert c) where
   rnf = rwhnf
+
+instance ToExpr (PoolCert c)
 
 poolCertKeyHashWitness :: PoolCert c -> KeyHash 'Witness c
 poolCertKeyHashWitness = \case

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Keys.Bootstrap (
   unpackByronVKey,
   makeBootstrapWitness,
   verifyBootstrapWit,
+  eqBootstrapWitnessRaw,
 )
 where
 
@@ -61,6 +62,7 @@ import Cardano.Ledger.Keys (
   verifySignedDSIGN,
  )
 import qualified Cardano.Ledger.Keys as Keys
+import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
@@ -233,3 +235,13 @@ makeBootstrapWitness txBodyHash byronSigningKey addrAttributes =
           (mempty :: ByteString)
           (Byron.unSigningKey byronSigningKey)
           (Hash.hashToBytes txBodyHash)
+
+eqBootstrapWitnessRaw :: Crypto c => BootstrapWitness c -> BootstrapWitness c -> Bool
+eqBootstrapWitnessRaw bw1 bw2 =
+  bwKey bw1 == bwKey bw2
+    && bwSig bw1 == bwSig bw2
+    && bwChainCode bw1 == bwChainCode bw2
+    && bwAttributes bw1 == bwAttributes bw2
+
+instance Crypto c => EqRaw (BootstrapWitness c) where
+  eqRaw = eqBootstrapWitnessRaw

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -13,6 +13,7 @@ module Cardano.Ledger.Keys.WitVKey (
   WitVKey (WitVKey),
   witVKeyBytes,
   witVKeyHash,
+  eqWitVKeyRaw,
 )
 where
 
@@ -41,6 +42,7 @@ import Cardano.Ledger.Keys (
   hashKey,
   hashSignature,
  )
+import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Control.DeepSeq
 import qualified Data.ByteString.Lazy as BSL
 import Data.Ord (comparing)
@@ -101,6 +103,9 @@ instance (Typeable kr, Crypto c) => DecCBOR (Annotator (WitVKey kr c)) where
       {-# INLINE mkWitVKey #-}
   {-# INLINE decCBOR #-}
 
+instance (Crypto c, Typeable kr) => EqRaw (WitVKey kr c) where
+  eqRaw = eqWitVKeyRaw
+
 pattern WitVKey ::
   (Typeable kr, Crypto c) =>
   VKey kr c ->
@@ -127,3 +132,6 @@ witVKeyHash = wvkKeyHash
 -- | Access CBOR encoded representation of the witness. Evaluated lazily
 witVKeyBytes :: WitVKey kr c -> BSL.ByteString
 witVKeyBytes = wvkBytes
+
+eqWitVKeyRaw :: (Crypto c, Typeable kr) => WitVKey kr c -> WitVKey kr c -> Bool
+eqWitVKeyRaw (WitVKey k1 s1) (WitVKey k2 s2) = k1 == k2 && s1 == s2


### PR DESCRIPTION
# Description

This PR adds a `EqRaw` class that can be used to compare the Haskell type ignoring the underlying binary reopresentation for memoized times, regardless if they use MemoBytes or not. Default implementation, however, uses the MemoBytes representation, which will work for flat types based on MemoBytes, which is the majority of them. This approach simplifies the testing a bit.

@nc6 I took your suggestion of creating a separate class for this concept, it works out slightly nicer, because it will make tests less complex.

As a bonus this PR also adds ToExpr instances for some of the core types.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
