### PR TITLE
Improve CI resiliency against GitHub issues

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -112,7 +112,15 @@ jobs:
         REF=a31ac75
         curl -L https://github.com/input-output-hk/cardano-mainnet-mirror/tarball/$REF -o mainnet-mirror.tgz
         tar -xzf mainnet-mirror.tgz
-        mv input-output-hk-cardano-mainnet-mirror-$REF/epochs .
+        if [ "$?" == 0 ]; then
+          mv input-output-hk-cardano-mainnet-mirror-$REF/epochs .
+        else
+          git clone https://github.com/input-output-hk/cardano-mainnet-mirror
+          cd cardano-mainnet-mirror
+          git checkout $REF
+          mv epochs ..
+          cd ..
+        fi
 
     - name: Run tests
       run: |


### PR DESCRIPTION
# Description

Recently we've been getting a lot of CI failures due to:
```
gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
```
when downloading a tarball of a repo.

This PR works around it by falling back to a slower `git clone`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
