### PR TITLE
PPU wellformedness tests

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -702,7 +702,7 @@ instance Crypto c => BabbageEraPParams (ConwayEra c) where
 instance Crypto c => ConwayEraPParams (ConwayEra c) where
   modifiedPPGroups (PParamsUpdate ppu) = conwayModifiedPPGroups ppu
   ppuWellFormed ppu =
-    and
+    and $
       [ -- Numbers
         isValid (/= 0) ppuMaxBBSizeL
       , isValid (/= 0) ppuMaxTxSizeL
@@ -717,6 +717,7 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       , isValid (/= zero) ppuDRepDepositL
       , ppu /= emptyPParamsUpdate
       ]
+        <> [govActionLifeTimeWithinDRepActivity]
     where
       isValid ::
         (t -> Bool) ->
@@ -725,6 +726,12 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       isValid p l = case ppu ^. l of
         SJust x -> p x
         SNothing -> True
+      govActionLifeTimeWithinDRepActivity =
+        case (ppu ^. ppuGovActionLifetimeL, ppu ^. ppuDRepActivityL) of
+          (SNothing, SNothing) -> True
+          (SJust _, SNothing) -> True
+          (SJust govActionLifetime, SJust drepActivity) -> govActionLifetime <= drepActivity
+          _ -> False
   hkdPoolVotingThresholdsL =
     lens (unTHKD . cppPoolVotingThresholds) $ \pp x -> pp {cppPoolVotingThresholds = THKD x}
   hkdDRepVotingThresholdsL =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -702,7 +702,7 @@ instance Crypto c => BabbageEraPParams (ConwayEra c) where
 instance Crypto c => ConwayEraPParams (ConwayEra c) where
   modifiedPPGroups (PParamsUpdate ppu) = conwayModifiedPPGroups ppu
   ppuWellFormed ppu =
-    and $
+    and
       [ -- Numbers
         isValid (/= 0) ppuMaxBBSizeL
       , isValid (/= 0) ppuMaxTxSizeL
@@ -717,7 +717,6 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       , isValid (/= zero) ppuDRepDepositL
       , ppu /= emptyPParamsUpdate
       ]
-        <> [govActionLifeTimeWithinDRepActivity]
     where
       isValid ::
         (t -> Bool) ->
@@ -726,12 +725,6 @@ instance Crypto c => ConwayEraPParams (ConwayEra c) where
       isValid p l = case ppu ^. l of
         SJust x -> p x
         SNothing -> True
-      govActionLifeTimeWithinDRepActivity =
-        case (ppu ^. ppuGovActionLifetimeL, ppu ^. ppuDRepActivityL) of
-          (SNothing, SNothing) -> True
-          (SJust _, SNothing) -> True
-          (SJust govActionLifetime, SJust drepActivity) -> govActionLifetime <= drepActivity
-          _ -> False
   hkdPoolVotingThresholdsL =
     lens (unTHKD . cppPoolVotingThresholds) $ \pp x -> pp {cppPoolVotingThresholds = THKD x}
   hkdDRepVotingThresholdsL =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -135,38 +135,6 @@ spec =
               }
           )
           [injectFailure $ MalformedProposal ga]
-      context "PPU GovActionLifetime cannot be greater than DRepActivity" $ do
-        let
-          runTest ga = do
-            rew <- registerRewardAccount
-            pp <- getsNES $ nesEsL . curPParamsEpochStateL
-            submitFailingProposal
-              ( ProposalProcedure
-                  { pProcReturnAddr = rew
-                  , pProcGovAction = ga
-                  , pProcDeposit = pp ^. ppGovActionDepositL
-                  , pProcAnchor = def
-                  }
-              )
-              [injectFailure $ MalformedProposal ga]
-        it "GovActionLifetime greater than DRepActivity" $
-          runTest $
-            ParameterChange
-              SNothing
-              ( emptyPParamsUpdate
-                  & ppuGovActionLifetimeL .~ SJust (EpochInterval 11)
-                  & ppuDRepActivityL .~ SJust (EpochInterval 10)
-              )
-              SNothing
-        it "GovActionLifetime as SNothing, DRepActivity as SJust" $
-          runTest $
-            ParameterChange
-              SNothing
-              ( emptyPParamsUpdate
-                  & ppuGovActionLifetimeL .~ SNothing
-                  & ppuDRepActivityL .~ SJust (EpochInterval 10)
-              )
-              SNothing
     context "Proposal-forests" $ do
       context "GOV, EPOCH, RATIFY and ENACT" $ do
         it "Proposals submitted without proper parent fail" $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Credential (Credential (KeyHashObj))
 import Cardano.Ledger.DRep (drepExpiryL)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Val (zero)
 import Data.Default.Class (Default (..))
 import Data.Foldable (Foldable (..), traverse_)
 import qualified Data.List.NonEmpty as NE
