### PR TITLE
Support for Plutus scripts in ImpTest

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.1.0
 
+* Add `NFData` instance for `AllegraUtxoPredFailure`
 * Add implementation for `getMinFeeTxUtxo`
 
 ## 1.3.0.0

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -65,6 +65,7 @@ import Cardano.Ledger.UTxO (
  )
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.Slot (SlotNo)
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
 import qualified Data.ByteString.Lazy as BSL (length)
@@ -134,6 +135,14 @@ instance
   , NoThunks (PPUPPredFailure era)
   ) =>
   NoThunks (AllegraUtxoPredFailure era)
+
+instance
+  ( Era era
+  , NFData (TxOut era)
+  , NFData (Value era)
+  , NFData (PPUPPredFailure era)
+  ) =>
+  NFData (AllegraUtxoPredFailure era)
 
 data AllegraUtxoEvent era
   = UpdateEvent (Event (EraRule "PPUP" era))

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -36,6 +36,8 @@ instance
 
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
 
+  fixupTx = shelleyFixupTx
+
 impAllegraSatisfyNativeScript ::
   (ShelleyEraImp era, NativeScript era ~ Timelock era) =>
   NativeScript era ->

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.7.0.0
 
+* Add `NFData` instances for:
+  * `CollectError`
+  * `AlonzoUtxoPredFailure`
+  * `FailureDescription`
+  * `TagMismatchDescription`
+  * `AlonzoUtxosPredFailure`
+  * `AlonzoUtxowPredFailure`
+* Add `Semigroup` and `Monoid` instances for `Redeemers`
 * Add `alonzoScriptPrefixTag`
 * Add implementation for `getMinFeeTxUtxo`
 * Deprecated `indexRedeemers` and `redeemerPointer`.
@@ -14,6 +22,11 @@
 * Add `SpendingPurpose`, `MintingPurpose`, `CertifyingPurpose`, `RewardingPurpose` pattern synonyms.
 * Add `getSpendingScriptsNeeded`, `getRewardingScriptsNeeded`, `getMintingScriptsNeeded`
 * Add `zipAsIxItem`
+
+### `testlib`
+
+* Add `Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec`
+* Add `alonzoFixupTx`, `impAddPlutusScript`
 
 ## 1.6.0.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -101,6 +101,8 @@ library testlib
         Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec
         Test.Cardano.Ledger.Alonzo.Binary.RoundTrip
         Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec
+        Test.Cardano.Ledger.Alonzo.Imp
+        Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec
         Test.Cardano.Ledger.Alonzo.ImpTest
         Test.Cardano.Ledger.Alonzo.TreeDiff
 
@@ -124,10 +126,12 @@ library testlib
         cardano-ledger-mary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-crypto-class,
+        cardano-strict-containers,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api,
         data-default-class,
         microlens,
+        microlens-mtl,
         text
 
 test-suite tests

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..))
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Control.DeepSeq (NFData)
 import Control.Monad (guard)
 import Data.Aeson (ToJSON (..), (.=), pattern String)
 import Data.List (intercalate)
@@ -77,6 +78,10 @@ deriving instance
 deriving instance
   (AlonzoEraScript era, NoThunks (ContextError era)) =>
   NoThunks (CollectError era)
+
+deriving instance
+  (AlonzoEraScript era, NFData (ContextError era)) =>
+  NFData (CollectError era)
 
 instance (AlonzoEraScript era, EncCBOR (ContextError era)) => EncCBOR (CollectError era) where
   encCBOR (NoRedeemer x) = encode $ Sum NoRedeemer 0 !> To x

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -94,6 +94,7 @@ import Cardano.Slotting.EpochInfo.API (EpochInfo, epochInfoSlotToUTCTime)
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Cardano.Slotting.Slot (SlotNo)
 import Cardano.Slotting.Time (SystemStart)
+import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (◁))
@@ -220,6 +221,15 @@ instance
   , NoThunks (TxOut era)
   ) =>
   NoThunks (AlonzoUtxoPredFailure era)
+
+instance
+  ( Era era
+  , NFData (Value era)
+  , NFData (UTxO era)
+  , NFData (PredicateFailure (EraRule "UTXOS" era))
+  , NFData (TxOut era)
+  ) =>
+  NFData (AlonzoUtxoPredFailure era)
 
 newtype AlonzoUtxoEvent era
   = UtxosEvent (Event (EraRule "UTXOS" era))

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -88,6 +88,7 @@ import Cardano.Ledger.UTxO (
  )
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Cardano.Slotting.Slot (SlotNo)
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (ReaderT, asks)
 import Control.State.Transition.Extended
 import Data.ByteString as BS (ByteString)
