### PR TITLE
Improve comment on `unit_interval` in cddl

### DIFF
--- a/eras/conway/impl/cddl-files/extra.cddl
+++ b/eras/conway/impl/cddl-files/extra.cddl
@@ -11,9 +11,20 @@ nonempty_oset<a> = #6.258([+ a]) / [+ a]
 positive_int = 1 .. 18446744073709551615
 
 unit_interval = #6.30([1, 2])
-  ; real unit_interval is: #6.30([uint, uint])
-  ; but this produces numbers outside the unit interval
-  ; and can also produce a zero in the denominator
+  ; unit_interval = #6.30([uint, uint])
+  ;
+  ; Comment above depicts the actual definition for `unit_interval`.
+  ;
+  ; Unit interval is a number in the range between 0 and 1, which
+  ; means there are two extra constraints:
+  ; * numerator <= denominator
+  ; * denominator > 0
+  ;
+  ; Relation between numerator and denominator cannot be expressed in CDDL, which
+  ; poses a problem for testing. We need to be able to generate random valid data
+  ; for testing implementation of our encoders/decoders. Which means we cannot use
+  ; the actual definition here and we hard code the value to 1/2
+
 
 nonnegative_interval = #6.30([uint, positive_int])
 

--- a/eras/conway/impl/cddl-files/extra.cddl
+++ b/eras/conway/impl/cddl-files/extra.cddl
@@ -15,8 +15,6 @@ unit_interval = #6.30([1, 2])
   ; but this produces numbers outside the unit interval
   ; and can also produce a zero in the denominator
 
-rational =  #6.30([int, positive_int])
-
 nonnegative_interval = #6.30([uint, positive_int])
 
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -593,7 +593,7 @@ data GovAction era
       !(Set (Credential 'ColdCommitteeRole (EraCrypto era)))
       -- | Constitutional committee members to be added
       !(Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
-      -- New quorum
+      -- | New quorum
       !UnitInterval
   | NewConstitution
       -- | Previous governance action id of `NewConstitution` type, which corresponds to


### PR DESCRIPTION
# Description

* Remove unused `rational`
* Add a better comment about `unit_interval`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
