### PR TITLE
Fail when conway features are present in transactions that use Plutus v1/v2

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -78,7 +78,6 @@ import Cardano.Ledger.TxIn (TxIn (..), txInToText)
 import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val (zero)
 import Cardano.Slotting.EpochInfo (EpochInfo)
-import Cardano.Slotting.Slot (EpochNo (..))
 import Cardano.Slotting.Time (SystemStart)
 import Control.Arrow (left)
 import Control.DeepSeq (NFData)
@@ -311,8 +310,8 @@ transTxCertCommon = \case
   RegPoolTxCert (PoolParams {ppId, ppVrf}) ->
     Just $
       PV1.DCertPoolRegister (transKeyHash ppId) (PV1.PubKeyHash (PV1.toBuiltin (hashToBytes ppVrf)))
-  RetirePoolTxCert poolId (EpochNo i) ->
-    Just $ PV1.DCertPoolRetire (transKeyHash poolId) (toInteger i)
+  RetirePoolTxCert poolId retireEpochNo ->
+    Just $ PV1.DCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
   _ -> Nothing
 
 transPlutusPurpose ::

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.13.0.0
 
+* Guard Conway-specific features in transactions that use Plutus v1 or v2. #4112
+  * Add `PlutusContextError` variants:
+    * `CurrentTreasuryValueFieldNotSupported`
+    * `VotingProceduresFieldNotSupported`
+    * `ProposalProceduresFieldNotSupported`
+    * `TreasuryDonationFieldNotSupported`
+  * Allow `RegDepositTxCert` and `UnRegDepositTxCert` to pass by ignoring the deposit or refund values, respectively.
 * Switch `EPOCH` rule environment back to `()`. Start using the latest stake pool
   distribution: #4115
 * Add:

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -133,7 +133,7 @@ library testlib
     build-depends:
         base,
         bytestring,
-        cardano-data:testlib,
+        cardano-data:{cardano-data, testlib},
         containers,
         plutus-ledger-api,
         deepseq,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -15,9 +15,8 @@ import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
-import Cardano.Ledger.Conway.Rules (
-  ConwayGovPredFailure,
- )
+import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure)
+import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
@@ -32,6 +31,7 @@ spec ::
   , GovState era ~ ConwayGovState era
   , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
   , Inject (BabbageContextError era) (ContextError era)
+  , Inject (ConwayContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   ) =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -12,70 +12,71 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..))
-import Cardano.Ledger.Babbage.Rules (
-  BabbageUtxoPredFailure (..),
- )
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
-import Cardano.Ledger.BaseTypes (
-  Inject (..),
-  Network (..),
-  StrictMaybe (..),
-  maybeToStrictMaybe,
- )
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Core (
-  AlonzoEraScript (..),
-  AlonzoEraTxOut (..),
-  BabbageEraTxBody (..),
-  BabbageEraTxOut (..),
-  Era (..),
-  EraTx (..),
-  EraTxBody (..),
-  EraTxOut (..),
-  EraTxWits (..),
-  InjectRuleFailure (..),
-  ScriptHash,
-  txIdTx,
- )
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Conway.TxInfo
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus (Data (..), TxOutSource (..), hashData)
+import Cardano.Ledger.Plutus.Language (Plutus, PlutusLanguage)
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.TxIn (TxId (..), mkTxInPartial)
+import Data.Default.Class (def)
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.OSet.Strict as OSet
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro
 import qualified PlutusLedgerApi.V1 as P1
-import Test.Cardano.Ledger.Conway.ImpTest (
-  ImpTestM,
-  ImpTestState,
-  ShelleyEraImp,
-  freshKeyHash,
-  impAddPlutusScript,
-  impAnn,
-  impLookupPlutusScript,
-  lookupKeyPair,
-  submitFailingTx,
-  submitTxAnn,
- )
+import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
+import Test.Cardano.Ledger.Core.Rational ((%!))
+import Test.Cardano.Ledger.Core.Utils
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Plutus (PlutusArgs (..), ScriptTestContext (..))
-import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3)
+import Test.Cardano.Ledger.Plutus (ScriptTestContext (..))
+import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3, guessTheNumber3V2)
 
 spendDatum :: P1.Data
 spendDatum = P1.I 3
 
