### PR TITLE
Fix epoch rule and tests

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -16,7 +16,12 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core (EraIndependentTxBody, EraTxOut)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Shelley.Core (EraGov)
-import Cardano.Ledger.Shelley.LedgerState (NewEpochState, StashedAVVMAddresses, curPParamsEpochStateL, nesEsL)
+import Cardano.Ledger.Shelley.LedgerState (
+  NewEpochState,
+  StashedAVVMAddresses,
+  curPParamsEpochStateL,
+  nesEsL,
+ )
 import Data.Default.Class (Default)
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## 1.10.0.0
 
-* Discard duplicates from `certsTxBodyL` and `proposalProceduresTxBodyL` #3779
+* Fix `NewEpochState` translation: #3801
+* Change order of arguments for `committeeAccepted` adn `spoAccepted` for consistency #3801
+* Add `spoAcceptedRatio` #3801
+* Export `snapshotGovActionStates` #3801
+* Change type for `snapshotRemoveIds` to also return the removed actions. #3801
+* Add `reDRepDistrL` #3759
+* Remove `GovSnapshots` #3759
+* Move `DRepPulser` from `cardano-ledger-core`. #3759
+* Add `DRepPulsingState` #3759: `pulseDRepPulsingState`, `completeDRepPulsingState`,
+  `extractDRepPulsingState`, `finishDRepPulser`, `computeDrepDistr`, `getRatifyState`,
+  `getPulsingStateDRepDistr`, `dormantEpoch`, `setFreshDRepPulsingState`,
+  `setCompleteDRepPulsingState`
+* Add `PulsingSnapshot` and `psProposalsL`, `psDRepDistrL`, `psDRepStateL` #3759
+* Add `RunConwayRatify` class #3759
+* Forbid duplicates from `certsTxBodyL` and `proposalProceduresTxBodyL` #3779
 * Add `enactStateGovStateL` to `ConwayEraGov`
 * Add `psDRepDistrG`.
 * Rename `ensPParams` to `ensCurPParams`.
@@ -38,6 +52,10 @@
 * Add  `ConwayEraPParams era` constraint to `isCommitteeVotingAllowed` and `votingCommitteeThreshold`
 * Switch to using `AlonzoEraUTxO` in rules
 * Change `cppProtocolVersion` to a `HKDNoUpdate` field
+
+### `testlib`
+
+* Addition of `ImpTest` interface
 
 ## 1.9.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -111,7 +111,7 @@ library testlib
         cardano-data:{cardano-data, testlib},
         containers,
         microlens,
