### PR TITLE
Conway genesis DRep injection

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.12.0.0
 
+* Add `registerInitialDReps` and `registerDRepDelegs`
+* Add `cgDRepDelegs`, `cgInitialDReps` to `ConwayGenesis`
 * Changed the type of lenses ppCommitteeMaxTermLengthL, ppuCommitteeMaxTermLengthL
 * Change 'getScriptWitnessConwayTxCert' so that DRepRegistration certificate requires a witness
 * Implement `ToJSON` and `FromJSON` instances for `PoolVotingThresholds` and

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -157,6 +157,7 @@ test-suite tests
     build-depends:
         aeson,
         base,
+        cardano-data,
         cardano-ledger-core:testlib,
         cardano-ledger-allegra,
         cardano-ledger-alonzo:testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -163,7 +163,7 @@ initEnactState ::
   PParams (ConwayEra c) ->
   PParams (ConwayEra c) ->
   EnactState (ConwayEra c)
-initEnactState (ConwayGenesis _ constitution committee) curPParams prevPParams =
+initEnactState (ConwayGenesis _ constitution committee _ _) curPParams prevPParams =
   def
     & ensConstitutionL .~ constitution
     & ensCommitteeL .~ SJust committee

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
@@ -7,9 +7,12 @@
 
 module Test.Cardano.Ledger.Conway.GenesisSpec (spec) where
 
