### PR TITLE
Fix the prose being inconsistent with the figure

### DIFF
--- a/eras/shelley/formal-spec/epoch.tex
+++ b/eras/shelley/formal-spec/epoch.tex
@@ -1392,7 +1392,7 @@ The $\fun{createRUpd}$ function does the following:
     labeled ``go'').
     As given by $\fun{maxPool}$, each pool can receive a maximal amount, determined by its
     performance.  The difference between the maximal amount and the actual amount received is
-    added to the amount moved to the treasury.
+    added to the amount moved to the reserves.
   \item The fee pot will be reduced by $\var{feeSS}$.
 \end{itemize}
 


### PR DESCRIPTION
# Description

Found by @HeinrichApfelmus. @TimSheard  can you check that the second field in `RewardUpdate` does go into the reserves in the code?

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
