### PR TITLE
Further proposals improvements. Take 2

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Rename `proposalsRemoveDescendentIds` to `proposalsRemoveWithDescendants` (fixed spelling too)
 * Rename:
   * `pfPParamUpdateL` to `grPParamUpdateL`
   * `pfHardForkL` to `grHardForkL`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -80,7 +80,7 @@ module Cardano.Ledger.Conway.Governance (
   grConstitutionL,
   proposalsActions,
   proposalsAddAction,
-  proposalsRemoveDescendentIds,
+  proposalsRemoveWithDescendants,
   proposalsAddVote,
   proposalsIds,
   proposalsApplyEnactment,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -434,13 +434,15 @@ proposalsApplyEnactment enactedGass expiredGais props =
               newGraph = Map.delete gpi $ withoutSiblings ^. pGraphL . forestL . pGraphNodesL
               (newOMap, enactedAction) =
                 OMap.extractKeys (Set.singleton gai) $ withoutSiblings ^. pPropsL
+              newProposals =
+                withoutSiblings
+                  & pGraphL . forestL . pGraphNodesL .~ newGraph
+                  & pRootsL . forestL . prRootL .~ SJust gpi -- Set the new root
+                  & pRootsL . forestL . prChildrenL .~ newRootChildren -- Set the new root children
+                  & pPropsL .~ newOMap
            in assert
                 (ps ^. pRootsL . forestL . prRootL == parent)
-                ( withoutSiblings
-                    & pGraphL . forestL . pGraphNodesL .~ newGraph
-                    & pRootsL . forestL . prRootL .~ SJust gpi -- Set the new root
-                    & pRootsL . forestL . prChildrenL .~ newRootChildren -- Set the new root children
-                    & pPropsL .~ newOMap
+                ( checkInvariantAfterDeletion (Set.singleton gai) withoutSiblings newProposals
                 , removed `Map.union` removedActions `Map.union` enactedAction
                 )
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -363,16 +363,16 @@ getAllDescendents ::
   GovActionId (EraCrypto era) ->
   Set (GovActionId (EraCrypto era))
 getAllDescendents (Proposals omap _roots graph) gai = case OMap.lookup gai omap of
-  Nothing -> Set.empty
+  Nothing -> assert False Set.empty
   Just gas -> withGovActionParent gas Set.empty $ \govRelationL _ ->
     let
-      go gpi =
+      go acc gpi =
         case Map.lookup gpi $ graph ^. govRelationL . pGraphNodesL of
           -- Impossible! getAllDescendents: GovPurposeId not found
           Nothing -> assert False mempty
-          Just (PEdges _parent children) -> children <> foldMap go children
+          Just (PEdges _parent children) -> foldl' go (children <> acc) children
      in
-      Set.map unGovPurposeId . go
+      Set.map unGovPurposeId . go Set.empty
 
 -- | Remove the set of given action-ids with their descendents from the
 -- @`Proposals`@ forest

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -330,8 +330,8 @@ ratifyTransition = do
 -- does match the last one of the same purpose that was enacted.
 prevActionAsExpected :: GovActionState era -> GovRelation StrictMaybe era -> Bool
 prevActionAsExpected gas prevGovActionIds =
-  withGovActionParent gas True $ \relationL parent _ ->
-    parent == prevGovActionIds ^. relationL
+  withGovActionParent gas True $ \govRelationL parent _ ->
+    parent == prevGovActionIds ^. govRelationL
 
 validCommitteeTerm ::
   ConwayEraPParams era =>


### PR DESCRIPTION
# Description

This is a follow up to: #4025

One important place where invariant was not verified was when enacted proposals are being removed. With adding the check there we no longer need to bother adding any other checks, as long as other internal functions are not being used for modifying the Proposals

Other changes are minor cleanups and performance improvements

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
