### PR TITLE
Delay semantics as per spec for expired but already ratified proposals

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -8,8 +8,10 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Val
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
+import qualified Data.OMap.Strict as OMap
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
@@ -28,73 +30,84 @@ delayingActionsSpec ::
   SpecWith (ImpTestState era)
 delayingActionsSpec =
   describe "Delaying actions" $ do
-    it "A delaying action delays its child even when both ere proposed and ratified in the same epoch" $ do
-      (dRep, committeeMember, _gpi) <- electBasicCommittee
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
-      gai0 <- submitInitConstitutionGovAction
-      gai1 <- submitChildConstitutionGovAction gai0
-      gai2 <- submitChildConstitutionGovAction gai1
-      gai3 <- submitChildConstitutionGovAction gai2
-      submitYesVote_ (DRepVoter dRep) gai0
-      submitYesVote_ (CommitteeVoter committeeMember) gai0
-      submitYesVote_ (DRepVoter dRep) gai1
-      submitYesVote_ (CommitteeVoter committeeMember) gai1
-      submitYesVote_ (DRepVoter dRep) gai2
-      submitYesVote_ (CommitteeVoter committeeMember) gai2
-      submitYesVote_ (DRepVoter dRep) gai3
-      submitYesVote_ (CommitteeVoter committeeMember) gai3
-      passNEpochs 2
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai0)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai1)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai3)
-      getConstitutionProposals `shouldReturn` Map.empty
-    it "A delaying action delays all other actions even when all of them may be ratified in the same epoch" $ do
-      (dRep, committeeMember, _gpi) <- electBasicCommittee
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
-      pGai0 <-
-        submitParameterChange
-          SNothing
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_000)
-      pGai1 <-
-        submitParameterChange
-          (SJust $ GovPurposeId pGai0)
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_001)
-      pGai2 <-
-        submitParameterChange
-          (SJust $ GovPurposeId pGai1)
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_002)
-      cGai0 <- submitInitConstitutionGovAction
-      cGai1 <- submitChildConstitutionGovAction cGai0
-      submitYesVote_ (DRepVoter dRep) cGai0
-      submitYesVote_ (CommitteeVoter committeeMember) cGai0
-      submitYesVote_ (DRepVoter dRep) cGai1
-      submitYesVote_ (CommitteeVoter committeeMember) cGai1
-      submitYesVote_ (DRepVoter dRep) pGai0
-      submitYesVote_ (CommitteeVoter committeeMember) pGai0
-      submitYesVote_ (DRepVoter dRep) pGai1
-      submitYesVote_ (CommitteeVoter committeeMember) pGai1
-      submitYesVote_ (DRepVoter dRep) pGai2
-      submitYesVote_ (CommitteeVoter committeeMember) pGai2
-      passNEpochs 2
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId cGai0)
-      getLastEnactedParameterChange `shouldReturn` SNothing
-      passEpoch
-      -- here 'ParameterChange' action does not get enacted even though
-      -- it is not related, since its priority is 4 while the priority
-      -- for 'NewConstitution' is 2, so it gets delayed a second time
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId cGai1)
-      getConstitutionProposals `shouldReturn` Map.empty
-      getLastEnactedParameterChange `shouldReturn` SNothing
-      passEpoch
-      -- all three actions, pGai0, pGai1 and pGai2, are enacted one
-      -- after the other in the same epoch
-      getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId pGai2)
-      getParameterChangeProposals `shouldReturn` Map.empty
-    describe "An action expires when delayed enough even after being ratified" $ do
+    describe "Ratified actions are delayed as expected" $ do
+      it "Same lineage" $ do
+        (dRep, committeeMember, _gpi) <- electBasicCommittee
+        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+        gai0 <- submitInitConstitutionGovAction
+        gai1 <- submitChildConstitutionGovAction gai0
+        gai2 <- submitChildConstitutionGovAction gai1
+        gai3 <- submitChildConstitutionGovAction gai2
+        submitYesVote_ (DRepVoter dRep) gai0
+        submitYesVote_ (CommitteeVoter committeeMember) gai0
+        submitYesVote_ (DRepVoter dRep) gai1
+        submitYesVote_ (CommitteeVoter committeeMember) gai1
+        submitYesVote_ (DRepVoter dRep) gai2
+        submitYesVote_ (CommitteeVoter committeeMember) gai2
+        submitYesVote_ (DRepVoter dRep) gai3
+        submitYesVote_ (CommitteeVoter committeeMember) gai3
+        passNEpochs 2
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai0)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai1)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai3)
+        getConstitutionProposals `shouldReturn` Map.empty
+      it "Other lineage" $ do
+        (dRep, committeeMember, _gpi) <- electBasicCommittee
+        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+        treasuryValue <- getCurrentTreasury
+        rewardAccount <- registerRewardAccount
+        twGai <-
+          submitTreasuryWithdrawals
+            [(rewardAccount, Coin 1_000)]
+        pGai0 <-
+          submitParameterChange
+            SNothing
+            $ def & ppuDRepDepositL .~ SJust (Coin 1_000_000)
+        pGai1 <-
+          submitParameterChange
+            (SJust $ GovPurposeId pGai0)
+            $ def & ppuDRepDepositL .~ SJust (Coin 1_000_001)
+        pGai2 <-
+          submitParameterChange
+            (SJust $ GovPurposeId pGai1)
+            $ def & ppuDRepDepositL .~ SJust (Coin 1_000_002)
+        cGai0 <- submitInitConstitutionGovAction
+        cGai1 <- submitChildConstitutionGovAction cGai0
+        submitYesVote_ (DRepVoter dRep) cGai0
+        submitYesVote_ (CommitteeVoter committeeMember) cGai0
+        submitYesVote_ (DRepVoter dRep) cGai1
+        submitYesVote_ (CommitteeVoter committeeMember) cGai1
+        submitYesVote_ (DRepVoter dRep) pGai0
+        submitYesVote_ (CommitteeVoter committeeMember) pGai0
+        submitYesVote_ (DRepVoter dRep) pGai1
+        submitYesVote_ (CommitteeVoter committeeMember) pGai1
+        submitYesVote_ (DRepVoter dRep) pGai2
+        submitYesVote_ (CommitteeVoter committeeMember) pGai2
+        submitYesVote_ (DRepVoter dRep) twGai
+        submitYesVote_ (CommitteeVoter committeeMember) twGai
+        passNEpochs 2
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId cGai0)
+        getLastEnactedParameterChange `shouldReturn` SNothing
+        passEpoch
+        -- here 'ParameterChange' and `TreasuryWithdrawals` do not
+        -- get enacted even though the are not related, since their
+        -- `actionPriority` is 4 and 5, while that for 'NewConstitution'
+        -- is 2, so they get delayed a second time
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId cGai1)
+        getConstitutionProposals `shouldReturn` Map.empty
+        getLastEnactedParameterChange `shouldReturn` SNothing
+        passEpoch
+        -- all three actions, pGai0, pGai1 and pGai2, are enacted one
+        -- after the other in the same epoch, and so is twGai
+        getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId pGai2)
+        getCurrentTreasury `shouldReturn` (treasuryValue <-> Coin 1_000)
+        getParameterChangeProposals `shouldReturn` Map.empty
+        fmap (^. pPropsL) getProposals `shouldReturn` OMap.empty
+    describe "Ratified actions do not expire when delayed beyond their expiry" $ do
       it "Same lineage" $ do
         (dRep, committeeMember, _gpi) <- electBasicCommittee
         gai0 <- submitInitConstitutionGovAction
