### PR TITLE
QuickCheck Imp integration

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## 1.9.0.0
 
 * Change the type of `ppEMaxL`
-	
+
+
+### `testlib`
+
+* Add `runImpTestM`, `runImpTestM_`, `evalImpTestM` and `execImpTestM`
 
 ## 1.8.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 * Change the type of `ppEMaxL`
 
-
 ### `testlib`
 
 * Add `runImpTestM`, `runImpTestM_`, `evalImpTestM` and `execImpTestM`
+* Add instance `Example (a -> ImpTestM era ())`, which allows use of `Arbitrary`
 
 ## 1.8.0.0
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -385,6 +385,11 @@ instance Example (ImpTestM era ()) where
 
   evaluateExample impTest = evaluateExample (`evalImpTestM` impTest)
 
+instance (Arbitrary a, Show a) => Example (a -> ImpTestM era ()) where
+  type Arg (a -> ImpTestM era ()) = ImpTestState era
+
+  evaluateExample impTest = evaluateExample (\s -> property $ evalImpTestM s . impTest)
+
 evalImpTestM :: ImpTestState era -> ImpTestM era b -> IO b
 evalImpTestM impState = fmap fst . runImpTestM impState
 


### PR DESCRIPTION
# Description

Changes in this PR allows us to write QuickCheck properties with ImpSpec:

We can either use `Arbitrary` (however only for a single argument, which can be a nested tuple):
```haskell
  it "test1" $ \(foo, blah) -> do
    kh <- freshKeyHash
    show kh `shouldBe` foo
    blah `shouldBe` foo
```
or manually running an `ImpTestM` somewhere inside a regular hspec/quickcheck property
```haskell
  it "test2" $ \impState ->
    forAll arbitrary $ \foo ->
      forAll arbitrary $ \blah ->
        evalImpTestM impState $ do
          kh <- freshKeyHash
          show kh `shouldBe` foo
          blah `shouldBe` foo
```
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
