### PR TITLE
Validate previously enacted govAction

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.8.0.0
 
+* Add `PrevGovActionIds`
+* Change `EnactState` to add `ensPrevGovActionIds`
+* Add  `ensPrevGovActionIdsL`, `ensPrevPParamUpdateL`, `ensPrevHardForkL` `ensPrevCommitteeL`, `ensPrevConstitutionL`
+* Add `EnactSignal` and the signal of `Enact` to it
 * Remove `rsFuture` from `RatifyState`
 * Add to `GovActionsState`:
   * `curGovActionsState`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -45,12 +45,15 @@ module Cardano.Ledger.Conway.Governance (
   cgGovActionsStateL,
   cgEnactStateL,
   cgRatifyStateL,
+  ensCommitteeL,
   ensConstitutionL,
+  ensCurPParamsL,
   ensPrevGovActionIdsL,
   ensPrevPParamUpdateL,
   ensPrevHardForkL,
   ensPrevCommitteeL,
   ensPrevConstitutionL,
+  ensProtVerL,
   rsEnactStateL,
   curPParamsConwayGovStateL,
   prevPParamsConwayGovStateL,
@@ -340,8 +343,14 @@ data EnactState era = EnactState
   }
   deriving (Generic)
 
+ensCommitteeL :: Lens' (EnactState era) (StrictMaybe (Committee era))
+ensCommitteeL = lens ensCommittee (\x y -> x {ensCommittee = y})
+
 ensConstitutionL :: Lens' (EnactState era) (Constitution era)
 ensConstitutionL = lens ensConstitution (\x y -> x {ensConstitution = y})
+
+ensProtVerL :: Lens' (EnactState era) ProtVer
+ensProtVerL = lens ensProtVer (\x y -> x {ensProtVer = y})
 
 ensCurPParamsL :: Lens' (EnactState era) (PParams era)
 ensCurPParamsL = lens ensPParams (\es x -> es {ensPParams = x})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -405,7 +405,7 @@ toEnactStatePairs cg@(EnactState _ _ _ _ _ _ _ _) =
       , "prevPParams" .= ensPParams
       , "treasury" .= ensTreasury
       , "withdrawals" .= ensWithdrawals