+import Cardano.Ledger.BaseTypes (textToUrl)
+import Cardano.Ledger.CertState (DRep (..), DRepState (..))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import Cardano.Ledger.Conway.Governance (Committee (..))
+import Cardano.Ledger.Conway.Governance (Anchor (..), Committee (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Crypto (StandardCrypto)
@@ -17,7 +20,10 @@ import Cardano.Ledger.Keys
 import Cardano.Ledger.Slot (EpochNo (..))
 import Data.Aeson hiding (Encoding)
 import Data.Default.Class (Default (def))
+import qualified Data.ListMap as ListMap
 import Data.Map as Map
+import Data.Maybe (fromJust)
+import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Ratio ((%))
 import Paths_cardano_ledger_conway (getDataFileName)
 import Test.Cardano.Ledger.Common
@@ -60,5 +66,60 @@ goldenConwayGenesisJSON =
     cg <- case dec of
       Left err -> error ("Failed to deserialize JSON: " ++ err)
       Right x -> pure x
-    let expectedCg = def {cgCommittee = comm}
+    let
+      expectedCg =
+        def
+          { cgCommittee = comm
+          , cgInitialDReps =
+              ListMap.fromList
+                [
+                  ( KeyHashObj
+                      (KeyHash "78301005df84ba67fa1f12f95f8ee10335bc5e86c42afbc593ab4cdd")
+                  , DRepState
+                      { drepExpiry = 1000
+                      , drepAnchor = SNothing
+                      , drepDeposit = Coin 5000
+                      }
+                  )
+                ,
+                  ( ScriptHashObj
+                      (ScriptHash "01305df84b078ac5e86c42afbc593ab4cdd67fa1f12f95f8ee10335b")
+                  , DRepState
+                      { drepExpiry = 300
+                      , drepAnchor =
+                          SJust $
+                            Anchor
+                              { anchorUrl = fromJust $ textToUrl 99 "example.com"
+                              , anchorDataHash = def
+                              }
+                      , drepDeposit = Coin 6000
+                      }
+                  )
+                ]
+          , cgDRepDelegs =
+              ListMap.fromList
+                [
+                  ( KeyHashObj
+                      (KeyHash "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a")
+                  , DRepAlwaysAbstain
+                  )
+                ,
+                  ( KeyHashObj
+                      (KeyHash "35bc5e86c42afbc593ab4cdd78301005df84ba67fa1f12f95f8ee103")
+                  , DRepAlwaysNoConfidence
+                  )
+                ,
+                  ( ScriptHashObj
+                      (ScriptHash "afbc5005df84ba5f8ee93ab435bc5e83067fa1f12f9110386c42cdd7")
+                  , DRepCredential
+                      (KeyHashObj (KeyHash "78301005df84ba67fa1f12f95f8ee10335bc5e86c42afbc593ab4cdd"))
+                  )
+                ,
+                  ( KeyHashObj
+                      (KeyHash "afbc5005df84ba5f8ee93ab435bc5e83067fa1f12f9110386c42cdd7")
+                  , DRepCredential
+                      (ScriptHashObj (ScriptHash "01305df84b078ac5e86c42afbc593ab4cdd67fa1f12f95f8ee10335b"))
+                  )
+                ]
+          }
     cg `shouldBe` expectedCg

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -35,5 +35,25 @@
       "scriptHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": 2
     },
     "quorum": 0.5
+  },
+  "dRepDelegs": {
+    "keyHash-4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a": "drep-alwaysAbstain",
+    "keyHash-35bc5e86c42afbc593ab4cdd78301005df84ba67fa1f12f95f8ee103": "drep-alwaysNoConfidence",
+    "scriptHash-afbc5005df84ba5f8ee93ab435bc5e83067fa1f12f9110386c42cdd7": "drep-keyHash-78301005df84ba67fa1f12f95f8ee10335bc5e86c42afbc593ab4cdd",
+    "keyHash-afbc5005df84ba5f8ee93ab435bc5e83067fa1f12f9110386c42cdd7": "drep-scriptHash-01305df84b078ac5e86c42afbc593ab4cdd67fa1f12f95f8ee10335b"
+  },
+  "initialDReps": {
+    "keyHash-78301005df84ba67fa1f12f95f8ee10335bc5e86c42afbc593ab4cdd": {
+      "expiry": 1000,
+      "deposit": 5000
+    },
+    "scriptHash-01305df84b078ac5e86c42afbc593ab4cdd67fa1f12f95f8ee10335b": {
+      "expiry": 300,
+      "deposit": 6000,
+      "anchor": {
+        "url": "example.com",
+        "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    }
   }
 }

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -72,7 +72,13 @@ instance (Arbitrary (PParams era), Arbitrary (PParamsUpdate era), Era era) => Ar
   arbitrary = DRComplete <$> arbitrary <*> arbitrary
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
-  arbitrary = ConwayGenesis <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary =
+    ConwayGenesis
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary (UpgradeConwayPParams Identity) where
   arbitrary =

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.9.0.0
 
+* Change the signature of `protectMainnet` to make it work with any
+  `TransitionConfig`
+* Add `protectMainnetLens`
+* Add `tcNetworkIDG`
+* Add `sgInitialFundsL` and `sgStakingL`
 * Stop exporting all of the internal `hkd*` functions and `PParamsHKD` from
   `Cardano.Ledger.Shelley.Core`.
 * Deprecated unused `hashMultiSigScript`, `txwitsScript`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -36,6 +36,8 @@ module Cardano.Ledger.Shelley.Genesis (
   toNominalDiffTimeMicroWithRounding,
   fromNominalDiffTimeMicro,
   secondsToNominalDiffTimeMicro,
+  sgInitialFundsL,
+  sgStakingL,
 )
 where
 
@@ -103,6 +105,7 @@ import Data.Time.Clock (
 import Data.Unit.Strict (forceElemsToWHNF)
 import Data.Word (Word32, Word64)
 import GHC.Generics (Generic)
+import Lens.Micro (Lens', lens)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 
 -- | Genesis Shelley staking configuration.
@@ -221,6 +224,12 @@ data ShelleyGenesis c = ShelleyGenesis
   --   out-of-memory problems in testing and benchmarking.
   }
   deriving stock (Generic)
+
+sgInitialFundsL :: Lens' (ShelleyGenesis c) (LM.ListMap (Addr c) Coin)
+sgInitialFundsL = lens sgInitialFunds (\sg x -> sg {sgInitialFunds = x})
+
+sgStakingL :: Lens' (ShelleyGenesis c) (ShelleyGenesisStaking c)
+sgStakingL = lens sgStaking (\sg x -> sg {sgStaking = x})
 
 deriving instance Crypto c => Show (ShelleyGenesis c)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `registerInitialDReps`, `registerDRepDelegs`
 * Stop exporting `CostModels` internal representation
 * Change return type of `mintedTxBodyF` to `Set PolicyID`
 * Remove old and deprecated functions `evaluateTransactionExecutionUnits`,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Transition.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Transition.hs
@@ -23,11 +23,17 @@ module Cardano.Ledger.Api.Transition (
   createInitialState,
   registerInitialFunds,
   registerInitialStaking,
+  registerInitialDReps,
+  registerDRepDelegs,
 ) where
 
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Api.Era (LatestKnownEra)
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Conway.Transition (
+  registerDRepDelegs,
+  registerInitialDReps,
+ )
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
 import Cardano.Ledger.Shelley.Transition (


### PR DESCRIPTION
# Description

This PR adds `cgDRepDelegs` and `cgInitialDReps` fields to `ConwayGenesis` so the benchmark team can inject DReps and DRep delegations into the state.

The actual injection is done via `registerDRepDelegs` and `registerInitialDReps`, which are exported in the API.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
