### PR TITLE
Refactor and improve constraint based STS tests

### DIFF
--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## 1.3.3.0
 
-* Add `PrettyA` instance for `NoUpdate`
+* Add `PrettyA` instances for:
+  * `NoUpdate`
+  * `ConwayGovCert`
+  * `ConwayGovCertEnv`
+  * `PoolEnv`
+  * `EnactSignal`
 
 ## 1.3.2.0
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Alonzo.hs
@@ -102,7 +102,11 @@ instance PrettyA ExUnits where
 
 ppCostModel :: CostModel -> PDoc
 ppCostModel cm =
-  ppSexp "CostModel" [ppLanguage (getCostModelLanguage cm), ppList ppInteger (getCostModelParams cm)]
+  ppSexp "CostModel" [ppLanguage (getCostModelLanguage cm), ppCMP]
+  where
+    ppCMP
+      | all (== 0) (getCostModelParams cm) = ppSexp "replicate" [ppInteger (fromIntegral $ length $ getCostModelParams cm), ppInteger 0]
+      | otherwise = ppList ppInteger (getCostModelParams cm)
 
 instance PrettyA CostModel where
   prettyA = ppCostModel

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -48,9 +48,11 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertPredFailure (..),
   ConwayCertsPredFailure (..),
   ConwayDelegPredFailure (..),
+  ConwayGovCertEnv (..),
   ConwayGovCertPredFailure,
   ConwayGovPredFailure,
   ConwayLedgerPredFailure (..),
+  EnactSignal (..),
   EnactState (..),
   PredicateFailure,
   RatifyState (..),
@@ -85,6 +87,7 @@ import Cardano.Ledger.Pretty (
   ppWithdrawals,
  )
 import Cardano.Ledger.Pretty.Babbage ()
+import Cardano.Ledger.Shelley.Rules (PoolEnv (..))
 import Data.Text (Text)
 import Lens.Micro ((^.))
 import Numeric.Natural (Natural)
@@ -143,6 +146,15 @@ instance PrettyA (ConwayDelegCert c) where
       , ("Delegatee", prettyA delegatee)
       , ("Deposit", prettyA deposit)
       ]
+
+instance PrettyA (ConwayGovCert c) where
+  prettyA = ppConwayGovCert
+
+instance PrettyA (PParams c) => PrettyA (ConwayGovCertEnv c) where
+  prettyA (ConwayGovCertEnv pp ce) = ppSexp "ConwayGovCertEnv" [prettyA pp, prettyA ce]
+
+instance PrettyA (PParams c) => PrettyA (PoolEnv c) where
+  prettyA (PoolEnv sn pp) = ppSexp "PoolEnv" [prettyA sn, prettyA pp]
 
 ppConwayTxCert :: ConwayTxCert era -> PDoc
 ppConwayTxCert = \case
@@ -429,6 +441,14 @@ instance PrettyA (PParams era) => PrettyA (EnactState era) where
           , ("Withdrawals", prettyA ensWithdrawals)
           , ("PrevGovActionIds", prettyA ensPrevGovActionIds)
           ]
+
+instance PrettyA (PParamsUpdate era) => PrettyA (EnactSignal era) where
+  prettyA EnactSignal {..} =
+    ppRecord
+      "EnactSignal"
+      [ ("Gov Action Id", prettyA esGovActionId)
+      , ("Gov Action", prettyA esGovAction)
+      ]
 
 instance PrettyA (PrevGovActionIds era) where
   prettyA PrevGovActionIds {..} =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Monad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Monad.hs
@@ -17,6 +17,7 @@ module Test.Cardano.Ledger.Constrained.Monad (
   generateWithSeed,
 ) where
 
+import GHC.Stack
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Random
 
@@ -63,13 +64,13 @@ requireAll xs answer = if null bad then answer else failT (concat msgs)
 -- runTyped :: Typed t => Either [String] x
 
 -- | Pushes the (Left msgs) into a call to 'error'
-errorTyped :: Typed t -> t
+errorTyped :: HasCallStack => Typed t -> t
 errorTyped t = case runTyped t of
   Right x -> x
   Left xs -> error (unlines ("\nSolver-time error" : xs))
 
 -- | Pushes the (Left msgs) into a call to 'error', then injects into a Monad
-monadTyped :: Monad m => Typed t -> m t
+monadTyped :: (HasCallStack, Monad m) => Typed t -> m t
 monadTyped t = pure $! errorTyped t
 
 -- ================================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -32,6 +32,24 @@ import Test.Tasty (TestTree, defaultMain)
 
 -- =========================================
 
+enactStateGenPreds :: Reflect era => Proof era -> [Pred era]
+enactStateGenPreds p =
+  [ Random committeeVar
+  , Random constitution
+  , prevPParams p :<-: (Constr "id" id ^$ pparams p)
+  , currPParams p :<-: (Constr "id" id ^$ pparams p)
+  , Random enactTreasury
+  , Random enactWithdrawals
+  , -- PrevGovActionsIds constraints
+    Random prevPParamUpdate
+  , Random prevHardFork
+  , Random prevCommittee
+  , Random prevConstitution
+  ]
+
+enactStateCheckPreds :: Proof era -> [Pred era]
+enactStateCheckPreds _ = []
+
 ledgerStatePreds :: forall era. Reflect era => UnivSize -> Proof era -> [Pred era]
 ledgerStatePreds usize p =
   [ -- Conway GovState Vars


### PR DESCRIPTION
# Description

This PR refactors the STS-based tests and introduces some pretty-printing and a functioning common HOF for writing the tests.

We introduce some minor prettyprinters and make the prettyprinter for cost models slightly less verbose in the case where the costmodel is irrelevant (i.e. when it's all 0s).

We also refactor some constraints (the ones we needed for the example) into separate "generation" and "checking" constraints to aide shrinking and checking properties.

Finally, we also add checking to the `prop_DELEG` and `prop_POOL` properties to check that the new state conforms to the checking constraints.

@TimSheard the `prop_DELEG` property fails because we have a constraint `Dom rewards :=: Rng ptrs` and the `ptrs` aren't updated by the `DELEG` rule. As far as I can tell the `ptrs` don't exist in the agda spec for conway - should the constraint be a subset constraint or is this a bug in the `DELEG` rule?

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
