### PR TITLE
Add disjoint RefInput PredicateFailure

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.6.0.1
+## 1.7.0.0
 
-*
+* Add the constructor BabbageNonDisjointRefInputs to BabbageUtxoPredFailure
+  * Utxo rule raises that PredicateFailure in Conway and future Eras when they are not disjoint.
 
 ## 1.6.0.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.6.0.1
+version:            1.7.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -47,9 +47,10 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits (nullRedeemers)
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Core
-import Cardano.Ledger.Babbage.Era (BabbageUTXO)
+import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXO)
 import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
 import Cardano.Ledger.BaseTypes (
+  ProtVer (..),
   ShelleyBase,
   epochInfo,
   networkId,
@@ -71,7 +72,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), areAllAdaOnly, balance)
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val (inject, isAdaOnly, pointwise)
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (◁))
 import Control.State.Transition.Extended (
@@ -89,6 +90,8 @@ import Data.Foldable (sequenceA_, toList)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro
@@ -110,6 +113,9 @@ data BabbageUtxoPredFailure era
     -- together with the minimum value for the given output.
     BabbageOutputTooSmallUTxO
       ![(TxOut era, Coin)]
+  | -- | TxIns that appear in both inputs and reference inputs
+    BabbageNonDisjointRefInputs
+      !(Set (TxIn (EraCrypto era)))
   deriving (Generic)
 
 deriving instance
@@ -118,6 +124,7 @@ deriving instance
   , Show (PredicateFailure (EraRule "UTXO" era))
   , Show (TxOut era)
   , Show (Script era)
+  , Show (TxIn (EraCrypto era))
   ) =>
   Show (BabbageUtxoPredFailure era)
 
@@ -127,6 +134,7 @@ deriving instance
   , Eq (PredicateFailure (EraRule "UTXO" era))
   , Eq (TxOut era)
   , Eq (Script era)
+  , Eq (TxIn (EraCrypto era))
   ) =>
   Eq (BabbageUtxoPredFailure era)
 
@@ -193,6 +201,20 @@ feesOK pp tx (UTxO utxo) =
           unless (nullRedeemers $ tx ^. witsTxL . rdmrsTxWitsL) $
             validateTotalCollateral pp txBody utxoCollateral
         ]
+
+disjointRefInputs ::
+  forall era.
+  EraPParams era =>
+  PParams era ->
+  Set (TxIn (EraCrypto era)) ->
+  Set (TxIn (EraCrypto era)) ->
+  Test (BabbageUtxoPredFailure era)
+disjointRefInputs pp inputs refInputs =
+  when
+    (pvMajor (pp ^. ppProtocolVersionL) > eraProtVerHigh @(BabbageEra (EraCrypto era)))
+    (failureIf (null common) (BabbageNonDisjointRefInputs common))
+  where
+    common = inputs `Set.intersection` refInputs
 
 validateTotalCollateral ::
   forall era.
@@ -320,6 +342,13 @@ utxoTransition = do
   {-   txb := txbody tx   -}
   let txBody = body tx
       allInputs = txBody ^. allInputsTxBodyF
+      refInputs :: Set (TxIn (EraCrypto era))
+      refInputs = txBody ^. referenceInputsTxBodyL
+      inputs :: Set (TxIn (EraCrypto era))
+      inputs = txBody ^. inputsTxBodyL
+
+  {- inputs ∩ refInputs = ∅ -}
+  runTest $ disjointRefInputs @era pp inputs refInputs
 
   {- ininterval slot (txvld txb) -}
   runTest $ Allegra.validateOutsideValidityIntervalUTxO slot txBody
@@ -431,6 +460,7 @@ instance
   , EncCBOR (PredicateFailure (EraRule "UTXOS" era))
   , EncCBOR (PredicateFailure (EraRule "UTXO" era))
   , EncCBOR (Script era)
+  , EncCBOR (TxIn (EraCrypto era))
   , Typeable (TxAuxData era)
   ) =>
   EncCBOR (BabbageUtxoPredFailure era)
@@ -440,6 +470,7 @@ instance
       AlonzoInBabbageUtxoPredFailure x -> Sum AlonzoInBabbageUtxoPredFailure 1 !> To x
       IncorrectTotalCollateralField c1 c2 -> Sum IncorrectTotalCollateralField 2 !> To c1 !> To c2
       BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 3 !> To x
