### PR TITLE
RATIFY and GOV constraint tests

### DIFF
--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -16,6 +16,10 @@
   * `ConwayGovCertEnv`
   * `PoolEnv`
   * `EnactSignal`
+  * `RatifyEnv`
+  * `RatifySignal`
+  * `GovEnv`
+  * `VotingProcedures`
 
 ## 1.3.2.0
 

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -367,11 +367,7 @@ ppSet :: (x -> Doc ann) -> Set x -> Doc ann
 ppSet p xs = encloseSep lbrace rbrace comma (map p (toList xs))
 
 ppList :: (x -> Doc ann) -> [x] -> Doc ann
-ppList p xs =
-  group $
-    flatAlt
-      (puncLeft lbracket (map p xs) comma rbracket)
-      (encloseSep (lbracket <> space) (space <> rbracket) (comma <> space) (map p xs))
+ppList p xs = brackets $ fillSep $ punctuate comma $ map p xs
 
 ppStrictSeq :: (a -> Doc ann) -> StrictSeq a -> Doc ann
 ppStrictSeq p xs = ppList p (foldr (:) [] xs)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
-import Cardano.Ledger.Pretty (PDoc, ppString)
+import Cardano.Ledger.Pretty (PDoc, PrettyA, ppString)
 import Cardano.Ledger.Shelley.Governance (ShelleyGovState (..))
 import qualified Cardano.Ledger.Shelley.Governance as Gov (GovState (..))
 import Cardano.Ledger.Shelley.PParams (pvCanFollow)
@@ -520,7 +520,7 @@ data TxF era where
 unTxF :: TxF era -> Tx era
 unTxF (TxF _ x) = x
 
-instance Show (TxF era) where
+instance PrettyA (PParamsUpdate era) => Show (TxF era) where
   show (TxF p x) = show ((unReflect pcTx p x) :: PDoc)
 
 instance Eq (TxF era) where
@@ -558,7 +558,7 @@ data TxBodyF era where
 unTxBodyF :: TxBodyF era -> TxBody era
 unTxBodyF (TxBodyF _ x) = x
 
