### PR TITLE
Change type of `mintedTxBodyL` to `PolicyID`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -452,8 +452,8 @@ rdptr ::
   ScriptPurpose era ->
   StrictMaybe RdmrPtr
 rdptr txBody = \case
-  Minting (PolicyID hash) ->
-    RdmrPtr Mint <$> indexOf hash (txBody ^. mintedTxBodyF :: Set (ScriptHash (EraCrypto era)))
+  Minting hash ->
+    RdmrPtr Mint <$> indexOf hash (txBody ^. mintedTxBodyF :: Set (PolicyID (EraCrypto era)))
   Spending txin ->
     RdmrPtr Spend <$> indexOf txin (txBody ^. inputsTxBodyL)
   Rewarding racnt ->
@@ -469,7 +469,7 @@ rdptrInv ::
   StrictMaybe (ScriptPurpose era)
 rdptrInv txBody = \case
   RdmrPtr Mint idx ->
-    Minting . PolicyID <$> fromIndex idx (txBody ^. mintedTxBodyF)
+    Minting <$> fromIndex idx (txBody ^. mintedTxBodyF)
   RdmrPtr Spend idx ->
     Spending <$> fromIndex idx (txBody ^. inputsTxBodyL)
   RdmrPtr Rewrd idx ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -98,7 +98,7 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
