### PR TITLE
Move `ImpTest` to Shelley testlib

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 1.3.0.0
 
+* Add `NFData` instance for `AllegraUtxoPredFailure`
 * Implement `getScriptsProvided`
 * Flip arguments on `validateTimelock`
+
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Allegra.ImpTest`
+* Add `EraImpTest` instance for `AllegraEra`
 
 ## 1.2.3.0
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -68,7 +68,10 @@ library
         validation-selective
 
 library testlib
-    exposed-modules:  Test.Cardano.Ledger.Allegra.Arbitrary
+    exposed-modules:
+        Test.Cardano.Ledger.Allegra.Arbitrary
+        Test.Cardano.Ledger.Allegra.ImpTest
+
     visibility:       public
     hs-source-dirs:   testlib
     default-language: Haskell2010
@@ -80,6 +83,7 @@ library testlib
     build-depends:
         base,
         cardano-ledger-allegra >=1.1,
+        cardano-crypto-class,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-core,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -62,6 +62,7 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), TxIn)
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..))
 import Cardano.Ledger.Shelley.UTxO (txup)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), txouts)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
@@ -134,6 +135,13 @@ instance
   , NoThunks (PPUPPredFailure era)
   ) =>
   NoThunks (AllegraUtxoPredFailure era)
+
+instance
+  ( ToExpr (TxOut era)
+  , ToExpr (Value era)
+  , ToExpr (PPUPPredFailure era)
+  ) =>
+  ToExpr (AllegraUtxoPredFailure era)
 
 data AllegraUtxoEvent era
   = UpdateEvent (Event (EraRule "PPUP" era))

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Allegra (Allegra)
+import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Allegra.ImpTest ()
 import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Allegra" $ do
       BinarySpec.spec
+      ImpTestSpec.spec $ Proxy @Allegra

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Allegra.ImpTest () where
+
+import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..))
+import Cardano.Crypto.Hash.Class (Hash)
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Core (EraIndependentTxBody)
+import Cardano.Ledger.Crypto (Crypto (..))
+import Test.Cardano.Ledger.Shelley.ImpTest (
+  EraImpTest (..),
+  emptyShelleyImpNES,
+  shelleyImpWitsVKeyNeeded,
+ )
+
+instance
+  ( Crypto c
+  , Signable
+      (DSIGN c)
+      (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  EraImpTest (AllegraEra c)
+  where
+  emptyImpNES = emptyShelleyImpNES
+
+  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### `testlib`
 
+* Add `emptyAlonzoImpNES`
+* Add `Test.Cardano.Ledger.Alonzo.ImpTest`
+* Add `EraImpTest` instance for `AlonzoEra`
 * Add `ToExpr` instances for:
   * `CollectError`
   * `AlonzoUtxoPredFailure`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -104,6 +104,7 @@ library testlib
         Test.Cardano.Ledger.Alonzo.Arbitrary
         Test.Cardano.Ledger.Alonzo.Binary.RoundTrip
         Test.Cardano.Ledger.Alonzo.CostModel
+        Test.Cardano.Ledger.Alonzo.ImpTest
 
     visibility:       public
     hs-source-dirs:   testlib
@@ -120,9 +121,12 @@ library testlib
         cardano-ledger-binary,
         cardano-ledger-mary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-crypto-class,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
         plutus-core,
+        data-default-class,
+        microlens,
         text
 
 test-suite tests
@@ -140,4 +144,5 @@ test-suite tests
         base,
         cardano-ledger-alonzo,
         cardano-ledger-core:testlib,
+        cardano-ledger-shelley:testlib,
         testlib

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Alonzo (Alonzo)
+import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Alonzo" $ do
       BinarySpec.spec
+      ImpTestSpec.spec $ Proxy @Alonzo

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Alonzo.ImpTest (
+  module ImpTest,
+  emptyAlonzoImpNES,
+) where
+
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
+import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppMaxValSizeL)
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Core (EraIndependentTxBody, EraTxOut)
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Shelley.Core (EraGov)
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState, StashedAVVMAddresses, curPParamsEpochStateL, nesEsL)
+import Data.Default.Class (Default)
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest
+
+emptyAlonzoImpNES ::
+  ( EraGov era
+  , EraTxOut era
+  , AlonzoEraPParams era
+  , Default (StashedAVVMAddresses era)
+  ) =>
+  Coin ->
+  NewEpochState era
+emptyAlonzoImpNES rootCoin =
+  emptyShelleyImpNES rootCoin
+    & nesEsL . curPParamsEpochStateL . ppMaxValSizeL .~ 1_000_000_000
+
+instance
+  ( Crypto c
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  EraImpTest (AlonzoEra c)
+  where
+  emptyImpNES = emptyAlonzoImpNES
+
+  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -76,7 +76,6 @@ import Cardano.Ledger.UTxO (
   EraUTxO (..),
   UTxO (..),
   coinBalance,
-  getScriptsHashesNeeded,
   getScriptsNeeded,
  )
 import Cardano.Ledger.Val (Val (isAdaOnly, (<+>), (<×>)))
@@ -453,7 +452,7 @@ instance Mock c => EraGen (AlonzoEra c) where
   genEraDone utxo pp tx =
     let theFee = tx ^. bodyTxL . feeTxBodyL -- Coin supplied to pay fees
         minimumFee = getMinFeeTx @(AlonzoEra c) pp tx
-        neededHashes = getScriptsHashesNeeded (getScriptsNeeded utxo (tx ^. bodyTxL))
+        neededHashes = getScriptsHashesNeeded $ getScriptsNeeded utxo (tx ^. bodyTxL)
         oldScriptWits = tx ^. witsTxL . scriptTxWitsL
         newWits = oldScriptWits `Map.restrictKeys` neededHashes
      in if minimumFee <= theFee

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -48,6 +48,7 @@ import qualified PlutusTx as Plutus
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Alonzo.PlutusScripts (testingCostModelV1)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr, mkWitnessesVKey)
+import Test.Cardano.Ledger.Core.Utils (mkDummySafeHash)
 import qualified Test.Cardano.Ledger.Mary.Examples.Consensus as SLE
 import qualified Test.Cardano.Ledger.Shelley.Examples.Consensus as SLE
 
@@ -92,13 +93,13 @@ ledgerExamplesAlonzo =
 exampleTxBodyAlonzo :: AlonzoTxBody Alonzo
 exampleTxBodyAlonzo =
   AlonzoTxBody
-    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 1)) 0]) -- inputs
-    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 2)) 1]) -- collateral
+    (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash Proxy 1)) 0]) -- inputs
+    (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash Proxy 2)) 1]) -- collateral
     ( StrictSeq.fromList
         [ AlonzoTxOut
             (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
             (SLE.exampleMultiAssetValue 2)
-            (SJust $ SLE.mkDummySafeHash Proxy 1) -- outputs
+            (SJust $ mkDummySafeHash Proxy 1) -- outputs
         ]
     )
     SLE.exampleCerts -- txcerts
@@ -120,8 +121,8 @@ exampleTxBodyAlonzo =
     ) -- txUpdates
     (Set.singleton $ SLE.mkKeyHash 212) -- reqSignerHashes
     exampleMultiAsset -- mint
-    (SJust $ SLE.mkDummySafeHash (Proxy @StandardCrypto) 42) -- scriptIntegrityHash
-    (SJust . AuxiliaryDataHash $ SLE.mkDummySafeHash (Proxy @StandardCrypto) 42) -- adHash
+    (SJust $ mkDummySafeHash (Proxy @StandardCrypto) 42) -- scriptIntegrityHash
+    (SJust . AuxiliaryDataHash $ mkDummySafeHash (Proxy @StandardCrypto) 42) -- adHash
     (SJust Mainnet) -- txnetworkid
   where
     MaryValue _ exampleMultiAsset = SLE.exampleMultiAssetValue 3

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -15,6 +15,11 @@
 * Remove unused `isTwoPhaseScriptAddress`
 * Deprecate `babbageTxScripts` and `refScripts`
 
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Babbage.ImpTest`
+* Add `EraImpTest` instance for `BabbageEra`
+
 ## 1.4.5.0
 
 * Add `ToExpr` instance for:

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -80,7 +80,10 @@ library
         validation-selective
 
 library testlib
-    exposed-modules:  Test.Cardano.Ledger.Babbage.Arbitrary
+    exposed-modules:
+        Test.Cardano.Ledger.Babbage.Arbitrary
+        Test.Cardano.Ledger.Babbage.ImpTest
+
     visibility:       public
     hs-source-dirs:   testlib
     default-language: Haskell2010
@@ -92,9 +95,12 @@ library testlib
     build-depends:
         base,
         cardano-ledger-alonzo:testlib,
+        cardano-ledger-shelley:testlib,
+        cardano-crypto-class,
         cardano-ledger-babbage,
         cardano-ledger-binary,
         cardano-ledger-core,
+        cardano-ledger-alonzo:testlib,
         small-steps,
         QuickCheck
 
@@ -113,6 +119,7 @@ test-suite tests
         base,
         cardano-ledger-alonzo,
         cardano-ledger-babbage,
+        cardano-ledger-shelley:testlib,
         cardano-ledger-core:testlib,
         cardano-ledger-alonzo:testlib,
         data-default-class,

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Babbage (Babbage)
+import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Babbage.ImpTest ()
 import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Babbage" $ do
       BinarySpec.spec
