### PR TITLE
Remove unused ubuntu packages to avoid running out of disk space

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,6 +46,25 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+
+      # Update the local package list in order to ensure that the action freeing up space will succeed
+    - name: "Update package list"
+      if: ${{ github.event_name == 'schedule' }}
+      run: |
+        sudo apt-get update
+      # there is not enough disk space to build nix derivations in the nightly build,
+      # so we're removing some unneccesary software from the ubuntu image
+    - name: Free disk space
+      if: ${{ github.event_name == 'schedule' }}
+      uses: jlumbroso/free-disk-space@main
+      with:
+        android: true
+        dotnet: true
+        haskell: false
+        large-packages: false # takes a long time to free not so much space, so it's disabled at the moment
+        docker-images: true
+        swap-storage: false # disabled, otherwise running out of memory during tests
+
     - uses: actions/checkout@v3
     - name: Set NIGHTLY environment variable if the job was triggered by the scheduler
       if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
when building nix derivations

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