-import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset (..), policies, policyID)
+import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset (..), policies)
 import Cardano.Ledger.MemoBytes (
   EqRaw,
   Mem,
@@ -308,7 +308,7 @@ instance Crypto c => MaryEraTxBody (AlonzoEra c) where
   mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
   {-# INLINEABLE mintValueTxBodyF #-}
 
-  mintedTxBodyF = to (Set.map policyID . policies . atbrMint . getMemoRawType)
+  mintedTxBodyF = to (policies . atbrMint . getMemoRawType)
   {-# INLINEABLE mintedTxBodyF #-}
 
 instance Crypto c => AlonzoEraTxBody (AlonzoEra c) where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -230,4 +230,4 @@ getAlonzoScriptsNeeded (UTxO u) txBody =
       mapMaybe (\cred -> (Certifying cred,) <$> getScriptWitnessTxCert cred) $
         toList (txBody ^. certsTxBodyL)
 
-    !minted = map (\hash -> (Minting (PolicyID hash), hash)) $ Set.toList $ txBody ^. mintedTxBodyF
+    !minted = map (\pId@(PolicyID hash) -> (Minting pId, hash)) $ Set.toList $ txBody ^. mintedTxBodyF

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -7,8 +7,16 @@
 * Stop exporting `AllegraEraTxBody`, `AlonzoEraTxBody`,`AlonzoTxBody`,
   `MaryEraTxBody`,`ShelleyEraTxBody`, `addrEitherBabbageTxOutL`,
   `valueEitherBabbageTxOutL`, `dataHashBabbageTxOutL`, `dataBabbageTxOutL`,
-  `datumBabbageTxOutL`, `referenceScriptBabbageTxOutL`, `getDatumBabbageTxOut` and `Datum`
-  from `Cardano.Ledger.Babbage.TxBody`
+  `datumBabbageTxOutL`, `referenceScriptBabbageTxOutL`, `getDatumBabbageTxOut`, `Datum`
+  `mkBabbageTxBody`, `inputsBabbageTxBodyL`, `outputsBabbageTxBodyL`, `feeBabbageTxBodyL`,
+  `auxDataHashBabbageTxBodyL`, `mintedBabbageTxBodyF`, `mintValueBabbageTxBodyF`,
+  `withdrawalsBabbbageTxBodyL`, `notSupportedInThisEraL`, `updateBabbageTxBodyL`,
+  `certsBabbageTxBodyL`, `vldtBabbageTxBodyL`, `mintBabbageTxBodyL`,
+  `collateralInputsBabbageTxBodyL`, `reqSignerHashesBabbageTxBodyL`,
+  `scriptIntegrityHashBabbageTxBodyL`, `networkIdBabbageTxBodyL`,
+  `sizedOutputsBabbageTxBodyL`, `referenceInputsBabbageTxBodyL`,
+  `totalCollateralBabbageTxBodyL`, `collateralReturnBabbageTxBodyL`,
+  `sizedCollateralReturnBabbageTxBodyL` from `Cardano.Ledger.Babbage.TxBody`
 * Remove `txInfoOutV1`, `txInfoOutV2`, `txInfoInV1` and `txInfoInV2`.
 * Add `transTxOutV1`, `transTxOutV2`, `transTxInInfoV1`, `transTxInInfoV2` and `transTxRedeemers`
 * Remove `babbageScriptPrefixTag`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -50,32 +50,9 @@ module Cardano.Ledger.Babbage.TxBody (
   ),
   BabbageTxBodyRaw (..),
   BabbageTxBodyUpgradeError (..),
-  mkBabbageTxBody,
-  inputsBabbageTxBodyL,
-  outputsBabbageTxBodyL,
-  feeBabbageTxBodyL,
-  auxDataHashBabbageTxBodyL,
-  babbageSpendableInputsTxBodyF,
   babbageAllInputsTxBodyF,
-  mintedBabbageTxBodyF,
-  mintValueBabbageTxBodyF,
-  withdrawalsBabbbageTxBodyL,
-  notSupportedInThisEraL,
-  updateBabbageTxBodyL,
-  certsBabbageTxBodyL,
-  vldtBabbageTxBodyL,
-  mintBabbageTxBodyL,
-  collateralInputsBabbageTxBodyL,
-  reqSignerHashesBabbageTxBodyL,
-  scriptIntegrityHashBabbageTxBodyL,
-  networkIdBabbageTxBodyL,
-  sizedOutputsBabbageTxBodyL,
-  referenceInputsBabbageTxBodyL,
-  totalCollateralBabbageTxBodyL,
-  collateralReturnBabbageTxBodyL,
-  sizedCollateralReturnBabbageTxBodyL,
+  babbageSpendableInputsTxBodyF,
   BabbageEraTxBody (..),
-  Datum (..),
   spendInputs',
   collateralInputs',
   referenceInputs',
@@ -140,7 +117,6 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
   zipMemoRawType,
  )
-import Cardano.Ledger.Plutus.Data (Datum (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
 import Cardano.Ledger.TxIn (TxIn (..))
@@ -434,7 +410,7 @@ instance Crypto c => EraTxBody (BabbageEra c) where
   type TxBody (BabbageEra c) = BabbageTxBody (BabbageEra c)
   type TxBodyUpgradeError (BabbageEra c) = BabbageTxBodyUpgradeError
 
-  mkBasicTxBody = mkBabbageTxBody
+  mkBasicTxBody = mkMemoized basicBabbageTxBodyRaw
 
   inputsTxBodyL = inputsBabbageTxBodyL
   {-# INLINE inputsTxBodyL #-}
@@ -701,9 +677,6 @@ pattern BabbageTxBody
             }
 
 {-# COMPLETE BabbageTxBody #-}
-
-mkBabbageTxBody :: BabbageEraTxBody era => BabbageTxBody era
-mkBabbageTxBody = mkMemoized basicBabbageTxBodyRaw
 
 instance c ~ EraCrypto era => HashAnnotated (BabbageTxBody era) EraIndependentTxBody c where
   hashAnnotated = getMemoSafeHash

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -126,7 +126,7 @@ import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset, policies, policyID)
+import Cardano.Ledger.Mary.Value (MaryValue (MaryValue), MultiAsset, PolicyID (..), policies)
 import Cardano.Ledger.MemoBytes (
   EqRaw,
   Mem,
@@ -301,8 +301,8 @@ babbageAllInputsTxBodyF =
       `Set.union` (txBody ^. referenceInputsTxBodyL)
 {-# INLINEABLE babbageAllInputsTxBodyF #-}
 
-mintedBabbageTxBodyF :: SimpleGetter (BabbageTxBody era) (Set (ScriptHash (EraCrypto era)))
-mintedBabbageTxBodyF = to (Set.map policyID . policies . btbrMint . getMemoRawType)
+mintedBabbageTxBodyF :: SimpleGetter (BabbageTxBody era) (Set (PolicyID (EraCrypto era)))
+mintedBabbageTxBodyF = to (policies . btbrMint . getMemoRawType)
 {-# INLINEABLE mintedBabbageTxBodyF #-}
 
 withdrawalsBabbbageTxBodyL ::

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), RdmrPtr (..), Redeemers 
 import Cardano.Ledger.Babbage (Babbage)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Translation ()
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..), Datum (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
@@ -26,6 +26,7 @@ import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus.Data (
   Data (..),
+  Datum (..),
   dataToBinaryData,
   hashData,
  )

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
@@ -18,11 +18,11 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Babbage (Babbage, BabbageEra)
 import Cardano.Ledger.Babbage.Core
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..), Datum (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Plutus.Data (Data (..))
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..))
 import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UTxO (UTxO (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -55,6 +55,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody (
   BabbageTxBody (..),
+  allSizedOutputsBabbageTxBodyF,
   babbageAllInputsTxBodyF,
   babbageSpendableInputsTxBodyF,
  )
@@ -118,8 +119,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad (when)
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.OSet.Strict as SOS
-import Data.Sequence.Strict (StrictSeq, (|>))
-import qualified Data.Sequence.Strict as StrictSeq
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
@@ -315,7 +315,7 @@ basicConwayTxBodyRaw =
     mempty
     mempty
     mempty
-    StrictSeq.empty
+    mempty
     SNothing
     SNothing
     SOS.empty
@@ -522,11 +522,7 @@ instance Crypto c => BabbageEraTxBody (ConwayEra c) where
     lensMemoRawType ctbrCollateralReturn (\txb x -> txb {ctbrCollateralReturn = x})
   {-# INLINE sizedCollateralReturnTxBodyL #-}
 
-  allSizedOutputsTxBodyF = to $ \txb ->
-    let txOuts = txb ^. sizedOutputsTxBodyL
-     in case txb ^. sizedCollateralReturnTxBodyL of
-          SNothing -> txOuts
-          SJust collTxOut -> txOuts |> collTxOut
+  allSizedOutputsTxBodyF = allSizedOutputsBabbageTxBodyF
   {-# INLINE allSizedOutputsTxBodyF #-}
 
 instance Crypto c => ConwayEraTxBody (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -97,7 +97,6 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (
   MaryValue (..),
   MultiAsset (..),
-  PolicyID (..),
   policies,
  )
 import Cardano.Ledger.MemoBytes (
@@ -122,7 +121,6 @@ import qualified Data.OSet.Strict as SOS
 import Data.Sequence.Strict (StrictSeq, (|>))
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
-import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', to, (^.))
@@ -479,7 +477,7 @@ instance Crypto c => MaryEraTxBody (ConwayEra c) where
   mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
 
   mintedTxBodyF =
-    to (\(TxBodyConstr (Memo txBodyRaw _)) -> Set.map policyID (policies (ctbrMint txBodyRaw)))
+    to (\(TxBodyConstr (Memo txBodyRaw _)) -> policies (ctbrMint txBodyRaw))
   {-# INLINE mintedTxBodyF #-}
 
 instance Crypto c => AlonzoEraTxBody (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   mkAlonzoTxAuxData,
  )
 import Cardano.Ledger.Alonzo.TxWits (RdmrPtr (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), Datum (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
@@ -37,6 +37,7 @@ import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus.Data (
   Data (..),
+  Datum (..),
   dataToBinaryData,
   hashData,
  )

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Change return type of `mintedTxBodyF` to `Set PolicyID`
 * Stop exporting all of the internal `hkd*` functions and `PParamsHKD` from
   `Cardano.Ledger.Mary.Core`.
 * Stop exporting `ValidityInterval` and `StrictMaybe` from `Cardano.Ledger.Mary.TxBody`

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -61,7 +61,7 @@ import Cardano.Ledger.Shelley.PParams (Update, upgradeUpdate)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData (..))
 import Data.Sequence.Strict (StrictSeq)
-import qualified Data.Set as Set (Set, map)
+import Data.Set (Set)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -71,7 +71,7 @@ class AllegraEraTxBody era => MaryEraTxBody era where
 
   mintValueTxBodyF :: SimpleGetter (TxBody era) (Value era)
 
-  mintedTxBodyF :: SimpleGetter (TxBody era) (Set.Set (ScriptHash (EraCrypto era)))
+  mintedTxBodyF :: SimpleGetter (TxBody era) (Set (PolicyID (EraCrypto era)))
 
 -- ===========================================================================
 -- Wrap it all up in a newtype, hiding the insides with a pattern constructor.
@@ -147,7 +147,7 @@ instance (c ~ EraCrypto era, Era era) => HashAnnotated (MaryTxBody era) EraIndep
 -- | A pattern to keep the newtype and the MemoBytes hidden
 pattern MaryTxBody ::
   (EraTxOut era, EraTxCert era) =>
-  Set.Set (TxIn (EraCrypto era)) ->
+  Set (TxIn (EraCrypto era)) ->
   StrictSeq (TxOut era) ->
   StrictSeq (TxCert era) ->
   Withdrawals (EraCrypto era) ->
@@ -309,6 +309,5 @@ instance Crypto c => MaryEraTxBody (MaryEra c) where
   {-# INLINEABLE mintValueTxBodyF #-}
 
   mintedTxBodyF =
-    to $ \(TxBodyConstr (Memo (MaryTxBodyRaw txBodyRaw) _)) ->
-      Set.map policyID (policies (atbrMint txBodyRaw))
+    to $ \(TxBodyConstr (Memo (MaryTxBodyRaw txBodyRaw) _)) -> policies (atbrMint txBodyRaw)
   {-# INLINEABLE mintedTxBodyF #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
 import Cardano.Ledger.Mary.TxBody ()
-import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.Mary.Value (MaryValue, policyID)
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
   getShelleyScriptsNeeded,
@@ -84,4 +84,5 @@ getMaryScriptsNeeded ::
 getMaryScriptsNeeded u txBody =
   case getShelleyScriptsNeeded u txBody of
     ShelleyScriptsNeeded shelleyScriptsNeeded ->
-      ShelleyScriptsNeeded (shelleyScriptsNeeded `Set.union` (txBody ^. mintedTxBodyF))
+      ShelleyScriptsNeeded $
+        shelleyScriptsNeeded `Set.union` Set.map policyID (txBody ^. mintedTxBodyF)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Change return type of `mintedTxBodyF` to `Set PolicyID`
 * Remove old and deprecated functions `evaluateTransactionExecutionUnits`,
   `evaluateTransactionExecutionUnitsWithLogs` and `updateTxBodyG`
 * Remove no longer necessary `ValidationFailed`

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 1.3.0.0
 
+* Add `decodeListLikeT` and `decodeListLike`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 * Add `encodeEnum` and `decodeEnumBounded`
+* Change first argument of `decodeRecordSum` and `Summands` from `String` to `Text`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Coders.hs
@@ -339,7 +339,7 @@ data Decode (w :: Wrapped) t where
   -- | Label the constructor of a Record-like datatype (one with multiple constructors) as an Decode.
   SumD :: t -> Decode 'Open t
   -- | Lift a Word to Decode function into a DeCode for a type with multiple constructors.
-  Summands :: String -> (Word -> Decode 'Open t) -> Decode ('Closed 'Dense) t
+  Summands :: Text.Text -> (Word -> Decode 'Open t) -> Decode ('Closed 'Dense) t
   -- | Lift a Word to Field function into a DeCode for a type with 1 constructor stored sparsely
   SparseKeyed ::
     Typeable t =>

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Babbage.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxBody (
   BabbageTxOut (..),
-  Datum (..),
   adHash',
   certs',
   collateralInputs',
@@ -38,7 +37,7 @@ import Cardano.Ledger.Babbage.TxBody (
  )
 import Cardano.Ledger.BaseTypes (BoundedRational (unboundRational))
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Plutus.Data (BinaryData, binaryDataToData)
+import Cardano.Ledger.Plutus.Data (BinaryData, Datum (..), binaryDataToData)
 import Cardano.Ledger.Pretty hiding (
   ppTxBody,
   ppTxOut,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -42,10 +42,7 @@ import Cardano.Ledger.Babbage (Babbage)
 import qualified Cardano.Ledger.Babbage.Collateral as Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
-import Cardano.Ledger.Babbage.TxBody (
-  BabbageTxBody (..),
-  Datum (..),
- )
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Babbage.TxInfo (
   ContextError (InlineDatumsNotSupported, ReferenceInputsNotSupported, ReferenceScriptsNotSupported),
  )
@@ -65,7 +62,7 @@ import Cardano.Ledger.Keys (
   KeyRole (..),
   hashKey,
  )
-import Cardano.Ledger.Plutus.Data (Data (..), dataToBinaryData, hashData)
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Plutus.Language (Language (..), Plutus (..), PlutusBinary (..), PlutusLanguage)
 import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -49,7 +49,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.PParams (BabbagePParams (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..), Datum (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   EpochNo (..),
@@ -71,7 +71,7 @@ import Cardano.Ledger.Keys (KeyHash, KeyRole (..), WitVKey (..), hashKey)
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..))
 import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
-import Cardano.Ledger.Plutus.Data (Data (..), hashData)
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), hashData)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams (..))
 import qualified Cardano.Ledger.Shelley.PParams as PP (Update)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -17,7 +17,6 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), collateral')
 import Cardano.Ledger.Babbage.TxBody (
   BabbageTxOut (..),
-  Datum (..),
   collateralInputs',
   collateralReturn',
   referenceInputs',
@@ -34,7 +33,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
 import Cardano.Ledger.Keys (KeyRole (..))
-import Cardano.Ledger.Plutus.Data (binaryDataToData, hashData)
+import Cardano.Ledger.Plutus.Data (Datum (..), binaryDataToData, hashData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Shelley.AdaPots (AdaPots (..), totalAdaPotsES)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   Redeemers (..),
   TxDats (..),
  )
-import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), Datum (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Network (..), mkTxIxPartial)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayTxCert (..))
@@ -46,7 +46,7 @@ import Cardano.Ledger.Keys (
   KeyRole (..),
   coerceKeyRole,
  )
-import Cardano.Ledger.Plutus.Data (Data, dataToBinaryData, hashData)
+import Cardano.Ledger.Plutus.Data (Data, Datum (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Pretty (PrettyA (..), ppRecord)
 import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -20,10 +20,7 @@ import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.Core
-import Cardano.Ledger.Babbage.TxBody as Babbage (
-  BabbageTxOut (..),
-  Datum (..),
- )
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.Conway.Governance (GovProcedures (..))
 import Cardano.Ledger.Conway.PParams (
   ppCommitteeMaxTermLengthL,
@@ -36,6 +33,7 @@ import Cardano.Ledger.Conway.PParams (
   ppPoolVotingThresholdsL,
  )
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
+import Cardano.Ledger.Plutus.Data (Datum (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Shelley.Tx as Shelley (
   ShelleyTx (..),
@@ -306,15 +304,15 @@ updateTxOut (Alonzo _) (out@(AlonzoTxOut a v h)) txoutd = case txoutd of
 updateTxOut (Babbage _) (BabbageTxOut a v h refscript) txoutd = case txoutd of
   Address addr -> BabbageTxOut addr v h refscript
   Amount val -> BabbageTxOut a val h refscript
-  DHash SNothing -> BabbageTxOut a v Babbage.NoDatum refscript
-  DHash (SJust dh) -> BabbageTxOut a v (Babbage.DatumHash dh) refscript
+  DHash SNothing -> BabbageTxOut a v NoDatum refscript
+  DHash (SJust dh) -> BabbageTxOut a v (DatumHash dh) refscript
   FDatum d -> BabbageTxOut a v d refscript
   RefScript s -> BabbageTxOut a v h s
 updateTxOut (Conway _) (BabbageTxOut a v h refscript) txoutd = case txoutd of
   Address addr -> BabbageTxOut addr v h refscript
   Amount val -> BabbageTxOut a val h refscript
-  DHash SNothing -> BabbageTxOut a v Babbage.NoDatum refscript
-  DHash (SJust dh) -> BabbageTxOut a v (Babbage.DatumHash dh) refscript
+  DHash SNothing -> BabbageTxOut a v NoDatum refscript
+  DHash (SJust dh) -> BabbageTxOut a v (DatumHash dh) refscript
   FDatum d -> BabbageTxOut a v d refscript
   RefScript s -> BabbageTxOut a v h s
 {-# NOINLINE updateTxOut #-}


### PR DESCRIPTION
# Description

Besides changing type of `mintedTxBodyL` to `PolicyID` this PR also:

* Adds new helper functions `decodeListLikeT` and `decodeListLike`
* Changes the first argument of `decodeRecordSum` and `Summonds` from `String` to `Text` for consistency.
* Removes a bunch of unnecessary exports from `Cardano.Ledger.Babbage.TxBody`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
