### PR TITLE
Fix Brute force failure

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -194,7 +194,7 @@ pulserWorks mcsfirst mcslast =
         ++ "\nLast "
         ++ showPulserState mcslast
     )
-    (bruteForceDRepDistr (mcsNes mcsfirst) === extractPulsingDRepDistr (mcsNes mcslast))
+    (bruteForceDRepDistr (mcsTickNes mcsfirst) === extractPulsingDRepDistr (mcsNes mcslast))
 
 bruteForceDRepDistr :: NewEpochState era -> Map.Map (DRep (EraCrypto era)) (CompactForm Coin)
 bruteForceDRepDistr nes = computeDrepDistr umap dreps incstk

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -2211,8 +2211,8 @@ pcDRepPulser x =
   ppRecord
     "DRepPulser"
     [ ("pulseSize", ppInt (dpPulseSize x))
-    , ("umap", uMapSummary (dpUMap x))
-    , ("balance", summaryMapCompact (dpBalance x))
+    , ("DRepUView Map", ppMap pcCredential pcDRep (dRepMap (dpUMap x)))
+    , ("balance", ppMap pcCredential (pcCoin . fromCompact) (dpBalance x))
     , ("stakeDistr", summaryMapCompact (dpStakeDistr x))
     , ("poolDistr", pcPoolDistr (dpStakePoolDistr x))
     , ("partialDrepDistr", summaryMapCompact (dpDRepDistr x))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -262,7 +262,7 @@ adaIsPreservedBabbage numTx gensize = adaIsPreserved (Babbage Mock) numTx gensiz
 
 -- | The incremental Stake invaraint is preserved over a trace of length 100=
 stakeInvariant :: EraTxOut era => MockChainState era -> MockChainState era -> Property
-stakeInvariant (MockChainState _ _ _) (MockChainState nes _ _) =
+stakeInvariant (MockChainState _ _ _ _) (MockChainState nes _ _ _) =
   case (lsUTxOState . esLState . nesEs) nes of
     (UTxOState utxo _ _ _ istake _) -> istake === updateStakeDistribution def mempty mempty utxo
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -194,7 +194,7 @@ initialMockChainState ::
   GenState era ->
   MockChainState era
 initialMockChainState proof gstate =
-  MockChainState newepochstate (getSlot gstate) 0
+  MockChainState newepochstate newepochstate (getSlot gstate) 0
   where
     ledgerstate = initialLedgerState gstate
     newepochstate =
@@ -384,7 +384,7 @@ smartTxBody proof u txbody = ppRecord "TxBody" pairs
 instance STS (MOCKCHAIN era)
   where
   type State (MOCKCHAIN era) = MockChainState era
-  type Signal (MOCKCHAIN era) = (MockBlock era,UTxO era)
+  type Signal (MOCKCHAIN era) = (MockBlock era)
   type Environment (MOCKCHAIN era) = ()
 -}
 -- ==============================================================
@@ -403,7 +403,7 @@ instance
 
   envGen _gstate = pure ()
 
-  sigGen (Gen1 txss gs) () mcs@(MockChainState newepoch (SlotNo lastSlot) count) = do
+  sigGen (Gen1 txss gs) () mcs@(MockChainState newepoch _ (SlotNo lastSlot) count) = do
     let NewEpochState epochnum _ _ epochstate _ pooldistr _ = newepoch
     issuerkey <- chooseIssuer epochnum lastSlot count pooldistr
     let (txs, nextSlotNo) = txss ! count


### PR DESCRIPTION
Fixed broken test, test comparing the brute force DRepDistr computation on the first MockChainState of an epoch to the Pulsed DrepDistr on the final MockhainState of the Epoch. 

This failed because we need the intermediate NES in the first state, since the LEDGERS rule changes the NES after the TICK rule runs. To do this we changed the internals of MockChainState from this
```
data MockChainState era = MockChainState
  { mcsNes :: !(NewEpochState era)
  , mcsLastBlock :: !SlotNo
  , mcsCount :: !Int -- Counts the blocks made
  }
```
to this
```
data MockChainState era = MockChainState
  { mcsNes :: !(NewEpochState era)
  , mcsTickNes ::  !(NewEpochState era)
  , mcsLastBlock :: !SlotNo
  , mcsCount :: !Int -- Counts the blocks made
  }
```

This stores the intermediate NewEpochState, after the TICK rule, but before the LEDGERS rule

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
