### PR TITLE
Fix mistaken use of dollar sign in cddl files

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -68,7 +68,7 @@ transaction_body =
  , ? 15 : network_id             ; New
  }
 
-required_signers = set<$addr_keyhash>
+required_signers = set<addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
                     , index : uint

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -70,7 +70,7 @@ transaction_body =
   , ? 18 : set<transaction_input> ; reference inputs; New
   }
 
-required_signers = set<$addr_keyhash>
+required_signers = set<addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
                     , index : uint

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -101,15 +101,15 @@ parameter_change_action = (0, gov_action_id / null, protocol_param_update)
 
 hard_fork_initiation_action = (1, gov_action_id / null, [protocol_version])
 
-treasury_withdrawals_action = (2, { $reward_account => coin })
+treasury_withdrawals_action = (2, { reward_account => coin })
 
 no_confidence = (3, gov_action_id / null)
 
-new_committee = (4, gov_action_id / null, set<$committee_cold_credential>, committee)
+new_committee = (4, gov_action_id / null, set<committee_cold_credential>, committee)
 
 new_constitution = (5, gov_action_id / null, constitution)
 
-committee = [{ $committee_cold_credential => epoch }, unit_interval]
+committee = [{ committee_cold_credential => epoch }, unit_interval]
 
 constitution =
   [ anchor
@@ -146,7 +146,7 @@ gov_action_id =
   , gov_action_index : uint
   ]
 
-required_signers = nonempty_set<$addr_keyhash>
+required_signers = nonempty_set<addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
                     , index : uint


### PR DESCRIPTION

# Description

At the moment , `cddl generate` that we use for cddl roundtrips does NOT generate values for these types that we prefixed with `$`.
The types for which values ARE generated correctly that are prefixed with $ (eg: $hash28, $vkey), are also defined in the same way, prefixed by dollar.

It's not very clear from the spec that this should be the case, but running `cddl generate` makes it  clear that it's simply ignoring $required_signers,  $treasury_withdrawals_action and $new_committee when defined in the way they are currently in the cddl. 




<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
