### PR TITLE
Improve native script handling

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.2.3.1
+## 1.3.0.0
 
 * Implement `getScriptsProvided`
+* Flip arguments on `validateTimelock`
 
 ## 1.2.3.0
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -19,7 +17,7 @@ import Cardano.Ledger.Allegra.Scripts (Timelock, evalTimelock)
 import Cardano.Ledger.Allegra.TxAuxData ()
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..))
 import Cardano.Ledger.Allegra.TxWits ()
-import Cardano.Ledger.Core (EraTx (..), EraTxAuxData (upgradeTxAuxData), EraTxWits (..), PhasedScript (..), upgradeTxBody)
+import Cardano.Ledger.Core (EraTx (..), EraTxAuxData (upgradeTxAuxData), EraTxWits (..), upgradeTxBody)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
 import Cardano.Ledger.Shelley.Tx (
@@ -55,8 +53,8 @@ instance Crypto c => EraTx (AllegraEra c) where
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) tx = validateTimelock @(AllegraEra c) script tx
-  {-# INLINE validateScript #-}
+  validateNativeScript = validateTimelock
+  {-# INLINE validateNativeScript #-}
 
   getMinFeeTx = shelleyMinFeeTx
 
@@ -72,8 +70,8 @@ instance Crypto c => EraTx (AllegraEra c) where
 -- We still need to correctly compute the witness set for TxBody as well.
 
 validateTimelock ::
-  (EraTx era, AllegraEraTxBody era) => Timelock era -> Tx era -> Bool
-validateTimelock timelock tx = evalTimelock vhks (tx ^. bodyTxL . vldtTxBodyL) timelock
+  (EraTx era, AllegraEraTxBody era) => Tx era -> Timelock era -> Bool
+validateTimelock tx timelock = evalTimelock vhks (tx ^. bodyTxL . vldtTxBodyL) timelock
   where
     vhks = Set.map witVKeyHash (tx ^. witsTxL . addrTxWitsL)
 {-# INLINEABLE validateTimelock #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -202,8 +202,8 @@ instance Crypto c => EraTx (AlonzoEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) = validateTimelock @(AlonzoEra c) script
-  {-# INLINE validateScript #-}
+  validateNativeScript = validateTimelock
+  {-# INLINE validateNativeScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
   {-# INLINE getMinFeeTx #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -51,8 +50,8 @@ instance Crypto c => EraTx (BabbageEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) = validateTimelock @(BabbageEra c) script
-  {-# INLINE validateScript #-}
+  validateNativeScript = validateTimelock
+  {-# INLINE validateNativeScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -68,7 +68,6 @@ library
     build-depends:
         base >=4.14 && <4.19,
         aeson,
-        bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.1.3,
         cardano-ledger-allegra >=1.1,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -13,7 +11,6 @@ module Cardano.Ledger.Conway.Scripts (
 where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
-import Cardano.Ledger.Alonzo.Language (Language)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   isPlutusScript,
@@ -23,19 +20,15 @@ import Cardano.Ledger.Babbage.Scripts (babbageScriptPrefixTag)
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
-import Data.ByteString.Short (ShortByteString)
-
-type instance SomeScript 'PhaseOne (ConwayEra c) = Timelock (ConwayEra c)
-
-type instance SomeScript 'PhaseTwo (ConwayEra c) = (Language, ShortByteString)
 
 instance Crypto c => EraScript (ConwayEra c) where
   type Script (ConwayEra c) = AlonzoScript (ConwayEra c)
+  type NativeScript (ConwayEra c) = Timelock (ConwayEra c)
 
   upgradeScript = translateAlonzoScript
 
   scriptPrefixTag = babbageScriptPrefixTag
 
-  phaseScript PhaseOneRep (TimelockScript s) = Just (Phase1Script s)
-  phaseScript PhaseTwoRep (PlutusScript plutus) = Just (Phase2Script plutus)
-  phaseScript _ _ = Nothing
+  getNativeScript = \case
+    TimelockScript ts -> Just ts
+    _ -> Nothing

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -54,8 +54,8 @@ instance Crypto c => EraTx (ConwayEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) = validateTimelock @(ConwayEra c) script
-  {-# INLINE validateScript #-}
+  validateNativeScript = validateTimelock
+  {-# INLINE validateNativeScript #-}
 
   getMinFeeTx = alonzoMinFeeTx
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Scripts (
@@ -18,17 +13,15 @@ import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 
-type instance SomeScript 'PhaseOne (MaryEra c) = Timelock (MaryEra c)
-
 -- | Since Timelock scripts are a strictly backwards compatible extension of
 -- MultiSig scripts, we can use the same 'scriptPrefixTag' tag here as we did
 -- for the ValidateScript instance in MultiSig
 instance Crypto c => EraScript (MaryEra c) where
   type Script (MaryEra c) = Timelock (MaryEra c)
+  type NativeScript (MaryEra c) = Timelock (MaryEra c)
 
   upgradeScript = translateTimelock
 
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
 
-  phaseScript PhaseOneRep timelock = Just (Phase1Script timelock)
-  phaseScript PhaseTwoRep _ = Nothing
+  getNativeScript = Just

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Tx (
@@ -14,13 +9,7 @@ module Cardano.Ledger.Mary.Tx (
 where
 
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
-import Cardano.Ledger.Core (
-  EraTx (..),
-  PhasedScript (..),
-  upgradeTxAuxData,
-  upgradeTxBody,
-  upgradeTxWits,
- )
+import Cardano.Ledger.Core (EraTx (..), upgradeTxAuxData, upgradeTxBody, upgradeTxWits)
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.PParams ()
@@ -58,8 +47,8 @@ instance Crypto c => EraTx (MaryEra c) where
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
 
-  validateScript (Phase1Script script) = validateTimelock @(MaryEra c) script
-  {-# INLINE validateScript #-}
+  validateNativeScript = validateTimelock
+  {-# INLINE validateNativeScript #-}
 
   getMinFeeTx = shelleyMinFeeTx
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -403,13 +403,10 @@ instance
 validateFailedNativeScripts ::
   EraTx era => ScriptsProvided era -> Tx era -> Test (ShelleyUtxowPredFailure era)
 validateFailedNativeScripts (ScriptsProvided scriptsProvided) tx = do
-  let phase1Map = getPhase1 scriptsProvided
-      failedScripts =
-        Map.filterWithKey
-          ( \hs (core, phase) ->
-              hashScript core /= hs || not (validateScript phase tx)
-          )
-          phase1Map
+  let failedScripts =
+        Map.filter -- we keep around only non-validating native scripts
+          (maybe False (not . validateNativeScript tx) . getNativeScript)
+          scriptsProvided
   failureUnless (Map.null failedScripts) $
     ScriptWitnessNotValidatingUTXOW (Map.keysSet failedScripts)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.6.1.0
 
-*
+* Export `isPlutusScript`
+* Add `NativeScript`, `getNativeScript` and `validateNativeScript`
+* Removed `phaseScript`
 
 ## 1.6.0.0
 

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -1,11 +1,13 @@
 module Cardano.Ledger.Api.Scripts (
   module Cardano.Ledger.Api.Scripts.Data,
-  EraScript (Script),
+  EraScript (Script, NativeScript),
   scriptPrefixTag,
   upgradeScript,
   hashScript,
-  phaseScript,
+  getNativeScript,
+  validateNativeScript,
   isNativeScript,
+  isPlutusScript,
   ScriptHash,
   CostModels (..),
   ValidityInterval (..),
@@ -13,8 +15,8 @@ module Cardano.Ledger.Api.Scripts (
 where
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModels (..))
+import Cardano.Ledger.Alonzo.Scripts (CostModels (..), isPlutusScript)
 import Cardano.Ledger.Api.Era ()
 import Cardano.Ledger.Api.Scripts.Data
-import Cardano.Ledger.Core (EraScript (..))
+import Cardano.Ledger.Core (EraScript (..), isNativeScript, validateNativeScript)
 import Cardano.Ledger.Hashes (ScriptHash)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -40,7 +40,6 @@ module Cardano.Ledger.Api.Tx (
   bodyTxL,
   witsTxL,
   auxDataTxL,
-  validateScript,
   sizeTxF,
   getMinFeeTx,
   setMinFeeTx,


### PR DESCRIPTION
# Description

* Remove redundant script hash verification. Script Hashes are not transmitted over the wire, they are computed upon deserialization. This means there is no point in recomputing and verifying those hashes as a predicate check in the rules
* Short circuit multisig and timelock verification for `RequireMOf` as soon as necessary number of scripts have been validated. Previously it was validating all scripts, regardless of how many was needed.
* Remove the whole Phased distinction, since it was not used nor is it needed for phase2 scripts. It was only necessary for native, phase1 scripts. That is why a simpler interface was added that deals with native scripts only. Addition of `NativeScript`, `getNativeScript` and `validateNativeScript`


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
