### PR TITLE
Deprecate `PPUPPredFailure`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Ppup.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Ppup.hs
@@ -9,6 +9,6 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure)
 
-type instance EraRuleFailure "PPUP" era = ShelleyPpupPredFailure era
+type instance EraRuleFailure "PPUP" (AllegraEra c) = ShelleyPpupPredFailure (AllegraEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (AllegraEra c)

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -19,7 +20,6 @@ import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (AllegraTxBody))
 import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (KeyHash (KeyHash), ShelleyTxAuxData (ShelleyTxAuxData))
-import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure)
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq, fromList)
 import Generic.Random (genericArbitraryU)
@@ -95,7 +95,7 @@ instance
   ( Era era
   , Arbitrary (Value era)
   , Arbitrary (TxOut era)
-  , Arbitrary (PPUPPredFailure era)
+  , Arbitrary (EraRuleFailure "PPUP" era)
   ) =>
   Arbitrary (AllegraUtxoPredFailure era)
   where

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -13,7 +14,6 @@ import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.PParams
-import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Shelley.TreeDiff
 
 -- Scripts
@@ -48,6 +48,6 @@ instance
 instance
   ( ToExpr (TxOut era)
   , ToExpr (Value era)
-  , ToExpr (PPUPPredFailure era)
+  , ToExpr (EraRuleFailure "PPUP" era)
   ) =>
   ToExpr (AllegraUtxoPredFailure era)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ppup.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ppup.hs
@@ -9,6 +9,6 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure)
 
-type instance EraRuleFailure "PPUP" era = ShelleyPpupPredFailure era
+type instance EraRuleFailure "PPUP" (AlonzoEra c) = ShelleyPpupPredFailure (AlonzoEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (AlonzoEra c)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -77,7 +77,6 @@ import Cardano.Ledger.Plutus.Language (
   plutusLanguage,
   withSLanguage,
  )
-import Cardano.Ledger.Shelley.LedgerState (PPUPPredFailure)
 import Cardano.Ledger.Shelley.Rules (PredicateFailure, ShelleyUtxowPredFailure)
 import Data.Functor.Identity (Identity)
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -311,7 +310,7 @@ instance Arbitrary TagMismatchDescription where
     oneof [pure PassedUnexpectedly, FailedUnexpectedly <$> ((:|) <$> arbitrary <*> arbitrary)]
 
 instance
-  (Era era, Arbitrary (PPUPPredFailure era)) =>
+  (Era era, Arbitrary (EraRuleFailure "PPUP" era)) =>
   Arbitrary (AlonzoUtxosPredFailure era)
   where
   arbitrary =

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -130,7 +130,7 @@ instance ToExpr TagMismatchDescription
 
 instance
   ( ToExpr (PlutusPurpose AsItem era)
-  , ToExpr (PPUPPredFailure era)
+  , ToExpr (EraRuleFailure "PPUP" era)
   , ToExpr (ContextError era)
   , ToExpr (TxCert era)
   ) =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ppup.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ppup.hs
@@ -9,6 +9,6 @@ import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure)
 
-type instance EraRuleFailure "PPUP" era = ShelleyPpupPredFailure era
+type instance EraRuleFailure "PPUP" (BabbageEra c) = ShelleyPpupPredFailure (BabbageEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (BabbageEra c)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -50,6 +50,7 @@ import Cardano.Ledger.Alonzo.TxWits (nullRedeemers)
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXO)
+import Cardano.Ledger.Babbage.Rules.Ppup ()
 import Cardano.Ledger.Babbage.Rules.Utxos (BabbageUTXOS)
 import Cardano.Ledger.BaseTypes (
   ProtVer (..),

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Babbage.Collateral (
  )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXOS)
