### PR TITLE
Report Plutus `ScriptHash` upon execution failure

### DIFF
--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PlutusScriptExamples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PlutusScriptExamples.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PlutusScriptExamples.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/PlutusScriptExamples.hs
@@ -17,7 +17,7 @@ where
 import Cardano.Ledger.Alonzo (Alonzo)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
-import Cardano.Ledger.Core (eraProtVerLow)
+import Cardano.Ledger.Core (EraCrypto, eraProtVerLow)
 import Cardano.Ledger.Plutus.Evaluate (
   PlutusDatums (..),
   PlutusWithContext (..),
@@ -28,6 +28,7 @@ import Cardano.Ledger.Plutus.Language (
   Language (..),
   Plutus (..),
   PlutusLanguage (..),
+  hashPlutusScript,
   plutusLanguage,
  )
 import Data.Bifunctor (first)
@@ -178,6 +179,7 @@ explainTest plutus mode ds =
         PlutusWithContext
           { pwcProtocolVersion = eraProtVerLow @era
           , pwcScript = Left plutus
+          , pwcScriptHash = hashPlutusScript @l @(EraCrypto era) plutus
           , pwcDatums = PlutusDatums ds
           , pwcExUnits = ExUnits 100000000 10000000
           , pwcCostModel = zeroTestingCostModel (plutusLanguage plutus)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
@@ -75,7 +75,7 @@ data TransactionScriptFailure era
       !ExUnits
       !P.EvaluationError
       ![Text]
-      !PlutusWithContext
+      !(PlutusWithContext (EraCrypto era))
   | -- | A redeemer points to a transaction input which is not
     --  present in the current UTxO.
     UnknownTxIn !(TxIn (EraCrypto era))
@@ -207,7 +207,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
         (\(sp, sh) -> (sp, lookupPlutusScript scriptsProvided sh, sh))
         scriptsNeeded
     findAndCount ptrToPlutusScript pointer (rdmr, exUnits) = do
-      (plutusPurpose, mPlutusScript, _) <-
+      (plutusPurpose, mPlutusScript, scriptHash) <-
         note (RedeemerPointsToUnknownScriptHash pointer) $
           Map.lookup pointer ptrToPlutusScript
       let ptrToPlutusScriptNoContext =
@@ -238,6 +238,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo sysStart = do
               PlutusWithContext
                 { pwcProtocolVersion = protVerMajor
                 , pwcScript = Left plutus
+                , pwcScriptHash = scriptHash
                 , pwcDatums = PlutusDatums (getPlutusData <$> datums)
                 , pwcExUnits = maxBudget
                 , pwcCostModel = costModel

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts/ExUnits.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.11.0.0
 
+* Add `pwcScriptHash` field to `PlutusWithContext`
+* Parameterize `PlutusWithContext c` on crypto.
 * Extract `hashScript` outside of `EraScript` type class.
 * Add `plutusLanguageTag` and `hashPlutusScript`
 * Add `setMinFeeTxUtxo`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -15,9 +12,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -47,6 +47,8 @@ import Cardano.Ledger.Binary (
   toPlainEncoding,
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Plutus.CostModels (
   CostModel,
   decodeCostModelFailHard,
@@ -60,10 +62,12 @@ import Cardano.Ledger.Plutus.Language (
   PlutusLanguage (..),
   PlutusRunnable (..),
   decodeWithPlutus,
+  hashPlutusScript,
   plutusFromRunnable,
   plutusLanguage,
  )
 import Cardano.Ledger.Plutus.TxInfo
+import Control.Monad (unless)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.UTF8 as BSU
 import Data.List.NonEmpty (NonEmpty (..))
@@ -77,7 +81,7 @@ import qualified PlutusLedgerApi.V3 as PV3
 import Prettyprinter (Pretty (..))
 
 -- | This type contains all that is necessary from Ledger to evaluate a plutus script.
-data PlutusWithContext where
+data PlutusWithContext c where
   PlutusWithContext ::
     PlutusLanguage l =>
     { pwcProtocolVersion :: !Version
@@ -87,6 +91,7 @@ data PlutusWithContext where
     -- serialized and deserialized. This is necesary for implementing the opptimization
     -- that preserves deserialized `PlutusRunnable` after verifying wellformedness of
     -- plutus scripts during transaction validation (yet to be implemented).
+    , pwcScriptHash :: !(ScriptHash c)
     , pwcDatums :: !PlutusDatums
     -- ^ All of the arguments to the Plutus scripts, including the redeemer and the
     -- Plutus context that was obtained from the transaction translation
@@ -96,13 +101,14 @@ data PlutusWithContext where
     -- ^ `CostModel` to be used during script evaluation. It must match the language
     -- version in the `pwcScript`
     } ->
-    PlutusWithContext
+    PlutusWithContext c
 
-deriving instance Show PlutusWithContext
+deriving instance Show (PlutusWithContext c)
 
-instance Eq PlutusWithContext where
+instance Eq (PlutusWithContext c) where
   pwc1@(PlutusWithContext {pwcScript = s1}) == pwc2@(PlutusWithContext {pwcScript = s2}) =
     pwcProtocolVersion pwc1 == pwcProtocolVersion pwc2
+      && pwcScriptHash pwc1 == pwcScriptHash pwc2
       && pwcDatums pwc1 == pwcDatums pwc2
       && pwcExUnits pwc1 == pwcExUnits pwc2
       && pwcCostModel pwc1 == pwcCostModel pwc2
@@ -114,25 +120,25 @@ instance Eq PlutusWithContext where
         plutusLanguage p1 == plutusLanguage p2 && plutusRunnable p1 == plutusRunnable p2
       eqScripts _ _ = False
 
-data ScriptFailure = ScriptFailure
+data ScriptFailure c = ScriptFailure
   { scriptFailureMessage :: Text
-  , scriptFailurePlutus :: PlutusWithContext
+  , scriptFailurePlutus :: PlutusWithContext c
   }
   deriving (Show, Generic)
 
-data ScriptResult
-  = Passes [PlutusWithContext]
-  | Fails [PlutusWithContext] (NonEmpty ScriptFailure)
+data ScriptResult c
+  = Passes [PlutusWithContext c]
+  | Fails [PlutusWithContext c] (NonEmpty (ScriptFailure c))
   deriving (Generic)
 
-scriptPass :: PlutusWithContext -> ScriptResult
+scriptPass :: PlutusWithContext c -> ScriptResult c
 scriptPass pwc = Passes [pwc]
 
-scriptFail :: ScriptFailure -> ScriptResult
+scriptFail :: ScriptFailure c -> ScriptResult c
 scriptFail sf = Fails [] (pure sf)
 
 withRunnablePlutusWithContext ::
-  PlutusWithContext ->
+  PlutusWithContext c ->
   -- | Handle the decoder failure
   (P.EvaluationError -> a) ->
   (forall l. PlutusLanguage l => PlutusRunnable l -> a) ->
@@ -145,13 +151,13 @@ withRunnablePlutusWithContext PlutusWithContext {pwcProtocolVersion, pwcScript} 
         Right pr -> f pr
         Left err -> onError (P.CodecError err)
 
-instance Semigroup ScriptResult where
+instance Semigroup (ScriptResult c) where
   Passes ps <> Passes qs = Passes (ps <> qs)
   Passes ps <> Fails qs xs = Fails (ps <> qs) xs
   Fails ps xs <> Passes qs = Fails (ps <> qs) xs
   Fails ps xs <> Fails qs ys = Fails (ps <> qs) (xs <> ys)
 
-instance Monoid ScriptResult where
+instance Monoid (ScriptResult c) where
   mempty = Passes mempty
 
 newtype PlutusDatums = PlutusDatums {unPlutusDatums :: [PV1.Data]}
@@ -163,34 +169,43 @@ instance EncCBOR PlutusDatums where
 instance DecCBOR PlutusDatums where
   decCBOR = PlutusDatums <$> decCBOR
 
-instance ToCBOR PlutusWithContext where
+instance Crypto c => ToCBOR (PlutusWithContext c) where
   toCBOR (PlutusWithContext {..}) =
-    Plain.encodeListLen 5
+    Plain.encodeListLen 6
       <> toCBOR pwcProtocolVersion
       <> toPlainEncoding pwcProtocolVersion (either encCBOR encCBOR pwcScript)
+      <> toPlainEncoding pwcProtocolVersion (encCBOR pwcScriptHash)
       <> toPlainEncoding pwcProtocolVersion (encCBOR pwcDatums)
       <> toPlainEncoding pwcProtocolVersion (encCBOR pwcExUnits)
       <> toPlainEncoding pwcProtocolVersion (encodeCostModel pwcCostModel)
 
-instance FromCBOR PlutusWithContext where
-  fromCBOR = Plain.decodeRecordNamed "PlutusWithContext" (const 5) $ do
+instance Crypto c => FromCBOR (PlutusWithContext c) where
+  fromCBOR = Plain.decodeRecordNamed "PlutusWithContext" (const 6) $ do
     pwcProtocolVersion <- fromCBOR
     toPlainDecoder pwcProtocolVersion $ decodeWithPlutus $ \plutus -> do
       let lang = plutusLanguage plutus
           pwcScript = Left plutus
+          scriptHash = hashPlutusScript plutus
+      pwcScriptHash <- decCBOR
+      unless (pwcScriptHash == scriptHash) $
+        fail $
+          "ScriptHash mismatch. Encoded: "
+            <> show pwcScriptHash
+            <> " doesn't match the actual: "
+            <> show scriptHash
       pwcDatums <- decCBOR
       pwcExUnits <- decCBOR
       pwcCostModel <- decodeCostModelFailHard lang
       pure PlutusWithContext {..}
 
-data PlutusDebugInfo
+data PlutusDebugInfo c
   = DebugBadHex String
   | DebugCannotDecode String
   | DebugSuccess [Text] PV1.ExBudget
-  | DebugFailure [Text] P.EvaluationError PlutusWithContext
+  | DebugFailure [Text] P.EvaluationError (PlutusWithContext c)
   deriving (Show)
 
-debugPlutus :: String -> PlutusDebugInfo
+debugPlutus :: Crypto c => String -> PlutusDebugInfo c
 debugPlutus db =
   case B64.decode (BSU.fromString db) of
     Left e -> DebugBadHex (show e)
@@ -209,12 +224,12 @@ debugPlutus db =
                 toDebugInfo $
                   evaluatePlutusRunnable pwcProtocolVersion PV1.Verbose cm eu plutusRunnable d
 
-runPlutusScript :: PlutusWithContext -> ScriptResult
+runPlutusScript :: PlutusWithContext c -> ScriptResult c
 runPlutusScript = snd . runPlutusScriptWithLogs
 
 runPlutusScriptWithLogs ::
-  PlutusWithContext ->
-  ([Text], ScriptResult)
+  PlutusWithContext c ->
+  ([Text], ScriptResult c)
 runPlutusScriptWithLogs pwc = toScriptResult <$> evaluatePlutusWithContext PV1.Quiet pwc
   where
     toScriptResult = \case
@@ -223,7 +238,7 @@ runPlutusScriptWithLogs pwc = toScriptResult <$> evaluatePlutusWithContext PV1.Q
 
 evaluatePlutusWithContext ::
   P.VerboseMode ->
-  PlutusWithContext ->
+  PlutusWithContext c ->
   ([Text], Either P.EvaluationError P.ExBudget)
 evaluatePlutusWithContext mode pwc@PlutusWithContext {..} =
   withRunnablePlutusWithContext pwc (([],) . Left) $ \plutusRunnable ->
@@ -245,9 +260,9 @@ evaluatePlutusWithContext mode pwc@PlutusWithContext {..} =
 -- way more information. But there is no guarantee the context data really can
 -- be decoded.
 explainPlutusEvaluationError ::
-  PlutusWithContext ->
+  PlutusWithContext c ->
   P.EvaluationError ->
-  ScriptResult
+  ScriptResult c
 explainPlutusEvaluationError pwc@PlutusWithContext {pwcProtocolVersion, pwcScript, pwcDatums} e =
   let lang = either plutusLanguage plutusLanguage pwcScript
       Plutus binaryScript = either id plutusFromRunnable pwcScript

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -266,7 +266,11 @@ explainPlutusEvaluationError ::
 explainPlutusEvaluationError pwc@PlutusWithContext {pwcProtocolVersion, pwcScript, pwcDatums} e =
   let lang = either plutusLanguage plutusLanguage pwcScript
       Plutus binaryScript = either id plutusFromRunnable pwcScript
-      firstLine = "The " ++ show lang ++ " script failed:"
+      firstLines =
+        [ "The " ++ show lang ++ " script failed:"
+        , "Base64-encoded script bytes:"
+        ]
+      shLine = "The script hash is:" ++ show (pwcScriptHash pwc)
       pvLine = "The protocol version is: " ++ show pwcProtocolVersion
       plutusError = "The plutus evaluation error is: " ++ show e
 
@@ -301,5 +305,5 @@ explainPlutusEvaluationError pwc@PlutusWithContext {pwcProtocolVersion, pwcScrip
             [ "Received an unexpected number of Data"
             , "The data is:\n" ++ show ds
             ]
-      line = pack . unlines $ "" : firstLine : show binaryScript : plutusError : pvLine : dataLines
+      line = pack . unlines $ "" : firstLines ++ show binaryScript : shLine : plutusError : pvLine : dataLines
    in scriptFail $ ScriptFailure line pwc

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Plutus.Evaluate (
   PlutusDatums (..),
   PlutusWithContext (..),
  )
-import Cardano.Ledger.Plutus.Language (Language (..))
+import Cardano.Ledger.Plutus.Language (Language (..), hashPlutusScript)
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val (inject)
@@ -83,7 +83,8 @@ collectTwoPhaseScriptInputsOutputOrdering = do
       [ withPlutusScript plutusScript $ \plutus ->
           PlutusWithContext
             { pwcProtocolVersion = pvMajor (pp apf ^. ppProtocolVersionL)
-            , pwcScript = Left $ plutus
+            , pwcScript = Left plutus
+            , pwcScriptHash = hashPlutusScript plutus
             , pwcDatums = PlutusDatums [unData @Alonzo datum, unData @Alonzo redeemer, context]
             , pwcExUnits = ExUnits 5000 5000
             , pwcCostModel = zeroTestingCostModel PlutusV1
@@ -160,7 +161,7 @@ collectInputs ::
   PParams era ->
   Tx era ->
   UTxO era ->
-  Either [CollectError era] [PlutusWithContext]
+  Either [CollectError era] [PlutusWithContext (EraCrypto era)]
 collectInputs Alonzo = collectPlutusScriptsWithContext
 collectInputs Babbage = collectPlutusScriptsWithContext
 collectInputs Conway = collectPlutusScriptsWithContext

--- a/libs/plutus-preprocessor/src/Debug.hs
+++ b/libs/plutus-preprocessor/src/Debug.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Plutus.Evaluate (debugPlutus)
 import System.Environment (getArgs)
 
 main :: IO ()
-main = print . debugPlutus . head =<< getArgs
+main = print . debugPlutus @StandardCrypto . head =<< getArgs


### PR DESCRIPTION
# Description
Resolves #3731 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
