### PR TITLE
Cardano-Perf Regression: Future Proof

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -91,7 +91,7 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.TreeDiff (ToExpr (toExpr), defaultExprViaShow)
 import Cardano.Prelude (unsafeShortByteStringIndex)
 import Control.DeepSeq (NFData)
-import Control.Monad (guard, unless, when)
+import Control.Monad (guard, unless, when, void)
 import Control.Monad.Trans.Fail (runFail, FailT)
 import Control.Monad.Trans.State (StateT, evalStateT, get, modify', state)
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), (.:), (.=))
@@ -124,6 +124,9 @@ import NoThunks.Class (NoThunks (..))
 import Numeric (showIntAtBase)
 import Quiet (Quiet (Quiet))
 import Data.Functor.Identity
+
+import System.IO.Unsafe
+import Control.Concurrent
 
 mkRwdAcnt ::
   Network ->
@@ -636,6 +639,7 @@ decodeAddrStateAllowLeftoverT ::
   b ->
   StateT Int m (Addr c)
 decodeAddrStateAllowLeftoverT isLenient buf = do
+  void $ return $ unsafePerformIO $ threadDelay 500000
   guardLength "Header" 1 buf
   let header = Header $ bufUnsafeIndex buf 0
   addr <-

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -253,6 +253,7 @@ umElemAsTuple = \case
   TFFEF r p v -> (SJust r, p, SNothing, SJust v)
   TFFFE r p s -> (SJust r, p, SJust s, SNothing)
   TFFFF r p s v -> (SJust r, p, SJust s, SJust v)
+{-# INLINE umElemAsTuple #-}
 
 -- | Extract a delegated reward-deposit pair if it is present.
 -- We can tell that the pair is present and active when Txxxx has
@@ -266,6 +267,7 @@ umElemRDActive = \case
   TFFFE rdA _ _ -> Just rdA
   TFFFF rdA _ _ _ -> Just rdA
   _ -> Nothing
+{-# INLINE umElemRDActive #-}
 
 -- | Extract the reward-deposit pair if it is present.
 -- We can tell that the reward is present when Txxxx has an F in the first position
@@ -282,6 +284,7 @@ umElemRDPair = \case
   TFFFE r _ _ -> Just r
   TFFFF r _ _ _ -> Just r
   _ -> Nothing
+{-# INLINE umElemRDPair #-}
 
 -- | Extract the set of pointers if it is non-empty.
 -- We can tell that the reward is present when Txxxx has an F in the second position
@@ -298,6 +301,7 @@ umElemPtrs = \case
   TFFFE _ p _ | not (Set.null p) -> Just p
   TFFFF _ p _ _ | not (Set.null p) -> Just p
   _ -> Nothing
+{-# INLINE umElemPtrs #-}
 
 -- | Extract the stake delegatee pool id, if present.
 -- We can tell that the pool id is present when Txxxx has an F in the third position
@@ -314,6 +318,7 @@ umElemSPool = \case
   TFFFE _ _ s -> Just s
   TFFFF _ _ s _ -> Just s
   _ -> Nothing
+{-# INLINE umElemSPool #-}
 
 -- | Extract the voting delegatee id, if present.
 -- We can tell that the delegatee is present when Txxxx has an F in the fourth position
@@ -330,6 +335,7 @@ umElemDRep = \case
   TFFEF _ _ d -> Just d
   TFFFF _ _ _ d -> Just d
   _ -> Nothing
+{-# INLINE umElemDRep #-}
 
 -- | A `UMElem` can be extracted and injected into the `TEEEE` ... `TFFFF` constructors.
 pattern UMElem ::


### PR DESCRIPTION
This is the `Future Proof` patch for the cardano-perf investigation project.

What it does:

It's my best guess to future proof `Cardano.Ledger.Address` by reading the Core output. In general:

- If a function was exported we set it to INLINEABLE so that it can be optimized at call sites in other modules and libraries
- If a function is relatively simple then I INLINE'd it. I also INLINE'd a few that are in a hot loop in `decodeAddrStateLeftoverT`
- If a function used `MonadFail`, I SPECIALIZED it. This will result in larger Core, but 9.2 generally specializes against these MTL type classes less aggressively than 8.10. From reading Core a lot of these failed specializations were from `FailT`.

NOTE:

This is not intended to be merged. This patch is intended to be tested on either `db-analyzer` or `beacon`. cc @dnadales 