### PR TITLE
Restructure computing Refunds and Deposits in a TxBody across all eras

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.Rules.ValidationMode (
  )
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.Governance
-import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure, keyTxRefunds)
+import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
@@ -212,7 +212,7 @@ utxoTransition = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ Shelley.validateMaxTxSizeUTxO pp tx
 
-  let refunded = keyTxRefunds pp dpstate txb
+  let refunded = getTotalRefundsTxBody pp dpstate txb
   let depositChange = getTotalDepositsTxBody pp dpstate txb Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txb) depositChange
   pure $! Shelley.updateUTxOState pp u txb depositChange ppup'

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -79,6 +79,7 @@ import Cardano.Ledger.Shelley.TxBody (
   ShelleyTxBody (..),
   Withdrawals (..),
   totalTxDepositsShelley,
+  totalTxRefundsShelley,
  )
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
@@ -385,6 +386,7 @@ instance Crypto c => ShelleyEraTxBody (AllegraEra c) where
   {-# INLINEABLE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (AllegraEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AllegraEra StandardCrypto) #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -75,7 +75,6 @@ import Cardano.Ledger.Shelley.Governance (EraGov (GovState), ShelleyGovState)
 import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
   UTxOState (..),
-  keyTxRefunds,
   updateStakeDistribution,
  )
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
@@ -248,7 +247,7 @@ alonzoEvalScriptsTxValid = do
     judgmentContext
   let txBody = tx ^. bodyTxL
       protVer = pp ^. ppProtocolVersionL
-      refunded = keyTxRefunds pp dpstate txBody
+      refunded = getTotalRefundsTxBody pp dpstate txBody
       depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   () <- pure $! traceEvent validBegin ()

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -111,7 +111,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Arrow (left)
@@ -289,6 +289,7 @@ instance Crypto c => ShelleyEraTxBody (AlonzoEra c) where
   {-# INLINEABLE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AlonzoEra StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -51,7 +51,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   CertState,
   PPUPPredFailure,
   UTxOState (..),
-  keyTxRefunds,
   updateStakeDistribution,
  )
 import Cardano.Ledger.Shelley.PParams (Update)
@@ -158,7 +157,7 @@ tellDepositChangeEvent ::
   Rule (s era) 'Transition Coin
 tellDepositChangeEvent pp dpstate txBody = do
   {- refunded := keyRefunds pp txb -}
