### PR TITLE
Ensure DRepRegistration certificate requires a witness

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0.0
 
+* Change 'getScriptWitnessConwayTxCert' so that DRepRegistration certificate requires a witness		
 * Add `transTxBodyWithdrawals`, `transTxCert`, `transDRepCred`, `transColdCommitteeCred`,
   `transHotCommitteeCred`, `transDelegatee`, `transDRep`, `transScriptPurpose`
 * Remove `conwayTxInfo` and `babbageScriptPrefixTag`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -614,8 +614,7 @@ getScriptWitnessConwayTxCert = \case
     govWitness = \case
       ConwayAuthCommitteeHotKey coldCred _hotCred -> credScriptHash coldCred
       ConwayResignCommitteeColdKey coldCred _ -> credScriptHash coldCred
-      -- Registration of a DRep does not require a witness
-      ConwayRegDRep {} -> Nothing
+      ConwayRegDRep cred _ _ -> credScriptHash cred
       ConwayUnRegDRep cred _ -> credScriptHash cred
       ConwayUpdateDRep cred _ -> credScriptHash cred
 
@@ -636,7 +635,7 @@ getVKeyWitnessConwayTxCert = \case
       ConwayAuthCommitteeHotKey coldCred _hotCred -> credKeyHashWitness coldCred
       ConwayResignCommitteeColdKey coldCred _ -> credKeyHashWitness coldCred
       -- Registration of a DRep does not require a witness
-      ConwayRegDRep {} -> Nothing
+      ConwayRegDRep cred _ _ -> credKeyHashWitness cred
       ConwayUnRegDRep cred _ -> credKeyHashWitness cred
       ConwayUpdateDRep cred _ -> credKeyHashWitness cred
 


### PR DESCRIPTION
Change 'getScriptWitnessConwayTxCert' so that DRepRegistration certificate requires a witness

Fix #3890 
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
