### PR TITLE
New ListWhere Pred added to the Constrained Solver.

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
@@ -647,6 +647,7 @@ predConstr SubMap {} = "SubMap"
 predConstr If {} = "If"
 predConstr Before {} = "Before"
 predConstr Oneof {} = "Oneof"
+predConstr ListWhere {} = "ListWhere"
 
 constraintProperty :: Maybe Int -> Bool -> [String] -> OrderInfo -> ([Pred TestEra] -> DependGraph TestEra -> Env TestEra -> Property) -> Property
 constraintProperty timeout strict whitelist info prop =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
@@ -30,7 +30,7 @@ import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (TxF (..))
 import Test.Cardano.Ledger.Constrained.Env (Env, Name, emptyEnv, findVar)
 import Test.Cardano.Ledger.Constrained.Examples (Babbage)
-import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
+import Test.Cardano.Ledger.Constrained.Monad (errorTyped, monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.Repl (goRepl)
 import Test.Cardano.Ledger.Constrained.Preds.Tx (adjustColInput, adjustFeeInput, txBodyPreds)
 import Test.Cardano.Ledger.Constrained.Rewrite (
@@ -218,6 +218,6 @@ genSig proof (_, sub, _) _ledgerEnv = do
   let preds = fmap (substPred sub) (txBodyPreds def proof)
   (env0, _sub, _graph) <- solvePipeline [Stage standardOrderInfo preds]
   env1 <- monadTyped $ adjustFeeInput env0
-  env2 <- monadTyped $ adjustColInput env1
+  env2 <- errorTyped $ adjustColInput env1
   (TxF _ tx) <- monadTyped (findVar (unVar txterm) env2)
   pure tx


### PR DESCRIPTION
Added the ListWhere Pred, and a test that it works.
Often we have some record structure, and we would like to generate a list of that structure
But we want each element in that list, to constrain each record field with some constraints.
```
  [ Sized (ExactSize 10) credsUniv
  , Sized (ExactSize 10) voteUniv
  , ListWhere (Range 2 4) ans (pairT CredR VCredR)
        [ Member (Right (pair1 CredR)) credsUniv, Member (Right (pair2 VCredR)) voteUniv]
  ]
```

Here we want to constrain 'ans', such that for each pair in 'ans', the first component is a subset of the credsUniv and the second component is a subset of the voteUniv.
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
