### PR TITLE
Improve error reporting on the postive coin decoder

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -199,7 +199,7 @@ instance
       bodyFields 22 =
         ofield
           (\x tx -> tx {ctbrTreasuryDonation = fromSMaybe zero x})
-          (D decodePositiveCoin)
+          (D (decodePositiveCoin "'treasuryWithdrawal' must be non-zero when supplied"))
       bodyFields n = field (\_ t -> t) (Invalid n)
       requiredFields :: [(Word, String)]
       requiredFields =

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Require `EqRaw` instance for `Script`, `TxWits`, `TxAuxData`, `TxBody` and `Tx`
 * Add `ToExpr` instance for `PoolCert`
 * Require `ToExpr` instance for `Script`, `TxAuxData` and `TxCert`
+* Require an extra argument for `decodePositiveCoin` in order to improve error reporting #3694
 
 ## 1.5.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -144,9 +144,9 @@ instance ToExpr DeltaCoin
 instance ToExpr (CompactForm Coin) where
   toExpr x = toExpr (fromCompact x)
 
-decodePositiveCoin :: Decoder s Coin
-decodePositiveCoin = do
+decodePositiveCoin :: String -> Decoder s Coin
+decodePositiveCoin errorMessage = do
   n <- decodeWord64
   if n == 0
-    then fail "Expected a positive Coin. Got 0 (zero)."
+    then fail $ errorMessage ++ ": Expected a positive Coin. Got 0 (zero)."
     else pure $ Coin (toInteger n)


### PR DESCRIPTION
# Description

Better error reporting for `decodePositiveCoin` decoder.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
