### PR TITLE
Cardano-Perf regression: UMap.size regression fix

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -133,6 +133,7 @@ decodeAddress28 stakeRef (Addr28Extra a b c d) = do
         hashFromPackedBytes $
           PackedBytes28 a b c (fromIntegral (d `shiftR` 32))
   pure $! Addr network paymentCred (StakeRefBase stakeRef)
+{-# INLINE decodeAddress28 #-}
 
 data AlonzoTxOut era
   = TxOutCompact'

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -637,7 +637,7 @@ getEitherAddrBabbageTxOut = \case
   TxOut_AddrHash28_AdaOnly_DataHash32 stakeRef addr28Extra _ _
     | Just addr <- decodeAddress28 stakeRef addr28Extra -> Left addr
     | otherwise -> error "Impossible: Compacted an address or a hash of non-standard size"
-{-# INLINEABLE getEitherAddrBabbageTxOut #-}
+{-# INLINE getEitherAddrBabbageTxOut #-}
 
 -- TODO: Switch to using `getDatumBabbageTxOut`
 getDataBabbageTxOut :: Era era => BabbageTxOut era -> StrictMaybe (Data era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -717,6 +717,7 @@ txIxToInt (TxIx w16) = fromIntegral w16
 
 txIxFromIntegral :: Integral a => a -> Maybe TxIx
 txIxFromIntegral = fmap (TxIx . fromIntegral) . word16FromInteger . toInteger
+{-# INLINE txIxFromIntegral #-}
 
 -- | Construct a `TxIx` from an arbitrary precision `Integer`. Throws an error for
 -- values out of range. Make sure to use it only for testing.
@@ -741,6 +742,7 @@ certIxToInt (CertIx w16) = fromIntegral w16
 
 certIxFromIntegral :: Integral a => a -> Maybe CertIx
 certIxFromIntegral = fmap (CertIx . fromIntegral) . word16FromInteger . toInteger
+{-# INLINE certIxFromIntegral #-}
 
 -- | Construct a `CertIx` from an arbitrary precision `Integer`. Throws an error for
 -- values out of range. Make sure to use it only for testing.
@@ -753,6 +755,7 @@ word16FromInteger :: Integer -> Maybe Word16
 word16FromInteger i
   | i < fromIntegral (minBound :: Word16) || i > fromIntegral (maxBound :: Word16) = Nothing
   | otherwise = Just (fromInteger i)
+{-# INLINE word16FromInteger #-}
 
 -- =================================
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -253,6 +253,7 @@ umElemAsTuple = \case
   TFFEF r p v -> (SJust r, p, SNothing, SJust v)
   TFFFE r p s -> (SJust r, p, SJust s, SNothing)
   TFFFF r p s v -> (SJust r, p, SJust s, SJust v)
+{-# INLINE umElemAsTuple #-}
 
 -- | Extract a delegated reward-deposit pair if it is present.
 -- We can tell that the pair is present and active when Txxxx has
@@ -266,6 +267,7 @@ umElemRDActive = \case
   TFFFE rdA _ _ -> Just rdA
   TFFFF rdA _ _ _ -> Just rdA
   _ -> Nothing
+{-# INLINE umElemRDActive #-}
 
 -- | Extract the reward-deposit pair if it is present.
 -- We can tell that the reward is present when Txxxx has an F in the first position
@@ -282,6 +284,7 @@ umElemRDPair = \case
   TFFFE r _ _ -> Just r
   TFFFF r _ _ _ -> Just r
   _ -> Nothing
+{-# INLINE umElemRDPair #-}
 
 -- | Extract the set of pointers if it is non-empty.
 -- We can tell that the reward is present when Txxxx has an F in the second position
@@ -298,6 +301,7 @@ umElemPtrs = \case
   TFFFE _ p _ | not (Set.null p) -> Just p
   TFFFF _ p _ _ | not (Set.null p) -> Just p
   _ -> Nothing
+{-# INLINE umElemPtrs #-}
 
 -- | Extract the stake delegatee pool id, if present.
 -- We can tell that the pool id is present when Txxxx has an F in the third position
@@ -314,6 +318,7 @@ umElemSPool = \case
   TFFFE _ _ s -> Just s
   TFFFF _ _ s _ -> Just s
   _ -> Nothing
+{-# INLINE umElemSPool #-}
 
 -- | Extract the voting delegatee id, if present.
 -- We can tell that the delegatee is present when Txxxx has an F in the fourth position
@@ -330,6 +335,7 @@ umElemDRep = \case
   TFFEF _ _ d -> Just d
   TFFFF _ _ _ d -> Just d
   _ -> Nothing
+{-# INLINE umElemDRep #-}
 
 -- | A `UMElem` can be extracted and injected into the `TEEEE` ... `TFFFF` constructors.
 pattern UMElem ::


### PR DESCRIPTION
This patch is just an assemblage of performance tweaks that I have found by auditing the code base, inspecting performance and tickyticky profiles. Most of the tweaks are inlining some key functions so that GHC can further optimize them at their respective call sites with `case-of-known-constructor` which leads to better Core.

cc @dnadales 