### PR TITLE
Index aware PlutusPurpose

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.6.0.1
+## 1.7.0.0
 
-*
+* Add `lookupRedeemer`
+* Add `AsIxItem` as well as `toAsItem`, `toAsIndex`.
+* Switch `PlutusPurpose` to `AsIxItem` in `AlonzoScriptsNeeded`
+* Add `hoistPlutusPurpose`, `toSpendingPurpose`, `toMintingPurpose`,
+  `toCertifyingPurpose`, `toRewardingPurpose`, `fromSpendingPurpose`,
+  `fromMintingPurpose`, `fromCertifyingPurpose`, `fromRewardingPurpose` to `AlonzoEraScript`
+* Add `SpendingPurpose`, `MintingPurpose`, `CertifyingPurpose`, `RewardingPurpose` pattern synonyms.
+* Add `getSpendingScriptsNeeded`, `getRewardingScriptsNeeded`, `getMintingScriptsNeeded`
+* Add `zipAsIxItem`
 
 ## 1.6.0.0
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Deprecated `indexRedeemers` and `redeemerPointer`.
 * Add `lookupRedeemer`
 * Add `AsIxItem` as well as `toAsItem`, `toAsIndex`.
 * Switch `PlutusPurpose` to `AsIxItem` in `AlonzoScriptsNeeded`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.6.0.1
+version:            1.7.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
@@ -4,6 +4,7 @@ module Cardano.Ledger.Alonzo.Core (
   AlonzoEraScript (..),
   AsIndex (..),
   AsItem (..),
+  AsIxItem (..),
   ScriptIntegrityHash,
   AlonzoEraTxBody (..),
   AlonzoEraTxWits (..),
@@ -49,7 +50,7 @@ import Cardano.Ledger.Alonzo.PParams (
   ppuMaxValSizeL,
   ppuPricesL,
  )
-import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript (..), AsIndex (..), AsItem (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript (..), AsIndex (..), AsItem (..), AsIxItem (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..), ScriptIntegrityHash)
 import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..))

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Cardano.Ledger.Alonzo.Core (
   AlonzoEraTx (..),
   AlonzoEraTxOut (..),
@@ -5,6 +7,10 @@ module Cardano.Ledger.Alonzo.Core (
   AsIndex (..),
   AsItem (..),
   AsIxItem (..),
+  pattern SpendingPurpose,
+  pattern MintingPurpose,
+  pattern CertifyingPurpose,
+  pattern RewardingPurpose,
   ScriptIntegrityHash,
   AlonzoEraTxBody (..),
   AlonzoEraTxWits (..),
@@ -50,7 +56,16 @@ import Cardano.Ledger.Alonzo.PParams (
   ppuMaxValSizeL,
   ppuPricesL,
  )
-import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript (..), AsIndex (..), AsItem (..), AsIxItem (..))
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoEraScript (..),
+  AsIndex (..),
+  AsItem (..),
+  AsIxItem (..),
+  pattern CertifyingPurpose,
+  pattern MintingPurpose,
+  pattern RewardingPurpose,
+  pattern SpendingPurpose,
+ )
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..), ScriptIntegrityHash)
 import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..))

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -24,7 +24,7 @@ where
 
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript,
-  AsItem (..),
+  AsIxItem (..),
   PlutusPurpose,
   PlutusScript (..),
  )
@@ -50,7 +50,7 @@ class (PlutusLanguage l, EraPlutusContext era) => EraPlutusTxInfo (l :: Language
 
   toPlutusScriptPurpose ::
     proxy l ->
-    PlutusPurpose AsItem era ->
+    PlutusPurpose AsIxItem era ->
     Either (ContextError era) (PlutusScriptPurpose l)
 
   toPlutusTxInfo ::
@@ -65,7 +65,7 @@ class (PlutusLanguage l, EraPlutusContext era) => EraPlutusTxInfo (l :: Language
   toPlutusScriptContext ::
     proxy l ->
     PlutusTxInfo l ->
-    PlutusPurpose AsItem era ->
+    PlutusPurpose AsIxItem era ->
     Either (ContextError era) (PlutusScriptContext l)
 
 class
@@ -84,7 +84,7 @@ class
 
   mkPlutusScriptContext ::
     PlutusScript era ->
-    PlutusPurpose AsItem era ->
+    PlutusPurpose AsIxItem era ->
     PParams era ->
     EpochInfo (Either Text) ->
     SystemStart ->
@@ -95,7 +95,7 @@ class
 mkPlutusLanguageContext ::
   (EraPlutusTxInfo l era, P.ToData (PlutusScriptContext l)) =>
   proxy l ->
-  PlutusPurpose AsItem era ->
+  PlutusPurpose AsIxItem era ->
   PParams era ->
   EpochInfo (Either Text) ->
   SystemStart ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -48,7 +48,7 @@ import Cardano.Crypto.Hash.Class (hashToBytes)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Plutus.Context
-import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), PlutusScript (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), PlutusScript (..), toAsItem)
 import Cardano.Ledger.Alonzo.TxWits (unTxDats)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
@@ -98,7 +98,7 @@ import qualified PlutusLedgerApi.V1 as PV1
 instance Crypto c => EraPlutusTxInfo 'PlutusV1 (AlonzoEra c) where
   toPlutusTxCert _ = pure . transTxCert
 
-  toPlutusScriptPurpose = transPlutusPurpose
+  toPlutusScriptPurpose proxy = transPlutusPurpose proxy . hoistPlutusPurpose toAsItem
 
   toPlutusTxInfo proxy pp epochInfo systemStart utxo tx = do
     timeRange <- transValidityInterval pp epochInfo systemStart (txBody ^. vldtTxBodyL)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (
   AlonzoUtxoEvent,
   AlonzoUtxoPredFailure,
  )
-import Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage)
+import Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage, toAsIndex, toAsItem)
 import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
 import Cardano.Ledger.Alonzo.TxWits (
   unRedeemers,
@@ -227,11 +227,9 @@ hasExactSetOfRedeemers ::
   AlonzoScriptsNeeded era ->
   Test (AlonzoUtxowPredFailure era)
 hasExactSetOfRedeemers tx (ScriptsProvided scriptsProvided) (AlonzoScriptsNeeded scriptsNeeded) = do
-  let txBody = tx ^. bodyTxL
-      redeemersNeeded =
-        [ (rp, (sp, sh))
+  let redeemersNeeded =
+        [ (hoistPlutusPurpose toAsIndex sp, (hoistPlutusPurpose toAsItem sp, sh))
         | (sp, sh) <- scriptsNeeded
-        , SJust rp <- [redeemerPointer @era txBody sp]
         , Just script <- [Map.lookup sh scriptsProvided]
         , not (isNativeScript script)
         ]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -49,6 +49,8 @@ module Cardano.Ledger.Alonzo.Scripts (
   AsItem (..),
   AsIndex (..),
   AsIxItem (..),
+  toAsItem,
+  toAsIndex,
 
   -- * Re-exports
   module Cardano.Ledger.Plutus.CostModels,
@@ -139,6 +141,10 @@ class
   , DecCBORGroup (PlutusPurpose AsIndex era)
   , NoThunks (PlutusPurpose AsIndex era)
   , NFData (PlutusPurpose AsIndex era)
+  , Eq (PlutusPurpose AsIxItem era)
+  , Show (PlutusPurpose AsIxItem era)
+  , NoThunks (PlutusPurpose AsIxItem era)
+  , NFData (PlutusPurpose AsIxItem era)
   ) =>
   AlonzoEraScript era
   where
@@ -172,6 +178,11 @@ class
     (forall l. PlutusLanguage l => Plutus l -> a) ->
     a
 
+  hoistPlutusPurpose ::
+    (forall ix it. g ix it -> f ix it) ->
+    PlutusPurpose g era ->
+    PlutusPurpose f era
+
   mkSpendingPurpose :: f Word32 (TxIn (EraCrypto era)) -> PlutusPurpose f era
 
   toSpendingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (TxIn (EraCrypto era)))
@@ -184,9 +195,9 @@ class
 
   toCertifyingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (TxCert era))
 
