### PR TITLE
Move unclaimed rewards from proposals to treasury

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -688,9 +688,10 @@ proposalWithRewardAccount ::
   ImpTestM era (ProposalProcedure era)
 proposalWithRewardAccount action = do
   rewardAccount <- registerRewardAccount
+  govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
   pure
     ProposalProcedure
-      { pProcDeposit = Coin 123
+      { pProcDeposit = govActionDeposit
       , pProcReturnAddr = rewardAccount
       , pProcGovAction = action
       , pProcAnchor = def

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -497,12 +497,12 @@ trySubmitGovActions ::
   ImpTestM era (Either [PredicateFailure (EraRule "LEDGER" era)] (Tx era))
 trySubmitGovActions gas = do
   deposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+  rewardAccount <- registerRewardAccount
   proposals <- forM gas $ \ga -> do
-    khPropRwd <- freshKeyHash
     pure
       ProposalProcedure
         { pProcDeposit = deposit
-        , pProcReturnAddr = RewardAccount Testnet (KeyHashObj khPropRwd)
+        , pProcReturnAddr = rewardAccount
         , pProcGovAction = ga
         , pProcAnchor = def
         }
@@ -740,9 +740,9 @@ logRatificationChecks gaId = do
           <> " [To Pass: "
           <> show
             (committeeAcceptedRatio members gasCommitteeVotes committeeState currentEpoch)
-          <> show " >= "
+          <> " >= "
           <> show (votingCommitteeThreshold ratSt gasAction)
-          <> show "]"
+          <> "]"
       , "spoAccepted:\t\t"
           <> show (spoAccepted ratEnv ratSt gas)
           <> " [To Pass: "

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 ## 1.10.0.0
 
+* Replace `depositsAdaPot` in `AdaPots` with `obligationsPot`
+* Add `sumAdaPots`
 * Deprecate `delPlAcnt` in favor of `delPlAccount`
 * Rename `RewardAccount` fields `getRwdNetwork` and `getRwdCred` to `raNetwork` and `raCredential` respectively
 * Deprecate `prAcnt` in favor of `prAccountState`
 * Deprecate `RewardAcnt` in favor of `RewardAccount`
+
+### `testlib`
+
+* Add:
+  * `expectRegisteredRewardAddress`
+  * `expectNotRegisteredRewardAddress`
+  * `expectTreasury`
+* Add `ToExpr` instances for `AdaPots` and `Obligations`
 
 ## 1.9.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Internal.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Internal.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Shelley.Internal (
 )
 where
 
+import Cardano.Ledger.CertState (Obligations (..))
 import Cardano.Ledger.Shelley.AdaPots (
   AdaPots (..),
   consumedTxBody,
@@ -54,10 +55,11 @@ compareAdaPots xlabel x ylabel y =
     , oneline "reservesAdaPot" reservesAdaPot
     , oneline "rewardsAdaPot" rewardsAdaPot
     , oneline "utxoAdaPot" utxoAdaPot
-    , oneline "keyDepositAdaPot" keyDepositAdaPot
-    , oneline "poolDepositAdaPot" poolDepositAdaPot
-    , oneline "depositsAdaPot" depositsAdaPot
     , oneline "feesAdaPot" feesAdaPot
+    , oneline "oblStakePot" (oblStake . obligationsPot)
+    , oneline "oblPoolPot" (oblPool . obligationsPot)
+    , oneline "oblDRepPot" (oblDRep . obligationsPot)
+    , oneline "oblProposalPot" (oblProposal . obligationsPot)
     ]
   where
     n = 25

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -11,7 +11,9 @@ module Test.Cardano.Ledger.Shelley.TreeDiff (
 
 import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.CertState (Obligations)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.AdaPots (AdaPots)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PParams
@@ -189,3 +191,7 @@ instance
   , ToExpr (PredicateFailure (EraRule "DELEGS" era))
   ) =>
   ToExpr (ShelleyLedgerPredFailure era)
+
+instance ToExpr Obligations
+
+instance ToExpr AdaPots

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -437,13 +437,15 @@ instance
 
 -- | Calculate the total ada pots in the chain state
 totalAdaPots ::
-  EraTxOut era =>
+  ( EraTxOut era
+  , EraGov era
+  ) =>
   ChainState era ->
   AdaPots
 totalAdaPots = totalAdaPotsES . nesEs . chainNes
 
 -- | Calculate the total ada in the chain state
-totalAda :: EraTxOut era => ChainState era -> Coin
+totalAda :: (EraTxOut era, EraGov era) => ChainState era -> Coin
 totalAda = totalAdaES . nesEs . chainNes
 
 instance

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -473,6 +473,7 @@ data Obligations = Obligations
   , oblDRep :: !Coin
   , oblProposal :: !Coin
   }
+  deriving (Eq, Ord, Generic)
 
 -- | Calculate total possible refunds in the system that are related to certificates
 --

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -3109,7 +3108,15 @@ pcSlotNo (SlotNo n) = ppWord64 n
 instance PrettyA SlotNo where
   prettyA = pcSlotNo
 
-pcAdaPot :: EraTxOut era => EpochState era -> PDoc
+instance PrettyA DP.Obligations where
+  prettyA = viaShow
+
+pcAdaPot ::
+  ( EraTxOut era
+  , EraGov era
+  ) =>
+  EpochState era ->
+  PDoc
 pcAdaPot es =
   let x = totalAdaPotsES es
    in ppRecord
@@ -3117,9 +3124,8 @@ pcAdaPot es =
         [ ("treasury", pcCoin (treasuryAdaPot x))
         , ("rewards", pcCoin (rewardsAdaPot x))
         , ("utxo", pcCoin (utxoAdaPot x))
-        , ("keydeposit", pcCoin (keyDepositAdaPot x))
-        , ("pooldeposit", pcCoin (poolDepositAdaPot x))
         , ("fees", pcCoin (feesAdaPot x))
+        , ("obligations", prettyA (obligationsPot x))
         , ("totalAda", pcCoin (totalAdaES es))
         ]
 


### PR DESCRIPTION
# Description

Unclaimed rewards from proposals are now moved to the treasury instead of being burned.

The `passTick` function now always checks that ADA is preserved after the TICK rule is run.

resolves #4017 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
