### PR TITLE
Delay all enactments by one extra epoch

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `cgFutureEnactState`, `cgFutureEnactStateL`
 * Add `ExpirationEpochTooSmall` data constructor to `ConwayGovPredFailure`
 * Add `ConflictingCommitteeUpdate` data constructor to `ConwayGovPredFailure`
 * Rename `NewCommitte` to `UpdateCommittee`

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -126,6 +126,7 @@ instance
     ConwayGovState
       <$> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -456,12 +456,13 @@ instance
   ) =>
   PrettyA (ConwayGovState era)
   where
-  prettyA cg@(ConwayGovState _ _) =
+  prettyA cg@(ConwayGovState _ _ _) =
     let ConwayGovState {..} = cg
      in ppRecord
           "ConwayGovState"
           [ ("GovSnapshots", prettyA cgGovSnapshots)
           , ("EnactState", prettyA cgEnactState)
+          , ("FutureEnactState", prettyA cgFutureEnactState)
           ]
 
 instance

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -1497,6 +1497,7 @@ conwayGovStateT _p =
   Invert "ConwayGovState" (typeRep @(ConwayGovState era)) ConwayGovState
     :$ Shift govSnapshotsT cgGovSnapshotsL
     :$ Shift enactStateT cgEnactStateL
+    :$ Shift enactStateT cgFutureEnactStateL
 
 govSnapshotsT :: forall era. Era era => RootTarget era (GovSnapshots era) (GovSnapshots era)
 govSnapshotsT =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1672,11 +1672,12 @@ pcPrevGovActionIds PrevGovActionIds {..} =
     ]
 
 pcConwayGovState :: Proof era -> ConwayGovState era -> PDoc
-pcConwayGovState p (ConwayGovState ss es) =
+pcConwayGovState p (ConwayGovState ss es fes) =
   ppRecord
     "ConwayGovState"
     [ ("govSnapshots", pcGovSnapshots ss)
     , ("enactState", pcEnactState p es)
+    , ("futureEnactState", pcEnactState p fes)
     ]
 
 pcProposalsSnapshot :: ProposalsSnapshot era -> PDoc


### PR DESCRIPTION
# Description

Delay all enactments by one extra epoch. The order of events for a governance action from proposal to enactment looks like this:

```
-- Epoch 0 --
Action P is proposed

<wait some epochs until P gets enough votes or expires>

-- Start of epoch n --
Take a snapshot and start calculating DRep distributions
  (we also do that on all previous epochs, but here we assume that this time the action is either ratified or expires)

-- Start of epoch n+1 --
If P has enough votes:
  - Apply P onto `cgFutureEnactState`
Remove P from the snapshots

-- Start of epoch n+2 --
Rotate `cgFutureEnactState` to `cgEnactState`
```

closes #3691

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
