### PR TITLE
Type safety bugfixes

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Allegra.Scripts (
     RequireTimeExpire,
     RequireTimeStart
   ),
-  TimelockRaw (..),
+  TimelockRaw,
   pattern TimelockConstr,
   inInterval,
   showTimelock,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -18,7 +18,7 @@
 
 module Cardano.Ledger.Allegra.TxAuxData (
   AllegraTxAuxData (AllegraTxAuxData),
-  AllegraTxAuxDataRaw (..),
+  AllegraTxAuxDataRaw,
 
   -- * Deprecations
   AuxiliaryData,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -26,7 +26,7 @@ module Cardano.Ledger.Alonzo.TxAuxData (
     atadTimelock,
     atadPlutus
   ),
-  AlonzoTxAuxDataRaw (..),
+  AlonzoTxAuxDataRaw,
   mkAlonzoTxAuxData,
   AuxiliaryDataHash (..),
   hashAlonzoTxAuxData,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -42,7 +42,7 @@ module Cardano.Ledger.Alonzo.TxBody (
     atbAuxDataHash,
     atbTxNetworkId
   ),
-  AlonzoTxBodyRaw (..),
+  AlonzoTxBodyRaw,
   AlonzoTxBodyUpgradeError (..),
   AlonzoEraTxBody (..),
   ShelleyEraTxBody (..),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -24,12 +24,12 @@
 module Cardano.Ledger.Alonzo.TxWits (
   RdmrPtr (..),
   Redeemers (Redeemers),
-  RedeemersRaw (..),
+  RedeemersRaw,
   unRedeemers,
   nullRedeemers,
   upgradeRedeemers,
   TxDats (TxDats, TxDats'),
-  TxDatsRaw (..),
+  TxDatsRaw,
   upgradeTxDats,
   AlonzoTxWits (
     AlonzoTxWits,
@@ -45,7 +45,7 @@ module Cardano.Ledger.Alonzo.TxWits (
     txdats',
     txrdmrs'
   ),
-  AlonzoTxWitsRaw (..),
+  AlonzoTxWitsRaw,
   addrAlonzoTxWitsL,
   bootAddrAlonzoTxWitsL,
   scriptAlonzoTxWitsL,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody.hs
@@ -48,7 +48,7 @@ module Cardano.Ledger.Babbage.TxBody (
     btbAuxDataHash,
     btbTxNetworkId
   ),
-  BabbageTxBodyRaw (..),
+  BabbageTxBodyRaw,
   BabbageTxBodyUpgradeError (..),
   babbageAllInputsTxBodyF,
   babbageSpendableInputsTxBodyF,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -43,10 +43,9 @@ module Cardano.Ledger.Conway.TxBody (
     ctbVotingProcedures,
     ctbProposalProcedures,
     ctbCurrentTreasuryValue,
-    ctbTreasuryDonation,
-    TxBodyConstr
+    ctbTreasuryDonation
   ),
-  ConwayTxBodyRaw (..),
+  ConwayTxBodyRaw,
   conwayTotalDepositsTxBody,
   conwayProposalsDeposits,
 ) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -586,10 +586,11 @@ toShelleyDelegCert = \case
   _ -> Nothing
 
 -- For both of the functions `getScriptWitnessConwayTxCert` and
--- `getVKeyWitnessConwayTxCert` we preserve the old behavior of not requiring a witness,
--- but only during the transitional period of Conway era and only for registration
--- cdertificates without a deposit. Future eras will require a witness for registration
--- certificates, because the one without a deposit will be removed.
+-- `getVKeyWitnessConwayTxCert` we preserve the old behavior of not requiring a witness
+-- for staking credential registration, but only during the transitional period of Conway
+-- era and only for staking credential registration certificates without a deposit. Future
+-- eras will require a witness for registration certificates, because the one without a
+-- deposit will be removed.
 
 getScriptWitnessConwayTxCert ::
   ConwayTxCert era ->
@@ -630,7 +631,6 @@ getVKeyWitnessConwayTxCert = \case
     govWitness = \case
       ConwayAuthCommitteeHotKey coldCred _hotCred -> credKeyHashWitness coldCred
       ConwayResignCommitteeColdKey coldCred _ -> credKeyHashWitness coldCred
-      -- Registration of a DRep does not require a witness
       ConwayRegDRep cred _ _ -> credKeyHashWitness cred
       ConwayUnRegDRep cred _ -> credKeyHashWitness cred
       ConwayUpdateDRep cred _ -> credKeyHashWitness cred

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -115,7 +115,7 @@ instance ToExpr (ConwayDelegPredFailure era)
 -- TxBody
 instance (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era)) => ToExpr (ConwayTxBodyRaw era)
 
-deriving instance
+instance
   (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era)) =>
   ToExpr (ConwayTxBody era)
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -31,7 +31,7 @@ module Cardano.Ledger.Mary.TxBody (
     mtbWithdrawals,
     mtbMint
   ),
-  MaryTxBodyRaw (..),
+  MaryTxBodyRaw,
 )
 where
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Shelley.Scripts (
   ScriptHash (..),
   nativeMultiSigTag,
   eqMultiSigRaw,
-  MultiSigRaw (..),
+  MultiSigRaw,
 )
 where
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Shelley.Tx (
     wits,
     auxiliaryData
   ),
