### PR TITLE
Bump Plutus deps to 1.22.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,7 +20,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-01-04T21:59:02Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-02-15T21:00:00Z
+  , cardano-haskell-packages 2024-02-22T17:04:08Z
 
 packages:
   eras/allegra/impl

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -90,7 +90,7 @@ library
         mtl,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         set-algebra >=1.0,
         small-steps >=1.0,
         text,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -59,7 +59,7 @@ library
         containers,
         data-default-class,
         microlens,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         QuickCheck,
         random,
         serialise,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -83,7 +83,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         set-algebra,
         small-steps,
         text,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -96,7 +96,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         set-algebra,
         small-steps,
         text,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1708015143,
-        "narHash": "sha256-KkKYA6TP2T+lt74+m3lzeA6I5zzk2JNjw3TClg0ynDM=",
+        "lastModified": 1708623073,
+        "narHash": "sha256-4V4gwvyqBQ9LD/H7W5C9SNw8XYX7DauLpo0upR7bD1Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "1d3af4a597179eedf818575254782f0767eb00bd",
+        "rev": "5a82d3179f692326bc560becc4fe14625a361840",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -67,7 +67,7 @@ library
         network,
         nothunks,
         primitive,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         recursion-schemes,
         serialise,
         tagged,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -139,7 +139,7 @@ library
         mtl,
         nothunks,
         hspec,
-        plutus-ledger-api ^>=1.21,
+        plutus-ledger-api ^>=1.22,
         prettyprinter,
         QuickCheck,
         small-steps,


### PR DESCRIPTION
This PR updates Plutus dependencies versions to 1.22.0.0

Related: https://github.com/IntersectMBO/cardano-haskell-packages/pull/669