@@ -115,11 +128,19 @@ delayingActionsSpec =
         getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai1)
         passEpoch
         getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
-        getConstitutionProposals `shouldReturn` Map.empty
         passEpoch
-        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai3)
+        getConstitutionProposals `shouldReturn` Map.empty
       it "Other lineage" $ do
         (dRep, committeeMember, _gpi) <- electBasicCommittee
+        treasuryValue <- getCurrentTreasury
+        rewardAccount <- registerRewardAccount
+        twGai0 <-
+          submitTreasuryWithdrawals
+            [(rewardAccount, Coin 1_000)]
+        twGai1 <-
+          submitTreasuryWithdrawals
+            [(rewardAccount, Coin 1_000)]
         pGai0 <-
           submitParameterChange
             SNothing
@@ -132,6 +153,10 @@ delayingActionsSpec =
           submitParameterChange
             (SJust $ GovPurposeId pGai1)
             $ def & ppuDRepDepositL .~ SJust (Coin 1_000_002)
+        pGai3 <-
+          submitParameterChange
+            (SJust $ GovPurposeId pGai2)
+            $ def & ppuDRepDepositL .~ SJust (Coin 1_000_003)
         cGai0 <- submitInitConstitutionGovAction
         cGai1 <- submitChildConstitutionGovAction cGai0
         cGai2 <- submitChildConstitutionGovAction cGai1
