### PR TITLE
Fail PParamsUpdate deserialization for invalid costmodels in Conway

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Provide CDDL spec files with `readAlonzoCddlFileNames` and `readAlonzoCddlFiles` from
   `Test.Cardano.Ledger.Alonzo.Binary.Cddl`
+* Expose `genValidAndUnknownCostModels` in `Arbitrary`
 
 ## 1.5.0.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -99,6 +99,7 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Alonzo.Arbitrary
         Test.Cardano.Ledger.Alonzo.Binary.Cddl
+        Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec
         Test.Cardano.Ledger.Alonzo.Binary.RoundTrip
         Test.Cardano.Ledger.Alonzo.CostModel
         Test.Cardano.Ledger.Alonzo.ImpTest

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -3,7 +3,9 @@
 module Main where
 
 import Cardano.Ledger.Alonzo (Alonzo)
+import Data.Proxy (Proxy (Proxy))
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CddlSpec as CddlSpec
+import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
@@ -17,3 +19,5 @@ main =
       CddlSpec.spec
       describe "Imp" $ do
         ShelleyImp.spec @Alonzo
+      describe "CostModels" $ do
+        CostModelsSpec.spec @Alonzo Proxy

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -21,6 +21,7 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   genAlonzoScript,
   genScripts,
   genValidCostModel,
+  genValidAndUnknownCostModels,
 ) where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
@@ -256,6 +257,13 @@ genValidCostModel lang = do
 
 genValidCostModelPair :: Language -> Gen (Language, CostModel)
 genValidCostModelPair lang = (,) lang <$> genValidCostModel lang