-  let refunded = keyTxRefunds pp dpstate txBody
+  let refunded = getTotalRefundsTxBody pp dpstate txBody
   {- depositChange := (totalDeposits pp poolParams txcerts txb) − refunded -}
   let depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -159,7 +159,7 @@ import Cardano.Ledger.MemoBytes (
 import Cardano.Ledger.Plutus.Data (Datum (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Arrow (left)
@@ -535,6 +535,7 @@ instance Crypto c => ShelleyEraTxBody (BabbageEra c) where
   {-# INLINE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (BabbageEra StandardCrypto) #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (Update, upgradeUpdate)
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
+import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -297,6 +297,7 @@ instance Crypto c => ShelleyEraTxBody (MaryEra c) where
   {-# INLINEABLE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (MaryEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (MaryEra StandardCrypto) #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -26,9 +26,6 @@ import Cardano.Ledger.CertState (
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
-  keyTxRefunds,
- )
 import Cardano.Ledger.Shelley.LedgerState.Types (
   AccountState (..),
   EpochState (..),
@@ -150,7 +147,7 @@ consumedTxBody ::
 consumedTxBody txBody pp dpstate (UTxO u) =
   Consumed
     { conInputs = coinBalance (UTxO (Map.restrictKeys u (txBody ^. inputsTxBodyL)))
-    , conRefunds = keyTxRefunds pp dpstate txBody
+    , conRefunds = getTotalRefundsTxBody pp dpstate txBody
     , conWithdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
     }
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -43,6 +43,7 @@ class (ShelleyEraTxCert era, EraTxBody era) => ShelleyEraTxBody era where
   updateTxBodyG = updateTxBodyL
 
   getTotalDepositsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
+  getTotalRefundsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
 
 type Wdrl c = Withdrawals c
 {-# DEPRECATED Wdrl "In favor of `Cardano.Ledger.Address.Withdrawals`" #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -42,7 +42,13 @@ class (ShelleyEraTxCert era, EraTxBody era) => ShelleyEraTxBody era where
   default updateTxBodyG :: ProtVerAtMost era 8 => SimpleGetter (TxBody era) (StrictMaybe (Update era))
   updateTxBodyG = updateTxBodyL
 
+  -- | Compute the total deposits from the Certs of a TxBody
+  --   This is the contribution of a TxBody towards the deposit pot (utxosDeposit field of the UTxOState) of the system
   getTotalDepositsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
+
+  -- | Compute the total refunds from the Certs of a TxBody.
+  --   This is the contribution of a TxBody towards the total 'Obligations' of the system
+  --   See the Types and Functions Cardano.Ledger.CertState(Obligations,obligationCertState) for more information.
   getTotalRefundsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
 
 type Wdrl c = Withdrawals c

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -47,7 +47,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   witsFromTxWitnesses,
 
   -- * DelegationState
-  keyTxRefunds,
+  totalTxRefundsShelley,
   payPoolDeposit,
   refundPoolDeposit,
   totalTxDeposits,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -34,9 +34,6 @@ import Cardano.Ledger.Keys (
   KeyRole (..),
  )
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
-  keyTxRefunds,
- )
 import Cardano.Ledger.Shelley.LedgerState.Types
 import Cardano.Ledger.Shelley.TxBody (MIRPot (..))
 import Cardano.Ledger.UMap (RDPair (..), UMElem (..), UMap (..))
@@ -118,7 +115,7 @@ depositPoolChange ls pp txBody = (currentPool <+> txDeposits) <-> txRefunds
 
     currentPool = (utxosDeposited . lsUTxOState) ls
     txDeposits = getTotalDepositsTxBody pp (lsCertState ls) txBody
-    txRefunds = keyTxRefunds pp (lsCertState ls) txBody
+    txRefunds = getTotalRefundsTxBody pp (lsCertState ls) txBody
 
 -- Remove the rewards from the UMap, but leave the deposits alone
 reapRewards ::

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/RefundsAndDeposits.hs
@@ -10,7 +10,7 @@
 module Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
   totalCertsDeposits,
   totalCertsDepositsCertState,
-  keyTxRefunds,
+  totalTxRefundsShelley,
   keyCertsRefunds,
   keyCertsRefundsCertState,
   totalTxDeposits,
@@ -132,10 +132,11 @@ keyCertsRefunds pp lookupDeposit certs = snd (foldl' accum (mempty, Coin 0) cert
               | Just deposit <- lookupDeposit k -> (regKeys, totalRefunds <+> deposit)
             _ -> (regKeys, totalRefunds)
 
-keyTxRefunds ::
+-- | Compute the refunds attributable to unregistering Stake credentials in a TxBody
+totalTxRefundsShelley ::
   ShelleyEraTxBody era =>
   PParams era ->
   CertState era ->
   TxBody era ->
   Coin
-keyTxRefunds pp dpstate tx = keyCertsRefundsCertState pp dpstate (tx ^. certsTxBodyL)
+totalTxRefundsShelley pp dpstate tx = keyCertsRefundsCertState pp dpstate (tx ^. certsTxBodyL)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -70,7 +70,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
   PPUPPredFailure,
   UTxOState (..),
-  keyTxRefunds,
  )
 import Cardano.Ledger.Shelley.LedgerState.IncrementalStake
 import Cardano.Ledger.Shelley.PParams (Update)
@@ -448,7 +447,7 @@ utxoInductive = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ validateMaxTxSizeUTxO pp tx
 
-  let refunded = keyTxRefunds pp dpstate txBody
+  let refunded = getTotalRefundsTxBody pp dpstate txBody
   let totalDeposits' = getTotalDepositsTxBody pp dpstate txBody
   let depositChange = totalDeposits' Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -341,6 +341,7 @@ instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   {-# INLINEABLE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+
   getTotalRefundsTxBody = totalTxRefundsShelley
 
 deriving newtype instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -62,6 +62,7 @@ module Cardano.Ledger.Shelley.TxBody (
   addrEitherShelleyTxOutL,
   valueEitherShelleyTxOutL,
   totalTxDepositsShelley,
+  totalTxRefundsShelley,
 ) where
 
 import Cardano.Ledger.Address (RewardAcnt (..))
@@ -107,7 +108,7 @@ import Cardano.Ledger.PoolParams
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (totalTxDepositsShelley)
+import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
@@ -340,6 +341,7 @@ instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   {-# INLINEABLE updateTxBodyL #-}
 
   getTotalDepositsTxBody = totalTxDepositsShelley
+  getTotalRefundsTxBody = totalTxRefundsShelley
 
 deriving newtype instance
   (Era era, NoThunks (TxOut era), NoThunks (TxCert era), NoThunks (PParamsUpdate era)) =>

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   deltaT,
   iRReserves,
   iRTreasury,
-  keyTxRefunds,
   prevPParamsEpochStateL,
   rewards,
   rs,
@@ -293,7 +292,7 @@ checkPreservation SourceSignalTarget {source, target, signal} count =
         ++ "total deposits "
         ++ show (getTotalDepositsTxBody currPP oldCertState (tx ^. bodyTxL))
         ++ "\ntotal refunds "
-        ++ show (keyTxRefunds currPP oldCertState (tx ^. bodyTxL))
+        ++ show (getTotalRefundsTxBody currPP oldCertState (tx ^. bodyTxL))
 
 -- If we are not at an Epoch Boundary (i.e. epoch source == epoch target)
 -- then the total rewards should change only by withdrawals
@@ -480,7 +479,7 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
             <+> getTotalDepositsTxBody pp_ dpstate txb
         consumed_ =
           coinBalance u
-            <+> keyTxRefunds pp_ dpstate txb
+            <+> getTotalRefundsTxBody pp_ dpstate txb
             <+> fold (unWithdrawals (txb ^. withdrawalsTxBodyL))
 
 -- | Preserve balance restricted to TxIns and TxOuts of the Tx
@@ -512,7 +511,7 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
           txb = tx ^. bodyTxL
           inps =
             coinBalance @era (UTxO (Map.restrictKeys u (txb ^. inputsTxBodyL)))
-              <> keyTxRefunds pp_ dpstate txb
+              <> getTotalRefundsTxBody pp_ dpstate txb
               <> fold (unWithdrawals (txb ^. withdrawalsTxBodyL))
           outs =
             coinBalance (txouts @era txb)


### PR DESCRIPTION
Add uniform ways to compute Refunds and Deposits in a TxBody by two methods of ShelleyEraTxBody
  getTotalDepositsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
  getTotalRefundsTxBody :: PParams era -> CertState era -> TxBody era -> Coin

Make instances for all eras
Adjust UTXO and UTXOS rules to use these correctly.




<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
