### PR TITLE
Improvements to support property tests on Traces with simple Tx with DRep related Certs

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -37,6 +37,7 @@ module Cardano.Ledger.Conway.Governance (
   PrevGovActionIds (..),
   PrevGovActionId (..),
   DRepPulsingState (..),
+  DRepPulser (..),
   govActionIdToText,
   Voter (..),
   Vote (..),
@@ -86,6 +87,7 @@ module Cardano.Ledger.Conway.Governance (
   prevPParamsConwayGovStateL,
   constitutionScriptL,
   constitutionAnchorL,
+  gasDepositL,
   gasCommitteeVotesL,
   gasDRepVotesL,
   gasExpiresAfterL,
@@ -170,6 +172,7 @@ import Cardano.Ledger.Conway.Governance.Procedures (
   VotingProcedures (..),
   gasCommitteeVotesL,
   gasDRepVotesL,
+  gasDepositL,
   gasExpiresAfterL,
   gasStakePoolVotesL,
   govActionIdToText,
@@ -949,6 +952,9 @@ data DRepPulser era (m :: Type -> Type) ans where
     , dpGlobals :: !Globals
     } ->
     DRepPulser era m ans
+
+instance EraPParams era => Eq (DRepPulser era Identity (RatifyState era)) where
+  x == y = finishDRepPulser (DRPulsing x) == finishDRepPulser (DRPulsing y)
 
 instance Pulsable (DRepPulser era) where
   done DRepPulser {dpBalance} = Map.null dpBalance

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -39,6 +39,7 @@ module Cardano.Ledger.Conway.Governance.Procedures (
   indexedGovProps,
   -- Lenses
   pProcDepositL,
+  gasDepositL,
   committeeMembersL,
   committeeQuorumL,
   gasDRepVotesL,
@@ -192,6 +193,9 @@ data GovActionState era = GovActionState
   , gasExpiresAfter :: !EpochNo
   }
   deriving (Generic)
+
+gasDepositL :: Lens' (GovActionState era) Coin
+gasDepositL = lens gasDeposit (\x y -> x {gasDeposit = y})
 
 gasCommitteeVotesL :: Lens' (GovActionState era) (Map (Credential 'HotCommitteeRole (EraCrypto era)) Vote)
 gasCommitteeVotesL = lens gasCommitteeVotes (\x y -> x {gasCommitteeVotes = y})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -223,7 +223,7 @@ instance
 
   renderAssertionViolation = renderDepositEqualsObligationViolation
 
-  assertions = shelleyLedgerAssertions
+  assertions = shelleyLedgerAssertions @era @ConwayLEDGER
 
 -- =======================================
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -155,7 +155,7 @@ newEpochTransition = do
   if eNo /= eL + 1
     then pure (nes & newEpochStateDRepPulsingStateL %~ pulseDRepPulsingState)
     else do
-      es1 <- case ru of
+      es1 <- case ru of -- Here is where we extract the result of Reward pulsing.
         SNothing -> pure es0
         SJust p@(Pulsing _ _) -> do
           (ans, event) <- liftSTS (completeRupd p)

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -35,11 +35,13 @@ library
         Test.Cardano.Ledger.Constrained.Preds.Repl
         Test.Cardano.Ledger.Constrained.Preds.Certs
         Test.Cardano.Ledger.Constrained.Preds.LedgerState
+        Test.Cardano.Ledger.Constrained.Preds.NewEpochState
         Test.Cardano.Ledger.Constrained.Trace.TraceMonad
         Test.Cardano.Ledger.Constrained.Trace.SimpleTx
         Test.Cardano.Ledger.Constrained.Trace.Actions
         Test.Cardano.Ledger.Constrained.Trace.Pipeline
         Test.Cardano.Ledger.Constrained.Trace.Tests
+        Test.Cardano.Ledger.Constrained.Trace.DrepCertTx
         Test.Cardano.Ledger.Constrained.Spec
         Test.Cardano.Ledger.Constrained.SpecClass
         Test.Cardano.Ledger.Constrained.Tests

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -555,8 +555,8 @@ univPreds p =
   , Dom goDelegs :⊆: credsUniv
   , Dom instanReserves :⊆: credsUniv
   , Dom instanTreasury :⊆: credsUniv
-  , Dom (proposalsT p) :⊆: Dom genesisHashUniv
-  , Dom (futureProposalsT p) :⊆: Dom genesisHashUniv
+  , Dom (pparamProposals p) :⊆: Dom genesisHashUniv
+  , Dom (futurePParamProposals p) :⊆: Dom genesisHashUniv
   , Dom genDelegs :⊆: Dom genesisHashUniv
   , Dom (utxo p) :⊆: txinUniv
   ]
@@ -578,7 +578,9 @@ dstatePreds _p =
   [ Sized (AtMost 8) rewards -- Small enough that its leaves some slack with credUniv
   , Dom rewards :=: Dom stakeDeposits
   , Dom delegations :⊆: Dom rewards
-  , Random dreps
+  , Random currentDRepState
+  , Random drepDelegation
+  , Random currentDRepState
   , Random committeeState
   , Random numDormantEpochs
   , Dom rewards :=: Rng ptrs
@@ -609,8 +611,8 @@ utxostatePreds proof =
   , SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits]
   , SumsTo (Right (Coin 1)) totalAda EQL [One utxoCoin, One treasury, One reserves, One fees, One deposits, SumMap rewards]
   , Random fees
-  , Random (proposalsT proof)
-  , Random (futureProposalsT proof)
+  , Random (pparamProposals proof)
+  , Random (futurePParamProposals proof)
   ]
 
 epochstatePreds :: EraGov era => Proof era -> [Pred era]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Constrained.Preds.CertState where
 