+
+genValidAndUnknownCostModels :: Gen CostModels
+genValidAndUnknownCostModels = do
+  langs <- sublistOf nonNativeLanguages
+  validCms <- Map.fromList <$> mapM genValidCostModelPair langs
+  unknown <- genUnknownCostModels
+  pure $ CostModels validCms mempty unknown
 
 -- | This Arbitrary instance assumes the inflexible deserialization
 -- scheme prior to version 9.

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/CostModelsSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/CostModelsSpec.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec (spec) where
+
+import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Binary (ToCBOR (..))
+import Cardano.Ledger.Binary.Decoding
+import Cardano.Ledger.Binary.Encoding
+import Cardano.Ledger.Plutus.Language
+import qualified Data.Map as Map
+import Data.Text (Text)
+import Data.Typeable
+import Data.Word (Word8)
+import Lens.Micro
+import Test.Cardano.Ledger.Alonzo.Arbitrary
+import Test.Cardano.Ledger.Common
+
+spec ::
+  forall era.
+  AlonzoEraPParams era =>
+  Proxy era ->
+  Spec
+spec pxy = do
+  describe "CostModels CBOR deserialization" $ do
+    validCostModelProp @era pxy
+    invalidCostModelProp @era Proxy
+    unknownCostModelProp @era Proxy
+
+validCostModelProp ::
+  forall era.
+  AlonzoEraPParams era =>
+  Proxy era ->
+  Spec
+validCostModelProp pxy = do
+  prop "valid CostModels deserialize correctly, both independently and within PParamsUpdate" $
+    \(lang :: Language) -> do
+      forAllShow (genValidCostModelEnc lang) (showEnc pxy) $
+        \validCmEnc -> do
+          encodeAndCheckDecoded @era validCmEnc $
+            \cmDecoded ppuDecoded -> do
+              expectRight cmDecoded >>= (`shouldSatisfy` validCm)
+              ppuRes <- expectRight ppuDecoded
+              ppuRes `shouldSatisfy` \ppu -> (validCm <$> ppu ^. ppuCostModelsL) == SJust True
+  where
+    genValidCostModelEnc lang = genCostModelEncForLanguage lang (costModelParamsCount lang)
+    validCm (CostModels valid errors unknown) =
+      not (null valid) && null errors && null unknown
+
+invalidCostModelProp ::
+  forall era.
+  AlonzoEraPParams era =>
+  Proxy era ->
+  Spec
+invalidCostModelProp pxy = do
+  prop "invalid CostModels fail within PParamsUpdate" $
+    \(lang :: Language) -> do
+      forAllShow (genInvalidCostModelEnc lang) (showEnc pxy) $
+        \invalidCmEnc -> do
+          encodeAndCheckDecoded @era invalidCmEnc $
+            \cmDecoded ppuDecoded -> do
+              -- pre-Conway we are failing when deserializing invalid costmodels
+              if eraProtVerHigh @era < natVersion @9
+                then expectDeserialiseFailure cmDecoded (Just "CostModels")
+                else do
+                  -- post-Conway, we are collecting CostModels deserialization errors
+                  cmRes <- expectRight cmDecoded
+                  cmRes `shouldSatisfy` invalidCm
+
+              -- in no era are we deserializing invalid costmodels within PParamsUpdate
+              expectDeserialiseFailure ppuDecoded Nothing
+  where
+    genInvalidCostModelEnc lang = do
+      let validCount = costModelParamsCount lang
+      count <- choose (0, validCount - 1)
+      genCostModelEncForLanguage lang count
+
+    invalidCm (CostModels valid errors _) =
+      null valid && not (null errors)
+
+unknownCostModelProp ::
+  forall era.
+  AlonzoEraPParams era =>
+  Proxy era ->
+  Spec
+unknownCostModelProp pxy = do
+  prop "unknown CostModels deserialize correctly within PParamsUpdate starting with Conway" $
+    forAllShow genUnknownCostModelEnc (showEnc pxy) $
+      \unknownCmEnc -> do
+        encodeAndCheckDecoded @era unknownCmEnc $
+          \cmDecoded ppuDecoded -> do
+            -- pre-Conway we are failing when deserializing unknown costmodels
+            if eraProtVerHigh @era < natVersion @9
+              then do
+                expectDeserialiseFailure cmDecoded (Just "CostModels")
+                expectDeserialiseFailure ppuDecoded Nothing
+              else do
+                -- post-Conway, we are collecting unknown CostModels
+                cmRes <- expectRight cmDecoded
+                cmRes `shouldSatisfy` unknownCm
+                ppuRes <- expectRight ppuDecoded
+                ppuRes `shouldSatisfy` \ppu -> (unknownCm <$> ppu ^. ppuCostModelsL) == SJust True
+  where
+    genUnknownCostModelEnc = do
+      let firstUnknownLang = fromEnum (maxBound @Language) + 1
+      lang <- choose (fromIntegral firstUnknownLang, maxBound @Word8)
+      NonNegative count <- arbitrary
+      genCostModelsEnc lang count
+    unknownCm (CostModels valid errors unknown) =
+      null valid && null errors && not (null unknown)
+
+encodeAndCheckDecoded ::
+  forall era.
+  AlonzoEraPParams era =>
+  Encoding ->
+  (Either DecoderError CostModels -> Either DecoderError (PParamsUpdate era) -> IO ()) ->
+  IO ()
+encodeAndCheckDecoded cmEnc check = do
+  let ver = eraProtVerHigh @era
+      ppuEnc =
+        fromPlainEncoding
+          . toCBOR
+          . Map.singleton (18 :: Int)
+          . toPlainEncoding ver
+          $ cmEnc
+      cmBytes = serialize ver cmEnc
+      ppuBytes = serialize ver ppuEnc
+  check
+    (decodeFull @CostModels ver cmBytes)
+    (decodeFull @(PParamsUpdate era) ver ppuBytes)
+
+genCostModelsEnc :: Word8 -> Int -> Gen Encoding
+genCostModelsEnc lang count = do
+  values <- vectorOf count (arbitrary :: Gen Int)
+  pure $ fromPlainEncoding . toCBOR $ Map.singleton lang values
+
+genCostModelEncForLanguage :: Language -> Int -> Gen Encoding
+genCostModelEncForLanguage lang =
+  genCostModelsEnc (fromIntegral (fromEnum lang))
+
+expectDeserialiseFailure :: (HasCallStack, Show t) => Either DecoderError t -> Maybe Text -> IO ()
+expectDeserialiseFailure e expectedTxt = do
+  res <- expectLeft e
+  res `shouldSatisfy` \case
+    DecoderErrorDeserialiseFailure txt _ -> maybe True (== txt) expectedTxt
+    _ -> True
+
+showEnc :: forall era. Era era => Proxy era -> Encoding -> String
+showEnc _ enc = show $ toPlainEncoding (eraProtVerHigh @era) enc

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -3,6 +3,8 @@
 module Main where
 
 import Cardano.Ledger.Babbage (Babbage)
