### PR TITLE
Added GetAccountStateQuery

### DIFF
--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `queryAccountState`
 * Add `estimateMinFeeTx`
 * Add `registerInitialDReps`, `registerDRepDelegs`
 * Stop exporting `CostModels` internal representation

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Ledger.Api.State.Query (
@@ -28,6 +27,9 @@ module Cardano.Ledger.Api.State.Query (
 
   -- * @GetCommitteeMembersState@
   queryCommitteeMembersState,
+
+  -- * @GetAccountState@
+  queryAccountState,
   CommitteeMemberState (..),
   CommitteeMembersState (..),
   HotCredAuthStatus (..),
@@ -73,6 +75,7 @@ import Data.Maybe (isJust)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (&), (<&>), (^.))
+import Lens.Micro.Extras (view)
 
 -- | Filter out stake pool delegations and rewards for a set of stake credentials
 filterStakePoolDelegsAndRewards ::
@@ -243,3 +246,8 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes = do
       , csQuorum = comQuorum
       , csEpochNo = currentEpoch
       }
+
+queryAccountState ::
+  NewEpochState era ->
+  AccountState
+queryAccountState = view $ nesEsL . esAccountStateL


### PR DESCRIPTION
# Description

Adds `GetAccountStateQuery` to the API.

resolves #3968 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
