### PR TITLE
Added SPO voting thresholds for security relevant parameters

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### `testlib`
 
+* Added `ShelleyEraImp` constraint to `emptyAlonzoImpNES`
 * Rename `emptyAlonzoImpNES` to `initAlonzoImpNES`
 * Remove `Test.Cardano.Ledger.Alonzo.CostModel` in favor of `Test.Cardano.Ledger.Plutus`
 * Move `costModelParamsCount` to `Cardano.Ledger.Plutus.CostModels`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -13,9 +13,8 @@ import Cardano.Crypto.Hash (Hash)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppMaxValSizeL)
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Core (EraIndependentTxBody, EraTxOut)
+import Cardano.Ledger.Core (EraIndependentTxBody)
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState,
   StashedAVVMAddresses,
@@ -30,10 +29,9 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest
 
 initAlonzoImpNES ::
-  ( EraGov era
-  , EraTxOut era
-  , AlonzoEraPParams era
+  ( AlonzoEraPParams era
   , Default (StashedAVVMAddresses era)
+  , ShelleyEraImp era
   ) =>
   Coin ->
   NewEpochState era

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.12.0.0
 
+* Add `pvtPPSecurityGroup`
+* Add lenses:
+  * `pvtCommitteeNormalL`
+  * `pvtCommitteeNoConfidenceL`
+  * `pvtPPSecurityGroupL`
+  * `dvtCommitteeNoConfidenceL`
+* Add `PPGroups` and `StakePoolGroup`
+* Add `ToStakePoolGroup` typeclass
+* Add `DRepGroup` and `ToDRepGroup` typeclass
+* Modify `THKD` replacing `PPGroup` with `PPGroups`
 * Add `ConwayPlutusPurpose`
 * Add `unGovActionIx`
 * Add `foldlVotingProcedures`
@@ -50,6 +60,10 @@
 
 ### `testlib`
 
+* Add `setupPoolWithStake`
+* Add:
+  * `registerPool`
+  * `sendCoinTo` and `sendValueTo`
 * Add `submitProposal_`
 * Add `submitTreasuryWithdrawals`
 * Remove `Test.Cardano.Ledger.Conway.PParamsSpec` and replace the unit test it contained

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -413,6 +413,7 @@ pool_voting_thresholds =
   , unit_interval ; committee normal
   , unit_interval ; committee no confidence
   , unit_interval ; hard fork initiation
+  , unit_interval ; security relevant parameter voting threshold
   ]
 
 drep_voting_thresholds =

--- a/eras/conway/impl/test/data/conway-genesis.json
+++ b/eras/conway/impl/test/data/conway-genesis.json
@@ -3,7 +3,8 @@
     "committeeNormal": 0,
     "committeeNoConfidence": 0,
     "hardForkInitiation": 0,
-    "motionNoConfidence": 0
+    "motionNoConfidence": 0,
+    "ppSecurityGroup": 0
   },
   "dRepVotingThresholds": {
     "motionNoConfidence": 0,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -579,6 +579,7 @@ instance Arbitrary PoolVotingThresholds where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary DRepVotingThresholds where
   arbitrary =

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -47,6 +47,10 @@
 
 ### `testlib`
 
+* Add `freshKeyHashVRF`
+* Add `registerPool`
+* Add `sendValueTo` and `sendCoinTo`
+* Add `dispenseIndex`
 * Add `fixupTx`, `impAddNativeScript` and `logToExpr`
 * Remove `mkTxWits`
 * Add `impNESG`, `impLastTickG`, `impKeyPairsG` and `impScriptsG`. Stop exporting

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -35,7 +35,6 @@ import Cardano.Ledger.Conway.PParams (
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (KeyHashObj))
 import Cardano.Ledger.Keys (
-  KeyHash,
   KeyRole (..),
  )
 import Cardano.Ledger.Shelley.LedgerState
@@ -60,14 +59,14 @@ spec =
   it "Committee queries" $ do
     setPParams
     drep <- setupSingleDRep
-    c1 <- freshKeyHash
-    c2 <- freshKeyHash
-    c3 <- freshKeyHash
-    c4 <- freshKeyHash
-    c5 <- freshKeyHash
-    c6 <- freshKeyHash
-    c7 <- freshKeyHash
-    c8 <- freshKeyHash
+    c1 <- KeyHashObj <$> freshKeyHash
+    c2 <- KeyHashObj <$> freshKeyHash
+    c3 <- KeyHashObj <$> freshKeyHash
+    c4 <- KeyHashObj <$> freshKeyHash
+    c5 <- KeyHashObj <$> freshKeyHash
+    c6 <- KeyHashObj <$> freshKeyHash
+    c7 <- KeyHashObj <$> freshKeyHash
+    c8 <- KeyHashObj <$> freshKeyHash
     let newMembers =
           [ (c1, EpochNo 12)
           , (c2, EpochNo 2)
@@ -98,8 +97,8 @@ spec =
     hk2 <- registerCommitteeHotKey c2
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
         , (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
         , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
         ]
@@ -109,7 +108,7 @@ spec =
       [Active, Unrecognized]
       ( Just
           [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-          , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+          , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
           ]
       )
 
@@ -121,11 +120,11 @@ spec =
     -- and expected change of `ToBeRemoved`
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Active (Just 2) ToBeExpired)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
         , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
         , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
-        , (c5, CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+        , (c5, CommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
         ]
     expectQueryResult
       [c2, c3, c5]
@@ -134,7 +133,7 @@ spec =
       ( Just $
           Map.singleton
             c5
-            (CommitteeMemberState (MemberAuthorized (KeyHashObj hk5)) Unrecognized Nothing ToBeRemoved)
+            (CommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
       )
 
     passEpoch -- epoch 3
@@ -142,8 +141,8 @@ spec =
     -- the member which in the previous epoch was expected `ToBeEpired`, has now MemberStatus `Expired` and `NoChangeExpected`
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) NoChangeExpected)
-        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) NoChangeExpected)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)
+        , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just 2) NoChangeExpected)
         , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
         , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
         ]
