### PR TITLE
Fix `ToJSON` instance of `BoundedRatio` to avoid precision loss

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Fix `ToJSON`/`FromJSON` instances of `Prices`
 * Update `FromJSON` instance of `BoundedRatio`
 * Fix `ToJSON` instance of `BoundedRatio` to avoid precision loss
 * Add `pwcScriptHash` field to `PlutusWithContext`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.11.0.0
 
+* Update `FromJSON` instance of `BoundedRatio`
+* Fix `ToJSON` instance of `BoundedRatio` to avoid precision loss
 * Add `pwcScriptHash` field to `PlutusWithContext`
 * Parameterize `PlutusWithContext c` on crypto.
 * Extract `hashScript` outside of `EraScript` type class.
@@ -24,6 +26,7 @@
 
 ### `testlib`
 
+* Remove `epsilonMaybeEq` from `Utils`
 * Add `PlutusArgs`, `ScriptTestContext`
 * Add `txInAt`
 * Add `mkScriptAddr`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -306,12 +306,12 @@ fromRationalBoundedRatio r
 -- when in doubt.
 fromRatioBoundedRatio ::
   forall b a.
-  (Bounded (BoundedRatio b a), Integral a) =>
+  (Bounded a, Bounded (BoundedRatio b a), Integral a) =>
   Ratio a ->
   Maybe (BoundedRatio b a)
 fromRatioBoundedRatio ratio
-  | r < toRationalBoundedRatio lowerBound
-      || r > toRationalBoundedRatio upperBound =
+  | r < unboundRational lowerBound
+      || r > unboundRational upperBound =
       Nothing -- ensure valid range
   | otherwise = Just $ BoundedRatio ratio
   where
@@ -328,7 +328,7 @@ instance
   where
   decCBOR = do
     r <- decodeRationalWithTag