-  mkRewardingPurpose :: f Word32 (RewardAcnt (EraCrypto era)) -> PlutusPurpose f era
+  mkRewardingPurpose :: f Word32 (RewardAccount (EraCrypto era)) -> PlutusPurpose f era
 
-  toRewardingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (RewardAcnt (EraCrypto era)))
+  toRewardingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (RewardAccount (EraCrypto era)))
 
   upgradePlutusPurposeAsIndex ::
     AlonzoEraScript (PreviousEra era) =>
@@ -248,6 +259,8 @@ data AsIxItem ix it = AsIxItem
   }
   deriving (Eq, Ord, Show, Generic)
 
+instance (NoThunks ix, NoThunks it) => NoThunks (AsIxItem ix it)
+
 instance (NFData ix, NFData it) => NFData (AsIxItem ix it) where
   rnf (AsIxItem ix it) = ix `deepseq` rnf it
 
@@ -264,6 +277,12 @@ instance (ToJSON ix, ToJSON it) => ToJSON (AsIxItem ix it) where
       , "item" .= toJSON it
       ]
 
+toAsItem :: AsIxItem ix it -> AsItem ix it
+toAsItem (AsIxItem _ it) = AsItem it
+
+toAsIndex :: AsIxItem ix it -> AsIndex ix it
+toAsIndex (AsIxItem ix _) = AsIndex ix
+
 data AlonzoPlutusPurpose f era
   = AlonzoSpending !(f Word32 (TxIn (EraCrypto era)))
   | AlonzoMinting !(f Word32 (PolicyID (EraCrypto era)))
@@ -279,6 +298,10 @@ instance NoThunks (AlonzoPlutusPurpose AsIndex era)
 deriving instance Eq (TxCert era) => Eq (AlonzoPlutusPurpose AsItem era)
 deriving instance Show (TxCert era) => Show (AlonzoPlutusPurpose AsItem era)
 instance NoThunks (TxCert era) => NoThunks (AlonzoPlutusPurpose AsItem era)
+
+deriving instance Eq (TxCert era) => Eq (AlonzoPlutusPurpose AsIxItem era)
+deriving instance Show (TxCert era) => Show (AlonzoPlutusPurpose AsIxItem era)
+instance NoThunks (TxCert era) => NoThunks (AlonzoPlutusPurpose AsIxItem era)
 
 instance
   (forall a b. (NFData a, NFData b) => NFData (f a b), NFData (TxCert era), Era era) =>
@@ -378,7 +401,7 @@ pattern CertifyingPurpose c <- (toCertifyingPurpose -> Just c)
     CertifyingPurpose c = mkCertifyingPurpose c
 
 pattern RewardingPurpose ::
-  AlonzoEraScript era => f Word32 (RewardAcnt (EraCrypto era)) -> PlutusPurpose f era
+  AlonzoEraScript era => f Word32 (RewardAccount (EraCrypto era)) -> PlutusPurpose f era
 pattern RewardingPurpose c <- (toRewardingPurpose -> Just c)
   where
     RewardingPurpose c = mkRewardingPurpose c
@@ -443,6 +466,12 @@ instance Crypto c => AlonzoEraScript (AlonzoEra c) where
       _ -> Nothing
 
   withPlutusScript (AlonzoPlutusV1 plutus) f = f plutus
