### PR TITLE
Committee expiration, validation and modification

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `ConflictingCommitteeUpdate` data constructor to `ConwayGovPredFailure`
 * Rename `NewCommitte` to `UpdateCommittee`
 * Remove `NewCommitteeSizeTooSmall` data constructor from `ConwayGovPredFailure`
 * Fix invalid order in `fromGovActionStateSeq`, thus also `DecCBOR` for `ProposalsSnapshot`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `ExpirationEpochTooSmall` data constructor to `ConwayGovPredFailure`
 * Add `ConflictingCommitteeUpdate` data constructor to `ConwayGovPredFailure`
 * Rename `NewCommitte` to `UpdateCommittee`
 * Remove `NewCommitteeSizeTooSmall` data constructor from `ConwayGovPredFailure`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Rename `NewCommitte` to `UpdateCommittee`
 * Fix invalid order in `fromGovActionStateSeq`, thus also `DecCBOR` for `ProposalsSnapshot`
 * Remove `DecCBOR`/`EncCBOR` and `FromCBOR`/`ToCBOR` for `RatifyState`, since that state
   is ephemeral and is never serialized.
@@ -51,6 +52,7 @@
 
 ### testlib
 
+* Rename `genNewCommittee` to `genUpdateCommitteee`
 * Add `genNewCommittee`
 * Add `genNoConfidence`
 * Add `genTreasuryWithdrawals`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0.0
 
 * Rename `NewCommitte` to `UpdateCommittee`
+* Remove `NewCommitteeSizeTooSmall` data constructor from `ConwayGovPredFailure`
 * Fix invalid order in `fromGovActionStateSeq`, thus also `DecCBOR` for `ProposalsSnapshot`
 * Remove `DecCBOR`/`EncCBOR` and `FromCBOR`/`ToCBOR` for `RatifyState`, since that state
   is ephemeral and is never serialized.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -632,7 +632,7 @@ votingStakePoolThresholdInternal pp isElectedCommittee action =
         } = pp ^. ppPoolVotingThresholdsL
    in case action of
         NoConfidence {} -> VotingThreshold pvtCommitteeNoConfidence
-        NewCommittee {} ->
+        UpdateCommittee {} ->
           VotingThreshold $
             if isElectedCommittee
               then pvtCommitteeNormal
@@ -666,7 +666,7 @@ votingCommitteeThresholdInternal ::
   VotingThreshold
 votingCommitteeThresholdInternal committee = \case
   NoConfidence {} -> NoVotingAllowed
-  NewCommittee {} -> NoVotingAllowed
+  UpdateCommittee {} -> NoVotingAllowed
   NewConstitution {} -> threshold
   HardForkInitiation {} -> threshold
   ParameterChange {} -> threshold
@@ -717,7 +717,7 @@ votingDRepThresholdInternal pp isElectedCommittee action =
         } = pp ^. ppDRepVotingThresholdsL
    in case action of
         NoConfidence {} -> VotingThreshold dvtCommitteeNoConfidence
-        NewCommittee {} ->
+        UpdateCommittee {} ->
           VotingThreshold $
             if isElectedCommittee
               then dvtCommitteeNormal

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -523,7 +523,7 @@ data GovAction era
       -- | Previous governance action id of `UpdateCommittee` or `NoConfidence` type, which
       -- corresponds to `CommitteePurpose`
       !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