@@ -64,6 +65,108 @@ spec =
       it "Hardfork minorFollow" (secondHardForkFollows minorFollow)
       it "Hardfork majorFollow" (secondHardForkFollows majorFollow)
       it "Hardfork cantFollow" secondHardForkCantFollow
+    describe "PPU needs to be wellformed" $ do
+      let testMalformedProposal lbl lenz val = it lbl $ do
+            pp <- getsNES $ nesEsL . curPParamsEpochStateL
+            rew <- registerRewardAccount
+            let ppUpdate =
+                  emptyPParamsUpdate
+                    & lenz .~ SJust val
+                ga = ParameterChange SNothing ppUpdate SNothing
+            submitFailingProposal
+              ( ProposalProcedure
+                  { pProcReturnAddr = rew
+                  , pProcGovAction = ga
+                  , pProcDeposit = pp ^. ppGovActionDepositL
+                  , pProcAnchor = def
+                  }
+              )
+              [injectFailure $ MalformedProposal ga]
+      testMalformedProposal
+        "ppuMaxBBSizeL cannot be 0"
+        ppuMaxBBSizeL
+        0
+      testMalformedProposal
+        "ppuMaxTxSizeL cannot be 0"
+        ppuMaxTxSizeL
+        0
+      testMalformedProposal
+        "ppuMaxBHSizeL cannot be 0"
+        ppuMaxBHSizeL
+        0
+      testMalformedProposal
+        "ppuMaxValSizeL cannot be 0"
+        ppuMaxValSizeL
+        0
+      testMalformedProposal
+        "ppuCollateralPercentageL cannot be 0"
+        ppuCollateralPercentageL
+        0
+      testMalformedProposal
+        "ppuCommitteeMaxTermLengthL cannot be 0"
+        ppuCommitteeMaxTermLengthL
+        $ EpochInterval 0
+      testMalformedProposal
+        "ppuGovActionLifetimeL cannot be 0"
+        ppuGovActionLifetimeL
+        $ EpochInterval 0
+      testMalformedProposal
+        "ppuPoolDepositL cannot be 0"
+        ppuPoolDepositL
+        zero
+      testMalformedProposal
+        "ppuGovActionDepositL cannot be 0"
+        ppuGovActionDepositL
+        zero
+      testMalformedProposal
+        "ppuDRepDepositL cannot be 0"
+        ppuDRepDepositL
+        zero
+      it "PPU cannot be empty" $ do
+        pp <- getsNES $ nesEsL . curPParamsEpochStateL
+        rew <- registerRewardAccount
+        let ga = ParameterChange SNothing emptyPParamsUpdate SNothing
+        submitFailingProposal
+          ( ProposalProcedure
+              { pProcReturnAddr = rew
+              , pProcGovAction = ga
+              , pProcDeposit = pp ^. ppGovActionDepositL
+              , pProcAnchor = def
+              }
+          )
+          [injectFailure $ MalformedProposal ga]
+      context "PPU GovActionLifetime cannot be greater than DRepActivity" $ do
+        let
+          runTest ga = do
+            rew <- registerRewardAccount
+            pp <- getsNES $ nesEsL . curPParamsEpochStateL
+            submitFailingProposal
+              ( ProposalProcedure
+                  { pProcReturnAddr = rew
+                  , pProcGovAction = ga
+                  , pProcDeposit = pp ^. ppGovActionDepositL
+                  , pProcAnchor = def
+                  }
+              )
+              [injectFailure $ MalformedProposal ga]
+        it "GovActionLifetime greater than DRepActivity" $
+          runTest $
+            ParameterChange
+              SNothing
+              ( emptyPParamsUpdate
+                  & ppuGovActionLifetimeL .~ SJust (EpochInterval 11)
+                  & ppuDRepActivityL .~ SJust (EpochInterval 10)
+              )
+              SNothing
+        it "GovActionLifetime as SNothing, DRepActivity as SJust" $
+          runTest $
+            ParameterChange
+              SNothing
+              ( emptyPParamsUpdate
+                  & ppuGovActionLifetimeL .~ SNothing
+                  & ppuDRepActivityL .~ SJust (EpochInterval 10)
+              )
+              SNothing
     context "Proposal-forests" $ do
       context "GOV, EPOCH, RATIFY and ENACT" $ do
         it "Proposals submitted without proper parent fail" $ do


### PR DESCRIPTION
# Description

Resolves #4090 

1. The `minUTxOValue` check is deprecated in `alonzo` but still present in a version of the spec [here](https://intersectmbo.github.io/formal-ledger-specifications/html/Ledger.PParams.html#2246)
2. ~~The `GovActionLifetime <= DRepActivity` check was missing and has been added.~~ This change has been reverted.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
