### PR TITLE
Removed call to tail, and the 'watchPulser' test

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -161,11 +161,8 @@ drepTree =
   testGroup
     "DRep property traces"
     [ testProperty
-        "Watch pulser on traces of length 120."
-        (withMaxSuccess 2 $ mockChainProp (Conway Standard) 120 (drepCertTxForTrace (Coin 100000)) (stepProp watchPulser))
-    , testProperty
         "All Tx are valid on traces of length 150."
-        (withMaxSuccess 2 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 100000)) (stepProp allValidSignals))
+        (withMaxSuccess 5 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 100000)) (stepProp allValidSignals))
     , testProperty
         "Bruteforce = Pulsed, in every epoch, on traces of length 150"
         (withMaxSuccess 5 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 60000)) (epochProp pulserWorks))
@@ -182,9 +179,6 @@ main = defaultMain drepTree
 
 allValidSignals :: MockChainState era -> MockBlock era -> MockChainState era -> Property
 allValidSignals _state0 (MockBlock _ _ _txs) _stateN = (property True)
-
-watchPulser :: ConwayEraGov era => MockChainState era -> MockBlock era -> MockChainState era -> Property
-watchPulser _state0 (MockBlock _ _ _txs) stateN = trace (showPulserState stateN) (property True)
 
 pulserWorks :: ConwayEraGov era => MockChainState era -> MockChainState era -> Property
 pulserWorks mcsfirst mcslast =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -444,7 +444,9 @@ mockChainProp proof n genTxAndUpdateEnv propf = do
 --   conjoin [p pstate0 sig1 state1, p state0 sig2 state2, p state0 sig3 state3]
 -- test that 'p' holds between state0 and stateN for all N
 stepProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
-stepProp p tr = conjoin (map (\(sig, st) -> p state0 sig st) (tail (zip sigs states)))
+stepProp p tr = case (zip sigs states) of
+  [] -> property True
+  (_ : more) -> conjoin (map (\(sig, st) -> p state0 sig st) more)
   where
     state0 = tr ^. traceInitState
     states = traceStates OldestFirst tr
@@ -454,7 +456,9 @@ stepProp p tr = conjoin (map (\(sig, st) -> p state0 sig st) (tail (zip sigs sta
 --   conjoin [p pstate0 sig1 state1, p state1 sig2 state2, p state2 sig3 state3]
 --   test that 'p' holds bteween (state0 stateN sig(N+1) state(N+1) for all N
 deltaProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
-deltaProp p tr = conjoin (map (\(statei, sig, statej) -> p statei sig statej) (zip3 states sigs (tail states)))
+deltaProp p tr = case states of
+  [] -> property True
+  (_ : more) -> conjoin (map (\(statei, sig, statej) -> p statei sig statej) (zip3 states sigs more))
   where
     states = traceStates OldestFirst tr
     sigs = traceSignals OldestFirst tr

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -444,9 +444,9 @@ mockChainProp proof n genTxAndUpdateEnv propf = do
 --   conjoin [p pstate0 sig1 state1, p state0 sig2 state2, p state0 sig3 state3]
 -- test that 'p' holds between state0 and stateN for all N
 stepProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
-stepProp p tr = case (zip sigs states) of
+stepProp p tr = case zipWith (p state0) sigs states of
   [] -> property True
-  (_ : more) -> conjoin (map (\(sig, st) -> p state0 sig st) more)
+  (_ : more) -> conjoin more
   where
     state0 = tr ^. traceInitState
     states = traceStates OldestFirst tr
@@ -455,10 +455,10 @@ stepProp p tr = case (zip sigs states) of
 -- | Given trace [(sig0,state0),(sig1,state1),(sig2,state2),(sig3,state3)]
 --   conjoin [p pstate0 sig1 state1, p state1 sig2 state2, p state2 sig3 state3]
 --   test that 'p' holds bteween (state0 stateN sig(N+1) state(N+1) for all N
-deltaProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> (Trace (MOCKCHAIN era) -> Property)
+deltaProp :: (MockChainState era -> MockBlock era -> MockChainState era -> Property) -> Trace (MOCKCHAIN era) -> Property
 deltaProp p tr = case states of
   [] -> property True
-  (_ : more) -> conjoin (map (\(statei, sig, statej) -> p statei sig statej) (zip3 states sigs more))
+  _ : more -> conjoin (zipWith3 p states sigs more)
   where
     states = traceStates OldestFirst tr
     sigs = traceSignals OldestFirst tr


### PR DESCRIPTION
The following test causes a failure on Master

TASTY_PATTERN='/Watch pulser on traces of length 120./' cabal test --test-options "--quickcheck-replay=433821"

to make a step test, where we test a property on every (state{n}, state{n+1}) pair in trace we used the following pattern
pairs = zip states (tail states)
But in very rare occasions, when the number of states is 0 or 1,  tail raises the empty List error.
We can easily fix this by pattern matching, and return true when that is the case.

We also removed the '/Watch pulser on traces of length 120./' test, which uses trace and prints too much stuff.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