@@ -147,6 +172,12 @@ delayingActionsSpec =
         submitYesVote_ (CommitteeVoter committeeMember) pGai1
         submitYesVote_ (DRepVoter dRep) pGai2
         submitYesVote_ (CommitteeVoter committeeMember) pGai2
+        submitYesVote_ (DRepVoter dRep) pGai3
+        submitYesVote_ (CommitteeVoter committeeMember) pGai3
+        submitYesVote_ (DRepVoter dRep) twGai0
+        submitYesVote_ (CommitteeVoter committeeMember) twGai0
+        submitYesVote_ (DRepVoter dRep) twGai1
+        submitYesVote_ (CommitteeVoter committeeMember) twGai1
         passNEpochs 2
         getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId cGai0)
         getLastEnactedParameterChange `shouldReturn` SNothing
@@ -158,7 +189,7 @@ delayingActionsSpec =
         getConstitutionProposals `shouldReturn` Map.empty
         getLastEnactedParameterChange `shouldReturn` SNothing
         passEpoch
-        -- all three actions, pGai0, pGai1 and pGai2, are expired here
-        -- and nothing gets enacted
-        getLastEnactedParameterChange `shouldReturn` SNothing
+        getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId pGai3)
+        getCurrentTreasury `shouldReturn` (treasuryValue <-> Coin (1_000 * 2))
         getParameterChangeProposals `shouldReturn` Map.empty
+        fmap (^. pPropsL) getProposals `shouldReturn` OMap.empty

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -80,6 +80,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
   getLastEnactedParameterChange,
   getConstitutionProposals,
   getParameterChangeProposals,
+  getCurrentTreasury,
 ) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN, Signable)
@@ -816,6 +817,9 @@ isSpoAccepted gaId = do
   action <- getGovActionState gaId
   pure $ spoAccepted ratifyEnv ratifyState action
 
+getCurrentTreasury :: ImpTestM era Coin
+getCurrentTreasury = getsNES $ nesEsL . esAccountStateL . asTreasuryL
+
 -- | Logs the results of each check required to make the governance action pass
 logRatificationChecks ::
   (ConwayEraGov era, ConwayEraPParams era) =>
@@ -828,7 +832,7 @@ logRatificationChecks gaId = do
   committee <- getsNES $ nesEsL . epochStateGovStateL . committeeGovStateL
   ratEnv <- getRatifyEnv
   let ratSt = RatifyState ens mempty mempty False
-  curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+  curTreasury <- getCurrentTreasury
   currentEpoch <- getsNES nesELL
   let
     members = foldMap' committeeMembers committee


### PR DESCRIPTION
# Description

Resolves #4109 

- [x] Merge #4144 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
