### PR TITLE
Add `ConwayDRepIncorrectRefund` and tests for `GovCert`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `ConwayDRepIncorrectRefund`
 * Stop exporting `utxosGovStateL` from `Cardano.Ledger.Conway.Governance`
 * Remove deprecated `curPParamsConwayGovStateL` and `prevPParamsConwayGovStateL`
 * Add `EraRuleFailure "POOL"` type instance for `ConwayEra`
@@ -65,6 +66,7 @@
 
 ### `testlib`
 
+* Add `Test.Cardano.Ledger.Conway.Imp.GovCertSpec`
 * Add `RuleListEra` instance for Conway
 * Rename `canGovActionBeDRepAccepted` to `isDRepAccepted` and refactor #4097
   * Add `isSPOAccepted`

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
-import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure)
+import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure, ConwayGovPredFailure)
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
 import Test.Cardano.Ledger.Common
@@ -38,6 +38,7 @@ spec ::
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   ) =>
   Spec
 spec = do
@@ -49,3 +50,4 @@ spec = do
     Utxo.spec @era
     Utxos.spec @era
     Ratify.spec @era
+    GovCert.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -1,80 +1,228 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (spec) where
 
-import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Credential (Credential (KeyHashObj))
-import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.BaseTypes (EpochInterval (..), EpochNo (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Core (EraGov (..), InjectRuleFailure (..), ppCommitteeMaxTermLengthL, ppDRepDepositL)
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov (..),
+  ConwayGovState,
+  GovAction (..),
+  GovPurposeId (..),
+  Voter (..),
+  committeeMembers,
+  committeeMembersL,
+ )
+import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure (..))
+import Cardano.Ledger.Conway.TxCert (
+  pattern AuthCommitteeHotKeyTxCert,
+  pattern RegDRepTxCert,
+  pattern ResignCommitteeColdTxCert,
+  pattern UnRegDRepTxCert,
+ )
+import Cardano.Ledger.Core (Era (..), EraTx (..), EraTxBody (..))
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.Shelley.LedgerState (
+  curPParamsEpochStateL,
+  esLStateL,
+  lsUTxOStateL,
+  nesEsL,
+  utxosGovStateL,
+ )
+import Cardano.Ledger.Val (Val (..))
 import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
