### PR TITLE
Enable Plutus v1 reference scripts in Conway

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -28,6 +28,13 @@
 
 ### `testlib`
 
+* Add:
+  * `impLookupPlutusScript`
+  * `fixupPPHash`
+  * `fixupPlutusScripts`
+  * `addCollateralInput`
+  * `impGetPlutusContexts`
+  * `fixupDatums`
 * Add `Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec`
 * Add `alonzoFixupTx`, `impAddPlutusScript`
 

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `babbageFixupTx`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add `NFData` instance for `BabbageUtxoPredFailure`, `BabbageUtxowPredFailure`
 * Add implementation for `getMinFeeTxUtxo`

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -1,17 +1,38 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Babbage.ImpTest () where
+module Test.Cardano.Ledger.Babbage.ImpTest (babbageFixupTx) where
 
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
 import Cardano.Crypto.Hash (Hash)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.Core (
+  AlonzoEraTxWits (..),
+  BabbageEraTxBody (..),
+ )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (..))
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
-import Test.Cardano.Ledger.Alonzo.ImpTest (alonzoFixupTx, initAlonzoImpNES)
+import Test.Cardano.Ledger.Alonzo.ImpTest (
+  ImpTestM,
+  addCollateralInput,
+  addNativeScriptTxWits,
+  addRootTxIn,
+  fixupDatums,
+  fixupFees,
+  fixupPPHash,
+  fixupPlutusScripts,
+  initAlonzoImpNES,
+  updateAddrTxWits,
+ )
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp (..))
@@ -26,4 +47,23 @@ instance
   where
   initImpNES = initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
-  fixupTx = alonzoFixupTx
+  fixupTx = babbageFixupTx
+
+babbageFixupTx ::
+  ( ShelleyEraImp era
+  , AlonzoEraTxWits era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , BabbageEraTxBody era
+  , AlonzoEraUTxO era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+babbageFixupTx =
+  addNativeScriptTxWits
+    >=> addCollateralInput
+    >=> addRootTxIn
+    >=> fixupPlutusScripts
+    >=> fixupDatums
+    >=> fixupPPHash
+    >=> fixupFees
+    >=> updateAddrTxWits

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.13.0.0
 
+* Add:
+  * `transTxInInfoV1`
+  * `transTxOutV1`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Remove `ConwayPOOL` rule, in favor of `ShelleyPOOL`
 * Add `NFData` instance for `BabbageUtxoPredFailure`
@@ -47,6 +50,7 @@
 
 ### `testlib`
 
+* Add `Test.Cardano.Ledger.Conway.Imp.UtxosSpec`
 * Add `getGovPolicy`
 * Add `submitGovActions` and `trySubmitGovActions`
 * Add `submitProposals` and `trySubmitProposal`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -117,6 +117,7 @@ library testlib
         Test.Cardano.Ledger.Conway.Imp.EnactSpec
         Test.Cardano.Ledger.Conway.Imp.GovSpec
         Test.Cardano.Ledger.Conway.Imp.UtxoSpec
+        Test.Cardano.Ledger.Conway.Imp.UtxosSpec
         Test.Cardano.Ledger.Conway.Proposals
         Test.Cardano.Ledger.Conway.TreeDiff
 
@@ -134,6 +135,7 @@ library testlib
         bytestring,
         cardano-data:testlib,
         containers,
+        plutus-ledger-api,
         deepseq,
         microlens,
         cardano-crypto-class,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -8,14 +8,22 @@
 
 module Test.Cardano.Ledger.Conway.Imp (spec) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
+import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
-import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure)
+import Cardano.Ledger.Conway.Rules (
+  ConwayGovPredFailure,
+ )
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Conway.Imp.GovSpec as Gov
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
+import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
 import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, withImpState)
 
 spec ::
@@ -23,6 +31,9 @@ spec ::
   ( ConwayEraImp era
   , GovState era ~ ConwayGovState era
   , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  , Inject (BabbageContextError era) (ContextError era)
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   ) =>
   Spec
 spec = do
