### PR TITLE
Fixed the 'All Tx are valid on traces of length 150'  intermittent bug

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -66,6 +66,7 @@ module Cardano.Ledger.Conway.Governance (
   PEdges (..),
   PGraph (..),
   pRootsL,
+  pPropsL,
   prRootL,
   prChildrenL,
   peChildrenL,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -70,6 +70,7 @@ library
         Test.Cardano.Ledger.Examples.AlonzoCollectInputs
         Test.Cardano.Ledger.Examples.AlonzoAPI
         Test.Cardano.Ledger.Examples.STSTestUtils
+        Test.Cardano.Ledger.EraClass
         Test.Cardano.Ledger.Generic.AggPropTests
         Test.Cardano.Ledger.Generic.ApplyTx
         Test.Cardano.Ledger.Generic.Indexed

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Pairing.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Pairing.hs
@@ -31,6 +31,7 @@ unpair z =
 
 -- Adapted from https://wiki.haskell.org/Generic_number_type
 squareRoot :: Int -> Int
+squareRoot n | n < 0 = error ("squareRoot works only for positive Int: " ++ show n)
 squareRoot 0 = 0
 squareRoot 1 = 1
 squareRoot n =
@@ -40,7 +41,9 @@ squareRoot n =
       newtonStep x = div (x + div n x) two
       iters = iterate newtonStep (squareRoot (div n lowerN) * lowerRoot)
       isRoot r = r ^ two <= n && n < (r + 1) ^ two
-   in head $ dropWhile (not . isRoot) iters
+   in case dropWhile (not . isRoot) iters of
+        (r : _) -> r
+        [] -> error ("Not possible, every positive Int has an Integral square root: " ++ show n)
 
 -- Defeat type defaulting without specifying the type every time.
 two :: Int

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -568,9 +568,9 @@ synopsis rep@(MapR a b) mp = case Map.toList mp of
   ((d, r) : _) -> "Map{" ++ synopsis a d ++ " -> " ++ synopsis b r ++ " | size = " ++ show (Map.size mp) ++ synSum rep mp ++ "}"
 synopsis (SetR IntR) x = "Set" ++ show (Set.toList x)
 synopsis (SetR Word64R) x = "Set" ++ show (Set.toList x)
-synopsis rep@(SetR a) t
-  | Set.null t = "(empty::Set " ++ show a ++ ")"
-  | otherwise = "Set{" ++ synopsis a (head (Set.elems t)) ++ " | size = " ++ show (Set.size t) ++ synSum rep t ++ "}"
+synopsis rep@(SetR a) t = case Set.elems t of
+  [] -> "(empty::Set " ++ show a ++ ")"
+  (h : _) -> "Set{" ++ synopsis a h ++ " | size = " ++ show (Set.size t) ++ synSum rep t ++ "}"
 synopsis (ListR IntR) x = show x
 synopsis (ListR Word64R) x = show x
 synopsis rep@(ListR a) ll = case ll of

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/EraClass.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/EraClass.hs
@@ -1,0 +1,156 @@
+-- | Everything you need to build Era polymorphic transactions, all in one place
+module Test.Cardano.Ledger.EraClass (
+  Era (EraCrypto),
+  -- Tx
+  EraTx (Tx, mkBasicTx, bodyTxL, witsTxL),
+  AlonzoEraTx (isValidTxL),
+  -- TxBody
+  EraTxBody (TxBody, mkBasicTxBody, inputsTxBodyL, outputsTxBodyL, feeTxBodyL, withdrawalsTxBodyL, auxDataHashTxBodyL, certsTxBodyL),
+  AllegraEraTxBody (vldtTxBodyL),
+  MaryEraTxBody (mintTxBodyL, mintValueTxBodyF, mintedTxBodyF),
+  AlonzoEraTxBody (
+    collateralInputsTxBodyL,
+    reqSignerHashesTxBodyL,
+    scriptIntegrityHashTxBodyL,
+    networkIdTxBodyL,
+    redeemerPointer,
+    redeemerPointerInverse
+  ),
+  ConwayEraTxBody (currentTreasuryValueTxBodyL, votingProceduresTxBodyL, proposalProceduresTxBodyL, treasuryDonationTxBodyL),
+  -- TxOut
+  EraTxOut (TxOut, mkBasicTxOut, valueTxOutL, compactValueTxOutL, valueEitherTxOutL, addrTxOutL, compactAddrTxOutL, addrEitherTxOutL),
+  AlonzoEraTxOut (dataHashTxOutL, datumTxOutF),
+  BabbageEraTxOut (referenceScriptTxOutL, dataTxOutL, datumTxOutL),
+  coinTxOutL,
+  -- TxWits
+  EraTxWits (TxWits, mkBasicTxWits, addrTxWitsL, bootAddrTxWitsL, scriptTxWitsL),
+  AlonzoEraTxWits (datsTxWitsL, rdmrsTxWitsL),
+  -- TxAuxData
+  EraTxAuxData (TxAuxData, hashTxAuxData, validateTxAuxData),
+  -- TxCerts
+  EraTxCert (
+    TxCert,
+    getVKeyWitnessTxCert,
+    getScriptWitnessTxCert,
+    mkRegPoolTxCert,
+    getRegPoolTxCert,
+    mkRetirePoolTxCert,
+    getRetirePoolTxCert,
+    lookupRegStakeTxCert,
+    lookupUnRegStakeTxCert,
+    getTotalDepositsTxCerts,
+    getTotalRefundsTxCerts
+  ),
+  ConwayEraTxCert (
+    mkRegDepositTxCert,
+    getRegDepositTxCert,
+    mkUnRegDepositTxCert,
+    getUnRegDepositTxCert,
+    mkDelegTxCert,
+    getDelegTxCert,
+    mkRegDepositDelegTxCert,
+    getRegDepositDelegTxCert,
+    mkAuthCommitteeHotKeyTxCert,
+    getAuthCommitteeHotKeyTxCert,
+    mkResignCommitteeColdTxCert,
+    getResignCommitteeColdTxCert,
+    mkRegDRepTxCert,
+    getRegDRepTxCert,
+    mkUnRegDRepTxCert,
+    getUnRegDRepTxCert,
+    mkUpdateDRepTxCert,
+    getUpdateDRepTxCert
+  ),
+  -- PParams
+  EraPParams (ppProtocolVersionL),
+  PParams,
+  emptyPParams,
+  ppMinFeeAL,
+  ppMinFeeBL,
+  ppMaxBBSizeL,
+  ppMaxTxSizeL,
+  ppMaxBHSizeL,
+  ppKeyDepositL,
+  ppPoolDepositL,
+  ppEMaxL,
+  ppNOptL,
+  ppA0L,
+  ppRhoL,
+  ppTauL,
+  ppDL,
+  -- PParamUpdate
+  PParamsUpdate,
+  emptyPParamsUpdate,
+  ppuMinFeeAL,
+  ppuMinFeeBL,
+  ppuMaxBBSizeL,
+  ppuMaxTxSizeL,
+  ppuMaxBHSizeL,
+  ppuKeyDepositL,
+  ppuPoolDepositL,
+  ppuEMaxL,
+  ppuNOptL,
+  ppuA0L,
+  ppuRhoL,
+  ppuTauL,
+  ppuDL,
+  -- Alonzo
+  AlonzoEraPParams,
+  ppCoinsPerUTxOWordL,
+  ppCostModelsL,
+  ppPricesL,
+  ppMaxTxExUnitsL,
+  ppMaxBlockExUnitsL,
+  ppMaxValSizeL,
+  ppCollateralPercentageL,
+  ppMaxCollateralInputsL,
+  ppuCoinsPerUTxOWordL,
+  ppuCostModelsL,
+  ppuPricesL,
+  ppuMaxTxExUnitsL,
+  ppuMaxBlockExUnitsL,
+  ppuMaxValSizeL,
+  ppuCollateralPercentageL,
+  ppuMaxCollateralInputsL,
+  -- Babbage
+  BabbageEraPParams (..),
+  ppCoinsPerUTxOByteL,
+  ppuCoinsPerUTxOByteL,
+  -- Conway
+  ConwayEraPParams,
+  ppPoolVotingThresholdsL,
+  ppDRepVotingThresholdsL,
+  ppCommitteeMinSizeL,
+  ppCommitteeMaxTermLengthL,
+  ppGovActionLifetimeL,
+  ppGovActionDepositL,
+  ppDRepDepositL,
+  ppDRepActivityL,
+  ppMinFeeRefScriptCoinsPerByteL,
+  ppuPoolVotingThresholdsL,
+  ppuDRepVotingThresholdsL,
+  ppuCommitteeMinSizeL,
+  ppuCommitteeMaxTermLengthL,
+  ppuGovActionLifetimeL,
+  ppuGovActionDepositL,
+  ppuDRepDepositL,
+  ppuDRepActivityL,
+  ppuMinFeeRefScriptCoinsPerByteL,
+  -- Scripts
+  EraScript (Script, NativeScript, getNativeScript, fromNativeScript),
+  hashScript,
+) where
+
+import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..))
+import Cardano.Ledger.Alonzo.PParams
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..))
+import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..))
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
+import Cardano.Ledger.Babbage.PParams (BabbageEraPParams (..), ppCoinsPerUTxOByteL, ppuCoinsPerUTxOByteL)
+import Cardano.Ledger.Babbage.TxOut (BabbageEraTxOut (..))
+import Cardano.Ledger.Conway.PParams
+import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
+import Cardano.Ledger.Conway.TxCert (ConwayEraTxCert (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Mary.TxBody (MaryEraTxBody (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -1406,8 +1406,7 @@ babbageFeatures =
 
 testExpectUTXOFailure ::
   forall era.
-  ( State (EraRule "UTXO" era) ~ UTxOState era
-  , PostShelley era
+  ( PostShelley era
   , Reflect era
   , BabbageEraTxBody era
   ) =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -504,7 +504,13 @@ whichScript Conway = ScriptAlonzoToConway
 
 data GovStateWit era where
   GovStateShelleyToBabbage :: (EraGov era, GovState era ~ ShelleyGovState era) => GovStateWit era
-  GovStateConwayToConway :: (RunConwayRatify era, EraGov era, GovState era ~ ConwayGovState era) => GovStateWit era
+  GovStateConwayToConway ::
+    ( ConwayEraPParams era
+    , RunConwayRatify era
+    , EraGov era
+    , GovState era ~ ConwayGovState era
+    ) =>
+    GovStateWit era
 
 whichGovState :: Proof era -> GovStateWit era
 whichGovState Shelley = GovStateShelleyToBabbage

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -426,12 +426,12 @@ instance
 
 mapProportion :: EpochNo -> Word64 -> Int -> Map.Map k Int -> Gen k
 mapProportion epochnum lastSlot count m =
-  if null pairs
-    then -- TODO, we need to figure out why this occurs. It always occurs near SlotNo 300, So I am assuming that
-    -- sometimes as we move into the 3rd epoch, however stakeDistr is computed becomes empty. This is probably
-    -- because there is to action in Test.Cardano.Ledger.Constrained.Trace.Actions for the epoch boundary.
-    -- This temporary fix is good enough for now. But the annoying trace message reminds us to fix this.
-
+  case pairs of
+    [] ->
+      -- TODO, we need to figure out why this occurs. It always occurs near SlotNo 300, So I am assuming that
+      -- sometimes as we move into the 3rd epoch, however stakeDistr is computed becomes empty. This is probably
+      -- because there is no action in Test.Cardano.Ledger.Constrained.Trace.Actions for the epoch boundary.
+      -- This temporary fix is good enough for now. But the annoying trace message reminds us to fix this.
       trace
         ( "There are no stakepools to choose an issuer from"
             ++ ", epoch="
@@ -442,9 +442,9 @@ mapProportion epochnum lastSlot count m =
             ++ show count
         )
         discard
-    else
+    (w : _) ->
       if all (\(n, _k) -> n == 0) pairs
-        then snd (head pairs) -- All stakepools have zero Stake, choose issuer arbitrarily. possible, but rare.
+        then snd w -- All stakepools have zero Stake, choose issuer arbitrarily. possible, but rare.
         else frequency pairs
   where
     pairs = [(n, pure k) | (k, n) <- Map.toList m]

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -485,7 +485,12 @@ listSumRange = constrained $ \xs ->
 listSumRangeUpper :: Numbery a => Spec Fn [a]
 listSumRangeUpper = constrained $ \xs ->
   let n = sum_ xs
-   in [ forAll xs $ \x -> x <. 5
+   in -- All it takes is one big negative number,
+      -- then we can't get enough small ones to exceed 10
+      -- in the number of tries allowed.
+      -- So we make x relatively large ( <. 12), If its is
+      -- relatively small ( <. 5), we can get unlucky.
+      [ forAll xs $ \x -> [x <. 12]
       , assert $ n <. 20
       , assert $ 10 <. n
       ]


### PR DESCRIPTION
Fixed the 'All Tx are valid on traces of length 150' bug.
This was occasionally triggered at the Epoch boundary when a ParameterChange Proposal was passed, 
and the PParamUpdate made random (stupid) changes to fields that made the Tx in the trace no longer valid.
Prime candidates were PParam fields that affected the computation of the fee, legal Tx sizes, and min txout values, etc. 
Added function 'reasonable' to ensure bad PParamUpdates are not used. Allows users to adjust PParamUpdates in Proposals
Added EraClass -- Everything you need to build Era polymorphic Tx, all in one place

I ran this test 1000's of times without a failure while I ate dinner. I hope we have fixed it for good.
Fixes #4057 addressing the  '/listSumRangeUpper.Int8.prop_sound/' bug, because it made the tests fail.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
