### PR TITLE
Rewrite testEql using Typeable to make it impossible to forget cases

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -288,14 +288,14 @@ instance Show (Term era t) where
   show (Pair r t) = "(Pair " ++ show r ++ " " ++ show t ++ ")"
   showList xs ans = unlines (ans : map show xs)
 
-instance Show (Sum era c) where
+instance Era era => Show (Sum era c) where
   show (SumMap t) = "sum " ++ show t
   show (SumList t) = "sum " ++ show t
   show (One t) = show t
   show (ProjOne _ c t) = seps ["ProjOne", show c, show t]
   show (ProjMap crep _lens t) = "ProjMap " ++ show crep ++ " " ++ show t
 
-instance Show (Pred era) where
+instance Era era => Show (Pred era) where
   show (MetaSize n t) = "MetaSize " ++ show n ++ " " ++ show t
   show (Sized n t) = "Sized " ++ show n ++ " " ++ show t
   show (x :=: y) = show x ++ " :=: " ++ show y
@@ -329,7 +329,7 @@ instance Show (Pred era) where
   show (Before x y) = "Before " ++ show x ++ " " ++ show y
   showList xs ans = unlines (ans : (map show xs))
 
-showAllTarget :: Target era t -> [Char]
+showAllTarget :: Era era => Target era t -> [Char]
 showAllTarget tar = "   forall " ++ showL show " " (Set.toList (varsOfTarget Set.empty tar)) ++ ". "
 
 instance Show (Target era t) where
@@ -380,7 +380,7 @@ targetPair x = (nameOf x, targetRecord x [])
 -- Their are no binders in any of these, so this is not so difficult
 -- But (V era t) may have different 't', so we hide 't' in 'Name'
 
-varsOfTerm :: Set (Name era) -> Term era t -> Set (Name era)
+varsOfTerm :: Era era => Set (Name era) -> Term era t -> Set (Name era)
 varsOfTerm ans s = case s of
   Lit _ _ -> ans
   Var v@(V _ _ _) -> Set.insert (Name v) ans
@@ -397,21 +397,21 @@ varsOfTerm ans s = case s of
   HashD st -> varsOfTerm ans st
   Pair a b -> varsOfTerm (varsOfTerm ans a) b
 
-vars :: Term era t -> Set (Name era)
+vars :: Era era => Term era t -> Set (Name era)
 vars x = varsOfTerm Set.empty x
 
-varsOfTarget :: Set (Name era) -> Target era t -> Set (Name era)
+varsOfTarget :: Era era => Set (Name era) -> Target era t -> Set (Name era)
 varsOfTarget ans s = case s of
   (a :$ b) -> varsOfTarget (varsOfTarget ans a) b
   (Simple x) -> varsOfTerm ans x
   (Constr _ _) -> ans
 
-expandSum :: Sum era c -> [Int] -> [Sum era c]
+expandSum :: Era era => Sum era c -> [Int] -> [Sum era c]
 expandSum (One (Var (V n r a))) ns = map (\i -> One (Var (V (n ++ "." ++ show i) r a))) ns
 expandSum (ProjOne l rep (Var (V n r a))) ns = map (\i -> ProjOne l rep (Var (V (n ++ "." ++ show i) r a))) ns
 expandSum x _ = error ("Bad Sum in expandSum: " ++ show x)
 
-varsOfPred :: Set (Name era) -> Pred era -> Set (Name era)
+varsOfPred :: Era era => Set (Name era) -> Pred era -> Set (Name era)
 varsOfPred ans s = case s of
   MetaSize _ term -> varsOfTerm ans term
   Sized a b -> varsOfTerm (varsOfTerm ans a) b
@@ -440,7 +440,7 @@ varsOfPred ans s = case s of
   If t x y -> varsOfTarget (varsOfPred (varsOfPred ans x) y) t
   Before a b -> varsOfTerm (varsOfTerm ans a) b
 
-varsOfTrips :: Set (Name era) -> [(Int, Target era t2, [Pred era])] -> Set (Name era)
+varsOfTrips :: Era era => Set (Name era) -> [(Int, Target era t2, [Pred era])] -> Set (Name era)
 varsOfTrips ans1 [] = ans1
 varsOfTrips ans1 ((_, t, ps) : more) = varsOfTrips (act ans1 t ps) more
   where
@@ -452,7 +452,7 @@ varsOfTrips ans1 ((_, t, ps) : more) = varsOfTrips (act ans1 t ps) more
         )
         ans2
 
-varsOfPairs :: Set (Name era) -> [(Target era t2, [Pred era])] -> Set (Name era)
+varsOfPairs :: Era era => Set (Name era) -> [(Target era t2, [Pred era])] -> Set (Name era)
 varsOfPairs ans1 [] = ans1
 varsOfPairs ans1 ((t, ps) : more) = varsOfPairs (act ans1 t ps) more
   where
@@ -464,7 +464,7 @@ varsOfPairs ans1 ((t, ps) : more) = varsOfPairs (act ans1 t ps) more
         )
         ans2
 
-varsOfPats :: Set (Name era) -> [(Pat era t2, [Pred era])] -> Set (Name era)
+varsOfPats :: Era era => Set (Name era) -> [(Pat era t2, [Pred era])] -> Set (Name era)
 varsOfPats ans1 [] = ans1
 varsOfPats ans1 ((pat0, ps) : more) = varsOfPats (act ans1 pat0 ps) more
   where
@@ -476,7 +476,7 @@ varsOfPats ans1 ((pat0, ps) : more) = varsOfPats (act ans1 pat0 ps) more
         )
         ans2
 
-varsOfSum :: Set (Name era) -> Sum era r -> Set (Name era)
+varsOfSum :: Era era => Set (Name era) -> Sum era r -> Set (Name era)
 varsOfSum ans (SumMap y) = varsOfTerm ans y
 varsOfSum ans (SumList y) = varsOfTerm ans y
 varsOfSum ans (One y) = varsOfTerm ans y
@@ -521,7 +521,7 @@ envToSubst (Env env) = Subst (Map.map f env)
   where
     f (Payload rep t access) = SubstElem rep (Lit rep t) access
 
