### PR TITLE
Fix cddl spec for CostModels in Conway

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -484,13 +484,12 @@ potential_languages = 0 .. 255
 ; The format for costmdls is flexible enough to allow adding Plutus built-ins and language
 ; versions in the future.
 ;
-; To construct valid cost models, however, you must restrict to:
-;
-; { ? 0 : [ 166* int ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
-; , ? 1 : [ 175* int ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
-; , ? 2 : [ 179* int ] ; Plutus v3, only 179 integers are used, but more are accepted (and ignored)
-; }
-costmdls = { * potential_languages => [int] }
+costmdls =
+  { ? 0 : [ 166* int ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+  , ? 1 : [ 175* int ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
+  , ? 2 : [ 223* int ] ; Plutus v3, only 223 integers are used, but more are accepted (and ignored)
+  , ? 3 : [ int ] ; Any 8-bit unsigned number can be used as a key.
+  }
 
 transaction_metadatum =
     { * transaction_metadatum => transaction_metadatum }


### PR DESCRIPTION
# Description

Fixing CDDL tests. CostModel deserialization was fixed, y making it stricter for PParamsUpdate in #3861

Received this error on CI: https://github.com/input-output-hk/cardano-ledger/actions/runs/6882361340/job/18720713406?pr=3874#step:15:4026
```
       Decoder error: Deserialisation failure while decoding GovAction (ConwayEra StandardCrypto).
       CBOR failed with error: DeserialiseFailure 41 "CMTooFewParamsError {cmTooFewExpected = 175, cmTooFewActual = 1}"
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
