### PR TITLE
Imptests -  treasury withdrawals

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -18,10 +18,12 @@ import Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Val ((<+>))
 import Control.State.Transition.Extended (STS (..))
 import Data.Default.Class (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
+import Data.Word (Word64)
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational
@@ -94,6 +96,96 @@ treasuryWithdrawalsSpec =
                    , (raCredential rewardAcount2, Coin 222)
                    ]
       ensTreasury enactState'' `shouldBe` Coin 1
+
+    it "Multiple proposals in a single Tx that add up to more than the balance" $ do
+      (drepC, committeeC, _gpi) <- electBasicCommittee
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+      rewardAccount1 <- registerRewardAccount
+      rewardAccount2 <- registerRewardAccount
+      rewardAccount3 <- registerRewardAccount
+      rewardAccount4 <- registerRewardAccount
+      rewardAccount5 <- registerRewardAccount
+      let eachWithdrawal = curTreasury `div` 4
+      gpi <-
+        submitTreasuryWithdrawals
+          [ (rewardAccount1, Coin eachWithdrawal)
+          , (rewardAccount2, Coin eachWithdrawal)
+          , (rewardAccount3, Coin eachWithdrawal)
+          , (rewardAccount4, Coin eachWithdrawal)
+          , (rewardAccount5, Coin eachWithdrawal)
+          ]
+      submitYesVote_ (DRepVoter drepC) gpi
+      submitYesVote_ (CommitteeVoter committeeC) gpi
+      passNEpochs 2
+      getsNES (nesEsL . esAccountStateL . asTreasuryL)
+        `shouldReturn` Coin curTreasury
+      modifyNES $
+        nesEsL . esAccountStateL . asTreasuryL
+          %~ (<+> Coin eachWithdrawal)
+      passNEpochs 2
+      getsNES (nesEsL . esAccountStateL . asTreasuryL)
+        `shouldReturn` Coin 0
+    it "Multiple proposals in a single Tx that add up to more than maxBound Word64" $ do
+      (drepC, committeeC, _gpi) <- electBasicCommittee
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      modifyNES $
+        nesEsL . esAccountStateL . asTreasuryL
+          .~ Coin (fromIntegral (maxBound :: Word64))
+      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+      rewardAccount1 <- registerRewardAccount
+      rewardAccount2 <- registerRewardAccount
+      rewardAccount3 <- registerRewardAccount
+      rewardAccount4 <- registerRewardAccount
+      rewardAccount5 <- registerRewardAccount
+      let eachWithdrawal = curTreasury `div` 4
+      gpi <-
+        submitTreasuryWithdrawals
+          [ (rewardAccount1, Coin eachWithdrawal)
+          , (rewardAccount2, Coin eachWithdrawal)
+          , (rewardAccount3, Coin eachWithdrawal)
+          , (rewardAccount4, Coin eachWithdrawal)
+          , (rewardAccount5, Coin eachWithdrawal)
+          ]
+      submitYesVote_ (DRepVoter drepC) gpi
+      submitYesVote_ (CommitteeVoter committeeC) gpi
+      passNEpochs 2
+      getsNES (nesEsL . esAccountStateL . asTreasuryL)
+        `shouldReturn` Coin curTreasury
+    it "Proposals in multiple epochs" $ do
+      (drepC, committeeC, _gpi) <- electBasicCommittee
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      modifyNES $
+        nesEsL . esAccountStateL . asTreasuryL
+          .~ Coin (fromIntegral (maxBound :: Word64))
+      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+      rewardAccount1 <- registerRewardAccount
+      rewardAccount2 <- registerRewardAccount
+      rewardAccount3 <- registerRewardAccount
+      rewardAccount4 <- registerRewardAccount
+      rewardAccount5 <- registerRewardAccount
+      let eachWithdrawal = curTreasury `div` 4
+      gpi1 <-
+        submitTreasuryWithdrawals
+          [ (rewardAccount1, Coin eachWithdrawal)
+          , (rewardAccount2, Coin eachWithdrawal)
+          , (rewardAccount3, Coin eachWithdrawal)
+          ]
+      submitYesVote_ (DRepVoter drepC) gpi1
+      submitYesVote_ (CommitteeVoter committeeC) gpi1
+      passNEpochs 2
+      getsNES (nesEsL . esAccountStateL . asTreasuryL)
+        `shouldReturn` Coin (curTreasury - 3 * eachWithdrawal)
+      gpi2 <-
+        submitTreasuryWithdrawals
+          [ (rewardAccount4, Coin eachWithdrawal)
+          , (rewardAccount5, Coin eachWithdrawal)
+          ]
+      submitYesVote_ (DRepVoter drepC) gpi2
+      submitYesVote_ (CommitteeVoter committeeC) gpi2
+      passNEpochs 2
+      getsNES (nesEsL . esAccountStateL . asTreasuryL)
+        `shouldReturn` Coin (curTreasury - 3 * eachWithdrawal)
 
 hardForkInitiationSpec :: ConwayEraImp era => SpecWith (ImpTestState era)
 hardForkInitiationSpec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -47,6 +47,7 @@ spec =
     hardForkInitiationSpec
     noConfidenceSpec
     constitutionSpec
