### PR TITLE
Remove `EnactState` from `ConwayGovState`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 1.13.0.0
 
+* Rename:
+  * `cgProposalsL` to `cgsProposalsL`
+  * `cgEnactStateL` to `cgsEnactStateL`
+  * `cgDRepPulsingStateL` to `cgsDRepPulsingStateL`
+* Add:
+  * `cgsPrevPParamsL`
+  * `cgsCommitteeL`
+  * `cgsConstitutionL`
+  * `govStatePrevGovActionIds`
+  * `mkEnactState`
+* Deprecated `curPParamsConwayGovStateL` and `curPParamsConwayGovStateL`
 * Add `TreeMaybe`, `toPForest` and `toPForestEither`
 * Remove `proposalsAreConsistent`
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -131,7 +131,6 @@ library testlib
         cardano-data:testlib,
         containers,
         microlens,
-        microlens-mtl,
         cardano-crypto-class,
         cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
         cardano-ledger-alonzo:testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -87,9 +87,12 @@ module Cardano.Ledger.Conway.Governance (
   proposalsSize,
   proposalsLookupId,
   proposalsActionsMap,
-  cgProposalsL,
-  cgEnactStateL,
-  cgDRepPulsingStateL,
+  cgsProposalsL,
+  cgsDRepPulsingStateL,
+  cgsCurPParamsL,
+  cgsPrevPParamsL,
+  cgsCommitteeL,
+  cgsConstitutionL,
   ensCommitteeL,
   ensConstitutionL,
   ensCurPParamsL,
@@ -144,6 +147,8 @@ module Cardano.Ledger.Conway.Governance (
   psDRepDistrL,
   psDRepStateL,
   RunConwayRatify (..),
+  govStatePrevGovActionIds,
+  mkEnactState,
 
   -- * Exported for testing
   pparamsUpdateThreshold,
@@ -159,6 +164,7 @@ import Cardano.Ledger.BaseTypes (
   StrictMaybe (..),
   UnitInterval,
   isSJust,
+  strictMaybeToMaybe,
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -237,6 +243,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.UMap
 import qualified Cardano.Ledger.UMap as UMap
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad.Trans.Reader (Reader, ReaderT, ask, runReader)
 import Control.State.Transition.Extended
@@ -258,6 +265,7 @@ import qualified Data.Set as Set
 import Data.Typeable
 import GHC.Generics (Generic)
 import Lens.Micro
+import Lens.Micro.Extras (view)
 import NoThunks.Class (NoThunks (..), allNoThunks)
 
 -- | A snapshot of information from the previous epoch stored inside the Pulser.
@@ -503,10 +511,13 @@ toRatifyStatePairs cg@(RatifyState _ _ _ _) =
 
 -- =============================================
 data ConwayGovState era = ConwayGovState
-  { cgProposals :: !(Proposals era)
-  , cgEnactState :: !(EnactState era)
-  , cgDRepPulsingState :: !(DRepPulsingState era)
-  -- ^ The 'cgDRepPulsingState' field is a pulser that incrementally computes the stake distribution of the DReps
+  { cgsProposals :: !(Proposals era)
+  , cgsCommittee :: !(StrictMaybe (Committee era))
+  , cgsConstitution :: !(Constitution era)
+  , cgsCurPParams :: !(PParams era)
+  , cgsPrevPParams :: !(PParams era)
+  , cgsDRepPulsingState :: !(DRepPulsingState era)
+  -- ^ The 'cgsDRepPulsingState' field is a pulser that incrementally computes the stake distribution of the DReps
   --   over the Epoch following the close of voting at end of the previous Epoch. It assembles this with some of
   --   its other internal components into a (RatifyEnv era) when it completes, and then calls the RATIFY rule
   --   and eventually returns the updated RatifyState. The pulser is created at the Epoch boundary, but does
@@ -516,32 +527,61 @@ data ConwayGovState era = ConwayGovState
 
 deriving instance EraPParams era => Eq (ConwayGovState era)
 
-cgProposalsL :: Lens' (ConwayGovState era) (Proposals era)
-cgProposalsL = lens cgProposals (\x y -> x {cgProposals = y})
+cgsProposalsL :: Lens' (ConwayGovState era) (Proposals era)
+cgsProposalsL = lens cgsProposals (\x y -> x {cgsProposals = y})
 
-cgEnactStateL :: Lens' (ConwayGovState era) (EnactState era)
-cgEnactStateL = lens cgEnactState (\x y -> x {cgEnactState = y})
+cgsDRepPulsingStateL :: Lens' (ConwayGovState era) (DRepPulsingState era)
+cgsDRepPulsingStateL = lens cgsDRepPulsingState (\x y -> x {cgsDRepPulsingState = y})
 
-cgDRepPulsingStateL :: Lens' (ConwayGovState era) (DRepPulsingState era)
-cgDRepPulsingStateL = lens cgDRepPulsingState (\x y -> x {cgDRepPulsingState = y})
+cgsCommitteeL :: Lens' (ConwayGovState era) (StrictMaybe (Committee era))
+cgsCommitteeL = lens cgsCommittee (\x y -> x {cgsCommittee = y})
+
+cgsConstitutionL :: Lens' (ConwayGovState era) (Constitution era)
+cgsConstitutionL = lens cgsConstitution (\x y -> x {cgsConstitution = y})
+
+cgsCurPParamsL :: Lens' (ConwayGovState era) (PParams era)
+cgsCurPParamsL = lens cgsCurPParams (\x y -> x {cgsCurPParams = y})
+
+cgsPrevPParamsL :: Lens' (ConwayGovState era) (PParams era)
+cgsPrevPParamsL = lens cgsPrevPParams (\x y -> x {cgsPrevPParams = y})
 
 curPParamsConwayGovStateL :: Lens' (ConwayGovState era) (PParams era)
-curPParamsConwayGovStateL = cgEnactStateL . ensCurPParamsL
+curPParamsConwayGovStateL = cgsCurPParamsL
+{-# DEPRECATED curPParamsConwayGovStateL "In favor of cgsCurPParamsL" #-}
 
 prevPParamsConwayGovStateL :: Lens' (ConwayGovState era) (PParams era)
-prevPParamsConwayGovStateL = cgEnactStateL . ensPrevPParamsL
+prevPParamsConwayGovStateL = cgsPrevPParamsL
+{-# DEPRECATED prevPParamsConwayGovStateL "In favor of cgsPrevPParamsL" #-}
+
+govStatePrevGovActionIds :: ConwayEraGov era => GovState era -> PrevGovActionIds era
+govStatePrevGovActionIds = view $ proposalsGovStateL . pRootsL . to toPrevGovActionIds
 
 conwayGovStateDRepDistrG :: SimpleGetter (ConwayGovState era) (Map (DRep (EraCrypto era)) (CompactForm Coin))
-conwayGovStateDRepDistrG = to (\govst -> (psDRepDistr . fst) $ finishDRepPulser (cgDRepPulsingState govst))
+conwayGovStateDRepDistrG = to (\govst -> (psDRepDistr . fst) $ finishDRepPulser (cgsDRepPulsingState govst))
 
 getRatifyState :: ConwayGovState era -> RatifyState era
-getRatifyState (ConwayGovState {cgDRepPulsingState}) = snd $ finishDRepPulser cgDRepPulsingState
+getRatifyState (ConwayGovState {cgsDRepPulsingState}) = snd $ finishDRepPulser cgsDRepPulsingState
+
+mkEnactState :: ConwayEraGov era => GovState era -> EnactState era
+mkEnactState gs =
+  EnactState
+    { ensCommittee = gs ^. committeeGovStateL
+    , ensConstitution = gs ^. constitutionGovStateL
+    , ensCurPParams = gs ^. curPParamsGovStateL
+    , ensPrevPParams = gs ^. prevPParamsGovStateL
+    , ensTreasury = zero
+    , ensWithdrawals = mempty
+    , ensPrevGovActionIds = govStatePrevGovActionIds gs
+    }
 
 -- TODO: Implement Sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance EraPParams era => DecShareCBOR (ConwayGovState era) where
   decShareCBOR _ =
     decode $
       RecD ConwayGovState
+        <! From
+        <! From
+        <! From
         <! From
         <! From
         <! From
@@ -553,14 +593,20 @@ instance EraPParams era => DecCBOR (ConwayGovState era) where
         <! From
         <! From
         <! From
+        <! From
+        <! From
+        <! From
 
 instance EraPParams era => EncCBOR (ConwayGovState era) where
   encCBOR ConwayGovState {..} =
     encode $
       Rec ConwayGovState
-        !> To cgProposals
-        !> To cgEnactState
-        !> To cgDRepPulsingState
+        !> To cgsProposals
+        !> To cgsCommittee
+        !> To cgsConstitution
+        !> To cgsCurPParams
+        !> To cgsPrevPParams
+        !> To cgsDRepPulsingState
 
 instance EraPParams era => ToCBOR (ConwayGovState era) where
   toCBOR = toEraCBOR @era
@@ -569,7 +615,7 @@ instance EraPParams era => FromCBOR (ConwayGovState era) where
   fromCBOR = fromEraCBOR @era
 
 instance EraPParams era => Default (ConwayGovState era) where
-  def = ConwayGovState def def (DRComplete def def)
+  def = ConwayGovState def def def def def (DRComplete def def)
 
 instance EraPParams era => NFData (ConwayGovState era)
 
@@ -580,19 +626,24 @@ instance EraPParams era => ToJSON (ConwayGovState era) where
   toEncoding = pairs . mconcat . toConwayGovPairs
 
 toConwayGovPairs :: (KeyValue e a, EraPParams era) => ConwayGovState era -> [a]
-toConwayGovPairs cg@(ConwayGovState _ _ _) =
+toConwayGovPairs cg@(ConwayGovState _ _ _ _ _ _) =
   let ConwayGovState {..} = cg
-   in [ "proposals" .= cgProposals
-      , "enactState" .= cgEnactState
-      , "nextRatifyState" .= extractDRepPulsingState cgDRepPulsingState
+   in [ "proposals" .= cgsProposals
+      , "nextRatifyState" .= extractDRepPulsingState cgsDRepPulsingState
+      , "commitee" .= cgsCommittee
+      , "constitution" .= cgsConstitution
+      , "currentPParams" .= cgsCurPParams
+      , "previousPParams" .= cgsPrevPParams
       ]
 
 instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
   type GovState (ConwayEra c) = ConwayGovState (ConwayEra c)
 
-  getConstitution g = Just $ g ^. cgEnactStateL . ensConstitutionL
+  getConstitution = Just . cgsConstitution
 
-  getCommitteeMembers g = ensCommitteeMembers (g ^. cgEnactStateL)
+  getCommitteeMembers g =
+    fmap (\c -> (committeeMembers c, committeeQuorum c)) . strictMaybeToMaybe $
+      g ^. cgsCommitteeL
 
   getNextEpochCommitteeMembers g = ensCommitteeMembers (getRatifyState g ^. rsEnactStateL)
 
@@ -602,7 +653,7 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
 
   obligationGovState st =
     Obligations
-      { oblProposal = foldMap' gasDeposit $ proposalsActions (st ^. cgProposalsL)
+      { oblProposal = foldMap' gasDeposit $ proposalsActions (st ^. cgsProposalsL)
       , oblDRep = Coin 0
       , oblStake = Coin 0
       , oblPool = Coin 0
@@ -621,13 +672,13 @@ class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)
   proposalsGovStateL :: Lens' (GovState era) (Proposals era)
   drepPulsingStateGovStateL :: Lens' (GovState era) (DRepPulsingState era)
-  enactStateGovStateL :: Lens' (GovState era) (EnactState era)
+  committeeGovStateL :: Lens' (GovState era) (StrictMaybe (Committee era))
 
 instance Crypto c => ConwayEraGov (ConwayEra c) where
-  constitutionGovStateL = cgEnactStateL . ensConstitutionL
-  proposalsGovStateL = cgProposalsL
-  drepPulsingStateGovStateL = cgDRepPulsingStateL
-  enactStateGovStateL = cgEnactStateL
+  constitutionGovStateL = cgsConstitutionL
+  proposalsGovStateL = cgsProposalsL
+  drepPulsingStateGovStateL = cgsDRepPulsingStateL
+  committeeGovStateL = cgsCommitteeL
 
 pparamsUpdateThreshold ::
   forall era.
@@ -1092,7 +1143,7 @@ setCompleteDRepPulsingState ::
   EpochState era
 setCompleteDRepPulsingState snapshot ratifyState epochState =
   epochState
-    & epochStateGovStateL . cgDRepPulsingStateL
+    & epochStateGovStateL . cgsDRepPulsingStateL
       .~ DRComplete snapshot ratifyState
 
 -- | Refresh the pulser in the EpochState using all the new data that is needed to compute
@@ -1101,6 +1152,7 @@ setFreshDRepPulsingState ::
   ( GovState era ~ ConwayGovState era
   , Monad m
   , RunConwayRatify era
+  , ConwayEraGov era
   ) =>
   EpochNo ->
   PoolDistr (EraCrypto era) ->
@@ -1129,7 +1181,7 @@ setFreshDRepPulsingState epochNo stakePoolDistr epochState = do
       pulseSize = max 1 (ceiling (toInteger stakeSize % (8 * toInteger k)))
       epochState' =
         epochState
-          & epochStateGovStateL . cgDRepPulsingStateL
+          & epochStateGovStateL . cgsDRepPulsingStateL
             .~ DRPulsing
               ( DRepPulser
                   { dpPulseSize = pulseSize
@@ -1142,10 +1194,9 @@ setFreshDRepPulsingState epochNo stakePoolDistr epochState = do
                   , dpCurrentEpoch = epochNo
                   , dpCommitteeState = vsCommitteeState vState
                   , dpEnactState =
-                      (cgEnactState govState)
-                        { ensTreasury = epochState ^. epochStateTreasuryL
-                        }
-                  , dpProposals = proposalsActions (govState ^. cgProposalsL)
+                      mkEnactState govState
+                        & ensTreasuryL .~ epochState ^. epochStateTreasuryL
+                  , dpProposals = proposalsActions (govState ^. cgsProposalsL)
                   , dpGlobals = globals
                   }
               )

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -40,10 +40,9 @@ import Cardano.Ledger.Conway.Governance (
   ConwayGovState (..),
   GovProcedures (..),
   Proposals,
-  enactStateGovStateL,
-  ensConstitutionL,
-  ensPrevGovActionIdsL,
+  pRootsL,
   proposalsGovStateL,
+  toPrevGovActionIds,
  )
 import Cardano.Ledger.Conway.Rules.Cert (CertEnv)
 import Cardano.Ledger.Conway.Rules.Certs (
@@ -100,7 +99,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Generics (Generic (..))
-import Lens.Micro
+import Lens.Micro as L
 import NoThunks.Class (NoThunks (..))
 
 data ConwayLedgerPredFailure era
@@ -299,8 +298,8 @@ ledgerTransition = do
                   (txIdTxBody txBody)
                   currentEpoch
                   pp
-                  (utxoState ^. utxosGovStateL . enactStateGovStateL . ensPrevGovActionIdsL)
-                  (utxoState ^. utxosGovStateL . enactStateGovStateL . ensConstitutionL . constitutionScriptL)
+                  (utxoState ^. utxosGovStateL . proposalsGovStateL . pRootsL . L.to toPrevGovActionIds)
+                  (utxoState ^. utxosGovStateL . constitutionGovStateL . constitutionScriptL)
               , utxoState ^. utxosGovStateL . proposalsGovStateL
               , govProcedures
               )

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -143,6 +143,9 @@ instance
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
 
 instance
   (Era era, Arbitrary (PParams era), Arbitrary (PParamsUpdate era)) =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.EnactSpec (spec) where
 
@@ -11,14 +10,12 @@ import Cardano.Ledger.Address
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (EnactSignal (..))
-import Cardano.Ledger.Shelley.LedgerState
-import Lens.Micro.Mtl
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
 spec ::
   forall era.
-  (ConwayEraImp era, GovState era ~ ConwayGovState era) =>
+  ConwayEraImp era =>
   SpecWith (ImpTestState era)
 spec =
   describe "ENACT" $ do
@@ -26,7 +23,7 @@ spec =
       rewardAcount1 <- registerRewardAccount
       govActionId <- submitTreasuryWithdrawals [(rewardAcount1, Coin 666)]
       GovActionState {gasAction = govAction} <- getGovActionState govActionId
-      enactStateInit <- use $ impNESG . newEpochStateGovStateL . cgEnactStateL
+      enactStateInit <- getEnactState
       let signal =
             EnactSignal
               { esGovActionId = govActionId

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -15,12 +15,11 @@ import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
   Anchor (..),
+  ConwayEraGov (..),
   ConwayGovState,
   GovAction (..),
   ProposalProcedure (..),
   Voter (..),
-  cgEnactStateL,
-  ensConstitutionL,
  )
 import Cardano.Ledger.Shelley.LedgerState (
   asTreasuryL,
@@ -121,7 +120,7 @@ spec =
 
       policy <-
         getsNES $
-          nesEpochStateL . epochStateGovStateL . cgEnactStateL . ensConstitutionL . constitutionScriptL
+          nesEpochStateL . epochStateGovStateL . constitutionGovStateL . constitutionScriptL
       govActionId <-
         submitProposal $
           ProposalProcedure

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -35,7 +35,7 @@ library
         cardano-ledger-babbage >=1.3 && <1.7,
         cardano-ledger-babbage-test >=1.1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-conway:{cardano-ledger-conway, testlib} >=1.9 && <1.14,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.13,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11,
         cardano-ledger-allegra >=1.2,
         cardano-ledger-mary >=1.4,

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Rename `cgProposalsL` to `cgsProposalsL`
+* Remove `cgEnactStateL`
 * Rename `RewardAccount` fields `getRwdNetwork` and `getRwdCred` to `raNetwork` and `raCredential` respectively
 * Deprecate `deserialiseRewardAcnt` in favor of `deserialiseRewardAccount`
 * Deprecate `serialiseRewardAcnt` in favor of `serialiseRewardAccount`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -22,8 +22,7 @@ module Cardano.Ledger.Api.Governance (
 
   -- ** Governance State
   ConwayGovState (..),
-  cgEnactStateL,
-  cgProposalsL,
+  cgsProposalsL,
   RatifyState (..),
   EnactState (..),
   Voter (..),
@@ -68,8 +67,7 @@ import Cardano.Ledger.Conway.Governance (
   Voter (..),
   VotingProcedure (..),
   VotingProcedures (..),
-  cgEnactStateL,
-  cgProposalsL,
+  cgsProposalsL,
   constitutionAnchorL,
   constitutionScriptL,
   govActionIdToText,

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -18,10 +18,9 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (Coin))
 import Cardano.Ledger.Conway.Governance (
   Committee (..),
+  ConwayEraGov (..),
   ConwayGovState,
   EraGov (..),
-  cgEnactStateL,
-  ensCommitteeL,
  )
 import Cardano.Ledger.Conway.PParams (
   dvtCommitteeNoConfidence,
@@ -244,7 +243,7 @@ spec =
     expectMembers expKhs = do
       committee <-
         getsNES $
-          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
       let members = Map.keysSet $ foldMap' committeeMembers committee
       impAnn "Expecting committee members" $ members `shouldBe` expKhs
 

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -23,11 +23,10 @@ import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (
   Committee (..),
-  ConwayEraGov,
+  ConwayEraGov (..),
   ConwayGovState,
   DRepPulsingState (..),
   RatifyState (..),
-  cgEnactStateL,
   ensCommitteeL,
   newEpochStateDRepPulsingStateL,
   rsEnactStateL,
@@ -86,7 +85,7 @@ committeeMembersStateSpec =
                   & nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
                     .~ committeeState
                   & newEpochStateDRepPulsingStateL .~ DRComplete def nextRatifyState
-                  & nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL . cgEnactStateL . ensCommitteeL
+                  & nesEpochStateL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
                     .~ maybeToStrictMaybe committee
               nextRatifyState =
                 (def @(RatifyState era))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -1921,11 +1921,16 @@ conwayGovStateT ::
   Proof era ->
   RootTarget era (ConwayGovState era) (ConwayGovState era)
 conwayGovStateT p =
-  Invert "ConwayGovState" (typeRep @(ConwayGovState era)) ConwayGovState
-    :$ Lensed (currProposals p) (cgProposalsL)
-    :$ Shift enactStateT cgEnactStateL
-    -- :$ Shift (completePulsingStateT p) cgDRepPulsingStateL
-    :$ Shift pulsingPulsingStateT cgDRepPulsingStateL
+  Invert
+    "ConwayGovState"
+    (typeRep @(ConwayGovState era))
+    (\pr com con (PParamsF _ cpp) (PParamsF _ ppp) pu -> ConwayGovState pr (maybeToStrictMaybe com) con cpp ppp pu)
+    :$ Lensed (currProposals p) cgsProposalsL
+    :$ Lensed committeeVar (cgsCommitteeL . strictMaybeToMaybeL) -- see 'committeeT' to construct a binding for committeeVar
+    :$ Lensed constitution cgsConstitutionL
+    :$ Lensed (currPParams reify) (cgsCurPParamsL . pparamsFL reify)
+    :$ Lensed (prevPParams reify) (cgsPrevPParamsL . pparamsFL reify)
+    :$ Shift pulsingPulsingStateT cgsDRepPulsingStateL
 
 -- | The sum of all the 'gasDeposit' fields of 'currProposals'
 proposalDeposits :: Era era => Term era Coin

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -2630,12 +2630,15 @@ instance PrettyA (PrevGovActionIds era) where
   prettyA = pcPrevGovActionIds
 
 pcConwayGovState :: Reflect era => Proof era -> ConwayGovState era -> PDoc
-pcConwayGovState p (ConwayGovState ss es dr) =
+pcConwayGovState p (ConwayGovState ss cmt con cpp ppp dr) =
   ppRecord
     "ConwayGovState"
     [ ("proposals", pcProposals ss)
-    , ("enactState", pcEnactState p es)
     , ("drepPulsingState", pcDRepPulsingState p dr)
+    , ("committee", ppStrictMaybe prettyA cmt)
+    , ("constitution", prettyA con)
+    , ("currentPParams", prettyA cpp)
+    , ("prevPParams", prettyA ppp)
     ]
 
 instance Reflect era => PrettyA (ConwayGovState era) where


### PR DESCRIPTION
# Description

This PR removes the `EnactState` field from `ConwayGovState`. The fields that have to be stored in the state are copied over to the `ConwayGovState`.

Since we're not storing the whole enact state in the ledger state any more, we don't have to check the invariants in the `EPOCH` rule.

resolves #3998

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
