### PR TITLE
Rename some PParams to be consistent with Agda specification

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Rename `ConwayPParams` to be consistent with the Agda specification. #
+  * `govActionExpiration` to `govActionLifetime`
 * Prevent `DRep` expiry when there are no active governance proposals to vote on (in ConwayCERTS). #3729
   * Add `updateNumDormantEpochs` function in `ConwayEPOCH` to update the dormant-epochs counter
   * Refactor access to `ConwayGovState` by making its lens part of `ConwayEraGov`.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rename `ConwayPParams` to be consistent with the Agda specification. #
   * `govActionExpiration` to `govActionLifetime`
   * `committeeTermLimit` to `committeeMaxTermLength`
+  * `minCommitteeSize` to `committeeMinSize`
 * Prevent `DRep` expiry when there are no active governance proposals to vote on (in ConwayCERTS). #3729
   * Add `updateNumDormantEpochs` function in `ConwayEPOCH` to update the dormant-epochs counter
   * Refactor access to `ConwayGovState` by making its lens part of `ConwayEraGov`.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename `ConwayPParams` to be consistent with the Agda specification. #
   * `govActionExpiration` to `govActionLifetime`
+  * `committeeTermLimit` to `committeeMaxTermLength`
 * Prevent `DRep` expiry when there are no active governance proposals to vote on (in ConwayCERTS). #3729
   * Add `updateNumDormantEpochs` function in `ConwayEPOCH` to update the dormant-epochs counter
   * Refactor access to `ConwayGovState` by making its lens part of `ConwayEraGov`.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.9.0.0
 
