### PR TITLE
Add extra time from 1 sec to 2 sec for prop_soundness test.

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -814,7 +814,7 @@ allExampleTests =
     , testPropMax 30 "Test 18a. Projection test" test18a
     , testPropMax 30 "Test 18b. Projection test" test18b
     , testPropMax 30 "Test 20. ptr & rewards are inverses" test20
-    , testPropMax 30 "Constraint soundness" $ prop_soundness
+    , testPropMax 30 "Constraint soundness" $ within 1000000 $ prop_soundness
     , testProperty "Shrinking soundness" $ withMaxSuccess 30 $ prop_shrinking
     , testProperty "NewEpochState and Tx generation" $ do
         (st, tx, _) <- genTxAndNewEpoch def $ Conway


### PR DESCRIPTION
Addressed issue #4137 
Adds more time to prop_soundness.  This is a big test. It looks like it times out infrequently, over running its 1 second
time bound.  I upped the time bound from 1 to 2 seconds.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
