### PR TITLE
Committee query improvements

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -649,8 +649,6 @@ toConwayGovPairs cg@(ConwayGovState _ _ _ _ _ _) =
 instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
   type GovState (ConwayEra c) = ConwayGovState (ConwayEra c)
 
-  getNextEpochCommitteeMembers g = ensCommitteeMembers (getRatifyState g ^. rsEnactStateL)
-
   curPParamsGovStateL = curPParamsConwayGovStateL
 
   prevPParamsGovStateL = prevPParamsConwayGovStateL
@@ -662,13 +660,6 @@ instance EraPParams (ConwayEra c) => EraGov (ConwayEra c) where
       , oblStake = Coin 0
       , oblPool = Coin 0
       }
-
-ensCommitteeMembers ::
-  EnactState era ->
-  Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
-ensCommitteeMembers ens = case ens ^. ensCommitteeL of
-  SJust Committee {..} -> Just (committeeMembers, committeeThreshold)
-  SNothing -> Nothing
 
 class EraGov era => ConwayEraGov era where
   constitutionGovStateL :: Lens' (GovState era) (Constitution era)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Remove `getNextEpochCommitteeMembers` from `EraGov`
 * Deprecated `PPUPPredFailure`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Remove `poolCertTransition`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -20,7 +20,6 @@ module Cardano.Ledger.Shelley.Governance (
   prevPParamsShelleyGovStateL,
 ) where
 
-import Cardano.Ledger.BaseTypes (EpochNo, UnitInterval)
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
   DecShareCBOR (..),
@@ -32,9 +31,7 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.CertState (Obligations)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto)
-import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
 import Control.DeepSeq (NFData)
@@ -47,7 +44,6 @@ import Data.Aeson (
  )
 import Data.Default.Class (Default (..))
 import Data.Kind (Type)
-import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens)
 import NoThunks.Class (NoThunks (..))
@@ -78,10 +74,6 @@ class
   -- pparams updates
   getProposedPPUpdates :: GovState era -> Maybe (ProposedPPUpdates era)
   getProposedPPUpdates _ = Nothing
-
-  getNextEpochCommitteeMembers ::
-    GovState era -> Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
-  getNextEpochCommitteeMembers = const Nothing
 
   -- | Lens for accessing current protocol parameters
   curPParamsGovStateL :: Lens' (GovState era) (PParams era)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Remove `getNextEpochCommitteeMembers` from `EraGov`
 * Remove `getDRepDistr`, `getConstitution` and `getCommitteeMembers` from `EraGov` #4033
 * Add `refScriptSize` parameter to `getMinFeeTx`, `setMinFeeTx` and `estimateMinFeeTx`
 * Add `hoistGovRelation`, `withGovActionParent` and `GovRelation`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.9.0.0
 
+* Change return type of `queryCommitteeMembersState` to `CommitteeMembersState`
+* Change type of `csThreshold` in `CommitteeMembersState` to `Maybe UnitInterval`
 * Remove `getNextEpochCommitteeMembers` from `EraGov`
 * Remove `getDRepDistr`, `getConstitution` and `getCommitteeMembers` from `EraGov` #4033
 * Add `refScriptSize` parameter to `getMinFeeTx`, `setMinFeeTx` and `estimateMinFeeTx`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -37,7 +37,6 @@ module Cardano.Ledger.Api.State.Query (
   NextEpochChange (..),
 
   -- * For testing
-  getCommitteeMembers,
   getNextEpochCommitteeMembers,
 ) where
 
@@ -48,7 +47,7 @@ import Cardano.Ledger.Api.State.Query.CommitteeMembersState (
   MemberStatus (..),
   NextEpochChange (..),
  )
