### PR TITLE
Remove generic-monoid dependency

### DIFF
--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-byron
-version:            1.0.0.3
+version:            1.0.0.4
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -347,7 +347,6 @@ test-suite cardano-ledger-byron-test
         directory,
         filepath,
         formatting,
-        generic-monoid,
         heapwords,
         hedgehog >=1.0.4,
         microlens,

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/Block.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Elaboration/Block.hs
@@ -56,7 +56,6 @@ import Data.Bimap (Bimap)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Map as Map
-import Data.Monoid.Generic (GenericMonoid (GenericMonoid), GenericSemigroup (GenericSemigroup))
 import qualified Data.Set as Set
 import Data.Time (Day (ModifiedJulianDay), UTCTime (UTCTime))
 import Lens.Micro (to, (^.), (^..))
@@ -80,9 +79,20 @@ data AbstractToConcreteIdMaps = AbstractToConcreteIdMaps
   { transactionIds :: !(Map Abstract.TxId UTxO.TxId)
   , proposalIds :: !(Map Abstract.Update.UpId Update.UpId)
   }
-  deriving (Eq, Show, Generic)
-  deriving (Semigroup) via GenericSemigroup AbstractToConcreteIdMaps
-  deriving (Monoid) via GenericMonoid AbstractToConcreteIdMaps
+  deriving (Eq, Generic, Show)
+
+instance Monoid AbstractToConcreteIdMaps where
+  mempty = AbstractToConcreteIdMaps mempty mempty
+  mconcat xs =
+    AbstractToConcreteIdMaps
+      (mconcat $ map transactionIds xs)
+      (mconcat $ map proposalIds xs)
+
+instance Semigroup AbstractToConcreteIdMaps where
+  a <> b =
+    AbstractToConcreteIdMaps
+      (transactionIds a <> transactionIds b)
+      (proposalIds a <> proposalIds b)
 
 -- | Elaborate an abstract block into a concrete block (without annotations).
 elaborate ::

--- a/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
+++ b/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
@@ -196,7 +196,6 @@ library
         directory,
         filepath,
         formatting,
-        generic-monoid,
         heapwords,
         hedgehog >=1.0.4,
         microlens,

--- a/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
+++ b/eras/byron/ledger/impl/test/cardano-ledger-byron-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-byron-test
-version:       1.5.0.0
+version:       1.5.0.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
# Description

This package on Hackage has no githib (or similar) repository listed, has no contact email address and does not build with ghc-9.8.

Its only used for a single two element sum type for which a hand written Monoid and Semigroup instances is trivial.

Fixes #3879 

# Checklist

-  [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