+import Cardano.Ledger.BaseTypes (EpochNo (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
+import Cardano.Ledger.DRep (drepAnchorL, drepDepositL, drepExpiryL)
 import Cardano.Ledger.Era (Era, EraCrypto)
 import Cardano.Ledger.Keys (GenDelegPair (..), KeyHash, KeyRole (..), asWitness, coerceKeyRole)
 import Cardano.Ledger.Shelley.LedgerState (availableAfterMIR)
@@ -16,8 +19,9 @@ import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
 import Test.Cardano.Ledger.Constrained.Examples (testIO)
-import Test.Cardano.Ledger.Constrained.Lenses (fGenDelegGenKeyHashL)
+import Test.Cardano.Ledger.Constrained.Lenses (fGenDelegGenKeyHashL, strictMaybeToMaybeL)
 import Test.Cardano.Ledger.Constrained.Monad (generateWithSeed, monadTyped)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
 import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
 import Test.Cardano.Ledger.Constrained.Preds.Universes hiding (demo, demoTest, main)
 import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
@@ -46,14 +50,39 @@ manyCoin size = do
 
 -- ======================================
 
-vstatePreds :: Era era => Proof era -> [Pred era]
-vstatePreds _p =
-  [ Sized (Range 3 8) dreps
-  , Sized (Range 5 7) (Dom committeeState)
-  , Subset (Dom dreps) voteUniv
-  , Subset (Dom committeeState) voteCredUniv
-  , Random numDormantEpochs
-  ]
+-- | Predicates for Voting State, only work in Conway or later Eras.
+vstatePreds :: forall era. Era era => Proof era -> [Pred era]
+vstatePreds p = case whichPParams p of
+  PParamsConwayToConway ->
+    [ Sized (Range 10 20) currentDRepState
+    , Sized (Range 5 7) (Dom committeeState)
+    , ForEach
+        (Range 25 25) -- It is possible we create duplicates, so we make a few more than 20 (the size of drepState)
+        drepStateSet
+        (Pat DRepStateR [Arg expire, Arg anchor, Arg deposit])
+        [ Random (fieldToTerm anchor)
+        , GenFrom (fieldToTerm expire) (Constr "+200To500" (\(EpochNo n) -> EpochNo <$> choose (n + 200, n + 500)) ^$ currentEpoch)
+        , drepDeposit p :=: (fieldToTerm deposit)
+        ]
+    , Subset (Dom currentDRepState) voteUniv
+    , Subset (Rng currentDRepState) drepStateSet
+    , SumsTo (Right (Coin 1)) totalDRepDeposit EQL [ProjMap CoinR drepDepositL currentDRepState]
+    , SumsTo (Left (Coin 1)) totalDRepDeposit EQL [SumList (Elems drepDeposits)]
+    , Subset (Dom committeeState) voteCredUniv
+    , Random numDormantEpochs
+    ]
+  _ ->
+    [ Sized (Range 0 0) currentDRepState
+    , Sized (Range 0 0) committeeState
+    , Lit EpochR (EpochNo 0) :=: numDormantEpochs
+    , Random currentDRepState
+    ]
+  where
+    drepStateSet = Var $ pV p "drepStateSet" (SetR DRepStateR) No
+    deposit = Field @era "deposit" CoinR DRepStateR drepDepositL
+    totalDRepDeposit = Var $ pV p "totalDRepDeposit" CoinR No
+    anchor = Field @era "anchor" (MaybeR AnchorR) DRepStateR (drepAnchorL . strictMaybeToMaybeL)
+    expire = Field @era "expire" EpochR DRepStateR drepExpiryL
 
 vstateStage ::
   Reflect era =>
@@ -64,10 +93,11 @@ vstateStage proof = toolChainSub proof standardOrderInfo (vstatePreds proof)
 
 demoV :: ReplMode -> IO ()
 demoV mode = do
-  let proof = Babbage Standard
+  let proof = Conway Standard
   env <-
     generate
       ( pure emptySubst
+          >>= pParamsStage proof
           >>= universeStage def proof
           >>= vstateStage proof
           >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
@@ -98,9 +128,10 @@ pstatePreds p = pstateGenPreds p ++ pstateCheckPreds p
 pstateGenPreds :: Era era => Proof era -> [Pred era]
 pstateGenPreds _ =
   [ -- These Sized constraints are needd to be ensure that regPools is bigger than retiring
-    Sized (ExactSize 3) retiring
-  , Sized (AtLeast 3) regPools
+    Sized (ExactSize 5) retiring
+  , Sized (AtLeast 20) regPools
   , Subset (Dom regPools) poolHashUniv
+  , Sized (Range 10 15) futureRegPools
   , Subset (Dom futureRegPools) poolHashUniv
   , Subset (Dom poolDeposits) poolHashUniv
   , Choose
@@ -111,12 +142,6 @@ pstateGenPreds _ =
       , (1, Constr "(+3)" (+ 3) ^$ e, [CanFollow e currentEpoch])
       , (1, Constr "(+5)" (+ 5) ^$ e, [CanFollow e currentEpoch])
       ]
-      -- poolDistr not needed in PState, but is needed in NewEpochState
-      -- But since it is so intimately tied to regPools we define it here
-      -- Alternately we could put this in NewEpochState, and insist that pStateStage
-      -- preceed newEpochStateStage
-      -- , Dom regPools :=: Dom poolDistr
-      -- , SumsTo (Right (1 % 1000)) (Lit RationalR 1) EQL [ProjMap RationalR individualPoolStakeL poolDistr]
   ]
   where
     e = var "e" EpochR
@@ -196,7 +221,7 @@ certStatePreds :: Era era => Proof era -> [Pred era]
 certStatePreds p = certStateGenPreds p ++ certStateCheckPreds p
 
 certStateGenPreds :: Era era => Proof era -> [Pred era]
-certStateGenPreds _p =
+certStateGenPreds p =
   [ MetaSize (SzExact (fromIntegral (quorumConstant + 2))) genDelegSize
   , --  , GenFrom quorum (constTarget (pure (fromIntegral quorumConstant)))
 
@@ -216,6 +241,14 @@ certStateGenPreds _p =
   , Dom rewards :⊆: credsUniv
   , GenFrom rewardRange (Constr "many" manyCoin ^$ rewardSize)
   , rewardRange :=: Elems rewards
+  , NotMember (Lit CoinR (Coin 0)) (Rng stakeDeposits)
+  , Dom rewards :=: Dom stakeDeposits
+  , Dom delegations :⊆: Dom rewards
+  , if protocolVersion p >= protocolVersion (Conway Standard)
+      then Sized (ExactSize 0) ptrs
+      else Dom rewards :=: Rng ptrs
+  , Dom drepDelegation :⊆: credsUniv
+  , Rng drepDelegation :⊆: drepUniv
   , -- Preds to compute genDelegs
     -- First, a set of GenDelegPairs, where no keyHash is repeated.
     Sized genDelegSize gdKeyHashSet
@@ -238,6 +271,8 @@ certStateGenPreds _p =
   , SumsTo (Right (DeltaCoin 1)) (Delta instanTreasurySum) LTH [One (Delta treasury), One deltaTreasury]
   , mirAvailTreasury :<-: (Constr "computeAvailTreasury" (availableAfterMIR TreasuryMIR) :$ Mask accountStateT :$ Mask instantaneousRewardsT)
   , mirAvailReserves :<-: (Constr "computeAvailReserves" (availableAfterMIR ReservesMIR) :$ Mask accountStateT :$ Mask instantaneousRewardsT)
+  , Dom drepDelegation :⊆: credsUniv
+  , Rng drepDelegation :⊆: drepUniv
   ]
   where
     rewardSize = var "rewardSize" SizeR
@@ -288,10 +323,11 @@ mainD seed = defaultMain $ testIO "Testing DState Stage" (demoD Interactive seed
 
 demoC :: ReplMode -> IO ()
 demoC mode = do
-  let proof = Babbage Standard
+  let proof = Conway Standard
   env <-
     generate
       ( pure emptySubst
+          >>= pParamsStage proof
           >>= universeStage def proof
           >>= vstateStage proof
           >>= pstateStage proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -168,8 +168,8 @@ makeDRepPred ::
 makeDRepPred drep vote =
   Oneof
     drep
-    [ (1, constTarget DRepAlwaysAbstain, [])
-    , (1, constTarget DRepAlwaysNoConfidence, [])
+    [ (1, constTarget DRepAlwaysAbstain, [Random vote])
+    , (1, constTarget DRepAlwaysNoConfidence, [Random vote])
     , (5, Constr "" DRepCredential ^$ vote, [Member (Left vote) voteUniv])
     ]
 
@@ -327,6 +327,7 @@ certsPreds p = case whichTxCert p of
           , cRegKey ^$ stakeCred ^$ mkeydeposit
           ,
             [ NotMember stakeCred (Dom rewards)
+            , Member (Left stakeCred) credsUniv
             , Maybe mkeydeposit (idTarget kd) [kd :=: (keyDepAmt p)]
             ]
           )
@@ -351,13 +352,19 @@ certsPreds p = case whichTxCert p of
         ,
           ( 1
           , cRegDelegStake ^$ stakeCred ^$ poolHash ^$ kd
-          , [Member (Left stakeCred) (Dom rewards), Member (Left poolHash) (Dom regPools), kd :=: (keyDepAmt p)]
+          ,
+            [ NotMember stakeCred (Dom rewards)
+            , Member (Left stakeCred) credsUniv
+            , Member (Left poolHash) (Dom regPools)
+            , kd :=: (keyDepAmt p)
+            ]
           )
         ,
           ( 1
           , cRegDelegVote ^$ stakeCred ^$ drep ^$ kd ^$ vote
           ,
-            [ Member (Left stakeCred) (Dom rewards)
+            [ NotMember stakeCred (Dom rewards)
+            , Member (Left stakeCred) credsUniv
             , kd :=: (keyDepAmt p)
             , makeDRepPred drep vote
             ]
@@ -366,7 +373,8 @@ certsPreds p = case whichTxCert p of
           ( 1
           , cRegDelegStakeVote ^$ stakeCred ^$ poolHash ^$ drep ^$ kd ^$ vote
           ,
-            [ Member (Left stakeCred) (Dom rewards)
+            [ NotMember stakeCred (Dom rewards)
+            , Member (Left stakeCred) credsUniv
             , makeDRepPred drep vote
             , Member (Left poolHash) (Dom regPools)
             , kd :=: (keyDepAmt p)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -8,9 +8,11 @@
 module Test.Cardano.Ledger.Constrained.Preds.LedgerState where
 
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Governance (gasDeposit)
 import Control.Monad (when)
 import Data.Default.Class (Default (def))
-import Data.Map.Strict as Map
+import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
@@ -45,6 +47,9 @@ enactStateGenPreds p =
   , Random prevHardFork
   , Random prevCommittee
   , Random prevConstitution
+  , Random prevDRepState
+  , Random partialDRepDistr
+  , Random prevDRepState
   ]
 
 enactStateCheckPreds :: Proof era -> [Pred era]
@@ -52,10 +57,7 @@ enactStateCheckPreds _ = []
 
 ledgerStatePreds :: forall era. Reflect era => UnivSize -> Proof era -> [Pred era]
 ledgerStatePreds usize p =
-  [ -- Conway GovState Vars
-    Random prevDRepState
-  , Random previousCommitteeState
-  , Random enactWithdrawals
+  [ Subset (Dom enactWithdrawals) credsUniv
   , Random enactTreasury
   , Random constitution
   , Random committeeVar
@@ -63,16 +65,14 @@ ledgerStatePreds usize p =
   , Random prevHardFork
   , Random prevConstitution
   , Random prevCommittee
-  , Random prevProposals
-  , Random prevDRepDistr
-  , Random currProposals
-  , Random ratifyState
-  , MetaSize (SzRng 90 (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
+  , Sized (Range 0 1) currProposals
+  , proposalDeposits :<-: (Constr "sumActionStateDeposits" (foldMap gasDeposit) :$ (Simple currProposals))
+  , -- TODO, introduce ProjList so we can write: SumsTo (Right (Coin 1)) proposalDeposits  EQL [ProjList CoinR gasDepositL currProposals]
+    MetaSize (SzRng 90 (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
   , Sized utxoSize preUtxo
   , Sized (Range 15 (usNumColUtxo usize)) colUtxo
   , MapMember feeTxIn feeTxOut (Right preUtxo)
-  , -- , Before feeTxIn colUtxo
-    Subset (Dom preUtxo) txinUniv
+  , Subset (Dom preUtxo) txinUniv
   , Subset (Rng preUtxo) (txoutUniv p)
   , utxo p :<-: (Constr "mapunion" Map.union ^$ preUtxo ^$ colUtxo)
   , Disjoint (Dom preUtxo) (Dom colUtxo)
@@ -80,18 +80,26 @@ ledgerStatePreds usize p =
   , Subset (Rng colUtxo) (colTxoutUniv p)
   , NotMember feeTxIn (Dom colUtxo)
   , NotMember feeTxOut (Rng colUtxo)
-  , SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits]
+  , SumsTo (Right (Coin 1)) deposits EQL [SumMap stakeDeposits, SumMap poolDeposits, One proposalDeposits, SumMap drepDeposits]
   , -- Some things we might want in the future.
     -- , SumsTo (Right (Coin 1)) utxoCoin EQL [ProjMap CoinR outputCoinL (utxo p)]
     -- , SumsTo (Right (Coin 1)) totalAda EQL [One utxoCoin, One treasury, One reserves, One fees, One deposits, SumMap rewards]
     Random fees
-  , Random (proposalsT p)
-  , Random (futureProposalsT p)
   , ledgerState :<-: (ledgerStateT p)
   , Sized (Range 1 10) donation
   , prevPParams p :<-: (Constr "id" id ^$ (pparams p))
   , currPParams p :<-: (Constr "id" id ^$ (pparams p))
+  , -- We need the poolDistr to generate a valid Pulser
+    Dom regPools :=: Dom poolDistr
+  , SumsTo (Left (1 % 1000)) (Lit RationalR 1) EQL [ProjMap RationalR individualPoolStakeL poolDistr]
   ]
+    ++ ( case whichGovState p of
+          GovStateConwayToConway -> prevPulsingPreds p -- Constraints to generate a valid Pulser
+          GovStateShelleyToBabbage ->
+            [ Sized (Range 0 1) (pparamProposals p)
+            , Sized (Range 0 1) (futurePParamProposals p)
+            ]
+       )
   where
     colUtxo = Var (V "colUtxo" (MapR TxInR (TxOutR p)) No)
     utxoSize = Var (V "utxoSize" SizeR No)
@@ -111,13 +119,8 @@ ledgerStateStage usize proof subst0 = do
     Nothing -> pure subst
     Just msg -> error msg
 
-demo :: ReplMode -> IO ()
-demo mode = do
-  let proof = Conway Standard
-  -- Babbage Standard
-  -- Alonzo Standard
-  -- Mary Standard
-  -- Shelley Standard
+demo :: Reflect era => Proof era -> ReplMode -> IO ()
+demo proof mode = do
   env <-
     generate
       ( pure emptySubst
@@ -130,11 +133,14 @@ demo mode = do
           >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
       )
   lstate <- monadTyped $ runTarget env (ledgerStateT proof)
+  let env2 = getTarget lstate (ledgerStateT proof) emptyEnv
   when (mode == Interactive) $ putStrLn (show (pcLedgerState proof lstate))
-  modeRepl mode proof env ""
+  modeRepl mode proof env2 ""
 
 demoTest :: TestTree
-demoTest = testIO "Testing LedgerState Stage" (demo CI)
+demoTest = testIO "Testing LedgerState Stage" (demo (Conway Standard) CI)
 
 main :: IO ()
-main = defaultMain $ testIO "Testing LedgerState Stage" (demo Interactive)
+main = defaultMain $ testIO "Testing LedgerState Stage" (demo (Conway Standard) Interactive)
+
+-- =================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Constrained.Preds.NewEpochState where
+
+import Cardano.Ledger.Era (Era)
+import Cardano.Ledger.Shelley.Core (EraGov)
+import Control.Monad (when)
+import Data.Default.Class (Default (def))
+import Data.Ratio ((%))
+import Test.Cardano.Ledger.Constrained.Ast
+import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
+import Test.Cardano.Ledger.Constrained.Env
+import Test.Cardano.Ledger.Constrained.Examples (testIO)
+import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
+import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
+import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStateStage)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
+import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
+import Test.Cardano.Ledger.Constrained.Rewrite (OrderInfo (..), standardOrderInfo)
+import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
+import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.PrettyCore (pcEpochState, pcNewEpochState)
+import Test.Cardano.Ledger.Generic.Proof
+import Test.QuickCheck
+import Test.Tasty (TestTree, defaultMain)
+
+-- ===========================================================
+
+epochstatePreds :: EraGov era => Proof era -> [Pred era]
+epochstatePreds _proof =
+  [ Dom markStake `Subset` credsUniv
+  , Dom markDelegs `Subset` credsUniv
+  , Rng markDelegs `Subset` poolHashUniv
+  , Sized (Range 1 2) markPools
+  , Dom markPools `Subset` poolHashUniv
+  , Dom setStake `Subset` credsUniv
+  , Dom setDelegs `Subset` credsUniv
+  , Rng setDelegs `Subset` poolHashUniv
+  , Sized (Range 1 2) setPools
+  , Dom setPools `Subset` poolHashUniv
+  , Dom goStake `Subset` credsUniv
+  , Dom goDelegs `Subset` credsUniv
+  , Rng goDelegs `Subset` poolHashUniv
+  , Sized (Range 1 2) goPools
+  , Dom goPools `Subset` poolHashUniv
+  , Random snapShotFee
+  , SumsTo (Right (1 % 1000)) (Lit RationalR 1) EQL [ProjMap RationalR individualPoolStakeL markPoolDistr]
+  , Sized (Range 2 6) markPoolDistr
+  ]
+
+newEpochStatePreds :: Era era => Proof era -> [Pred era]
+newEpochStatePreds _proof =
+  [ Sized (ExactSize 4) (Dom prevBlocksMade) -- Both prevBlocksMade and prevBlocksMadeDom will have size 4
+  , Sized (ExactSize 4) (Dom currBlocksMade)
+  , Dom prevBlocksMade `Subset` poolHashUniv
+  , Dom currBlocksMade `Subset` poolHashUniv
+  ]
+
+-- ========================
+
+epochStateStage ::
+  Reflect era =>
+  Proof era ->
+  Subst era ->
+  Gen (Subst era)
+epochStateStage proof = toolChainSub proof standardOrderInfo (epochstatePreds proof)
+
+demoES :: Reflect era => Proof era -> ReplMode -> IO ()
+demoES proof mode = do
+  env <-
+    generate
+      ( pure emptySubst
+          >>= pParamsStage proof
+          >>= universeStage def proof
+          >>= vstateStage proof
+          >>= pstateStage proof
+          >>= dstateStage proof
+          >>= ledgerStateStage def proof
+          >>= epochStateStage proof
+          >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
+      )
+  epochstate <- monadTyped $ runTarget env (epochStateT proof)
+  let env2 = getTarget epochstate (epochStateT proof) emptyEnv
+  when (mode == Interactive) $ print (pcEpochState proof epochstate)
+  modeRepl mode proof env2 ""
+
+demoESTest :: TestTree
+demoESTest = testIO "Testing EpochState Stage" (demoES (Conway Standard) CI)
+
+mainES :: IO ()
+mainES = defaultMain $ testIO "Testing EpochState Stage" (demoES (Conway Standard) Interactive)
+
+-- ====================================================
+
+newEpochStateStage ::
+  Reflect era =>
+  Proof era ->
+  Subst era ->
+  Gen (Subst era)
+newEpochStateStage proof = toolChainSub proof (standardOrderInfo {sumBeforeParts = False}) (newEpochStatePreds proof)
+
+demoNES :: Reflect era => Proof era -> ReplMode -> IO ()
+demoNES proof mode = do
+  env <-
+    generate
+      ( pure emptySubst
+          >>= pParamsStage proof
+          >>= universeStage def proof
+          >>= vstateStage proof
+          >>= pstateStage proof
+          >>= dstateStage proof
+          >>= ledgerStateStage def proof
+          >>= epochStateStage proof
+          >>= newEpochStateStage proof
+          >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
+      )
+  newepochstate <- monadTyped $ runTarget env (newEpochStateT proof)
+  let env2 = getTarget newepochstate (newEpochStateT proof) emptyEnv
+  when (mode == Interactive) $ putStrLn (show (pcNewEpochState proof newepochstate))
+  modeRepl mode proof env2 ""
+
+demoNESTest :: TestTree
+demoNESTest = testIO "Testing NewEpochState Stage" (demoNES (Conway Standard) CI)
+
+mainNES :: IO ()
+mainNES = defaultMain $ testIO "Testing NewEpochState Stage" (demoNES (Conway Standard) Interactive)
+
+-- ==========================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
@@ -13,6 +13,7 @@ import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Script (Prices (..))
 import Cardano.Ledger.Api.Era
 import Cardano.Ledger.BaseTypes (
+  EpochNo (..),
   NonNegativeInterval,
   boundRational,
  )
@@ -51,6 +52,17 @@ nonNegativeInterval r = case (boundRational @NonNegativeInterval r) of
   Just nn -> nn
   Nothing -> error ("Can't make NonNegativeInterval from: " ++ show r)
 
+{- Preds we want to be True in pparams. This comment is meant as a statement of intent
+   The actual code acheives this algorithmically, but we want this declaration of what should be true
+  [ Sized (AtLeast 1) (maxBHSize proof)
+  , Sized (AtLeast 1) (maxTxSize proof)
+  , SumsTo (Right 1) (maxBBSize proof) LTE [One (maxBHSize proof), One (maxTxSize proof)]
+  , Component
+      (Right (pparams proof))
+      [field pp (maxTxSize proof), field pp (maxBHSize proof), field pp (maxBBSize proof)]
+  ]
+-}
+
 genPParams :: Reflect era => Proof era -> Natural -> Natural -> Natural -> Gen (PParamsF era)
 genPParams proof tx bb bh = do
   maxTxExUnits2 <- ExUnits <$> (fromIntegral <$> choose (100 :: Int, 10000)) <*> (fromIntegral <$> choose (100 :: Int, 10000))
@@ -76,6 +88,9 @@ genPParams proof tx bb bh = do
           , ProtocolVersion $ protocolVersion proof
           , PoolDeposit $ Coin 5
           , KeyDeposit $ Coin 2
+          , DRepDeposit $ Coin 7
+          , GovActionDeposit $ Coin 13
+          , DRepActivity $ EpochNo 8
           , EMax 100
           ]
     )
@@ -106,9 +121,15 @@ pParamsPreds p =
             [ extract (maxTxExUnits p) (pparams p)
             , extract (collateralPercentage p) (pparams p)
             ]
-          PParamsBabbageToConway ->
+          PParamsBabbageToBabbage ->
             [ extract (maxTxExUnits p) (pparams p)
             , extract (collateralPercentage p) (pparams p)
+            ]
+          PParamsConwayToConway ->
+            [ extract (maxTxExUnits p) (pparams p)
+            , extract (collateralPercentage p) (pparams p)
+            , extract (drepDeposit p) (pparams p)
+            , extract (drepActivity p) (pparams p)
             ]
        )
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
@@ -247,6 +247,7 @@ fresh (n, sub) (Lensed expr _) = mksub n (HashSet.toList (vars expr))
       where
         sub2 = zipWith (\(Name v@(V nm r _)) m1 -> SubItem v (Var (V (index nm m1) r No))) names [m ..]
 fresh (n, sub) (f :$ x) = fresh (fresh (n, sub) f) x
+fresh (n, sub) (Virtual x _ _) = fresh (n, sub) (Simple x)
 
 freshP :: (Int, SubItems era) -> Pat era t -> (Int, SubItems era)
 freshP (n, sub) (Pat _ as) = List.foldl' freshA (n, sub) as
@@ -642,7 +643,6 @@ componentVars (AnyF (FConst _ _ _ _) : cs) = componentVars cs
 initialOrder :: forall era. Era era => OrderInfo -> [Pred era] -> Typed [Name era]
 initialOrder info cs0 = do
   mmm <- flatOrError (stronglyConnComp listDep)
-  -- pure $ trace ("\nGraph\n"++showGraph (show.getname) _graph1) (map getname mmm)
   pure $ map getname mmm
   where
     allvs = List.foldl' varsOfPred HashSet.empty cs0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -158,6 +158,7 @@ simplifyList r1 term = do
 isMapVar :: Name era -> Sum era c -> Bool
 isMapVar n1 (SumMap (Var v2)) = n1 == Name v2
 isMapVar n1 (ProjMap _ _ (Var v2)) = n1 == Name v2
+isMapVar n1 (SumList (Elems (Var v2))) = n1 == Name v2
 isMapVar _ _ = False
 
 exactlyOne :: (a -> Bool) -> [a] -> Bool
@@ -399,6 +400,9 @@ solveMapSummands ::
   c -> -- The sum of the other expressions on the rhs
   [Sum era c] ->
   Typed (RngSpec era rng)
+solveMapSummands small lhsC msgs cond (V _ (MapR _ r) _) c [SumList (Elems (Var (V name (MapR _ r1) _)))] = do
+  Refl <- sameRep r r1
+  pure (RngSum small (varOnRightSize msgs lhsC cond c name))
 solveMapSummands small lhsC msgs cond (V _ (MapR _ r) _) c [ProjMap _crep l (Var (V name (MapR _ r1) _))] = do
   Refl <- sameRep r r1
   pure (RngProj small r l (varOnRightSize msgs lhsC cond c name))
@@ -433,7 +437,7 @@ solveSet v1@(V _ (SetR r) _) predicate = case predicate of
   (List (Var v2@(V _ (SetR r2) _)) expr@(x : _)) | Just Refl <- sameName v1 v2 -> do
     Refl <- sameRep (termRep x) r2
     xs <- mapM (simplifyAtType r2) expr
-    setSpec (SzExact (length xs)) (relEqual r (makeFromList @(Set a) @a xs))
+    setSpec (SzMost (length xs)) (relEqual r (makeFromList @(Set a) @a xs))
   (Var v2 :=: expr) | Name v1 == Name v2 -> do
     With set <- simplifySet r expr
     setSpec (SzExact (Set.size set)) (relEqual r set)
@@ -753,12 +757,16 @@ dispatch v1 preds | Just (If tar x y) <- List.find isIf preds = do
   b <- simplifyTarget tar
   let others = filter (not . isIf) preds
   if b then dispatch v1 (x : others) else dispatch v1 (y : others)
-dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ show preds) $ case preds of
+dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ "\n" ++ unlines (map show preds)) $ case preds of
   [Var v2 :=: Lit r2 t] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2
     pure (pure t)
   [Lit r2 t :=: Var v2] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2
+    pure (pure t)
+  [expr :=: Var v2] | Name v1 == Name v2 -> do
+    Refl <- sameRep r1 (termRep expr)
+    t <- simplify expr
     pure (pure t)
   [Sized (Var v2@(V _ r2 _)) term] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2
@@ -768,6 +776,12 @@ dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ show
     Refl <- sameRep r1 r2
     sz <- simplify sizeterm
     pure $ do n <- genFromSize sz; genSizedRep n r2
+  -- Here we solve for 'nm' by evaluating term, then use the 'lenz' to select the right component of 'x'
+  -- then return that value to bind to 'nm'
+  [cc@(Component (Left term) [AnyF (Field nm t _ lenz)])] | Name v1 == Name (V nm t No) -> explain ("Solving " ++ show cc) $ do
+    Refl <- sameV v1 (V nm t No)
+    x <- simplify term
+    pure (pure (x ^. lenz))
   [cc@(Component (Right (Var v2)) cs)] | Name v1 == Name v2 -> explain ("Solving " ++ show cc) $ do
     pairs <- mapM (anyToUpdate r1) cs
     pure $ do t <- genRep r1; pure (update t pairs)
@@ -864,6 +878,15 @@ dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ show
     xs <- mapM simplify expr
     pure $ pure (makeFromList xs)
   [Random (Var v2)] | Name v1 == Name v2 -> pure $ genRep r1
+  [p1@(Member (Left (Var v2)) y), p2@(NotMember (Var v3) z)]
+    | Just Refl <- sameName v1 v2
+    , Just Refl <- sameName v1 v3 -> do
+        yval <- simplify y
+        zval <- simplify z
+        pure (fst <$> itemFromSet ["Solving (Member & NotMember), for variable " ++ nam, show p1, show p2] (Set.difference yval zval))
+  [nm@(NotMember {}), m@(Member {})] -> dispatch v1 [m, nm]
+  [x, Random (Var v2)] | Name v1 == Name v2 -> dispatch v1 [x]
+  [Random (Var v2), x] | Name v1 == Name v2 -> dispatch v1 [x]
   cs -> case r1 of
     MapR dom rng -> do
       spec <- solveMaps v1 cs
@@ -889,8 +912,7 @@ dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ show
                 ++ nam
                 ++ " at type "
                 ++ show r1
-                ++ " for conditions "
-                ++ show cs
+                ++ " for conditions:\n"
                 ++ show (List.nubBy cpeq cs)
             ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Stage.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Stage.hs
@@ -44,11 +44,15 @@ ledgerPipeline :: Reflect era => UnivSize -> Proof era -> Pipeline era
 ledgerPipeline sizes proof =
   [ Stage standardOrderInfo (pParamsPreds proof)
   , Stage standardOrderInfo (universePreds sizes proof)
-  , Stage standardOrderInfo (vstatePreds proof)
-  , Stage standardOrderInfo (pstatePreds proof)
-  , Stage standardOrderInfo (certStatePreds proof)
-  , Stage standardOrderInfo (ledgerStatePreds sizes proof)
   ]
+    ++ ( case whichPParams proof of
+          PParamsConwayToConway -> [Stage standardOrderInfo (vstatePreds proof)]
+          _ -> []
+       )
+    ++ [ Stage standardOrderInfo (pstatePreds proof)
+       , Stage standardOrderInfo (certStatePreds proof)
+       , Stage standardOrderInfo (ledgerStatePreds sizes proof)
+       ]
 
 -- | Translate a Stage into a DependGraph, given the set
 --   of variables that have aready been solved for.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE GADTs #-}
+
 module Test.Cardano.Ledger.Constrained.Trace.Actions where
 
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (Era (..), TxBody)
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..), ConwayTxCert (..))
+import Cardano.Ledger.Core (Era (..), TxBody, TxCert)
+import Cardano.Ledger.DRep (DRepState (DRepState))
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
 import Cardano.Ledger.Val (Val (..))
+import Control.Monad (forM_)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Test.Cardano.Ledger.Constrained.Classes (TxOutF (..))
-import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (TraceM, updateVar)
-import Test.Cardano.Ledger.Constrained.Vars (fees, utxo)
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (TraceM, getTerm, updateVar)
+import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 
 -- ====================================================================
@@ -27,3 +32,24 @@ outputsAction proof txb outs = updateVar (utxo proof) (\u -> Map.union u (makema
 
 feesAction :: Era era => Coin -> TraceM era ()
 feesAction feeCoin = updateVar fees (<+> feeCoin)
+
+certAction :: Era era => Proof era -> TxCert era -> TraceM era ()
+certAction p@(Conway _) cert =
+  case cert of
+    ConwayTxCertGov (ConwayRegDRep cred _ manchor) -> do
+      epoch <- getTerm currentEpoch
+      activity <- getTerm (drepActivity p)
+      dep <- getTerm (drepDeposit p)
+      updateVar currentDRepState (Map.insert cred (DRepState (epoch + activity) manchor dep))
+    ConwayTxCertGov (ConwayUnRegDRep cred dep) -> do
+      updateVar currentDRepState (Map.delete cred)
+      updateVar deposits (<-> dep)
+    ConwayTxCertGov (ConwayUpdateDRep cred mAnchor) -> do
+      epoch <- getTerm currentEpoch
+      activity <- getTerm (drepActivity p)
+      updateVar currentDRepState (Map.adjust (\(DRepState _ _ deposit) -> DRepState (epoch + activity) mAnchor deposit) cred)
+    _ -> pure ()
+certAction _ _ = pure ()
+
+certsAction :: (Foldable t, Era era) => Proof era -> t (TxCert era) -> TraceM era ()
+certsAction p xs = forM_ xs (certAction p)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Generate a Simple Tx with 1 inout, 1 output, and 1 DRep related Cert
+module Test.Cardano.Ledger.Constrained.Trace.DrepCertTx where
+
+import Cardano.Ledger.Coin (Coin (..), CompactForm)
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov,
+  PulsingSnapshot (..),
+  computeDrepDistr,
+  finishDRepPulser,
+  newEpochStateDRepPulsingStateL,
+  utxosGovStateL,
+ )
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..), ConwayTxCert (..))
+import Cardano.Ledger.Core (
+  Era (..),
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  Tx,
+  TxCert,
+  coinTxOutL,
+ )
+import Cardano.Ledger.DRep hiding (drepDeposit)
+import Cardano.Ledger.Pretty (ppList)
+import Cardano.Ledger.Shelley.LedgerState (
+  CertState (..),
+  DState (..),
+  EpochState (..),
+  IncrementalStake (..),
+  LedgerState (..),
+  NewEpochState (..),
+  UTxOState (..),
+  VState (..),
+  allObligations,
+ )
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Set as Set
+import Debug.Trace (trace)
+import Lens.Micro
+import Test.Cardano.Ledger.Constrained.Ast (RootTarget (..), (^$))
+import Test.Cardano.Ledger.Constrained.Classes (TxF (..), TxOutF (..))
+import Test.Cardano.Ledger.Constrained.Combinators (itemFromSet)
+import Test.Cardano.Ledger.Constrained.Preds.Tx (hashBody)
+import Test.Cardano.Ledger.Constrained.Trace.Actions (certsAction, feesAction, inputsAction, outputsAction)
+import Test.Cardano.Ledger.Constrained.Trace.SimpleTx (completeTxBody, plutusFreeCredential, simpleTxBody)
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (
+  TraceM,
+  epochProp,
+  getTarget,
+  getTerm,
+  liftGen,
+  mockChainProp,
+  setVar,
+  showPulserState,
+  stepProp,
+ )
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..))
+import Test.Cardano.Ledger.Generic.MockChain (MockBlock (..), MockChainState (..))
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert)
+import Test.Cardano.Ledger.Generic.Proof (
+  ConwayEra,
+  Evidence (..),
+  Proof (..),
+  Reflect (..),
+  StandardCrypto,
+  TxCertWit (..),
+  whichTxCert,
+ )
+import Test.Cardano.Ledger.Generic.Updaters (newTxBody)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Cardano.Crypto.Hash.Class (Hash)
+import Cardano.Ledger.Crypto (HASH)
+import Cardano.Ledger.Hashes (EraIndependentTxBody)
+
+-- =========================================================================
+
+-- | Fix the first Outputs field in a [TxBodyField], by applying the delta Coin to the first Output in that Outputs field
+--   This is used to compensate for certificates which make deposits, and this Coin must come from somewhere, so it is
+--   added (subtracted if the Coin is negative) from the first TxOut.
+fixOutput :: EraTxOut era => Coin -> [TxBodyField era] -> [TxBodyField era]
+fixOutput _ [] = []
+fixOutput delta (Outputs' (txout : more) : others) =
+  (Outputs' ((txout & coinTxOutL <>~ delta) : more)) : others
+fixOutput delta (x : xs) = x : fixOutput delta xs
+
+-- | Compute a valid Cert, and the change in the stored Deposits from that Cert.
+drepCert :: Reflect era => Proof era -> TraceM era (Coin, [TxBodyField era])
+drepCert proof = case whichTxCert proof of
+  TxCertShelleyToBabbage -> pure (mempty, [])
+  TxCertConwayToConway -> do
+    plutusmap <- getTerm plutusUniv
+    drepCreds <- Set.filter (plutusFreeCredential plutusmap) <$> getTerm voteUniv
+    (cred, _) <- liftGen (itemFromSet [] drepCreds)
+    mdrepstate <- getTarget (Constr "mapMember" (Map.lookup cred) ^$ currentDRepState)
+    deposit@(Coin m) <- getTerm (drepDeposit proof)
+    case mdrepstate of
+      Nothing -> pure (Coin (-m), [Certs' [ConwayTxCertGov $ ConwayRegDRep cred deposit SNothing]])
+      Just (DRepState _expiry _manchor _dep) ->
+        liftGen $
+          oneof
+            [ pure (deposit, [Certs' [ConwayTxCertGov $ ConwayUnRegDRep cred deposit]])
+            , do
+                mAnchor <- arbitrary
+                pure (Coin 0, [Certs' [ConwayTxCertGov $ ConwayUpdateDRep cred mAnchor]])
+            ]
+
+drepCertTx :: Reflect era => Coin -> Proof era -> TraceM era (TxF era)
+drepCertTx maxFeeEstimate proof = do
+  simplefields <- simpleTxBody proof maxFeeEstimate
+  (deltadeposit, certfields) <- drepCert proof
+  let txb = newTxBody proof (fixOutput deltadeposit simplefields ++ certfields)
+  tx <- completeTxBody proof maxFeeEstimate txb
+  setVar txterm (TxF proof tx)
+  pure (TxF proof tx)
+
+-- ============================================
+
+-- | Update the internal Env by applying the Actions
+--   appropriate for a SimpleTx with DRepCerts.
+--   Changes to the Env are done by side effects in the TraceM mondad.
+applyDRepCertActions :: Reflect era => Proof era -> Tx era -> TraceM era ()
+applyDRepCertActions proof tx = do
+  let txb = tx ^. bodyTxL
+      feeCoin = txb ^. feeTxBodyL
+      txbcerts = txb ^. certsTxBodyL
+  inputsAction proof (txb ^. inputsTxBodyL)
+  outputsAction proof txb (fmap (TxOutF proof) (toList (txb ^. outputsTxBodyL)))
+  feesAction feeCoin
+  certsAction proof txbcerts
+
+-- ================================================
+
+-- | Generate a Tx that can be made into a Trace, because it applies the
+--   necessary Actions to update the Env. The Env must contain the Vars that
+--   are updated by 'applyDRepCertActions' . It is best to intialize the whole
+--   LedgerState to do this.
+drepCertTxForTrace :: Reflect era => Coin -> Proof era -> TraceM era (Tx era)
+drepCertTxForTrace maxFeeEstimate proof = do
+  (TxF _ tx) <- drepCertTx maxFeeEstimate proof
+  applyDRepCertActions proof tx
+  pure tx
+
+-- ======================================
+
+conway :: Proof (ConwayEra StandardCrypto)
+conway = Conway Standard
+
+drepTree :: TestTree
+drepTree =
+  testGroup
+    "DRep property traces"
+    [ testProperty
+        "Watch pulser on traces of length 120."
+        (withMaxSuccess 2 $ mockChainProp (Conway Standard) 120 (drepCertTxForTrace (Coin 100000)) (stepProp watchPulser))
+    , testProperty
+        "All Tx are valid on traces of length 150."
+        (withMaxSuccess 2 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 100000)) (stepProp allValidSignals))
+    , testProperty
+        "Bruteforce = Pulsed, in every epoch, on traces of length 150"
+        (withMaxSuccess 5 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 60000)) (epochProp pulserWorks))
+    ]
+
+main :: IO ()
+main = defaultMain drepTree
+
+-- =================================================
+-- Example functions that can be lifted to
+-- Trace (MOCKCHAIN era) -> Property
+-- using 'stepProp', 'deltaProp', 'preserveProp', and 'epochProp'
+-- this lifted value is then passed to 'mockChainProp' to make a Property
+
+allValidSignals :: MockChainState era -> MockBlock era -> MockChainState era -> Property
+allValidSignals _state0 (MockBlock _ _ _txs) _stateN = (property True)
+
+watchPulser :: ConwayEraGov era => MockChainState era -> MockBlock era -> MockChainState era -> Property
+watchPulser _state0 (MockBlock _ _ _txs) stateN = trace (showPulserState stateN) (property True)
+
+pulserWorks :: ConwayEraGov era => MockChainState era -> MockChainState era -> Property
+pulserWorks mcsfirst mcslast =
+  counterexample
+    ( "\nFirst "
+        ++ showPulserState mcsfirst
+        ++ "\nLast "
+        ++ showPulserState mcslast
+    )
+    (bruteForceDRepDistr (mcsNes mcsfirst) === extractPulsingDRepDistr (mcsNes mcslast))
+
+bruteForceDRepDistr :: NewEpochState era -> Map.Map (DRep (EraCrypto era)) (CompactForm Coin)
+bruteForceDRepDistr nes = computeDrepDistr umap dreps incstk
+  where
+    ls = (esLState . nesEs) nes
+    cs = lsCertState ls
+    IStake incstk _ = (utxosStakeDistr . lsUTxOState) ls
+    umap = dsUnified (certDState cs)
+    dreps = vsDReps (certVState cs)
+
+extractPulsingDRepDistr :: ConwayEraGov era => NewEpochState era -> Map.Map (DRep (EraCrypto era)) (CompactForm Coin)
+extractPulsingDRepDistr nes = (psDRepDistr . fst . finishDRepPulser) (nes ^. newEpochStateDRepPulsingStateL)
+
+-- ===============================================
+-- helper functions
+
+showCerts :: Proof era -> [TxCert era] -> String
+showCerts proof cs = show (ppList (pcTxCert proof) cs)
+
+certsOf :: EraTx era => Tx era -> [TxCert era]
+certsOf tx = toList (tx ^. (bodyTxL . certsTxBodyL))
+
+hashTx :: EraTx era => Proof era -> Tx era -> Hash (HASH (EraCrypto era)) EraIndependentTxBody
+hashTx proof tx = hashBody proof (tx ^. bodyTxL)
+
+showMap :: (Show k, Show v) => String -> Map.Map k v -> String
+showMap msg m = unlines (msg : map show (Map.toList m))
+
+traceMap :: (Show k, Show v) => String -> Map.Map k v -> a -> a
+traceMap s m x = trace (showMap s m) x
+
+showPotObl :: ConwayEraGov era => NewEpochState era -> String
+showPotObl nes = "\nPOT " ++ show (utxosDeposited us) ++ "\nAll " ++ show (allObligations certSt (us ^. utxosGovStateL))
+  where
+    es = nesEs nes
+    ls = esLState es
+    us = lsUTxOState ls
+    certSt = lsCertState ls

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -12,6 +12,7 @@ import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
+import Cardano.Ledger.BaseTypes (TxIx)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (Era (..), EraTx (..), EraTxBody (..), EraTxOut (..), Script, Tx, TxBody, Value, coinTxOutL)
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -19,6 +20,8 @@ import Cardano.Ledger.Hashes (DataHash, ScriptHash)
 import Cardano.Ledger.Keys (GenDelegs (..), KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.Plutus.Data (Data (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), getScriptsNeeded)
 import Cardano.Ledger.Val (Val (..))
@@ -31,7 +34,10 @@ import qualified Data.Set as Set
 import Debug.Trace
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
-import Test.Cardano.Ledger.Constrained.Classes (ScriptF (..), TxBodyF (..), TxCertF (..), TxF (..), TxOutF (..), liftUTxO, unScriptF)
+import Test.Cardano.Ledger.Constrained.Ast (runTarget, runTerm)
+import Test.Cardano.Ledger.Constrained.Classes (PParamsF (..), ScriptF (..), TxBodyF (..), TxCertF (..), TxF (..), TxOutF (..), liftUTxO, unScriptF)
+import Test.Cardano.Ledger.Constrained.Env (Env)
+import Test.Cardano.Ledger.Constrained.Monad (Typed)
 import Test.Cardano.Ledger.Constrained.Preds.Tx (
   adjustNeededByRefScripts,
   allValid,
@@ -45,14 +51,38 @@ import Test.Cardano.Ledger.Constrained.Preds.Tx (
   necessaryKeyHashes,
   sufficientKeyHashes,
  )
-import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (TraceM, fromSetTerm, getTerm, liftGen, reqSig)
+import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (
+  TraceM,
+  fromSetTerm,
+  getTerm,
+  liftGen,
+  reqSig,
+ )
 import qualified Test.Cardano.Ledger.Constrained.Trace.TraceMonad as TraceMonad (refInputs)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..), TxField (..), WitnessesField (..))
-import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (..), UTxOWit (..), ValueWit (..), whichUTxO, whichValue)
+import Test.Cardano.Ledger.Generic.Proof (
+  Proof (..),
+  Reflect (..),
+  UTxOWit (..),
+  ValueWit (..),
+  whichUTxO,
+  whichValue,
+ )
 import Test.Cardano.Ledger.Generic.Updaters (merge, newTx, newTxBody, newWitnesses)
 import Test.QuickCheck (discard, shuffle)
+
+-- ===================================================
+
+-- | Given an (Env era) construct the pair the the LendgerEnv and the LedgerState
+getSTSLedgerEnv :: Reflect era => Proof era -> TxIx -> Env era -> Typed (LedgerEnv era, LedgerState era)
+getSTSLedgerEnv proof txIx env = do
+  ledgerstate <- runTarget env (ledgerStateT proof)
+  slot <- runTerm env currentSlot
+  (PParamsF _ pp) <- runTerm env (pparams proof)
+  accntState <- runTarget env accountStateT
+  pure $ (LedgerEnv slot txIx pp accntState, ledgerstate)
 
 -- ====================================================================
 -- Picking things that have no Plutus Scripts inside. To make very
@@ -82,6 +112,10 @@ plutusFreeValue proof plutusmap v = case (whichValue proof, v) of
 plutusFreePolicyID :: Map (ScriptHash c) a -> PolicyID c -> Bool
 plutusFreePolicyID plutusmap (PolicyID h) = Map.notMember h plutusmap
 
+plutusFreeCredential :: Map (ScriptHash c) a -> Credential kr c -> Bool
+plutusFreeCredential _ (KeyHashObj _) = True
+plutusFreeCredential plutusmap (ScriptHashObj h) = Map.notMember h plutusmap
+
 -- ====================================================================
 -- Code to generate simple, but valid Transactions
 -- ====================================================================
@@ -91,7 +125,7 @@ plutusFreePolicyID plutusmap (PolicyID h) = Map.notMember h plutusmap
 --   Coin in the TxOut with the feeEstimate and the actual Coin in the UTxO output that corresponds to the input.
 --   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
 --   See 'genLedgerStateEnv' for an example of how to do that.
-simpleTxBody :: Reflect era => Proof era -> Coin -> TraceM era (TxBody era)
+simpleTxBody :: Reflect era => Proof era -> Coin -> TraceM era [TxBodyField era]
 simpleTxBody proof feeEstimate = do
   plutusmap <- getTerm plutusUniv
   let ok (_, TxOutF _ v) = (v ^. coinTxOutL) >= feeEstimate && plutusFree plutusmap v
@@ -105,37 +139,38 @@ simpleTxBody proof feeEstimate = do
   addr <- fromSetTerm addrUniv
   vldt <- getTerm validityInterval
   let output = mkBasicTxOut addr (inject (inputCoin <-> feeEstimate))
-  pure $
-    newTxBody
-      proof
-      [ Inputs' [input]
-      , Outputs' [output]
-      , Txfee feeEstimate
-      , Vldt vldt
-      , Mint (liftMultiAsset (minusMultiValue proof (output ^. valueTxOutL) (out ^. valueTxOutL)))
-      ]
-
--- | The 60000 is arbitrary chosen by experience. The fee for most simpleTx as less than 60000. But in
---   at least one case we have seen as high as 108407. If that case happens we will discard.
---   A large fee is rare because it is caused by many scripts and fees that need large witnesses,
-maxFeeEstimate :: Coin
-maxFeeEstimate = Coin 60000
+  pure
+    [ Inputs' [input]
+    , Outputs' [output]
+    , Txfee feeEstimate
+    , Vldt vldt
+    , Mint (liftMultiAsset (minusMultiValue proof (output ^. valueTxOutL) (out ^. valueTxOutL)))
+    ]
 
 -- | Generate a (Tx era) from a simple (TxBody era), with 1 input and 1 output.
 --   Apply the "finishing" function 'completeTxBody' to make the result a valid Tx.
---   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
-simpleTx :: Reflect era => Proof era -> TraceM era (Tx era)
-simpleTx proof = do
-  txb <- simpleTxBody proof maxFeeEstimate
-  completeTxBody proof txb
+--   Only works if the internal Env of the TraceM monad stores variables capable of
+--   creating the LedgerState. The parameter 'maxFeeEstimate' has to be chosen by
+--   experience. The fee for most simpleTx as less than 60000. But in at least one
+--   case we have seen as high as 108407. If that case happens we will discard.
+--   A large fee is rare because it is caused by many scripts and fees that need large witnesses,
+simpleTx :: Reflect era => Proof era -> Coin -> TraceM era (Tx era)
+simpleTx proof maxFeeEstimate = do
+  fields <- simpleTxBody proof maxFeeEstimate
+  let txb = newTxBody proof fields
+  completeTxBody proof maxFeeEstimate txb
+
+-- ====================================================================================
+-- Once we have a TxBody, we need to make a complete Tx, By filling in Missing pieces.
+-- ====================================================================================
 
 -- | Complete a TxBody, by running a fix-point computation that
 --   1) Adds the appropriate witnesses.
 --   2) Adjusts the the first output to pay the estimated fee.
 --   Run the computation until both the fee and the hash of the TxBody reach a fixpoint.
 --   Only works if the internal Env of the TraceM monad stores variables capable of creating the LedgerState
-completeTxBody :: Reflect era => Proof era -> TxBody era -> TraceM era (Tx era)
-completeTxBody proof txBody = do
+completeTxBody :: Reflect era => Proof era -> Coin -> TxBody era -> TraceM era (Tx era)
+completeTxBody proof maxFeeEstimate txBody = do
   u <- getTerm (utxo proof)
   scriptuniv <- getTerm (allScriptUniv proof)
   plutusuniv <- getTerm plutusUniv
@@ -186,7 +221,7 @@ completeTxBody proof txBody = do
 -- ========================================================================================
 
 -- | Add witnesses to the TxBody to construct a Tx with the appropriate witnesses.
---   This is a compicated function, but it should be applicable to ANY Tx generated using
+--   This is a compilcated function, but it should be applicable to ANY Tx generated using
 --   the Universes.
 addWitnesses ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -1,42 +1,71 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Test.Cardano.Ledger.Constrained.Trace.TraceMonad
 where
 
 import Cardano.Ledger.Babbage.TxBody (referenceInputsTxBodyL, reqSignerHashesTxBodyL)
-import Cardano.Ledger.Core (Era (..), TxBody)
+import Cardano.Ledger.BaseTypes (Globals, SlotNo (..))
+import Cardano.Ledger.Conway.Governance (ConwayEraGov, DRepPulser (..), DRepPulsingState (..), PulsingSnapshot (..), newEpochStateDRepPulsingStateL)
+import Cardano.Ledger.Core (Era (..), Tx, TxBody)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.Pretty (ppList, ppPair, ppSlotNo, ppStrictSeq)
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState (..))
+import Cardano.Ledger.Shelley.Rules (runIdentity)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Except
+import Control.Monad.Trans.Reader (runReaderT)
 import Control.Monad.Trans.State.Strict hiding (State)
