### PR TITLE
Post release changes

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.2.5.1
+
+*
+
 ## 1.2.5.0
 
 ### `testlib`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.5.1.1
+
+*
+
 ## 1.5.1.0
 
 * Move `Cardano.Ledger.Alonzo.Scripts.Data` to `Cardano.Ledger.Plutus.Data`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -124,7 +124,6 @@ library testlib
         cardano-crypto-class,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
-        plutus-core,
         data-default-class,
         microlens,
         text

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.5.1.0
+version:            1.5.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/CostModel.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/CostModel.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module Test.Cardano.Ledger.Alonzo.CostModel (
   freeCostModel,
   costModelParamsCount,
@@ -14,13 +12,12 @@ import qualified Data.Map.Strict as Map
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
-import PlutusPrelude (enumerate)
 
 costModelParamsCount :: Language -> Int
 costModelParamsCount lang = case lang of
-  PlutusV1 -> length (enumerate @PV1.ParamName)
-  PlutusV2 -> length (enumerate @PV2.ParamName)
-  PlutusV3 -> length (enumerate @PV3.ParamName)
+  PlutusV1 -> length ([minBound .. maxBound] :: [PV1.ParamName])
+  PlutusV2 -> length ([minBound .. maxBound] :: [PV2.ParamName])
+  PlutusV3 -> length ([minBound .. maxBound] :: [PV3.ParamName])
 
 -- | A cost model that sets everything as being free
 freeCostModel :: Language -> CostModel

--- a/eras/alonzo/test-suite/CHANGELOG.md
+++ b/eras/alonzo/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo-test`
 
+## 1.1.2.8
+
+*
+
 ## 1.1.2.7
 
 * Move `cddl-files` to `cardano-ledger-alonzo`

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-alonzo-test
-version:       1.1.2.7
+version:       1.1.2.8
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.5.1.1
+
+*
+
 ## 1.5.1.0
 
 ### `testlib`

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.5.1.0
+version:            1.5.1.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/babbage/test-suite/CHANGELOG.md
+++ b/eras/babbage/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage-test`
 
+## 1.1.1.9
+
+*
+
 ## 1.1.1.8
 
 * Move `cddl-files` to `cardano-ledger-alonzo`

--- a/eras/byron/ledger/impl/CHANGELOG.md
+++ b/eras/byron/ledger/impl/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Revision history for `cardano-ledger-byron`
 
+## 1.0.0.4
+
+*
+
 ## 1.0.0.3
 
 * Update `streaming-binary` dependency to 0.4.
+
+## 1.0.0.2
+
+*
 
 ## 1.0.0.1
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.11.0.1
+
+*
+
 ## 1.11.0.0
 
 * Switch `ppCommitteeMaxTermLength` to `EpochNo`, rather than `Natural`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.11.0.0
+version:            1.11.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway-test`
 
+## 1.2.1.3
+
+*
+
 ## 1.2.1.2
 
 * Move `cddl-files` to `cardano-ledger-alonzo`

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.4.0.1
+
+*
+
 ## 1.4.0.0
 
 * Switch `MaryValue` field for ADA from `Integer` to `Coin`

--- a/eras/shelley-ma/test-suite/CHANGELOG.md
+++ b/eras/shelley-ma/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley-ma-test`
 
+## 1.2.1.6
+
+*
+
 ## 1.2.1.5
 
 * Move `cddl-files` to `cardano-ledger-allegra` and `cardano-ledger-mary`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.8.0.1
+
+*
+
 ## 1.8.0.0
 
 * Add `shelleyTotalDepositsTxCerts` and `shelleyTotalRefundsTxCerts`

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley-test`
 
+## 1.3.0.1
+
+*
+
 ## 1.3.0.0
 
 * Move `CDDLUtils` functionality into `cardano-ledger-binary`

--- a/flake.nix
+++ b/flake.nix
@@ -96,14 +96,14 @@
           # tools we want in our shell, from hackage
           shell.tools =
             {
-              cabal = "3.10.1.0";
+              cabal = "3.10.2.1";
               ghcid = "0.8.9";
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
               fourmolu = "0.14.0.0";
               hlint = "3.6.1";
-              haskell-language-server = { src = nixpkgs.haskell-nix.sources."hls-2.2"; };
+              haskell-language-server = "2.4.0.0";
             };
 
           # and from nixpkgs or other inputs

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Version history for `cardano-data`
 
+## 1.1.2.1
+
+*
+
 ## 1.1.2.0
 
-- Add Data.OMap.Strict #3791
+* Add Data.OMap.Strict #3791
 
 ## 1.1.1.0
 
-- Add Data.OSet.Strict #3779
+* Add Data.OSet.Strict #3779
 
 ## 1.1.0.0
 
-- Remove `Data.UMap` #3371
+* Remove `Data.UMap` #3371
 
 ## 1.0.1.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-api`
 
+## 1.7.0.2
+
+*
+
 ## 1.7.0.1
 
 *

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-binary`
 
+## 1.2.1.1
+
+*
+
 ## 1.2.1.0
 
 * Export `decodeListLikeEnforceNoDuplicates` #3791

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.2.1.0
+version:       1.2.1.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-core`
 
+## 1.9.0.1
+
+*
+
 ## 1.9.0.0
 
 * Add `certsTotalDepositsTxBody` and `certsTotalRefundsTxBody`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.9.0.0
+version:            1.9.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -113,7 +113,6 @@ library
         nothunks,
         partial-order,
         plutus-ledger-api,
-        plutus-core,
         prettyprinter,
         quiet,
         serialise,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
@@ -83,7 +83,6 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import Cardano.Slotting.Time (SystemStart)
 import Data.ByteString as BS (ByteString)
 import qualified Data.Map.Strict as Map
-import Data.SatInt (SatInt, fromSatInt)
 import Data.Text (Text)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -93,8 +92,8 @@ import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks)
 import Numeric.Natural (Natural)
