### PR TITLE
Committee query - implement  next epoch change

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Moved `ToExpr` instances out of the main library and into the testlib.
 * Changed the type of ConwayPParam's fields  cppEMax,  cppGovActionLifetime, cppDRepActivity
 * Changed types of lenses: `ppGovActionLifetimeL`, `ppDRepActivityL`, `ppCommitteeMaxTermLengthL` and `ppuGovActionLifetimeL`, `ppuDRepActivityL`, `ppuCommitteeMaxTermLengthL`
+* Implement `getNextEpochCommitteeMembers` in Conway `EraGov`
 
 ## 1.11.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -617,10 +617,9 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
 
   getConstitution g = Just $ g ^. cgEnactStateL . ensConstitutionL
 
-  getCommitteeMembers g =
-    case g ^. cgEnactStateL . ensCommitteeL of
-      SJust Committee {..} -> Just (committeeMembers, committeeQuorum)
-      SNothing -> Nothing
+  getCommitteeMembers g = ensCommitteeMembers (g ^. cgEnactStateL)
+
+  getNextEpochCommitteeMembers g = ensCommitteeMembers (getRatifyState g ^. rsEnactStateL)
 
   curPParamsGovStateL = curPParamsConwayGovStateL
 
@@ -635,6 +634,13 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
       }
 
   getDRepDistr govst = psDRepDistr . fst $ finishDRepPulser (govst ^. drepPulsingStateGovStateL)
+
+ensCommitteeMembers ::
+  EnactState era ->
+  Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
+ensCommitteeMembers ens = case ens ^. ensCommitteeL of
+  SJust Committee {..} -> Just (committeeMembers, committeeQuorum)
+  SNothing -> Nothing
 
 class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -40,6 +40,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
   logAcceptedRatio,
   canGovActionBeDRepAccepted,
   logRatificationChecks,
+  resignCommitteeColdKey,
   registerCommitteeHotKey,
   logCurPParams,
 ) where
@@ -117,6 +118,7 @@ import Cardano.Ledger.Conway.TxCert (
   Delegatee (..),
   pattern AuthCommitteeHotKeyTxCert,
   pattern RegDRepTxCert,
+  pattern ResignCommitteeColdTxCert,
  )
 import Cardano.Ledger.Core (EraRule)
 import Cardano.Ledger.Credential (Credential (..))
@@ -646,6 +648,18 @@ registerCommitteeHotKey coldKey = do
         & bodyTxL . certsTxBodyL
           .~ SSeq.singleton (AuthCommitteeHotKeyTxCert (KeyHashObj coldKey) (KeyHashObj hotKey))
   pure hotKey
+
+-- | Submits a transaction that resigns the cold key
+resignCommitteeColdKey ::
+  (ShelleyEraImp era, ConwayEraTxCert era) =>
+  KeyHash 'ColdCommitteeRole (EraCrypto era) ->
+  ImpTestM era ()
+resignCommitteeColdKey coldKey = do
+  void $
+    submitTx "Resigning cold key" $
+      mkBasicTx mkBasicTxBody
+        & bodyTxL . certsTxBodyL
+          .~ SSeq.singleton (ResignCommitteeColdTxCert (KeyHashObj coldKey) SNothing)
 
 logCurPParams :: (EraGov era, ToExpr (PParamsHKD Identity era)) => ImpTestM era ()
 logCurPParams = do

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Add `runImpTestM`, `runImpTestM_`, `evalImpTestM` and `execImpTestM`
 * Add instance `Example (a -> ImpTestM era ())`, which allows use of `Arbitrary`
+* Add `getNextEpochCommitteeMembers` to `EraGov` typeclass, with a default empty implementation
 
 ## 1.8.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -101,6 +101,10 @@ class
     GovState era -> Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
   getCommitteeMembers = const Nothing
 
+  getNextEpochCommitteeMembers ::
+    GovState era -> Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
+  getNextEpochCommitteeMembers = const Nothing
+
   -- | Lens for accessing current protocol parameters
   curPParamsGovStateL :: Lens' (GovState era) (PParams era)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -8,6 +8,7 @@
   `ppuCommitteeMaxTermLengthL`
 * Move all `ToExpr` instances into `testlib`s.
 * Introduce `ToBeExpired` data constructor to `NextEpochChange`
+* Introduce `TermAdjusted` data constructor to `NextEpochChange`
 
 ## 1.7.0.1
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -7,6 +7,7 @@
   `ppCommitteeMaxTermLengthL`, `ppuGovActionLifetimeL`, `ppuDRepActivityL` and
   `ppuCommitteeMaxTermLengthL`
 * Move all `ToExpr` instances into `testlib`s.
+* Introduce `ToBeExpired` data constructor to `NextEpochChange`
 
 ## 1.7.0.1
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -109,6 +109,7 @@ test-suite cardano-ledger-api-test
         base,
         bytestring,
         cardano-ledger-api,
+        data-default-class,
         testlib,
         cardano-ledger-binary,
         cardano-ledger-babbage:testlib,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -97,6 +97,7 @@ test-suite cardano-ledger-api-test
     other-modules:
         Test.Cardano.Ledger.Api.Tx.Out
         Test.Cardano.Ledger.Api.Tx.Body
+        Test.Cardano.Ledger.Api.State.Imp.QuerySpec
         Test.Cardano.Ledger.Api.State.QuerySpec
 
     default-language: Haskell2010
@@ -118,4 +119,5 @@ test-suite cardano-ledger-api-test
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-strict-containers,
         containers,
-        microlens
+        microlens,
+        microlens-mtl

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -69,6 +69,7 @@ import Cardano.Ledger.UMap (
 import Control.Monad (guard)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (&), (<&>), (^.))
@@ -219,10 +220,13 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes = do
       nextEpochChange ck
         | not inCurrent && inNext = ToBeEnacted
         | not inNext = ToBeRemoved
+        | expiring = ToBeExpired
         | otherwise = NoChangeExpected
         where
-          inCurrent = Map.member ck comMembers
+          lookupCurrent = Map.lookup ck comMembers
+          inCurrent = isJust lookupCurrent
           inNext = Set.member ck nextComMembers
