### PR TITLE
Test proposals rewrite

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -115,6 +115,7 @@ library testlib
         Test.Cardano.Ledger.Conway.Imp.EnactSpec
         Test.Cardano.Ledger.Conway.Imp.GovSpec
         Test.Cardano.Ledger.Conway.Imp.UtxoSpec
+        Test.Cardano.Ledger.Conway.Proposals
         Test.Cardano.Ledger.Conway.TreeDiff
 
     visibility:       public
@@ -131,6 +132,7 @@ library testlib
         bytestring,
         cardano-data:testlib,
         containers,
+        deepseq,
         microlens,
         cardano-crypto-class,
         cardano-ledger-allegra:{cardano-ledger-allegra, testlib},

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -410,7 +410,11 @@ proposalsApplyEnactment enactedGass expiredGais props =
           )
         enactWithoutRoot =
           let (newOMap, removedActions) = OMap.extractKeys (Set.singleton gai) $ ps ^. pPropsL
-           in (ps & pPropsL .~ newOMap, removed `Map.union` removedActions)
+           in assert -- we want an AssertionFailure here for exhaustive property-testing
+                (not $ Map.null removedActions)
+                ( ps & pPropsL .~ newOMap
+                , removed `Map.union` removedActions
+                )
         enactFromRoot ::
           (forall f. Lens' (GovRelation f era) (f (GovPurposeId p era))) ->
           StrictMaybe (GovPurposeId p era) ->

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -14,6 +14,7 @@ import qualified Test.Cardano.Ledger.Conway.GenesisSpec as Genesis
 import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorder
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
 import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
+import qualified Test.Cardano.Ledger.Conway.Proposals as Proposals
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
@@ -21,6 +22,7 @@ main :: IO ()
 main =
   ledgerTestMain $
     describe "Conway" $ do
+      Proposals.spec
       Binary.spec
       Cddl.spec
       DRepRatify.spec

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GovActionReorderSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GovActionReorderSpec.hs
@@ -1,8 +1,32 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Test.Cardano.Ledger.Conway.GovActionReorderSpec (spec) where
 
+import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.Governance (GovActionState (..), actionPriority, reorderActions)
+import Data.Foldable (Foldable (..))
+import Data.List (sort)
+import qualified Data.Sequence.Strict as Seq
+import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary (ShuffledGovActionStates (..))
 
 spec :: Spec
-spec = pure ()
-
--- Bringing back tests in: https://github.com/IntersectMBO/cardano-ledger/pull/3981
+spec =
+  describe "Conway governance actions reordering" $ do
+    prop "preserves length when reordered" $
+      \(actions :: Seq.StrictSeq (GovActionState Conway)) ->
+        Seq.length actions `shouldBe` Seq.length (reorderActions @Conway actions)
+    prop "sorts by priority" $
+      \(actions :: Seq.StrictSeq (GovActionState Conway)) ->
+        sort (toList (actionPriority . gasAction @Conway <$> actions))
+          `shouldBe` toList (actionPriority . gasAction <$> reorderActions actions)
+    prop "same priority actions are not rearranged" $
+      \(a :: GovActionState Conway) (as :: Seq.StrictSeq (GovActionState Conway)) ->
+        let filterPrio b = actionPriority (gasAction a) == actionPriority (gasAction b)
+         in filter filterPrio (toList $ reorderActions @Conway (a Seq.:<| as))
+              `shouldBe` filter filterPrio (toList $ reorderActions (a Seq.:<| as))
+    prop "orders actions correctly with shuffles" $
+      \(ShuffledGovActionStates gass shuffledGass :: ShuffledGovActionStates Conway) -> do
+        reorderActions (Seq.fromList gass) `shouldBe` reorderActions (Seq.fromList shuffledGass)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -6,13 +6,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Test.Cardano.Ledger.Conway.Imp (
-  spec,
-) where
+module Test.Cardano.Ledger.Conway.Imp (spec) where
 
-import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Governance (ConwayGovState, GovState)
-import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure (..))
+import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure, ConwayLedgerPredFailure)
 import Cardano.Ledger.Core (EraRule)
 import Control.State.Transition.Extended (PredicateFailure)
 import Test.Cardano.Ledger.Common
@@ -26,7 +23,8 @@ spec ::
   forall era.
   ( ConwayEraImp era
   , GovState era ~ ConwayGovState era
-  , Inject (ConwayGovPredFailure era) (PredicateFailure (EraRule "LEDGER" era))
+  , PredicateFailure (EraRule "LEDGER" era) ~ ConwayLedgerPredFailure era
+  , PredicateFailure (EraRule "GOV" era) ~ ConwayGovPredFailure era
   ) =>
   Spec
 spec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -147,9 +147,7 @@ spec =
 
 treasuryWithdrawalExpectation ::
   forall era.
-  ( ConwayEraImp era
-  , GovState era ~ ConwayGovState era
-  ) =>
+  ConwayEraImp era =>
   [GovAction era] ->
   ImpTestM era ()
 treasuryWithdrawalExpectation extraWithdrawals = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Proposals.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Proposals.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cardano.Ledger.Conway.Proposals where
