### PR TITLE
Add extra type-safety to ensure that all predicate failures have roundtrip tests

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Add `NFData` instance for `AllegraUtxoPredFailure`
 * Add implementation for `getMinFeeTxUtxo`
 
+### `testlib`
+
+* Add `RuleListEra` instance for Allegra
+
 ## 1.3.0.0
 
 * Remove `ShelleyEraTxBody` superclass constraint on `AllegraEraTxBody`

--- a/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
+++ b/eras/allegra/impl/test/Test/Cardano/Ledger/Allegra/BinarySpec.hs
@@ -1,13 +1,18 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Allegra.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra
+import Cardano.Ledger.Crypto (Crypto)
 import Data.Default.Class (def)
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Allegra.TreeDiff ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (RuleListEra (..))
 import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
 
 spec :: Spec
@@ -15,3 +20,17 @@ spec = do
   specUpgrade @Allegra def
   describe "RoundTrip" $ do
     roundTripShelleyCommonSpec @Allegra
+
+instance Crypto c => RuleListEra (AllegraEra c) where
+  type
+    EraRules (AllegraEra c) =
+      '[ "DELEG"
+       , "DELEGS"
+       , "DELPL"
+       , "LEDGER"
+       , "LEDGERS"
+       , "POOL"
+       , "PPUP"
+       , "UTXO"
+       , "UTXOW"
+       ]

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### `testlib`
 
+* Add `RuleListEra` instance for Alonzo
 * Add:
   * `impLookupPlutusScriptMaybe`
   * `fixupOutputDatums`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/RoundTrip.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/RoundTrip.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (
   roundTripAlonzoCommonSpec,
   roundTripAlonzoEraTypesSpec,
 ) where
 
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Plutus.Data
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState
@@ -38,6 +41,7 @@ roundTripAlonzoCommonSpec ::
   , Arbitrary (GovState era)
   , Arbitrary (PParams era)
   , Arbitrary (PParamsUpdate era)
+  , RuleListEra era
   ) =>
   Spec
 roundTripAlonzoCommonSpec = do
@@ -57,3 +61,18 @@ roundTripAlonzoEraTypesSpec = do
       -- It doesn't roundtrip because we do not en/decode NoDatum
       -- Possibly use peekAvailable, but haven't looked into the issue too deeply
       roundTripEraTypeSpec @era @Datum
+
+instance Crypto c => RuleListEra (AlonzoEra c) where
+  type
+    EraRules (AlonzoEra c) =
+      '[ "DELEG"
+       , "DELEGS"
+       , "DELPL"
+       , "LEDGER"
+       , "LEDGERS"
+       , "POOL"
+       , "PPUP"
+       , "UTXO"
+       , "UTXOW"
+       , "UTXOS"
+       ]

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -10,6 +10,10 @@
   * Utxo rule raises that `PredicateFailure` in Conway and future Eras when they are not disjoint.
 * Modify `PParams` JSON instances to match `cardano-api`
 
+### `testlib`
+
+* Add `RuleListEra` instance for Babbage
+
 ## 1.6.0.0
 
 * Remove deprecated `getDatumBabbage`, `babbageTxScripts`, `refScripts`

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/BinarySpec.hs
@@ -1,16 +1,20 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Babbage.BinarySpec (spec) where
 
 import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Babbage
+import Cardano.Ledger.Crypto (Crypto)
 import Data.Default.Class (def)
 import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary (specUpgrade)
-import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraSpec)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (RuleListEra (..), roundTripEraSpec)
 
 spec :: Spec
 spec = do
@@ -20,3 +24,18 @@ spec = do
     -- CostModel serialization changes drastically for Conway, which requires a different
     -- QuickCheck generator, hence Arbitrary can't be reused
     roundTripEraSpec @Babbage @CostModels
+
+instance Crypto c => RuleListEra (BabbageEra c) where
+  type
+    EraRules (BabbageEra c) =
+      '[ "DELEG"
+       , "DELEGS"
+       , "DELPL"
+       , "LEDGER"
+       , "LEDGERS"
+       , "POOL"
+       , "PPUP"
+       , "UTXO"
+       , "UTXOW"
+       , "UTXOS"
+       ]

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Stop exporting `utxosGovStateL` from `Cardano.Ledger.Conway.Governance`
 * Remove deprecated `curPParamsConwayGovStateL` and `prevPParamsConwayGovStateL`