@@ -317,6 +318,8 @@ data FailureDescription
   = PlutusFailure Text BS.ByteString
   deriving (Show, Eq, Generic, NoThunks)
 
+instance NFData FailureDescription
+
 instance EncCBOR FailureDescription where
   -- This strange encoding results from the fact that 'FailureDescription'
   -- used to have another constructor, which used key 0.
@@ -338,6 +341,8 @@ data TagMismatchDescription
   = PassedUnexpectedly
   | FailedUnexpectedly (NonEmpty FailureDescription)
   deriving (Show, Eq, Generic, NoThunks)
+
+instance NFData TagMismatchDescription
 
 instance EncCBOR TagMismatchDescription where
   encCBOR PassedUnexpectedly = encode (Sum PassedUnexpectedly 0)
@@ -427,6 +432,15 @@ instance
   , NoThunks (PPUPPredFailure era)
   ) =>
   NoThunks (AlonzoUtxosPredFailure era)
+
+instance
+  ( AlonzoEraScript era
+  , NFData (TxCert era)
+  , NFData (ContextError era)
+  , NFData (Shelley.UTxOState era)
+  , NFData (PPUPPredFailure era)
+  ) =>
+  NFData (AlonzoUtxosPredFailure era)
 
 --------------------------------------------------------------------------------
 -- 2-phase checks

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -26,7 +26,7 @@ module Cardano.Ledger.Alonzo.Rules.Utxow (
 )
 where
 
-import Cardano.Crypto.DSIGN.Class (Signable)
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..), Signable)
 import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoUTXOW)
@@ -70,6 +70,7 @@ import Cardano.Ledger.Shelley.Tx (witsFromTxWitnesses)
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..))
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (domain, eval, (⊆), (➖))
 import Control.State.Transition.Extended
@@ -139,6 +140,14 @@ instance
   , NoThunks (PredicateFailure (EraRule "UTXO" era))
   ) =>
   NoThunks (AlonzoUtxowPredFailure era)
