### PR TITLE
Fix too many discards.

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -37,6 +37,7 @@ library
         Test.Cardano.Ledger.Constrained.Preds.Certs
         Test.Cardano.Ledger.Constrained.Preds.LedgerState
         Test.Cardano.Ledger.Constrained.Preds.NewEpochState
+        Test.Cardano.Ledger.Constrained.Preds.UTxO
         Test.Cardano.Ledger.Constrained.Trace.TraceMonad
         Test.Cardano.Ledger.Constrained.Trace.SimpleTx
         Test.Cardano.Ledger.Constrained.Trace.Actions

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -249,7 +249,10 @@ certStateGenPreds p =
   , rewardRange :=: Elems rewards
   , NotMember (Lit CoinR (Coin 0)) (Rng stakeDeposits)
   , Dom rewards :=: Dom stakeDeposits
+  , Sized (AtMost 8) delegations
   , Dom delegations :⊆: Dom rewards
+  , Dom delegations :⊆: Dom incrementalStake
+  , Rng delegations :⊆: Dom regPools
   , if protocolVersion p >= protocolVersion (Conway Standard)
       then Sized (ExactSize 0) ptrs
       else Dom rewards :=: Rng ptrs

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/UTxO.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/UTxO.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Constrained.Preds.UTxO where
+
+import Control.Monad (when)
+import Data.Default.Class (Default (def))
+import qualified Data.Map.Strict as Map
+import Test.Cardano.Ledger.Constrained.Ast
+import Test.Cardano.Ledger.Constrained.Env
+import Test.Cardano.Ledger.Constrained.Monad (monadTyped)
+import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
+import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (UnivSize (..), universeStage)
+import Test.Cardano.Ledger.Constrained.Rewrite (standardOrderInfo)
+import Test.Cardano.Ledger.Constrained.Size (Size (..))
+import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
+import Test.Cardano.Ledger.Constrained.TypeRep
+import Test.Cardano.Ledger.Constrained.Vars
+import Test.Cardano.Ledger.Generic.PrettyCore (pcUTxO)
+import Test.Cardano.Ledger.Generic.Proof
+import Test.QuickCheck
+
+-- ===========================================================
+
+utxoPreds :: forall era. Reflect era => UnivSize -> Proof era -> [Pred era]
+utxoPreds usize p =
+  [ MetaSize (SzExact (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (maxsize collateral 3)
+  , Sized utxoSize preUtxo
+  , Sized (AtLeast 6) colUtxo
+  , MapMember feeTxIn feeTxOut (Right preUtxo)
+  , Subset (Dom preUtxo) txinUniv
+  , Subset (Rng preUtxo) (txoutUniv p)
+  , utxo p :<-: (Constr "mapunion" Map.union ^$ preUtxo ^$ colUtxo)
+  , Disjoint (Dom preUtxo) (Dom colUtxo)
+  , Subset (Dom colUtxo) txinUniv
+  , Subset (Rng colUtxo) (colTxoutUniv p)
+  , NotMember feeTxIn (Dom colUtxo)
+  , NotMember feeTxOut (Rng colUtxo)
+  , incrementalStake :<-: incrementalStakeT p -- Computes incrementalStake from the Term 'utxo' and the proof 'p'
+  ]
+  where
+    colUtxo = Var (V "colUtxo" (MapR TxInR (TxOutR p)) No)
+    utxoSize = Var (V "utxoSize" SizeR No)
+    preUtxo = Var (V "preUtxo" (MapR TxInR (TxOutR p)) No)
+
+utxoStage ::
+  Reflect era =>
+  UnivSize ->
+  Proof era ->
+  Subst era ->
+  Gen (Subst era)
+utxoStage usize proof subst0 = do
+  let preds = utxoPreds usize proof
+  subst <- toolChainSub proof standardOrderInfo preds subst0
+  (_env, status) <- pure (undefined, Nothing) -- monadTyped $ checkForSoundness preds subst
+  case status of
+    Nothing -> pure subst
+    Just msg -> error msg
+
+demoUTxO :: Reflect era => Proof era -> ReplMode -> IO ()
+demoUTxO proof mode = do
+  env <-
+    generate
+      ( pure emptySubst
+          >>= pParamsStage proof
+          >>= universeStage def proof
+          >>= utxoStage def proof
+          >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
+      )
+  utx <- monadTyped $ runTerm env (utxo proof)
+  when (mode == Interactive) $ putStrLn (show (pcUTxO proof (liftUTxO utx)))
+  modeRepl mode proof env ""

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -493,7 +493,8 @@ universePreds :: Reflect era => UnivSize -> Proof era -> [Pred era]
 universePreds size p =
   [ Sized (Range 100 500) currentSlot
   , Sized (Range 0 30) beginSlotDelta -- Note that (currentSlot - beginSlotDelta) is aways positive
-  , Sized (Range 300 500) endSlotDelta
+  , Sized (Range 900 1000) endSlotDelta -- Note each block may have spacing of 2-4 blocks,
+  -- So for a Trace of length at most 300, we need at least 900 slots on average
   , Sized (ExactSize (usNumKeys size)) keypairs
   , keymapUniv :<-: (Constr "xx" (\s -> Map.fromList (map (\x -> (hashKey (vKey x), x)) s)) ^$ keypairs)
   , Sized (ExactSize (usNumPools size)) prePoolUniv


### PR DESCRIPTION
Figure out how to get non-empty poolDistr from "random" SnapShots.

The test  "Bruteforce = Pulsed, in every epoch, on traces of length 150" 
Some times fails because at the epoch boundary because "There are no stakepools to choose an issuer from"
We set this up to discard, but occasionally we reach 150 discards and the test fails.
A lot of analysis discovers that in the random initial NewEpochState, the mark snapshot is not well formed, in that when ones computes the PoolDistr from such a snap shot, PoolDistr is empty.

The fix is to arrange random snapshots such that they never result in an empty PoolDistr. So we had to change the constraints for 'regPools' , 'incrementalStake', and 'delegations' so this never happens. In order to do that
we had to change the order we solve constraints, so that 'utxo' and  'incementalStake' are solved before 'delegations' . To do that we created a new Stage  utxoStage, in the module Preds/UTxO.hs, 
so we can see the UTxO when specifying the DState and PState.



# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
