### PR TITLE
Modify PParams to use similar naming to ProtocolParams in `cardano-api` 

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add `SpendingPurpose`, `MintingPurpose`, `CertifyingPurpose`, `RewardingPurpose` pattern synonyms.
 * Add `getSpendingScriptsNeeded`, `getRewardingScriptsNeeded`, `getMintingScriptsNeeded`
 * Add `zipAsIxItem`
+* Modify `PParams` JSON instances to match `cardano-api`
 
 ### `testlib`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -468,9 +468,7 @@ alonzoPParamsPairs ::
   PParamsHKD Identity (AlonzoEra c) ->
   [a]
 alonzoPParamsPairs pp =
-  uncurry (.=)
-    <$> alonzoPParamsHKDPairs (Proxy @Identity) pp
-      ++ ["minUTxOValue" .= Aeson.Null]
+  uncurry (.=) <$> alonzoPParamsHKDPairs (Proxy @Identity) pp
 
 instance FromJSON (AlonzoPParams Identity era) where
   parseJSON =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -64,11 +64,10 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   NonNegativeInterval,
-  Nonce (NeutralNonce, Nonce),
+  Nonce (NeutralNonce),
   StrictMaybe (..),
   UnitInterval,
   isSNothing,
-  parseAsRational,
  )
 import qualified Cardano.Ledger.BaseTypes as BT (ProtVer (..))
 import Cardano.Ledger.Binary (
@@ -486,11 +485,11 @@ instance FromJSON (AlonzoPParams Identity era) where
         <*> obj .: "stakePoolDeposit"
         <*> obj .: "poolRetireMaxEpoch"
         <*> obj .: "stakePoolTargetNum"
-        <*> parseAsRational (obj .: "poolPledgeInfluence")
-        <*> parseAsRational (obj .: "monetaryExpansion")
-        <*> parseAsRational (obj .: "treasuryCut")
-        <*> parseAsRational (obj .: "decentralization")
-        <*> (obj .: "extraPraosEntropy" >>= jsonToNonce)
+        <*> obj .: "poolPledgeInfluence"
+        <*> obj .: "monetaryExpansion"
+        <*> obj .: "treasuryCut"
+        <*> obj .: "decentralization"
+        <*> obj .: "extraPraosEntropy"
         <*> obj .: "protocolVersion"
         <*> obj .: "minPoolCost" .!= mempty
         <*> obj .: "utxoCostPerByte"
@@ -501,10 +500,6 @@ instance FromJSON (AlonzoPParams Identity era) where
         <*> obj .: "maxValueSize"
         <*> obj .: "collateralPercentage"
         <*> obj .: "maxCollateralInputs"
-    where
-      jsonToNonce :: Aeson.Value -> Aeson.Parser Nonce
-      jsonToNonce Aeson.Null = return NeutralNonce
-      jsonToNonce x = Nonce <$> parseJSON x
 
 newtype CoinPerWord = CoinPerWord {unCoinPerWord :: Coin}
   deriving stock (Eq, Ord)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -64,10 +64,11 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   NonNegativeInterval,
-  Nonce (NeutralNonce),
+  Nonce (NeutralNonce, Nonce),
   StrictMaybe (..),
   UnitInterval,
   isSNothing,
+  parseAsRational,
  )
 import qualified Cardano.Ledger.BaseTypes as BT (ProtVer (..))
 import Cardano.Ledger.Binary (
@@ -137,7 +138,7 @@ import Data.Aeson as Aeson (
   (.!=),
   (.:),
  )
-import qualified Data.Aeson as Aeson (Value)
+import qualified Data.Aeson.Types as Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
@@ -468,36 +469,42 @@ alonzoPParamsPairs ::
   PParamsHKD Identity (AlonzoEra c) ->
   [a]
 alonzoPParamsPairs pp =
-  uncurry (.=) <$> alonzoPParamsHKDPairs (Proxy @Identity) pp
+  uncurry (.=)
+    <$> alonzoPParamsHKDPairs (Proxy @Identity) pp
+      ++ ["minUTxOValue" .= Aeson.Null]
 
 instance FromJSON (AlonzoPParams Identity era) where
   parseJSON =
     Aeson.withObject "PParams" $ \obj ->
       AlonzoPParams
-        <$> obj .: "minFeeA"
-        <*> obj .: "minFeeB"
+        <$> obj .: "txFeePerByte"
+        <*> obj .: "txFeeFixed"
         <*> obj .: "maxBlockBodySize"
         <*> obj .: "maxTxSize"
         <*> obj .: "maxBlockHeaderSize"
-        <*> obj .: "keyDeposit"
-        <*> obj .: "poolDeposit"
-        <*> obj .: "eMax"
-        <*> obj .: "nOpt"
-        <*> obj .: "a0"
-        <*> obj .: "rho"
-        <*> obj .: "tau"
-        <*> obj .: "decentralisationParam"
-        <*> obj .: "extraEntropy"
+        <*> obj .: "stakeAddressDeposit"
+        <*> obj .: "stakePoolDeposit"
+        <*> obj .: "poolRetireMaxEpoch"
+        <*> obj .: "stakePoolTargetNum"
+        <*> parseAsRational (obj .: "poolPledgeInfluence")
+        <*> parseAsRational (obj .: "monetaryExpansion")
+        <*> parseAsRational (obj .: "treasuryCut")
+        <*> parseAsRational (obj .: "decentralization")
+        <*> (obj .: "extraPraosEntropy" >>= jsonToNonce)
         <*> obj .: "protocolVersion"
         <*> obj .: "minPoolCost" .!= mempty
-        <*> obj .: "lovelacePerUTxOWord"
-        <*> obj .: "costmdls"
-        <*> obj .: "prices"
-        <*> obj .: "maxTxExUnits"
-        <*> obj .: "maxBlockExUnits"
-        <*> obj .: "maxValSize"
+        <*> obj .: "utxoCostPerByte"
+        <*> obj .: "costModels"
+        <*> obj .: "executionUnitPrices"
+        <*> obj .: "maxTxExecutionUnits"
+        <*> obj .: "maxBlockExecutionUnits"
+        <*> obj .: "maxValueSize"
         <*> obj .: "collateralPercentage"
         <*> obj .: "maxCollateralInputs"
+    where
+      jsonToNonce :: Aeson.Value -> Aeson.Parser Nonce
+      jsonToNonce Aeson.Null = return NeutralNonce
+      jsonToNonce x = Nonce <$> parseJSON x
 
 newtype CoinPerWord = CoinPerWord {unCoinPerWord :: Coin}
   deriving stock (Eq, Ord)
@@ -730,7 +737,7 @@ alonzoPParamsHKDPairs px pp =
   alonzoCommonPParamsHKDPairs px pp
     ++ shelleyCommonPParamsHKDPairsV8 px pp
     ++ shelleyCommonPParamsHKDPairsV6 px pp
-    ++ [("lovelacePerUTxOWord", hkdMap px (toJSON @CoinPerWord) (pp ^. hkdCoinsPerUTxOWordL @_ @f))]
+    ++ [("utxoCostPerByte", hkdMap px (toJSON @CoinPerWord) (pp ^. hkdCoinsPerUTxOWordL @_ @f))]
 
 -- | These are the fields that are common across all eras starting with Alonzo.
 alonzoCommonPParamsHKDPairs ::
@@ -741,11 +748,11 @@ alonzoCommonPParamsHKDPairs ::
   [(Key, HKD f Aeson.Value)]
 alonzoCommonPParamsHKDPairs px pp =
   shelleyCommonPParamsHKDPairs px pp
-    ++ [ ("costmdls", hkdMap px (toJSON @CostModels) (pp ^. hkdCostModelsL @era @f))
-       , ("prices", hkdMap px (toJSON @Prices) (pp ^. hkdPricesL @era @f))
-       , ("maxTxExUnits", hkdMap px (toJSON @ExUnits) (pp ^. hkdMaxTxExUnitsL @era @f))
-       , ("maxBlockExUnits", hkdMap px (toJSON @ExUnits) (pp ^. hkdMaxBlockExUnitsL @era @f))
-       , ("maxValSize", hkdMap px (toJSON @Natural) (pp ^. hkdMaxValSizeL @era @f))
+    ++ [ ("costModels", hkdMap px (toJSON @CostModels) (pp ^. hkdCostModelsL @era @f))
+       , ("executionUnitPrices", hkdMap px (toJSON @Prices) (pp ^. hkdPricesL @era @f))
+       , ("maxTxExecutionUnits", hkdMap px (toJSON @ExUnits) (pp ^. hkdMaxTxExUnitsL @era @f))
+       , ("maxBlockExecutionUnits", hkdMap px (toJSON @ExUnits) (pp ^. hkdMaxBlockExUnitsL @era @f))
+       , ("maxValueSize", hkdMap px (toJSON @Natural) (pp ^. hkdMaxValSizeL @era @f))
        , ("collateralPercentage", hkdMap px (toJSON @Natural) (pp ^. hkdCollateralPercentageL @era @f))
        , ("maxCollateralInputs", hkdMap px (toJSON @Natural) (pp ^. hkdMaxCollateralInputsL @era @f))
        ]

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `getReferenceScriptsNonDistinct`
 * Add the constructor `BabbageNonDisjointRefInputs` to `BabbageUtxoPredFailure`
   * Utxo rule raises that `PredicateFailure` in Conway and future Eras when they are not disjoint.
+* Modify `PParams` JSON instances to match `cardano-api`
 
 ## 1.6.0.0
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -102,7 +102,7 @@ import Data.Aeson as Aeson (
   Key,
   KeyValue ((.=)),
   ToJSON (..),
-  Value (Null),
+  Value,
   object,
   pairs,
   withObject,
@@ -350,12 +350,7 @@ babbagePParamsPairs ::
   PParamsHKD Identity era ->
   [a]
 babbagePParamsPairs pp =
-  uncurry (.=)
-    <$> babbagePParamsHKDPairs (Proxy @Identity) pp
-      ++ [ "decentralization" .= Aeson.Null
-         , "extraPraosEntropy" .= Aeson.Null
-         , "minUTxOValue" .= Aeson.Null
-         ]
+  uncurry (.=) <$> babbagePParamsHKDPairs (Proxy @Identity) pp
 
 instance FromJSON (BabbagePParams Identity era) where
   parseJSON =

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -66,7 +66,6 @@ import Cardano.Ledger.BaseTypes (
   StrictMaybe (..),
   UnitInterval,
   isSNothing,
-  parseAsRational,
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -371,9 +370,9 @@ instance FromJSON (BabbagePParams Identity era) where
         <*> obj .: "stakePoolDeposit"
         <*> obj .: "poolRetireMaxEpoch"
         <*> obj .: "stakePoolTargetNum"
-        <*> parseAsRational (obj .: "poolPledgeInfluence")
-        <*> parseAsRational (obj .: "monetaryExpansion")
-        <*> parseAsRational (obj .: "treasuryCut")
+        <*> obj .: "poolPledgeInfluence"
+        <*> obj .: "monetaryExpansion"
+        <*> obj .: "treasuryCut"
         <*> obj .: "protocolVersion"
         <*> obj .: "minPoolCost" .!= mempty
         <*> obj .: "utxoCostPerByte"

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -60,6 +60,7 @@
 * Add `TreeMaybe`, `toGovRelationTree` and `toGovRelationTreeEither`
 * Remove `proposalsAreConsistent`
 * Remove `registerDelegs` and `registerInitialDReps`
+* Modify `PParams` JSON instances to match `cardano-api`
 
 ### `testlib`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -840,34 +840,34 @@ conwayPParamsPairs pp =
 
 instance Era era => FromJSON (ConwayPParams Identity era) where
   parseJSON =
-    withObject "PParams" $ \obj ->
+    withObject "ProtocolParameters" $ \obj ->
       ConwayPParams
-        <$> obj .: "minFeeA"
-        <*> obj .: "minFeeB"
+        <$> obj .: "txFeePerByte"
+        <*> obj .: "txFeeFixed"
         <*> obj .: "maxBlockBodySize"
         <*> obj .: "maxTxSize"
         <*> obj .: "maxBlockHeaderSize"
-        <*> obj .: "keyDeposit"
-        <*> obj .: "poolDeposit"
-        <*> obj .: "eMax"
-        <*> obj .: "nOpt"
-        <*> obj .: "a0"
-        <*> obj .: "rho"
-        <*> obj .: "tau"
+        <*> obj .: "stakeAddressDeposit"
+        <*> obj .: "stakePoolDeposit"
+        <*> obj .: "poolRetireMaxEpoch"
+        <*> obj .: "stakePoolTargetNum"
+        <*> obj .: "poolPledgeInfluence"
+        <*> obj .: "monetaryExpansion"
+        <*> obj .: "treasuryCut"
         <*> obj .: "protocolVersion"
         <*> obj .: "minPoolCost" .!= mempty
-        <*> obj .: "coinsPerUTxOByte"
-        <*> obj .: "costmdls"
-        <*> obj .: "prices"
-        <*> obj .: "maxTxExUnits"
-        <*> obj .: "maxBlockExUnits"
-        <*> obj .: "maxValSize"
+        <*> obj .: "utxoCostPerByte"
+        <*> obj .: "costModels"
+        <*> obj .: "executionUnitPrices"
+        <*> obj .: "maxTxExecutionUnits"
+        <*> obj .: "maxBlockExecutionUnits"
+        <*> obj .: "maxValueSize"
         <*> obj .: "collateralPercentage"
         <*> obj .: "maxCollateralInputs"
         <*> obj .: "poolVotingThresholds"
         <*> obj .: "dRepVotingThresholds"
-        <*> obj .: "committeeMinSize"
-        <*> obj .: "committeeMaxTermLength"
+        <*> obj .: "minCommitteeSize"
+        <*> obj .: "committeeTermLength"
         <*> obj .: "govActionLifetime"
         <*> obj .: "govActionDeposit"
         <*> obj .: "dRepDeposit"
@@ -1085,8 +1085,8 @@ conwayUpgradePParamsHKDPairs ::
 conwayUpgradePParamsHKDPairs px pp =
   [ ("poolVotingThresholds", hkdMap px (toJSON @PoolVotingThresholds) (pp ^. hkdPoolVotingThresholdsL @era @f))
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
-  , ("committeeMinSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
-  , ("committeeMaxTermLength", hkdMap px (toJSON @EpochInterval) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
+  , ("minCommitteeSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
+  , ("committeeTermLength", hkdMap px (toJSON @EpochInterval) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
   , ("govActionLifetime", hkdMap px (toJSON @EpochInterval) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
   , ("dRepDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdDRepDepositL @era @f))
@@ -1106,8 +1106,8 @@ upgradeConwayPParamsHKDPairs :: UpgradeConwayPParams Identity -> [(Key, Aeson.Va
 upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   [ ("poolVotingThresholds", (toJSON @PoolVotingThresholds) ucppPoolVotingThresholds)
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
-  , ("committeeMinSize", (toJSON @Natural) ucppCommitteeMinSize)
-  , ("committeeMaxTermLength", (toJSON @EpochInterval) ucppCommitteeMaxTermLength)
+  , ("minCommitteeSize", (toJSON @Natural) ucppCommitteeMinSize)
+  , ("committeeTermLength", (toJSON @EpochInterval) ucppCommitteeMaxTermLength)
   , ("govActionLifetime", (toJSON @EpochInterval) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
   , ("dRepDeposit", (toJSON @Coin) ucppDRepDeposit)
@@ -1121,8 +1121,8 @@ instance FromJSON (UpgradeConwayPParams Identity) where
       UpgradeConwayPParams
         <$> o .: "poolVotingThresholds"
         <*> o .: "dRepVotingThresholds"
-        <*> o .: "committeeMinSize"
-        <*> o .: "committeeMaxTermLength"
+        <*> o .: "minCommitteeSize"
+        <*> o .: "committeeTermLength"
         <*> o .: "govActionLifetime"
         <*> o .: "govActionDeposit"
         <*> o .: "dRepDeposit"

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -1121,8 +1121,8 @@ instance FromJSON (UpgradeConwayPParams Identity) where
       UpgradeConwayPParams
         <$> o .: "poolVotingThresholds"
         <*> o .: "dRepVotingThresholds"
-        <*> o .: "minCommitteeSize"
-        <*> o .: "committeeTermLength"
+        <*> o .: "committeeMinSize"
+        <*> o .: "committeeMaxTermLength"
         <*> o .: "govActionLifetime"
         <*> o .: "govActionDeposit"
         <*> o .: "dRepDeposit"

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -866,8 +866,8 @@ instance Era era => FromJSON (ConwayPParams Identity era) where
         <*> obj .: "maxCollateralInputs"
         <*> obj .: "poolVotingThresholds"
         <*> obj .: "dRepVotingThresholds"
-        <*> obj .: "minCommitteeSize"
-        <*> obj .: "committeeTermLength"
+        <*> obj .: "committeeMinSize"
+        <*> obj .: "committeeMaxTermLength"
         <*> obj .: "govActionLifetime"
         <*> obj .: "govActionDeposit"
         <*> obj .: "dRepDeposit"
@@ -1085,8 +1085,8 @@ conwayUpgradePParamsHKDPairs ::
 conwayUpgradePParamsHKDPairs px pp =
   [ ("poolVotingThresholds", hkdMap px (toJSON @PoolVotingThresholds) (pp ^. hkdPoolVotingThresholdsL @era @f))
   , ("dRepVotingThresholds", hkdMap px (toJSON @DRepVotingThresholds) (pp ^. hkdDRepVotingThresholdsL @era @f))
-  , ("minCommitteeSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
-  , ("committeeTermLength", hkdMap px (toJSON @EpochInterval) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
+  , ("committeeMinSize", hkdMap px (toJSON @Natural) (pp ^. hkdCommitteeMinSizeL @era @f))
+  , ("committeeMaxTermLength", hkdMap px (toJSON @EpochInterval) (pp ^. hkdCommitteeMaxTermLengthL @era @f))
   , ("govActionLifetime", hkdMap px (toJSON @EpochInterval) (pp ^. hkdGovActionLifetimeL @era @f))
   , ("govActionDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdGovActionDepositL @era @f))
   , ("dRepDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdDRepDepositL @era @f))
@@ -1106,8 +1106,8 @@ upgradeConwayPParamsHKDPairs :: UpgradeConwayPParams Identity -> [(Key, Aeson.Va
 upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =
   [ ("poolVotingThresholds", (toJSON @PoolVotingThresholds) ucppPoolVotingThresholds)
   , ("dRepVotingThresholds", (toJSON @DRepVotingThresholds) ucppDRepVotingThresholds)
-  , ("minCommitteeSize", (toJSON @Natural) ucppCommitteeMinSize)
-  , ("committeeTermLength", (toJSON @EpochInterval) ucppCommitteeMaxTermLength)
+  , ("committeeMinSize", (toJSON @Natural) ucppCommitteeMinSize)
+  , ("committeeMaxTermLength", (toJSON @EpochInterval) ucppCommitteeMaxTermLength)
   , ("govActionLifetime", (toJSON @EpochInterval) ucppGovActionLifetime)
   , ("govActionDeposit", (toJSON @Coin) ucppGovActionDeposit)
   , ("dRepDeposit", (toJSON @Coin) ucppDRepDeposit)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Remove `registerInitialFunds` and `registerInitialStaking`
 * Add `registerInitialFundsThenStaking`
 * Modify `PParams` JSON instances to match `cardano-api`
+* Add wrapper to `PParams` in `ShelleyGenesis` to preserve the legacy behaviour of JSON instances
 
 ### `testlib`
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Deprecate `RewardAcnt` in favor of `RewardAccount`
 * Remove `registerInitialFunds` and `registerInitialStaking`
 * Add `registerInitialFundsThenStaking`
+* Modify `PParams` JSON instances to match `cardano-api`
 
 ### `testlib`
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -78,7 +78,6 @@ import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Data.Aeson (FromJSON (..), Key, KeyValue, ToJSON (..), object, pairs, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
 import Data.Foldable (fold)
 import Data.Functor.Identity (Identity)
 import Data.List (nub)
@@ -259,15 +258,6 @@ shelleyPParamsPairs ::
 shelleyPParamsPairs pp =
   uncurry (.=)
     <$> shelleyPParamsHKDPairs (Proxy @Identity) pp
-      ++ [ "collateralPercentage" .= Aeson.Null
-         , "costModels" .= Aeson.emptyObject
-         , "executionUnitPrices" .= Aeson.Null
-         , "maxBlockExecutionUnits" .= Aeson.Null
-         , "maxCollateralInputs" .= Aeson.Null
-         , "maxTxExecutionUnits" .= Aeson.Null
-         , "maxValueSize" .= Aeson.Null
-         , "utxoCostPerByte" .= Aeson.Null
-         ]
 
 instance FromJSON (ShelleyPParams Identity era) where
   parseJSON =

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -27,8 +27,7 @@
 * Deprecate `deserialiseRewardAcnt` in favor of `deserialiseRewardAccount`
 * Deprecate `serialiseRewardAcnt` in favor of `serialiseRewardAccount`
 * Deprecate `RewardAcnt` in favor of `RewardAccount`
-* Add `toRationalJSON` and `parseAsRational` JSON Aeson helpers
-* Nodify `Prices` JSON instances to match `cardano-api`
+* Modify `Prices` and `Nonce` JSON instances to match `cardano-api`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Deprecate `deserialiseRewardAcnt` in favor of `deserialiseRewardAccount`
 * Deprecate `serialiseRewardAcnt` in favor of `serialiseRewardAccount`
 * Deprecate `RewardAcnt` in favor of `RewardAccount`
+* Add `toRationalJSON` and `parseAsRational` JSON Aeson helpers
+* Nodify `Prices` JSON instances to match `cardano-api`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -77,6 +78,10 @@ module Cardano.Ledger.BaseTypes (
 
   -- * Injection
   Inject (..),
+
+  -- * Rationals and Aeson
+  toRationalJSON,
+  parseAsRational,
 )
 where
 
@@ -146,7 +151,7 @@ import Data.Aeson (
   (.:),
   (.=),
  )
-import Data.Aeson.Types (Pair)
+import Data.Aeson.Types (Pair, Parser)
 import qualified Data.Binary.Put as B
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -338,11 +343,8 @@ instance
       Just u -> pure u
 
 instance Bounded (BoundedRatio b Word64) => ToJSON (BoundedRatio b Word64) where
-  toJSON = toRationalJSON . unboundRational
-    where
-      toRationalJSON r = case fromRationalRepetendLimited maxDecimalsWord64 r of
-        Right (s, Nothing) -> toJSON s
-        _ -> toJSON r
+  toJSON :: BoundedRatio b Word64 -> Value
+  toJSON = toRationalJSON
 
 instance Bounded (BoundedRatio b Word64) => FromJSON (BoundedRatio b Word64) where
   parseJSON = \case
@@ -844,3 +846,21 @@ class Inject t s where
 -- | Helper function for a common pattern of creating objects
 kindObject :: Text -> [Pair] -> Value
 kindObject name obj = object $ ("kind" .= name) : obj
+
+-- | Loseless way of representing BoundedRational as JSON that uses decimals when feasible
+toRationalJSON :: BoundedRational a => a -> Value
+toRationalJSON br =
+  case fromRationalRepetendLimited 20 r of
+    Right (s, Nothing) -> toJSON s
+    _ -> toJSON r
+  where
+    r = unboundRational br
+
+-- | Aeson parser that works with the result of toRationalJSON
+-- | (It adapts a BoundedRational so that it uses the Rational parser instead)
+parseAsRational :: BoundedRational r => Parser Rational -> Parser r
+parseAsRational parser = do
+  rational <- parser
+  case boundRational rational of
+    Nothing -> fail "Cannot convert to BoundRational"
+    Just x -> return x


### PR DESCRIPTION
# Description

This PR modifies `FromJSON` and `ToJSON` instances for `PParams` of all eras so that they match those of `ProtocolParams`. That way `cardano-api` can move to use `PParams` directly.
See [the corresponding cardano-api PR](https://github.com/IntersectMBO/cardano-api/pull/457).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
