### PR TITLE
Switch ContextError to an injective type family from a data family

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
@@ -74,7 +74,7 @@ class
   ) =>
   EraPlutusContext era
   where
-  data ContextError era :: Type
+  type ContextError era = (r :: Type) | r -> era
 
   mkPlutusScriptContext ::
     PlutusScript era ->

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Alonzo.TreeDiff (
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.PParams
+import Cardano.Ledger.Alonzo.Plutus.Context
 import Cardano.Ledger.Alonzo.Plutus.Evaluate
 import Cardano.Ledger.Alonzo.Plutus.TxInfo
 import Cardano.Ledger.Alonzo.Rules
@@ -103,7 +104,7 @@ instance
 instance ToExpr (TxCert era) => ToExpr (ScriptPurpose era)
 
 -- Plutus/TxInfo
-instance ToExpr (ContextError (AlonzoEra c))
+instance ToExpr (AlonzoContextError era)
 
 instance (ToExpr (ContextError era), ToExpr (TxCert era)) => ToExpr (CollectError era)
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules
 import Cardano.Ledger.Babbage.TxBody
-import Cardano.Ledger.Babbage.TxInfo (ContextError (..))
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Shelley.Rules
@@ -32,7 +32,7 @@ deriving newtype instance ToExpr CoinPerByte
 instance ToExpr (PlutusScript (BabbageEra c))
 
 -- PlutusContext
-instance ToExpr (ContextError (BabbageEra c))
+instance ToExpr (BabbageContextError era)
 
 -- PParams
 instance ToExpr (BabbagePParams StrictMaybe era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Conway.TxCert
-import Cardano.Ledger.Conway.TxInfo (ContextError)
+import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.HKD
 import Data.Functor.Identity
@@ -35,7 +35,7 @@ instance ToExpr DRepVotingThresholds
 instance ToExpr (PlutusScript (ConwayEra c))
 
 -- PlutusContext
-instance ToExpr (ContextError (ConwayEra c))
+instance ToExpr (TxCert era) => ToExpr (ConwayContextError era)
 
 -- Governance/Procedure
 instance ToExpr GovActionIx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -14,9 +14,8 @@
 module Test.Cardano.Ledger.Examples.AlonzoCollectInputs (tests) where
 
 import Cardano.Ledger.Alonzo (Alonzo)
-import Cardano.Ledger.Alonzo.Plutus.Context (mkPlutusScriptContext)
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, mkPlutusScriptContext)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..), collectPlutusScriptsWithContext)
-import Cardano.Ledger.Alonzo.Plutus.TxInfo
 import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript (..), AlonzoScript (..), ExUnits (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Tag (Tag (..))
 import Cardano.Ledger.Alonzo.Tx (

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Babbage.TxInfo (
-  ContextError (InlineDatumsNotSupported, ReferenceInputsNotSupported, ReferenceScriptsNotSupported),
+  BabbageContextError (InlineDatumsNotSupported, ReferenceInputsNotSupported, ReferenceScriptsNotSupported),
  )
 import Cardano.Ledger.BaseTypes (
   Network (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -22,8 +22,8 @@ import Cardano.Ledger.Address (Addr (..), RewardAcnt (..))
 import Cardano.Ledger.Allegra.Rules as Allegra (AllegraUtxoPredFailure (..))
 import Cardano.Ledger.Allegra.Scripts (Timelock (..))
 import Cardano.Ledger.Alonzo.Core (CoinPerWord (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
-import Cardano.Ledger.Alonzo.Plutus.TxInfo (ContextError)
 import Cardano.Ledger.Alonzo.Rules as Alonzo (
   AlonzoBbodyPredFailure (..),
   AlonzoUtxoPredFailure (..),


### PR DESCRIPTION
# Description

This change is necessary because we can not use the initial approach of downgrading type families to previous eras. If we don't switch to type family from data family we can not use type families in the errors (eg. `TxCert`)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