+import Cardano.Ledger.Babbage.Rules.Ppup ()
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
@@ -58,11 +59,7 @@ import Cardano.Ledger.Plutus.Evaluate (
   ScriptResult (..),
  )
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.LedgerState (
-  PPUPPredFailure,
-  UTxOState (..),
-  updateStakeDistribution,
- )
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), updateStakeDistribution)
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (
   PpupEnv (..),
@@ -104,9 +101,9 @@ instance
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , Signal (BabbageUTXOS era) ~ Tx era
-  , EncCBOR (PPUPPredFailure era) -- Serializing the PredicateFailure
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , EncCBOR (EraRuleFailure "PPUP" era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   ) =>
   STS (BabbageUTXOS era)
   where
@@ -121,7 +118,7 @@ instance
 instance
   ( Era era
   , STS (ShelleyPPUP era)
-  , PPUPPredFailure era ~ ShelleyPpupPredFailure era
+  , EraRuleFailure "PPUP" era ~ ShelleyPpupPredFailure era
   , Event (EraRule "PPUP" era) ~ Event (ShelleyPPUP era)
   ) =>
   Embed (ShelleyPPUP era) (BabbageUTXOS era)
@@ -143,9 +140,9 @@ utxosTransition ::
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , Signal (BabbageUTXOS era) ~ Tx era
-  , EncCBOR (PPUPPredFailure era)
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , EncCBOR (EraRuleFailure "PPUP" era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   , EraPlutusContext era
   ) =>
   TransitionRule (BabbageUTXOS era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -47,9 +47,24 @@ instance Crypto c => Era (ConwayEra c) where
 type instance Value (ConwayEra c) = MaryValue c
 
 -------------------------------------------------------------------------------
--- Disabled rules
+-- Deprecated rules
 -------------------------------------------------------------------------------
+
+type instance EraRule "UPEC" (ConwayEra c) = VoidEraRule "UPEC" (ConwayEra c)
+
+type instance EraRule "NEWPP" (ConwayEra c) = VoidEraRule "NEWPP" (ConwayEra c)
+
+type instance EraRule "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
 type instance EraRuleFailure "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
+
+type instance EraRule "MIR" (ConwayEra c) = VoidEraRule "MIR" (ConwayEra c)
+type instance EraRuleFailure "MIR" (ConwayEra c) = VoidEraRule "MIR" (ConwayEra c)
+
+type instance EraRule "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
+type instance EraRuleFailure "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
+
+type instance EraRule "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
+type instance EraRuleFailure "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -47,6 +47,11 @@ instance Crypto c => Era (ConwayEra c) where
 type instance Value (ConwayEra c) = MaryValue c
 
 -------------------------------------------------------------------------------
+-- Disabled rules
+-------------------------------------------------------------------------------
+type instance EraRuleFailure "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
+
+-------------------------------------------------------------------------------
 -- Era Mapping
 -------------------------------------------------------------------------------
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -84,7 +84,7 @@ import Cardano.Ledger.Conway.PParams (
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
-import Cardano.Ledger.Rules.ValidationMode (Inject (..), Test, runTest)
+import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import Cardano.Ledger.Shelley.PParams (pvCanFollow)
 import Cardano.Ledger.TxIn (TxId (..))
 import Control.DeepSeq (NFData)
@@ -428,9 +428,6 @@ govTransition = do
   tellEvent $ GovNewProposals txid updatedProposalStates
 
   pure updatedProposalStates
-
-instance Inject (ConwayGovPredFailure era) (ConwayGovPredFailure era) where
-  inject = id
 
 -- | If the GovAction is a HardFork, then return 3 things (if they exist)
 -- 1) The (StrictMaybe GovPurposeId), pointed to by the HardFork proposal

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -1,21 +1,27 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Conway.Rules.Utxo () where
+module Cardano.Ledger.Conway.Rules.Utxo (allegraToConwayUtxoPredFailure) where
 
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure, shelleyToAllegraUtxoPredFailure)
+import Cardano.Ledger.Allegra.Rules (shelleyToAllegraUtxoPredFailure)
+import qualified Cardano.Ledger.Allegra.Rules as Allegra (AllegraUtxoPredFailure (..))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure (..),
   AlonzoUtxosPredFailure,
-  allegraToAlonzoUtxoPredFailure,
  )
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..))
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Rules.Utxos ()
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure (..))
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
 
 type instance EraRuleFailure "UTXO" (ConwayEra c) = BabbageUtxoPredFailure (ConwayEra c)
 
@@ -27,11 +33,31 @@ instance InjectRuleFailure "UTXO" AlonzoUtxoPredFailure (ConwayEra c) where
 instance InjectRuleFailure "UTXO" ShelleyUtxoPredFailure (ConwayEra c) where
   injectFailure =
     AlonzoInBabbageUtxoPredFailure
-      . allegraToAlonzoUtxoPredFailure
+      . allegraToConwayUtxoPredFailure
       . shelleyToAllegraUtxoPredFailure
 
