### PR TITLE
Indicate that tag 258 is optional for OSet. Fix rational CDDL

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Switch `ppCommitteeMaxTermLength` to `EpochNo`, rather than `Natural`
 * Rename data-type `ProposalsSnapshot` to `Proposals`. #3859
   * Rename module `Governance.Snapshots` to `Governance.Proposals`.
   * Rename all the functions related to the data-type.

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -399,7 +399,7 @@ protocol_param_update =
   , ? 25: pool_voting_thresholds ; pool voting thresholds
   , ? 26: drep_voting_thresholds ; DRep voting thresholds
   , ? 27: uint                   ; min committee size
-  , ? 28: uint                   ; committee term limit
+  , ? 28: epoch                  ; committee term limit
   , ? 29: epoch                  ; governance action validity period
   , ? 30: coin                   ; governance action deposit
   , ? 31: coin                   ; DRep deposit

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -375,16 +375,16 @@ url = tstr .size (0..64)
 withdrawals = { + reward_account => coin }
 
 protocol_param_update =
-  { ? 0:  uint                   ; minfee A
-  , ? 1:  uint                   ; minfee B
+  { ? 0:  coin                   ; minfee A
+  , ? 1:  coin                   ; minfee B
   , ? 2:  uint                   ; max block body size
   , ? 3:  uint                   ; max transaction size
   , ? 4:  uint                   ; max block header size
   , ? 5:  coin                   ; key deposit
   , ? 6:  coin                   ; pool deposit
-  , ? 7: epoch                   ; maximum epoch
-  , ? 8: uint                    ; n_opt: desired number of stake pools
-  , ? 9: rational                ; pool pledge influence
+  , ? 7:  epoch                  ; maximum epoch
+  , ? 8:  uint                   ; n_opt: desired number of stake pools
+  , ? 9:  nonnegative_interval   ; pool pledge influence
   , ? 10: unit_interval          ; expansion rate
   , ? 11: unit_interval          ; treasury growth rate
   , ? 16: coin                   ; min pool cost
@@ -473,7 +473,7 @@ redeemer_tag =
 ex_units = [mem: uint, steps: uint]
 
 ex_unit_prices =
-  [ mem_price: sub_coin, step_price: sub_coin ]
+  [ mem_price: nonnegative_interval, step_price: nonnegative_interval ]
 
 language = 0 ; Plutus v1
          / 1 ; Plutus v2
@@ -544,8 +544,6 @@ invalid_before = (4, uint)
 invalid_hereafter = (5, uint)
 
 coin = uint
-
-sub_coin = positive_interval
 
 multiasset<a> = { + policy_id => { + asset_name => a } }
 policy_id = scripthash

--- a/eras/conway/impl/cddl-files/extra.cddl
+++ b/eras/conway/impl/cddl-files/extra.cddl
@@ -1,8 +1,12 @@
+; Conway era introduces an optional 258 tag for sets, which will become mandatory in the
+; next era. We recommend all the tooling to account for this future breaking change now,
+; rather than in the next era when it will be enforced.
+
 set<a> = #6.258([* a]) / [* a]
 
 nonempty_set<a> = #6.258([+ a]) / [+ a]
 
-nonempty_oset<a> = #6.258([+ a])
+nonempty_oset<a> = #6.258([+ a]) / [+ a]
 
 positive_int = 1 .. 18446744073709551615
 

--- a/eras/conway/impl/cddl-files/extra.cddl
+++ b/eras/conway/impl/cddl-files/extra.cddl
@@ -15,9 +15,9 @@ unit_interval = #6.30([1, 2])
   ; but this produces numbers outside the unit interval
   ; and can also produce a zero in the denominator
 
-rational =  #6.30([uint, positive_int])
+rational =  #6.30([int, positive_int])
 
-positive_interval = #6.30([uint, positive_int])
+nonnegative_interval = #6.30([uint, positive_int])
 
 
 address =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -221,7 +221,6 @@ data ConwayPParams f era = ConwayPParams
   , cppCommitteeMinSize :: !(THKD 'GovGroup f Natural)
   -- ^ Minimum size of the Constitutional Committee
   , cppCommitteeMaxTermLength :: !(THKD 'GovGroup f Natural) -- TODO: This too should be EpochNo
-
   -- ^ The Constitutional Committee Term limit in number of Slots
   , cppGovActionLifetime :: !(THKD 'GovGroup f EpochNo)
   -- ^ Gov action lifetime in number of Epochs

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -212,15 +212,14 @@ data ConwayPParams f era = ConwayPParams
   -- including non-native scripts.
   , cppMaxCollateralInputs :: !(THKD 'NetworkGroup f Natural)
   -- ^ Maximum number of collateral inputs allowed in a transaction
-  --
-  -- New ones for Conway
-  , cppPoolVotingThresholds :: !(THKD 'GovGroup f PoolVotingThresholds)
+  , -- New ones for Conway:
+    cppPoolVotingThresholds :: !(THKD 'GovGroup f PoolVotingThresholds)
   -- ^ Thresholds for SPO votes
   , cppDRepVotingThresholds :: !(THKD 'GovGroup f DRepVotingThresholds)
   -- ^ Thresholds for DRep votes
   , cppCommitteeMinSize :: !(THKD 'GovGroup f Natural)
   -- ^ Minimum size of the Constitutional Committee
-  , cppCommitteeMaxTermLength :: !(THKD 'GovGroup f Natural) -- TODO: This too should be EpochNo
+  , cppCommitteeMaxTermLength :: !(THKD 'GovGroup f EpochNo)
   -- ^ The Constitutional Committee Term limit in number of Slots
   , cppGovActionLifetime :: !(THKD 'GovGroup f EpochNo)
   -- ^ Gov action lifetime in number of Epochs
@@ -259,7 +258,7 @@ data UpgradeConwayPParams f = UpgradeConwayPParams
   { ucppPoolVotingThresholds :: !(HKD f PoolVotingThresholds)
   , ucppDRepVotingThresholds :: !(HKD f DRepVotingThresholds)
   , ucppCommitteeMinSize :: !(HKD f Natural)
-  , ucppCommitteeMaxTermLength :: !(HKD f Natural)
+  , ucppCommitteeMaxTermLength :: !(HKD f EpochNo)
   , ucppGovActionLifetime :: !(HKD f EpochNo)
   , ucppGovActionDeposit :: !(HKD f Coin)
   , ucppDRepDeposit :: !(HKD f Coin)
@@ -411,7 +410,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       , isValid (/= 0) ppuMaxValSizeL
       , isValid (/= 0) ppuCollateralPercentageL
       , isValid (/= 0) ppuCommitteeMaxTermLengthL
-      , isValid (/= EpochNo 0) ppuGovActionLifetimeL
+      , isValid (/= 0) ppuGovActionLifetimeL
       , -- Coins
         isValid (/= zero) ppuPoolDepositL
       , isValid (/= zero) ppuGovActionDepositL
@@ -740,7 +739,7 @@ conwayUpgradePParamsHKDPairs px pp =
   [ ("poolVotingThresholds", hkdMap px (toJSON @PoolVotingThresholds) (pp ^. hkdPoolVotingThresholdsL @era @f))
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
   , ("committeeMinSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
-  , ("committeeMaxTermLength", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
+  , ("committeeMaxTermLength", hkdMap px (toJSON @EpochNo) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
   , ("govActionLifetime", hkdMap px (toJSON @EpochNo) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
   , ("dRepDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdDRepDepositL @era @f))
@@ -760,7 +759,7 @@ upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   [ ("poolVotingThresholds", (toJSON @PoolVotingThresholds) ucppPoolVotingThresholds)
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
   , ("committeeMinSize", (toJSON @Natural) ucppCommitteeMinSize)
-  , ("committeeMaxTermLength", (toJSON @Natural) ucppCommitteeMaxTermLength)
+  , ("committeeMaxTermLength", (toJSON @EpochNo) ucppCommitteeMaxTermLength)
   , ("govActionLifetime", (toJSON @EpochNo) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
   , ("dRepDeposit", (toJSON @Coin) ucppDRepDeposit)
@@ -863,7 +862,7 @@ class BabbageEraPParams era => ConwayEraPParams era where
   hkdPoolVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f PoolVotingThresholds)
   hkdDRepVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f DRepVotingThresholds)
   hkdCommitteeMinSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
-  hkdCommitteeMaxTermLengthL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdCommitteeMaxTermLengthL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
   hkdGovActionLifetimeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochNo)
   hkdGovActionDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
   hkdDRepDepositL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Coin)
@@ -880,7 +879,7 @@ ppDRepVotingThresholdsL = ppLens . hkdDRepVotingThresholdsL @era @Identity
 ppCommitteeMinSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
 ppCommitteeMinSizeL = ppLens . hkdCommitteeMinSizeL @era @Identity
 
-ppCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
+ppCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochNo
 ppCommitteeMaxTermLengthL = ppLens . hkdCommitteeMaxTermLengthL @era @Identity
 
 ppGovActionLifetimeL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochNo
@@ -908,7 +907,7 @@ ppuCommitteeMinSizeL ::
 ppuCommitteeMinSizeL = ppuLens . hkdCommitteeMinSizeL @era @StrictMaybe
 
 ppuCommitteeMaxTermLengthL ::
-  forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
+  forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe EpochNo)
 ppuCommitteeMaxTermLengthL = ppuLens . hkdCommitteeMaxTermLengthL @era @StrictMaybe
 
 ppuGovActionLifetimeL ::

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -357,7 +357,7 @@ validCommitteeTerm ::
 validCommitteeTerm committee pp currentEpoch =
   let maxCommitteeTerm = pp ^. ppCommitteeMaxTermLengthL
       members = foldMap' (^. committeeMembersL) committee
-   in all (<= currentEpoch + fromIntegral maxCommitteeTerm) members
+   in all (<= currentEpoch + maxCommitteeTerm) members
 
 instance EraGov era => Embed (ConwayENACT era) (ConwayRATIFY era) where
   wrapFailed = absurd

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -240,7 +240,7 @@ instance SpecTranslate (ConwayPParams Identity era) where
       <*> toSpecRep (cppDRepDeposit x)
       <*> toSpecRep (cppDRepActivity x)
       <*> Right (toInteger . unTHKD $ cppCommitteeMinSize x)
-      <*> Right (toInteger . unTHKD $ cppCommitteeMaxTermLength x)
+      <*> Right (toInteger . unEpochNo . unTHKD $ cppCommitteeMaxTermLength x)
       -- This is the minimumAVS field which we ended up not needing. It will be
       -- removed from the spec.
       <*> Right (error "minimumAVS is not in Conway, do not use this field")


### PR DESCRIPTION
# Description

* #3860 added optional 258 tags to sets, but not the oset in CDDL. This PR fixes that ommission
* Fix definition of `rational` in CDDL. It is no longer non-negative
* Remove `positive_rational` in favor of new `nonnegative_rational`, since that is the actual type that is used in PParams
* Switch `ppCommitteeMaxTermLength` to `EpochNo`, rather than `Natural`

# Checklist
- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
