### PR TITLE
Treasury withdrawals tests

### DIFF
--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -3,12 +3,11 @@
 module Main where
 
 import Cardano.Ledger.Allegra (Allegra)
-import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Allegra.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Allegra.ImpTest ()
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -16,4 +15,5 @@ main =
     describe "Allegra" $ do
       BinarySpec.spec
       CddlSpec.spec
-      ImpTestSpec.spec $ Proxy @Allegra
+      describe "Imp" $ do
+        ShelleyImp.spec @Allegra

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -9,7 +9,7 @@ import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Core (EraIndependentTxBody)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Test.Cardano.Ledger.Shelley.ImpTest (
-  EraImpTest (..),
+  ShelleyEraImp (..),
   emptyShelleyImpNES,
   shelleyImpWitsVKeyNeeded,
  )
@@ -20,7 +20,7 @@ instance
       (DSIGN c)
       (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (AllegraEra c)
+  ShelleyEraImp (AllegraEra c)
   where
   emptyImpNES = emptyShelleyImpNES
 

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -3,12 +3,11 @@
 module Main where
 
 import Cardano.Ledger.Alonzo (Alonzo)
-import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -16,4 +15,5 @@ main =
     describe "Alonzo" $ do
       BinarySpec.spec
       CddlSpec.spec
-      ImpTestSpec.spec $ Proxy @Alonzo
+      describe "Imp" $ do
+        ShelleyImp.spec @Alonzo

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -42,7 +42,7 @@ instance
   ( Crypto c
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (AlonzoEra c)
+  ShelleyEraImp (AlonzoEra c)
   where
   emptyImpNES = emptyAlonzoImpNES
 

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -3,12 +3,11 @@
 module Main where
 
 import Cardano.Ledger.Babbage (Babbage)
-import Data.Data (Proxy (..))
 import qualified Test.Cardano.Ledger.Babbage.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Babbage.ImpTest ()
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -16,4 +15,5 @@ main =
     describe "Babbage" $ do
       BinarySpec.spec
       CddlSpec.spec
-      ImpTestSpec.spec $ Proxy @Babbage
+      describe "Imp" $ do
+        ShelleyImp.spec @Babbage

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Core (EraIndependentTxBody)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Test.Cardano.Ledger.Alonzo.ImpTest (emptyAlonzoImpNES)
 import Test.Cardano.Ledger.Shelley.ImpTest (
-  EraImpTest (..),
+  ShelleyEraImp (..),
   shelleyImpWitsVKeyNeeded,
  )
 
@@ -19,7 +19,7 @@ instance
   ( Crypto c
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (BabbageEra c)
+  ShelleyEraImp (BabbageEra c)
   where
   emptyImpNES = emptyAlonzoImpNES
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -130,7 +130,7 @@ library testlib
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-conway,
         data-default-class,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-ledger-shelley,
         cardano-strict-containers,
         small-steps
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -103,6 +103,9 @@ library testlib
         Test.Cardano.Ledger.Conway.Binary.RoundTrip
         Test.Cardano.Ledger.Conway.PParamsSpec
         Test.Cardano.Ledger.Conway.ImpTest
+        Test.Cardano.Ledger.Conway.Imp
+        Test.Cardano.Ledger.Conway.Imp.EpochSpec
+        Test.Cardano.Ledger.Conway.Imp.EnactSpec
 
     visibility:       public
     hs-source-dirs:   testlib
@@ -119,6 +122,7 @@ library testlib
         cardano-data:{cardano-data, testlib},
         containers,
         microlens,
+        microlens-mtl,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-crypto-class,
         cardano-ledger-core:{cardano-ledger-core, testlib},
@@ -126,7 +130,7 @@ library testlib
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-conway,
         data-default-class,
-        cardano-ledger-shelley,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-strict-containers,
         small-steps
 
@@ -141,7 +145,6 @@ test-suite tests
         Test.Cardano.Ledger.Conway.CommitteeRatifySpec
         Test.Cardano.Ledger.Conway.GenesisSpec
         Test.Cardano.Ledger.Conway.GovActionReorderSpec
-        Test.Cardano.Ledger.Conway.EpochSpec
         Test.Cardano.Ledger.Conway.GovSpec
         Paths_cardano_ledger_conway
 
@@ -165,5 +168,4 @@ test-suite tests
         data-default-class,
         microlens,
         testlib,
-        cardano-strict-containers,
-        microlens
+        cardano-strict-containers

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -665,7 +665,7 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
   obligationGovState st =
     foldMap' gasDeposit $ snapshotActions (st ^. cgProposalsL)
 
-  getDRepDistr govst = (psDRepDistr . fst) $ finishDRepPulser (govst ^. drepPulsingStateGovStateL)
+  getDRepDistr govst = psDRepDistr . fst $ finishDRepPulser (govst ^. drepPulsingStateGovStateL)
 
 class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -165,7 +165,6 @@ conwayCertsTransition ::
   forall era.
   ( EraTx era
   , ConwayEraTxBody era
-  , ConwayEraPParams era
   , State (EraRule "CERT" era) ~ CertState era
   , Embed (EraRule "CERT" era) (ConwayCERTS era)
   , Environment (EraRule "CERT" era) ~ CertEnv era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -108,7 +108,6 @@ utxosTransition ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ConwayEraTxBody era
-  , ConwayEraPParams era
   , EraGov era
   , EraPlutusContext 'PlutusV1 era
   , ExtendedUTxO era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -429,7 +429,7 @@ instance
   getTotalDepositsTxBody = totalTxDepositsConway
 
 totalProposalDeposits ::
-  (ConwayEraTxBody era, ConwayEraPParams era) =>
+  ConwayEraTxBody era =>
   PParams era ->
   TxBody era ->
   Coin
@@ -678,7 +678,7 @@ instance ConwayEraTxBody era => EncCBOR (ConwayTxBodyRaw era) where
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (ConwayTxBody era)
 
-class (BabbageEraTxBody era, ConwayEraTxCert era) => ConwayEraTxBody era where
+class (BabbageEraTxBody era, ConwayEraTxCert era, ConwayEraPParams era) => ConwayEraTxBody era where
   -- | Lens for getting and setting number of `Coin` that is expected to be in the
   -- Treasury at the current Epoch
   currentTreasuryValueTxBodyL :: Lens' (TxBody era) (StrictMaybe Coin)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -81,9 +81,7 @@ getConwayScriptsNeeded utxo txb = getAlonzoScriptsNeeded utxo txb <> voterScript
         txb ^. votingProceduresTxBodyL
 
 conwayProducedValue ::
-  ( ConwayEraTxBody era
-  , ConwayEraPParams era
-  ) =>
+  ConwayEraTxBody era =>
   PParams era ->
   (KeyHash 'StakePool (EraCrypto era) -> Bool) ->
   TxBody era ->

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -5,28 +5,29 @@ module Main where
 import Cardano.Ledger.Conway (Conway)
 import Data.Proxy (Proxy (..))
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as CddlSpec
-import qualified Test.Cardano.Ledger.Conway.BinarySpec as BinarySpec
-import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatifySpec
-import qualified Test.Cardano.Ledger.Conway.DRepRatifySpec as DRepRatifySpec
-import qualified Test.Cardano.Ledger.Conway.EpochSpec as EpochSpec
-import qualified Test.Cardano.Ledger.Conway.GenesisSpec as GenesisSpec
-import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorderSpec
-import qualified Test.Cardano.Ledger.Conway.GovSpec as GovSpec
-import qualified Test.Cardano.Ledger.Conway.PParamsSpec as PParamsSpec
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
+import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
+import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatify
+import qualified Test.Cardano.Ledger.Conway.DRepRatifySpec as DRepRatify
+import qualified Test.Cardano.Ledger.Conway.GenesisSpec as Genesis
+import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorder
+import qualified Test.Cardano.Ledger.Conway.GovSpec as Gov
+import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
+import qualified Test.Cardano.Ledger.Conway.PParamsSpec as PParams
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
   ledgerTestMain $
     describe "Conway" $ do
-      BinarySpec.spec
-      CddlSpec.spec
-      DRepRatifySpec.spec
-      CommitteeRatifySpec.spec
-      GenesisSpec.spec
-      GovActionReorderSpec.spec
-      EpochSpec.spec
-      ImpTestSpec.spec $ Proxy @Conway
-      GovSpec.spec
-      PParamsSpec.spec $ Proxy @Conway
+      Binary.spec
+      Cddl.spec
+      DRepRatify.spec
+      CommitteeRatify.spec
+      Genesis.spec
+      GovActionReorder.spec
+      Gov.spec
+      PParams.spec $ Proxy @Conway
+      describe "Imp" $ do
+        ConwayImp.spec @Conway
+        ShelleyImp.spec @Conway

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conway.Imp (
+  spec,
+) where
+
+import Cardano.Ledger.Conway.Governance (ConwayGovState, GovState)
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
+import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
+import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp)
+
+spec ::
+  forall era.
+  ( ConwayEraImp era
+  , GovState era ~ ConwayGovState era
+  ) =>
+  Spec
+spec = do
+  describe "ConwayImpSpec" $ do
+    Enact.spec @era
+    Epoch.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -11,7 +11,7 @@ module Test.Cardano.Ledger.Conway.Imp.EnactSpec (spec) where
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Shelley.ImpTest
 
-spec :: forall era. EraImpTest era => Spec
+spec :: forall era. ShelleyEraImp era => Spec
 spec =
   describe "ENACT" $ do
     itM @era "TreasuryWithdrawal" $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Imp.EnactSpec (spec) where
+
+-- import Cardano.Ledger.Conway.Governance
+-- import Cardano.Ledger.Core
+-- import Cardano.Ledger.Shelley.LedgerState
+-- import Lens.Micro.Mtl
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec :: forall era. EraImpTest era => Spec
+spec =
+  describe "ENACT" $ do
+    itM @era "TreasuryWithdrawal" $ do
+      -- enactState <~ impNESL . newEpochStateGovStateL . rsEnactStateL
+      pure ()

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -1,19 +1,60 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.EnactSpec (spec) where
 
--- import Cardano.Ledger.Conway.Governance
--- import Cardano.Ledger.Core
--- import Cardano.Ledger.Shelley.LedgerState
--- import Lens.Micro.Mtl
+import Cardano.Ledger.Address
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.Rules (EnactSignal (..))
+import Cardano.Ledger.Shelley.LedgerState
+import Lens.Micro.Mtl
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Shelley.ImpTest
+import Test.Cardano.Ledger.Conway.ImpTest
 
-spec :: forall era. ShelleyEraImp era => Spec
+spec :: forall era. (ConwayEraImp era, GovState era ~ ConwayGovState era) => Spec
 spec =
   describe "ENACT" $ do
     itM @era "TreasuryWithdrawal" $ do
-      -- enactState <~ impNESL . newEpochStateGovStateL . rsEnactStateL
-      pure ()
+      rewardAcount1 <- registerRewardAccount
+      let govAction = TreasuryWithdrawals [(rewardAcount1, Coin 666)]
+      govActionId <- submitProposal govAction
+      enactStateInit <- use $ impNESL . newEpochStateGovStateL . cgEnactStateL
+      let signal =
+            EnactSignal
+              { esGovActionId = govActionId
+              , esGovAction = govAction
+              }
+          enactState =
+            enactStateInit
+              { ensTreasury = Coin 1000
+              }
+      enactState' <- runImpRule @"ENACT" () enactState signal
+      impIO $ ensWithdrawals enactState' `shouldBe` [(getRwdCred rewardAcount1, Coin 666)]
+
+      rewardAcount2 <- registerRewardAccount
+      let withdrawals' =
+            [ (rewardAcount1, Coin 111)
+            , (rewardAcount2, Coin 222)
+            ]
+          govAction' = TreasuryWithdrawals withdrawals'
+      govActionId' <- submitProposal govAction'
+      let signal' =
+            EnactSignal
+              { esGovActionId = govActionId'
+              , esGovAction = govAction'
+              }
+
+      enactState'' <- runImpRule @"ENACT" () enactState' signal'
+
+      impIO $ do
+        ensWithdrawals enactState''
+          `shouldBe` [ (getRwdCred rewardAcount1, Coin 777)
+                     , (getRwdCred rewardAcount2, Coin 222)
+                     ]
+        ensTreasury enactState'' `shouldBe` Coin 1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -2,24 +2,25 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.Cardano.Ledger.Conway.Imp.EpochSpec (spec) where
 
+import Cardano.Ledger.Address
 import Cardano.Ledger.BaseTypes (textToUrl)
-import Cardano.Ledger.Conway.Core (
-  Constitution (..),
-  DRepVotingThresholds (..),
- )
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Compactible
+import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
   ConwayGovState,
   GovAction (..),
-  GovState,
   Voter (..),
   cgEnactStateL,
   ensCommitteeL,
@@ -30,12 +31,18 @@ import Cardano.Ledger.Conway.PParams (
   ppGovActionLifetimeL,
  )
 import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.LedgerState (
+  asTreasuryL,
+  epochStateUMapL,
+  esAccountStateL,
   esLStateL,
   lsUTxOStateL,
   nesEsL,
   utxosGovStateL,
  )
+import Cardano.Ledger.UMap as UMap
+import Cardano.Ledger.Val
 import Data.Default.Class (Default (..))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
@@ -62,28 +69,6 @@ spec =
       passEpoch
 
     itM @era "constitution is accepted after two epochs" $ do
-      logEntry "Setting up PParams and DRep"
-      modifyPParams $ \pp ->
-        pp
-          & ppDRepVotingThresholdsL
-            .~ def
-              { dvtCommitteeNormal = 1 %! 1
-              , dvtCommitteeNoConfidence = 1 %! 2
-              , dvtUpdateToConstitution = 1 %! 2
-              }
-          & ppCommitteeMaxTermLengthL .~ 10
-          & ppGovActionLifetimeL .~ 2
-      khDRep <- setupSingleDRep
-
-      logEntry "Registering committee member"
-      khCommitteeMember <- freshKeyHash
-      let
-        committeeAction =
-          UpdateCommittee
-            SNothing
-            mempty
-            (Map.singleton (KeyHashObj khCommitteeMember) 10)
-            (1 %! 2)
       constitutionHash <- freshSafeHash
       let
         constitutionAction =
@@ -96,41 +81,19 @@ spec =
                 )
                 SNothing
             )
-      gaidCommitteeProp <- submitProposal committeeAction
-
       -- Submit NewConstitution proposal two epoch too early to check that the action
       -- doesn't expire prematurely (ppGovActionLifetimeL is set to two epochs)
+      logEntry "Submitting new constitution"
       gaidConstitutionProp <- submitProposal constitutionAction
 
-      _ <- voteForProposal (DRepVoter $ KeyHashObj khDRep) gaidCommitteeProp
-
-      let
-        assertNoCommittee = do
-          committee <-
-            getsNES $
-              nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
-          impIOMsg "There should not be a committee" $ committee `shouldBe` SNothing
-      logRatificationChecks gaidCommitteeProp
-      assertNoCommittee
-
-      passEpoch
-      logRatificationChecks gaidCommitteeProp
-      assertNoCommittee
-      passEpoch
-      do
-        committee <-
-          getsNES $
-            nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
-        impIOMsg "There should be a committee" $ committee `shouldSatisfy` isSJust
-      logEntry "Submitting new constitution"
+      (dRepCred, committeeHotCred) <- electBasicCommittee
 
       logRatificationChecks gaidConstitutionProp
       do
         isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
         impIOMsg "Gov action should not be accepted" $ isAccepted `shouldBe` False
-      khCommitteeMemberHot <- registerCommitteeHotKey khCommitteeMember
-      _ <- voteForProposal (DRepVoter $ KeyHashObj khDRep) gaidConstitutionProp
-      _ <- voteForProposal (CommitteeVoter $ KeyHashObj khCommitteeMemberHot) gaidConstitutionProp
+      _ <- voteForProposal (DRepVoter dRepCred) gaidConstitutionProp
+      _ <- voteForProposal (CommitteeVoter committeeHotCred) gaidConstitutionProp
       logAcceptedRatio gaidConstitutionProp
       do
         isAccepted <- canGovActionBeDRepAccepted gaidConstitutionProp
@@ -146,3 +109,83 @@ spec =
 
       passEpoch
       constitutionShouldBe "constitution.0"
+
+    itM @era "TreasuryWithdrawal" $ do
+      (dRepCred, committeeHotCred) <- electBasicCommittee
+
+      treasuryStart <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+
+      rewardAcount <- registerRewardAccount
+      let withdrawalAmount = Coin 666
+          govAction = TreasuryWithdrawals [(rewardAcount, withdrawalAmount)]
+      govActionId <- submitProposal govAction
+
+      _ <- voteForProposal (DRepVoter dRepCred) govActionId
+      _ <- voteForProposal (CommitteeVoter committeeHotCred) govActionId
+
+      passEpoch
+      passEpoch
+
+      treasuryEnd <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+      umap <- getsNES $ nesEsL . epochStateUMapL
+      impIO $ do
+        let cred = getRwdCred rewardAcount
+        case UMap.lookup cred (RewDepUView umap) of
+          Nothing -> error $ "Expected a reward account: " ++ show cred
+          Just RDPair {rdReward} -> fromCompact rdReward `shouldBe` withdrawalAmount
+        treasuryStart <-> treasuryEnd `shouldBe` withdrawalAmount
+
+electBasicCommittee ::
+  forall era.
+  ( ConwayEraImp era
+  , GovState era ~ ConwayGovState era
+  ) =>
+  ImpTestM era (Credential 'DRepRole (EraCrypto era), Credential 'HotCommitteeRole (EraCrypto era))
+electBasicCommittee = do
+  logEntry "Setting up PParams and DRep"
+  modifyPParams $ \pp ->
+    pp
+      & ppDRepVotingThresholdsL
+        .~ def
+          { dvtCommitteeNormal = 1 %! 1
+          , dvtCommitteeNoConfidence = 1 %! 2
+          , dvtUpdateToConstitution = 1 %! 2
+          }
+      & ppCommitteeMaxTermLengthL .~ 10
+      & ppGovActionLifetimeL .~ 2
+  khDRep <- setupSingleDRep
+
+  logEntry "Registering committee member"
+  khCommitteeMember <- freshKeyHash
+  let
+    committeeAction =
+      UpdateCommittee
+        SNothing
+        mempty
+        (Map.singleton (KeyHashObj khCommitteeMember) 10)
+        (1 %! 2)
+  gaidCommitteeProp <- submitProposal committeeAction
+
+  _ <- voteForProposal (DRepVoter $ KeyHashObj khDRep) gaidCommitteeProp
+
+  let
+    assertNoCommittee = do
+      committee <-
+        getsNES $
+          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+      impIOMsg "There should not be a committee" $ committee `shouldBe` SNothing
+  logRatificationChecks gaidCommitteeProp
+  assertNoCommittee
+
+  passEpoch
+  logRatificationChecks gaidCommitteeProp
+  assertNoCommittee
+  passEpoch
+  do
+    committee <-
+      getsNES $
+        nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+    impIOMsg "There should be a committee" $ committee `shouldSatisfy` isSJust
+
+  khCommitteeMemberHot <- registerCommitteeHotKey khCommitteeMember
+  pure (KeyHashObj khDRep, KeyHashObj khCommitteeMemberHot)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -7,17 +8,18 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Test.Cardano.Ledger.Conway.EpochSpec (spec) where
+module Test.Cardano.Ledger.Conway.Imp.EpochSpec (spec) where
 
 import Cardano.Ledger.BaseTypes (textToUrl)
-import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core (
   Constitution (..),
   DRepVotingThresholds (..),
  )
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
+  ConwayGovState,
   GovAction (..),
+  GovState,
   Voter (..),
   cgEnactStateL,
   ensCommitteeL,
@@ -39,20 +41,19 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import Data.Maybe.Strict (StrictMaybe (..), isSJust)
 import Lens.Micro ((&), (.~))
-import Test.Cardano.Ledger.Common (
-  HasCallStack,
-  Spec,
-  describe,
-  shouldBe,
-  shouldSatisfy,
- )
+import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 
-spec :: HasCallStack => Spec
+spec ::
+  forall era.
+  ( ConwayEraImp era
+  , GovState era ~ ConwayGovState era
+  ) =>
+  Spec
 spec =
-  describe "Ratify traces" $ do
-    itM @Conway "DRep registration should succeed" $ do
+  describe "EPOCH" $ do
+    itM @era "DRep registration should succeed" $ do
       logEntry "Stake distribution before DRep registration:"
       logStakeDistr
       _ <- registerDRep
@@ -60,7 +61,7 @@ spec =
       logStakeDistr
       passEpoch
 
-    itM @Conway "constitution is accepted after two epochs" $ do
+    itM @era "constitution is accepted after two epochs" $ do
       logEntry "Setting up PParams and DRep"
       modifyPParams $ \pp ->
         pp

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -8,10 +8,12 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conway.ImpTest (
   module ImpTest,
+  ConwayEraImp,
   submitProposal,
   submitFailingProposal,
   voteForProposal,
@@ -182,6 +184,19 @@ instance
   impWitsVKeyNeeded = conwayImpWitsVKeyNeeded
 
   modifyPParams = conwayModifyPParams
+
+class
+  ( EraImpTest era
+  , ConwayEraGov era
+  , ConwayEraTxBody era
+  ) =>
+  ConwayEraImp era
+
+instance
+  ( Crypto c
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  ConwayEraImp (ConwayEra c)
 
 -- | Submit a transaction that registers a new DRep and return the keyhash
 -- belonging to that DRep

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -170,7 +170,7 @@ instance
   ( Crypto c
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (ConwayEra c)
+  ShelleyEraImp (ConwayEra c)
   where
   emptyImpNES rootCoin =
     let nes =
@@ -186,7 +186,7 @@ instance
   modifyPParams = conwayModifyPParams
 
 class
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraGov era
   , ConwayEraTxBody era
   ) =>
@@ -202,7 +202,7 @@ instance
 -- belonging to that DRep
 registerDRep ::
   forall era.
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxCert era
   ) =>
   ImpTestM era (KeyHash 'DRepRole (EraCrypto era))
@@ -228,7 +228,7 @@ registerDRep = do
 setupSingleDRep ::
   forall era.
   ( ConwayEraTxCert era
-  , EraImpTest era
+  , ShelleyEraImp era
   ) =>
   ImpTestM era (KeyHash 'DRepRole (EraCrypto era))
 setupSingleDRep = do
@@ -258,7 +258,7 @@ setupSingleDRep = do
 -- | Submits a transaction that votes "Yes" for the given governance action as
 -- some voter
 voteForProposal ::
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxBody era
   ) =>
   Voter (EraCrypto era) ->
@@ -284,7 +284,7 @@ voteForProposal voter gaId = do
 -- | Submits a transaction that votes "Yes" for the given governance action as
 -- some voter, and expects an `Either` result.
 tryVoteForProposal ::
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxBody era
   ) =>
   Voter (EraCrypto era) ->
@@ -314,7 +314,7 @@ tryVoteForProposal voter gaId = do
 
 -- | Submits a transaction that proposes the given governance action
 trySubmitProposal ::
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxBody era
   ) =>
   GovAction era ->
@@ -351,7 +351,7 @@ trySubmitProposal ga = do
 
 submitProposal ::
   forall era.
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxBody era
   ) =>
   GovAction era ->
@@ -359,7 +359,7 @@ submitProposal ::
 submitProposal ga = trySubmitProposal ga >>= impExpectSuccess
 
 submitFailingProposal ::
-  ( EraImpTest era
+  ( ShelleyEraImp era
   , ConwayEraTxBody era
   ) =>
   GovAction era ->
@@ -515,7 +515,7 @@ logRatificationChecks gaId = do
 -- | Submits a transaction that registers a hot key for the given cold key.
 -- Returns the hot key hash.
 registerCommitteeHotKey ::
-  (EraImpTest era, ConwayEraTxCert era) =>
+  (ShelleyEraImp era, ConwayEraTxCert era) =>
   KeyHash 'ColdCommitteeRole (EraCrypto era) ->
   ImpTestM era (KeyHash 'HotCommitteeRole (EraCrypto era))
 registerCommitteeHotKey coldKey = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -36,7 +36,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
 import Cardano.Crypto.DSIGN.Class (Signable)
 import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Address (RewardAcnt (..))
-import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Network (..), ShelleyBase, StrictMaybe (..))
 import Cardano.Ledger.CertState (DRep (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
@@ -82,6 +82,7 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.PParams (ConwayEraPParams, ppDRepActivityL, ppGovActionLifetimeL)
 import Cardano.Ledger.Conway.Rules (
+  EnactSignal,
   committeeAccepted,
   committeeAcceptedRatio,
   conwayWitsVKeyNeeded,
@@ -189,6 +190,11 @@ class
   ( ShelleyEraImp era
   , ConwayEraGov era
   , ConwayEraTxBody era
+  , STS (EraRule "ENACT" era)
+  , BaseM (EraRule "ENACT" era) ~ ShelleyBase
+  , State (EraRule "ENACT" era) ~ EnactState era
+  , Signal (EraRule "ENACT" era) ~ EnactSignal era
+  , Environment (EraRule "ENACT" era) ~ ()
   ) =>
   ConwayEraImp era
 

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -3,13 +3,12 @@
 module Main where
 
 import Cardano.Ledger.Mary (Mary)
-import Data.Data (Proxy (..))
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -18,4 +17,5 @@ main =
       ValueSpec.spec
       BinarySpec.spec
       CddlSpec.spec
-      ImpTestSpec.spec $ Proxy @Mary
+      describe "Imp" $ do
+        ShelleyImp.spec @Mary

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -9,7 +9,7 @@ import Cardano.Ledger.Core (EraIndependentTxBody)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Mary (MaryEra)
 import Test.Cardano.Ledger.Shelley.ImpTest (
-  EraImpTest (..),
+  ShelleyEraImp (..),
   emptyShelleyImpNES,
   shelleyImpWitsVKeyNeeded,
  )
@@ -18,7 +18,7 @@ instance
   ( Crypto c
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (MaryEra c)
+  ShelleyEraImp (MaryEra c)
   where
   emptyImpNES = emptyShelleyImpNES
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -142,7 +142,9 @@ library testlib
         Test.Cardano.Ledger.Shelley.Binary.RoundTrip
         Test.Cardano.Ledger.Shelley.Constants
         Test.Cardano.Ledger.Shelley.ImpTest
-        Test.Cardano.Ledger.Shelley.ImpTestSpec
+        Test.Cardano.Ledger.Shelley.Imp
+        Test.Cardano.Ledger.Shelley.Imp.EpochSpec
+        Test.Cardano.Ledger.Shelley.Imp.LedgerSpec
 
     visibility:       public
     hs-source-dirs:   testlib

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -3,11 +3,10 @@
 module Main where
 
 import Cardano.Ledger.Shelley (Shelley)
-import Data.Data (Proxy (..))
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Shelley.BinarySpec as Binary
-import qualified Test.Cardano.Ledger.Shelley.ImpTestSpec as ImpTestSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as Imp
 
 main :: IO ()
 main =
@@ -15,4 +14,4 @@ main =
     describe "Shelley" $ do
       Binary.spec
       Cddl.spec
-      ImpTestSpec.spec $ Proxy @Shelley
+      Imp.spec @Shelley

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -9,9 +9,9 @@ module Test.Cardano.Ledger.Shelley.Imp (
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
-import Test.Cardano.Ledger.Shelley.ImpTest (EraImpTest)
+import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp)
 
-spec :: forall era. EraImpTest era => Spec
+spec :: forall era. ShelleyEraImp era => Spec
 spec =
   describe "ShelleyImpSpec" $ do
     Ledger.spec @era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.Imp (
+  spec,
+) where
+
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
+import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
+import Test.Cardano.Ledger.Shelley.ImpTest (EraImpTest)
+
+spec :: forall era. EraImpTest era => Spec
+spec =
+  describe "ShelleyImpSpec" $ do
+    Ledger.spec @era
+    Epoch.spec @era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Val (Val (..))
 import Test.Cardano.Ledger.Common (Spec, describe, shouldBe)
 import Test.Cardano.Ledger.Shelley.ImpTest (
-  EraImpTest,
+  ShelleyEraImp,
   getsNES,
   impIO,
   itM,
@@ -30,7 +30,7 @@ import Test.Cardano.Ledger.Shelley.ImpTest (
 
 spec ::
   forall era.
-  EraImpTest era =>
+  ShelleyEraImp era =>
   Spec
 spec = describe "EPOCH" $ do
   itM @era "Runs basic transaction" $ do

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.Imp.EpochSpec (
+  spec,
+) where
+
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.LedgerState (
+  esLStateL,
+  lsCertStateL,
+  lsUTxOStateL,
+  nesELL,
+  nesEsL,
+  totalObligation,
+  utxosDepositedL,
+  utxosGovStateL,
+ )
+import Cardano.Ledger.Val (Val (..))
+import Test.Cardano.Ledger.Common (Spec, describe, shouldBe)
+import Test.Cardano.Ledger.Shelley.ImpTest (
+  EraImpTest,
+  getsNES,
+  impIO,
+  itM,
+  passEpoch,
+  submitTx,
+ )
+
+spec ::
+  forall era.
+  EraImpTest era =>
+  Spec
+spec = describe "EPOCH" $ do
+  itM @era "Runs basic transaction" $ do
+    do
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      govState <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+      impIO $ totalObligation certState govState `shouldBe` zero
+    do
+      deposited <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosDepositedL
+      impIO $ deposited `shouldBe` zero
+    _ <- submitTx "simple transaction" $ mkBasicTx mkBasicTxBody
+    passEpoch
+
+  itM @era "Crosses the epoch boundary" $ do
+    do
+      epoch <- getsNES nesELL
+      impIO $ epoch `shouldBe` 0
+    passEpoch
+    do
+      epoch <- getsNES nesELL
+      impIO $ epoch `shouldBe` 1

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
@@ -1,26 +1,39 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Cardano.Ledger.Shelley.ImpTestSpec (
+module Test.Cardano.Ledger.Shelley.Imp.LedgerSpec (
   spec,
 ) where
 
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (EraTx (..), EraTxBody (..), EraTxOut (..), coinTxOutL)
-import Cardano.Ledger.Shelley.LedgerState (esLStateL, lsCertStateL, lsUTxOStateL, nesELL, nesEsL, totalObligation, utxosDepositedL, utxosGovStateL, utxosUtxoL)
+import Cardano.Ledger.Shelley.LedgerState (
+  esLStateL,
+  lsUTxOStateL,
+  nesEsL,
+  utxosUtxoL,
+ )
 import Cardano.Ledger.Shelley.UTxO (UTxO (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
-import Data.Data (Proxy (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Common (Spec, describe, shouldBe)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
-import Test.Cardano.Ledger.Shelley.ImpTest (EraImpTest, ImpTestM, freshKeyHash, getsNES, impIO, itM, lookupKeyPair, passEpoch, submitTx)
+import Test.Cardano.Ledger.Shelley.ImpTest (
+  EraImpTest,
+  ImpTestM,
+  freshKeyHash,
+  getsNES,
+  impIO,
+  itM,
+  lookupKeyPair,
+  submitTx,
+ )
 
 getUTxO :: ImpTestM era (UTxO era)
 getUTxO = getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
@@ -28,28 +41,8 @@ getUTxO = getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
 spec ::
   forall era.
   EraImpTest era =>
-  Proxy era ->
   Spec
-spec _ = describe "ImpTest spec" $ do
-  itM @era "Runs basic transaction" $ do
-    do
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      govState <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-      impIO $ totalObligation certState govState `shouldBe` zero
-    do
-      deposited <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosDepositedL
-      impIO $ deposited `shouldBe` zero
-    _ <- submitTx "simple transaction" $ mkBasicTx mkBasicTxBody
-    passEpoch
-
-  itM @era "Crosses the epoch boundary" $ do
-    do
-      epoch <- getsNES nesELL
-      impIO $ epoch `shouldBe` 0
-    passEpoch
-    do
-      epoch <- getsNES nesELL
-      impIO $ epoch `shouldBe` 1
+spec = describe "LEDGER" $ do
   itM @era "Transactions update UTxO" $ do
     kpPayment1 <- lookupKeyPair =<< freshKeyHash
     kpStaking1 <- lookupKeyPair =<< freshKeyHash

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
@@ -25,8 +25,8 @@ import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Common (Spec, describe, shouldBe)
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Shelley.ImpTest (
-  EraImpTest,
   ImpTestM,
+  ShelleyEraImp,
   freshKeyHash,
   getsNES,
   impIO,
@@ -40,7 +40,7 @@ getUTxO = getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
 
 spec ::
   forall era.
-  EraImpTest era =>
+  ShelleyEraImp era =>
   Spec
 spec = describe "LEDGER" $ do
   itM @era "Transactions update UTxO" $ do

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -21,7 +21,7 @@
 module Test.Cardano.Ledger.Shelley.ImpTest (
   ImpTestM,
   ImpException (..),
-  EraImpTest (..),
+  ShelleyEraImp (..),
   logStakeDistr,
   emptyShelleyImpNES,
   shelleyImpWitsVKeyNeeded,
@@ -202,7 +202,7 @@ class
   , NFData (PredicateFailure (EraRule "TICK" era))
   , NFData (StashedAVVMAddresses era)
   ) =>
-  EraImpTest era
+  ShelleyEraImp era
   where
   emptyImpNES :: Coin -> NewEpochState era
 
@@ -326,7 +326,7 @@ instance
   ( Crypto c
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
   ) =>
-  EraImpTest (ShelleyEra c)
+  ShelleyEraImp (ShelleyEra c)
   where
   emptyImpNES = emptyShelleyImpNES
 
@@ -353,7 +353,7 @@ runShelleyBase act = runIdentity $ runReaderT act testGlobals
 
 fixupFees ::
   forall era.
-  EraImpTest era =>
+  ShelleyEraImp era =>
   Tx era ->
   ImpTestM era (Tx era)
 fixupFees tx = do
@@ -381,7 +381,7 @@ fixupFees tx = do
 
 submitTx_ ::
   forall era.
-  EraImpTest era =>
+  ShelleyEraImp era =>
   Tx era ->
   ImpTestM
     era
@@ -404,7 +404,7 @@ submitTx_ tx = do
   pure $ (,txFixed) <$> runShelleyBase (applySTSTest @(EraRule "LEDGER" era) trc)
 
 trySubmitTx ::
-  EraImpTest era =>
+  ShelleyEraImp era =>
   Tx era ->
   ImpTestM era (Either [PredicateFailure (EraRule "LEDGER" era)] (TxId (EraCrypto era)))
 trySubmitTx tx = do
@@ -419,7 +419,7 @@ trySubmitTx tx = do
 -- outputs are automatically balanced.
 submitFailingTx ::
   ( HasCallStack
-  , EraImpTest era
+  , ShelleyEraImp era
   ) =>
   Tx era ->
   ImpTestM era ()
@@ -507,7 +507,7 @@ logEntry e = impLogL %= (<> pretty e <> line)
 -- | Make the `ImpTestM` into a Spec item with the given description
 itM ::
   forall era a.
-  EraImpTest era =>
+  ShelleyEraImp era =>
   String ->
   ImpTestM era a ->
   Spec
@@ -528,7 +528,7 @@ itM desc (ImpTestM m) =
 -- | Returns the @TxWits@ needed for sumbmitting the transaction
 mkTxWits ::
   ( HasCallStack
-  , EraImpTest era
+  , ShelleyEraImp era
   ) =>
   TxBody era ->
   ImpTestM era (TxWits era)
@@ -607,7 +607,7 @@ impIO = impIOMsg ""
 
 submitTx ::
   ( HasCallStack
-  , EraImpTest era
+  , ShelleyEraImp era
   ) =>
   String ->
   Tx era ->

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -399,7 +399,6 @@ submitTx_ ::
 submitTx_ tx = do
   st <- gets impNES
   txFixed <- fixupFees tx
-  logEntry $ showExpr txFixed
   lEnv <- impLedgerEnv st
   globals <- use $ to impGlobals
   let

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/ConwayFeatures.hs
@@ -392,7 +392,6 @@ preventDRepExpiry ::
   , Scriptic era
   , ConwayEraTxBody era
   , GovState era ~ ConwayGovState era
-  , ConwayEraPParams era
   , ConwayEraGov era
   ) =>
   Proof era ->
@@ -532,7 +531,6 @@ testGov ::
   , ConwayEraGov era
   , GovState era ~ ConwayGovState era
   , TxCert era ~ ConwayTxCert era
-  , ConwayEraPParams era
   ) =>
   Proof era ->
   Assertion


### PR DESCRIPTION
# Description

This PR reorganized the ImpTest framework a little. Gives it a bit more structure.

Adds ability to create reward accounts in ImpTest

Adds tests for TreasuryWithdrawals that replicate #3827 bug and confirm #3831 fix

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
