### PR TITLE
Move functionality of Cardano.Ledger.Pretty  to Test.Cardano.Ledger.Generic.PrettyCore

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -47,7 +47,6 @@ library
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.5.1,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.10 && <1.11,
-        cardano-ledger-pretty,
         cardano-ledger-allegra >=1.2,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.10,
         cardano-ledger-shelley-test >=1.2,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -67,7 +67,6 @@ import Cardano.Ledger.Mary.Value (
  )
 import Cardano.Ledger.Plutus.Data (Data (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty.Alonzo ()
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -43,7 +43,6 @@ library
         bytestring,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.2,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.3,
-        cardano-ledger-pretty,
         cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.3,
         cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.5,
         cardano-slotting,

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.Binary (encCBOR, serialize')
 import Cardano.Ledger.Coin (Coin)
 import qualified Cardano.Ledger.Crypto as CryptoClass
 import Cardano.Ledger.Keys (KeyHash)
-import Cardano.Ledger.Pretty.Mary ()
 import Cardano.Ledger.Shelley.API (KeyRole (Witness))
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Tx (pattern ShelleyTx)

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -81,7 +81,6 @@ library
         cardano-ledger-byron,
         cardano-ledger-byron-test,
         cardano-ledger-core:{cardano-ledger-core, testlib} ^>=1.10,
-        cardano-ledger-pretty,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.9,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting,
@@ -130,7 +129,6 @@ test-suite cardano-ledger-shelley-test
         Test.Cardano.Ledger.Shelley.Examples.Updates
         Test.Cardano.Ledger.Shelley.Fees
         Test.Cardano.Ledger.Shelley.MultiSigExamples
-        Test.Cardano.Ledger.Shelley.Pretty
         Test.Cardano.Ledger.Shelley.SafeHash
         Test.Cardano.Ledger.Shelley.Serialisation
         Test.Cardano.Ledger.Shelley.Serialisation.Golden.Address
@@ -160,7 +158,6 @@ test-suite cardano-ledger-shelley-test
         cardano-data,
         cardano-ledger-byron,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-pretty,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-ledger-shelley-test >=1.1,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
@@ -172,7 +169,6 @@ test-suite cardano-ledger-shelley-test
         groups,
         iproute,
         microlens,
-        prettyprinter,
         scientific,
         small-steps,
         small-steps-test,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -39,7 +39,6 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
 import Cardano.Ledger.Keys (KeyRole (Witness), WitVKey)
-import Cardano.Ledger.Pretty (PrettyA (..))
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Cardano.Ledger.Shelley.API (
   Addr (Addr),
@@ -167,10 +166,6 @@ class
   , ScriptClass era
   , EraPParams era
   , MinGenTxout era
-  , PrettyA (Tx era)
-  , PrettyA (TxBody era)
-  , PrettyA (TxWits era)
-  , PrettyA (Value era)
   , Default (StashedAVVMAddresses era)
   ) =>
   EraGen era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (DSIGN, KES)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
-import Cardano.Ledger.Pretty ()
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (
   Coin (..),

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -21,7 +21,6 @@ module Test.Cardano.Ledger.Shelley.Rewards (
   defaultMain,
   newEpochProp,
   newEpochEventsProp,
-  ppAgg,
   RewardUpdateOld (..),
   createRUpdOld,
   createRUpdOld_,
@@ -65,7 +64,6 @@ import Cardano.Ledger.Keys (
   VKey (..),
   hashKey,
  )
-import Cardano.Ledger.Pretty (PDoc, PrettyA (..), ppMap, ppReward, ppSet)
 import Cardano.Ledger.Shelley.API (NonMyopic, SnapShot (..), SnapShots (..))
 import Cardano.Ledger.Shelley.API.Types (PoolParams (..))
 import Cardano.Ledger.Shelley.Core
@@ -622,7 +620,7 @@ oldEqualsNew ::
   Property
 oldEqualsNew pv newepochstate =
   counterexample
-    (show (prettyA newepochstate) ++ show (ansiWlEditExprCompact $ ediff old new))
+    (show newepochstate ++ show (ansiWlEditExprCompact $ ediff old new))
     (old === new)
   where
     globals = testGlobals
@@ -736,17 +734,11 @@ eventsMirrorRewards events nes = same eventRew compRew
               x
               y
 
-ppAgg :: Map (Credential 'Staking (EraCrypto C)) (Set (Reward (EraCrypto C))) -> PDoc
-ppAgg = ppMap prettyA (ppSet ppReward)
-
 instance Terse (Reward c) where
-  terse x = show (ppReward x)
+  terse (Reward ty pl (Coin n)) = "Reward{" ++ show ty ++ ", #" ++ take 9 (show pl) ++ ", " ++ show n ++ "}"
 
-instance PrettyA x => Terse (Set x) where
-  terse x = show (ppSet prettyA x)
-
-instance PrettyA (Reward c) where
-  prettyA = ppReward
+instance Terse x => Terse (Set x) where
+  terse x = unlines (Set.toList (Set.map terse x))
 
 -- ================================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -52,8 +52,6 @@ import Cardano.Ledger.Keys (
   coerceKeyRole,
  )
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
-import Cardano.Ledger.Pretty (PrettyA)
-import qualified Cardano.Ledger.Pretty as PP
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.AdaPots (
   AdaPots (..),
@@ -447,32 +445,6 @@ totalAdaPots = totalAdaPotsES . nesEs . chainNes
 -- | Calculate the total ada in the chain state
 totalAda :: EraTxOut era => ChainState era -> Coin
 totalAda = totalAdaES . nesEs . chainNes
-
-ppChainState ::
-  ( PP.CanPrettyPrintLedgerState era
-  , PrettyA (GovState era)
-  ) =>
-  ChainState era ->
-  PP.PDoc
-ppChainState (ChainState nes ocert epochnonce evolvenonce prevnonce candnonce lastab) =
-  PP.ppRecord
-    "ChainState"
-    [ ("newepoch", PP.ppNewEpochState nes)
-    , ("ocerts", PP.ppMap PP.ppKeyHash PP.ppWord64 ocert)
-    , ("epochNonce", PP.ppNonce epochnonce)
-    , ("evolvingNonce", PP.ppNonce evolvenonce)
-    , ("candidateNonce", PP.ppNonce prevnonce)
-    , ("prevepochNonce", PP.ppNonce candnonce)
-    , ("lastApplidBlock", PP.ppWithOrigin PP.ppLastAppliedBlock lastab)
-    ]
-
-instance
-  ( PP.CanPrettyPrintLedgerState era
-  , PrettyA (GovState era)
-  ) =>
-  PP.PrettyA (ChainState era)
-  where
-  prettyA = ppChainState
 
 instance
   ( ToExpr (PParams era)

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -9,7 +9,6 @@ import qualified Test.Cardano.Ledger.Shelley.Address.Bootstrap as Bootstrap (
   bootstrapHashTest,
  )
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
-import qualified Test.Cardano.Ledger.Shelley.Pretty as Pretty (prettyTest)
 import Test.Cardano.Ledger.Shelley.PropertyTests (commonTests)
 import qualified Test.Cardano.Ledger.Shelley.Rewards as Rewards (tests)
 import qualified Test.Cardano.Ledger.Shelley.Rules.AdaPreservation as AdaPreservation
@@ -61,7 +60,6 @@ defaultTests =
     , RulesTests.multisigExamples
     , RulesTests.testTickF
     , UnitTests.unitTests
-    , Pretty.prettyTest
     , SafeHash.safeHashTest
     ]
 

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -71,6 +71,7 @@ library
         Test.Cardano.Ledger.Generic.MockChain
         Test.Cardano.Ledger.Generic.ModelState
         Test.Cardano.Ledger.Generic.PrettyCore
+        Test.Cardano.Ledger.Generic.PrettyTest
         Test.Cardano.Ledger.Generic.Properties
         Test.Cardano.Ledger.Generic.Same
         Test.Cardano.Ledger.Generic.Scriptic
@@ -92,6 +93,7 @@ library
     build-depends:
         array,
         base >=4.14 && <5,
+        bech32,
         bytestring,
         cardano-data,
         cardano-crypto-class,
@@ -107,7 +109,6 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-pretty,
         cardano-ledger-mary,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-ledger-shelley-test,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Core (Era (EraCrypto), EraScript (..), hashScript)
 import Cardano.Ledger.Hashes (DataHash, ScriptHash (..))
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
-import Cardano.Ledger.Pretty
 import Data.Char (toLower)
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
@@ -52,6 +51,7 @@ import Test.Cardano.Ledger.Constrained.Env (
 import Test.Cardano.Ledger.Constrained.Monad (HasConstraint (With), Typed (..), failT, monadTyped)
 import Test.Cardano.Ledger.Constrained.Size (Size (..), runSize, seps)
 import Test.Cardano.Ledger.Constrained.TypeRep (Rep (..), format, hasEq, synopsis, testEql, (:~:) (Refl))
+import Test.Cardano.Ledger.Generic.PrettyCore (PDoc, ppRecord, ppString)
 import Test.Cardano.Ledger.Generic.Proof (Reflect)
 import Test.QuickCheck (Gen, oneof)
 import Type.Reflection (TypeRep, Typeable, typeRep)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
-import Cardano.Ledger.Pretty (PDoc, PrettyA, ppString)
 import Cardano.Ledger.Shelley.Governance (ShelleyGovState (..))
 import qualified Cardano.Ledger.Shelley.Governance as Gov (GovState (..))
 import Cardano.Ledger.Shelley.PParams (pvCanFollow)
@@ -67,6 +66,8 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 import Test.Cardano.Ledger.Generic.PrettyCore (
+  PDoc,
+  PrettyA,
   pcScript,
   pcScriptsNeeded,
   pcTx,
@@ -75,6 +76,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   pcTxOut,
   pcVal,
   pcWitnesses,
+  ppString,
  )
 import Test.Cardano.Ledger.Generic.Proof (
   GoodCrypto,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -30,7 +30,6 @@ import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Era (Era (EraCrypto))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.PoolParams (PoolMetadata, PoolParams (..))
-import Cardano.Ledger.Pretty (ppList)
 import Cardano.Ledger.Shelley.LedgerState (AccountState, InstantaneousRewards, availableAfterMIR)
 import Cardano.Ledger.Shelley.TxCert (
   EraTxCert (..),
@@ -61,7 +60,7 @@ import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
 import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
-import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert, ppList)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.QuickCheck
 import Test.Tasty (TestTree, defaultMain)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Mary.Value (
   multiAssetFromList,
  )
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData, hashData)
-import Cardano.Ledger.Pretty (ppList, ppMap)
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Control.Monad (when)
 import Data.Default.Class (Default (def))
@@ -59,7 +58,7 @@ import Test.Cardano.Ledger.Constrained.TypeRep
 import Test.Cardano.Ledger.Constrained.Utils (testIO)
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..), TxOutField (..))
-import Test.Cardano.Ledger.Generic.PrettyCore (pcData, pcDataHash, pcScript, pcScriptHash, pcTxOut)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcData, pcDataHash, pcScript, pcScriptHash, pcTxOut, ppList, ppMap)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Updaters (newTxBody, newTxOut)
 import Test.QuickCheck

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -27,7 +27,6 @@ import Cardano.Ledger.Core (
   coinTxOutL,
  )
 import Cardano.Ledger.DRep hiding (drepDeposit)
-import Cardano.Ledger.Pretty (ppList)
 import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
   DState (..),
@@ -65,7 +64,7 @@ import Test.Cardano.Ledger.Constrained.Trace.TraceMonad (
 import Test.Cardano.Ledger.Constrained.Vars
 import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..))
 import Test.Cardano.Ledger.Generic.MockChain (MockBlock (..), MockChainState (..))
-import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert, ppList)
 import Test.Cardano.Ledger.Generic.Proof (
   ConwayEra,
   Evidence (..),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -22,7 +22,6 @@ import Cardano.Ledger.Conway.Governance (
   newEpochStateDRepPulsingStateL,
  )
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Cardano.Ledger.Pretty (ppList, ppPair, ppSlotNo, ppStrictSeq)
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState (..))
 import Cardano.Ledger.Shelley.Rules (runIdentity)
 import Cardano.Ledger.TxIn (TxIn)
@@ -93,7 +92,7 @@ import Test.Cardano.Ledger.Constrained.Rewrite (
 import Test.Cardano.Ledger.Constrained.Solver (solveOneVar)
 import Test.Cardano.Ledger.Constrained.Vars (currentSlot, newEpochStateT)
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockBlock (..), MockChainState (..))
-import Test.Cardano.Ledger.Generic.PrettyCore (pcTx, summaryMapCompact)
+import Test.Cardano.Ledger.Generic.PrettyCore (pcSlotNo, pcTx, ppList, ppPair, ppStrictSeq, summaryMapCompact)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 import Test.Cardano.Ledger.Generic.Trace (chooseIssuer)
 import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, runShelleyBase, testGlobals)
@@ -356,7 +355,7 @@ genNewEpochStateEnv proof = do
 data PredGen era = PredGen (Vector (StrictSeq (Tx era), SlotNo)) (Env era)
 
 instance Reflect era => Show (PredGen era) where
-  show (PredGen xs _) = show (ppList (ppPair (ppStrictSeq (pcTx reify)) (ppSlotNo)) (toList xs))
+  show (PredGen xs _) = show (ppList (ppPair (ppStrictSeq (pcTx reify)) (pcSlotNo)) (toList xs))
 
 instance
   ( STS (MOCKCHAIN era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -94,21 +94,6 @@ import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData)
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (ppId))
-import Cardano.Ledger.Pretty (
-  PDoc,
-  ppHash,
-  ppInteger,
-  ppList,
-  ppMap,
-  ppMaybe,
-  ppRecord',
-  ppSet,
-  ppString,
-  ppVKey,
-  ppWord32,
- )
-import Cardano.Ledger.Pretty.Alonzo (ppRdmrPtr)
-import Cardano.Ledger.Pretty.Mary (ppValidityInterval)
 import Cardano.Ledger.SafeHash (SafeHash, extractHash)
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks (restrictPoolMetadataHash)
@@ -175,6 +160,7 @@ import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Fields (WitnessesField (..))
 import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 import Test.Cardano.Ledger.Generic.PrettyCore (
+  PDoc,
   credSummary,
   keyHashSummary,
   pcAnchor,
@@ -217,6 +203,18 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   pcWitVKey,
   pcWitnesses,
   pcWitnessesField,
+  ppHash,
+  ppInteger,
+  ppList,
+  ppMap,
+  ppMaybe,
+  ppRdmrPtr,
+  ppRecord',
+  ppSet,
+  ppString,
+  ppVKey,
+  ppValidityInterval,
+  ppWord32,
   trim,
  )
 import Test.Cardano.Ledger.Generic.Proof

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
@@ -22,7 +22,6 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (getMinFeeTx)
 import Cardano.Ledger.Plutus.Data (Data (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (evaluateTransactionFee)
 import qualified Data.Map.Strict as Map

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -47,7 +47,6 @@ import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.PoolParams (PoolMetadata (..))
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (
   CertState (..),
@@ -132,14 +131,12 @@ tests =
 
 alonzoBBODYexamplesP ::
   forall era.
-  ( GoodCrypto (EraCrypto era)
-  , HasTokens era
+  ( HasTokens era
   , PostShelley era
   , Value era ~ MaryValue (EraCrypto era)
   , EraSegWits era
-  , EraGov era
+  , Reflect era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
-  , ShelleyEraTxCert era
   ) =>
   Proof era ->
   TestTree

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -31,7 +31,6 @@ import Cardano.Ledger.Plutus.Evaluate (
   PlutusWithContext (..),
  )
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val (inject)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -54,7 +54,6 @@ import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus.CostModels (emptyCostModels)
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.Core hiding (TranslationError)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
@@ -118,13 +117,10 @@ alonzoUTXOWTests ::
   forall era.
   ( AlonzoBased era (PredicateFailure (EraRule "UTXOW" era))
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , GoodCrypto (EraCrypto era)
   , HasTokens era
-  , EraTx era
+  , Reflect era
   , PostShelley era -- MAYBE WE CAN REPLACE THIS BY GoodCrypto,
   , Value era ~ MaryValue (EraCrypto era)
-  , EraGov era
-  , ShelleyEraTxCert era
   ) =>
   Proof era ->
   TestTree
@@ -935,9 +931,8 @@ noCostModelTx pf pp' =
 
 testU ::
   forall era.
-  ( GoodCrypto (EraCrypto era)
-  , PostShelley era
-  , EraTx era
+  ( PostShelley era
+  , Reflect era
   , HasCallStack
   ) =>
   Proof era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Credential (
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (
   ProtVer (..),
@@ -98,13 +97,10 @@ tests =
 alonzoUTXOWTests ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
-  , GoodCrypto (EraCrypto era)
   , HasTokens era
-  , EraTx era
+  , Reflect era
   , PostShelley era -- MAYBE WE CAN REPLACE THIS BY GoodCrypto,
   , Value era ~ MaryValue (EraCrypto era)
-  , EraGov era
-  , ShelleyEraTxCert era
   ) =>
   Proof era ->
   TestTree
@@ -954,9 +950,8 @@ expectedUTxO' pf = expectedUTxO (initUTxO pf)
 
 testU ::
   forall era.
-  ( GoodCrypto (EraCrypto era)
-  , PostShelley era
-  , EraTx era
+  ( PostShelley era
+  , Reflect era
   , HasCallStack
   ) =>
   Proof era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -64,7 +64,6 @@ import Cardano.Ledger.Keys (
  )
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Plutus.Language (Language (..), Plutus (..), PlutusBinary (..), PlutusLanguage)
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.API (ProtVer (..), UTxO (..))
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), smartUTxOState)
@@ -160,7 +159,7 @@ plainAddr pf = Addr Testnet pCred sCred
     pCred = KeyHashObj . hashKey . vKey $ someKeys pf
     sCred = StakeRefBase . KeyHashObj . hashKey $ svk
 
-scriptAddr :: forall era. Scriptic era => Proof era -> Script era -> Addr (EraCrypto era)
+scriptAddr :: forall era. Reflect era => Proof era -> Script era -> Addr (EraCrypto era)
 scriptAddr _pf s = Addr Testnet pCred sCred
   where
     pCred = ScriptHashObj . hashScript @era $ s
@@ -174,7 +173,7 @@ malformedScriptAddr pf = Addr Testnet pCred sCred
     (_ssk, svk) = mkKeyPair @(EraCrypto era) (RawSeed 0 0 0 0 0)
     sCred = StakeRefBase . KeyHashObj . hashKey $ svk
 
-simpleScriptAddr :: forall era. Scriptic era => Proof era -> Addr (EraCrypto era)
+simpleScriptAddr :: forall era. (Reflect era, Scriptic era) => Proof era -> Addr (EraCrypto era)
 simpleScriptAddr pf = scriptAddr pf (simpleScript pf)
 
 datumExampleEven :: Era era => Data era
@@ -227,7 +226,7 @@ pp pf = newPParams pf defaultPPs
 -- Spend a EUTxO with an inline datum (without and with a failing script)
 -- =========================================================================
 
-inlineDatum :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+inlineDatum :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 inlineDatum pf =
   TestCaseData
     { txBody =
@@ -259,7 +258,7 @@ inlineDatum pf =
         ]
     }
 
-inlineDatumFailingScript :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+inlineDatumFailingScript :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 inlineDatumFailingScript pf =
   TestCaseData
     { txBody =
@@ -295,7 +294,7 @@ inlineDatumFailingScript pf =
 -- Valid: Use a reference script.
 -- =========================================================================
 
-referenceScript :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+referenceScript :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 referenceScript pf =
   TestCaseData
     { txBody =
@@ -342,7 +341,7 @@ referenceScript pf =
 
 inlineDatumAndRefScript ::
   forall era.
-  (Scriptic era, EraTxBody era) =>
+  (Scriptic era, Reflect era) =>
   Proof era ->
   TestCaseData era
 inlineDatumAndRefScript pf =
@@ -390,7 +389,7 @@ inlineDatumAndRefScript pf =
 
 inlineDatumAndRefScriptWithRedundantWitScript ::
   forall era.
-  (Scriptic era, EraTxBody era) =>
+  (Scriptic era, Reflect era) =>
   Proof era ->
   TestCaseData era
 inlineDatumAndRefScriptWithRedundantWitScript pf =
@@ -476,7 +475,7 @@ refInputWithDataHashNoWit pf =
 
 refInputWithDataHashWithWit ::
   forall era.
-  (Scriptic era, EraTxBody era) =>
+  (Scriptic era, Reflect era) =>
   Proof era ->
   TestCaseData era
 refInputWithDataHashWithWit pf =
@@ -560,7 +559,7 @@ refscriptForDelegCert pf =
 --  Invalid: Use a collateral output
 -- ====================================================================================
 
-useCollateralReturn :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+useCollateralReturn :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 useCollateralReturn pf =
   TestCaseData
     { txBody =
@@ -599,7 +598,7 @@ useCollateralReturn pf =
 -- Invalid: Invalid collateral total
 -- ====================================================================================
 
-incorrectCollateralTotal :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+incorrectCollateralTotal :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 incorrectCollateralTotal pf =
   TestCaseData
     { txBody =
@@ -639,7 +638,7 @@ incorrectCollateralTotal pf =
 
 inlineDatumRedundantDatumWit ::
   forall era.
-  (Scriptic era, EraTxBody era) =>
+  (Scriptic era, Reflect era) =>
   Proof era ->
   TestCaseData era
 inlineDatumRedundantDatumWit pf =
@@ -678,7 +677,7 @@ inlineDatumRedundantDatumWit pf =
 -- Invalid:  Using inline datums with Plutus V1 script
 -- ====================================================================================
 
-inlineDatumWithPlutusV1Script :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+inlineDatumWithPlutusV1Script :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 inlineDatumWithPlutusV1Script pf =
   TestCaseData
     { txBody =
@@ -714,7 +713,7 @@ inlineDatumWithPlutusV1Script pf =
 -- Invalid:  Using reference script with Plutus V1 script
 -- ====================================================================================
 
-referenceScriptWithPlutusV1Script :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+referenceScriptWithPlutusV1Script :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 referenceScriptWithPlutusV1Script pf =
   TestCaseData
     { txBody =
@@ -751,7 +750,7 @@ referenceScriptWithPlutusV1Script pf =
 -- Invalid:  Using reference input with Plutus V1 script
 -- ====================================================================================
 
-referenceInputWithPlutusV1Script :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+referenceInputWithPlutusV1Script :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 referenceInputWithPlutusV1Script pf =
   TestCaseData
     { txBody =
@@ -869,7 +868,7 @@ refScriptInOutput pf =
 --  Valid: Unlock Simple Scripts with a Reference Script
 -- ====================================================================================
 
-simpleScriptOutWithRefScriptUTxOState :: (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+simpleScriptOutWithRefScriptUTxOState :: (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 simpleScriptOutWithRefScriptUTxOState pf =
   TestCaseData
     { txBody =
@@ -980,7 +979,7 @@ malformedScriptWit pf =
 -- inline datum and have it count for the datum witness where ever it is needed.
 -- =============================================================================
 
-noSuchThingAsReferenceDatum :: forall era. (Scriptic era, EraTxBody era) => Proof era -> TestCaseData era
+noSuchThingAsReferenceDatum :: forall era. (Scriptic era, Reflect era) => Proof era -> TestCaseData era
 noSuchThingAsReferenceDatum pf =
   TestCaseData
     { txBody =
@@ -1137,11 +1136,9 @@ txFromTestCaseData
 testExpectSuccessValid ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
-  , GoodCrypto (EraCrypto era)
   , PostShelley era
-  , EraTx era
+  , Reflect era
   , BabbageEraTxBody era
-  , EraGov era
   ) =>
   Proof era ->
   TestCaseData era ->
@@ -1182,11 +1179,9 @@ testExpectSuccessInvalid ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
   , TxBody era ~ BabbageTxBody era
-  , GoodCrypto (EraCrypto era)
   , PostShelley era
-  , EraTx era
+  , Reflect era
   , BabbageEraTxBody era
-  , EraGov era
   ) =>
   Proof era ->
   TestCaseData era ->
@@ -1207,10 +1202,9 @@ testExpectSuccessInvalid
 testExpectFailure ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
-  , GoodCrypto (EraCrypto era)
   , PostShelley era
   , BabbageEraTxBody era
-  , EraTx era
+  , Reflect era
   ) =>
   Proof era ->
   TestCaseData era ->
@@ -1228,11 +1222,9 @@ testExpectFailure
 genericBabbageFeatures ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
-  , GoodCrypto (EraCrypto era)
   , BabbageEraTxBody era
   , PostShelley era
-  , EraTx era
-  , EraGov era
+  , Reflect era
   ) =>
   Proof era ->
   TestTree

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -65,8 +65,6 @@ import Cardano.Ledger.Credential (
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyRole (..), hashKey)
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
-import Cardano.Ledger.Pretty
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.Shelley.API (
   Block (..),
   EpochState (..),
@@ -98,7 +96,7 @@ import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Fields (
   TxOutField (..),
  )
-import Test.Cardano.Ledger.Generic.PrettyCore ()
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..), ppList)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic (..), after, matchkey)
 import Test.Cardano.Ledger.Generic.Updaters
@@ -284,7 +282,7 @@ trustMeP _ _ tx = tx
 -- and expected are ValidationTagMismatch. Of course the 'path' to ValidationTagMismatch differs by Era.
 -- so we need to case over the Era proof, to get the path correctly.
 testBBODY ::
-  (GoodCrypto (EraCrypto era), HasCallStack) =>
+  (Reflect era, HasCallStack) =>
   WitRule "BBODY" era ->
   ShelleyBbodyState era ->
   Block (BHeaderView (EraCrypto era)) era ->
@@ -301,9 +299,7 @@ testBBODY wit@(BBODY proof) initialSt block expected pparams =
 
 testUTXOW ::
   forall era.
-  ( GoodCrypto (EraCrypto era)
-  , PostShelley era
-  , EraTx era
+  ( Reflect era
   , HasCallStack
   ) =>
   WitRule "UTXOW" era ->
@@ -322,10 +318,7 @@ testUTXOW (UTXOW other) _ _ _ = error ("Cannot use testUTXOW in era " ++ show ot
 testUTXOWsubset
   , testUTXOspecialCase ::
     forall era.
-    ( GoodCrypto (EraCrypto era)
-    , PostShelley era
-    , EraTx era
-    , EraGov era
+    ( Reflect era
     , HasCallStack
     ) =>
     WitRule "UTXOW" era ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -89,8 +89,6 @@ import Cardano.Ledger.Keys (
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Cardano.Ledger.PoolParams (PoolParams (..))
-import Cardano.Ledger.Pretty (PDoc, ppInt, ppMap, ppRecord, ppSet, ppString)
-import Cardano.Ledger.Pretty.Mary (ppValidityInterval)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
@@ -143,7 +141,8 @@ import Test.Cardano.Ledger.Generic.ModelState (
   pcModelNewEpochState,
  )
 import Test.Cardano.Ledger.Generic.PrettyCore (
-  PrettyC (..),
+  PDoc,
+  PrettyA (..),
   pcCoin,
   pcCredential,
   pcIndividualPoolStake,
@@ -151,6 +150,12 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   pcPoolParams,
   pcTxIn,
   pcTxOut,
+  ppInt,
+  ppMap,
+  ppRecord,
+  ppSet,
+  ppString,
+  ppValidityInterval,
  )
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 import Test.Cardano.Ledger.Generic.Updaters (defaultCostModels, newPParams)
@@ -682,7 +687,7 @@ viewGenState proof gsize verbose = do
   st <- generate (genGenState proof gsize)
   when verbose $ print (pcGenState proof st)
 
-instance Reflect era => PrettyC (GenState era) era where prettyC = pcGenState
+instance Reflect era => PrettyA (GenState era) where prettyA = pcGenState reify
 
 instance era ~ BabbageEra Mock => Show (GenState era) where
   show x = show (pcGenState (Babbage Mock) x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -14,119 +14,24 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+-- | Tools for building unique Key (and related types) by just supplying an Int
+--   Each Int returns a different Key (or related type)
+--   Useful when writing unit tests
 module Test.Cardano.Ledger.Generic.Indexed where
 
 import Cardano.Crypto.DSIGN.Class ()
-import Cardano.Ledger.Allegra.Scripts (Timelock (..))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript, AlonzoScript (..))
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto (Crypto)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Witness), SignKeyDSIGN, VKey, WitVKey (..), hashKey)
-import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), PolicyID (..))
-import qualified Cardano.Ledger.Mary.Value as Mary (MultiAsset (..))
-import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Pretty (
-  PrettyA (..),
-  PrettyAnn (Width),
-  ppPair,
-  ppRecord,
-  ppString,
-  ppVKey,
- )
-import Cardano.Ledger.Pretty.Alonzo ()
-import Cardano.Ledger.Pretty.Mary ()
 import Cardano.Ledger.SafeHash (SafeHash)
-import Cardano.Ledger.Shelley.Scripts (MultiSig)
-import qualified Cardano.Ledger.Shelley.Scripts as Multi
-import Cardano.Slotting.Slot (SlotNo (..))
-import Data.ByteString.Short (ShortByteString, pack, unpack)
-import qualified Data.Map.Strict as Map
-import Data.Proxy (Proxy (..))
-import qualified Data.Sequence.Strict as Seq (fromList)
-import Prettyprinter (reAnnotate, viaShow)
-import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysFails, alwaysSucceeds)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
 import Test.Cardano.Ledger.Generic.Proof (
-  AlonzoEra,
-  BabbageEra,
-  ConwayEra,
-  Evidence (..),
   GoodCrypto,
-  Mock,
   Proof (..),
-  Reflect (..),
  )
 import Test.Cardano.Ledger.Shelley.Utils (RawSeed (..), mkKeyPair)
-
--- ===========================================================================
--- Classes for "picking" the unique element of a type associated with an Int
-
-class PrettyA t => Fixed t where
-  unique :: Int -> t
-  size :: Proxy t -> Maybe Int
-  size _ = Nothing
-
-class Era e => IndexedE t e where
-  pickE :: Int -> Proof e -> t e
-
-pickCbyCrypto :: Fixed (t c) => Int -> Evidence c -> t c
-pickCbyCrypto n Standard = unique n
-pickCbyCrypto n Mock = unique n
-
-pickCbyEra :: Fixed (t (EraCrypto era)) => Int -> Proof era -> t (EraCrypto era)
-pickCbyEra n _ = unique n
-
--- =======================================================
--- Examples where the type is independent of Era
-
-names :: ShortByteString
-names = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-allnames :: [ShortByteString]
-allnames = map (\x -> pack [x]) (unpack names)
-
-instance Fixed AssetName where
-  unique n = map AssetName allnames !! n
-  size _ = Just (length allnames)
-
-instance Fixed Coin where
-  size _ = Nothing
-  unique n = Coin (fromIntegral n)
-
--- =======================================================
--- Examples where type depends on Crypto
-
-data MultiAsset era where
-  MultiAsset :: Era era => MaryValue (EraCrypto era) -> MultiAsset era
-
-unMulti :: MultiAsset era -> MaryValue (EraCrypto era)
-unMulti (MultiAsset x) = x
-
-deriving instance Show (MultiAsset era)
-
-instance (Reflect era, EraScript era, Fixed (Script era)) => Fixed (MultiAsset era) where
-  unique n =
-    MultiAsset
-      ( MaryValue
-          (Coin (fromIntegral n))
-          ( Mary.MultiAsset
-              ( Map.singleton
-                  (lift (pickPolicyID @era n))
-                  (Map.singleton (unique @AssetName n) (fromIntegral n))
-              )
-          )
-      )
-  size _ = lift (scriptsize @era)
-
-scriptsize :: forall era. Fixed (Script era) => Proof era -> Maybe Int
-scriptsize _ = size (Proxy @(Script era))
-
-instance CC.Crypto c => Fixed (MaryValue c) where
-  size _ = Nothing
-  unique n = MaryValue (Coin (fromIntegral n)) (Mary.MultiAsset Map.empty)
 
 -- =======================================================
 -- Keys and KeyHashes
@@ -134,14 +39,11 @@ instance CC.Crypto c => Fixed (MaryValue c) where
 -- | A signing key
 newtype SKey (kr :: KeyRole) c = SKey (SignKeyDSIGN c)
 
-instance CC.Crypto c => Fixed (KeyPair kr c) where
-  unique n = KeyPair a b
-    where
-      m1 = fromIntegral n
-      (b, a) = mkKeyPair (RawSeed 0 0 0 0 m1)
-
-theKeyPair :: CC.Crypto c => Int -> KeyPair kr c
-theKeyPair = unique
+-- By changing the parameter 'n', we get a different keyPair
+theKeyPair :: Crypto c => Int -> KeyPair kr c
+theKeyPair n = KeyPair a b
+  where
+    (b, a) = mkKeyPair (RawSeed 0 0 0 0 (fromIntegral n))
 
 theVKey :: CC.Crypto c => Int -> VKey kr c
 theVKey n = vKey (theKeyPair n)
@@ -163,176 +65,3 @@ aScriptHashObj _wit s = ScriptHashObj . hashScript @era $ s
 
 theStakeReference :: CC.Crypto c => Int -> StakeReference c
 theStakeReference n = (StakeRefBase . KeyHashObj . hashKey) (theVKey n)
-
--- ====================================================
--- SlotNo
-
-instance Fixed SlotNo where
-  unique n = SlotNo (fromIntegral n)
-
--- ==========================================================================
--- An example where there is no easy algorithmic way to pick a (T era) from
--- an Int, so we compute a "basket" of (T era) and then just choose one from
--- the "basket".  We do this for all of the kinds of scripts.
--- ==========================================================================
--- MultiSig Scripts
-
-multisigSimple :: forall era. Era era => Proof era -> [MultiSig era]
-multisigSimple _c =
-  [ Multi.RequireAnyOf mempty -- always False
-  , Multi.RequireAllOf mempty -- always True
-  ]
-
-multisigFrom :: forall era. Era era => Proof era -> Int -> [MultiSig era]
-multisigFrom _c n =
-  [ Multi.RequireSignature (theKeyHash n)
-  ]
-
-multisigCompound :: forall era. Era era => Proof era -> Int -> [MultiSig era]
-multisigCompound c n =
-  [ Multi.RequireAnyOf (multisigFrom c n)
-  , Multi.RequireAllOf (multisigFrom c n)
-  , Multi.RequireMOf 1 (multisigFrom c n)
-  , Multi.RequireMOf 2 (multisigFrom c n)
-  ]
-
-somemultisigs :: Era era => Proof era -> [MultiSig era]
-somemultisigs c =
-  multisigSimple c
-    ++ concat [multisigFrom c i | i <- [1 .. 5]]
-    ++ concat [multisigCompound c i | i <- [1 .. 5]]
-
-instance (Era era, Reflect era) => Fixed (MultiSig era) where
-  unique n = (somemultisigs reify) !! n
-  size _ = Just multisiglength
-
-multisiglength :: Int
-multisiglength = length (somemultisigs (Shelley Mock)) - 1
-
--- ====================================================
--- Timelock Scripts
-
-timelockSimple :: forall era. Era era => Proof era -> [Timelock era]
-timelockSimple _c =
-  [ RequireAnyOf mempty -- always False
-  , RequireAllOf mempty -- always True
-  ]
-
-timelockFrom :: forall era. Era era => Proof era -> Int -> [Timelock era]
-timelockFrom _c n =
-  [ RequireSignature (theKeyHash n)
-  , RequireTimeExpire (unique @SlotNo n)
-  , RequireTimeStart (unique @SlotNo n)
-  ]
-
-timelockCompound :: forall era. Era era => Proof era -> Int -> [Timelock era]
-timelockCompound c n =
-  [ RequireAnyOf (Seq.fromList (timelockFrom c n))
-  , RequireAllOf (Seq.fromList (timelockFrom c n))
-  , RequireMOf 1 (Seq.fromList (timelockFrom c n))
-  , RequireMOf 2 (Seq.fromList (timelockFrom c n))
-  ]
-
-sometimelocks :: Era era => Proof era -> [Timelock era]
-sometimelocks c =
-  timelockSimple c
-    ++ concat [timelockFrom c i | i <- [1 .. 5]]
-    ++ concat [timelockCompound c i | i <- [1 .. 5]]
-
-timelocklength :: Int
-timelocklength = length (sometimelocks (Shelley Mock)) - 1
-
-instance (Era era, Reflect era) => Fixed (Timelock era) where
-  unique n = lift sometimelocks !! n
-  size _ = Just timelocklength
-
--- ====================================================
--- Alonzo Scripts
-
-alonzoSimple :: forall era. (Script era ~ AlonzoScript era, AlonzoEraScript era) => [AlonzoScript era]
-alonzoSimple =
-  [ alwaysFails @'PlutusV1 1 -- always False
-  , alwaysSucceeds @'PlutusV1 1 -- always True
-  ]
-
-somealonzo :: (Script era ~ AlonzoScript era, AlonzoEraScript era) => Proof era -> [AlonzoScript era]
-somealonzo c =
-  alonzoSimple
-    ++ ( fmap
-          TimelockScript
-          ( concat [timelockFrom c i | i <- [1 .. 5]]
-              ++ concat [timelockCompound c i | i <- [1 .. 5]]
-          )
-       )
-
-alonzolength :: Int
-alonzolength = length (somealonzo (Alonzo Mock) :: [Script (AlonzoEra Mock)]) - 1
-
-instance Reflect (AlonzoEra c) => Fixed (AlonzoScript (AlonzoEra c)) where
-  unique n = lift somealonzo !! n
-  size _ = Just alonzolength
-
-instance Reflect (BabbageEra c) => Fixed (AlonzoScript (BabbageEra c)) where
-  unique n = lift somealonzo !! n
-  size _ = Just alonzolength
-
-instance Reflect (ConwayEra c) => Fixed (AlonzoScript (ConwayEra c)) where
-  unique n = lift somealonzo !! n
-  size _ = Just alonzolength
-
--- ==============================================
--- Type families (and other Types uniquely determined from type families like Hashes)
--- Because we can't make instances over type families, we can't say things like
--- instance IndexedE (Value era) where pickE x wit = ...
--- So instead we make a special pickXXX function where XXX is the name of a type family
-
-pickValue :: forall era. Reflect era => Int -> Proof era -> Value era
-pickValue n (Shelley _) = unique @Coin n
-pickValue n (Allegra _) = unique @Coin n
-pickValue n (Mary _) = unMulti (unique @(MultiAsset era) n)
-pickValue n (Alonzo _) = unMulti (unique @(MultiAsset era) n)
-pickValue n (Babbage _) = unMulti (unique @(MultiAsset era) n)
-pickValue n (Conway _) = unMulti (unique @(MultiAsset era) n)
-
-pickScript :: Int -> Proof era -> Script era
-pickScript n p@(Shelley _) = somemultisigs p !! n
-pickScript n p@(Allegra _) = sometimelocks p !! n
-pickScript n p@(Mary _) = sometimelocks p !! n
-pickScript n p@(Alonzo _) = somealonzo p !! n
-pickScript n p@(Babbage _) = somealonzo p !! n
-pickScript n p@(Conway _) = somealonzo p !! n
-
-pickScriptHash :: forall era. Reflect era => Int -> Proof era -> ScriptHash (EraCrypto era)
-pickScriptHash n wit = hashScript @era (pickScript n wit)
-
-pickPolicyID :: Reflect era => Int -> Proof era -> PolicyID (EraCrypto era)
-pickPolicyID n wit = PolicyID (pickScriptHash n wit)
-
--- ===========================================================================
--- An example where the 'pick' is the same type across all Crypto Evidence
-
-data PublicSecret kr kr' c = PublicSecret (KeyPair kr c) (KeyPair kr' c)
-
-instance CC.Crypto c => Fixed (PublicSecret kr kr' c) where
-  unique n = PublicSecret (KeyPair a b) (KeyPair c d)
-    where
-      m1 = fromIntegral (2 * n)
-      m2 = fromIntegral (2 * n + 1)
-      (b, a) = mkKeyPair (RawSeed m1 m1 m1 m1 m1)
-      (d, c) = mkKeyPair (RawSeed m2 m2 m2 m2 m2)
-
--- ===============================================================
--- PrettyA instances
-
-instance Crypto c => PrettyA (KeyPair r c) where
-  prettyA (KeyPair x y) =
-    ppRecord "KeyPair" [("vKey", ppVKey x), ("sKey", reAnnotate (Width 5 :) (viaShow y))]
-
-instance CC.Crypto c => PrettyA (PublicSecret kr kr' c) where
-  prettyA (PublicSecret x y) = ppPair prettyA prettyA (x, y)
-
-instance PrettyA (SKey kr c) where
-  prettyA (SKey _x) = ppString "SKey"
-
-instance PrettyA (MultiAsset era) where
-  prettyA (MultiAsset v) = prettyA v

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -16,14 +16,6 @@ module Test.Cardano.Ledger.Generic.MockChain where
 
 import Cardano.Ledger.BaseTypes (BlocksMade (..), ShelleyBase)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Pretty (
-  PDoc,
-  PrettyA (..),
-  ppInt,
-  ppKeyHash,
-  ppRecord,
-  ppSlotNo,
- )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -62,8 +54,14 @@ import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks, ThunkInfo, noThunks)
 import Test.Cardano.Ledger.Generic.Functions (TotalAda (..))
 import Test.Cardano.Ledger.Generic.PrettyCore (
+  PDoc,
+  PrettyA (..),
+  pcKeyHash,
   pcNewEpochState,
-  ppLedgersPredicateFailure,
+  pcSlotNo,
+  ppInt,
+  ppRecord,
+  ppShelleyLedgersPredFailure,
   ppTickPredicateFailure,
  )
 import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (reify))
@@ -219,7 +217,7 @@ ppMockChainState (MockChainState nes _ sl count) =
   ppRecord
     "MockChainState"
     [ ("NewEpochState", pcNewEpochState reify nes)
-    , ("LastBlock", ppSlotNo sl)
+    , ("LastBlock", pcSlotNo sl)
     , ("Count", ppInt count)
     ]
 
@@ -230,8 +228,8 @@ ppMockBlock :: MockBlock era -> PDoc
 ppMockBlock (MockBlock iss sl txs) =
   ppRecord
     "MockBock"
-    [ ("Issuer", ppKeyHash iss)
-    , ("Slot", ppSlotNo sl)
+    [ ("Issuer", pcKeyHash iss)
+    , ("Slot", pcSlotNo sl)
     , ("Transactions", ppInt (length txs))
     ]
 
@@ -247,12 +245,12 @@ ppMockChainFailure proof x = case proof of
   (Shelley _) -> help x
   where
     help (MockChainFromTickFailure y) = ppTickPredicateFailure y
-    help (MockChainFromLedgersFailure y) = ppLedgersPredicateFailure y
+    help (MockChainFromLedgersFailure y) = ppShelleyLedgersPredFailure proof y
     help (BlocksOutOfOrder lastslot cand) =
       ppRecord
         "BlocksOutOfOrder"
-        [ ("Last applied block", ppSlotNo lastslot)
-        , ("Candidate block", ppSlotNo cand)
+        [ ("Last applied block", pcSlotNo lastslot)
+        , ("Candidate block", pcSlotNo cand)
         ]
 
 noThunksGen :: Proof era -> MockChainState era -> IO (Maybe ThunkInfo)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -33,11 +33,14 @@ import Cardano.Ledger.Alonzo.Rules as Alonzo (
   TagMismatchDescription (..),
  )
 import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoEraScript (..),
   AlonzoScript (..),
   ExUnits (..),
-  plutusScriptBinary,
+  Tag (..),
   plutusScriptLanguage,
  )
+import qualified Cardano.Ledger.Alonzo.Scripts as Scripts (Prices (..))
+
 import Cardano.Ledger.Alonzo.Tx (IsValid (..), ScriptPurpose (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..), unTxDats)
@@ -48,11 +51,20 @@ import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (
   Anchor (..),
   BlocksMade (..),
+  EpochInterval (..),
+  EpochNo (..),
+  FixedPoint,
   Network (..),
+  Nonce (..),
   ProtVer (..),
   SlotNo (..),
   TxIx (..),
+  UnitInterval,
+  Version,
+  certIxToInt,
+  getVersion64,
   txIxToInt,
+  unboundRational,
  )
 import Cardano.Ledger.CertState (CommitteeState (..))
 import qualified Cardano.Ledger.CertState as DP
@@ -74,6 +86,8 @@ import Cardano.Ledger.Conway.Governance (
   ProposalProcedure (..),
   Proposals,
   PulsingSnapshot (..),
+  RatifyEnv (..),
+  RatifySignal (..),
   RatifyState (..),
   Vote (..),
   Voter (..),
@@ -89,9 +103,10 @@ import Cardano.Ledger.Credential (
     KeyHashObj,
     ScriptHashObj
   ),
+  Ptr (..),
   StakeReference (..),
  )
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.EpochBoundary (
   SnapShot (..),
@@ -108,7 +123,7 @@ import Cardano.Ledger.Keys (
   WitVKey (..),
   hashKey,
  )
-import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..))
+import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..), ChainCode (..))
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -124,12 +139,7 @@ import Cardano.Ledger.Plutus.Data (
  )
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
 import Cardano.Ledger.PoolParams (PoolParams (..))
-import Cardano.Ledger.Pretty
-import Cardano.Ledger.Pretty.Alonzo
-import qualified Cardano.Ledger.Pretty.Babbage as Babbage
-import Cardano.Ledger.Pretty.Conway (ppConwayTxBody)
-import Cardano.Ledger.Pretty.Mary
-import Cardano.Ledger.SafeHash (hashAnnotated)
+import Cardano.Ledger.SafeHash (SafeHash, extractHash, hashAnnotated)
 import Cardano.Ledger.Shelley.AdaPots (
   AdaPots (..),
   totalAdaES,
@@ -148,17 +158,17 @@ import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState (..),
   PPUPPredFailure,
   PState (..),
+  RewardUpdate (..),
   UTxOState (..),
   VState (..),
  )
 import Cardano.Ledger.Shelley.Rules as Shelley (
   ShelleyBbodyPredFailure (..),
   ShelleyBbodyState (..),
-  ShelleyDelegPredFailure,
+  ShelleyDelegPredFailure (..),
   ShelleyDelegsPredFailure (..),
   ShelleyDelplPredFailure (..),
   ShelleyEpochPredFailure (..),
-  ShelleyLedgerPredFailure (..),
   ShelleyLedgersPredFailure (..),
   ShelleyNewEpochPredFailure (..),
   ShelleyNewppPredFailure (..),
@@ -172,9 +182,9 @@ import Cardano.Ledger.Shelley.Rules as Shelley (
   ShelleyUtxowPredFailure (..),
  )
 import qualified Cardano.Ledger.Shelley.Scripts as SS (MultiSig (..))
-import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
-
 import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
+import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
+import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, prettyWitnessSetParts)
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap (
@@ -202,7 +212,6 @@ import qualified Data.VMap as VMap
 import Data.Void (absurd)
 import Lens.Micro ((^.))
 import qualified PlutusLedgerApi.V1 as PV1 (Data (..))
-import Prettyprinter (hsep, parens, viaShow, vsep)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..))
 import Test.Cardano.Ledger.Generic.Fields (
   PParamsField (..),
@@ -214,11 +223,9 @@ import Test.Cardano.Ledger.Generic.Fields (
   abstractTxBody,
   abstractWitnesses,
  )
+import qualified Test.Cardano.Ledger.Generic.Fields as Fields
 import Test.Cardano.Ledger.Generic.Proof (
   AllegraEra,
-  AlonzoEra,
-  BabbageEra,
-  ConwayEra,
   GovStateWit (..),
   MaryEra,
   Proof (..),
@@ -228,386 +235,1494 @@ import Test.Cardano.Ledger.Generic.Proof (
   whichGovState,
  )
 
--- =====================================================
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), RdmrPtr (..))
+import Cardano.Ledger.Conway.Rules (
+  ConwayCertsPredFailure (..),
+  -- ConwayCertPredFailure(..),
+  ConwayDelegPredFailure (..),
+  ConwayGovCertEnv (..),
+  ConwayGovCertPredFailure (..),
+  ConwayGovPredFailure (..),
+  ConwayLedgerPredFailure (..),
+  ConwayNewEpochPredFailure,
+  EnactSignal (..),
+  GovEnv (..),
+  GovRuleState (..),
+ )
+import qualified Cardano.Ledger.Conway.Rules as ConwayRules
+import qualified Cardano.Ledger.Plutus.ExUnits as ExUnits (Prices)
+import Cardano.Ledger.Plutus.Language (Language (..))
+import Cardano.Ledger.Shelley.PoolRank (Likelihood (..), LogWeight (..), NonMyopic (..))
+import Cardano.Ledger.Shelley.Rules (PoolEnv (..), ShelleyLedgerPredFailure (..), UpecPredFailure)
+import Codec.Binary.Bech32
+import qualified Data.ByteString as Long (ByteString)
+import qualified Data.ByteString.Lazy as Lazy (ByteString, toStrict)
+import Data.OSet.Strict (OSet)
+import Data.Sequence.Strict (StrictSeq)
+import Data.Void (Void)
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.Natural (Natural)
+import Prettyprinter (
+  Pretty (pretty),
+  align,
+  brackets,
+  comma,
+  encloseSep,
+  fillSep,
+  flatAlt,
+  group,
+  hang,
+  hsep,
+  lbrace,
+  lparen,
+  parens,
+  punctuate,
+  rbrace,
+  reAnnotate,
+  rparen,
+  sep,
+  space,
+  vcat,
+  viaShow,
+  vsep,
+  (<+>),
+ )
+import Prettyprinter.Internal (Doc (Empty))
+import Prettyprinter.Util (putDocW)
 
-class Era era => PrettyCore era where
-  prettyTx :: Tx era -> PDoc
-  prettyScript :: Script era -> PDoc
-  prettyTxBody :: TxBody era -> PDoc
-  prettyWitnesses :: TxWits era -> PDoc
-  prettyValue :: Value era -> PDoc
-  prettyTxOut :: TxOut era -> PDoc
+import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
+import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
+import Cardano.Ledger.Alonzo.TxAuxData (
+  AlonzoTxAuxData (atadMetadata),
+  getAlonzoTxAuxDataScripts,
+ )
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..))
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.MemoBytes (MemoBytes (..))
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
+import qualified Cardano.Ledger.Shelley.PParams as PParams (Update (..))
+import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
+import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))
+import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), ShelleyTxBodyRaw (..))
 
