### PR TITLE
add unsafeMkProposals to be used for testing

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -102,6 +102,7 @@ module Cardano.Ledger.Conway.Governance.Proposals (
   pRootsL,
   pGraphL,
   mkProposals,
+  unsafeMkProposals,
   PRoot (..),
   prRootL,
   prChildrenL,
@@ -238,30 +239,46 @@ proposalsAddAction ::
   GovActionState era ->
   Proposals era ->
   Maybe (Proposals era)
-proposalsAddAction gas ps = withGovActionParent gas (Just psWithGas) update
+proposalsAddAction gas ps = checkInvariantAfterAddition gas ps <$> runProposalsAddAction gas ps
+
+-- | Add a single @`GovActionState`@ to the @`Proposals`@ forest.
+-- The tree to which it is added is picked according to its
+-- @`GovActionPurpose`@.
+unsafeProposalsAddAction ::
+  forall era.
+  HasCallStack =>
+  GovActionState era ->
+  Proposals era ->
+  Proposals era
+unsafeProposalsAddAction gas ps =
+  case runProposalsAddAction gas ps of
+    Just p -> p
+    Nothing -> error $ "unsafeProposalsAddAction: runProposalsAddAction failed for " ++ show (gas ^. gasIdL)
+
+runProposalsAddAction ::
+  forall era.
+  GovActionState era ->
+  Proposals era ->
+  Maybe (Proposals era)
+runProposalsAddAction gas ps = withGovActionParent gas (Just psWithGas) update
   where
     psWithGas = ps & pPropsL %~ (OMap.||> gas)
     -- Append a new GovActionState to the Proposals and then add it to the set of children
     -- for its parent as well as initiate an empty lineage for this new child.
     update ::
-      HasCallStack =>
       (forall f. Lens' (GovRelation f era) (f (GovPurposeId p era))) ->
       StrictMaybe (GovPurposeId p era) ->
       GovPurposeId p era ->
       Maybe (Proposals era)
     update govRelationL parent newId
       | parent == ps ^. pRootsL . govRelationL . prRootL =
-          Just $
-            checkInvariantAfterAddition gas ps $
-              psWithGas
-                & pRootsL . govRelationL . prChildrenL %~ Set.insert newId
-                & pGraphL . govRelationL . pGraphNodesL %~ Map.insert newId (PEdges parent Set.empty)
+          Just $ psWithGas
+               & pRootsL . govRelationL . prChildrenL %~ Set.insert newId
+               & pGraphL . govRelationL . pGraphNodesL %~ Map.insert newId (PEdges parent Set.empty)
       | SJust parentId <- parent
       , Map.member parentId $ ps ^. pGraphL . govRelationL . pGraphNodesL =
-          Just $
-            checkInvariantAfterAddition gas ps $
-              psWithGas
-                & pGraphL . govRelationL . pGraphNodesL
+          Just $ psWithGas
+               & pGraphL . govRelationL . pGraphNodesL
                   %~ ( Map.insert newId (PEdges (SJust parentId) Set.empty)
                         . Map.adjust (peChildrenL %~ Set.insert newId) parentId
                      )
@@ -288,6 +305,19 @@ mkProposals pgais omap = do
   pure ps
   where
     initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
+
+-- | Reconstruct the @`Proposals`@ forest from an @`OMap`@ of
+-- @`GovActionState`@s and the 4 roots (@`PrevGovActionIds`@).
+-- This function can fail and may return a malformed `Proposals`
+-- if not given correct inputs.
+--
+-- WARNING: Should only be used for testing!
+unsafeMkProposals ::
+  GovRelation StrictMaybe era ->
+  OMap.OMap (GovActionId (EraCrypto era)) (GovActionState era) ->
+  Proposals era
+unsafeMkProposals pgais omap = foldl' (flip unsafeProposalsAddAction) initialProposals omap
+  where initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
 
 instance EraPParams era => EncCBOR (Proposals era) where
   encCBOR ps =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -241,20 +241,6 @@ proposalsAddAction ::
   Maybe (Proposals era)
 proposalsAddAction gas ps = checkInvariantAfterAddition gas ps <$> runProposalsAddAction gas ps
 
--- | Add a single @`GovActionState`@ to the @`Proposals`@ forest.
--- The tree to which it is added is picked according to its
--- @`GovActionPurpose`@.
-unsafeProposalsAddAction ::
-  forall era.
-  HasCallStack =>
-  GovActionState era ->
-  Proposals era ->
-  Proposals era
-unsafeProposalsAddAction gas ps =
-  case runProposalsAddAction gas ps of
-    Just p -> p
-    Nothing -> error $ "unsafeProposalsAddAction: runProposalsAddAction failed for " ++ show (gas ^. gasIdL)
-
 runProposalsAddAction ::
   forall era.
   GovActionState era ->
@@ -321,6 +307,10 @@ unsafeMkProposals ::
 unsafeMkProposals pgais omap = foldl' (flip unsafeProposalsAddAction) initialProposals omap
   where
     initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
+    unsafeProposalsAddAction gas ps =
+      case runProposalsAddAction gas ps of
+        Just p -> p
+        Nothing -> error $ "unsafeMkProposals: runProposalsAddAction failed for " ++ show (gas ^. gasIdL)
 
 instance EraPParams era => EncCBOR (Proposals era) where
   encCBOR ps =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -272,16 +272,18 @@ runProposalsAddAction gas ps = withGovActionParent gas (Just psWithGas) update
       Maybe (Proposals era)
     update govRelationL parent newId
       | parent == ps ^. pRootsL . govRelationL . prRootL =
-          Just $ psWithGas
-               & pRootsL . govRelationL . prChildrenL %~ Set.insert newId
-               & pGraphL . govRelationL . pGraphNodesL %~ Map.insert newId (PEdges parent Set.empty)
+          Just $
+            psWithGas
+              & pRootsL . govRelationL . prChildrenL %~ Set.insert newId
+              & pGraphL . govRelationL . pGraphNodesL %~ Map.insert newId (PEdges parent Set.empty)
       | SJust parentId <- parent
       , Map.member parentId $ ps ^. pGraphL . govRelationL . pGraphNodesL =
-          Just $ psWithGas
-               & pGraphL . govRelationL . pGraphNodesL
-                  %~ ( Map.insert newId (PEdges (SJust parentId) Set.empty)
-                        . Map.adjust (peChildrenL %~ Set.insert newId) parentId
-                     )
+          Just $
+            psWithGas
+              & pGraphL . govRelationL . pGraphNodesL
+                %~ ( Map.insert newId (PEdges (SJust parentId) Set.empty)
+                      . Map.adjust (peChildrenL %~ Set.insert newId) parentId
+                   )
       | otherwise = Nothing
 
 -- | Reconstruct the @`Proposals`@ forest from an @`OMap`@ of
@@ -317,7 +319,8 @@ unsafeMkProposals ::
   OMap.OMap (GovActionId (EraCrypto era)) (GovActionState era) ->
   Proposals era
 unsafeMkProposals pgais omap = foldl' (flip unsafeProposalsAddAction) initialProposals omap
-  where initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
+  where
+    initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
 
 instance EraPParams era => EncCBOR (Proposals era) where
   encCBOR ps =


### PR DESCRIPTION
# Description

When profiling `prop_GOV` that I'm working on over on the branch `PR-fix-prop_GOV` I found that after fixing a bunch of performance bottle necks in `constrained-generators` (now running many X faster!) `checkInvariantAfterAddition` was taking 24% of the time. This seemed excessive as the whole point of the constraint-based generator is to generate correct stuff by default.

This PR adds `unsafeMkProposals` to make it possible to side-step `checkInvariantAfterAddition` when generating test data.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