-    case fromRationalBoundedRatio r of
+    case boundRational r of
       Nothing ->
         cborError $ DecoderErrorCustom "BoundedRatio" (Text.pack $ show r)
       Just u -> pure u

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -138,7 +138,7 @@ import Data.Aeson (
   FromJSON (..),
   KeyValue,
   ToJSON (..),
-  Value,
+  Value (..),
   object,
   pairs,
   withObject,
@@ -161,8 +161,8 @@ import Data.Scientific (
   Scientific,
   base10Exponent,
   coefficient,
+  fromRationalRepetendLimited,
   normalize,
-  scientific,
  )
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -333,48 +333,41 @@ instance
         cborError $ DecoderErrorCustom "BoundedRatio" (Text.pack $ show r)
       Just u -> pure u
 
-instance ToJSON (BoundedRatio b Word64) where
-  toJSON = toJSON . toScientificBoundedRatioWord64WithRounding
-
-toScientificBoundedRatioWord64WithRounding :: BoundedRatio b Word64 -> Scientific
-toScientificBoundedRatioWord64WithRounding (toRationalBoundedRatio -> ur) =
-  scientific q 0 + scientific ((r * scale) `quot` d) (negate exp10)
-  where
-    n = numerator ur
-    d = denominator ur
-    (q, r) = n `quotRem` d
-    -- We need to reduce precision for numbers bigger than 1 in order to make them
-    -- parsable without overflowing
-    exp10 = 19 - min 19 (numDigits q)
-    scale = 10 ^ exp10
-    numDigits :: Integer -> Int
-    numDigits = go 0
-      where
-        go ds 0 = ds
-        go ds i = ds `seq` go (ds + 1) (i `quot` 10)
+instance Bounded (BoundedRatio b Word64) => ToJSON (BoundedRatio b Word64) where
+  toJSON = toRationalJSON . unboundRational
+    where
+      toRationalJSON r = case fromRationalRepetendLimited 19 r of
+        Right (s, Nothing) -> toJSON s
+        _ -> toJSON r
 
 instance Bounded (BoundedRatio b Word64) => FromJSON (BoundedRatio b Word64) where
-  parseJSON = either fail pure . fromScientificBoundedRatioWord64 <=< parseJSON
+  parseJSON = \case
+    rational@(Object _) -> parseWith fromRationalEither rational
+    sci -> parseWith fromScientificBoundedRatioWord64 sci
+    where
+      parseWith f = either fail pure . f <=< parseJSON
 
 fromScientificBoundedRatioWord64 ::
   Bounded (BoundedRatio b Word64) =>
   Scientific ->
   Either String (BoundedRatio b Word64)
 fromScientificBoundedRatioWord64 (normalize -> sci)
-  | coeff < 0 = failWith "negative"
+  | coeff < 0 = failWith "negative" sci
   | exp10 <= 0 = do
-      when (exp10 < -19) $ failWith "too precise"
+      when (exp10 < -19) $ failWith "too precise" sci
       fromRationalEither (coeff % (10 ^ negate exp10))
   | otherwise = do
-      when (19 < exp10) $ failWith "too big"
+      when (19 < exp10) $ failWith "too big" sci
       fromRationalEither (coeff * 10 ^ exp10 % 1)
   where
     coeff = coefficient sci
     exp10 = base10Exponent sci
-    failWith :: String -> Either String a
-    failWith msg = Left $ "Value is " ++ msg ++ ": " ++ show sci
-    fromRationalEither =
-      maybe (failWith "outside of bounds") Right . fromRationalBoundedRatio
+
+fromRationalEither :: Bounded (BoundedRatio b Word64) => Rational -> Either String (BoundedRatio b Word64)
+fromRationalEither r = maybe (failWith "outside of bounds" r) Right $ boundRational r
+
+failWith :: Show a => String -> a -> Either String b
+failWith msg val = Left $ "Value is " <> msg <> ": " <> show val
 
 -- | Type to represent a value in the interval [0; +∞)
 newtype NonNegativeInterval

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -176,6 +176,9 @@ import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 import Quiet (Quiet (Quiet))
 
+maxDecimalsWord64 :: Int
+maxDecimalsWord64 = 19
+
 data ProtVer = ProtVer {pvMajor :: !Version, pvMinor :: !Natural}
   deriving (Show, Eq, Generic, Ord, NFData)
   deriving (EncCBOR) via (CBORGroup ProtVer)
@@ -336,7 +339,7 @@ instance
 instance Bounded (BoundedRatio b Word64) => ToJSON (BoundedRatio b Word64) where
   toJSON = toRationalJSON . unboundRational
     where
-      toRationalJSON r = case fromRationalRepetendLimited 19 r of
+      toRationalJSON r = case fromRationalRepetendLimited maxDecimalsWord64 r of
         Right (s, Nothing) -> toJSON s
         _ -> toJSON r
 
@@ -354,10 +357,10 @@ fromScientificBoundedRatioWord64 ::
 fromScientificBoundedRatioWord64 (normalize -> sci)
   | coeff < 0 = failWith "negative" sci
   | exp10 <= 0 = do
-      when (exp10 < -19) $ failWith "too precise" sci
+      when (exp10 < -maxDecimalsWord64) $ failWith "too precise" sci
       fromRationalEither (coeff % (10 ^ negate exp10))
   | otherwise = do
-      when (19 < exp10) $ failWith "too big" sci
+      when (maxDecimalsWord64 < exp10) $ failWith "too big" sci
       fromRationalEither (coeff * 10 ^ exp10 % 1)
   where
     coeff = coefficient sci
@@ -411,7 +414,7 @@ instance Bounded (BoundedRatio PositiveInterval Word64) where
 
 -- | The smallest decimal value that can roundtrip JSON
 positiveIntervalEpsilon :: BoundedRatio b Word64
-positiveIntervalEpsilon = BoundedRatio (1 % 10 ^ (19 :: Int))
+positiveIntervalEpsilon = BoundedRatio (1 % 10 ^ (maxDecimalsWord64 :: Int))
 
 -- | Type to represent a value in the unit interval (0; 1]
 newtype PositiveUnitInterval

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
@@ -31,7 +31,6 @@ where
 import Cardano.Ledger.BaseTypes (
   BoundedRational (unboundRational),
   NonNegativeInterval,
-  boundRational,
  )
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
@@ -166,28 +165,9 @@ instance NoThunks Prices
 
 instance NFData Prices
 
-instance ToJSON Prices where
-  toJSON Prices {prSteps, prMem} =
-    -- We cannot round-trip via NonNegativeInterval, so we go via Rational
-    object
-      [ "prSteps" .= toRationalJSON (unboundRational prSteps)
-      , "prMem" .= toRationalJSON (unboundRational prMem)
-      ]
+instance ToJSON Prices
 
-instance FromJSON Prices where
-  parseJSON =
-    withObject "prices" $ \o -> do
-      steps <- o .: "prSteps"
-      mem <- o .: "prMem"
-      prSteps <- checkBoundedRational steps
-      prMem <- checkBoundedRational mem
-      return Prices {prSteps, prMem}
-    where
-      -- We cannot round-trip via NonNegativeInterval, so we go via Rational
-      checkBoundedRational r =
-        case boundRational r of
-          Nothing -> fail ("too much precision for bounded rational: " ++ show r)
-          Just s -> return s
+instance FromJSON Prices
 
 -- | Compute the cost of a script based upon prices and the number of execution
 -- units.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
@@ -59,11 +59,9 @@ import Data.Aeson (
   (.:),
   (.=),
  )
-import qualified Data.Aeson as Aeson (Value)
 import Data.DerivingVia (InstantiatedAt (..))
 import Data.Int (Int64)
 import Data.Measure (BoundedMeasure, Measure)
-import Data.Scientific (fromRationalRepetendLimited)
 import Data.Semigroup (All (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -175,12 +173,6 @@ instance ToJSON Prices where
       [ "prSteps" .= toRationalJSON (unboundRational prSteps)
       , "prMem" .= toRationalJSON (unboundRational prMem)
       ]
-
-toRationalJSON :: Rational -> Aeson.Value
-toRationalJSON r =
-  case fromRationalRepetendLimited 20 r of
-    Right (s, Nothing) -> toJSON s
-    _ -> toJSON r
 
 instance FromJSON Prices where
   parseJSON =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ExUnits.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -15,7 +14,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Plutus.ExUnits (

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -158,6 +158,9 @@ import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
 import Test.QuickCheck
 import Test.QuickCheck.Hedgehog (hedgehog)
 
+maxDecimalsWord64 :: Int
+maxDecimalsWord64 = 19
+
 instance (Era era, EncCBOR (f era), Arbitrary (f era)) => Arbitrary (Sized (f era)) where
   arbitrary = mkSized (eraProtVerHigh @era) <$> arbitrary
 
@@ -211,7 +214,7 @@ instance Arbitrary Port where
 -- | Decimal numbers only
 instance Arbitrary UnitInterval where
   arbitrary = do
-    p <- chooseInt (0, 19)
+    p <- chooseInt (0, maxDecimalsWord64)
     let y = 10 ^ p :: Word64
     x <- choose (0, y)
     pure $ unsafeBoundRational $ promoteRatio (x % y)
@@ -219,7 +222,7 @@ instance Arbitrary UnitInterval where
 -- | Decimal numbers only
 instance Arbitrary PositiveUnitInterval where
   arbitrary = do
-    p <- chooseInt (0, 19)
+    p <- chooseInt (0, maxDecimalsWord64)
     let y = 10 ^ p :: Word64
     x <- choose (1, y)
     pure $ unsafeBoundRational $ promoteRatio (x % y)
@@ -227,17 +230,17 @@ instance Arbitrary PositiveUnitInterval where
 -- | Decimal numbers only
 instance Arbitrary PositiveInterval where
   arbitrary = do
-    p <- chooseInt (0, 19)
+    p <- chooseInt (0, maxDecimalsWord64)
     let y = 10 ^ p :: Word64
-    x <- choose (1, 10 ^ (19 :: Int))
+    x <- choose (1, 10 ^ (maxDecimalsWord64 :: Int))
     pure $ unsafeBoundRational $ promoteRatio (x % y)
 
 -- | Decimal numbers only
 instance Arbitrary NonNegativeInterval where
   arbitrary = do
-    p <- chooseInt (0, 19)
+    p <- chooseInt (0, maxDecimalsWord64)
     let y = 10 ^ p :: Word64
-    x <- choose (0, 10 ^ (19 :: Int))
+    x <- choose (0, 10 ^ (maxDecimalsWord64 :: Int))
     pure $ unsafeBoundRational $ promoteRatio (x % y)
 
 instance Validity UnitInterval where

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
@@ -3,7 +3,6 @@
 
 module Test.Cardano.Ledger.Core.Utils (
   unsafeBoundRational,
-  epsilonMaybeEq,
   testGlobals,
   mkDummySafeHash,
   txInAt,
@@ -27,26 +26,6 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Rational (unsafeBoundRational)
-
--- | This test for equality takes into account magnitude of the arguments
-epsilonMaybeEq ::
-  -- | Epsilon, a maximum tolerated error. Sign is ignored.
-  Rational ->
-  -- | Expected result.
-  Rational ->
-  -- | Tested value.
-  Rational ->
-  Property
-epsilonMaybeEq epsilon x y =
-  counterexample
-    ( concat
-        [show x, " /= ", show y, " (Tolerance: ", show diff, " > ", show n, ")"]
-    )
-    (classify True "Exactly" (x === y) .||. diff <= n)
-  where
-    (absx, absy) = (abs x, abs y)
-    n = epsilon * (1 + max absx absy)
-    diff = abs (y - x)
 
 testGlobals :: Globals
 testGlobals =


### PR DESCRIPTION
# Description
Resolves #4026 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
