### PR TITLE
Improve deposits refunds re-usability

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -59,7 +59,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.8 && <1.9,
+        cardano-ledger-core >=1.9 && <1.10,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -43,7 +43,6 @@ import Cardano.Ledger.Binary (
   invalidKey,
   serialize,
  )
-import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -163,33 +162,33 @@ utxoTransition ::
   ) =>
   TransitionRule (AllegraUTXO era)
 utxoTransition = do
-  TRC (Shelley.UtxoEnv slot pp dpstate genDelegs, u, tx) <- judgmentContext
-  let Shelley.UTxOState utxo _ _ ppup _ _ = u
-  let txb = tx ^. bodyTxL
+  TRC (Shelley.UtxoEnv slot pp certState genDelegs, utxos, tx) <- judgmentContext
+  let Shelley.UTxOState utxo _ _ ppup _ _ = utxos
+  let txBody = tx ^. bodyTxL
 
   {- ininterval slot (txvld tx) -}
-  runTest $ validateOutsideValidityIntervalUTxO slot txb
+  runTest $ validateOutsideValidityIntervalUTxO slot txBody
 
   {- txins txb ≠ ∅ -}
   -- runValidationTransMaybe fromShelleyFailure $ Shelley.validateInputSetEmptyUTxO txb
-  runTest $ Shelley.validateInputSetEmptyUTxO txb
+  runTest $ Shelley.validateInputSetEmptyUTxO txBody
 
   {- minfee pp tx ≤ txfee txb -}
   runTest $ Shelley.validateFeeTooSmallUTxO pp tx
 
   {- txins txb ⊆ dom utxo -}
-  runTest $ Shelley.validateBadInputsUTxO utxo $ txb ^. inputsTxBodyL
+  runTest $ Shelley.validateBadInputsUTxO utxo $ txBody ^. inputsTxBodyL
 
   netId <- liftSTS $ asks networkId
 
   {- ∀(_ → (a, _)) ∈ txouts txb, netId a = NetworkId -}
-  runTest $ Shelley.validateWrongNetwork netId . toList $ txb ^. outputsTxBodyL
+  runTest $ Shelley.validateWrongNetwork netId . toList $ txBody ^. outputsTxBodyL
 
   {- ∀(a → ) ∈ txwdrls txb, netId a = NetworkId -}
-  runTest $ Shelley.validateWrongNetworkWithdrawal netId txb
+  runTest $ Shelley.validateWrongNetworkWithdrawal netId txBody
 
   {- consumed pp utxo txb = produced pp poolParams txb -}
-  runTest $ Shelley.validateValueNotConservedUTxO pp utxo dpstate txb
+  runTest $ Shelley.validateValueNotConservedUTxO pp utxo certState txBody
 
   -- process Protocol Parameter Update Proposals
   ppup' <-
@@ -198,7 +197,7 @@ utxoTransition = do
   {- adaPolicy ∉ supp mint tx
      above check not needed because mint field of type MultiAsset cannot contain ada -}
 
-  let outputs = txouts txb
+  let outputs = txouts txBody
   {- ∀ txout ∈ txouts txb, getValue txout ≥ inject (scaledMinDeposit v (minUTxOValue pp)) -}
   runTest $ validateOutputTooSmallUTxO pp outputs
 
@@ -212,10 +211,8 @@ utxoTransition = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ Shelley.validateMaxTxSizeUTxO pp tx
 
-  let refunded = certsTotalRefundsTxBody pp dpstate txb
-  let depositChange = certsTotalDepositsTxBody pp dpstate txb Val.<-> refunded
-  tellEvent $ TotalDeposits (hashAnnotated txb) depositChange
-  pure $! Shelley.updateUTxOState pp u txb depositChange ppup'
+  Shelley.updateUTxOState pp utxos txBody certState ppup' $
+    tellEvent . TotalDeposits (hashAnnotated txBody)
 
 -- | Ensure the transaction is within the validity window.
 --

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Binary (
   invalidKey,
   serialize,
  )
+import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -60,7 +61,6 @@ import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (PpupEnv (..), ShelleyPPUP, ShelleyPpupPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..), TxIn)
-import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..))
 import Cardano.Ledger.Shelley.UTxO (txup)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), txouts)
@@ -212,8 +212,8 @@ utxoTransition = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ Shelley.validateMaxTxSizeUTxO pp tx
 