+
+instance
+  ( AlonzoEraScript era
+  , NFData (TxCert era)
+  , NFData (PredicateFailure (EraRule "UTXO" era))
+  , NFData (VerKeyDSIGN (DSIGN (EraCrypto era)))
+  ) =>
+  NFData (AlonzoUtxowPredFailure era)
 
 instance
   ( AlonzoEraScript era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -179,6 +179,12 @@ deriving newtype instance AlonzoEraScript era => NFData (Redeemers era)
 deriving newtype instance AlonzoEraScript era => NoThunks (Redeemers era)
 deriving instance AlonzoEraScript era => Show (Redeemers era)
 
+instance AlonzoEraScript era => Semigroup (Redeemers era) where
+  Redeemers x <> Redeemers y = Redeemers $ x <> y
+
+instance AlonzoEraScript era => Monoid (Redeemers era) where
+  mempty = Redeemers mempty
+
 -- =====================================================
 -- Pattern for Redeemers
 

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
@@ -21,6 +22,7 @@ main =
       roundTripJsonEraSpec @Alonzo
       describe "Imp" $ do
         ShelleyImp.spec @Alonzo
+        AlonzoImp.spec @Alonzo
       describe "CostModels" $ do
         CostModelsSpec.spec @Alonzo
       describe "TxWits" $ do

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Imp where
+
+import Cardano.Ledger.Alonzo.Core (AlonzoEraTxOut, AlonzoEraTxWits)
+import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
+import Test.Cardano.Ledger.Alonzo.ImpTest (ShelleyEraImp, withImpState)
+import Test.Cardano.Ledger.Common (Spec, describe)
+
+spec ::
+  forall era.
+  ( ShelleyEraImp era
+  , AlonzoEraTxWits era
+  , AlonzoEraTxOut era
+  ) =>
+  Spec
+spec =
+  describe "AlonzoImpTest" . withImpState @era $ do
+    Utxos.spec @era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Core (AlonzoEraTxOut (..), AlonzoEraTxWits (..))
+import Cardano.Ledger.BaseTypes (Inject (..), Network (..), StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (EraTx (..), EraTxBody (..), EraTxOut (..))
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Plutus.Data (Data (..), hashData)
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Lens.Micro ((&), (.~))
+import qualified PlutusLedgerApi.V1 as P
+import Test.Cardano.Ledger.Alonzo.ImpTest (
+  ImpTestState,
+  PlutusArgs (..),
+  ShelleyEraImp,
+  impAddPlutusScript,
+  submitTxAnn,
+  submitTxAnn_,
+ )
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Utils (txInAt)
+import Test.Cardano.Ledger.Plutus (ScriptTestContext (..))
+import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3)
+
+spec ::
+  forall era.
+  ( ShelleyEraImp era
+  , AlonzoEraTxWits era
+  , AlonzoEraTxOut era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXOS" $ do
+  it "Plutus script transactions are fixed up" $ do
+    let spendDatum = P.I 3
+    shSpending <-
+      impAddPlutusScript
+        ScriptTestContext
+          { stcScript = guessTheNumber3
+          , stcArgs =
+              PlutusArgs
+                { paSpendDatum = Just spendDatum
+                , paData = P.I 3
+                }
+          }
+    tx0 <-
+      submitTxAnn "Sumbit a transaction with a script output" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . outputsTxBodyL
+            .~ SSeq.singleton
+              ( mkBasicTxOut
+                  (Addr Testnet (ScriptHashObj shSpending) StakeRefNull)
+                  (inject (Coin 100))
+                  & dataHashTxOutL .~ SJust (hashData @era $ Data spendDatum)
+              )
+    submitTxAnn_ "Submit a transaction that consumes the script output" $
+      mkBasicTx mkBasicTxBody
+        & bodyTxL . inputsTxBodyL
+          .~ Set.singleton (txInAt (0 :: Int) tx0)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -1,43 +1,219 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.ImpTest (
   module ImpTest,
   initAlonzoImpNES,
+  PlutusArgs (..),
+  impAddPlutusScript,
+  alonzoFixupTx,
 ) where
 
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
 import Cardano.Crypto.Hash (Hash)
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppMaxValSizeL)
-import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Core (EraIndependentTxBody)
+import Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxOut (..), Era (..), EraGov)
+import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, getLanguageView, ppCostModelsL, ppMaxTxExUnitsL, ppMaxValSizeL)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), plutusScriptLanguage, toAsIndex)
+import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
+import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..))
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..), Redeemers (..), TxDats (..))
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (
+  EraIndependentTxBody,
+  EraScript (..),
+  EraTx (..),
+  EraTxBody (..),
+  EraTxWits (..),
+  ScriptHash,
+ )
 import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), binaryDataToData, hashData)
+import Cardano.Ledger.Plutus.Language (Language (..), Plutus, PlutusLanguage, hashPlutusScript)
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState,
   StashedAVVMAddresses,
   curPParamsEpochStateL,
+  esLStateL,
+  lsUTxOStateL,
   nesEsL,
+  utxosUtxoL,
  )
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), txinLookup)
+import Cardano.Ledger.TxIn (TxIn)
+import Control.Monad (forM)
 import Data.Default.Class (Default)
-import Lens.Micro ((&), (.~))
+import Data.Foldable (Foldable (..))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Lens.Micro ((%~), (&), (.~), (<>~), (^.))
+import Lens.Micro.Mtl (use, (%=), (.=))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Plutus (PlutusArgs (..), ScriptTestContext (..), testingCostModels)
 import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest
 
 initAlonzoImpNES ::
+  forall era.
   ( AlonzoEraPParams era
   , Default (StashedAVVMAddresses era)
   , ShelleyEraImp era
+  , AlonzoEraScript era
   ) =>
   Coin ->
   NewEpochState era
 initAlonzoImpNES rootCoin =
   initShelleyImpNES rootCoin
