### PR TITLE
Imp script fixes

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Add `zipAsIxItem`
 
 ### `testlib`
-
+* Rename `fixupPlutusScripts` to `fixupRedeemers`
 * Add:
   * `impLookupPlutusScript`
   * `fixupPPHash`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -16,7 +16,7 @@ module Test.Cardano.Ledger.Alonzo.ImpTest (
   impAddPlutusScript,
   impLookupPlutusScript,
   fixupPPHash,
-  fixupPlutusScripts,
+  fixupRedeemers,
   addCollateralInput,
   alonzoFixupTx,
   impGetPlutusContexts,
@@ -141,7 +141,7 @@ impGetPlutusContexts tx = do
     pure $ (prp,sh,) <$> ctx
   pure $ catMaybes mbyContexts
 
-fixupPlutusScripts ::
+fixupRedeemers ::
   forall era.
   ( EraUTxO era
   , EraGov era
@@ -151,7 +151,7 @@ fixupPlutusScripts ::
   ) =>
   Tx era ->
   ImpTestM era (Tx era)
-fixupPlutusScripts tx = do
+fixupRedeemers tx = do
   contexts <- impGetPlutusContexts tx
   exUnits <- getsNES $ nesEsL . curPParamsEpochStateL . ppMaxTxExUnitsL
   let
@@ -273,7 +273,7 @@ alonzoFixupTx =
   addNativeScriptTxWits
     >=> addCollateralInput
     >=> addRootTxIn
-    >=> fixupPlutusScripts
+    >=> fixupRedeemers
     >=> fixupScriptWits
     >=> fixupDatums
     >=> fixupPPHash

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -64,19 +64,18 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
-import Control.Monad (forM)
+import Control.Monad (forM, join)
 import Data.Default.Class (Default)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (fromElems)
 import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Lens.Micro ((%~), (&), (.~), (<>~), (^.))
+import Lens.Micro
 import Lens.Micro.Mtl (use, (%=), (.=))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Imp.Common (expectJust)
 import Test.Cardano.Ledger.Plutus (PlutusArgs (..), ScriptTestContext (..), testingCostModels)
 import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest
 
@@ -203,26 +202,34 @@ fixupDatums ::
   ImpTestM era (Tx era)
 fixupDatums tx = do
   contexts <- impGetPlutusContexts tx
-  scripts <- use impScriptsL
-  let
-    txOutScriptHash txOut
-      | Addr _ (ScriptHashObj sh) _ <- txOut ^. addrTxOutL = sh
-      | otherwise = error "TxOut does not have a payment script"
-    spendDatum (ScriptTestContext _ (PlutusArgs _ (Just d))) = Data d
-    spendDatum _ = error "Context does not have a spending datum"
-    filterInline (purpose, _, _) = do
-      AsItem txIn <- expectJust . toSpendingPurpose $ hoistPlutusPurpose toAsItem purpose
-      txOut <- impLookupUTxO @era txIn
-      pure $ case txOut ^. datumTxOutF of
-        DatumHash _dh -> spendDatum <$> Map.lookup (txOutScriptHash txOut) scripts
-        _ -> Nothing
-  datums <- traverse filterInline contexts
+  let purposes = (^. _1) <$> contexts
+  datums <- traverse collectDatums purposes
   let TxDats prevDats = tx ^. witsTxL . datsTxWitsL
   pure $
     tx
       & witsTxL . datsTxWitsL
         .~ TxDats
           (Map.union prevDats $ fromElems hashData (catMaybes datums))
+  where
+    collectDatums :: PlutusPurpose AsIxItem era -> ImpTestM era (Maybe (Data era))
+    collectDatums purpose = do
+      let txIn = unAsItem <$> toSpendingPurpose (hoistPlutusPurpose toAsItem purpose)
+      txOut <- traverse (impLookupUTxO @era) txIn
+      join <$> traverse getData txOut
+
+    getData :: TxOut era -> ImpTestM era (Maybe (Data era))
+    getData txOut = do
+      scripts <- use impScriptsL
+      pure $ case txOut ^. datumTxOutF of
+        DatumHash _dh -> spendDatum <$> Map.lookup (txOutScriptHash txOut) scripts
+        _ -> Nothing
+
+    txOutScriptHash txOut
+      | Addr _ (ScriptHashObj sh) _ <- txOut ^. addrTxOutL = sh
+      | otherwise = error "TxOut does not have a payment script"
+
+    spendDatum (ScriptTestContext _ (PlutusArgs _ (Just d))) = Data d
+    spendDatum _ = error "Context does not have a spending datum"
 
 fixupPPHash ::
   forall era.

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.7.0.0
 
-* Add `babbageFixupTx`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add `NFData` instance for `BabbageUtxoPredFailure`, `BabbageUtxowPredFailure`
 * Add implementation for `getMinFeeTxUtxo`

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -5,6 +5,7 @@ module Main where
 import Cardano.Ledger.Babbage (Babbage)
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
+import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import qualified Test.Cardano.Ledger.Babbage.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Babbage.ImpTest ()
@@ -20,6 +21,7 @@ main =
       CddlSpec.spec
       roundTripJsonEraSpec @Babbage
       describe "Imp" $ do
+        AlonzoImp.spec @Babbage
         ShelleyImp.spec @Babbage
       describe "CostModels" $ do
         CostModelsSpec.spec @Babbage

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -7,31 +7,17 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Babbage.ImpTest (babbageFixupTx) where
+module Test.Cardano.Ledger.Babbage.ImpTest () where
 
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
 import Cardano.Crypto.Hash (Hash)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageEra)