+    actionPrioritySpec
 
 treasuryWithdrawalsSpec ::
   forall era.
@@ -337,3 +338,61 @@ constitutionSpec =
       rsEnacted pulserRatifyState `shouldBe` Seq.empty
       enactState <- getEnactState
       rsEnactState pulserRatifyState `shouldBe` enactState
+
+actionPrioritySpec ::
+  forall era.
+  ConwayEraImp era =>
+  SpecWith (ImpTestState era)
+actionPrioritySpec =
+  describe "Action priority" $ do
+    it "Only the first of proposals with same priority is enacted" $ do
+      (drepC, _, gpi) <- electBasicCommittee
+      (poolKH, _, _) <- setupPoolWithStake $ Coin 1_000_000
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      cc <- KeyHashObj <$> freshKeyHash
+      gai1 <-
+        submitGovAction $
+          UpdateCommittee (SJust gpi) mempty (Map.singleton cc (EpochNo 30)) $
+            1 %! 2
+      -- gai2 is the first action of a higher priority
+      gai2 <- submitGovAction $ NoConfidence $ SJust gpi
+      gai3 <- submitGovAction $ NoConfidence $ SJust gpi
+      submitYesVote_ (DRepVoter drepC) gai1
+      submitYesVote_ (StakePoolVoter poolKH) gai1
+      submitYesVote_ (DRepVoter drepC) gai2
+      submitYesVote_ (StakePoolVoter poolKH) gai2
+      submitYesVote_ (DRepVoter drepC) gai3
+      submitYesVote_ (StakePoolVoter poolKH) gai3
+      passNEpochs 2
+      getLastEnactedCommittee
+        `shouldReturn` SJust (GovPurposeId gai2)
+      checkProposalsEmpty
+
+    it "Contiguous ratified proposals are enacted in the same epoch, unless delayed" $ do
+      (drepC, committeeC, _) <- electBasicCommittee
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      pGai0 <-
+        submitParameterChange
+          SNothing
+          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_000)
+      pGai1 <-
+        submitParameterChange
+          (SJust $ GovPurposeId pGai0)
+          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_001)
+      pGai2 <-
+        submitParameterChange
+          (SJust $ GovPurposeId pGai1)
+          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_002)
+      submitYesVote_ (DRepVoter drepC) pGai0
+      submitYesVote_ (CommitteeVoter committeeC) pGai0
+      submitYesVote_ (DRepVoter drepC) pGai1
+      submitYesVote_ (CommitteeVoter committeeC) pGai1
+      submitYesVote_ (DRepVoter drepC) pGai2
+      submitYesVote_ (CommitteeVoter committeeC) pGai2
+      passNEpochs 2
+      getLastEnactedParameterChange
+        `shouldReturn` SJust (GovPurposeId pGai2)
+      checkProposalsEmpty
+
+checkProposalsEmpty :: ConwayEraGov era => ImpTestM era ()
+checkProposalsEmpty = null . proposalsIds <$> getProposals `shouldReturn` True

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -18,10 +18,12 @@ import Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Val ((<+>))
+import Cardano.Ledger.Val (zero, (<->))
 import Control.State.Transition.Extended (STS (..))
 import Data.Default.Class (def)