+          expiring = maybe False (== currentEpoch) lookupCurrent
 
   pure
     CommitteeMembersState

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
@@ -80,6 +80,7 @@ data NextEpochChange
   | -- | Member will be removed
     ToBeRemoved
   | NoChangeExpected
+  | ToBeExpired
   deriving (Show, Eq, Enum, Bounded, Generic, Ord, ToJSON)
 
 instance EncCBOR NextEpochChange where

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
@@ -81,13 +81,27 @@ data NextEpochChange
     ToBeRemoved
   | NoChangeExpected
   | ToBeExpired
-  deriving (Show, Eq, Enum, Bounded, Generic, Ord, ToJSON)
+  | TermAdjusted EpochNo
+  deriving (Show, Eq, Generic, Ord, ToJSON)
 
 instance EncCBOR NextEpochChange where
-  encCBOR = encodeEnum
+  encCBOR =
+    encode . \case
+      ToBeEnacted -> Sum ToBeEnacted 0
+      ToBeRemoved -> Sum ToBeRemoved 1
+      NoChangeExpected -> Sum NoChangeExpected 2
+      ToBeExpired -> Sum ToBeExpired 3
+      TermAdjusted e -> Sum TermAdjusted 4 !> To e
 
 instance DecCBOR NextEpochChange where