-      , "PrevGovActionIds" .= ensPrevGovActionIds
+      , "prevGovActionIds" .= ensPrevGovActionIds
       ]
 
 deriving instance Eq (PParams era) => Eq (EnactState era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Conway.Governance (
   GovActionIx (..),
   GovActionId (..),
   GovActionPurpose (..),
+  PrevGovActionIds (..),
   PrevGovActionId (..),
   govActionIdToText,
   Voter (..),
@@ -45,6 +46,11 @@ module Cardano.Ledger.Conway.Governance (
   cgEnactStateL,
   cgRatifyStateL,
   ensConstitutionL,
+  ensPrevGovActionIdsL,
+  ensPrevPParamUpdateL,
+  ensPrevHardForkL,
+  ensPrevCommitteeL,
+  ensPrevConstitutionL,
   rsEnactStateL,
   curPParamsConwayGovStateL,
   prevPParamsConwayGovStateL,
@@ -270,16 +276,67 @@ instance EraPParams era => ToCBOR (GovActionsState era) where
 instance EraPParams era => FromCBOR (GovActionsState era) where
   fromCBOR = fromEraCBOR @era
 
+data PrevGovActionIds era = PrevGovActionIds
+  { pgaPParamUpdate :: !(StrictMaybe (PrevGovActionId 'PParamUpdatePurpose (EraCrypto era)))
+  -- ^ The last enacted GovActionId for a protocol parameter update
+  , pgaHardFork :: !(StrictMaybe (PrevGovActionId 'HardForkPurpose (EraCrypto era)))
+  -- ^ The last enacted GovActionId for a hard fork
+  , pgaCommittee :: !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
+  -- ^ The last enacted GovActionId for a committee change or no confidence vote
+  , pgaConstitution :: !(StrictMaybe (PrevGovActionId 'ConstitutionPurpose (EraCrypto era)))
+  -- ^ The last enacted GovActionId for a new constitution
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks (PrevGovActionIds era)
+instance Era era => NFData (PrevGovActionIds era)
+instance Default (PrevGovActionIds era)
+
+instance Era era => DecCBOR (PrevGovActionIds era) where
+  decCBOR =
+    decode $
+      RecD PrevGovActionIds
+        <! From
+        <! From
+        <! From
+        <! From
+
+instance Era era => EncCBOR (PrevGovActionIds era) where
+  encCBOR PrevGovActionIds {..} =
+    encode $
+      Rec (PrevGovActionIds @era)
+        !> To pgaPParamUpdate
+        !> To pgaHardFork
+        !> To pgaCommittee
+        !> To pgaConstitution
+
+toPrevGovActionIdsParis :: (KeyValue a, Era era) => PrevGovActionIds era -> [a]
+toPrevGovActionIdsParis pga@(PrevGovActionIds _ _ _ _) =
+  let PrevGovActionIds {..} = pga
+   in [ "pgaPParamUpdate" .= pgaPParamUpdate
+      , "pgaHardFork" .= pgaHardFork
+      , "pgaCommittee" .= pgaCommittee
+      , "pgaConstitution" .= pgaConstitution
+      ]
+
+instance Era era => ToJSON (PrevGovActionIds era) where
+  toJSON = object . toPrevGovActionIdsParis
+  toEncoding = pairs . mconcat . toPrevGovActionIdsParis
+
+instance ToExpr (PrevGovActionIds era)
+
 data EnactState era = EnactState
   { ensCommittee :: !(StrictMaybe (Committee era))
   -- ^ Constitutional Committee
   , ensConstitution :: !(Constitution era)
-  -- ^ Hash of the Constitution
+  -- ^ Constitution
   , ensProtVer :: !ProtVer
   , ensPParams :: !(PParams era)
   , ensPrevPParams :: !(PParams era)
   , ensTreasury :: !Coin
   , ensWithdrawals :: !(Map (Credential 'Staking (EraCrypto era)) Coin)
+  , ensPrevGovActionIds :: !(PrevGovActionIds era)
+  -- ^ Last enacted GovAction Ids
   }
   deriving (Generic)
 
@@ -292,6 +349,37 @@ ensCurPParamsL = lens ensPParams (\es x -> es {ensPParams = x})
 ensPrevPParamsL :: Lens' (EnactState era) (PParams era)
 ensPrevPParamsL = lens ensPrevPParams (\es x -> es {ensPrevPParams = x})
 
+ensPrevGovActionIdsL :: Lens' (EnactState era) (PrevGovActionIds era)
+ensPrevGovActionIdsL = lens ensPrevGovActionIds (\es x -> es {ensPrevGovActionIds = x})
+
+ensPrevPParamUpdateL ::
+  Lens' (EnactState era) (StrictMaybe (PrevGovActionId 'PParamUpdatePurpose (EraCrypto era)))
+ensPrevPParamUpdateL =
+  lens
+    (pgaPParamUpdate . ensPrevGovActionIds)
+    (\es x -> es {ensPrevGovActionIds = (ensPrevGovActionIds es) {pgaPParamUpdate = x}})
+
+ensPrevHardForkL ::
+  Lens' (EnactState era) (StrictMaybe (PrevGovActionId 'HardForkPurpose (EraCrypto era)))
+ensPrevHardForkL =
+  lens
+    (pgaHardFork . ensPrevGovActionIds)
+    (\es x -> es {ensPrevGovActionIds = (ensPrevGovActionIds es) {pgaHardFork = x}})
+
+ensPrevCommitteeL ::
+  Lens' (EnactState era) (StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
+ensPrevCommitteeL =
+  lens
+    (pgaCommittee . ensPrevGovActionIds)
+    (\es x -> es {ensPrevGovActionIds = (ensPrevGovActionIds es) {pgaCommittee = x}})
+
+ensPrevConstitutionL ::
+  Lens' (EnactState era) (StrictMaybe (PrevGovActionId 'ConstitutionPurpose (EraCrypto era)))
+ensPrevConstitutionL =
+  lens
+    (pgaConstitution . ensPrevGovActionIds)
+    (\es x -> es {ensPrevGovActionIds = (ensPrevGovActionIds es) {pgaConstitution = x}})
+
 instance ToExpr (PParamsHKD Identity era) => ToExpr (EnactState era)
 
 instance EraPParams era => ToJSON (EnactState era) where
@@ -299,7 +387,7 @@ instance EraPParams era => ToJSON (EnactState era) where
   toEncoding = pairs . mconcat . toEnactStatePairs
 
 toEnactStatePairs :: (KeyValue a, EraPParams era) => EnactState era -> [a]
-toEnactStatePairs cg@(EnactState _ _ _ _ _ _ _) =
+toEnactStatePairs cg@(EnactState _ _ _ _ _ _ _ _) =
   let EnactState {..} = cg
    in [ "committee" .= ensCommittee
       , "constitution" .= ensConstitution
@@ -308,6 +396,7 @@ toEnactStatePairs cg@(EnactState _ _ _ _ _ _ _) =
       , "prevPParams" .= ensPParams
       , "treasury" .= ensTreasury
       , "withdrawals" .= ensWithdrawals
+      , "PrevGovActionIds" .= ensPrevGovActionIds
       ]
 
 deriving instance Eq (PParams era) => Eq (EnactState era)
@@ -324,11 +413,13 @@ instance EraPParams era => Default (EnactState era) where
       def
       (Coin 0)
       def
+      def
 
 instance EraPParams era => DecCBOR (EnactState era) where
   decCBOR =
     decode $
       RecD EnactState
+        <! From
         <! From
         <! From
         <! From
@@ -348,6 +439,7 @@ instance EraPParams era => EncCBOR (EnactState era) where
         !> To ensPrevPParams
         !> To ensTreasury
         !> To ensWithdrawals
+        !> To ensPrevGovActionIds
 
 instance EraPParams era => ToCBOR (EnactState era) where
   toCBOR = toEraCBOR @era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -206,9 +206,9 @@ ratifyTransition = do
   case rsig of
     ast :<| sigs -> do
       let GovActionState {gasId, gasAction, gasExpiresAfter} = ast
-      if spoAccepted env ast
+      if prevActionAsExpected gasAction (ensPrevGovActionIds rsEnactState)
+        && spoAccepted env ast
         && dRepAccepted env ast dRepThreshold
-        && prevActionAsExpected gasAction (ensPrevGovActionIds rsEnactState)
         then do
           -- Update ENACT state with the governance action that was ratified
           es <-

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -121,6 +121,14 @@ instance
 instance Crypto (EraCrypto era) => Arbitrary (Constitution era) where
   arbitrary = Constitution <$> arbitrary <*> arbitrary
 
+instance Era era => Arbitrary (PrevGovActionIds era) where
+  arbitrary =
+    PrevGovActionIds
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>
   Arbitrary (EnactState era)
@@ -128,6 +136,7 @@ instance
   arbitrary =
     EnactState
       <$> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.Conway.Governance (
   GovActionsState (..),
   GovProcedures,
   PrevGovActionId (..),
+  PrevGovActionIds (..),
   ProposalProcedure (..),
   Vote (..),
   Voter (..),
@@ -319,7 +320,7 @@ instance PrettyA (Constitution era) where
       ]
 
 instance PrettyA (PParams era) => PrettyA (EnactState era) where
-  prettyA ens@(EnactState _ _ _ _ _ _ _) =
+  prettyA ens@(EnactState _ _ _ _ _ _ _ _) =
     let EnactState {..} = ens
      in ppRecord
           "EnactState"
@@ -330,7 +331,18 @@ instance PrettyA (PParams era) => PrettyA (EnactState era) where
           , ("Constitution", prettyA ensConstitution)
           , ("Treasury", prettyA ensTreasury)
           , ("Withdrawals", prettyA ensWithdrawals)
+          , ("PrevGovActionIds", prettyA ensPrevGovActionIds)
           ]
+
+instance PrettyA (PrevGovActionIds era) where
+  prettyA PrevGovActionIds {..} =
+    ppRecord
+      "PrevGovActionIds"
+      [ ("LastPParamUpdate", prettyA pgaPParamUpdate)
+      , ("LastHardFork", prettyA pgaHardFork)
+      , ("LastCommittee", prettyA pgaCommittee)
+      , ("LastConstitution", prettyA pgaConstitution)
+      ]
 
 instance
   ( PrettyA (PParamsUpdate era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -441,6 +441,10 @@ testGov pf = do
       Right x -> x
       Left e -> error $ "Error running runEPOCH: " <> show e
     constitution2 = epochState4 ^. esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensConstitutionL
+  assertExprEqualWithMessage
+    "prevGovAction set correctly"
+    (SJust (PrevGovActionId govActionId))
+    (epochState4 ^. esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensPrevConstitutionL)
   assertEqual "constitution after enactment after no votes" constitution2 (proposedConstitution @era)
   let
     currentGovActions =


### PR DESCRIPTION
# Description

Closes https://github.com/input-output-hk/cardano-ledger/issues/3656

* EnactState: store the last enacted GovId for each of the 4 types of actions for which it is relevant (corresponding to GovActionPurpose)  
* Ratify: check that the previous govId that we have from the proposal matches the one that we store in the enact state. 
If it doesn't match, we "drop" the signal  (we don't enact it and it will eventually expire)
* Enact:  when enacting, update the stored value for last govId 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