-import Cardano.Ledger.BaseTypes (EpochNo (EpochNo), UnitInterval, binOpEpochNo, strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (EpochNo (EpochNo), binOpEpochNo, strictMaybeToMaybe)
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible (fromCompact)
@@ -56,7 +55,6 @@ import Cardano.Ledger.Conway.Governance (
   Committee (committeeMembers),
   Constitution (constitutionAnchor),
   ConwayEraGov (..),
-  committeeMembersL,
   committeeThresholdL,
   ensCommitteeL,
   finishDRepPulser,
@@ -166,15 +164,6 @@ queryCommitteeState nes =
   vsCommitteeState $ certVState $ lsCertState $ esLState $ nesEs nes
 {-# DEPRECATED queryCommitteeState "In favor of `queryCommitteeMembersState`" #-}
 
-getCommitteeMembers ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  Maybe (Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo, UnitInterval)
-getCommitteeMembers nes =
-  fmap (\c -> (c ^. committeeMembersL, c ^. committeeThresholdL)) $
-    strictMaybeToMaybe $
-      queryGovState nes ^. committeeGovStateL
-
 -- | Query committee members. Whenever the system is in No Confidence mode this query will
 -- return `Nothing`.
 queryCommitteeMembersState ::
@@ -188,82 +177,83 @@ queryCommitteeMembersState ::
   -- (useful, for discovering, for example, only active members)
   Set MemberStatus ->
   NewEpochState era ->
-  Maybe (CommitteeMembersState (EraCrypto era))
-queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes = do
-  (comMembers, comThreshold) <- getCommitteeMembers nes
-  let nextComMembers = getNextEpochCommitteeMembers nes
-      comStateMembers =
-        csCommitteeCreds $
-          nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
+  CommitteeMembersState (EraCrypto era)
+queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
+  let
+    committee = queryGovState nes ^. committeeGovStateL
+    comMembers = foldMap' committeeMembers committee
+    nextComMembers = getNextEpochCommitteeMembers nes
+    comStateMembers =
+      csCommitteeCreds $
+        nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
 
-      withFilteredColdCreds s
-        | Set.null coldCredsFilter = s
-        | otherwise = s `Set.intersection` coldCredsFilter
+    withFilteredColdCreds s
+      | Set.null coldCredsFilter = s
+      | otherwise = s `Set.intersection` coldCredsFilter
 
-      relevantColdKeys
-        | Set.null statusFilter || Set.member Unrecognized statusFilter =
-            withFilteredColdCreds $
-              Set.unions
-                [ Map.keysSet comMembers
-                , Map.keysSet comStateMembers
-                , Map.keysSet nextComMembers
-                ]
-        | otherwise = withFilteredColdCreds $ Map.keysSet comMembers
+    relevantColdKeys
+      | Set.null statusFilter || Set.member Unrecognized statusFilter =
+          withFilteredColdCreds $
+            Set.unions
+              [ Map.keysSet comMembers
+              , Map.keysSet comStateMembers
+              , Map.keysSet nextComMembers
+              ]
+      | otherwise = withFilteredColdCreds $ Map.keysSet comMembers
 
-      relevantHotKeys =
-        Map.keysSet $
-          Map.filter (maybe False (`Set.member` hotCredsFilter)) comStateMembers
+    relevantHotKeys =
+      Map.keysSet $
+        Map.filter (maybe False (`Set.member` hotCredsFilter)) comStateMembers
 
-      relevant
-        | Set.null hotCredsFilter = relevantColdKeys
-        | otherwise = relevantColdKeys `Set.intersection` relevantHotKeys
+    relevant
+      | Set.null hotCredsFilter = relevantColdKeys
+      | otherwise = relevantColdKeys `Set.intersection` relevantHotKeys
 
-      cms = Map.mapMaybe id $ Map.fromSet mkMaybeMemberState relevant
-      currentEpoch = nes ^. nesELL
+    cms = Map.mapMaybe id $ Map.fromSet mkMaybeMemberState relevant
+    currentEpoch = nes ^. nesELL
 
-      mkMaybeMemberState ::
-        Credential 'ColdCommitteeRole (EraCrypto era) ->
-        Maybe (CommitteeMemberState (EraCrypto era))
-      mkMaybeMemberState coldCred = do
-        let mbExpiry = Map.lookup coldCred comMembers
-        let status = case mbExpiry of
-              Nothing -> Unrecognized
-              Just expiry
-                | currentEpoch > expiry -> Expired
-                | otherwise -> Active
-        guard (null statusFilter || status `Set.member` statusFilter)
-        let hkStatus =
-              case Map.lookup coldCred comStateMembers of
-                Nothing -> MemberNotAuthorized
-                Just Nothing -> MemberResigned
-                Just (Just hk) -> MemberAuthorized hk
-        pure $ CommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
+    mkMaybeMemberState ::
+      Credential 'ColdCommitteeRole (EraCrypto era) ->
+      Maybe (CommitteeMemberState (EraCrypto era))
+    mkMaybeMemberState coldCred = do
+      let mbExpiry = Map.lookup coldCred comMembers
+      let status = case mbExpiry of
+            Nothing -> Unrecognized
+            Just expiry
+              | currentEpoch > expiry -> Expired
+              | otherwise -> Active
+      guard (null statusFilter || status `Set.member` statusFilter)
+      let hkStatus =
+            case Map.lookup coldCred comStateMembers of
+              Nothing -> MemberNotAuthorized
+              Just Nothing -> MemberResigned
+              Just (Just hk) -> MemberAuthorized hk
+      pure $ CommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
 
-      nextEpochChange :: Credential 'ColdCommitteeRole (EraCrypto era) -> NextEpochChange
-      nextEpochChange ck
-        | not inCurrent && inNext = ToBeEnacted
-        | not inNext = ToBeRemoved
-        | Just curTerm <- lookupCurrent
-        , Just nextTerm <- lookupNext
-        , curTerm /= nextTerm
-        , -- if the term is adjusted such that it expires in the next epoch,
-          -- we set it to ToBeExpired instead of TermAdjusted
-          not expiringNext =
-            TermAdjusted nextTerm
-        | expiringCurrent || expiringNext = ToBeExpired
-        | otherwise = NoChangeExpected
-        where
-          lookupCurrent = Map.lookup ck comMembers
-          lookupNext = Map.lookup ck nextComMembers
-          inCurrent = isJust lookupCurrent
-          inNext = isJust lookupNext
-          expiringCurrent = lookupCurrent == Just currentEpoch
-          expiringNext = lookupNext == Just currentEpoch
-
-  pure
+    nextEpochChange :: Credential 'ColdCommitteeRole (EraCrypto era) -> NextEpochChange
+    nextEpochChange ck
+      | not inCurrent && inNext = ToBeEnacted
+      | not inNext = ToBeRemoved
+      | Just curTerm <- lookupCurrent
+      , Just nextTerm <- lookupNext
+      , curTerm /= nextTerm
+      , -- if the term is adjusted such that it expires in the next epoch,
+        -- we set it to ToBeExpired instead of TermAdjusted
+        not expiringNext =
+          TermAdjusted nextTerm
+      | expiringCurrent || expiringNext = ToBeExpired
+      | otherwise = NoChangeExpected
+      where
+        lookupCurrent = Map.lookup ck comMembers
+        lookupNext = Map.lookup ck nextComMembers
+        inCurrent = isJust lookupCurrent
+        inNext = isJust lookupNext
+        expiringCurrent = lookupCurrent == Just currentEpoch
+        expiringNext = lookupNext == Just currentEpoch
+   in
     CommitteeMembersState
       { csCommittee = cms
-      , csThreshold = comThreshold
+      , csThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
       , csEpochNo = currentEpoch
       }
 
@@ -278,5 +268,5 @@ getNextEpochCommitteeMembers ::
   Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo
 getNextEpochCommitteeMembers nes =
   let ratifyState = snd . finishDRepPulser $ queryGovState nes ^. drepPulsingStateGovStateL
-      committee = strictMaybeToMaybe $ ratifyState ^. rsEnactStateL . ensCommitteeL
+      committee = ratifyState ^. rsEnactStateL . ensCommitteeL
    in foldMap' committeeMembers committee

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/CommitteeMembersState.hs
@@ -148,7 +148,7 @@ toCommitteeMemberStatePairs c@(CommitteeMemberState _ _ _ _) =
 
 data CommitteeMembersState c = CommitteeMembersState
   { csCommittee :: !(Map (Credential 'ColdCommitteeRole c) (CommitteeMemberState c))
-  , csThreshold :: !UnitInterval
+  , csThreshold :: !(Maybe UnitInterval)
   , csEpochNo :: !EpochNo
   -- ^ Current epoch number. This is necessary to interpret committee member states
   }

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Api.State.Query (
   NextEpochChange (..),
   filterStakePoolDelegsAndRewards,
   getCommitteeMembers,
+  getNextEpochCommitteeMembers,
   queryCommitteeMembersState,
  )
 import Cardano.Ledger.BaseTypes
@@ -443,11 +444,7 @@ committeeInfo ::
 committeeInfo nes = do
   (comMembers, comQurum) <- getCommitteeMembers nes
   let ledgerState = nes ^. nesEpochStateL . esLStateL
-  let nextCommitteeMembers =
-        maybe
-          Map.empty
-          fst
-          $ getNextEpochCommitteeMembers (ledgerState ^. lsUTxOStateL . utxosGovStateL)
+  let nextCommitteeMembers = getNextEpochCommitteeMembers nes
   let comState = ledgerState ^. lsCertStateL . certVStateL . vsCommitteeStateL
   pure (Committee comMembers comQurum, comState, nextCommitteeMembers)
 


### PR DESCRIPTION
# Description

This was initially meant to be a test to verify the behavior reported in this issue: https://github.com/IntersectMBO/cardano-ledger/issues/4001
However  I realized that we could improve the query by returning  results independent of whether there exists a current committee, since it's possible that we have relevant information even when there is no currently elected committee (for example: information about the next epoch committee, or about pre-authorized members). 
It's possible that returning better results helps with clarifying the behavior reported in the bug, for which I added a test in the last commit. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
