### PR TITLE
Fixup ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,16 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+
 sphinx:
   configuration: doc/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
Just adding the `build.os` key to make the build successful again.