-import Cardano.Ledger.Babbage.Core (
-  AlonzoEraTxWits (..),
-  BabbageEraTxBody (..),
- )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Shelley.UTxO (EraUTxO (..))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
 import Test.Cardano.Ledger.Alonzo.ImpTest (
-  ImpTestM,
-  addCollateralInput,
-  addNativeScriptTxWits,
-  addRootTxIn,
-  fixupDatums,
-  fixupFees,
-  fixupPPHash,
-  fixupPlutusScripts,
+  alonzoFixupTx,
   initAlonzoImpNES,
-  updateAddrTxWits,
  )
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
@@ -47,23 +33,4 @@ instance
   where
   initImpNES = initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
-  fixupTx = babbageFixupTx
-
-babbageFixupTx ::
-  ( ShelleyEraImp era
-  , AlonzoEraTxWits era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , BabbageEraTxBody era
-  , AlonzoEraUTxO era
-  ) =>
-  Tx era ->
-  ImpTestM era (Tx era)
-babbageFixupTx =
-  addNativeScriptTxWits
-    >=> addCollateralInput
-    >=> addRootTxIn
-    >=> fixupPlutusScripts
-    >=> fixupDatums
-    >=> fixupPPHash
-    >=> fixupFees
-    >=> updateAddrTxWits
+  fixupTx = alonzoFixupTx

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -5,6 +5,7 @@ module Main where
 import Cardano.Ledger.Conway (Conway)
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
+import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
@@ -31,6 +32,7 @@ main =
       GovActionReorder.spec
       roundTripJsonEraSpec @Conway
       describe "Imp" $ do
+        AlonzoImp.spec @Conway
         ConwayImp.spec @Conway
         ShelleyImp.spec @Conway
       describe "CostModels" $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -37,7 +37,6 @@ import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val (zero)
 import Data.Default.Class (Default (..))
 import Data.Foldable (Foldable (..), traverse_)
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.Sequence as Seq
@@ -681,31 +680,6 @@ spec =
                       SNothing
                   )
           submitGovAction_ constitutionAction1
-    describe "Votes fail as expected" $ do
-      it "on expired gov-actions" $ do
-        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2 -- Voting after the 3rd epoch should fail
-        (khDRep, _, _) <- setupSingleDRep 1_000_000
-        gaidConstitutionProp <- submitInitConstitutionGovAction
-        passEpoch
-        passEpoch
-        passEpoch
-        let voter = DRepVoter $ KeyHashObj khDRep
-        submitFailingVote
-          voter
-          gaidConstitutionProp
-          [ injectFailure $
-              VotingOnExpiredGovAction $
-                (voter, gaidConstitutionProp) NE.:| []
-          ]
-      it "on non-existant gov-actions" $ do
-        (khDRep, _, _) <- setupSingleDRep 1_000_000
-        gaidConstitutionProp <- submitInitConstitutionGovAction
-        let voter = DRepVoter $ KeyHashObj khDRep
-            dummyGaid = gaidConstitutionProp {gaidGovActionIx = GovActionIx 99} -- non-existant `GovActionId`
-        submitFailingVote
-          voter
-          dummyGaid
-          [injectFailure $ GovActionsDoNotExist $ dummyGaid NE.:| []]
 
     describe "Voting" $ do
       context "fails for" $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -157,7 +157,6 @@ import qualified GHC.Exts as GHC (fromList)
 import Lens.Micro (Lens', (%~), (&), (.~), (^.))
 import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
 import Test.Cardano.Ledger.Alonzo.ImpTest as ImpTest
-import Test.Cardano.Ledger.Babbage.ImpTest (babbageFixupTx)
 import Test.Cardano.Ledger.Conway.TreeDiff ()
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr)
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
@@ -201,7 +200,7 @@ instance
 
   modifyPParams = conwayModifyPParams
 
-  fixupTx = babbageFixupTx
+  fixupTx = alonzoFixupTx
 
 class
   ( ShelleyEraImp era


### PR DESCRIPTION
# Description

Miscellaneous fixes and improvements related to plutus scripts support in Imp tests: 
* tolerating  non-spending  purpose
* fixing scriptWits fixup, such that both reference and non-reference scripts are supported (by not providing what already is provided) 
* running Alonzo Imp tests in babbage and conway eras  (failing without the previous fix) 
 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