@@ -170,14 +169,14 @@ spec =
     -- members that part of only next committee are `ToBeEnacted`
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 12) (TermAdjusted 13))
-        , (c2, CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) (TermAdjusted 13))
+        , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just 2) ToBeRemoved)
         , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
         , -- though its term was adjusted, `ToBeExpired` takes precedence
           (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) ToBeExpired)
-        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Unrecognized Nothing ToBeEnacted)
+        , (c6, CommitteeMemberState (MemberAuthorized hk6) Unrecognized Nothing ToBeEnacted)
         , (c7, CommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
-        , (c8, CommitteeMemberState (MemberAuthorized (KeyHashObj hk8)) Unrecognized Nothing ToBeRemoved)
+        , (c8, CommitteeMemberState (MemberAuthorized hk8) Unrecognized Nothing ToBeRemoved)
         ]
     expectQueryResult
       [c2]
@@ -186,7 +185,7 @@ spec =
       ( Just $
           Map.singleton
             c2
-            (CommitteeMemberState (MemberAuthorized (KeyHashObj hk2)) Expired (Just 2) ToBeRemoved)
+            (CommitteeMemberState (MemberAuthorized hk2) Expired (Just 2) ToBeRemoved)
       )
 
     passEpoch >> passEpoch -- epoch 6
@@ -194,10 +193,10 @@ spec =
     expectMembers [c1, c3, c4, c6, c7]
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) NoChangeExpected)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 13) NoChangeExpected)
         , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
         , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) NoChangeExpected)
-        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 6) ToBeExpired)
+        , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just 6) ToBeExpired)
         , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
         ]
     expectQueryResult
@@ -224,10 +223,10 @@ spec =
     -- members whose term changed have next epoch change `TermAdjusted`
     expectNoFilterQueryResult $
       Just
-        [ (c1, CommitteeMemberState (MemberAuthorized (KeyHashObj hk1)) Active (Just 13) ToBeRemoved)
+        [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 13) ToBeRemoved)
         , (c3, CommitteeMemberState MemberResigned Active (Just 7) (TermAdjusted 9))
         , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) (TermAdjusted 9))
-        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Expired (Just 6) (TermAdjusted 9))
+        , (c6, CommitteeMemberState (MemberAuthorized hk6) Expired (Just 6) (TermAdjusted 9))
         , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) ToBeExpired)
         ]
     passEpoch -- epoch 8
@@ -236,40 +235,40 @@ spec =
       Just
         [ (c3, CommitteeMemberState MemberResigned Active (Just 9) NoChangeExpected)
         , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 9) NoChangeExpected)
-        , (c6, CommitteeMemberState (MemberAuthorized (KeyHashObj hk6)) Active (Just 9) NoChangeExpected)
+        , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just 9) NoChangeExpected)
         , (c7, CommitteeMemberState MemberNotAuthorized Expired (Just 7) NoChangeExpected)
         ]
   where
     expectMembers ::
-      HasCallStack => Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) -> ImpTestM era ()
+      HasCallStack => Set.Set (Credential 'ColdCommitteeRole (EraCrypto era)) -> ImpTestM era ()
     expectMembers expKhs = do
       committee <-
         getsNES $
           nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
       let members = Map.keysSet $ foldMap' committeeMembers committee
-      impAnn "Expecting committee members" $ members `shouldBe` Set.map KeyHashObj expKhs
+      impAnn "Expecting committee members" $ members `shouldBe` expKhs
 
     expectQueryResult ::
       HasCallStack =>
-      Set.Set (KeyHash 'ColdCommitteeRole (EraCrypto era)) ->
-      Set.Set (KeyHash 'HotCommitteeRole (EraCrypto era)) ->
+      Set.Set (Credential 'ColdCommitteeRole (EraCrypto era)) ->
+      Set.Set (Credential 'HotCommitteeRole (EraCrypto era)) ->
       Set.Set MemberStatus ->
-      Maybe (Map.Map (KeyHash 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
+      Maybe (Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
       ImpTestM era ()
     expectQueryResult ckFilter hkFilter statusFilter expResult = do
       nes <- use impNESG
       let res =
             queryCommitteeMembersState
-              (Set.map KeyHashObj ckFilter)
-              (Set.map KeyHashObj hkFilter)
+              ckFilter
+              hkFilter
               statusFilter
               nes
       impAnn "Expecting query result" $
-        csCommittee <$> res `shouldBe` Map.mapKeys KeyHashObj <$> expResult
+        csCommittee <$> res `shouldBe` expResult
 
     expectNoFilterQueryResult ::
       HasCallStack =>
-      Maybe (Map.Map (KeyHash 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
+      Maybe (Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era))) ->
       ImpTestM era ()
     expectNoFilterQueryResult =
       expectQueryResult mempty mempty mempty

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 ### `testlib`
 
+* Add `integralToByteStringN`
 * Add `ByronKeyPair`
 * Add `Arbitrary` instances for Byron types: `Address`, `Attributes` and `AddrAttributes`
 * Add `Test.Cardano.Ledger.Core.JSON` with `roundTripJsonSpec`, `roundTripJsonEraSpec` and


### PR DESCRIPTION
# Description

This PR adds a way to mark protocol parameter fields as `SecurityRelevant`. The security relevant fields require sufficient votes from SPOs, where the required votes are determined by the `pvtSecurityRelevant` parameter.

resolves #3925 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