+import Data.Proxy (Proxy (Proxy))
+import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Babbage.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Babbage.ImpTest ()
@@ -17,3 +19,5 @@ main =
       CddlSpec.spec
       describe "Imp" $ do
         ShelleyImp.spec @Babbage
+      describe "CostModels" $ do
+        CostModelsSpec.spec @Babbage Proxy

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -159,6 +159,7 @@ test-suite tests
         base,
         cardano-ledger-core:testlib,
         cardano-ledger-allegra,
+        cardano-ledger-alonzo:testlib,
         cardano-ledger-alonzo,
         cardano-ledger-conway,
         cardano-ledger-shelley:testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -79,6 +79,7 @@ import Cardano.Ledger.Conway.Core hiding (Value)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.HKD (HKD, HKDFunctor (..), HKDNoUpdate, NoUpdate (..))
+import Cardano.Ledger.Plutus.CostModels (decodeValidAndUnknownCostModels)
 import Cardano.Ledger.TreeDiff (ToExpr (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..))
@@ -675,7 +676,7 @@ updateField = \case
   11 -> field (\x up -> up {cppTau = THKD (SJust x)}) From
   16 -> field (\x up -> up {cppMinPoolCost = THKD (SJust x)}) From
   17 -> field (\x up -> up {cppCoinsPerUTxOByte = THKD (SJust x)}) From
-  18 -> field (\x up -> up {cppCostModels = THKD (SJust x)}) From
+  18 -> field (\x up -> up {cppCostModels = THKD (SJust x)}) $ D decodeValidAndUnknownCostModels
   19 -> field (\x up -> up {cppPrices = THKD (SJust x)}) From
   20 -> field (\x up -> up {cppMaxTxExUnits = THKD (SJust x)}) From
   21 -> field (\x up -> up {cppMaxBlockExUnits = THKD (SJust x)}) From

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Cardano.Ledger.Conway (Conway)
 import Data.Proxy (Proxy (..))
+import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
@@ -29,3 +30,5 @@ main =
       describe "Imp" $ do
         ConwayImp.spec @Conway
         ShelleyImp.spec @Conway
+      describe "CostModels" $ do
+        CostModelsSpec.spec @Conway Proxy

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -64,7 +64,7 @@ import Data.List (nubBy)
 import qualified Data.Sequence.Strict as Seq
 import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Data.Arbitrary ()
-import Test.Cardano.Ledger.Alonzo.Arbitrary (genAlonzoScript, unFlexibleCostModels)
+import Test.Cardano.Ledger.Alonzo.Arbitrary (genAlonzoScript, genValidAndUnknownCostModels, unFlexibleCostModels)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common
 
@@ -504,7 +504,7 @@ instance Era era => Arbitrary (ConwayPParams StrictMaybe era) where
       <*> pure NoUpdate
       <*> arbitrary
       <*> arbitrary
-      <*> (THKD . fmap unFlexibleCostModels <$> arbitrary)
+      <*> (THKD <$> oneof [SJust <$> genValidAndUnknownCostModels, pure SNothing])
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Move `Cardano.Ledger.Alonzo.Scritps.Data` to `Cardano.Ledger.Plutus.Data`
 * Move some parts of `Cardano.Ledger.Alonzo.TxInfo` into
   `Cardano.Ledger.Plutus.TxInfo` and `Cardano.Ledger.Plutus.Evaluate`
+* Expose `decodeValidAndUnknownCostModels` in `CostModels`
 
 ### `testlib`
 


### PR DESCRIPTION
# Description

Closes https://github.com/input-output-hk/cardano-ledger/issues/3772

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
