### PR TITLE
Allow 128 byte Url and DnsNames for decoder version atleast 9.

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -349,7 +349,7 @@ pool_params = ( operator:       pool_keyhash
 port = uint .le 65535
 ipv4 = bytes .size 4
 ipv6 = bytes .size 16
-dns_name = tstr .size (0..64)
+dns_name = tstr .size (0..128)
 
 single_host_addr = ( 0
                    , port / null
@@ -370,7 +370,7 @@ relay =
   ]
 
 pool_metadata = [url, pool_metadata_hash]
-url = tstr .size (0..64)
+url = tstr .size (0..128)
 
 withdrawals = { + reward_account => coin }
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -58,7 +58,7 @@ spec =
             SNothing
             ( Constitution
                 ( Anchor
-                    (fromJust $ textToUrl "constitution.0")
+                    (fromJust $ textToUrl 64 "constitution.0")
                     constitutionHash
                 )
                 SNothing

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -449,7 +449,7 @@ newConstitution = do
   pure $
     Constitution
       ( Anchor
-          (fromJust $ textToUrl "constitution.0")
+          (fromJust $ textToUrl 64 "constitution.0")
           constitutionHash
       )
       SNothing

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -781,7 +781,7 @@ constitutionShouldBe cUrl = do
         fromMaybe
           (error "No constitution has been set")
           constitution
-  anchorUrl `shouldBe` fromJust (textToUrl $ T.pack cUrl)
+  anchorUrl `shouldBe` fromJust (textToUrl 64 $ T.pack cUrl)
 
 -- | Performs the action without running the fix-up function on any transactions
 withNoFixup :: ImpTestM era a -> ImpTestM era a

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -137,7 +137,7 @@ alicePoolParams =
     , ppMetadata =
         SJust $
           PoolMetadata
-            { pmUrl = fromJust $ textToUrl "alice.pool"
+            { pmUrl = fromJust $ textToUrl 64 "alice.pool"
             , pmHash = BS.pack "{}"
             }
     }

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -395,7 +395,7 @@ testEpochInfo = epochInfoPure testGlobals
 mkDummyAnchor :: Crypto c => Int -> Anchor c
 mkDummyAnchor n =
   Anchor
-    { anchorUrl = fromJust . textToUrl $ "dummy@" <> pack (show n)
+    { anchorUrl = fromJust . textToUrl 64 $ "dummy@" <> pack (show n)
     , anchorDataHash = mkDummySafeHash Proxy n
     }
 
@@ -567,7 +567,7 @@ examplePoolParams =
     , ppMetadata =
         SJust $
           PoolMetadata
-            { pmUrl = fromJust $ textToUrl "consensus.pool"
+            { pmUrl = fromJust $ textToUrl 64 "consensus.pool"
             , pmHash = "{}"
             }
     }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -121,11 +121,11 @@ alicePoolParams =
         StrictSeq.singleton $
           SingleHostName SNothing $
             fromJust $
-              textToDns "relay.io"
+              textToDns 64 "relay.io"
     , ppMetadata =
         SJust $
           PoolMetadata
-            { pmUrl = fromJust $ textToUrl "alice.pool"
+            { pmUrl = fromJust $ textToUrl 64 "alice.pool"
             , pmHash = BS.pack "{}"
             }
     }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -543,8 +543,8 @@ tests =
           poolRelays =
             StrictSeq.fromList
               [ SingleHostAddr SNothing (SJust ipv4) SNothing
-              , SingleHostName (SJust 42) $ Maybe.fromJust $ textToDns "singlehost.relay.com"
-              , MultiHostName $ Maybe.fromJust $ textToDns "multihost.relay.com"
+              , SingleHostName (SJust 42) $ Maybe.fromJust $ textToDns 64 "singlehost.relay.com"
+              , MultiHostName $ Maybe.fromJust $ textToDns 64 "multihost.relay.com"
               ]
        in checkEncodingCBOR
             shelleyProtVer
@@ -562,7 +562,7 @@ tests =
                     , ppMetadata =
                         SJust $
                           PoolMetadata
-                            { pmUrl = Maybe.fromJust $ textToUrl poolUrl
+                            { pmUrl = Maybe.fromJust $ textToUrl 64 poolUrl
                             , pmHash = poolMDHash
                             }
                     }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
@@ -248,8 +248,8 @@ exampleShelleyGenesis =
             (L.SJust $ L.Port 1234)
             (L.SJust $ read "0.0.0.0")
             (L.SJust $ read "2001:db8:a::123")
-        , L.SingleHostName L.SNothing (fromJust $ textToDns "cool.domain.com")
-        , L.MultiHostName (fromJust $ textToDns "cool.domain.com")
+        , L.SingleHostName L.SNothing (fromJust $ textToDns 64 "cool.domain.com")
+        , L.MultiHostName (fromJust $ textToDns 64 "cool.domain.com")
         ]
     poolParams :: L.PoolParams c
     poolParams =
@@ -265,7 +265,7 @@ exampleShelleyGenesis =
         , L.ppMetadata =
             L.SJust $
               L.PoolMetadata
-                { L.pmUrl = fromJust $ textToUrl "best.pool.com"
+                { L.pmUrl = fromJust $ textToUrl 64 "best.pool.com"
                 , L.pmHash = BS.pack "100ab{}100ab{}"
                 }
         }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -622,7 +622,7 @@ alicePoolParamsSmallCost =
     , ppMetadata =
         SJust $
           PoolMetadata
-            { pmUrl = fromJust $ textToUrl "alice.pool"
+            { pmUrl = fromJust $ textToUrl 64 "alice.pool"
             , pmHash = BS.pack "{}"
             }
     }

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -534,7 +534,7 @@ textSizeN :: MonadFail m => Int -> Text -> m Text
 textSizeN n t =
   if BS.length (encodeUtf8 t) <= n
     then pure t
-    else fail $ ("Text exceeds " ++ show n ++ " bytes:" ++ show t)
+    else fail $ "Text exceeds " ++ show n ++ " bytes:" ++ show t
 
 textDecCBOR :: Int -> Decoder s Text
 textDecCBOR n = decCBOR >>= textSizeN n

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -197,14 +197,14 @@ instance Arbitrary DnsName where
   arbitrary = do
     n <- chooseInt (5, 64)
     txt <- genDnsName n
-    pure $! guardLength n txt $ textToDns txt
+    pure $! guardLength n txt $ textToDns 64 txt
 
 instance Arbitrary Url where
   arbitrary = do
     let prefix = "https://"
     n <- chooseInt (5, 64 - T.length prefix)
     txt <- genDnsName n
-    pure $! guardLength n txt $ textToUrl (prefix <> txt)
+    pure $! guardLength n txt $ textToUrl 64 (prefix <> txt)
 
 instance Arbitrary Port where
   arbitrary = fromIntegral @Word16 @Port <$> arbitrary

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -582,7 +582,7 @@ poolMDHTooBigTx pf =
             , ppRewardAcnt = RewardAcnt Testnet (scriptStakeCredSuceed pf)
             , ppOwners = mempty
             , ppRelays = mempty
-            , ppMetadata = SJust $ PoolMetadata (fromJust $ textToUrl "") tooManyBytes
+            , ppMetadata = SJust $ PoolMetadata (fromJust $ textToUrl 64 "") tooManyBytes
             }
 
 -- ============================== Expected UTXO  ===============================


### PR DESCRIPTION
Make it possible to have Urls and DnsNames contain at most 128 bytes with dcoder versions at least 9
Add max byte size as extra parameters to functions  textToDns, and textToUrl,
Changed calls to "textToUrl xxx"  to   "textToUrl 64 xxx".  Same for textToDns.

Fixes #3941 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
