### PR TITLE
Plutusv3 initialization tests

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -150,6 +150,7 @@ library testlib
         cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
         cardano-ledger-conway,
         cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-mary,
         cardano-ledger-shelley,
         cardano-strict-containers,
         data-default-class,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -605,8 +605,9 @@ submitParameterChange ::
   StrictMaybe (GovPurposeId 'PParamUpdatePurpose era) ->
   PParamsUpdate era ->
   ImpTestM era (GovActionId (EraCrypto era))
-submitParameterChange parent ppu =
-  submitGovAction $ ParameterChange parent ppu SNothing
+submitParameterChange parent ppu = do
+  policy <- getGovPolicy
+  submitGovAction $ ParameterChange parent ppu policy
 
 getGovPolicy :: ConwayEraGov era => ImpTestM era (StrictMaybe (ScriptHash (EraCrypto era)))
 getGovPolicy =


### PR DESCRIPTION
# Description

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4153

- Adds tests for various initialization scenarios
- Reorganizes UtxosSpec file to make it easier to read

It's easier to review the commits separately, since the second one might make it difficult to see the added tests. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
