### PR TITLE
`MaryValue` fixes

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -74,7 +74,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.0.1,
         cardano-ledger-core >=1.8.1 && <1.9,
-        cardano-ledger-mary >=1.1,
+        cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -103,6 +103,7 @@ import Cardano.Ledger.Binary.Coders (
   (!>),
   (<!),
  )
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Core as Core hiding (TranslationError)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Value (
@@ -283,7 +284,7 @@ transMintValue m = transMultiAssetInternal m justZeroAda
     justZeroAda = PV1.singleton PV1.adaSymbol PV1.adaToken 0
 
 transValue :: MaryValue c -> PV1.Value
-transValue (MaryValue n m) = justAda <> transMultiAsset m
+transValue (MaryValue (Coin n) m) = justAda <> transMultiAsset m
   where
     justAda = PV1.singleton PV1.adaSymbol PV1.adaToken n
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -305,7 +305,7 @@ instance Crypto c => MaryEraTxBody (AlonzoEra c) where
     lensMemoRawType atbrMint (\txBodyRaw mint_ -> txBodyRaw {atbrMint = mint_})
   {-# INLINEABLE mintTxBodyL #-}
 
-  mintValueTxBodyF = mintTxBodyL . to (MaryValue 0)
+  mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
   {-# INLINEABLE mintValueTxBodyF #-}
 
   mintedTxBodyF = to (Set.map policyID . policies . atbrMint . getMemoRawType)

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -53,7 +53,7 @@ library
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.9,
         cardano-ledger-shelley-test >=1.2,
         cardano-ledger-shelley-ma-test ^>=1.2,
-        cardano-ledger-mary ^>=1.3,
+        cardano-ledger-mary >=1.4,
         cardano-protocol-tpraos ^>=1.0,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Binary (decCBOR, decodeFullAnnotator)
 import Cardano.Ledger.Binary.Plain as Plain (serialize)
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Mary.Value (MaryValue (..), valueFromList)
+import Cardano.Ledger.Mary.Value (valueFromList)
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Protocol.TPraos.BHeader (BHeader)
@@ -96,7 +96,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               carlAddr
-              (valueFromList 1407406 [(pid1, smallestName, 1)])
+              (valueFromList (Coin 1407406) [(pid1, smallestName, 1)])
               (SJust $ hashData @Alonzo (Data (PV1.List [])))
           )
           @?= Coin 1655136
@@ -104,7 +104,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               bobAddr
-              (valueFromList 1407406 [(pid1, smallestName, 1)])
+              (valueFromList (Coin 1407406) [(pid1, smallestName, 1)])
               SNothing
           )
           @?= Coin 1310316
@@ -112,7 +112,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               aliceAddr
-              (valueFromList 1444443 [(pid1, smallName 1, 1)])
+              (valueFromList (Coin 1444443) [(pid1, smallName 1, 1)])
               SNothing
           )
           @?= Coin 1344798
@@ -121,7 +121,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               aliceAddr
               ( valueFromList
-                  1555554
+                  (Coin 1555554)
                   [ (pid1, smallName 1, 1)
                   , (pid1, smallName 2, 1)
                   , (pid1, smallName 3, 1)
@@ -134,7 +134,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               carlAddr
-              (valueFromList 1555554 [(pid1, largestName 65, 1)])
+              (valueFromList (Coin 1555554) [(pid1, largestName 65, 1)])
               SNothing
           )
           @?= Coin 1448244
@@ -143,7 +143,7 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               carlAddr
               ( valueFromList
-                  1962961
+                  (Coin 1962961)
                   [ (pid1, largestName 65, 1)
                   , (pid1, largestName 66, 1)
                   , (pid1, largestName 67, 1)
@@ -156,7 +156,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               aliceAddr
-              (valueFromList 1592591 [(pid1, smallestName, 1), (pid2, smallestName, 1)])
+              (valueFromList (Coin 1592591) [(pid1, smallestName, 1), (pid2, smallestName, 1)])
               SNothing
           )
           @?= Coin 1482726
@@ -164,7 +164,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               aliceAddr
-              (valueFromList 1592591 [(pid1, smallestName, 1), (pid2, smallestName, 1)])
+              (valueFromList (Coin 1592591) [(pid1, smallestName, 1), (pid2, smallestName, 1)])
               (SJust $ hashData @Alonzo (Data (PV1.Constr 0 [])))
           )
           @?= Coin 1827546
@@ -172,7 +172,7 @@ goldenUTxOEntryMinAda =
         calcMinUTxO
           ( AlonzoTxOut
               bobAddr
-              (valueFromList 1629628 [(pid1, smallName 1, 1), (pid2, smallName 2, 1)])
+              (valueFromList (Coin 1629628) [(pid1, smallName 1, 1), (pid2, smallName 2, 1)])
               SNothing
           )
           @?= Coin 1517208
@@ -181,7 +181,13 @@ goldenUTxOEntryMinAda =
           ( AlonzoTxOut
               aliceAddr
               ( let f i c = (i, smallName c, 1)
-                 in valueFromList 7407400 [f i c | (i, cs) <- [(pid1, [32 .. 63]), (pid2, [64 .. 95]), (pid3, [96 .. 127])], c <- cs]
+                 in valueFromList
+                      (Coin 7407400)
+                      [ f i c
+                      | (i, cs) <-
+                          [(pid1, [32 .. 63]), (pid2, [64 .. 95]), (pid3, [96 .. 127])]
+                      , c <- cs
+                      ]
               )
               SNothing
           )
@@ -191,7 +197,7 @@ goldenUTxOEntryMinAda =
         -- with the old parameter minUTxOValue.
         -- If we wish to keep the ada-only, no datum hash, minimum value nearly the same,
         -- we can divide minUTxOValue by 29 and round.
-        utxoEntrySize @Alonzo (AlonzoTxOut aliceAddr (MaryValue 0 mempty) SNothing) @?= 29
+        utxoEntrySize @Alonzo (AlonzoTxOut aliceAddr mempty SNothing) @?= 29
     ]
 
 goldenSerialization :: TestTree

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -69,7 +69,7 @@ library
         cardano-ledger-alonzo >=1.5.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-core >=1.8.1 && <1.9,