+import Control.State.Transition.Extended (IRC (..), STS, TRC (..))
+import Control.State.Transition.Trace (Trace (..), TraceOrder (OldestFirst), lastState, traceInitState, traceSignals, traceStates)
+import Control.State.Transition.Trace.Generator.QuickCheck (HasTrace (..), shrinkTrace, traceFromInitState)
 import Data.Default.Class (Default (def))
+import Data.Foldable (toList)
+import qualified Data.Foldable as Fold (toList)
 import qualified Data.HashSet as HashSet
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Pulse (foldlM')
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as SS (fromList)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Vector (Vector, fromList, (!))
+import qualified Data.Vector as Vector (length)
+import Data.Word (Word64)
 import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Ast (
   Pred (..),
   RootTarget (..),
   Subst (..),
   Term (..),
+  emptySubst,
   runTarget,
   runTerm,
   substPredWithVarTest,
+  substToEnv,
  )
 import Test.Cardano.Ledger.Constrained.Combinators (genFromMap, itemFromSet, suchThatErr)
 import Test.Cardano.Ledger.Constrained.Env
 import Test.Cardano.Ledger.Constrained.Monad (Typed (..), runTyped)
-import Test.Cardano.Ledger.Constrained.Preds.CertState (certStatePreds, pstatePreds, vstatePreds)
-import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStatePreds)
-import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsPreds)
-import Test.Cardano.Ledger.Constrained.Preds.Universes (universePreds)
+import Test.Cardano.Ledger.Constrained.Preds.CertState (
+  dstateStage,
+  pstateStage,
+  vstateStage,
+ )
+import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStateStage)
+import Test.Cardano.Ledger.Constrained.Preds.NewEpochState (epochStateStage, newEpochStateStage)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
 import Test.Cardano.Ledger.Constrained.Rewrite (
   DependGraph (..),
   OrderInfo,
@@ -44,11 +73,15 @@ import Test.Cardano.Ledger.Constrained.Rewrite (
   mkDependGraph,
   notBefore,
   rewriteGen,
-  standardOrderInfo,
  )
 import Test.Cardano.Ledger.Constrained.Solver (solveOneVar)
+import Test.Cardano.Ledger.Constrained.Vars (currentSlot, newEpochStateT)
+import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockBlock (..), MockChainState (..))
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTx, summaryMapCompact)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
-import Test.QuickCheck (Gen)
+import Test.Cardano.Ledger.Generic.Trace (chooseIssuer)
+import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, runShelleyBase, testGlobals)
+import Test.Tasty.QuickCheck
 
 -- ================================
 