+import Data.Foldable (foldl', traverse_)
 import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
 import qualified Data.Sequence as Seq
 import Data.Word (Word64)
 import Lens.Micro
@@ -57,7 +59,7 @@ treasuryWithdrawalsSpec ::
   SpecWith (ImpTestState era)
 treasuryWithdrawalsSpec =
   describe "Treasury withdrawals" $ do
-    it "modify EnactState as expected" $ do
+    it "Modify EnactState as expected" $ do
       rewardAcount1 <- registerRewardAccount
       govActionId <- submitTreasuryWithdrawals [(rewardAcount1, Coin 666)]
       gas <- getGovActionState govActionId
@@ -97,95 +99,94 @@ treasuryWithdrawalsSpec =
                    ]
       ensTreasury enactState'' `shouldBe` Coin 1
 
-    it "Multiple proposals in a single Tx that add up to more than the balance" $ do
-      (drepC, committeeC, _gpi) <- electBasicCommittee
+    it "Withdrawals exceeding treasury submitted in a single proposal" $ do
+      (drepC, committeeC, _) <- electBasicCommittee
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
-      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
-      rewardAccount1 <- registerRewardAccount
-      rewardAccount2 <- registerRewardAccount
-      rewardAccount3 <- registerRewardAccount
-      rewardAccount4 <- registerRewardAccount
-      rewardAccount5 <- registerRewardAccount
-      let eachWithdrawal = curTreasury `div` 4
-      gpi <-
-        submitTreasuryWithdrawals
-          [ (rewardAccount1, Coin eachWithdrawal)
-          , (rewardAccount2, Coin eachWithdrawal)
-          , (rewardAccount3, Coin eachWithdrawal)
-          , (rewardAccount4, Coin eachWithdrawal)
-          , (rewardAccount5, Coin eachWithdrawal)
-          ]
-      submitYesVote_ (DRepVoter drepC) gpi
-      submitYesVote_ (CommitteeVoter committeeC) gpi
+      initialTreasury <- getTreasury
+      numWithdrawals <- choose (1, 10)
+      withdrawals <- genWithdrawalsExceeding initialTreasury numWithdrawals 100
+
+      gaId <- submitTreasuryWithdrawals withdrawals
+      submitYesVote_ (DRepVoter drepC) gaId
+      submitYesVote_ (CommitteeVoter committeeC) gaId
       passNEpochs 2
-      getsNES (nesEsL . esAccountStateL . asTreasuryL)
-        `shouldReturn` Coin curTreasury
-      modifyNES $
-        nesEsL . esAccountStateL . asTreasuryL
-          %~ (<+> Coin eachWithdrawal)
+      getTreasury `shouldReturn` initialTreasury
+      -- reward accounts are empty
+      sumRewardAccounts withdrawals `shouldReturn` zero
+
+      let sumRequested = mconcat $ snd <$> withdrawals
+
+      impAnn "Submit a treasury donation that can cover the withdrawals" $ do
+        let tx =
+              mkBasicTx mkBasicTxBody
+                & bodyTxL . treasuryDonationTxBodyL .~ (sumRequested <-> initialTreasury)
+        submitTx_ tx
       passNEpochs 2
