### PR TITLE
Fix pvCanFollow usage in Conway and improve clarity in Shelley

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-alonzo-test
-version:       1.1.2.9
+version:       1.1.2.8
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -440,7 +440,7 @@ legalProtVer ::
   Maybe (GovActionId (EraCrypto era), (ProtVer, ProtVer))
 legalProtVer pp pgaids ps gas = do
   (newProtVer, prevProtVer) <- preceedingHardFork (gasAction gas) pp pgaids ps
-  if pvCanFollow newProtVer (SJust prevProtVer)
+  if pvCanFollow prevProtVer newProtVer
     then Nothing
     else Just (gasId gas, (newProtVer, prevProtVer))
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.9.0.0
 
 * Change the type of `ppEMaxL`
+* Change the type of `pvCanFollow` to make sure new protocol version is not optional
+* Add `hasLegalProtVerUpdate`
 
 ### `testlib`
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -124,7 +124,7 @@ library
         nothunks,
         quiet,
         set-algebra >=1.0,
-        small-steps >=1.0,
+        small-steps >=1.0.1,
         cardano-strict-containers,
         text,
         time,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.PParams (
   ProposedPPUpdates (ProposedPPUpdates),
   emptyPPPUpdates,
-  pvCanFollow,
+  hasLegalProtVerUpdate,
  )
 import Control.DeepSeq (NFData)
 import Control.State.Transition (
@@ -130,9 +130,7 @@ updatePpup ppupSt pp =
     & futureProposalsL .~ emptyPPPUpdates
   where
     ProposedPPUpdates newProposals = futureProposals ppupSt
-    goodPV ppu =
-      pvCanFollow (pp ^. ppProtocolVersionL) $ ppu ^. ppuProtocolVersionL
     ps =
-      if all goodPV newProposals
+      if all (hasLegalProtVerUpdate pp) newProposals
         then ProposedPPUpdates newProposals
         else emptyPPPUpdates

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -38,7 +38,6 @@ import Data.Default.Class (Default (def))
 import qualified Data.List as List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe.Strict (StrictMaybe (SJust))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable
@@ -458,7 +457,7 @@ instance Count Int where
   genSucc n = pure (n + 1)
 
 instance Count ProtVer where
-  canFollow succX predX = pvCanFollow predX (SJust succX)
+  canFollow succX predX = pvCanFollow predX succX
   genPred succX@(ProtVer n 0)
     | n == minBound = error ("genPredFromSucc @ProtVer is undefined on " ++ show succX)
   genPred (ProtVer n 0) = ProtVer (pred n) <$> elements [0, 1, 2, 3]

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `small-steps`
 
-## 1.0.0.1
+## 1.0.1.0
 
-*
+* Add `failOnJust`, `failOnNonEmpty`, `failureOnJust`, `failureOnNonEmpty`
 
 ## 1.0.0.0
 

--- a/libs/small-steps/small-steps.cabal
+++ b/libs/small-steps/small-steps.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               small-steps
-version:            1.0.0.0
+version:            1.0.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
# Description

Fix wrong usage of `pvCanFollow` in Conway: fix #3901 and fix #3873
This problem happened because there was no documentation on `pvCanFollow` and names for bindings where totally useless. This proves my belief even further that ticks are not very useful for bindings.

Besides the bug fix this PR also includes:

* Make `pvCanFollow` match the spec and remove the `SNothing` wrapper
  around the newly proposed `ProtVer`
* Reduce duplication by adding `hasLegalProtVerUpdate`
* Add helper functions `failOnJust`, `failOnNonEmpty`, `failureOnJust`,
  `failureOnNonEmpty` to `small-steps`, which allow us to lazily get the
  offending value, without forcing the validation, when validation is
  turned off.
`cardano-ledger-alonzo-test-1.1.2.8` has not been released yet, so the
version bump in https://github.com/input-output-hk/cardano-ledger/pull/3876 was incorrect

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