-instance CC.Crypto c => PrettyCore (ShelleyEra c) where
-  prettyTx = Cardano.Ledger.Pretty.ppTx
-  prettyScript = ppMultiSig
-  prettyTxBody = Cardano.Ledger.Pretty.ppTxBody
-  prettyWitnesses = ppWitnessSetHKD
-  prettyValue = ppCoin
-  prettyTxOut = Cardano.Ledger.Pretty.ppTxOut
+-- ================================================
 
-instance CC.Crypto c => PrettyCore (AllegraEra c) where
-  prettyTx = Cardano.Ledger.Pretty.ppTx
-  prettyScript = ppTimelock
-  prettyTxBody = prettyA
-  prettyWitnesses = ppWitnessSetHKD
-  prettyValue = ppCoin
-  prettyTxOut = Cardano.Ledger.Pretty.ppTxOut
+class PrettyA t where
+  prettyA :: t -> PDoc
 
-instance CC.Crypto c => PrettyCore (MaryEra c) where
-  prettyTx = Cardano.Ledger.Pretty.ppTx
-  prettyScript = ppTimelock
-  prettyTxBody = prettyA
-  prettyWitnesses = ppWitnessSetHKD
-  prettyValue = ppValue
-  prettyTxOut = Cardano.Ledger.Pretty.ppTxOut
+instance PrettyA () where
+  prettyA = ppString . show
 
-instance CC.Crypto c => PrettyCore (AlonzoEra c) where
-  prettyTx = Cardano.Ledger.Pretty.Alonzo.ppTx
-  prettyScript = ppScript
-  prettyTxBody = Cardano.Ledger.Pretty.Alonzo.ppTxBody
-  prettyWitnesses = ppTxWitness
-  prettyValue = ppValue
-  prettyTxOut = Cardano.Ledger.Pretty.Alonzo.ppTxOut
+instance PrettyA Void where
+  prettyA = absurd
 
-instance CC.Crypto c => PrettyCore (BabbageEra c) where
-  prettyTx = Cardano.Ledger.Pretty.Alonzo.ppTx
-  prettyScript = ppScript
-  prettyTxBody = Babbage.ppTxBody
-  prettyWitnesses = ppTxWitness
-  prettyValue = pcValue
-  prettyTxOut = Babbage.ppTxOut
-
-instance CC.Crypto c => PrettyCore (ConwayEra c) where
-  prettyTx = Cardano.Ledger.Pretty.Alonzo.ppTx
-  prettyScript = ppScript
-  prettyTxBody = ppConwayTxBody
-  prettyWitnesses = ppTxWitness
-  prettyValue = ppValue
-  prettyTxOut = Babbage.ppTxOut
-
-prettyUTxO :: Proof era -> UTxO era -> PDoc
-prettyUTxO proof = prettyUTxOMap proof . unUTxO
-
-prettyUTxOMap :: Proof era -> Map.Map (TxIn (EraCrypto era)) (TxOut era) -> PDoc
-prettyUTxOMap (Conway _) mp = ppMap ppTxIn prettyTxOut mp
-prettyUTxOMap (Babbage _) mp = ppMap ppTxIn prettyTxOut mp
-prettyUTxOMap (Alonzo _) mp = ppMap ppTxIn prettyTxOut mp
-prettyUTxOMap (Mary _) mp = ppMap ppTxIn prettyTxOut mp
-prettyUTxOMap (Allegra _) mp = ppMap ppTxIn prettyTxOut mp
-prettyUTxOMap (Shelley _) mp = ppMap ppTxIn prettyTxOut mp
-
--- ===================================================================
--- PrettyA instances for UTXOW, UTXO, UTXOS, PPUP predicate failures
--- There are sometimes two versions:
--- one introduced in Shelley, one introduced in Alonzo
--- ===================================================================
-
--- Predicate Failure for LEDGER
-
-ppLedgerPredicateFailure ::
-  ( PrettyA (PredicateFailure (EraRule "UTXOW" era))
-  , Show (PredicateFailure (EraRule "DELEGS" era))
-  ) =>
-  ShelleyLedgerPredFailure era ->
-  PDoc
-ppLedgerPredicateFailure (UtxowFailure x) = prettyA x
-ppLedgerPredicateFailure (DelegsFailure x) = ppString (show x)
-
-instance
-  ( PrettyA (PredicateFailure (EraRule "UTXOW" era))
-  , Show (PredicateFailure (EraRule "DELEGS" era))
-  ) =>
-  PrettyA (ShelleyLedgerPredFailure era)
-  where
-  prettyA = ppLedgerPredicateFailure
-
-instance
-  ( PrettyA (PredicateFailure (EraRule "UTXOW" era))
-  , Show (PredicateFailure (EraRule "DELEGS" era))
-  ) =>
-  PrettyA [ShelleyLedgerPredFailure era]
-  where
+instance PrettyA x => PrettyA [x] where
   prettyA = ppList prettyA