+      ImpTestSpec.spec $ Proxy @Babbage

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Babbage.ImpTest () where
+
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
+import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Core (EraIndependentTxBody)
+import Cardano.Ledger.Crypto (Crypto (..))
+import Test.Cardano.Ledger.Alonzo.ImpTest (emptyAlonzoImpNES)
+import Test.Cardano.Ledger.Shelley.ImpTest (
+  EraImpTest (..),
+  shelleyImpWitsVKeyNeeded,
+ )
+
+instance
+  ( Crypto c
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  EraImpTest (BabbageEra c)
+  where
+  emptyImpNES = emptyAlonzoImpNES
+
+  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -54,6 +53,7 @@ import Lens.Micro
 import qualified PlutusTx as Plutus
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr, mkWitnessesVKey)
+import qualified Test.Cardano.Ledger.Core.Utils as SLE
 import qualified Test.Cardano.Ledger.Mary.Examples.Consensus as MarySLE
 import qualified Test.Cardano.Ledger.Shelley.Examples.Consensus as SLE
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Add `enactStateGovStateL` to `ConwayEraGov`
 * Add `psDRepDistrG`.
 * Rename `ensPParams` to `ensCurPParams`.
 * Add `ToJSON` instance for `RatifyState`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -68,6 +68,7 @@ library
     build-depends:
         base >=4.14 && <4.19,
         aeson,
+        data-default-class,
         cardano-crypto-class,
         cardano-data,
         cardano-ledger-binary >=1.1.3,
@@ -80,7 +81,6 @@ library
         cardano-slotting,
         cardano-strict-containers,
         containers,
-        data-default-class,
         deepseq,
         microlens,
         nothunks,
@@ -95,8 +95,8 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Conway.Arbitrary
         Test.Cardano.Ledger.Conway.Binary.RoundTrip
-        Test.Cardano.Ledger.Conway.ImpTest
         Test.Cardano.Ledger.Conway.PParamsSpec
+        Test.Cardano.Ledger.Conway.ImpTest
 
     visibility:       public
     hs-source-dirs:   testlib
@@ -108,29 +108,19 @@ library testlib
 
     build-depends:
         base,
-        transformers,
-        bytestring,
         cardano-data:testlib,
-        data-default-class,
         containers,
         microlens,
-        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-binary,
         cardano-crypto-class,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-babbage:testlib,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-        cardano-slotting,
         cardano-ledger-conway,
-        small-steps-test,
+        data-default-class,
         cardano-ledger-shelley,
-        cardano-ledger-babbage,
-        mtl,
-        time,
         cardano-strict-containers,
-        small-steps,
-        microlens-mtl,
-        unliftio,
-        deepseq
+        small-steps
 
 test-suite tests
     type:             exitcode-stdio-1.0
@@ -157,13 +147,12 @@ test-suite tests
         base,
         cardano-ledger-core:testlib,
         cardano-ledger-conway,
-        cardano-ledger-shelley,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-ledger-core,
         cardano-ledger-binary:testlib,
         containers,
         data-default-class,
         microlens,
         testlib,
-        text,
         cardano-strict-containers,
         microlens

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -653,11 +653,13 @@ class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)
   proposalsGovStateL :: Lens' (GovState era) (ProposalsSnapshot era)
   drepPulsingStateGovStateL :: Lens' (GovState era) (DRepPulsingState era)
+  enactStateGovStateL :: Lens' (GovState era) (EnactState era)
 
 instance Crypto c => ConwayEraGov (ConwayEra c) where
   constitutionGovStateL = cgEnactStateL . ensConstitutionL
   proposalsGovStateL = cgProposalsL
   drepPulsingStateGovStateL = cgDRepPulsingStateL
+  enactStateGovStateL = cgEnactStateL
 
 pparamsUpdateThreshold ::
   forall era.

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Cardano.Ledger.Conway.GenesisSpec as GenesisSpec
 import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorderSpec
 import qualified Test.Cardano.Ledger.Conway.GovSpec as GovSpec
 import qualified Test.Cardano.Ledger.Conway.PParamsSpec as PParamsSpec
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
@@ -24,5 +25,6 @@ main =
       GenesisSpec.spec
       GovActionReorderSpec.spec
       EpochSpec.spec
+      ImpTestSpec.spec $ Proxy @Conway
       GovSpec.spec
       PParamsSpec.spec $ Proxy @Conway

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -13,86 +10,34 @@
 module Test.Cardano.Ledger.Conway.EpochSpec (spec) where
 
 import Cardano.Ledger.BaseTypes (textToUrl)
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core (
   Constitution (..),
   DRepVotingThresholds (..),
-  EraGov (..),
-  EraTx (..),
-  EraTxBody (..),
-  EraTxOut (..),
-  PParams,
  )
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
-  Committee (..),
-  ConwayEraGov (..),
-  EnactState (..),
   GovAction (..),
-  GovActionId (..),
-  GovActionState (..),
-  RatifyEnv (..),
-  RatifyState (RatifyState),
-  Vote (..),
   Voter (..),
-  VotingProcedure (..),
-  VotingProcedures (VotingProcedures),
   cgEnactStateL,
   ensCommitteeL,
-  epochStateDRepPulsingStateL,
-  epochStateIncrStakeDistrL,
-  gasDRepVotesL,
-  psDRepDistrG,
-  rsDelayed,
-  rsEnactState,
-  rsRemoved,
-  snapshotLookupId,
  )
-import Cardano.Ledger.Conway.PParams (ppCommitteeMaxTermLengthL, ppDRepVotingThresholdsL)
-import Cardano.Ledger.Conway.Rules (committeeAccepted, committeeAcceptedRatio, dRepAccepted, dRepAcceptedRatio, prevActionAsExpected, spoAccepted, validCommitteeTerm, withdrawalCanWithdraw)
-import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
-import Cardano.Ledger.Conway.TxCert (
-  ConwayDelegCert (..),
-  ConwayEraTxCert (mkRegDRepTxCert),
-  ConwayTxCert (..),
-  Delegatee (DelegStakeVote),
-  pattern AuthCommitteeHotKeyTxCert,
+import Cardano.Ledger.Conway.PParams (
+  ppCommitteeMaxTermLengthL,
+  ppDRepVotingThresholdsL,
  )
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Crypto (StandardCrypto)
-import Cardano.Ledger.DRep (DRep (..))
-import Cardano.Ledger.Keys (KeyHash, KeyRole (..), coerceKeyRole)
 import Cardano.Ledger.Shelley.LedgerState (
-  IncrementalStake (..),
-  certVStateL,
-  curPParamsEpochStateL,
   esLStateL,
-  lsCertStateL,
   lsUTxOStateL,
-  nesELL,
   nesEsL,
-  nesPdL,
-  prevPParamsEpochStateL,
-  totalObligation,
-  utxosDepositedL,
   utxosGovStateL,
-  utxosStakeDistrL,
-  vsCommitteeStateL,
-  vsDRepsL,
  )
-import Cardano.Ledger.TxIn (TxId)
-import Cardano.Ledger.Val (Val (..))
 import Data.Default.Class (Default (..))
-import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust)
 import Data.Maybe.Strict (StrictMaybe (..), isSJust)
