### PR TITLE
Use upstream testing instances for very basic types

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-11-15T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-11-24T00:00:00Z
+  , cardano-haskell-packages 2023-11-29T12:13:23Z
 
 packages:
   eras/allegra/impl

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1700750031,
-        "narHash": "sha256-jRCC//vPTBvcHRoLA2xoj0dT3B+7xKcvITox4JHtMOU=",
+        "lastModified": 1701690664,
+        "narHash": "sha256-5vu1lWh3HB0sipkDbEmaasSxrhgMwCmyafiiZMw1bjY=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "1da3413060d7314829bfd533d53f5e4ff39e320e",
+        "rev": "8120918b61283117846973302d9699a9c7e7410f",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -106,7 +106,7 @@ library testlib
         cardano-ledger-binary,
         cardano-prelude-test,
         cardano-strict-containers,
-        cardano-slotting,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
         cborg,
         containers,
         formatting,

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
@@ -23,7 +23,7 @@ import Cardano.Crypto.Util
 import Cardano.Crypto.VRF.Class
 import Cardano.Ledger.Binary.Version
 import Cardano.Slotting.Block (BlockNo (..))
-import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..), WithOrigin (..))
+import Cardano.Slotting.Slot (EpochSize (..), WithOrigin (..))
 import Cardano.Slotting.Time (SystemStart (..))
 import Codec.CBOR.ByteArray (ByteArray (..))
 import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (..))
@@ -50,6 +50,7 @@ import Data.Word
 import GHC.Stack
 import System.Random.Stateful hiding (genByteString, genShortByteString)
 import Test.Cardano.Ledger.Binary.Random (QC (QC))
+import Test.Cardano.Slotting.Arbitrary ()
 import Test.Crypto.Hash ()
 import Test.Crypto.KES ()
 import Test.Crypto.VRF ()
@@ -197,15 +198,11 @@ instance
       genCertVRF :: Gen (CertVRF v)
       genCertVRF = arbitrary
 
-deriving instance Arbitrary SlotNo
-
 instance Arbitrary t => Arbitrary (WithOrigin t) where
   arbitrary = frequency [(20, pure Origin), (80, At <$> arbitrary)]
   shrink = \case
     Origin -> []
     At x -> Origin : map At (shrink x)
-
-deriving instance Arbitrary EpochNo
 
 deriving instance Arbitrary EpochSize
 

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -26,8 +26,6 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Crypto.Hash.Class ()
 import Cardano.Ledger.Binary
-import Cardano.Slotting.Block (BlockNo)
-import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..), WithOrigin (..))
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 import Control.Monad (unless)
@@ -41,6 +39,7 @@ import Data.IP (IPv4, IPv6)
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.TreeDiff
+import Test.Cardano.Slotting.TreeDiff ()
 import Test.Hspec (Expectation, HasCallStack, expectationFailure)
 import Test.Tasty.HUnit (Assertion, assertFailure)
 
@@ -56,16 +55,6 @@ trimExprViaShow _n x = defaultExprViaShow x -- App (take n (drop 1 (show x)) ++ 
 instance ToExpr IPv4
 
 instance ToExpr IPv6
-
-instance ToExpr SlotNo
-
-instance ToExpr BlockNo
-
-instance ToExpr EpochNo
-
-instance ToExpr EpochSize
-
-instance ToExpr x => ToExpr (WithOrigin x)
 
 instance ToExpr (Hash.Hash c index) where
   toExpr = trimExprViaShow 10


### PR DESCRIPTION
# Description

Use Arbitrary and ToExpr from upstream. Enables input-output-hk/ouroboros-consensus#517

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
