### PR TITLE
Add `GovInfoEvent` and add event testing capabilities to `ImpTest`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0.0
 
+* Add type `EraRuleEvent` instances for `LEDGER` and `TICK` events
+* Add `Eq` and `NFData` instances for `AllegraUtxoEvent`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add `shelleyToAllegraUtxoPredFailure`
 * Add `NFData` instance for `AllegraUtxoPredFailure`
@@ -9,6 +11,7 @@
 
 ### `testlib`
 
+* Add `ToExpr` instance for `AllegraUtxoEvent`
 * Add `RuleListEra` instance for Allegra
 
 ## 1.3.0.0

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -109,6 +109,7 @@ library testlib
         generic-random,
         microlens,
         mtl,
+        small-steps,
         QuickCheck
 
 test-suite tests

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Cardano.Ledger.Allegra.Rules (
   module Cardano.Ledger.Allegra.Rules.Utxo,
   module Cardano.Ledger.Allegra.Rules.Utxow,
 )
 where
 
+import Cardano.Ledger.Allegra.Core (EraRuleEvent)
+import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Rules.Bbody ()
 import Cardano.Ledger.Allegra.Rules.Deleg ()
 import Cardano.Ledger.Allegra.Rules.Delegs ()
@@ -14,3 +19,6 @@ import Cardano.Ledger.Allegra.Rules.Pool ()
 import Cardano.Ledger.Allegra.Rules.Ppup ()
 import Cardano.Ledger.Allegra.Rules.Utxo
 import Cardano.Ledger.Allegra.Rules.Utxow
+import Cardano.Ledger.Shelley.Rules (ShelleyTickEvent)
+
+type instance EraRuleEvent "TICK" (AllegraEra c) = ShelleyTickEvent (AllegraEra c)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Ledger.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Ledger.hs
@@ -13,6 +13,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
   ShelleyDelegsPredFailure,
   ShelleyDelplPredFailure,
+  ShelleyLedgerEvent,
   ShelleyLedgerPredFailure (..),
   ShelleyPoolPredFailure,
   ShelleyPpupPredFailure,
@@ -44,3 +45,5 @@ instance InjectRuleFailure "LEDGER" ShelleyPoolPredFailure (AllegraEra c) where
 
 instance InjectRuleFailure "LEDGER" ShelleyDelegPredFailure (AllegraEra c) where
   injectFailure = DelegsFailure . injectFailure
+
+type instance EraRuleEvent "LEDGER" (AllegraEra c) = ShelleyLedgerEvent (AllegraEra c)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -161,6 +161,21 @@ data AllegraUtxoEvent era
       (UTxO era)
       -- | UTxO created
       (UTxO era)
+  deriving (Generic)
+
+deriving instance
+  ( Era era
+  , Eq (TxOut era)
+  , Eq (Event (EraRule "PPUP" era))
+  ) =>
+  Eq (AllegraUtxoEvent era)
+
+instance
+  ( Era era
+  , NFData (TxOut era)
+  , NFData (Event (EraRule "PPUP" era))
+  ) =>
+  NFData (AllegraUtxoEvent era)
 
 -- | The UTxO transition rule for the Allegra era.
 utxoTransition ::

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.PParams
+import Control.State.Transition.Extended (STS (..))
 import Test.Cardano.Ledger.Shelley.TreeDiff
 
 -- Scripts
@@ -51,3 +52,10 @@ instance
   , ToExpr (EraRuleFailure "PPUP" era)
   ) =>
   ToExpr (AllegraUtxoPredFailure era)
+
+instance
+  ( Era era
+  , ToExpr (TxOut era)
+  , ToExpr (Event (EraRule "PPUP" era))
+  ) =>
+  ToExpr (AllegraUtxoEvent era)

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7.0.0
 
+* Add type `EraRuleEvent` instances for `PPUP`, `LEDGER` and `TICK` events
+* Add `Eq` and `NFData` instances for `AlonzoUtxoEvent`, `AlonzoUtxowEvent` and `AlonzoUtxosEvent`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add `allegraToAlonzoUtxoPredFailure`
 * Add `NFData` instances for:
@@ -29,6 +31,7 @@
 
 ### `testlib`
 
+* Add `ToExpr` instances for `AlonzoUtxoEvent`, `AlonzoUtxowEvent` and `AlonzoUtxosEvent`
 * Add `RuleListEra` instance for Alonzo
 * Add:
   * `impLookupPlutusScriptMaybe`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -138,7 +138,8 @@ library testlib
         plutus-ledger-api,
         generic-random,
         microlens,
-        text
+        text,
+        tree-diff
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Cardano.Ledger.Alonzo.Rules (
   module Cardano.Ledger.Alonzo.Rules.Bbody,
   module Cardano.Ledger.Alonzo.Rules.Ledger,
@@ -7,6 +10,8 @@ module Cardano.Ledger.Alonzo.Rules (
 )
 where
 
+import Cardano.Ledger.Alonzo.Core (EraRuleEvent)
+import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Rules.Bbody
 import Cardano.Ledger.Alonzo.Rules.Deleg ()
 import Cardano.Ledger.Alonzo.Rules.Delegs ()
@@ -18,3 +23,7 @@ import Cardano.Ledger.Alonzo.Rules.Ppup ()
 import Cardano.Ledger.Alonzo.Rules.Utxo
 import Cardano.Ledger.Alonzo.Rules.Utxos
 import Cardano.Ledger.Alonzo.Rules.Utxow
+import Cardano.Ledger.Shelley.Rules (ShelleyLedgerEvent, ShelleyTickEvent)
+
+type instance EraRuleEvent "LEDGER" (AlonzoEra c) = ShelleyLedgerEvent (AlonzoEra c)
+type instance EraRuleEvent "TICK" (AlonzoEra c) = ShelleyTickEvent (AlonzoEra c)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ppup.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ppup.hs
@@ -7,8 +7,10 @@ module Cardano.Ledger.Alonzo.Rules.Ppup () where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure)
+import Cardano.Ledger.Shelley.Rules (PpupEvent, ShelleyPpupPredFailure)
 
 type instance EraRuleFailure "PPUP" (AlonzoEra c) = ShelleyPpupPredFailure (AlonzoEra c)
+
+type instance EraRuleEvent "PPUP" (AlonzoEra c) = PpupEvent (AlonzoEra c)
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure (AlonzoEra c)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -247,6 +247,11 @@ instance
 
 newtype AlonzoUtxoEvent era
   = UtxosEvent (Event (EraRule "UTXOS" era))
