### PR TITLE
Remove code repetition in Conway era CDDL

### DIFF
--- a/eras/babbage/impl/cddl-files/babbage.cddl
+++ b/eras/babbage/impl/cddl-files/babbage.cddl
@@ -34,7 +34,7 @@ header_body =
   , block_body_size  : uint
   , block_body_hash  : $hash32 ; merkle triple root
   , operational_cert
-  , [ protocol_version ]
+  , protocol_version
   ]
 
 operational_cert =
@@ -48,7 +48,7 @@ next_major_protocol_version = 9
 
 major_protocol_version = 1..next_major_protocol_version
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = [(major_protocol_version, uint)]
 
 transaction_body =
   { 0 : set<transaction_input>    ; inputs
@@ -280,7 +280,7 @@ protocol_param_update =
   , ? 9: nonnegative_interval ; pool pledge influence
   , ? 10: unit_interval       ; expansion rate
   , ? 11: unit_interval       ; treasury growth rate
-  , ? 14: [protocol_version]  ; protocol version
+  , ? 14: protocol_version    ; protocol version
   , ? 16: coin                ; min pool cost
   , ? 17: coin                ; ada per utxo byte
   , ? 18: costmdls            ; cost models for script languages

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -34,7 +34,7 @@ header_body =
   , block_body_size  : uint
   , block_body_hash  : $hash32 ; merkle triple root
   , operational_cert
-  , [ protocol_version ]
+  , protocol_version
   ]
 
 operational_cert =
@@ -48,7 +48,7 @@ next_major_protocol_version = 10
 
 major_protocol_version = 1..next_major_protocol_version
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = [(major_protocol_version, uint)]
 
 transaction_body =
   { 0 : set<transaction_input>             ; inputs
@@ -105,7 +105,7 @@ policy_hash = scripthash
 
 parameter_change_action = (0, gov_action_id / null, protocol_param_update, policy_hash / null)
 
-hard_fork_initiation_action = (1, gov_action_id / null, [protocol_version])
+hard_fork_initiation_action = (1, gov_action_id / null, protocol_version)
 
 treasury_withdrawals_action = (2, { reward_account => coin }, policy_hash / null)
 


### PR DESCRIPTION
# Description

`protocol_version` is defined as a group and always referred nested (alone) inside an array.

I introduced `protocol_version_` with the purpose to not change `protocol_version` definition: I don't know if there are some reasons to keep the definitions unchanged between CDDL versions; if that's not the case and I was too scrupulous, we could simplify this PR removing `protocol_version_` and changing `protocol_version` definition.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