-      -- | Old committee
+      -- | Constitutional Committe members to be removed
       !(Set (Credential 'ColdCommitteeRole (EraCrypto era)))
       -- | Constitutional committee members to be added
       !(Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -516,17 +516,19 @@ data GovAction era
       -- | Proposed treasury withdrawals
       !(Map (RewardAcnt (EraCrypto era)) Coin)
   | NoConfidence
-      -- | Previous governance action id of `NoConfidence` or `NewCommittee` type, which
+      -- | Previous governance action id of `NoConfidence` or `UpdateCommittee` type, which
       -- corresponds to `CommitteePurpose`
       !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
-  | NewCommittee
-      -- | Previous governance action id of `NewCommittee` or `NoConfidence` type, which
+  | UpdateCommittee
+      -- | Previous governance action id of `UpdateCommittee` or `NoConfidence` type, which
       -- corresponds to `CommitteePurpose`
       !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
       -- | Old committee
       !(Set (Credential 'ColdCommitteeRole (EraCrypto era)))
-      -- | New Committee
-      !(Committee era)
+      -- | Constitutional committee members to be added
+      !(Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
+      -- New quorum
+      !UnitInterval
   | NewConstitution
       -- | Previous governance action id of `NewConstitution` type, which corresponds to
       -- `ConstitutionPurpose`
@@ -554,7 +556,7 @@ instance EraPParams era => DecCBOR (GovAction era) where
       1 -> SumD HardForkInitiation <! D (decodeNullStrictMaybe decCBOR) <! From
       2 -> SumD TreasuryWithdrawals <! From
       3 -> SumD NoConfidence <! D (decodeNullStrictMaybe decCBOR)
-      4 -> SumD NewCommittee <! D (decodeNullStrictMaybe decCBOR) <! From <! From
+      4 -> SumD UpdateCommittee <! D (decodeNullStrictMaybe decCBOR) <! From <! From <! From
       5 -> SumD NewConstitution <! D (decodeNullStrictMaybe decCBOR) <! From
       6 -> SumD InfoAction
       k -> Invalid k
@@ -571,8 +573,8 @@ instance EraPParams era => EncCBOR (GovAction era) where
         Sum TreasuryWithdrawals 2 !> To ws
       NoConfidence gid ->
         Sum NoConfidence 3 !> E (encodeNullStrictMaybe encCBOR) gid
-      NewCommittee gid old new ->
-        Sum NewCommittee 4 !> E (encodeNullStrictMaybe encCBOR) gid !> To old !> To new
+      UpdateCommittee gid old new q ->
+        Sum UpdateCommittee 4 !> E (encodeNullStrictMaybe encCBOR) gid !> To old !> To new !> To q
       NewConstitution gid c ->
         Sum NewConstitution 5 !> E (encodeNullStrictMaybe encCBOR) gid !> To c
       InfoAction ->

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -61,7 +61,6 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.Governance.Procedures (
   GovAction (..),
-  committeeMembersL,
  )
 import Cardano.Ledger.Conway.Governance.Snapshots (snapshotGovActionStates)
 import Cardano.Ledger.Conway.PParams (
@@ -267,9 +266,9 @@ govTransition = do
                   Set.filter ((/= expectedNetworkId) . getRwdNetwork) $ Map.keysSet wdrls
              in Set.null mismatchedAccounts
                   ?! TreasuryWithdrawalsNetworkIdMismatch mismatchedAccounts expectedNetworkId
-          NewCommittee _mPrevGovActionId _oldColdCreds newCommittee ->
+          UpdateCommittee _mPrevGovActionId _membersToRemove membersToAdd _qrm -> do
             let minCommitteeSize = pp ^. ppMinCommitteeSizeL
-                newCommitteeSize = fromIntegral . Map.size $ newCommittee ^. committeeMembersL
+                newCommitteeSize = fromIntegral . Map.size $ membersToAdd
              in newCommitteeSize
                   >= minCommitteeSize
                     ?! NewCommitteeSizeTooSmall newCommitteeSize minCommitteeSize

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -201,7 +201,7 @@ dRepAcceptedRatio RatifyEnv {reDRepDistr, reDRepState, reCurrentEpoch} gasDRepVo
 delayingAction :: GovAction era -> Bool
 delayingAction NoConfidence {} = True
 delayingAction HardForkInitiation {} = True
-delayingAction NewCommittee {} = True
+delayingAction UpdateCommittee {} = True
 delayingAction NewConstitution {} = True
 delayingAction TreasuryWithdrawals {} = False
 delayingAction ParameterChange {} = False
@@ -209,7 +209,7 @@ delayingAction InfoAction {} = False
 
 actionPriority :: GovAction era -> Int
 actionPriority NoConfidence {} = 0
-actionPriority NewCommittee {} = 1
+actionPriority UpdateCommittee {} = 1
 actionPriority NewConstitution {} = 2
 actionPriority HardForkInitiation {} = 3
 actionPriority ParameterChange {} = 4
@@ -280,11 +280,11 @@ prevActionAsExpected (HardForkInitiation prev _) (PrevGovActionIds {pgaHardFork}
   prev == pgaHardFork
 prevActionAsExpected (NoConfidence prev) (PrevGovActionIds {pgaCommittee}) =
   prev == pgaCommittee
-prevActionAsExpected (NewCommittee prev _ _) (PrevGovActionIds {pgaCommittee}) =
+prevActionAsExpected (UpdateCommittee prev _ _ _) (PrevGovActionIds {pgaCommittee}) =
   prev == pgaCommittee
 prevActionAsExpected (NewConstitution prev _) (PrevGovActionIds {pgaConstitution}) =
   prev == pgaConstitution
-prevActionAsExpected _ _ = True -- for the other actions, the last action is not relevant
+prevActionAsExpected _ _ = True -- for the other actions, the previous action is not relevant
 
 instance EraGov era => Embed (ConwayENACT era) (ConwayRATIFY era) where
   wrapFailed = absurd

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -8,7 +8,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conway.Arbitrary (
-  genNewCommittee,
+  genUpdateCommittee,
   genNoConfidence,
   genTreasuryWithdrawals,
   genHardForkInitiation,
@@ -227,8 +227,13 @@ genTreasuryWithdrawals = TreasuryWithdrawals <$> arbitrary
 genNoConfidence :: Era era => Gen (GovAction era)
 genNoConfidence = NoConfidence <$> arbitrary
 
-genNewCommittee :: Era era => Gen (GovAction era)
-genNewCommittee = NewCommittee <$> arbitrary <*> arbitrary <*> arbitrary
+genUpdateCommittee :: Era era => Gen (GovAction era)
+genUpdateCommittee =
+  UpdateCommittee
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
 
 genNewConstitution :: Era era => Gen (GovAction era)
 genNewConstitution = NewConstitution <$> arbitrary <*> arbitrary
@@ -243,7 +248,7 @@ govActionGenerators =
   , genHardForkInitiation
   , genTreasuryWithdrawals
   , genNoConfidence
-  , genNewCommittee
+  , genUpdateCommittee
   , genNewConstitution
   , pure InfoAction
   ]

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -92,7 +92,7 @@ gov_action =
   // hard_fork_initiation_action
   // treasury_withdrawals_action
   // no_confidence
-  // new_committee
+  // update_committee
   // new_constitution
   // info_action
   ]
@@ -105,7 +105,7 @@ treasury_withdrawals_action = (2, { reward_account => coin })
 
 no_confidence = (3, gov_action_id / null)
 
-new_committee = (4, gov_action_id / null, set<committee_cold_credential>, committee)
+update_committee = (4, gov_action_id / null, set<committee_cold_credential>, { committee_cold_credential => epoch }, unit_interval)
 
 new_constitution = (5, gov_action_id / null, constitution)
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -223,12 +223,13 @@ instance PrettyA (PParamsUpdate era) => PrettyA (GovAction era) where
       [("withdrawals map", prettyA ws)]
   prettyA (NoConfidence pgaid) =
     ppRecord "NoConfidence" [("previous governance action id", prettyA pgaid)]
-  prettyA (NewCommittee pgaid old committee) =
+  prettyA (UpdateCommittee pgaid toRemove toAdd qrm) =
     ppRecord
-      "NewCommittee"
+      "UpdateCommittee"
       [ ("previous governance action id", prettyA pgaid)
-      , ("oldMembers", prettyA old)
-      , ("committee", prettyA committee)
+      , ("membersToRemove", prettyA toRemove)
+      , ("membersToAdd", prettyA toAdd)
+      , ("quorum", prettyA qrm)
       ]
   prettyA (NewConstitution pgaid Constitution {..}) =
     ppRecord

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1729,12 +1729,13 @@ pcGovAction x = case x of
       [ppMap pcRewardAcnt pcCoin ws]
   (NoConfidence pgaid) ->
     ppRecord "NoConfidence" [("PrevGovActId", ppStrictMaybe pcPrevGovActionId pgaid)]
-  (NewCommittee pgaid old committee) ->
+  (UpdateCommittee pgaid toRemove toAdd quor) ->
     ppRecord
       "NewCommittee"
       [ ("PrevGovActId", ppStrictMaybe pcPrevGovActionId pgaid)
-      , ("oldMembers", ppSet pcCredential old)
-      , ("committee", pcCommittee committee)
+      , ("membersToRemove", ppSet pcCredential toRemove)
+      , ("members", ppMap pcCredential ppEpochNo toAdd)
+      , ("quorum", ppUnitInterval quor)
       ]
   (NewConstitution pgaid c) ->
     ppRecord


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Closes https://github.com/input-output-hk/cardano-ledger/issues/3443

* In Gov rule, check the `NewCommittee` action failing if : 
   * the members to be removed are not part of the current committee (for this, the current committee from EnactState had to be added to GovEnv) 
   * the expiration epoch of the new members are not exceeding the ppCommitteeTermLimitL, given the current epoch
* Rename `NewCommittee` to `UpdateCommittee` and change its semantics to  "update committee", rather than "replace committee".  This means: in Enact rule: adding and removing members correctly, and in Gov rule: checking correctly the minimum committee size, considering the current committee.
* Update CommitteeState when members get removed

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
