### PR TITLE
Make shelley `TxWits` consistent with other eras

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -122,7 +122,11 @@ import Cardano.Ledger.Plutus.Language (
   plutusLanguage,
  )
 import Cardano.Ledger.SafeHash (SafeToHash (..))
-import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..), shelleyEqTxWitsRaw)
+import Cardano.Ledger.Shelley.TxWits (
+  ShelleyTxWits (..),
+  mapTraverseableDecoderA,
+  shelleyEqTxWitsRaw,
+ )
 import Control.DeepSeq (NFData)
 import Control.Monad (when, (>=>))
 import Data.Bifunctor (Bifunctor (first))
@@ -731,13 +735,6 @@ alonzoEqTxWitsRaw txWits1 txWits2 =
   shelleyEqTxWitsRaw txWits1 txWits2
     && eqRawType (txWits1 ^. datsTxWitsL) (txWits2 ^. datsTxWitsL)
     && eqRawType (txWits1 ^. rdmrsTxWitsL) (txWits2 ^. rdmrsTxWitsL)
-
-mapTraverseableDecoderA ::
-  Traversable f =>
-  Decoder s (f (Annotator a)) ->
-  (f a -> m b) ->
-  Decoder s (Annotator (m b))
-mapTraverseableDecoderA decList transformList = fmap transformList . sequence <$> decList
 
 encodeWithSetTag :: EncCBOR a => a -> Encoding
 encodeWithSetTag xs =

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Removed `prettyWitnessSetParts`
 * Re-implemented `ShelleyTxWits` with `MemoBytes`
 * Re-implemented `ShelleyTxAuxData` with `MemoBytes`
 * Remove `getNextEpochCommitteeMembers` from `EraGov`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Re-implemented `ShelleyTxWits` with `MemoBytes`
 * Re-implemented `ShelleyTxAuxData` with `MemoBytes`
 * Remove `getNextEpochCommitteeMembers` from `EraGov`
 * Deprecated `PPUPPredFailure`
@@ -26,6 +27,7 @@
 
 ### `testlib`
 
+* Added `ToExpr` instance for `ShelleyTxWitsRaw`
 * Add argument to `impSatisfyNativeScript` that accounts for already satisifed witnesses
 * Remove `impFreshIdxL`
 * Remove root coin argument from `initImpNES`, `initShelleyImpNES`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -32,7 +32,6 @@ module Cardano.Ledger.Shelley.TxWits (
   addrShelleyTxWitsL,
   bootAddrShelleyTxWitsL,
   addrWits',
-  prettyWitnessSetParts,
   shelleyEqTxWitsRaw,
   mapTraverseableDecoderA,
 
@@ -219,18 +218,6 @@ shelleyEqTxWitsRaw txWits1 txWits2 =
   liftEq eqRaw (txWits1 ^. addrTxWitsL) (txWits2 ^. addrTxWitsL)
     && liftEq eqRaw (txWits1 ^. scriptTxWitsL) (txWits2 ^. scriptTxWitsL)
     && liftEq eqRaw (txWits1 ^. bootAddrTxWitsL) (txWits2 ^. bootAddrTxWitsL)
-
--- | Exports the relevant parts from a (WintessSetHKD Identity era) for
---     use by the pretty printer without all the horrible constraints.
---     Uses the non-exported WitnessSet' constructor.
-prettyWitnessSetParts ::
-  EraScript era =>
-  ShelleyTxWits era ->
-  ( Set (WitVKey 'Witness (EraCrypto era))
-  , Map (ScriptHash (EraCrypto era)) (Script era)
-  , Set (BootstrapWitness (EraCrypto era))
-  )
-prettyWitnessSetParts (ShelleyTxWits a b c) = (a, b, c)
 
 instance EraScript era => DecCBOR (Annotator (ShelleyTxWitsRaw era)) where
   decCBOR = decodeWits

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Shelley.TxWits (
   addrWits',
   prettyWitnessSetParts,
   shelleyEqTxWitsRaw,
+  mapTraverseableDecoderA,
 
   -- * Re-exports
   WitVKey (..),
@@ -282,9 +283,14 @@ decodeWits =
         (\x wits -> wits {bootWits' = x})
         (D $ mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
     witField n = fieldAA (\_ wits -> wits) (Invalid n)
-    mapTraverseableDecoderA decList transformList =
-      fmap transformList . sequence <$> decList
 
 keyBy :: Ord k => (a -> k) -> [a] -> Map k a
 keyBy f xs = Map.fromList $ (\x -> (f x, x)) <$> xs
 {-# DEPRECATED keyBy "In favor of `Data.MapExtras.fromElems`" #-}
+
+mapTraverseableDecoderA ::
+  Traversable f =>
+  Decoder s (f (Annotator a)) ->
+  (f a -> m b) ->
+  Decoder s (Annotator (m b))
+mapTraverseableDecoderA decList transformList = fmap transformList . sequence <$> decList

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -67,6 +67,8 @@ instance ToExpr (ShelleyDelegCert c)
 -- TxWits
 instance (Era era, ToExpr (Script era)) => ToExpr (ShelleyTxWits era)
 
+instance (Era era, ToExpr (Script era)) => ToExpr (ShelleyTxWitsRaw era)
+
 -- Rules/Ppup
 instance ToExpr VotingPeriod
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -238,7 +238,7 @@ import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))
 import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), ShelleyTxBodyRaw (..))
 import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
-import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, prettyWitnessSetParts)
+import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap (
@@ -719,14 +719,13 @@ instance Crypto c => PrettyA (BootstrapWitness c) where
   prettyA = ppBootstrapWitness
 
 ppWitnessSetHKD :: forall era. Reflect era => ShelleyTxWits era -> PDoc
-ppWitnessSetHKD x =
-  let (addr, scr, boot) = prettyWitnessSetParts x
-   in ppRecord
-        "ShelleyTxWits"
-        [ ("addrWits", ppSet (pcWitVKey @era reify) addr)
-        , ("scriptWits", ppMap pcScriptHash (pcScript reify) scr)
-        , ("bootWits", ppSet ppBootstrapWitness boot)
-        ]
+ppWitnessSetHKD (ShelleyTxWits addr scr boot) =
+  ppRecord
+    "ShelleyTxWits"
+    [ ("addrWits", ppSet (pcWitVKey @era reify) addr)
+    , ("scriptWits", ppMap pcScriptHash (pcScript reify) scr)
+    , ("bootWits", ppSet ppBootstrapWitness boot)
+    ]
 
 instance Reflect era => PrettyA (ShelleyTxWits era) where
   prettyA = ppWitnessSetHKD


### PR DESCRIPTION
# Description
Resolves #3959
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
