### PR TITLE
Add certs to conformance testing

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: 31f592b682171df7d5f395b7dfcbb06421589580
-  --sha256: sha256-yd5Md2OlSj9DN3msLYgV2H6jwUTD4rxSk02ktwQNXiM=
+  tag: ddfb7f4a311dcc52971b3bb847ba52b68d0b0a3f
+  --sha256: sha256-dQVyvzVhVUOsLUuX8XQvN/wPGmbIvYeAmX7RpnT1gk8=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0.0
 
+* Add `getVoteDelegatee`
 * Track and prune unreachable proposals #3855
   * Move `PrevGovActionIds` from `Governance` to `Governance.Proposals`
   * Add `PrevGovActionIdsChildren` to `EnactState`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -26,6 +26,7 @@ module Cardano.Ledger.Conway.TxCert (
   getVKeyWitnessConwayTxCert,
   getDelegateeTxCert,
   getStakePoolDelegatee,
+  getVoteDelegatee,
   conwayDRepDepositsTxCerts,
   conwayDRepRefundsTxCerts,
   conwayTotalDepositsTxCerts,
@@ -353,6 +354,11 @@ getStakePoolDelegatee = \case
   DelegStake targetPool -> Just targetPool
   DelegVote {} -> Nothing
   DelegStakeVote targetPool _ -> Just targetPool
+
+getVoteDelegatee :: Delegatee c -> Maybe (DRep c)
+getVoteDelegatee DelegStake {} = Nothing
+getVoteDelegatee (DelegVote x) = Just x
+getVoteDelegatee (DelegStakeVote _ x) = Just x
 
 instance NFData (Delegatee c)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -68,7 +69,7 @@ import Cardano.Ledger.Shelley.TxBody (WitVKey (..))
 import Cardano.Ledger.Shelley.TxCert (isInstantaneousRewards)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..))
-import Cardano.Ledger.Val (Val ((<+>), (<->)), inject)
+import Cardano.Ledger.Val (Val (..), inject)
 import Control.Monad (when)
 import Control.State.Transition.Extended (STS (..), TRC (..))
 import Data.Default.Class (Default (def))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -105,6 +105,11 @@ data UnivSize = UnivSize
   , usMaxInputs :: Int
   , usMinCollaterals :: Int
   , usMaxCollaterals :: Int
+  , usRegKeyFreq :: Int
+  , usUnRegKeyFreq :: Int
+  , usAllowReRegisterPool :: Bool
+  , usSpendScriptFreq :: Int
+  , usCredScriptFreq :: Int
   }
 
 instance Default UnivSize where
@@ -135,6 +140,11 @@ instance Default UnivSize where
       , usMaxInputs = 10
       , usMinCollaterals = 2
       , usMaxCollaterals = 2
+      , usAllowReRegisterPool = True
+      , usRegKeyFreq = 1
+      , usUnRegKeyFreq = 1
+      , usSpendScriptFreq = 3
+      , usCredScriptFreq = 1
       }
 
 -- ============================================================
@@ -497,7 +507,7 @@ universePreds size p =
   , Choose
       (ExactSize (usNumCredentials size))
       credList
-      [ (1, scriptHashObjT scripthash, [Member (Left scripthash) (Dom (nonSpendScriptUniv p))])
+      [ (usCredScriptFreq size, scriptHashObjT scripthash, [Member (Left scripthash) (Dom (nonSpendScriptUniv p))])
       , (1, keyHashObjT keyhash, [Member (Left keyhash) (Dom keymapUniv)])
       ]
   , credsUniv :<-: listToSetTarget credList
@@ -507,7 +517,7 @@ universePreds size p =
   , Choose
       (ExactSize 70)
       spendcredList
-      [ (3, scriptHashObjT scripthash, [Member (Left scripthash) (Dom (spendscriptUniv p))])
+      [ (usSpendScriptFreq size, scriptHashObjT scripthash, [Member (Left scripthash) (Dom (spendscriptUniv p))])
       , (2, keyHashObjT keyhash, [Member (Left keyhash) (Dom keymapUniv)])
       ]
   , spendCredsUniv :<-: listToSetTarget spendcredList

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Scripts.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Scripts.hs
@@ -139,7 +139,8 @@ genCoreScript proof tag keymap vi = case proof of
   Conway _ ->
     frequency
       [ (1, TimelockScript <$> genTimelock keymap vi proof)
-      , (1, snd <$> genPlutusScript tag proof)
+      -- TODO Add this once scripts are working in Conway
+      -- , (1, snd <$> genPlutusScript tag proof)
       ]
   Babbage _ ->
     frequency


### PR DESCRIPTION
# Description

This adds support for certificates in conformance testing. Currently we can't do `RegKey` and `UnRegKey`, since these are not in the spec yet.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