+
+  hoistPlutusPurpose f = \case
+    AlonzoSpending x -> AlonzoSpending $ f x
+    AlonzoMinting x -> AlonzoMinting $ f x
+    AlonzoCertifying x -> AlonzoCertifying $ f x
+    AlonzoRewarding x -> AlonzoRewarding $ f x
 
   mkSpendingPurpose = AlonzoSpending
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -84,10 +84,11 @@ import Cardano.Ledger.Alonzo.PParams (
   ppPricesL,
  )
 import Cardano.Ledger.Alonzo.Scripts (
-  AlonzoEraScript (PlutusPurpose),
-  AsItem (..),
+  AlonzoEraScript (PlutusPurpose, hoistPlutusPurpose),
+  AsIxItem,
   CostModel,
   ExUnits (..),
+  toAsIndex,
   txscriptfee,
  )
 import Cardano.Ledger.Alonzo.TxBody (
@@ -377,15 +378,13 @@ getMapFromValue (MaryValue _ (MultiAsset m)) = m
 
 -- | Find the Data and ExUnits assigned to a plutus script.
 indexRedeemers ::
-  (AlonzoEraTxBody era, AlonzoEraTxWits era, EraTx era) =>
+  (AlonzoEraTxWits era, EraTx era) =>
   Tx era ->
-  PlutusPurpose AsItem era ->
+  PlutusPurpose AsIxItem era ->
   Maybe (Data era, ExUnits)
-indexRedeemers tx sp = case redeemerPointer (tx ^. bodyTxL) sp of
-  SNothing -> Nothing
-  SJust rPtr -> Map.lookup rPtr rdmrs
-    where
-      rdmrs = unRedeemers (tx ^. witsTxL . rdmrsTxWitsL)
+indexRedeemers tx sp = Map.lookup (hoistPlutusPurpose toAsIndex sp) redeemers
+  where
+    redeemers = unRedeemers (tx ^. witsTxL . rdmrsTxWitsL)
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -385,6 +385,7 @@ indexRedeemers ::
 indexRedeemers tx sp = Map.lookup (hoistPlutusPurpose toAsIndex sp) redeemers
   where
     redeemers = unRedeemers (tx ^. witsTxL . rdmrsTxWitsL)
+{-# DEPRECATED indexRedeemers "As no longer needed" #-}
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -173,6 +173,7 @@ class (MaryEraTxBody era, AlonzoEraTxOut era) => AlonzoEraTxBody era where
     TxBody era ->
     PlutusPurpose AsIndex era ->
     StrictMaybe (PlutusPurpose AsIxItem era)
+{-# DEPRECATED redeemerPointer "As no longer needed" #-}
 
 -- ======================================
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Alonzo.TxWits (
   RedeemersRaw,
   unRedeemers,
   nullRedeemers,
+  lookupRedeemer,
   upgradeRedeemers,
   TxDats (TxDats, TxDats'),
   TxDatsRaw,
@@ -192,6 +193,13 @@ nullRedeemers = Map.null . unRedeemers
 
 emptyRedeemers :: AlonzoEraScript era => Redeemers era
 emptyRedeemers = Redeemers mempty
+
+lookupRedeemer ::
+  Ord (PlutusPurpose AsIndex era) =>
+  PlutusPurpose AsIndex era ->
+  Redeemers era ->
+  Maybe (Data era, ExUnits)
+lookupRedeemer key = Map.lookup key . unRedeemers
 
 -- | Upgrade redeemers from one era to another. The underlying data structure
 -- will remain identical, but the memoised serialisation may change to reflect

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -128,7 +128,7 @@ getAlonzoSpendingDatum ::
   PlutusPurpose AsItem era ->
   Maybe (Data era)
 getAlonzoSpendingDatum (UTxO m) tx sp = do
-  txIn <- plutusPurposeSpendingTxIn sp
+  AsItem txIn <- toSpendingPurpose sp
   txOut <- Map.lookup txIn m
   SJust hash <- Just $ txOut ^. dataHashTxOutL
   Map.lookup hash (unTxDats $ tx ^. witsTxL . datsTxWitsL)
@@ -140,7 +140,7 @@ getAlonzoSpendingTxIn = \case
   AlonzoMinting _policyId -> Nothing
   AlonzoRewarding _rewardAccount -> Nothing
   AlonzoCertifying _txCert -> Nothing
-{-# DEPRECATED getAlonzoSpendingTxIn "In favor of more general `plutusPurposeSpendingTxIn`" #-}
+{-# DEPRECATED getAlonzoSpendingTxIn "In favor of more general `toSpendingPurpose`" #-}
 
 getAlonzoScriptsHashesNeeded :: AlonzoScriptsNeeded era -> Set.Set (ScriptHash (EraCrypto era))
 getAlonzoScriptsHashesNeeded (AlonzoScriptsNeeded sn) = Set.fromList (map snd sn)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -398,6 +398,20 @@ instance
       , AlonzoRewarding <$> arbitrary
       ]
 
+instance
+  ( Era era
+  , Arbitrary (TxCert era)
+  ) =>
+  Arbitrary (AlonzoPlutusPurpose AsIxItem era)
+  where
+  arbitrary =
+    oneof
+      [ AlonzoSpending <$> arbitrary
+      , AlonzoMinting <$> arbitrary
+      , AlonzoCertifying <$> arbitrary
+      , AlonzoRewarding <$> arbitrary
+      ]
+
 instance Era era => Arbitrary (AlonzoPlutusPurpose AsIndex era) where
   arbitrary = arbitrary >>= genAlonzoPlutusPurposePointer
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -372,6 +372,9 @@ deriving instance Arbitrary ix => Arbitrary (AsIndex ix it)
 
 deriving instance Arbitrary it => Arbitrary (AsItem ix it)
 
+instance (Arbitrary ix, Arbitrary it) => Arbitrary (AsIxItem ix it) where
+  arbitrary = AsIxItem <$> arbitrary <*> arbitrary
+
 genAlonzoPlutusPurposePointer :: Word32 -> Gen (AlonzoPlutusPurpose AsIndex era)
 genAlonzoPlutusPurposePointer i =
   elements

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -44,7 +44,7 @@ library
     build-depends:
         base >=4.14 && <5,
         bytestring,
-        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.5.1,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.7,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.12,
         cardano-ledger-allegra >=1.2,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -66,7 +66,7 @@ library
         cardano-crypto-class,
         cardano-data >=1.2,
         cardano-ledger-allegra ^>=1.3,
-        cardano-ledger-alonzo ^>=1.6,
+        cardano-ledger-alonzo ^>=1.7,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.11,
         cardano-ledger-mary ^>=1.5,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -76,6 +76,12 @@ instance Crypto c => AlonzoEraScript (BabbageEra c) where
   withPlutusScript (BabbagePlutusV1 plutus) f = f plutus
   withPlutusScript (BabbagePlutusV2 plutus) f = f plutus
 
+  hoistPlutusPurpose f = \case
+    AlonzoSpending x -> AlonzoSpending $ f x
+    AlonzoMinting x -> AlonzoMinting $ f x
+    AlonzoCertifying x -> AlonzoCertifying $ f x
+    AlonzoRewarding x -> AlonzoRewarding $ f x
+
   mkSpendingPurpose = AlonzoSpending
 
   toSpendingPurpose (AlonzoSpending i) = Just i

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -76,9 +76,25 @@ instance Crypto c => AlonzoEraScript (BabbageEra c) where
   withPlutusScript (BabbagePlutusV1 plutus) f = f plutus
   withPlutusScript (BabbagePlutusV2 plutus) f = f plutus
 
-  plutusPurposeSpendingTxIn = \case
-    AlonzoSpending (AsItem txIn) -> Just txIn
-    _ -> Nothing
+  mkSpendingPurpose = AlonzoSpending
+
+  toSpendingPurpose (AlonzoSpending i) = Just i
+  toSpendingPurpose _ = Nothing
+
+  mkMintingPurpose = AlonzoMinting
+
+  toMintingPurpose (AlonzoMinting i) = Just i
+  toMintingPurpose _ = Nothing
+
+  mkCertifyingPurpose = AlonzoCertifying
+
+  toCertifyingPurpose (AlonzoCertifying i) = Just i
+  toCertifyingPurpose _ = Nothing
+
+  mkRewardingPurpose = AlonzoRewarding
+
+  toRewardingPurpose (AlonzoRewarding i) = Just i
+  toRewardingPurpose _ = Nothing
 
   upgradePlutusPurposeAsIndex = \case
     AlonzoMinting (AsIndex ix) -> AlonzoMinting (AsIndex ix)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..))
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
+import Cardano.Ledger.Alonzo.Scripts (toAsItem)
 import Cardano.Ledger.Alonzo.Tx (Data)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemers)
 import Cardano.Ledger.Babbage.Core
@@ -283,7 +284,7 @@ instance ToJSON (PlutusPurpose AsIndex era) => ToJSON (BabbageContextError era) 
 instance Crypto c => EraPlutusTxInfo 'PlutusV1 (BabbageEra c) where
   toPlutusTxCert _ = pure . Alonzo.transTxCert
 
-  toPlutusScriptPurpose = Alonzo.transPlutusPurpose
+  toPlutusScriptPurpose proxy = Alonzo.transPlutusPurpose proxy . hoistPlutusPurpose toAsItem
 
   toPlutusTxInfo proxy pp epochInfo systemStart utxo tx = do
     let refInputs = txBody ^. referenceInputsTxBodyL
@@ -319,7 +320,7 @@ instance Crypto c => EraPlutusTxInfo 'PlutusV1 (BabbageEra c) where
 instance Crypto c => EraPlutusTxInfo 'PlutusV2 (BabbageEra c) where
   toPlutusTxCert _ = pure . Alonzo.transTxCert
 
-  toPlutusScriptPurpose = Alonzo.transPlutusPurpose
+  toPlutusScriptPurpose proxy = Alonzo.transPlutusPurpose proxy . hoistPlutusPurpose toAsItem
 
   toPlutusTxInfo proxy pp epochInfo systemStart utxo tx = do
     timeRange <- Alonzo.transValidityInterval pp epochInfo systemStart (txBody ^. vldtTxBodyL)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary (sizedValue)
-import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Shelley.UTxO (shelleyProducedValue)
@@ -37,6 +37,7 @@ import qualified Data.Set as Set
 import Lens.Micro
 
 instance Crypto c => EraUTxO (BabbageEra c) where
+  {-# SPECIALIZE instance EraUTxO (BabbageEra StandardCrypto) #-}
   type ScriptsNeeded (BabbageEra c) = AlonzoScriptsNeeded (BabbageEra c)
 
   getConsumedValue = getConsumedMaryValue
@@ -46,6 +47,7 @@ instance Crypto c => EraUTxO (BabbageEra c) where
   getScriptsProvided = getBabbageScriptsProvided
 
   getScriptsNeeded = getAlonzoScriptsNeeded
+  {-# INLINEABLE getScriptsNeeded #-}
 
   getScriptsHashesNeeded = getAlonzoScriptsHashesNeeded
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -79,7 +79,7 @@ getBabbageSpendingDatum ::
   PlutusPurpose AsItem era ->
   Maybe (Data era)
 getBabbageSpendingDatum (UTxO utxo) tx sp = do
-  txIn <- plutusPurposeSpendingTxIn sp
+  AsItem txIn <- toSpendingPurpose sp
   txOut <- Map.lookup txIn utxo
   let txOutDataFromWits = do
         dataHash <- strictMaybeToMaybe (txOut ^. dataHashTxOutL)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.13.0.0
 
+* Fix `ConwayTxBody` pattern synonym, by changing its certificates arguments to `OSet`
+  from a `StrictSeq`.
+* Add `VotingPurpose` and `ProposingPurpose` pattern synonyms
+* Add `ConwayEraScript` with `toVotingPurpose`, `toProposingPurpose`, `fromVotingPurpose`,
+  `fromProposingPurpose`.
+* Add upgrade failure: `CTBUEContainsDuplicateCerts`
 * Rename `proposalsRemoveDescendentIds` to `proposalsRemoveWithDescendants` (fixed spelling too)
 * Rename:
   * `pfPParamUpdateL` to `grPParamUpdateL`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -83,7 +83,7 @@ library
         cardano-data >=1.2.1,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-allegra ^>=1.3,
-        cardano-ledger-alonzo ^>=1.6,
+        cardano-ledger-alonzo ^>=1.7,
         cardano-ledger-babbage ^>=1.7,
         cardano-ledger-core ^>=1.11,
         cardano-ledger-mary ^>=1.5,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Core.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Cardano.Ledger.Conway.Core (
   ConwayEraTxBody (..),
   ConwayEraPParams,
@@ -24,6 +26,9 @@ module Cardano.Ledger.Conway.Core (
   dvtPPTechnicalGroupL,
   dvtPPEconomicGroupL,
   dvtUpdateToConstitutionL,
+  ConwayEraScript (..),
+  pattern VotingPurpose,
+  pattern ProposingPurpose,
   module Cardano.Ledger.Babbage.Core,
 )
 where
@@ -54,6 +59,11 @@ import Cardano.Ledger.Conway.PParams (
   ppuGovActionDepositL,
   ppuGovActionLifetimeL,
   ppuPoolVotingThresholdsL,
+ )
+import Cardano.Ledger.Conway.Scripts (
+  ConwayEraScript (..),
+  pattern ProposingPurpose,
+  pattern VotingPurpose,
  )
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -5,17 +5,22 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Scripts (
+  ConwayEraScript (..),
   AlonzoScript (..),
   PlutusScript (..),
   isPlutusScript,
   ConwayPlutusPurpose (..),
+  pattern VotingPurpose,
+  pattern ProposingPurpose,
 )
 where
 
@@ -49,6 +54,15 @@ import Data.Typeable
 import Data.Word (Word16, Word32, Word8)
 import GHC.Generics
 import NoThunks.Class (NoThunks (..))
+
+class AlonzoEraScript era => ConwayEraScript era where
+  mkVotingPurpose :: f Word32 (Voter (EraCrypto era)) -> PlutusPurpose f era
+
+  toVotingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (Voter (EraCrypto era)))
+
+  mkProposingPurpose :: f Word32 (ProposalProcedure era) -> PlutusPurpose f era
+
+  toProposingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (ProposalProcedure era))
 
 instance Crypto c => EraScript (ConwayEra c) where
   type Script (ConwayEra c) = AlonzoScript (ConwayEra c)
@@ -92,15 +106,42 @@ instance Crypto c => AlonzoEraScript (ConwayEra c) where
   withPlutusScript (ConwayPlutusV2 plutus) f = f plutus
   withPlutusScript (ConwayPlutusV3 plutus) f = f plutus
 
-  plutusPurposeSpendingTxIn = \case
-    ConwaySpending (AsItem txIn) -> Just txIn
-    _ -> Nothing
+  mkSpendingPurpose = ConwaySpending
+
+  toSpendingPurpose (ConwaySpending i) = Just i
+  toSpendingPurpose _ = Nothing
+
+  mkMintingPurpose = ConwayMinting
+
+  toMintingPurpose (ConwayMinting i) = Just i
+  toMintingPurpose _ = Nothing
+
+  mkCertifyingPurpose = ConwayCertifying
+
+  toCertifyingPurpose (ConwayCertifying i) = Just i
+  toCertifyingPurpose _ = Nothing
+
+  mkRewardingPurpose = ConwayRewarding
+
+  toRewardingPurpose (ConwayRewarding i) = Just i
+  toRewardingPurpose _ = Nothing
 
   upgradePlutusPurposeAsIndex = \case
     AlonzoSpending (AsIndex ix) -> ConwaySpending (AsIndex ix)
     AlonzoMinting (AsIndex ix) -> ConwayMinting (AsIndex ix)
     AlonzoCertifying (AsIndex ix) -> ConwayCertifying (AsIndex ix)
     AlonzoRewarding (AsIndex ix) -> ConwayRewarding (AsIndex ix)
+
+instance Crypto c => ConwayEraScript (ConwayEra c) where
+  mkVotingPurpose = ConwayVoting
+
+  toVotingPurpose (ConwayVoting i) = Just i
+  toVotingPurpose _ = Nothing
+
+  mkProposingPurpose = ConwayProposing
+
+  toProposingPurpose (ConwayProposing i) = Just i
+  toProposingPurpose _ = Nothing
 
 instance NFData (PlutusScript (ConwayEra c)) where
   rnf = rwhnf
@@ -213,3 +254,15 @@ instance
     ConwayProposing n -> kindObjectWithValue "ConwayProposing" n
     where
       kindObjectWithValue name n = kindObject name ["value" .= n]
+
+pattern VotingPurpose ::
+  ConwayEraScript era => f Word32 (Voter (EraCrypto era)) -> PlutusPurpose f era
+pattern VotingPurpose c <- (toVotingPurpose -> Just c)
+  where
+    VotingPurpose c = mkVotingPurpose c
+
+pattern ProposingPurpose ::
+  ConwayEraScript era => f Word32 (ProposalProcedure era) -> PlutusPurpose f era
+pattern ProposingPurpose c <- (toProposingPurpose -> Just c)
+  where
+    ProposingPurpose c = mkProposingPurpose c

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -106,6 +107,14 @@ instance Crypto c => AlonzoEraScript (ConwayEra c) where
   withPlutusScript (ConwayPlutusV2 plutus) f = f plutus
   withPlutusScript (ConwayPlutusV3 plutus) f = f plutus
 
+  hoistPlutusPurpose f = \case
+    ConwaySpending x -> ConwaySpending $ f x
+    ConwayMinting x -> ConwayMinting $ f x
+    ConwayCertifying x -> ConwayCertifying $ f x
+    ConwayRewarding x -> ConwayRewarding $ f x
+    ConwayVoting x -> ConwayVoting $ f x
+    ConwayProposing x -> ConwayProposing $ f x
+
   mkSpendingPurpose = ConwaySpending
 
   toSpendingPurpose (ConwaySpending i) = Just i
@@ -186,6 +195,10 @@ deriving via
     , DecCBOR (TxCert era)
     ) =>
     DecCBOR (ConwayPlutusPurpose f era)
+
+deriving instance (Eq (TxCert era), EraPParams era) => Eq (ConwayPlutusPurpose AsIxItem era)
+deriving instance (Show (TxCert era), EraPParams era) => Show (ConwayPlutusPurpose AsIxItem era)
+instance (NoThunks (TxCert era), EraPParams era) => NoThunks (ConwayPlutusPurpose AsIxItem era)
 
 instance
   (forall a b. (NFData a, NFData b) => NFData (f a b), NFData (TxCert era), EraPParams era) =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -86,7 +86,7 @@ import Cardano.Ledger.Coin (Coin (..), decodePositiveCoin)
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (ProposalProcedure, VotingProcedures (..))
 import Cardano.Ledger.Conway.PParams (ConwayEraPParams, ppGovActionDepositL)
-import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
+import Cardano.Ledger.Conway.Scripts (ConwayEraScript, ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxCert (
   ConwayEraTxCert,
   ConwayTxCert (..),
@@ -689,7 +689,10 @@ instance ConwayEraTxBody era => EncCBOR (ConwayTxBodyRaw era) where
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (ConwayTxBody era)
 
-class (BabbageEraTxBody era, ConwayEraTxCert era, ConwayEraPParams era) => ConwayEraTxBody era where
+class
+  (BabbageEraTxBody era, ConwayEraTxCert era, ConwayEraPParams era, ConwayEraScript era) =>
+  ConwayEraTxBody era
+  where
   -- | Lens for getting and setting number of `Coin` that is expected to be in the
   -- Treasury at the current Epoch
   currentTreasuryValueTxBodyL :: Lens' (TxBody era) (StrictMaybe Coin)
@@ -726,7 +729,7 @@ conwayRedeemerPointerInverse ::
   ConwayEraTxBody era =>
   TxBody era ->
   ConwayPlutusPurpose AsIndex era ->
-  StrictMaybe (ConwayPlutusPurpose AsItem era)
+  StrictMaybe (ConwayPlutusPurpose AsIxItem era)
 conwayRedeemerPointerInverse txBody = \case
   ConwayMinting idx ->
     ConwayMinting <$> fromIndex idx (txBody ^. mintedTxBodyF)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -17,17 +17,21 @@ module Cardano.Ledger.Conway.UTxO (
   getConwayWitsVKeyNeeded,
 ) where
 
-import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
   getAlonzoScriptsHashesNeeded,
+  getMintingScriptsNeeded,
+  getRewardingScriptsNeeded,
+  getSpendingScriptsNeeded,
+  zipAsIxItem,
  )
 import Cardano.Ledger.Babbage.UTxO (
   getBabbageScriptsProvided,
   getBabbageSpendingDatum,
   getBabbageSupplementalDataHashes,
  )
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (
@@ -36,75 +40,62 @@ import Cardano.Ledger.Conway.Governance.Procedures (
   Voter (..),
   unVotingProcedures,
  )
-import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Credential (credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..), asWitness)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
-import Cardano.Ledger.Mary.Value (PolicyID (..))
 import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov, shelleyProducedValue)
-import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), getScriptHash)
+import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.Val (Val (..), inject)
-import Data.Foldable (Foldable (..), toList)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (mapMaybe)
-import Data.Maybe.Strict (strictMaybeToMaybe)
+import Data.Maybe (catMaybes)
 import qualified Data.Set as Set
 import Lens.Micro ((^.))
-import Lens.Micro.Extras (view)
 
 getConwayScriptsNeeded ::
-  (ConwayEraTxBody era, PlutusPurpose AsItem era ~ ConwayPlutusPurpose AsItem era) =>
+  ConwayEraTxBody era =>
   UTxO era ->
   TxBody era ->
   AlonzoScriptsNeeded era
-getConwayScriptsNeeded (UTxO utxo) txBody =
-  AlonzoScriptsNeeded (spending ++ rewarding ++ certifying ++ minting ++ voting ++ proposing)
+getConwayScriptsNeeded utxo txBody =
+  getSpendingScriptsNeeded utxo txBody
+    <> getRewardingScriptsNeeded txBody
+    <> certifyingScriptsNeeded
+    <> getMintingScriptsNeeded txBody
+    <> votingScriptsNeeded
+    <> proposingScriptsNeeded
   where
-    collect !txIn = do
-      addr <- view addrTxOutL <$> Map.lookup txIn utxo
-      hash <- getScriptHash addr
-      return (ConwaySpending (AsItem txIn), hash)
+    certifyingScriptsNeeded =
+      AlonzoScriptsNeeded $
+        catMaybes $
+          zipAsIxItem (txBody ^. certsTxBodyL) $
+            \asIxItem@(AsIxItem _ txCert) ->
+              (CertifyingPurpose asIxItem,) <$> getScriptWitnessTxCert txCert
 
-    spending = mapMaybe collect (Set.toList $ txBody ^. inputsTxBodyL)
-
-    rewarding = mapMaybe fromRewardAccount (Map.keys withdrawals)
-      where
-        withdrawals = unWithdrawals $ txBody ^. withdrawalsTxBodyL
-        fromRewardAccount rewardAccount = do
-          hash <- credScriptHash $ raCredential rewardAccount
-          return (ConwayRewarding (AsItem rewardAccount), hash)
-
-    certifying =
-      mapMaybe (\cred -> (ConwayCertifying (AsItem cred),) <$> getScriptWitnessTxCert cred) $
-        toList (txBody ^. certsTxBodyL)
-
-    minting =
-      map (\policyId@(PolicyID hash) -> (ConwayMinting (AsItem policyId), hash)) $
-        Set.toList (txBody ^. mintedTxBodyF)
-
-    voting =
-      mapMaybe toConwayVoting $
-        Map.keys (unVotingProcedures (txBody ^. votingProceduresTxBodyL))
+    votingScriptsNeeded =
+      AlonzoScriptsNeeded $
+        catMaybes $
+          zipAsIxItem (Map.keys (unVotingProcedures (txBody ^. votingProceduresTxBodyL))) $
+            \asIxItem@(AsIxItem _ voter) ->
+              (VotingPurpose asIxItem,) <$> getVoterScriptHash voter
       where
         getVoterScriptHash = \case
           CommitteeVoter cred -> credScriptHash cred
           DRepVoter cred -> credScriptHash cred
           StakePoolVoter _ -> Nothing
-        toConwayVoting voter = do
-          scriptHash <- getVoterScriptHash voter
-          let !purpose = ConwayVoting (AsItem voter)
-          pure (purpose, scriptHash)
 
-    proposing =
-      mapMaybe proposalPolicy . toList $ txBody ^. proposalProceduresTxBodyL
+    proposingScriptsNeeded =
+      AlonzoScriptsNeeded $
+        catMaybes $
+          zipAsIxItem (txBody ^. proposalProceduresTxBodyL) $
+            \asIxItem@(AsIxItem _ proposal) ->
+              (ProposingPurpose asIxItem,) <$> getProposalScriptHash proposal
       where
-        proposalPolicy proposal@ProposalProcedure {pProcGovAction} = do
-          govPolicy <- case pProcGovAction of
-            ParameterChange _ _ p -> strictMaybeToMaybe p
-            TreasuryWithdrawals _ p -> strictMaybeToMaybe p
+        getProposalScriptHash ProposalProcedure {pProcGovAction} =
+          case pProcGovAction of
+            ParameterChange _ _ (SJust govPolicyHash) -> Just govPolicyHash
+            TreasuryWithdrawals _ (SJust govPolicyHash) -> Just govPolicyHash
             _ -> Nothing
-          pure (ConwayProposing (AsItem proposal), govPolicy)
 
 conwayProducedValue ::
   ConwayEraTxBody era =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -486,6 +486,23 @@ instance
       ]
 
 instance
