### PR TITLE
Added `cardano-ledger-conformance`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
+  tag: 1dc69a3b8b80838ffa38a600879ae530c0fcab16
+
 index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-09-29T00:20:27Z
@@ -55,6 +60,7 @@ packages:
   eras/byron/crypto/test
 
   -- Packages used during development and are not released to CHaPs:
+  libs/cardano-ledger-conformance
   libs/cardano-ledger-test
   libs/plutus-preprocessor
   libs/ledger-state

--- a/hie.yaml
+++ b/hie.yaml
@@ -177,6 +177,9 @@ cradle:
     - path: "libs/cardano-ledger-binary/test"
       component: "cardano-ledger-binary:test:tests"
 
+    - path: "libs/cardano-ledger-conformance/src"
+      component: "lib:cardano-ledger-conformance"
+
     - path: "libs/cardano-ledger-core/src"
       component: "lib:cardano-ledger-core"
 

--- a/libs/cardano-ledger-conformance/Setup.hs
+++ b/libs/cardano-ledger-conformance/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -1,0 +1,36 @@
+cabal-version:      3.0
+name:               cardano-ledger-conformance
+version:            0.1.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:           Testing utilities for conformance testing
+description:        Testing utilities for conformance testing
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-conformance
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:  Test.Cardano.Ledger.Conformance
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        cardano-ledger-executable-spec
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -1,0 +1,10 @@
+module Test.Cardano.Ledger.Conformance (
+
+) where
+
+import Lib (TxBody)
+
+-- Placeholder so that the compiler wouldn't complain about
+-- `cardano-ledger-executable-spec` being a redundant dependency
+_placeholder :: TxBody
+_placeholder = undefined


### PR DESCRIPTION
# Description

Adds the `cardano-ledger-conformance` package, which imports the executable spec generated from Agda. Currently it pulls the generated code from Github, but hopefully we can do that via Nix in the future without the need for an additional repo. 

Resolves steps 0 and 1 in #3811.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
