### PR TITLE
Add missing `InjectFailure` instances for `ConwayUtxosPredFailure`

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Conway.Rules.Gov (ConwayGovPredFailure)
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledgers ()
+import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
   ShelleyBbodyPredFailure (..),
@@ -70,6 +71,9 @@ instance InjectRuleFailure "BBODY" AlonzoUtxoPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
 
 instance InjectRuleFailure "BBODY" AlonzoUtxosPredFailure (ConwayEra c) where
+  injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
+
+instance InjectRuleFailure "BBODY" ConwayUtxosPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
 
 instance InjectRuleFailure "BBODY" ShelleyUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -67,6 +67,7 @@ import Cardano.Ledger.Conway.Rules.Gov (
   GovEnv (..),
  )
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxow ()
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto (..))
@@ -150,6 +151,9 @@ instance InjectRuleFailure "LEDGER" AlonzoUtxoPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure . injectFailure
 
 instance InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure (ConwayEra c) where
+  injectFailure = ConwayUtxowFailure . injectFailure
+
+instance InjectRuleFailure "LEDGER" ConwayUtxosPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure . injectFailure
 
 instance InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure)
 import Cardano.Ledger.Conway.Rules.Gov (ConwayGovPredFailure)
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
   ShelleyLedgersPredFailure (..),
@@ -50,6 +51,9 @@ instance InjectRuleFailure "LEDGERS" AlonzoUtxoPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" AlonzoUtxosPredFailure (ConwayEra c) where
+  injectFailure = LedgerFailure . injectFailure
+
+instance InjectRuleFailure "LEDGERS" ConwayUtxosPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" ShelleyUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -38,6 +38,7 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXOW)
 import Cardano.Ledger.Conway.Rules.Utxo ()
+import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
 import Cardano.Ledger.Crypto (DSIGN, HASH)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
@@ -79,6 +80,9 @@ instance InjectRuleFailure "UTXOW" AlonzoUtxoPredFailure (ConwayEra c) where
   injectFailure = UtxoFailure . injectFailure
 
 instance InjectRuleFailure "UTXOW" AlonzoUtxosPredFailure (ConwayEra c) where
+  injectFailure = UtxoFailure . injectFailure
+
+instance InjectRuleFailure "UTXOW" ConwayUtxosPredFailure (ConwayEra c) where
   injectFailure = UtxoFailure . injectFailure
 
 instance InjectRuleFailure "UTXOW" ShelleyUtxoPredFailure (ConwayEra c) where


### PR DESCRIPTION
# Description

The type was introduced in #4150 but was lacking `InjectFailure` instances

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