-        cardano-ledger-binary,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-crypto-class,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-babbage:testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -63,6 +63,7 @@ module Cardano.Ledger.Conway.Governance (
   snapshotIds,
   snapshotRemoveIds,
   snapshotLookupId,
+  snapshotGovActionStates,
   fromGovActionStateSeq,
   isConsistent_,
   -- Lenses
@@ -109,6 +110,8 @@ module Cardano.Ledger.Conway.Governance (
   psDRepDistrG,
   dormantEpoch,
   PulsingSnapshot (..),
+  setCompleteDRepPulsingState,
+  setFreshDRepPulsingState,
   psProposalsL,
   psDRepDistrL,
   psDRepStateL,
@@ -177,6 +180,7 @@ import Cardano.Ledger.Conway.Governance.Snapshots (
   isConsistent_,
   snapshotActions,
   snapshotAddVote,
+  snapshotGovActionStates,
   snapshotIds,
   snapshotInsertGovAction,
   snapshotLookupId,
@@ -212,20 +216,31 @@ import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
   NewEpochState (..),
+  certDState,
+  certVState,
+  credMap,
+  dsUnified,
+  epochStateGovStateL,
   epochStateIncrStakeDistrL,
   epochStateRegDrepL,
   epochStateStakeDistrL,
+  epochStateTreasuryL,
   epochStateUMapL,
   esLStateL,
+  lsCertState,
+  lsUTxOState,
   lsUTxOStateL,
   nesEsL,
   utxosGovStateL,
+  utxosStakeDistr,
+  vsCommitteeState,
+  vsDReps,
  )
 import Cardano.Ledger.TreeDiff (Expr (App), ToExpr (..))
 import Cardano.Ledger.UMap
 import qualified Cardano.Ledger.UMap as UMap
 import Control.DeepSeq (NFData (..), deepseq)
-import Control.Monad.Trans.Reader (Reader, runReader)
+import Control.Monad.Trans.Reader (Reader, ReaderT, ask, runReader)
 import Control.State.Transition.Extended
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Default.Class (Default (..))
@@ -235,6 +250,7 @@ import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Pulse (Pulsable (..), pulse)
+import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SS
 import Data.Set (Set)
@@ -997,7 +1013,7 @@ class
           Right ratifyState' -> ratifyState'
 
 finishDRepPulser :: forall era. DRepPulsingState era -> (PulsingSnapshot era, RatifyState era)
-finishDRepPulser (DRComplete snap ratstate) = (snap, ratstate)
+finishDRepPulser (DRComplete snap ratifyState) = (snap, ratifyState)
 finishDRepPulser (DRPulsing (DRepPulser {..})) =
   (PulsingSnapshot dpProposals finalDRepDistr dpDRepState, ratifyState')
   where
@@ -1125,6 +1141,67 @@ completeDRepPulsingState x@(DRComplete {}) = x
 extractDRepPulsingState :: DRepPulsingState era -> RatifyState era
 extractDRepPulsingState x@(DRPulsing _) = snd (finishDRepPulser x)
 extractDRepPulsingState (DRComplete _ x) = x
+
+setCompleteDRepPulsingState ::
+  GovState era ~ ConwayGovState era =>
+  PulsingSnapshot era ->
+  RatifyState era ->
+  EpochState era ->
+  EpochState era
+setCompleteDRepPulsingState snapshot ratifyState epochState =
+  epochState
+    & epochStateGovStateL . cgDRepPulsingStateL
+      .~ DRComplete snapshot ratifyState
+
+setFreshDRepPulsingState ::
+  ( GovState era ~ ConwayGovState era
+  , Monad m
+  , RunConwayRatify era
+  ) =>
+  EpochNo ->
+  PoolDistr (EraCrypto era) ->
+  EpochState era ->
+  ReaderT Globals m (EpochState era)
+setFreshDRepPulsingState epochNo stakePoolDistr epochState = do
+  -- We are now finished with the pulser started at the last epoch boundary, so we need to
+  -- initialize a fresh DRep pulser, by computing the pulse size, and gathering the data we
+  -- will snapshot inside the pulser. We expect approximately 10*k-many blocks to be produced
+  -- each epoch. Therefore to safely and evenly space out the DRep calculation, we divide
+  -- the number of stake credentials by 8*k (8, rather than 10, to be sure we finish
+  -- two stability windows before the end of the epoch)
+  globals <- ask
+  let ledgerState = epochState ^. esLStateL
+      utxoState = lsUTxOState ledgerState
+      stakeDistr = credMap $ utxosStakeDistr utxoState
+      certState = lsCertState ledgerState
+      dState = certDState certState
+      vState = certVState certState
+      govState = epochState ^. epochStateGovStateL
+      stakeSize = Map.size stakeDistr
+      -- Maximum number of blocks we are allowed to roll back
+      k = securityParameter globals
+      pulseSize = max 1 (ceiling (toInteger stakeSize % (8 * toInteger k)))
+      epochState' =
+        epochState
+          & epochStateGovStateL . cgDRepPulsingStateL
+            .~ DRPulsing
+              ( DRepPulser
+                  { dpPulseSize = pulseSize
+                  , dpUMap = dsUnified dState
+                  , dpBalance = stakeDistr -- used as the balance of things left to iterate over
+                  , dpStakeDistr = stakeDistr -- used as part of the snapshot
+                  , dpStakePoolDistr = stakePoolDistr
+                  , dpDRepDistr = Map.empty -- The partial result starts as the empty map
+                  , dpDRepState = vsDReps vState
+                  , dpCurrentEpoch = epochNo
+                  , dpCommitteeState = vsCommitteeState vState
+                  , dpEnactState = cgEnactState govState
+                  , dpProposals = snapshotActions (govState ^. cgProposalsL)
+                  , dpTreasury = epochState ^. epochStateTreasuryL
+                  , dpGlobals = globals
+                  }
+              )
+  pure epochState'
 
 -- ===================================
 -- RatifyEnv

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Snapshots.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Conway.Governance.Snapshots (
   snapshotRemoveIds,
   snapshotLookupId,
   fromGovActionStateSeq,
+  snapshotGovActionStates,
   -- Testing
   isConsistent_,
   snapshotGovActionStates,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -39,8 +39,6 @@ import Cardano.Ledger.Conway.Governance (
   pulseDRepPulsingState,
  )
 import Cardano.Ledger.Conway.Rules.Epoch (ConwayEpochEvent)
-
--- import Cardano.Ledger.Conway.Rules.Ratify
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.EpochBoundary
 import Cardano.Ledger.Keys (KeyRole (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -80,7 +80,7 @@ instance Crypto c => TranslateEra (ConwayEra c) NewEpochState where
     let es = translateEra' ctxt $ nesEs nes
         -- We need to ensure that we have the same initial EnactState in the pulser as
         -- well as in the current EnactState, otherwise in the very first EPOCH rule call
-        -- the pulsert will reset it.
+        -- the pulser will reset it.
         ratifyState = def & rsEnactStateL .~ (es ^. epochStateGovStateL . cgEnactStateL)
     pure $
       NewEpochState

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/CommitteeRatifySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/CommitteeRatifySpec.hs
@@ -89,7 +89,7 @@ acceptedProp =
   prop "Only NoConfidence or UpdateCommittee should pass without a committee" $
     forAll (arbitrary @(RatifyState era, RatifyEnv era, GovActionState era)) $ do
       \(rs, rEnv, gas) -> do
-        committeeAccepted @era (rs & rsEnactStateL . ensCommitteeL .~ SNothing) rEnv gas
+        committeeAccepted rEnv (rs & rsEnactStateL . ensCommitteeL .~ SNothing) gas
           `shouldBe` isNoConfidenceOrUpdateCommittee gas
   where
     isNoConfidenceOrUpdateCommittee GovActionState {gasAction} =

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
@@ -71,7 +71,7 @@ spec =
               , dvtUpdateToConstitution = 1 %! 2
               }
           & ppCommitteeMaxTermLengthL .~ 10
-          & ppGovActionLifetimeL .~ 1
+          & ppGovActionLifetimeL .~ 2
       khDRep <- setupSingleDRep
 
       logEntry "Registering committee member"
@@ -88,7 +88,9 @@ spec =
 
       let
         assertNoCommittee = do
-          committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+          committee <-
+            getsNES $
+              nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
           impIOMsg "There should not be a committee" $ committee `shouldBe` SNothing
       logRatificationChecks gaidCommitteeProp
       assertNoCommittee
@@ -98,7 +100,9 @@ spec =
       assertNoCommittee
       passEpoch
       do
-        committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+        committee <-
+          getsNES $
+            nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
         impIOMsg "There should be a committee" $ committee `shouldSatisfy` isSJust
       logEntry "Submitting new constitution"
       constitutionHash <- freshSafeHash
@@ -116,10 +120,12 @@ spec =
       gaidConstitutionProp <-
         submitProposal constitutionAction
       logRatificationChecks gaidConstitutionProp
+      passEpoch
+      passEpoch
       do
         isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
         impIOMsg "Gov action should not be accepted" $ isAccepted `shouldBe` False
-      khCommitteeMemberHot <- registerCCHotKey khCommitteeMember
+      khCommitteeMemberHot <- registerCommitteeHotKey khCommitteeMember
       _ <- voteForProposal (DRepVoter $ KeyHashObj khDRep) gaidConstitutionProp
       _ <- voteForProposal (CommitteeVoter $ KeyHashObj khCommitteeMemberHot) gaidConstitutionProp
       logAcceptedRatio gaidConstitutionProp

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/EpochSpec.hs
@@ -117,19 +117,19 @@ spec =
         submitProposal constitutionAction
       logRatificationChecks gaidConstitutionProp
       do
-        isAccepted <- isGovActionAccepted gaidConstitutionProp
+        isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
         impIOMsg "Gov action should not be accepted" $ isAccepted `shouldBe` False
       khCommitteeMemberHot <- registerCCHotKey khCommitteeMember
       _ <- voteForProposal (DRepVoter $ KeyHashObj khDRep) gaidConstitutionProp
       _ <- voteForProposal (CommitteeVoter $ KeyHashObj khCommitteeMemberHot) gaidConstitutionProp
       logAcceptedRatio gaidConstitutionProp
       do
-        isAccepted <- isGovActionAccepted gaidConstitutionProp
+        isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
         impIOMsg "Gov action should be accepted" $ isAccepted `shouldBe` True
 
       passEpoch
       do
-        isAccepted <- isGovActionAccepted gaidConstitutionProp
+        isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
         impIOMsg "Gov action should be accepted" $ isAccepted `shouldBe` True
       logAcceptedRatio gaidConstitutionProp
       logRatificationChecks gaidConstitutionProp

--- a/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/GovSnapshot.hs
+++ b/eras/conway/test-suite/test/Test/Cardano/Ledger/Conway/GovSnapshot.hs
@@ -41,11 +41,10 @@ govSnapshotProps =
           _ -> pure True
     , testProperty "Removing action preserves consistency" $ do
         as <- uniqueIdGovActions @Conway
-        case as of
+        pure $ case as of
           xs@(GovActionState {gasId} :<| _) ->
-            pure $
-              isConsistent_ (snapshotRemoveIds (Set.singleton gasId) $ fromGovActionStateSeq xs)
-          _ -> pure True
+            isConsistent_ $ fst $ snapshotRemoveIds (Set.singleton gasId) $ fromGovActionStateSeq xs
+          _ -> True
     , testProperty "Adding vote preserves consistency" $ do
         as <- uniqueIdGovActions @Conway
         voter <- arbitrary

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -120,6 +120,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   epochStateUMapL,
   epochStateRegDrepL,
   epochStateIncrStakeDistrL,
+  epochStateDonationL,
   newEpochStateGovStateL,
   epochStateTreasuryL,
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -716,6 +716,9 @@ newEpochStateGovStateL = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
 epochStateGovStateL :: Lens' (EpochState era) (GovState era)
 epochStateGovStateL = esLStateL . lsUTxOStateL . utxosGovStateL
 
+epochStateDonationL :: Lens' (EpochState era) Coin
+epochStateDonationL = esLStateL . lsUTxOStateL . utxosDonationL
+
 epochStateTreasuryL :: Lens' (EpochState era) Coin
 epochStateTreasuryL = esAccountStateL . asTreasuryL
 

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -37,7 +37,7 @@ where
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
   EncCBOR (encCBOR),
-  decodeDeduplicate,
+  decodeSetLikeEnforceNoDuplicates,
   encodeStrictSeq,
   encodeTag,
   setTag,
@@ -102,7 +102,7 @@ instance EncCBOR a => EncCBOR (OSet a) where
   encCBOR (OSet seq _set) = encodeTag setTag <> encodeStrictSeq encCBOR seq
 
 instance (Show a, Ord a, DecCBOR a) => DecCBOR (OSet a) where
-  decCBOR = decodeDeduplicate decCBOR member (flip snoc)
+  decCBOR = decodeSetLikeEnforceNoDuplicates member (flip snoc) decCBOR
 
 -- | \( O(1) \). Shallow invariant using just `length` and `size`.
 invariantHolds :: OSet a -> Bool

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Version history for `cardano-ledger-api`
 
-## 1.6.1.0
+## 1.7.0.0
 
 * Export `isPlutusScript`
 * Add `NativeScript`, `getNativeScript` and `validateNativeScript`
 * Removed `phaseScript`
+* Remove `GovSnapshots`, `cgGovSnapshotsL`, `cgRatifyStateL`, `cgGovSnapshotsL` and
+  `cgRatifyStateL`
+* Add `cgProposalsL`
 
 ## 1.6.0.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-api
-version:            1.6.0.1
+version:            1.7.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.2.0.0
 
-* Export `decodeSetTag`, `allowTag`, `variableListLenEncoding`, and `decodeDeduplicate` #3779
+* Export `decodeSetTag`, `allowTag`, `variableListLenEncoding`, and
+  `decodeSetLikeEnforceNoDuplicates` #3779
 * Removed `diffExpr` `diffExprNoColor` `ediffEq`
 
 ## 1.1.3.0


### PR DESCRIPTION
# Description

A whole collection of bug is fixed in this PR:

## In the EPOCH Rule

* `totalObligation` for the `utxosDeposited` field was computed before proposal deposits were returned
* DRepPulser was started with a state that was not fully updated. Creation of the pulser must be the last step in the EPOCH rule
* DRepPulser was started with an epoch number value that was one into the future, which would result in proposals expiring one epoch too soon and theoretically, although very unlikely, could affect DRep expiry as well.

## In the translation

When NewEpochState was translated from Babbage to Conway, only the pparams in the EnactState were updated, but not the state of the Pulser. Which normally would result in PParams to be reset at the very first Epoch in Conway, however, together with a bug in the EPOCH rule this resulted in alternation of `emptyPParams` with actual `PParams`

## In testing

* PParams where not set properly. Similar problem to the one mentioned above. Only the PParams in the EnactState where updated, but not in the DRepPulser. This bug was present both in the `modifyPParams` function and in the `emptyImpNES`
* ConwayFeatures in cardano-ledger-test had wrong assumptions on the state of proposals.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
