### PR TITLE
Fix Haddocks CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -50,8 +50,14 @@ jobs:
             git branch -D "$REFNAME"
           done
         git checkout -b gh-pages
+
         git rm -rfq .
-        git commit -qm "Remove all files"
+        git commit -qm "Remove all existing files"
+
+        echo "cardano-ledger.cardano.intersectmbo.org" >CNAME
+        touch .nojekyll
+        git add CNAME .nojekyll
+        git commit -qm "Add CNAME and .nojekyll"
 
         # Preserve benchmark results, if any
         git ls-remote origin --heads gh-pages |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Github Pages
+name: Haddocks to GitHub Pages
 
 on:
   push:
@@ -12,28 +12,27 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.iog.io https://cache.nixos.org/
-      - name: Build haddocks
-        run: nix develop --command bash -c 'cabal update && ./scripts/haddocks.sh haddocks all'
-      - name: Add files
-        run: |
-              git config --local user.name ${{ github.actor }}
-              git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-              git add -A --force ./haddocks
-              git mv ./haddocks/* .
-              git commit -m "Updated"
-              rm -rf haddocks
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://cache.iog.io https://cache.nixos.org/
+    - name: Build haddocks
+      run: nix develop --command bash -c 'cabal update && ./scripts/haddocks.sh haddocks all'
+    - name: Add files
+      run: |
+        git config --local user.name ${{ github.actor }}
+        git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+        git add -A --force ./haddocks
+        git mv ./haddocks/* .
+        git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
 
-      - name: Push to gh-pages
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            branch: gh-pages
-            force: true
-            directory: .
+    - name: Push to gh-pages
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        force: true
+        directory: .

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,15 +12,33 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: actions/checkout@v4
+
+    - name: Install Haskell
+      uses: input-output-hk/setup-haskell@v1
+      id: setup-haskell
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          substituters = https://cache.iog.io https://cache.nixos.org/
+        ghc-version: "9.2.8"
+        cabal-version: latest
+
+    - name: Install system dependencies
+      uses: input-output-hk/actions/base@latest
+      with:
+        use-sodium-vrf: false # default is true
+
+    - name: Configure to use libsodium
+      run: |
+        cat >> cabal.project <<EOF
+        package cardano-crypto-praos
+          flags: -external-libsodium-vrf
+        EOF
+
+    - name: Cabal update
+      run: cabal update
+
     - name: Build haddocks
-      run: nix develop --command bash -c 'cabal update && ./scripts/haddocks.sh haddocks all'
+      run: scripts/haddocks.sh haddocks all
+
     - name: Add files
       run: |
         git config --local user.name ${{ github.actor }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,8 +19,8 @@ jobs:
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.iog.io https://cache.nixos.org/
-      - name: Build projects and haddocks
-        run: nix develop --command bash -c 'cabal update && cabal build --enable-documentation all && ./scripts/haddocks.sh haddocks all'
+      - name: Build haddocks
+        run: nix develop --command bash -c 'cabal update && ./scripts/haddocks.sh haddocks all'
       - name: Add files
         run: |
               git config --local user.name ${{ github.actor }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,6 +44,15 @@ jobs:
         git config --local user.name ${{ github.actor }}
         git config --local user.email "${{ github.actor }}@users.noreply.github.com"
 
+        # Start a new version of the gh-pages branch
+        git for-each-ref refs/heads/gh-pages --format='%(refname:short)' |
+          while read -r REFNAME; do
+            git branch -D "$REFNAME"
+          done
+        git checkout -b gh-pages
+        git rm -rfq .
+        git commit -qm "Remove all files"
+
         # Preserve benchmark results, if any
         git ls-remote origin --heads gh-pages |
           while read -r _SHA REFNAME; do

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.iog.io https://cache.nixos.org/
       - name: Build projects and haddocks
-        run: nix develop --command bash -c 'cabal update && cabal build --enable-documentation all && ./scripts/haddocks.sh'
+        run: nix develop --command bash -c 'cabal update && cabal build --enable-documentation all && ./scripts/haddocks.sh haddocks all'
       - name: Add files
         run: |
               git config --local user.name ${{ github.actor }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,6 +43,18 @@ jobs:
       run: |
         git config --local user.name ${{ github.actor }}
         git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+
+        # Preserve benchmark results, if any
+        git ls-remote origin --heads gh-pages |
+          while read -r _SHA REFNAME; do
+            git fetch origin "$REFNAME"
+            if git diff --name-only FETCH_HEAD -- dev | grep -q .; then
+              git checkout FETCH_HEAD dev
+              git commit -qC "$(git log -1 --format=%H FETCH_HEAD dev)"
+            fi
+          done
+
+        # Add Haddocks
         git add -A --force ./haddocks
         git mv ./haddocks/* .
         git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cardano-ledger.cardano.intersectmbo.org

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -102,13 +102,8 @@ haddock \
   "${interface_options[@]}"
 
 # Assemble a toplevel `doc-index.json` from package level ones.
-echo "[]" > "${OUTPUT_DIR}/doc-index.json"
 for file in "$OUTPUT_DIR"/*/doc-index.json; do
   project=$(basename "$(dirname "$file")");