-instance Show (TxBodyF era) where
+instance PrettyA (PParamsUpdate era) => Show (TxBodyF era) where
   show (TxBodyF p x) = show ((unReflect pcTxBody p x) :: PDoc)
 
 instance Eq (TxBodyF era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Provides variables (V era t), and mappings of them to objects of type 't'

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -53,14 +53,25 @@ manyCoin size = do
 vstatePreds :: Era era => Proof era -> [Pred era]
 vstatePreds p = vstateGenPreds p ++ vstateCheckPreds p
 
-vstateGenPreds :: Era era => Proof era -> [Pred era]
+vstateGenPreds :: forall era. Era era => Proof era -> [Pred era]
 vstateGenPreds p = case whichPParams p of
   PParamsConwayToConway ->
-    [ Sized (Range 10 20) currentDRepState
+    [ MetaSize (SzRng 5 15) currentDRepStateSize
+    , Sized currentDRepStateSize currentDRepState
     , Sized (Range 5 7) (Dom committeeState)
     , Subset (Dom currentDRepState) voteUniv
     , Subset (Dom committeeState) voteCredUniv
-    , Random numDormantEpochs
+    , Sized (Range 0 5) numDormantEpochs
+    , ForEach
+        currentDRepStateSize
+        drepStateList
+        (Pat DRepStateR [Arg expire, Arg anchor, Arg deposit])
+        [ Random (fieldToTerm anchor)
+        , GenFrom (fieldToTerm expire) (Constr "+200To500" (\(EpochNo n) -> EpochNo <$> choose (n + 200, n + 500)) ^$ currentEpoch)
+        , drepDeposit p :=: (fieldToTerm deposit)
+        ]
+    , drepStateList :=: (Elems currentDRepState)
+    , SumsTo (Left (Coin 1)) totalDRepDeposit EQL [ProjMap CoinR drepDepositL currentDRepState]
     ]
   _ ->
     [ Sized (Range 0 0) currentDRepState
@@ -68,29 +79,16 @@ vstateGenPreds p = case whichPParams p of
     , Lit EpochR (EpochNo 0) :=: numDormantEpochs
     , Random currentDRepState
     ]
-
-vstateCheckPreds :: forall era. Era era => Proof era -> [Pred era]
-vstateCheckPreds p = case whichPParams p of
-  PParamsConwayToConway ->
-    [ ForEach
-        (Range 25 25) -- It is possible we create duplicates, so we make a few more than 20 (the size of drepState)
-        drepStateSet
-        (Pat DRepStateR [Arg expire, Arg anchor, Arg deposit])
-        [ Random (fieldToTerm anchor)
-        , GenFrom (fieldToTerm expire) (Constr "+200To500" (\(EpochNo n) -> EpochNo <$> choose (n + 200, n + 500)) ^$ currentEpoch)
-        , drepDeposit p :=: (fieldToTerm deposit)
-        ]
-    , Subset (Rng currentDRepState) drepStateSet
-    , SumsTo (Right (Coin 1)) totalDRepDeposit EQL [ProjMap CoinR drepDepositL currentDRepState]
-    , SumsTo (Left (Coin 1)) totalDRepDeposit EQL [SumList (Elems drepDeposits)]
-    ]
-  _ -> []
   where
-    drepStateSet = Var $ pV p "drepStateSet" (SetR DRepStateR) No
+    drepStateList = Var $ pV p "drepStateList" (ListR DRepStateR) No
     deposit = Field @era "deposit" CoinR DRepStateR drepDepositL
-    totalDRepDeposit = Var $ pV p "totalDRepDeposit" CoinR No
     anchor = Field @era "anchor" (MaybeR AnchorR) DRepStateR (drepAnchorL . strictMaybeToMaybeL)
     expire = Field @era "expire" EpochR DRepStateR drepExpiryL
+    totalDRepDeposit = Var $ pV p "totalDRepDeposit" CoinR No
+    currentDRepStateSize = Var $ pV p "currentDRepStateSize" SizeR No
+
+vstateCheckPreds :: Proof era -> [Pred era]
+vstateCheckPreds _p = []
 
 vstateStage ::
   Reflect era =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -34,6 +34,17 @@ import Test.Tasty (TestTree, defaultMain)
 
 -- =========================================
 
+prevGovActionIdsGenPreds :: Reflect era => Proof era -> [Pred era]
+prevGovActionIdsGenPreds _ =
+  [ Random prevPParamUpdate
+  , Random prevHardFork
+  , Random prevCommittee
+  , Random prevConstitution
+  ]
+
+prevGovActionIdsCheckPreds :: Proof era -> [Pred era]
+prevGovActionIdsCheckPreds _ = []
+
 enactStateGenPreds :: Reflect era => Proof era -> [Pred era]
 enactStateGenPreds p =
   [ Random committeeVar
@@ -47,10 +58,10 @@ enactStateGenPreds p =
   , Random prevHardFork
   , Random prevCommittee
   , Random prevConstitution
-  , Random prevDRepState
-  , Random partialDRepDistr
-  , Random prevDRepState
+  , Subset (Dom prevDRepState) voteUniv
+  , Subset (Dom partialDRepDistr) drepUniv
   ]
+    ++ prevGovActionIdsGenPreds p
 
 enactStateCheckPreds :: Proof era -> [Pred era]
 enactStateCheckPreds _ = []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -9,6 +9,7 @@ module Test.Cardano.Ledger.Constrained.Preds.LedgerState where
 
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Governance (gasDeposit)
+import Cardano.Ledger.DRep (drepDepositL)
 import Control.Monad (when)
 import Data.Default.Class (Default (def))
 import qualified Data.Map.Strict as Map
@@ -91,7 +92,11 @@ ledgerStatePreds usize p =
   , Subset (Rng colUtxo) (colTxoutUniv p)
   , NotMember feeTxIn (Dom colUtxo)
   , NotMember feeTxOut (Rng colUtxo)
-  , SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits, One proposalDeposits, SumMap drepDeposits]
+  , SumsTo
+      (Right (Coin 1))
+      deposits
+      EQL
+      [SumMap stakeDeposits, SumMap poolDeposits, One proposalDeposits, ProjMap CoinR drepDepositL currentDRepState]
   , -- Some things we might want in the future.
     -- , SumsTo (Right (Coin 1)) utxoCoin EQL [ProjMap CoinR outputCoinL (utxo p)]
     -- , SumsTo (Right (Coin 1)) totalAda EQL [One utxoCoin, One treasury, One reserves, One fees, One deposits, SumMap rewards]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
@@ -128,8 +128,9 @@ pParamsPreds p =
           PParamsConwayToConway ->
             [ extract (maxTxExUnits p) (pparams p)
             , extract (collateralPercentage p) (pparams p)
-            , extract (drepDeposit p) (pparams p)
             , extract (drepActivity p) (pparams p)
+            , extract (drepDeposit p) (pparams p)
+            , extract (proposalDeposit p) (pparams p)
             ]
        )
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -495,7 +495,7 @@ minusMultiValue p v1 v2 = case whichValue p of
 -- Using constraints to generate a TxBody
 -- ==============================================================
 