+  deriving (Generic)
+
+deriving instance Eq (Event (EraRule "UTXOS" era)) => Eq (AlonzoUtxoEvent era)
+
+instance NFData (Event (EraRule "UTXOS" era)) => NFData (AlonzoUtxoEvent era)
 
 -- | Returns true for VKey locked addresses, and false for any kind of
 -- script-locked address.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -72,6 +72,7 @@ import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (
   PpupEnv (..),
+  PpupEvent,
   ShelleyPPUP,
   ShelleyPpupPredFailure,
   UtxoEnv (..),
@@ -135,7 +136,7 @@ instance
   transitionRules = [utxosTransition]
 
 data AlonzoUtxosEvent era
-  = AlonzoPpupToUtxosEvent (Event (EraRule "PPUP" era))
+  = AlonzoPpupToUtxosEvent (EraRuleEvent "PPUP" era)
   | TotalDeposits (SafeHash (EraCrypto era) EraIndependentTxBody) Coin
   | SuccessfulPlutusScriptsEvent (NonEmpty (PlutusWithContext (EraCrypto era)))
   | FailedPlutusScriptsEvent (NonEmpty (PlutusWithContext (EraCrypto era)))
@@ -145,12 +146,28 @@ data AlonzoUtxosEvent era
       (UTxO era)
       -- | UTxO created
       (UTxO era)
+  deriving (Generic)
+
+deriving instance
+  ( Era era
+  , Eq (TxOut era)
+  , Eq (EraRuleEvent "PPUP" era)
+  ) =>
+  Eq (AlonzoUtxosEvent era)
+
+instance
+  ( Era era
+  , NFData (TxOut era)
+  , NFData (EraRuleEvent "PPUP" era)
+  ) =>
+  NFData (AlonzoUtxosEvent era)
 
 instance
   ( Era era
   , STS (ShelleyPPUP era)
   , EraRuleFailure "PPUP" era ~ ShelleyPpupPredFailure era
   , Event (EraRule "PPUP" era) ~ Event (ShelleyPPUP era)
+  , EraRuleEvent "PPUP" era ~ PpupEvent era
   ) =>
   Embed (ShelleyPPUP era) (AlonzoUTXOS era)
   where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -197,6 +197,11 @@ instance
 
 newtype AlonzoUtxowEvent era
   = WrappedShelleyEraEvent (ShelleyUtxowEvent era)
+  deriving (Generic)
+
+deriving instance Eq (Event (EraRule "UTXO" era)) => Eq (AlonzoUtxowEvent era)
+
+instance NFData (Event (EraRule "UTXO" era)) => NFData (AlonzoUtxowEvent era)
 
 instance
   ( AlonzoEraScript era

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.7.0.0
 
+* Add type `EraRuleEvent` instances for the event type of:
+  * `UTXOS`
+  * `PPUP`
+  * `LEDGER`
+  * `TICK`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add `NFData` instance for `BabbageUtxoPredFailure`, `BabbageUtxowPredFailure`
 * Add implementation for `getMinFeeTxUtxo`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Cardano.Ledger.Babbage.Rules (
   module Cardano.Ledger.Babbage.Rules.Ledger,
   module Cardano.Ledger.Babbage.Rules.Utxo,
@@ -6,6 +9,8 @@ module Cardano.Ledger.Babbage.Rules (
 )
 where
 
+import Cardano.Ledger.Babbage.Core (EraRuleEvent)
+import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Rules.Bbody ()
 import Cardano.Ledger.Babbage.Rules.Deleg ()
 import Cardano.Ledger.Babbage.Rules.Delegs ()
@@ -17,3 +22,10 @@ import Cardano.Ledger.Babbage.Rules.Ppup ()
 import Cardano.Ledger.Babbage.Rules.Utxo
 import Cardano.Ledger.Babbage.Rules.Utxos
 import Cardano.Ledger.Babbage.Rules.Utxow
+import Cardano.Ledger.Shelley.Rules (PpupEvent, ShelleyLedgerEvent, ShelleyTickEvent)
+
+type instance EraRuleEvent "TICK" (BabbageEra c) = ShelleyTickEvent (BabbageEra c)
+
+type instance EraRuleEvent "LEDGER" (BabbageEra c) = ShelleyLedgerEvent (BabbageEra c)
+
+type instance EraRuleEvent "PPUP" (BabbageEra c) = PpupEvent (BabbageEra c)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 1.13.0.0
 
+* Remove `ConwayDelegEvent`, `ConwayGovCertEvent`
+* Add `GovInfoEvent`
+* Add `ConwayUtxosEvent`
+* Add `Generic`, `Eq` and `NFData` instances for `ConwayEpochEvent`
+* Add `Eq` and `NFData` instances for:
+  * `ConwayGovEvent`
+  * `ConwayCertEvent`
+  * `ConwayCertsEvent`
+  * `ConwayLedgerEvent`
+  * `ConwayNewEpochEvent`
+* Add type `EraRuleEvent` instances for the event type of:
+  * `UPEC`
+  * `NEWPP`
+  * `PPUP`
+  * `MIR`
+  * `DELEGS`
+  * `TICK`
+  * `ENACT`
+  * `LEDGER`
+  * `UTXOS`
 * Add `ConwayDRepIncorrectRefund`
 * Stop exporting `utxosGovStateL` from `Cardano.Ledger.Conway.Governance`
 * Remove deprecated `curPParamsConwayGovStateL` and `prevPParamsConwayGovStateL`
@@ -66,6 +86,13 @@
 
 ### `testlib`
 
+* Add `ToExpr` instances for:
+  * `ConwayNewEpochEvent`
+  * `ConwayEpochEvent`
+  * `ConwayLedgerEvent`
+  * `ConwayCertsEvent`
+  * `ConwayCertEvent`
+  * `ConwayGovEvent`
 * Change the types of some functions in `Test.Cardano.Ledger.Conway.ImpTest`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`
   - `submitFailingVote`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -155,8 +155,9 @@ library testlib
         cardano-strict-containers,
         data-default-class,
         generic-random,
-        small-steps >=1.1,
-        text
+        mtl,
+        text,
+        small-steps >=1.1
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -52,20 +52,24 @@ type instance Value (ConwayEra c) = MaryValue c
 -------------------------------------------------------------------------------
 
 type instance EraRule "UPEC" (ConwayEra c) = VoidEraRule "UPEC" (ConwayEra c)
+type instance EraRuleFailure "UPEC" (ConwayEra c) = VoidEraRule "UPEC" (ConwayEra c)
+type instance EraRuleEvent "UPEC" (ConwayEra c) = VoidEraRule "UPEC" (ConwayEra c)
 
 type instance EraRule "NEWPP" (ConwayEra c) = VoidEraRule "NEWPP" (ConwayEra c)
+type instance EraRuleFailure "NEWPP" (ConwayEra c) = VoidEraRule "NEWPP" (ConwayEra c)
+type instance EraRuleEvent "NEWPP" (ConwayEra c) = VoidEraRule "NEWPP" (ConwayEra c)
 
 type instance EraRule "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
 type instance EraRuleFailure "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
+type instance EraRuleEvent "PPUP" (ConwayEra c) = VoidEraRule "PPUP" (ConwayEra c)
 
 type instance EraRule "MIR" (ConwayEra c) = VoidEraRule "MIR" (ConwayEra c)
 type instance EraRuleFailure "MIR" (ConwayEra c) = VoidEraRule "MIR" (ConwayEra c)
+type instance EraRuleEvent "MIR" (ConwayEra c) = VoidEraRule "MIR" (ConwayEra c)
 
 type instance EraRule "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
 type instance EraRuleFailure "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
-
-type instance EraRule "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
-type instance EraRuleFailure "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
+type instance EraRuleEvent "DELEGS" (ConwayEra c) = VoidEraRule "DELEGS" (ConwayEra c)
 
 -------------------------------------------------------------------------------
 -- Era Mapping

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Cert,
   module Cardano.Ledger.Conway.Rules.Deleg,
@@ -15,6 +20,8 @@ module Cardano.Ledger.Conway.Rules (
 )
 where
 
+import Cardano.Ledger.Conway.Core (EraRuleEvent, InjectRuleEvent (..))
+import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Rules.Bbody ()
 import Cardano.Ledger.Conway.Rules.Cert
 import Cardano.Ledger.Conway.Rules.Certs
@@ -32,3 +39,9 @@ import Cardano.Ledger.Conway.Rules.Tickf
 import Cardano.Ledger.Conway.Rules.Utxo ()
 import Cardano.Ledger.Conway.Rules.Utxos
 import Cardano.Ledger.Conway.Rules.Utxow
+import Cardano.Ledger.Shelley.Rules (ShelleyTickEvent (..))
+
+type instance EraRuleEvent "TICK" (ConwayEra c) = ShelleyTickEvent (ConwayEra c)
+
+instance InjectRuleEvent "TICK" ConwayEpochEvent (ConwayEra c) where
+  injectEvent = TickNewEpochEvent . EpochEvent

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -18,6 +18,7 @@ module Cardano.Ledger.Conway.Rules.Bbody () where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules (
+  AlonzoBbodyEvent,
   AlonzoBbodyPredFailure (..),
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -43,6 +44,8 @@ import Cardano.Ledger.Shelley.Rules (
  )
 
 type instance EraRuleFailure "BBODY" (ConwayEra c) = AlonzoBbodyPredFailure (ConwayEra c)
+
+type instance EraRuleEvent "BBODY" (ConwayEra c) = AlonzoBbodyEvent (ConwayEra c)
 
 instance InjectRuleFailure "BBODY" AlonzoBbodyPredFailure (ConwayEra c)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -84,6 +84,8 @@ data ConwayCertPredFailure era
 
 type instance EraRuleFailure "CERT" (ConwayEra c) = ConwayCertPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "CERT" (ConwayEra c) = ConwayCertEvent (ConwayEra c)
+
 instance InjectRuleFailure "CERT" ConwayCertPredFailure (ConwayEra c)
 
 instance InjectRuleFailure "CERT" ConwayDelegPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -94,6 +94,8 @@ data ConwayCertsPredFailure era
 
 type instance EraRuleFailure "CERTS" (ConwayEra c) = ConwayCertsPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "CERTS" (ConwayEra c) = ConwayCertsEvent (ConwayEra c)
+
 instance InjectRuleFailure "CERTS" ConwayCertsPredFailure (ConwayEra c)
 
 instance InjectRuleFailure "CERTS" ConwayCertPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -125,6 +125,11 @@ instance
   NFData (ConwayCertsPredFailure era)
 
 newtype ConwayCertsEvent era = CertEvent (Event (EraRule "CERT" era))
+  deriving (Generic)
+
+deriving instance Eq (Event (EraRule "CERT" era)) => Eq (ConwayCertsEvent era)
+
+instance NFData (Event (EraRule "CERT" era)) => NFData (ConwayCertsEvent era)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -15,7 +15,6 @@
 
 module Cardano.Ledger.Conway.Rules.Deleg (
   ConwayDELEG,
-  ConwayDelegEvent (..),
   ConwayDelegPredFailure (..),
 ) where
 
@@ -58,6 +57,7 @@ import Control.State.Transition (
  )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks)
@@ -101,8 +101,6 @@ instance Era era => DecCBOR (ConwayDelegPredFailure era) where
     5 -> SumD DRepAlreadyRegisteredForStakeKeyDELEG <! From
     n -> Invalid n
 
-newtype ConwayDelegEvent era = DelegEvent (Event (EraRule "DELEG" era))
-
 instance
   ( EraPParams era
   , State (EraRule "DELEG" era) ~ DState era
@@ -117,7 +115,7 @@ instance
   type Environment (ConwayDELEG era) = PParams era
   type BaseM (ConwayDELEG era) = ShelleyBase
   type PredicateFailure (ConwayDELEG era) = ConwayDelegPredFailure era
-  type Event (ConwayDELEG era) = ConwayDelegEvent era
+  type Event (ConwayDELEG era) = Void
 
   transitionRules = [conwayDelegTransition @era]
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -72,6 +72,8 @@ data ConwayDelegPredFailure era
 
 type instance EraRuleFailure "DELEG" (ConwayEra c) = ConwayDelegPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "DELEG" (ConwayEra c) = VoidEraRule "DELEG" (ConwayEra c)
+
 instance InjectRuleFailure "DELEG" ConwayDelegPredFailure (ConwayEra c)
 
 instance NoThunks (ConwayDelegPredFailure era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
@@ -17,7 +17,7 @@ module Cardano.Ledger.Conway.Rules.Enact (
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Era (ConwayENACT)
+import Cardano.Ledger.Conway.Era (ConwayENACT, ConwayEra)
 import Cardano.Ledger.Conway.Governance (
   Committee (..),
   EnactState (..),
@@ -48,6 +48,8 @@ import qualified Data.Set as Set
 import Data.Void (Void)
 import GHC.Generics
 import Lens.Micro
+
+type instance EraRuleEvent "ENACT" (ConwayEra c) = VoidEraRule "ENACT" (ConwayEra c)
 
 data EnactSignal era = EnactSignal
   { esGovActionId :: !(GovActionId (EraCrypto era))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.CertState (
  )
 import Cardano.Ledger.Coin (Coin, compactCoinOrError)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Era (ConwayEPOCH, ConwayRATIFY)
+import Cardano.Ledger.Conway.Era (ConwayEPOCH, ConwayEra, ConwayRATIFY)
 import Cardano.Ledger.Conway.Governance (
   Committee,
   ConwayEraGov (..),
@@ -133,6 +133,8 @@ data ConwayEpochEvent era
       (Set (GovActionState era)) -- expired
       (Set (GovActionId (EraCrypto era))) -- unclaimed
   deriving (Generic)
+
+type instance EraRuleEvent "EPOCH" (ConwayEra c) = ConwayEpochEvent (ConwayEra c)
 
 deriving instance
   ( EraPParams era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -166,6 +166,8 @@ data ConwayGovPredFailure era
 
 type instance EraRuleFailure "GOV" (ConwayEra c) = ConwayGovPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "GOV" (ConwayEra c) = ConwayGovEvent (ConwayEra c)
+
 instance InjectRuleFailure "GOV" ConwayGovPredFailure (ConwayEra c)
 
 instance EraPParams era => NFData (ConwayGovPredFailure era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -227,6 +227,9 @@ instance EraPParams era => FromCBOR (ConwayGovPredFailure era) where
 
 data ConwayGovEvent era
   = GovNewProposals !(TxId (EraCrypto era)) !(Proposals era)
+  deriving (Generic, Eq)
+
+instance EraPParams era => NFData (ConwayGovEvent era)
 
 instance
   ( ConwayEraPParams era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -81,6 +81,8 @@ data ConwayGovCertPredFailure era
 
 type instance EraRuleFailure "GOVCERT" (ConwayEra c) = ConwayGovCertPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "GOVCERT" (ConwayEra c) = VoidEraRule "GOVCERT" (ConwayEra c)
+
 instance InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure (ConwayEra c)
 
 instance NoThunks (ConwayGovCertPredFailure era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -16,7 +16,6 @@
 
 module Cardano.Ledger.Conway.Rules.GovCert (
   ConwayGOVCERT,
-  ConwayGovCertEvent (..),
   ConwayGovCertPredFailure (..),
   ConwayGovCertEnv (..),
 )
@@ -56,6 +55,7 @@ import Control.State.Transition.Extended (
  )
 import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
+import Data.Void (Void)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Lens.Micro ((&), (.~), (^.))
@@ -140,8 +140,6 @@ instance
         pure (3, ConwayDRepIncorrectRefund refund expectedRefund)
       k -> invalidKey k
 
-newtype ConwayGovCertEvent era = GovCertEvent (Event (EraRule "GOVCERT" era))
-
 instance
   ( ConwayEraPParams era
   , State (EraRule "GOVCERT" era) ~ VState era
@@ -158,7 +156,7 @@ instance
   type Environment (ConwayGOVCERT era) = ConwayGovCertEnv era
   type BaseM (ConwayGOVCERT era) = ShelleyBase
   type PredicateFailure (ConwayGOVCERT era) = ConwayGovCertPredFailure era
-  type Event (ConwayGOVCERT era) = ConwayGovCertEvent era
+  type Event (ConwayGOVCERT era) = Void
 
   transitionRules = [conwayGovCertTransition @era]
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -133,6 +133,8 @@ data ConwayLedgerPredFailure era
 
 type instance EraRuleFailure "LEDGER" (ConwayEra c) = ConwayLedgerPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "LEDGER" (ConwayEra c) = ConwayLedgerEvent (ConwayEra c)
+
 instance InjectRuleFailure "LEDGER" ConwayLedgerPredFailure (ConwayEra c)
 
 instance InjectRuleFailure "LEDGER" BabbageUtxowPredFailure (ConwayEra c) where
@@ -179,8 +181,6 @@ instance InjectRuleFailure "LEDGER" ConwayGovCertPredFailure (ConwayEra c) where
 
 instance InjectRuleFailure "LEDGER" ConwayGovPredFailure (ConwayEra c) where
   injectFailure = ConwayGovFailure
-
-type instance EraRuleEvent "LEDGER" (ConwayEra c) = ConwayLedgerEvent (ConwayEra c)
 
 deriving instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -180,6 +180,8 @@ instance InjectRuleFailure "LEDGER" ConwayGovCertPredFailure (ConwayEra c) where
 instance InjectRuleFailure "LEDGER" ConwayGovPredFailure (ConwayEra c) where
   injectFailure = ConwayGovFailure
 
+type instance EraRuleEvent "LEDGER" (ConwayEra c) = ConwayLedgerEvent (ConwayEra c)
+
 deriving instance
   ( Era era
   , Eq (PredicateFailure (EraRule "UTXOW" era))
@@ -251,6 +253,21 @@ data ConwayLedgerEvent era
   = UtxowEvent (Event (EraRule "UTXOW" era))
   | CertsEvent (Event (EraRule "CERTS" era))
   | GovEvent (Event (EraRule "GOV" era))
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "CERTS" era))
+  , Eq (Event (EraRule "UTXOW" era))
+  , Eq (Event (EraRule "GOV" era))
+  ) =>
+  Eq (ConwayLedgerEvent era)
+
+instance
+  ( NFData (Event (EraRule "CERTS" era))
+  , NFData (Event (EraRule "UTXOW" era))
+  , NFData (Event (EraRule "GOV" era))
+  ) =>
+  NFData (ConwayLedgerEvent era)
 
 instance
   ( AlonzoEraTx era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
+  ShelleyLedgersEvent,
   ShelleyLedgersPredFailure (..),
   ShelleyPoolPredFailure,
   ShelleyUtxoPredFailure,
@@ -29,6 +30,8 @@ import Cardano.Ledger.Shelley.Rules (
  )
 
 type instance EraRuleFailure "LEDGERS" (ConwayEra c) = ShelleyLedgersPredFailure (ConwayEra c)
+
+type instance EraRuleEvent "LEDGERS" (ConwayEra c) = ShelleyLedgersEvent (ConwayEra c)
 
 instance InjectRuleFailure "LEDGERS" ShelleyLedgersPredFailure (ConwayEra c)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (toDeltaCoin)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Era (ConwayEPOCH, ConwayNEWEPOCH)
+import Cardano.Ledger.Conway.Era (ConwayEPOCH, ConwayEra, ConwayNEWEPOCH)
 import Cardano.Ledger.Conway.Governance (
   ConwayEraGov,
   ConwayGovState (..),
@@ -87,6 +87,8 @@ data ConwayNewEpochEvent era
   | EpochEvent !(Event (EraRule "EPOCH" era))
   | TotalAdaPotsEvent !AdaPots
   deriving (Generic)
+
+type instance EraRuleEvent "NEWEPOCH" (ConwayEra c) = ConwayNewEpochEvent (ConwayEra c)
 
 deriving instance
   ( Eq (Event (EraRule "EPOCH" era))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -86,6 +86,19 @@ data ConwayNewEpochEvent era
   | TotalRewardEvent !EpochNo !(Map.Map (Credential 'Staking (EraCrypto era)) (Set (Reward (EraCrypto era))))
   | EpochEvent !(Event (EraRule "EPOCH" era))
   | TotalAdaPotsEvent !AdaPots
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "EPOCH" era))
+  , Eq (Event (EraRule "RUPD" era))
+  ) =>
+  Eq (ConwayNewEpochEvent era)
+
+instance
+  ( NFData (Event (EraRule "EPOCH" era))
+  , NFData (Event (EraRule "RUPD" era))
+  ) =>
+  NFData (ConwayNewEpochEvent era)
 
 instance
   ( EraTxOut era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -4,9 +4,9 @@
 module Cardano.Ledger.Conway.Rules.Pool () where
 
 import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Core (EraRuleFailure)
-import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+import Cardano.Ledger.Core (EraRuleEvent, EraRuleFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
-type instance
-  EraRuleFailure "POOL" (ConwayEra c) =
-    ShelleyPoolPredFailure (ConwayEra c)
+type instance EraRuleFailure "POOL" (ConwayEra c) = ShelleyPoolPredFailure (ConwayEra c)
+
+type instance EraRuleEvent "POOL" (ConwayEra c) = PoolEvent (ConwayEra c)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.Conway.Rules.Utxo (allegraToConwayUtxoPredFailure) where
 import Cardano.Ledger.Allegra.Rules (shelleyToAllegraUtxoPredFailure)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra (AllegraUtxoPredFailure (..))
 import Cardano.Ledger.Alonzo.Rules (
+  AlonzoUtxoEvent,
   AlonzoUtxoPredFailure (..),
   AlonzoUtxosPredFailure,
  )
@@ -24,6 +25,8 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
 
 type instance EraRuleFailure "UTXO" (ConwayEra c) = BabbageUtxoPredFailure (ConwayEra c)
+
+type instance EraRuleEvent "UTXO" (ConwayEra c) = AlonzoUtxoEvent (ConwayEra c)
 
 instance InjectRuleFailure "UTXO" BabbageUtxoPredFailure (ConwayEra c)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -65,6 +65,8 @@ conwayWitsVKeyNeeded = getConwayWitsVKeyNeeded
 
 type instance EraRuleFailure "UTXOW" (ConwayEra c) = BabbageUtxowPredFailure (ConwayEra c)
 
+type instance EraRuleEvent "UTXOW" (ConwayEra c) = AlonzoUtxowEvent (ConwayEra c)
+
 instance InjectRuleFailure "UTXOW" BabbageUtxowPredFailure (ConwayEra c)
 
 instance InjectRuleFailure "UTXOW" AlonzoUtxowPredFailure (ConwayEra c) where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -15,9 +15,15 @@ import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
-import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure, ConwayGovPredFailure)
+import Cardano.Ledger.Conway.Rules (
+  ConwayEpochEvent,
+  ConwayGovCertPredFailure,
+  ConwayGovPredFailure,
+  ConwayNewEpochEvent,
+ )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
+import Cardano.Ledger.Shelley.Rules (Event, ShelleyUtxowPredFailure (..))
+import Data.Typeable (Typeable)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
@@ -39,6 +45,13 @@ spec ::
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
+  , NFData (Event (EraRule "ENACT" era))
+  , ToExpr (Event (EraRule "ENACT" era))
+  , Eq (Event (EraRule "ENACT" era))
+  , Typeable (Event (EraRule "ENACT" era))
+  , InjectRuleEvent "TICK" ConwayEpochEvent era
+  , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
+  , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   ) =>
   Spec
 spec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,6 +18,7 @@ import Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Shelley.LedgerState
+import Control.State.Transition.Extended (STS (..))
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
@@ -24,11 +26,16 @@ import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational
 import Test.Cardano.Ledger.Imp.Common
+import Type.Reflection (Typeable)
 
 spec ::
   forall era.
   ( ConwayEraImp era
   , GovState era ~ ConwayGovState era
+  , NFData (Event (EraRule "ENACT" era))
+  , ToExpr (Event (EraRule "ENACT" era))
+  , Eq (Event (EraRule "ENACT" era))
+  , Typeable (Event (EraRule "ENACT" era))
   ) =>
   SpecWith (ImpTestState era)
 spec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -338,11 +338,7 @@ eventsSpec = describe "Events" $ do
       let
         proposeCostModel = do
           newTau <- arbitrary
-          submitGovAction @era $
-            ParameterChange
-              SNothing
-              (def & ppuTauL .~ SJust newTau)
-              SNothing
+          submitParameterChange SNothing $ def & ppuTauL .~ SJust newTau
       proposalA <- impAnn "proposalA" proposeCostModel
       proposalB <- impAnn "proposalB" proposeCostModel
       rewardAccount@(RewardAccount _ rewardCred) <- registerRewardAccount

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -121,6 +121,7 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core hiding (proposals)
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
+  ConwayGovEvent,
   EnactSignal,
   committeeAccepted,
   committeeAcceptedRatio,
@@ -212,6 +213,7 @@ instance
   , NFData (VerKeyDSIGN (DSIGN c))
   , DSIGN c ~ Ed25519DSIGN
   , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  , Eq (ConwayGovEvent (ConwayEra c))
   ) =>
   ShelleyEraImp (ConwayEra c)
   where
@@ -249,7 +251,6 @@ class
   , Environment (EraRule "ENACT" era) ~ ()
   , NativeScript era ~ Timelock era
   , Script era ~ AlonzoScript era
-  , ToExpr (PredicateFailure (EraRule "CERTS" era))
   ) =>
   ConwayEraImp era
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -2,10 +2,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -26,6 +24,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.HKD
+import Control.State.Transition.Extended (STS (..))
 import Data.Functor.Identity
 import Test.Cardano.Data.TreeDiff ()
 import Test.Cardano.Ledger.Babbage.TreeDiff
@@ -178,3 +177,44 @@ instance
   ToExpr (ConwayLedgerPredFailure era)
 
 instance ToExpr (Constitution era)
+
+instance
+  ( ToExpr (Event (EraRule "EPOCH" era))
+  , ToExpr (Event (EraRule "RUPD" era))
+  ) =>
+  ToExpr (ConwayNewEpochEvent era)
+
+instance
+  ( EraPParams era
+  , ToExpr (PParamsHKD Identity era)
+  , ToExpr (PParamsHKD StrictMaybe era)
+  , ToExpr (Event (EraRule "POOLREAP" era))
+  , ToExpr (Event (EraRule "SNAP" era))
+  ) =>
+  ToExpr (ConwayEpochEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "CERTS" era))
+  , ToExpr (Event (EraRule "UTXOW" era))
+  , ToExpr (Event (EraRule "GOV" era))
+  ) =>
+  ToExpr (ConwayLedgerEvent era)
+
+instance
+  ToExpr (Event (EraRule "CERT" era)) =>
+  ToExpr (ConwayCertsEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "DELEG" era))
+  , ToExpr (Event (EraRule "GOVCERT" era))
+  , ToExpr (Event (EraRule "POOL" era))
+  ) =>
+  ToExpr (ConwayCertEvent era)
+
+instance ToExpr (TxOut era) => ToExpr (ConwayUtxosEvent era)
+
+instance
+  ( Era era
+  , ToExpr (PParamsHKD StrictMaybe era)
+  ) =>
+  ToExpr (ConwayGovEvent era)

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.1.0
 
+* Add type `EraRuleEvent` instances for the event type of `TICK` and `LEDGER`
 * Add instances for `InjectRuleFailure` and switch to using `injectFailure`
 * Add implementation for `getMinFeeTxUtxo`
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Rules.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Rules.hs
@@ -1,5 +1,10 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Cardano.Ledger.Mary.Rules () where
 
+import Cardano.Ledger.Mary.Core (EraRuleEvent)
+import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Rules.Bbody ()
 import Cardano.Ledger.Mary.Rules.Deleg ()
 import Cardano.Ledger.Mary.Rules.Delegs ()
@@ -10,3 +15,6 @@ import Cardano.Ledger.Mary.Rules.Pool ()
 import Cardano.Ledger.Mary.Rules.Ppup ()
 import Cardano.Ledger.Mary.Rules.Utxo ()
 import Cardano.Ledger.Mary.Rules.Utxow ()
+import Cardano.Ledger.Shelley.Rules (ShelleyTickEvent)
+
+type instance EraRuleEvent "TICK" (MaryEra c) = ShelleyTickEvent (MaryEra c)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Ledger.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Ledger.hs
@@ -13,6 +13,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
   ShelleyDelegsPredFailure,
   ShelleyDelplPredFailure,
+  ShelleyLedgerEvent,
   ShelleyLedgerPredFailure (..),
   ShelleyPoolPredFailure,
   ShelleyPpupPredFailure,
@@ -44,3 +45,5 @@ instance InjectRuleFailure "LEDGER" ShelleyPoolPredFailure (MaryEra c) where
 
 instance InjectRuleFailure "LEDGER" ShelleyDelegPredFailure (MaryEra c) where
   injectFailure = DelegsFailure . injectFailure
+
+type instance EraRuleEvent "LEDGER" (MaryEra c) = ShelleyLedgerEvent (MaryEra c)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 1.10.0.0
 
+* Add `NFData` instance for `AdaPots`, `ShelleyDelegEvent`
+* Add `Generic`, `Eq` and `NFData` instances for:
+  * `ShelleyDelegsEvent`
+  * `ShelleyDelplEvent`
+  * `ShelleyEpochEvent`
+  * `ShelleyLedgerEvent`
+  * `ShelleyMirEvent`
+  * `ShelleyNewEpochEvent`
+  * `PoolEvent`
+  * `PoolReap`
+  * `PpupEvent`
+  * `RupdEvent`
+  * `SnapEvent`
+  * `ShelleyTickEvent`
+  * `UtxoEvent`
+  * `ShelleyUtxowEvent`
+* Rename `NewEpoch` constructor of `ShelleyDelegEvent` to `DelegNewEpoch`
 * Rename `ShelleyGovState` fields:
   * `proposals` to `sgsCurProposals`
   * `futureProposals` to `sgsFutureProposals`
@@ -37,6 +54,22 @@
 
 ### `testlib`
 
+* Add `ToExpr` instances for:
+  * `ShelleyDelegsEvent`
+  * `ShelleyDelplEvent`
+  * `ShelleyEpochEvent`
+  * `ShelleyLedgerEvent`
+  * `ShelleyMirEvent`
+  * `ShelleyNewEpochEvent`
+  * `PoolEvent`
+  * `PoolReap`
+  * `PpupEvent`
+  * `RupdEvent`
+  * `SnapEvent`
+  * `ShelleyTickEvent`
+  * `UtxoEvent`
+  * `ShelleyUtxowEvent`
+* Add `SomeSTSEvent`
 * Replaced `small-steps-test` dependency with `small-steps:testlib`
 * Change `submitFailingTx`, `tryRunImpRule` and `trySubmitTx`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -175,7 +175,7 @@ library testlib
         prettyprinter,
         QuickCheck,
         random,
-        small-steps:{small-steps, testlib} >=1.1,
+        small-steps >=1.1,
         text,
         transformers,
         microlens,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Shelley.LedgerState.Types (
 import Cardano.Ledger.Shelley.TxBody (unWithdrawals)
 import Cardano.Ledger.UMap (sumRewardsUView)
 import Cardano.Ledger.UTxO (UTxO (..), coinBalance, txInsFilter, txouts)
+import Control.DeepSeq (NFData)
 import Data.Foldable (fold)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
@@ -56,6 +57,8 @@ data AdaPots = AdaPots
   , obligationsPot :: Obligations
   }
   deriving (Show, Eq, Generic)
+
+instance NFData AdaPots
 
 -- | Calculate the total ada pots in the epoch state
 totalAdaPotsES ::

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -137,6 +137,11 @@ instance InjectRuleFailure "DELEGS" ShelleyDelegPredFailure (ShelleyEra c) where
   injectFailure = DelplFailure . injectFailure
 
 newtype ShelleyDelegsEvent era = DelplEvent (Event (EraRule "DELPL" era))
+  deriving (Generic)
+
+deriving instance Eq (Event (EraRule "DELPL" era)) => Eq (ShelleyDelegsEvent era)
+
+instance NFData (Event (EraRule "DELPL" era)) => NFData (ShelleyDelegsEvent era)
 
 deriving stock instance
   Show (PredicateFailure (EraRule "DELPL" era)) =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
@@ -116,6 +116,21 @@ data ShelleyEpochEvent era
   = PoolReapEvent (Event (EraRule "POOLREAP" era))
   | SnapEvent (Event (EraRule "SNAP" era))
   | UpecEvent (Event (EraRule "UPEC" era))
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "POOLREAP" era))
+  , Eq (Event (EraRule "SNAP" era))
+  , Eq (Event (EraRule "UPEC" era))
+  ) =>
+  Eq (ShelleyEpochEvent era)
+
+instance
+  ( NFData (Event (EraRule "POOLREAP" era))
+  , NFData (Event (EraRule "SNAP" era))
+  , NFData (Event (EraRule "UPEC" era))
+  ) =>
+  NFData (ShelleyEpochEvent era)
 
 instance
   ( EraTxOut era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -127,9 +127,24 @@ instance InjectRuleFailure "LEDGER" ShelleyPoolPredFailure (ShelleyEra c) where
 instance InjectRuleFailure "LEDGER" ShelleyDelegPredFailure (ShelleyEra c) where
   injectFailure = DelegsFailure . injectFailure
 
+type instance EraRuleEvent "LEDGER" (ShelleyEra c) = ShelleyLedgerEvent (ShelleyEra c)
+
 data ShelleyLedgerEvent era
   = UtxowEvent (Event (EraRule "UTXOW" era))
   | DelegsEvent (Event (EraRule "DELEGS" era))
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "UTXOW" era))
+  , Eq (Event (EraRule "DELEGS" era))
+  ) =>
+  Eq (ShelleyLedgerEvent era)
+
+instance
+  ( NFData (Event (EraRule "UTXOW" era))
+  , NFData (Event (EraRule "DELEGS" era))
+  ) =>
+  NFData (ShelleyLedgerEvent era)
 
 deriving stock instance
   ( Show (PredicateFailure (EraRule "DELEGS" era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -69,6 +69,8 @@ newtype ShelleyLedgersPredFailure era
 
 type instance EraRuleFailure "LEDGERS" (ShelleyEra c) = ShelleyLedgersPredFailure (ShelleyEra c)
 
+type instance EraRuleEvent "LEDGERS" (ShelleyEra c) = ShelleyLedgersEvent (ShelleyEra c)
+
 instance InjectRuleFailure "LEDGERS" ShelleyLedgersPredFailure (ShelleyEra c)
 
 instance InjectRuleFailure "LEDGERS" ShelleyLedgerPredFailure (ShelleyEra c) where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -72,6 +73,11 @@ data ShelleyMirEvent era
     --   This event gives the rewards we wanted to pay, plus the available
     --   reserves and treasury.
     NoMirTransfer (InstantaneousRewards (EraCrypto era)) Coin Coin
+  deriving (Generic)
+
+deriving instance Eq (ShelleyMirEvent era)
+
+instance NFData (ShelleyMirEvent era)
 
 instance NoThunks (ShelleyMirPredFailure era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -93,6 +93,21 @@ data ShelleyNewEpochEvent era
   | EpochEvent (Event (EraRule "EPOCH" era))
   | MirEvent (Event (EraRule "MIR" era))
   | TotalAdaPotsEvent AdaPots
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "EPOCH" era))
+  , Eq (Event (EraRule "MIR" era))
+  , Eq (Event (EraRule "RUPD" era))
+  ) =>
+  Eq (ShelleyNewEpochEvent era)
+
+instance
+  ( NFData (Event (EraRule "EPOCH" era))
+  , NFData (Event (EraRule "MIR" era))
+  , NFData (Event (EraRule "RUPD" era))
+  ) =>
+  NFData (ShelleyNewEpochEvent era)
 
 instance
   ( EraTxOut era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Keys (KeyRole (Staking))
 import Cardano.Ledger.PoolDistr (PoolDistr (..))
 import Cardano.Ledger.Shelley.AdaPots (AdaPots, totalAdaPotsES)
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.Shelley.Era (ShelleyNEWEPOCH)
+import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyNEWEPOCH)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rewards (sumRewards)
 import Cardano.Ledger.Shelley.Rules.Epoch
@@ -108,6 +108,8 @@ instance
   , NFData (Event (EraRule "RUPD" era))
   ) =>
   NFData (ShelleyNewEpochEvent era)
+
+type instance EraRuleEvent "NEWEPOCH" (ShelleyEra c) = ShelleyNewEpochEvent (ShelleyEra c)
 
 instance
   ( EraTxOut era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -122,6 +122,9 @@ instance (ShelleyEraTxCert era, EraPParams era) => STS (ShelleyPOOL era) where
 data PoolEvent era
   = RegisterPool (KeyHash 'StakePool (EraCrypto era))
   | ReregisterPool (KeyHash 'StakePool (EraCrypto era))
+  deriving (Generic, Eq)
+
+instance NFData (PoolEvent era)
 
 instance Era era => EncCBOR (ShelleyPoolPredFailure era) where
   encCBOR = \case

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
 import Cardano.Ledger.PoolParams (ppRewardAccount)
-import Cardano.Ledger.Shelley.Era (ShelleyPOOLREAP)
+import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyPOOLREAP)
 import Cardano.Ledger.Shelley.Governance (EraGov)
 import Cardano.Ledger.Shelley.LedgerState (
   AccountState (..),
@@ -112,6 +112,8 @@ instance NoThunks (ShelleyPoolreapPredFailure era)
 
 instance Default (UTxOState era) => Default (ShelleyPoolreapState era) where
   def = PoolreapState def def def def
+
+type instance EraRuleEvent "POOLREAP" (ShelleyEra c) = ShelleyPoolreapEvent (ShelleyEra c)
 
 instance
   ( Default (ShelleyPoolreapState era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -102,6 +102,11 @@ data ShelleyPoolreapEvent era = RetiredPools
   , unclaimedPools :: Map.Map (Credential 'Staking (EraCrypto era)) (Map.Map (KeyHash 'StakePool (EraCrypto era)) Coin)
   , epochNo :: EpochNo
   }
+  deriving (Generic)
+
+deriving instance Eq (ShelleyPoolreapEvent era)
+
+instance NFData (ShelleyPoolreapEvent era)
 
 instance NoThunks (ShelleyPoolreapPredFailure era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -119,7 +119,10 @@ instance NoThunks (ShelleyPpupPredFailure era)
 
 instance NFData (ShelleyPpupPredFailure era)
 
-newtype PpupEvent era = NewEpoch EpochNo
+newtype PpupEvent era = PpupNewEpoch EpochNo
+  deriving (Generic, Eq)
+
+instance NFData (PpupEvent era)
 
 instance (EraPParams era, ProtVerAtMost era 8) => STS (ShelleyPPUP era) where
   type State (ShelleyPPUP era) = ShelleyGovState era
@@ -191,7 +194,7 @@ ppupTransitionNonEmpty = do
         epochInfo <- liftSTS $ asks epochInfoPure
         epochNo <- liftSTS $ epochInfoEpoch epochInfo slot
         let nextEpochNo = succ epochNo
-        tellEvent $ NewEpoch nextEpochNo
+        tellEvent $ PpupNewEpoch nextEpochNo
         liftSTS $ do
           (,) epochNo <$> epochInfoFirst epochInfo nextEpochNo
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -105,6 +105,9 @@ data RupdEvent c
   = RupdEvent
       !EpochNo
       !(Map.Map (Credential 'Staking c) (Set (Reward c)))
+  deriving (Generic, Eq)
+
+instance NFData (RupdEvent c)
 
 -- | tell a RupdEvent only if the map is non-empty
 tellRupd :: String -> RupdEvent (EraCrypto era) -> Rule (ShelleyRUPD era) rtype ()

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -62,6 +63,11 @@ instance NoThunks (ShelleySnapPredFailure era)
 
 newtype SnapEvent era
   = StakeDistEvent (Map (Credential 'Staking (EraCrypto era)) (Coin, KeyHash 'StakePool (EraCrypto era)))
+  deriving (Generic)
+
+deriving instance Eq (SnapEvent era)
+
+instance NFData (SnapEvent era)
 
 data SnapEnv era = SnapEnv !(LedgerState era) !(PParams era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Tick.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfoPure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.EpochBoundary (SnapShots (ssStakeMark, ssStakeMarkPoolDistr))
 import Cardano.Ledger.Keys (GenDelegs (..))
-import Cardano.Ledger.Shelley.Era (ShelleyTICK, ShelleyTICKF)
+import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyTICK, ShelleyTICKF)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState (
   CertState (..),
@@ -107,6 +107,20 @@ data ShelleyTickEvent era
   = TickNewEpochEvent (Event (EraRule "NEWEPOCH" era))
   | TickRupdEvent (Event (EraRule "RUPD" era))
   deriving (Generic)
+
+type instance EraRuleEvent "TICK" (ShelleyEra c) = ShelleyTickEvent (ShelleyEra c)
+
+deriving instance
+  ( Eq (Event (EraRule "NEWEPOCH" era))
+  , Eq (Event (EraRule "RUPD" era))
+  ) =>
+  Eq (ShelleyTickEvent era)
+
+instance
+  ( NFData (Event (EraRule "NEWEPOCH" era))
+  , NFData (Event (EraRule "RUPD" era))
+  ) =>
+  NFData (ShelleyTickEvent era)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -139,6 +139,16 @@ data UtxoEvent era
       (UTxO era)
       -- | UTxO created
       (UTxO era)
+  deriving (Generic)
+
+deriving instance
+  ( Era era
+  , Eq (TxOut era)
+  , Eq (Event (EraRule "PPUP" era))
+  ) =>
+  Eq (UtxoEvent era)
+
+instance (Era era, NFData (Event (EraRule "PPUP" era)), NFData (TxOut era)) => NFData (UtxoEvent era)
 
 data ShelleyUtxoPredFailure era
   = BadInputsUTxO

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -163,6 +162,11 @@ instance InjectRuleFailure "UTXOW" ShelleyPpupPredFailure (ShelleyEra c) where
 
 newtype ShelleyUtxowEvent era
   = UtxoEvent (Event (EraRule "UTXO" era))
+  deriving (Generic)
+
+deriving instance Eq (Event (EraRule "UTXO" era)) => Eq (ShelleyUtxowEvent era)
+
+instance NFData (Event (EraRule "UTXO" era)) => NFData (ShelleyUtxowEvent era)
 
 instance
   ( NoThunks (PredicateFailure (EraRule "UTXO" era))

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -197,3 +197,66 @@ instance
 instance ToExpr Obligations
 
 instance ToExpr AdaPots
+
+-- Events
+instance
+  ( ToExpr (Event (EraRule "UTXOW" era))
+  , ToExpr (Event (EraRule "DELEGS" era))
+  ) =>
+  ToExpr (ShelleyLedgerEvent era)
+
+instance
+  ToExpr (Event (EraRule "UTXO" era)) =>
+  ToExpr (ShelleyUtxowEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "PPUP" era))
+  , ToExpr (TxOut era)
+  ) =>
+  ToExpr (UtxoEvent era)
+
+instance ToExpr (PpupEvent era)
+
+instance ToExpr (Event (EraRule "DELPL" era)) => ToExpr (ShelleyDelegsEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "DELEG" era))
+  , ToExpr (Event (EraRule "POOL" era))
+  ) =>
+  ToExpr (ShelleyDelplEvent era)
+
+instance ToExpr (ShelleyDelegEvent era)
+
+instance ToExpr (PoolEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "NEWEPOCH" era))
+  , ToExpr (Event (EraRule "RUPD" era))
+  ) =>
+  ToExpr (ShelleyTickEvent era)
+
+instance ToExpr RewardType
+
+instance ToExpr (Reward c)
+
+instance
+  ( ToExpr (Event (EraRule "EPOCH" era))
+  , ToExpr (Event (EraRule "MIR" era))
+  , ToExpr (Event (EraRule "RUPD" era))
+  ) =>
+  ToExpr (ShelleyNewEpochEvent era)
+
+instance
+  ( ToExpr (Event (EraRule "POOLREAP" era))
+  , ToExpr (Event (EraRule "SNAP" era))
+  , ToExpr (Event (EraRule "UPEC" era))
+  ) =>
+  ToExpr (ShelleyEpochEvent era)
+
+instance ToExpr (ShelleyPoolreapEvent era)
+
+instance ToExpr (SnapEvent era)
+
+instance ToExpr (ShelleyMirEvent era)
+
+instance ToExpr (RupdEvent era)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.11.0.0
 
+* Add `EraRuleEvent`, `InjectRuleEvent`
+* Add `NFData` instance for `Obligations`, `PlutusWithContext`, `PlutusDatums`
+* Add `Eq`, `Show`, `Generic` instances for `PlutusDatums`
 * Add `CommitteeAuthorization` and use it to represent hot key credential in `CommitteeState`
 * Change `applySTSValidateSuchThat` and `applySTSNonStatic`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`
@@ -34,6 +37,7 @@
 
 ### `testlib`
 
+* Add `shouldContainExpr`
 * Add `EraRuleProof`, `UnliftRules`, `roundTripAllPredicateFailures`
 * Add `Test.Cardano.Ledger.Plutus.ScriptTestContext`
 * Add `genByronVKeyAddr`, `genByronAddrFromVKey`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -506,6 +506,8 @@ data Obligations = Obligations
   }
   deriving (Eq, Ord, Generic)
 
+instance NFData Obligations
+
 -- | Calculate total possible refunds in the system that are related to certificates
 --
 -- There is an invariant that the sum of all the fields should be the same as the

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -22,9 +22,11 @@ module Cardano.Ledger.Core.Era (
   -- ** Rules
   EraRule,
   EraRuleFailure,
+  EraRuleEvent,
   VoidEraRule,
   absurdEraRule,
   InjectRuleFailure (..),
+  InjectRuleEvent (..),
 
   -- ** Protocol Version
   AtMostEra,
@@ -50,7 +52,7 @@ import Cardano.Ledger.Binary
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Crypto
 import Control.DeepSeq (NFData (..))
-import Control.State.Transition.Extended (PredicateFailure)
+import Control.State.Transition.Extended (PredicateFailure, STS (..))
 import Data.Kind (Constraint, Type)
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)
@@ -130,6 +132,8 @@ type family EraRule (rule :: Symbol) era = (r :: Type) | r -> rule
 -- does not provide for us unfortunately.
 type family EraRuleFailure (rule :: Symbol) era = (r :: Type) | r -> rule era
 
+type family EraRuleEvent (rule :: Symbol) era = (r :: Type) | r -> rule era
+
 -- | This is a type with no inhabitans for the rules. It is used to indicate that a rule
 -- does not have a predicate failure as well as marking rules that have been disabled when
 -- comparing to prior eras.
@@ -171,6 +175,14 @@ class
   injectFailure :: t era -> EraRuleFailure rule era
   default injectFailure :: t era ~ EraRuleFailure rule era => t era -> EraRuleFailure rule era
   injectFailure = id
+
+class
+  EraRuleEvent rule era ~ Event (EraRule rule era) =>
+  InjectRuleEvent (rule :: Symbol) t era
+  where
+  injectEvent :: t era -> EraRuleEvent rule era
+  default injectEvent :: t era ~ EraRuleEvent rule era => t era -> EraRuleEvent rule era
+  injectEvent = id
 
 -----------------------------
 -- Protocol version bounds --

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -62,6 +62,7 @@ import Cardano.Ledger.Plutus.Language (
   plutusLanguage,
  )
 import Cardano.Ledger.Plutus.TxInfo
+import Control.DeepSeq (NFData (..))
 import Control.Monad (unless)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.UTF8 as BSU
@@ -99,6 +100,15 @@ data PlutusWithContext c where
     PlutusWithContext c
 
 deriving instance Show (PlutusWithContext c)
+
+instance NFData (PlutusWithContext c) where
+  rnf PlutusWithContext {..} =
+    rnf pwcProtocolVersion `seq`
+      rnf pwcScript `seq`
+        rnf pwcScriptHash `seq`
+          rnf pwcDatums `seq`
+            rnf pwcExUnits `seq`
+              rnf pwcCostModel
 
 instance Eq (PlutusWithContext c) where
   pwc1@(PlutusWithContext {pwcScript = s1}) == pwc2@(PlutusWithContext {pwcScript = s2}) =
@@ -156,7 +166,9 @@ instance Monoid (ScriptResult c) where
   mempty = Passes mempty
 
 newtype PlutusDatums = PlutusDatums {unPlutusDatums :: [PV1.Data]}
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance NFData PlutusDatums
 
 instance EncCBOR PlutusDatums where
   encCBOR (PlutusDatums d) = encCBOR d

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -36,6 +36,7 @@ module Test.Cardano.Ledger.Imp.Common (
   shouldBeLeft,
   shouldBeRightExpr,
   shouldBeLeftExpr,
+  shouldContainExpr,
   expectRight,
   expectRightDeep_,
   expectRightDeep,
@@ -131,6 +132,7 @@ import Control.Monad.State
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
 import Data.Kind
+import Data.List (isInfixOf)
 import Foreign.Storable
 import qualified System.Random.Stateful as R
 
@@ -211,6 +213,16 @@ shouldEndWith x y = liftIO $ H.shouldEndWith x y
 -- | Lifted version of `H.shouldContain`.
 shouldContain :: (HasCallStack, Show a, Eq a, MonadIO m) => [a] -> [a] -> m ()
 shouldContain x y = liftIO $ H.shouldContain x y
+
+shouldContainExpr :: (HasCallStack, ToExpr a, Eq a, MonadIO m) => [a] -> [a] -> m ()
+shouldContainExpr x y
+  | y `isInfixOf` x = pure ()
+  | otherwise =
+      assertFailure $
+        "First list does not contain the second list:\n"
+          <> show (toExpr x)
+          <> "\ndoes not contain\n"
+          <> show (toExpr y)
 
 -- | Lifted version of `H.shouldMatchList`.
 shouldMatchList :: (HasCallStack, Show a, Eq a, MonadIO m) => [a] -> [a] -> m ()


### PR DESCRIPTION
# Description

This PR adds an event to `EPOCH` which contains sets with expired and enacted governance actions and a set with all the governance action IDs that are unclaimed.

I also added a way to write tests about events and cleaned up Conway events. The `ConwayUtxosEvent`is necessary because we have to get rid of `PPUP` events in Conway as we no longer have a `PPUP` rule.

resolves #4165

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