-setupPlutusV1Script :: AlonzoEraScript era => ImpTestM era (ScriptHash (EraCrypto era))
-setupPlutusV1Script = do
+setupScriptPlutus ::
+  (AlonzoEraScript era, PlutusLanguage p) =>
+  Plutus p ->
+  ImpTestM era (ScriptHash (EraCrypto era))
+setupScriptPlutus script =
   impAddPlutusScript
     ScriptTestContext
-      { stcScript = guessTheNumber3
+      { stcScript = script
       , stcArgs =
           PlutusArgs
             { paSpendDatum = Just spendDatum
             , paData = spendDatum
             }
       }
+
+setupScriptPlutusV1 :: AlonzoEraScript era => ImpTestM era (ScriptHash (EraCrypto era))
+setupScriptPlutusV1 = setupScriptPlutus guessTheNumber3
+
+setupScriptPlutusV2 :: AlonzoEraScript era => ImpTestM era (ScriptHash (EraCrypto era))
+setupScriptPlutusV2 = setupScriptPlutus guessTheNumber3V2
+
+txWithPlutus ::
+  forall era.
+  ConwayEraImp era =>
+  ImpTestM era (ScriptHash (EraCrypto era)) ->
+  ImpTestM era (Tx era)
+txWithPlutus setupScript = do
+  sh <- setupScript
+  submitTxAnn "Submit a Plutus" $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . outputsTxBodyL
+        .~ SSeq.singleton (scriptLockedTxOut sh)
 
 scriptLockedTxOut ::
   forall era.
@@ -104,7 +105,7 @@ setupRefTx ::
   ) =>
   ImpTestM era (TxId (EraCrypto era))
 setupRefTx = do
-  shSpending <- setupPlutusV1Script
+  shSpending <- setupScriptPlutusV1
   refTxOut <- mkRefTxOut shSpending
   fmap txIdTx . submitTxAnn "Producing transaction" $
     mkBasicTx mkBasicTxBody
@@ -115,75 +116,342 @@ setupRefTx = do
           , scriptLockedTxOut shSpending
           ]
 
+testPlutusV1V2Failure ::
+  forall era a.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , HasCallStack
+  ) =>
+  ImpTestM era (ScriptHash (EraCrypto era)) ->
+  a ->
+  Lens' (TxBody era) a ->
+  ContextError era ->
+  ImpTestM era ()
+testPlutusV1V2Failure setupScript badField lenz errorField = do
+  tx <- txWithPlutus @era setupScript
+  submitFailingTx
+    ( mkBasicTx mkBasicTxBody
+        & bodyTxL . inputsTxBodyL
+          .~ Set.singleton (txInAt (0 :: Int) tx)
+        & bodyTxL . lenz
+          .~ badField
+    )
+    [injectFailure $ CollectErrors [BadTranslation errorField]]
+
 spec ::
   forall era.
