### PR TITLE
Ignore thunks in `utxosDeposited`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -79,7 +79,7 @@ import qualified Data.Map.Strict as Map
 import Data.VMap (VB, VMap, VP)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import Numeric.Natural (Natural)
 
 -- ==================================
@@ -300,12 +300,16 @@ deriving stock instance
   ) =>
   Eq (UTxOState era)
 
-instance
-  ( NoThunks (UTxO era)
-  , NoThunks (Value era)
-  , NoThunks (GovState era)
-  ) =>
-  NoThunks (UTxOState era)
+deriving via
+  AllowThunksIn
+    '["utxosDeposited"]
+    (UTxOState era)
+  instance
+    ( NoThunks (UTxO era)
+    , NoThunks (GovState era)
+    , Era era
+    ) =>
+    NoThunks (UTxOState era)
 
 instance
   ( EraTxOut era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -452,8 +453,9 @@ payPoolDeposit ::
 payPoolDeposit keyhash pp pstate = pstate {psDeposits = newpool}
   where
     pool = psDeposits pstate
+    !deposit = pp ^. ppPoolDepositL
     newpool
-      | Map.notMember keyhash pool = Map.insert keyhash (pp ^. ppPoolDepositL) pool
+      | Map.notMember keyhash pool = Map.insert keyhash deposit pool
       | otherwise = pool
 
 refundPoolDeposit :: KeyHash 'StakePool (EraCrypto era) -> PState era -> (Coin, PState era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -709,7 +710,7 @@ initialLedgerState gstate = LedgerState utxostate dpstate
     pools = gsInitialPoolParams gstate
     pp = mPParams (gsModel gstate)
     keyDeposit = pp ^. ppKeyDepositL
-    poolDeposit = pp ^. ppPoolDepositL
+    !poolDeposit = pp ^. ppPoolDepositL
     rdpair rew = UM.RDPair (UM.compactCoinOrError rew) (UM.compactCoinOrError keyDeposit)
 
 -- =============================================


### PR DESCRIPTION
# Description

This fixes the "thunks present" failures in the nightly tests. We allow thunks in the `utxosDeposited` field because we only use that field in tests. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
