### PR TITLE
Add some Imp tests for HardForkInitiation. Fixed a bug in Conway.Rules.Gov

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -11,7 +11,6 @@ module Test.Cardano.Ledger.Conway.Imp (
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject)
-import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (ConwayGovState, GovState)
 import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure (..))
 import Cardano.Ledger.Core (EraRule)
@@ -34,6 +33,3 @@ spec = do
     Enact.spec @era
     Epoch.spec @era
     Gov.spec @era
-
-_main :: IO ()
-_main = ledgerTestMain (spec @Conway)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -11,6 +11,7 @@ module Test.Cardano.Ledger.Conway.Imp (
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject)
+import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (ConwayGovState, GovState)
 import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure (..))
 import Cardano.Ledger.Core (EraRule)
@@ -33,3 +34,6 @@ spec = do
     Enact.spec @era
     Epoch.spec @era
     Gov.spec @era
+
+_main :: IO ()
+_main = ledgerTestMain (spec @Conway)


### PR DESCRIPTION
Added 6 Imp tests for HardforkInitiation GovActions
Fixed a bug in Conway.Rules.Gov where we used Proposals (already proposed in the past) instead of  ProposalProcedure whats proposed in the current Tx

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