-findV :: Subst era -> V era t -> Term era t
+findV :: Era era => Subst era -> V era t -> Term era t
 findV (Subst m) v@(V n1 rep1 _) = case Map.lookup n1 m of
   Nothing -> Var v -- If its not in the Subst, return the Var
   Just (SubstElem rep2 term _) -> case testEql rep1 rep2 of
@@ -563,7 +563,7 @@ itemsToSubst ss = Subst (List.foldr accum Map.empty ss)
 -- =====================================================
 -- Subtitution of (V era t) inside of (Spec era t)
 
-substTerm :: Subst era -> Term era t -> Term era t
+substTerm :: Era era => Subst era -> Term era t -> Term era t
 substTerm sub (Var v) = findV sub v
 substTerm _ (Lit r k) = Lit r k
 substTerm sub (Dom x) = Dom (substTerm sub x)
@@ -579,7 +579,7 @@ substTerm sub (HashS s) = HashS (substTerm sub s)
 substTerm sub (HashD s) = HashD (substTerm sub s)
 substTerm sub (Pair a b) = Pair (substTerm sub a) (substTerm sub b)
 
-substPred :: Subst era -> Pred era -> Pred era
+substPred :: Era era => Subst era -> Pred era -> Pred era
 substPred sub (MetaSize a b) = MetaSize a (substTerm sub b)
 substPred sub (Sized a b) = Sized (substTerm sub a) (substTerm sub b)
 substPred sub (a :=: b) = substTerm sub a :=: substTerm sub b
@@ -630,7 +630,7 @@ substPred sub (If t x y) = If (substTarget sub t) (substPred sub x) (substPred s
 substPred sub (Before a b) = Before (substTerm sub a) (substTerm sub b)
 
 -- | Apply the Subst, and test if all variables are removed.
-substPredWithVarTest :: Subst era -> Pred era -> Pred era
+substPredWithVarTest :: Era era => Subst era -> Pred era -> Pred era
 substPredWithVarTest sub oldpred =
   let newpred = substPred sub oldpred
       freevars = varsOfPred Set.empty newpred
@@ -648,20 +648,20 @@ substPredWithVarTest sub oldpred =
             )
   where
 
-substFromTarget :: Target era t -> Subst era
+substFromTarget :: Era era => Target era t -> Subst era
 substFromTarget tar = substFromNames (varsOfTarget Set.empty tar)
 
-substFromPat :: Pat era t -> Subst era
+substFromPat :: Era era => Pat era t -> Subst era
 substFromPat pat = substFromNames (varsOfPat Set.empty pat)
 
-substSum :: Subst era -> Sum era t -> Sum era t
+substSum :: Era era => Subst era -> Sum era t -> Sum era t
 substSum sub (SumMap x) = SumMap (substTerm sub x)
 substSum sub (SumList x) = SumList (substTerm sub x)
 substSum sub (One x) = One (substTerm sub x)
 substSum sub (ProjOne l r x) = ProjOne l r (substTerm sub x)
 substSum sub (ProjMap crep l x) = ProjMap crep l (substTerm sub x)
 
-substTarget :: Subst era -> Target era t -> Target era t
+substTarget :: Era era => Subst era -> Target era t -> Target era t
 substTarget sub (Simple e) = Simple (substTerm sub e)
 substTarget sub (a :$ b) = substTarget sub a :$ substTarget sub b
 substTarget _ (Constr n f) = Constr n f
@@ -718,7 +718,7 @@ simplify (Pair s m) = do
 simplify x = failT ["Can't simplify term: " ++ show x ++ ", to a value."]
 
 -- | Simplify constant Sum's
-simplifySum :: Sum era c -> Typed c
+simplifySum :: Era era => Sum era c -> Typed c
 simplifySum (One (Lit _ x)) = pure x
 simplifySum (One (Delta (Lit CoinR (Coin n)))) = pure (DeltaCoin n)
 simplifySum (One (Negate (Lit DeltaCoinR (DeltaCoin n)))) = pure (DeltaCoin (-n))
@@ -737,7 +737,7 @@ simplifyTarget (x :$ y) = do
   pure (f z)
 
 -- | Fully evaluate a `Term`, looking up the variables in the `Env`.
-runTerm :: Env era -> Term era t -> Typed t
+runTerm :: Era era => Env era -> Term era t -> Typed t
 runTerm _ (Lit _ x) = pure x
 runTerm env (Dom x) = Map.keysSet <$> runTerm env x
 runTerm env (Rng x) = Set.fromList . Map.elems <$> runTerm env x
@@ -774,7 +774,7 @@ runTerm env (Pair s m) =
     mv <- runTerm env m
     pure (sv, mv)
 
-runTarget :: Env era -> Target era t -> Typed t
+runTarget :: Era era => Env era -> Target era t -> Typed t
 runTarget env (Simple t) = runTerm env t
 runTarget _ (Constr _ f) = pure f
 runTarget env (x :$ y) = do
@@ -782,16 +782,16 @@ runTarget env (x :$ y) = do
   z <- runTarget env y
   pure (f z)
 
-runPred :: Env era -> Pred era -> Typed Bool
+runPred :: Era era => Env era -> Pred era -> Typed Bool
 runPred env (MetaSize w x) = do
   sz <- runTerm env x
   case sz of
     SzExact n -> pure $ runSize n w
     _ -> pure $ False
-runPred env (Sized w x) = do
-  sz <- runTerm env w
-  item <- runTerm env x
-  pure (runSize (getSize item) sz)
+runPred env (Sized szt tt) = do
+  sz <- runTerm env szt
+  t <- runTerm env tt
+  pure $ runSize (getSize t) sz
 runPred env (x :=: y) = do
   x2 <- runTerm env x
   y2 <- runTerm env y
@@ -889,7 +889,7 @@ runPred env (Oneof _ preds) = do
 
 --   other predicates P(x) would exapnd to 3 copies like P(x.1) P(x.2) P(x.3)
 --   This is called Sum extension, is implemented by `extendSum`
-extendableSumsTo :: Pat era t -> Pred era -> Bool
+extendableSumsTo :: Era era => Pat era t -> Pred era -> Bool
 extendableSumsTo pat (SumsTo _ t _ [One s]) =
   Set.size boundS == 1 && Set.isSubsetOf boundS free && Set.disjoint boundT free
   where
@@ -905,7 +905,7 @@ extendableSumsTo pat (SumSplit _ t _ [One s]) =
 extendableSumsTo _ _ = False
 
 -- | run a bunch of Preds, and and together the results