@@ -213,23 +246,259 @@ toolChainTrace _proof order cs subst0 = do
 
 -- =====================================================================
 -- Lift some [Pred era] into TraceM (monadic) (Subst era) transformers
-
 -- Create tool (TraceM era (Subst era)) functions that can be chained together
 
 universeTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-universeTrace proof subst = toolChainTrace proof standardOrderInfo (universePreds def proof) subst
+universeTrace proof subst = liftGen (universeStage def proof subst)
 
 pparamsTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-pparamsTrace proof subst = toolChainTrace proof standardOrderInfo (pParamsPreds proof) subst
+pparamsTrace proof subst = liftGen (pParamsStage proof subst)
 
 pstateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-pstateTrace proof subst = toolChainTrace proof standardOrderInfo (pstatePreds proof) subst
+pstateTrace proof subst = liftGen (pstateStage proof subst)
 
 vstateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-vstateTrace proof subst = toolChainTrace proof standardOrderInfo (vstatePreds proof) subst
+vstateTrace proof subst = liftGen (vstateStage proof subst)
 
-certStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-certStateTrace proof subst = toolChainTrace proof standardOrderInfo (certStatePreds proof) subst
+dstateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+dstateTrace proof subst = liftGen (dstateStage proof subst)
 
 ledgerStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
