### PR TITLE
Add comments on deprecating certs to Conway CDDL

### DIFF
--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -286,8 +286,8 @@ certificate =
   // update_drep_cert
   ]
 
-stake_registration = (0, stake_credential)
-stake_deregistration = (1, stake_credential)
+stake_registration = (0, stake_credential) ; to be deprecated in era after Conway
+stake_deregistration = (1, stake_credential) ; to be deprecated in era after Conway
 stake_delegation = (2, stake_credential, pool_keyhash)
 
 ; POOL


### PR DESCRIPTION
# Description

- Added Comment to Conway CDDL, that articulates that `stake_registration` and `stake_deregistration` are to deprecated in the era past Conway.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
