### PR TITLE
cardano-ledger-conformance: Remove CHANGELOG.md from cabal file

### DIFF
--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -1,14 +1,13 @@
-cabal-version:      3.0
-name:               cardano-ledger-conformance
-version:            0.1.0.0
-license:            Apache-2.0
-maintainer:         operations@iohk.io
-author:             IOHK
-bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
-synopsis:           Testing utilities for conformance testing
-description:        Testing utilities for conformance testing
-build-type:         Simple
-extra-source-files: CHANGELOG.md
+cabal-version: 3.0
+name:          cardano-ledger-conformance
+version:       0.1.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+bug-reports:   https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:      Testing utilities for conformance testing
+description:   Testing utilities for conformance testing
+build-type:    Simple
 
 source-repository head
     type:     git


### PR DESCRIPTION
Currently empty.

# Description

Without this file, this repository cannot be used as a `source-package-repository` because:
```
> cabal build all
HEAD is now at a62edfae6 CI: Add ghc-9.8.1 to the build matrix
Error: cabal: sdist of cardano-ledger-conformance-0.1.0.0: filepath wildcard
'CHANGELOG.md' does not match any files.
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
