### PR TITLE
Further improvements to `Proposals`

### DIFF
--- a/eras/babbage/impl/cddl-files/babbage.cddl
+++ b/eras/babbage/impl/cddl-files/babbage.cddl
@@ -76,9 +76,11 @@ transaction_input = [ transaction_id : $hash32
                     , index : uint
                     ]
 
-transaction_output = legacy_transaction_output / post_alonzo_transaction_output ; New
+; Both of the Alonzo and Babbage style TxOut formats are equally valid
+; and can be used interchangeably
+transaction_output = pre_babbage_transaction_output / post_alonzo_transaction_output ; New
 
-legacy_transaction_output =
+pre_babbage_transaction_output =
   [ address
   , amount : value
   , ? datum_hash : $hash32

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 1.13.0.0
 
 * Rename:
+  * `pfPParamUpdateL` to `grPParamUpdateL`
+  * `pfHardForkL` to `grHardForkL`
+  * `pfCommitteeL` to `grCommitteeL`
+  * `pfConstitutionL` to `grConstitutionL`
+* Rename:
   * `cgProposalsL` to `cgsProposalsL`
   * `cgEnactStateL` to `cgsEnactStateL`
   * `cgDRepPulsingStateL` to `cgsDRepPulsingStateL`
@@ -13,7 +18,9 @@
   * `govStatePrevGovActionIds`
   * `mkEnactState`
 * Deprecated `curPParamsConwayGovStateL` and `curPParamsConwayGovStateL`
-* Add `TreeMaybe`, `toPForest` and `toPForestEither`
+* Rename `PForest` to `GovRelation`
+* Add `hoistGovRelation` and `withGovActionParent`
+* Add `TreeMaybe`, `toGovRelationTree` and `toGovRelationTreeEither`
 * Remove `proposalsAreConsistent`
 
 ### `testlib`

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -156,9 +156,11 @@ transaction_input = [ transaction_id : $hash32
                     , index : uint
                     ]
 
-transaction_output = legacy_transaction_output / post_alonzo_transaction_output
+; Both of the Alonzo and Babbage style TxOut formats are equally valid
+; and can be used interchangeably
+transaction_output = pre_babbage_transaction_output / post_alonzo_transaction_output
 
-legacy_transaction_output =
+pre_babbage_transaction_output =
   [ address
   , amount : value
   , ? datum_hash : $hash32

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -164,7 +164,8 @@ data PRoot a = PRoot
   { prRoot :: !(StrictMaybe a)
   , prChildren :: !(Set a)
   }
-  deriving (Show, Eq, Ord, Generic, NoThunks, NFData, Default)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass (NoThunks, NFData, Default)
 
 -- | A non-root edges in a `Proposals` tree. `peParent` is expected to be
 -- a `SNothing` only at the begining when no governance actions has been
@@ -173,7 +174,8 @@ data PEdges a = PEdges
   { peParent :: !(StrictMaybe a)
   , peChildren :: !(Set a)
   }
-  deriving (Show, Eq, Ord, Generic, NoThunks, NFData, Default)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass (NoThunks, NFData, Default)
 
 -- | A single proposal-tree. This map represents all the action-ids that
 -- form a tree.
@@ -247,19 +249,19 @@ pfCommitteeL = lens pfCommittee $ \x y -> x {pfCommittee = y}
 pfConstitutionL :: Lens' (PForest f era) (f (GovPurposeId 'ConstitutionPurpose era))
 pfConstitutionL = lens pfConstitution $ \x y -> x {pfConstitution = y}
 