+  ( Era era
+  , Arbitrary (TxCert era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (ConwayPlutusPurpose AsIxItem era)
+  where
+  arbitrary =
+    oneof
+      [ ConwaySpending <$> arbitrary
+      , ConwayMinting <$> arbitrary
+      , ConwayCertifying <$> arbitrary
+      , ConwayRewarding <$> arbitrary
+      , ConwayVoting <$> arbitrary
+      , ConwayProposing <$> arbitrary
+      ]
+
+instance
   Era era =>
   Arbitrary (ConwayPlutusPurpose AsIndex era)
   where

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -30,6 +30,7 @@ library
 
     build-depends:
         base >=4.14 && <5,
+        cardano-data,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.6,
         cardano-ledger-alonzo-test,
         cardano-ledger-babbage >=1.3 && <1.8,

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -57,8 +57,8 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import Control.State.Transition.Extended (Embed (..))
 import Data.Default.Class (Default (def))
 import qualified Data.Map.Strict as Map
+import qualified Data.OSet.Strict as OSet
 import Data.Proxy (Proxy (..))
-import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Lens.Micro
@@ -119,9 +119,9 @@ collateralOutput =
     NoDatum
     SNothing
 
-exampleConwayCerts :: Era era => StrictSeq (ConwayTxCert era)
+exampleConwayCerts :: Era era => OSet.OSet (ConwayTxCert era)
 exampleConwayCerts =
-  StrictSeq.fromList -- TODO should I add the new certs here?
+  OSet.fromList -- TODO should I add the new certs here?
     [ ConwayTxCertPool (RegPool examplePoolParams)
     ]
 

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.1.0
 
+* Add `OSet.fromList`
 * Add `fromFoldableDuplicates`
 
 ## 1.2.0.0

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -20,6 +20,7 @@ module Data.OSet.Strict (
   lookup,
   member,
   (!?),
+  fromList,
   fromStrictSeq,
   fromStrictSeqDuplicates,
   toStrictSeq,
@@ -49,7 +50,7 @@ import Control.DeepSeq (NFData)
 import Data.Foldable qualified as F
 import Data.Sequence.Strict qualified as SSeq
 import Data.Set qualified as Set
-import GHC.Exts (IsList (..))
+import qualified GHC.Exts as GHC (IsList (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Prelude hiding (filter, lookup, null, seq)
@@ -75,9 +76,9 @@ instance Ord a => Semigroup (OSet a) where
 instance Ord a => Monoid (OSet a) where
   mempty = empty
 
-instance Ord a => IsList (OSet a) where
+instance Ord a => GHC.IsList (OSet a) where
   type Item (OSet a) = a
-  fromList = fromFoldable
+  fromList = fromList
   toList = F.toList . osSSeq
 
 instance Foldable OSet where
@@ -178,16 +179,22 @@ unsnoc (OSet seq set) = case seq of
   SSeq.Empty -> Nothing
   xs' SSeq.:|> x -> Just (OSet xs' (x `Set.delete` set), x)
 
+-- | \(O(n \log n)\). Convert to an OSet from a List.
+fromList :: Ord a => [a] -> OSet a
+fromList = fromFoldable
+
 -- | Using a `Foldable` instance of the source data structure convert it to an `OSet`
 fromFoldable :: (Foldable f, Ord a) => f a -> OSet a
 fromFoldable = F.foldl' snoc empty
 
 -- | \(O(n \log n)\). Checks membership before snoc-ing.
 -- De-duplicates the StrictSeq without overwriting.
--- Starts from the left or head, using `foldl'`
 fromStrictSeq :: Ord a => SSeq.StrictSeq a -> OSet a
 fromStrictSeq = fromFoldable
 
+-- | \(O(n \log n)\). Checks membership before snoc-ing.
+-- Returns a 2-tuple, with `fst` as a `Set` of duplicates found
+-- and the `snd` as the de-duplicated `OSet` without overwriting.
 fromFoldableDuplicates :: (Foldable f, Ord a) => f a -> (Set.Set a, OSet a)
 fromFoldableDuplicates = F.foldl' snoc' (Set.empty, empty)
   where

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -50,7 +50,7 @@ import Control.DeepSeq (NFData)
 import Data.Foldable qualified as F
 import Data.Sequence.Strict qualified as SSeq
 import Data.Set qualified as Set
-import qualified GHC.Exts as GHC (IsList (..))
+import GHC.Exts qualified as GHC (IsList (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Prelude hiding (filter, lookup, null, seq)

--- a/libs/cardano-data/test/Test/Cardano/Data/OSet/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OSet/StrictSpec.hs
@@ -9,7 +9,8 @@ import Cardano.Ledger.Binary (natVersion)
 import Control.Monad (forM_)
 import Data.OSet.Strict hiding (empty)
 import Data.Proxy
-import Data.Sequence.Strict (StrictSeq, fromList, (><))
+import Data.Sequence.Strict (StrictSeq, (><))
+import qualified Data.Sequence.Strict as SSeq (fromList)
 import Data.Set (Set, elems, empty)
 import Test.Cardano.Data.Arbitrary ()
 import Test.Cardano.Ledger.Binary.RoundTrip (cborTrip, embedTripSpec, roundTripCborSpec)
@@ -69,17 +70,17 @@ spec =
         oset ><| oset' `shouldSatisfy` invariantHolds'
         fromStrictSeq sseq `shouldSatisfy` invariantHolds'
         fromSet set `shouldSatisfy` invariantHolds'
-    prop "fromStrictSeq preserves order" $
+    prop "fromList preserves order" $
       \(set :: Set Int) ->
-        let sseq = fromList $ elems set
-         in toStrictSeq (fromStrictSeq sseq) `shouldBe` sseq
+        let sseq = SSeq.fromList $ elems set
+         in toStrictSeq (fromList (elems set)) `shouldBe` sseq
     context "fromStrictSeqDuplicates" $ do
       prop "with duplicates" $ \(set :: (Set Int)) ->
-        let sseq = fromList $ elems set
+        let sseq = SSeq.fromList $ elems set
             oset = fromStrictSeq sseq
          in fromStrictSeqDuplicates (sseq >< sseq) `shouldBe` (set, oset)
       prop "without duplicates" $ \(set :: (Set Int)) ->
-        let sseq = fromList $ elems set
+        let sseq = SSeq.fromList $ elems set
             oset = fromStrictSeq sseq
          in fromStrictSeqDuplicates sseq `shouldBe` (empty, oset)
     context "CBOR round-trip" $ do

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -55,7 +55,7 @@ library
         aeson >=2.2,
         bytestring,
         cardano-ledger-allegra ^>=1.3,
-        cardano-ledger-alonzo ^>=1.6,
+        cardano-ledger-alonzo ^>=1.7,
         cardano-ledger-babbage ^>=1.7,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-conway ^>=1.13,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -1,22 +1,59 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Cardano.Ledger.Api.Scripts (
   module Cardano.Ledger.Api.Scripts.Data,
   EraScript (Script, NativeScript),
+  ScriptHash,
   scriptPrefixTag,
   upgradeScript,
   hashScript,
   getNativeScript,
   validateNativeScript,
   isNativeScript,
-  isPlutusScript,
-  ScriptHash,
-  CostModels,
   ValidityInterval (..),
+
+  -- * Alonzo
+  AlonzoEraScript (
+    PlutusScript,
+    PlutusPurpose,
+    toSpendingPurpose,
+    toMintingPurpose,
+    toCertifyingPurpose,
+    toRewardingPurpose
+  ),
+  isPlutusScript,
+  pattern SpendingPurpose,
+  pattern MintingPurpose,
+  pattern CertifyingPurpose,
+  pattern RewardingPurpose,
+  CostModels,
+
+  -- * Conway
+  ConwayEraScript (
+    toVotingPurpose,
+    toProposingPurpose
+  ),
+  pattern VotingPurpose,
+  pattern ProposingPurpose,
 )
 where
 
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
-import Cardano.Ledger.Alonzo.Scripts (CostModels, isPlutusScript)
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoEraScript (..),
+  CostModels,
+  isPlutusScript,
+  pattern CertifyingPurpose,
+  pattern MintingPurpose,
+  pattern RewardingPurpose,
+  pattern SpendingPurpose,
+ )
 import Cardano.Ledger.Api.Era ()
 import Cardano.Ledger.Api.Scripts.Data
+import Cardano.Ledger.Conway.Scripts (
+  ConwayEraScript (..),
+  pattern ProposingPurpose,
+  pattern VotingPurpose,
+ )
 import Cardano.Ledger.Core (EraScript (..), isNativeScript, validateNativeScript)
 import Cardano.Ledger.Hashes (ScriptHash)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
@@ -240,8 +240,8 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
       -- inline datums, when they are present, since for PlutusV1 presence of inline
       -- datums would short circuit earlier on PlutusContext translation.
       datums <-
-        case plutusPurposeSpendingTxIn plutusPurpose of
-          Just txIn -> do
+        case toSpendingPurpose plutusPurpose of
+          Just (AsItem txIn) -> do
             txOut <- note (UnknownTxIn txIn) $ Map.lookup txIn (unUTxO utxo)
             datum <-
               case txOut ^. datumTxOutF of

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
@@ -25,24 +25,11 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (mkPlutusScriptContext),
  )
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (lookupPlutusScript)
-import Cardano.Ledger.Alonzo.Scripts (
-  AlonzoEraScript (..),
-  AsIndex (..),
-  AsItem (..),
-  PlutusPurpose (..),
-  plutusScriptLanguage,
- )
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
-import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (redeemerPointer))
-import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..))
-import Cardano.Ledger.Alonzo.TxWits (
-  AlonzoEraTxWits (..),
-  unRedeemers,
-  unTxDats,
- )
+import Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage, toAsIndex, toAsItem)
+import Cardano.Ledger.Alonzo.TxWits (unRedeemers, unTxDats)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.BaseTypes (StrictMaybe (..), pvMajor)
-import Cardano.Ledger.Core
+import Cardano.Ledger.BaseTypes (pvMajor)
+import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Plutus.CostModels (costModelsValid)
 import Cardano.Ledger.Plutus.Data (Datum (..), binaryDataToData, getPlutusData)
 import Cardano.Ledger.Plutus.Evaluate (
@@ -202,13 +189,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
               utxo
               tx
           pure (plutusScript, scriptContext)
-      -- Since `getScriptsNeeded` used the `txBody` to create script purposes, it would be
-      -- a logic error if `redeemerPointer` was not able to find `plutusPurpose`.
-      let !pointer =
-            case redeemerPointer txBody plutusPurpose of
-              SNothing ->
-                error "Impossible: Redeemer pointer was not found in the TxBody"
-              SJust p -> p
+      let pointer = hoistPlutusPurpose toAsIndex plutusPurpose
       pure (pointer, (plutusPurpose, mPlutusScriptAndContext, scriptHash))
   pure $ Map.mapWithKey (findAndCount $ Map.fromList ptrToPlutusScript) rdmrs
   where
@@ -230,7 +211,9 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
         note (RedeemerPointsToUnknownScriptHash pointer) $
           Map.lookup pointer ptrToPlutusScript
       let ptrToPlutusScriptNoContext =
-            Map.map (\(sp, mps, sh) -> (sp, fst <$> mps, sh)) ptrToPlutusScript
+            Map.map
+              (\(sp, mps, sh) -> (hoistPlutusPurpose toAsItem sp, fst <$> mps, sh))
+              ptrToPlutusScript
       (plutusScript, scriptContext) <-
         note (MissingScript pointer ptrToPlutusScriptNoContext) mPlutusScript
       let lang = plutusScriptLanguage plutusScript
@@ -241,7 +224,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
       -- datums would short circuit earlier on PlutusContext translation.
       datums <-
         case toSpendingPurpose plutusPurpose of
-          Just (AsItem txIn) -> do
+          Just (AsIxItem _ txIn) -> do
             txOut <- note (UnknownTxIn txIn) $ Map.lookup txIn (unUTxO utxo)
             datum <-
               case txOut ^. datumTxOutF of

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -13,7 +13,7 @@
 
 module Test.Cardano.Ledger.Constrained.Classes where
 
-import Cardano.Ledger.Alonzo.Scripts (AsIndex, AsItem, PlutusPurpose)
+import Cardano.Ledger.Alonzo.Scripts (AsIndex, AsIxItem, PlutusPurpose)
 import Cardano.Ledger.Alonzo.TxOut (AlonzoTxOut (..))
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
@@ -79,7 +79,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   pcVal,
   pcWitnesses,
   ppPlutusPurposeAsIndex,
-  ppPlutusPurposeAsItem,
+  ppPlutusPurposeAsIxItem,
   ppString,
  )
 import Test.Cardano.Ledger.Generic.Proof (
@@ -597,9 +597,9 @@ instance Eq (TxCertF era) where
 
 -- ==================
 data PlutusPurposeF era where
-  PlutusPurposeF :: Proof era -> PlutusPurpose AsItem era -> PlutusPurposeF era
+  PlutusPurposeF :: Proof era -> PlutusPurpose AsIxItem era -> PlutusPurposeF era
 
-unPlutusPurposeF :: PlutusPurposeF era -> PlutusPurpose AsItem era
+unPlutusPurposeF :: PlutusPurposeF era -> PlutusPurpose AsIxItem era
 unPlutusPurposeF (PlutusPurposeF _ pp) = pp
 
 data PlutusPointerF era where
@@ -609,7 +609,7 @@ unPlutusPointerF :: PlutusPointerF era -> PlutusPurpose AsIndex era
 unPlutusPointerF (PlutusPointerF _ pp) = pp
 
 instance Show (PlutusPurposeF era) where
-  show (PlutusPurposeF p x) = unReflect (\_ -> show (ppPlutusPurposeAsItem x)) p
+  show (PlutusPurposeF p x) = unReflect (\_ -> show (ppPlutusPurposeAsIxItem x)) p
 
 instance Show (PlutusPointerF era) where
   show (PlutusPointerF p x) = unReflect (\_ -> show (ppPlutusPurposeAsIndex x)) p

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -16,12 +16,12 @@ module Test.Cardano.Ledger.Constrained.Preds.Tx where
 
 import Cardano.Crypto.Signing (SigningKey)
 import Cardano.Ledger.Address (Addr (..), BootstrapAddress, RewardAccount (..))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..), plutusScriptLanguage)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..), plutusScriptLanguage, toAsIndex)
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (TxDats (..))
 import Cardano.Ledger.Alonzo.UTxO (getInputDataHashesTxBody)
 import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