-  decCBOR = decodeEnumBounded
+  decCBOR =
+    decode $ Summands "NextEpochChange" $ \case
+      0 -> SumD ToBeEnacted
+      1 -> SumD ToBeRemoved
+      2 -> SumD NoChangeExpected
+      3 -> SumD ToBeExpired
+      4 -> SumD TermAdjusted <! From
+      k -> Invalid k
 
 data CommitteeMemberState c = CommitteeMemberState
   { cmsHotCredAuthStatus :: !(HotCredAuthStatus c)

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -1,0 +1,262 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Api.State.Imp.QuerySpec where
+
+import Cardano.Ledger.Api.State.Query (
+  CommitteeMemberState (..),
+  CommitteeMembersState (..),
+  HotCredAuthStatus (..),
+  MemberStatus (..),
+  NextEpochChange (..),
+  queryCommitteeMembersState,
+ )
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin (Coin (Coin))
+import Cardano.Ledger.Conway.Governance (
+  Committee (..),
+  ConwayGovState,
+  EraGov (..),
+  GovAction (..),
+  GovActionPurpose (..),
+  PrevGovActionId (..),
+  Voter (DRepVoter),
+  cgEnactStateL,
+  ensCommitteeL,
+ )
+import Cardano.Ledger.Conway.PParams (
+  dvtCommitteeNoConfidence,
+  dvtCommitteeNormal,
+  dvtUpdateToConstitution,
+  ppCommitteeMaxTermLengthL,
+  ppDRepVotingThresholdsL,
+  ppGovActionDepositL,
+  ppGovActionLifetimeL,
+ )
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (KeyHashObj))
+import Cardano.Ledger.Keys (
+  KeyHash,
+  KeyRole (..),
+ )
+import Cardano.Ledger.Shelley.LedgerState
+import Data.Default.Class (Default (..))
+import Data.Foldable (Foldable (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Lens.Micro ((&), (.~))
+import Lens.Micro.Mtl
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
+import Test.Cardano.Ledger.Imp.Common
+
+spec ::
+  forall era.
+  ( HasCallStack
+  , ConwayEraImp era
+  , GovState era ~ ConwayGovState era
+  ) =>
+  SpecWith (ImpTestState era)
+spec =
+  it "Committee queries" $ do
+    setPParams
+    drep <- setupSingleDRep
+    c1 <- freshKeyHash
+    c2 <- freshKeyHash
+    c3 <- freshKeyHash
+    c4 <- freshKeyHash
+    c5 <- freshKeyHash
+    c6 <- freshKeyHash
+    c7 <- freshKeyHash
+    c8 <- freshKeyHash
+    let newMembers =
+          Map.fromList
+            [ (c1, EpochNo 12)
+            , (c2, EpochNo 1)
+            , (c3, EpochNo 11)
+            , (c4, EpochNo 2)
+            ]
+    ga1 <-
+      electCommittee
+        SNothing
+        drep
+        Set.empty
+        newMembers
+
+    expectMembers Set.empty
+    expectNoFilterQueryResult Nothing
+    passEpoch >> passEpoch
+    expectMembers $ Map.keysSet newMembers
+    expectNoFilterQueryResult $
+      Just $
+        Map.fromList
+          [ (c1, CommitteeMemberState MemberNotAuthorized Active (Just 12) NoChangeExpected)
+          , (c2, CommitteeMemberState MemberNotAuthorized Expired (Just 1) NoChangeExpected)
+          , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 11) NoChangeExpected)
+          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 2) NoChangeExpected)
+          ]
+    hk1 <- registerCommitteeHotKey c1
+    hk2 <- registerCommitteeHotKey c2
+    expectNoFilterQueryResult $
+      Just $
+        Map.fromList
+          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 1) NoChangeExpected)
+          , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 11) NoChangeExpected)
+          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 2) NoChangeExpected)
+          ]
+    expectQueryResult
+      (Set.fromList [c2, c3, c5])
+      mempty
+      (Set.fromList [Active, Unrecognized])
+      ( Just $
+          Map.singleton c3 (CommitteeMemberState MemberNotAuthorized Active (Just 11) NoChangeExpected)
+      )
+
+    _ <- resignCommitteeColdKey c3
+    hk5 <- registerCommitteeHotKey c5
+    passTick
+    expectNoFilterQueryResult $
+      Just $
+        Map.fromList
+          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 1) NoChangeExpected)
+          , (c3, CommitteeMemberState MemberResigned Active (Just 11) NoChangeExpected)
+          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 2) NoChangeExpected)
+          , (c5, CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+          ]
+    expectQueryResult
+      (Set.fromList [c2, c3, c5])
+      (Set.singleton hk5)
+      (Set.fromList [Active, Unrecognized])
+      ( Just $
+          Map.singleton c5 (CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+      )
+
+    _ <-
+      electCommittee -- elect new committee to be: c1, c4, c6, c7
+        (SJust ga1)
+        drep
+        (Set.fromList [c2, c3])
+        ( Map.fromList
+            [ (c6, EpochNo 10)
+            , (c7, EpochNo 10)
+            ]
+        )
+    passEpoch
+    hk6 <- registerCommitteeHotKey c6
+    hk8 <- registerCommitteeHotKey c8
+
+    expectMembers $ Set.fromList [c1, c2, c3, c4]
+    expectNoFilterQueryResult $
+      Just $
+        Map.fromList
+          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 1) ToBeRemoved)
+          , (c3, CommitteeMemberState MemberResigned Active (Just 11) ToBeRemoved)
+          , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 2) NoChangeExpected)
+          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Unrecognized Nothing ToBeEnacted)
+          , (c7, CommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
+          , (c8, CommitteeMemberState (MemberAuthorized (KeyHashObj hk8)) Unrecognized Nothing ToBeRemoved)
+          ]
+    expectQueryResult
+      (Set.fromList [c2])
+      (Set.singleton hk2)
+      (Set.fromList [Expired])
+      ( Just $
+          Map.singleton c2 (CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 1) ToBeRemoved)
+      )
+
+    passEpoch
+    expectMembers $ Set.fromList [c1, c4, c6, c7]
+    expectNoFilterQueryResult $
+      Just $
+        Map.fromList
+          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+          , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 2) NoChangeExpected)
+          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 10) NoChangeExpected)
+          , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 10) NoChangeExpected)
+          ]
+    expectQueryResult
+      Set.empty
+      Set.empty
+      (Set.fromList [Unrecognized])
+      (Just Map.empty)
+  where
+    expectMembers ::
+      HasCallStack => Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) -> ImpTestM era ()
+    expectMembers expKhs = do
+      committee <-
+        getsNES $
+          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+      let members = Map.keysSet $ foldMap' committeeMembers committee
+      impAnn "Expecting committee members" $ members `shouldBe` Set.map KeyHashObj expKhs
+
+    expectQueryResult ::
+      HasCallStack =>
+      Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) ->
+      Set.Set (KeyHash 'HotCommitteeRole (EraCrypto era)) ->
+      Set.Set MemberStatus ->
+      Maybe (Map.Map (KeyHash 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
+      ImpTestM era ()
+    expectQueryResult ckFilter hkFilter statusFilter expResult = do
+      nes <- use impNESL
+      let res =
+            queryCommitteeMembersState
+              (Set.map KeyHashObj ckFilter)
+              (Set.map KeyHashObj hkFilter)
+              statusFilter
+              nes
+      impAnn "Expecting query result" $
+        csCommittee <$> res `shouldBe` Map.mapKeys KeyHashObj <$> expResult
+
+    expectNoFilterQueryResult ::
+      HasCallStack =>
+      Maybe (Map.Map (KeyHash 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
+      ImpTestM era ()
+    expectNoFilterQueryResult =
+      expectQueryResult mempty mempty mempty
+
+electCommittee ::
+  forall era.
+  ( HasCallStack
+  , ConwayEraImp era
+  ) =>
+  StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)) ->
+  KeyHash 'DRepRole (EraCrypto era) ->
+  Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) ->
+  Map.Map (KeyHash 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
+  ImpTestM era (PrevGovActionId 'CommitteePurpose (EraCrypto era))
+electCommittee prevGovId drep toRemove toAdd = do
+  let
+    committeeAction =
+      UpdateCommittee
+        prevGovId
+        (Set.map KeyHashObj toRemove)
+        (Map.mapKeys KeyHashObj toAdd)
+        (1 %! 2)
+  gaidCommitteeProp <- submitGovAction committeeAction
+  submitYesVote_ (DRepVoter $ KeyHashObj drep) gaidCommitteeProp
+  pure (PrevGovActionId gaidCommitteeProp)
+
+setPParams ::
+  forall era.
+  ( HasCallStack
+  , ConwayEraImp era
+  ) =>
+  ImpTestM era ()
+setPParams = do
+  modifyPParams $ \pp ->
+    pp
+      & ppDRepVotingThresholdsL
+        .~ def
+          { dvtCommitteeNormal = 1 %! 1
+          , dvtCommitteeNoConfidence = 1 %! 2
+          , dvtUpdateToConstitution = 1 %! 2
+          }
+      & ppCommitteeMaxTermLengthL .~ 10
+      & ppGovActionLifetimeL .~ 2
+      & ppGovActionDepositL .~ Coin 123

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -73,12 +73,11 @@ spec =
     c7 <- freshKeyHash
     c8 <- freshKeyHash
     let newMembers =
-          Map.fromList
-            [ (c1, EpochNo 12)
-            , (c2, EpochNo 2)
-            , (c3, EpochNo 7)
-            , (c4, EpochNo 5)
-            ]
+          [ (c1, EpochNo 12)
+          , (c2, EpochNo 2)
+          , (c3, EpochNo 7)
+          , (c4, EpochNo 5)
+          ]
     ga1 <-
       electCommittee
         SNothing
@@ -92,33 +91,30 @@ spec =
     expectMembers $ Map.keysSet newMembers
     -- members for which the expiration epoch is the current epoch are `ToBeExpired`
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState MemberNotAuthorized Active (Just 12) NoChangeExpected)
-          , (c2, CommitteeMemberState MemberNotAuthorized Active (Just 2) ToBeExpired)
-          , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
-          ]
+      Just
+        [ (c1, CommitteeMemberState MemberNotAuthorized Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState MemberNotAuthorized Active (Just 2) ToBeExpired)
+        , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
+        ]
     -- hot cred status of members with registered hot keys becomes `MemberAuthorized`
     hk1 <- registerCommitteeHotKey c1
     hk2 <- registerCommitteeHotKey c2
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
-          , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+        , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
+        ]
     expectQueryResult
-      (Set.fromList [c2, c3, c5])
+      [c2, c3, c5]
       mempty
-      (Set.fromList [Active, Unrecognized])
-      ( Just $
-          Map.fromList
-            [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-            , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
-            ]
+      [Active, Unrecognized]
+      ( Just
+          [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
+          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+          ]
       )
 
     _ <- resignCommitteeColdKey c3
@@ -128,92 +124,90 @@ spec =
     -- registering a hot key for a credential that's not part of the committee will yield `Unrecognized` member status
     -- and expected change of `ToBeRemoved`
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
-          , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
-          , (c5, CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+        , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
+        , (c5, CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+        ]
     expectQueryResult
-      (Set.fromList [c2, c3, c5])
-      (Set.singleton hk5)
-      (Set.fromList [Unrecognized])
+      [c2, c3, c5]
+      [hk5]
+      [Unrecognized]
       ( Just $
-          Map.singleton c5 (CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+          Map.singleton
+            c5
+            (CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
       )
 
     passEpoch -- epoch 3
     -- the `Unrecognized` member gets removed from the query result
     -- the member which in the previous epoch was expected `ToBeEpired`, has now MemberStatus `Expired` and `NoChangeExpected`
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) NoChangeExpected)
-          , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) NoChangeExpected)
+        , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
+        ]
 
     -- elect new committee to be: c1 (term extended ), c3 (no changes), c4 (term shortened, expiring next epoch), c6, c7 (new)
     ga2 <-
       electCommittee
         (SJust ga1)
         drep