-import qualified Data.Sequence.Strict as SSeq
-import qualified Data.Sequence.Strict as Seq
-import qualified Data.Text as T
-import Lens.Micro (to, (%~), (&), (.~), (^.))
-import Test.Cardano.Ledger.Binary.TreeDiff (showExpr)
+import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Common (
   HasCallStack,
   Spec,
@@ -101,262 +46,11 @@ import Test.Cardano.Ledger.Common (
   shouldSatisfy,
  )
 import Test.Cardano.Ledger.Conway.ImpTest
-import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
-
--- | Modify the PParams in the current state with the given function
-modifyPParams :: EraGov era => (PParams era -> PParams era) -> ImpTestM era ()
-modifyPParams f = do
-  modifyNES $ nesEsL . curPParamsEpochStateL %~ f
-  modifyNES $ nesEsL . prevPParamsEpochStateL %~ f
-
--- | Submit a transaction that registers a new DRep and return the keyhash
--- belonging to that DRep
-registerDRep :: ImpTestM Conway (KeyHash 'DRepRole StandardCrypto)
-registerDRep = do
-  -- Register a DRep
-  khDRep <- freshKeyHash
-  _ <- submitBasicConwayTx "register DRep" $ \tx ->
-    tx
-      & bodyTxL . certsTxBodyL
-        .~ SSeq.singleton
-          ( mkRegDRepTxCert
-              (KeyHashObj khDRep)
-              zero
-              SNothing
-          )
-  dreps <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
-  impIO $ dreps `shouldSatisfy` Map.member (KeyHashObj khDRep)
-  pure khDRep
-
--- | Registers a new DRep and delegates 1 ADA to it. Returns the keyhash of the
--- DRep
-setupSingleDRep :: ImpTestM Conway (KeyHash 'DRepRole StandardCrypto)
-setupSingleDRep = do
-  khDRep <- registerDRep
-
-  khDelegator <- freshKeyHash
-  kpDelegator <- lookupKeyPair khDelegator
-  kpSpending <- lookupKeyPair =<< freshKeyHash
-  _ <- submitBasicConwayTx "Delegate to DRep" $ \tx ->
-    tx
-      & bodyTxL . outputsTxBodyL
-        .~ Seq.singleton
-          ( mkBasicTxOut
-              (mkAddr (kpSpending, kpDelegator))
-              (inject $ Coin 1000000)
-          )
-      & bodyTxL . certsTxBodyL
-        .~ Seq.fromList
-          [ ConwayTxCertDeleg $
-              ConwayRegDelegCert
-                (KeyHashObj khDelegator)
-                (DelegStakeVote (coerceKeyRole khDRep) (DRepCredential $ KeyHashObj khDRep))
-                zero
-          ]
-  pure khDRep
-
--- | Submits a transaction that votes "Yes" for the given governance action as
--- some voter
-voteForProposal ::
-  Voter StandardCrypto ->
-  GovActionId StandardCrypto ->
-  ImpTestM Conway (TxId StandardCrypto)
-voteForProposal voter gaId = do
-  submitBasicConwayTx "Vote as DRep" $ \tx ->
-    tx
-      & bodyTxL . votingProceduresTxBodyL
-        .~ VotingProcedures
-          ( Map.singleton
-              voter
-              ( Map.singleton
-                  gaId
-                  ( VotingProcedure
-                      { vProcVote = VoteYes
-                      , vProcAnchor = SNothing
-                      }
-                  )
-              )
-          )
-
--- | Asserts that the URL of the current constitution is equal to the given
--- string
-constitutionShouldBe :: HasCallStack => String -> ImpTestM Conway ()
-constitutionShouldBe cUrl = do
-  constitution <-
-    getsNES $
-      nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . to getConstitution
-  Constitution {constitutionAnchor = Anchor {anchorUrl}} <-
-    impIOMsg "Expecting a constitution" $ do
-      pure $
-        fromMaybe
-          (error "No constitution has been set")
-          constitution
-  impIO $ anchorUrl `shouldBe` fromJust (textToUrl $ T.pack cUrl)
-
--- | Looks up the governance action state corresponding to the governance
--- action id
-lookupGovActionState :: HasCallStack => GovActionId StandardCrypto -> ImpTestM Conway (GovActionState Conway)
-lookupGovActionState aId = do
-  proposals <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . proposalsGovStateL
-  impIOMsg "Expecting an action state" $ do
-    maybe (error $ "Could not find action state for action " <> show aId) pure $
-      snapshotLookupId aId proposals
-
--- | Builds a RatifyState from the current state
-getRatifyEnv :: ImpTestM Conway (RatifyEnv Conway)
-getRatifyEnv = do
-  eNo <- getsNES nesELL
-  stakeDistr <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosStakeDistrL
-  poolDistr <- getsNES nesPdL
-  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
-  drepState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
-  committeeState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-  pure
-    RatifyEnv
-      { reStakePoolDistr = poolDistr
-      , reStakeDistr = credMap stakeDistr
-      , reDRepState = drepState
-      , reDRepDistr = drepDistr
-      , reCurrentEpoch = eNo - 1
-      , reCommitteeState = committeeState
-      }
-
--- | Calculates the ratio of DReps that have voted for the governance action
-calculateDRepAcceptedRatio :: GovActionId StandardCrypto -> ImpTestM Conway Rational
-calculateDRepAcceptedRatio gaId = do
-  ratEnv <- getRatifyEnv
-  gas <- lookupGovActionState gaId
-  pure $
-    dRepAcceptedRatio @Conway
-      ratEnv
-      (gas ^. gasDRepVotesL)
-      (gasAction gas)
-
--- | Calculates the ratio of CC members that have voted for the governance
--- action
-calculateCommitteeAcceptedRatio :: GovActionId StandardCrypto -> ImpTestM Conway Rational
-calculateCommitteeAcceptedRatio gaId = do
-  eNo <- getsNES nesELL
-  RatifyEnv {reCommitteeState} <- getRatifyEnv
-  GovActionState {gasCommitteeVotes} <- lookupGovActionState gaId
-  committee <-
-    getsNES $
-      nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
-  let
-    members = foldMap' committeeMembers committee
-  pure $
-    committeeAcceptedRatio
-      members
-      gasCommitteeVotes
-      reCommitteeState
-      eNo
-
--- | Logs the ratios of accepted votes per category
-logAcceptedRatio :: GovActionId StandardCrypto -> ImpTestM Conway ()
-logAcceptedRatio aId = do
-  dRepRatio <- calculateDRepAcceptedRatio aId
-  committeeRatio <- calculateCommitteeAcceptedRatio aId
-  logEntry "----- ACCEPTED RATIOS -----"
-  logEntry $ "DRep accepted ratio:\t\t" <> show dRepRatio
-  logEntry $ "Committee accepted ratio:\t" <> show committeeRatio
-  logEntry ""
-
--- | Checks whether the governance action has enough votes to be accepted
-isGovActionAccepted :: GovActionId StandardCrypto -> ImpTestM Conway Bool
-isGovActionAccepted gaId = do
-  eNo <- getsNES nesELL
-  stakeDistr <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosStakeDistrL
-  poolDistr <- getsNES nesPdL
-  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
-  drepState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
-  action <- lookupGovActionState gaId
-  enactSt <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL
-  committeeState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-  let
-    ratEnv =
-      RatifyEnv
-        { reStakePoolDistr = poolDistr
-        , reStakeDistr = credMap stakeDistr
-        , reDRepState = drepState
-        , reDRepDistr = drepDistr
-        , reCurrentEpoch = eNo - 1
-        , reCommitteeState = committeeState
-        }
-    ratSt =
-      RatifyState
-        { rsRemoved = mempty
-        , rsEnactState = enactSt
-        , rsDelayed = False
-        }
-  pure $ dRepAccepted ratEnv ratSt action
-
--- | Logs the current stake distribution
-logStakeDistr :: ImpTestM era ()
-logStakeDistr = do
-  stakeDistr <- getsNES $ nesEsL . epochStateIncrStakeDistrL
-  logEntry $ "Stake distr: " <> showExpr stakeDistr
-
--- | Logs the results of each check required to make the governance action pass
-logRatificationChecks :: GovActionId StandardCrypto -> ImpTestM Conway ()
-logRatificationChecks gaId = do
-  gas@GovActionState {gasAction} <- lookupGovActionState gaId
-  ens@EnactState {..} <-
-    getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL
-  ratEnv <- getRatifyEnv
-  let
-    ratSt = RatifyState ens mempty False
-  currentEpoch <- getsNES nesELL
-  logEntry $
-    unlines
-      [ "----- RATIFICATION CHECKS -----"
-      , "prevActionAsExpected:\t" <> show (prevActionAsExpected gasAction ensPrevGovActionIds)
-      , "validCommitteeTerm:\t"
-          <> show (validCommitteeTerm ensCommittee ensCurPParams currentEpoch)
-      , "notDelayed:\t\t??"
-      , "withdrawalCanWithdraw:\t" <> show (withdrawalCanWithdraw gasAction ensTreasury)
-      , "committeeAccepted:\t" <> show (committeeAccepted ratSt ratEnv gas)
-      , "spoAccepted:\t\t" <> show (spoAccepted ratSt ratEnv gas)
-      , "dRepAccepted:\t\t" <> show (dRepAccepted ratEnv ratSt gas)
-      , ""
-      ]
-
--- | Submits a transaction that registers a hot key for the given cold key.
--- Returns the hot key hash.
-registerCCHotKey ::
-  KeyHash 'ColdCommitteeRole StandardCrypto ->
-  ImpTestM Conway (KeyHash 'HotCommitteeRole StandardCrypto)
-registerCCHotKey coldKey = do
-  hotKey <- freshKeyHash
-  _ <- submitBasicConwayTx "Registering hot key" $ \tx ->
-    tx
-      & bodyTxL . certsTxBodyL
-        .~ Seq.singleton (AuthCommitteeHotKeyTxCert (KeyHashObj coldKey) (KeyHashObj hotKey))
-  pure hotKey
 
 spec :: HasCallStack => Spec
 spec =
   describe "Ratify traces" $ do
-    itM @Conway "Runs basic transaction" $ do
-      do
-        certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-        govState <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-        impIO $ totalObligation certState govState `shouldBe` zero
-      do
-        deposited <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosDepositedL
-        impIO $ deposited `shouldBe` zero
-      _ <- submitBasicConwayTx "simple transaction" id
-      passEpoch
-
-    itM @Conway "Crosses the epoch boundary" $ do
-      do
-        epoch <- getsNES nesELL
-        impIO $ epoch `shouldBe` 0
-      passEpoch
-      do
-        epoch <- getsNES nesELL
-        impIO $ epoch `shouldBe` 1
-
     itM @Conway "DRep registration should succeed" $ do
       logEntry "Stake distribution before DRep registration:"
       logStakeDistr

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -64,6 +64,7 @@ import Lens.Micro
 import qualified PlutusTx as Plutus
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr, mkWitnessesVKey)
+import Test.Cardano.Ledger.Core.Utils (mkDummySafeHash)
 import qualified Test.Cardano.Ledger.Mary.Examples.Consensus as MarySLE
 import Test.Cardano.Ledger.Shelley.Examples.Consensus (examplePoolParams)
 import qualified Test.Cardano.Ledger.Shelley.Examples.Consensus as SLE
@@ -126,9 +127,9 @@ exampleConwayCerts =
 exampleTxBodyConway :: TxBody Conway
 exampleTxBodyConway =
   ConwayTxBody
-    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 1)) 0]) -- spending inputs
-    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 2)) 1]) -- collateral inputs
-    (Set.fromList [mkTxInPartial (TxId (SLE.mkDummySafeHash Proxy 1)) 3]) -- reference inputs
+    (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash Proxy 1)) 0]) -- spending inputs
+    (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash Proxy 2)) 1]) -- collateral inputs
+    (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash Proxy 1)) 3]) -- reference inputs
     ( StrictSeq.fromList
         [ mkSized (eraProtVerHigh @Conway) $
             BabbageTxOut
@@ -150,8 +151,8 @@ exampleTxBodyConway =
     (ValidityInterval (SJust (SlotNo 2)) (SJust (SlotNo 4))) -- txvldt
     (Set.singleton $ SLE.mkKeyHash 212) -- reqSignerHashes
     exampleMultiAsset -- mint
-    (SJust $ SLE.mkDummySafeHash (Proxy @StandardCrypto) 42) -- scriptIntegrityHash
-    (SJust . AuxiliaryDataHash $ SLE.mkDummySafeHash (Proxy @StandardCrypto) 42) -- adHash
+    (SJust $ mkDummySafeHash (Proxy @StandardCrypto) 42) -- scriptIntegrityHash
+    (SJust . AuxiliaryDataHash $ mkDummySafeHash (Proxy @StandardCrypto) 42) -- adHash
     (SJust Mainnet) -- txnetworkid
     (VotingProcedures mempty)
     mempty

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.3.4.1
+## 1.3.5.0
 
 * Add `ToExpr` instance for `CompactValue`
 * Implement `getScriptsProvided`
+
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Mary.ImpTest`
+* Add `EraImpTest` instance for `MaryEra`
 
 ## 1.3.4.0
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.4.1
+version:            1.3.5.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -75,7 +75,10 @@ library
         ghc-options: -fno-ignore-asserts
 
 library testlib
-    exposed-modules:  Test.Cardano.Ledger.Mary.Arbitrary
+    exposed-modules:
+        Test.Cardano.Ledger.Mary.Arbitrary
+        Test.Cardano.Ledger.Mary.ImpTest
+
     visibility:       public
     hs-source-dirs:   testlib
     default-language: Haskell2010
@@ -93,6 +96,7 @@ library testlib
         cardano-ledger-core,
         cardano-ledger-mary >=1.0.0.1,
         cardano-ledger-allegra:testlib,
+        cardano-ledger-shelley:testlib,
         cardano-strict-containers,
         QuickCheck
 

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Mary (Mary)
+import Data.Data (Proxy (..))
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
+import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
@@ -10,3 +16,4 @@ main =
     describe "Mary" $ do
       ValueSpec.spec
       BinarySpec.spec
+      ImpTestSpec.spec $ Proxy @Mary

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Mary.ImpTest () where
+
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
+import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Core (EraIndependentTxBody)
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Mary (MaryEra)
+import Test.Cardano.Ledger.Shelley.ImpTest (
+  EraImpTest (..),
+  emptyShelleyImpNES,
+  shelleyImpWitsVKeyNeeded,
+ )
+
+instance
+  ( Crypto c
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  EraImpTest (MaryEra c)
+  where
+  emptyImpNES = emptyShelleyImpNES
+
+  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -19,6 +19,7 @@ import Data.Proxy
 import qualified Data.Sequence.Strict as StrictSeq
 import Lens.Micro
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
+import Test.Cardano.Ledger.Core.Utils (mkDummySafeHash)
 import Test.Cardano.Ledger.Shelley.Examples.Consensus
 
 -- | ShelleyLedgerExamples for Allegra era

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 1.7.0.0
 
+* Add `ToExpr` instances for:
+  * `ShelleyDelegPredFailure`
+  * `ShelleyDelegsPredFailure`
+  * `ShelleyDelplPredFailure`
+  * `ShelleyEpochPredFailure`
+  * `ShelleyLedgerPredFailure`
+  * `ShelleyPpupPredFailure`
+  * `ShelleyUtxoPredFailure`
+  * `VotingPeriod`
+* Add `NFData` instances for:
+  * `ShelleyMirPredFailure`
+  * `ShelleyNewEpochPredFailure`
+  * `ShelleyNewppPredFailure`
+  * `ShelleyPoolreapPredFailure`
+  * `ShelleySnapPredFailure`
+  * `ShelleyUpecPredFailure`
 * Add `epochStateGovStateL`
 * Add `shelleyCommonPParamsHKDPairsV8`
 * Add `ToExpr` instances for:
@@ -13,6 +29,12 @@
 * Rename `validateFailedScripts` to `validateFailedNativeScripts` and change its
   arguments.
 * Change type of `validateMissingScripts`
+
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Shelley.ImpTest`
+* Add `Test.Cardano.Ledger.Shelley.ImpTestSpec`
+* Add `EraImpTest` instance for `ShelleyEra`
 
 ## 1.6.1.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -135,6 +135,8 @@ library testlib
         Test.Cardano.Ledger.Shelley.Binary.Golden
         Test.Cardano.Ledger.Shelley.Binary.RoundTrip
         Test.Cardano.Ledger.Shelley.Constants
+        Test.Cardano.Ledger.Shelley.ImpTest
+        Test.Cardano.Ledger.Shelley.ImpTestSpec
 
     visibility:       public
     hs-source-dirs:   testlib
@@ -148,6 +150,7 @@ library testlib
         base,
         bytestring,
         cardano-crypto-class,
+        data-default-class,
         cardano-data,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-core:{cardano-ledger-core, testlib},
@@ -155,8 +158,17 @@ library testlib
         cardano-ledger-byron-test,
         cardano-ledger-shelley,
         containers,
+        deepseq,
         generic-random,
         containers,
+        transformers,
+        small-steps,
+        small-steps-test,
+        cardano-strict-containers,
+        microlens,
+        microlens-mtl,
+        prettyprinter,
+        unliftio,
         vector-map,
         mtl,
         text,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -71,6 +71,7 @@ import Cardano.Ledger.Slot (
   (*-),
   (+*),
  )
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UMap (RDPair (..), UView (..), compactCoinOrError, fromCompact)
 import qualified Cardano.Ledger.UMap as UM
 import Control.DeepSeq
@@ -154,6 +155,8 @@ instance (EraPParams era, ShelleyEraTxCert era, ProtVerAtMost era 8) => STS (She
 instance NoThunks (ShelleyDelegPredFailure era)
 
 instance NFData (ShelleyDelegPredFailure era)
+
+instance ToExpr (ShelleyDelegPredFailure era)
 
 instance
   (Era era, Typeable (Script era)) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -71,6 +71,7 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.TxCert (ShelleyEraTxCert, pattern DelegStakeTxCert)
 import Cardano.Ledger.Slot (SlotNo)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UMap (UMElem (..), UMap (..), UView (..), fromCompact)
 import qualified Cardano.Ledger.UMap as UM
 import Control.DeepSeq
@@ -135,6 +136,10 @@ deriving stock instance
 instance
   NFData (PredicateFailure (EraRule "DELPL" era)) =>
   NFData (ShelleyDelegsPredFailure era)
+
+instance
+  ToExpr (PredicateFailure (EraRule "DELPL" era)) =>
+  ToExpr (ShelleyDelegsPredFailure era)
 
 instance
   ( EraTx era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Shelley.Rules.Pool (PoolEnv (..), ShelleyPOOL, ShelleyPool
 import Cardano.Ledger.Shelley.TxBody (Ptr)
 import Cardano.Ledger.Shelley.TxCert (GenesisDelegCert (..), ShelleyTxCert (..))
 import Cardano.Ledger.Slot (SlotNo)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq
 import Control.State.Transition
 import Data.Typeable (Typeable)
@@ -91,6 +92,12 @@ instance
   , NFData (PredicateFailure (EraRule "POOL" era))
   ) =>
   NFData (ShelleyDelplPredFailure era)
+
+instance
+  ( ToExpr (PredicateFailure (EraRule "DELEG" era))
+  , ToExpr (PredicateFailure (EraRule "POOL" era))
+  ) =>
+  ToExpr (ShelleyDelplPredFailure era)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
@@ -56,6 +56,7 @@ import Cardano.Ledger.Shelley.Rules.PoolReap (
 import Cardano.Ledger.Shelley.Rules.Snap (ShelleySNAP, ShelleySnapPredFailure, SnapEnv (..), SnapEvent)
 import Cardano.Ledger.Shelley.Rules.Upec (ShelleyUPEC, ShelleyUpecPredFailure, UpecState (..))
 import Cardano.Ledger.Slot (EpochNo)
+import Control.DeepSeq (NFData)
 import Control.SetAlgebra (eval, (⨃))
 import Control.State.Transition (
   Embed (..),
@@ -103,6 +104,13 @@ deriving stock instance
   , Show (UpecPredFailure era)
   ) =>
   Show (ShelleyEpochPredFailure era)
+
+instance
+  ( NFData (PredicateFailure (EraRule "POOLREAP" era))
+  , NFData (PredicateFailure (EraRule "SNAP" era))
+  , NFData (UpecPredFailure era)
+  ) =>
+  NFData (ShelleyEpochPredFailure era)
 
 data ShelleyEpochEvent era
   = PoolReapEvent (Event (EraRule "POOLREAP" era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Shelley.Rules.Reports (showTxCerts, synopsisCoinMap)
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.Rules.Utxow (ShelleyUTXOW, ShelleyUtxowPredFailure)
 import Cardano.Ledger.Slot (EpochNo, SlotNo, epochInfoEpoch)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UMap (depositMap)
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Reader (Reader)
@@ -158,6 +159,12 @@ instance
           a <- decCBOR
           pure (2, DelegsFailure a)
         k -> invalidKey k
+
+instance
+  ( ToExpr (PredicateFailure (EraRule "UTXOW" era))
+  , ToExpr (PredicateFailure (EraRule "DELEGS" era))
+  ) =>
+  ToExpr (ShelleyLedgerPredFailure era)
 
 epochFromSlot :: SlotNo -> Reader Globals EpochNo
 epochFromSlot slot = do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.UMap (compactCoinOrError)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<->))
+import Control.DeepSeq (NFData)
 import Control.SetAlgebra (eval, (∪+))
 import Control.State.Transition (
   Assertion (..),
@@ -62,6 +63,8 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleyMirPredFailure era
   deriving (Show, Generic, Eq)
+
+instance NFData (ShelleyMirPredFailure era)
 
 data ShelleyMirEvent era
   = MirTransfer (InstantaneousRewards (EraCrypto era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Shelley.Rules.Mir (ShelleyMIR, ShelleyMirEvent, ShelleyMir
 import Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))
 import Cardano.Ledger.Slot (EpochNo (EpochNo))
 import qualified Cardano.Ledger.Val as Val
+import Control.DeepSeq (NFData)
 import Control.State.Transition
 import Data.Default.Class (Default, def)
 import qualified Data.Map.Strict as Map
@@ -75,6 +76,12 @@ instance
   , NoThunks (PredicateFailure (EraRule "MIR" era))
   ) =>
   NoThunks (ShelleyNewEpochPredFailure era)
+
+instance
+  ( NFData (PredicateFailure (EraRule "EPOCH" era))
+  , NFData (PredicateFailure (EraRule "MIR" era))
+  ) =>
+  NFData (ShelleyNewEpochPredFailure era)
 
 data ShelleyNewEpochEvent era
   = DeltaRewardEvent (Event (EraRule "RUPD" era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Shelley.PParams (
   emptyPPPUpdates,
   pvCanFollow,
  )
+import Control.DeepSeq (NFData)
 import Control.State.Transition (
   STS (..),
   TRC (..),
@@ -62,6 +63,8 @@ data ShelleyNewppPredFailure era
   deriving (Show, Eq, Generic)
 
 instance NoThunks (ShelleyNewppPredFailure era)
+
+instance NFData (ShelleyNewppPredFailure era)
 
 instance
   ( EraGov era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Ledger.UMap (UView (RewDepUView, SPoolUView), compactCoinOrError)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<+>), (<->))
+import Control.DeepSeq (NFData)
 import Control.SetAlgebra (dom, eval, setSingleton, (⋪), (▷), (◁))
 import Control.State.Transition (
   Assertion (..),
@@ -79,6 +80,8 @@ deriving stock instance Show (UTxOState era) => Show (ShelleyPoolreapState era)
 
 data ShelleyPoolreapPredFailure era -- No predicate failures
   deriving (Show, Eq, Generic)
+
+instance NFData (ShelleyPoolreapPredFailure era)
 
 data ShelleyPoolreapEvent era = RetiredPools
   { refundPools :: Map.Map (Credential 'Staking (EraCrypto era)) (Map.Map (KeyHash 'StakePool (EraCrypto era)) Coin)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.Slot (
   epochInfoFirst,
   (*-),
  )
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (dom, eval, (⊆), (⨃))
@@ -85,6 +86,8 @@ instance DecCBOR VotingPeriod where
       0 -> pure VoteForThisEpoch
       1 -> pure VoteForNextEpoch
       k -> invalidKey k
+
+instance ToExpr VotingPeriod
 
 data ShelleyPpupPredFailure era
   = -- | An update was proposed by a key hash that is not one of the genesis keys.
@@ -156,6 +159,8 @@ instance Era era => DecCBOR (ShelleyPpupPredFailure era) where
         p <- decCBOR
         pure (2, PVCannotFollowPPUP p)
       k -> invalidKey k
+
+instance ToExpr (ShelleyPpupPredFailure era)
 
 ppupTransitionNonEmpty :: (EraPParams era, ProtVerAtMost era 8) => TransitionRule (ShelleyPPUP era)
 ppupTransitionNonEmpty = do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   UTxOState (..),
   incrementalStakeDistr,
  )
+import Control.DeepSeq (NFData)
 import Control.State.Transition (
   STS (..),
   TRC (..),
@@ -54,6 +55,8 @@ import NoThunks.Class (NoThunks (..))
 
 data ShelleySnapPredFailure era -- No predicate failures
   deriving (Show, Generic, Eq)
+
+instance NFData (ShelleySnapPredFailure era)
 
 instance NoThunks (ShelleySnapPredFailure era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -40,8 +40,10 @@ import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Cardano.Ledger.Shelley.Rules.Newpp (
   NewppEnv (..),
   ShelleyNEWPP,
+  ShelleyNewppPredFailure,
   ShelleyNewppState (..),
  )
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition (
   Embed (..),
@@ -73,6 +75,8 @@ newtype ShelleyUpecPredFailure era
   deriving (Eq, Show, Generic)
 
 instance NoThunks (ShelleyUpecPredFailure era)
+
+instance NFData (ShelleyNewppPredFailure era) => NFData (ShelleyUpecPredFailure era)
 
 instance
   ( EraGov era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -89,6 +89,7 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.UTxO (consumed, produced, txup)
 import Cardano.Ledger.Slot (SlotNo)
+import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UTxO (
   EraUTxO,
   UTxO (..),
@@ -309,6 +310,13 @@ instance
           outs <- decCBOR
           pure (2, OutputBootAddrAttrsTooBig outs)
         k -> invalidKey k
+
+instance
+  ( ToExpr (PPUPPredFailure era)
+  , ToExpr (Value era)
+  , ToExpr (TxOut era)
+  ) =>
+  ToExpr (ShelleyUtxoPredFailure era)
 
 instance
   ( EraTx era

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Shelley (Shelley)
+import Data.Data (Proxy (..))
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.BinarySpec as Binary
+import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Shelley" $ do
       Binary.spec
+      ImpTestSpec.spec $ Proxy @Shelley

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1,0 +1,631 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Test.Cardano.Ledger.Shelley.ImpTest (
+  ImpTestM,
+  ImpException (..),
+  EraImpTest (..),
+  logStakeDistr,
+  emptyShelleyImpNES,
+  shelleyImpWitsVKeyNeeded,
+  modifyPParams,
+  passEpoch,
+  passTick,
+  itM,
+  freshKeyHash,
+  freshSafeHash,
+  lookupKeyPair,
+  submitTx,
+  submitFailingTx,
+  trySubmitTx,
+  impExpectFailure,
+  impExpectSuccess,
+  logEntry,
+  modifyNES,
+  getsNES,
+  impIO,
+  impIOMsg,
+  mkTxWits,
+  impNESL,
+  constitutionShouldBe,
+) where
+
+import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), seedSizeDSIGN)
+import Cardano.Crypto.Hash (Hash)
+import Cardano.Crypto.Seed (mkSeedFromBytes)
+import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.BaseTypes (
+  Anchor (..),
+  BlocksMade (..),
+  EpochSize (..),
+  Globals (..),
+  Network (..),
+  ShelleyBase,
+  SlotNo,
+  StrictMaybe (..),
+  TxIx (..),
+  textToUrl,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (
+  Era (..),
+  EraIndependentTxBody,
+  EraRule,
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  EraTxWits (..),
+  PParams,
+  ProtVerAtMost,
+  emptyPParams,
+  setMinFeeTx,
+ )
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.EpochBoundary (emptySnapShots)
+import Cardano.Ledger.Keys (
+  HasKeyRole (..),
+  KeyHash,
+  KeyRole (..),
+  hashKey,
+ )
+import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
+import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeHash)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.Core (Constitution (..), EraGov (..), ShelleyEraTxBody)
+import Cardano.Ledger.Shelley.LedgerState (
+  AccountState (..),
+  EpochState (..),
+  LedgerState (..),
+  NewEpochState (..),
+  StashedAVVMAddresses,
+  certDStateL,
+  curPParamsEpochStateL,
+  dsGenDelegsL,
+  epochStateIncrStakeDistrL,
+  esAccountStateL,
+  esLStateL,
+  lsCertStateL,
+  lsUTxOStateL,
+  nesELL,
+  nesEsL,
+  prevPParamsEpochStateL,
+  smartUTxOState,
+  startStep,
+  utxosGovStateL,
+  utxosUtxoL,
+ )
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..), shelleyWitsVKeyNeeded)
+import Cardano.Ledger.TreeDiff (ToExpr (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), sumAllCoin)
+import Cardano.Ledger.Val (Val (..))
+import Control.DeepSeq (NFData)
+import Control.Exception (Exception (..), SomeException (..), throwIO)
+import Control.Monad (void)
+import Control.Monad.State.Strict (
+  MonadState (..),
+  MonadTrans (..),
+  StateT (..),
+  execStateT,
+  gets,
+  modify,
+ )
+import Control.Monad.Trans.Reader (ReaderT (..))
+import qualified Control.Monad.Trans.State.Strict as M
+import Control.State.Transition (STS (..), TRC (..))
+import Control.State.Transition.Trace (applySTSTest)
+import qualified Data.ByteString as BS
+import Data.Coerce (coerce)
+import Data.Data (Proxy (..))
+import Data.Default.Class (Default (..))
+import Data.Functor.Identity (Identity (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust, fromMaybe)
+import Data.Sequence.Strict (StrictSeq ((:<|)))
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Lens.Micro (Lens', SimpleGetter, lens, to, (%~), (&), (.~), (^.))
+import Lens.Micro.Mtl (view, (%=), (+=), (.=))
+import Prettyprinter (Doc, Pretty (..), defaultLayoutOptions, layoutPretty, line)
+import Prettyprinter.Render.String (renderString)
+import Test.Cardano.Ledger.Binary.TreeDiff (showExpr)
+import Test.Cardano.Ledger.Common (HasCallStack, Spec, it, shouldBe)
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr, mkKeyHash, mkKeyPair, mkWitnessVKey)
+import Test.Cardano.Ledger.Core.Utils (mkDummySafeHash, testGlobals)
+import UnliftIO (catchAnyDeep)
+
+data ImpTestState era = ImpTestState
+  { impNES :: !(NewEpochState era)
+  , impRootTxCoin :: !Coin
+  , impRootTxId :: !(TxId (EraCrypto era))
+  , impSafeHashIdx :: !Int
+  , impKeyPairs :: !(forall k. Map (KeyHash k (EraCrypto era)) (KeyPair k (EraCrypto era)))
+  , impLastTick :: !SlotNo
+  , impLog :: !(Doc ())
+  }
+
+impLogL :: Lens' (ImpTestState era) (Doc ())
+impLogL = lens impLog (\x y -> x {impLog = y})
+
+impNESL :: Lens' (ImpTestState era) (NewEpochState era)
+impNESL = lens impNES (\x y -> x {impNES = y})
+
+impLastTickL :: Lens' (ImpTestState era) SlotNo
+impLastTickL = lens impLastTick (\x y -> x {impLastTick = y})
+
+impRootTxCoinL :: Lens' (ImpTestState era) Coin
+impRootTxCoinL = lens impRootTxCoin (\x y -> x {impRootTxCoin = y})
+
+impRootTxIdL :: Lens' (ImpTestState era) (TxId (EraCrypto era))
+impRootTxIdL = lens impRootTxId (\x y -> x {impRootTxId = y})
+
+class
+  ( Show (NewEpochState era)
+  , ToExpr (NewEpochState era)
+  , Signal (EraRule "LEDGER" era) ~ Tx era
+  , BaseM (EraRule "LEDGER" era) ~ ReaderT Globals Identity
+  , STS (EraRule "LEDGER" era)
+  , Signable
+      (DSIGN (EraCrypto era))
+      (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
+  , ToExpr (PredicateFailure (EraRule "LEDGER" era))
+  , EraUTxO era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , EraGov era
+  , BaseM (EraRule "TICK" era) ~ ReaderT Globals Identity
+  , Signal (EraRule "TICK" era) ~ SlotNo
+  , Environment (EraRule "TICK" era) ~ ()
+  , State (EraRule "TICK" era) ~ NewEpochState era
+  , STS (EraRule "TICK" era)
+  , NFData (PredicateFailure (EraRule "TICK" era))
+  , NFData (StashedAVVMAddresses era)
+  ) =>
+  EraImpTest era
+  where
+  emptyImpNES :: Coin -> NewEpochState era
+
+  impWitsVKeyNeeded ::
+    NewEpochState era ->
+    TxBody era ->
+    Set.Set (KeyHash 'Witness (EraCrypto era))
+
+impLedgerEnv :: EraGov era => NewEpochState era -> ImpTestM era (LedgerEnv era)
+impLedgerEnv nes = do
+  slotNo <- gets impLastTick
+  pure
+    LedgerEnv
+      { ledgerSlotNo = slotNo
+      , ledgerPp = nes ^. nesEsL . curPParamsEpochStateL
+      , ledgerIx = TxIx 0
+      , ledgerAccount = nes ^. nesEsL . esAccountStateL
+      }
+
+-- | Modify the PParams in the current state with the given function
+modifyPParams ::
+  EraGov era =>
+  (PParams era -> PParams era) ->
+  ImpTestM era ()
+modifyPParams f = do
+  modifyNES $ nesEsL . curPParamsEpochStateL %~ f
+  modifyNES $ nesEsL . prevPParamsEpochStateL %~ f
+
+-- | Logs the current stake distribution
+logStakeDistr :: ImpTestM era ()
+logStakeDistr = do
+  stakeDistr <- getsNES $ nesEsL . epochStateIncrStakeDistrL
+  logEntry $ "Stake distr: " <> showExpr stakeDistr
+
+emptyShelleyImpNES ::
+  forall era.
+  ( EraGov era
+  , EraTxOut era
+  , Default (StashedAVVMAddresses era)
+  ) =>
+  Coin ->
+  NewEpochState era
+emptyShelleyImpNES rootCoin =
+  NewEpochState
+    { stashedAVVMAddresses = def
+    , nesRu =
+        SJust $
+          startStep
+            (EpochSize 432_000)
+            (BlocksMade (Map.singleton testKeyHash 10))
+            epochState
+            (Coin 45)
+            (activeSlotCoeff testGlobals)
+            10
+    , nesPd =
+        PoolDistr $
+          Map.fromList
+            [
+              ( testKeyHash
+              , IndividualPoolStake
+                  1
+                  (VRF.hashVerKeyVRF . VRF.deriveVerKeyVRF . VRF.genKeyVRF . mkSeedFromBytes $ BS.replicate seedSize 1)
+              )
+            ]
+    , nesEs = epochState
+    , nesEL = 0
+    , nesBprev = BlocksMade (Map.singleton testKeyHash 10)
+    , nesBcur = BlocksMade mempty
+    }
+  where
+    testKeyHash = mkKeyHash (-1)
+    rootTxId = TxId (mkDummySafeHash Proxy 0)
+    seedSize = fromIntegral . seedSizeDSIGN $ Proxy @(DSIGN (EraCrypto era))
+    epochState =
+      EpochState
+        { esAccountState =
+            AccountState
+              { asTreasury = Coin 10_000
+              , asReserves = Coin 1_000
+              }
+        , esSnapshots = emptySnapShots
+        , esLState =
+            LedgerState
+              { lsUTxOState =
+                  smartUTxOState
+                    emptyPParams
+                    utxo
+                    zero
+                    zero
+                    emptyGovState
+                    mempty
+              , lsCertState = def
+              }
+        , esNonMyopic = def
+        }
+        & prevPParamsEpochStateL .~ emptyPParams
+        & curPParamsEpochStateL .~ emptyPParams
+    addr =
+      Addr
+        Testnet
+        (KeyHashObj $ hashKey vk)
+        (StakeRefBase (KeyHashObj testKeyHash))
+    utxo =
+      UTxO $
+        Map.fromList
+          [
+            ( TxIn rootTxId minBound
+            , mkBasicTxOut addr $ inject rootCoin
+            )
+          ]
+    KeyPair vk _ = mkKeyPair 0
+
+instance
+  ( Crypto c
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  EraImpTest (ShelleyEra c)
+  where
+  emptyImpNES = emptyShelleyImpNES
+
+  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded
+
+shelleyImpWitsVKeyNeeded ::
+  ( ProtVerAtMost era 8
+  , EraTx era
+  , ShelleyEraTxBody era
+  ) =>
+  NewEpochState era ->
+  TxBody era ->
+  Set.Set (KeyHash 'Witness (EraCrypto era))
+shelleyImpWitsVKeyNeeded nes txb = shelleyWitsVKeyNeeded utxo txb genDelegs
+  where
+    utxo = nes ^. nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
+    genDelegs = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . dsGenDelegsL
+
+newtype ImpTestM era a = ImpTestM (M.StateT (ImpTestState era) IO a)
+  deriving (Functor, Applicative, Monad, MonadState (ImpTestState era))
+
+runShelleyBase :: ShelleyBase a -> a
+runShelleyBase act = runIdentity $ runReaderT act testGlobals
+
+fixupFees ::
+  forall era.
+  EraImpTest era =>
+  Tx era ->
+  ImpTestM era (Tx era)
+fixupFees tx = do
+  ImpTestState {impRootTxId, impRootTxCoin} <- get
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  kpSpending <- lookupKeyPair =<< freshKeyHash
+  kpStaking <- lookupKeyPair =<< freshKeyHash
+  let
+    outputsTotalCoin = sumAllCoin $ tx ^. bodyTxL . outputsTxBodyL
+    remainingCoin = impRootTxCoin <-> outputsTotalCoin
+    remainingTxOut =
+      mkBasicTxOut @era
+        (mkAddr (kpSpending, kpStaking))
+        (inject remainingCoin)
+  impRootTxCoinL .= remainingCoin
+  let
+    balancedTx =
+      setMinFeeTx pp tx
+        & bodyTxL . inputsTxBodyL %~ Set.insert (TxIn impRootTxId $ TxIx 0)
+        & bodyTxL . outputsTxBodyL %~ (remainingTxOut :<|)
+    txId = TxId . hashAnnotated $ balancedTx ^. bodyTxL
+  impRootTxIdL .= txId
+  wits <- mkTxWits (balancedTx ^. bodyTxL)
+  pure $ balancedTx & witsTxL .~ wits
+
+submitTx_ ::
+  forall era.
+  EraImpTest era =>
+  Tx era ->
+  ImpTestM
+    era
+    ( Either
+        [PredicateFailure (EraRule "LEDGER" era)]
+        (State (EraRule "LEDGER" era), Tx era)
+    )
+submitTx_ tx = do
+  st <- gets impNES
+  txFixed <- fixupFees tx
+  logEntry $ showExpr txFixed
+  lEnv <- impLedgerEnv st
+  let
+    trc =
+      TRC
+        ( lEnv
+        , st ^. nesEsL . esLStateL
+        , txFixed
+        )
+  pure $ (,txFixed) <$> runShelleyBase (applySTSTest @(EraRule "LEDGER" era) trc)
+
+trySubmitTx ::
+  EraImpTest era =>
+  Tx era ->
+  ImpTestM era (Either [PredicateFailure (EraRule "LEDGER" era)] (TxId (EraCrypto era)))
+trySubmitTx tx = do
+  res <- submitTx_ tx
+  case res of
+    Right (st, finalTx) -> do
+      modify $ impNESL . nesEsL . esLStateL .~ st
+      pure . Right . TxId . hashAnnotated $ finalTx ^. bodyTxL
+    Left err -> pure $ Left err
+
+-- | Submit a transaction that is expected to be rejected. The inputs and
+-- outputs are automatically balanced.
+submitFailingTx ::
+  ( HasCallStack
+  , EraImpTest era
+  ) =>
+  Tx era ->
+  ImpTestM era ()
+submitFailingTx tx = trySubmitTx tx >>= impExpectFailure
+
+-- | Runs the TICK rule once
+passTick ::
+  forall era.
+  ( HasCallStack
+  , BaseM (EraRule "TICK" era) ~ ReaderT Globals Identity
+  , Environment (EraRule "TICK" era) ~ ()
+  , STS (EraRule "TICK" era)
+  , Signal (EraRule "TICK" era) ~ SlotNo
+  , State (EraRule "TICK" era) ~ NewEpochState era
+  , NFData (PredicateFailure (EraRule "TICK" era))
+  , NFData (State (EraRule "TICK" era))
+  ) =>
+  ImpTestM era ()
+passTick = do
+  impLastTick <- gets impLastTick
+  curNES <- getsNES id
+  let
+    trc = TRC ((), curNES, impLastTick)
+  res <-
+    impIOMsg "Failed to run TICK" $
+      pure $
+        runShelleyBase (applySTSTest @(EraRule "TICK" era) trc)
+  case res of
+    Right !x -> do
+      impLastTickL += 1
+      impNESL .= x
+    Left e ->
+      impIO . error $
+        unlines $
+          "Failed to run TICK:" : map show e
+
+-- | Runs the TICK rule until the next epoch is reached
+passEpoch ::
+  forall era.
+  ( BaseM (EraRule "TICK" era) ~ ReaderT Globals Identity
+  , Environment (EraRule "TICK" era) ~ ()
+  , STS (EraRule "TICK" era)
+  , Signal (EraRule "TICK" era) ~ SlotNo
+  , NFData (PredicateFailure (EraRule "TICK" era))
+  , NFData (State (EraRule "TICK" era))
+  , State (EraRule "TICK" era) ~ NewEpochState era
+  ) =>
+  ImpTestM era ()
+passEpoch = do
+  startEpoch <- getsNES nesELL
+  let
+    tickUntilNewEpoch curEpoch = do
+      passTick @era
+      newEpoch <- getsNES nesELL
+      if newEpoch > curEpoch
+        then logEntry $ "Entered " <> show newEpoch
+        else tickUntilNewEpoch newEpoch
+  tickUntilNewEpoch startEpoch
+
+-- | Stores extra information about the failure of the unit test
+data ImpException e = ImpException
+  { ieLog :: Doc ()
+  -- ^ Log entries up to the point where the test failed
+  , ieDescription :: String
+  -- ^ Description of the IO action that caused the failure
+  , ieThrownException :: e
+  -- ^ Exception that caused the test to fail
+  }
+
+instance Exception e => Show (ImpException e) where
+  show (ImpException msgLog msg e) =
+    "Log:\n"
+      <> renderString (layoutPretty defaultLayoutOptions msgLog)
+      <> "\nFailed at:\n\t"
+      <> msg
+      <> "\nException:\n\t"
+      <> displayException e
+
+instance Exception e => Exception (ImpException e)
+
+-- | Adds a string to the log, which is only shown if the test fails
+logEntry :: String -> ImpTestM era ()
+logEntry e = impLogL %= (<> pretty e <> line)
+
+-- | Make the `ImpTestM` into a Spec item with the given description
+itM ::
+  forall era a.
+  EraImpTest era =>
+  String ->
+  ImpTestM era a ->
+  Spec
+itM desc (ImpTestM m) =
+  it desc . void . execStateT m $
+    ImpTestState
+      { impNES = emptyImpNES rootCoin
+      , impRootTxCoin = rootCoin
+      , impRootTxId = TxId (mkDummySafeHash Proxy 0)
+      , impSafeHashIdx = 0
+      , impKeyPairs = mempty
+      , impLastTick = 0
+      , impLog = mempty
+      }
+  where
+    rootCoin = Coin 1_000_000_000
+
+-- | Returns the @TxWits@ needed for sumbmitting the transaction
+mkTxWits ::
+  ( HasCallStack
+  , EraImpTest era
+  ) =>
+  TxBody era ->
+  ImpTestM era (TxWits era)
+mkTxWits txb = do
+  nes <- getsNES id
+  keyPairs <- gets impKeyPairs
+  let
+    txbHash = hashAnnotated txb
+    witsNeeded =
+      impWitsVKeyNeeded nes txb
+    mkTxWit kh =
+      mkWitnessVKey txbHash
+        . fromMaybe (error "Could not find a keypair corresponding to keyhash. Always use `freshKeyHash` to create key hashes.")
+        $ Map.lookup kh keyPairs
+  pure $
+    mkBasicTxWits
+      & addrTxWitsL .~ Set.map mkTxWit witsNeeded
+
+-- | Creates a fresh @SafeHash@
+freshSafeHash :: Era era => ImpTestM era (SafeHash (EraCrypto era) a)
+freshSafeHash = do
+  ImpTestState {impSafeHashIdx} <- get
+  modify $ \st -> st {impSafeHashIdx = succ impSafeHashIdx}
+  pure $ mkDummySafeHash Proxy impSafeHashIdx
+
+-- | Adds a key pair to the keyhash lookup map
+addKeyPair :: Era era => KeyPair r (EraCrypto era) -> ImpTestM era ()
+addKeyPair kp@(KeyPair vk _) = do
+  ImpTestState {impKeyPairs} <- get
+  modify $ \st ->
+    st
+      { impKeyPairs =
+          Map.insert
+            (coerceKeyRole $ hashKey vk)
+            (coerce kp)
+            impKeyPairs
+      }
+
+-- | Looks up the keypair corresponding to the keyhash. The keyhash must be
+-- created with @freshKeyHash@ for this to work.
+lookupKeyPair :: HasCallStack => KeyHash r (EraCrypto era) -> ImpTestM era (KeyPair r (EraCrypto era))
+lookupKeyPair kh = do
+  ImpTestState {impKeyPairs} <- get
+  maybe (error $ "Could not find keyhash from the keypairs map: " ++ show kh) (pure . coerce) $
+    Map.lookup (coerceKeyRole kh) impKeyPairs
+
+-- | Generates a fresh keyhash and stores the corresponding keypair in the
+-- ImpTestState. Use @lookupKeyPair@ to look up the keypair corresponding to the
+-- keyhash
+freshKeyHash :: Era era => ImpTestM era (KeyHash r (EraCrypto era))
+freshKeyHash = do
+  ImpTestState {impKeyPairs} <- get
+  let kp@(KeyPair kh _) = mkKeyPair $ Map.size impKeyPairs
+  addKeyPair kp
+  pure $ hashKey kh
+
+-- | Modify the current new epoch state with a function
+modifyNES :: (NewEpochState era -> NewEpochState era) -> ImpTestM era ()
+modifyNES = (impNESL %=)
+
+-- | Get a value from the current new epoch state using the lens
+getsNES :: SimpleGetter (NewEpochState era) a -> ImpTestM era a
+getsNES l = gets . view $ impNESL . l
+
+-- | Runs an IO action and throws an @ImpException@ with the given message on
+-- failure
+impIOMsg :: NFData a => String -> IO a -> ImpTestM era a
+impIOMsg msg m = ImpTestM $ do
+  logs <- gets impLog
+  lift . catchAnyDeep m $ \(SomeException e) -> throwIO $ ImpException logs msg e
+
+-- | Runs an IO action and throws an @ImpException@ with a generic message on
+-- failure
+impIO :: NFData a => IO a -> ImpTestM era a
+impIO = impIOMsg ""
+
+submitTx ::
+  ( HasCallStack
+  , EraImpTest era
+  ) =>
+  String ->
+  Tx era ->
+  ImpTestM era (TxId (EraCrypto era))
+submitTx msg tx = logEntry msg >> trySubmitTx tx >>= impExpectSuccess
+
+impExpectSuccess :: (HasCallStack, NFData a, ToExpr e) => Either e a -> ImpTestM era a
+impExpectSuccess (Right x) = pure x
+impExpectSuccess (Left err) =
+  impIO . error $
+    "Expected success, got:\n" <> showExpr err
+
+impExpectFailure :: HasCallStack => Either a b -> ImpTestM era ()
+impExpectFailure (Right _) = impIO . error $ "Expected a failure, but got a success"
+impExpectFailure (Left _) = pure ()
+
+-- | Asserts that the URL of the current constitution is equal to the given
+-- string
+constitutionShouldBe :: (HasCallStack, EraGov era) => String -> ImpTestM era ()
+constitutionShouldBe cUrl = do
+  constitution <-
+    getsNES $
+      nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . to getConstitution
+  Constitution {constitutionAnchor = Anchor {anchorUrl}} <-
+    impIOMsg "Expecting a constitution" $ do
+      pure $
+        fromMaybe
+          (error "No constitution has been set")
+          constitution
+  impIO $ anchorUrl `shouldBe` fromJust (textToUrl $ T.pack cUrl)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTestSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTestSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.ImpTestSpec (
+  spec,
+) where
+
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (EraTx (..), EraTxBody (..), EraTxOut (..), coinTxOutL)
+import Cardano.Ledger.Shelley.LedgerState (esLStateL, lsCertStateL, lsUTxOStateL, nesELL, nesEsL, totalObligation, utxosDepositedL, utxosGovStateL, utxosUtxoL)
+import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Ledger.Val (Val (..))
+import Data.Data (Proxy (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Lens.Micro ((&), (.~), (^.))
+import Test.Cardano.Ledger.Common (Spec, describe, shouldBe)
+import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
+import Test.Cardano.Ledger.Shelley.ImpTest (EraImpTest, ImpTestM, freshKeyHash, getsNES, impIO, itM, lookupKeyPair, passEpoch, submitTx)
+
+getUTxO :: ImpTestM era (UTxO era)
+getUTxO = getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
+
+spec ::
+  forall era.
+  EraImpTest era =>
+  Proxy era ->
+  Spec
+spec _ = describe "ImpTest spec" $ do
+  itM @era "Runs basic transaction" $ do
+    do
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      govState <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+      impIO $ totalObligation certState govState `shouldBe` zero
+    do
+      deposited <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosDepositedL
+      impIO $ deposited `shouldBe` zero
+    _ <- submitTx "simple transaction" $ mkBasicTx mkBasicTxBody
+    passEpoch
+
+  itM @era "Crosses the epoch boundary" $ do
+    do
+      epoch <- getsNES nesELL
+      impIO $ epoch `shouldBe` 0
+    passEpoch
+    do
+      epoch <- getsNES nesELL
+      impIO $ epoch `shouldBe` 1
+  itM @era "Transactions update UTxO" $ do
+    kpPayment1 <- lookupKeyPair =<< freshKeyHash
+    kpStaking1 <- lookupKeyPair =<< freshKeyHash
+    UTxO utxo0 <- getUTxO
+    impIO $ length utxo0 `shouldBe` 1
+    let coin1 = Coin 1000
+    txId1 <-
+      submitTx "First transaction" . mkBasicTx $
+        mkBasicTxBody
+          & outputsTxBodyL @era
+            .~ SSeq.singleton
+              (mkBasicTxOut (mkAddr (kpPayment1, kpStaking1)) $ inject coin1)
+    UTxO utxo1 <- getUTxO
+    impIO $ case Map.lookup (TxIn txId1 $ TxIx 1) utxo1 of
+      Just out1 -> do
+        out1 ^. coinTxOutL `shouldBe` coin1
+      Nothing -> error "Could not find the TxOut of the first transaction"
+    kpPayment2 <- lookupKeyPair =<< freshKeyHash
+    kpStaking2 <- lookupKeyPair =<< freshKeyHash
+    let coin2 = Coin 500
+    txId2 <-
+      submitTx "Second transaction" . mkBasicTx $
+        mkBasicTxBody
+          & inputsTxBodyL
+            .~ Set.singleton
+              (TxIn txId1 $ TxIx 0)
+          & outputsTxBodyL @era
+            .~ SSeq.singleton
+              (mkBasicTxOut (mkAddr (kpPayment2, kpStaking2)) $ inject coin2)
+    UTxO utxo2 <- getUTxO
+    impIO $ case Map.lookup (TxIn txId2 $ TxIx 1) utxo2 of
+      Just out1 -> do
+        out1 ^. coinTxOutL `shouldBe` coin2
+      Nothing -> error "Could not find the TxOut of the second transaction"

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -393,11 +393,6 @@ exampleLedgerChainDepState seed =
 testEpochInfo :: EpochInfo Identity
 testEpochInfo = epochInfoPure testGlobals
 
-mkDummySafeHash :: forall c a. Crypto c => Proxy c -> Int -> SafeHash c a
-mkDummySafeHash _ =
-  unsafeMakeSafeHash
-    . mkDummyHash @(HASH c)
-
 mkDummyAnchor :: Crypto c => Int -> Anchor c
 mkDummyAnchor n =
   Anchor

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -26,9 +26,7 @@ module Test.Cardano.Ledger.Shelley.Utils (
   mkKESKeyPair,
   mkVRFKeyPair,
   runShelleyBase,
-  testGlobals,
   maxKESIterations,
-  unsafeBoundRational,
   slotsPerKESIteration,
   testSTS,
   maxLLSupply,
@@ -38,6 +36,7 @@ module Test.Cardano.Ledger.Shelley.Utils (
   ChainProperty,
   RawSeed (..),
   Split (..),
+  module CoreUtils,
 )
 where
 
@@ -66,11 +65,9 @@ import Cardano.Crypto.VRF (
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.BaseTypes (
   Globals (..),
-  Network (..),
   Nonce,
   ShelleyBase,
   epochInfoPure,
-  mkActiveSlotCoeff,
   mkNonceFromOutputVRF,
  )
 import Cardano.Ledger.Binary (EncCBOR (..), hashWithEncoder, shelleyProtVer)
@@ -87,9 +84,7 @@ import Cardano.Slotting.EpochInfo (
   epochInfoEpoch,
   epochInfoFirst,
   epochInfoSize,
-  fixedEpochInfo,
  )
-import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Control.Monad.Reader.Class (asks)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition.Extended hiding (Assertion)
@@ -101,11 +96,10 @@ import Control.State.Transition.Trace (
  )
 import Data.Coerce (Coercible, coerce)
 import Data.Functor.Identity (runIdentity)
-import Data.Time.Clock.POSIX
 import Data.Typeable (Proxy (Proxy))
 import Data.Word (Word64)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair, pattern KeyPair)
-import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
+import Test.Cardano.Ledger.Core.Utils as CoreUtils
 import Test.Cardano.Ledger.Shelley.Arbitrary (RawSeed (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (Mock)
 import Test.Cardano.Protocol.TPraos.Create (KESKeyPair (..), VRFKeyPair (..), evolveKESUntil)
@@ -220,23 +214,6 @@ mkKESKeyPair seed =
         { kesSignKey = sk
         , kesVerKey = deriveVerKeyKES sk
         }
-
-testGlobals :: Globals
-testGlobals =
-  Globals
-    { epochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
-    , slotsPerKESPeriod = 20
-    , stabilityWindow = 33
-    , randomnessStabilisationWindow = 33
-    , securityParameter = 10
-    , maxKESEvo = 10
-    , quorum = 5
-    , maxMajorPV = maxBound
-    , maxLovelaceSupply = 45 * 1000 * 1000 * 1000 * 1000 * 1000
-    , activeSlotCoeff = mkActiveSlotCoeff . unsafeBoundRational $ 0.9
-    , networkId = Testnet
-    , systemStart = SystemStart $ posixSecondsToUTCTime 0
-    }
 
 runShelleyBase :: ShelleyBase a -> a
 runShelleyBase act = runIdentity $ runReaderT act testGlobals

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### `testlib`
 
+* Add `testGlobals` and `mkDummySafeHash`
 * Add `Test.Cardano.Ledger.Core.Rational`
 
 ## 1.7.0.0

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -161,7 +161,9 @@ library testlib
         QuickCheck,
         random >=1.2,
         text,
-        vector-map
+        vector-map,
+        time,
+        cardano-slotting
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-name-shadowing

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
@@ -1,9 +1,27 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Test.Cardano.Ledger.Core.Utils (
   unsafeBoundRational,
   epsilonMaybeEq,
+  testGlobals,
+  mkDummySafeHash,
 )
 where
 
+import Cardano.Ledger.BaseTypes (
+  EpochSize (..),
+  Globals (..),
+  Network (..),
+  mkActiveSlotCoeff,
+ )
+import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.SafeHash (SafeHash, unsafeMakeSafeHash)
+import Cardano.Slotting.EpochInfo (fixedEpochInfo)
+import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
+import Data.Data (Proxy)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Rational (unsafeBoundRational)
 
@@ -26,3 +44,23 @@ epsilonMaybeEq epsilon x y =
     (absx, absy) = (abs x, abs y)
     n = epsilon * (1 + max absx absy)
     diff = abs (y - x)
+
+testGlobals :: Globals
+testGlobals =
+  Globals
+    { epochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
+    , slotsPerKESPeriod = 20
+    , stabilityWindow = 33
+    , randomnessStabilisationWindow = 33
+    , securityParameter = 10
+    , maxKESEvo = 10
+    , quorum = 5
+    , maxMajorPV = maxBound
+    , maxLovelaceSupply = 45 * 1000 * 1000 * 1000 * 1000 * 1000
+    , activeSlotCoeff = mkActiveSlotCoeff . unsafeBoundRational $ 0.9
+    , networkId = Testnet
+    , systemStart = SystemStart $ posixSecondsToUTCTime 0
+    }
+
+mkDummySafeHash :: forall c a. Crypto c => Proxy c -> Int -> SafeHash c a
+mkDummySafeHash _ = unsafeMakeSafeHash . mkDummyHash @(HASH c)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -72,6 +72,7 @@ import Lens.Micro
 import Test.Cardano.Ledger.Binary.TreeDiff (assertExprEqualWithMessage)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
+import qualified Test.Cardano.Ledger.Core.Utils as SLE
 import Test.Cardano.Ledger.Examples.BabbageFeatures (
   InitOutputs (..),
   KeyPairRole (..),


### PR DESCRIPTION
# Description

Moved `ImpTest` to core and added the `EraImpTest` class together with an instance in the `Conway` era. Moved some tests into `ImpTestSpec` in Shelley and made it run in every era.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