-  ShelleyTxRaw (..),
+  ShelleyTxRaw,
   bodyShelleyTxL,
   witsShelleyTxL,
   auxDataShelleyTxL,

--- a/hie.yaml
+++ b/hie.yaml
@@ -177,6 +177,9 @@ cradle:
     - path: "libs/cardano-ledger-binary/test"
       component: "cardano-ledger-binary:test:tests"
 
+    - path: "libs/cardano-ledger-binary/bench/Bench.hs"
+      component: "cardano-ledger-binary:bench:bench"
+
     - path: "libs/cardano-ledger-conformance/src"
       component: "lib:cardano-ledger-conformance"
 

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -101,7 +101,7 @@ instance EncCBOR a => EncCBOR (OSet a) where
   encCBOR (OSet seq _set) = encodeTag setTag <> encodeStrictSeq encCBOR seq
 
 instance (Show a, Ord a, DecCBOR a) => DecCBOR (OSet a) where
-  decCBOR = decodeSetLikeEnforceNoDuplicates member (flip snoc) decCBOR
+  decCBOR = decodeSetLikeEnforceNoDuplicates (flip snoc) (\oset -> (size oset, oset)) decCBOR
 
 -- | \( O(1) \). Shallow invariant using just `length` and `size`.
 invariantHolds :: OSet a -> Bool

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0.0
 
+* Remove unused and badly named `decodeMapNoDuplicates`
 * Fix `decodeVMap` to no longer allow duplicates
 * Add `decodeMapLikeEnforceNoDuplicates` and `decodeListLikeWithCount`
 * Change the semantics of one argument for `decodeListLikeEnforceNoDuplicates` and

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.3.0.0
 
+* Fix `decodeVMap` to no longer allow duplicates
+* Add `decodeMapLikeEnforceNoDuplicates` and `decodeListLikeWithCount`
+* Change the semantics of one argument for `decodeListLikeEnforceNoDuplicates` and
+  `decodeSetLikeEnforceNoDuplicates` functions from checking membership to geting the size
+* Change `decodeListLikeEnforceNoDuplicates` to also accept length decoding function
 * Add `decodeListLikeT` and `decodeListLike`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 * Add `encodeEnum` and `decodeEnumBounded`