-        (Set.fromList [c2])
-        ( Map.fromList
-            [ (c1, 13)
-            , (c4, 4)
-            , (c6, 6)
-            , (c7, 7)
-            ]
-        )
+        [c2]
+        [ (c1, 13)
+        , (c4, 4)
+        , (c6, 6)
+        , (c7, 7)
+        ]
     passEpoch -- epoch 4
     hk6 <- registerCommitteeHotKey c6
     hk8 <- registerCommitteeHotKey c8
 
     -- in the next epoch after the election, the old committee is still in place
-    expectMembers $ Set.fromList [c1, c2, c3, c4]
+    expectMembers [c1, c2, c3, c4]
     -- members that are not be part of the next committee are `ToBeRemoved`
     -- members that are part of both current and next committee have `NoChangeExpected` or `TermAdjusted`
     -- members that part of only next committee are `ToBeEnacted`
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) (TermAdjusted 13))
-          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
-          , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
-          , -- though its term was adjusted, `ToBeExpired` takes precedence
-            (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) ToBeExpired)
-          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Unrecognized Nothing ToBeEnacted)
-          , (c7, CommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
-          , (c8, CommitteeMemberState (MemberAuthorized (KeyHashObj hk8)) Unrecognized Nothing ToBeRemoved)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) (TermAdjusted 13))
+        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
+        , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+        , -- though its term was adjusted, `ToBeExpired` takes precedence
+          (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) ToBeExpired)
+        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Unrecognized Nothing ToBeEnacted)
+        , (c7, CommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
+        , (c8, CommitteeMemberState (MemberAuthorized (KeyHashObj hk8)) Unrecognized Nothing ToBeRemoved)
+        ]
     expectQueryResult
-      (Set.fromList [c2])
-      (Set.singleton hk2)
-      (Set.fromList [Expired])
+      [c2]
+      [hk2]
+      [Expired]
       ( Just $
-          Map.singleton c2 (CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
+          Map.singleton
+            c2
+            (CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
       )
 
     passEpoch >> passEpoch -- epoch 6
     -- the new committee is in place with the adjusted terms
-    expectMembers $ Set.fromList [c1, c3, c4, c6, c7]
+    expectMembers [c1, c3, c4, c6, c7]
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) NoChangeExpected)
-          , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) NoChangeExpected)
-          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 6) ToBeExpired)
-          , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) NoChangeExpected)
+        , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) NoChangeExpected)
+        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 6) ToBeExpired)
+        , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
+        ]
     expectQueryResult
       Set.empty
       Set.empty
-      (Set.fromList [Unrecognized])
+      [Unrecognized]
       (Just Map.empty)
 
     -- elect new committee to be:
@@ -225,34 +219,30 @@ spec =
       electCommittee
         (SJust ga2)
         drep
-        (Set.fromList [c1])
-        ( Map.fromList
-            [ (c3, 9)
-            , (c4, 9)
-            , (c6, 9)
-            ]
-        )
+        [c1]
+        [ (c3, 9)
+        , (c4, 9)
+        , (c6, 9)
+        ]
     passEpoch -- epoch 7
     -- members whose term changed have next epoch change `TermAdjusted`
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) ToBeRemoved)
-          , (c3, CommitteeMemberState MemberResigned Active (Just 7) (TermAdjusted 9))
-          , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) (TermAdjusted 9))
-          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Expired (Just 6) (TermAdjusted 9))
-          , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) ToBeExpired)
-          ]
+      Just
+        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) ToBeRemoved)
+        , (c3, CommitteeMemberState MemberResigned Active (Just 7) (TermAdjusted 9))
+        , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) (TermAdjusted 9))
+        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Expired (Just 6) (TermAdjusted 9))
+        , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) ToBeExpired)
+        ]
     passEpoch -- epoch 8
-    expectMembers $ Set.fromList [c3, c4, c6, c7]
+    expectMembers [c3, c4, c6, c7]
     expectNoFilterQueryResult $
