### PR TITLE
Add new ledger event exposing drep registration/unregistration

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -18,7 +18,7 @@
 module Cardano.Ledger.Conway.Rules.Cert (
   ConwayCERT,
   ConwayCertPredFailure (..),
-  ConwayCertEvent,
+  ConwayCertEvent (GovCertEvent),
   CertEnv (..),
 ) where
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -51,6 +51,7 @@ import Control.State.Transition.Extended (
   TransitionRule,
   failBecause,
   judgmentContext,
+  tellEvent,
   transitionRules,
   (?!),
  )
@@ -126,7 +127,11 @@ instance
         pure (2, ConwayCommitteeHasPreviouslyResigned keyH)
       k -> invalidKey k
 
-newtype ConwayGovCertEvent era = GovCertEvent (Event (EraRule "GOVCERT" era))
+data ConwayGovCertEvent c
+  = -- | Event indicating that a DRep is registrating
+    DRepRegistration !(Credential 'DRepRole c)
+  | -- | Event indicating that a DRep is unregistrating
+    DRepUnregistration !(Credential 'DRepRole c)
 
 instance
   ( ConwayEraPParams era
@@ -144,7 +149,7 @@ instance
   type Environment (ConwayGOVCERT era) = ConwayGovCertEnv era
   type BaseM (ConwayGOVCERT era) = ShelleyBase
   type PredicateFailure (ConwayGOVCERT era) = ConwayGovCertPredFailure era
-  type Event (ConwayGOVCERT era) = ConwayGovCertEvent era
+  type Event (ConwayGOVCERT era) = ConwayGovCertEvent (EraCrypto era)
 
   transitionRules = [conwayGovCertTransition @era]
 
@@ -163,6 +168,7 @@ conwayGovCertTransition = do
     ConwayRegDRep cred deposit mAnchor -> do
       Map.notMember cred vsDReps ?! ConwayDRepAlreadyRegistered cred
       deposit == ppDRepDeposit ?! ConwayDRepIncorrectDeposit deposit ppDRepDeposit
+      tellEvent $ DRepRegistration cred
       pure
         vState
           { vsDReps =
@@ -170,6 +176,7 @@ conwayGovCertTransition = do
           }
     ConwayUnRegDRep cred deposit -> do
       checkRegistrationAndDepositAgainstPaidDeposit vsDReps cred deposit
+      tellEvent $ DRepUnregistration cred
       pure vState {vsDReps = Map.delete cred vsDReps}
     ConwayAuthCommitteeHotKey coldCred hotCred ->
       checkAndOverwriteCommitteeHotCred vState coldCred $ Just hotCred


### PR DESCRIPTION
# Description

These new events will make it possible to write tests in [cardano-testnet](https://github.com/IntersectMBO/cardano-node/tree/master/cardano-testnet) that do not rely on timeouts.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- NA When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- NA The version bounds in `.cabal` files for all affected packages are updated.
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- NA Cabal files are formatted (use `scripts/cabal-format.sh`)
- NA [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [X] Self-reviewed the diff