+
+instance (PrettyA a, PrettyA b) => PrettyA (Map a b) where
+  prettyA = ppMap prettyA prettyA
+
+instance (PrettyA a, PrettyA b) => PrettyA (a, b) where
+  prettyA (x, y) = encloseSep lparen rparen comma [prettyA x, prettyA y]
+
+-- =====================================
+-- Operations for pretty printing
+-- =====================================
+
+isEmpty :: Doc ann -> Bool
+isEmpty Empty = True
+isEmpty _ = False
+
+putDoc :: Doc ann -> IO ()
+putDoc = putDocW 80
+
+newtype PrettyAnn = Width Int
+
+type Ann = [PrettyAnn]
+
+type PDoc = Doc Ann
+
+text :: Text -> Doc ann
+text = pretty
+
+trim :: PDoc -> PDoc
+trim x = ppString (take 10 (show x))
+
+-- ================================================
+-- Named pretty printers for simple Haskell types
+-- ================================================
+
+ppString :: String -> Doc a
+ppString = pretty
+
+ppDouble :: Double -> Doc a
+ppDouble = viaShow
+
+ppInteger :: Integer -> Doc a
+ppInteger = viaShow
+
+ppRational :: Rational -> Doc a
+ppRational = viaShow
+
+ppFloat :: Float -> Doc a
+ppFloat = viaShow
+
+ppNatural :: Natural -> Doc a
+ppNatural = viaShow
+
+ppWord64 :: Word64 -> Doc a
+ppWord64 = viaShow
+
+ppWord32 :: Word32 -> Doc a
+ppWord32 = viaShow
+
+ppWord8 :: Word8 -> Doc a
+ppWord8 = viaShow
+
+ppWord16 :: Word16 -> Doc a
+ppWord16 = viaShow
+
+ppFixedPoint :: FixedPoint -> Doc a
+ppFixedPoint = viaShow
+
+ppPair :: (t1 -> PDoc) -> (t2 -> PDoc) -> (t1, t2) -> PDoc
+ppPair pp1 pp2 (x, y) = ppSexp' mempty [pp1 x, pp2 y]
+
+-- ppSignedDSIGN :: SignedDSIGN a b -> Doc ann
+ppSignedDSIGN :: Show a => a -> PDoc
+ppSignedDSIGN x = reAnnotate (Width 5 :) (viaShow x)
+
+ppBool :: Bool -> Doc a
+ppBool = viaShow
+
+ppInt :: Int -> Doc a
+ppInt = viaShow
+
+-- ======================
+-- Byte Strings in Bech32 format
+
+long_bech32 :: Long.ByteString -> Text
+long_bech32 x =
+  case humanReadablePartFromText "*" of
+    Right human ->
+      case encode human (dataPartFromBytes x) of
+        Right ans -> ans
+        Left _ -> "bech32Error"
+    Left _ -> "bech32Error"
+
+lazy_bech32 :: Lazy.ByteString -> Text
+lazy_bech32 x =
+  case humanReadablePartFromText "*" of
+    Right human ->
+      case encode human (dataPartFromBytes (Lazy.toStrict x)) of
+        Right ans -> ans
+        Left _ -> "bech32Error"
+    Left _ -> "bech32Error"
+
+ppLong :: Long.ByteString -> PDoc
+ppLong x = text (long_bech32 x)
+
+ppLazy :: Lazy.ByteString -> PDoc
+ppLazy x = text (lazy_bech32 x)
+
+instance PrettyA Long.ByteString where
+  prettyA = ppLong
+
+instance PrettyA Lazy.ByteString where
+  prettyA = ppLazy
+
+-- ============================================
+-- Combinators for common patterns of layout
+-- ============================================
+
+-- | x == y
+equate :: Doc a -> Doc a -> Doc a
+equate x y = group (flatAlt (hang 2 (sep [x <+> text "=", y])) (hsep [x, text "=", y]))
+
+-- | x -> y
+arrow :: (Doc a, Doc a) -> Doc a
+arrow (x, y) = group (flatAlt (hang 2 (sep [x <+> text "->", y])) (hsep [x, text "->", y]))
+
+-- | ppSexp x [w,y,z] --> (x w y z)
+ppSexp :: Text -> [PDoc] -> PDoc
+ppSexp con = ppSexp' (text con)
+
+ppSexp' :: PDoc -> [PDoc] -> PDoc
+ppSexp' con fields =
+  group $
+    flatAlt
+      (hang 2 (encloseSep lparen rparen space docs))
+      (encloseSep lparen rparen space docs)
+  where
+    docs = if isEmpty con then fields else con : fields
+
+-- | ppRecord name [("a",x),("b",y),("c",z)] --> name { a = x, b = y, c = z }
+ppRecord :: Text -> [(Text, PDoc)] -> PDoc
+ppRecord con = ppRecord' (text con)
+
+ppRecord' :: PDoc -> [(Text, PDoc)] -> PDoc
+ppRecord' con fields =
+  group $
+    flatAlt
+      (hang 1 (vcat [con, puncLeft lbrace (map (\(x, y) -> equate (text x) y) fields) comma rbrace]))
+      (con <> encloseSep (lbrace <> space) (space <> rbrace) (comma <> space) (map (\(x, y) -> equate (text x) y) fields))
+
+-- | Vertical layout with commas aligned on the left hand side
+puncLeft :: Doc ann -> [Doc ann] -> Doc ann -> Doc ann -> Doc ann
+puncLeft open [] _ close = hsep [open, close]
+puncLeft open [x] _ close = hsep [open, x, close]
+puncLeft open (x : xs) coma close = align (sep ((open <+> x) : help xs))
+  where
+    help [] = mempty
+    help [y] = [hsep [coma, y, close]]
+    help (y : ys) = (coma <+> y) : help ys
+
+ppSet :: (x -> Doc ann) -> Set x -> Doc ann
+ppSet p xs = encloseSep lbrace rbrace comma (map p (toList xs))
+
+ppList :: (x -> Doc ann) -> [x] -> Doc ann
+ppList p xs = brackets $ fillSep $ punctuate comma $ map p xs
+
+ppStrictSeq :: (a -> Doc ann) -> StrictSeq a -> Doc ann
+ppStrictSeq p xs = ppList p (foldr (:) [] xs)
+
+ppOSet :: (a -> Doc ann) -> OSet a -> Doc ann
+ppOSet p xs = ppList p (foldr (:) [] xs)
+
+ppStrictMaybe :: (x -> Doc ann) -> StrictMaybe x -> Doc ann
+ppStrictMaybe _ SNothing = text "?-"
+ppStrictMaybe p (SJust x) = text "?" <> p x
+
+ppMaybe :: (x -> Doc ann) -> Maybe x -> Doc ann
+ppMaybe _ Nothing = text "?-"
+ppMaybe p (Just x) = text "?" <> p x
+
+ppAssocList :: PDoc -> (k -> PDoc) -> (v -> PDoc) -> [(k, v)] -> PDoc
+ppAssocList name kf vf xs =
+  let docs = fmap (\(k, v) -> arrow (kf k, vf v)) xs
+      vertical =
+        if isEmpty name
+          then hang 1 (puncLeft lbrace docs comma rbrace)
+          else hang 1 (vcat [name, puncLeft lbrace docs comma rbrace])
+   in group $
+        flatAlt
+          vertical
+          (name <> encloseSep (lbrace <> space) (space <> rbrace) (comma <> space) docs)
+
+ppMap' :: PDoc -> (k -> PDoc) -> (v -> PDoc) -> Map.Map k v -> PDoc
+ppMap' name kf vf = ppAssocList name kf vf . Map.toList
+
+ppMap :: (k -> PDoc) -> (v -> PDoc) -> Map.Map k v -> PDoc
+ppMap = ppMap' (text "Map")
+
+ppVMap ::
+  (VMap.Vector kv k, VMap.Vector vv v) =>
+  (k -> PDoc) ->
+  (v -> PDoc) ->
+  VMap.VMap kv vv k v ->
+  PDoc
+ppVMap pk pv = ppAssocList (text "VMap") pk pv . VMap.toList
+
+-- =====================================================================================================
+-- Pretty printers Cardano.Ledger types
+-- =====================================================================================================
+
+ppPolicyID :: PolicyID c -> PDoc
+ppPolicyID (PolicyID sh) = pcScriptHash sh
+
+ppLogWeight :: LogWeight -> PDoc
+ppLogWeight (LogWeight n) = ppSexp "LogWeight" [ppFloat n]
+
+instance PrettyA LogWeight where
+  prettyA = ppLogWeight
+
+ppPrices :: ExUnits.Prices -> PDoc
+ppPrices (Scripts.Prices prMem prSteps) =
+  ppRecord
+    "Prices"
+    [ ("prMem", ppRational $ unboundRational prMem)
+    , ("prSteps", ppRational $ unboundRational prSteps)
+    ]
+
+instance PrettyA ExUnits.Prices where
+  prettyA = ppPrices
+
+ppRewardType :: RewardType -> PDoc
+ppRewardType MemberReward = text "MemberReward"
+ppRewardType LeaderReward = text "LeaderReward"
+
+ppLikelihood :: Likelihood -> PDoc
+ppLikelihood (Likelihood ns) = ppSexp "Likelihood" [ppStrictSeq ppLogWeight ns]
+
+ppNonMyopic :: NonMyopic c -> PDoc
+ppNonMyopic (NonMyopic m c) =
+  ppRecord
+    "NonMyopic"
+    [ ("likelihood", ppMap' "" pcKeyHash ppLikelihood m)
+    , ("rewardPot", pcCoin c)
+    ]
+
+ppRewardUpdate :: RewardUpdate c -> PDoc
+ppRewardUpdate (RewardUpdate dt dr rss df nonmyop) =
+  ppRecord
+    "RewardUpdate"
+    [ ("deltaT", pcDeltaCoin dt)
+    , ("deltaR", pcDeltaCoin dr)
+    , ("rs", ppMap' mempty pcCredential (ppSet pcReward) rss)
+    , ("deltaF", pcDeltaCoin df)
+    , ("nonMyopic", ppNonMyopic nonmyop)
+    ]
+
+instance PrettyA (RewardUpdate c) where
+  prettyA = ppRewardUpdate
+
+ppTag :: Tag -> PDoc
+ppTag x = ppString (show x)
+
+ppRdmrPtr :: RdmrPtr -> PDoc
+ppRdmrPtr (RdmrPtr tag w) = ppSexp "RdmrPtr" [ppTag tag, ppWord64 w]
+
+ppLanguage :: Language -> PDoc
+ppLanguage = ppString . show
+
+ppTxWitness :: forall era. Reflect era => AlonzoTxWits era -> PDoc
+ppTxWitness (AlonzoTxWits' vk wb sc da (Redeemers rd)) =
+  ppRecord
+    "AlonzoTxWits"
+    [ ("keys", ppSet (pcWitVKey @era reify) vk)
+    , ("bootstrap witnesses", ppSet ppBootstrapWitness wb)
+    , ("scripts map", ppMap pcScriptHash (pcScript reify) sc)
+    , ("Data map", ppMap ppSafeHash pcData (unTxDats da))
+    , ("Redeemer map", ppMap ppRdmrPtr (ppPair pcData pcExUnits) rd)
+    ]
+
+instance Reflect era => PrettyA (AlonzoTxWits era) where
+  prettyA = ppTxWitness
+
+ppIsValid :: IsValid -> PDoc
+ppIsValid (IsValid True) = ppString "True"
+ppIsValid (IsValid False) = ppString "False"
+
+ppVersion :: Version -> PDoc
+ppVersion = ppWord64 . getVersion64
+
+ppNetwork :: Network -> PDoc
+ppNetwork Testnet = text "Testnet"
+ppNetwork Mainnet = text "Mainnet"
+
+ppValidityInterval :: ValidityInterval -> PDoc
+ppValidityInterval (ValidityInterval b a) =
+  ppRecord
+    "ValidityInterval"
+    [ ("invalidBefore", ppStrictMaybe pcSlotNo b)
+    , ("invalidHereafter", ppStrictMaybe pcSlotNo a)
+    ]
+
+instance PrettyA ValidityInterval where
+  prettyA = ppValidityInterval
+
+ppAuxiliaryDataHash :: AuxiliaryDataHash c -> PDoc
+ppAuxiliaryDataHash (AuxiliaryDataHash h) = ppSexp "AuxiliaryDataHash" [ppSafeHash h]
+
+instance PrettyA (AuxiliaryDataHash c) where
+  prettyA = ppAuxiliaryDataHash
+
+ppSafeHash :: SafeHash c index -> PDoc
+ppSafeHash x = ppHash (extractHash x)
+
+instance PrettyA (SafeHash x y) where
+  prettyA = ppSafeHash
+
+ppEpochNo :: EpochNo -> Doc ann
+ppEpochNo (EpochNo x) = text "EpochNo" <+> pretty x
+
+instance PrettyA EpochNo where
+  prettyA = ppEpochNo
+
+ppEpochInterval :: EpochInterval -> Doc ann
+ppEpochInterval (EpochInterval x) = text "EpochInterval" <+> pretty x
+
+instance PrettyA EpochInterval where
+  prettyA = ppEpochInterval
+
+ppHash :: Hash.Hash a b -> PDoc
+ppHash x = text "#" <> reAnnotate (Width 5 :) (viaShow x)
+
+ppUnitInterval :: UnitInterval -> PDoc
+ppUnitInterval = viaShow
+
+instance PrettyA UnitInterval where
+  prettyA = ppUnitInterval
+
+ppNonce :: Nonce -> PDoc
+ppNonce (Nonce h) = text "Nonce" <+> ppHash h
+ppNonce NeutralNonce = text "NeutralNonce"
+
+ppPtr :: Ptr -> PDoc
+ppPtr (Ptr slot txIx certIx) =
+  ppSexp "Ptr" [pcSlotNo slot, pretty (txIxToInt txIx), pretty (certIxToInt certIx)]
+
+instance PrettyA Ptr where
+  prettyA = ppPtr
+
+ppProtVer :: ProtVer -> PDoc
+ppProtVer (ProtVer maj mi) = ppRecord "ProtVer" [("major", ppVersion maj), ("minor", ppNatural mi)]
+
+instance PrettyA ProtVer where
+  prettyA = ppProtVer
+
+ppVKey :: Crypto c => VKey r c -> PDoc
+ppVKey vk@(VKey x) = vsep [reAnnotate (Width 5 :) (viaShow x), "hash = " <+> pcKeyHash (hashKey vk)]
+
+instance Crypto c => PrettyA (VKey r c) where
+  prettyA = ppVKey
+
+ppBootstrapWitness :: Crypto c => BootstrapWitness c -> PDoc
+ppBootstrapWitness (BootstrapWitness key sig (ChainCode code) attr) =
+  ppRecord
+    "BootstrapWitness"
+    [ ("key", ppVKey key)
+    , ("signature", ppSignedDSIGN sig)
+    , ("chaincode", ppLong code)
+    , ("attributes", ppLong attr)
+    ]
+
+instance Crypto c => PrettyA (BootstrapWitness c) where
+  prettyA = ppBootstrapWitness
+
+ppWitnessSetHKD :: forall era. Reflect era => ShelleyTxWits era -> PDoc
+ppWitnessSetHKD x =
+  let (addr, scr, boot) = prettyWitnessSetParts x
+   in ppRecord
+        "ShelleyTxWits"
+        [ ("addrWits", ppSet (pcWitVKey @era reify) addr)
+        , ("scriptWits", ppMap pcScriptHash (pcScript reify) scr)
+        , ("bootWits", ppSet ppBootstrapWitness boot)
+        ]
+
+instance Reflect era => PrettyA (ShelleyTxWits era) where
+  prettyA = ppWitnessSetHKD
+
+-- TODO Redo this with Fields?
+ppPParamsUpdate ::
+  (ProtVerAtMost era 4, ProtVerAtMost era 6, ProtVerAtMost era 8, EraPParams era) =>
+  PParamsUpdate era ->
+  PDoc
+ppPParamsUpdate pp =
+  ppRecord
+    "PParamsUdate"
+    [ ("minfeeA", ppStrictMaybe pcCoin $ pp ^. ppuMinFeeAL)
+    , ("minfeeB", ppStrictMaybe pcCoin $ pp ^. ppuMinFeeBL)
+    , ("maxBBSize", ppStrictMaybe ppWord32 $ pp ^. ppuMaxBBSizeL)
+    , ("maxTxSize", ppStrictMaybe ppWord32 $ pp ^. ppuMaxTxSizeL)
+    , ("maxBHSize", ppStrictMaybe ppWord16 $ pp ^. ppuMaxBHSizeL)
+    , ("keyDeposit", ppStrictMaybe pcCoin $ pp ^. ppuKeyDepositL)
+    , ("poolDeposit", ppStrictMaybe pcCoin $ pp ^. ppuPoolDepositL)
+    , ("eMax", ppStrictMaybe ppEpochInterval $ pp ^. ppuEMaxL)
+    , ("nOpt", ppStrictMaybe ppNatural $ pp ^. ppuNOptL)
+    , ("a0", ppStrictMaybe (ppRational . unboundRational) $ pp ^. ppuA0L)
+    , ("rho", ppStrictMaybe ppUnitInterval $ pp ^. ppuRhoL)
+    , ("tau", ppStrictMaybe ppUnitInterval $ pp ^. ppuTauL)
+    , ("d", ppStrictMaybe ppUnitInterval $ pp ^. ppuDL)
+    , ("extraEntropy", ppStrictMaybe ppNonce $ pp ^. ppuExtraEntropyL)
+    , ("protocolVersion", ppStrictMaybe ppProtVer $ pp ^. ppuProtocolVersionL)
+    , ("minUTxOValue", ppStrictMaybe pcCoin $ pp ^. ppuMinUTxOValueL)
+    , ("minPoolCost", ppStrictMaybe pcCoin $ pp ^. ppuMinPoolCostL)
+    ]
+
+-- TODO Do we need all these instances?
+-- Does this resolve the constraints  (ProtVerAtMost era 4, ProtVerAtMost era 6, ProtVerAtMost era 8)
+instance Crypto c => PrettyA (PParamsUpdate (ShelleyEra c)) where
+  prettyA = ppPParamsUpdate
+
+instance Crypto c => PrettyA (PParamsUpdate (AllegraEra c)) where
+  prettyA = ppPParamsUpdate
+
+instance Crypto c => PrettyA (PParamsUpdate (MaryEra c)) where
+  prettyA = ppPParamsUpdate
+
+ppUpdate :: PrettyA (PParamsUpdate era) => PParams.Update era -> PDoc
+ppUpdate (PParams.Update prop epn) = ppSexp "Update" [ppProposedPPUpdates prop, ppEpochNo epn]
+
+instance PrettyA (PParamsUpdate e) => PrettyA (PParams.Update e) where
+  prettyA = ppUpdate
+
+ppProposedPPUpdates :: PrettyA (PParamsUpdate era) => ProposedPPUpdates era -> PDoc
+ppProposedPPUpdates (ProposedPPUpdates m) = ppMap pcKeyHash prettyA m
+
+instance PrettyA (PParamsUpdate e) => PrettyA (ProposedPPUpdates e) where
+  prettyA = ppProposedPPUpdates
+
+ppMetadatum :: Metadatum -> PDoc
+ppMetadatum (Map m) =
+  let pairs = fmap (\(k, v) -> arrow (ppMetadatum k, ppMetadatum v)) m
+   in ppSexp
+        "Map"
+        [ group $
+            flatAlt
+              (hang 1 (puncLeft lbrace pairs comma rbrace))
+              (encloseSep (lbrace <> space) (space <> rbrace) (comma <> space) pairs)
+        ]
+ppMetadatum (List ds) = ppSexp "List" [ppList ppMetadatum ds]
+ppMetadatum (I n) = ppSexp "I" [ppInteger n]
+ppMetadatum (B bs) = ppSexp "B" [ppLong bs]
+ppMetadatum (S txt) = ppSexp "S" [text txt]
+
+instance PrettyA Metadatum where
+  prettyA = ppMetadatum
+
+ppShelleyTxAuxData :: Era era => ShelleyTxAuxData era -> PDoc
+ppShelleyTxAuxData (ShelleyTxAuxData m) = ppMap' (text "ShelleyTxAuxData") ppWord64 ppMetadatum m
+
+instance Era era => PrettyA (ShelleyTxAuxData era) where
+  prettyA = ppShelleyTxAuxData
+
+ppAllegraTxAuxData :: Reflect era => AllegraTxAuxData era -> PDoc
+ppAllegraTxAuxData (AllegraTxAuxData m sp) =
+  ppRecord
+    "AllegraTxAuxData"
+    [ ("metadata", ppMap' (text "Metadata") ppWord64 ppMetadatum m)
+    , ("auxiliaryScripts", ppStrictSeq prettyA sp)
+    ]
+
+instance Reflect era => PrettyA (AllegraTxAuxData era) where
+  prettyA = ppAllegraTxAuxData
+
+ppAlonzoTxAuxData ::
+  ( Reflect era
+  , Script era ~ AlonzoScript era
+  , AlonzoEraScript era
+  ) =>
+  AlonzoTxAuxData era ->
+  PDoc
+ppAlonzoTxAuxData auxData =
+  ppSexp
+    "AuxiliaryData"
+    [ ppMap ppWord64 ppMetadatum (atadMetadata auxData)
+    , ppStrictSeq (pcScript reify) (getAlonzoTxAuxDataScripts auxData)
+    ]
+
+instance (Reflect era, Script era ~ AlonzoScript era, AlonzoEraScript era) => PrettyA (AlonzoTxAuxData era) where
+  prettyA = ppAlonzoTxAuxData
+
+pcAuxData :: Reflect era => Proof era -> TxAuxData era -> PDoc
+pcAuxData (Shelley _) x = ppShelleyTxAuxData x
+pcAuxData (Allegra _) x = ppAllegraTxAuxData x
+pcAuxData (Mary _) x = ppAllegraTxAuxData x
+pcAuxData (Alonzo _) x = ppAlonzoTxAuxData x
+pcAuxData (Babbage _) x = ppAlonzoTxAuxData x
+pcAuxData (Conway _) x = ppAlonzoTxAuxData x
+
+ppWithdrawals :: Withdrawals c -> PDoc
+ppWithdrawals (Withdrawals m) = ppSexp "Withdrawals" [ppMap' (text "Wdr") pcRewardAcnt pcCoin m]
+
+instance PrettyA (Withdrawals c) where
+  prettyA = ppWithdrawals
+
+ppWitHashes :: Set (KeyHash 'Witness c) -> PDoc
+ppWitHashes hs = ppSexp "WitHashes" [ppSet pcKeyHash hs]
+
+pcScriptPurpose :: Proof era -> ScriptPurpose era -> PDoc
+pcScriptPurpose _ (Minting policy) = ppSexp "Minting" [pcPolicyID policy]
+pcScriptPurpose _ (Spending txin) = ppSexp "Spending" [pcTxIn txin]
+pcScriptPurpose _ (Rewarding acct) = ppSexp "Rewarding" [pcRewardAcnt acct]
+pcScriptPurpose p (Certifying dcert) = ppSexp "Certifying" [pcTxCert p dcert]
+
+instance Reflect era => PrettyA (ScriptPurpose era) where
+  prettyA = pcScriptPurpose reify
+
+-- ================================================
+-- Pretty printers for Tx and TxBody
+-- ================================================
+
+ppShelleyTx ::
+  Reflect era =>
+  Tx era ->
+  PDoc
+ppShelleyTx tx =
+  ppRecord
+    "Tx"
+    [ ("body", pcTxBody reify $ tx ^. bodyTxL)
+    , ("witnessSet", ppCoreWitnesses reify $ tx ^. witsTxL)
+    , ("metadata", ppStrictMaybe (pcAuxData reify) $ tx ^. auxDataTxL)
+    ]
+
+instance
+  ( Reflect era
+  , Tx era ~ ShelleyTx era
+  ) =>
+  PrettyA (ShelleyTx era)
+  where
+  prettyA = ppShelleyTx
+
+ppAlonzoTx :: forall era. (Reflect era, Tx era ~ AlonzoTx era) => AlonzoTx era -> PDoc
+ppAlonzoTx tx = ppRecord "AlonzoTx" pairs
+  where
+    fields = abstractTx reify tx
+    pairs = concatMap (pcTxField @era (reify @era)) fields
+
+instance (Reflect era, Tx era ~ AlonzoTx era) => PrettyA (AlonzoTx era) where
+  prettyA = ppAlonzoTx
+
+ppShelleyTxBody ::
+  ( Reflect era
+  , PrettyA (PParamsUpdate era)
+  ) =>
+  ShelleyTxBody era ->
+  PDoc
+ppShelleyTxBody (TxBodyConstr (Memo (ShelleyTxBodyRaw ins outs cs withdrawals fee ttl upd mdh) _)) =
+  ppRecord
+    "TxBody"
+    [ ("inputs", ppSet pcTxIn ins)
+    , ("outputs", ppStrictSeq (pcTxOut reify) outs)
+    , ("cert", ppStrictSeq (pcTxCert reify) cs)
+    , ("withdrawals", ppWithdrawals withdrawals)
+    , ("fee", pcCoin fee)
+    , ("timetolive", pcSlotNo ttl)
+    , ("update", ppStrictMaybe ppUpdate upd)
+    , ("metadatahash", ppStrictMaybe ppAuxiliaryDataHash mdh)
+    ]
+
+instance
+  ( EraTxOut era
+  , PrettyA (PParamsUpdate era)
+  , Reflect era
+  ) =>
+  PrettyA (ShelleyTxBody era)
+  where
+  prettyA = ppShelleyTxBody
+
+ppAllegraTxBody :: forall era. (TxBody era ~ AllegraTxBody era, Reflect era) => AllegraTxBody era -> PDoc
+ppAllegraTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+  where
+    fields = abstractTxBody reify txbody
+    pairs = concatMap (pcTxBodyField reify) fields
+
+instance (TxBody era ~ AllegraTxBody era, Reflect era) => PrettyA (AllegraTxBody era) where
+  prettyA = ppAllegraTxBody
+
+ppAlonzoTxBody :: forall era. (TxBody era ~ AlonzoTxBody era, Reflect era) => AlonzoTxBody era -> PDoc
+ppAlonzoTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+  where
+    fields = abstractTxBody reify txbody
+    pairs = concatMap (pcTxBodyField reify) fields
+
+instance (TxBody era ~ AlonzoTxBody era, Reflect era) => PrettyA (AlonzoTxBody era) where
+  prettyA = ppAlonzoTxBody
+
+ppMaryTxBody :: forall era. (TxBody era ~ MaryTxBody era, Reflect era) => MaryTxBody era -> PDoc
+ppMaryTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+  where
+    fields = abstractTxBody reify txbody
+    pairs = concatMap (pcTxBodyField reify) fields
+
+instance (TxBody era ~ MaryTxBody era, Reflect era) => PrettyA (MaryTxBody era) where
+  prettyA = ppMaryTxBody
+
+-- =============================================================
+-- Pretty Printers for Type families must have a (Proof era) as
+-- an argument. Because they are type families, they cannot
+-- have a PrettyA instance. As one cannot write an instance for
+-- any type family.
+-- ==============================================================
+
+ppCoreWitnesses :: Reflect era => Proof era -> TxWits era -> PDoc
+ppCoreWitnesses (Conway _) x = ppTxWitness x
+ppCoreWitnesses (Babbage _) x = ppTxWitness x
+ppCoreWitnesses (Alonzo _) x = ppTxWitness x
+ppCoreWitnesses (Mary _) x = ppWitnessSetHKD x
+ppCoreWitnesses (Allegra _) x = ppWitnessSetHKD x
+ppCoreWitnesses (Shelley _) x = ppWitnessSetHKD x
+
+pcTxOut :: Reflect era => Proof era -> TxOut era -> PDoc
+pcTxOut p@(Conway _) (BabbageTxOut addr v d s) =
+  ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
+pcTxOut p@(Babbage _) (BabbageTxOut addr v d s) =
+  ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
+pcTxOut (Alonzo _) (AlonzoTxOut addr v md) =
+  ppSexp "TxOut" [pcAddr addr, pcValue v, ppStrictMaybe pcDataHash md]
+pcTxOut p@(Mary _) (ShelleyTxOut addr v) =
+  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
+pcTxOut p@(Allegra _) (ShelleyTxOut addr v) =
+  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
+pcTxOut p@(Shelley _) (ShelleyTxOut addr v) =
+  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
+
+pcScript :: forall era. Reflect era => Proof era -> Script era -> PDoc
+pcScript (Conway _) (TimelockScript t) = pcTimelock @era t
+pcScript p@(Conway _) s@(PlutusScript v) =
+  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
+pcScript (Babbage _) (TimelockScript t) = pcTimelock @era t
+pcScript p@(Babbage _) s@(PlutusScript v) =
+  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
+pcScript (Alonzo _) (TimelockScript t) = pcTimelock @era t
+pcScript p@(Alonzo _) s@(PlutusScript v) =
+  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
+pcScript (Mary _) s = pcTimelock @era s
+pcScript (Allegra _) s = pcTimelock @era s
+pcScript p@(Shelley _) s = pcMultiSig @era (pcHashScript @era p s) s
+
+pcWitnesses :: Reflect era => Proof era -> TxWits era -> PDoc
+pcWitnesses proof txwits = ppRecord "Witnesses" pairs
+  where
+    fields = abstractWitnesses proof txwits
+    pairs = concat (map (pcWitnessesField proof) fields)
+
+pcTx :: Proof era -> Tx era -> PDoc
+pcTx proof tx = ppRecord "Tx" pairs
+  where
+    fields = abstractTx proof tx
+    pairs = concatMap (unReflect pcTxField proof) fields
+
+pcTxBody :: Proof era -> TxBody era -> PDoc
+pcTxBody proof txbody = ppRecord ("TxBody " <> pack (show proof)) pairs
+  where
+    fields = abstractTxBody proof txbody
+    pairs = concatMap (pcTxBodyField proof) fields
+
+pcPParams :: Proof era -> PParams era -> PDoc
+pcPParams proof pp = ppRecord ("TxBody " <> pack (show proof)) pairs
+  where
+    fields = abstractPParams proof pp
+    pairs = concatMap pcPParamsField fields
+
+-- | Unike other type families, PParams CAN have a PrettyA instance, as they
+--   are a newtype wrapped around a type family.
+instance Reflect era => PrettyA (PParams era) where
+  prettyA = pcPParams reify
+
+-- =================================
+-- Type families that have Fields, can be pretty printed (for all eras) by using
+-- function that can pretty print each field.
+-- =================================
+
+pcTxBodyField ::
+  Proof era ->
+  TxBodyField era ->
+  [(Text, PDoc)]
+pcTxBodyField proof x = case x of
+  Inputs s -> [("spend inputs", ppSet pcTxIn s)]
+  Collateral s -> [("coll inputs", ppSet pcTxIn s)]
+  RefInputs s -> [("ref inputs", ppSet pcTxIn s)]
+  Outputs s -> [("outputs", ppList (unReflect pcTxOut proof) (toList s))]
+  CollateralReturn SNothing -> []
+  CollateralReturn (SJust txout) -> [("coll return", unReflect pcTxOut proof txout)]
+  TotalCol SNothing -> []
+  TotalCol (SJust c) -> [("total coll", pcCoin c)]
+  Certs xs -> [("certs", ppList (pcTxCert proof) (toList xs))]
+  Withdrawals' (Withdrawals m) -> [("withdrawal", ppMap pcRewardAcnt pcCoin m)]
+  Txfee c -> [("fee", pcCoin c)]
+  Vldt v -> [("validity interval", ppValidityInterval v)]
+  TTL slot -> [("time to live", pcSlotNo slot)]
+  Update SNothing -> []
+  Update (SJust _) -> [("update", ppString "UPDATE")]
+  ReqSignerHashes s -> [("required hashes", ppSet pcKeyHash s)]
+  Fields.Mint (MultiAsset m) -> [("minted", ppSet pcPolicyID (Map.keysSet m))]
+  WppHash SNothing -> []
+  WppHash (SJust h) -> [("integrity hash", trim (ppSafeHash h))]
+  AdHash SNothing -> []
+  AdHash (SJust (AuxiliaryDataHash h)) -> [("aux data hash", trim (ppSafeHash h))]
+  Txnetworkid SNothing -> [("network id", ppString "Nothing")]
+  Txnetworkid (SJust nid) -> [("network id", pcNetwork nid)]
+  GovProcs ga -> [("gov procedures", pcGovProcedures ga)]
+  CurrentTreasuryValue ctv -> [("current treasury value", ppStrictMaybe pcCoin ctv)]
+  TreasuryDonation td -> [("treasury donation", pcCoin td)]
+
+pcTxField ::
+  forall era.
+  Reflect era =>
+  Proof era ->
+  TxField era ->
+  [(Text, PDoc)]
+pcTxField proof x = case x of
+  Body b -> [("txbody hash", ppSafeHash (hashAnnotated b)), ("body", pcTxBody proof b)]
+  BodyI xs -> [("body", ppRecord "TxBody" (concat (map (pcTxBodyField proof) xs)))]
+  TxWits w -> [("witnesses", pcWitnesses proof w)]
+  WitnessesI ws -> [("witnesses", ppRecord "Witnesses" (concat (map (pcWitnessesField proof) ws)))]
+  AuxData SNothing -> []
+  AuxData (SJust auxdata) -> [("aux data", pcAuxData proof auxdata)]
+  Valid (IsValid v) -> [("is valid", ppString (show v))]
+
+pcWitnessesField :: forall era. Reflect era => Proof era -> WitnessesField era -> [(Text, PDoc)]
+pcWitnessesField proof x = case x of
+  AddrWits set -> [("key wits", ppSet (pcWitVKey proof) set)]
+  BootWits bwits -> [("boot wits", ppSet (\z -> ppVKey (bwKey z)) bwits)]
+  ScriptWits mp -> [("script wits", ppMap pcScriptHash (pcScript proof) mp)]
+  DataWits (TxDats m) -> [("data wits", ppMap pcDataHash pcData m)]
+  RdmrWits (Redeemers m) ->
+    [("redeemer wits", ppMap ppRdmrPtr (pcPair pcData pcExUnits) m)]
+
+pcPParamsField ::
+  PParamsField era ->
+  [(Text, PDoc)]
+pcPParamsField x = case x of
+  MinfeeA coin -> [("minfeeA", pcCoin coin)]
+  MinfeeB coin -> [("minfeeB", pcCoin coin)]
+  MaxBBSize natural -> [("maxBBsize", ppWord32 natural)]
+  MaxTxSize natural -> [("maxTxsize", ppWord32 natural)]
+  MaxBHSize natural -> [("maxBHsize", ppWord16 natural)]
+  KeyDeposit coin -> [("keydeposit", pcCoin coin)]
+  PoolDeposit coin -> [("pooldeposit", pcCoin coin)]
+  EMax n -> [("emax", ppEpochInterval n)]
+  NOpt natural -> [("NOpt", ppNatural natural)]
+  A0 i -> [("A0", viaShow i)]
+  Rho u -> [("Rho", ppUnitInterval u)]
+  Tau u -> [("Tau", ppUnitInterval u)]
+  D u -> [("D", ppUnitInterval u)]
+  ExtraEntropy n -> [("extraEntropy", ppNonce n)]
+  ProtocolVersion protVer -> [("ProtocolVersion", ppProtVer protVer)]
+  MinPoolCost coin -> [("minPoolCost", pcCoin coin)]
+  MinUTxOValue coin -> [("minUTxOValue", pcCoin coin)]
+  CoinPerUTxOWord (CoinPerWord c) -> [("coinPerUTxOWord", pcCoin c)]
+  CoinPerUTxOByte (CoinPerByte c) -> [("coinPerUTxOByte", pcCoin c)]
+  Costmdls _ -> [("costmodels", ppString "?")]
+  Fields.Prices prices -> [("prices", ppPrices prices)]
+  MaxTxExUnits e -> [("maxTxExUnits", pcExUnits e)]
+  MaxBlockExUnits e -> [("maxBlockExUnits", pcExUnits e)]
+  MaxValSize n -> [("maxValSize", ppNatural n)]
+  CollateralPercentage n -> [("Collateral%", ppNatural n)]
+  MaxCollateralInputs n -> [("maxCollateralInputs", ppNatural n)]
+  PoolVotingThreshold _ -> [("PoolVotingThresholds", ppString "?")]
+  DRepVotingThreshold _ -> [("DRepVotingThresholds", ppString "?")]
+  MinCommitteeSize n -> [("minCommitteeSize", ppNatural n)]
+  CommitteeTermLimit n -> [("committeeTermLimit", ppEpochInterval n)]
+  GovActionExpiration epochNo -> [("govActionExpire", ppEpochInterval epochNo)]
+  GovActionDeposit coin -> [("govActiondDeposit", pcCoin coin)]
+  DRepDeposit coin -> [("drepdeposit", pcCoin coin)]
+  DRepActivity epochNo -> [("drepActivity", ppEpochInterval epochNo)]
+
+-- =======================================================
+-- @@
+-- Pretty printers for PredicateFailures can be difficult because they often have componenents like
+-- PredicateFailure (EraRule "LEDGER" era)
+-- where both PredicateFailure and (EraRule "LEDGER" era) are type families.
+-- Note that field can be different for every era. For example look at the type of the constructor
+-- LedgerFailure :: PredicateFailure (EraRule "LEDGER" era) -> ShelleyLedgersPredFailure era
+-- So we must resort to case analysis over Proofs
+-- So for some EraRule "XXX", we write ppXXX :: Proof era -> PredicateFailure (EraRule "XXX") -> PDoc
+-- Complicated because some Eras do NOT have type instances for all (EraRule "XXX")
+
+ppUTXOW :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXOW" era) -> PDoc
+ppUTXOW (Shelley _) x = ppShelleyUtxowPredFailure x
+ppUTXOW (Allegra _) x = ppShelleyUtxowPredFailure x
+ppUTXOW (Mary _) x = ppShelleyUtxowPredFailure x
+ppUTXOW (Alonzo _) x = ppAlonzoUtxowPredFailure x
+ppUTXOW p@(Babbage _) x = ppBabbageUtxowPredFailure p x
+ppUTXOW p@(Conway _) x = ppBabbageUtxowPredFailure p x
+
+ppUTXOS :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXOS" era) -> PDoc
+ppUTXOS (Alonzo _) x = ppUtxosPredicateFailure x
+ppUTXOS (Babbage _) x = ppUtxosPredicateFailure x
+ppUTXOS (Conway _) x = ppUtxosPredicateFailure x
+ppUTXOS proof _ =
+  error
+    ( "Only the AlonzoEra, BabbageEra, and ConwayEra have a (PredicateFailure (EraRule \"UTXOS\" era))."
+        ++ "This Era is "
+        ++ show proof
+    )
+
+ppDELEGS :: Proof era -> PredicateFailure (EraRule "DELEGS" era) -> PDoc
+ppDELEGS p@(Shelley _) x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@(Allegra _) x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@(Mary _) x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@(Alonzo _) x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@(Babbage _) x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@(Conway _) _ =
+  error
+    ( "Only the Shelley, Allegra, Mary, Alonzo, and Babbage era have a (PredicateFailure (EraRule \"DELEGS\" era))."
+        ++ "This Era is "
+        ++ show p
+    )
+
+ppDELEG :: Proof era -> PredicateFailure (EraRule "DELEG" era) -> PDoc
+ppDELEG (Shelley _) x = ppShelleyDelegPredFailure x
+ppDELEG (Allegra _) x = ppShelleyDelegPredFailure x
+ppDELEG (Mary _) x = ppShelleyDelegPredFailure x
+ppDELEG (Alonzo _) x = ppShelleyDelegPredFailure x
+ppDELEG (Babbage _) x = ppShelleyDelegPredFailure x
+ppDELEG (Conway _) x = ppConwayDelegPredFailure x
+
+ppPOOL :: Proof era -> PredicateFailure (EraRule "POOL" era) -> PDoc
+ppPOOL (Shelley _) x = ppShelleyPoolPredFailure x
+ppPOOL (Allegra _) x = ppShelleyPoolPredFailure x
+ppPOOL (Mary _) x = ppShelleyPoolPredFailure x
+ppPOOL (Alonzo _) x = ppShelleyPoolPredFailure x
+ppPOOL (Babbage _) x = ppShelleyPoolPredFailure x
+ppPOOL (Conway _) x = ppShelleyPoolPredFailure x
+
+ppLEDGER :: Reflect era => Proof era -> PredicateFailure (EraRule "LEDGER" era) -> PDoc
+ppLEDGER p@(Shelley _) x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@(Allegra _) x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@(Mary _) x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@(Alonzo _) x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@(Babbage _) x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@(Conway _) x = ppConwayLedgerPredFailure p x
+
+ppUTXO :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXO" era) -> PDoc
+ppUTXO (Shelley _) x = ppShelleyUtxoPredFailure x
+ppUTXO (Allegra _) x = ppAllegraUtxoPredFailure x
+ppUTXO (Mary _) x = ppAllegraUtxoPredFailure x
+ppUTXO (Alonzo _) x = ppAlonzoUtxoPredFailure x
+ppUTXO (Babbage _) x = ppBabbageUtxoPredFailure x
+ppUTXO (Conway _) x = ppBabbageUtxoPredFailure x
+
+ppLEDGERS :: Proof era -> PredicateFailure (EraRule "LEDGERS" era) -> PDoc
+ppLEDGERS p@(Shelley _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@(Allegra _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@(Mary _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@(Alonzo _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@(Babbage _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@(Conway _) x = unReflect ppShelleyLedgersPredFailure p x
+
+ppDELPL :: Proof era -> PredicateFailure (EraRule "DELPL" era) -> PDoc
+ppDELPL p@(Shelley _) x = ppShelleyDelplPredFailure p x
+ppDELPL p@(Allegra _) x = ppShelleyDelplPredFailure p x
+ppDELPL p@(Mary _) x = ppShelleyDelplPredFailure p x
+ppDELPL p@(Alonzo _) x = ppShelleyDelplPredFailure p x
+ppDELPL p@(Babbage _) x = ppShelleyDelplPredFailure p x
+ppDELPL p@(Conway _) _ =
+  error
+    ( "Only the Shelley, Allegra, Mary, Alonzo, and Babbage era have a (PredicateFailure (EraRule \"DELPL\" era))."
+        ++ "This Era is "
+        ++ show p
+    )
+
+ppNEWEPOCH :: Reflect era => Proof era -> PredicateFailure (EraRule "NEWEPOCH" era) -> PDoc
+ppNEWEPOCH (Shelley _) x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH (Allegra _) x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH (Mary _) x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH (Alonzo _) x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH (Babbage _) x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH (Conway _) x = ppConwayNewEpochPredFailure x
+
+ppEPOCH :: Reflect era => Proof era -> PredicateFailure (EraRule "EPOCH" era) -> PDoc
+ppEPOCH (Shelley _) x = ppShelleyEpochPredFailure x
+ppEPOCH (Allegra _) x = ppShelleyEpochPredFailure x
+ppEPOCH (Mary _) x = ppShelleyEpochPredFailure x
+ppEPOCH (Alonzo _) x = ppShelleyEpochPredFailure x
+ppEPOCH (Babbage _) x = ppShelleyEpochPredFailure x
+ppEPOCH (Conway _) _ = ppString "PredicateFailure (ConwayEPOCH era) = Void, and can never Fail"
+
+-- | A bit different since it is NOT of the form: PredicateFailure (EraRule "UPEC" era)
+--   but instead, the type family UpecPredFailurePV pv era
+--   where, type UpecPredFailure era = UpecPredFailurePV (ProtVerLow era) era
+--   But the effect is still the same. The Proof era, fixes the type family result.
+ppUPEC :: Proof era -> UpecPredFailure era -> PDoc
+ppUPEC (Shelley _) x = ppUpecPredicateFailure x
+ppUPEC (Mary _) x = ppUpecPredicateFailure x
+ppUPEC (Alonzo _) x = ppUpecPredicateFailure x
+ppUPEC (Allegra _) x = ppUpecPredicateFailure x
+ppUPEC (Babbage _) x = ppUpecPredicateFailure x
+ppUPEC (Conway _) x = absurd x
+
+-- | A bit different since it is NOT of the form: PredicateFailure (EraRule "LEDGERS" era)
+--   but instead:  State (EraRule "LEDGERS" era)
+--   But the effect is still the same. The Proof era, fixes the type family result.
+ppStateLEDGERS :: Proof era -> State (EraRule "LEDGERS" era) -> PDoc
+ppStateLEDGERS p@(Shelley _) = pcLedgerState p
+ppStateLEDGERS p@(Allegra _) = pcLedgerState p
+ppStateLEDGERS p@(Mary _) = pcLedgerState p
+ppStateLEDGERS p@(Alonzo _) = pcLedgerState p
+ppStateLEDGERS p@(Babbage _) = pcLedgerState p
+ppStateLEDGERS p@(Conway _) = pcLedgerState p
+
+-- ============================================================================
+-- pretty printers for concrete types that are the target of PredicateFailure type instances
+
+ppShelleyDelegsPredFailure :: forall era. Proof era -> ShelleyDelegsPredFailure era -> PDoc
+ppShelleyDelegsPredFailure _ (Shelley.DelegateeNotRegisteredDELEG x) = pcKeyHash x
+ppShelleyDelegsPredFailure _ (WithdrawalsNotInRewardsDELEGS x) = ppMap pcRewardAcnt pcCoin x
+ppShelleyDelegsPredFailure p (DelplFailure x) = ppDELPL p x
+
+instance Reflect era => PrettyA (ShelleyDelegsPredFailure era) where
+  prettyA = ppShelleyDelegsPredFailure reify
+
+ppBabbageUtxoPredFailure :: Reflect era => BabbageUtxoPredFailure era -> PDoc
+ppBabbageUtxoPredFailure (AlonzoInBabbageUtxoPredFailure x) = ppAlonzoUtxoPredFailure x
+ppBabbageUtxoPredFailure (IncorrectTotalCollateralField c1 c2) =
+  ppRecord
+    "IncorrectTotalCollateralField"
+    [("collateral provided", pcCoin c1), ("collateral declared", pcCoin c2)]
+ppBabbageUtxoPredFailure (BabbageOutputTooSmallUTxO xs) =
+  ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair (pcTxOut reify) pcCoin) xs]
+
+instance Reflect era => PrettyA (BabbageUtxoPredFailure era) where
+  prettyA = ppBabbageUtxoPredFailure
+
+ppShelleyLedgersPredFailure :: Reflect era => Proof era -> ShelleyLedgersPredFailure era -> PDoc
+ppShelleyLedgersPredFailure p (LedgerFailure x) = ppLEDGER p x
+
+instance Reflect era => PrettyA (ShelleyLedgersPredFailure era) where
+  prettyA = ppShelleyLedgersPredFailure reify
+
+ppConwayLedgerPredFailure :: Reflect era => Proof era -> ConwayLedgerPredFailure era -> PDoc
+ppConwayLedgerPredFailure proof x = case x of
+  ConwayWdrlNotDelegatedToDRep s -> ppSexp "ConwayWdrlNotDelegatedToDRep" [ppSet pcCredential s]
+  ConwayTreasuryValueMismatch c1 c2 -> ppSexp "ConwayTreasuryValueMismatch" [pcCoin c1, pcCoin c2]
+  ConwayGovFailure y -> case proof of
+    Conway _ -> ppSexp "ConwayGovFailure" [ppConwayGovPredFailure y]
+    _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOV\" era)). This Era is " ++ show proof)
+  ConwayUtxowFailure y -> ppUTXOW proof y
+  {- case proof of -- (PredicateFailure (EraRule "UTXOW" era))
+    Shelley _ -> ppShelleyUtxowPredFailure y
+    Allegra _ -> ppShelleyUtxowPredFailure y
+    Mary _ -> ppShelleyUtxowPredFailure y
+    Alonzo _ -> ppAlonzoUtxowPredFailure y
+    Babbage _ -> ppBabbageUtxowPredFailure proof y
+    Conway _ -> ppBabbageUtxowPredFailure proof y -}
+  ConwayCertsFailure pf -> case proof of
+    Conway _ -> ppConwayCertsPredFailure proof pf
+    _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"CERTS\" era)). This Era is " ++ show proof)
+
+instance Reflect era => PrettyA (ConwayLedgerPredFailure era) where
+  prettyA = ppConwayLedgerPredFailure reify
+
+ppConwayCertPredFailure :: Proof era -> ConwayRules.ConwayCertPredFailure era -> PDoc
+ppConwayCertPredFailure proof x = case x of
+  ConwayRules.DelegFailure pf -> ppSexp "DelegFailure" [ppDELEG proof pf] -- (PredicateFailure (EraRule "DELEG" era))
+  ConwayRules.PoolFailure pf -> ppSexp ".PoolFailure" [ppPOOL proof pf] -- (PredicateFailure (EraRule "POOL" era))
+  ConwayRules.GovCertFailure pf -> case proof of
+    Conway _ -> ppSexp "GovCertFailure" [ppConwayGovCertPredFailure pf] -- (PredicateFailure (EraRule "GOVCERT" era))
+    _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOVCERT\" era)). This Era is " ++ show proof)
+
+instance Reflect era => PrettyA (ConwayRules.ConwayCertPredFailure era) where
+  prettyA = ppConwayCertPredFailure reify
+
+ppConwayGovCertPredFailure :: ConwayGovCertPredFailure era -> PDoc
+ppConwayGovCertPredFailure z = case z of
+  ConwayDRepAlreadyRegistered x -> ppSexp "ConwayDRepAlreadyRegistered" [pcCredential x]
+  ConwayDRepNotRegistered x -> ppSexp "ConwayDRepNotRegistered" [pcCredential x]
+  ConwayDRepIncorrectDeposit c1 c2 -> ppSexp " ConwayDRepIncorrectDeposit" [pcCoin c1, pcCoin c2]
+  ConwayCommitteeHasPreviouslyResigned x -> ppSexp "ConwayCommitteeHasPreviouslyResigned" [pcCredential x]
+
+instance PrettyA (ConwayGovCertPredFailure era) where
+  prettyA = ppConwayGovCertPredFailure
+
+ppConwayCertsPredFailure :: Proof era -> ConwayCertsPredFailure era -> PDoc
+ppConwayCertsPredFailure proof x = case x of
+  ConwayRules.DelegateeNotRegisteredDELEG kh -> ppSexp "DelegateeNotRegisteredDELEG" [pcKeyHash kh]
+  WithdrawalsNotInRewardsCERTS m -> ppSexp "WithdrawalsNotInRewardsCERTS" [ppMap pcRewardAcnt pcCoin m]
+  CertFailure pf -> case proof of
+    Conway _ -> ppSexp " CertFailure" [ppConwayCertPredFailure proof pf] -- !(PredicateFailure (EraRule "CERT" era))
+    _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"CERT\" era)). This Era is " ++ show proof)
+
+instance Reflect era => PrettyA (ConwayCertsPredFailure era) where
+  prettyA = ppConwayCertsPredFailure reify
+
+ppConwayGovPredFailure :: ConwayGovPredFailure era -> PDoc
+ppConwayGovPredFailure x = case x of
+  GovActionsDoNotExist c -> ppSexp "GovActionsDoNotExist" [ppSet pcGovActionId c]
+  MalformedProposal ga -> ppSexp " MalformedProposal" [pcGovAction ga] -- (GovAction era)
+  ProposalProcedureNetworkIdMismatch racnt nw ->
+    ppSexp "ProposalProcedureNetworkIdMismatch" [pcRewardAcnt racnt, pcNetwork nw]
+  TreasuryWithdrawalsNetworkIdMismatch sr nw ->
+    ppSexp "TreasuryWithdrawalsNetworkIdMismatch" [ppSet pcRewardAcnt sr, pcNetwork nw]
+  ProposalDepositIncorrect c1 c2 -> ppSexp "ProposalDepositIncorrect" [pcCoin c1, pcCoin c2]
+  DisallowedVoters m -> ppSexp "DisallowedVoters" [ppMap pcGovActionId pcVoter m]
+  ConflictingCommitteeUpdate s ->
+    ppSexp "ConflictingCommitteeUpdate" [ppSet pcCredential s]
+  ExpirationEpochTooSmall m -> ppSexp " ExpirationEpochTooSmall" [ppMap pcCredential ppEpochNo m]
+  InvalidPrevGovActionId p -> ppSexp "InvalidPrevGovActionId" [pcProposalProcedure p]
+  VotingOnExpiredGovAction m ->
+    ppSexp "VotingOnExpiredGovAction" [ppMap pcGovActionId pcVoter m]
+  ProposalCantFollow s1 p1 p2 ->
+    ppSexp "ProposalCantFollow" [ppStrictMaybe pcPrevGovActionId s1, ppProtVer p1, ppProtVer p2]
+
+instance PrettyA (ConwayGovPredFailure era) where
+  prettyA = ppConwayGovPredFailure
+
+-- Note there is both: ppShelleyLedgerPredFailure and ppShelleyLedgersPredFailure (Ledger vs Ledgers)
+ppShelleyLedgerPredFailure :: Reflect era => Proof era -> ShelleyLedgerPredFailure era -> PDoc
+ppShelleyLedgerPredFailure proof (UtxowFailure x) = ppUTXOW proof x
+ppShelleyLedgerPredFailure proof (DelegsFailure x) = ppDELEGS proof x
+
+instance Reflect era => PrettyA (ShelleyLedgerPredFailure era) where
+  prettyA = ppShelleyLedgerPredFailure reify
+
+ppBabbageUtxowPredFailure :: Reflect era => Proof era -> BabbageUtxowPredFailure era -> PDoc
+ppBabbageUtxowPredFailure proof failure = case failure of
+  AlonzoInBabbageUtxowPredFailure x -> ppSexp "AlonzoInBabbageUtxowPredFailure" [ppAlonzoUtxowPredFailure x]
+  Cardano.Ledger.Babbage.Rules.UtxoFailure x -> ppSexp "UtxoFailure" [ppUTXO proof x]
+  MalformedScriptWitnesses x -> ppSexp "MalformedScriptWitnesses" [ppSet pcScriptHash x]
+  MalformedReferenceScripts x -> ppSexp "MalformedReferenceScripts" [ppSet pcScriptHash x] -- !(Set (ScriptHash (EraCrypto era)))
+
+instance Reflect era => PrettyA (BabbageUtxowPredFailure era) where
+  prettyA = ppBabbageUtxowPredFailure reify
+
+-- ================
+
+ppBbodyPredicateFailure :: forall era. Reflect era => ShelleyBbodyPredFailure era -> PDoc
+ppBbodyPredicateFailure (WrongBlockBodySizeBBODY x y) =
+  ppRecord
+    "WrongBlockBodySizeBBODY"
+    [ ("actual computed BBody size", ppInt x)
+    , ("claimed BBody Size in Header", ppInt y)
+    ]
+ppBbodyPredicateFailure (InvalidBodyHashBBODY h1 h2) =
+  ppRecord
+    "(InvalidBodyHashBBODY"
+    [ ("actual hash", ppHash h1)
+    , ("claimed hash", ppHash h2)
+    ]
+ppBbodyPredicateFailure (LedgersFailure x) =
+  ppSexp "LedgersFailure" [ppLEDGERS @era reify x]
+
+instance Reflect era => PrettyA (ShelleyBbodyPredFailure era) where
+  prettyA = ppBbodyPredicateFailure
+
+-- ================
+
+ppAlonzoBbodyPredFail :: Reflect era => AlonzoBbodyPredFailure era -> PDoc
+ppAlonzoBbodyPredFail (ShelleyInAlonzoBbodyPredFailure x) =
+  ppSexp "ShelleyInAlonzoPredFail" [ppBbodyPredicateFailure x]
+ppAlonzoBbodyPredFail (TooManyExUnits e1 e2) =
+  ppRecord
+    "TooManyExUnits"
+    [ ("Computed Sum of ExUnits for all plutus scripts", pcExUnits e1)
+    , ("Maximum allowed by protocal parameters", pcExUnits e2)
+    ]
+
+instance Reflect era => PrettyA (AlonzoBbodyPredFailure era) where
+  prettyA = ppAlonzoBbodyPredFail
+
+-- ===============
+ppTickPredicateFailure ::
+  forall era.
+  Reflect era =>
+  ShelleyTickPredFailure era ->
+  PDoc
+ppTickPredicateFailure (NewEpochFailure x) = ppNEWEPOCH @era reify x
+ppTickPredicateFailure (RupdFailure _) =
+  ppString "RupdPredicateFailure has no constructors"
+
+instance Reflect era => PrettyA (ShelleyTickPredFailure era) where
+  prettyA = ppTickPredicateFailure
+
+ppShelleyNewEpochPredicateFailure ::
+  forall era. Reflect era => ShelleyNewEpochPredFailure era -> PDoc
+ppShelleyNewEpochPredicateFailure (EpochFailure x) = ppEPOCH @era reify x
+ppShelleyNewEpochPredicateFailure (CorruptRewardUpdate x) =
+  ppSexp "CorruptRewardUpdate" [ppRewardUpdate x]
+ppShelleyNewEpochPredicateFailure (MirFailure _) =
+  error "In the Conway era, there is no (EraRule MIR) type instance."
+
+instance Reflect era => PrettyA (ShelleyNewEpochPredFailure era) where
+  prettyA = ppShelleyNewEpochPredicateFailure
+
+ppConwayNewEpochPredFailure :: ConwayNewEpochPredFailure era -> PDoc
+ppConwayNewEpochPredFailure (ConwayRules.CorruptRewardUpdate x) =
+  ppSexp "CorruptRewardUpdate" [ppRewardUpdate x]
+
+instance PrettyA (ConwayNewEpochPredFailure era) where
+  prettyA = ppConwayNewEpochPredFailure
+
+-- ===============
+
+ppShelleyEpochPredFailure :: forall era. Reflect era => ShelleyEpochPredFailure era -> PDoc
+ppShelleyEpochPredFailure (PoolReapFailure _) =
+  ppString "PoolreapPredicateFailure has no constructors"
+ppShelleyEpochPredFailure (SnapFailure _) =
+  ppString "SnapPredicateFailure has no constructors"
+ppShelleyEpochPredFailure (UpecFailure x) = ppUPEC @era reify x
+
+instance Reflect era => PrettyA (ShelleyEpochPredFailure era) where
+  prettyA = ppShelleyEpochPredFailure
+
+-- This type has no constructors, so the show instance is fine.
+instance PrettyA (ShelleyPoolreapPredFailure era) where
+  prettyA = viaShow
+
+-- This type has no constructors, so the show instance is fine.
+instance PrettyA (ShelleySnapPredFailure era) where
+  prettyA = viaShow
+
+-- ===============
+
+ppUpecPredicateFailure :: ShelleyUpecPredFailure era -> PDoc
+ppUpecPredicateFailure (NewPpFailure x) = ppNewppPredicateFailure x
+
+instance PrettyA (ShelleyUpecPredFailure era) where
+  prettyA = ppUpecPredicateFailure
+
+-- ===============
+ppNewppPredicateFailure :: ShelleyNewppPredFailure era -> PDoc
+ppNewppPredicateFailure (UnexpectedDepositPot c1 c2) =
+  ppRecord
+    "UnexpectedDepositPot"
+    [ ("The total outstanding deposits", pcCoin c1)
+    , ("The deposit pot", pcCoin c2)
+    ]
+
+instance PrettyA (ShelleyNewppPredFailure era) where prettyA = ppNewppPredicateFailure
 
 -- =========================================
 -- Predicate Failure for Alonzo UTXOW
 
-ppUtxowPredicateFail ::
-  ( PrettyA (PredicateFailure (EraRule "UTXO" era))
-  , PrettyCore era
-  , PrettyA (TxCert era)
-  ) =>
-  AlonzoUtxowPredFailure era ->
-  PDoc
-ppUtxowPredicateFail (ShelleyInAlonzoUtxowPredFailure x) = prettyA x
-ppUtxowPredicateFail (MissingRedeemers xs) =
-  ppSexp "MissingRedeemers" [ppList (ppPair ppScriptPurpose ppScriptHash) xs]
-ppUtxowPredicateFail (MissingRequiredDatums s1 s2) =
+ppAlonzoUtxowPredFailure :: forall era. Reflect era => AlonzoUtxowPredFailure era -> PDoc
+ppAlonzoUtxowPredFailure (ShelleyInAlonzoUtxowPredFailure x) = ppShelleyUtxowPredFailure x
+ppAlonzoUtxowPredFailure (MissingRedeemers xs) =
+  ppSexp "MissingRedeemers" [ppList (ppPair (pcScriptPurpose reify) pcScriptHash) xs]
+ppAlonzoUtxowPredFailure (MissingRequiredDatums s1 s2) =
   ppRecord
     "MissingRequiredDatums"
     [ ("missing data hashes", ppSet ppSafeHash s1)
     , ("received data hashes", ppSet ppSafeHash s2)
     ]
-ppUtxowPredicateFail (NotAllowedSupplementalDatums s1 s2) =
+ppAlonzoUtxowPredFailure (NotAllowedSupplementalDatums s1 s2) =
   ppRecord
     "NotAllowedSupplementalDatums"
     [ ("unallowed data hashes", ppSet ppSafeHash s1)
     , ("acceptable data hashes", ppSet ppSafeHash s2)
     ]
-ppUtxowPredicateFail (PPViewHashesDontMatch h1 h2) =
+ppAlonzoUtxowPredFailure (PPViewHashesDontMatch h1 h2) =
   ppRecord
     "PPViewHashesDontMatch"
     [ ("PPHash in the TxBody", ppStrictMaybe ppSafeHash h1)
     , ("PPHash Computed from the current Protocol Parameters", ppStrictMaybe ppSafeHash h2)
     ]
-ppUtxowPredicateFail (MissingRequiredSigners x) =
-  ppSexp "MissingRequiredSigners" [ppSet ppKeyHash x]
-ppUtxowPredicateFail (UnspendableUTxONoDatumHash x) =
-  ppSexp "UnspendableUTxONoDatumHash" [ppSet ppTxIn x]
-ppUtxowPredicateFail (ExtraRedeemers x) =
-  ppSexp "ExtraRedeemers" [ppList prettyA x]
+ppAlonzoUtxowPredFailure (MissingRequiredSigners x) =
+  ppSexp "MissingRequiredSigners" [ppSet pcKeyHash x]
+ppAlonzoUtxowPredFailure (UnspendableUTxONoDatumHash x) =
+  ppSexp "UnspendableUTxONoDatumHash" [ppSet pcTxIn x]
+ppAlonzoUtxowPredFailure (ExtraRedeemers x) =
+  ppSexp "ExtraRedeemers" [ppList ppRdmrPtr x]
 
-instance
-  ( PrettyA (PredicateFailure (EraRule "UTXO" era))
-  , PrettyCore era
-  , PrettyA (TxCert era)
-  ) =>
-  PrettyA (AlonzoUtxowPredFailure era)
-  where
-  prettyA = ppUtxowPredicateFail
+instance Reflect era => PrettyA (AlonzoUtxowPredFailure era) where
+  prettyA = ppAlonzoUtxowPredFailure
 
 -- ====================================================
 -- Predicate Failure for Shelley UTXOW
 
-ppUtxowPredicateFailure ::
-  ( PrettyA (PredicateFailure (EraRule "UTXO" era))
-  , PrettyCore era
-  ) =>
-  ShelleyUtxowPredFailure era ->
-  PDoc
-ppUtxowPredicateFailure (InvalidWitnessesUTXOW vkeyws) =
+ppShelleyUtxowPredFailure :: forall era. Reflect era => ShelleyUtxowPredFailure era -> PDoc
+ppShelleyUtxowPredFailure (InvalidWitnessesUTXOW vkeyws) =
   ppSexp "InvalidWitnessesUTXOW" [ppList ppVKey vkeyws]
-ppUtxowPredicateFailure (MissingVKeyWitnessesUTXOW whs) =
+ppShelleyUtxowPredFailure (MissingVKeyWitnessesUTXOW whs) =
   ppSexp "MissingVKeyWitnessesUTXOW" [ppWitHashes whs]
-ppUtxowPredicateFailure (MissingScriptWitnessesUTXOW m) =
-  ppSexp "MissingScriptWitnessesUTXOW" [ppSet ppScriptHash m]
-ppUtxowPredicateFailure (ScriptWitnessNotValidatingUTXOW m) =
-  ppSexp "ScriptWitnessNotValidatingUTXOW" [ppSet ppScriptHash m]
-ppUtxowPredicateFailure (UtxoFailure m) = ppSexp "UtxoFailure" [prettyA m]
-ppUtxowPredicateFailure (MIRInsufficientGenesisSigsUTXOW m) =
-  ppSexp "MIRInsufficientGenesisSigsUTXOW" [ppSet ppKeyHash m]
-ppUtxowPredicateFailure (MissingTxBodyMetadataHash m) =
+ppShelleyUtxowPredFailure (MissingScriptWitnessesUTXOW m) =
+  ppSexp "MissingScriptWitnessesUTXOW" [ppSet pcScriptHash m]
+ppShelleyUtxowPredFailure (ScriptWitnessNotValidatingUTXOW m) =
+  ppSexp "ScriptWitnessNotValidatingUTXOW" [ppSet pcScriptHash m]
+ppShelleyUtxowPredFailure (Shelley.UtxoFailure m) = ppSexp "UtxoFailure" [ppUTXO (reify @era) m]
+ppShelleyUtxowPredFailure (MIRInsufficientGenesisSigsUTXOW m) =
+  ppSexp "MIRInsufficientGenesisSigsUTXOW" [ppSet pcKeyHash m]
+ppShelleyUtxowPredFailure (MissingTxBodyMetadataHash m) =
   ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
-ppUtxowPredicateFailure (MissingTxMetadata m) =
+ppShelleyUtxowPredFailure (MissingTxMetadata m) =
   ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
-ppUtxowPredicateFailure (ConflictingMetadataHash h1 h2) =
+ppShelleyUtxowPredFailure (ConflictingMetadataHash h1 h2) =
   ppRecord
     "ConflictingMetadataHash"
     [("Hash in the body", ppAuxiliaryDataHash h1), ("Hash of full metadata", ppAuxiliaryDataHash h2)]
-ppUtxowPredicateFailure InvalidMetadata =
+ppShelleyUtxowPredFailure InvalidMetadata =
   ppSexp "InvalidMetadata" []
-ppUtxowPredicateFailure (ExtraneousScriptWitnessesUTXOW m) =
-  ppSexp "ExtraneousScriptWitnessesUTXOW" [ppSet ppScriptHash m]
+ppShelleyUtxowPredFailure (ExtraneousScriptWitnessesUTXOW m) =
+  ppSexp "ExtraneousScriptWitnessesUTXOW" [ppSet pcScriptHash m]
 
-instance
-  ( PrettyA (PredicateFailure (EraRule "UTXO" era))
-  , PrettyCore era
-  ) =>
-  PrettyA (ShelleyUtxowPredFailure era)
-  where
-  prettyA = ppUtxowPredicateFailure
+instance Reflect era => PrettyA (ShelleyUtxowPredFailure era) where
+  prettyA = ppShelleyUtxowPredFailure
 
 -- ========================================================
 -- Predicate Failure for Alonzo UTXO
 
-ppUtxoPredicateFailure ::
-  forall era.
-  ( PrettyCore era
-  , PrettyA (PredicateFailure (EraRule "UTXOS" era))
-  , PrettyA (TxOut era) -- From ppUTxO FIXME
-  ) =>
-  AlonzoUtxoPredFailure era ->
-  PDoc
-ppUtxoPredicateFailure (Alonzo.BadInputsUTxO x) =
-  ppSexp "BadInputsUTxO" [ppSet ppTxIn x]
-ppUtxoPredicateFailure (Alonzo.OutsideValidityIntervalUTxO vi slot) =
-  ppRecord "OutsideValidityIntervalUTxO" [("validity interval", ppValidityInterval vi), ("slot", ppSlotNo slot)]
-ppUtxoPredicateFailure (Alonzo.MaxTxSizeUTxO actual maxs) =
-  ppRecord
-    "MaxTxSizeUTxO"
-    [ ("Actual", ppInteger actual)
-    , ("max transaction size", ppInteger maxs)
-    ]
-ppUtxoPredicateFailure Alonzo.InputSetEmptyUTxO =
-  ppSexp "InputSetEmptyUTxO" []
-ppUtxoPredicateFailure (Alonzo.FeeTooSmallUTxO computed supplied) =
-  ppRecord
-    "FeeTooSmallUTxO"
-    [ ("min fee for thistransaction", ppCoin computed)
-    , ("fee supplied by transaction", ppCoin supplied)
-    ]
-ppUtxoPredicateFailure (Alonzo.ValueNotConservedUTxO consumed produced) =
-  ppRecord
-    "ValueNotConservedUTxO"
-    [ ("coin consumed", prettyValue @era consumed)
-    , ("coin produced", prettyValue @era produced)
-    ]
-ppUtxoPredicateFailure (Alonzo.WrongNetwork n add) =
-  ppRecord
-    "WrongNetwork"
-    [ ("expected network id", ppNetwork n)
-    , ("set addresses with wrong network id", ppSet ppAddr add)
-    ]
-ppUtxoPredicateFailure (Alonzo.WrongNetworkWithdrawal n accnt) =
-  ppRecord
-    "WrongNetworkWithdrawal"
-    [ ("expected network id", ppNetwork n)
-    , ("set reward address with wrong network id", ppSet ppRewardAcnt' accnt)
-    ]
-ppUtxoPredicateFailure (Alonzo.OutputTooSmallUTxO xs) =
-  ppSexp "OutputTooSmallUTxO" [ppList prettyTxOut xs]
-ppUtxoPredicateFailure (UtxosFailure subpred) = prettyA subpred
--- ppSexp "UtxosFailure" [prettyA subpred]
-ppUtxoPredicateFailure (Alonzo.OutputBootAddrAttrsTooBig x) =
-  ppSexp "OutputBootAddrAttrsTooBig" [ppList prettyTxOut x]
-ppUtxoPredicateFailure Alonzo.TriesToForgeADA =
-  ppSexp "TriesToForgeADA" []
-ppUtxoPredicateFailure (Alonzo.OutputTooBigUTxO xs) =
-  ppSexp
-    "OutputTooBigUTxO"
-    [ ppList
-        ( \(a, b, c) ->
-            ppRecord
-              ""
-              [("actual size", ppInteger a), ("PParam max value", ppInteger b), ("TxOut", prettyTxOut c)]
-        )
-        xs
-    ]
-ppUtxoPredicateFailure (InsufficientCollateral x y) =
-  ppRecord
-    "InsufficientCollateral"
-    [ ("balance computed", ppCoin x)
-    , ("the required collateral for the given fee", ppCoin y)
-    ]
-ppUtxoPredicateFailure (ScriptsNotPaidUTxO x) =
-  ppSexp "ScriptsNotPaidUTxO" [ppUTxO x]
-ppUtxoPredicateFailure (ExUnitsTooBigUTxO x y) =
-  ppRecord
-    "ExUnitsTooBigUTxO"
-    [ ("Max EXUnits from the protocol parameters", ppExUnits x)
-    , ("EXUnits supplied", ppExUnits y)
-    ]
-ppUtxoPredicateFailure (CollateralContainsNonADA x) =
-  ppSexp "CollateralContainsNonADA" [prettyValue @era x]
-ppUtxoPredicateFailure (WrongNetworkInTxBody x y) =
-  ppRecord
-    "WrongNetworkInTxBody"
-    [ ("Actual Network ID", ppNetwork x)
-    , ("Network ID in transaction body", ppNetwork y)
-    ]
-ppUtxoPredicateFailure (OutsideForecast x) =
-  ppRecord "OutsideForecast" [("slot number outside consensus forecast range", ppSlotNo x)]
-ppUtxoPredicateFailure (TooManyCollateralInputs x y) =
-  ppRecord
-    "TooManyCollateralInputs"
-    [ ("Max allowed collateral inputs", ppNatural x)
-    , ("Number of collateral inputs", ppNatural y)
-    ]
-ppUtxoPredicateFailure NoCollateralInputs =
-  ppSexp "NoCollateralInputs" []
-
-instance
-  ( PrettyCore era
-  , PrettyA (PredicateFailure (EraRule "UTXOS" era))
-  , PrettyA (TxOut era) -- From ppUTxO FIXME
-  ) =>
-  PrettyA (AlonzoUtxoPredFailure era)
-  where
-  prettyA = ppUtxoPredicateFailure
-
-instance
-  PrettyA (PredicateFailure (EraRule "DELPL" era)) =>
-  PrettyA (ShelleyDelegsPredFailure era)
-  where
-  prettyA (DelegateeNotRegisteredDELEG x) =
+ppAlonzoUtxoPredFailure :: forall era. Reflect era => AlonzoUtxoPredFailure era -> PDoc
+ppAlonzoUtxoPredFailure x = case x of
+  Alonzo.BadInputsUTxO txins -> ppSexp "BadInputsUTxO" [ppSet pcTxIn txins]
+  Alonzo.OutsideValidityIntervalUTxO vi slot ->
     ppRecord
-      "DelegateeNotRegisteredDELEG"
-      [("KeyHash", prettyA x)]
-  prettyA (WithdrawalsNotInRewardsDELEGS x) =
-    ppRecord
-      "WithdrawalsNotInRewardsDELEGS"
-      [("Missing Withdrawals", prettyA x)]
-  prettyA (DelplFailure x) = prettyA x
-
-instance
-  ( PrettyA (PredicateFailure (EraRule "POOL" era))
-  , PrettyA (PredicateFailure (EraRule "DELEG" era))
-  ) =>
-  PrettyA (ShelleyDelplPredFailure era)
-  where
-  prettyA (PoolFailure x) = prettyA x
-  prettyA (DelegFailure x) = prettyA x
-
-instance PrettyA (ShelleyPoolPredFailure era) where
-  prettyA (StakePoolNotRegisteredOnKeyPOOL kh) =
-    ppRecord
-      "StakePoolNotRegisteredOnKeyPOOL"
-      [ ("KeyHash", prettyA kh)
+      "OutsideValidityIntervalUTxO"
+      [ ("provided interval", ppValidityInterval vi)
+      , ("current slot", pcSlotNo slot)
       ]
-  prettyA
-    ( StakePoolRetirementWrongEpochPOOL
-        curEpoch
-        poolRetEpoch
-        firstTooFarEpoch
-      ) =
-      ppRecord
-        "StakePoolRetirementWrongEpochPOOL"
-        [ ("Current Epoch", prettyA curEpoch)
-        , ("Pool Retirement Epoch", prettyA poolRetEpoch)
-        , ("First Epoch Too Far", prettyA firstTooFarEpoch)
-        ]
-  prettyA
-    ( StakePoolCostTooLowPOOL
-        prcStakePoolCost
-        ppStakePoolCost
-      ) =
-      ppRecord
-        "StakePoolCostTooLowPOOL"
-        [ ("PRC Stake Pool Cost", prettyA prcStakePoolCost)
-        , ("PP Stake Pool Cost", prettyA ppStakePoolCost)
-        ]
-  prettyA
-    ( WrongNetworkPOOL
-        nwId
-        regCertNwId
-        stakePoolId
-      ) =
-      ppRecord
-        "WrongNetworkPOOL"
-        [ ("Network ID", prettyA nwId)
-        , ("Registration Certificate Network ID", prettyA regCertNwId)
-        , ("Stake Pool ID", prettyA stakePoolId)
-        ]
-  prettyA
-    ( PoolMedataHashTooBig
-        stakePoolId
-        metadataHashSize
-      ) =
-      ppRecord
-        "PoolMedataHashTooBig"
-        [ ("Stake Pool ID", prettyA stakePoolId)
-        , ("Metadata Hash Size", prettyA metadataHashSize)
-        ]
+  Alonzo.MaxTxSizeUTxO actual maxs ->
+    ppRecord "MaxTxSizeUTxO" [("Actual", ppInteger actual), ("max transaction size", ppInteger maxs)]
+  Alonzo.InputSetEmptyUTxO -> ppString "InputSetEmptyUTxO"
+  Alonzo.FeeTooSmallUTxO computed supplied ->
+    ppRecord
+      "FeeTooSmallUTxO"
+      [ ("min fee for this transaction", pcCoin computed)
+      , ("fee supplied by this transaction", pcCoin supplied)
+      ]
+  Alonzo.ValueNotConservedUTxO consumed produced ->
+    ppRecord
+      "ValueNotConservedUTxO"
+      [("coin consumed", pcVal @era reify consumed), ("coin produced", pcVal @era reify produced)]
+  Alonzo.WrongNetwork n add ->
+    ppRecord
+      "WrongNetwork"
+      [ ("expected network id", ppNetwork n)
+      , ("set of addresses with wrong network id", ppSet pcAddr add)
+      ]
+  Alonzo.WrongNetworkWithdrawal n accnt ->
+    ppRecord
+      "WrongNetworkWithdrawal"
+      [("expected network id", ppNetwork n), ("set reward address with wrong network id", ppSet pcRewardAcnt accnt)]
+  Alonzo.OutputTooSmallUTxO xs ->
+    ppRecord
+      "OutputTooSmallUTxO"
+      [("list of supplied transaction outputs that are too small", ppList (pcTxOut reify) xs)]
+  Alonzo.UtxosFailure yy -> ppSexp "UtxosFailure" [ppUTXOS @era reify yy]
+  Alonzo.OutputBootAddrAttrsTooBig xs ->
+    ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList (pcTxOut reify) xs)]
+  Alonzo.TriesToForgeADA -> ppString "TriesToForgeADA"
+  Alonzo.OutputTooBigUTxO xs ->
+    ppSexp
+      "OutputTooBigUTxO"
+      [ ppList
+          ( \(a, b, c) ->
+              ppRecord'
+                ""
+                [("actual size", ppInteger a), ("PParam max value", ppInteger b), ("TxOut", pcTxOut reify c)]
+          )
+          xs
+      ]
+  InsufficientCollateral c1 c2 ->
+    ppRecord
+      "InsufficientCollateral"
+      [ ("balance computed", pcCoin c1)
+      , ("the required collateral for the given fee", pcCoin c2)
+      ]
+  ScriptsNotPaidUTxO u -> ppSexp "ScriptsNotPaidUTxO" [pcUTxO reify u]
+  ExUnitsTooBigUTxO e1 e2 ->
+    ppRecord
+      "ExUnitsTooBigUTxO"
+      [ ("Max EXUnits from the protocol parameters", pcExUnits e1)
+      , ("EXUnits supplied", pcExUnits e2)
+      ]
+  CollateralContainsNonADA v -> ppSexp "CollateralContainsNonADA" [pcVal (reify @era) v]
+  WrongNetworkInTxBody n1 n2 ->
+    ppRecord
+      "WrongNetworkInTxBody"
+      [ ("Actual Network ID", ppNetwork n1)
+      , ("Network ID in transaction body", ppNetwork n2)
+      ]
+  OutsideForecast slot -> ppRecord "OutsideForecast" [("slot number outside consensus forecast range", pcSlotNo slot)]
+  TooManyCollateralInputs n1 n2 ->
+    ppRecord
+      "TooManyCollateralInputs"
+      [ ("Max allowed collateral inputs", ppNatural n1)
+      , ("Number of collateral inputs", ppNatural n2)
+      ]
+  NoCollateralInputs -> ppSexp " NoCollateralInputs" []
+
+instance Reflect era => PrettyA (AlonzoUtxoPredFailure era) where
+  prettyA = ppAlonzoUtxoPredFailure
+
+-- =================================
+
+ppShelleyDelegPredFailure :: ShelleyDelegPredFailure era -> PDoc
+ppShelleyDelegPredFailure x = case x of
+  StakeKeyAlreadyRegisteredDELEG cred -> ppSexp "StakeKeyAlreadyRegisteredDELEG" [pcCredential cred]
+  StakeKeyInRewardsDELEG cred -> ppSexp "StakeKeyInRewardsDELEG" [pcCredential cred]
+  Shelley.StakeKeyNotRegisteredDELEG cred -> ppSexp "StakeKeyNotRegisteredDELEG" [pcCredential cred]
+  StakeKeyNonZeroAccountBalanceDELEG mcoin -> ppSexp " StakeKeyNonZeroAccountBalanceDELEG" [ppMaybe pcCoin mcoin]
+  StakeDelegationImpossibleDELEG cred -> ppSexp "StakeDelegationImpossibleDELEG" [pcCredential cred]
+  WrongCertificateTypeDELEG -> ppSexp "WrongCertificateTypeDELEG" []
+  GenesisKeyNotInMappingDELEG kh -> ppSexp "GenesisKeyNotInMappingDELEG" [pcKeyHash kh]
+  DuplicateGenesisDelegateDELEG kh -> ppSexp "DuplicateGenesisDelegateDELEG" [pcKeyHash kh]
+  InsufficientForInstantaneousRewardsDELEG pot c1 c2 ->
+    ppSexp
+      "InsufficientForInstantaneousRewardsDELEG"
+      [ppString (show pot), pcCoin c1, pcCoin c2]
+  MIRCertificateTooLateinEpochDELEG s1 s2 ->
+    ppSexp "MIRCertificateTooLateinEpochDELEG" [pcSlotNo s1, pcSlotNo s2]
+  DuplicateGenesisVRFDELEG hash -> ppSexp "DuplicateGenesisVRFDELEG" [ppHash hash]
+  MIRTransferNotCurrentlyAllowed -> ppString "MIRTransferNotCurrentlyAllowed"
+  MIRNegativesNotCurrentlyAllowed -> ppString " MIRNegativesNotCurrentlyAllowed"
+  InsufficientForTransferDELEG pot c1 c2 ->
+    ppSexp "InsufficientForTransferDELEG" [ppString (show pot), pcCoin c1, pcCoin c2]
+  MIRProducesNegativeUpdate -> ppString "MIRProducesNegativeUpdate"
+  MIRNegativeTransfer pot c1 -> ppSexp " MIRNegativeTransfer" [ppString (show pot), pcCoin c1]
 
 instance PrettyA (ShelleyDelegPredFailure era) where
-  prettyA = ppString . show -- TODO
+  prettyA = ppShelleyDelegPredFailure
+
+ppShelleyDelplPredFailure :: Proof era -> ShelleyDelplPredFailure era -> PDoc
+ppShelleyDelplPredFailure p (PoolFailure x) = ppPOOL p x
+ppShelleyDelplPredFailure p (DelegFailure x) = ppDELEG p x
+
+instance Reflect era => PrettyA (ShelleyDelplPredFailure era) where
+  prettyA = ppShelleyDelplPredFailure reify
+
+ppConwayDelegPredFailure :: ConwayDelegPredFailure era -> PDoc
+ppConwayDelegPredFailure x = case x of
+  IncorrectDepositDELEG c -> ppSexp "IncorrectDepositDELEG" [pcCoin c]
+  StakeKeyRegisteredDELEG cred -> ppSexp "StakeKeyRegisteredDELEG" [pcCredential cred]
+  ConwayRules.StakeKeyNotRegisteredDELEG cred ->
+    ppSexp "StakeKeyNotRegisteredDELEG" [pcCredential cred]
+  StakeKeyHasNonZeroRewardAccountBalanceDELEG c ->
+    ppSexp "StakeKeyHasNonZeroRewardAccountBalanceDELEG" [pcCoin c]
+  DRepAlreadyRegisteredForStakeKeyDELEG cred ->
+    ppSexp "DRepAlreadyRegisteredForStakeKeyDELEG" [pcCredential cred]
+
+instance PrettyA (ConwayDelegPredFailure era) where
+  prettyA = ppConwayDelegPredFailure
+
+ppShelleyPoolPredFailure :: ShelleyPoolPredFailure era -> PDoc
+ppShelleyPoolPredFailure (StakePoolNotRegisteredOnKeyPOOL kh) =
+  ppRecord
+    "StakePoolNotRegisteredOnKeyPOOL"
+    [ ("KeyHash", pcKeyHash kh)
+    ]
+ppShelleyPoolPredFailure
+  ( StakePoolRetirementWrongEpochPOOL
+      curEpoch
+      poolRetEpoch
+      firstTooFarEpoch
+    ) =
+    ppRecord
+      "StakePoolRetirementWrongEpochPOOL"
+      [ ("Current Epoch", ppEpochNo curEpoch)
+      , ("Pool Retirement Epoch", ppEpochNo poolRetEpoch)
+      , ("First Epoch Too Far", ppEpochNo firstTooFarEpoch)
+      ]
+ppShelleyPoolPredFailure
+  ( StakePoolCostTooLowPOOL
+      prcStakePoolCost
+      ppStakePoolCost
+    ) =
+    ppRecord
+      "StakePoolCostTooLowPOOL"
+      [ ("PRC Stake Pool Cost", pcCoin prcStakePoolCost)
+      , ("PP Stake Pool Cost", pcCoin ppStakePoolCost)
+      ]
+ppShelleyPoolPredFailure
+  ( WrongNetworkPOOL
+      nwId
+      regCertNwId
+      stakePoolId
+    ) =
+    ppRecord
+      "WrongNetworkPOOL"
+      [ ("Network ID", ppNetwork nwId)
+      , ("Registration Certificate Network ID", ppNetwork regCertNwId)
+      , ("Stake Pool ID", pcKeyHash stakePoolId)
+      ]
+ppShelleyPoolPredFailure
+  ( PoolMedataHashTooBig
+      stakePoolId
+      metadataHashSize
+    ) =
+    ppRecord
+      "PoolMedataHashTooBig"
+      [ ("Stake Pool ID", pcKeyHash stakePoolId)
+      , ("Metadata Hash Size", ppInt metadataHashSize)
+      ]
+
+instance PrettyA (ShelleyPoolPredFailure era) where
+  prettyA = ppShelleyPoolPredFailure
 
 -- =========================================
 -- Predicate Failure for Alonzo UTXOS
 
 ppUtxosPredicateFailure ::
-  (Show (ContextError era), PrettyA (PPUPPredFailure era), PrettyA (TxCert era)) =>
+  forall era.
+  ( Show (ContextError era)
+  , Reflect era
+  ) =>
   AlonzoUtxosPredFailure era ->
   PDoc
 ppUtxosPredicateFailure (ValidationTagMismatch isvalid tag) =
@@ -618,24 +1733,23 @@ ppUtxosPredicateFailure (ValidationTagMismatch isvalid tag) =
     ]
 ppUtxosPredicateFailure (CollectErrors es) =
   ppRecord' mempty [("When collecting inputs for twophase scripts, these went wrong.", ppList ppCollectError es)]
-ppUtxosPredicateFailure (Alonzo.UpdateFailure p) = prettyA p
+ppUtxosPredicateFailure (Alonzo.UpdateFailure p) = ppPPUPPredFailure @era p
 
 instance
-  ( PrettyA (PPUPPredFailure era)
-  , PrettyA (TxCert era)
+  ( Reflect era
   , Show (ContextError era)
   ) =>
   PrettyA (AlonzoUtxosPredFailure era)
   where
   prettyA = ppUtxosPredicateFailure
 
-ppCollectError :: (Show (ContextError era), PrettyA (TxCert era)) => CollectError era -> PDoc
-ppCollectError (NoRedeemer sp) = ppSexp "NoRedeemer" [ppScriptPurpose sp]
-ppCollectError (NoWitness sh) = ppSexp "NoWitness" [ppScriptHash sh]
+ppCollectError :: (Show (ContextError era), Reflect era) => CollectError era -> PDoc
+ppCollectError (NoRedeemer sp) = ppSexp "NoRedeemer" [pcScriptPurpose reify sp]
+ppCollectError (NoWitness sh) = ppSexp "NoWitness" [pcScriptHash sh]
 ppCollectError (NoCostModel l) = ppSexp "NoCostModel" [ppLanguage l]
 ppCollectError (BadTranslation x) = ppSexp "BadTranslation" [ppString (show x)]
 
-instance (Show (ContextError era), PrettyA (TxCert era)) => PrettyA (CollectError era) where
+instance (Show (ContextError era), Reflect era) => PrettyA (CollectError era) where
   prettyA = ppCollectError
 
 ppTagMismatchDescription :: TagMismatchDescription -> PDoc
@@ -656,65 +1770,54 @@ instance PrettyA FailureDescription where
 -- =======================================
 -- Predicate Failure for Shelley UTxO
 
-ppUtxoPFShelley ::
-  forall era.
-  ( PrettyCore era
-  , PrettyA (PPUPPredFailure era)
-  ) =>
-  ShelleyUtxoPredFailure era ->
-  PDoc
-ppUtxoPFShelley (Shelley.BadInputsUTxO x) =
-  ppSexp "BadInputsUTxO" [ppSet ppTxIn x]
-ppUtxoPFShelley (Shelley.ExpiredUTxO ttl slot) =
-  ppRecord "ExpiredUTxO" [("transaction time to live", ppSlotNo ttl), ("current slot", ppSlotNo slot)]
-ppUtxoPFShelley (Shelley.MaxTxSizeUTxO actual maxs) =
+ppShelleyUtxoPredFailure :: forall era. Reflect era => ShelleyUtxoPredFailure era -> PDoc
+ppShelleyUtxoPredFailure (Shelley.BadInputsUTxO x) =
+  ppSexp "BadInputsUTxO" [ppSet pcTxIn x]
+ppShelleyUtxoPredFailure (Shelley.ExpiredUTxO ttl slot) =
+  ppRecord "ExpiredUTxO" [("transaction time to live", pcSlotNo ttl), ("current slot", pcSlotNo slot)]
+ppShelleyUtxoPredFailure (Shelley.MaxTxSizeUTxO actual maxs) =
   ppRecord
     "MaxTxSizeUTxO"
     [ ("Actual", ppInteger actual)
     , ("max transaction size", ppInteger maxs)
     ]
-ppUtxoPFShelley (Shelley.InputSetEmptyUTxO) =
+ppShelleyUtxoPredFailure (Shelley.InputSetEmptyUTxO) =
   ppSexp "InputSetEmptyUTxO" []
-ppUtxoPFShelley (Shelley.FeeTooSmallUTxO computed supplied) =
+ppShelleyUtxoPredFailure (Shelley.FeeTooSmallUTxO computed supplied) =
   ppRecord
     "FeeTooSmallUTxO"
-    [ ("min fee for this transaction", ppCoin computed)
-    , ("fee supplied by this transaction", ppCoin supplied)
+    [ ("min fee for this transaction", pcCoin computed)
+    , ("fee supplied by this transaction", pcCoin supplied)
     ]
-ppUtxoPFShelley (Shelley.ValueNotConservedUTxO consumed produced) =
+ppShelleyUtxoPredFailure (Shelley.ValueNotConservedUTxO consumed produced) =
   ppRecord
     "ValueNotConservedUTxO"
-    [ ("coin consumed", prettyValue @era consumed)
-    , ("coin produced", prettyValue @era produced)
+    [ ("coin consumed", pcVal @era reify consumed)
+    , ("coin produced", pcVal @era reify produced)
     ]
-ppUtxoPFShelley (Shelley.WrongNetwork n add) =
+ppShelleyUtxoPredFailure (Shelley.WrongNetwork n add) =
   ppRecord
     "WrongNetwork"
     [ ("expected network id", ppNetwork n)
-    , ("set of addresses with wrong network id", ppSet ppAddr add)
+    , ("set of addresses with wrong network id", ppSet pcAddr add)
     ]
-ppUtxoPFShelley (Shelley.WrongNetworkWithdrawal n accnt) =
+ppShelleyUtxoPredFailure (Shelley.WrongNetworkWithdrawal n accnt) =
   ppRecord
     "WrongNetworkWithdrawal"
     [ ("expected network id", ppNetwork n)
-    , ("set of reward address with wrong network id", ppSet ppRewardAcnt' accnt)
+    , ("set of reward address with wrong network id", ppSet pcRewardAcnt accnt)
     ]
-ppUtxoPFShelley (Shelley.OutputTooSmallUTxO xs) =
+ppShelleyUtxoPredFailure (Shelley.OutputTooSmallUTxO xs) =
   ppRecord
     "OutputTooSmallUTxO"
-    [("list of supplied transaction outputs that are too small", ppList prettyTxOut xs)]
-ppUtxoPFShelley (Shelley.UpdateFailure x) =
-  ppSexp "UpdateFailure" [prettyA x]
-ppUtxoPFShelley (Shelley.OutputBootAddrAttrsTooBig xs) =
-  ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList prettyTxOut xs)]
+    [("list of supplied transaction outputs that are too small", ppList (pcTxOut reify) xs)]
+ppShelleyUtxoPredFailure (Shelley.UpdateFailure x) =
+  ppSexp "UpdateFailure" [ppPPUPPredFailure @era x]
+ppShelleyUtxoPredFailure (Shelley.OutputBootAddrAttrsTooBig xs) =
+  ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList (pcTxOut reify) xs)]
 
-instance
-  ( PrettyCore era
-  , PrettyA (PPUPPredFailure era)
-  ) =>
-  PrettyA (ShelleyUtxoPredFailure era)
-  where
-  prettyA = ppUtxoPFShelley
+instance Reflect era => PrettyA (ShelleyUtxoPredFailure era) where
+  prettyA = ppShelleyUtxoPredFailure
 
 -- =======================================
 -- Predicate Failure for Shelley PPUP
@@ -723,8 +1826,8 @@ ppPpupPredicateFailure :: ShelleyPpupPredFailure era -> PDoc
 ppPpupPredicateFailure (NonGenesisUpdatePPUP x y) =
   ppRecord
     "NonGenesisUpdatePPUP"
-    [ ("KeyHashes which are voting", ppSet ppKeyHash x)
-    , ("KeyHashes which should be voting", ppSet ppKeyHash y)
+    [ ("KeyHashes which are voting", ppSet pcKeyHash x)
+    , ("KeyHashes which should be voting", ppSet pcKeyHash y)
     ]
 ppPpupPredicateFailure (PPUpdateWrongEpoch x y z) =
   ppRecord
@@ -742,339 +1845,86 @@ instance PrettyA (ShelleyPpupPredFailure era) where
 -- =====================================================
 -- Predicate failure for Mary UTXO
 
-ppUtxoPFMary ::
+ppPPUPPredFailure :: PPUPPredFailure era -> PDoc
+ppPPUPPredFailure _ = ppString "PPUPPredFailure" -- TODO FIXME
+
+ppAllegraUtxoPredFailure ::
   forall era.
-  ( PrettyCore era
-  , PrettyA (PPUPPredFailure era)
-  ) =>
+  Reflect era =>
   AllegraUtxoPredFailure era ->
   PDoc
-ppUtxoPFMary (Allegra.BadInputsUTxO txins) =
-  ppSexp "BadInputsUTxO" [ppSet ppTxIn txins]
-ppUtxoPFMary (Allegra.OutsideValidityIntervalUTxO vi slot) =
+ppAllegraUtxoPredFailure (Allegra.BadInputsUTxO txins) =
+  ppSexp "BadInputsUTxO" [ppSet pcTxIn txins]
+ppAllegraUtxoPredFailure (Allegra.OutsideValidityIntervalUTxO vi slot) =
   ppRecord
     "OutsideValidityIntervalUTxO"
     [ ("provided interval", ppValidityInterval vi)
-    , ("current slot", ppSlotNo slot)
+    , ("current slot", pcSlotNo slot)
     ]
-ppUtxoPFMary (Allegra.MaxTxSizeUTxO actual maxs) =
+ppAllegraUtxoPredFailure (Allegra.MaxTxSizeUTxO actual maxs) =
   ppRecord
     "MaxTxSizeUTxO"
     [ ("Actual", ppInteger actual)
     , ("max transaction size", ppInteger maxs)
     ]
-ppUtxoPFMary (Allegra.InputSetEmptyUTxO) = ppSexp "InputSetEmptyUTxO" []
-ppUtxoPFMary (Allegra.FeeTooSmallUTxO computed supplied) =
+ppAllegraUtxoPredFailure (Allegra.InputSetEmptyUTxO) = ppSexp "InputSetEmptyUTxO" []
+ppAllegraUtxoPredFailure (Allegra.FeeTooSmallUTxO computed supplied) =
   ppRecord
     "FeeTooSmallUTxO"
-    [ ("min fee for this transaction", ppCoin computed)
-    , ("fee supplied by this transaction", ppCoin supplied)
+    [ ("min fee for this transaction", pcCoin computed)
+    , ("fee supplied by this transaction", pcCoin supplied)
     ]
-ppUtxoPFMary (Allegra.ValueNotConservedUTxO consumed produced) =
+ppAllegraUtxoPredFailure (Allegra.ValueNotConservedUTxO consumed produced) =
   ppRecord
     "ValueNotConservedUTxO"
-    [ ("coin consumed", prettyValue @era consumed)
-    , ("coin produced", prettyValue @era produced)
+    [ ("coin consumed", pcVal @era reify consumed)
+    , ("coin produced", pcVal @era reify produced)
     ]
-ppUtxoPFMary (Allegra.WrongNetwork n add) =
+ppAllegraUtxoPredFailure (Allegra.WrongNetwork n add) =
   ppRecord
     "WrongNetwork"
     [ ("expected network id", ppNetwork n)
-    , ("set of addresses with wrong network id", ppSet ppAddr add)
+    , ("set of addresses with wrong network id", ppSet pcAddr add)
     ]
-ppUtxoPFMary (Allegra.WrongNetworkWithdrawal n accnt) =
+ppAllegraUtxoPredFailure (Allegra.WrongNetworkWithdrawal n accnt) =
   ppRecord
     "WrongNetworkWithdrawal"
     [ ("expected network id", ppNetwork n)
-    , ("set reward address with wrong network id", ppSet ppRewardAcnt' accnt)
+    , ("set reward address with wrong network id", ppSet pcRewardAcnt accnt)
     ]
-ppUtxoPFMary (Allegra.OutputTooSmallUTxO xs) =
+ppAllegraUtxoPredFailure (Allegra.OutputTooSmallUTxO xs) =
   ppRecord
     "OutputTooSmallUTxO"
-    [("list of supplied transaction outputs that are too small", ppList prettyTxOut xs)]
-ppUtxoPFMary (Allegra.UpdateFailure x) =
-  ppSexp "UpdateFailure" [prettyA x]
-ppUtxoPFMary (Allegra.OutputBootAddrAttrsTooBig xs) =
-  ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList prettyTxOut xs)]
-ppUtxoPFMary (Allegra.TriesToForgeADA) = ppSexp "TriesToForgeADA" []
-ppUtxoPFMary (Allegra.OutputTooBigUTxO outs) =
-  ppRecord "OutputTooBigUTxO" [("list of TxOuts which are too big", ppList prettyTxOut outs)]
+    [("list of supplied transaction outputs that are too small", ppList (pcTxOut reify) xs)]
+ppAllegraUtxoPredFailure (Allegra.UpdateFailure x) =
+  ppSexp "UpdateFailure" [ppPPUPPredFailure @era x]
+ppAllegraUtxoPredFailure (Allegra.OutputBootAddrAttrsTooBig xs) =
+  ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList (pcTxOut reify) xs)]
+ppAllegraUtxoPredFailure (Allegra.TriesToForgeADA) = ppSexp "TriesToForgeADA" []
+ppAllegraUtxoPredFailure (Allegra.OutputTooBigUTxO outs) =
+  ppRecord "OutputTooBigUTxO" [("list of TxOuts which are too big", ppList (pcTxOut reify) outs)]
 
-instance
-  ( PrettyCore era
-  , PrettyA (PPUPPredFailure era)
-  ) =>
-  PrettyA (AllegraUtxoPredFailure era)
-  where
-  prettyA = ppUtxoPFMary
+instance Reflect era => PrettyA (AllegraUtxoPredFailure era) where
+  prettyA = ppAllegraUtxoPredFailure
 
--- =====================================================
--- Probably should be moved elsewhere
+-- ==========================================
+-- LedgerState objects
+-- ==========================================
 
--- LedgerState.hs
-ppWitHashes :: Set (KeyHash 'Witness c) -> PDoc
-ppWitHashes hs = ppSexp "WitHashes" [ppSet ppKeyHash hs]
-
--- Defined in ‘Cardano.Ledger.Alonzo.Tx’
-ppScriptPurpose :: PrettyA (TxCert era) => ScriptPurpose era -> PDoc
-ppScriptPurpose (Minting policy) = ppSexp "Minting" [prettyA policy] -- FIXME fill in the blanks
-ppScriptPurpose (Spending txin) = ppSexp "Spending" [ppTxIn txin]
-ppScriptPurpose (Rewarding acct) = ppSexp "Rewarding" [ppRewardAcnt' acct]
-ppScriptPurpose (Certifying dcert) = ppSexp "Certifying" [prettyA dcert]
-
-instance PrettyA (TxCert era) => PrettyA (ScriptPurpose era) where
-  prettyA = ppScriptPurpose
-
-instance PrettyA x => PrettyA [x] where
-  prettyA = ppList prettyA
-
--- =====================================================
-
-dots :: PDoc -> PDoc
-dots _ = ppString "..."
-
-dotsF :: (a -> PDoc) -> (a -> PDoc)
-dotsF _f _x = ppString "..."
-
-ppMyWay :: (Typeable keyrole, CC.Crypto c) => WitVKey keyrole c -> PDoc
-ppMyWay wvk@(WitVKey vkey _) = ppSexp "MyWay" [ppKeyHash (hashKey vkey), ppWitVKey wvk]
-
-ppCoreWitnesses :: Proof era -> TxWits era -> PDoc
-ppCoreWitnesses (Conway _) x = ppTxWitness x
-ppCoreWitnesses (Babbage _) x = ppTxWitness x
-ppCoreWitnesses (Alonzo _) x = ppTxWitness x
-ppCoreWitnesses (Mary _) x = ppWitnessSetHKD x
-ppCoreWitnesses (Allegra _) x = ppWitnessSetHKD x
-ppCoreWitnesses (Shelley _) x = ppWitnessSetHKD x
-
-ppCoreScript :: Proof era -> Script era -> PDoc
-ppCoreScript (Conway _) (PlutusScript plutusScript) =
-  ppString (show (plutusScriptBinary plutusScript))
-ppCoreScript (Conway _) (TimelockScript x) = ppTimelock x
-ppCoreScript (Babbage _) (PlutusScript plutusScript) =
-  ppString (show (plutusScriptBinary plutusScript))
-ppCoreScript (Babbage _) (TimelockScript x) = ppTimelock x
-ppCoreScript (Alonzo _) (PlutusScript plutusScript) =
-  ppString (show (plutusScriptBinary plutusScript))
-ppCoreScript (Alonzo _) (TimelockScript x) = ppTimelock x
-ppCoreScript (Mary _) x = ppTimelock x
-ppCoreScript (Allegra _) x = ppTimelock x
-ppCoreScript (Shelley _) x = ppMultiSig x
-
--- =======================================================
-
-ppLedgersPredicateFailure ::
-  PrettyA (PredicateFailure (EraRule "LEDGER" era)) => ShelleyLedgersPredFailure era -> PDoc
-ppLedgersPredicateFailure (LedgerFailure x) = prettyA x
-
-instance
-  PrettyA (PredicateFailure (EraRule "LEDGER" era)) =>
-  PrettyA (ShelleyLedgersPredFailure era)
-  where
-  prettyA = ppLedgersPredicateFailure
-
--- ================
-ppBbodyPredicateFailure ::
-  PrettyA (PredicateFailure (EraRule "LEDGERS" era)) =>
-  ShelleyBbodyPredFailure era ->
-  PDoc
-ppBbodyPredicateFailure (WrongBlockBodySizeBBODY x y) =
-  ppRecord
-    "WrongBlockBodySizeBBODY"
-    [ ("actual computed BBody size", ppInt x)
-    , ("claimed BBody Size in Header", ppInt y)
-    ]
-ppBbodyPredicateFailure (InvalidBodyHashBBODY h1 h2) =
-  ppRecord
-    "(InvalidBodyHashBBODY"
-    [ ("actual hash", ppHash h1)
-    , ("claimed hash", ppHash h2)
-    ]
-ppBbodyPredicateFailure (LedgersFailure x) =
-  ppSexp "LedgersFailure" [prettyA x]
-
-instance
-  PrettyA (PredicateFailure (EraRule "LEDGERS" era)) =>
-  PrettyA (ShelleyBbodyPredFailure era)
-  where
-  prettyA = ppBbodyPredicateFailure
-
--- ================
-
-ppAlonzoBbodyPredFail ::
-  PrettyA (PredicateFailure (EraRule "LEDGERS" era)) =>
-  AlonzoBbodyPredFailure era ->
-  PDoc
-ppAlonzoBbodyPredFail (ShelleyInAlonzoBbodyPredFailure x) =
-  ppSexp "ShelleyInAlonzoPredFail" [ppBbodyPredicateFailure x]
-ppAlonzoBbodyPredFail (TooManyExUnits e1 e2) =
-  ppRecord
-    "TooManyExUnits"
-    [ ("Computed Sum of ExUnits for all plutus scripts", ppExUnits e1)
-    , ("Maximum allowed by protocal parameters", ppExUnits e2)
-    ]
-
-instance
-  PrettyA (PredicateFailure (EraRule "LEDGERS" era)) =>
-  PrettyA (AlonzoBbodyPredFailure era)
-  where
-  prettyA = ppAlonzoBbodyPredFail
-
--- ===============
-ppTickPredicateFailure ::
-  forall era.
-  Reflect era =>
-  ShelleyTickPredFailure era ->
-  PDoc
-ppTickPredicateFailure (NewEpochFailure x) = ppNewEpochPredicateFailure @era x
-ppTickPredicateFailure (RupdFailure _) =
-  ppString "RupdPredicateFailure has no constructors"
-
-instance
-  ( ShelleyNewEpochPredFailure era ~ PredicateFailure (EraRule "NEWEPOCH" era)
-  , ShelleyEpochPredFailure era ~ PredicateFailure (EraRule "EPOCH" era)
-  , Reflect era
-  ) =>
-  PrettyA (ShelleyTickPredFailure era)
-  where
-  prettyA = ppTickPredicateFailure
-
--- ===============
-ppNewEpochPredicateFailure ::
-  forall era.
-  Reflect era =>
-  PredicateFailure (EraRule "NEWEPOCH" era) ->
-  PDoc
-ppNewEpochPredicateFailure x = case reify @era of
-  Shelley _ -> ppShelleyNewEpochPredicateFailure x
-  Allegra _ -> ppShelleyNewEpochPredicateFailure x
-  Mary _ -> ppShelleyNewEpochPredicateFailure x
-  Alonzo _ -> ppShelleyNewEpochPredicateFailure x
-  Babbage _ -> ppShelleyNewEpochPredicateFailure x
-  Conway _ -> ppString "FIXME" -- ppConwayNewEpochPredicateFailure x
-
-ppShelleyNewEpochPredicateFailure ::
-  forall era.
-  ( PredicateFailure (EraRule "EPOCH" era) ~ ShelleyEpochPredFailure era
-  , -- , PredicateFailure (EraRule "UPEC" era) ~ ShelleyUpecPredFailure era
-    Reflect era
-  ) =>
-  ShelleyNewEpochPredFailure era ->
-  PDoc
-ppShelleyNewEpochPredicateFailure (EpochFailure x) = ppEpochPredicateFailure @era x
-ppShelleyNewEpochPredicateFailure (CorruptRewardUpdate x) =
-  ppSexp "CorruptRewardUpdate" [ppRewardUpdate x]
-ppShelleyNewEpochPredicateFailure (MirFailure _) =
-  ppString "MirPredicateFailure has no constructors"
-
-{-
-ppConwayNewEpochPredicateFailure ::
-  forall era.
-  ( PredicateFailure (EraRule "EPOCH" era) ~ ConwayEpochPredFailure era
-  , PrettyA (PredicateFailure (EraRule "EPOCH" era))
-  , PrettyA (PredicateFailure (EraRule "RATIFY" era))
-  ) =>
-  ConwayNewEpochPredFailure era ->
-  PDoc
--- TODO FIX ME
--- ppConwayNewEpochPredicateFailure (Conway.EpochFailure x) = ppEpochPredicateFailure @era x
-ppConwayNewEpochPredicateFailure (Conway.CorruptRewardUpdate x) =
-  ppSexp "CorruptRewardUpdate" [ppRewardUpdate x]
-ppConwayNewEpochPredicateFailure (Conway.RatifyFailure x) = ppRatifyPredicateFailure @era x
--}
-
-instance
-  ( Reflect era
-  , PredicateFailure (EraRule "EPOCH" era) ~ ShelleyEpochPredFailure era
-  , PredicateFailure (EraRule "UPEC" era) ~ ShelleyUpecPredFailure era
-  ) =>
-  PrettyA (ShelleyNewEpochPredFailure era)
-  where
-  prettyA = ppShelleyNewEpochPredicateFailure
-
--- ===============
-ppEpochPredicateFailure ::
-  forall era.
-  Reflect era =>
-  ShelleyEpochPredFailure era ->
-  PDoc
-ppEpochPredicateFailure (PoolReapFailure _) =
-  ppString "PoolreapPredicateFailure has no constructors"
-ppEpochPredicateFailure (SnapFailure _) =
-  ppString "SnapPredicateFailure has no constructors"
-ppEpochPredicateFailure (UpecFailure x) = case reify @era of
-  Shelley _ -> ppUpecPredicateFailure x
-  Mary _ -> ppUpecPredicateFailure x
-  Alonzo _ -> ppUpecPredicateFailure x
-  Allegra _ -> ppUpecPredicateFailure x
-  Babbage _ -> ppUpecPredicateFailure x
-  Conway _ -> absurd x
-
-instance
-  ( ShelleyEpochPredFailure era ~ PredicateFailure (EraRule "EPOCH" era)
-  , ShelleyUpecPredFailure era ~ PredicateFailure (EraRule "UPEC" era)
-  , Reflect era
-  ) =>
-  PrettyA (ShelleyEpochPredFailure era)
-  where
-  prettyA = ppEpochPredicateFailure
-
-instance PrettyA (ShelleyPoolreapPredFailure era) where
-  prettyA = \case {}
-
-instance PrettyA (ShelleySnapPredFailure era) where
-  prettyA = \case {}
-
--- ===============
-ppUpecPredicateFailure :: ShelleyUpecPredFailure era -> PDoc
-ppUpecPredicateFailure (NewPpFailure x) = ppNewppPredicateFailure x
-
-instance
-  ShelleyUpecPredFailure era ~ PredicateFailure (EraRule "UPEC" era) =>
-  PrettyA (ShelleyUpecPredFailure era)
-  where
-  prettyA = ppUpecPredicateFailure
-
--- ===============
-ppNewppPredicateFailure :: ShelleyNewppPredFailure era -> PDoc
-ppNewppPredicateFailure (UnexpectedDepositPot c1 c2) =
-  ppRecord
-    "UnexpectedDepositPot"
-    [ ("The total outstanding deposits", ppCoin c1)
-    , ("The deposit pot", ppCoin c2)
-    ]
-
-instance PrettyA (ShelleyNewppPredFailure era) where prettyA = ppNewppPredicateFailure
-
--- ===================
-
-ppBbodyState ::
-  ( PrettyA (TxOut era)
-  , PrettyA (PParams era)
-  , PrettyA (GovState era)
-  , State (EraRule "LEDGERS" era) ~ LedgerState era
-  ) =>
-  ShelleyBbodyState era ->
-  PDoc
+ppBbodyState :: forall era. Reflect era => ShelleyBbodyState era -> PDoc
 ppBbodyState (BbodyState ls (BlocksMade mp)) =
   ppRecord
     "BbodyState"
-    [ ("ledger state", ppLedgerState ls)
-    , ("blocks made", ppMap ppKeyHash ppNatural mp)
+    [ ("ledger state", ppStateLEDGERS @era reify ls)
+    , ("blocks made", ppMap pcKeyHash ppNatural mp)
     ]
 
-instance
-  ( PrettyA (TxOut era)
-  , PrettyA (PParams era)
-  , PrettyA (GovState era)
-  , State (EraRule "LEDGERS" era) ~ LedgerState era
-  ) =>
-  PrettyA (ShelleyBbodyState era)
-  where
+instance Reflect era => PrettyA (ShelleyBbodyState era) where
   prettyA = ppBbodyState
 
 -- =======================================================
--- Summaries
+-- Summaries. A Summary prints just some information
+-- For examplle, just the size of a Map or List.
 
 txBodyFieldSummary :: EraTxBody era => TxBodyField era -> [(Text, PDoc)]
 txBodyFieldSummary txb = case txb of
@@ -1083,24 +1933,24 @@ txBodyFieldSummary txb = case txb of
   (RefInputs s) -> [("RefInputs", ppInt (Set.size s))]
   (Outputs xs) -> [("Outputs", ppInt (length xs))]
   (CollateralReturn (SJust _)) -> [("Collateral Return", ppString "?")]
-  (TotalCol (SJust c)) -> [("TotalCollateral", ppCoin c)]
+  (TotalCol (SJust c)) -> [("TotalCollateral", pcCoin c)]
   (Certs xs) -> [("Certs", ppInt (length xs))]
   (Withdrawals' x) -> [("Withdrawals", ppInt (Map.size (unWithdrawals x)))]
   (Vldt x) -> [("Validity interval", ppValidityInterval x)]
-  (Txfee c) -> [("Fee", ppCoin c)]
+  (Txfee c) -> [("Fee", pcCoin c)]
   (Update (SJust _)) -> [("Collateral Return", ppString "?")]
   (ReqSignerHashes x) -> [("Required Signer hashes", ppInt (Set.size x))]
-  (Mint ma) -> [("Mint", ppInteger (Val.size (MaryValue mempty ma)) <> ppString " bytes")]
+  (Fields.Mint ma) -> [("Mint", ppInteger (Val.size (MaryValue mempty ma)) <> ppString " bytes")]
   (WppHash (SJust _)) -> [("WppHash", ppString "?")]
   (AdHash (SJust _)) -> [("AdHash", ppString "?")]
   (Txnetworkid (SJust x)) -> [("Network id", ppNetwork x)]
   _ -> []
 
 bodySummary :: EraTxBody era => Proof era -> TxBody era -> PDoc
-bodySummary proof body =
+bodySummary proof txbody =
   ppRecord
     "TxBody"
-    (concat (map txBodyFieldSummary (abstractTxBody proof body)))
+    (concat (map txBodyFieldSummary (abstractTxBody proof txbody)))
 
 witnessFieldSummary :: Era era => WitnessesField era -> (Text, PDoc)
 witnessFieldSummary wit = case wit of
@@ -1111,10 +1961,10 @@ witnessFieldSummary wit = case wit of
   (RdmrWits (Redeemers m)) -> ("Redeemer Witnesses", ppInt (Map.size m))
 
 witnessSummary :: Era era => Proof era -> TxWits era -> PDoc
-witnessSummary proof wits =
+witnessSummary proof txwits =
   ppRecord
     "Witnesses"
-    (map witnessFieldSummary (abstractWitnesses proof wits))
+    (map witnessFieldSummary (abstractWitnesses proof txwits))
 
 txFieldSummary :: EraTxBody era => Proof era -> TxField era -> [PDoc]
 txFieldSummary proof tx = case tx of
@@ -1132,9 +1982,6 @@ txSummary proof tx =
 
 -- =================================
 -- Summary version of UTxO
-
-trim :: PDoc -> PDoc
-trim x = ppString (take 10 (show x))
 
 txInSummary :: TxIn era -> PDoc
 txInSummary (TxIn (TxId h) n) = ppSexp "TxIn" [trim (ppSafeHash h), ppInt (txIxToInt n)]
@@ -1170,7 +2017,7 @@ multiAssetSummary (MultiAsset m) = ppString ("num tokens = " ++ show (Map.size m
 
 vSummary :: MaryValue c -> PDoc
 vSummary (MaryValue n ma) =
-  ppSexp "Value" [ppCoin n, multiAssetSummary ma]
+  ppSexp "Value" [pcCoin n, multiAssetSummary ma]
 
 scriptSummary :: forall era. Proof era -> Script era -> PDoc
 scriptSummary p@(Conway _) script = plutusSummary p script
@@ -1213,11 +2060,11 @@ keyHashSummary (KeyHash h) = trim (ppHash h)
 dataHashSummary :: DataHash era -> PDoc
 dataHashSummary dh = trim (ppSafeHash dh)
 
-keyPairSummary :: CC.Crypto c => KeyPair r c -> PDoc
+keyPairSummary :: Crypto c => KeyPair r c -> PDoc
 keyPairSummary (KeyPair x y) =
   ppRecord "KeyPair" [("vKey", vKeySummary x), ("sKey", viaShow y)]
 
-vKeySummary :: CC.Crypto c => VKey r c -> PDoc
+vKeySummary :: Crypto c => VKey r c -> PDoc
 vKeySummary vk@(VKey x) = viaShow x <> " (hash " <> keyHashSummary (hashKey vk) <> ")"
 
 timelockSummary :: Era era => Timelock era -> PDoc
@@ -1230,9 +2077,9 @@ timelockSummary (RequireAnyOf ms) =
 timelockSummary (RequireMOf m ms) =
   ppSexp "MOfN" (ppInteger (fromIntegral m) : foldr (:) [] (fmap timelockSummary ms))
 timelockSummary (RequireTimeExpire mslot) =
-  ppSexp "Expires" [ppSlotNo mslot]
+  ppSexp "Expires" [pcSlotNo mslot]
 timelockSummary (RequireTimeStart mslot) =
-  ppSexp "Starts" [ppSlotNo mslot]
+  ppSexp "Starts" [pcSlotNo mslot]
 
 multiSigSummary :: Era era => SS.MultiSig era -> PDoc
 multiSigSummary (SS.RequireSignature hk) = ppSexp "ReqSig" [keyHashSummary hk]
@@ -1268,8 +2115,8 @@ instantSummary (InstantaneousRewards reserves treasury dreserves dtreasury) =
     "InstantaneousRewards"
     [ ("Rewards from reserves", ppInt (Map.size reserves))
     , ("Rewards from treasury", ppInt (Map.size treasury))
-    , ("Treasury to reserves", ppDeltaCoin dreserves)
-    , ("Reserves to treasury", ppDeltaCoin dtreasury)
+    , ("Treasury to reserves", pcDeltaCoin dreserves)
+    , ("Reserves to treasury", pcDeltaCoin dtreasury)
     ]
 
 uMapSummary :: UM.UMap c -> PDoc
@@ -1293,46 +2140,44 @@ pStateSummary (PState pp fpp retire deposit) =
     ]
 
 dpStateSummary :: CertState era -> PDoc
-dpStateSummary (CertState v p d) = vsep [prettyA v, pStateSummary p, dStateSummary d]
+dpStateSummary (CertState v p d) = vsep [pcVState v, pStateSummary p, dStateSummary d]
 
 -- =============================================
-
-class PrettyC t era where
-  prettyC :: Proof era -> t -> PDoc
+-- Pretty printers for more Ledger specific types
 
 pcTxId :: TxId c -> PDoc
 pcTxId (TxId safehash) = trim (ppSafeHash safehash)
 
-instance c ~ EraCrypto era => PrettyC (TxId c) era where prettyC _ = pcTxId
+instance PrettyA (TxId c) where prettyA = pcTxId
 
 pcTxIn :: TxIn c -> PDoc
 pcTxIn (TxIn (TxId h) (TxIx i)) = parens (hsep [ppString "TxIn", trim (ppSafeHash h), ppWord64 i])
 
-instance c ~ EraCrypto era => PrettyC (TxIn c) era where prettyC _ = pcTxIn
+instance PrettyA (TxIn c) where prettyA = pcTxIn
 
 pcNetwork :: Network -> PDoc
 pcNetwork Testnet = ppString "TestNet"
 pcNetwork Mainnet = ppString "Mainnet"
 
-instance PrettyC Network era where prettyC _ = pcNetwork
+instance PrettyA Network where prettyA = pcNetwork
 
 pcKeyHash :: KeyHash discriminator c -> PDoc
 pcKeyHash (KeyHash h) = trim (ppHash h)
 
-instance c ~ EraCrypto era => PrettyC (KeyHash d c) era where prettyC _ = pcKeyHash
+instance PrettyA (KeyHash d c) where prettyA = pcKeyHash
 
 pcCredential :: Credential keyrole c -> PDoc
 pcCredential (ScriptHashObj (ScriptHash h)) = hsep [ppString "(Script", trim (ppHash h) <> ppString ")"]
 pcCredential (KeyHashObj (KeyHash h)) = hsep [ppString "(Key", trim (ppHash h) <> ppString ")"]
 
-instance c ~ EraCrypto era => PrettyC (Credential keyrole c) era where prettyC _ = pcCredential
+instance PrettyA (Credential keyrole c) where prettyA = pcCredential
 
 pcStakeReference :: StakeReference c -> PDoc
 pcStakeReference StakeRefNull = ppString "Null"
 pcStakeReference (StakeRefBase cred) = pcCredential cred
 pcStakeReference (StakeRefPtr _) = ppString "Ptr"
 
-instance c ~ EraCrypto era => PrettyC (StakeReference c) era where prettyC _ = pcStakeReference
+instance PrettyA (StakeReference c) where prettyA = pcStakeReference
 
 pcAddr :: Addr c -> PDoc
 pcAddr (Addr nw pay stk) =
@@ -1345,8 +2190,9 @@ pcAddr (Addr nw pay stk) =
       ]
 pcAddr (AddrBootstrap _) = ppString "Bootstrap"
 
-instance c ~ EraCrypto era => PrettyC (Addr c) era where prettyC _ = pcAddr
+instance PrettyA (Addr c) where prettyA = pcAddr
 
+-- | Value is a type family, so it has no PrettyA instance.
 pcCoreValue :: Proof era -> Value era -> PDoc
 pcCoreValue (Conway _) v = vSummary v
 pcCoreValue (Babbage _) v = vSummary v
@@ -1358,19 +2204,19 @@ pcCoreValue (Shelley _) (Coin n) = hsep [ppString "₳", ppInteger n]
 pcCoin :: Coin -> PDoc
 pcCoin (Coin n) = hsep [ppString "₳", ppInteger n]
 
-instance PrettyC Coin era where prettyC _ = pcCoin
+instance PrettyA Coin where prettyA = pcCoin
 
 pcValue :: MaryValue c -> PDoc
 pcValue (MaryValue n (MultiAsset m)) =
   ppSexp
     "Value"
-    [ ppCoin n
+    [ pcCoin n
     , -- , ppString ("num tokens = " ++ show (Map.size m))
       ppSet pcPolicyID (Map.keysSet m)
     ]
 
-instance c ~ EraCrypto era => PrettyC (MaryValue c) era where
-  prettyC _ = pcValue
+instance PrettyA (MaryValue c) where
+  prettyA = pcValue
 
 pcVal :: Proof era -> Value era -> PDoc
 pcVal (Shelley _) v = pcCoin v
@@ -1385,7 +2231,7 @@ pcDatum NoDatum = ppString "NoDatum"
 pcDatum (DatumHash h) = ppSexp "DHash" [trim (ppSafeHash h)]
 pcDatum (Datum b) = pcData (binaryDataToData b)
 
-instance Era era => PrettyC (Datum era) era where prettyC _ = pcDatum
+instance Era era => PrettyA (Datum era) where prettyA = pcDatum
 
 pcData :: forall era. Era era => Data era -> PDoc
 pcData d@(Data (PV1.Constr n _)) =
@@ -1399,15 +2245,18 @@ pcData d@(Data (PV1.I n)) =
 pcData d@(Data (PV1.B bytes)) =
   ppSexp "B" [trim (viaShow bytes), ppString "Hash", trim $ ppSafeHash (hashData d)]
 
-instance Era era => PrettyC (Data era) era where prettyC _ = pcData
+instance Era era => PrettyA (Data era) where prettyA = pcData
 
 pcTimelock :: forall era. Reflect era => Timelock era -> PDoc
 pcTimelock (RequireSignature akh) = ppSexp "Sign" [pcKeyHash akh]
 pcTimelock (RequireAllOf ts) = ppSexp "AllOf" [ppList pcTimelock (toList ts)]
 pcTimelock (RequireAnyOf ts) = ppSexp "AnyOf" [ppList pcTimelock (toList ts)]
 pcTimelock (RequireMOf m ts) = ppSexp "MOfN" (ppInteger (fromIntegral m) : [ppList pcTimelock (toList ts)])
-pcTimelock (RequireTimeExpire mslot) = ppSexp "Expires" [ppSlotNo mslot]
-pcTimelock (RequireTimeStart mslot) = ppSexp "Starts" [ppSlotNo mslot]
+pcTimelock (RequireTimeExpire mslot) = ppSexp "Expires" [pcSlotNo mslot]
+pcTimelock (RequireTimeStart mslot) = ppSexp "Starts" [pcSlotNo mslot]
+
+instance Reflect era => PrettyA (Timelock era) where
+  prettyA = pcTimelock
 
 pcMultiSig :: Reflect era => PDoc -> SS.MultiSig era -> PDoc
 pcMultiSig h (SS.RequireSignature hk) = ppSexp "ReqSig" [keyHashSummary hk, h]
@@ -1415,8 +2264,14 @@ pcMultiSig h (SS.RequireAllOf _) = ppSexp "AllOf" [h]
 pcMultiSig h (SS.RequireAnyOf _) = ppSexp "AnyOf" [h]
 pcMultiSig h (SS.RequireMOf m _) = ppSexp "MOf" [ppInt m, h]
 
+instance Reflect era => PrettyA (SS.MultiSig era) where
+  prettyA = pcMultiSig mempty
+
 pcScriptHash :: ScriptHash era -> PDoc
 pcScriptHash (ScriptHash h) = trim (ppHash h)
+
+instance PrettyA (ScriptHash era) where
+  prettyA = pcScriptHash
 
 pcHashScript :: forall era. Reflect era => Proof era -> Script era -> PDoc
 pcHashScript (Conway _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
@@ -1426,52 +2281,19 @@ pcHashScript (Mary _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
 pcHashScript (Allegra _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
 pcHashScript (Shelley _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
 
-pcScript :: forall era. Reflect era => Proof era -> Script era -> PDoc
-{- Old style with hash
-pcScript p@(Conway _) s@(TimelockScript t) = pcTimelock @era (pcHashScript @era p s) t
-pcScript p@(Conway _) s@(PlutusScript (Plutus v _)) =
-  parens (hsep [ppString ("PlutusScript " <> show v <> " "), pcHashScript p s])
-pcScript p@(Babbage _) s@(TimelockScript t) = pcTimelock @era (pcHashScript @era p s) t
-pcScript p@(Babbage _) s@(PlutusScript (Plutus v _)) =
-  parens (hsep [ppString ("PlutusScript " <> show v <> " "), pcHashScript p s])
-pcScript p@(Alonzo _) s@(TimelockScript t) = pcTimelock @era (pcHashScript @era p s) t
-pcScript p@(Alonzo _) s@(PlutusScript (Plutus v _)) =
--}
-
-pcScript (Conway _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Conway _) s@(PlutusScript v) =
-  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Babbage _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Babbage _) s@(PlutusScript v) =
-  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Alonzo _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Alonzo _) s@(PlutusScript v) =
-  parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Mary _) s = pcTimelock @era s
-pcScript (Allegra _) s = pcTimelock @era s
-pcScript p@(Shelley _) s = pcMultiSig @era (pcHashScript @era p s) s
+instance (Script era ~ AlonzoScript era, Reflect era) => PrettyA (AlonzoScript era) where
+  prettyA = pcScript reify
 
 pcDataHash :: DataHash era -> PDoc
 pcDataHash dh = trim (ppSafeHash dh)
 
-pcTxOut :: Reflect era => Proof era -> TxOut era -> PDoc
-pcTxOut p@(Conway _) (BabbageTxOut addr v d s) =
-  ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
-pcTxOut p@(Babbage _) (BabbageTxOut addr v d s) =
-  ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
-pcTxOut (Alonzo _) (AlonzoTxOut addr v md) =
-  ppSexp "TxOut" [pcAddr addr, pcValue v, ppStrictMaybe pcDataHash md]
-pcTxOut p@(Mary _) (ShelleyTxOut addr v) =
-  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
-pcTxOut p@(Allegra _) (ShelleyTxOut addr v) =
-  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
-pcTxOut p@(Shelley _) (ShelleyTxOut addr v) =
-  ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
+instance PrettyA (DataHash era) where
+  prettyA = pcDataHash
 
 pcUTxO :: Proof era -> UTxO era -> PDoc
 pcUTxO proof = ppMap pcTxIn (unReflect pcTxOut proof) . unUTxO
 
-instance Reflect era => PrettyC (UTxO era) era where prettyC = pcUTxO
+instance Reflect era => PrettyA (UTxO era) where prettyA = pcUTxO reify
 
 pcPoolParams :: PoolParams era -> PDoc
 pcPoolParams x =
@@ -1481,20 +2303,21 @@ pcPoolParams x =
     , ("reward accnt", pcCredential (getRwdCred (ppRewardAcnt x)))
     ]
 
-instance PrettyC (PoolParams era) era where prettyC _ = pcPoolParams
+instance PrettyA (PoolParams era) where prettyA = pcPoolParams
 
 pcDelegCert :: ShelleyDelegCert c -> PDoc
 pcDelegCert (ShelleyRegCert cred) = ppSexp "ShelleyRegCert" [pcCredential cred]
 pcDelegCert (ShelleyUnRegCert cred) = ppSexp "ShelleyUnRegCert" [pcCredential cred]
 pcDelegCert (ShelleyDelegCert x y) = ppSexp "ShelleyDelegCert" [pcCredential x, pcKeyHash y]
 
-instance c ~ EraCrypto era => PrettyC (ShelleyDelegCert c) era where prettyC _ = pcDelegCert
+instance PrettyA (ShelleyDelegCert c) where prettyA = pcDelegCert
 
 pcPoolCert :: PoolCert c -> PDoc
 pcPoolCert (RegPool poolp) = ppSexp "RegPool" [pcPoolParams poolp]
 pcPoolCert (RetirePool keyhash epoch) = ppSexp "RetirePool" [pcKeyHash keyhash, ppEpochNo epoch]
 
-instance c ~ EraCrypto era => PrettyC (PoolCert c) era where prettyC _ = pcPoolCert
+instance PrettyA (PoolCert c) where
+  prettyA = pcPoolCert
 
 pcShelleyTxCert :: ShelleyTxCert c -> PDoc
 pcShelleyTxCert (ShelleyTxCertDelegCert x) = pcDelegCert x
@@ -1513,10 +2336,16 @@ pcShelleyTxCert (ShelleyTxCertMir (MIRCert x (SendToOppositePotMIR c))) =
     , ("Amount", pcCoin c)
     ]
 
+instance PrettyA (ShelleyTxCert c) where
+  prettyA = pcShelleyTxCert
+
 pcConwayTxCert :: ConwayTxCert c -> PDoc
 pcConwayTxCert (ConwayTxCertDeleg dc) = pcConwayDelegCert dc
 pcConwayTxCert (ConwayTxCertPool poolc) = pcPoolCert poolc
 pcConwayTxCert (ConwayTxCertGov x) = pcConwayGovCert x
+
+instance PrettyA (ConwayTxCert c) where
+  prettyA = pcConwayTxCert
 
 pcConwayGovCert :: ConwayGovCert c -> PDoc
 pcConwayGovCert (ConwayRegDRep cred c smA) =
@@ -1532,6 +2361,9 @@ pcConwayGovCert (ConwayResignCommitteeColdKey cred anch) =
     "ConwayResignCommitteeColdKey"
     [("cred", pcCredential cred), ("anchor", ppStrictMaybe pcAnchor anch)]
 
+instance PrettyA (ConwayGovCert c) where
+  prettyA = pcConwayGovCert
+
 pcConwayDelegCert :: ConwayDelegCert c -> PDoc
 pcConwayDelegCert (ConwayRegCert cred mcoin) =
   ppSexp "RegCert" [pcCredential cred, ppStrictMaybe pcCoin mcoin]
@@ -1542,10 +2374,16 @@ pcConwayDelegCert (ConwayDelegCert cred d) =
 pcConwayDelegCert (ConwayRegDelegCert cred d c) =
   ppSexp "RegDelegCert" [pcCredential cred, pcDelegatee d, pcCoin c]
 
+instance PrettyA (ConwayDelegCert c) where
+  prettyA = pcConwayDelegCert
+
 pcDelegatee :: Delegatee c -> PDoc
 pcDelegatee (DelegStake kh) = ppSexp "DelegStake" [pcKeyHash kh]
 pcDelegatee (DelegVote cred) = ppSexp "DelegVote" [pcDRep cred]
 pcDelegatee (DelegStakeVote kh cred) = ppSexp "DelegStakeVote" [pcKeyHash kh, pcDRep cred]
+
+instance PrettyA (Delegatee c) where
+  prettyA = pcDelegatee
 
 pcTxCert :: Proof era -> TxCert era -> PDoc
 pcTxCert (Shelley _) x = pcShelleyTxCert x
@@ -1563,9 +2401,15 @@ pcGovProcedures (GovProcedures vote proposal) =
     , ("proposal", ppList (pcProposalProcedure @era) (toList proposal))
     ]
 
+instance PrettyA (GovProcedures era) where
+  prettyA = pcGovProcedures
+
 pcVotingProcedures :: VotingProcedures era -> PDoc
 pcVotingProcedures (VotingProcedures m) =
   ppSexp "VotingProcedures" [ppMap pcVoter (ppMap pcGovActionId pcVotingProcedure) m]
+
+instance PrettyA (VotingProcedures era) where
+  prettyA = pcVotingProcedures
 
 pcProposalProcedure :: ProposalProcedure era -> PDoc
 pcProposalProcedure (ProposalProcedure c rewacnt govact anch) =
@@ -1577,89 +2421,41 @@ pcProposalProcedure (ProposalProcedure c rewacnt govact anch) =
     , ("Anchor", pcAnchor anch)
     ]
 
+instance PrettyA (ProposalProcedure era) where
+  prettyA = pcProposalProcedure
+
 pcVoter :: (Voter c) -> PDoc
 pcVoter (CommitteeVoter cred) = ppSexp "CommitteeVoter" [pcCredential cred]
 pcVoter (DRepVoter cred) = ppSexp "DRepVoter" [pcCredential cred]
 pcVoter (StakePoolVoter keyhash) = ppSexp "StakePoolVoter" [pcKeyHash keyhash]
 
+instance PrettyA (Voter c) where
+  prettyA = pcVoter
+
 pcVotingProcedure :: VotingProcedure era -> PDoc
 pcVotingProcedure (VotingProcedure v smA) =
   ppRecord "VotingProcedure" [("vote", pcVote v), ("anchor", ppStrictMaybe pcAnchor smA)]
 
--- ============================================================
+instance PrettyA (VotingProcedure era) where
+  prettyA = pcVotingProcedure
 
-instance c ~ EraCrypto era => PrettyC (ShelleyTxCert c) era where prettyC _ = pcShelleyTxCert
+-- ============================================================
 
 pcRewardAcnt :: RewardAcnt c -> PDoc
 pcRewardAcnt (RewardAcnt net cred) = ppSexp "RewAccnt" [pcNetwork net, pcCredential cred]
 
-instance c ~ EraCrypto era => PrettyC (RewardAcnt c) era where prettyC _ = pcRewardAcnt
+instance PrettyA (RewardAcnt c) where prettyA = pcRewardAcnt
 
 pcExUnits :: ExUnits -> PDoc
 pcExUnits (ExUnits mem step) =
   ppSexp "ExUnits" [ppNatural mem, ppNatural step]
 
-pcTxBodyField ::
-  Proof era ->
-  TxBodyField era ->
-  [(Text, PDoc)]
-pcTxBodyField proof x = case x of
-  Inputs s -> [("spend inputs", ppSet pcTxIn s)]
-  Collateral s -> [("coll inputs", ppSet pcTxIn s)]
-  RefInputs s -> [("ref inputs", ppSet pcTxIn s)]
-  Outputs s -> [("outputs", ppList (unReflect pcTxOut proof) (toList s))]
-  CollateralReturn SNothing -> []
-  CollateralReturn (SJust txout) -> [("coll return", unReflect pcTxOut proof txout)]
-  TotalCol SNothing -> []
-  TotalCol (SJust c) -> [("total coll", pcCoin c)]
-  Certs xs -> [("certs", ppList (pcTxCert proof) (toList xs))]
-  Withdrawals' (Withdrawals m) -> [("withdrawal", ppMap pcRewardAcnt pcCoin m)]
-  Txfee c -> [("fee", pcCoin c)]
-  Vldt v -> [("validity interval", ppValidityInterval v)]
-  TTL slot -> [("time to live", ppSlotNo slot)]
-  Update SNothing -> []
-  Update (SJust _) -> [("update", ppString "UPDATE")]
-  ReqSignerHashes s -> [("required hashes", ppSet pcKeyHash s)]
-  -- Mint v -> [("minted", multiAssetSummary v)]
-  Mint (MultiAsset m) -> [("minted", ppSet pcPolicyID (Map.keysSet m))]
-  WppHash SNothing -> []
-  WppHash (SJust h) -> [("integrity hash", trim (ppSafeHash h))]
-  AdHash SNothing -> []
-  AdHash (SJust (AuxiliaryDataHash h)) -> [("aux data hash", trim (ppSafeHash h))]
-  Txnetworkid SNothing -> [("network id", ppString "Nothing")]
-  Txnetworkid (SJust nid) -> [("network id", pcNetwork nid)]
-  GovProcs ga -> [("gov procedures", pcGovProcedures ga)]
-  CurrentTreasuryValue ctv -> [("current treasury value", prettyA ctv)]
-  TreasuryDonation td -> [("treasury donation", prettyA td)]
-
-pcTxField ::
-  forall era.
-  Reflect era =>
-  Proof era ->
-  TxField era ->
-  [(Text, PDoc)]
-pcTxField proof x = case x of
-  Body b -> [("txbody hash", ppSafeHash (hashAnnotated b)), ("body", pcTxBody proof b)]
-  BodyI xs -> [("body", ppRecord "TxBody" (concat (map (pcTxBodyField proof) xs)))]
-  TxWits w -> [("witnesses", pcWitnesses proof w)]
-  WitnessesI ws -> [("witnesses", ppRecord "Witnesses" (concat (map (pcWitnessesField proof) ws)))]
-  AuxData SNothing -> []
-  AuxData (SJust _auxdata) -> [("aux data", ppString "AUXDATA")] -- ppAuxiliaryData auxdata)]
-  Valid (IsValid v) -> [("is valid", ppString (show v))]
-
-pcWitnessesField :: forall era. Reflect era => Proof era -> WitnessesField era -> [(Text, PDoc)]
-pcWitnessesField proof x = case x of
-  AddrWits set -> [("key wits", ppSet (pcWitVKey proof) set)]
-  BootWits bwits -> [("boot wits", ppSet (\z -> ppVKey (bwKey z)) bwits)]
-  ScriptWits mp -> [("script wits", ppMap pcScriptHash (pcScript proof) mp)]
-  DataWits (TxDats m) -> [("data wits", ppMap pcDataHash pcData m)]
-  RdmrWits (Redeemers m) ->
-    [("redeemer wits", ppMap ppRdmrPtr (pcPair pcData pcExUnits) m)]
+instance PrettyA ExUnits where prettyA = pcExUnits
 
 pcPair :: (t1 -> PDoc) -> (t2 -> PDoc) -> (t1, t2) -> PDoc
 pcPair pp1 pp2 (x, y) = parens (hsep [pp1 x, ppString ",", pp2 y])
 
-pcWitVKey :: (Reflect era, Typeable keyrole) => Proof era -> WitVKey keyrole (EraCrypto era) -> PDoc
+pcWitVKey :: forall era keyrole. (Reflect era, Typeable keyrole) => Proof era -> WitVKey keyrole (EraCrypto era) -> PDoc
 pcWitVKey _p (WitVKey vk@(VKey x) sig) =
   ppSexp
     "WitVKey"
@@ -1672,27 +2468,20 @@ pcWitVKey _p (WitVKey vk@(VKey x) sig) =
     hash = pcKeyHash (hashKey vk)
     sigstring = show sig
 
-pcWitnesses :: Reflect era => Proof era -> TxWits era -> PDoc
-pcWitnesses proof wits = ppRecord "Witnesses" pairs
+instance
+  forall era c keyrole.
+  ( Reflect era
+  , c ~ EraCrypto era
+  , Typeable keyrole
+  ) =>
+  PrettyA (WitVKey keyrole c)
   where
-    fields = abstractWitnesses proof wits
-    pairs = concat (map (pcWitnessesField proof) fields)
-
-pcTx :: Proof era -> Tx era -> PDoc
-pcTx proof tx = ppRecord "Tx" pairs
-  where
-    fields = abstractTx proof tx
-    pairs = concatMap (unReflect pcTxField proof) fields
-
-pcTxBody :: Proof era -> TxBody era -> PDoc
-pcTxBody proof txbody = ppRecord ("TxBody " <> pack (show proof)) pairs
-  where
-    fields = abstractTxBody proof txbody
-    pairs = concatMap (pcTxBodyField proof) fields
+  prettyA = pcWitVKey @era reify
 
 -- =====================================
 -- Governance Actions etc
 
+-- | GovState is a type family, No PrettyA instance
 pcGovState :: Proof era -> GovState era -> PDoc
 pcGovState p x = case whichGovState p of
   (GovStateShelleyToBabbage) -> pcShelleyGovState p x
@@ -1707,6 +2496,9 @@ pcShelleyGovState p (ShelleyGovState _proposal _futproposal pp prevpp) =
     , ("pparams", pcPParamsSynopsis p pp)
     , ("prevParams", pcPParamsSynopsis p prevpp)
     ]
+
+instance Reflect era => PrettyA (ShelleyGovState era) where
+  prettyA = pcShelleyGovState reify
 
 pcEnactState :: Proof era -> EnactState era -> PDoc
 pcEnactState p ens@(EnactState _ _ _ _ _ _ _ _) =
@@ -1723,11 +2515,20 @@ pcEnactState p ens@(EnactState _ _ _ _ _ _ _ _) =
         , ("PrevGovActionIdsChildren", pcPrevGovActionIdsChildren ensPrevGovActionIdsChildren)
         ]
 
+instance Reflect era => PrettyA (EnactState era) where
+  prettyA = pcEnactState reify
+
 pcGovActionId :: GovActionId c -> PDoc
 pcGovActionId (GovActionId txid (GovActionIx a)) = ppSexp "GovActId" [pcTxId txid, ppWord32 a]
 
+instance PrettyA (GovActionId c) where
+  prettyA = pcGovActionId
+
 pcPrevGovActionId :: PrevGovActionId a c -> PDoc
 pcPrevGovActionId (PrevGovActionId x) = pcGovActionId x
+
+instance PrettyA (PrevGovActionId a c) where
+  prettyA = pcPrevGovActionId
 
 pcPrevGovActionIds :: PrevGovActionIds era -> PDoc
 pcPrevGovActionIds PrevGovActionIds {..} =
@@ -1739,6 +2540,9 @@ pcPrevGovActionIds PrevGovActionIds {..} =
     , ("LastConstitution", ppStrictMaybe pcPrevGovActionId pgaConstitution)
     ]
 
+instance PrettyA (PrevGovActionIds era) where
+  prettyA = pcPrevGovActionIds
+
 pcPrevGovActionIdsChildren :: PrevGovActionIdsChildren era -> PDoc
 pcPrevGovActionIdsChildren PrevGovActionIdsChildren {..} =
   ppRecord
@@ -1749,6 +2553,9 @@ pcPrevGovActionIdsChildren PrevGovActionIdsChildren {..} =
     , ("ConstitutionChildren", ppSet pcPrevGovActionId pgacConstitution)
     ]
 
