### PR TITLE
Add predicate failure: current treasury value mismatch in LEDGER

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.9.0.0
 
-* Add PredicateFailure for current treasury value mismatch in tx body in LEDGER #
+* Add PredicateFailure for current treasury value mismatch in tx body in LEDGER #3749
 * Rename `ConwayPParams` to be consistent with the Agda specification. #3739
   * `govActionExpiration` to `govActionLifetime`
   * `committeeTermLimit` to `committeeMaxTermLength`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add PredicateFailure for current treasury value mismatch in tx body in LEDGER #
 * Rename `ConwayPParams` to be consistent with the Agda specification. #3739
   * `govActionExpiration` to `govActionLifetime`
   * `committeeTermLimit` to `committeeMaxTermLength`

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -356,6 +356,8 @@ instance
   prettyA (ConwayGovFailure x) = prettyA x
   prettyA (ConwayWdrlNotDelegatedToDRep x) =
     ppSexp "ConwayWdrlNotDelegatedToDRep" [prettyA x]
+  prettyA (ConwayTreasuryValueMismatch x y) =
+    ppSexp "ConwayTreasuryValueMismatch" [prettyA x, prettyA y]
 
 instance EraPParams era => PrettyA (ConwayGovPredFailure era) where
   prettyA = viaShow


### PR DESCRIPTION
# Description

Closes #3537

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
