### PR TITLE
Update cddl gem and dependencies

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install cbor-diag and cddl
       run: |
-        gem install cddl -v 0.8.15
+        gem install cddl -v 0.10.3
         gem install cbor-diag
 
     - name: Install Haskell

--- a/nix/pkgs/cddl/Gemfile.lock
+++ b/nix/pkgs/cddl/Gemfile.lock
@@ -1,27 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    abnc (0.1.0)
-    abnftt (0.2.2)
+    abnc (0.1.1)
+    abnftt (0.2.4)
+    base32 (0.3.4)
     cbor-canonical (0.1.2)
     cbor-deterministic (0.1.3)
-    cbor-diag (0.7.6)
+    cbor-diag (0.8.7)
       cbor-canonical
       cbor-deterministic
       cbor-packed
-      json
+      json_pure
       neatjson
       treetop (~> 1)
     cbor-packed (0.1.3)
-    cddl (0.8.27)
+    cddl (0.10.3)
       abnc
       abnftt
+      base32 (~> 0.3)
       cbor-diag
       colorize
-      json
+      json_pure
       regexp-examples
     colorize (0.8.1)
-    json (2.6.1)
+    json_pure (2.7.1)
     neatjson (0.9)
     polyglot (0.3.5)
     regexp-examples (1.5.1)

--- a/nix/pkgs/cddl/gemset.nix
+++ b/nix/pkgs/cddl/gemset.nix
@@ -4,20 +4,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13nvzrk72nj130fs8bq8q3cfm48939rdzh7l31ncj5c4969hrbig";
+      sha256 = "0yj09gc9w208wsy0d45vzha4zfwxdpsqvkm9vms0chm4lxdwdg9x";
       type = "gem";
     };
-    version = "0.1.0";
+    version = "0.1.1";
   };
   abnftt = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06ixnwqh5j83z7q7dab3p4xa3vbc332y42i7zkj1x6hzsvvkwngj";
+      sha256 = "1z7ibh0xv9mqk61rvvmz9fnfk6hffvnppqd8fx61vazjhisi9bcs";
       type = "gem";
     };
-    version = "0.2.2";
+    version = "0.2.4";
+  };
+  base32 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fjs0l3c5g9qxwp43kcnhc45slx29yjb6m6jxbb2x1krgjmi166b";
+      type = "gem";
+    };
+    version = "0.3.4";
   };
   cbor-canonical = {
     groups = ["default"];
@@ -40,15 +50,15 @@
     version = "0.1.3";
   };
   cbor-diag = {
-    dependencies = ["cbor-canonical" "cbor-deterministic" "cbor-packed" "json" "neatjson" "treetop"];
+    dependencies = ["cbor-canonical" "cbor-deterministic" "cbor-packed" "json_pure" "neatjson" "treetop"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1r84bf00h6lv05l9bb9sj27jl5kbr466qk4i18z3fimn3z62i908";
+      sha256 = "0rwd88xngbjamgydj9rg3wvgl53pfzhal2n702s9afa1yp8mjm51";
       type = "gem";
     };
-    version = "0.7.6";
+    version = "0.8.7";
   };
   cbor-packed = {
     groups = ["default"];
@@ -61,15 +71,16 @@
     version = "0.1.3";
   };
   cddl = {
-    dependencies = ["abnc" "abnftt" "cbor-diag" "colorize" "json" "regexp-examples"];
+    dontPatchShebangs = 1;
+    dependencies = ["abnc" "abnftt" "base32" "cbor-diag" "colorize" "json_pure" "regexp-examples"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09jw3ynhbrsim9vg83l6xrh168111xr6x8mzyp5zqpm782gzqs5v";
+      sha256 = "1qll1qvn3g75r742kr4da7240zdk2qj4vh325965rrjqp8brz23q";
       type = "gem";
     };
-    version = "0.8.27";
+    version = "0.10.3";
   };
   colorize = {
     groups = ["default"];
@@ -81,15 +92,15 @@
     };
     version = "0.8.1";
   };
-  json = {
+  json_pure = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1z9grvjyfz16ag55hg522d3q4dh07hf391sf9s96npc0vfi85xkz";
+      sha256 = "09w7f7xlcas9irlaavhz0rnh17cjvjmmqm07drgghx5gwjcrar31";
       type = "gem";
     };
-    version = "2.6.1";
+    version = "2.7.1";
   };
   neatjson = {
     groups = ["default"];


### PR DESCRIPTION
# Description

The version we are using (0.8.27) is almost two years old. And it wasn't matching the one used in ci. 
I tried the new version in hope it will help with something in particular, which turns out to not be the case, but since there seem to be bug fixes and improvements in the past two years, I thought we might as well update it.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
