### PR TITLE
Use (CompactForm Coin) in IncrementalStake, DRepDistr (and other places) instead of Coin

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -89,8 +89,7 @@ library
         small-steps,
         text,
         transformers,
-        validation-selective,
-        vector-map
+        validation-selective
 
 library testlib
     exposed-modules:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -186,7 +186,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   utxosGovStateL,
  )
 import Cardano.Ledger.TreeDiff (ToExpr)
-import Cardano.Ledger.UMap (compactCoinOrError)
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Default.Class (Default (..))
@@ -196,7 +195,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.VMap as VMap
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -802,4 +800,4 @@ freshDRepPulser n es =
     n
     (es ^. epochStateUMapL)
     (es ^. epochStateRegDrepL)
-    (VMap.fromMap (compactCoinOrError <$> (es ^. epochStateIncrStakeDistrL)))
+    (es ^. epochStateIncrStakeDistrL)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -74,7 +74,7 @@ import Data.Word (Word64)
 import Lens.Micro ((^.))
 
 data RatifyEnv era = RatifyEnv
-  { reStakeDistr :: !(Map (Credential 'Staking (EraCrypto era)) Coin)
+  { reStakeDistr :: !(Map (Credential 'Staking (EraCrypto era)) (CompactForm Coin))
   , reStakePoolDistr :: !(PoolDistr (EraCrypto era))
   , reDRepDistr :: !(Map (DRep (EraCrypto era)) (CompactForm Coin))
   , reDRepState :: !(Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era)))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.CertState (
  )
 import Cardano.Ledger.Coin (
   Coin (..),
+  CompactForm (CompactCoin),
   addDeltaCoin,
  )
 import Cardano.Ledger.Compactible
@@ -63,7 +64,6 @@ import Cardano.Ledger.Shelley.Rewards (
 import Cardano.Ledger.UMap (
   UMElem,
   UMap (..),
-  compactCoinOrError,
   member,
  )
 import qualified Cardano.Ledger.UMap as UM
@@ -73,7 +73,6 @@ import Cardano.Ledger.UTxO (
 import Control.DeepSeq (NFData (rnf), deepseq)
 import Control.Exception (assert)
 import Data.Foldable (fold)
-import Data.Group (invert)
 import Data.Map.Internal.Debug as Map (valid)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -95,12 +94,20 @@ updateStakeDistribution ::
   IncrementalStake (EraCrypto era)
 updateStakeDistribution pp incStake0 utxoDel utxoAdd = incStake2
   where
-    incStake1 = incrementalAggregateUtxoCoinByCredential pp id utxoAdd incStake0
-    incStake2 = incrementalAggregateUtxoCoinByCredential pp invert utxoDel incStake1
+    incStake1 = incrementalAggregateUtxoCoinByCredential pp Id utxoAdd incStake0
+    incStake2 = incrementalAggregateUtxoCoinByCredential pp Invert utxoDel incStake1
+
+-- | Should a value be added (Id) or subtracted (Invert)
+data Mode = Id | Invert
+
+-- | add or subtract a Coin (depending on Mode) to a (CompactForm Coin)
+addCompact :: Mode -> CompactForm Coin -> CompactForm Coin -> CompactForm Coin
+addCompact Id (CompactCoin n) (CompactCoin m) = CompactCoin (m + fromIntegral n)
+addCompact Invert (CompactCoin n) (CompactCoin m) = CompactCoin (m - fromIntegral n)
 
 -- | Incrementally sum up all the Coin, for each staking Credential, in the outputs of the UTxO, and
 --   "add" them to the IncrementalStake. "add" has different meaning depending on if we are inserting
---   or deleting the UtxO entries. For inserts (mode is the identity: id) and for deletes (mode is invert).
+--   or deleting the UtxO entries. For inserts (the mode is Id) and for deletes (the mode is Invert).
 --   Never store a (Coin 0) balance, since these do not occur in the non-incremental style that
 --   works directly from the whole UTxO.
 --   This function has a non-incremental analog 'aggregateUtxoCoinByCredential' . In this incremental
@@ -110,30 +117,30 @@ incrementalAggregateUtxoCoinByCredential ::
   forall era.
   EraTxOut era =>
   PParams era ->
-  (Coin -> Coin) ->
+  Mode ->
   UTxO era ->
   IncrementalStake (EraCrypto era) ->
   IncrementalStake (EraCrypto era)
 incrementalAggregateUtxoCoinByCredential pp mode (UTxO u) initial =
   Map.foldl' accum initial u
   where
-    keepOrDelete new Nothing =
-      case mode new of
-        Coin 0 -> Nothing
+    keepOrDeleteCompact new Nothing =
+      case new of
+        CompactCoin 0 -> Nothing
         final -> Just final
-    keepOrDelete new (Just old) =
-      case mode new <> old of
-        Coin 0 -> Nothing
+    keepOrDeleteCompact new (Just old) =
+      case addCompact mode new old of
+        CompactCoin 0 -> Nothing
         final -> Just final
     ignorePtrs = HardForks.forgoPointerAddressResolution (pp ^. ppProtocolVersionL)
     accum ans@(IStake stake ptrs) out =
-      let c = out ^. coinTxOutL
+      let cc = out ^. compactCoinTxOutL
        in case out ^. addrTxOutL of
             Addr _ _ (StakeRefPtr p) ->
               if ignorePtrs
                 then ans
-                else IStake stake (Map.alter (keepOrDelete c) p ptrs)
-            Addr _ _ (StakeRefBase hk) -> IStake (Map.alter (keepOrDelete c) hk stake) ptrs
+                else IStake stake (Map.alter (keepOrDeleteCompact cc) p ptrs)
+            Addr _ _ (StakeRefBase hk) -> IStake (Map.alter (keepOrDeleteCompact cc) hk stake) ptrs
             _other -> ans
 
 -- ================================================
@@ -204,7 +211,7 @@ incrementalStakeDistr ::
   SnapShot (EraCrypto era)
 incrementalStakeDistr pp (IStake credStake ptrStake) ds ps =
   SnapShot
-    (Stake $ VMap.fromMap (compactCoinOrError <$> step2))
+    (Stake $ VMap.fromMap step2) -- (compactCoinOrError <$> step2))
     delegs_
     (VMap.fromMap poolParams)
   where
@@ -220,19 +227,19 @@ incrementalStakeDistr pp (IStake credStake ptrStake) ds ps =
       if ignorePtrs
         then activeCreds
         else -- Resolve inserts and delets which were indexed by ptrs, by looking them up in the ptrsMap
-        -- and combining the result of the lookup with teh ordinary stake, keeping only the active credentials
+        -- and combining the result of the lookup with the ordinary stake, keeping only the active credentials
           Map.foldlWithKey' addResolvedPointer activeCreds ptrStake
     step2 = aggregateActiveStake triplesMap step1
-    addResolvedPointer ans ptr coin =
+    addResolvedPointer ans ptr ccoin =
       case Map.lookup ptr ptrsMap of -- map of ptrs to credentials
-        Just cred | VMap.member cred delegs_ -> Map.insertWith (<>) cred coin ans
+        Just cred | VMap.member cred delegs_ -> Map.insertWith (<>) cred ccoin ans
         _ -> ans
 
 -- | Aggregate active stake by merging two maps. The triple map from the
 --   UMap, and the IncrementalStake. Only keep the active stake. Active can
 --   be determined if there is a (SJust deleg) in the Tuple.  This is step2 =
 --   aggregate (dom activeDelegs ◁ rewards) step1
-aggregateActiveStake :: Ord k => Map k (UMElem c) -> Map k Coin -> Map k Coin
+aggregateActiveStake :: Ord k => Map k (UMElem c) -> Map k (CompactForm Coin) -> Map k (CompactForm Coin)
 aggregateActiveStake m1 m2 = assert (Map.valid m) m
   where
     m =
@@ -241,15 +248,15 @@ aggregateActiveStake m1 m2 = assert (Map.valid m) m
         -- 'coin1' and 'coin2' have the same key, '_k', and the stake is active if the delegation is SJust
         (\_k trip coin2 -> extractAndAdd coin2 <$> UM.umElemRDActive trip)
         -- what to do when a key appears just in 'tripmap', we only add the coin if the key is active
-        (Map.mapMaybe (\trip -> fromCompact . UM.rdReward <$> UM.umElemRDActive trip))
+        (Map.mapMaybe (\trip -> UM.rdReward <$> UM.umElemRDActive trip))
         -- what to do when a key is only in 'incremental', keep everything, because at
         -- the call site of aggregateActiveStake, the arg 'incremental' is filtered by
         -- 'resolveActiveIncrementalPtrs' which guarantees that only active stake is included.
         id
         m1
         m2
-    extractAndAdd :: Coin -> UM.RDPair -> Coin
-    extractAndAdd coin (UM.RDPair rew _dep) = coin <> fromCompact rew
+    extractAndAdd :: CompactForm Coin -> UM.RDPair -> CompactForm Coin
+    extractAndAdd coin (UM.RDPair rew _dep) = coin <> rew
 
 -- =====================================================
 -- Part 3 Apply a reward update, in NewEpoch rule

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -211,7 +211,7 @@ incrementalStakeDistr ::
   SnapShot (EraCrypto era)
 incrementalStakeDistr pp (IStake credStake ptrStake) ds ps =
   SnapShot
-    (Stake $ VMap.fromMap step2) -- (compactCoinOrError <$> step2))
+    (Stake $ VMap.fromMap step2)
     delegs_
     (VMap.fromMap poolParams)
   where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -221,8 +221,8 @@ toEpochStatePairs es@(EpochState _ _ _ _) =
 --   the epoch boundary is reached we 'resolve' these pointers, to see if any have
 --   become non-dangling since the time they were first used in the incremental computation.
 data IncrementalStake c = IStake
-  { credMap :: !(Map (Credential 'Staking c) Coin)
-  , ptrMap :: !(Map Ptr Coin)
+  { credMap :: !(Map (Credential 'Staking c) (CompactForm Coin))
+  , ptrMap :: !(Map Ptr (CompactForm Coin))
   }
   deriving (Generic, Show, Eq, Ord, NoThunks, NFData)
 
@@ -702,10 +702,10 @@ utxosDonationL = lens utxosDonation (\x y -> x {utxosDonation = y})
 
 -- ================ IncremetalStake ===========================
 
-credMapL :: Lens' (IncrementalStake c) (Map (Credential 'Staking c) Coin)
+credMapL :: Lens' (IncrementalStake c) (Map (Credential 'Staking c) (CompactForm Coin))
 credMapL = lens credMap (\x y -> x {credMap = y})
 
-ptrMapL :: Lens' (IncrementalStake c) (Map Ptr Coin)
+ptrMapL :: Lens' (IncrementalStake c) (Map Ptr (CompactForm Coin))
 ptrMapL = lens ptrMap (\x y -> x {ptrMap = y})
 
 -- ====================  Compound Lenses =======================
@@ -716,7 +716,7 @@ newEpochStateGovStateL = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
 epochStateIncrStakeDistrL ::
   Lens'
     (EpochState era)
-    (Map (Credential 'Staking (EraCrypto era)) Coin)
+    (Map (Credential 'Staking (EraCrypto era)) (CompactForm Coin))
 epochStateIncrStakeDistrL = esLStateL . lsUTxOStateL . utxosStakeDistrL . credMapL
 
 epochStateRegDrepL ::

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -136,7 +136,7 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
                 ]
               )
           )
-          $ utxoBal === incrStakeBal
+          $ utxoBal === fromCompact incrStakeBal
         where
           utxoBal = coinBalance u'
           incrStakeBal = fold (credMap sd') <> fold (ptrMap sd')

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/TerseTools.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/TerseTools.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | This module suppies tools to tersely describe the differences between 2 values of the same type.
 module Test.Cardano.Ledger.TerseTools where
 
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (
   Credential (..),
@@ -99,6 +100,9 @@ instance CC.Crypto era => Terse (TxIn era) where
 
 instance Terse (Coin) where
   terse (Coin n) = show n
+
+instance Terse (CompactForm Coin) where
+  terse (CompactCoin n) = show n
 
 tersediffincremental :: String -> IncrementalStake c -> IncrementalStake c -> String
 tersediffincremental message (IStake a b) (IStake c d) =

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -738,8 +738,8 @@ ppIncrementalStake :: IncrementalStake c -> PDoc
 ppIncrementalStake (IStake st dangle) =
   ppRecord
     "IncrementalStake"
-    [ ("credMap", ppMap ppCredential ppCoin st)
-    , ("ptrMap", ppMap ppPtr ppCoin dangle)
+    [ ("credMap", ppMap ppCredential (ppCoin . fromCompact) st)
+    , ("ptrMap", ppMap ppPtr (ppCoin . fromCompact) dangle)
     ]
 
 ppUTxOState ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -9,6 +9,7 @@ module Test.Cardano.Ledger.Constrained.Lenses where
 
 import Cardano.Ledger.BaseTypes (SlotNo)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
+import Cardano.Ledger.Compactible (Compactible (fromCompact))
 import Cardano.Ledger.Core (DRep)
 import Cardano.Ledger.Credential (Credential, Ptr)
 import Cardano.Ledger.Keys (GenDelegPair (..), GenDelegs (..), KeyHash, KeyRole (..))
@@ -73,10 +74,10 @@ fGenDelegGenKeyHashL = lens fGenDelegGenKeyHash (\ds u -> ds {fGenDelegGenKeyHas
 -- IncrementalStake
 
 isCredMapL :: Lens' (IncrementalStake c) (Map (Credential 'Staking c) Coin)
-isCredMapL = lens credMap (\ds u -> ds {credMap = u})
+isCredMapL = lens (fmap fromCompact . credMap) (\ds u -> ds {credMap = fmap compactCoinOrError u})
 
 isPtrMapL :: Lens' (IncrementalStake c) (Map Ptr Coin)
-isPtrMapL = lens ptrMap (\ds u -> ds {ptrMap = u})
+isPtrMapL = lens (fmap fromCompact . ptrMap) (\ds u -> ds {ptrMap = fmap compactCoinOrError u})
 
 -- ===============================================
 -- NonMyopic


### PR DESCRIPTION
Changed the IncrementallStake 'credMap' field to (Map (Credential 'Staking c) (CompactForm Coin))
This facilitated changing it in DRepDistr and RatifyEnv as well, Now taking a snapshot of one of these is a simple pointer copy.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
