### PR TITLE
Add `ConwayUtxosPredFailure`

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -136,6 +136,7 @@ library testlib
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         data-default-class,
         plutus-ledger-api,
+        generic-random,
         microlens,
         text
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -414,7 +414,7 @@ deriving stock instance
   ) =>
   Show (AlonzoUtxosPredFailure era)
 
-instance
+deriving stock instance
   ( AlonzoEraScript era
   , Eq (TxCert era)
   , Eq (ContextError era)
@@ -422,11 +422,6 @@ instance
   , Eq (EraRuleFailure "PPUP" era)
   ) =>
   Eq (AlonzoUtxosPredFailure era)
-  where
-  (ValidationTagMismatch a x) == (ValidationTagMismatch b y) = a == b && x == y
-  (CollectErrors x) == (CollectErrors y) = x == y
-  (UpdateFailure x) == (UpdateFailure y) = x == y
-  _ == _ = False
 
 instance
   ( AlonzoEraScript era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Plutus.Evaluate (
   ScriptFailure (..),
   ScriptResult (..),
  )
-import Cardano.Ledger.Rules.ValidationMode (Inject (..), lblStatic)
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.SafeHash (SafeHash, hashAnnotated)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), updateStakeDistribution)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
@@ -373,9 +373,6 @@ instance InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure (AlonzoEra c)
 
 instance InjectRuleFailure "UTXOS" ShelleyPpupPredFailure (AlonzoEra c) where
   injectFailure = UpdateFailure
-
-instance EraRuleFailure "PPUP" era ~ () => Inject () (AlonzoUtxosPredFailure era) where
-  inject () = UpdateFailure ()
 
 instance
   ( EraTxCert era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -398,7 +398,7 @@ instance
   ) =>
   DecCBOR (AlonzoUtxosPredFailure era)
   where
-  decCBOR = decode (Summands "UtxosPredicateFailure" dec)
+  decCBOR = decode (Summands "AlonzoUtxosPredicateFailure" dec)
     where
       dec 0 = SumD ValidationTagMismatch <! From <! From
       dec 1 = SumD (CollectErrors @era) <! From

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -356,7 +356,19 @@ instance
   ) =>
   Arbitrary (AlonzoUtxowPredFailure era)
   where
-  arbitrary = genericArbitraryU
+  -- Switch to this implementation once #4110 is taken care of
+  -- arbitrary = genericArbitraryU
+  arbitrary =
+    oneof
+      [ ShelleyInAlonzoUtxowPredFailure <$> arbitrary
+      , -- MissingRedeemers <$> arbitrary -- see #4110
+        MissingRequiredDatums <$> arbitrary <*> arbitrary
+      , NotAllowedSupplementalDatums <$> arbitrary <*> arbitrary
+      , PPViewHashesDontMatch <$> arbitrary <*> arbitrary
+      , MissingRequiredSigners <$> arbitrary
+      , UnspendableUTxONoDatumHash <$> arbitrary
+      -- , ExtraRedeemers <$> arbitrary -- see #4110
+      ]
 
 deriving instance Arbitrary ix => Arbitrary (AsIx ix it)
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -116,6 +116,7 @@ library testlib
         cardano-ledger-babbage,
         cardano-ledger-binary,
         cardano-ledger-core:{cardano-ledger-core, testlib},
+        generic-random,
         small-steps,
         QuickCheck
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
-import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (Sized)
 import Cardano.Ledger.Crypto (Crypto)
@@ -89,7 +89,17 @@ instance
   ) =>
   Arbitrary (BabbageContextError era)
   where
