### PR TITLE
Added a test for genTxAndNewEpoch

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -19,6 +19,7 @@ library
     exposed-modules:
         Test.Cardano.Ledger.Alonzo.Tools
         Test.Cardano.Ledger.Constrained.Ast
+        Test.Cardano.Ledger.Constrained.Utils
         Test.Cardano.Ledger.Constrained.Classes
         Test.Cardano.Ledger.Constrained.Combinators
         Test.Cardano.Ledger.Constrained.Env
@@ -114,6 +115,7 @@ library
         cardano-ledger-shelley-ma-test,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
         cardano-slotting,
+        deepseq,
         containers,
         formatting,
         groups,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -18,7 +18,6 @@ import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Lenses (fGenDelegGenKeyHashL, strictMaybeToMaybeL)
 import Test.Cardano.Ledger.Constrained.Monad (generateWithSeed, monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
@@ -28,6 +27,7 @@ import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Size (Size (..), genFromSize)
 import Test.Cardano.Ledger.Constrained.Solver
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 import Test.Cardano.Ledger.Generic.PrettyCore (

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -45,7 +45,6 @@ import Lens.Micro (Lens', lens)
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (generateWithSeed, monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
@@ -54,6 +53,7 @@ import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
 import Test.Cardano.Ledger.Constrained.Rewrite
 import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert)
 import Test.Cardano.Ledger.Generic.Proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -17,7 +17,6 @@ import Data.Ratio ((%))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
@@ -27,6 +26,7 @@ import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Size (Size (..))
 import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.PrettyCore (pcLedgerState)
 import Test.Cardano.Ledger.Generic.Proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
@@ -15,7 +15,6 @@ import Data.Ratio ((%))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.LedgerState (ledgerStateStage)
@@ -25,6 +24,7 @@ import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
 import Test.Cardano.Ledger.Constrained.Rewrite (OrderInfo (..), standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.PrettyCore (pcEpochState, pcNewEpochState)
 import Test.Cardano.Ledger.Generic.Proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
@@ -24,12 +24,12 @@ import Lens.Micro ((^.))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env (Access (..), V (..), emptyEnv)
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
 import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Solver
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Fields
 import Test.Cardano.Ledger.Generic.Functions (protocolVersion)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -84,7 +84,6 @@ import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (checkForSoundness, testIO)
 import Test.Cardano.Ledger.Constrained.Monad (Typed, failT, generateWithSeed, monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.Certs (certsStage)
@@ -122,12 +121,14 @@ import Test.QuickCheck
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
+import Cardano.Ledger.DRep (drepDepositL)
 import qualified Test.Cardano.Ledger.Constrained.Preds.CertState as CertState
 import qualified Test.Cardano.Ledger.Constrained.Preds.Certs as Certs
 import qualified Test.Cardano.Ledger.Constrained.Preds.LedgerState as LedgerState
 import qualified Test.Cardano.Ledger.Constrained.Preds.PParams as PParams
 import qualified Test.Cardano.Ledger.Constrained.Preds.TxOut as TxOut
 import qualified Test.Cardano.Ledger.Constrained.Preds.Universes as Universes
+import Test.Cardano.Ledger.Constrained.Utils (checkForSoundness, testIO)
 
 predsTests :: TestTree
 predsTests =
@@ -554,8 +555,9 @@ txBodyPreds sizes p =
        , tempTx :<-: txTarget tempTxBody tempBootWits tempKeyWits
        , -- Compute the real fee, and then recompute the TxBody and the Tx
          txfee :<-: (Constr "finalFee" computeFinalFee ^$ (pparams p) ^$ tempTx)
-         --  , txbodyterm :<-: txbodyTarget txfee wppHash totalCol
+       , --  , txbodyterm :<-: txbodyTarget txfee wppHash totalCol
          --  , txterm :<-: txTarget txbodyterm bootWits keyWits
+         ProjM drepDepositL CoinR currentDRepState :=: drepDepositsView
        ]
     ++ case whichUTxO p of
       UTxOShelleyToMary ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
@@ -47,7 +47,6 @@ import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes
 import Test.Cardano.Ledger.Constrained.Combinators (genFromMap, itemFromSet)
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.Repl
 import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
@@ -56,6 +55,7 @@ import Test.Cardano.Ledger.Constrained.Rewrite (rewriteGen, standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Size
 import Test.Cardano.Ledger.Constrained.Solver (toolChain, toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..), TxOutField (..))
 import Test.Cardano.Ledger.Generic.PrettyCore (pcData, pcDataHash, pcScript, pcScriptHash, pcTxOut)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -61,13 +61,13 @@ import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes hiding (genTxOut)
 import Test.Cardano.Ledger.Constrained.Combinators (genFromMap, itemFromSet, setSized)
 import Test.Cardano.Ledger.Constrained.Env
-import Test.Cardano.Ledger.Constrained.Examples (testIO)
 import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
 import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
 import Test.Cardano.Ledger.Constrained.Scripts (allPlutusScripts, genCoreScript, spendPlutusScripts)
 import Test.Cardano.Ledger.Constrained.Solver
 import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Utils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Utils.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Test.Cardano.Ledger.Constrained.Utils (
+  testIO,
+  checkForSoundness,
+  explainBad,
+) where
+
+import Cardano.Ledger.Conway.Core (Era)
+import qualified Control.Exception as Exc
+import Control.Monad (void)
+import qualified Data.HashSet as HashSet
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import Test.Cardano.Ledger.Constrained.Ast (Pred, Subst (..), SubstElem (..), makeTest, substToEnv, varsOfPred)
+import Test.Cardano.Ledger.Constrained.Env (Env, Name (..), V (..), emptyEnv)
+import Test.Cardano.Ledger.Constrained.Monad (Typed, monadTyped)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (assertFailure, testCase)
+
+testIO :: String -> IO a -> TestTree
+testIO msg x = testCase msg (Exc.catch (void x) handler)
+  where
+    -- handler :: Exc.ErrorCall -> IO ()
+    handler (Exc.SomeException zs) = assertFailure (unlines [msg, show zs])
+
+checkForSoundness :: Era era => [Pred era] -> Subst era -> Typed (Env era, Maybe String)
+checkForSoundness preds subst = do
+  !env <- monadTyped $ substToEnv subst emptyEnv
+  testTriples <- mapM (makeTest env) preds
+  let bad = filter (\(_, b, _) -> not b) testTriples
+  if null bad
+    then pure (env, Nothing)
+    else pure (env, Just ("Some conditions fail\n" ++ explainBad bad subst))
+
+explainBad :: Era era => [(String, Bool, Pred era)] -> Subst era -> String
+explainBad cs (Subst subst) = unlines (map getString cs) ++ "\n" ++ show restricted
+  where
+    names = List.foldl' varsOfPred HashSet.empty (map getPred cs)
+    restricted = Map.filterWithKey ok subst
+    ok key (SubstElem rep _term access) = HashSet.member (Name (V key rep access)) names
+    getString (s, _, _) = s
+    getPred (_, _, pr) = pr


### PR DESCRIPTION
# Description

Adds a test for `genTxAndNewEpoch` that checks whether the generator successfully generates a value. Moved some functions from `Examples` to `Utils`. 

@TimSheard helped me find and fix the bug and now the test should pass

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