+instance PrettyA (PrevGovActionIdsChildren era) where
+  prettyA = pcPrevGovActionIdsChildren
+
 pcConwayGovState :: Proof era -> ConwayGovState era -> PDoc
 pcConwayGovState p (ConwayGovState ss es dr) =
   ppRecord
@@ -1758,14 +2565,20 @@ pcConwayGovState p (ConwayGovState ss es dr) =
     , ("drepPulsingState", pcDRepPulsingState p dr)
     ]
 
+instance Reflect era => PrettyA (ConwayGovState era) where
+  prettyA = pcConwayGovState reify
+
 pcPulsingSnapshot :: PulsingSnapshot era -> PDoc
 pcPulsingSnapshot (PulsingSnapshot x y z) =
   ppRecord
     "Snapshot"
     [ ("proposals", ppStrictSeq pcGovActionState x)
-    , ("drepDistr", ppMap pcDRep (ppCoin . fromCompact) y)
+    , ("drepDistr", ppMap pcDRep (pcCoin . fromCompact) y)
     , ("drepState", ppMap pcCredential pcDRepState z)
     ]
+
+instance PrettyA (PulsingSnapshot era) where
+  prettyA = pcPulsingSnapshot
 
 pcDRepPulsingState :: Proof era -> DRepPulsingState era -> PDoc
 pcDRepPulsingState p (DRComplete x y) =