+
+import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Governance
+import Control.DeepSeq (force)
+import Control.Exception (AssertionFailed (..), evaluate)
+import Data.Either (isRight)
+import Data.Foldable (foldl', toList)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Sequence (fromList)
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Arbitrary (
+  ProposalsForEnactment (..),
+  ProposalsNewActions (..),
+ )
+
+spec :: Spec
+spec = do
+  describe "Proposals" $ do
+    context "Construction" $ do
+      prop "Adding new nodes keeps Proposals consistent" $
+        \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
+          let ps' =
+                foldl'
+                  (\p action -> fromMaybe (error "Unable to add action") $ proposalsAddAction action p)
+                  ps
+                  actions
+              actionsMap = foldl' (\accum gas -> Map.insert (gasId gas) gas accum) Map.empty actions
+           in actionsMap `shouldBe` (actionsMap `Map.intersection` proposalsActionsMap ps')
+    context "Removal" $ do
+      prop "Removing leaf nodes keeps Proposals consistent" $
+        \(ps :: Proposals Conway) -> do
+          let gais = Set.fromList $ toList $ SSeq.takeLast 4 $ proposalsIds ps
+              ps' = fst $ proposalsRemoveWithDescendants gais ps
+          proposalsSize ps' `shouldBe` proposalsSize ps - Set.size gais
+      prop "Removing root nodes keeps Proposals consistent" $
+        \(ps :: Proposals Conway) -> do
+          let gais = Set.fromList $ toList $ SSeq.take 4 $ proposalsIds ps
+              ps' = fst $ proposalsRemoveWithDescendants gais ps
+          proposalsSize ps' `shouldSatisfy` (<= proposalsSize ps)
+      prop "Removing non-member nodes throws an AssertionFailure" $
+        \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
+          (evaluate . force) (proposalsRemoveWithDescendants (Set.fromList $ gasId <$> actions) ps)
+            `shouldThrow` \AssertionFailed {} -> True
+    context "Enactment" $ do
+      prop "Adding votes preserves consistency" $
+        \(ProposalsForEnactment ps gass _ :: ProposalsForEnactment Conway, voter :: Voter era, vote :: Vote) -> do
+          case gass of
+            gas Seq.:<| _gass -> isRight . toGovRelationTreeEither $ proposalsAddVote voter vote (gasId gas) ps
+            _ -> True
+      prop "Enacting exhaustive lineages reduces Proposals to their roots" $
+        \(ProposalsForEnactment ps gass _ :: ProposalsForEnactment Conway) -> do
+          let toEnact = Set.fromList $ toList gass
+              (_ps', enactedRemoved, expiredRemoved) = proposalsApplyEnactment gass Set.empty ps
+          expiredRemoved `shouldSatisfy` Map.null
+          toEnact `shouldSatisfy` (`Set.isSubsetOf` Set.fromList (Map.elems enactedRemoved))
+      prop "Enacting non-member nodes throws an AssertionFailure" $
+        \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
+          (evaluate . force) (proposalsApplyEnactment (fromList actions) Set.empty ps)
+            `shouldThrow` \AssertionFailed {} -> True
+      prop "Expiring compliments of exhaustive lineages keeps proposals consistent" $
+        \(ProposalsForEnactment ps _ gais :: ProposalsForEnactment Conway) -> do
+          let (_ps', enactedRemoved, expiredRemoved) = proposalsApplyEnactment Seq.Empty gais ps
+          enactedRemoved `shouldSatisfy` Map.null
+          gais `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet expiredRemoved)
+      prop "Expiring non-member nodes throws an AssertionFailure" $
+        \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
+          (evaluate . force) (proposalsApplyEnactment Seq.Empty (Set.fromList $ gasId <$> actions) ps)
+            `shouldThrow` \AssertionFailed {} -> True
+      prop "Enacting and expiring exhaustive lineages reduces Proposals to their roots" $
+        \(ProposalsForEnactment ps toEnact toExpire :: ProposalsForEnactment Conway) -> do
+          let (ps', enactedRemoved, expiredRemoved) = proposalsApplyEnactment toEnact toExpire ps
+          Set.fromList (toList toEnact) `shouldSatisfy` (`Set.isSubsetOf` Set.fromList (Map.elems enactedRemoved))
+          Set.fromList (toList toExpire) `shouldSatisfy` (`Set.isSubsetOf` Map.keysSet expiredRemoved)
+          proposalsSize ps' `shouldBe` 0

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Cardano.Ledger.Shelley.Imp (
-  spec,
-) where
+module Test.Cardano.Ledger.Shelley.Imp (spec) where
 
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -268,6 +268,7 @@ class
       (DSIGN (EraCrypto era))
       (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
   , ToExpr (PredicateFailure (EraRule "LEDGER" era))
+  , ToExpr (PredicateFailure (EraRule "UTXOW" era))
   , EraUTxO era
   , ShelleyEraTxCert era
   , State (EraRule "LEDGER" era) ~ LedgerState era


### PR DESCRIPTION
# Description

Closes #3894 

## Pending
- [x] Get rid of the pattern synonyms to make sure `Conway` constraint is done away with and all tests are sufficiently polymorphic over `era`
- [x] Reduces duplication by comparing entire tree structures rather than individual proposals
- [x] Address any other review comments

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
