### PR TITLE
Use Alonzo-style TxOut encoder when possible

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -94,6 +94,7 @@ import Cardano.Ledger.Binary (
   decodeFullAnnotator,
   decodeListLenOrIndef,
   decodeNestedCborBytes,
+  encodeListLen,
   encodeNestedCbor,
   getDecoderVersion,
   interns,
@@ -465,8 +466,8 @@ instance (EraScript era, Val (Value era)) => EncCBOR (BabbageTxOut era) where
   encCBOR = \case
     TxOutCompactRefScript addr cv d rs -> encodeTxOut addr cv d (SJust rs)
     TxOutCompactDatum addr cv d -> encodeTxOut addr cv (Datum d) SNothing
-    TxOutCompactDH addr cv dh -> encodeTxOut @era addr cv (DatumHash dh) SNothing
-    TxOutCompact addr cv -> encodeTxOut @era addr cv NoDatum SNothing
+    TxOutCompactDH addr cv dh -> encodeListLen 3 <> encCBOR addr <> encCBOR cv <> encCBOR dh
+    TxOutCompact addr cv -> encodeListLen 2 <> encCBOR addr <> encCBOR cv
 
 instance (EraScript era, Val (Value era)) => DecCBOR (BabbageTxOut era) where
   decCBOR = decodeBabbageTxOut fromCborBothAddr


### PR DESCRIPTION
# Description

Closes #3362 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