-  ( ShelleyEraImp era
-  , BabbageEraTxBody era
-  , Inject (BabbageContextError era) (ContextError era)
+  ( Inject (BabbageContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , ConwayEraImp era
+  , Inject (ConwayContextError era) (ContextError era)
   ) =>
   SpecWith (ImpTestState era)
 spec =
   describe "UTXOS" $ do
-    it "can use reference scripts" $ do
-      producingTx <- setupRefTx
-      referringTx <-
-        submitTxAnn "Transaction that refers to the script" $
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . inputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 1)
-            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
-      (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
-    it "can use regular inputs for reference" $ do
-      producingTx <- setupRefTx
-      referringTx <-
-        submitTxAnn "Consuming transaction" $
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . inputsTxBodyL
-              .~ Set.fromList
-                [ mkTxInPartial producingTx 0
-                , mkTxInPartial producingTx 1
+    datumAndReferenceInputsSpec
+    conwayFeaturesPlutusV1V2FailureSpec
+
+datumAndReferenceInputsSpec ::
+  forall era.
+  ( Inject (BabbageContextError era) (ContextError era)
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , ConwayEraImp era
+  ) =>
+  SpecWith (ImpTestState era)
+datumAndReferenceInputsSpec = do
+  it "can use reference scripts" $ do
+    producingTx <- setupRefTx
+    referringTx <-
+      submitTxAnn "Transaction that refers to the script" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 1)
+          & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+    (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
+  it "can use regular inputs for reference" $ do
+    producingTx <- setupRefTx
+    referringTx <-
+      submitTxAnn "Consuming transaction" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL
+            .~ Set.fromList
+              [ mkTxInPartial producingTx 0
+              , mkTxInPartial producingTx 1
+              ]
+    (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
+  it "fails with same txIn in regular inputs and reference inputs" $ do
+    producingTx <- setupRefTx
+    let
+      consumingTx =
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL
+            .~ Set.fromList
+              [ mkTxInPartial producingTx 0
+              , mkTxInPartial producingTx 1
+              ]
+          & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+    _ <-
+      submitFailingTx
+        consumingTx
+        [ injectFailure . BabbageNonDisjointRefInputs $
+            mkTxInPartial producingTx 0 :| []
+        ]
+    pure ()
+  it "fails when using inline datums for PlutusV1" $ do
+    shSpending <- setupScriptPlutusV1
+    refTxOut <- mkRefTxOut shSpending
+    producingTx <-
+      fmap txIdTx . submitTxAnn "Producing transaction" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . outputsTxBodyL
+            .~ SSeq.fromList
+              [ refTxOut
+              , scriptLockedTxOut shSpending & dataTxOutL .~ SJust (Data spendDatum)
+              ]
+    let
+      lockedTxIn = mkTxInPartial producingTx 1
+      consumingTx =
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL .~ Set.singleton lockedTxIn
+          & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
+    impAnn "Consuming transaction" $
+      submitFailingTx
+        consumingTx
+        [ injectFailure $
+            CollectErrors
+              [BadTranslation . inject . InlineDatumsNotSupported @era $ TxOutFromInput lockedTxIn]
+        ]
+
+conwayFeaturesPlutusV1V2FailureSpec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , Inject (ConwayContextError era) (ContextError era)
+  ) =>
+  SpecWith (ImpTestState era)
+conwayFeaturesPlutusV1V2FailureSpec = do
+  describe "Conway features fail in Plutusdescribe v1 and v2" $ do
+    describe "Unsupported Fields" $ do
+      describe "CurrentTreasuryValue" $ do
+        it "V1"
+          $ testPlutusV1V2Failure
+            setupScriptPlutusV1
+            (SJust (Coin 10_000))
+            currentTreasuryValueTxBodyL
+          $ inject
+          $ CurrentTreasuryFieldNotSupported @era
+          $ Coin 10_000
+        it "V2"
+          $ testPlutusV1V2Failure
+            setupScriptPlutusV2
+            (SJust (Coin 10_000))
+            currentTreasuryValueTxBodyL
+          $ inject
+          $ CurrentTreasuryFieldNotSupported @era
+          $ Coin 10_000
+      describe "VotingProcedures" $ do
+        it "V1" $ do
+          drepC <- KeyHashObj <$> registerDRep
+          cc <- KeyHashObj <$> freshKeyHash
+          proposal <-
+            submitGovAction $
+              UpdateCommittee SNothing mempty (Map.singleton cc $ EpochNo 10) (1 %! 2)
+          let badField =
+                VotingProcedures
+                  $ Map.singleton
+                    (DRepVoter drepC)
+                  $ Map.singleton proposal
+                  $ VotingProcedure VoteYes SNothing
+          testPlutusV1V2Failure
+            setupScriptPlutusV1
+            badField
+            votingProceduresTxBodyL
+            $ inject
+            $ VotingProceduresFieldNotSupported badField
+        it "V2" $ do
+          drepC <- KeyHashObj <$> registerDRep
+          cc <- KeyHashObj <$> freshKeyHash
+          proposal <-
+            submitGovAction $
+              UpdateCommittee SNothing mempty (Map.singleton cc $ EpochNo 10) (1 %! 2)
+          let badField =
+                VotingProcedures
+                  $ Map.singleton
+                    (DRepVoter drepC)
+                  $ Map.singleton proposal
+                  $ VotingProcedure VoteYes SNothing
+          testPlutusV1V2Failure
+            setupScriptPlutusV2
+            badField
+            votingProceduresTxBodyL
+            $ inject
+            $ VotingProceduresFieldNotSupported badField
+      describe "ProposalProcedures" $ do
+        it "V1" $ do
+          deposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+          rewardAccount <- registerRewardAccount
+          let badField = OSet.singleton $ ProposalProcedure deposit rewardAccount InfoAction def
+          testPlutusV1V2Failure
+            setupScriptPlutusV1
+            badField
+            proposalProceduresTxBodyL
+            $ inject
+            $ ProposalProceduresFieldNotSupported badField
+        it "V2" $ do
+          deposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+          rewardAccount <- registerRewardAccount
+          let badField = OSet.singleton $ ProposalProcedure deposit rewardAccount InfoAction def
+          testPlutusV1V2Failure
+            setupScriptPlutusV2
+            badField
+            proposalProceduresTxBodyL
+            $ inject
+            $ ProposalProceduresFieldNotSupported badField
+      describe "TreasuryDonation" $ do
+        it "V1"
+          $ testPlutusV1V2Failure
+            setupScriptPlutusV1
+            (Coin 10_000)
+            treasuryDonationTxBodyL
+          $ inject
+          $ TreasuryDonationFieldNotSupported @era
+          $ Coin 10_000
+        it "V2"
+          $ testPlutusV1V2Failure
+            setupScriptPlutusV2
+            (Coin 10_000)
+            treasuryDonationTxBodyL
+          $ inject
+          $ TreasuryDonationFieldNotSupported @era
+          $ Coin 10_000
+    describe "Certificates" $ do
+      describe "Translated" $ do
+        let testCertificateTranslated okCert tx = do
+              submitTx_
+                ( mkBasicTx mkBasicTxBody
+                    & bodyTxL . inputsTxBodyL
+                      .~ Set.singleton (txInAt (0 :: Int) tx)
+                    & bodyTxL . certsTxBodyL
+                      .~ SSeq.singleton okCert
+                )
+        describe "RegDepositTxCert" $ do
+          it "V1" $ do
+            stakingC <- KeyHashObj <$> freshKeyHash
+            let regDepositTxCert = RegDepositTxCert stakingC (Coin 0)
+            testCertificateTranslated regDepositTxCert =<< txWithPlutus setupScriptPlutusV1
+          it "V2" $ do
+            stakingC <- KeyHashObj <$> freshKeyHash
+            let regDepositTxCert = RegDepositTxCert stakingC (Coin 0)
+            testCertificateTranslated regDepositTxCert =<< txWithPlutus setupScriptPlutusV2
+        describe "UnRegDepositTxCert" $ do
+          it "V1" $ do
+            (_poolKH, _spendingC, stakingC) <- setupPoolWithStake $ Coin 1_000
+            let unRegDepositTxCert = UnRegDepositTxCert stakingC (Coin 0)
+            testCertificateTranslated unRegDepositTxCert =<< txWithPlutus setupScriptPlutusV1
+          it "V2" $ do
+            (_poolKH, _spendingC, stakingC) <- setupPoolWithStake $ Coin 1_000
+            let unRegDepositTxCert = UnRegDepositTxCert stakingC (Coin 0)
+            testCertificateTranslated unRegDepositTxCert =<< txWithPlutus setupScriptPlutusV2
+      describe "Unsupported" $ do
+        let testCertificateNotSupportedV1 badCert =
+              testCertificateNotSupported badCert =<< txWithPlutus @era setupScriptPlutusV1
+            testCertificateNotSupportedV2 badCert =
+              testCertificateNotSupported badCert =<< txWithPlutus @era setupScriptPlutusV2
+            testCertificateNotSupported badCert tx = do
+              submitFailingTx
+                ( mkBasicTx mkBasicTxBody
+                    & bodyTxL . inputsTxBodyL
+                      .~ Set.singleton (txInAt (0 :: Int) tx)
+                    & bodyTxL . certsTxBodyL
+                      .~ SSeq.singleton badCert
+                )
+                [ injectFailure $
+                    CollectErrors
+                      [ BadTranslation $
+                          inject $
+                            CertificateNotSupported badCert
+                      ]
                 ]
-      (referringTx ^. witsTxL . scriptTxWitsL) `shouldBe` mempty
-    it "fails with same txIn in regular inputs and reference inputs" $ do
-      producingTx <- setupRefTx
-      let
-        consumingTx =
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . inputsTxBodyL
-              .~ Set.fromList
-                [ mkTxInPartial producingTx 0
-                , mkTxInPartial producingTx 1
-                ]
-            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
-      _ <-
-        submitFailingTx
-          consumingTx
-          [ injectFailure . BabbageNonDisjointRefInputs $
-              mkTxInPartial producingTx 0 :| []
-          ]
-      pure ()
-    it "fails when using inline datums for PlutusV1" $ do
-      shSpending <- setupPlutusV1Script
-      refTxOut <- mkRefTxOut shSpending
-      producingTx <-
-        fmap txIdTx . submitTxAnn "Producing transaction" $
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . outputsTxBodyL
-              .~ SSeq.fromList
-                [ refTxOut
-                , scriptLockedTxOut shSpending & dataTxOutL .~ SJust (Data spendDatum)
-                ]
-      let
-        lockedTxIn = mkTxInPartial producingTx 1
-        consumingTx =
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . inputsTxBodyL .~ Set.singleton lockedTxIn
-            & bodyTxL . referenceInputsTxBodyL .~ Set.singleton (mkTxInPartial producingTx 0)
-      impAnn "Consuming transaction" $
-        submitFailingTx
-          consumingTx
-          [ injectFailure $
-              CollectErrors
-                [BadTranslation . inject . InlineDatumsNotSupported @era $ TxOutFromInput lockedTxIn]
-          ]
+        describe "DelegTxCert" $ do
+          it "V1" $ do
+            (drepKH, delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let delegTxCert =
+                  DelegTxCert @era
+                    (KeyHashObj delegatorKH)
+                    (DelegVote (DRepCredential $ KeyHashObj drepKH))
+            testCertificateNotSupportedV1 delegTxCert
+          it "V2" $ do
+            (drepKH, delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let delegTxCert =
+                  DelegTxCert @era
+                    (KeyHashObj delegatorKH)
+                    (DelegVote (DRepCredential $ KeyHashObj drepKH))
+            testCertificateNotSupportedV2 delegTxCert
+        describe "RegDepositDelegTxCert" $ do
+          it "V1" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            unregisteredDelegatorKH <- freshKeyHash
+            let regDepositDelegTxCert =
+                  RegDepositDelegTxCert @era
+                    (KeyHashObj unregisteredDelegatorKH)
+                    (DelegVote (DRepCredential $ KeyHashObj drepKH))
+                    (Coin 0)
+            testCertificateNotSupportedV1 regDepositDelegTxCert
+          it "V2" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            unregisteredDelegatorKH <- freshKeyHash
+            let regDepositDelegTxCert =
+                  RegDepositDelegTxCert @era
+                    (KeyHashObj unregisteredDelegatorKH)
+                    (DelegVote (DRepCredential $ KeyHashObj drepKH))
+                    (Coin 0)
+            testCertificateNotSupportedV2 regDepositDelegTxCert
+        describe "AuthCommitteeHotKeyTxCert" $ do
+          it "V1" $ do
+            coldKey <- KeyHashObj <$> freshKeyHash
+            hotKey <- KeyHashObj <$> freshKeyHash
+            let authCommitteeHotKeyTxCert = AuthCommitteeHotKeyTxCert @era coldKey hotKey
+            testCertificateNotSupportedV1 authCommitteeHotKeyTxCert
+          it "V2" $ do
+            coldKey <- KeyHashObj <$> freshKeyHash
+            hotKey <- KeyHashObj <$> freshKeyHash
+            let authCommitteeHotKeyTxCert = AuthCommitteeHotKeyTxCert @era coldKey hotKey
+            testCertificateNotSupportedV2 authCommitteeHotKeyTxCert
+        describe "ResignCommitteeColdTxCert" $ do
+          it "V1" $ do
+            coldKey <- KeyHashObj <$> freshKeyHash
+            let resignCommitteeColdTxCert = ResignCommitteeColdTxCert @era coldKey SNothing
+            testCertificateNotSupportedV1 resignCommitteeColdTxCert
+          it "V2" $ do
+            coldKey <- KeyHashObj <$> freshKeyHash
+            let resignCommitteeColdTxCert = ResignCommitteeColdTxCert @era coldKey SNothing
+            testCertificateNotSupportedV2 resignCommitteeColdTxCert
+        describe "RegDRepTxCert" $ do
+          it "V1" $ do
+            unregisteredDRepKH <- freshKeyHash
+            let regDRepTxCert = RegDRepTxCert @era (KeyHashObj unregisteredDRepKH) (Coin 0) SNothing
+            testCertificateNotSupportedV1 regDRepTxCert
+          it "V2" $ do
+            unregisteredDRepKH <- freshKeyHash
+            let regDRepTxCert = RegDRepTxCert @era (KeyHashObj unregisteredDRepKH) (Coin 0) SNothing
+            testCertificateNotSupportedV2 regDRepTxCert
+        describe "UnRegDRepTxCert" $ do
+          it "V1" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let unRegDRepTxCert = UnRegDRepTxCert @era (KeyHashObj drepKH) (Coin 0)
+            testCertificateNotSupportedV1 unRegDRepTxCert
+          it "V1" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let unRegDRepTxCert = UnRegDRepTxCert @era (KeyHashObj drepKH) (Coin 0)
+            testCertificateNotSupportedV2 unRegDRepTxCert
+        describe "UpdateDRepTxCert" $ do
+          it "V1" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let updateDRepTxCert = UpdateDRepTxCert @era (KeyHashObj drepKH) SNothing
+            testCertificateNotSupportedV1 updateDRepTxCert
+          it "V2" $ do
+            (drepKH, _delegatorKH, _spendingKP) <- setupSingleDRep 1_000
+            let updateDRepTxCert = UpdateDRepTxCert @era (KeyHashObj drepKH) SNothing
+            testCertificateNotSupportedV2 updateDRepTxCert

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -48,7 +48,9 @@ instance
 
 -- PlutusContext
 instance
-  ( ToExpr (TxCert era)
+  ( Era era
+  , ToExpr (PParamsHKD StrictMaybe era)
+  , ToExpr (TxCert era)
   , ToExpr (PlutusPurpose AsIx era)
   , ToExpr (PlutusPurpose AsItem era)
   ) =>

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.1.0
 
+* Add `ToJSON` instance for `OSet` #4112
 * Add `fromKeys`, `fromElems`
 * Add `OSet.fromList`
 * Add `fromFoldableDuplicates`

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -47,6 +47,7 @@ import Cardano.Ledger.Binary (
   setTag,
  )
 import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON (toJSON))
 import Data.Foldable qualified as F
 import Data.Sequence.Strict qualified as SSeq
 import Data.Set qualified as Set
@@ -106,6 +107,9 @@ instance EncCBOR a => EncCBOR (OSet a) where
 
 instance (Show a, Ord a, DecCBOR a) => DecCBOR (OSet a) where
   decCBOR = decodeSetLikeEnforceNoDuplicates (flip snoc) (\oset -> (size oset, oset)) decCBOR
+
+instance ToJSON a => ToJSON (OSet a) where
+  toJSON = toJSON . F.toList
 
 -- | \( O(1) \). Shallow invariant using just `length` and `size`.
 invariantHolds :: OSet a -> Bool


### PR DESCRIPTION
# Description

Resolves #4101 

~~This PR will be followed up by one that implements the tests.~~
Also adds tests :sweat_smile: 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
