### PR TITLE
Add the ability to do constraints over trees in `constrained-generators`

### DIFF
--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -31,6 +31,7 @@ library
         Constrained.Spec.Generics
         Constrained.Spec.Pairs
         Constrained.Spec.Maps
+        Constrained.Spec.Tree
         Constrained.Test
         Constrained.Internals
 

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1326,6 +1326,8 @@ isLit = isJust . fromLit
 
 simplifyPred :: BaseUniverse fn => Pred fn -> Pred fn
 simplifyPred = \case
+  -- If the term simplifies away to a literal, that means there is no
+  -- more generation to do so we can get rid of `GenHint`
   GenHint h t -> case simplifyTerm t of
     Lit {} -> TruePred
     t' -> GenHint h t'
@@ -1597,6 +1599,8 @@ aggressiveInlining inlineable p
             tell $ Any True
             pure $ assertExplain es b
         | otherwise -> pure p
+      -- If the term turns into a literal, there is no more generation to do here
+      -- so we can ignore the `GenHint`
       GenHint _ t
         | not (isLit t)
         , Lit {} <- simplifyTerm $ substituteTerm sub t -> do

--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -170,6 +170,8 @@ listOfT gen = do
   lst <- pureGen . listOf $ runGenT gen Loose
   catGEs lst
 
+-- | Generate a list of elements of length at most `goalLen`, but accepting failure
+-- to get that many elements so long as `validLen` is true.
 -- TODO: possibly one could return "more, fewer, ok" in the `validLen` instead
 -- of `Bool`
 listOfUntilLenT :: MonadGenError m => GenT GE a -> Int -> (Int -> Bool) -> GenT m [a]

--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -170,6 +170,16 @@ listOfT gen = do
   lst <- pureGen . listOf $ runGenT gen Loose
   catGEs lst
 
+-- TODO: possibly one could return "more, fewer, ok" in the `validLen` instead
+-- of `Bool`
+listOfUntilLenT :: MonadGenError m => GenT GE a -> Int -> (Int -> Bool) -> GenT m [a]
+listOfUntilLenT gen goalLen validLen =
+  genList `suchThatT` validLen . length
+  where
+    genList = do
+      res <- pureGen . vectorOf goalLen $ runGenT gen Loose
+      catGEs res
+
 vectorOfT :: MonadGenError m => Int -> GenT GE a -> GenT m [a]
 vectorOfT i gen = GenT $ \mode -> do
   res <- fmap sequence . vectorOf i $ runGenT gen Strict
@@ -206,6 +216,12 @@ oneofT :: MonadGenError m => [GenT GE a] -> GenT m a
 oneofT gs = do
   mode <- getMode
   r <- explain ["suchThatT in oneofT"] $ pureGen (oneof [runGenT g mode | g <- gs]) `suchThatT` isOk
+  runGE r
+
+frequencyT :: MonadGenError m => [(Int, GenT GE a)] -> GenT m a
+frequencyT gs = do
+  mode <- getMode
+  r <- explain ["suchThatT in oneofT"] $ pureGen (frequency [(f, runGenT g mode) | (f, g) <- gs]) `suchThatT` isOk
   runGE r
 
 chooseT :: (Random a, Ord a, Show a, MonadGenError m) => (a, a) -> GenT m a

--- a/libs/constrained-generators/src/Constrained/Spec.hs
+++ b/libs/constrained-generators/src/Constrained/Spec.hs
@@ -18,4 +18,5 @@ import Constrained.Instances ()
 import Constrained.Spec.Generics as X
 import Constrained.Spec.Maps as X
 import Constrained.Spec.Pairs as X
+import Constrained.Spec.Tree as X
 import Constrained.Univ ()