-* Rename `ConwayPParams` to be consistent with the Agda specification. #
+* Rename `ConwayPParams` to be consistent with the Agda specification. #3739
   * `govActionExpiration` to `govActionLifetime`
   * `committeeTermLimit` to `committeeMaxTermLength`
   * `minCommitteeSize` to `committeeMinSize`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -36,7 +36,7 @@ module Cardano.Ledger.Conway.PParams (
   ppPoolVotingThresholdsL,
   ppDRepVotingThresholdsL,
   ppMinCommitteeSizeL,
-  ppCommitteeTermLimitL,
+  ppCommitteeMaxTermLengthL,
   ppGovActionLifetimeL,
   ppGovActionDepositL,
   ppDRepDepositL,
@@ -44,7 +44,7 @@ module Cardano.Ledger.Conway.PParams (
   ppuPoolVotingThresholdsL,
   ppuDRepVotingThresholdsL,
   ppuMinCommitteeSizeL,
-  ppuCommitteeTermLimitL,
+  ppuCommitteeMaxTermLengthL,
   ppuGovActionLifetimeL,
   ppuGovActionDepositL,
   ppuDRepDepositL,
@@ -87,7 +87,7 @@ import Numeric.Natural (Natural)
 -- * @poolVotingThresholds@
 -- * @dRepVotingThresholds@
 -- * @minCommitteeSize@
--- * @committeeTermLimit@
+-- * @committeeMaxTermLength@
 -- * @govActionLifetime@
 -- * @govActionDeposit@
 -- * @dRepDeposit@
@@ -147,7 +147,7 @@ data ConwayPParams f era = ConwayPParams
   -- ^ Thresholds for DRep votes
   , cppMinCommitteeSize :: !(HKD f Natural)
   -- ^ Minimum size of the Constitutional Committee
-  , cppCommitteeTermLimit :: !(HKD f Natural) -- TODO: This too should be EpochNo
+  , cppCommitteeMaxTermLength :: !(HKD f Natural) -- TODO: This too should be EpochNo
 
   -- ^ The Constitutional Committee Term limit in number of Slots
   , cppGovActionLifetime :: !(HKD f EpochNo)
@@ -187,7 +187,7 @@ data UpgradeConwayPParams f = UpgradeConwayPParams
   { ucppPoolVotingThresholds :: !(HKD f PoolVotingThresholds)
   , ucppDRepVotingThresholds :: !(HKD f DRepVotingThresholds)
   , ucppMinCommitteeSize :: !(HKD f Natural)
-  , ucppCommitteeTermLimit :: !(HKD f Natural)
+  , ucppCommitteeMaxTermLength :: !(HKD f Natural)
   , ucppGovActionLifetime :: !(HKD f EpochNo)
   , ucppGovActionDeposit :: !(HKD f Coin)
   , ucppDRepDeposit :: !(HKD f Coin)
@@ -223,7 +223,7 @@ instance Default (UpgradeConwayPParams Identity) where
       { ucppPoolVotingThresholds = def
       , ucppDRepVotingThresholds = def
       , ucppMinCommitteeSize = 0
-      , ucppCommitteeTermLimit = 0
+      , ucppCommitteeMaxTermLength = 0
       , ucppGovActionLifetime = EpochNo 0
       , ucppGovActionDeposit = Coin 0
       , ucppDRepDeposit = Coin 0
@@ -236,7 +236,7 @@ instance Default (UpgradeConwayPParams StrictMaybe) where
       { ucppPoolVotingThresholds = SNothing
       , ucppDRepVotingThresholds = SNothing
       , ucppMinCommitteeSize = SNothing
-      , ucppCommitteeTermLimit = SNothing
+      , ucppCommitteeMaxTermLength = SNothing
       , ucppGovActionLifetime = SNothing
       , ucppGovActionDeposit = SNothing
       , ucppDRepDeposit = SNothing
@@ -250,7 +250,7 @@ instance EncCBOR (UpgradeConwayPParams Identity) where
         !> To ucppPoolVotingThresholds
         !> To ucppDRepVotingThresholds
         !> To ucppMinCommitteeSize
-        !> To ucppCommitteeTermLimit
+        !> To ucppCommitteeMaxTermLength
         !> To ucppGovActionLifetime
         !> To ucppGovActionDeposit
         !> To ucppDRepDeposit
@@ -349,7 +349,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       <*> pGroup GovernanceGroup cppPoolVotingThresholds
       <*> pGroup GovernanceGroup cppDRepVotingThresholds
       <*> pGroup GovernanceGroup cppMinCommitteeSize
-      <*> pGroup GovernanceGroup cppCommitteeTermLimit
+      <*> pGroup GovernanceGroup cppCommitteeMaxTermLength
       <*> pGroup GovernanceGroup cppGovActionLifetime
       <*> pGroup GovernanceGroup cppGovActionDeposit
       <*> pGroup GovernanceGroup cppDRepDeposit
@@ -363,7 +363,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       , isValid (/= 0) ppuMaxBHSizeL
       , isValid (/= 0) ppuMaxValSizeL
       , isValid (/= 0) ppuCollateralPercentageL
-      , isValid (/= 0) ppuCommitteeTermLimitL
+      , isValid (/= 0) ppuCommitteeMaxTermLengthL
       , isValid (/= EpochNo 0) ppuGovActionLifetimeL
       , -- Coins
         isValid (/= zero) ppuPoolDepositL
@@ -382,7 +382,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
   hkdPoolVotingThresholdsL = lens cppPoolVotingThresholds (\pp x -> pp {cppPoolVotingThresholds = x})
   hkdDRepVotingThresholdsL = lens cppDRepVotingThresholds (\pp x -> pp {cppDRepVotingThresholds = x})
   hkdMinCommitteeSizeL = lens cppMinCommitteeSize (\pp x -> pp {cppMinCommitteeSize = x})
-  hkdCommitteeTermLimitL = lens cppCommitteeTermLimit (\pp x -> pp {cppCommitteeTermLimit = x})
+  hkdCommitteeMaxTermLengthL = lens cppCommitteeMaxTermLength (\pp x -> pp {cppCommitteeMaxTermLength = x})
   hkdGovActionLifetimeL = lens cppGovActionLifetime (\pp x -> pp {cppGovActionLifetime = x})
   hkdGovActionDepositL = lens cppGovActionDeposit (\pp x -> pp {cppGovActionDeposit = x})
   hkdDRepDepositL = lens cppDRepDeposit (\pp x -> pp {cppDRepDeposit = x})
@@ -418,7 +418,7 @@ instance Era era => EncCBOR (ConwayPParams Identity era) where
         !> To cppPoolVotingThresholds
         !> To cppDRepVotingThresholds
         !> To cppMinCommitteeSize
-        !> To cppCommitteeTermLimit
+        !> To cppCommitteeMaxTermLength
         !> To cppGovActionLifetime
         !> To cppGovActionDeposit
         !> To cppDRepDeposit
@@ -508,7 +508,7 @@ emptyConwayPParams =
       cppPoolVotingThresholds = def
     , cppDRepVotingThresholds = def
     , cppMinCommitteeSize = 0
-    , cppCommitteeTermLimit = 0
+    , cppCommitteeMaxTermLength = 0
     , cppGovActionLifetime = EpochNo 0
     , cppGovActionDeposit = Coin 0
     , cppDRepDeposit = Coin 0
@@ -544,7 +544,7 @@ emptyConwayPParamsUpdate =
       cppPoolVotingThresholds = SNothing
     , cppDRepVotingThresholds = SNothing
     , cppMinCommitteeSize = SNothing
-    , cppCommitteeTermLimit = SNothing
+    , cppCommitteeMaxTermLength = SNothing
     , cppGovActionLifetime = SNothing
     , cppGovActionDeposit = SNothing
     , cppDRepDeposit = SNothing
@@ -582,7 +582,7 @@ encodePParamsUpdate ppup =
     !> omitStrictMaybe 25 (cppPoolVotingThresholds ppup) encCBOR
     !> omitStrictMaybe 26 (cppDRepVotingThresholds ppup) encCBOR
     !> omitStrictMaybe 27 (cppMinCommitteeSize ppup) encCBOR
-    !> omitStrictMaybe 28 (cppCommitteeTermLimit ppup) encCBOR
+    !> omitStrictMaybe 28 (cppCommitteeMaxTermLength ppup) encCBOR
     !> omitStrictMaybe 29 (cppGovActionLifetime ppup) encCBOR
     !> omitStrictMaybe 30 (cppGovActionDeposit ppup) encCBOR
     !> omitStrictMaybe 31 (cppDRepDeposit ppup) encCBOR
@@ -626,7 +626,7 @@ updateField = \case
   25 -> field (\x up -> up {cppPoolVotingThresholds = SJust x}) From
   26 -> field (\x up -> up {cppDRepVotingThresholds = SJust x}) From
   27 -> field (\x up -> up {cppMinCommitteeSize = SJust x}) From
-  28 -> field (\x up -> up {cppCommitteeTermLimit = SJust x}) From
+  28 -> field (\x up -> up {cppCommitteeMaxTermLength = SJust x}) From
   29 -> field (\x up -> up {cppGovActionLifetime = SJust x}) From
   30 -> field (\x up -> up {cppGovActionDeposit = SJust x}) From
   31 -> field (\x up -> up {cppDRepDeposit = SJust x}) From
@@ -679,7 +679,7 @@ conwayUpgradePParamsHKDPairs px pp =
   [ ("poolVotingThresholds", hkdMap px (toJSON @PoolVotingThresholds) (pp ^. hkdPoolVotingThresholdsL @era @f))
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
   , ("minCommitteeSize", hkdMap px (toJSON @Natural) (pp ^. hkdMinCommitteeSizeL @era @f))
-  , ("committeeTermLimit", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeTermLimitL @era @f))
+  , ("committeeMaxTermLength", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
   , ("govActionLifetime", hkdMap px (toJSON @EpochNo) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
   , ("dRepDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdDRepDepositL @era @f))
@@ -699,7 +699,7 @@ upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   [ ("poolVotingThresholds", (toJSON @PoolVotingThresholds) ucppPoolVotingThresholds)
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
   , ("minCommitteeSize", (toJSON @Natural) ucppMinCommitteeSize)
-  , ("committeeTermLimit", (toJSON @Natural) ucppCommitteeTermLimit)
+  , ("committeeMaxTermLength", (toJSON @Natural) ucppCommitteeMaxTermLength)
   , ("govActionLifetime", (toJSON @EpochNo) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
   , ("dRepDeposit", (toJSON @Coin) ucppDRepDeposit)
@@ -717,7 +717,7 @@ instance FromJSON (UpgradeConwayPParams Identity) where
         <$> o .: "poolVotingThresholds"
         <*> o .: "dRepVotingThresholds"
         <*> o .: "minCommitteeSize"
-        <*> o .: "committeeTermLimit"
+        <*> o .: "committeeMaxTermLength"
         <*> o .: "govActionLifetime"
         <*> o .: "govActionDeposit"
         <*> o .: "dRepDeposit"
@@ -756,7 +756,7 @@ upgradeConwayPParams UpgradeConwayPParams {..} BabbagePParams {..} =
       cppPoolVotingThresholds = ucppPoolVotingThresholds
     , cppDRepVotingThresholds = ucppDRepVotingThresholds
     , cppMinCommitteeSize = ucppMinCommitteeSize
-    , cppCommitteeTermLimit = ucppCommitteeTermLimit
+    , cppCommitteeMaxTermLength = ucppCommitteeMaxTermLength
     , cppGovActionLifetime = ucppGovActionLifetime
     , cppGovActionDeposit = ucppGovActionDeposit
     , cppDRepDeposit = ucppDRepDeposit
@@ -825,7 +825,7 @@ class BabbageEraPParams era => ConwayEraPParams era where
   hkdPoolVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f PoolVotingThresholds)
   hkdDRepVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f DRepVotingThresholds)
   hkdMinCommitteeSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
-  hkdCommitteeTermLimitL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdCommitteeMaxTermLengthL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
   hkdGovActionLifetimeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
   hkdGovActionDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
   hkdDRepDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
@@ -840,8 +840,8 @@ ppDRepVotingThresholdsL = ppLens . hkdDRepVotingThresholdsL @era @Identity
 ppMinCommitteeSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
 ppMinCommitteeSizeL = ppLens . hkdMinCommitteeSizeL @era @Identity
 
-ppCommitteeTermLimitL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
-ppCommitteeTermLimitL = ppLens . hkdCommitteeTermLimitL @era @Identity
+ppCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
+ppCommitteeMaxTermLengthL = ppLens . hkdCommitteeMaxTermLengthL @era @Identity
 
 ppGovActionLifetimeL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochNo
 ppGovActionLifetimeL = ppLens . hkdGovActionLifetimeL @era @Identity
@@ -864,8 +864,8 @@ ppuDRepVotingThresholdsL = ppuLens . hkdDRepVotingThresholdsL @era @StrictMaybe
 ppuMinCommitteeSizeL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
 ppuMinCommitteeSizeL = ppuLens . hkdMinCommitteeSizeL @era @StrictMaybe
 
-ppuCommitteeTermLimitL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
-ppuCommitteeTermLimitL = ppuLens . hkdCommitteeTermLimitL @era @StrictMaybe
+ppuCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
+ppuCommitteeMaxTermLengthL = ppuLens . hkdCommitteeMaxTermLengthL @era @StrictMaybe
 
 ppuGovActionLifetimeL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe EpochNo)
 ppuGovActionLifetimeL = ppuLens . hkdGovActionLifetimeL @era @StrictMaybe

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -35,7 +35,7 @@ module Cardano.Ledger.Conway.PParams (
   ConwayEraPParams (..),
   ppPoolVotingThresholdsL,
   ppDRepVotingThresholdsL,
-  ppMinCommitteeSizeL,
+  ppCommitteeMinSizeL,
   ppCommitteeMaxTermLengthL,
   ppGovActionLifetimeL,
   ppGovActionDepositL,
@@ -43,7 +43,7 @@ module Cardano.Ledger.Conway.PParams (
   ppDRepActivityL,
   ppuPoolVotingThresholdsL,
   ppuDRepVotingThresholdsL,
-  ppuMinCommitteeSizeL,
+  ppuCommitteeMinSizeL,
   ppuCommitteeMaxTermLengthL,
   ppuGovActionLifetimeL,
   ppuGovActionDepositL,
@@ -86,7 +86,7 @@ import Numeric.Natural (Natural)
 -- | Conway Protocol parameters. The following parameters have been added since Babbage:
 -- * @poolVotingThresholds@
 -- * @dRepVotingThresholds@
--- * @minCommitteeSize@
+-- * @committeeMinSize@
 -- * @committeeMaxTermLength@
 -- * @govActionLifetime@
 -- * @govActionDeposit@
@@ -145,7 +145,7 @@ data ConwayPParams f era = ConwayPParams
   -- ^ Thresholds for SPO votes
   , cppDRepVotingThresholds :: !(HKD f DRepVotingThresholds)
   -- ^ Thresholds for DRep votes
-  , cppMinCommitteeSize :: !(HKD f Natural)
+  , cppCommitteeMinSize :: !(HKD f Natural)
   -- ^ Minimum size of the Constitutional Committee
   , cppCommitteeMaxTermLength :: !(HKD f Natural) -- TODO: This too should be EpochNo
 
@@ -186,7 +186,7 @@ instance NFData (ConwayPParams StrictMaybe era)
 data UpgradeConwayPParams f = UpgradeConwayPParams
   { ucppPoolVotingThresholds :: !(HKD f PoolVotingThresholds)
   , ucppDRepVotingThresholds :: !(HKD f DRepVotingThresholds)
-  , ucppMinCommitteeSize :: !(HKD f Natural)
+  , ucppCommitteeMinSize :: !(HKD f Natural)
   , ucppCommitteeMaxTermLength :: !(HKD f Natural)
   , ucppGovActionLifetime :: !(HKD f EpochNo)
   , ucppGovActionDeposit :: !(HKD f Coin)
@@ -222,7 +222,7 @@ instance Default (UpgradeConwayPParams Identity) where
     UpgradeConwayPParams
       { ucppPoolVotingThresholds = def
       , ucppDRepVotingThresholds = def
-      , ucppMinCommitteeSize = 0
+      , ucppCommitteeMinSize = 0
       , ucppCommitteeMaxTermLength = 0
       , ucppGovActionLifetime = EpochNo 0
       , ucppGovActionDeposit = Coin 0
@@ -235,7 +235,7 @@ instance Default (UpgradeConwayPParams StrictMaybe) where
     UpgradeConwayPParams
       { ucppPoolVotingThresholds = SNothing
       , ucppDRepVotingThresholds = SNothing
-      , ucppMinCommitteeSize = SNothing
+      , ucppCommitteeMinSize = SNothing
       , ucppCommitteeMaxTermLength = SNothing
       , ucppGovActionLifetime = SNothing
       , ucppGovActionDeposit = SNothing
@@ -249,7 +249,7 @@ instance EncCBOR (UpgradeConwayPParams Identity) where
       Rec (UpgradeConwayPParams @Identity)
         !> To ucppPoolVotingThresholds
         !> To ucppDRepVotingThresholds
-        !> To ucppMinCommitteeSize
+        !> To ucppCommitteeMinSize
         !> To ucppCommitteeMaxTermLength
         !> To ucppGovActionLifetime
         !> To ucppGovActionDeposit
@@ -348,7 +348,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       <*> pGroup NetworkGroup cppMaxCollateralInputs
       <*> pGroup GovernanceGroup cppPoolVotingThresholds
       <*> pGroup GovernanceGroup cppDRepVotingThresholds
-      <*> pGroup GovernanceGroup cppMinCommitteeSize
+      <*> pGroup GovernanceGroup cppCommitteeMinSize
       <*> pGroup GovernanceGroup cppCommitteeMaxTermLength
       <*> pGroup GovernanceGroup cppGovActionLifetime
       <*> pGroup GovernanceGroup cppGovActionDeposit
@@ -381,7 +381,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
 
   hkdPoolVotingThresholdsL = lens cppPoolVotingThresholds (\pp x -> pp {cppPoolVotingThresholds = x})
   hkdDRepVotingThresholdsL = lens cppDRepVotingThresholds (\pp x -> pp {cppDRepVotingThresholds = x})
-  hkdMinCommitteeSizeL = lens cppMinCommitteeSize (\pp x -> pp {cppMinCommitteeSize = x})
+  hkdCommitteeMinSizeL = lens cppCommitteeMinSize (\pp x -> pp {cppCommitteeMinSize = x})
   hkdCommitteeMaxTermLengthL = lens cppCommitteeMaxTermLength (\pp x -> pp {cppCommitteeMaxTermLength = x})
   hkdGovActionLifetimeL = lens cppGovActionLifetime (\pp x -> pp {cppGovActionLifetime = x})
   hkdGovActionDepositL = lens cppGovActionDeposit (\pp x -> pp {cppGovActionDeposit = x})
@@ -417,7 +417,7 @@ instance Era era => EncCBOR (ConwayPParams Identity era) where
         -- New for Conway
         !> To cppPoolVotingThresholds
         !> To cppDRepVotingThresholds
-        !> To cppMinCommitteeSize
+        !> To cppCommitteeMinSize
         !> To cppCommitteeMaxTermLength
         !> To cppGovActionLifetime
         !> To cppGovActionDeposit
@@ -507,7 +507,7 @@ emptyConwayPParams =
     , -- New in Conway
       cppPoolVotingThresholds = def
     , cppDRepVotingThresholds = def
-    , cppMinCommitteeSize = 0
+    , cppCommitteeMinSize = 0
     , cppCommitteeMaxTermLength = 0
     , cppGovActionLifetime = EpochNo 0
     , cppGovActionDeposit = Coin 0
@@ -543,7 +543,7 @@ emptyConwayPParamsUpdate =
     , -- New for Conway
       cppPoolVotingThresholds = SNothing
     , cppDRepVotingThresholds = SNothing
-    , cppMinCommitteeSize = SNothing
+    , cppCommitteeMinSize = SNothing
     , cppCommitteeMaxTermLength = SNothing
     , cppGovActionLifetime = SNothing
     , cppGovActionDeposit = SNothing
@@ -581,7 +581,7 @@ encodePParamsUpdate ppup =
     -- New for Conway
     !> omitStrictMaybe 25 (cppPoolVotingThresholds ppup) encCBOR
     !> omitStrictMaybe 26 (cppDRepVotingThresholds ppup) encCBOR
-    !> omitStrictMaybe 27 (cppMinCommitteeSize ppup) encCBOR
+    !> omitStrictMaybe 27 (cppCommitteeMinSize ppup) encCBOR
     !> omitStrictMaybe 28 (cppCommitteeMaxTermLength ppup) encCBOR
     !> omitStrictMaybe 29 (cppGovActionLifetime ppup) encCBOR
     !> omitStrictMaybe 30 (cppGovActionDeposit ppup) encCBOR
@@ -625,7 +625,7 @@ updateField = \case
   -- New for Conway
   25 -> field (\x up -> up {cppPoolVotingThresholds = SJust x}) From
   26 -> field (\x up -> up {cppDRepVotingThresholds = SJust x}) From
-  27 -> field (\x up -> up {cppMinCommitteeSize = SJust x}) From
+  27 -> field (\x up -> up {cppCommitteeMinSize = SJust x}) From
   28 -> field (\x up -> up {cppCommitteeMaxTermLength = SJust x}) From
   29 -> field (\x up -> up {cppGovActionLifetime = SJust x}) From
   30 -> field (\x up -> up {cppGovActionDeposit = SJust x}) From
@@ -678,7 +678,7 @@ conwayUpgradePParamsHKDPairs ::
 conwayUpgradePParamsHKDPairs px pp =
   [ ("poolVotingThresholds", hkdMap px (toJSON @PoolVotingThresholds) (pp ^. hkdPoolVotingThresholdsL @era @f))
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
-  , ("minCommitteeSize", hkdMap px (toJSON @Natural) (pp ^. hkdMinCommitteeSizeL @era @f))
+  , ("committeeMinSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
   , ("committeeMaxTermLength", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
   , ("govActionLifetime", hkdMap px (toJSON @EpochNo) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
@@ -698,7 +698,7 @@ upgradeConwayPParamsHKDPairs :: UpgradeConwayPParams Identity -> [(Key, Aeson.Va
 upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   [ ("poolVotingThresholds", (toJSON @PoolVotingThresholds) ucppPoolVotingThresholds)
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
-  , ("minCommitteeSize", (toJSON @Natural) ucppMinCommitteeSize)
+  , ("committeeMinSize", (toJSON @Natural) ucppCommitteeMinSize)
   , ("committeeMaxTermLength", (toJSON @Natural) ucppCommitteeMaxTermLength)
   , ("govActionLifetime", (toJSON @EpochNo) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
@@ -716,7 +716,7 @@ instance FromJSON (UpgradeConwayPParams Identity) where
       UpgradeConwayPParams
         <$> o .: "poolVotingThresholds"
         <*> o .: "dRepVotingThresholds"
-        <*> o .: "minCommitteeSize"
+        <*> o .: "committeeMinSize"
         <*> o .: "committeeMaxTermLength"
         <*> o .: "govActionLifetime"
         <*> o .: "govActionDeposit"
@@ -755,7 +755,7 @@ upgradeConwayPParams UpgradeConwayPParams {..} BabbagePParams {..} =
     , -- New for Conway
       cppPoolVotingThresholds = ucppPoolVotingThresholds
     , cppDRepVotingThresholds = ucppDRepVotingThresholds
-    , cppMinCommitteeSize = ucppMinCommitteeSize
+    , cppCommitteeMinSize = ucppCommitteeMinSize
     , cppCommitteeMaxTermLength = ucppCommitteeMaxTermLength
     , cppGovActionLifetime = ucppGovActionLifetime
     , cppGovActionDeposit = ucppGovActionDeposit
@@ -824,7 +824,7 @@ class BabbageEraPParams era => ConwayEraPParams era where
 
   hkdPoolVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f PoolVotingThresholds)
   hkdDRepVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f DRepVotingThresholds)
-  hkdMinCommitteeSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdCommitteeMinSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
   hkdCommitteeMaxTermLengthL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
   hkdGovActionLifetimeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
   hkdGovActionDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
@@ -837,8 +837,8 @@ ppPoolVotingThresholdsL = ppLens . hkdPoolVotingThresholdsL @era @Identity
 ppDRepVotingThresholdsL :: forall era. ConwayEraPParams era => Lens' (PParams era) DRepVotingThresholds
 ppDRepVotingThresholdsL = ppLens . hkdDRepVotingThresholdsL @era @Identity
 
-ppMinCommitteeSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
-ppMinCommitteeSizeL = ppLens . hkdMinCommitteeSizeL @era @Identity
+ppCommitteeMinSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
+ppCommitteeMinSizeL = ppLens . hkdCommitteeMinSizeL @era @Identity
 
 ppCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
 ppCommitteeMaxTermLengthL = ppLens . hkdCommitteeMaxTermLengthL @era @Identity
@@ -861,8 +861,8 @@ ppuPoolVotingThresholdsL = ppuLens . hkdPoolVotingThresholdsL @era @StrictMaybe
 ppuDRepVotingThresholdsL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe DRepVotingThresholds)
 ppuDRepVotingThresholdsL = ppuLens . hkdDRepVotingThresholdsL @era @StrictMaybe
 
-ppuMinCommitteeSizeL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
-ppuMinCommitteeSizeL = ppuLens . hkdMinCommitteeSizeL @era @StrictMaybe
+ppuCommitteeMinSizeL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
+ppuCommitteeMinSizeL = ppuLens . hkdCommitteeMinSizeL @era @StrictMaybe
 
 ppuCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
 ppuCommitteeMaxTermLengthL = ppuLens . hkdCommitteeMaxTermLengthL @era @StrictMaybe

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -37,7 +37,7 @@ module Cardano.Ledger.Conway.PParams (
   ppDRepVotingThresholdsL,
   ppMinCommitteeSizeL,
   ppCommitteeTermLimitL,
-  ppGovActionExpirationL,
+  ppGovActionLifetimeL,
   ppGovActionDepositL,
   ppDRepDepositL,
   ppDRepActivityL,
@@ -45,7 +45,7 @@ module Cardano.Ledger.Conway.PParams (
   ppuDRepVotingThresholdsL,
   ppuMinCommitteeSizeL,
   ppuCommitteeTermLimitL,
-  ppuGovActionExpirationL,
+  ppuGovActionLifetimeL,
   ppuGovActionDepositL,
   ppuDRepDepositL,
   ppuDRepActivityL,
@@ -88,7 +88,7 @@ import Numeric.Natural (Natural)
 -- * @dRepVotingThresholds@
 -- * @minCommitteeSize@
 -- * @committeeTermLimit@
--- * @govActionExpiration@
+-- * @govActionLifetime@
 -- * @govActionDeposit@
 -- * @dRepDeposit@
 -- * @dRepActivity@
@@ -150,8 +150,8 @@ data ConwayPParams f era = ConwayPParams
   , cppCommitteeTermLimit :: !(HKD f Natural) -- TODO: This too should be EpochNo
 
   -- ^ The Constitutional Committee Term limit in number of Slots
-  , cppGovActionExpiration :: !(HKD f EpochNo)
-  -- ^ Gov action expiration in number of Epochs
+  , cppGovActionLifetime :: !(HKD f EpochNo)
+  -- ^ Gov action lifetime in number of Epochs
   , cppGovActionDeposit :: !(HKD f Coin)
   -- ^ The amount of the Gov Action deposit
   , cppDRepDeposit :: !(HKD f Coin)
@@ -188,7 +188,7 @@ data UpgradeConwayPParams f = UpgradeConwayPParams
   , ucppDRepVotingThresholds :: !(HKD f DRepVotingThresholds)
   , ucppMinCommitteeSize :: !(HKD f Natural)
   , ucppCommitteeTermLimit :: !(HKD f Natural)
-  , ucppGovActionExpiration :: !(HKD f EpochNo)
+  , ucppGovActionLifetime :: !(HKD f EpochNo)
   , ucppGovActionDeposit :: !(HKD f Coin)
   , ucppDRepDeposit :: !(HKD f Coin)
   , ucppDRepActivity :: !(HKD f EpochNo)
@@ -224,7 +224,7 @@ instance Default (UpgradeConwayPParams Identity) where
       , ucppDRepVotingThresholds = def
       , ucppMinCommitteeSize = 0
       , ucppCommitteeTermLimit = 0
-      , ucppGovActionExpiration = EpochNo 0
+      , ucppGovActionLifetime = EpochNo 0
       , ucppGovActionDeposit = Coin 0
       , ucppDRepDeposit = Coin 0
       , ucppDRepActivity = EpochNo 0
@@ -237,7 +237,7 @@ instance Default (UpgradeConwayPParams StrictMaybe) where
       , ucppDRepVotingThresholds = SNothing
       , ucppMinCommitteeSize = SNothing
       , ucppCommitteeTermLimit = SNothing
-      , ucppGovActionExpiration = SNothing
+      , ucppGovActionLifetime = SNothing
       , ucppGovActionDeposit = SNothing
       , ucppDRepDeposit = SNothing
       , ucppDRepActivity = SNothing
@@ -251,7 +251,7 @@ instance EncCBOR (UpgradeConwayPParams Identity) where
         !> To ucppDRepVotingThresholds
         !> To ucppMinCommitteeSize
         !> To ucppCommitteeTermLimit
-        !> To ucppGovActionExpiration
+        !> To ucppGovActionLifetime
         !> To ucppGovActionDeposit
         !> To ucppDRepDeposit
         !> To ucppDRepActivity
@@ -350,7 +350,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       <*> pGroup GovernanceGroup cppDRepVotingThresholds
       <*> pGroup GovernanceGroup cppMinCommitteeSize
       <*> pGroup GovernanceGroup cppCommitteeTermLimit
-      <*> pGroup GovernanceGroup cppGovActionExpiration
+      <*> pGroup GovernanceGroup cppGovActionLifetime
       <*> pGroup GovernanceGroup cppGovActionDeposit
       <*> pGroup GovernanceGroup cppDRepDeposit
       <*> pGroup GovernanceGroup cppDRepActivity
@@ -364,7 +364,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       , isValid (/= 0) ppuMaxValSizeL
       , isValid (/= 0) ppuCollateralPercentageL
       , isValid (/= 0) ppuCommitteeTermLimitL
-      , isValid (/= EpochNo 0) ppuGovActionExpirationL
+      , isValid (/= EpochNo 0) ppuGovActionLifetimeL
       , -- Coins
         isValid (/= zero) ppuPoolDepositL
       , isValid (/= zero) ppuGovActionDepositL
@@ -383,7 +383,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
   hkdDRepVotingThresholdsL = lens cppDRepVotingThresholds (\pp x -> pp {cppDRepVotingThresholds = x})
   hkdMinCommitteeSizeL = lens cppMinCommitteeSize (\pp x -> pp {cppMinCommitteeSize = x})
   hkdCommitteeTermLimitL = lens cppCommitteeTermLimit (\pp x -> pp {cppCommitteeTermLimit = x})
-  hkdGovActionExpirationL = lens cppGovActionExpiration (\pp x -> pp {cppGovActionExpiration = x})
+  hkdGovActionLifetimeL = lens cppGovActionLifetime (\pp x -> pp {cppGovActionLifetime = x})
   hkdGovActionDepositL = lens cppGovActionDeposit (\pp x -> pp {cppGovActionDeposit = x})
   hkdDRepDepositL = lens cppDRepDeposit (\pp x -> pp {cppDRepDeposit = x})
   hkdDRepActivityL = lens cppDRepActivity (\pp x -> pp {cppDRepActivity = x})
@@ -419,7 +419,7 @@ instance Era era => EncCBOR (ConwayPParams Identity era) where
         !> To cppDRepVotingThresholds
         !> To cppMinCommitteeSize
         !> To cppCommitteeTermLimit
-        !> To cppGovActionExpiration
+        !> To cppGovActionLifetime
         !> To cppGovActionDeposit
         !> To cppDRepDeposit
         !> To cppDRepActivity
@@ -509,7 +509,7 @@ emptyConwayPParams =
     , cppDRepVotingThresholds = def
     , cppMinCommitteeSize = 0
     , cppCommitteeTermLimit = 0
-    , cppGovActionExpiration = EpochNo 0
+    , cppGovActionLifetime = EpochNo 0
     , cppGovActionDeposit = Coin 0
     , cppDRepDeposit = Coin 0
     , cppDRepActivity = EpochNo 0
@@ -545,7 +545,7 @@ emptyConwayPParamsUpdate =
     , cppDRepVotingThresholds = SNothing
     , cppMinCommitteeSize = SNothing
     , cppCommitteeTermLimit = SNothing
-    , cppGovActionExpiration = SNothing
+    , cppGovActionLifetime = SNothing
     , cppGovActionDeposit = SNothing
     , cppDRepDeposit = SNothing
     , cppDRepActivity = SNothing
@@ -583,7 +583,7 @@ encodePParamsUpdate ppup =
     !> omitStrictMaybe 26 (cppDRepVotingThresholds ppup) encCBOR
     !> omitStrictMaybe 27 (cppMinCommitteeSize ppup) encCBOR
     !> omitStrictMaybe 28 (cppCommitteeTermLimit ppup) encCBOR
-    !> omitStrictMaybe 29 (cppGovActionExpiration ppup) encCBOR
+    !> omitStrictMaybe 29 (cppGovActionLifetime ppup) encCBOR
     !> omitStrictMaybe 30 (cppGovActionDeposit ppup) encCBOR
     !> omitStrictMaybe 31 (cppDRepDeposit ppup) encCBOR
     !> omitStrictMaybe 32 (cppDRepActivity ppup) encCBOR
@@ -627,7 +627,7 @@ updateField = \case
   26 -> field (\x up -> up {cppDRepVotingThresholds = SJust x}) From
   27 -> field (\x up -> up {cppMinCommitteeSize = SJust x}) From
   28 -> field (\x up -> up {cppCommitteeTermLimit = SJust x}) From
-  29 -> field (\x up -> up {cppGovActionExpiration = SJust x}) From
+  29 -> field (\x up -> up {cppGovActionLifetime = SJust x}) From
   30 -> field (\x up -> up {cppGovActionDeposit = SJust x}) From
   31 -> field (\x up -> up {cppDRepDeposit = SJust x}) From
   32 -> field (\x up -> up {cppDRepActivity = SJust x}) From
@@ -680,7 +680,7 @@ conwayUpgradePParamsHKDPairs px pp =
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
   , ("minCommitteeSize", hkdMap px (toJSON @Natural) (pp ^. hkdMinCommitteeSizeL @era @f))
   , ("committeeTermLimit", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeTermLimitL @era @f))
-  , ("govActionExpiration", hkdMap px (toJSON @EpochNo) (pp ^. hkdGovActionExpirationL @era @f))
+  , ("govActionLifetime", hkdMap px (toJSON @EpochNo) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
   , ("dRepDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdDRepDepositL @era @f))
   , ("dRepActivity", hkdMap px (toJSON @EpochNo) (pp ^. hkdDRepActivityL @era @f))
@@ -700,7 +700,7 @@ upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
   , ("minCommitteeSize", (toJSON @Natural) ucppMinCommitteeSize)
   , ("committeeTermLimit", (toJSON @Natural) ucppCommitteeTermLimit)
-  , ("govActionExpiration", (toJSON @EpochNo) ucppGovActionExpiration)
+  , ("govActionLifetime", (toJSON @EpochNo) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
   , ("dRepDeposit", (toJSON @Coin) ucppDRepDeposit)
   , ("dRepActivity", (toJSON @EpochNo) ucppDRepActivity)
@@ -718,7 +718,7 @@ instance FromJSON (UpgradeConwayPParams Identity) where
         <*> o .: "dRepVotingThresholds"
         <*> o .: "minCommitteeSize"
         <*> o .: "committeeTermLimit"
-        <*> o .: "govActionExpiration"
+        <*> o .: "govActionLifetime"
         <*> o .: "govActionDeposit"
         <*> o .: "dRepDeposit"
         <*> o .: "dRepActivity"
@@ -757,7 +757,7 @@ upgradeConwayPParams UpgradeConwayPParams {..} BabbagePParams {..} =
     , cppDRepVotingThresholds = ucppDRepVotingThresholds
     , cppMinCommitteeSize = ucppMinCommitteeSize
     , cppCommitteeTermLimit = ucppCommitteeTermLimit
-    , cppGovActionExpiration = ucppGovActionExpiration
+    , cppGovActionLifetime = ucppGovActionLifetime
     , cppGovActionDeposit = ucppGovActionDeposit
     , cppDRepDeposit = ucppDRepDeposit
     , cppDRepActivity = ucppDRepActivity
@@ -826,7 +826,7 @@ class BabbageEraPParams era => ConwayEraPParams era where
   hkdDRepVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f DRepVotingThresholds)
   hkdMinCommitteeSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
   hkdCommitteeTermLimitL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
-  hkdGovActionExpirationL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
+  hkdGovActionLifetimeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
   hkdGovActionDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
   hkdDRepDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
   hkdDRepActivityL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
@@ -843,8 +843,8 @@ ppMinCommitteeSizeL = ppLens . hkdMinCommitteeSizeL @era @Identity
 ppCommitteeTermLimitL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
 ppCommitteeTermLimitL = ppLens . hkdCommitteeTermLimitL @era @Identity
 
-ppGovActionExpirationL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochNo
-ppGovActionExpirationL = ppLens . hkdGovActionExpirationL @era @Identity
+ppGovActionLifetimeL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochNo
+ppGovActionLifetimeL = ppLens . hkdGovActionLifetimeL @era @Identity
 
 ppGovActionDepositL :: forall era. ConwayEraPParams era => Lens' (PParams era) Coin
 ppGovActionDepositL = ppLens . hkdGovActionDepositL @era @Identity
@@ -867,8 +867,8 @@ ppuMinCommitteeSizeL = ppuLens . hkdMinCommitteeSizeL @era @StrictMaybe
 ppuCommitteeTermLimitL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
 ppuCommitteeTermLimitL = ppuLens . hkdCommitteeTermLimitL @era @StrictMaybe
 
-ppuGovActionExpirationL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe EpochNo)
-ppuGovActionExpirationL = ppuLens . hkdGovActionExpirationL @era @StrictMaybe
+ppuGovActionLifetimeL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe EpochNo)
+ppuGovActionLifetimeL = ppuLens . hkdGovActionLifetimeL @era @StrictMaybe
 
 ppuGovActionDepositL :: forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Coin)
 ppuGovActionDepositL = ppuLens . hkdGovActionDepositL @era @StrictMaybe

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -66,7 +66,7 @@ import Cardano.Ledger.Conway.Governance.Snapshots (snapshotGovActionStates)
 import Cardano.Ledger.Conway.PParams (
   ConwayEraPParams (..),
   ppGovActionDepositL,
-  ppGovActionExpirationL,
+  ppGovActionLifetimeL,
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
@@ -288,7 +288,7 @@ govTransition = do
         let st'' =
               addAction
                 currentEpoch
-                (pp ^. ppGovActionExpirationL)
+                (pp ^. ppGovActionLifetimeL)
                 (GovActionId txid idx)
                 pProcDeposit
                 pProcReturnAddr

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.Conway.Governance (
 import Cardano.Ledger.Conway.Governance.Procedures (committeeMembersL)
 import Cardano.Ledger.Conway.PParams (
   ConwayEraPParams,
-  ppCommitteeTermLimitL,
+  ppCommitteeMaxTermLengthL,
   ppMinCommitteeSizeL,
  )
 import Cardano.Ledger.Conway.Rules.Enact (EnactSignal (..), EnactState (..))
@@ -310,7 +310,7 @@ validCommitteeTerm ::
   EpochNo ->
   Bool
 validCommitteeTerm committee pp currentEpoch =
-  let maxCommitteeTerm = pp ^. ppCommitteeTermLimitL
+  let maxCommitteeTerm = pp ^. ppCommitteeMaxTermLengthL
       members = foldMap' (^. committeeMembersL) committee
    in all (<= currentEpoch + fromIntegral maxCommitteeTerm) members
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Conway.Governance.Procedures (committeeMembersL)
 import Cardano.Ledger.Conway.PParams (
   ConwayEraPParams,
   ppCommitteeMaxTermLengthL,
-  ppMinCommitteeSizeL,
+  ppCommitteeMinSizeL,
  )
 import Cardano.Ledger.Conway.Rules.Enact (EnactSignal (..), EnactState (..))
 import Cardano.Ledger.Credential (Credential (..))
@@ -299,9 +299,9 @@ prevActionAsExpected _ _ = True -- for the other actions, the previous action is
 
 validCommitteeSize :: ConwayEraPParams era => StrictMaybe (Committee era) -> PParams era -> Bool
 validCommitteeSize committee pp =
-  let minCommitteeSize = pp ^. ppMinCommitteeSizeL
+  let committeeMinSize = pp ^. ppCommitteeMinSizeL
       members = foldMap' (^. committeeMembersL) committee
-   in Map.size members >= fromIntegral minCommitteeSize
+   in Map.size members >= fromIntegral committeeMinSize
 
 validCommitteeTerm ::
   ConwayEraPParams era =>

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -18,7 +18,7 @@
         "dvtPPGovGroup":0,
         "dvtTreasuryWithdrawal":0
      },
-     "minCommitteeSize":0,
+     "committeeMinSize":0,
      "committeeMaxTermLength":0,
      "govActionLifetime":0,
      "govActionDeposit":0,

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -19,7 +19,7 @@
         "dvtTreasuryWithdrawal":0
      },
      "minCommitteeSize":0,
-     "committeeTermLimit":0,
+     "committeeMaxTermLength":0,
      "govActionLifetime":0,
      "govActionDeposit":0,
      "dRepDeposit":0,

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -20,7 +20,7 @@
      },
      "minCommitteeSize":0,
      "committeeTermLimit":0,
-     "govActionExpiration":0,
+     "govActionLifetime":0,
      "govActionDeposit":0,
      "dRepDeposit":0,
      "dRepActivity":0

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -294,7 +294,7 @@ ppConwayPParams n pp =
     , ("MaxBHSize", prettyA $ pp ^. hkdMaxBHSizeL @era @f)
     , ("MaxBBSize", prettyA $ pp ^. hkdMaxBBSizeL @era @f)
     , ("KeyDeposit", prettyA $ pp ^. hkdKeyDepositL @era @f)
-    , ("GovActionExpiration", prettyA $ pp ^. hkdGovActionExpirationL @era @f)
+    , ("GovActionLifetime", prettyA $ pp ^. hkdGovActionLifetimeL @era @f)
     , ("GovActionDeposit", prettyA $ pp ^. hkdGovActionDepositL @era @f)
     , ("EMax", prettyA $ pp ^. hkdEMaxL @era @f)
     , ("DRepVotingThresholds", prettyA $ pp ^. hkdDRepVotingThresholdsL @era @f)

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -301,7 +301,7 @@ ppConwayPParams n pp =
     , ("DRepDeposit", prettyA $ pp ^. hkdDRepDepositL @era @f)
     , ("DRepActivity", prettyA $ pp ^. hkdDRepActivityL @era @f)
     , ("CostModels", prettyA $ pp ^. hkdCostModelsL @era @f)
-    , ("CommitteeTermLimit", prettyA $ pp ^. hkdCommitteeTermLimitL @era @f)
+    , ("CommitteeMaxTermLength", prettyA $ pp ^. hkdCommitteeMaxTermLengthL @era @f)
     , ("CollateralPercentage", prettyA $ pp ^. hkdCollateralPercentageL @era @f)
     , ("CoinsPerUTxOByte", prettyA $ pp ^. hkdCoinsPerUTxOByteL @era @f)
     , ("A0", prettyA $ pp ^. hkdA0L @era @f)

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -285,7 +285,7 @@ ppConwayPParams n pp =
     , ("MinPoolCost", prettyA $ pp ^. hkdMinPoolCostL @era @f)
     , ("MinFeeB", prettyA $ pp ^. hkdMinFeeBL @era @f)
     , ("MinFeeA", prettyA $ pp ^. hkdMinFeeAL @era @f)
-    , ("MinCommitteeSize", prettyA $ pp ^. hkdMinCommitteeSizeL @era @f)
+    , ("CommitteeMinSize", prettyA $ pp ^. hkdCommitteeMinSizeL @era @f)
     , ("MaxValSize", prettyA $ pp ^. hkdMaxValSizeL @era @f)
     , ("MaxTxSize", prettyA $ pp ^. hkdMaxTxSizeL @era @f)
     , ("MaxTxExUnits", prettyA $ pp ^. hkdMaxTxExUnitsL @era @f)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -220,7 +220,7 @@ pp =
   emptyPParams
     & ppMaxValSizeL .~ 1000000000
     & ppDRepActivityL .~ 100
-    & ppGovActionExpirationL .~ 30
+    & ppGovActionLifetimeL .~ 30
     & ppGovActionDepositL .~ proposalDeposit
     & ppDRepVotingThresholdsL . dvtUpdateToConstitutionL
       .~ fromJust (boundRational (1 % 2))
@@ -347,7 +347,7 @@ preventDRepExpiry ::
 preventDRepExpiry pf = do
   let
     (utxo0, _) = utxoFromTestCaseData pf (proposal pf)
-    pp' = pp & ppGovActionExpirationL .~ 3
+    pp' = pp & ppGovActionLifetimeL .~ 3
     proposalTx = txFromTestCaseData pf (proposal pf)
     govActionId = GovActionId (txid (proposalTx ^. bodyTxL)) (GovActionIx 0)
     initialGov =


### PR DESCRIPTION
# Description

Closes #3732 

* Rename `ConwayPParams` to be consistent with the Agda specification. #
  * `govActionExpiration` to `govActionLifetime`
  * `committeeTermLimit` to `committeeMaxTermLength`
  * `minCommitteeSize` to `committeeMinSize`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