-  jq -s \
-    ".[0] + [.[1][] | (. + {link: (\"${project}/\" + .link)}) ]" \
-    "${OUTPUT_DIR}/doc-index.json" \
-    "${file}" \
-    > /tmp/doc-index.json
-  mv /tmp/doc-index.json "${OUTPUT_DIR}/doc-index.json"
-done
+  jq ".[] | .link = \"${project}/\(.link)\"" "${file}"
+done |
+  jq -s . >"${OUTPUT_DIR}/doc-index.json"

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -8,106 +8,107 @@
 #
 # $1 - where to put the generated pages, this directory contents will be wiped
 #      out (so don't pass `/` or `./` - the latter will delete your 'dist-newstyle')
-#      (the default is './haddocks')
+#      (the default is 'haddocks')
 # $2 - whether to re-build haddocks with `cabal haddock` command or a component name
 #      (the default is true)
 #
 
 set -euo pipefail
 
-OUTPUT_DIR=${1:-"./haddocks"}
-REGENERATE=${2:-"true"}
+OUTPUT_DIR=${1:-haddocks}
+REGENERATE=${2:-true}
 
-BUILD_DIR="dist-newstyle"
+BUILD_DIR=dist-newstyle
 GHC_VERSION=$(ghc --numeric-version)
-OS_ARCH="$(cat dist-newstyle/cache/plan.json | jq -r '.arch + "-" + .os' | head -n 1 | xargs)"
-
+OS_ARCH=$(jq -r '"\(.arch)-\(.os)"' "$BUILD_DIR/cache/plan.json")
 
 # Generate  `doc-index.json` and `doc-index.html` per package, to assemble them later at the top level.
 HADDOCK_OPTS=(
-    --builddir "${BUILD_DIR}"
-    --haddock-all
-    --haddock-internal
-    --haddock-html
-    --haddock-quickjump
-    --haddock-hyperlink-source
-    --haddock-option "--show-all"
-    --haddock-option "--use-unicode"
-    --haddock-option="--base-url=.."
-  )
+  --builddir "${BUILD_DIR}"
+  --haddock-all
+  --haddock-internal
+  --haddock-html
+  --haddock-quickjump
+  --haddock-hyperlink-source
+  --haddock-option "--show-all"
+  --haddock-option "--use-unicode"
+  --haddock-option="--base-url=.."
+)
 
 # build documentation of all modules
-if [ ${REGENERATE} == "true" ]; then
+if [ "${REGENERATE}" == "true" ]; then
   cabal haddock "${HADDOCK_OPTS[@]}" all
-elif [ ${REGENERATE} != "false" ]; then
-  cabal haddock "${HADDOCK_OPTS[@]}" ${REGENERATE}
+elif [ "${REGENERATE}" != "false" ]; then
+  cabal haddock "${HADDOCK_OPTS[@]}" "${REGENERATE}"
 fi
 
-if [[ !( -d ${OUTPUT_DIR} ) ]]; then
-  mkdir -p ${OUTPUT_DIR}
+if [[ ! -d "${OUTPUT_DIR}" ]]; then
+  mkdir -p "${OUTPUT_DIR}"
 fi
 
 # make all files user writable
 chmod -R u+w "${OUTPUT_DIR}"
 
 # copy the new docs
-for dir in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}"); do
-  package=$(echo "${dir}" | sed 's/-[0-9]\+\(\.[0-9]\+\)*//')
-  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}" ]; then
-    cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}" ${OUTPUT_DIR}
-  else continue;
+for package_dir in "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}"/*; do
+  package=$(basename "${package_dir}" | sed 's/-[0-9]\+\(\.[0-9]\+\)*//')
+  if [ -d "${package_dir}/doc/html/${package}" ]; then
+    cp -r "${package_dir}/doc/html/${package}" "${OUTPUT_DIR}"
+  else continue
   fi
   # copy test packages documentation when it exists