+* Add `EraRuleFailure "POOL"` type instance for `ConwayEra`
 * Add `ConwayUtxosPredFailure`
 * Support for intra-era hard fork with `ProtVerHigh` set to `10`
 * Guard Conway-specific features in transactions that use Plutus v1 or v2. #4112
@@ -64,6 +65,7 @@
 
 ### `testlib`
 
+* Add `RuleListEra` instance for Conway
 * Rename `canGovActionBeDRepAccepted` to `isDRepAccepted` and refactor #4097
   * Add `isSPOAccepted`
   * Change `setupSingleDRep` to return relevant keyhashes

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -65,6 +65,7 @@ library
         Cardano.Ledger.Conway.Rules.Ledgers
         Cardano.Ledger.Conway.Rules.NewEpoch
         Cardano.Ledger.Conway.Rules.Gov
+        Cardano.Ledger.Conway.Rules.Pool
         Cardano.Ledger.Conway.Rules.Ratify
         Cardano.Ledger.Conway.Rules.Tickf
         Cardano.Ledger.Conway.Rules.Utxo

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -26,6 +26,7 @@ import Cardano.Ledger.Conway.Rules.GovCert
 import Cardano.Ledger.Conway.Rules.Ledger
 import Cardano.Ledger.Conway.Rules.Ledgers ()
 import Cardano.Ledger.Conway.Rules.NewEpoch
+import Cardano.Ledger.Conway.Rules.Pool ()
 import Cardano.Ledger.Conway.Rules.Ratify
 import Cardano.Ledger.Conway.Rules.Tickf
 import Cardano.Ledger.Conway.Rules.Utxo ()

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -185,6 +185,7 @@ instance EraPParams era => DecCBOR (ConwayGovPredFailure era) where
     8 -> SumD InvalidPrevGovActionId <! From
     9 -> SumD VotingOnExpiredGovAction <! From
     10 -> SumD ProposalCantFollow <! From <! From <! From
+    11 -> SumD InvalidPolicyHash <! From <! From
     k -> Invalid k
 
 instance EraPParams era => EncCBOR (ConwayGovPredFailure era) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Ledger.Conway.Rules.Pool () where
+
+import Cardano.Ledger.Conway.Era (ConwayEra)
+import Cardano.Ledger.Core (EraRuleFailure)
+import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+
+type instance
+  EraRuleFailure "POOL" (ConwayEra c) =
+    ShelleyPoolPredFailure (ConwayEra c)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Tickf.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Rules.Tickf (

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conway.Binary.RoundTrip (
   roundTripConwayCommonSpec,
@@ -12,8 +14,10 @@ module Test.Cardano.Ledger.Conway.Binary.RoundTrip (
 
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Compactible
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley.LedgerState
 import Test.Cardano.Ledger.Alonzo.Arbitrary (FlexibleCostModels (..))
 import Test.Cardano.Ledger.Alonzo.Binary.RoundTrip (roundTripAlonzoCommonSpec)
@@ -39,6 +43,7 @@ roundTripConwayCommonSpec ::
   , Arbitrary (PParams era)
   , Arbitrary (PParamsUpdate era)
   , Arbitrary (PParamsHKD StrictMaybe era)
+  , RuleListEra era
   ) =>
   Spec
 roundTripConwayCommonSpec = do
@@ -69,3 +74,19 @@ roundTripConwayEraTypesSpec = do
     roundTripShareEraTypeSpec @era @DRepPulsingState
     roundTripShareEraTypeSpec @era @PulsingSnapshot
     roundTripShareEraTypeSpec @era @RatifyState
+
+instance Crypto c => RuleListEra (ConwayEra c) where
+  type
+    EraRules (ConwayEra c) =
+      '[ "GOV"
+       , "UTXOS"
+       , "LEDGER"
+       , "CERTS"
+       , "CERT"
+       , "DELEG"
+       , "GOVCERT"
+       , "UTXOW"
+       , "UTXO"
+       , "LEDGERS"
+       , "POOL"
+       ]

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add implementation for `getMinFeeTxUtxo`
 
+### `testlib`
+
+* Add `RuleListEra` instance for Mary
+
 ## 1.5.0.0
 
 * Change return type of `mintedTxBodyF` to `Set PolicyID`

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/BinarySpec.hs
@@ -1,11 +1,16 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Mary.BinarySpec (spec) where
 
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary
 import Data.Default.Class (def)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary (specUpgrade)
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (RuleListEra (..))
 import Test.Cardano.Ledger.Mary.Arbitrary ()
 import Test.Cardano.Ledger.Mary.TreeDiff ()
 import Test.Cardano.Ledger.Shelley.Binary.RoundTrip (roundTripShelleyCommonSpec)
@@ -15,3 +20,17 @@ spec = do
   specUpgrade @Mary def
   describe "RoundTrip" $ do
     roundTripShelleyCommonSpec @Mary
+
+instance Crypto c => RuleListEra (MaryEra c) where
+  type
+    EraRules (MaryEra c) =
+      '[ "DELEG"
+       , "DELEGS"
+       , "DELPL"
+       , "LEDGER"
+       , "LEDGERS"
+       , "POOL"
+       , "PPUP"
+       , "UTXO"
+       , "UTXOW"
+       ]

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### `testlib`
 
 * Added `ToExpr` instance for `ShelleyTxWitsRaw`
