### PR TITLE
Conway and other eras roundtrip tests

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.2.0
+version:            1.2.2.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -52,8 +52,8 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6 && <1.7,
-        cardano-ledger-shelley >=1.6 && <1.7,
+        cardano-ledger-core >=1.6.1 && <1.7,
+        cardano-ledger-shelley >=1.6.1 && <1.7,
         cardano-strict-containers,
         cardano-slotting,
         cborg,
@@ -100,4 +100,5 @@ test-suite tests
         base,
         cardano-ledger-core:testlib,
         cardano-ledger-allegra,
+        cardano-ledger-shelley:testlib,
         testlib

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -5,7 +5,11 @@ module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
 import Cardano.Ledger.Allegra
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
 
 spec :: Spec
-spec = specUpgrade @Allegra True
+spec = do
+  specUpgrade @Allegra True
+  describe "RoundTrip" $ do
+    roundTripShelleyCommonSpec @Allegra

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.4.1.1
+## 1.4.2.0
 
-*
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Alonzo.Binary.RoundTrip` module with:
+  * `roundTripAlonzoCommonSpec`
+  * `roundTripAlonzoEraTypesSpec`
 
 ## 1.4.1.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.4.1.0
+version:            1.4.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -67,9 +67,9 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.6 && <1.7,
+        cardano-ledger-core >=1.6.1 && <1.7,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.6,
+        cardano-ledger-shelley ^>=1.6.1,
         cardano-slotting,
         cardano-strict-containers,
         containers,
@@ -99,7 +99,10 @@ library
         ghc-options: -Wno-name-shadowing
 
 library testlib
-    exposed-modules:  Test.Cardano.Ledger.Alonzo.Arbitrary
+    exposed-modules:
+        Test.Cardano.Ledger.Alonzo.Arbitrary
+        Test.Cardano.Ledger.Alonzo.Binary.RoundTrip
+
     visibility:       public
     hs-source-dirs:   testlib
     default-language: Haskell2010
@@ -115,7 +118,7 @@ library testlib
         cardano-ledger-binary,
         cardano-ledger-mary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-shelley,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
         plutus-core,
         text
@@ -133,6 +136,6 @@ test-suite tests
 
     build-depends:
         base,
-        cardano-ledger-core:testlib,
         cardano-ledger-alonzo,
+        cardano-ledger-core:testlib,
         testlib

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/BinarySpec.hs
@@ -3,12 +3,23 @@
 module Test.Cardano.Ledger.Alonzo.BinarySpec (spec) where
 
 import Cardano.Ledger.Alonzo
+import Cardano.Ledger.Alonzo.Genesis
+import Cardano.Ledger.Alonzo.Scripts
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
-spec =
+spec = do
   -- Scripts are not upgradeable from Mary through their CBOR instances, since Mary had no
   -- concept of a prefix.
   specUpgrade @Alonzo False
+  describe "RoundTrip" $ do
+    roundTripAlonzoCommonSpec @Alonzo
+    -- AlonzoGenesis only makes sense in Alonzo era
+    roundTripEraSpec @Alonzo @AlonzoGenesis
+    -- CostModel serialization changes drastically for Conway, which requires a different
+    -- QuickCheck generator, hence Arbitrary can't be reused
+    roundTripEraSpec @Alonzo @CostModels

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/RoundTrip.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/RoundTrip.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (
+  roundTripAlonzoCommonSpec,
+  roundTripAlonzoEraTypesSpec,
+) where
+
+import Cardano.Ledger.Alonzo.Scripts.Data
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Governance
+import Cardano.Ledger.Shelley.LedgerState
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary.RoundTrip
+import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
+
+roundTripAlonzoCommonSpec ::
+  forall era.
+  ( EraTx era
+  , EraGov era
+  , StashedAVVMAddresses era ~ ()
+  , Arbitrary (Tx era)
+  , Arbitrary (TxBody era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (TxWits era)
+  , Arbitrary (TxAuxData era)
+  , Arbitrary (Value era)
+  , Arbitrary (CompactForm (Value era))
+  , Arbitrary (Script era)
+  , Arbitrary (GovState era)
+  , Arbitrary (PParams era)
+  , Arbitrary (PParamsUpdate era)
+  ) =>
+  Spec
+roundTripAlonzoCommonSpec = do
+  roundTripAlonzoEraTypesSpec @era
+  roundTripShelleyCommonSpec @era
+
+roundTripAlonzoEraTypesSpec ::
+  forall era.
+  Era era =>
+  Spec
+roundTripAlonzoEraTypesSpec = do
+  describe "Alonzo era types" $ do
+    roundTripAnnEraTypeSpec @era @Data
+    roundTripEraTypeSpec @era @BinaryData
+    xdescribe "Datum doesn't roundtrip" $ do
+      -- TODO: Adjust Datum implementation somehow to avoid this situtaiton
+      -- It doesn't roundtrip because we do not en/decode NoDatum
+      -- Possibly use peekAvailable, but haven't looked into the issue too deeply
+      roundTripEraTypeSpec @era @Datum

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Serialisation/Tripping.hs
@@ -15,14 +15,11 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxosPredFailure,
   AlonzoUtxowPredFailure,
  )
-import Cardano.Ledger.Alonzo.Scripts (CostModels, eqAlonzoScriptRaw)
+import Cardano.Ledger.Alonzo.Scripts (eqAlonzoScriptRaw)
 import Cardano.Ledger.Alonzo.Scripts.Data (BinaryData, Data (..))
-import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits)
-import Cardano.Ledger.Binary.Version (natVersion)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (zipMemoRawType)
-import Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
@@ -37,70 +34,24 @@ tests :: TestTree
 tests =
   testGroup
     "Alonzo CBOR round-trip"
-    [ testProperty "alonzo/Script" $
-        roundTripAnnRangeExpectation @(Script Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , skip $
+    [ skip $
         testProperty "alonzo/Script twiddled" $
           roundTripAnnTwiddledProperty @(Script Alonzo) eqAlonzoScriptRaw
-    , testProperty "alonzo/Data" $
-        roundTripAnnRangeExpectation @(Data Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
     , skip $
         testProperty "alonzo/Data twiddled" $
           roundTripAnnTwiddledProperty @(Data Alonzo) (zipMemoRawType (===))
-    , testProperty "alonzo/BinaryData" $
-        roundTripCborExpectation @(BinaryData Alonzo)
     , skip $
         testProperty "alonzo/BinaryData twiddled" $
           roundTripTwiddledProperty @(BinaryData Alonzo)
-    , testProperty "alonzo/TxAuxData" $
-        roundTripAnnRangeExpectation @(ShelleyTxAuxData Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , testProperty "alonzo/AlonzoTxWits" $
-        roundTripAnnRangeExpectation @(AlonzoTxWits Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , testProperty "alonzo/TxBody" $
-        roundTripAnnRangeExpectation @(TxBody Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
     , skip $
         testProperty "alonzo/TxBody twiddled" $
           roundTripAnnTwiddledProperty @(TxBody Alonzo) (zipMemoRawType (===))
-    , testProperty "alonzo/CostModels" $
-        roundTripCborRangeExpectation @CostModels
-          (natVersion @2)
-          maxBound
-    , testProperty "alonzo/PParams" $
-        roundTripCborRangeExpectation @(PParams Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , testProperty "alonzo/PParamsUpdate" $
-        roundTripCborRangeExpectation @(PParamsUpdate Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , testProperty "alonzo/AuxiliaryData" $
-        roundTripAnnRangeExpectation @(TxAuxData Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
     , testProperty "alonzo/AlonzoUtxowPredFailure" $
         roundTripCborExpectation @(AlonzoUtxowPredFailure Alonzo)
     , testProperty "alonzo/AlonzoUtxoPredFailure" $
         roundTripCborExpectation @(AlonzoUtxoPredFailure Alonzo)
     , testProperty "alonzo/AlonzoUtxosPredFailure" $
         roundTripCborExpectation @(AlonzoUtxosPredFailure Alonzo)
-    , testProperty "Script" $
-        roundTripAnnRangeExpectation @(Script Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
-    , testProperty "alonzo/Tx" $
-        roundTripAnnRangeExpectation @(Tx Alonzo)
-          (eraProtVerLow @Alonzo)
-          (eraProtVerHigh @Alonzo)
     , testProperty "alonzo/Block" $
         roundTripAnnRangeExpectation @(Block (BHeader StandardCrypto) Alonzo)
           (eraProtVerLow @Alonzo)

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -60,9 +60,9 @@ library
         cardano-crypto-class,
         cardano-data >=1.0,
         cardano-ledger-allegra >=1.1,
-        cardano-ledger-alonzo ^>=1.4.1,
+        cardano-ledger-alonzo ^>=1.4.2,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6 && <1.7,
+        cardano-ledger-core >=1.6.1 && <1.7,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley ^>=1.6,
         cardano-slotting,
@@ -110,6 +110,8 @@ test-suite tests
 
     build-depends:
         base,
-        cardano-ledger-core:testlib,
+        cardano-ledger-alonzo,
         cardano-ledger-babbage,
+        cardano-ledger-core:testlib,
+        cardano-ledger-alonzo:testlib,
         testlib

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
@@ -2,10 +2,19 @@
 
 module Test.Cardano.Ledger.Babbage.BinarySpec (spec) where
 
+import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Babbage
+import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
-spec = specUpgrade @Babbage True
+spec = do
+  specUpgrade @Babbage True
+  describe "RoundTrip" $ do
+    roundTripAlonzoCommonSpec @Babbage
+    -- CostModel serialization changes drastically for Conway, which requires a different
+    -- QuickCheck generator, hence Arbitrary can't be reused
+    roundTripEraSpec @Babbage @CostModels

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -94,7 +94,7 @@ test-suite cardano-ledger-babbage-test
     build-depends:
         base,
         bytestring,
-        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-binary:testlib,
         cardano-ledger-allegra,
         cardano-ledger-alonzo,
         cardano-ledger-alonzo-test,

--- a/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
+++ b/eras/babbage/test-suite/test/Test/Cardano/Ledger/Babbage/Serialisation/Tripping.hs
@@ -6,10 +6,8 @@
 
 module Test.Cardano.Ledger.Babbage.Serialisation.Tripping where
 
-import Cardano.Ledger.Alonzo.Scripts (CostModels)
 import Cardano.Ledger.Babbage (Babbage)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
-import Cardano.Ledger.Binary.Version (natVersion)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Cardano.Protocol.TPraos.BHeader (BHeader)
@@ -25,47 +23,7 @@ tests :: TestTree
 tests =
   testGroup
     "Babbage CBOR round-trip"
-    [ testProperty "babbage/Script" $
-        roundTripAnnRangeExpectation @(Script Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/Metadata" $
-        roundTripAnnRangeExpectation @(TxAuxData Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/TxOut" $
-        roundTripCborRangeExpectation @(TxOut Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/TxBody" $
-        roundTripAnnRangeExpectation @(TxBody Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/CostModel" $
-        roundTripCborRangeExpectation @CostModels
-          (natVersion @2)
-          maxBound
-    , testProperty "babbage/PParams" $
-        roundTripCborRangeExpectation @(PParams Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/PParamsUpdate" $
-        roundTripCborRangeExpectation @(PParamsUpdate Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/AuxiliaryData" $
-        roundTripAnnRangeExpectation @(TxAuxData Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "Script" $
-        roundTripAnnRangeExpectation @(Script Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/Tx" $
-        roundTripAnnRangeExpectation @(Tx Babbage)
-          (eraProtVerLow @Babbage)
-          (eraProtVerHigh @Babbage)
-    , testProperty "babbage/BabbageUtxoPredFailure" $
+    [ testProperty "babbage/BabbageUtxoPredFailure" $
         roundTripCborRangeExpectation @(BabbageUtxoPredFailure Babbage)
           (eraProtVerLow @Babbage)
           (eraProtVerHigh @Babbage)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.9.0.0
 
+* Fix invalid order in `fromGovActionStateSeq`, thus also `DecCBOR` for `ProposalsSnapshot`
+* Remove `DecCBOR`/`EncCBOR` and `FromCBOR`/`ToCBOR` for `RatifyState`, since that state
+  is ephemeral and is never serialized.
 * Add `PredicateFailure` for `Voter` - `GovAction` mismatches, with `checkVotesAreValid`. #3718
   * Add `DisallowedVoters (Map (GovActionId (EraCrypto era)) (Voter (EraCrypto era)))` inhabitant to the `ConwayGovPredFailure` data type.
   * Fix naming for `toPrevGovActionIdsParis` to `toPrevGovActionIdsPairs`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -71,11 +71,11 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.1.3,
         cardano-ledger-allegra >=1.1,
-        cardano-ledger-alonzo ^>=1.4.1,
+        cardano-ledger-alonzo ^>=1.4.2,
         cardano-ledger-babbage >=1.4.1,
-        cardano-ledger-core ^>=1.6,
+        cardano-ledger-core ^>=1.6.1,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley ^>=1.6,
+        cardano-ledger-shelley ^>=1.6.1,
         cardano-slotting,
         cardano-strict-containers,
         containers,
@@ -91,7 +91,10 @@ library
         validation-selective
 
 library testlib
-    exposed-modules:  Test.Cardano.Ledger.Conway.Arbitrary
+    exposed-modules:
+        Test.Cardano.Ledger.Conway.Arbitrary
+        Test.Cardano.Ledger.Conway.Binary.RoundTrip
+
     visibility:       public
     hs-source-dirs:   testlib
     default-language: Haskell2010
@@ -108,6 +111,7 @@ library testlib
         cardano-ledger-babbage:testlib,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-conway,
+        cardano-ledger-shelley,
         cardano-strict-containers,
         small-steps
 
@@ -134,6 +138,7 @@ test-suite tests
         cardano-ledger-core:testlib,
         cardano-ledger-conway,
         cardano-ledger-core,
+        cardano-ledger-binary:testlib,
         containers,
         data-default-class,
         testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -92,9 +92,11 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
+  DecShareCBOR (..),
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
+  decNoShareCBOR,
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -250,20 +252,21 @@ instance EraPParams era => EncCBOR (GovSnapshots era) where
         !> To prevDRepsState
         !> To prevCommitteeState
 
-instance EraPParams era => DecCBOR (GovSnapshots era) where
-  decCBOR =
+-- TODO: Implement Sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+instance EraPParams era => DecShareCBOR (GovSnapshots era) where
+  decShareCBOR _ =
     decode $
       RecD GovSnapshots
+        <! (D decNoShareCBOR)
+        <! (D decNoShareCBOR)
         <! From
-        <! From
-        <! From
-        <! From
+        <! (D decNoShareCBOR)
 
 instance EraPParams era => ToCBOR (GovSnapshots era) where
   toCBOR = toEraCBOR @era
 
 instance EraPParams era => FromCBOR (GovSnapshots era) where
-  fromCBOR = fromEraCBOR @era
+  fromCBOR = fromEraShareCBOR @era
 
 data PrevGovActionIds era = PrevGovActionIds
   { pgaPParamUpdate :: !(StrictMaybe (PrevGovActionId 'PParamUpdatePurpose (EraCrypto era)))
@@ -408,7 +411,11 @@ instance EraPParams era => Default (EnactState era) where
       def
 
 instance EraPParams era => DecCBOR (EnactState era) where
-  decCBOR =
+  decCBOR = decNoShareCBOR
+
+-- TODO: Implement Sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+instance EraPParams era => DecShareCBOR (EnactState era) where
+  decShareCBOR _ =
     decode $
       RecD EnactState
         <! From
@@ -459,43 +466,9 @@ instance EraPParams era => ToExpr (RatifyState era)
 
 instance EraPParams era => Default (RatifyState era)
 
-instance EraPParams era => DecCBOR (RatifyState era) where
-  decCBOR =
-    decode $
-      RecD RatifyState
-        <! From
-        <! From
-        <! From
-
-instance EraPParams era => EncCBOR (RatifyState era) where
-  encCBOR RatifyState {..} =
-    encode $
-      Rec RatifyState
-        !> To rsEnactState
-        !> To rsRemoved
-        !> To rsDelayed
-
-instance EraPParams era => ToCBOR (RatifyState era) where
-  toCBOR = toEraCBOR @era
-
-instance EraPParams era => FromCBOR (RatifyState era) where
-  fromCBOR = fromEraCBOR @era
-
 instance EraPParams era => NFData (RatifyState era)
 
 instance EraPParams era => NoThunks (RatifyState era)
-
-instance EraPParams era => ToJSON (RatifyState era) where
-  toJSON = object . toRatifyStatePairs
-  toEncoding = pairs . mconcat . toRatifyStatePairs
-
-toRatifyStatePairs :: (KeyValue a, EraPParams era) => RatifyState era -> [a]
-toRatifyStatePairs cg@(RatifyState _ _ _) =
-  let RatifyState {..} = cg
-   in [ "enactState" .= rsEnactState
-      , "removed" .= rsRemoved
-      , "delayed" .= rsDelayed
-      ]
 
 data ConwayGovState era = ConwayGovState
   { cgGovSnapshots :: !(GovSnapshots era)
@@ -522,12 +495,16 @@ curPParamsConwayGovStateL = cgEnactStateL . ensCurPParamsL
 prevPParamsConwayGovStateL :: Lens' (ConwayGovState era) (PParams era)
 prevPParamsConwayGovStateL = cgEnactStateL . ensPrevPParamsL
 
-instance EraPParams era => DecCBOR (ConwayGovState era) where
-  decCBOR =
+-- TODO: Implement Sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+instance EraPParams era => DecShareCBOR (ConwayGovState era) where
+  decShareCBOR _ =
     decode $
       RecD ConwayGovState
+        <! (D decNoShareCBOR)
         <! From
-        <! From
+
+instance EraPParams era => DecCBOR (ConwayGovState era) where
+  decCBOR = decNoShareCBOR
 
 instance EraPParams era => EncCBOR (ConwayGovState era) where
   encCBOR ConwayGovState {..} =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -53,7 +53,9 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
+  DecShareCBOR (..),
   EncCBOR (..),
+  decNoShareCBOR,
   decodeEnumBounded,
   decodeMapByKey,
   decodeNullStrictMaybe,
@@ -219,8 +221,9 @@ instance EraPParams era => NoThunks (GovActionState era)
 
 instance EraPParams era => NFData (GovActionState era)
 
-instance EraPParams era => DecCBOR (GovActionState era) where
-  decCBOR =
+-- TODO: Implement Sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+instance EraPParams era => DecShareCBOR (GovActionState era) where
+  decShareCBOR _ =
     decode $
       RecD GovActionState
         <! From
@@ -232,6 +235,9 @@ instance EraPParams era => DecCBOR (GovActionState era) where
         <! From
         <! From
         <! From
+
+instance EraPParams era => DecCBOR (GovActionState era) where
+  decCBOR = decNoShareCBOR
 
 instance EraPParams era => EncCBOR (GovActionState era) where
   encCBOR GovActionState {..} =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
@@ -17,7 +17,7 @@ module Cardano.Ledger.Conway.Governance.Snapshots (
   snapshotGovActionStates,
 ) where
 
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary (DecCBOR (..), DecShareCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Conway.Core (Era (..), EraPParams)
 import Cardano.Ledger.Conway.Governance.Procedures (
   GovActionId,
@@ -65,8 +65,9 @@ instance Default (ProposalsSnapshot era) where
 instance EraPParams era => EncCBOR (ProposalsSnapshot era) where
   encCBOR = encCBOR . snapshotActions
 
-instance EraPParams era => DecCBOR (ProposalsSnapshot era) where
-  decCBOR = fromGovActionStateSeq <$> decCBOR
+-- TODO: Implement Sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+instance EraPParams era => DecShareCBOR (ProposalsSnapshot era) where
+  decShareCBOR _ = fromGovActionStateSeq <$> decCBOR
 
 snapshotInsertGovAction ::
   GovActionState era ->

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/BinarySpec.hs
@@ -1,11 +1,30 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Conway.BinarySpec (spec) where
 
 import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Genesis
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Crypto
+import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
-import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Conway.Binary.RoundTrip (roundTripConwayCommonSpec)
+import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
 
 spec :: Spec
-spec = specUpgrade @Conway True
+spec = do
+  specUpgrade @Conway True
+  describe "RoundTrip" $ do
+    roundTripCborSpec @(GovActionId StandardCrypto)
+    roundTripCborSpec @(PrevGovActionId 'PParamUpdatePurpose StandardCrypto)
+    roundTripCborSpec @(PrevGovActionId 'HardForkPurpose StandardCrypto)
+    roundTripCborSpec @(PrevGovActionId 'CommitteePurpose StandardCrypto)
+    roundTripCborSpec @(PrevGovActionId 'ConstitutionPurpose StandardCrypto)
+    roundTripCborSpec @Vote
+    roundTripCborSpec @(Voter StandardCrypto)
+    roundTripConwayCommonSpec @Conway
+    -- ConwayGenesis only makes sense in Conway era
+    roundTripEraSpec @Conway @(ConwayGenesis StandardCrypto)

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -33,8 +33,8 @@
   },
   "committee" :{
     "members" : {
-       "keyhash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1 ,
-       "scripthash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
+       "keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1 ,
+       "scriptHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
      },
     "quorum": 0.5
   }

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -58,7 +58,7 @@ import Data.Functor.Identity (Identity)
 import Data.List (nubBy)
 import qualified Data.Sequence.Strict as Seq
 import Test.Cardano.Data (genNonEmptyMap)
-import Test.Cardano.Ledger.Alonzo.Arbitrary (genAlonzoScript)
+import Test.Cardano.Ledger.Alonzo.Arbitrary (genAlonzoScript, unFlexibleCostModels)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
 
@@ -149,9 +149,6 @@ instance
       <*> arbitrary
       <*> arbitrary
 
-instance Crypto (EraCrypto era) => Arbitrary (Constitution era) where
-  arbitrary = Constitution <$> arbitrary <*> arbitrary
-
 instance Era era => Arbitrary (PrevGovActionIds era) where
   arbitrary =
     PrevGovActionIds
@@ -176,14 +173,14 @@ instance
 
 uniqueIdGovActions ::
   ( Era era
-  , Arbitrary (PParamsHKD StrictMaybe era)
+  , Arbitrary (PParamsUpdate era)
   ) =>
   Gen (Seq.StrictSeq (GovActionState era))
 uniqueIdGovActions = Seq.fromList . nubBy (\x y -> gasId x == gasId y) <$> arbitrary
 
 instance
   ( Era era
-  , Arbitrary (PParamsHKD StrictMaybe era)
+  , Arbitrary (PParamsUpdate era)
   ) =>
   Arbitrary (ProposalsSnapshot era)
   where
@@ -191,7 +188,7 @@ instance
 
 instance
   ( Era era
-  , Arbitrary (PParamsHKD StrictMaybe era)
+  , Arbitrary (PParamsUpdate era)
   ) =>
   Arbitrary (GovSnapshots era)
   where
@@ -464,7 +461,7 @@ instance Era era => Arbitrary (ConwayPParams Identity era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> (unFlexibleCostModels <$> arbitrary)
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
@@ -498,7 +495,7 @@ instance Era era => Arbitrary (ConwayPParams StrictMaybe era) where
       <*> pure SNothing
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> (fmap unFlexibleCostModels <$> arbitrary)
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conway.Binary.RoundTrip (
+  roundTripConwayCommonSpec,
+  roundTripConwayEraTypesSpec,
+) where
+
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.LedgerState
+import Test.Cardano.Ledger.Alonzo.Arbitrary (FlexibleCostModels (..))
+import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary ()
+import Test.Cardano.Ledger.Core.Binary.RoundTrip
+
+roundTripConwayCommonSpec ::
+  forall era.
+  ( EraTx era
+  , EraGov era
+  , StashedAVVMAddresses era ~ ()
+  , Arbitrary (Tx era)
+  , Arbitrary (TxBody era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (TxWits era)
+  , Arbitrary (TxAuxData era)
+  , Arbitrary (Value era)
+  , Arbitrary (CompactForm (Value era))
+  , Arbitrary (Script era)
+  , Arbitrary (GovState era)
+  , Arbitrary (PParams era)
+  , Arbitrary (PParamsUpdate era)
+  ) =>
+  Spec
+roundTripConwayCommonSpec = do
+  roundTripConwayEraTypesSpec @era
+  roundTripAlonzoCommonSpec @era
+
+roundTripConwayEraTypesSpec ::
+  forall era.
+  ( Arbitrary (PParams era)
+  , Arbitrary (PParamsUpdate era)
+  , EraPParams era
+  ) =>
+  Spec
+roundTripConwayEraTypesSpec = do
+  describe "Conway Transaction Types" $ do
+    roundTripEraTypeSpec @era @GovAction
+    roundTripEraTypeSpec @era @VotingProcedure
+    roundTripEraTypeSpec @era @VotingProcedures
+    roundTripEraTypeSpec @era @ProposalProcedure
+    -- Conway adds ability to serialize unknown cost models, i.e. FlexibleCostModels
+    prop "CostModels" $ roundTripEraExpectation @era . unFlexibleCostModels
+  describe "Conway State Types" $ do
+    roundTripShareEraTypeSpec @era @EnactState
+    roundTripShareEraTypeSpec @era @GovActionState
+    roundTripShareEraTypeSpec @era @ProposalsSnapshot

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.3.0
+version:            1.3.3.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -59,8 +59,8 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.6 && <1.7,
-        cardano-ledger-shelley >=1.6 && <1.7,
+        cardano-ledger-core >=1.6.1 && <1.7,
+        cardano-ledger-shelley >=1.6.1 && <1.7,
         containers,
         deepseq,
         groups,
@@ -117,4 +117,5 @@ test-suite tests
         cardano-ledger-binary:testlib >=1.1,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary,
+        cardano-ledger-shelley:testlib,
         testlib

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -4,8 +4,12 @@ module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
 
 import Cardano.Ledger.Mary
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary as UpgradeSpec
+import Test.Cardano.Ledger.Core.Binary (specUpgrade)
 import Test.Cardano.Ledger.Mary.Arbitrary ()
+import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
 
 spec :: Spec
-spec = specUpgrade @Mary True
+spec = do
+  specUpgrade @Mary True
+  describe "RoundTrip" $ do
+    roundTripShelleyCommonSpec @Mary

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -17,7 +17,6 @@ import Control.State.Transition.Extended (PredicateFailure)
 import Data.Proxy (Proxy (Proxy))
 import Data.Typeable (typeRep)
 import Test.Cardano.Ledger.Binary.RoundTrip (
-  roundTripAnnRangeExpectation,
   roundTripCborExpectation,
  )
 import Test.Cardano.Ledger.Mary.Arbitrary ()
@@ -31,10 +30,6 @@ import Test.Tasty.QuickCheck (testProperty)
 eraRoundTripProps ::
   forall e.
   ( ApplyTx e
-  , Arbitrary (TxBody e)
-  , Arbitrary (TxAuxData e)
-  , Arbitrary (Value e)
-  , Arbitrary (Script e)
   , Arbitrary (ApplyTxError e)
   , EncCBOR (PredicateFailure (EraRule "LEDGER" e))
   , DecCBOR (PredicateFailure (EraRule "LEDGER" e))
@@ -43,20 +38,7 @@ eraRoundTripProps ::
 eraRoundTripProps =
   testGroup
     (show $ typeRep (Proxy @e))
-    [ testProperty "TxBody" $
-        roundTripAnnRangeExpectation @(TxBody e)
-          (eraProtVerLow @e)
-          (eraProtVerHigh @e)
-    , testProperty "Metadata" $
-        roundTripAnnRangeExpectation @(TxAuxData e)
-          (eraProtVerLow @e)
-          (eraProtVerHigh @e)
-    , testProperty "Value" $ roundTripCborExpectation @(Value e)
-    , testProperty "Script" $
-        roundTripAnnRangeExpectation @(Script e)
-          (eraProtVerLow @e)
-          (eraProtVerHigh @e)
-    , testProperty "ApplyTxError" $ roundTripCborExpectation @(ApplyTxError e)
+    [ testProperty "ApplyTxError" $ roundTripCborExpectation @(ApplyTxError e)
     ]
 
 allEraRoundtripTests :: TestTree

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 * Add `FromJSON` instance for `Constitution`
 
+### `testlib`
+
+* Add `Arbitrary` instance for `Constitution`
+* `Test.Cardano.Ledger.Shelley.Binary.RoundTrip` module with:
+  * `roundTripShelleyCommonSpec`
+  * `roundTripStateEraTypesSpec`
+
 ## 1.6.0.0
 
 * Deprecate `isRegKey` and `isDeRegKey` in favor of `isRegStakeTxCert` and `isUnRegStakeTxCert` #3700

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -132,6 +132,7 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Shelley.Arbitrary
         Test.Cardano.Ledger.Shelley.Binary.Golden
+        Test.Cardano.Ledger.Shelley.Binary.RoundTrip
         Test.Cardano.Ledger.Shelley.Constants
 
     visibility:       public
@@ -164,7 +165,11 @@ test-suite tests
     type:             exitcode-stdio-1.0
     main-is:          Main.hs
     hs-source-dirs:   test
-    other-modules:    Test.Cardano.Ledger.Shelley.Binary.GoldenSpec
+    other-modules:
+        Test.Cardano.Ledger.Shelley.BinarySpec
+        Test.Cardano.Ledger.Shelley.Binary.GoldenSpec
+        Test.Cardano.Ledger.Shelley.Binary.RoundTripSpec
+
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates
@@ -173,6 +178,7 @@ test-suite tests
 
     build-depends:
         base,
-        cardano-ledger-core:testlib,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-shelley,
         testlib

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -25,9 +25,11 @@ module Cardano.Ledger.Shelley.Governance (
 import Cardano.Ledger.BaseTypes (Anchor)
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
+  DecShareCBOR (..),
   EncCBOR (encCBOR),
   FromCBOR (..),
   ToCBOR (..),
+  decNoShareCBOR,
   decodeNullStrictMaybe,
   encodeNullStrictMaybe,
  )
@@ -67,6 +69,7 @@ class
   , NFData (GovState era)
   , EncCBOR (GovState era)
   , DecCBOR (GovState era)
+  , DecShareCBOR (GovState era)
   , ToCBOR (GovState era)
   , FromCBOR (GovState era)
   , Default (GovState era)
@@ -178,15 +181,24 @@ instance
   , DecCBOR (PParamsUpdate era)
   , DecCBOR (PParams era)
   ) =>
-  DecCBOR (ShelleyGovState era)
+  DecShareCBOR (ShelleyGovState era)
   where
-  decCBOR =
+  decShareCBOR _ =
     decode $
       RecD ShelleyGovState
         <! From
         <! From
         <! From
         <! From
+
+instance
+  ( Era era
+  , DecCBOR (PParamsUpdate era)
+  , DecCBOR (PParams era)
+  ) =>
+  DecCBOR (ShelleyGovState era)
+  where
+  decCBOR = decNoShareCBOR
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -257,7 +257,7 @@ instance Crypto c => ToJSON (IncrementalStake c) where
   toEncoding = pairs . mconcat . toIncrementalStakePairs
 
 toIncrementalStakePairs ::
-  (KeyValue a, Crypto crypto) => IncrementalStake crypto -> [a]
+  (KeyValue a, Crypto c) => IncrementalStake c -> [a]
 toIncrementalStakePairs iStake@(IStake _ _) =
   let IStake {..} = iStake -- guard against addition or removal of fields
    in [ "credentials" .= credMap
@@ -339,7 +339,8 @@ instance
       utxosUtxo <- decShareCBOR credInterns
       utxosDeposited <- decCBOR
       utxosFees <- decCBOR
-      utxosGovState <- decCBOR
+      -- TODO: implement proper sharing: https://github.com/input-output-hk/cardano-ledger/issues/3486
+      utxosGovState <- decNoShareCBOR
       utxosStakeDistr <- decShareCBOR credInterns
       utxosDonation <- decCBOR
       pure UTxOState {..}

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -1,10 +1,10 @@
 module Main where
 
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Shelley.Binary.GoldenSpec as GoldenSpec
+import qualified Test.Cardano.Ledger.Shelley.BinarySpec as Binary
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Shelley" $ do
-      GoldenSpec.spec
+      Binary.spec

--- a/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/Binary/RoundTripSpec.hs
+++ b/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/Binary/RoundTripSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.Binary.RoundTripSpec (spec) where
+
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley
+import Cardano.Ledger.Shelley.Genesis
+import Cardano.Ledger.Shelley.RewardUpdate
+import Test.Cardano.Ledger.Binary.RoundTrip (roundTripCborSpec)
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
+import Test.Cardano.Ledger.Shelley.Arbitrary ()
+import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
+
+spec :: Spec
+spec =
+  describe "RoundTrip" $ do
+    roundTripShelleyCommonSpec @Shelley
+    describe "Non era parametric Shelley types" $ do
+      roundTripCborSpec @NominalDiffTimeMicro
+      roundTripCborSpec @(ShelleyGenesisStaking StandardCrypto)
+      -- ShelleyGenesis only makes sense in Shelley era
+      roundTripEraSpec @Shelley @(ShelleyGenesis StandardCrypto)
+      roundTripCborSpec @(RewardUpdate StandardCrypto)
+      roundTripCborSpec @(RewardSnapShot StandardCrypto)
+      roundTripCborSpec @(FreeVars StandardCrypto)
+      roundTripCborSpec @(Pulser StandardCrypto)
+      roundTripCborSpec @(PulsingRewUpdate StandardCrypto)

--- a/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/BinarySpec.hs
+++ b/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/BinarySpec.hs
@@ -1,0 +1,10 @@
+module Test.Cardano.Ledger.Shelley.BinarySpec (spec) where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.Binary.GoldenSpec as Golden
+import qualified Test.Cardano.Ledger.Shelley.Binary.RoundTripSpec as RoundTrip
+
+spec :: Spec
+spec = do
+  Golden.spec
+  RoundTrip.spec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -104,7 +104,8 @@ instance Era era => Arbitrary (ShelleyPParams StrictMaybe era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-deriving newtype instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ProposedPPUpdates era)
+instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ProposedPPUpdates era) where
+  arbitrary = ProposedPPUpdates <$> scale (`div` 15) arbitrary
 
 ------------------------------------------------------------------------------------------
 -- Cardano.Ledger.Shelley.TxOut ----------------------------------------------------------

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -30,7 +30,6 @@ import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.EpochBoundary
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (
   ApplyTxError (ApplyTxError),
@@ -151,24 +150,6 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-  shrink = genericShrink
-
-instance Crypto c => Arbitrary (SnapShot c) where
-  arbitrary =
-    SnapShot
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-  shrink = genericShrink
-
-instance Crypto c => Arbitrary (SnapShots c) where
-  arbitrary = do
-    ssStakeMark <- arbitrary
-    ssStakeSet <- arbitrary
-    ssStakeGo <- arbitrary
-    ssFee <- arbitrary
-    let ssStakeMarkPoolDistr = calculatePoolDistr ssStakeMark
-    pure $ SnapShots {..}
   shrink = genericShrink
 
 instance
@@ -318,7 +299,7 @@ instance Crypto c => Arbitrary (FreeVars c) where
   shrink = genericShrink
 
 ------------------------------------------------------------------------------------------
--- Cardano.Ledger.Shelley.Rules ----------------------------------------------------------
+-- Cardano.Ledger.Shelley.Governance -----------------------------------------------------
 ------------------------------------------------------------------------------------------
 
 instance
@@ -331,8 +312,11 @@ instance
   arbitrary = ShelleyGovState <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink
 
+instance Era era => Arbitrary (Constitution era) where
+  arbitrary = Constitution <$> arbitrary <*> arbitrary
+
 ------------------------------------------------------------------------------------------
--- Cardano.Ledger.Shelley.TxAuxData ----------------------------------------------------------
+-- Cardano.Ledger.Shelley.TxAuxData ------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
 -- | Max size of generated Metadatum List and Map

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.Binary.RoundTrip (
+  roundTripShelleyCommonSpec,
+  roundTripStateEraTypesSpec,
+) where
+
+import Cardano.Ledger.Binary
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Governance
+import Cardano.Ledger.Shelley.LedgerState
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary.RoundTrip
+import Test.Cardano.Ledger.Shelley.Arbitrary ()
+
+roundTripShelleyCommonSpec ::
+  forall era.
+  ( EraTx era
+  , EraGov era
+  , Eq (StashedAVVMAddresses era)
+  , Show (StashedAVVMAddresses era)
+  , EncCBOR (StashedAVVMAddresses era)
+  , DecCBOR (StashedAVVMAddresses era)
+  , Arbitrary (StashedAVVMAddresses era)
+  , Arbitrary (Tx era)
+  , Arbitrary (TxBody era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (TxWits era)
+  , Arbitrary (TxAuxData era)
+  , Arbitrary (Value era)
+  , Arbitrary (CompactForm (Value era))
+  , Arbitrary (Script era)
+  , Arbitrary (GovState era)
+  , Arbitrary (PParams era)
+  , Arbitrary (PParamsUpdate era)
+  ) =>
+  Spec
+roundTripShelleyCommonSpec = do
+  roundTripCoreEraTypesSpec @era
+  roundTripStateEraTypesSpec @era
+
+roundTripStateEraTypesSpec ::
+  forall era.
+  ( EraTxOut era
+  , EraGov era
+  , Eq (StashedAVVMAddresses era)
+  , Show (StashedAVVMAddresses era)
+  , EncCBOR (StashedAVVMAddresses era)
+  , DecCBOR (StashedAVVMAddresses era)
+  , Arbitrary (StashedAVVMAddresses era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (Value era)
+  , Arbitrary (PParams era)
+  , Arbitrary (GovState era)
+  ) =>
+  Spec
+roundTripStateEraTypesSpec = do
+  describe "State Types Families" $ do
+    roundTripShareEraSpec @era @(GovState era)
+  describe "State Types" $ do
+    roundTripShareEraTypeSpec @era @UTxOState
+    roundTripEraTypeSpec @era @EpochState
+    roundTripEraTypeSpec @era @NewEpochState
+    roundTripEraTypeSpec @era @Constitution

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley-test
-version:            1.2.0.4
+version:            1.2.0.5
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -87,7 +87,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-byron,
         cardano-ledger-byron-test,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3.1,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.6.1,
         cardano-ledger-pretty,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.7,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,

--- a/eras/shelley/test-suite/test/Golden/ShelleyGenesis
+++ b/eras/shelley/test-suite/test/Golden/ShelleyGenesis
@@ -41,7 +41,7 @@
                 "rewardAccount": {
                     "network": "Testnet",
                     "credential": {
-                        "key hash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
+                        "keyHash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
                     }
                 },
                 "relays": [

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Tripping/CBOR.hs
@@ -12,27 +12,13 @@ module Test.Cardano.Ledger.Shelley.Serialisation.Tripping.CBOR (
 )
 where
 
-import Cardano.Ledger.Binary (
-  DecCBOR (..),
-  EncCBOR (..),
- )
-import qualified Cardano.Ledger.Binary.Plain as Plain
-import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.API as Ledger
-import Cardano.Ledger.Shelley.RewardUpdate (
-  FreeVars (..),
-  Pulser,
-  PulsingRewUpdate (..),
-  RewardSnapShot (..),
- )
 import qualified Cardano.Ledger.Shelley.Rules as STS
 import qualified Cardano.Protocol.TPraos.BHeader as TP
 import qualified Cardano.Protocol.TPraos.Rules.Prtcl as STS (PrtclState)
-import Data.Maybe (fromJust)
-import qualified Test.Cardano.Ledger.Binary.Plain.RoundTrip as Plain
 import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
@@ -52,28 +38,8 @@ testCoreTypes =
         roundTripAnnExpectation @(TP.BHeader StandardCrypto)
     , testProperty "Block Header Hash" $
         roundTripExpectation @(TP.HashHeader StandardCrypto) cborTrip
-    , testProperty "Bootstrap Witness" $
-        roundTripAnnExpectation @(BootstrapWitness StandardCrypto)
-    , testProperty "TxId" $
-        roundTripExpectation @(TxId StandardCrypto) cborTrip
     , testProperty "Protocol State" $
         roundTripExpectation @(STS.PrtclState StandardCrypto) cborTrip
-    , testProperty "SnapShots" $
-        roundTripExpectation @(SnapShots StandardCrypto) (mkTrip encCBOR decCBOR)
-    , testProperty "coin CompactCoin cbor" $
-        roundTripExpectation @Coin (mkTrip (encCBOR . fromJust . toCompact) decCBOR)
-    , testProperty "coin cbor CompactCoin" $
-        roundTripExpectation @Coin (mkTrip encCBOR (fromCompact <$> decCBOR))
-    , testProperty "RewardUpdate" $
-        roundTripExpectation @(RewardUpdate StandardCrypto) cborTrip
-    , testProperty "RewardSnapShot" $
-        roundTripExpectation @(RewardSnapShot StandardCrypto) cborTrip
-    , testProperty "RewardFreeVars" $
-        roundTripExpectation @(FreeVars StandardCrypto) cborTrip
-    , testProperty "RewardPulser" $
-        roundTripExpectation @(Pulser StandardCrypto) cborTrip
-    , testProperty "PulsingRewUpdate" $
-        roundTripExpectation @(PulsingRewUpdate StandardCrypto) cborTrip
     ]
 
 tests :: TestTree
@@ -84,36 +50,7 @@ tests =
           roundTripAnnRangeExpectation @(Block (TP.BHeader StandardCrypto) Shelley)
             (eraProtVerLow @Shelley)
             (eraProtVerHigh @Shelley)
-      , testProperty "TxBody" $
-          roundTripAnnRangeExpectation @(ShelleyTxBody Shelley)
-            (eraProtVerLow @Shelley)
-            (eraProtVerHigh @Shelley)
-      , testProperty "Tx" $
-          roundTripAnnRangeExpectation @(ShelleyTx Shelley)
-            (eraProtVerLow @Shelley)
-            (eraProtVerHigh @Shelley)
-      , testProperty "TxOut" $
-          roundTripExpectation @(ShelleyTxOut Shelley) cborTrip
       , testProperty "LEDGER Predicate Failures" $
           roundTripExpectation @([STS.PredicateFailure (STS.ShelleyLEDGERS Shelley)]) cborTrip
-      , testProperty "Ledger State" $
-          Plain.roundTripExpectation @(LedgerState Shelley) $
-            Plain.mkTrip Plain.toCBOR Plain.fromCBOR
-      , testProperty "Epoch State" $
-          Plain.roundTripExpectation @(EpochState Shelley) Plain.cborTrip
-      , testProperty "NewEpoch State" $
-          Plain.roundTripExpectation @(NewEpochState Shelley) Plain.cborTrip
-      , testProperty "MultiSig" $
-          roundTripAnnRangeExpectation @(MultiSig Shelley)
-            (eraProtVerLow @Shelley)
-            (eraProtVerHigh @Shelley)
-      , testProperty "TxAuxData" $
-          roundTripAnnRangeExpectation @(ShelleyTxAuxData Shelley)
-            (eraProtVerLow @Shelley)
-            (eraProtVerHigh @Shelley)
-      , testProperty "Shelley Genesis" $
-          Plain.roundTripExpectation @(ShelleyGenesis StandardCrypto) Plain.cborTrip
-      , testProperty "NominalDiffTimeMicro" $
-          roundTripExpectation @NominalDiffTimeMicro cborTrip
       , testCoreTypes
       ]

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## 1.1.3.0
 
 * Add `fieldGuarded` to be able to conditionally construct a `Field` #3712
+  * Expose `showDecoderError` from `Cardano.Ledger.Binary.Plain`
+
+### `testlib`
+
+* Add `roundTripCborSpec` and `roundTripAnnCborSpec`
+* Adjust output of `showHexBytesGrouped`
+* Add helper functions: `showMaybeDecoderError` and `showFailedTermsWithReSerialization`
+* Improve failure reporting when re-serialization does not match for RoundTrip tests.
 
 ## 1.1.2.0
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -151,7 +151,13 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
 )
 where
 
-import Cardano.Ledger.Binary.Plain (DecoderError (..), cborError, invalidKey, toCborError)
+import Cardano.Ledger.Binary.Plain (
+  DecoderError (..),
+  cborError,
+  invalidKey,
+  showDecoderError,
+  toCborError,
+ )
 import Cardano.Ledger.Binary.Version (Version, mkVersion64, natVersion)
 import Cardano.Slotting.Slot (WithOrigin, withOriginFromMaybe)
 import Codec.CBOR.ByteArray (ByteArray)
@@ -252,8 +258,6 @@ import Data.Typeable (Proxy (Proxy), Typeable, typeRep)
 import qualified Data.VMap as VMap
 import qualified Data.Vector.Generic as VG
 import Data.Word (Word16, Word32, Word64, Word8)
-import Formatting (build, formatToString)
-import qualified Formatting.Buildable as B (Buildable (..))
 import GHC.Exts as Exts (IsList (..))
 import Network.Socket (HostAddress6)
 import Numeric.Natural (Natural)
@@ -376,9 +380,6 @@ unlessDecoderVersionAtLeast atLeast decoder = do
 --------------------------------------------------------------------------------
 -- Error reporting
 --------------------------------------------------------------------------------
-
-showDecoderError :: B.Buildable e => e -> String
-showDecoderError = formatToString build
 
 decodeVersion :: Decoder s Version
 decodeVersion = decodeWord64 >>= mkVersion64

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Plain.hs
@@ -7,6 +7,7 @@
 module Cardano.Ledger.Binary.Plain (
   module Cardano.Binary,
   module Codec.CBOR.Term,
+  showDecoderError,
   invalidKey,
   decodeRecordNamed,
   decodeRecordNamedT,
@@ -56,6 +57,11 @@ import Control.Monad.Trans.Identity (IdentityT (runIdentityT))
 import Data.ByteString.Base16 as B16
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import Formatting (build, formatToString)
+import qualified Formatting.Buildable as B (Buildable (..))
+
+showDecoderError :: B.Buildable e => e -> String
+showDecoderError = formatToString build
 
 -- | Encode a type as CBOR and encode it as base16
 serializeAsHexText :: ToCBOR a => a -> Text.Text

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -118,10 +118,13 @@ hexByteStringExpr bs =
 -- | Show a ByteString as hex groups of 8bytes each. This is a slightly more
 -- useful form for debugging, rather than bunch of escaped characters.
 showHexBytesGrouped :: BS.ByteString -> [String]
-showHexBytesGrouped bs =
-  [ "0x" <> BS8.unpack (BS.take 128 $ BS.drop i bs16)
-  | i <- [0, 128 .. BS.length bs16 - 1]
-  ]
+showHexBytesGrouped bs
+  | BS.null bs = []
+  | otherwise =
+      ("0x" <> BS8.unpack (BS.take 128 bs16))
+        : [ "  " <> BS8.unpack (BS.take 128 $ BS.drop i bs16)
+          | i <- [128, 256 .. BS.length bs16 - 1]
+          ]
   where
     bs16 = Base16.encode bs
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.6.1.0
 
 * Add `FromJSON` instance to `Anchor`
+* Change `ToJSON/FromJSON` implementation of `Credential` to use `keyHash` vs `key hash`
+  and `scriptHash` vs `script hash` JSON keys.
+* Change `ToJSONKey/FromJSONKey` implementation of `Credential` to use `keyHash-` vs `keyhash-`
+  and `scriptHash-` vs `scripthash-` prefixes.
 
 ## 1.6.0.0
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 ## 1.6.1.0
 
+* Add `fromEraShareCBOR`
+* Remove redundant `DecCBOR` constraint in `eraDecoder`
 * Add `FromJSON` instance to `Anchor`
 * Change `ToJSON/FromJSON` implementation of `Credential` to use `keyHash` vs `key hash`
   and `scriptHash` vs `script hash` JSON keys.
 * Change `ToJSONKey/FromJSONKey` implementation of `Credential` to use `keyHash-` vs `keyhash-`
   and `scriptHash-` vs `scripthash-` prefixes.
+
+### `testlib`
+
+* Add `Arbitrary` instance for `DRepDistr`
+* Move `Arbitrary` instance for `SnapShot` and `SnapShots` from `cardano-ledger-shelley:testlib`
+* Add `Test.Cardano.Ledger.Core.Binary.RoundTrip` with:
+  * `roundTripEraSpec`
+  * `roundTripAnnEraSpec`
+  * `roundTripEraTypeSpec`
+  * `roundTripAnnEraTypeSpec`
+  * `roundTripShareEraSpec`
+  * `roundTripShareEraTypeSpec`
+  * `roundTripEraExpectation`
+  * `roundTripEraTypeExpectation`
+  * `roundTripAnnEraExpectation`
+  * `roundTripAnnEraTypeExpectation`
+  * `roundTripShareEraExpectation`
+  * `roundTripShareEraTypeExpectation`
+  * `roundTripCoreEraTypesSpec`
 
 ## 1.6.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -127,6 +127,7 @@ library testlib
         Test.Cardano.Ledger.Core.Address
         Test.Cardano.Ledger.Core.Arbitrary
         Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
         Test.Cardano.Ledger.Core.KeyPair
         Test.Cardano.Ledger.Core.Utils
 
@@ -170,6 +171,7 @@ test-suite tests
     other-modules:
         Test.Cardano.Ledger.AddressSpec
         Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
         Test.Cardano.Ledger.UMapSpec
 
     default-language: Haskell2010

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Coin (
   toDeltaCoin,
   integerToWord64,
   decodePositiveCoin,
+  compactCoinOrError,
 )
 where
 
@@ -47,6 +48,7 @@ import Data.Primitive.Types
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import GHC.Stack
 import NoThunks.Class (NoThunks (..))
 import Quiet
 
@@ -122,6 +124,12 @@ integerToWord64 c
   | c > fromIntegral (maxBound :: Word64) = Nothing
   | otherwise = Just $ fromIntegral c
 {-# INLINE integerToWord64 #-}
+
+compactCoinOrError :: HasCallStack => Coin -> CompactForm Coin
+compactCoinOrError c =
+  case toCompact c of
+    Nothing -> error $ "Invalid ADA value: " <> show c
+    Just compactCoin -> compactCoin
 
 instance EncCBOR (CompactForm Coin) where
   encCBOR (CompactCoin c) = encCBOR c

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -30,6 +30,7 @@ module Cardano.Ledger.Core.Era (
   eraProtVerHigh,
   toEraCBOR,
   fromEraCBOR,
+  fromEraShareCBOR,
   eraDecoder,
 )
 where
@@ -207,8 +208,14 @@ fromEraCBOR :: forall era t s. (Era era, DecCBOR t) => Plain.Decoder s t
 fromEraCBOR = eraDecoder @era decCBOR
 {-# INLINE fromEraCBOR #-}
 
+-- | Convert a type that implements `DecCBOR` to plain `Plain.Decoder` using the lowest
+-- protocol version for the supplied @era@
+fromEraShareCBOR :: forall era t s. (Era era, DecShareCBOR t) => Plain.Decoder s t
+fromEraShareCBOR = eraDecoder @era decNoShareCBOR
+{-# INLINE fromEraShareCBOR #-}
+
 -- | Convert a versioned `Decoder` to plain a `Plain.Decoder` using the lowest protocol
 -- version for the supplied @era@
-eraDecoder :: forall era t s. (Era era, DecCBOR t) => Decoder s t -> Plain.Decoder s t
+eraDecoder :: forall era t s. Era era => Decoder s t -> Plain.Decoder s t
 eraDecoder = toPlainDecoder (eraProtVerLow @era)
 {-# INLINE eraDecoder #-}

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -208,7 +208,7 @@ fromEraCBOR :: forall era t s. (Era era, DecCBOR t) => Plain.Decoder s t
 fromEraCBOR = eraDecoder @era decCBOR
 {-# INLINE fromEraCBOR #-}
 
--- | Convert a type that implements `DecCBOR` to plain `Plain.Decoder` using the lowest
+-- | Convert a type that implements `DecShareCBOR` to plain `Plain.Decoder` using the lowest
 -- protocol version for the supplied @era@
 fromEraShareCBOR :: forall era t s. (Era era, DecShareCBOR t) => Plain.Decoder s t
 fromEraShareCBOR = eraDecoder @era decNoShareCBOR

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRepDistr.hs
@@ -213,9 +213,15 @@ instance ToExpr (DRepDistr era) where
 -- ==============================================
 -- Functions for pulsing DRepDistr
 
-startDRepDistr :: Int -> UMap c -> Map (Credential 'DRepRole c) (DRepState c) -> VMap VB VP (Credential 'Staking c) (CompactForm Coin) -> DRepDistr c
-startDRepDistr _ _ regDreps _ | Map.null regDreps = DRComplete Map.empty
-startDRepDistr stepSize um regDreps stakeDistr = DRPulsing $ DRepPulser stepSize um regDreps stakeDistr Map.empty
+startDRepDistr ::
+  Int ->
+  UMap c ->
+  Map (Credential 'DRepRole c) (DRepState c) ->
+  VMap VB VP (Credential 'Staking c) (CompactForm Coin) ->
+  DRepDistr c
+startDRepDistr stepSize um regDreps stakeDistr
+  | stepSize <= 0 || Map.null regDreps = DRComplete Map.empty
+  | otherwise = DRPulsing $ DRepPulser stepSize um regDreps stakeDistr Map.empty
 
 pulseDRepDistr :: DRepDistr c -> DRepDistr c
 pulseDRepDistr x@(DRComplete _) = x

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys.hs
@@ -14,8 +14,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Cardano.Ledger.Keys (
   KeyRole (..),
@@ -330,10 +328,8 @@ instance Crypto c => FromJSON (GenDelegPair c) where
 newtype GenDelegs c = GenDelegs
   { unGenDelegs :: Map (KeyHash 'Genesis c) (GenDelegPair c)
   }
-  deriving (Eq, DecCBOR, NoThunks, NFData, Generic, FromJSON)
+  deriving (Eq, EncCBOR, DecCBOR, NoThunks, NFData, Generic, FromJSON)
   deriving (Show) via Quiet (GenDelegs c)
-
-deriving instance Crypto c => EncCBOR (GenDelegs c)
 
 deriving instance Crypto c => ToJSON (GenDelegs c)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -107,7 +107,7 @@ module Cardano.Ledger.UMap (
 where
 
 import Cardano.Ledger.Binary
-import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin), compactCoinOrError)
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core.TxCert (DRep)
 import Cardano.Ledger.Credential (Credential (..), Ptr)
@@ -129,7 +129,6 @@ import qualified Data.Set as Set
 import qualified Data.Set.Internal as SI (Set (Tip))
 import qualified Data.VMap as VMap
 import GHC.Generics (Generic)
-import GHC.Stack (HasCallStack)
 import NoThunks.Class (NoThunks (..))
 import Prelude hiding (lookup, null)
 
@@ -1006,12 +1005,6 @@ unify rd ptr sPool dRep = um4
     um2 = unUView $ Map.foldlWithKey' (\um k v -> insert' k v um) (SPoolUView um1) sPool
     um3 = unUView $ Map.foldlWithKey' (\um k v -> insert' k v um) (DRepUView um2) dRep
     um4 = unUView $ Map.foldlWithKey' (\um k v -> insert' k v um) (PtrUView um3) ptr
-
-compactCoinOrError :: HasCallStack => Coin -> CompactForm Coin
-compactCoinOrError c =
-  case toCompact c of
-    Nothing -> error $ "Invalid ADA value in staking: " <> show c
-    Just compactCoin -> compactCoin
 
 addCompact :: CompactForm Coin -> CompactForm Coin -> CompactForm Coin
 addCompact (CompactCoin x) (CompactCoin y) = CompactCoin (x + y)

--- a/libs/cardano-ledger-core/test/Main.hs
+++ b/libs/cardano-ledger-core/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import qualified Test.Cardano.Ledger.AddressSpec as AddressSpec
 import qualified Test.Cardano.Ledger.BaseTypesSpec as BaseTypesSpec
+import qualified Test.Cardano.Ledger.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.UMapSpec as UMapSpec
 
@@ -10,5 +10,5 @@ main =
   ledgerTestMain $
     describe "Core" $ do
       BaseTypesSpec.spec
-      AddressSpec.spec
+      BinarySpec.spec
       UMapSpec.spec

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Cardano.Ledger.AddressSpec (spec) where
+module Test.Cardano.Ledger.AddressSpec (roundTripAddressSpec) where
 
 import qualified Cardano.Crypto.Hash.Class as Hash
 import Cardano.Ledger.Address
@@ -26,16 +26,17 @@ import Data.Proxy
 import Data.Word
 import Test.Cardano.Ledger.Binary.RoundTrip (
   cborTrip,
-  roundTripExpectation,
+  roundTripCborSpec,
   roundTripRangeExpectation,
  )
 import Test.Cardano.Ledger.Common hiding ((.&.))
 import Test.Cardano.Ledger.Core.Address
 import Test.Cardano.Ledger.Core.Arbitrary (genAddrBadPtr, genCompactAddrBadPtr)
 
-spec :: Spec
-spec = describe "Address" $ do
+roundTripAddressSpec :: Spec
+roundTripAddressSpec = describe "Address" $ do
   describe "CompactAddr" $ do
+    roundTripCborSpec @(CompactAddr StandardCrypto)
     prop "compactAddr/decompactAddr round trip" $
       forAll genAddrBadPtr $
         propCompactAddrRoundTrip @StandardCrypto
@@ -46,8 +47,6 @@ spec = describe "Address" $ do
       propDecompactErrors @StandardCrypto
     prop "Ensure RewardAcnt failures on incorrect binary data" $
       propDeserializeRewardAcntErrors @StandardCrypto
-    prop "RoundTrip-valid" $
-      roundTripExpectation @(CompactAddr StandardCrypto) cborTrip
     prop "RoundTrip-invalid" $
       forAll genCompactAddrBadPtr $
         roundTripRangeExpectation @(CompactAddr StandardCrypto)
@@ -58,16 +57,14 @@ spec = describe "Address" $ do
       propDecompactAddrWithJunk @StandardCrypto
     prop "Same as old decompactor" $ propSameAsOldDecompactAddr @StandardCrypto
   describe "Addr" $ do
-    prop "RoundTrip-valid" $
-      roundTripExpectation @(Addr StandardCrypto) cborTrip
+    roundTripCborSpec @(Addr StandardCrypto)
     prop "RoundTrip-invalid" $
       forAll genAddrBadPtr $
         roundTripRangeExpectation @(Addr StandardCrypto) cborTrip (natVersion @2) (natVersion @6)
     prop "Deserializing an address matches old implementation" $
       propValidateNewDeserialize @StandardCrypto
   describe "RewardAcnt" $ do
-    prop "RewardAcnt" $
-      roundTripExpectation @(RewardAcnt StandardCrypto) cborTrip
+    roundTripCborSpec @(RewardAcnt StandardCrypto)
 
 propSameAsOldDecompactAddr :: forall c. Crypto c => CompactAddr c -> Expectation
 propSameAsOldDecompactAddr cAddr = do

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.BinarySpec (spec) where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Binary
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.DRepDistr
+import Cardano.Ledger.Hashes (EraIndependentData, ScriptHash)
+import Cardano.Ledger.Keys
+import Cardano.Ledger.Keys.Bootstrap
+import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.TxIn
+import Cardano.Ledger.UMap (RDPair)
+import Test.Cardano.Ledger.AddressSpec (roundTripAddressSpec)
+import Test.Cardano.Ledger.Binary.RoundTrip
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Arbitrary ()
+
+spec :: Spec
+spec = do
+  describe "RoundTrip" $ do
+    roundTripCborSpec @Coin
+    roundTripCborSpec @(CompactForm Coin)
+    prop "Encode CompactCoin - Decode Coin" $
+      roundTripExpectation @Coin (mkTrip (encCBOR . compactCoinOrError) decCBOR)
+    prop "Encode Coin - Decode CompactCoin" $
+      roundTripExpectation @Coin (mkTrip encCBOR (fromCompact <$> decCBOR))
+    roundTripCborSpec @ProtVer
+    roundTripCborSpec @Nonce
+    roundTripCborSpec @Url
+    roundTripCborSpec @DnsName
+    roundTripCborSpec @Port
+    roundTripCborSpec @ActiveSlotCoeff
+    roundTripCborSpec @Network
+    roundTripCborSpec @(BlocksMade StandardCrypto)
+    roundTripCborSpec @TxIx
+    roundTripCborSpec @CertIx
+    roundTripCborSpec @(Anchor StandardCrypto)
+    roundTripAddressSpec
+    roundTripAnnCborSpec @(BootstrapWitness StandardCrypto)
+    roundTripCborSpec @(TxId StandardCrypto)
+    roundTripCborSpec @(GenDelegPair StandardCrypto)
+    roundTripCborSpec @(GenDelegs StandardCrypto)
+    roundTripCborSpec @(DRepState StandardCrypto)
+    roundTripCborSpec @(DRepDistr StandardCrypto)
+    roundTripCborSpec @RDPair
+    roundTripCborSpec @(ScriptHash StandardCrypto)
+    roundTripCborSpec @(SafeHash StandardCrypto EraIndependentData)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Core.Binary.RoundTrip (
+  -- * Spec
+  roundTripEraSpec,
+  roundTripAnnEraSpec,
+  roundTripEraTypeSpec,
+  roundTripAnnEraTypeSpec,
+  roundTripShareEraSpec,
+  roundTripShareEraTypeSpec,
+
+  -- * Expectation
+  roundTripEraExpectation,
+  roundTripEraTypeExpectation,
+  roundTripAnnEraExpectation,
+  roundTripAnnEraTypeExpectation,
+  roundTripShareEraExpectation,
+  roundTripShareEraTypeExpectation,
+  roundTripCoreEraTypesSpec,
+) where
+
+import Cardano.Ledger.Binary
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Core
+import Cardano.Ledger.EpochBoundary
+import Cardano.Ledger.Keys.Bootstrap
+import Cardano.Ledger.UTxO
+import Data.Typeable
+import Test.Cardano.Ledger.Binary.RoundTrip
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Arbitrary ()
+
+-- | QuickCheck property spec that uses `roundTripEraExpectation`
+roundTripEraSpec ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecCBOR t, Arbitrary t) =>
+  Spec
+roundTripEraSpec =
+  prop (show (typeRep $ Proxy @t)) $ roundTripEraExpectation @era @t
+
+-- | Roundtrip CBOR testing for types and type families that implement
+-- EncCBOR/DecCBOR. Requires TypeApplication of an @@era@
+roundTripEraExpectation ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecCBOR t) =>
+  t ->
+  Expectation
+roundTripEraExpectation =
+  roundTripCborRangeExpectation (eraProtVerLow @era) (eraProtVerHigh @era)
+
+-- | QuickCheck property spec that uses `roundTripAnnEraExpectation`
+roundTripAnnEraSpec ::
+  forall era t.
+  (Era era, Show t, Eq t, ToCBOR t, DecCBOR (Annotator t), Arbitrary t) =>
+  Spec
+roundTripAnnEraSpec =
+  prop (show (typeRep $ Proxy @t)) $ roundTripAnnEraExpectation @era @t
+
+-- | Similar to `roundTripEraExpectation`, but for Annotator decoders. Note the
+-- constraint `ToCBOR` vs `EncCBOR`, this is due to the requirement for memoized types
+-- to be already fully encoded.
+roundTripAnnEraExpectation ::
+  forall era t.
+  (Era era, Show t, Eq t, ToCBOR t, DecCBOR (Annotator t)) =>
+  t ->
+  Expectation
+roundTripAnnEraExpectation =
+  roundTripAnnRangeExpectation (eraProtVerLow @era) (eraProtVerHigh @era)
+
+-- | QuickCheck property spec that uses `roundTripEraTypeExpectation`
+roundTripEraTypeSpec ::
+  forall era t.
+  (Era era, Show (t era), Eq (t era), EncCBOR (t era), DecCBOR (t era), Arbitrary (t era)) =>
+  Spec
+roundTripEraTypeSpec =
+  prop (show (typeRep $ Proxy @(t era))) $ roundTripEraTypeExpectation @era @t
+
+-- | Roundtrip CBOR testing for types that implement EncCBOR/DecCBOR. Unlike
+-- `roundTripEraExpectation`, this function can't be used with type families, but the
+-- types of this function are unambiguous.
+roundTripEraTypeExpectation ::
+  forall era t.
+  (Era era, Show (t era), Eq (t era), EncCBOR (t era), DecCBOR (t era)) =>
+  t era ->
+  Expectation
+roundTripEraTypeExpectation = roundTripEraExpectation @era @(t era)
+
+-- | QuickCheck property spec that uses `roundTripAnnEraTypeExpectation`
+roundTripAnnEraTypeSpec ::
+  forall era t.
+  ( Era era
+  , Show (t era)
+  , Eq (t era)
+  , ToCBOR (t era)
+  , DecCBOR (Annotator (t era))
+  , Arbitrary (t era)
+  ) =>
+  Spec
+roundTripAnnEraTypeSpec =
+  prop (show (typeRep $ Proxy @(t era))) $ roundTripAnnEraTypeExpectation @era @t
+
+-- | Same as `roundTripAnnEraExpectation`, but is not suitable for type families.
+roundTripAnnEraTypeExpectation ::
+  forall era t.
+  ( Era era
+  , Show (t era)
+  , Eq (t era)
+  , ToCBOR (t era)
+  , DecCBOR (Annotator (t era))
+  ) =>
+  t era ->
+  Expectation
+roundTripAnnEraTypeExpectation = roundTripAnnEraExpectation @era @(t era)
+
+-- | QuickCheck property spec that uses `roundTripShareEraExpectation`
+roundTripShareEraSpec ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecShareCBOR t, Arbitrary t) =>
+  Spec
+roundTripShareEraSpec =
+  prop (show (typeRep $ Proxy @t)) $ roundTripShareEraExpectation @era @t
+
+-- | Roundtrip CBOR testing for types and type families that implement
+-- EncCBOR/DecShareCBOR. Requires TypeApplication of an @@era@
+roundTripShareEraExpectation ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecShareCBOR t) =>
+  t ->
+  Expectation
+roundTripShareEraExpectation =
+  roundTripRangeExpectation
+    (mkTrip encCBOR decNoShareCBOR)
+    (eraProtVerLow @era)
+    (eraProtVerHigh @era)
+
+-- | QuickCheck property spec that uses `roundTripShareEraTypeExpectation`
+roundTripShareEraTypeSpec ::
+  forall era t.
+  (Era era, Show (t era), Eq (t era), EncCBOR (t era), DecShareCBOR (t era), Arbitrary (t era)) =>
+  Spec
+roundTripShareEraTypeSpec =
+  prop (show (typeRep $ Proxy @(t era))) $ roundTripShareEraTypeExpectation @era @t
+
+-- | Roundtrip CBOR testing for types that implement EncCBOR/DecShareCBOR. Unlike
+-- `roundTripShareEraExpectation`, this function can't be used with type families, but the
+-- types of this function are unambiguous.
+roundTripShareEraTypeExpectation ::
+  forall era t.
+  (Era era, Show (t era), Eq (t era), EncCBOR (t era), DecShareCBOR (t era)) =>
+  t era ->
+  Expectation
+roundTripShareEraTypeExpectation = roundTripShareEraExpectation @era @(t era)
+
+-- | CBOR RoundTrip spec for all the core types and type families that are parametrized on era.
+roundTripCoreEraTypesSpec ::
+  forall era.
+  ( EraTx era
+  , Arbitrary (Tx era)
+  , Arbitrary (TxBody era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (TxWits era)
+  , Arbitrary (TxAuxData era)
+  , Arbitrary (Value era)
+  , Arbitrary (CompactForm (Value era))
+  , Arbitrary (Script era)
+  , Arbitrary (PParams era)
+  , Arbitrary (PParamsUpdate era)
+  ) =>
+  Spec
+roundTripCoreEraTypesSpec = do
+  describe "Core Type Families" $ do
+    roundTripEraSpec @era @(Value era)
+    roundTripEraSpec @era @(CompactForm (Value era))
+    roundTripEraSpec @era @(TxOut era)
+    roundTripEraSpec @era @(TxCert era)
+    roundTripEraSpec @era @(PParams era)
+    roundTripEraSpec @era @(PParamsUpdate era)
+    roundTripAnnEraSpec @era @(BootstrapWitness (EraCrypto era))
+    roundTripAnnEraSpec @era @(Script era)
+    roundTripAnnEraSpec @era @(TxAuxData era)
+    roundTripAnnEraSpec @era @(TxWits era)
+    roundTripAnnEraSpec @era @(TxBody era)
+    roundTripAnnEraSpec @era @(Tx era)
+  describe "Core State Types" $ do
+    roundTripShareEraSpec @era @(SnapShots (EraCrypto era))
+    roundTripShareEraTypeSpec @era @DState
+    roundTripShareEraTypeSpec @era @PState
+    roundTripShareEraTypeSpec @era @CommitteeState
+    roundTripShareEraTypeSpec @era @VState
+    roundTripShareEraTypeSpec @era @CertState
+    roundTripShareEraTypeSpec @era @UTxO


### PR DESCRIPTION
# Description

This PR organizes CBOR RoundTrip tests into a nice hierarchy

It captures all of the Conway types and most of the types from other eras, but not all of them. Fixes: #3158 

One important one is still missing is CBOR RoundTrip tests for PredicateFailures, but we can take care of it as a separate task.

Besides tests there other notable changes:

* Fix roundtrip serialization for `ProposalsSnapshot`
* Improve `ToJSON/FromJSON` implementation of `Credential`
* Improvements to RoundTrip tests failure reporting, namely addition of diffing for re-serialization testing

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