-ledgerStateTrace proof subst = toolChainTrace proof standardOrderInfo (ledgerStatePreds def proof) subst
+ledgerStateTrace proof subst = liftGen (ledgerStateStage def proof subst)
+
+epochStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+epochStateTrace proof subst = liftGen (epochStateStage proof subst)
+
+newEpochStateTrace :: Reflect era => Proof era -> Subst era -> TraceM era (Subst era)
+newEpochStateTrace proof subst = liftGen (newEpochStateStage proof subst)
+
+-- ==============================================================
+-- Code to make Traces
+
+-- | Iterate a function 'make' to make a trace of length 'n'. Each call to 'make' gets the
+--   most recent value of the Env internal to TraceM. The function 'make' is
+--   supposed to compute 'a', and (possibly) update the Env internal to TraceM.
+makeTrace :: Int -> TraceM era a -> TraceM era [(Env era, a)]
+makeTrace 0 _ = pure []
+makeTrace n make = do
+  env0 <- getEnv
+  a <- make
+  xs <- makeTrace (n - 1) make
+  pure ((env0, a) : xs)
+
+data TraceStep era a = TraceStep {tsBefore :: !(Env era), tsAfter :: !(Env era), tsA :: !a}
+
+beforeAfterTrace :: Int -> (Int -> TraceM era a) -> TraceM era [TraceStep era a]
+beforeAfterTrace 0 _ = pure []
+beforeAfterTrace !n make = do
+  !beforeEnv <- getEnv
+  !a <- make n
+  !afterEnv <- getEnv
+  xs <- beforeAfterTrace (n - 1) make
+  let !ans = TraceStep {tsBefore = beforeEnv, tsAfter = afterEnv, tsA = a} : xs
+  pure ans
+
+-- =====================================================================
+
+-- | Generate an Env that contains the pieces of the LedgerState
+--   by chaining smaller pieces together.
+genLedgerStateEnv :: Reflect era => Proof era -> TraceM era (Env era)
+genLedgerStateEnv proof = do
+  subst <-
+    pure emptySubst
+      >>= pparamsTrace proof
+      >>= universeTrace proof
+      >>= vstateTrace proof
+      >>= pstateTrace proof
+      >>= dstateTrace proof
+      >>= ledgerStateTrace proof
+  env <- liftTyped (substToEnv subst emptyEnv)
+  putEnv env
+
+-- | Generate an Env that contains the pieces of the NewEpochState
+--   by chaining smaller pieces together.
+genNewEpochStateEnv :: Reflect era => Proof era -> TraceM era (Env era)
+genNewEpochStateEnv proof = do
+  subst <-
+    pure emptySubst
+      >>= pparamsTrace proof
+      >>= universeTrace proof
+      >>= vstateTrace proof
+      >>= pstateTrace proof
+      >>= dstateTrace proof
+      >>= ledgerStateTrace proof
+      >>= epochStateTrace proof
+      >>= newEpochStateTrace proof
+  env <- liftTyped (substToEnv subst emptyEnv)
+  putEnv env
+
+-- ======================================================================
+-- Using traces by running the MOCKCHAIN STS instance
+-- ======================================================================
+
+-- | How we encode a trace, when we run STS of (MOCKCHAIN era)
+data PredGen era = PredGen (Vector (StrictSeq (Tx era), SlotNo)) (Env era)
+
+instance Reflect era => Show (PredGen era) where
+  show (PredGen xs _) = show (ppList (ppPair (ppStrictSeq (pcTx reify)) (ppSlotNo)) (toList xs))
+
+instance
+  ( STS (MOCKCHAIN era)
+  , Reflect era
+  ) =>
+  HasTrace (MOCKCHAIN era) (PredGen era)
+  where
+  type BaseEnv (MOCKCHAIN era) = Globals
+
+  interpretSTS globals act = runIdentity $ runReaderT act globals
+
+  envGen _gstate = pure ()
+
+  sigGen (PredGen txss _) () mcs@(MockChainState newepoch (SlotNo lastSlot) count) = do
+    let NewEpochState epochnum _ _ _epochstate _ pooldistr _ = newepoch
+    issuerkey <- chooseIssuer epochnum lastSlot count pooldistr
+    let (txs, nextSlotNo) = txss ! count
+    -- Assmble it into a MockBlock
+    let mockblock = MockBlock issuerkey nextSlotNo txs
+    -- Run the STS Rules for MOCKCHAIN with generated signal
+    case runShelleyBase (applySTSTest (TRC @(MOCKCHAIN era) ((), mcs, mockblock))) of
+      Left pdfs ->
+        let _txsl = Fold.toList txs
+         in error ("FAILS\n" ++ unlines (map show pdfs))
+      Right mcs2 -> seq mcs2 (pure mockblock)
+
+  shrinkSignal _ = []
+
+-- ==================================================
+-- Now to run a Property test we need two things
+-- 1) An initial (MockChainState newepochstate slot count)
+-- 2) A (PredGen blocks env)
+-- We need to generate these together so that the trace is valid, i.e. it passes all the STS rules
+
+genTraceParts ::
+  Reflect era =>
+  Proof era ->
+  Int ->
+  (Proof era -> TraceM era (Tx era)) ->
+  TraceM era ([TraceStep era (Tx era)], Maybe (IRC (MOCKCHAIN era) -> Gen (Either a (MockChainState era))), PredGen era)
+genTraceParts proof len genTx = do
+  env0 <- genNewEpochStateEnv proof
+  newepochstate <- liftTyped $ runTarget env0 (newEpochStateT proof)
+  SlotNo currslot <- liftTyped $ runTerm env0 currentSlot
+  let initStateFun = Just (\(IRC ()) -> pure (Right (MockChainState newepochstate (SlotNo currslot) 0)))
+  steps <- beforeAfterTrace len (\_ -> genTx proof)
+  let getTx (TraceStep _ _ x) = x
+  zs <- traceStepToVector getTx steps (currslot + 1) []
+  pure (steps, initStateFun, PredGen zs env0)
+
+traceStepToVector ::
+  (step -> Tx era) ->
+  [step] ->
+  Word64 ->
+  [([Tx era], SlotNo)] ->
+  TraceM era (Vector (StrictSeq (Tx era), SlotNo))
+traceStepToVector _ [] _ zs = pure (fromList (reverse (map (\(x, y) -> (SS.fromList x, y)) zs)))
+traceStepToVector getTx steps m prev = do
+  n <- liftGen $ choose (1, 2)
+  let steplist = take n steps
+  nextslot <- liftGen ((+ m) <$> choose (2, 4))
+  traceStepToVector getTx (drop n steps) nextslot ((map getTx steplist, SlotNo m) : prev)
+
+-- | Generate a Control.State.Transition.Trace(Trace) from a (TraceM era (Tx era))
+newStsTrace ::
+  ( Reflect era
+  , STS (MOCKCHAIN era)
+  ) =>
+  Proof era ->
+  Int ->
+  (Proof era -> TraceM era (Tx era)) ->
+  Gen (Trace (MOCKCHAIN era))
+newStsTrace proof len genTx = do
+  (_, initfun, predgen@(PredGen zs _)) <- toGen $ genTraceParts proof len genTx
+  traceFromInitState testGlobals (fromIntegral (Vector.length zs - 1)) predgen initfun
+
+-- | Create a testable Property from two things
+--   1) A function that generates Tx
+--   2) A function that creates a property from a (Trace (MOCKCHAIN era))
+mockChainProp ::
+  forall era.
+  (Reflect era, STS (MOCKCHAIN era)) =>
+  Proof era ->
+  Int ->
+  (Proof era -> TraceM era (Tx era)) ->
+  (Trace (MOCKCHAIN era) -> Property) ->
+  Property
+mockChainProp proof n genTxAndUpdateEnv propf = do
+  let genTrace = newStsTrace proof n genTxAndUpdateEnv
+  forAllShrinkBlind
+    genTrace
+    ( if False
+        then shrinkTrace @(MOCKCHAIN era) @(PredGen era) testGlobals
+        else (\_ -> [])
+    )
+    propf
+
+-- ===========================================================================
+
+-- | Given trace [(sig0,state0),(sig1,state1),(sig2,state2),(sig3,state3)]
+--   conjoin [p pstate0 sig1 state1, p state0 sig2 state2, p state0 sig3 state3]
+-- test that 'p' holds between state0 and stateN for all N
+stepProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
+stepProp p tr = conjoin (map (\(sig, st) -> p state0 sig st) (tail (zip sigs states)))
+  where
+    state0 = tr ^. traceInitState
+    states = traceStates OldestFirst tr
+    sigs = traceSignals OldestFirst tr
+
+-- | Given trace [(sig0,state0),(sig1,state1),(sig2,state2),(sig3,state3)]
+--   conjoin [p pstate0 sig1 state1, p state1 sig2 state2, p state2 sig3 state3]
+--   test that 'p' holds bteween (state0 stateN sig(N+1) state(N+1) for all N
+deltaProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
+deltaProp p tr = conjoin (map (\(statei, sig, statej) -> p statei sig statej) (zip3 states sigs (tail states)))
+  where
+    states = traceStates OldestFirst tr
+    sigs = traceSignals OldestFirst tr
+
+-- | Given trace [(sig0,state0),(sig1,state1),(sig2,state2),(sig3,state3)]
+--   test that (p state0 stateN),  where stateN is the last state in the trace
+preserveProp :: (MockChainState era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
+preserveProp p tr = p state0 stateN
+  where
+    state0 = tr ^. traceInitState
+    stateN = lastState tr
+
+-- | Apply '(preserveProp p)' to each full Epoch in a Trace. A partial epoch at the end of the trace is not tested.
+epochProp :: ConwayEraGov era => (MockChainState era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
+epochProp p tr = counterexample message $ conjoin (map (\(epoch, _n) -> (p (head epoch) (last epoch))) epochs)
+  where
+    states = traceStates OldestFirst tr
+    epochs = zip (splitEpochs states) [0 :: Int ..]
+    showEpoch (epoch, n) = unlines (("EPOCH " ++ show n) : map showPulserState epoch)
+    message = "Trace length " ++ show (length states) ++ unlines (map showEpoch epochs)
+
+splitE :: (a -> a -> Bool) -> [a] -> [a] -> [[a]] -> [[a]]
+splitE _ [] epoch epochs = reverse (reverse epoch : epochs)
+splitE _ [x] epoch epochs = reverse (reverse (x : epoch) : epochs)
+splitE boundary (x : y : more) epoch epochs =
+  if boundary x y
+    then splitE boundary (y : more) [] (reverse (x : epoch) : epochs)
+    else splitE boundary (y : more) (x : epoch) epochs
+
+splitTest :: [[(Int, Char)]]
+splitTest = splitE boundary (zip [1, 1, 1, 2, 2, 1, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 8, 8] "abcdefghijklmnopqrstuvwxyz") [] []
+  where
+    boundary :: (Int, Char) -> (Int, Char) -> Bool
+    boundary (n, _) (m, _) = n + 1 <= m
+
+splitEpochs :: [MockChainState era] -> [[MockChainState era]]
+splitEpochs xs = init $ splitE boundary xs [] [] -- We only want full traces, so we drop the last potential trace
+  where
+    boundary mcs1 mcs2 = nesEL (mcsNes mcs1) + 1 <= nesEL (mcsNes mcs2)
+
+-- =====================
+
+showPulserState :: ConwayEraGov era => MockChainState era -> String
+showPulserState (MockChainState nes slot _) = "Slot = " ++ show slot ++ "   " ++ getPulserInfo (nes ^. newEpochStateDRepPulsingStateL)
+  where
+    getPulserInfo (DRPulsing x) = "Balance = " ++ show (summaryMapCompact (dpBalance x)) ++ "    DRepDistr = " ++ show (summaryMapCompact (dpDRepDistr x))
+    getPulserInfo (DRComplete psnap _) = "Complete DRepDistr = " ++ show (summaryMapCompact (psDRepDistr psnap))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -216,7 +216,7 @@ defaultPPs =
   , MaxBlockExUnits $ ExUnits 1000000 1000000
   , ProtocolVersion $ ProtVer (natVersion @7) 0
   , CollateralPercentage 1
-  , AdaPerUTxOByte (CoinPerByte (Coin 5))
+  , CoinPerUTxOByte (CoinPerByte (Coin 5))
   ]
 
 pp :: EraPParams era => Proof era -> PParams era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -76,18 +76,21 @@ import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core (AlonzoEraPParams, AlonzoEraTxBody)
+import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core (BabbageEraPParams)
+import Cardano.Ledger.Babbage.PParams (BabbagePParams (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageEraTxOut (..), BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import qualified Cardano.Ledger.BaseTypes as Base (Seed)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (ConwayGovState (..))
+import Cardano.Ledger.Conway.Governance (ConwayGovState (..), RunConwayRatify (..))
+import Cardano.Ledger.Conway.PParams (ConwayEraPParams (..), ConwayPParams (..))
 import Cardano.Ledger.Conway.TxCert (ConwayEraTxCert, ConwayTxCert (..))
 import Cardano.Ledger.Core (
   Era (EraCrypto),
@@ -97,6 +100,7 @@ import Cardano.Ledger.Core (
   EraTx,
   EraTxAuxData,
   EraTxOut,
+  PParamsHKD,
   ProtVerAtMost,
   Script,
   TxCert,
@@ -111,6 +115,7 @@ import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core (EraGov, EraIndependentTxBody, ShelleyEraTxBody, ShelleyEraTxCert)
 import Cardano.Ledger.Shelley.Governance (EraGov (..), ShelleyGovState (..))
+import Cardano.Ledger.Shelley.PParams (ShelleyPParams (..))
 import Cardano.Ledger.Shelley.Scripts (MultiSig)
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert)
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
@@ -121,6 +126,7 @@ import Cardano.Protocol.TPraos.API (PraosCrypto)
 import Cardano.Protocol.TPraos.BHeader (BHBody)
 import Cardano.Protocol.TPraos.OCert
 import Control.State.Transition.Extended hiding (Assertion)
+import Data.Functor.Identity (Identity)
 import Data.Kind (Type)
 import Data.Universe (Shape (..), Shaped (..), Singleton (..), Some (..), (:~:) (Refl))
 import GHC.TypeLits (Symbol)
@@ -474,7 +480,7 @@ whichTxOut (Conway _) = TxOutBabbageToConway
 
 data TxCertWit era where
   TxCertShelleyToBabbage :: (TxCert era ~ ShelleyTxCert era, ShelleyEraTxCert era, ProtVerAtMost era 8) => TxCertWit era
-  TxCertConwayToConway :: (TxCert era ~ ConwayTxCert era, ConwayEraTxCert era) => TxCertWit era
+  TxCertConwayToConway :: (TxCert era ~ ConwayTxCert era, ConwayEraTxCert era, ConwayEraPParams era) => TxCertWit era
 
 whichTxCert :: Proof era -> TxCertWit era
 whichTxCert (Shelley _) = TxCertShelleyToBabbage
@@ -497,17 +503,18 @@ whichValue (Babbage _) = ValueMaryToConway
 whichValue (Conway _) = ValueMaryToConway
 
 data PParamsWit era where
-  PParamsShelleyToMary :: EraPParams era => PParamsWit era
-  PParamsAlonzoToAlonzo :: AlonzoEraPParams era => PParamsWit era
-  PParamsBabbageToConway :: BabbageEraPParams era => PParamsWit era
+  PParamsShelleyToMary :: (PParamsHKD Identity era ~ ShelleyPParams Identity era, EraPParams era) => PParamsWit era
+  PParamsAlonzoToAlonzo :: (PParamsHKD Identity era ~ AlonzoPParams Identity era, AlonzoEraPParams era) => PParamsWit era
+  PParamsBabbageToBabbage :: (PParamsHKD Identity era ~ BabbagePParams Identity era, BabbageEraPParams era) => PParamsWit era
+  PParamsConwayToConway :: (PParamsHKD Identity era ~ ConwayPParams Identity era, ConwayEraPParams era) => PParamsWit era
 
 whichPParams :: Proof era -> PParamsWit era
 whichPParams (Shelley _) = PParamsShelleyToMary
 whichPParams (Allegra _) = PParamsShelleyToMary
 whichPParams (Mary _) = PParamsShelleyToMary
 whichPParams (Alonzo _) = PParamsAlonzoToAlonzo
-whichPParams (Babbage _) = PParamsBabbageToConway
-whichPParams (Conway _) = PParamsBabbageToConway
+whichPParams (Babbage _) = PParamsBabbageToBabbage
+whichPParams (Conway _) = PParamsConwayToConway
 
 data UTxOWit era where
   UTxOShelleyToMary ::
@@ -550,7 +557,7 @@ whichScript (Conway _) = ScriptAlonzoToConway
 
 data GovStateWit era where
   GovStateShelleyToBabbage :: (EraGov era, GovState era ~ ShelleyGovState era) => GovStateWit era
-  GovStateConwayToConway :: (EraGov era, GovState era ~ ConwayGovState era) => GovStateWit era
+  GovStateConwayToConway :: (RunConwayRatify era, EraGov era, GovState era ~ ConwayGovState era) => GovStateWit era
 
 whichGovState :: Proof era -> GovStateWit era
 whichGovState (Shelley _) = GovStateShelleyToBabbage

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -25,7 +25,16 @@ import Cardano.Ledger.Babbage.TxBody as Babbage (
   Datum (..),
  )
 import Cardano.Ledger.Conway.Governance (GovProcedures (..))
-import Cardano.Ledger.Conway.PParams (ppGovActionDepositL)
+import Cardano.Ledger.Conway.PParams (
+  ppCommitteeMaxTermLengthL,
+  ppCommitteeMinSizeL,
+  ppDRepActivityL,
+  ppDRepDepositL,
+  ppDRepVotingThresholdsL,
+  ppGovActionDepositL,
+  ppGovActionLifetimeL,
+  ppPoolVotingThresholdsL,
+ )
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Shelley.Tx as Shelley (
@@ -360,7 +369,7 @@ updatePParams proof pp' ppf =
           case ppf of
             D d -> pp & ppDL .~ d
             ExtraEntropy nonce -> pp & ppExtraEntropyL .~ nonce
-            AdaPerUTxOWord coinPerWord -> pp & ppCoinsPerUTxOWordL .~ coinPerWord
+            CoinPerUTxOWord coinPerWord -> pp & ppCoinsPerUTxOWordL .~ coinPerWord
             Costmdls costModels -> pp & ppCostModelsL .~ costModels
             Prices prices -> pp & ppPricesL .~ prices
             MaxTxExUnits maxTxExUnits -> pp & ppMaxTxExUnitsL .~ maxTxExUnits
@@ -371,7 +380,7 @@ updatePParams proof pp' ppf =
             _ -> pp
         Babbage _ ->
           case ppf of
-            AdaPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
+            CoinPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
             Costmdls costModels -> pp & ppCostModelsL .~ costModels
             Prices prices -> pp & ppPricesL .~ prices
             MaxTxExUnits maxTxExUnits -> pp & ppMaxTxExUnitsL .~ maxTxExUnits
@@ -382,7 +391,7 @@ updatePParams proof pp' ppf =
             _ -> pp
         Conway _ ->
           case ppf of
-            AdaPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
+            CoinPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
             Costmdls costModels -> pp & ppCostModelsL .~ costModels
             Prices prices -> pp & ppPricesL .~ prices
             MaxTxExUnits maxTxExUnits -> pp & ppMaxTxExUnitsL .~ maxTxExUnits
@@ -391,6 +400,13 @@ updatePParams proof pp' ppf =
             CollateralPercentage colPerc -> pp & ppCollateralPercentageL .~ colPerc
             MaxCollateralInputs maxColInputs -> pp & ppMaxCollateralInputsL .~ maxColInputs
             GovActionDeposit c -> pp & ppGovActionDepositL .~ c
+            DRepDeposit c -> pp & ppDRepDepositL .~ c
+            DRepActivity c -> pp & ppDRepActivityL .~ c
+            PoolVotingThreshold c -> pp & ppPoolVotingThresholdsL .~ c
+            DRepVotingThreshold c -> pp & ppDRepVotingThresholdsL .~ c
+            MinCommitteeSize c -> pp & ppCommitteeMinSizeL .~ c
+            CommitteeTermLimit c -> pp & ppCommitteeMaxTermLengthL .~ c
+            GovActionExpiration c -> pp & ppGovActionLifetimeL .~ c
             _ -> pp
 
 newPParams :: EraPParams era => Proof era -> [PParamsField era] -> PParams era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -54,7 +54,8 @@ import Test.Cardano.Ledger.Constrained.Shrink
 import Test.Cardano.Ledger.Constrained.Solver
 import Test.Cardano.Ledger.Constrained.Tests
 import Test.Cardano.Ledger.Constrained.TypeRep
-import Test.Cardano.Ledger.Constrained.Vars hiding (delegations, rewards)
+import Test.Cardano.Ledger.Constrained.Vars hiding (delegations, drepDeposit, rewards)
+import qualified Test.Cardano.Ledger.Constrained.Vars as Vars
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Shelley.Utils
 import Test.QuickCheck
@@ -390,7 +391,9 @@ prop_GOVCERT sub =
   stsProperty @"GOVCERT"
     sub
     (\PropEnv {..} -> ConwayGovCertEnv pePParams peEpochNo)
-    (\_ -> genShrinkFromConstraints conwayProof sub vstatePreds (const []) vstateT)
+    (\_ -> genShrinkFromConstraints conwayProof sub (\p -> Random (Vars.drepDeposit p) : vstatePreds p) (const []) vstateT)
+    -- \^ vstatePreds are designed to run after pparams are defined because they depend upon 'Vars.drepDeposit'
+    --   Since we are not defining 'pparams' but only the Universes we need to add the 'Random (Vars.drepDeposit p)'
     -- TODO: this should eventually be replaced by constraints based generator
     (\PropEnv {..} st -> (genConwayGovCert pePParams st, shrinkConwayGovCert pePParams st))
     $ \_pEnv _env _st _sig _st' -> property True -- TODO: property?

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -14,7 +14,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
 import Test.Cardano.Ledger.Constrained.Examples (allExampleTests)
 import Test.Cardano.Ledger.Constrained.Preds.Tx (predsTests)
 import Test.Cardano.Ledger.Constrained.Spec (allSpecTests)
-import Test.Cardano.Ledger.Constrained.Trace.Tests (conwayTrace)
+import Test.Cardano.Ledger.Constrained.Trace.Tests (conwayTrace, conwayTxwithDRepCertsTraceTests)
 import qualified Test.Cardano.Ledger.Examples.AlonzoAPI as AlonzoAPI (tests)
 import qualified Test.Cardano.Ledger.Examples.AlonzoBBODY as AlonzoBBODY (tests)
 import qualified Test.Cardano.Ledger.Examples.AlonzoCollectInputs as AlonzoCollectInputs (tests)
@@ -59,6 +59,7 @@ defaultTests =
   , genericProperties def
   , aggTests
   , ConstraintSTS.tests_STS
+  , conwayTxwithDRepCertsTraceTests
   ]
 
 nightlyTests :: [TestTree]


### PR DESCRIPTION
Added features for chains of simple transactions.
Added Univ for DRep and DRepState,
Better constraints for VState, Added constraints for EpochState and NewEpochState.
New vars for Conway PParams, and needed (Rep era t). 
Added missing Conway PParams fields, added abstractPParams, and pcParams. 
Added module DrepCertTx which generates simple Tx with just Conway DRep Certs. 
Added RootTarget for DRepPulser. Introduced idea of RootTarget for Pairs. 
Added Virtual RootTarget like Lensed with additional name. 
Added a new HasTrace instances, simplified MockChain 
Added STS (MOCKCHAIN era) instance and helper functions. 
Fixed pot Equal obligation in Pool Reap and problems with tracking obligations. 
Made 'There are no "stakepools to choose an issuer from" a discard. 
Added property tests on traces with simple Tx with certs on DReps.

Fixes #3610 

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
