### PR TITLE
Shelley rules cleanup

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
@@ -50,7 +50,7 @@ instance Crypto c => EraGov (AllegraEra c) where
       emptyPParams
       emptyPParams
 
-  getProposedPPUpdates = Just . proposals
+  getProposedPPUpdates = Just . sgsCurProposals
 
   curPParamsGovStateL = curPParamsShelleyGovStateL
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -15,30 +15,25 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.CertState (CommitteeState (..))
-import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.API (
+import Cardano.Ledger.Shelley.Core
+import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
   DState (..),
   EpochState (..),
   LedgerState (..),
   NewEpochState (..),
   PState (..),
-  ProposedPPUpdates (..),
-  ShelleyGovState (..),
-  ShelleyTx (..),
-  ShelleyTxOut (..),
-  UTxO (..),
   UTxOState (..),
-  Update,
   VState (..),
- )
-import qualified Cardano.Ledger.Shelley.LedgerState as LS (
   returnRedeemAddrsToReserves,
  )
-import Cardano.Ledger.Shelley.PParams (Update (..))
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
+import Cardano.Ledger.Shelley.Tx (ShelleyTx)
+import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut)
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits)
+import Cardano.Ledger.UTxO (UTxO (..))
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 
@@ -72,7 +67,7 @@ instance Crypto c => TranslateEra (AllegraEra c) NewEpochState where
         { nesEL = nesEL nes
         , nesBprev = nesBprev nes
         , nesBcur = nesBcur nes
-        , nesEs = translateEra' ctxt $ LS.returnRedeemAddrsToReserves . nesEs $ nes
+        , nesEs = translateEra' ctxt $ returnRedeemAddrsToReserves $ nesEs nes
         , nesRu = nesRu nes
         , nesPd = nesPd nes
         , -- At this point, the consensus layer has passed in our stashed AVVM
@@ -101,10 +96,10 @@ instance Crypto c => TranslateEra (AllegraEra c) ShelleyGovState where
   translateEra ctxt ps =
     return
       ShelleyGovState
-        { proposals = translateEra' ctxt $ proposals ps
-        , futureProposals = translateEra' ctxt $ futureProposals ps
-        , sgovPp = translateEra' ctxt $ sgovPp ps
-        , sgovPrevPp = translateEra' ctxt $ sgovPrevPp ps
+        { sgsCurProposals = translateEra' ctxt $ sgsCurProposals ps
+        , sgsFutureProposals = translateEra' ctxt $ sgsFutureProposals ps
+        , sgsCurPParams = translateEra' ctxt $ sgsCurPParams ps
+        , sgsPrevPParams = translateEra' ctxt $ sgsPrevPParams ps
         }
 
 instance Crypto c => TranslateEra (AllegraEra c) ShelleyTxOut where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -385,7 +385,7 @@ instance Crypto c => EraGov (AlonzoEra c) where
       emptyPParams
       emptyPParams
 
-  getProposedPPUpdates = Just . proposals
+  getProposedPPUpdates = Just . sgsCurProposals
 
   curPParamsGovStateL = curPParamsShelleyGovStateL
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -270,7 +270,7 @@ instance Crypto c => EraGov (BabbageEra c) where
       emptyPParams
       emptyPParams
 
-  getProposedPPUpdates = Just . proposals
+  getProposedPPUpdates = Just . sgsCurProposals
 
   curPParamsGovStateL = curPParamsShelleyGovStateL
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -17,20 +17,23 @@ import Cardano.Ledger.Babbage.Core hiding (Tx)
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams ()
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.CertState (CommitteeState (..))
 import qualified Cardano.Ledger.Core as Core (Tx)
 import Cardano.Ledger.Crypto (Crypto)
-import Cardano.Ledger.Shelley.API (
+import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
   DState (..),
   EpochState (..),
+  LedgerState (..),
   NewEpochState (..),
   PState (..),
-  StrictMaybe (..),
+  UTxOState (..),
   VState (..),
  )
-import qualified Cardano.Ledger.Shelley.API as API
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
+import Cardano.Ledger.UTxO (UTxO (..))
 import qualified Data.Map.Strict as Map
 import Lens.Micro
 
@@ -123,43 +126,43 @@ instance Crypto c => TranslateEra (BabbageEra c) CertState where
         , certVState = translateEra' ctxt $ certVState ls
         }
 
-instance Crypto c => TranslateEra (BabbageEra c) API.LedgerState where
+instance Crypto c => TranslateEra (BabbageEra c) LedgerState where
   translateEra ctxt ls =
     pure
-      API.LedgerState
-        { API.lsUTxOState = translateEra' ctxt $ API.lsUTxOState ls
-        , API.lsCertState = translateEra' ctxt $ API.lsCertState ls
+      LedgerState
+        { lsUTxOState = translateEra' ctxt $ lsUTxOState ls
+        , lsCertState = translateEra' ctxt $ lsCertState ls
         }
 
-instance Crypto c => TranslateEra (BabbageEra c) API.UTxOState where
+instance Crypto c => TranslateEra (BabbageEra c) UTxOState where
   translateEra ctxt us =
     pure
-      API.UTxOState
-        { API.utxosUtxo = translateEra' ctxt $ API.utxosUtxo us
-        , API.utxosDeposited = API.utxosDeposited us
-        , API.utxosFees = API.utxosFees us
-        , API.utxosGovState = translateEra' ctxt $ API.utxosGovState us
-        , API.utxosStakeDistr = API.utxosStakeDistr us
-        , API.utxosDonation = API.utxosDonation us
+      UTxOState
+        { utxosUtxo = translateEra' ctxt $ utxosUtxo us
+        , utxosDeposited = utxosDeposited us
+        , utxosFees = utxosFees us
+        , utxosGovState = translateEra' ctxt $ utxosGovState us
+        , utxosStakeDistr = utxosStakeDistr us
+        , utxosDonation = utxosDonation us
         }
 
-instance Crypto c => TranslateEra (BabbageEra c) API.UTxO where
+instance Crypto c => TranslateEra (BabbageEra c) UTxO where
   translateEra _ctxt utxo =
-    pure $ API.UTxO $ translateTxOut `Map.map` API.unUTxO utxo
+    pure $ UTxO $ translateTxOut `Map.map` unUTxO utxo
 
-instance Crypto c => TranslateEra (BabbageEra c) API.ShelleyGovState where
+instance Crypto c => TranslateEra (BabbageEra c) ShelleyGovState where
   translateEra ctxt ps =
     pure
-      API.ShelleyGovState
-        { API.proposals = translateEra' ctxt $ API.proposals ps
-        , API.futureProposals = translateEra' ctxt $ API.futureProposals ps
-        , API.sgovPrevPp = upgradePParams () $ sgovPrevPp ps
-        , API.sgovPp = upgradePParams () $ sgovPp ps
+      ShelleyGovState
+        { sgsCurProposals = translateEra' ctxt $ sgsCurProposals ps
+        , sgsFutureProposals = translateEra' ctxt $ sgsFutureProposals ps
+        , sgsCurPParams = translateEra' ctxt $ sgsCurPParams ps
+        , sgsPrevPParams = translateEra' ctxt $ sgsPrevPParams ps
         }
 
-instance Crypto c => TranslateEra (BabbageEra c) API.ProposedPPUpdates where
-  translateEra _ctxt (API.ProposedPPUpdates ppup) =
-    pure $ API.ProposedPPUpdates $ fmap (upgradePParamsUpdate ()) ppup
+instance Crypto c => TranslateEra (BabbageEra c) ProposedPPUpdates where
+  translateEra _ctxt (ProposedPPUpdates ppup) =
+    pure $ ProposedPPUpdates $ fmap (upgradePParamsUpdate ()) ppup
 
 translateTxOut ::
   Crypto c =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -118,7 +118,7 @@ import Cardano.Ledger.CertState (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Core hiding (proposals)
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
   EnactSignal,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
@@ -55,7 +55,7 @@ instance Crypto c => EraGov (MaryEra c) where
       emptyPParams
       emptyPParams
 
-  getProposedPPUpdates = Just . proposals
+  getProposedPPUpdates = Just . sgsCurProposals
 
   curPParamsGovStateL = curPParamsShelleyGovStateL
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -14,13 +14,26 @@ module Cardano.Ledger.Mary.Translation where
 
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.CertState (CommitteeState (..))
-import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Scripts (Timelock, translateTimelock)
-import Cardano.Ledger.Mary.Tx ()
 import Cardano.Ledger.Mary.TxAuxData (AllegraTxAuxData (..))
-import Cardano.Ledger.Shelley.API hiding (Metadata)
+import Cardano.Ledger.Shelley.LedgerState (
+  CertState (..),
+  DState (..),
+  EpochState (..),
+  LedgerState (..),
+  NewEpochState (..),
+  PState (..),
+  UTxOState (..),
+  VState (..),
+ )
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
+import Cardano.Ledger.Shelley.Tx (ShelleyTx)
+import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut)
+import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits)
+import Cardano.Ledger.UTxO (UTxO (..))
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 
@@ -113,10 +126,10 @@ instance Crypto c => TranslateEra (MaryEra c) ShelleyGovState where
   translateEra ctxt ps =
     return
       ShelleyGovState
-        { proposals = translateEra' ctxt $ proposals ps
-        , futureProposals = translateEra' ctxt $ futureProposals ps
-        , sgovPrevPp = translateEra' ctxt $ sgovPrevPp ps
-        , sgovPp = translateEra' ctxt $ sgovPp ps
+        { sgsCurProposals = translateEra' ctxt $ sgsCurProposals ps
+        , sgsFutureProposals = translateEra' ctxt $ sgsFutureProposals ps
+        , sgsCurPParams = translateEra' ctxt $ sgsCurPParams ps
+        , sgsPrevPParams = translateEra' ctxt $ sgsPrevPParams ps
         }
 
 instance Crypto c => TranslateEra (MaryEra c) UTxOState where

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Change `UPEC` environment to `LedgerState`
 * Rename `currentPp` to `usCurPParams` and `ppupState` to `usGovState`
 * Change `ApplyTxError`, `TickTransitionError` and `BlockTransitionError`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.10.0.0
 
+* Rename `ShelleyGovState` fields:
+  * `proposals` to `sgsCurProposals`
+  * `futureProposals` to `sgsFutureProposals`
+  * `sgovPp` to `sgsCurPParams`
+  * `sgovPrevPp` to `sgsPrevPParams`
 * Change `UPEC` environment to `LedgerState`
 * Rename `currentPp` to `usCurPParams` and `ppupState` to `usGovState`
 * Change `ApplyTxError`, `TickTransitionError` and `BlockTransitionError`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Rename `currentPp` to `usCurPParams` and `ppupState` to `usGovState`
 * Change `ApplyTxError`, `TickTransitionError` and `BlockTransitionError`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`
 * Removed `prettyWitnessSetParts`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -224,8 +224,9 @@ incrementalStakeDistr pp (IStake credStake ptrStake) ds ps =
     step1 =
       if ignorePtrs
         then activeCreds
-        else -- Resolve inserts and delets which were indexed by ptrs, by looking them up in the ptrsMap
-        -- and combining the result of the lookup with the ordinary stake, keeping only the active credentials
+        else -- Resolve inserts and deletes which were indexed by ptrs, by looking them up
+        -- in the ptrsMap and combining the result of the lookup with the ordinary
+        -- stake, keeping only the active credentials
           Map.foldlWithKey' addResolvedPointer activeCreds ptrStake
     step2 = aggregateActiveStake triplesMap step1
     addResolvedPointer ans ptr ccoin =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Shelley.PParams (
   hasLegalProtVerUpdate,
  )
 import Control.DeepSeq (NFData)
+import Control.Monad (forM_)
 import Control.State.Transition (
   STS (..),
   TRC (..),
@@ -100,9 +101,10 @@ newPpTransition = do
           (utxoState ^. utxosGovStateL)
 
   -- TODO: remove this predicate check. See #4158
-  obligationCurr
-    == utxosDeposited utxoState
-      ?! UnexpectedDepositPot obligationCurr (utxosDeposited utxoState)
+  forM_ mppNew $ \_ ->
+    obligationCurr
+      == utxosDeposited utxoState
+        ?! UnexpectedDepositPot obligationCurr (utxosDeposited utxoState)
 
   case mppNew of
     Just ppNew

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -130,7 +130,7 @@ updatePpup ppupState pp =
     & proposalsL .~ ps
     & futureProposalsL .~ emptyPPPUpdates
   where
-    ProposedPPUpdates newProposals = futureProposals ppupState
+    ProposedPPUpdates newProposals = sgsFutureProposals ppupState
     ps =
       if all (hasLegalProtVerUpdate pp) newProposals
         then ProposedPPUpdates newProposals

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -23,8 +23,6 @@ import Cardano.Ledger.Shelley.Era (ShelleyNEWPP)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
-  DState (..),
-  PState (..),
   UTxOState (utxosDeposited),
   totalObligation,
   utxosGovStateL,
@@ -50,11 +48,10 @@ import NoThunks.Class (NoThunks (..))
 data ShelleyNewppState era
   = NewppState (PParams era) (ShelleyGovState era)
 
-data NewppEnv era
-  = NewppEnv
-      (DState era)
-      (PState era)
-      (UTxOState era)
+data NewppEnv era = NewppEnv
+  { neCertState :: !(CertState era)
+  , neUTxOState :: !(UTxOState era)
+  }
 
 data ShelleyNewppPredFailure era
   = UnexpectedDepositPot
@@ -92,26 +89,28 @@ newPpTransition ::
   TransitionRule (ShelleyNEWPP era)
 newPpTransition = do
   TRC
-    ( NewppEnv dstate pstate utxoSt
-      , NewppState pp ppupSt
-      , ppNew
+    ( NewppEnv certState utxoState
+      , NewppState pp ppupState
+      , mppNew
       ) <-
     judgmentContext
+  let obligationCurr =
+        totalObligation
+          certState
+          (utxoState ^. utxosGovStateL)
 
-  case ppNew of
-    Just ppNew' -> do
-      let Coin oblgCurr =
-            totalObligation
-              (CertState def pstate dstate)
-              (utxoSt ^. utxosGovStateL)
-      Coin oblgCurr
-        == utxosDeposited utxoSt
-          ?! UnexpectedDepositPot (Coin oblgCurr) (utxosDeposited utxoSt)
+  -- TODO: remove this predicate check. See #4158
+  obligationCurr
+    == utxosDeposited utxoState
+      ?! UnexpectedDepositPot obligationCurr (utxosDeposited utxoState)
 
-      if toInteger (ppNew' ^. ppMaxTxSizeL) + toInteger (ppNew' ^. ppMaxBHSizeL) < toInteger (ppNew' ^. ppMaxBBSizeL)
-        then pure $ NewppState ppNew' (updatePpup ppupSt ppNew')
-        else pure $ NewppState pp (updatePpup ppupSt pp)
-    Nothing -> pure $ NewppState pp (updatePpup ppupSt pp)
+  case mppNew of
+    Just ppNew
+      | toInteger (ppNew ^. ppMaxTxSizeL)
+          + toInteger (ppNew ^. ppMaxBHSizeL)
+          < toInteger (ppNew ^. ppMaxBBSizeL) ->
+          pure $ NewppState ppNew $ updatePpup ppupState ppNew
+    _ -> pure $ NewppState pp $ updatePpup ppupState pp
 
 -- | Update the protocol parameter updates by clearing out the proposals
 -- and making the future proposals become the new proposals,
@@ -124,12 +123,12 @@ updatePpup ::
   GovState era ->
   PParams era ->
   ShelleyGovState era
-updatePpup ppupSt pp =
-  ppupSt
+updatePpup ppupState pp =
+  ppupState
     & proposalsL .~ ps
     & futureProposalsL .~ emptyPPPUpdates
   where
-    ProposedPPUpdates newProposals = futureProposals ppupSt
+    ProposedPPUpdates newProposals = futureProposals ppupState
     ps =
       if all (hasLegalProtVerUpdate pp) newProposals
         then ProposedPPUpdates newProposals

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -166,8 +166,8 @@ ppupTransitionNonEmpty = do
   TRC
     ( PPUPEnv slot pp (GenDelegs genDelegs)
       , pps@( ShelleyGovState
-                { proposals = ProposedPPUpdates pupS
-                , futureProposals = ProposedPPUpdates fpupS
+                { sgsCurProposals = ProposedPPUpdates pupS
+                , sgsFutureProposals = ProposedPPUpdates fpupS
                 }
               )
       , update
@@ -203,16 +203,16 @@ ppupTransitionNonEmpty = do
             ?! PPUpdateWrongEpoch currentEpochNo targetEpochNo VoteForThisEpoch
           pure $
             pps
-              { proposals = ProposedPPUpdates (eval (pupS ⨃ pup))
-              , futureProposals = ProposedPPUpdates fpupS
+              { sgsCurProposals = ProposedPPUpdates (eval (pupS ⨃ pup))
+              , sgsFutureProposals = ProposedPPUpdates fpupS
               }
         else do
           (succ currentEpochNo == targetEpochNo)
             ?! PPUpdateWrongEpoch currentEpochNo targetEpochNo VoteForNextEpoch
           pure $
             pps
-              { proposals = ProposedPPUpdates pupS
-              , futureProposals = ProposedPPUpdates (eval (fpupS ⨃ pup))
+              { sgsCurProposals = ProposedPPUpdates pupS
+              , sgsFutureProposals = ProposedPPUpdates (eval (fpupS ⨃ pup))
               }
 
 type PPUPPredFailure era = EraRuleFailure "PPUP" era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -164,26 +164,20 @@ instance Era era => DecCBOR (ShelleyPpupPredFailure era) where
 ppupTransitionNonEmpty :: (EraPParams era, ProtVerAtMost era 8) => TransitionRule (ShelleyPPUP era)
 ppupTransitionNonEmpty = do
   TRC
-    ( PPUPEnv slot pp (GenDelegs _genDelegs)
+    ( PPUPEnv slot pp (GenDelegs genDelegs)
       , pps@( ShelleyGovState
-                (ProposedPPUpdates pupS)
-                (ProposedPPUpdates fpupS)
-                _
-                _
+                { proposals = ProposedPPUpdates pupS
+                , futureProposals = ProposedPPUpdates fpupS
+                }
               )
-      , up
+      , update
       ) <-
     judgmentContext
 
-  case up of
-    SNothing ->
-      pure $
-        pps
-          { proposals = ProposedPPUpdates pupS
-          , futureProposals = ProposedPPUpdates fpupS
-          }
-    SJust (Update (ProposedPPUpdates pup) te) -> do
-      eval (dom pup ⊆ dom _genDelegs) ?! NonGenesisUpdatePPUP (eval (dom pup)) (eval (dom _genDelegs))
+  case update of
+    SNothing -> pure pps
+    SJust (Update (ProposedPPUpdates pup) targetEpochNo) -> do
+      eval (dom pup ⊆ dom genDelegs) ?! NonGenesisUpdatePPUP (eval (dom pup)) (eval (dom genDelegs))
 
       let firstIllegalProtVerUpdate = do
             ppu <- F.find (not . hasLegalProtVerUpdate pp) pup
@@ -193,28 +187,28 @@ ppupTransitionNonEmpty = do
       failOnJust firstIllegalProtVerUpdate PVCannotFollowPPUP
 
       sp <- liftSTS $ asks stabilityWindow
-      firstSlotNextEpoch <- do
-        ei <- liftSTS $ asks epochInfoPure
-        EpochNo e <- liftSTS $ epochInfoEpoch ei slot
-        let newEpochNo = EpochNo $ e + 1
-        tellEvent $ NewEpoch newEpochNo
-        liftSTS $ epochInfoFirst ei newEpochNo
-      let tooLate = firstSlotNextEpoch *- Duration (2 * sp)
+      (currentEpochNo, firstSlotNextEpoch) <- do
+        epochInfo <- liftSTS $ asks epochInfoPure
+        epochNo <- liftSTS $ epochInfoEpoch epochInfo slot
+        let nextEpochNo = succ epochNo
+        tellEvent $ NewEpoch nextEpochNo
+        liftSTS $ do
+          (,) epochNo <$> epochInfoFirst epochInfo nextEpochNo
 
-      currentEpoch <- liftSTS $ do
-        ei <- asks epochInfoPure
-        epochInfoEpoch ei slot
+      let tooLate = firstSlotNextEpoch *- Duration (2 * sp)
 
       if slot < tooLate
         then do
-          currentEpoch == te ?! PPUpdateWrongEpoch currentEpoch te VoteForThisEpoch
+          (currentEpochNo == targetEpochNo)
+            ?! PPUpdateWrongEpoch currentEpochNo targetEpochNo VoteForThisEpoch
           pure $
             pps
               { proposals = ProposedPPUpdates (eval (pupS ⨃ pup))
               , futureProposals = ProposedPPUpdates fpupS
               }
         else do
-          succ currentEpoch == te ?! PPUpdateWrongEpoch currentEpoch te VoteForNextEpoch
+          (succ currentEpochNo == targetEpochNo)
+            ?! PPUpdateWrongEpoch currentEpochNo targetEpochNo VoteForNextEpoch
           pure $
             pps
               { proposals = ProposedPPUpdates pupS

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -195,7 +195,7 @@ validatingTickTransitionFORECAST ::
   , BaseM (tick era) ~ ShelleyBase
   , State (EraRule "UPEC" era) ~ UpecState era
   , Signal (EraRule "UPEC" era) ~ ()
-  , Environment (EraRule "UPEC" era) ~ EpochState era
+  , Environment (EraRule "UPEC" era) ~ LedgerState era
   , Embed (EraRule "UPEC" era) (tick era)
   , STS (tick era)
   , GovState era ~ ShelleyGovState era
@@ -234,10 +234,11 @@ validatingTickTransitionFORECAST nes slot = do
       -- return value here was used to validate their headers.
 
       let pp = es ^. curPParamsEpochStateL
-          updates = utxosGovState . lsUTxOState . esLState $ es
+          ls = esLState es
+          updates = utxosGovState $ lsUTxOState ls
       UpecState pp' _ <-
         trans @(EraRule "UPEC" era) $
-          TRC (es, UpecState pp updates, ())
+          TRC (ls, UpecState pp updates, ())
       let es' =
             adoptGenesisDelegs es slot
               & curPParamsEpochStateL .~ pp'
@@ -341,18 +342,14 @@ instance
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , Signal (EraRule "UPEC" era) ~ ()
   , State (EraRule "UPEC" era) ~ UpecState era
-  , Environment (EraRule "UPEC" era) ~ EpochState era
+  , Environment (EraRule "UPEC" era) ~ LedgerState era
   , Embed (EraRule "UPEC" era) (ShelleyTICKF era)
   , GovState era ~ ShelleyGovState era
   ) =>
   STS (ShelleyTICKF era)
   where
-  type
-    State (ShelleyTICKF era) =
-      NewEpochState era
-  type
-    Signal (ShelleyTICKF era) =
-      SlotNo
+  type State (ShelleyTICKF era) = NewEpochState era
+  type Signal (ShelleyTICKF era) = SlotNo
   type Environment (ShelleyTICKF era) = ()
   type BaseM (ShelleyTICKF era) = ShelleyBase
   type PredicateFailure (ShelleyTICKF era) = ShelleyTickfPredFailure era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -100,7 +100,7 @@ instance
         coreNodeQuorum <- liftSTS $ asks quorum
 
         let utxoState = lsUTxOState ls
-            pup = proposals ppupState
+            pup = sgsCurProposals ppupState
             ppNew = votedValue pup pp (fromIntegral coreNodeQuorum)
         NewppState pp' ppupState' <-
           trans @(ShelleyNEWPP era) $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -28,12 +28,9 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Era (ShelleyUPEC)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState (
-  EpochState,
-  UTxOState (..),
-  esLState,
+  LedgerState,
   lsCertState,
   lsUTxOState,
-  pattern EpochState,
  )
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Cardano.Ledger.Shelley.Rules.Newpp (
@@ -87,16 +84,14 @@ instance
   where
   type State (ShelleyUPEC era) = UpecState era
   type Signal (ShelleyUPEC era) = ()
-  type Environment (ShelleyUPEC era) = EpochState era
+  type Environment (ShelleyUPEC era) = LedgerState era
   type BaseM (ShelleyUPEC era) = ShelleyBase
   type PredicateFailure (ShelleyUPEC era) = ShelleyUpecPredFailure era
   initialRules = []
   transitionRules =
     [ do
         TRC
-          ( EpochState
-              { esLState = ls
-              }
+          ( ls
             , UpecState pp ppupState
             , _
             ) <-
@@ -105,7 +100,7 @@ instance
         coreNodeQuorum <- liftSTS $ asks quorum
 
         let utxoState = lsUTxOState ls
-            pup = proposals $ utxosGovState utxoState
+            pup = proposals ppupState
             ppNew = votedValue pup pp (fromIntegral coreNodeQuorum)
         NewppState pp' ppupState' <-
           trans @(ShelleyNEWPP era) $

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -239,7 +239,7 @@ checkPreservation SourceSignalTarget {source, target, signal} count =
     oldPoolDeposit = psDeposits . certPState . lsCertState $ lsOld
     newPoolDeposit = psDeposits . certPState . lsCertState $ lsNew
 
-    proposal = votedValue (proposals . utxosGovState . lsUTxOState $ lsOld) currPP 5
+    proposal = votedValue (sgsCurProposals . utxosGovState . lsUTxOState $ lsOld) currPP 5
     obligationMsgs = case proposal of
       Nothing -> []
       Just proposal' ->

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -727,7 +727,7 @@ setCurrentProposals ps cs = cs {chainNes = nes'}
     ls = esLState es
     utxoSt = lsUTxOState ls
     ppupSt = utxosGovState utxoSt
-    ppupSt' = ppupSt {proposals = ps}
+    ppupSt' = ppupSt {sgsCurProposals = ps}
     utxoSt' = utxoSt {utxosGovState = ppupSt'}
     ls' = ls {lsUTxOState = utxoSt'}
     es' = es {esLState = ls'}
@@ -749,7 +749,7 @@ setFutureProposals ps cs = cs {chainNes = nes'}
     ls = esLState es
     utxoSt = lsUTxOState ls
     ppupSt = utxosGovState utxoSt
-    ppupSt' = ppupSt {futureProposals = ps}
+    ppupSt' = ppupSt {sgsFutureProposals = ps}
     utxoSt' = utxoSt {utxosGovState = ppupSt'}
     ls' = ls {lsUTxOState = utxoSt'}
     es' = es {esLState = ls'}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -69,6 +69,7 @@ import Cardano.Ledger.Plutus.Data (Data (..), Datum (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..), PoolDistr (..))
 import Cardano.Ledger.PoolParams (PoolParams)
 import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.Shelley.Governance (futureProposalsL, proposalsL)
 import qualified Cardano.Ledger.Shelley.Governance as Gov
 import Cardano.Ledger.Shelley.HardForks as HardForks (allowMIRTransfer)
 import Cardano.Ledger.Shelley.LedgerState hiding (credMapL, delegations, deltaReserves, deltaTreasury, ptrMap, rewards)
@@ -378,8 +379,8 @@ ppupStateT ::
   RootTarget era (ShelleyGovState era) (ShelleyGovState era)
 ppupStateT p =
   Invert "PPUPState" (typeRep @(ShelleyGovState era)) ppupfun
-    :$ Lensed (pparamProposals p) (shellyGovStateProposedPPUpdatesL . proposedMapL p)
-    :$ Lensed (futurePParamProposals p) (futureproposalsL . proposedMapL p)
+    :$ Lensed (pparamProposals p) (proposalsL . proposedMapL p)
+    :$ Lensed (futurePParamProposals p) (futureProposalsL . proposedMapL p)
     :$ Lensed (currPParams p) (Gov.curPParamsGovStateL . pparamsFL p)
     :$ Lensed (prevPParams p) (Gov.curPParamsGovStateL . pparamsFL p)
   where
@@ -2026,12 +2027,6 @@ smCommL = lens getter (\_ t -> SJust t)
   where
     getter SNothing = Committee Map.empty maxBound
     getter (SJust x) = x
-
-shellyGovStateProposedPPUpdatesL :: Lens' (ShelleyGovState era) (ProposedPPUpdates era)
-shellyGovStateProposedPPUpdatesL = lens proposals (\x y -> x {proposals = y})
-
-futureproposalsL :: Lens' (ShelleyGovState era) (ProposedPPUpdates era)
-futureproposalsL = lens futureProposals (\x y -> x {futureProposals = y})
 
 proposedMapL :: Proof era -> Lens' (ProposedPPUpdates era) (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdateF era))
 proposedMapL p =


### PR DESCRIPTION
# Description

Collection of improvements to Shelley rules. This work is done as part of preparation to implementing #4006 

Probably easier to review commit by commit

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
