### PR TITLE
Simplify implementation of ToJSON1 of ListMap

### DIFF
--- a/libs/cardano-data/src/Data/ListMap.hs
+++ b/libs/cardano-data/src/Data/ListMap.hs
@@ -91,11 +91,9 @@ instance (EncCBOR k, EncCBOR v) => EncCBOR (ListMap k v) where
 
 instance ToJSONKey k => ToJSON1 (ListMap k) where
   liftToJSON _ g _ = case toJSONKey of
-    ToJSONKeyText f _ -> Object . KM.fromList . unListMap . mapKeyValO f g
+    ToJSONKeyText f _ -> Object . KM.fromList . unListMap . bimap f g
     ToJSONKeyValue f _ -> Array . V.fromList . L.map (toJSONPair f g) . unListMap
     where
-      mapKeyValO :: (k1 -> k2) -> (v1 -> v2) -> ListMap k1 v1 -> ListMap k2 v2
-      mapKeyValO fk kv = ListMap . foldrWithKey (\(k, v) -> ((fk k, kv v) :)) []
       toJSONPair :: (a -> Value) -> (b -> Value) -> (a, b) -> Value
       toJSONPair a b = liftToJSON2 (const False) a (listValue a) (const False) b (listValue b)
 


### PR DESCRIPTION
# Description

I was investigating a memory issue and found this in the process, which turned out not to be the issue. But still I think it is a good simplification, and is probably more efficient in general. I did some experiments in `ghci` and `map` seemed much more efficient than `foldr`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