-txBodyPreds :: forall era. (HasCallStack, Reflect era) => UnivSize -> Proof era -> [Pred era]
+txBodyPreds :: forall era. (Reflect era, HasCallStack) => UnivSize -> Proof era -> [Pred era]
 txBodyPreds sizes p =
   (txOutPreds sizes p balanceCoin (outputs p))
     ++ [ mint :<-: (Constr "sumAssets" (\out spend -> minusMultiValue p (txoutSum out) (txoutSum spend)) ^$ (outputs p) ^$ spending)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -537,7 +537,7 @@ txBodyPreds sizes p =
           :<-: ( Constr "certsRefunds" certsRefunds
                   ^$ pparams p
                   ^$ stakeDeposits
-                  ^$ drepDeposits
+                  ^$ drepDepositsView
                   ^$ certs
                )
        , txdeposits :<-: (Constr "certsDeposits" certsDeposits ^$ pparams p ^$ regPools ^$ certs)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -79,7 +80,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UMap (compactCoinOrError, fromCompact, ptrMap, rdPairMap, sPoolMap, unify)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val (Val (..))
-import Data.Foldable (toList)
+import qualified Data.Foldable as F
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -460,8 +461,11 @@ snapshotsL = nesEsL . esSnapshotsL
 ppFL :: Proof era -> Lens' (PParams era) (PParamsF era)
 ppFL p = lens (\pp -> PParamsF p pp) (\_ (PParamsF _ qq) -> qq)
 
+pparamsVar :: Gov.EraGov era => Proof era -> V era (PParamsF era)
+pparamsVar p = (V "pparams" (PParamsR p) (Yes NewEpochStateR (nesEsL . curPParamsEpochStateL . ppFL p)))
+
 pparams :: Gov.EraGov era => Proof era -> Term era (PParamsF era)
-pparams p = Var (V "pparams" (PParamsR p) (Yes NewEpochStateR (nesEsL . curPParamsEpochStateL . ppFL p)))
+pparams p = Var $ pparamsVar p
 
 nmLikelihoodsT :: Era era => Term era (Map (KeyHash 'StakePool (EraCrypto era)) [Float])
 nmLikelihoodsT = Var (V "likelihoodsNM" (MapR PoolHashR (ListR FloatR)) (Yes NewEpochStateR (nesEsL . esNonMyopicL . nmLikelihoodsL)))
@@ -1694,6 +1698,11 @@ initPulser proof utx credDRepMap poold credDRepStateMap epoch commstate enactsta
         -- treas
         testGlobals
 
+proposalsT :: forall era. Era era => RootTarget era (Proposals era) (Proposals era)
+proposalsT =
+  Invert "fromGovActionStateSeq" (typeRep @(Proposals era)) (fromGovActionStateSeq . SS.fromList)
+    :$ Lensed prevProposals (lens (F.toList . proposalsActions) $ const (fromGovActionStateSeq . SS.fromList))
+
 -- ==================================================
 -- Second form of DRepPulsingState 'DRComplete'
 -- ==================================================
@@ -1744,7 +1753,7 @@ prevProposals = Var $ V "prevProposals" (ListR GovActionStateR) No
 prevProposalsL :: Lens' (DRepPulser era Identity (RatifyState era)) [GovActionState era]
 prevProposalsL =
   lens
-    (\x -> toList (dpProposals x))
+    (\x -> F.toList (dpProposals x))
     (\x y -> x {dpProposals = SS.fromList y})
 
 -- | Partially computed DRepDistr inside the pulser

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1663,6 +1663,10 @@ pcWitnesses proof wits = ppRecord "Witnesses" pairs
     fields = abstractWitnesses proof wits
     pairs = concat (map (pcWitnessesField proof) fields)
 
+<<<<<<< HEAD
+
+=======
+>>>>>>> b633f3e42 (rebased on latest ts-constrained-trace)
 pcTx :: Proof era -> Tx era -> PDoc
 pcTx proof tx = ppRecord "Tx" pairs
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1663,10 +1663,6 @@ pcWitnesses proof wits = ppRecord "Witnesses" pairs
     fields = abstractWitnesses proof wits
     pairs = concat (map (pcWitnessesField proof) fields)
 
-<<<<<<< HEAD
-
-=======
->>>>>>> b633f3e42 (rebased on latest ts-constrained-trace)
 pcTx :: Proof era -> Tx era -> PDoc
 pcTx proof tx = ppRecord "Tx" pairs
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -506,6 +506,7 @@ sameBabbageTxBody
 
 sameConwayTxBody ::
   ( ConwayEraTxBody era
+  , PrettyA (PParamsUpdate era)
   , Reflect era
   ) =>
   Proof era ->


### PR DESCRIPTION
# Description

A bunch more work on constraint-based STS testing. This time for running the RATIFY and GOV rules. The GOV rule doesn't work yet because we need to extend the constraint language a bit to handle the map-of-maps in the GOV signal.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
