### PR TITLE
Added RATIFY thresholds

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 1.8.0.0
 
+* Add:
+  * `PParamGroup`
+  * `ParamGrouper`
+  * `pGroup`
+  * `pUngrouped`
+  * `modifiedGroups`
+  * `dvtPPNetworkGroupL`
+  * `dvtPPGovGroupL`
+  * `dvtPPTechnicalGroupL`
+  * `dvtPPEconomicGroupL`
+  * `threshold`
+  * `ensCommitteeL`
+* Add `pparamsGroups` to `ConwayEraPParams`
 * Add `PrevGovActionIds`
 * Change `EnactState` to add `ensPrevGovActionIds`
 * Add  `ensPrevGovActionIdsL`, `ensPrevPParamUpdateL`, `ensPrevHardForkL` `ensPrevCommitteeL`, `ensPrevConstitutionL`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -36,7 +36,6 @@ where
 import Cardano.Ledger.Alonzo.PParams (OrdExUnits (..))
 import Cardano.Ledger.Alonzo.Scripts (CostModels, ExUnits (..), Prices (Prices), emptyCostModels)
 import Cardano.Ledger.Babbage (BabbageEra)
-import Cardano.Ledger.Babbage.Core hiding (Value)
 import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.BaseTypes (EpochNo (EpochNo), NonNegativeInterval, ProtVer (ProtVer), UnitInterval)
 import Cardano.Ledger.Binary
@@ -299,6 +298,39 @@ instance Crypto c => BabbageEraPParams (ConwayEra c) where
   hkdCoinsPerUTxOByteL = lens cppCoinsPerUTxOByte (\pp x -> pp {cppCoinsPerUTxOByte = x})
 
 instance Crypto c => ConwayEraPParams (ConwayEra c) where