--- a/libs/cardano-ledger-binary/bench/Bench.hs
+++ b/libs/cardano-ledger-binary/bench/Bench.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import Cardano.Ledger.Binary hiding (serialize)
+import Cardano.Ledger.Binary.Coders
+import Control.DeepSeq
+import Control.Monad
+import Criterion.Main
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import System.Random.Stateful
+
+data Serialized a = Serialized !Version !BS.ByteString
+
+instance NFData (Serialized a) where
+  rnf (Serialized v bs) = v `deepseq` rnf bs
+
+serialize :: Version -> (a -> Encoding) -> a -> Serialized a
+serialize v e t = Serialized v (serialize' v (e t))
+
+deserialize :: (forall s. Decoder s a) -> Serialized a -> a
+deserialize d (Serialized v bs) =
+  case decodeFullDecoder' v "Bench" d bs of
+    Left err -> error $ "Unexpected deserialization error: " ++ show err
+    Right val -> val
+
+deserializeA :: (forall s. Decoder s (Annotator a)) -> Serialized a -> a
+deserializeA d (Serialized v bs) =
+  case decodeFullAnnotator v "Bench" d (BSL.fromStrict bs) of
+    Left err -> error $ "Unexpected deserialization error: " ++ show err
+    Right val -> val
+
+main :: IO ()
+main = do
+  let
+    sz = 100000
+    stdGen = mkStdGen 2023
+    unifomMapM :: StatefulGen g m => Int -> g -> m (Map Integer Integer)
+    unifomMapM mapSize gen =
+      let largeInteger = uniformRM (0, 100000000 * toInteger (maxBound :: Word)) gen
+       in Map.fromList <$> replicateM mapSize ((,) <$> largeInteger <*> largeInteger)
+    uniformMapIO n = runStateGenT_ stdGen (unifomMapM n)
+
+  defaultMain
+    [ bgroup "Map" (benchMap (uniformMapIO sz))
+    , bgroup "Set" (benchSet (Map.keysSet <$> uniformMapIO sz))
+    ]
+
+benchMap ::
+  (EncCBOR a, EncCBOR b, NFData a, NFData b, Ord a, DecCBOR a, DecCBOR b) =>
+  IO (Map a b) ->
+  [Benchmark]
+benchMap mkUniformMap =
+  [ bgroup
+      "decodeMap"
+      [ env (serialize (natVersion @1) encCBOR <$> mkUniformMap) $
+          bench "Byron" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @2) encCBOR <$> mkUniformMap) $
+          bench "Shelley" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformMap) $
+          bench "Conway" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformMap) $
+          bench "Older" . nf (deserialize decodeMapCheckDuplicates)
+      ]
+  , bgroup
+      "Coders"
+      [ env (serialize (natVersion @2) encCBOR <$> mkUniformMap) $
+          bench "D Shelley" . nf (deserialize (decode From))
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformMap) $
+          bench "D Conway" . nf (deserialize (decode From))
+      ]
+  , bgroup
+      "mapDecodeA"
+      [ env (serialize (natVersion @2) encCBOR <$> mkUniformMap) $
+          bench "Shelley"
+            . nf (deserializeA (decode (mapDecodeA (D (pure <$> decCBOR)) (D (pure <$> decCBOR)))))
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformMap) $
+          bench "Conway"
+            . nf (deserializeA (decode (mapDecodeA (D (pure <$> decCBOR)) (D (pure <$> decCBOR)))))
+      ]
+  ]
+  where
+    -- older implementation that checked duplicates for each element and used an insert
+    decodeMapCheckDuplicates = do
+      let decodeInlinedPair m = do
+            !key <- decCBOR
+            when (key `Map.member` m) $ fail "Duplicate detected"
+            !value <- decCBOR
+            pure (key, value)
+      snd <$> decodeListLikeWithCount decodeMapLenOrIndef (uncurry Map.insert) decodeInlinedPair
+
+benchSet ::
+  (EncCBOR a, NFData a, Ord a, DecCBOR a) =>
+  IO (Set a) ->
+  [Benchmark]
+benchSet mkUniformSet =
+  [ bgroup
+      "decodeSet"
+      [ env (serialize (natVersion @1) encCBOR <$> mkUniformSet) $
+          bench "Byron" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @2) encCBOR <$> mkUniformSet) $
+          bench "Shelley" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformSet) $
+          bench "Conway" . nf (deserialize decCBOR)
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformSet) $
+          bench "Older" . nf (deserialize decodeSetCheckDuplicates)
+      ]
+  , bgroup
+      "Coders"
+      [ env (serialize (natVersion @2) encCBOR <$> mkUniformSet) $
+          bench "D Shelley" . nf (deserialize (decode From))
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformSet) $
+          bench "D Conway" . nf (deserialize (decode From))
+      ]
+  , bgroup
+      "mapDecodeA"
+      [ env (serialize (natVersion @2) encCBOR <$> mkUniformSet) $
+          bench "Shelley"
+            . nf (deserializeA (decode (setDecodeA (D (pure <$> decCBOR)))))
+      , env (serialize (natVersion @9) encCBOR <$> mkUniformSet) $
+          bench "Conway"
+            . nf (deserializeA (decode (setDecodeA (D (pure <$> decCBOR)))))
+      ]
+  ]
+  where
+    -- older implementation that checked duplicates for each element and used an insert
+    decodeSetCheckDuplicates = do
+      let decodeInlinedPair m = do
+            !value <- decCBOR
+            when (value `Set.member` m) $ fail "Duplicate detected"
+            pure value
+      allowTag setTag
+      snd <$> decodeListLikeWithCount decodeListLenOrIndef Set.insert decodeInlinedPair

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -59,6 +59,7 @@ library
         containers,
         data-fix,
         deepseq,
+        FailT,
         formatting,
         iproute,
         microlens,

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -173,3 +173,22 @@ test-suite tests
         time,
         vector,
         vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -74,7 +74,6 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
   decodeSetLikeEnforceNoDuplicates,
   decodeListLikeEnforceNoDuplicates,
   decodeMapContents,