-      getsNES (nesEsL . esAccountStateL . asTreasuryL)
-        `shouldReturn` Coin 0
-    it "Multiple proposals in a single Tx that add up to more than maxBound Word64" $ do
-      (drepC, committeeC, _gpi) <- electBasicCommittee
+      getTreasury `shouldReturn` zero
+      sumRewardAccounts withdrawals `shouldReturn` sumRequested
+
+    it "Withdrawals exceeding maxBound Word64 submitted in a single proposal" $ do
+      (drepC, committeeC, _) <- electBasicCommittee
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
-      modifyNES $
-        nesEsL . esAccountStateL . asTreasuryL
-          .~ Coin (fromIntegral (maxBound :: Word64))
-      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
-      rewardAccount1 <- registerRewardAccount
-      rewardAccount2 <- registerRewardAccount
-      rewardAccount3 <- registerRewardAccount
-      rewardAccount4 <- registerRewardAccount
-      rewardAccount5 <- registerRewardAccount
-      let eachWithdrawal = curTreasury `div` 4
-      gpi <-
-        submitTreasuryWithdrawals
-          [ (rewardAccount1, Coin eachWithdrawal)
-          , (rewardAccount2, Coin eachWithdrawal)
-          , (rewardAccount3, Coin eachWithdrawal)
-          , (rewardAccount4, Coin eachWithdrawal)
-          , (rewardAccount5, Coin eachWithdrawal)
-          ]
-      submitYesVote_ (DRepVoter drepC) gpi
-      submitYesVote_ (CommitteeVoter committeeC) gpi
+      initialTreasury <- getTreasury
+      numWithdrawals <- choose (1, 10)
+      withdrawals <- genWithdrawalsExceeding (Coin (fromIntegral (maxBound :: Word64))) numWithdrawals 100
+      gaId <- submitTreasuryWithdrawals withdrawals
+
+      submitYesVote_ (DRepVoter drepC) gaId
+      submitYesVote_ (CommitteeVoter committeeC) gaId
       passNEpochs 2