-runPreds :: Env era -> [Pred era] -> Typed Bool
+runPreds :: Era era => Env era -> [Pred era] -> Typed Bool
 runPreds env ps = do
   bs <- mapM (runPred env) ps
   pure (and bs)
@@ -914,10 +914,10 @@ bind :: Target era t -> t -> Env era -> Env era
 bind (Simple (Var v)) x env = storeVar v x env
 bind t _ _ = error ("Non simple Target in bind: " ++ show t)
 
-runComp :: Env era -> s -> AnyF era s -> Typed Bool
-runComp env t (AnyF (Field n r rx l)) = do
-  t' <- runTerm env $ Var (V n r (Yes rx l))
-  With _ <- hasEq r r
+runComp :: Era era => Env era -> s -> AnyF era s -> Typed Bool
+runComp env t (AnyF (Field n rt rx l)) = do
+  t' <- runTerm env $ Var (V n rt (Yes rx l))
+  With _ <- hasEq rt rt
   pure $ t ^. l == t'
 runComp _ t (AnyF (FConst r v _ l)) = do
   With _ <- hasEq r r
@@ -939,7 +939,7 @@ termRep (HashD _) = DataHashR
 termRep (HashS _) = ScriptHashR
 termRep (Pair a b) = PairR (termRep a) (termRep b)
 
-runSum :: Env era -> Sum era c -> Typed c
+runSum :: Era era => Env era -> Sum era c -> Typed c
 runSum env (SumMap t) = Map.foldl' add zero <$> runTerm env t
 runSum env (SumList t) = List.foldl' add zero <$> runTerm env t
 runSum env (One t) = runTerm env t
@@ -950,12 +950,12 @@ runSum env (ProjMap _ l t) = Map.foldl' accum zero <$> runTerm env t
   where
     accum ans x = add ans (x ^. l)
 
-makeTest :: Env era -> Pred era -> Typed (String, Bool, Pred era)
+makeTest :: Era era => Env era -> Pred era -> Typed (String, Bool, Pred era)
 makeTest env c = do
   b <- runPred env c
   pure (show c ++ " => " ++ show b, b, c)
 
-displayTerm :: Env era -> Term era a -> IO ()
+displayTerm :: Era era => Env era -> Term era a -> IO ()
 displayTerm env (Var v@(V nm rep _)) = do
   x <- monadTyped (findVar v env)
   putStrLn (nm ++ "\n" ++ format rep x)
@@ -986,7 +986,7 @@ data Arg era t where
   Arg :: !(Field era t s) -> Arg era t
 
 -- | Succeds if 'term' is a variable with an embedded (Lens' t2 t1)
-patt :: Rep era t1 -> Term era t2 -> Pat era t1
+patt :: Era era => Rep era t1 -> Term era t2 -> Pat era t1
 patt rep term = Pat rep [arg rep term]
 
 instance Show (Pat era t) where
@@ -997,28 +997,28 @@ instance Show (Arg era t) where
   show (ArgPs (Field nm _ _ _) qs) = nm ++ " [" ++ showL show ", " qs ++ "]"
   show (ArgPs f@(FConst _ _ _ _) qs) = show f ++ " [" ++ showL show ", " qs ++ "]"
 
-varsOfField :: Set.Set (Name era) -> Field era s t -> Set.Set (Name era)
+varsOfField :: Era era => Set.Set (Name era) -> Field era s t -> Set.Set (Name era)
 varsOfField l (Field n r rx l2) = Set.insert (Name $ V n r (Yes rx l2)) l
 varsOfField l (FConst _ _ _ _) = l
 
-varsOfPat :: Set.Set (Name era) -> Pat era t -> Set.Set (Name era)
+varsOfPat :: Era era => Set.Set (Name era) -> Pat era t -> Set.Set (Name era)
 varsOfPat ans (Pat _ qs) = List.foldl' varsOfArg ans qs
 
-varsOfArg :: Set.Set (Name era) -> Arg era t -> Set.Set (Name era)
+varsOfArg :: Era era => Set.Set (Name era) -> Arg era t -> Set.Set (Name era)
 varsOfArg ans (ArgPs f qs) = List.foldl' varsOfPat (varsOfField ans f) qs
 varsOfArg ans (Arg f) = varsOfField ans f
 
-substField :: Subst era -> Field era rec fld -> Field era rec fld
+substField :: Era era => Subst era -> Field era rec fld -> Field era rec fld
 substField _ w@(FConst _ _ _ _) = w
 substField sub w@(Field n r rx l) = case findV sub (V n r (Yes rx l)) of
   (Lit rep x) -> FConst rep x rx l
   (Var (V n2 r2 _a2)) -> Field n2 r2 rx l
   _ -> w
 
-substPat :: Subst era -> Pat era t -> Pat era t
+substPat :: Era era => Subst era -> Pat era t -> Pat era t
 substPat sub (Pat r as) = Pat r (map (substArg sub) as)
 
-substArg :: Subst era -> Arg era t -> Arg era t
+substArg :: Era era => Subst era -> Arg era t -> Arg era t
 substArg sub (ArgPs r as) = ArgPs (substField sub r) (map (substPat sub) as)
 substArg sub (Arg r) = Arg (substField sub r)
 
@@ -1038,7 +1038,7 @@ bindArg t env (ArgPs (Field n r rx l) qs) =
 --   3) A list of sub-patterns.
 --   Check that all the embedded Access have the right Lens'.
 --   If not throw an error.
-argP :: Rep era s -> Term era t -> [Pat era t] -> Arg era s
+argP :: Era era => Rep era s -> Term era t -> [Pat era t] -> Arg era s
 argP repS1 (Var (V name rept (Yes repS2 ll))) qs = case testEql repS1 repS2 of
   Just Refl -> ArgPs (Field name rept repS2 ll) qs
   Nothing ->
