### PR TITLE
Conway Genesis  additions

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Add `insertGovActionsState`
 * Change type of `rsRemoved` in `RatifyState` to use  `GovActionState` instead of a tuple
 * Change `RatifySignal` to use `GovActionsState` instead of a tuple
+* Add `FromJSON` instance for `Committee`
 
 ## 1.7.1.0
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -76,6 +76,7 @@
 * Change type of `rsRemoved` in `RatifyState` to use  `GovActionState` instead of a tuple
 * Change `RatifySignal` to use `GovActionsState` instead of a tuple
 * Add `FromJSON` instance for `Committee`
+* Add `constitution` and `committee` fields to `ConwayGenesis`
 
 ## 1.7.1.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -11,6 +11,7 @@ description:
 
 category:           Network
 build-type:         Simple
+data-files:         data/*.json
 extra-source-files: CHANGELOG.md
 
 source-repository head
@@ -115,6 +116,8 @@ test-suite tests
     other-modules:
         Test.Cardano.Ledger.Conway.BinarySpec
         Test.Cardano.Ledger.Conway.RatifySpec
+        Test.Cardano.Ledger.Conway.GenesisSpec
+        Paths_cardano_ledger_conway
 
     default-language: Haskell2010
     ghc-options:
@@ -123,9 +126,11 @@ test-suite tests
         -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
+        aeson,
         base,
         cardano-ledger-core:testlib,
         cardano-ledger-conway,
         cardano-ledger-core,
         containers,
+        data-default-class,
         testlib

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -92,6 +92,7 @@ import Data.Aeson (
   (.:),
  )
 import Data.Aeson.Types (toJSONKeyText)
+import Data.Default.Class
 import Data.Map.Strict (Map)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Sequence (Seq (..))
@@ -352,6 +353,9 @@ instance ToExpr (Committee era)
 instance Era era => NoThunks (Committee era)
 
 instance Era era => NFData (Committee era)
+
+instance Default (Committee era) where
+  def = Committee mempty minBound
 
 committeeMembersL :: Lens' (Committee era) (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
 committeeMembersL = lens committeeMembers (\c m -> c {committeeMembers = m})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -28,7 +28,11 @@ import Cardano.Ledger.CertState (CommitteeState (..))
 import Cardano.Ledger.Conway.Core hiding (Tx)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import Cardano.Ledger.Conway.Governance ()
+import Cardano.Ledger.Conway.Governance (
+  cgEnactStateL,
+  ensCommitteeL,
+  ensConstitutionL,
+ )
 import Cardano.Ledger.Conway.Scripts ()
 import Cardano.Ledger.Conway.Tx ()
 import qualified Cardano.Ledger.Core as Core (Tx)
@@ -45,6 +49,7 @@ import Cardano.Ledger.Shelley.API (
  )
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, prevPParamsEpochStateL)
+import Data.Default.Class (Default (def))
 import qualified Data.Map.Strict as Map
 import Lens.Micro
 
@@ -63,7 +68,7 @@ import Lens.Micro
 -- being total. Do not change it!
 --------------------------------------------------------------------------------
 
-type instance TranslationContext (ConwayEra c) = ConwayGenesis (ConwayEra c)
+type instance TranslationContext (ConwayEra c) = ConwayGenesis c
 
 instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
   translateEra ctxt nes =
@@ -154,10 +159,15 @@ translateGovState ::
   TranslationContext (ConwayEra c) ->
   GovState (BabbageEra c) ->
   GovState (ConwayEra c)
-translateGovState ctxt sgov =
+translateGovState ctxt@(ConwayGenesis _ constitution committee) sgov =
   emptyGovState
     & curPParamsGovStateL .~ translateEra' ctxt (sgov ^. curPParamsGovStateL)
     & prevPParamsGovStateL .~ translateEra' ctxt (sgov ^. prevPParamsGovStateL)
+    & cgEnactStateL
+      .~ ( def
+            & ensConstitutionL .~ constitution
+            & ensCommitteeL .~ SJust committee
+         )
 
 instance Crypto c => TranslateEra (ConwayEra c) UTxOState where
   translateEra ctxt us =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -63,7 +63,7 @@ import Lens.Micro
 -- being total. Do not change it!
 --------------------------------------------------------------------------------
 
-type instance TranslationContext (ConwayEra c) = ConwayGenesis c
+type instance TranslationContext (ConwayEra c) = ConwayGenesis (ConwayEra c)
 
 instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
   translateEra ctxt nes =

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Conway.GenesisSpec as GenesisSpec
 import qualified Test.Cardano.Ledger.Conway.RatifySpec as RatifySpec
 
 main :: IO ()
@@ -10,3 +11,4 @@ main =
     describe "Conway" $ do
       BinarySpec.spec
       RatifySpec.spec
+      GenesisSpec.spec

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cardano.Ledger.Conway.GenesisSpec (spec) where
+
+import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Conway.Governance (Committee (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys
+import Cardano.Ledger.Slot (EpochNo (..))
+import Data.Aeson hiding (Encoding)
+import Data.Default.Class (Default (def))
+import Data.Map as Map
+import Data.Ratio ((%))
+import Paths_cardano_ledger_conway (getDataFileName)
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
+
+spec :: Spec
+spec = do
+  describe "Genesis Golden Spec" $ do
+    goldenConwayGenesisJSON
+
+goldenConwayGenesisJSON :: Spec
+goldenConwayGenesisJSON =
+  it "should deserialize to the default value" $ do
+    let fileName = "test/data/conway-genesis.json"
+        credMember =
+          KeyHashObj
+            (KeyHash "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a") ::
+            Credential 'ColdCommitteeRole StandardCrypto
+        scriptMember =
+          ScriptHashObj
+            (ScriptHash "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a") ::
+            Credential 'ColdCommitteeRole StandardCrypto
+        comm =
+          Committee
+            ( Map.fromList
+                [
+                  ( credMember
+                  , EpochNo 1
+                  )
+                ,
+                  ( scriptMember
+                  , EpochNo 2
+                  )
+                ]
+            )
+            (unsafeBoundRational (1 % 2)) ::
+            Committee Conway
+    file <- getDataFileName fileName
+    dec <- eitherDecodeFileStrict' file
+    cg <- case dec of
+      Left err -> error ("Failed to deserialize JSON: " ++ err)
+      Right x -> pure x
+    let expectedCg = def {cgCommittee = comm}
+    cg `shouldBe` expectedCg

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -1,0 +1,41 @@
+{
+  "upgradeProtocolParams":{
+     "poolVotingThresholds":{
+        "pvtCommitteeNormal":0,
+        "pvtCommitteeNoConfidence":0,
+        "pvtHardForkInitiation":0,
+        "pvtMotionNoConfidence":0
+     },
+     "dRepVotingThresholds":{
+        "dvtMotionNoConfidence":0,
+        "dvtCommitteeNormal":0,
+        "dvtCommitteeNoConfidence":0,
+        "dvtUpdateToConstitution":0,
+        "dvtHardForkInitiation":0,
+        "dvtPPNetworkGroup":0,
+        "dvtPPEconomicGroup":0,
+        "dvtPPTechnicalGroup":0,
+        "dvtPPGovGroup":0,
+        "dvtTreasuryWithdrawal":0
+     },
+     "minCommitteeSize":0,
+     "committeeTermLimit":0,
+     "govActionExpiration":0,
+     "govActionDeposit":0,
+     "dRepDeposit":0,
+     "dRepActivity":0
+  },
+  "constitution": {
+    "anchor": {
+      "url": "",
+      "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "committee" :{
+    "members" : {
+       "keyhash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1 ,
+       "scripthash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
+     },
+    "quorum": 0.5
+  }
+}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -33,7 +33,7 @@ import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
-  arbitrary = ConwayGenesis <$> arbitrary
+  arbitrary = ConwayGenesis <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary (UpgradeConwayPParams Identity) where
   arbitrary =

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import Cardano.Ledger.Conway.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj))
-import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
@@ -200,6 +200,5 @@ exampleConwayNewEpochState =
     emptyPParams
     (emptyPParams & ppCoinsPerUTxOByteL .~ CoinPerByte (Coin 1))
 
-exampleConwayGenesis :: ConwayGenesis c
-exampleConwayGenesis =
-  ConwayGenesis def
+exampleConwayGenesis :: Crypto c => ConwayGenesis c
+exampleConwayGenesis = def

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0.0
 
 * Add lenses for `UTxOEnv` #3688
+* Add `FromJSON` instance for `Constitution`
 * Add `getTotalTxDepositsBody` to `ShelleyEraTxBody`
 * Add `obligationGovState` to `EraGov`
 * Add `ToExpr` instance to `Constitution`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add `ToExpr` instance for `PoolCert`
 * Require `ToExpr` instance for `Script`, `TxAuxData` and `TxCert`
 * Require an extra argument for `decodePositiveCoin` in order to improve error reporting #3694
+* Add `FromJSON` instance to `Anchor`
 
 ## 1.5.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -131,6 +131,7 @@ import Data.Aeson (
   ToJSON (..),
   object,
   pairs,
+  withObject,
   (.:),
   (.=),
  )
@@ -820,6 +821,12 @@ instance Crypto c => EncCBOR (Anchor c) where
 instance Crypto c => ToJSON (Anchor c) where
   toJSON = object . toAnchorPairs
   toEncoding = pairs . mconcat . toAnchorPairs
+
+instance Crypto c => FromJSON (Anchor c) where
+  parseJSON = withObject "Anchor" $ \o -> do
+    anchorUrl <- o .: "url"
+    anchorDataHash <- o .: "dataHash"
+    pure $ Anchor {..}
 
 instance ToExpr (Anchor c)
 


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Closes https://github.com/input-output-hk/cardano-ledger/issues/3652

* Adds two fields to ConwayGenesis:  Constitution and Committee
* Updates Conway Translation to create EnactState using the two new fields from ConwayGenesis
* Also added a trivial JSON gold test, to prevent accidental changes of the json serialization

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
