### PR TITLE
Revert argument order swap.

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.6.0.0
-
-* Swap the order of arguments for `updateCostModels`
+## 1.5.1.0
 
 ### `testlib`
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.6.0.0
+version:            1.5.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -547,13 +547,13 @@ data CostModels = CostModels
 emptyCostModels :: CostModels
 emptyCostModels = CostModels mempty mempty mempty
 
--- | Updates the second @CostModels@ with the first one so that only the
--- cost models that are present in the first one get updated while all the
+-- | Updates the first @CostModels@ with the second one so that only the
+-- cost models that are present in the second one get updated while all the
 -- others stay unchanged
 updateCostModels :: CostModels -> CostModels -> CostModels
 updateCostModels
-  (CostModels newValid newErrors newUnk)
-  (CostModels oldValid oldErrors oldUnk) =
+  (CostModels oldValid oldErrors oldUnk)
+  (CostModels newValid newErrors newUnk) =
     CostModels
       (Map.union newValid oldValid)
       (Map.union newErrors oldErrors)

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -78,7 +78,7 @@ library
         cardano-data >=1.1.2.0,
         cardano-ledger-binary >=1.2,
         cardano-ledger-allegra >=1.1,
-        cardano-ledger-alonzo ^>=1.6,
+        cardano-ledger-alonzo ^>=1.5,
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.8,
         cardano-ledger-mary >=1.1,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -983,7 +983,7 @@ conwayApplyPPUpdates pp ppu =
     ppUpdateCostModels (THKD curCostModel) (THKD ppuCostModel) =
       case ppuCostModel of
         SNothing -> THKD curCostModel
-        SJust costModelUpdate -> THKD $ updateCostModels costModelUpdate curCostModel
+        SJust costModelUpdate -> THKD $ updateCostModels curCostModel costModelUpdate
 
 conwayModifiedPPGroups :: ConwayPParams StrictMaybe era -> Set PPGroup
 conwayModifiedPPGroups


### PR DESCRIPTION
# Description

This change was accidentally merge into master in #3836 

Reversion of this change is desired since it can be dangerous if a wrong version of cardano-ledger-alonzo gets used somehow  by cardano-ledegr-conway
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
