### PR TITLE
Implement the remaining upgradable families

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.3.0
 
+* Add `ToExpr` instance for `AllegraTxBody`
 * Add `EraTransition` instance.
 
 ## 1.2.2.0

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -103,4 +103,5 @@ test-suite tests
         cardano-ledger-core:testlib,
         cardano-ledger-allegra,
         cardano-ledger-shelley:testlib,
+        data-default-class,
         testlib

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -54,7 +54,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6.1 && <1.8,
+        cardano-ledger-core >=1.7 && <1.8,
         cardano-ledger-shelley >=1.6.1 && <1.7,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
@@ -19,11 +19,11 @@ import Cardano.Ledger.Allegra.Scripts (Timelock, evalTimelock)
 import Cardano.Ledger.Allegra.TxAuxData ()
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..))
 import Cardano.Ledger.Allegra.TxWits ()
-import Cardano.Ledger.Core (EraTx (..), EraTxWits (..), PhasedScript (..))
+import Cardano.Ledger.Core (EraTx (..), EraTxAuxData (upgradeTxAuxData), EraTxWits (..), PhasedScript (..), upgradeTxBody)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
 import Cardano.Ledger.Shelley.Tx (
-  ShelleyTx,
+  ShelleyTx (..),
   auxDataShelleyTxL,
   bodyShelleyTxL,
   mkBasicShelleyTx,
@@ -59,6 +59,12 @@ instance Crypto c => EraTx (AllegraEra c) where
   {-# INLINE validateScript #-}
 
   getMinFeeTx = shelleyMinFeeTx
+
+  upgradeTx (ShelleyTx txb txwits txAux) =
+    ShelleyTx
+      <$> upgradeTxBody txb
+      <*> pure (upgradeTxWits txwits)
+      <*> pure (fmap upgradeTxAuxData txAux)
 
 -- =======================================================
 -- Validating timelock scripts

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash, hashAnnotated)
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum, ShelleyTxAuxData (..), validMetadatum)
-import Cardano.Ledger.TreeDiff (ToExpr)
+import Cardano.Ledger.TreeDiff (ToExpr (..))
 import Codec.CBOR.Decoding (
   TokenType (
     TypeListLen,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -81,6 +81,7 @@ import Cardano.Ledger.Shelley.TxBody (
   Withdrawals (..),
   totalTxDepositsShelley,
  )
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import qualified Data.Map.Strict as Map
@@ -120,6 +121,14 @@ deriving instance Generic (AllegraTxBodyRaw ma era)
 deriving instance
   (Era era, NoThunks (TxOut era), NoThunks (TxCert era), NoThunks (PParamsUpdate era), NoThunks ma) =>
   NoThunks (AllegraTxBodyRaw ma era)
+
+instance
+  ( ToExpr ma
+  , ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (AllegraTxBodyRaw ma era)
 
 instance (DecCBOR ma, Monoid ma, AllegraEraTxBody era) => DecCBOR (AllegraTxBodyRaw ma era) where
   decCBOR =
@@ -230,6 +239,13 @@ deriving newtype instance
   , Era era
   ) =>
   NFData (AllegraTxBody era)
+
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (AllegraTxBody era)
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (AllegraTxBody era)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -37,5 +36,8 @@ instance Crypto c => EraTxWits (AllegraEra c) where
   scriptTxWitsL = scriptShelleyTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-  upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
-    ShelleyTxWits addrWits (fmap upgradeScript scriptWits) bootWits
+  upgradeTxWits stw =
+    ShelleyTxWits
+      (addrWits stw)
+      (upgradeScript <$> scriptWits stw)
+      (bootWits stw)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxWits.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -11,10 +12,10 @@ module Cardano.Ledger.Allegra.TxWits () where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.TxAuxData ()
-import Cardano.Ledger.Core (EraTxWits (..))
+import Cardano.Ledger.Core (EraScript (upgradeScript), EraTxWits (..))
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Shelley.TxWits (
-  ShelleyTxWits,
+  ShelleyTxWits (..),
   addrShelleyTxWitsL,
   bootAddrShelleyTxWitsL,
   scriptShelleyTxWitsL,
@@ -35,3 +36,6 @@ instance Crypto c => EraTxWits (AllegraEra c) where
 
   scriptTxWitsL = scriptShelleyTxWitsL
   {-# INLINE scriptTxWitsL #-}
+
+  upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
+    ShelleyTxWits addrWits (fmap upgradeScript scriptWits) bootWits

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -3,6 +3,7 @@
 module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra
+import Data.Default.Class (def)
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary (specUpgrade)
@@ -10,6 +11,6 @@ import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
 
 spec :: Spec
 spec = do
-  specUpgrade @Allegra True
+  specUpgrade @Allegra def
   describe "RoundTrip" $ do
     roundTripShelleyCommonSpec @Allegra

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 1.4.2.0
 
+* Add `ToExpr` instance for:
+  * `PlutusData`
+  * `Data`
+  * `BinaryData`
+  * `Datum`
+  * `AlonzoTx`
+  * `AlonzoTxBody`
+  * `AlonzoTxOut`
+  * `AlozoTxWits`
+  * `IsValid`
+  * `Addr28Extra`
+  * `DataHash32`
+  * `RdmrPtr`
+  * `Redeemers`
+* Add `Generic` instance for :
+  * `AlonzoTxBody`
+  * `Redeemers`
+  * `TxDats`
+* Add `upgradeData`, `upgradeRedeemers` and `upgradeTxDats`
+* Add `TxUpgradeError` type to `EraTx`
+* Add `AlonzoTxBodyUpgradeError`, `AlonzoTxUpgradeError`
 * Add `toAlonzoTransitionConfigPairs` and `EraTransition` instance.
 * Rename `alonzoGenesisAesonPairs` -> `toAlonzoGenesisPairs` for consistency.
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -68,7 +68,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.6.1 && <1.8,
+        cardano-ledger-core >=1.7 && <1.8,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.6.1,
         cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts/Data.hs
@@ -23,6 +23,7 @@
 module Cardano.Ledger.Alonzo.Scripts.Data (
   Data (Data),
   DataHash,
+  upgradeData,
   hashData,
   getPlutusData,
   dataHashSize,
@@ -76,7 +77,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON (..), Value (Null))
 import Data.ByteString.Lazy (fromStrict)
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
-import Data.Coerce
+import Data.Coerce (coerce)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
@@ -124,6 +125,12 @@ pattern Data p <- (getMemoRawType -> PlutusData p)
     Data p = mkMemoized $ PlutusData p
 
 {-# COMPLETE Data #-}
+
+-- | Upgrade 'Data' from one era to another. While the underlying data will
+-- remain the same, the memoised serialisation may change to reflect the
+-- versioned serialisation of the new era.
+upgradeData :: (Era era1, Era era2) => Data era1 -> Data era2
+upgradeData (Data d) = Data d
 
 getPlutusData :: Data era -> PV1.Data
 getPlutusData (getMemoRawType -> PlutusData d) = d

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -80,7 +80,6 @@ where
 
 import Cardano.Crypto.Hash.Class (HashAlgorithm)
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
-import Cardano.Ledger.Allegra.Core ()
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
 import Cardano.Ledger.Alonzo.Core (AlonzoEraPParams, ppPricesL)
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
@@ -133,7 +132,7 @@ import Cardano.Ledger.Language (nonNativeLanguages)
 import Cardano.Ledger.Mary.Value (AssetName, MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.SafeHash (HashAnnotated, SafeToHash (..), hashAnnotated)
-import Cardano.Ledger.Shelley.Tx (shelleyEqTxRaw)
+import Cardano.Ledger.Shelley.Tx (ShelleyTx (ShelleyTx), shelleyEqTxRaw)
 import Cardano.Ledger.Shelley.TxBody (Withdrawals (..), unWithdrawals)
 import Cardano.Ledger.TxIn (TxIn (..))
 import qualified Cardano.Ledger.UTxO as Shelley
@@ -196,6 +195,13 @@ instance Crypto c => EraTx (AlonzoEra c) where
 
   getMinFeeTx = alonzoMinFeeTx
   {-# INLINE getMinFeeTx #-}
+
+  upgradeTx (ShelleyTx body wits aux) =
+    AlonzoTx
+      <$> upgradeTxBody body
+      <*> pure (upgradeTxWits wits)
+      <*> pure (IsValid True)
+      <*> pure (fmap upgradeTxAuxData aux)
 
 instance (Tx era ~ AlonzoTx era, AlonzoEraTx era) => EqRaw (AlonzoTx era) where
   eqRaw = alonzoEqTxRaw

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -154,6 +154,7 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Lens.Micro hiding (set)
 import NoThunks.Class (NoThunks)
+import Cardano.Ledger.TreeDiff (ToExpr)
 
 -- ===================================================
 
@@ -161,7 +162,7 @@ import NoThunks.Class (NoThunks)
 -- to validate. This is added by the block creator when constructing the block.
 newtype IsValid = IsValid Bool
   deriving (Eq, Show, Generic)
-  deriving newtype (NoThunks, NFData, ToCBOR, EncCBOR, DecCBOR)
+  deriving newtype (NoThunks, NFData, ToCBOR, EncCBOR, DecCBOR, ToExpr)
 
 data AlonzoTx era = AlonzoTx
   { body :: !(TxBody era)
@@ -170,6 +171,9 @@ data AlonzoTx era = AlonzoTx
   , auxiliaryData :: !(StrictMaybe (TxAuxData era))
   }
   deriving (Generic)
+
+instance (ToExpr (TxBody era), ToExpr (TxWits era), ToExpr (TxAuxData era)) =>
+  ToExpr (AlonzoTx era)
 
 instance Crypto c => EraTx (AlonzoEra c) where
   {-# SPECIALIZE instance EraTx (AlonzoEra StandardCrypto) #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -109,7 +109,7 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
-import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update)
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
 import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
@@ -122,6 +122,8 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
+import Cardano.Ledger.TreeDiff (ToExpr)
+import Cardano.Ledger.Mary.Value ()
 
 -- ======================================
 
@@ -158,12 +160,20 @@ deriving instance
   (Era era, Show (TxOut era), Show (TxCert era), Show (PParamsUpdate era)) =>
   Show (AlonzoTxBodyRaw era)
 
+instance
+  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
+  ToExpr (AlonzoTxBodyRaw era)
+
 newtype AlonzoTxBody era = TxBodyConstr (MemoBytes AlonzoTxBodyRaw era)
-  deriving (ToCBOR)
+  deriving (ToCBOR, Generic)
   deriving newtype (SafeToHash)
 
 instance Memoized AlonzoTxBody where
   type RawType AlonzoTxBody = AlonzoTxBodyRaw
+
+instance
+  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
+  ToExpr (AlonzoTxBody era)
 
 instance Crypto c => EraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance EraTxBody (AlonzoEra StandardCrypto) #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -74,6 +74,7 @@ import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential (..), PaymentCredential, StakeReference (..))
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.Mary.Value (ToExpr)
 import Cardano.Ledger.SafeHash (
   extractHash,
   unsafeMakeSafeHash,
@@ -103,6 +104,8 @@ data Addr28Extra
       {-# UNPACK #-} !Word64 -- Payment Addr (32bits) + ... +  0/1 for Testnet/Mainnet + 0/1 Script/Pubkey
   deriving (Eq, Generic, NoThunks)
 
+instance ToExpr Addr28Extra
+
 data DataHash32
   = DataHash32
       {-# UNPACK #-} !Word64 -- DataHash
@@ -110,6 +113,8 @@ data DataHash32
       {-# UNPACK #-} !Word64 -- DataHash
       {-# UNPACK #-} !Word64 -- DataHash
   deriving (Eq, Generic, NoThunks)
+
+instance ToExpr DataHash32
 
 decodeAddress28 ::
   forall c.
@@ -155,6 +160,8 @@ deriving instance Generic (AlonzoTxOut era)
 -- | Already in NF
 instance NFData (AlonzoTxOut era) where
   rnf = rwhnf
+
+instance ToExpr (CompactForm (Value era)) => ToExpr (AlonzoTxOut era)
 
 addressErrorMsg :: String
 addressErrorMsg = "Impossible: Compacted an address of non-standard size"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
@@ -24,7 +25,9 @@ module Cardano.Ledger.Alonzo.TxWits (
   Redeemers (Redeemers),
   unRedeemers,
   nullRedeemers,
+  upgradeRedeemers,
   TxDats (TxDats, TxDats'),
+  upgradeTxDats,
   AlonzoTxWits (
     AlonzoTxWits,
     txwitsVKey,
@@ -56,7 +59,7 @@ import Cardano.Crypto.DSIGN.Class (SigDSIGN, VerKeyDSIGN)
 import Cardano.Crypto.Hash.Class (HashAlgorithm)
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..), Tag)
-import Cardano.Ledger.Alonzo.Scripts.Data (Data, hashData)
+import Cardano.Ledger.Alonzo.Scripts.Data (Data, hashData, upgradeData)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
@@ -87,8 +90,9 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (SafeToHash (..))
 import Cardano.Ledger.Shelley.TxBody (WitVKey)
-import Cardano.Ledger.Shelley.TxWits (keyBy, shelleyEqTxWitsRaw)
+import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..), keyBy, shelleyEqTxWitsRaw)
 import Control.DeepSeq (NFData)
+import Data.Bifunctor (Bifunctor (first))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -178,6 +182,18 @@ unRedeemers (Redeemers rs) = rs
 
 nullRedeemers :: Era era => Redeemers era -> Bool
 nullRedeemers = Map.null . unRedeemers
+
+emptyRedeemers :: Era era => Redeemers era
+emptyRedeemers = Redeemers mempty
+
+-- | Upgrade redeemers from one era to another. The underlying data structure
+-- will remain identical, but the memoised serialisation may change to reflect
+-- the versioned serialisation of the new era.
+upgradeRedeemers :: (Era era1, Era era2) => Redeemers era1 -> Redeemers era2
+upgradeRedeemers (Redeemers m) =
+  Redeemers m'
+  where
+    m' = fmap (first upgradeData) m
 
 -- ====================================================================
 -- In the Spec, AlonzoTxWits has 4 logical fields. Here in the implementation
@@ -306,6 +322,15 @@ deriving via
   instance
     Era era => DecCBOR (Annotator (TxDats era))
 
+-- | Upgrade 'TxDats' from one era to another. The underlying data structure
+-- will remain identical, but the memoised serialisation may change to reflect
+-- the versioned serialisation of the new era.
+upgradeTxDats ::
+  (Era era1, Era era2, EraCrypto era1 ~ EraCrypto era2) =>
+  TxDats era1 ->
+  TxDats era2
+upgradeTxDats (TxDats datMap) = TxDats $ fmap upgradeData datMap
+
 -- =====================================================
 -- AlonzoTxWits instances
 
@@ -422,6 +447,9 @@ instance (EraScript (AlonzoEra c), Crypto c) => EraTxWits (AlonzoEra c) where
 
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
+
+  upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
+    AlonzoTxWits addrWits bootWits (upgradeScript <$> scriptWits) mempty emptyRedeemers
 
 class EraTxWits era => AlonzoEraTxWits era where
   datsTxWitsL :: Lens' (TxWits era) (TxDats era)
@@ -554,7 +582,6 @@ instance
         []
     where
       emptyTxWitness = AlonzoTxWitsRaw mempty mempty mempty mempty emptyRedeemers
-      emptyRedeemers = Redeemers mempty
 
       txWitnessField :: Word -> Field (Annotator (AlonzoTxWitsRaw era))
       txWitnessField 0 =

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
@@ -8,14 +8,16 @@ import Cardano.Ledger.Alonzo.Scripts
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary (BinaryUpgradeOpts (..), specUpgrade)
 import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
 spec = do
-  -- Scripts are not upgradeable from Mary through their CBOR instances, since Mary had no
-  -- concept of a prefix.
-  specUpgrade @Alonzo False
+  -- Scripts are not upgradeable from Mary through their CBOR instances, since
+  -- Mary had no concept of a prefix.
+  -- Transactions are also not upgradeable through deserialisation, though we
+  -- check them via the translateEra method
+  specUpgrade @Alonzo (BinaryUpgradeOpts False False)
   describe "RoundTrip" $ do
     roundTripAlonzoCommonSpec @Alonzo
     -- AlonzoGenesis only makes sense in Alonzo era

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.4.5.0
 
+* Add `ToExpr` instance for:
+  * `BabbageTxBody`
+  * `BabbageTxOut`
+* Add `Generic` instance for `BabbageTxBody`
+* Add `BabbageTxUpgradeError` and `BabbageTxBodyUpgradeError`
 * Add `EraTransition` instance.
 
 ## 1.4.4.0

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -63,7 +63,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.4.2,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6.1 && <1.8,
+        cardano-ledger-core >=1.7 && <1.8,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.6,
         cardano-slotting,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -115,4 +115,5 @@ test-suite tests
         cardano-ledger-babbage,
         cardano-ledger-core:testlib,
         cardano-ledger-alonzo:testlib,
+        data-default-class,
         testlib

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -512,11 +512,14 @@ upgradeBabbagePParams updateCoinsPerUTxOWord AlonzoPParams {..} =
     , bppTau = appTau
     , bppProtocolVersion = appProtocolVersion
     , bppMinPoolCost = appMinPoolCost
-    , bppCoinsPerUTxOByte = hkdMap (Proxy @f)
-        (if updateCoinsPerUTxOWord then
-          coinsPerUTxOWordToCoinsPerUTxOByte else
-          coinsPerUTxOWordToCoinsPerUTxOByteInTx)
-        appCoinsPerUTxOWord
+    , bppCoinsPerUTxOByte =
+        hkdMap
+          (Proxy @f)
+          ( if updateCoinsPerUTxOWord
+              then coinsPerUTxOWordToCoinsPerUTxOByte
+              else coinsPerUTxOWordToCoinsPerUTxOByteInTx
+          )
+          appCoinsPerUTxOWord
     , bppCostModels = appCostModels
     , bppPrices = appPrices
     , bppMaxTxExUnits = appMaxTxExUnits

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -492,7 +492,6 @@ babbagePParamsHKDPairs px pp =
 upgradeBabbagePParams ::
   forall f c.
   HKDFunctor f =>
-  -- | Should we update the
   Bool ->
   PParamsHKD f (AlonzoEra c) ->
   BabbagePParams f (BabbageEra c)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -69,6 +69,13 @@ instance Crypto c => EraTx (BabbageEra c) where
 
   getMinFeeTx = alonzoMinFeeTx
 
+  upgradeTx (AlonzoTx b w valid aux) =
+    AlonzoTx
+      <$> upgradeTxBody b
+      <*> pure (upgradeTxWits w)
+      <*> pure valid
+      <*> pure (fmap upgradeTxAuxData aux)
+
 instance Crypto c => AlonzoEraTx (BabbageEra c) where
   {-# SPECIALIZE instance AlonzoEraTx (BabbageEra StandardCrypto) #-}
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -30,7 +30,8 @@ import Cardano.Ledger.Babbage.TxBody (
   BabbageEraTxBody (..),
   BabbageEraTxOut (..),
   BabbageTxBody (..),
-  dataHashTxOutL, BabbageTxBodyUpgradeError,
+  BabbageTxBodyUpgradeError,
+  dataHashTxOutL,
  )
 import Cardano.Ledger.Babbage.TxWits ()
 import Cardano.Ledger.Core
@@ -38,16 +39,16 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Control.Applicative ((<|>))
+import Control.Arrow (left)
 import Control.SetAlgebra (eval, (◁))
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (SJust, SNothing), strictMaybeToMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro
-import Control.Arrow (left)
 
-newtype  BabbageTxUpgradeError =
-  BTUEBodyUpgradeError BabbageTxBodyUpgradeError
+newtype BabbageTxUpgradeError
+  = BTUEBodyUpgradeError BabbageTxBodyUpgradeError
   deriving (Eq, Show)
 
 instance Crypto c => EraTx (BabbageEra c) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -155,6 +155,7 @@ import Cardano.Ledger.MemoBytes (
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
 import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData)
 import Data.Sequence.Strict (StrictSeq, (|>))
@@ -207,12 +208,16 @@ instance
   (Era era, NFData (TxOut era), NFData (TxCert era), NFData (PParamsUpdate era)) =>
   NFData (BabbageTxBodyRaw era)
 
+instance
+  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
+  ToExpr (BabbageTxBodyRaw era)
+
 deriving instance
   (Era era, Show (TxOut era), Show (TxCert era), Show (PParamsUpdate era)) =>
   Show (BabbageTxBodyRaw era)
 
 newtype BabbageTxBody era = TxBodyConstr (MemoBytes BabbageTxBodyRaw era)
-  deriving newtype (SafeToHash, ToCBOR)
+  deriving newtype (Generic, SafeToHash, ToCBOR)
 
 instance Memoized BabbageTxBody where
   type RawType BabbageTxBody = BabbageTxBodyRaw
@@ -220,6 +225,10 @@ instance Memoized BabbageTxBody where
 deriving newtype instance
   (Era era, NFData (TxOut era), NFData (TxCert era), NFData (PParamsUpdate era)) =>
   NFData (BabbageTxBody era)
+
+instance
+  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
+  ToExpr (BabbageTxBody era)
 
 inputsBabbageTxBodyL ::
   BabbageEraTxBody era => Lens' (BabbageTxBody era) (Set (TxIn (EraCrypto era)))

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -105,7 +105,10 @@ import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto (Crypto (ADDRHASH), StandardCrypto)
 import Cardano.Ledger.Keys (KeyRole (..))
-import Cardano.Ledger.TreeDiff (ToExpr)
+import Cardano.Ledger.TreeDiff (
+  Expr (App),
+  ToExpr (toExpr),
+ )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (rnf), rwhnf)
 import Control.Monad ((<$!>))
@@ -148,7 +151,16 @@ data BabbageTxOut era
       {-# UNPACK #-} !DataHash32
   deriving (Generic)
 
-instance (ToExpr (CompactForm (Value era)), ToExpr (BinaryData era), ToExpr (Datum era), ToExpr (Script era)) => ToExpr (BabbageTxOut era)
+instance
+  ( EraTxOut era
+  , ToExpr (Value era)
+  , ToExpr (BinaryData era)
+  , ToExpr (Datum era)
+  , ToExpr (Script era)
+  ) =>
+  ToExpr (BabbageTxOut era)
+  where
+  toExpr (BabbageTxOut addr val dat sc) = App "BabbageTxOut" [toExpr addr, toExpr val, toExpr dat, toExpr sc]
 
 instance Crypto c => EraTxOut (BabbageEra c) where
   {-# SPECIALIZE instance EraTxOut (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -105,6 +105,7 @@ import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto (Crypto (ADDRHASH), StandardCrypto)
 import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (rnf), rwhnf)
 import Control.Monad ((<$!>))
@@ -146,6 +147,8 @@ data BabbageTxOut era
       {-# UNPACK #-} !(CompactForm Coin) -- Ada value
       {-# UNPACK #-} !DataHash32
   deriving (Generic)
+
+instance (ToExpr (CompactForm (Value era)), ToExpr (BinaryData era), ToExpr (Datum era), ToExpr (Script era)) => ToExpr (BabbageTxOut era)
 
 instance Crypto c => EraTxOut (BabbageEra c) where
   {-# SPECIALIZE instance EraTxOut (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -44,13 +43,13 @@ instance Crypto c => EraTxWits (BabbageEra c) where
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-  upgradeTxWits (AlonzoTxWits {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs}) =
+  upgradeTxWits atw =
     AlonzoTxWits
-      { txwitsVKey
-      , txwitsBoot
-      , txscripts = upgradeScript <$> txscripts
-      , txdats = upgradeTxDats txdats
-      , txrdmrs = upgradeRedeemers txrdmrs
+      { txwitsVKey = txwitsVKey atw
+      , txwitsBoot = txwitsBoot atw
+      , txscripts = upgradeScript <$> txscripts atw
+      , txdats = upgradeTxDats (txdats atw)
+      , txrdmrs = upgradeRedeemers (txrdmrs atw)
       }
 
 instance Crypto c => AlonzoEraTxWits (BabbageEra c) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxWits.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -21,6 +20,8 @@ import Cardano.Ledger.Alonzo.TxWits (
 import Cardano.Ledger.Alonzo.TxWits as BabbageTxWitsReExport (
   AlonzoEraTxWits (..),
   AlonzoTxWits (..),
+  upgradeRedeemers,
+  upgradeTxDats,
  )
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.TxBody ()
@@ -42,6 +43,15 @@ instance Crypto c => EraTxWits (BabbageEra c) where
 
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
+
+  upgradeTxWits (AlonzoTxWits {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs}) =
+    AlonzoTxWits
+      { txwitsVKey
+      , txwitsBoot
+      , txscripts = upgradeScript <$> txscripts
+      , txdats = upgradeTxDats txdats
+      , txrdmrs = upgradeRedeemers txrdmrs
+      }
 
 instance Crypto c => AlonzoEraTxWits (BabbageEra c) where
   {-# SPECIALIZE instance AlonzoEraTxWits (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
@@ -4,6 +4,7 @@ module Test.Cardano.Ledger.Babbage.BinarySpec (spec) where
 
 import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Babbage
+import Data.Default.Class (def)
 import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
@@ -12,7 +13,7 @@ import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
 spec = do
-  specUpgrade @Babbage True
+  specUpgrade @Babbage def
   describe "RoundTrip" $ do
     roundTripAlonzoCommonSpec @Babbage
     -- CostModel serialization changes drastically for Conway, which requires a different

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Version history for `cardano-ledger-conway`
 
 ## 1.9.0.0
+* Add  `ConwayEraPParams era` constraint to `isCommitteeVotingAllowed` and `votingCommitteeThreshold`
+* Add `ToExpr` instance for:
+  * `Voter`
+  * `VotingProcedures`
+  * `VotingProcedure`
+  * `ProposalProcedure`
+  * `ConwayTxBody`
+* Add `ConwayTxBodyUpgradeError`, `ConwayTxCertUpgradeError`
 * Add to `Ratify`:
   * `committeeAccepted`
   * `committeeAcceptedRatio`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -265,6 +265,8 @@ data Voter c
 
 instance Crypto c => ToJSON (Voter c)
 
+instance Crypto c => ToExpr (Voter c)
+
 instance Crypto c => ToJSONKey (Voter c) where
   toJSONKey = toJSONKeyText $ \case
     CommitteeVoter cred ->
@@ -330,6 +332,8 @@ newtype VotingProcedures era = VotingProcedures
 
 deriving newtype instance Era era => NFData (VotingProcedures era)
 
+instance Era era => ToExpr (VotingProcedures era)
+
 instance Era era => DecCBOR (VotingProcedures era) where
   decCBOR =
     fmap VotingProcedures $ decodeMapByKey decCBOR $ \voter -> do
@@ -347,6 +351,7 @@ data VotingProcedure era = VotingProcedure
   deriving (Generic, Eq, Show)
 
 instance NoThunks (VotingProcedure era)
+instance ToExpr (VotingProcedure era)
 
 instance Crypto (EraCrypto era) => NFData (VotingProcedure era)
 
@@ -412,6 +417,8 @@ pProcDepositL = lens pProcDeposit (\p x -> p {pProcDeposit = x})
 instance EraPParams era => NoThunks (ProposalProcedure era)
 
 instance EraPParams era => NFData (ProposalProcedure era)
+
+instance EraPParams era => ToExpr (ProposalProcedure era)
 
 instance EraPParams era => DecCBOR (ProposalProcedure era) where
   decCBOR =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Tx (
@@ -37,6 +38,7 @@ instance Crypto c => EraTx (ConwayEra c) where
   {-# SPECIALIZE instance EraTx (ConwayEra StandardCrypto) #-}
 
   type Tx (ConwayEra c) = AlonzoTx (ConwayEra c)
+  type TxUpgradeError (ConwayEra c) = TxBodyUpgradeError (ConwayEra c)
 
   mkBasicTx = mkBasicAlonzoTx
 
@@ -56,6 +58,13 @@ instance Crypto c => EraTx (ConwayEra c) where
   {-# INLINE validateScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
+
+  upgradeTx (AlonzoTx b w valid aux) =
+    AlonzoTx
+      <$> upgradeTxBody b
+      <*> pure (upgradeTxWits w)
+      <*> pure valid
+      <*> pure (fmap upgradeTxAuxData aux)
 
 instance Crypto c => AlonzoEraTx (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTx (ConwayEra StandardCrypto) #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -120,6 +120,7 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', to, (^.))
 import NoThunks.Class (NoThunks)
+import Cardano.Ledger.TreeDiff (ToExpr)
 
 instance Memoized ConwayTxBody where
   type RawType ConwayTxBody = ConwayTxBodyRaw
@@ -148,6 +149,7 @@ data ConwayTxBodyRaw era = ConwayTxBodyRaw
   deriving (Generic, Typeable)
 
 deriving instance (EraPParams era, Eq (TxOut era)) => Eq (ConwayTxBodyRaw era)
+instance (EraPParams era, ToExpr (TxOut era)) => ToExpr (ConwayTxBodyRaw era)
 
 instance
   (EraPParams era, NoThunks (TxOut era)) =>
@@ -275,6 +277,10 @@ deriving newtype instance
 deriving instance
   (EraPParams era, Show (TxOut era)) =>
   Show (ConwayTxBody era)
+
+deriving instance
+  (EraPParams era, ToExpr (TxOut era)) =>
+  ToExpr (ConwayTxBody era)
 
 type instance MemoHashIndex ConwayTxBodyRaw = EraIndependentTxBody
 
@@ -419,6 +425,7 @@ instance Crypto c => EraTxBody (ConwayEra c) where
           , ctbCurrentTreasuryValue = SNothing
           , ctbProposalProcedures = mempty
           , ctbVotingProcedures = VotingProcedures mempty
+          , ctbTreasuryDonation = Coin 0
           }
 
 instance

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -375,58 +374,40 @@ instance Crypto c => EraTxBody (ConwayEra c) where
   certsTxBodyL = lensMemoRawType ctbrCerts (\txb x -> txb {ctbrCerts = x})
   {-# INLINE certsTxBodyL #-}
 
-  upgradeTxBody
-    BabbageTxBody
-      { btbInputs
-      , btbOutputs
-      , btbCerts
-      , btbWithdrawals
-      , btbTxFee
-      , btbValidityInterval
-      , btbUpdate
-      , btbAuxDataHash
-      , btbMint
-      , btbCollateral
-      , btbReqSignerHashes
-      , btbScriptIntegrityHash
-      , btbTxNetworkId
-      , btbReferenceInputs
-      , btbCollateralReturn
-      , btbTotalCollateral
-      } = do
-      when (isSJust btbUpdate) $
-        Left CTBUEContainsUpdate
-      certs <- traverse (left CTBUETxCert . upgradeTxCert) btbCerts
-      pure $
-        ConwayTxBody
-          { ctbSpendInputs = btbInputs
-          , ctbOutputs =
-              mkSized (eraProtVerLow @(ConwayEra c))
-                . upgradeTxOut
-                . sizedValue
-                <$> btbOutputs
-          , ctbCerts = certs
-          , ctbWithdrawals = btbWithdrawals
-          , ctbTxfee = btbTxFee
-          , ctbVldt = btbValidityInterval
-          , ctbAdHash = btbAuxDataHash
-          , ctbMint = btbMint
-          , ctbCollateralInputs = btbCollateral
-          , ctbReqSignerHashes = btbReqSignerHashes
-          , ctbScriptIntegrityHash = btbScriptIntegrityHash
-          , ctbTxNetworkId = btbTxNetworkId
-          , ctbReferenceInputs = btbReferenceInputs
-          , ctbCollateralReturn =
-              mkSized (eraProtVerLow @(ConwayEra c))
-                . upgradeTxOut
-                . sizedValue
-                <$> btbCollateralReturn
-          , ctbTotalCollateral = btbTotalCollateral
-          , ctbCurrentTreasuryValue = SNothing
-          , ctbProposalProcedures = mempty
-          , ctbVotingProcedures = VotingProcedures mempty
-          , ctbTreasuryDonation = Coin 0
-          }
+  upgradeTxBody btb = do
+    when (isSJust (btbUpdate btb)) $
+      Left CTBUEContainsUpdate
+    certs <- traverse (left CTBUETxCert . upgradeTxCert) (btbCerts btb)
+    pure $
+      ConwayTxBody
+        { ctbSpendInputs = btbInputs btb
+        , ctbOutputs =
+            mkSized (eraProtVerLow @(ConwayEra c))
+              . upgradeTxOut
+              . sizedValue
+              <$> btbOutputs btb
+        , ctbCerts = certs
+        , ctbWithdrawals = btbWithdrawals btb
+        , ctbTxfee = btbTxFee btb
+        , ctbVldt = btbValidityInterval btb
+        , ctbAdHash = btbAuxDataHash btb
+        , ctbMint = btbMint btb
+        , ctbCollateralInputs = btbCollateral btb
+        , ctbReqSignerHashes = btbReqSignerHashes btb
+        , ctbScriptIntegrityHash = btbScriptIntegrityHash btb
+        , ctbTxNetworkId = btbTxNetworkId btb
+        , ctbReferenceInputs = btbReferenceInputs btb
+        , ctbCollateralReturn =
+            mkSized (eraProtVerLow @(ConwayEra c))
+              . upgradeTxOut
+              . sizedValue
+              <$> btbCollateralReturn btb
+        , ctbTotalCollateral = btbTotalCollateral btb
+        , ctbCurrentTreasuryValue = SNothing
+        , ctbProposalProcedures = mempty
+        , ctbVotingProcedures = VotingProcedures mempty
+        , ctbTreasuryDonation = Coin 0
+        }
 
 instance
   ( Crypto c

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -106,6 +106,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.Arrow (left)
@@ -120,7 +121,6 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', to, (^.))
 import NoThunks.Class (NoThunks)
-import Cardano.Ledger.TreeDiff (ToExpr)
 
 instance Memoized ConwayTxBody where
   type RawType ConwayTxBody = ConwayTxBodyRaw

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -14,6 +14,7 @@
 
 module Cardano.Ledger.Conway.TxCert (
   ConwayTxCert (..),
+  ConwayTxCertUpgradeError (..),
   ConwayDelegCert (..),
   ConwayGovCert (..),
   Delegatee (..),

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -42,13 +41,13 @@ instance Crypto c => EraTxWits (ConwayEra c) where
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-  upgradeTxWits (AlonzoTxWits {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs}) =
+  upgradeTxWits atw =
     AlonzoTxWits
-      { txwitsVKey
-      , txwitsBoot
-      , txscripts = upgradeScript <$> txscripts
-      , txdats = upgradeTxDats txdats
-      , txrdmrs = upgradeRedeemers txrdmrs
+      { txwitsVKey = txwitsVKey atw
+      , txwitsBoot = txwitsBoot atw
+      , txscripts = upgradeScript <$> txscripts atw
+      , txdats = upgradeTxDats (txdats atw)
+      , txrdmrs = upgradeRedeemers (txrdmrs atw)
       }
 
 instance Crypto c => AlonzoEraTxWits (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxWits.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -13,6 +14,8 @@ import Cardano.Ledger.Alonzo.TxWits (
   datsAlonzoTxWitsL,
   rdmrsAlonzoTxWitsL,
   scriptAlonzoTxWitsL,
+  upgradeRedeemers,
+  upgradeTxDats,
  )
 import Cardano.Ledger.Alonzo.TxWits as BabbageTxWitsReExport (
   AlonzoEraTxWits (..),
@@ -38,6 +41,15 @@ instance Crypto c => EraTxWits (ConwayEra c) where
 
   scriptTxWitsL = scriptAlonzoTxWitsL
   {-# INLINE scriptTxWitsL #-}
+
+  upgradeTxWits (AlonzoTxWits {txwitsVKey, txwitsBoot, txscripts, txdats, txrdmrs}) =
+    AlonzoTxWits
+      { txwitsVKey
+      , txwitsBoot
+      , txscripts = upgradeScript <$> txscripts
+      , txdats = upgradeTxDats txdats
+      , txrdmrs = upgradeRedeemers txrdmrs
+      }
 
 instance Crypto c => AlonzoEraTxWits (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTxWits (ConwayEra StandardCrypto) #-}

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
@@ -7,6 +7,7 @@ import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Genesis
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Crypto
+import Data.Default.Class (def)
 import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
@@ -16,7 +17,7 @@ import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
 spec = do
-  specUpgrade @Conway True
+  specUpgrade @Conway def
   describe "RoundTrip" $ do
     roundTripCborSpec @(GovActionId StandardCrypto)
     roundTripCborSpec @(PrevGovActionId 'PParamUpdatePurpose StandardCrypto)

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.3.4.0
 
+* Add `ToExpr` instance for:
+  * `MaryTxBody`
+  * `CompactForm (MaryValue)`
+  * `CompactValue`
+* Add `Generic` instance for `CompactValue`
 * Add `EraTransition` instance.
 
 ## 1.3.3.0

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -119,4 +119,5 @@ test-suite tests
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary,
         cardano-ledger-shelley:testlib,
+        data-default-class,
         testlib

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -60,7 +60,7 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6.1 && <1.8,
+        cardano-ledger-core >=1.7 && <1.8,
         cardano-ledger-shelley >=1.6.1 && <1.7,
         containers,
         deepseq,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -14,7 +14,13 @@ module Cardano.Ledger.Mary.Tx (
 where
 
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
-import Cardano.Ledger.Core (EraTx (..), PhasedScript (..))
+import Cardano.Ledger.Core (
+  EraTx (..),
+  PhasedScript (..),
+  upgradeTxAuxData,
+  upgradeTxBody,
+  upgradeTxWits,
+ )
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.PParams ()
@@ -22,7 +28,7 @@ import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody ()
 import Cardano.Ledger.Mary.TxWits ()
 import Cardano.Ledger.Shelley.Tx (
-  ShelleyTx,
+  ShelleyTx (..),
   auxDataShelleyTxL,
   bodyShelleyTxL,
   mkBasicShelleyTx,
@@ -56,3 +62,9 @@ instance Crypto c => EraTx (MaryEra c) where
   {-# INLINE validateScript #-}
 
   getMinFeeTx = shelleyMinFeeTx
+
+  upgradeTx (ShelleyTx txb txwits txAux) =
+    ShelleyTx
+      <$> upgradeTxBody txb
+      <*> pure (upgradeTxWits txwits)
+      <*> pure (fmap upgradeTxAuxData txAux)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -73,6 +73,13 @@ import NoThunks.Class (NoThunks (..))
 
 newtype MaryTxBodyRaw era = MaryTxBodyRaw (AllegraTxBodyRaw (MultiAsset (EraCrypto era)) era)
 
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (MaryTxBodyRaw era)
+
 deriving newtype instance
   (Era era, NFData (TxOut era), NFData (TxCert era), NFData (PParamsUpdate era)) =>
   NFData (MaryTxBodyRaw era)
@@ -102,6 +109,13 @@ instance Era era => EncCBOR (MaryTxBody era)
 instance
   (Era era, Eq (PParamsUpdate era), Eq (TxOut era), Eq (TxCert era)) =>
   EqRaw (MaryTxBody era)
+
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (MaryTxBody era)
 
 instance AllegraEraTxBody era => DecCBOR (Annotator (MaryTxBodyRaw era)) where
   decCBOR = pure <$> decCBOR

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -35,7 +35,6 @@ module Cardano.Ledger.Mary.TxBody (
 )
 where
 
-import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.TxBody
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR (..), ToCBOR (..))
@@ -58,7 +57,7 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
-import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (Update))
+import Cardano.Ledger.Shelley.PParams (Update, upgradeUpdate)
 import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
@@ -282,24 +281,10 @@ instance Crypto c => EraTxBody (MaryEra c) where
         , mtbWithdrawals = atbWithdrawals atb
         , mtbTxFee = atbTxFee atb
         , mtbValidityInterval = atbValidityInterval atb
-        , mtbUpdate = upgradeUpdate <$> atbUpdate atb
+        , mtbUpdate = upgradeUpdate () <$> atbUpdate atb
         , mtbAuxDataHash = atbAuxDataHash atb
         , mtbMint = mempty
         }
-    where
-      upgradeUpdate :: Update (AllegraEra c) -> Update (MaryEra c)
-      upgradeUpdate (Update pp epoch) = Update (upgradeProposedPPUpdates pp) epoch
-
-      upgradeProposedPPUpdates ::
-        ProposedPPUpdates (AllegraEra c) ->
-        ProposedPPUpdates (MaryEra c)
-      upgradeProposedPPUpdates (ProposedPPUpdates m) =
-        ProposedPPUpdates $
-          fmap
-            ( \(PParamsUpdate pphkd) ->
-                PParamsUpdate $ upgradePParamsHKD () pphkd
-            )
-            m
 
 instance Crypto c => ShelleyEraTxBody (MaryEra c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (MaryEra StandardCrypto) #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -37,5 +36,8 @@ instance Crypto c => EraTxWits (MaryEra c) where
   scriptTxWitsL = scriptShelleyTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
-  upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
-    ShelleyTxWits addrWits (fmap upgradeScript scriptWits) bootWits
+  upgradeTxWits stw =
+    ShelleyTxWits
+      (addrWits stw)
+      (upgradeScript <$> scriptWits stw)
+      (bootWits stw)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxWits.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -9,12 +10,12 @@
 
 module Cardano.Ledger.Mary.TxWits () where
 
-import Cardano.Ledger.Core (EraTxWits (..))
+import Cardano.Ledger.Core (EraTxWits (..), upgradeScript)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Shelley.TxWits (
-  ShelleyTxWits,
+  ShelleyTxWits (..),
   addrShelleyTxWitsL,
   bootAddrShelleyTxWitsL,
   scriptShelleyTxWitsL,
@@ -35,3 +36,6 @@ instance Crypto c => EraTxWits (MaryEra c) where
 
   scriptTxWitsL = scriptShelleyTxWitsL
   {-# INLINE scriptTxWitsL #-}
+
+  upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
+    ShelleyTxWits addrWits (fmap upgradeScript scriptWits) bootWits

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -417,7 +417,7 @@ instance ToJSONKey AssetName where
 
 instance Crypto c => Compactible (MaryValue c) where
   newtype CompactForm (MaryValue c) = CompactValue (CompactValue c)
-    deriving (Eq, Typeable, Show, NoThunks, EncCBOR, DecCBOR, NFData)
+    deriving (Eq, Typeable, Show, NoThunks, EncCBOR, DecCBOR, NFData, ToExpr)
   toCompact x = CompactValue <$> to x
   fromCompact (CompactValue x) = from x
 
@@ -439,13 +439,15 @@ data CompactValue c
       {-# UNPACK #-} !(CompactForm Coin) -- ada
       {-# UNPACK #-} !Word32 -- number of ma's
       {-# UNPACK #-} !ShortByteString -- rep
-  deriving (Show, Typeable)
+  deriving (Generic, Show, Typeable)
 
 instance NFData (CompactValue c) where
   rnf = rwhnf
 
 instance Crypto c => Eq (CompactValue c) where
   a == b = from a == from b
+
+instance ToExpr (CompactValue c)
 
 deriving via
   OnlyCheckWhnfNamed "CompactValue" (CompactValue c)

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -3,6 +3,7 @@
 module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
 
 import Cardano.Ledger.Mary
+import Data.Default.Class (def)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary (specUpgrade)
 import Test.Cardano.Ledger.Mary.Arbitrary ()
@@ -10,6 +11,6 @@ import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
 
 spec :: Spec
 spec = do
-  specUpgrade @Mary True
+  specUpgrade @Mary def
   describe "RoundTrip" $ do
     roundTripShelleyCommonSpec @Mary

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.6.1.0
 
+* Add `ToExpr` instance for:
+  * `Update`
+  * `ShelleyTx`
+  * `ShelleyTxBody`
+  * `ShelleyTxWits`
+* Add `Generic` instance for `ShelleyTx`
+* Add `Memoized` instance for `ShelleyTx`
 * Add lens `epochStateTreasuryL` #3748
 * Introduce `Cardano.Ledger.Shelley.Transition` module with `EraTransition` interface.
 * Deprecated `CanStartFromGenesis` interface in favor of `EraTransition`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -106,7 +106,7 @@ library
         cardano-data >=1.0,
         cardano-ledger-binary >=1.0,
         cardano-ledger-byron,
-        cardano-ledger-core >=1.6.1 && <1.8,
+        cardano-ledger-core >=1.7 && <1.8,
         cardano-slotting,
         vector-map >=1.0,
         containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -522,3 +522,5 @@ instance ToExpr (PParamsUpdate era) => ToExpr (ProposedPPUpdates era)
 instance ToExpr (ShelleyPParams StrictMaybe era)
 
 instance ToExpr (ShelleyPParams Identity era)
+
+instance ToExpr (PParamsUpdate era) => ToExpr (Update era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Shelley.PParams (
 
   -- * Deprecated
   updatePParams,
+  upgradeUpdate,
 )
 where
 
@@ -514,6 +515,28 @@ pvCanFollow :: ProtVer -> StrictMaybe ProtVer -> Bool
 pvCanFollow _ SNothing = True
 pvCanFollow (ProtVer m n) (SJust (ProtVer m' n')) =
   (succVersion m, 0) == (Just m', n') || (m, n + 1) == (m', n')
+
+upgradeUpdate ::
+  forall era.
+  ( EraPParams era
+  , EraPParams (PreviousEra era)
+  , EraCrypto (PreviousEra era) ~ EraCrypto era
+  ) =>
+  UpgradePParams StrictMaybe era ->
+  Update (PreviousEra era) ->
+  Update era
+upgradeUpdate args (Update pp epoch) = Update (upgradeProposedPPUpdates @era args pp) epoch
+
+upgradeProposedPPUpdates ::
+  ( EraPParams era
+  , EraPParams (PreviousEra era)
+  , EraCrypto (PreviousEra era) ~ EraCrypto era
+  ) =>
+  UpgradePParams StrictMaybe era ->
+  ProposedPPUpdates (PreviousEra era) ->
+  ProposedPPUpdates era
+upgradeProposedPPUpdates args (ProposedPPUpdates ppus) =
+  ProposedPPUpdates $ upgradePParamsUpdate args <$> ppus
 
 -- ==============================================
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -215,6 +215,8 @@ instance Crypto c => EraTx (ShelleyEra c) where
 
   getMinFeeTx = shelleyMinFeeTx
 
+  upgradeTx = error "Calling this function will cause a compilation error, since there is no Tx instance for Byron"
+
 instance (Tx era ~ ShelleyTx era, EraTx era) => EqRaw (ShelleyTx era) where
   eqRaw = shelleyEqTxRaw
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.MemoBytes (
   EqRaw (..),
   Mem,
   MemoBytes,
+  Memoized (..),
   memoBytes,
   mkMemoBytes,
   pattern Memo,
@@ -83,6 +84,7 @@ import Cardano.Ledger.Shelley.Scripts (MultiSig (..), nativeMultiSigTag)
 import Cardano.Ledger.Shelley.TxAuxData ()
 import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits ()
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.Val ((<+>), (<×>))
 import Control.DeepSeq (NFData)
@@ -143,8 +145,26 @@ instance
   ) =>
   NoThunks (ShelleyTxRaw era)
 
+instance
+  ( ToExpr (TxAuxData era)
+  , ToExpr (TxBody era)
+  , ToExpr (TxWits era)
+  ) =>
+  ToExpr (ShelleyTxRaw era)
+
 newtype ShelleyTx era = TxConstr (MemoBytes ShelleyTxRaw era)
   deriving newtype (SafeToHash, ToCBOR)
+  deriving (Generic)
+
+instance Memoized ShelleyTx where
+  type RawType ShelleyTx = ShelleyTxRaw
+
+instance
+  ( ToExpr (TxAuxData era)
+  , ToExpr (TxBody era)
+  , ToExpr (TxWits era)
+  ) =>
+  ToExpr (ShelleyTx era)
 
 -- | `TxBody` setter and getter for `ShelleyTx`. The setter does update
 -- memoized binary representation.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -311,6 +311,8 @@ instance Crypto c => EraTxBody (ShelleyEra c) where
     lensMemoRawType stbrCerts $ \txBodyRaw certs -> txBodyRaw {stbrCerts = certs}
   {-# INLINEABLE certsTxBodyL #-}
 
+  upgradeTxBody = error "Calling this function will cause a compilation error, since there is no TxBody instance for ByronEra"
+
 instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyEra StandardCrypto) #-}
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -122,6 +122,7 @@ import Cardano.Ledger.Shelley.TxOut (
   valueEitherShelleyTxOutL,
  )
 import Cardano.Ledger.Slot (SlotNo (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
@@ -164,6 +165,13 @@ deriving instance
 deriving instance
   (Era era, Show (TxOut era), Show (TxCert era), Show (PParamsUpdate era)) =>
   Show (ShelleyTxBodyRaw era)
+
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (ShelleyTxBodyRaw era)
 
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (ShelleyTxBody era)
@@ -273,6 +281,13 @@ instance Memoized ShelleyTxBody where
 instance
   (Era era, Eq (TxOut era), Eq (TxCert era), Eq (PParamsUpdate era)) =>
   EqRaw (ShelleyTxBody era)
+
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (TxCert era)
+  , ToExpr (Update era)
+  ) =>
+  ToExpr (ShelleyTxBody era)
 
 instance Crypto c => EraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance EraTxBody (ShelleyEra StandardCrypto) #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -242,11 +242,10 @@ data GenesisDelegCert c
   deriving (Show, Generic, Eq)
 
 instance NoThunks (GenesisDelegCert c)
+instance ToExpr (GenesisDelegCert c)
 
 instance NFData (GenesisDelegCert c) where
   rnf = rwhnf
-
-instance ToExpr (GenesisDelegCert c)
 
 genesisKeyHashWitness :: GenesisDelegCert c -> KeyHash 'Witness c
 genesisKeyHashWitness (GenesisDelegCert gk _ _) = asWitness gk
@@ -258,6 +257,7 @@ data MIRPot = ReservesMIR | TreasuryMIR
   deriving (Show, Generic, Eq, NFData, Ord, Enum, Bounded)
 
 deriving instance NoThunks MIRPot
+instance ToExpr MIRPot
 
 instance EncCBOR MIRPot where
   encCBOR ReservesMIR = encodeWord8 0
@@ -270,8 +270,6 @@ instance DecCBOR MIRPot where
       1 -> pure TreasuryMIR
       k -> invalidKey k
 
-instance ToExpr MIRPot
-
 -- | MIRTarget specifies if funds from either the reserves
 -- or the treasury are to be handed out to a collection of
 -- reward accounts or instead transfered to the opposite pot.
@@ -281,6 +279,7 @@ data MIRTarget c
   deriving (Show, Generic, Eq, NFData)
 
 deriving instance NoThunks (MIRTarget c)
+instance ToExpr (MIRTarget c)
 
 instance Crypto c => DecCBOR (MIRTarget c) where
   decCBOR = do
@@ -294,8 +293,6 @@ instance Crypto c => EncCBOR (MIRTarget c) where
   encCBOR (StakeAddressesMIR m) = encCBOR m
   encCBOR (SendToOppositePotMIR c) = encCBOR c
 
-instance ToExpr (MIRTarget c)
-
 -- | Move instantaneous rewards certificate
 data MIRCert c = MIRCert
   { mirPot :: !MIRPot
@@ -304,6 +301,7 @@ data MIRCert c = MIRCert
   deriving (Show, Generic, Eq, NFData)
 
 instance NoThunks (MIRCert c)
+instance ToExpr (MIRCert c)
 
 instance Crypto c => DecCBOR (MIRCert c) where
   decCBOR =
@@ -314,8 +312,6 @@ instance Crypto c => EncCBOR (MIRCert c) where
     encodeListLen 2
       <> encCBOR pot
       <> encCBOR targets
-
-instance ToExpr (MIRCert c)
 
 -- | A heavyweight certificate.
 data ShelleyTxCert era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -190,6 +190,8 @@ instance Crypto c => EraTxWits (ShelleyEra c) where
   scriptTxWitsL = scriptShelleyTxWitsL
   {-# INLINE scriptTxWitsL #-}
 
+  upgradeTxWits = error "Calling this function will cause a compilation error, since there is no TxWits instance for ByronEra"
+
 instance (TxWits era ~ ShelleyTxWits era, EraTxWits era) => EqRaw (ShelleyTxWits era) where
   eqRaw = shelleyEqTxWitsRaw
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -74,6 +74,7 @@ import Cardano.Ledger.SafeHash (SafeToHash (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.Scripts ()
 import Cardano.Ledger.Shelley.TxAuxData ()
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (fold)
@@ -127,6 +128,8 @@ deriving newtype instance EraScript era => Eq (ShelleyTxWits era)
 deriving newtype instance EraScript era => Show (ShelleyTxWits era)
 
 deriving newtype instance Era era => Generic (ShelleyTxWits era)
+
+instance (Era era, ToExpr (Script era)) => ToExpr (ShelleyTxWits era)
 
 instance
   ( Era era

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.3.0
 
+* Add `ToExpr` instance for:
+  * `Sized`
+  * `SignedDSIGN`
+* Add `Generic` instance for `CompactValue`
 * Add `fieldGuarded` to be able to conditionally construct a `Field` #3712
   * Expose `showDecoderError` from `Cardano.Ledger.Binary.Plain`
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sized.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.Binary.Decoding.Decoder (Decoder)
 import Cardano.Ledger.Binary.Encoding (serialize)
 import Cardano.Ledger.Binary.Encoding.EncCBOR (EncCBOR (encCBOR))
 import Cardano.Ledger.Binary.Version (Version)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (..), deepseq)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Int (Int64)
@@ -39,6 +40,8 @@ instance NoThunks a => NoThunks (Sized a)
 
 instance NFData a => NFData (Sized a) where
   rnf (Sized val sz) = val `deepseq` sz `seq` ()
+
+instance ToExpr a => ToExpr (Sized a)
 
 -- | Construct a `Sized` value by serializing it first and recording the amount
 -- of bytes it requires. Note, however, CBOR serialization is not canonical,

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/TreeDiff.hs
@@ -16,6 +16,7 @@ module Cardano.Ledger.TreeDiff (
 )
 where
 
+import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Crypto.Hash.Class ()
 import Cardano.Slotting.Block (BlockNo)
@@ -59,7 +60,10 @@ instance ToExpr EpochSize
 instance ToExpr x => ToExpr (WithOrigin x)
 
 instance ToExpr (Hash.Hash c index) where
-  toExpr x = trimExprViaShow 10 x
+  toExpr = trimExprViaShow 10
+
+instance DSIGN.DSIGNAlgorithm c => ToExpr (DSIGN.SignedDSIGN c index) where
+  toExpr = trimExprViaShow 10
 
 instance ToExpr a => ToExpr (StrictSeq a) where
   toExpr x = App "StrictSeqFromList" [listToExpr (toList x)]

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 1.7.0.0
 
+* Require `ToExpr` for `EraTx` class
+* Add `upgradeTx` function to `EraTx` class
+* Require `ToExpr` for `EraTxBody` class
+* Add `upgradeTxBody` function to `EraTxBody` class
+* Require `ToExpr` for `EraTxWits` class
+* Add `upgradeTxWits` function to `EraTxWits` class
+* Add `ToExpr` instance to:
+  * `CompactAddr`
+  * `Withdrawals`
+  * `AuxiliaryDataHash`
+  * `VKey`
+  * `ChainCode`
+  * `BootstrapWitness`
+  * `WitVKey`
+* Add `Generic` instance to `AuxiliaryDataHash`
 * Add `vsNumDormantEpochs` to `VState` to track the number of contiguous epochs in which there were no governance proposals to vote on. #3729
 * Add `fromEraShareCBOR`
 * Remove redundant `DecCBOR` constraint in `eraDecoder`
@@ -13,6 +28,7 @@
 
 ### `testlib`
 
+* Added `BinaryUpgradeOpts`
 * Add `Arbitrary` instance for `DRepDistr`
 * Move `Arbitrary` instance for `SnapShot` and `SnapShots` from `cardano-ledger-shelley:testlib`
 * Add `Test.Cardano.Ledger.Core.Binary.RoundTrip` with:

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -148,6 +148,7 @@ library testlib
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-byron-test,
         containers,
+        data-default-class,
         deepseq,
         generic-random,
         genvalidity,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -405,7 +405,7 @@ instance ToExpr (BootstrapAddress c) where
 
 newtype CompactAddr c = UnsafeCompactAddr ShortByteString
   deriving stock (Eq, Generic, Ord)
-  deriving newtype (NoThunks, NFData)
+  deriving newtype (NoThunks, NFData, ToExpr)
 
 instance Crypto c => Show (CompactAddr c) where
   show c = show (decompactAddr c)
@@ -945,3 +945,5 @@ fromBoostrapCompactAddress = UnsafeCompactAddr . Byron.unsafeGetCompactAddress
 newtype Withdrawals c = Withdrawals {unWithdrawals :: Map (RewardAcnt c) Coin}
   deriving (Show, Eq, Generic)
   deriving newtype (NoThunks, NFData, EncCBOR, DecCBOR)
+
+instance ToExpr (Withdrawals c)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -18,14 +19,18 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Hashes (EraIndependentTxAuxData)
 import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (ToJSON)
+import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
 newtype AuxiliaryDataHash c = AuxiliaryDataHash
   { unsafeAuxiliaryDataHash :: SafeHash c EraIndependentTxAuxData
   }
-  deriving (Show, Eq, Ord, NoThunks, NFData)
+  deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
+
+instance ToExpr (AuxiliaryDataHash c)
 
 deriving instance Crypto c => EncCBOR (AuxiliaryDataHash c)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -146,6 +146,7 @@ class
   , Show (Tx era)
   , Eq (Tx era)
   , EqRaw (Tx era)
+  , ToExpr (Tx era)
   ) =>
   EraTx era
   where
@@ -186,6 +187,7 @@ class
   , Show (TxBody era)
   , Eq (TxBody era)
   , EqRaw (TxBody era)
+  , ToExpr (TxBody era)
   ) =>
   EraTxBody era
   where
@@ -451,6 +453,7 @@ class
   , ToCBOR (TxWits era)
   , EncCBOR (TxWits era)
   , DecCBOR (Annotator (TxWits era))
+  , ToExpr (TxWits era)
   ) =>
   EraTxWits era
   where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -125,6 +125,7 @@ import Data.Maybe (fromMaybe)
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
+import Data.Void (Void)
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
 import GHC.TypeLits (Symbol)
@@ -150,6 +151,9 @@ class
   where
   type Tx era = (r :: Type) | r -> era
 
+  type TxUpgradeError era :: Type
+  type TxUpgradeError era = Void
+
   mkBasicTx :: TxBody era -> Tx era
 
   bodyTxL :: Lens' (Tx era) (TxBody era)
@@ -163,6 +167,11 @@ class
   validateScript :: PhasedScript 'PhaseOne era -> Tx era -> Bool
 
   getMinFeeTx :: PParams era -> Tx era -> Coin
+
+  upgradeTx ::
+    EraTx (PreviousEra era) =>
+    Tx (PreviousEra era) ->
+    Either (TxUpgradeError era) (Tx era)
 
 class
   ( EraTxOut era
@@ -182,6 +191,9 @@ class
   where
   -- | The body of a transaction.
   type TxBody era = (r :: Type) | r -> era
+
+  type TxBodyUpgradeError era :: Type
+  type TxBodyUpgradeError era = Void
 
   mkBasicTxBody :: TxBody era
 
@@ -206,6 +218,22 @@ class
   allInputsTxBodyF :: SimpleGetter (TxBody era) (Set (TxIn (EraCrypto era)))
 
   certsTxBodyL :: Lens' (TxBody era) (StrictSeq (TxCert era))
+
+  -- | Upgrade the transaction body from the previous era.
+  --
+  -- This can fail where elements of the transaction body are deprecated.
+  -- Compare this to `translateEraThroughCBOR`:
+  -- - `upgradeTxBody` will use the Haskell representation, but will not
+  --   preserve the serialised form. However, it will be suitable for iterated
+  --   translation through eras.
+  -- - `translateEraThroughCBOR` will preserve the binary representation, but is
+  --   not guaranteed to work through multiple eras - that is, the serialised
+  --   representation from era n is guaranteed valid in era n + 1, but not
+  --   necessarily in era n + 2.
+  upgradeTxBody ::
+    EraTxBody (PreviousEra era) =>
+    TxBody (PreviousEra era) ->
+    Either (TxBodyUpgradeError era) (TxBody era)
 
 -- | Abstract interface into specific fields of a `TxOut`
 class
@@ -436,6 +464,8 @@ class
   bootAddrTxWitsL :: Lens' (TxWits era) (Set (BootstrapWitness (EraCrypto era)))
 
   scriptTxWitsL :: Lens' (TxWits era) (Map (ScriptHash (EraCrypto era)) (Script era))
+
+  upgradeTxWits :: EraTxWits (PreviousEra era) => TxWits (PreviousEra era) -> TxWits era
 
 -- | This is a helper lens that will hash the scripts when adding as witnesses.
 hashScriptTxWitsL ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -143,10 +143,10 @@ data PoolCert c
 
 instance NoThunks (PoolCert c)
 
+instance ToExpr (PoolCert c)
+
 instance NFData (PoolCert c) where
   rnf = rwhnf
-
-instance ToExpr (PoolCert c)
 
 poolCertKeyHashWitness :: PoolCert c -> KeyHash 'Witness c
 poolCertKeyHashWitness = \case

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -87,7 +87,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Binary.Crypto
 import Cardano.Ledger.Crypto (ADDRHASH, Crypto, DSIGN, HASH, KES, VRF)
-import Cardano.Ledger.TreeDiff (Expr (App), ToExpr (toExpr))
+import Cardano.Ledger.TreeDiff (Expr (App), ToExpr (toExpr), defaultExprViaShow)
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey, (.:), (.=))
 import qualified Data.Aeson as Aeson
@@ -173,6 +173,9 @@ deriving instance
   NFData (VKey kd c)
 
 deriving instance Crypto c => NoThunks (VKey kd c)
+
+instance Crypto c => ToExpr (VKey kd c) where
+  toExpr = defaultExprViaShow
 
 instance HasKeyRole VKey
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Keys (
  )
 import qualified Cardano.Ledger.Keys as Keys
 import Cardano.Ledger.MemoBytes (EqRaw (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
@@ -77,7 +78,7 @@ import Quiet
 newtype ChainCode = ChainCode {unChainCode :: ByteString}
   deriving (Eq, Generic)
   deriving (Show) via Quiet ChainCode
-  deriving newtype (NoThunks, EncCBOR, DecCBOR, NFData)
+  deriving newtype (NoThunks, EncCBOR, DecCBOR, NFData, ToExpr)
 
 data BootstrapWitness c = BootstrapWitness'
   { bwKey' :: !(VKey 'Witness c)
@@ -92,6 +93,7 @@ data BootstrapWitness c = BootstrapWitness'
   }
   deriving (Generic)
 
+instance Crypto c => ToExpr (BootstrapWitness c)
 deriving instance Crypto c => Show (BootstrapWitness c)
 
 deriving instance Crypto c => Eq (BootstrapWitness c)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Keys (
   hashSignature,
  )
 import Cardano.Ledger.MemoBytes (EqRaw (..))
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq
 import qualified Data.ByteString.Lazy as BSL
 import Data.Ord (comparing)
@@ -60,6 +61,8 @@ data WitVKey kr c = WitVKeyInternal
   , wvkBytes :: BSL.ByteString
   }
   deriving (Generic)
+
+instance Crypto c => ToExpr (WitVKey kr c)
 
 deriving instance Crypto c => Show (WitVKey kr c)
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -9,9 +10,22 @@ module Test.Cardano.Ledger.Core.Binary where
 
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (EqRaw (eqRaw))
+import Data.Default.Class (Default (def))
 import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Binary.TreeDiff (diffExpr)
 import Test.Cardano.Ledger.Common
+
+data BinaryUpgradeOpts = BinaryUpgradeOpts
+  { isScriptUpgradeable :: Bool
+  , isTxUpgradeable :: Bool
+  }
+
+instance Default BinaryUpgradeOpts where
+  def =
+    BinaryUpgradeOpts
+      { isScriptUpgradeable = True
+      , isTxUpgradeable = True
+      }
 
 specTxOutUpgrade ::
   forall era.
@@ -126,95 +140,6 @@ specTxBodyUpgrade ::
   Spec
 specTxBodyUpgrade =
   prop "upgradeTxBody is preserved through serialization" $ \prevTxBody -> do
-    case embedTrip (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) cborTrip prevTxBody of
-      Left err
-        | Right _ <- upgradeTxBody prevTxBody ->
-            -- We expect deserialization to succeed, when upgrade is possible
-            expectationFailure $
-              "Expected to deserialize: =======================================================\n"
-                ++ show err
-        | otherwise -> pure () -- Both upgrade and deserializer fail successfully
-      Right (curTxBody :: TxBody era)
-        | Right upgradedTxBody <- upgradeTxBody prevTxBody ->
-          unless (eqRaw curTxBody upgradedTxBody) $
-            expectationFailure $
-              "Expected raw representation of TxBody to be equal: \n"
-                <> diffExpr curTxBody upgradedTxBody
-        | otherwise -> expectationFailure "Expected upgradeTxBody to succeed"
-
-specTxUpgrade ::
-  forall era.
-  ( EraTx (PreviousEra era)
-  , EraTx era
-  , Arbitrary (Tx (PreviousEra era))
-  , HasCallStack
-  ) =>
-  Spec
-specTxUpgrade =
-  prop "upgradeTx is preserved through serialization" $ \prevTx -> do
-    case embedTrip (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) cborTrip prevTx of
-      Left err
-        | Right _ <- upgradeTx prevTx ->
-            -- We expect deserialization to succeed, when upgrade is possible
-            expectationFailure $
-              "Expected to deserialize: =======================================================\n"
-                ++ show err
-        | otherwise -> pure () -- Both upgrade and deserializer fail successfully
-      Right (curTx :: Tx era)
-        | Right upgradedTx <- upgradeTx prevTx ->
-          unless (eqRaw curTx upgradedTx) $
-            expectationFailure $
-              "Expected raw representation of Tx to be equal: \n"
-                <> diffExpr curTx upgradedTx
-        | otherwise -> expectationFailure "Expected upgradeTx to succeed"
-
-specUpgrade ::
-  forall era.
-  ( EraTxOut (PreviousEra era)
-  , EraTxOut era
-  , Arbitrary (TxOut (PreviousEra era))
-  , EraTxCert (PreviousEra era)
-  , EraTxCert era
-  , Arbitrary (TxCert (PreviousEra era))
-  , EraTxAuxData (PreviousEra era)
-  , EraTxAuxData era
-  , Arbitrary (TxAuxData (PreviousEra era))
-  , EraTxWits (PreviousEra era)
-  , EraTxWits era
-  , Arbitrary (TxWits (PreviousEra era))
-  , EraTxBody (PreviousEra era)
-  , EraTxBody era
-  , Arbitrary (TxBody (PreviousEra era))
-  , EraTx (PreviousEra era)
-  , EraTx era
-  , Arbitrary (Tx (PreviousEra era))
-  , HasCallStack
-  ) =>
-  Spec
-specTxWitsUpgrade =
-  prop "upgradeTxWits is preserved through serialization" $ \prevTxWits -> do
-    case embedTripAnn (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) prevTxWits of
-      Left err ->
-        expectationFailure $
-          "Expected to deserialize: =======================================================\n"
-            ++ show err
-      Right (curTxWits :: TxWits era) -> do
-        let upgradedTxWits = upgradeTxWits prevTxWits
-        unless (eqRaw curTxWits upgradedTxWits) $
-          expectationFailure $
-            "Expected raw representation of TxWits to be equal: \n"
-              <> diffExpr curTxWits upgradedTxWits
-
-specTxBodyUpgrade ::
-  forall era.
-  ( EraTxBody (PreviousEra era)
-  , EraTxBody era
-  , Arbitrary (TxBody (PreviousEra era))
-  , HasCallStack
-  ) =>
-  Spec
-specTxBodyUpgrade =
-  prop "upgradeTxBody is preserved through serialization" $ \prevTxBody -> do
     case embedTripAnn (eraProtVerHigh @(PreviousEra era)) (eraProtVerLow @era) prevTxBody of
       Left err
         | Right _ <- upgradeTxBody prevTxBody ->
@@ -225,10 +150,10 @@ specTxBodyUpgrade =
         | otherwise -> pure () -- Both upgrade and deserializer fail successfully
       Right (curTxBody :: TxBody era)
         | Right upgradedTxBody <- upgradeTxBody prevTxBody ->
-          unless (eqRaw curTxBody upgradedTxBody) $
-            expectationFailure $
-              "Expected raw representation of TxBody to be equal: \n"
-                <> diffExpr curTxBody upgradedTxBody
+            unless (eqRaw curTxBody upgradedTxBody) $
+              expectationFailure $
+                "Expected raw representation of TxBody to be equal: \n"
+                  <> diffExpr curTxBody upgradedTxBody
         | otherwise -> expectationFailure "Expected upgradeTxBody to succeed"
 
 specTxUpgrade ::
@@ -251,10 +176,10 @@ specTxUpgrade =
         | otherwise -> pure () -- Both upgrade and deserializer fail successfully
       Right (curTx :: Tx era)
         | Right upgradedTx <- upgradeTx prevTx ->
-          unless (eqRaw curTx upgradedTx) $
-            expectationFailure $
-              "Expected raw representation of Tx to be equal: \n"
-                <> diffExpr curTx upgradedTx
+            unless (eqRaw curTx upgradedTx) $
+              expectationFailure $
+                "Expected raw representation of Tx to be equal: \n"
+                  <> diffExpr curTx upgradedTx
         | otherwise -> expectationFailure "Expected upgradeTx to succeed"
 
 specUpgrade ::
@@ -269,15 +194,17 @@ specUpgrade ::
   , Arbitrary (Tx (PreviousEra era))
   , Arbitrary (Script (PreviousEra era))
   , HasCallStack
-  ) =>Bool ->
+  ) =>
+  BinaryUpgradeOpts ->
   Spec
-specUpgrade isScriptUpgradeable =
+specUpgrade BinaryUpgradeOpts {isScriptUpgradeable, isTxUpgradeable} =
   describe ("Upgrade from " ++ eraName @(PreviousEra era) ++ " to " ++ eraName @era) $ do
     specTxOutUpgrade @era
     specTxCertUpgrade @era
     specTxAuxDataUpgrade @era
     specTxWitsUpgrade @era
     specTxBodyUpgrade @era
-    specTxUpgrade @era
+    when isTxUpgradeable $
+      specTxUpgrade @era
     when isScriptUpgradeable $
       specScriptUpgrade @era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
@@ -4,21 +4,14 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Constrained.Trace.Tests
 where
 
-import Cardano.Ledger.Alonzo.Scripts.Data (BinaryData, Datum (..))
-import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (TxIx)
 import Cardano.Ledger.Core (EraRule, EraTx (..), EraTxBody (..), Tx)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
-import Cardano.Ledger.TreeDiff (
-  Expr (App),
-  ToExpr (toExpr),
- )
 import Control.State.Transition.Extended (STS (..), TRC (..))
 import Data.Foldable (toList)
 import Lens.Micro ((^.))
@@ -55,21 +48,6 @@ import Test.Cardano.Ledger.Generic.TxGen (applySTSByProof)
 import Test.QuickCheck (Arbitrary (..), Property, conjoin, counterexample, generate, whenFail, withMaxSuccess, (===))
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)
-
--- =================================
-
-instance ToExpr (BabbageTxOut (BabbageEra StandardCrypto)) where
-  toExpr (BabbageTxOut addr val dat sc) = App "BabbageTxOut" [toExpr addr, toExpr val, toExpr dat, toExpr sc]
-
-instance ToExpr (Datum (BabbageEra StandardCrypto)) where
-  toExpr NoDatum = App "NoDatum" []
-  toExpr (DatumHash x) = App "DatumHash" [toExpr x]
-  toExpr (Datum bd) = App "Datum" [toExpr bd]
-
-instance ToExpr (BinaryData (BabbageEra StandardCrypto)) where
-  toExpr _ = App "BinaryData" []
-
--- ===================================================
 
 -- | Generate an Env that contains the pieces of the LedgerState
 --   by chaining smaller pieces together.


### PR DESCRIPTION
# Description

This PR adds the remaining upgrade functions described in #3618 

- Adds `upgradeTxBody`, `upgradeTxWits`, and `upgradeTx`
- Derive `ToExpr` in various places throughout the code in order to print the diffs
- Implements some logic to handle specific cases which may fail:
  - Mary->Alonzo Tx and TxBody may fail due to dropped protocol parameters
  - Mary->Alonzo Tx fails due to the introduction of `isValid` and not doing translation via deserialisation of the Tx.
  - Alonzo->Babbage Tx and TxBody may fail due to dropped protocol parameters
  - Alonzo transactions with a protocol parameter update to `coinsPerUTxOWord` will deserialise correctly in Babbage but with an altered meaning. We account for this in the upgrade function. An alternative would be to explicitly fail on any transactions that attempted to update this field, but this would require that the translation logic unpack the transaction, and doesn't seem worth it since these will never occur.

Resolves #3618

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