@@ -1775,6 +2588,9 @@ pcDRepPulsingState p (DRComplete x y) =
     , ("ratifyState", pcRatifyState p y)
     ]
 pcDRepPulsingState _ (DRPulsing x) = ppSexp "DRPulsing" [pcDRepPulser x]
+
+instance Reflect era => PrettyA (DRepPulsingState era) where
+  prettyA = pcDRepPulsingState reify
 
 pcRatifyState :: Proof era -> RatifyState era -> PDoc
 pcRatifyState p (RatifyState enactedState removedPs enactedPs delayedPs) =
@@ -1786,8 +2602,14 @@ pcRatifyState p (RatifyState enactedState removedPs enactedPs delayedPs) =
     , ("delayed", ppBool delayedPs)
     ]
 
+instance Reflect era => PrettyA (RatifyState era) where
+  prettyA = pcRatifyState reify
+
 pcProposals :: Proposals era -> PDoc
 pcProposals x = ppSexp "Proposals" (map pcGovActionState (toList (proposalsActions x)))
+
+instance PrettyA (Proposals era) where
+  prettyA = pcProposals
 
 pcGovActionState :: GovActionState era -> PDoc
 pcGovActionState gas@(GovActionState _ _ _ _ _ _ _ _ _ _) =
@@ -1806,8 +2628,14 @@ pcGovActionState gas@(GovActionState _ _ _ _ _ _ _ _ _ _) =
         , ("Children", ppSet pcGovActionId gasChildren)
         ]
 
