### PR TITLE
Change hot credential representation in `CommitteeState`

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Conway.Rules.Ratify (
 ) where
 
 import Cardano.Ledger.BaseTypes (BoundedRational (..), ShelleyBase, StrictMaybe (..), addEpochInterval)
-import Cardano.Ledger.CertState (CommitteeState (csCommitteeCreds))
+import Cardano.Ledger.CertState (CommitteeAuthorization (..), CommitteeState (csCommitteeCreds))
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Conway.Core (
   Era (EraCrypto),
@@ -155,8 +155,8 @@ committeeAcceptedRatio members votes committeeState currentEpoch
       | otherwise =
           case Map.lookup member (csCommitteeCreds committeeState) of
             Nothing -> (yes, tot) -- member is not registered, vote "abstain"
-            Just Nothing -> (yes, tot) -- member has resigned, vote "abstain"
-            Just (Just hotKey) ->
+            Just (CommitteeMemberResigned _) -> (yes, tot) -- member has resigned, vote "abstain"
+            Just (CommitteeHotCredential hotKey) ->
               case Map.lookup hotKey votes of
                 Nothing -> (yes, tot + 1) -- member hasn't voted, vote "no"
                 Just Abstain -> (yes, tot) -- member voted "abstain"

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -96,7 +96,7 @@ spec = describe "GOVCERT" $ do
     _hotKey <- registerCommitteeHotKey cc
     ccShouldNotBeResigned cc
     -- Have them resign
-    resignCommitteeColdKey cc
+    resignCommitteeColdKey cc SNothing
     ccShouldBeResigned cc
     -- Re-add the same CC
     let reAddCCAction = UpdateCommittee (SJust $ GovPurposeId addCCGaid) mempty (Map.singleton cc 20) (1 %! 2)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add optional `Anchor` to `MemberResigned` in `CommitteeMembersState`
 * Change return type of `queryCommitteeMembersState` to `CommitteeMembersState`
 * Change type of `csThreshold` in `CommitteeMembersState` to `Maybe UnitInterval`
 * Remove `getNextEpochCommitteeMembers` from `EraGov`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -230,7 +230,7 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
       let hkStatus =
             case Map.lookup coldCred comStateMembers of
               Nothing -> MemberNotAuthorized
-              Just (CommitteeMemberResigned _) -> MemberResigned
+              Just (CommitteeMemberResigned anchor) -> MemberResigned (strictMaybeToMaybe anchor)
               Just (CommitteeHotCredential hk) -> MemberAuthorized hk
       pure $ CommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
 

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -130,12 +130,12 @@ spec = do
       [c2, c3, c5]
       mempty
       [Active, Unrecognized]
-      ( [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
-        , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
-        ]
-      )
+      [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
+      , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
+      ]
 
-    _ <- resignCommitteeColdKey c3
+    c3Anchor <- arbitrary
+    _ <- resignCommitteeColdKey c3 (SJust c3Anchor)
     hk5 <- registerCommitteeHotKey c5
     passTick
     -- hot cred status of resigned member becomes `Resigned`
@@ -144,7 +144,7 @@ spec = do
     expectNoFilterQueryResult
       [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)
       , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just 2) ToBeExpired)
-      , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 7) NoChangeExpected)
       , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
       , (c5, CommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
       ]
@@ -163,7 +163,7 @@ spec = do
     expectNoFilterQueryResult
       [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)
       , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just 2) NoChangeExpected)
-      , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 7) NoChangeExpected)
       , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) NoChangeExpected)
       ]
 
@@ -190,7 +190,7 @@ spec = do
     expectNoFilterQueryResult
       [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) (TermAdjusted 13))
       , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just 2) ToBeRemoved)
-      , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 7) NoChangeExpected)
       , -- though its term was adjusted, `ToBeExpired` takes precedence
         (c4, CommitteeMemberState MemberNotAuthorized Active (Just 5) ToBeExpired)
       , (c6, CommitteeMemberState (MemberAuthorized hk6) Unrecognized Nothing ToBeEnacted)
@@ -211,7 +211,7 @@ spec = do
     expectMembers [c1, c3, c4, c6, c7]
     expectNoFilterQueryResult
       [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 13) NoChangeExpected)
-      , (c3, CommitteeMemberState MemberResigned Active (Just 7) NoChangeExpected)
+      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 7) NoChangeExpected)
       , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) NoChangeExpected)
       , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just 6) ToBeExpired)
       , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) NoChangeExpected)
@@ -240,7 +240,7 @@ spec = do
     -- members whose term changed have next epoch change `TermAdjusted`
     expectNoFilterQueryResult
       [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 13) ToBeRemoved)
