### PR TITLE
Fix sums with negative RHS.

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -384,7 +384,7 @@ solveMap v1@(V _ r@(MapR dom rng) _) predicate = explain msg $ case predicate of
       (RngRel (relSubset rng (Set.fromList (Map.elems m))))
   other -> failT ["Cannot solve map condition: " ++ show other]
   where
-    msg = ("Solving for " ++ show v1 ++ " Predicate \n   " ++ show predicate)
+    msg = ("Solving for " ++ show v1 ++ "\nPredicate = " ++ show predicate)
 
 -- | We are solving for a (V era (Map d r)). This must occurr exactly once in the [Sum era c]
 --   That can only happen in a (RngSum cond c) or a (RngProj cond rep c) constructor of 'Sum'


### PR DESCRIPTION
When solving for a variable (like 'N') that appears on the right-hand-side of a summation constraint like this
```
SumsTo (Right (Coin 1)) ₳ 15 <= ∑ sum Map{34 -> ₳ 5 | size = 15, sum = ₳ 125} + sum N
```
There is a problem with the current algorithm, if the type of the variable 'N' does not support negative values.
The current algorithm solves this by subtracting the the constants on the right (125) from the constants on the left (15), resulting in (-110) <= N,  which has a solution N is at Least (-109). But since N cannot be negative we must settle for a solution N is at Least 0.

We add special code to consider this case. And also made a few error messages more precise.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
