### PR TITLE
Bump Plutus to 1.18

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2023-11-15T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-11-29T12:13:23Z
+  , cardano-haskell-packages 2023-12-07T15:09:47Z
 
 packages:
   eras/allegra/impl

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -84,7 +84,7 @@ library
         mtl,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.17,
+        plutus-ledger-api ^>=1.18,
         set-algebra >=1.0,
         small-steps >=1.0,
         text,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -62,7 +62,7 @@ library
         data-default-class,
         microlens,
         plutus-tx,
-        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.17,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.18,
         QuickCheck,
         random,
         serialise,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -77,7 +77,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.17,
+        plutus-ledger-api ^>=1.18,
         set-algebra,
         small-steps,
         text,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -89,7 +89,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.17,
+        plutus-ledger-api ^>=1.18,
         set-algebra,
         small-steps,
         text,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1701690664,
-        "narHash": "sha256-5vu1lWh3HB0sipkDbEmaasSxrhgMwCmyafiiZMw1bjY=",
+        "lastModified": 1701964264,
+        "narHash": "sha256-sOs8bLbMvtIBQLywB3AM6wcpHr5JUmHJyDhtBmRkHBI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "8120918b61283117846973302d9699a9c7e7410f",
+        "rev": "b3ccccc588891d765bd68cd2fc1110844a3bef35",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -66,7 +66,7 @@ library
         network,
         nothunks,
         primitive,
-        plutus-ledger-api ^>=1.17,
+        plutus-ledger-api ^>=1.18,
         recursion-schemes,
         serialise,
         tagged,

--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -37,7 +37,7 @@ executable plutus-preprocessor
         serialise,
         template-haskell
 
-    if (impl(ghc <9.2) || impl(ghc >=9.3))
+    if (impl(ghc <9.6) || impl(ghc >=9.7))
         buildable: False
 
 executable plutus-debug


### PR DESCRIPTION
Note that plutus-tx-plugin only builds with GHC 9.6 now.