### PR TITLE
Fix inactive PoolStake not counting as Drep Stake

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -73,7 +73,7 @@ library
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.6,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.5,
+        cardano-ledger-shelley ^>=1.5.1,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -86,8 +86,7 @@ library
         small-steps,
         text,
         transformers,
-        validation-selective,
-        vector-map
+        validation-selective
 
 library testlib
     exposed-modules:  Test.Cardano.Ledger.Conway.Arbitrary

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -164,7 +164,7 @@ newEpochTransition = do
       -- Therefore to safely and evenly space out the DRep calculation, we divide
       -- the number of stake credentials by 8*k (8, rather than 10, to be sure we finish a bit early)
       k <- liftSTS $ asks securityParameter -- Maximum number of blocks we are allowed to roll back
-      let stakeSize = Map.size (es2 ^. epochStateStakeDistrL)
+      let stakeSize = Map.size (es2 ^. epochStateIncrStakeDistrL)
       let pulseSize = max 1 (ceiling ((fromIntegral stakeSize :: Ratio Word64) / (8 * (fromIntegral k :: Ratio Word64))))
       let es3 = es2 & epochStateDRepDistrL .~ freshDRepPulser pulseSize es2 -- Install a new (as yet unpulsed) DRepDistr pulser
       let adaPots = totalAdaPotsES es2

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -52,7 +52,6 @@ import Data.Default.Class (Default (..))
 import qualified Data.Map.Strict as Map
 import Data.Ratio (Ratio)
 import Data.Set (Set)
-import qualified Data.VMap as VMap
 import Data.Word (Word64)
 import Lens.Micro ((&), (.~), (^.))
 
@@ -161,11 +160,11 @@ newEpochTransition = do
         SJust (Complete ru') -> updateRewards es0 eNo ru'
       es2 <- trans @(EraRule "EPOCH" era) $ TRC (pd, es1, eNo)
 
-      -- Initiaize DRep pulser. We expect approximately 10*k-many blocks to be produced each epoch.
+      -- Initialize DRep pulser. We expect approximately 10*k-many blocks to be produced each epoch.
       -- Therefore to safely and evenly space out the DRep calculation, we divide
       -- the number of stake credentials by 8*k (8, rather than 10, to be sure we finish a bit early)
       k <- liftSTS $ asks securityParameter -- Maximum number of blocks we are allowed to roll back
-      let stakeSize = VMap.size (es2 ^. epochStateStakeDistrL)
+      let stakeSize = Map.size (es2 ^. epochStateStakeDistrL)
       let pulseSize = max 1 (ceiling ((fromIntegral stakeSize :: Ratio Word64) / (8 * (fromIntegral k :: Ratio Word64))))
       let es3 = es2 & epochStateDRepDistrL .~ freshDRepPulser pulseSize es2 -- Install a new (as yet unpulsed) DRepDistr pulser
       let adaPots = totalAdaPotsES es2

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Add `eqMultiSigRaw`, `shelleyEqTxRaw` and `shelleyEqTxWitsRaw`
 * Add `EqRaw` instance for `MultiSig`, `ShelleyTxWits`, `ShelleyTxAuxData`, `TxBody` and `Tx`
 * Add `ToExpr` instance for `GenesisDelegCert`, `MIRPot`, `MirTarget`, `MIRCert`,
-  `ShelleyTxCert`, `ShelleyDelegCert`, `MultiSig` and `MultiSigRaw`
+	`ShelleyTxCert`, `ShelleyDelegCert`, `MultiSig` and `MultiSigRaw`
+* Add new lens 'epochStateIncrStakeDistrL',  that points to the 'credmap' field of 'IncrementalStake' from 'EpochState'
 
 ## 1.5.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -118,6 +118,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   newEpochStateDRepDistrL,
   epochStateDRepDistrL,
   epochStateStakeDistrL,
+  epochStateIncrStakeDistrL,
   epochStateRegDrepL,
   epochStateUMapL,
   freshDRepPulser,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -50,11 +50,11 @@ import Cardano.Ledger.CertState (
   vsDRepDistrL,
   vsDRepsL,
  )
-import Cardano.Ledger.Coin (Coin (..), CompactForm)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), Ptr (..))
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.DRepDistr (DRepDistr (..), startDRepDistr)
-import Cardano.Ledger.EpochBoundary (SnapShots (..), ssStakeDistrL, ssStakeMarkL)
+import Cardano.Ledger.EpochBoundary (SnapShots (..))
 import Cardano.Ledger.Keys (
   KeyHash (..),
   KeyPair,
@@ -66,7 +66,7 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PoolRank (NonMyopic (..))
 import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..))
 import Cardano.Ledger.TreeDiff (ToExpr)