-  arbitrary = genericArbitraryU
+  -- Switch to this implementation once #4110 is taken care of
+  -- arbitrary = genericArbitraryU
+  arbitrary =
+    oneof
+      [ AlonzoContextError <$> arbitrary
+      , ByronTxOutInContext <$> arbitrary
+      , -- , RedeemerPointerPointsToNothing <$> arbitrary -- see #4110
+        InlineDatumsNotSupported <$> arbitrary
+      , ReferenceScriptsNotSupported <$> arbitrary
+      , ReferenceInputsNotSupported <$> arbitrary
+      ]
 
 instance
   ( EraTxOut era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -15,10 +15,14 @@ import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (Sized)
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Plutus.TxInfo (TxOutSource)
 import Control.State.Transition (STS (PredicateFailure))
 import Data.Functor.Identity (Identity)
+import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.QuickCheck
 
@@ -76,6 +80,17 @@ instance Arbitrary (BabbagePParams StrictMaybe era) where
       <*> arbitrary
       <*> arbitrary
 
+instance Crypto crypto => Arbitrary (TxOutSource crypto) where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
+  Arbitrary (BabbageContextError era)
+  where
+  arbitrary = genericArbitraryU
+
 instance
   ( EraTxOut era
   , Arbitrary (Value era)
@@ -84,27 +99,18 @@ instance
   ) =>
   Arbitrary (BabbageUtxoPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ AlonzoInBabbageUtxoPredFailure <$> arbitrary
-      , IncorrectTotalCollateralField <$> arbitrary <*> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance
   ( Era era
   , Arbitrary (PredicateFailure (EraRule "UTXO" era))
-  , Arbitrary (PlutusPurpose AsItem era)
   , Arbitrary (TxCert era)
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
   ) =>
   Arbitrary (BabbageUtxowPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ AlonzoInBabbageUtxowPredFailure <$> arbitrary
-      , UtxoFailure <$> arbitrary
-      , MalformedScriptWitnesses <$> arbitrary
-      , MalformedReferenceScripts <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance
   ( EraTxOut era

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `ConwayUtxosPredFailure`
 * Support for intra-era hard fork with `ProtVerHigh` set to `10`
 * Guard Conway-specific features in transactions that use Plutus v1 or v2. #4112
   * Add `PlutusContextError` variants:

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -149,6 +149,7 @@ library testlib
         cardano-ledger-shelley,
         cardano-strict-containers,
         data-default-class,
+        generic-random,
         small-steps,
         text
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -151,7 +151,8 @@ library testlib
         data-default-class,
         generic-random,
         small-steps,
-        text
+        text,
+        small-steps
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..))
 import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Conway.Rules.Utxos ()
+import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
 
@@ -39,8 +39,11 @@ instance InjectRuleFailure "UTXO" ShelleyUtxoPredFailure (ConwayEra c) where
 instance InjectRuleFailure "UTXO" Allegra.AllegraUtxoPredFailure (ConwayEra c) where
   injectFailure = AlonzoInBabbageUtxoPredFailure . allegraToConwayUtxoPredFailure
 
-instance InjectRuleFailure "UTXO" AlonzoUtxosPredFailure (ConwayEra c) where
+instance InjectRuleFailure "UTXO" ConwayUtxosPredFailure (ConwayEra c) where
   injectFailure = AlonzoInBabbageUtxoPredFailure . UtxosFailure
+
+instance InjectRuleFailure "UTXO" AlonzoUtxosPredFailure (ConwayEra c) where
+  injectFailure = AlonzoInBabbageUtxoPredFailure . UtxosFailure . injectFailure
 
 allegraToConwayUtxoPredFailure ::
   forall era.

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -48,6 +48,7 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.HKD (HKD, NoUpdate (..))
 import Control.State.Transition.Extended (STS (Event))
@@ -82,6 +83,17 @@ instance
   Arbitrary (DRepPulsingState era)
   where
   arbitrary = DRComplete <$> arbitrary <*> arbitrary
+
+instance
+  ( EraPParams era
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (ConwayContextError era)
+  where
+  arbitrary = genericArbitraryU
 
 instance Crypto c => Arbitrary (ConwayGenesis c) where
   arbitrary =
@@ -588,18 +600,14 @@ instance
   arbitrary = genericArbitraryU
 
 instance
-  ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "UTXOW" era))
   , Arbitrary (PredicateFailure (EraRule "CERTS" era))
   , Arbitrary (PredicateFailure (EraRule "GOV" era))
   ) =>
   Arbitrary (ConwayLedgerPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ ConwayUtxowFailure <$> arbitrary
-      , ConwayCertsFailure <$> arbitrary
-      , ConwayGovFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- EPOCH
 
@@ -638,12 +646,7 @@ instance
   ) =>
   Arbitrary (ConwayCertsPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ DelegateeNotRegisteredDELEG <$> arbitrary
-      , WithdrawalsNotInRewardsCERTS <$> arbitrary
-      , CertFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- CERT
 
@@ -655,12 +658,7 @@ instance
   ) =>
   Arbitrary (ConwayCertPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ DelegFailure <$> arbitrary
-      , PoolFailure <$> arbitrary
-      , GovCertFailure <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- DELEG
 
@@ -668,25 +666,12 @@ instance
   Era era =>
   Arbitrary (ConwayDelegPredFailure era)
   where
-  arbitrary =
-    oneof
-      [ IncorrectDepositDELEG <$> arbitrary
-      , StakeKeyRegisteredDELEG <$> arbitrary
-      , StakeKeyNotRegisteredDELEG <$> arbitrary
-      , StakeKeyHasNonZeroRewardAccountBalanceDELEG <$> arbitrary
-      , DRepAlreadyRegisteredForStakeKeyDELEG <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 -- GOVCERT
 
 instance Era era => Arbitrary (ConwayGovCertPredFailure era) where
-  arbitrary =
-    oneof
-      [ ConwayDRepAlreadyRegistered <$> arbitrary
-      , ConwayDRepNotRegistered <$> arbitrary
-      , ConwayDRepIncorrectDeposit <$> arbitrary <*> arbitrary
-      , ConwayCommitteeHasPreviouslyResigned <$> arbitrary
-      ]
+  arbitrary = genericArbitraryU
 
 instance Arbitrary (HKD f a) => Arbitrary (THKD t f a) where
   arbitrary = THKD <$> arbitrary

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -33,6 +33,7 @@ module Test.Cardano.Ledger.Conway.Arbitrary (
   ShuffledGovActionStates (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (Sized)
 import Cardano.Ledger.Conway.Core
@@ -59,6 +60,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Word
+import Generic.Random (genericArbitraryU)
 import Lens.Micro
 import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Data.Arbitrary ()
@@ -569,8 +571,21 @@ instance (EraPParams era, Arbitrary (PParamsUpdate era)) => Arbitrary (GovProced
     GovProcedures <$> arbitrary <*> arbitrary
   shrink (GovProcedures vp pp) = [GovProcedures vp' pp' | (vp', pp') <- shrink (vp, pp)]
 
-instance Era era => Arbitrary (ConwayGovPredFailure era) where
-  arbitrary = GovActionsDoNotExist <$> arbitrary
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (ConwayGovPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (CollectError era)
+  ) =>
+  Arbitrary (ConwayUtxosPredFailure era)
+  where
+  arbitrary = genericArbitraryU
 
 instance
   ( Arbitrary (PredicateFailure (EraRule "UTXOW" era))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -13,6 +13,7 @@ module Test.Cardano.Ledger.Conway.TreeDiff (
   module Test.Cardano.Ledger.Babbage.TreeDiff,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
@@ -136,11 +137,17 @@ instance ToExpr (ConwayGovCert c)
 
 instance ToExpr (ConwayTxCert c)
 
--- Rules/GovCert
+-- Rules
 instance ToExpr (ConwayGovCertPredFailure era)
 
--- Rules/Delegs
 instance ToExpr (ConwayDelegPredFailure era)
+
+instance
+  ( ToExpr (PlutusPurpose AsItem era)
+  , ToExpr (ContextError era)
+  , ToExpr (TxCert era)
+  ) =>
+  ToExpr (ConwayUtxosPredFailure era)
 
 -- TxBody
 instance (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era)) => ToExpr (ConwayTxBodyRaw era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.BaseTypes (
   mkTxIxPartial,
  )
 import Cardano.Ledger.Coin (Coin (..))
+import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Credential (
   Credential (..),
   StakeCredential,
@@ -454,10 +455,10 @@ specialCont proof expected computed =
 findMismatch ::
   Proof era ->
   PredicateFailure (EraRule "UTXOW" era) ->
-  Maybe (AlonzoUtxosPredFailure era)
-findMismatch Alonzo (ShelleyInAlonzoUtxowPredFailure (Shelley.UtxoFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just x
-findMismatch Babbage (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just x
-findMismatch Conway (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just x
+  Maybe (PredicateFailure (EraRule "UTXOS" era))
+findMismatch Alonzo (ShelleyInAlonzoUtxowPredFailure (Shelley.UtxoFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just $ injectFailure x
+findMismatch Babbage (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just $ injectFailure x
+findMismatch Conway (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(Conway.ValidationTagMismatch _ _)))) = Just $ injectFailure x
 findMismatch _ _ = Nothing
 
 isSubset :: Eq t => [t] -> [t] -> Bool


### PR DESCRIPTION
# Description

Introduced new predicate failure `ConwayUtxosPredFailure` that does not contain `PPUP` predicate failures

Also supersedes and resuses work from #4103 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
