### PR TITLE
Reduce duplication in Conway UTXOW rule

### DIFF
--- a/eras/alonzo/formal-spec/utxo.tex
+++ b/eras/alonzo/formal-spec/utxo.tex
@@ -885,7 +885,7 @@ by the UTXO transition (the application of which is also part of the conditions)
       \lor
       (\var{adh}=\fun{hashAD}~\var{ad})
       \\~\\
-      \hldiff{\fun{languages}~{txw} \subseteq \dom(\fun{costmdls}~tx)} \\
+      \hldiff{\fun{languages}~{txw} \subseteq \dom(\fun{costmdls}~{pp})} \\
       \hldiff{\fun{scriptIntegrityHash}~{txb} = 
         \fun{hashScriptIntegrity}~\var{pp}~(\fun{languages}~{txw})~(\fun{txrdmrs}~{txw})~(\fun{txdats}~{txw})}
       \\~\\

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -352,10 +352,9 @@ alonzoStyleWitness = do
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
   runTestOnSignal $ Shelley.validateMetadata pp tx
 
-  {- languages txw ⊆ dom(costmdls tx)  -}
+  {- languages txw ⊆ dom(costmdls pp)  -}
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails
-  -- It raises 'NoCostModel' a construcotr of the predicate failure 'CollectError'. This check
-  -- which appears in the spec, seems broken since costmdls is a projection of PParams, not Tx
+  -- It raises 'NoCostModel' a constructor of the predicate failure 'CollectError'.
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptsHashesNeeded

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -299,7 +299,7 @@ alonzoStyleWitness ::
   ) =>
   TransitionRule (AlonzoUTXOW era)
 alonzoStyleWitness = do
-  (TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx)) <- judgmentContext
+  TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx) <- judgmentContext
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -350,8 +350,7 @@ alonzoStyleWitness = do
   -- check metadata hash
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  runTestOnSignal $
-    Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp tx
 
   {- languages txw ⊆ dom(costmdls tx)  -}
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -343,10 +343,9 @@ babbageUtxowTransition = do
   -- Note that Datum validation is done during deserialization,
   -- as given by the decoders in the Plutus libraray
 
-  {- languages tx utxo ⊆ dom(costmdls tx) -}
+  {- languages tx utxo ⊆ dom(costmdls pp) -}
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails
-  -- It raises 'NoCostModel' a construcotr of the predicate failure 'CollectError'. This check
-  -- which appears in the spec, seems broken since costmdls is a projection of PParams, not Tx
+  -- It raises 'NoCostModel' a construcotr of the predicate failure 'CollectError'.
 
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ ppViewHashesMatch tx pp scriptsProvided scriptHashesNeeded


### PR DESCRIPTION
# Description

Fixes #3916 

The only difference between Conway's and Babbage's UTXOW rule implementation is that latter has MIR certificate witness validation.

This PR extract MIR validation into a separate action and uses it only in Babbage, while the rest of the logic is reused in Conway.

This PR also fixes a small issue in Alonzo spec, where `costmdls` was applied to `tx` instead of `pp`, which was noted in the rule.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
