### PR TITLE
Update CDDL for praos headers.

### DIFF
--- a/eras/babbage/test-suite/CHANGELOG.md
+++ b/eras/babbage/test-suite/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ## 1.1.1.6
 
-*
+* Update CDDL files to reflect the change in header structure in
+  cardano-protocol-praos.
 
 ## 1.1.1.5
 

--- a/eras/babbage/test-suite/cddl-files/babbage.cddl
+++ b/eras/babbage/test-suite/cddl-files/babbage.cddl
@@ -34,15 +34,15 @@ header_body =
   , block_body_size  : uint
   , block_body_hash  : $hash32 ; merkle triple root
   , operational_cert
-  , protocol_version
+  , [ protocol_version ]
   ]
 
 operational_cert =
-  ( hot_vkey        : $kes_vkey
+  [ hot_vkey        : $kes_vkey
   , sequence_number : uint
   , kes_period      : uint
   , sigma           : $signature
-  )
+  ]
 
 next_major_protocol_version = 9
 

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## 1.2.1.0
 
 * Add `Crypto c` constraint to `exampleConwayGenesis`
+* Update CDDL files to reflect the change in header structure in
+  cardano-protocol-praos.
 
 ## 1.2.0.5
 

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -34,15 +34,15 @@ header_body =
   , block_body_size  : uint
   , block_body_hash  : $hash32 ; merkle triple root
   , operational_cert
-  , protocol_version
+  , [ protocol_version ]
   ]
 
 operational_cert =
-  ( hot_vkey        : $kes_vkey
+  [ hot_vkey        : $kes_vkey
   , sequence_number : uint
   , kes_period      : uint
   , sigma           : $signature
-  )
+  ]
 
 next_major_protocol_version = 10
 


### PR DESCRIPTION
# Description

cardano-protocol-praos does not inline ocert and protocol version into the header, treating them instead as nested objects. This is not accurately reflected in the CDDL.

This is a stopgap solution, since this can no longer be tested here due to cardano-protocol-praos living in the consensus repository.

Addresses #3559 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