--- a/libs/constrained-generators/src/Constrained/Spec/Tree.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Tree.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Constrained.Spec.Tree (BinTree (..), RoseTree (..), RoseTreeFn, roseRoot_) where
+
+import Data.Kind
+
+import Constrained.Base
+import Constrained.Core
+import Constrained.GenT
+import Constrained.List
+import Constrained.Spec.Generics
+import Constrained.Spec.Pairs
+import Constrained.Univ
+
+------------------------------------------------------------------------
+-- The types
+------------------------------------------------------------------------
+
+data BinTree a
+  = BinTip
+  | BinNode (BinTree a) a (BinTree a)
+  deriving (Ord, Eq, Show)
+
+data RoseTree a = RoseNode a [RoseTree a]
+  deriving (Ord, Eq, Show)
+
+------------------------------------------------------------------------
+-- HasSpec for BinTree
+------------------------------------------------------------------------
+
+data BinTreeSpec fn a = BinTreeSpec Int (Spec fn (BinTree a, a, BinTree a))
+  deriving (Show)
+
+instance Forallable (BinTree a) (BinTree a, a, BinTree a) where
+  forAllSpec = typeSpec . BinTreeSpec 1000
+  forAllToList BinTip = []
+  forAllToList (BinNode left a right) = (left, a, right) : forAllToList left ++ forAllToList right
+
+instance HasSpec fn a => HasSpec fn (BinTree a) where
+  type TypeSpec fn (BinTree a) = BinTreeSpec fn a
+
+  emptySpec = BinTreeSpec 1000 TrueSpec
+
+  combineSpec (BinTreeSpec sz s) (BinTreeSpec sz' s') =
+    typeSpec $ BinTreeSpec (min sz sz') (s <> s')
+
+  conformsTo BinTip _ = True
+  conformsTo (BinNode left a right) s@(BinTreeSpec _ es) =
+    and
+      [ (left, a, right) `conformsToSpec` es
+      , left `conformsTo` s
+      , right `conformsTo` s
+      ]
+
+  genFromTypeSpec (BinTreeSpec sz s)
+    | sz <= 0 = pure BinTip
+    | otherwise = do
+        let sz' = sz `div` 2
+        oneofT
+          [ do
+              (left, a, right) <- genFromSpec @fn @(BinTree a, a, BinTree a) $
+                constrained $ \ctx ->
+                  [ match ctx $ \left _ right ->
+                      [ forAll left (`satisfies` s)
+                      , genHint sz' left
+                      , forAll right (`satisfies` s)
+                      , genHint sz' right
+                      ]
+                  , ctx `satisfies` s
+                  ]
+              pure $ BinNode left a right
+          , pure BinTip
+          ]
+
+  toPreds t (BinTreeSpec sz s) =
+    (forAll t $ \n -> n `satisfies` s)
+      <> genHint sz t
+
+instance HasSpec fn a => HasGenHint fn (BinTree a) where
+  type Hint (BinTree a) = Int
+  giveHint h = typeSpec $ BinTreeSpec h TrueSpec
+
+------------------------------------------------------------------------
+-- HasSpec for RoseTree
+------------------------------------------------------------------------
+
+data RoseTreeSpec fn a = RoseTreeSpec
+  { roseTreeAvgLength :: Maybe Int
+  , roseTreeMaxSize :: Int
+  , roseTreeRootSpec :: Spec fn a
+  , roseTreeCtxSpec :: Spec fn (a, [RoseTree a])
+  }
+
+deriving instance (HasSpec fn a, Member (RoseTreeFn fn) fn) => Show (RoseTreeSpec fn a)
+
+instance Forallable (RoseTree a) (a, [RoseTree a]) where
+  forAllSpec = guardRoseSpec . RoseTreeSpec Nothing 8000 TrueSpec
+  forAllToList (RoseNode a children) = (a, children) : concatMap forAllToList children
+
+isErrorLike :: Spec fn a -> Bool
+isErrorLike ErrorSpec {} = True
+isErrorLike (MemberSpec []) = True
+isErrorLike _ = False
+
+-- TODO: get rid of this when we implement `cardinality`
+-- in `HasSpec`
+guardRoseSpec :: HasSpec fn (RoseTree a) => RoseTreeSpec fn a -> Spec fn (RoseTree a)
+guardRoseSpec spec@(RoseTreeSpec _ _ rs s)
+  | isErrorLike rs = ErrorSpec ["guardRoseSpec: rootSpec is error"]
+  | isErrorLike s = ErrorSpec ["guardRoseSpec: ctxSpec is error"]
+  | otherwise = TypeSpec spec []
+
+instance (HasSpec fn a, Member (RoseTreeFn fn) fn) => HasSpec fn (RoseTree a) where
+  type TypeSpec fn (RoseTree a) = RoseTreeSpec fn a
+
+  emptySpec = RoseTreeSpec Nothing 8000 TrueSpec TrueSpec
+
+  combineSpec (RoseTreeSpec mal sz rs s) (RoseTreeSpec mal' sz' rs' s')
+    | isErrorLike (typeSpec (Cartesian rs'' TrueSpec) <> s'') = ErrorSpec []
+    | otherwise =
+        guardRoseSpec $
+          RoseTreeSpec
+            (unionWithMaybe max mal mal')
+            (min sz sz')
+            rs''
+            s''
+    where
+      rs'' = rs <> rs'
+      s'' = s <> s'
+
+  conformsTo (RoseNode a children) spec@(RoseTreeSpec _ _ rs s) =
+    and
+      [ (a, children) `conformsToSpec` s
+      , all (`conformsTo` spec) children
+      , a `conformsToSpec` rs
+      ]
+
+  genFromTypeSpec (RoseTreeSpec mal sz rs s) = do
+    let sz' = maybe (sz `div` 4) (sz `div`) mal
+    fmap (uncurry RoseNode) $
+      genFromSpec @fn @(a, [RoseTree a]) $
+        constrained $ \ctx ->
+          [ forAll (snd_ ctx) $ \t ->
+              [ forAll t (`satisfies` s)
+              , genHint (mal, sz') t
+              ]
+          , assert $ length_ (snd_ ctx) <=. lit sz
+          , fst_ ctx `satisfies` rs
+          , ctx `satisfies` s
+          ]
+
+  toPreds t (RoseTreeSpec mal sz rs s) =
+    (forAll t $ \n -> n `satisfies` s)
+      <> roseRoot_ t `satisfies` rs
+      <> genHint (mal, sz) t
+
+instance (Member (RoseTreeFn fn) fn, HasSpec fn a) => HasGenHint fn (RoseTree a) where
+  type Hint (RoseTree a) = (Maybe Int, Int)
+  giveHint (avgLen, sz) = typeSpec $ RoseTreeSpec avgLen sz TrueSpec TrueSpec
+
+data RoseTreeFn (fn :: [Type] -> Type -> Type) args res where
+  RoseRoot :: RoseTreeFn fn '[RoseTree a] a
+
+deriving instance Eq (RoseTreeFn fn args res)
+deriving instance Show (RoseTreeFn fn args res)
+
+instance FunctionLike (RoseTreeFn fn) where
+  sem RoseRoot = \(RoseNode a _) -> a
+
+instance (Member (RoseTreeFn fn) fn, BaseUniverse fn) => Functions (RoseTreeFn fn) fn where
+  propagateSpecFun _ _ TrueSpec = TrueSpec
+  propagateSpecFun _ _ (ErrorSpec err) = ErrorSpec err
+  propagateSpecFun _ _ (MemberSpec []) = MemberSpec []
+  propagateSpecFun fn ctx spec = case fn of
+    _
+      | SuspendedSpec v ps <- spec
+      , ListCtx pre HOLE suf <- ctx ->
+          constrained $ \v' ->
+            let args = appendList (mapList (\(Value a) -> Lit a) pre) (v' :> mapList (\(Value a) -> Lit a) suf)
+             in Let (App (injectFn fn) args) (v :-> ps)
+    RoseRoot ->
+      -- No TypeAbstractions in ghc-8.10
+      case fn of
+        (_ :: RoseTreeFn fn '[RoseTree a] a)
+          | NilCtx HOLE <- ctx -> typeSpec $ RoseTreeSpec Nothing 8000 spec TrueSpec
+
+  -- NOTE: this function over-approximates and returns a liberal spec.
+  mapTypeSpec f ts = case f of
+    RoseRoot ->
+      -- No TypeAbstractions in ghc-8.10
+      case f of
+        (_ :: RoseTreeFn fn '[RoseTree a] a)
+          | RoseTreeSpec _ _ rs _ <- ts -> rs
+
+roseRoot_ ::
+  forall fn a.
+  (Member (RoseTreeFn fn) fn, HasSpec fn a) =>
+  Term fn (RoseTree a) ->
+  Term fn a
+roseRoot_ = app (injectFn $ RoseRoot @fn)

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -581,14 +581,14 @@ instance BaseUniverse fn => HasSpec fn Three
 mapSizeConstrained :: Spec BaseFn (Map Three Int)
 mapSizeConstrained = constrained $ \m -> size_ (dom_ m) <=. 3
 
-andPair :: Spec BaseFn (Int, Int)
-andPair = constrained $ \p ->
-  match p $ \x y ->
+andPair :: Spec BaseFn [(Int, Int)]
+andPair = constrained $ \ps ->
+  forAll' ps $ \x y ->
     x <=. 5 &&. y <=. 1
 
-orPair :: Spec BaseFn (Int, Int)
-orPair = constrained $ \p ->
-  match p $ \x y ->
+orPair :: Spec BaseFn [(Int, Int)]
+orPair = constrained $ \ps ->
+  forAll' ps $ \x y ->
     x <=. 5 ||. y <=. 5
 
 -- TODO: how on earth does this terminate with such a high likelihood?!

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -87,9 +87,14 @@ prop_sound ::
   Spec fn a ->
   Property
 prop_sound spec =
-  QC.forAllBlind (strictGen $ genFromSpec spec) $ \ma -> fromGEDiscard $ do
-    a <- ma
-    pure $ counterexample (show a) $ conformsToSpecProp a spec
+  checkCoverage $
+    QC.forAllBlind (strictGen $ genFromSpec spec) $ \ma ->
+      fromGE (\_ -> cover 80 False "successful" True) $ do
+        a <- ma
+        pure $
+          cover 80 True "successful" $
+            counterexample (show a) $
+              conformsToSpecProp a spec
 
 -- | `prop_complete ps` assumes that `ps` is satisfiable
 prop_complete :: HasSpec fn a => Spec fn a -> Property

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Constrained.Test where
@@ -86,9 +87,9 @@ prop_sound ::
   Spec fn a ->
   Property
 prop_sound spec =
-  QC.forAll (strictGen $ genFromSpec spec) $ \ma -> fromGEDiscard $ do
+  QC.forAllBlind (strictGen $ genFromSpec spec) $ \ma -> fromGEDiscard $ do
     a <- ma
-    pure $ conformsToSpecProp a spec
+    pure $ counterexample (show a) $ conformsToSpecProp a spec
 
 -- | `prop_complete ps` assumes that `ps` is satisfiable
 prop_complete :: HasSpec fn a => Spec fn a -> Property
@@ -113,6 +114,7 @@ tests =
     [ testSpec "setSpec" setSpec
     , testSpec "leqPair" leqPair
     , testSpec "setPair" setPair
+    , testSpec "listEmpty" listEmpty
     , testSpec "compositionalSpec" compositionalSpec
     , testSpec "simplePairSpec" simplePairSpec
     , testSpec "trickyCompositional" trickyCompositional
@@ -152,6 +154,14 @@ tests =
     , testSpec "listSumPair" (listSumPair @Int)
     , testSpec "parallelLetPair" parallelLetPair
     , testSpec "mapSizeConstrained" mapSizeConstrained
+    , testSpec "allZeroTree" allZeroTree
+    , testSpec "noChildrenSameTree" noChildrenSameTree
+    , testSpec "isBST" isBST
+    , testSpec "pairListError" pairListError
+    , testSpec "listMustSizeIssue" listMustSizeIssue
+    , testSpec "successiveChildren" successiveChildren
+    , testSpec "successiveChildren8" successiveChildren8
+    , testSpec "roseTreeList" roseTreeList
     , numberyTests
     , testSpec "andPair" andPair
     , testSpec "orPair" orPair
@@ -214,7 +224,7 @@ testNumberyListSpec n p =
       , N @Int8 Proxy
       ]
 
-testSpec :: HasSpec BaseFn a => String -> Spec BaseFn a -> TestTree
+testSpec :: HasSpec fn a => String -> Spec fn a -> TestTree
 testSpec n s = do
   sequentialTestGroup
     n
@@ -520,6 +530,12 @@ listSumPair = constrained $ \xs ->
   , forAll' xs $ \x y -> [20 <. x, x <. 30, y <. 100]
   ]
 
+listEmpty :: Spec BaseFn [Int]
+listEmpty = constrained $ \xs ->
+  [ forAll xs $ \_ -> False
+  , assert $ length_ xs <=. 10
+  ]
+
 dependencyWeirdness :: Spec BaseFn (Int, Int, Int)
 dependencyWeirdness = constrained' $ \x y z ->
   reify (x + y) id $ \zv -> z ==. zv
@@ -569,3 +585,93 @@ orPair :: Spec BaseFn (Int, Int)
 orPair = constrained $ \p ->
   match p $ \x y ->
     x <=. 5 ||. y <=. 5
+
+-- TODO: how on earth does this terminate with such a high likelihood?!
+allZeroTree :: Spec BaseFn (BinTree Int)
+allZeroTree = constrained $ \t ->
+  [ forAll' t $ \_ a _ -> a ==. 0
+  , genHint 10 t
+  ]
+
+isBST :: Spec BaseFn (BinTree Int)
+isBST = constrained $ \t ->
+  [ forAll' t $ \left a right ->
+      -- TODO: if there was a `binTreeRoot` function on trees
+      -- this wouldn't need to be quadratic as we would
+      -- only check agains the head of the left and right
+      -- subtrees, not _every element_
+      [ forAll' left $ \_ l _ -> l <. a
+      , forAll' right $ \_ h _ -> a <. h
+      ]
+  , genHint 10 t
+  ]
+
+noChildrenSameTree :: Spec BaseFn (BinTree Int)
+noChildrenSameTree = constrained $ \t ->
+  [ forAll' t $ \left a right ->
+      [ forAll' left $ \_ l _ -> l /=. a
+      , forAll' right $ \_ r _ -> r /=. a
+      ]
+  , genHint 8 t
+  ]
+
+type RoseFn = Fix (OneofL (RoseTreeFn : BaseFns))
+
+allZeroRoseTree :: Spec RoseFn (RoseTree Int)
+allZeroRoseTree = constrained $ \t ->
+  [ forAll' t $ \a cs ->
+      [ a ==. 0
+      , length_ cs <=. 4
+      ]
+  , genHint (Just 2, 30) t
+  ]
+
+noSameChildrenRoseTree :: Spec RoseFn (RoseTree Int)
+noSameChildrenRoseTree = constrained $ \t ->
+  [ forAll' t $ \a cs ->
+      [ assert $ a `elem_` lit [1 .. 8]
+      , forAll cs $ \t' ->
+          forAll' t' $ \b _ ->
+            b /=. a
+      ]
+  , genHint (Just 2, 30) t
+  ]
+
+successiveChildren :: Spec RoseFn (RoseTree Int)
+successiveChildren = constrained $ \t ->
+  [ forAll' t $ \a cs ->
+      [ forAll cs $ \t' ->
+          roseRoot_ t' ==. a + 1
+      ]
+  , genHint (Just 2, 10) t
+  ]
+
+successiveChildren8 :: Spec RoseFn (RoseTree Int)
+successiveChildren8 = constrained $ \t ->
+  [ t `satisfies` successiveChildren
+  , forAll' t $ \a _ -> a `elem_` lit [1 .. 5]
+  ]
+
+roseTreeList :: Spec RoseFn [RoseTree Int]
+roseTreeList = constrained $ \ts ->
+  [ assert $ length_ ts <=. 10
+  , forAll ts $ \t ->
+      [ forAll t $ \_ -> False
+      ]
+  ]
+
+pairListError :: Spec BaseFn [(Int, Int)]
+pairListError = constrained $ \ps ->
+  [ assert $ length_ ps <=. 10
+  , forAll' ps $ \a b ->
+      [ a `elem_` lit [1 .. 8]
+      , a ==. 9
+      , b ==. a
+      ]
+  ]
+
+listMustSizeIssue :: Spec BaseFn [Int]
+listMustSizeIssue = constrained $ \xs ->
+  [ 1 `elem_` xs
+  , length_ xs ==. 1
+  ]

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -87,14 +87,10 @@ prop_sound ::
   Spec fn a ->
   Property
 prop_sound spec =
-  checkCoverage $
-    QC.forAllBlind (strictGen $ genFromSpec spec) $ \ma ->
-      fromGE (\_ -> cover 80 False "successful" True) $ do
-        a <- ma
-        pure $
-          cover 80 True "successful" $
-            counterexample (show a) $
-              conformsToSpecProp a spec
+  QC.forAllBlind (strictGen $ genFromSpec spec) $ \ma ->
+    case ma of
+      Result _ a -> cover 80 True "successful" $ counterexample (show a) $ conformsToSpecProp a spec
+      _ -> cover 80 False "successful" True
 
 -- | `prop_complete ps` assumes that `ps` is satisfiable
 prop_complete :: HasSpec fn a => Spec fn a -> Property
@@ -236,7 +232,8 @@ testSpec n s = do
     AllSucceed
     [ -- NOTE: during development you want to uncomment the line below:
       -- testProperty "prop_complete" $ within 10_000_000 $ withMaxSuccess 100 $ prop_complete s,
-      testProperty "prop_sound" $ within 10_000_000 $ withMaxSuccess 100 $ prop_sound s
+      -- NOTE: doing `withMaxSuccess` here does nothing as we are using `checkCoverage`.
+      testProperty "prop_sound" $ within 10_000_000 $ checkCoverage $ prop_sound s
     ]
 
 -- Examples ---------------------------------------------------------------


### PR DESCRIPTION
# Description

Also fixes some minor issues around list size

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