-    & nesEsL . curPParamsEpochStateL . ppMaxValSizeL .~ 1_000_000_000
+    & nesEsL . curPParamsEpochStateL %~ initPParams
+  where
+    initPParams pp =
+      pp
+        & ppMaxValSizeL .~ 1_000_000_000
+        & ppMaxTxExUnitsL .~ ExUnits 10_000_000 10_000_000
+        & ppCostModelsL
+          .~ testingCostModels
+            [PlutusV1 .. eraMaxLanguage @era]
+
+makeCollateralInput :: ImpTestM era (TxIn (EraCrypto era))
+makeCollateralInput = do
+  x : xs <- use impCollateralTxIdsL
+  impCollateralTxIdsL .= xs
+  pure x
+
+addCollateralInput ::
+  (AlonzoEraTxBody era, EraTx era) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+addCollateralInput tx = do
+  collInput <- makeCollateralInput
+  pure $
+    tx
+      & bodyTxL . collateralInputsTxBodyL <>~ Set.singleton collInput
+
+impLookupPlutusScript ::
+  AlonzoEraScript era =>
+  ScriptHash (EraCrypto era) ->
+  ImpTestM era (Maybe (PlutusScript era))
+impLookupPlutusScript sh = do
+  mbyCtx <- getScriptTestContext sh
+  case mbyCtx of
+    Just (ScriptTestContext plutus _) -> pure $ mkPlutusScript plutus
+    Nothing -> pure Nothing
+
+fixupPlutusScripts ::
+  forall era.
+  ( EraUTxO era
+  , EraGov era
+  , AlonzoEraTxBody era
+  , AlonzoEraTxWits era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+fixupPlutusScripts tx = do
+  utxo <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
+  let
+    txBody = tx ^. bodyTxL
+    AlonzoScriptsNeeded asn = getScriptsNeeded utxo txBody
+  mbyContexts <- forM asn $ \(prp, sh) -> do
+    ctx <- getScriptTestContext sh
+    pure $ (prp,sh,) <$> ctx
+  let
+    contexts = catMaybes mbyContexts
+    plutusToScript ::
+      forall l.
+      PlutusLanguage l =>
+      Plutus l ->
+      ImpTestM era (Script era)
+    plutusToScript p =
+      case mkPlutusScript @era p of
+        Just x -> pure $ fromPlutusScript x
+        Nothing -> error "Plutus version not supported by era"
+  scriptWits <- forM contexts $ \(_, sh, ScriptTestContext plutus _) ->
+    (sh,) <$> plutusToScript plutus
+  exUnits <- getsNES $ nesEsL . curPParamsEpochStateL . ppMaxTxExUnitsL
+  let
+    mkNewRedeemers (prpIdx, _, ScriptTestContext _ (PlutusArgs dat _)) =
+      (hoistPlutusPurpose @era toAsIndex prpIdx, (Data dat, exUnits))
+    newRedeemers = Redeemers . Map.fromList $ mkNewRedeemers <$> contexts
+    mkTxDats (_, _, ScriptTestContext _ (PlutusArgs _ datum)) =
+      (\d -> (hashData d, d)) . Data <$> datum
+    txDats = mkTxDats <$> contexts
+    mkInputDats txIn =
+      case txinLookup txIn utxo of
+        Just txOut ->
+          case txOut ^. datumTxOutF of
+            Datum bin -> do
+              let dat = binaryDataToData bin
+              Just (hashData dat, dat)
+            _ -> Nothing
+        Nothing -> error $ "TxIn not found in the UTxO: " <> show txIn
+    inputDats = mkInputDats <$> toList (txBody ^. inputsTxBodyL)
+  pure $
+    tx
+      & witsTxL . scriptTxWitsL <>~ Map.fromList scriptWits
+      & witsTxL . rdmrsTxWitsL <>~ newRedeemers
+      & witsTxL . datsTxWitsL
+        <>~ TxDats
+          (Map.fromList . catMaybes $ txDats ++ inputDats)
+
+fixupPPHash ::
+  forall era.
+  ( AlonzoEraTxBody era
+  , AlonzoEraTxWits era
+  , EraGov era
+  , EraUTxO era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+fixupPPHash tx = do
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  utxo <- getUTxO
+  let
+    scriptHashes :: Set (ScriptHash (EraCrypto era))
+    scriptHashes = getScriptsHashesNeeded . getScriptsNeeded utxo $ tx ^. bodyTxL
+    plutusLanguage sh = do
+      mbyPlutus <- impLookupPlutusScript sh
+      pure $ getLanguageView pp . plutusScriptLanguage <$> mbyPlutus
+  langs <- traverse plutusLanguage $ Set.toList scriptHashes
+  let
+    integrityHash =
+      hashScriptIntegrity
+        (Set.fromList $ catMaybes langs)
+        (tx ^. witsTxL . rdmrsTxWitsL)
+        (tx ^. witsTxL . datsTxWitsL)
+  pure $
+    tx
+      & bodyTxL . scriptIntegrityHashTxBodyL .~ integrityHash
+
+alonzoFixupTx ::
+  ( ShelleyEraImp era
+  , AlonzoEraTxWits era
+  , AlonzoEraTxBody era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+alonzoFixupTx =
+  addNativeScriptTxWits
+    >=> addCollateralInput
+    >=> addRootTxIn
+    >=> fixupPlutusScripts
+    >=> fixupPPHash
+    >=> fixupFees
+    >=> updateAddrTxWits
 
 instance
   ( Crypto c
@@ -49,3 +225,14 @@ instance
   where
   initImpNES = initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
+  fixupTx = alonzoFixupTx
+
+impAddPlutusScript ::
+  forall era.
+  AlonzoEraScript era =>
+  ScriptTestContext ->
+  ImpTestM era (ScriptHash (EraCrypto era))
+impAddPlutusScript stc@(ScriptTestContext plutus _) = do
+  let sh = hashPlutusScript plutus
+  impScriptsL %= Map.insert sh stc
+  pure sh

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `NFData` instance for `BabbageUtxoPredFailure`, `BabbageUtxowPredFailure`
 * Add implementation for `getMinFeeTxUtxo`
 * Add `getReferenceScriptsNonDistinct`
 * Add the constructor `BabbageNonDisjointRefInputs` to `BabbageUtxoPredFailure`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..), areAllAdaOnly, balance)
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val (inject, isAdaOnly, pointwise)
+import Control.DeepSeq (NFData)
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Reader (asks)
 import Control.SetAlgebra (eval, (◁))
@@ -138,6 +139,14 @@ deriving instance
   , Eq (TxIn (EraCrypto era))
   ) =>
   Eq (BabbageUtxoPredFailure era)
+
+instance
+  ( Era era
+  , NFData (Value era)
+  , NFData (TxOut era)
+  , NFData (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  NFData (BabbageUtxoPredFailure era)
 
 -- ===============================================
 -- Inject instances

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -24,7 +24,7 @@ module Cardano.Ledger.Babbage.Rules.Utxow (
 )
 where
 
-import Cardano.Crypto.DSIGN.Class (Signable)
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..), Signable)
 import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxowEvent (WrappedShelleyEraEvent),
@@ -63,6 +63,7 @@ import Cardano.Ledger.Shelley.Rules (
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.Tx (witsFromTxWitnesses)
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..))
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
   Embed (..),
