### PR TITLE
Enhance `CommitteeMembersState` query to return quorum and NoConfidence:

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -653,7 +653,10 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
 
   getConstitution g = Just $ g ^. cgEnactStateL . ensConstitutionL
 
-  getCommitteeMembers g = foldMap' committeeMembers (g ^. cgEnactStateL . ensCommitteeL)
+  getCommitteeMembers g =
+    case g ^. cgEnactStateL . ensCommitteeL of
+      SJust Committee {..} -> Just (committeeMembers, committeeQuorum)
+      SNothing -> Nothing
 
   curPParamsGovStateL = curPParamsConwayGovStateL
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Change the return type of `getCommitteeMembers`
 * Remove `validateDelegationRegistered` in favor of a new and more specific validating
   function `validateStakePoolDelegateeRegistered`.
 * Add `ToExpr` instances for:

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Shelley.Governance (
   constitutionScriptL,
 ) where
 
-import Cardano.Ledger.BaseTypes (Anchor, EpochNo)
+import Cardano.Ledger.BaseTypes (Anchor, EpochNo, UnitInterval)
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
   DecShareCBOR (..),
@@ -98,8 +98,9 @@ class
   getConstitution :: GovState era -> Maybe (Constitution era)
   getConstitution = const Nothing
 
-  getCommitteeMembers :: GovState era -> Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo
-  getCommitteeMembers = const Map.empty
+  getCommitteeMembers ::
+    GovState era -> Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
+  getCommitteeMembers = const Nothing
 
   -- | Lens for accessing current protocol parameters
   curPParamsGovStateL :: Lens' (GovState era) (PParams era)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7.0.0
 
+* Deprecate `GetCommitteeState` query
+* Add `GetCommitteeMembersState` query
 * Export `isPlutusScript`
 * Add `NativeScript`, `getNativeScript` and `validateNativeScript`
 * Removed `phaseScript`

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -61,7 +61,7 @@ library
         cardano-ledger-conway >=1.10,
         cardano-ledger-core >=1.8 && <1.9,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley >=1.6,
