### PR TITLE
Fix `prop_GOV` so that it runs again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,10 @@ specs/**/.ghc.environment.x86_64-linux-*
 ## python for generating the doc site's transitive dependencies
 .venv
 
+## ignore profiling output
+**/*.eventlog
+**/*.eventlog.json
+**/*.prof
+
 ## Misc
 .pre-commit-config.yaml

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -52,6 +52,7 @@ module Cardano.Ledger.Conway.Governance (
   actionPriority,
   Proposals,
   mkProposals,
+  unsafeMkProposals,
   GovPurposeId (..),
   PRoot (..),
   PEdges (..),

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -125,6 +125,7 @@ data GovEnv era = GovEnv
   }
   deriving (Generic)
 
+instance (NFData (PParams era), Era era) => NFData (GovEnv era)
 deriving instance (Show (PParams era), Era era) => Show (GovEnv era)
 deriving instance Eq (PParams era) => Eq (GovEnv era)
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -231,6 +231,9 @@ cradle:
     - path: "libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/StakeDistr.hs"
       component: "cardano-ledger-test:bench:bench"
 
+    - path: "libs/cardano-ledger-test/bench/Bench/Constrained/STS.hs"
+      component: "cardano-ledger-test:bench:bench"
+
     - path: "libs/cardano-ledger-test/benchProperty/Main.hs"
       component: "cardano-ledger-test:bench:benchProperty"
 
@@ -248,6 +251,9 @@ cradle:
 
     - path: "libs/constrained-generators/test"
       component: "constrained-generators:test:constrained"
+
+    - path: "libs/constrained-generators/bench/Main.hs"
+      component: "constrained-generators:bench:bench"
 
     - path: "libs/ledger-state/src"
       component: "lib:ledger-state"

--- a/libs/cardano-ledger-test/bench/Bench/Constrained/STS.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Constrained/STS.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Bench.Constrained.STS where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Crypto
+import Constrained
+import Constrained.Bench
+import Criterion
+import Test.Cardano.Ledger.Constrained.V2.Conway
+import Test.Cardano.Ledger.Constrained.V2.Conway.GOV
+
+govEnv :: GovEnv (ConwayEra StandardCrypto)
+govEnv = genFromSpecWithSeed 10 30 (govEnvSpec @ConwayFn)
+
+singleProposalTreeSpec :: Spec ConwayFn ProposalTree
+singleProposalTreeSpec = constrained $ \ppupTree ->
+  [ wellFormedChildren (lit SNothing) ppupTree
+  , allGASInTree ppupTree $ \gas ->
+      isCon @"ParameterChange" (pProcGovAction_ . gasProposalProcedure_ $ gas)
+  , forAll (snd_ ppupTree) (genHint $ (Just 2, 10))
+  ]
+
+stsBenchmarks :: Benchmark
+stsBenchmarks =
+  bgroup
+    "constrainedSTS"
+    [ benchSpec 10 30 "govEnvSpec" (govEnvSpec @ConwayFn)
+    , benchSpec 13 30 "govProposalsSpec" govPropSpec
+    , benchSpec 13 30 "singleProposalTreeSpec" singleProposalTreeSpec
+    , bench "theProposalSpec" (nf (show . govProposalsSpec @ConwayFn) govEnv)
+    ]
+  where
+    govPropSpec = govProposalsSpec @ConwayFn govEnv

--- a/libs/cardano-ledger-test/bench/Main.hs
+++ b/libs/cardano-ledger-test/bench/Main.hs
@@ -9,6 +9,7 @@ import qualified Bench.Cardano.Ledger.Serialisation.Generators as SerGen
 import qualified Bench.Cardano.Ledger.StakeDistr as StakeDistr (tickfRuleBench)
 import qualified Bench.Cardano.Ledger.SumStake as SumStake
 import qualified Bench.Cardano.Ledger.TxOut as TxOut
+import qualified Bench.Constrained.STS as ConstrainedSTS
 import Criterion.Main (defaultMain)
 
 main :: IO ()
@@ -20,5 +21,6 @@ main =
     , ApplyTx.applyTxBenchmarks
     , Epoch.aggregateUtxoBench
     , SumStake.sumStakeBenchmarks
+    , ConstrainedSTS.stsBenchmarks
     -- Balance.balanceBenchmarks
     ]

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -153,7 +153,8 @@ library
         transformers,
         unordered-containers,
         vector,
-        constrained-generators
+        constrained-generators,
+        random
 
 test-suite cardano-ledger-test
     type:             exitcode-stdio-1.0
@@ -183,6 +184,7 @@ benchmark bench
         Bench.Cardano.Ledger.SumStake
         Bench.Cardano.Ledger.TxOut
         Bench.Cardano.Ledger.StakeDistr
+        Bench.Constrained.STS
 
     default-language: Haskell2010
     ghc-options:
@@ -199,6 +201,7 @@ benchmark bench
         cardano-ledger-alonzo,
         cardano-ledger-alonzo-test,
         cardano-ledger-binary,
+        cardano-ledger-conway,
         cardano-ledger-test,
         cardano-ledger-core,
         cardano-ledger-shelley-ma-test,
@@ -217,7 +220,8 @@ benchmark bench
         random,
         small-steps:{small-steps, testlib} >=1.1,
         cardano-strict-containers >=0.1.1,
-        text
+        text,
+        constrained-generators
 
 benchmark benchProperty
     type:             exitcode-stdio-1.0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway.hs
@@ -701,8 +701,8 @@ instance IsConwayUniv fn => HasSpec fn ProtVer
 -- We do this like this to get the right bounds for `VersionRep`
 -- while ensuring that we don't have to add instances for e.g. `Num`
 -- to version.
-newtype VersionRep = VersionRep Word64
-  deriving (Show, Eq, Ord, Num, Random) via Word64
+newtype VersionRep = VersionRep Word8
+  deriving (Show, Eq, Ord, Num, Random) via Word8
 instance BaseUniverse fn => HasSpec fn VersionRep where
   type TypeSpec fn VersionRep = NumSpec VersionRep
   emptySpec = emptyNumSpec
@@ -711,13 +711,13 @@ instance BaseUniverse fn => HasSpec fn VersionRep where
   conformsTo = conformsToNumSpec
   toPreds = toPredsNumSpec
 instance Bounded VersionRep where
-  minBound = VersionRep $ getVersion64 minBound
-  maxBound = VersionRep $ getVersion64 maxBound
+  minBound = VersionRep $ getVersion minBound
+  maxBound = VersionRep $ getVersion maxBound
 instance MaybeBounded VersionRep
 
 instance HasSimpleRep Version where
   type SimpleRep Version = VersionRep
-  fromSimpleRep (VersionRep rep) = case mkVersion64 rep of
+  fromSimpleRep (VersionRep rep) = case mkVersion rep of
     Left err ->
       error $
         unlines
@@ -726,7 +726,7 @@ instance HasSimpleRep Version where
           , err
           ]
     Right a -> a
-  toSimpleRep = VersionRep . getVersion64
+  toSimpleRep = VersionRep . getVersion
 instance BaseUniverse fn => HasSpec fn Version
 instance BaseUniverse fn => OrdLike fn Version
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/GOV.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/GOV.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the GOV rule
 module Test.Cardano.Ledger.Constrained.V2.Conway.GOV where
+
+import Data.Coerce
 
 import Cardano.Ledger.Api
 import Cardano.Ledger.BaseTypes
@@ -27,10 +31,219 @@ govEnvSpec = constrained $ \ge ->
   match ge $ \_ _ pp _ _ ->
     satisfies pp pparamsSpec
 
+-- TODO:
+--  - check `toGovRelationTree` invariants here
+--  - check `checkInvariantOnAddition` invariants here
+--  - check `checkInvariantOnDeletion` invariants here
+--  - check `toPTree` invariants here
+
+-- NOTE: it is probably OK not to check uniqueness of ids here, because a clash
+-- is never going to be generated, and the real representation of `Proposals` doesn't
+-- allow the id to appear twice.
 govProposalsSpec ::
+  IsConwayUniv fn =>
   GovEnv (ConwayEra StandardCrypto) ->
   Spec fn (Proposals (ConwayEra StandardCrypto))
-govProposalsSpec GovEnv {} = TrueSpec
+govProposalsSpec GovEnv {..} =
+  constrained $ \props ->
+    match props $ \ppupTree hardForkTree committeeTree constitutionTree unorderedProposals ->
+      [ -- Protocol parameter updates
+        wellFormedChildren (lit $ coerce grPParamUpdate) ppupTree
+      , allGASInTree ppupTree $ \gas ->
+          [ isCon @"ParameterChange" (pProcGovAction_ . gasProposalProcedure_ $ gas)
+          , onCon @"ParameterChange" (pProcGovAction_ . gasProposalProcedure_ $ gas) $
+              \_ ppup policy ->
+                [ wfPParamsUpdate ppup
+                , assert $ policy ==. lit gePPolicy
+                ]
+          ]
+      , forAll (snd_ ppupTree) (genHint treeGenHint)
+      , genHint listSizeHint (snd_ ppupTree)
+      , -- Hard forks
+        wellFormedChildren (lit $ coerce grHardFork) hardForkTree
+      , allGASInTree hardForkTree $ \gas ->
+          isCon @"HardForkInitiation" (pProcGovAction_ . gasProposalProcedure_ $ gas)
+      , allGASAndChildInTree hardForkTree $ \gas gas' ->
+          [ onHardFork gas $ \_ pv ->
+              onHardFork gas' $ \_ pv' ->
+                match pv $ \majV minV ->
+                  match pv' $ \majV' minV' ->
+                    [ assert $ majV <=. majV'
+                    , ifElse
+                        (majV ==. lit maxBound)
+                        (majV' ==. majV)
+                        (majV' <=. succV_ majV)
+                    , ifElse
+                        (majV ==. majV')
+                        (minV' ==. minV + 1)
+                        (minV' ==. 0)
+                    , minV' `dependsOn` majV'
+                    ]
+          , -- TODO: get rid of this when we've fixed the performance problem around deep forall
+            -- fusion
+            isCon @"HardForkInitiation" (pProcGovAction_ . gasProposalProcedure_ $ gas)
+          ]
+      , forAll (snd_ hardForkTree) (genHint treeGenHint)
+      , genHint listSizeHint (snd_ hardForkTree)
+      , -- Committee
+        wellFormedChildren (lit $ coerce grCommittee) committeeTree
+      , -- TODO: it would be nice to have a trick like `isCon` that can
+        -- do disjunction without having to write down all the cases.
+        allGASInTree committeeTree $ \gas ->
+          caseOn
+            (pProcGovAction_ . gasProposalProcedure_ $ gas)
+            (branch $ \_ _ _ -> False)
+            (branch $ \_ _ -> False)
+            (branch $ \_ _ -> False)
+            (branch $ \_ -> True)
+            -- UpdateCommittee
+            ( branch $ \_ _ added _ ->
+                forAll (rng_ added) $ \epoch ->
+                  lit geEpoch <. epoch
+            )
+            (branch $ \_ _ -> False)
+            (branch $ \_ -> False)
+      , forAll (snd_ committeeTree) (genHint treeGenHint)
+      , genHint listSizeHint (snd_ committeeTree)
+      , -- Constitution
+        wellFormedChildren (lit $ coerce grConstitution) constitutionTree
+      , allGASInTree constitutionTree $ \gas ->
+          isCon @"NewConstitution" (pProcGovAction_ . gasProposalProcedure_ $ gas)
+      , forAll (snd_ constitutionTree) (genHint treeGenHint)
+      , genHint listSizeHint (snd_ constitutionTree)
+      , -- Withdrawals and info
+        forAll unorderedProposals $ \gas ->
+          caseOn
+            (pProcGovAction_ . gasProposalProcedure_ $ gas)
+            (branch $ \_ _ _ -> False)
+            (branch $ \_ _ -> False)
+            -- Treasury Withdrawal
+            ( branch $ \withdrawMap policy ->
+                [ forAll (dom_ withdrawMap) $ \rewAcnt ->
+                    match rewAcnt $ \net _ -> net ==. lit Testnet
+                , assert $ policy ==. lit gePPolicy
+                ]
+            )
+            (branch $ \_ -> False)
+            (branch $ \_ _ _ _ -> False)
+            (branch $ \_ _ -> False)
+            -- Info
+            (branch $ \_ -> True)
+      , genHint listSizeHint unorderedProposals
+      ]
+  where
+    GovRelation {..} = gePrevGovActionIds
+    treeGenHint = (Just 2, 10)
+    listSizeHint = 5
+
+allGASInTree ::
+  (IsConwayUniv fn, IsPred p fn) =>
+  Term fn ProposalTree ->
+  (Term fn (GovActionState (ConwayEra StandardCrypto)) -> p) ->
+  Pred fn
+allGASInTree t k =
+  forAll (snd_ t) $ \t' ->
+    forAll' t' $ \gas _ ->
+      k gas
+
+allGASAndChildInTree ::
+  (IsConwayUniv fn, IsPred p fn) =>
+  Term fn ProposalTree ->
+  ( Term fn (GovActionState (ConwayEra StandardCrypto)) ->
+    Term fn (GovActionState (ConwayEra StandardCrypto)) ->
+    p
+  ) ->
+  Pred fn
+allGASAndChildInTree t k =
+  forAll (snd_ t) $ \t' ->
+    forAll' t' $ \gas cs ->
+      forAll cs $ \t'' ->
+        k gas (roseRoot_ t'')
+
+wellFormedChildren ::
+  IsConwayUniv fn =>
+  Term fn (StrictMaybe (GovActionId StandardCrypto)) ->
+  Term fn ProposalTree ->
+  Pred fn
+wellFormedChildren root rootAndTrees =
+  match rootAndTrees $ \root' trees ->
+    [ assert $ root ==. root' -- The root matches the root given in the environment
+    , forAll trees $ \t ->
+        [ -- Every node just below the root has the root as its parent
+          withPrevActId (roseRoot_ t) (assert . (==. root))
+        , -- Every node's children have the id of the node as its parent
+          forAll' t $ \gas children ->
+            [ forAll children $ \t' ->
+                [ withPrevActId (roseRoot_ t') (assert . (==. cSJust_ (gasId_ gas)))
+                -- TODO: figure out why this causes a crash!
+                -- , t' `dependsOn` gas
+                ]
+            , children `dependsOn` gas
+            ]
+        ]
+    ]
+
+withPrevActId ::
+  IsConwayUniv fn =>
+  Term fn (GovActionState (ConwayEra StandardCrypto)) ->
+  (Term fn (StrictMaybe (GovActionId StandardCrypto)) -> Pred fn) ->
+  Pred fn
+withPrevActId gas k =
+  caseOn
+    (pProcGovAction_ . gasProposalProcedure_ $ gas)
+    ( branch $ \mPrevActionId _ _ ->
+        caseOn
+          mPrevActionId
+          (branch $ \_ -> k cSNothing_)
+          (branch $ \i -> k (cSJust_ $ toGeneric_ i))
+    )
+    ( branch $ \mPrevActionId _ ->
+        caseOn
+          mPrevActionId
+          (branch $ \_ -> k cSNothing_)
+          (branch $ \i -> k (cSJust_ $ toGeneric_ i))
+    )
+    (branch $ \_ _ -> True)
+    -- NoConfidence
+    --   !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
+    ( branch $ \mPrevActionId ->
+        caseOn
+          mPrevActionId
+          (branch $ \_ -> k cSNothing_)
+          (branch $ \i -> k (cSJust_ $ toGeneric_ i))
+    )
+    -- UpdateCommittee
+    --   !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
+    --   !(Set (Credential 'ColdCommitteeRole (EraCrypto era)))
+    --   !(Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
+    --   !UnitInterval
+    ( branch $ \mPrevActionId _ _ _ ->
+        caseOn
+          mPrevActionId
+          (branch $ \_ -> k cSNothing_)
+          (branch $ \i -> k (cSJust_ $ toGeneric_ i))
+    )
+    -- NewConstitution
+    --  !(StrictMaybe (PrevGovActionId 'ConstitutionPurpose (EraCrypto era)))
+    --  !(Constitution era)
+    ( branch $ \mPrevActionId _ ->
+        caseOn
+          mPrevActionId
+          (branch $ \_ -> k cSNothing_)
+          (branch $ \i -> k (cSJust_ $ toGeneric_ i))
+    )
+    -- InfoAction
+    (branch $ \_ -> True)
+
+onHardFork ::
+  (IsConwayUniv fn, IsPred p fn) =>
+  Term fn (GovActionState (ConwayEra StandardCrypto)) ->
+  ( Term fn (StrictMaybe (GovPurposeId 'HardForkPurpose (ConwayEra StandardCrypto))) ->
+    Term fn ProtVer ->
+    p
+  ) ->
+  Pred fn
+onHardFork gas k = onCon @"HardForkInitiation" (pProcGovAction_ . gasProposalProcedure_ $ gas) k
 
 govProceduresSpec ::
   IsConwayUniv fn =>
@@ -75,7 +288,8 @@ govProceduresSpec ge@GovEnv {..} ps =
           ]
 
 -- TODO: The pointer to the previous action could also point to a
--- key in the `Proposals`
+-- key in the `Proposals`, need a more flexible way to say what previous
+-- action id is correct
 wfGovAction ::
   IsConwayUniv fn =>
   GovEnv (ConwayEra StandardCrypto) ->
@@ -85,47 +299,63 @@ wfGovAction GovEnv {..} govAction =
   caseOn
     govAction
     -- ParameterChange
-    --   !(StrictMaybe (GovPurposeId 'PParamUpdatePurpose era))
-    --   !(PParamsUpdate era)
-    --   !(StrictMaybe (ScriptHash (EraCrypto era)))
-    ( branch $ \mPrevActionId ppUpdate _ ->
+    ( branch $ \mPrevActionId ppUpdate policy ->
+        -- TODO: this should be any ppup proposal in the tree
         [ assert $ mPrevActionId ==. lit (gePrevGovActionIds ^. grPParamUpdateL)
         , wfPParamsUpdate ppUpdate
+        , assert $ policy ==. lit gePPolicy
         ]
     )
     -- HardForkInitiation
-    --   !(StrictMaybe (PrevGovActionId 'HardForkPurpose (EraCrypto era)))
-    --   !ProtVer
-    ( branch $ \mPrevActionId _protVer ->
-        mPrevActionId ==. lit (gePrevGovActionIds ^. grHardForkL)
-        -- TODO: here we need to say that the `protVer` can follow the last prot ver
+    ( branch $ \mPrevActionId protVer ->
+        [ -- TODO: this needs to be loosened to be any hard for proposal in the tree
+          assert $ mPrevActionId ==. lit (gePrevGovActionIds ^. grHardForkL)
+        , -- TODO: here we need to say that the `protVer` can follow the last prot ver
+          --        - the tricky thing about this is that it's not enough to say that you
+          --        follow what is in the Env, you actually have to follow what is in the
+          --        node above you in the tree
+          let ProtVer currentMajorVersion currentMinorVersion = gePParams ^. ppProtocolVersionL
+           in match protVer $ \majorVersion minorVersion ->
+                case succVersion currentMajorVersion of
+                  Nothing ->
+                    [ assert $ majorVersion ==. lit currentMajorVersion
+                    , assert $ minorVersion ==. lit currentMinorVersion + 1
+                    ]
+                  Just majorVersion' ->
+                    [ assert $ majorVersion `elem_` lit [currentMajorVersion, majorVersion']
+                    , ifElse
+                        (lit currentMajorVersion <. majorVersion)
+                        (minorVersion ==. 0)
+                        (minorVersion ==. lit currentMinorVersion + 1)
+                    ]
+        ]
     )
-    -- TreasuryWithdrawals !(Map (RewardAcnt (EraCrypto era)) Coin)
-    ( branch $ \withdrawMap _ ->
-        forAll (dom_ withdrawMap) $ \rewAcnt ->
-          match rewAcnt $ \net _ -> net ==. lit Testnet
+    -- TreasuryWithdrawals
+    ( branch $ \withdrawMap policy ->
+        [ forAll (dom_ withdrawMap) $ \rewAcnt ->
+            match rewAcnt $ \net _ -> net ==. lit Testnet
+        , assert $ policy ==. lit gePPolicy
+        ]
     )
     -- NoConfidence
-    --   !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
     ( branch $ \mPrevActionId ->
-        mPrevActionId ==. lit (gePrevGovActionIds ^. grCommitteeL)
+        -- TODO: this should be any committee purpose in the tree
+        [ assert $ mPrevActionId ==. lit (gePrevGovActionIds ^. grCommitteeL)
+        ]
     )
     -- UpdateCommittee
-    --   !(StrictMaybe (PrevGovActionId 'CommitteePurpose (EraCrypto era)))
-    --   !(Set (Credential 'ColdCommitteeRole (EraCrypto era)))
-    --   !(Map (Credential 'ColdCommitteeRole (EraCrypto era)) EpochNo)
-    --   !UnitInterval
     ( branch $ \mPrevActionId _removed added _quorum ->
+        -- TODO: this should be any committee purpose in the tree
         [ assert $ mPrevActionId ==. lit (gePrevGovActionIds ^. grCommitteeL)
         , forAll (rng_ added) $ \epoch ->
             lit geEpoch <. epoch
         ]
     )
     -- NewConstitution
-    --  !(StrictMaybe (PrevGovActionId 'ConstitutionPurpose (EraCrypto era)))
-    --  !(Constitution era)
     ( branch $ \mPrevActionId _c ->
-        mPrevActionId ==. lit (gePrevGovActionIds ^. grConstitutionL)
+        -- TODO: this should be any constitution purpose in the tree
+        [ assert $ mPrevActionId ==. lit (gePrevGovActionIds ^. grConstitutionL)
+        ]
     )
     -- InfoAction
     (branch $ \_ -> True)
@@ -153,7 +383,7 @@ wfPParamsUpdate ppu =
          _cppProtocolVersion
          _cppMinPoolCost
          _cppCoinsPerUTxOByte
-         _cppCostModels
+         cppCostModels
          _cppPrices
          _cppMaxTxExUnits
          _cppMaxBlockExUnits
@@ -179,5 +409,7 @@ wfPParamsUpdate ppu =
             , cppPoolDeposit /=. lit (THKD $ SJust mempty)
             , cppGovActionDeposit /=. lit (THKD $ SJust mempty)
             , cppDRepDeposit /=. lit (THKD $ SJust mempty)
+            , cppCostModels ==. lit (THKD SNothing) -- NOTE: this is because the cost
+            -- model generator is way too slow
             ]
     ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -264,9 +264,12 @@ tests_STS :: TestTree
 tests_STS =
   testGroup
     "STS property tests"
-    [ testProperty "prop_EPOCH" prop_EPOCH
-    , govTests
+    [ govTests
     -- , utxoTests
+    -- TODO: this is probably one of the last things we want to
+    -- get passing as it depends on being able to generate a complete
+    -- `EpochState era`
+    -- , testProperty "prop_EPOCH" prop_EPOCH
     -- , testProperty "prop_LEDGER" prop_LEDGER
     ]
 
@@ -280,7 +283,7 @@ govTests =
     , testProperty "prop_ENACT" prop_ENACT
     , testProperty "prop_RATIFY" prop_RATIFY
     , testProperty "prop_CERT" prop_CERT
-    -- , testProperty "prop_GOV" prop_GOV
+    , testProperty "prop_GOV" prop_GOV
     ]
 
 utxoTests :: TestTree

--- a/libs/constrained-generators/bench/Main.hs
+++ b/libs/constrained-generators/bench/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Constrained.Bench
+import Criterion.Main (defaultMain)
+
+main :: IO ()
+main = defaultMain [benchmarks]

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -34,6 +34,7 @@ library
         Constrained.Spec.Tree
         Constrained.Test
         Constrained.Internals
+        Constrained.Bench
 
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -50,7 +51,10 @@ library
         QuickCheck,
         random,
         tasty,
-        tasty-quickcheck
+        tasty-quickcheck,
+        ghc-prim,
+        deepseq,
+        criterion
 
 test-suite constrained
     type:             exitcode-stdio-1.0
@@ -66,3 +70,18 @@ test-suite constrained
         base,
         constrained-generators,
         tasty
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        criterion,
+        constrained-generators

--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -15,6 +15,7 @@ module Constrained (
   OrdLike (..),
   Forallable (..),
   Foldy (..),
+  MaybeBounded (..),
   FunctionLike (..),
   Functions (..),
   HOLE (..),
@@ -38,10 +39,15 @@ module Constrained (
   FoldSpec (..),
   genFromSpec,
   genFromSpec_,
+  genFromSpecWithSeed,
   conformsToSpec,
   conformsToSpecProp,
+  giveHint,
   typeSpec,
   con,
+  isCon,
+  onCon,
+  sel,
   caseBoolSpec,
   constrained,
   constrained',
@@ -52,7 +58,11 @@ module Constrained (
   assertExplain,
   caseOn,
   branch,
+  ifElse,
+  onJust,
+  isJust,
   reify,
+  genHint,
   dependsOn,
   forAll,
   forAll',
@@ -65,6 +75,7 @@ module Constrained (
   (<.),
   (==.),
   (/=.),
+  (||.),
   member_,
   subset_,
   disjoint_,
@@ -83,6 +94,12 @@ module Constrained (
   injectFn,
   app,
   lit,
+  -- Working with number-like types
+  emptyNumSpec,
+  combineNumSpec,
+  genFromNumSpec,
+  conformsToNumSpec,
+  toPredsNumSpec,
   -- TODO: this is super yucky, it would be good to implement
   -- the linear lambda thing to get rid of this.
   composeFn,
@@ -102,3 +119,4 @@ where
 import Constrained.GenT as X
 import Constrained.Internals
 import Constrained.List as X
+import Constrained.Spec.Tree as X

--- a/libs/constrained-generators/src/Constrained/Bench.hs
+++ b/libs/constrained-generators/src/Constrained/Bench.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Constrained.Bench where
+
+import Constrained
+import Constrained.Test
+import Control.DeepSeq
+import Criterion
+import Data.Map (Map)
+import Data.Set (Set)
+
+benchmarks :: Benchmark
+benchmarks =
+  bgroup
+    "constrained"
+    [ benchSpec 10 30 "TrueSpec@Map" (TrueSpec :: Spec BaseFn (Map Int Int))
+    , benchSpec 10 30 "TrueSpec@[]" (TrueSpec :: Spec BaseFn [Int])
+    , benchSpec 10 30 "TrueSpec@Set" (TrueSpec :: Spec BaseFn (Set Int))
+    , benchSpec
+        10
+        30
+        "TrueSpec@RoseTree"
+        (giveHint (Nothing, 30) <> TrueSpec :: Spec RoseFn (RoseTree Int))
+    , benchSpec 10 30 "roseTreeMaybe" roseTreeMaybe
+    , benchSpec 10 30 "listSumPair" (listSumPair @Int)
+    ]
+
+benchSpec :: (HasSpec fn a, NFData a) => Int -> Int -> String -> Spec fn a -> Benchmark
+benchSpec seed size nm spec =
+  bench (unlines [nm, show (genFromSpecWithSeed seed size spec)]) $
+    nf (genFromSpecWithSeed seed size) spec

--- a/libs/constrained-generators/src/Constrained/Core.hs
+++ b/libs/constrained-generators/src/Constrained/Core.hs
@@ -11,7 +11,6 @@
 module Constrained.Core where
 
 import Control.Applicative
-import Control.Monad
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Typeable
@@ -27,9 +26,8 @@ instance Show (Var a) where
   show v = "v" ++ show (nameOf v)
 
 eqVar :: forall a a'. (Typeable a, Typeable a') => Var a -> Var a' -> Maybe (a :~: a')
-eqVar v v' = do
-  Refl <- eqT @a @a'
-  Refl <$ guard (v == v')
+eqVar v v' | nameOf v == nameOf v' = eqT @a @a'
+eqVar _ _ = Nothing
 
 -- Variable renaming ------------------------------------------------------
 

--- a/libs/constrained-generators/src/Constrained/Env.hs
+++ b/libs/constrained-generators/src/Constrained/Env.hs
@@ -8,7 +8,6 @@ module Constrained.Env where
 
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe
 import Data.Typeable
 
 import Constrained.Core
@@ -25,20 +24,13 @@ data EnvValue where
 deriving instance Show EnvValue
 
 data EnvKey where
-  EnvKey :: Typeable a => !(Var a) -> EnvKey
+  EnvKey :: !(Var a) -> EnvKey
 
 instance Eq EnvKey where
-  EnvKey v == EnvKey v' = isJust $ eqVar v v'
+  EnvKey v == EnvKey v' = nameOf v == nameOf v'
 
 instance Ord EnvKey where
-  -- Lexicographic ordering on `(typeRep v, v)`
-  compare (EnvKey v) (EnvKey v')
-    -- If the keys point to something of the same type
-    -- (`cast` returns `Just`) then compare the variable
-    -- indexes.
-    | Just v'' <- cast v = compare v'' v'
-    -- Otherwise compare the types.
-    | otherwise = compare (typeRep v) (typeRep v')
+  compare (EnvKey v) (EnvKey v') = compare (nameOf v) (nameOf v')
 
 instance Show EnvKey where
   show (EnvKey var) = show var
@@ -46,7 +38,7 @@ instance Show EnvKey where
 extendEnv :: (Typeable a, Show a) => Var a -> a -> Env -> Env
 extendEnv v a (Env m) = Env $ Map.insert (EnvKey v) (EnvValue a) m
 
-removeVar :: Typeable a => Var a -> Env -> Env
+removeVar :: Var a -> Env -> Env
 removeVar v (Env m) = Env $ Map.delete (EnvKey v) m
 
 singletonEnv :: (Typeable a, Show a) => Var a -> a -> Env

--- a/libs/constrained-generators/src/Constrained/Graph.hs
+++ b/libs/constrained-generators/src/Constrained/Graph.hs
@@ -26,8 +26,8 @@ instance Ord node => Semigroup (Graph node) where
 instance Ord node => Monoid (Graph node) where
   mempty = Graph mempty mempty
 
-nodes :: Ord node => Graph node -> Set node
-nodes (Graph e o) = Map.keysSet e <> Map.keysSet o
+nodes :: Graph node -> Set node
+nodes (Graph e _) = Map.keysSet e
 
 opGraph :: Graph node -> Graph node
 opGraph (Graph e o) = Graph o e
@@ -52,9 +52,15 @@ dependency x xs =
 
 irreflexiveDependencyOn :: Ord node => Set node -> Set node -> Graph node
 irreflexiveDependencyOn xs ys =
-  foldMap (\x -> dependency x (Set.difference ys xs)) xs
-    <> noDependencies xs
-    <> noDependencies ys
+  deps <> noDependencies ys
+  where
+    diff = Set.difference ys xs
+    deps =
+      Graph
+        (Map.fromDistinctAscList [(x, diff) | x <- Set.toList xs])
+        ( Map.fromDistinctAscList [(a, xs) | a <- Set.toList diff]
+            <> Map.fromDistinctAscList [(a, mempty) | a <- Set.toList xs]
+        )
 
 transitiveDependencies :: Ord node => node -> Graph node -> Set node
 transitiveDependencies x (Graph e _) = go (Set.singleton x) x

--- a/libs/constrained-generators/src/Constrained/Instances.hs
+++ b/libs/constrained-generators/src/Constrained/Instances.hs
@@ -37,7 +37,12 @@ instance
   mapTypeSpec (Fix fn) = mapTypeSpec fn
 
 instance
-  (Typeable fn, Typeable fn', Typeable fnU, Functions (fn fnU) fnU, Functions (fn' fnU) fnU) =>
+  ( Typeable fn
+  , Typeable fn'
+  , Typeable fnU
+  , Functions (fn fnU) fnU
+  , Functions (fn' fnU) fnU
+  ) =>
   Functions (Oneof fn fn' fnU) fnU
   where
   propagateSpecFun (OneofLeft fn) = propagateSpecFun fn
@@ -74,7 +79,7 @@ instance BaseUniverse fn => Functions (BoolFn fn) fn where
   propagateSpecFun Or (HOLE :? Value (s :: Bool) :> Nil) spec = caseBoolSpec spec (okOr s)
   propagateSpecFun Or (Value (s :: Bool) :! NilCtx HOLE) spec = caseBoolSpec spec (okOr s)
 
-  mapTypeSpec Not _ = typeSpec ()
+  mapTypeSpec Not (SumSpec a b) = typeSpec $ SumSpec b a
 
 -- | We have something like ('constant' ||. HOLE) must evaluate to 'need'. Return a (Spec fn Bool) for HOLE, that makes that True.
 okOr :: Bool -> Bool -> Spec fn Bool


### PR DESCRIPTION
# Description

This is kindof a big PR that uses the new `Tree` extension to `constrained-generators` to make sure `prop_GOV` ticks.

To make this work I had to make a bunch of performance improvements to `constrained-generators` that will hopefully be reflected in CI times going forward.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