-import Cardano.Ledger.UMap (UMap (..))
+import Cardano.Ledger.UMap (UMap (..), compactCoinOrError)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Control.DeepSeq (NFData)
 import Control.Monad.State.Strict (evalStateT)
@@ -76,7 +76,7 @@ import Data.Default.Class (Default, def)
 import Data.Group (Group, invert)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.VMap (VB, VMap, VP)
+import qualified Data.VMap as VMap
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -699,11 +699,19 @@ utxosStakeDistrL = lens utxosStakeDistr (\x y -> x {utxosStakeDistr = y})
 utxosDonationL :: Lens' (UTxOState era) Coin
 utxosDonationL = lens utxosDonation (\x y -> x {utxosDonation = y})
 
+-- ================ IncremetalStake ===========================
+
+credMapL :: Lens' (IncrementalStake c) (Map (Credential 'Staking c) Coin)
+credMapL = lens credMap (\x y -> x {credMap = y})
+
+ptrMapL :: Lens' (IncrementalStake c) (Map Ptr Coin)
+ptrMapL = lens ptrMap (\x y -> x {ptrMap = y})
+
 -- ===================================================================
 -- Lenses for access to
 -- 1. (DRepDistr (EraCrypto era))
 -- 2. The 3 inputs we need to initialize one
---    a. (VMap VB VP (Credential 'Staking (EraCrypto era)) (CompactForm Coin)). Part of the Mark SnapShot
+--    a. (VMap VB VP (Credential 'Staking (EraCrypto era)) (CompactForm Coin)). Extracted from Incremental
 --    b. (Set (Credential 'DRepRole (EraCrypto era))). Registered DReps in the CertState
 --    c. (UMap (EraCrypto era)). The unified map in the DState.
 --                               We will use the to DRepUView to obtain  (Map (Credential 'Staking c) (DRep c))
@@ -719,8 +727,8 @@ epochStateDRepDistrL = esLStateL . lsCertStateL . certVStateL . vsDRepDistrL
 epochStateStakeDistrL ::
   Lens'
     (EpochState era)
-    (VMap VB VP (Credential 'Staking (EraCrypto era)) (CompactForm Coin))
-epochStateStakeDistrL = esSnapshotsL . ssStakeMarkL . ssStakeDistrL
+    (Map (Credential 'Staking (EraCrypto era)) Coin)
+epochStateStakeDistrL = esLStateL . lsUTxOStateL . utxosStakeDistrL . credMapL
 
 epochStateRegDrepL ::
   Lens'
@@ -741,4 +749,4 @@ freshDRepPulser n es =
     n
     (es ^. epochStateUMapL)
     (es ^. epochStateRegDrepL)
-    (es ^. epochStateStakeDistrL)
+    (VMap.fromMap (compactCoinOrError <$> (es ^. epochStateStakeDistrL)))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
@@ -91,7 +91,8 @@ drepDepositL = lens drepDeposit (\x y -> x {drepDeposit = y})
 -- | Given three inputs
 --   1) Map (Credential 'Staking c) (DRep c).   The delegation map. Inside the DRepUView of the UMap 'um' from the DState.
 --   2) regDreps :: Map (Credential 'DRepRole c) (DRepState c). The map of registered DReps to their state. The first part of the VState.
---   3) stakeDistr :: VMap VB VP (Credential 'Staking c) (CompactForm Coin). The aggregated state distr. The first part of the Mark SnapShot.
+--   3) stakeDistr :: VMap VB VP (Credential 'Staking c) (CompactForm Coin). The aggregated stake distr extracted from the
+--      first component of the IncrementalStake i.e. (IStake credmap _) where credmap is converted to a VMap
 --   Compute the Drep distribution of stake(Coin)
 --  cost is expected to be O(size of 'stakeDistr' * log (size of 'um') * log (size of 'regDreps'))
 --  This is going to be expensive, so we will want to pulse it. Without pulsing, we estimate 3-5 seconds


### PR DESCRIPTION

Changed freshDRepPulser to use map form IncrementalStake rather than the Mark SnapShot

addresses issue #3672

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