+        cardano-ledger-shelley >=1.7,
         cardano-slotting,
         containers,
         microlens,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -26,7 +26,7 @@ module Cardano.Ledger.Api.State.Query (
   -- * @GetCommitteeState@
   queryCommitteeState,
 
-  -- * @GetCommitteeState@
+  -- * @GetCommitteeMembersState@
   queryCommitteeMembersState,
   CommitteeMemberState (..),
   CommitteeMembersState (..),

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -15,13 +16,19 @@ import Cardano.Ledger.Api.State.Query (
   filterStakePoolDelegsAndRewards,
   queryCommitteeMembersState,
  )
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.UMap (UMap)
+import Data.Foldable (foldMap')
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust, isNothing)
+import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Api.Arbitrary ()
@@ -30,13 +37,6 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Core.Arbitrary (genValidUMapWithCreds)
 import Test.Cardano.Ledger.Shelley.Arbitrary ()
-
-import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.Keys (KeyRole (..))
-import Data.Foldable (foldMap')
-import Data.Maybe (isJust, isNothing)
-import Data.Set (Set)
 
 spec :: Spec
 spec = do
@@ -47,175 +47,203 @@ spec = do
           `shouldBe` getFilteredDelegationsAndRewardAccounts umap creds
 
   describe "GetCommitteeMembersState" $ do
-    committeeMembersStateSpec
+    committeeMembersStateSpec @Conway
 
-committeeMembersStateSpec :: Spec
+committeeMembersStateSpec ::
+  forall era.
+  ( EraTxOut era
+  , EraGov era
+  , Arbitrary (PParams era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (Value era)
+  , Arbitrary (GovState era)
+  , Arbitrary (StashedAVVMAddresses era)
+  , Show (StashedAVVMAddresses era)
+  ) =>
+  Spec
 committeeMembersStateSpec =
-  prop "CommitteeMembersState Query" $ do
-    forAll (arbitrary @(NewEpochState Conway)) $ \nes' -> do
-      forAll
-        ( arbitrary
-            @( Set (Credential 'ColdCommitteeRole StandardCrypto)
-             , Set (Credential 'HotCommitteeRole StandardCrypto)
-             , Set MemberStatus
-             )
-        )
-        $ \(ckFilter', hkFilter', statusFilter) -> do
-          -- replace some arbitrary number of cold keys from the committeeState with the ones from the committee
-          -- so we can have Active members
-          let (comMembers, comStateMembers) = committeeInfo nes'
-          forAll (genCommonMembers comMembers comStateMembers) $ \newCommitteeState -> do
-            let nes =
-                  nes'
-                    & nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-                      .~ newCommitteeState
-            -- replace some cold and hot keys from the filter with known ones from both committee and committeeState
-            forAll
-              ( (,)
-                  <$> genRelevantColdCredsFilter ckFilter' comMembers comStateMembers
-                  <*> genRelevantHotCredsFilter hkFilter' comStateMembers
-              )
-              $ \(ckFilter, hkFilter) -> do
-                propEmpty nes
-                propComplete nes
-                propAuthorized nes
-                propActiveAuthorized nes
-                propNotAuthorized nes
-                propResigned nes
-                propUnrecognized nes
-                propFilters ckFilter hkFilter statusFilter nes
+  prop "CommitteeMembersState Query" $ \nes' ckFilter' hkFilter' statusFilter -> do
+    case committeeInfo nes' of
+      Nothing -> property ()
+      Just (comMembers, _, comStateMembers) -> do
+        -- replace some arbitrary number of cold keys from the committeeState with the
+        -- ones from the committee so we can have Active members
+        forAll (genCommonMembers comMembers comStateMembers) $ \newCommitteeState ->
+          let nes :: NewEpochState era
+              nes =
+                nes'
+                  & nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
+                    .~ newCommitteeState
+           in -- replace some cold and hot keys from the filter with known ones from both
+              -- committee and committeeState
+              forAll (genRelevantColdCredsFilter ckFilter' comMembers comStateMembers) $ \ckFilter ->
+                forAll (genRelevantHotCredsFilter hkFilter' comStateMembers) $ \hkFilter -> do
+                  propEmpty nes
+                  propComplete nes
+                  propAuthorized nes
+                  propActiveAuthorized nes
+                  propNotAuthorized nes
+                  propResigned nes
+                  propUnrecognized nes
+                  propFilters ckFilter hkFilter statusFilter nes
 
-propEmpty :: NewEpochState Conway -> Expectation
+propEmpty ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
 propEmpty nes = do
-  let (comMembers, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  Map.null result `shouldBe` (Map.null comMembers && Map.null comStateMembers)
+  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
+    Map.null (csCommittee noFilterResult)
+      `shouldBe` (Map.null comMembers && Map.null comStateMembers)
 
-propComplete :: NewEpochState Conway -> Expectation
+propComplete ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
 propComplete nes = do
-  let (comMembers, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  -- if a credential appears in either Committee or CommitteeState, it should appear in the result
-  Map.keysSet comMembers
-    `Set.union` Map.keysSet comStateMembers
-    `shouldBe` Map.keysSet result
+  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
+    -- if a credential appears in either Committee or CommitteeState, it should appear
+    -- in the result
+    Map.keysSet comMembers
+      `Set.union` Map.keysSet comStateMembers
+      `shouldBe` Map.keysSet (csCommittee noFilterResult)
 
-propNotAuthorized :: NewEpochState Conway -> Expectation
+propNotAuthorized ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
 propNotAuthorized nes = do
-  let (_, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  let notAuthorized =
-        Map.filter
-          ( \case
-              CommitteeMemberState MemberNotAuthorized _ _ _ -> True
-              _ -> False
-          )
-          result
-  -- if the member is NotAuthorized, it should not have an associated hot credential in the committeeState
-  Map.intersection comStateMembers notAuthorized `shouldBe` Map.empty
+  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
+    let notAuthorized =
+          Map.filter
+            ( \case
+                CommitteeMemberState MemberNotAuthorized _ _ _ -> True
+                _ -> False
+            )
+            (csCommittee noFilterResult)
+    -- if the member is NotAuthorized, it should not have an associated hot credential in the committeeState
+    Map.intersection comStateMembers notAuthorized `shouldBe` Map.empty
 
-propAuthorized :: NewEpochState Conway -> Expectation
+propAuthorized ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
 propAuthorized nes = do
-  let (_, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  let ckHk =
-        Map.foldMapWithKey
-          ( \ck cms ->
-              case cms of
-                CommitteeMemberState (MemberAuthorized hk) _ _ _ -> [(ck, Just hk)]
-                _ -> []
-          )
-          result
-  -- if the member is Authorized, it should appear in the commiteeState
-  Map.filter isJust comStateMembers `shouldBe` Map.fromList ckHk
-
-propResigned :: NewEpochState Conway -> Expectation
-propResigned nes = do
-  let (_, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  let resigned =
-        Map.filter
-          ( \case
-              CommitteeMemberState MemberResigned _ _ _ -> True
-              _ -> False
-          )
-          result
-  -- if the member is Resignd, it should appear in the commiteeState as Nothing
-  Map.keysSet (Map.filter isNothing comStateMembers) `shouldBe` Map.keysSet resigned
-
-propUnrecognized :: NewEpochState Conway -> Expectation
-propUnrecognized nes = do
-  let (comMembers, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  let unrecognized =
-        Map.filter
-          ( \case
-              CommitteeMemberState _ Unrecognized _ _ -> True
-              _ -> False
-          )
-          result
-  -- if the member is Unrecognized, it should not be in the committe, but it should be in the committeeState
-  Map.intersection comMembers unrecognized `shouldBe` Map.empty
-  Map.keysSet unrecognized `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
-
-propActiveAuthorized :: NewEpochState Conway -> Expectation
-propActiveAuthorized nes = do
-  let (comMembers, comStateMembers) = committeeInfo nes
-  let CommitteeMembersState result _ = queryCommitteeMembersStateNoFilters nes
-  let activeAuthorized =
-        Map.fromList $
+  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
+    let ckHk =
           Map.foldMapWithKey
             ( \ck cms ->
                 case cms of
-                  CommitteeMemberState (MemberAuthorized hk) Active _ _ -> [(ck, hk)]
+                  CommitteeMemberState (MemberAuthorized hk) _ _ _ -> [(ck, Just hk)]
                   _ -> []
             )
-            result
-  let epochNo = nes ^. nesELL
-  -- if a member is active and authorized, then it should be:
-  --   - in Committee and not expired
-  --   - in CommitteeState, not empty
-  Map.keysSet activeAuthorized
-    `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comMembers)
-  Map.keysSet activeAuthorized
-    `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
-  Map.intersection comMembers activeAuthorized
-    `shouldSatisfy` all (>= epochNo)
-  Map.intersection comStateMembers activeAuthorized
-    `shouldSatisfy` all isJust
+            (csCommittee noFilterResult)
+    -- if the member is Authorized, it should appear in the commiteeState
+    Map.filter isJust comStateMembers `shouldBe` Map.fromList ckHk
+
+propResigned ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
+propResigned nes = do
+  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
+    let resigned =
+          Map.filter
+            ( \case
+                CommitteeMemberState MemberResigned _ _ _ -> True
+                _ -> False
+            )
+            (csCommittee noFilterResult)
+    -- if the member is Resignd, it should appear in the commiteeState as Nothing
+    Map.keysSet (Map.filter isNothing comStateMembers) `shouldBe` Map.keysSet resigned
+
+propUnrecognized ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
+propUnrecognized nes = do
+  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
+    let unrecognized =
+          Map.filter
+            ( \case
+                CommitteeMemberState _ Unrecognized _ _ -> True
+                _ -> False
+            )
+            (csCommittee noFilterResult)
+    -- if the member is Unrecognized, it should not be in the committe, but it should be
+    -- in the committeeState
+    Map.intersection comMembers unrecognized `shouldBe` Map.empty
+    Map.keysSet unrecognized `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
+
+propActiveAuthorized ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
+propActiveAuthorized nes = do
+  withCommitteeInfo nes $ \comMembers comQuorum comStateMembers noFilterResult -> do
+    let activeAuthorized =
+          Map.fromList $
+            Map.foldMapWithKey
+              ( \ck cms ->
+                  case cms of
+                    CommitteeMemberState (MemberAuthorized hk) Active _ _ -> [(ck, hk)]
+                    _ -> []
+              )
+              (csCommittee noFilterResult)
+    let epochNo = nes ^. nesELL
+    -- if a member is active and authorized, then it should be:
+    --   - in Committee and not expired
+    --   - in CommitteeState, not empty
+    Map.keysSet activeAuthorized
+      `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comMembers)
+    Map.keysSet activeAuthorized
+      `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
+    Map.intersection comMembers activeAuthorized
+      `shouldSatisfy` all (>= epochNo)
+    Map.intersection comStateMembers activeAuthorized
+      `shouldSatisfy` all isJust
+    csEpochNo noFilterResult `shouldBe` epochNo
+    csQuorum noFilterResult `shouldBe` comQuorum
 
 propFilters ::
-  Set (Credential 'ColdCommitteeRole StandardCrypto) ->
-  Set (Credential 'HotCommitteeRole StandardCrypto) ->
+  forall era.
+  EraGov era =>
+  Set (Credential 'ColdCommitteeRole (EraCrypto era)) ->
+  Set (Credential 'HotCommitteeRole (EraCrypto era)) ->
   Set MemberStatus ->
-  NewEpochState Conway ->
+  NewEpochState era ->
   Expectation
 propFilters ckFilter hkFilter statusFilter nes = do
-  let CommitteeMembersState result _ =
-        queryCommitteeMembersState @Conway
-          ckFilter
-          hkFilter
-          statusFilter
-          nes
-  let allCks = Map.keysSet result
-  let (allHks, allMemberStatuses) =
-        foldMap'
-          ( \case
-              CommitteeMemberState (MemberAuthorized hk) ms _ _ -> (Set.singleton hk, Set.singleton ms)
-              CommitteeMemberState _ ms _ _ -> (Set.empty, Set.singleton ms)
-          )
-          result
-  unless (Set.null ckFilter) $
-    result `shouldSatisfy` const (allCks `Set.isSubsetOf` ckFilter)
-  unless (Set.null hkFilter) $
-    result `shouldSatisfy` const (allHks `Set.isSubsetOf` hkFilter)
-  unless (Set.null statusFilter) $
-    result `shouldSatisfy` const (allMemberStatuses `Set.isSubsetOf` statusFilter)
+  let qRes = queryCommitteeMembersState @era ckFilter hkFilter statusFilter nes
+  forM_ qRes $ \(CommitteeMembersState result _ _) -> do
+    let allCks = Map.keysSet result
+    let (allHks, allMemberStatuses) =
+          foldMap'
+            ( \case
+                CommitteeMemberState (MemberAuthorized hk) ms _ _ -> (Set.singleton hk, Set.singleton ms)
+                CommitteeMemberState _ ms _ _ -> (Set.empty, Set.singleton ms)
+            )
+            result
+    unless (Set.null ckFilter) $
+      result `shouldSatisfy` const (allCks `Set.isSubsetOf` ckFilter)
+    unless (Set.null hkFilter) $
+      result `shouldSatisfy` const (allHks `Set.isSubsetOf` hkFilter)
+    unless (Set.null statusFilter) $
+      result `shouldSatisfy` const (allMemberStatuses `Set.isSubsetOf` statusFilter)
 
 genCommonMembers ::
-  Map.Map (Credential 'ColdCommitteeRole StandardCrypto) EpochNo ->
-  Map.Map (Credential 'ColdCommitteeRole StandardCrypto) (Maybe (Credential 'HotCommitteeRole StandardCrypto)) ->
-  Gen (CommitteeState Conway)
+  Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
+  Map.Map
+    (Credential 'ColdCommitteeRole (EraCrypto era))
+    (Maybe (Credential 'HotCommitteeRole (EraCrypto era))) ->
+  Gen (CommitteeState era)
 genCommonMembers comMembers comStateMembers = do
   s <- choose (0, Map.size comMembers)
   let chosen = Map.take s comMembers
@@ -228,10 +256,10 @@ genCommonMembers comMembers comStateMembers = do
   pure $ CommitteeState $ x `Map.union` (Map.drop s comStateMembers)
 
 genRelevantColdCredsFilter ::
-  Set.Set (Credential 'ColdCommitteeRole StandardCrypto) ->
-  Map.Map (Credential 'ColdCommitteeRole StandardCrypto) EpochNo ->
-  Map.Map (Credential 'ColdCommitteeRole StandardCrypto) (Maybe (Credential 'HotCommitteeRole StandardCrypto)) ->
-  Gen (Set.Set (Credential 'ColdCommitteeRole StandardCrypto))
+  Set.Set (Credential 'ColdCommitteeRole c) ->
+  Map.Map (Credential 'ColdCommitteeRole c) EpochNo ->
+  Map.Map (Credential 'ColdCommitteeRole c) (Maybe (Credential 'HotCommitteeRole c)) ->
+  Gen (Set.Set (Credential 'ColdCommitteeRole c))
 genRelevantColdCredsFilter flt comMembers comStateMembers = do
   s <- choose (0, Set.size flt)
   let cm1 = Map.keysSet $ Map.take (s `div` 2) comMembers
@@ -239,29 +267,59 @@ genRelevantColdCredsFilter flt comMembers comStateMembers = do
   pure $ Set.unions [Set.drop s flt, cm1, cm2]
 
 genRelevantHotCredsFilter ::
-  Set.Set (Credential 'HotCommitteeRole StandardCrypto) ->
-  Map.Map (Credential 'ColdCommitteeRole StandardCrypto) (Maybe (Credential 'HotCommitteeRole StandardCrypto)) ->
-  Gen (Set.Set (Credential 'HotCommitteeRole StandardCrypto))
+  Set.Set (Credential 'HotCommitteeRole c) ->
+  Map.Map (Credential 'ColdCommitteeRole c) (Maybe (Credential 'HotCommitteeRole c)) ->
+  Gen (Set.Set (Credential 'HotCommitteeRole c))
 genRelevantHotCredsFilter flt comStateMembers = do
   s <- choose (0, Set.size flt)
   let cm = Set.fromList $ Map.elems (Map.mapMaybe id (Map.take s comStateMembers))
   pure $ Set.drop s flt `Set.union` cm
 
+withCommitteeInfo ::
+  EraGov era =>
+  NewEpochState era ->
+  ( Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
+    UnitInterval ->
+    Map.Map
+      (Credential 'ColdCommitteeRole (EraCrypto era))
+      (Maybe (Credential 'HotCommitteeRole (EraCrypto era))) ->
+    CommitteeMembersState (EraCrypto era) ->
+    Expectation
+  ) ->
+  Expectation
+withCommitteeInfo nes expectation =
+  case committeeInfo nes of
+    Nothing -> queryCommitteeMembersStateNoFilters nes `shouldBe` Nothing
+    Just (comMembers, comQuorum, comStateMembers) ->
+      case queryCommitteeMembersStateNoFilters nes of
+        Just noFilterQueryResult ->
+          expectation comMembers comQuorum comStateMembers noFilterQueryResult
+        Nothing ->
+          expectationFailure "Expected queryCommitteeMembersState to return a Just value"
+
 committeeInfo ::
-  NewEpochState Conway ->
-  ( Map.Map (Credential 'ColdCommitteeRole StandardCrypto) EpochNo
-  , Map.Map (Credential 'ColdCommitteeRole StandardCrypto) (Maybe (Credential 'HotCommitteeRole StandardCrypto))
-  )
-committeeInfo nes =
-  let comMembers = getCommitteeMembers (nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL)
-      comStateMembers =
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Maybe
+    ( Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo
+    , UnitInterval
+    , Map.Map
+        (Credential 'ColdCommitteeRole (EraCrypto era))
+        (Maybe (Credential 'HotCommitteeRole (EraCrypto era)))
+    )
+committeeInfo nes = do
+  (comMembers, comQurum) <-
+    getCommitteeMembers (nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL)
+  let comStateMembers =
         csCommitteeCreds $
           nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-   in (comMembers, comStateMembers)
+  pure (comMembers, comQurum, comStateMembers)
 
-queryCommitteeMembersStateNoFilters :: NewEpochState Conway -> CommitteeMembersState StandardCrypto
+queryCommitteeMembersStateNoFilters ::
+  forall era. EraGov era => NewEpochState era -> Maybe (CommitteeMembersState (EraCrypto era))
 queryCommitteeMembersStateNoFilters =
-  queryCommitteeMembersState @Conway
+  queryCommitteeMembersState @era
     Set.empty
     Set.empty
     Set.empty


### PR DESCRIPTION

# Description
When designing the query we forgot about two important pieces of information relevant for the constitutional commitee, namely the quorum value and the overall presence of the committee. There is a difference between an empty committee and no committe, the latter means that the system is in a state of no confidence.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