-  let refunded = getTotalRefundsTxBody pp dpstate txb
-  let depositChange = getTotalDepositsTxBody pp dpstate txb Val.<-> refunded
+  let refunded = certsTotalRefundsTxBody pp dpstate txb
+  let depositChange = certsTotalDepositsTxBody pp dpstate txb Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txb) depositChange
   pure $! Shelley.updateUTxOState pp u txb depositChange ppup'
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody.hs
@@ -78,8 +78,6 @@ import Cardano.Ledger.Shelley.TxBody (
   ShelleyEraTxBody (..),
   ShelleyTxBody (..),
   Withdrawals (..),
-  totalTxDepositsShelley,
-  totalTxRefundsShelley,
  )
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
@@ -384,9 +382,6 @@ instance Crypto c => ShelleyEraTxBody (AllegraEra c) where
   updateTxBodyL =
     lensMemoRawType atbrUpdate $ \txBodyRaw update -> txBodyRaw {atbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
-
-  getTotalDepositsTxBody = totalTxDepositsShelley
-  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (AllegraEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AllegraEra StandardCrypto) #-}

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
@@ -5,6 +5,7 @@
 module Cardano.Ledger.Allegra.TxCert () where
 
 import Cardano.Ledger.Allegra.Era
+import Cardano.Ledger.Allegra.PParams ()
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Shelley.TxCert
 
@@ -35,6 +36,10 @@ instance Crypto c => EraTxCert (AllegraEra c) where
   lookupUnRegStakeTxCert = \case
     UnRegTxCert c -> Just c
     _ -> Nothing
+
+  getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
+
+  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
 
 instance Crypto c => ShelleyEraTxCert (AllegraEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (AllegraEra StandardCrypto) #-}

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -73,7 +73,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
-        cardano-ledger-core >=1.8.1 && <1.9,
+        cardano-ledger-core >=1.9 && <1.10,
         cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -66,6 +66,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), serialize')
 import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus.Language (Language (..))
@@ -247,8 +248,8 @@ alonzoEvalScriptsTxValid = do
     judgmentContext
   let txBody = tx ^. bodyTxL
       protVer = pp ^. ppProtocolVersionL
-      refunded = getTotalRefundsTxBody pp dpstate txBody
-      depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
+      refunded = certsTotalRefundsTxBody pp dpstate txBody
+      depositChange = certsTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   () <- pure $! traceEvent validBegin ()
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -111,7 +111,6 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Arrow (left)
@@ -287,9 +286,6 @@ instance Crypto c => ShelleyEraTxBody (AlonzoEra c) where
   updateTxBodyL =
     lensMemoRawType atbrUpdate (\txBodyRaw update_ -> txBodyRaw {atbrUpdate = update_})
   {-# INLINEABLE updateTxBodyL #-}
-
-  getTotalDepositsTxBody = totalTxDepositsShelley
-  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (AlonzoEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (AlonzoEra StandardCrypto) #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
@@ -6,6 +6,7 @@
 module Cardano.Ledger.Alonzo.TxCert () where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
+import Cardano.Ledger.Alonzo.PParams ()
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Shelley.TxCert
 
@@ -36,6 +37,10 @@ instance Crypto c => EraTxCert (AlonzoEra c) where
   lookupUnRegStakeTxCert = \case
     UnRegTxCert c -> Just c
     _ -> Nothing
+
+  getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
+
+  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
 
 instance Crypto c => ShelleyEraTxCert (AlonzoEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (AlonzoEra StandardCrypto) #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -62,7 +62,7 @@ deriving instance (Era era, Show (TxCert era)) => Show (AlonzoScriptsNeeded era)
 instance Crypto c => EraUTxO (AlonzoEra c) where
   type ScriptsNeeded (AlonzoEra c) = AlonzoScriptsNeeded (AlonzoEra c)
 
-  getConsumedValue pp lookupKeyDeposit _ = getConsumedMaryValue pp lookupKeyDeposit
+  getConsumedValue = getConsumedMaryValue
 
   getProducedValue = shelleyProducedValue
 

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -47,7 +47,7 @@ library
         bytestring,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.5.1,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.5 && <1.9,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.5 && <1.10,
         cardano-ledger-pretty,
         cardano-ledger-allegra ^>=1.2,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.9,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -68,7 +68,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo >=1.5.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.8.1 && <1.9,
+        cardano-ledger-core >=1.9 && <1.10,
         cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Babbage.Era (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, strictMaybeToMaybe, systemStart)
 import Cardano.Ledger.Binary (EncCBOR (..))
+import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.SafeHash (hashAnnotated)
@@ -157,9 +158,9 @@ tellDepositChangeEvent ::
   Rule (s era) 'Transition Coin
 tellDepositChangeEvent pp dpstate txBody = do
   {- refunded := keyRefunds pp txb -}
-  let refunded = getTotalRefundsTxBody pp dpstate txBody
+  let refunded = certsTotalRefundsTxBody pp dpstate txBody
   {- depositChange := (totalDeposits pp poolParams txcerts txb) − refunded -}
-  let depositChange = getTotalDepositsTxBody pp dpstate txBody <-> refunded
+  let depositChange = certsTotalDepositsTxBody pp dpstate txBody <-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   pure depositChange
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -159,7 +159,6 @@ import Cardano.Ledger.MemoBytes (
 import Cardano.Ledger.Plutus.Data (Datum (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Arrow (left)
@@ -533,9 +532,6 @@ instance Crypto c => ShelleyEraTxBody (BabbageEra c) where
 
   updateTxBodyL = updateBabbageTxBodyL
   {-# INLINE updateTxBodyL #-}
-
-  getTotalDepositsTxBody = totalTxDepositsShelley
-  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (BabbageEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
@@ -5,6 +5,7 @@
 module Cardano.Ledger.Babbage.TxCert () where
 
 import Cardano.Ledger.Babbage.Era
+import Cardano.Ledger.Babbage.PParams ()
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Shelley.TxCert
 
@@ -35,6 +36,10 @@ instance Crypto c => EraTxCert (BabbageEra c) where
   lookupUnRegStakeTxCert = \case
     UnRegTxCert c -> Just c
     _ -> Nothing
+
+  getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
+
+  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
 
 instance Crypto c => ShelleyEraTxCert (BabbageEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (BabbageEra StandardCrypto) #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -50,7 +50,7 @@ import Lens.Micro
 instance Crypto c => EraUTxO (BabbageEra c) where
   type ScriptsNeeded (BabbageEra c) = AlonzoScriptsNeeded (BabbageEra c)
 
-  getConsumedValue pp lookupKeyDeposit _ = getConsumedMaryValue pp lookupKeyDeposit
+  getConsumedValue = getConsumedMaryValue
 
   getProducedValue = shelleyProducedValue
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.11.0.0
 
 * Switch `ppCommitteeMaxTermLength` to `EpochNo`, rather than `Natural`
+* Add `conwayTotalDepositsTxBody` and `conwayProposalsDeposits`
+* Add `conwayDRepDepositsTxCerts`, `conwayDRepRefundsTxCerts`,
+  `conwayTotalDepositsTxCerts` and `conwayTotalRefundsTxCerts`
 * Rename data-type `ProposalsSnapshot` to `Proposals`. #3859
   * Rename module `Governance.Snapshots` to `Governance.Proposals`.
   * Rename all the functions related to the data-type.

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -79,7 +79,7 @@ library
         cardano-ledger-allegra >=1.1,
         cardano-ledger-alonzo ^>=1.5.1,
         cardano-ledger-babbage >=1.4.1,
-        cardano-ledger-core ^>=1.8.1,
+        cardano-ledger-core ^>=1.9,
         cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -22,8 +22,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.TxBody (
-  totalTxRefundsConway,
-  drepRefundsConway,
   ConwayEraTxBody (..),
   ConwayTxBody (
     ConwayTxBody,
@@ -79,18 +77,19 @@ import Cardano.Ledger.Binary.Coders (
   ofield,
   (!>),
  )
-import Cardano.Ledger.CertState (CertState (..))
 import Cardano.Ledger.Coin (Coin (..), decodePositiveCoin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (ProposalProcedure, VotingProcedures (..))
-import Cardano.Ledger.Conway.PParams (ConwayEraPParams, ppDRepDepositL, ppGovActionDepositL)
+import Cardano.Ledger.Conway.PParams (ConwayEraPParams, ppGovActionDepositL)
 import Cardano.Ledger.Conway.Scripts ()
-import Cardano.Ledger.Conway.TxCert (ConwayEraTxCert, ConwayTxCert (..), ConwayTxCertUpgradeError, pattern RegDRepTxCert, pattern UnRegDRepTxCert)
+import Cardano.Ledger.Conway.TxCert (
+  ConwayEraTxCert,
+  ConwayTxCert (..),
+  ConwayTxCertUpgradeError,
+ )
 import Cardano.Ledger.Conway.TxOut ()
-import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.DRep (DRepState (..))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (
   MaryValue (..),
@@ -110,19 +109,14 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
-import Cardano.Ledger.Shelley.LedgerState (VState (..), totalTxRefundsShelley)
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley)
 import Cardano.Ledger.TreeDiff (ToExpr)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.Arrow (left)
 import Control.DeepSeq (NFData)
 import Control.Monad (when)
-import Data.Foldable (foldMap', foldl')
-import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.OSet.Strict as SOS
-import Data.Semigroup (getSum)
 import Data.Sequence.Strict (StrictSeq, (|>))
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
@@ -382,8 +376,14 @@ instance Crypto c => EraTxBody (ConwayEra c) where
   withdrawalsTxBodyL = lensMemoRawType ctbrWithdrawals (\txb x -> txb {ctbrWithdrawals = x})
   {-# INLINE withdrawalsTxBodyL #-}
 
-  certsTxBodyL = lensMemoRawType (SOS.toStrictSeq . ctbrCerts) (\txb x -> txb {ctbrCerts = SOS.fromStrictSeq x})
+  certsTxBodyL =
+    lensMemoRawType (SOS.toStrictSeq . ctbrCerts) (\txb x -> txb {ctbrCerts = SOS.fromStrictSeq x})
   {-# INLINE certsTxBodyL #-}
+
+  getTotalDepositsTxBody = conwayTotalDepositsTxBody
+
+  getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody =
+    getTotalRefundsTxCerts pp lookupStakingDeposit lookupDRepDeposit (txBody ^. certsTxBodyL)
 
   upgradeTxBody btb = do
     when (isSJust (btbUpdate btb)) $
@@ -436,74 +436,38 @@ instance
 
   updateTxBodyG = to (const SNothing)
 
-  getTotalDepositsTxBody = totalTxDepositsConway
-
-  getTotalRefundsTxBody = totalTxRefundsConway
-
 -- ==========================================
 -- Deposits and Refunds for Conway TxBody
 
-totalProposalDeposits ::
+-- | Compute all the deposits in a TxBody. This includes deposits for:
+--
+--   1. registering Stake
+--   2. registering a StakePool
+--   3. registering a DRep
+--   4. submitting a Proposal
+--
+-- This is the contribution of a TxBody towards the total
+-- `Cardano.Ledger.CertState.Obligations`
+conwayTotalDepositsTxBody ::
+  ConwayEraTxBody era =>
+  PParams era ->
+  (KeyHash 'StakePool (EraCrypto era) -> Bool) ->
+  TxBody era ->
+  Coin
+conwayTotalDepositsTxBody pp isPoolRegisted txBody =
+  getTotalDepositsTxCerts pp isPoolRegisted (txBody ^. certsTxBodyL)
+    <+> conwayProposalsDeposits pp txBody
+
+-- | Total number of deposits in the proposals in TxBody
+conwayProposalsDeposits ::
   ConwayEraTxBody era =>
   PParams era ->
   TxBody era ->
   Coin
-totalProposalDeposits pp txb = nProposals <×> depositPerProposal
+conwayProposalsDeposits pp txBody = numProposals <×> depositPerProposal
   where
-    nProposals = length (txb ^. proposalProceduresTxBodyL)
+    numProposals = length (txBody ^. proposalProceduresTxBodyL)
     depositPerProposal = pp ^. ppGovActionDepositL
-
-totalDRepDeposits ::
-  ConwayEraTxBody era =>
-  PParams era ->
-  TxBody era ->
-  Coin
-totalDRepDeposits pp txb = nDReps <×> depositPerDRep
-  where
-    nDReps = getSum @Int (foldMap' (\case RegDRepTxCert {} -> 1; _ -> 0) (txb ^. certsTxBodyL))
-    depositPerDRep = pp ^. ppDRepDepositL
-
--- | Compute all the deposits in a TxBody
---   This includes deposits for
---   1) registering Stake
---   2) registering a StakePool
---   3) registering a DRep
---   4) making a Proposal
--- This is the contribution of a TxBody towards the total 'Obligations' of the system
--- See the Tyeps and Functions Cardano.Ledger.CertState(Obligations,obligationCertState) for more information.
-totalTxDepositsConway ::
-  Crypto c =>
-  PParams (ConwayEra c) ->
-  CertState (ConwayEra c) ->
-  TxBody (ConwayEra c) ->
-  Coin
-totalTxDepositsConway pp cs txb =
-  totalTxDepositsShelley pp cs txb -- Stake and StakePool
-    <> totalProposalDeposits pp txb -- only in Conway and later
-    <> totalDRepDeposits pp txb -- only in Conway and later
-
--- | Compute the Refunds from a TxBody, given a function that computes a partial Coin for known Credentials.
-drepRefundsConway :: ConwayEraTxBody era => (Credential 'DRepRole (EraCrypto era) -> Maybe Coin) -> TxBody era -> Coin
-drepRefundsConway lookupDRepDeposit txBody =
-  let go accum@(!drepRegsInTx, !totalRefund) = \case
-        RegDRepTxCert c deposit _ ->
-          -- Track registrations
-          (Map.insert c deposit drepRegsInTx, totalRefund)
-        UnRegDRepTxCert c _
-          -- DRep previously registered in the same tx.
-          | Just deposit <- Map.lookup c drepRegsInTx -> (Map.delete c drepRegsInTx, totalRefund <+> deposit)
-          -- DRep previously registered in some other tx.
-          | Just deposit <- lookupDRepDeposit c -> (drepRegsInTx, totalRefund <+> deposit)
-        _ -> accum
-   in inject $ snd $ foldl' go (Map.empty, Coin 0) $ txBody ^. certsTxBodyL
-
--- | Compute the refunds from both unregistering DReps and unregistering stake credentials
---   in a TxBody. Refunds for Proposals and StakePools are handled at the epoch boundary,
---   and are handled separately, so are not included here.
-totalTxRefundsConway :: ConwayEraTxBody era => PParams era -> CertState era -> TxBody era -> Coin
-totalTxRefundsConway pp certState txb = drepRefundsConway depositOf txb <+> totalTxRefundsShelley pp certState txb -- Unregistering DReps
-  where
-    depositOf cred = drepDeposit <$> Map.lookup cred (vsDReps (certVState certState))
 
 instance Crypto c => AllegraEraTxBody (ConwayEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (ConwayEra StandardCrypto) #-}
@@ -519,19 +483,23 @@ instance Crypto c => MaryEraTxBody (ConwayEra c) where
 
   mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
 
-  mintedTxBodyF = to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (ctbrMint txBodyRaw)))
+  mintedTxBodyF =
+    to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (ctbrMint txBodyRaw)))
   {-# INLINE mintedTxBodyF #-}
 
 instance Crypto c => AlonzoEraTxBody (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTxBody (ConwayEra StandardCrypto) #-}
 
-  collateralInputsTxBodyL = lensMemoRawType ctbrCollateralInputs (\txb x -> txb {ctbrCollateralInputs = x})
+  collateralInputsTxBodyL =
+    lensMemoRawType ctbrCollateralInputs (\txb x -> txb {ctbrCollateralInputs = x})
   {-# INLINE collateralInputsTxBodyL #-}
 
-  reqSignerHashesTxBodyL = lensMemoRawType ctbrReqSignerHashes (\txb x -> txb {ctbrReqSignerHashes = x})
+  reqSignerHashesTxBodyL =
+    lensMemoRawType ctbrReqSignerHashes (\txb x -> txb {ctbrReqSignerHashes = x})
   {-# INLINE reqSignerHashesTxBodyL #-}
 
-  scriptIntegrityHashTxBodyL = lensMemoRawType ctbrScriptIntegrityHash (\txb x -> txb {ctbrScriptIntegrityHash = x})
+  scriptIntegrityHashTxBodyL =
+    lensMemoRawType ctbrScriptIntegrityHash (\txb x -> txb {ctbrScriptIntegrityHash = x})
   {-# INLINE scriptIntegrityHashTxBodyL #-}
 
   networkIdTxBodyL = lensMemoRawType ctbrTxNetworkId (\txb x -> txb {ctbrTxNetworkId = x})
@@ -543,10 +511,12 @@ instance Crypto c => BabbageEraTxBody (ConwayEra c) where
   sizedOutputsTxBodyL = lensMemoRawType ctbrOutputs (\txb x -> txb {ctbrOutputs = x})
   {-# INLINE sizedOutputsTxBodyL #-}
 
-  referenceInputsTxBodyL = lensMemoRawType ctbrReferenceInputs (\txb x -> txb {ctbrReferenceInputs = x})
+  referenceInputsTxBodyL =
+    lensMemoRawType ctbrReferenceInputs (\txb x -> txb {ctbrReferenceInputs = x})
   {-# INLINE referenceInputsTxBodyL #-}
 
-  totalCollateralTxBodyL = lensMemoRawType ctbrTotalCollateral (\txb x -> txb {ctbrTotalCollateral = x})
+  totalCollateralTxBodyL =
+    lensMemoRawType ctbrTotalCollateral (\txb x -> txb {ctbrTotalCollateral = x})
   {-# INLINE totalCollateralTxBodyL #-}
 
   collateralReturnTxBodyL =
@@ -555,7 +525,8 @@ instance Crypto c => BabbageEraTxBody (ConwayEra c) where
       (\txb x -> txb {ctbrCollateralReturn = mkSized (eraProtVerLow @(ConwayEra c)) <$> x})
   {-# INLINE collateralReturnTxBodyL #-}
 
-  sizedCollateralReturnTxBodyL = lensMemoRawType ctbrCollateralReturn (\txb x -> txb {ctbrCollateralReturn = x})
+  sizedCollateralReturnTxBodyL =
+    lensMemoRawType ctbrCollateralReturn (\txb x -> txb {ctbrCollateralReturn = x})
   {-# INLINE sizedCollateralReturnTxBodyL #-}
 
   allSizedOutputsTxBodyF = to $ \txb ->

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -45,6 +45,8 @@ module Cardano.Ledger.Conway.TxBody (
     ctbCurrentTreasuryValue,
     ctbTreasuryDonation
   ),
+  conwayTotalDepositsTxBody,
+  conwayProposalsDeposits,
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -24,7 +24,6 @@ import Cardano.Ledger.Babbage.UTxO (
   getBabbageSpendingDatum,
   getBabbageSupplementalDataHashes,
  )
-import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core (
   Era (..),
   EraTxBody (..),
@@ -33,26 +32,20 @@ import Cardano.Ledger.Conway.Core (
  )
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (
-  ProposalProcedure (..),
   Voter (..),
   VotingProcedures (..),
  )
-import Cardano.Ledger.Conway.PParams (ppDRepDepositL)
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
-import Cardano.Ledger.Conway.TxCert (conwayDRepRefundsTxCerts, pattern RegDRepTxCert)
-import Cardano.Ledger.Credential (Credential, credScriptHash)
+import Cardano.Ledger.Credential (credScriptHash)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Mary (MaryValue)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
 import Cardano.Ledger.Shelley.UTxO (shelleyProducedValue)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO)
 import Cardano.Ledger.Val (Val (..))
-import Data.Foldable (foldMap')
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
-import Data.Semigroup (getSum)
 import Lens.Micro ((^.))
 
 getConwayScriptsNeeded ::
@@ -80,33 +73,13 @@ conwayProducedValue ::
   TxBody era ->
   Value era
 conwayProducedValue pp isStakePool txBody =
-  inject propDeposits
+  shelleyProducedValue pp isStakePool txBody
     <+> inject (txBody ^. treasuryDonationTxBodyL)
-    <+> shelleyProducedValue pp isStakePool txBody
-    <+> inject drepDeposits
-  where
-    propDeposits = foldMap pProcDeposit $ txBody ^. proposalProceduresTxBodyL
-    drepDeposits = getSum @Int (foldMap' (\case RegDRepTxCert {} -> 1; _ -> 0) (txBody ^. certsTxBodyL)) <×> pp ^. ppDRepDepositL
-
-conwayConsumedValue ::
-  ( ConwayEraTxBody era
-  , Value era ~ MaryValue (EraCrypto era)
-  ) =>
-  PParams era ->
-  (Credential 'Staking (EraCrypto era) -> Maybe Coin) ->
-  (Credential 'DRepRole (EraCrypto era) -> Maybe Coin) ->
-  UTxO era ->
-  TxBody era ->
-  Value era
-conwayConsumedValue pp lookupKeyDeposit lookupDRepDeposit utxo txBody =
-  let maryRefunds = getConsumedMaryValue pp lookupKeyDeposit utxo txBody
-      drepRefunds = inject $ conwayDRepRefundsTxCerts lookupDRepDeposit (txBody ^. certsTxBodyL)
-   in maryRefunds <+> drepRefunds
 
 instance Crypto c => EraUTxO (ConwayEra c) where
   type ScriptsNeeded (ConwayEra c) = AlonzoScriptsNeeded (ConwayEra c)
 
-  getConsumedValue = conwayConsumedValue
+  getConsumedValue = getConsumedMaryValue
 
   getProducedValue = conwayProducedValue
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -39,8 +39,8 @@ import Cardano.Ledger.Conway.Governance.Procedures (
  )
 import Cardano.Ledger.Conway.PParams (ppDRepDepositL)
 import Cardano.Ledger.Conway.Tx ()
-import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..), drepRefundsConway)
-import Cardano.Ledger.Conway.TxCert (pattern RegDRepTxCert)
+import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
+import Cardano.Ledger.Conway.TxCert (conwayDRepRefundsTxCerts, pattern RegDRepTxCert)
 import Cardano.Ledger.Credential (Credential, credScriptHash)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
@@ -100,7 +100,7 @@ conwayConsumedValue ::
   Value era
 conwayConsumedValue pp lookupKeyDeposit lookupDRepDeposit utxo txBody =
   let maryRefunds = getConsumedMaryValue pp lookupKeyDeposit utxo txBody
-      drepRefunds = inject $ drepRefundsConway lookupDRepDeposit txBody
+      drepRefunds = inject $ conwayDRepRefundsTxCerts lookupDRepDeposit (txBody ^. certsTxBodyL)
    in maryRefunds <+> drepRefunds
 
 instance Crypto c => EraUTxO (ConwayEra c) where

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.4.0.0
 
 * Switch `MaryValue` field for ADA from `Integer` to `Coin`
+* Make sure that `getConsumedMaryValue` can also handle `DRep` deposits. This is safe for
+  all pre-Conway eras and useful for Conway onwards eras.
 
 ### `testlib`
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -65,7 +65,7 @@ library
         cardano-data,
         cardano-ledger-allegra >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-core >=1.8 && <1.9,
+        cardano-ledger-core >=1.9 && <1.10,
         cardano-ledger-shelley >=1.7 && <1.9,
         containers,
         deepseq,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -58,7 +58,6 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (Update, upgradeUpdate)
-import Cardano.Ledger.Shelley.TxBody (totalTxDepositsShelley, totalTxRefundsShelley)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
@@ -295,9 +294,6 @@ instance Crypto c => ShelleyEraTxBody (MaryEra c) where
   updateTxBodyL =
     lensMaryTxBodyRaw atbrUpdate $ \txBodyRaw update -> txBodyRaw {atbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
-
-  getTotalDepositsTxBody = totalTxDepositsShelley
-  getTotalRefundsTxBody = totalTxRefundsShelley
 
 instance Crypto c => AllegraEraTxBody (MaryEra c) where
   {-# SPECIALIZE instance AllegraEraTxBody (MaryEra StandardCrypto) #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
@@ -7,6 +7,7 @@ module Cardano.Ledger.Mary.TxCert () where
 
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.Mary.Era (MaryEra)
+import Cardano.Ledger.Mary.PParams ()
 import Cardano.Ledger.Shelley.TxCert (
   EraTxCert (..),
   PoolCert (..),
@@ -15,6 +16,8 @@ import Cardano.Ledger.Shelley.TxCert (
   ShelleyTxCert (..),
   getScriptWitnessShelleyTxCert,
   getVKeyWitnessShelleyTxCert,
+  shelleyTotalDepositsTxCerts,
+  shelleyTotalRefundsTxCerts,
   upgradeShelleyTxCert,
   pattern RegTxCert,
   pattern UnRegTxCert,
@@ -47,6 +50,10 @@ instance Crypto c => EraTxCert (MaryEra c) where
   lookupUnRegStakeTxCert = \case
     UnRegTxCert c -> Just c
     _ -> Nothing
+
+  getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
+
+  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
 
 instance Crypto c => ShelleyEraTxCert (MaryEra c) where
   {-# SPECIALIZE instance ShelleyEraTxCert (MaryEra StandardCrypto) #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
 import Cardano.Ledger.Mary.TxBody ()
 import Cardano.Ledger.Mary.Value (MaryValue)
-import Cardano.Ledger.Shelley.LedgerState (keyCertsRefunds)
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
   getShelleyScriptsNeeded,
@@ -69,7 +68,7 @@ getConsumedMaryValue pp lookupRefund (UTxO u) txBody = consumedValue <> txBody ^
     consumedValue =
       balance (UTxO (Map.restrictKeys u (txBody ^. inputsTxBodyL)))
         <> inject (refunds <> withdrawals)
-    refunds = keyCertsRefunds pp lookupRefund (txBody ^. certsTxBodyL)
+    refunds = getTotalRefundsTxBody pp lookupRefund (const Nothing) txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 -- | Computes the set of script hashes required to unlock the transaction inputs and the

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -10,7 +10,7 @@ module Cardano.Ledger.Mary.UTxO (getConsumedMaryValue) where
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Keys (KeyRole (Staking))
+import Cardano.Ledger.Keys (KeyRole (DRepRole, Staking))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
@@ -36,7 +36,7 @@ import Lens.Micro
 instance Crypto c => EraUTxO (MaryEra c) where
   type ScriptsNeeded (MaryEra c) = ShelleyScriptsNeeded (MaryEra c)
 
-  getConsumedValue pp lookupKeyDeposit _ = getConsumedMaryValue pp lookupKeyDeposit
+  getConsumedValue = getConsumedMaryValue
 
   getProducedValue = shelleyProducedValue
 
@@ -59,16 +59,18 @@ getConsumedMaryValue ::
   (MaryEraTxBody era, Value era ~ MaryValue (EraCrypto era)) =>
   PParams era ->
   (Credential 'Staking (EraCrypto era) -> Maybe Coin) ->
+  (Credential 'DRepRole (EraCrypto era) -> Maybe Coin) ->
   UTxO era ->
   TxBody era ->
   MaryValue (EraCrypto era)
-getConsumedMaryValue pp lookupRefund (UTxO u) txBody = consumedValue <> txBody ^. mintValueTxBodyF
+getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit (UTxO u) txBody =
+  consumedValue <> txBody ^. mintValueTxBodyF
   where
     {- balance (txins tx ◁ u) + wbalance (txwdrls tx) + keyRefunds pp tx -}
     consumedValue =
       balance (UTxO (Map.restrictKeys u (txBody ^. inputsTxBodyL)))
         <> inject (refunds <> withdrawals)
-    refunds = getTotalRefundsTxBody pp lookupRefund (const Nothing) txBody
+    refunds = getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 -- | Computes the set of script hashes required to unlock the transaction inputs and the

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.8.0.0
 
+* Add `shelleyTotalDepositsTxCerts` and `shelleyTotalRefundsTxCerts`
+* Remove dead functions: `depositPoolChange` and `reapRewards`
+* Move `getTotalDepositsTxBody` and `getTotalRefundsTxBody` into
+  `cardano-ledger-core:Cardano.Ledger.Core.EraTxBody` from `ShelleyEraTxBody`
+* Change type signature and behavior of `updateUTxOState`
+* Deprecate `totalCertsDeposits`, `totalCertsDepositsCertState`, `totalTxDepositsShelley`,
+  `keyCertsRefundsCertState`, `keyCertsRefunds` and `totalTxRefundsShelley`
+
 ### `testlib`
 
 * Provide CDDL spec files with `readBabbageCddlFileNames` and `readBabbageCddlFiles` from

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -111,7 +111,7 @@ library
         cardano-data >=1.0,
         cardano-ledger-binary >=1.0,
         cardano-ledger-byron,
-        cardano-ledger-core >=1.8 && <1.9,
+        cardano-ledger-core >=1.9 && <1.10,
         cardano-slotting,
         vector-map >=1.0,
         containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -21,6 +21,8 @@ import Cardano.Ledger.CertState (
   CertState (..),
   DState (..),
   PState (..),
+  certsTotalDepositsTxBody,
+  certsTotalRefundsTxBody,
   rewards,
  )
 import Cardano.Ledger.Coin (Coin (..))
@@ -147,7 +149,7 @@ consumedTxBody ::
 consumedTxBody txBody pp dpstate (UTxO u) =
   Consumed
     { conInputs = coinBalance (UTxO (Map.restrictKeys u (txBody ^. inputsTxBodyL)))
-    , conRefunds = getTotalRefundsTxBody pp dpstate txBody
+    , conRefunds = certsTotalRefundsTxBody pp dpstate txBody
     , conWithdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
     }
 
@@ -162,5 +164,5 @@ producedTxBody txBody pp dpstate =
   Produced
     { proOutputs = coinBalance (txouts txBody)
     , proFees = txBody ^. feeTxBodyL
-    , proDeposits = getTotalDepositsTxBody pp dpstate txBody
+    , proDeposits = certsTotalDepositsTxBody pp dpstate txBody
     }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -20,7 +20,6 @@ module Cardano.Ledger.Shelley.Core (
 where
 
 import Cardano.Ledger.Address
-import Cardano.Ledger.CertState (CertState)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
@@ -41,15 +40,6 @@ class (ShelleyEraTxCert era, EraTxBody era) => ShelleyEraTxBody era where
   updateTxBodyG :: SimpleGetter (TxBody era) (StrictMaybe (Update era))
   default updateTxBodyG :: ProtVerAtMost era 8 => SimpleGetter (TxBody era) (StrictMaybe (Update era))
   updateTxBodyG = updateTxBodyL
-
-  -- | Compute the total deposits from the Certs of a TxBody
-  --   This is the contribution of a TxBody towards the deposit pot (utxosDeposit field of the UTxOState) of the system
-  getTotalDepositsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
-
-  -- | Compute the total refunds from the Certs of a TxBody.
-  --   This is the contribution of a TxBody towards the total 'Obligations' of the system
-  --   See the Types and Functions Cardano.Ledger.CertState(Obligations,obligationCertState) for more information.
-  getTotalRefundsTxBody :: PParams era -> CertState era -> TxBody era -> Coin
 
 type Wdrl c = Withdrawals c
 {-# DEPRECATED Wdrl "In favor of `Cardano.Ledger.Address.Withdrawals`" #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -83,10 +83,8 @@ module Cardano.Ledger.Shelley.LedgerState (
   -- * Remove Bootstrap Redeem Addresses
   returnRedeemAddrsToReserves,
   updateNonMyopic,
-  depositPoolChange,
   emptyRewardUpdate,
   pvCanFollow,
-  reapRewards,
   availableAfterMIR,
   ShelleyGovState (..),
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -96,6 +96,7 @@ import Cardano.Ledger.UTxO (
   balance,
   txouts,
  )
+import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq
 import Control.Monad.Trans.Reader (asks)
@@ -408,8 +409,8 @@ utxoInductive ::
   ) =>
   TransitionRule (utxo era)
 utxoInductive = do
-  TRC (UtxoEnv slot pp dpstate genDelegs, u, tx) <- judgmentContext
-  let UTxOState utxo _ _ ppup _ _ = u
+  TRC (UtxoEnv slot pp certState genDelegs, utxos, tx) <- judgmentContext
+  let UTxOState utxo _ _ ppup _ _ = utxos
       txBody = tx ^. bodyTxL
       outputs = txBody ^. outputsTxBodyL
 
@@ -434,7 +435,7 @@ utxoInductive = do
   runTest $ validateWrongNetworkWithdrawal netId txBody
 
   {- consumed pp utxo txb = produced pp poolParams txb -}
-  runTest $ validateValueNotConservedUTxO pp utxo dpstate txBody
+  runTest $ validateValueNotConservedUTxO pp utxo certState txBody
 
   -- process Protocol Parameter Update Proposals
   ppup' <- trans @(EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txup tx)
@@ -448,11 +449,8 @@ utxoInductive = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ validateMaxTxSizeUTxO pp tx
 
-  let refunded = certsTotalRefundsTxBody pp dpstate txBody
-  let totalDeposits' = certsTotalDepositsTxBody pp dpstate txBody
-  let depositChange = totalDeposits' Val.<-> refunded
-  tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
-  pure $! updateUTxOState pp u txBody depositChange ppup'
+  updateUTxOState pp utxos txBody certState ppup' $
+    tellEvent . TotalDeposits (hashAnnotated txBody)
 
 -- | The ttl field marks the top of an open interval, so it must be strictly
 -- less than the slot, so fail if it is (>=).
@@ -611,30 +609,42 @@ validateMaxTxSizeUTxO pp tx =
     maxTxSize = toInteger (pp ^. ppMaxTxSizeL)
     txSize = tx ^. sizeTxF
 
+-- | This monadic action captures the final stages of the UTXO(S) rule. In particular it
+-- applies all of the UTxO related aditions and removals, gathers all of the fees into the
+-- fee pot `utxosFees` and updates the `utxosDeposited` field. Continuation supplied will
+-- be called on the @deposit - refund@ change, which is normally used to emit the
+-- `TotalDeposits` event.
 updateUTxOState ::
-  EraTxBody era =>
+  (EraTxBody era, Monad m) =>
   PParams era ->
   UTxOState era ->
   TxBody era ->
-  Coin ->
+  CertState era ->
   GovState era ->
-  UTxOState era
-updateUTxOState pp UTxOState {utxosUtxo, utxosDeposited, utxosFees, utxosStakeDistr, utxosDonation} txb depositChange govState =
-  let UTxO utxo = utxosUtxo
-      !utxoAdd = txouts txb -- These will be inserted into the UTxO
+  (Coin -> m ()) ->
+  m (UTxOState era)
+updateUTxOState pp utxos txBody certState govState depositChangeEvent = do
+  let UTxOState {utxosUtxo, utxosDeposited, utxosFees, utxosStakeDistr, utxosDonation} = utxos
+      UTxO utxo = utxosUtxo
+      !utxoAdd = txouts txBody -- These will be inserted into the UTxO
       {- utxoDel  = txins txb ◁ utxo -}
-      !(utxoWithout, utxoDel) = extractKeys utxo (txb ^. inputsTxBodyL)
+      !(utxoWithout, utxoDel) = extractKeys utxo (txBody ^. inputsTxBodyL)
       {- newUTxO = (txins txb ⋪ utxo) ∪ outs txb -}
       newUTxO = utxoWithout `Map.union` unUTxO utxoAdd
       newIncStakeDistro = updateStakeDistribution pp utxosStakeDistr (UTxO utxoDel) utxoAdd
-   in UTxOState
-        { utxosUtxo = UTxO newUTxO
-        , utxosDeposited = utxosDeposited <> depositChange
-        , utxosFees = utxosFees <> txb ^. feeTxBodyL
-        , utxosGovState = govState
-        , utxosStakeDistr = newIncStakeDistro
-        , utxosDonation = utxosDonation
-        }
+      totalRefunds = certsTotalRefundsTxBody pp certState txBody
+      totalDeposits = certsTotalDepositsTxBody pp certState txBody
+      depositChange = totalDeposits <-> totalRefunds
+  depositChangeEvent depositChange
+  pure $!
+    UTxOState
+      { utxosUtxo = UTxO newUTxO
+      , utxosDeposited = utxosDeposited <> depositChange
+      , utxosFees = utxosFees <> txBody ^. feeTxBodyL
+      , utxosGovState = govState
+      , utxosStakeDistr = newIncStakeDistro
+      , utxosDonation = utxosDonation
+      }
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Binary (
   decodeRecordSum,
   encodeListLen,
  )
+import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (GenDelegs)
@@ -447,8 +448,8 @@ utxoInductive = do
   {- txsize tx ≤ maxTxSize pp -}
   runTest $ validateMaxTxSizeUTxO pp tx
 
-  let refunded = getTotalRefundsTxBody pp dpstate txBody
-  let totalDeposits' = getTotalDepositsTxBody pp dpstate txBody
+  let refunded = certsTotalRefundsTxBody pp dpstate txBody
+  let totalDeposits' = certsTotalDepositsTxBody pp dpstate txBody
   let depositChange = totalDeposits' Val.<-> refunded
   tellEvent $ TotalDeposits (hashAnnotated txBody) depositChange
   pure $! updateUTxOState pp u txBody depositChange ppup'

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -62,7 +62,6 @@ module Cardano.Ledger.Shelley.TxBody (
   addrEitherShelleyTxOutL,
   valueEitherShelleyTxOutL,
   totalTxDepositsShelley,
-  totalTxRefundsShelley,
 ) where
 
 import Cardano.Ledger.Address (RewardAcnt (..))
@@ -108,7 +107,7 @@ import Cardano.Ledger.PoolParams
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (totalTxDepositsShelley, totalTxRefundsShelley)
+import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (totalTxDepositsShelley)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
@@ -327,7 +326,10 @@ instance Crypto c => EraTxBody (ShelleyEra c) where
     lensMemoRawType stbrCerts $ \txBodyRaw certs -> txBodyRaw {stbrCerts = certs}
   {-# INLINEABLE certsTxBodyL #-}
 
-  upgradeTxBody = error "Calling this function will cause a compilation error, since there is no TxBody instance for ByronEra"
+  upgradeTxBody =
+    error $
+      "Calling this function will cause a compilation error, "
+        ++ "since there is no TxBody instance for ByronEra"
 
 instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   {-# SPECIALIZE instance ShelleyEraTxBody (ShelleyEra StandardCrypto) #-}
@@ -339,10 +341,6 @@ instance Crypto c => ShelleyEraTxBody (ShelleyEra c) where
   updateTxBodyL =
     lensMemoRawType stbrUpdate $ \txBodyRaw update -> txBodyRaw {stbrUpdate = update}
   {-# INLINEABLE updateTxBodyL #-}
-
-  getTotalDepositsTxBody = totalTxDepositsShelley
-
-  getTotalRefundsTxBody = totalTxRefundsShelley
 
 deriving newtype instance
   (Era era, NoThunks (TxOut era), NoThunks (TxCert era), NoThunks (PParamsUpdate era)) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -55,8 +55,6 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.TxCert (
   ShelleyEraTxCert,
-  shelleyTotalDepositsTxCerts,
-  shelleyTotalRefundsTxCerts,
   pattern DelegStakeTxCert,
   pattern RegTxCert,
   pattern UnRegTxCert,
@@ -168,9 +166,10 @@ shelleyProducedValue ::
 shelleyProducedValue pp isRegPoolId txBody =
   sumAllValue (txBody ^. outputsTxBodyL)
     <+> Val.inject
-      (txBody ^. feeTxBodyL <+> shelleyTotalDepositsTxCerts pp isRegPoolId (txBody ^. certsTxBodyL))
+      (txBody ^. feeTxBodyL <+> getTotalDepositsTxBody pp isRegPoolId txBody)
 
--- | Compute the lovelace which are destroyed by the transaction
+-- | Compute the lovelace which are destroyed by the transaction. This implementation is
+-- suitable for Shelley and Allegra only.
 getConsumedCoin ::
   ShelleyEraTxBody era =>
   PParams era ->
@@ -184,7 +183,7 @@ getConsumedCoin pp lookupRefund (UTxO u) txBody =
     <> refunds
     <> withdrawals
   where
-    refunds = shelleyTotalRefundsTxCerts pp lookupRefund (txBody ^. certsTxBodyL)
+    refunds = getTotalRefundsTxBody pp lookupRefund (const Nothing) txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set.Set (ScriptHash (EraCrypto era)))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -46,10 +46,6 @@ import Cardano.Ledger.Credential (Credential (..), credScriptHash)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits (
-  keyCertsRefunds,
-  totalCertsDeposits,
- )
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Tx ()
 import Cardano.Ledger.Shelley.TxBody (
@@ -59,6 +55,8 @@ import Cardano.Ledger.Shelley.TxBody (
  )
 import Cardano.Ledger.Shelley.TxCert (
   ShelleyEraTxCert,
+  shelleyTotalDepositsTxCerts,
+  shelleyTotalRefundsTxCerts,
   pattern DelegStakeTxCert,
   pattern RegTxCert,
   pattern UnRegTxCert,
@@ -170,7 +168,7 @@ shelleyProducedValue ::
 shelleyProducedValue pp isRegPoolId txBody =
   sumAllValue (txBody ^. outputsTxBodyL)
     <+> Val.inject
-      (txBody ^. feeTxBodyL <+> totalCertsDeposits pp isRegPoolId (txBody ^. certsTxBodyL))
+      (txBody ^. feeTxBodyL <+> shelleyTotalDepositsTxCerts pp isRegPoolId (txBody ^. certsTxBodyL))
 
 -- | Compute the lovelace which are destroyed by the transaction
 getConsumedCoin ::
@@ -186,7 +184,7 @@ getConsumedCoin pp lookupRefund (UTxO u) txBody =
     <> refunds
     <> withdrawals
   where
-    refunds = keyCertsRefunds pp lookupRefund (txBody ^. certsTxBodyL)
+    refunds = shelleyTotalRefundsTxCerts pp lookupRefund (txBody ^. certsTxBodyL)
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set.Set (ScriptHash (EraCrypto era)))

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -69,6 +69,7 @@ import Cardano.Ledger.BaseTypes (
   TxIx (..),
   textToUrl,
  )
+import Cardano.Ledger.CertState (certsTotalDepositsTxBody, certsTotalRefundsTxBody)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..), credToText)
@@ -425,8 +426,8 @@ fixupFees tx = do
   kpSpending <- lookupKeyPair =<< freshKeyHash
   kpStaking <- lookupKeyPair =<< freshKeyHash
   let
-    deposits = getTotalDepositsTxBody pp certState (tx ^. bodyTxL)
-    refunds = getTotalRefundsTxBody pp certState (tx ^. bodyTxL)
+    deposits = certsTotalDepositsTxBody pp certState (tx ^. bodyTxL)
+    refunds = certsTotalRefundsTxBody pp certState (tx ^. bodyTxL)
     outputsTotalCoin = sumAllCoin $ tx ^. bodyTxL . outputsTxBodyL
     remainingCoin = impRootTxCoin <-> (outputsTotalCoin <+> deposits <-> refunds)
     remainingTxOut =

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -80,7 +80,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.2,
         cardano-ledger-byron,
         cardano-ledger-byron-test,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.6.1,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.9,
         cardano-ledger-pretty,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.9,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -180,7 +180,7 @@ genTx
           ksIndexedGenDelegates
           pparams
           (utxoSt, dpState)
-      (certs, deposits, refunds, dpState', (certWits, certScripts)) <-
+      (certs, deposits, refunds, dpState', certWits, certScripts) <-
         genTxCerts ge pparams dpState slot txIx reserves
       metadata <- genEraAuxiliaryData @era constants
       -------------------------------------------------------------------------
@@ -248,7 +248,7 @@ genTx
           slot
           (Set.fromList inputs)
           draftOutputs
-          certs
+          (StrictSeq.fromList certs)
           (Withdrawals (Map.fromList wdrls))
           draftFee
           (maybeToStrictMaybe update)

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -59,7 +59,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-conway >=1.10,
-        cardano-ledger-core >=1.8.1 && <1.9,
+        cardano-ledger-core >=1.8.1 && <1.10,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley >=1.7,
         cardano-slotting,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Version history for `cardano-ledger-core`
 
-## 1.8.1.0
+## 1.9.0.0
 
+* Add `certsTotalDepositsTxBody` and `certsTotalRefundsTxBody`
+* Add `getTotalDepositsTxBody` and `getTotalRefundsTxBody` to `EraTxBody`. Corresponding
+  functions have been removed from `ShelleyEraTxBody` in favor of the two above
+* Add `getTotalDepositsTxCerts` and `getTotalRefundsTxCerts` to `EraTxCert`
 * Deprecated `Cardano.Ledger.Ap`, since we no longer use this module
 * Moved `Cardano.Ledger.Language` to `Cardano.Ledger.Plutus.Language` with deprecation.
 * Move `ExUnits` and `Prices` from `Cardano.Ledger.Alonzo.Scripts` to new

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.8.1.0
+version:            1.9.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -26,7 +26,9 @@ module Cardano.Ledger.Core.TxCert (
 where
 
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR, ToCBOR)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core.Era (Era (EraCrypto))
+import Cardano.Ledger.Core.PParams (PParams)
 import Cardano.Ledger.Core.Translation
 import Cardano.Ledger.Credential (Credential (..), StakeCredential)
 import Cardano.Ledger.Hashes (ScriptHash)
@@ -86,6 +88,26 @@ class
 
   -- | Extract staking credential from any certificate that can unregister such credential
   lookupUnRegStakeTxCert :: TxCert era -> Maybe (Credential 'Staking (EraCrypto era))
+
+  -- | Compute the total deposits from a list of certificates.
+  getTotalDepositsTxCerts ::
+    Foldable f =>
+    PParams era ->
+    -- | Check whether stake pool is registered or not
+    (KeyHash 'StakePool (EraCrypto era) -> Bool) ->
+    f (TxCert era) ->
+    Coin
+
+  -- | Compute the total refunds from a list of certificates.
+  getTotalRefundsTxCerts ::
+    Foldable f =>
+    PParams era ->
+    -- | Lookup current deposit for Staking credential if one is registered
+    (Credential 'Staking (EraCrypto era) -> Maybe Coin) ->
+    -- | Lookup current deposit for DRep credential if one is registered
+    (Credential 'DRepRole (EraCrypto era) -> Maybe Coin) ->
+    f (TxCert era) ->
+    Coin
 
 pattern RegPoolTxCert :: EraTxCert era => PoolParams (EraCrypto era) -> TxCert era
 pattern RegPoolTxCert d <- (getRegPoolTxCert -> Just d)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -49,7 +49,7 @@ import Cardano.Ledger.Core (
   valueTxOutL,
  )
 import Cardano.Ledger.Credential (Credential, Ptr)
-import Cardano.Ledger.DRep (DRep (..), DRepState (..))
+import Cardano.Ledger.DRep (DRep (..), DRepState (..), drepDepositL)
 import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..), Stake (..))
 import Cardano.Ledger.Era (Era (EraCrypto))
 import Cardano.Ledger.Hashes (DataHash, EraIndependentScriptIntegrity, ScriptHash (..))
@@ -283,6 +283,12 @@ dreps = Var $ V "dreps" (MapR VCredR DRepStateR) (Yes NewEpochStateR drepsL)
 
 drepsL :: NELens era (Map (Credential 'DRepRole (EraCrypto era)) (DRepState (EraCrypto era)))
 drepsL = nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
+
+drepDeposits :: Era era => Term era (Map (Credential 'DRepRole (EraCrypto era)) Coin)
+drepDeposits = Var $ V "drepDeposits" (MapR VCredR CoinR) (Yes NewEpochStateR drepDepositsL)
+
+drepDepositsL :: NELens era (Map (Credential 'DRepRole (EraCrypto era)) Coin)
+drepDepositsL = drepsL . lens (fmap drepDeposit) (Map.intersectionWith (flip (set drepDepositL)))
 
 committeeState :: Era era => Term era (Map (Credential 'ColdCommitteeRole (EraCrypto era)) (Maybe (Credential 'HotCommitteeRole (EraCrypto era))))
 committeeState = Var $ V "committeeState" (MapR CommColdCredR (MaybeR CommHotCredR)) (Yes NewEpochStateR committeeStateL)


### PR DESCRIPTION
# Description

This PR creates consistent behavior for how we compute deposits and refunds. In particular it adds two functions to `EraTxCert` class that are responsible for getting the refunds and deposits from a list of certificates:

* `getTotalDepositsTxCerts`
* `getTotalRefundsTxCerts`

There are now also matching `EraTxBody` functions:

* `getTotalDepositsTxBody`
* `getTotalRefundsTxBody`

Which will call into `getTotalDepositsTxCerts` and `getTotalRefundsTxBody` respectively for all eras except Conway, because in Conway is the first era where we have one more place where we collect deposits from besides the certificates, namely we also called deposits from proposal procedures.

Most important change in this PR is that it makes deposits and refunds computation and location of implementation logic is consistent. In particular it discourages usage of era specific function for refunds and deposits calculation, except for instance declaration of corresponding functions.

Other improvements include:
* Reduction in duplication in UTXOS/UTXO rules
* Reduction of duplication in `EraUTxO` instances.
* Fixing constraint based generator to account for DRep deposits

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
