### PR TITLE
Disallow empty fields in ConwayTxBodyRaw

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.9.0.0
 
+* Fix `ConwayTxBodyRaw` decoder to disallow empty `Field`s #3712
+  * `certsTxBodyL`
+  * `withdrawalsTxBodyL`
+  * `mintTxBodyL`
+  * `collateralInputsTxBodyL`
+  * `reqSignerHashesTxBodyL`
+  * `referenceInputsTxBodyL`
+  * `votingProceduresTxBodyL`
+  * `proposalProceduresTxBodyL`
 * Add `reorderActions`, `actionPriority`
 * Remove `ensProtVer` field from `EnactState`: #3705
 * Move `ConwayEraTxBody` to `Cardano.Ledger.Conway.TxBody`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -69,7 +69,7 @@ library
         aeson,
         bytestring,
         cardano-crypto-class,
-        cardano-ledger-binary >=1.1,
+        cardano-ledger-binary >=1.1.3,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.4.1,
         cardano-ledger-babbage >=1.4.1,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -242,7 +242,7 @@ instance
       bodyFields 22 =
         ofield
           (\x tx -> tx {ctbrTreasuryDonation = fromSMaybe zero x})
-          (D (decodePositiveCoin $ emptyFailure "Treasury Donation" "non-empty"))
+          (D (decodePositiveCoin $ emptyFailure "Treasury Donation" "non-zero"))
       bodyFields n = field (\_ t -> t) (Invalid n)
       requiredFields :: [(Word, String)]
       requiredFields =

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -51,26 +51,26 @@ major_protocol_version = 1..next_major_protocol_version
 protocol_version = (major_protocol_version, uint)
 
 transaction_body =
-  { 0 : set<transaction_input>      ; inputs
+  { 0 : set<transaction_input>             ; inputs
   , 1 : [* transaction_output]
-  , 2 : coin                        ; fee
-  , ? 3 : uint                      ; time to live
-  , ? 4 : [* certificate]
+  , 2 : coin                               ; fee
+  , ? 3 : uint                             ; time to live
+  , ? 4 : [+ certificate]
   , ? 5 : withdrawals
   , ? 7 : auxiliary_data_hash
-  , ? 8 : uint                      ; validity interval start
+  , ? 8 : uint                             ; validity interval start
   , ? 9 : mint
   , ? 11 : script_data_hash
-  , ? 13 : set<transaction_input>   ; collateral inputs
+  , ? 13 : nonempty_set<transaction_input> ; collateral inputs
   , ? 14 : required_signers
   , ? 15 : network_id
-  , ? 16 : transaction_output       ; collateral return
-  , ? 17 : coin                     ; total collateral
-  , ? 18 : set<transaction_input>   ; reference inputs
-  , ? 19 : voting_procedures        ; New; Voting procedures
-  , ? 20 : [* proposal_procedure]   ; New; Proposal procedures
-  , ? 21 : coin                     ; New; current treasury value
-  , ? 22 : positive_coin            ; New; donation
+  , ? 16 : transaction_output              ; collateral return
+  , ? 17 : coin                            ; total collateral
+  , ? 18 : nonempty_set<transaction_input> ; reference inputs
+  , ? 19 : voting_procedures               ; New; Voting procedures
+  , ? 20 : [+ proposal_procedure]          ; New; Proposal procedures
+  , ? 21 : coin                            ; New; current treasury value
+  , ? 22 : positive_coin                   ; New; donation
   }
 
 voting_procedures = { + voter => { + gov_action_id => voting_procedure } }
@@ -146,7 +146,7 @@ gov_action_id =
   , gov_action_index : uint
   ]
 
-required_signers = set<$addr_keyhash>
+required_signers = nonempty_set<$addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
                     , index : uint
@@ -370,7 +370,7 @@ relay =
 pool_metadata = [url, pool_metadata_hash]
 url = tstr .size (0..64)
 
-withdrawals = { * reward_account => coin }
+withdrawals = { + reward_account => coin }
 
 protocol_param_update =
   { ? 0:  uint                   ; minfee A

--- a/eras/conway/test-suite/cddl-files/mock/extras.cddl
+++ b/eras/conway/test-suite/cddl-files/mock/extras.cddl
@@ -1,6 +1,8 @@
 set<a> = [a]
   ; real set is [* a]
 
+nonempty_set<a> = [+ a]
+
 unit_interval = #6.30([1, 2])
   ; real unit_interval is: #6.30([uint, uint])
   ; but this produces numbers outside the unit interval

--- a/eras/conway/test-suite/cddl-files/real/extras.cddl
+++ b/eras/conway/test-suite/cddl-files/real/extras.cddl
@@ -1,4 +1,6 @@
-finite_set<a> = [* a ]
+finite_set<a> = [* a]
+
+nonempty_finite_set<a> = [+ a]
 
 unit_interval = #6.30([uint, uint])
 

--- a/eras/conway/test-suite/test/Tests.hs
+++ b/eras/conway/test-suite/test/Tests.hs
@@ -19,7 +19,7 @@ defaultTests =
   testGroup
     "Conway tests"
     [ Roundtrip.allprops @Conway
-    , CDDL.tests 5
+    , CDDL.tests 10
     , Babbage.txInfoTests (Proxy @Conway)
     , Conway.txInfoTests (Proxy @Conway)
     , govSnapshotProps

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-binary`
 
-## 1.1.2.1
+## 1.1.3.0
 
-*
+* Add `fieldGuarded` to be able to conditionally construct a `Field` #3712
 
 ## 1.1.2.0
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.1.2.1
+version:       1.1.3.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
# Disallow empty fields in ConwayTxBodyRaw

- Fix `ConwayTxBodyRaw` decoder to disallow empty
  - `certsTxBodyL`
  - `withdrawalsTxBodyL`
  - `mintTxBodyL`
  - `collateralInputsTxBodyL`
  - `reqSignerHashesTxBodyL`
  - `referenceInputsTxBodyL`
  - `votingProceduresTxBodyL`
  - `proposalProceduresTxBodyL`
- Add `fieldGuarded` to conditionally construct a `Field`
- Fix the related CDDL for Conway

Closes #3707 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
