### PR TITLE
Prefix Set encoding with tag 258

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -76,6 +76,7 @@ import Cardano.Ledger.Binary (
   Decoder,
   EncCBOR (..),
   EncCBORGroup (..),
+  Encoding,
   ToCBOR (..),
   allowTag,
   decodeList,
@@ -275,14 +276,14 @@ isEmptyTxWitness (getMemoRawType -> AlonzoTxWitsRaw a b c d (Redeemers e)) =
   Set.null a && Set.null b && Map.null c && nullDats d && Map.null e
 
 -- =====================================================
-newtype TxDatsRaw era = TxDatsRaw (Map (DataHash (EraCrypto era)) (Data era))
+newtype TxDatsRaw era = TxDatsRaw {unTxDatsRaw :: Map (DataHash (EraCrypto era)) (Data era)}
   deriving (Generic, Typeable, Eq)
   deriving newtype (NoThunks, NFData)
 
 deriving instance HashAlgorithm (HASH (EraCrypto era)) => Show (TxDatsRaw era)
 
 instance (Typeable era, EncCBOR (Data era)) => EncCBOR (TxDatsRaw era) where
-  encCBOR (TxDatsRaw m) = encCBOR $ Map.elems m
+  encCBOR = encodeWithSetTag . Map.elems . unTxDatsRaw
 
 pattern TxDats' :: Map (DataHash (EraCrypto era)) (Data era) -> TxDats era
 pattern TxDats' m <- (getMemoRawType -> TxDatsRaw m)
@@ -306,7 +307,11 @@ instance Era era => DecCBOR (Annotator (TxDatsRaw era)) where
   decCBOR =
     ifDecoderVersionAtLeast
       (natVersion @9)
-      (mapTraverseableDecoderA (decodeNonEmptyList decCBOR) (TxDatsRaw . keyBy hashData . NE.toList))
+      ( allowTag setTag
+          >> mapTraverseableDecoderA
+            (decodeNonEmptyList decCBOR)
+            (TxDatsRaw . keyBy hashData . NE.toList)
+      )
       (mapTraverseableDecoderA (decodeList decCBOR) (TxDatsRaw . keyBy hashData))
   {-# INLINE decCBOR #-}
 
@@ -508,11 +513,6 @@ instance AlonzoEraScript era => EncCBOR (AlonzoTxWitsRaw era) where
         !> Omit nullDats (Key 4 $ To dats)
         !> Omit nullRedeemers (Key 5 $ To rdmrs)
     where
-      encodeWithSetTag xs =
-        ifEncodingVersionAtLeast
-          (natVersion @9)
-          (encodeTag setTag <> encCBOR xs)
-          (encCBOR xs)
       encodePlutus ::
         PlutusLanguage l =>
         SLanguage l ->
@@ -700,3 +700,10 @@ mapTraverseableDecoderA ::
   (f a -> m b) ->
   Decoder s (Annotator (m b))
 mapTraverseableDecoderA decList transformList = fmap transformList . sequence <$> decList
+
+encodeWithSetTag :: EncCBOR a => a -> Encoding
+encodeWithSetTag xs =
+  ifEncodingVersionAtLeast
+    (natVersion @9)
+    (encodeTag setTag <> encCBOR xs)
+    (encCBOR xs)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -593,7 +593,9 @@ instance
           ( D $
               ifDecoderVersionAtLeast
                 (natVersion @9)
-                (mapTraverseableDecoderA (decodeNonEmptyList decCBOR) (Set.fromList . NE.toList))
+                ( allowTag setTag
+                    >> mapTraverseableDecoderA (decodeNonEmptyList decCBOR) (Set.fromList . NE.toList)
+                )
                 (mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
           )
       txWitnessField 1 =
@@ -606,7 +608,9 @@ instance
           ( D $
               ifDecoderVersionAtLeast
                 (natVersion @9)
-                (mapTraverseableDecoderA (decodeNonEmptyList decCBOR) (Set.fromList . NE.toList))
+                ( allowTag setTag
+                    >> mapTraverseableDecoderA (decodeNonEmptyList decCBOR) (Set.fromList . NE.toList)
+                )
                 (mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
           )
       txWitnessField 3 = fieldA addScripts (decodePlutus SPlutusV1)

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -430,9 +430,9 @@ drep_voting_thresholds =
   ]
 
 transaction_witness_set =
-  { ? 0: [+ vkeywitness ]
+  { ? 0: nonempty_set<vkeywitness>
   , ? 1: [+ native_script ]
-  , ? 2: [+ bootstrap_witness ]
+  , ? 2: nonempty_set<bootstrap_witness>
   , ? 3: nonempty_set<plutus_v1_script>
   , ? 4: [+ plutus_data ]
   , ? 5: redeemers

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -434,7 +434,7 @@ transaction_witness_set =
   , ? 1: nonempty_set<native_script>
   , ? 2: nonempty_set<bootstrap_witness>
   , ? 3: nonempty_set<plutus_v1_script>
-  , ? 4: [+ plutus_data ]
+  , ? 4: nonempty_set<plutus_data>
   , ? 5: redeemers
   , ? 6: nonempty_set<plutus_v2_script>
   , ? 7: nonempty_set<plutus_v3_script>

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -431,7 +431,7 @@ drep_voting_thresholds =
 
 transaction_witness_set =
   { ? 0: nonempty_set<vkeywitness>
-  , ? 1: [+ native_script ]
+  , ? 1: nonempty_set<native_script>
   , ? 2: nonempty_set<bootstrap_witness>
   , ? 3: nonempty_set<plutus_v1_script>
   , ? 4: [+ plutus_data ]

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.0.0
 
+* Add `fromFoldable`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 
 ## 1.1.2.0

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.0.0
 
+* Add `toSet`
 * Add `fromFoldable`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -91,5 +91,5 @@ test-suite cardano-data-tests
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         testlib,
         QuickCheck,
-        quickcheck-classes-base,
+        quickcheck-classes,
         microlens

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -88,7 +88,7 @@ test-suite cardano-data-tests
         containers,
         hspec,
         cardano-data,
-        cardano-ledger-binary:testlib,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
         testlib,
         QuickCheck,
         quickcheck-classes-base,

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -24,6 +24,7 @@ module Data.OSet.Strict (
   fromStrictSeqDuplicates,
   toStrictSeq,
   fromSet,
+  fromFoldable,
   invariantHolds,
   invariantHolds',
   (|>),
@@ -74,7 +75,7 @@ instance Ord a => Monoid (OSet a) where
 
 instance Ord a => IsList (OSet a) where
   type Item (OSet a) = a
-  fromList = fromStrictSeq . SSeq.fromList
+  fromList = fromFoldable
   toList = F.toList . osSSeq
 
 instance Foldable OSet where
@@ -175,11 +176,15 @@ unsnoc (OSet seq set) = case seq of
   SSeq.Empty -> Nothing
   xs' SSeq.:|> x -> Just (OSet xs' (x `Set.delete` set), x)
 
+-- | Using a `Foldable` instance of the source data structure convert it to an `OSet`
+fromFoldable :: (Foldable f, Ord a) => f a -> OSet a
+fromFoldable = F.foldl' snoc empty
+
 -- | \(O(n \log n)\). Checks membership before snoc-ing.
 -- De-duplicates the StrictSeq without overwriting.
 -- Starts from the left or head, using `foldl'`
 fromStrictSeq :: Ord a => SSeq.StrictSeq a -> OSet a
-fromStrictSeq = F.foldl' snoc empty
+fromStrictSeq = fromFoldable
 
 -- | \(O(n \log n)\). Checks membership before snoc-ing.
 -- Returns a 2-tuple, with `fst` as a `Set` of duplicates found

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -23,6 +23,7 @@ module Data.OSet.Strict (
   fromStrictSeq,
   fromStrictSeqDuplicates,
   toStrictSeq,
+  toSet,
   fromSet,
   fromFoldable,
   invariantHolds,
@@ -199,9 +200,13 @@ fromStrictSeqDuplicates = F.foldl' snoc' (Set.empty, empty)
         then (x `Set.insert` duplicates, oset)
         else (duplicates, OSet (seq SSeq.|> x) (x `Set.insert` set))
 
--- | \( O(1) \).
+-- | \( O(1) \) -  Extract underlying strict sequence
 toStrictSeq :: OSet a -> SSeq.StrictSeq a
 toStrictSeq = osSSeq
+
+-- | \( O(1) \) -  Extract underlying Set
+toSet :: OSet a -> Set.Set a
+toSet = osSet
 
 -- | \( O(n) \).
 fromSet :: Set.Set a -> OSet a

--- a/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OMap/StrictSpec.hs
@@ -19,7 +19,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck (Arbitrary)
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
-import Test.QuickCheck.Classes.Base
+import Test.QuickCheck.Classes
 import Prelude hiding (elem, filter, lookup, null)
 
 spec :: Spec
@@ -148,7 +148,8 @@ spec =
       it "Type" $
         lawsCheckOne
           (Proxy :: Proxy (OMap Int Int))
-          [ isListLaws
+          [ eqLaws
+          , isListLaws
           , semigroupLaws
           , monoidLaws
           , semigroupMonoidLaws

--- a/libs/cardano-data/test/Test/Cardano/Data/OSet/StrictSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/OSet/StrictSpec.hs
@@ -15,7 +15,7 @@ import Test.Cardano.Data.Arbitrary ()
 import Test.Cardano.Ledger.Binary.RoundTrip (cborTrip, embedTripSpec, roundTripCborSpec)
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Test.QuickCheck.Classes.Base
+import Test.QuickCheck.Classes
 
 spec :: Spec
 spec =
@@ -94,7 +94,9 @@ spec =
       it "Type" $
         lawsCheckOne
           (Proxy :: Proxy (OSet Int))
-          [ isListLaws
+          [ eqLaws
+          , ordLaws
+          , isListLaws
           , semigroupLaws
           , monoidLaws
           , semigroupMonoidLaws

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -13,7 +13,7 @@ import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.QuickCheck
 
 instance (Arbitrary a, Ord a) => Arbitrary (OSet.OSet a) where
-  arbitrary = fmap (OSet.fromSet . Set.fromList) . shuffle . Set.toList =<< arbitrary
+  arbitrary = fmap OSet.fromFoldable . shuffle . Set.toList =<< arbitrary
 
 instance (Ord v, Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
   arbitrary =

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Ledger.Binary.Decoding.Annotated (
@@ -28,11 +30,15 @@ where
 import Cardano.Ledger.Binary.Decoding.DecCBOR (DecCBOR (..))
 import Cardano.Ledger.Binary.Decoding.Decoder (
   Decoder,
+  allowTag,
   decodeList,
   decodeWithByteSpan,
   fromPlainDecoder,
+  setTag,
+  whenDecoderVersionAtLeast,
  )
 import Cardano.Ledger.Binary.Encoding (EncCBOR, Version, serialize')
+import Cardano.Ledger.Binary.Version (natVersion)
 import Codec.CBOR.Read (ByteOffset)
 import qualified Codec.Serialise as Serialise (decode)
 import Control.DeepSeq (NFData)
@@ -192,6 +198,8 @@ withSlice dec = do
 -- order to enforce no duplicates.
 decodeAnnSet :: Ord t => Decoder s (Annotator t) -> Decoder s (Annotator (Set.Set t))
 decodeAnnSet dec = do
+  whenDecoderVersionAtLeast (natVersion @9) $
+    allowTag setTag
   xs <- decodeList dec
   pure (Set.fromList <$> sequence xs)
 {-# INLINE decodeAnnSet #-}


### PR DESCRIPTION
# Description

Starting with Conway we need to prefix all places with a tag where a Set is used when encoding

Original problem was reported in https://github.com/IntersectMBO/cardano-cli/issues/567

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
