### PR TITLE
Fix an issue with txinfo and unusual notation in Babbage UTXO rule

### DIFF
--- a/eras/alonzo/formal-spec/txinfo.tex
+++ b/eras/alonzo/formal-spec/txinfo.tex
@@ -318,7 +318,7 @@ $\fun{txInfo}$ summarizes all the necessary transaction and chain state informat
         & ~~~~ [~ c_P \mid c \in \fun{txcerts}~{tx} ~] , \\
         & ~~~~ \{~(s_P,~c_P)\mid s\mapsto c \in \fun{txwdrls}~{tx}~\} , \\
         & ~~~~ \fun{transVITime} ~pp ~ei~ sysS~ (\fun{txvldt}~tx)  , \\
-        & ~~~~ \{~k_P\mid k \in \dom \fun{txwitsVKey}~{tx}~\} , \\
+        & ~~~~ \{~k_P\mid k \in \fun{reqSignerHashes}~{tx}~\} , \\
         & ~~~~ \{~(h_P,~d_P)\mid h\mapsto d \in \fun{txdats}~{tx}~\} , \\
         & ~~~~ (\fun{txid}~{tx})_P) \\
         &\text{Summarizes transaction data}

--- a/eras/babbage/formal-spec/txinfo.tex
+++ b/eras/babbage/formal-spec/txinfo.tex
@@ -32,7 +32,7 @@ without the execution units budget.
         & ~~~~ [~ c_P \mid c \in \fun{txcerts}~{tx} ~] , \\
         & ~~~~ \{~(s_P,~c_P)\mid s\mapsto c \in \fun{txwdrls}~{tx}~\} , \\
         & ~~~~ \fun{transVITime} ~pp ~ei~ sysS~ (\fun{txvldt}~tx)  , \\
-        & ~~~~ \{~k_P\mid k \in \dom \fun{txwitsVKey}~{tx}~\} , \\
+        & ~~~~ \{~k_P\mid k \in \fun{reqSignerHashes}~{tx}~\} , \\
         & ~~~~ \hldiff{\{ (sp_P, d_P) \mid sp \mapsto (d, \_) \in \fun{indexedRdmrs}~tx \}}, \\
         & ~~~~ \{~(h_P,~d_P)\mid h\mapsto d \in \fun{txdats}~{tx}~\} , \\
         & ~~~~ (\fun{txid}~{tx})_P)

--- a/eras/babbage/formal-spec/utxo.tex
+++ b/eras/babbage/formal-spec/utxo.tex
@@ -299,7 +299,8 @@ addresses.
       \forall \var{s} \in (\fun{txscripts}~txw~\hldiff{utxo~\var{neededHashes}}) \cap \ScriptPhOne,
       \fun{validateScript}~\var{s}~\var{tx}\\~\\
       \var{neededHashes} - \hldiff{\dom (\fun{refScripts}~tx~utxo)} = \dom (\fun{txwitscripts}~txw) \\~\\
-      \var{inputHashes} \subseteq_{\{h \mid (\wcard, \wcard, h, \wcard)\in\fun{allOuts}~tx \cup \hldiff{\var{utxo}~(\fun{refInputs}~{tx})}\}} \dom (\fun{txdats}~{txw})  \\~\\
+      \var{inputHashes} \subseteq \dom (\fun{txdats}~{txw})  \\
+      \dom (\fun{txdats}~{txw}) \subseteq \var{inputHashes} \cup {\{h \mid (\wcard, \wcard, h, \wcard)\in\fun{allOuts}~tx \cup \hldiff{\var{utxo}~(\fun{refInputs}~{tx})}\}} \\~\\
       \\~\\
       \dom (\fun{txrdmrs}~tx) = \left\{ \fun{rdptr}~txb~sp \,\middle|
         {


### PR DESCRIPTION
# Description

Fixes #4095 and replace an unusual notation with something standard.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