-      , (c3, CommitteeMemberState MemberResigned Active (Just 7) (TermAdjusted 9))
+      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 7) (TermAdjusted 9))
       , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just 4) (TermAdjusted 9))
       , (c6, CommitteeMemberState (MemberAuthorized hk6) Expired (Just 6) (TermAdjusted 9))
       , (c7, CommitteeMemberState MemberNotAuthorized Active (Just 7) ToBeExpired)
@@ -248,7 +248,7 @@ spec = do
     passEpoch -- epoch 8
     expectMembers [c3, c4, c6, c7]
     expectNoFilterQueryResult
-      [ (c3, CommitteeMemberState MemberResigned Active (Just 9) NoChangeExpected)
+      [ (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just 9) NoChangeExpected)
       , (c4, CommitteeMemberState MemberNotAuthorized Active (Just 9) NoChangeExpected)
       , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just 9) NoChangeExpected)
       , (c7, CommitteeMemberState MemberNotAuthorized Expired (Just 7) NoChangeExpected)

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -175,7 +175,7 @@ propResigned nes = do
     \_ (CommitteeState comStateMembers) _ noFilterResult -> do
       let resigned =
             [ ck
-            | (ck, CommitteeMemberState MemberResigned _ _ _) <- Map.toList (csCommittee noFilterResult)
+            | (ck, CommitteeMemberState (MemberResigned _) _ _ _) <- Map.toList (csCommittee noFilterResult)
             ]
       -- if the member is Resignd, it should appear in the commiteeState as Nothing
       resigned `shouldBe` [ck | (ck, CommitteeMemberResigned _) <- Map.toList comStateMembers]

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -42,7 +42,7 @@ import Cardano.Ledger.UMap (UMap)
 import Data.Default.Class (Default (..))
 import Data.Foldable (foldMap')
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust, isNothing)
+import Data.Maybe (isNothing)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~), (^.))
@@ -159,14 +159,11 @@ propAuthorized nes = do
   withCommitteeInfo nes $
     \_ (CommitteeState comStateMembers) _ noFilterResult -> do
       let ckHk =
-            Map.mapMaybe
-              ( \case
-                  CommitteeMemberState (MemberAuthorized hk) _ _ _ -> Just hk
-                  _ -> Nothing
-              )
-              (csCommittee noFilterResult)
+            [ (ck, hk)
+            | (ck, CommitteeMemberState (MemberAuthorized hk) _ _ _) <- Map.toList (csCommittee noFilterResult)
+            ]
       -- if the member is Authorized, it should appear in the commiteeState
-      Map.mapMaybe id comStateMembers `shouldBe` ckHk
+      ckHk `shouldBe` [(ck, hk) | (ck, CommitteeHotCredential hk) <- Map.toList comStateMembers]
 
 propResigned ::
   forall era.
@@ -177,14 +174,11 @@ propResigned nes = do
   withCommitteeInfo nes $
     \_ (CommitteeState comStateMembers) _ noFilterResult -> do
       let resigned =
-            Map.filter
-              ( \case
-                  CommitteeMemberState MemberResigned _ _ _ -> True
-                  _ -> False
-              )
-              (csCommittee noFilterResult)
+            [ ck
+            | (ck, CommitteeMemberState MemberResigned _ _ _) <- Map.toList (csCommittee noFilterResult)
+            ]
       -- if the member is Resignd, it should appear in the commiteeState as Nothing
-      Map.keysSet (Map.filter isNothing comStateMembers) `shouldBe` Map.keysSet resigned
+      resigned `shouldBe` [ck | (ck, CommitteeMemberResigned _) <- Map.toList comStateMembers]
 
 propUnrecognized ::
   forall era.
@@ -242,7 +236,12 @@ propActiveAuthorized nes = do
       Map.intersection comMembers activeAuthorized
         `shouldSatisfy` all (>= epochNo)
       Map.intersection comStateMembers activeAuthorized
-        `shouldSatisfy` all isJust
+        `shouldSatisfy` all
+          ( \case
+              CommitteeHotCredential _ -> True
+              _ -> False
+          )
+
       csEpochNo noFilterResult `shouldBe` epochNo
 
 propFilters ::