-      Just $
-        Map.fromList
-          [ (c3, CommitteeMemberState MemberResigned Active (Just 9) NoChangeExpected)
-          , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 9) NoChangeExpected)
-          , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 9) NoChangeExpected)
-          , (c7, CommitteeMemberState MemberNotAuthorized Expired (Just 7) NoChangeExpected)
-          ]
+      Just
+        [ (c3, CommitteeMemberState MemberResigned Active (Just 9) NoChangeExpected)
+        , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 9) NoChangeExpected)
+        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 9) NoChangeExpected)
+        , (c7, CommitteeMemberState MemberNotAuthorized Expired (Just 7) NoChangeExpected)
+        ]
   where
     expectMembers ::
       HasCallStack => Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) -> ImpTestM era ()

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -13,18 +13,29 @@ import Cardano.Ledger.Api.State.Query (
   CommitteeMembersState (..),
   HotCredAuthStatus (..),
   MemberStatus (..),
+  NextEpochChange (..),
   filterStakePoolDelegsAndRewards,
   queryCommitteeMembersState,
  )
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.Governance (
+  Committee (..),
+  ConwayEraGov,
+  DRepPulsingState (..),
+  RatifyState (..),
+  ensCommitteeL,
+  newEpochStateDRepPulsingStateL,
+  rsEnactStateL,
+ )
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.UMap (UMap)
+import Data.Default.Class (Default (..))
 import Data.Foldable (foldMap')
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust, isNothing)
@@ -51,8 +62,8 @@ spec = do
 
 committeeMembersStateSpec ::
   forall era.
