### PR TITLE
Fix MIR rule using wrong values for treasury and reserves

### DIFF
--- a/eras/alonzo/formal-spec/mir.tex
+++ b/eras/alonzo/formal-spec/mir.tex
@@ -240,7 +240,7 @@ Lastly, Figure \ref{fig:rules:mir} is the updated MIR rule.
       \\
       \var{acnt'}\leteq
       {\begin{cases}
-          (\var{treasury}-\var{totT},~\var{reserves}-\var{totR})
+          (\hldiff{\var{availableTreasury}}-\var{totT},~\hldiff{\var{availableReserves}}-\var{totR})
           & \var{enough}
           \\
           \var{acnt}


### PR DESCRIPTION
# Description

Fixes #4077.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