@@ -31,3 +42,4 @@ spec = do
     Epoch.spec @era
     Gov.spec @era
     Utxo.spec @era
+    Utxos.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Imp.UtxosSpec where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..))
+import Cardano.Ledger.Babbage.Rules (
+  BabbageUtxoPredFailure (..),
+ )
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
+import Cardano.Ledger.BaseTypes (
+  Inject (..),
+  Network (..),
+  StrictMaybe (..),
+  maybeToStrictMaybe,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Core (
+  AlonzoEraScript (..),
+  AlonzoEraTxOut (..),
+  BabbageEraTxBody (..),
+  BabbageEraTxOut (..),
+  Era (..),
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  EraTxWits (..),
+  InjectRuleFailure (..),
+  ScriptHash,
+  txIdTx,
+ )
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Plutus (Data (..), TxOutSource (..), hashData)
+import Cardano.Ledger.TxIn (TxId (..), mkTxInPartial)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Sequence.Strict as SSeq
+import qualified Data.Set as Set
+import Lens.Micro ((&), (.~), (^.))
+import qualified PlutusLedgerApi.V1 as P1
+import Test.Cardano.Ledger.Conway.ImpTest (
+  ImpTestM,
+  ImpTestState,
+  ShelleyEraImp,
+  freshKeyHash,
+  impAddPlutusScript,
+  impAnn,
+  impLookupPlutusScript,
+  lookupKeyPair,
+  submitFailingTx,
+  submitTxAnn,
+ )
+import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus (PlutusArgs (..), ScriptTestContext (..))
+import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3)
+
+spendDatum :: P1.Data
+spendDatum = P1.I 3
+
+setupPlutusV1Script :: AlonzoEraScript era => ImpTestM era (ScriptHash (EraCrypto era))
+setupPlutusV1Script = do
+  impAddPlutusScript
+    ScriptTestContext
+      { stcScript = guessTheNumber3
+      , stcArgs =
+          PlutusArgs
+            { paSpendDatum = Just spendDatum
+            , paData = spendDatum
+            }
+      }
+
+scriptLockedTxOut ::
+  forall era.
+  AlonzoEraTxOut era =>
+  ScriptHash (EraCrypto era) ->
+  TxOut era
+scriptLockedTxOut shSpending =
+  mkBasicTxOut
+    (Addr Testnet (ScriptHashObj shSpending) StakeRefNull)
+    (inject $ Coin 1_000_000)
+    & dataHashTxOutL .~ SJust (hashData @era $ Data spendDatum)
+
+mkRefTxOut :: BabbageEraTxOut era => ScriptHash (EraCrypto era) -> ImpTestM era (TxOut era)
+mkRefTxOut sh = do
+  kpPayment <- lookupKeyPair =<< freshKeyHash
+  kpStaking <- lookupKeyPair =<< freshKeyHash
+  mbyPlutusScript <- impLookupPlutusScript sh
+  pure $
+    mkBasicTxOut (mkAddr (kpPayment, kpStaking)) (inject $ Coin 100)
+      & referenceScriptTxOutL .~ maybeToStrictMaybe (fromPlutusScript <$> mbyPlutusScript)
+
+setupRefTx ::
+  forall era.
+  ( BabbageEraTxOut era
+  , ShelleyEraImp era
+  ) =>
+  ImpTestM era (TxId (EraCrypto era))
+setupRefTx = do
+  shSpending <- setupPlutusV1Script
+  refTxOut <- mkRefTxOut shSpending
+  fmap txIdTx . submitTxAnn "Producing transaction" $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . outputsTxBodyL
+        .~ SSeq.fromList
+          [ refTxOut
+          , scriptLockedTxOut shSpending
+          , scriptLockedTxOut shSpending
+          ]
+
+spec ::
+  forall era.
+  ( ShelleyEraImp era
+  , BabbageEraTxBody era
+  , Inject (BabbageContextError era) (ContextError era)
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec =
+  describe "UTXOS" $ do
+    it "can use reference scripts" $ do
+      producingTx <- setupRefTx
+      referringTx <-
+        submitTxAnn "Transaction that refers to the script" $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 1)
+            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+      (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
+    it "can use regular inputs for reference" $ do
+      producingTx <- setupRefTx
+      referringTx <-
+        submitTxAnn "Consuming transaction" $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL
+              .~ Set.fromList
+                [ mkTxInPartial producingTx 0
+                , mkTxInPartial producingTx 1
+                ]
+      (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
+    it "fails with same txIn in regular inputs and reference inputs" $ do
+      producingTx <- setupRefTx
+      let
+        consumingTx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL
+              .~ Set.fromList
+                [ mkTxInPartial producingTx 0
+                , mkTxInPartial producingTx 1
+                ]
+            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+      _ <-
+        submitFailingTx
+          consumingTx
+          [ injectFailure . BabbageNonDisjointRefInputs $
+              mkTxInPartial producingTx 0 :| []
+          ]
+      pure ()
+    it "fails when using inline datums for PlutusV1" $ do
+      shSpending <- setupPlutusV1Script
+      refTxOut <- mkRefTxOut shSpending
+      producingTx <-
+        fmap txIdTx . submitTxAnn "Producing transaction" $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . outputsTxBodyL
+              .~ SSeq.fromList
+                [ refTxOut
+                , scriptLockedTxOut shSpending & dataTxOutL .~ SJust (Data spendDatum)
+                ]
+      let
+        lockedTxIn = mkTxInPartial producingTx 1
+        consumingTx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL .~ Set.singleton lockedTxIn
+            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+      impAnn "Consuming transaction" $
+        submitFailingTx
+          consumingTx
+          [ injectFailure $
+              CollectErrors
+                [BadTranslation . inject . InlineDatumsNotSupported @era $ TxOutFromInput lockedTxIn]
+          ]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -156,6 +154,7 @@ import qualified GHC.Exts as GHC (fromList)
 import Lens.Micro (Lens', (%~), (&), (.~), (^.))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
 import Test.Cardano.Ledger.Alonzo.ImpTest as ImpTest
+import Test.Cardano.Ledger.Babbage.ImpTest (babbageFixupTx)
 import Test.Cardano.Ledger.Conway.TreeDiff ()
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
@@ -199,7 +198,7 @@ instance
 
   modifyPParams = conwayModifyPParams
 
-  fixupTx = alonzoFixupTx
+  fixupTx = babbageFixupTx
 
 class
   ( ShelleyEraImp era

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -46,6 +46,8 @@ module Test.Cardano.Ledger.Imp.Common (
   expectLeftExpr,
   expectLeftDeep,
   expectLeftDeepExpr,
+  expectJust,
+  expectNothingExpr,
 
   -- * MonadGen
   module QuickCheckT,
@@ -297,6 +299,16 @@ shouldBeLeft e x = expectLeft e >>= (`shouldBe` x)
 -- | Same as `shouldBeExpr`, except it checks that the value is `Left`
 shouldBeLeftExpr :: (HasCallStack, ToExpr a, ToExpr b, Eq a, MonadIO m) => Either a b -> a -> m ()
 shouldBeLeftExpr e x = expectLeftExpr e >>= (`shouldBeExpr` x)
+
+expectJust :: (HasCallStack, MonadIO m) => Maybe a -> m a
+expectJust (Just x) = pure x
+expectJust Nothing = assertFailure "Expected Just, got Nothing"
+
+expectNothingExpr :: (HasCallStack, MonadIO m, ToExpr a) => Maybe a -> m ()
+expectNothingExpr (Just x) =
+  assertFailure $
+    "Expected Nothing, got Just:\n" <> show (toExpr x)
+expectNothingExpr Nothing = pure ()
 
 ---------------------------
 -- MonadGen alternatives --


### PR DESCRIPTION
# Description

This PR removes a check from conway that fails a transaction when it's trying to use reference scripts for Plutus V1.

I also added support for reference scripts in ImpTests.

resolves #3965

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
