### PR TITLE
Change Test.Cardano.Ledger.Generic.Proof so that there is no more Crypto Evidence.

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Alonzo/Tools.hs
@@ -47,7 +47,7 @@ import Test.Cardano.Ledger.Examples.STSTestUtils (
   someAddr,
   someKeys,
  )
-import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (Alonzo, Babbage))
+import Test.Cardano.Ledger.Generic.Proof (Proof (Alonzo, Babbage))
 import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic, always)
 import Test.Cardano.Ledger.Generic.Updaters
 import Test.Cardano.Ledger.Plutus (zeroTestingCostModels)
@@ -63,13 +63,13 @@ tests =
     [ testProperty "Plutus ExUnit translation round-trip" exUnitsTranslationRoundTrip
     , testGroup
         "Alonzo"
-        [ testCase "calculate ExUnits" (exampleExUnitCalc (Alonzo Mock))
-        , testCase "attempt calculate ExUnits with invalid tx" (exampleInvalidExUnitCalc (Alonzo Mock))
+        [ testCase "calculate ExUnits" (exampleExUnitCalc Alonzo)
+        , testCase "attempt calculate ExUnits with invalid tx" (exampleInvalidExUnitCalc Alonzo)
         ]
     , testGroup
         "Babbage"
-        [ testCase "calculate ExUnits" (exampleExUnitCalc (Babbage Mock))
-        , testCase "attempt calculate ExUnits with invalid tx" (exampleInvalidExUnitCalc (Babbage Mock))
+        [ testCase "calculate ExUnits" (exampleExUnitCalc Babbage)
+        , testCase "attempt calculate ExUnits with invalid tx" (exampleInvalidExUnitCalc Babbage)
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -373,12 +373,12 @@ instance Reflect era => Sums (TxOutF era) Coin where
 genTxOutX :: Reflect era => Proof era -> Coin -> Gen (TxOutF era)
 genTxOutX p coins = do
   txout <- case p of
-    Shelley _ -> arbitrary
-    Allegra _ -> arbitrary
-    Mary _ -> arbitrary
-    Alonzo _ -> arbitrary
-    Babbage _ -> arbitrary
-    Conway _ -> arbitrary
+    Shelley -> arbitrary
+    Allegra -> arbitrary
+    Mary -> arbitrary
+    Alonzo -> arbitrary
+    Babbage -> arbitrary
+    Conway -> arbitrary
   pure $ TxOutF p (txout & coinTxOutL .~ coins)
 
 instance Reflect era => Sums (ValueF era) Coin where
@@ -498,23 +498,23 @@ instance Show (TxAuxDataF era) where
   show (TxAuxDataF p x) = show ((unReflect pcAuxData p x) :: PDoc)
 
 instance Eq (TxAuxDataF era) where
-  (TxAuxDataF (Shelley _) x) == (TxAuxDataF (Shelley _) y) = x == y
-  (TxAuxDataF (Allegra _) x) == (TxAuxDataF (Allegra _) y) = x == y
-  (TxAuxDataF (Mary _) x) == (TxAuxDataF (Mary _) y) = x == y
-  (TxAuxDataF (Alonzo _) x) == (TxAuxDataF (Alonzo _) y) = x == y
-  (TxAuxDataF (Babbage _) x) == (TxAuxDataF (Babbage _) y) = x == y
-  (TxAuxDataF (Conway _) x) == (TxAuxDataF (Conway _) y) = x == y
+  (TxAuxDataF Shelley x) == (TxAuxDataF Shelley y) = x == y
+  (TxAuxDataF Allegra x) == (TxAuxDataF Allegra y) = x == y
+  (TxAuxDataF Mary x) == (TxAuxDataF Mary y) = x == y
+  (TxAuxDataF Alonzo x) == (TxAuxDataF Alonzo y) = x == y
+  (TxAuxDataF Babbage x) == (TxAuxDataF Babbage y) = x == y
+  (TxAuxDataF Conway x) == (TxAuxDataF Conway y) = x == y
 
 pcAuxData :: Proof era -> TxAuxData era -> PDoc
 pcAuxData p _x = ppString ("TxAuxData " ++ show p) -- TODO make this more accurate
 
 genTxAuxDataF :: Proof era -> Gen (TxAuxDataF era)
-genTxAuxDataF p@(Shelley _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
-genTxAuxDataF p@(Allegra _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
-genTxAuxDataF p@(Mary _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
-genTxAuxDataF p@(Alonzo _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
-genTxAuxDataF p@(Babbage _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
-genTxAuxDataF p@(Conway _) = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Shelley = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Allegra = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Mary = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Alonzo = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Babbage = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
+genTxAuxDataF p@Conway = TxAuxDataF p <$> suchThat arbitrary (validateTxAuxData (protocolVersion p))
 
 -- ==============
 
@@ -528,12 +528,12 @@ instance PrettyA (PParamsUpdate era) => Show (TxF era) where
   show (TxF p x) = show ((unReflect pcTx p x) :: PDoc)
 
 instance Eq (TxF era) where
-  (TxF (Shelley _) x) == (TxF (Shelley _) y) = x == y
-  (TxF (Allegra _) x) == (TxF (Allegra _) y) = x == y
-  (TxF (Mary _) x) == (TxF (Mary _) y) = x == y
-  (TxF (Alonzo _) x) == (TxF (Alonzo _) y) = x == y
-  (TxF (Babbage _) x) == (TxF (Babbage _) y) = x == y
-  (TxF (Conway _) x) == (TxF (Conway _) y) = x == y
+  (TxF Shelley x) == (TxF Shelley y) = x == y
+  (TxF Allegra x) == (TxF Allegra y) = x == y
+  (TxF Mary x) == (TxF Mary y) = x == y
+  (TxF Alonzo x) == (TxF Alonzo y) = x == y
+  (TxF Babbage x) == (TxF Babbage y) = x == y
+  (TxF Conway x) == (TxF Conway y) = x == y
 
 -- ==============
 
@@ -547,12 +547,12 @@ instance Show (TxWitsF era) where
   show (TxWitsF p x) = show ((unReflect pcWitnesses p x) :: PDoc)
 
 instance Eq (TxWitsF era) where
-  (TxWitsF (Shelley _) x) == (TxWitsF (Shelley _) y) = x == y
-  (TxWitsF (Allegra _) x) == (TxWitsF (Allegra _) y) = x == y
-  (TxWitsF (Mary _) x) == (TxWitsF (Mary _) y) = x == y
-  (TxWitsF (Alonzo _) x) == (TxWitsF (Alonzo _) y) = x == y
-  (TxWitsF (Babbage _) x) == (TxWitsF (Babbage _) y) = x == y
-  (TxWitsF (Conway _) x) == (TxWitsF (Conway _) y) = x == y
+  (TxWitsF Shelley x) == (TxWitsF Shelley y) = x == y
+  (TxWitsF Allegra x) == (TxWitsF Allegra y) = x == y
+  (TxWitsF Mary x) == (TxWitsF Mary y) = x == y
+  (TxWitsF Alonzo x) == (TxWitsF Alonzo y) = x == y
+  (TxWitsF Babbage x) == (TxWitsF Babbage y) = x == y
+  (TxWitsF Conway x) == (TxWitsF Conway y) = x == y
 
 -- ==============================
 
@@ -566,12 +566,12 @@ instance PrettyA (PParamsUpdate era) => Show (TxBodyF era) where
   show (TxBodyF p x) = show ((unReflect pcTxBody p x) :: PDoc)
 
 instance Eq (TxBodyF era) where
-  (TxBodyF (Shelley _) x) == (TxBodyF (Shelley _) y) = x == y
-  (TxBodyF (Allegra _) x) == (TxBodyF (Allegra _) y) = x == y
-  (TxBodyF (Mary _) x) == (TxBodyF (Mary _) y) = x == y
-  (TxBodyF (Alonzo _) x) == (TxBodyF (Alonzo _) y) = x == y
-  (TxBodyF (Babbage _) x) == (TxBodyF (Babbage _) y) = x == y
-  (TxBodyF (Conway _) x) == (TxBodyF (Conway _) y) = x == y
+  (TxBodyF Shelley x) == (TxBodyF Shelley y) = x == y
+  (TxBodyF Allegra x) == (TxBodyF Allegra y) = x == y
+  (TxBodyF Mary x) == (TxBodyF Mary y) = x == y
+  (TxBodyF Alonzo x) == (TxBodyF Alonzo y) = x == y
+  (TxBodyF Babbage x) == (TxBodyF Babbage y) = x == y
+  (TxBodyF Conway x) == (TxBodyF Conway y) = x == y
 
 -- ==================
 data TxCertF era where
@@ -584,12 +584,12 @@ instance Show (TxCertF era) where
   show (TxCertF p x) = show (pcTxCert p x)
 
 instance Eq (TxCertF era) where
-  (TxCertF (Shelley _) x) == (TxCertF (Shelley _) y) = x == y
-  (TxCertF (Allegra _) x) == (TxCertF (Allegra _) y) = x == y
-  (TxCertF (Mary _) x) == (TxCertF (Mary _) y) = x == y
-  (TxCertF (Alonzo _) x) == (TxCertF (Alonzo _) y) = x == y
-  (TxCertF (Babbage _) x) == (TxCertF (Babbage _) y) = x == y
-  (TxCertF (Conway _) x) == (TxCertF (Conway _) y) = x == y
+  (TxCertF Shelley x) == (TxCertF Shelley y) = x == y
+  (TxCertF Allegra x) == (TxCertF Allegra y) = x == y
+  (TxCertF Mary x) == (TxCertF Mary y) = x == y
+  (TxCertF Alonzo x) == (TxCertF Alonzo y) = x == y
+  (TxCertF Babbage x) == (TxCertF Babbage y) = x == y
+  (TxCertF Conway x) == (TxCertF Conway y) = x == y
 
 -- ==================
 data PlutusPurposeF era where
@@ -611,21 +611,21 @@ instance Show (PlutusPointerF era) where
   show (PlutusPointerF p x) = unReflect (\_ -> show (ppPlutusPurposeAsIndex x)) p
 
 instance Eq (PlutusPurposeF era) where
-  PlutusPurposeF (Alonzo _) x == PlutusPurposeF (Alonzo _) y = x == y
-  PlutusPurposeF (Babbage _) x == PlutusPurposeF (Babbage _) y = x == y
-  PlutusPurposeF (Conway _) x == PlutusPurposeF (Conway _) y = x == y
+  PlutusPurposeF Alonzo x == PlutusPurposeF Alonzo y = x == y
+  PlutusPurposeF Babbage x == PlutusPurposeF Babbage y = x == y
+  PlutusPurposeF Conway x == PlutusPurposeF Conway y = x == y
   _ == _ = error "Unsupported"
 
 instance Eq (PlutusPointerF era) where
-  PlutusPointerF (Alonzo _) x == PlutusPointerF (Alonzo _) y = x == y
-  PlutusPointerF (Babbage _) x == PlutusPointerF (Babbage _) y = x == y
-  PlutusPointerF (Conway _) x == PlutusPointerF (Conway _) y = x == y
+  PlutusPointerF Alonzo x == PlutusPointerF Alonzo y = x == y
+  PlutusPointerF Babbage x == PlutusPointerF Babbage y = x == y
+  PlutusPointerF Conway x == PlutusPointerF Conway y = x == y
   _ == _ = error "Unsupported"
 
 instance Ord (PlutusPointerF era) where
-  compare (PlutusPointerF (Alonzo _) x) (PlutusPointerF (Alonzo _) y) = compare x y
-  compare (PlutusPointerF (Babbage _) x) (PlutusPointerF (Babbage _) y) = compare x y
-  compare (PlutusPointerF (Conway _) x) (PlutusPointerF (Conway _) y) = compare x y
+  compare (PlutusPointerF Alonzo x) (PlutusPointerF Alonzo y) = compare x y
+  compare (PlutusPointerF Babbage x) (PlutusPointerF Babbage y) = compare x y
+  compare (PlutusPointerF Conway x) (PlutusPointerF Conway y) = compare x y
   compare _ _ = error "Unsupported"
 
 -- =========
@@ -639,17 +639,17 @@ instance Eq (TxOutF era) where
   x1 == x2 = compare x1 x2 == EQ
 
 instance Ord (TxOutF era) where
-  compare (TxOutF (Shelley _) (ShelleyTxOut a1 v1)) (TxOutF (Shelley _) (ShelleyTxOut a2 v2)) =
+  compare (TxOutF Shelley (ShelleyTxOut a1 v1)) (TxOutF Shelley (ShelleyTxOut a2 v2)) =
     compare a1 a2 <> compare v1 v2
-  compare (TxOutF (Allegra _) (ShelleyTxOut a1 v1)) (TxOutF (Allegra _) (ShelleyTxOut a2 v2)) =
+  compare (TxOutF Allegra (ShelleyTxOut a1 v1)) (TxOutF Allegra (ShelleyTxOut a2 v2)) =
     compare (a1, v1) (a2, v2)
-  compare (TxOutF (Mary _) (ShelleyTxOut a1 v1)) (TxOutF (Mary _) (ShelleyTxOut a2 v2)) =
+  compare (TxOutF Mary (ShelleyTxOut a1 v1)) (TxOutF Mary (ShelleyTxOut a2 v2)) =
     compare (a1, v1) (a2, v2)
-  compare (TxOutF (Alonzo _) (AlonzoTxOut a1 v1 d1)) (TxOutF (Alonzo _) (AlonzoTxOut a2 v2 d2)) =
+  compare (TxOutF Alonzo (AlonzoTxOut a1 v1 d1)) (TxOutF Alonzo (AlonzoTxOut a2 v2 d2)) =
     compare (a1, v1, d1) (a2, v2, d2)
-  compare (TxOutF (Babbage _) (BabbageTxOut a1 v1 d1 x1)) (TxOutF (Babbage _) (BabbageTxOut a2 v2 d2 x2)) =
+  compare (TxOutF Babbage (BabbageTxOut a1 v1 d1 x1)) (TxOutF Babbage (BabbageTxOut a2 v2 d2 x2)) =
     compare (a1, v1, d1, fmap hashScript x1) (a2, v2, d2, fmap hashScript x2)
-  compare (TxOutF (Conway _) (BabbageTxOut a1 v1 d1 x1)) (TxOutF (Conway _) (BabbageTxOut a2 v2 d2 x2)) =
+  compare (TxOutF Conway (BabbageTxOut a1 v1 d1 x1)) (TxOutF Conway (BabbageTxOut a2 v2 d2 x2)) =
     compare (a1, v1, d1, fmap hashScript x1) (a2, v2, d2, fmap hashScript x2)
 
 -- ======
@@ -669,12 +669,12 @@ instance Eq (ValueF era) where
   x == y = compare x y == EQ
 
 instance Ord (ValueF era) where
-  (ValueF (Shelley _) x) `compare` (ValueF (Shelley _) y) = compare x y
-  (ValueF (Allegra _) x) `compare` (ValueF (Allegra _) y) = compare x y
-  (ValueF (Mary _) (MaryValue c1 m1)) `compare` (ValueF (Mary _) (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
-  (ValueF (Alonzo _) (MaryValue c1 m1)) `compare` (ValueF (Alonzo _) (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
-  (ValueF (Babbage _) (MaryValue c1 m1)) `compare` (ValueF (Babbage _) (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
-  (ValueF (Conway _) (MaryValue c1 m1)) `compare` (ValueF (Conway _) (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
+  (ValueF Shelley x) `compare` (ValueF Shelley y) = compare x y
+  (ValueF Allegra x) `compare` (ValueF Allegra y) = compare x y
+  (ValueF Mary (MaryValue c1 m1)) `compare` (ValueF Mary (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
+  (ValueF Alonzo (MaryValue c1 m1)) `compare` (ValueF Alonzo (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
+  (ValueF Babbage (MaryValue c1 m1)) `compare` (ValueF Babbage (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
+  (ValueF Conway (MaryValue c1 m1)) `compare` (ValueF Conway (MaryValue c2 m2)) = compare c1 c2 <> compare m1 m2
 
 -- ======
 data PParamsF era where
@@ -738,20 +738,20 @@ govProposedL =
     (\(GovState p _) y -> GovState p (putPPUP p y))
 
 getPPUP :: forall era. Proof era -> Gov.GovState era -> ShelleyGovState era
-getPPUP (Shelley _) x = x
-getPPUP (Allegra _) x = x
-getPPUP (Mary _) x = x
-getPPUP (Alonzo _) x = x
-getPPUP (Babbage _) x = x
-getPPUP (Conway _) _ = def @(ShelleyGovState era)
+getPPUP Shelley x = x
+getPPUP Allegra x = x
+getPPUP Mary x = x
+getPPUP Alonzo x = x
+getPPUP Babbage x = x
+getPPUP Conway _ = def @(ShelleyGovState era)
 
 putPPUP :: forall era. Proof era -> ShelleyGovState era -> Gov.GovState era
-putPPUP (Shelley _) x = x
-putPPUP (Allegra _) x = x
-putPPUP (Mary _) x = x
-putPPUP (Alonzo _) x = x
-putPPUP (Babbage _) x = x
-putPPUP (Conway _) _ = Gov.emptyGovState @era
+putPPUP Shelley x = x
+putPPUP Allegra x = x
+putPPUP Mary x = x
+putPPUP Alonzo x = x
+putPPUP Babbage x = x
+putPPUP Conway _ = Gov.emptyGovState @era
 
 -- ================
 liftUTxO :: Map (TxIn (EraCrypto era)) (TxOutF era) -> UTxO era
@@ -774,12 +774,12 @@ instance Show (ProposedPPUpdatesF era) where
 
 genValue :: Proof era -> Gen (ValueF era)
 genValue p = case p of
-  (Shelley _) -> ValueF p <$> arbitrary
-  (Allegra _) -> ValueF p <$> arbitrary
-  (Mary _) -> ValueF p <$> arbitrary
-  (Alonzo _) -> ValueF p <$> arbitrary
-  (Babbage _) -> ValueF p <$> arbitrary
-  (Conway _) -> ValueF p <$> arbitrary
+  Shelley -> ValueF p <$> arbitrary
+  Allegra -> ValueF p <$> arbitrary
+  Mary -> ValueF p <$> arbitrary
+  Alonzo -> ValueF p <$> arbitrary
+  Babbage -> ValueF p <$> arbitrary
+  Conway -> ValueF p <$> arbitrary
 
 genTxOut :: Proof era -> Gen (TxOutF era)
 genTxOut p = do
@@ -788,48 +788,48 @@ genTxOut p = do
 
 genPParams :: Proof era -> Gen (PParamsF era)
 genPParams p = case p of
-  (Shelley _) -> PParamsF p <$> arbitrary
-  (Allegra _) -> PParamsF p <$> arbitrary
-  (Mary _) -> PParamsF p <$> arbitrary
-  (Alonzo _) -> PParamsF p <$> arbitrary
-  (Babbage _) -> PParamsF p <$> arbitrary
-  (Conway _) -> PParamsF p <$> arbitrary
+  Shelley -> PParamsF p <$> arbitrary
+  Allegra -> PParamsF p <$> arbitrary
+  Mary -> PParamsF p <$> arbitrary
+  Alonzo -> PParamsF p <$> arbitrary
+  Babbage -> PParamsF p <$> arbitrary
+  Conway -> PParamsF p <$> arbitrary
 
 genPParamsUpdate :: Proof era -> Gen (PParamsUpdateF era)
 genPParamsUpdate p = case p of
-  (Shelley _) -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
-  (Allegra _) -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
-  (Mary _) -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
-  (Alonzo _) -> PParamsUpdateF p <$> arbitrary
-  (Babbage _) -> PParamsUpdateF p <$> arbitrary
-  (Conway _) -> PParamsUpdateF p <$> arbitrary
+  Shelley -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
+  Allegra -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
+  Mary -> PParamsUpdateF p <$> genShelleyPParamsUpdate defaultConstants def
+  Alonzo -> PParamsUpdateF p <$> arbitrary
+  Babbage -> PParamsUpdateF p <$> arbitrary
+  Conway -> PParamsUpdateF p <$> arbitrary
 
 genProposedPPUpdates :: Proof era -> Gen (ProposedPPUpdatesF era)
 genProposedPPUpdates p = case p of
-  (Shelley _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
-  (Allegra _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
-  (Mary _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
-  (Alonzo _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
-  (Babbage _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
-  (Conway _) -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Shelley -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Allegra -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Mary -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Alonzo -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Babbage -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
+  Conway -> ProposedPPUpdatesF p . PP.ProposedPPUpdates <$> arbitrary
 
 genGovState :: Proof era -> Gen (GovState era)
 genGovState p = case p of
-  (Shelley _) -> GovState p <$> arbitrary
-  (Allegra _) -> GovState p <$> arbitrary
-  (Mary _) -> GovState p <$> arbitrary
-  (Alonzo _) -> GovState p <$> arbitrary
-  (Babbage _) -> GovState p <$> arbitrary
-  (Conway _) -> pure $ GovState p Gov.emptyGovState
+  Shelley -> GovState p <$> arbitrary
+  Allegra -> GovState p <$> arbitrary
+  Mary -> GovState p <$> arbitrary
+  Alonzo -> GovState p <$> arbitrary
+  Babbage -> GovState p <$> arbitrary
+  Conway -> pure $ GovState p Gov.emptyGovState
 
 genUTxO :: Proof era -> Gen (UTxO era)
 genUTxO p = case p of
-  (Shelley _) -> arbitrary
-  (Allegra _) -> arbitrary
-  (Mary _) -> arbitrary
-  (Alonzo _) -> arbitrary
-  (Babbage _) -> arbitrary
-  (Conway _) -> arbitrary
+  Shelley -> arbitrary
+  Allegra -> arbitrary
+  Mary -> arbitrary
+  Alonzo -> arbitrary
+  Babbage -> arbitrary
+  Conway -> arbitrary
 
 -- ========================
 
@@ -854,12 +854,12 @@ instance Show (ScriptF era) where
   show (ScriptF p t) = show ((unReflect pcScript p t) :: PDoc)
 
 instance Eq (ScriptF era) where
-  (ScriptF (Shelley _) x) == (ScriptF (Shelley _) y) = x == y
-  (ScriptF (Allegra _) x) == (ScriptF (Allegra _) y) = x == y
-  (ScriptF (Mary _) x) == (ScriptF (Mary _) y) = x == y
-  (ScriptF (Alonzo _) x) == (ScriptF (Alonzo _) y) = x == y
-  (ScriptF (Babbage _) x) == (ScriptF (Babbage _) y) = x == y
-  (ScriptF (Conway _) x) == (ScriptF (Conway _) y) = x == y
+  (ScriptF Shelley x) == (ScriptF Shelley y) = x == y
+  (ScriptF Allegra x) == (ScriptF Allegra y) = x == y
+  (ScriptF Mary x) == (ScriptF Mary y) = x == y
+  (ScriptF Alonzo x) == (ScriptF Alonzo y) = x == y
+  (ScriptF Babbage x) == (ScriptF Babbage y) = x == y
+  (ScriptF Conway x) == (ScriptF Conway y) = x == y
 
 genScriptF :: Era era => Proof era -> Gen (ScriptF era)
 genScriptF proof = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Env.hs
@@ -68,12 +68,12 @@ pattern V s r a <- VRaw s r _ a
 
 -- | Construct a V, dsicharging the (Era era) constraint, using the Proof
 pV :: Proof era -> String -> Rep era t -> Access era s t -> V era t
-pV (Shelley _) = V
-pV (Allegra _) = V
-pV (Mary _) = V
-pV (Alonzo _) = V
-pV (Babbage _) = V
-pV (Conway _) = V
+pV Shelley = V
+pV Allegra = V
+pV Mary = V
+pV Alonzo = V
+pV Babbage = V
+pV Conway = V
 
 {-# COMPLETE V #-}
 
@@ -222,14 +222,6 @@ instance Hashable (Shape a) where
   hashWithSalt s (Nary n xs) = s `hashWithSalt` (1 :: Int) `hashWithSalt` n `hashWithSalt` xs
   hashWithSalt s (Esc _ _) = s `hashWithSalt` (2 :: Int)
   {-# INLINE hashWithSalt #-}
-
-instance Hashable (Evidence c) where
-  hashWithSalt s x = s `hashWithSalt` (shape x)
-  {-# INLINE hashWithSalt #-}
-
-instance Eq (Evidence c) where
-  x == y = shape x == shape y
-  {-# INLINE (==) #-}
 
 instance Hashable (Proof e) where
   hashWithSalt s x = s `hashWithSalt` (shape x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -171,12 +171,12 @@ cyclicPred = [a :⊆: b, b :⊆: c, c :⊆: d, d :⊆: a, Random d]
 test1 :: IO ()
 test1 = do
   putStrLn "testing: Detect cycles"
-  runCompile @Babbage cyclicPred
+  runCompile @Babbage aCyclicPred
   putStrLn "+++ OK, passed 1 test."
 
 -- ===================================
 test3 :: Gen Property
-test3 = testn (Mary Standard) "Test 3. PState example" False stoi cs (Assemble pstateT)
+test3 = testn Mary "Test 3. PState example" False stoi cs (Assemble pstateT)
   where
     cs =
       [ Sized (ExactSize 10) poolHashUniv
@@ -192,7 +192,7 @@ test3 = testn (Mary Standard) "Test 3. PState example" False stoi cs (Assemble p
 -- ==============================
 
 test4 :: IO ()
-test4 = failn (Mary Standard) "Test 4. Inconsistent Size" False stoi cs Skip
+test4 = failn Mary "Test 4. Inconsistent Size" False stoi cs Skip
   where
     cs =
       [ Sized (ExactSize 5) rewards
@@ -200,7 +200,7 @@ test4 = failn (Mary Standard) "Test 4. Inconsistent Size" False stoi cs Skip
       ]
 
 test5 :: IO ()
-test5 = failn (Mary Standard) "Test 5. Bad Sum, impossible partition." False stoi cs Skip
+test5 = failn Mary "Test 5. Bad Sum, impossible partition." False stoi cs Skip
   where
     cs =
       [ Sized (ExactSize 5) rewards
@@ -253,7 +253,7 @@ test6 :: Bool -> IO ()
 test6 loud = do
   putStrLn "testing: find a viable order of variables"
   when loud $ putStrLn "======================================================="
-  case runTyped (compile standardOrderInfo $ constraints (Shelley Standard)) of
+  case runTyped (compile standardOrderInfo $ constraints Shelley) of
     Right x ->
       if loud
         then print x
@@ -265,7 +265,7 @@ test7 :: Bool -> IO ()
 test7 loud = do
   putStrLn "testing: compute a solution"
   when loud $ putStrLn "======================================================="
-  let proof = Shelley Standard
+  let proof = Shelley
   when loud $ putStrLn (show $ constraints proof)
   graph <- monadTyped $ compile standardOrderInfo $ constraints proof
   when loud $ putStrLn (show graph)
@@ -307,7 +307,7 @@ pstateConstraints =
 test8 :: Gen Property
 test8 =
   testn
-    (Alonzo Standard)
+    Alonzo
     "Test 8. Pstate constraints"
     False
     -- (stoi{setBeforeSubset = False})  -- Both of these choices work
@@ -333,7 +333,7 @@ sumPreds proof =
     utxoAmt = Var (V "utxoAmt" CoinR No)
 
 test9 :: Gen Property
-test9 = testn (Alonzo Standard) "Test 9. Test of summing" False stoi (sumPreds (Alonzo Standard)) Skip
+test9 = testn Alonzo "Test 9. Test of summing" False stoi (sumPreds Alonzo) Skip
 
 test10 :: Gen Property
 test10 =
@@ -360,7 +360,7 @@ test10 =
     tsumGTE = Var (V "tsumGTE" rep No)
     tsumEQL = Var (V "tsumEQL" rep No)
     rep = CoinR
-    proof = Mary Standard
+    proof = Mary
 
 test11 :: Gen Property
 test11 =
@@ -381,7 +381,7 @@ test11 =
     ]
     Skip
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 -- =====================================================
 
@@ -401,7 +401,7 @@ test12 =
     Skip
   where
     pp = PParamsR p
-    p = Shelley Standard
+    p = Shelley
 
 -- ==============================================================
 -- Test the Component Predicate
@@ -437,14 +437,14 @@ test13 =
     (componentPreds proof)
     Skip
   where
-    proof = Shelley Standard
+    proof = Shelley
 
 -- ==============================================
 
 test14 :: IO ()
 test14 =
   failn
-    (Allegra Standard)
+    Allegra
     "Test 14. Catch unsolveable use of Sized"
     False
     stoi
@@ -474,7 +474,7 @@ test15 =
     ]
     Skip
   where
-    proof = Alonzo Standard
+    proof = Alonzo
     pp = PParamsR proof
 
 -- ============================================================
@@ -502,7 +502,7 @@ test16 =
     (preds16 proof)
     Skip
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 -- ==============================================
 
@@ -649,7 +649,7 @@ test17 =
     (newepochConstraints proof)
     (Assemble (newEpochStateT proof))
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 -- ==========================================================
 -- Tests of the Term projection function ProjS
@@ -673,7 +673,7 @@ projPreds2 _proof =
 test18a :: Gen Property
 test18a = testn proof "Test 18a. Projection test" False stoi (projPreds1 proof) Skip
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 test18b :: Gen Property
 test18b =
@@ -685,7 +685,7 @@ test18b =
     (projPreds2 proof)
     (Assemble (Constr "Pair" (,) ^$ futureGenDelegs ^$ genDelegs))
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 -- ===============================================
 -- test of projOnDom
@@ -703,7 +703,7 @@ help19 _proof = do
 test19 :: IO ()
 test19 = do
   putStrLn "testing: Test 19. test of projOnDom function"
-  ans <- generate (help19 (Mary Standard))
+  ans <- generate (help19 Mary)
   putStrLn (synopsis (MapR (FutureGenDelegR @TT) GenDelegPairR) ans) -- (ppMap pcFutureGenDeleg pcGenDelegPair ans))
   putStrLn "+++ OK, passed 1 test"
 
@@ -731,11 +731,11 @@ test20 =
     (preds20 proof)
     Skip
   where
-    proof = Alonzo Standard
+    proof = Alonzo
 
 test21 :: Int -> IO Bool
 test21 seed = do
-  let proof = Babbage Standard
+  let proof = Babbage
       w = Var (V "w" (ListR IntR) No)
       a = Var (V "a" IntR No)
       b = Var (V "b" IntR No)
@@ -795,7 +795,7 @@ allExampleTests =
           Left xs -> assertFailure (unlines xs)
     , testIO
         "test 19 Test of projOnDom function"
-        (generate (help19 (Mary Standard)))
+        (generate (help19 Mary))
     , testIO "Test 4. Inconsistent Size" test4
     , testIO "Test 5. Bad Sum, impossible partition." test5
     , testIO "Test6. Find a viable order of variables" (test6 False)
@@ -817,9 +817,9 @@ allExampleTests =
     , testPropMax 30 "Constraint soundness" $ prop_soundness
     , testProperty "Shrinking soundness" $ withMaxSuccess 30 $ prop_shrinking
     , testProperty "NewEpochState and Tx generation" $ do
-        (st, tx, _) <- genTxAndNewEpoch def $ Conway Standard
+        (st, tx, _) <- genTxAndNewEpoch def $ Conway
         (st, tx) `deepseq` pure True
-    , testPreds "ListWhereTest" (Conway Standard) listWherePreds
+    , testPreds "ListWhereTest" Conway listWherePreds
     ]
 
 -- ==============================
@@ -870,7 +870,7 @@ listWherePreds =
     ans = Var (V "ans" (ListR (PairR CredR VCredR)) No)
 
 mainListWhere :: IO ()
-mainListWhere = demoPreds (Conway Standard) listWherePreds
+mainListWhere = demoPreds Conway listWherePreds
 
 govPreds :: [Pred (ConwayEra StandardCrypto)]
 govPreds =
@@ -897,4 +897,4 @@ govPreds =
   ]
 
 mainGov :: IO ()
-mainGov = demoPreds (Conway Standard) govPreds
+mainGov = demoPreds Conway govPreds

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/CertState.hs
@@ -99,7 +99,7 @@ vstateStage proof = toolChainSub proof standardOrderInfo (vstatePreds proof)
 
 demoV :: ReplMode -> IO ()
 demoV mode = do
-  let proof = Conway Standard
+  let proof = Conway
   env <-
     generate
       ( pure emptySubst
@@ -170,7 +170,7 @@ pstateStage proof = toolChainSub proof standardOrderInfo (pstatePreds proof)
 
 demoP :: ReplMode -> IO ()
 demoP mode = do
-  let proof = Babbage Standard
+  let proof = Babbage
   env <-
     generate
       ( pure emptySubst
@@ -253,7 +253,7 @@ certStateGenPreds p =
   , Dom delegations :⊆: Dom rewards
   , Dom delegations :⊆: Dom incrementalStake
   , Rng delegations :⊆: Dom regPools
-  , if protocolVersion p >= protocolVersion (Conway Standard)
+  , if protocolVersion p >= protocolVersion Conway
       then Sized (ExactSize 0) ptrs
       else Dom rewards :=: Rng ptrs
   , Dom drepDelegation :⊆: credsUniv
@@ -295,7 +295,7 @@ certStateCheckPreds p =
   [ NotMember (Lit CoinR (Coin 0)) (Rng stakeDeposits)
   , Dom rewards :=: Dom stakeDeposits
   , Dom delegations :⊆: Dom rewards
-  , if protocolVersion p >= protocolVersion (Conway Standard)
+  , if protocolVersion p >= protocolVersion Conway
       then Sized (ExactSize 0) ptrs
       else Dom rewards :=: Rng ptrs
   ]
@@ -309,7 +309,7 @@ dstateStage proof = toolChainSub proof standardOrderInfo (certStatePreds proof)
 
 demoD :: ReplMode -> Int -> IO ()
 demoD mode seed = do
-  let proof = Babbage Standard
+  let proof = Babbage
   env <-
     generateWithSeed
       seed
@@ -332,7 +332,7 @@ mainD seed = defaultMain $ testIO "Testing DState Stage" (demoD Interactive seed
 
 demoC :: ReplMode -> IO ()
 demoC mode = do
-  let proof = Conway Standard
+  let proof = Conway
   env <-
     generate
       ( pure emptySubst

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -557,8 +557,8 @@ certsStage us proof subst0 = do
 demo :: ReplMode -> Int -> IO ()
 demo mode seed = do
   let proof =
-        Conway Standard
-  -- Babbage Standard
+        Conway
+  -- Babbage
   env <-
     generateWithSeed
       seed

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -161,10 +161,10 @@ demo proof mode = do
   modeRepl mode proof env2 ""
 
 demoTest :: TestTree
-demoTest = testIO "Testing LedgerState Stage" (demo (Conway Standard) CI)
+demoTest = testIO "Testing LedgerState Stage" (demo Conway CI)
 
 main :: IO ()
-main = defaultMain $ testIO "Testing LedgerState Stage" (demo (Conway Standard) Interactive)
+main = defaultMain $ testIO "Testing LedgerState Stage" (demo Conway Interactive)
 
 -- =================================
 
@@ -290,7 +290,7 @@ demoGov proof mode = do
   modeRepl mode proof env ""
 
 mainGov :: IO ()
-mainGov = demoGov (Conway Standard) Interactive
+mainGov = demoGov Conway Interactive
 
 setActionId :: GovAction era -> Maybe (GovActionId (EraCrypto era)) -> GovAction era
 setActionId (ParameterChange _ pp p) x = ParameterChange (liftId x) pp p

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/NewEpochState.hs
@@ -109,10 +109,10 @@ demoES proof mode = do
   modeRepl mode proof env2 ""
 
 demoESTest :: TestTree
-demoESTest = testIO "Testing EpochState Stage" (demoES (Conway Standard) CI)
+demoESTest = testIO "Testing EpochState Stage" (demoES Conway CI)
 
 mainES :: IO ()
-mainES = defaultMain $ testIO "Testing EpochState Stage" (demoES (Conway Standard) Interactive)
+mainES = defaultMain $ testIO "Testing EpochState Stage" (demoES Conway Interactive)
 
 -- ====================================================
 
@@ -144,9 +144,9 @@ demoNES proof mode = do
   modeRepl mode proof env2 ""
 
 demoNESTest :: TestTree
-demoNESTest = testIO "Testing NewEpochState Stage" (demoNES (Conway Standard) CI)
+demoNESTest = testIO "Testing NewEpochState Stage" (demoNES Conway CI)
 
 mainNES :: IO ()
-mainNES = defaultMain $ testIO "Testing NewEpochState Stage" (demoNES (Conway Standard) Interactive)
+mainNES = defaultMain $ testIO "Testing NewEpochState Stage" (demoNES Conway Interactive)
 
 -- ==========================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/PParams.hs
@@ -143,7 +143,7 @@ pParamsStage proof = toolChainSub proof standardOrderInfo (pParamsPreds proof)
 
 demo :: ReplMode -> IO ()
 demo mode = do
-  let proof = Babbage Standard
+  let proof = Babbage
   subst <- generate (pParamsStage proof emptySubst)
   env <- monadTyped (substToEnv subst emptyEnv)
   when (mode == Interactive) $ putStrLn "\n" >> putStrLn (show subst)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
@@ -193,7 +193,7 @@ txOutPreds size@UnivSize {usDatumFreq} p balanceCoin outputS =
 
 demo :: ReplMode -> IO ()
 demo mode = do
-  let proof = Conway Standard
+  let proof = Conway
   env <-
     generate
       ( pure emptySubst

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -386,7 +386,7 @@ genStakeRefWith proof ps cs =
   frequency
     [ (80, StakeRefBase <$> pick1 ["from genStakeRefWith StakeRefBase"] cs)
     ,
-      ( if protocolVersion proof >= protocolVersion (Conway Standard) then 0 else 5
+      ( if protocolVersion proof >= protocolVersion Conway then 0 else 5
       , StakeRefPtr <$> pick1 ["from genStakeRefWith StakeRefPtr"] ps
       )
     , (15, pure StakeRefNull)
@@ -639,7 +639,7 @@ universeStage size proof = toolChainSub proof standardOrderInfo (universePreds s
 
 demo :: ReplMode -> IO ()
 demo mode = do
-  let proof = Shelley Standard
+  let proof = Shelley
   subst <- generate (universeStage def proof emptySubst)
   if mode == Interactive
     then putStrLn "\n" >> putStrLn (show subst)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Scripts.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Scripts.hs
@@ -122,10 +122,10 @@ genPlutusScript tag proof = do
   -- For reasons unknown, this number differs from Alonzo to Babbage
   -- Perhaps because Babbage is using PlutusV2 scripts?
   let numArgs = case (proof, tag) of
-        (Conway _, Spending) -> 2
-        (Conway _, _) -> 1
-        (Babbage _, Spending) -> 2
-        (Babbage _, _) -> 1
+        (Conway, Spending) -> 2
+        (Conway, _) -> 1
+        (Babbage, Spending) -> 2
+        (Babbage, _) -> 1
         (_, Spending) -> 3
         (_, _) -> 2
   -- While using varying number of arguments for alwaysSucceeds we get
@@ -143,25 +143,25 @@ genCoreScript ::
   ValidityInterval ->
   Gen (Script era)
 genCoreScript proof tag keymap vi = case proof of
-  Conway _ ->
+  Conway ->
     frequency
       [ (1, TimelockScript <$> genTimelock keymap vi proof)
       -- TODO Add this once scripts are working in Conway
       -- , (1, snd <$> genPlutusScript tag proof)
       ]
-  Babbage _ ->
+  Babbage ->
     frequency
       [ (1, TimelockScript <$> genTimelock keymap vi proof)
       , (1, snd <$> genPlutusScript tag proof)
       ]
-  Alonzo _ ->
+  Alonzo ->
     frequency
       [ (1, TimelockScript <$> genTimelock keymap vi proof)
       , (1, snd <$> genPlutusScript tag proof)
       ]
-  Mary _ -> genTimelock keymap vi proof
-  Allegra _ -> genTimelock keymap vi proof
-  Shelley _ -> genMultiSig keymap proof
+  Mary -> genTimelock keymap vi proof
+  Allegra -> genTimelock keymap vi proof
+  Shelley -> genMultiSig keymap proof
 
 -- | For any given Era, there are only a finite number of Plutus scripts.
 --   This function computes all of them. There will be two failing scripts
@@ -187,10 +187,10 @@ plutusByTag :: Proof era -> PlutusPurposeTag -> [(IsValid, Script era)]
 plutusByTag proof tag = trueS ++ falseS
   where
     numArgs = case (proof, tag) of
-      (Conway _, Spending) -> 2
-      (Conway _, _) -> 1
-      (Babbage _, Spending) -> 2
-      (Babbage _, _) -> 1
+      (Conway, Spending) -> 2
+      (Conway, _) -> 1
+      (Babbage, Spending) -> 2
+      (Babbage, _) -> 1
       (_, Spending) -> 3
       (_, _) -> 2
     trueS = [(IsValid True, alwaysTrue proof mlanguage (numArgs + n)) | n <- [0, 1, 2, 3 :: Natural]]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -947,12 +947,12 @@ genOrFailList ::
 genOrFailList loud = foldlM' (genOrFail loud)
 
 genDependGraph :: Bool -> Proof era -> DependGraph era -> Gen (Either [String] (Subst era))
-genDependGraph loud (Shelley _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
-genDependGraph loud (Allegra _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
-genDependGraph loud (Mary _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
-genDependGraph loud (Alonzo _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
-genDependGraph loud (Babbage _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
-genDependGraph loud (Conway _) (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Shelley (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Allegra (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Mary (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Alonzo (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Babbage (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
+genDependGraph loud Conway (DependGraph pairs) = genOrFailList loud (Right emptySubst) pairs
 
 -- | Solve for one variable, and add its solution to the substitution
 solveOneVar :: Era era => Subst era -> ([Name era], [Pred era]) -> Gen (Subst era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Tests.hs
@@ -574,7 +574,7 @@ shrinkPreds (preds, env) =
 type TestEra = ShelleyEra Standard
 
 testProof :: Proof TestEra
-testProof = Shelley Standard
+testProof = Shelley
 
 testEnv :: Env TestEra
 testEnv = Env $ Map.fromList [("A", Payload CoinR (Coin 5) No)]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Actions.hs
@@ -35,7 +35,7 @@ feesAction :: Era era => Coin -> TraceM era ()
 feesAction feeCoin = updateVar fees (<+> feeCoin)
 
 certAction :: Era era => Proof era -> TxCert era -> TraceM era ()
-certAction p@(Conway _) cert =
+certAction p@Conway cert =
   case cert of
     ConwayTxCertGov (ConwayRegDRep cred _ manchor) -> do
       epoch <- getTerm currentEpoch

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -66,11 +66,8 @@ import Test.Cardano.Ledger.Generic.Fields (TxBodyField (..))
 import Test.Cardano.Ledger.Generic.MockChain (MockBlock (..), MockChainState (..))
 import Test.Cardano.Ledger.Generic.PrettyCore (pcTxCert, ppList)
 import Test.Cardano.Ledger.Generic.Proof (
-  ConwayEra,
-  Evidence (..),
   Proof (..),
   Reflect (..),
-  StandardCrypto,
   TxCertWit (..),
   whichTxCert,
  )
@@ -160,19 +157,16 @@ drepCertTxForTrace maxFeeEstimate proof = do
 
 -- ======================================
 
-conway :: Proof (ConwayEra StandardCrypto)
-conway = Conway Standard
-
 drepTree :: TestTree
 drepTree =
   testGroup
     "DRep property traces"
     [ testProperty
         "All Tx are valid on traces of length 150."
-        (withMaxSuccess 5 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 100000)) (stepProp allValidSignals))
+        (withMaxSuccess 5 $ mockChainProp Conway 150 (drepCertTxForTrace (Coin 100000)) (stepProp allValidSignals))
     , testProperty
         "Bruteforce = Pulsed, in every epoch, on traces of length 150"
-        (withMaxSuccess 5 $ mockChainProp (Conway Standard) 150 (drepCertTxForTrace (Coin 60000)) (epochProp pulserWorks))
+        (withMaxSuccess 5 $ mockChainProp Conway 150 (drepCertTxForTrace (Coin 60000)) (epochProp pulserWorks))
     ]
 
 -- =================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Pipeline.hs
@@ -150,7 +150,7 @@ solvePipeline2 pipes = do
 
 main :: IO ()
 main = do
-  let proof = Babbage Standard
+  let proof = Babbage
   ((env, DependGraph zs), _, _) <- generate (runTraceM 0 emptyEnv (solvePipeline2 (ledgerPipeline def proof)))
   let vs = varsOfTarget HashSet.empty dstateT
       ok = any (`HashSet.member` vs) . fst
@@ -205,7 +205,7 @@ sts1 state ctx sig apply test =
     )
 
 proofx :: Proof (BabbageEra StandardCrypto)
-proofx = Babbage Standard
+proofx = Babbage
 
 genLedgerState :: Gen (Env Babbage, Subst Babbage, LedgerState Babbage)
 genLedgerState = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/Tests.hs
@@ -58,7 +58,7 @@ import Test.Tasty.QuickCheck (testProperty)
 --  Computed by using 'inputsAction' , 'outputsAction' , and 'feesAction'
 genAndRunSimpleTx :: TraceM (ConwayEra StandardCrypto) Property
 genAndRunSimpleTx = do
-  let proof = Conway Standard
+  let proof = Conway
   _ <- genLedgerStateEnv proof
 
   -- Compute the TRC before we make the Tx, because that adds things to the Env
@@ -165,7 +165,7 @@ conwayTrace :: TestTree
 conwayTrace =
   testProperty
     ("Testing each Tx in a Conway trace of length=" ++ show tracelen ++ " passes applySTS.")
-    (withMaxSuccess n (fstTriple <$> (runTraceM 0 emptyEnv (testTrace (Conway Standard) tracelen))))
+    (withMaxSuccess n (fstTriple <$> (runTraceM 0 emptyEnv (testTrace Conway tracelen))))
   where
     tracelen = 100
     n = 10

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -219,20 +219,20 @@ setVar term _ = failTrace ["Non Var term in call to 'setVar'", show term]
 -- A few helper functions that need to do different things in different Eras.
 
 refInputs :: Proof era -> TxBody era -> Set (TxIn (EraCrypto era))
-refInputs (Shelley _) _ = Set.empty
-refInputs (Allegra _) _ = Set.empty
-refInputs (Mary _) _ = Set.empty
-refInputs (Alonzo _) _ = Set.empty
-refInputs (Babbage _) txb = txb ^. referenceInputsTxBodyL
-refInputs (Conway _) txb = txb ^. referenceInputsTxBodyL
+refInputs Shelley _ = Set.empty
+refInputs Allegra _ = Set.empty
+refInputs Mary _ = Set.empty
+refInputs Alonzo _ = Set.empty
+refInputs Babbage txb = txb ^. referenceInputsTxBodyL
+refInputs Conway txb = txb ^. referenceInputsTxBodyL
 
 reqSig :: Proof era -> TxBody era -> Set (KeyHash 'Witness (EraCrypto era))
-reqSig (Shelley _) _ = Set.empty
-reqSig (Allegra _) _ = Set.empty
-reqSig (Mary _) _ = Set.empty
-reqSig (Alonzo _) _ = Set.empty
-reqSig (Babbage _) txb = txb ^. reqSignerHashesTxBodyL
-reqSig (Conway _) txb = txb ^. reqSignerHashesTxBodyL
+reqSig Shelley _ = Set.empty
+reqSig Allegra _ = Set.empty
+reqSig Mary _ = Set.empty
+reqSig Alonzo _ = Set.empty
+reqSig Babbage txb = txb ^. reqSignerHashesTxBodyL
+reqSig Conway txb = txb ^. reqSignerHashesTxBodyL
 
 -- =======================================================================================
 -- Code to run the standard [Pred era] found in the Preds directory in the TraceM monad

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -35,7 +35,6 @@ module Test.Cardano.Ledger.Constrained.TypeRep (
   unPParamsUpdate,
   liftUTxO,
   Proof (..),
-  Evidence (..),
   stringR,
   hasOrd,
   hasEq,
@@ -414,6 +413,14 @@ repHasInstances r = case r of
   IntegerR {} -> IsOrd
   ScriptsNeededR {} -> IsTypeable
   ScriptPurposeR {} -> IsEq
+  {-
+    ScriptPurposeR Shelley -> IsEq
+    ScriptPurposeR Mary -> IsEq
+    ScriptPurposeR Allegra -> IsEq
+    ScriptPurposeR Alonzo -> IsEq
+    ScriptPurposeR Babbage -> IsEq
+    ScriptPurposeR Conway -> IsEq
+  -}
   TxBodyR {} -> IsEq
   ShelleyTxCertR {} -> IsEq
   ConwayTxCertR {} -> IsEq
@@ -691,12 +698,12 @@ synSum (ListR ExUnitsR) m = ", sum = " ++ show (List.foldl' add zero m)
 synSum _ _ = ""
 
 accumTxOut :: Proof era -> Coin -> TxOutF era -> Coin
-accumTxOut (Shelley _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
-accumTxOut (Allegra _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
-accumTxOut (Mary _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
-accumTxOut (Alonzo _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
-accumTxOut (Babbage _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
-accumTxOut (Conway _) z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Shelley z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Allegra z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Mary z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Alonzo z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Babbage z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
+accumTxOut Conway z (TxOutF _ out) = z <+> (out ^. Core.coinTxOutL)
 
 -- ==================================================
 
@@ -759,12 +766,12 @@ genSizedRep _ PolicyIDR = arbitrary
 genSizedRep _ (WitnessesFieldR _) = pure $ AddrWits Set.empty
 genSizedRep _ AssetNameR = arbitrary
 genSizedRep _ RewardAcntR = RewardAcnt <$> pure Testnet <*> arbitrary
-genSizedRep _ (TxCertR (Shelley c)) = TxCertF (Shelley c) <$> arbitrary
-genSizedRep _ (TxCertR (Allegra c)) = TxCertF (Allegra c) <$> arbitrary
-genSizedRep _ (TxCertR (Mary c)) = TxCertF (Mary c) <$> arbitrary
-genSizedRep _ (TxCertR (Alonzo c)) = TxCertF (Alonzo c) <$> arbitrary
-genSizedRep _ (TxCertR (Babbage c)) = TxCertF (Babbage c) <$> arbitrary
-genSizedRep _ (TxCertR (Conway c)) = TxCertF (Conway c) <$> arbitrary
+genSizedRep _ (TxCertR Shelley) = TxCertF Shelley <$> arbitrary
+genSizedRep _ (TxCertR Allegra) = TxCertF Allegra <$> arbitrary
+genSizedRep _ (TxCertR Mary) = TxCertF Mary <$> arbitrary
+genSizedRep _ (TxCertR Alonzo) = TxCertF Alonzo <$> arbitrary
+genSizedRep _ (TxCertR Babbage) = TxCertF Babbage <$> arbitrary
+genSizedRep _ (TxCertR Conway) = TxCertF Conway <$> arbitrary
 genSizedRep _ ValidityIntervalR = arbitrary
 genSizedRep _ KeyPairR = arbitrary
 genSizedRep n (GenR x) = pure (genSizedRep n x)
@@ -773,16 +780,16 @@ genSizedRep _ ScriptHashR = arbitrary
 genSizedRep _ NetworkR = arbitrary
 genSizedRep n (RdmrPtrR p) =
   case p of
-    Shelley _ -> error "Redeemers are not supported in Shelley"
-    Allegra _ -> error "Redeemers are not supported in Allegra"
-    Mary _ -> error "Redeemers are not supported in Mary"
-    Alonzo _ -> do
+    Shelley -> error "Redeemers are not supported in Shelley"
+    Allegra -> error "Redeemers are not supported in Allegra"
+    Mary -> error "Redeemers are not supported in Mary"
+    Alonzo -> do
       i <- choose (0, fromIntegral n)
       PlutusPointerF p <$> genAlonzoPlutusPurposePointer i
-    Babbage _ -> do
+    Babbage -> do
       i <- choose (0, fromIntegral n)
       PlutusPointerF p <$> genAlonzoPlutusPurposePointer i
-    Conway _ -> do
+    Conway -> do
       i <- choose (0, fromIntegral n)
       PlutusPointerF p <$> genConwayPlutusPurposePointer i
 genSizedRep _ DataR = arbitrary
@@ -805,39 +812,39 @@ genSizedRep _ (ScriptsNeededR p) = case whichUTxO p of
   UTxOAlonzoToConway -> pure $ ScriptsNeededF p (AlonzoScriptsNeeded [])
 genSizedRep _ (ScriptPurposeR p) =
   case p of
-    Shelley _ -> error "PlutusPurpose is not supported in Shelley"
-    Allegra _ -> error "PlutusPurpose is not supported in Allegra"
-    Mary _ -> error "PlutusPurpose is not supported in Mary"
-    Alonzo _ -> PlutusPurposeF p <$> arbitrary
-    Babbage _ -> PlutusPurposeF p <$> arbitrary
-    Conway _ -> PlutusPurposeF p <$> arbitrary
+    Shelley -> error "PlutusPurpose is not supported in Shelley"
+    Allegra -> error "PlutusPurpose is not supported in Allegra"
+    Mary -> error "PlutusPurpose is not supported in Mary"
+    Alonzo -> PlutusPurposeF p <$> arbitrary
+    Babbage -> PlutusPurposeF p <$> arbitrary
+    Conway -> PlutusPurposeF p <$> arbitrary
 genSizedRep _ (TxBodyR p) =
   case p of
-    Shelley _ -> pure (TxBodyF p (newTxBody p []))
-    Allegra _ -> pure (TxBodyF p (newTxBody p []))
-    Mary _ -> pure (TxBodyF p (newTxBody p []))
-    Alonzo _ -> pure (TxBodyF p (newTxBody p []))
-    Babbage _ -> pure (TxBodyF p (newTxBody p []))
-    Conway _ -> pure (TxBodyF p (newTxBody p []))
+    Shelley -> pure (TxBodyF p (newTxBody p []))
+    Allegra -> pure (TxBodyF p (newTxBody p []))
+    Mary -> pure (TxBodyF p (newTxBody p []))
+    Alonzo -> pure (TxBodyF p (newTxBody p []))
+    Babbage -> pure (TxBodyF p (newTxBody p []))
+    Conway -> pure (TxBodyF p (newTxBody p []))
 genSizedRep _ BootstrapWitnessR = arbitrary
 genSizedRep _ SigningKeyR = genSigningKey
 genSizedRep _ (TxWitsR p) =
   case p of
-    Shelley _ -> TxWitsF p <$> arbitrary
-    Allegra _ -> TxWitsF p <$> arbitrary
-    Mary _ -> TxWitsF p <$> arbitrary
-    Alonzo _ -> TxWitsF p <$> arbitrary
-    Babbage _ -> TxWitsF p <$> arbitrary
-    Conway _ -> TxWitsF p <$> arbitrary
+    Shelley -> TxWitsF p <$> arbitrary
+    Allegra -> TxWitsF p <$> arbitrary
+    Mary -> TxWitsF p <$> arbitrary
+    Alonzo -> TxWitsF p <$> arbitrary
+    Babbage -> TxWitsF p <$> arbitrary
+    Conway -> TxWitsF p <$> arbitrary
 genSizedRep _ PayHashR = arbitrary
 genSizedRep _ (TxR p) =
   case p of
-    Shelley _ -> TxF p <$> arbitrary
-    Allegra _ -> TxF p <$> arbitrary
-    Mary _ -> TxF p <$> arbitrary
-    Alonzo _ -> TxF p <$> arbitrary
-    Babbage _ -> TxF p <$> arbitrary
-    Conway _ -> TxF p <$> arbitrary
+    Shelley -> TxF p <$> arbitrary
+    Allegra -> TxF p <$> arbitrary
+    Mary -> TxF p <$> arbitrary
+    Alonzo -> TxF p <$> arbitrary
+    Babbage -> TxF p <$> arbitrary
+    Conway -> TxF p <$> arbitrary
 genSizedRep _ ScriptIntegrityHashR = arbitrary
 genSizedRep _ AuxiliaryDataHashR = arbitrary
 genSizedRep _ GovActionR = NoConfidence <$> arbitrary
@@ -847,12 +854,12 @@ genSizedRep _ CommColdCredR = arbitrary
 genSizedRep _ CommHotCredR = arbitrary
 genSizedRep _ LanguageR = arbitrary
 genSizedRep _ (LedgerStateR p) = case p of
-  Shelley _ -> arbitrary
-  Allegra _ -> arbitrary
-  Mary _ -> arbitrary
-  Alonzo _ -> arbitrary
-  Babbage _ -> arbitrary
-  Conway _ -> arbitrary
+  Shelley -> arbitrary
+  Allegra -> arbitrary
+  Mary -> arbitrary
+  Alonzo -> arbitrary
+  Babbage -> arbitrary
+  Conway -> arbitrary
 genSizedRep _ StakeHashR = arbitrary
 genSizedRep _ BoolR = arbitrary
 genSizedRep _ DRepR = arbitrary
@@ -959,12 +966,12 @@ protVerRange :: forall era. Era era => Proof era -> [Version]
 protVerRange _ = [Core.eraProtVerLow @era .. Core.eraProtVerHigh @era]
 
 genpup :: Rep era (ShelleyGovState era) -> Gen (ShelleyGovState era)
-genpup (PPUPStateR (Shelley _)) = arbitrary
-genpup (PPUPStateR (Allegra _)) = arbitrary
-genpup (PPUPStateR (Mary _)) = arbitrary
-genpup (PPUPStateR (Alonzo _)) = arbitrary
-genpup (PPUPStateR (Babbage _)) = arbitrary
-genpup (PPUPStateR (Conway _)) = arbitrary -- FIXME when Conway is fully defined.
+genpup (PPUPStateR Shelley) = arbitrary
+genpup (PPUPStateR Allegra) = arbitrary
+genpup (PPUPStateR Mary) = arbitrary
+genpup (PPUPStateR Alonzo) = arbitrary
+genpup (PPUPStateR Babbage) = arbitrary
+genpup (PPUPStateR Conway) = arbitrary -- FIXME when Conway is fully defined.
 
 -- ===========================
 -- QuickCheck shrinking
@@ -1017,12 +1024,12 @@ shrinkRep MultiAssetR t = shrink t
 shrinkRep PolicyIDR t = shrink t
 shrinkRep (WitnessesFieldR _) _ = []
 shrinkRep AssetNameR t = shrink t
-shrinkRep (TxCertR (Shelley _)) (TxCertF p x) = map (TxCertF p) (shrink x)
-shrinkRep (TxCertR (Allegra _)) (TxCertF p x) = map (TxCertF p) (shrink x)
-shrinkRep (TxCertR (Mary _)) (TxCertF p x) = map (TxCertF p) (shrink x)
-shrinkRep (TxCertR (Alonzo _)) (TxCertF p x) = map (TxCertF p) (shrink x)
-shrinkRep (TxCertR (Babbage _)) (TxCertF p x) = map (TxCertF p) (shrink x)
-shrinkRep (TxCertR (Conway _)) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Shelley) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Allegra) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Mary) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Alonzo) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Babbage) (TxCertF p x) = map (TxCertF p) (shrink x)
+shrinkRep (TxCertR Conway) (TxCertF p x) = map (TxCertF p) (shrink x)
 shrinkRep RewardAcntR t = shrink t
 shrinkRep ValidityIntervalR _ = []
 shrinkRep KeyPairR t = shrink t

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -350,12 +350,12 @@ ppup :: Era era => Proof era -> Term era (ShelleyGovState era)
 ppup p = Var $ pV p "ppup" (PPUPStateR p) (Yes NewEpochStateR (ppupsL p))
 
 ppupsL :: Proof era -> NELens era (ShelleyGovState era)
-ppupsL (Shelley _) = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-ppupsL (Allegra _) = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-ppupsL (Mary _) = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-ppupsL (Alonzo _) = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-ppupsL (Babbage _) = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
-ppupsL (Conway _) = error "Conway era does not have a PPUPState, in ppupsL"
+ppupsL Shelley = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+ppupsL Allegra = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+ppupsL Mary = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+ppupsL Alonzo = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+ppupsL Babbage = nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL
+ppupsL Conway = error "Conway era does not have a PPUPState, in ppupsL"
 
 pparamProposals :: Era era => Proof era -> Term era (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
 pparamProposals p = Var (pV p "pparamProposals" (MapR GenHashR (PParamsUpdateR p)) No)
@@ -395,27 +395,27 @@ govL :: Lens' (GovState era) (Gov.GovState era)
 govL = lens f g
   where
     f :: GovState era -> Gov.GovState era
-    f (GovState (Shelley _) x) = x
-    f (GovState (Allegra _) x) = x
-    f (GovState (Mary _) x) = x
-    f (GovState (Alonzo _) x) = x
-    f (GovState (Babbage _) x) = x
-    f (GovState (Conway _) x) = x
+    f (GovState Shelley x) = x
+    f (GovState Allegra x) = x
+    f (GovState Mary x) = x
+    f (GovState Alonzo x) = x
+    f (GovState Babbage x) = x
+    f (GovState Conway x) = x
     g :: GovState era -> Gov.GovState era -> GovState era
-    g (GovState p@(Shelley _) _) y = GovState p y
-    g (GovState p@(Allegra _) _) y = GovState p y
-    g (GovState p@(Mary _) _) y = GovState p y
-    g (GovState p@(Alonzo _) _) y = GovState p y
-    g (GovState p@(Babbage _) _) y = GovState p y
-    g (GovState p@(Conway _) _) y = GovState p y
+    g (GovState p@Shelley _) y = GovState p y
+    g (GovState p@Allegra _) y = GovState p y
+    g (GovState p@Mary _) y = GovState p y
+    g (GovState p@Alonzo _) y = GovState p y
+    g (GovState p@Babbage _) y = GovState p y
+    g (GovState p@Conway _) y = GovState p y
 
 govStateT :: forall era. Era era => Proof era -> RootTarget era (GovState era) (GovState era)
-govStateT p@(Shelley _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
-govStateT p@(Allegra _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
-govStateT p@(Mary _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
-govStateT p@(Alonzo _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
-govStateT p@(Babbage _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
-govStateT p@(Conway _) = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (unReflect conwayGovStateT p) govL
+govStateT p@Shelley = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
+govStateT p@Allegra = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
+govStateT p@Mary = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
+govStateT p@Alonzo = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
+govStateT p@Babbage = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (ppupStateT p) govL
+govStateT p@Conway = Invert "GovState" (typeRep @(GovState era)) (GovState p) :$ Shift (unReflect conwayGovStateT p) govL
 
 individualPoolStakeL :: Lens' (IndividualPoolStake c) Rational
 individualPoolStakeL = lens individualPoolStake (\ds u -> ds {individualPoolStake = u})
@@ -902,12 +902,12 @@ newEpochStateConstr
       SNothing
       (PoolDistr nesPd')
       ( case proof of
-          Shelley _ -> UTxO Map.empty
-          Allegra _ -> ()
-          Mary _ -> ()
-          Alonzo _ -> ()
-          Babbage _ -> ()
-          Conway _ -> ()
+          Shelley -> UTxO Map.empty
+          Allegra -> ()
+          Mary -> ()
+          Alonzo -> ()
+          Babbage -> ()
+          Conway -> ()
       )
 
 -- | Target for NewEpochState
@@ -1048,7 +1048,7 @@ instantaneousRewardsT =
 
 -- | A String that pretty prints the complete set of variables of the NewEpochState
 allvars :: String
-allvars = show (ppTarget (newEpochStateT (Conway Standard)))
+allvars = show (ppTarget (newEpochStateT Conway))
 
 printTarget :: RootTarget era root t -> IO ()
 printTarget t = putStrLn (show (ppTarget t))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
@@ -51,7 +51,7 @@ tests :: TestTree
 tests =
   testGroup "Alonzo API" [testCase "evaluateTransactionFee" testEvaluateTransactionFee]
 
-type A = AlonzoEra C_Crypto
+type A = AlonzoEra StandardCrypto
 
 testEvaluateTransactionFee :: Assertion
 testEvaluateTransactionFee =
@@ -61,7 +61,7 @@ testEvaluateTransactionFee =
     1
     @?= getMinFeeTx pparams validatingTx
   where
-    pf = Alonzo Mock
+    pf = Alonzo
     pparams = newPParams pf $ defaultPPs ++ [MinfeeA (Coin 1)]
     validatingTxNoWits =
       newTx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -125,9 +125,9 @@ tests :: TestTree
 tests =
   testGroup
     "Generic Tests, testing Alonzo PredicateFailures, in postAlonzo eras."
-    [ alonzoBBODYexamplesP (Alonzo Mock)
-    , alonzoBBODYexamplesP (Babbage Mock)
-    -- alonzoBBODYexamplesP (Conway Mock) TODO
+    [ alonzoBBODYexamplesP Alonzo
+    , alonzoBBODYexamplesP Babbage
+    -- alonzoBBODYexamplesP Conway TODO
     ]
 
 alonzoBBODYexamplesP ::
@@ -212,9 +212,9 @@ testAlonzoBlock pf =
     ]
 
 testAlonzoBadPMDHBlock :: GoodCrypto (EraCrypto era) => Proof era -> Block (BHeaderView (EraCrypto era)) era
-testAlonzoBadPMDHBlock pf@(Alonzo _) = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
-testAlonzoBadPMDHBlock pf@(Babbage _) = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
-testAlonzoBadPMDHBlock pf@(Conway _) = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
+testAlonzoBadPMDHBlock pf@Alonzo = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
+testAlonzoBadPMDHBlock pf@Babbage = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
+testAlonzoBadPMDHBlock pf@Conway = makeNaiveBlock [trustMeP pf True $ poolMDHTooBigTx pf]
 testAlonzoBadPMDHBlock other = error ("testAlonzoBadPMDHBlock does not work in era " ++ show other)
 
 -- ============================== DATA ===============================
@@ -680,13 +680,13 @@ testBBodyState pf =
 -- ============================== Helper functions ===============================
 
 makeTooBig :: Proof era -> AlonzoBbodyPredFailure era
-makeTooBig proof@(Alonzo _) =
+makeTooBig proof@Alonzo =
   ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . DelegsFailure . DelplFailure . PoolFailure $
     PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys proof) (hashsize @Mock + 1)
-makeTooBig proof@(Babbage _) =
+makeTooBig proof@Babbage =
   ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . DelegsFailure . DelplFailure . PoolFailure $
     PoolMedataHashTooBig (coerceKeyRole . hashKey . vKey $ someKeys proof) (hashsize @Mock + 1)
--- makeTooBig proof@(Conway _) =
+-- makeTooBig proof@Conway =
 --   ShelleyInAlonzoBbodyPredFailure . LedgersFailure . LedgerFailure . ConwayCertsFailure . CertFailure . PoolFailure $ ConwayPoolPredFailure -- FIXME: This needs fixing after POOL rules are implemented for Conway
 makeTooBig proof = error ("makeTooBig does not work in era " ++ show proof)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -90,7 +90,7 @@ collectTwoPhaseScriptInputsOutputOrdering = do
             }
       ]
   where
-    apf = Alonzo Standard
+    apf = Alonzo
     plutusScript = case always 3 apf of
       TimelockScript _ -> error "always was not a Plutus script"
       PlutusScript ps -> ps
@@ -161,9 +161,9 @@ collectInputs ::
   Tx era ->
   UTxO era ->
   Either [CollectError era] [PlutusWithContext]
-collectInputs (Alonzo _) = collectPlutusScriptsWithContext
-collectInputs (Babbage _) = collectPlutusScriptsWithContext
-collectInputs (Conway _) = collectPlutusScriptsWithContext
+collectInputs Alonzo = collectPlutusScriptsWithContext
+collectInputs Babbage = collectPlutusScriptsWithContext
+collectInputs Conway = collectPlutusScriptsWithContext
 collectInputs x = error ("collectInputs Not defined in era " ++ show x)
 
 mkPlutusScriptContext' ::
@@ -176,9 +176,9 @@ mkPlutusScriptContext' ::
   UTxO era ->
   Tx era ->
   Either (ContextError era) (Data era)
-mkPlutusScriptContext' (Alonzo _) = mkPlutusScriptContext
-mkPlutusScriptContext' (Babbage _) = mkPlutusScriptContext
-mkPlutusScriptContext' (Conway _) = mkPlutusScriptContext
+mkPlutusScriptContext' Alonzo = mkPlutusScriptContext
+mkPlutusScriptContext' Babbage = mkPlutusScriptContext
+mkPlutusScriptContext' Conway = mkPlutusScriptContext
 mkPlutusScriptContext' era = error ("mkPlutusScriptContext is not defined in era " ++ show era)
 
 testEpochInfo :: EpochInfo (Either Text)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoInvalidTxUTXOW.hs
@@ -119,9 +119,9 @@ tests :: TestTree
 tests =
   testGroup
     "Generic Tests for invalid transactions, testing Alonzo UTXOW PredicateFailures, in postAlonzo eras."
-    [ alonzoUTXOWTests (Alonzo Mock)
-    , alonzoUTXOWTests (Babbage Mock)
-    -- alonzoUTXOWTests (Conway Mock) TODO
+    [ alonzoUTXOWTests Alonzo
+    , alonzoUTXOWTests Babbage
+    -- alonzoUTXOWTests Conway TODO
     ]
 
 alonzoUTXOWTests ::
@@ -205,7 +205,7 @@ alonzoUTXOWTests pf =
               ( Left
                   [ -- these redeemers are associated with phase-1 scripts
                     fromPredFail @era . ExtraRedeemers $
-                      [ mkPlutusPurposePointer pf Minting 1
+                      [ mkPlutusPurposePointer pf Minting 0
                       , mkPlutusPurposePointer pf Certifying 1
                       , mkPlutusPurposePointer pf Rewarding 0
                       ]
@@ -222,7 +222,7 @@ alonzoUTXOWTests pf =
                   , -- now "wrong redeemer label" means there are both unredeemable scripts and extra redeemers
                     fromPredFail @era . MissingRedeemers $
                       [(spendingPurpose1 pf, alwaysSucceedsHash 3 pf)]
-                  , fromPredFail @era $ ExtraRedeemers [mkPlutusPurposePointer pf Minting 0]
+                  , fromPredFail @era $ ExtraRedeemers [mkPlutusPurposePointer pf Minting 1]
                   ]
               )
         , testCase "missing datum" $
@@ -562,7 +562,7 @@ validatingManyScriptsRedeemers pf =
     [ ((Spending, 0), (Data (PV1.I 101), ExUnits 5000 5000))
     , ((Certifying, 1), (Data (PV1.I 102), ExUnits 5000 5000))
     , ((Rewarding, 0), (Data (PV1.I 103), ExUnits 5000 5000))
-    , ((Minting, 1), (Data (PV1.I 104), ExUnits 5000 5000))
+    , ((Minting, 0), (Data (PV1.I 104), ExUnits 5000 5000))
     ]
 
 wrongRedeemerLabelTx ::
@@ -596,7 +596,7 @@ wrongRedeemerLabelTx pf =
         ]
     misPurposedRedeemer =
       -- The label *should* be Spend, not Mint
-      mkRedeemersFromTags pf [((Minting, 0), (Data (PV1.I 42), ExUnits 5000 5000))]
+      mkRedeemersFromTags pf [((Minting, 1), (Data (PV1.I 42), ExUnits 5000 5000))]
 
 missingDatumTx ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -88,9 +88,9 @@ tests :: TestTree
 tests =
   testGroup
     "Generic Tests for valid transactions, testing Alonzo UTXOW PredicateFailures, in postAlonzo eras."
-    [ alonzoUTXOWTests (Alonzo Mock)
-    , alonzoUTXOWTests (Babbage Mock)
-    -- alonzoUTXOWTests (Conway Mock) TODO
+    [ alonzoUTXOWTests Alonzo
+    , alonzoUTXOWTests Babbage
+    -- alonzoUTXOWTests Conway TODO
     ]
 
 alonzoUTXOWTests ::
@@ -708,7 +708,7 @@ validatingManyScriptsRedeemers proof =
     [ ((Spending, 0), (Data (PV1.I 101), ExUnits 5000 5000))
     , ((Certifying, 1), (Data (PV1.I 102), ExUnits 5000 5000))
     , ((Rewarding, 0), (Data (PV1.I 103), ExUnits 5000 5000))
-    , ((Minting, 1), (Data (PV1.I 104), ExUnits 5000 5000))
+    , ((Minting, 0), (Data (PV1.I 104), ExUnits 5000 5000))
     ]
 
 validatingManyScriptsMint :: forall era. (PostShelley era, HasTokens era) => Proof era -> MultiAsset (EraCrypto era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -136,12 +136,12 @@ simpleScript pf = fromNativeScript $ allOf [require @era (keyHashForMultisig pf)
 evenData3ArgsScript :: HasCallStack => Proof era -> Script era
 evenData3ArgsScript proof =
   case proof of
-    Shelley _ -> error unsupported
-    Mary _ -> error unsupported
-    Allegra _ -> error unsupported
-    Alonzo _ -> evenData3ArgsLang @'PlutusV1
-    Babbage _ -> evenData3ArgsLang @'PlutusV2
-    Conway _ -> evenData3ArgsLang @'PlutusV2
+    Shelley -> error unsupported
+    Mary -> error unsupported
+    Allegra -> error unsupported
+    Alonzo -> evenData3ArgsLang @'PlutusV1
+    Babbage -> evenData3ArgsLang @'PlutusV2
+    Conway -> evenData3ArgsLang @'PlutusV2
   where
     unsupported = "Plutus scripts are not supported in:" ++ show proof
     evenData3ArgsLang :: forall l era'. (PlutusLanguage l, AlonzoEraScript era') => Script era'
@@ -1356,7 +1356,7 @@ babbageFeatures :: TestTree
 babbageFeatures =
   testGroup
     "Babbage Features"
-    [ genericBabbageFeatures (Babbage Standard)
-    , genericBabbageFailures (Babbage Standard)
-    -- genericBabbageFeatures (Conway Mock) TODO
+    [ genericBabbageFeatures Babbage
+    , genericBabbageFailures Babbage
+    -- genericBabbageFeatures Conway -- TODO
     ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
@@ -47,7 +47,7 @@ import Test.Cardano.Ledger.Generic.Functions (
  )
 import Test.Cardano.Ledger.Generic.GenState (GenSize (..), initStableFields)
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, MockBlock (..), MockChainState (..))
-import Test.Cardano.Ledger.Generic.Proof (Evidence (..), Proof (..), Reflect (..), Some (..), preBabbage, unReflect)
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (..), Some (..), preBabbage, unReflect)
 import Test.Cardano.Ledger.Generic.Trace (Gen1, genTrace, testPropMax)
 import Test.QuickCheck
 import Test.Tasty
@@ -96,9 +96,9 @@ aggTests :: TestTree
 aggTests =
   testGroup
     "tests, aggregating Tx's over a Trace."
-    [ testPropMax 30 "UTxO size in Babbage" (aggUTxO (Babbage Mock))
-    , testPropMax 30 "UTxO size in Alonzo" (aggUTxO (Alonzo Mock))
-    , testPropMax 30 "UTxO size in Mary" (aggUTxO (Mary Mock))
+    [ testPropMax 30 "UTxO size in Babbage" (aggUTxO Babbage)
+    , testPropMax 30 "UTxO size in Alonzo" (aggUTxO Alonzo)
+    , testPropMax 30 "UTxO size in Mary" (aggUTxO Mary)
     ]
 
 -- ===============================================================
@@ -107,17 +107,17 @@ aggTests =
 -- We will add additional analogs (ledgerTraceFromBlock, poolTraceFromBlock) soon,
 -- and then redo the tests in that module in the Generic fashion
 forAllChainTrace :: (Testable prop, Reflect era) => Proof era -> Int -> (Trace (MOCKCHAIN era) -> prop) -> Property
-forAllChainTrace p@(Conway _) n propf =
+forAllChainTrace p@Conway n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
-forAllChainTrace p@(Babbage _) n propf =
+forAllChainTrace p@Babbage n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
-forAllChainTrace p@(Alonzo _) n propf =
+forAllChainTrace p@Alonzo n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
-forAllChainTrace p@(Mary _) n propf =
+forAllChainTrace p@Mary n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
-forAllChainTrace p@(Allegra _) n propf =
+forAllChainTrace p@Allegra n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
-forAllChainTrace p@(Shelley _) n propf =
+forAllChainTrace p@Shelley n propf =
   property $ propf <$> genTrace p n (def {blocksizeMax = 4, slotDelta = (6, 12)}) initStableFields
 
 -- ===========================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ApplyTx.hs
@@ -163,12 +163,12 @@ applyWithdrawals _proof model (RewardAcnt _network cred) coin =
 
 applyCert :: forall era. Reflect era => Model era -> TxCert era -> Model era
 applyCert = case reify @era of
-  Shelley _ -> applyShelleyCert
-  Mary _ -> applyShelleyCert
-  Allegra _ -> applyShelleyCert
-  Alonzo _ -> applyShelleyCert
-  Babbage _ -> applyShelleyCert
-  Conway _ -> undefined -- TODO once Conway era is done
+  Shelley -> applyShelleyCert
+  Mary -> applyShelleyCert
+  Allegra -> applyShelleyCert
+  Alonzo -> applyShelleyCert
+  Babbage -> applyShelleyCert
+  Conway -> undefined -- TODO once Conway era is done
 
 applyShelleyCert :: forall era. EraPParams era => Model era -> ShelleyTxCert era -> Model era
 applyShelleyCert model dcert = case dcert of
@@ -299,13 +299,13 @@ additions bodyhash firstTxIx outputs =
 --   the BabbageFeatures.hs unit test file.
 go :: IO ()
 go = do
-  let proof = Babbage Mock
+  let proof = Babbage
       tx = (notValidatingTx proof) {isValid = IsValid False}
       allinputs = txbody ^. allInputsTxBodyF
       txbody = body tx
       doc = pcTx proof tx
       model1 =
-        (mNewEpochStateZero @(BabbageEra Mock))
+        (mNewEpochStateZero @(BabbageEra StandardCrypto))
           { mUTxO = Map.restrictKeys (unUTxO (initUTxO proof)) allinputs
           , mCount = 0
           , mFees = Coin 10

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -365,28 +365,28 @@ initWithdrawals :: Withdrawals c
 initWithdrawals = Withdrawals Map.empty
 
 initialTxBody :: Era era => Proof era -> TxBody era
-initialTxBody (Shelley _) = mkBasicTxBody
-initialTxBody (Allegra _) = mkBasicTxBody
-initialTxBody (Mary _) = mkBasicTxBody
-initialTxBody (Alonzo _) = mkBasicTxBody
-initialTxBody (Babbage _) = mkBasicTxBody
-initialTxBody (Conway _) = mkBasicTxBody
+initialTxBody Shelley = mkBasicTxBody
+initialTxBody Allegra = mkBasicTxBody
+initialTxBody Mary = mkBasicTxBody
+initialTxBody Alonzo = mkBasicTxBody
+initialTxBody Babbage = mkBasicTxBody
+initialTxBody Conway = mkBasicTxBody
 
 initialWitnesses :: Era era => Proof era -> TxWits era
-initialWitnesses (Shelley _) = mkBasicTxWits
-initialWitnesses (Allegra _) = mkBasicTxWits
-initialWitnesses (Mary _) = mkBasicTxWits
-initialWitnesses (Alonzo _) = mkBasicTxWits
-initialWitnesses (Babbage _) = mkBasicTxWits
-initialWitnesses (Conway _) = mkBasicTxWits
+initialWitnesses Shelley = mkBasicTxWits
+initialWitnesses Allegra = mkBasicTxWits
+initialWitnesses Mary = mkBasicTxWits
+initialWitnesses Alonzo = mkBasicTxWits
+initialWitnesses Babbage = mkBasicTxWits
+initialWitnesses Conway = mkBasicTxWits
 
 initialTx :: forall era. Proof era -> Tx era
-initialTx era@(Shelley _) = mkBasicTx (initialTxBody era)
-initialTx era@(Allegra _) = mkBasicTx (initialTxBody era)
-initialTx era@(Mary _) = mkBasicTx (initialTxBody era)
-initialTx era@(Alonzo _) = mkBasicTx (initialTxBody era)
-initialTx era@(Babbage _) = mkBasicTx (initialTxBody era)
-initialTx era@(Conway _) = mkBasicTx (initialTxBody era)
+initialTx era@Shelley = mkBasicTx (initialTxBody era)
+initialTx era@Allegra = mkBasicTx (initialTxBody era)
+initialTx era@Mary = mkBasicTx (initialTxBody era)
+initialTx era@Alonzo = mkBasicTx (initialTxBody era)
+initialTx era@Babbage = mkBasicTx (initialTxBody era)
+initialTx era@Conway = mkBasicTx (initialTxBody era)
 
 -- | A Meaningless Addr.
 initialAddr :: Era era => Proof era -> Addr (EraCrypto era)
@@ -397,31 +397,31 @@ initialAddr _wit = Addr Testnet pCred sCred
     sCred = StakeRefBase . KeyHashObj . hashKey $ svk
 
 initialTxOut :: Era era => Proof era -> TxOut era
-initialTxOut wit@(Shelley _) = mkBasicTxOut (initialAddr wit) mempty
-initialTxOut wit@(Allegra _) = mkBasicTxOut (initialAddr wit) mempty
-initialTxOut wit@(Mary _) = mkBasicTxOut (initialAddr wit) mempty
-initialTxOut wit@(Alonzo _) = mkBasicTxOut (initialAddr wit) mempty
-initialTxOut wit@(Babbage _) = mkBasicTxOut (initialAddr wit) mempty
-initialTxOut wit@(Conway _) = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Shelley = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Allegra = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Mary = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Alonzo = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Babbage = mkBasicTxOut (initialAddr wit) mempty
+initialTxOut wit@Conway = mkBasicTxOut (initialAddr wit) mempty
 
 -- ============================================================
 
 abstractTx :: Proof era -> Tx era -> [TxField era]
-abstractTx (Conway _) (AlonzoTx txBody wit v auxdata) =
+abstractTx Conway (AlonzoTx txBody wit v auxdata) =
   [Body txBody, TxWits wit, Valid v, AuxData auxdata]
-abstractTx (Babbage _) (AlonzoTx txBody wit v auxdata) =
+abstractTx Babbage (AlonzoTx txBody wit v auxdata) =
   [Body txBody, TxWits wit, Valid v, AuxData auxdata]
-abstractTx (Alonzo _) (AlonzoTx txBody wit v auxdata) =
+abstractTx Alonzo (AlonzoTx txBody wit v auxdata) =
   [Body txBody, TxWits wit, Valid v, AuxData auxdata]
-abstractTx (Shelley _) (ShelleyTx txBody wit auxdata) =
+abstractTx Shelley (ShelleyTx txBody wit auxdata) =
   [Body txBody, TxWits wit, AuxData auxdata]
-abstractTx (Mary _) (ShelleyTx txBody wit auxdata) =
+abstractTx Mary (ShelleyTx txBody wit auxdata) =
   [Body txBody, TxWits wit, AuxData auxdata]
-abstractTx (Allegra _) (ShelleyTx txBody wit auxdata) =
+abstractTx Allegra (ShelleyTx txBody wit auxdata) =
   [Body txBody, TxWits wit, AuxData auxdata]
 
 abstractTxBody :: Proof era -> TxBody era -> [TxBodyField era]
-abstractTxBody (Alonzo _) (AlonzoTxBody inp col out cert wdrl fee vldt up req mnt sih adh net) =
+abstractTxBody Alonzo (AlonzoTxBody inp col out cert wdrl fee vldt up req mnt sih adh net) =
   [ Inputs inp
   , Collateral col
   , Outputs out
@@ -436,7 +436,7 @@ abstractTxBody (Alonzo _) (AlonzoTxBody inp col out cert wdrl fee vldt up req mn
   , AdHash adh
   , Txnetworkid net
   ]
-abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol cert wdrl fee vldt req mnt sih adh net vp pp ctv td) =
+abstractTxBody Conway (ConwayTxBody inp col ref out colret totcol cert wdrl fee vldt req mnt sih adh net vp pp ctv td) =
   [ Inputs inp
   , Collateral col
   , RefInputs ref
@@ -456,7 +456,7 @@ abstractTxBody (Conway _) (ConwayTxBody inp col ref out colret totcol cert wdrl 
   , CurrentTreasuryValue ctv
   , TreasuryDonation td
   ]
-abstractTxBody (Babbage _) (BabbageTxBody inp col ref out colret totcol cert wdrl fee vldt up req mnt sih adh net) =
+abstractTxBody Babbage (BabbageTxBody inp col ref out colret totcol cert wdrl fee vldt up req mnt sih adh net) =
   [ Inputs inp
   , Collateral col
   , RefInputs ref
@@ -474,32 +474,32 @@ abstractTxBody (Babbage _) (BabbageTxBody inp col ref out colret totcol cert wdr
   , AdHash adh
   , Txnetworkid net
   ]
-abstractTxBody (Shelley _) (ShelleyTxBody inp out cert wdrl fee ttlslot up adh) =
+abstractTxBody Shelley (ShelleyTxBody inp out cert wdrl fee ttlslot up adh) =
   [Inputs inp, Outputs out, Certs cert, Withdrawals' wdrl, Txfee fee, TTL ttlslot, Update up, AdHash adh]
-abstractTxBody (Mary _) (MaryTxBody inp out cert wdrl fee vldt up adh mnt) =
+abstractTxBody Mary (MaryTxBody inp out cert wdrl fee vldt up adh mnt) =
   [Inputs inp, Outputs out, Certs cert, Withdrawals' wdrl, Txfee fee, Vldt vldt, Update up, AdHash adh, Mint mnt]
-abstractTxBody (Allegra _) (AllegraTxBody inp out cert wdrl fee vldt up adh) =
+abstractTxBody Allegra (AllegraTxBody inp out cert wdrl fee vldt up adh) =
   [Inputs inp, Outputs out, Certs cert, Withdrawals' wdrl, Txfee fee, Vldt vldt, Update up, AdHash adh]
 
 abstractWitnesses :: Proof era -> TxWits era -> [WitnessesField era]
-abstractWitnesses (Shelley _) (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
-abstractWitnesses (Allegra _) (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
-abstractWitnesses (Mary _) (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
-abstractWitnesses (Alonzo _) (AlonzoTxWits key boot scripts dats red) =
+abstractWitnesses Shelley (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
+abstractWitnesses Allegra (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
+abstractWitnesses Mary (ShelleyTxWits keys scripts boot) = [AddrWits keys, ScriptWits scripts, BootWits boot]
+abstractWitnesses Alonzo (AlonzoTxWits key boot scripts dats red) =
   [AddrWits key, ScriptWits scripts, BootWits boot, DataWits dats, RdmrWits red]
-abstractWitnesses (Babbage _) (AlonzoTxWits key boot scripts dats red) =
+abstractWitnesses Babbage (AlonzoTxWits key boot scripts dats red) =
   [AddrWits key, ScriptWits scripts, BootWits boot, DataWits dats, RdmrWits red]
-abstractWitnesses (Conway _) (AlonzoTxWits key boot scripts dats red) =
+abstractWitnesses Conway (AlonzoTxWits key boot scripts dats red) =
   [AddrWits key, ScriptWits scripts, BootWits boot, DataWits dats, RdmrWits red]
 
 abstractTxOut :: Era era => Proof era -> TxOut era -> [TxOutField era]
-abstractTxOut (Shelley _) (ShelleyTxOut addr c) = [Address addr, Amount c]
-abstractTxOut (Allegra _) (ShelleyTxOut addr c) = [Address addr, Amount c]
-abstractTxOut (Mary _) (ShelleyTxOut addr val) = [Address addr, Amount val]
-abstractTxOut (Alonzo _) (AlonzoTxOut addr val d) = [Address addr, Amount val, DHash d]
-abstractTxOut (Babbage _) (BabbageTxOut addr val d refscr) =
+abstractTxOut Shelley (ShelleyTxOut addr c) = [Address addr, Amount c]
+abstractTxOut Allegra (ShelleyTxOut addr c) = [Address addr, Amount c]
+abstractTxOut Mary (ShelleyTxOut addr val) = [Address addr, Amount val]
+abstractTxOut Alonzo (AlonzoTxOut addr val d) = [Address addr, Amount val, DHash d]
+abstractTxOut Babbage (BabbageTxOut addr val d refscr) =
   [Address addr, Amount val, FDatum d, RefScript refscr]
-abstractTxOut (Conway _) (BabbageTxOut addr val d refscr) =
+abstractTxOut Conway (BabbageTxOut addr val d refscr) =
   [Address addr, Amount val, FDatum d, RefScript refscr]
 
 -- =================================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -79,33 +79,33 @@ import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
 -- other XX types Mostly by pattern matching against Proof objects
 
 maxCollateralInputs' :: Proof era -> PParams era -> Natural
-maxCollateralInputs' (Alonzo _) pp = pp ^. ppMaxCollateralInputsL
-maxCollateralInputs' (Babbage _) pp = pp ^. ppMaxCollateralInputsL
-maxCollateralInputs' (Conway _) pp = pp ^. ppMaxCollateralInputsL
+maxCollateralInputs' Alonzo pp = pp ^. ppMaxCollateralInputsL
+maxCollateralInputs' Babbage pp = pp ^. ppMaxCollateralInputsL
+maxCollateralInputs' Conway pp = pp ^. ppMaxCollateralInputsL
 maxCollateralInputs' _proof _pp = 0
 {-# NOINLINE maxCollateralInputs' #-}
 
 maxTxExUnits' :: Proof era -> PParams era -> ExUnits
-maxTxExUnits' (Alonzo _) pp = pp ^. ppMaxTxExUnitsL
-maxTxExUnits' (Babbage _) pp = pp ^. ppMaxTxExUnitsL
-maxTxExUnits' (Conway _) pp = pp ^. ppMaxTxExUnitsL
+maxTxExUnits' Alonzo pp = pp ^. ppMaxTxExUnitsL
+maxTxExUnits' Babbage pp = pp ^. ppMaxTxExUnitsL
+maxTxExUnits' Conway pp = pp ^. ppMaxTxExUnitsL
 maxTxExUnits' _proof _x = mempty
 {-# NOINLINE maxTxExUnits' #-}
 
 collateralPercentage' :: Proof era -> PParams era -> Natural
-collateralPercentage' (Alonzo _) pp = pp ^. ppCollateralPercentageL
-collateralPercentage' (Babbage _) pp = pp ^. ppCollateralPercentageL
-collateralPercentage' (Conway _) pp = pp ^. ppCollateralPercentageL
+collateralPercentage' Alonzo pp = pp ^. ppCollateralPercentageL
+collateralPercentage' Babbage pp = pp ^. ppCollateralPercentageL
+collateralPercentage' Conway pp = pp ^. ppCollateralPercentageL
 collateralPercentage' _proof _pp = 0
 {-# NOINLINE collateralPercentage' #-}
 
 protocolVersion :: Proof era -> ProtVer
-protocolVersion (Conway _) = ProtVer (natVersion @9) 0
-protocolVersion (Babbage _) = ProtVer (natVersion @7) 0
-protocolVersion (Alonzo _) = ProtVer (natVersion @6) 0
-protocolVersion (Mary _) = ProtVer (natVersion @4) 0
-protocolVersion (Allegra _) = ProtVer (natVersion @3) 0
-protocolVersion (Shelley _) = ProtVer (natVersion @2) 0
+protocolVersion Conway = ProtVer (natVersion @9) 0
+protocolVersion Babbage = ProtVer (natVersion @7) 0
+protocolVersion Alonzo = ProtVer (natVersion @6) 0
+protocolVersion Mary = ProtVer (natVersion @4) 0
+protocolVersion Allegra = ProtVer (natVersion @3) 0
+protocolVersion Shelley = ProtVer (natVersion @2) 0
 {-# NOINLINE protocolVersion #-}
 
 -- | Positive numbers are "deposits owed", negative amounts are "refunds gained"
@@ -129,40 +129,40 @@ depositsAndRefunds pp certificates keydeposits = List.foldl' accum (Coin 0) cert
 -- | Compute the set of ScriptHashes for which there should be ScriptWitnesses. In Babbage
 --  Era and later, where inline Scripts are allowed, they should not appear in this set.
 scriptWitsNeeded' :: Proof era -> MUtxo era -> TxBody era -> Set (ScriptHash (EraCrypto era))
-scriptWitsNeeded' (Conway _) utxo txBody = regularScripts `Set.difference` inlineScripts
+scriptWitsNeeded' Conway utxo txBody = regularScripts `Set.difference` inlineScripts
   where
     theUtxo = UTxO utxo
     inputs = txBody ^. inputsTxBodyL
     inlineScripts = keysSet $ getReferenceScripts theUtxo inputs
     regularScripts = getScriptsHashesNeeded (getScriptsNeeded theUtxo txBody)
-scriptWitsNeeded' (Babbage _) utxo txBody = regularScripts `Set.difference` inlineScripts
+scriptWitsNeeded' Babbage utxo txBody = regularScripts `Set.difference` inlineScripts
   where
     theUtxo = UTxO utxo
     inputs = spendInputs' txBody `Set.union` referenceInputs' txBody
     inlineScripts = keysSet $ getReferenceScripts theUtxo inputs
     regularScripts = getScriptsHashesNeeded (getScriptsNeeded theUtxo txBody)
-scriptWitsNeeded' (Alonzo _) utxo txBody =
+scriptWitsNeeded' Alonzo utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptWitsNeeded' (Mary _) utxo txBody =
+scriptWitsNeeded' Mary utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptWitsNeeded' (Allegra _) utxo txBody =
+scriptWitsNeeded' Allegra utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptWitsNeeded' (Shelley _) utxo txBody =
+scriptWitsNeeded' Shelley utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
 {-# NOINLINE scriptWitsNeeded' #-}
 
 scriptsNeeded' :: Proof era -> MUtxo era -> TxBody era -> Set (ScriptHash (EraCrypto era))
-scriptsNeeded' (Conway _) utxo txBody =
+scriptsNeeded' Conway utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptsNeeded' (Babbage _) utxo txBody =
+scriptsNeeded' Babbage utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptsNeeded' (Alonzo _) utxo txBody =
+scriptsNeeded' Alonzo utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptsNeeded' (Mary _) utxo txBody =
+scriptsNeeded' Mary utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptsNeeded' (Allegra _) utxo txBody =
+scriptsNeeded' Allegra utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
-scriptsNeeded' (Shelley _) utxo txBody =
+scriptsNeeded' Shelley utxo txBody =
   getScriptsHashesNeeded (getScriptsNeeded (UTxO utxo) txBody)
 {-# NOINLINE scriptsNeeded' #-}
 
@@ -176,40 +176,40 @@ txInBalance txinSet m = coinBalance (UTxO (restrictKeys m txinSet))
 
 -- | Break a TxOut into its mandatory and optional parts
 txoutFields :: Proof era -> TxOut era -> (Addr (EraCrypto era), Value era, [TxOutField era])
-txoutFields (Conway _) (BabbageTxOut addr val d h) = (addr, val, [FDatum d, RefScript h])
-txoutFields (Babbage _) (BabbageTxOut addr val d h) = (addr, val, [FDatum d, RefScript h])
-txoutFields (Alonzo _) (AlonzoTxOut addr val dh) = (addr, val, [DHash dh])
-txoutFields (Mary _) (ShelleyTxOut addr val) = (addr, val, [])
-txoutFields (Allegra _) (ShelleyTxOut addr val) = (addr, val, [])
-txoutFields (Shelley _) (ShelleyTxOut addr val) = (addr, val, [])
+txoutFields Conway (BabbageTxOut addr val d h) = (addr, val, [FDatum d, RefScript h])
+txoutFields Babbage (BabbageTxOut addr val d h) = (addr, val, [FDatum d, RefScript h])
+txoutFields Alonzo (AlonzoTxOut addr val dh) = (addr, val, [DHash dh])
+txoutFields Mary (ShelleyTxOut addr val) = (addr, val, [])
+txoutFields Allegra (ShelleyTxOut addr val) = (addr, val, [])
+txoutFields Shelley (ShelleyTxOut addr val) = (addr, val, [])
 {-# NOINLINE txoutFields #-}
 
 injectFee :: EraTxOut era => Proof era -> Coin -> TxOut era -> TxOut era
 injectFee _ fee txOut = txOut & valueTxOutL %~ (<+> inject fee)
 
 getTxOutRefScript :: Proof era -> TxOut era -> StrictMaybe (Script era)
-getTxOutRefScript (Conway _) (BabbageTxOut _ _ _ ms) = ms
-getTxOutRefScript (Babbage _) (BabbageTxOut _ _ _ ms) = ms
+getTxOutRefScript Conway (BabbageTxOut _ _ _ ms) = ms
+getTxOutRefScript Babbage (BabbageTxOut _ _ _ ms) = ms
 getTxOutRefScript _ _ = SNothing
 {-# NOINLINE getTxOutRefScript #-}
 
 emptyPPUPstate :: forall era. Proof era -> ShelleyGovState era
-emptyPPUPstate (Conway _) = def
-emptyPPUPstate (Babbage _) = def
-emptyPPUPstate (Alonzo _) = def
-emptyPPUPstate (Mary _) = def
-emptyPPUPstate (Allegra _) = def
-emptyPPUPstate (Shelley _) = def
+emptyPPUPstate Conway = def
+emptyPPUPstate Babbage = def
+emptyPPUPstate Alonzo = def
+emptyPPUPstate Mary = def
+emptyPPUPstate Allegra = def
+emptyPPUPstate Shelley = def
 {-# NOINLINE emptyPPUPstate #-}
 
 maxRefInputs :: Proof era -> Int
-maxRefInputs (Babbage _) = 3
+maxRefInputs Babbage = 3
 maxRefInputs _ = 0
 
 isValid' :: Proof era -> Tx era -> IsValid
-isValid' (Conway _) x = isValid x
-isValid' (Babbage _) x = isValid x
-isValid' (Alonzo _) x = isValid x
+isValid' Conway x = isValid x
+isValid' Babbage x = isValid x
+isValid' Alonzo x = isValid x
 isValid' _ _ = IsValid True
 {-# NOINLINE isValid' #-}
 
@@ -221,27 +221,27 @@ txoutEvidence ::
   Proof era ->
   TxOut era ->
   ([Credential 'Payment (EraCrypto era)], Maybe (DataHash (EraCrypto era)))
-txoutEvidence (Alonzo _) (AlonzoTxOut addr _ (SJust dh)) =
+txoutEvidence Alonzo (AlonzoTxOut addr _ (SJust dh)) =
   (addrCredentials addr, Just dh)
-txoutEvidence (Alonzo _) (AlonzoTxOut addr _ SNothing) =
+txoutEvidence Alonzo (AlonzoTxOut addr _ SNothing) =
   (addrCredentials addr, Nothing)
-txoutEvidence (Conway _) (BabbageTxOut addr _ NoDatum _) =
+txoutEvidence Conway (BabbageTxOut addr _ NoDatum _) =
   (addrCredentials addr, Nothing)
-txoutEvidence (Conway _) (BabbageTxOut addr _ (DatumHash dh) _) =
+txoutEvidence Conway (BabbageTxOut addr _ (DatumHash dh) _) =
   (addrCredentials addr, Just dh)
-txoutEvidence (Conway _) (BabbageTxOut addr _ (Datum _d) _) =
+txoutEvidence Conway (BabbageTxOut addr _ (Datum _d) _) =
   (addrCredentials addr, Just (hashData @era (binaryDataToData _d)))
-txoutEvidence (Babbage _) (BabbageTxOut addr _ NoDatum _) =
+txoutEvidence Babbage (BabbageTxOut addr _ NoDatum _) =
   (addrCredentials addr, Nothing)
-txoutEvidence (Babbage _) (BabbageTxOut addr _ (DatumHash dh) _) =
+txoutEvidence Babbage (BabbageTxOut addr _ (DatumHash dh) _) =
   (addrCredentials addr, Just dh)
-txoutEvidence (Babbage _) (BabbageTxOut addr _ (Datum _d) _) =
+txoutEvidence Babbage (BabbageTxOut addr _ (Datum _d) _) =
   (addrCredentials addr, Just (hashData @era (binaryDataToData _d)))
-txoutEvidence (Mary _) (ShelleyTxOut addr _) =
+txoutEvidence Mary (ShelleyTxOut addr _) =
   (addrCredentials addr, Nothing)
-txoutEvidence (Allegra _) (ShelleyTxOut addr _) =
+txoutEvidence Allegra (ShelleyTxOut addr _) =
   (addrCredentials addr, Nothing)
-txoutEvidence (Shelley _) (ShelleyTxOut addr _) =
+txoutEvidence Shelley (ShelleyTxOut addr _) =
   (addrCredentials addr, Nothing)
 {-# NOINLINE txoutEvidence #-}
 
@@ -260,21 +260,21 @@ getBody :: EraTx era => Proof era -> Tx era -> TxBody era
 getBody _ tx = tx ^. bodyTxL
 
 getCollateralInputs :: Proof era -> TxBody era -> Set (TxIn (EraCrypto era))
-getCollateralInputs (Conway _) tx = tx ^. collateralInputsTxBodyL
-getCollateralInputs (Babbage _) tx = collateralInputs' tx
-getCollateralInputs (Alonzo _) tx = collateral' tx
-getCollateralInputs (Mary _) _ = Set.empty
-getCollateralInputs (Allegra _) _ = Set.empty
-getCollateralInputs (Shelley _) _ = Set.empty
+getCollateralInputs Conway tx = tx ^. collateralInputsTxBodyL
+getCollateralInputs Babbage tx = collateralInputs' tx
+getCollateralInputs Alonzo tx = collateral' tx
+getCollateralInputs Mary _ = Set.empty
+getCollateralInputs Allegra _ = Set.empty
+getCollateralInputs Shelley _ = Set.empty
 {-# NOINLINE getCollateralInputs #-}
 
 getCollateralOutputs :: Proof era -> TxBody era -> [TxOut era]
-getCollateralOutputs (Conway _) tx = case tx ^. collateralReturnTxBodyL of SNothing -> []; SJust x -> [x]
-getCollateralOutputs (Babbage _) tx = case collateralReturn' tx of SNothing -> []; SJust x -> [x]
-getCollateralOutputs (Alonzo _) _ = []
-getCollateralOutputs (Mary _) _ = []
-getCollateralOutputs (Allegra _) _ = []
-getCollateralOutputs (Shelley _) _ = []
+getCollateralOutputs Conway tx = case tx ^. collateralReturnTxBodyL of SNothing -> []; SJust x -> [x]
+getCollateralOutputs Babbage tx = case collateralReturn' tx of SNothing -> []; SJust x -> [x]
+getCollateralOutputs Alonzo _ = []
+getCollateralOutputs Mary _ = []
+getCollateralOutputs Allegra _ = []
+getCollateralOutputs Shelley _ = []
 {-# NOINLINE getCollateralOutputs #-}
 
 getInputs :: EraTxBody era => Proof era -> TxBody era -> Set (TxIn (EraCrypto era))
@@ -293,34 +293,34 @@ getWitnesses :: EraTx era => Proof era -> Tx era -> TxWits era
 getWitnesses _ tx = tx ^. witsTxL
 
 primaryLanguage :: Proof era -> Maybe Language
-primaryLanguage (Conway _) = Just PlutusV2
-primaryLanguage (Babbage _) = Just PlutusV2
-primaryLanguage (Alonzo _) = Just PlutusV1
+primaryLanguage Conway = Just PlutusV2
+primaryLanguage Babbage = Just PlutusV2
+primaryLanguage Alonzo = Just PlutusV1
 primaryLanguage _ = Nothing
 {-# NOINLINE primaryLanguage #-}
 
 alwaysTrue :: forall era. Proof era -> Maybe Language -> Natural -> Script era
-alwaysTrue (Conway _) (Just l) n = alwaysSucceedsLang @era l n
-alwaysTrue p@(Conway _) Nothing _ = fromNativeScript $ allOf [] p
-alwaysTrue (Babbage _) (Just l) n = alwaysSucceedsLang @era l n
-alwaysTrue p@(Babbage _) Nothing _ = fromNativeScript $ allOf [] p
-alwaysTrue (Alonzo _) (Just l) n = alwaysSucceedsLang @era l n
-alwaysTrue p@(Alonzo _) Nothing _ = fromNativeScript $ allOf [] p
-alwaysTrue p@(Mary _) _ n = always n p
-alwaysTrue p@(Allegra _) _ n = always n p
-alwaysTrue p@(Shelley _) _ n = always n p
+alwaysTrue Conway (Just l) n = alwaysSucceedsLang @era l n
+alwaysTrue p@Conway Nothing _ = fromNativeScript $ allOf [] p
+alwaysTrue Babbage (Just l) n = alwaysSucceedsLang @era l n
+alwaysTrue p@Babbage Nothing _ = fromNativeScript $ allOf [] p
+alwaysTrue Alonzo (Just l) n = alwaysSucceedsLang @era l n
+alwaysTrue p@Alonzo Nothing _ = fromNativeScript $ allOf [] p
+alwaysTrue p@Mary _ n = always n p
+alwaysTrue p@Allegra _ n = always n p
+alwaysTrue p@Shelley _ n = always n p
 {-# NOINLINE alwaysTrue #-}
 
 alwaysFalse :: forall era. Proof era -> Maybe Language -> Natural -> Script era
-alwaysFalse (Conway _) (Just l) n = alwaysFailsLang @era l n
-alwaysFalse p@(Conway _) Nothing _ = fromNativeScript $ anyOf [] p
-alwaysFalse (Babbage _) (Just l) n = alwaysFailsLang @era l n
-alwaysFalse p@(Babbage _) Nothing _ = fromNativeScript $ anyOf [] p
-alwaysFalse (Alonzo _) (Just l) n = alwaysFailsLang @era l n
-alwaysFalse p@(Alonzo _) Nothing _ = fromNativeScript $ anyOf [] p
-alwaysFalse p@(Mary _) _ n = never n p
-alwaysFalse p@(Allegra _) _ n = never n p
-alwaysFalse p@(Shelley _) _ n = never n p
+alwaysFalse Conway (Just l) n = alwaysFailsLang @era l n
+alwaysFalse p@Conway Nothing _ = fromNativeScript $ anyOf [] p
+alwaysFalse Babbage (Just l) n = alwaysFailsLang @era l n
+alwaysFalse p@Babbage Nothing _ = fromNativeScript $ anyOf [] p
+alwaysFalse Alonzo (Just l) n = alwaysFailsLang @era l n
+alwaysFalse p@Alonzo Nothing _ = fromNativeScript $ anyOf [] p
+alwaysFalse p@Mary _ n = never n p
+alwaysFalse p@Allegra _ n = never n p
+alwaysFalse p@Shelley _ n = never n p
 {-# NOINLINE alwaysFalse #-}
 
 certs :: (ShelleyEraTxBody era, EraTx era) => Proof era -> Tx era -> [TxCert era]
@@ -347,12 +347,12 @@ createRUpdNonPulsing' proof model =
         Left err -> error ("Failed to calculate slots per epoch:\n" ++ show err)
         Right x -> x
    in (`runReader` testGlobals) $ case proof of
-        Conway _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
-        Babbage _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
-        Alonzo _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
-        Mary _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
-        Allegra _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
-        Shelley _ -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Conway -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Babbage -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Alonzo -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Mary -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Allegra -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
+        Shelley -> createRUpdOld_ @era slotsPerEpoch bm ss reserves pp totalStake rs def
 {-# NOINLINE createRUpdNonPulsing' #-}
 
 languagesUsed ::
@@ -363,12 +363,12 @@ languagesUsed ::
   Set (ScriptHash (EraCrypto era)) ->
   Set Language
 languagesUsed proof tx utxo sNeeded = case proof of
-  (Shelley _) -> Set.empty
-  (Allegra _) -> Set.empty
-  (Mary _) -> Set.empty
-  (Alonzo _) -> languages tx utxo sNeeded
-  (Babbage _) -> languages tx utxo sNeeded
-  (Conway _) -> languages tx utxo sNeeded
+  Shelley -> Set.empty
+  Allegra -> Set.empty
+  Mary -> Set.empty
+  Alonzo -> languages tx utxo sNeeded
+  Babbage -> languages tx utxo sNeeded
+  Conway -> languages tx utxo sNeeded
 {-# NOINLINE languagesUsed #-}
 
 -- | Compute the Set of Languages in an era, where 'AlonzoScripts' are used
@@ -426,12 +426,12 @@ instance TotalAda (ShelleyGovState era) where
 
 govStateTotalAda :: forall era. Reflect era => GovState era -> Coin
 govStateTotalAda = case reify @era of
-  Shelley _ -> totalAda
-  Mary _ -> totalAda
-  Allegra _ -> totalAda
-  Alonzo _ -> totalAda
-  Babbage _ -> totalAda
-  Conway _ -> mempty
+  Shelley -> totalAda
+  Mary -> totalAda
+  Allegra -> totalAda
+  Alonzo -> totalAda
+  Babbage -> totalAda
+  Conway -> mempty
 
 instance Reflect era => TotalAda (LedgerState era) where
   totalAda (LedgerState utxos dps) = totalAda utxos <+> totalAda dps
@@ -443,10 +443,10 @@ instance Reflect era => TotalAda (NewEpochState era) where
   totalAda nes = totalAda (nesEs nes)
 
 adaPots :: Proof era -> EpochState era -> AdaPots
-adaPots (Conway _) es = totalAdaPotsES es
-adaPots (Babbage _) es = totalAdaPotsES es
-adaPots (Alonzo _) es = totalAdaPotsES es
-adaPots (Mary _) es = totalAdaPotsES es
-adaPots (Allegra _) es = totalAdaPotsES es
-adaPots (Shelley _) es = totalAdaPotsES es
+adaPots Conway es = totalAdaPotsES es
+adaPots Babbage es = totalAdaPotsES es
+adaPots Alonzo es = totalAdaPotsES es
+adaPots Mary es = totalAdaPotsES es
+adaPots Allegra es = totalAdaPotsES es
+adaPots Shelley es = totalAdaPotsES es
 {-# NOINLINE adaPots #-}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Indexed.hs
@@ -27,10 +27,7 @@ import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Witness), SignKeyDSIGN, VKey, WitVKey (..), hashKey)
 import Cardano.Ledger.SafeHash (SafeHash)
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
-import Test.Cardano.Ledger.Generic.Proof (
-  GoodCrypto,
-  Proof (..),
- )
+import Test.Cardano.Ledger.Generic.Proof (GoodCrypto, Proof (..))
 import Test.Cardano.Ledger.Shelley.Utils (RawSeed (..), mkKeyPair)
 
 -- =======================================================
@@ -54,7 +51,11 @@ theSKey n = SKey (sKey (theKeyPair @c n))
 theKeyHash :: CC.Crypto c => Int -> KeyHash kr c
 theKeyHash n = hashKey (theVKey n)
 
-theWitVKey :: GoodCrypto c => Int -> SafeHash c EraIndependentTxBody -> WitVKey 'Witness c
+theWitVKey ::
+  GoodCrypto c =>
+  Int ->
+  SafeHash c EraIndependentTxBody ->
+  WitVKey 'Witness c
 theWitVKey n hash = mkWitnessVKey hash (theKeyPair n)
 
 theKeyHashObj :: CC.Crypto c => Int -> Credential kr c

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -237,12 +237,12 @@ instance PrettyA (MockBlock era) where prettyA = ppMockBlock
 
 ppMockChainFailure :: Reflect era => Proof era -> MockChainFailure era -> PDoc
 ppMockChainFailure proof x = case proof of
-  (Conway _) -> help x
-  (Babbage _) -> help x
-  (Alonzo _) -> help x
-  (Mary _) -> help x
-  (Allegra _) -> help x
-  (Shelley _) -> help x
+  Conway -> help x
+  Babbage -> help x
+  Alonzo -> help x
+  Mary -> help x
+  Allegra -> help x
+  Shelley -> help x
   where
     help (MockChainFromTickFailure y) = ppTickPredicateFailure y
     help (MockChainFromLedgersFailure y) = ppShelleyLedgersPredFailure proof y
@@ -254,9 +254,9 @@ ppMockChainFailure proof x = case proof of
         ]
 
 noThunksGen :: Proof era -> MockChainState era -> IO (Maybe ThunkInfo)
-noThunksGen (Conway _) = noThunks []
-noThunksGen (Babbage _) = noThunks []
-noThunksGen (Alonzo _) = noThunks []
-noThunksGen (Mary _) = noThunks []
-noThunksGen (Allegra _) = noThunks []
-noThunksGen (Shelley _) = noThunks []
+noThunksGen Conway = noThunks []
+noThunksGen Babbage = noThunks []
+noThunksGen Alonzo = noThunks []
+noThunksGen Mary = noThunks []
+noThunksGen Allegra = noThunks []
+noThunksGen Shelley = noThunks []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -109,9 +109,9 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
  )
 import Test.Cardano.Ledger.Generic.Proof (
   BabbageEra,
-  Mock,
   Proof (..),
   Reflect (..),
+  StandardCrypto,
  )
 import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
 
@@ -220,12 +220,12 @@ nonMyopicZero :: NonMyopic c
 nonMyopicZero = NonMyopic Map.empty mempty
 
 pParamsZeroByProof :: Proof era -> PParams era
-pParamsZeroByProof (Conway _) = def
-pParamsZeroByProof (Babbage _) = def
-pParamsZeroByProof (Alonzo _) = def
-pParamsZeroByProof (Mary _) = def
-pParamsZeroByProof (Allegra _) = def
-pParamsZeroByProof (Shelley _) = def
+pParamsZeroByProof Conway = def
+pParamsZeroByProof Babbage = def
+pParamsZeroByProof Alonzo = def
+pParamsZeroByProof Mary = def
+pParamsZeroByProof Allegra = def
+pParamsZeroByProof Shelley = def
 
 uTxOStateZero :: forall era. Reflect era => UTxOState era
 uTxOStateZero =
@@ -265,12 +265,12 @@ newEpochStateZero =
     (stashedAVVMAddressesZero (reify :: Proof era))
 
 stashedAVVMAddressesZero :: Proof era -> StashedAVVMAddresses era
-stashedAVVMAddressesZero (Shelley _) = utxoZero
-stashedAVVMAddressesZero (Conway _) = ()
-stashedAVVMAddressesZero (Babbage _) = ()
-stashedAVVMAddressesZero (Alonzo _) = ()
-stashedAVVMAddressesZero (Mary _) = ()
-stashedAVVMAddressesZero (Allegra _) = ()
+stashedAVVMAddressesZero Shelley = utxoZero
+stashedAVVMAddressesZero Conway = ()
+stashedAVVMAddressesZero Babbage = ()
+stashedAVVMAddressesZero Alonzo = ()
+stashedAVVMAddressesZero Mary = ()
+stashedAVVMAddressesZero Allegra = ()
 
 mNewEpochStateZero :: Reflect era => ModelNewEpochState era
 mNewEpochStateZero =
@@ -299,10 +299,10 @@ mNewEpochStateZero =
     , mRu = SNothing
     }
 
-testNES :: NewEpochState (BabbageEra Mock)
+testNES :: NewEpochState (BabbageEra StandardCrypto)
 testNES = newEpochStateZero
 
-testMNES :: ModelNewEpochState (BabbageEra Mock)
+testMNES :: ModelNewEpochState (BabbageEra StandardCrypto)
 testMNES = mNewEpochStateZero
 
 -- ======================================================================
@@ -445,5 +445,5 @@ epochBoundaryPDoc _proof x =
 
 instance Reflect era => PrettyA (ModelNewEpochState era) where prettyA = pcModelNewEpochState reify
 
-instance era ~ BabbageEra Mock => Show (ModelNewEpochState era) where
+instance Reflect era => Show (ModelNewEpochState era) where
   show x = show (prettyA x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -817,12 +817,12 @@ extractAlonzoTxAuxDataScripts ::
   StrictSeq (Script era)
 extractAlonzoTxAuxDataScripts auxData =
   case reify @era of
-    Shelley _ -> error "Unsuported"
-    Allegra _ -> error "Unsuported"
-    Mary _ -> error "Unsuported"
-    Alonzo _ -> getAlonzoTxAuxDataScripts auxData
-    Babbage _ -> getAlonzoTxAuxDataScripts auxData
-    Conway _ -> getAlonzoTxAuxDataScripts auxData
+    Shelley -> error "Unsuported"
+    Allegra -> error "Unsuported"
+    Mary -> error "Unsuported"
+    Alonzo -> getAlonzoTxAuxDataScripts auxData
+    Babbage -> getAlonzoTxAuxDataScripts auxData
+    Conway -> getAlonzoTxAuxDataScripts auxData
 
 instance
   (Reflect era, Script era ~ AlonzoScript era) =>
@@ -830,13 +830,13 @@ instance
   where
   prettyA = ppAlonzoTxAuxData
 
-pcAuxData :: Reflect era => Proof era -> TxAuxData era -> PDoc
-pcAuxData (Shelley _) x = ppShelleyTxAuxData x
-pcAuxData (Allegra _) x = ppAllegraTxAuxData x
-pcAuxData (Mary _) x = ppAllegraTxAuxData x
-pcAuxData (Alonzo _) x = ppAlonzoTxAuxData x
-pcAuxData (Babbage _) x = ppAlonzoTxAuxData x
-pcAuxData (Conway _) x = ppAlonzoTxAuxData x
+pcAuxData :: Proof era -> TxAuxData era -> PDoc
+pcAuxData Shelley x = ppShelleyTxAuxData x
+pcAuxData Allegra x = ppAllegraTxAuxData x
+pcAuxData Mary x = ppAllegraTxAuxData x
+pcAuxData Alonzo x = ppAlonzoTxAuxData x
+pcAuxData Babbage x = ppAlonzoTxAuxData x
+pcAuxData Conway x = ppAlonzoTxAuxData x
 
 ppWithdrawals :: Withdrawals c -> PDoc
 ppWithdrawals (Withdrawals m) = ppSexp "Withdrawals" [ppMap' (text "Wdr") pcRewardAcnt pcCoin m]
@@ -949,41 +949,41 @@ instance (TxBody era ~ MaryTxBody era, Reflect era) => PrettyA (MaryTxBody era) 
 -- any type family.
 -- ==============================================================
 
-ppCoreWitnesses :: Reflect era => Proof era -> TxWits era -> PDoc
-ppCoreWitnesses (Conway _) x = ppTxWitness x
-ppCoreWitnesses (Babbage _) x = ppTxWitness x
-ppCoreWitnesses (Alonzo _) x = ppTxWitness x
-ppCoreWitnesses (Mary _) x = ppWitnessSetHKD x
-ppCoreWitnesses (Allegra _) x = ppWitnessSetHKD x
-ppCoreWitnesses (Shelley _) x = ppWitnessSetHKD x
+ppCoreWitnesses :: Proof era -> TxWits era -> PDoc
+ppCoreWitnesses Conway x = ppTxWitness x
+ppCoreWitnesses Babbage x = ppTxWitness x
+ppCoreWitnesses Alonzo x = ppTxWitness x
+ppCoreWitnesses Mary x = ppWitnessSetHKD x
+ppCoreWitnesses Allegra x = ppWitnessSetHKD x
+ppCoreWitnesses Shelley x = ppWitnessSetHKD x
 
 pcTxOut :: Reflect era => Proof era -> TxOut era -> PDoc
-pcTxOut p@(Conway _) (BabbageTxOut addr v d s) =
+pcTxOut p@Conway (BabbageTxOut addr v d s) =
   ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
-pcTxOut p@(Babbage _) (BabbageTxOut addr v d s) =
+pcTxOut p@Babbage (BabbageTxOut addr v d s) =
   ppSexp "TxOut" [pcAddr addr, pcValue v, pcDatum d, ppStrictMaybe (pcScript p) s]
-pcTxOut (Alonzo _) (AlonzoTxOut addr v md) =
+pcTxOut Alonzo (AlonzoTxOut addr v md) =
   ppSexp "TxOut" [pcAddr addr, pcValue v, ppStrictMaybe pcDataHash md]
-pcTxOut p@(Mary _) (ShelleyTxOut addr v) =
+pcTxOut p@Mary (ShelleyTxOut addr v) =
   ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
-pcTxOut p@(Allegra _) (ShelleyTxOut addr v) =
+pcTxOut p@Allegra (ShelleyTxOut addr v) =
   ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
-pcTxOut p@(Shelley _) (ShelleyTxOut addr v) =
+pcTxOut p@Shelley (ShelleyTxOut addr v) =
   ppSexp "TxOut" [pcAddr addr, pcCoreValue p v]
 
 pcScript :: forall era. Reflect era => Proof era -> Script era -> PDoc
-pcScript (Conway _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Conway _) s@(PlutusScript v) =
+pcScript Conway (TimelockScript t) = pcTimelock @era t
+pcScript p@Conway s@(PlutusScript v) =
   parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Babbage _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Babbage _) s@(PlutusScript v) =
+pcScript Babbage (TimelockScript t) = pcTimelock @era t
+pcScript p@Babbage s@(PlutusScript v) =
   parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Alonzo _) (TimelockScript t) = pcTimelock @era t
-pcScript p@(Alonzo _) s@(PlutusScript v) =
+pcScript Alonzo (TimelockScript t) = pcTimelock @era t
+pcScript p@Alonzo s@(PlutusScript v) =
   parens (hsep [ppString ("PlutusScript " <> show (plutusScriptLanguage v) <> " "), pcHashScript p s])
-pcScript (Mary _) s = pcTimelock @era s
-pcScript (Allegra _) s = pcTimelock @era s
-pcScript p@(Shelley _) s = pcMultiSig @era (pcHashScript @era p s) s
+pcScript Mary s = pcTimelock @era s
+pcScript Allegra s = pcTimelock @era s
+pcScript p@Shelley s = pcMultiSig @era (pcHashScript @era p s) s
 
 pcWitnesses ::
   Reflect era =>
@@ -1135,17 +1135,17 @@ pcPParamsField x = case x of
 -- Complicated because some Eras do NOT have type instances for all (EraRule "XXX")
 
 ppUTXOW :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXOW" era) -> PDoc
-ppUTXOW (Shelley _) x = ppShelleyUtxowPredFailure x
-ppUTXOW (Allegra _) x = ppShelleyUtxowPredFailure x
-ppUTXOW (Mary _) x = ppShelleyUtxowPredFailure x
-ppUTXOW (Alonzo _) x = ppAlonzoUtxowPredFailure x
-ppUTXOW p@(Babbage _) x = ppBabbageUtxowPredFailure p x
-ppUTXOW p@(Conway _) x = ppBabbageUtxowPredFailure p x
+ppUTXOW Shelley x = ppShelleyUtxowPredFailure x
+ppUTXOW Allegra x = ppShelleyUtxowPredFailure x
+ppUTXOW Mary x = ppShelleyUtxowPredFailure x
+ppUTXOW Alonzo x = ppAlonzoUtxowPredFailure x
+ppUTXOW p@Babbage x = ppBabbageUtxowPredFailure p x
+ppUTXOW p@Conway x = ppBabbageUtxowPredFailure p x
 
-ppUTXOS :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXOS" era) -> PDoc
-ppUTXOS (Alonzo _) x = ppUtxosPredicateFailure x
-ppUTXOS (Babbage _) x = ppUtxosPredicateFailure x
-ppUTXOS (Conway _) x = ppUtxosPredicateFailure x
+ppUTXOS :: Proof era -> PredicateFailure (EraRule "UTXOS" era) -> PDoc
+ppUTXOS Alonzo x = ppUtxosPredicateFailure x
+ppUTXOS Babbage x = ppUtxosPredicateFailure x
+ppUTXOS Conway x = ppUtxosPredicateFailure x
 ppUTXOS proof _ =
   error
     ( "Only the AlonzoEra, BabbageEra, and ConwayEra have a (PredicateFailure (EraRule \"UTXOS\" era))."
@@ -1154,12 +1154,12 @@ ppUTXOS proof _ =
     )
 
 ppDELEGS :: Proof era -> PredicateFailure (EraRule "DELEGS" era) -> PDoc
-ppDELEGS p@(Shelley _) x = ppShelleyDelegsPredFailure p x
-ppDELEGS p@(Allegra _) x = ppShelleyDelegsPredFailure p x
-ppDELEGS p@(Mary _) x = ppShelleyDelegsPredFailure p x
-ppDELEGS p@(Alonzo _) x = ppShelleyDelegsPredFailure p x
-ppDELEGS p@(Babbage _) x = ppShelleyDelegsPredFailure p x
-ppDELEGS p@(Conway _) _ =
+ppDELEGS p@Shelley x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@Allegra x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@Mary x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@Alonzo x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@Babbage x = ppShelleyDelegsPredFailure p x
+ppDELEGS p@Conway _ =
   error
     ( "Only the Shelley, Allegra, Mary, Alonzo, and Babbage era have a (PredicateFailure (EraRule \"DELEGS\" era))."
         ++ "This Era is "
@@ -1167,96 +1167,96 @@ ppDELEGS p@(Conway _) _ =
     )
 
 ppDELEG :: Proof era -> PredicateFailure (EraRule "DELEG" era) -> PDoc
-ppDELEG (Shelley _) x = ppShelleyDelegPredFailure x
-ppDELEG (Allegra _) x = ppShelleyDelegPredFailure x
-ppDELEG (Mary _) x = ppShelleyDelegPredFailure x
-ppDELEG (Alonzo _) x = ppShelleyDelegPredFailure x
-ppDELEG (Babbage _) x = ppShelleyDelegPredFailure x
-ppDELEG (Conway _) x = ppConwayDelegPredFailure x
+ppDELEG Shelley x = ppShelleyDelegPredFailure x
+ppDELEG Allegra x = ppShelleyDelegPredFailure x
+ppDELEG Mary x = ppShelleyDelegPredFailure x
+ppDELEG Alonzo x = ppShelleyDelegPredFailure x
+ppDELEG Babbage x = ppShelleyDelegPredFailure x
+ppDELEG Conway x = ppConwayDelegPredFailure x
 
 ppPOOL :: Proof era -> PredicateFailure (EraRule "POOL" era) -> PDoc
-ppPOOL (Shelley _) x = ppShelleyPoolPredFailure x
-ppPOOL (Allegra _) x = ppShelleyPoolPredFailure x
-ppPOOL (Mary _) x = ppShelleyPoolPredFailure x
-ppPOOL (Alonzo _) x = ppShelleyPoolPredFailure x
-ppPOOL (Babbage _) x = ppShelleyPoolPredFailure x
-ppPOOL (Conway _) x = ppShelleyPoolPredFailure x
+ppPOOL Shelley x = ppShelleyPoolPredFailure x
+ppPOOL Allegra x = ppShelleyPoolPredFailure x
+ppPOOL Mary x = ppShelleyPoolPredFailure x
+ppPOOL Alonzo x = ppShelleyPoolPredFailure x
+ppPOOL Babbage x = ppShelleyPoolPredFailure x
+ppPOOL Conway x = ppShelleyPoolPredFailure x
 
 ppLEDGER :: Reflect era => Proof era -> PredicateFailure (EraRule "LEDGER" era) -> PDoc
-ppLEDGER p@(Shelley _) x = ppShelleyLedgerPredFailure p x
-ppLEDGER p@(Allegra _) x = ppShelleyLedgerPredFailure p x
-ppLEDGER p@(Mary _) x = ppShelleyLedgerPredFailure p x
-ppLEDGER p@(Alonzo _) x = ppShelleyLedgerPredFailure p x
-ppLEDGER p@(Babbage _) x = ppShelleyLedgerPredFailure p x
-ppLEDGER p@(Conway _) x = ppConwayLedgerPredFailure p x
+ppLEDGER p@Shelley x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@Allegra x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@Mary x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@Alonzo x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@Babbage x = ppShelleyLedgerPredFailure p x
+ppLEDGER p@Conway x = ppConwayLedgerPredFailure p x
 
-ppUTXO :: Reflect era => Proof era -> PredicateFailure (EraRule "UTXO" era) -> PDoc
-ppUTXO (Shelley _) x = ppShelleyUtxoPredFailure x
-ppUTXO (Allegra _) x = ppAllegraUtxoPredFailure x
-ppUTXO (Mary _) x = ppAllegraUtxoPredFailure x
-ppUTXO (Alonzo _) x = ppAlonzoUtxoPredFailure x
-ppUTXO (Babbage _) x = ppBabbageUtxoPredFailure x
-ppUTXO (Conway _) x = ppBabbageUtxoPredFailure x
+ppUTXO :: Proof era -> PredicateFailure (EraRule "UTXO" era) -> PDoc
+ppUTXO Shelley x = ppShelleyUtxoPredFailure x
+ppUTXO Allegra x = ppAllegraUtxoPredFailure x
+ppUTXO Mary x = ppAllegraUtxoPredFailure x
+ppUTXO Alonzo x = ppAlonzoUtxoPredFailure x
+ppUTXO Babbage x = ppBabbageUtxoPredFailure x
+ppUTXO Conway x = ppBabbageUtxoPredFailure x
 
 ppLEDGERS :: Proof era -> PredicateFailure (EraRule "LEDGERS" era) -> PDoc
-ppLEDGERS p@(Shelley _) x = unReflect ppShelleyLedgersPredFailure p x
-ppLEDGERS p@(Allegra _) x = unReflect ppShelleyLedgersPredFailure p x
-ppLEDGERS p@(Mary _) x = unReflect ppShelleyLedgersPredFailure p x
-ppLEDGERS p@(Alonzo _) x = unReflect ppShelleyLedgersPredFailure p x
-ppLEDGERS p@(Babbage _) x = unReflect ppShelleyLedgersPredFailure p x
-ppLEDGERS p@(Conway _) x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Shelley x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Allegra x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Mary x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Alonzo x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Babbage x = unReflect ppShelleyLedgersPredFailure p x
+ppLEDGERS p@Conway x = unReflect ppShelleyLedgersPredFailure p x
 
 ppDELPL :: Proof era -> PredicateFailure (EraRule "DELPL" era) -> PDoc
-ppDELPL p@(Shelley _) x = ppShelleyDelplPredFailure p x
-ppDELPL p@(Allegra _) x = ppShelleyDelplPredFailure p x
-ppDELPL p@(Mary _) x = ppShelleyDelplPredFailure p x
-ppDELPL p@(Alonzo _) x = ppShelleyDelplPredFailure p x
-ppDELPL p@(Babbage _) x = ppShelleyDelplPredFailure p x
-ppDELPL p@(Conway _) _ =
+ppDELPL p@Shelley x = ppShelleyDelplPredFailure p x
+ppDELPL p@Allegra x = ppShelleyDelplPredFailure p x
+ppDELPL p@Mary x = ppShelleyDelplPredFailure p x
+ppDELPL p@Alonzo x = ppShelleyDelplPredFailure p x
+ppDELPL p@Babbage x = ppShelleyDelplPredFailure p x
+ppDELPL p@Conway _ =
   error
     ( "Only the Shelley, Allegra, Mary, Alonzo, and Babbage era have a (PredicateFailure (EraRule \"DELPL\" era))."
         ++ "This Era is "
         ++ show p
     )
 
-ppNEWEPOCH :: Reflect era => Proof era -> PredicateFailure (EraRule "NEWEPOCH" era) -> PDoc
-ppNEWEPOCH (Shelley _) x = ppShelleyNewEpochPredicateFailure x
-ppNEWEPOCH (Allegra _) x = ppShelleyNewEpochPredicateFailure x
-ppNEWEPOCH (Mary _) x = ppShelleyNewEpochPredicateFailure x
-ppNEWEPOCH (Alonzo _) x = ppShelleyNewEpochPredicateFailure x
-ppNEWEPOCH (Babbage _) x = ppShelleyNewEpochPredicateFailure x
-ppNEWEPOCH (Conway _) x = ppConwayNewEpochPredFailure x
+ppNEWEPOCH :: Proof era -> PredicateFailure (EraRule "NEWEPOCH" era) -> PDoc
+ppNEWEPOCH Shelley x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH Allegra x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH Mary x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH Alonzo x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH Babbage x = ppShelleyNewEpochPredicateFailure x
+ppNEWEPOCH Conway x = ppConwayNewEpochPredFailure x
 
-ppEPOCH :: Reflect era => Proof era -> PredicateFailure (EraRule "EPOCH" era) -> PDoc
-ppEPOCH (Shelley _) x = ppShelleyEpochPredFailure x
-ppEPOCH (Allegra _) x = ppShelleyEpochPredFailure x
-ppEPOCH (Mary _) x = ppShelleyEpochPredFailure x
-ppEPOCH (Alonzo _) x = ppShelleyEpochPredFailure x
-ppEPOCH (Babbage _) x = ppShelleyEpochPredFailure x
-ppEPOCH (Conway _) _ = ppString "PredicateFailure (ConwayEPOCH era) = Void, and can never Fail"
+ppEPOCH :: Proof era -> PredicateFailure (EraRule "EPOCH" era) -> PDoc
+ppEPOCH Shelley x = ppShelleyEpochPredFailure x
+ppEPOCH Allegra x = ppShelleyEpochPredFailure x
+ppEPOCH Mary x = ppShelleyEpochPredFailure x
+ppEPOCH Alonzo x = ppShelleyEpochPredFailure x
+ppEPOCH Babbage x = ppShelleyEpochPredFailure x
+ppEPOCH Conway _ = ppString "PredicateFailure (ConwayEPOCH era) = Void, and can never Fail"
 
 -- | A bit different since it is NOT of the form: PredicateFailure (EraRule "UPEC" era)
 --   but instead, the type family UpecPredFailurePV pv era
 --   where, type UpecPredFailure era = UpecPredFailurePV (ProtVerLow era) era
 --   But the effect is still the same. The Proof era, fixes the type family result.
 ppUPEC :: Proof era -> UpecPredFailure era -> PDoc
-ppUPEC (Shelley _) x = ppUpecPredicateFailure x
-ppUPEC (Mary _) x = ppUpecPredicateFailure x
-ppUPEC (Alonzo _) x = ppUpecPredicateFailure x
-ppUPEC (Allegra _) x = ppUpecPredicateFailure x
-ppUPEC (Babbage _) x = ppUpecPredicateFailure x
-ppUPEC (Conway _) x = absurd x
+ppUPEC Shelley x = ppUpecPredicateFailure x
+ppUPEC Mary x = ppUpecPredicateFailure x
+ppUPEC Alonzo x = ppUpecPredicateFailure x
+ppUPEC Allegra x = ppUpecPredicateFailure x
+ppUPEC Babbage x = ppUpecPredicateFailure x
+ppUPEC Conway x = absurd x
 
 -- | A bit different since it is NOT of the form: PredicateFailure (EraRule "LEDGERS" era)
 --   but instead:  State (EraRule "LEDGERS" era)
 --   But the effect is still the same. The Proof era, fixes the type family result.
 ppStateLEDGERS :: Proof era -> State (EraRule "LEDGERS" era) -> PDoc
-ppStateLEDGERS p@(Shelley _) = pcLedgerState p
-ppStateLEDGERS p@(Allegra _) = pcLedgerState p
-ppStateLEDGERS p@(Mary _) = pcLedgerState p
-ppStateLEDGERS p@(Alonzo _) = pcLedgerState p
-ppStateLEDGERS p@(Babbage _) = pcLedgerState p
-ppStateLEDGERS p@(Conway _) = pcLedgerState p
+ppStateLEDGERS p@Shelley = pcLedgerState p
+ppStateLEDGERS p@Allegra = pcLedgerState p
+ppStateLEDGERS p@Mary = pcLedgerState p
+ppStateLEDGERS p@Alonzo = pcLedgerState p
+ppStateLEDGERS p@Babbage = pcLedgerState p
+ppStateLEDGERS p@Conway = pcLedgerState p
 
 -- ============================================================================
 -- pretty printers for concrete types that are the target of PredicateFailure type instances
@@ -1292,18 +1292,18 @@ ppConwayLedgerPredFailure proof x = case x of
   ConwayWdrlNotDelegatedToDRep s -> ppSexp "ConwayWdrlNotDelegatedToDRep" [ppSet pcCredential s]
   ConwayTreasuryValueMismatch c1 c2 -> ppSexp "ConwayTreasuryValueMismatch" [pcCoin c1, pcCoin c2]
   ConwayGovFailure y -> case proof of
-    Conway _ -> ppSexp "ConwayGovFailure" [ppConwayGovPredFailure y]
+    Conway -> ppSexp "ConwayGovFailure" [ppConwayGovPredFailure y]
     _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOV\" era)). This Era is " ++ show proof)
   ConwayUtxowFailure y -> ppUTXOW proof y
   {- case proof of -- (PredicateFailure (EraRule "UTXOW" era))
-    Shelley _ -> ppShelleyUtxowPredFailure y
-    Allegra _ -> ppShelleyUtxowPredFailure y
-    Mary _ -> ppShelleyUtxowPredFailure y
-    Alonzo _ -> ppAlonzoUtxowPredFailure y
-    Babbage _ -> ppBabbageUtxowPredFailure proof y
-    Conway _ -> ppBabbageUtxowPredFailure proof y -}
+    Shelley -> ppShelleyUtxowPredFailure y
+    Allegra -> ppShelleyUtxowPredFailure y
+    Mary -> ppShelleyUtxowPredFailure y
+    Alonzo -> ppAlonzoUtxowPredFailure y
+    Babbage -> ppBabbageUtxowPredFailure proof y
+    Conway -> ppBabbageUtxowPredFailure proof y -}
   ConwayCertsFailure pf -> case proof of
-    Conway _ -> ppConwayCertsPredFailure proof pf
+    Conway -> ppConwayCertsPredFailure proof pf
     _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"CERTS\" era)). This Era is " ++ show proof)
 
 instance Reflect era => PrettyA (ConwayLedgerPredFailure era) where
@@ -1314,7 +1314,7 @@ ppConwayCertPredFailure proof x = case x of
   ConwayRules.DelegFailure pf -> ppSexp "DelegFailure" [ppDELEG proof pf] -- (PredicateFailure (EraRule "DELEG" era))
   ConwayRules.PoolFailure pf -> ppSexp ".PoolFailure" [ppPOOL proof pf] -- (PredicateFailure (EraRule "POOL" era))
   ConwayRules.GovCertFailure pf -> case proof of
-    Conway _ -> ppSexp "GovCertFailure" [ppConwayGovCertPredFailure pf] -- (PredicateFailure (EraRule "GOVCERT" era))
+    Conway -> ppSexp "GovCertFailure" [ppConwayGovCertPredFailure pf] -- (PredicateFailure (EraRule "GOVCERT" era))
     _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOVCERT\" era)). This Era is " ++ show proof)
 
 instance Reflect era => PrettyA (ConwayRules.ConwayCertPredFailure era) where
@@ -1335,7 +1335,7 @@ ppConwayCertsPredFailure proof x = case x of
   ConwayRules.DelegateeNotRegisteredDELEG kh -> ppSexp "DelegateeNotRegisteredDELEG" [pcKeyHash kh]
   WithdrawalsNotInRewardsCERTS m -> ppSexp "WithdrawalsNotInRewardsCERTS" [ppMap pcRewardAcnt pcCoin m]
   CertFailure pf -> case proof of
-    Conway _ -> ppSexp " CertFailure" [ppConwayCertPredFailure proof pf] -- !(PredicateFailure (EraRule "CERT" era))
+    Conway -> ppSexp " CertFailure" [ppConwayCertPredFailure proof pf] -- !(PredicateFailure (EraRule "CERT" era))
     _ -> error ("Only the ConwayEra has a (PredicateFailure (EraRule \"CERT\" era)). This Era is " ++ show proof)
 
 instance Reflect era => PrettyA (ConwayCertsPredFailure era) where
@@ -1797,32 +1797,32 @@ ppCollectError (BadTranslation x) = ppSexp "BadTranslation" [ppContextError x]
 ppContextError :: forall era. Reflect era => ContextError era -> PDoc
 ppContextError e =
   case reify @era of
-    Shelley _ -> error "Unsuported"
-    Allegra _ -> error "Unsuported"
-    Mary _ -> error "Unsuported"
-    Alonzo _ -> ppString (show e)
-    Babbage _ -> ppString (show e)
-    Conway _ -> ppString (show e)
+    Shelley -> error "Unsuported"
+    Allegra -> error "Unsuported"
+    Mary -> error "Unsuported"
+    Alonzo -> ppString (show e)
+    Babbage -> ppString (show e)
+    Conway -> ppString (show e)
 
 ppPlutusPurposeAsIndex :: forall era. Reflect era => PlutusPurpose AsIndex era -> PDoc
 ppPlutusPurposeAsIndex p =
   case reify @era of
-    Shelley _ -> error "Unsuported"
-    Allegra _ -> error "Unsuported"
-    Mary _ -> error "Unsuported"
-    Alonzo _ -> prettyA p
-    Babbage _ -> prettyA p
-    Conway _ -> prettyA p
+    Shelley -> error "Unsuported"
+    Allegra -> error "Unsuported"
+    Mary -> error "Unsuported"
+    Alonzo -> prettyA p
+    Babbage -> prettyA p
+    Conway -> prettyA p
 
 ppPlutusPurposeAsItem :: forall era. Reflect era => PlutusPurpose AsItem era -> PDoc
 ppPlutusPurposeAsItem p =
   case reify @era of
-    Shelley _ -> error "Unsuported"
-    Allegra _ -> error "Unsuported"
-    Mary _ -> error "Unsuported"
-    Alonzo _ -> prettyA p
-    Babbage _ -> prettyA p
-    Conway _ -> prettyA p
+    Shelley -> error "Unsuported"
+    Allegra -> error "Unsuported"
+    Mary -> error "Unsuported"
+    Alonzo -> prettyA p
+    Babbage -> prettyA p
+    Conway -> prettyA p
 
 instance Reflect era => PrettyA (CollectError era) where
   prettyA = ppCollectError
@@ -2062,15 +2062,15 @@ txInSummary :: TxIn era -> PDoc
 txInSummary (TxIn (TxId h) n) = ppSexp "TxIn" [trim (ppSafeHash h), ppInt (txIxToInt n)]
 
 txOutSummary :: Proof era -> TxOut era -> PDoc
-txOutSummary p@(Conway _) (BabbageTxOut addr v d s) =
+txOutSummary p@Conway (BabbageTxOut addr v d s) =
   ppSexp "TxOut" [addrSummary addr, pcCoreValue p v, datumSummary d, ppStrictMaybe (scriptSummary p) s]
-txOutSummary p@(Babbage _) (BabbageTxOut addr v d s) =
+txOutSummary p@Babbage (BabbageTxOut addr v d s) =
   ppSexp "TxOut" [addrSummary addr, pcCoreValue p v, datumSummary d, ppStrictMaybe (scriptSummary p) s]
-txOutSummary p@(Alonzo _) (AlonzoTxOut addr v md) =
+txOutSummary p@Alonzo (AlonzoTxOut addr v md) =
   ppSexp "TxOut" [addrSummary addr, pcCoreValue p v, ppStrictMaybe dataHashSummary md]
-txOutSummary p@(Mary _) (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
-txOutSummary p@(Allegra _) (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
-txOutSummary p@(Shelley _) (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
+txOutSummary p@Mary (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
+txOutSummary p@Allegra (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
+txOutSummary p@Shelley (ShelleyTxOut addr v) = ppSexp "TxOut" [addrSummary addr, pcCoreValue p v]
 
 datumSummary :: Era era => Datum era -> PDoc
 datumSummary NoDatum = ppString "NoDatum"
@@ -2095,12 +2095,12 @@ vSummary (MaryValue n ma) =
   ppSexp "Value" [pcCoin n, multiAssetSummary ma]
 
 scriptSummary :: forall era. Proof era -> Script era -> PDoc
-scriptSummary p@(Conway _) script = plutusSummary p script
-scriptSummary p@(Babbage _) script = plutusSummary p script
-scriptSummary p@(Alonzo _) script = plutusSummary p script
-scriptSummary (Mary _) script = timelockSummary script
-scriptSummary (Allegra _) script = timelockSummary script
-scriptSummary (Shelley _) script = multiSigSummary script
+scriptSummary p@Conway script = plutusSummary p script
+scriptSummary p@Babbage script = plutusSummary p script
+scriptSummary p@Alonzo script = plutusSummary p script
+scriptSummary Mary script = timelockSummary script
+scriptSummary Allegra script = timelockSummary script
+scriptSummary Shelley script = multiSigSummary script
 
 networkSummary :: Network -> PDoc
 networkSummary Testnet = ppString "Test"
@@ -2163,15 +2163,15 @@ multiSigSummary (SS.RequireAnyOf ps) = ppSexp "AnyOf" (map multiSigSummary ps)
 multiSigSummary (SS.RequireMOf m ps) = ppSexp "MOf" (ppInt m : map multiSigSummary ps)
 
 plutusSummary :: forall era. Proof era -> AlonzoScript era -> PDoc
-plutusSummary (Conway _) s@(PlutusScript plutusScript) =
+plutusSummary Conway s@(PlutusScript plutusScript) =
   ppString (show (plutusScriptLanguage plutusScript) ++ " ") <> scriptHashSummary (hashScript @era s)
-plutusSummary (Conway _) (TimelockScript x) = timelockSummary x
-plutusSummary (Babbage _) s@(PlutusScript plutusScript) =
+plutusSummary Conway (TimelockScript x) = timelockSummary x
+plutusSummary Babbage s@(PlutusScript plutusScript) =
   ppString (show (plutusScriptLanguage plutusScript) ++ " ") <> scriptHashSummary (hashScript @era s)
-plutusSummary (Babbage _) (TimelockScript x) = timelockSummary x
-plutusSummary (Alonzo _) s@(PlutusScript plutusScript) =
+plutusSummary Babbage (TimelockScript x) = timelockSummary x
+plutusSummary Alonzo s@(PlutusScript plutusScript) =
   ppString (show (plutusScriptLanguage plutusScript) ++ " ") <> scriptHashSummary (hashScript @era s)
-plutusSummary (Alonzo _) (TimelockScript x) = timelockSummary x
+plutusSummary Alonzo (TimelockScript x) = timelockSummary x
 plutusSummary other _ = ppString ("Plutus script in era " ++ show other ++ "???")
 
 dStateSummary :: DState c -> PDoc
@@ -2269,12 +2269,12 @@ instance PrettyA (Addr c) where prettyA = pcAddr
 
 -- | Value is a type family, so it has no PrettyA instance.
 pcCoreValue :: Proof era -> Value era -> PDoc
-pcCoreValue (Conway _) v = vSummary v
-pcCoreValue (Babbage _) v = vSummary v
-pcCoreValue (Alonzo _) v = vSummary v
-pcCoreValue (Mary _) v = vSummary v
-pcCoreValue (Allegra _) (Coin n) = hsep [ppString "₳", ppInteger n]
-pcCoreValue (Shelley _) (Coin n) = hsep [ppString "₳", ppInteger n]
+pcCoreValue Conway v = vSummary v
+pcCoreValue Babbage v = vSummary v
+pcCoreValue Alonzo v = vSummary v
+pcCoreValue Mary v = vSummary v
+pcCoreValue Allegra (Coin n) = hsep [ppString "₳", ppInteger n]
+pcCoreValue Shelley (Coin n) = hsep [ppString "₳", ppInteger n]
 
 pcCoin :: Coin -> PDoc
 pcCoin (Coin n) = hsep [ppString "₳", ppInteger n]
@@ -2294,12 +2294,12 @@ instance PrettyA (MaryValue c) where
   prettyA = pcValue
 
 pcVal :: Proof era -> Value era -> PDoc
-pcVal (Shelley _) v = pcCoin v
-pcVal (Allegra _) v = pcCoin v
-pcVal (Mary _) v = pcValue v
-pcVal (Alonzo _) v = pcValue v
-pcVal (Babbage _) v = pcValue v
-pcVal (Conway _) v = pcValue v
+pcVal Shelley v = pcCoin v
+pcVal Allegra v = pcCoin v
+pcVal Mary v = pcValue v
+pcVal Alonzo v = pcValue v
+pcVal Babbage v = pcValue v
+pcVal Conway v = pcValue v
 
 pcDatum :: Era era => Datum era -> PDoc
 pcDatum NoDatum = ppString "NoDatum"
@@ -2349,12 +2349,12 @@ instance PrettyA (ScriptHash era) where
   prettyA = pcScriptHash
 
 pcHashScript :: forall era. Reflect era => Proof era -> Script era -> PDoc
-pcHashScript (Conway _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
-pcHashScript (Babbage _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
-pcHashScript (Alonzo _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
-pcHashScript (Mary _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
-pcHashScript (Allegra _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
-pcHashScript (Shelley _) s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Conway s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Babbage s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Alonzo s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Mary s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Allegra s = ppString "Hash " <> pcScriptHash (hashScript @era s)
+pcHashScript Shelley s = ppString "Hash " <> pcScriptHash (hashScript @era s)
 
 instance (Script era ~ AlonzoScript era, Reflect era) => PrettyA (AlonzoScript era) where
   prettyA = pcScript reify
@@ -2461,12 +2461,12 @@ instance PrettyA (Delegatee c) where
   prettyA = pcDelegatee
 
 pcTxCert :: Proof era -> TxCert era -> PDoc
-pcTxCert (Shelley _) x = pcShelleyTxCert x
-pcTxCert (Allegra _) x = pcShelleyTxCert x
-pcTxCert (Mary _) x = pcShelleyTxCert x
-pcTxCert (Alonzo _) x = pcShelleyTxCert x
-pcTxCert (Babbage _) x = pcShelleyTxCert x
-pcTxCert (Conway _) x = pcConwayTxCert x
+pcTxCert Shelley x = pcShelleyTxCert x
+pcTxCert Allegra x = pcShelleyTxCert x
+pcTxCert Mary x = pcShelleyTxCert x
+pcTxCert Alonzo x = pcShelleyTxCert x
+pcTxCert Babbage x = pcShelleyTxCert x
+pcTxCert Conway x = pcConwayTxCert x
 
 pcGovProcedures :: forall era. GovProcedures era -> PDoc
 pcGovProcedures (GovProcedures vote proposal) =
@@ -2897,12 +2897,12 @@ pcPoolDistr (PoolDistr pdistr) =
 instance PrettyA (PoolDistr c) where prettyA = pcPoolDistr
 
 withEraPParams :: forall era a. Proof era -> (Core.EraPParams era => a) -> a
-withEraPParams (Shelley _) x = x
-withEraPParams (Mary _) x = x
-withEraPParams (Allegra _) x = x
-withEraPParams (Alonzo _) x = x
-withEraPParams (Babbage _) x = x
-withEraPParams (Conway _) x = x
+withEraPParams Shelley x = x
+withEraPParams Mary x = x
+withEraPParams Allegra x = x
+withEraPParams Alonzo x = x
+withEraPParams Babbage x = x
+withEraPParams Conway x = x
 
 -- | Print just a few of the PParams fields
 pcPParamsSynopsis :: forall era. Proof era -> Core.PParams era -> PDoc
@@ -3172,16 +3172,16 @@ instance
     ConwayVoting i -> ppSexp "ConwayVoting" [prettyA i]
     ConwayProposing i -> ppSexp "ConwayProposing" [prettyA i]
 
--- ScriptsNeeded is a typr family so it doesn't have PrettyA instance, use pcScriptsNeeded instead of prettyA
+-- ScriptsNeeded is a type family so it doesn't have PrettyA instance, use pcScriptsNeeded instead of prettyA
 pcScriptsNeeded :: Reflect era => Proof era -> ScriptsNeeded era -> PDoc
-pcScriptsNeeded (Shelley _) (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
-pcScriptsNeeded (Allegra _) (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
-pcScriptsNeeded (Mary _) (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
-pcScriptsNeeded (Alonzo _) (AlonzoScriptsNeeded pl) =
+pcScriptsNeeded Shelley (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
+pcScriptsNeeded Allegra (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
+pcScriptsNeeded Mary (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
+pcScriptsNeeded Alonzo (AlonzoScriptsNeeded pl) =
   ppSexp "ScriptsNeeded" [ppList (ppPair prettyA pcScriptHash) pl]
-pcScriptsNeeded (Babbage _) (AlonzoScriptsNeeded pl) =
+pcScriptsNeeded Babbage (AlonzoScriptsNeeded pl) =
   ppSexp "ScriptsNeeded" [ppList (ppPair prettyA pcScriptHash) pl]
-pcScriptsNeeded (Conway _) (AlonzoScriptsNeeded pl) =
+pcScriptsNeeded Conway (AlonzoScriptsNeeded pl) =
   ppSexp "ScriptsNeeded" [ppList (ppPair prettyA pcScriptHash) pl]
 
 pcDRepPulser :: DRepPulser era Identity (RatifyState era) -> PDoc

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyTest.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyTest.hs
@@ -8,7 +8,7 @@ import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Prettyprinter.Util (putDocW)
 import Test.Cardano.Ledger.Generic.PrettyCore
-import Test.Cardano.Ledger.Generic.Proof (Evidence (Standard), Proof (Shelley))
+import Test.Cardano.Ledger.Generic.Proof (Proof (Shelley))
 import Test.Cardano.Ledger.Shelley.Arbitrary ()
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.Tasty
@@ -56,4 +56,4 @@ prettyTest =
     , testPP "LedgerState" (pcLedgerState proof) ls
     ]
   where
-    proof = Shelley Standard
+    proof = Shelley

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -79,22 +79,22 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 -- Top level generators of TRC
 
 genTxAndUTXOState :: Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
-genTxAndUTXOState proof@(Conway _) gsize = do
+genTxAndUTXOState proof@Conway gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Babbage _) gsize = do
+genTxAndUTXOState proof@Babbage gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Alonzo _) gsize = do
+genTxAndUTXOState proof@Alonzo gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Mary _) gsize = do
+genTxAndUTXOState proof@Mary gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Allegra _) gsize = do
+genTxAndUTXOState proof@Allegra gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
-genTxAndUTXOState proof@(Shelley _) gsize = do
+genTxAndUTXOState proof@Shelley gsize = do
   (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <- genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 
@@ -180,35 +180,35 @@ coreTypesRoundTrip =
     "Core types make generic roundtrips"
     [ testGroup
         "TxWits roundtrip"
-        [ testPropMax 30 "Babbage era" $ txWitRoundTrip (Babbage Mock)
-        , testPropMax 30 "Alonzo era" $ txWitRoundTrip (Alonzo Mock)
-        , testPropMax 30 "Mary era" $ txWitRoundTrip (Mary Mock)
-        , testPropMax 30 "Allegra era" $ txWitRoundTrip (Allegra Mock)
-        , testPropMax 30 "Shelley era" $ txWitRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txWitRoundTrip Babbage
+        , testPropMax 30 "Alonzo era" $ txWitRoundTrip Alonzo
+        , testPropMax 30 "Mary era" $ txWitRoundTrip Mary
+        , testPropMax 30 "Allegra era" $ txWitRoundTrip Allegra
+        , testPropMax 30 "Shelley era" $ txWitRoundTrip Shelley
         ]
     , testGroup
         "TxBody roundtrips"
-        [ testPropMax 30 "Babbage era" $ txBodyRoundTrip (Babbage Mock)
-        , testPropMax 30 "Alonzo era" $ txBodyRoundTrip (Alonzo Mock)
-        , testPropMax 30 "Mary era" $ txBodyRoundTrip (Mary Mock)
-        , testPropMax 30 "Allegra era" $ txBodyRoundTrip (Allegra Mock)
-        , testPropMax 30 "Shelley era" $ txBodyRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txBodyRoundTrip Babbage
+        , testPropMax 30 "Alonzo era" $ txBodyRoundTrip Alonzo
+        , testPropMax 30 "Mary era" $ txBodyRoundTrip Mary
+        , testPropMax 30 "Allegra era" $ txBodyRoundTrip Allegra
+        , testPropMax 30 "Shelley era" $ txBodyRoundTrip Shelley
         ]
     , testGroup
         "TxOut roundtrips"
-        [ testPropMax 30 "Babbage era" $ txOutRoundTrip (Babbage Mock)
-        , testPropMax 30 "Alonzo era" $ txOutRoundTrip (Alonzo Mock)
-        , testPropMax 30 "Mary era" $ txOutRoundTrip (Mary Mock)
-        , testPropMax 30 "Allegra era" $ txOutRoundTrip (Allegra Mock)
-        , testPropMax 30 "Shelley era" $ txOutRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txOutRoundTrip Babbage
+        , testPropMax 30 "Alonzo era" $ txOutRoundTrip Alonzo
+        , testPropMax 30 "Mary era" $ txOutRoundTrip Mary
+        , testPropMax 30 "Allegra era" $ txOutRoundTrip Allegra
+        , testPropMax 30 "Shelley era" $ txOutRoundTrip Shelley
         ]
     , testGroup
         "Tx roundtrips"
-        [ testPropMax 30 "Babbage era" $ txRoundTrip (Babbage Mock)
-        , testPropMax 30 "Alonzo era" $ txRoundTrip (Alonzo Mock)
-        , testPropMax 30 "Mary era" $ txRoundTrip (Mary Mock)
-        , testPropMax 30 "Allegra era" $ txRoundTrip (Allegra Mock)
-        , testPropMax 30 "Shelley era" $ txRoundTrip (Shelley Mock)
+        [ testPropMax 30 "Babbage era" $ txRoundTrip Babbage
+        , testPropMax 30 "Alonzo era" $ txRoundTrip Alonzo
+        , testPropMax 30 "Mary era" $ txRoundTrip Mary
+        , testPropMax 30 "Allegra era" $ txRoundTrip Allegra
+        , testPropMax 30 "Shelley era" $ txRoundTrip Shelley
         ]
     ]
 
@@ -218,18 +218,18 @@ txPreserveAda genSize =
   testGroup
     "Individual Tx's preserve Ada"
     [ testPropMax 30 "Shelley Tx preserves ADA" $
-        forAll (genTxAndLEDGERState (Shelley Mock) genSize) (testTxValidForLEDGER (Shelley Mock))
+        forAll (genTxAndLEDGERState Shelley genSize) (testTxValidForLEDGER Shelley)
     , testPropMax 30 "Allegra Tx preserves ADA" $
-        forAll (genTxAndLEDGERState (Allegra Mock) genSize) (testTxValidForLEDGER (Allegra Mock))
+        forAll (genTxAndLEDGERState Allegra genSize) (testTxValidForLEDGER Allegra)
     , testPropMax 30 "Mary Tx preserves ADA" $
-        forAll (genTxAndLEDGERState (Mary Mock) genSize) (testTxValidForLEDGER (Mary Mock))
+        forAll (genTxAndLEDGERState Mary genSize) (testTxValidForLEDGER Mary)
     , testPropMax 30 "Alonzo ValidTx preserves ADA" $
-        forAll (genTxAndLEDGERState (Alonzo Mock) genSize) (testTxValidForLEDGER (Alonzo Mock))
+        forAll (genTxAndLEDGERState Alonzo genSize) (testTxValidForLEDGER Alonzo)
     , testPropMax 30 "Babbage ValidTx preserves ADA" $
-        forAll (genTxAndLEDGERState (Babbage Mock) genSize) (testTxValidForLEDGER (Babbage Mock))
+        forAll (genTxAndLEDGERState Babbage genSize) (testTxValidForLEDGER Babbage)
         -- TODO
         -- testPropMax 30 "Conway ValidTx preserves ADA" $
-        --  forAll (genTxAndLEDGERState (Conway Mock) genSize) (testTxValidForLEDGER (Conway Mock))
+        --  forAll (genTxAndLEDGERState Conway genSize) (testTxValidForLEDGER Conway)
     ]
 
 -- | Ada is preserved over a trace of length 100
@@ -254,14 +254,14 @@ tracePreserveAda numTx gensize =
   testGroup
     ("Total Ada is preserved over traces of length " ++ show numTx)
     [ adaIsPreservedBabbage numTx gensize
-    , adaIsPreserved (Alonzo Mock) numTx gensize
-    , adaIsPreserved (Mary Mock) numTx gensize
-    , adaIsPreserved (Allegra Mock) numTx gensize
-    , adaIsPreserved (Shelley Mock) numTx gensize
+    , adaIsPreserved Alonzo numTx gensize
+    , adaIsPreserved Mary numTx gensize
+    , adaIsPreserved Allegra numTx gensize
+    , adaIsPreserved Shelley numTx gensize
     ]
 
 adaIsPreservedBabbage :: Int -> GenSize -> TestTree
-adaIsPreservedBabbage numTx gensize = adaIsPreserved (Babbage Mock) numTx gensize
+adaIsPreservedBabbage numTx gensize = adaIsPreserved Babbage numTx gensize
 
 -- | The incremental Stake invaraint is preserved over a trace of length 100=
 stakeInvariant :: EraTxOut era => MockChainState era -> MockChainState era -> Property
@@ -285,12 +285,12 @@ incrementalStake genSize =
   testGroup
     "Incremental Stake invariant holds"
     [ -- TODO re-enable this once we have added all the new rules to Conway
-      -- incrementStakeInvariant (Conway Mock) genSize,
-      incrementStakeInvariant (Babbage Mock) genSize
-    , incrementStakeInvariant (Alonzo Mock) genSize
-    , incrementStakeInvariant (Mary Mock) genSize
-    , incrementStakeInvariant (Allegra Mock) genSize
-    , incrementStakeInvariant (Shelley Mock) genSize
+      -- incrementStakeInvariant Conway genSize,
+      incrementStakeInvariant Babbage genSize
+    , incrementStakeInvariant Alonzo genSize
+    , incrementStakeInvariant Mary genSize
+    , incrementStakeInvariant Allegra genSize
+    , incrementStakeInvariant Shelley genSize
     ]
 
 genericProperties :: GenSize -> TestTree
@@ -310,11 +310,11 @@ epochPreserveAda :: GenSize -> TestTree
 epochPreserveAda genSize =
   testGroup
     "Ada is preserved in each epoch"
-    [ adaIsPreservedInEachEpoch (Babbage Mock) genSize
-    , adaIsPreservedInEachEpoch (Alonzo Mock) genSize
-    , adaIsPreservedInEachEpoch (Mary Mock) genSize
-    , adaIsPreservedInEachEpoch (Allegra Mock) genSize
-    , adaIsPreservedInEachEpoch (Shelley Mock) genSize
+    [ adaIsPreservedInEachEpoch Babbage genSize
+    , adaIsPreservedInEachEpoch Alonzo genSize
+    , adaIsPreservedInEachEpoch Mary genSize
+    , adaIsPreservedInEachEpoch Allegra genSize
+    , adaIsPreservedInEachEpoch Shelley genSize
     ]
 
 adaIsPreservedInEachEpoch ::
@@ -361,22 +361,22 @@ main :: IO ()
 main = defaultMain $ adaIsPreservedBabbage 100 (def {blocksizeMax = 4})
 
 main8 :: IO ()
-main8 = test 100 (Babbage Mock)
+main8 = test 100 Babbage
 
-test :: ReflectC (EraCrypto era) => Int -> Proof era -> IO ()
+test :: Int -> Proof era -> IO ()
 test n proof = defaultMain $
   case proof of
     -- TODO
-    -- Conway _ ->
+    -- Conway ->
     --  testPropMax 30 "Conway ValidTx preserves ADA" $
     --    withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
-    Babbage _ ->
+    Babbage ->
       testPropMax 30 "Babbage ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
-    Alonzo _ ->
+    Alonzo ->
       testPropMax 30 "Alonzo ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
-    Shelley _ ->
+    Shelley ->
       testPropMax 30 "Shelley ValidTx preserves ADA" $
         withMaxSuccess n (forAll (genTxAndLEDGERState proof def) (testTxValidForLEDGER proof))
     other -> error ("NO Test in era " ++ show other)
@@ -402,9 +402,9 @@ runTest computeWith action proof = do
   action ans
 
 main2 :: IO ()
-main2 = runTest (\x -> fst <$> genAlonzoTx x (SlotNo 0)) (const (pure ())) (Babbage Mock)
+main2 = runTest (\x -> fst <$> genAlonzoTx x (SlotNo 0)) (const (pure ())) Babbage
 
 main3 :: IO ()
-main3 = runTest (\_x -> UTxO . fst <$> genUTxO) action (Alonzo Mock)
+main3 = runTest (\_x -> UTxO . fst <$> genUTxO) action Alonzo
   where
     action (UTxO x) = putStrLn ("Size = " ++ show (Map.size x))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -146,21 +146,21 @@ instance Same era (VState era) where
     ]
 
 sameUTxO :: Proof era -> UTxO era -> UTxO era -> Maybe PDoc
-sameUTxO (Shelley _) x y = eqByShow x y
-sameUTxO (Allegra _) x y = eqByShow x y
-sameUTxO (Mary _) x y = eqByShow x y
-sameUTxO (Alonzo _) x y = eqByShow x y
-sameUTxO (Babbage _) x y = eqByShow x y
-sameUTxO (Conway _) x y = eqByShow x y
+sameUTxO Shelley x y = eqByShow x y
+sameUTxO Allegra x y = eqByShow x y
+sameUTxO Mary x y = eqByShow x y
+sameUTxO Alonzo x y = eqByShow x y
+sameUTxO Babbage x y = eqByShow x y
+sameUTxO Conway x y = eqByShow x y
 {-# NOINLINE sameUTxO #-}
 
 samePPUP :: Proof era -> ShelleyGovState era -> ShelleyGovState era -> Maybe PDoc
-samePPUP (Shelley _) x y = eqByShow x y
-samePPUP (Allegra _) x y = eqByShow x y
-samePPUP (Mary _) x y = eqByShow x y
-samePPUP (Alonzo _) x y = eqByShow x y
-samePPUP (Babbage _) x y = eqByShow x y
-samePPUP (Conway _) x y = eqByShow x y
+samePPUP Shelley x y = eqByShow x y
+samePPUP Allegra x y = eqByShow x y
+samePPUP Mary x y = eqByShow x y
+samePPUP Alonzo x y = eqByShow x y
+samePPUP Babbage x y = eqByShow x y
+samePPUP Conway x y = eqByShow x y
 {-# NOINLINE samePPUP #-}
 
 instance Reflect era => Same era (UTxOState era) where
@@ -175,12 +175,12 @@ instance Reflect era => Same era (UTxOState era) where
       ppuPretty :: GovState era ~ ShelleyGovState era => [(String, Maybe PDoc)]
       ppuPretty = [("ShelleyGovState", samePPUP proof (utxosGovState u1) (utxosGovState u2))]
       ppu = case reify @era of
-        Shelley _ -> ppuPretty
-        Mary _ -> ppuPretty
-        Allegra _ -> ppuPretty
-        Alonzo _ -> ppuPretty
-        Babbage _ -> ppuPretty
-        Conway _ -> []
+        Shelley -> ppuPretty
+        Mary -> ppuPretty
+        Allegra -> ppuPretty
+        Alonzo -> ppuPretty
+        Babbage -> ppuPretty
+        Conway -> []
 
 instance Reflect era => Same era (LedgerState era) where
   same proof x1 x2 =
@@ -201,12 +201,12 @@ sameStashedAVVMAddresses ::
   Proof era -> StashedAVVMAddresses era -> StashedAVVMAddresses era -> Maybe PDoc
 sameStashedAVVMAddresses proof x y =
   case proof of
-    Shelley _ -> if x == y then Nothing else Just (viaShow x)
-    Allegra _ -> if x == y then Nothing else Just (viaShow x)
-    Mary _ -> if x == y then Nothing else Just (viaShow x)
-    Alonzo _ -> if x == y then Nothing else Just (viaShow x)
-    Babbage _ -> if x == y then Nothing else Just (viaShow x)
-    Conway _ -> if x == y then Nothing else Just (viaShow x)
+    Shelley -> if x == y then Nothing else Just (viaShow x)
+    Allegra -> if x == y then Nothing else Just (viaShow x)
+    Mary -> if x == y then Nothing else Just (viaShow x)
+    Alonzo -> if x == y then Nothing else Just (viaShow x)
+    Babbage -> if x == y then Nothing else Just (viaShow x)
+    Conway -> if x == y then Nothing else Just (viaShow x)
 
 instance
   Reflect era =>
@@ -271,12 +271,12 @@ instance Era era => Same era (ShelleyResultExamples era) where
     ,
       ( "ProposedPPUpdates"
       , case proof of
-          Shelley _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
-          Allegra _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
-          Mary _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
-          Alonzo _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
-          Babbage _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
-          Conway _ -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Shelley -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Allegra -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Mary -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Alonzo -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Babbage -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
+          Conway -> sameProposedPPUpdates (sreProposedPPUpdates r1) (sreProposedPPUpdates r2)
       )
     , ("poolDistr", eqByShow (srePoolDistr r1) (srePoolDistr r2))
     , ("NonMyopicRewards", eqByShow (sreNonMyopicRewards r1) (sreNonMyopicRewards r2))
@@ -295,30 +295,30 @@ instance Era era => Same era (ShelleyResultExamples era) where
 -- We also can avoid all extra constraints by pattern matching against all current Proofs.
 
 samePParams :: Proof era -> PParams era -> PParams era -> Maybe PDoc
-samePParams (Shelley _) x y = eqByShow x y
-samePParams (Allegra _) x y = eqByShow x y
-samePParams (Mary _) x y = eqByShow x y
-samePParams (Alonzo _) x y = eqByShow x y
-samePParams (Babbage _) x y = eqByShow x y
-samePParams (Conway _) x y = eqByShow x y
+samePParams Shelley x y = eqByShow x y
+samePParams Allegra x y = eqByShow x y
+samePParams Mary x y = eqByShow x y
+samePParams Alonzo x y = eqByShow x y
+samePParams Babbage x y = eqByShow x y
+samePParams Conway x y = eqByShow x y
 {-# NOINLINE samePParams #-}
 
 samePParamsUpdate :: Proof era -> PParamsUpdate era -> PParamsUpdate era -> Maybe PDoc
-samePParamsUpdate (Shelley _) x y = eqByShow x y
-samePParamsUpdate (Allegra _) x y = eqByShow x y
-samePParamsUpdate (Mary _) x y = eqByShow x y
-samePParamsUpdate (Alonzo _) x y = eqByShow x y
-samePParamsUpdate (Babbage _) x y = eqByShow x y
-samePParamsUpdate (Conway _) x y = eqByShow x y
+samePParamsUpdate Shelley x y = eqByShow x y
+samePParamsUpdate Allegra x y = eqByShow x y
+samePParamsUpdate Mary x y = eqByShow x y
+samePParamsUpdate Alonzo x y = eqByShow x y
+samePParamsUpdate Babbage x y = eqByShow x y
+samePParamsUpdate Conway x y = eqByShow x y
 {-# NOINLINE samePParamsUpdate #-}
 
 sameTxOut :: Proof era -> TxOut era -> TxOut era -> Maybe PDoc
-sameTxOut (Shelley _) x y = eqByShow x y
-sameTxOut (Allegra _) x y = eqByShow x y
-sameTxOut (Mary _) x y = eqByShow x y
-sameTxOut (Alonzo _) x y = eqByShow x y
-sameTxOut (Babbage _) x y = eqByShow x y
-sameTxOut (Conway _) x y = eqByShow x y
+sameTxOut Shelley x y = eqByShow x y
+sameTxOut Allegra x y = eqByShow x y
+sameTxOut Mary x y = eqByShow x y
+sameTxOut Alonzo x y = eqByShow x y
+sameTxOut Babbage x y = eqByShow x y
+sameTxOut Conway x y = eqByShow x y
 {-# NOINLINE sameTxOut #-}
 
 sameLedgerFail ::
@@ -326,12 +326,12 @@ sameLedgerFail ::
   ApplyTxError era ->
   ApplyTxError era ->
   Maybe PDoc
-sameLedgerFail (Shelley _) x y = eqByShow x y
-sameLedgerFail (Allegra _) x y = eqByShow x y
-sameLedgerFail (Mary _) x y = eqByShow x y
-sameLedgerFail (Alonzo _) x y = eqByShow x y
-sameLedgerFail (Babbage _) x y = eqByShow x y
-sameLedgerFail (Conway _) x y = eqByShow x y
+sameLedgerFail Shelley x y = eqByShow x y
+sameLedgerFail Allegra x y = eqByShow x y
+sameLedgerFail Mary x y = eqByShow x y
+sameLedgerFail Alonzo x y = eqByShow x y
+sameLedgerFail Babbage x y = eqByShow x y
+sameLedgerFail Conway x y = eqByShow x y
 {-# NOINLINE sameLedgerFail #-}
 
 sameTransCtx ::
@@ -339,12 +339,12 @@ sameTransCtx ::
   TranslationContext era ->
   TranslationContext era ->
   Maybe PDoc
-sameTransCtx (Shelley _) x y = eqByShow x y
-sameTransCtx (Allegra _) x y = eqByShow x y
-sameTransCtx (Mary _) x y = eqByShow x y
-sameTransCtx (Alonzo _) x y = eqByShow x y
-sameTransCtx (Babbage _) x y = eqByShow x y
-sameTransCtx (Conway _) x y = eqByShow x y
+sameTransCtx Shelley x y = eqByShow x y
+sameTransCtx Allegra x y = eqByShow x y
+sameTransCtx Mary x y = eqByShow x y
+sameTransCtx Alonzo x y = eqByShow x y
+sameTransCtx Babbage x y = eqByShow x y
+sameTransCtx Conway x y = eqByShow x y
 {-# NOINLINE sameTransCtx #-}
 
 -- ==========================
@@ -382,12 +382,12 @@ sameAlonzoTxWits
     ]
 
 sameTxWits :: Reflect era => Proof era -> TxWits era -> TxWits era -> [(String, Maybe PDoc)]
-sameTxWits proof@(Shelley _) x y = sameShelleyTxWits proof x y
-sameTxWits proof@(Allegra _) x y = sameShelleyTxWits proof x y
-sameTxWits proof@(Mary _) x y = sameShelleyTxWits proof x y
-sameTxWits proof@(Alonzo _) x y = sameAlonzoTxWits proof x y
-sameTxWits proof@(Babbage _) x y = sameAlonzoTxWits proof x y
-sameTxWits proof@(Conway _) x y = sameAlonzoTxWits proof x y
+sameTxWits proof@Shelley x y = sameShelleyTxWits proof x y
+sameTxWits proof@Allegra x y = sameShelleyTxWits proof x y
+sameTxWits proof@Mary x y = sameShelleyTxWits proof x y
+sameTxWits proof@Alonzo x y = sameAlonzoTxWits proof x y
+sameTxWits proof@Babbage x y = sameAlonzoTxWits proof x y
+sameTxWits proof@Conway x y = sameAlonzoTxWits proof x y
 
 -- =======================
 -- Comparing TxBody for Sameness
@@ -539,12 +539,12 @@ sameConwayTxBody
     ]
 
 sameTxBody :: Reflect era => Proof era -> TxBody era -> TxBody era -> [(String, Maybe PDoc)]
-sameTxBody proof@(Shelley _) x y = sameShelleyTxBody proof x y
-sameTxBody proof@(Allegra _) x y = sameAllegraTxBody proof x y
-sameTxBody proof@(Mary _) x y = sameMaryTxBody proof x y
-sameTxBody proof@(Alonzo _) x y = sameAlonzoTxBody proof x y
-sameTxBody proof@(Babbage _) x y = sameBabbageTxBody proof x y
-sameTxBody proof@(Conway _) x y = sameConwayTxBody proof x y
+sameTxBody proof@Shelley x y = sameShelleyTxBody proof x y
+sameTxBody proof@Allegra x y = sameAllegraTxBody proof x y
+sameTxBody proof@Mary x y = sameMaryTxBody proof x y
+sameTxBody proof@Alonzo x y = sameAlonzoTxBody proof x y
+sameTxBody proof@Babbage x y = sameBabbageTxBody proof x y
+sameTxBody proof@Conway x y = sameConwayTxBody proof x y
 
 -- =======================
 -- Comparing Tx for Sameness
@@ -579,12 +579,12 @@ sameAlonzoTx proof (AlonzoTx b1 w1 v1 aux1) (AlonzoTx b2 w2 v2 aux2) =
 {-# NOINLINE sameAlonzoTx #-}
 
 sameTx :: Reflect era => Proof era -> Tx era -> Tx era -> [(String, Maybe PDoc)]
-sameTx proof@(Shelley _) x y = sameShelleyTx proof x y
-sameTx proof@(Allegra _) x y = sameShelleyTx proof x y
-sameTx proof@(Mary _) x y = sameShelleyTx proof x y
-sameTx proof@(Alonzo _) x y = sameAlonzoTx proof x y
-sameTx proof@(Babbage _) x y = sameAlonzoTx proof x y
-sameTx proof@(Conway _) x y = sameAlonzoTx proof x y
+sameTx proof@Shelley x y = sameShelleyTx proof x y
+sameTx proof@Allegra x y = sameShelleyTx proof x y
+sameTx proof@Mary x y = sameShelleyTx proof x y
+sameTx proof@Alonzo x y = sameAlonzoTx proof x y
+sameTx proof@Babbage x y = sameAlonzoTx proof x y
+sameTx proof@Conway x y = sameAlonzoTx proof x y
 {-# NOINLINE sameTx #-}
 
 -- ==========================
@@ -622,10 +622,10 @@ sameAlonzoTxSeq proof (AlonzoTxSeq ss1) (AlonzoTxSeq ss2) =
     f n t1 t2 = SomeM (show n) (sameTx proof) t1 t2
 
 sameTxSeq :: Reflect era => Proof era -> TxSeq era -> TxSeq era -> [(String, Maybe PDoc)]
-sameTxSeq proof@(Shelley _) x y = sameShelleyTxSeq proof x y
-sameTxSeq proof@(Allegra _) x y = sameShelleyTxSeq proof x y
-sameTxSeq proof@(Mary _) x y = sameShelleyTxSeq proof x y
-sameTxSeq proof@(Alonzo _) x y = sameAlonzoTxSeq proof x y
-sameTxSeq proof@(Babbage _) x y = sameAlonzoTxSeq proof x y
-sameTxSeq proof@(Conway _) x y = sameAlonzoTxSeq proof x y
+sameTxSeq proof@Shelley x y = sameShelleyTxSeq proof x y
+sameTxSeq proof@Allegra x y = sameShelleyTxSeq proof x y
+sameTxSeq proof@Mary x y = sameShelleyTxSeq proof x y
+sameTxSeq proof@Alonzo x y = sameAlonzoTxSeq proof x y
+sameTxSeq proof@Babbage x y = sameAlonzoTxSeq proof x y
+sameTxSeq proof@Conway x y = sameAlonzoTxSeq proof x y
 {-# NOINLINE sameTxSeq #-}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Scriptic.hs
@@ -48,43 +48,43 @@ class HasTokens era where
   forge :: Integer -> Script era -> MultiAsset (EraCrypto era)
 
 instance Crypto c => Scriptic (ShelleyEra c) where
-  never _ (Shelley _) = Multi.RequireAnyOf mempty -- always False
-  always _ (Shelley _) = Multi.RequireAllOf mempty -- always True
-  alwaysAlt _ (Shelley _) = Multi.RequireAllOf mempty -- always True
-  require key (Shelley _) = Multi.RequireSignature key
-  allOf xs (Shelley c) = Multi.RequireAllOf (map ($ Shelley c) xs)
-  anyOf xs (Shelley c) = Multi.RequireAnyOf (map ($ Shelley c) xs)
-  mOf n xs (Shelley c) = Multi.RequireMOf n (map ($ Shelley c) xs)
+  never _ Shelley = Multi.RequireAnyOf mempty -- always False
+  always _ Shelley = Multi.RequireAllOf mempty -- always True
+  alwaysAlt _ Shelley = Multi.RequireAllOf mempty -- always True
+  require key Shelley = Multi.RequireSignature key
+  allOf xs Shelley = Multi.RequireAllOf (map ($ Shelley) xs)
+  anyOf xs Shelley = Multi.RequireAnyOf (map ($ Shelley) xs)
+  mOf n xs Shelley = Multi.RequireMOf n (map ($ Shelley) xs)
 
 -- Make Scripts in AllegraEra
 
 instance Crypto c => Scriptic (AllegraEra c) where
-  never _ (Allegra _) = RequireAnyOf mempty -- always False
-  always _ (Allegra _) = RequireAllOf mempty -- always True
-  alwaysAlt _ (Allegra _) = RequireAllOf mempty -- always True
-  require key (Allegra _) = RequireSignature key
+  never _ Allegra = RequireAnyOf mempty -- always False
+  always _ Allegra = RequireAllOf mempty -- always True
+  alwaysAlt _ Allegra = RequireAllOf mempty -- always True
+  require key Allegra = RequireSignature key
   allOf xs proof = RequireAllOf (Seq.fromList (map ($ proof) xs))
   anyOf xs proof = RequireAnyOf (Seq.fromList (map ($ proof) xs))
   mOf n xs proof = RequireMOf n (Seq.fromList (map ($ proof) xs))
 
 instance Crypto c => PostShelley (AllegraEra c) where
-  before n (Allegra _) = RequireTimeStart (theSlot n)
-  after n (Allegra _) = RequireTimeExpire (theSlot n)
+  before n Allegra = RequireTimeStart (theSlot n)
+  after n Allegra = RequireTimeExpire (theSlot n)
 
 -- Make Scripts in Mary era
 
 instance Crypto c => Scriptic (MaryEra c) where
-  never _ (Mary _) = RequireAnyOf mempty -- always False
-  always _ (Mary _) = RequireAllOf mempty -- always True
-  alwaysAlt _ (Mary _) = RequireAllOf mempty -- always True
-  require key (Mary _) = RequireSignature key
+  never _ Mary = RequireAnyOf mempty -- always False
+  always _ Mary = RequireAllOf mempty -- always True
+  alwaysAlt _ Mary = RequireAllOf mempty -- always True
+  require key Mary = RequireSignature key
   allOf xs proof = RequireAllOf (Seq.fromList (map ($ proof) xs))
   anyOf xs proof = RequireAnyOf (Seq.fromList (map ($ proof) xs))
   mOf n xs proof = RequireMOf n (Seq.fromList (map ($ proof) xs))
 
 instance Crypto c => PostShelley (MaryEra c) where
-  before n (Mary _) = RequireTimeStart (theSlot n)
-  after n (Mary _) = RequireTimeExpire (theSlot n)
+  before n Mary = RequireTimeStart (theSlot n)
+  after n Mary = RequireTimeExpire (theSlot n)
 
 instance forall c. Crypto c => HasTokens (MaryEra c) where
   forge n s = MultiAsset $ Map.singleton pid (Map.singleton an n)
@@ -114,47 +114,47 @@ instance forall c. Crypto c => HasTokens (ConwayEra c) where
 -- Make Scripts in Alonzo era
 
 instance Crypto c => Scriptic (AlonzoEra c) where
-  never n (Alonzo _) = alwaysFails @'PlutusV1 n -- always False
-  always n (Alonzo _) = alwaysSucceeds @'PlutusV1 n -- always True
-  alwaysAlt n (Alonzo _) = alwaysSucceeds @'PlutusV1 n -- always True
-  require key (Alonzo _) = RequireSignature key
+  never n Alonzo = alwaysFails @'PlutusV1 n -- always False
+  always n Alonzo = alwaysSucceeds @'PlutusV1 n -- always True
+  alwaysAlt n Alonzo = alwaysSucceeds @'PlutusV1 n -- always True
+  require key Alonzo = RequireSignature key
   allOf xs proof = RequireAllOf (Seq.fromList (($ proof) <$> xs))
   anyOf xs proof = RequireAnyOf (Seq.fromList (($ proof) <$> xs))
   mOf n xs proof = RequireMOf n (Seq.fromList (($ proof) <$> xs))
 
 instance Crypto c => PostShelley (AlonzoEra c) where
-  before n (Alonzo _) = RequireTimeStart (theSlot n)
-  after n (Alonzo _) = RequireTimeExpire (theSlot n)
+  before n Alonzo = RequireTimeStart (theSlot n)
+  after n Alonzo = RequireTimeExpire (theSlot n)
 
 -- =================================
 
 instance Crypto c => Scriptic (BabbageEra c) where
-  never n (Babbage _) = alwaysFails @'PlutusV1 n -- always False
-  always n (Babbage _) = alwaysSucceeds @'PlutusV1 n -- always True
-  alwaysAlt n (Babbage _) = alwaysSucceeds @'PlutusV2 n -- always True
-  require key (Babbage _) = RequireSignature key
+  never n Babbage = alwaysFails @'PlutusV1 n -- always False
+  always n Babbage = alwaysSucceeds @'PlutusV1 n -- always True
+  alwaysAlt n Babbage = alwaysSucceeds @'PlutusV2 n -- always True
+  require key Babbage = RequireSignature key
   allOf xs proof = RequireAllOf (Seq.fromList (($ proof) <$> xs))
   anyOf xs proof = RequireAnyOf (Seq.fromList (($ proof) <$> xs))
   mOf n xs proof = RequireMOf n (Seq.fromList (($ proof) <$> xs))
 
 instance Crypto c => PostShelley (BabbageEra c) where
-  before n (Babbage _) = RequireTimeStart (theSlot n)
-  after n (Babbage _) = RequireTimeExpire (theSlot n)
+  before n Babbage = RequireTimeStart (theSlot n)
+  after n Babbage = RequireTimeExpire (theSlot n)
 
 -- =================================
 
 instance Crypto c => Scriptic (ConwayEra c) where
-  never n (Conway _) = alwaysFails @'PlutusV1 n -- always False
-  always n (Conway _) = alwaysSucceeds @'PlutusV1 n -- always True
-  alwaysAlt n (Conway _) = alwaysSucceeds @'PlutusV2 n -- always True
-  require key (Conway _) = RequireSignature key
+  never n Conway = alwaysFails @'PlutusV1 n -- always False
+  always n Conway = alwaysSucceeds @'PlutusV1 n -- always True
+  alwaysAlt n Conway = alwaysSucceeds @'PlutusV2 n -- always True
+  require key Conway = RequireSignature key
   allOf xs proof = RequireAllOf (Seq.fromList (($ proof) <$> xs))
   anyOf xs proof = RequireAnyOf (Seq.fromList (($ proof) <$> xs))
   mOf n xs proof = RequireMOf n (Seq.fromList (($ proof) <$> xs))
 
 instance Crypto c => PostShelley (ConwayEra c) where
-  before n (Conway _) = RequireTimeStart (theSlot n)
-  after n (Conway _) = RequireTimeExpire (theSlot n)
+  before n Conway = RequireTimeStart (theSlot n)
+  after n Conway = RequireTimeExpire (theSlot n)
 
 -- =======================================
 -- Some examples that work in multiple Eras

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -218,16 +218,16 @@ genGenericScriptWitness ::
   GenRS era (SafeHash (EraCrypto era) EraIndependentTxBody -> [WitnessesField era])
 genGenericScriptWitness proof mTag script =
   case proof of
-    Shelley _ -> mkMultiSigWit proof mTag script
-    Allegra _ -> mkTimelockWit proof mTag script
-    Mary _ -> mkTimelockWit proof mTag script
-    Alonzo _ -> case script of
+    Shelley -> mkMultiSigWit proof mTag script
+    Allegra -> mkTimelockWit proof mTag script
+    Mary -> mkTimelockWit proof mTag script
+    Alonzo -> case script of
       TimelockScript timelock -> mkTimelockWit proof mTag timelock
       PlutusScript _ -> pure (const [])
-    Babbage _ -> case script of
+    Babbage -> case script of
       TimelockScript timelock -> mkTimelockWit proof mTag timelock
       PlutusScript _ -> pure (const [])
-    Conway _ -> case script of
+    Conway -> case script of
       TimelockScript timelock -> mkTimelockWit proof mTag timelock
       PlutusScript _ -> pure (const [])
 
@@ -326,13 +326,13 @@ genCredKeyWit era mTag cred = mkWitVKey era mTag cred
 
 makeDatumWitness :: Proof era -> TxOut era -> GenRS era [WitnessesField era]
 makeDatumWitness proof txout = case (proof, txout) of
-  (Babbage _, BabbageTxOut _ _ (DatumHash h) _) -> mkDatumWit (SJust h)
-  (Babbage _, BabbageTxOut _ _ (Datum _) _) -> pure []
-  (Babbage _, BabbageTxOut _ _ NoDatum _) -> pure []
-  (Conway _, BabbageTxOut _ _ (DatumHash h) _) -> mkDatumWit (SJust h)
-  (Conway _, BabbageTxOut _ _ (Datum _) _) -> pure []
-  (Conway _, BabbageTxOut _ _ NoDatum _) -> pure []
-  (Alonzo _, AlonzoTxOut _ _ mDatum) -> mkDatumWit mDatum
+  (Babbage, BabbageTxOut _ _ (DatumHash h) _) -> mkDatumWit (SJust h)
+  (Babbage, BabbageTxOut _ _ (Datum _) _) -> pure []
+  (Babbage, BabbageTxOut _ _ NoDatum _) -> pure []
+  (Conway, BabbageTxOut _ _ (DatumHash h) _) -> mkDatumWit (SJust h)
+  (Conway, BabbageTxOut _ _ (Datum _) _) -> pure []
+  (Conway, BabbageTxOut _ _ NoDatum _) -> pure []
+  (Alonzo, AlonzoTxOut _ _ mDatum) -> mkDatumWit mDatum
   _ -> pure [] -- No other era has data witnesses
   where
     mkDatumWit SNothing = pure []
@@ -421,19 +421,19 @@ genRefScript proof = do
 genDataHashField :: Reflect era => Proof era -> Maybe (Script era) -> GenRS era [TxOutField era]
 genDataHashField proof maybeCoreScript =
   case proof of
-    Conway _ -> case maybeCoreScript of
+    Conway -> case maybeCoreScript of
       Just (PlutusScript _) -> do
         datum <- genBabbageDatum
         script <- genRefScript proof
         pure [FDatum datum, RefScript script]
       _ -> pure []
-    Babbage _ -> case maybeCoreScript of
+    Babbage -> case maybeCoreScript of
       Just (PlutusScript _) -> do
         datum <- genBabbageDatum
         script <- genRefScript proof
         pure [FDatum datum, RefScript script]
       _ -> pure []
-    Alonzo _ -> case maybeCoreScript of
+    Alonzo -> case maybeCoreScript of
       Just (PlutusScript _) -> do
         (datahash, _data) <- genDatumWithHash
         pure [DHash (SJust datahash)]
@@ -580,12 +580,12 @@ genShelleyDelegCert =
 
 genTxCertDeleg :: forall era. Reflect era => GenRS era (TxCert era)
 genTxCertDeleg = case reify @era of
-  Shelley _ -> genShelleyDelegCert
-  Mary _ -> genShelleyDelegCert
-  Allegra _ -> genShelleyDelegCert
-  Alonzo _ -> genShelleyDelegCert
-  Babbage _ -> genShelleyDelegCert
-  Conway _ -> genShelleyDelegCert
+  Shelley -> genShelleyDelegCert
+  Mary -> genShelleyDelegCert
+  Allegra -> genShelleyDelegCert
+  Alonzo -> genShelleyDelegCert
+  Babbage -> genShelleyDelegCert
+  Conway -> genShelleyDelegCert
 
 genTxCert :: forall era. Reflect era => SlotNo -> GenRS era (TxCert era)
 genTxCert slot =
@@ -610,21 +610,21 @@ genTxCert slot =
 
 -- getShelleyTxCertDelegG :: forall era. Reflect era => TxCert era -> Maybe (ShelleyDelegCert (EraCrypto era))
 -- getShelleyTxCertDelegG = case reify @era of
---   Shelley _ -> getShelleyTxCertDeleg
---   Mary _ -> getShelleyTxCertDeleg
---   Allegra _ -> getShelleyTxCertDeleg
---   Alonzo _ -> getShelleyTxCertDeleg
---   Babbage _ -> getShelleyTxCertDeleg
---   Conway _ -> getShelleyTxCertDeleg -- TODO write a generator for Conway certs
+--   Shelley -> getShelleyTxCertDeleg
+--   Mary -> getShelleyTxCertDeleg
+--   Allegra -> getShelleyTxCertDeleg
+--   Alonzo -> getShelleyTxCertDeleg
+--   Babbage -> getShelleyTxCertDeleg
+--   Conway -> getShelleyTxCertDeleg -- TODO write a generator for Conwayerts
 
 -- mkShelleyTxCertDelegG :: forall era. Reflect era => ShelleyDelegCert (EraCrypto era) -> TxCert era
 -- mkShelleyTxCertDelegG = case reify @era of
---   Shelley _ -> mkShelleyTxCertDeleg
---   Mary _ -> mkShelleyTxCertDeleg
---   Allegra _ -> mkShelleyTxCertDeleg
---   Alonzo _ -> mkShelleyTxCertDeleg
---   Babbage _ -> mkShelleyTxCertDeleg
---   Conway _ -> mkShelleyTxCertDeleg -- TODO write a generator for Conway certs
+--   Shelley -> mkShelleyTxCertDeleg
+--   Mary -> mkShelleyTxCertDeleg
+--   Allegra -> mkShelleyTxCertDeleg
+--   Alonzo -> mkShelleyTxCertDeleg
+--   Babbage -> mkShelleyTxCertDeleg
+--   Conway -> mkShelleyTxCertDeleg -- TODO write a generator for Conwayerts
 
 genTxCerts :: forall era. Reflect era => SlotNo -> GenRS era [TxCert era]
 genTxCerts slot = do
@@ -803,12 +803,12 @@ genRecipientsFrom txOuts = do
 
 getTxCertCredential :: forall era. Reflect era => TxCert era -> Maybe (Credential 'Staking (EraCrypto era))
 getTxCertCredential = case reify @era of
-  Shelley _ -> getShelleyTxCertCredential
-  Mary _ -> getShelleyTxCertCredential
-  Allegra _ -> getShelleyTxCertCredential
-  Alonzo _ -> getShelleyTxCertCredential
-  Babbage _ -> getShelleyTxCertCredential
-  Conway _ -> getConwayTxCertCredential
+  Shelley -> getShelleyTxCertCredential
+  Mary -> getShelleyTxCertCredential
+  Allegra -> getShelleyTxCertCredential
+  Alonzo -> getShelleyTxCertCredential
+  Babbage -> getShelleyTxCertCredential
+  Conway -> getConwayTxCertCredential
 
 getShelleyTxCertCredential :: ShelleyTxCert era -> Maybe (Credential 'Staking (EraCrypto era))
 getShelleyTxCertCredential = \case
@@ -962,7 +962,7 @@ genAlonzoTxAndInfo proof slot = do
       updateTotalColl (SJust (Coin n)) (Coin m) = SJust (Coin (n + m))
   -- If Babbage era, or greater, add a stub for a CollateralReturn TxOut
   bogusCollReturn <-
-    if Some proof >= Some (Babbage Mock)
+    if Some proof >= Some Babbage
       then
         frequencyT
           [ (1, pure SNothing)
@@ -989,7 +989,7 @@ genAlonzoTxAndInfo proof slot = do
           , Certs' dcerts
           , Withdrawals' withdrawals
           , Txfee maxCoin
-          , if Some proof >= Some (Allegra Mock)
+          , if Some proof >= Some Allegra
               then Vldt validityInterval
               else TTL (timeToLive validityInterval)
           , Update' []
@@ -1020,12 +1020,12 @@ genAlonzoTxAndInfo proof slot = do
 
   keyDeposits <- gets (mKeyDeposits . gsModel)
   let deposits = case proof of
-        Shelley _ -> depositsAndRefunds gePParams dcerts keyDeposits
-        Mary _ -> depositsAndRefunds gePParams dcerts keyDeposits
-        Allegra _ -> depositsAndRefunds gePParams dcerts keyDeposits
-        Alonzo _ -> depositsAndRefunds gePParams dcerts keyDeposits
-        Babbage _ -> depositsAndRefunds gePParams dcerts keyDeposits
-        Conway _ -> depositsAndRefunds gePParams dcerts keyDeposits
+        Shelley -> depositsAndRefunds gePParams dcerts keyDeposits
+        Mary -> depositsAndRefunds gePParams dcerts keyDeposits
+        Allegra -> depositsAndRefunds gePParams dcerts keyDeposits
+        Alonzo -> depositsAndRefunds gePParams dcerts keyDeposits
+        Babbage -> depositsAndRefunds gePParams dcerts keyDeposits
+        Conway -> depositsAndRefunds gePParams dcerts keyDeposits
 
   -- 8. Crank up the amount in one of outputs to account for the fee and deposits. Note
   -- this is a hack that is not possible in a real life, but in the end it does produce
@@ -1134,13 +1134,13 @@ instance
 
 applySTSByProof ::
   forall era.
-  (Era era, GoodCrypto (EraCrypto era)) =>
+  Era era =>
   Proof era ->
   RuleContext 'Transition (EraRule "LEDGER" era) ->
   Either [PredicateFailure (EraRule "LEDGER" era)] (State (EraRule "LEDGER" era))
-applySTSByProof (Conway _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Babbage _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Alonzo _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Mary _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Allegra _) trc = runShelleyBase $ applySTS trc
-applySTSByProof (Shelley _) trc = runShelleyBase $ applySTS trc
+applySTSByProof Conway trc = runShelleyBase $ applySTS trc
+applySTSByProof Babbage trc = runShelleyBase $ applySTS trc
+applySTSByProof Alonzo trc = runShelleyBase $ applySTS trc
+applySTSByProof Mary trc = runShelleyBase $ applySTS trc
+applySTSByProof Allegra trc = runShelleyBase $ applySTS trc
+applySTSByProof Shelley trc = runShelleyBase $ applySTS trc

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -107,7 +107,7 @@ instance Merge (Map (ScriptHash c) v) where
 -- Updaters for Tx
 
 updateTx :: Proof era -> Tx era -> TxField era -> Tx era
-updateTx wit@(Shelley _) tx@(ShelleyTx b w d) dt =
+updateTx wit@Shelley tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
@@ -115,7 +115,7 @@ updateTx wit@(Shelley _) tx@(ShelleyTx b w d) dt =
     WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
     AuxData faux -> ShelleyTx b w faux
     Valid _ -> tx
-updateTx wit@(Allegra _) tx@(ShelleyTx b w d) dt =
+updateTx wit@Allegra tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
@@ -123,7 +123,7 @@ updateTx wit@(Allegra _) tx@(ShelleyTx b w d) dt =
     WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
     AuxData faux -> ShelleyTx b w faux
     Valid _ -> tx
-updateTx wit@(Mary _) tx@(ShelleyTx b w d) dt =
+updateTx wit@Mary tx@(ShelleyTx b w d) dt =
   case dt of
     Body fbody -> ShelleyTx fbody w d
     BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
@@ -131,7 +131,7 @@ updateTx wit@(Mary _) tx@(ShelleyTx b w d) dt =
     WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
     AuxData faux -> ShelleyTx b w faux
     Valid _ -> tx
-updateTx wit@(Alonzo _) (Alonzo.AlonzoTx b w iv d) dt =
+updateTx wit@Alonzo (Alonzo.AlonzoTx b w iv d) dt =
   case dt of
     Body fbody -> Alonzo.AlonzoTx fbody w iv d
     BodyI bfields -> Alonzo.AlonzoTx (newTxBody wit bfields) w iv d
@@ -139,7 +139,7 @@ updateTx wit@(Alonzo _) (Alonzo.AlonzoTx b w iv d) dt =
     WitnessesI wfields -> Alonzo.AlonzoTx b (newWitnesses override wit wfields) iv d
     AuxData faux -> Alonzo.AlonzoTx b w iv faux
     Valid iv' -> Alonzo.AlonzoTx b w iv' d
-updateTx wit@(Babbage _) (AlonzoTx b w iv d) dt =
+updateTx wit@Babbage (AlonzoTx b w iv d) dt =
   case dt of
     Body fbody -> AlonzoTx fbody w iv d
     BodyI bfields -> AlonzoTx (newTxBody wit bfields) w iv d
@@ -147,7 +147,7 @@ updateTx wit@(Babbage _) (AlonzoTx b w iv d) dt =
     WitnessesI wfields -> AlonzoTx b (newWitnesses override wit wfields) iv d
     AuxData faux -> AlonzoTx b w iv faux
     Valid iv' -> AlonzoTx b w iv' d
-updateTx wit@(Conway _) (AlonzoTx b w iv d) dt =
+updateTx wit@Conway (AlonzoTx b w iv d) dt =
   case dt of
     Body fbody -> AlonzoTx fbody w iv d
     BodyI bfields -> AlonzoTx (newTxBody wit bfields) w iv d
@@ -170,26 +170,26 @@ updateTxBody pf txBody dt =
     _ | Outputs outs <- dt -> txBody & outputsTxBodyL .~ outs
     _ | Txfee fee <- dt -> txBody & feeTxBodyL .~ fee
     _ | AdHash auxDataHash <- dt -> txBody & auxDataHashTxBodyL .~ auxDataHash
-    Shelley _ -> case dt of
+    Shelley -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       TTL ttl -> txBody & ttlTxBodyL .~ ttl
       Update update -> txBody & updateTxBodyL .~ update
       _ -> txBody
-    Allegra _ -> case dt of
+    Allegra -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
       Update update -> txBody & updateTxBodyL .~ update
       _ -> txBody
-    Mary _ -> case dt of
+    Mary -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
       Update update -> txBody & updateTxBodyL .~ update
       Mint mint -> txBody & mintTxBodyL .~ mint
       _ -> txBody
-    Alonzo _ -> case dt of
+    Alonzo -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
@@ -200,7 +200,7 @@ updateTxBody pf txBody dt =
       WppHash scriptIntegrityHash -> txBody & scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
       Txnetworkid networkId -> txBody & networkIdTxBodyL .~ networkId
       _ -> txBody
-    Babbage _ -> case dt of
+    Babbage -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
@@ -214,7 +214,7 @@ updateTxBody pf txBody dt =
       TotalCol totalCol -> txBody & totalCollateralTxBodyL .~ totalCol
       CollateralReturn collateralReturn -> txBody & collateralReturnTxBodyL .~ collateralReturn
       _ -> txBody
-    Conway _ -> case dt of
+    Conway -> case dt of
       Certs certs -> txBody & certsTxBodyL .~ certs
       Withdrawals' withdrawals -> txBody & withdrawalsTxBodyL .~ withdrawals
       Vldt vldt -> txBody & vldtTxBodyL .~ vldt
@@ -237,34 +237,34 @@ newTxBody era = List.foldl' (updateTxBody era) (initialTxBody era)
 -- Updaters for TxWits
 
 updateWitnesses :: forall era. Policy -> Proof era -> TxWits era -> WitnessesField era -> TxWits era
-updateWitnesses p (Shelley _) w dw = case dw of
+updateWitnesses p Shelley w dw = case dw of
   (AddrWits ks) -> w {Shelley.addrWits = p (Shelley.addrWits w) ks}
   (BootWits boots) -> w {Shelley.bootWits = p (Shelley.bootWits w) boots}
   (ScriptWits ss) -> w {Shelley.scriptWits = p (Shelley.scriptWits w) ss}
   _ -> w
-updateWitnesses p (Allegra _) w dw = case dw of
+updateWitnesses p Allegra w dw = case dw of
   (AddrWits ks) -> w {Shelley.addrWits = p (Shelley.addrWits w) ks}
   (BootWits boots) -> w {Shelley.bootWits = p (Shelley.bootWits w) boots}
   (ScriptWits ss) -> w {Shelley.scriptWits = p (Shelley.scriptWits w) ss}
   _ -> w
-updateWitnesses p (Mary _) w dw = case dw of
+updateWitnesses p Mary w dw = case dw of
   (AddrWits ks) -> w {Shelley.addrWits = p (Shelley.addrWits w) ks}
   (BootWits boots) -> w {Shelley.bootWits = p (Shelley.bootWits w) boots}
   (ScriptWits ss) -> w {Shelley.scriptWits = p (Shelley.scriptWits w) ss}
   _ -> w
-updateWitnesses p (Alonzo _) w dw = case dw of
+updateWitnesses p Alonzo w dw = case dw of
   (AddrWits ks) -> w {txwitsVKey = p (txwitsVKey w) ks}
   (BootWits boots) -> w {txwitsBoot = p (txwitsBoot w) boots}
   (ScriptWits ss) -> w {txscripts = p (txscripts w) ss}
   (DataWits ds) -> w {txdats = p (txdats w) ds}
   (RdmrWits r) -> w {txrdmrs = p (txrdmrs w) r}
-updateWitnesses p (Babbage _) w dw = case dw of
+updateWitnesses p Babbage w dw = case dw of
   (AddrWits ks) -> w {txwitsVKey = p (txwitsVKey w) ks}
   (BootWits boots) -> w {txwitsBoot = p (txwitsBoot w) boots}
   (ScriptWits ss) -> w {txscripts = p (txscripts w) ss}
   (DataWits ds) -> w {txdats = p (txdats w) ds}
   (RdmrWits r) -> w {txrdmrs = p (txrdmrs w) r}
-updateWitnesses p (Conway _) w dw = case dw of
+updateWitnesses p Conway w dw = case dw of
   (AddrWits ks) -> w {txwitsVKey = p (txwitsVKey w) ks}
   (BootWits boots) -> w {txwitsBoot = p (txwitsBoot w) boots}
   (ScriptWits ss) -> w {txscripts = p (txscripts w) ss}
@@ -283,32 +283,32 @@ notAddress (Address _) = False
 notAddress _ = True
 
 updateTxOut :: Proof era -> TxOut era -> TxOutField era -> TxOut era
-updateTxOut (Shelley _) (out@(ShelleyTxOut a v)) txoutd = case txoutd of
+updateTxOut Shelley (out@(ShelleyTxOut a v)) txoutd = case txoutd of
   Address addr -> ShelleyTxOut addr v
   Amount val -> ShelleyTxOut a val
   _ -> out
-updateTxOut (Allegra _) (out@(ShelleyTxOut a v)) txoutd = case txoutd of
+updateTxOut Allegra (out@(ShelleyTxOut a v)) txoutd = case txoutd of
   Address addr -> ShelleyTxOut addr v
   Amount val -> ShelleyTxOut a val
   _ -> out
-updateTxOut (Mary _) (out@(ShelleyTxOut a v)) txoutd = case txoutd of
+updateTxOut Mary (out@(ShelleyTxOut a v)) txoutd = case txoutd of
   Address addr -> ShelleyTxOut addr v
   Amount val -> ShelleyTxOut a val
   _ -> out
-updateTxOut (Alonzo _) (out@(AlonzoTxOut a v h)) txoutd = case txoutd of
+updateTxOut Alonzo (out@(AlonzoTxOut a v h)) txoutd = case txoutd of
   Address addr -> AlonzoTxOut addr v h
   Amount val -> AlonzoTxOut a val h
   DHash mdh -> AlonzoTxOut a v mdh
   FDatum d -> error ("This feature is only available from Babbage onward " ++ show d)
   _ -> out
-updateTxOut (Babbage _) (BabbageTxOut a v h refscript) txoutd = case txoutd of
+updateTxOut Babbage (BabbageTxOut a v h refscript) txoutd = case txoutd of
   Address addr -> BabbageTxOut addr v h refscript
   Amount val -> BabbageTxOut a val h refscript
   DHash SNothing -> BabbageTxOut a v NoDatum refscript
   DHash (SJust dh) -> BabbageTxOut a v (DatumHash dh) refscript
   FDatum d -> BabbageTxOut a v d refscript
   RefScript s -> BabbageTxOut a v h s
-updateTxOut (Conway _) (BabbageTxOut a v h refscript) txoutd = case txoutd of
+updateTxOut Conway (BabbageTxOut a v h refscript) txoutd = case txoutd of
   Address addr -> BabbageTxOut addr v h refscript
   Amount val -> BabbageTxOut a val h refscript
   DHash SNothing -> BabbageTxOut a v NoDatum refscript
@@ -345,25 +345,25 @@ updatePParams proof pp' ppf =
         MinPoolCost coin -> pp' & ppMinPoolCostL .~ coin
         _ -> pp'
    in case proof of
-        Shelley _ ->
+        Shelley ->
           case ppf of
             D d -> pp & ppDL .~ d
             ExtraEntropy nonce -> pp & ppExtraEntropyL .~ nonce
             MinUTxOValue mu -> pp & ppMinUTxOValueL .~ mu
             _ -> pp
-        Allegra _ ->
+        Allegra ->
           case ppf of
             D d -> pp & ppDL .~ d
             ExtraEntropy nonce -> pp & ppExtraEntropyL .~ nonce
             MinUTxOValue mu -> pp & ppMinUTxOValueL .~ mu
             _ -> pp
-        Mary _ ->
+        Mary ->
           case ppf of
             D d -> pp & ppDL .~ d
             ExtraEntropy nonce -> pp & ppExtraEntropyL .~ nonce
             MinUTxOValue mu -> pp & ppMinUTxOValueL .~ mu
             _ -> pp
-        Alonzo _ ->
+        Alonzo ->
           case ppf of
             D d -> pp & ppDL .~ d
             ExtraEntropy nonce -> pp & ppExtraEntropyL .~ nonce
@@ -376,7 +376,7 @@ updatePParams proof pp' ppf =
             CollateralPercentage colPerc -> pp & ppCollateralPercentageL .~ colPerc
             MaxCollateralInputs maxColInputs -> pp & ppMaxCollateralInputsL .~ maxColInputs
             _ -> pp
-        Babbage _ ->
+        Babbage ->
           case ppf of
             CoinPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
             Costmdls costModels -> pp & ppCostModelsL .~ costModels
@@ -387,7 +387,7 @@ updatePParams proof pp' ppf =
             CollateralPercentage colPerc -> pp & ppCollateralPercentageL .~ colPerc
             MaxCollateralInputs maxColInputs -> pp & ppMaxCollateralInputsL .~ maxColInputs
             _ -> pp
-        Conway _ ->
+        Conway ->
           case ppf of
             CoinPerUTxOByte coinPerByte -> pp & ppCoinsPerUTxOByteL .~ coinPerByte
             Costmdls costModels -> pp & ppCostModelsL .~ costModels
@@ -420,26 +420,26 @@ newScriptIntegrityHash ::
   Redeemers era ->
   TxDats era ->
   StrictMaybe (Alonzo.ScriptIntegrityHash (EraCrypto era))
-newScriptIntegrityHash (Conway _) pp ls rds dats =
+newScriptIntegrityHash Conway pp ls rds dats =
   hashScriptIntegrity (Set.map (Alonzo.getLanguageView pp) (Set.fromList ls)) rds dats
-newScriptIntegrityHash (Babbage _) pp ls rds dats =
+newScriptIntegrityHash Babbage pp ls rds dats =
   hashScriptIntegrity (Set.map (Alonzo.getLanguageView pp) (Set.fromList ls)) rds dats
-newScriptIntegrityHash (Alonzo _) pp ls rds dats =
+newScriptIntegrityHash Alonzo pp ls rds dats =
   hashScriptIntegrity (Set.map (Alonzo.getLanguageView pp) (Set.fromList ls)) rds dats
 newScriptIntegrityHash _wit _pp _ls _rds _dats = SNothing
 
 defaultCostModels :: Proof era -> PParamsField era
-defaultCostModels (Shelley _) = Costmdls emptyCostModels
-defaultCostModels (Allegra _) = Costmdls emptyCostModels
-defaultCostModels (Mary _) = Costmdls emptyCostModels
-defaultCostModels (Alonzo _) = Costmdls $ zeroTestingCostModels [PlutusV1]
-defaultCostModels (Babbage _) = Costmdls $ zeroTestingCostModels [PlutusV1, PlutusV2]
-defaultCostModels (Conway _) = Costmdls $ zeroTestingCostModels [PlutusV1, PlutusV2]
+defaultCostModels Shelley = Costmdls emptyCostModels
+defaultCostModels Allegra = Costmdls emptyCostModels
+defaultCostModels Mary = Costmdls emptyCostModels
+defaultCostModels Alonzo = Costmdls $ zeroTestingCostModels [PlutusV1]
+defaultCostModels Babbage = Costmdls $ zeroTestingCostModels [PlutusV1, PlutusV2]
+defaultCostModels Conway = Costmdls $ zeroTestingCostModels [PlutusV1, PlutusV2]
 
 languages :: Proof era -> [Language]
-languages (Shelley _) = []
-languages (Allegra _) = []
-languages (Mary _) = []
-languages (Alonzo _) = [PlutusV1]
-languages (Babbage _) = [PlutusV1, PlutusV2]
-languages (Conway _) = [PlutusV1, PlutusV2]
+languages Shelley = []
+languages Allegra = []
+languages Mary = []
+languages Alonzo = [PlutusV1]
+languages Babbage = [PlutusV1, PlutusV2]
+languages Conway = [PlutusV1, PlutusV2]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/NoThunks.hs
@@ -12,7 +12,7 @@ import Control.State.Transition.Extended (STS)
 import Data.Default.Class (def)
 import Test.Cardano.Ledger.Generic.GenState (GenSize)
 import Test.Cardano.Ledger.Generic.MockChain (MOCKCHAIN, noThunksGen)
-import Test.Cardano.Ledger.Generic.Proof (Evidence (Mock), Proof (..), Reflect)
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect)
 import Test.Cardano.Ledger.Generic.Trace (traceProp)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -21,11 +21,11 @@ test :: TestTree
 test =
   testGroup
     "There are no unexpected thunks in MockChainState"
-    [ f $ Babbage Mock
-    , f $ Alonzo Mock
-    , f $ Allegra Mock
-    , f $ Mary Mock
-    , f $ Shelley Mock
+    [ f $ Babbage
+    , f $ Alonzo
+    , f $ Allegra
+    , f $ Mary
+    , f $ Shelley
     ]
   where
     f proof = testThunks proof 100 def

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -187,7 +187,7 @@ genShrinkFromConstraints proof sub generationPreds checkPreds target =
 ------------------------------------------------------------------------
 
 conwayProof :: Proof (ConwayEra StandardCrypto)
-conwayProof = Conway Standard
+conwayProof = Conway
 
 -- PParams ----------------------------------------------------------------
 
@@ -621,7 +621,7 @@ prop_GOV sub =
 ------------------------------------------------------------------------
 
 genUniverse :: IO (Subst (ConwayEra StandardCrypto))
-genUniverse = generate (genSubstFromConstraints (Conway Standard) standardOrderInfo (universePreds def (Conway Standard)))
+genUniverse = generate (genSubstFromConstraints Conway standardOrderInfo (universePreds def Conway))
 
 -- NOTE: these tests can be slow (~10 seconds) because it takes time to generate
 -- the initial universe. Reducing the number of tests will NOT help.


### PR DESCRIPTION
Proof no longer takes an Evidence parameter (choosing which crypto, either Standard or Mock). Everything now runs in Standard Crypto. This simplifies many things, because we no longer need to pattern match against (Alonzo _) but just Alonzo (for example).

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