-instance InjectRuleFailure "UTXO" AllegraUtxoPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxoPredFailure . allegraToAlonzoUtxoPredFailure
+instance InjectRuleFailure "UTXO" Allegra.AllegraUtxoPredFailure (ConwayEra c) where
+  injectFailure = AlonzoInBabbageUtxoPredFailure . allegraToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" AlonzoUtxosPredFailure (ConwayEra c) where
   injectFailure = AlonzoInBabbageUtxoPredFailure . UtxosFailure
+
+allegraToConwayUtxoPredFailure ::
+  forall era.
+  EraRuleFailure "PPUP" era ~ VoidEraRule "PPUP" era =>
+  Allegra.AllegraUtxoPredFailure era ->
+  AlonzoUtxoPredFailure era
+allegraToConwayUtxoPredFailure = \case
+  Allegra.BadInputsUTxO x -> BadInputsUTxO x
+  Allegra.OutsideValidityIntervalUTxO vi slotNo -> OutsideValidityIntervalUTxO vi slotNo
+  Allegra.MaxTxSizeUTxO x y -> MaxTxSizeUTxO x y
+  Allegra.InputSetEmptyUTxO -> InputSetEmptyUTxO
+  Allegra.FeeTooSmallUTxO c1 c2 -> FeeTooSmallUTxO c1 c2
+  Allegra.ValueNotConservedUTxO vc vp -> ValueNotConservedUTxO vc vp
+  Allegra.WrongNetwork x y -> WrongNetwork x y
+  Allegra.WrongNetworkWithdrawal x y -> WrongNetworkWithdrawal x y
+  Allegra.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
+  Allegra.UpdateFailure x -> absurdEraRule @"PPUP" @era x
+  Allegra.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
+  Allegra.TriesToForgeADA -> TriesToForgeADA
+  Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (map (0,0,) xs)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -37,11 +37,7 @@ import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXOS)
 import Cardano.Ledger.Conway.Governance (ConwayGovState (..))
 import Cardano.Ledger.Conway.TxInfo ()
 import Cardano.Ledger.SafeHash (hashAnnotated)
-import Cardano.Ledger.Shelley.LedgerState (
-  PPUPPredFailure,
-  UTxOState (..),
-  utxosDonationL,
- )
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), utxosDonationL)
 import Cardano.Ledger.Shelley.Rules (
   UtxoEnv (..),
   updateUTxOState,
@@ -65,8 +61,8 @@ instance
   , GovState era ~ ConwayGovState era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (ConwayUTXOS era) ~ Tx era
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   ) =>
   STS (ConwayUTXOS era)
   where
@@ -91,8 +87,8 @@ instance
   , PredicateFailure (EraRule "UTXOS" era) ~ AlonzoUtxosPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (ConwayUTXOS era) ~ Tx era
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   ) =>
   Embed (ConwayUTXOS era) (BabbageUTXO era)
   where
@@ -109,8 +105,8 @@ utxosTransition ::
   , GovState era ~ ConwayGovState era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (ConwayUTXOS era) ~ Tx era
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   ) =>
   TransitionRule (ConwayUTXOS era)
 utxosTransition =

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Ppup.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Ppup.hs
@@ -9,6 +9,6 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure)
 