@@ -165,6 +166,14 @@ deriving via
   InspectHeapNamed "BabbageUtxowPred" (BabbageUtxowPredFailure era)
   instance
     NoThunks (BabbageUtxowPredFailure era)
+
+instance
+  ( AlonzoEraScript era
+  , NFData (TxCert era)
+  , NFData (PredicateFailure (EraRule "UTXO" era))
+  , NFData (VerKeyDSIGN (DSIGN (EraCrypto era)))
+  ) =>
+  NFData (BabbageUtxowPredFailure era)
 
 -- ==================================================
 -- Reuseable tests first used in the Babbage Era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -10,7 +11,7 @@ import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (..))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
-import Test.Cardano.Ledger.Alonzo.ImpTest (initAlonzoImpNES)
+import Test.Cardano.Ledger.Alonzo.ImpTest (alonzoFixupTx, initAlonzoImpNES)
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp (..))
@@ -25,3 +26,4 @@ instance
   where
   initImpNES = initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
+  fixupTx = alonzoFixupTx

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `NFData` instance for `BabbageUtxoPredFailure`
 * Rename `MinFeeRefScriptCoinsPerByte` to `MinFeeRefScriptCostPerByte` and change its type from `CoinsPerByte` to `NonNegativeInterval` #4055
 * Rename `committeeQuorum` to `committeeThreshold` #4053
 * Changed `GovActionState` to have 1 field (`gasProposalProcedure`) rather than 3 (`gasDeposit`, `gasAction`, `gasReturnAddr`)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -61,6 +61,7 @@ import Cardano.Ledger.Shelley.Rules (
   validateStakePoolDelegateeRegistered,
   validateZeroRewards,
  )
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
   Embed (..),
@@ -108,6 +109,10 @@ deriving stock instance
 instance
   NoThunks (PredicateFailure (EraRule "CERT" era)) =>
   NoThunks (ConwayCertsPredFailure era)
