### PR TITLE
Abstract `getWitsVKeyNeeded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ If you are looking for the Ledger Releasing and Versioning Process then you can 
 [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd).
 
 ## 8.7
-	
+
 - Fix `PParamsUpdate` governance action ratification. Votes of DReps are now accounted for.
 - Move CDDL specification files from test packages into libraries that actually implement each era.
 - Add ability to retain Plutus logs for debugging when running scripts

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Binary (
   invalidKey,
   serialize,
  )
+import Cardano.Ledger.CertState (certDState, dsGenDelegs)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
@@ -169,9 +170,10 @@ utxoTransition ::
   ) =>
   TransitionRule (AllegraUTXO era)
 utxoTransition = do
-  TRC (Shelley.UtxoEnv slot pp certState genDelegs, utxos, tx) <- judgmentContext
+  TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
   let Shelley.UTxOState utxo _ _ ppup _ _ = utxos
-  let txBody = tx ^. bodyTxL
+      txBody = tx ^. bodyTxL
+      genDelegs = dsGenDelegs (certDState certState)
 
   {- ininterval slot (txvld tx) -}
   runTest $ validateOutsideValidityIntervalUTxO slot txBody

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -6,15 +6,14 @@
 
 module Cardano.Ledger.Allegra.UTxO () where
 
+import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.Era (AllegraEra)
-import Cardano.Ledger.Allegra.Tx ()
-import Cardano.Ledger.Allegra.TxBody ()
-import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
   getConsumedCoin,
   getShelleyScriptsNeeded,
+  getShelleyWitsVKeyNeeded,
   shelleyProducedValue,
  )
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..))
@@ -32,3 +31,5 @@ instance Crypto c => EraUTxO (AllegraEra c) where
   getScriptsNeeded = getShelleyScriptsNeeded
 
   getScriptsHashesNeeded (ShelleyScriptsNeeded scriptHashes) = scriptHashes
+
+  getWitsVKeyNeeded = getShelleyWitsVKeyNeeded

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -12,7 +12,6 @@ import Test.Cardano.Ledger.Allegra.TreeDiff ()
 import Test.Cardano.Ledger.Shelley.ImpTest (
   ShelleyEraImp (..),
   emptyShelleyImpNES,
-  shelleyImpWitsVKeyNeeded,
  )
 
 instance
@@ -24,5 +23,3 @@ instance
   ShelleyEraImp (AllegraEra c)
   where
   emptyImpNES = emptyShelleyImpNES
-
-  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -83,7 +83,7 @@ import Cardano.Ledger.Rules.ValidationMode (
  )
 import Cardano.Ledger.Shelley.LedgerState (
   PPUPPredFailure,
-  UTxOState (UTxOState),
+  UTxOState (utxosUtxo),
  )
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, UtxoEnv (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -468,8 +468,8 @@ utxoTransition ::
   ) =>
   TransitionRule (AlonzoUTXO era)
 utxoTransition = do
-  TRC (UtxoEnv slot pp dpstate _genDelegs, u, tx) <- judgmentContext
-  let UTxOState utxo _deposits _fees _ppup _ _ = u
+  TRC (UtxoEnv slot pp dpstate, utxos, tx) <- judgmentContext
+  let utxo = utxosUtxo utxos
 
   {-   txb := txbody tx   -}
   let txBody = tx ^. bodyTxL

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Binary.Coders
 import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.CertState (certDState, dsGenDelegs)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus.Evaluate (
@@ -257,9 +258,10 @@ alonzoEvalScriptsTxValid ::
   ) =>
   TransitionRule (AlonzoUTXOS era)
 alonzoEvalScriptsTxValid = do
-  TRC (UtxoEnv slot pp certState genDelegs, utxos@(UTxOState utxo _ _ pup _ _), tx) <-
+  TRC (UtxoEnv slot pp certState, utxos@(UTxOState utxo _ _ pup _ _), tx) <-
     judgmentContext
   let txBody = tx ^. bodyTxL
+      genDelegs = dsGenDelegs (certDState certState)
 
   () <- pure $! traceEvent validBegin ()
 
@@ -297,7 +299,7 @@ alonzoEvalScriptsTxInvalid ::
   ) =>
   TransitionRule (AlonzoUTXOS era)
 alonzoEvalScriptsTxInvalid = do
-  TRC (UtxoEnv slot pp _ _, us@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
+  TRC (UtxoEnv slot pp _, us@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
   let txBody = tx ^. bodyTxL
 
   let !_ = traceEvent invalidBegin ()

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -73,7 +73,6 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxowEvent (UtxoEvent),
   ShelleyUtxowPredFailure (..),
   UtxoEnv (..),
-  shelleyWitsVKeyNeeded,
   validateNeededWitnesses,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -325,7 +324,7 @@ alonzoStyleWitness ::
   ) =>
   TransitionRule (AlonzoUTXOW era)
 alonzoStyleWitness = do
-  (TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)) <- judgmentContext
+  (TRC (UtxoEnv slot pp certState genDelegs, u, tx)) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -363,7 +362,7 @@ alonzoStyleWitness = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
-  let needed = shelleyWitsVKeyNeeded utxo (tx ^. bodyTxL) genDelegs
+  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
   runTest $ validateNeededWitnesses @era witsKeyHashes needed
 
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but
@@ -393,7 +392,7 @@ alonzoStyleWitness = do
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptsHashesNeeded
 
   trans @(EraRule "UTXO" era) $
-    TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
+    TRC (UtxoEnv slot pp certState genDelegs, u, tx)
 
 -- ================================
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -363,8 +363,7 @@ alonzoStyleWitness = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
-  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
-  runTest $ validateNeededWitnesses @era witsKeyHashes needed
+  runTest $ validateNeededWitnesses witsKeyHashes certState utxo txBody
 
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but
       witsVKeyNeeded must include the reqSignerHashes in the union   -}

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
 import Cardano.Ledger.Mary.Value (PolicyID (..))
 import Cardano.Ledger.Plutus.Data (Data, Datum (..))
 import Cardano.Ledger.Shelley.TxBody (Withdrawals (..), getRwdCred)
-import Cardano.Ledger.Shelley.UTxO (shelleyProducedValue)
+import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeeded, shelleyProducedValue)
 import Cardano.Ledger.TxIn
 import Cardano.Ledger.UTxO (
   EraUTxO (..),
@@ -71,6 +71,8 @@ instance Crypto c => EraUTxO (AlonzoEra c) where
   getScriptsNeeded = getAlonzoScriptsNeeded
 
   getScriptsHashesNeeded = getAlonzoScriptsHashesNeeded
+
+  getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
 class EraUTxO era => AlonzoEraUTxO era where
   -- | Get data hashes for a transaction that are not required. Such datums are optional,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -46,5 +46,3 @@ instance
   ShelleyEraImp (AlonzoEra c)
   where
   emptyImpNES = emptyAlonzoImpNES
-
-  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -52,6 +52,7 @@ import Cardano.Ledger.BaseTypes (
   systemStart,
  )
 import Cardano.Ledger.Binary (EncCBOR (..))
+import Cardano.Ledger.CertState (certDState, dsGenDelegs)
 import Cardano.Ledger.Plutus.Evaluate (
   ScriptFailure (..),
   ScriptResult (..),
@@ -198,9 +199,10 @@ babbageEvalScriptsTxValid ::
   ) =>
   TransitionRule (BabbageUTXOS era)
 babbageEvalScriptsTxValid = do
-  TRC (UtxoEnv slot pp certState genDelegs, utxos@(UTxOState utxo _ _ pup _ _), tx) <-
+  TRC (UtxoEnv slot pp certState, utxos@(UTxOState utxo _ _ pup _ _), tx) <-
     judgmentContext
   let txBody = tx ^. bodyTxL
+      genDelegs = dsGenDelegs (certDState certState)
 
   -- We intentionally run the PPUP rule before evaluating any Plutus scripts.
   -- We do not want to waste computation running plutus scripts if the
@@ -240,7 +242,7 @@ babbageEvalScriptsTxInvalid ::
   ) =>
   TransitionRule (s era)
 babbageEvalScriptsTxInvalid = do
-  TRC (UtxoEnv _ pp _ _, us@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
+  TRC (UtxoEnv _ pp _, us@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
   {- txb := txbody tx -}
   let txBody = tx ^. bodyTxL
   sysSt <- liftSTS $ asks systemStart

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -56,7 +56,6 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxowEvent (UtxoEvent),
   ShelleyUtxowPredFailure,
   UtxoEnv (..),
-  shelleyWitsVKeyNeeded,
   validateNeededWitnesses,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -271,7 +270,7 @@ babbageUtxowTransition ::
   ) =>
   TransitionRule (BabbageUTXOW era)
 babbageUtxowTransition = do
-  (TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)) <- judgmentContext
+  (TRC (UtxoEnv slot pp certState genDelegs, u, tx)) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -310,7 +309,7 @@ babbageUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
-  let needed = shelleyWitsVKeyNeeded utxo (tx ^. bodyTxL) genDelegs
+  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
   runTest $ validateNeededWitnesses @era witsKeyHashes needed
   -- TODO can we add the required signers to witsVKeyNeeded so we dont need the check below?
 
@@ -348,7 +347,7 @@ babbageUtxowTransition = do
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptHashesNeeded
 
   trans @(EraRule "UTXO" era) $
-    TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
+    TRC (UtxoEnv slot pp certState genDelegs, u, tx)
 
 -- ================================
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -310,8 +310,7 @@ babbageUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes                   -}
-  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
-  runTest $ validateNeededWitnesses @era witsKeyHashes needed
+  runTest $ validateNeededWitnesses @era witsKeyHashes certState utxo txBody
   -- TODO can we add the required signers to witsVKeyNeeded so we dont need the check below?
 
   {-  THIS DOES NOT APPPEAR IN THE SPEC as a separate check, but

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
-import Cardano.Ledger.Shelley.UTxO (shelleyProducedValue)
+import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeeded, shelleyProducedValue)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..))
 import Control.Applicative
@@ -59,6 +59,8 @@ instance Crypto c => EraUTxO (BabbageEra c) where
   getScriptsNeeded = getAlonzoScriptsNeeded
 
   getScriptsHashesNeeded = getAlonzoScriptsHashesNeeded
+
+  getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
 instance Crypto c => AlonzoEraUTxO (BabbageEra c) where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -11,10 +11,7 @@ import Cardano.Ledger.Core (EraIndependentTxBody)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Test.Cardano.Ledger.Alonzo.ImpTest (emptyAlonzoImpNES)
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
-import Test.Cardano.Ledger.Shelley.ImpTest (
-  ShelleyEraImp (..),
-  shelleyImpWitsVKeyNeeded,
- )
+import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp (..))
 
 instance
   ( Crypto c
@@ -23,5 +20,3 @@ instance
   ShelleyEraImp (BabbageEra c)
   where
   emptyImpNES = emptyAlonzoImpNES
-
-  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs
@@ -152,7 +152,7 @@ data HDPassphrase = HDPassphrase !ByteString
 --
 -- It consisted of
 --
---   * serialiazed and encrypted using HDPassphrase derivation path from the
+--   * serialized and encrypted using HDPassphrase derivation path from the
 --   root key to given descendant key (using ChaChaPoly1305 algorithm)
 --
 --   * cryptographic tag

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.BaseTypes (Inject (..), ShelleyBase, StrictMaybe (..), epo
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Block (txid)
-import Cardano.Ledger.CertState (certDStateL, dsGenDelegsL)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayCERTS, ConwayGOV, ConwayLEDGER, ConwayUTXOW)
@@ -320,7 +319,7 @@ ledgerTransition = do
         -- Pass to UTXOW the unmodified CertState in its Environment, so it can process
         -- refunds of deposits for deregistering stake credentials and DReps.
         -- The modified CertState (certStateAfterCERTS) has these already removed from its UMap.
-        ( UtxoEnv @era slot pp certState (certState ^. certDStateL . dsGenDelegsL)
+        ( UtxoEnv @era slot pp certState
         , utxoState'
         , tx
         )

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -127,7 +127,7 @@ conwayEvalScriptsTxValid ::
   ) =>
   TransitionRule (ConwayUTXOS era)
 conwayEvalScriptsTxValid = do
-  TRC (UtxoEnv _ pp certState _, utxos@(UTxOState utxo _ _ govState _ _), tx) <-
+  TRC (UtxoEnv _ pp certState, utxos@(UTxOState utxo _ _ govState _ _), tx) <-
     judgmentContext
   let txBody = tx ^. bodyTxL
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -40,10 +40,9 @@ import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayUTXOW)
-import Cardano.Ledger.Conway.Governance (Voter (..), VotingProcedures (..))
-import Cardano.Ledger.Credential (credKeyHashWitness)
+import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
 import Cardano.Ledger.Crypto (DSIGN, HASH)
-import Cardano.Ledger.Keys (KeyHash, KeyRole (..), asWitness)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Rules.ValidationMode (runTest, runTestOnSignal)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Cardano.Ledger.Shelley.Rules (
@@ -88,7 +87,7 @@ conwayUtxowTransition ::
   ) =>
   TransitionRule (ConwayUTXOW era)
 conwayUtxowTransition = do
-  (TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)) <- judgmentContext
+  (TRC (UtxoEnv slot pp certState genDelegs, u, tx)) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -127,14 +126,13 @@ conwayUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx ⊆ witsKeyHashes                   -}
-  let needed = conwayWitsVKeyNeeded utxo (tx ^. bodyTxL)
+  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
   runTest $ validateNeededWitnesses @era witsKeyHashes needed
 
   -- check metadata hash
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  runTestOnSignal $
-    Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp tx
 
   {- ∀x ∈ range(txdats txw) ∪ range(txwitscripts txw) ∪ (⋃ ( , ,d,s) ∈ txouts tx {s, d}),
                          x ∈ Script ∪ Datum ⇒ isWellFormed x
@@ -152,31 +150,15 @@ conwayUtxowTransition = do
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptHashesNeeded
 
   trans @(EraRule "UTXO" era) $
-    TRC (UtxoEnv slot pp stakepools genDelegs, u, tx)
-
-voterWitnesses ::
-  ConwayEraTxBody era =>
-  TxBody era ->
-  Set (KeyHash 'Witness (EraCrypto era))
-voterWitnesses txb =
-  Map.foldrWithKey' accum mempty (unVotingProcedures (txb ^. votingProceduresTxBodyL))
-  where
-    accum voter _ khs =
-      maybe khs (`Set.insert` khs) $
-        case voter of
-          CommitteeVoter cred -> credKeyHashWitness cred
-          DRepVoter cred -> credKeyHashWitness cred
-          StakePoolVoter poolId -> Just $ asWitness poolId
+    TRC (UtxoEnv slot pp certState genDelegs, u, tx)
 
 conwayWitsVKeyNeeded ::
   (EraTx era, ConwayEraTxBody era) =>
   UTxO era ->
   TxBody era ->
   Set (KeyHash 'Witness (EraCrypto era))
-conwayWitsVKeyNeeded utxo txBody =
-  Shelley.witsVKeyNeededNoGov utxo txBody
-    `Set.union` (txBody ^. reqSignerHashesTxBodyL)
-    `Set.union` voterWitnesses txBody
+conwayWitsVKeyNeeded = getConwayWitsVKeyNeeded
+{-# DEPRECATED conwayWitsVKeyNeeded "In favor of `getConwayWitsVKeyNeeded` or `getWitsVKeyNeeded`" #-}
 
 -- ================================
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -126,8 +126,7 @@ conwayUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {-  witsVKeyNeeded utxo tx ⊆ witsKeyHashes                   -}
-  let needed = getWitsVKeyNeeded certState utxo (tx ^. bodyTxL)
-  runTest $ validateNeededWitnesses @era witsKeyHashes needed
+  runTest $ validateNeededWitnesses witsKeyHashes certState utxo txBody
 
   -- check metadata hash
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -87,7 +87,7 @@ conwayUtxowTransition ::
   ) =>
   TransitionRule (ConwayUTXOW era)
 conwayUtxowTransition = do
-  (TRC (UtxoEnv slot pp certState genDelegs, u, tx)) <- judgmentContext
+  (TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx)) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -149,8 +149,7 @@ conwayUtxowTransition = do
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptHashesNeeded
 
-  trans @(EraRule "UTXO" era) $
-    TRC (UtxoEnv slot pp certState genDelegs, u, tx)
+  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, tx)
 
 conwayWitsVKeyNeeded ::
   (EraTx era, ConwayEraTxBody era) =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -102,7 +102,6 @@ import Cardano.Ledger.Conway.Rules (
   EnactSignal,
   committeeAccepted,
   committeeAcceptedRatio,
-  conwayWitsVKeyNeeded,
   dRepAccepted,
   dRepAcceptedRatio,
   prevActionAsExpected,
@@ -123,7 +122,6 @@ import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState (
   IncrementalStake (..),
-  NewEpochState,
   asTreasuryL,
   certVStateL,
   curPParamsEpochStateL,
@@ -137,7 +135,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesPdL,
   newEpochStateGovStateL,
   utxosStakeDistrL,
-  utxosUtxoL,
   vsCommitteeStateL,
   vsDRepsL,
  )
@@ -151,7 +148,6 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (isSJust)
 import qualified Data.OSet.Strict as OSet
 import qualified Data.Sequence.Strict as SSeq
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (&), (.~), (^.))
 import Test.Cardano.Ledger.Alonzo.ImpTest as ImpTest
@@ -159,17 +155,6 @@ import Test.Cardano.Ledger.Conway.TreeDiff ()
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
-
-conwayImpWitsVKeyNeeded ::
-  ( EraTx era
-  , ConwayEraTxBody era
-  ) =>
-  NewEpochState era ->
-  TxBody era ->
-  Set (KeyHash 'Witness (EraCrypto era))
-conwayImpWitsVKeyNeeded nes = conwayWitsVKeyNeeded utxo
-  where
-    utxo = nes ^. nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
 
 -- | Modify the PParams in the current state with the given function
 conwayModifyPParams ::
@@ -202,8 +187,6 @@ instance
         epochState = nes ^. nesEsL
         ratifyState = def & rsEnactStateL .~ (epochState ^. epochStateGovStateL . cgEnactStateL)
      in nes & nesEsL .~ setCompleteDRepPulsingState def ratifyState epochState
-
-  impWitsVKeyNeeded = conwayImpWitsVKeyNeeded
 
   modifyPParams = conwayModifyPParams
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -13,12 +13,11 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyRole (DRepRole, Staking))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
-import Cardano.Ledger.Mary.Tx ()
-import Cardano.Ledger.Mary.TxBody ()
 import Cardano.Ledger.Mary.Value (MaryValue, policyID)
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
   getShelleyScriptsNeeded,
+  getShelleyWitsVKeyNeeded,
   shelleyProducedValue,
  )
 import Cardano.Ledger.UTxO (
@@ -45,6 +44,8 @@ instance Crypto c => EraUTxO (MaryEra c) where
   getScriptsNeeded = getMaryScriptsNeeded
 
   getScriptsHashesNeeded (ShelleyScriptsNeeded scriptHashes) = scriptHashes
+
+  getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
 -- | Calculate the value consumed by the transation.
 --

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -12,7 +12,6 @@ import Test.Cardano.Ledger.Mary.TreeDiff ()
 import Test.Cardano.Ledger.Shelley.ImpTest (
   ShelleyEraImp (..),
   emptyShelleyImpNES,
-  shelleyImpWitsVKeyNeeded,
  )
 
 instance
@@ -22,5 +21,3 @@ instance
   ShelleyEraImp (MaryEra c)
   where
   emptyImpNES = emptyShelleyImpNES
-
-  impWitsVKeyNeeded = shelleyImpWitsVKeyNeeded

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `getShelleyWitsVKeyNeeded` and `getShelleyWitsVKeyNeededNoGov`
 * Deprecate `witsVKeyNeededNoGov` and `shelleyWitsVKeyNeeded`
+* Get rid of `ueGenDelegs` and `ueGenDelegsL` as unnecessary.
 * Change the signature of `protectMainnet` to make it work with any
   `TransitionConfig`
 * Add `protectMainnetLens`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Change the type signature and the logic in `validateNeededWitnesses`
 * Add `getShelleyWitsVKeyNeeded` and `getShelleyWitsVKeyNeededNoGov`
 * Deprecate `witsVKeyNeededNoGov` and `shelleyWitsVKeyNeeded`
 * Get rid of `ueGenDelegs` and `ueGenDelegsL` as unnecessary.

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Add `getShelleyWitsVKeyNeeded` and `getShelleyWitsVKeyNeededNoGov`
+* Deprecate `witsVKeyNeededNoGov` and `shelleyWitsVKeyNeeded`
 * Change the signature of `protectMainnet` to make it work with any
   `TransitionConfig`
 * Add `protectMainnetLens`
@@ -36,6 +38,7 @@
 
 ### `testlib`
 
+* Extract `impWitsVKeyNeeded` from the `ShelleyEraImp` type class
 * Add:
   `fixupFees`
   `impLastTickL`

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Address/Bootstrap.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Keys (
-  GenDelegs (..),
   KeyRole (..),
   VKey (..),
   coerceKeyRole,
@@ -176,7 +175,6 @@ utxoEnv =
     0
     (emptyPParams & ppMaxTxSizeL .~ 1000)
     def
-    (GenDelegs mempty)
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin 1000000

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -17,10 +17,7 @@ module Test.Cardano.Ledger.Shelley.MultiSigExamples (
 ) where
 
 import qualified Cardano.Crypto.Hash as Hash
-import Cardano.Ledger.Address (
-  Addr,
-  pattern Addr,
- )
+import Cardano.Ledger.Address (Addr (Addr))
 import Cardano.Ledger.BaseTypes (
   Network (..),
   StrictMaybe (..),
@@ -35,7 +32,6 @@ import Cardano.Ledger.Credential (
   pattern StakeRefBase,
  )
 import Cardano.Ledger.Keys (
-  GenDelegs (..),
   KeyHash (..),
   KeyRole (..),
   asWitness,
@@ -253,7 +249,6 @@ initialUTxOState aliceKeep msigs =
                         (SlotNo 0)
                         initPParams
                         def
-                        (GenDelegs Map.empty)
                     , lsUTxOState genesis
                     , tx
                     )
@@ -307,7 +302,6 @@ applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
                   (SlotNo 0)
                   initPParams
                   def
-                  (GenDelegs Map.empty)
               , utxoSt
               , tx
               )

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -78,9 +78,7 @@ import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeHash, extractHash)
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState,
   UTxOState (..),
-  certDStateL,
   curPParamsEpochStateL,
-  dsGenDelegsL,
   esLStateL,
   lsCertStateL,
   lsUTxOStateL,
@@ -617,7 +615,6 @@ trySubmitTxConform txPreFixup = do
       UtxoEnv
         { ueSlot = lastTick
         , uePParams = pParams
-        , ueGenDelegs = certState ^. certDStateL . dsGenDelegsL
         , ueCertState = certState
         }
   agdaUtxoEnv <- expectRight $ toSpecRep utxoEnv

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.10.0.0
 
-* Changed the type of the Lenses ppMaxBBSizeL, ppMaxTxSizeL, ppMaxBHSizeL, ppuMaxBBSizeL, ppuMaxTxSizeL and ppuMaxBHSizeL
+* Add `getWitsVKeyNeeded` to `EraUTxO`
+* Changed the type of the lenses `ppMaxBBSizeL`, `ppMaxTxSizeL`, `ppMaxBHSizeL`,
+  `ppuMaxBBSizeL`, `ppuMaxTxSizeL` and `ppuMaxBHSizeL`
 * Fix `ToJSON`/`FromJSON` for `CostModels`. Make sure that `CostModels` can roundtrip
   through JSON. Also report `CostModels` failures in JSON.
 * Add `costModelParamsCount`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
@@ -46,6 +46,7 @@ import Cardano.Ledger.Binary (
   decodeMap,
  )
 import Cardano.Ledger.Block (txid)
+import Cardano.Ledger.CertState (CertState)
 import Cardano.Ledger.Coin (Coin, CompactForm (CompactCoin))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
@@ -252,3 +253,7 @@ class EraTx era => EraUTxO era where
 
   -- | Extract the set of all script hashes that are needed for script validation.
   getScriptsHashesNeeded :: ScriptsNeeded era -> Set (ScriptHash (EraCrypto era))
+
+  -- | Extract all of the KeyHash witnesses that are required for validating the transaction
+  getWitsVKeyNeeded ::
+    CertState era -> UTxO era -> TxBody era -> Set (KeyHash 'Witness (EraCrypto era))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -19,7 +19,6 @@ import Cardano.Ledger.Api.Tx (TransactionScriptFailure (..), evalTxExUnits)
 import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase, inject)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.Plutus.Data (Data (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Plutus.TxInfo (exBudgetToExUnits, transExUnits)
@@ -228,7 +227,7 @@ exampleEpochInfo :: Monad m => EpochInfo m
 exampleEpochInfo = fixedEpochInfo (EpochSize 100) (mkSlotLength 1)
 
 uenv :: AlonzoEraPParams era => UtxoEnv era
-uenv = UtxoEnv (SlotNo 0) testPParams def (GenDelegs mempty)
+uenv = UtxoEnv (SlotNo 0) testPParams def
 
 ustate ::
   ( EraTxOut era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -62,12 +62,8 @@ import Cardano.Ledger.Credential (
   StakeCredential,
   StakeReference (..),
  )
-import qualified Cardano.Ledger.Crypto as CC
-import Cardano.Ledger.Keys (
-  GenDelegs (..),
-  KeyRole (..),
-  hashKey,
- )
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.Keys (KeyRole (..), hashKey)
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Pretty
 import Cardano.Ledger.Pretty.Babbage ()
@@ -271,7 +267,7 @@ instance AlonzoBased (ConwayEra c) (BabbageUtxowPredFailure (ConwayEra c)) where
 -- ========================= Shared helper functions  ===================
 -- ======================================================================
 
-mkGenesisTxIn :: (CH.HashAlgorithm (CC.HASH c), HasCallStack) => Integer -> TxIn c
+mkGenesisTxIn :: (CH.HashAlgorithm (HASH c), HasCallStack) => Integer -> TxIn c
 mkGenesisTxIn = TxIn genesisId . mkTxIxPartial
 
 mkTxDats :: Era era => Data era -> TxDats era
@@ -347,7 +343,7 @@ testUTXOWsubset (UTXOW other) _ = error ("Cannot use testUTXOW in era " ++ show 
 
 -- | Use a test where any two (ValidationTagMismatch x y) failures match regardless of 'x' and 'y'
 testUTXOspecialCase wit@(UTXOW proof) utxo pparam tx expected =
-  let env = UtxoEnv (SlotNo 0) pparam def (GenDelegs mempty)
+  let env = UtxoEnv (SlotNo 0) pparam def
       state = smartUTxOState pparam utxo (Coin 0) (Coin 0) def mempty
    in case proof of
         Alonzo _ -> runSTS wit (TRC (env, state, tx)) (specialCont proof expected)
@@ -374,7 +370,7 @@ testUTXOWwith ::
   Result era ->
   Assertion
 testUTXOWwith wit@(UTXOW proof) cont utxo pparams tx expected =
-  let env = UtxoEnv (SlotNo 0) pparams def (GenDelegs mempty)
+  let env = UtxoEnv (SlotNo 0) pparams def
       state = smartUTxOState pparams utxo (Coin 0) (Coin 0) def mempty
    in case proof of
         Conway _ -> runSTS wit (TRC (env, state, tx)) (cont expected)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..), IsValid (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
-import Cardano.Ledger.Keys (GenDelegs (..))
 import Cardano.Ledger.Pretty (PrettyA (..), ppList)
 import Cardano.Ledger.Shelley.LedgerState (
   AccountState (..),
@@ -41,7 +40,12 @@ import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.Cardano.Ledger.Binary.Twiddle (Twiddle, twiddleInvariantProp)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
-import Test.Cardano.Ledger.Generic.Fields (abstractTx, abstractTxBody, abstractTxOut, abstractWitnesses)
+import Test.Cardano.Ledger.Generic.Fields (
+  abstractTx,
+  abstractTxBody,
+  abstractTxOut,
+  abstractWitnesses,
+ )
 import Test.Cardano.Ledger.Generic.Functions (TotalAda (totalAda), isValid')
 import Test.Cardano.Ledger.Generic.GenState (
   GenEnv (..),
@@ -78,22 +82,22 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 genTxAndUTXOState :: Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
 genTxAndUTXOState proof@(Conway _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Babbage _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Alonzo _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Mary _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Allegra _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@(Shelley _) gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
-  pure (TRC (UtxoEnv slotNo pp def (GenDelegs mempty), lsUTxOState ledgerState, vtx), genState)
+  pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 
 genTxAndLEDGERState ::
   forall era.


### PR DESCRIPTION
# Description

Turns out `GenDelegs` is totally unnecessary in the `UtxoEnv`. This PR removes it.

Also it adds an era agnostic `getWitsVKeyNeeded` that we can now use in UTXOW rules for all eras.

This is a nice organization and simplification, but the real reason for this change is that we need to provide a proper min fee computation for CLI, which will be implemented in a subsequent PR

Fixes #3485 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