-  ( EraTxOut era
-  , EraGov era
+  ( ConwayEraGov era
+  , EraTxOut era
   , Arbitrary (PParams era)
   , Arbitrary (TxOut era)
   , Arbitrary (Value era)
@@ -65,27 +76,34 @@ committeeMembersStateSpec =
   prop "CommitteeMembersState Query" $ \nes' ckFilter' hkFilter' statusFilter -> do
     case committeeInfo nes' of
       Nothing -> property ()
-      Just (comMembers, _, comStateMembers) -> do
-        -- replace some arbitrary number of cold keys from the committeeState with the
-        -- ones from the committee so we can have Active members
-        forAll (genCommonMembers comMembers comStateMembers) $ \newCommitteeState ->
-          let nes :: NewEpochState era
-              nes =
-                nes'
-                  & nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-                    .~ newCommitteeState
-           in -- replace some cold and hot keys from the filter with known ones from both
-              -- committee and committeeState
-              forAll (genRelevantColdCredsFilter ckFilter' comMembers comStateMembers) $ \ckFilter ->
-                forAll (genRelevantHotCredsFilter hkFilter' comStateMembers) $ \hkFilter -> do
-                  propEmpty nes
-                  propComplete nes
-                  propAuthorized nes
-                  propActiveAuthorized nes
-                  propNotAuthorized nes
-                  propResigned nes
-                  propUnrecognized nes
-                  propFilters ckFilter hkFilter statusFilter nes
+      Just (committee, _, _) -> do
+        -- half of the committee members in the next epoch will overlap with the current ones
+        forAll (genNextCommittee @era committee) $ \nextCommittee ->
+          -- replace some arbitrary number of cold keys from the committeeState with the
+          -- ones from the committee so we can have Active members
+          forAll (genRelevantCommitteeState @era committee nextCommittee) $ \committeeState ->
+            let nes =
+                  nes'
+                    & nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
+                      .~ committeeState
+                    & newEpochStateDRepPulsingStateL .~ DRComplete def nextRatifyState
+                nextRatifyState =
+                  (def @(RatifyState era))
+                    & rsEnactStateL . ensCommitteeL .~ maybeToStrictMaybe nextCommittee
+             in -- replace some cold and hot keys from the filter with known ones from both
+                -- committee and committeeState
+                forAll (genRelevantColdCredsFilter ckFilter' committee committeeState) $ \ckFilter ->
+                  forAll (genRelevantHotCredsFilter hkFilter' committeeState) $ \hkFilter -> do
+                    propEmpty nes
+                    propComplete nes
+                    propAuthorized nes
+                    propActiveAuthorized nes
+                    propNotAuthorized nes
+                    propResigned nes
+                    propUnrecognized nes
+                    propNextEpoch nes
+                    propNoExpiration nes
+                    propFilters ckFilter hkFilter statusFilter nes
 
 propEmpty ::
   forall era.
@@ -93,9 +111,10 @@ propEmpty ::
   NewEpochState era ->
   Expectation
 propEmpty nes = do
-  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
-    Map.null (csCommittee noFilterResult)
-      `shouldBe` (Map.null comMembers && Map.null comStateMembers)
+  withCommitteeInfo nes $
+    \(Committee comMembers _) (CommitteeState comStateMembers) nextComMembers noFilterResult -> do
+      Map.null (csCommittee noFilterResult)
+        `shouldBe` (Map.null comMembers && Map.null comStateMembers && Map.null nextComMembers)
 
 propComplete ::
   forall era.
@@ -103,12 +122,12 @@ propComplete ::
   NewEpochState era ->
   Expectation
 propComplete nes = do
-  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
-    -- if a credential appears in either Committee or CommitteeState, it should appear
-    -- in the result
-    Map.keysSet comMembers
-      `Set.union` Map.keysSet comStateMembers
-      `shouldBe` Map.keysSet (csCommittee noFilterResult)
+  withCommitteeInfo nes $
+    \(Committee comMembers _) (CommitteeState comStateMembers) nextComMembers noFilterResult -> do
+      -- if a credential appears in either Committee or CommitteeState, it should appear
+      -- in the result
+      Set.unions [Map.keysSet comMembers, Map.keysSet nextComMembers, Map.keysSet comStateMembers]
+        `shouldBe` Map.keysSet (csCommittee noFilterResult)
 
 propNotAuthorized ::
   forall era.
@@ -116,16 +135,17 @@ propNotAuthorized ::
   NewEpochState era ->
   Expectation
 propNotAuthorized nes = do
-  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
-    let notAuthorized =
-          Map.filter
-            ( \case
-                CommitteeMemberState MemberNotAuthorized _ _ _ -> True
-                _ -> False
-            )
-            (csCommittee noFilterResult)
-    -- if the member is NotAuthorized, it should not have an associated hot credential in the committeeState
-    Map.intersection comStateMembers notAuthorized `shouldBe` Map.empty
+  withCommitteeInfo nes $
+    \_ (CommitteeState comStateMembers) _ noFilterResult -> do
+      let notAuthorized =
+            Map.filter
+              ( \case
+                  CommitteeMemberState MemberNotAuthorized _ _ _ -> True
+                  _ -> False
+              )
+              (csCommittee noFilterResult)
+      -- if the member is NotAuthorized, it should not have an associated hot credential in the committeeState
+      Map.intersection comStateMembers notAuthorized `shouldBe` Map.empty
 
 propAuthorized ::
   forall era.
@@ -133,17 +153,17 @@ propAuthorized ::
   NewEpochState era ->
   Expectation
 propAuthorized nes = do
-  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
-    let ckHk =
-          Map.foldMapWithKey
-            ( \ck cms ->
-                case cms of
-                  CommitteeMemberState (MemberAuthorized hk) _ _ _ -> [(ck, Just hk)]
-                  _ -> []
-            )
-            (csCommittee noFilterResult)
-    -- if the member is Authorized, it should appear in the commiteeState
-    Map.filter isJust comStateMembers `shouldBe` Map.fromList ckHk
+  withCommitteeInfo nes $
+    \_ (CommitteeState comStateMembers) _ noFilterResult -> do
+      let ckHk =
+            Map.mapMaybe
+              ( \case
+                  CommitteeMemberState (MemberAuthorized hk) _ _ _ -> Just hk
+                  _ -> Nothing
+              )
+              (csCommittee noFilterResult)
+      -- if the member is Authorized, it should appear in the commiteeState
+      Map.mapMaybe id comStateMembers `shouldBe` ckHk
 
 propResigned ::
   forall era.
@@ -151,16 +171,17 @@ propResigned ::
   NewEpochState era ->
   Expectation
 propResigned nes = do
-  withCommitteeInfo nes $ \_comMembers _ comStateMembers noFilterResult -> do
-    let resigned =
-          Map.filter
-            ( \case
-                CommitteeMemberState MemberResigned _ _ _ -> True
-                _ -> False
-            )
-            (csCommittee noFilterResult)
-    -- if the member is Resignd, it should appear in the commiteeState as Nothing
-    Map.keysSet (Map.filter isNothing comStateMembers) `shouldBe` Map.keysSet resigned
+  withCommitteeInfo nes $
+    \_ (CommitteeState comStateMembers) _ noFilterResult -> do
+      let resigned =
+            Map.filter
+              ( \case
+                  CommitteeMemberState MemberResigned _ _ _ -> True
+                  _ -> False
+              )
+              (csCommittee noFilterResult)
+      -- if the member is Resignd, it should appear in the commiteeState as Nothing
+      Map.keysSet (Map.filter isNothing comStateMembers) `shouldBe` Map.keysSet resigned
 
 propUnrecognized ::
   forall era.
@@ -168,18 +189,28 @@ propUnrecognized ::
   NewEpochState era ->
   Expectation
 propUnrecognized nes = do
-  withCommitteeInfo nes $ \comMembers _ comStateMembers noFilterResult -> do
-    let unrecognized =
-          Map.filter
-            ( \case
-                CommitteeMemberState _ Unrecognized _ _ -> True
-                _ -> False
-            )
-            (csCommittee noFilterResult)
-    -- if the member is Unrecognized, it should not be in the committe, but it should be
-    -- in the committeeState
-    Map.intersection comMembers unrecognized `shouldBe` Map.empty
-    Map.keysSet unrecognized `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
+  withCommitteeInfo nes $
+    \(Committee comMembers _) (CommitteeState comStateMembers) nextComMembers' noFilterResult -> do
+      let unrecognized =
+            Map.filter
+              ( \case
+                  CommitteeMemberState _ Unrecognized _ _ -> True
+                  _ -> False
+              )
+              (csCommittee noFilterResult)
+      let nextComMembers = Map.keysSet nextComMembers'
+      -- if the member is Unrecognized, it should not be in the committe, but it should be
+      -- in the committeeState or in the nextCommittee
+      Map.intersection comMembers unrecognized `shouldBe` Map.empty
+      Map.keysSet unrecognized
+        `shouldSatisfy` (`Set.isSubsetOf` (Map.keysSet comStateMembers `Set.union` nextComMembers))
+      -- all Unrecognized members will be either enacted or removed in the next epoch
+      Set.fromList (cmsNextEpochChange <$> Map.elems unrecognized)
+        `shouldSatisfy` (`Set.isSubsetOf` Set.fromList [ToBeEnacted, ToBeRemoved])
+      Map.keysSet (Map.filter (\x -> cmsNextEpochChange x == ToBeEnacted) unrecognized)
+        `shouldSatisfy` (`Set.isSubsetOf` nextComMembers)
+      Map.keysSet (Map.filter (\x -> cmsNextEpochChange x == ToBeRemoved) unrecognized)
+        `shouldSatisfy` (\s -> Set.null s || not (s `Set.isSubsetOf` nextComMembers))
 
 propActiveAuthorized ::
   forall era.
@@ -187,30 +218,30 @@ propActiveAuthorized ::
   NewEpochState era ->
   Expectation
 propActiveAuthorized nes = do
-  withCommitteeInfo nes $ \comMembers comQuorum comStateMembers noFilterResult -> do
-    let activeAuthorized =
-          Map.fromList $
-            Map.foldMapWithKey
-              ( \ck cms ->
-                  case cms of
-                    CommitteeMemberState (MemberAuthorized hk) Active _ _ -> [(ck, hk)]
-                    _ -> []
+  withCommitteeInfo nes $
+    \(Committee comMembers comQuorum) (CommitteeState comStateMembers) _ noFilterResult -> do
+      let activeAuthorized =
+            Map.mapMaybe
+              ( \case
+                  CommitteeMemberState (MemberAuthorized hk) Active _ _ -> Just hk
+                  _ -> Nothing
               )
               (csCommittee noFilterResult)
-    let epochNo = nes ^. nesELL
-    -- if a member is active and authorized, then it should be:
-    --   - in Committee and not expired
-    --   - in CommitteeState, not empty
-    Map.keysSet activeAuthorized
-      `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comMembers)
-    Map.keysSet activeAuthorized
-      `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
-    Map.intersection comMembers activeAuthorized
-      `shouldSatisfy` all (>= epochNo)
-    Map.intersection comStateMembers activeAuthorized
-      `shouldSatisfy` all isJust
-    csEpochNo noFilterResult `shouldBe` epochNo
-    csQuorum noFilterResult `shouldBe` comQuorum
+      let epochNo = nes ^. nesELL
+
+      -- if a member is active and authorized, then it should be:
+      --   - in Committee and not expired
+      --   - in CommitteeState, not empty
+      Map.keysSet activeAuthorized
+        `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comMembers)
+      Map.keysSet activeAuthorized
+        `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet comStateMembers)
+      Map.intersection comMembers activeAuthorized
+        `shouldSatisfy` all (>= epochNo)
+      Map.intersection comStateMembers activeAuthorized
+        `shouldSatisfy` all isJust
+      csEpochNo noFilterResult `shouldBe` epochNo
+      csQuorum noFilterResult `shouldBe` comQuorum
 
 propFilters ::
   forall era.
@@ -238,39 +269,99 @@ propFilters ckFilter hkFilter statusFilter nes = do
     unless (Set.null statusFilter) $
       result `shouldSatisfy` const (allMemberStatuses `Set.isSubsetOf` statusFilter)
 
-genCommonMembers ::
-  Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
-  Map.Map
-    (Credential 'ColdCommitteeRole (EraCrypto era))
-    (Maybe (Credential 'HotCommitteeRole (EraCrypto era))) ->
+propNextEpoch ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
+propNextEpoch nes = do
+  withCommitteeInfo nes $
+    \(Committee cm _) (CommitteeState comStateMembers') nextComMembers' noFilterResult -> do
+      let comMembers = Map.keysSet cm
+      let comStateMembers = Map.keysSet comStateMembers'
+      let nextComMembers = Map.keysSet nextComMembers'
+
+      filterNext ToBeEnacted noFilterResult
+        `shouldSatisfy` (\res -> Map.keysSet res == nextComMembers `Set.difference` comMembers)
+
+      filterNext ToBeRemoved noFilterResult
+        `shouldSatisfy` (\res -> Map.keysSet res == (comMembers `Set.union` comStateMembers) `Set.difference` nextComMembers)
+
+      filterNext NoChangeExpected noFilterResult
+        `shouldSatisfy` (\res -> Map.keysSet res == (comMembers `Set.intersection` nextComMembers))
+  where
+    filterNext nextEpochChange cms =
+      Map.filter
+        ( \case
+            CommitteeMemberState _ _ _ nextEpochChange' ->
+              nextEpochChange == nextEpochChange'
+        )
+        (csCommittee cms)
+
+propNoExpiration ::
+  forall era.
+  EraGov era =>
+  NewEpochState era ->
+  Expectation
+propNoExpiration nes =
+  withCommitteeInfo nes $
+    \_ _ _ noFilterResult -> do
+      let noExpiration = Map.filter (isNothing . cmsExpiration) (csCommittee noFilterResult)
+      unless (Map.null noExpiration) $
+        -- only Unrecognized members should have no expiration
+        Set.fromList (cmsStatus <$> Map.elems noExpiration) `shouldBe` Set.singleton Unrecognized
+
+genRelevantCommitteeState ::
+  forall era.
+  EraTxOut era =>
+  Committee era ->
+  Maybe (Committee era) ->
   Gen (CommitteeState era)
-genCommonMembers comMembers comStateMembers = do
-  s <- choose (0, Map.size comMembers)
-  let chosen = Map.take s comMembers
+genRelevantCommitteeState (Committee cm _) nextCom = do
+  CommitteeState comStateMembers <- arbitrary @(CommitteeState era)
+  let comMembers = Map.keysSet cm
+  let nextComMembers = Map.keysSet (foldMap' committeeMembers nextCom)
+  let third = Set.size comMembers `div` 3
+  let chosen = Set.toList $ Set.take third comMembers
+  let nextChosen = Set.toList $ Set.take third nextComMembers
   let x =
         Map.fromList $
           zipWith
-            (\(k1, _) (_, v2) -> (k1, v2))
-            (Map.assocs chosen)
+            (\k1 (_, v2) -> (k1, v2))
+            (chosen <> nextChosen)
             (Map.assocs comStateMembers)
-  pure $ CommitteeState $ x `Map.union` (Map.drop s comStateMembers)
+  pure $ CommitteeState $ x `Map.union` Map.drop (length chosen + length nextChosen) comStateMembers
+
+genNextCommittee ::
+  forall era.
+  EraTxOut era =>
+  Committee era ->
+  Gen (Maybe (Committee era))
+genNextCommittee (Committee comMembers _) =
+  oneof [pure Nothing, Just <$> genCom]
+  where
+    genCom = do
+      new <- arbitrary @(Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
+      q <- arbitrary
+      retainSize <- choose (0, Map.size comMembers)
+      pure $ Committee (Map.union new (Map.take retainSize comMembers)) q
 
 genRelevantColdCredsFilter ::
-  Set.Set (Credential 'ColdCommitteeRole c) ->
-  Map.Map (Credential 'ColdCommitteeRole c) EpochNo ->
-  Map.Map (Credential 'ColdCommitteeRole c) (Maybe (Credential 'HotCommitteeRole c)) ->
-  Gen (Set.Set (Credential 'ColdCommitteeRole c))
-genRelevantColdCredsFilter flt comMembers comStateMembers = do
+  Set.Set (Credential 'ColdCommitteeRole (EraCrypto era)) ->
+  Committee era ->
+  CommitteeState era ->
+  Gen (Set.Set (Credential 'ColdCommitteeRole (EraCrypto era)))
+genRelevantColdCredsFilter flt (Committee comMembers _) (CommitteeState comStateMembers) = do
   s <- choose (0, Set.size flt)
   let cm1 = Map.keysSet $ Map.take (s `div` 2) comMembers
   let cm2 = Map.keysSet $ Map.take (s `div` 2) comStateMembers
   pure $ Set.unions [Set.drop s flt, cm1, cm2]
 
 genRelevantHotCredsFilter ::
-  Set.Set (Credential 'HotCommitteeRole c) ->
-  Map.Map (Credential 'ColdCommitteeRole c) (Maybe (Credential 'HotCommitteeRole c)) ->
-  Gen (Set.Set (Credential 'HotCommitteeRole c))
-genRelevantHotCredsFilter flt comStateMembers = do
+  Set.Set (Credential 'HotCommitteeRole (EraCrypto era)) ->
+  CommitteeState era ->
+  Gen (Set.Set (Credential 'HotCommitteeRole (EraCrypto era)))
+genRelevantHotCredsFilter flt (CommitteeState comStateMembers) = do
   s <- choose (0, Set.size flt)
   let cm = Set.fromList $ Map.elems (Map.mapMaybe id (Map.take s comStateMembers))
   pure $ Set.drop s flt `Set.union` cm
@@ -278,11 +369,9 @@ genRelevantHotCredsFilter flt comStateMembers = do
 withCommitteeInfo ::
   EraGov era =>
   NewEpochState era ->
-  ( Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
-    UnitInterval ->
-    Map.Map
-      (Credential 'ColdCommitteeRole (EraCrypto era))
-      (Maybe (Credential 'HotCommitteeRole (EraCrypto era))) ->
+  ( Committee era ->
+    CommitteeState era ->
+    Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo -> -- next epoch committee members
     CommitteeMembersState (EraCrypto era) ->
     Expectation
   ) ->
@@ -290,10 +379,10 @@ withCommitteeInfo ::
 withCommitteeInfo nes expectation =
   case committeeInfo nes of
     Nothing -> queryCommitteeMembersStateNoFilters nes `shouldBe` Nothing
-    Just (comMembers, comQuorum, comStateMembers) ->
+    Just (committee, comState, nextComMembers) ->
       case queryCommitteeMembersStateNoFilters nes of
         Just noFilterQueryResult ->
-          expectation comMembers comQuorum comStateMembers noFilterQueryResult
+          expectation committee comState nextComMembers noFilterQueryResult
         Nothing ->
           expectationFailure "Expected queryCommitteeMembersState to return a Just value"
 
@@ -302,19 +391,21 @@ committeeInfo ::
   EraGov era =>
   NewEpochState era ->
   Maybe
-    ( Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo
-    , UnitInterval
-    , Map.Map
-        (Credential 'ColdCommitteeRole (EraCrypto era))
-        (Maybe (Credential 'HotCommitteeRole (EraCrypto era)))
+    ( Committee era
+    , CommitteeState era
+    , Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo
     )
 committeeInfo nes = do
   (comMembers, comQurum) <-
     getCommitteeMembers (nes ^. nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL)
-  let comStateMembers =
-        csCommitteeCreds $
-          nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-  pure (comMembers, comQurum, comStateMembers)
+  let ledgerState = nes ^. nesEpochStateL . esLStateL
+  let nextCommitteeMembers =
+        maybe
+          Map.empty
+          fst
+          $ getNextEpochCommitteeMembers (ledgerState ^. lsUTxOStateL . utxosGovStateL)
+  let comState = ledgerState ^. lsCertStateL . certVStateL . vsCommitteeStateL
+  pure (Committee comMembers comQurum, comState, nextCommitteeMembers)
 
 queryCommitteeMembersStateNoFilters ::
   forall era. EraGov era => NewEpochState era -> Maybe (CommitteeMembersState (EraCrypto era))

--- a/libs/cardano-ledger-api/test/Tests.hs
+++ b/libs/cardano-ledger-api/test/Tests.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Conway (Conway)
+import qualified Test.Cardano.Ledger.Api.State.Imp.QuerySpec as ImpQuery (spec)
 import qualified Test.Cardano.Ledger.Api.State.QuerySpec as StateQuery (spec)
 import qualified Test.Cardano.Ledger.Api.Tx.Body as TxBody (spec)
 import qualified Test.Cardano.Ledger.Api.Tx.Out as TxOut (spec)
+import Test.Cardano.Ledger.Conway.ImpTest (withImpState)
+
 import Test.Cardano.Ledger.Common
 
 -- ====================================================================================
@@ -15,6 +21,8 @@ apiSpec =
       TxBody.spec
     describe "State" $ do
       StateQuery.spec
+    describe "Imp" $ withImpState @Conway $ do
+      ImpQuery.spec @Conway
 
 main :: IO ()
 main = ledgerTestMain apiSpec


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Closes: https://github.com/input-output-hk/cardano-ledger/issues/3810

I'm not convinced about a few things in this implementation: 
1.  describing members from both current and next epoch committee as `Active`  (with the only difference between them being that the former has `NextEpochChange` either `ToBeRemoved` or `NoChangeExpected`  and the latter `ToBeEnacted`).
In the current acceptance of the Query, `Active`  means not expired, so it is technically compatible with the above, but I think it can be confusing. 
What can we do ? 
* Adding another value to this status, say `ActiveNextEpoch` ? Maybe, but it would kinda mix the categories.  Is it possible for a member from the nextCommittee to be already expired? Then which value would this field take, ActiveNextEpoch or Expired?  
* Another option would be to return only the current committee members, and use the nextEpoch committee members to determine if a member will be removed or no change expected. So `ToBeEnacted` would never appear as a value in this implementation. 
2. members that are Unrecognized (so: they have a hot key in the CommitteeState but no corresponding cold key in either the current committee or the committee in the next epoch), will have the field set to `NoChangeExpected`.  Because what else can it be?  `ToBeRemoved` doesn't really match, since they are not in the committee.  `ToBeEnacted` also no, because they are not in the next committee. 
3. At first I thought that expiration of the committee member should be part of the computation of this field, but I have decided against it, because 
   * the expiration dimension is dealt with in another field , namely MemberStatus
   * expired members are not technically removed from the committee (though their vote doesn't count, in the same way as members without a hot key don't count). 
  So i thought it would be better to keep the two separate. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
