### PR TITLE
Implement `Show` instance for `Rep` using `IsTypeable`

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -160,21 +160,21 @@ infix 4 :⊆:
 pattern (:⊆:) :: forall era. (forall a. Ord a => Term era (Set a) -> Term era (Set a) -> Pred era)
 pattern x :⊆: y = Subset x y
 
-pattern ExactSize :: Int -> Term era Size
+pattern ExactSize :: Era era => Int -> Term era Size
 pattern ExactSize x <- (sameRng -> Just x)
   where
     ExactSize x = Lit SizeR (SzRng x x)
 
-pattern AtLeast :: Int -> Term era Size
+pattern AtLeast :: Era era => Int -> Term era Size
 pattern AtLeast n = Lit SizeR (SzLeast n)
 
-pattern Size :: Size -> Term era Size
+pattern Size :: Era era => Size -> Term era Size
 pattern Size n = Lit SizeR n
 
-pattern AtMost :: Int -> Term era Size
+pattern AtMost :: Era era => Int -> Term era Size
 pattern AtMost n = Lit SizeR (SzMost n)
 
-pattern Range :: Int -> Int -> Term era Size
+pattern Range :: Era era => Int -> Int -> Term era Size
 pattern Range i j <- Lit SizeR (SzRng i j)
   where
     Range i j =
@@ -195,7 +195,7 @@ sameRng :: Term era Size -> Maybe Int
 sameRng (Lit SizeR (SzRng x y)) = if x == y then Just x else Nothing
 sameRng _ = Nothing
 
-pattern Word64 :: Word64 -> Term era Word64
+pattern Word64 :: Era era => Word64 -> Term era Word64
 pattern Word64 x = Lit Word64R x
 
 var :: Era era => String -> Rep era t -> Term era t
@@ -232,10 +232,10 @@ infixl 0 ^$
 (^$) :: Target era (a -> t) -> Term era a -> Target era t
 (^$) f x = f :$ Simple x
 
-constTarget :: t -> Target era t
+constTarget :: Era era => t -> Target era t
 constTarget t = Constr "constTarget" (const t) ^$ Lit UnitR ()
 
-emptyTarget :: Target era ()
+emptyTarget :: Era era => Target era ()
 emptyTarget = Simple (Lit UnitR ())
 
 justTarget :: Term era t -> Target era (Maybe t)
@@ -1009,7 +1009,7 @@ runComp _ t (AnyF (FConst r v _ l)) = do
   With _ <- hasEq r r
   pure $ t ^. l == v
 
-termRep :: Term era t -> Rep era t
+termRep :: Era era => Term era t -> Rep era t
 termRep (Lit r _) = r
 termRep (Var (V _ r _)) = r
 termRep (Dom (termRep -> MapR r _)) = SetR r
@@ -1041,7 +1041,7 @@ makeTest env c = do
   b <- runPred env c
   pure (show c ++ " => " ++ show b, b, c)
 
