### PR TITLE
Fix small error in the prose

### DIFF
--- a/eras/shelley/formal-spec/delegation.tex
+++ b/eras/shelley/formal-spec/delegation.tex
@@ -718,7 +718,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     advance will curb the growth of the $\var{retiring}$ list in the ledger state.
 
     The pools scheduled for retirement must be removed from
-    the $\var{retiring}$ state variable at the end of the epoch they are scheduled
+    the $\var{retiring}$ state variable at the beginning of the epoch they are scheduled
     to retire in. This non-signaled transition (triggered, instead, directly by a
     change of current slot number in the environment), along with all other transitions
     that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.


### PR DESCRIPTION
# Description

The retirement epoch is the first epoch where the pool will be retired, not the last one where it is active which the prose incorrectly claimed.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