+  pparamsGroups (PParamsUpdate ConwayPParams {..}) =
+    ConwayPParams
+      <$> pGroup EconomicGroup cppMinFeeA
+      <*> pGroup EconomicGroup cppMinFeeB
+      <*> pGroup NetworkGroup cppMaxBBSize
+      <*> pGroup NetworkGroup cppMaxTxSize
+      <*> pGroup NetworkGroup cppMaxBHSize
+      <*> pGroup EconomicGroup cppKeyDeposit
+      <*> pGroup EconomicGroup cppPoolDeposit
+      <*> pGroup TechnicalGroup cppEMax
+      <*> pGroup TechnicalGroup cppNOpt
+      <*> pGroup TechnicalGroup cppA0
+      <*> pGroup EconomicGroup cppRho
+      <*> pGroup EconomicGroup cppTau
+      <*> pUngrouped
+      <*> pGroup EconomicGroup cppMinPoolCost
+      <*> pGroup EconomicGroup cppCoinsPerUTxOByte
+      <*> pGroup TechnicalGroup cppCostModels
+      <*> pGroup EconomicGroup cppPrices
+      <*> pGroup NetworkGroup cppMaxTxExUnits
+      <*> pGroup NetworkGroup cppMaxBlockExUnits
+      <*> pGroup NetworkGroup cppMaxValSize
+      <*> pGroup TechnicalGroup cppCollateralPercentage
+      <*> pGroup NetworkGroup cppMaxCollateralInputs
+      <*> pGroup GovernanceGroup cppPoolVotingThresholds
+      <*> pGroup GovernanceGroup cppDRepVotingThresholds
+      <*> pGroup GovernanceGroup cppMinCommitteeSize
+      <*> pGroup GovernanceGroup cppCommitteeTermLimit
+      <*> pGroup GovernanceGroup cppGovActionExpiration
+      <*> pGroup GovernanceGroup cppGovActionDeposit
+      <*> pGroup GovernanceGroup cppDRepDeposit
+      <*> pGroup GovernanceGroup cppDRepActivity
+
   ppuWellFormed ppu =
     and
       [ -- Numbers

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add `Ap`, `hoistAp`, `runAp`, `runAp_`
 * Add `eqBootstrapWitnessRaw` and `eqWitVKeyRaw`
 * Add `eqRawType`
 * Add `EqRaw` type class with `eqRaw`.

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -27,6 +27,7 @@ flag asserts
 library
     exposed-modules:
         Cardano.Ledger.Address
+        Cardano.Ledger.Ap
         Cardano.Ledger.CompactAddress
         Cardano.Ledger.AuxiliaryData
         Cardano.Ledger.BaseTypes

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Ap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Ap.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- | This is taken from Edward Kmett's `free` library
+-- See: https://hackage.haskell.org/package/free-5.2
+module Cardano.Ledger.Ap (
+  Ap (..),
+  hoistAp,
+  runAp,
+  runAp_,
+) where
+
+--------------------------------------------------------------------------------
+-- \|
+-- A faster free applicative.
+-- Based on <https://www.eyrie.org/~zednenem/2013/05/27/freeapp Dave Menendez's work>.
+--------------------------------------------------------------------------------
+import Control.Applicative
+
+-- | The free applicative is composed of a sequence of effects,
+-- and a pure function to apply that sequence to.
+-- The fast free applicative separates these from each other,
+-- so that the sequence may be built up independently,
+-- and so that 'fmap' can run in constant time by having immediate access to the pure function.
+data ASeq f a where
+  ANil :: ASeq f ()
+  ACons :: f a -> ASeq f u -> ASeq f (a, u)
+
+-- | Interprets the sequence of effects using the semantics for
+--   `pure` and `<*>` given by the Applicative instance for 'f'.
+reduceASeq :: Applicative f => ASeq f u -> f u
+reduceASeq ANil = pure ()
+reduceASeq (ACons x xs) = (,) <$> x <*> reduceASeq xs
+
+-- | Given a natural transformation from @f@ to @g@ this gives a natural transformation from @ASeq f@ to @ASeq g@.
+hoistASeq :: (forall x. f x -> g x) -> ASeq f a -> ASeq g a
+hoistASeq _ ANil = ANil
+hoistASeq u (ACons x xs) = ACons (u x) (u `hoistASeq` xs)
+
+-- | It may not be obvious, but this essentially acts like ++,
+-- traversing the first sequence and creating a new one by appending the second sequence.
+-- The difference is that this also has to modify the return functions and that the return type depends on the input types.
+--
+-- See the source of 'hoistAp' as an example usage.
+rebaseASeq ::
+  ASeq f u ->
+  (forall x. (x -> y) -> ASeq f x -> z) ->
+  (v -> u -> y) ->
+  ASeq f v ->
+  z
+rebaseASeq ANil k f = k (`f` ())
+rebaseASeq (ACons x xs) k f =
+  rebaseASeq
+    xs
+    (\g s -> k (\(a, u) -> g u a) (ACons x s))
+    (\v u a -> f v (a, u))
+
+-- | The faster free 'Applicative'.
+newtype Ap f a = Ap
+  { unAp ::
+      forall u y z.
+      (forall x. (x -> y) -> ASeq f x -> z) ->
+      (u -> a -> y) ->
+      ASeq f u ->
+      z
+  }
+
+-- | Given a natural transformation from @f@ to @g@, this gives a canonical monoidal natural transformation from @'Ap' f@ to @g@.
+--
+-- prop> runAp t == retractApp . hoistApp t
+runAp :: Applicative g => (forall x. f x -> g x) -> Ap f a -> g a
+runAp u = retractAp . hoistAp u
+
+-- | Perform a monoidal analysis over free applicative value.
+--
+-- Example:
+--
+-- @
+-- count :: Ap f a -> Int
+-- count = getSum . runAp_ (\\_ -> Sum 1)
+-- @
+runAp_ :: Monoid m => (forall a. f a -> m) -> Ap f b -> m
+runAp_ f = getConst . runAp (Const . f)
+
+instance Functor (Ap f) where
+  fmap g x = Ap (\k f -> unAp x k (\s -> f s . g))
+
+instance Applicative (Ap f) where
+  pure a = Ap (\k f -> k (`f` a))
+  x <*> y = Ap (\k f -> unAp y (unAp x k) (\s a g -> f s (g a)))
+
+-- | Given a natural transformation from @f@ to @g@ this gives a monoidal natural transformation from @Ap f@ to @Ap g@.
+hoistAp :: (forall x. f x -> g x) -> Ap f a -> Ap g a
+hoistAp g x =
+  Ap
+    ( \k f s ->
+        unAp
+          x
+          ( \f' s' ->
+              rebaseASeq
+                (hoistASeq g s')
+                k
+                (\v u -> f v (f' u))
+                s
+          )
+          (const id)
+          ANil
+    )
+
+-- | Interprets the free applicative functor over f using the semantics for
+--   `pure` and `<*>` given by the Applicative instance for f.
+--
+--   prop> retractApp == runAp id
+retractAp :: Applicative f => Ap f a -> f a
+retractAp x = unAp x (\f s -> f <$> reduceASeq s) (\() -> id) ANil

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog for `cardano-ledger-pretty`
 
-## 1.3.0.1
+## 1.3.1.0
 
-*
+* Add `PrettyA` instances for:
+  * `NonNegativeInterval`
+  * `CostModels`
+  * `CoinPerByte`
+  * `PoolVotingThresholds`
+  * `DRepVotingThresholds`
+* Add `ppConwayPParams`
 
 ## 1.3.0.0
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.BaseTypes (
   FixedPoint,
   Globals (..),
   Network (..),
+  NonNegativeInterval,
   Nonce (..),
   Port (..),
   ProtVer (..),
@@ -1644,6 +1645,9 @@ instance PrettyA Nonce where
 
 instance PrettyA UnitInterval where
   prettyA = ppUnitInterval
+
+instance PrettyA NonNegativeInterval where
+  prettyA = viaShow
 
 instance PrettyA Port where
   prettyA = ppPort

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -110,6 +110,9 @@ instance PrettyA CostModel where
 ppCostModels :: CostModels -> PDoc
 ppCostModels cms = ppMap ppLanguage ppCostModel (costModelsValid cms)
 
+instance PrettyA CostModels where
+  prettyA = ppCostModels
+
 ppPrices :: Prices -> PDoc
 ppPrices Prices {prMem, prSteps} =
   ppRecord

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -78,7 +79,7 @@ ppBabbagePParams pp =
     , ("tau", ppUnitInterval $ pp ^. ppTauL)
     , ("protocolVersion", ppProtVer $ pp ^. ppProtocolVersionL)
     , ("minPoolCost", ppCoin $ pp ^. ppMinPoolCostL)
-    , ("coinPerByte", (ppCoin . unCoinPerByte) $ pp ^. ppCoinsPerUTxOByteL)
+    , ("coinPerByte", prettyA $ pp ^. ppCoinsPerUTxOByteL)
     , ("costmdls", ppCostModels $ pp ^. ppCostModelsL)
     , ("prices", ppPrices $ pp ^. ppPricesL)
     , ("maxTxExUnits", ppExUnits $ pp ^. ppMaxTxExUnitsL)
@@ -87,6 +88,9 @@ ppBabbagePParams pp =
     , ("collateral%", ppNatural $ pp ^. ppCollateralPercentageL)
     , ("maxCollateralInputs", ppNatural $ pp ^. ppMaxCollateralInputsL)
     ]
+
+instance PrettyA CoinPerByte where
+  prettyA = prettyA . unCoinPerByte
 
 ppBabbagePParamsUpdate :: BabbageEraPParams era => PParamsUpdate era -> PDoc
 ppBabbagePParamsUpdate pp =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayWithdrawalDelay.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayWithdrawalDelay.hs
@@ -1,1 +1,0 @@
-module Test.Cardano.Ledger.Examples.ConwayWithdrawalDelay where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayWithdrawalDelay.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayWithdrawalDelay.hs
@@ -1,0 +1,1 @@
+module Test.Cardano.Ledger.Examples.ConwayWithdrawalDelay where


### PR DESCRIPTION
# Description

Implemented ratification thresholds. I used a free applicative to assign the fields of `PParams` into groups. The applicative adds some type safety in ensuring that all the fields are handled while also making it easy to gather all the modified groups in a `PParamsUpdate`.

closes #3524

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
