### PR TITLE
Cleanup JSON instances for Conway governance

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.10.0.0
 
+* Rename `ensPParams` to `ensCurPParams`.
+* Add `ToJSON` instance for `RatifyState`
+* Change `ToJSON` instance for `ConwayGovState`:
+  * Add `"nextRatifyState"` field
+  * Rename `"ratify"` to `"enactState"`
+  * Rename `"gov"` to `"proposals"`
+* Fix `ToJSON` instance for `EnactState`, previously current PParams were used for `"prevPParams"`.
 * Add an anchor argument to `ResignCommitteeColdTxCert`
 * Prevent invalid previous gov-action ids in proposals #3768
   * Also, add lenses

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -8,7 +8,10 @@
   * Add `"nextRatifyState"` field
   * Rename `"ratify"` to `"enactState"`
   * Rename `"gov"` to `"proposals"`
-* Fix `ToJSON` instance for `EnactState`, previously current PParams were used for `"prevPParams"`.
+* Fix `ToJSON` instance for `EnactState`:
+  * Current PParams were wrongfully used for `"prevPParams"`.
+  * Remove `"treasury"` and `"withdrawals"` as those are temporary bindings needed only
+    for `ENACT` rule
 * Add an anchor argument to `ResignCommitteeColdTxCert`
 * Prevent invalid previous gov-action ids in proposals #3768
   * Also, add lenses

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Add `psDRepDistrG`.
 * Rename `ensPParams` to `ensCurPParams`.
 * Add `ToJSON` instance for `RatifyState`
 * Change `ToJSON` instance for `ConwayGovState`:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -106,11 +106,10 @@ module Cardano.Ledger.Conway.Governance (
   computeDrepDistr,
   getRatifyState,
   conwayGovStateDRepDistrG,
-  getPulsingStateDRepDistr,
+  psDRepDistrG,
   dormantEpoch,
   PulsingSnapshot (..),
   psProposalsL,
-  pulsingStateSnapshotL,
   psDRepDistrL,
   psDRepStateL,
   RunConwayRatify (..),
@@ -201,7 +200,6 @@ import Cardano.Ledger.Core (
   PParamsUpdate,
   emptyPParams,
   fromEraCBOR,
-  -- fromEraShareCBOR,
   ppProtocolVersionL,
   toEraCBOR,
  )
@@ -928,15 +926,16 @@ data DRepPulser era (m :: Type -> Type) ans where
     DRepPulser era m ans
 
 instance Pulsable (DRepPulser era) where
-  done (DRepPulser {..}) = Map.null dpBalance
+  done DRepPulser {dpBalance} = Map.null dpBalance
 
   current x@(DRepPulser {}) = snd $ finishDRepPulser (DRPulsing x)
 
-  pulseM pulser@(DRepPulser {..}) | Map.null dpBalance = pure $ pulser
-  pulseM pulser@(DRepPulser {..}) =
-    let !(!steps, !balance') = Map.splitAt dpPulseSize dpBalance
-        drep' = Map.foldlWithKey' (accumDRepDistr dpUMap dpDRepState) dpDRepDistr steps
-     in pure (pulser {dpBalance = balance', dpDRepDistr = drep'})
+  pulseM pulser@(DRepPulser {..})
+    | Map.null dpBalance = pure pulser
+    | otherwise =
+        let !(!steps, !balance') = Map.splitAt dpPulseSize dpBalance
+            drep' = Map.foldlWithKey' (accumDRepDistr dpUMap dpDRepState) dpDRepDistr steps
+         in pure (pulser {dpBalance = balance', dpDRepDistr = drep'})
 
   completeM x@(DRepPulser {}) = pure (snd $ finishDRepPulser @era (DRPulsing x))
 
@@ -988,17 +987,17 @@ class
   where
   runConwayRatify :: Globals -> RatifyEnv era -> RatifyState era -> RatifySignal era -> RatifyState era
   runConwayRatify globals ratifyEnv ratifyState ratifySig =
-    case runReader
-      ( applySTS @(ConwayRATIFY era)
-          (TRC (ratifyEnv, ratifyState, ratifySig))
-      )
-      globals of
-      Left ps -> error (unlines ("The ConwayRATIFY rule, which should never fail, did." : map show ps))
-      Right ratifyState' -> ratifyState'
+    let ratifyResult =
+          runReader (applySTS @(ConwayRATIFY era) (TRC (ratifyEnv, ratifyState, ratifySig))) globals
+     in case ratifyResult of
+          Left ps ->
+            error (unlines ("Impossible: RATIFY rule never fails, but it did:" : map show ps))
+          Right ratifyState' -> ratifyState'
 
 finishDRepPulser :: forall era. DRepPulsingState era -> (PulsingSnapshot era, RatifyState era)
 finishDRepPulser (DRComplete snap ratstate) = (snap, ratstate)
-finishDRepPulser (DRPulsing (DRepPulser {..})) = (PulsingSnapshot dpProposals finalDRepDistr dpDRepState, ratifyState')
+finishDRepPulser (DRPulsing (DRepPulser {..})) =
+  (PulsingSnapshot dpProposals finalDRepDistr dpDRepState, ratifyState')
   where
     !finalDRepDistr = Map.foldlWithKey' (accumDRepDistr dpUMap dpDRepState) dpDRepDistr dpBalance
     !ratifyEnv =
@@ -1030,23 +1029,18 @@ data DRepPulsingState era
       !(RatifyState era)
   deriving (Generic, NoThunks, NFData)
 
-pulsingStateSnapshotL :: Lens' (DRepPulsingState era) (PulsingSnapshot era)
-pulsingStateSnapshotL = lens getter setter
-  where
-    getter (DRComplete x _) = x
-    getter state = fst (finishDRepPulser state)
-    setter (DRComplete _ y) snap = DRComplete snap y
-    setter state snap = (\(_, y) -> DRComplete snap y) (finishDRepPulser state)
-
 dormantEpoch :: DRepPulsingState era -> Bool
 dormantEpoch (DRPulsing x) = SS.null (dpProposals x)
 dormantEpoch (DRComplete b _) = SS.null (psProposals b)
 
-getPulsingStateDRepDistr :: SimpleGetter (DRepPulsingState era) (Map (DRep (EraCrypto era)) (CompactForm Coin))
-getPulsingStateDRepDistr = to get
+-- | This is potentially an expensive getter. Make sure not to use it in the first 80% of
+-- the epoch.
+psDRepDistrG ::
+  SimpleGetter (DRepPulsingState era) (Map (DRep (EraCrypto era)) (CompactForm Coin))
+psDRepDistrG = to get
   where
     get (DRComplete x _) = psDRepDistr x
-    get x = (psDRepDistr . fst) $ finishDRepPulser x
+    get x = psDRepDistr . fst $ finishDRepPulser x
 
 instance EraPParams era => Eq (DRepPulsingState era) where
   x == y = finishDRepPulser x == finishDRepPulser y
@@ -1096,14 +1090,14 @@ startDRepPulsingState ::
   Coin ->
   Globals ->
   DRepPulsingState era
-startDRepPulsingState stepSize umap stakedistr pooldistr dstate epoch committee enact proposals treas global =
+startDRepPulsingState stepSize umap stakeDistr poolDistr dstate epoch committee enact proposals treas global =
   DRPulsing
     ( DRepPulser
         stepSize
         umap
-        stakedistr -- used as the balance of things left to iterate over
-        stakedistr -- used as part of the snapshot
-        pooldistr
+        stakeDistr -- used as the balance of things left to iterate over
+        stakeDistr -- used as part of the snapshot
+        poolDistr
         Map.empty -- The partial result starts as the empty map
         dstate
         epoch

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -281,8 +281,8 @@ toPulsingSnapshotsPairs :: (KeyValue a, EraPParams era) => PulsingSnapshot era -
 toPulsingSnapshotsPairs gas@(PulsingSnapshot _ _ _) =
   let (PulsingSnapshot {..}) = gas
    in [ "psProposals" .= psProposals
-      , -- , "psDRepDistr" .=  psDRepDistr   -- TODO   FIX ME
-        "psDRepState" .= psDRepState
+      , "psDRepDistr" .= psDRepDistr
+      , "psDRepState" .= psDRepState
       ]
 
 instance EraPParams era => ToJSON (PulsingSnapshot era) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -455,8 +455,6 @@ toEnactStatePairs cg@(EnactState _ _ _ _ _ _ _) =
       , "constitution" .= ensConstitution
       , "curPParams" .= ensCurPParams
       , "prevPParams" .= ensPrevPParams
-      , "treasury" .= ensTreasury
-      , "withdrawals" .= ensWithdrawals
       , "prevGovActionIds" .= ensPrevGovActionIds
       ]
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -296,7 +296,7 @@ ratifyTransition = do
   TRC
     ( env@RatifyEnv {reCurrentEpoch}
       , st@( RatifyState
-              rsEnactState@EnactState {ensCommittee, ensPParams, ensTreasury, ensPrevGovActionIds}
+              rsEnactState@EnactState {ensCommittee, ensCurPParams, ensTreasury, ensPrevGovActionIds}
               rsRemoved
               rsDelayed
             )
@@ -309,7 +309,7 @@ ratifyTransition = do
       let gas@GovActionState {gasId, gasAction, gasExpiresAfter} = ast
           notDelayed = not rsDelayed
       if prevActionAsExpected gasAction ensPrevGovActionIds
-        && validCommitteeTerm ensCommittee ensPParams reCurrentEpoch
+        && validCommitteeTerm ensCommittee ensCurPParams reCurrentEpoch
         && notDelayed
         && withdrawalCanWithdraw gasAction ensTreasury
         && committeeAccepted st env gas

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Conway.Governance (
   epochStateDRepPulsingStateL,
   epochStateIncrStakeDistrL,
   gasDRepVotesL,
-  getPulsingStateDRepDistr,
+  psDRepDistrG,
   rsDelayed,
   rsEnactState,
   rsRemoved,
@@ -209,7 +209,7 @@ getRatifyEnv = do
   eNo <- getsNES nesELL
   stakeDistr <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosStakeDistrL
   poolDistr <- getsNES nesPdL
-  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . getPulsingStateDRepDistr
+  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
   drepState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
   committeeState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
   pure
@@ -268,7 +268,7 @@ isGovActionAccepted gaId = do
   eNo <- getsNES nesELL
   stakeDistr <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosStakeDistrL
   poolDistr <- getsNES nesPdL
-  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . getPulsingStateDRepDistr
+  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
   drepState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
   action <- lookupGovActionState gaId
   enactSt <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
@@ -307,15 +307,19 @@ logRatificationChecks gaId = do
   let
     ratSt = RatifyState ens mempty False
   currentEpoch <- getsNES nesELL
-  logEntry "----- RATIFICATION CHECKS -----"
-  logEntry $ "prevActionAsExpected:\t" <> show (prevActionAsExpected gasAction ensPrevGovActionIds)
-  logEntry $ "validCommitteeTerm:\t" <> show (validCommitteeTerm ensCommittee ensPParams currentEpoch)
-  logEntry "notDelayed:\t\t??"
-  logEntry $ "withdrawalCanWithdraw:\t" <> show (withdrawalCanWithdraw gasAction ensTreasury)
-  logEntry $ "committeeAccepted:\t" <> show (committeeAccepted ratSt ratEnv gas)
-  logEntry $ "spoAccepted:\t\t" <> show (spoAccepted ratSt ratEnv gas)
-  logEntry $ "dRepAccepted:\t\t" <> show (dRepAccepted ratEnv ratSt gas)
-  logEntry ""
+  logEntry $
+    unlines
+      [ "----- RATIFICATION CHECKS -----"
+      , "prevActionAsExpected:\t" <> show (prevActionAsExpected gasAction ensPrevGovActionIds)
+      , "validCommitteeTerm:\t"
+          <> show (validCommitteeTerm ensCommittee ensCurPParams currentEpoch)
+      , "notDelayed:\t\t??"
+      , "withdrawalCanWithdraw:\t" <> show (withdrawalCanWithdraw gasAction ensTreasury)
+      , "committeeAccepted:\t" <> show (committeeAccepted ratSt ratEnv gas)
+      , "spoAccepted:\t\t" <> show (spoAccepted ratSt ratEnv gas)
+      , "dRepAccepted:\t\t" <> show (dRepAccepted ratEnv ratSt gas)
+      , ""
+      ]
 
 -- | Submits a transaction that registers a hot key for the given cold key.
 -- Returns the hot key hash.

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `epochStateGovStateL`
 * Add `shelleyCommonPParamsHKDPairsV8`
 * Add `ToExpr` instances for:
   * `ShelleyPoolPredFailure`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -115,6 +115,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   utxosGovStateL,
   utxosStakeDistrL,
   utxosDonationL,
+  epochStateGovStateL,
   epochStateStakeDistrL,
   epochStateUMapL,
   epochStateRegDrepL,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -713,6 +713,9 @@ ptrMapL = lens ptrMap (\x y -> x {ptrMap = y})
 newEpochStateGovStateL :: Lens' (NewEpochState era) (GovState era)
 newEpochStateGovStateL = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
 
+epochStateGovStateL :: Lens' (EpochState era) (GovState era)
+epochStateGovStateL = esLStateL . lsUTxOStateL . utxosGovStateL
+
 epochStateTreasuryL :: Lens' (EpochState era) Coin
 epochStateTreasuryL = esAccountStateL . asTreasuryL
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Add `ToJSON`/`FromJSON` and `ToJSONKey`/`FromJSONKey` instances for `DRep`
+* Add `parseCredential`
 * Add `NoUpdate`, `HKDNoUpdate`
 * Add `toNoUpdate` and `fromNoUpdate` methods to `HKDFunctor`
 * Add `Updatable` instance for `NoUpdate`

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -424,7 +424,7 @@ instance PrettyA (PParams era) => PrettyA (EnactState era) where
      in ppRecord
           "EnactState"
           [ ("Constitutional Committee", prettyA ensCommittee)
-          , ("PParams", prettyA ensPParams)
+          , ("CurPParams", prettyA ensCurPParams)
           , ("PrevPParams", prettyA ensPrevPParams)
           , ("Constitution", prettyA ensConstitution)
           , ("Treasury", prettyA ensTreasury)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1642,7 +1642,7 @@ pcEnactState p ens@(EnactState _ _ _ _ _ _ _) =
         "EnactState"
         [ ("Constitutional Committee", ppStrictMaybe pcCommittee ensCommittee)
         , ("Constitution", pcConstitution ensConstitution)
-        , ("PParams", pcPParamsSynopsis p ensPParams)
+        , ("CurPParams", pcPParamsSynopsis p ensCurPParams)
         , ("PrevPParams", pcPParamsSynopsis p ensPrevPParams)
         , ("Treasury", pcCoin ensTreasury)
         , ("Withdrawals", ppMap pcCredential pcCoin ensWithdrawals)


### PR DESCRIPTION
# Description

This is a collection of small JSON related issues. 

Also addition of Assertions for EPOCH rule that verify that withdrawals and treasury fields of EnactState are always zero before and after the EPOCH rule.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