-displayTerm :: Env era -> Term era a -> IO ()
+displayTerm :: Era era => Env era -> Term era a -> IO ()
 displayTerm env (Var v@(V nm rep _)) = do
   x <- monadTyped (findVar v env)
   putStrLn (nm ++ "\n" ++ format rep x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -232,10 +232,10 @@ infixl 0 ^$
 (^$) :: Target era (a -> t) -> Term era a -> Target era t
 (^$) f x = f :$ Simple x
 
-constTarget :: Era era => t -> Target era t
+constTarget :: t -> Target era t
 constTarget t = Constr "constTarget" (const t) ^$ Lit UnitR ()
 
-emptyTarget :: Era era => Target era ()
+emptyTarget :: Target era ()
 emptyTarget = Simple (Lit UnitR ())
 
 justTarget :: Term era t -> Target era (Maybe t)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -727,7 +727,7 @@ test19 = do
 
 -- ===================================================
 
-preds20 :: Proof era -> [Pred era]
+preds20 :: Era era => Proof era -> [Pred era]
 preds20 proof =
   [ Sized (ExactSize 10) intUniv
   , Sized (AtMost 6) rewardsx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -480,5 +480,5 @@ maybeSL = lens foo bar
 poolMetaL :: Lens' (PoolParams era) (StrictMaybe PoolMetadata)
 poolMetaL = lens ppMetadata (\x r -> x {ppMetadata = r})
 
-poolMetadata :: Proof era -> Term era (Maybe PoolMetadata)
+poolMetadata :: Era era => Proof era -> Term era (Maybe PoolMetadata)
 poolMetadata p = Var (pV p "poolMetadata" (MaybeR (PoolMetadataR p)) (Yes PoolParamsR (poolMetaL . sMaybeL)))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -130,7 +130,7 @@ isCountType rep = case hasCount rep rep of
 -- ==================================================
 -- Extras, simple helper functions
 
-sameRep :: Era era => Rep era i -> Rep era j -> Typed (i :~: j)
+sameRep :: Rep era i -> Rep era j -> Typed (i :~: j)
 sameRep r1 r2 = case testEql r1 r2 of
   Just x -> pure x
   Nothing -> failT ["Type error in sameRep:\n  " ++ show r1 ++ " =/=\n  " ++ show r2]
@@ -167,7 +167,7 @@ exactlyOne pp xs = 1 == length (filter pp xs)
 --   This has been superceeded by the RelLens  RelSpec
 projOnDom ::
   forall era a dom rng.
-  (Era era, Ord dom) =>
+  Ord dom =>
   Set a ->
   Lens' dom a ->
   Rep era dom ->
@@ -180,7 +180,7 @@ projOnDom setA lensDomA repDom repRng = do
   where
     genThenOverwriteA a = Lens.set lensDomA a <$> genRep repDom
 
-atLeast :: (Era era, Adds c) => Rep era c -> c -> Gen c
+atLeast :: Adds c => Rep era c -> c -> Gen c
 atLeast rep c = add c <$> genRep rep
 
 -- ================================================================
@@ -623,7 +623,7 @@ summandsAsInt (x : xs) = do
   m <- summandsAsInt xs
   pure (m + n)
 
-sameV :: Era era => V era s -> V era t -> Typed (s :~: t)
+sameV :: V era s -> V era t -> Typed (s :~: t)
 sameV (V _ r1 _) (V _ r2 _) = sameRep r1 r2
 
 unique2 :: Adds c => V era t -> (Int, Bool, [Name era]) -> Sum era c -> Typed (Int, Bool, [Name era])
@@ -689,7 +689,7 @@ solveLists v@(V nm (ListR _) _) cs =
 -- Helper functions for use in 'dispatch'
 
 -- | Combine solving an generating for a variable with a 'Counts' instance
-genCount :: (Count t, Era era) => V era t -> [Pred era] -> Typed (Gen t)
+genCount :: Count t => V era t -> [Pred era] -> Typed (Gen t)
 genCount v1@(V _ rep _) [Random (Var v2)] | Name v1 == Name v2 = pure (genRep rep)
 genCount v1@(V _ r1 _) [Var v2@(V _ r2 _) :=: expr] | Name v1 == Name v2 = do
   Refl <- sameRep r1 r2
@@ -731,7 +731,7 @@ update :: t -> [Update t] -> t
 update t [] = t
 update t (Update s l : more) = update (Lens.set l s t) more
 
-anyToUpdate :: Era era => Rep era t1 -> (AnyF era t2) -> Typed (Update t1)
+anyToUpdate :: Rep era t1 -> (AnyF era t2) -> Typed (Update t1)
 anyToUpdate rep1 (AnyF (FConst _ s rep2 l)) = do
   Refl <- sameRep rep1 rep2
   pure (Update s l)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
@@ -1546,7 +1546,7 @@ runElemSpec xs spec = case spec of
 
 genElemSpec ::
   forall w era.
-  (Adds w, Era era) =>
+  Adds w =>
   Rep era w ->
   -- Rep era c ->
   SomeLens era w ->
@@ -1583,7 +1583,6 @@ genElemSpec repw (SomeLens (l :: Lens' w c)) siz = do
 
 genFromElemSpec ::
   forall era r.
-  Era era =>
   [String] ->
   Gen r ->
   Int ->
@@ -1710,7 +1709,7 @@ runListSpec xs spec = case spec of
 
 genListSpec ::
   forall w era.
-  (Adds w, Era era) =>
+  Adds w =>
   Rep era w ->
   -- Rep era c ->
   SomeLens era w ->
@@ -1722,7 +1721,6 @@ genListSpec repw l size = do
 
 genFromListSpec ::
   forall era r.
-  Era era =>
   [String] ->
   Gen r ->
   ListSpec era r ->
@@ -1838,7 +1836,7 @@ someSet g = do
   n <- pos @Int
   Set.fromList <$> vectorOf n g
 
-someMap :: forall era t d. (Ord d, TestAdd t, Era era) => Rep era d -> Gen (Map d t)
+someMap :: forall era t d. (Ord d, TestAdd t) => Rep era d -> Gen (Map d t)
 someMap r = do
   n <- pos @Int
   rs <- vectorOf n anyAdds
@@ -1857,7 +1855,7 @@ testm = do
   b <- aMap
   monadTyped (liftT (a <> b))
 
-aList :: Era era => Gen (ListSpec era Word64)
+aList :: Gen (ListSpec era Word64)
 aList = genSize >>= genListSpec Word64R (SomeLens word64CoinL)
 
 testl :: Gen (ListSpec TT Word64)
@@ -2174,7 +2172,7 @@ runPairSpec m1 (PairSpec _ _ VarOnRight m2) = Map.isSubmapOf m2 m1
 -- and insist that when solving 'var' it contains the pairs from 'm2' and possibly more pairs
 runPairSpec m1 (PairSpec _ _ VarOnLeft m2) = Map.isSubmapOf m1 m2
 
-genPairSpec :: (Era era, Ord dom, Eq rng) => Rep era dom -> Rep era rng -> Gen (PairSpec era dom rng)
+genPairSpec :: forall era dom rng. (Ord dom, Eq rng) => Rep era dom -> Rep era rng -> Gen (PairSpec era dom rng)
 genPairSpec domr rngr =
   frequency
     [ (1, pure PairAny)
@@ -2202,7 +2200,7 @@ fixSide _ PairAny = PairAny
 fixSide side (PairSpec d r _ m) = PairSpec d r side m
 
 genConsistentPairSpec ::
-  (Ord dom, Era era, Eq rng) =>
+  (Ord dom, Eq rng) =>
   Rep era dom ->
   Rep era rng ->
   PairSpec era dom rng ->
@@ -2236,7 +2234,7 @@ genConsistentPairSpec _ _ (PairSpec d r VarOnLeft m) =
       )
     ]
 
-genFromPairSpec :: (Era era, Ord dom) => [String] -> PairSpec era dom rng -> Gen (Map dom rng)
+genFromPairSpec :: forall era dom rng. Ord dom => [String] -> PairSpec era dom rng -> Gen (Map dom rng)
 genFromPairSpec msgs (PairNever xs) = errorMess "genFromPairSpec failed due to PairNever" (msgs ++ xs)
 genFromPairSpec _msgs PairAny = pure $ Map.empty
 genFromPairSpec msgs p@(PairSpec domr rngr VarOnRight mp) = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
@@ -16,7 +16,7 @@ import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 -- Some experiments with updating the state (Stored in the Env)
 -- Used as a means to track what applySTS does.
 
-inputsAction :: Proof era -> Set (TxIn (EraCrypto era)) -> TraceM era ()
+inputsAction :: Era era => Proof era -> Set (TxIn (EraCrypto era)) -> TraceM era ()
 inputsAction proof is = updateVar (utxo proof) (\u -> Map.withoutKeys u is)
 
 outputsAction :: Reflect era => Proof era -> TxBody era -> [TxOutF era] -> TraceM era ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -58,7 +58,6 @@ import Cardano.Ledger.Conway.Governance (Committee (..), Constitution, GovAction
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential, Ptr)
-import Cardano.Ledger.Crypto (Crypto)
 import qualified Cardano.Ledger.Crypto as CC (Crypto (HASH))
 import Cardano.Ledger.DRepDistr (DRepState)
 import Cardano.Ledger.EpochBoundary (SnapShots (..))
@@ -212,101 +211,101 @@ data Rep era t where
   MapR :: Ord a => Rep era a -> Rep era b -> Rep era (Map a b)
   SetR :: Ord a => Rep era a -> Rep era (Set a)
   ListR :: Rep era a -> Rep era [a]
-  AddrR :: Rep era (Addr (EraCrypto era))
-  CredR :: Rep era (Credential 'Staking (EraCrypto era))
-  VCredR :: Rep era (Credential 'DRepRole (EraCrypto era))
-  PoolHashR :: Rep era (KeyHash 'StakePool (EraCrypto era))
-  WitHashR :: Rep era (KeyHash 'Witness (EraCrypto era))
-  GenHashR :: Rep era (KeyHash 'Genesis (EraCrypto era))
-  GenDelegHashR :: Rep era (KeyHash 'GenesisDelegate (EraCrypto era))
-  VHashR :: Rep era (KeyHash 'DRepRole (EraCrypto era))
-  CommColdCredR :: Rep era (Credential 'ColdCommitteeRole (EraCrypto era))
-  CommHotCredR :: Rep era (Credential 'HotCommitteeRole (EraCrypto era))
-  PoolParamsR :: Rep era (PoolParams (EraCrypto era))
-  NewEpochStateR :: Rep era (NewEpochState era)
+  AddrR :: Era era => Rep era (Addr (EraCrypto era))
+  CredR :: Era era => Rep era (Credential 'Staking (EraCrypto era))
+  VCredR :: Era era => Rep era (Credential 'DRepRole (EraCrypto era))
+  PoolHashR :: Era era => Rep era (KeyHash 'StakePool (EraCrypto era))
+  WitHashR :: Era era => Rep era (KeyHash 'Witness (EraCrypto era))
+  GenHashR :: Era era => Rep era (KeyHash 'Genesis (EraCrypto era))
+  GenDelegHashR :: Era era => Rep era (KeyHash 'GenesisDelegate (EraCrypto era))
+  VHashR :: Era era => Rep era (KeyHash 'DRepRole (EraCrypto era))
+  CommColdCredR :: Era era => Rep era (Credential 'ColdCommitteeRole (EraCrypto era))
+  CommHotCredR :: Era era => Rep era (Credential 'HotCommitteeRole (EraCrypto era))
+  PoolParamsR :: Era era => Rep era (PoolParams (EraCrypto era))
+  NewEpochStateR :: Era era => Rep era (NewEpochState era)
   IntR :: Rep era Int
   FloatR :: Rep era Float
   NaturalR :: Rep era Natural
   Word64R :: Rep era Word64
-  TxInR :: Rep era (TxIn (EraCrypto era))
+  TxInR :: Era era => Rep era (TxIn (EraCrypto era))
   CharR :: Rep era Char
   UnitR :: Rep era ()
   PairR :: Rep era a -> Rep era b -> Rep era (a, b)
-  ProtVerR :: Proof era -> Rep era ProtVer -- We need the Proof to get arbitrary instances correct
+  ProtVerR :: Era era => Proof era -> Rep era ProtVer -- We need the Proof to get arbitrary instances correct
   -- \^ Rep's for type families (or those that embed type families)
-  ValueR :: Proof era -> Rep era (ValueF era)
-  UTxOR :: Proof era -> Rep era (UTxO era)
-  TxOutR :: Proof era -> Rep era (TxOutF era)
-  PParamsR :: Proof era -> Rep era (PParamsF era)
-  PParamsUpdateR :: Proof era -> Rep era (PParamsUpdateF era)
+  ValueR :: Era era => Proof era -> Rep era (ValueF era)
+  UTxOR :: Era era => Proof era -> Rep era (UTxO era)
+  TxOutR :: Era era => Proof era -> Rep era (TxOutF era)
+  PParamsR :: Era era => Proof era -> Rep era (PParamsF era)
+  PParamsUpdateR :: Era era => Proof era -> Rep era (PParamsUpdateF era)
   --
   DeltaCoinR :: Rep era DeltaCoin
-  GenDelegPairR :: Rep era (GenDelegPair (EraCrypto era))
-  FutureGenDelegR :: Rep era (FutureGenDeleg (EraCrypto era))
-  PPUPStateR :: Proof era -> Rep era (ShelleyGovState era)
+  GenDelegPairR :: Era era => Rep era (GenDelegPair (EraCrypto era))
+  FutureGenDelegR :: Era era => Rep era (FutureGenDeleg (EraCrypto era))
+  PPUPStateR :: Era era => Proof era -> Rep era (ShelleyGovState era)
   PtrR :: Rep era Ptr
-  IPoolStakeR :: Rep era (IndividualPoolStake (EraCrypto era))
-  SnapShotsR :: Rep era (SnapShots (EraCrypto era))
-  RewardR :: Rep era (Reward (EraCrypto era))
+  IPoolStakeR :: Era era => Rep era (IndividualPoolStake (EraCrypto era))
+  SnapShotsR :: Era era => Rep era (SnapShots (EraCrypto era))
+  RewardR :: Era era => Rep era (Reward (EraCrypto era))
   MaybeR :: Rep era t -> Rep era (Maybe t)
   SlotNoR :: Rep era SlotNo
   SizeR :: Rep era Size
-  MultiAssetR :: Crypto (EraCrypto era) => Rep era (MultiAsset (EraCrypto era))
-  PolicyIDR :: Rep era (PolicyID (EraCrypto era))
-  WitnessesFieldR :: Proof era -> Rep era (WitnessesField era)
+  MultiAssetR :: Era era => Rep era (MultiAsset (EraCrypto era))
+  PolicyIDR :: Era era => Rep era (PolicyID (EraCrypto era))
+  WitnessesFieldR :: Era era => Proof era -> Rep era (WitnessesField era)
   AssetNameR :: Rep era AssetName
-  TxCertR :: Proof era -> Rep era (TxCertF era)
-  RewardAcntR :: Rep era (RewardAcnt (EraCrypto era))
-  ValidityIntervalR :: Rep era ValidityInterval
-  KeyPairR :: Rep era (KeyPair 'Witness (EraCrypto era))
+  TxCertR :: Era era => Proof era -> Rep era (TxCertF era)
+  RewardAcntR :: Era era => Rep era (RewardAcnt (EraCrypto era))
+  ValidityIntervalR :: Era era => Rep era ValidityInterval
+  KeyPairR :: Era era => Rep era (KeyPair 'Witness (EraCrypto era))
   GenR :: Rep era x -> Rep era (Gen x)
-  ScriptR :: Proof era -> Rep era (ScriptF era)
-  ScriptHashR :: Rep era (ScriptHash (EraCrypto era))
+  ScriptR :: Era era => Proof era -> Rep era (ScriptF era)
+  ScriptHashR :: Era era => Rep era (ScriptHash (EraCrypto era))
   NetworkR :: Rep era Network
   RdmrPtrR :: Rep era RdmrPtr
   DataR :: Era era => Rep era (Data era)
   DatumR :: Era era => Rep era (Datum era)
   ExUnitsR :: Rep era ExUnits
   TagR :: Rep era Tag
-  DataHashR :: Rep era (DataHash (EraCrypto era))
-  PCredR :: Rep era (Credential 'Payment (EraCrypto era))
-  ShelleyTxCertR :: Rep era (ShelleyTxCert era)
-  ConwayTxCertR :: Rep era (ConwayTxCert era)
+  DataHashR :: Era era => Rep era (DataHash (EraCrypto era))
+  PCredR :: Era era => Rep era (Credential 'Payment (EraCrypto era))
+  ShelleyTxCertR :: Era era => Rep era (ShelleyTxCert era)
+  ConwayTxCertR :: Era era => Rep era (ConwayTxCert era)
   MIRPotR :: Rep era MIRPot
   IsValidR :: Rep era IsValid
   IntegerR :: Rep era Integer
-  ScriptsNeededR :: Proof era -> Rep era (ScriptsNeededF era)
-  ScriptPurposeR :: Proof era -> Rep era (ScriptPurpose era)
-  TxBodyR :: Proof era -> Rep era (TxBodyF era)
-  BootstrapWitnessR :: Crypto (EraCrypto era) => Rep era (BootstrapWitness (EraCrypto era))
+  ScriptsNeededR :: Era era => Proof era -> Rep era (ScriptsNeededF era)
+  ScriptPurposeR :: Era era => Proof era -> Rep era (ScriptPurpose era)
+  TxBodyR :: Era era => Proof era -> Rep era (TxBodyF era)
+  BootstrapWitnessR :: Era era => Rep era (BootstrapWitness (EraCrypto era))
   SigningKeyR :: Rep era SigningKey
-  TxWitsR :: Proof era -> Rep era (TxWitsF era)
-  PayHashR :: Rep era (KeyHash 'Payment (EraCrypto era))
-  TxR :: Proof era -> Rep era (TxF era)
-  ScriptIntegrityHashR :: Rep era (SafeHash (EraCrypto era) EraIndependentScriptIntegrity)
-  AuxiliaryDataHashR :: Rep era (AuxiliaryDataHash (EraCrypto era))
-  GovActionR :: Rep era (GovAction era)
-  WitVKeyR :: Proof era -> Rep era (WitVKey 'Witness (EraCrypto era))
-  TxAuxDataR :: Proof era -> Rep era (TxAuxDataF era)
+  TxWitsR :: Era era => Proof era -> Rep era (TxWitsF era)
+  PayHashR :: Era era => Rep era (KeyHash 'Payment (EraCrypto era))
+  TxR :: Era era => Proof era -> Rep era (TxF era)
+  ScriptIntegrityHashR :: Era era => Rep era (SafeHash (EraCrypto era) EraIndependentScriptIntegrity)
+  AuxiliaryDataHashR :: Era era => Rep era (AuxiliaryDataHash (EraCrypto era))
+  GovActionR :: Era era => Rep era (GovAction era)
+  WitVKeyR :: Era era => Proof era -> Rep era (WitVKey 'Witness (EraCrypto era))
+  TxAuxDataR :: Era era => Proof era -> Rep era (TxAuxDataF era)
   LanguageR :: Rep era Language
-  LedgerStateR :: Proof era -> Rep era (LedgerState era)
-  StakeHashR :: Rep era (KeyHash 'Staking (EraCrypto era))
+  LedgerStateR :: Era era => Proof era -> Rep era (LedgerState era)
+  StakeHashR :: Era era => Rep era (KeyHash 'Staking (EraCrypto era))
   BoolR :: Rep era Bool
-  DRepR :: Rep era (Core.DRep (EraCrypto era))
-  PoolMetadataR :: Proof era -> Rep era PoolMetadata
-  DRepStateR :: Rep era (DRepState (EraCrypto era))
-  DStateR :: Rep era (DState era)
-  GovActionIdR :: Rep era (GovActionId (EraCrypto era))
+  DRepR :: Era era => Rep era (Core.DRep (EraCrypto era))
+  PoolMetadataR :: Era era => Proof era -> Rep era PoolMetadata
+  DRepStateR :: Era era => Rep era (DRepState (EraCrypto era))
+  DStateR :: Era era => Rep era (DState era)
+  GovActionIdR :: Era era => Rep era (GovActionId (EraCrypto era))
   GovActionIxR :: Rep era GovActionIx
-  GovActionStateR :: Rep era (GovActionState era)
+  GovActionStateR :: Era era => Rep era (GovActionState era)
   UnitIntervalR :: Rep era UnitInterval
-  CommitteeR :: Rep era (Committee era)
-  ConstitutionR :: Rep era (Constitution era)
-  PrevGovActionIdsR :: Rep era (PrevGovActionIds era)
-  PrevPParamUpdateR :: Rep era (PrevGovActionId 'PParamUpdatePurpose (EraCrypto era))
-  PrevHardForkR :: Rep era (PrevGovActionId 'HardForkPurpose (EraCrypto era))
-  PrevCommitteeR :: Rep era (PrevGovActionId 'CommitteePurpose (EraCrypto era))
-  PrevConstitutionR :: Rep era (PrevGovActionId 'ConstitutionPurpose (EraCrypto era))
+  CommitteeR :: Era era => Rep era (Committee era)
+  ConstitutionR :: Era era => Rep era (Constitution era)
+  PrevGovActionIdsR :: Era era => Rep era (PrevGovActionIds era)
+  PrevPParamUpdateR :: Era era => Rep era (PrevGovActionId 'PParamUpdatePurpose (EraCrypto era))
+  PrevHardForkR :: Era era => Rep era (PrevGovActionId 'HardForkPurpose (EraCrypto era))
+  PrevCommitteeR :: Era era => Rep era (PrevGovActionId 'CommitteePurpose (EraCrypto era))
+  PrevConstitutionR :: Era era => Rep era (PrevGovActionId 'ConstitutionPurpose (EraCrypto era))
 
 stringR :: Rep era String
 stringR = ListR CharR
@@ -317,7 +316,7 @@ stringR = ListR CharR
 data IsTypeable a where
   IsTypeable :: Typeable a => IsTypeable a
 
-repTypeable :: Era era => Rep era t -> IsTypeable t
+repTypeable :: Rep era t -> IsTypeable t
 repTypeable r = case r of
   DRepStateR -> IsTypeable
   CommColdCredR -> IsTypeable
@@ -424,7 +423,7 @@ repTypeable r = case r of
   PrevCommitteeR {} -> IsTypeable
   PrevConstitutionR {} -> IsTypeable
 
-instance Era era => Singleton (Rep era) where
+instance Singleton (Rep era) where
   testEql
     (repTypeable -> IsTypeable :: IsTypeable a)
     (repTypeable -> IsTypeable :: IsTypeable b) = eqT @a @b
@@ -434,106 +433,7 @@ instance Era era => Singleton (Rep era) where
 -- Show instances
 
 instance Show (Rep era t) where
-  show CoinR = "Coin"
-  show (a :-> b) = "(" ++ show a ++ " -> " ++ show b ++ ")"
-  show (MapR a b) = "(Map " ++ show a ++ " " ++ show b ++ ")"
-  show (SetR a) = "(Set " ++ show a ++ ")"
-  show (ListR a) = "[" ++ show a ++ "]"
-  show AddrR = "Addr"
-  show CredR = "(Credential 'Staking c)"
-  show PoolHashR = "(KeyHash 'StakePool c)"
-  show WitHashR = "(KeyHash 'Witness c)"
-  show GenHashR = "(KeyHash 'Genesis c)"
-  show GenDelegHashR = "(KeyHash 'GenesisDelegate c)"
-  show PoolParamsR = "(PoolParams c)"
-  show EpochR = "EpochNo"
-  show RationalR = "Rational"
-  show Word64R = "Word64"
-  show IntR = "Int"
-  show NaturalR = "Natural"
-  show FloatR = "Float"
-  show TxInR = "TxIn"
-  show (ValueR x) = "(Value " ++ short x ++ ")"
-  show (TxOutR x) = "(TxOut " ++ short x ++ ")"
-  show (UTxOR x) = "(UTxO " ++ short x ++ ")"
-  show (PParamsR x) = "(PParams " ++ short x ++ ")"
-  show (PParamsUpdateR x) = "(PParamsUpdate " ++ short x ++ ")"
-  show CharR = "Char"
-  show DeltaCoinR = "DeltaCoin"
-  show GenDelegPairR = "(GenDelegPair c)"
-  show FutureGenDelegR = "(FutureGenDeleg c)"
-  show (PPUPStateR p) = "(ShelleyGovState " ++ short p ++ ")"
-  show PtrR = "Ptr"
-  show IPoolStakeR = "(IndividualPoolStake c)"
-  show SnapShotsR = "(SnapShots c)"
-  show UnitR = "()"
-  show (PairR a b) = "(" ++ show a ++ ", " ++ show b ++ ")"
-  show RewardR = "(Reward c)"
-  show (MaybeR x) = "(Maybe " ++ show x ++ ")"
-  show NewEpochStateR = "NewEpochState"
-  show (ProtVerR x) = "(ProtVer " ++ short x ++ ")"
-  show SlotNoR = "(SlotNo c)"
-  show SizeR = "Size"
-  show VCredR = "(Credential 'Voting c)"
-  show VHashR = "(KeyHash 'Voting c)"
-  show MultiAssetR = "(MultiAsset c)"
-  show PolicyIDR = "(PolicyID c)"
-  show (WitnessesFieldR p) = "(WitnessesField " ++ short p ++ ")"
-  show AssetNameR = "AssetName"
-  show (TxCertR p) = "(TxCert " ++ short p ++ ")"
-  show RewardAcntR = "(RewardAcnt c)"
-  show ValidityIntervalR = "ValidityInterval"
-  show KeyPairR = "(KeyPair 'Witness era)"
-  show (GenR x) = "(Gen " ++ show x ++ ")"
-  show (ScriptR x) = "(Script " ++ short x ++ ")"
-  show ScriptHashR = "(ScriptHash c)"
-  show NetworkR = "Network"
-  show RdmrPtrR = "RdmrPtr"
-  show DataR = "(Data era)"
-  show DatumR = "(Datum era)"
-  show ExUnitsR = "ExUnits"
-  show TagR = "Tag"
-  show DataHashR = "(DataHash c)"
-  show PCredR = "(Credential 'Payment c)"
-  show ConwayTxCertR = "(ConwayTxCert era)"
-  show ShelleyTxCertR = "(ShelleyTxCert era)"
-  show MIRPotR = "MIRPot"
-  show IsValidR = "IsValid"
-  show IntegerR = "Integer"
-  show (ScriptsNeededR p) = "(ScriptsNeeded " ++ short p ++ ")"
-  show (ScriptPurposeR p) = "(ScriptPurpose " ++ short p ++ ")"
-  show (TxBodyR p) = "(TxBody " ++ short p ++ ")"
-  show BootstrapWitnessR = "(BootstrapWitness c)"
-  show SigningKeyR = "Byron.SigningKey"
-  show (TxWitsR p) = "(TxWits " ++ short p ++ ")"
-  show PayHashR = "(KeyHash 'Payment c)"
-  show (TxR p) = "(Tx " ++ short p ++ ")"
-  show ScriptIntegrityHashR = "ScriptIntegrityHash"
-  show AuxiliaryDataHashR = "AuxiliaryDataHash"
-  show GovActionR = "GovAction"
-  show (WitVKeyR _) = "(WitVKey 'Witness c)"
-  show (TxAuxDataR p) = "(TxAuxData " ++ short p ++ ")"
-  show CommColdCredR = "CommColdCred"
-  show CommHotCredR = "CommHotCred"
-  show LanguageR = "Language"
-  show (LedgerStateR p) = "(LedgerState " ++ short p ++ ")"
-  show StakeHashR = "(KeyHash 'Staking c)"
-  show BoolR = "Bool"
-  show DRepR = "(DRep c)"
-  show (PoolMetadataR _) = "PoolMetadata"
-  show DRepStateR = "DRepState"
-  show DStateR = "(DState c)"
-  show GovActionIdR = "(GovActionId c)"
-  show GovActionIxR = "GovActionIx"
-  show GovActionStateR = "GovActionState"
-  show UnitIntervalR = "UnitInterval"
-  show CommitteeR = "Committee"
-  show ConstitutionR = "Constitution"
-  show PrevGovActionIdsR = "PrevGovActionIds"
-  show PrevPParamUpdateR = "(PrevGovActionId 'PParamUpdate c)"
-  show PrevHardForkR = "(PrevGovActionId 'HardFork c)"
-  show PrevCommitteeR = "(PrevGovActionId 'Committee c)"
-  show PrevConstitutionR = "(PrevGovActionId 'Constitution c)"
+  showsPrec d (repTypeable -> IsTypeable :: IsTypeable t) = showsPrec d $ typeRep (Proxy @t)
 
 synopsis :: forall e t. Rep e t -> t -> String
 synopsis RationalR r = show r
@@ -780,14 +680,13 @@ instance Shaped (Rep era) any where
   shape PrevCommitteeR = Nullary 98
   shape PrevConstitutionR = Nullary 99
 
-compareRep :: forall era t s. Era era => Rep era t -> Rep era s -> Ordering
+compareRep :: forall era t s. Rep era t -> Rep era s -> Ordering
 compareRep = cmpIndex @(Rep era)
 
 -- ================================================
 
 genSizedRep ::
   forall era t.
-  Era era =>
   Int ->
   Rep era t ->
   Gen t
@@ -960,7 +859,6 @@ genSizedRep _ PrevConstitutionR = arbitrary
 
 genRep ::
   forall era b.
-  Era era =>
   Rep era b ->
   Gen b
 genRep IntR = choose (0, 10000)
@@ -995,7 +893,7 @@ genpup (PPUPStateR (Conway _)) = arbitrary -- FIXME when Conway is fully defined
 
 -- Not all types in the universe have Arbitrary instances and thus don't shrink (the `[]` cases).
 -- TODO: add instances for these types.
-shrinkRep :: Era era => Rep era t -> t -> [t]
+shrinkRep :: Rep era t -> t -> [t]
 shrinkRep CoinR t = shrink t
 shrinkRep (_ :-> _) _ = []
 shrinkRep (MapR a b) t = shrinkMapBy Map.fromList Map.toList (shrinkRep $ ListR (PairR a b)) t
@@ -1103,14 +1001,6 @@ shrinkRep PrevCommitteeR x = shrink x
 shrinkRep PrevConstitutionR x = shrink x
 
 -- ===========================
-
-short :: Proof era -> String
-short (Shelley _) = "Shelley"
-short (Allegra _) = "Allegra"
-short (Mary _) = "Mary"
-short (Alonzo _) = "Alonzo"
-short (Babbage _) = "Babbage"
-short (Conway _) = "Conway"
 
 hasOrd :: Rep era t -> s t -> Typed (HasConstraint Ord (s t))
 hasOrd rep xx = explain ("'hasOrd " ++ show rep ++ "' fails") (help rep xx)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -284,7 +284,7 @@ committeeStateL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeS
 
 -- UTxOState
 
-utxo :: Proof era -> Term era (Map (TxIn (EraCrypto era)) (TxOutF era))
+utxo :: Era era => Proof era -> Term era (Map (TxIn (EraCrypto era)) (TxOutF era))
 utxo p = Var $ pV p "utxo" (MapR TxInR (TxOutR p)) (Yes NewEpochStateR (utxoL p))
 
 utxoL :: Proof era -> NELens era (Map (TxIn (EraCrypto era)) (TxOutF era))
@@ -311,7 +311,7 @@ donation = Var $ V "donation" CoinR (Yes NewEpochStateR donationL)
 donationL :: NELens era Coin
 donationL = nesEsL . esLStateL . lsUTxOStateL . utxosDonationL
 
-ppup :: Proof era -> Term era (ShelleyGovState era)
+ppup :: Era era => Proof era -> Term era (ShelleyGovState era)
 ppup p = Var $ pV p "ppup" (PPUPStateR p) (Yes NewEpochStateR (ppupsL p))
 
 ppupsL :: Proof era -> NELens era (ShelleyGovState era)
@@ -324,14 +324,14 @@ ppupsL (Conway _) = error "Conway era does not have a PPUPState, in ppupsL"
 
 -- nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . ???
 
-proposalsT :: Proof era -> Term era (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
+proposalsT :: Era era => Proof era -> Term era (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
 proposalsT p = Var (pV p "proposals" (MapR GenHashR (PParamsUpdateR p)) No)
 
 futureProposalsT ::
-  Proof era -> Term era (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
+  Era era => Proof era -> Term era (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
 futureProposalsT p = Var (pV p "futureProposals" (MapR GenHashR (PParamsUpdateR p)) No)
 
-currPParams :: Proof era -> Term era (PParamsF era)
+currPParams :: Era era => Proof era -> Term era (PParamsF era)
 currPParams p = Var (pV p "currPParams" (PParamsR p) No)
 
 prevPParams :: Gov.EraGov era => Proof era -> Term era (PParamsF era)
@@ -670,15 +670,15 @@ payUniv = Var $ V "payUniv" (SetR PCredR) No
 -- | The universe of Scripts (and their hashes) useable in spending contexts
 --  That means if they are Plutus scripts then they will be passed an additional
 --  argument (the TxInfo context)
-spendscriptUniv :: Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
+spendscriptUniv :: Era era => Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
 spendscriptUniv p = Var (pV p "spendscriptUniv" (MapR ScriptHashR (ScriptR p)) No)
 
 -- | The universe of Scripts (and their hashes) useable in contexts other than Spending
-nonSpendScriptUniv :: Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
+nonSpendScriptUniv :: Era era => Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
 nonSpendScriptUniv p = Var (pV p "nonSpendScriptUniv" (MapR ScriptHashR (ScriptR p)) No)
 
 -- | The union of 'spendscriptUniv' and 'nonSpendScriptUniv'. All possible scripts in any context
-allScriptUniv :: Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
+allScriptUniv :: Era era => Proof era -> Term era (Map (ScriptHash (EraCrypto era)) (ScriptF era))
 allScriptUniv p = Var (pV p "allScriptUniv" (MapR ScriptHashR (ScriptR p)) No)
 
 -- | The universe of Data (and their hashes)
@@ -709,13 +709,13 @@ txinUniv = Var $ V "txinUniv" (SetR TxInR) No
 -- | The universe of TxOuts.
 --   It contains 'colTxoutUniv' as a sublist and 'feeOutput' as an element
 --   See also 'feeOutput' which is defined by the universes, and is related.
-txoutUniv :: Proof era -> Term era (Set (TxOutF era))
+txoutUniv :: Era era => Proof era -> Term era (Set (TxOutF era))
 txoutUniv p = Var (pV p "txoutUniv" (SetR (TxOutR p)) No)
 
 -- | The universe of TxOuts useable for collateral
 --   The collateral TxOuts consists only of VKey addresses
 --   and The collateral TxOuts do not contain any non-ADA part
-colTxoutUniv :: Proof era -> Term era (Set (TxOutF era))
+colTxoutUniv :: Era era => Proof era -> Term era (Set (TxOutF era))
 colTxoutUniv p = Var (pV p "colTxoutUniv" (SetR (TxOutR p)) No)
 
 -- | A TxOut, guaranteed to have
@@ -979,7 +979,7 @@ withEraPParams (Babbage _) x = x
 withEraPParams (Conway _) x = x
 
 -- | ProtVer in pparams
-protVer :: Proof era -> Term era ProtVer
+protVer :: Era era => Proof era -> Term era ProtVer
 protVer proof =
   Var
     ( pV
@@ -990,7 +990,7 @@ protVer proof =
     )
 
 -- | ProtVer in prevPParams
-prevProtVer :: Proof era -> Term era ProtVer
+prevProtVer :: Era era => Proof era -> Term era ProtVer
 prevProtVer proof =
   Var
     ( pV
@@ -1000,7 +1000,7 @@ prevProtVer proof =
         (Yes (PParamsR proof) $ withEraPParams proof (pparamsWrapperL . ppProtocolVersionL))
     )
 
-minFeeA :: Proof era -> Term era Coin
+minFeeA :: Era era => Proof era -> Term era Coin
 minFeeA proof =
   Var
     ( pV
@@ -1010,7 +1010,7 @@ minFeeA proof =
         (Yes (PParamsR proof) $ withEraPParams proof (pparamsWrapperL . ppMinFeeAL))
     )
 
-minFeeB :: Proof era -> Term era Coin
+minFeeB :: Era era => Proof era -> Term era Coin
 minFeeB proof =
   Var
     ( pV
@@ -1021,7 +1021,7 @@ minFeeB proof =
     )
 
 -- | Max Block Body Size
-maxBBSize :: Proof era -> Term era Natural
+maxBBSize :: Era era => Proof era -> Term era Natural
 maxBBSize p =
   Var
     ( pV
@@ -1032,7 +1032,7 @@ maxBBSize p =
     )
 
 -- | Max Tx Size
-maxTxSize :: Proof era -> Term era Natural
+maxTxSize :: Era era => Proof era -> Term era Natural
 maxTxSize p =
   Var
     ( pV
@@ -1043,7 +1043,7 @@ maxTxSize p =
     )
 
 -- | Max Block Header Size
-maxBHSize :: Proof era -> Term era Natural
+maxBHSize :: Era era => Proof era -> Term era Natural
 maxBHSize p =
   Var
     ( pV
@@ -1053,7 +1053,7 @@ maxBHSize p =
         (Yes (PParamsR p) (withEraPParams p (pparamsWrapperL . ppMaxBHSizeL)))
     )
 
-poolDepAmt :: Proof era -> Term era Coin
+poolDepAmt :: Era era => Proof era -> Term era Coin
 poolDepAmt p =
   Var $
     pV
@@ -1062,7 +1062,7 @@ poolDepAmt p =
       CoinR
       (Yes (PParamsR p) (withEraPParams p (pparamsWrapperL . ppPoolDepositL)))
 
-keyDepAmt :: Proof era -> Term era Coin
+keyDepAmt :: Era era => Proof era -> Term era Coin
 keyDepAmt p =
   Var $
     pV
@@ -1089,7 +1089,7 @@ collateralPercentage p =
       NaturalR
       (Yes (PParamsR p) (withEraPParams p (pparamsWrapperL . ppCollateralPercentageL)))
 
-maxEpoch :: Proof era -> Term era EpochNo
+maxEpoch :: Era era => Proof era -> Term era EpochNo
 maxEpoch p =
   Var $
     pV
@@ -1113,10 +1113,10 @@ collateral = Var $ V "collateral" (SetR TxInR) No
 refInputs :: Era era => Term era (Set (TxIn (EraCrypto era)))
 refInputs = Var $ V "refInputs" (SetR TxInR) No
 
-outputs :: Proof era -> Term era [TxOutF era]
+outputs :: Era era => Proof era -> Term era [TxOutF era]
 outputs p = Var $ pV p "outputs" (ListR (TxOutR p)) No
 
-collateralReturn :: Proof era -> Term era (TxOutF era)
+collateralReturn :: Era era => Proof era -> Term era (TxOutF era)
 collateralReturn p = Var $ pV p "collateralReturn" (TxOutR p) No
 
 -- | The sum of all the 'collateral' inputs. The Tx is constucted


### PR DESCRIPTION
# Description

We used to be doing this manually but this should be much cleaner.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
