### PR TITLE
Add many new features to the Constrained modues in cardano-ledger-test

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -546,8 +546,7 @@ validateValueNotConservedUTxO ::
   TxBody era ->
   Test (ShelleyUtxoPredFailure era)
 validateValueNotConservedUTxO pp utxo dpstate txb =
-  failureUnless (consumedValue == producedValue) $
-    (ValueNotConservedUTxO consumedValue producedValue)
+  failureUnless (consumedValue == producedValue) $ ValueNotConservedUTxO consumedValue producedValue
   where
     consumedValue = consumed pp dpstate utxo txb
     producedValue = produced pp dpstate txb

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,8 @@
           # specific enough, or doesn't allow setting these.
           modules = [
             ({pkgs, ...}: {
+              # packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
+              # uncomment when profiling
               packages.byron-spec-chain.configureFlags = ["--ghc-option=-Werror"];
               packages.byron-spec-ledger.configureFlags = ["--ghc-option=-Werror"];
               packages.delegation.configureFlags = ["--ghc-option=-Werror"];

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -26,6 +26,7 @@ library
         Test.Cardano.Ledger.Constrained.Lenses
         Test.Cardano.Ledger.Constrained.Monad
         Test.Cardano.Ledger.Constrained.Pairing
+        Test.Cardano.Ledger.Constrained.Stage
         Test.Cardano.Ledger.Constrained.Preds.PParams
         Test.Cardano.Ledger.Constrained.Preds.Universes
         Test.Cardano.Ledger.Constrained.Preds.TxOut
@@ -34,6 +35,11 @@ library
         Test.Cardano.Ledger.Constrained.Preds.Repl
         Test.Cardano.Ledger.Constrained.Preds.Certs
         Test.Cardano.Ledger.Constrained.Preds.LedgerState
+        Test.Cardano.Ledger.Constrained.Trace.TraceMonad
+        Test.Cardano.Ledger.Constrained.Trace.SimpleTx
+        Test.Cardano.Ledger.Constrained.Trace.Actions
+        Test.Cardano.Ledger.Constrained.Trace.Pipeline
+        Test.Cardano.Ledger.Constrained.Trace.Tests
         Test.Cardano.Ledger.Constrained.Spec
         Test.Cardano.Ledger.Constrained.SpecClass
         Test.Cardano.Ledger.Constrained.Tests
@@ -110,6 +116,7 @@ library
         formatting,
         groups,
         haskeline,
+        hashable,
         vector-map,
         data-default-class,
         microlens,
@@ -130,6 +137,7 @@ library
         text,
         time,
         transformers,
+        unordered-containers,
         vector
 
 test-suite cardano-ledger-test

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Provides variables (V era t), and mappings of them to objects of type 't'
 module Test.Cardano.Ledger.Constrained.Env (
-  V (..),
+  V (V, VRaw),
+  pV,
   Field (..),
   AnyF (..),
   vToField,
@@ -29,52 +32,77 @@ module Test.Cardano.Ledger.Constrained.Env (
 ) where
 
 import Cardano.Ledger.Era (Era)
+import Data.Hashable
 import Data.List (intercalate)
 import qualified Data.List as List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
 import Data.Universe (Shaped (..))
 import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Monad (Typed (..), failT)
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Generic.Proof (BabbageEra, ConwayEra, StandardCrypto)
 
 -- ================================================================
 -- V
 
 -- | A proto variable. May or may not contain a Lens (encoded as Access)
 data V era t where
-  V :: String -> Rep era t -> Access era s t -> V era t
+  VRaw :: Era era => String -> Rep era t -> Int -> Access era s t -> V era t
 
 data Access era s t where
   Yes :: Rep era s -> Lens' s t -> Access era s t
   No :: Access era s t
 
 instance Show (V era t) where
-  show (V nm rep _) = nm ++ " :: " ++ show rep
+  show (VRaw nm rep _ _) = nm ++ " :: " ++ show rep
+
+-- | We make hashing of 'V' cheap by memoizing most of the hash computation in in the
+--   3rd argument of 'VRaw', we provide this pattern to hide this from every other use.
+pattern V :: () => Era era => String -> Rep era t -> Access era s t -> V era t
+pattern V s r a <- VRaw s r _ a
+  where
+    V s r a = VRaw s r (0 `hashWithSalt` s `hashWithSalt` r) a
+
+-- | Construct a V, dsicharging the (Era era) constraint, using the Proof
+pV :: Proof era -> String -> Rep era t -> Access era s t -> V era t
+pV (Shelley _) = V
+pV (Allegra _) = V
+pV (Mary _) = V
+pV (Alonzo _) = V
+pV (Babbage _) = V
+pV (Conway _) = V
+
+{-# COMPLETE V #-}
 
 -- ===========================================================
 -- Name
 
 -- | An existentially quantified (V era t), hiding the 't'
---   Usefull because unlike (V era t), it has both Eq and Ord instances
+--   The Hashable instance is inherited from 'V'
 data Name era where
   Name :: V era t -> Name era
 
 instance Show (Name era) where
-  show (Name (V n _ _)) = n
+  show (Name (VRaw n _ _ _)) = n
 
 -- | Does not satisfy extensionality
-instance Era era => Eq (Name era) where
-  Name (V n1 rep1 _) == Name (V n2 rep2 _) = n1 == n2 && isJust (testEql rep1 rep2)
+instance Eq (Name era) where
+  Name (V n1 rep1 _) == Name (V n2 rep2 _) = case testEql rep1 rep2 of
+    Nothing -> False
+    Just Refl -> n1 == n2
+  {-# INLINE (==) #-}
 
-instance Era era => Ord (Name era) where
-  compare v1@(Name (V n1 rep1 _)) v2@(Name (V n2 rep2 _)) =
-    if v1 == v2
-      then EQ
-      else compare n1 n2 <> compareRep rep1 rep2
+instance Ord (Name era) where
+  {-# SPECIALIZE instance Ord (Name (BabbageEra StandardCrypto)) #-}
+  {-# SPECIALIZE instance Ord (Name (ConwayEra StandardCrypto)) #-}
+  compare (Name (V n1 rep1 _)) (Name (V n2 rep2 _)) =
+    case compare n1 n2 of
+      EQ -> compareRep rep1 rep2
+      other -> other
+  {-# INLINE compare #-}
 
-sameName :: Era era => V era t -> V era s -> Maybe (t :~: s)
+sameName :: V era t -> V era s -> Maybe (t :~: s)
 sameName (V x r1 _) (V y r2 _) | x == y = testEql r1 r2
 sameName _ _ = Nothing
 
@@ -83,7 +111,7 @@ sameName _ _ = Nothing
 
 -- | Fields are like V, except they expose the type of the Lens
 data Field era s t where
-  Field :: String -> Rep era t -> Rep era s -> Lens' s t -> Field era s t
+  Field :: Era era => String -> Rep era t -> Rep era s -> Lens' s t -> Field era s t
   FConst :: Rep era t -> t -> Rep era s -> Lens' s t -> Field era s t
 
 -- SubField :: String -> Rep era t -> Access era s t -> Field era t r -> Field era s t
@@ -112,7 +140,7 @@ vToField reps (V name rept (Yes reps' l)) = case testEql reps reps' of
       ]
 vToField _ v@(V _ _ No) = failT ["Cannot convert a V with a No access to a Field", show v]
 
-fieldToV :: Field era s t -> Typed (V era t)
+fieldToV :: Era era => Field era s t -> Typed (V era t)
 fieldToV (Field name rep repx l) = pure $ V name rep (Yes repx l)
 fieldToV (FConst _ _ _ _) = failT ["Cannot convert a FieldConst to a V"]
 
@@ -137,7 +165,7 @@ instance Show (Env era) where
 emptyEnv :: Env era
 emptyEnv = Env Map.empty
 
-findVar :: Era era => V era t -> Env era -> Typed t
+findVar :: V era t -> Env era -> Typed t
 findVar (V name rep1 _) (Env m) =
   case Map.lookup name m of
     Nothing -> failT ["Cannot find " ++ name ++ " in env"]
@@ -181,4 +209,55 @@ bulkStore ps env = List.foldl' accum env ps
   where
     accum e (P v t) = storeVar v t e
 
--- ===================================
+-- ==========================================================================
+--  Hashable instances so we can make HashSets of Name
+--  Something like 60% of all time consumed involves manipulating sets of Name
+--  If the set is Data.Set, then we need instance Ord (Name era). This is very expensive
+--  So instead we use Data.HashSet where we need instance Hashable(Name era). We can
+--  make this very cheap by memoizing most of the hash computation in 'V' in the
+--  constructor 'VRaw' and hiding 'VRaw' with pattern 'V'
+
+-- | Inheriting the Hashable instancefor types that have Shapes, Works for types whose
+--   Shaped instances don't mention 'Esc', Like Evidence, Proof, Rep
+--   But we CANNOT use this strategy for (V era t)  since its's Shape instance use Esc
+instance Hashable (Shape a) where
+  hashWithSalt s (Nullary n) = s `hashWithSalt` (0 :: Int) `hashWithSalt` n
+  hashWithSalt s (Nary n xs) = s `hashWithSalt` (1 :: Int) `hashWithSalt` n `hashWithSalt` xs
+  hashWithSalt s (Esc _ _) = s `hashWithSalt` (2 :: Int)
+  {-# INLINE hashWithSalt #-}
+
+instance Hashable (Evidence c) where
+  hashWithSalt s x = s `hashWithSalt` (shape x)
+  {-# INLINE hashWithSalt #-}
+
+instance Eq (Evidence c) where
+  x == y = shape x == shape y
+  {-# INLINE (==) #-}
+
+instance Hashable (Proof e) where
+  hashWithSalt s x = s `hashWithSalt` (shape x)
+  {-# INLINE hashWithSalt #-}
+
+instance Eq (Proof e) where
+  x == y = shape x == shape y
+  {-# INLINE (==) #-}
+
+instance Hashable (Rep e t) where
+  hashWithSalt s x = s `hashWithSalt` (shape x)
+  {-# INLINE hashWithSalt #-}
+
+instance Eq (Rep e t) where
+  x == y = shape x == shape y
+  {-# INLINE (==) #-}
+
+instance Hashable (V era t) where
+  hashWithSalt s (VRaw _ _ h _) = s `hashWithSalt` h
+  {-# INLINE hashWithSalt #-}
+
+instance Eq (V era t) where
+  (V n1 r1 _) == (V n2 r2 _) = n1 == n2 && r1 == r2
+  {-# INLINE (==) #-}
+
+instance Era era => Hashable (Name era) where
+  hashWithSalt s (Name (VRaw _ _ h _)) = s `hashWithSalt` h
+  {-# INLINE hashWithSalt #-}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 
--- | Define Lenses that facilitate accessing the types in the Var Model
+-- | Define Lenses that facilitate accessing the types in the Var Model.
+--   Note the types in the Model, are often wrapped in a newtype in the real state,
+--   or they are embedded in something like UMap to save space. So we need interesting
+--   Lenses to make this possible.
 --   Many other (more standard) Lenses are defined in Cardano.Ledger.Shelley.LedgerState
 module Test.Cardano.Ledger.Constrained.Lenses where
 
@@ -30,8 +33,6 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (fromList)
 import Data.Set (Set)
 import Lens.Micro
-
--- import Numeric.Natural (Natural)
 
 -- ====================================================
 -- Lenses

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -4,57 +4,73 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-unused-binds #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Test.Cardano.Ledger.Constrained.Preds.LedgerState where
 
 import Cardano.Ledger.Coin (Coin (..))
-import Data.Map.Strict (Map)
+import Control.Monad (when)
+import Data.Default.Class (Default (def))
 import Data.Map.Strict as Map
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (checkForSoundness)
-import Test.Cardano.Ledger.Constrained.Monad (Typed, failT, monadTyped)
+import Test.Cardano.Ledger.Constrained.Examples (testIO)
+import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
-import Test.Cardano.Ledger.Constrained.Preds.Repl (goRepl)
-import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
+import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (UnivSize (..), universeStage)
 import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Size (Size (..))
 import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
 import Test.Cardano.Ledger.Constrained.Vars
-import Test.Cardano.Ledger.Generic.PrettyCore (pcLedgerState, pcUTxOState)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcLedgerState)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.QuickCheck
+import Test.Tasty (TestTree, defaultMain)
 
 -- =========================================
 
-ledgerStatePreds :: forall era. Reflect era => Proof era -> [Pred era]
-ledgerStatePreds p =
-  [ MetaSize (SzRng 20 25) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
+ledgerStatePreds :: forall era. Reflect era => UnivSize -> Proof era -> [Pred era]
+ledgerStatePreds usize p =
+  [ -- Conway GovState Vars
+    Random previousGovSnapshots
+  , Random previousDRepsState
+  , Random previousCommitteeState
+  , Random enactWithdrawals
+  , Random enactTreasury
+  , Random currentGovSnapshots
+  , Random constitution
+  , Random committeeVar
+  , Random prevPParamUpdate
+  , Random prevHardFork
+  , Random prevConstitution
+  , Random prevCommittee
+  , MetaSize (SzRng 90 (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
   , Sized utxoSize preUtxo
-  , Sized (Range 14 16) colUtxo
+  , Sized (Range 15 (usNumColUtxo usize)) colUtxo
   , MapMember feeTxIn feeTxOut (Right preUtxo)
-  , Subset (Dom preUtxo) txinUniv
+  , -- , Before feeTxIn colUtxo
+    Subset (Dom preUtxo) txinUniv
   , Subset (Rng preUtxo) (txoutUniv p)
   , utxo p :<-: (Constr "mapunion" Map.union ^$ preUtxo ^$ colUtxo)
-  , --
-    Disjoint (Dom colUtxo) (Dom preUtxo)
+  , Disjoint (Dom preUtxo) (Dom colUtxo)
   , Subset (Dom colUtxo) txinUniv
   , Subset (Rng colUtxo) (colTxoutUniv p)
   , NotMember feeTxIn (Dom colUtxo)
   , NotMember feeTxOut (Rng colUtxo)
-  , --
-    SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits]
-  , -- , SumsTo (Right (Coin 1)) utxoCoin EQL [ProjMap CoinR outputCoinL (utxo p)]
+  , SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits]
+  , -- Some things we might want in the future.
+    -- , SumsTo (Right (Coin 1)) utxoCoin EQL [ProjMap CoinR outputCoinL (utxo p)]
     -- , SumsTo (Right (Coin 1)) totalAda EQL [One utxoCoin, One treasury, One reserves, One fees, One deposits, SumMap rewards]
     Random fees
   , Random (proposalsT p)
   , Random (futureProposalsT p)
   , ledgerState :<-: (ledgerStateT p)
+  , Sized (Range 1 10) donation
+  , prevPParams p :<-: (Constr "id" id ^$ (pparams p))
+  , currPParams p :<-: (Constr "id" id ^$ (pparams p))
   ]
   where
     colUtxo = Var (V "colUtxo" (MapR TxInR (TxOutR p)) No)
@@ -63,19 +79,20 @@ ledgerStatePreds p =
 
 ledgerStateStage ::
   Reflect era =>
+  UnivSize ->
   Proof era ->
   Subst era ->
   Gen (Subst era)
-ledgerStateStage proof subst0 = do
-  let preds = ledgerStatePreds proof
+ledgerStateStage usize proof subst0 = do
+  let preds = ledgerStatePreds usize proof
   subst <- toolChainSub proof standardOrderInfo preds subst0
   (_env, status) <- pure (undefined, Nothing) -- monadTyped $ checkForSoundness preds subst
   case status of
     Nothing -> pure subst
     Just msg -> error msg
 
-main :: IO ()
-main = do
+demo :: ReplMode -> IO ()
+demo mode = do
   let proof = Conway Standard
   -- Babbage Standard
   -- Alonzo Standard
@@ -85,13 +102,19 @@ main = do
     generate
       ( pure emptySubst
           >>= pParamsStage proof
-          >>= universeStage proof
+          >>= universeStage def proof
           >>= vstateStage proof
           >>= pstateStage proof
           >>= dstateStage proof
-          >>= ledgerStateStage proof
+          >>= ledgerStateStage def proof
           >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
       )
   lstate <- monadTyped $ runTarget env (ledgerStateT proof)
-  putStrLn (show (pcLedgerState proof lstate))
-  goRepl proof env ""
+  when (mode == Interactive) $ putStrLn (show (pcLedgerState proof lstate))
+  modeRepl mode proof env ""
+
+demoTest :: TestTree
+demoTest = testIO "Testing LedgerState Stage" (demo CI)
+
+main :: IO ()
+main = defaultMain $ testIO "Testing LedgerState Stage" (demo Interactive)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Repl.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Repl.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Cardano.Ledger.Constrained.Preds.Repl where
+module Test.Cardano.Ledger.Constrained.Preds.Repl (goRepl, repl, ReplMode (..), modeRepl) where
 
 import Data.Char (toLower)
 import qualified Data.List as List
@@ -59,3 +59,14 @@ helpRepl proof env@(Env emap) more = do
   outputStrLn (seps matches)
   outputStrLn ""
   loop proof env
+
+-- ========================================
+
+data ReplMode = Interactive | CI
+  deriving (Eq)
+
+modeRepl :: ReplMode -> Proof era -> Env era -> String -> IO ()
+modeRepl Interactive p e s = goRepl p e s
+modeRepl CI _ (Env emap) _ = do
+  let keys = Set.toList (Map.keysSet emap)
+  putStrLn (seps keys)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Shrink.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Shrink.hs
@@ -68,8 +68,8 @@ fixupVar :: Era era => Name era -> [Pred era] -> Payload era -> Maybe (Payload e
 fixupVar v cs p = listToMaybe [p' | p' <- [p | validAssignment v p cs] ++ reverse (shrinkVar v cs p)]
 
 -- | Assumes the variable is the only free variable in the constraints.
-validAssignment :: Era era => Name era -> Payload era -> [Pred era] -> Bool
+validAssignment :: Name era -> Payload era -> [Pred era] -> Bool
 validAssignment v p cs = all (runPred_ $ storeName v p emptyEnv) cs
 
-runPred_ :: Era era => Env era -> Pred era -> Bool
+runPred_ :: Env era -> Pred era -> Bool
 runPred_ env p = either (const False) id $ runTyped $ runPred env p

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/SpecClass.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/SpecClass.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+-- | Code which defines a class that encapsulates what it means to be a Spec
+--   Eventually this will repace the most of the tests in Spec.hs
 module Test.Cardano.Ledger.Constrained.SpecClass where
 
 import Cardano.Ledger.Coin (Coin, DeltaCoin)
@@ -70,6 +72,8 @@ import Test.Tasty.QuickCheck (testProperty)
 -- import Lens.Micro (Lens')
 
 {-
+-- NOtes about current functions and their types for each Spec. This helps
+-- design what the SpecClass should provide.
 class (Monoid spec, LiftT spec) => Specification spec t | spec -> t where
   type Count :: Type -> Type
   -- type Count Size = ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Stage.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Stage.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Constrained.Stage where
+
+import Cardano.Ledger.Core (Era (..))
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import qualified Data.Map.Strict as Map
+import Data.Pulse (foldlM')
+import Test.Cardano.Ledger.Constrained.Ast
+import Test.Cardano.Ledger.Constrained.Env (Env, Name, emptyEnv)
+import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
+import Test.Cardano.Ledger.Constrained.Preds.CertState (certStatePreds, pstatePreds, vstatePreds)
+import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStatePreds)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsPreds)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (UnivSize (..), universePreds)
+import Test.Cardano.Ledger.Constrained.Rewrite (
+  DependGraph (..),
+  OrderInfo,
+  initialOrder,
+  mkDependGraph,
+  notBefore,
+  rewriteGen,
+  standardOrderInfo,
+ )
+import Test.Cardano.Ledger.Constrained.Solver (solveOneVar)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.QuickCheck
+
+-- ====================================
+
+-- | Group together some Preds and OrderInfo about how to decide the
+--   order in which to solve the variables appearing in the Preds
+data Stage era = Stage OrderInfo [Pred era]
+
+type Pipeline era = [Stage era]
+
+-- | A pipeline for specifying the LederState
+ledgerPipeline :: Reflect era => UnivSize -> Proof era -> Pipeline era
+ledgerPipeline sizes proof =
+  [ Stage standardOrderInfo (pParamsPreds proof)
+  , Stage standardOrderInfo (universePreds sizes proof)
+  , Stage standardOrderInfo (vstatePreds proof)
+  , Stage standardOrderInfo (pstatePreds proof)
+  , Stage standardOrderInfo (certStatePreds proof)
+  , Stage standardOrderInfo (ledgerStatePreds sizes proof)
+  ]
+
+-- | Translate a Stage into a DependGraph, given the set
+--   of variables that have aready been solved for.
+stageToGraph :: Era era => Int -> Stage era -> HashSet (Name era) -> Gen (Int, DependGraph era)
+stageToGraph n0 (Stage info ps) alreadyDefined = do
+  (n1, simple) <- rewriteGen (n0, ps)
+  orderedNames <- monadTyped $ initialOrder info simple
+  graph <-
+    monadTyped $
+      mkDependGraph
+        (length orderedNames)
+        []
+        alreadyDefined
+        orderedNames
+        []
+        (Prelude.filter notBefore simple)
+  pure (n1, graph)
+
+-- | Merge a Pipeline into an existing DependGraph, given the set of variables
+--   that have aready been solved for, to get a larger DependGraph
+mergePipeline :: Era era => Int -> Pipeline era -> HashSet (Name era) -> DependGraph era -> Gen (Int, DependGraph era)
+mergePipeline n [] _ graph = pure (n, graph)
+mergePipeline n0 (pipe : more) defined (DependGraph xs) = do
+  (n1, DependGraph ys) <- stageToGraph n0 pipe defined
+  let names = concat (map fst ys)
+  mergePipeline n1 more (HashSet.union (HashSet.fromList names) defined) (DependGraph (xs ++ ys))
+
+-- | Solve a Pipeline to get a Env, Subst, and a DependGraph
+solvePipeline :: Reflect era => Pipeline era -> Gen (Env era, Subst era, DependGraph era)
+solvePipeline pipes = do
+  (_, gr@(DependGraph pairs)) <- mergePipeline 0 pipes HashSet.empty (DependGraph [])
+  Subst subst <- foldlM' solveOneVar emptySubst pairs
+  let isTempV k = not (elem '.' k)
+  let sub = Subst (Map.filterWithKey (\k _ -> isTempV k) subst)
+  env <- monadTyped (substToEnv sub emptyEnv)
+  pure (env, sub, gr)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
@@ -1,0 +1,29 @@
+module Test.Cardano.Ledger.Constrained.Trace.Actions where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (Era (..), TxBody)
+import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
+import Cardano.Ledger.Val (Val (..))
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import Test.Cardano.Ledger.Constrained.Classes (TxOutF (..))
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (TraceM, updateVar)
+import Test.Cardano.Ledger.Constrained.Vars (fees, utxo)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+
+-- ====================================================================
+-- Some experiments with updating the state (Stored in the Env)
+-- Used as a means to track what applySTS does.
+
+inputsAction :: Proof era -> Set (TxIn (EraCrypto era)) -> TraceM era ()
+inputsAction proof is = updateVar (utxo proof) (\u -> Map.withoutKeys u is)
+
+outputsAction :: Reflect era => Proof era -> TxBody era -> [TxOutF era] -> TraceM era ()
+outputsAction proof txb outs = updateVar (utxo proof) (\u -> Map.union u (makemap outs))
+  where
+    makemap outPuts = Map.fromList (fmap (\(out, n) -> (mkTxInPartial txid n, out)) (zip outPuts [0 ..]))
+    txid = TxId (hashAnnotated txb)
+
+feesAction :: Era era => Coin -> TraceM era ()
+feesAction feeCoin = updateVar fees (<+> feeCoin)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
@@ -1,0 +1,223 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Constrained.Trace.Pipeline where
+
+import Cardano.Ledger.BaseTypes (Globals)
+import Cardano.Ledger.Core (Era, EraRule, Tx)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState)
+import Cardano.Ledger.Shelley.Rules
+import Control.Monad.Reader (Reader, runReader)
+import Control.State.Transition.Extended (
+  BaseM,
+  RuleType (Transition),
+  STS (..),
+  TRC (..),
+  applySTS,
+ )
+import Data.Default.Class (Default (def))
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import qualified Data.Map.Strict as Map
+import Data.Pulse (foldlM')
+import GHC.TypeLits (Symbol)
+import Test.Cardano.Ledger.Constrained.Ast
+import Test.Cardano.Ledger.Constrained.Classes (TxF (..))
+import Test.Cardano.Ledger.Constrained.Env (Env, Name, emptyEnv, findVar)
+import Test.Cardano.Ledger.Constrained.Examples (Babbage)
+import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
+import Test.Cardano.Ledger.Constrained.Preds.Repl (goRepl)
+import Test.Cardano.Ledger.Constrained.Preds.Tx (adjustColInput, adjustFeeInput, txBodyPreds)
+import Test.Cardano.Ledger.Constrained.Rewrite (
+  DependGraph (..),
+  initialOrder,
+  mkDependGraph,
+  notBefore,
+  rewriteGen,
+  standardOrderInfo,
+ )
+import Test.Cardano.Ledger.Constrained.Solver (solveOneVar)
+import Test.Cardano.Ledger.Constrained.Stage (Pipeline, Stage (..), ledgerPipeline, solvePipeline)
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.Proof hiding (WitRule (..), lift)
+import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
+import Test.QuickCheck
+
+-- =============================================
+
+data Rule (i :: Symbol) where
+  DELEG :: Rule "DELEG"
+  DELEGS :: Rule "DELEGS"
+  DELPL :: Rule "DELPL"
+  EPOCH :: Rule "EPOCH"
+  LEDGER :: Rule "LEDGER"
+  LEDGERS :: Rule "LEDGERS"
+  MIR :: Rule "MIR"
+  NEWEPOCH :: Rule "NEWSPOCH"
+  NEWPP :: Rule "NEWPP"
+  POOL :: Rule "POOL"
+  POOLREAP :: Rule "POOLREAP"
+  PPUP :: Rule "PPUP"
+  RUPD :: Rule "RUPD"
+  SNAP :: Rule "SNAP"
+  TICK :: Rule "TICK"
+  TICKF :: Rule "TICKF"
+  UPEC :: Rule "UPEC"
+  UTXO :: Rule "UTXO"
+  UTXOW :: Rule "UTXOW"
+  GOVCERT :: Rule "GOVCERT"
+  GOV :: Rule "GOV"
+
+trc ::
+  Proof era ->
+  Rule tag ->
+  Environment (EraRule tag era) ->
+  State (EraRule tag era) ->
+  Signal (EraRule tag era) ->
+  TRC (EraRule tag era)
+trc _proof _rule env state sig = TRC (env, state, sig)
+
+sts ::
+  forall era tag.
+  ( BaseM (EraRule tag era) ~ Reader Globals
+  , STS (EraRule tag era)
+  ) =>
+  Proof era ->
+  Rule tag ->
+  Environment (EraRule tag era) ->
+  State (EraRule tag era) ->
+  Signal (EraRule tag era) ->
+  Either [PredicateFailure (EraRule tag era)] (State (EraRule tag era))
+sts proof rule env state sig =
+  runReader
+    ( applySTS @(EraRule tag era) @(Reader _) @'Transition
+        (trc proof rule env state sig)
+    )
+    testGlobals
+
+stsWithContinuations ::
+  forall era tag ans.
+  ( BaseM (EraRule tag era) ~ Reader Globals
+  , STS (EraRule tag era)
+  ) =>
+  Proof era ->
+  Rule tag ->
+  ([PredicateFailure (EraRule tag era)] -> ans) ->
+  (State (EraRule tag era) -> ans) ->
+  Environment (EraRule tag era) ->
+  State (EraRule tag era) ->
+  Signal (EraRule tag era) ->
+  ans
+stsWithContinuations proof rule fails succeeds env state sig =
+  case sts proof rule env state sig of
+    Left xs -> fails xs
+    Right x -> succeeds x
+
+-- ====================================
+
+-- | Translate a Pipe into a DependGraph, given the set
+--   of variables that have aready been solved for.
+pipeToGraph :: Era era => Stage era -> HashSet (Name era) -> TraceM era (DependGraph era)
+pipeToGraph (Stage info ps) alreadyDefined = do
+  simple <- liftCounter rewriteGen ps
+  orderedNames <- liftTyped $ initialOrder info simple
+  liftTyped $ mkDependGraph (length orderedNames) [] alreadyDefined orderedNames [] (Prelude.filter notBefore simple)
+
+-- | Merge a Pipeline into an existing DependGraph, given the set of variables
+--   that have aready been solved for, to get a larger DependGraph
+mergePipeline :: Era era => Pipeline era -> HashSet (Name era) -> DependGraph era -> TraceM era (DependGraph era)
+mergePipeline [] _ graph = pure graph
+mergePipeline (pipe : more) defined (DependGraph xs) = do
+  DependGraph ys <- pipeToGraph pipe defined
+  let names = concatMap fst ys
+  mergePipeline more (HashSet.union (HashSet.fromList names) defined) (DependGraph (xs ++ ys))
+
+-- | Solve a Pipeline to get both an Env and a DependGraph
+solvePipeline2 :: Reflect era => Pipeline era -> TraceM era (Env era, DependGraph era)
+solvePipeline2 pipes = do
+  gr@(DependGraph pairs) <- mergePipeline pipes HashSet.empty (DependGraph [])
+  Subst subst <- liftGen (foldlM' solveOneVar emptySubst pairs)
+  let isTempV k = notElem '.' k
+  let sub = Subst (Map.filterWithKey (\k _ -> isTempV k) subst)
+  env <- liftTyped (substToEnv sub emptyEnv)
+  pure (env, gr)
+
+main :: IO ()
+main = do
+  let proof = Babbage Standard
+  ((env, DependGraph zs), _, _) <- generate (runTraceM 0 emptyEnv (solvePipeline2 (ledgerPipeline def proof)))
+  let vs = varsOfTarget HashSet.empty dstateT
+      ok = any (`HashSet.member` vs) . fst
+  putStrLn (show (DependGraph (filter ok zs)))
+  goRepl proof env ""
+
+-- =================================================
+-- Staging and STS rules
+
+sts0 ::
+  (Show ctx, Show state, Show sig, Testable prop) =>
+  Gen ctx ->
+  (ctx -> Gen state) ->
+  (ctx -> state -> Gen sig) ->
+  (ctx -> state -> sig -> state) ->
+  (state -> state -> prop) ->
+  Property
+sts0 ctx state sig apply test =
+  forAll
+    ctx
+    ( \c ->
+        forAll
+          (state c)
+          ( \s ->
+              withMaxSuccess
+                100
+                (forAll (sig c s) (\tx -> test s (apply c s tx)))
+          )
+    )
+
+-- | When we run a STS rule, the context (env) is a subset of the state, so
+--   it makes sense to generate state, and then extract the context.
+sts1 ::
+  (Show ctx, Show state, Show sig, Testable prop) =>
+  Gen state ->
+  (state -> Gen ctx) ->
+  (state -> ctx -> Gen sig) ->
+  ((ctx, state, sig) -> state) ->
+  (state -> state -> prop) ->
+  Property
+sts1 state ctx sig apply test =
+  forAll
+    state
+    ( \s ->
+        forAll
+          (ctx s)
+          ( \c ->
+              withMaxSuccess
+                100
+                (forAll (sig s c) (\tx -> test s (apply (c, s, tx))))
+          )
+    )
+
+proofx :: Proof (BabbageEra StandardCrypto)
+proofx = Babbage Standard
+
+genLedgerState :: Gen (Env Babbage, Subst Babbage, LedgerState Babbage)
+genLedgerState = do
+  (env, sub, _graph) <- solvePipeline (ledgerPipeline def proofx)
+  ledgerstate <- monadTyped $ runTarget env (ledgerStateT proofx)
+  pure (env, sub, ledgerstate)
+
+genSig :: Reflect era => Proof era -> (a, Subst era, b) -> p -> Gen (Tx era)
+genSig proof (_, sub, _) _ledgerEnv = do
+  let preds = fmap (substPred sub) (txBodyPreds def proof)
+  (env0, _sub, _graph) <- solvePipeline [Stage standardOrderInfo preds]
+  env1 <- monadTyped $ adjustFeeInput env0
+  env2 <- monadTyped $ adjustColInput env1
+  (TxF _ tx) <- monadTyped (findVar (unVar txterm) env2)
+  pure tx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -1,0 +1,323 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Constrained.Trace.SimpleTx where
+
+import Cardano.Crypto.Signing (SigningKey)
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
+import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..), TxDats (..))
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (Era (..), EraTx (..), EraTxBody (..), EraTxOut (..), Script, Tx, TxBody, Value, coinTxOutL)
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Hashes (DataHash, ScriptHash)
+import Cardano.Ledger.Keys (GenDelegs (..), KeyHash (..), KeyRole (..))
+import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
+import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
+import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), getScriptsNeeded)
+import Cardano.Ledger.Val (Val (..))
+import Data.Foldable (toList)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq (Empty, (:<|)))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Debug.Trace
+import Lens.Micro
+import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Constrained.Classes (ScriptF (..), TxBodyF (..), TxCertF (..), TxF (..), TxOutF (..), liftUTxO, unScriptF)
+import Test.Cardano.Ledger.Constrained.Preds.Tx (
+  adjustNeededByRefScripts,
+  allValid,
+  bootWitsT,
+  computeFinalFee,
+  getPlutusDataHashes,
+  getRdmrPtrs,
+  hashBody,
+  makeKeyWitness,
+  minusMultiValue,
+  necessaryKeyHashes,
+  sufficientKeyHashes,
+ )
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (TraceM, fromSetTerm, getTerm, liftGen, reqSig)
+import qualified Test.Cardano.Ledger.Constrained.Trace.TraceMonad as TraceMonad (refInputs)
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
+import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..), TxField (..), WitnessesField (..))
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (..), UTxOWit (..), ValueWit (..), whichUTxO, whichValue)
+import Test.Cardano.Ledger.Generic.Updaters (merge, newTx, newTxBody, newWitnesses)
+import Test.QuickCheck (discard, shuffle)
+
+-- ====================================================================
+-- Picking things that have no Plutus Scripts inside. To make very
+-- simple Transactions we need to avoid plutus scripts as they require
+-- Collateral inputs and hashes that ensure prootocl versions match.
+-- ====================================================================
+
+-- | Does a TxOut have only Non-Plutus Scripts. Non-Plutus status is measured by non-membership
+--   in the Map of script hashes of all Plutus scripts.
+plutusFree :: forall era a. Reflect era => Map (ScriptHash (EraCrypto era)) a -> TxOut era -> Bool
+plutusFree plutusmap txout =
+  plutusFreeAddr plutusmap (txout ^. addrTxOutL)
+    && plutusFreeValue (reify @era) plutusmap (txout ^. valueTxOutL)
+
+plutusFreeAddr :: Map (ScriptHash c) a -> Addr c -> Bool
+plutusFreeAddr plutusmap addr = case addr of
+  Addr _ (ScriptHashObj h1) (StakeRefBase (ScriptHashObj h2)) -> Map.notMember h1 plutusmap && Map.notMember h2 plutusmap
+  Addr _ (ScriptHashObj h1) _ -> Map.notMember h1 plutusmap
+  Addr _ _ (StakeRefBase (ScriptHashObj h2)) -> Map.notMember h2 plutusmap
+  _ -> True
+
+plutusFreeValue :: Proof era -> Map (ScriptHash (EraCrypto era)) a -> Value era -> Bool
+plutusFreeValue proof plutusmap v = case (whichValue proof, v) of
+  (ValueShelleyToAllegra, _) -> True
+  (ValueMaryToConway, MaryValue _ (MultiAsset m)) -> all (plutusFreePolicyID plutusmap) (Map.keysSet m)
+
+plutusFreePolicyID :: Map (ScriptHash c) a -> PolicyID c -> Bool
+plutusFreePolicyID plutusmap (PolicyID h) = Map.notMember h plutusmap
+
+-- ====================================================================
+-- Code to generate simple, but valid Transactions
+-- ====================================================================
+
+-- | Make a simple TxBody with 1 input and 1 output. We estimate that such a TxBody will lead to a fee
+--   of less than 'feeEstimate'. So only pick inputs from the utxo that have at least that much coin. Balance the
+--   Coin in the TxOut with the feeEstimate and the actual Coin in the UTxO output that corresponds to the input.
+--   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
+--   See 'genLedgerStateEnv' for an example of how to do that.
+simpleTxBody :: Reflect era => Proof era -> Coin -> TraceM era (TxBody era)
+simpleTxBody proof feeEstimate = do
+  plutusmap <- getTerm plutusUniv
+  let ok (_, TxOutF _ v) = (v ^. coinTxOutL) >= feeEstimate && plutusFree plutusmap v
+  utxopairs <- (filter ok . Map.toList) <$> getTerm (utxo proof)
+  (input, TxOutF _ out) <- do
+    zs <- liftGen (shuffle utxopairs)
+    case zs of
+      [] -> trace ("There are no entries in the UTxO that are big enough for the feeEstimate: " ++ show feeEstimate ++ " Discard") discard
+      (x : _) -> pure x
+  let inputCoin = out ^. coinTxOutL
+  addr <- fromSetTerm addrUniv
+  vldt <- getTerm validityInterval
+  let output = mkBasicTxOut addr (inject (inputCoin <-> feeEstimate))
+  pure $
+    newTxBody
+      proof
+      [ Inputs' [input]
+      , Outputs' [output]
+      , Txfee feeEstimate
+      , Vldt vldt
+      , Mint (liftMultiAsset (minusMultiValue proof (output ^. valueTxOutL) (out ^. valueTxOutL)))
+      ]
+
+-- | The 60000 is arbitrary chosen by experience. The fee for most simpleTx as less than 60000. But in
+--   at least one case we have seen as high as 108407. If that case happens we will discard.
+--   A large fee is rare because it is caused by many scripts and fees that need large witnesses,
+maxFeeEstimate :: Coin
+maxFeeEstimate = Coin 60000
+
+-- | Generate a (Tx era) from a simple (TxBody era), with 1 input and 1 output.
+--   Apply the "finishing" function 'completeTxBody' to make the result a valid Tx.
+--   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
+simpleTx :: Reflect era => Proof era -> TraceM era (Tx era)
+simpleTx proof = do
+  txb <- simpleTxBody proof maxFeeEstimate
+  completeTxBody proof txb
+
+-- | Complete a TxBody, by running a fix-point computation that
+--   1) Adds the appropriate witnesses.
+--   2) Adjusts the the first output to pay the estimated fee.
+--   Run the computation until both the fee and the hash of the TxBody reach a fixpoint.
+--   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
+completeTxBody :: Reflect era => Proof era -> TxBody era -> TraceM era (Tx era)
+completeTxBody proof txBody = do
+  u <- getTerm (utxo proof)
+  scriptuniv <- getTerm (allScriptUniv proof)
+  plutusuniv <- getTerm plutusUniv
+  byronuniv <- getTerm byronAddrUniv
+  datauniv <- getTerm dataUniv
+  gd <- getTerm genDelegs
+  pp <- getTerm (pparams proof)
+  keymapuniv <- getTerm keymapUniv
+  -- compute the inital inputs to the fix-point computation
+  let hash1 = hashBody proof txBody
+      tx =
+        addWitnesses
+          proof
+          (fmap unScriptF scriptuniv)
+          plutusuniv
+          byronuniv
+          keymapuniv
+          datauniv
+          txBody
+          (liftUTxO u)
+          (GenDelegs gd)
+      initialfee = computeFinalFee pp (TxF proof tx)
+  let loop _ _ fee _ | fee >= maxFeeEstimate = trace ("LOOP: fee >= maxFeeEstimate, Discard") $ discard
+      loop count txx fee hash = do
+        let adjustedtx = adjustTxForFee proof fee txx
+            txb = adjustedtx ^. bodyTxL
+            hash2 = hashBody proof txb
+            completedtx =
+              addWitnesses
+                proof
+                (fmap unScriptF scriptuniv)
+                plutusuniv
+                byronuniv
+                keymapuniv
+                datauniv
+                txb
+                (liftUTxO u)
+                (GenDelegs gd)
+            newfee = computeFinalFee pp (TxF proof completedtx)
+        if (fee == newfee) && (hash == hash2)
+          then pure completedtx
+          else
+            if count > (0 :: Int)
+              then loop (count - 1) completedtx newfee hash2
+              else trace ("LOOP: count <= 0, fee is osccilating, Discard") $ discard
+  loop 10 tx initialfee hash1
+
+-- ========================================================================================
+
+-- | Add witnesses to the TxBody to construct a Tx with the appropriate witnesses.
+--   This is a compicated function, but it should be applicable to ANY Tx generated using
+--   the Universes.
+addWitnesses ::
+  forall era.
+  Reflect era =>
+  Proof era ->
+  Map (ScriptHash (EraCrypto era)) (Script era) ->
+  Map (ScriptHash (EraCrypto era)) (IsValid, ScriptF era) ->
+  Map (KeyHash 'Payment (EraCrypto era)) (Addr (EraCrypto era), SigningKey) ->
+  Map (KeyHash 'Witness (EraCrypto era)) (KeyPair 'Witness (EraCrypto era)) ->
+  Map (DataHash (EraCrypto era)) (Data era) ->
+  TxBody era ->
+  UTxO era ->
+  GenDelegs (EraCrypto era) ->
+  Tx era
+addWitnesses proof scriptUniv plutusuniv byronuniv keymapuniv datauniv txb ut gd = tx
+  where
+    needed = getScriptsNeeded ut txb
+    neededWits, scriptwits :: Map (ScriptHash (EraCrypto era)) (Script era)
+    plutusValids :: [IsValid]
+    rptrs :: Set RdmrPtr
+    dataw :: Map (DataHash (EraCrypto era)) (Data era)
+    (scriptwits, neededWits, plutusValids, rptrs, dataw) = case whichUTxO proof of
+      UTxOShelleyToMary -> (witss, witss, [], Set.empty, Map.empty)
+        where
+          ShelleyScriptsNeeded setneed = needed
+          witss = Map.restrictKeys scriptUniv setneed
+      UTxOAlonzoToConway ->
+        let AlonzoScriptsNeeded xs = needed
+            neededHashset = Set.fromList (fmap snd xs)
+            refAdjusted =
+              adjustNeededByRefScripts
+                proof
+                (txb ^. inputsTxBodyL)
+                (TraceMonad.refInputs proof txb)
+                (fmap (TxOutF proof) (unUTxO ut))
+                neededHashset
+            validities = fmap fst (Map.elems (Map.restrictKeys plutusuniv neededHashset))
+         in ( Map.restrictKeys scriptUniv refAdjusted
+            , Map.restrictKeys scriptUniv neededHashset
+            , validities
+            , getRdmrPtrs (TxBodyF proof txb) xs plutusuniv
+            , Map.restrictKeys
+                datauniv
+                ( getPlutusDataHashes
+                    (fmap (TxOutF proof) (unUTxO ut))
+                    (TxBodyF proof txb)
+                    (Map.map (ScriptF proof) scriptUniv)
+                )
+            )
+    sufficient =
+      sufficientKeyHashes
+        proof
+        (fmap (ScriptF proof) neededWits)
+        (toList (fmap (TxCertF proof) (txb ^. certsTxBodyL)))
+        (unGenDelegs gd)
+    necessaryKH =
+      necessaryKeyHashes
+        (TxBodyF proof txb)
+        (fmap (TxOutF proof) (unUTxO ut))
+        (unGenDelegs gd)
+        (reqSig proof txb)
+    keywits =
+      makeKeyWitness
+        (TxBodyF proof txb)
+        necessaryKH
+        sufficient
+        keymapuniv
+        (fmap (ScriptF proof) scriptwits)
+        (unGenDelegs gd)
+        byronuniv
+    bootwits =
+      bootWitsT
+        proof
+        (Map.restrictKeys (fmap (TxOutF proof) (unUTxO ut)) (txb ^. inputsTxBodyL))
+        (TxBodyF proof txb)
+        byronuniv
+    redeem =
+      Set.foldl'
+        (\ans x -> Map.insert x (Data @era (PV1.I 1), ExUnits 3 3) ans)
+        -- It doesn't actuallly matter what the Data is, and the ExUnits only need to be small
+        -- as maxTxExUnits is usually something big like (ExUnits mem=1217 data=3257)
+        Map.empty
+        rptrs
+    wits =
+      newWitnesses
+        merge
+        proof
+        [ AddrWits keywits
+        , BootWits bootwits
+        , ScriptWits scriptwits
+        , DataWits (TxDats dataw)
+        , RdmrWits (Redeemers redeem)
+        ]
+    tx =
+      newTx
+        proof
+        [ Body txb
+        , TxWits wits
+        , --  , AuxData' (fixM auxs)
+          Valid (allValid plutusValids)
+        ]
+
+-- =======================================================================
+
+-- | adjust a Tx for the fee, by setting the fee to the correct value then
+--   moving the excess to the outputs
+adjustTxForFee :: EraTx era => Proof era -> Coin -> Tx era -> Tx era
+adjustTxForFee _proof actualfee tx =
+  tx
+    & feeCoinL
+      .~ actualfee
+    & firstOutputCoinL
+      .~ (outputCoin <+> (currentfee <-> actualfee))
+  where
+    currentfee = tx ^. feeCoinL
+    outputCoin = tx ^. firstOutputCoinL
+
+feeCoinL :: EraTx era => Lens' (Tx era) Coin
+feeCoinL = bodyTxL . feeTxBodyL
+
+firstOutputCoinL :: EraTx era => Lens' (Tx era) Coin
+firstOutputCoinL = bodyTxL . outputsTxBodyL . strictSeqHeadL . coinTxOutL
+
+strictSeqHeadL :: Lens' (StrictSeq a) a
+strictSeqHeadL =
+  lens
+    gethead
+    ( \x h -> case x of
+        (_ :<| xs) -> h :<| xs
+        Empty -> h :<| Empty
+    )
+  where
+    gethead (x :<| _) = x
+    gethead _ = error "Empty sequence in strictSeqHeadL"

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Constrained.Trace.Tests
+where
+
+import Cardano.Ledger.Alonzo.Scripts.Data (BinaryData, Datum (..))
+import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
+import Cardano.Ledger.BaseTypes (TxIx)
+import Cardano.Ledger.Core (EraRule, EraTx (..), EraTxBody (..), Tx)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
+import Cardano.Ledger.TreeDiff (
+  Expr (App),
+  ToExpr (toExpr),
+ )
+import Control.State.Transition.Extended (STS (..), TRC (..))
+import Data.Foldable (toList)
+import Lens.Micro ((^.))
+import System.IO (hSetEncoding, stdout, utf8)
+import Test.Cardano.Ledger.Constrained.Ast (emptySubst, runTarget, runTerm, substToEnv)
+import Test.Cardano.Ledger.Constrained.Classes (PParamsF (..), TxF (..), TxOutF (..))
+import Test.Cardano.Ledger.Constrained.Env (Env (..), emptyEnv)
+import Test.Cardano.Ledger.Constrained.Monad (Typed)
+import Test.Cardano.Ledger.Constrained.Preds.Repl (goRepl)
+import Test.Cardano.Ledger.Constrained.Trace.Actions (feesAction, inputsAction, outputsAction)
+import Test.Cardano.Ledger.Constrained.Trace.SimpleTx (simpleTx)
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (
+  TraceM,
+  certStateTrace,
+  fstTriple,
+  getEnv,
+  getTarget,
+  ledgerStateTrace,
+  liftGen,
+  liftTyped,
+  pparamsTrace,
+  pstateTrace,
+  putEnv,
+  runTraceM,
+  setVar,
+  toGen,
+  universeTrace,
+  vstateTrace,
+ )
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTx)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.Cardano.Ledger.Generic.TxGen (applySTSByProof)
+import Test.QuickCheck (Arbitrary (..), Property, conjoin, counterexample, generate, whenFail, withMaxSuccess, (===))
+import Test.Tasty
+import Test.Tasty.QuickCheck (testProperty)
+
+-- =================================
+
+instance ToExpr (BabbageTxOut (BabbageEra StandardCrypto)) where
+  toExpr (BabbageTxOut addr val dat sc) = App "BabbageTxOut" [toExpr addr, toExpr val, toExpr dat, toExpr sc]
+
+instance ToExpr (Datum (BabbageEra StandardCrypto)) where
+  toExpr NoDatum = App "NoDatum" []
+  toExpr (DatumHash x) = App "DatumHash" [toExpr x]
+  toExpr (Datum bd) = App "Datum" [toExpr bd]
+
+instance ToExpr (BinaryData (BabbageEra StandardCrypto)) where
+  toExpr _ = App "BinaryData" []
+
+-- ===================================================
+
+-- | Generate an Env that contains the pieces of the LedgerState
+--   by chaining smaller pieces together.
+genLedgerStateEnv :: Reflect era => Proof era -> TraceM era (Env era)
+genLedgerStateEnv proof = do
+  subst <-
+    pure emptySubst
+      >>= pparamsTrace proof
+      >>= universeTrace proof
+      >>= vstateTrace proof
+      >>= pstateTrace proof
+      >>= certStateTrace proof
+      >>= ledgerStateTrace proof
+  env <- liftTyped (substToEnv subst emptyEnv)
+  putEnv env
+
+go :: IO ()
+go = do
+  x <- generate (fstTriple <$> runTraceM 0 emptyEnv (genLedgerStateEnv (Babbage Standard)))
+  goRepl (Babbage Standard) x ""
+
+-- | Given an (Env era) construct the pair the the LendgerEnv and the LedgerState
+getSTSLedgerEnv :: Reflect era => Proof era -> TxIx -> Env era -> Typed (LedgerEnv era, LedgerState era)
+getSTSLedgerEnv proof txIx env = do
+  ledgerstate <- runTarget env (ledgerStateT proof)
+  slot <- runTerm env currentSlot
+  (PParamsF _ pp) <- runTerm env (pparams proof)
+  accntState <- runTarget env accountStateT
+  pure $ (LedgerEnv slot txIx pp accntState, ledgerstate)
+
+-- =======================================================================
+-- Test that simpleTx and the 'actions' actually agree with the applySTS
+
+-- | Construct and run one simpleTx, and run it through applySTS
+--  Check that the computed LedgerState is the same as the expected LedgerState
+--  Computed by using 'inputsAction' , 'outputsAction' , and 'feesAction'
+genAndRunSimpleTx :: TraceM (ConwayEra StandardCrypto) Property
+genAndRunSimpleTx = do
+  let proof = Conway Standard
+  _ <- genLedgerStateEnv proof
+
+  -- Compute the TRC before we make the Tx, because that adds things to the Env
+  txIx <- liftGen arbitrary
+  env0 <- getEnv
+  (lenv, ledgerstate) <- liftTyped $ getSTSLedgerEnv proof txIx env0
+
+  -- Now generate a simpleTx, and store it in the Env
+  -- apply the changes we expect this Tx to make, and save the result.
+  tx <- simpleTx proof
+  setVar txterm (TxF proof tx)
+  let txb = tx ^. bodyTxL
+      feeCoin = txb ^. feeTxBodyL
+  inputsAction proof (txb ^. inputsTxBodyL)
+  outputsAction proof txb (fmap (TxOutF proof) (toList (txb ^. outputsTxBodyL)))
+  feesAction feeCoin
+  expectedLedgerState <- getTarget (ledgerStateT proof)
+  env1 <- getEnv
+  -- Now compute the env we compute using the STS
+  pure $ ledgerStateEqProp proof env1 expectedLedgerState lenv ledgerstate tx
+
+-- | Create a Property by testing that applying the STS "LEDGER" rule, succeeds and
+--   returns the expected LedgerState. If it fails, print out the failures and
+--   drop into the Repl, so that users can explore the inputs.
+ledgerStateEqProp ::
+  ( Signal (EraRule "LEDGER" era) ~ Tx era
+  , Reflect era
+  , Show (State (EraRule "LEDGER" era))
+  , Show (PredicateFailure (EraRule "LEDGER" era))
+  , Eq (State (EraRule "LEDGER" era))
+  ) =>
+  Proof era ->
+  Env era ->
+  State (EraRule "LEDGER" era) ->
+  Environment (EraRule "LEDGER" era) ->
+  State (EraRule "LEDGER" era) ->
+  Signal (EraRule "LEDGER" era) ->
+  Property
+ledgerStateEqProp proof env1 expectedLedgerState ledgerenv ledgerstate tx =
+  case applySTSByProof proof (TRC (ledgerenv, ledgerstate, tx)) of
+    Right ledgerState' ->
+      ledgerState' === {- `ediffEq` -} expectedLedgerState
+    Left errs ->
+      let errsLines = "" : "applySTS fails" : map show errs
+       in counterexample
+            (unlines (errsLines ++ ["Tx =", show (pcTx proof tx)]))
+            ( whenFail
+                (putStrLn (unlines errsLines) >> goRepl proof env1 "")
+                False
+            )
+
+main1 :: IO ()
+main1 = do
+  hSetEncoding stdout utf8
+  defaultMain $ testProperty "TraceMain" (withMaxSuccess 50 (toGen genAndRunSimpleTx))
+
+-- ==============================================================
+-- Code to make Traces
+
+-- | Iterate a function 'make' to make a trace of length 'n'. Each call to 'make' gets the
+--   most recent value of the Env internal to TraceM. The function 'make' is
+--   supposed to compute 'a', and (possibly) update the Env internal to TraceM.
+makeTrace :: Int -> TraceM era a -> TraceM era [(Env era, a)]
+makeTrace 0 _ = pure []
+makeTrace n make = do
+  env0 <- getEnv
+  a <- make
+  xs <- makeTrace (n - 1) make
+  pure ((env0, a) : xs)
+
+data TraceStep era a = TraceStep !(Env era) !(Env era) !a
+
+beforeAfterTrace :: Int -> (Int -> TraceM era a) -> TraceM era [TraceStep era a]
+beforeAfterTrace 0 _ = pure []
+beforeAfterTrace !n make = do
+  !beforeEnv <- getEnv
+  !a <- make n
+  !afterEnv <- getEnv
+  xs <- beforeAfterTrace (n - 1) make
+  let !ans = TraceStep beforeEnv afterEnv a : xs
+  pure ans
+
+-- =================================================================
+-- Show that each step in a trace computes the right LedgerState
+
+runOne ::
+  ( Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ Tx era
+  , Show (PredicateFailure (EraRule "LEDGER" era))
+  , Reflect era
+  ) =>
+  Proof era ->
+  TxIx ->
+  TraceStep era (Signal (EraRule "LEDGER" era)) ->
+  Typed Property
+runOne proof txIx (TraceStep beforeEnv afterEnv tx) = do
+  (lenv, ledgerstate) <- getSTSLedgerEnv proof txIx beforeEnv
+  expectedLedgerState <- runTarget afterEnv (ledgerStateT proof)
+  pure $ ledgerStateEqProp proof afterEnv expectedLedgerState lenv ledgerstate tx
+
+oneTx :: Reflect era => Proof era -> Int -> TraceM era (Tx era)
+oneTx proof _n = do
+  !tx <- simpleTx proof
+  setVar txterm (TxF proof tx)
+  let !txb = tx ^. bodyTxL
+      !feeCoin = txb ^. feeTxBodyL
+  inputsAction proof (txb ^. inputsTxBodyL)
+  outputsAction proof txb (fmap (TxOutF proof) (toList (txb ^. outputsTxBodyL)))
+  feesAction feeCoin
+  pure tx
+
+testTrace ::
+  ( Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ Tx era
+  , Reflect era
+  , Show (PredicateFailure (EraRule "LEDGER" era))
+  ) =>
+  Proof era ->
+  Int ->
+  TraceM era Property
+testTrace proof tracelen = do
+  !_ <- genLedgerStateEnv proof
+  !txIx <- liftGen arbitrary
+  !pairs <- beforeAfterTrace tracelen (oneTx proof)
+  conjoin <$> mapM (\ !x -> liftTyped (runOne proof txIx x)) pairs
+
+conwayTrace :: TestTree
+conwayTrace =
+  testProperty
+    ("Testing each Tx in a Conway trace of length=" ++ show tracelen ++ " passes applySTS.")
+    (withMaxSuccess n (fstTriple <$> (runTraceM 0 emptyEnv (testTrace (Conway Standard) tracelen))))
+  where
+    tracelen = 100
+    n = 10
+
+main :: IO ()
+main = do
+  hSetEncoding stdout utf8
+  defaultMain conwayTrace

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Test.Cardano.Ledger.Constrained.Trace.TraceMonad
+where
+
+import Cardano.Ledger.Babbage.TxBody (referenceInputsTxBodyL, reqSignerHashesTxBodyL)
+import Cardano.Ledger.Core (Era (..), TxBody)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.TxIn (TxIn)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.State.Strict hiding (State)
+import Data.Default.Class (Default (def))
+import qualified Data.HashSet as HashSet
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Pulse (foldlM')
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Lens.Micro
+import Test.Cardano.Ledger.Constrained.Ast (
+  Pred (..),
+  RootTarget (..),
+  Subst (..),
+  Term (..),
+  runTarget,
+  runTerm,
+  substPredWithVarTest,
+ )
+import Test.Cardano.Ledger.Constrained.Combinators (genFromMap, itemFromSet, suchThatErr)
+import Test.Cardano.Ledger.Constrained.Env
+import Test.Cardano.Ledger.Constrained.Monad (Typed (..), runTyped)
+import Test.Cardano.Ledger.Constrained.Preds.CertState (certStatePreds, pstatePreds, vstatePreds)
+import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStatePreds)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsPreds)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (universePreds)
+import Test.Cardano.Ledger.Constrained.Rewrite (
+  DependGraph (..),
+  OrderInfo,
+  initialOrder,
+  mkDependGraph,
+  notBefore,
+  rewriteGen,
+  standardOrderInfo,
+ )
+import Test.Cardano.Ledger.Constrained.Solver (solveOneVar)
+import Test.Cardano.Ledger.Generic.Proof hiding (lift)
+import Test.QuickCheck (Gen)
+
+-- ================================
+
+data TraceState era = TraceState !Int !(Env era)
+
+newtype TraceM era x = TraceM (StateT (TraceState era) (ExceptT [String] Gen) x)
+  deriving (Functor, Applicative, Monad)
+
+runTraceM :: Int -> Env era -> TraceM era a -> Gen (a, Int, Env era)
+runTraceM n env (TraceM x) = do
+  y <- runExceptT (runStateT x (TraceState n env))
+  case y of
+    Left xs -> error (unlines xs)
+    Right (z, TraceState i s) -> pure (z, i, s)
+
+fstTriple :: (a, b, c) -> a
+fstTriple = (\(p, _, _) -> p)
+
+toGen :: TraceM era a -> Gen a
+toGen ax = fstTriple <$> runTraceM 0 emptyEnv ax
+
+failTrace :: [String] -> TraceM era a
+failTrace ss = TraceM (lift (throwE ss))
+
+instance MonadFail (TraceM era) where
+  fail err = failTrace [err]
+
+-- ==============================
+-- Lift a (Type era a) to (TraceM era a)
+
+liftTyped :: Typed a -> TraceM era a
+liftTyped x = do
+  case runTyped x of
+    Left ss -> failTrace ss
+    Right a -> pure a
+
+liftGen :: Gen a -> TraceM era a
+liftGen g = TraceM (lift (lift g))
+
+getEnv :: TraceM era (Env era)
+getEnv = TraceM (state (\s@(TraceState _ !e) -> (e, s)))
+
+getCount :: TraceM era Int
+getCount = TraceM (state (\s@(TraceState !i _) -> (i, s)))
+
+putEnv :: Env era -> TraceM era (Env era)
+putEnv env = TraceM (state (\(TraceState i _) -> (env, TraceState i env)))
+
+putCount :: Int -> TraceM era ()
+putCount i = TraceM (state (\(TraceState _ !e) -> ((), TraceState i e)))
+
+liftCounter :: ((Int, a) -> Gen (Int, b)) -> a -> TraceM era b
+liftCounter f a = do
+  !i <- getCount
+  (!j, !b) <- liftGen (f (i, a))
+  putCount j
+  pure b
+
+-- ========================
+
+-- | Lookup the value of a Term in the Env internal to TraceM.
+getTerm :: Term era a -> TraceM era a
+getTerm term = do
+  env <- getEnv
+  case runTyped (runTerm env term) of
+    Right a -> pure a
+    Left ss -> failTrace (ss ++ ["in call to (getTerm " ++ show term ++ ")"])
+
+getTarget :: RootTarget era r a -> TraceM era a
+getTarget tar = do
+  env <- getEnv
+  case runTyped (runTarget env tar) of
+    Right a -> pure a
+    Left ss -> failTrace (ss ++ ["in call to (getTarget " ++ show tar ++ ")"])
+
+-- | Pick a random (key,value) pair from a Map
+fromMapTerm :: Term era (Map k a) -> TraceM era (k, a)
+fromMapTerm term = do
+  u <- getTerm term
+  liftGen $ genFromMap ["fromMapTerm " ++ show term] u
+
+-- | Pick a random (key,value) pair from a Map such that the (key,value) pair meets predicate 'p'
+fromMapTermSuchThat :: Term era (Map k a) -> ((k, a) -> Bool) -> TraceM era (k, a)
+fromMapTermSuchThat term p = do
+  u <- getTerm term
+  let n = Map.size u
+  liftGen $
+    suchThatErr
+      ["suchThatErr call (fromMapTermSuchThat " ++ show term ++ " size = " ++ show n]
+      (genFromMap ["fromMapTerm " ++ show term] u)
+      p
+
+-- | Pick a random element from a Set
+fromSetTerm :: Term era (Set b) -> TraceM era b
+fromSetTerm term = do
+  u <- getTerm term
+  liftGen (fst <$> (itemFromSet ["fromSetTerm " ++ show term] u))
+
+-- | Update the Env internal to TraceM.
+update :: (Env era -> TraceM era (Env era)) -> TraceM era ()
+update f = getEnv >>= f >>= putEnv >> pure ()
+
+-- | Update the value of one variable stored in the Env internal to TraceM.
+updateVar :: Term era t -> (t -> t) -> TraceM era ()
+updateVar term@(Var v) adjust = TraceM $ do
+  TraceState i env <- get
+  case runTyped (runTerm env term) of
+    Right valA -> put (TraceState i (storeVar v (adjust valA) env))
+    Left ss -> lift (throwE (ss ++ ["in call to 'updateVar'"]))
+updateVar term _ = failTrace ["Non Var term in call to 'updateVar'", show term]
+
+setVar :: Term era t -> t -> TraceM era ()
+setVar (Var v) t = TraceM $ do
+  TraceState i env <- get
+  put (TraceState i (storeVar v t env))
+setVar term _ = failTrace ["Non Var term in call to 'setVar'", show term]
+
+-- ============================================================================
+-- A few helper functions that need to do different things in different Eras.
+
+refInputs :: Proof era -> TxBody era -> Set (TxIn (EraCrypto era))
+refInputs (Shelley _) _ = Set.empty
+refInputs (Allegra _) _ = Set.empty
+refInputs (Mary _) _ = Set.empty
+refInputs (Alonzo _) _ = Set.empty
+refInputs (Babbage _) txb = txb ^. referenceInputsTxBodyL
+refInputs (Conway _) txb = txb ^. referenceInputsTxBodyL
+
+reqSig :: Proof era -> TxBody era -> Set (KeyHash 'Witness (EraCrypto era))
+reqSig (Shelley _) _ = Set.empty
+reqSig (Allegra _) _ = Set.empty
+reqSig (Mary _) _ = Set.empty
+reqSig (Alonzo _) _ = Set.empty
+reqSig (Babbage _) txb = txb ^. reqSignerHashesTxBodyL
+reqSig (Conway _) txb = txb ^. reqSignerHashesTxBodyL
+
+-- =======================================================================================
+-- Code to run the standard [Pred era] found in the Preds directory in the TraceM monad
+-- First code to compile in the TraceM monad, and then use the compiled version to run
+-- the solver in the TraceM monad
+
+-- | Compile [Pred era] in the TraceM monad
+--   First: Apply the Rewriter
+--   Second: appy the Subst
+--   Third: Construct the DependGraph
+compileTraceWithSubst :: Era era => OrderInfo -> Subst era -> [Pred era] -> TraceM era (DependGraph era)
+compileTraceWithSubst info subst0 cs0 = do
+  simple <- liftCounter rewriteGen cs0
+  graph <- liftTyped $ do
+    let instanPreds = fmap (substPredWithVarTest subst0) simple
+    orderedNames <- initialOrder info instanPreds
+    mkDependGraph (length orderedNames) [] HashSet.empty orderedNames [] (Prelude.filter notBefore instanPreds)
+  pure graph
+
+-- | Use the tool chain to generate a Subst from a list of Pred, in the TraceM monad.
+toolChainTrace :: Era era => Proof era -> OrderInfo -> [Pred era] -> Subst era -> TraceM era (Subst era)
+toolChainTrace _proof order cs subst0 = do
+  (DependGraph pairs) <- compileTraceWithSubst order subst0 cs
+  Subst subst <- liftGen (foldlM' solveOneVar subst0 pairs)
+  let isTempV k = not (elem '.' k)
+  pure $ (Subst (Map.filterWithKey (\k _ -> isTempV k) subst))
+
+-- =====================================================================
+-- Lift some [Pred era] into TraceM (monadic) (Subst era) transformers
+
+-- Create tool (TraceM era (Subst era)) functions that can be chained together
+
+universeTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+universeTrace proof subst = toolChainTrace proof standardOrderInfo (universePreds def proof) subst
+
+pparamsTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+pparamsTrace proof subst = toolChainTrace proof standardOrderInfo (pParamsPreds proof) subst
+
+pstateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+pstateTrace proof subst = toolChainTrace proof standardOrderInfo (pstatePreds proof) subst
+
+vstateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+vstateTrace proof subst = toolChainTrace proof standardOrderInfo (vstatePreds proof) subst
+
+certStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+certStateTrace proof subst = toolChainTrace proof standardOrderInfo (certStatePreds proof) subst
+
+ledgerStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+ledgerStateTrace proof subst = toolChainTrace proof standardOrderInfo (ledgerStatePreds def proof) subst

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
@@ -48,7 +48,7 @@ import Test.Cardano.Ledger.Generic.Functions (
 import Test.Cardano.Ledger.Generic.GenState (GenSize (..), initStableFields)
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockBlock (..), MockChainState (..))
 import Test.Cardano.Ledger.Generic.Proof (Evidence (..), Proof (..), Reflect (..), Some (..), preBabbage, unReflect)
-import Test.Cardano.Ledger.Generic.Trace (Gen1, genTrace)
+import Test.Cardano.Ledger.Generic.Trace (Gen1, genTrace, testPropMax)
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)
@@ -96,9 +96,9 @@ aggTests :: TestTree
 aggTests =
   testGroup
     "tests, aggregating Tx's over a Trace."
-    [ testProperty "UTxO size in Babbage" (aggUTxO (Babbage Mock))
-    , testProperty "UTxO size in Alonzo" (aggUTxO (Alonzo Mock))
-    , testProperty "UTxO size in Mary" (aggUTxO (Mary Mock))
+    [ testPropMax 30 "UTxO size in Babbage" (aggUTxO (Babbage Mock))
+    , testPropMax 30 "UTxO size in Alonzo" (aggUTxO (Alonzo Mock))
+    , testPropMax 30 "UTxO size in Mary" (aggUTxO (Mary Mock))
     ]
 
 -- ===============================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -57,12 +57,14 @@ module Test.Cardano.Ledger.Generic.Proof (
   PParamsWit (..),
   UTxOWit (..),
   ScriptWit (..),
+  GovStateWit (..),
   whichValue,
   whichTxOut,
   whichTxCert,
   whichPParams,
   whichUTxO,
   whichScript,
+  whichGovState,
 ) where
 
 import Cardano.Crypto.DSIGN as DSIGN
@@ -85,6 +87,7 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import qualified Cardano.Ledger.BaseTypes as Base (Seed)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (ConwayGovState (..))
 import Cardano.Ledger.Conway.TxCert (ConwayEraTxCert, ConwayTxCert (..))
 import Cardano.Ledger.Core (
   Era (EraCrypto),
@@ -107,6 +110,7 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core (EraGov, EraIndependentTxBody, ShelleyEraTxBody, ShelleyEraTxCert)
+import Cardano.Ledger.Shelley.Governance (EraGov (..), ShelleyGovState (..))
 import Cardano.Ledger.Shelley.Scripts (MultiSig)
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert)
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
@@ -543,3 +547,15 @@ whichScript (Mary _) = ScriptAllegraToMary
 whichScript (Alonzo _) = ScriptAlonzoToConway
 whichScript (Babbage _) = ScriptAlonzoToConway
 whichScript (Conway _) = ScriptAlonzoToConway
+
+data GovStateWit era where
+  GovStateShelleyToBabbage :: (EraGov era, GovState era ~ ShelleyGovState era) => GovStateWit era
+  GovStateConwayToConway :: (EraGov era, GovState era ~ ConwayGovState era) => GovStateWit era
+
+whichGovState :: Proof era -> GovStateWit era
+whichGovState (Shelley _) = GovStateShelleyToBabbage
+whichGovState (Allegra _) = GovStateShelleyToBabbage
+whichGovState (Mary _) = GovStateShelleyToBabbage
+whichGovState (Alonzo _) = GovStateShelleyToBabbage
+whichGovState (Babbage _) = GovStateShelleyToBabbage
+whichGovState (Conway _) = GovStateConwayToConway

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -57,7 +57,7 @@ import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockChainState (..))
 import Test.Cardano.Ledger.Generic.ModelState
 import Test.Cardano.Ledger.Generic.PrettyCore (PrettyC (..), pcLedgerState, pcTx)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
-import Test.Cardano.Ledger.Generic.Trace (Gen1, forEachEpochTrace, testTraces, traceProp)
+import Test.Cardano.Ledger.Generic.Trace (Gen1, forEachEpochTrace, testPropMax, testTraces, traceProp)
 import Test.Cardano.Ledger.Generic.TxGen (
   Box (..),
   applySTSByProof,
@@ -71,7 +71,6 @@ import Test.Cardano.Ledger.Generic.TxGen (
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.QuickCheck
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
 
 -- =====================================
 -- Top level generators of TRC
@@ -178,35 +177,35 @@ coreTypesRoundTrip =
     "Core types make generic roundtrips"
     [ testGroup
         "TxWits roundtrip"
-        [ testProperty "Babbage era" $ txWitRoundTrip (Babbage Mock)
-        , testProperty "Alonzo era" $ txWitRoundTrip (Alonzo Mock)
-        , testProperty "Mary era" $ txWitRoundTrip (Mary Mock)
-        , testProperty "Allegra era" $ txWitRoundTrip (Allegra Mock)
-        , testProperty "Shelley era" $ txWitRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txWitRoundTrip (Babbage Mock)
+        , testPropMax 30 "Alonzo era" $ txWitRoundTrip (Alonzo Mock)
+        , testPropMax 30 "Mary era" $ txWitRoundTrip (Mary Mock)
+        , testPropMax 30 "Allegra era" $ txWitRoundTrip (Allegra Mock)
+        , testPropMax 30 "Shelley era" $ txWitRoundTrip (Shelley Mock)
         ]
     , testGroup
         "TxBody roundtrips"
-        [ testProperty "Babbage era" $ txBodyRoundTrip (Babbage Mock)
-        , testProperty "Alonzo era" $ txBodyRoundTrip (Alonzo Mock)
-        , testProperty "Mary era" $ txBodyRoundTrip (Mary Mock)
-        , testProperty "Allegra era" $ txBodyRoundTrip (Allegra Mock)
-        , testProperty "Shelley era" $ txBodyRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txBodyRoundTrip (Babbage Mock)
+        , testPropMax 30 "Alonzo era" $ txBodyRoundTrip (Alonzo Mock)
+        , testPropMax 30 "Mary era" $ txBodyRoundTrip (Mary Mock)
+        , testPropMax 30 "Allegra era" $ txBodyRoundTrip (Allegra Mock)
+        , testPropMax 30 "Shelley era" $ txBodyRoundTrip (Shelley Mock)
         ]
     , testGroup
         "TxOut roundtrips"
-        [ testProperty "Babbage era" $ txOutRoundTrip (Babbage Mock)
-        , testProperty "Alonzo era" $ txOutRoundTrip (Alonzo Mock)
-        , testProperty "Mary era" $ txOutRoundTrip (Mary Mock)
-        , testProperty "Allegra era" $ txOutRoundTrip (Allegra Mock)
-        , testProperty "Shelley era" $ txOutRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txOutRoundTrip (Babbage Mock)
+        , testPropMax 30 "Alonzo era" $ txOutRoundTrip (Alonzo Mock)
+        , testPropMax 30 "Mary era" $ txOutRoundTrip (Mary Mock)
+        , testPropMax 30 "Allegra era" $ txOutRoundTrip (Allegra Mock)
+        , testPropMax 30 "Shelley era" $ txOutRoundTrip (Shelley Mock)
         ]
     , testGroup
         "Tx roundtrips"
-        [ testProperty "Babbage era" $ txRoundTrip (Babbage Mock)
-        , testProperty "Alonzo era" $ txRoundTrip (Alonzo Mock)
-        , testProperty "Mary era" $ txRoundTrip (Mary Mock)
-        , testProperty "Allegra era" $ txRoundTrip (Allegra Mock)
-        , testProperty "Shelley era" $ txRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txRoundTrip (Babbage Mock)
+        , testPropMax 30 "Alonzo era" $ txRoundTrip (Alonzo Mock)
+        , testPropMax 30 "Mary era" $ txRoundTrip (Mary Mock)
+        , testPropMax 30 "Allegra era" $ txRoundTrip (Allegra Mock)
+        , testPropMax 30 "Shelley era" $ txRoundTrip (Shelley Mock)
         ]
     ]
 
@@ -215,18 +214,18 @@ txPreserveAda :: GenSize -> TestTree
 txPreserveAda genSize =
   testGroup
     "Individual Tx's preserve Ada"
-    [ testProperty "Shelley Tx preserves ADA" $
+    [ testPropMax 30 "Shelley Tx preserves ADA" $
         forAll (genTxAndLEDGERState (Shelley Mock) genSize) (testTxValidForLEDGER (Shelley Mock))
-    , testProperty "Allegra Tx preserves ADA" $
+    , testPropMax 30 "Allegra Tx preserves ADA" $
         forAll (genTxAndLEDGERState (Allegra Mock) genSize) (testTxValidForLEDGER (Allegra Mock))
-    , testProperty "Mary Tx preserves ADA" $
+    , testPropMax 30 "Mary Tx preserves ADA" $
         forAll (genTxAndLEDGERState (Mary Mock) genSize) (testTxValidForLEDGER (Mary Mock))
-    , testProperty "Alonzo ValidTx preserves ADA" $
+    , testPropMax 30 "Alonzo ValidTx preserves ADA" $
         forAll (genTxAndLEDGERState (Alonzo Mock) genSize) (testTxValidForLEDGER (Alonzo Mock))
-    , testProperty "Babbage ValidTx preserves ADA" $
+    , testPropMax 30 "Babbage ValidTx preserves ADA" $
         forAll (genTxAndLEDGERState (Babbage Mock) genSize) (testTxValidForLEDGER (Babbage Mock))
         -- TODO
-        -- testProperty "Conway ValidTx preserves ADA" $
+        -- testPropMax 30 "Conway ValidTx preserves ADA" $
         --  forAll (genTxAndLEDGERState (Conway Mock) genSize) (testTxValidForLEDGER (Conway Mock))
     ]
 
@@ -240,7 +239,7 @@ adaIsPreserved ::
   GenSize ->
   TestTree
 adaIsPreserved proof numTx gensize =
-  testProperty (show proof ++ " era. Trace length = " ++ show numTx) $
+  testPropMax 30 (show proof ++ " era. Trace length = " ++ show numTx) $
     traceProp
       proof
       numTx
@@ -275,7 +274,7 @@ incrementStakeInvariant ::
   GenSize ->
   TestTree
 incrementStakeInvariant proof gensize =
-  testProperty (show proof ++ " era. Trace length = 100") $
+  testPropMax 30 (show proof ++ " era. Trace length = 100") $
     traceProp proof 100 gensize stakeInvariant
 
 incrementalStake :: GenSize -> TestTree
@@ -322,7 +321,7 @@ adaIsPreservedInEachEpoch ::
   GenSize ->
   TestTree
 adaIsPreservedInEachEpoch proof genSize =
-  testProperty (show proof) $
+  testPropMax 30 (show proof) $
     forEachEpochTrace proof 200 genSize withTrace
   where
     withTrace :: Trace (MOCKCHAIN era) -> Property
@@ -340,7 +339,7 @@ twiddleInvariantHolds ::
   String ->
   TestTree
 twiddleInvariantHolds name =
-  testProperty name $ twiddleInvariantProp @a
+  testPropMax 30 name $ twiddleInvariantProp @a
 
 twiddleInvariantHoldsEras :: TestTree
 twiddleInvariantHoldsEras =
@@ -366,16 +365,16 @@ test n proof = defaultMain $
   case proof of
     -- TODO
     -- Conway _ ->
-    --  testProperty "Conway ValidTx preserves ADA" $
+    --  testPropMax 30 "Conway ValidTx preserves ADA" $
     --    withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
     Babbage _ ->
-      testProperty "Babbage ValidTx preserves ADA" $
+      testPropMax 30 "Babbage ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
     Alonzo _ ->
-      testProperty "Alonzo ValidTx preserves ADA" $
+      testPropMax 30 "Alonzo ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
     Shelley _ ->
-      testProperty "Shelley ValidTx preserves ADA" $
+      testPropMax 30 "Shelley ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
     other -> error ("NO Test in era " ++ show other)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -541,6 +541,13 @@ forAllTraceFromInitState baseEnv maxTraceLength traceGenEnv genSt0 =
 -- =========================================================================
 -- Test for just making a trace
 
+-- | We are making 'smoke' tests, testing for smoke rather than fire.
+--   Under the assumption that shorter tests have advantages
+--   like not getting turned off because the tests take too long. A glaring failure is
+--   likely to be caught in 'n' tests, rather than the standard '100'
+testPropMax :: Testable prop => Int -> String -> prop -> TestTree
+testPropMax n name x = testProperty name (withMaxSuccess n x)
+
 chainTest ::
   forall era.
   ( Reflect era
@@ -551,7 +558,7 @@ chainTest ::
   Int ->
   GenSize ->
   TestTree
-chainTest proof n gsize = testProperty message action
+chainTest proof n gsize = testPropMax 30 message action
   where
     message = show proof ++ " era."
     action = do
@@ -592,7 +599,8 @@ multiEpochTest proof numTx gsize =
       getEpoch mockchainstate = nesEL (mcsNes mockchainstate)
       propf firstSt lastSt =
         collect (getEpoch lastSt) (totalAda firstSt === totalAda lastSt)
-   in testProperty
+   in testPropMax
+        30
         ("Multi epoch. Ada is preserved. " ++ show proof ++ " era. Trace length = " ++ show numTx)
         (traceProp proof numTx gensize propf)
 

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -11,6 +11,10 @@ import Data.Default.Class (Default (def))
 import System.Environment (lookupEnv)
 import System.IO (hSetEncoding, stdout, utf8)
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
+import Test.Cardano.Ledger.Constrained.Examples (allExampleTests)
+import Test.Cardano.Ledger.Constrained.Preds.Tx (predsTests)
+import Test.Cardano.Ledger.Constrained.Spec (allSpecTests)
+import Test.Cardano.Ledger.Constrained.Trace.Tests (conwayTrace)
 import qualified Test.Cardano.Ledger.Examples.AlonzoAPI as AlonzoAPI (tests)
 import qualified Test.Cardano.Ledger.Examples.AlonzoBBODY as AlonzoBBODY (tests)
 import qualified Test.Cardano.Ledger.Examples.AlonzoCollectInputs as AlonzoCollectInputs (tests)
@@ -34,7 +38,11 @@ main = do
 
 defaultTests :: [TestTree]
 defaultTests =
-  [ depositTests
+  [ allSpecTests
+  , allExampleTests
+  , conwayTrace
+  , predsTests
+  , depositTests
   , calcPoolDistOldEqualsNew
   , Tools.tests
   , testGroup


### PR DESCRIPTION
The goal of this PR was to add Traces of simple transactions, and shrinking to tests generated from constraints.
In order to do this we had to add   many new features. Here is a summary

    Added module Test.Cardano.Ledger.Constrained.Trace.TraceMonad. A monad for generating traces
    Includes an example of making a simple Tx's with 1 input and output.
    Added 'actions' that update the Env in the TraceM monad for inputs, outputs and fees.
    Added Tests that such Tx's pass the applySTS and that the 'actions' compute the same state.
    Added Tests that traces of length 100, are real traces and lead to valid states.
    Added Stage.hs, to break up large constraint lists into reusable pieces
    Added Two experiments to make Targets invertible.
    Added Profile improvements, use HashSet(Name era) rather than Set(Name era)
    Parameterized the Preds directory files by UnivSize, so on can control the size of the universes.
    Added the Gadt Rule, and sts :: Proof era -> Rule tag -> ...
    Replaced Target with RootTarget, added some examples in Vars.hs
    Added all the Constrained sub directory tests to the Tests in cardano-ledger-test

# Description

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