+
+instance
+  NFData (PredicateFailure (EraRule "CERT" era)) =>
+  NFData (ConwayCertsPredFailure era)
 
 newtype ConwayCertsEvent era = CertEvent (Event (EraRule "CERT" era))
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -197,6 +197,8 @@ instance
 
   modifyPParams = conwayModifyPParams
 
+  fixupTx = alonzoFixupTx
+
 class
   ( ShelleyEraImp era
   , ConwayEraGov era
@@ -795,7 +797,7 @@ electCommittee ::
   Set.Set (Credential 'ColdCommitteeRole (EraCrypto era)) ->
   Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo ->
   ImpTestM era (GovPurposeId 'CommitteePurpose era)
-electCommittee prevGovId drep toRemove toAdd = do
+electCommittee prevGovId drep toRemove toAdd = impAnn "Electing committee" $ do
   let
     committeeAction =
       UpdateCommittee

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -15,6 +16,7 @@ import Test.Cardano.Ledger.Mary.TreeDiff ()
 import Test.Cardano.Ledger.Shelley.ImpTest (
   ShelleyEraImp (..),
   initShelleyImpNES,
+  shelleyFixupTx,
  )
 
 instance
@@ -27,3 +29,4 @@ instance
   where
   initImpNES = initShelleyImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
+  fixupTx = shelleyFixupTx

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -20,6 +20,19 @@
 ### `testlib`
 
 * Add:
+  * `PlutusArgs`
+  * `ScriptTestContext`
+  * `shelleyFixupTx`
+  * `getScriptTestContext`
+  * `updateAddrTxWits`
+  * `addNativeScriptTxWits`
+  * `addRootTxIn`
+  * `fixupFees`
+  * `logFeeMismatch`
+  * `impScriptsL`
+  * `impCollateralTxIdsL`
+  * `impNativeScriptsG`
+* Add:
   * `expectRegisteredRewardAddress`
   * `expectNotRegisteredRewardAddress`
   * `expectTreasury`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/LedgerSpec.hs
@@ -27,7 +27,7 @@ spec = describe "LEDGER" $ do
     kpPayment1 <- lookupKeyPair =<< freshKeyHash
     kpStaking1 <- lookupKeyPair =<< freshKeyHash
     UTxO utxo0 <- getUTxO
-    length utxo0 `shouldBe` 1
+    length utxo0 `shouldBe` 101
     let coin1 = Coin 1000
     tx1 <-
       submitTxAnn "First transaction" . mkBasicTx $

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### `testlib`
 
+* Add `PlutusArgs`, `ScriptTestContext`
 * Add `txInAt`
 * Add `mkScriptAddr`
 * Deprecate `deserialiseRewardAcntOld` in favor of `deserialiseRewardAccountOld`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Test.Cardano.Ledger.Plutus (
+  PlutusArgs (..),
+  ScriptTestContext (..),
+
   -- * Plutus
   alwaysSucceedsPlutus,
   alwaysFailsPlutus,
@@ -29,7 +33,7 @@ import Cardano.Ledger.Plutus.CostModels (
   mkCostModel,
   mkCostModels,
  )
-import Cardano.Ledger.Plutus.Language (Language (..), Plutus (..), PlutusBinary (..))
+import Cardano.Ledger.Plutus.Language (Language (..), Plutus (..), PlutusBinary (..), PlutusLanguage)
 import qualified Data.Map.Strict as Map
 import GHC.Stack
 import Numeric.Natural (Natural)
@@ -41,6 +45,19 @@ import qualified PlutusLedgerApi.Test.V1.EvaluationContext as PV1
 import qualified PlutusLedgerApi.Test.V2.EvaluationContext as PV2
 import qualified PlutusLedgerApi.Test.V3.EvaluationContext as PV3
 import PlutusLedgerApi.V1 as PV1
+
+data PlutusArgs = PlutusArgs
+  { paData :: Data
+  , paSpendDatum :: Maybe Data
+  }
+
+data ScriptTestContext where
+  ScriptTestContext ::
+    PlutusLanguage l =>
+    { stcScript :: Plutus l
+    , stcArgs :: PlutusArgs
+    } ->
+    ScriptTestContext
 
 -- | Construct a test cost model where all parameters are set to the same value
 mkCostModelConst :: HasCallStack => Language -> Integer -> CostModel


### PR DESCRIPTION
# Description

This PR adds the necessary fixup phases to make it possible to submit transactions which need to run scripts. I also converted the fixup pipeline to a point-free representation in order to improve readability and make it easier to modify the pipeline.

resolves #4022

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
