### PR TITLE
Use a Data.OMap.Strict to replace ProposalsSnapshot

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.1.0
 
+* Switch to using `OMap` for `ProposalsSnapshot` #3791
 * Add `VotingOnExpiredGovAction` predicate failure in `GOV` #3825
 
 ### `testlib`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -75,7 +75,7 @@ library
         aeson >=2.2,
         data-default-class,
         cardano-crypto-class,
-        cardano-data >=1.1.1.0,
+        cardano-data >=1.1.2.0,
         cardano-ledger-binary >=1.2,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.5,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -14,6 +16,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Conway.Governance.Procedures (
@@ -105,6 +108,7 @@ import Data.Aeson.Types (toJSONKeyText)
 import Data.Default.Class
 import Data.Map.Strict (Map)
 import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.OMap.Strict as OMap
 import qualified Data.OSet.Strict as OSet
 import qualified Data.Sequence as Seq
 import Data.Set (Set)
@@ -263,6 +267,13 @@ instance EraPParams era => EncCBOR (GovActionState era) where
         !> To gasAction
         !> To gasProposedIn
         !> To gasExpiresAfter
+
+-- Ref: https://gitlab.haskell.org/ghc/ghc/-/issues/14046
+instance
+  c ~ EraCrypto era =>
+  OMap.HasOKey (GovActionId c) (GovActionState era)
+  where
+  okeyL = lens gasId $ \gas gi -> gas {gasId = gi}
 
 data Voter c
   = CommitteeVoter !(Credential 'HotCommitteeRole c)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
@@ -84,7 +84,7 @@ snapshotInsertGovAction ::
   ProposalsSnapshot era ->
   ProposalsSnapshot era
 snapshotInsertGovAction gas (ProposalsSnapshot omap) =
-  ProposalsSnapshot (omap OMap.:|>: gas)
+  ProposalsSnapshot (omap OMap.|> gas)
 
 snapshotActions ::
   ProposalsSnapshot era ->
@@ -127,7 +127,7 @@ snapshotRemoveIds ::
   ProposalsSnapshot era ->
   (ProposalsSnapshot era, Map.Map (GovActionId (EraCrypto era)) (GovActionState era))
 snapshotRemoveIds gais (ProposalsSnapshot omap) =
-  let (removed, retained) = OMap.extractKeys gais omap
+  let (retained, removed) = OMap.extractKeys gais omap
    in (ProposalsSnapshot retained, removed)
 
 snapshotLookupId ::

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Governance.Snapshots (
   ProposalsSnapshot,
@@ -32,25 +36,27 @@ import Cardano.Ledger.TreeDiff (ToExpr)
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON)
 import Data.Default.Class (Default (..))
-import Data.Foldable (Foldable (..))
-import Data.List (sort)
 import qualified Data.Map as Map
 import Data.Map.Strict (Map)
-import Data.MapExtras (extractKeys)
-import Data.Maybe (fromMaybe)
+import qualified Data.OMap.Strict as OMap
 import Data.Sequence.Strict (StrictSeq (..))
 import Data.Set (Set)
-import qualified Data.Set as Set
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', (%~))
+import Lens.Micro (Lens', lens, (%~))
 import NoThunks.Class (NoThunks)
 
-data ProposalsSnapshot era = ProposalsSnapshot
-  { psGovActionStates :: !(Map (GovActionId (EraCrypto era)) (GovActionState era))
-  , psProposalOrder :: !(StrictSeq (GovActionId (EraCrypto era)))
-  -- ^ Newer actions are near the end
-  }
-  deriving (Generic, Eq, Show)
+-- Ref: https://gitlab.haskell.org/ghc/ghc/-/issues/14046
+instance
+  c ~ EraCrypto era =>
+  OMap.HasOKey (GovActionId c) (GovActionState era)
+  where
+  okeyL = lens gasId $ \gas gi -> gas {gasId = gi}
+
+newtype ProposalsSnapshot era
+  = ProposalsSnapshot
+      (OMap.OMap (GovActionId (EraCrypto era)) (GovActionState era))
+  deriving newtype (Show, Eq)
+  deriving stock (Generic)
 
 instance EraPParams era => ToExpr (ProposalsSnapshot era)
 
@@ -61,7 +67,7 @@ instance EraPParams era => NFData (ProposalsSnapshot era)
 instance EraPParams era => NoThunks (ProposalsSnapshot era)
 
 instance Default (ProposalsSnapshot era) where
-  def = ProposalsSnapshot def def
+  def = ProposalsSnapshot def
 
 instance EraPParams era => EncCBOR (ProposalsSnapshot era) where
   encCBOR = encCBOR . snapshotActions
@@ -77,34 +83,23 @@ snapshotInsertGovAction ::
   GovActionState era ->
   ProposalsSnapshot era ->
   ProposalsSnapshot era
-snapshotInsertGovAction gas@GovActionState {gasId} ps@ProposalsSnapshot {..}
-  | Map.member gasId psGovActionStates =
-      ps {psGovActionStates = Map.insert gasId gas psGovActionStates}
-  | otherwise =
-      ProposalsSnapshot
-        { psGovActionStates = Map.insert gasId gas psGovActionStates
-        , psProposalOrder = psProposalOrder :|> gasId
-        }
+snapshotInsertGovAction gas (ProposalsSnapshot omap) =
+  ProposalsSnapshot (omap OMap.:|>: gas)
 
 snapshotActions ::
   ProposalsSnapshot era ->
   StrictSeq (GovActionState era)
-snapshotActions ProposalsSnapshot {..} = toGovAction <$> psProposalOrder
-  where
-    toGovAction gaId =
-      fromMaybe
-        (error $ "Impossible: ProposalsSnapshot invariant is not maintained: " <> show gaId)
-        (Map.lookup gaId psGovActionStates)
+snapshotActions (ProposalsSnapshot omap) = OMap.toStrictSeq omap
 
 snapshotIds ::
   ProposalsSnapshot era ->
   StrictSeq (GovActionId (EraCrypto era))
-snapshotIds = psProposalOrder
+snapshotIds (ProposalsSnapshot omap) = OMap.toStrictSeqOKeys omap
 
 snapshotGovActionStates ::
   ProposalsSnapshot era ->
   Map (GovActionId (EraCrypto era)) (GovActionState era)
-snapshotGovActionStates = psGovActionStates
+snapshotGovActionStates (ProposalsSnapshot omap) = OMap.toMap omap
 
 snapshotAddVote ::
   Voter (EraCrypto era) ->
@@ -112,10 +107,8 @@ snapshotAddVote ::
   GovActionId (EraCrypto era) ->
   ProposalsSnapshot era ->
   ProposalsSnapshot era
-snapshotAddVote voter vote gId ps@ProposalsSnapshot {..} =
-  ps
-    { psGovActionStates = Map.update (Just . updateVote) gId psGovActionStates
-    }
+snapshotAddVote voter vote gai (ProposalsSnapshot omap) =
+  ProposalsSnapshot $ OMap.adjust updateVote gai omap
   where
     insertVote ::
       Ord k =>
@@ -133,35 +126,24 @@ snapshotRemoveIds ::
   Set (GovActionId (EraCrypto era)) ->
   ProposalsSnapshot era ->
   (ProposalsSnapshot era, Map.Map (GovActionId (EraCrypto era)) (GovActionState era))
-snapshotRemoveIds gIds (ProposalsSnapshot {..}) = (retainedProposals, removedGovActionStates)
-  where
-    (retainedGovActionStates, removedGovActionStates) = psGovActionStates `extractKeys` gIds
-    retainedProposals =
-      ProposalsSnapshot
-        { psGovActionStates = retainedGovActionStates
-        , psProposalOrder =
-            foldl' (\s x -> if x `Set.member` gIds then s else x :<| s) mempty psProposalOrder
-        }
+snapshotRemoveIds gais (ProposalsSnapshot omap) =
+  let (removed, retained) = OMap.extractKeys gais omap
+   in (ProposalsSnapshot retained, removed)
 
 snapshotLookupId ::
   GovActionId (EraCrypto era) ->
   ProposalsSnapshot era ->
   Maybe (GovActionState era)
-snapshotLookupId gId ProposalsSnapshot {psGovActionStates} =
-  Map.lookup gId psGovActionStates
+snapshotLookupId gai (ProposalsSnapshot omap) = OMap.lookup gai omap
 
 -- | Converts a sequence of `GovActionState`s to a `ProposalsSnapshot`.
 --
 -- /Warning/ - This function expects `GovActionState`'s to have unique
 -- `GovActionId`s, because duplicate Ids will result in `GovActionStates`
 -- to be dropped.
-fromGovActionStateSeq ::
-  StrictSeq (GovActionState era) ->
-  ProposalsSnapshot era
-fromGovActionStateSeq = foldl' (flip snapshotInsertGovAction) def
+fromGovActionStateSeq :: StrictSeq (GovActionState era) -> ProposalsSnapshot era
+fromGovActionStateSeq = ProposalsSnapshot . OMap.fromStrictSeq
 
 -- | Internal function for checking if the invariants are maintained
-isConsistent_ :: ProposalsSnapshot era -> Bool
-isConsistent_ (ProposalsSnapshot {psGovActionStates, psProposalOrder}) =
-  Map.keys psGovActionStates == sort (toList psProposalOrder)
-    && all (\(k, GovActionState {gasId}) -> k == gasId) (Map.toList psGovActionStates)
+isConsistent_ :: EraPParams era => ProposalsSnapshot era -> Bool
+isConsistent_ (ProposalsSnapshot omap) = OMap.invariantHolds' omap

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Governance.Snapshots (
   ProposalsSnapshot,
@@ -43,15 +41,8 @@ import qualified Data.OMap.Strict as OMap
 import Data.Sequence.Strict (StrictSeq (..))
 import Data.Set (Set)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', lens, (%~))
+import Lens.Micro (Lens', (%~))
 import NoThunks.Class (NoThunks)
-
--- Ref: https://gitlab.haskell.org/ghc/ghc/-/issues/14046
-instance
-  c ~ EraCrypto era =>
-  OMap.HasOKey (GovActionId c) (GovActionState era)
-  where
-  okeyL = lens gasId $ \gas gi -> gas {gasId = gi}
 
 newtype ProposalsSnapshot era
   = ProposalsSnapshot
@@ -151,7 +142,7 @@ snapshotLookupId gai (ProposalsSnapshot omap) = OMap.lookup gai omap
 -- `GovActionId`s, because duplicate Ids will result in `GovActionStates`
 -- to be dropped.
 fromGovActionStateSeq :: StrictSeq (GovActionState era) -> ProposalsSnapshot era
-fromGovActionStateSeq = ProposalsSnapshot . OMap.fromStrictSeq
+fromGovActionStateSeq = ProposalsSnapshot . OMap.fromFoldable
 
 -- | Internal function for checking if the invariants are maintained
 isConsistent_ :: ProposalsSnapshot era -> Bool

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-data`
 
+## 1.1.2.0
+
+- Add Data.OMap.Strict #3791
+
 ## 1.1.1.0
 
 - Add Data.OSet.Strict #3779

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -64,7 +64,8 @@ library testlib
         hspec,
         QuickCheck,
         cardano-ledger-binary:testlib,
-        cardano-data
+        cardano-data,
+        microlens
 
 test-suite cardano-data-tests
     type:             exitcode-stdio-1.0

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -37,6 +37,7 @@ library
         cardano-ledger-binary >=1.2,
         cardano-strict-containers >=0.1.2.1,
         containers,
+        data-default-class,
         deepseq,
         mtl,
         nothunks,

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-data
-version:            1.1.1.0
+version:            1.1.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -23,6 +23,7 @@ library
         Data.ListMap
         Data.Universe
         Data.OSet.Strict
+        Data.OMap.Strict
 
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -39,7 +40,8 @@ library
         deepseq,
         mtl,
         nothunks,
-        vector
+        vector,
+        microlens
 
 library testlib
     exposed-modules:
@@ -55,6 +57,8 @@ library testlib
 
     build-depends:
         base,
+        cardano-data,
+        cardano-ledger-binary:testlib,
         containers,
         hspec,
         QuickCheck,
@@ -68,6 +72,7 @@ test-suite cardano-data-tests
     other-modules:
         Test.Cardano.Data.MapExtrasSpec
         Test.Cardano.Data.OSet.StrictSpec
+        Test.Cardano.Data.OMap.StrictSpec
 
     default-language: Haskell2010
     ghc-options:
@@ -77,11 +82,12 @@ test-suite cardano-data-tests
 
     build-depends:
         base,
+        cardano-strict-containers,
         containers,
         hspec,
         cardano-data,
         cardano-ledger-binary:testlib,
-        cardano-strict-containers,
         testlib,
         QuickCheck,
-        quickcheck-classes-base
+        quickcheck-classes-base,
+        microlens

--- a/libs/cardano-data/src/Data/OMap/Strict.hs
+++ b/libs/cardano-data/src/Data/OMap/Strict.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Data.OMap.Strict (
+  HasOKey (okeyL),
+  OMap (Empty, (:<|:), (:|>:)),
+  null,
+  size,
+  empty,
+  singleton,
+  lookup,
+  member,
+  (!?),
+  fromSet,
+  fromStrictSeq,
+  fromStrictSeqDuplicates,
+  toStrictSeq,
+  toStrictSeqOKeys,
+  toStrictSeqOfPairs,
+  invariantHolds,
+  invariantHolds',
+  (|>),
+  (<|),
+  (|><),
+  (><|),
+  elem,
+  filter,
+)
+where
+
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR (encCBOR), decodeDeduplicate, encodeStrictSeq, encodeTag, setTag)
+import Cardano.Ledger.Binary.Decoding (DecCBOR (decCBOR))
+import Data.Foldable qualified as F
+import Data.Map.Strict qualified as Map
+import Data.Sequence.Strict qualified as SSeq
+import Data.Set qualified as Set
+import Data.Typeable (Typeable)
+import GHC.Exts (IsList (..))
+import Lens.Micro
+import Prelude hiding (elem, filter, lookup, null, seq)
+
+-- | Class of types that can be mapped by a lens or a projection to a
+-- Ord type.
+--
+-- For a type @V@, defines a lens from @V@ to and Ord type @K@.
+class HasOKey k v | v -> k where
+  okeyL :: Lens' v k
+
+-- | A general-purpose finite, insert-ordered, map that is strict in its
+-- keys and values.
+--
+-- The strictness is enforced by the underlying strict `Map` that can
+-- be looked-up by a projection or lens. and the ordering is maintained
+-- by the constructing functions, leveraging `StrictSeq` to hold the
+-- insert-order of the values.
+--
+-- TODO: DecShareCBOR instance
+data OMap k v = OMap
+  { omSSeq :: !(SSeq.StrictSeq v)
+  , _omMap :: !(HasOKey k v => Map.Map k v)
+  }
+
+deriving instance (Show k, Show v, HasOKey k v) => Show (OMap k v)
+
+instance (Eq v, HasOKey k v) => Eq (OMap k v) where
+  (OMap seql _kvl) == (OMap seqr _kvr) = seql == seqr
+
+instance (HasOKey k v, Ord k) => Semigroup (OMap k v) where
+  (<>) = (|><)
+
+instance (HasOKey k v, Ord k) => Monoid (OMap k v) where
+  mempty = empty
+
+instance (HasOKey k v, Ord k) => IsList (OMap k v) where
+  type Item (OMap k v) = v
+  fromList = fromStrictSeq . SSeq.fromList
+  toList = F.toList . omSSeq
+
+instance Foldable (OMap k) where
+  foldMap f = F.foldMap f . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldMap #-}
+  foldr f z = F.foldr f z . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldr #-}
+  foldl f z = F.foldl f z . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldl #-}
+  foldr' f z = F.foldr' f z . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldr' #-}
+  foldl' f z = F.foldl' f z . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldl' #-}
+  foldr1 f = F.foldr1 f . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldr1 #-}
+  foldl1 f = F.foldl1 f . SSeq.fromStrict . omSSeq
+  {-# INLINEABLE foldl1 #-}
+  length = F.length . SSeq.fromStrict . omSSeq
+  {-# INLINE length #-}
+  null = F.null . SSeq.fromStrict . omSSeq
+  {-# INLINE null #-}
+
+instance (Typeable k, EncCBOR v) => EncCBOR (OMap k v) where
+  encCBOR (OMap seq _kv) = encodeTag setTag <> encodeStrictSeq encCBOR seq
+
+instance (Typeable k, HasOKey k v, DecCBOR v, Ord k) => DecCBOR (OMap k v) where
+  decCBOR = decodeDeduplicate decCBOR isMember insert
+    where
+      isMember = member . (^. okeyL)
+      insert v omap = omap |> (v ^. okeyL, v)
+
+-- | \(O(1)\). Shallow invariant using just `length` and `size`.
+invariantHolds :: HasOKey k v => OMap k v -> Bool
+invariantHolds (OMap seq kv) = SSeq.length seq == Map.size kv
+
+-- | \(O(n^2)\). Deep, costly invariant using membership check for each
+-- value. By the pigeon-hole principle, this check is exhaustive.
+invariantHolds' :: (HasOKey k v, Eq v) => OMap k v -> Bool
+invariantHolds' omap@(OMap seq kv) =
+  let vs = Map.elems kv
+   in invariantHolds omap && all (`F.elem` vs) seq
+
+-- | \(O(1)\).
+null :: OMap k v -> Bool
+null (OMap seq _) = SSeq.null seq
+
+-- | \(O(1)\).
+size :: OMap k v -> Int
+size (OMap seq _) = SSeq.length seq
+
+-- | \(O(1)\).
+empty :: OMap k v
+empty = OMap SSeq.Empty Map.empty
+
+-- | \(O(1)\). Strict in its arguments.
+singleton :: k -> v -> OMap k v
+singleton !k !v = OMap (SSeq.singleton v) (Map.singleton k v)
+
+-- | \(O(\log n)\). The element at the specified position, counting from
+-- 0. If the specified position is negative or at least the length of
+-- the sequence, 'lookup' returns 'Nothing'.
+lookup :: (HasOKey k v, Ord k) => k -> OMap k v -> Maybe v
+lookup k (OMap _seq kv) = Map.lookup k kv
+
+-- | `flip`ed version of `lookup`
+(!?) :: (HasOKey k v, Ord k) => OMap k v -> k -> Maybe v
+(!?) = flip lookup
+
+-- | \(O(\log n)\). Checks membership before cons'ing.
+cons :: (HasOKey k v, Ord k) => (k, v) -> OMap k v -> OMap k v
+cons (k, v) omap@(OMap seq kv) =
+  case Map.lookup k kv of
+    Just _ -> omap
+    Nothing -> OMap (v SSeq.<| seq) (Map.insert k v kv)
+
+(<|) :: (HasOKey k v, Ord k) => (k, v) -> OMap k v -> OMap k v
+(<|) = cons
+
+infixr 5 <|
+
+-- | \(O(\log n)\). Checks membership before snoc'ing.
+snoc :: (HasOKey k v, Ord k) => OMap k v -> (k, v) -> OMap k v
+snoc omap@(OMap seq kv) (k, v) =
+  case Map.lookup k kv of
+    Just _ -> omap
+    Nothing -> OMap (seq SSeq.|> v) (Map.insert k v kv)
+
+(|>) :: (HasOKey k v, Ord k) => OMap k v -> (k, v) -> OMap k v
+(|>) = snoc
+
+infixl 5 |>
+
+-- | \(O(\log n)\).
+uncons :: (HasOKey k v, Ord k) => OMap k v -> Maybe ((k, v), OMap k v)
+uncons (OMap seq kv) = case seq of
+  SSeq.Empty -> Nothing
+  v SSeq.:<| vs ->
+    let k = v ^. okeyL
+     in if Map.member k kv
+          then Just ((k, v), OMap vs (Map.delete k kv))
+          else error "Invariant falsified! In OMap, element from sequence not found in corresponding map"
+
+-- | \(O(\log n)\).
+unsnoc :: (HasOKey k v, Ord k) => OMap k v -> Maybe (OMap k v, (k, v))
+unsnoc (OMap seq kv) = case seq of
+  SSeq.Empty -> Nothing
+  vs SSeq.:|> v ->
+    let k = v ^. okeyL
+     in if Map.member k kv
+          then Just (OMap vs (Map.delete k kv), (k, v))
+          else error "Invariant falsified! In OMap, element from sequence not found in corresponding map"
+
+-- | \(O(n\log n)\). Checks membership before snoc'ing.
+-- De-duplicates the StrictSeq without overwriting.
+-- Starts from the left or head, using `foldl'`
+fromStrictSeq :: (HasOKey k v, Ord k) => SSeq.StrictSeq v -> OMap k v
+fromStrictSeq = F.foldl' snoc' empty
+  where
+    snoc' :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
+    snoc' omap@(OMap seq kv) v =
+      let k = v ^. okeyL
+       in if Map.member k kv
+            then omap
+            else OMap (seq SSeq.|> v) (Map.insert k v kv)
+
+-- | \(O(n\log n)\). Checks membership before snoc'ing.
+-- De-duplicates the StrictSeq and collects and returns the duplicates found.
+-- Starts from the left or head, using `foldl'`
+fromStrictSeqDuplicates :: (HasOKey k v, Ord k, Ord v) => SSeq.StrictSeq v -> (Set.Set v, OMap k v)
+fromStrictSeqDuplicates = F.foldl' snoc' (Set.empty, empty)
+  where
+    snoc' :: (HasOKey k v, Ord k, Ord v) => (Set.Set v, OMap k v) -> v -> (Set.Set v, OMap k v)
+    snoc' (duplicates, omap@(OMap seq kv)) v =
+      let k = v ^. okeyL
+       in if Map.member k kv
+            then (Set.insert v duplicates, omap)
+            else (duplicates, OMap (seq SSeq.|> v) (Map.insert k v kv))
+
+-- | \(O(n\log n)\).
+fromSet :: (HasOKey k v, Ord k) => Set.Set v -> OMap k v
+fromSet = fromStrictSeq . SSeq.fromList . Set.elems
+
+-- | \(O(1)\).
+toStrictSeq :: OMap k v -> SSeq.StrictSeq v
+toStrictSeq = omSSeq
+
+-- | \(O(n\log n)\).
+toStrictSeqOKeys :: HasOKey k v => OMap k v -> SSeq.StrictSeq k
+toStrictSeqOKeys = fmap (^. okeyL) . omSSeq
+
+-- | \(O(n\log n)\).
+toStrictSeqOfPairs :: HasOKey k v => OMap k v -> SSeq.StrictSeq (k, v)
+toStrictSeqOfPairs = fmap (\v -> (v ^. okeyL, v)) . omSSeq
+
+-- | \(O(\log n)\). Key membership check.
+member :: (HasOKey k v, Ord k) => k -> OMap k v -> Bool
+member k (OMap _seq kv) = Map.member k kv
+
+-- | \(O(\log n)\). Value membership check.
+elem :: (HasOKey k v, Ord k) => v -> OMap k v -> Bool
+elem v = member (v ^. okeyL)
+
+-- -- | \(O(n\log n)\)
+filter :: (HasOKey k v, Ord k) => (v -> Bool) -> OMap k v -> OMap k v
+filter f = F.foldl' combine empty
+  where
+    combine accum v =
+      if f v
+        then accum |> (v ^. okeyL, v)
+        else accum
+
+-- | \(O(1)\)
+pattern Empty :: OMap k v
+pattern Empty <- (null -> True)
+  where
+    Empty = empty
+
+-- | \(O(\log n)\).
+pattern (:<|:) :: (HasOKey k v, Ord k) => (k, v) -> OMap k v -> OMap k v
+pattern x :<|: xs <- (uncons -> Just (x, xs))
+  where
+    x :<|: xs = x <| xs
+
+infixr 5 :<|:
+
+-- | \(O(\log n)\).
+pattern (:|>:) :: (HasOKey k v, Ord k) => OMap k v -> (k, v) -> OMap k v
+pattern xs :|>: x <- (unsnoc -> Just (xs, x))
+  where
+    xs :|>: x = xs |> x
+
+infixl 5 :|>:
+
+{-# COMPLETE Empty, (:|>:) #-}
+{-# COMPLETE Empty, (:<|:) #-}
+
+-- | \( O(n\log(m*n)) \). For every uncons-ed element from the sequence on the right,
+-- check its membership in the sequence on the left, before snoc'ing it.
+-- Preserve order. Remove duplicates from sequence on the right.
+(|><) :: (HasOKey k v, Ord k) => OMap k v -> OMap k v -> OMap k v
+omapl |>< omapr = case omapr of
+  Empty -> omapl
+  r :<|: rs -> (omapl |> r) |>< rs
+
+infixl 5 |><
+
+-- | \( O(m\log(m+n)) \). For every unsnoc-ed element from the sequence on the left,
+-- check its membership in the sequence on the right, before cons'ing it.
+-- Preserve order. Remove duplicates from sequence on the left.
+(><|) :: (HasOKey k v, Ord k) => OMap k v -> OMap k v -> OMap k v
+omapl ><| omapr = case omapl of
+  Empty -> omapr
+  ls :|>: l -> ls ><| (l <| omapr)
+
+infixr 5 ><|

--- a/libs/cardano-data/src/Data/OMap/Strict.hs
+++ b/libs/cardano-data/src/Data/OMap/Strict.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -7,10 +9,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
 
 module Data.OMap.Strict (
   HasOKey (okeyL),
@@ -33,16 +34,26 @@ module Data.OMap.Strict (
   invariantHolds',
   (|>),
   (<|),
+  (<||),
+  (||>),
   (|><),
   (><|),
   elem,
-  filter,
-  adjust,
+  elem',
   extractKeys,
+  adjust,
+  filter,
 )
 where
 
-import Cardano.Ledger.Binary (DecCBOR, EncCBOR (encCBOR), decodeSetLikeEnforceNoDuplicates, encodeStrictSeq, encodeTag, setTag)
+import Cardano.Ledger.Binary (
+  DecCBOR,
+  EncCBOR (encCBOR),
+  decodeSetLikeEnforceNoDuplicates,
+  encodeStrictSeq,
+  encodeTag,
+  setTag,
+ )
 import Cardano.Ledger.Binary.Decoding (DecCBOR (decCBOR))
 import Cardano.Ledger.TreeDiff (ToExpr (..))
 import Control.DeepSeq (NFData (..))
@@ -51,16 +62,17 @@ import Data.Default.Class (Default (..))
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as Map
 import Data.MapExtras qualified as MapE
+import Data.Maybe (fromJust, isJust)
 import Data.Sequence.Strict qualified as SSeq
 import Data.Set qualified as Set
 import Data.Typeable (Typeable)
 import GHC.Exts (IsList (..))
+import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 import Prelude hiding (elem, filter, lookup, null, seq)
-import GHC.Generics (Generic)
 
--- | Class of types that can be mapped by a lens or a projection to a
+-- | Class of types that can be mapped by a lens or a projection to an
 -- Ord type.
 --
 -- For a type @V@, defines a lens from @V@ to and Ord type @K@.
@@ -73,89 +85,35 @@ class HasOKey k v | v -> k where
 -- The strictness is enforced by the underlying strict `Map` that can
 -- be looked-up by a projection or lens. and the ordering is maintained
 -- by the constructing functions, leveraging `StrictSeq` to hold the
--- insert-order of the values.
+-- insert-order of the keys.
 --
 -- TODO: DecShareCBOR instance
 data OMap k v = OMap
-  { omSSeq :: !(SSeq.StrictSeq v)
+  { omSSeq :: !(SSeq.StrictSeq k)
   , omMap :: !(Map.Map k v)
-  } deriving (Generic)
+  }
+  deriving (Generic, Show, Eq)
 
 deriving instance (NoThunks k, NoThunks v) => NoThunks (OMap k v)
 
-instance (HasOKey k v, ToExpr v) => ToExpr (OMap k v) where
-  listToExpr = listToExpr . F.toList
-  toExpr = toExpr . F.toList
+deriving instance (NFData k, NFData v) => NFData (OMap k v)
 
-instance (HasOKey k v, NFData v) => NFData (OMap k v) where
-  rnf = rnf . omSSeq
-
--- instance (HasOKey k v, NoThunks v) => NoThunks (OMap k v) where
---   noThunks ctx omap = noThunks ctx $ omSSeq omap
---   wNoThunks ctx omap = wNoThunks ctx $ omSSeq omap
---   showTypeOf = const "OMap"
-
-instance (HasOKey k v, ToJSON v) => ToJSON (OMap k v) where
-  toJSON = toJSON . omSSeq
-  toEncoding = toEncoding . omSSeq
-
-deriving instance (Show k, Show v, HasOKey k v) => Show (OMap k v)
-
-instance (Eq v, HasOKey k v) => Eq (OMap k v) where
-  (OMap seql _kvl) == (OMap seqr _kvr) = seql == seqr
+-- | \(O(1)\).
+empty :: OMap k v
+empty = OMap SSeq.Empty Map.empty
 
 instance Default (OMap k v) where
   def = empty
-
-instance (HasOKey k v, Ord k) => Semigroup (OMap k v) where
-  (<>) = (|><)
-
-instance (HasOKey k v, Ord k) => Monoid (OMap k v) where
-  mempty = empty
-
-instance (HasOKey k v, Ord k) => IsList (OMap k v) where
-  type Item (OMap k v) = v
-  fromList = fromStrictSeq . SSeq.fromList
-  toList = F.toList . omSSeq
-
-instance Foldable (OMap k) where
-  foldMap f = F.foldMap f . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldMap #-}
-  foldr f z = F.foldr f z . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldr #-}
-  foldl f z = F.foldl f z . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldl #-}
-  foldr' f z = F.foldr' f z . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldr' #-}
-  foldl' f z = F.foldl' f z . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldl' #-}
-  foldr1 f = F.foldr1 f . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldr1 #-}
-  foldl1 f = F.foldl1 f . SSeq.fromStrict . omSSeq
-  {-# INLINEABLE foldl1 #-}
-  length = F.length . SSeq.fromStrict . omSSeq
-  {-# INLINE length #-}
-  null = F.null . SSeq.fromStrict . omSSeq
-  {-# INLINE null #-}
-
-instance (Typeable k, EncCBOR v) => EncCBOR (OMap k v) where
-  encCBOR (OMap seq _kv) = encodeTag setTag <> encodeStrictSeq encCBOR seq
-
-instance (Typeable k, HasOKey k v, DecCBOR v, Ord k) => DecCBOR (OMap k v) where
-  decCBOR = decodeSetLikeEnforceNoDuplicates isMember insert decCBOR
-    where
-      isMember = member . (^. okeyL)
-      insert v omap = omap |> v
 
 -- | \(O(1)\). Shallow invariant using just `length` and `size`.
 invariantHolds :: OMap k v -> Bool
 invariantHolds (OMap seq kv) = SSeq.length seq == Map.size kv
 
--- | \(O(n^2)\). Deep, costly invariant using membership check for each
+-- | \(O(n \log n)\). Deep, costly invariant using membership check for each
 -- value. By the pigeon-hole principle, this check is exhaustive.
-invariantHolds' :: (HasOKey k v, Eq v, Ord k) => OMap k v -> Bool
+invariantHolds' :: Ord k => OMap k v -> Bool
 invariantHolds' omap@(OMap seq kv) =
-  invariantHolds omap && all (\v -> Map.lookup (v ^. okeyL) kv == Just v) seq
+  invariantHolds omap && all (\k -> isJust $ Map.lookup k kv) seq
 
 -- | \(O(1)\).
 null :: OMap k v -> Bool
@@ -165,22 +123,19 @@ null (OMap seq _) = SSeq.null seq
 size :: OMap k v -> Int
 size (OMap seq _) = SSeq.length seq
 
--- | \(O(1)\).
-empty :: OMap k v
-empty = OMap SSeq.Empty Map.empty
-
 -- | \(O(1)\). Strict in its arguments.
 singleton :: HasOKey k v => v -> OMap k v
-singleton !v = OMap (SSeq.singleton v) (Map.singleton (v ^. okeyL) v)
+singleton !v =
+  let k = v ^. okeyL
+   in OMap (SSeq.singleton k) (Map.singleton k v)
 
--- | \(O(\log n)\). The element at the specified position, counting from
--- 0. If the specified position is negative or at least the length of
--- the sequence, 'lookup' returns 'Nothing'.
-lookup :: ( Ord k) =>k -> OMap k v -> Maybe v
+-- | \(O(\log n)\). If the key is not present 'lookup' returns
+-- 'Nothing'.
+lookup :: Ord k => k -> OMap k v -> Maybe v
 lookup k (OMap _seq kv) = Map.lookup k kv
 
 -- | `flip`ed version of `lookup`
-(!?) :: ( Ord k) =>OMap k v -> k -> Maybe v
+(!?) :: Ord k => OMap k v -> k -> Maybe v
 (!?) = flip lookup
 
 -- | \(O(\log n)\). Checks membership before cons'ing.
@@ -189,12 +144,29 @@ cons v omap@(OMap seq kv) =
   let k = v ^. okeyL
    in case Map.lookup k kv of
         Just _ -> omap
-        Nothing -> OMap (v SSeq.<| seq) (Map.insert k v kv)
+        Nothing -> OMap (k SSeq.<| seq) (Map.insert k v kv)
 
+-- | \(O(\log n)\). Checks membership before cons'ing.
 (<|) :: (HasOKey k v, Ord k) => v -> OMap k v -> OMap k v
 (<|) = cons
 
 infixr 5 <|
+
+-- | \(O(\log n)\). Checks membership before cons'ing. Overwrites a
+-- duplicate.
+cons' :: (HasOKey k v, Ord k) => v -> OMap k v -> OMap k v
+cons' v (OMap seq kv) =
+  let k = v ^. okeyL
+   in case Map.lookup k kv of
+        Just _ -> OMap seq (Map.insert k v kv)
+        Nothing -> OMap (k SSeq.<| seq) (Map.insert k v kv)
+
+-- | \(O(\log n)\). Checks membership before cons'ing. Overwrites a
+-- duplicate.
+(<||) :: (HasOKey k v, Ord k) => v -> OMap k v -> OMap k v
+(<||) = cons'
+
+infixr 5 <||
 
 -- | \(O(\log n)\). Checks membership before snoc'ing.
 snoc :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
@@ -202,60 +174,75 @@ snoc omap@(OMap seq kv) v =
   let k = v ^. okeyL
    in case Map.lookup k kv of
         Just _ -> omap
-        Nothing -> OMap (seq SSeq.|> v) (Map.insert k v kv)
+        Nothing -> OMap (seq SSeq.|> k) (Map.insert k v kv)
 
+-- | \(O(\log n)\). Checks membership before snoc'ing.
 (|>) :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
 (|>) = snoc
 
 infixl 5 |>
 
+-- | \(O(\log n)\). Checks membership before snoc'ing. Overwrites a
+-- duplicate.
+snoc' :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
+snoc' (OMap seq kv) v =
+  let k = v ^. okeyL
+   in case Map.lookup k kv of
+        Just _ -> OMap seq (Map.insert k v kv)
+        Nothing -> OMap (seq SSeq.|> k) (Map.insert k v kv)
+
+-- | \(O(\log n)\). Checks membership before snoc'ing. Overwrites a
+-- duplicate.
+(||>) :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
+(||>) = snoc'
+
+infixl 5 ||>
+
 -- | \(O(\log n)\).
-uncons :: (HasOKey k v, Ord k) => OMap k v -> Maybe (v, OMap k v)
+uncons :: Ord k => OMap k v -> Maybe (v, OMap k v)
 uncons (OMap seq kv) = case seq of
   SSeq.Empty -> Nothing
-  v SSeq.:<| vs ->
-    let k = v ^. okeyL
-     in if Map.member k kv
-          then Just (v, OMap vs (Map.delete k kv))
-          else error "Invariant falsified! In OMap, element from sequence not found in corresponding map"
+  k SSeq.:<| ks ->
+    case Map.lookup k kv of
+      Just v -> Just (v, OMap ks (Map.delete k kv))
+      Nothing -> error "Invariant falsified! In OMap, key from sequence not found in corresponding map"
 
 -- | \(O(\log n)\).
-unsnoc :: (HasOKey k v, Ord k) => OMap k v -> Maybe (OMap k v, v)
+unsnoc :: Ord k => OMap k v -> Maybe (OMap k v, v)
 unsnoc (OMap seq kv) = case seq of
   SSeq.Empty -> Nothing
-  vs SSeq.:|> v ->
-    let k = v ^. okeyL
-     in if Map.member k kv
-          then Just (OMap vs (Map.delete k kv), v)
-          else error "Invariant falsified! In OMap, element from sequence not found in corresponding map"
+  ks SSeq.:|> k ->
+    case Map.lookup k kv of
+      Just v -> Just (OMap ks (Map.delete k kv), v)
+      Nothing -> error "Invariant falsified! In OMap, key from sequence not found in corresponding map"
 
--- | \(O(n\log n)\). Checks membership before snoc'ing.
+-- | \(O(n \log n)\). Checks membership before snoc'ing.
 -- De-duplicates the StrictSeq without overwriting.
 -- Starts from the left or head, using `foldl'`
 fromStrictSeq :: (HasOKey k v, Ord k) => SSeq.StrictSeq v -> OMap k v
-fromStrictSeq = F.foldl' snoc' empty
+fromStrictSeq = F.foldl' snoc_ empty
   where
-    snoc' :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
-    snoc' omap@(OMap seq kv) v =
+    snoc_ :: (HasOKey k v, Ord k) => OMap k v -> v -> OMap k v
+    snoc_ omap@(OMap seq kv) v =
       let k = v ^. okeyL
        in if Map.member k kv
             then omap
-            else OMap (seq SSeq.|> v) (Map.insert k v kv)
+            else OMap (seq SSeq.|> k) (Map.insert k v kv)
 
--- | \(O(n\log n)\). Checks membership before snoc'ing.
+-- | \(O(n \log n)\). Checks membership before snoc'ing.
 -- De-duplicates the StrictSeq and collects and returns the duplicates found.
 -- Starts from the left or head, using `foldl'`
 fromStrictSeqDuplicates :: (HasOKey k v, Ord k, Ord v) => SSeq.StrictSeq v -> (Set.Set v, OMap k v)
-fromStrictSeqDuplicates = F.foldl' snoc' (Set.empty, empty)
+fromStrictSeqDuplicates = F.foldl' snoc_ (Set.empty, empty)
   where
-    snoc' :: (HasOKey k v, Ord k, Ord v) => (Set.Set v, OMap k v) -> v -> (Set.Set v, OMap k v)
-    snoc' (duplicates, omap@(OMap seq kv)) v =
+    snoc_ :: (HasOKey k v, Ord k, Ord v) => (Set.Set v, OMap k v) -> v -> (Set.Set v, OMap k v)
+    snoc_ (duplicates, omap@(OMap seq kv)) v =
       let k = v ^. okeyL
        in if Map.member k kv
             then (Set.insert v duplicates, omap)
-            else (duplicates, OMap (seq SSeq.|> v) (Map.insert k v kv))
+            else (duplicates, OMap (seq SSeq.|> k) (Map.insert k v kv))
 
--- | \(O(n\log n)\).
+-- | \(O(n + n \log n)\).
 fromSet :: (HasOKey k v, Ord k) => Set.Set v -> OMap k v
 fromSet = fromStrictSeq . SSeq.fromList . Set.elems
 
@@ -263,62 +250,60 @@ fromSet = fromStrictSeq . SSeq.fromList . Set.elems
 toMap :: OMap k v -> Map.Map k v
 toMap = omMap
 
+-- | \(O(n \log n)\). Uses partial `fromJust`.
+toStrictSeq :: Ord k => OMap k v -> SSeq.StrictSeq v
+toStrictSeq (OMap seq kv) = fromJust $ traverse (`Map.lookup` kv) seq
+
 -- | \(O(1)\).
-toStrictSeq :: OMap k v -> SSeq.StrictSeq v
-toStrictSeq = omSSeq
+toStrictSeqOKeys :: OMap k v -> SSeq.StrictSeq k
+toStrictSeqOKeys = omSSeq
 
--- | \(O(n\log n)\).
-toStrictSeqOKeys :: HasOKey k v => OMap k v -> SSeq.StrictSeq k
-toStrictSeqOKeys = fmap (^. okeyL) . omSSeq
-
--- | \(O(n\log n)\).
-toStrictSeqOfPairs :: HasOKey k v => OMap k v -> SSeq.StrictSeq (k, v)
-toStrictSeqOfPairs = fmap (\v -> (v ^. okeyL, v)) . omSSeq
+-- | \(O(n \log n)\). Uses partial `fromJust`.
+toStrictSeqOfPairs :: Ord k => OMap k v -> SSeq.StrictSeq (k, v)
+toStrictSeqOfPairs (OMap seq kv) = fromJust $ traverse (\k -> (k,) <$> Map.lookup k kv) seq
 
 -- | \(O(\log n)\). Key membership check.
 member :: Ord k => k -> OMap k v -> Bool
 member k (OMap _seq kv) = Map.member k kv
 
--- | \(O(\log n)\). Value membership check.
+-- | \(O(\log n)\). Value membership check, via key membership.
 elem :: (HasOKey k v, Ord k) => v -> OMap k v -> Bool
 elem v = member (v ^. okeyL)
 
--- | \(O(n\log n)\)
-filter :: (HasOKey k v, Ord k) => (v -> Bool) -> OMap k v -> OMap k v
-filter f = F.foldl' combine empty
-  where
-    combine accum v =
-      if f v
-        then accum |> v
-        else accum
+-- | \(O(n)\). Expensive value membership check.
+elem' :: Eq v => v -> OMap k v -> Bool
+elem' v (OMap _seq kv) = F.elem v $ Map.elems kv
 
 -- | \(O(n)\). Given a `Set` of @k@s, and an `OMap` @k@ @v@ return
--- a pair of `Map` and `OMap` where the @ks@ in the `Set` have been
+-- a pair of `Map` and `OMap` where the @k@s in the `Set` have been
 -- removed from the `OMap` and presented as a separate `Map`.
-extractKeys :: (HasOKey k v, Ord k) => Set.Set k -> OMap k v -> (OMap k v, Map.Map k v)
+extractKeys :: Ord k => Set.Set k -> OMap k v -> (OMap k v, Map.Map k v)
 extractKeys ks (OMap seq kv) =
   let (kv', extractedKv) = MapE.extractKeys kv ks
       seq' =
         F.foldl'
-          (\accum v -> if Set.member (v ^. okeyL) ks then accum else accum SSeq.|> v)
+          (\accum k -> if Set.member k ks then accum else accum SSeq.|> k)
           SSeq.empty
           seq
    in (OMap seq' kv', extractedKv)
 
 -- | \(O(\log n)\). Like `Map.adjust`. Returns the original `OMap`
--- unaltered when the key does not exist in the `OMap` or when the
--- `OMap` invariant is not sustained after the operation.
+-- unaltered when the key does not exist in the `OMap`. Throws an error
+-- when the `OMap` invariant is not sustained after the operation.
+-- Does not touch the underlying `StrictSeq`.
 adjust :: (HasOKey k v, Ord k) => (v -> v) -> k -> OMap k v -> OMap k v
 adjust f k omap@(OMap seq kv) =
   case Map.lookup k kv of
     Nothing -> omap
-    Just v -> case SSeq.findIndexL (== v) seq of
-      Nothing -> omap
-      Just i -> 
-        let v' = f v
-         in if v' ^. okeyL == k
-              then OMap (SSeq.) (Map.insert k v' kv)
-              else omap
+    Just v ->
+      let v' = f v
+       in if v' ^. okeyL == k
+            then OMap seq (Map.insert k v' kv)
+            else
+              error $
+                "OMap invariant violated! The provided adjusting "
+                  <> "function is expected to only adjust the value without "
+                  <> "changing its `okeyL` lens."
 
 -- | \(O(1)\)
 pattern Empty :: OMap k v
@@ -345,7 +330,7 @@ infixl 5 :|>:
 {-# COMPLETE Empty, (:|>:) #-}
 {-# COMPLETE Empty, (:<|:) #-}
 
--- | \( O(n\log(m*n)) \). For every uncons-ed element from the sequence on the right,
+-- | \( O(n \log m) \). For every uncons-ed element from the sequence on the right,
 -- check its membership in the sequence on the left, before snoc'ing it.
 -- Preserve order. Remove duplicates from sequence on the right.
 (|><) :: (HasOKey k v, Ord k) => OMap k v -> OMap k v -> OMap k v
@@ -355,7 +340,7 @@ omapl |>< omapr = case omapr of
 
 infixl 5 |><
 
--- | \( O(m\log(m+n)) \). For every unsnoc-ed element from the sequence on the left,
+-- | \( O(m \log n) \). For every unsnoc-ed element from the sequence on the left,
 -- check its membership in the sequence on the right, before cons'ing it.
 -- Preserve order. Remove duplicates from sequence on the left.
 (><|) :: (HasOKey k v, Ord k) => OMap k v -> OMap k v -> OMap k v
@@ -364,3 +349,58 @@ omapl ><| omapr = case omapl of
   ls :|>: l -> ls ><| (l <| omapr)
 
 infixr 5 ><|
+
+instance (HasOKey k v, Ord k) => IsList (OMap k v) where
+  type Item (OMap k v) = v
+  fromList = fromStrictSeq . SSeq.fromList
+  toList = F.toList . toStrictSeq
+
+instance (HasOKey k v, ToExpr v, Ord k) => ToExpr (OMap k v) where
+  listToExpr = listToExpr . F.toList
+  toExpr = toExpr . F.toList
+
+instance (HasOKey k v, ToJSON v, Ord k) => ToJSON (OMap k v) where
+  toJSON = toJSON . toStrictSeq
+  toEncoding = toEncoding . toStrictSeq
+
+instance (HasOKey k v, Ord k) => Semigroup (OMap k v) where
+  (<>) = (|><)
+
+instance (HasOKey k v, Ord k) => Monoid (OMap k v) where
+  mempty = empty
+
+instance Ord k => Foldable (OMap k) where
+  foldMap f = F.foldMap f . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldMap #-}
+  foldr f z = F.foldr f z . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldr #-}
+  foldl f z = F.foldl f z . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldl #-}
+  foldr' f z = F.foldr' f z . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldr' #-}
+  foldl' f z = F.foldl' f z . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldl' #-}
+  foldr1 f = F.foldr1 f . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldr1 #-}
+  foldl1 f = F.foldl1 f . SSeq.fromStrict . toStrictSeq
+  {-# INLINEABLE foldl1 #-}
+  length = F.length . SSeq.fromStrict . toStrictSeq
+  {-# INLINE length #-}
+  null = F.null . SSeq.fromStrict . toStrictSeq
+  {-# INLINE null #-}
+
+instance (Typeable k, EncCBOR v, Ord k) => EncCBOR (OMap k v) where
+  encCBOR omap = encodeTag setTag <> encodeStrictSeq encCBOR (toStrictSeq omap)
+
+instance (Typeable k, HasOKey k v, DecCBOR v, Ord k) => DecCBOR (OMap k v) where
+  decCBOR = decodeSetLikeEnforceNoDuplicates isMember insert decCBOR
+    where
+      isMember = elem
+      insert v omap = omap |> v
+
+-- | \( O(n \log n) \)
+filter :: Ord k => (v -> Bool) -> OMap k v -> OMap k v
+filter f (OMap seq kv) =
+  let kv' = Map.filter f kv
+      seq' = F.foldl' (\accum k -> if Map.member k kv' then accum SSeq.:|> k else accum) SSeq.empty seq
+   in OMap seq' kv'

--- a/libs/cardano-data/test/Main.hs
+++ b/libs/cardano-data/test/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
 module Main where
 
 import System.IO (
@@ -8,7 +10,8 @@ import System.IO (
   utf8,
  )
 import Test.Cardano.Data.MapExtrasSpec (mapExtrasSpec)
-import qualified Test.Cardano.Data.OSet.StrictSpec as SOSet
+import Test.Cardano.Data.OMap.StrictSpec qualified as OMap
+import Test.Cardano.Data.OSet.StrictSpec qualified as OSet
 import Test.Hspec
 import Test.Hspec.Runner
 
@@ -23,7 +26,8 @@ spec :: Spec
 spec =
   describe "cardano-data" $ do
     describe "MapExtras" mapExtrasSpec
-    describe "OSet.Strict" SOSet.spec
+    describe "OSet.Strict" OSet.spec
+    describe "OMap.Strict" OMap.spec
 
 main :: IO ()
 main = do

--- a/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Data.OMap.StrictSpec where
+
+import Data.OMap.Strict
+import Data.Proxy (Proxy (Proxy))
+import Data.Sequence.Strict qualified as SSeq
+import Data.Set qualified as Set
+import Lens.Micro hiding (set)
+import Test.Cardano.Data.Arbitrary ()
+import Test.Cardano.Ledger.Binary.RoundTrip (roundTripCborSpec)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck.Classes.Base
+
+spec :: Spec
+spec =
+  describe "OMap.Strict" $ do
+    context "membership checks work" $ do
+      prop "unconsed" $ \(m :: OMap Int Int) -> case m of
+        Empty -> pure ()
+        (k, _v) :<|: _kv -> k `shouldSatisfy` (`member` m)
+      prop "unsnoced" $ \(m :: OMap Int Int) -> case m of
+        Empty -> pure ()
+        _kv :|>: (k, _v) -> k `shouldSatisfy` (`member` m)
+    context "when cons-ing" $ do
+      prop "adding a duplicate results in a no-op" $ \(m :: OMap Int Int) -> do
+        case m of
+          Empty -> pure ()
+          (k, v) :<|: _kv -> m `shouldBe` (k, v) <| m
+        case m of
+          Empty -> pure ()
+          _kv :|>: (k, v) -> m `shouldBe` (k, v) <| m
+      prop "new values get added" $ \((m, k, v) :: (OMap Int Int, Int, Int)) -> do
+        if k `member` m
+          then (k, v) <| m `shouldBe` m
+          else (k, v) <| m `shouldBe` (k, v) :<|: m
+    context "when snoc-ing" $ do
+      prop "adding a duplicate results in a no-op" $ \(m :: OMap Int Int) -> do
+        case m of
+          Empty -> pure ()
+          (k, v) :<|: _kv -> m `shouldBe` m |> (k, v)
+        case m of
+          Empty -> pure ()
+          _kv :|>: (k, v) -> m `shouldBe` m |> (k, v)
+      prop "new values get added" $ \((m, k, v) :: (OMap Int Int, Int, Int)) -> do
+        if k `member` m
+          then m |> (k, v) `shouldBe` m
+          else m |> (k, v) `shouldBe` m :|>: (k, v)
+    context "mappend preserves uniqueness" $ do
+      prop "mappending with itself should be a no-op" $ \(i :: OMap Int Int) -> do
+        i |>< i `shouldBe` i
+        i ><| i `shouldBe` i
+      prop "mappending with duplicates: left-preserving" $ \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
+        case j of
+          Empty -> i `shouldBe` i |>< j
+          j' :<|: _js -> i |>< j `shouldBe` (i |> j') |>< j
+      prop "mappending with duplicates: right-preserving" $ \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
+        case i of
+          Empty -> i ><| j `shouldBe` j
+          _is :|>: i' -> i ><| j `shouldBe` i ><| (i' <| j)
+    prop "operations preserve invariant" $
+      \((omap, omap', sseq, set) :: (OMap Int Int, OMap Int Int, SSeq.StrictSeq Int, Set.Set Int)) -> do
+        omap |>< omap' `shouldSatisfy` invariantHolds'
+        omap ><| omap' `shouldSatisfy` invariantHolds'
+        fromStrictSeq sseq `shouldSatisfy` invariantHolds'
+        fromSet set `shouldSatisfy` invariantHolds'
+    prop "fromStrictSeq preserves order" $
+      \(set :: Set.Set Int) ->
+        let sseq = SSeq.fromList $ Set.elems set
+         in toStrictSeq (fromStrictSeq sseq) `shouldBe` sseq
+    context "fromStrictSeqDuplicates" $ do
+      prop "with duplicates" $ \(set :: (Set.Set Int)) ->
+        let sseq = SSeq.fromList $ Set.elems set
+            omap = fromStrictSeq sseq
+         in fromStrictSeqDuplicates (sseq SSeq.>< sseq) `shouldBe` (set, omap)
+      prop "without duplicates" $ \(set :: (Set.Set Int)) ->
+        let sseq = SSeq.fromList $ Set.elems set
+            omap = fromStrictSeq sseq
+         in fromStrictSeqDuplicates sseq `shouldBe` (Set.empty, omap)
+    context "CBOR round-trip" $ do
+      roundTripCborSpec @(OMap Int Int)
+    context "Typeclass laws" $ do
+      it "Type" $
+        lawsCheckOne
+          (Proxy :: Proxy (OMap Int Int))
+          [ isListLaws
+          , semigroupLaws
+          , monoidLaws
+          , semigroupMonoidLaws
+          ]
+
+instance HasOKey Int Int where
+  okeyL = lens id const

--- a/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
@@ -1,11 +1,15 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Data.OMap.StrictSpec where
 
+import Control.Exception (evaluate)
+import Control.Monad (unless)
 import Data.OMap.Strict
 import Data.Proxy (Proxy (Proxy))
 import Data.Sequence.Strict qualified as SSeq
@@ -15,82 +19,148 @@ import Test.Cardano.Data.Arbitrary ()
 import Test.Cardano.Ledger.Binary.RoundTrip (roundTripCborSpec)
 import Test.Hspec
 import Test.Hspec.QuickCheck
+import Test.QuickCheck (Arbitrary)
+import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
 import Test.QuickCheck.Classes.Base
-import Prelude hiding (filter)
+import Prelude hiding (elem, filter, lookup, null)
 
 spec :: Spec
 spec =
   describe "OMap.Strict" $ do
     context "membership checks work" $ do
-      prop "unconsed" $ \(m :: OMap Int Int) -> case m of
-        Empty -> pure ()
-        v :<|: _kv -> v ^. okeyL `shouldSatisfy` (`member` m)
-      prop "unsnoced" $ \(m :: OMap Int Int) -> case m of
-        Empty -> pure ()
-        _kv :|>: v -> v ^. okeyL `shouldSatisfy` (`member` m)
+      prop "unconsed" $
+        \(m :: OMap Int Int) -> case m of
+          Empty -> pure ()
+          v :<|: _kv -> v ^. okeyL `shouldSatisfy` (`member` m)
+      prop "unsnoced" $
+        \(m :: OMap Int Int) -> case m of
+          Empty -> pure ()
+          _kv :|>: v -> v ^. okeyL `shouldSatisfy` (`member` m)
     context "when cons-ing" $ do
-      prop "adding a duplicate results in a no-op" $ \(m :: OMap Int Int) -> do
-        case m of
-          Empty -> pure ()
-          v :<|: _kv -> m `shouldBe` v <| m
-        case m of
-          Empty -> pure ()
-          _kv :|>: v -> m `shouldBe` v <| m
-      prop "new values get added" $ \((m, v) :: (OMap Int Int, Int)) -> do
-        if (v ^. okeyL) `member` m
-          then v <| m `shouldBe` m
-          else v <| m `shouldBe` v :<|: m
+      prop "adding a duplicate results in a no-op" $
+        \(m :: OMap Int Int) -> do
+          case m of
+            Empty -> pure ()
+            v :<|: _kv -> m `shouldBe` v <| m
+          case m of
+            Empty -> pure ()
+            _kv :|>: v -> m `shouldBe` v <| m
+      prop "new values get added" $
+        \((m, v) :: (OMap Int Int, Int)) ->
+          if v `elem` m
+            then v <| m `shouldBe` m
+            else v <| m `shouldBe` v :<|: m
     context "when snoc-ing" $ do
-      prop "adding a duplicate results in a no-op" $ \(m :: OMap Int Int) -> do
-        case m of
-          Empty -> pure ()
-          v :<|: _kv -> m `shouldBe` m |> v
-        case m of
-          Empty -> pure ()
-          _kv :|>: v -> m `shouldBe` m |> v
-      prop "new values get added" $ \((m, v) :: (OMap Int Int, Int)) -> do
-        if (v ^. okeyL) `member` m
-          then m |> v `shouldBe` m
-          else m |> v `shouldBe` m :|>: v
+      prop "adding a duplicate results in a no-op" $
+        \(m :: OMap Int Int) -> do
+          case m of
+            Empty -> pure ()
+            v :<|: _kv -> m `shouldBe` m |> v
+          case m of
+            Empty -> pure ()
+            _kv :|>: v -> m `shouldBe` m |> v
+      prop "new values get added" $
+        \((m, v) :: (OMap Int Int, Int)) ->
+          if v `elem` m
+            then m |> v `shouldBe` m
+            else m |> v `shouldBe` m :|>: v
     context "mappend preserves uniqueness" $ do
-      prop "mappending with itself should be a no-op" $ \(i :: OMap Int Int) -> do
-        i |>< i `shouldBe` i
-        i ><| i `shouldBe` i
-      prop "mappending with duplicates: left-preserving" $ \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
-        case j of
-          Empty -> i `shouldBe` i |>< j
-          j' :<|: _js -> i |>< j `shouldBe` (i |> j') |>< j
-      prop "mappending with duplicates: right-preserving" $ \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
-        case i of
-          Empty -> i ><| j `shouldBe` j
-          _is :|>: i' -> i ><| j `shouldBe` i ><| (i' <| j)
-    prop "filter and extractKeys" $
-      \((omap, set, i) :: (OMap Int Int, Set.Set Int, Int)) -> do
-        filter (< i) omap `shouldSatisfy` all (< i)
-        extractKeys set omap `shouldSatisfy` (all (`Set.member` set) . snd)
-        extractKeys set omap `shouldSatisfy` (all (`Set.notMember` set) . fst)
-    prop "operations preserve invariant" $
-      \((omap, omap', sseq, set, i) :: (OMap Int Int, OMap Int Int, SSeq.StrictSeq Int, Set.Set Int, Int)) -> do
-        omap |>< omap' `shouldSatisfy` invariantHolds'
-        omap ><| omap' `shouldSatisfy` invariantHolds'
-        fromStrictSeq sseq `shouldSatisfy` invariantHolds'
-        fromSet set `shouldSatisfy` invariantHolds'
-        filter (> i) omap `shouldSatisfy` invariantHolds'
-        extractKeys set omap `shouldSatisfy` invariantHolds' . fst
-        adjust id i omap `shouldSatisfy` invariantHolds'
+      prop "mappending with itself should be a no-op" $
+        \(i :: OMap Int Int) ->
+          let il = i |>< i
+              ir = i ><| i
+           in do
+                il `shouldBe` i
+                ir `shouldBe` i
+                il `shouldSatisfy` invariantHolds'
+                ir `shouldSatisfy` invariantHolds'
+      prop "mappending with duplicates: left-preserving" $
+        \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
+          case j of
+            Empty -> i `shouldBe` i |>< j
+            j' :<|: _js ->
+              let result = i |>< j
+               in do
+                    result `shouldBe` (i |> j') |>< j
+                    result `shouldSatisfy` invariantHolds'
+      prop "mappending with duplicates: right-preserving" $
+        \((i, j) :: (OMap Int Int, OMap Int Int)) -> do
+          case i of
+            Empty -> i ><| j `shouldBe` j
+            _is :|>: i' ->
+              let result = i ><| j
+               in do
+                    result `shouldBe` i ><| (i' <| j)
+                    result `shouldSatisfy` invariantHolds'
+    prop "extractKeys should satisfy membership" $
+      \((omap, set) :: (OMap Int Int, Set.Set Int)) ->
+        let result = extractKeys set omap
+         in do
+              result `shouldSatisfy` (all (`Set.notMember` set) . fst)
+              result `shouldSatisfy` (all (`Set.member` set) . snd)
+              result `shouldSatisfy` invariantHolds' . fst
+    prop "filter" $
+      \((omap, i) :: (OMap Int Int, Int)) ->
+        let result = filter (< i) omap
+         in do
+              result `shouldSatisfy` all (< i)
+              result `shouldSatisfy` invariantHolds'
+    prop "adjust" $
+      \((omap, i) :: (OMap Int OMapTest, Int)) ->
+        let validAdjustingFn omt@OMapTest {omSnd} = omt {omSnd = omSnd + 1}
+            -- Changes the `okeyL`. Violates the invariant.
+            invalidAdjustingFn omt@OMapTest {omFst} = omt {omFst = omFst + 1}
+         in do
+              adjust validAdjustingFn i omap `shouldSatisfy` invariantHolds'
+              unless (null omap || not (member i omap)) $
+                evaluate (adjust invalidAdjustingFn i omap) `shouldThrow` anyErrorCall
+    context "overwriting" $ do
+      prop "cons' - (<||)" $
+        \((omap, i) :: (OMap Int OMapTest, OMapTest)) ->
+          let consed = i <|| omap
+           in if i `elem` omap
+                then
+                  let adjusted = adjust (const i) (i ^. okeyL) omap
+                   in do
+                        consed `shouldBe` adjusted
+                else do
+                  consed `shouldBe` i <| omap
+      prop "snoc' - (||>)" $
+        \((omap, i) :: (OMap Int OMapTest, OMapTest)) ->
+          let snoced = omap ||> i
+           in if i `elem` omap
+                then
+                  let adjusted = adjust (const i) (i ^. okeyL) omap
+                   in do
+                        snoced `shouldBe` adjusted
+                else do
+                  snoced `shouldBe` omap |> i
     prop "fromStrictSeq preserves order" $
       \(set :: Set.Set Int) ->
         let sseq = SSeq.fromList $ Set.elems set
-         in toStrictSeq (fromStrictSeq sseq) `shouldBe` sseq
-    context "fromStrictSeqDuplicates" $ do
-      prop "with duplicates" $ \(set :: (Set.Set Int)) ->
-        let sseq = SSeq.fromList $ Set.elems set
             omap = fromStrictSeq sseq
-         in fromStrictSeqDuplicates (sseq SSeq.>< sseq) `shouldBe` (set, omap)
-      prop "without duplicates" $ \(set :: (Set.Set Int)) ->
-        let sseq = SSeq.fromList $ Set.elems set
-            omap = fromStrictSeq sseq
-         in fromStrictSeqDuplicates sseq `shouldBe` (Set.empty, omap)
+         in do
+              toStrictSeq omap `shouldBe` sseq
+              omap `shouldSatisfy` invariantHolds'
+    context "fromStrictSeqDuplicates preserves order" $ do
+      prop "with duplicates" $
+        \(set :: Set.Set Int) ->
+          let sseq = SSeq.fromList $ Set.elems set
+              omap = fromStrictSeq sseq
+              result = fromStrictSeqDuplicates (sseq SSeq.>< sseq)
+           in do
+                (toStrictSeq . snd) result `shouldBe` sseq
+                result `shouldBe` (set, omap)
+                snd result `shouldSatisfy` invariantHolds'
+      prop "without duplicates" $
+        \(set :: Set.Set Int) ->
+          let sseq = SSeq.fromList $ Set.elems set
+              omap = fromStrictSeq sseq
+              result = fromStrictSeqDuplicates sseq
+           in do
+                (toStrictSeq . snd) result `shouldBe` sseq
+                result `shouldBe` (Set.empty, omap)
+                snd result `shouldSatisfy` invariantHolds'
     context "CBOR round-trip" $ do
       roundTripCborSpec @(OMap Int Int)
     context "Typeclass laws" $ do
@@ -105,3 +175,12 @@ spec =
 
 instance HasOKey Int Int where
   okeyL = lens id const
+
+data OMapTest = OMapTest {omFst :: Int, omSnd :: Int}
+  deriving (Eq, Show, Ord)
+
+instance HasOKey Int OMapTest where
+  okeyL = lens omFst $ \om u -> om {omFst = u}
+
+instance Arbitrary OMapTest where
+  arbitrary = OMapTest <$> arbitrary <*> arbitrary

--- a/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
@@ -8,8 +8,6 @@
 
 module Test.Cardano.Data.OMap.StrictSpec where
 
-import Control.Exception (evaluate)
-import Control.Monad (unless)
 import Data.OMap.Strict
 import Data.Proxy (Proxy (Proxy))
 import Data.Sequence.Strict qualified as SSeq
@@ -107,13 +105,11 @@ spec =
               result `shouldSatisfy` invariantHolds'
     prop "adjust" $
       \((omap, i) :: (OMap Int OMapTest, Int)) ->
-        let validAdjustingFn omt@OMapTest {omSnd} = omt {omSnd = omSnd + 1}
-            -- Changes the `okeyL`. Violates the invariant.
-            invalidAdjustingFn omt@OMapTest {omFst} = omt {omFst = omFst + 1}
+        let adjustingFn omt@OMapTest {omSnd} = omt {omSnd = omSnd + 1}
+            overwritingAdjustingFn omt@OMapTest {omFst} = omt {omFst = omFst + 1} -- Changes the `okeyL`.
          in do
-              adjust validAdjustingFn i omap `shouldSatisfy` invariantHolds'
-              unless (null omap || not (member i omap)) $
-                evaluate (adjust invalidAdjustingFn i omap) `shouldThrow` anyErrorCall
+              adjust adjustingFn i omap `shouldSatisfy` invariantHolds'
+              adjust overwritingAdjustingFn i omap `shouldSatisfy` invariantHolds'
     context "overwriting" $ do
       prop "cons' - (<||)" $
         \((omap, i) :: (OMap Int OMapTest, OMapTest)) ->

--- a/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
@@ -67,8 +67,8 @@ spec =
     prop "filter and extractKeys" $
       \((omap, set, i) :: (OMap Int Int, Set.Set Int, Int)) -> do
         filter (< i) omap `shouldSatisfy` all (< i)
-        extractKeys set omap `shouldSatisfy` (all (`Set.member` set) . fst)
-        extractKeys set omap `shouldSatisfy` (all (`Set.notMember` set) . snd)
+        extractKeys set omap `shouldSatisfy` (all (`Set.member` set) . snd)
+        extractKeys set omap `shouldSatisfy` (all (`Set.notMember` set) . fst)
     prop "operations preserve invariant" $
       \((omap, omap', sseq, set, i) :: (OMap Int Int, OMap Int Int, SSeq.StrictSeq Int, Set.Set Int, Int)) -> do
         omap |>< omap' `shouldSatisfy` invariantHolds'
@@ -76,7 +76,8 @@ spec =
         fromStrictSeq sseq `shouldSatisfy` invariantHolds'
         fromSet set `shouldSatisfy` invariantHolds'
         filter (> i) omap `shouldSatisfy` invariantHolds'
-        extractKeys set omap `shouldSatisfy` invariantHolds' . snd
+        extractKeys set omap `shouldSatisfy` invariantHolds' . fst
+        adjust id i omap `shouldSatisfy` invariantHolds'
     prop "fromStrictSeq preserves order" $
       \(set :: Set.Set Int) ->
         let sseq = SSeq.fromList $ Set.elems set

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Data.Arbitrary where
 
-import Data.OSet.Strict
+import Data.OMap.Strict qualified as OMap
+import Data.OSet.Strict qualified as OSet
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.QuickCheck
 
-instance (Arbitrary a, Ord a) => Arbitrary (OSet a) where
-  arbitrary = fromSet <$> arbitrary
+instance (Arbitrary a, Ord a) => Arbitrary (OSet.OSet a) where
+  arbitrary = OSet.fromSet <$> arbitrary
+
+instance (Ord k, Ord v, Arbitrary v, OMap.HasOKey k v) => Arbitrary (OMap.OMap k v) where
+  arbitrary = OMap.fromSet <$> arbitrary

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -4,13 +4,17 @@
 
 module Test.Cardano.Data.Arbitrary where
 
+import Data.Map.Strict qualified as Map
 import Data.OMap.Strict qualified as OMap
 import Data.OSet.Strict qualified as OSet
+import Data.Set qualified as Set
+import Lens.Micro (set)
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.QuickCheck
 
 instance (Arbitrary a, Ord a) => Arbitrary (OSet.OSet a) where
-  arbitrary = OSet.fromSet <$> arbitrary
+  arbitrary = fmap (OSet.fromSet . Set.fromList) . shuffle . Set.toList =<< arbitrary
 
-instance (Ord k, Ord v, Arbitrary v, OMap.HasOKey k v) => Arbitrary (OMap.OMap k v) where
-  arbitrary = OMap.fromSet <$> arbitrary
+instance (Ord v, Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
+  arbitrary =
+    fmap OMap.fromFoldable . shuffle . Map.elems . Map.mapWithKey (flip (set OMap.okeyL)) =<< arbitrary

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.1.0
 
+* Export `decodeListLikeEnforceNoDuplicates` #3791
 * Add `Show` and `Eq` for `CBORGroup`
 
 ### `testlib`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -845,7 +845,7 @@ decodeListLikeEnforceNoDuplicates ::
   Monoid (f a) =>
   -- | Check for membership. Decoder will fail if this predicate returns True
   (a -> f a -> Bool) ->
-  -- | Add an aelement into the decoded List like data structure
+  -- | Add an element into the decoded List like data structure
   (a -> f a -> f a) ->
   Decoder s a ->
   Decoder s (f a)


### PR DESCRIPTION
# Description

Closes #3789

- [x] Merge #3779 first.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
