### PR TITLE
Update `NoThunks` instances to reflect thunks in `PState`and `CertState`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -73,6 +73,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad.State.Strict (evalStateT)
 import Control.Monad.Trans (MonadTrans (lift))
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
+import Data.Data (Typeable)
 import Data.Default.Class (Default, def)
 import Data.Group (Group, invert)
 import Data.Map.Strict (Map)
@@ -81,7 +82,7 @@ import Data.VMap (VB, VMap, VP)
 import qualified Data.VMap as VMap
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import Numeric.Natural (Natural)
 
 -- ==================================
@@ -302,12 +303,12 @@ deriving stock instance
   ) =>
   Eq (UTxOState era)
 
-instance
-  ( NoThunks (UTxO era)
-  , NoThunks (Value era)
-  , NoThunks (GovState era)
-  ) =>
-  NoThunks (UTxOState era)
+deriving via
+  AllowThunksIn
+    '["utxosDeposited"]
+    (UTxOState era)
+  instance
+    (Typeable era, NoThunks (UTxO era), NoThunks (GovState era)) => NoThunks (UTxOState era)
 
 instance
   ( EraTxOut era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -99,7 +100,7 @@ import qualified Data.Map.Strict as Map
 import Data.Typeable
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, (^.), _1, _2)
-import NoThunks.Class (NoThunks (..))
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 
 -- ======================================
 
@@ -246,8 +247,10 @@ data PState era = PState
   }
   deriving (Show, Eq, Generic)
 
-instance NoThunks (PState era)
-
+deriving via
+  AllowThunksIn '["psDeposits"] (PState era)
+  instance
+    Typeable era => NoThunks (PState era)
 instance NFData (PState era)
 
 instance Era era => EncCBOR (PState era) where
@@ -346,7 +349,7 @@ data CertState era = CertState
   }
   deriving (Show, Eq, Generic)
 
-instance Typeable (EraCrypto era) => NoThunks (CertState era)
+instance (Typeable era, Typeable (EraCrypto era)) => NoThunks (CertState era)
 
 instance Era era => NFData (CertState era)
 


### PR DESCRIPTION
# Description

Changing `utxosDeposited` in `UTxOState` to  be lazy is causing the  (nightly run) `NoThunks` test to fail. 
Simply changing the NoThunks implementation in `UTxOState` to allow thunks in `utxosDeposited`  is not enough though, it seems that we have to allow them for  `psDeposits`  in `PState`. 
I don't understand exactly why this is the case, given that `PState` is part of `CertState`, which  is defined alongside with `UTxOState` inside `LedgerState`, but I guess it is a consequence of how the rules and assertions are invoked, 

This PR simply makes the `NoThunks` test pass again, but I'm not convinced :
1)  Is there a better way to make the test pass (instead of allowing thunks in PState) 
2) If we have to allow thunks in PState, do we still want to have `utxosDeposited` strict? 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
