### PR TITLE
ToJson instances for context error

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add `ToJSON` for `AlonzoContextError` and `CollectError`
 * Stop exporting all of the internal `hkd*` functions and `PParamsHKD` from
   `Cardano.Ledger.Alonzo.Core`.
 * Export `AlonzoEraTx` from `Cardano.Ledger.Alonzo.Core`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON)
 import Data.Kind (Type)
 import Data.Text (Text)
 import NoThunks.Class (NoThunks)
@@ -71,6 +72,7 @@ class
   , NoThunks (ContextError era)
   , EncCBOR (ContextError era)
   , DecCBOR (ContextError era)
+  , ToJSON (ContextError era)
   ) =>
   EraPlutusContext era
   where

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add `ToJSON` for `BabbageContextError`
 * `FromJSON` instance for `PParamsUPdate`: #3949
 * Fixed JSON serialization of `PParams` to include the `protocolVersion`: #3953
 * Stop exporting all of the internal `hkd*` functions and `PParamsHKD` from

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.12.0.0
 
+* Add `ToJSON` instance for `ConwayContextError`, `ConwayTxCert`, `ConwayDelegCert`,
+  `Delegatee` and `ConwayGovCert`
 * Add `forceDRepPulsingState`
 * Add `registerInitialDReps` and `registerDRepDelegs`
 * Add `cgDRepDelegs`, `cgInitialDReps` to `ConwayGenesis`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Add `ToJSON` instance for `ShelleyTxCert`, `ShelleyDelegCert`, `MIRCert`, `MIRTarget`,
+  `MIRPot` and `GenesisDelegCert`
 * Deprecate `evaluateTransactionFee` in favor of `Cardano.Ledger.Api.Tx.estimateMinFeeTx`
 * Change the type signature and the logic in `validateNeededWitnesses`
 * Add `getShelleyWitsVKeyNeeded` and `getShelleyWitsVKeyNeededNoGov`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.10.0.0
 
+* Add `kindObject`
+* Add `ToJSON` instance for `TxOutSource` and `PoolCert`
+* Expose `txInToText`
 * Add `getWitsVKeyNeeded` to `EraUTxO`
 * Changed the type of the lenses `ppMaxBBSizeL`, `ppMaxTxSizeL`, `ppMaxBHSizeL`,
   `ppuMaxBBSizeL`, `ppuMaxTxSizeL` and `ppuMaxBHSizeL`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -55,6 +55,7 @@ module Cardano.Ledger.BaseTypes (
   BlocksMade (..),
   EpochInterval (..),
   addEpochInterval,
+  kindObject,
 
   -- * Indices
   TxIx (..),
@@ -137,13 +138,14 @@ import Data.Aeson (
   FromJSON (..),
   KeyValue,
   ToJSON (..),
+  Value,
   object,
   pairs,
   withObject,
   (.:),
   (.=),
  )
-import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Pair)
 import qualified Data.Binary.Put as B
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -189,14 +191,14 @@ instance NoThunks ProtVer
 
 instance ToJSON ProtVer where
   toJSON (ProtVer major minor) =
-    Aeson.object
+    object
       [ "major" .= getVersion64 major
       , "minor" .= minor
       ]
 
 instance FromJSON ProtVer where
   parseJSON =
-    Aeson.withObject "ProtVer" $ \obj -> do
+    withObject "ProtVer" $ \obj -> do
       pvMajor <- mkVersion64 =<< obj .: "major"
       pvMinor <- obj .: "minor"
       pure ProtVer {..}
@@ -853,3 +855,7 @@ class Inject t s where
   inject :: t -> s
   default inject :: t ~ s => t -> s
   inject = id
+
+-- | Helper function for a common pattern of creating objects
+kindObject :: Text -> [Pair] -> Value
+kindObject name obj = object $ ("kind" .= name) : obj

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
@@ -20,6 +20,7 @@
 
 module Cardano.Ledger.Plutus.TxInfo (
   TxOutSource (..),
+  txOutSourceToText,
   transAddr,
   transProtocolVersion,
   transDataHash,
@@ -65,12 +66,13 @@ import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Plutus.Data (Data (..), getPlutusData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.SafeHash (SafeHash, extractHash)
-import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..), txInToText)
 import Cardano.Slotting.EpochInfo (EpochInfo, epochInfoSlotToUTCTime)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData (..), rwhnf)
-import Data.Text (Text)
+import Data.Aeson (ToJSON (..), Value (String))
+import Data.Text as T (Text, pack)
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word64)
@@ -104,6 +106,14 @@ instance Crypto c => DecCBOR (TxOutSource c) where
       dec 0 = SumD TxOutFromInput <! From
       dec 1 = SumD TxOutFromOutput <! From
       dec n = Invalid n
+
+instance ToJSON (TxOutSource c) where
+  toJSON = String . txOutSourceToText
+
+txOutSourceToText :: TxOutSource c -> Text
+txOutSourceToText = \case
+  TxOutFromInput txIn -> "Input: " <> txInToText txIn
+  TxOutFromOutput txIx -> "Output: " <> T.pack (show txIx)
 
 transProtocolVersion :: ProtVer -> PV1.MajorProtocolVersion
 transProtocolVersion (ProtVer major _minor) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.TxIn (
   _unTxId,
   TxIn (TxIn),
   mkTxInPartial,
+  txInToText,
   TxIx,
 )
 where


### PR DESCRIPTION
# Description

This PR transfers `ToJSON` instance for `CollectError` failure type and adds `ToJSON` instances for other types that are needed for above instance

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