-        cardano-ledger-mary >=1.1,
+        cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -353,7 +353,7 @@ mintBabbageTxBodyL =
 mintValueBabbageTxBodyF ::
   (BabbageEraTxBody era, Value era ~ MaryValue (EraCrypto era)) =>
   SimpleGetter (BabbageTxBody era) (Value era)
-mintValueBabbageTxBodyF = mintBabbageTxBodyL . to (MaryValue 0)
+mintValueBabbageTxBodyF = mintBabbageTxBodyL . to (MaryValue mempty)
 {-# INLINEABLE mintValueBabbageTxBodyF #-}
 
 collateralInputsBabbageTxBodyL ::

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -39,7 +39,7 @@ library
         cardano-ledger-babbage:{cardano-ledger-babbage, testlib} ^>=1.5,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.8.1,
         cardano-ledger-shelley-ma-test >=1.1,
-        cardano-ledger-mary ^>=1.3,
+        cardano-ledger-mary >=1.4,
         cardano-ledger-shelley-test >=1.1,
         cardano-ledger-shelley >=1.6 && <1.9,
         cardano-strict-containers,

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -99,7 +99,7 @@ collateralOutput :: BabbageTxOut Babbage
 collateralOutput =
   BabbageTxOut
     (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
-    (MaryValue 8675309 mempty)
+    (MaryValue (Coin 8675309) mempty)
     NoDatum
     SNothing
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -80,7 +80,7 @@ library
         cardano-ledger-alonzo ^>=1.5.1,
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.8.1,
-        cardano-ledger-mary >=1.1,
+        cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.7 && <1.9,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -557,7 +557,7 @@ nonZeroInt64 = negInt64 / posInt64 ; this is the same as the current int64 defin
 
 positive_coin = 1 .. 18446744073709551615
 
-value = positive_coin / [positive_coin,multiasset<positive_coin>]
+value = coin / [coin, multiasset<positive_coin>]
 
 mint = multiasset<nonZeroInt64>
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -517,7 +517,7 @@ instance Crypto c => MaryEraTxBody (ConwayEra c) where
   mintTxBodyL = lensMemoRawType ctbrMint (\txb x -> txb {ctbrMint = x})
   {-# INLINE mintTxBodyL #-}
 
-  mintValueTxBodyF = mintTxBodyL . to (MaryValue 0)
+  mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
 
   mintedTxBodyF = to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (ctbrMint txBodyRaw)))
   {-# INLINE mintedTxBodyF #-}

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -39,7 +39,7 @@ library
         cardano-ledger-conway:{cardano-ledger-conway, testlib} >=1.9 && <1.12,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.8.1,
         cardano-ledger-allegra ^>=1.2,
-        cardano-ledger-mary ^>=1.3,
+        cardano-ledger-mary ^>=1.4,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-shelley-test >=1.1,
         cardano-ledger-shelley >=1.6,

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -114,7 +114,7 @@ collateralOutput :: BabbageTxOut Conway
 collateralOutput =
   BabbageTxOut
     (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
-    (MaryValue 8675309 mempty)
+    (MaryValue (Coin 8675309) mempty)
     NoDatum
     SNothing
 

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.3.6.0
+## 1.4.0.0
+
+* Switch `MaryValue` field for ADA from `Integer` to `Coin`
 
 ### `testlib`
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -101,12 +101,11 @@ library testlib
         cardano-data:testlib,
         cardano-crypto-class,
         cardano-ledger-binary:testlib,
-        cardano-ledger-core,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary >=1.0.0.1,
         cardano-ledger-allegra:testlib,
         cardano-ledger-shelley:testlib,
-        cardano-strict-containers,
-        QuickCheck
+        cardano-strict-containers
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.3.6.0
+version:            1.4.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -316,7 +316,7 @@ instance Crypto c => MaryEraTxBody (MaryEra c) where
 
   mintValueTxBodyF =
     to $ \(TxBodyConstr (Memo (MaryTxBodyRaw txBodyRaw) _)) ->
-      MaryValue 0 (atbrMint txBodyRaw)
+      MaryValue mempty (atbrMint txBodyRaw)
   {-# INLINEABLE mintValueTxBodyF #-}
 
   mintedTxBodyF =

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -35,6 +35,7 @@ import Test.Cardano.Ledger.Mary.Arbitrary (
   genMultiAsset,
   genMultiAssetToFail,
   genMultiAssetZero,
+  genNegativeInt,
  )
 
 spec :: Spec
@@ -61,13 +62,11 @@ spec = do
         forAll (genEmptyMultiAsset @StandardCrypto) $
           roundTripCborRangeFailureExpectation (natVersion @9) maxBound
     context "MaryValue" $ do
-      prop "Positive MaryValue succeeds for all eras" $
-        forAll
-          (genMaryValue (genMultiAsset @StandardCrypto (toInteger <$> chooseInt (1, maxBound))))
-          roundTripCborExpectation
+      prop "Positive MaryValue succeeds for all eras" $ \(mv :: MaryValue StandardCrypto) ->
+        roundTripCborExpectation mv
       prop "Negative MaryValue fails for all eras" $
         forAll
-          (genMaryValue (genMultiAsset @StandardCrypto (toInteger <$> chooseInt (minBound, -1))))
+          (genMaryValue (genMultiAsset @StandardCrypto (toInteger <$> genNegativeInt)))
           roundTripCborFailureExpectation
       prop "Zero MaryValue fails for Conway" $
         forAll (genMaryValue (genMultiAssetZero @StandardCrypto)) $

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
@@ -18,6 +18,7 @@ module Test.Cardano.Ledger.Mary.Arbitrary (
 ) where
 
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, castHash, hashWith)
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -212,7 +213,7 @@ genMaryValue :: Gen (MultiAsset c) -> Gen (MaryValue c)
 genMaryValue genMA = do
   i <- toInteger <$> genPositiveInt
   ma <- genMA
-  pure $ MaryValue i ma
+  pure $ MaryValue (Coin i) ma
 
 instance Crypto c => Arbitrary (MaryValue c) where
   arbitrary =

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Mary.Arbitrary (
   genMultiAssetZero,
   genPositiveInt,
   genNegativeInt,
+  genNonNegativeInt,
 ) where
 
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, castHash, hashWith)
@@ -194,6 +195,14 @@ genEmptyMultiAsset :: Crypto c => Gen (MultiAsset c)
 genEmptyMultiAsset =
   MultiAsset <$> genNonEmptyMap arbitrary (pure Map.empty)
 
+-- | Better generator for a Non-Negative Int that explores more values
+genNonNegativeInt :: Gen Int
+genNonNegativeInt =
+  oneof
+    [ choose (0, maxBound)
+    , getNonNegative <$> arbitrary
+    ]
+
 -- | Better generator for a positive Int that explores more values
 genPositiveInt :: Gen Int
 genPositiveInt =
@@ -202,6 +211,7 @@ genPositiveInt =
     , getPositive <$> arbitrary
     ]
 
+-- | Better generator for a Negative Int that explores more values
 genNegativeInt :: Gen Int
 genNegativeInt =
   oneof
@@ -211,7 +221,7 @@ genNegativeInt =
 
 genMaryValue :: Gen (MultiAsset c) -> Gen (MaryValue c)
 genMaryValue genMA = do
-  i <- toInteger <$> genPositiveInt
+  i <- toInteger <$> genNonNegativeInt
   ma <- genMA
   pure $ MaryValue (Coin i) ma
 

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -45,7 +45,7 @@ library
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3,
         cardano-ledger-pretty,
         cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.2,
-        cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.3,
+        cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.4,
         cardano-slotting,
         containers,
         hashable,

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Examples/Consensus.hs
@@ -6,6 +6,7 @@
 
 module Test.Cardano.Ledger.Mary.Examples.Consensus where
 
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary (Mary)
 import Cardano.Ledger.Mary.Core
@@ -29,7 +30,7 @@ ledgerExamplesMary =
     mempty
 
 exampleMultiAssetValue :: Crypto c => Int -> MaryValue c
-exampleMultiAssetValue x = MaryValue 100 $ exampleMultiAsset x
+exampleMultiAssetValue x = MaryValue (Coin 100) $ exampleMultiAsset x
 
 exampleMultiAsset :: forall c. Crypto c => Int -> MultiAsset c
 exampleMultiAsset x =

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Mary/Golden.hs
@@ -83,7 +83,7 @@ goldenScaledMinDeposit =
     "golden tests - scaledMinDeposit"
     [ testCase "one policy, one (smallest) name" $
         scaledMinDeposit
-          ( MaryValue 1407406 $
+          ( MaryValue (Coin 1407406) $
               MultiAsset $
                 Map.singleton pid1 (Map.fromList [(smallestName, 1)])
           )
@@ -91,7 +91,7 @@ goldenScaledMinDeposit =
           @?= Coin 1407406
     , testCase "one policy, one (small) name" $
         scaledMinDeposit
-          ( MaryValue 1444443 $
+          ( MaryValue (Coin 1444443) $
               MultiAsset $
                 Map.singleton
                   pid1
@@ -101,7 +101,7 @@ goldenScaledMinDeposit =
           @?= Coin 1444443
     , testCase "one policy, one (real) name" $
         scaledMinDeposit
-          ( MaryValue 1444443 $
+          ( MaryValue (Coin 1444443) $
               MultiAsset $
                 Map.singleton
                   pid1
@@ -111,7 +111,7 @@ goldenScaledMinDeposit =
           @?= Coin 1481480
     , testCase "one policy, three (small) name" $
         scaledMinDeposit
-          ( MaryValue 1555554 $
+          ( MaryValue (Coin 1555554) $
               MultiAsset $
                 Map.singleton
                   pid1
@@ -126,7 +126,7 @@ goldenScaledMinDeposit =
           @?= Coin 1555554
     , testCase "one policy, one (largest) name" $
         scaledMinDeposit
-          ( MaryValue 1555554 $
+          ( MaryValue (Coin 1555554) $
               MultiAsset $
                 Map.singleton
                   pid1
@@ -136,7 +136,7 @@ goldenScaledMinDeposit =
           @?= Coin 1555554
     , testCase "one policy, three (largest) name" $
         scaledMinDeposit
-          ( MaryValue 1962961 $
+          ( MaryValue (Coin 1962961) $
               MultiAsset $
                 Map.singleton
                   pid1
@@ -151,7 +151,7 @@ goldenScaledMinDeposit =
           @?= Coin 1962961
     , testCase "two policies, one (smallest) name" $
         scaledMinDeposit
-          ( MaryValue 1592591 $
+          ( MaryValue (Coin 1592591) $
               MultiAsset $
                 Map.fromList
                   [
@@ -168,7 +168,7 @@ goldenScaledMinDeposit =
           @?= Coin 1592591
     , testCase "two policies, two (small) names" $
         scaledMinDeposit
-          ( MaryValue 1629628 $
+          ( MaryValue (Coin 1629628) $
               MultiAsset $
                 Map.fromList
                   [
@@ -185,7 +185,7 @@ goldenScaledMinDeposit =
           @?= Coin 1629628
     , testCase "three policies, ninety-six (small) names" $
         scaledMinDeposit
-          ( MaryValue 7407400 $
+          ( MaryValue (Coin 7407400) $
               MultiAsset $
                 Map.fromList
                   [

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -272,7 +272,7 @@ addTokens ::
 addTokens proxy tooLittleLovelace pparams ts (txOut :<| os) =
   if txOut ^. coinTxOutL < getMinCoinTxOut pparams txOut
     then addTokens proxy (txOut :<| tooLittleLovelace) pparams ts os
-    else Just $ tooLittleLovelace >< addValToTxOut @era (MaryValue 0 ts) txOut <| os
+    else Just $ tooLittleLovelace >< addValToTxOut @era (MaryValue mempty ts) txOut <| os
 addTokens _proxy _ _ _ StrictSeq.Empty = Nothing
 
 -- | This function is only good in the Mary Era
@@ -317,11 +317,13 @@ genTxBody pparams slot ins outs cert wdrl fee upd meta = do
     )
 
 instance Split (MaryValue era) where
-  vsplit (MaryValue n _) 0 = ([], Coin n)
-  vsplit (MaryValue n mp) m
+  vsplit (MaryValue n _) 0 = ([], n)
+  vsplit (MaryValue (Coin n) mp) m
     | m <= 0 = error "must split coins into positive parts"
     | otherwise =
-        ( take (fromIntegral m) (MaryValue (n `div` m) mp : repeat (MaryValue (n `div` m) mempty))
+        ( take
+            (fromIntegral m)
+            (MaryValue (Coin (n `div` m)) mp : repeat (MaryValue (Coin (n `div` m)) mempty))
         , Coin (n `rem` m)
         )
 

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -152,7 +152,7 @@ aliceCoinSimpleEx1 :: Coin
 aliceCoinSimpleEx1 = aliceInitCoin <-> feeEx
 
 tokensSimpleEx1 :: MaryValue StandardCrypto
-tokensSimpleEx1 = (MaryValue 0 mintSimpleEx1) <+> Val.inject aliceCoinSimpleEx1
+tokensSimpleEx1 = MaryValue mempty mintSimpleEx1 <+> Val.inject aliceCoinSimpleEx1
 
 -- Mint a purple token bundle, consisting of thirteen plums and two amethysts.
 -- Give the bundle to Alice.
@@ -192,13 +192,13 @@ aliceCoinsSimpleEx2 = aliceCoinSimpleEx1 <-> (feeEx <+> minUtxoSimpleEx2)
 
 aliceTokensSimpleEx2 :: MaryValue StandardCrypto
 aliceTokensSimpleEx2 =
-  MaryValue (unCoin aliceCoinsSimpleEx2) $
+  MaryValue aliceCoinsSimpleEx2 $
     MultiAsset $
       Map.singleton purplePolicyId (Map.fromList [(plum, 8), (amethyst, 2)])
 
 bobTokensSimpleEx2 :: MaryValue StandardCrypto
 bobTokensSimpleEx2 =
-  MaryValue (unCoin minUtxoSimpleEx2) $
+  MaryValue minUtxoSimpleEx2 $
     MultiAsset $
       Map.singleton purplePolicyId (Map.singleton plum 5)
 
@@ -276,7 +276,7 @@ aliceCoinsTimeEx1 :: Coin
 aliceCoinsTimeEx1 = aliceInitCoin <-> feeEx
 
 tokensTimeEx1 :: MaryValue StandardCrypto
-tokensTimeEx1 = (MaryValue 0 mintTimeEx1) <+> Val.inject aliceCoinsTimeEx1
+tokensTimeEx1 = MaryValue mempty mintTimeEx1 <+> Val.inject aliceCoinsTimeEx1
 
 -- Mint tokens
 txbodyTimeEx1 :: StrictMaybe SlotNo -> StrictMaybe SlotNo -> TxBody Mary
@@ -330,7 +330,7 @@ mintTimeEx2 = Coin 120
 
 bobTokensTimeEx2 :: MaryValue StandardCrypto
 bobTokensTimeEx2 =
-  MaryValue (unCoin mintTimeEx2) $
+  MaryValue mintTimeEx2 $
     MultiAsset $
       Map.singleton boundedTimePolicyId (Map.singleton tokenTimeEx 1)
 
@@ -396,7 +396,7 @@ bobCoinsSingWitEx1 :: Coin
 bobCoinsSingWitEx1 = bobInitCoin <-> feeEx
 
 tokensSingWitEx1 :: MaryValue StandardCrypto
-tokensSingWitEx1 = (MaryValue 0 mintSingWitEx1) <+> Val.inject bobCoinsSingWitEx1
+tokensSingWitEx1 = MaryValue mempty mintSingWitEx1 <+> Val.inject bobCoinsSingWitEx1
 
 -- Bob pays the fees, but only alice can witness the minting
 txbodySingWitEx1 :: TxBody Mary
@@ -449,7 +449,7 @@ mintNegEx1 =
 
 aliceTokensNegEx1 :: MaryValue StandardCrypto
 aliceTokensNegEx1 =
-  MaryValue (unCoin $ aliceCoinsSimpleEx2 <-> feeEx) $
+  MaryValue (aliceCoinsSimpleEx2 <-> feeEx) $
     MultiAsset $
       Map.singleton purplePolicyId (Map.singleton amethyst 2)
 
@@ -492,7 +492,7 @@ mintNegEx2 =
 
 aliceTokensNegEx2 :: MaryValue StandardCrypto
 aliceTokensNegEx2 =
-  MaryValue (unCoin $ aliceCoinsSimpleEx2 <-> feeEx) $
+  MaryValue (aliceCoinsSimpleEx2 <-> feeEx) $
     MultiAsset $
       Map.singleton purplePolicyId (Map.fromList [(plum, -1), (amethyst, 2)])
 
@@ -526,7 +526,9 @@ smallValue =
 
 smallOut :: ShelleyTxOut Mary
 smallOut =
-  ShelleyTxOut Cast.aliceAddr $ (MaryValue 0 smallValue) <+> Val.inject (aliceInitCoin <-> (feeEx <+> minUtxoBigEx))
+  ShelleyTxOut Cast.aliceAddr $
+    MaryValue mempty smallValue
+      <+> Val.inject (aliceInitCoin <-> (feeEx <+> minUtxoBigEx))
 
 numAssets :: Int
 numAssets = 1000
@@ -539,7 +541,7 @@ bigValue =
       (Map.fromList $ map (\x -> (AssetName . fromString $ show x, 1)) [1 .. numAssets])
 
 bigOut :: ShelleyTxOut Mary
-bigOut = ShelleyTxOut Cast.aliceAddr $ (MaryValue 0 bigValue) <+> Val.inject minUtxoBigEx
+bigOut = ShelleyTxOut Cast.aliceAddr $ MaryValue mempty bigValue <+> Val.inject minUtxoBigEx
 
 txbodyWithBigValue :: TxBody Mary
 txbodyWithBigValue =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Value.hs
@@ -90,7 +90,9 @@ insert3 combine pid aid new (MaryValue c (MultiAsset m1)) =
 
 -- | Make a Value with no coin, and just one token.
 unit :: PolicyID c -> AssetName -> Integer -> MaryValue c
-unit pid aid n = MaryValue 0 $ MultiAsset (canonicalInsert pickNew pid (canonicalInsert pickNew aid n empty) empty)
+unit pid aid n =
+  MaryValue mempty $
+    MultiAsset (canonicalInsert pickNew pid (canonicalInsert pickNew aid n empty) empty)
 
 -- Use <+> and <->
 
@@ -117,17 +119,17 @@ insert2 combine pid aid new m1 =
 -- 3 functions that build Values from Policy Asset triples.
 
 valueFromList :: [(PolicyID StandardCrypto, AssetName, Integer)] -> Integer -> MaryValue StandardCrypto
-valueFromList list c = MaryValue c $ foldr acc mempty list
+valueFromList list c = MaryValue (Coin c) $ foldr acc mempty list
   where
     acc (policy, asset, count) m = insertMultiAsset (+) policy asset count m
 
 valueFromList3 :: [(PolicyID StandardCrypto, AssetName, Integer)] -> Integer -> MaryValue StandardCrypto
-valueFromList3 list c = foldr acc (MaryValue c mempty) list
+valueFromList3 list c = foldr acc (MaryValue (Coin c) mempty) list
   where
     acc (policy, asset, count) m = insert3 (+) policy asset count m
 
 valueFromList2 :: [(PolicyID StandardCrypto, AssetName, Integer)] -> Integer -> MaryValue StandardCrypto
-valueFromList2 list c = foldr acc (MaryValue c mempty) list
+valueFromList2 list c = foldr acc (MaryValue (Coin c) mempty) list
   where
     acc (policy, asset, count) m = insert2 (+) policy asset count m
 

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -296,7 +296,7 @@ goldenEncodingTestsMary =
     , checkEncodingCBOR
         (eraProtVerHigh @Mary)
         "not_just_ada_value"
-        ( MaryValue @StandardCrypto 2 $
+        ( MaryValue @StandardCrypto (Coin 2) $
             MultiAsset $
               Map.fromList
                 [
@@ -349,7 +349,10 @@ goldenEncodingTestsMary =
     , checkEncodingCBORDecodeFailure
         (eraProtVerHigh @Mary)
         "value_with_negative"
-        (MaryValue 1 $ MultiAsset $ Map.singleton policyID1 (Map.singleton (AssetName assetName1) (-19)))
+        ( MaryValue (Coin 1) $
+            MultiAsset $
+              Map.singleton policyID1 (Map.singleton (AssetName assetName1) (-19))
+        )
         ( T
             ( TkListLen 2
                 . TkInteger 1

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -218,23 +218,23 @@ instance
   encCBOR = \case
     BadInputsUTxO ins ->
       encodeListLen 2 <> encCBOR (0 :: Word8) <> encCBOR ins
-    (ExpiredUTxO a b) ->
+    ExpiredUTxO a b ->
       encodeListLen 3
         <> encCBOR (1 :: Word8)
         <> encCBOR a
         <> encCBOR b
-    (MaxTxSizeUTxO a b) ->
+    MaxTxSizeUTxO a b ->
       encodeListLen 3
         <> encCBOR (2 :: Word8)
         <> encCBOR a
         <> encCBOR b
     InputSetEmptyUTxO -> encodeListLen 1 <> encCBOR (3 :: Word8)
-    (FeeTooSmallUTxO a b) ->
+    FeeTooSmallUTxO a b ->
       encodeListLen 3
         <> encCBOR (4 :: Word8)
         <> encCBOR a
         <> encCBOR b
-    (ValueNotConservedUTxO a b) ->
+    ValueNotConservedUTxO a b ->
       encodeListLen 3
         <> encCBOR (5 :: Word8)
         <> encCBOR a
@@ -243,16 +243,16 @@ instance
       encodeListLen 2
         <> encCBOR (6 :: Word8)
         <> encCBOR outs
-    (UpdateFailure a) ->
+    UpdateFailure a ->
       encodeListLen 2
         <> encCBOR (7 :: Word8)
         <> encCBOR a
-    (WrongNetwork right wrongs) ->
+    WrongNetwork right wrongs ->
       encodeListLen 3
         <> encCBOR (8 :: Word8)
         <> encCBOR right
         <> encCBOR wrongs
-    (WrongNetworkWithdrawal right wrongs) ->
+    WrongNetworkWithdrawal right wrongs ->
       encodeListLen 3
         <> encCBOR (9 :: Word8)
         <> encCBOR right
@@ -273,7 +273,7 @@ instance
       \case
         0 -> do
           ins <- decCBOR
-          pure (2, BadInputsUTxO ins) -- The (2,..) indicates the number of things decoded, INCLUDING the tags, which are decoded by decodeRecordSumNamed
+          pure (2, BadInputsUTxO ins)
         1 -> do
           a <- decCBOR
           b <- decCBOR

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -42,7 +42,7 @@ library
         cardano-ledger-byron,
         cardano-ledger-conway >=1.11,
         cardano-ledger-core >=1.8.1,
-        cardano-ledger-mary >=1.0,
+        cardano-ledger-mary >=1.4,
         cardano-ledger-shelley >=1.6,
         cardano-protocol-tpraos >=1.0,
         cardano-slotting,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Mary.hs
@@ -12,7 +12,6 @@ import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
-import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Crypto as CC
 import Cardano.Ledger.Mary.TxBody
 import Cardano.Ledger.Mary.Value
@@ -41,7 +40,7 @@ instance CC.Crypto c => PrettyA (MultiAsset c) where
   prettyA x = ppSexp "MultiAsset" [ppMultiAsset x]
 
 ppValue :: MaryValue c -> PDoc
-ppValue (MaryValue n m) = ppSexp "Value" $ [ppCoin (Coin n), ppMultiAsset m] ++ ppBad
+ppValue (MaryValue n m) = ppSexp "Value" $ [ppCoin n, ppMultiAsset m] ++ ppBad
   where
     ppBad = case getBadMultiAsset m of
       [] -> []

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/TxOut.hs
@@ -39,7 +39,9 @@ benchTxOut =
       addr :: Int -> Addr StandardCrypto
       addr n = Addr Mainnet (key n) stake
       value :: MaryValue StandardCrypto
-      value = MaryValue 200 $ MultiAsset (singleton (PolicyID policyId28) (singleton assName 217))
+      value =
+        MaryValue (Coin 200) $
+          MultiAsset (singleton (PolicyID policyId28) (singleton assName 217))
       txOutAddr :: Int -> TxOut Alonzo
       txOutAddr n =
         mkBasicTxOut (addr n) value & dataHashTxOutL .~ SJust dataHash32

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -551,8 +551,8 @@ multiAsset size scripts = do
       pure $ multiAssetFromList xs
 
 genValueF :: UnivSize -> Proof era -> Coin -> Map (ScriptHash (EraCrypto era)) (ScriptF era) -> Gen (Value era)
-genValueF size proof (Coin c) scripts = case whichValue proof of
-  ValueShelleyToAllegra -> pure (Coin c)
+genValueF size proof c scripts = case whichValue proof of
+  ValueShelleyToAllegra -> pure c
   ValueMaryToConway -> MaryValue c <$> multiAsset size scripts
 
 stakeToVote :: Credential 'Staking c -> Credential 'DRepRole c

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.Shelley.TxCert (pattern UnRegTxCert)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UMap (UView (RewDepUView))
 import qualified Cardano.Ledger.UMap as UM
-import Cardano.Ledger.Val (inject, (<+>), (<->))
+import Cardano.Ledger.Val (inject, (<->))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.State.Transition.Extended (STS (..))
 import qualified Data.ByteString as BS (replicate)
@@ -510,7 +510,8 @@ multiAsset :: forall era. (Scriptic era, HasTokens era) => Proof era -> MultiAss
 multiAsset pf = forge @era 1 (always 2 pf)
 
 validatingTxWithMintOut :: forall era. (HasTokens era, EraTxOut era, Scriptic era, Value era ~ MaryValue (EraCrypto era)) => Proof era -> TxOut era
-validatingTxWithMintOut pf = newTxOut pf [Address (someAddr pf), Amount (MaryValue 0 (multiAsset pf) <+> inject (Coin 995))]
+validatingTxWithMintOut pf =
+  newTxOut pf [Address (someAddr pf), Amount (MaryValue (Coin 995) (multiAsset pf))]
 
 notValidatingTxWithMint ::
   forall era.
@@ -538,7 +539,7 @@ notValidatingTxWithMint pf =
         pf
         [ Inputs' [mkGenesisTxIn 8]
         , Collateral' [mkGenesisTxIn 18]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (MaryValue 0 ma <+> inject (Coin 995))]]
+        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (MaryValue (Coin 995) ma)]]
         , Txfee (Coin 5)
         , Mint ma
         , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] notValidatingRedeemersWithMint mempty)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -61,7 +61,7 @@ import Cardano.Ledger.Shelley.TxBody (
   RewardAcnt (..),
  )
 import Cardano.Ledger.Shelley.TxCert (pattern UnRegTxCert)
-import Cardano.Ledger.Val (inject, (<+>))
+import Cardano.Ledger.Val (inject)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -534,7 +534,7 @@ validatingManyScriptsBody pf =
       newTxOut
         pf
         [ Address (someAddr pf)
-        , Amount (MaryValue 0 mint <+> inject (Coin 4996))
+        , Amount (MaryValue (Coin 4996) mint)
         ]
     mint = forge @era 1 (always 2 pf) <> forge @era 1 (timelockScript 1 pf)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -563,8 +563,16 @@ validatingWithMintRedeemers =
 multiAsset :: forall era. (Scriptic era, HasTokens era) => Proof era -> MultiAsset (EraCrypto era)
 multiAsset pf = forge @era 1 (always 2 pf)
 
-validatingWithMintTxOut :: (HasTokens era, EraTxOut era, Scriptic era, Value era ~ MaryValue (EraCrypto era)) => Proof era -> TxOut era
-validatingWithMintTxOut pf = newTxOut pf [Address (someAddr pf), Amount (MaryValue 0 (multiAsset pf) <+> inject (Coin 995))]
+validatingWithMintTxOut ::
+  ( HasTokens era
+  , EraTxOut era
+  , Scriptic era
+  , Value era ~ MaryValue (EraCrypto era)
+  ) =>
+  Proof era ->
+  TxOut era
+validatingWithMintTxOut pf =
+  newTxOut pf [Address (someAddr pf), Amount (MaryValue mempty (multiAsset pf) <+> inject (Coin 995))]
 
 validatingWithMintState ::
   forall era.
@@ -612,7 +620,7 @@ notValidatingWithMintTx pf =
         pf
         [ Inputs' [mkGenesisTxIn 8]
         , Collateral' [mkGenesisTxIn 18]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (MaryValue 0 mint <+> inject (Coin 995))]]
+        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (MaryValue mempty mint <+> inject (Coin 995))]]
         , Txfee (Coin 5)
         , Mint mint
         , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
@@ -711,7 +719,7 @@ validatingManyScriptsTxOut pf =
   newTxOut
     pf
     [ Address (someAddr pf)
-    , Amount (MaryValue 0 (validatingManyScriptsMint pf) <+> inject (Coin 4996))
+    , Amount (MaryValue mempty (validatingManyScriptsMint pf) <+> inject (Coin 4996))
     ]
 
 validatingManyScriptsState ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -117,7 +117,7 @@ instance (Reflect era, EraScript era, Fixed (Script era)) => Fixed (MultiAsset e
   unique n =
     MultiAsset
       ( MaryValue
-          (fromIntegral n)
+          (Coin (fromIntegral n))
           ( Mary.MultiAsset
               ( Map.singleton
                   (lift (pickPolicyID @era n))
@@ -132,7 +132,7 @@ scriptsize _ = size (Proxy @(Script era))
 
 instance CC.Crypto c => Fixed (MaryValue c) where
   size _ = Nothing
-  unique n = MaryValue (fromIntegral n) (Mary.MultiAsset Map.empty)
+  unique n = MaryValue (Coin (fromIntegral n)) (Mary.MultiAsset Map.empty)
 
 -- =======================================================
 -- Keys and KeyHashes

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1063,7 +1063,7 @@ txBodyFieldSummary txb = case txb of
   (Txfee c) -> [("Fee", ppCoin c)]
   (Update (SJust _)) -> [("Collateral Return", ppString "?")]
   (ReqSignerHashes x) -> [("Required Signer hashes", ppInt (Set.size x))]
-  (Mint ma) -> [("Mint", ppInteger (Val.size (MaryValue 0 ma)) <> ppString " bytes")]
+  (Mint ma) -> [("Mint", ppInteger (Val.size (MaryValue mempty ma)) <> ppString " bytes")]
   (WppHash (SJust _)) -> [("WppHash", ppString "?")]
   (AdHash (SJust _)) -> [("AdHash", ppString "?")]
   (Txnetworkid (SJust x)) -> [("Network id", ppNetwork x)]
@@ -1143,7 +1143,7 @@ multiAssetSummary (MultiAsset m) = ppString ("num tokens = " ++ show (Map.size m
 
 vSummary :: MaryValue c -> PDoc
 vSummary (MaryValue n ma) =
-  ppSexp "Value" [ppInteger n, multiAssetSummary ma]
+  ppSexp "Value" [ppCoin n, multiAssetSummary ma]
 
 scriptSummary :: forall era. Proof era -> Script era -> PDoc
 scriptSummary p@(Conway _) script = plutusSummary p script
@@ -1337,7 +1337,7 @@ pcValue :: MaryValue c -> PDoc
 pcValue (MaryValue n (MultiAsset m)) =
   ppSexp
     "Value"
-    [ ppInteger n
+    [ ppCoin n
     , -- , ppString ("num tokens = " ++ show (Map.size m))
       ppSet pcPolicyID (Map.keysSet m)
     ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/ValueFromList.hs
@@ -5,7 +5,8 @@
 -- interacted with somewhat generically.
 module Test.Cardano.Ledger.ValueFromList where
 
-import qualified Cardano.Ledger.Crypto as C
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary.Value as Mary (
   AssetName,
   MaryValue (..),
@@ -24,12 +25,12 @@ class Val.Val val => ValueFromList val c | val -> c where
 
   gettriples :: val -> (Integer, [(PolicyID c, AssetName, Integer)])
 
-instance C.Crypto c => ValueFromList (MaryValue c) c where
-  valueFromList c triples = MaryValue c (Mary.multiAssetFromList triples)
+instance Crypto c => ValueFromList (MaryValue c) c where
+  valueFromList c triples = MaryValue (Coin c) (Mary.multiAssetFromList triples)
 
   insert combine pid an new (MaryValue c ma) = MaryValue c $ Mary.insertMultiAsset combine pid an new ma
 
-  gettriples (MaryValue c (MultiAsset m1)) = (c, triples)
+  gettriples (MaryValue (Coin c) (MultiAsset m1)) = (c, triples)
     where
       triples =
         [ (policyId, aname, amount)

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -587,7 +587,7 @@ countTxOutStats = foldMap countTxOutStat
     countTxOutStat :: TxOut CurrentEra -> TxOutStats
     countTxOutStat txOut =
       let addr = txOut ^. addrTxOutL
-          MaryValue v (MultiAsset m) = txOut ^. valueTxOutL
+          MaryValue (Coin v) (MultiAsset m) = txOut ^. valueTxOutL
           !dataStat =
             strictMaybe
               mempty


### PR DESCRIPTION
# Description

This PR split into 3 major commits (thus it probably would be easier to review commit by commit)

* improves MaryValue generators
* fixes MaryValue deserialization. It reverts back the enforcement of positive ADA in the MaryValue back to non-negative ADA. This must be the case due to possibility of zero ADA in `ValueNotConservedUTxO`.
* Changes type for ADA in `MaryValue` from `Integer` to `Coin`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
