### PR TITLE
Add policy hash protection to `TreasuryWithdrawals` and `ParameterChange`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.12.0.0
 
+* Add a policy field to `ParameterChange` and `TreasuryWithdrawals` constructors
+  of `GovAction`
+* Add `InvalidPolicyHash` to `ConwayGovPredFailure`
 * Add `ToJSON` instance for `ConwayContextError`, `ConwayTxCert`, `ConwayDelegCert`,
   `Delegatee` and `ConwayGovCert`
 * Add `forceDRepPulsingState`
@@ -44,6 +47,7 @@
 
 ### `testlib`
 
+* Add `submitTreasuryWithdrawals`
 * Remove `Test.Cardano.Ledger.Conway.PParamsSpec` and replace the unit test it contained
   with a new property test in `Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec`
 

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -101,11 +101,13 @@ gov_action =
   // info_action
   ]
 
-parameter_change_action = (0, gov_action_id / null, protocol_param_update)
+policy_hash = scripthash
+
+parameter_change_action = (0, gov_action_id / null, protocol_param_update, policy_hash / null)
 
 hard_fork_initiation_action = (1, gov_action_id / null, [protocol_version])
 
-treasury_withdrawals_action = (2, { reward_account => coin })
+treasury_withdrawals_action = (2, { reward_account => coin }, policy_hash / null)
 
 no_confidence = (3, gov_action_id / null)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -839,7 +839,7 @@ votingDRepThresholdInternal pp isElectedCommittee action =
               else dvtCommitteeNoConfidence
         NewConstitution {} -> VotingThreshold dvtUpdateToConstitution
         HardForkInitiation {} -> VotingThreshold dvtHardForkInitiation
-        ParameterChange _ ppu -> VotingThreshold $ pparamsUpdateThreshold pp ppu
+        ParameterChange _ ppu _ -> VotingThreshold $ pparamsUpdateThreshold pp ppu
         TreasuryWithdrawals {} -> VotingThreshold dvtTreasuryWithdrawal
         InfoAction {} -> NoVotingThreshold
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -332,11 +332,11 @@ addToEnactedPrevGovActionIdsChildren ::
   Maybe (PrevGovActionIdsChildren era)
 addToEnactedPrevGovActionIdsChildren gas PrevGovActionIds {..} children =
   case gas ^. gasActionL of
-    ParameterChange prev _ ->
+    ParameterChange prev _ _ ->
       guard (pgaPParamUpdate == prev) $> update pgacPParamUpdateL
     HardForkInitiation prev _ ->
       guard (pgaHardFork == prev) $> update pgacHardForkL
-    TreasuryWithdrawals _ -> Just children
+    TreasuryWithdrawals _ _ -> Just children
     NoConfidence prev ->
       guard (pgaCommittee == prev) $> update pgacCommitteeL
     UpdateCommittee prev _ _ _ ->
@@ -362,7 +362,7 @@ proposalsAddChild ::
   Maybe (Proposals era)
 proposalsAddChild gas proposals@(Proposals omap) =
   case gas ^. gasActionL of
-    ParameterChange prev _ ->
+    ParameterChange prev _ _ ->
       updateProposals prev $ \case
         ParameterChange {} -> True
         _ -> False
@@ -370,7 +370,7 @@ proposalsAddChild gas proposals@(Proposals omap) =
       updateProposals prev $ \case
         HardForkInitiation {} -> True
         _ -> False
-    TreasuryWithdrawals _ -> Just proposals
+    TreasuryWithdrawals _ _ -> Just proposals
     NoConfidence prev ->
       updateProposals prev $ \case
         NoConfidence {} -> True

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
@@ -67,7 +67,7 @@ enactmentTransition = do
   TRC ((), st, EnactSignal govActionId act) <- judgmentContext
 
   case act of
-    ParameterChange _ ppup ->
+    ParameterChange _ ppup _ ->
       pure $
         st
           & ensCurPParamsL %~ (`applyPPUpdates` ppup)
@@ -77,7 +77,7 @@ enactmentTransition = do
         st
           & ensProtVerL .~ pv
           & ensPrevHardForkL .~ SJust (PrevGovActionId govActionId)