+instance PrettyA (GovActionState era) where
+  prettyA = pcGovActionState
+
 pcVote :: Vote -> PDoc
 pcVote x = ppString (show x)
+
+instance PrettyA Vote where
+  prettyA = pcVote
 
 pcCommittee :: Committee era -> PDoc
 pcCommittee (Committee mem quor) =
@@ -1816,6 +2644,9 @@ pcCommittee (Committee mem quor) =
     [ ("members", ppMap pcCredential ppEpochNo mem)
     , ("quorum", ppUnitInterval quor)
     ]
+
+instance PrettyA (Committee era) where
+  prettyA = pcCommittee
 
 pcGovAction :: GovAction era -> PDoc
 pcGovAction x = case x of
@@ -1853,11 +2684,23 @@ pcGovAction x = case x of
       ]
   InfoAction -> ppString "InfoAction"
 
+instance PrettyA (GovAction era) where
+  prettyA = pcGovAction
+
 pcConstitution :: Constitution c -> PDoc
 pcConstitution (Constitution x y) =
   ppRecord
     "Constitution"
     [("anchor", pcAnchor x), ("scripthash", ppStrictMaybe pcScriptHash y)]
+
+instance PrettyA (Constitution c) where
+  prettyA = pcConstitution
+
+pcCommitteeState :: CommitteeState era -> PDoc
+pcCommitteeState x = ppMap pcCredential (ppMaybe pcCredential) (csCommitteeCreds x)
+
+instance (PrettyA (CommitteeState era)) where
+  prettyA = pcCommitteeState
 
 -- ===================================================
 
