### PR TITLE
Add proposal delaying, remove predicate failure from ENACT

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## 1.8.0.0
 
+* Change `PredicateFailure (ConwayENACT era)` to `Void`
+* Remove `EnactPredFailure`
+* Change `PredicateFailure (ConwayEPOCH era)` to `Void`
+* Remove `ConwayEpochPredFailure`
+* Remove `EpochFailure` and `RatifyFailure` from `ConwayNewEpochPredFailure`
+* Change `PredicateFailure (ConwayRATIFY era)` to `Void`
 * Add:
+  * `rsDelayed`
   * `PParamGroup`
   * `ParamGrouper`
   * `pGroup`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -20,11 +20,33 @@ module Cardano.Ledger.Conway.Rules.Gov (
 ) where
 
 import Cardano.Ledger.Address (RewardAcnt, getRwdNetwork)
-import Cardano.Ledger.BaseTypes (EpochNo (..), Network, ShelleyBase, networkId)
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.BaseTypes (
+  EpochNo (..),
+  Network,
+  ShelleyBase,
+  networkId,
+ )
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+  FromCBOR (..),
+  ToCBOR (..),
+ )
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Core (ConwayEraPParams (..), ppGovActionDepositL, ppGovActionExpirationL, ppMinCommitteeSizeL)
+import Cardano.Ledger.Conway.Core (
+  ConwayEraPParams (..),
+  ppGovActionDepositL,
+  ppGovActionExpirationL,
+  ppMinCommitteeSizeL,
+ )
 import Cardano.Ledger.Conway.Era (ConwayGOV)
 import Cardano.Ledger.Conway.Governance (
   GovActionId (..),
@@ -38,7 +60,10 @@ import Cardano.Ledger.Conway.Governance (
   curGovActionsStateL,
   indexedGovProps,
  )
-import Cardano.Ledger.Conway.Governance.Procedures (GovAction (..), committeeMembersL)
+import Cardano.Ledger.Conway.Governance.Procedures (
+  GovAction (..),
+  committeeMembersL,
+ )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (Inject (..), Test, runTest)
 import Cardano.Ledger.Shelley.Tx (TxId (..))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -105,6 +105,7 @@ instance
     RatifyState
       <$> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog for `cardano-ledger-pretty`
 
-## 1.3.1.0
+## 1.4.0.0
 
+* Remove `ppRatifyPredicateFailure`
+* Remove `PrettyA (ConwayEpochPredFailure era)`
+* Remove `PrettyA (EnactPredFailure era)`
 * Add `PrettyA` instances for:
   * `NonNegativeInterval`
   * `CostModels`

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-pretty
-version:            1.3.0.1
+version:            1.3.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -437,12 +437,13 @@ instance
   ) =>
   PrettyA (RatifyState era)
   where
-  prettyA rs@(RatifyState _ _) =
+  prettyA rs@(RatifyState _ _ _) =
     let RatifyState {..} = rs
      in ppRecord
           "RatifyState"
           [ ("EnactState", prettyA rsEnactState)
           , ("Removed", prettyA rsRemoved)
+          , ("Delayed", prettyA rsDelayed)
           ]
 
 instance

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -54,11 +54,6 @@ import Cardano.Ledger.CertState (CommitteeState (..))
 import qualified Cardano.Ledger.CertState as DP
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Conway.Governance (GovActionsState (..))
-import Cardano.Ledger.Conway.Rules (
-  ConwayEpochPredFailure (..),
-  EnactPredFailure (..),
- )
-import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayTxCert (..), Delegatee (..))
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Core as Core
@@ -939,14 +934,6 @@ ppConwayNewEpochPredicateFailure (Conway.CorruptRewardUpdate x) =
 ppConwayNewEpochPredicateFailure (Conway.RatifyFailure x) = ppRatifyPredicateFailure @era x
 -}
 
-ppRatifyPredicateFailure :: Conway.EnactPredFailure era -> PDoc
-ppRatifyPredicateFailure (Conway.EnactTreasuryInsufficientFunds wdrl tr) =
-  ppRecord
-    "EnactTreasuryInsufficientFunds"
-    [ ("Withdrawals", prettyA wdrl)
-    , ("Treasury", prettyA tr)
-    ]
-
 instance
   ( Reflect era
   , PredicateFailure (EraRule "EPOCH" era) ~ ShelleyEpochPredFailure era
@@ -983,29 +970,11 @@ instance
   where
   prettyA = ppEpochPredicateFailure
 
-instance
-  ( PrettyA (PredicateFailure (EraRule "POOLREAP" era))
-  , PrettyA (PredicateFailure (EraRule "SNAP" era))
-  , PrettyA (PredicateFailure (EraRule "RATIFY" era))
-  ) =>
-  PrettyA (ConwayEpochPredFailure era)
-  where
-  prettyA (ConwayPoolReapFailure x) = prettyA x
-  prettyA (ConwaySnapFailure x) = prettyA x
-  prettyA (ConwayRatifyFailure x) = prettyA x
-
 instance PrettyA (ShelleyPoolreapPredFailure era) where
   prettyA = \case {}
 
 instance PrettyA (ShelleySnapPredFailure era) where
   prettyA = \case {}
-
-instance PrettyA (Conway.EnactPredFailure era) where
-  prettyA (EnactTreasuryInsufficientFunds x y) =
-    "Not enough funds in treasury. \nWitdrawals: "
-      <> prettyA x
-      <> "\nRemaining funds in treasury:"
-      <> prettyA y
 
 -- ===============
 ppUpecPredicateFailure :: ShelleyUpecPredFailure era -> PDoc


### PR DESCRIPTION
# Description

Removed the predicate failure from ENACT. Made the enactment of some actions delay all the other actions. Treasury withdrawals are now delayed when there is not enough ADA in the treasury.

I also changed the logic of `RATIFY` so that actions with invalid previous governance action ID get delayed rather than dropped.

closes #3675 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