-    TreasuryWithdrawals wdrls -> do
+    TreasuryWithdrawals wdrls _ -> do
       let wdrlsAmount = fold wdrls
           wdrlsNoNetworkId = Map.mapKeys getRwdCred wdrls
       pure

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -40,6 +40,7 @@ import Cardano.Ledger.Conway.Governance (
   ConwayGovState (..),
   GovProcedures (..),
   enactStateGovStateL,
+  ensConstitutionL,
   ensPrevGovActionIdsChildrenL,
   ensPrevGovActionIdsL,
   proposalsGovStateL,
@@ -300,6 +301,7 @@ ledgerTransition = do
                   currentEpoch
                   pp
                   (utxoState ^. utxosGovStateL . enactStateGovStateL . ensPrevGovActionIdsL)
+                  (utxoState ^. utxosGovStateL . enactStateGovStateL . ensConstitutionL . constitutionScriptL)
               , GovRuleState
                   (utxoState ^. utxosGovStateL . proposalsGovStateL)
                   (utxoState ^. utxosGovStateL . enactStateGovStateL . ensPrevGovActionIdsChildrenL)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -288,7 +288,7 @@ reorderActions :: StrictSeq (GovActionState era) -> StrictSeq (GovActionState er
 reorderActions = Seq.fromList . sortOn (actionPriority . gasAction) . toList
 
 withdrawalCanWithdraw :: GovAction era -> Coin -> Bool
-withdrawalCanWithdraw (TreasuryWithdrawals m) treasury =
+withdrawalCanWithdraw (TreasuryWithdrawals m _) treasury =
   Map.foldr' (<+>) zero m <= treasury
 withdrawalCanWithdraw _ _ = True
 
@@ -357,9 +357,9 @@ ratifyTransition = do
 --   does match the last one of the same purpose that was enacted.
 prevActionAsExpected :: forall era. GovAction era -> PrevGovActionIds era -> Bool
 prevActionAsExpected = \case
-  ParameterChange prev _ -> (prev ==) . pgaPParamUpdate
+  ParameterChange prev _ _ -> (prev ==) . pgaPParamUpdate
   HardForkInitiation prev _ -> (prev ==) . pgaHardFork
-  TreasuryWithdrawals _ -> const True
+  TreasuryWithdrawals _ _ -> const True
   NoConfidence prev -> (prev ==) . pgaCommittee
   UpdateCommittee prev _ _ _ -> (prev ==) . pgaCommittee
   NewConstitution prev _ -> (prev ==) . pgaConstitution
@@ -370,7 +370,7 @@ getSiblings :: PrevGovActionIdsChildren era -> GovAction era -> Set.Set (GovActi
 getSiblings pgac = \case
   ParameterChange {} -> Set.map unPrevGovActionId (pgac ^. pgacPParamUpdateL)
   HardForkInitiation {} -> Set.map unPrevGovActionId (pgac ^. pgacHardForkL)
-  TreasuryWithdrawals _ -> mempty
+  TreasuryWithdrawals _ _ -> mempty
   NoConfidence {} -> Set.map unPrevGovActionId (pgac ^. pgacCommitteeL)
   UpdateCommittee {} -> Set.map unPrevGovActionId (pgac ^. pgacCommitteeL)
   NewConstitution {} -> Set.map unPrevGovActionId (pgac ^. pgacConstitutionL)
@@ -384,7 +384,7 @@ updatePrevGovActionIdsChildren gas pgac =
   case gas ^. gasActionL of
     ParameterChange {} -> pgac & pgacPParamUpdateL .~ Set.map coerce children
     HardForkInitiation {} -> pgac & pgacHardForkL .~ Set.map coerce children
-    TreasuryWithdrawals _ -> pgac
+    TreasuryWithdrawals _ _ -> pgac
     NoConfidence {} -> pgac & pgacCommitteeL .~ Set.map coerce children
     UpdateCommittee {} -> pgac & pgacCommitteeL .~ Set.map coerce children
     NewConstitution {} -> pgac & pgacConstitutionL .~ Set.map coerce children

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -228,13 +228,13 @@ instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovActionState e
   arbitrary = genGovActionStateFromAction =<< arbitrary
 
 genParameterChange :: (Era era, Arbitrary (PParamsUpdate era)) => Gen (GovAction era)
-genParameterChange = ParameterChange <$> arbitrary <*> arbitrary
+genParameterChange = ParameterChange <$> arbitrary <*> arbitrary <*> arbitrary
 
 genHardForkInitiation :: Era era => Gen (GovAction era)
 genHardForkInitiation = HardForkInitiation <$> arbitrary <*> arbitrary
 
 genTreasuryWithdrawals :: Era era => Gen (GovAction era)
-genTreasuryWithdrawals = TreasuryWithdrawals <$> arbitrary
+genTreasuryWithdrawals = TreasuryWithdrawals <$> arbitrary <*> arbitrary
 
 genNoConfidence :: Era era => Gen (GovAction era)
 genNoConfidence = NoConfidence <$> arbitrary
@@ -334,6 +334,7 @@ instance (Era era, Arbitrary (PParamsHKD Identity era)) => Arbitrary (GovEnv era
   arbitrary =
     GovEnv
       <$> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -24,8 +24,8 @@ spec =
   describe "ENACT" $ do
     it "TreasuryWithdrawal" $ do
       rewardAcount1 <- registerRewardAccount
-      let govAction = TreasuryWithdrawals [(rewardAcount1, Coin 666)]
-      govActionId <- submitGovAction govAction
+      govActionId <- submitTreasuryWithdrawals [(rewardAcount1, Coin 666)]
+      GovActionState {gasAction = govAction} <- getGovActionState govActionId
       enactStateInit <- use $ impNESL . newEpochStateGovStateL . cgEnactStateL
       let signal =
             EnactSignal
@@ -44,8 +44,8 @@ spec =
             [ (rewardAcount1, Coin 111)
             , (rewardAcount2, Coin 222)
             ]
-          govAction' = TreasuryWithdrawals withdrawals'
-      govActionId' <- submitGovAction govAction'
+      govActionId' <- submitTreasuryWithdrawals withdrawals'
+      GovActionState {gasAction = govAction'} <- getGovActionState govActionId'
       let signal' =
             EnactSignal
               { esGovActionId = govActionId'

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -257,11 +257,12 @@ instance PrettyA (PrevGovActionIdsChildren era) where
   prettyA = viaShow
 
 instance PrettyA (PParamsUpdate era) => PrettyA (GovAction era) where
-  prettyA (ParameterChange pgaid ppup) =
+  prettyA (ParameterChange pgaid ppup policy) =
     ppRecord
       "ParameterChange"
       [ ("previous governance action id", prettyA pgaid)
       , ("protocol parameters update", prettyA ppup)
+      , ("policy hash", prettyA policy)
       ]
   prettyA (HardForkInitiation pgaid pv) =
     ppRecord
@@ -269,10 +270,12 @@ instance PrettyA (PParamsUpdate era) => PrettyA (GovAction era) where
       [ ("previous governance action id", prettyA pgaid)
       , ("protocol version", prettyA pv)
       ]
-  prettyA (TreasuryWithdrawals ws) =
+  prettyA (TreasuryWithdrawals ws policy) =
     ppRecord
       "TreasuryWithdrawals"
-      [("withdrawals map", prettyA ws)]
+      [ ("withdrawals map", prettyA ws)
+      , ("policy hash", prettyA policy)
+      ]
   prettyA (NoConfidence pgaid) =
     ppRecord "NoConfidence" [("previous governance action id", prettyA pgaid)]
   prettyA (UpdateCommittee pgaid toRemove toAdd qrm) =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -307,23 +307,23 @@ mainGov :: IO ()
 mainGov = demoGov (Conway Standard) Interactive
 
 setActionId :: GovAction era -> Maybe (GovActionId (EraCrypto era)) -> GovAction era
-setActionId (ParameterChange _ pp) x = ParameterChange (liftId x) pp
+setActionId (ParameterChange _ pp p) x = ParameterChange (liftId x) pp p
 setActionId (HardForkInitiation _ y) x = HardForkInitiation (liftId x) y
 setActionId (UpdateCommittee _ w y z) x = UpdateCommittee (liftId x) w y z
 setActionId (NewConstitution _ y) x = NewConstitution (liftId x) y
 setActionId InfoAction _ = InfoAction
 setActionId (NoConfidence _) x = NoConfidence (liftId x)
-setActionId x@(TreasuryWithdrawals _) _ = x
+setActionId x@(TreasuryWithdrawals _ _) _ = x
 
 actionIdL :: Lens' (GovAction era) (Maybe (GovActionId (EraCrypto era)))
 actionIdL = lens getter setter
   where
-    getter (ParameterChange x _) = dropId x
+    getter (ParameterChange x _ _) = dropId x
     getter (HardForkInitiation x _) = dropId x
     getter (UpdateCommittee x _ _ _) = dropId x
     getter (NewConstitution x _) = dropId x
     getter (NoConfidence x) = dropId x
-    getter (TreasuryWithdrawals _) = Nothing
+    getter (TreasuryWithdrawals _ _) = Nothing
     getter InfoAction = Nothing
     setter ga mid = setActionId ga mid
 
@@ -360,7 +360,7 @@ genGovActionStates proof gaids = do
 
 genGovAction :: forall era. Era era => Proof era -> GovActionPurpose -> Maybe (GovActionId (EraCrypto era)) -> Gen (GovAction era)
 genGovAction proof purpose gaid = case purpose of
-  PParamUpdatePurpose -> ParameterChange (liftId gaid) <$> (unPParamsUpdate <$> genPParamsUpdate proof)
+  PParamUpdatePurpose -> ParameterChange (liftId gaid) <$> (unPParamsUpdate <$> genPParamsUpdate proof) <*> arbitrary
   HardForkPurpose -> HardForkInitiation (liftId gaid) <$> arbitrary
   CommitteePurpose ->
     frequency

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1331,6 +1331,8 @@ ppConwayGovPredFailure x = case x of
     ppSexp "VotingOnExpiredGovAction" [ppMap pcGovActionId pcVoter m]
   ProposalCantFollow s1 p1 p2 ->
     ppSexp "ProposalCantFollow" [ppStrictMaybe pcPrevGovActionId s1, ppProtVer p1, ppProtVer p2]
+  InvalidPolicyHash a b ->
+    ppSexp "InvalidPolicyHash" [ppStrictMaybe prettyA a, ppStrictMaybe prettyA b]
 
 instance PrettyA (ConwayGovPredFailure era) where
   prettyA = ppConwayGovPredFailure
@@ -2650,11 +2652,12 @@ instance PrettyA (Committee era) where
 
 pcGovAction :: GovAction era -> PDoc
 pcGovAction x = case x of
-  (ParameterChange pgaid _ppup) ->
+  (ParameterChange pgaid _ppup policy) ->
     ppRecord
       "ParameterChange"
       [ ("PrevGovActId", ppStrictMaybe pcPrevGovActionId pgaid)
       , ("PPUpdate", ppString "(PParamsUpdate ...)")
+      , ("Policy", ppStrictMaybe prettyA policy)
       ]
   (HardForkInitiation pgaid pv) ->
     ppRecord
@@ -2662,10 +2665,12 @@ pcGovAction x = case x of
       [ ("PrevGovActId", ppStrictMaybe pcPrevGovActionId pgaid)
       , ("ProtVer", ppString (showProtver pv))
       ]
-  (TreasuryWithdrawals ws) ->
-    ppSexp
+  (TreasuryWithdrawals ws policy) ->
+    ppRecord
       "TreasuryWithdrawals"
-      [ppMap pcRewardAcnt pcCoin ws]
+      [ ("Withdrawals", ppMap pcRewardAcnt pcCoin ws)
+      , ("Policy", ppStrictMaybe prettyA policy)
+      ]
   (NoConfidence pgaid) ->
     ppRecord "NoConfidence" [("PrevGovActId", ppStrictMaybe pcPrevGovActionId pgaid)]
   (UpdateCommittee pgaid toRemove toAdd quor) ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -435,9 +435,10 @@ ratifyStateCheckPreds p = enactStateCheckPreds p
 
 govEnvT :: forall era. Reflect era => PropEnv era -> RootTarget era (GovEnv era) (GovEnv era)
 govEnvT PropEnv {..} =
-  Invert "GovEnv" (typeRep @(GovEnv era)) (\txid pgovact -> GovEnv txid peEpochNo pePParams pgovact)
+  Invert "GovEnv" (typeRep @(GovEnv era)) (\txid pgovact policy -> GovEnv txid peEpochNo pePParams pgovact $ maybeToStrictMaybe policy)
     :$ Lensed txIdV (lens geTxId $ \ge x -> ge {geTxId = x})
     :$ Shift prevGovActionIdsT (lens gePrevGovActionIds $ \ge x -> ge {gePrevGovActionIds = x})
+    :$ Lensed gaPolicy (lens (strictMaybeToMaybe . gePPolicy) $ \ge x -> ge {gePPolicy = maybeToStrictMaybe x})
 
 txIdV :: Reflect era => Term era (TxId (EraCrypto era))
 txIdV = Var $ V "txId" TxIdR No


### PR DESCRIPTION
# Description

Adds hash protection to `TreasuryWithdrawals` and `ParameterChange`. The hashes are checked in the GOV rule, and if a policy script is present, then we require a witness for it in the UTXOW rule.

The tests rely on #3960

resolves #3957

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