@@ -1870,6 +2713,9 @@ pcReward (Reward ty pl c) =
     , ("amount", pcCoin c)
     ]
 
+instance PrettyA (Reward c) where
+  prettyA = pcReward
+
 pcFutureGenDeleg :: FutureGenDeleg c -> PDoc
 pcFutureGenDeleg (FutureGenDeleg (SlotNo x) y) =
   ppRecord
@@ -1878,26 +2724,11 @@ pcFutureGenDeleg (FutureGenDeleg (SlotNo x) y) =
     , ("keyHash", pcKeyHash y)
     ]
 
-instance (PrettyC x era, PrettyC y era) => PrettyC (x, y) era where
-  prettyC p (x, y) = vsep [prettyC p x, prettyC p y]
+instance PrettyA (FutureGenDeleg c) where
+  prettyA = pcFutureGenDeleg
 
-instance
-  c ~ EraCrypto era =>
-  PrettyC (Map (FutureGenDeleg c) (GenDelegPair c)) era
-  where
-  prettyC _ x = ppMap pcFutureGenDeleg pcGenDelegPair x
-
-instance
-  c ~ EraCrypto era =>
-  PrettyC (Map (KeyHash 'Genesis c) (GenDelegPair c)) era
-  where
-  prettyC _ x = ppMap pcKeyHash pcGenDelegPair x
-
-instance PrettyC (PState era) era where
-  prettyC _ x = pcPState x
-
-instance PrettyC (VState era) era where
-  prettyC _ st = pcVState st
+instance PrettyA (GenDelegPair c) where
+  prettyA = pcGenDelegPair
 
 pcCertState :: CertState era -> PDoc
 pcCertState (CertState vst pst dst) =
@@ -1917,6 +2748,9 @@ pcVState (VState dreps (CommitteeState committeeHotCreds) numDormantEpochs) =
     , ("Number of dormant epochs", ppEpochNo numDormantEpochs)
     ]
 
+instance PrettyA (VState era) where
+  prettyA st = pcVState st
+
 pcAnchor :: Anchor c -> PDoc
 pcAnchor (Anchor u h) =
   ppRecord
@@ -1925,25 +2759,28 @@ pcAnchor (Anchor u h) =
     , ("datahash", trim $ ppSafeHash h)
     ]
 
+instance PrettyA (Anchor c) where
+  prettyA = pcAnchor
+
 pcDRepState :: DRepState c -> PDoc
 pcDRepState (DRepState expire anchor deposit) =
   ppRecord
     "DRepState"
     [ ("expire", ppEpochNo expire)
     , ("anchor", ppStrictMaybe pcAnchor anchor)
-    , ("deposit", ppCoin deposit)
+    , ("deposit", pcCoin deposit)
     ]
+
+instance PrettyA (DRepState c) where
+  prettyA = pcDRepState
 
 pcDRep :: DRep c -> PDoc
 pcDRep (DRepCredential cred) = ppSexp "DRepCred" [pcCredential cred]
 pcDRep DRepAlwaysAbstain = ppSexp "DRep" [ppString "Abstain"]
 pcDRep DRepAlwaysNoConfidence = ppSexp "DRep" [ppString "NoConfidence"]
 
-instance c ~ EraCrypto era => PrettyC (DRep c) era where prettyC = (\_ x -> pcDRep x)
-
-instance Reflect era => PrettyC (LedgerState era) era where prettyC = pcLedgerState
-
-instance Reflect era => PrettyC (EpochState era) era where prettyC = pcEpochState
+instance PrettyA (DRep c) where
+  prettyA = pcDRep
 
 pcSnapShotL :: Text -> SnapShot c -> [(Text, PDoc)]
 pcSnapShotL prefix ss =