-  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t" ]; then
-      for test_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t"); do
-          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/doc/html/${package}/${test_package}" ]; then
-              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/t/${test_package}/doc/html/${package}/${test_package}" "${OUTPUT_DIR}/${package}:${test_package}"
-              cp -n "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${test_package}"
-          fi
-      done
+  if [ -d "${package_dir}/t" ]; then
+    for test_package_dir in "${package_dir}/t"/*; do
+      test_package=$(basename "${test_package_dir}")
+      if [ -d "${test_package_dir}/doc/html/${package}/${test_package}" ]; then
+        cp -r "${test_package_dir}/doc/html/${package}/${test_package}" "${OUTPUT_DIR}/${package}:${test_package}"
+        cp -n "${package_dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${test_package}"
+      fi
+    done
   fi
   # copy lib packages documentation when it exists
-  if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l" ]; then
-      for lib_package in $(ls "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l"); do
-          if [ -d "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${lib_package}/doc/html/${package}" ]; then
-              cp -r "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/l/${lib_package}/doc/html/${package}" "${OUTPUT_DIR}/${package}:${lib_package}"
-              cp -n "${BUILD_DIR}/build/${OS_ARCH}/ghc-${GHC_VERSION}/${dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${lib_package}"
-          fi
-      done
+  if [ -d "${package_dir}/l" ]; then
+    for lib_package_dir in "${package_dir}/l"/*; do
+      lib_package=$(basename "${lib_package_dir}")
+      if [ -d "${lib_package_dir}/doc/html/${package}" ]; then
+        cp -r "${lib_package_dir}/doc/html/${package}" "${OUTPUT_DIR}/${package}:${lib_package}"
+        cp -n "${package_dir}/doc/html/${package}"/{*.css,*.js}  "${OUTPUT_DIR}/${package}:${lib_package}"
+      fi
+    done
   fi
 done
 
 # build read-interface arguments for haddock
-interface_options () {
-    for package in $(ls "${OUTPUT_DIR}"); do
-        if [[ -d "${OUTPUT_DIR}/${package}" ]]; then
-            haddock_file=$(ls -1 ${OUTPUT_DIR}/${package}/*.haddock | head -1)
-            echo "--read-interface=${package},${haddock_file}"
-        fi
-  done
-}
+interface_options=()
+for package_dir in "${OUTPUT_DIR}"/*; do
+  package=$(basename "${package_dir}")
+  if [[ -d "${package_dir}" ]]; then
+    haddock_files=("${package_dir}"/*.haddock)
+    interface_options+=("--read-interface=${package},${haddock_files[0]}")
+  fi
+done
 
-./scripts/mkprolog.sh ./haddocks ./scripts/prolog
+./scripts/mkprolog.sh "${OUTPUT_DIR}" scripts/prolog
 
 # Generate top level index using interface files
 haddock \
-  -o ${OUTPUT_DIR} \
+  -o "${OUTPUT_DIR}" \
   --title "cardano-ledger" \
   --package-name "Cardano Ledger" \
   --gen-index \
   --gen-contents \
   --quickjump \
   --prolog ./scripts/prolog \
-  $(interface_options)
+  "${interface_options[@]}"
 
 # Assemble a toplevel `doc-index.json` from package level ones.
 echo "[]" > "${OUTPUT_DIR}/doc-index.json"
-for file in $(ls $OUTPUT_DIR/*/doc-index.json); do
-  project=$(basename $(dirname $file));
+for file in "$OUTPUT_DIR"/*/doc-index.json; do
+  project=$(basename "$(dirname "$file")");
   jq -s \
     ".[0] + [.[1][] | (. + {link: (\"${project}/\" + .link)}) ]" \
     "${OUTPUT_DIR}/doc-index.json" \
-    ${file} \
+    "${file}" \
     > /tmp/doc-index.json
   mv /tmp/doc-index.json "${OUTPUT_DIR}/doc-index.json"
 done

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -4,19 +4,19 @@
 # `cardano-ledger` repository.
 #
 # usage:
-# ./haddocks.sh directory [true|false]
+# ./haddocks.sh directory [components ...]
 #
 # $1 - where to put the generated pages, this directory contents will be wiped
 #      out (so don't pass `/` or `./` - the latter will delete your 'dist-newstyle')
 #      (the default is 'haddocks')
-# $2 - whether to re-build haddocks with `cabal haddock` command or a component name
-#      (the default is true)
+# $2 - the components to re-build haddocks for, or 'all'
+#      (the default is none)
 #
 
 set -euo pipefail
 
 OUTPUT_DIR=${1:-haddocks}
-REGENERATE=${2:-true}
+REGENERATE=("${@:2}")
 
 BUILD_DIR=dist-newstyle
 GHC_VERSION=$(ghc --numeric-version)
@@ -35,11 +35,9 @@ HADDOCK_OPTS=(
   --haddock-option="--base-url=.."
 )
 
-# build documentation of all modules
-if [ "${REGENERATE}" == "true" ]; then
-  cabal haddock "${HADDOCK_OPTS[@]}" all
-elif [ "${REGENERATE}" != "false" ]; then
-  cabal haddock "${HADDOCK_OPTS[@]}" "${REGENERATE}"
+# Rebuild documentation if requested
+if (( "${#REGENERATE[@]}" > 0 )); then
+  cabal haddock "${HADDOCK_OPTS[@]}" "${REGENERATE[@]}"
 fi
 
 if [[ ! -d "${OUTPUT_DIR}" ]]; then


### PR DESCRIPTION
# Description

Fix the broken Haddocks CI

Resolves #4156
Resolves #4193

* Avoid adding all of the repo files to the gh-pages branch
* Ensure `scripts/haddocks.sh` doesn't fail when optional files don't exist
* Preserve benchmark results in gh-pages when adding Haddocks
* Don't build Haddocks using `nix develop`, to avoid running out of disk space

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