+* Add `RuleListEra` instance for Shelley
 * Add argument to `impSatisfyNativeScript` that accounts for already satisifed witnesses
 * Remove `impFreshIdxL`
 * Remove root coin argument from `initImpNES`, `initShelleyImpNES`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Shelley.Binary.RoundTrip (
   roundTripShelleyCommonSpec,
@@ -12,6 +14,8 @@ module Test.Cardano.Ledger.Shelley.Binary.RoundTrip (
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState
 import Test.Cardano.Ledger.Common
@@ -39,11 +43,13 @@ roundTripShelleyCommonSpec ::
   , Arbitrary (GovState era)
   , Arbitrary (PParams era)
   , Arbitrary (PParamsUpdate era)
+  , RuleListEra era
   ) =>
   Spec
 roundTripShelleyCommonSpec = do
   roundTripCoreEraTypesSpec @era
   roundTripStateEraTypesSpec @era
+  roundTripAllPredicateFailures @era
 
 roundTripStateEraTypesSpec ::
   forall era.
@@ -67,3 +73,17 @@ roundTripStateEraTypesSpec = do
     roundTripShareEraTypeSpec @era @UTxOState
     roundTripEraTypeSpec @era @EpochState
     roundTripEraTypeSpec @era @NewEpochState
+
+instance Crypto c => RuleListEra (ShelleyEra c) where
+  type
+    EraRules (ShelleyEra c) =
+      '[ "DELEG"
+       , "DELEGS"
+       , "DELPL"
+       , "LEDGER"
+       , "LEDGERS"
+       , "POOL"
+       , "PPUP"
+       , "UTXO"
+       , "UTXOW"
+       ]

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### `testlib`
 
+* Add `EraRuleProof`, `UnliftRules`, `roundTripAllPredicateFailures`
 * Add `Test.Cardano.Ledger.Plutus.ScriptTestContext`
 * Add `genByronVKeyAddr`, `genByronAddrFromVKey`
 * Add `Uniform` instances for `ByronKeyPair` and `KeyPair`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -196,7 +196,8 @@ library testlib
         vector-map:{vector-map, testlib},
         time,
         cardano-slotting,
-        unliftio
+        unliftio,
+        small-steps
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-name-shadowing

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}


### PR DESCRIPTION
# Description

This PR adds the `RuleListEra` typeclass, which has an associated type level list with all the (fallible) rules in that era. This gives us a closed world view of the rules and that makes it easier to write tests that iterate over each rule. See `roundTripAllPredicateFailures` for an example.

resolves #3866 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