-import Cardano.Ledger.BaseTypes (Network (..), ProtVer (..), StrictMaybe (..), strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (Network (..), ProtVer (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary.Decoding (mkSized, sizedSize)
 import Cardano.Ledger.Binary.Encoding (EncCBOR)
 import Cardano.Ledger.CertState (CertState, certDStateL, dsGenDelegsL)
@@ -197,28 +197,26 @@ needT proof = Constr "neededScripts" needed
     needed (TxBodyF _ txbodyV) ut = ScriptsNeededF proof (getScriptsNeeded (liftUTxO ut) txbodyV)
 
 rdmrPtrsT ::
-  AlonzoEraTxBody era =>
+  AlonzoEraScript era =>
   Target
     era
-    ( TxBodyF era ->
-      [((PlutusPurposeF era), (ScriptHash (EraCrypto era)))] ->
+    ( [((PlutusPurposeF era), (ScriptHash (EraCrypto era)))] ->
       Map (ScriptHash (EraCrypto era)) any ->
       Set (PlutusPointerF era)
     )
 rdmrPtrsT = Constr "getRdmrPtrs" getRdmrPtrs
 
 getRdmrPtrs ::
-  AlonzoEraTxBody era =>
-  TxBodyF era ->
+  AlonzoEraScript era =>
   [((PlutusPurposeF era), (ScriptHash (EraCrypto era)))] ->
   Map (ScriptHash (EraCrypto era)) any ->
   Set (PlutusPointerF era)
-getRdmrPtrs (TxBodyF _ txbodyV) xs allplutus = List.foldl' accum Set.empty xs
+getRdmrPtrs xs allplutus = List.foldl' accum Set.empty xs
   where
     accum ans (PlutusPurposeF p sp, hash)
-      | Map.member hash allplutus
-      , SJust x <- redeemerPointer txbodyV sp =
-          Set.insert (PlutusPointerF p x) ans
+      | Map.member hash allplutus =
+          let ptr = hoistPlutusPurpose toAsIndex sp
+           in Set.insert (PlutusPointerF p ptr) ans
       | otherwise = ans
 
 getPlutusDataHashes ::
@@ -601,7 +599,7 @@ txBodyPreds sizes@UnivSize {..} p =
         , -- , scriptWits :=: Restrict refAdjusted (allScriptUniv p)
           Restrict refAdjusted (allScriptUniv p) :=: scriptWits
         , Elems (ProjM fstL IsValidR (Restrict neededHashSet plutusUniv)) :=: valids
-        , rdmrPtrs :<-: (rdmrPtrsT ^$ tempTxBody ^$ acNeeded ^$ plutusUniv)
+        , rdmrPtrs :<-: (rdmrPtrsT ^$ acNeeded ^$ plutusUniv)
         , rdmrPtrs :=: Dom redeemers
         , If
             (Constr "null" Set.null ^$ rdmrPtrs)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -285,7 +285,7 @@ addWitnesses proof scriptUniv plutusuniv byronuniv keymapuniv datauniv txb ut gd
          in ( Map.restrictKeys scriptUniv refAdjusted
             , Map.restrictKeys scriptUniv neededHashset
             , validities
-            , getRdmrPtrs (TxBodyF proof txb) xs' plutusuniv
+            , getRdmrPtrs xs' plutusuniv
             , Map.restrictKeys
                 datauniv
                 ( getPlutusDataHashes

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..), collectPlutusSc
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   AlonzoScript (..),
-  AsItem (..),
+  AsIxItem (..),
   ExUnits (..),
  )
 import Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
@@ -169,7 +169,7 @@ collectInputs x = error ("collectInputs Not defined in era " ++ show x)
 mkPlutusScriptContext' ::
   Proof era ->
   PlutusScript era ->
-  PlutusPurpose AsItem era ->
+  PlutusPurpose AsIxItem era ->
   PParams era ->
   EpochInfo (Either Text) ->
   SystemStart ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -81,6 +81,7 @@ import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Slotting.Slot (SlotNo (..))
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.OSet.Strict as OSet
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SSeq (fromList)
 import Data.Set (Set)
@@ -443,7 +444,7 @@ abstractTxBody Conway (ConwayTxBody inp col ref out colret totcol cert wdrl fee 
   , Outputs (sizedValue <$> out)
   , CollateralReturn (sizedValue <$> colret)
   , TotalCol totcol
-  , Certs cert
+  , Certs $ OSet.toStrictSeq cert
   , Withdrawals' wdrl
   , Txfee fee
   , Vldt vldt

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -40,6 +40,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   AsIndex (..),
   AsItem (..),
+  AsIxItem (..),
   ExUnits (..),
   PlutusPurpose,
   plutusScriptLanguage,
@@ -1819,18 +1820,21 @@ ppContextError e =
     Babbage -> ppString (show e)
     Conway -> ppString (show e)
 
-ppPlutusPurposeAsIndex :: forall era. Reflect era => PlutusPurpose AsIndex era -> PDoc
-ppPlutusPurposeAsIndex p =
-  case reify @era of
-    Shelley -> error "Unsuported"
-    Allegra -> error "Unsuported"
-    Mary -> error "Unsuported"
-    Alonzo -> prettyA p
-    Babbage -> prettyA p
-    Conway -> prettyA p
+ppPlutusPurposeAsIndex :: Reflect era => PlutusPurpose AsIndex era -> PDoc
+ppPlutusPurposeAsIndex = ppPlutusPurpose @AsIndex
 
-ppPlutusPurposeAsItem :: forall era. Reflect era => PlutusPurpose AsItem era -> PDoc
-ppPlutusPurposeAsItem p =
+ppPlutusPurposeAsItem :: Reflect era => PlutusPurpose AsItem era -> PDoc
+ppPlutusPurposeAsItem = ppPlutusPurpose @AsItem
+
+ppPlutusPurposeAsIxItem :: Reflect era => PlutusPurpose AsIxItem era -> PDoc
+ppPlutusPurposeAsIxItem = ppPlutusPurpose @AsIxItem
+
+ppPlutusPurpose ::
+  forall f era.
+  (Reflect era, forall ix it. (PrettyA ix, PrettyA it) => PrettyA (f ix it)) =>
+  PlutusPurpose f era ->
+  PDoc
+ppPlutusPurpose p =
   case reify @era of
     Shelley -> error "Unsuported"
     Allegra -> error "Unsuported"
@@ -3153,25 +3157,21 @@ pcMultiAsset m = ppList pptriple (flattenMultiAsset m)
 instance PrettyA (MultiAsset c) where
   prettyA = pcMultiAsset
 
-instance PrettyA a => PrettyA (AsIndex a b) where
-  prettyA (AsIndex i) = ppSexp "AsIndex" [prettyA i]
+instance PrettyA ix => PrettyA (AsIndex ix it) where
+  prettyA (AsIndex ix) = ppSexp "AsIndex" [prettyA ix]
 
-instance PrettyA b => PrettyA (AsItem a b) where
-  prettyA (AsItem i) = ppSexp "AsItem" [prettyA i]
+instance PrettyA it => PrettyA (AsItem ix it) where
+  prettyA (AsItem it) = ppSexp "AsItem" [prettyA it]
 
-instance
-  Reflect era =>
-  PrettyA (AlonzoPlutusPurpose AsIndex era)
-  where
-  prettyA = \case
-    AlonzoMinting i -> ppSexp "AlonzoMinting" [ppString (show i)]
-    AlonzoSpending i -> ppSexp "AlonzoSpending" [ppString (show i)]
-    AlonzoRewarding i -> ppSexp "AlonzoRewarding" [ppString (show i)]
-    AlonzoCertifying i -> ppSexp "AlonzoCertifying" [ppString (show i)]
+instance (PrettyA ix, PrettyA it) => PrettyA (AsIxItem ix it) where
+  prettyA (AsIxItem ix it) = ppSexp "AsIxItem" [prettyA ix, prettyA it]
 
 instance
-  (Reflect era, PrettyA (TxCert era)) =>
-  PrettyA (AlonzoPlutusPurpose AsItem era)
+  ( forall ix it. (PrettyA ix, PrettyA it) => PrettyA (f ix it)
+  , Reflect era
+  , PrettyA (TxCert era)
+  ) =>
+  PrettyA (AlonzoPlutusPurpose f era)
   where
   prettyA = \case
     AlonzoMinting i -> ppSexp "AlonzoMinting" [prettyA i]
@@ -3180,20 +3180,11 @@ instance
     AlonzoCertifying i -> ppSexp "AlonzoCertifying" [prettyA i]
 
 instance
-  Reflect era =>
-  PrettyA (ConwayPlutusPurpose AsIndex era)
-  where
-  prettyA = \case
-    ConwayMinting i -> ppSexp "ConwayMinting" [ppString (show i)]
-    ConwaySpending i -> ppSexp "ConwaySpending" [ppString (show i)]
-    ConwayRewarding i -> ppSexp "ConwayRewarding" [ppString (show i)]
-    ConwayCertifying i -> ppSexp "ConwayCertifying" [ppString (show i)]
-    ConwayVoting i -> ppSexp "ConwayVoting" [ppString (show i)]
-    ConwayProposing i -> ppSexp "ConwayProposing" [ppString (show i)]
-
-instance
-  (Reflect era, PrettyA (TxCert era)) =>
-  PrettyA (ConwayPlutusPurpose AsItem era)
+  ( forall ix it. (PrettyA ix, PrettyA it) => PrettyA (f ix it)
+  , Reflect era
+  , PrettyA (TxCert era)
+  ) =>
+  PrettyA (ConwayPlutusPurpose f era)
   where
   prettyA = \case
     ConwayMinting i -> ppSexp "ConwayMinting" [prettyA i]
@@ -3203,7 +3194,8 @@ instance
     ConwayVoting i -> ppSexp "ConwayVoting" [prettyA i]
     ConwayProposing i -> ppSexp "ConwayProposing" [prettyA i]
 
--- ScriptsNeeded is a type family so it doesn't have PrettyA instance, use pcScriptsNeeded instead of prettyA
+-- ScriptsNeeded is a type family so it doesn't have PrettyA instance, use pcScriptsNeeded
+-- instead of prettyA
 pcScriptsNeeded :: Reflect era => Proof era -> ScriptsNeeded era -> PDoc
 pcScriptsNeeded Shelley (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]
 pcScriptsNeeded Allegra (ShelleyScriptsNeeded ss) = ppSexp "ScriptsNeeded" [ppSet pcScriptHash ss]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -69,7 +69,7 @@ import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core (AlonzoEraPParams, AlonzoEraTxBody)
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (..))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript, AlonzoScript (..))
 import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
@@ -471,6 +471,7 @@ data UTxOWit era where
     UTxOWit era
   UTxOAlonzoToConway ::
     ( EraUTxO era
+    , AlonzoEraScript era
     , AlonzoEraTxBody era
     , AlonzoEraPParams era
     , AlonzoEraTxOut era


### PR DESCRIPTION
# Description

* Add `AsIxItem`, which allows us having a `PlutusPurpose` be both item and index aware, thus avoiding the reverse lookup of an item in order to find its index.
* Fix `ConwayTxBody` pattern synonym, by changing its certificates arguments to `OSet`
  from a `StrictSeq`
* Add `SpendingPurpose`, `MintingPurpose`, `CertifyingPurpose`, `RewardingPurpose`, 
`VotingPurpose` and `ProposingPurpose` pattern synonyms to allow era agnostic handling of `PlutusPurpose`


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
