### PR TITLE
Imptests - action priority

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.EnactSpec (spec) where
 
@@ -20,6 +19,7 @@ import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Val (zero, (<->))
 import Data.Default.Class (def)
 import Data.Foldable (foldl', traverse_)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
 import qualified Data.Sequence as Seq
@@ -325,8 +325,8 @@ actionPrioritySpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 actionPrioritySpec =
-  describe "Action priority" $ do
-    it "Only the first of proposals with same priority is enacted" $ do
+  describe "Competing proposals ratified in the same epoch" $ do
+    it "The first submitted proposal of higher priority wins, even when submitted after a lower priority one" $ do
       (drepC, _, gpi) <- electBasicCommittee
       (poolKH, _, _) <- setupPoolWithStake $ Coin 1_000_000
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
@@ -338,41 +338,82 @@ actionPrioritySpec =
       -- gai2 is the first action of a higher priority
       gai2 <- submitGovAction $ NoConfidence $ SJust gpi
       gai3 <- submitGovAction $ NoConfidence $ SJust gpi
-      submitYesVote_ (DRepVoter drepC) gai1
-      submitYesVote_ (StakePoolVoter poolKH) gai1
-      submitYesVote_ (DRepVoter drepC) gai2
-      submitYesVote_ (StakePoolVoter poolKH) gai2
-      submitYesVote_ (DRepVoter drepC) gai3
-      submitYesVote_ (StakePoolVoter poolKH) gai3
+      traverse_ @[]
+        ( \gaid -> do
+            submitYesVote_ (DRepVoter drepC) gaid
+            submitYesVote_ (StakePoolVoter poolKH) gaid
+        )
+        [gai1, gai2, gai3]
       passNEpochs 2
       getLastEnactedCommittee
         `shouldReturn` SJust (GovPurposeId gai2)
       checkProposalsEmpty
 
-    it "Contiguous ratified proposals are enacted in the same epoch, unless delayed" $ do
+      committee <-
+        getsNES $
+          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
+      committee `shouldBe` SNothing
+
+    let val1 = Coin 1_000_001
+    let val2 = Coin 1_000_002
+    let val3 = Coin 1_000_003
+
+    it "The first submitted proposal of the same priority gets enacted first" $ do
       (drepC, committeeC, _) <- electBasicCommittee
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       pGai0 <-
         submitParameterChange
           SNothing
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_000)
+          $ def & ppuDRepDepositL .~ SJust val1
       pGai1 <-
         submitParameterChange
           (SJust $ GovPurposeId pGai0)
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_001)
+          $ def & ppuDRepDepositL .~ SJust val2
       pGai2 <-
         submitParameterChange
           (SJust $ GovPurposeId pGai1)
-          $ def & ppuDRepDepositL .~ SJust (Coin 1_000_002)
-      submitYesVote_ (DRepVoter drepC) pGai0
-      submitYesVote_ (CommitteeVoter committeeC) pGai0
-      submitYesVote_ (DRepVoter drepC) pGai1
-      submitYesVote_ (CommitteeVoter committeeC) pGai1
-      submitYesVote_ (DRepVoter drepC) pGai2
-      submitYesVote_ (CommitteeVoter committeeC) pGai2
+          $ def & ppuDRepDepositL .~ SJust val3
+      traverse_ @[]
+        ( \gaid -> do
+            submitYesVote_ (DRepVoter drepC) gaid
+            submitYesVote_ (CommitteeVoter committeeC) gaid
+        )
+        [pGai0, pGai1, pGai2]
       passNEpochs 2
       getLastEnactedParameterChange
         `shouldReturn` SJust (GovPurposeId pGai2)
+      checkProposalsEmpty
+      getsNES (nesEsL . curPParamsEpochStateL . ppDRepDepositL)
+        `shouldReturn` val3
+
+    it "If submitted in the same transaction, only the first action gets enacted" $ do
+      (drepC, committeeC, _) <- electBasicCommittee
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
+      gaids <-
+        submitGovActions $
+          NE.fromList
+            [ ParameterChange
+                SNothing
+                (def & ppuDRepDepositL .~ SJust val1)
+                SNothing
+            , ParameterChange
+                SNothing
+                (def & ppuDRepDepositL .~ SJust val2)
+                SNothing
+            , ParameterChange
+                SNothing
+                (def & ppuDRepDepositL .~ SJust val3)
+                SNothing
+            ]
+      traverse_
+        ( \gaid -> do
+            submitYesVote_ (DRepVoter drepC) gaid
+            submitYesVote_ (CommitteeVoter committeeC) gaid
+        )
+        gaids
+      passNEpochs 2
+      getsNES (nesEsL . curPParamsEpochStateL . ppDRepDepositL)
+        `shouldReturn` val1
       checkProposalsEmpty
 
 checkProposalsEmpty :: ConwayEraGov era => ImpTestM era ()


### PR DESCRIPTION
# Description

The second part of Aniket's PR https://github.com/IntersectMBO/cardano-ledger/pull/4179, resolving: https://github.com/IntersectMBO/cardano-ledger/issues/4128
I extracted the actions-related tests from the original one and added some small improvements.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