-type instance EraRuleFailure "PPUP" era = ShelleyPpupPredFailure era
+type instance EraRuleFailure "PPUP" (MaryEra c) = ShelleyPpupPredFailure (MaryEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (MaryEra c)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Deprecated `PPUPPredFailure`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Remove `poolCertTransition`
 * Remove `getDRepDistr`, `getConstitution` and `getCommitteeMembers` from `EraGov` #4033

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -111,7 +111,7 @@ data ShelleyPpupPredFailure era
       !ProtVer
   deriving (Show, Eq, Generic)
 
-type instance EraRuleFailure "PPUP" era = ShelleyPpupPredFailure era
+type instance EraRuleFailure "PPUP" (ShelleyEra c) = ShelleyPpupPredFailure (ShelleyEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (ShelleyEra c)
 
@@ -221,14 +221,5 @@ ppupTransitionNonEmpty = do
               , futureProposals = ProposedPPUpdates (eval (fpupS ⨃ pup))
               }
 
-type PPUPPredFailure era = PPUPPredFailurePV (ProtVerLow era) era
-
-type family PPUPPredFailurePV pv era where
-  PPUPPredFailurePV 2 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 3 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 4 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 5 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 6 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 7 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV 8 era = ShelleyPpupPredFailure era
-  PPUPPredFailurePV _ _ = ()
+type PPUPPredFailure era = EraRuleFailure "PPUP" era
+{-# DEPRECATED PPUPPredFailure "In favor of `EraRuleFailure` PPUP era" #-}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -63,7 +63,7 @@ import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.AdaPots (consumedTxBody, producedTxBody)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyUTXO)
-import Cardano.Ledger.Shelley.LedgerState (CertState (..), PPUPPredFailure, UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (CertState (..), UTxOState (..))
 import Cardano.Ledger.Shelley.LedgerState.IncrementalStake
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules.Ppup (
@@ -164,7 +164,7 @@ data ShelleyUtxoPredFailure era
       !(Set (RewardAccount (EraCrypto era))) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
       ![TxOut era] -- list of supplied transaction outputs that are too small
-  | UpdateFailure (PPUPPredFailure era) -- Subtransition Failures
+  | UpdateFailure (EraRuleFailure "PPUP" era) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
       ![TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
@@ -179,21 +179,21 @@ instance InjectRuleFailure "UTXO" ShelleyPpupPredFailure (ShelleyEra c) where
 deriving stock instance
   ( Show (Value era)
   , Show (TxOut era)
-  , Show (PPUPPredFailure era)
+  , Show (EraRuleFailure "PPUP" era)
   ) =>
   Show (ShelleyUtxoPredFailure era)
 
 deriving stock instance
   ( Eq (Value era)
   , Eq (TxOut era)
-  , Eq (PPUPPredFailure era)
+  , Eq (EraRuleFailure "PPUP" era)
   ) =>
   Eq (ShelleyUtxoPredFailure era)
 
 instance
   ( NoThunks (Value era)
   , NoThunks (TxOut era)
-  , NoThunks (PPUPPredFailure era)
+  , NoThunks (EraRuleFailure "PPUP" era)
   ) =>
   NoThunks (ShelleyUtxoPredFailure era)
 
@@ -201,7 +201,7 @@ instance
   ( Era era
   , NFData (Value era)
   , NFData (TxOut era)
-  , NFData (PPUPPredFailure era)
+  , NFData (EraRuleFailure "PPUP" era)
   ) =>
   NFData (ShelleyUtxoPredFailure era)
 
@@ -209,7 +209,7 @@ instance
   ( Era era
   , EncCBOR (Value era)
   , EncCBOR (TxOut era)
-  , EncCBOR (PPUPPredFailure era)
+  , EncCBOR (EraRuleFailure "PPUP" era)
   ) =>
   EncCBOR (ShelleyUtxoPredFailure era)
   where
@@ -262,7 +262,7 @@ instance
 
 instance
   ( EraTxOut era
-  , DecCBOR (PPUPPredFailure era)
+  , DecCBOR (EraRuleFailure "PPUP" era)
   ) =>
   DecCBOR (ShelleyUtxoPredFailure era)
   where
@@ -319,8 +319,8 @@ instance
   , Environment (EraRule "PPUP" era) ~ PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , Eq (PPUPPredFailure era)
-  , Show (PPUPPredFailure era)
+  , Eq (EraRuleFailure "PPUP" era)
+  , Show (EraRuleFailure "PPUP" era)
   , EraRule "UTXO" era ~ ShelleyUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   ) =>
@@ -645,7 +645,7 @@ updateUTxOState pp utxos txBody certState govState depositChangeEvent txUtxODiff
 instance
   ( Era era
   , STS (ShelleyPPUP era)
-  , PPUPPredFailure era ~ ShelleyPpupPredFailure era
+  , EraRuleFailure "PPUP" era ~ ShelleyPpupPredFailure era
   , Event (EraRule "PPUP" era) ~ PpupEvent era
   ) =>
   Embed (ShelleyPPUP era) (ShelleyUTXO era)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -718,7 +718,7 @@ instance
   ( Era era
   , Arbitrary (Value era)
   , Arbitrary (TxOut era)
-  , Arbitrary (PPUPPredFailure era)
+  , Arbitrary (EraRuleFailure "PPUP" era)
   ) =>
   Arbitrary (ShelleyUtxoPredFailure era)
   where

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -151,7 +151,7 @@ instance ToExpr (IncrementalStake c)
 
 -- Rules/Utxo
 instance
-  ( ToExpr (PPUPPredFailure era)
+  ( ToExpr (EraRuleFailure "PPUP" era)
   , ToExpr (Value era)
   , ToExpr (TxOut era)
   ) =>

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.11.0.0
 
 * Add `EraRuleFailure` type family and `InjectRuleFailure` type class
-* Add `VoidRuleFailure`
+* Add `VoidFailure`
 * Fix `ToJSON`/`FromJSON` instances of `Prices`
 * Update `FromJSON` instance of `BoundedRatio`
 * Fix `ToJSON` instance of `BoundedRatio` to avoid precision loss

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -41,6 +41,7 @@ import Cardano.Ledger.UTxO
 import Data.Functor.Identity
 import Data.TreeDiff.OMap
 import Data.VMap hiding (fromList)
+import GHC.TypeLits
 import Test.Cardano.Ledger.Binary.TreeDiff
 import Test.Data.VMap.TreeDiff ()
 
@@ -89,6 +90,10 @@ instance ToExpr Language
 instance ToExpr (t era) => ToExpr (MemoBytes t era)
 
 -- Core
+
+instance ToExpr (VoidEraRule (rule :: Symbol) era) where
+  toExpr = absurdEraRule
+
 instance ToExpr (ScriptHash c)
 
 instance ToExpr CostModelError where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -197,7 +197,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   InstantaneousRewards (..),
   LedgerState (..),
   NewEpochState (..),
-  PPUPPredFailure,
   PState (..),
   RewardUpdate (..),
   UTxOState (..),
@@ -1802,7 +1801,7 @@ ppUtxosPredicateFailure (CollectErrors es) =
       , ppList ppCollectError es
       )
     ]
-ppUtxosPredicateFailure (Alonzo.UpdateFailure p) = ppPPUPPredFailure @era p
+ppUtxosPredicateFailure (Alonzo.UpdateFailure p) = ppPPUPPredFailure p
 
 instance Reflect era => PrettyA (AlonzoUtxosPredFailure era) where
   prettyA = ppUtxosPredicateFailure
@@ -1912,7 +1911,7 @@ ppShelleyUtxoPredFailure (Shelley.OutputTooSmallUTxO xs) =
     "OutputTooSmallUTxO"
     [("list of supplied transaction outputs that are too small", ppList (pcTxOut reify) xs)]
 ppShelleyUtxoPredFailure (Shelley.UpdateFailure x) =
-  ppSexp "UpdateFailure" [ppPPUPPredFailure @era x]
+  ppSexp "UpdateFailure" [ppPPUPPredFailure x]
 ppShelleyUtxoPredFailure (Shelley.OutputBootAddrAttrsTooBig xs) =
   ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList (pcTxOut reify) xs)]
 
@@ -1945,7 +1944,7 @@ instance PrettyA (ShelleyPpupPredFailure era) where
 -- =====================================================
 -- Predicate failure for Mary UTXO
 
-ppPPUPPredFailure :: PPUPPredFailure era -> PDoc
+ppPPUPPredFailure :: a -> PDoc
 ppPPUPPredFailure _ = ppString "PPUPPredFailure" -- TODO FIXME
 
 ppAllegraUtxoPredFailure ::
@@ -1997,7 +1996,7 @@ ppAllegraUtxoPredFailure (Allegra.OutputTooSmallUTxO xs) =
     "OutputTooSmallUTxO"
     [("list of supplied transaction outputs that are too small", ppList (pcTxOut reify) xs)]
 ppAllegraUtxoPredFailure (Allegra.UpdateFailure x) =
-  ppSexp "UpdateFailure" [ppPPUPPredFailure @era x]
+  ppSexp "UpdateFailure" [ppPPUPPredFailure x]
 ppAllegraUtxoPredFailure (Allegra.OutputBootAddrAttrsTooBig xs) =
   ppRecord "OutputBootAddrAttrsTooBig" [("list of supplied bad transaction outputs", ppList (pcTxOut reify) xs)]
 ppAllegraUtxoPredFailure (Allegra.TriesToForgeADA) = ppSexp "TriesToForgeADA" []


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
