### PR TITLE
NewConstraints phase1. Add BoolFn And and Or and tests

### DIFF
--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -3291,6 +3291,22 @@ not_ ::
   Term fn Bool
 not_ = app notFn
 
+infixr 3 &&.
+(&&.) ::
+  IsUniverse fn =>
+  Term fn Bool ->
+  Term fn Bool ->
+  Term fn Bool
+(&&.) = app andFn
+
+infixr 2 ||.
+(||.) ::
+  IsUniverse fn =>
+  Term fn Bool ->
+  Term fn Bool ->
+  Term fn Bool
+(||.) = app orFn
+
 elem_ ::
   forall a fn.
   HasSpec fn a =>

--- a/libs/constrained-generators/src/Constrained/Instances.hs
+++ b/libs/constrained-generators/src/Constrained/Instances.hs
@@ -67,5 +67,25 @@ instance IsUniverse fn => Functions (BoolFn fn) fn where
       let args = appendList (mapList (\(Value a) -> Lit a) pre) (v' :> mapList (\(Value a) -> Lit a) suf)
        in Let (App (injectFn fn) args) (v :-> ps)
   propagateSpecFun Not (NilCtx HOLE) spec = caseBoolSpec spec (equalSpec . not)
+  propagateSpecFun And (HOLE :? Value (s :: Bool) :> Nil) spec = caseBoolSpec spec (okAnd s)
+  propagateSpecFun And (Value (s :: Bool) :! NilCtx HOLE) spec = caseBoolSpec spec (okAnd s)
+  propagateSpecFun Or (HOLE :? Value (s :: Bool) :> Nil) spec = caseBoolSpec spec (okOr s)
+  propagateSpecFun Or (Value (s :: Bool) :! NilCtx HOLE) spec = caseBoolSpec spec (okOr s)
 
   mapTypeSpec Not _ = typeSpec ()
+
+-- | We have something like ('constant' &&. HOLE) must evaluate to 'need'. Return a (Spec fn Bool) for HOLE, that makes that True.
+okAnd :: Bool -> Bool -> Spec fn Bool
+okAnd constant need = case (constant, need) of
+  (True, True) -> MemberSpec [True]
+  (True, False) -> MemberSpec [False]
+  (False, False) -> TrueSpec
+  (False, True) -> ErrorSpec ["(" ++ show constant ++ " &&. HOLE) must equal True. That cannot be the case."]
+
+-- | We have something like ('constant' ||. HOLE) must evaluate to 'need'. Return a (Spec fn Bool) for HOLE, that makes that True.
+okOr :: Bool -> Bool -> Spec fn Bool
+okOr constant need = case (constant, need) of
+  (True, True) -> TrueSpec
+  (True, False) -> ErrorSpec ["(" ++ show constant ++ "||. HOLE) must equal False. That cannot be the case."]
+  (False, False) -> MemberSpec [False]
+  (False, True) -> MemberSpec [True]

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -153,6 +153,8 @@ tests =
     , testSpec "parallelLetPair" parallelLetPair
     , testSpec "mapSizeConstrained" mapSizeConstrained
     , numberyTests
+    , testSpec "andPair" andPair
+    , testSpec "orPair" orPair
     ]
       ++ [ testSpec ("intRangeSpec " ++ show i) (intRangeSpec i)
          | i <- [-1000, -100, -10, 0, 10, 100, 1000]
@@ -557,3 +559,13 @@ instance IsUniverse fn => HasSpec fn Three
 
 mapSizeConstrained :: Spec Fn (Map Three Int)
 mapSizeConstrained = constrained $ \m -> size_ (dom_ m) <=. 3
+
+andPair :: Spec Fn (Int, Int)
+andPair = constrained $ \p ->
+  match p $ \x y ->
+    x <=. 5 &&. y <=. 1
+
+orPair :: Spec Fn (Int, Int)
+orPair = constrained $ \p ->
+  match p $ \x y ->
+    x <=. 5 ||. y <=. 5

--- a/libs/constrained-generators/src/Constrained/Univ.hs
+++ b/libs/constrained-generators/src/Constrained/Univ.hs
@@ -133,14 +133,24 @@ instance FunctionLike (EqFn fn) where
 notFn :: forall fn. Member (BoolFn fn) fn => fn '[Bool] Bool
 notFn = injectFn $ Not @fn
 
+andFn :: forall fn. Member (BoolFn fn) fn => fn '[Bool, Bool] Bool
+andFn = injectFn $ And @fn
+
+orFn :: forall fn. Member (BoolFn fn) fn => fn '[Bool, Bool] Bool
+orFn = injectFn $ Or @fn
+
 data BoolFn (fn :: [Type] -> Type -> Type) as b where
   Not :: BoolFn fn '[Bool] Bool
+  And :: BoolFn fn '[Bool, Bool] Bool
+  Or :: BoolFn fn '[Bool, Bool] Bool
 
 deriving instance Eq (BoolFn fn as b)
 deriving instance Show (BoolFn fn as b)
 
 instance FunctionLike (BoolFn fn) where
   sem Not = not
+  sem And = (&&)
+  sem Or = (||)
 
 ------------------------------------------------------------------------
 -- Pairs


### PR DESCRIPTION
Add And and Or to BoolFn
complete the necessary instances
add the test mapSizeConstrained  as a baseline for future work.
add a test for (&&.) and (||.)

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
