### PR TITLE
Add missing arbitrary instance for predicate failures.

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -136,6 +136,7 @@ library testlib
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api,
         data-default-class,
+        generic-random,
         microlens,
         microlens-mtl,
         text

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -116,6 +116,7 @@ library testlib
         cardano-ledger-babbage,
         cardano-ledger-binary,
         cardano-ledger-core:{cardano-ledger-core, testlib},
+        generic-random,
         small-steps,
         QuickCheck
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -15,10 +15,14 @@ import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (Sized)
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Plutus.TxInfo (TxOutSource)
 import Control.State.Transition (STS (PredicateFailure))
 import Data.Functor.Identity (Identity)
+import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.QuickCheck
 
@@ -76,6 +80,17 @@ instance Arbitrary (BabbagePParams StrictMaybe era) where
       <*> arbitrary
       <*> arbitrary
 
+instance Crypto crypto => Arbitrary (TxOutSource crypto) where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
+  Arbitrary (BabbageContextError era)
+  where
+  arbitrary = genericArbitraryU
+
 instance
   ( EraTxOut era
   , Arbitrary (Value era)
@@ -84,27 +99,18 @@ instance
   ) =>
   Arbitrary (BabbageUtxoPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ AlonzoInBabbageUtxoPredFailure <$> arbitrary
-      , IncorrectTotalCollateralField <$> arbitrary <*> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance
   ( Era era
   , Arbitrary (PredicateFailure (EraRule "UTXO" era))
-  , Arbitrary (PlutusPurpose AsItem era)
   , Arbitrary (TxCert era)
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
   ) =>
   Arbitrary (BabbageUtxowPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ AlonzoInBabbageUtxowPredFailure <$> arbitrary
-      , UtxoFailure <$> arbitrary
-      , MalformedScriptWitnesses <$> arbitrary
-      , MalformedReferenceScripts <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance
   ( EraTxOut era

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -148,8 +148,10 @@ library testlib
         cardano-ledger-shelley,
         cardano-strict-containers,
         data-default-class,
+        generic-random,
         small-steps,
-        text
+        text,
+        small-steps
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -47,6 +47,7 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.HKD (HKD, NoUpdate (..))
 import Control.State.Transition.Extended (STS (Event))
@@ -59,6 +60,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Word
+import Generic.Random (genericArbitraryU)
 import Lens.Micro
 import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Data.Arbitrary ()
@@ -80,6 +82,16 @@ instance
   Arbitrary (DRepPulsingState era)
   where
   arbitrary = DRComplete <$> arbitrary <*> arbitrary
+
+instance
+  ( Era era
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  , Arbitrary (TxCert era)
+  ) =>
+  Arbitrary (ConwayContextError era)
+  where
+  arbitrary = genericArbitraryU
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
   arbitrary =
@@ -569,22 +581,23 @@ instance (EraPParams era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovProced
     GovProcedures <$> arbitrary <*> arbitrary
   shrink (GovProcedures vp pp) = [GovProcedures vp' pp' | (vp', pp') <- shrink (vp, pp)]
 
-instance Era era => Arbitrary (ConwayGovPredFailure era) where
-  arbitrary = GovActionsDoNotExist <$> arbitrary
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (ConwayGovPredFailure era)
+  where
+  arbitrary = genericArbitraryU
 
 instance
-  ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "UTXOW" era))
   , Arbitrary (PredicateFailure (EraRule "CERTS" era))
   , Arbitrary (PredicateFailure (EraRule "GOV" era))
   ) =>
   Arbitrary (ConwayLedgerPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ ConwayUtxowFailure <$> arbitrary
-      , ConwayCertsFailure <$> arbitrary
-      , ConwayGovFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- EPOCH
 
@@ -623,12 +636,7 @@ instance
   ) =>
   Arbitrary (ConwayCertsPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ DelegateeNotRegisteredDELEG <$> arbitrary
-      , WithdrawalsNotInRewardsCERTS <$> arbitrary
-      , CertFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- CERT
 
@@ -640,12 +648,7 @@ instance
   ) =>
   Arbitrary (ConwayCertPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ DelegFailure <$> arbitrary
-      , PoolFailure <$> arbitrary
-      , GovCertFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- DELEG
 
@@ -653,25 +656,12 @@ instance
   Era era =>
   Arbitrary (ConwayDelegPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ IncorrectDepositDELEG <$> arbitrary
-      , StakeKeyRegisteredDELEG <$> arbitrary
-      , StakeKeyNotRegisteredDELEG <$> arbitrary
-      , StakeKeyHasNonZeroRewardAccountBalanceDELEG <$> arbitrary
-      , DRepAlreadyRegisteredForStakeKeyDELEG <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- GOVCERT
 
 instance Era era => Arbitrary (ConwayGovCertPredFailure era) where
-  arbitrary =
-    oneof
-      [ ConwayDRepAlreadyRegistered <$> arbitrary
-      , ConwayDRepNotRegistered <$> arbitrary
-      , ConwayDRepIncorrectDeposit <$> arbitrary <*> arbitrary
-      , ConwayCommitteeHasPreviouslyResigned <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance Arbitrary (HKD f a) => Arbitrary (THKD t f a) where
   arbitrary = THKD <$> arbitrary


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Several variants from predicate failures types are missing from arbitrary generators, resulting in gaps in testing. I've switch to leverage generics since there's no particular constraints on those generators and it'll avoid the future oversights when adding new variants to the types (since the compiler won't raise any exhaustiveness error in this case). 

Note: the PR is made on top of `cardano-ledger-conway-1.12.0.0`. There might be changes on top of that since then. I let it to whoever will pick this up to rebase and resolve conflicts if any.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
