### PR TITLE
Add Conway Ratify Event

### DIFF
--- a/docs/LedgerEvents.md
+++ b/docs/LedgerEvents.md
@@ -101,6 +101,11 @@ paid by the given transaction (both stake credential registration deposits and
 stake pool registration deposits) minus the sum of all refunds. It also contains
 the transaction hash.
 
+### `RatifyEvent RatifyEnv EnactState (Set (GovActionId))`
+
+This event only occurs on epoch boundaries, it contains the environment and the
+result of Ratifying.
+
 ### `RegisterPool poolID`
 
 This event happens for every new stake pool registration certificate.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version history for `cardano-ledger-conway`
 
 ## 1.9.0.0
+* Add new constructor `RatifyEvent` for `ConwayEpochEvent`
 * Add to `Ratify`:
   * `committeeAccepted`
   * `committeeAcceptedRatio`


### PR DESCRIPTION
# Description

I included the whole `RatifyEnv` even though I'm not sure everything in needed.
Also the `reStakeDistr` part of the environment is not used by the ledger at all. Will it be used or removed in the future?
Initially I wanted to define an `Event (ConwayRATIFY era)`, however the recursive implementation of the ratify rules doesn't make it that easy.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
