### PR TITLE
Cardano-perf Regression: Status Quo

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
-{-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-redundant-constraints -flate-specialise -fspecialise-aggressively #-}
 
 -- | This module defines core type families which we know to vary from era to
 -- era.
@@ -282,7 +282,7 @@ class
           Right cValue -> fromCompact cValue
       )
       (\txOut value -> txOut & valueEitherTxOutL .~ Left value)
-  {-# INLINE valueTxOutL #-}
+  {-# INLINEABLE valueTxOutL #-}
 
   compactValueTxOutL :: HasCallStack => Lens' (TxOut era) (CompactForm (Value era))
   compactValueTxOutL =
@@ -292,7 +292,7 @@ class
           Right cValue -> cValue
       )
       (\txOut cValue -> txOut & valueEitherTxOutL .~ Right cValue)
-  {-# INLINE compactValueTxOutL #-}
+  {-# INLINEABLE compactValueTxOutL #-}
 
   -- | Lens for getting and setting in TxOut either an address or its compact
   -- version by doing the least amount of work.
@@ -306,7 +306,7 @@ class
           Right cAddr -> decompactAddr cAddr
       )
       (\txOut addr -> txOut & addrEitherTxOutL .~ Left addr)
-  {-# INLINE addrTxOutL #-}
+  {-# INLINEABLE addrTxOutL #-}
 
   compactAddrTxOutL :: Lens' (TxOut era) (CompactAddr (EraCrypto era))
   compactAddrTxOutL =
@@ -316,7 +316,7 @@ class
           Right cAddr -> cAddr
       )
       (\txOut cAddr -> txOut & addrEitherTxOutL .~ Right cAddr)
-  {-# INLINE compactAddrTxOutL #-}
+  {-# INLINEABLE compactAddrTxOutL #-}
 
   -- | Lens for getting and setting in TxOut either an address or its compact
   -- version by doing the least amount of work.
@@ -353,7 +353,7 @@ bootAddrTxOutF = to $ \txOut ->
           AddrBootstrap bootstrapAddr <- Just (decompactAddr cAddr)
           Just bootstrapAddr
     _ -> Nothing
-{-# INLINE bootAddrTxOutF #-}
+{-# INLINEABLE bootAddrTxOutF #-}
 
 coinTxOutL :: (HasCallStack, EraTxOut era) => Lens' (TxOut era) Coin
 coinTxOutL =
@@ -369,7 +369,7 @@ coinTxOutL =
           Right cVal ->
             txOut & compactValueTxOutL .~ modifyCompactCoin (const (toCompactPartial c)) cVal
     )
-{-# INLINE coinTxOutL #-}
+{-# INLINEABLE coinTxOutL #-}
 
 compactCoinTxOutL :: (HasCallStack, EraTxOut era) => Lens' (TxOut era) (CompactForm Coin)
 compactCoinTxOutL =
@@ -385,7 +385,7 @@ compactCoinTxOutL =
           Right cVal ->
             txOut & compactValueTxOutL .~ modifyCompactCoin (const cCoin) cVal
     )
-{-# INLINE compactCoinTxOutL #-}
+{-# INLINEABLE compactCoinTxOutL #-}
 
 -- | This is a getter that implements an efficient way to check whether 'TxOut'
 -- contains ADA only.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -253,6 +253,7 @@ umElemAsTuple = \case
   TFFEF r p v -> (SJust r, p, SNothing, SJust v)
   TFFFE r p s -> (SJust r, p, SJust s, SNothing)
   TFFFF r p s v -> (SJust r, p, SJust s, SJust v)
+{-# INLINE umElemAsTuple #-}
 
 -- | Extract a delegated reward-deposit pair if it is present.
 -- We can tell that the pair is present and active when Txxxx has
@@ -266,6 +267,7 @@ umElemRDActive = \case
   TFFFE rdA _ _ -> Just rdA
   TFFFF rdA _ _ _ -> Just rdA
   _ -> Nothing
+{-# INLINE umElemRDActive #-}
 
 -- | Extract the reward-deposit pair if it is present.
 -- We can tell that the reward is present when Txxxx has an F in the first position
@@ -282,6 +284,7 @@ umElemRDPair = \case
   TFFFE r _ _ -> Just r
   TFFFF r _ _ _ -> Just r
   _ -> Nothing
+{-# INLINE umElemRDPair #-}
 
 -- | Extract the set of pointers if it is non-empty.
 -- We can tell that the reward is present when Txxxx has an F in the second position
@@ -298,6 +301,7 @@ umElemPtrs = \case
   TFFFE _ p _ | not (Set.null p) -> Just p
   TFFFF _ p _ _ | not (Set.null p) -> Just p
   _ -> Nothing
+{-# INLINE umElemPtrs #-}
 
 -- | Extract the stake delegatee pool id, if present.
 -- We can tell that the pool id is present when Txxxx has an F in the third position
@@ -314,6 +318,7 @@ umElemSPool = \case
   TFFFE _ _ s -> Just s
   TFFFF _ _ s _ -> Just s
   _ -> Nothing
+{-# INLINE umElemSPool #-}
 
 -- | Extract the voting delegatee id, if present.
 -- We can tell that the delegatee is present when Txxxx has an F in the fourth position
@@ -330,6 +335,7 @@ umElemDRep = \case
   TFFEF _ _ d -> Just d
   TFFFF _ _ _ d -> Just d
   _ -> Nothing
+{-# INLINE umElemDRep #-}
 
 -- | A `UMElem` can be extracted and injected into the `TEEEE` ... `TFFFF` constructors.
 pattern UMElem ::


### PR DESCRIPTION
This is the 2nd patch in the Cardano perf regression project. Its meant to test the hypothesis that 9.2 is under-specializing. It marks all exported functions in `Cardano.Ledger.Address` as `INLINEABLE` and uses module level flags to let GHC specialize more aggressively.

NOTE

This is not intended to be merged. This patch is intended to be tested on either db-analyzer or beacon. cc @dnadales