### PR TITLE
Integration work for node 8.7.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,9 +18,9 @@ source-repository-package
 
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2023-09-29T00:20:27Z
+  , hackage.haskell.org 2023-11-09T23:50:15Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-10-30T04:08:41Z
+  , cardano-haskell-packages 2023-11-08T10:13:53Z
 
 packages:
   eras/allegra/impl
@@ -66,6 +66,11 @@ packages:
   libs/plutus-preprocessor
   libs/ledger-state
 
+constraints:
+  -- Plutus is incompatible with 0.1.5 because of the Identity instance, once
+  -- they fix that we shall remove this constraint.
+  nothunks == 0.1.4
+
 program-options
   ghc-options: -Werror
 
@@ -90,14 +95,3 @@ benchmarks: true
 
 -- The only sensible test display option
 test-show-details: streaming
-
-if impl(ghc >= 9.6)
-  allow-newer:
-    , *:base
-    , *:ghc-prim
-    , *:template-haskell
-    , *:vector
-
-  constraints:
-      -- Earlier versions have a slightly different set of type constraints.
-      persistent >= 2.14

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -13,8 +13,8 @@ category:           Network
 build-type:         Simple
 data-files:
     cddl-files/allegra.cddl
-    cddl-files/real/crypto.cddl
-    cddl-files/mock/extras.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
 
 extra-source-files: CHANGELOG.md
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -14,8 +14,8 @@ category:           Network
 build-type:         Simple
 data-files:
     cddl-files/alonzo.cddl
-    cddl-files/real/crypto.cddl
-    cddl-files/mock/extras.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
 
 extra-source-files: CHANGELOG.md
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -16,8 +16,8 @@ category:           Network
 build-type:         Simple
 data-files:
     cddl-files/babbage.cddl
-    cddl-files/real/crypto.cddl
-    cddl-files/mock/extras.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
 
 extra-source-files: CHANGELOG.md
 

--- a/eras/byron/ledger/impl/CHANGELOG.md
+++ b/eras/byron/ledger/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for `cardano-ledger-byron`
 
+## 1.0.0.3
+
+* Update `streaming-binary` dependency to 0.4.
+
 ## 1.0.0.1
 
 * Make it build with `ghc-9.6`.

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-byron
-version:            1.0.0.2
+version:            1.0.0.3
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -252,7 +252,7 @@ library
         quiet,
         resourcet,
         streaming,
-        streaming-binary >=0.2 && <0.3,
+        streaming-binary >=0.2 && <0.4,
         streaming-bytestring,
         text,
         time,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -14,6 +14,7 @@ build-type:         Simple
 data-files:
     test/data/*.json
     cddl-files/conway.cddl
+    cddl-files/crypto.cddl
     cddl-files/extra.cddl
 
 extra-source-files: CHANGELOG.md

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -14,8 +14,8 @@ category:           Network
 build-type:         Simple
 data-files:
     cddl-files/mary.cddl
-    cddl-files/real/crypto.cddl
-    cddl-files/mock/extras.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
 
 extra-source-files: CHANGELOG.md
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -8,8 +8,8 @@ synopsis:           Shelley Ledger Executable Model
 build-type:         Simple
 data-files:
     cddl-files/shelley.cddl
-    cddl-files/real/crypto.cddl
-    cddl-files/mock/extras.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
 
 extra-source-files: CHANGELOG.md
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1698645491,
-        "narHash": "sha256-P+cNk+SltCS+gqlG8KdE5KjJmpOYfPfZLg1/Q7kdWQ0=",
+        "lastModified": 1699449503,
+        "narHash": "sha256-JY4N+0U3kj3aW7TGeNBGzz6atjR9Ty4qzC8gapGHt1Q=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "f83ad7ac03011b4d409b2eb00a9eba960a698d9c",
+        "rev": "ae52e4fa9ede02cb7b8336c7403a5ca7c7ab0a04",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1696465466,
-        "narHash": "sha256-YlazbA1gGX6DGONHpGsA7vEgS0y43TzmarLkRjL0Nn0=",
+        "lastModified": 1699575932,
+        "narHash": "sha256-ncwq1sRA0/AdyMFsvACX2Bt1Z0YJnqwD3MmoEKyf6N8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a99556cc8d1b2296eb1cc11c301564e1ee9324d1",
+        "rev": "cdd0cf2e90d2ceb60c82ca923bc21c45f72df02d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -157,15 +157,15 @@
             ({pkgs, ...}:
               lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
                 packages.set-algebra.components.tests.tests.buildable = lib.mkForce false;
-                packages.plutus-preprocessor.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-shelley.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-allegra.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-mary.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-alonzo.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-babbage.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-conway.package.buildable = lib.mkForce false;
-                packages.cardano-protocol-tpraos.package.buildable = lib.mkForce false;
+                packages.plutus-preprocessor.buildable = lib.mkForce false;
+                packages.cardano-ledger-test.buildable = lib.mkForce false;
+                packages.cardano-ledger-shelley.buildable = lib.mkForce false;
+                packages.cardano-ledger-allegra.buildable = lib.mkForce false;
+                packages.cardano-ledger-mary.buildable = lib.mkForce false;
+                packages.cardano-ledger-alonzo.buildable = lib.mkForce false;
+                packages.cardano-ledger-babbage.buildable = lib.mkForce false;
+                packages.cardano-ledger-conway.buildable = lib.mkForce false;
+                packages.cardano-protocol-tpraos.buildable = lib.mkForce false;
               })
           ];
         });


### PR DESCRIPTION
# Description

* Updates `streaming-binary` dependency from `cardano-ledger-byron`
* Fixes the paths to the `cddl` data files.
* Uses `buildable = False` instead of `package.buildable = False` in Nix-Windows

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
