### PR TITLE
Fix epoch boundary check in ImpTest

### DIFF
--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -159,6 +159,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   produced,
   smartUTxOState,
   startStep,
+  utxosDonationL,
   utxosUtxoL,
  )
 import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
@@ -940,7 +941,10 @@ epochBoundaryCheck preNES postNES = do
       "Total ADA in the epoch state is not preserved\n\tpost - pre = "
         <> show (postSum <-> preSum)
   where
-    tot nes = sumAdaPots $ totalAdaPotsES $ nes ^. nesEsL
+    tot nes =
+      (<+>)
+        (sumAdaPots (totalAdaPotsES (nes ^. nesEsL)))
+        (nes ^. nesEsL . esLStateL . lsUTxOStateL . utxosDonationL)
 
 -- | Runs the TICK rule until the `n` epochs are passed
 passNEpochs ::


### PR DESCRIPTION
# Description

In `ImpTest.passEpoch`, we are checking that the sum of  the AdaPots are preserved before and after the epoch change.
Starting with Conway, we also have donations which get added to the treasury at the epoch boundary, so we have to take them into account if we want to check to hold after donations are being made.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
