### PR TITLE
Add CARDANO_MAINNET_MIRROR to Nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ nix develop --command make watch
 
 # Testing
 
-Before running tests with `cabal test`, the `CARDANO_MAINNET_MIRROR` environment variable should be set to the path to [mainnet epochs](https://github.com/input-output-hk/cardano-mainnet-mirror/tree/master/epochs) on your local storage.
-Note that this is only needed for the Byron tests.
+Run `cabal test all` to run all tests or `cabal test <package>` to run the tests for a specific package.
+
+Note: The `CARDANO_MAINNET_MIRROR` environment variable can be overriden in `flake.nix` if one desires to run
+the Byron tests with a different version of the [mainnet epochs](https://github.com/input-output-hk/cardano-mainnet-mirror/tree/master/epochs).
 
 # Submitting an issue
 

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
           shell.shellHook = ''
             export LANG=en_US.UTF-8
             export LC_ALL=en_US.UTF-8
+            export CARDANO_MAINNET_MIRROR="${inputs.cardano-mainnet-mirror}/epochs"
           '' + lib.optionalString (nixpkgs.glibcLocales != null && nixpkgs.stdenv.hostPlatform.libc == "glibc") ''
             export LOCALE_ARCHIVE="${nixpkgs.glibcLocales}/lib/locale/locale-archive"
             DEFAULT_PS1="\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] "


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
