### PR TITLE
Add capability to hash `Plutus` scripts directly

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `alonzoScriptPrefixTag`
 * Add implementation for `getMinFeeTxUtxo`
 * Deprecated `indexRedeemers` and `redeemerPointer`.
 * Add `lookupRedeemer`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoPlutusPurpose (..),
   AlonzoScript (..),
   PlutusScript (..),
+  alonzoScriptPrefixTag,
   isPlutusScript,
  )
 import Cardano.Ledger.Babbage.Era
@@ -34,7 +35,6 @@ import Cardano.Ledger.Babbage.TxCert ()
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.SafeHash (SafeToHash (..))
-import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import Control.DeepSeq (NFData (..), rwhnf)
 import GHC.Generics
 import NoThunks.Class (NoThunks (..))
@@ -47,10 +47,7 @@ instance Crypto c => EraScript (BabbageEra c) where
     TimelockScript ts -> TimelockScript $ translateTimelock ts
     PlutusScript (AlonzoPlutusV1 ps) -> PlutusScript $ BabbagePlutusV1 ps
 
-  scriptPrefixTag = \case
-    TimelockScript _ -> nativeMultiSigTag -- "\x00"
-    PlutusScript (BabbagePlutusV1 _) -> "\x01"
-    PlutusScript (BabbagePlutusV2 _) -> "\x02"
+  scriptPrefixTag = alonzoScriptPrefixTag
 
   getNativeScript = \case
     TimelockScript ts -> Just ts

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -27,7 +27,12 @@ where
 
 import Cardano.Ledger.Address (RewardAccount)
 import Cardano.Ledger.Allegra.Scripts (Timelock, translateTimelock)
-import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), AlonzoScript (..), isPlutusScript)
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoPlutusPurpose (..),
+  AlonzoScript (..),
+  alonzoScriptPrefixTag,
+  isPlutusScript,
+ )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Scripts (PlutusScript (..))
 import Cardano.Ledger.BaseTypes (kindObject)
@@ -47,7 +52,6 @@ import Cardano.Ledger.Crypto
 import Cardano.Ledger.Mary.Value (PolicyID)
 import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.SafeHash (SafeToHash (..))
-import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (ToJSON (..), (.=))
@@ -74,11 +78,7 @@ instance Crypto c => EraScript (ConwayEra c) where
     PlutusScript (BabbagePlutusV1 ps) -> PlutusScript $ ConwayPlutusV1 ps
     PlutusScript (BabbagePlutusV2 ps) -> PlutusScript $ ConwayPlutusV2 ps
 
-  scriptPrefixTag = \case
-    TimelockScript _ -> nativeMultiSigTag -- "\x00"
-    PlutusScript (ConwayPlutusV1 _) -> "\x01"
-    PlutusScript (ConwayPlutusV2 _) -> "\x02"
-    PlutusScript (ConwayPlutusV3 _) -> "\x03"
+  scriptPrefixTag = alonzoScriptPrefixTag
 
   getNativeScript = \case
     TimelockScript ts -> Just ts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -59,10 +59,11 @@ import Cardano.Ledger.Binary (
 import qualified Cardano.Ledger.Binary.Plain as Plain (ToCBOR (..), encodePreEncoded)
 import Cardano.Ledger.Core (
   Era (EraCrypto),
-  EraScript (Script, hashScript),
+  EraScript (Script),
   EraTxWits (..),
   ScriptHash,
   eraProtVerLow,
+  hashScript,
  )
 import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import Cardano.Ledger.HKD (HKD)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
@@ -20,7 +20,7 @@ module Test.Cardano.Ledger.Shelley.Generator.Presets (
 )
 where
 
-import Cardano.Ledger.Core (EraScript (hashScript))
+import Cardano.Ledger.Core (EraScript, hashScript)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (
   GenDelegPair (..),

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -55,5 +55,5 @@ import Cardano.Ledger.Conway.Scripts (
   pattern ProposingPurpose,
   pattern VotingPurpose,
  )
-import Cardano.Ledger.Core (EraScript (..), isNativeScript, validateNativeScript)
+import Cardano.Ledger.Core (EraScript (..), hashScript, isNativeScript, validateNativeScript)
 import Cardano.Ledger.Hashes (ScriptHash)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Add `plutusLanguageTag` and `hashPlutusScript`
 * Add `setMinFeeTxUtxo`
 * Add `getMinFeeTxUtxo` to `EraUTxO`
 * Change signature by adding `refScriptsSize` parameter for:

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Extract `hashScript` outside of `EraScript` type class.
 * Add `plutusLanguageTag` and `hashPlutusScript`
 * Add `setMinFeeTxUtxo`
 * Add `getMinFeeTxUtxo` to `EraUTxO`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Core (
   EraTxAuxData (..),
   EraTxWits (..),
   EraScript (..),
+  hashScript,
   isNativeScript,
   hashScriptTxWitsL,
   Value,
@@ -550,21 +551,20 @@ class
 
   scriptPrefixTag :: Script era -> BS.ByteString
 
-  hashScript :: Script era -> ScriptHash (EraCrypto era)
-  -- ONE SHOULD NOT OVERIDE THE hashScript DEFAULT METHOD
-  -- UNLESS YOU UNDERSTAND THE SafeToHash class, AND THE ROLE OF THE scriptPrefixTag
-  hashScript =
-    ScriptHash
-      . Hash.castHash
-      . Hash.hashWith
-        (\x -> scriptPrefixTag @era x <> originalBytes x)
-
   getNativeScript :: Script era -> Maybe (NativeScript era)
 
   fromNativeScript :: NativeScript era -> Script era
 
 isNativeScript :: EraScript era => Script era -> Bool
 isNativeScript = isJust . getNativeScript
+
+-- | Compute `ScriptHash` of a `Script` for a particular era.
+hashScript :: forall era. EraScript era => Script era -> ScriptHash (EraCrypto era)
+hashScript =
+  ScriptHash
+    . Hash.castHash
+    . Hash.hashWith
+      (\x -> scriptPrefixTag @era x <> originalBytes x)
 
 --------------------------------------------------------------------------------
 -- Segregated Witness

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Ast.hs
@@ -13,7 +13,7 @@
 module Test.Cardano.Ledger.Constrained.Ast where
 
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
-import Cardano.Ledger.Core (Era (EraCrypto), EraScript (..), hashScript)
+import Cardano.Ledger.Core (Era (EraCrypto), hashScript)
 import Cardano.Ledger.Hashes (DataHash, ScriptHash (..))
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Data.Char (toLower)


### PR DESCRIPTION
# Description

This is going to be a useful function for some of the ongoing work #4030 and #4022

Also extract `hashScript` out of `EraScript` class for improved safety

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
