### PR TITLE
Add ledger event TxUTxODiff

### DIFF
--- a/docs/LedgerEvents.md
+++ b/docs/LedgerEvents.md
@@ -132,6 +132,10 @@ This event happens on the epoch boundary and gives us the ratification state (`R
 
 This event is triggered on each tx and gives us the votes, proposals and txid of a particular tx.
 
+### `TxUTxODiff utxosConsumed utxosCreated`
+
+This event is triggered on each tx and gives us the consumed and created UTxOs of that valid tx.
+
 ## Notes / TODO
 
 There appears to be multiple, redundant `NewEpoch` events.

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
   `Cardano.Ledger.Allegra.Core`.
 * Export `ValidityInterval` from `Cardano.Ledger.Allegra.Core`
 * Moved `ToExpr` instances out of the main library and into the testlib.
+* Add `TxUTxODiff (UTxO era) (UTxO era)` inhabitant to the `AllegraUtxoEvent era` data type.
 
 ## 1.2.5.1
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Delete `utxoPredFailMaToAlonzo`, `utxoPredFailShelleyToAlonzo`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 * Changed the type of the ConwayPParams field appEMax
+* Add `TxUTxODiff (UTxO era) (UTxO era)` inhabitant to the `AlonzoUtxosEvent era` data type.
 
 ### `testlib`
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -34,14 +34,28 @@ import Cardano.Ledger.Alonzo.Rules (
   validEnd,
   when2Phase,
  )
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
-import Cardano.Ledger.Babbage.Collateral (collAdaBalance, collOuts)
+import Cardano.Ledger.Alonzo.UTxO (
+  AlonzoEraUTxO (..),
+  AlonzoScriptsNeeded,
+ )
+import Cardano.Ledger.Babbage.Collateral (
+  collAdaBalance,
+  collOuts,
+ )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageUTXOS)
 import Cardano.Ledger.Babbage.Tx
-import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, strictMaybeToMaybe, systemStart)
+import Cardano.Ledger.BaseTypes (
+  ShelleyBase,
+  epochInfo,
+  strictMaybeToMaybe,
+  systemStart,
+ )
 import Cardano.Ledger.Binary (EncCBOR (..))
-import Cardano.Ledger.Plutus.Evaluate (ScriptFailure (..), ScriptResult (..))
+import Cardano.Ledger.Plutus.Evaluate (
+  ScriptFailure (..),
+  ScriptResult (..),
+ )
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
@@ -200,8 +214,14 @@ babbageEvalScriptsTxValid = do
   expectScriptsToPass pp tx utxo
   () <- pure $! traceEvent validEnd ()
 
-  updateUTxOState pp utxos txBody certState ppup' $
-    tellEvent . TotalDeposits (hashAnnotated txBody)
+  updateUTxOState
+    pp
+    utxos
+    txBody
+    certState
+    ppup'
+    (tellEvent . TotalDeposits (hashAnnotated txBody))
+    (\a b -> tellEvent $ TxUTxODiff a b)
 
 babbageEvalScriptsTxInvalid ::
   forall s era.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,7 +20,10 @@ import Cardano.Ledger.Alonzo.Rules (
   validBegin,
   validEnd,
  )
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Alonzo.UTxO (
+  AlonzoEraUTxO,
+  AlonzoScriptsNeeded,
+ )
 import Cardano.Ledger.Babbage.Rules (
   BabbageUTXO,
   BabbageUtxoPredFailure (..),
@@ -40,7 +42,10 @@ import Cardano.Ledger.Shelley.LedgerState (
   UTxOState (..),
   utxosDonationL,
  )
-import Cardano.Ledger.Shelley.Rules (UtxoEnv (..), updateUTxOState)
+import Cardano.Ledger.Shelley.Rules (
+  UtxoEnv (..),
+  updateUTxOState,
+ )
 import Cardano.Ledger.UTxO (EraUTxO (..))
 import Control.State.Transition.Extended
 import Debug.Trace (traceEvent)
@@ -131,6 +136,12 @@ conwayEvalScriptsTxValid = do
   () <- pure $! traceEvent validEnd ()
 
   utxos' <-
-    updateUTxOState pp utxos txBody certState govState $
-      tellEvent . TotalDeposits (hashAnnotated txBody)
+    updateUTxOState
+      pp
+      utxos
+      txBody
+      certState
+      govState
+      (tellEvent . TotalDeposits (hashAnnotated txBody))
+      (\a b -> tellEvent $ TxUTxODiff a b)
   pure $! utxos' & utxosDonationL <>~ txBody ^. treasuryDonationTxBodyL

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add `runImpTestM`, `runImpTestM_`, `evalImpTestM` and `execImpTestM`
 * Add instance `Example (a -> ImpTestM era ())`, which allows use of `Arbitrary`
 * Add `getNextEpochCommitteeMembers` to `EraGov` typeclass, with a default empty implementation
+* Add `TxUTxODiff (UTxO era) (UTxO era)` inhabitant to the `UtxoEvent era` data type.
 
 ## 1.8.0.0
 


### PR DESCRIPTION

# Description

This emits consumed and created UTxOs due to a single tx

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
