### PR TITLE
Apply enacted treasury withdrawals

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Apply enacted `TreasuryWithdrawals` in `ConwayEPOCH` #3748
+  * Add lenses `ensWithdrawalsL` and `ensTreasuryL`
 * Change `To/FromJSON` format for `ConwayGenesis`
 * Add `EraTransition` instance and `toConwayTransitionConfigPairs`.
 * Expose `toConwayGenesisPairs` and `toUpgradeConwayPParamsUpdatePairs`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -65,6 +65,8 @@ module Cardano.Ledger.Conway.Governance (
   ensConstitutionL,
   ensCurPParamsL,
   ensPrevPParamsL,
+  ensWithdrawalsL,
+  ensTreasuryL,
   ensPrevGovActionIdsL,
   ensPrevPParamUpdateL,
   ensPrevHardForkL,
@@ -374,6 +376,12 @@ ensCurPParamsL = lens ensPParams (\es x -> es {ensPParams = x})
 
 ensPrevPParamsL :: Lens' (EnactState era) (PParams era)
 ensPrevPParamsL = lens ensPrevPParams (\es x -> es {ensPrevPParams = x})
+
+ensTreasuryL :: Lens' (EnactState era) Coin
+ensTreasuryL = lens ensTreasury $ \es x -> es {ensTreasury = x}
+
+ensWithdrawalsL :: Lens' (EnactState era) (Map (Credential 'Staking (EraCrypto era)) Coin)
+ensWithdrawalsL = lens ensWithdrawals $ \es x -> es {ensWithdrawals = x}
 
 ensPrevGovActionIdsL :: Lens' (EnactState era) (PrevGovActionIds era)
 ensPrevGovActionIdsL = lens ensPrevGovActionIds (\es x -> es {ensPrevGovActionIds = x})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -36,6 +36,8 @@ import Cardano.Ledger.Conway.Governance (
   PrevGovActionIds (..),
   RatifyState (..),
   Vote (..),
+  ensTreasuryL,
+  rsEnactStateL,
   votingDRepThreshold,
   votingStakePoolThreshold,
  )
@@ -71,7 +73,7 @@ import qualified Data.Sequence.Strict as Seq
 import qualified Data.Set as Set
 import Data.Void (Void, absurd)
 import Data.Word (Word64)
-import Lens.Micro ((^.))
+import Lens.Micro ((&), (.~), (^.))
 
 data RatifyEnv era = RatifyEnv
   { reStakeDistr :: !(Map (Credential 'Staking (EraCrypto era)) Coin)
@@ -280,7 +282,7 @@ ratifyTransition = do
           if gasExpiresAfter < reCurrentEpoch
             then pure st' {rsRemoved = Set.insert gasId rsRemoved} -- Action expires after current Epoch. Remove it.
             else pure st'
-    Empty -> pure st
+    Empty -> pure $ st & rsEnactStateL . ensTreasuryL .~ Coin 0
 
 -- | Check that the previous governance action id specified in the proposal
 --   does match the last one of the same purpose that was enacted.

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.1.0
 
+* Add lens `epochStateTreasuryL` #3748
 * Introduce `Cardano.Ledger.Shelley.Transition` module with `EraTransition` interface.
 * Deprecated `CanStartFromGenesis` interface in favor of `EraTransition`
 * Add `Semigroup` and `Monoid` instances for `ShelleyGenesisStaking`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -120,6 +120,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   epochStateRegDrepL,
   epochStateIncrStakeDistrL,
   newEpochStateGovStateL,
+  epochStateTreasuryL,
 
   -- * Lenses from CertState
   certDStateL,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -713,6 +713,9 @@ ptrMapL = lens ptrMap (\x y -> x {ptrMap = y})
 newEpochStateGovStateL :: Lens' (NewEpochState era) (GovState era)
 newEpochStateGovStateL = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
 
+epochStateTreasuryL :: Lens' (EpochState era) Coin
+epochStateTreasuryL = esAccountStateL . asTreasuryL
+
 epochStateIncrStakeDistrL ::
   Lens'
     (EpochState era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.BaseTypes (BlocksMade (..), EpochNo, Network (..), ProtVer
 import qualified Cardano.Ledger.BaseTypes as Base (Globals (..))
 import Cardano.Ledger.CertState (CommitteeState (..), csCommitteeCredsL, vsNumDormantEpochsL)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
-import Cardano.Ledger.Conway.Governance hiding (GovState)
+import Cardano.Ledger.Conway.Governance hiding (GovState, ensTreasuryL, ensWithdrawalsL)
 import Cardano.Ledger.Core (
   EraPParams,
   PParams,


### PR DESCRIPTION
# Description

Closes #3736 

Also add lenses `ensWithdrawalsL`, `ensTreasuryL` and `epochStateTreasuryL`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
