### PR TITLE
Implement EraTransition

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.2.2.1
+## 1.2.3.0
 
-*
+* Add `EraTransition` instance.
 
 ## 1.2.2.0
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.2.2.1
+version:            1.2.3.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -24,6 +24,7 @@ library
         Cardano.Ledger.Allegra.Core
         Cardano.Ledger.Allegra.Rules
         Cardano.Ledger.Allegra.Scripts
+        Cardano.Ledger.Allegra.Transition
         Cardano.Ledger.Allegra.Translation
         Cardano.Ledger.Allegra.Tx
         Cardano.Ledger.Allegra.TxAuxData
@@ -49,6 +50,7 @@ library
 
     build-depends:
         base >=4.14 && <4.19,
+        aeson,
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- CanStartFromGenesis
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra (
@@ -14,6 +16,7 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.PParams ()
 import Cardano.Ledger.Allegra.Rules ()
 import Cardano.Ledger.Allegra.Scripts ()
+import Cardano.Ledger.Allegra.Transition ()
 import Cardano.Ledger.Allegra.Translation ()
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.Allegra.TxSeq ()

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Allegra.Transition (TransitionConfig (..)) where
+
+import Cardano.Ledger.Allegra.Era
+import Cardano.Ledger.Allegra.Translation ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley
+import Cardano.Ledger.Shelley.Transition
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+instance Crypto c => EraTransition (AllegraEra c) where
+  newtype TransitionConfig (AllegraEra c) = AllegraTransitionConfig
+    { atcShelleyTransitionConfig :: TransitionConfig (ShelleyEra c)
+    }
+    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+
+  mkTransitionConfig () = AllegraTransitionConfig
+
+  tcPreviousEraConfigL =
+    lens atcShelleyTransitionConfig (\atc pc -> atc {atcShelleyTransitionConfig = pc})
+
+  tcTranslationContextL = lens (const ()) (const . id)

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.4.2.0
 
+* Add `toAlonzoTransitionConfigPairs` and `EraTransition` instance.
+* Rename `alonzoGenesisAesonPairs` -> `toAlonzoGenesisPairs` for consistency.
+
 ### `testlib`
 
 * Add `Test.Cardano.Ledger.Alonzo.Binary.RoundTrip` module with:

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -24,6 +24,7 @@ library
         Cardano.Ledger.Alonzo
         Cardano.Ledger.Alonzo.Core
         Cardano.Ledger.Alonzo.Data
+        Cardano.Ledger.Alonzo.Transition
         Cardano.Ledger.Alonzo.Genesis
         Cardano.Ledger.Alonzo.Language
         Cardano.Ledger.Alonzo.PlutusScriptApi

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- CanStartFromGenesis
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Alonzo (
@@ -27,6 +29,7 @@ import Cardano.Ledger.Alonzo.PlutusScriptApi (getDatumAlonzo)
 import Cardano.Ledger.Alonzo.Rules ()
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.Scripts.Data ()
+import Cardano.Ledger.Alonzo.Transition ()
 import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx ()
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -25,9 +25,10 @@ module Cardano.Ledger.Alonzo.Genesis (
     agCollateralPercentage,
     agMaxCollateralInputs
   ),
-  alonzoGenesisAesonPairs,
+  toAlonzoGenesisPairs,
 
   -- * Deprecated
+  alonzoGenesisAesonPairs,
   coinsPerUTxOWord,
   costmdls,
   prices,
@@ -58,7 +59,7 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Crypto (StandardCrypto)
-import Data.Aeson (FromJSON (..), ToJSON (..), object, (.:), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Functor.Identity (Identity)
 import GHC.Generics (Generic)
@@ -188,10 +189,11 @@ instance FromJSON AlonzoGenesis where
     return AlonzoGenesis {..}
 
 instance ToJSON AlonzoGenesis where
-  toJSON = object . alonzoGenesisAesonPairs
+  toJSON = object . toAlonzoGenesisPairs
+  toEncoding = pairs . mconcat . toAlonzoGenesisPairs
 
-alonzoGenesisAesonPairs :: Aeson.KeyValue a => AlonzoGenesis -> [a]
-alonzoGenesisAesonPairs ag =
+toAlonzoGenesisPairs :: Aeson.KeyValue a => AlonzoGenesis -> [a]
+toAlonzoGenesisPairs ag =
   [ "lovelacePerUTxOWord" .= coinsPerUTxOWord ag
   , "costModels" .= costmdls ag
   , "executionPrices" .= prices ag
@@ -201,6 +203,10 @@ alonzoGenesisAesonPairs ag =
   , "collateralPercentage" .= collateralPercentage ag
   , "maxCollateralInputs" .= maxCollateralInputs ag
   ]
+
+alonzoGenesisAesonPairs :: Aeson.KeyValue a => AlonzoGenesis -> [a]
+alonzoGenesisAesonPairs = toAlonzoGenesisPairs
+{-# DEPRECATED alonzoGenesisAesonPairs "In favor of `toAlonzoGenesisPairs`" #-}
 
 coinsPerUTxOWord :: AlonzoGenesis -> CoinPerWord
 coinsPerUTxOWord = agCoinsPerUTxOWord

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Alonzo.Transition (
+  TransitionConfig (..),
+  toAlonzoTransitionConfigPairs,
+) where
+
+import Cardano.Ledger.Alonzo.Era
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis, toAlonzoGenesisPairs)
+import Cardano.Ledger.Alonzo.Translation ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary
+import Cardano.Ledger.Mary.Transition (TransitionConfig (MaryTransitionConfig))
+import Cardano.Ledger.Shelley.Transition
+import Data.Aeson (
+  FromJSON (..),
+  KeyValue (..),
+  ToJSON (..),
+  Value (..),
+  object,
+  pairs,
+  withObject,
+  (.:),
+ )
+import GHC.Generics
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+instance Crypto c => EraTransition (AlonzoEra c) where
+  data TransitionConfig (AlonzoEra c) = AlonzoTransitionConfig
+    { atcAlonzoGenesis :: !AlonzoGenesis
+    , atcMaryTransitionConfig :: !(TransitionConfig (MaryEra c))
+    }
+    deriving (Show, Eq, Generic)
+
+  mkTransitionConfig = AlonzoTransitionConfig
+
+  tcPreviousEraConfigL =
+    lens atcMaryTransitionConfig (\atc pc -> atc {atcMaryTransitionConfig = pc})
+
+  tcTranslationContextL =
+    lens atcAlonzoGenesis (\atc ag -> atc {atcAlonzoGenesis = ag})
+
+instance Crypto c => NoThunks (TransitionConfig (AlonzoEra c))
+
+instance Crypto c => ToJSON (TransitionConfig (AlonzoEra c)) where
+  toJSON = object . toAlonzoTransitionConfigPairs
+  toEncoding = pairs . mconcat . toAlonzoTransitionConfigPairs
+
+toAlonzoTransitionConfigPairs :: (KeyValue a, Crypto c) => TransitionConfig (AlonzoEra c) -> [a]
+toAlonzoTransitionConfigPairs alonzoConfig =
+  toShelleyTransitionConfigPairs shelleyConfig
+    ++ ["alonzo" .= object (toAlonzoGenesisPairs (alonzoConfig ^. tcTranslationContextL))]
+  where
+    maryConfig = alonzoConfig ^. tcPreviousEraConfigL
+    allegraConfig = maryConfig ^. tcPreviousEraConfigL
+    shelleyConfig = allegraConfig ^. tcPreviousEraConfigL
+
+instance Crypto c => FromJSON (TransitionConfig (AlonzoEra c)) where
+  parseJSON = withObject "AlonzoTransitionConfig" $ \o -> do
+    pc <- parseJSON (Object o)
+    ag <- o .: "alonzo"
+    pure $ mkTransitionConfig pc ag

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.4.4.1
+## 1.4.5.0
 
-*
+* Add `EraTransition` instance.
 
 ## 1.4.4.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.4.4.0
+version:            1.4.5.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -34,6 +34,7 @@ library
         Cardano.Ledger.Babbage.TxOut
         Cardano.Ledger.Babbage.TxInfo
         Cardano.Ledger.Babbage.TxWits
+        Cardano.Ledger.Babbage.Transition
         Cardano.Ledger.Babbage.Translation
 
     hs-source-dirs:   src

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- CanStartFromGenesis
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage (
@@ -27,6 +29,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams ()
 import Cardano.Ledger.Babbage.Rules ()
+import Cardano.Ledger.Babbage.Transition ()
 import Cardano.Ledger.Babbage.Translation ()
 import Cardano.Ledger.Babbage.Tx (
   babbageTxScripts,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Babbage.Transition (TransitionConfig (..)) where
+
+import Cardano.Ledger.Alonzo
+import Cardano.Ledger.Alonzo.Transition
+import Cardano.Ledger.Babbage.Era
+import Cardano.Ledger.Babbage.Translation ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley.Transition
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+instance Crypto c => EraTransition (BabbageEra c) where
+  newtype TransitionConfig (BabbageEra c) = BabbageTransitionConfig
+    { btcAlonzoTransitionConfig :: TransitionConfig (AlonzoEra c)
+    }
+    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+
+  mkTransitionConfig () = BabbageTransitionConfig
+
+  tcPreviousEraConfigL =
+    lens btcAlonzoTransitionConfig (\btc pc -> btc {btcAlonzoTransitionConfig = pc})
+
+  tcTranslationContextL = lens (const ()) (const . id)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 1.9.0.0
 
+* Change `To/FromJSON` format for `ConwayGenesis`
+* Add `EraTransition` instance and `toConwayTransitionConfigPairs`.
+* Expose `toConwayGenesisPairs` and `toUpgradeConwayPParamsUpdatePairs`
 * Rename `ConwayPParams` to be consistent with the Agda specification. #3739
   * `govActionExpiration` to `govActionLifetime`
   * `committeeTermLimit` to `committeeMaxTermLength`
   * `minCommitteeSize` to `committeeMinSize`
-* Prevent `DRep` expiry when there are no active governance proposals to vote on (in ConwayCERTS). #3729
+* Prevent `DRep` expiry when there are no active governance proposals to vote on (in
+  ConwayCERTS). #3729
   * Add `updateNumDormantEpochs` function in `ConwayEPOCH` to update the dormant-epochs counter
   * Refactor access to `ConwayGovState` by making its lens part of `ConwayEraGov`.
   * Export `gasExpiresAfterL` for use in tests
@@ -18,7 +22,8 @@
 * Remove `DecCBOR`/`EncCBOR` and `FromCBOR`/`ToCBOR` for `RatifyState`, since that state
   is ephemeral and is never serialized.
 * Add `PredicateFailure` for `Voter` - `GovAction` mismatches, with `checkVotesAreValid`. #3718
-  * Add `DisallowedVoters (Map (GovActionId (EraCrypto era)) (Voter (EraCrypto era)))` inhabitant to the `ConwayGovPredFailure` data type.
+  * Add `DisallowedVoters (Map (GovActionId (EraCrypto era)) (Voter (EraCrypto era)))`
+    inhabitant to the `ConwayGovPredFailure` data type.
   * Fix naming for `toPrevGovActionIdsParis` to `toPrevGovActionIdsPairs`
 * Rename:
   * `thresholdSPO` -> `votingStakePoolThreshold`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -29,6 +29,7 @@ library
         Cardano.Ledger.Conway.TxInfo
         Cardano.Ledger.Conway.TxOut
         Cardano.Ledger.Conway.TxWits
+        Cardano.Ledger.Conway.Transition
         Cardano.Ledger.Conway.Translation
         Cardano.Ledger.Conway.Scripts
         Cardano.Ledger.Conway

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- CanStartFromGenesis
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway (
@@ -24,6 +26,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Rules ()
+import Cardano.Ledger.Conway.Transition ()
 import Cardano.Ledger.Conway.Translation ()
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxInfo (conwayTxInfo)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -7,6 +7,7 @@
 
 module Cardano.Ledger.Conway.Genesis (
   ConwayGenesis (..),
+  toConwayGenesisPairs,
 )
 where
 
@@ -16,12 +17,13 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.PParams (UpgradeConwayPParams)
+import Cardano.Ledger.Conway.PParams (UpgradeConwayPParams, toUpgradeConwayPParamsUpdatePairs)
 import Cardano.Ledger.Crypto (Crypto)
 import Data.Aeson (
   FromJSON (..),
   KeyValue (..),
   ToJSON (..),
+  Value (..),
   object,
   pairs,
   withObject,
@@ -61,19 +63,20 @@ instance Crypto c => ToJSON (ConwayGenesis c) where
 
 instance Crypto c => FromJSON (ConwayGenesis c) where
   parseJSON =
-    withObject "ConwayGenesis" $ \obj ->
+    withObject "ConwayGenesis" $ \obj -> do
+      upgradeProtocolPParams <- parseJSON (Object obj)
       ConwayGenesis
-        <$> obj .: "upgradeProtocolParams"
+        <$> pure upgradeProtocolPParams
         <*> obj .: "constitution"
         <*> obj .: "committee"
 
 toConwayGenesisPairs :: (Crypto c, KeyValue a) => ConwayGenesis c -> [a]
 toConwayGenesisPairs cg@(ConwayGenesis _ _ _) =
   let ConwayGenesis {..} = cg
-   in [ "upgradeProtocolParams" .= cgUpgradePParams
-      , "constitution" .= cgConstitution
+   in [ "constitution" .= cgConstitution
       , "committee" .= cgCommittee
       ]
+        ++ toUpgradeConwayPParamsUpdatePairs cgUpgradePParams
 
 instance Crypto c => Default (ConwayGenesis c) where
   def = ConwayGenesis def def def

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -30,6 +30,7 @@ module Cardano.Ledger.Conway.PParams (
   encodeLangViews,
   upgradeConwayPParams,
   UpgradeConwayPParams (..),
+  toUpgradeConwayPParamsUpdatePairs,
   PoolVotingThresholds (..),
   DRepVotingThresholds (..),
   ConwayEraPParams (..),
@@ -687,11 +688,11 @@ conwayUpgradePParamsHKDPairs px pp =
   ]
 
 instance ToJSON (UpgradeConwayPParams Identity) where
-  toJSON = object . upgradeConwayPParamsUpdatePairs
-  toEncoding = pairs . mconcat . upgradeConwayPParamsUpdatePairs
+  toJSON = object . toUpgradeConwayPParamsUpdatePairs
+  toEncoding = pairs . mconcat . toUpgradeConwayPParamsUpdatePairs
 
-upgradeConwayPParamsUpdatePairs :: KeyValue a => UpgradeConwayPParams Identity -> [a]
-upgradeConwayPParamsUpdatePairs upp =
+toUpgradeConwayPParamsUpdatePairs :: KeyValue a => UpgradeConwayPParams Identity -> [a]
+toUpgradeConwayPParamsUpdatePairs upp =
   uncurry (.=) <$> upgradeConwayPParamsHKDPairs upp
 
 upgradeConwayPParamsHKDPairs :: UpgradeConwayPParams Identity -> [(Key, Aeson.Value)]

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Transition (TransitionConfig (..), toConwayTransitionConfigPairs) where
+
+import Cardano.Ledger.Alonzo.Transition (toAlonzoTransitionConfigPairs)
+import Cardano.Ledger.Babbage
+import Cardano.Ledger.Babbage.Transition (TransitionConfig (BabbageTransitionConfig))
+import Cardano.Ledger.Conway.Era
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis, toConwayGenesisPairs)
+import Cardano.Ledger.Conway.Translation ()
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley.Transition
+import Data.Aeson (
+  FromJSON (..),
+  KeyValue (..),
+  ToJSON (..),
+  Value (..),
+  object,
+  pairs,
+  withObject,
+  (.:),
+ )
+import GHC.Generics
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+instance Crypto c => EraTransition (ConwayEra c) where
+  data TransitionConfig (ConwayEra c) = ConwayTransitionConfig
+    { ctcConwayGenesis :: !(ConwayGenesis c)
+    , ctcBabbageTransitionConfig :: !(TransitionConfig (BabbageEra c))
+    }
+    deriving (Show, Eq, Generic)
+
+  mkTransitionConfig = ConwayTransitionConfig
+
+  tcPreviousEraConfigL =
+    lens ctcBabbageTransitionConfig (\ctc pc -> ctc {ctcBabbageTransitionConfig = pc})
+
+  tcTranslationContextL =
+    lens ctcConwayGenesis (\ctc ag -> ctc {ctcConwayGenesis = ag})
+
+instance Crypto c => NoThunks (TransitionConfig (ConwayEra c))
+
+instance Crypto c => ToJSON (TransitionConfig (ConwayEra c)) where
+  toJSON = object . toConwayTransitionConfigPairs
+  toEncoding = pairs . mconcat . toConwayTransitionConfigPairs
+
+toConwayTransitionConfigPairs :: (KeyValue a, Crypto c) => TransitionConfig (ConwayEra c) -> [a]
+toConwayTransitionConfigPairs conwayConfig =
+  toAlonzoTransitionConfigPairs alonzoConfig
+    ++ ["conway" .= object (toConwayGenesisPairs (conwayConfig ^. tcTranslationContextL))]
+  where
+    babbageConfig = conwayConfig ^. tcPreviousEraConfigL
+    alonzoConfig = babbageConfig ^. tcPreviousEraConfigL
+
+instance Crypto c => FromJSON (TransitionConfig (ConwayEra c)) where
+  parseJSON = withObject "ConwayTransitionConfig" $ \o -> do
+    pc <- parseJSON (Object o)
+    ag <- o .: "conway"
+    pure $ mkTransitionConfig pc ag

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -1,41 +1,39 @@
 {
-  "upgradeProtocolParams":{
-     "poolVotingThresholds":{
-        "pvtCommitteeNormal":0,
-        "pvtCommitteeNoConfidence":0,
-        "pvtHardForkInitiation":0,
-        "pvtMotionNoConfidence":0
-     },
-     "dRepVotingThresholds":{
-        "dvtMotionNoConfidence":0,
-        "dvtCommitteeNormal":0,
-        "dvtCommitteeNoConfidence":0,
-        "dvtUpdateToConstitution":0,
-        "dvtHardForkInitiation":0,
-        "dvtPPNetworkGroup":0,
-        "dvtPPEconomicGroup":0,
-        "dvtPPTechnicalGroup":0,
-        "dvtPPGovGroup":0,
-        "dvtTreasuryWithdrawal":0
-     },
-     "committeeMinSize":0,
-     "committeeMaxTermLength":0,
-     "govActionLifetime":0,
-     "govActionDeposit":0,
-     "dRepDeposit":0,
-     "dRepActivity":0
+  "poolVotingThresholds": {
+    "pvtCommitteeNormal": 0,
+    "pvtCommitteeNoConfidence": 0,
+    "pvtHardForkInitiation": 0,
+    "pvtMotionNoConfidence": 0
   },
+  "dRepVotingThresholds": {
+    "dvtMotionNoConfidence": 0,
+    "dvtCommitteeNormal": 0,
+    "dvtCommitteeNoConfidence": 0,
+    "dvtUpdateToConstitution": 0,
+    "dvtHardForkInitiation": 0,
+    "dvtPPNetworkGroup": 0,
+    "dvtPPEconomicGroup": 0,
+    "dvtPPTechnicalGroup": 0,
+    "dvtPPGovGroup": 0,
+    "dvtTreasuryWithdrawal": 0
+  },
+  "committeeMinSize": 0,
+  "committeeMaxTermLength": 0,
+  "govActionLifetime": 0,
+  "govActionDeposit": 0,
+  "dRepDeposit": 0,
+  "dRepActivity": 0,
   "constitution": {
     "anchor": {
       "url": "",
       "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "committee" :{
-    "members" : {
-       "keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1 ,
-       "scriptHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
-     },
+  "committee": {
+    "members": {
+      "keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 1,
+      "scriptHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
+    },
     "quorum": 0.5
   }
 }

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.3.3.1
+## 1.3.4.0
 
-*
+* Add `EraTransition` instance.
 
 ## 1.3.3.0
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.3.1
+version:            1.3.4.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -27,6 +27,7 @@ library
     exposed-modules:
         Cardano.Ledger.Mary
         Cardano.Ledger.Mary.Core
+        Cardano.Ledger.Mary.Transition
         Cardano.Ledger.Mary.Translation
         Cardano.Ledger.Mary.TxBody
         Cardano.Ledger.Mary.TxOut

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- CanStartFromGenesis
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary (
@@ -20,6 +22,7 @@ import Cardano.Ledger.Keys (DSignable)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.PParams ()
 import Cardano.Ledger.Mary.Scripts ()
+import Cardano.Ledger.Mary.Transition ()
 import Cardano.Ledger.Mary.Translation ()
 import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody (MaryTxBody)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Mary.Transition (TransitionConfig (..)) where
+
+import Cardano.Ledger.Allegra
+import Cardano.Ledger.Allegra.Transition
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Mary.Era
+import Cardano.Ledger.Mary.Translation ()
+import Cardano.Ledger.Shelley.Transition
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+instance Crypto c => EraTransition (MaryEra c) where
+  newtype TransitionConfig (MaryEra c) = MaryTransitionConfig
+    { mtcAllegraTransitionConfig :: TransitionConfig (AllegraEra c)
+    }
+    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+
+  mkTransitionConfig () = MaryTransitionConfig
+
+  tcPreviousEraConfigL =
+    lens mtcAllegraTransitionConfig (\mtc pc -> mtc {mtcAllegraTransitionConfig = pc})
+
+  tcTranslationContextL = lens (const ()) (const . id)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.6.1.0
 
+* Introduce `Cardano.Ledger.Shelley.Transition` module with `EraTransition` interface.
+* Deprecated `CanStartFromGenesis` interface in favor of `EraTransition`
+* Add `Semigroup` and `Monoid` instances for `ShelleyGenesisStaking`
 * Add `FromJSON` instance for `Constitution`
 
 ### `testlib`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -51,6 +51,7 @@ library
         Cardano.Ledger.Shelley.SoftForks
         Cardano.Ledger.Shelley.StabilityWindow
         Cardano.Ledger.Shelley.Rules
+        Cardano.Ledger.Shelley.Transition
         Cardano.Ledger.Shelley.Translation
         Cardano.Ledger.Shelley.Tx
         Cardano.Ledger.Shelley.TxAuxData

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Genesis.hs
@@ -67,6 +67,10 @@ class
     NewEpochState era
   initialState = initialStateFromGenesis
 
+{-# DEPRECATED CanStartFromGenesis "Use `Cardano.Ledger.Shelley.Transition.EraTransition` instead" #-}
+{-# DEPRECATED fromShelleyPParams "Use `Cardano.Ledger.Shelley.Transition.tcInitialPParamsG` instead" #-}
+{-# DEPRECATED initialState "Use `Cardano.Ledger.Shelley.Transition.createInitialState` instead" #-}
+
 instance
   Crypto c =>
   CanStartFromGenesis (ShelleyEra c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -1,0 +1,454 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- | Besides capturing all configuration that is necessary to progress to a specific era,
+-- this interface also provides fast forward functionality that is used in testing and
+-- benchmarking in order to initilize a chain in a particular era without going through
+-- the trouble of generating all the history for preceeding eras.
+module Cardano.Ledger.Shelley.Transition (
+  EraTransition (..),
+  mkShelleyTransitionConfig,
+  tcInitialFundsL,
+  tcInitialStakingL,
+  createInitialState,
+  registerInitialFunds,
+  registerInitialStaking,
+  toShelleyTransitionConfigPairs,
+) where
+
+import Cardano.Ledger.Address
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.EpochBoundary
+import Cardano.Ledger.Keys
+import Cardano.Ledger.PoolDistr
+import Cardano.Ledger.Shelley.Era
+import Cardano.Ledger.Shelley.Genesis
+import Cardano.Ledger.Shelley.Governance
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Translation (
+  FromByronTranslationContext (..),
+  toFromByronTranslationContext,
+ )
+import qualified Cardano.Ledger.UMap as UM
+import Cardano.Ledger.UTxO
+import Cardano.Ledger.Val
+import Data.Aeson (FromJSON (..), KeyValue (..), ToJSON (..), object, pairs, withObject, (.:))
+import Data.Default.Class
+import Data.Kind
+import qualified Data.ListMap as LM
+import qualified Data.ListMap as ListMap
+import qualified Data.Map.Strict as Map
+import Data.Void (Void)
+import GHC.Generics (Generic)
+import GHC.Stack
+import Lens.Micro
+import NoThunks.Class (NoThunks (..))
+
+class
+  ( EraTxOut era
+  , EraGov era
+  , ToJSON (TransitionConfig era)
+  , FromJSON (TransitionConfig era)
+  , Default (StashedAVVMAddresses era)
+  ) =>
+  EraTransition era
+  where
+  -- | Cumulative configuration that is needed to be able to start in a current era
+  data TransitionConfig era :: Type
+
+  mkTransitionConfig ::
+    -- | Translation context necessary for advancing from previous era into the current
+    -- one. This will usually be the contents of genesis file, if one exists for the
+    -- current era
+    TranslationContext era ->
+    -- | Transition configuration for the previous era.
+    TransitionConfig (PreviousEra era) ->
+    TransitionConfig era
+
+  -- | In case when a previous era is available, we should always be able to access
+  -- `TransitionConfig` for the previous era, from within the current era's
+  -- `TransitionConfig`
+  tcPreviousEraConfigL ::
+    EraTransition (PreviousEra era) =>
+    Lens' (TransitionConfig era) (TransitionConfig (PreviousEra era))
+
+  -- | Lens for the `TranslationContext` for the current era from the `TransitionConfig`
+  -- Translation context is a different name for the Genesis type for each era, they are
+  -- one and the same concept.
+  tcTranslationContextL ::
+    Lens' (TransitionConfig era) (TranslationContext era)
+
+  -- | Lens for the `ShelleyGenesis` from the `TransitionConfig`. Default implementation
+  -- looks in the previous era's config
+  tcShelleyGenesisL :: Lens' (TransitionConfig era) (ShelleyGenesis (EraCrypto era))
+  default tcShelleyGenesisL ::
+    (EraTransition (PreviousEra era), EraCrypto (PreviousEra era) ~ EraCrypto era) =>
+    Lens' (TransitionConfig era) (ShelleyGenesis (EraCrypto era))
+  tcShelleyGenesisL = tcPreviousEraConfigL . tcShelleyGenesisL
+
+  -- | Get the initial PParams for the current era from the `TransitionConfig`. Note that
+  -- this is only useful for testing and fast forward functionality, because this function
+  -- assumes no on-chain changes to PParams through PParamsUpdate functionality.
+  --
+  -- Default implementation will use the PParams from the Previous era and the current
+  -- `TranslationContext` to construct PParams for the current era.
+  --
+  -- /Warning/ - Should only be used in testing and benchmarking
+  tcInitialPParamsG :: SimpleGetter (TransitionConfig era) (PParams era)
+  default tcInitialPParamsG ::
+    ( EraTransition (PreviousEra era)
+    , TranslateEra era PParams
+    , TranslationError era PParams ~ Void
+    ) =>
+    SimpleGetter (TransitionConfig era) (PParams era)
+  tcInitialPParamsG =
+    to $ \tc ->
+      translateEra' (tc ^. tcTranslationContextL) (tc ^. tcPreviousEraConfigL . tcInitialPParamsG)
+
+instance Crypto c => EraTransition (ShelleyEra c) where
+  newtype TransitionConfig (ShelleyEra c) = ShelleyTransitionConfig
+    { stcShelleyGenesis :: ShelleyGenesis c
+    }
+    deriving (Eq, Show, Generic)
+
+  mkTransitionConfig =
+    error "Impossible: There is no EraTransition instance for ByronEra"
+
+  tcPreviousEraConfigL = notSupportedInThisEraL
+
+  tcTranslationContextL =
+    tcShelleyGenesisL . lens toFromByronTranslationContext setFBTC
+    where
+      setFBTC shelleyGenesis FromByronTranslationContext {..} =
+        shelleyGenesis
+          { sgGenDelegs = fbtcGenDelegs
+          , sgProtocolParams = fbtcProtocolParams
+          , sgMaxLovelaceSupply = fbtcMaxLovelaceSupply
+          }
+
+  tcShelleyGenesisL = lens stcShelleyGenesis (\tc sg -> tc {stcShelleyGenesis = sg})
+
+  tcInitialPParamsG = to (sgProtocolParams . stcShelleyGenesis)
+
+-- | Constructor for the base Shelley `TransitionConfig`
+mkShelleyTransitionConfig :: ShelleyGenesis c -> TransitionConfig (ShelleyEra c)
+mkShelleyTransitionConfig = ShelleyTransitionConfig
+
+-- | Get the initial funds from the `TransitionConfig`. This value must be non-empty
+-- only during testing and benchmarking, it must never contain anything on a real system.
+--
+-- /Warning/ - Should only be used in testing and benchmarking. Will result in an error
+-- when NetworkId is set to Mainnet
+tcInitialFundsL ::
+  (HasCallStack, EraTransition era) =>
+  Lens' (TransitionConfig era) (LM.ListMap (Addr (EraCrypto era)) Coin)
+tcInitialFundsL =
+  tcShelleyGenesisL
+    . lens
+      (\sg -> protectMainnet "InitialFunds" sg null (sgInitialFunds sg))
+      (\sg initialFunds -> sg {sgInitialFunds = initialFunds})
+
+-- | Get the initial staking from the `TransitionConfig`. This value must be non-empty
+-- only during testing and benchmarking, it must never contain anything on a real system.
+--
+-- /Warning/ - Should only be used in testing and benchmarking. Will result in an error
+-- when NetworkId is set to Mainnet
+tcInitialStakingL ::
+  (HasCallStack, EraTransition era) =>
+  Lens' (TransitionConfig era) (ShelleyGenesisStaking (EraCrypto era))
+tcInitialStakingL =
+  tcShelleyGenesisL
+    . lens
+      (\sg -> protectMainnet "InitialStaking" sg (== mempty) (sgStaking sg))
+      (\sg staking -> sg {sgStaking = staking})
+
+protectMainnet :: HasCallStack => String -> ShelleyGenesis c -> (a -> Bool) -> a -> a
+protectMainnet name sg isMainnetSafe m =
+  if sgNetworkId sg == Mainnet && not (isMainnetSafe m)
+    then error $ "Injection of " ++ name ++ " is not possible on Mainnet"
+    else m
+
+deriving instance Crypto c => NoThunks (TransitionConfig (ShelleyEra c))
+
+instance Crypto c => ToJSON (TransitionConfig (ShelleyEra c)) where
+  toJSON = object . toShelleyTransitionConfigPairs
+  toEncoding = pairs . mconcat . toShelleyTransitionConfigPairs
+
+instance Crypto c => FromJSON (TransitionConfig (ShelleyEra c)) where
+  parseJSON = withObject "ShelleyTransitionConfig" $ \o -> do
+    sg <- o .: "shelley"
+    pure $ ShelleyTransitionConfig {stcShelleyGenesis = sg}
+
+toShelleyTransitionConfigPairs ::
+  (KeyValue a, Crypto c) =>
+  TransitionConfig (ShelleyEra c) ->
+  [a]
+toShelleyTransitionConfigPairs stc@(ShelleyTransitionConfig _) =
+  ["shelley" .= object (toShelleyGenesisPairs (stcShelleyGenesis stc))]
+
+-- | Helper function for constructing the initial state for any era
+--
+-- /Warning/ - Should only be used in testing and benchmarking. Will result in an error
+-- when NetworkId is set to Mainnet
+createInitialState ::
+  forall era.
+  (EraTransition era, HasCallStack) =>
+  TransitionConfig era ->
+  NewEpochState era
+createInitialState tc =
+  protectMainnet
+    "InitialState"
+    sg
+    (const False)
+    NewEpochState
+      { nesEL = initialEpochNo
+      , nesBprev = BlocksMade Map.empty
+      , nesBcur = BlocksMade Map.empty
+      , nesEs =
+          EpochState
+            { esAccountState = AccountState zero reserves
+            , esSnapshots = emptySnapShots
+            , esLState =
+                LedgerState
+                  { lsUTxOState =
+                      smartUTxOState pp initialUtxo zero zero govState zero
+                  , lsCertState =
+                      CertState
+                        { certDState = dState {dsGenDelegs = GenDelegs (sgGenDelegs sg)}
+                        , certPState = def
+                        , certVState = def
+                        }
+                  }
+            , esNonMyopic = def
+            }
+      , nesRu = SNothing
+      , nesPd = PoolDistr Map.empty
+      , stashedAVVMAddresses = def
+      }
+  where
+    dState :: DState era
+    dState = def
+    govState :: GovState era
+    govState =
+      emptyGovState
+        & curPParamsGovStateL .~ pp
+        & prevPParamsGovStateL .~ pp
+    pp :: PParams era
+    pp = tc ^. tcInitialPParamsG
+    sg :: ShelleyGenesis (EraCrypto era)
+    sg = tc ^. tcShelleyGenesisL
+    initialEpochNo :: EpochNo
+    initialEpochNo = 0
+    initialUtxo :: UTxO era
+    initialUtxo = genesisUTxO sg
+    reserves :: Coin
+    reserves = word64ToCoin (sgMaxLovelaceSupply sg) <-> coinBalance initialUtxo
+
+-- | Register the initial staking information in the 'NewEpochState'.
+--
+-- HERE BE DRAGONS! This function is intended to help in testing.
+--
+-- In production, the genesis should /not/ contain any initial staking.
+--
+-- Any existing staking information is overridden, but the UTxO is left
+-- untouched.
+--
+-- /Warning/ - Should only be used in testing and benchmarking. Will result in an error
+-- when NetworkId is set to Mainnet
+registerInitialStaking ::
+  forall era.
+  ( EraTransition era
+  , HasCallStack
+  ) =>
+  TransitionConfig era ->
+  NewEpochState era ->
+  NewEpochState era
+registerInitialStaking tc nes =
+  nes
+    { nesEs =
+        epochState
+          { esLState =
+              ledgerState
+                { lsCertState =
+                    dpState
+                      { certDState = dState'
+                      , certPState = pState'
+                      }
+                }
+          , esSnapshots =
+              (esSnapshots epochState)
+                { ssStakeMark = initSnapShot
+                , ssStakeMarkPoolDistr = calculatePoolDistr initSnapShot
+                }
+          }
+    , -- Note that this is only applicable in the initial configuration where
+      -- there is no existing stake distribution, since it would completely
+      -- overwrite any such thing.
+      nesPd = calculatePoolDistr initSnapShot
+    }
+  where
+    ShelleyGenesisStaking {sgsPools, sgsStake} = tc ^. tcInitialStakingL
+    NewEpochState {nesEs = epochState} = nes
+    ledgerState = esLState epochState
+    dpState = lsCertState ledgerState
+
+    -- New delegation state. Since we're using base addresses, we only care
+    -- about updating the '_delegations' field.
+    --
+    -- See STS DELEG for details
+    dState' :: DState era
+    dState' =
+      (certDState dpState)
+        { dsUnified =
+            UM.unify
+              ( Map.map (const $ UM.RDPair (CompactCoin 0) (CompactCoin 0))
+                  . Map.mapKeys KeyHashObj
+                  $ sgsStakeMap
+              )
+              mempty
+              (Map.mapKeys KeyHashObj sgsStakeMap)
+              mempty
+        }
+      where
+        sgsStakeMap = ListMap.toMap sgsStake
+
+    -- We consider pools as having been registered in slot 0
+    -- See STS POOL for details
+    pState' :: PState era
+    pState' =
+      (certPState dpState)
+        { psStakePoolParams = ListMap.toMap sgsPools
+        }
+
+    pp = nes ^. nesEsL . curPParamsEpochStateL
+
+    -- The new stake distribution is made on the basis of a snapshot taken
+    -- during the previous epoch. We create a "fake" snapshot in order to
+    -- establish an initial stake distribution.
+    initSnapShot :: SnapShot (EraCrypto era)
+    initSnapShot =
+      -- Since we build a stake from nothing, we first initialise an
+      -- 'IncrementalStake' as empty, and then:
+      --
+      -- 1. Add the initial UTxO, whilst deleting nothing.
+      -- 2. Update the stake map given the initial delegation.
+      incrementalStakeDistr
+        pp
+        -- Note that 'updateStakeDistribution' takes first the set of UTxO to
+        -- delete, and then the set to add. In our case, there is nothing to
+        -- delete, since this is an initial UTxO set.
+        (updateStakeDistribution pp mempty mempty (utxosUtxo (lsUTxOState ledgerState)))
+        dState'
+        pState'
+
+-- | Register the initial funds in the 'NewEpochState'.
+--
+-- HERE BE DRAGONS! This function is intended to help in testing.
+--
+-- In production, the genesis should /not/ contain any initial funds.
+--
+-- The given funds are /added/ to the existing UTxO.
+--
+-- PRECONDITION: the given funds must not be part of the existing UTxO.
+-- > forall (addr, _) in initialFunds.
+-- >    Map.notElem (initialFundsPseudoTxIn addr) existingUTxO
+--
+-- PROPERTY:
+-- >    genesisUTxO genesis
+-- > == <genesisUTxO'> (sgInitialFunds genesis)
+-- > == <extractUTxO> (registerInitialFunds (sgInitialFunds genesis)
+-- >                                        <empty NewEpochState>)
+--
+-- /Warning/ - Should only be used in testing and benchmarking. Will result in an error
+-- when NetworkId is set to Mainnet
+registerInitialFunds ::
+  forall era.
+  ( EraTransition era
+  , HasCallStack
+  ) =>
+  TransitionConfig era ->
+  NewEpochState era ->
+  NewEpochState era
+registerInitialFunds tc nes =
+  nes
+    { nesEs =
+        epochState
+          { esAccountState = accountState'
+          , esLState = ledgerState'
+          }
+    }
+  where
+    epochState = nesEs nes
+    accountState = esAccountState epochState
+    ledgerState = esLState epochState
+    utxoState = lsUTxOState ledgerState
+    utxo = utxosUtxo utxoState
+    reserves = asReserves accountState
+
+    initialFundsUtxo :: UTxO era
+    initialFundsUtxo =
+      UTxO $
+        Map.fromList
+          [ (txIn, txOut)
+          | (addr, amount) <- ListMap.toList (tc ^. tcInitialFundsL)
+          , let txIn = initialFundsPseudoTxIn addr
+                txOut = mkBasicTxOut addr (inject amount)
+          ]
+
+    utxo' = mergeUtxoNoOverlap utxo initialFundsUtxo
+
+    -- Update the reserves
+    accountState' =
+      accountState
+        { asReserves = reserves <-> coin (balance initialFundsUtxo)
+        }
+
+    -- Since we only add entries to our UTxO, rather than spending them, there
+    -- is nothing to delete in the incremental update.
+    utxoToDel = UTxO mempty
+    ledgerState' =
+      ledgerState
+        { lsUTxOState =
+            utxoState
+              { utxosUtxo = utxo'
+              , -- Normally we would incrementally update here. But since we pass
+                -- the full UTxO as "toAdd" rather than a delta, we simply
+                -- reinitialise the full incremental stake.
+                utxosStakeDistr =
+                  updateStakeDistribution
+                    (nes ^. nesEsL . curPParamsEpochStateL)
+                    mempty
+                    utxoToDel
+                    utxo'
+              }
+        }
+
+    -- Merge two UTxOs, throw an 'error' in case of overlap
+    mergeUtxoNoOverlap ::
+      HasCallStack =>
+      UTxO era ->
+      UTxO era ->
+      UTxO era
+    mergeUtxoNoOverlap (UTxO m1) (UTxO m2) =
+      UTxO $
+        Map.unionWithKey
+          (\k _ _ -> error $ "initial fund part of UTxO: " <> show k)
+          m1
+          m2

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.6.0.0
 
+* Add `LatestKnownEra`
+* Add `Cardano.Ledger.Api.Transition` module
 * Add the dormant-epochs counter to `DRep` expiry in `queryDRepState` #3729
   * If it is not zero.
 * Rename:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -27,6 +27,7 @@ library
         Cardano.Ledger.Api.PParams
         Cardano.Ledger.Api.Scripts
         Cardano.Ledger.Api.Scripts.Data
+        Cardano.Ledger.Api.Transition
         Cardano.Ledger.Api.Tx
         Cardano.Ledger.Api.Tx.Address
         Cardano.Ledger.Api.Tx.AuxData

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -34,6 +34,9 @@ module Cardano.Ledger.Api.Era (
   Conway,
   ConwayEra,
 
+  -- ** Latest Known
+  LatestKnownEra,
+
   -- * Crypto
   StandardCrypto,
   Crypto (..),
@@ -77,3 +80,7 @@ import Cardano.Ledger.Core (
 import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
 import Cardano.Ledger.Mary (Mary, MaryEra)
 import Cardano.Ledger.Shelley (Shelley, ShelleyEra)
+
+-- | Sometimes it is useful to specify that a type corresponds to a latest era that is
+-- currently implemented
+type LatestKnownEra c = ConwayEra c

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Transition.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Transition.hs
@@ -1,0 +1,57 @@
+-- | This module is used for defining initial configuration for all. It is also used in
+-- testing and benchmarking to initilize a chain in a particular era without going through
+-- the trouble of generating all the history for preceeding eras.
+module Cardano.Ledger.Api.Transition (
+  EraTransition,
+  TransitionConfig,
+  mkLatestTransitionConfig,
+  mkTransitionConfig,
+  mkShelleyTransitionConfig,
+  tcShelleyGenesisL,
+  tcPreviousEraConfigL,
+  tcTranslationContextL,
+
+  -- * Genesis
+  ShelleyGenesis (..),
+  AlonzoGenesis (..),
+  ConwayGenesis (..),
+
+  -- * Functions for Testing
+  tcInitialPParamsG,
+  tcInitialFundsL,
+  tcInitialStakingL,
+  createInitialState,
+  registerInitialFunds,
+  registerInitialStaking,
+) where
+
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
+import Cardano.Ledger.Api.Era (LatestKnownEra)
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
+import Cardano.Ledger.Shelley.Transition (
+  EraTransition (..),
+  TransitionConfig,
+  createInitialState,
+  mkShelleyTransitionConfig,
+  registerInitialFunds,
+  registerInitialStaking,
+  tcInitialFundsL,
+  tcInitialStakingL,
+ )
+import Data.Function ((&))
+
+mkLatestTransitionConfig ::
+  Crypto c =>
+  ShelleyGenesis c ->
+  AlonzoGenesis ->
+  ConwayGenesis c ->
+  TransitionConfig (LatestKnownEra c)
+mkLatestTransitionConfig shelleyGenesis alonzoGenesis conwayGenesis =
+  mkShelleyTransitionConfig shelleyGenesis
+    & mkTransitionConfig ()
+    & mkTransitionConfig ()
+    & mkTransitionConfig alonzoGenesis
+    & mkTransitionConfig ()
+    & mkTransitionConfig conwayGenesis


### PR DESCRIPTION
# Description

Era Transition defines all of the configuration that is needed to transition from Shelley to a current era.

* `EraTransition` type class can be used to deal with cumulative
  configuration necessary for getting to a particular era
* It can also be used for testing and benchmarking to inject initial
  staking and funds into the initial state as well as fast forward the
  state into any era by translating it and upgrading PParams.
  This was done by migrating `registerInitialFunds` and
  `registerInitialStaking` functions from consensus:
* Also additions to the `cardano-ledger-api`:
  * Add `LatestKnownEra`
  * Export `EraTransition` interface
  * Add `mkLatestTransitionConfig` that works for `LatestKnownEra`

Fixes #3337 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