@@ -393,7 +392,9 @@ genRelevantHotCredsFilter ::
   CommitteeState era ->
   Gen (Set.Set (Credential 'HotCommitteeRole (EraCrypto era)))
 genRelevantHotCredsFilter (CommitteeState comStateMembers) =
-  Set.fromList <$> genRetaining (Map.elems (Map.mapMaybe id comStateMembers))
+  Set.fromList
+    <$> genRetaining
+      [hk | (_, CommitteeHotCredential hk) <- Map.toList comStateMembers]
 
 genMembersRetaining ::
   forall era.

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Add `CommitteeAuthorization` and use it to represent hot key credential in `CommitteeState`
 * Change `applySTSValidateSuchThat` and `applySTSNonStatic`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`
 * Added `boom` placeholder

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -78,6 +78,7 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR, Sized, mkSized)
 import Cardano.Ledger.CertState (
   Anchor (..),
   CertState (..),
+  CommitteeAuthorization (..),
   CommitteeState (..),
   DState (..),
   FutureGenDeleg (..),
@@ -719,6 +720,13 @@ instance Crypto c => Arbitrary (Anchor c) where
     Anchor
       <$> arbitrary
       <*> arbitrary
+
+instance Crypto c => Arbitrary (CommitteeAuthorization c) where
+  arbitrary =
+    oneof
+      [ CommitteeHotCredential <$> arbitrary
+      , CommitteeMemberResigned <$> arbitrary
+      ]
 
 deriving instance Era era => Arbitrary (CommitteeState era)
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -241,6 +241,8 @@ instance ToExpr (FutureGenDeleg c)
 
 instance ToExpr (InstantaneousRewards c)
 
+instance ToExpr (CommitteeAuthorization c)
+
 instance ToExpr (CommitteeState era)
 
 -- UTxO

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -348,6 +348,7 @@ data Rep era t where
   DRepHashR :: Era era => Rep era (KeyHash 'DRepRole (EraCrypto era))
   AnchorR :: Era era => Rep era (Anchor (EraCrypto era))
   CommitteeStateR :: Era era => Rep era (CommitteeState era)
+  CommitteeAuthorizationR :: Era era => Rep era (CommitteeAuthorization (EraCrypto era))
   VStateR :: Era era => Rep era (VState era)
   EnactStateR :: Reflect era => Rep era (EnactState era)
   DRepPulserR :: (RunConwayRatify era, Reflect era) => Rep era (DRepPulser era Identity (RatifyState era))
@@ -488,6 +489,7 @@ repHasInstances r = case r of
   GovActionIxR {} -> IsOrd
   GovActionStateR {} -> IsTypeable
   ProposalsR {} -> IsTypeable
+  CommitteeAuthorizationR {} -> IsOrd
   CommitteeStateR {} -> IsOrd
   UnitIntervalR {} -> IsOrd
   CommitteeR {} -> IsEq
@@ -671,6 +673,7 @@ synopsis PrevCommitteeR (GovPurposeId x) = synopsis @e GovActionIdR x
 synopsis PrevConstitutionR (GovPurposeId x) = synopsis @e GovActionIdR x
 synopsis RatifyStateR dr = show (pcRatifyState reify dr)
 synopsis NumDormantEpochsR x = show x
+synopsis CommitteeAuthorizationR x = show x
 synopsis CommitteeStateR x = show x
 synopsis VStateR x = show x
 synopsis DRepHashR k = "(KeyHash 'DRepRole " ++ show (keyHashSummary k) ++ ")"
@@ -912,6 +915,7 @@ genSizedRep n RatifyStateR =
     <*> pure mempty
     <*> arbitrary
 genSizedRep _ NumDormantEpochsR = arbitrary
+genSizedRep _ CommitteeAuthorizationR = arbitrary
 genSizedRep _ CommitteeStateR = arbitrary
 genSizedRep _ VStateR = arbitrary
 genSizedRep _ DRepHashR = arbitrary
@@ -938,7 +942,7 @@ genSizedRep _ DRepPulserR =
     <*> arbitrary -- committeestate
     <*> genRep EnactStateR
     <*> (SS.fromList . (: []) <$> genRep GovActionStateR) -- proposals
-    <*> (pure testGlobals)
+    <*> pure testGlobals
 genSizedRep n DelegateeR =
   oneof
     [ DelegStake <$> genSizedRep n (PoolHashR @era)
@@ -1092,6 +1096,7 @@ shrinkRep PrevHardForkR x = shrink x
 shrinkRep PrevCommitteeR x = shrink x
 shrinkRep PrevConstitutionR x = shrink x
 shrinkRep RatifyStateR _ = []
+shrinkRep CommitteeAuthorizationR _ = []
 shrinkRep CommitteeStateR _ = []
 shrinkRep VStateR x = shrink x
 shrinkRep EnactStateR _ = []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway.hs
@@ -843,6 +843,9 @@ instance IsConwayUniv fn => HasSpec fn ValidityInterval
 instance HasSimpleRep (DRepState c)
 instance (IsConwayUniv fn, Crypto c) => HasSpec fn (DRepState c)
 
+instance HasSimpleRep (CommitteeAuthorization c)
+instance (IsConwayUniv fn, Crypto c) => HasSpec fn (CommitteeAuthorization c)
+
 instance HasSimpleRep (CommitteeState era)
 instance (IsConwayUniv fn, Era era) => HasSpec fn (CommitteeState era)
 


### PR DESCRIPTION
# Description

* Represent hot keys in CommitteState as a new, more comprehensive  type `CommitteeAuthorization`.  For resigned members, this will also contain the anchor registered during resignation. 
* Reflect the anchor in the committee query result

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4147
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