+      BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 4 !> To x
 
 instance
   ( Era era
@@ -456,6 +487,7 @@ instance
     1 -> SumD AlonzoInBabbageUtxoPredFailure <! From
     2 -> SumD IncorrectTotalCollateralField <! From <! From
     3 -> SumD BabbageOutputTooSmallUTxO <! From
+    4 -> SumD BabbageNonDisjointRefInputs <! From
     n -> Invalid n
 
 deriving via

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -36,7 +36,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.5.1,
         cardano-ledger-alonzo-test >=1.1,
-        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.5 && <1.7,
+        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.5 && <1.8,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11,
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-mary >=1.4,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -84,7 +84,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-allegra ^>=1.3,
         cardano-ledger-alonzo ^>=1.6,
-        cardano-ledger-babbage ^>=1.6,
+        cardano-ledger-babbage ^>=1.7,
         cardano-ledger-core ^>=1.11,
         cardano-ledger-mary ^>=1.5,
         cardano-ledger-shelley ^>=1.10,

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -32,7 +32,7 @@ library
         base >=4.14 && <5,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.6,
         cardano-ledger-alonzo-test,
-        cardano-ledger-babbage >=1.3 && <1.7,
+        cardano-ledger-babbage >=1.3 && <1.8,
         cardano-ledger-babbage-test >=1.1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-conway:{cardano-ledger-conway, testlib} ^>=1.13,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -56,7 +56,7 @@ library
         bytestring,
         cardano-ledger-allegra ^>=1.3,
         cardano-ledger-alonzo ^>=1.6,
-        cardano-ledger-babbage ^>=1.6,
+        cardano-ledger-babbage ^>=1.7,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-conway ^>=1.13,
         cardano-ledger-core ^>=1.11,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -660,7 +660,7 @@ conformsWhen makeTestsSmall condition impState =
       x
         { usNumPreUtxo = 3
         , usNumColUtxo = 3
-        , usMinInputs = 1
+        , usMinInputs = 2
         , usMaxInputs = 3
         , usMinCollaterals = 1
         , usMaxCollaterals = 3

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -533,6 +533,8 @@ txBodyPreds sizes@UnivSize {..} p =
        , -- refInputs
          Sized (Range 0 1) refInputs
        , Subset refInputs (Dom (utxo p))
+       , NotMember feeTxIn refInputs
+       , Disjoint refInputs inputs -- New constraint in Conway, added PR #4024
        , Sized (Range 1 2) reqSignerHashes
        , Subset reqSignerHashes (Dom keymapUniv)
        , ttl :<-: (Constr "(+5)" (\x -> x + 5) ^$ currentSlot)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -13,6 +14,7 @@
 
 module Test.Cardano.Ledger.Examples.STSTestUtils (
   AlonzoBased (..),
+  ToUTXOW (..),
   initUTxO,
   mkGenesisTxIn,
   mkTxDats,
@@ -263,6 +265,30 @@ instance AlonzoBased (ConwayEra c) (BabbageUtxowPredFailure (ConwayEra c)) where
   fromUtxo = Babbage.UtxoFailure . AlonzoInBabbageUtxoPredFailure
   fromUtxow = AlonzoInBabbageUtxowPredFailure . ShelleyInAlonzoUtxowPredFailure
   fromPredFail = AlonzoInBabbageUtxowPredFailure
+
+class ToUTXOW era where
+  fromUtxos' :: AlonzoUtxosPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+  fromUtxo' :: AlonzoUtxoPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+  fromUtxow' :: ShelleyUtxowPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+  fromPredFail' :: AlonzoUtxowPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+  fromUtxoB' :: BabbageUtxoPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+  fromUtxowB' :: BabbageUtxowPredFailure era -> PredicateFailure (EraRule "UTXOW" era)
+
+instance ToUTXOW (ConwayEra c) where
+  fromUtxos' = Babbage.UtxoFailure . AlonzoInBabbageUtxoPredFailure . UtxosFailure
+  fromUtxo' = Babbage.UtxoFailure . AlonzoInBabbageUtxoPredFailure
+  fromUtxow' = AlonzoInBabbageUtxowPredFailure . ShelleyInAlonzoUtxowPredFailure
+  fromPredFail' = AlonzoInBabbageUtxowPredFailure
+  fromUtxoB' = Babbage.UtxoFailure
+  fromUtxowB' = id
+
+instance ToUTXOW (BabbageEra c) where
+  fromUtxos' = Babbage.UtxoFailure . AlonzoInBabbageUtxoPredFailure . UtxosFailure
+  fromUtxo' = Babbage.UtxoFailure . AlonzoInBabbageUtxoPredFailure
+  fromUtxow' = AlonzoInBabbageUtxowPredFailure . ShelleyInAlonzoUtxowPredFailure
+  fromPredFail' = AlonzoInBabbageUtxowPredFailure
+  fromUtxoB' = Babbage.UtxoFailure
+  fromUtxowB' = id
 
 -- ======================================================================
 -- ========================= Shared helper functions  ===================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1288,7 +1288,7 @@ ppBabbageUtxoPredFailure (IncorrectTotalCollateralField c1 c2) =
 ppBabbageUtxoPredFailure (BabbageOutputTooSmallUTxO xs) =
   ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair (pcTxOut reify) pcCoin) xs]
 ppBabbageUtxoPredFailure (BabbageNonDisjointRefInputs xs) =
-  ppSexp "BabbageNonDisjointRefInputs" [ppSet pcTxIn xs]
+  ppSexp "BabbageNonDisjointRefInputs" [ppList pcTxIn (toList xs)]
 
 instance Reflect era => PrettyA (BabbageUtxoPredFailure era) where
   prettyA = ppBabbageUtxoPredFailure

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1287,6 +1287,8 @@ ppBabbageUtxoPredFailure (IncorrectTotalCollateralField c1 c2) =
     [("collateral provided", pcCoin c1), ("collateral declared", pcCoin c2)]
 ppBabbageUtxoPredFailure (BabbageOutputTooSmallUTxO xs) =
   ppSexp "BabbageOutputTooSmallUTxO" [ppList (ppPair (pcTxOut reify) pcCoin) xs]
+ppBabbageUtxoPredFailure (BabbageNonDisjointRefInputs xs) =
+  ppSexp "BabbageNonDisjointRefInputs" [ppSet pcTxIn xs]
 
 instance Reflect era => PrettyA (BabbageUtxoPredFailure era) where
   prettyA = ppBabbageUtxoPredFailure


### PR DESCRIPTION
Address issue #4007 
Added some unit tests in Test.Cardano.Ledger.Example.BabbageFeatures.hs
Generalized the BabbageFeatures to work on Babbage and Conway Eras.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