@@ -1054,7 +1054,7 @@ argP _ term _ = error ("argP can only be applied to variable terms: " ++ show te
 
 -- | Construct an Arg from a variable (Term era s) with a Yes Access.
 --   Check that the Access has the right Lens'. If not throw an error.
-arg :: Rep era s -> Term era t -> Arg era s
+arg :: Era era => Rep era s -> Term era t -> Arg era s
 arg repS1 (Var (V name rept (Yes repS2 l))) = case testEql repS1 repS2 of
   Just Refl -> Arg (Field name rept repS2 l)
   Nothing ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Ledger.Constrained.Preds.PParams (
 
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Script (Prices (..))
+import Cardano.Ledger.Api.Era
 import Cardano.Ledger.BaseTypes (
   NonNegativeInterval,
   boundRational,
@@ -30,7 +31,7 @@ import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Updaters (defaultCostModels, newPParams)
 import Test.Tasty.QuickCheck
 
-extract :: Term era t -> Term era s -> Pred era
+extract :: Era era => Term era t -> Term era s -> Pred era
 extract term@(Var (V _ _ (Yes r1 lens))) record =
   case testEql r1 (termRep record) of
     Just Refl -> term :<-: (Constr "lookup" (\x -> x ^. lens) ^$ record)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -736,20 +736,20 @@ adjustC (i : is) m extra@(Coin n) coinL = case compare n 0 of
         Nothing -> error ("Collateral input: " ++ show i ++ " is not found in UTxO in 'adjust'")
       subextra outf = outf & coinL .~ (Coin (max 1 (unCoin ((outf ^. coinL) <+> extra))))
 
-updateVal :: (a -> b -> a) -> Term era a -> b -> Env era -> Typed (Env era)
+updateVal :: Era era => (a -> b -> a) -> Term era a -> b -> Env era -> Typed (Env era)
 updateVal adjust term@(Var v) delta env = do
   varV <- runTerm env term
   pure $ storeVar v (adjust varV delta) env
 updateVal _ v _ _ = failT ["Non Var in updateVal: " ++ show v]
 
-updateTerm :: (a -> b -> a) -> Term era a -> Term era b -> Env era -> Typed (Env era)
+updateTerm :: Era era => (a -> b -> a) -> Term era a -> Term era b -> Env era -> Typed (Env era)
 updateTerm adjust term@(Var v) delta env = do
   varV <- runTerm env term
   deltaV <- runTerm env delta
   pure $ storeVar v (adjust varV deltaV) env
 updateTerm _ v _ _ = failT ["Non Var in updateTerm: " ++ show v]
 
-updateTarget :: (a -> b -> a) -> Term era a -> Target era b -> Env era -> Typed (Env era, b)
+updateTarget :: Era era => (a -> b -> a) -> Term era a -> Target era b -> Env era -> Typed (Env era, b)
 updateTarget adjust term@(Var v) delta env = do
   varV <- runTerm env term
   deltaV <- runTarget env delta

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Shrink.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Shrink.hs
@@ -68,8 +68,8 @@ fixupVar :: Era era => Name era -> [Pred era] -> Payload era -> Maybe (Payload e
 fixupVar v cs p = listToMaybe [p' | p' <- [p | validAssignment v p cs] ++ reverse (shrinkVar v cs p)]
 
 -- | Assumes the variable is the only free variable in the constraints.
-validAssignment :: Name era -> Payload era -> [Pred era] -> Bool
+validAssignment :: Era era => Name era -> Payload era -> [Pred era] -> Bool
 validAssignment v p cs = all (runPred_ $ storeName v p emptyEnv) cs
 
-runPred_ :: Env era -> Pred era -> Bool
+runPred_ :: Era era => Env era -> Pred era -> Bool
 runPred_ env p = either (const False) id $ runTyped $ runPred env p

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -130,32 +130,32 @@ isCountType rep = case hasCount rep rep of
 -- ==================================================
 -- Extras, simple helper functions
 
-sameRep :: Rep era i -> Rep era j -> Typed (i :~: j)
+sameRep :: Era era => Rep era i -> Rep era j -> Typed (i :~: j)
 sameRep r1 r2 = case testEql r1 r2 of
   Just x -> pure x
   Nothing -> failT ["Type error in sameRep:\n  " ++ show r1 ++ " =/=\n  " ++ show r2]
 
 -- | Simplify and return with evidence that 'expr' has type 's'
-simplifyAtType :: Rep era s -> Term era t -> Typed s
+simplifyAtType :: Era era => Rep era s -> Term era t -> Typed s
 simplifyAtType r1 term = do
   t <- simplify term
   Refl <- sameRep r1 (termRep term)
   pure t
 
-simplifySet :: Ord rng => Rep era rng -> Term era y -> Typed (HasConstraint Ord (Set rng))
+simplifySet :: (Ord rng, Era era) => Rep era rng -> Term era y -> Typed (HasConstraint Ord (Set rng))
 simplifySet r1 term = do
   x <- simplify term
   Refl <- sameRep (SetR r1) (termRep term)
   pure (With x)
 
-simplifyList :: Rep era rng -> Term era y -> Typed (HasConstraint Eq [rng])
+simplifyList :: Era era => Rep era rng -> Term era y -> Typed (HasConstraint Eq [rng])
 simplifyList r1 term = do
   x <- simplify term
   Refl <- sameRep (ListR r1) (termRep term)
   hasEq r1 x
 
 -- | Is the Sum a variable (of a map). Only SumMap and Project store maps.
-isMapVar :: Name era -> Sum era c -> Bool
+isMapVar :: Era era => Name era -> Sum era c -> Bool
 isMapVar n1 (SumMap (Var v2)) = n1 == Name v2
 isMapVar n1 (ProjMap _ _ (Var v2)) = n1 == Name v2
 isMapVar _ _ = False
@@ -390,7 +390,7 @@ solveMap v1@(V _ r@(MapR dom rng) _) predicate = explain msg $ case predicate of
 --   That can only happen in a (RngSum cond c) or a (RngProj cond rep c) constructor of 'Sum'
 --   Because we don't know if 'c' can have negative values, we do the summation as an Integer
 solveMapSummands ::
-  Adds c =>
+  (Adds c, Era era) =>
   c ->
   c ->
   [String] ->
@@ -426,7 +426,7 @@ solveMaps v@(V _ (MapR _ _) _) cs =
 
 -- | Given a variable: 'v1', with a Set type, compute a SetSpec
 --   which describes the constraints implied by the Pred 'predicate'
-solveSet :: forall era a. V era (Set a) -> Pred era -> Typed (SetSpec era a)
+solveSet :: forall era a. Era era => V era (Set a) -> Pred era -> Typed (SetSpec era a)
 solveSet v1@(V _ (SetR r) _) predicate = case predicate of
   (Sized (Size sz) (Var v2)) | Name v1 == Name v2 -> setSpec sz RelAny
   (List (Var v2@(V _ (SetR _) _)) []) | Just Refl <- sameName v1 v2 -> setSpec (SzExact 0) RelAny
@@ -501,7 +501,7 @@ solveSet v1@(V _ (SetR r) _) predicate = case predicate of
         setSpec (SzMost (Map.size x)) (RelLens lensbt r trep (relSubset drep (Map.keysSet x)))
   cond -> failT ["Can't solveSet " ++ show cond ++ " for variable " ++ show v1]
 
-solveSets :: V era (Set a) -> [Pred era] -> Typed (SetSpec era a)
+solveSets :: Era era => V era (Set a) -> [Pred era] -> Typed (SetSpec era a)
 solveSets v@(V nm (SetR _) _) cs =
   explain ("\nSolving for " ++ nm ++ ", Set Predicates\n" ++ unlines (map (("  " ++) . show) cs)) $
     foldlM' accum mempty cs
@@ -513,7 +513,7 @@ solveSets v@(V nm (SetR _) _) cs =
 -- ========================================================
 -- Solving for variables with an Adds instance
 
-solveSum :: Adds t => V era t -> Pred era -> Typed (AddsSpec t)
+solveSum :: forall era t. (Adds t, Era era) => V era t -> Pred era -> Typed (AddsSpec t)
 solveSum v1@(V nam r _) predx =
   case predx of
     (Sized expr (Var v2@(V nm _ _))) | Name v1 == Name v2 -> do
@@ -580,7 +580,7 @@ solveSum v1@(V nam r _) predx =
       pure (AddsSpecSize nm (SzExact (toI x)))
     other -> failT ["Can't solveSum " ++ show (Name v1) ++ " = " ++ show other]
 
-solveSums :: Adds t => V era t -> [Pred era] -> Typed (AddsSpec t)
+solveSums :: (Adds t, Era era) => V era t -> [Pred era] -> Typed (AddsSpec t)
 solveSums v@(V nm r _) cs =
   explain ("\nGiven (Add " ++ show r ++ "), Solving for " ++ nm ++ " :: " ++ show r ++ ",  with Predicates \n" ++ unlines (map (("  " ++) . show) cs)) $
     foldlM' accum mempty cs
@@ -591,7 +591,7 @@ solveSums v@(V nm r _) cs =
         ("Solving Sum constraint (" ++ show cond ++ ") for variable " ++ show nm)
         (liftT (spec <> sumVspec))
 
-summandAsInt :: Adds c => Sum era c -> Typed Int
+summandAsInt :: (Era era, Adds c) => Sum era c -> Typed Int
 summandAsInt (One (Lit _ x)) = pure (toI x)
 summandAsInt (One (Delta (Lit CoinR (Coin n)))) = pure (toI (DeltaCoin n))
 summandAsInt (One (Negate (Lit DeltaCoinR (DeltaCoin n)))) = pure (toI ((DeltaCoin (-n))))
@@ -601,23 +601,23 @@ summandAsInt (SumList (Lit _ m)) = pure (toI (List.foldl' add zero m))
 summandAsInt (ProjMap _ l (Lit _ m)) = pure (toI (List.foldl' (\ans x -> add ans (x ^. l)) zero m))
 summandAsInt x = failT ["Can't compute summandAsInt: " ++ show x ++ ", to an Int."]
 
-genSum :: Adds x => Sum era x -> Rep era x -> x -> Subst era -> Gen (Subst era)
+genSum :: (Era era, Adds x) => Sum era x -> Rep era x -> x -> Subst era -> Gen (Subst era)
 genSum (One (Var v)) rep x sub = pure $ extend v (Lit rep x) sub
 genSum (One (Delta (Var v))) DeltaCoinR d sub = pure $ extend v (Lit CoinR (fromI [] (toI d))) sub
 genSum (One (Negate (Var v))) DeltaCoinR (DeltaCoin n) sub = pure $ extend v (Lit DeltaCoinR (DeltaCoin (-n))) sub
 genSum other rep x _ = errorMess ("Can't genSum " ++ show other) [show rep, show x]
 
-summandsAsInt :: Adds c => [Sum era c] -> Typed Int
+summandsAsInt :: (Adds c, Era era) => [Sum era c] -> Typed Int
 summandsAsInt [] = pure 0
 summandsAsInt (x : xs) = do
   n <- summandAsInt x
   m <- summandsAsInt xs
   pure (m + n)
 
-sameV :: V era s -> V era t -> Typed (s :~: t)
+sameV :: Era era => V era s -> V era t -> Typed (s :~: t)
 sameV (V _ r1 _) (V _ r2 _) = sameRep r1 r2
 
-unique2 :: Adds c => V era t -> (Int, Bool, [Name era]) -> Sum era c -> Typed (Int, Bool, [Name era])
+unique2 :: (Adds c, Era era) => V era t -> (Int, Bool, [Name era]) -> Sum era c -> Typed (Int, Bool, [Name era])
 unique2 v1 (c, b, ns) (One (Var v2)) =
   if Name v1 == Name v2
     then pure (c, b, Name v2 : ns)
@@ -639,7 +639,7 @@ unique2 _ (c1, b, ns) sumexpr = do c2 <- summandAsInt sumexpr; pure (c1 + c2, b,
 -- | Check that there is exactly 1 occurence of 'v',
 --   and return the sum of the other terms in 'ss'
 --   which should all be constants.
-intSumWithUniqueV :: Adds c => V era t -> [Sum era c] -> Typed (Int, Bool)
+intSumWithUniqueV :: (Adds c, Era era) => V era t -> [Sum era c] -> Typed (Int, Bool)
 intSumWithUniqueV v@(V nam _ _) ss = do
   (c, b, ns) <- foldlM' (unique2 v) (0, False, []) ss
   case ns of
@@ -652,7 +652,7 @@ intSumWithUniqueV v@(V nam _ _) ss = do
 
 -- | Given a variable: 'v1', with a List type, compute a ListSpec
 --   which describes the constraints implied by the Pred 'predicate'
-solveList :: V era [a] -> Pred era -> Typed (ListSpec era a)
+solveList :: Era era => V era [a] -> Pred era -> Typed (ListSpec era a)
 solveList v1@(V _ (ListR r) _) predicate = case predicate of
   (Sized (Size sz) (Var v2)) | Name v1 == Name v2 -> pure $ ListSpec sz ElemAny
   (Var v2 :=: expr) | Name v1 == Name v2 -> do
@@ -667,7 +667,7 @@ solveList v1@(V _ (ListR r) _) predicate = case predicate of
     pure $ ListSpec (SzExact (length ys)) (ElemEqual r ys)
   cond -> failT ["Can't solveList " ++ show cond ++ " for variable " ++ show v1]
 
-solveLists :: V era [a] -> [Pred era] -> Typed (ListSpec era a)
+solveLists :: Era era => V era [a] -> [Pred era] -> Typed (ListSpec era a)
 solveLists v@(V nm (ListR _) _) cs =
   explain ("\nSolving for " ++ nm ++ ", List Predicates\n" ++ unlines (map (("  " ++) . show) cs)) $
     foldlM' accum mempty cs
@@ -722,7 +722,7 @@ update :: t -> [Update t] -> t
 update t [] = t
 update t (Update s l : more) = update (Lens.set l s t) more
 
-anyToUpdate :: Rep era t1 -> (AnyF era t2) -> Typed (Update t1)
+anyToUpdate :: Era era => Rep era t1 -> (AnyF era t2) -> Typed (Update t1)
 anyToUpdate rep1 (AnyF (FConst _ s rep2 l)) = do
   Refl <- sameRep rep1 rep2
   pure (Update s l)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -102,7 +102,8 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Universe (Eql, Shape (..), Shaped (..), Singleton (..), cmpIndex, (:~:) (Refl))
+import Data.Typeable
+import Data.Universe (Eql, Shape (..), Shaped (..), Singleton (..), cmpIndex)
 import Data.Word (Word16, Word64)
 import Formatting (formatToString)
 import Lens.Micro
@@ -148,7 +149,6 @@ import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 import Test.Cardano.Ledger.Generic.PrettyCore (
   credSummary,
   keyHashSummary,
-  pcAddr,
   pcCoin,
   pcConwayTxCert,
   pcDRep,
@@ -182,6 +182,9 @@ import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
 import Test.QuickCheck hiding (Fixed, total)
 
+data IsTypeable a where
+  IsTypeable :: Typeable a => IsTypeable a
+
 -- =======================================================================
 -- Special functions for dealing with SoftForks properties that
 -- depend upon the ProtVer. Whiach can be computed from a (Proof era)
@@ -203,6 +206,7 @@ data Rep era t where
   MapR :: Ord a => Rep era a -> Rep era b -> Rep era (Map a b)
   SetR :: Ord a => Rep era a -> Rep era (Set a)
   ListR :: Rep era a -> Rep era [a]
+  AddrR :: Rep era (Addr (EraCrypto era))
   CredR :: Rep era (Credential 'Staking (EraCrypto era))
   VCredR :: Rep era (Credential 'DRepRole (EraCrypto era))
   PoolHashR :: Rep era (KeyHash 'StakePool (EraCrypto era))
@@ -259,7 +263,6 @@ data Rep era t where
   ExUnitsR :: Rep era ExUnits
   TagR :: Rep era Tag
   DataHashR :: Rep era (DataHash (EraCrypto era))
-  AddrR :: Rep era (Addr (EraCrypto era))
   PCredR :: Rep era (Credential 'Payment (EraCrypto era))
   ShelleyTxCertR :: Rep era (ShelleyTxCert era)
   ConwayTxCertR :: Rep era (ConwayTxCert era)
@@ -294,128 +297,106 @@ stringR = ListR CharR
 -- ===========================================================
 -- Proof of Rep equality
 
-instance Singleton (Rep e) where
-  testEql RationalR RationalR = Just Refl
-  testEql CoinR CoinR = Just Refl
-  testEql EpochR EpochR = Just Refl
-  testEql (a :-> b) (x :-> y) = do
-    Refl <- testEql a x
-    Refl <- testEql b y
-    Just Refl
-  testEql (MapR a b) (MapR x y) = do
-    Refl <- testEql a x
-    Refl <- testEql b y
-    Just Refl
-  testEql (SetR a) (SetR b) = do
-    Refl <- testEql a b
-    Just Refl
-  testEql (ListR a) (ListR b) = do
-    Refl <- testEql a b
-    Just Refl
-  testEql CredR CredR = Just Refl
-  testEql VCredR VCredR = Just Refl
-  testEql PoolHashR PoolHashR = Just Refl
-  testEql WitHashR WitHashR = Just Refl
-  testEql GenHashR GenHashR = Just Refl
-  testEql GenDelegHashR GenDelegHashR = Just Refl
-  testEql VHashR VHashR = Just Refl
-  testEql PoolParamsR PoolParamsR = Just Refl
-  testEql NewEpochStateR NewEpochStateR = Just Refl
-  testEql IntR IntR = Just Refl
-  testEql FloatR FloatR = Just Refl
-  testEql NaturalR NaturalR = Just Refl
-  testEql Word64R Word64R = Just Refl
-  testEql TxInR TxInR = Just Refl
-  testEql CharR CharR = Just Refl
-  testEql UnitR UnitR = Just Refl
-  testEql (PairR a b) (PairR x y) = do
-    Refl <- testEql a x
-    Refl <- testEql b y
-    Just Refl
-  testEql (ProtVerR c) (ProtVerR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (ValueR c) (ValueR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (UTxOR p1) (UTxOR p2) = do
-    Refl <- testEql p1 p2
-    pure Refl
-  testEql (TxOutR c) (TxOutR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (PParamsR c) (PParamsR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (PParamsUpdateR c) (PParamsUpdateR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql DeltaCoinR DeltaCoinR = Just Refl
-  testEql GenDelegPairR GenDelegPairR = Just Refl
-  testEql FutureGenDelegR FutureGenDelegR = Just Refl
-  testEql (PPUPStateR c) (PPUPStateR d) = do Refl <- testEql c d; pure Refl
-  testEql PtrR PtrR = Just Refl
-  testEql IPoolStakeR IPoolStakeR = Just Refl
-  testEql SnapShotsR SnapShotsR = Just Refl
-  testEql RewardR RewardR = Just Refl
-  testEql (MaybeR c) (MaybeR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql SlotNoR SlotNoR = Just Refl
-  testEql SizeR SizeR = Just Refl
-  testEql (WitnessesFieldR c) (WitnessesFieldR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql MultiAssetR MultiAssetR = pure Refl
-  testEql PolicyIDR PolicyIDR = pure Refl
-  testEql AssetNameR AssetNameR = pure Refl
-  testEql (TxCertR c) (TxCertR d) = do Refl <- testEql c d; pure Refl
-  testEql ValidityIntervalR ValidityIntervalR = Just Refl
-  testEql RewardAcntR RewardAcntR = Just Refl
-  testEql KeyPairR KeyPairR = Just Refl
-  testEql (GenR x) (GenR y) = do Refl <- testEql x y; pure Refl
-  testEql (ScriptR c) (ScriptR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql ScriptHashR ScriptHashR = Just Refl
-  testEql NetworkR NetworkR = Just Refl
-  testEql RdmrPtrR RdmrPtrR = Just Refl
-  testEql DataR DataR = pure Refl
-  testEql DatumR DatumR = pure Refl
-  testEql ExUnitsR ExUnitsR = Just Refl
-  testEql TagR TagR = Just Refl
-  testEql DataHashR DataHashR = Just Refl
-  testEql AddrR AddrR = Just Refl
-  testEql PCredR PCredR = Just Refl
-  testEql ConwayTxCertR ConwayTxCertR = Just Refl
-  testEql ShelleyTxCertR ShelleyTxCertR = Just Refl
-  testEql MIRPotR MIRPotR = Just Refl
-  testEql IsValidR IsValidR = Just Refl
-  testEql IntegerR IntegerR = Just Refl
-  testEql (ScriptsNeededR c) (ScriptsNeededR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (ScriptPurposeR c) (ScriptPurposeR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (TxBodyR c) (TxBodyR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql BootstrapWitnessR BootstrapWitnessR = Just Refl
-  testEql SigningKeyR SigningKeyR = Just Refl
-  testEql (TxWitsR c) (TxWitsR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql PayHashR PayHashR = Just Refl
-  testEql (TxR c) (TxR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql ScriptIntegrityHashR ScriptIntegrityHashR = Just Refl
-  testEql AuxiliaryDataHashR AuxiliaryDataHashR = Just Refl
-  testEql GovActionR GovActionR = Just Refl
-  testEql (WitVKeyR c) (WitVKeyR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql (TxAuxDataR c) (TxAuxDataR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql CommColdCredR CommColdCredR = Just Refl
-  testEql CommHotCredR CommHotCredR = Just Refl
-  testEql LanguageR LanguageR = Just Refl
-  testEql (LedgerStateR c) (LedgerStateR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql StakeHashR StakeHashR = Just Refl
-  testEql BoolR BoolR = Just Refl
-  testEql DRepR DRepR = Just Refl
-  testEql (PoolMetadataR c) (PoolMetadataR d) =
-    do Refl <- testEql c d; pure Refl
-  testEql _ _ = Nothing
+repTypeable :: Era era => Rep era t -> IsTypeable t
+repTypeable r = case r of
+  DRepStateR -> IsTypeable
+  CommitteeStateR -> IsTypeable
+  CommColdCredR -> IsTypeable
+  CommHotCredR -> IsTypeable
+  GovActionR -> IsTypeable
+  PoolMetadataR {} -> IsTypeable
+  StakeHashR {} -> IsTypeable
+  BoolR {} -> IsTypeable
+  DRepR {} -> IsTypeable
+  WitVKeyR {} -> IsTypeable
+  TxAuxDataR {} -> IsTypeable
+  LanguageR {} -> IsTypeable
+  LedgerStateR {} -> IsTypeable
+  TxR {} -> IsTypeable
+  ScriptIntegrityHashR {} -> IsTypeable
+  AuxiliaryDataHashR {} -> IsTypeable
+  BootstrapWitnessR {} -> IsTypeable
+  SigningKeyR {} -> IsTypeable
+  TxWitsR {} -> IsTypeable
+  PayHashR {} -> IsTypeable
+  IntegerR {} -> IsTypeable
+  ScriptsNeededR {} -> IsTypeable
+  ScriptPurposeR {} -> IsTypeable
+  TxBodyR {} -> IsTypeable
+  ShelleyTxCertR {} -> IsTypeable
+  ConwayTxCertR {} -> IsTypeable
+  MIRPotR {} -> IsTypeable
+  IsValidR {} -> IsTypeable
+  ExUnitsR {} -> IsTypeable
+  TagR {} -> IsTypeable
+  DataHashR {} -> IsTypeable
+  PCredR {} -> IsTypeable
+  NetworkR {} -> IsTypeable
+  RdmrPtrR {} -> IsTypeable
+  DataR {} -> IsTypeable
+  DatumR {} -> IsTypeable
+  KeyPairR {} -> IsTypeable
+  ScriptR {} -> IsTypeable
+  ScriptHashR {} -> IsTypeable
+  TxCertR {} -> IsTypeable
+  RewardAcntR {} -> IsTypeable
+  ValidityIntervalR {} -> IsTypeable
+  AssetNameR {} -> IsTypeable
+  WitnessesFieldR {} -> IsTypeable
+  MultiAssetR {} -> IsTypeable
+  PolicyIDR {} -> IsTypeable
+  CharR {} -> IsTypeable
+  RationalR {} -> IsTypeable
+  CoinR {} -> IsTypeable
+  EpochR {} -> IsTypeable
+  AddrR {} -> IsTypeable
+  CredR {} -> IsTypeable
+  VCredR {} -> IsTypeable
+  PoolHashR {} -> IsTypeable
+  WitHashR {} -> IsTypeable
+  GenHashR {} -> IsTypeable
+  GenDelegHashR {} -> IsTypeable
+  VHashR {} -> IsTypeable
+  PoolParamsR {} -> IsTypeable
+  NewEpochStateR {} -> IsTypeable
+  IntR {} -> IsTypeable
+  FloatR {} -> IsTypeable
+  NaturalR {} -> IsTypeable
+  Word64R {} -> IsTypeable
+  TxInR {} -> IsTypeable
+  UnitR {} -> IsTypeable
+  ProtVerR {} -> IsTypeable
+  ValueR {} -> IsTypeable
+  UTxOR {} -> IsTypeable
+  TxOutR {} -> IsTypeable
+  PParamsR {} -> IsTypeable
+  PParamsUpdateR {} -> IsTypeable
+  DeltaCoinR {} -> IsTypeable
+  GenDelegPairR {} -> IsTypeable
+  FutureGenDelegR {} -> IsTypeable
+  PPUPStateR {} -> IsTypeable
+  PtrR {} -> IsTypeable
+  IPoolStakeR {} -> IsTypeable
+  SnapShotsR {} -> IsTypeable
+  RewardR {} -> IsTypeable
+  SlotNoR {} -> IsTypeable
+  SizeR {} -> IsTypeable
+  (repTypeable -> IsTypeable) :-> (repTypeable -> IsTypeable) -> IsTypeable
+  MapR
+    (repTypeable -> IsTypeable)
+    (repTypeable -> IsTypeable) -> IsTypeable
+  SetR (repTypeable -> IsTypeable) -> IsTypeable
+  ListR (repTypeable -> IsTypeable) -> IsTypeable
+  PairR
+    (repTypeable -> IsTypeable)
+    (repTypeable -> IsTypeable) -> IsTypeable
+  MaybeR (repTypeable -> IsTypeable) -> IsTypeable
+  GenR (repTypeable -> IsTypeable) -> IsTypeable
 
+instance Era era => Singleton (Rep era) where
+  testEql
+    (repTypeable -> IsTypeable :: IsTypeable a)
+    (repTypeable -> IsTypeable :: IsTypeable b) = eqT @a @b
   cmpIndex x y = compare (shape x) (shape y)
 
 -- ============================================================
@@ -427,6 +408,7 @@ instance Show (Rep era t) where
   show (MapR a b) = "(Map " ++ show a ++ " " ++ show b ++ ")"
   show (SetR a) = "(Set " ++ show a ++ ")"
   show (ListR a) = "[" ++ show a ++ "]"
+  show AddrR = "Addr"
   show CredR = "(Credential 'Staking c)"
   show PoolHashR = "(KeyHash 'StakePool c)"
   show WitHashR = "(KeyHash 'Witness c)"
@@ -481,7 +463,6 @@ instance Show (Rep era t) where
   show ExUnitsR = "ExUnits"
   show TagR = "Tag"
   show DataHashR = "(DataHash c)"
-  show AddrR = "(Addr c)"
   show PCredR = "(Credential 'Payment c)"
   show ConwayTxCertR = "(ConwayTxCert era)"
   show ShelleyTxCertR = "(ShelleyTxCert era)"
@@ -531,6 +512,7 @@ synopsis (ListR Word64R) x = show x
 synopsis rep@(ListR a) ll = case ll of
   [] -> "(empty::" ++ show (ListR a) ++ "]"
   (d : _) -> "[" ++ synopsis a d ++ " | size = " ++ show (length ll) ++ synSum rep ll ++ "]"
+synopsis AddrR a = show a
 synopsis CredR c = show (credSummary c)
 synopsis PoolHashR k = "(KeyHash 'PoolStake " ++ show (keyHashSummary k) ++ ")"
 synopsis GenHashR k = "(KeyHash 'Genesis " ++ show (keyHashSummary k) ++ ")"
@@ -583,7 +565,6 @@ synopsis DatumR x = show (pcDatum x)
 synopsis ExUnitsR (ExUnits m d) = "(ExUnits mem=" ++ show m ++ " data=" ++ show d ++ ")"
 synopsis TagR x = show x
 synopsis DataHashR x = show (pcDataHash x)
-synopsis AddrR x = show (pcAddr x)
 synopsis PCredR c = show (credSummary c)
 synopsis ConwayTxCertR x = show (pcConwayTxCert x)
 synopsis ShelleyTxCertR x = show (pcShelleyTxCert x)
@@ -735,7 +716,7 @@ instance Shaped (Rep era) any where
   shape DRepStateR = Nullary 87
   shape CommitteeStateR = Nullary 87
 
-compareRep :: forall era t s. Rep era t -> Rep era s -> Ordering
+compareRep :: forall era t s. Era era => Rep era t -> Rep era s -> Ordering
 compareRep = cmpIndex @(Rep era)
 
 -- ================================================
@@ -754,8 +735,9 @@ genSizedRep n (_a :-> b) = const <$> genSizedRep n b
 genSizedRep n r@(MapR a b) = do
   mapSized ["From genSizedRep " ++ show r] n (genRep a) (genRep b)
 genSizedRep n r@(SetR a) = do
-  setSized ["From genSizedRep " ++ show r] n (genRep a)
-genSizedRep n (ListR a) = vectorOf n (genRep a)
+  setSized ["From genSizedRep " ++ show r] n (genSizedRep n a)
+genSizedRep n (ListR a) = vectorOf n (genSizedRep n a)
+genSizedRep _ AddrR = arbitrary
 genSizedRep _ CredR = arbitrary
 genSizedRep _ PoolHashR = arbitrary
 genSizedRep _ WitHashR = arbitrary
@@ -820,7 +802,6 @@ genSizedRep n DatumR =
 genSizedRep _ ExUnitsR = arbitrary
 genSizedRep _ TagR = arbitrary
 genSizedRep _ DataHashR = arbitrary
-genSizedRep _ AddrR = arbitrary
 genSizedRep _ PCredR = arbitrary
 genSizedRep _ ShelleyTxCertR = arbitrary
 genSizedRep _ ConwayTxCertR = arbitrary

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -122,7 +122,7 @@ import qualified Test.Cardano.Ledger.Shelley.Utils as Utils (testGlobals)
 -- Where fooPart1 :: Term era a, and fooPart2 :: Term era b
 -- And fooPart1 has an (Access foo a)
 -- And fooPart2 has an (Access foo b)
-field :: Rep era s -> Term era t -> AnyF era s
+field :: Era era => Rep era s -> Term era t -> AnyF era s
 field repS1 (Var (V name rept (Yes repS2 l))) = case testEql repS1 repS2 of
   Just Refl -> AnyF (Field name rept repS2 l)
   Nothing ->


### PR DESCRIPTION
# Description

Everything is `Typeable` so we can use that to reduce some clutter.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