-      getsNES (nesEsL . esAccountStateL . asTreasuryL)
-        `shouldReturn` Coin curTreasury
-    it "Proposals in multiple epochs" $ do
-      (drepC, committeeC, _gpi) <- electBasicCommittee
+      getTreasury `shouldReturn` initialTreasury
+      sumRewardAccounts withdrawals `shouldReturn` zero
+
+    it "Withdrawals exceeding treasury submitted in several proposals within the same epoch" $ do
+      (drepC, committeeC, _) <- electBasicCommittee
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
-      modifyNES $
-        nesEsL . esAccountStateL . asTreasuryL
-          .~ Coin (fromIntegral (maxBound :: Word64))
-      Coin curTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
-      rewardAccount1 <- registerRewardAccount
-      rewardAccount2 <- registerRewardAccount
-      rewardAccount3 <- registerRewardAccount
-      rewardAccount4 <- registerRewardAccount
-      rewardAccount5 <- registerRewardAccount
-      let eachWithdrawal = curTreasury `div` 4
-      gpi1 <-
-        submitTreasuryWithdrawals
-          [ (rewardAccount1, Coin eachWithdrawal)
-          , (rewardAccount2, Coin eachWithdrawal)
-          , (rewardAccount3, Coin eachWithdrawal)
-          ]
-      submitYesVote_ (DRepVoter drepC) gpi1
-      submitYesVote_ (CommitteeVoter committeeC) gpi1
-      passNEpochs 2
-      getsNES (nesEsL . esAccountStateL . asTreasuryL)
-        `shouldReturn` Coin (curTreasury - 3 * eachWithdrawal)
-      gpi2 <-
-        submitTreasuryWithdrawals
-          [ (rewardAccount4, Coin eachWithdrawal)
-          , (rewardAccount5, Coin eachWithdrawal)
-          ]
-      submitYesVote_ (DRepVoter drepC) gpi2
-      submitYesVote_ (CommitteeVoter committeeC) gpi2
-      passNEpochs 2
-      getsNES (nesEsL . esAccountStateL . asTreasuryL)
-        `shouldReturn` Coin (curTreasury - 3 * eachWithdrawal)
+      initialTreasury <- getTreasury
+      -- generate withdrawals which individually do not exceed the treasury, but their sum does
+      numWithdrawals <- choose (1, 10)
+      withdrawals <- genWithdrawalsExceeding initialTreasury numWithdrawals 50
+
+      impAnn "submit in the same proposal, with no effect on the treasury" $ do
+        gaId <- submitTreasuryWithdrawals withdrawals
+        submitYesVote_ (DRepVoter drepC) gaId
+        submitYesVote_ (CommitteeVoter committeeC) gaId
+        passNEpochs 2
+        getTreasury `shouldReturn` initialTreasury
+
+      impAnn "submit in individual proposals in the same epoch" $ do
+        traverse_
+          ( \w -> do
+              gaId <- submitTreasuryWithdrawals @era [w]
+              submitYesVote_ (DRepVoter drepC) gaId
+              submitYesVote_ (CommitteeVoter committeeC) gaId
+          )
+          withdrawals
+        passNEpochs 2
+
+        let expectedTreasury =
+              foldl'
+                ( \acc (_, x) ->
+                    if acc <-> x >= zero
+                      then acc <-> x
+                      else acc
+                )
+                initialTreasury
+                withdrawals
+
+        getTreasury `shouldReturn` expectedTreasury
+        -- check that the sum of the rewards matches what was spent from the treasury
+        sumRewardAccounts withdrawals `shouldReturn` (initialTreasury <-> expectedTreasury)
+  where
+    getTreasury = getsNES (nesEsL . esAccountStateL . asTreasuryL)
+    sumRewardAccounts withdrawals = mconcat <$> traverse (getRewardAccountAmount . fst) withdrawals
+    genWithdrawalsExceeding (Coin val) n maxExcess = do
+      accounts <- replicateM n $ registerRewardAccount @era
+      pcts <- replicateM n (choose (1, 100) :: ImpTestM era Integer)
+      let tot = sum pcts
+      excess <- choose (1, maxExcess) :: ImpTestM era Integer
+      let amounts = fmap (\x -> Coin $ ceiling ((x + excess) % tot * fromIntegral val)) pcts
+      pure $ zip accounts amounts
 
 hardForkInitiationSpec :: ConwayEraImp era => SpecWith (ImpTestState era)
 hardForkInitiationSpec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -21,6 +21,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
   module ImpTest,
   ConwayEraImp,
   enactConstitution,
+  enactTreasuryWithdrawals,
   submitGovAction,
   submitGovAction_,
   submitGovActions,
@@ -600,6 +601,19 @@ submitTreasuryWithdrawals ::
 submitTreasuryWithdrawals wdrls = do
   policy <- getGovPolicy
   submitGovAction $ TreasuryWithdrawals (Map.fromList wdrls) policy
+
+enactTreasuryWithdrawals ::
+  ConwayEraImp era =>
+  [(RewardAccount (EraCrypto era), Coin)] ->
+  Credential 'DRepRole (EraCrypto era) ->
+  Credential 'HotCommitteeRole (EraCrypto era) ->
+  ImpTestM era (GovActionId (EraCrypto era))
+enactTreasuryWithdrawals withdrawals dRep cm = do
+  gaId <- submitTreasuryWithdrawals withdrawals
+  submitYesVote_ (DRepVoter dRep) gaId
+  submitYesVote_ (CommitteeVoter cm) gaId
+  passNEpochs 2
+  pure gaId
 
 submitParameterChange ::
   ConwayEraImp era =>


### PR DESCRIPTION
# Description

This is the first part of @aniketd 's PR: https://github.com/IntersectMBO/cardano-ledger/pull/4179/commits, closing: https://github.com/IntersectMBO/cardano-ledger/issues/4133

I have re-arranged the test a little bit and added his commit that is actually adding the tests, and improved the tests with the comments from the review.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