-import Lens.Micro
+import Lens.Micro ((&), (.~), (^.))
+import Test.Cardano.Ledger.Common hiding (assertBool, shouldBe)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
-import Test.Cardano.Ledger.Imp.Common hiding (Success)
+import Test.Cardano.Ledger.Imp.Common
+
+electCommittee1 :: ConwayEraImp era => ImpTestM era (Credential 'ColdCommitteeRole (EraCrypto era))
+electCommittee1 = do
+  modifyPParams $ ppCommitteeMaxTermLengthL .~ EpochInterval 100
+  drep <- registerDRep
+  EpochInterval ccTerm <- getsNES $ nesEsL . curPParamsEpochStateL . ppCommitteeMaxTermLengthL
+  ccCred <- KeyHashObj <$> freshKeyHash
+  let
+    committee = Map.singleton ccCred (EpochNo $ fromIntegral ccTerm)
+  _ <- electCommittee SNothing drep mempty committee
+  passNEpochs 3
+  newCommittee <-
+    getsNES $
+      nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
+  fmap committeeMembers newCommittee `shouldBe` SJust committee
+  pure ccCred
 
 spec ::
   forall era.
   ( ConwayEraImp era
   , GovState era ~ ConwayGovState era
+  , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   ) =>
   SpecWith (ImpTestState era)
-spec =
-  describe "GOVCERT" $ do
-    it "A CC that has resigned will need to be first voted out and then voted in to be considered active" $ do
-      (dRep, _, gaidCC) <- electBasicCommittee
-      passNEpochs 2
-      -- Add a fresh CC
-      cc <- KeyHashObj <$> freshKeyHash
-      let addCCAction = UpdateCommittee (SJust gaidCC) mempty (Map.singleton cc 20) (1 %! 2)
-      addCCGaid <- submitGovAction addCCAction
-      submitYesVote_ (DRepVoter dRep) addCCGaid
-      passNEpochs 2
-      -- Confirm that they are added
-      SJust committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-      let assertCCMembership comm =
-            assertBool "Expected CC to be present in the committee" $
-              Map.member cc (comm ^. committeeMembersL)
-          assertCCMissing comm =
-            assertBool "Expected CC to be absent in the committee" $
-              Map.notMember cc (comm ^. committeeMembersL)
-      assertCCMembership committee
-      -- Confirm their hot key registration
-      _hotKey <- registerCommitteeHotKey cc
-      ccShouldNotBeResigned cc
-      -- Have them resign
-      resignCommitteeColdKey cc
-      ccShouldBeResigned cc
-      -- Re-add the same CC
-      let reAddCCAction = UpdateCommittee (SJust $ GovPurposeId addCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
-      reAddCCGaid <- submitGovAction reAddCCAction
-      submitYesVote_ (DRepVoter dRep) reAddCCGaid
-      passNEpochs 2
-      -- Confirm that they are still resigned
-      ccShouldBeResigned cc
-      -- Remove them
-      let removeCCAction = UpdateCommittee (SJust $ GovPurposeId reAddCCGaid) (Set.singleton cc) mempty (1 %! 2)
-      removeCCGaid <- submitGovAction removeCCAction
-      submitYesVote_ (DRepVoter dRep) removeCCGaid
-      passNEpochs 2
-      -- Confirm that they have been removed
-      SJust committeeAfterRemove <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-      assertCCMissing committeeAfterRemove
-      -- Add the same CC back a second time
-      let secondAddCCAction = UpdateCommittee (SJust $ GovPurposeId removeCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
-      secondAddCCGaid <- submitGovAction secondAddCCAction
-      submitYesVote_ (DRepVoter dRep) secondAddCCGaid
-      passNEpochs 2
-      -- Confirm that they have been added
-      SJust committeeAfterRemoveAndAdd <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-      assertCCMembership committeeAfterRemoveAndAdd
-      -- Confirm that after registering a hot key, they are active
-      _hotKey <- registerCommitteeHotKey cc
-      ccShouldNotBeResigned cc
+spec = describe "GOVCERT" $ do
+  it "A CC that has resigned will need to be first voted out and then voted in to be considered active" $ do
+    (dRep, _, gaidCC) <- electBasicCommittee
+    passNEpochs 2
+    -- Add a fresh CC
+    cc <- KeyHashObj <$> freshKeyHash
+    let addCCAction = UpdateCommittee (SJust gaidCC) mempty (Map.singleton cc 20) (1 %! 2)
+    addCCGaid <- submitGovAction addCCAction
+    submitYesVote_ (DRepVoter dRep) addCCGaid
+    passNEpochs 2
+    -- Confirm that they are added
+    SJust committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
+    let assertCCMembership comm =
+          assertBool "Expected CC to be present in the committee" $
+            Map.member cc (comm ^. committeeMembersL)
+        assertCCMissing comm =
+          assertBool "Expected CC to be absent in the committee" $
+            Map.notMember cc (comm ^. committeeMembersL)
+    assertCCMembership committee
+    -- Confirm their hot key registration
+    _hotKey <- registerCommitteeHotKey cc
+    ccShouldNotBeResigned cc
+    -- Have them resign
+    resignCommitteeColdKey cc
+    ccShouldBeResigned cc
+    -- Re-add the same CC
+    let reAddCCAction = UpdateCommittee (SJust $ GovPurposeId addCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
+    reAddCCGaid <- submitGovAction reAddCCAction
+    submitYesVote_ (DRepVoter dRep) reAddCCGaid
+    passNEpochs 2
+    -- Confirm that they are still resigned
+    ccShouldBeResigned cc
+    -- Remove them
+    let removeCCAction = UpdateCommittee (SJust $ GovPurposeId reAddCCGaid) (Set.singleton cc) mempty (1 %! 2)
+    removeCCGaid <- submitGovAction removeCCAction
+    submitYesVote_ (DRepVoter dRep) removeCCGaid
+    passNEpochs 2
+    -- Confirm that they have been removed
+    SJust committeeAfterRemove <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
+    assertCCMissing committeeAfterRemove
+    -- Add the same CC back a second time
+    let secondAddCCAction = UpdateCommittee (SJust $ GovPurposeId removeCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
+    secondAddCCGaid <- submitGovAction secondAddCCAction
+    submitYesVote_ (DRepVoter dRep) secondAddCCGaid
+    passNEpochs 2
+    -- Confirm that they have been added
+    SJust committeeAfterRemoveAndAdd <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
+    assertCCMembership committeeAfterRemoveAndAdd
+    -- Confirm that after registering a hot key, they are active
+    _hotKey <- registerCommitteeHotKey cc
+    ccShouldNotBeResigned cc
+  describe "succeeds for" $ do
+    it "registering and unregistering a DRep" $ do
+      modifyPParams $ ppDRepDepositL .~ Coin 100
+      drepCred <- KeyHashObj <$> freshKeyHash
+      drepDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppDRepDepositL
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton (RegDRepTxCert drepCred drepDeposit SNothing)
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton (UnRegDRepTxCert drepCred drepDeposit)
+    it "resigning a non-CC key" $ do
+      someCred <- KeyHashObj <$> freshKeyHash
+      submitTx_
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton (ResignCommitteeColdTxCert someCred SNothing)
+        )
+    it "re-registering a CC hot key" $ do
+      ccCred <- electCommittee1
+      replicateM_ 10 $ do
+        ccHotCred <- KeyHashObj <$> freshKeyHash
+        submitTx_ $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton (AuthCommitteeHotKeyTxCert ccCred ccHotCred)
+  describe "fails for" $ do
+    it "invalid deposit provided with DRep registration cert" $ do
+      modifyPParams $ ppDRepDepositL .~ Coin 100
+      expectedDRepDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppDRepDepositL
+      let providedDRepDeposit = expectedDRepDeposit <+> Coin 10
+      khDRep <- freshKeyHash
+      submitFailingTx
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton
+                (RegDRepTxCert (KeyHashObj khDRep) providedDRepDeposit SNothing)
+        )
+        [ injectFailure $
+            ConwayDRepIncorrectDeposit providedDRepDeposit expectedDRepDeposit
+        ]
+    it "invalid refund provided with DRep deregistration cert" $ do
+      modifyPParams $ ppDRepDepositL .~ Coin 100
+      drepDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppDRepDepositL
+      let refund = drepDeposit <+> Coin 10
+      drepCred <- KeyHashObj <$> freshKeyHash
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton
+              (RegDRepTxCert drepCred drepDeposit SNothing)
+      submitFailingTx
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton
+                (UnRegDRepTxCert drepCred refund)
+        )
+        [ injectFailure $
+            ConwayDRepIncorrectRefund refund drepDeposit
+        ]
+    it "DRep already registered" $ do
+      modifyPParams $ ppDRepDepositL .~ Coin 100
+      drepDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppDRepDepositL
+      drepCred <- KeyHashObj <$> freshKeyHash
+      let
+        regTx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton
+                (RegDRepTxCert drepCred drepDeposit SNothing)
+      submitTx_ regTx
+      submitFailingTx
+        regTx
+        [injectFailure $ ConwayDRepAlreadyRegistered drepCred]
+    it "unregistering a nonexistent DRep" $ do
+      modifyPParams $ ppDRepDepositL .~ Coin 100
+      drepDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppDRepDepositL
+      drepCred <- KeyHashObj <$> freshKeyHash
+      submitFailingTx
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton (UnRegDRepTxCert drepCred drepDeposit)
+        )
+        [injectFailure $ ConwayDRepNotRegistered drepCred]
+    it "registering a resigned CC member hotkey" $ do
+      ccCred <- electCommittee1
+      ccHotCred <- KeyHashObj <$> freshKeyHash
+      let
+        registerHotKeyTx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ SSeq.singleton (AuthCommitteeHotKeyTxCert ccCred ccHotCred)
+      submitTx_ registerHotKeyTx
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton (ResignCommitteeColdTxCert ccCred SNothing)
+      submitFailingTx
+        registerHotKeyTx
+        [injectFailure $ ConwayCommitteeHasPreviouslyResigned ccCred]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1342,8 +1342,9 @@ ppConwayGovCertPredFailure :: ConwayGovCertPredFailure era -> PDoc
 ppConwayGovCertPredFailure z = case z of
   ConwayDRepAlreadyRegistered x -> ppSexp "ConwayDRepAlreadyRegistered" [pcCredential x]
   ConwayDRepNotRegistered x -> ppSexp "ConwayDRepNotRegistered" [pcCredential x]
-  ConwayDRepIncorrectDeposit c1 c2 -> ppSexp " ConwayDRepIncorrectDeposit" [pcCoin c1, pcCoin c2]
+  ConwayDRepIncorrectDeposit c1 c2 -> ppSexp "ConwayDRepIncorrectDeposit" [pcCoin c1, pcCoin c2]
   ConwayCommitteeHasPreviouslyResigned x -> ppSexp "ConwayCommitteeHasPreviouslyResigned" [pcCredential x]
+  ConwayDRepIncorrectRefund c1 c2 -> ppSexp "ConwayDRepIncorrectRefund" [pcCoin c1, pcCoin c2]
 
 instance PrettyA (ConwayGovCertPredFailure era) where
   prettyA = ppConwayGovCertPredFailure


### PR DESCRIPTION
# Description

This PR adds the `ConwayDRepIncorrectRefund` predicate failure to `GOVCERT`. This failure happens when trying to unregister a DRep with invalid `Coin` in the cert. I also added tests for other `GOVCERT` predicate failures.

resolves #4135 
resolves #4136

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