-  decodeMapNoDuplicates,
 
   -- **** Applicaitve
   decodeMapTraverse,
@@ -995,22 +994,6 @@ decodeSeq decoder = Seq.fromList <$> decodeCollection decodeListLenOrIndef decod
 decodeStrictSeq :: Decoder s a -> Decoder s (SSeq.StrictSeq a)
 decodeStrictSeq decoder = SSeq.fromList <$> decodeCollection decodeListLenOrIndef decoder
 {-# INLINE decodeStrictSeq #-}
-
--- | Just like `decodeMap`, but assumes that there are no duplicate keys, which is not enforced.
-decodeMapNoDuplicates :: Ord a => Decoder s a -> Decoder s b -> Decoder s (Map.Map a b)
-decodeMapNoDuplicates decodeKey decodeValue =
-  snd
-    <$> decodeListLikeWithCount
-      decodeMapLenOrIndef
-      (uncurry Map.insert)
-      (const decodeInlinedPair)
-  where
-    decodeInlinedPair = do
-      !key <- decodeKey
-      !value <- decodeValue
-      pure (key, value)
-    {-# INLINE decodeInlinedPair #-}
-{-# INLINE decodeMapNoDuplicates #-}
 
 decodeMapContents :: Decoder s a -> Decoder s [a]
 decodeMapContents = decodeCollection decodeMapLenOrIndef

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -30,6 +30,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Control.DeepSeq (NFData)
+import Control.Monad.Trans.Fail.String (errorFail)
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
@@ -43,13 +44,17 @@ import NoThunks.Class (NoThunks)
 -- | Protocol version number that is used during encoding and decoding. All supported
 -- versions are in the range from `MinVersion` to `MaxVersion`.
 newtype Version = Version Word64
-  deriving (Eq, Ord, Show, Enum, NFData, NoThunks, ToCBOR, ToJSON)
+  deriving (Eq, Ord, Show, NFData, NoThunks, ToCBOR, ToJSON)
 
 -- | Minimum supported version
 type MinVersion = 0
 
 -- | Maximum supported version. This is the protocol version of the next upcoming era
 type MaxVersion = 10
+
+instance Enum Version where
+  toEnum = errorFail . mkVersion
+  fromEnum (Version v) = fromEnum v
 
 instance Bounded Version where
   minBound = Version (fromInteger (natVal (Proxy @MinVersion)))

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -10,7 +10,7 @@
 
 module Cardano.Ledger.Binary.Version (
   -- * Versioning
-  Version (..),
+  Version,
   getVersion,
   MinVersion,
   MaxVersion,

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -69,7 +69,7 @@ instance ToExpr a => ToExpr (StrictSeq a) where
 instance ToExpr a => ToExpr (StrictMaybe a)
 
 instance ToExpr Version where
-  toExpr (Version n) = App "Version" [toExpr n]
+  toExpr v = App "Version" [toExpr (getVersion64 v)]
 
 instance ToExpr a => ToExpr (Sized a)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -35,7 +35,6 @@ module Cardano.Ledger.BaseTypes (
   PositiveInterval,
   NonNegativeInterval,
   BoundedRational (..),
-  BoundedRatio (..),
   fpPrecision,
   promoteRatio,
   invalidKey,

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -119,7 +119,11 @@ instance ToExpr TxIx
 instance ToExpr CertIx where
   toExpr (CertIx x) = App "CertIx" [toExpr x]
 
-instance ToExpr UnitInterval
+instance ToExpr UnitInterval where
+  toExpr = toExpr . unboundRational
+
+instance ToExpr NonNegativeInterval where
+  toExpr = toExpr . unboundRational
 
 instance ToExpr Network
 
@@ -132,10 +136,6 @@ instance ToExpr Nonce where
   toExpr (Nonce x) = App "Nonce" [trimExprViaShow 10 x]
 
 instance ToExpr DnsName
-
-instance (ToExpr x, ToExpr y, Integral y) => ToExpr (BoundedRatio x y)
-
-instance ToExpr NonNegativeInterval
 
 instance ToExpr (BlocksMade c)
 


### PR DESCRIPTION
# Description

#3893 exported a bunch of constructors that it shouldn't have

This PR fixes that.

Besides that there are two more fixes:

* Enum instance for Version was dangerous, since it was derived from the underlying `Word64`
* `decodeVMap` did not enforce no duplicate. Which is safe to fix without a hard fork, because that type is not used for the on-chain data

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