@@ -1960,7 +2797,7 @@ pcIndividualPoolStake x =
     , ("vrf", trim (ppHash (individualPoolStakeVrf x)))
     ]
 
-instance c ~ EraCrypto era => PrettyC (IndividualPoolStake c) era where prettyC _ = pcIndividualPoolStake
+instance PrettyA (IndividualPoolStake c) where prettyA = pcIndividualPoolStake
 
 pcSnapShots :: SnapShots c -> PDoc
 pcSnapShots sss =
@@ -1971,11 +2808,15 @@ pcSnapShots sss =
       ++ pcSnapShotL "go" (ssStakeGo sss)
       ++ [("fee", pcCoin (ssFee sss))]
 
+instance PrettyA (SnapShots c) where prettyA = pcSnapShots
+
 pcPoolDistr :: PoolDistr c -> PDoc
 pcPoolDistr (PoolDistr pdistr) =
   ppMap pcKeyHash pcIndividualPoolStake pdistr
     <> ppString " total = "
     <> ppRational (Map.foldl' (+) 0 (fmap individualPoolStake pdistr))
+
+instance PrettyA (PoolDistr c) where prettyA = pcPoolDistr
 
 withEraPParams :: forall era a. Proof era -> (Core.EraPParams era => a) -> a
 withEraPParams (Shelley _) x = x
@@ -2014,6 +2855,15 @@ pcEpochState proof es@(EpochState (AccountState tre res) ls sss _) =
     , ("AdaPots", pcAdaPot es)
     ]
 
+instance Reflect era => PrettyA (EpochState era) where
+  prettyA = pcEpochState reify
+
+pcAccountState :: AccountState -> PDoc
+pcAccountState (AccountState tr re) = ppRecord' "" [("treasury", pcCoin tr), ("reserves", pcCoin re)]
+
+instance PrettyA AccountState where
+  prettyA = pcAccountState
+
 -- | Like pcEpochState.but it only prints a summary of the UTxO
 psEpochState :: Reflect era => Proof era -> EpochState era -> PDoc
 psEpochState proof es@(EpochState (AccountState tre res) ls sss _) =
@@ -2036,7 +2886,7 @@ pcNewEpochState proof (NewEpochState en (BlocksMade pbm) (BlocksMade cbm) es _ (
     , ("EpochNo", ppEpochNo en)
     ]
 
-instance Reflect era => PrettyC (NewEpochState era) era where prettyC = pcNewEpochState
+instance Reflect era => PrettyA (NewEpochState era) where prettyA = pcNewEpochState reify
 
 -- | Like pcEpochState.but it only prints a summary of the UTxO
 psNewEpochState :: Reflect era => Proof era -> NewEpochState era -> PDoc
@@ -2059,8 +2909,11 @@ pcUTxOState proof (UTxOState u dep fs gs (IStake m _) don) =
     , ("fees", pcCoin fs)
     , ("govState", pcGovState proof gs)
     , ("incremental stake distr", ppString ("size = " ++ show (Map.size m))) -- This is not part of the model
-    , ("donation", prettyA don)
+    , ("donation", pcCoin don)
     ]
+
+instance Reflect era => PrettyA (UTxOState era) where
+  prettyA = pcUTxOState reify
 
 -- | Like pcUTxOState, except it prints only a summary of the UTxO
 psUTxOState :: forall era. Reflect era => Proof era -> UTxOState era -> PDoc
@@ -2072,10 +2925,8 @@ psUTxOState proof (UTxOState (UTxO u) dep fs gs (IStake m _) don) =
     , ("fees", pcCoin fs)
     , ("govState", pcGovState proof gs)
     , ("incremental stake distr", ppString ("size = " ++ show (Map.size m))) -- This is not part of the model
-    , ("donation", prettyA don)
+    , ("donation", pcCoin don)
     ]
-
-instance Reflect era => PrettyC (UTxOState era) era where prettyC = pcUTxOState
 
 pcLedgerState :: Proof era -> LedgerState era -> PDoc
 pcLedgerState proof ls =
@@ -2084,6 +2935,9 @@ pcLedgerState proof ls =
     [ ("utxoState", pcUTxOState proof (lsUTxOState ls))
     , ("certState", pcCertState (lsCertState ls))
     ]
+
+instance Reflect era => PrettyA (LedgerState era) where
+  prettyA = pcLedgerState reify
 
 -- | Like pcLedgerState, except it prints only a summary of the UTxO
 psLedgerState :: Reflect era => Proof era -> LedgerState era -> PDoc
@@ -2104,6 +2958,9 @@ pcPState (PState regP fregP ret dep) =
     , ("poolDeposits", ppMap pcKeyHash pcCoin dep)
     ]
 
+instance PrettyA (PState era) where
+  prettyA = pcPState
+
 pcDState :: DState c -> PDoc
 pcDState ds =
   ppRecord
@@ -2112,11 +2969,14 @@ pcDState ds =
     , ("deposits", ppMap pcCredential pcCoin (depositMap (dsUnified ds)))
     , ("delegate", ppMap pcCredential pcKeyHash (sPoolMap (dsUnified ds)))
     , ("drepDeleg", ppMap pcCredential pcDRep (dRepMap (dsUnified ds)))
-    , ("ptrs", ppMap ppPtr ppCredential (ptrMap (dsUnified ds)))
+    , ("ptrs", ppMap ppPtr pcCredential (ptrMap (dsUnified ds)))
     , ("fGenDel", ppMap pcFutureGenDeleg pcGenDelegPair (dsFutureGenDelegs ds))
     , ("GenDel", ppMap pcKeyHash pcGenDelegPair (unGenDelegs (dsGenDelegs ds)))
     , ("iRewards", pcIRewards (dsIRewards ds))
     ]
+
+instance PrettyA (DState era) where
+  prettyA = pcDState
 
 pcGenDelegPair :: GenDelegPair c -> PDoc
 pcGenDelegPair x =
@@ -2139,8 +2999,14 @@ pcIRewards xs =
 pcDeltaCoin :: DeltaCoin -> PDoc
 pcDeltaCoin (DeltaCoin n) = hsep [ppString "▵₳", ppInteger n]
 
+instance PrettyA DeltaCoin where
+  prettyA = pcDeltaCoin
+
 pcSlotNo :: SlotNo -> PDoc
 pcSlotNo (SlotNo n) = ppWord64 n
+
+instance PrettyA SlotNo where
+  prettyA = pcSlotNo
 
 pcAdaPot :: EraTxOut era => EpochState era -> PDoc
 pcAdaPot es =
@@ -2161,23 +3027,24 @@ pcAdaPot es =
 pcPolicyID :: PolicyID c -> PDoc
 pcPolicyID (PolicyID sh) = pcScriptHash sh
 
+instance PrettyA (PolicyID c) where
+  prettyA = pcPolicyID
+
 pcAssetName :: AssetName -> PDoc
 pcAssetName x = trim (viaShow x)
+
+instance PrettyA AssetName where
+  prettyA = pcAssetName
 
 pcMultiAsset :: MultiAsset c -> PDoc
 pcMultiAsset m = ppList pptriple (flattenMultiAsset m)
   where
     pptriple (i, asset, num) = hsep ["(", pcPolicyID i, pcAssetName asset, ppInteger num, ")"]
 
-pcScriptPurpose :: Proof era -> ScriptPurpose era -> PDoc
-pcScriptPurpose _ (Minting policy) = ppSexp "Minting" [pcPolicyID policy]
-pcScriptPurpose _ (Spending txin) = ppSexp "Spending" [pcTxIn txin]
-pcScriptPurpose _ (Rewarding acct) = ppSexp "Rewarding" [pcRewardAcnt acct]
-pcScriptPurpose p (Certifying dcert) = ppSexp "Certifying" [pcTxCert p dcert]
+instance PrettyA (MultiAsset c) where
+  prettyA = pcMultiAsset
 
-instance PrettyC (ScriptPurpose era) era where
-  prettyC = pcScriptPurpose
-
+-- ScriptsNeeded is a typr family so it doesn't have PrettyA instance, use pcScriptsNeeded instead of prettyA
 pcScriptsNeeded :: Proof era -> ScriptsNeeded era -> PDoc
 pcScriptsNeeded (Shelley _) (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
 pcScriptsNeeded (Allegra _) (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
@@ -2188,51 +3055,6 @@ pcScriptsNeeded p@(Babbage _) (AlonzoScriptsNeeded pl) =
   ppSexp "ScriptsNeeded" [ppList (ppPair (pcScriptPurpose p) pcScriptHash) pl]
 pcScriptsNeeded p@(Conway _) (AlonzoScriptsNeeded pl) =
   ppSexp "ScriptsNeeded" [ppList (ppPair (pcScriptPurpose p) pcScriptHash) pl]
-
-pcPParamsField ::
-  PParamsField era ->
-  [(Text, PDoc)]
-pcPParamsField x = case x of
-  MinfeeA coin -> [("minfeeA", pcCoin coin)]
-  MinfeeB coin -> [("minfeeB", pcCoin coin)]
-  MaxBBSize natural -> [("maxBBsize", ppWord32 natural)]
-  MaxTxSize natural -> [("maxTxsize", ppWord32 natural)]
-  MaxBHSize natural -> [("maxBHsize", ppWord16 natural)]
-  KeyDeposit coin -> [("keydeposit", pcCoin coin)]
-  PoolDeposit coin -> [("pooldeposit", pcCoin coin)]
-  EMax n -> [("emax", ppEpochInterval n)]
-  NOpt natural -> [("NOpt", ppNatural natural)]
-  A0 i -> [("A0", viaShow i)]
-  Rho u -> [("Rho", ppUnitInterval u)]
-  Tau u -> [("Tau", ppUnitInterval u)]
-  D u -> [("D", ppUnitInterval u)]
-  ExtraEntropy n -> [("extraEntropy", ppNonce n)]
-  ProtocolVersion protVer -> [("ProtocolVersion", ppProtVer protVer)]
-  MinPoolCost coin -> [("minPoolCost", pcCoin coin)]
-  MinUTxOValue coin -> [("minUTxOValue", pcCoin coin)]
-  CoinPerUTxOWord (CoinPerWord c) -> [("coinPerUTxOWord", pcCoin c)]
-  CoinPerUTxOByte (CoinPerByte c) -> [("coinPerUTxOByte", pcCoin c)]
-  Costmdls _ -> [("costmodels", ppString "?")]
-  Prices prices -> [("prices", ppPrices prices)]
-  MaxTxExUnits e -> [("maxTxExUnits", pcExUnits e)]
-  MaxBlockExUnits e -> [("maxBlockExUnits", pcExUnits e)]
-  MaxValSize n -> [("maxValSize", ppNatural n)]
-  CollateralPercentage n -> [("Collateral%", ppNatural n)]
-  MaxCollateralInputs n -> [("maxCollateralInputs", ppNatural n)]
-  PoolVotingThreshold _ -> [("PoolVotingThresholds", ppString "?")]
-  DRepVotingThreshold _ -> [("DRepVotingThresholds", ppString "?")]
-  MinCommitteeSize n -> [("minCommitteeSize", ppNatural n)]
-  CommitteeTermLimit n -> [("committeeTermLimit", ppEpochInterval n)]
-  GovActionExpiration epochNo -> [("govActionExpire", ppEpochInterval epochNo)]
-  GovActionDeposit coin -> [("govActiondDeposit", pcCoin coin)]
-  DRepDeposit coin -> [("drepdeposit", pcCoin coin)]
-  DRepActivity epochNo -> [("drepActivity", ppEpochInterval epochNo)]
-
-pcPParams :: Proof era -> PParams era -> PDoc
-pcPParams proof pp = ppRecord ("TxBody " <> pack (show proof)) pairs
-  where
-    fields = abstractPParams proof pp
-    pairs = concatMap pcPParamsField fields
 
 pcDRepPulser :: DRepPulser era Identity (RatifyState era) -> PDoc
 pcDRepPulser x =
@@ -2253,3 +3075,75 @@ pcDRepPulser x =
 
 summaryMapCompact :: Map a (CompactForm Coin) -> PDoc
 summaryMapCompact x = ppString ("Count " ++ show (Map.size x) ++ ", Total " ++ show (Map.foldl' (<>) mempty x))
+
+-- ========================
+
+pcConwayGovCertEnv :: forall era. Reflect era => ConwayGovCertEnv era -> PDoc
+pcConwayGovCertEnv (ConwayGovCertEnv pp ce) = ppSexp "ConwayGovCertEnv" [pcPParams @era reify pp, ppEpochNo ce]
+
+instance Reflect era => PrettyA (ConwayGovCertEnv era) where
+  prettyA = pcConwayGovCertEnv
+
+pcPoolEnv :: Reflect era => PoolEnv era -> PDoc
+pcPoolEnv (PoolEnv sn pp) = ppSexp "PoolEnv" [pcSlotNo sn, pcPParams reify pp]
+
+instance forall era. Reflect era => PrettyA (PoolEnv era) where
+  prettyA = pcPoolEnv
+
+pcEnactSignal :: EnactSignal era -> PDoc
+pcEnactSignal EnactSignal {..} =
+  ppRecord
+    "EnactSignal"
+    [ ("Gov Action Id", pcGovActionId esGovActionId)
+    , ("Gov Action", pcGovAction esGovAction)
+    ]
+
+instance PrettyA (EnactSignal era) where
+  prettyA = pcEnactSignal
+
+pcRatifySignal :: RatifySignal era -> PDoc
+pcRatifySignal (RatifySignal s) = ppStrictSeq pcGovActionState s
+
+instance PrettyA (RatifySignal era) where
+  prettyA = pcRatifySignal
+
+pcRatifyEnv :: RatifyEnv era -> PDoc
+pcRatifyEnv rs@(RatifyEnv {}) =
+  let RatifyEnv {..} = rs
+   in ppRecord
+        "RatifyEnv"
+        [ ("StakeDistr", ppMap pcCredential (pcCoin . fromCompact) reStakeDistr)
+        , ("StakePoolDistr", pcPoolDistr reStakePoolDistr)
+        , ("DRepDistr", ppMap pcDRep (pcCoin . fromCompact) reDRepDistr)
+        , ("DRepState", ppMap pcCredential pcDRepState reDRepState)
+        , ("CurrentEpoch", ppEpochNo reCurrentEpoch)
+        , ("CommitteeState", pcCommitteeState reCommitteeState)
+        ]
+
+instance PrettyA (RatifyEnv era) where
+  prettyA = pcRatifyEnv
+
+pcGovRuleState :: GovRuleState era -> PDoc
+pcGovRuleState grs@(GovRuleState _ _) =
+  let GovRuleState {..} = grs
+   in ppRecord
+        "GovRuleState"
+        [ ("grsPrevGovActionIdsChildren", pcPrevGovActionIdsChildren grsPrevGovActionIdsChildren)
+        , ("grsProposals", pcProposals grsProposals)
+        ]
+
+instance PrettyA (GovRuleState era) where
+  prettyA = pcGovRuleState
+
+pcGovEnv :: Reflect era => GovEnv era -> PDoc
+pcGovEnv GovEnv {..} =
+  ppRecord
+    "GovEnv"
+    [ ("TxId", pcTxId geTxId)
+    , ("Epoch", ppEpochNo geEpoch)
+    , ("PParams", pcPParams reify gePParams)
+    , ("PrevGovActionId", pcPrevGovActionIds gePrevGovActionIds)
+    ]
+
+instance Reflect era => PrettyA (GovEnv era) where
+  prettyA = pcGovEnv

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyTest.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyTest.hs
@@ -1,13 +1,14 @@
-module Test.Cardano.Ledger.Shelley.Pretty (testwidth, prettyTest) where
+module Test.Cardano.Ledger.Generic.PrettyTest (testwidth, prettyTest) where
 
 import Cardano.Ledger.Core (Tx, TxBody)
-import Cardano.Ledger.Pretty
 import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState)
 import Cardano.Ledger.UTxO (UTxO)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Prettyprinter.Util (putDocW)
+import Test.Cardano.Ledger.Generic.PrettyCore
+import Test.Cardano.Ledger.Generic.Proof (Evidence (Standard), Proof (Shelley))
 import Test.Cardano.Ledger.Shelley.Arbitrary ()
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.Tasty
@@ -49,8 +50,10 @@ prettyTest :: TestTree
 prettyTest =
   testGroup
     "Pretty printer tests"
-    [ testPP "UTxO" ppUTxO utxo
-    , testPP "TxBody" ppTxBody txbody
-    , testPP "Tx" ppTx tx
-    , testPP "LedgerState" ppLedgerState ls
+    [ testPP "UTxO" (pcUTxO proof) utxo
+    , testPP "TxBody" (pcTxBody proof) txbody
+    , testPP "Tx" (pcTx proof) tx
+    , testPP "LedgerState" (pcLedgerState proof) ls
     ]
+  where
+    proof = Shelley Standard

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..), IsValid (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
-import Cardano.Ledger.Pretty (PrettyA (..), ppList)
 import Cardano.Ledger.Shelley.LedgerState (
   AccountState (..),
   EpochState (..),
@@ -59,7 +58,7 @@ import Test.Cardano.Ledger.Generic.GenState (
  )
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockChainState (..))
 import Test.Cardano.Ledger.Generic.ModelState
-import Test.Cardano.Ledger.Generic.PrettyCore (PrettyC (..), pcLedgerState, pcTx)
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..), pcLedgerState, pcTx, ppList)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 import Test.Cardano.Ledger.Generic.Trace (Gen1, forEachEpochTrace, testPropMax, testTraces, traceProp)
 import Test.Cardano.Ledger.Generic.TxGen (
@@ -392,14 +391,14 @@ makeGen :: Reflect era => Proof era -> (Proof era -> GenRS era b) -> Gen b
 makeGen proof computeWith = fst <$> runGenRS proof def (computeWith proof)
 
 runTest ::
-  (Reflect era, PrettyC a era) =>
+  (Reflect era, PrettyA a) =>
   (Proof era -> GenRS era a) ->
   (a -> IO ()) ->
   Proof era ->
   IO ()
 runTest computeWith action proof = do
   ans <- generate (makeGen proof computeWith)
-  print (prettyC proof ans)
+  print (prettyA ans)
   action ans
 
 main2 :: IO ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -30,9 +30,6 @@ import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Genesis))
 import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
-import Cardano.Ledger.Pretty
-import Cardano.Ledger.Pretty.Alonzo (ppRdmrPtr)
-import Cardano.Ledger.Pretty.Mary (ppValidityInterval)
 import Cardano.Ledger.SafeHash (SafeToHash)
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTxError)
 import Cardano.Ledger.Shelley.BlockChain (ShelleyTxSeq (..))
@@ -396,7 +393,7 @@ sameTxWits proof@(Conway _) x y = sameAlonzoTxWits proof x y
 -- Comparing TxBody for Sameness
 
 sameShelleyTxBody ::
-  (Reflect era, PrettyA (TxCert era)) =>
+  Reflect era =>
   Proof era ->
   ShelleyTxBody era ->
   ShelleyTxBody era ->
@@ -404,16 +401,16 @@ sameShelleyTxBody ::
 sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Withdrawals w1) f1 s1 pu1 d1) (ShelleyTxBody i2 o2 c2 (Withdrawals w2) f2 s2 pu2 d2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
   , ("Outputs", eqVia (ppList (pcTxOut proof) . toList) o1 o2)
-  , ("TxCert", eqVia (ppList prettyA . toList) c1 c2)
+  , ("TxCert", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
   , ("WDRL", eqVia (ppMap pcRewardAcnt pcCoin) w1 w2)
   , ("Fee", eqVia pcCoin f1 f2)
-  , ("TimeToLive", eqVia ppSlotNo s1 s2)
+  , ("TimeToLive", eqVia pcSlotNo s1 s2)
   , ("PPupdate", eqVia (\_ -> ppString "Update") pu1 pu2)
   , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
   ]
 
 sameAllegraTxBody ::
-  (Reflect era, PrettyA (TxCert era)) =>
+  Reflect era =>
   Proof era ->
   AllegraTxBody era ->
   AllegraTxBody era ->
@@ -421,7 +418,7 @@ sameAllegraTxBody ::
 sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1) (AllegraTxBody i2 o2 c2 (Withdrawals w2) f2 v2 pu2 d2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
   , ("Outputs", eqVia (ppList (pcTxOut proof) . toList) o1 o2)
-  , ("TxCert", eqVia (ppList prettyA . toList) c1 c2)
+  , ("TxCert", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
   , ("WDRL", eqVia (ppMap pcRewardAcnt pcCoin) w1 w2)
   , ("Fee", eqVia pcCoin f1 f2)
   , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
@@ -430,7 +427,7 @@ sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1) (
   ]
 
 sameMaryTxBody ::
-  (Reflect era, PrettyA (TxCert era)) =>
+  Reflect era =>
   Proof era ->
   MaryTxBody era ->
   MaryTxBody era ->
@@ -438,7 +435,7 @@ sameMaryTxBody ::
 sameMaryTxBody proof (MaryTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1 m1) (MaryTxBody i2 o2 c2 (Withdrawals w2) f2 v2 pu2 d2 m2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
   , ("Outputs", eqVia (ppList (pcTxOut proof) . toList) o1 o2)
-  , ("TxCert", eqVia (ppList prettyA . toList) c1 c2)
+  , ("TxCert", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
   , ("WDRL", eqVia (ppMap pcRewardAcnt pcCoin) w1 w2)
   , ("Fee", eqVia pcCoin f1 f2)
   , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
@@ -448,7 +445,7 @@ sameMaryTxBody proof (MaryTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1 m1) (Mar
   ]
 
 sameAlonzoTxBody ::
-  (Reflect era, PrettyA (TxCert era)) =>
+  Reflect era =>
   Proof era ->
   AlonzoTxBody era ->
   AlonzoTxBody era ->
@@ -460,7 +457,7 @@ sameAlonzoTxBody
     [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
     , ("Collateral", eqVia (ppSet pcTxIn) cl1 cl2)
     , ("Outputs", eqVia (ppList (pcTxOut proof) . toList) o1 o2)
-    , ("Certs", eqVia (ppList prettyA . toList) c1 c2)
+    , ("Certs", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
     , ("WDRL", eqVia (ppMap pcRewardAcnt pcCoin) w1 w2)
     , ("Fee", eqVia pcCoin f1 f2)
     , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
@@ -475,7 +472,6 @@ sameAlonzoTxBody
 sameBabbageTxBody ::
   ( Reflect era
   , BabbageEraTxBody era
-  , PrettyA (TxCert era)
   ) =>
   Proof era ->
   BabbageTxBody era ->
@@ -491,7 +487,7 @@ sameBabbageTxBody
     , ("Outputs", eqVia (ppList (pcTxOut proof . sizedValue) . toList) o1 o2)
     , ("ColReturn", eqVia (ppStrictMaybe (pcTxOut proof . sizedValue)) cr1 cr2)
     , ("TotalCol", eqVia (ppStrictMaybe pcCoin) tc1 tc2)
-    , ("Certs", eqVia (ppList prettyA . toList) c1 c2)
+    , ("Certs", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
     , ("WDRL", eqVia (ppMap pcRewardAcnt pcCoin) w1 w2)
     , ("Fee", eqVia pcCoin f1 f2)
     , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
@@ -505,7 +501,6 @@ sameBabbageTxBody
 
 sameConwayTxBody ::
   ( ConwayEraTxBody era
-  , PrettyA (PParamsUpdate era)
   , Reflect era
   ) =>
   Proof era ->
@@ -531,10 +526,16 @@ sameConwayTxBody
     , ("ScriptIntegrityHash", eqVia (ppStrictMaybe (trim . ppSafeHash)) s1 s2)
     , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
     , ("NetworkId", eqVia (ppStrictMaybe pcNetwork) n1 n2)
-    , ("VotingProcedures", eqVia prettyA (unVotingProcedures vp1) (unVotingProcedures vp2))
-    , ("ProposalProcedures", eqVia (ppOSet prettyA) pp1 pp2)
-    , ("CurrentTreasuryValue", eqVia (ppStrictMaybe prettyA) ctv1 ctv2)
-    , ("TreasuryDonation", eqVia prettyA td1 td2)
+    ,
+      ( "VotingProcedures"
+      , eqVia
+          (ppMap pcVoter (ppMap pcGovActionId pcVotingProcedure))
+          (unVotingProcedures vp1)
+          (unVotingProcedures vp2)
+      )
+    , ("ProposalProcedures", eqVia (ppOSet pcProposalProcedure) pp1 pp2)
+    , ("CurrentTreasuryValue", eqVia (ppStrictMaybe pcCoin) ctv1 ctv2)
+    , ("TreasuryDonation", eqVia pcCoin td1 td2)
     ]
 
 sameTxBody :: Reflect era => Proof era -> TxBody era -> TxBody era -> [(String, Maybe PDoc)]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -26,19 +26,6 @@ import Cardano.Ledger.BaseTypes (BlocksMade (..), Globals)
 import Cardano.Ledger.EpochBoundary (SnapShots (..), calculatePoolDistr)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
-import Cardano.Ledger.Pretty (
-  PDoc,
-  PrettyA (..),
-  ppInt,
-  ppList,
-  ppMap,
-  ppRecord,
-  ppSafeHash,
-  ppSet,
-  ppSlotNo,
-  ppString,
-  ppWord64,
- )
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -117,14 +104,25 @@ import Test.Cardano.Ledger.Generic.GenState (
 import Test.Cardano.Ledger.Generic.MockChain
 import Test.Cardano.Ledger.Generic.ModelState (MUtxo, stashedAVVMAddressesZero)
 import Test.Cardano.Ledger.Generic.PrettyCore (
+  PDoc,
+  PrettyA (..),
   pcCoin,
   pcCredential,
   pcKeyHash,
   pcPoolParams,
   pcScript,
   pcScriptHash,
+  pcSlotNo,
   pcTxBodyField,
   pcTxIn,
+  ppInt,
+  ppList,
+  ppMap,
+  ppRecord,
+  ppSafeHash,
+  ppSet,
+  ppString,
+  ppWord64,
   scriptSummary,
  )
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
@@ -635,7 +633,7 @@ main3 = showVector pretty
     pretty :: Proof era -> [Tx era] -> SlotNo -> PDoc
     pretty (Babbage Mock) xs slot =
       vsep
-        [ ppSlotNo slot
+        [ pcSlotNo slot
         , vsep (map (ppList prettyA . Fold.toList . certs' . body) xs)
         ]
     pretty p _ _ = ppString ("main3 does not work in era " ++ show p)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -47,8 +47,6 @@ import Cardano.Ledger.Keys (
   coerceKeyRole,
  )
 import Cardano.Ledger.Plutus.Data (Data, Datum (..), dataToBinaryData, hashData)
-import Cardano.Ledger.Pretty (PrettyA (..), ppRecord)
-import Cardano.Ledger.Pretty.Babbage ()
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.API (
   Addr (..),
@@ -134,6 +132,7 @@ import Test.Cardano.Ledger.Generic.ModelState (
   ModelNewEpochState (..),
   UtxoEntry,
  )
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..), ppRecord)
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
 import Test.Cardano.Ledger.Generic.Updaters hiding (first)
 import Test.Cardano.Ledger.Shelley.Generator.Core (genNatural)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -31,7 +31,6 @@ import qualified Cardano.Ledger.Crypto as CC (Crypto (HASH))
 import Cardano.Ledger.Keys
 import Cardano.Ledger.PoolDistr
 import Cardano.Ledger.PoolParams
-import Cardano.Ledger.Pretty
 import Cardano.Ledger.Shelley.Rules hiding (epochNo, slotNo)
 import Cardano.Ledger.TxIn (TxId (..))
 import qualified Cardano.Ledger.UMap as UM
@@ -63,6 +62,7 @@ import Test.Cardano.Ledger.Constrained.Tests
 import Test.Cardano.Ledger.Constrained.TypeRep
 import Test.Cardano.Ledger.Constrained.Vars hiding (delegations, drepDeposit, rewards)
 import qualified Test.Cardano.Ledger.Constrained.Vars as Vars
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..), ppList, ppString, withEraPParams)
 import Test.Cardano.Ledger.Generic.Proof
 import Test.Cardano.Ledger.Shelley.Utils
 import Test.QuickCheck

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -22,6 +22,7 @@ import qualified Test.Cardano.Ledger.Examples.AlonzoInvalidTxUTXOW as AlonzoInva
 import qualified Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW as AlonzoValidTxUTXOW (tests)
 import Test.Cardano.Ledger.Examples.BabbageFeatures (babbageFeatures)
 import Test.Cardano.Ledger.Generic.AggPropTests (aggTests, depositTests)
+import qualified Test.Cardano.Ledger.Generic.PrettyTest as Pretty
 import Test.Cardano.Ledger.Generic.Properties (genericProperties)
 import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 import qualified Test.Cardano.Ledger.STS as ConstraintSTS
@@ -38,7 +39,8 @@ main = do
 
 defaultTests :: [TestTree]
 defaultTests =
-  [ allSpecTests
+  [ Pretty.prettyTest
+  , allSpecTests
   , allExampleTests
   , conwayTrace
   , predsTests


### PR DESCRIPTION
First step in the process of removing cardano-ledger-pretty
1) removed all reference to Cardano.Ledger.Pretty in Test.Cardano.Ledger
2) did this by moving functionality of Cardano.Ledger.Pretty  to Test.Cardano.Ledger.Generic.PrettyCore
3) Added new pretty printers for Predicate failures

Fixes #3974
Fixes #3926

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
