### PR TITLE
fix `prop_DELEG` in STS tests

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
@@ -36,14 +36,20 @@ delegCertSpec ::
 delegCertSpec pp ds =
   let rewardMap = unUnify $ rewards ds
       delegMap = unUnify $ delegations ds
+      depositOf k =
+        case fromCompact . rdDeposit <$> Map.lookup k rewardMap of
+          Just d | d > 0 -> SJust d
+          _              -> SNothing
    in constrained $ \dc ->
         (caseOn dc)
           -- ConwayRegCert !(StakeCredential c) !(StrictMaybe Coin)
           (branch $ \_ mc -> mc ==. lit (SJust (pp ^. ppKeyDepositL)))
           -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
           ( branch $ \sc mc ->
-              onJust' mc $ \c ->
-                elem_ (pair_ sc c) $ lit [(k, r) | (k, RDPair (fromCompact -> r) _) <- Map.toList rewardMap]
+              [ assert $ elem_ sc $ lit (Map.keys $ Map.filter ((== 0) . fromCompact . rdReward) rewardMap)
+              , assert $ elem_ sc $ lit (Map.keys delegMap)
+              , reify sc depositOf (==. mc)
+              ]
           )
           -- ConwayDelegCert !(StakeCredential c) !(Delegatee c)
           (branch $ \sc _ -> member_ sc $ lit (Map.keysSet delegMap))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
@@ -36,6 +36,7 @@ delegCertSpec ::
 delegCertSpec pp ds =
   let rewardMap = unUnify $ rewards ds
       delegMap = unUnify $ delegations ds
+      zeroReward = (== 0) . fromCompact . rdReward
       depositOf k =
         case fromCompact . rdDeposit <$> Map.lookup k rewardMap of
           Just d | d > 0 -> SJust d
@@ -46,7 +47,7 @@ delegCertSpec pp ds =
           (branch $ \_ mc -> mc ==. lit (SJust (pp ^. ppKeyDepositL)))
           -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
           ( branch $ \sc mc ->
-              [ assert $ elem_ sc $ lit (Map.keys $ Map.filter ((== 0) . fromCompact . rdReward) rewardMap)
+              [ assert $ elem_ sc $ lit (Map.keys $ Map.filter zeroReward rewardMap)
               , assert $ elem_ sc $ lit (Map.keys delegMap)
               , reify sc depositOf (==. mc)
               ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
@@ -47,9 +47,11 @@ delegCertSpec pp ds =
           (branch $ \_ mc -> mc ==. lit (SJust (pp ^. ppKeyDepositL)))
           -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
           ( branch $ \sc mc ->
-              [ assert $ elem_ sc $ lit (Map.keys $ Map.filter zeroReward rewardMap)
+              [ -- You can only unregister things with 0 reward
+                assert $ elem_ sc $ lit (Map.keys $ Map.filter zeroReward rewardMap)
               , assert $ elem_ sc $ lit (Map.keys delegMap)
-              , reify sc depositOf (==. mc)
+              , -- The `StrictMaybe` needs to be precisely what is in the delegation map
+                reify sc depositOf (==. mc)
               ]
           )
           -- ConwayDelegCert !(StakeCredential c) !(Delegatee c)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/DELEG.hs
@@ -40,7 +40,7 @@ delegCertSpec pp ds =
       depositOf k =
         case fromCompact . rdDeposit <$> Map.lookup k rewardMap of
           Just d | d > 0 -> SJust d
-          _              -> SNothing
+          _ -> SNothing
    in constrained $ \dc ->
         (caseOn dc)
           -- ConwayRegCert !(StakeCredential c) !(StrictMaybe Coin)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -279,8 +279,8 @@ govTests =
     , testProperty "prop_DELEG" prop_DELEG
     , testProperty "prop_ENACT" prop_ENACT
     , testProperty "prop_RATIFY" prop_RATIFY
+    , testProperty "prop_CERT" prop_CERT
     -- , testProperty "prop_GOV" prop_GOV
-    -- , testProperty "prop_CERT" prop_CERT
     ]
 
 utxoTests :: TestTree

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -276,8 +276,8 @@ govTests =
     "GOV tests"
     [ testProperty "prop_GOVCERT" prop_GOVCERT
     , testProperty "prop_POOL" prop_POOL
-    , -- , testProperty "prop_DELEG" prop_DELEG
-      testProperty "prop_ENACT" prop_ENACT
+    , testProperty "prop_DELEG" prop_DELEG
+    , testProperty "prop_ENACT" prop_ENACT
     , testProperty "prop_RATIFY" prop_RATIFY
     -- , testProperty "prop_GOV" prop_GOV
     -- , testProperty "prop_CERT" prop_CERT


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
