### PR TITLE
Fix wrong prose for new epoch environment

### DIFF
--- a/eras/shelley/formal-spec/chain.tex
+++ b/eras/shelley/formal-spec/chain.tex
@@ -230,15 +230,9 @@ we reset both of the instantaneous reward mappings back to the empty mapping.
 \subsection{New Epoch Transition}
 \label{sec:new-epoch-trans}
 
-For the transition to a new epoch ($\mathsf{NEWEPOCH}$), the environment is
-given in Figure~\ref{fig:ts-types:newepoch}, it consists of
-
-\begin{itemize}
-\item The current slot.
-\item The set of genesis keys.
-\end{itemize}
-The new epoch state is given in Figure~\ref{fig:ts-types:newepoch}, it consists
-of
+For the transition to a new epoch ($\mathsf{NEWEPOCH}$), the
+environment is empty and state is given in
+Figure~\ref{fig:ts-types:newepoch}, it consists of
 
 \begin{itemize}
 \item The number of the last epoch.


### PR DESCRIPTION
# Description

The environment for NEWEPOCH is empty, but the prose claimed otherwise. Found in #4043.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