-deriving instance
+deriving stock instance
   (forall p. Eq (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   Eq (PForest f era)
-deriving instance
+deriving stock instance
   (forall p. Ord (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   Ord (PForest f era)
-deriving instance
+deriving anyclass instance
   (forall p. NoThunks (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   NoThunks (PForest f era)
-deriving instance
+deriving anyclass instance
   (forall p. NFData (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   NFData (PForest f era)
-deriving instance
+deriving anyclass instance
   (forall p. Default (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   Default (PForest f era)
 
@@ -288,7 +290,8 @@ data Proposals era = Proposals
   , pRoots :: !(PForest PRoot era)
   , pGraph :: !(PForest PGraph era)
   }
-  deriving (Show, Eq, Generic, NoThunks, NFData, Default)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (NoThunks, NFData, Default)
 
 pPropsL :: Lens' (Proposals era) (OMap.OMap (GovActionId (EraCrypto era)) (GovActionState era))
 pPropsL = lens pProps $ \x y -> x {pProps = y}
@@ -599,14 +602,11 @@ proposalsLookupId gai (Proposals omap _ _) = OMap.lookup gai omap
 newtype PrevGovActionIds era = PrevGovActionIds
   { unPrevGovActionIds :: PForest StrictMaybe era
   }
-  deriving (Show, Eq, Generic)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (NoThunks, NFData, Default)
 
 prevGovActionIdsL :: Lens' (PrevGovActionIds era) (PForest StrictMaybe era)
 prevGovActionIdsL = lens unPrevGovActionIds $ \_x y -> PrevGovActionIds y
-
-instance Era era => NoThunks (PrevGovActionIds era)
-instance Era era => NFData (PrevGovActionIds era)
-instance Era era => Default (PrevGovActionIds era)
 
 instance Era era => DecCBOR (PrevGovActionIds era) where
   decCBOR =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -211,6 +211,30 @@ deriving instance
   (forall p. Show (f (GovPurposeId (p :: GovActionPurpose) era))) =>
   Show (PForest f era)
 
+instance
+  (forall p. Semigroup (f (GovPurposeId (p :: GovActionPurpose) era))) =>
+  Semigroup (PForest f era)
+  where
+  (<>) p1 p2 =
+    PForest
+      { pfPParamUpdate = pfPParamUpdate p1 <> pfPParamUpdate p2
+      , pfHardFork = pfHardFork p1 <> pfHardFork p2
+      , pfCommittee = pfCommittee p1 <> pfCommittee p2
+      , pfConstitution = pfConstitution p1 <> pfConstitution p2
+      }
+
+instance
+  (forall p. Monoid (f (GovPurposeId (p :: GovActionPurpose) era))) =>
+  Monoid (PForest f era)
+  where
+  mempty =
+    PForest
+      { pfPParamUpdate = mempty
+      , pfHardFork = mempty
+      , pfCommittee = mempty
+      , pfConstitution = mempty
+      }
+
 pfPParamUpdateL :: Lens' (PForest f era) (f (GovPurposeId 'PParamUpdatePurpose era))
 pfPParamUpdateL = lens pfPParamUpdate $ \x y -> x {pfPParamUpdate = y}
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -55,18 +55,17 @@ import Cardano.Ledger.Conway.Governance (
   GovActionState (..),
   GovProcedures (..),
   GovPurposeId (..),
-  PrevGovActionIds (..),
+  GovRelation (..),
   ProposalProcedure (..),
   Proposals,
   Voter (..),
   VotingProcedure (..),
   foldlVotingProcedures,
+  grHardForkL,
   indexedGovProps,
   isCommitteeVotingAllowed,
   isDRepVotingAllowed,
   isStakePoolVotingAllowed,
-  pfHardForkL,
-  prevGovActionIdsL,
   proposalsActionsMap,
   proposalsAddAction,
   proposalsAddVote,
@@ -117,7 +116,7 @@ data GovEnv era = GovEnv
   { geTxId :: !(TxId (EraCrypto era))
   , geEpoch :: !EpochNo
   , gePParams :: !(PParams era)
-  , gePrevGovActionIds :: !(PrevGovActionIds era)
+  , gePrevGovActionIds :: !(GovRelation StrictMaybe era)
   , gePPolicy :: !(StrictMaybe (ScriptHash (EraCrypto era)))
   }
 
@@ -424,11 +423,11 @@ preceedingHardFork ::
   EraPParams era =>
   GovAction era ->
   PParams era ->
-  PrevGovActionIds era ->
+  GovRelation StrictMaybe era ->
   Proposals era ->
   Maybe (StrictMaybe (GovPurposeId 'HardForkPurpose era), ProtVer, ProtVer)
 preceedingHardFork (HardForkInitiation mPrev newProtVer) pp pgaids ps
-  | mPrev == pgaids ^. prevGovActionIdsL . pfHardForkL = Just (mPrev, newProtVer, pp ^. ppProtocolVersionL)
+  | mPrev == pgaids ^. grHardForkL = Just (mPrev, newProtVer, pp ^. ppProtocolVersionL)
   | otherwise = do
       SJust (GovPurposeId prevGovActionId) <- Just mPrev
       HardForkInitiation _ prevProtVer <- gasAction <$> proposalsLookupId prevGovActionId ps

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -99,14 +99,14 @@ import Cardano.Ledger.Conway.Governance (
   epochStateDRepPulsingStateL,
   finishDRepPulser,
   gasDRepVotesL,
+  grCommitteeL,
+  grConstitutionL,
+  grHardForkL,
+  grPParamUpdateL,
   mkEnactState,
   pGraphL,
   pGraphNodesL,
   pRootsL,
-  pfCommitteeL,
-  pfConstitutionL,
-  pfHardForkL,
-  pfPParamUpdateL,
   proposalsIds,
   proposalsLookupId,
   proposalsSize,
@@ -731,7 +731,7 @@ logRatificationChecks gaId = do
   logEntry $
     unlines
       [ "----- RATIFICATION CHECKS -----"
-      , "prevActionAsExpected:\t" <> show (prevActionAsExpected gasAction ensPrevGovActionIds)
+      , "prevActionAsExpected:\t" <> show (prevActionAsExpected gas ensPrevGovActionIds)
       , "validCommitteeTerm:\t" <> show (validCommitteeTerm gasAction curPParams currentEpoch)
       , "notDelayed:\t\t??"
       , "withdrawalCanWithdraw:\t" <> show (withdrawalCanWithdraw gasAction curTreasury)
@@ -889,25 +889,25 @@ proposalsShowDebug ps showRoots =
     , ""
     , "Roots"
     , "> PParamUpdate"
-    , show $ ps ^. pRootsL . pfPParamUpdateL
+    , show $ ps ^. pRootsL . grPParamUpdateL
     , "> HardFork"
-    , show $ ps ^. pRootsL . pfHardForkL
+    , show $ ps ^. pRootsL . grHardForkL
     , "> Committee"
-    , show $ ps ^. pRootsL . pfCommitteeL
+    , show $ ps ^. pRootsL . grCommitteeL
     , "> Constitution"
-    , show $ ps ^. pRootsL . pfConstitutionL
+    , show $ ps ^. pRootsL . grConstitutionL
     ]
       <> ( if showRoots
             then
               [ "Hierarchy"
               , ">> PParamUpdate"
-              , show $ ps ^. pGraphL . pfPParamUpdateL . pGraphNodesL
+              , show $ ps ^. pGraphL . grPParamUpdateL . pGraphNodesL
               , ">> HardFork"
-              , show $ ps ^. pGraphL . pfHardForkL . pGraphNodesL
+              , show $ ps ^. pGraphL . grHardForkL . pGraphNodesL
               , ">> Committee"
-              , show $ ps ^. pGraphL . pfCommitteeL . pGraphNodesL
+              , show $ ps ^. pGraphL . grCommitteeL . pGraphNodesL
               , ">> Constitution"
-              , show $ ps ^. pGraphL . pfConstitutionL . pGraphNodesL
+              , show $ ps ^. pGraphL . grConstitutionL . pGraphNodesL
               ]
             else mempty
          )

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -82,13 +84,9 @@ instance ToExpr a => ToExpr (PEdges a)
 
 instance ToExpr a => ToExpr (PGraph a)
 
-instance Era era => ToExpr (PForest PRoot era)
-
-instance Era era => ToExpr (PForest PGraph era)
-
-instance Era era => ToExpr (PForest StrictMaybe era)
-
-instance Era era => ToExpr (PrevGovActionIds era)
+instance
+  (forall p. ToExpr (f (GovPurposeId (p :: GovActionPurpose) era))) =>
+  ToExpr (GovRelation f era)
 
 instance (Era era, ToExpr (PParamsHKD StrictMaybe era)) => ToExpr (Proposals era)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.9.0.0
 
+* Add `hoistGovRelation`, `withGovActionParent` and `GovRelation`
+
+* Remove `PrevGovActionIds`
 * Rename `cgProposalsL` to `cgsProposalsL`
 * Remove `cgEnactStateL`
 * Rename `RewardAccount` fields `getRwdNetwork` and `getRwdCred` to `raNetwork` and `raCredential` respectively

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Governance.hs
@@ -34,7 +34,9 @@ module Cardano.Ledger.Api.Governance (
   GovActionIx (..),
   GovActionState (..),
   GovActionPurpose (..),
-  PrevGovActionIds (..),
+  GovRelation (..),
+  hoistGovRelation,
+  withGovActionParent,
   GovPurposeId (..),
   govActionIdToText,
 
@@ -60,7 +62,7 @@ import Cardano.Ledger.Conway.Governance (
   GovActionPurpose (..),
   GovActionState (..),
   GovPurposeId (..),
-  PrevGovActionIds (..),
+  GovRelation (..),
   ProposalProcedure (..),
   RatifyState (..),
   Vote (..),
@@ -71,6 +73,8 @@ import Cardano.Ledger.Conway.Governance (
   constitutionAnchorL,
   constitutionScriptL,
   govActionIdToText,
+  hoistGovRelation,
+  withGovActionParent,
  )
 import Cardano.Ledger.Shelley.Governance (
   EraGov (GovState),

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.BaseTypes (
   Network (..),
   ProtVer (..),
   SlotNo (..),
+  StrictMaybe (..),
   UnitInterval,
   mkTxIxPartial,
  )
@@ -74,7 +75,7 @@ import Cardano.Ledger.Conway.Governance (
   GovActionPurpose (..),
   GovActionState (..),
   GovPurposeId (..),
-  PrevGovActionIds (..),
+  GovRelation (..),
   Proposals,
   RatifyState (..),
   RunConwayRatify (..),
@@ -335,7 +336,7 @@ data Rep era t where
   UnitIntervalR :: Rep era UnitInterval
   CommitteeR :: Era era => Rep era (Committee era)
   ConstitutionR :: Era era => Rep era (Constitution era)
-  PrevGovActionIdsR :: Era era => Rep era (PrevGovActionIds era)
+  PrevGovActionIdsR :: Era era => Rep era (GovRelation StrictMaybe era)
   PrevPParamUpdateR :: Era era => Rep era (GovPurposeId 'PParamUpdatePurpose era)
   PrevHardForkR :: Era era => Rep era (GovPurposeId 'HardForkPurpose era)
   PrevCommitteeR :: Era era => Rep era (GovPurposeId 'CommitteePurpose era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -1947,7 +1947,7 @@ currProposals :: Era era => Proof era -> Term era (Proposals era)
 currProposals p = Var $ V "currProposals" (ProposalsR p) No
 
 -- | Part of the EnactState, it is computed by selecting from currProposals
-prevGovActionIds :: forall era. Reflect era => Term era (PrevGovActionIds era)
+prevGovActionIds :: forall era. Reflect era => Term era (GovRelation StrictMaybe era)
 prevGovActionIds = Var $ V "prevGovActionIds" PrevGovActionIdsR No
 
 -- | This is a view of currProposals, so will compute it once

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -86,10 +86,9 @@ import Cardano.Ledger.Conway.Governance (
   GovActionState (..),
   GovProcedures (..),
   GovPurposeId (..),
+  GovRelation (..),
   PEdges (..),
-  PForest (..),
   PGraph (..),
-  PrevGovActionIds (..),
   ProposalProcedure (..),
   Proposals,
   PulsingSnapshot (..),
@@ -2616,17 +2615,17 @@ instance PrettyA (GovActionId c) where
 pcGovPurposeId :: GovPurposeId p era -> PDoc
 pcGovPurposeId (GovPurposeId x) = pcGovActionId x
 
-pcPrevGovActionIds :: PrevGovActionIds era -> PDoc
-pcPrevGovActionIds (PrevGovActionIds (PForest {pfPParamUpdate, pfHardFork, pfCommittee, pfConstitution})) =
+pcPrevGovActionIds :: GovRelation StrictMaybe era -> PDoc
+pcPrevGovActionIds GovRelation {grPParamUpdate, grHardFork, grCommittee, grConstitution} =
   ppRecord
     "PrevGovActionIds"
-    [ ("LastPParamUpdate", ppStrictMaybe pcGovPurposeId pfPParamUpdate)
-    , ("LastHardFork", ppStrictMaybe pcGovPurposeId pfHardFork)
-    , ("LastCommittee", ppStrictMaybe pcGovPurposeId pfCommittee)
-    , ("LastConstitution", ppStrictMaybe pcGovPurposeId pfConstitution)
+    [ ("LastPParamUpdate", ppStrictMaybe pcGovPurposeId grPParamUpdate)
+    , ("LastHardFork", ppStrictMaybe pcGovPurposeId grHardFork)
+    , ("LastCommittee", ppStrictMaybe pcGovPurposeId grCommittee)
+    , ("LastConstitution", ppStrictMaybe pcGovPurposeId grConstitution)
     ]
 
-instance PrettyA (PrevGovActionIds era) where
+instance PrettyA (GovRelation StrictMaybe era) where
   prettyA = pcPrevGovActionIds
 
 pcConwayGovState :: Reflect era => Proof era -> ConwayGovState era -> PDoc
@@ -2681,7 +2680,7 @@ pcRatifyState p (RatifyState enactedState enactedPs expiredPs delayedPs) =
 instance Reflect era => PrettyA (RatifyState era) where
   prettyA = pcRatifyState reify
 
-pcProposals :: Era era => Proposals era -> PDoc
+pcProposals :: Proposals era -> PDoc
 pcProposals p =
   ppRecord
     "Proposals"
@@ -2698,8 +2697,8 @@ pcPEdges (PEdges x y) =
     , ("children", ppSet pcGovPurposeId y)
     ]
 
-pcForest :: PForest PGraph era -> PDoc
-pcForest (PForest a b c d) =
+pcForest :: GovRelation PGraph era -> PDoc
+pcForest (GovRelation a b c d) =
   ppRecord
     "Forest PGraph"
     [ ("pparamupdate", ppMap pcGovPurposeId pcPEdges (unPGraph a))


### PR DESCRIPTION
# Description

Rename `PForest` to `GovRelation` and make it public:
  * Remove `PrevGovActionIds` in favor of direct usage of `GovRelation` 
  * Abstract common usage pattern in `withGovActionParent`
  * Add another invariant verification to Proposal's

Rename `legacy_transaction_output` to `pre_babbage_transaction_output` in CDDL
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