+import PlutusLedgerApi.V1 (SatInt, fromSatInt)
 import qualified PlutusLedgerApi.V1 as PV1
-import PlutusLedgerApi.V1.Contexts ()
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
 

--- a/libs/cardano-ledger-pretty/CHANGELOG.md
+++ b/libs/cardano-ledger-pretty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `cardano-ledger-pretty`
 
+## 1.3.3.2
+
+*
+
 ## 1.3.3.1
 
 *

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -124,7 +124,7 @@ library
         nothunks,
         plutus-core,
         hspec,
-        plutus-ledger-api ^>=1.16,
+        plutus-ledger-api,
         prettyprinter,
         QuickCheck,
         small-steps,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -122,7 +122,6 @@ library
         microlens,
         mtl,
         nothunks,
-        plutus-core,
         hspec,
         plutus-ledger-api,
         prettyprinter,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -107,7 +107,6 @@ import GHC.Natural (Natural)
 import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
-import PlutusPrelude (enumerate)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Fields (
   TxOutField (..),
@@ -144,14 +143,14 @@ freeCostModelV1 :: CostModel
 freeCostModelV1 =
   fromRight (error "corrupt freeCostModelV1") $
     mkCostModel PlutusV1 $
-      0 <$ (enumerate @PV1.ParamName)
+      0 <$ ([minBound .. maxBound] :: [PV1.ParamName])
 
 -- | A cost model that sets everything as being free
 freeCostModelV2 :: CostModel
 freeCostModelV2 =
   fromRight (error "corrupt freeCostModelV2") $
     mkCostModel PlutusV1 $
-      0 <$ (enumerate @PV2.ParamName)
+      0 <$ ([minBound .. maxBound] :: [PV2.ParamName])
 
 someKeys :: forall era. Era era => Proof era -> KeyPair 'Payment (EraCrypto era)
 someKeys _pf = KeyPair vk sk

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-protocol-tpraos`
 
+## 1.0.3.8
+
+*
+
 ## 1.0.3.7
 
 * Add a test suite


### PR DESCRIPTION
# Description

Some cleanup and needed changes:

* As usual after the release we need add new versions to Changelogs: https://github.com/input-output-hk/cardano-haskell-packages/pull/560
* #3871 did not include the necessary version bumps 
* Dependency on `plutus-core` is redundant
* Update cabal and hls versions

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
